### PR TITLE
Fix margins of the "Upload Theme" button on mobile

### DIFF
--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -6,10 +6,10 @@
 		box-sizing: border-box;
 		width: 100%;
 	}
-	
+
 	+ .dialog__action-buttons {
 		text-align: center;
-		
+
 		.button:first-child {
 			margin-left: 0;
 		}
@@ -26,7 +26,7 @@
 		p {
 			margin: 0;
 		}
-		
+
 		+ span {
 			display: block;
 			text-align: center;
@@ -111,10 +111,12 @@
 		}
 
 		@include breakpoint( "<480px" ) {
-			margin-top: 20px;
+			margin-top: 24px;
+			margin-right: 15px;
 			font-size: 0;
 			.gridicon {
 				padding: 0;
+				margin-right: 0;
 			}
 		}
 	}


### PR DESCRIPTION
The "Upload Theme" button on mobile currently:

- Is pushed up against the edge of the page
- Does not line up vertically with the text to the left of it
- Has extra padding on its right side

This PR corrects those issues.
(I couldn't find an existing bug for this, but please let me know if there is one)

## Screenshots: 

Before
<img width="320" alt="screen shot 2018-03-06 at 3 24 04 pm" src="https://user-images.githubusercontent.com/1202812/37056642-01d0ecce-2153-11e8-9696-191818428ea4.png">

After
<img width="320" alt="screen shot 2018-03-06 at 3 24 04 pm copy" src="https://user-images.githubusercontent.com/1202812/37056726-3a5101ba-2153-11e8-9066-33145afb7fec.png">

## To test:

- Visit http://calypso.localhost:3000/themes
- Compare screenshots to make sure the button appears as described. 