### PR TITLE
Reader: consume site block status from /read/sites/:site endpoint

### DIFF
--- a/client/state/reader/site-blocks/reducer.js
+++ b/client/state/reader/site-blocks/reducer.js
@@ -1,22 +1,46 @@
 /** @format */
 /**
- * Internal dependencies
+ * External dependencies
  */
-import { READER_SITE_BLOCK, READER_SITE_UNBLOCK } from 'state/action-types';
-import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import { omit } from 'lodash';
 
 /**
- * Tracks all known site block statuses, indexed by site ID.
+ * Internal dependencies
  */
-export const items = keyedReducer(
-	'payload.siteId',
-	createReducer(
-		{},
-		{
-			[ READER_SITE_BLOCK ]: () => true,
-			[ READER_SITE_UNBLOCK ]: () => false,
-		}
-	)
+import {
+	READER_SITE_BLOCK,
+	READER_SITE_UNBLOCK,
+	READER_SITE_REQUEST_SUCCESS,
+} from 'state/action-types';
+import { combineReducers, createReducer } from 'state/utils';
+
+export const items = createReducer(
+	{},
+	{
+		[ READER_SITE_BLOCK ]: ( state, action ) => {
+			return {
+				...state,
+				[ action.payload.siteId ]: true,
+			};
+		},
+		[ READER_SITE_UNBLOCK ]: ( state, action ) => {
+			return omit( state, action.payload.siteId );
+		},
+		[ READER_SITE_REQUEST_SUCCESS ]: ( state, action ) => {
+			if ( ! action.payload.is_blocked ) {
+				if ( ! state[ action.payload.ID ] ) {
+					return state;
+				}
+
+				return omit( state, action.payload.ID );
+			}
+
+			return {
+				...state,
+				[ action.payload.ID ]: true,
+			};
+		},
+	}
 );
 
 export default combineReducers( {

--- a/client/state/reader/site-blocks/test/reducer.js
+++ b/client/state/reader/site-blocks/test/reducer.js
@@ -8,7 +8,11 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import { items } from '../reducer';
-import { READER_SITE_BLOCK, READER_SITE_UNBLOCK } from 'state/action-types';
+import {
+	READER_SITE_BLOCK,
+	READER_SITE_UNBLOCK,
+	READER_SITE_REQUEST_SUCCESS,
+} from 'state/action-types';
 
 describe( 'reducer', () => {
 	describe( '#items()', () => {
@@ -36,7 +40,40 @@ describe( 'reducer', () => {
 				payload: { siteId: 123 },
 			} );
 
-			expect( state[ 123 ] ).toEqual( false );
+			expect( state[ 123 ] ).toBeUndefined();
+		} );
+
+		test( 'should add a new block from a successful site request', () => {
+			const original = deepFreeze( {} );
+
+			const state = items( original, {
+				type: READER_SITE_REQUEST_SUCCESS,
+				payload: { ID: 123, is_blocked: true },
+			} );
+
+			expect( state[ 123 ] ).toEqual( true );
+		} );
+
+		test( 'should remove a block from a successful site request', () => {
+			const original = deepFreeze( { 123: true } );
+
+			const state = items( original, {
+				type: READER_SITE_REQUEST_SUCCESS,
+				payload: { ID: 123, is_blocked: false },
+			} );
+
+			expect( state[ 123 ] ).toBeUndefined();
+		} );
+
+		test( 'should make no changes from a successful site request with is_blocked false', () => {
+			const original = deepFreeze( {} );
+
+			const state = items( original, {
+				type: READER_SITE_REQUEST_SUCCESS,
+				payload: { ID: 123, is_blocked: false },
+			} );
+
+			expect( state[ 123 ] ).toBeUndefined();
 		} );
 	} );
 } );

--- a/client/state/reader/sites/fields.js
+++ b/client/state/reader/sites/fields.js
@@ -16,4 +16,5 @@ export const fields = [
 	'subscribers_count',
 	'options', // have to include this to get options at all
 	'subscription',
+	'is_blocked',
 ];

--- a/client/state/reader/sites/schema.js
+++ b/client/state/reader/sites/schema.js
@@ -1,7 +1,7 @@
 /** @format */
 import { sitesSchema } from 'state/sites/schema';
 
-// we're based on the normal site endpoint schema, but we want to add in a feed_ID property
+// based on the normal site endpoint schema with a few extra properties
 export const readerSitesSchema = {
 	...sitesSchema,
 	patternProperties: {
@@ -12,6 +12,7 @@ export const readerSitesSchema = {
 				...sitesSchema.patternProperties[ '^\\d+$' ].properties,
 				feed_ID: { type: 'number' },
 				subscription: { type: 'object' },
+				is_blocked: { type: 'boolean' },
 			},
 		},
 	},


### PR DESCRIPTION
When you block a site in Reader, the posts are hidden in the blog stream/feed stream and you have the option to undo the block.

Next time you visit, there's no sign that the block was ever made. This PR aims to remedy this (fixes https://github.com/Automattic/wp-calypso/issues/19642).

We now consume the new `is_blocked` flag from the /read/sites/:site endpoint, added in r171220-wpcom. This means that the blocked status should be visible if you return to a stream after a refresh.

<img width="976" alt="32618666-41557264-c570-11e7-879a-7f546815a8a4" src="https://user-images.githubusercontent.com/17325/37043916-e92a0af0-2159-11e8-8ed9-88510b6ba954.png">

### To test

Block a site like http://calypso.localhost:3000/read/feeds/55011230. Notice that all the post cards change to the 'blocked' card.

Do a hard refresh of the feed stream, and verify that the blocked cards return after the page loads.
