### PR TITLE
Settings: Add anchors to SEO and Analytics sections

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -138,7 +138,7 @@ class GoogleAnalyticsForm extends Component {
 			: translate( 'Enable Google Analytics by upgrading to the Business plan' );
 
 		return (
-			<form id="site-settings" onSubmit={ handleSubmitForm }>
+			<form id="analytics" onSubmit={ handleSubmitForm }>
 				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }
 
 				{ isJetpackUnsupported &&

--- a/client/my-sites/site-settings/seo-settings/help.jsx
+++ b/client/my-sites/site-settings/seo-settings/help.jsx
@@ -24,7 +24,7 @@ const SeoSettingsHelpCard = ( { hasAdvancedSEOFeature, siteIsJetpack, translate 
 		: 'https://en.blog.wordpress.com/2013/03/22/seo-on-wordpress-com/';
 
 	return (
-		<div>
+		<div id="seo">
 			<SectionHeader label={ translate( 'Search engine optimization' ) } />
 			{ hasAdvancedSEOFeature && (
 				<Card>


### PR DESCRIPTION
This PR updates the SEO and Analytics site settings sections to have the `id` attribute, so we can lead to those sections directly. 

Part of https://github.com/Automattic/jetpack/issues/8704

To test:
* Checkout this branch
* Go to `http://calypso.localhost:3000/settings/traffic/:site#seo` where `:site` is one of your Jetpack sites.
* Verify you're scrolled to the "Search engine optimization" settings section.
* Go to `http://calypso.localhost:3000/settings/traffic/:site#analytics` where `:site` is one of your Jetpack sites.
* Verify you're scrolled to the Analytics settings section.