### PR TITLE
Reader: defend against invalid URL keys

### DIFF
--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -36,6 +36,11 @@ function updateEmailSubscription( state, { payload, type } ) {
 		return state;
 	}
 
+	const urlKey = prepareComparableUrl( follow.URL );
+	if ( ! urlKey ) {
+		return state;
+	}
+
 	const currentFollowState = get( follow, [ 'delivery_methods', 'email' ], {} );
 
 	const newProps = {};
@@ -65,7 +70,7 @@ function updateEmailSubscription( state, { payload, type } ) {
 
 	return {
 		...state,
-		[ prepareComparableUrl( follow.URL ) ]: {
+		[ urlKey ]: {
 			...follow,
 			delivery_methods: {
 				email: newFollowState,
@@ -78,6 +83,11 @@ function updateEmailSubscription( state, { payload, type } ) {
 function updateNotificationSubscription( state, { payload, type } ) {
 	const follow = find( state, { blog_ID: +payload.blogId } );
 	if ( ! follow ) {
+		return state;
+	}
+
+	const urlKey = prepareComparableUrl( follow.URL );
+	if ( ! urlKey ) {
 		return state;
 	}
 
@@ -95,7 +105,7 @@ function updateNotificationSubscription( state, { payload, type } ) {
 
 	return {
 		...state,
-		[ prepareComparableUrl( follow.URL ) ]: {
+		[ urlKey ]: {
 			...follow,
 			delivery_methods: {
 				email: get( follow, [ 'delivery_methods', 'email' ], {} ),
@@ -112,6 +122,9 @@ export const items = createReducer(
 	{
 		[ READER_RECORD_FOLLOW ]: ( state, action ) => {
 			const urlKey = prepareComparableUrl( action.payload.url );
+			if ( ! urlKey ) {
+				return state;
+			}
 			return {
 				...state,
 				[ urlKey ]: merge( {}, state[ urlKey ], { is_following: true } ),
@@ -119,6 +132,9 @@ export const items = createReducer(
 		},
 		[ READER_RECORD_UNFOLLOW ]: ( state, action ) => {
 			const urlKey = prepareComparableUrl( action.payload.url );
+			if ( ! urlKey ) {
+				return state;
+			}
 			return {
 				...state,
 				[ urlKey ]: merge( {}, state[ urlKey ], { is_following: false } ),
@@ -126,6 +142,9 @@ export const items = createReducer(
 		},
 		[ READER_FOLLOW_ERROR ]: ( state, action ) => {
 			const urlKey = prepareComparableUrl( action.payload.feedUrl );
+			if ( ! urlKey ) {
+				return state;
+			}
 			return {
 				...state,
 				[ urlKey ]: merge( {}, state[ urlKey ], { error: action.payload.error } ),
@@ -133,6 +152,9 @@ export const items = createReducer(
 		},
 		[ READER_FOLLOW ]: ( state, action ) => {
 			let urlKey = prepareComparableUrl( action.payload.feedUrl );
+			if ( ! urlKey ) {
+				return state;
+			}
 			const newValues = { is_following: true };
 
 			const actualFeedUrl = get( action.payload, [ 'follow', 'feed_URL' ], action.payload.feedUrl );
@@ -181,6 +203,9 @@ export const items = createReducer(
 		},
 		[ READER_UNFOLLOW ]: ( state, action ) => {
 			const urlKey = prepareComparableUrl( action.payload.feedUrl );
+			if ( ! urlKey ) {
+				return state;
+			}
 			const currentFollow = state[ urlKey ];
 			if ( ! ( currentFollow && currentFollow.is_following ) ) {
 				return state;
@@ -202,6 +227,9 @@ export const items = createReducer(
 				follows,
 				( hash, follow ) => {
 					const urlKey = prepareComparableUrl( follow.URL );
+					if ( ! urlKey ) {
+						return hash;
+					}
 					const newFollow = {
 						...follow,
 						is_following: true,
@@ -219,7 +247,7 @@ export const items = createReducer(
 				return state;
 			}
 			const urlKey = prepareComparableUrl( incomingSite.feed_URL );
-			const currentFollow = state[ urlKey ];
+			const currentFollow = urlKey && state[ urlKey ];
 			const newFollow = {
 				delivery_methods: get( incomingSite, 'subscription.delivery_methods' ),
 				is_following: true,

--- a/client/state/reader/follows/test/utils.js
+++ b/client/state/reader/follows/test/utils.js
@@ -1,0 +1,19 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { prepareComparableUrl } from '../utils';
+
+describe( 'utils', () => {
+	describe( '#prepareComparableUrl', () => {
+		test( 'should reject an invalid URL', () => {
+			const result = prepareComparableUrl( 'http://www.' );
+			expect( result ).toBeNull();
+		} );
+	} );
+
+	test( 'should format a valid URL nicely', () => {
+		const result = prepareComparableUrl( 'http://www.EXAMPLE.com/bananas/feed' );
+		expect( result ).toEqual( 'www.example.com/bananas/feed' );
+	} );
+} );

--- a/client/state/reader/follows/utils.js
+++ b/client/state/reader/follows/utils.js
@@ -5,6 +5,14 @@
 import { untrailingslashit } from 'lib/route';
 
 export function prepareComparableUrl( url ) {
-	const preparedUrl = url && untrailingslashit( url );
-	return preparedUrl && preparedUrl.replace( /^https?:\/\//, '' ).toLowerCase();
+	const unslashedUrl = url && untrailingslashit( url );
+	if ( ! unslashedUrl ) {
+		return null;
+	}
+	const preparedUrl = unslashedUrl.replace( /^https?:\/\//, '' ).toLowerCase();
+	if ( preparedUrl === 'www' || preparedUrl === 'www.' ) {
+		return null;
+	}
+
+	return preparedUrl;
 }

--- a/client/state/reader/follows/utils.js
+++ b/client/state/reader/follows/utils.js
@@ -3,16 +3,20 @@
  * Internal Dependencies
  */
 import { untrailingslashit } from 'lib/route';
+import { resemblesUrl } from 'lib/url';
 
 export function prepareComparableUrl( url ) {
 	const unslashedUrl = url && untrailingslashit( url );
 	if ( ! unslashedUrl ) {
 		return null;
 	}
-	const preparedUrl = unslashedUrl.replace( /^https?:\/\//, '' ).toLowerCase();
-	if ( preparedUrl === 'www' || preparedUrl === 'www.' ) {
+
+	// Check that the basic URL format appears valid
+	if ( ! resemblesUrl( unslashedUrl ) ) {
 		return null;
 	}
+
+	const preparedUrl = unslashedUrl.replace( /^https?:\/\//, '' ).toLowerCase();
 
 	return preparedUrl;
 }

--- a/client/state/selectors/get-reader-aliased-follow-feed-url.js
+++ b/client/state/selectors/get-reader-aliased-follow-feed-url.js
@@ -26,6 +26,10 @@ export const commonExtensions = [ 'rss', 'rss.xml', 'feed', 'feed/atom', 'atom.x
 export default function getReaderAliasedFollowFeedUrl( state, feedUrl ) {
 	const urlKey = prepareComparableUrl( feedUrl );
 
+	if ( ! urlKey ) {
+		return null;
+	}
+
 	// first check for exact match
 	if ( state.reader.follows.items[ urlKey ] ) {
 		return urlKey;
@@ -38,6 +42,7 @@ export default function getReaderAliasedFollowFeedUrl( state, feedUrl ) {
 			includes( follow.alias_feed_URLs, urlKey ) ||
 			some( commonExtensions, ext => `${ urlKey }/${ ext }` === key )
 	);
+
 	if ( foundAlias ) {
 		return foundAlias.feed_URL;
 	}

--- a/client/state/selectors/is-following.js
+++ b/client/state/selectors/is-following.js
@@ -13,13 +13,19 @@ import { prepareComparableUrl } from 'state/reader/follows/utils';
 
 export default function isFollowing( state, { feedUrl, feedId, blogId } ) {
 	let follow;
+	let comparableUrl;
+
 	if ( feedUrl ) {
-		const url = prepareComparableUrl( feedUrl );
-		follow = state.reader.follows.items[ url ];
+		comparableUrl = prepareComparableUrl( feedUrl );
+	}
+
+	if ( comparableUrl ) {
+		follow = state.reader.follows.items[ comparableUrl ];
 	} else if ( feedId ) {
 		follow = find( state.reader.follows.items, { feed_ID: feedId } );
 	} else if ( blogId ) {
 		follow = find( state.reader.follows.items, { blog_ID: blogId } );
 	}
+
 	return !! follow && follow.is_following;
 }

--- a/client/state/selectors/test/get-reader-aliased-follow-feed-url.js
+++ b/client/state/selectors/test/get-reader-aliased-follow-feed-url.js
@@ -10,13 +10,13 @@ import { expect } from 'chai';
  */
 import { getReaderAliasedFollowFeedUrl } from 'state/selectors';
 
-const site1UrlKey = 'discover.wordpress.com';
-const site1Aliases = [ 'site1 alias!', 'site1 second alias!' ];
+const site1UrlKey = 'example.com';
+const site1Aliases = [ 'www.example.com', 'www.example.com/discover/feed' ];
 
-const siteA = 'sitea/feed';
-const siteB = 'siteb/rss';
-const siteC = 'sitec/rss.xml';
-const siteD = 'sited/feed/atom';
+const siteA = 'example.com/a/feed';
+const siteB = 'example.com/b/rss';
+const siteC = 'example.com/c/rss.xml';
+const siteD = 'example.com/d/feed/atom';
 
 describe( 'getReaderAliasedFollowFeedUrl()', () => {
 	const state = {
@@ -55,10 +55,10 @@ describe( 'getReaderAliasedFollowFeedUrl()', () => {
 	} );
 
 	test( 'should try to guess basic rss/feed extensions', () => {
-		const feedUrlA = getReaderAliasedFollowFeedUrl( state, 'siteA' );
-		const feedUrlB = getReaderAliasedFollowFeedUrl( state, 'siteB' );
-		const feedUrlC = getReaderAliasedFollowFeedUrl( state, 'siteC' );
-		const feedUrlD = getReaderAliasedFollowFeedUrl( state, 'siteD' );
+		const feedUrlA = getReaderAliasedFollowFeedUrl( state, 'example.com/a' );
+		const feedUrlB = getReaderAliasedFollowFeedUrl( state, 'example.com/b' );
+		const feedUrlC = getReaderAliasedFollowFeedUrl( state, 'example.com/c' );
+		const feedUrlD = getReaderAliasedFollowFeedUrl( state, 'example.com/d' );
 
 		expect( feedUrlA ).eql( siteA );
 		expect( feedUrlB ).eql( siteB );


### PR DESCRIPTION
While working with subscriptions in state, I noticed I had deleted sites in my `state.reader.follows.items` with the keys `www` and `www.`. 

This PR adds checks for these common invalid keys, and as a result drops any subscriptions that have an empty feed URL.

### To test

Clear your local storage. 

Try subscribing and unsubscribing to feeds, and loading your subscriptions at http://calypso.localhost:3000/following/manage. Check there are no regressions.

Type `state.reader.follows.items` into your console and check that there are no subscriptions keyed off 'www' or 'www.'.
