### PR TITLE
Reduxification User: get rid of isRtl method

### DIFF
--- a/client/components/auto-direction/index.jsx
+++ b/client/components/auto-direction/index.jsx
@@ -188,11 +188,11 @@ const setChildDirection = ( child, isRtl ) => {
 			}
 
 			if ( inlineComponents.some( inlineComponent => innerChild.type === inlineComponent ) ) {
-				innerChildDirection = getChildDirection( innerChild );
+				innerChildDirection = getChildDirection( innerChild, isRtl );
 				return innerChild;
 			}
 
-			return setChildDirection( innerChild );
+			return setChildDirection( innerChild, isRtl );
 		} );
 
 		return React.cloneElement(

--- a/client/components/auto-direction/index.jsx
+++ b/client/components/auto-direction/index.jsx
@@ -5,17 +5,16 @@
  */
 
 import React from 'react';
+import { connect } from 'react-redux';
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import userModule from 'lib/user';
 import { stripHTML } from 'lib/formatting';
 import { isRTLCharacter, isLTRCharacter } from './direction';
 import Emojify from 'components/emojify';
-
-const user = userModule();
+import { isRtl as isRtlSelector } from 'state/selectors';
 
 const MAX_LENGTH_OF_TEXT_TO_EXAMINE = 100;
 
@@ -109,10 +108,11 @@ const getContent = reactElement => {
  * Gets the main directionality in a text
  * It returns what kind of characters we had the most, RTL or LTR according to some ratio
  *
- * @param {string} text the text to be examined
+ * @param {string}  text  the text to be examined
+ * @param {boolean} isRtl whether current language is RTL
  * @returns {string} either 'rtl' or 'ltr'
  */
-const getTextMainDirection = text => {
+const getTextMainDirection = ( text, isRtl ) => {
 	let rtlCount = 0;
 	let ltrCount = 0;
 
@@ -126,7 +126,7 @@ const getTextMainDirection = text => {
 	}
 
 	if ( rtlCount + ltrCount === 0 ) {
-		return user.isRTL() ? 'rtl' : 'ltr';
+		return isRtl ? 'rtl' : 'ltr';
 	}
 
 	return rtlCount > ltrCount ? 'rtl' : 'ltr';
@@ -140,12 +140,12 @@ const getDirectionProps = ( child, direction ) => ( {
 	} ),
 } );
 
-const getChildDirection = child => {
+const getChildDirection = ( child, isRtl ) => {
 	const childContent = getContent( child );
 
 	if ( childContent ) {
-		const textMainDirection = getTextMainDirection( childContent );
-		const userDirection = user.isRTL() ? 'rtl' : 'ltr';
+		const textMainDirection = getTextMainDirection( childContent, isRtl );
+		const userDirection = isRtl ? 'rtl' : 'ltr';
 
 		if ( textMainDirection !== userDirection ) {
 			return textMainDirection;
@@ -163,10 +163,11 @@ const inlineComponents = [ Emojify ];
  * to text content and only leaf components have those.
  *
  * @param {React.Element} child
+ * @param {boolean}       isRtl whether current language is RTL
  * @returns {React.Element} transformed child
  */
-const setChildDirection = child => {
-	const childDirection = getChildDirection( child );
+const setChildDirection = ( child, isRtl ) => {
+	const childDirection = getChildDirection( child, isRtl );
 
 	if ( childDirection ) {
 		return React.cloneElement( child, getDirectionProps( child, childDirection ) );
@@ -209,11 +210,11 @@ const setChildDirection = child => {
  * @param {Object.children} props react element props that must contain some children
  * @returns {React.Element} returns a react element with adjusted children
  */
-const AutoDirection = props => {
-	const { children } = props;
-	const directionedChild = setChildDirection( children );
+export const AutoDirection = props => {
+	const { children, isRtl } = props;
+	const directionedChild = setChildDirection( children, isRtl );
 
 	return directionedChild;
 };
 
-export default AutoDirection;
+export default connect( state => ( { isRtl: isRtlSelector( state ) } ) )( AutoDirection );

--- a/client/components/auto-direction/test/auto-direction.jsx
+++ b/client/components/auto-direction/test/auto-direction.jsx
@@ -13,7 +13,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import AutoDirection from '..';
+import { AutoDirection } from '..';
 import Emojify from 'components/emojify';
 
 describe( 'AutoDirection', () => {

--- a/client/components/chart/label.jsx
+++ b/client/components/chart/label.jsx
@@ -6,20 +6,14 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import userModule from 'lib/user';
+import { isRtl as isRtlSelector } from 'state/selectors';
 
-/**
- * Module variables
- */
-const user = userModule();
-
-export default class extends React.Component {
-	static displayName = 'ModuleChartLabel';
-
+class ModuleChartLabel extends React.Component {
 	static propTypes = {
 		width: PropTypes.number.isRequired,
 		x: PropTypes.number.isRequired,
@@ -27,10 +21,10 @@ export default class extends React.Component {
 	};
 
 	render() {
-		const dir = user.isRTL() ? 'right' : 'left';
-		let labelStyle;
+		const { isRtl } = this.props;
 
-		labelStyle = {
+		const dir = isRtl ? 'right' : 'left';
+		const labelStyle = {
 			width: this.props.width + 'px',
 		};
 
@@ -43,3 +37,5 @@ export default class extends React.Component {
 		);
 	}
 }
+
+export default connect( state => ( { isRtl: isRtlSelector( state ) } ) )( ModuleChartLabel );

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -18,6 +18,7 @@ import { isMobile } from 'lib/viewport';
 import { preload } from 'sections-preload';
 import { getSelectedSite } from 'state/ui/selectors';
 import MasterbarDrafts from './drafts';
+import { isRtl as isRtlSelector } from 'state/selectors';
 
 class MasterbarItemNew extends React.Component {
 	static propTypes = {
@@ -61,11 +62,13 @@ class MasterbarItemNew extends React.Component {
 	preloadPostEditor = () => preload( 'post-editor' );
 
 	getPopoverPosition() {
+		const { isRtl } = this.props;
+
 		if ( isMobile() ) {
 			return 'bottom';
 		}
 
-		if ( this.props.user.isRTL() ) {
+		if ( isRtl ) {
 			return 'bottom right';
 		}
 
@@ -119,6 +122,7 @@ class MasterbarItemNew extends React.Component {
 const mapStateToProps = state => {
 	return {
 		selectedSite: getSelectedSite( state ),
+		isRtl: isRtlSelector( state ),
 	};
 };
 

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -241,11 +241,6 @@ User.prototype.getAvatarUrl = function( options ) {
 	return avatar + '?' + qs.stringify( options );
 };
 
-User.prototype.isRTL = function() {
-	const language = this.getLanguage();
-	return language && language.rtl;
-};
-
 /**
  * Clear any user data.
  *

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -19,12 +19,11 @@ import { getMimePrefix } from 'lib/media/utils';
 import ListItem from './list-item';
 import ListNoResults from './list-no-results';
 import ListNoContent from './list-no-content';
-import userFactory from 'lib/user';
-const user = userFactory();
 
 import SortedGrid from 'components/sorted-grid';
 import ListPlanUpgradeNudge from './list-plan-upgrade-nudge';
 import { getPreference } from 'state/preferences/selectors';
+import { isRtl as isRtlSelector } from 'state/selectors';
 
 const GOOGLE_MAX_RESULTS = 1000;
 
@@ -97,7 +96,9 @@ export class MediaLibraryList extends React.Component {
 		if ( ! isFillingEntireRow && ! isLastInRow ) {
 			marginValue = ( 1 % this.props.mediaScale ) / ( itemsPerRow - 1 ) * 100 + '%';
 
-			if ( user.isRTL() ) {
+			const { isRtl } = this.props;
+
+			if ( isRtl ) {
 				style.marginLeft = marginValue;
 			} else {
 				style.marginRight = marginValue;
@@ -294,6 +295,7 @@ export class MediaLibraryList extends React.Component {
 export default connect(
 	state => ( {
 		mediaScale: getPreference( state, 'mediaScale' ),
+		isRtl: isRtlSelector( state ),
 	} ),
 	null,
 	null,


### PR DESCRIPTION
Part of solving #19828.

In this PR, we replace all instances of `user.isRtl` method with `state/selectors/is-rtl` selector.

## Testing

Test commit by commit, smoke testing all the touched files/components.