### PR TITLE
SidebarBanner: Increase space between text and CTA button on tablet breakpoint - they were too close

### DIFF
--- a/client/my-sites/current-site/sidebar-banner/style.scss
+++ b/client/my-sites/current-site/sidebar-banner/style.scss
@@ -10,6 +10,10 @@
 			padding: 0 24px;
 		}
 
+		@include breakpoint( "<960px" ) {
+			margin-right: 5px;
+		}
+
 		.sidebar-banner__icon-wrapper {
 			flex: 0 0 auto;
 			padding: 5px 5px 2px;
@@ -54,6 +58,10 @@
 			box-sizing: border-box;
 			overflow: visible;
 			padding: 2px 8px 3px 8px;
+			@include breakpoint( "<960px" ) {
+				padding-left: 5px;
+				padding-right: 5px;
+			}
 			height: 24px;
 			line-height: 18px;
 			background-color: $alert-green;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/205419/37032462-f318583a-2142-11e8-8130-e0a739e3dfeb.png)

After:
<img width="245" alt="zrzut ekranu 2018-03-06 o 13 28 12" src="https://user-images.githubusercontent.com/205419/37032461-f2fc1ff8-2142-11e8-9fff-bd891a3cf731.png">

There is a test running on those banners right now but that's just a cosmetic change - I don't think we need to restart it. 