### PR TITLE
Plugins: Remove unused noticon CSS

### DIFF
--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -67,10 +67,6 @@
 	float: right;
 }
 
-.plugin-action__children .noticon {
-	margin-left: 8px;
-}
-
 .plugin-action__disabled-info.info-popover {
 	flex: none;
 	margin: -1px 4px;


### PR DESCRIPTION
Doesn’t look like this CSS is used anymore, and we no longer use noticons.