### PR TITLE
Purchases: Add appropriate instructions for subdomain mapping

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/domain-mapping-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/domain-mapping-details.jsx
@@ -5,36 +5,34 @@
  */
 
 import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { localize } from 'i18n-calypso';
 import PurchaseDetail from 'components/purchase-detail';
-import { MAP_EXISTING_DOMAIN } from 'lib/url/support';
+import { isSubdomain } from 'lib/domains';
+import { isBusiness } from 'lib/products-values';
+import { MAP_EXISTING_DOMAIN, MAP_SUBDOMAIN } from 'lib/url/support';
+import { getSelectedSite } from 'state/ui/selectors';
 
-const DomainMappingDetails = ( { domain, registrarSupportUrl, translate } ) => {
+const DomainMappingDetails = ( {
+	domain,
+	isBusinessPlan,
+	isSubdomainMapping,
+	registrarSupportUrl,
+	selectedSiteDomain,
+	translate,
+} ) => {
 	const registrarSupportLink = registrarSupportUrl ? (
 		<a target="_blank" rel="noopener noreferrer" href={ registrarSupportUrl } />
 	) : (
 		<span />
 	);
-	const description = (
+
+	const domainInstructions = (
 		<div>
-			<p>
-				{ translate(
-					'Your domain {{em}}%(domain)s{{/em}} has to be configured to work with WordPress.com.',
-					{
-						args: { domain },
-						components: { em: <em /> },
-					}
-				) }
-			</p>
-			<p>
-				{ translate(
-					'If you already did this yourself, or if the domain was already configured for you, no further action is needed.'
-				) }
-			</p>
 			<p>
 				{ translate(
 					"If not, you will need to log into {{registrarSupportLink}}your registrar's site{{/registrarSupportLink}} " +
@@ -51,6 +49,70 @@ const DomainMappingDetails = ( { domain, registrarSupportUrl, translate } ) => {
 				<li>ns2.wordpress.com</li>
 				<li>ns3.wordpress.com</li>
 			</ul>
+		</div>
+	);
+
+	const subdomainInstructions = (
+		<div>
+			<p>
+				{ translate(
+					"If not, you will need to log into {{registrarSupportLink}}your registrar's site{{/registrarSupportLink}} " +
+						'(where you purchased the domain originally) and add the following "CNAME" record:',
+					{
+						components: {
+							registrarSupportLink: registrarSupportLink,
+						},
+					}
+				) }
+			</p>
+			<ul className="checkout-thank-you__domain-mapping-details-nameservers">
+				<li>
+					{ domain }. IN CNAME { selectedSiteDomain }.
+				</li>
+			</ul>
+		</div>
+	);
+
+	const subdomainInstructionsBusiness = (
+		<div>
+			<p>
+				{ translate(
+					"If not, you will need to log into {{registrarSupportLink}}your registrar's site{{/registrarSupportLink}} " +
+						'(where you purchased the domain originally) and add the following "NS" records:',
+					{
+						components: {
+							registrarSupportLink: registrarSupportLink,
+						},
+					}
+				) }
+			</p>
+			<ul className="checkout-thank-you__domain-mapping-details-nameservers">
+				<li>{ domain }. IN NS ns1.wordpress.com.</li>
+				<li>{ domain }. IN NS ns2.wordpress.com.</li>
+				<li>{ domain }. IN NS ns3.wordpress.com.</li>
+			</ul>
+		</div>
+	);
+
+	const description = (
+		<div>
+			<p>
+				{ translate(
+					'Your domain {{em}}%(domain)s{{/em}} has to be configured to work with WordPress.com.',
+					{
+						args: { domain },
+						components: { em: <em /> },
+					}
+				) }
+			</p>
+			<p>
+				{ translate(
+					'If you already did this yourself, or if the domain was already configured for you, no further action is needed.'
+				) }
+			</p>
+			{ ! isSubdomainMapping && domainInstructions }
+			{ isSubdomainMapping && ! isBusinessPlan && subdomainInstructions }
+			{ isSubdomainMapping && isBusinessPlan && subdomainInstructionsBusiness }
 			<p>
 				{ translate(
 					'Once you make the change, just wait a few hours and the domain should start loading your site automatically.'
@@ -65,7 +127,7 @@ const DomainMappingDetails = ( { domain, registrarSupportUrl, translate } ) => {
 				icon="cog"
 				description={ description }
 				buttonText={ translate( 'Learn more' ) }
-				href={ MAP_EXISTING_DOMAIN }
+				href={ isSubdomainMapping ? MAP_SUBDOMAIN : MAP_EXISTING_DOMAIN }
 				target="_blank"
 				rel="noopener noreferrer"
 				isRequired
@@ -74,4 +136,13 @@ const DomainMappingDetails = ( { domain, registrarSupportUrl, translate } ) => {
 	);
 };
 
-export default localize( DomainMappingDetails );
+const mapStateToProps = ( state, { domain } ) => {
+	const selectedSite = getSelectedSite( state );
+	return {
+		isBusinessPlan: isBusiness( selectedSite.plan ),
+		isSubdomainMapping: isSubdomain( domain ),
+		selectedSiteDomain: selectedSite.domain,
+	};
+};
+
+export default connect( mapStateToProps )( localize( DomainMappingDetails ) );


### PR DESCRIPTION
Fix #11848 

After purchasing a domain mapping, display the correct instructions according to the following cases:

- Domain
- Subdomain (non-Business Plan)
- Subdomain (Business Plan)

The "Learn More" button has been updated as well to point to the [Map a Subdomain](https://en.support.wordpress.com/domains/map-subdomain/) support page.

The instructions for subdomain were copied straight off that support page.

| Domain | Subdomain | Subdomain (Biz) |
| --- | --- | --- |
| <img width="723" alt="screen shot 2018-03-06 at 12 39 24" src="https://user-images.githubusercontent.com/2070010/37032940-17a99a1c-213c-11e8-9495-f947acead73e.png"> | <img width="714" alt="screen shot 2018-03-06 at 12 37 24" src="https://user-images.githubusercontent.com/2070010/37032954-1e981164-213c-11e8-87e1-87445c6d7077.png"> | <img width="718" alt="screen shot 2018-03-06 at 12 36 56" src="https://user-images.githubusercontent.com/2070010/37032958-22c97944-213c-11e8-98c0-93162eeaaa14.png"> |

### Testing instructions

Add a domain mapping to some sites and make sure that:

- If the mapped domain is an actual domain, the instructions show a list of:
`ns1.wordpress.com` (etc.).
- If it's a subdomain and the site plan is not Business, the instructions show a single line:
`subdomain.foo.bar IN CNAME sitename.wordpress.com`.
- If it's a subdomain for a Business plan, the instructions show a list of:
`subdomain.foo.bar IN NS ns1.wordpress.com` (etc.).

Also make sure that the "Learn More" button points to the correct page (map domain or map subdomain).