### PR TITLE
Guided Tour: make external link color more legible

### DIFF
--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -162,6 +162,7 @@ a.config-elements__text-link,
 
 	.external-link {
 		font-style: normal;
+		color: $white;
 		border-top: 1px solid $gray-dark;
 		display: block;
 		padding-top: 12px;


### PR DESCRIPTION
This PR changes the color of the external link on Guided Tours to make it more legible.

Fixes #22759 

### Before

![image](https://user-images.githubusercontent.com/390760/37048047-a1f6beac-2164-11e8-991e-f8849b6fe7c0.png)


### After

![image](https://user-images.githubusercontent.com/390760/37048030-963d556c-2164-11e8-8f4f-ee2c628ffa1f.png)

### How to test

- Open https://calypso.live/?branch=fix/guided-tours-link-color&tour=main
- Complete the Guided Tour
