### PR TITLE
Jetpack Plans: fix scrollLeft value to center the recommended plan

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -106,7 +106,7 @@ class PlanFeatures extends Component {
 
 		// center plans
 		if ( isInSignup && plansWrapper ) {
-			displayJetpackPlans ? ( plansWrapper.scrollLeft = 190 ) : ( plansWrapper.scrollLeft = 495 );
+			displayJetpackPlans ? ( plansWrapper.scrollLeft = 312 ) : ( plansWrapper.scrollLeft = 495 );
 		}
 	};
 


### PR DESCRIPTION
This PR fixes the value required to correctly center the recommended plan, when viewing the plans table on a smaller screen.

Discussion over in #22730 sparked this fix.

### Before

![image](https://user-images.githubusercontent.com/390760/37035531-c4cc671c-2144-11e8-95f1-55a7996b0195.png)

### After

![image](https://user-images.githubusercontent.com/390760/37035515-ba7b1498-2144-11e8-8da2-c9f977f2b33e.png)
