### PR TITLE
Comments: Remove unnecessary onClick prop

### DIFF
--- a/client/my-sites/comments/comment-navigation/comment-navigation-tab.jsx
+++ b/client/my-sites/comments/comment-navigation/comment-navigation-tab.jsx
@@ -7,10 +7,8 @@
 import React from 'react';
 import classNames from 'classnames';
 
-export const CommentNavigationTab = ( { children, className, onClick } ) => (
-	<div className={ classNames( 'comment-navigation__tab', className ) } onClick={ onClick }>
-		{ children }
-	</div>
+export const CommentNavigationTab = ( { children, className } ) => (
+	<div className={ classNames( 'comment-navigation__tab', className ) }>{ children }</div>
 );
 
 export default CommentNavigationTab;


### PR DESCRIPTION
Remove an unnecessary `onClick` prop from the `<CommentNavigationTab>` component.

This change also fixes the following ESLint errors:
- `jsx-a11y/click-events-have-key-events`
- `jsx-a11y/no-static-element-interactions `

### Note

We could also drop the whole component and replace it with a simple div, but then we'd need to keep the [`<SectionNav>` logic](https://github.com/Automattic/wp-calypso/blob/master/client/components/section-nav/index.jsx#L180) in check, which is out of this PR scope.