### PR TITLE
Replace bug noticon with gridicon

### DIFF
--- a/assets/stylesheets/_main.scss
+++ b/assets/stylesheets/_main.scss
@@ -333,8 +333,8 @@ object {
 		text-align: center;
 		z-index: z-index( '.environment-badge', '.environment-badge .bug-report' );
 		transition: border-radius 0.2s ease-out;
-		&:before {
-			@include noticon( '\f50a', 14px );
+
+		.gridicon {
 			vertical-align: middle;
 		}
 	}

--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -6,6 +6,7 @@
 
 import React, { Fragment } from 'react';
 import classNames from 'classnames';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -91,7 +92,9 @@ class Desktop extends React.Component {
 								href={ feedbackURL }
 								title="Report an issue"
 								target="_blank"
-							/>
+							>
+								<Gridicon icon="bug" size={ 18 } />
+							</a>
 						</div>
 					) }
 

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -7,6 +7,7 @@
 import React, { Fragment } from 'react';
 import classNames from 'classnames';
 import { get } from 'lodash';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -145,7 +146,9 @@ class Document extends React.Component {
 								href={ feedbackURL }
 								title="Report an issue"
 								target="_blank"
-							/>
+							>
+								<Gridicon icon="bug" size={ 18 } />
+							</a>
 						</div>
 					) }
 


### PR DESCRIPTION
This replaces the bug noticon in the environment badge with a gridicon.

This affects both desktop and web. It should apply to all dev environments (staging, etc.)

I did not test the desktop app.

Before
![screen shot 2018-03-06 at 11 54 14 am](https://user-images.githubusercontent.com/618551/37049150-9c4a05d8-2135-11e8-8173-69bce490f28a.png)

After 
![screen shot 2018-03-06 at 11 52 22 am](https://user-images.githubusercontent.com/618551/37049159-a3cf0da8-2135-11e8-9d87-f29c78614839.png)

