### PR TITLE
Store Transactions: execute the submit step callback asynchronously

### DIFF
--- a/client/lib/upgrades/actions/checkout.js
+++ b/client/lib/upgrades/actions/checkout.js
@@ -1,5 +1,10 @@
 /** @format */
 /**
+ * External dependencies
+ */
+import { defer } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { action as ActionTypes } from '../constants';
@@ -37,16 +42,20 @@ export function submitTransaction( { cart, transaction }, onComplete ) {
 			payment: transaction.payment,
 			domainDetails: transaction.domainDetails,
 		},
-		step => {
-			Dispatcher.handleViewAction( {
-				type: ActionTypes.TRANSACTION_STEP_SET,
-				step,
-			} );
+		// Execute every step handler in its own event loop tick, so that a complete React
+		// rendering cycle happens on each step and `componentWillReceiveProps` of objects
+		// like the `TransactionStepsMixin` are called with every step.
+		step =>
+			defer( () => {
+				Dispatcher.handleViewAction( {
+					type: ActionTypes.TRANSACTION_STEP_SET,
+					step,
+				} );
 
-			if ( onComplete && step.name === 'received-wpcom-response' ) {
-				onComplete( step.error, step.data );
-			}
-		}
+				if ( onComplete && step.name === 'received-wpcom-response' ) {
+					onComplete( step.error, step.data );
+				}
+			} )
 	);
 }
 


### PR DESCRIPTION
This patch fixes a bug where multiple submit `onStep` callbacks would be called synchronously after each other, and would cause only one React rendering update at the end. The `componentWillReceiveProps` lifetime method in `TransactionStepsMixin` expects that it will be called once for each step, not only once at the end. I'm fixing the bug by wrapping the callback in `_.defer`.

When we were using the Node.js Stream, it seems that the callbacks were called asynchronously there and the change where we started to call them synchronously matters and has material consequences.

This bug is an example why implementing app logic inside React lifetime methods is not a good idea -- these should be used only for UI rendering. I'm wondering how many insidious bugs like this will be uncovered as React becomes more Fiber-ish and more things become async.

Reported by @yoavf in https://github.com/Automattic/wp-calypso/pull/22539#issuecomment-370452114

**How to test:**
1. Turn on analytics debugging by typing `localStorage.debug = 'calypso:analytics:*'` in your console (and reload the page to apply these settings)
2. Buy anything on WP.com and pay with credits
3. Check that the `calypso_checkout_form_submit` tracks event was recorded:

<img width="705" alt="screen shot 2018-03-05 at 16 36 22" src="https://user-images.githubusercontent.com/664258/37008295-3b27ef8a-2096-11e8-9cf7-d7ea6c67124f.png">
