### PR TITLE
Editor: Confirmation: Shorting the heading text and make it easier to read.

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/header.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/header.jsx
@@ -3,18 +3,13 @@
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getPostTypes } from 'state/post-types/selectors';
 import * as utils from 'lib/posts/utils';
 
 class EditorConfirmationSidebarHeader extends PureComponent {
@@ -77,16 +72,4 @@ class EditorConfirmationSidebarHeader extends PureComponent {
 	}
 }
 
-export default connect( ( state, { post } ) => {
-	const siteId = getSelectedSiteId( state );
-	const postTypes = getPostTypes( state, siteId );
-	const postTypeLabel =
-		post &&
-		postTypes &&
-		postTypes[ post.type ] &&
-		get( postTypes[ post.type ], 'labels.singular_name' );
-
-	return {
-		postTypeLabel,
-	};
-} )( localize( EditorConfirmationSidebarHeader ) );
+export default localize( EditorConfirmationSidebarHeader );

--- a/client/post-editor/editor-confirmation-sidebar/header.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/header.jsx
@@ -23,131 +23,47 @@ class EditorConfirmationSidebarHeader extends PureComponent {
 	};
 
 	renderPublishHeader() {
-		const { post, translate } = this.props;
-		const postType = get( post, 'type', 'post' );
+		const { translate } = this.props;
 
-		switch ( postType ) {
-			case 'post':
-				return (
-					<div className="editor-confirmation-sidebar__header">
-						{ translate(
-							'{{strong}}Almost there!{{/strong}} ' +
-								'Double-check your post’s settings, then ' +
-								'use the big green button to publish!',
-							{
-								comment:
-									'This string appears as the header for the confirmation sidebar ' +
-									'when a user publishes a post.',
-								components: {
-									strong: <strong />,
-								},
-							}
-						) }
-					</div>
-				);
-			case 'page':
-				return (
-					<div className="editor-confirmation-sidebar__header">
-						{ translate(
-							'{{strong}}Almost there!{{/strong}} ' +
-								'Double-check your page’s settings, then ' +
-								'use the big green button to publish!',
-							{
-								comment:
-									'This string appears as the header for the confirmation sidebar ' +
-									'when a user publishes a page.',
-								components: {
-									strong: <strong />,
-								},
-							}
-						) }
-					</div>
-				);
-			default:
-				return (
-					<div className="editor-confirmation-sidebar__header">
-						{ translate(
-							'{{strong}}Almost there!{{/strong}} ' +
-								'Double-check your settings, then ' +
-								'use the big green button to publish!',
-							{
-								comment:
-									'This string appears as the header for the confirmation sidebar ' +
-									'when a user publishes a custom post type.',
-								components: {
-									strong: <strong />,
-								},
-							}
-						) }
-					</div>
-				);
-		}
+		return (
+			<div className="editor-confirmation-sidebar__header">
+				{ translate(
+					'{{strong}}Almost there!{{/strong}} ' +
+						'Double-check your settings, then ' +
+						'use the big green button to publish!',
+					{
+						comment:
+							'This string appears as the header for the confirmation sidebar ' +
+							'when a user publishes a post.',
+						components: {
+							strong: <strong />,
+						},
+					}
+				) }
+			</div>
+		);
 	}
 
 	renderScheduleHeader() {
-		const { post, postTypeLabel, translate } = this.props;
-		const postType = get( post, 'type', 'post' );
+		const { translate } = this.props;
 
-		switch ( postType ) {
-			case 'post':
-				return (
-					<div className="editor-confirmation-sidebar__header">
-						{ translate(
-							'{{strong}}Almost there!{{/strong}} ' +
-								'You can double-check your post’s settings below. When you’re happy, ' +
-								'use the big green button to schedule your post!',
-							{
-								comment:
-									'This string appears as the header for the confirmation sidebar ' +
-									'when a user schedules the publishing of a post.',
-								components: {
-									strong: <strong />,
-								},
-							}
-						) }
-					</div>
-				);
-			case 'page':
-				return (
-					<div className="editor-confirmation-sidebar__header">
-						{ translate(
-							'{{strong}}Almost there!{{/strong}} ' +
-								'You can double-check your page’s settings below. When you’re happy, ' +
-								'use the big green button to schedule your page!',
-							{
-								comment:
-									'This string appears as the header for the confirmation sidebar ' +
-									'when a user schedules the publishing of a page.',
-								components: {
-									strong: <strong />,
-								},
-							}
-						) }
-					</div>
-				);
-			default:
-				return (
-					<div className="editor-confirmation-sidebar__header">
-						{ translate(
-							'{{strong}}Almost there!{{/strong}} ' +
-								'You can double-check your settings below. When you’re happy, ' +
-								'use the big green button to schedule your %(postTypeLabel)s!',
-							{
-								comment:
-									'This string appears as the header for the confirmation sidebar ' +
-									'when a user schedules a custom post type. `postTypeLabel` is the singular ' +
-									'name of the custom post type.',
-								args: {
-									postTypeLabel,
-								},
-								components: {
-									strong: <strong />,
-								},
-							}
-						) }
-					</div>
-				);
-		}
+		return (
+			<div className="editor-confirmation-sidebar__header">
+				{ translate(
+					'{{strong}}Almost there!{{/strong}} ' +
+						'Double-check your settings below, then ' +
+						'use the big green button to schedule!',
+					{
+						comment:
+							'This string appears as the header for the confirmation sidebar ' +
+							'when a user schedules the publishing of a post.',
+						components: {
+							strong: <strong />,
+						},
+					}
+				) }
+			</div>
+		);
 	}
 
 	render() {

--- a/client/post-editor/editor-confirmation-sidebar/header.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/header.jsx
@@ -23,7 +23,7 @@ class EditorConfirmationSidebarHeader extends PureComponent {
 	};
 
 	renderPublishHeader() {
-		const { post, postTypeLabel, translate } = this.props;
+		const { post, translate } = this.props;
 		const postType = get( post, 'type', 'post' );
 
 		switch ( postType ) {
@@ -32,8 +32,8 @@ class EditorConfirmationSidebarHeader extends PureComponent {
 					<div className="editor-confirmation-sidebar__header">
 						{ translate(
 							'{{strong}}Almost there!{{/strong}} ' +
-								'You can double-check your post’s settings below. When you’re happy, ' +
-								'use the big green button to send your post out into the world!',
+								'Double-check your post’s settings, then ' +
+								'use the big green button to publish!',
 							{
 								comment:
 									'This string appears as the header for the confirmation sidebar ' +
@@ -50,8 +50,8 @@ class EditorConfirmationSidebarHeader extends PureComponent {
 					<div className="editor-confirmation-sidebar__header">
 						{ translate(
 							'{{strong}}Almost there!{{/strong}} ' +
-								'You can double-check your page’s settings below. When you’re happy, ' +
-								'use the big green button to send your page out into the world!',
+								'Double-check your page’s settings, then ' +
+								'use the big green button to publish!',
 							{
 								comment:
 									'This string appears as the header for the confirmation sidebar ' +
@@ -68,16 +68,12 @@ class EditorConfirmationSidebarHeader extends PureComponent {
 					<div className="editor-confirmation-sidebar__header">
 						{ translate(
 							'{{strong}}Almost there!{{/strong}} ' +
-								'You can double-check your settings below. When you’re happy, ' +
-								'use the big green button to send your %(postTypeLabel)s out into the world!',
+								'Double-check your settings, then ' +
+								'use the big green button to publish!',
 							{
 								comment:
 									'This string appears as the header for the confirmation sidebar ' +
-									'when a user publishes a custom post type. `postTypeLabel` is the singular ' +
-									'name of the custom post type.',
-								args: {
-									postTypeLabel,
-								},
+									'when a user publishes a custom post type.',
 								components: {
 									strong: <strong />,
 								},

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -134,7 +134,7 @@ input[type='checkbox'].editor-confirmation-sidebar__display-preference-checkbox 
 }
 
 .editor-confirmation-sidebar__header {
-	color: $gray-text-min;
-	font-size: 14px;
-	padding-bottom: 16px;
+	color: $gray-dark;
+	font-size: 15px;
+	padding-bottom: 24px;
 }


### PR DESCRIPTION
The text on the publish confirmation is really long, and due to it's low contrast its hard to read. This PR increases the contrast and font size, as well and reducing the text down to a sentence.

Also, this removes the need for all the variations in the wording by avoiding using terms like "post" or "page." This means a lot less code, too.

Before:
<img width="311" alt="screen shot 2018-03-05 at 3 21 30 pm" src="https://user-images.githubusercontent.com/191598/36997826-e5ee3108-2088-11e8-90f5-73f1db441c4f.png">

After:
<img width="332" alt="screen shot 2018-03-05 at 3 57 58 pm" src="https://user-images.githubusercontent.com/191598/36999406-0013c598-208e-11e8-8dd2-d931914b9034.png">
