### PR TITLE
JITM: Fix incorrect messaging on themes upgrade

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -96,7 +96,9 @@ const ConnectedSingleSiteJetpack = connectOptions( props => {
 						plan={ PLAN_JETPACK_PREMIUM }
 						title={ translate( 'Access all our premium themes with our Professional plan!' ) }
 						description={ translate(
-							'Get advanced customization, more storage space, and video support along with all your new themes.'
+							'In addition to more than 100 premium themes, ' +
+								'get Elasticsearch-powered site search, real-time offsite backups, ' +
+								'and security scanning.'
 						) }
 						event="themes_plans_free_personal_premium"
 					/>


### PR DESCRIPTION
This resolves #22747 by changing the wording as suggested.

![image](https://user-images.githubusercontent.com/1883296/36989698-73c5ee94-2070-11e8-952b-17893a46d06b.png)
