### PR TITLE
Jetpack Settings: Replace SEO Tools activation notice with a module toggle

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -39,7 +39,6 @@ import { isJetpackModuleActive, isHiddenSite, isPrivateSite } from 'state/select
 import { toApi as seoTitleToApi } from 'components/seo/meta-title-editor/mappings';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestSite } from 'state/sites/actions';
-import { activateModule } from 'state/jetpack/modules/actions';
 import { isBusiness, isEnterprise, isJetpackBusiness, isJetpackPremium } from 'lib/products-values';
 import { hasFeature } from 'state/sites/plans/selectors';
 import { getPlugins } from 'state/plugins/installed/selectors';
@@ -286,7 +285,6 @@ export class SeoForm extends React.Component {
 			showPreview = false,
 		} = this.state;
 
-		const activateSeoTools = () => this.props.activateModule( siteId, 'seo-tools' );
 		const isJetpackUnsupported = siteIsJetpack && ! jetpackVersionSupportsSeo;
 		const isDisabled = isJetpackUnsupported || isSubmittingForm || isFetchingSettings;
 		const isSeoDisabled = isDisabled || isSeoToolsActive === false;
@@ -362,17 +360,6 @@ export class SeoForm extends React.Component {
 						<NoticeAction href={ jetpackUpdateUrl }>{ translate( 'Update Now' ) }</NoticeAction>
 					</Notice>
 				) }
-				{ siteIsJetpack &&
-					hasSupportingPlan( site.plan ) &&
-					isSeoToolsActive === false && (
-						<Notice
-							status="is-warning"
-							showDismiss={ false }
-							text={ translate( 'SEO Tools module is disabled in Jetpack.' ) }
-						>
-							<NoticeAction onClick={ activateSeoTools }>{ translate( 'Enable' ) }</NoticeAction>
-						</Notice>
-					) }
 
 				{ ! this.props.hasSeoPreviewFeature &&
 					! this.props.hasAdvancedSEOFeature && (
@@ -524,7 +511,6 @@ const mapDispatchToProps = {
 		recordTracksEvent,
 		'calypso_seo_tools_front_page_meta_updated'
 	),
-	activateModule,
 };
 
 export default connect(

--- a/client/my-sites/site-settings/seo-settings/help.jsx
+++ b/client/my-sites/site-settings/seo-settings/help.jsx
@@ -53,7 +53,7 @@ const SeoSettingsHelpCard = ( {
 					<JetpackModuleToggle
 						siteId={ siteId }
 						moduleSlug="seo-tools"
-						label={ translate( 'Enable SEO Tools' ) }
+						label={ translate( 'Enable SEO Tools to optimize your site for search engines' ) }
 						disabled={ disabled }
 					/>
 				</Card>

--- a/client/my-sites/site-settings/seo-settings/help.jsx
+++ b/client/my-sites/site-settings/seo-settings/help.jsx
@@ -12,13 +12,20 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
+import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import SectionHeader from 'components/section-header';
 import { hasFeature } from 'state/sites/plans/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { FEATURE_ADVANCED_SEO } from 'lib/plans/constants';
 
-const SeoSettingsHelpCard = ( { hasAdvancedSEOFeature, siteIsJetpack, translate } ) => {
+const SeoSettingsHelpCard = ( {
+	disabled,
+	hasAdvancedSEOFeature,
+	siteId,
+	siteIsJetpack,
+	translate,
+} ) => {
 	const seoHelpLink = siteIsJetpack
 		? 'https://jetpack.com/support/seo-tools/'
 		: 'https://en.blog.wordpress.com/2013/03/22/seo-on-wordpress-com/';
@@ -27,7 +34,7 @@ const SeoSettingsHelpCard = ( { hasAdvancedSEOFeature, siteIsJetpack, translate 
 		<div>
 			<SectionHeader label={ translate( 'Search engine optimization' ) } />
 			{ hasAdvancedSEOFeature && (
-				<Card>
+				<Card className="seo-settings__help">
 					<p>
 						{ translate(
 							'{{b}}WordPress.com has great SEO{{/b}} out of the box. All of our themes are optimized ' +
@@ -42,6 +49,13 @@ const SeoSettingsHelpCard = ( { hasAdvancedSEOFeature, siteIsJetpack, translate 
 							}
 						) }
 					</p>
+
+					<JetpackModuleToggle
+						siteId={ siteId }
+						moduleSlug="seo-tools"
+						label={ translate( 'Enable SEO Tools' ) }
+						disabled={ disabled }
+					/>
 				</Card>
 			) }
 		</div>
@@ -54,6 +68,7 @@ export default connect( state => {
 	const hasAdvancedSEOFeature = hasFeature( state, siteId, FEATURE_ADVANCED_SEO );
 
 	return {
+		siteId,
 		siteIsJetpack,
 		hasAdvancedSEOFeature,
 	};

--- a/client/my-sites/site-settings/settings-traffic/main.jsx
+++ b/client/my-sites/site-settings/settings-traffic/main.jsx
@@ -95,7 +95,7 @@ const SiteSettingsTraffic = ( {
 					fields={ fields }
 				/>
 			) }
-			<SeoSettingsHelpCard />
+			<SeoSettingsHelpCard disabled={ isRequestingSettings || isSavingSettings } />
 			<SeoSettingsMain />
 			<AnalyticsSettings />
 			<Sitemaps

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -233,7 +233,8 @@
 .site-settings__writing-settings,
 .site-settings__traffic-settings,
 .site-settings__security-settings,
-.manage-connection {
+.manage-connection,
+.seo-settings__help {
 	.form-toggle__label {
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
Currently, when the SEO Tools module is disabled for a Jetpack site, we display the following notice:

![](https://cldup.com/P36jw3qT_A.png)

This is inconsistent with the rest of the settings, where we display a Jetpack module toggle. This PR removes the notice and introduces a toggle that allows the user to activate and deactivate the SEO Tools module:

![](https://cldup.com/aYSt7ysFMN.png)

Fixes #22213.

To test:
* Checkout this branch.
* Select a Jetpack site that has either Premium or Professional plan.
* Disable SEO Tools for your Jetpack site - you can do it by calling the following CLI command on your console: `wp jetpack module deactivate seo-tools`
* Go to `http://calypso.localhost:3000/settings/traffic/:site`, where `:site` is your Jetpack site.
* Scroll down to the "Search engine optimization" card.
* Verify you can see the new module toggle.
* Click the toggle, verify it activates the module properly (you can check the module status by calling the following CLI command on your console: `wp jetpack module list | grep "seo-tools"`.
* Click the toggle again, verify it deactivates the module properly.
* Verify that every activation and deactivation respectively enables and disables the form fields of the "Page Title Structure" card below.