### PR TITLE
Editor: Update publish messaging to be consistent with updating.

### DIFF
--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -122,15 +122,10 @@ export class EditorNotice extends Component {
 				}
 
 				if ( 'page' === type ) {
-					return translate( 'Page published on {{siteLink/}}! {{a}}Add another page{{/a}}', {
+					return translate( 'Page published on {{pageLink/}}! {{a}}Add another page{{/a}}', {
 						components: {
-							siteLink: (
-								<a
-									href={ site.URL }
-									target="_blank"
-									rel="noopener noreferrer"
-									onClick={ this.handlePillExternalClick }
-								>
+							pageLink: (
+								<a href={ postUrl } onClick={ this.handlePillExternalClick }>
 									{ site.title }
 								</a>
 							),
@@ -138,46 +133,34 @@ export class EditorNotice extends Component {
 								<a href={ `/page/${ site.slug }` } onClick={ this.handlePillAddPagePromptClick } />
 							),
 						},
-						comment:
-							'Editor: Message displayed when a page is published, with a link to the site it was published on.',
+						comment: 'Editor: Message displayed when a page is published, with a link to the page.',
 					} );
 				}
 
 				if ( 'post' !== type && typeLabel ) {
-					return translate( '%(typeLabel)s published on {{siteLink/}}!', {
+					return translate( '%(typeLabel)s published on {{postLink/}}!', {
 						args: { typeLabel },
 						components: {
-							siteLink: (
-								<a
-									href={ site.URL }
-									target="_blank"
-									rel="noopener noreferrer"
-									onClick={ this.handlePillExternalClick }
-								>
+							postLink: (
+								<a href={ postUrl } onClick={ this.handlePillExternalClick }>
 									{ site.title }
 								</a>
 							),
 						},
 						comment:
-							'Editor: Message displayed when a post of a custom type is published, with a link to the site it was published on.',
+							'Editor: Message displayed when a post of a custom type is published, with a link to the post.',
 					} );
 				}
 
-				return translate( 'Post published on {{siteLink/}}!', {
+				return translate( 'Post published on {{postLink/}}!', {
 					components: {
-						siteLink: (
-							<a
-								href={ site.URL }
-								target="_blank"
-								rel="noopener noreferrer"
-								onClick={ this.handlePillExternalClick }
-							>
+						postLink: (
+							<a href={ postUrl } onClick={ this.handlePillExternalClick }>
 								{ site.title }
 							</a>
 						),
 					},
-					comment:
-						'Editor: Message displayed when a post is published, with a link to the site it was published on.',
+					comment: 'Editor: Message displayed when a post is published, with a link to the post.',
 				} );
 
 			case 'scheduled':

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -73,8 +74,7 @@ export class EditorNotice extends Component {
 		/* eslint-disable max-len */
 		const { translate, type, typeObject, site, postUrl, postDate, moment } = this.props;
 		const formattedPostDate = moment( postDate ).format( 'lll' );
-		const typeLabel =
-			typeObject && typeObject.labels.singular_name ? typeObject.labels.singular_name : type;
+		const typeLabel = get( typeObject, 'labels.singular_name', type );
 
 		switch ( key ) {
 			case 'warnPublishDateChange':
@@ -85,17 +85,21 @@ export class EditorNotice extends Component {
 				);
 
 			case 'publishFailure':
-				return translate( 'Publishing of %(typeLabel)s failed.', { args: { typeLabel } } );
+				return translate( 'Publishing of %(typeLabel)s failed.', {
+					args: { typeLabel: typeLabel.toLowerCase() },
+				} );
 
 			case 'saveFailure':
 				return translate( 'Saving of draft failed.' );
 
 			case 'trashFailure':
-				return translate( 'Trashing of %(typeLabel)s failed.', { args: { typeLabel } } );
+				return translate( 'Trashing of %(typeLabel)s failed.', {
+					args: { typeLabel: typeLabel.toLowerCase() },
+				} );
 
 			case 'published':
 				if ( ! site ) {
-					return translate( '%(typeLabel)s published!', { args: { typeLabel } } );
+					return translate( '%(typeLabel)s published!', { args: { typeLabel: typeLabel } } );
 				}
 
 				if ( 'page' === type ) {
@@ -115,7 +119,7 @@ export class EditorNotice extends Component {
 				}
 
 				return translate( '%(typeLabel)s published on {{postLink/}}!', {
-					args: { typeLabel },
+					args: { typeLabel: typeLabel },
 					components: {
 						postLink: (
 							<a href={ postUrl } onClick={ this.handlePillExternalClick }>

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -40,12 +40,12 @@ export class EditorNotice extends Component {
 		postDate: PropTypes.string,
 	};
 
-	handlePillExternalClick = () => {
-		this.props.recordTracksEvent( 'calypso_editor_pill_site_external_click' );
+	handleViewPostClick = () => {
+		this.props.recordTracksEvent( 'calypso_editor_notif_view_post_click' );
 	};
 
-	handlePillAddPagePromptClick = () => {
-		this.props.recordTracksEvent( 'calypso_editor_pill_add_page_prompt_click' );
+	handleAddPagePromptClick = () => {
+		this.props.recordTracksEvent( 'calypso_editor_notif_add_page_prompt_click' );
 	};
 
 	componentWillReceiveProps( nextProps ) {
@@ -106,13 +106,11 @@ export class EditorNotice extends Component {
 					return translate( 'Page published on {{pageLink/}}! {{a}}Add another page{{/a}}', {
 						components: {
 							pageLink: (
-								<a href={ postUrl } onClick={ this.handlePillExternalClick }>
+								<a href={ postUrl } onClick={ this.handleViewPostClick }>
 									{ site.title }
 								</a>
 							),
-							a: (
-								<a href={ `/page/${ site.slug }` } onClick={ this.handlePillAddPagePromptClick } />
-							),
+							a: <a href={ `/page/${ site.slug }` } onClick={ this.handleAddPagePromptClick } />,
 						},
 						comment: 'Editor: Message displayed when a page is published, with a link to the page.',
 					} );
@@ -122,7 +120,7 @@ export class EditorNotice extends Component {
 					args: { typeLabel: typeLabel },
 					components: {
 						postLink: (
-							<a href={ postUrl } onClick={ this.handlePillExternalClick }>
+							<a href={ postUrl } onClick={ this.handleViewPostClick }>
 								{ site.title }
 							</a>
 						),
@@ -175,7 +173,7 @@ export class EditorNotice extends Component {
 				return translate( '%(typeLabel)s updated! {{postLink}}Visit %(typeLabel)s{{/postLink}}.', {
 					args: { typeLabel },
 					components: {
-						postLink: <a href={ postUrl } onClick={ this.handlePillExternalClick } />,
+						postLink: <a href={ postUrl } onClick={ this.handleViewPostClick } />,
 					},
 					comment:
 						'Editor: Message displayed when a page, post, or post of a custom type is updated, with a link to the updated post.',

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -73,7 +73,8 @@ export class EditorNotice extends Component {
 		/* eslint-disable max-len */
 		const { translate, type, typeObject, site, postUrl, postDate, moment } = this.props;
 		const formattedPostDate = moment( postDate ).format( 'lll' );
-		const typeLabel = typeObject && typeObject.labels.singular_name;
+		const typeLabel =
+			typeObject && typeObject.labels.singular_name ? typeObject.labels.singular_name : type;
 
 		switch ( key ) {
 			case 'warnPublishDateChange':
@@ -84,41 +85,17 @@ export class EditorNotice extends Component {
 				);
 
 			case 'publishFailure':
-				if ( 'page' === type ) {
-					return translate( 'Publishing of page failed.' );
-				}
-
-				if ( 'post' !== type && typeLabel ) {
-					return translate( 'Publishing of %(typeLabel)s failed.', { args: { typeLabel } } );
-				}
-
-				return translate( 'Publishing of post failed.' );
+				return translate( 'Publishing of %(typeLabel)s failed.', { args: { typeLabel } } );
 
 			case 'saveFailure':
 				return translate( 'Saving of draft failed.' );
 
 			case 'trashFailure':
-				if ( 'page' === type ) {
-					return translate( 'Trashing of page failed.' );
-				}
-
-				if ( 'post' !== type && typeLabel ) {
-					return translate( 'Trashing of %(typeLabel)s failed.', { args: { typeLabel } } );
-				}
-
-				return translate( 'Trashing of post failed.' );
+				return translate( 'Trashing of %(typeLabel)s failed.', { args: { typeLabel } } );
 
 			case 'published':
 				if ( ! site ) {
-					if ( 'page' === type ) {
-						return translate( 'Page published!' );
-					}
-
-					if ( 'post' !== type && typeLabel ) {
-						return translate( '%(typeLabel)s published!', { args: { typeLabel } } );
-					}
-
-					return translate( 'Post published!' );
+					return translate( '%(typeLabel)s published!', { args: { typeLabel } } );
 				}
 
 				if ( 'page' === type ) {
@@ -137,22 +114,8 @@ export class EditorNotice extends Component {
 					} );
 				}
 
-				if ( 'post' !== type && typeLabel ) {
-					return translate( '%(typeLabel)s published on {{postLink/}}!', {
-						args: { typeLabel },
-						components: {
-							postLink: (
-								<a href={ postUrl } onClick={ this.handlePillExternalClick }>
-									{ site.title }
-								</a>
-							),
-						},
-						comment:
-							'Editor: Message displayed when a post of a custom type is published, with a link to the post.',
-					} );
-				}
-
-				return translate( 'Post published on {{postLink/}}!', {
+				return translate( '%(typeLabel)s published on {{postLink/}}!', {
+					args: { typeLabel },
 					components: {
 						postLink: (
 							<a href={ postUrl } onClick={ this.handlePillExternalClick }>
@@ -160,42 +123,19 @@ export class EditorNotice extends Component {
 							</a>
 						),
 					},
-					comment: 'Editor: Message displayed when a post is published, with a link to the post.',
+					comment:
+						'Editor: Message displayed when a post or post of a custom type is published, with a link to the post.',
 				} );
 
 			case 'scheduled':
 				if ( ! site ) {
-					if ( 'page' === type ) {
-						return translate( 'Page scheduled!' );
-					}
-
-					if ( 'post' !== type && typeLabel ) {
-						return translate( '%(typeLabel)s scheduled!', { args: { typeLabel } } );
-					}
-
-					return translate( 'Post scheduled!' );
+					return translate( '%(typeLabel)s scheduled!', { args: { typeLabel } } );
 				}
 
-				if ( 'page' === type ) {
-					return translate( 'Page scheduled for %(formattedPostDate)s!', {
-						args: { formattedPostDate },
-						comment:
-							'Editor: Message displayed when a page is scheduled, with the scheduled date and time.',
-					} );
-				}
-
-				if ( 'post' !== type && typeLabel ) {
-					return translate( '%(typeLabel)s scheduled for %(formattedPostDate)s!', {
-						args: { typeLabel, formattedPostDate },
-						comment:
-							'Editor: Message displayed when a post of a custom type is scheduled, with the scheduled date and time.',
-					} );
-				}
-
-				return translate( 'Post scheduled for %(formattedPostDate)s!', {
-					args: { formattedPostDate },
+				return translate( '%(typeLabel)s scheduled for %(formattedPostDate)s!', {
+					args: { typeLabel, formattedPostDate },
 					comment:
-						'Editor: Message displayed when a post is scheduled, with the scheduled date and time.',
+						'Editor: Message displayed when a post, page, or post of a custom type is scheduled, with the scheduled date and time.',
 				} );
 
 			case 'publishedPrivately':
@@ -225,47 +165,16 @@ export class EditorNotice extends Component {
 
 			case 'updated':
 				if ( ! site ) {
-					if ( 'page' === type ) {
-						return translate( 'Page updated!' );
-					}
-
-					if ( 'post' !== type && typeLabel ) {
-						return translate( '%(typeLabel)s updated!', { args: { typeLabel } } );
-					}
-
-					return translate( 'Post updated!' );
+					return translate( '%(typeLabel)s updated!', { args: { typeLabel } } );
 				}
 
-				if ( 'page' === type ) {
-					return translate( 'Page updated! {{postLink}}Visit page{{/postLink}}.', {
-						components: {
-							postLink: <a href={ postUrl } onClick={ this.handlePillExternalClick } />,
-						},
-						comment:
-							'Editor: Message displayed when a page is updated, with a link to the updated page.',
-					} );
-				}
-
-				if ( 'post' !== type && typeLabel ) {
-					return translate(
-						'%(typeLabel)s updated! {{postLink}}Visit %(typeLabel)s{{/postLink}}.',
-						{
-							args: { typeLabel },
-							components: {
-								postLink: <a href={ postUrl } onClick={ this.handlePillExternalClick } />,
-							},
-							comment:
-								'Editor: Message displayed when a post of a custom type is updated, with a link to the updated post.',
-						}
-					);
-				}
-
-				return translate( 'Post updated! {{postLink}}Visit post{{/postLink}}.', {
+				return translate( '%(typeLabel)s updated! {{postLink}}Visit %(typeLabel)s{{/postLink}}.', {
+					args: { typeLabel },
 					components: {
 						postLink: <a href={ postUrl } onClick={ this.handlePillExternalClick } />,
 					},
 					comment:
-						'Editor: Message displayed when a post is updated, with a link to the updated post.',
+						'Editor: Message displayed when a page, post, or post of a custom type is updated, with a link to the updated post.',
 				} );
 		}
 		/* eslint-enable max-len */

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -41,11 +41,11 @@ export class EditorNotice extends Component {
 	};
 
 	handleViewPostClick = () => {
-		this.props.recordTracksEvent( 'calypso_editor_notif_view_post_click' );
+		this.props.recordTracksEvent( 'calypso_editor_notice_view_post_click' );
 	};
 
 	handleAddPagePromptClick = () => {
-		this.props.recordTracksEvent( 'calypso_editor_notif_add_page_prompt_click' );
+		this.props.recordTracksEvent( 'calypso_editor_notice_add_page_prompt_click' );
 	};
 
 	componentWillReceiveProps( nextProps ) {
@@ -130,10 +130,6 @@ export class EditorNotice extends Component {
 				} );
 
 			case 'scheduled':
-				if ( ! site ) {
-					return translate( '%(typeLabel)s scheduled!', { args: { typeLabel } } );
-				}
-
 				return translate( '%(typeLabel)s scheduled for %(formattedPostDate)s!', {
 					args: { typeLabel, formattedPostDate },
 					comment:
@@ -152,24 +148,12 @@ export class EditorNotice extends Component {
 				);
 
 			case 'view':
-				if ( 'page' === type ) {
-					return translate( 'View Page' );
-				}
-
-				if ( 'post' !== type && typeObject ) {
-					return typeObject.labels.view_item;
-				}
-
-				return translate( 'View Post' );
+				return typeObject.labels.view_item;
 
 			case 'preview':
 				return translate( 'View Preview' );
 
 			case 'updated':
-				if ( ! site ) {
-					return translate( '%(typeLabel)s updated!', { args: { typeLabel } } );
-				}
-
 				return translate( '%(typeLabel)s updated! {{postLink}}Visit %(typeLabel)s{{/postLink}}.', {
 					args: { typeLabel },
 					components: {

--- a/client/post-editor/editor-notice/test/__snapshots__/index.jsx.snap
+++ b/client/post-editor/editor-notice/test/__snapshots__/index.jsx.snap
@@ -7,14 +7,24 @@ exports[`EditorNotice should display custom post type view label 1`] = `
   <Localized(Notice)
     showDismiss={true}
     status="is-success"
+    text="View Project"
+  />
+</div>
+`;
+
+exports[`EditorNotice should display publish success for custom post type 1`] = `
+<div
+  className="editor-notice is-global"
+>
+  <Localized(Notice)
+    showDismiss={true}
+    status="is-success"
     text={
       Array [
-        "Post published on ",
+        "jetpack-testimonial published on ",
         <a
-          href="https://example.wordpress.com"
+          href={undefined}
           onClick={[Function]}
-          rel="noopener noreferrer"
-          target="_blank"
         >
           Example Site
         </a>,
@@ -36,10 +46,8 @@ exports[`EditorNotice should display publish success for page 1`] = `
       Array [
         "Page published on ",
         <a
-          href="https://example.wordpress.com"
+          href={undefined}
           onClick={[Function]}
-          rel="noopener noreferrer"
-          target="_blank"
         >
           Example Site
         </a>,
@@ -50,6 +58,29 @@ exports[`EditorNotice should display publish success for page 1`] = `
         >
           Add another page
         </a>,
+      ]
+    }
+  />
+</div>
+`;
+
+exports[`EditorNotice should display publish success for post 1`] = `
+<div
+  className="editor-notice is-global"
+>
+  <Localized(Notice)
+    showDismiss={true}
+    status="is-success"
+    text={
+      Array [
+        "post published on ",
+        <a
+          href={undefined}
+          onClick={[Function]}
+        >
+          Example Site
+        </a>,
+        "!",
       ]
     }
   />

--- a/client/post-editor/editor-notice/test/index.jsx
+++ b/client/post-editor/editor-notice/test/index.jsx
@@ -20,7 +20,7 @@ describe( 'EditorNotice', () => {
 		chaiExpect( wrapper ).to.not.have.descendants( Notice );
 	} );
 
-	test( 'should display an no content error message if recognized', () => {
+	test( 'should display a no content error message if recognized', () => {
 		const wrapper = shallow(
 			<EditorNotice
 				translate={ translate }
@@ -84,6 +84,50 @@ describe( 'EditorNotice', () => {
 			.equal( 'is-success' );
 	} );
 
+	test( 'should display publish success for post', () => {
+		const wrapper = shallow(
+			<EditorNotice
+				translate={ translate }
+				moment={ moment }
+				message="published"
+				status="is-success"
+				type="post"
+				site={ {
+					URL: 'https://example.wordpress.com',
+					title: 'Example Site',
+					slug: 'example.wordpress.com',
+				} }
+			/>
+		);
+
+		expect( wrapper ).toMatchSnapshot();
+		chaiExpect( wrapper.find( Notice ) )
+			.to.have.prop( 'status' )
+			.equal( 'is-success' );
+	} );
+
+	test( 'should display publish success for custom post type', () => {
+		const wrapper = shallow(
+			<EditorNotice
+				translate={ translate }
+				moment={ moment }
+				message="published"
+				status="is-success"
+				type="jetpack-testimonial"
+				site={ {
+					URL: 'https://example.wordpress.com',
+					title: 'Example Site',
+					slug: 'example.wordpress.com',
+				} }
+			/>
+		);
+
+		expect( wrapper ).toMatchSnapshot();
+		chaiExpect( wrapper.find( Notice ) )
+			.to.have.prop( 'status' )
+			.equal( 'is-success' );
+	} );
+
 	test( 'should display custom post type view label', () => {
 		const wrapper = shallow(
 			<EditorNotice
@@ -95,7 +139,7 @@ describe( 'EditorNotice', () => {
 						view_item: 'View Project',
 					},
 				} }
-				message="published"
+				message="view"
 				status="is-success"
 				site={ {
 					URL: 'https://example.wordpress.com',


### PR DESCRIPTION
Fixes #22778.

This makes sure that the link in the publish notification links directly to the published item. It also consolidates translation strings, renames the notification Tracks events, and cleans up the tests.

<img width="1174" alt="screen shot 2018-03-06 at 3 04 52 pm" src="https://user-images.githubusercontent.com/942359/37055461-caf3f2b2-214f-11e8-939a-b0d7067acd58.png">

**To test:**
- For a preview-able site, when publishing a post, custom post type, or page, a preview should be shown and the success notice should match the following:
 - Post: `Post published on [post link]{Site name}[/post link]!`
 - Custom Post Type: `{Post type} published on [post link]{Site name}[/post link]!`
 - Page: `Page published on [page link]{Site name}[/page link]! [new page link]Add another page[/new page link].`