### PR TITLE
Plans: Add Happychat to sites plans page

### DIFF
--- a/client/components/happychat/connection.jsx
+++ b/client/components/happychat/connection.jsx
@@ -9,6 +9,10 @@ import PropTypes from 'prop-types';
 export class HappychatConnection extends Component {
 	componentDidMount() {
 		if ( this.props.isHappychatEnabled && this.props.isConnectionUninitialized ) {
+			/**
+			 * @TODO: When happychat correctly handles site switching, remove manual
+			 * site update action from client/my-sites/plans-features-main/index.jsx
+			 */
 			this.props.initConnection( this.props.getAuth() );
 		}
 	}

--- a/client/components/happychat/connection.jsx
+++ b/client/components/happychat/connection.jsx
@@ -11,7 +11,7 @@ export class HappychatConnection extends Component {
 		if ( this.props.isHappychatEnabled && this.props.isConnectionUninitialized ) {
 			/**
 			 * @TODO: When happychat correctly handles site switching, remove manual
-			 * site update action from client/my-sites/plans-features-main/index.jsx
+			 * selectSiteId action from client/my-sites/plans-features-main/index.jsx
 			 */
 			this.props.initConnection( this.props.getAuth() );
 		}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -7,6 +7,7 @@ import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { filter, get } from 'lodash';
 import classNames from 'classnames';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -36,6 +37,9 @@ import { plansLink } from 'lib/plans';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
 import PaymentMethods from 'blocks/payment-methods';
+import HappychatButton from 'components/happychat/button';
+import HappychatConnection from 'components/happychat/connection-connected';
+import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 
 class PlansFeaturesMain extends Component {
 	getPlanFeatures() {
@@ -139,7 +143,14 @@ class PlansFeaturesMain extends Component {
 	}
 
 	getJetpackFAQ() {
-		const { translate } = this.props;
+		const { isChatAvailable, translate } = this.props;
+
+		const helpLink =
+			isEnabled( 'jetpack/happychat' ) && isChatAvailable ? (
+				<HappychatButton />
+			) : (
+				<a href="https://jetpack.com/contact-support/" target="_blank" rel="noopener noreferrer" />
+			);
 
 		return (
 			<FAQ>
@@ -190,17 +201,9 @@ class PlansFeaturesMain extends Component {
 				<FAQItem
 					question={ translate( 'Have more questions?' ) }
 					answer={ translate(
-						'No problem! Feel free to {{a}}get in touch{{/a}} with our Happiness Engineers.',
+						'No problem! Feel free to {{helpLink}}get in touch{{/helpLink}} with our Happiness Engineers.',
 						{
-							components: {
-								a: (
-									<a
-										href="https://jetpack.com/contact-support/"
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							},
+							components: { helpLink },
 						}
 					) }
 				/>
@@ -396,6 +399,7 @@ class PlansFeaturesMain extends Component {
 
 		return (
 			<div className="plans-features-main">
+				<HappychatConnection />
 				<div className="plans-features-main__notice" />
 				{ displayJetpackPlans ? this.getIntervalTypeToggle() : null }
 				<QueryPlans />
@@ -431,4 +435,6 @@ PlansFeaturesMain.defaultProps = {
 	showFAQ: true,
 };
 
-export default localize( PlansFeaturesMain );
+export default connect( state => ( {
+	isChatAvailable: isHappychatAvailable( state ),
+} ) )( localize( PlansFeaturesMain ) );

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -212,7 +212,14 @@ class PlansFeaturesMain extends Component {
 	}
 
 	getFAQ() {
-		const { site, translate } = this.props;
+		const { isChatAvailable, site, translate } = this.props;
+
+		const helpLink =
+			isEnabled( 'happychat' ) && isChatAvailable ? (
+				<HappychatButton className="plans-features-main__happychat-button" />
+			) : (
+				<a href="https://wordpress.com/help" target="_blank" rel="noopener noreferrer" />
+			);
 
 		return (
 			<FAQ>
@@ -333,13 +340,9 @@ class PlansFeaturesMain extends Component {
 					question={ translate( 'Have more questions?' ) }
 					answer={ translate(
 						'Need help deciding which plan works for you? Our happiness engineers are available for' +
-							' any questions you may have. {{a}}Get help{{/a}}.',
+							' any questions you may have. {{helpLink}}Get help{{/helpLink}}.',
 						{
-							components: {
-								a: (
-									<a href="https://wordpress.com/help" target="_blank" rel="noopener noreferrer" />
-								),
-							},
+							components: { helpLink },
 						}
 					) }
 				/>

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -147,7 +147,7 @@ class PlansFeaturesMain extends Component {
 
 		const helpLink =
 			isEnabled( 'jetpack/happychat' ) && isChatAvailable ? (
-				<HappychatButton />
+				<HappychatButton className="plans-features-main__happychat-button" />
 			) : (
 				<a href="https://jetpack.com/contact-support/" target="_blank" rel="noopener noreferrer" />
 			);

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -40,8 +40,25 @@ import PaymentMethods from 'blocks/payment-methods';
 import HappychatButton from 'components/happychat/button';
 import HappychatConnection from 'components/happychat/connection-connected';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
+import { selectSiteId } from 'state/help/actions';
 
 class PlansFeaturesMain extends Component {
+	componentWillUpdate( nextProps ) {
+		/**
+		 * Happychat does not update with the selected site right now :(
+		 * This ensures that Happychat groups are correct in case we switch sites while on the plans
+		 * page, for example between a Jetpack and Simple site.
+		 *
+		 * @TODO: When happychat correctly handles site switching, remove manual
+		 * site update action from client/my-sites/plans-features-main/index.jsx
+		 */
+		const siteId = get( this.props, [ 'site', 'ID' ] );
+		const nextSiteId = get( nextProps, [ 'site', 'ID' ] );
+		if ( siteId !== nextSiteId && nextSiteId ) {
+			this.props.selectSiteId( nextSiteId );
+		}
+	}
+
 	getPlanFeatures() {
 		const {
 			basePlansPath,
@@ -438,6 +455,9 @@ PlansFeaturesMain.defaultProps = {
 	showFAQ: true,
 };
 
-export default connect( state => ( {
-	isChatAvailable: isHappychatAvailable( state ),
-} ) )( localize( PlansFeaturesMain ) );
+export default connect(
+	state => ( {
+		isChatAvailable: isHappychatAvailable( state ),
+	} ),
+	{ selectSiteId }
+)( localize( PlansFeaturesMain ) );

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -49,8 +49,7 @@ class PlansFeaturesMain extends Component {
 		 * This ensures that Happychat groups are correct in case we switch sites while on the plans
 		 * page, for example between a Jetpack and Simple site.
 		 *
-		 * @TODO: When happychat correctly handles site switching, remove manual
-		 * site update action from client/my-sites/plans-features-main/index.jsx
+		 * @TODO: When happychat correctly handles site switching, remove selectSiteId action.
 		 */
 		const siteId = get( this.props, [ 'site', 'ID' ] );
 		const nextSiteId = get( nextProps, [ 'site', 'ID' ] );

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -437,6 +437,7 @@ PlansFeaturesMain.propTypes = {
 	displayJetpackPlans: PropTypes.bool.isRequired,
 	hideFreePlan: PropTypes.bool,
 	intervalType: PropTypes.string,
+	isChatAvailable: PropTypes.bool,
 	isInSignup: PropTypes.bool,
 	isLandingPage: PropTypes.bool,
 	onUpgradeClick: PropTypes.func,
@@ -450,8 +451,9 @@ PlansFeaturesMain.defaultProps = {
 	basePlansPath: null,
 	hideFreePlan: false,
 	intervalType: 'yearly',
-	site: {},
+	isChatAvailable: false,
 	showFAQ: true,
+	site: {},
 };
 
 export default connect(

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -1,9 +1,24 @@
+/** @format */
+
 .plans-features-main__group {
-	@include breakpoint( ">1040px" ) {
+	@include breakpoint( '>1040px' ) {
 		padding-top: 19px; // popular banner height adjustment
 	}
 
 	+ .faq {
 		margin-top: 20px;
+	}
+}
+
+// Required additional specificity
+.plans-features-main .plans-features-main__happychat-button {
+	color: $blue-wordpress;
+	font-weight: normal;
+	padding: 0;
+	text-decoration: underline;
+
+	&:hover,
+	&:focus {
+		color: $blue-wordpress;
 	}
 }


### PR DESCRIPTION
This PR adds Happychat to the support contact links in the `/plans` FAQs.

Fixes #22731 

Happiness announcement and coordination: pbg9X-cDn-p2

## Screens

No visual differences. Affected links shown.

![jp](https://user-images.githubusercontent.com/841763/36986835-265d455a-209b-11e8-9a90-c209a44110f3.png)
![wp](https://user-images.githubusercontent.com/841763/36986836-2683d7e2-209b-11e8-96a8-479a4881c49b.png)

## Known issues

✅ ~The Happychat connection does not correctly update with redux state.~

## Testing
1. Visit `/plans` for a WordPress.com Simple site.
1. Does the link open Happychat? (see screenshot)
1. Visit `/plans` for a WordPress.com Atomic site.
1. Does the link open Happychat? (see screenshot)
1. Visit `/plans` for a Jetpack site.
1. Does the link open Happychat? (see screenshot)
1. Ensure that each link is associated with the correct support group (Simple, Atomic -> WordPress.com; Jetpack -> Jetpack).