### PR TITLE
Reader: Fix Conversations excerpt overflowing in FF

### DIFF
--- a/client/blocks/conversations/style.scss
+++ b/client/blocks/conversations/style.scss
@@ -48,7 +48,7 @@
 
 	.reader-excerpt__content {
 		margin-top: 2px;
-		white-space: nowrap;
+		width: 100%;
 
 		&::before {
 			@include long-content-fade( $size: 35px );
@@ -70,7 +70,6 @@
 	}
 }
 
-.conversations__stream .reader-post-card.has-thumbnail .reader-post-card__title,
 .conversations__stream .reader-post-card.has-thumbnail .reader-excerpt__content {
 	width: calc( 100% - 120px );
 }

--- a/client/blocks/conversations/style.scss
+++ b/client/blocks/conversations/style.scss
@@ -17,7 +17,6 @@
 	.reader-post-card__byline-details {
 		flex-wrap: wrap;
 		max-height: none;
-		max-width: calc( 100% - 140px );
 	}
 
 	.reader-post-card__byline-author-site {
@@ -70,8 +69,9 @@
 	}
 }
 
-.conversations__stream .reader-post-card.has-thumbnail .reader-excerpt__content {
-	width: calc( 100% - 120px );
+.conversations__stream .reader-post-card.card.is-compact .reader-post-card__post-details {
+	min-width: 0;
+	white-space: nowrap;
 }
 
 .conversations__comment-list-ul {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/20657

**Before:**
![screenshot 2018-03-05 11 12 45](https://user-images.githubusercontent.com/4924246/36994770-ef89ee90-2066-11e8-8ebd-7456b328de5b.png)

**After:**
![screenshot 2018-03-05 11 13 12](https://user-images.githubusercontent.com/4924246/36994771-efa4bd06-2066-11e8-8955-4b094bf5d1da.png)
