### PR TITLE
Add the error message for recently expired domains 

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -43,6 +43,7 @@ export const domainAvailability = {
 	NOT_REGISTRABLE: 'available_but_not_registrable',
 	PURCHASES_DISABLED: 'domain_registration_unavailable',
 	RECENTLY_UNMAPPED: 'recently_mapped',
+	RECENTLY_EXPIRED: 'recently_expired',
 	REGISTERED: 'registered_domain',
 	REGISTERED_OTHER_SITE_SAME_USER: 'registered_on_other_site_same_user',
 	REGISTERED_SAME_SITE: 'registered_on_same_site',

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -231,8 +231,12 @@ function getAvailabilityNotice( domain, error, site ) {
 
 		case domainAvailability.RECENTLY_EXPIRED:
 			message = translate(
-				'This domain is expired and cannot be mapped at this time. ' +
-					'Please contact support to restore your domain.'
+				'This domain expired recently. To get it back please {{a}}contact support{{/a}}.',
+				{
+					components: {
+						a: <a href={ CALYPSO_CONTACT } />,
+					},
+				}
 			);
 			break;
 

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -229,6 +229,13 @@ function getAvailabilityNotice( domain, error, site ) {
 			);
 			break;
 
+		case domainAvailability.RECENTLY_EXPIRED:
+			message = translate(
+				'This domain is expired and cannot be mapped at this time. ' +
+					'Please contact support to restore your domain.'
+			);
+			break;
+
 		case domainAvailability.UNKOWN_ACTIVE:
 			message = translate(
 				'This domain is still active and is not available to map yet. ' +


### PR DESCRIPTION
Depends on D10707-code

Expired domains cannot be mapped so we should show the correct error message.

Testing: Try to map a domain that is expired and you will see the new error message.