### PR TITLE
Themes: Fix Link on Professional Plan Banner

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -20,7 +20,7 @@ import JetpackUpgradeMessage from './jetpack-upgrade-message';
 import JetpackManageDisabledMessage from './jetpack-manage-disabled-message';
 import { connectOptions } from './theme-options';
 import Banner from 'components/banner';
-import { PLAN_JETPACK_BUSINESS } from 'lib/plans/constants';
+import { FEATURE_UNLIMITED_PREMIUM_THEMES, PLAN_JETPACK_BUSINESS } from 'lib/plans/constants';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
@@ -34,7 +34,6 @@ import {
 	hasJetpackSiteJetpackThemesExtendedFeatures,
 	isJetpackSiteMultiSite,
 } from 'state/sites/selectors';
-import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
 
 const ConnectedThemesSelection = connectOptions( props => {
 	return (

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -20,7 +20,7 @@ import JetpackUpgradeMessage from './jetpack-upgrade-message';
 import JetpackManageDisabledMessage from './jetpack-manage-disabled-message';
 import { connectOptions } from './theme-options';
 import Banner from 'components/banner';
-import { PLAN_JETPACK_PREMIUM } from 'lib/plans/constants';
+import { PLAN_JETPACK_BUSINESS } from 'lib/plans/constants';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
@@ -93,7 +93,7 @@ const ConnectedSingleSiteJetpack = connectOptions( props => {
 			{ ! requestingSitePlans &&
 				! hasUnlimitedPremiumThemes && (
 					<Banner
-						plan={ PLAN_JETPACK_PREMIUM }
+						plan={ PLAN_JETPACK_BUSINESS }
 						title={ translate( 'Access all our premium themes with our Professional plan!' ) }
 						description={ translate(
 							'Get advanced customization, more storage space, and video support along with all your new themes.'


### PR DESCRIPTION
On a JP site that doesn't have a Business Plan, the Upgrade Nudge Banner found at `/themes/<yourJPsite>`

![image](https://user-images.githubusercontent.com/96308/36975608-831f002c-2072-11e8-92db-3dd56606e89e.png)

would previously incorrectly point to `/plans/<yourJPsite>?plan=jetpack_premium`. This resulted in the 'Suggested' ribbon being added to the Premium plan:

![image](https://user-images.githubusercontent.com/96308/36976191-9ac75efc-2074-11e8-80eb-2efc40e800f1.png)

(You can verify by visiting `wordpress.com/themes/<yourJPsite>`.)

This PR fixes the link. To verify, try `calypso.localhost:3000/themes/<yourJPsite>`, and click the banner there. You should be taken to `http://calypso.localhost:3000/plans/<yourJPsite>?plan=jetpack_business`, where the 'Suggested' ribbon is now added to the 'Business' plan:

![image](https://user-images.githubusercontent.com/96308/36976023-fa51340c-2073-11e8-851b-6991f827c2b9.png)

Also verify that behavior hasn't changed for WP.com sites.

Fixes #22748.