### PR TITLE
server(context): rename 'config' prop to 'ssrConfig'

### DIFF
--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -26,7 +26,7 @@ class Desktop extends React.Component {
 			lang,
 			urls,
 			hasSecondary,
-			ssrConfig,
+			clientData,
 			isFluidWidth,
 			env,
 			isDebug,
@@ -107,11 +107,11 @@ class Desktop extends React.Component {
 							} }
 						/>
 					) }
-					{ ssrConfig && (
+					{ clientData && (
 						<script
 							type="text/javascript"
 							dangerouslySetInnerHTML={ {
-								__html: ssrConfig,
+								__html: `var configData = ${ jsonStringifyForHtml( clientData ) };`,
 							} }
 						/>
 					) }

--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -26,7 +26,7 @@ class Desktop extends React.Component {
 			lang,
 			urls,
 			hasSecondary,
-			config,
+			ssrConfig,
 			isFluidWidth,
 			env,
 			isDebug,
@@ -107,11 +107,11 @@ class Desktop extends React.Component {
 							} }
 						/>
 					) }
-					{ config && (
+					{ ssrConfig && (
 						<script
 							type="text/javascript"
 							dangerouslySetInnerHTML={ {
-								__html: config,
+								__html: ssrConfig,
 							} }
 						/>
 					) }

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -36,7 +36,7 @@ class Document extends React.Component {
 			urls,
 			hasSecondary,
 			sectionGroup,
-			ssrConfig,
+			clientData,
 			isFluidWidth,
 			sectionCss,
 			env,
@@ -60,7 +60,7 @@ class Document extends React.Component {
 			( initialReduxState
 				? `var initialReduxState = ${ jsonStringifyForHtml( initialReduxState ) };\n`
 				: '' ) +
-			( ssrConfig ? ssrConfig : '' );
+			( clientData ? `var configData = ${ jsonStringifyForHtml( clientData ) };` : '' );
 
 		return (
 			<html

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -36,7 +36,7 @@ class Document extends React.Component {
 			urls,
 			hasSecondary,
 			sectionGroup,
-			config,
+			ssrConfig,
 			isFluidWidth,
 			sectionCss,
 			env,
@@ -60,7 +60,7 @@ class Document extends React.Component {
 			( initialReduxState
 				? `var initialReduxState = ${ jsonStringifyForHtml( initialReduxState ) };\n`
 				: '' ) +
-			( config ? config : '' );
+			( ssrConfig ? ssrConfig : '' );
 
 		return (
 			<html

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -7,12 +7,11 @@ const configPath = require( 'path' ).resolve( __dirname, '..', '..', 'config' );
 const parser = require( './parser' );
 const createConfig = require( 'lib/create-config' );
 
-const { serverData: data, clientData } = parser( configPath, {
+const { serverData, clientData } = parser( configPath, {
 	env: process.env.CALYPSO_ENV || process.env.NODE_ENV || 'development',
 	enabledFeatures: process.env.ENABLE_FEATURES,
 	disabledFeatures: process.env.DISABLE_FEATURES,
 } );
-const ssrConfig = `var configData = ${ JSON.stringify( clientData ) };`;
 
-module.exports = createConfig( data );
-module.exports.ssrConfig = ssrConfig;
+module.exports = createConfig( serverData );
+module.exports.clientData = clientData;

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -184,7 +184,7 @@ export function serverRender( req, res ) {
 	}
 
 	context.head = { title, metas, links };
-	context.config = config.ssrConfig;
+	context.ssrConfig = config.ssrConfig;
 
 	if ( config.isEnabled( 'desktop' ) ) {
 		res.send( renderJsx( 'desktop', context ) );

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -184,7 +184,7 @@ export function serverRender( req, res ) {
 	}
 
 	context.head = { title, metas, links };
-	context.ssrConfig = config.ssrConfig;
+	context.clientData = config.clientData;
 
 	if ( config.isEnabled( 'desktop' ) ) {
 		res.send( renderJsx( 'desktop', context ) );


### PR DESCRIPTION
This is just a tiny detail I stumbled upon last week where I wasn't sure what `config` (used as prop for the `index` and `desktop` template) actually is 'cause it isn't the general config object but the string we pass on to the client. To be more clear about that I renamed the corresponding variable to match the config attribute.

### testing

1. Go to https://calypso.localhost:3000 and/or [calypso.live deploy](https://calypso.live/?branch=update/template/ssr-config)
2. Make sure the site is loading as expected
3. Inspect the source and make sure the `configData` (set within a script tag) hasn't changed compared to master (it's easier when using a diff tool)

<img width="329" alt="screen shot 2018-03-05 at 19 44 29" src="https://user-images.githubusercontent.com/9202899/36993268-ab6cc402-20ad-11e8-9779-9940354442ba.png">
