### PR TITLE
Me: Purchases: Tweak expiring notice for purchases with credits

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -134,6 +134,10 @@ function isPaidWithPaypal( purchase ) {
 	return 'paypal' === purchase.payment.type;
 }
 
+function isPaidWithCredits( purchase ) {
+	return purchase.payment && 'credits' === purchase.payment.type;
+}
+
 function isPendingTransfer( purchase ) {
 	return purchase.pendingTransfer;
 }
@@ -320,6 +324,7 @@ export {
 	isPaidWithCreditCard,
 	isPaidWithPayPalDirect,
 	isPaidWithPaypal,
+	isPaidWithCredits,
 	isExpired,
 	isExpiring,
 	isIncludedWithPlan,

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -135,7 +135,7 @@ function isPaidWithPaypal( purchase ) {
 }
 
 function isPaidWithCredits( purchase ) {
-	return purchase.payment && 'credits' === purchase.payment.type;
+	return 'undefined' !== typeof purchase.payment && 'credits' === purchase.payment.type;
 }
 
 function isPendingTransfer( purchase ) {

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -265,7 +265,11 @@ function monthsUntilCardExpires( purchase ) {
 }
 
 function subscribedWithinPastWeek( purchase ) {
-	return purchase.subscribedDate && moment( purchase.subscribedDate ).diff( moment(), 'days' ) < 7;
+	// Subscribed date should always be in the past. One week ago would be -7 days.
+	return (
+		'undefined' !== typeof purchase.subscribedDate &&
+		moment( purchase.subscribedDate ).diff( moment(), 'days' ) >= -7
+	);
 }
 
 /**

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -264,6 +264,10 @@ function monthsUntilCardExpires( purchase ) {
 	return purchase.payment.creditCard.expiryMoment.diff( moment(), 'months' );
 }
 
+function subscribedWithinPastWeek( purchase ) {
+	return purchase.subscribedDate && moment( purchase.subscribedDate ).diff( moment(), 'days' ) < 7;
+}
+
 /**
  * Returns the payment logo to display based on the payment method
  *
@@ -339,4 +343,5 @@ export {
 	purchaseType,
 	cardProcessorSupportsUpdates,
 	showCreditCardExpiringWarning,
+	subscribedWithinPastWeek,
 };

--- a/client/lib/purchases/test/data/index.js
+++ b/client/lib/purchases/test/data/index.js
@@ -74,6 +74,28 @@ const PLAN_PURCHASE = {
 	isDomainRegistration: false,
 };
 
+const PLAN_PURCHASE_WITH_CREDITS = {
+	id: 4002,
+	payment: {
+		type: 'credits',
+		countryCode: 'US',
+		countryName: 'United States',
+	},
+	productId: 2006,
+	productName: 'Personal',
+	productSlug: 'jetpack_personal_monthly',
+};
+
+const PLAN_PURCHASE_WITH_PAYPAL = {
+	id: 4003,
+	payment: {
+		type: 'paypal',
+	},
+	productId: 2006,
+	productName: 'Personal',
+	productSlug: 'jetpack_personal_monthly',
+};
+
 export default {
 	DOMAIN_PURCHASE,
 	DOMAIN_PURCHASE_PENDING_TRANSFER,
@@ -84,4 +106,6 @@ export default {
 	PLAN_PURCHASE,
 	SITE_REDIRECT_PURCHASE,
 	SITE_REDIRECT_PURCHASE_EXPIRED,
+	PLAN_PURCHASE_WITH_CREDITS,
+	PLAN_PURCHASE_WITH_PAYPAL,
 };

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -80,9 +80,7 @@ describe( 'index', () => {
 			expect( isPaidWithCredits( PLAN_PURCHASE_WITH_PAYPAL ) ).to.be.false;
 		} );
 		test( 'should be false when payment not set on purchase', () => {
-			const purchase = Object.assign( {}, DOMAIN_PURCHASE );
-			delete purchase.payment;
-			expect( isPaidWithCredits( PLAN_PURCHASE_WITH_PAYPAL ) ).to.be.false;
+			expect( isPaidWithCredits( {} ) ).to.be.false;
 		} );
 	} );
 	describe( '#subscribedWithinPastWeek', () => {

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -93,7 +93,7 @@ describe( 'index', () => {
 			expect(
 				subscribedWithinPastWeek( {
 					subscribedDate: moment()
-						.subtract( 'days', 8 )
+						.subtract( 8, 'days' )
 						.format(),
 				} )
 			).to.be.false;
@@ -102,7 +102,7 @@ describe( 'index', () => {
 			expect(
 				subscribedWithinPastWeek( {
 					subscribedDate: moment()
-						.substract( 'days', 3 )
+						.subtract( 3, 'days' )
 						.format(),
 				} )
 			).to.be.true;

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -8,7 +8,8 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { isRemovable, isCancelable } from '../index';
+import { isRemovable, isCancelable, isPaidWithCredits } from '../index';
+
 import {
 	DOMAIN_PURCHASE,
 	DOMAIN_PURCHASE_PENDING_TRANSFER,
@@ -19,6 +20,8 @@ import {
 	PLAN_PURCHASE,
 	SITE_REDIRECT_PURCHASE,
 	SITE_REDIRECT_PURCHASE_EXPIRED,
+	PLAN_PURCHASE_WITH_CREDITS,
+	PLAN_PURCHASE_WITH_PAYPAL,
 } from './data';
 
 describe( 'index', () => {
@@ -66,6 +69,19 @@ describe( 'index', () => {
 
 		test( 'should not be cancelable if domain is pending transfer', () => {
 			expect( isCancelable( DOMAIN_PURCHASE_PENDING_TRANSFER ) ).to.be.false;
+		} );
+	} );
+	describe( '#isPaidWithCredits', () => {
+		test( 'should be true when paid with credits', () => {
+			expect( isPaidWithCredits( PLAN_PURCHASE_WITH_CREDITS ) ).to.be.true;
+		} );
+		test( 'should false when not paid with credits', () => {
+			expect( isPaidWithCredits( PLAN_PURCHASE_WITH_PAYPAL ) ).to.be.false;
+		} );
+		test( 'should be false when payment not set on purchase', () => {
+			const purchase = Object.assign( {}, DOMAIN_PURCHASE );
+			delete purchase.payment;
+			expect( isPaidWithCredits( PLAN_PURCHASE_WITH_PAYPAL ) ).to.be.false;
 		} );
 	} );
 } );

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -4,11 +4,12 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import moment from 'moment';
 
 /**
  * Internal dependencies
  */
-import { isRemovable, isCancelable, isPaidWithCredits } from '../index';
+import { isRemovable, isCancelable, isPaidWithCredits, subscribedWithinPastWeek } from '../index';
 
 import {
 	DOMAIN_PURCHASE,
@@ -82,6 +83,29 @@ describe( 'index', () => {
 			const purchase = Object.assign( {}, DOMAIN_PURCHASE );
 			delete purchase.payment;
 			expect( isPaidWithCredits( PLAN_PURCHASE_WITH_PAYPAL ) ).to.be.false;
+		} );
+	} );
+	describe( '#subscribedWithinPastWeek', () => {
+		test( 'should return false when no subscribed date', () => {
+			expect( subscribedWithinPastWeek( {} ) ).to.be.false;
+		} );
+		test( 'should return false when subscribed more than 1 week ago', () => {
+			expect(
+				subscribedWithinPastWeek( {
+					subscribedDate: moment()
+						.subtract( 'days', 8 )
+						.format(),
+				} )
+			).to.be.false;
+		} );
+		test( 'should return true when subscribed less than 1 week ago', () => {
+			expect(
+				subscribedWithinPastWeek( {
+					subscribedDate: moment()
+						.substract( 'days', 3 )
+						.format(),
+				} )
+			).to.be.true;
 		} );
 	} );
 } );

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -25,6 +25,7 @@ import {
 	isRenewable,
 	showCreditCardExpiringWarning,
 	isPaidWithCredits,
+	subscribedWithinPastWeek,
 } from 'lib/purchases';
 import { isDomainTransfer } from 'lib/products-values';
 import { getPurchase, getSelectedSite } from '../utils';
@@ -145,7 +146,10 @@ class PurchaseNotice extends Component {
 			return null;
 		}
 
-		if ( purchase.expiryMoment < moment().add( 90, 'days' ) ) {
+		if (
+			! subscribedWithinPastWeek( purchase ) &&
+			purchase.expiryMoment < moment().add( 90, 'days' )
+		) {
 			noticeStatus = 'is-error';
 		}
 

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -109,11 +109,7 @@ class PurchaseNotice extends Component {
 			);
 		}
 
-		const renewText = isPaidWithCredits( purchase )
-			? translate( 'Add Payment Method' )
-			: translate( 'Renew Now' );
-
-		return <NoticeAction onClick={ onClick }>{ renewText }</NoticeAction>;
+		return <NoticeAction onClick={ onClick }>{ translate( 'Renew Now' ) }</NoticeAction>;
 	}
 
 	trackImpression( warning ) {

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -48,27 +48,29 @@ class PurchaseNotice extends Component {
 		const { translate, moment, selectedSite } = this.props;
 
 		if ( selectedSite && purchase.expiryStatus === 'manualRenew' ) {
-			return isPaidWithCredits( purchase )
-				? translate(
-						'You purchased %(purchaseName)s with credits and it will expire %(expiry)s. ' +
-							'Please, add a credit card if you want it to autorenew.',
-						{
-							args: {
-								purchaseName: getName( purchase ),
-								expiry: moment( purchase.expiryMoment ).fromNow(),
-							},
-						}
-					)
-				: translate(
-						'%(purchaseName)s will expire and be removed from your site %(expiry)s. ' +
-							'Please, add a credit card if you want it to autorenew. ',
-						{
-							args: {
-								purchaseName: getName( purchase ),
-								expiry: moment( purchase.expiryMoment ).fromNow(),
-							},
-						}
-					);
+			if ( isPaidWithCredits( purchase ) ) {
+				return translate(
+					'You purchased %(purchaseName)s with credits. Please add a credit card before your ' +
+						"plan expires %(expiry)s so that you don't lose out on your paid features!",
+					{
+						args: {
+							purchaseName: getName( purchase ),
+							expiry: moment( purchase.expiryMoment ).fromNow(),
+						},
+					}
+				);
+			}
+
+			return translate(
+				'%(purchaseName)s will expire and be removed from your site %(expiry)s. ' +
+					"Add a credit card so you don't lose out on your paid features!",
+				{
+					args: {
+						purchaseName: getName( purchase ),
+						expiry: moment( purchase.expiryMoment ).fromNow(),
+					},
+				}
+			);
 		}
 		if ( isMonthly( purchase.productSlug ) ) {
 			const expiryMoment = moment( purchase.expiryMoment );

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -24,6 +24,7 @@ import {
 	isOneTimePurchase,
 	isRenewable,
 	showCreditCardExpiringWarning,
+	isPaidWithCredits,
 } from 'lib/purchases';
 import { isDomainTransfer } from 'lib/products-values';
 import { getPurchase, getSelectedSite } from '../utils';
@@ -45,17 +46,29 @@ class PurchaseNotice extends Component {
 
 	getExpiringText( purchase ) {
 		const { translate, moment, selectedSite } = this.props;
+
 		if ( selectedSite && purchase.expiryStatus === 'manualRenew' ) {
-			return translate(
-				'%(purchaseName)s will expire and be removed from your site %(expiry)s. ' +
-					'Please, add a credit card if you want it to autorenew. ',
-				{
-					args: {
-						purchaseName: getName( purchase ),
-						expiry: moment( purchase.expiryMoment ).fromNow(),
-					},
-				}
-			);
+			return isPaidWithCredits( purchase )
+				? translate(
+						'You purchased %(purchaseName)s with credits and it will expire %(expiry)s. ' +
+							'Please, add a credit card if you want it to autorenew.',
+						{
+							args: {
+								purchaseName: getName( purchase ),
+								expiry: moment( purchase.expiryMoment ).fromNow(),
+							},
+						}
+					)
+				: translate(
+						'%(purchaseName)s will expire and be removed from your site %(expiry)s. ' +
+							'Please, add a credit card if you want it to autorenew. ',
+						{
+							args: {
+								purchaseName: getName( purchase ),
+								expiry: moment( purchase.expiryMoment ).fromNow(),
+							},
+						}
+					);
 		}
 		if ( isMonthly( purchase.productSlug ) ) {
 			const expiryMoment = moment( purchase.expiryMoment );
@@ -96,7 +109,11 @@ class PurchaseNotice extends Component {
 			);
 		}
 
-		return <NoticeAction onClick={ onClick }>{ translate( 'Renew Now' ) }</NoticeAction>;
+		const renewText = isPaidWithCredits( purchase )
+			? translate( 'Add Payment Method' )
+			: translate( 'Renew Now' );
+
+		return <NoticeAction onClick={ onClick }>{ renewText }</NoticeAction>;
 	}
 
 	trackImpression( warning ) {

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -20,6 +20,7 @@ import {
 	isRenewing,
 	purchaseType,
 	showCreditCardExpiringWarning,
+	subscribedWithinPastWeek,
 } from 'lib/purchases';
 import {
 	isDomainProduct,
@@ -66,8 +67,9 @@ class PurchaseItem extends Component {
 
 		if ( isExpiring( purchase ) ) {
 			if ( purchase.expiryMoment < moment().add( 30, 'days' ) ) {
+				const status = subscribedWithinPastWeek( purchase ) ? 'is-info' : 'is-error';
 				return (
-					<Notice isCompact status="is-error" icon="notice">
+					<Notice isCompact status={ status } icon="notice">
 						{ translate( 'Expires %(timeUntilExpiry)s', {
 							args: {
 								timeUntilExpiry: purchase.expiryMoment.fromNow(),


### PR DESCRIPTION
Fixes #22758

In #22758, @beaulebens reported that showing an error notice when a user purchases a monthly plan can be pretty confusing. 

To reproduce the issue, simply buy a Jetpack Personal Monthly plan for your Jetpack site with credits. Then go to `/me/purchases` and click on the site where you bought the plan. You should see the notice that @beaulebens mentions:

![screen shot 2018-02-23 at 7 57 59 am](https://user-images.githubusercontent.com/108942/36600385-57b4073a-186f-11e8-806a-f05e603aae81.png)

A couple of things are going on here. Beau purchased the plan with credits which requires a manual renew. This is why the notice is shown. But, to show an error notice right after subscribing seems weird. 

To address that, I've updated the wording to be more in line with Automattic/jetpack#8948 and I've also added some logic that will make the notice show as an informational (blue) notice if the subscription is less than a week old.

Here's what that looks like:

<img width="742" alt="screen shot 2018-03-06 at 4 39 04 pm" src="https://user-images.githubusercontent.com/1126811/37064002-03334c48-2161-11e8-8c07-a520d28cceb6.png">
<img width="744" alt="screen shot 2018-03-06 at 4 57 15 pm" src="https://user-images.githubusercontent.com/1126811/37064003-03483df6-2161-11e8-84f0-bdb2c00c5dfb.png">


To test:

- Follow instructions above about buying a Jetpack Personal Monthly plan with credits
- Purchase a yearly Jetpack plan on another site. Go to `https://worpdress.com/me/purchases` and click on that site. Ensure that the notice has an info status and has the same wording as @beaulebens's screenshot above
- Checkout this branch then go to `calypso.localhost:3000/me/purchases` and ensure the notice color and wording has changed