### PR TITLE
Checkout: Disable coupon form if coupon field is empty

### DIFF
--- a/client/my-sites/checkout/cart/cart-coupon.jsx
+++ b/client/my-sites/checkout/cart/cart-coupon.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-
+import { trim } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -102,7 +102,11 @@ class CartCoupon extends React.Component {
 					onChange={ this.handleCouponInput }
 					value={ this.state.couponInputValue }
 				/>
-				<button type="submit" className="button">
+				<button
+					type="submit"
+					className="cart__button button"
+					disabled={ ! trim( this.state.couponInputValue ) }
+				>
 					{ this.props.translate( 'Apply' ) }
 				</button>
 			</form>

--- a/client/my-sites/checkout/cart/cart-coupon.jsx
+++ b/client/my-sites/checkout/cart/cart-coupon.jsx
@@ -5,12 +5,13 @@
  */
 
 import React from 'react';
-import { trim } from 'lodash';
+import { isEmpty, trim } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import analytics from 'lib/analytics';
 import { applyCoupon } from 'lib/upgrades/actions';
 
@@ -102,13 +103,9 @@ class CartCoupon extends React.Component {
 					onChange={ this.handleCouponInput }
 					value={ this.state.couponInputValue }
 				/>
-				<button
-					type="submit"
-					className="cart__button button"
-					disabled={ ! trim( this.state.couponInputValue ) }
-				>
+				<Button type="submit" disabled={ isEmpty( trim( this.state.couponInputValue ) ) }>
 					{ this.props.translate( 'Apply' ) }
-				</button>
+				</Button>
 			</form>
 		);
 	};


### PR DESCRIPTION
Fix #3799

Disable the coupon form if the coupon field is empty.

### Testing instructions

- Proceed to checkout and click on "Have a coupon code?" in the sidebar to show the coupon form.
- The coupon form submit button should be disable when the coupon field is empty or has only space characters.

### Note

> Not allowing the submission of an invalid coupon code (if there is a common format for them).

@klimeryk I've checked our coupons and they don't seem to share any format, so I've disregarded the request.