### PR TITLE
Editor: Fix visual issue in editor sidebar when content is expanded

### DIFF
--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -53,6 +53,7 @@
 	display: flex;
 	flex-direction: row;
 	padding-left: 10px;
+	flex: none;
 
 	.button {
 		&.inline-help {

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -52,8 +52,8 @@
 	margin: auto 0 0;
 	display: flex;
 	flex-direction: row;
+	flex-shrink: 0;
 	padding-left: 10px;
-	flex: none;
 
 	.button {
 		&.inline-help {


### PR DESCRIPTION
### Summary

I noticed that there was a visual issue with the editor sidebar footer when any of the content/accordian items were expanded enough to push beyond the natural height of the sidebar.
Heres how that looks:

<img width="280" alt="screen shot 2018-03-06 at 11 52 26" src="https://user-images.githubusercontent.com/4335450/37028763-7d63feee-2135-11e8-82d6-a8a41a166250.png">

Heres how it looks with the fix:
<img width="281" alt="screen shot 2018-03-06 at 11 52 10" src="https://user-images.githubusercontent.com/4335450/37028764-7d83e13c-2135-11e8-893f-89545fdb0655.png">

I'm not 100% sure that `flex: none` is the perfect solution and I'm not so sure if there could be unintended side effects, so tagging some CSS wizards for review - feel free to remove yourself if you're too busy though!

Thanks!