### PR TITLE
Domains: Update Privacy Policy upgrade to replace noticons and improve contrast

### DIFF
--- a/client/my-sites/domains/domain-management/privacy-protection/card/content.jsx
+++ b/client/my-sites/domains/domain-management/privacy-protection/card/content.jsx
@@ -40,7 +40,7 @@ class Content extends React.PureComponent {
 				</div>
 				<div className="privacy-protection-card__features">
 					<h5>
-						<Gridicon icon="checkmark-circle" size={ 16 } />
+						<Gridicon icon="checkmark-circle" size={ 18 } />
 						{ translate( '{{strong}}Protects{{/strong}} Your Identity Online', {
 							components: {
 								strong: <strong />,
@@ -49,7 +49,7 @@ class Content extends React.PureComponent {
 					</h5>
 
 					<h5>
-						<Gridicon icon="checkmark-circle" size={ 16 } />
+						<Gridicon icon="checkmark-circle" size={ 18 } />
 						{ translate( '{{strong}}Reduces{{/strong}} Email Spam', {
 							components: {
 								strong: <strong />,
@@ -58,7 +58,7 @@ class Content extends React.PureComponent {
 					</h5>
 
 					<h5>
-						<Gridicon icon="checkmark-circle" size={ 16 } />
+						<Gridicon icon="checkmark-circle" size={ 18 } />
 						{ translate( '{{strong}}Helps{{/strong}} Prevent Domain Hacking', {
 							components: {
 								strong: <strong />,

--- a/client/my-sites/domains/domain-management/privacy-protection/card/content.jsx
+++ b/client/my-sites/domains/domain-management/privacy-protection/card/content.jsx
@@ -7,6 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -39,7 +40,7 @@ class Content extends React.PureComponent {
 				</div>
 				<div className="privacy-protection-card__features">
 					<h5>
-						<span className="noticon noticon-checkmark" />
+						<Gridicon icon="checkmark-circle" size="16" />
 						{ translate( '{{strong}}Protects{{/strong}} Your Identity Online', {
 							components: {
 								strong: <strong />,
@@ -48,7 +49,7 @@ class Content extends React.PureComponent {
 					</h5>
 
 					<h5>
-						<span className="noticon noticon-checkmark" />
+						<Gridicon icon="checkmark-circle" size="16" />
 						{ translate( '{{strong}}Reduces{{/strong}} Email Spam', {
 							components: {
 								strong: <strong />,
@@ -57,7 +58,7 @@ class Content extends React.PureComponent {
 					</h5>
 
 					<h5>
-						<span className="noticon noticon-checkmark" />
+						<Gridicon icon="checkmark-circle" size="16" />
 						{ translate( '{{strong}}Helps{{/strong}} Prevent Domain Hacking', {
 							components: {
 								strong: <strong />,

--- a/client/my-sites/domains/domain-management/privacy-protection/card/content.jsx
+++ b/client/my-sites/domains/domain-management/privacy-protection/card/content.jsx
@@ -40,7 +40,7 @@ class Content extends React.PureComponent {
 				</div>
 				<div className="privacy-protection-card__features">
 					<h5>
-						<Gridicon icon="checkmark-circle" size="16" />
+						<Gridicon icon="checkmark-circle" size={ 16 } />
 						{ translate( '{{strong}}Protects{{/strong}} Your Identity Online', {
 							components: {
 								strong: <strong />,
@@ -49,7 +49,7 @@ class Content extends React.PureComponent {
 					</h5>
 
 					<h5>
-						<Gridicon icon="checkmark-circle" size="16" />
+						<Gridicon icon="checkmark-circle" size={ 16 } />
 						{ translate( '{{strong}}Reduces{{/strong}} Email Spam', {
 							components: {
 								strong: <strong />,
@@ -58,7 +58,7 @@ class Content extends React.PureComponent {
 					</h5>
 
 					<h5>
-						<Gridicon icon="checkmark-circle" size="16" />
+						<Gridicon icon="checkmark-circle" size={ 16 } />
 						{ translate( '{{strong}}Helps{{/strong}} Prevent Domain Hacking', {
 							components: {
 								strong: <strong />,

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -516,7 +516,7 @@ ul.email-forwarding__list {
 }
 
 .privacy-protection-card__header {
-	border-bottom: 2px solid $gray-lighten-20;
+	border-bottom: 1px solid $gray-lighten-30;
 	display: block;
 	overflow: auto;
 	padding: 16px 16px 20px;
@@ -568,7 +568,6 @@ ul.email-forwarding__list {
 }
 
 .privacy-protection-card__content {
-	background: $gray-light;
 	clear: both;
 	display: block;
 	overflow: auto;
@@ -615,9 +614,11 @@ ul.email-forwarding__list {
 			margin-bottom: 0;
 		}
 
-		.noticon {
-			color: $alert-green;
+		.gridicon {
+			fill: $alert-green;
 			margin-right: 5px;
+			position: relative;
+				top: 3px;
 		}
 	}
 }

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -618,7 +618,7 @@ ul.email-forwarding__list {
 			fill: $alert-green;
 			margin-right: 5px;
 			position: relative;
-				top: 3px;
+				top: 4px;
 		}
 	}
 }


### PR DESCRIPTION
Replacing Noticons with Gridicons, and changing a gray background to a white background to improve text contrast.

![slice](https://user-images.githubusercontent.com/191598/37050415-d1ce8538-2141-11e8-8f4e-478d65ba43be.png)

To test, you'll need a custom domain setup that *doesn't* have privacy protection enabled. Then, head to `/domains/manage/:domain/privacy-protection/:site` for your domain and site.