### PR TITLE
Jetpack Settings: Replace Verification Tools activation notice with a module toggle

### DIFF
--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -20,12 +20,9 @@ import FormInput from 'components/forms/form-text-input-with-affixes';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormFieldset from 'components/forms/form-fieldset';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import SectionHeader from 'components/section-header';
-import { activateModule } from 'state/jetpack/modules/actions';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackModuleActive } from 'state/selectors';
 import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
@@ -192,12 +189,6 @@ class SiteVerification extends Component {
 		};
 	}
 
-	activateVerificationServices = () => {
-		const { siteId } = this.props;
-
-		this.props.activateModule( siteId, 'verification-tools' );
-	};
-
 	getVerificationError( isPasteError ) {
 		const { translate } = this.props;
 
@@ -301,19 +292,6 @@ class SiteVerification extends Component {
 			<div className="seo-settings__site-verification">
 				<QuerySiteSettings siteId={ siteId } />
 				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }
-
-				{ siteIsJetpack &&
-					isVerificationToolsActive === false && (
-						<Notice
-							status="is-warning"
-							showDismiss={ false }
-							text={ translate( 'Site Verification Services are disabled in Jetpack.' ) }
-						>
-							<NoticeAction onClick={ this.activateVerificationServices }>
-								{ translate( 'Enable' ) }
-							</NoticeAction>
-						</Notice>
-					) }
 
 				<SectionHeader label={ translate( 'Site Verification Services' ) }>
 					<Button
@@ -478,7 +456,6 @@ export default connect(
 				service,
 			} ),
 		trackFormSubmitted: partial( recordTracksEvent, 'calypso_seo_settings_form_submit' ),
-		activateModule,
 	},
 	undefined,
 	{ pure: false } // defaults to true, but this component has internal state

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -305,14 +305,16 @@ class SiteVerification extends Component {
 					</Button>
 				</SectionHeader>
 				<Card>
-					<FormFieldset>
-						<JetpackModuleToggle
-							siteId={ siteId }
-							moduleSlug="verification-tools"
-							label={ translate( 'Enable Site Verification Services.' ) }
-							disabled={ isDisabled }
-						/>
-					</FormFieldset>
+					{ siteIsJetpack && (
+						<FormFieldset>
+							<JetpackModuleToggle
+								siteId={ siteId }
+								moduleSlug="verification-tools"
+								label={ translate( 'Enable Site Verification Services.' ) }
+								disabled={ isDisabled }
+							/>
+						</FormFieldset>
+					) }
 
 					<p>
 						{ translate(

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -19,6 +19,7 @@ import ExternalLink from 'components/external-link';
 import FormInput from 'components/forms/form-text-input-with-affixes';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormFieldset from 'components/forms/form-fieldset';
+import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
@@ -297,7 +298,7 @@ class SiteVerification extends Component {
 		yandexCode = this.getMetaTag( 'yandex', yandexCode || '' );
 
 		return (
-			<div>
+			<div className="seo-settings__site-verification">
 				<QuerySiteSettings siteId={ siteId } />
 				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }
 
@@ -326,6 +327,15 @@ class SiteVerification extends Component {
 					</Button>
 				</SectionHeader>
 				<Card>
+					<FormFieldset>
+						<JetpackModuleToggle
+							siteId={ siteId }
+							moduleSlug="verification-tools"
+							label={ translate( 'Enable Site Verification Services.' ) }
+							disabled={ isDisabled }
+						/>
+					</FormFieldset>
+
 					<p>
 						{ translate(
 							'Note that {{b}}verifying your site with these services is not necessary{{/b}} in order' +

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -233,7 +233,8 @@
 .site-settings__writing-settings,
 .site-settings__traffic-settings,
 .site-settings__security-settings,
-.manage-connection {
+.manage-connection,
+.seo-settings__site-verification {
 	.form-toggle__label {
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
Currently, when the Verification Tools module is disabled for a Jetpack site, we display the following notice:

![](https://cldup.com/SY6TNrqKuG.png)

This is inconsistent with the rest of the settings, where we display a Jetpack module toggle. This PR removes the notice and introduces a toggle that allows the user to activate and deactivate the Verification Tools module:

![](https://cldup.com/lyPslBnSsi.png)

And when the module is active, form fields become enabled:

![](https://cldup.com/nYPD3ZhRcW.png)

Fixes #22215.

To test:
* Checkout this branch.
* Select a Jetpack site.
* Disable Verification Tools for your Jetpack site - you can do it by calling the following CLI command on your console: `wp jetpack module deactivate verification-tools`
* Go to `http://calypso.localhost:3000/settings/traffic/:site`, where `:site` is your Jetpack site.
* Scroll down to the "Site Verification Services" card.
* Verify you can see the new module toggle.
* Click the toggle, verify it activates the module properly (you can check the module status by calling the following CLI command on your console: `wp jetpack module list | grep "verification-tools"`.
* Click the toggle again, verify it deactivates the module properly.
* Verify that every activation and deactivation respectively enables and disables the form fields of the "Site Verification Services" card.
* Verify the module toggle doesn't appear for a .com site.