### PR TITLE
Fix: Upgrade Pricing A/B test should not be assigned to unauthenticated users.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -94,8 +94,8 @@ export default {
 		defaultVariation: 'original',
 		allowExistingUsers: true,
 	},
-	upgradePricingDisplay: {
-		datestamp: '20180213',
+	upgradePricingDisplayV2: {
+		datestamp: '20180305',
 		variations: {
 			original: 50,
 			modified: 50,

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -230,7 +230,7 @@ export const PLANS_LIST = {
 			FEATURE_ALL_FREE_FEATURES,
 		],
 		getBillingTimeFrame: abtest => {
-			if ( abtest && abtest( 'upgradePricingDisplay' ) === 'modified' ) {
+			if ( abtest && abtest( 'upgradePricingDisplayV2' ) === 'modified' ) {
 				// Note: Don't make this translatable because it's only visible to English-language users
 				return '/month, billed annually';
 			}
@@ -300,7 +300,7 @@ export const PLANS_LIST = {
 			FEATURE_ALL_PERSONAL_FEATURES,
 		],
 		getBillingTimeFrame: abtest => {
-			if ( abtest && abtest( 'upgradePricingDisplay' ) === 'modified' ) {
+			if ( abtest && abtest( 'upgradePricingDisplayV2' ) === 'modified' ) {
 				// Note: Don't make this translatable because it's only visible to English-language users
 				return '/month, billed annually';
 			}
@@ -399,7 +399,7 @@ export const PLANS_LIST = {
 			FEATURE_ALL_PREMIUM_FEATURES,
 		],
 		getBillingTimeFrame: abtest => {
-			if ( abtest && abtest( 'upgradePricingDisplay' ) === 'modified' ) {
+			if ( abtest && abtest( 'upgradePricingDisplayV2' ) === 'modified' ) {
 				// Note: Don't make this translatable because it's only visible to English-language users
 				return '/month, billed annually';
 			}
@@ -543,7 +543,7 @@ export const PLANS_LIST = {
 				FEATURE_ALL_PERSONAL_FEATURES,
 			] ),
 		getBillingTimeFrame: abtest => {
-			if ( abtest && abtest( 'upgradePricingDisplay' ) === 'modified' ) {
+			if ( abtest && abtest( 'upgradePricingDisplayV2' ) === 'modified' ) {
 				// Note: Don't make this translatable because it's only visible to English-language users
 				return '/month, billed annually';
 			}
@@ -623,7 +623,7 @@ export const PLANS_LIST = {
 			FEATURE_ALL_FREE_FEATURES,
 		],
 		getBillingTimeFrame: abtest => {
-			if ( abtest && abtest( 'upgradePricingDisplay' ) === 'modified' ) {
+			if ( abtest && abtest( 'upgradePricingDisplayV2' ) === 'modified' ) {
 				// Note: Don't make this translatable because it's only visible to English-language users
 				return '/month, billed annually';
 			}
@@ -744,7 +744,7 @@ export const PLANS_LIST = {
 				FEATURE_ALL_PREMIUM_FEATURES,
 			] ),
 		getBillingTimeFrame: abtest => {
-			if ( abtest && abtest( 'upgradePricingDisplay' ) === 'modified' ) {
+			if ( abtest && abtest( 'upgradePricingDisplayV2' ) === 'modified' ) {
 				// Note: Don't make this translatable because it's only visible to English-language users
 				return '/month, billed annually';
 			}

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -111,38 +111,10 @@ class PlanFeatures extends Component {
 	};
 
 	renderCreditNotice() {
-		const { canPurchase, hasPlaceholders, planProperties, site, translate } = this.props;
+		const { canPurchase, hasPlaceholders, maxCredits, translate } = this.props;
 		const bannerContainer = document.querySelector( '.plans-features-main__notice' );
 
-		if ( hasPlaceholders || ! canPurchase || ! bannerContainer ) {
-			return null;
-		}
-
-		const credits = planProperties.reduce(
-			( prev, prop ) => {
-				let current = 0;
-				if ( prop.discountPrice ) {
-					current = prop.rawPrice - prop.discountPrice;
-					if ( ! site.jetpack ) {
-						current = current * 12;
-					}
-				} else if ( prop.relatedMonthlyPlan ) {
-					current = prop.relatedMonthlyPlan.raw_price * 12 - prop.rawPrice;
-				}
-
-				if ( current > prev.amount ) {
-					return {
-						amount: current,
-						currencyCode: prop.currencyCode,
-					};
-				}
-
-				return prev;
-			},
-			{ amount: 0, currencyCode: '' }
-		);
-
-		if ( ! credits.amount ) {
+		if ( hasPlaceholders || ! canPurchase || ! bannerContainer || ! maxCredits.amount ) {
 			return null;
 		}
 
@@ -158,7 +130,7 @@ class PlanFeatures extends Component {
 						'Apply the value of your current plan towards an upgrade before your credits expire!',
 					{
 						args: {
-							credits: formatCurrency( credits.amount, credits.currencyCode ),
+							credits: formatCurrency( maxCredits.amount, maxCredits.currencyCode ),
 						},
 						components: {
 							b: <strong />,
@@ -347,7 +319,7 @@ class PlanFeatures extends Component {
 			const { rawPrice, discountPrice } = properties;
 			const classes = classNames( 'plan-features__table-item', 'has-border-top' );
 			let audience = planConstantObj.getAudience();
-			let billingTimeFrame = planConstantObj.getBillingTimeFrame( abtest );
+			let billingTimeFrame = planConstantObj.getBillingTimeFrame( getABTestVariation );
 
 			if ( isInSignup && ! displayJetpackPlans ) {
 				switch ( siteType ) {
@@ -667,6 +639,32 @@ function filterFreePlan( { planName } ) {
 	return isFreePlan( planName );
 }
 
+function getMaxCredits( planProperties, isJetpack ) {
+	return planProperties.reduce(
+		( prev, prop ) => {
+			let current = 0;
+			if ( prop.discountPrice ) {
+				current = prop.rawPrice - prop.discountPrice;
+				if ( ! isJetpack ) {
+					current = current * 12;
+				}
+			} else if ( prop.relatedMonthlyPlan ) {
+				current = prop.relatedMonthlyPlan.raw_price * 12 - prop.rawPrice;
+			}
+
+			if ( current > prev.amount ) {
+				return {
+					amount: current,
+					currencyCode: prop.currencyCode,
+				};
+			}
+
+			return prev;
+		},
+		{ amount: 0, currencyCode: '' }
+	);
+}
+
 export default connect(
 	( state, ownProps ) => {
 		const {
@@ -685,8 +683,6 @@ export default connect(
 		const signupDependencies = getSignupDependencyStore( state );
 		const siteType = signupDependencies.designType;
 		const canPurchase = ! isPaid || isCurrentUserCurrentPlanOwner( state, selectedSiteId );
-		const showModifiedPricingDisplay =
-			! isInSignup && abtest( 'upgradePricingDisplay' ) === 'modified';
 		let freePlanProperties = null;
 		let planProperties = compact(
 			map( plans, plan => {
@@ -790,12 +786,17 @@ export default connect(
 			planProperties = reject( planProperties, filterFreePlan );
 		}
 
+		const maxCredits = getMaxCredits( planProperties, ownProps.site.jetpack );
+		const showModifiedPricingDisplay =
+			! isInSignup && !! maxCredits.amount && abtest( 'upgradePricingDisplayV2' ) === 'modified';
+
 		return {
 			canPurchase,
 			planProperties,
 			freePlanProperties,
 			siteType,
 			sitePlan,
+			maxCredits,
 			showModifiedPricingDisplay,
 		};
 	},


### PR DESCRIPTION
As @markryall mentioned, the previous `upgradePricingDisplay` test had been assigned to unauthenticated users who are not the target audiences of this test. This PR fixes the buggy assignment and restarts the test with the new name to avoid data corruption.

The criteria also have changed as per @markryall's suggestion. As of now, the test is triggered only when they have credits.

See also #22244

cc @markryall 