### PR TITLE
Store: Fix Shipping Dimensions Overflow

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/style.scss
@@ -34,7 +34,7 @@
 	flex-grow: 1;
 	flex-direction: row;
 
-	@include breakpoint( '<1040px' ) {
+	@include breakpoint( '<1280px' ) {
 		flex-direction: column;
 	}
 


### PR DESCRIPTION
Fixes #22548 

Quick one-liner to make the breakpoint larger on the `.shipping__units` to prevent the dimension selections from overflowing the card. To test view the shipping settings page, and adjust the screen width.

__Before__
![before-dimensions](https://user-images.githubusercontent.com/22080/37010215-5a8baffc-209f-11e8-96e2-3aee28aaff9e.gif)

__After__
![after-dimensions](https://user-images.githubusercontent.com/22080/37010222-60f90a9c-209f-11e8-9105-f9663f188718.gif)
