### PR TITLE
Set the address bar to the masterbar color on supported browsers

### DIFF
--- a/client/components/head/index.jsx
+++ b/client/components/head/index.jsx
@@ -21,6 +21,7 @@ const Head = ( { title = 'WordPress.com', faviconURL, children, cdn } ) => {
 			<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 			<meta name="format-detection" content="telephone=no" />
 			<meta name="mobile-web-app-capable" content="yes" />
+			<meta name="theme-color" content="#0087be" />
 			<meta name="apple-mobile-web-app-capable" content="yes" />
 			<meta name="referrer" content="origin" />
 

--- a/client/components/head/index.jsx
+++ b/client/components/head/index.jsx
@@ -21,8 +21,8 @@ const Head = ( { title = 'WordPress.com', faviconURL, children, cdn } ) => {
 			<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 			<meta name="format-detection" content="telephone=no" />
 			<meta name="mobile-web-app-capable" content="yes" />
-			<meta name="theme-color" content="#0087be" />
 			<meta name="apple-mobile-web-app-capable" content="yes" />
+			<meta name="theme-color" content="#0087be" />
 			<meta name="referrer" content="origin" />
 
 			<link

--- a/client/components/head/test/__snapshots__/index.jsx.snap
+++ b/client/components/head/test/__snapshots__/index.jsx.snap
@@ -29,6 +29,10 @@ exports[`Head should render custom title 1`] = `
     name="apple-mobile-web-app-capable"
   />
   <meta
+    content="#0087be"
+    name="theme-color"
+  />
+  <meta
     content="origin"
     name="referrer"
   />
@@ -169,6 +173,10 @@ exports[`Head should render default title 1`] = `
   <meta
     content="yes"
     name="apple-mobile-web-app-capable"
+  />
+  <meta
+    content="#0087be"
+    name="theme-color"
   />
   <meta
     content="origin"


### PR DESCRIPTION
On supported browsers and devices, this change sets the header and address bar background color to that of the Master Bar (`$blue-wordpress` / `--masterbar-background` / `#0087be`).

Sites which set the `theme-color` meta to their header navigation's background color feel more "app like" and immersive on my Android device than those which do not.

Before:
![disabled](https://user-images.githubusercontent.com/1587282/37006110-1726e136-20d7-11e8-99b2-fae12faa4b39.png)

After:
![enabled](https://user-images.githubusercontent.com/1587282/37005991-6f9583d2-20d6-11e8-99f8-c080f7fa1e26.png)

It does the same for the browser chrome in the tab switching UI.  Note the difference between the blue "tab" chrome in this branch vs. the current light gray:

![tab-switching-diff](https://user-images.githubusercontent.com/1587282/37006006-800095ae-20d6-11e8-8ff3-a1024ba9b653.png)

Chrome mobile has [supported](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/) this on Android for a while.

iOS handles it a bit differently with:
`<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">` (see the link above).

We should evaluate these independently to weigh each on its own merits given our color scheme, so I haven't included the iOS change in this PR.

## To Test

Open https://calypso.live/?branch=try/pwa-theme-color in the release version of Chrome on a modern & updated Android device.
