### PR TITLE
Themes: Use Selectors to determine if Plan has Unlimited Themes

### DIFF
--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -16,33 +16,34 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import { connectOptions } from './theme-options';
 import Banner from 'components/banner';
-import { PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM } from 'lib/plans/constants';
-import { getCurrentPlan } from 'state/sites/plans/selectors';
+import { FEATURE_UNLIMITED_PREMIUM_THEMES, PLAN_PREMIUM } from 'lib/plans/constants';
+import { getCurrentPlan, hasFeature, isRequestingSitePlans } from 'state/sites/plans/selectors';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
 import { getSiteSlug } from 'state/sites/selectors';
 
 const ConnectedSingleSiteWpcom = connectOptions( props => {
-	const { siteId, siteSlug, currentPlanSlug, translate } = props;
+	const { hasUnlimitedPremiumThemes, requestingSitePlans, siteId, siteSlug, translate } = props;
 
 	const upsellUrl = `/plans/${ siteSlug }`;
 	return (
 		<div>
 			<SidebarNavigation />
 			<CurrentTheme siteId={ siteId } />
-			{ ( currentPlanSlug === PLAN_FREE || currentPlanSlug === PLAN_PERSONAL ) && (
-				<Banner
-					plan={ PLAN_PREMIUM }
-					title={ translate(
-						'Access all our premium themes with our Premium and Business plans!'
-					) }
-					description={ translate(
-						'Get advanced customization, more storage space, and video support along with all your new themes.'
-					) }
-					event="themes_plans_free_personal"
-				/>
-			) }
+			{ ! requestingSitePlans &&
+				! hasUnlimitedPremiumThemes && (
+					<Banner
+						plan={ PLAN_PREMIUM }
+						title={ translate(
+							'Access all our premium themes with our Premium and Business plans!'
+						) }
+						description={ translate(
+							'Get advanced customization, more storage space, and video support along with all your new themes.'
+						) }
+						event="themes_plans_free_personal"
+					/>
+				) }
 
 			<ThemeShowcase { ...props } upsellUrl={ upsellUrl } siteId={ siteId }>
 				{ siteId && <QuerySitePlans siteId={ siteId } /> }
@@ -58,5 +59,7 @@ export default connect( ( state, { siteId } ) => {
 	return {
 		siteSlug: getSiteSlug( state, siteId ),
 		currentPlanSlug: get( currentPlan, 'productSlug', null ),
+		hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
+		requestingSitePlans: isRequestingSitePlans( state, siteId ),
 	};
 } )( ConnectedSingleSiteWpcom );

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -6,7 +6,6 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,7 +16,7 @@ import ThanksModal from 'my-sites/themes/thanks-modal';
 import { connectOptions } from './theme-options';
 import Banner from 'components/banner';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES, PLAN_PREMIUM } from 'lib/plans/constants';
-import { getCurrentPlan, hasFeature, isRequestingSitePlans } from 'state/sites/plans/selectors';
+import { hasFeature, isRequestingSitePlans } from 'state/sites/plans/selectors';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
@@ -54,12 +53,8 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 	);
 } );
 
-export default connect( ( state, { siteId } ) => {
-	const currentPlan = getCurrentPlan( state, siteId );
-	return {
-		siteSlug: getSiteSlug( state, siteId ),
-		currentPlanSlug: get( currentPlan, 'productSlug', null ),
-		hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
-		requestingSitePlans: isRequestingSitePlans( state, siteId ),
-	};
-} )( ConnectedSingleSiteWpcom );
+export default connect( ( state, { siteId } ) => ( {
+	siteSlug: getSiteSlug( state, siteId ),
+	hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
+	requestingSitePlans: isRequestingSitePlans( state, siteId ),
+} ) )( ConnectedSingleSiteWpcom );


### PR DESCRIPTION
This uses the same generic logic for single-site-wpcom.jsx that we're already using for [`single-site-jetpack.jsx`](https://github.com/Automattic/wp-calypso/blob/c781f2ee6271a03b5d01c1b1d91790523bbc6be2/client/my-sites/themes/single-site-jetpack.jsx).

To test: Verify that for WP.com sites, on `http://calypso.localhost:3000/themes/yoursite.wordpress.com`, the 'Upgrade' nudge banner behavior is unchanged, i.e. the banner is still displayed on sites with a Free or Personal plan.

![image](https://user-images.githubusercontent.com/96308/36976757-a2754cb6-2076-11e8-944b-8de94623f56d.png)

Found while working on #22981.