### PR TITLE
Fix calypso_page_view events for checkout routes

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -30,18 +30,22 @@ import CheckoutThankYouComponent from './checkout-thank-you';
 const productsList = productsFactory();
 
 const checkoutRoutes = [
-	new Route( '/checkout/thank-you' ),
-	new Route( '/checkout/thank-you/:receipt' ),
-	new Route( '/checkout/:product' ),
-	new Route( '/checkout/:product/renew/:receipt' ),
-	new Route( '/checkout/:site/with-gsuite/:domain/:receipt' ),
+	new Route( '/checkout/thank-you/no-site/:receipt' ),
+	new Route( '/checkout/thank-you/:site/:receipt' ),
+	new Route( '/checkout/thank-you/:site/:receipt/with-gsuite/:gsuiteReceipt' ),
+	new Route( '/checkout/features/:feature/:domain/:plan_name' ),
+	new Route( '/checkout/thank-you/features/:feature/:site/:receipt' ),
+	new Route( '/checkout/no-site' ),
+	new Route( '/checkout/:site/:product' ),
+	new Route( '/checkout/:product/renew/:purchaseId/:site' ),
+	new Route( '/checkout/:site/with-gsuite/:domain/:receipt?' ),
 ];
 
 export default {
 	checkout: function( context, next ) {
 		const { routePath, routeParams } = sectionifyWithRoutes( context.path, checkoutRoutes );
-		const product = context.params.product;
-		const selectedFeature = context.params.feature;
+		const { params } = context;
+		const { feature, product } = params;
 
 		const state = context.store.getState();
 		const selectedSite = getSelectedSite( state );
@@ -61,7 +65,7 @@ export default {
 					product={ product }
 					productsList={ productsList }
 					purchaseId={ context.params.purchaseId }
-					selectedFeature={ selectedFeature }
+					selectedFeature={ feature }
 					couponCode={ context.query.code }
 				/>
 			</CheckoutData>
@@ -100,15 +104,15 @@ export default {
 		const receiptId = Number( context.params.receiptId );
 		const gsuiteReceiptId = Number( context.params.gsuiteReceiptId ) || 0;
 
+		const state = context.store.getState();
+		const selectedSite = getSelectedSite( state );
+
 		analytics.pageView.record( routePath, 'Checkout Thank You', routeParams );
 
 		context.store.dispatch( setSection( { name: 'checkout-thank-you' }, { hasSidebar: false } ) );
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Thank You' ) ) );
-
-		const state = context.store.getState();
-		const selectedSite = getSelectedSite( state );
 
 		context.primary = (
 			<CheckoutThankYouComponent

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -30,9 +30,9 @@ import CheckoutThankYouComponent from './checkout-thank-you';
 const productsList = productsFactory();
 
 const checkoutRoutes = [
-	new Route( '/checkout/features/:feature/:domain/:plan_name' ),
-	new Route( '/checkout/features/:feature/:domain' ),
-	new Route( '/checkout/:product/renew/:purchaseId/:site' ),
+	new Route( '/checkout/features/:feature/:site/:plan' ),
+	new Route( '/checkout/features/:feature/:site' ),
+	new Route( '/checkout/:product/renew/:purchase/:site' ),
 	new Route( '/checkout/:site/:product' ),
 	new Route( '/checkout/:site' ),
 ];
@@ -43,13 +43,14 @@ const checkoutGSuiteNudgeRoutes = [
 ];
 
 const checkoutThankYouRoutes = [
-	new Route( '/checkout/thank-you/no-site' ),
 	new Route( '/checkout/thank-you/no-site/:receipt' ),
-	new Route( '/checkout/thank-you/:site' ),
+	new Route( '/checkout/thank-you/no-site' ),
 	new Route( '/checkout/thank-you/:site/:receipt' ),
+	new Route( '/checkout/thank-you/:site' ),
 	new Route( '/checkout/thank-you/:site/:receipt/with-gsuite/:gsuiteReceipt' ),
-	new Route( '/checkout/thank-you/features/:feature/:site' ),
+	new Route( '/checkout/thank-you/:site/:receipt/with-gsuite' ),
 	new Route( '/checkout/thank-you/features/:feature/:site/:receipt' ),
+	new Route( '/checkout/thank-you/features/:feature/:site' ),
 ];
 
 export default {

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -30,15 +30,26 @@ import CheckoutThankYouComponent from './checkout-thank-you';
 const productsList = productsFactory();
 
 const checkoutRoutes = [
+	new Route( '/checkout/features/:feature/:domain/:plan_name' ),
+	new Route( '/checkout/features/:feature/:domain' ),
+	new Route( '/checkout/:product/renew/:purchaseId/:site' ),
+	new Route( '/checkout/:site/:product' ),
+	new Route( '/checkout/:site' ),
+];
+
+const checkoutGSuiteNudgeRoutes = [
+	new Route( '/checkout/:site/with-gsuite/:domain/:receipt' ),
+	new Route( '/checkout/:site/with-gsuite/:domain' ),
+];
+
+const checkoutThankYouRoutes = [
+	new Route( '/checkout/thank-you/no-site' ),
 	new Route( '/checkout/thank-you/no-site/:receipt' ),
+	new Route( '/checkout/thank-you/:site' ),
 	new Route( '/checkout/thank-you/:site/:receipt' ),
 	new Route( '/checkout/thank-you/:site/:receipt/with-gsuite/:gsuiteReceipt' ),
-	new Route( '/checkout/features/:feature/:domain/:plan_name' ),
+	new Route( '/checkout/thank-you/features/:feature/:site' ),
 	new Route( '/checkout/thank-you/features/:feature/:site/:receipt' ),
-	new Route( '/checkout/no-site' ),
-	new Route( '/checkout/:site/:product' ),
-	new Route( '/checkout/:product/renew/:purchaseId/:site' ),
-	new Route( '/checkout/:site/with-gsuite/:domain/:receipt?' ),
 ];
 
 export default {
@@ -100,7 +111,7 @@ export default {
 	},
 
 	checkoutThankYou: function( context, next ) {
-		const { routePath, routeParams } = sectionifyWithRoutes( context.path, checkoutRoutes );
+		const { routePath, routeParams } = sectionifyWithRoutes( context.path, checkoutThankYouRoutes );
 		const receiptId = Number( context.params.receiptId );
 		const gsuiteReceiptId = Number( context.params.gsuiteReceiptId ) || 0;
 
@@ -129,7 +140,10 @@ export default {
 	},
 
 	gsuiteNudge( context, next ) {
-		const { routePath, routeParams } = sectionifyWithRoutes( context.path, checkoutRoutes );
+		const { routePath, routeParams } = sectionifyWithRoutes(
+			context.path,
+			checkoutGSuiteNudgeRoutes
+		);
 		const { domain, site, receiptId } = context.params;
 		context.store.dispatch( setSection( { name: 'gsuite-nudge' }, { hasSidebar: false } ) );
 

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -40,14 +40,6 @@ export default function() {
 	);
 
 	page(
-		'/checkout/features/:feature/:domain/:plan_name?',
-		siteSelection,
-		checkoutController.checkout,
-		makeLayout,
-		clientRender
-	);
-
-	page(
 		'/checkout/thank-you/features/:feature/:site/:receiptId?',
 		siteSelection,
 		checkoutController.checkoutThankYou,
@@ -59,6 +51,14 @@ export default function() {
 		'/checkout/no-site',
 		noSite,
 		checkoutController.sitelessCheckout,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/checkout/features/:feature/:domain/:plan_name?',
+		siteSelection,
+		checkoutController.checkout,
 		makeLayout,
 		clientRender
 	);


### PR DESCRIPTION
The routes for checkout were out of sync with the route list to ensure the correct placeholders are used in calypso calypso_page_view events.

This results in calypso_page_view containing a path such as `/checkout/thank-you/foo.com/12345` instead of `/checkout/thank-you/:site/:receipt` (making the event fairly unusable in funnels).

This addresses part of #16902

# Testing

Enable tracks logging to the console: `localStorage.setItem('debug', 'calypso:analytics:tracks');`

For any site, verify that each of the following routes trigger a `calyso_page_view` event with the corresponding path:

## checkout routes:

* `/checkout/features/google-analytics/ryall.blog/business` ->`/checkout/features/:feature/:site/:plan` (this route might no longer be in use)
* `/checkout/features/google-analytics/ryall.blog` ->`/checkout/features/:feature/:site` (this route might no longer be in use)
* `/checkout/business/renew/12345/ryall.blog` ->`/checkout/:product/renew/:purchaseId/:site`
* `/checkout/ryall.blog/business` ->`/checkout/:site/:product`
* `/checkout/ryall.blog` -> `/checkout/:site` (this route might no longer be in use)

* `/checkout/ryall.blog/with-gsuite/ryall.blog/12345` -> `/checkout/:site/with-gsuite/:domain/:receipt`
* `/checkout/ryall.blog/with-gsuite/ryall.blog` -> `/checkout/:site/with-gsuite/:domain`

## checkout thank you routes:

* `/checkout/thank-you/no-site` -> `/checkout/thank-you/no-site`
* `/checkout/thank-you/no-site/12345` -> `/checkout/thank-you/no-site/:receipt`
* `/checkout/thank-you/ryall.blog` -> `/checkout/thank-you/:site`
* `/checkout/thank-you/ryall.blog/12345` -> `/checkout/thank-you/:site/:receipt`
* `/checkout/thank-you/ryall.blog/12345/with-gsuite`-> `/checkout/thank-you/:site/:receipt/with-gsuite/:gsuiteReceipt` (this route might no longer be in use)
* `/checkout/thank-you/ryall.blog/12345/with-gsuite/56789`-> `/checkout/thank-you/:site/:receipt/with-gsuite/:gsuiteReceipt`
* `/checkout/thank-you/features/google-analytics/ryall.blog` -> `/checkout/thank-you/features/:feature/:site`
* `/checkout/thank-you/features/google-analytics/ryall.blog/12345` -> `/checkout/thank-you/features/:feature/:site/:receipt`

Note that several routes may not actually be used.  Once this PR is merged, tracks funnels can be set to find out which are no longer required.