### PR TITLE
Add page view event to checklist page

### DIFF
--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -27,6 +27,7 @@ import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import ChecklistShowShare from './share';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import userFactory from 'lib/user';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 const user = userFactory();
 
@@ -136,12 +137,15 @@ class ChecklistShow extends PureComponent {
 		const completed = tasks && ! find( tasks, { completed: false } );
 
 		let title = 'Site Checklist';
+		let path = '/checklist/:site';
 		if ( displayMode ) {
 			title = 'Thank You';
+			path += `/${ displayMode }`;
 		}
 
 		return (
 			<Main className="checklist-show">
+				<PageViewTracker path={ path } title={ title } />
 				<SidebarNavigation />
 				<DocumentHead title={ title } />
 				{ siteId && <QuerySiteChecklist siteId={ siteId } /> }


### PR DESCRIPTION
`/checklist/<site>` does not currently fire a calypso_page_view event.

This PR just ensures the event is added.

# Testing

* enable tracks debugging with `localStorage.setItem('debug', 'calypso:analytics:tracks');`
* select any site and browse to `/checklist/<site>`
* you should see a calypso_page_view event fired for '/checklist/:site'
* select any site and browse to `/checklist/<site>/paid`
* you should see a calypso_page_view event fired for '/checklist/:site/paid'