### PR TITLE
Reader: add missing external link icon to subscriptions

### DIFF
--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -27,6 +27,7 @@ import {
 import { untrailingslashit } from 'lib/route';
 import ReaderSubscriptionListItemPlaceholder from 'blocks/reader-subscription-list-item/placeholder';
 import { recordTrack, recordTrackWithRailcar } from 'reader/stats';
+import ExternalLink from 'components/external-link';
 
 /**
  * Takes in a string and removes the starting https, www., and removes a trailing slash
@@ -138,15 +139,15 @@ function ReaderSubscriptionListItem( {
 					) }
 				{ siteUrl && (
 					<div className="reader-subscription-list-item__site-url-timestamp">
-						<a
+						<ExternalLink
 							href={ siteUrl }
-							target="_blank"
-							rel="noopener noreferrer"
 							className="reader-subscription-list-item__site-url"
 							onClick={ recordSiteUrlClick }
+							icon={ true }
+							iconSize={ 14 }
 						>
 							{ formatUrlForDisplay( siteUrl ) }
-						</a>
+						</ExternalLink>
 						{ showLastUpdatedDate && (
 							<span className="reader-subscription-list-item__timestamp">
 								{ feed && feed.last_update && translate( 'updated %s', { args: lastUpdatedDate } ) }

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -135,6 +135,10 @@
 		height: 100%;
 		top: auto;
 	}
+
+	.external-link .gridicons-external {
+		margin-left: 4px;
+	}
 }
 
 .reader-subscription-list-item__site-url {


### PR DESCRIPTION
When Manage Following was refreshed, the external link icon was omitted from links that open a new window. As @alisterscott points out in #14080:

> This is good to know [especially] for desktop app where the user is taken to their browser from the app.

Fixes #14080.

![screen shot 2018-03-05 at 17 47 05](https://user-images.githubusercontent.com/17325/36990848-d0962206-209d-11e8-9e24-7c4e41966fe7.png)

### To test

Head to http://calypso.localhost:3000/following/manage and ensure that external links show the icon.