### PR TITLE
Settings: Add Markdown setting for JP sites

### DIFF
--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -52,7 +52,9 @@ const Composing = ( {
 					isSavingSettings={ isSavingSettings }
 					onChangeField={ onChangeField }
 				/>
-				<Markdown disabled={ isRequestingSettings || isSavingSettings } siteId={ siteId } />
+				{ jetpackSettingsUISupported && (
+					<Markdown disabled={ isRequestingSettings || isSavingSettings } siteId={ siteId } />
+				) }
 			</CardComponent>
 
 			{ jetpackSettingsUISupported && (

--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -52,6 +52,7 @@ const Composing = ( {
 					isSavingSettings={ isSavingSettings }
 					onChangeField={ onChangeField }
 				/>
+				<Markdown disabled={ isRequestingSettings || isSavingSettings } siteId={ siteId } />
 			</CardComponent>
 
 			{ jetpackSettingsUISupported && (
@@ -63,7 +64,6 @@ const Composing = ( {
 					setFieldValue={ setFieldValue }
 				/>
 			) }
-			<Markdown disabled={ isRequestingSettings || isSavingSettings } siteId={ siteId } />
 			{ hasDateTimeFormats && (
 				<DateTimeFormat
 					fields={ fields }

--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -16,6 +16,7 @@ import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import DateTimeFormat from '../date-time-format';
 import DefaultPostFormat from './default-post-format';
+import Markdown from './markdown';
 import PublishConfirmation from './publish-confirmation';
 import {
 	isJetpackMinimumVersion,
@@ -35,6 +36,7 @@ const Composing = ( {
 	jetpackSettingsUISupported,
 	onChangeField,
 	setFieldValue,
+	siteId,
 	updateFields,
 } ) => {
 	const CardComponent = jetpackSettingsUISupported ? CompactCard : Card;
@@ -61,6 +63,7 @@ const Composing = ( {
 					setFieldValue={ setFieldValue }
 				/>
 			) }
+			<Markdown disabled={ isRequestingSettings || isSavingSettings } siteId={ siteId } />
 			{ hasDateTimeFormats && (
 				<DateTimeFormat
 					fields={ fields }
@@ -99,5 +102,6 @@ export default connect( state => {
 	return {
 		hasDateTimeFormats: ! siteIsJetpack || isJetpackMinimumVersion( state, siteId, '4.7' ),
 		jetpackSettingsUISupported: siteIsJetpack && siteSupportsJetpackSettingsUi( state, siteId ),
+		siteId,
 	};
 } )( Composing );

--- a/client/my-sites/site-settings/composing/markdown.jsx
+++ b/client/my-sites/site-settings/composing/markdown.jsx
@@ -1,0 +1,39 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FormFieldset from 'components/forms/form-fieldset';
+import JetpackModuleToggle from '../jetpack-module-toggle';
+
+class Markdown extends PureComponent {
+	static propTypes = {
+		disabled: PropTypes.bool,
+		siteId: PropTypes.number,
+		translate: PropTypes.func,
+	};
+
+	render() {
+		const { disabled, siteId, translate } = this.props;
+
+		return (
+			<FormFieldset className="composing__markdown has-divider is-bottom-only">
+				<JetpackModuleToggle
+					disabled={ disabled }
+					label={ translate( 'Write posts or pages in plain-text Markdown syntax' ) }
+					moduleSlug="markdown"
+					siteId={ siteId }
+				/>
+			</FormFieldset>
+		);
+	}
+}
+
+export default localize( Markdown );

--- a/client/my-sites/site-settings/composing/markdown.jsx
+++ b/client/my-sites/site-settings/composing/markdown.jsx
@@ -11,6 +11,8 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import FormFieldset from 'components/forms/form-fieldset';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import ExternalLink from 'components/external-link';
 import JetpackModuleToggle from '../jetpack-module-toggle';
 
 class Markdown extends PureComponent {
@@ -31,6 +33,11 @@ class Markdown extends PureComponent {
 					moduleSlug="markdown"
 					siteId={ siteId }
 				/>
+				<FormSettingExplanation isIndented>
+					<ExternalLink href="https://jetpack.com/support/markdown/">
+						{ translate( 'Learn more' ) }
+					</ExternalLink>
+				</FormSettingExplanation>
 			</FormFieldset>
 		);
 	}

--- a/client/my-sites/site-settings/composing/markdown.jsx
+++ b/client/my-sites/site-settings/composing/markdown.jsx
@@ -24,7 +24,7 @@ class Markdown extends PureComponent {
 		const { disabled, siteId, translate } = this.props;
 
 		return (
-			<FormFieldset className="composing__markdown has-divider is-bottom-only">
+			<FormFieldset className="composing__markdown has-divider">
 				<JetpackModuleToggle
 					disabled={ disabled }
 					label={ translate( 'Write posts or pages in plain-text Markdown syntax' ) }

--- a/client/my-sites/site-settings/composing/markdown.jsx
+++ b/client/my-sites/site-settings/composing/markdown.jsx
@@ -24,7 +24,7 @@ class Markdown extends PureComponent {
 		const { disabled, siteId, translate } = this.props;
 
 		return (
-			<FormFieldset className="composing__markdown has-divider">
+			<FormFieldset className="composing__markdown has-divider is-top-only">
 				<JetpackModuleToggle
 					disabled={ disabled }
 					label={ translate( 'Write posts or pages in plain-text Markdown syntax' ) }

--- a/client/my-sites/site-settings/composing/markdown.jsx
+++ b/client/my-sites/site-settings/composing/markdown.jsx
@@ -3,8 +3,8 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import PropTypes from 'prop-types';
-import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -15,32 +15,26 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import ExternalLink from 'components/external-link';
 import JetpackModuleToggle from '../jetpack-module-toggle';
 
-class Markdown extends PureComponent {
-	static propTypes = {
-		disabled: PropTypes.bool,
-		siteId: PropTypes.number,
-		translate: PropTypes.func,
-	};
+const Markdown = ( { disabled, siteId, translate } ) => (
+	<FormFieldset className="composing__markdown has-divider is-top-only">
+		<JetpackModuleToggle
+			disabled={ disabled }
+			label={ translate( 'Write posts or pages in plain-text Markdown syntax' ) }
+			moduleSlug="markdown"
+			siteId={ siteId }
+		/>
+		<FormSettingExplanation isIndented>
+			<ExternalLink href="https://jetpack.com/support/markdown/">
+				{ translate( 'Learn more' ) }
+			</ExternalLink>
+		</FormSettingExplanation>
+	</FormFieldset>
+);
 
-	render() {
-		const { disabled, siteId, translate } = this.props;
-
-		return (
-			<FormFieldset className="composing__markdown has-divider is-top-only">
-				<JetpackModuleToggle
-					disabled={ disabled }
-					label={ translate( 'Write posts or pages in plain-text Markdown syntax' ) }
-					moduleSlug="markdown"
-					siteId={ siteId }
-				/>
-				<FormSettingExplanation isIndented>
-					<ExternalLink href="https://jetpack.com/support/markdown/">
-						{ translate( 'Learn more' ) }
-					</ExternalLink>
-				</FormSettingExplanation>
-			</FormFieldset>
-		);
-	}
-}
+Markdown.propTypes = {
+	disabled: PropTypes.bool,
+	siteId: PropTypes.number,
+	translate: PropTypes.func,
+};
 
 export default localize( Markdown );

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -113,6 +113,7 @@ class SiteSettingsFormDiscussion extends Component {
 			fields,
 			handleAutosavingToggle,
 			isJetpack,
+			isMarkdownModuleActive,
 			isRequestingSettings,
 			isSavingSettings,
 			siteId,
@@ -192,15 +193,16 @@ class SiteSettingsFormDiscussion extends Component {
 					moduleSlug="gravatar-hovercards"
 					siteId={ siteId }
 				/>
-				{ isJetpack && (
-					<CompactFormToggle
-						checked={ !! fields.page_comments }
-						disabled={ isRequestingSettings || isSavingSettings }
-						onChange={ handleAutosavingToggle( 'wpcom_publish_comments_with_markdown' ) }
-					>
-						{ translate( 'Enable Markdown for comments.' ) }
-					</CompactFormToggle>
-				) }
+				{ isJetpack &&
+					isMarkdownModuleActive && (
+						<CompactFormToggle
+							checked={ !! fields.page_comments }
+							disabled={ isRequestingSettings || isSavingSettings }
+							onChange={ handleAutosavingToggle( 'wpcom_publish_comments_with_markdown' ) }
+						>
+							{ translate( 'Enable Markdown for comments.' ) }
+						</CompactFormToggle>
+					) }
 				<JetpackModuleToggle
 					disabled={ isRequestingSettings || isSavingSettings }
 					label={ translate( 'Enable comment likes' ) }
@@ -643,6 +645,7 @@ const connectComponent = connect( state => {
 	const isJetpack = isJetpackSite( state, siteId );
 	const jetpackSettingsUISupported = siteSupportsJetpackSettingsUi( state, siteId );
 	const isLikesModuleActive = isJetpackModuleActive( state, siteId, 'likes' );
+	const isMarkdownModuleActive = isJetpackModuleActive( state, siteId, 'markdown' );
 
 	return {
 		siteId,
@@ -650,6 +653,7 @@ const connectComponent = connect( state => {
 		isJetpack,
 		jetpackSettingsUISupported,
 		isLikesModuleActive,
+		isMarkdownModuleActive,
 	};
 } );
 

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -112,6 +112,7 @@ class SiteSettingsFormDiscussion extends Component {
 		const {
 			fields,
 			handleAutosavingToggle,
+			isJetpack,
 			isRequestingSettings,
 			isSavingSettings,
 			siteId,
@@ -191,13 +192,15 @@ class SiteSettingsFormDiscussion extends Component {
 					moduleSlug="gravatar-hovercards"
 					siteId={ siteId }
 				/>
-				<CompactFormToggle
-					checked={ !! fields.page_comments }
-					disabled={ isRequestingSettings || isSavingSettings }
-					onChange={ handleAutosavingToggle( 'wpcom_publish_comments_with_markdown' ) }
-				>
-					{ translate( 'Enable Markdown for comments.' ) }
-				</CompactFormToggle>
+				{ isJetpack && (
+					<CompactFormToggle
+						checked={ !! fields.page_comments }
+						disabled={ isRequestingSettings || isSavingSettings }
+						onChange={ handleAutosavingToggle( 'wpcom_publish_comments_with_markdown' ) }
+					>
+						{ translate( 'Enable Markdown for comments.' ) }
+					</CompactFormToggle>
+				) }
 				<JetpackModuleToggle
 					disabled={ isRequestingSettings || isSavingSettings }
 					label={ translate( 'Enable comment likes' ) }

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -191,6 +191,13 @@ class SiteSettingsFormDiscussion extends Component {
 					moduleSlug="gravatar-hovercards"
 					siteId={ siteId }
 				/>
+				<CompactFormToggle
+					checked={ !! fields.page_comments }
+					disabled={ isRequestingSettings || isSavingSettings }
+					onChange={ handleAutosavingToggle( 'wpcom_publish_comments_with_markdown' ) }
+				>
+					{ translate( 'Enable Markdown for comments.' ) }
+				</CompactFormToggle>
 				<JetpackModuleToggle
 					disabled={ isRequestingSettings || isSavingSettings }
 					label={ translate( 'Enable comment likes' ) }
@@ -675,6 +682,7 @@ const getFormSettings = settings => {
 		'subscriptions',
 		'stb_enabled',
 		'stc_enabled',
+		'wpcom_publish_comments_with_markdown',
 	] );
 };
 

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -196,7 +196,7 @@ class SiteSettingsFormDiscussion extends Component {
 				{ isJetpack &&
 					isMarkdownModuleActive && (
 						<CompactFormToggle
-							checked={ !! fields.page_comments }
+							checked={ !! fields.wpcom_publish_comments_with_markdown }
 							disabled={ isRequestingSettings || isSavingSettings }
 							onChange={ handleAutosavingToggle( 'wpcom_publish_comments_with_markdown' ) }
 						>

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -92,7 +92,8 @@
 
 	.form-toggle__wrapper + p.form-setting-explanation.is-indented,
 	.indented-form-field,
-	.indented-form-field + p.form-setting-explanation.is-indented {
+	.indented-form-field + p.form-setting-explanation.is-indented,
+	.jetpack-module-toggle + p.form-setting-explanation.is-indented {
 		margin-left: 36px;
 	}
 


### PR DESCRIPTION
Add settings to enable Markdown editing on Jetpack sites, mimicking Jetpack's wp-admin UI -- see screenshots in #16884 (with one exception -- the `InfoPopover` next to 'Write posts or pages in plain-text Markdown syntax' just felt like terrible UX, which is why I opted for the 'Learn more' link instead).

### Before:

`/settings/writing/<JPsite>`, 'Composing' section:

![image](https://user-images.githubusercontent.com/96308/37046862-407c12ce-2161-11e8-92ac-9c2707db92d2.png)

`/settings/discussion/<JPsite>`, bottom of 'Comments' section:

![image](https://user-images.githubusercontent.com/96308/36990941-13090644-209e-11e8-864e-1ddebc0e3df8.png)

### After:

`/settings/writing/<JPsite>`, 'Composing' section:

![image](https://user-images.githubusercontent.com/96308/37046791-11852f3c-2161-11e8-8511-dcff8974393d.png)

`/settings/discussion/<JPsite>`, bottom of 'Comments' section:

![image](https://user-images.githubusercontent.com/96308/37046960-7e9e64e4-2161-11e8-9621-a17b5ce50acd.png)

### To test

* Verify that these settings are only present for JP sites, but not for WP.com ones.
* Verify that the 'Enable Markdown for comments.' toggle is not shown (by default), unless the 'Write posts or pages in plain-text Markdown syntax' toggle is enabled.
* Verify that flipping the 'Write posts or pages in plain-text Markdown syntax' toggle works (no errors, toggle state persisted after a reload), and causes the 'Enable Markdown for comments.' toggle to be shown.
* Verify that the 'Enable Markdown for comments.' works.
* Verify that once enabled, you can actually use Markdown to write posts and comments, respectively.

Fixes #16884.
