### PR TITLE
Replace WordPress logo noticon loading state with svg

### DIFF
--- a/assets/stylesheets/_main.scss
+++ b/assets/stylesheets/_main.scss
@@ -6,15 +6,15 @@ $sidebar-width-max: 272px;
 $sidebar-width-min: 228px;
 
 .wpcom-site__logo {
-	color: $gray-lighten-20;
-	font-size: 12vw;
+	fill: $gray-lighten-20;
 	position: fixed;
 		top: 50%;
 		left: 50%;
 	transform: translate( -50%, -50% );
 
 	@include breakpoint( ">960px" ) {
-		font-size: 120px;
+		width: 100px;
+		height: 100px;
 	}
 }
 

--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -60,8 +60,7 @@ class Desktop extends React.Component {
 						<div className="layout">
 							<div className="masterbar" />
 							<div className="layout__content">
-								// <div className="wpcom-site__logo noticon noticon-wordpress" />
-								<WordPressLogo size={ 72 } />
+								<WordPressLogo size={ 72 } className="wpcom-site__logo" />
 								{ hasSecondary && (
 									<Fragment>
 										<div className="layout__secondary" />

--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -6,6 +6,7 @@
 
 import React, { Fragment } from 'react';
 import classNames from 'classnames';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -59,7 +60,8 @@ class Desktop extends React.Component {
 						<div className="layout">
 							<div className="masterbar" />
 							<div className="layout__content">
-								<div className="wpcom-site__logo noticon noticon-wordpress" />
+								// <div className="wpcom-site__logo noticon noticon-wordpress" />
+								<Gridicon icon="my-sites" size={ 24 } className="wpcom-site__logo" />
 								{ hasSecondary && (
 									<Fragment>
 										<div className="layout__secondary" />

--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -6,7 +6,6 @@
 
 import React, { Fragment } from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -14,6 +13,7 @@ import Gridicon from 'gridicons';
 import { jsonStringifyForHtml } from '../../server/sanitize';
 import Head from '../components/head';
 import getStylesheet from './utils/stylesheet';
+import WordPressLogo from 'components/wordpress-logo';
 
 class Desktop extends React.Component {
 	render() {
@@ -61,7 +61,7 @@ class Desktop extends React.Component {
 							<div className="masterbar" />
 							<div className="layout__content">
 								// <div className="wpcom-site__logo noticon noticon-wordpress" />
-								<Gridicon icon="my-sites" size={ 24 } className="wpcom-site__logo" />
+								<WordPressLogo size={ 72 } />
 								{ hasSecondary && (
 									<Fragment>
 										<div className="layout__secondary" />

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -7,7 +7,6 @@
 import React, { Fragment } from 'react';
 import classNames from 'classnames';
 import { get } from 'lodash';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -16,6 +15,7 @@ import { default as appConfig } from 'config';
 import { jsonStringifyForHtml } from '../../server/sanitize';
 import Head from '../components/head';
 import getStylesheet from './utils/stylesheet';
+import WordPressLogo from 'components/wordpress-logo';
 
 class Document extends React.Component {
 	render() {
@@ -108,7 +108,7 @@ class Document extends React.Component {
 								<div className="masterbar" />
 								<div className="layout__content">
 									// <div className="wpcom-site__logo noticon noticon-wordpress" />
-									<Gridicon icon="my-sites" size={ 24 } className="wpcom-site__logo" />
+									<WordPressLogo size={ 72 } />
 									{ hasSecondary && (
 										<Fragment>
 											<div className="layout__secondary" />

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -107,8 +107,7 @@ class Document extends React.Component {
 							>
 								<div className="masterbar" />
 								<div className="layout__content">
-									// <div className="wpcom-site__logo noticon noticon-wordpress" />
-									<WordPressLogo size={ 72 } />
+									<WordPressLogo size={ 72 } className="wpcom-site__logo" />
 									{ hasSecondary && (
 										<Fragment>
 											<div className="layout__secondary" />

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -7,6 +7,7 @@
 import React, { Fragment } from 'react';
 import classNames from 'classnames';
 import { get } from 'lodash';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -106,7 +107,8 @@ class Document extends React.Component {
 							>
 								<div className="masterbar" />
 								<div className="layout__content">
-									<div className="wpcom-site__logo noticon noticon-wordpress" />
+									// <div className="wpcom-site__logo noticon noticon-wordpress" />
+									<Gridicon icon="my-sites" size={ 24 } className="wpcom-site__logo" />
 									{ hasSecondary && (
 										<Fragment>
 											<div className="layout__secondary" />

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -8,6 +8,7 @@ import { compact, get } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -144,7 +145,12 @@ class JetpackOnboardingMain extends React.PureComponent {
 						steps={ steps }
 					/>
 				) : (
-					<div className="jetpack-onboarding__loading wpcom-site__logo noticon noticon-wordpress" />
+					// <div className="jetpack-onboarding__loading wpcom-site__logo noticon noticon-wordpress" />
+					<Gridicon
+						icon="my-sites"
+						size={ 24 }
+						className="jetpack-onboarding__loading wpcom-site__logo"
+					/>
 				) }
 			</Main>
 		);

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -8,7 +8,6 @@ import { compact, get } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -17,6 +16,7 @@ import config from 'config';
 import Main from 'components/main';
 import QueryJetpackOnboardingSettings from 'components/data/query-jetpack-onboarding-settings';
 import Wizard from 'components/wizard';
+import WordPressLogo from 'components/wordpress-logo';
 import { addQueryArgs, externalRedirect } from 'lib/route';
 import {
 	JETPACK_ONBOARDING_COMPONENTS as COMPONENTS,
@@ -146,11 +146,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 					/>
 				) : (
 					// <div className="jetpack-onboarding__loading wpcom-site__logo noticon noticon-wordpress" />
-					<Gridicon
-						icon="my-sites"
-						size={ 24 }
-						className="jetpack-onboarding__loading wpcom-site__logo"
-					/>
+					<WordPressLogo size={ 72 } />
 				) }
 			</Main>
 		);

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -145,8 +145,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 						steps={ steps }
 					/>
 				) : (
-					// <div className="jetpack-onboarding__loading wpcom-site__logo noticon noticon-wordpress" />
-					<WordPressLogo size={ 72 } />
+					<WordPressLogo size={ 72 } className="jetpack-onboarding__loading wpcom-site__logo" />
 				) }
 			</Main>
 		);


### PR DESCRIPTION
This replaces the WordPress logo noticon shown in the loading state of Calypso with the WordPressLogo component.

The icon increases in size after the 960px breakpoint just like before.

There are 3 files in which the noticon was used:

- client/document/index.jsx
- client/document/desktop.jsx
- client/jetpack-onboarding/main.jsx

## What I need help testing

- IE
- The desktop app (not sure how to test changes)
- The jetpack onboarding (not sure how to test changes)

Before

![before 2](https://user-images.githubusercontent.com/618551/37042147-74b219be-2123-11e8-86fa-4bdc1823998c.png)
![before](https://user-images.githubusercontent.com/618551/37042148-74c3cf74-2123-11e8-84d9-f750b993b0e0.png)

After

![download-1](https://user-images.githubusercontent.com/618551/37042158-793d873e-2123-11e8-8d4e-5d8fc3d69d06.png)
![after](https://user-images.githubusercontent.com/618551/37042159-798eba32-2123-11e8-89b3-f3276f158554.png)
