### PR TITLE
JetpackModuleToggle: Destructure ownProps

### DIFF
--- a/client/my-sites/site-settings/jetpack-module-toggle.jsx
+++ b/client/my-sites/site-settings/jetpack-module-toggle.jsx
@@ -75,11 +75,11 @@ class JetpackModuleToggle extends Component {
 }
 
 export default connect(
-	( state, ownProps ) => {
-		const active = isJetpackModuleActive( state, ownProps.siteId, ownProps.moduleSlug );
-		const activating = isActivatingJetpackModule( state, ownProps.siteId, ownProps.moduleSlug );
-		const moduleDetails = getJetpackModule( state, ownProps.siteId, ownProps.moduleSlug );
-		const deactivating = isDeactivatingJetpackModule( state, ownProps.siteId, ownProps.moduleSlug );
+	( state, { moduleSlug, siteId } ) => {
+		const active = isJetpackModuleActive( state, siteId, moduleSlug );
+		const activating = isActivatingJetpackModule( state, siteId, moduleSlug );
+		const moduleDetails = getJetpackModule( state, siteId, moduleSlug );
+		const deactivating = isDeactivatingJetpackModule( state, siteId, moduleSlug );
 		const moduleDetailsNotLoaded = moduleDetails === null;
 		const toggling = activating || deactivating;
 		return {
@@ -87,7 +87,7 @@ export default connect(
 			checked: ( active && ! deactivating ) || ( ! active && activating ),
 			toggling,
 			toggleDisabled: moduleDetailsNotLoaded || toggling,
-			isJetpackSite: isJetpackSite( state, ownProps.siteId ),
+			isJetpackSite: isJetpackSite( state, siteId ),
 		};
 	},
 	{


### PR DESCRIPTION
By-product of a #fixtheflows PR that I ended up discarding. Thought it'd be an okay change anyway.

To test: On `http://calypso.localhost:3000/settings/discussion/<JPsite>`, make sure that the "Enable pop-up business cards over commenters’ Gravatars" and "Enable comment likes" toggles still work.

![image](https://user-images.githubusercontent.com/96308/36989938-0a8516dc-209b-11e8-8bbc-b48f91fe3bf2.png)
