### PR TITLE
Jetpack: Use toggle for stats module

### DIFF
--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -113,7 +113,7 @@ class JetpackSiteStats extends Component {
 		);
 	}
 
-	renderCardSettings() {
+	render() {
 		const {
 			activatingStatsModule,
 			moduleUnavailable,
@@ -122,6 +122,7 @@ class JetpackSiteStats extends Component {
 			siteSlug,
 			translate,
 		} = this.props;
+
 		const header = (
 			<JetpackModuleToggle
 				siteId={ siteId }
@@ -134,79 +135,71 @@ class JetpackSiteStats extends Component {
 		);
 
 		return (
-			<Fragment>
-				<FoldableCard
-					className="site-settings__foldable-card is-top-level"
-					header={ header }
-					clickableHeader
-				>
-					<FormFieldset>
-						<div className="site-settings__info-link-container">
-							<InfoPopover position="left">
-								<ExternalLink
-									href="https://jetpack.com/support/wordpress-com-stats/"
-									target="_blank"
-								>
-									{ translate( 'Learn more about WordPress.com Stats' ) }
-								</ExternalLink>
-							</InfoPopover>
-						</div>
-
-						{ this.renderToggle(
-							'admin_bar',
-							translate( 'Put a chart showing 48 hours of views in the admin bar' )
-						) }
-						{ this.renderToggle( 'hide_smile', translate( 'Hide the stats smiley face image' ) ) }
-						<FormSettingExplanation isIndented>
-							{ translate( 'The image helps collect stats, but should work when hidden.' ) }
-						</FormSettingExplanation>
-					</FormFieldset>
-
-					<FormFieldset>
-						<FormLegend>{ translate( 'Count logged in page views from' ) }</FormLegend>
-						{ siteRoles &&
-							siteRoles.map( role =>
-								this.renderToggle(
-									'count_roles_' + role.name,
-									role.display_name,
-									includes( this.getCurrentGroupFields( 'count_roles' ), role.name ),
-									this.onChangeToggleGroup( 'count_roles', role.name )
-								)
-							) }
-					</FormFieldset>
-
-					<FormFieldset>
-						<FormLegend>{ translate( 'Allow stats reports to be viewed by' ) }</FormLegend>
-						{ siteRoles &&
-							siteRoles.map( role =>
-								this.renderToggle(
-									'roles_' + role.name,
-									role.display_name,
-									includes( this.getCurrentGroupFields( 'roles' ), role.name ),
-									this.onChangeToggleGroup( 'roles', role.name )
-								)
-							) }
-					</FormFieldset>
-				</FoldableCard>
-
-				<CompactCard href={ getStatsPathForTab( 'day', siteSlug ) }>
-					{ translate( 'View your site stats' ) }
-				</CompactCard>
-			</Fragment>
-		);
-	}
-
-	render() {
-		const { siteId, translate } = this.props;
-
-		return (
 			<div className="site-settings__traffic-settings">
 				<QueryJetpackConnection siteId={ siteId } />
 				<QuerySiteRoles siteId={ siteId } />
 
 				<SectionHeader label={ translate( 'Site stats' ) } />
 
-				{ this.renderCardSettings() }
+				<Fragment>
+					<FoldableCard
+						className="site-settings__foldable-card is-top-level"
+						header={ header }
+						clickableHeader
+					>
+						<FormFieldset>
+							<div className="site-settings__info-link-container">
+								<InfoPopover position="left">
+									<ExternalLink
+										href="https://jetpack.com/support/wordpress-com-stats/"
+										target="_blank"
+									>
+										{ translate( 'Learn more about WordPress.com Stats' ) }
+									</ExternalLink>
+								</InfoPopover>
+							</div>
+
+							{ this.renderToggle(
+								'admin_bar',
+								translate( 'Put a chart showing 48 hours of views in the admin bar' )
+							) }
+							{ this.renderToggle( 'hide_smile', translate( 'Hide the stats smiley face image' ) ) }
+							<FormSettingExplanation isIndented>
+								{ translate( 'The image helps collect stats, but should work when hidden.' ) }
+							</FormSettingExplanation>
+						</FormFieldset>
+
+						<FormFieldset>
+							<FormLegend>{ translate( 'Count logged in page views from' ) }</FormLegend>
+							{ siteRoles &&
+								siteRoles.map( role =>
+									this.renderToggle(
+										'count_roles_' + role.name,
+										role.display_name,
+										includes( this.getCurrentGroupFields( 'count_roles' ), role.name ),
+										this.onChangeToggleGroup( 'count_roles', role.name )
+									)
+								) }
+						</FormFieldset>
+
+						<FormFieldset>
+							<FormLegend>{ translate( 'Allow stats reports to be viewed by' ) }</FormLegend>
+							{ siteRoles &&
+								siteRoles.map( role =>
+									this.renderToggle(
+										'roles_' + role.name,
+										role.display_name,
+										includes( this.getCurrentGroupFields( 'roles' ), role.name ),
+										this.onChangeToggleGroup( 'roles', role.name )
+									)
+								) }
+						</FormFieldset>
+					</FoldableCard>
+
+					<CompactCard href={ getStatsPathForTab( 'day', siteSlug ) }>
+						{ translate( 'View your site stats' ) }
+					</CompactCard>
+				</Fragment>
 			</div>
 		);
 	}

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -7,28 +7,26 @@ import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { includes } from 'lodash';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
-import Banner from 'components/banner';
-import FoldableCard from 'components/foldable-card';
-import Card from 'components/card';
 import CompactCard from 'components/card/compact';
-import SectionHeader from 'components/section-header';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
+import ExternalLink from 'components/external-link';
+import FoldableCard from 'components/foldable-card';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
-import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import QuerySiteRoles from 'components/data/query-site-roles';
-import { getStatsPathForTab } from 'lib/route';
+import SectionHeader from 'components/section-header';
+import { activateModule } from 'state/jetpack/modules/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getSiteRoles } from 'state/site-roles/selectors';
-import { activateModule } from 'state/jetpack/modules/actions';
+import { getStatsPathForTab } from 'lib/route';
 import {
 	isActivatingJetpackModule,
 	isJetpackModuleActive,
@@ -115,30 +113,24 @@ class JetpackSiteStats extends Component {
 		);
 	}
 
-	renderModuleEnableBanner() {
-		const { translate } = this.props;
-
-		return (
-			<Banner
-				title={ translate( 'Site Stats module is disabled' ) }
-				description={ translate(
-					'Enable this to see detailed information about your traffic, likes, comments, and subscribers.'
-				) }
-				callToAction={ translate( 'Enable' ) }
-				onClick={ this.handleStatsActivationButton }
-				event={ 'site_stats_module_enable_banner' }
-				icon="stats"
-			/>
-		);
-	}
-
 	renderCardSettings() {
-		const { siteRoles, siteSlug, translate } = this.props;
+		const {
+			activatingStatsModule,
+			moduleUnavailable,
+			siteId,
+			siteRoles,
+			siteSlug,
+			translate,
+		} = this.props;
 		const header = (
-			<div>
-				<Gridicon icon="checkmark" />
-				{ translate( "Enabled! You're collecting valuable data and insights." ) }
-			</div>
+			<JetpackModuleToggle
+				siteId={ siteId }
+				moduleSlug="stats"
+				label={ translate(
+					'See detailed information about your traffic, likes, comments, and subscribers.'
+				) }
+				disabled={ activatingStatsModule || moduleUnavailable }
+			/>
 		);
 
 		return (
@@ -204,29 +196,6 @@ class JetpackSiteStats extends Component {
 		);
 	}
 
-	renderPlaceholder() {
-		return (
-			<Card className="site-settings__card is-placeholder">
-				<div />
-			</Card>
-		);
-	}
-
-	renderCardContent() {
-		const { activatingStatsModule, statsModuleActive } = this.props;
-
-		if ( activatingStatsModule ) {
-			return this.renderPlaceholder();
-		}
-
-		if ( statsModuleActive === true ) {
-			return this.renderCardSettings();
-		} else if ( statsModuleActive === false ) {
-			return this.renderModuleEnableBanner();
-		}
-		return this.renderPlaceholder();
-	}
-
 	render() {
 		const { siteId, translate } = this.props;
 
@@ -237,7 +206,7 @@ class JetpackSiteStats extends Component {
 
 				<SectionHeader label={ translate( 'Site stats' ) } />
 
-				{ this.renderCardContent() }
+				{ this.renderCardSettings() }
 			</div>
 		);
 	}

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -64,14 +64,6 @@ class JetpackSiteStats extends Component {
 		};
 	};
 
-	handleStatsActivationButton = event => {
-		const { siteId } = this.props;
-
-		this.props.activateModule( siteId, 'stats' );
-
-		event.preventDefault();
-	};
-
 	getCurrentGroupFields( groupName ) {
 		const { fields } = this.props;
 

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -3,10 +3,10 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
-import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { includes } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -141,65 +141,63 @@ class JetpackSiteStats extends Component {
 
 				<SectionHeader label={ translate( 'Site stats' ) } />
 
-				<Fragment>
-					<FoldableCard
-						className="site-settings__foldable-card is-top-level"
-						header={ header }
-						clickableHeader
-					>
-						<FormFieldset>
-							<div className="site-settings__info-link-container">
-								<InfoPopover position="left">
-									<ExternalLink
-										href="https://jetpack.com/support/wordpress-com-stats/"
-										target="_blank"
-									>
-										{ translate( 'Learn more about WordPress.com Stats' ) }
-									</ExternalLink>
-								</InfoPopover>
-							</div>
+				<FoldableCard
+					className="site-settings__foldable-card is-top-level"
+					header={ header }
+					clickableHeader
+				>
+					<FormFieldset>
+						<div className="site-settings__info-link-container">
+							<InfoPopover position="left">
+								<ExternalLink
+									href="https://jetpack.com/support/wordpress-com-stats/"
+									target="_blank"
+								>
+									{ translate( 'Learn more about WordPress.com Stats' ) }
+								</ExternalLink>
+							</InfoPopover>
+						</div>
 
-							{ this.renderToggle(
-								'admin_bar',
-								translate( 'Put a chart showing 48 hours of views in the admin bar' )
+						{ this.renderToggle(
+							'admin_bar',
+							translate( 'Put a chart showing 48 hours of views in the admin bar' )
+						) }
+						{ this.renderToggle( 'hide_smile', translate( 'Hide the stats smiley face image' ) ) }
+						<FormSettingExplanation isIndented>
+							{ translate( 'The image helps collect stats, but should work when hidden.' ) }
+						</FormSettingExplanation>
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLegend>{ translate( 'Count logged in page views from' ) }</FormLegend>
+						{ siteRoles &&
+							siteRoles.map( role =>
+								this.renderToggle(
+									'count_roles_' + role.name,
+									role.display_name,
+									includes( this.getCurrentGroupFields( 'count_roles' ), role.name ),
+									this.onChangeToggleGroup( 'count_roles', role.name )
+								)
 							) }
-							{ this.renderToggle( 'hide_smile', translate( 'Hide the stats smiley face image' ) ) }
-							<FormSettingExplanation isIndented>
-								{ translate( 'The image helps collect stats, but should work when hidden.' ) }
-							</FormSettingExplanation>
-						</FormFieldset>
+					</FormFieldset>
 
-						<FormFieldset>
-							<FormLegend>{ translate( 'Count logged in page views from' ) }</FormLegend>
-							{ siteRoles &&
-								siteRoles.map( role =>
-									this.renderToggle(
-										'count_roles_' + role.name,
-										role.display_name,
-										includes( this.getCurrentGroupFields( 'count_roles' ), role.name ),
-										this.onChangeToggleGroup( 'count_roles', role.name )
-									)
-								) }
-						</FormFieldset>
+					<FormFieldset>
+						<FormLegend>{ translate( 'Allow stats reports to be viewed by' ) }</FormLegend>
+						{ siteRoles &&
+							siteRoles.map( role =>
+								this.renderToggle(
+									'roles_' + role.name,
+									role.display_name,
+									includes( this.getCurrentGroupFields( 'roles' ), role.name ),
+									this.onChangeToggleGroup( 'roles', role.name )
+								)
+							) }
+					</FormFieldset>
+				</FoldableCard>
 
-						<FormFieldset>
-							<FormLegend>{ translate( 'Allow stats reports to be viewed by' ) }</FormLegend>
-							{ siteRoles &&
-								siteRoles.map( role =>
-									this.renderToggle(
-										'roles_' + role.name,
-										role.display_name,
-										includes( this.getCurrentGroupFields( 'roles' ), role.name ),
-										this.onChangeToggleGroup( 'roles', role.name )
-									)
-								) }
-						</FormFieldset>
-					</FoldableCard>
-
-					<CompactCard href={ getStatsPathForTab( 'day', siteSlug ) }>
-						{ translate( 'View your site stats' ) }
-					</CompactCard>
-				</Fragment>
+				<CompactCard href={ getStatsPathForTab( 'day', siteSlug ) }>
+					{ translate( 'View your site stats' ) }
+				</CompactCard>
 			</div>
 		);
 	}

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -23,12 +23,10 @@ import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import QuerySiteRoles from 'components/data/query-site-roles';
 import SectionHeader from 'components/section-header';
-import { activateModule } from 'state/jetpack/modules/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getSiteRoles } from 'state/site-roles/selectors';
 import { getStatsPathForTab } from 'lib/route';
 import {
-	isActivatingJetpackModule,
 	isJetpackModuleActive,
 	isJetpackModuleUnavailableInDevelopmentMode,
 	isJetpackSiteInDevelopmentMode,
@@ -106,14 +104,7 @@ class JetpackSiteStats extends Component {
 	}
 
 	render() {
-		const {
-			activatingStatsModule,
-			moduleUnavailable,
-			siteId,
-			siteRoles,
-			siteSlug,
-			translate,
-		} = this.props;
+		const { moduleUnavailable, siteId, siteRoles, siteSlug, translate } = this.props;
 
 		const header = (
 			<JetpackModuleToggle
@@ -122,7 +113,7 @@ class JetpackSiteStats extends Component {
 				label={ translate(
 					'See detailed information about your traffic, likes, comments, and subscribers.'
 				) }
-				disabled={ activatingStatsModule || moduleUnavailable }
+				disabled={ moduleUnavailable }
 			/>
 		);
 
@@ -195,26 +186,20 @@ class JetpackSiteStats extends Component {
 	}
 }
 
-export default connect(
-	state => {
-		const siteId = getSelectedSiteId( state );
-		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, siteId );
-		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
-			state,
-			siteId,
-			'stats'
-		);
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+	const siteInDevMode = isJetpackSiteInDevelopmentMode( state, siteId );
+	const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
+		state,
+		siteId,
+		'stats'
+	);
 
-		return {
-			siteId,
-			siteSlug: getSelectedSiteSlug( state, siteId ),
-			activatingStatsModule: isActivatingJetpackModule( state, siteId, 'stats' ),
-			statsModuleActive: isJetpackModuleActive( state, siteId, 'stats' ),
-			moduleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
-			siteRoles: getSiteRoles( state, siteId ),
-		};
-	},
-	{
-		activateModule,
-	}
-)( localize( JetpackSiteStats ) );
+	return {
+		siteId,
+		siteSlug: getSelectedSiteSlug( state, siteId ),
+		statsModuleActive: isJetpackModuleActive( state, siteId, 'stats' ),
+		moduleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
+		siteRoles: getSiteRoles( state, siteId ),
+	};
+} )( localize( JetpackSiteStats ) );

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { includes } from 'lodash';
@@ -142,7 +142,7 @@ class JetpackSiteStats extends Component {
 		);
 
 		return (
-			<div>
+			<Fragment>
 				<FoldableCard
 					className="site-settings__foldable-card is-top-level"
 					header={ header }
@@ -200,7 +200,7 @@ class JetpackSiteStats extends Component {
 				<CompactCard href={ getStatsPathForTab( 'day', siteSlug ) }>
 					{ translate( 'View your site stats' ) }
 				</CompactCard>
-			</div>
+			</Fragment>
 		);
 	}
 


### PR DESCRIPTION
Change the Jetpack `stats` module control from a single one-way button to a toggle.

## Screens

### Before

#### Disabled

![before-dis](https://user-images.githubusercontent.com/841763/37032726-d57a908a-2143-11e8-81fa-43b6042f603c.png)

#### Enabled

![before-en](https://user-images.githubusercontent.com/841763/37032725-d3eba524-2143-11e8-8d36-ef86910f9130.png)

### After

#### Disabled

![after-dis](https://user-images.githubusercontent.com/841763/37032729-d895271c-2143-11e8-89fd-e4ccf85eb595.png)

#### Enabled

![after-en](https://user-images.githubusercontent.com/841763/37032750-e192ebd8-2143-11e8-9430-026ed651c609.png)

## Testing
1. Set up a Jetpack site
1. Visit https://calypso.live/settings/traffic?branch=fix/22216-jp-stats-toggle
1. Verify that the new toggle behaves as expected, settings are correctly modified and persisted.

Fixes #22216