### PR TITLE
Jetpack plans: centers plans on larger screens when HappyChat is active

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -656,3 +656,11 @@
 .jetpack-connect__navigation {
 	text-align: center;
 }
+
+.layout.has-chat.is-section-jetpack-connect:not(.is-group-editor):not(.is-section-theme):not(.is-group-reader)
+	.layout__content {
+	@include breakpoint( '>1040px' ) {
+		padding-left: 32px;
+		padding-right: 319px;
+	}
+}


### PR DESCRIPTION
The CSS changes in this PR adjust the plans table, centering it horizontally, when a chat is triggered. This tweak is restricted to screens larger than 1040px wide, to match the responsive states of the HappyChat element itself.

This is a quick solution for now, @fditrapani and I talked a bit about improving the plans table in the future.

Fixes #22730 

### Before

![image](https://user-images.githubusercontent.com/390760/37041340-e529f6be-2153-11e8-94c3-5f7b8a718ce3.png)

### After

![image](https://user-images.githubusercontent.com/390760/37041275-b962e162-2153-11e8-8225-becc83683674.png)
