### PR TITLE
Themes: Open Customizer Always in Same Tab

### DIFF
--- a/client/my-sites/themes/current-theme/button.jsx
+++ b/client/my-sites/themes/current-theme/button.jsx
@@ -9,12 +9,6 @@ import React from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
-/**
- * Internal dependencies
- */
-
-import { isOutsideCalypso } from 'lib/url';
-
 export default class extends React.Component {
 	static displayName = 'CurrentThemeButton';
 
@@ -35,7 +29,6 @@ export default class extends React.Component {
 				} ) }
 				onClick={ this.props.onClick.bind( null, this.props.name ) }
 				href={ this.props.href }
-				target={ isOutsideCalypso( this.props.href ) ? '_blank' : null }
 			>
 				<Gridicon icon={ this.props.icon } size={ 18 } />
 				<span className="current-theme__button-label">{ this.props.label }</span>


### PR DESCRIPTION
Previously, we had links pointing outside of Calypso open in a new tab. In particular, the 'Customize' button in the Theme Showcase's 'Current Theme' component opened a new tab for a Jetpack site (but not for a WP.com one). #22765 requests this to be changed, which probably makes sense now that we no longer want to emphasize which functionality is in wp-admin -- most things have been brought into Calypso, while some (such as a JP site's customizer) will just have to remain there.

![image](https://user-images.githubusercontent.com/96308/36977550-6b599ffe-2079-11e8-8768-5abce926719f.png)

To test:
* Go to `http://calypso.localhost:3000/themes/<yourJPsite>`
* Verify that the 'Customize' button opens the JP site's customizer in the same tab.

_Note that in your local dev environment, clicking the 'X' (close) button in the customizer's upper left corner will have you end up at the site's fronted. However, this works fine in other environments. The reason is that we're using a `return=` qarg, for which we had to whitelist a number of domains (`wordpress.com`, most notably) through a filter in Jetpack. We just didn't include `calypso.localhost:3000` in that whitelist._

Fixes #22765.