### PR TITLE
Login: Add support for 2FA codes with white spaces

### DIFF
--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -76,9 +76,7 @@ class VerificationCodeForm extends Component {
 
 		this.props.formUpdate();
 
-		this.setState( {
-			[ name ]: value.trim(),
-		} );
+		this.setState( { [ name ]: value } );
 	};
 
 	onSubmitForm = event => {
@@ -156,7 +154,7 @@ class VerificationCodeForm extends Component {
 								'is-error': requestError && requestError.field === 'twoStepCode',
 							} ) }
 							name="twoStepCode"
-							pattern="[0-9]*"
+							pattern="[0-9 ]*"
 							ref={ this.saveRef }
 							disabled={ this.state.isDisabled }
 							type="tel"

--- a/client/me/security-account-recovery/recovery-phone-validation-notice.jsx
+++ b/client/me/security-account-recovery/recovery-phone-validation-notice.jsx
@@ -10,10 +10,10 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import FormTelInput from 'components/forms/form-tel-input';
-import FormButtonsBar from 'components/forms/form-buttons-bar';
 import FormButton from 'components/forms/form-button';
+import FormButtonsBar from 'components/forms/form-buttons-bar';
 import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 
@@ -49,8 +49,6 @@ class RecoveryPhoneValidationNotice extends Component {
 
 		const { candidateCode } = this.state;
 
-		const validationCodeLength = 8;
-		const isCodeLengthValid = validationCodeLength !== candidateCode.length;
 		const validateButtonText = isValidating ? translate( 'Validating' ) : translate( 'Validate' );
 
 		return (
@@ -69,20 +67,25 @@ class RecoveryPhoneValidationNotice extends Component {
 						</NoticeAction>
 					) }
 				</Notice>
+
 				<FormLabel className="security-account-recovery__recovery-phone-validation-label">
 					{ translate( 'Enter the code you receive via SMS:' ) }
 				</FormLabel>
-				<FormTelInput
+
+				<FormTextInput
 					autoComplete="off"
-					disabled={ false }
-					placeholder={ translate( 'e.g. 12345678' ) }
+					disabled={ isValidating }
+					placeholder={ translate( 'e.g. 1234 5678' ) }
 					onChange={ this.onChange }
 					value={ candidateCode }
+					pattern="[0-9 ]*"
+					type="tel"
 				/>
+
 				<FormButtonsBar className="security-account-recovery__recovery-phone-validation-buttons">
 					<FormButton
 						isPrimary={ true }
-						disabled={ isValidating || isCodeLengthValid }
+						disabled={ isValidating }
 						onClick={ this.onValidate }
 					>
 						{ validateButtonText }

--- a/client/state/account-recovery/settings/actions.js
+++ b/client/state/account-recovery/settings/actions.js
@@ -1,9 +1,13 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import { replace } from 'lodash';
+
+/**
  * Internal dependencies
  */
-
 import wpcom from 'lib/wp';
 import {
 	ACCOUNT_RECOVERY_SETTINGS_FETCH,
@@ -229,7 +233,7 @@ export const validateAccountRecoveryPhone = code => dispatch => {
 	return wpcom
 		.undocumented()
 		.me()
-		.validateAccountRecoveryPhone( code )
+		.validateAccountRecoveryPhone( replace( code, /\s/g, '' ) )
 		.then( () => dispatch( validateAccountRecoveryPhoneSuccess() ) )
 		.catch( error => dispatch( validateAccountRecoveryPhoneFailed( error ) ) );
 };

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import request from 'superagent';
-import { get, defer } from 'lodash';
+import { get, defer, replace } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -138,7 +138,7 @@ export const loginUserWithTwoFactorVerificationCode = ( twoStepCode, twoFactorAu
 		.send( {
 			user_id: getTwoFactorUserId( getState() ),
 			auth_type: twoFactorAuthType,
-			two_step_code: twoStepCode,
+			two_step_code: replace( twoStepCode, /\s/g, '' ),
 			two_step_nonce: getTwoFactorAuthNonce( getState(), twoFactorAuthType ),
 			remember_me: true,
 			client_id: config( 'wpcom_signup_id' ),


### PR DESCRIPTION
This pull request - along server-side patch D10671-code - fixes https://github.com/Automattic/wp-calypso/issues/21067 by updating the [`Verification Code` page](http://calypso.localhost:3000/log-in/sms) to accept codes formatted into chunks in order to improve their readability:

<img width="736" alt="screenshot" src="https://user-images.githubusercontent.com/594356/37041132-ba93b5c2-215b-11e8-98a3-3c8aabf6121d.png">

#### Testing instructions

1. Run `git checkout update/login-2fa-codes` and start your server, or open a [live branch](https://calypso.live/?branch=update/login-2fa-codes)
2. See instructions in D10671-code

#### Reviews

- [ ] Code
- [x] Product