### PR TITLE
Domains: Update Domain Mapping Thank You

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/domain-mapping-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/domain-mapping-details.jsx
@@ -21,12 +21,12 @@ const DomainMappingDetails = ( {
 	domain,
 	isBusinessPlan,
 	isSubdomainMapping,
-	isRegisteredWithUs,
+	isRootDomainWithUs,
 	registrarSupportUrl,
 	selectedSiteDomain,
 	translate,
 } ) => {
-	if ( isSubdomainMapping && isRegisteredWithUs ) {
+	if ( isSubdomainMapping && isRootDomainWithUs ) {
 		return null;
 	}
 

--- a/client/my-sites/checkout/checkout-thank-you/domain-mapping-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/domain-mapping-details.jsx
@@ -31,12 +31,13 @@ const DomainMappingDetails = ( {
 		<span />
 	);
 
-	const domainInstructions = (
+	let instructions = (
 		<div>
 			<p>
 				{ translate(
-					"If not, you will need to log into {{registrarSupportLink}}your registrar's site{{/registrarSupportLink}} " +
-						'(where you purchased the domain originally) and change the "Name Servers" to:',
+					'To point your domain at your WordPress.com site, log in to your' +
+						"{{registrarSupportLink}}domain provider's site{{/registrarSupportLink}} " +
+						'(where you purchased the domain), and update your name servers to:',
 					{
 						components: {
 							registrarSupportLink: registrarSupportLink,
@@ -52,72 +53,58 @@ const DomainMappingDetails = ( {
 		</div>
 	);
 
-	const subdomainInstructions = (
-		<div>
-			<p>
-				{ translate(
-					"If not, you will need to log into {{registrarSupportLink}}your registrar's site{{/registrarSupportLink}} " +
-						'(where you purchased the domain originally) and add the following "CNAME" record:',
-					{
-						components: {
-							registrarSupportLink: registrarSupportLink,
-						},
-					}
-				) }
-			</p>
-			<ul className="checkout-thank-you__domain-mapping-details-nameservers">
-				<li>
-					{ domain }. IN CNAME { selectedSiteDomain }.
-				</li>
-			</ul>
-		</div>
-	);
+	if ( isSubdomainMapping ) {
+		instructions = (
+			<div>
+				<p>
+					{ translate(
+						'To point your domain at your WordPress.com site, log in to your ' +
+							"{{registrarSupportLink}}domain provider's site{{/registrarSupportLink}} " +
+							'(where you purchased the domain), and edit the DNS records to add a CNAME record:',
+						{
+							components: {
+								registrarSupportLink: registrarSupportLink,
+							},
+						}
+					) }
+				</p>
+				<ul className="checkout-thank-you__domain-mapping-details-nameservers">
+					<li>
+						{ domain }. IN CNAME { selectedSiteDomain }.
+					</li>
+				</ul>
+			</div>
+		);
+	}
 
-	const subdomainInstructionsBusiness = (
-		<div>
-			<p>
-				{ translate(
-					"If not, you will need to log into {{registrarSupportLink}}your registrar's site{{/registrarSupportLink}} " +
-						'(where you purchased the domain originally) and add the following "NS" records:',
-					{
-						components: {
-							registrarSupportLink: registrarSupportLink,
-						},
-					}
-				) }
-			</p>
-			<ul className="checkout-thank-you__domain-mapping-details-nameservers">
-				<li>{ domain }. IN NS ns1.wordpress.com.</li>
-				<li>{ domain }. IN NS ns2.wordpress.com.</li>
-				<li>{ domain }. IN NS ns3.wordpress.com.</li>
-			</ul>
-		</div>
-	);
+	if ( isSubdomainMapping && isBusinessPlan ) {
+		instructions = (
+			<div>
+				<p>
+					{ translate(
+						'To point your domain at your WordPress.com site, log in to your ' +
+							"{{registrarSupportLink}}domain provider's site{{/registrarSupportLink}} " +
+							'(where you purchased the domain), and edit the DNS records to add NS records:',
+						{
+							components: {
+								registrarSupportLink: registrarSupportLink,
+							},
+						}
+					) }
+				</p>
+				<ul className="checkout-thank-you__domain-mapping-details-nameservers">
+					<li>{ domain }. IN NS ns1.wordpress.com.</li>
+					<li>{ domain }. IN NS ns2.wordpress.com.</li>
+					<li>{ domain }. IN NS ns3.wordpress.com.</li>
+				</ul>
+			</div>
+		);
+	}
 
 	const description = (
 		<div>
-			<p>
-				{ translate(
-					'Your domain {{em}}%(domain)s{{/em}} has to be configured to work with WordPress.com.',
-					{
-						args: { domain },
-						components: { em: <em /> },
-					}
-				) }
-			</p>
-			<p>
-				{ translate(
-					'If you already did this yourself, or if the domain was already configured for you, no further action is needed.'
-				) }
-			</p>
-			{ ! isSubdomainMapping && domainInstructions }
-			{ isSubdomainMapping && ! isBusinessPlan && subdomainInstructions }
-			{ isSubdomainMapping && isBusinessPlan && subdomainInstructionsBusiness }
-			<p>
-				{ translate(
-					'Once you make the change, just wait a few hours and the domain should start loading your site automatically.'
-				) }
-			</p>
+			{ instructions }
+			<p>{ translate( 'If you already did this, no further action is required.' ) }</p>
 		</div>
 	);
 

--- a/client/my-sites/checkout/checkout-thank-you/domain-mapping-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/domain-mapping-details.jsx
@@ -5,36 +5,34 @@
  */
 
 import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { localize } from 'i18n-calypso';
 import PurchaseDetail from 'components/purchase-detail';
-import { MAP_EXISTING_DOMAIN } from 'lib/url/support';
+import { isSubdomain } from 'lib/domains';
+import { isBusiness } from 'lib/products-values';
+import { MAP_EXISTING_DOMAIN, MAP_SUBDOMAIN } from 'lib/url/support';
+import { getSelectedSite } from 'state/ui/selectors';
 
-const DomainMappingDetails = ( { domain, registrarSupportUrl, translate } ) => {
+const DomainMappingDetails = ( {
+	domain,
+	isBusinessPlan,
+	isSubdomainMapping,
+	registrarSupportUrl,
+	selectedSiteDomain,
+	translate,
+} ) => {
 	const registrarSupportLink = registrarSupportUrl ? (
 		<a target="_blank" rel="noopener noreferrer" href={ registrarSupportUrl } />
 	) : (
 		<span />
 	);
-	const description = (
+
+	const domainInstructions = (
 		<div>
-			<p>
-				{ translate(
-					'Your domain {{em}}%(domain)s{{/em}} has to be configured to work with WordPress.com.',
-					{
-						args: { domain },
-						components: { em: <em /> },
-					}
-				) }
-			</p>
-			<p>
-				{ translate(
-					'If you already did this yourself, or if the domain was already configured for you, no further action is needed.'
-				) }
-			</p>
 			<p>
 				{ translate(
 					"If not, you will need to log into {{registrarSupportLink}}your registrar's site{{/registrarSupportLink}} " +
@@ -51,6 +49,70 @@ const DomainMappingDetails = ( { domain, registrarSupportUrl, translate } ) => {
 				<li>ns2.wordpress.com</li>
 				<li>ns3.wordpress.com</li>
 			</ul>
+		</div>
+	);
+
+	const subdomainInstructions = (
+		<div>
+			<p>
+				{ translate(
+					"If not, you will need to log into {{registrarSupportLink}}your registrar's site{{/registrarSupportLink}} " +
+						'(where you purchased the domain originally) and add the following "CNAME" record:',
+					{
+						components: {
+							registrarSupportLink: registrarSupportLink,
+						},
+					}
+				) }
+			</p>
+			<ul className="checkout-thank-you__domain-mapping-details-nameservers">
+				<li>
+					{ domain }. IN CNAME { selectedSiteDomain }.
+				</li>
+			</ul>
+		</div>
+	);
+
+	const subdomainInstructionsBusiness = (
+		<div>
+			<p>
+				{ translate(
+					"If not, you will need to log into {{registrarSupportLink}}your registrar's site{{/registrarSupportLink}} " +
+						'(where you purchased the domain originally) and add the following "NS" records:',
+					{
+						components: {
+							registrarSupportLink: registrarSupportLink,
+						},
+					}
+				) }
+			</p>
+			<ul className="checkout-thank-you__domain-mapping-details-nameservers">
+				<li>{ domain }. IN NS ns1.wordpress.com.</li>
+				<li>{ domain }. IN NS ns2.wordpress.com.</li>
+				<li>{ domain }. IN NS ns3.wordpress.com.</li>
+			</ul>
+		</div>
+	);
+
+	const description = (
+		<div>
+			<p>
+				{ translate(
+					'Your domain {{em}}%(domain)s{{/em}} has to be configured to work with WordPress.com.',
+					{
+						args: { domain },
+						components: { em: <em /> },
+					}
+				) }
+			</p>
+			<p>
+				{ translate(
+					'If you already did this yourself, or if the domain was already configured for you, no further action is needed.'
+				) }
+			</p>
+			{ ! isSubdomainMapping && domainInstructions }
+			{ isSubdomainMapping && ! isBusinessPlan && subdomainInstructions }
+			{ isSubdomainMapping && isBusinessPlan && subdomainInstructionsBusiness }
 			<p>
 				{ translate(
 					'Once you make the change, just wait a few hours and the domain should start loading your site automatically.'
@@ -65,7 +127,7 @@ const DomainMappingDetails = ( { domain, registrarSupportUrl, translate } ) => {
 				icon="cog"
 				description={ description }
 				buttonText={ translate( 'Learn more' ) }
-				href={ MAP_EXISTING_DOMAIN }
+				href={ isSubdomainMapping ? MAP_SUBDOMAIN : MAP_EXISTING_DOMAIN }
 				target="_blank"
 				rel="noopener noreferrer"
 				isRequired
@@ -74,4 +136,13 @@ const DomainMappingDetails = ( { domain, registrarSupportUrl, translate } ) => {
 	);
 };
 
-export default localize( DomainMappingDetails );
+const mapStateToProps = ( state, { domain } ) => {
+	const selectedSite = getSelectedSite( state );
+	return {
+		isBusinessPlan: isBusiness( selectedSite.plan ),
+		isSubdomainMapping: isSubdomain( domain ),
+		selectedSiteDomain: selectedSite.domain,
+	};
+};
+
+export default connect( mapStateToProps )( localize( DomainMappingDetails ) );

--- a/client/my-sites/checkout/checkout-thank-you/domain-mapping-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/domain-mapping-details.jsx
@@ -21,15 +21,21 @@ const DomainMappingDetails = ( {
 	domain,
 	isBusinessPlan,
 	isSubdomainMapping,
+	isRegisteredWithUs,
 	registrarSupportUrl,
 	selectedSiteDomain,
 	translate,
 } ) => {
+	if ( isSubdomainMapping && isRegisteredWithUs ) {
+		return null;
+	}
+
 	const registrarSupportLink = registrarSupportUrl ? (
 		<a target="_blank" rel="noopener noreferrer" href={ registrarSupportUrl } />
 	) : (
 		<span />
 	);
+
 	let instructions = (
 		<div>
 			<p>

--- a/client/my-sites/checkout/checkout-thank-you/domain-mapping-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/domain-mapping-details.jsx
@@ -30,12 +30,11 @@ const DomainMappingDetails = ( {
 	) : (
 		<span />
 	);
-
 	let instructions = (
 		<div>
 			<p>
 				{ translate(
-					'To point your domain at your WordPress.com site, log in to your' +
+					'To point your domain at your WordPress.com site, log in to your ' +
 						"{{registrarSupportLink}}domain provider's site{{/registrarSupportLink}} " +
 						'(where you purchased the domain), and update your name servers to:',
 					{
@@ -84,7 +83,7 @@ const DomainMappingDetails = ( {
 					{ translate(
 						'To point your domain at your WordPress.com site, log in to your ' +
 							"{{registrarSupportLink}}domain provider's site{{/registrarSupportLink}} " +
-							'(where you purchased the domain), and edit the DNS records to add NS records:',
+							'(where you purchased the domain), and edit the DNS records to add these NS records:',
 						{
 							components: {
 								registrarSupportLink: registrarSupportLink,

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -50,7 +50,7 @@ class CheckoutThankYouHeader extends PureComponent {
 		if (
 			primaryPurchase &&
 			isDomainMapping( primaryPurchase ) &&
-			! primaryPurchase.isRegisteredWithUs
+			! primaryPurchase.isRootDomainWithUs
 		) {
 			return preventWidows( translate( 'Almost done!' ) );
 		}
@@ -106,7 +106,7 @@ class CheckoutThankYouHeader extends PureComponent {
 		}
 
 		if ( isDomainMapping( primaryPurchase ) ) {
-			if ( primaryPurchase.isRegisteredWithUs ) {
+			if ( primaryPurchase.isRootDomainWithUs ) {
 				return translate(
 					'Your domain {{strong}}%(domain)s{{/strong}} was added to your site. ' +
 						'We have set everything up for you but it may take a little while to start working.',
@@ -276,7 +276,7 @@ class CheckoutThankYouHeader extends PureComponent {
 			svg = 'items-failed.svg';
 		} else if (
 			primaryPurchase &&
-			( ( isDomainMapping( primaryPurchase ) && ! primaryPurchase.isRegisteredWithUs ) ||
+			( ( isDomainMapping( primaryPurchase ) && ! primaryPurchase.isRootDomainWithUs ) ||
 				isDelayedDomainTransfer( primaryPurchase ) )
 		) {
 			svg = 'publish-button.svg';

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -109,7 +109,7 @@ class CheckoutThankYouHeader extends PureComponent {
 			if ( primaryPurchase.isRootDomainWithUs ) {
 				return translate(
 					'Your domain {{strong}}%(domain)s{{/strong}} was added to your site. ' +
-						'We have set everything up for you but it may take a little while to start working.',
+						'We have set everything up for you, but it may take a little while to start working.',
 					{
 						args: {
 							domain: primaryPurchase.meta,

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -51,7 +51,10 @@ class CheckoutThankYouHeader extends PureComponent {
 			return translate( 'Thank you!' );
 		}
 
-		if ( primaryPurchase && isDomainTransfer( primaryPurchase ) ) {
+		if (
+			primaryPurchase &&
+			( isDomainMapping( primaryPurchase ) || isDelayedDomainTransfer( primaryPurchase ) )
+		) {
 			if ( isDelayedDomainTransfer( primaryPurchase ) ) {
 				return preventWidows( translate( 'Almost done!' ) );
 			}
@@ -252,7 +255,10 @@ class CheckoutThankYouHeader extends PureComponent {
 		let svg = 'thank-you.svg';
 		if ( hasFailedPurchases ) {
 			svg = 'items-failed.svg';
-		} else if ( primaryPurchase && isDelayedDomainTransfer( primaryPurchase ) ) {
+		} else if (
+			primaryPurchase &&
+			( isDomainMapping( primaryPurchase ) || isDelayedDomainTransfer( primaryPurchase ) )
+		) {
 			svg = 'publish-button.svg';
 		} else if ( primaryPurchase && isDomainTransfer( primaryPurchase ) ) {
 			svg = 'check-emails-desktop.svg';
@@ -261,7 +267,7 @@ class CheckoutThankYouHeader extends PureComponent {
 		return (
 			<div className={ classNames( 'checkout-thank-you__header', classes ) }>
 				<div className="checkout-thank-you__header-icon">
-					<img src={ `/calypso/images/upgrades/${ svg }` } />
+					<img src={ `/calypso/images/upgrades/${ svg }` } alt="" />
 				</div>
 				<div className="checkout-thank-you__header-content">
 					<div className="checkout-thank-you__header-copy">

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -47,14 +47,15 @@ class CheckoutThankYouHeader extends PureComponent {
 			return translate( 'Some items failed.' );
 		}
 
+		if ( primaryPurchase && isDomainMapping( primaryPurchase ) ) {
+			return preventWidows( translate( 'Almost done!' ) );
+		}
+
 		if ( primaryPurchase && isChargeback( primaryPurchase ) ) {
 			return translate( 'Thank you!' );
 		}
 
-		if (
-			primaryPurchase &&
-			( isDomainMapping( primaryPurchase ) || isDelayedDomainTransfer( primaryPurchase ) )
-		) {
+		if ( primaryPurchase && isDomainTransfer( primaryPurchase ) ) {
 			if ( isDelayedDomainTransfer( primaryPurchase ) ) {
 				return preventWidows( translate( 'Almost done!' ) );
 			}

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -102,8 +102,7 @@ class CheckoutThankYouHeader extends PureComponent {
 
 		if ( isDomainMapping( primaryPurchase ) ) {
 			return translate(
-				'Your domain {{strong}}%(domainName)s{{/strong}} was added to your site. ' +
-					'It may take a little while to start working – see below for more information.',
+				'Follow the instructions below to finish setting up your domain {{strong}}%(domainName)s{{/strong}}.',
 				{
 					args: { domainName: primaryPurchase.meta },
 					components: { strong: <strong /> },

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -47,7 +47,11 @@ class CheckoutThankYouHeader extends PureComponent {
 			return translate( 'Some items failed.' );
 		}
 
-		if ( primaryPurchase && isDomainMapping( primaryPurchase ) ) {
+		if (
+			primaryPurchase &&
+			isDomainMapping( primaryPurchase ) &&
+			! primaryPurchase.isRegisteredWithUs
+		) {
 			return preventWidows( translate( 'Almost done!' ) );
 		}
 
@@ -102,6 +106,21 @@ class CheckoutThankYouHeader extends PureComponent {
 		}
 
 		if ( isDomainMapping( primaryPurchase ) ) {
+			if ( primaryPurchase.isRegisteredWithUs ) {
+				return translate(
+					'Your domain {{strong}}%(domain)s{{/strong}} was added to your site. ' +
+						'We have set everything up for you but it may take a little while to start working.',
+					{
+						args: {
+							domain: primaryPurchase.meta,
+						},
+						components: {
+							strong: <strong />,
+						},
+					}
+				);
+			}
+
 			return translate(
 				'Follow the instructions below to finish setting up your domain {{strong}}%(domainName)s{{/strong}}.',
 				{
@@ -257,7 +276,8 @@ class CheckoutThankYouHeader extends PureComponent {
 			svg = 'items-failed.svg';
 		} else if (
 			primaryPurchase &&
-			( isDomainMapping( primaryPurchase ) || isDelayedDomainTransfer( primaryPurchase ) )
+			( ( isDomainMapping( primaryPurchase ) && ! primaryPurchase.isRegisteredWithUs ) ||
+				isDelayedDomainTransfer( primaryPurchase ) )
 		) {
 			svg = 'publish-button.svg';
 		} else if ( primaryPurchase && isDomainTransfer( primaryPurchase ) ) {

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -439,15 +439,20 @@ class CheckoutThankYou extends React.Component {
 	};
 
 	productRelatedMessages = () => {
-		const { selectedSite, sitePlans } = this.props,
-			purchases = getPurchases( this.props ),
-			failedPurchases = getFailedPurchases( this.props ),
-			hasFailedPurchases = failedPurchases.length > 0,
-			[ ComponentClass, primaryPurchase, domain ] = this.getComponentAndPrimaryPurchaseAndDomain(),
-			registrarSupportUrl =
-				! ComponentClass || this.isGenericReceipt() || hasFailedPurchases
-					? null
-					: primaryPurchase.registrarSupportUrl;
+		const { selectedSite, sitePlans } = this.props;
+		const purchases = getPurchases( this.props );
+		const failedPurchases = getFailedPurchases( this.props );
+		const hasFailedPurchases = failedPurchases.length > 0;
+		const [
+			ComponentClass,
+			primaryPurchase,
+			domain,
+		] = this.getComponentAndPrimaryPurchaseAndDomain();
+		const registrarSupportUrl =
+			! ComponentClass || this.isGenericReceipt() || hasFailedPurchases
+				? null
+				: get( primaryPurchase, 'registrarSupportUrl', null );
+		const isRegisteredWithUs = get( primaryPurchase, 'isRegisteredWithUs', false );
 
 		if ( ! this.isDataLoaded() ) {
 			return (
@@ -489,6 +494,7 @@ class CheckoutThankYou extends React.Component {
 							domain={ domain }
 							purchases={ purchases }
 							failedPurchases={ failedPurchases }
+							isRegisteredWithUs={ isRegisteredWithUs }
 							registrarSupportUrl={ registrarSupportUrl }
 							selectedSite={ selectedSite }
 							selectedFeature={ getFeatureByKey( this.props.selectedFeature ) }

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -452,7 +452,7 @@ class CheckoutThankYou extends React.Component {
 			! ComponentClass || this.isGenericReceipt() || hasFailedPurchases
 				? null
 				: get( primaryPurchase, 'registrarSupportUrl', null );
-		const isRegisteredWithUs = get( primaryPurchase, 'isRegisteredWithUs', false );
+		const isRootDomainWithUs = get( primaryPurchase, 'isRootDomainWithUs', false );
 
 		if ( ! this.isDataLoaded() ) {
 			return (
@@ -494,7 +494,7 @@ class CheckoutThankYou extends React.Component {
 							domain={ domain }
 							purchases={ purchases }
 							failedPurchases={ failedPurchases }
-							isRegisteredWithUs={ isRegisteredWithUs }
+							isRootDomainWithUs={ isRootDomainWithUs }
 							registrarSupportUrl={ registrarSupportUrl }
 							selectedSite={ selectedSite }
 							selectedFeature={ getFeatureByKey( this.props.selectedFeature ) }

--- a/client/state/receipts/assembler.js
+++ b/client/state/receipts/assembler.js
@@ -16,7 +16,7 @@ export function createReceiptObject( data ) {
 				productNameShort: purchase.product_name_short,
 				registrarSupportUrl: purchase.registrar_support_url,
 				isEmailVerified: Boolean( purchase.is_email_verified ),
-				isRegisteredWithUs: Boolean( purchase.is_registered_with_us ),
+				isRootDomainWithUs: Boolean( purchase.is_root_domain_with_us ),
 			};
 		} ),
 		failedPurchases: ( data.failedPurchases || [] ).map( purchase => {

--- a/client/state/receipts/assembler.js
+++ b/client/state/receipts/assembler.js
@@ -16,6 +16,7 @@ export function createReceiptObject( data ) {
 				productNameShort: purchase.product_name_short,
 				registrarSupportUrl: purchase.registrar_support_url,
 				isEmailVerified: Boolean( purchase.is_email_verified ),
+				isRegisteredWithUs: Boolean( purchase.is_registered_with_us ),
 			};
 		} ),
 		failedPurchases: ( data.failedPurchases || [] ).map( purchase => {


### PR DESCRIPTION
Fix #11848 
Depends on D10749-code

After purchasing a domain mapping, display the correct instructions according to the following cases:

- Domain
- Subdomain (non-Business Plan)
- Subdomain (Business Plan)
- Subdomain with root domain registered with us

The "Learn More" button has been updated as well to point to the [Map a Subdomain](https://en.support.wordpress.com/domains/map-subdomain/) support page.

| Domain | Subdomain | Subdomain (Biz) |
| --- | --- | --- |
| <img width="723" alt="screen shot 2018-03-06 at 12 39 24" src="https://user-images.githubusercontent.com/1103398/37035903-4c3cc300-214e-11e8-9480-2bc1fd69c00b.png"> | <img width="714" alt="screen shot 2018-03-06 at 12 37 24" src="https://user-images.githubusercontent.com/1103398/37035924-61036668-214e-11e8-9cb4-44377a71123d.png"> | <img width="718" alt="screen shot 2018-03-06 at 12 36 56" src="https://user-images.githubusercontent.com/1103398/37035933-68a9d6b8-214e-11e8-99c9-7e1f32ac7bee.png"> |

### Testing instructions

Add a domain mapping to some sites and make sure that:

- If the mapped domain is an actual domain, the instructions show a list of:
`ns1.wordpress.com` (etc.).
- If it's a subdomain and the site plan is not Business, the instructions show a single line:
`subdomain.foo.bar IN CNAME sitename.wordpress.com`.
- If it's a subdomain for a Business plan, the instructions show a list of:
`subdomain.foo.bar IN NS ns1.wordpress.com` (etc.).
- If it's a subdomain with a root domain registered with us, it should show a congratulations screen w/o any instructions because we set everything up automatically.

Also make sure that the "Learn More" button points to the correct page (map domain or map subdomain).

/cc @Copons as I shamelessly stole his PR description. I used your work, and built on it to improve the copy. Thanks!