### PR TITLE
Billing History: Group domain-related purchases of the same domain

### DIFF
--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { reject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,6 +19,7 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { billingHistory } from 'me/purchases/paths';
 import QueryBillingTransactions from 'components/data/query-billing-transactions';
 import tableRows from './table-rows';
+import { groupDomainProducts } from './utils';
 import { getPastBillingTransaction, getPastBillingTransactions } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
@@ -143,11 +143,7 @@ class BillingReceipt extends React.Component {
 
 	renderLineItems() {
 		const { transaction, translate } = this.props;
-
-		const groupedTransactionItems = [
-			...reject( transaction.items, { product: 'Domain' } ),
-			...transaction.domain_items,
-		];
+		const groupedTransactionItems = groupDomainProducts( transaction.items, translate );
 
 		const items = groupedTransactionItems.map( item => {
 			return (

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { reject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -142,7 +143,13 @@ class BillingReceipt extends React.Component {
 
 	renderLineItems() {
 		const { transaction, translate } = this.props;
-		const items = transaction.items.map( item => {
+
+		const groupedTransactionItems = [
+			...reject( transaction.items, { product: 'Domain' } ),
+			...transaction.domain_items,
+		];
+
+		const items = groupedTransactionItems.map( item => {
 			return (
 				<tr key={ item.id }>
 					<td className="billing-history__receipt-item-name">

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -109,15 +109,18 @@ class TransactionsTable extends React.Component {
 			return this.serviceNameDescription( transaction );
 		}
 
-		const groupedTransactionItems = groupDomainProducts( transaction.items, this.props.translate );
+		const [ transactionItem, ...moreTransactionItems ] = groupDomainProducts(
+			transaction.items,
+			this.props.translate
+		);
 
-		if ( groupedTransactionItems.length > 1 ) {
+		if ( moreTransactionItems.length > 0 ) {
 			return <strong>{ this.props.translate( 'Multiple items' ) }</strong>;
 		}
 
 		return this.serviceNameDescription( {
-			...groupedTransactionItems[ 0 ],
-			plan: capitalPDangit( titleCase( groupedTransactionItems[ 0 ].variation ) ),
+			...transactionItem,
+			plan: capitalPDangit( titleCase( transactionItem.variation ) ),
 		} );
 	};
 

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { defer, isEmpty, pick, reject } from 'lodash';
+import { defer, isEmpty, pick } from 'lodash';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import titleCase from 'to-title-case';
@@ -15,7 +15,7 @@ import { capitalPDangit } from 'lib/formatting';
  */
 import TransactionsHeader from './transactions-header';
 import tableRows from './table-rows';
-
+import { groupDomainProducts } from './utils';
 import SearchCard from 'components/search-card';
 
 class TransactionsTable extends React.Component {
@@ -109,10 +109,7 @@ class TransactionsTable extends React.Component {
 			return this.serviceNameDescription( transaction );
 		}
 
-		const groupedTransactionItems = [
-			...reject( transaction.items, { product: 'Domain' } ),
-			...transaction.domain_items,
-		];
+		const groupedTransactionItems = groupDomainProducts( transaction.items, this.props.translate );
 
 		if ( groupedTransactionItems.length > 1 ) {
 			return <strong>{ this.props.translate( 'Multiple items' ) }</strong>;

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { defer, isEmpty, pick } from 'lodash';
+import { defer, isEmpty, pick, reject } from 'lodash';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import titleCase from 'to-title-case';
@@ -105,19 +105,23 @@ class TransactionsTable extends React.Component {
 	}
 
 	serviceName = transaction => {
-		var item, name;
-
 		if ( ! transaction.items ) {
-			name = this.serviceNameDescription( transaction );
-		} else if ( transaction.items.length === 1 ) {
-			item = transaction.items[ 0 ];
-			item.plan = capitalPDangit( titleCase( item.variation ) );
-			name = this.serviceNameDescription( item );
-		} else {
-			name = <strong>{ this.props.translate( 'Multiple items' ) }</strong>;
+			return this.serviceNameDescription( transaction );
 		}
 
-		return name;
+		const groupedTransactionItems = [
+			...reject( transaction.items, { product: 'Domain' } ),
+			...transaction.domain_items,
+		];
+
+		if ( groupedTransactionItems.length > 1 ) {
+			return <strong>{ this.props.translate( 'Multiple items' ) }</strong>;
+		}
+
+		return this.serviceNameDescription( {
+			...groupedTransactionItems[ 0 ],
+			plan: capitalPDangit( titleCase( groupedTransactionItems[ 0 ].variation ) ),
+		} );
 	};
 
 	serviceNameDescription = transaction => {

--- a/client/me/billing-history/utils.js
+++ b/client/me/billing-history/utils.js
@@ -10,7 +10,9 @@ import { map, partition, reduce } from 'lodash';
 import formatCurrency from 'lib/format-currency';
 
 export const groupDomainProducts = ( transactionItems, translate ) => {
-	const [ domainProducts, otherProducts ] = partition( transactionItems, { product: 'Domain' } );
+	const [ domainProducts, otherProducts ] = partition( transactionItems, {
+		product_slug: 'wp-domains',
+	} );
 
 	const groupedDomainProducts = reduce(
 		domainProducts,
@@ -20,6 +22,8 @@ export const groupDomainProducts = ( transactionItems, translate ) => {
 			} else {
 				groups[ product.domain ] = product;
 			}
+			groups[ product.domain ].hasPrivateRegistration |=
+				product.variation_slug === 'wp-private-registration';
 			return groups;
 		},
 		{}
@@ -30,7 +34,9 @@ export const groupDomainProducts = ( transactionItems, translate ) => {
 		...map( groupedDomainProducts, product => ( {
 			...product,
 			amount: formatCurrency( product.raw_amount, product.currency ),
-			variation: translate( 'Domain Registration' ),
+			variation: product.hasPrivateRegistration
+				? translate( 'Domain Registration with Privacy Protection' )
+				: translate( 'Domain Registration' ),
 		} ) ),
 	];
 };

--- a/client/me/billing-history/utils.js
+++ b/client/me/billing-history/utils.js
@@ -1,0 +1,36 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { map, partition, reduce } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import formatCurrency from 'lib/format-currency';
+
+export const groupDomainProducts = ( transactionItems, translate ) => {
+	const [ domainProducts, otherProducts ] = partition( transactionItems, { product: 'Domain' } );
+
+	const groupedDomainProducts = reduce(
+		domainProducts,
+		( groups, product ) => {
+			if ( !! groups[ product.domain ] ) {
+				groups[ product.domain ].raw_amount += product.raw_amount;
+			} else {
+				groups[ product.domain ] = product;
+			}
+			return groups;
+		},
+		{}
+	);
+
+	return [
+		...otherProducts,
+		...map( groupedDomainProducts, product => ( {
+			...product,
+			amount: formatCurrency( product.raw_amount, product.currency ),
+			variation: translate( 'Domain Registration' ),
+		} ) ),
+	];
+};

--- a/client/me/billing-history/utils.js
+++ b/client/me/billing-history/utils.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { map, partition, reduce } from 'lodash';
+import { find, map, partition, reduce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,8 +19,10 @@ export const groupDomainProducts = ( transactionItems, translate ) => {
 		( groups, product ) => {
 			if ( !! groups[ product.domain ] ) {
 				groups[ product.domain ].raw_amount += product.raw_amount;
+				groups[ product.domain ].groupCount++;
 			} else {
 				groups[ product.domain ] = product;
+				groups[ product.domain ].groupCount = 1;
 			}
 			groups[ product.domain ].hasPrivateRegistration |=
 				product.variation_slug === 'wp-private-registration';
@@ -31,12 +33,17 @@ export const groupDomainProducts = ( transactionItems, translate ) => {
 
 	return [
 		...otherProducts,
-		...map( groupedDomainProducts, product => ( {
-			...product,
-			amount: formatCurrency( product.raw_amount, product.currency ),
-			variation: product.hasPrivateRegistration
-				? translate( 'Domain Registration with Privacy Protection' )
-				: translate( 'Domain Registration' ),
-		} ) ),
+		...map( groupedDomainProducts, product => {
+			if ( 1 === product.groupCount ) {
+				return find( domainProducts, { domain: product.domain } );
+			}
+			return {
+				...product,
+				amount: formatCurrency( product.raw_amount, product.currency ),
+				variation: product.hasPrivateRegistration
+					? translate( 'Domain Registration with Privacy Protection' )
+					: translate( 'Domain Registration' ),
+			};
+		} ),
 	];
 };


### PR DESCRIPTION
Fix #2525 
Require D10703-code

Additional context: p2MSmN-3nc-p2

When a user purchases a domain registration, the receipt shows 2 or 3 different products ("Domain Registration", "Domain Mapping", and sometimes "Private Registration") causing confusion to the user.

This patch groups all the domain-related products for the same domain into one single product, and list them in the new `domain_items` property of the `billing-history` endpoint.

If there is only one domain-related product for a given domain, it is shown as-is.
If a group contains a Private Registration, it will be called "Domain Registration with Privacy Protection"; otherwise just "Domain Registration".

| Before | After |
| --- | --- |
| <img width="671" alt="screen shot 2018-03-06 at 19 10 46" src="https://user-images.githubusercontent.com/2070010/37052772-2aef9406-2172-11e8-829e-178ca1f355d4.png"> | <img width="675" alt="screen shot 2018-03-15 at 14 53 36" src="https://user-images.githubusercontent.com/2070010/37470992-b3e09f54-2860-11e8-8553-2cd462fb2287.png"> |

### Notes

- Please note that this PR does not change the email receipt, which has a different format and is generated in a different manner:

<img width="554" alt="screen shot 2018-03-06 at 19 21 27" src="https://user-images.githubusercontent.com/2070010/37053382-e8214b04-2173-11e8-847e-e634a00e0ed8.png">

## Testing instructions

Sandbox the API and apply 10703-code.
Navigate to `/me/purchases/billing`.

- Make sure that items previously marked as "Multiple items" because containing only multiple products for the same domain, are now listed as "Domain Registration" or "Domain Registration with Privacy Protection".
- Items that contain both multiple products for the same domain and other products (e.g. a plan), should still be listed as "Multiple items".

- Open a receipt containing multiple products for the same domain (e.g. domain registration, mapping, private registration).
  - Make sure that the receipt only shows one "Domain Registration" for that domain, and its amount is the sum of all single domain-related products.
  - If the receipt contains both a domain and privacy registration for the same domain, the product shown is "Domain Registration with Privacy Protection".
- Open a receipt containing only one product for a domain (e.g. only domain mapping).
  - Make sure that the receipt shows "Domain Mapping".