### PR TITLE
Media Lib: remove noticon from source picker

### DIFF
--- a/client/my-sites/media-library/data-source.jsx
+++ b/client/my-sites/media-library/data-source.jsx
@@ -112,6 +112,7 @@ export class MediaLibraryDataSource extends Component {
 				>
 					{ currentSelected && currentSelected.icon }
 					{ this.renderScreenReader( currentSelected ) }
+					<Gridicon icon="chevron-down" size={ 18 } />
 
 					<PopoverMenu
 						context={ this.refs && this.refs.popoverMenuButton }

--- a/client/my-sites/media-library/list-item.scss
+++ b/client/my-sites/media-library/list-item.scss
@@ -66,15 +66,6 @@
 .media-library__list-item.is-placeholder .media-library__list-item-figure {
 	background-color: $gray-lighten-20;
 	animation: loading-fade 1.6s ease-in-out infinite;
-
-	&::before {
-		@include noticon( '\f473', 80px );
-		position: absolute;
-			left: 50%;
-			top: 50%;
-		transform: translate( -50%, -50% );
-		color: white;
-	}
 }
 
 .media-library__list-item.is-transient .media-library__list-item-figure::after {

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -116,9 +116,9 @@
 			align-items: normal;
 			padding-top: 6px;
 		}
-		
+
 		@include breakpoint( "<660px" ) {
-			margin-bottom: 9px;	
+			margin-bottom: 9px;
 		}
 	}
 }
@@ -142,45 +142,14 @@
 		margin-top: 2px;
 	}
 
-	.gridicons-chevron-down {
-		top: -3px;
-	}
-
 	.gridicon {
 		top: 4px;
 	}
 
-	&:after {
-		@include noticon( '\f431', 20px );
-		line-height: 16px;
-		color: rgba( $gray, 0.5 );
-		padding-top: 6px;
-	}
-
-	@include breakpoint( "<480px" ) {
-		.gridicons-chevron-down {
-			width: 18px;
-			height: 18px;
-			color: rgba( $gray, 0.5 );
-		}
-
-		.gridicon {
-			top: 2px;
-		}
-
-		&:after {
-			padding-top: 3px;
-		}
-	}
-}
-
-.media-library__source-button.is-open.is-borderless {
-	&:after {
-		@include noticon( '\f432', 20px );
-	}
-
-	.gridicon {
-		color: $gray-dark;
+	.gridicons-chevron-down {
+		width: 18px;
+		height: 18px;
+		top: 2px;
 	}
 }
 


### PR DESCRIPTION
This removes the chevron noticon that was being used for the source picker button.

Notice that the icon is darker now, and does not change rotation. I did not change the icon in the add image button, but shown in the gifs just for demo purposes.

I tested mobile viewport widths in Chrome. The media library in the post editor uses the same components, so it works just the same there also.

Before

![before](https://user-images.githubusercontent.com/618551/37058065-e6d05f08-214e-11e8-9e47-68c2a4969007.gif)

After

![after](https://user-images.githubusercontent.com/618551/37058069-eaaf181c-214e-11e8-92a5-e3905b6f3aff.gif)

---

I decided to also take care of the placeholder image noticon. I just removed it instead of replacing it with a gridicon. I don't think the image icon in the placeholder adds much value.

before 

![before 2](https://user-images.githubusercontent.com/618551/37060908-5407ea5c-2157-11e8-8499-ba5ddecfef2b.gif)

after

![after 3](https://user-images.githubusercontent.com/618551/37060915-5ad5149a-2157-11e8-9c84-45e62cc6b540.gif)
