### PR TITLE
Enable the /checkout/:domain/:product route for logged-out users

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import ReactDom from 'react-dom';
 import { Provider as ReduxProvider } from 'react-redux';
@@ -12,8 +11,10 @@ import page from 'page';
 /**
  * Internal Dependencies
  */
+import config from 'config';
 import Layout from 'layout';
 import LayoutLoggedOut from 'layout/logged-out';
+import { login } from 'lib/paths';
 import { makeLayoutMiddleware } from './shared.js';
 import { getCurrentUser } from 'state/current-user/selectors';
 import userFactory from 'lib/user';
@@ -63,6 +64,20 @@ export function redirectLoggedIn( context, next ) {
 		return;
 	}
 
+	next();
+}
+
+export function redirectLoggedOut( context, next ) {
+	const currentUser = getCurrentUser( context.store.getState() );
+
+	if ( ! currentUser ) {
+		return page.redirect(
+			login( {
+				isNative: config.isEnabled( 'login/native-login-links' ),
+				redirectTo: context.path,
+			} )
+		);
+	}
 	next();
 }
 

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -7,82 +7,89 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { noSite, siteSelection } from 'my-sites/controller';
 import checkoutController from './controller';
 import SiftScience from 'lib/siftscience';
-import { makeLayout, render as clientRender } from 'controller';
+import userFactory from 'lib/user';
+import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
+import { noSite, siteSelection } from 'my-sites/controller';
 
 export default function() {
+	const user = userFactory();
+	const isLoggedIn = !! user.get();
+
 	SiftScience.recordUser();
 
-	page(
-		'/checkout/thank-you/no-site/:receiptId?',
-		noSite,
-		checkoutController.checkoutThankYou,
-		makeLayout,
-		clientRender
-	);
+	if ( isLoggedIn ) {
+		page(
+			'/checkout/thank-you/no-site/:receiptId?',
+			noSite,
+			checkoutController.checkoutThankYou,
+			makeLayout,
+			clientRender
+		);
 
-	page(
-		'/checkout/thank-you/:site/:receiptId?',
-		siteSelection,
-		checkoutController.checkoutThankYou,
-		makeLayout,
-		clientRender
-	);
+		page(
+			'/checkout/thank-you/:site/:receiptId?',
+			siteSelection,
+			checkoutController.checkoutThankYou,
+			makeLayout,
+			clientRender
+		);
 
-	page(
-		'/checkout/thank-you/:site/:receiptId/with-gsuite/:gsuiteReceiptId',
-		siteSelection,
-		checkoutController.checkoutThankYou,
-		makeLayout,
-		clientRender
-	);
+		page(
+			'/checkout/thank-you/:site/:receiptId/with-gsuite/:gsuiteReceiptId',
+			siteSelection,
+			checkoutController.checkoutThankYou,
+			makeLayout,
+			clientRender
+		);
 
-	page(
-		'/checkout/thank-you/features/:feature/:site/:receiptId?',
-		siteSelection,
-		checkoutController.checkoutThankYou,
-		makeLayout,
-		clientRender
-	);
+		page(
+			'/checkout/thank-you/features/:feature/:site/:receiptId?',
+			siteSelection,
+			checkoutController.checkoutThankYou,
+			makeLayout,
+			clientRender
+		);
 
-	page(
-		'/checkout/no-site',
-		noSite,
-		checkoutController.sitelessCheckout,
-		makeLayout,
-		clientRender
-	);
+		page(
+			'/checkout/no-site',
+			noSite,
+			checkoutController.sitelessCheckout,
+			makeLayout,
+			clientRender
+		);
 
-	page(
-		'/checkout/features/:feature/:domain/:plan_name?',
-		siteSelection,
-		checkoutController.checkout,
-		makeLayout,
-		clientRender
-	);
+		page(
+			'/checkout/features/:feature/:domain/:plan_name?',
+			siteSelection,
+			checkoutController.checkout,
+			makeLayout,
+			clientRender
+		);
+
+		page(
+			'/checkout/:product/renew/:purchaseId/:domain',
+			siteSelection,
+			checkoutController.checkout,
+			makeLayout,
+			clientRender
+		);
+
+		page(
+			'/checkout/:site/with-gsuite/:domain/:receiptId?',
+			siteSelection,
+			checkoutController.gsuiteNudge,
+			makeLayout,
+			clientRender
+		);
+	}
 
 	page(
 		'/checkout/:domain/:product?',
+		redirectLoggedOut,
 		siteSelection,
 		checkoutController.checkout,
-		makeLayout,
-		clientRender
-	);
-
-	page(
-		'/checkout/:product/renew/:purchaseId/:domain',
-		siteSelection,
-		checkoutController.checkout,
-		makeLayout,
-		clientRender
-	);
-
-	page(
-		'/checkout/:site/with-gsuite/:domain/:receiptId?',
-		siteSelection,
-		checkoutController.gsuiteNudge,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -7,7 +7,6 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-
 import checkoutController from './controller';
 import SiftScience from 'lib/siftscience';
 import userFactory from 'lib/user';
@@ -20,7 +19,7 @@ export default function() {
 
 	SiftScience.recordUser();
 
-	// TODO (seear): Temporary logged-out handling. Remove when a general solution in #23785 arrives.
+	// TODO (seear): Temporary logged-out handling. Remove when a general solution arrives in #23785.
 	if ( isLoggedOut ) {
 		page(
 			'/checkout/:domain/:product?',

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -7,6 +7,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+
 import checkoutController from './controller';
 import SiftScience from 'lib/siftscience';
 import userFactory from 'lib/user';
@@ -15,81 +16,91 @@ import { noSite, siteSelection } from 'my-sites/controller';
 
 export default function() {
 	const user = userFactory();
-	const isLoggedIn = !! user.get();
+	const isLoggedOut = ! user.get();
 
 	SiftScience.recordUser();
 
-	if ( isLoggedIn ) {
+	// TODO (seear): Temporary logged-out handling. Remove when a general solution in #23785 arrives.
+	if ( isLoggedOut ) {
 		page(
-			'/checkout/thank-you/no-site/:receiptId?',
-			noSite,
-			checkoutController.checkoutThankYou,
-			makeLayout,
-			clientRender
-		);
-
-		page(
-			'/checkout/thank-you/:site/:receiptId?',
-			siteSelection,
-			checkoutController.checkoutThankYou,
-			makeLayout,
-			clientRender
-		);
-
-		page(
-			'/checkout/thank-you/:site/:receiptId/with-gsuite/:gsuiteReceiptId',
-			siteSelection,
-			checkoutController.checkoutThankYou,
-			makeLayout,
-			clientRender
-		);
-
-		page(
-			'/checkout/thank-you/features/:feature/:site/:receiptId?',
-			siteSelection,
-			checkoutController.checkoutThankYou,
-			makeLayout,
-			clientRender
-		);
-
-		page(
-			'/checkout/no-site',
-			noSite,
-			checkoutController.sitelessCheckout,
-			makeLayout,
-			clientRender
-		);
-
-		page(
-			'/checkout/features/:feature/:domain/:plan_name?',
+			'/checkout/:domain/:product?',
+			redirectLoggedOut,
 			siteSelection,
 			checkoutController.checkout,
 			makeLayout,
 			clientRender
 		);
-
-		page(
-			'/checkout/:product/renew/:purchaseId/:domain',
-			siteSelection,
-			checkoutController.checkout,
-			makeLayout,
-			clientRender
-		);
-
-		page(
-			'/checkout/:site/with-gsuite/:domain/:receiptId?',
-			siteSelection,
-			checkoutController.gsuiteNudge,
-			makeLayout,
-			clientRender
-		);
+		return;
 	}
 
 	page(
-		'/checkout/:domain/:product?',
-		redirectLoggedOut,
+		'/checkout/thank-you/no-site/:receiptId?',
+		noSite,
+		checkoutController.checkoutThankYou,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/checkout/thank-you/:site/:receiptId?',
+		siteSelection,
+		checkoutController.checkoutThankYou,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/checkout/thank-you/:site/:receiptId/with-gsuite/:gsuiteReceiptId',
+		siteSelection,
+		checkoutController.checkoutThankYou,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/checkout/thank-you/features/:feature/:site/:receiptId?',
+		siteSelection,
+		checkoutController.checkoutThankYou,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/checkout/no-site',
+		noSite,
+		checkoutController.sitelessCheckout,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/checkout/features/:feature/:domain/:plan_name?',
 		siteSelection,
 		checkoutController.checkout,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/checkout/:domain/:product?',
+		siteSelection,
+		checkoutController.checkout,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/checkout/:product/renew/:purchaseId/:domain',
+		siteSelection,
+		checkoutController.checkout,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/checkout/:site/with-gsuite/:domain/:receiptId?',
+		siteSelection,
+		checkoutController.gsuiteNudge,
 		makeLayout,
 		clientRender
 	);

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -231,6 +231,7 @@ const sections = [
 		module: 'my-sites/checkout',
 		secondary: true,
 		group: 'sites',
+		enableLoggedOut: true,
 	},
 	{
 		name: 'plans',


### PR DESCRIPTION
Fixes #22857

Allows logged-out users to arrive at `wordpress.com/checkout/:domain/:product`. 

Adds a common middleware for diverting to Calypso /log-in form, before redirecting to the original requested route, meaning customers must log in before completing the purchase.

All other checkout routes remain logged-in only for now.

NOTE: This is a temporary solution for #22857 in lieu of a general fix in #23785.


## Testing
* Check that purchase flows still work logged-in, for example, upgrading a site to business
* In a logged-out browser window, arrive direct at a route such as
 https://calypso.live/checkout/dying-dark.jurassic.ninja/profesional?branch=update/checkout-logged-out (site can be wpcom or already-connected Jetpack)
and check that you are prompted to log in before completing the purchase


