### PR TITLE
i18n: supporting locale variants

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -29,10 +29,9 @@ import authController from 'auth/controller';
 const debug = debugFactory( 'calypso' );
 
 const switchUserLocale = ( currentUser, reduxStore ) => {
-	const localeSlug = currentUser.get().localeSlug;
-
-	if ( localeSlug ) {
-		reduxStore.dispatch( setLocale( localeSlug ) );
+	const currentUserData = currentUser.get();
+	if ( currentUserData.localeSlug ) {
+		reduxStore.dispatch( setLocale( currentUserData.localeSlug, currentUserData.localeVariant ) );
 	}
 };
 

--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -66,7 +66,6 @@ export class LanguagePicker extends PureComponent {
 		if ( ! language ) {
 			return;
 		}
-
 		// onChange takes an object in shape of a DOM event as argument
 		const value = language[ this.props.valueKey ];
 		const event = { target: { value } };
@@ -134,10 +133,13 @@ export class LanguagePicker extends PureComponent {
 		if ( ! language ) {
 			return this.renderPlaceholder();
 		}
-
-		const [ langCode, langSubcode ] = language.langSlug.split( '-' );
 		const langName = language.name;
 		const { disabled, translate } = this.props;
+
+		// assumes xx-yy_variant abstract this into a function and translate( 'formal' )
+		const languageCodes = language.langSlug.split( /[_-]+/ );
+		const langCode = languageCodes[ 0 ];
+		const langSubcode = languageCodes.indexOf( 'formal' ) > -1 ? null : languageCodes[ 1 ];
 
 		return (
 			<div

--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -53,6 +53,13 @@ export class LanguagePicker extends PureComponent {
 		}
 	}
 
+	shouldComponentUpdate( nextProps ) {
+		if ( nextProps.disabled === true ) {
+			return false;
+		}
+		return true;
+	}
+
 	findLanguage( valueKey, value ) {
 		return find( this.props.languages, lang => {
 			// The value passed is sometimes string instead of number - need to use ==
@@ -66,8 +73,8 @@ export class LanguagePicker extends PureComponent {
 		if ( ! language ) {
 			return;
 		}
-		// onChange takes an object in shape of a DOM event as argument
 		const value = language[ this.props.valueKey ];
+		// onChange takes an object in shape of a DOM event as argument
 		const event = { target: { value } };
 		this.props.onChange( event );
 		this.setState( {

--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -19,7 +19,7 @@ import QueryGeo from 'components/data/query-geo';
 import LanguagePickerModal from './modal';
 import QueryLanguageNames from 'components/data/query-language-names';
 
-export class LanguagePicker extends PureComponent {
+export class LanguagePicker extends Component {
 	static propTypes = {
 		languages: PropTypes.array.isRequired,
 		valueKey: PropTypes.string,

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -72,6 +72,8 @@
 	text-transform: uppercase;
 	font-weight: 700;
 	line-height: 1;
+	font-size: 12px;
+
 }
 
 .language-picker__name {

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -17,7 +17,6 @@ import { setSection as setSectionAction } from 'state/ui/actions';
 import { getSection } from 'state/ui/selectors';
 import { setLocale } from 'state/ui/language/actions';
 import isRTL from 'state/selectors/is-rtl';
-import { getLanguage } from 'lib/i18n-utils';
 
 export function makeLayoutMiddleware( LayoutComponent ) {
 	return ( context, next ) => {

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -17,6 +17,7 @@ import { setSection as setSectionAction } from 'state/ui/actions';
 import { getSection } from 'state/ui/selectors';
 import { setLocale } from 'state/ui/language/actions';
 import isRTL from 'state/selectors/is-rtl';
+import { getLanguage } from 'lib/i18n-utils';
 
 export function makeLayoutMiddleware( LayoutComponent ) {
 	return ( context, next ) => {
@@ -63,12 +64,16 @@ export function setUpLocale( context, next ) {
 	const currentUser = getCurrentUser( context.store.getState() );
 
 	if ( context.params.lang ) {
+		// what if this is a variant?
 		context.lang = context.params.lang;
 	} else if ( currentUser ) {
 		context.lang = currentUser.localeSlug;
 	}
 
-	context.store.dispatch( setLocale( context.lang || config( 'i18n_default_locale_slug' ) ) );
+	context.store.dispatch(
+		setLocale( context.lang || config( 'i18n_default_locale_slug' ) ),
+		currentUser.localeVariant
+	);
 
 	loadSectionCSS( context, next );
 }

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -61,16 +61,16 @@ function loadSectionCSS( context, next ) {
 
 export function setUpLocale( context, next ) {
 	const currentUser = getCurrentUser( context.store.getState() );
-
+	let localeVariant;
 	if ( context.params.lang ) {
-		// what if this is a variant?
 		context.lang = context.params.lang;
 	} else if ( currentUser ) {
 		context.lang = currentUser.localeSlug;
+		localeVariant = currentUser.localeVariant;
 	}
 
 	context.store.dispatch(
-		setLocale( context.lang || config( 'i18n_default_locale_slug' ) ),
+		setLocale( context.lang || config( 'i18n_default_locale_slug' ), localeVariant ),
 		currentUser.localeVariant
 	);
 

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -70,8 +70,7 @@ export function setUpLocale( context, next ) {
 	}
 
 	context.store.dispatch(
-		setLocale( context.lang || config( 'i18n_default_locale_slug' ), localeVariant ),
-		currentUser.localeVariant
+		setLocale( context.lang || config( 'i18n_default_locale_slug' ), localeVariant )
 	);
 
 	loadSectionCSS( context, next );

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -10,7 +10,7 @@ import { parse } from 'url';
  */
 import config from 'config';
 
-const localeRegex = /^[A-Z]{2,3}(_[A-Z]{2,6})?$/i;
+const localeRegex = /^[A-Z]{2,3}(-[A-Z]{2,3})?(_[A-Z]{2,6})?$/i;
 
 function getPathParts( path ) {
 	// Remove trailing slash then split. If there is a trailing slash,

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -10,8 +10,7 @@ import { parse } from 'url';
  */
 import config from 'config';
 
-const localeRegex = /^[A-Z]{2,3}$/i;
-const localeWithRegionRegex = /^[A-Z]{2,3}-[A-Z]{2,3}$/i;
+const localeRegex = /^[A-Z]{2,3}(_[A-Z]{2,6})?$/i;
 
 function getPathParts( path ) {
 	// Remove trailing slash then split. If there is a trailing slash,
@@ -31,8 +30,7 @@ export function isDefaultLocale( locale ) {
 
 export function getLanguage( langSlug ) {
 	let language;
-
-	if ( localeRegex.test( langSlug ) || localeWithRegionRegex.test( langSlug ) ) {
+	if ( localeRegex.test( langSlug ) ) {
 		language =
 			find( config( 'languages' ), { langSlug } ) ||
 			find( config( 'languages' ), { langSlug: langSlug.split( '-' )[ 0 ] } );

--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -258,6 +258,11 @@ UserSettings.prototype.getSetting = function( settingName ) {
  * @return {Boolean} updating successful response
  */
 UserSettings.prototype.updateSetting = function( settingName, value ) {
+	/*
+		settingName for local_variant is different
+	 */
+	// eslint-disable-next-line
+	console.log( 'UserSettings.prototype.updateSetting()', settingName, value );
 	if ( has( this.settings, settingName ) ) {
 		set( this.unsavedSettings, settingName, value );
 
@@ -265,6 +270,7 @@ UserSettings.prototype.updateSetting = function( settingName, value ) {
 		 * If the two match, we don't consider the setting "changed".
 		 * user_login is a special case since the logic for validating and saving a username
 		 * is more complicated.
+		 * language is a special case too because a user may switch form a variant to the parent
 		 */
 		if (
 			get( this.settings, settingName ) === get( this.unsavedSettings, settingName ) &&
@@ -276,10 +282,9 @@ UserSettings.prototype.updateSetting = function( settingName, value ) {
 
 		this.emit( 'change' );
 		return true;
-	} else {
-		debug( settingName + ' does not exist in user-settings data module.' );
-		return false;
 	}
+	debug( settingName + ' does not exist in user-settings data module.' );
+	return false;
 };
 
 UserSettings.prototype.isSettingUnsaved = function( settingName ) {

--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -266,9 +266,11 @@ UserSettings.prototype.updateSetting = function( settingName, value ) {
 		 * user_login is a special case since the logic for validating and saving a username
 		 * is more complicated.
 		 */
-		if ( get( this.settings, settingName ) === get( this.unsavedSettings, settingName ) &&
+		if (
+			get( this.settings, settingName ) === get( this.unsavedSettings, settingName ) &&
 			'user_login' !== settingName &&
-			'language' !== settingName ) {
+			'language' !== settingName
+		) {
 			canDeleteUnsavedSetting = true;
 		}
 
@@ -278,10 +280,12 @@ UserSettings.prototype.updateSetting = function( settingName, value ) {
  		*/
 		if ( 'language' === settingName ) {
 			if (
-				// if the incoming language code is not the root of the current variant
+				// if the incoming language code is same as the saved language code and there's no saved variant (isEmpty)
+				// it means we're dealing with the same locale === setting hasn't changed
+				// if there is a saved variant is not empty we know that the user is changing back to the root language
 				( value === this.settings.language && isEmpty( this.settings.locale_variant ) ) ||
-				// if the incoming language code is not the variant itself
-				( value === this.settings.locale_variant )
+				// if the incoming language code is the variant itself === setting hasn't changed
+				value === this.settings.locale_variant
 			) {
 				canDeleteUnsavedSetting = true;
 			}

--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -78,7 +78,7 @@ export function getComputedAttributes( attributes ) {
 	return {
 		primarySiteSlug: getSiteSlug( primaryBlogUrl ),
 		localeSlug: attributes.language,
-		localeVariant: attributes.locale_variant || null,
+		localeVariant: attributes.locale_variant,
 		isRTL: !! ( language && language.rtl ),
 	};
 }

--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -73,11 +73,12 @@ export function filterUserObject( obj ) {
 }
 
 export function getComputedAttributes( attributes ) {
-	const language = getLanguage( attributes.language );
+	const language = getLanguage( attributes.locale_variant || attributes.language );
 	const primaryBlogUrl = attributes.primary_blog_url || '';
 	return {
 		primarySiteSlug: getSiteSlug( primaryBlogUrl ),
 		localeSlug: attributes.language,
+		localeVariant: attributes.locale_variant || null,
 		isRTL: !! ( language && language.rtl ),
 	};
 }

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -135,7 +135,6 @@ User.prototype.fetch = function() {
 				this.handleFetchFailure( error );
 				return;
 			}
-
 			const userData = filterUserObject( data );
 			this.handleFetchSuccess( userData );
 			debug( 'User successfully retrieved' );
@@ -175,7 +174,6 @@ User.prototype.handleFetchSuccess = function( userData ) {
 	// Release lock from subsequent fetches
 	this.fetching = false;
 	this.clearStoreIfChanged( userData.ID );
-
 	// Store user info in `this.data` and localstorage as `wpcom_user`
 	store.set( 'wpcom_user', userData );
 	if ( userData.abtests ) {

--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -9,7 +9,7 @@ import qs from 'querystring';
 /**
  * Internal dependencies
  */
-import { getCurrentUserLocale } from 'state/current-user/selectors';
+import { getCurrentUserLocale, getCurrentUserLocaleVariant } from 'state/current-user/selectors';
 
 /**
  * Module variables
@@ -88,7 +88,9 @@ export function injectLocalization( wpcom ) {
  */
 export function bindState( store ) {
 	function setLocaleFromState() {
-		setLocale( getCurrentUserLocale( store.getState() ) );
+		setLocale(
+			getCurrentUserLocaleVariant( store.getState() ) || getCurrentUserLocale( store.getState() )
+		);
 	}
 
 	store.subscribe( setLocaleFromState );

--- a/client/lib/wp/localization/test/index.js
+++ b/client/lib/wp/localization/test/index.js
@@ -8,10 +8,14 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { addLocaleQueryParam, bindState, getLocale, injectLocalization, setLocale } from '../';
-import { getCurrentUserLocale as getCurrentUserLocaleMock } from 'state/current-user/selectors';
+import {
+	getCurrentUserLocale as getCurrentUserLocaleMock,
+	getCurrentUserLocaleVariant as getCurrentUserLocaleVariantMock,
+} from 'state/current-user/selectors';
 
 jest.mock( 'state/current-user/selectors', () => ( {
 	getCurrentUserLocale: jest.fn(),
+	getCurrentUserLocaleVariant: jest.fn(),
 } ) );
 
 describe( 'index', () => {
@@ -78,6 +82,12 @@ describe( 'index', () => {
 			getCurrentUserLocaleMock.mockReturnValueOnce( 'fr' );
 			bindState( { subscribe() {}, getState() {} } );
 			expect( getLocale() ).to.equal( 'fr' );
+		} );
+
+		test( 'should prefer and set initial variant locale from state', () => {
+			getCurrentUserLocaleVariantMock.mockReturnValueOnce( 'fr_formal' );
+			bindState( { subscribe() {}, getState() {} } );
+			expect( getLocale() ).to.equal( 'fr_formal' );
 		} );
 
 		test( 'should subscribe to the store, setting locale on change', () => {

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -103,8 +103,10 @@ const Account = createReactClass( {
 	updateLanguage( event ) {
 		const { value } = event.target;
 		const originalLanguage = this.props.userSettings.getOriginalSetting( 'language' );
+		const originalLocaleVariant = this.props.userSettings.getOriginalSetting( 'locale_variant' );
+
 		this.updateUserSetting( 'language', value );
-		const redirect = value !== originalLanguage ? '/me/account' : false;
+		const redirect = value !== originalLanguage || value !== originalLocaleVariant ? '/me/account' : false;
 		this.setState( { redirect } );
 	},
 

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -103,7 +103,6 @@ const Account = createReactClass( {
 	updateLanguage( event ) {
 		const { value } = event.target;
 		const originalLanguage = this.props.userSettings.getOriginalSetting( 'language' );
-
 		this.updateUserSetting( 'language', value );
 		const redirect = value !== originalLanguage ? '/me/account' : false;
 		this.setState( { redirect } );
@@ -534,7 +533,9 @@ const Account = createReactClass( {
 						languages={ config( 'languages' ) }
 						onClick={ this.recordClickEvent( 'Interface Language Field' ) }
 						valueKey="langSlug"
-						value={ this.getUserSetting( 'language' ) || '' }
+						value={
+							this.getUserSetting( 'locale_variant' ) || this.getUserSetting( 'language' ) || ''
+						}
 						onChange={ this.updateLanguage }
 					/>
 					<FormSettingExplanation>

--- a/client/me/form-base/index.js
+++ b/client/me/form-base/index.js
@@ -79,7 +79,6 @@ export default {
 		this.setState( { submittingForm: true } );
 		this.props.userSettings.saveSettings(
 			function( error, response ) {
-				this.setState( { submittingForm: false } );
 				if ( error ) {
 					debug( 'Error saving settings: ' + JSON.stringify( error ) );
 
@@ -89,6 +88,7 @@ export default {
 					} else {
 						notices.error( this.props.translate( 'There was a problem saving your changes.' ) );
 					}
+					this.setState( { submittingForm: false } );
 				} else {
 					this.props.markSaved && this.props.markSaved();
 
@@ -100,8 +100,8 @@ export default {
 						} );
 						return;
 					}
-
-					this.setState( { showNotice: true } );
+					// if we set submittingForm too soon the UI updates before the response is handled
+					this.setState( { showNotice: true, submittingForm: false } );
 					this.showNotice();
 					debug( 'Settings saved successfully ' + JSON.stringify( response ) );
 				}

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -60,7 +60,8 @@ const EditUserForm = createReactClass( {
 				originalUser[ setting ] !== this.state[ setting ]
 			);
 		} );
-
+		// eslint-disable-next-line
+		console.log( 'getChangedSettings() this.state, originalUser, changedKeys', this.state, originalUser, changedKeys );
 		return pick( this.state, changedKeys );
 	},
 

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -29,7 +29,7 @@ import analytics from 'lib/analytics';
 import config from 'config';
 import { recordTracksEvent } from 'state/analytics/actions';
 import NotificationsPanel, { refreshNotes } from 'notifications-panel';
-import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
+import { getCurrentUserLocale } from 'state/current-user/selectors';
 
 /**
  * Returns whether or not the browser session
@@ -248,7 +248,7 @@ export class Notifications extends Component {
 
 export default connect(
 	state => ( {
-		currentLocaleSlug: getCurrentLocaleSlug( state ),
+		currentLocaleSlug: getCurrentUserLocale( state ),
 	} ),
 	{ recordTracksEvent }
 )( Notifications );

--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -56,6 +56,14 @@ export const createCurrentUserSelector = ( path, otherwise = null ) => state => 
 export const getCurrentUserLocale = createCurrentUserSelector( 'localeSlug' );
 
 /**
+ * Returns the locale variant slug for the current user.
+ * See: getComputedAttributes() in client/lib/user/shared-utils.js
+ * @param  {Object}  state  Global state tree
+ * @return {?String}        Current user locale variant
+ */
+export const getCurrentUserLocaleVariant = createCurrentUserSelector( 'localeVariant' );
+
+/**
  * Returns the country code for the current user.
  *
  * @param  {Object}  state  Global state tree

--- a/client/state/current-user/test/selectors.js
+++ b/client/state/current-user/test/selectors.js
@@ -12,6 +12,7 @@ import {
 	getCurrentUserId,
 	getCurrentUser,
 	getCurrentUserLocale,
+	getCurrentUserLocaleVariant,
 	getCurrentUserDate,
 	isValidCapability,
 	getCurrentUserCurrencyCode,
@@ -97,6 +98,53 @@ describe( 'selectors', () => {
 			} );
 
 			expect( locale ).to.equal( 'fr' );
+		} );
+	} );
+
+	describe( '#getCurrentUserLocaleVariant', () => {
+		test( 'should return null if the current user is not set', () => {
+			const locale = getCurrentUserLocaleVariant( {
+				currentUser: {
+					id: null,
+				},
+			} );
+
+			expect( locale ).to.be.null;
+		} );
+
+		test( 'should return null if the current user locale slug is not set', () => {
+			const locale = getCurrentUserLocaleVariant( {
+				users: {
+					items: {
+						73705554: { ID: 73705554, login: 'testonesite2014' },
+					},
+				},
+				currentUser: {
+					id: 73705554,
+				},
+			} );
+
+			expect( locale ).to.be.null;
+		} );
+
+		test( 'should return the current user locale variant slug', () => {
+			const locale = getCurrentUserLocaleVariant( {
+				users: {
+					items: {
+						73705554: {
+							ID: 73705554,
+							login: 'testonesite2014',
+							localeSlug: 'fr',
+							localeVariant: 'fr_formal',
+						},
+					},
+				},
+				currentUser: {
+					id: 73705554,
+				},
+			} );
+
+			expect( locale ).to.equal( 'fr_formal' );
 		} );
 	} );
 

--- a/client/state/ui/language/README.md
+++ b/client/state/ui/language/README.md
@@ -5,7 +5,7 @@ Language UI State
 
 ###`setLocale()`
 
-Change the locale of the application
+Change the locale and, optionally, the locale variant of the application.
 
 ## Reducers
 
@@ -14,3 +14,13 @@ The included reducers add the following keys to the global state tree, under `ui
 ###`localeSlug`
 
 The value of the current locale slug ('en', 'fr'...)
+
+###`localeVariant`
+
+The locale variant refers to a subset of the locale, for example formal German (Sie) ('de_formal'). 
+
+###`isRtl`
+
+The isRtl state of the ui language.
+
+

--- a/client/state/ui/language/actions.js
+++ b/client/state/ui/language/actions.js
@@ -13,16 +13,18 @@ import i18n from 'i18n-calypso';
 import { LOCALE_SET } from 'state/action-types';
 
 /**
- * Set the ui locale
+ * Set the ui locale and ui locale variant
  *
- * @param   {Object} localeSlug the locale slug to change the locale to
+ * @param   {String} localeSlug the locale slug to change the ui locale to
+ * @param   {String} localeVariant optional local variant to switch to
  * @returns {Function} Action thunk
  */
-export const setLocale = localeSlug => {
-	switchLocale( localeSlug );
+export const setLocale = ( localeSlug, localeVariant ) => {
+	switchLocale( localeSlug, localeVariant );
 	return {
 		type: LOCALE_SET,
 		localeSlug,
+		localeVariant,
 	};
 };
 

--- a/client/state/ui/language/actions.js
+++ b/client/state/ui/language/actions.js
@@ -39,5 +39,6 @@ export const setLocaleRawData = localeData => {
 	return {
 		type: LOCALE_SET,
 		localeSlug: localeData[ '' ].localeSlug,
+		localeVariant: localeData[ '' ].localeVariant,
 	};
 };

--- a/client/state/ui/language/reducer.js
+++ b/client/state/ui/language/reducer.js
@@ -6,7 +6,7 @@
 
 import { combineReducers, createReducer } from 'state/utils';
 import { LOCALE_SET } from 'state/action-types';
-import { localeSlugSchema, isRtlSchema } from './schema';
+import { localeSlugSchema, localeVariantSchema, isRtlSchema } from './schema';
 import { getLanguage } from 'lib/i18n-utils/utils';
 
 /**
@@ -26,6 +26,22 @@ export const localeSlug = createReducer(
 );
 
 /**
+ * Tracks the state of the ui locale variant
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ *
+ */
+export const localeVariant = createReducer(
+	null,
+	{
+		[ LOCALE_SET ]: ( state, action ) => action.localeVariant,
+	},
+	localeVariantSchema
+);
+
+/**
  * Tracks the state of the ui language isRtl.
  *
  * @param  {Object} state  Current state
@@ -37,7 +53,7 @@ export const isRtl = createReducer(
 	null,
 	{
 		[ LOCALE_SET ]: ( state, action ) => {
-			const localeSlugFromAction = action.localeSlug;
+			const localeSlugFromAction = action.localeVariant || action.localeSlug;
 
 			if ( ! localeSlugFromAction ) {
 				return null;
@@ -55,4 +71,4 @@ export const isRtl = createReducer(
 	isRtlSchema
 );
 
-export default combineReducers( { localeSlug, isRtl } );
+export default combineReducers( { localeSlug, localeVariant, isRtl } );

--- a/client/state/ui/language/reducer.js
+++ b/client/state/ui/language/reducer.js
@@ -30,13 +30,13 @@ export const localeSlug = createReducer(
  *
  * @param  {Object} state  Current state
  * @param  {Object} action Action payload
- * @return {Object}        Updated state
+ * @return {Object}        Updated or default state
  *
  */
 export const localeVariant = createReducer(
 	null,
 	{
-		[ LOCALE_SET ]: ( state, action ) => action.localeVariant,
+		[ LOCALE_SET ]: ( state, action ) => action.localeVariant || state,
 	},
 	localeVariantSchema
 );

--- a/client/state/ui/language/schema.js
+++ b/client/state/ui/language/schema.js
@@ -1,4 +1,6 @@
 /** @format */
 export const localeSlugSchema = { type: [ 'string', 'null' ] };
 
+export const localeVariantSchema = { type: [ 'string', 'null' ] };
+
 export const isRtlSchema = { type: [ 'boolean', 'null' ] };

--- a/client/state/ui/language/test/actions.js
+++ b/client/state/ui/language/test/actions.js
@@ -17,6 +17,15 @@ describe( 'actions', () => {
 			expect( setLocale( 'he' ) ).to.eql( {
 				type: LOCALE_SET,
 				localeSlug: 'he',
+				localeVariant: undefined,
+			} );
+		} );
+
+		test( 'returns an appropriate action with localeVariant', () => {
+			expect( setLocale( 'he', 'he_formal' ) ).to.eql( {
+				type: LOCALE_SET,
+				localeSlug: 'he',
+				localeVariant: 'he_formal',
 			} );
 		} );
 	} );
@@ -27,11 +36,13 @@ describe( 'actions', () => {
 				setLocaleRawData( {
 					'': {
 						localeSlug: 'he',
+						localeVariant: 'he_formal',
 					},
 				} )
 			).to.eql( {
 				type: LOCALE_SET,
 				localeSlug: 'he',
+				localeVariant: 'he_formal',
 			} );
 		} );
 	} );

--- a/client/state/ui/language/test/reducer.js
+++ b/client/state/ui/language/test/reducer.js
@@ -50,8 +50,8 @@ describe( 'reducer', () => {
 			expect( localeVariant( undefined, { type: 'foobar' } ) ).to.be.null;
 		} );
 
-		test( 'returns undefined with undefined state and missing slug', () => {
-			expect( localeVariant( undefined, { type: LOCALE_SET } ) ).to.be.undefined;
+		test( 'returns default state of null with undefined state and missing slug', () => {
+			expect( localeVariant( undefined, { type: LOCALE_SET } ) ).to.be.null;
 		} );
 
 		test( 'returns new state with valid slug', () => {

--- a/client/state/ui/language/test/reducer.js
+++ b/client/state/ui/language/test/reducer.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { localeSlug, isRtl } from '../reducer';
+import { localeSlug, localeVariant, isRtl } from '../reducer';
 import { LOCALE_SET } from 'state/action-types';
 
 describe( 'reducer', () => {
@@ -34,6 +34,31 @@ describe( 'reducer', () => {
 			const action = { type: LOCALE_SET, localeSlug: 'he' };
 
 			expect( localeSlug( state, action ) ).to.eql( 'he' );
+		} );
+	} );
+
+	describe( 'localeVariant', () => {
+		test( 'returns default state with undefined state and empty action', () => {
+			expect( localeVariant( undefined, {} ) ).to.be.null;
+		} );
+
+		test( 'returns previous state with empty action', () => {
+			expect( localeVariant( 'de_formal', {} ) ).to.eql( 'de_formal' );
+		} );
+
+		test( 'returns default state with undefined state and invalid action type', () => {
+			expect( localeVariant( undefined, { type: 'foobar' } ) ).to.be.null;
+		} );
+
+		test( 'returns undefined with undefined state and missing slug', () => {
+			expect( localeVariant( undefined, { type: LOCALE_SET } ) ).to.be.undefined;
+		} );
+
+		test( 'returns new state with valid slug', () => {
+			const state = 'en';
+			const action = { type: LOCALE_SET, localeVariant: 'de_formal' };
+
+			expect( localeVariant( state, action ) ).to.eql( 'de_formal' );
 		} );
 	} );
 

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -63,6 +63,7 @@
         { "value": 13, "langSlug": "cy", "name": "Cymraeg", "wpLocale": "cy", "territories": [ "154" ] },
         { "value": 14, "langSlug": "da", "name": "Dansk", "wpLocale": "da_DK", "territories": [ "154" ] },
         { "value": 15, "langSlug": "de", "name": "Deutsch", "wpLocale": "de_DE", "popular": 4, "territories": [ "155" ] },
+        { "value": 900, "langSlug": "de_formal", "name": "Deutsch (Sie)", "wpLocale": "de_DE_formal", "parentLangSlug": "de", "territories": [ "155" ] },
         { "value": 427, "langSlug": "dv", "name": "ދިވެހި", "wpLocale": "dv", "rtl": true, "territories": [ "034" ] },
         { "value": 16, "langSlug": "dz", "name": "ཇོང་ཁ", "wpLocale": "", "territories": [ "034" ] },
         { "value": 17, "langSlug": "el", "name": "Ελληνικά", "wpLocale": "el", "territories": [ "039" ] },

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -308,6 +308,7 @@ function setUpLoggedInRoute( req, res, next ) {
 				req.context.store.dispatch( {
 					type: LOCALE_SET,
 					localeSlug: data.localeSlug,
+					localeVariant: data.localeVariant,
 				} );
 			}
 

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -153,6 +153,7 @@ export function serverRender( req, res ) {
 		}
 
 		context.lang = getCurrentLocaleSlug( context.store.getState() ) || context.lang;
+
 		const isLocaleRTL = isRTL( context.store.getState() );
 		context.isRTL = isLocaleRTL !== null ? isLocaleRTL : context.isRTL;
 	}


### PR DESCRIPTION
This is a hacky hack week hack :)

## Work in progress....

<img width="689" alt="screen shot 2018-03-08 at 2 36 40 pm" src="https://user-images.githubusercontent.com/6458278/37131774-2e5f3548-22de-11e8-86db-c0ff3f9fb03d.png">

## TODOS
- [ ] Filling the HTML lang code doesn't seem to work on dev, needs testing
- [ ] Check for `getLanguages` and `setLocales` I've missed...
- [ ] What to do about `getLocaleSlug` from `i18n-calypso`. Is there anything to do?

## Notes
We're assuming a variant slug of `de_formal`. Here's the regex:

`const localeRegex = /^[A-Z]{2,3}(-[A-Z]{2,3})?(_[A-Z]{2,6})?$/i`

We add the locale [variant slug to API calls](https://github.com/Automattic/wp-calypso/pull/23025/files#diff-d114d13ba624c38fbca0f5afc1995768R91).

## Testing
Checkout `code-D10642`
Add/uncomment the `de_formal` in the language locale id list (being deliberately vague here, ping me for questions)

## What is a locale variant?

A locale variant is a alternative subset of a language  that **features exclusively the grammatical/lexical/syntactical components** of that language. 

For example, the German formal (_Sie_) and informal (_du_) as spoken in Germany are features of the same language, that is, German (_de_DE_). We can accordingly create two translation sets:

1. German formal (_Sie_) 
2. German informal (_du_) 

even though the overall language, German, is the same.


