### PR TITLE
Store: Show full/regular price for products when editing promotions.

### DIFF
--- a/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/index.js
+++ b/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/index.js
@@ -122,6 +122,7 @@ class PromotionAppliesToField extends React.Component {
 				value={ productIds }
 				onChange={ this.onProductIdsChange }
 				singular={ singular }
+				showRegularPrice
 			/>
 		);
 	};

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -29,6 +29,7 @@ import {
 class ProductSearch extends Component {
 	static propTypes = {
 		singular: PropTypes.bool,
+		showRegularPrice: PropTypes.bool,
 		value: PropTypes.oneOfType( [ PropTypes.array, PropTypes.number ] ),
 		onChange: PropTypes.func.isRequired,
 		products: PropTypes.array,
@@ -132,7 +133,7 @@ class ProductSearch extends Component {
 	};
 
 	renderList = () => {
-		const { isLoading, products, singular, value } = this.props;
+		const { isLoading, products, singular, value, showRegularPrice } = this.props;
 		if ( isLoading ) {
 			return this.renderPlaceholder();
 		}
@@ -149,6 +150,7 @@ class ProductSearch extends Component {
 					onChange={ onChange }
 					product={ product }
 					singular={ singular }
+					showRegularPrice={ showRegularPrice }
 					value={ value }
 				/>
 			);

--- a/client/extensions/woocommerce/components/product-search/row.js
+++ b/client/extensions/woocommerce/components/product-search/row.js
@@ -181,8 +181,15 @@ class ProductSearchRow extends Component {
 	};
 
 	renderInputName = product => {
-		const { currency, translate } = this.props;
-		const price = formatCurrency( product.price, currency );
+		const { currency, translate, showRegularPrice } = this.props;
+
+		let price;
+		if ( showRegularPrice ) {
+			price = formatCurrency( product.regular_price || '0', currency );
+		} else {
+			price = formatCurrency( product.price, currency );
+		}
+
 		let nameWithPrice = `${ product.name } - ${ price }`;
 		// Some things do need special handling…
 		if ( product.isVariation ) {


### PR DESCRIPTION
When editing or creating a promotion, the product search component shows the current price (so sale price if a sale is configured, which means if you are also adding a coupon for a product, you won't see the full price) of a product. This PR adds a new prop so the product search component will always show the "regular" price of the product independent of a sale going on.

The orders page remains unchanged.

To Test:
* Configure a product sale for a product
* Go create a coupon for a specific product
* Verify that the price shown in the component is the full/regular price of the product

