### PR TITLE
Posts: List scheduled posts by soonest first (ASC)

### DIFF
--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -47,13 +47,15 @@ class PostsMain extends React.Component {
 			'is-multisite': ! this.props.siteId,
 			'is-single-site': this.props.siteId,
 		} );
+		const status = mapStatus( statusSlug );
 		const query = {
 			author,
 			category,
 			number: 20, // max supported by /me/posts endpoint for all-sites mode
+			order: status === 'future' ? 'ASC' : 'DESC',
 			search,
 			site_visibility: ! siteId ? 'visible' : undefined,
-			status: mapStatus( statusSlug ),
+			status,
 			tag,
 			type: 'post',
 		};


### PR DESCRIPTION
Fixes #17953

This PR changes the sort order for the Scheduled posts section to soonest first (ascending date).

To test:
- Verify that Scheduled posts are listed soonest first (make sure to test with enough posts to trigger paging; 20+).
- Verify that new scheduled posts are inserted correctly in the list.
- Verify that other sections (Published, Drafts, Trashed) continue to be sorted most recent first (descending date).