### PR TITLE
JP Remote Install: Fix credentials submission

### DIFF
--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -190,10 +190,10 @@ export class OrgCredentialsForm extends Component {
 			<MainWrapper>
 				{ this.renderHeadersText() }
 				<Card className="jetpack-connect__site-url-input-container">
-					<div onSubmit={ this.handleSubmit }>
+					<form onSubmit={ this.handleSubmit }>
 						{ this.formFields() }
 						{ this.formFooter() }
-					</div>
+					</form>
 				</Card>
 				{ this.footerLink() }
 			</MainWrapper>


### PR DESCRIPTION
Add back in the `<form />` element (unintentionally removed with some styling changes) so that user/password can be submitted, triggering the API request.

Should be no visual differences

## Testing
* In development mode, go to /jetpack/connect
* Enter URL of a .org site without jetpack installed
* Enter credentials at the next screen. Hitting the button should install jetpack and connect the site.
