### PR TITLE
Reader Combined Card: add ellipsis menu

### DIFF
--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -23,6 +23,7 @@ import { recordTrack } from 'reader/stats';
 import { getSiteName } from 'reader/get-helpers';
 import FollowButton from 'reader/follow-button';
 import { getPostsByKeys } from 'state/reader/posts/selectors';
+import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
 
 class ReaderCombinedCard extends React.Component {
 	static propTypes = {
@@ -134,6 +135,18 @@ class ReaderCombinedCard extends React.Component {
 						/>
 					) ) }
 				</ul>
+				<div className="reader-combined-card__footer">
+					<ReaderPostOptionsMenu
+						className="reader-combined-card__options-menu ignore-click"
+						showFollow={ true }
+						showConversationFollow={ false }
+						showVisitPost={ false }
+						showEditPost={ false }
+						showReportSite={ true }
+						showReportPost={ false }
+						post={ posts[ 0 ] }
+					/>
+				</div>
 				{ feedId && <QueryReaderFeed feedId={ +feedId } includeMeta={ false } /> }
 				{ siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
 			</Card>

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -4,7 +4,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { get, size, filter, isEmpty } from 'lodash';
+import { get, size, filter, isEmpty, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -24,6 +24,7 @@ import { getSiteName } from 'reader/get-helpers';
 import FollowButton from 'reader/follow-button';
 import { getPostsByKeys } from 'state/reader/posts/selectors';
 import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
+import PostBlocked from 'blocks/reader-post-card/blocked';
 
 class ReaderCombinedCard extends React.Component {
 	static propTypes = {
@@ -36,11 +37,13 @@ class ReaderCombinedCard extends React.Component {
 		selectedPostKey: PropTypes.object,
 		showFollowButton: PropTypes.bool,
 		followSource: PropTypes.string,
+		blockedSites: PropTypes.array,
 	};
 
 	static defaultProps = {
 		isDiscover: false,
 		showFollowButton: false,
+		blockedSites: [],
 	};
 
 	componentDidMount() {
@@ -77,6 +80,7 @@ class ReaderCombinedCard extends React.Component {
 			selectedPostKey,
 			onClick,
 			isDiscover,
+			blockedSites,
 			translate,
 		} = this.props;
 		const feedId = postKey.feedId;
@@ -88,6 +92,11 @@ class ReaderCombinedCard extends React.Component {
 		const isSelectedPost = post => keysAreEqual( keyForPost( post ), selectedPostKey );
 		const followUrl = ( feed && feed.URL ) || ( site && site.URL );
 		const mediaCount = filter( posts, post => post && ! isEmpty( post.canonical_media ) ).length;
+
+		// Handle blocked sites here rather than in the post lifecycle, because we don't have the posts there
+		if ( posts[ 0 ] && ! posts[ 0 ].is_external && includes( blockedSites, +posts[ 0 ].site_ID ) ) {
+			return <PostBlocked post={ posts[ 0 ] } />;
+		}
 
 		return (
 			<Card className="reader-combined-card">

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -1,4 +1,3 @@
-/* Header */
 .reader-combined-card__header {
 	font-size: 13px;
 	display: flex;
@@ -115,10 +114,10 @@
 		&::before {
 			content: '';
 			position: absolute;
-				top: -2px;
-				bottom: 2px;
-				left: -8px;
-				width: 2px;
+			top: -2px;
+			bottom: 2px;
+			left: -8px;
+			width: 2px;
 			background: $blue-wordpress;
 
 			@include breakpoint( '>660px' ) {
@@ -180,7 +179,7 @@
 	position: relative;
 	margin-top: 3px;
 
-	&:not( .is-placeholder )::after {
+	&:not(.is-placeholder)::after {
 		@include long-content-fade( $size: 20% );
 	}
 }
@@ -222,7 +221,7 @@
 	margin-top: 4px;
 	white-space: nowrap;
 
-	&:not( .is-placeholder )::after {
+	&:not(.is-placeholder)::after {
 		@include long-content-fade( $size: 10% );
 	}
 }
@@ -253,6 +252,16 @@
 	}
 }
 
+.reader-combined-card__footer {
+	display: flex;
+	justify-content: flex-end;
+	margin-bottom: 7px;
+}
+
+.reader-combined-card__options-menu {
+	align-self: flex-end;
+}
+
 // Follow button for stream cards - copied and pasted from reader-post-card.
 // TODO: consolidate somewhere. preferably reader/follow-button
 .reader-combined-card__header .follow-button {
@@ -261,8 +270,8 @@
 	float: right;
 	padding: 0;
 	position: absolute;
-		right: 0;
-		top: 13px;
+	right: 0;
+	top: 13px;
 
 	.gridicon {
 		fill: $blue-medium;

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -98,7 +98,6 @@
 }
 
 .reader-combined-card__post-list {
-	height: 25px;
 	margin: 0;
 	width: 100%;
 }
@@ -254,6 +253,7 @@
 
 .reader-combined-card__footer {
 	display: flex;
+	height: 25px;
 	justify-content: flex-end;
 	margin-bottom: 5px;
 }

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -98,8 +98,8 @@
 }
 
 .reader-combined-card__post-list {
-	margin-left: 0;
-	margin-bottom: 18px;
+	height: 25px;
+	margin: 0;
 	width: 100%;
 }
 
@@ -255,7 +255,7 @@
 .reader-combined-card__footer {
 	display: flex;
 	justify-content: flex-end;
-	margin-bottom: 7px;
+	margin-bottom: 5px;
 }
 
 .reader-combined-card__options-menu {

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -38,6 +38,11 @@ class ReaderPostOptionsMenu extends React.Component {
 		feed: PropTypes.object,
 		onBlock: PropTypes.func,
 		showFollow: PropTypes.bool,
+		showVisitPost: PropTypes.bool,
+		showEditPost: PropTypes.bool,
+		showConversationFollow: PropTypes.bool,
+		showReportPost: PropTypes.bool,
+		showReportSite: PropTypes.bool,
 		position: PropTypes.string,
 	};
 
@@ -45,6 +50,11 @@ class ReaderPostOptionsMenu extends React.Component {
 		onBlock: noop,
 		position: 'top left',
 		showFollow: true,
+		showVisitPost: true,
+		showEditPost: true,
+		showConversationFollow: true,
+		showReportPost: true,
+		showReportSite: false,
 	};
 
 	blockSite = () => {
@@ -66,6 +76,21 @@ class ReaderPostOptionsMenu extends React.Component {
 
 		window.open(
 			'https://wordpress.com/abuse/?report_url=' + encodeURIComponent( this.props.post.URL ),
+			'_blank'
+		);
+	};
+
+	reportSite = () => {
+		if ( ! this.props.site || ! this.props.site.URL ) {
+			return;
+		}
+
+		stats.recordAction( 'report_site' );
+		stats.recordGaEvent( 'Clicked Report Site', 'post_options' );
+		stats.recordTrackForPost( 'calypso_reader_site_reported', this.props.site );
+
+		window.open(
+			'https://wordpress.com/abuse/?report_url=' + encodeURIComponent( this.props.site.URL ),
 			'_blank'
 		);
 	};
@@ -128,7 +153,8 @@ class ReaderPostOptionsMenu extends React.Component {
 		const isDiscoverPost = DiscoverHelper.isDiscoverPost( post );
 		const followUrl = this.getFollowUrl();
 		const isTeamMember = isAutomatticTeamMember( teams );
-		const showConversationFollowButton = shouldShowConversationFollowButton( post );
+		const showConversationFollowButton =
+			this.props.showConversationFollow && shouldShowConversationFollowButton( post );
 
 		let isBlockPossible = false;
 
@@ -180,17 +206,19 @@ class ReaderPostOptionsMenu extends React.Component {
 						/>
 					) }
 
-					{ post.URL && (
-						<PopoverMenuItem onClick={ this.visitPost } icon="external">
-							{ translate( 'Visit Post' ) }
-						</PopoverMenuItem>
-					) }
+					{ this.props.showVisitPost &&
+						post.URL && (
+							<PopoverMenuItem onClick={ this.visitPost } icon="external">
+								{ translate( 'Visit Post' ) }
+							</PopoverMenuItem>
+						) }
 
-					{ isEditPossible && (
-						<PopoverMenuItem onClick={ this.editPost } icon="pencil">
-							{ translate( 'Edit Post' ) }
-						</PopoverMenuItem>
-					) }
+					{ this.props.showEditPost &&
+						isEditPossible && (
+							<PopoverMenuItem onClick={ this.editPost } icon="pencil">
+								{ translate( 'Edit Post' ) }
+							</PopoverMenuItem>
+						) }
 
 					{ ( this.props.showFollow || isEditPossible || post.URL ) &&
 						( isBlockPossible || isDiscoverPost ) && (
@@ -203,11 +231,19 @@ class ReaderPostOptionsMenu extends React.Component {
 						</PopoverMenuItem>
 					) }
 
-					{ ( isBlockPossible || isDiscoverPost ) && (
+					{ ( ( this.props.showReportPost && isBlockPossible ) || isDiscoverPost ) && (
 						<PopoverMenuItem onClick={ this.reportPost }>
 							{ translate( 'Report this Post' ) }
 						</PopoverMenuItem>
 					) }
+
+					{ this.props.showReportSite &&
+						site &&
+						isBlockPossible && (
+							<PopoverMenuItem onClick={ this.reportSite }>
+								{ translate( 'Report this Site' ) }
+							</PopoverMenuItem>
+						) }
 				</EllipsisMenu>
 			</span>
 		);

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -61,6 +61,7 @@ class PostLifecycle extends React.Component {
 					selectedPostKey={ selectedPostKey }
 					followSource={ followSource }
 					showFollowButton={ this.props.showPrimaryFollowButtonOnCards }
+					blockedSites={ this.props.blockedSites }
 				/>
 			);
 		} else if ( postKey.isRecommendation ) {


### PR DESCRIPTION
Fixes #13379, which notes that there's no ellipsis menu shown on Reader combined cards. This PR adds one with the following options:
- Follow
- Block Site
- Report Site
- Blog Stickering (superadmins only)

![screen shot 2018-03-05 at 15 18 26](https://user-images.githubusercontent.com/17325/36982874-dd24cca8-2088-11e8-9ec6-21c0a59b3f49.png)

For non-admins:

![screen shot 2018-03-05 at 15 25 45](https://user-images.githubusercontent.com/17325/36983152-8db6fe10-2089-11e8-81a3-37b0f37d8072.png)

### To test

Follow a high-traffic feed like http://calypso.localhost:3000/read/feeds/18743358 and check out a combined card. The ellipsis menu should appear with the options shown above (where applicable).
