### PR TITLE
Jetpack Settings: Replace Analytics activation notice with a module toggle

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -24,6 +24,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextValidation from 'components/forms/form-input-validation';
 import FormAnalyticsStores from './form-analytics-stores';
+import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import { isBusiness, isEnterprise, isJetpackBusiness, isJetpackPremium } from 'lib/products-values';
@@ -194,6 +195,20 @@ class GoogleAnalyticsForm extends Component {
 					/>
 				) : (
 					<Card className="analytics-settings site-settings__analytics-settings">
+						{ siteIsJetpack &&
+							! showUpgradeNudge && (
+								<fieldset>
+									<JetpackModuleToggle
+										siteId={ siteId }
+										moduleSlug="google-analytics"
+										label={ translate(
+											'Track your WordPress site statistics with Google Analytics.'
+										) }
+										disabled={ isRequestingSettings || isSavingSettings }
+									/>
+								</fieldset>
+							) }
+
 						<fieldset>
 							<FormLabel htmlFor="wgaCode">
 								{ translate( 'Google Analytics Tracking ID', { context: 'site setting' } ) }

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -28,7 +28,6 @@ import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import { isBusiness, isEnterprise, isJetpackBusiness, isJetpackPremium } from 'lib/products-values';
-import { activateModule } from 'state/jetpack/modules/actions';
 import {
 	getSiteOption,
 	isJetpackMinimumVersion,
@@ -97,7 +96,6 @@ class GoogleAnalyticsForm extends Component {
 			handleSubmitForm,
 			isRequestingSettings,
 			isSavingSettings,
-			jetpackModuleActive,
 			jetpackVersionSupportsModule,
 			showUpgradeNudge,
 			site,
@@ -111,7 +109,6 @@ class GoogleAnalyticsForm extends Component {
 			translate,
 			uniqueEventTracker,
 		} = this.props;
-		const activateGoogleAnalytics = () => this.props.activateModule( siteId, 'google-analytics' );
 		const placeholderText = isRequestingSettings ? translate( 'Loading' ) : '';
 		const isJetpackUnsupported = siteIsJetpack && ! jetpackVersionSupportsModule;
 		const analyticsSupportUrl = siteIsJetpack
@@ -151,21 +148,6 @@ class GoogleAnalyticsForm extends Component {
 						>
 							<NoticeAction href={ `/plugins/jetpack/${ siteSlug }` }>
 								{ translate( 'Update Now' ) }
-							</NoticeAction>
-						</Notice>
-					) }
-
-				{ siteIsJetpack &&
-					jetpackModuleActive === false &&
-					! isJetpackUnsupported &&
-					! showUpgradeNudge && (
-						<Notice
-							status="is-warning"
-							showDismiss={ false }
-							text={ translate( 'The Google Analytics module is disabled in Jetpack.' ) }
-						>
-							<NoticeAction onClick={ activateGoogleAnalytics }>
-								{ translate( 'Enable' ) }
 							</NoticeAction>
 						</Notice>
 					) }
@@ -343,7 +325,6 @@ const mapStateToProps = state => {
 		showUpgradeNudge: ! isGoogleAnalyticsEligible,
 		enableForm: isGoogleAnalyticsEligible && googleAnalyticsEnabled,
 		jetpackManagementUrl,
-		jetpackModuleActive,
 		jetpackVersionSupportsModule,
 		sitePlugins,
 		siteSupportsBasicEcommerceTracking,
@@ -352,14 +333,7 @@ const mapStateToProps = state => {
 	};
 };
 
-const connectComponent = connect(
-	mapStateToProps,
-	{
-		activateModule,
-	},
-	null,
-	{ pure: false }
-);
+const connectComponent = connect( mapStateToProps, null, null, { pure: false } );
 
 const getFormSettings = partialRight( pick, [ 'wga' ] );
 

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -177,19 +177,18 @@ class GoogleAnalyticsForm extends Component {
 					/>
 				) : (
 					<Card className="analytics-settings site-settings__analytics-settings">
-						{ siteIsJetpack &&
-							! showUpgradeNudge && (
-								<fieldset>
-									<JetpackModuleToggle
-										siteId={ siteId }
-										moduleSlug="google-analytics"
-										label={ translate(
-											'Track your WordPress site statistics with Google Analytics.'
-										) }
-										disabled={ isRequestingSettings || isSavingSettings }
-									/>
-								</fieldset>
-							) }
+						{ siteIsJetpack && (
+							<fieldset>
+								<JetpackModuleToggle
+									siteId={ siteId }
+									moduleSlug="google-analytics"
+									label={ translate(
+										'Track your WordPress site statistics with Google Analytics.'
+									) }
+									disabled={ isRequestingSettings || isSavingSettings }
+								/>
+							</fieldset>
+						) }
 
 						<fieldset>
 							<FormLabel htmlFor="wgaCode">


### PR DESCRIPTION
Currently, when the Google Analytics module is disabled for a Jetpack site, we display the following notice:

![](https://cldup.com/08H8q4UNcU.png)

This is inconsistent with the rest of the settings, where we display a Jetpack module toggle. This PR removes the notice and introduces a toggle that allows the user to activate and deactivate the Google Analytics module:

![](https://cldup.com/-lAVrrfk4L.png)

And when the module is active, form fields become enabled:

![](https://cldup.com/MkND1EEUA8.png)

Fixes #22214.

To test:
* Checkout this branch.
* Select a Jetpack site that has either Premium or Professional plan.
* Disable Google Analytics for your Jetpack site - you can do it by calling the following CLI command on your console: `wp jetpack module deactivate google-analytics`
* Go to `http://calypso.localhost:3000/settings/traffic/:site`, where `:site` is your Jetpack site.
* Scroll down to the "Google Analytics" card.
* Verify you can see the new module toggle.
* Click the toggle, verify it activates the module properly (you can check the module status by calling the following CLI command on your console: `wp jetpack module list | grep "google-analytics"`.
* Click the toggle again, verify it deactivates the module properly.
* Verify that every activation and deactivation respectively enables and disables the form fields of the "Google Analytics" card.
* Verify the module toggle doesn't appear for a .com site with a Premium or a Business plan.