### PR TITLE
Reader: Remove non-standard breakpoints

### DIFF
--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -2,7 +2,7 @@
 .comments__comment-list {
 	border-top: 1px solid $gray-lighten-20;
 	clear: both;
-	margin: 36px 0 0;
+	margin: 36px 0;
 	padding-top: 11px;
 
 	.segmented-control {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -1,10 +1,3 @@
-// Custom breakpoints needed to match original design
-
-$reader-post-card-breakpoint-xxlarge: '( min-width: 1100px )';
-$reader-post-card-breakpoint-xlarge: '( min-width: 1040px )';
-$reader-post-card-breakpoint-large: '( min-width: 961px ) and ( max-width: 1040px )';
-$reader-post-card-breakpoint-medium: '( min-width: 661px ) and ( max-width: 940px )';
-$reader-post-card-breakpoint-small: '( max-width: 550px )';
 
 // Adds a top border to first card in the Site Stream
 .is-reader-page .is-site-stream .reader-post-card.card {
@@ -57,20 +50,6 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 
 			@include breakpoint( '>960px' ) {
 				max-width: 250px;
-			}
-
-			@media #{$reader-post-card-breakpoint-medium} {
-				height: 100px;
-				max-width: none;
-				width: 100%;
-				margin-bottom: 10px;
-			}
-
-			@media #{$reader-post-card-breakpoint-small} {
-				height: 100px;
-				max-width: none;
-				width: 100%;
-				margin-bottom: 10px;
 			}
 		}
 
@@ -131,18 +110,6 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 
 		.reader-post-card__post-details {
 			flex: 1;
-
-			@media #{$reader-post-card-breakpoint-medium} {
-				flex: 0 auto;
-				margin-top: 7px;
-				width: 100%;
-			}
-
-			@media #{$reader-post-card-breakpoint-small} {
-				flex: 0 auto;
-				margin-top: 7px;
-				width: 100%;
-			}
 		}
 	}
 
@@ -439,18 +406,6 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 		flex: 1 auto;
 		width: 100%;
 	}
-
-	@media #{$reader-post-card-breakpoint-large} {
-		flex-direction: row;
-	}
-
-	@media #{$reader-post-card-breakpoint-medium} {
-		flex-direction: column;
-	}
-
-	@media #{$reader-post-card-breakpoint-small} {
-		flex-direction: column;
-	}
 }
 
 .reader-post-card.is-expanded-video .reader-post-card__post {
@@ -586,29 +541,14 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 		@include breakpoint( '>960px' ) {
 			top: 1px;
 		}
-
-		@media #{$reader-post-card-breakpoint-xxlarge} {
-			top: 0;
-		}
-
-		@media #{$reader-post-card-breakpoint-medium} {
-			top: 1px;
-		}
-
-		@include breakpoint( '<660px' ) {
-			top: 1px;
-		}
 	}
 
 	.reader-share__button-label,
 	.comment-button__label-status,
 	.like-button__label-status {
+
 		@include breakpoint( '>960px' ) {
 			display: none;
-		}
-
-		@media #{$reader-post-card-breakpoint-xxlarge} {
-			display: inline;
 		}
 
 		@include breakpoint( '<660px' ) {
@@ -667,22 +607,17 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 
 // If chat window is open
 .is-group-reader.has-chat {
-	@media #{$reader-post-card-breakpoint-xlarge} {
-		.reader-post-card__post {
-			flex-direction: column;
-		}
 
-		.reader-post-card__post .reader-featured-image {
-			height: 100px;
-			margin-right: 0;
-			max-width: 100%;
-		}
+	.reader-post-card__post .reader-featured-image {
+		height: 100px;
+		margin-right: 0;
+		max-width: 100%;
+	}
 
-		.reader-share__button-label,
-		.comment-button__label-status,
-		.like-button__label-status {
-			display: none;
-		}
+	.reader-share__button-label,
+	.comment-button__label-status,
+	.like-button__label-status {
+		display: none;
 	}
 }
 
@@ -691,14 +626,6 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 	display: flex;
 	margin: 0 0 17px;
 	padding: 0;
-
-	@media #{$reader-post-card-breakpoint-medium} {
-		margin: 0 0 10px;
-	}
-
-	@media #{$reader-post-card-breakpoint-small} {
-		margin: 0 0 10px;
-	}
 }
 
 .reader-post-card__gallery-item {
@@ -712,14 +639,9 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 		margin-right: 0;
 	}
 
-	&:last-child {
-		@media #{$reader-post-card-breakpoint-medium} {
-			display: none;
-		}
-	}
-
 	&:nth-last-of-type(-n + 2) {
-		@include breakpoint( '<480px' ) {
+
+		@include breakpoint( "<480px" ) {
 			display: none;
 		}
 	}
@@ -727,14 +649,6 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 
 .reader-post-card .reader-featured-video__video {
 	padding-bottom: 17px;
-
-	@media #{$reader-post-card-breakpoint-medium} {
-		padding-bottom: 10px;
-	}
-
-	@media #{$reader-post-card-breakpoint-small} {
-		padding-bottom: 10px;
-	}
 }
 
 .reader-post-card__gallery-image {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -21,8 +21,8 @@
 	padding: 18px 0 20px;
 	position: relative;
 
-	@include breakpoint( '>660px' ) {
-		margin: 0;
+	@include breakpoint( "<660px" ) {
+		padding: 18px 15px 20px;
 	}
 
 	&.is-selected {
@@ -36,7 +36,7 @@
 				width: 2px;
 			background: $blue-wordpress;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint( ">660px" ) {
 				left: -16px;
 			}
 		}
@@ -50,7 +50,7 @@
 			max-width: 190px;
 			box-sizing: border-box;
 
-			@include breakpoint( '>960px' ) {
+			@include breakpoint( ">960px" ) {
 				max-width: 250px;
 			}
 		}
@@ -155,7 +155,7 @@
 			margin-top: 0;
 			margin-left: 0;
 
-			@include breakpoint( '>480px' ) {
+			@include breakpoint( ">480px" ) {
 				margin-left: 5px;
 			}
 		}
@@ -440,7 +440,7 @@
 		color: $gray-dark;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint( ">480px" ) {
 		font-size: 19px;
 	}
 }
@@ -606,7 +606,7 @@
 		margin-bottom: 3px;
 
 		.follow-button__label {
-			@include breakpoint( '<660px' ) {
+			@include breakpoint( "<660px" ) {
 				display: inline;
 			}
 		}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -1,28 +1,22 @@
 // Adds a top border to first card in the Site Stream
-.is-reader-page .is-site-stream .reader-post-card.card {
-
-	&:nth-child(2) {
-		border-top: 1px solid $gray-lighten-20;
-	}
+.is-reader-page .is-site-stream .reader-post-card.card:nth-child(2) {
+	border-top: 1px solid $gray-lighten-20;
 }
 
 // Removes top border from first card in Discover Stream
-.is-reader-page .is-discover-stream.is-site-stream .reader-post-card.card {
-
-	&:nth-child(2) {
-		border-top: 0;
-	}
+.is-reader-page .is-discover-stream.is-site-stream .reader-post-card.card:nth-child(2) {
+	border-top: 0;
 }
 
 .reader-post-card.card {
 	border-bottom: 1px solid $gray-lighten-20;
 	box-shadow: none;
-	margin: 0 8px 0 0;
+	margin: 0 15px;
 	padding: 18px 0 20px;
 	position: relative;
 
-	@include breakpoint( "<660px" ) {
-		padding: 18px 15px 20px;
+	@include breakpoint( ">660px" ) {
+		margin: 0;
 	}
 
 	&.is-selected {
@@ -43,6 +37,7 @@
 	}
 
 	&.has-thumbnail {
+
 		.reader-featured-image {
 			flex-basis: auto;
 			flex-grow: 1;
@@ -52,6 +47,12 @@
 
 			@include breakpoint( ">960px" ) {
 				max-width: 250px;
+			}
+
+			@include breakpoint( "<480px" ) {
+				height: 100px;
+				margin: 0 0 15px 0;
+				max-width: 100%;
 			}
 		}
 
@@ -407,6 +408,10 @@
 	flex-direction: row;
 	margin-top: 14px;
 
+	@include breakpoint( "<480px" ) {
+		flex-direction: column;
+	}
+
 	.reader-post-card__post-details {
 		flex: 1 auto;
 		width: 100%;
@@ -494,7 +499,7 @@
 }
 
 // 3 line excerpt for thumbnail cards
-.reader-post-card.card.has-thumbnail:not(.is-gallery):not(.is-discover):not(.is-compact) {
+.reader-post-card.card.has-thumbnail:not(.is-gallery):not(.is-compact) {
 
 	.reader-excerpt {
 		max-height: 15px * 1.6 * 3.2;
@@ -507,13 +512,10 @@
 	font-size: 14px;
 	height: 22px;
 
-	&.reader-post-actions__visit {
-
-		.gridicon {
-			position: relative;
-				left: -2px;
-				top: -1px;
-		}
+	&.reader-post-actions__visit .gridicon {
+		position: relative;
+			left: -2px;
+			top: -1px;
 	}
 
 	.gridicons-external {
@@ -540,14 +542,6 @@
 	.comment-button .gridicon {
 		top: 4px;
 		margin-right: 2px;
-	}
-
-	.reader-share_button .gridicon {
-		position: relative;
-
-		@include breakpoint( ">960px" ) {
-			top: 1px;
-		}
 	}
 
 	.reader-share__button-label,

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -1,6 +1,6 @@
-
 // Adds a top border to first card in the Site Stream
 .is-reader-page .is-site-stream .reader-post-card.card {
+
 	&:nth-child(2) {
 		border-top: 1px solid $gray-lighten-20;
 	}
@@ -8,6 +8,7 @@
 
 // Removes top border from first card in Discover Stream
 .is-reader-page .is-discover-stream.is-site-stream .reader-post-card.card {
+
 	&:nth-child(2) {
 		border-top: 0;
 	}
@@ -16,7 +17,7 @@
 .reader-post-card.card {
 	border-bottom: 1px solid $gray-lighten-20;
 	box-shadow: none;
-	margin: 0 15px;
+	margin: 0 8px 0 0;
 	padding: 18px 0 20px;
 	position: relative;
 
@@ -25,6 +26,7 @@
 	}
 
 	&.is-selected {
+
 		&::before {
 			content: '';
 			position: absolute;
@@ -119,6 +121,7 @@
 
 	&.is-gallery,
 	&.is-photo {
+
 		.reader-post-card__post {
 			margin-top: 16px;
 		}
@@ -129,6 +132,7 @@
 	}
 
 	&.is-compact {
+
 		.reader-post-card__byline-details {
 			display: flex;
 			flex-direction: row;
@@ -158,6 +162,7 @@
 
 		.reader-post-card__byline-author-site,
 		.reader-post-card__timestamp-and-tag {
+
 			&::after {
 				display: none;
 			}
@@ -184,7 +189,7 @@
 		.reader-post-card__post {
 			margin-top: 0;
 
-			@include breakpoint( '<960px' ) {
+			@include breakpoint( "<960px" ) {
 				flex-direction: row;
 			}
 		}
@@ -296,7 +301,7 @@
 		@include long-content-fade( $size: 10% );
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint( ">660px" ) {
 		width: calc( 100% - 90px );
 	}
 }
@@ -323,12 +328,12 @@
 	position: relative;
 	width: calc( 100% - 140px );
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint( "<480px" ) {
 		max-width: 500px;
 	}
 
 	&::after {
-		@include long-content-fade( $size: 10% );
+		@include long-content-fade( $size: 35px );
 	}
 }
 
@@ -460,7 +465,7 @@
 		max-height: 15px * 1.6 * 3.2;
 
 		// Clamp to 2 lines on wider viewports
-		@include breakpoint( '>960px' ) {
+		@include breakpoint( ">960px" ) {
 			max-height: 15px * 1.6 * 2;
 		}
 
@@ -490,6 +495,7 @@
 
 // 3 line excerpt for thumbnail cards
 .reader-post-card.card.has-thumbnail:not(.is-gallery):not(.is-discover):not(.is-compact) {
+
 	.reader-excerpt {
 		max-height: 15px * 1.6 * 3.2;
 		overflow: hidden;
@@ -502,6 +508,7 @@
 	height: 22px;
 
 	&.reader-post-actions__visit {
+
 		.gridicon {
 			position: relative;
 				left: -2px;
@@ -538,7 +545,7 @@
 	.reader-share_button .gridicon {
 		position: relative;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint( ">960px" ) {
 			top: 1px;
 		}
 	}
@@ -547,11 +554,11 @@
 	.comment-button__label-status,
 	.like-button__label-status {
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint( ">960px" ) {
 			display: none;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint( "<660px" ) {
 			display: none;
 		}
 	}
@@ -581,6 +588,7 @@
 	}
 
 	&.is-following {
+
 		.gridicon {
 			fill: $alert-green;
 		}
@@ -633,7 +641,6 @@
 	cursor: pointer;
 	flex: 1;
 	list-style-type: none;
-	margin-right: 1px;
 
 	&:last-child {
 		margin-right: 0;
@@ -654,7 +661,7 @@
 .reader-post-card__gallery-image {
 	height: 100px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint( ">960px" ) {
 		height: 130px;
 	}
 }

--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -1,7 +1,3 @@
-// Custom breakpoints needed to match Related Posts
-$reader-related-card-breakpoint-medium: "( min-width: 661px ) and ( max-width: 730px )";
-$reader-related-card-breakpoint-small: "( max-width: 535px )";
-
 .reader-recommended-sites {
 
 	@include breakpoint( "<660px" ) {
@@ -36,20 +32,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 	flex-direction: row;
 	margin: 0 0 20px;
 	padding: 0;
-
-	@media #{$reader-related-card-breakpoint-medium} {
-		flex-direction: column;
-	}
-
-	@include breakpoint( "<660px" ) {
-		flex-direction: row;
-		flex: 0;
-	}
-
-	@media #{$reader-related-card-breakpoint-small} {
-		flex-direction: column;
-		flex: 0;
-	}
 }
 
 .reader-recommended-sites__site-list-item {
@@ -58,26 +40,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 	flex-direction: column;
 	list-style-type: none;
 	margin-top: -40px;
-
-	@media #{$reader-related-card-breakpoint-medium} {
-		flex-direction: row;
-		flex: 0 1 auto;
-		margin-top: 0;
-
-		& + & {
-			margin-top: 10px;
-		}
-	}
-
-	@media #{$reader-related-card-breakpoint-small} {
-		flex-direction: row;
-		flex: 0 1 auto;
-		margin-top: 0;
-
-		& + & {
-			margin-top: 10px;
-		}
-	}
 
 	> :nth-child(2) {
 		flex: 1 1 auto;
@@ -99,14 +61,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 				top: -2px;
 				right: -2px;
 			}
-
-			@media #{$reader-related-card-breakpoint-medium}{
-				right: 0;
-			}
-
-			@media #{$reader-related-card-breakpoint-small}{
-				top: 8px;
-			}
 		}
 
 		.button.is-borderless .gridicon,
@@ -121,10 +75,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 	.reader-subscription-list-item {
 		padding: 5px 0;
 		position: relative;
-
-		@media #{$reader-related-card-breakpoint-medium} {
-			margin: 0 0 0 10px;
-		}
 
 		@include breakpoint( "<660px" ) {
 			margin: 10px 0 0 10px;
@@ -147,27 +97,10 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 
 	&:first-child {
 		margin-right: 20px;
-
-		@media #{$reader-related-card-breakpoint-small} {
-			margin-right: 0;
-		}
 	}
 
 	&:last-child {
 		margin-left: 20px;
-
-		@media #{$reader-related-card-breakpoint-small} {
-			margin-left: 0;
-		}
-	}
-
-	&:first-child,
-	&:last-child {
-
-		@media #{$reader-related-card-breakpoint-medium} {
-			margin-left: 0;
-			margin-right: 0;
-		}
 	}
 
 	&:only-child {
@@ -207,7 +140,7 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 
 		&:not(.is-placeholder) {
 			&::after {
-				@include long-content-fade( $size: 20% );
+				@include long-content-fade( $size: 35px );
 			}
 		}
 

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -252,7 +252,7 @@
 
 .reader-related-card__featured-image {
 	border: 1px solid $gray-lighten-30;
-	min-height: 100px;
+	min-height: 78px;
 
 	@include breakpoint( ">960px" ) {
 		min-height: 153px;

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -1,3 +1,4 @@
+
 // Custom breakpoints
 $reader-related-card-breakpoint-medium: "( min-width: 661px ) and ( max-width: 730px )";
 $reader-related-card-breakpoint-small: "( max-width: 535px )";
@@ -442,7 +443,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 	display: flex;
 	font-weight: 500;
 	max-height: 14px * 1.75;
-	max-width: 200px;
 	overflow: hidden;
 	overflow-wrap: break-word;
 	position: relative;
@@ -452,26 +452,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 
 	&::after {
 		@include long-content-fade( $size: 15% );
-	}
-
-	@include breakpoint( "<960px" ) {
-		max-width: 145px;
-	}
-
-	@media #{$reader-related-card-breakpoint-medium} {
-		max-width: 200px;
-	}
-
-	@include breakpoint( "<660px" ) {
-		max-width: 145px;
-	}
-
-	@media #{$reader-related-card-breakpoint-small} {
-		max-width: 200px;
-	}
-
-	@include breakpoint( "<480px" ) {
-		max-width: 110px;
 	}
 }
 

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -1,8 +1,3 @@
-
-// Custom breakpoints
-$reader-related-card-breakpoint-medium: "( min-width: 661px ) and ( max-width: 730px )";
-$reader-related-card-breakpoint-small: "( max-width: 535px )";
-
 .reader-related-card__heading {
 	color: $gray;
 	font-size: 14px;
@@ -20,11 +15,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 	&::after{
 		@include long-content-fade( $size: 35px );
 	}
-
-	@include breakpoint( "<660px" ) {
-		margin-bottom: 0;
-		padding-bottom: 20px;
-	}
 }
 
 .reader-related-card__link,
@@ -39,20 +29,12 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 
 .reader-related-card__list {
 	display: flex;
-	flex-direction: row;
+	flex-direction: column;
 	margin: 0;
 	padding: 0;
 
-	@media #{$reader-related-card-breakpoint-medium} {
-		display: block;
-	}
-
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( ">480px" ) {
 		flex-direction: row;
-	}
-
-	@media #{$reader-related-card-breakpoint-small} {
-		display: block;
 	}
 }
 
@@ -81,14 +63,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 	&:first-child,
 	&:last-child {
 
-		@media #{$reader-related-card-breakpoint-medium} {
-			margin: 0 0 20px 0;
-		}
-
-		@media #{$reader-related-card-breakpoint-small} {
-			margin: 0 0 20px 0;
-		}
-
 		@include breakpoint( "<480px" ) {
 			margin: 0 0 20px 0;
 		}
@@ -106,16 +80,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 	padding: 0;
 
 	@include breakpoint( "<480px" ) {
-		display: flex;
-		flex-direction: column;
-	}
-
-	@media #{$reader-related-card-breakpoint-medium} {
-		display: flex;
-		flex-direction: column;
-	}
-
-	@media #{$reader-related-card-breakpoint-small} {
 		display: flex;
 		flex-direction: column;
 	}
@@ -146,14 +110,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 		display: block;
 		overflow: hidden;
 
-		@media #{$reader-related-card-breakpoint-medium} {
-			display: flex;
-		}
-
-		@media #{$reader-related-card-breakpoint-small} {
-			display: flex;
-		}
-
 		&::after {
 			@include long-content-fade( $size: 35px );
 				bottom: 0;
@@ -164,21 +120,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 	}
 
 	&.has-thumbnail {
-
-		.reader-related-card__meta {
-			margin-bottom: 16px;
-		}
-
-		.reader-related-card__site-info {
-
-			@media #{$reader-related-card-breakpoint-small} {
-				flex: 3 0 0;
-			}
-
-			@media #{$reader-related-card-breakpoint-medium} {
-				flex: 3 0 0;
-			}
-		}
 
 		.reader-related-card__title {
 			font-size: 17px;
@@ -196,25 +137,22 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 
 .reader-related-card__blocks {
 	border-top: 1px solid $gray-lighten-20;
-	padding-top: 11px;
+	margin-top: 30px;
 
-	.reader-related-card__post {
-		max-height: 206px;
+	@include breakpoint( "<480px" ) {
+		margin-top: 0;
+	}
 
-		&::after {
-			@include long-content-fade( $size: 35px );
-			bottom: 0;
-			height: 22px;
-			top: inherit;
-			visibility: visible;
-		}
+	.reader-related-card__post::after  {
+
+		@include long-content-fade( $size: 35px );
+		bottom: 0;
+		height: 22px;
+		top: inherit;
+		visibility: visible;
 	}
 
 	&.is-same-site {
-
-		.reader-related-card {
-			margin-top: -6px;
-		}
 
 		.reader-related-card__meta {
 			display: none !important; // Hides meta info from "More In Site"
@@ -224,172 +162,30 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 			margin: 0 0 14px;
 		}
 
-		.has-thumbnail {
-
-			.reader-related-card__post {
-				max-height: 17px * 1.6 * 4;
-
-				@media #{$reader-related-card-breakpoint-medium} {
-					max-height: 17px * 1.6 * 4;
-				}
-
-				@media #{$reader-related-card-breakpoint-small} {
-					max-height: 17px * 1.6 * 4;
-				}
-			}
-		}
-
-		.reader-related-card__post {
-
-			@media #{$reader-related-card-breakpoint-medium} {
-				flex: 3 0 0;
-			}
-
-			@media #{$reader-related-card-breakpoint-small} {
-				flex: 3 0 0;
-			}
-		}
-
-		.reader-related-card.has-thumbnail {
-			margin-top: 0;
+		.has-thumbnail .reader-related-card__post {
+			max-height: 17px * 1.6 * 4;
 		}
 	}
 
 	&.is-other-site {
-		margin-top: 30px;
 
 		.reader-related-card__post {
-			max-height: 17px * 1.6 * 7.5;
+			max-height: 17px * 1.6 * 4;
 
-			@media #{$reader-related-card-breakpoint-medium} {
-				max-height: 17px * 1.6 * 4;
-			}
-
-			@media #{$reader-related-card-breakpoint-small} {
-				max-height: 17px * 1.6 * 4;
-			}
-
-			@include breakpoint( "<480px" ) {
-				max-height: 17px * 1.6 * 4;
-			}
-		}
-
-		.reader-related-card__featured-image {
-
-			@media #{$reader-related-card-breakpoint-medium} {
-				margin: 0 15px 0 0;
-			}
-
-			@media #{$reader-related-card-breakpoint-small} {
-				margin: 0 15px 0 0;
-			}
-		}
-
-		.reader-related-card__meta {
-
-			@media #{$reader-related-card-breakpoint-medium} {
-				position: absolute;
-				width: 100%;
-			}
-
-			@media #{$reader-related-card-breakpoint-small} {
-				position: absolute;
-			}
-		}
-
-		.reader-related-card__post {
-
-			@media #{$reader-related-card-breakpoint-medium} {
-				margin-top: 50px;
-			}
-
-			@media #{$reader-related-card-breakpoint-small} {
-				margin-top: 50px;
+			@include breakpoint( ">480px" ) {
+				max-height: 17px * 1.6 * 7.5;
 			}
 		}
 
 		.has-thumbnail {
 
-			.reader-related-card__site-info {
-
-				@media #{$reader-related-card-breakpoint-medium} {
-					margin-top: 20px;
-				}
-
-				@media #{$reader-related-card-breakpoint-small} {
-					margin-top: 20px;
-				}
-			}
-
-			.reader-related-card__meta {
-				margin-bottom: 19px;
-
-				@media #{$reader-related-card-breakpoint-medium} {
-					margin-top: -4px;
-					right: 0;
-					width: calc( 100% - 97px );
-				}
-
-				@media #{$reader-related-card-breakpoint-small} {
-					margin-top: -4px;
-					right: 0;
-					width: calc( 100% - 97px );
-				}
-			}
-
 			.reader-related-card__post {
 				max-height: 17px * 1.6 * 4;
-
-				@media #{$reader-related-card-breakpoint-medium} {
-					flex: 3 0 0;
-					margin-top: 25px;
-					max-height: 17px * 1.6 * 4.7;
-				}
-
-				@media #{$reader-related-card-breakpoint-small} {
-					flex: 3 0 0;
-					margin-top: 25px;
-					max-height: 17px * 1.6 * 4.7;
-				}
 			}
-		}
-
-		.reader-related-card {
-			margin-top: -5px;
 		}
 
 		.reader-related-card__featured-image {
 			margin: 0 0 14px;
-		}
-	}
-
-	&.is-same-site,
-	&.is-other-site {
-
-		.reader-related-card {
-
-			@media #{$reader-related-card-breakpoint-medium} {
-				flex-direction: row;
-			}
-
-			@media #{$reader-related-card-breakpoint-small} {
-				flex-direction: row;
-			}
-		}
-
-		.reader-related-card__featured-image {
-
-			@media #{$reader-related-card-breakpoint-medium} {
-				flex: 0 0 80px;
-				margin: 0 15px 0 0;
-				width: 80px;
-			}
-
-			@media #{$reader-related-card-breakpoint-small} {
-				flex: 0 0 80px;
-				margin: 0 15px 0 0;
-				width: 80px;
-			}
 		}
 	}
 }
@@ -447,7 +243,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 	overflow-wrap: break-word;
 	position: relative;
 	text-overflow: ellipsis;
-	white-space: nowrap;
 	word-wrap: break-word;
 
 	&::after {
@@ -457,24 +252,10 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 
 .reader-related-card__featured-image {
 	border: 1px solid $gray-lighten-30;
-	min-height: 153px;
+	min-height: 100px;
 
-	@media #{$reader-related-card-breakpoint-small} {
-		flex: 1 1 0;
-		height: auto;
-		margin: 0 15px 0 0;
-		min-height: 78px;
-	}
-
-	@media #{$reader-related-card-breakpoint-medium} {
-		height: auto;
-		flex: 1 1 0;
-		margin: 0 15px 0 0;
-		min-height: 78px;
-	}
-
-	@include breakpoint( "<660px" ) {
-		min-height: 78px;
+	@include breakpoint( ">960px" ) {
+		min-height: 153px;
 	}
 }
 
@@ -492,24 +273,20 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 	font-size: 17px;
 	font-weight: 700;
 	line-height: 25px;
+	overflow: hidden;
+	max-height: 16px * 1.5 * 2;
+	word-wrap: break-word;
 
-	// Clamp to 2 lines on narrow viewports
-	@include breakpoint( "<660px" ) {
-		overflow: hidden;
-		max-height: 16px * 1.5 * 2;
-		word-wrap: break-word;
-
-		&::after {
-			@include long-content-fade( $size: 35px );
-			top: 16px * 1.4;
-			height: 16px * 1.4;
-		}
+	&::after {
+		@include long-content-fade( $size: 35px );
+		top: 16px * 1.4;
+		height: 16px * 1.4;
 	}
 
 	// Clamp to 3 lines on larger viewports
 	@include breakpoint( ">660px" ) {
 		overflow: hidden;
-		max-height: 17px * 1.56 * 3;
+		max-height: 17px * 1.48 * 3;
 		word-wrap: break-word;
 
 		&::after {
@@ -593,17 +370,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 		border: 0;
 	}
 
-	.reader-related-card__site-info {
-
-		@media #{$reader-related-card-breakpoint-medium} {
-			flex: 3 0 0;
-		}
-
-		@media #{$reader-related-card-breakpoint-small} {
-			flex: 3 0 0;
-		}
-	}
-
 	.reader-related-card__post {
 		// Clobber the long-content-fade
 		&::after {
@@ -613,6 +379,7 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 }
 
 .reader-related-card__meta.is-placeholder {
+
 	.reader-related-card__byline-author,
 	.reader-related-card__byline-site {
 		@include placeholder;

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -71,7 +71,20 @@
 // Post recommendations in Search
 .is-reader-page .search-stream .reader__content {
 	display: flex;
-	flex-flow: row wrap; // So post recs are side by side
+	flex-flow: row wrap;
+
+	@include breakpoint( "<960px") {
+		flex-flow: column wrap;
+	}
+
+	@include breakpoint( "<660px" ) {
+		flex-flow: row wrap;
+		padding: 15px 5px 15px 15px;
+	}
+
+	@include breakpoint( "<480px" ) {
+		flex-flow: column wrap;
+	}
 }
 
 .is-reader-page .search-stream.search-stream__with-sites .search-stream__results.is-two-columns .reader__content,
@@ -85,62 +98,30 @@
 	border-bottom: 1px solid $gray-lighten-20;
 	display: flex;
 	flex-basis: calc( 50% - 15px );
-	margin-left: 15px;
-	padding: 18px 0 21px 0;
-
-	@media #{$reader-related-card-breakpoint-medium} {
-		flex-basis: 100%;
-		margin: 0;
-	}
+	margin: 0 0 0 15px;
+	padding: 20px 0;
 
 	@include breakpoint( "<660px" ) {
-		flex-basis: calc( 50% - 30px );
-		margin-left: 15px;
-		margin-right: 15px;
-	}
-
-	@media #{$reader-related-card-breakpoint-small}  {
-		flex-basis: 100%;
-		margin-left: 15px;
-		margin-right: 15px;
+		margin: 0 0 0 15px;
 	}
 
 	&:nth-child( 2n ) {
-		flex-basis: calc( 50% - 15px );
-		margin-left: 0;
-		margin-right: 15px;
+		margin: 0 15px 0 0;
 
-		@media #{$reader-related-card-breakpoint-medium} {
-			flex-basis: 100%;
-			margin-right: 0;
+		@include breakpoint( "<960px" ) {
+			margin: 0;
 		}
 
 		@include breakpoint( "<660px" ) {
-			flex-basis: calc( 50% - 30px );
-			margin-left: 15px;
-			margin-right: 15px;
-		}
-
-		@media #{$reader-related-card-breakpoint-small} {
-			flex-basis: 100%;
-			margin-left: 15px;
-			margin-right: 15px;
+			margin: 0 5px 0 0;
 		}
 	}
 
 	.reader-related-card__post {
 		max-height: 208px;
 
-		@media #{$reader-related-card-breakpoint-medium} {
-			max-height: 105px;
-		}
-
 		@include breakpoint( "<660px" ) {
 			max-height: 206px;
-		}
-
-		@media #{$reader-related-card-breakpoint-small} {
-			max-height: 103px;
 		}
 
 		.reader-related-card__excerpt {
@@ -152,14 +133,6 @@
 
 		.reader-related-card__post {
 			max-height: 110px;
-
-			@media #{$reader-related-card-breakpoint-small} {
-				max-height: 104px;
-			}
-
-			@media #{$reader-related-card-breakpoint-medium} {
-				max-height: 104px;
-			}
 		}
 
 		.reader-related-card__meta {
@@ -367,22 +340,12 @@
 
 	.reader-post-card__post {
 
-		@media #{$reader-post-card-breakpoint-large} {
-			flex-direction: column;
-		}
-
 		@include breakpoint( "<960px" ) {
 			flex-direction: column;
 		}
 	}
 
 	.reader-post-card.card.has-thumbnail .reader-featured-image {
-
-		@media #{$reader-post-card-breakpoint-large} {
-			height: 80px;
-			margin: 0 0 20px;
-			max-width: 100%;
-		}
 
 		@include breakpoint( "<960px" ) {
 			height: 80px;
@@ -396,10 +359,6 @@
 	}
 
 	.reader-post-card.is-gallery .reader-post-card__gallery-item:last-child {
-
-		@media #{$reader-post-card-breakpoint-large} {
-			display: none;
-		}
 
 		@include breakpoint( "<960px" ) {
 			display: block;

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -101,8 +101,16 @@
 	margin: 0 0 0 15px;
 	padding: 20px 0;
 
+	@include breakpoint( "<960px" ) {
+		margin: 0;
+	}
+
 	@include breakpoint( "<660px" ) {
 		margin: 0 0 0 15px;
+	}
+
+	@include breakpoint( "<480px" ) {
+		margin: 0 5px 0 0;
 	}
 
 	&:nth-child( 2n ) {
@@ -118,14 +126,10 @@
 	}
 
 	.reader-related-card__post {
-		max-height: 208px;
+		max-height: 16px * 1.6 * 11;
 
-		@include breakpoint( "<660px" ) {
-			max-height: 206px;
-		}
-
-		.reader-related-card__excerpt {
-			-webkit-line-clamp: initial;
+		@include breakpoint( "<960px" ) {
+			max-height: 16px * 1.6 * 8;
 		}
 	}
 
@@ -410,6 +414,7 @@
 	z-index: z-index( 'root', '.following-manage__url-follow' );
 
 	.follow-button {
+
 		.gridicon {
 			fill: $blue-medium;
 		}
@@ -417,7 +422,7 @@
 		.follow-button__label {
 			color: $blue-medium;
 
-			@include breakpoint ("<660px" ) {
+			@include breakpoint ( "<660px" ) {
 				display: inline;
 			}
 		}

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -443,69 +443,35 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 .reader-stream__recommended-posts-list {
 	display: flex;
 	flex-direction: row;
-	margin: 0 0 -30px;
+	margin: 0;
 	padding: 0;
 
-	@media #{$reader-related-card-breakpoint-medium} {
+	@include breakpoint( "<480px" ) {
 		flex-direction: column;
-		margin: 0 0 -10px;
-	}
-
-	@include breakpoint( "<660px" ) {
-		flex-direction: row;
-		margin: 0 0 -30px;
-	}
-
-	@media #{$reader-related-card-breakpoint-small} {
-		flex-direction: column;
-		margin: 0 0 -10px;
 	}
 }
 
 .reader-stream__recommended-posts-list-item {
+	display: flex;
+	flex-direction: row;
 	list-style-type: none;
-	position: relative;
-	width: 50%;
-	position: relative;
-		top: -41px;
+	width: 100%;
 
-	@media #{$reader-related-card-breakpoint-medium} {
-		flex-direction: row;
-		top: 0;
-		width: 100%;
-	}
-
-	@media #{$reader-related-card-breakpoint-small} {
-		flex-direction: row;
-		top: 0;
-		width: 100%;
+	@include breakpoint( ">960px" ) {
+		flex-direction: column;
+		margin-top: -40px;
+		width: 50%;
 	}
 
 	.reader-stream__recommended-post-dismiss {
 		height: 30px;
 
+		@include breakpoint( "<960px" ) {
+			margin-right: 15px;
+		}
+
 		.button {
 			float: right;
-
-			@media #{$reader-related-card-breakpoint-medium} {
-				float: none;
-			}
-
-			@media #{$reader-related-card-breakpoint-small} {
-				float: none;
-			}
-		}
-
-		@media #{$reader-related-card-breakpoint-medium} {
-			float: left;
-			position: relative;
-			width: 20px;
-		}
-
-		@media #{$reader-related-card-breakpoint-small} {
-			float: left;
-			position: relative;
-			width: 20px;
 		}
 
 		.gridicon {
@@ -513,28 +479,12 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 			width: 14px;
 			height: 14px;
 			top: -3px;
-
-			@media #{$reader-related-card-breakpoint-medium} {
-				top: -10px;
-			}
-
-			@media #{$reader-related-card-breakpoint-small} {
-				top: -10px;
-			}
 		}
 	}
 
 	.card.reader-related-card {
 		margin: 0;
 		padding-top: 6px;
-
-		@media #{$reader-related-card-breakpoint-medium} {
-			padding-top: 0;
-		}
-
-		@media #{$reader-related-card-breakpoint-small} {
-			padding-top: 0;
-		}
 
 		.reader-related-card__meta .gravatar {
 			margin: 3px 8px 0 0;
@@ -544,42 +494,15 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 
 			.reader-related-card__meta {
 				margin-bottom: 17px;
-
-				@media #{$reader-related-card-breakpoint-medium} {
-					margin-top: -2px;
-				}
-
-				@media #{$reader-related-card-breakpoint-small} {
-					margin-top: -2px;
-				}
 			}
 
 			.reader-related-card__meta .follow-button {
 				margin-top: -9px;
 			}
 
-			.reader-related-card__site-info {
-
-				@media #{$reader-related-card-breakpoint-small} {
-					margin-top: 20px;
-				}
-
-				@media #{$reader-related-card-breakpoint-medium} {
-					margin-top: 20px;
-				}
-			}
-
 			.reader-related-card__post {
 				margin-top: 0;
 				max-height: 108px;
-
-				@media #{$reader-related-card-breakpoint-small} {
-					max-height: 128px;
-				}
-
-				@media #{$reader-related-card-breakpoint-medium} {
-					max-height: 128px;
-				}
 
 				@include breakpoint( "<480px" ) {
 					max-height: 125px;
@@ -607,14 +530,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 	&:first-child,
 	&:last-child {
 
-		@media #{$reader-related-card-breakpoint-medium} {
-			margin: 0 0 20px 0;
-		}
-
-		@media #{$reader-related-card-breakpoint-small} {
-			margin: 0 0 20px 0;
-		}
-
 		@include breakpoint( "<480px" ) {
 			margin: 0 0 20px 0;
 		}
@@ -632,16 +547,8 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 		margin-top: -2px;
 		max-height: 208px;
 
-		@media #{$reader-related-card-breakpoint-medium} {
-			max-height: 107px;
-		}
-
 		@include breakpoint( "<660px" ) {
 			max-height: 207px;
-		}
-
-		@media #{$reader-related-card-breakpoint-small} {
-			max-height: 104px;
 		}
 
 		.reader-related-card__excerpt {
@@ -652,13 +559,5 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 	.reader-related-card__featured-image {
 		border: 1px solid $gray-lighten-30;
 		margin: 0 0 14px;
-
-		@media #{$reader-related-card-breakpoint-medium} {
-			margin: 0 15px 0 0;
-		}
-
-		@media #{$reader-related-card-breakpoint-small} {
-			margin: 0 15px 0 0;
-		}
 	}
 }


### PR DESCRIPTION
In Reader, we use several custom media queries for post recommendations:

```-$reader-post-card-breakpoint-xxlarge:` '( min-width: 1100px )';
-$reader-post-card-breakpoint-xlarge: '( min-width: 1040px )';
-$reader-post-card-breakpoint-large: '( min-width: 961px ) and ( max-width: 1040px )';
-$reader-post-card-breakpoint-medium: '( min-width: 661px ) and ( max-width: 940px )';
-$reader-post-card-breakpoint-small: '( max-width: 550px )';
-$reader-related-card-breakpoint-medium: "( min-width: 661px ) and ( max-width: 730px )";
-$reader-related-card-breakpoint-small: "( max-width: 535px `)";```

This PR makes sure we use standard Calypso breakpoint mixins and tidies up the CSS a bit.

## Search recs:

- The cards get stacked at `960px` instead of at random `731px`:

Side by side:
![screenshot 2018-03-06 12 47 24](https://user-images.githubusercontent.com/4924246/37057791-5c3db22a-213d-11e8-8cda-774430088e0b.png)

Stacked:
![screenshot 2018-03-06 12 53 37](https://user-images.githubusercontent.com/4924246/37057802-66f3b05c-213d-11e8-8a7b-cba10da429db.png)

## Fullpost recs:

- The cards remain side by side until `<480px` where they get stacked. The layout where the thumbnail is on the left at `<731px` and `<536px` gets omitted:

Side by side:
![screenshot 2018-03-06 13 00 47](https://user-images.githubusercontent.com/4924246/37058154-6f5d58d2-213e-11e8-8d73-2656c0108953.png)

Stacked:
![screenshot 2018-03-06 13 00 55](https://user-images.githubusercontent.com/4924246/37058157-737b979e-213e-11e8-8a48-ecbf51a2cac6.png)

This layout gets omitted:
![screenshot 2018-03-06 13 01 36](https://user-images.githubusercontent.com/4924246/37058175-831c31f4-213e-11e8-93a4-52c1507db353.png)

## In-stream recs:
- The cards remain side by side until `<480px` where they get stacked. They no longer get stacked at `<731px` and `<536px`:

Side by side:
![screenshot 2018-03-06 13 05 51](https://user-images.githubusercontent.com/4924246/37058362-206e730e-213f-11e8-9892-063fb521f1aa.png)

Stacked:
![screenshot 2018-03-06 13 05 59](https://user-images.githubusercontent.com/4924246/37058365-23f2aa36-213f-11e8-9811-1b338918a8d5.png)

Let's keep an eye out on stats to see if these changes affect clickthroughs for recommendations at all.
