### PR TITLE
Update form properties on login click

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -204,7 +204,7 @@ export class LoginForm extends Component {
 		event.preventDefault();
 
 		if ( ! this.props.hasAccountTypeLoaded ) {
-			const usernameOrEmail = this.usernameOrEmail.props.value;
+			const usernameOrEmail = document.getElementById( this.usernameOrEmail.props.id ).value;
 
 			this.props.getAuthAccountType( usernameOrEmail );
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -202,7 +202,10 @@ export class LoginForm extends Component {
 
 	onSubmitForm = event => {
 		event.preventDefault();
-		this.props.formUpdate();
+
+		// focus on the email field to retrieve any changes
+		// that may have been ignored due to chrome not using events for autofill
+		this.usernameOrEmail.focus();
 
 		if ( ! this.props.hasAccountTypeLoaded ) {
 			this.props.getAuthAccountType( this.state.usernameOrEmail );

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -180,10 +180,8 @@ export class LoginForm extends Component {
 	};
 
 	loginUser() {
-		const { usernameOrEmail } = this.state;
+		const { password, usernameOrEmail } = this.state;
 		const { onSuccess, redirectTo } = this.props;
-
-		const password = this.password.value;
 
 		this.props.recordTracksEvent( 'calypso_login_block_login_form_submit' );
 
@@ -206,7 +204,7 @@ export class LoginForm extends Component {
 		event.preventDefault();
 
 		if ( ! this.props.hasAccountTypeLoaded ) {
-			const usernameOrEmail = this.usernameOrEmail.value;
+			const usernameOrEmail = this.usernameOrEmail.props.value;
 
 			this.props.getAuthAccountType( usernameOrEmail );
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -206,8 +206,11 @@ export class LoginForm extends Component {
 		const usernameOrEmail = this.usernameOrEmail.value;
 
 		if ( ! this.props.hasAccountTypeLoaded ) {
-			// this.props.getAuthAccountType( this.state.usernameOrEmail );
 			this.props.getAuthAccountType( usernameOrEmail );
+
+			this.setState( {
+				usernameOrEmail,
+			} );
 
 			return;
 		}

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -207,6 +207,10 @@ export class LoginForm extends Component {
 		// that may have been ignored due to chrome not using events for autofill
 		this.usernameOrEmail.focus();
 
+		this.setState( {
+			usernameOrEmail: this.usernameOrEmail.value,
+		} );
+
 		if ( ! this.props.hasAccountTypeLoaded ) {
 			this.props.getAuthAccountType( this.state.usernameOrEmail );
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -203,14 +203,6 @@ export class LoginForm extends Component {
 	onSubmitForm = event => {
 		event.preventDefault();
 
-		// focus on the email field to retrieve any changes
-		// that may have been ignored due to chrome not using events for autofill
-		this.usernameOrEmail.focus();
-
-		this.setState( {
-			usernameOrEmail: this.usernameOrEmail.value,
-		} );
-
 		if ( ! this.props.hasAccountTypeLoaded ) {
 			this.props.getAuthAccountType( this.state.usernameOrEmail );
 
@@ -320,6 +312,7 @@ export class LoginForm extends Component {
 							ref={ this.saveUsernameOrEmailRef }
 							value={ this.state.usernameOrEmail }
 							disabled={ isFormDisabled || this.isPasswordView() }
+							autoComplete="username"
 						/>
 
 						{ requestError &&

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -180,8 +180,10 @@ export class LoginForm extends Component {
 	};
 
 	loginUser() {
-		const { password, usernameOrEmail } = this.state;
+		const { usernameOrEmail } = this.state;
 		const { onSuccess, redirectTo } = this.props;
+
+		const password = this.password.value;
 
 		this.props.recordTracksEvent( 'calypso_login_block_login_form_submit' );
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -318,7 +318,6 @@ export class LoginForm extends Component {
 							ref={ this.saveUsernameOrEmailRef }
 							value={ this.state.usernameOrEmail }
 							disabled={ isFormDisabled || this.isPasswordView() }
-							autoComplete="username"
 						/>
 
 						{ requestError &&

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -203,9 +203,9 @@ export class LoginForm extends Component {
 	onSubmitForm = event => {
 		event.preventDefault();
 
-		const usernameOrEmail = this.usernameOrEmail.value;
-
 		if ( ! this.props.hasAccountTypeLoaded ) {
+			const usernameOrEmail = this.usernameOrEmail.value;
+
 			this.props.getAuthAccountType( usernameOrEmail );
 
 			this.setState( {

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -8,6 +8,7 @@ import { capitalize, defer, includes } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
@@ -204,7 +205,10 @@ export class LoginForm extends Component {
 		event.preventDefault();
 
 		if ( ! this.props.hasAccountTypeLoaded ) {
-			const usernameOrEmail = document.getElementById( this.usernameOrEmail.props.id ).value;
+			// Google Chrome on iOS will autofill without sending events, leading the user
+			// to see a filled box but getting an error. We fetch the value directly from
+			// the DOM as a workaround.
+			const usernameOrEmail = ReactDom.findDOMNode( this.usernameOrEmail ).value;
 
 			this.props.getAuthAccountType( usernameOrEmail );
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -202,6 +202,7 @@ export class LoginForm extends Component {
 
 	onSubmitForm = event => {
 		event.preventDefault();
+		this.props.formUpdate();
 
 		if ( ! this.props.hasAccountTypeLoaded ) {
 			this.props.getAuthAccountType( this.state.usernameOrEmail );

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -203,8 +203,11 @@ export class LoginForm extends Component {
 	onSubmitForm = event => {
 		event.preventDefault();
 
+		const usernameOrEmail = this.usernameOrEmail.value;
+
 		if ( ! this.props.hasAccountTypeLoaded ) {
-			this.props.getAuthAccountType( this.state.usernameOrEmail );
+			// this.props.getAuthAccountType( this.state.usernameOrEmail );
+			this.props.getAuthAccountType( usernameOrEmail );
 
 			return;
 		}


### PR DESCRIPTION
It seems that Chrome on iOS is stingy with "changed" events ( see discussion [here](https://github.com/erikras/redux-form/issues/2649) )

To avoid situations like #22085 we should grab the input fields one last time on submission.

## Testing

### Prerequisites
* iOS Device with Google Chrome
* Non-iOS Device with Google Chrome

### Instructions

1. Make sure Chrome on your non-iOS device is set to save logins.
2. Navigate to https://calypso.live/log-in?branch=fix/chrome-ios-autofill on Chrome on your non-iOS device.
3. Proceed through the login steps. After inputting your password it should prompt you to save the login. Make sure the username is filled in and save the login.
4. Switch to Chrome on your iOS device after waiting a few minutes to make sure the autofill information has synced.
5. Navigate to https://calypso.live/log-in?branch=fix/chrome-ios-autofill
6. Your user name should already be filled in
7. You should be able to proceed with entering your password an authentication code.

If you were able to login the fix was successful! Note that it is known that sometimes going through the login process on non-Safari iOS browsers will not actually log you in. Getting through each of the above steps without errors is enough to test the fix. 

## Before Merging

Squash! 