### PR TITLE
Plugins: Fix description height

### DIFF
--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -26,21 +26,28 @@ class PluginSections extends React.Component {
 	state = {
 		selectedSection: false,
 		readMore: false,
+		descriptionHeight: 0,
 	};
 
 	_COLLAPSED_DESCRIPTION_HEIGHT = 140;
-	descriptionHeight = 0;
 
 	recordEvent = eventAction => {
 		analytics.ga.recordEvent( 'Plugins', eventAction, 'Plugin Name', this.props.plugin.slug );
 	};
 
+	componentDidMount() {
+		this.calculateDescriptionHeight();
+	}
+
 	componentDidUpdate() {
+		this.calculateDescriptionHeight();
+	}
+
+	calculateDescriptionHeight() {
 		if ( this.refs.content ) {
 			const node = this.refs.content;
-
-			if ( node && node.offsetHeight ) {
-				this.descriptionHeight = node.offsetHeight;
+			if ( node && node.offsetHeight && node.offsetHeight !== this.state.descriptionHeight ) {
+				this.setState( { descriptionHeight: node.offsetHeight } );
 			}
 		}
 	}
@@ -142,7 +149,7 @@ class PluginSections extends React.Component {
 	};
 
 	renderReadMore = () => {
-		if ( this.props.isWpcom || this.descriptionHeight < this._COLLAPSED_DESCRIPTION_HEIGHT ) {
+		if ( this.props.isWpcom || this.state.descriptionHeight < this._COLLAPSED_DESCRIPTION_HEIGHT ) {
 			return null;
 		}
 		const button = (


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/22000

The plugin description box height wasn't being calculated correctly when navigating from other sections. This PR fixes it.

WARNING: This is an ugly hack made over this 3-years-old code to make it work as expected. All this component should be refactored to modern standards.

To test:
======
1. You need a connected Jetpack site
2. Select your site and navigate to /plugins  (you need to navigate from there... if you load the page directly the bug wasn't happening)
3. Click on a plugin with a long description ( for example, `Google Analytics for WordPress ` )
4. You should get a "read more" button in the bottom of the description box

![image](https://user-images.githubusercontent.com/1554855/36989806-190d6472-20a3-11e8-991c-fe69b1d0bdaa.png)
