### PR TITLE
Jetpack: Prevent redundant install requests

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -6,7 +6,6 @@
 
 import React, { Component } from 'react';
 import page from 'page';
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { difference, filter, get, map, range, reduce, some } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -669,5 +668,9 @@ export default connect(
 			planSlug,
 		};
 	},
-	dispatch => bindActionCreators( { requestSites, fetchPluginData, installPlugin }, dispatch )
+	{
+		fetchPluginData,
+		installPlugin,
+		requestSites,
+	}
 )( localize( JetpackThankYouCard ) );

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -90,12 +90,9 @@ const akismetFeatures = {
 };
 
 class JetpackThankYouCard extends Component {
-	constructor( props ) {
-		super( props );
-		this.state = {
-			completedJetpackFeatures: {},
-		};
-	}
+	state = {
+		completedJetpackFeatures: {},
+	};
 
 	trackConfigFinished( eventName, options = null ) {
 		if ( ! this.sentTracks ) {

--- a/client/state/plugins/premium/selectors.js
+++ b/client/state/plugins/premium/selectors.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { find, filter, some, every } from 'lodash';
+import { every, filter, find, includes, some } from 'lodash';
 
 export const isRequesting = function( state, siteId ) {
 	// if the `isRequesting` attribute doesn't exist yet,
@@ -67,14 +67,14 @@ export const isInstalling = function( state, siteId, whitelist = false ) {
 
 	// If any plugin is not done/waiting/error'd, it's in an installing state.
 	return some( pluginList, item => {
-		return -1 === [ 'done', 'wait' ].indexOf( item.status ) && item.error === null;
+		return ! includes( [ 'done', 'wait' ], item.status ) && item.error === null;
 	} );
 };
 
 export const getActivePlugin = function( state, siteId, whitelist = false ) {
 	const pluginList = getPluginsForSite( state, siteId, whitelist );
 	const plugin = find( pluginList, item => {
-		return -1 === [ 'done', 'wait' ].indexOf( item.status ) && item.error === null;
+		return ! includes( [ 'done', 'wait' ], item.status ) && item.error === null;
 	} );
 	if ( typeof plugin === 'undefined' ) {
 		return false;


### PR DESCRIPTION
After checkout of a paid Jetpack plan, a thank you card is shown and some additional plugins may be installed.

Some race conditions exist between requesting an install, component updates, and install re-request. An install should only be requested a single time.

This PR removes redundant requests by tracking install requests with some local component state.

It also includes some cleanup:

- Remove redundant `bindActionCreators`
- Replace `-1 === [].indexOf()` with `! includes`

## Testing
1. Start with a Jetpack connected site on the Free plan
1. Go to `https://wordpress.com/checkout/JETPACK_SITE/premium` for your site
1. Complete checkout (ensure network tab is open in dev tools)
1. You will land on a thank you card page. 
1. Verify that each plugin only distpatches a single install request (like below):
   ```
   https://public-api.wordpress.com/rest/v1.1/sites/SITE_ID/plugins/akismet/install
   ```
1. Ensure that the install proceeds correctly

Fixes #15653