### PR TITLE
Reader: allow blocking of Jetpack sites

### DIFF
--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -135,8 +135,7 @@ class ReaderPostOptionsMenu extends React.Component {
 		// Should we show the 'block' option?
 		if (
 			post.site_ID &&
-			! post.is_external &&
-			! post.is_jetpack &&
+			( ! post.is_external || post.is_jetpack ) &&
 			! isEditPossible &&
 			! isDiscoverPost
 		) {

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -83,7 +83,10 @@ class PostLifecycle extends React.Component {
 			);
 		} else if ( post._state === 'error' ) {
 			return <PostUnavailable post={ post } />;
-		} else if ( ! post.is_external && includes( this.props.blockedSites, +post.site_ID ) ) {
+		} else if (
+			( ! post.is_external || post.is_jetpack ) &&
+			includes( this.props.blockedSites, +post.site_ID )
+		) {
 			return <PostBlocked post={ post } />;
 		} else if ( isXPost( post ) ) {
 			const xMetadata = XPostHelper.getXPostMetadata( post );


### PR DESCRIPTION
Following on from the backend change r171214-wpcom, this allows Jetpack sites to be blocked in Reader.

Previously it was only possible to block wordpress.com sites in Reader.

![screen shot 2018-03-06 at 14 21 14](https://user-images.githubusercontent.com/17325/37037182-a62ba674-2149-11e8-8bc6-cd9c8964e378.png)

Should fix #22780.

### To test

Follow a feed for a Jetpack site, such as http://calypso.localhost:3000/read/feeds/59175237, and then block it from the post options menu.

Make sure that it doesn't appear in your Following stream after blocking.
