### PR TITLE
Send users to a different signup flow based on a query string parameter

### DIFF
--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -21,6 +21,7 @@ import WordPressWordmark from 'components/wordpress-wordmark';
 import { addQueryArgs } from 'lib/route';
 import { getCurrentQueryArguments, getCurrentRoute } from 'state/selectors';
 import { login } from 'lib/paths';
+import flows from 'signup/config/flows';
 
 class MasterbarLoggedOut extends PureComponent {
 	static propTypes = {
@@ -98,6 +99,7 @@ class MasterbarLoggedOut extends PureComponent {
 		}
 
 		let signupUrl = config( 'signup_url' );
+		const signupFlow = get( currentQuery, 'signup_flow' );
 		if (
 			// Match locales like `/log-in/jetpack/es`
 			startsWith( currentRoute, '/log-in/jetpack' )
@@ -118,6 +120,8 @@ class MasterbarLoggedOut extends PureComponent {
 			}
 		} else if ( 'jetpack-connect' === sectionName ) {
 			signupUrl = '/jetpack/new';
+		} else if ( signupFlow && flows.isValidFlow( signupFlow ) ) {
+			signupUrl += '/' + signupFlow;
 		}
 
 		return (

--- a/client/layout/test/index.js
+++ b/client/layout/test/index.js
@@ -11,6 +11,18 @@ import { renderToString } from 'react-dom/server';
  */
 import LayoutLoggedOut from '../logged-out';
 
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+jest.mock( 'lib/signup/step-actions', () => ( {} ) );
+jest.mock( 'lib/user', () => () => {
+	return {
+		get() {
+			return {};
+		},
+	};
+} );
+
 describe( 'index', () => {
 	describe( 'when trying to renderToString() LayoutLoggedOut ', () => {
 		test( "doesn't throw an exception", () => {

--- a/client/lib/products-list/index.js
+++ b/client/lib/products-list/index.js
@@ -7,7 +7,6 @@
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:ProductsList' );
-import store from 'store';
 
 /**
  * Internal dependencies
@@ -45,7 +44,9 @@ ProductsList.prototype.get = function() {
 	if ( ! this.data ) {
 		debug( 'First time loading ProductsList, check store' );
 
-		data = store.get( 'ProductsList' );
+		if ( typeof localStorage !== 'undefined' ) {
+			data = localStorage.getItem( 'ProductsList' );
+		}
 
 		if ( data ) {
 			this.initialize( data );
@@ -93,7 +94,9 @@ ProductsList.prototype.fetch = function() {
 
 			this.emit( 'change' );
 
-			store.set( 'ProductsList', productsList );
+			if ( typeof localStorage !== 'undefined' ) {
+				localStorage.setItem( 'ProductsList', productsList );
+			}
 		}.bind( this )
 	);
 };

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -24,7 +24,7 @@ import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selecto
 const enhanceContextWithLogin = context => {
 	const { path, params: { flow, isJetpack, socialService, twoFactorAuthType } } = context;
 
-	context.cacheQueryKeys = [ 'client_id' ];
+	context.cacheQueryKeys = [ 'client_id', 'signup_flow' ];
 
 	context.primary = (
 		<WPLogin

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -457,6 +457,10 @@ const Flows = {
 		return flows;
 	},
 
+	isValidFlow( flowName ) {
+		return Boolean( Flows.getFlows()[ flowName ] );
+	},
+
 	/**
 	 * Preload AB Test variations after a certain step has been completed.
 	 *


### PR DESCRIPTION
This pull request fixes #2019 by sending users to a different signup flow based on the value of a `signup_flow` query string parameter.
  
This has also required some changes to the way we store data in localStorage, which won't work server side.
  
#### Testing instructions
  
1. Run `git checkout fix/2019` and start your server
2. Open the [`Login` page](http://calypso.localhost:3000/log-in)
3. Try adding various different parameters to the URL for different signup flows:
- ?signup_flow=account
- ?signup_flow=desktop
- ?signup_flow=asdfghdsa
4. Check that when the flow exists, the "Signup" button in the header goes to the correct flow, and when it doesn't it just goes to `/start`
  
#### Reviews
- [x] Code
- [x] Product

