### PR TITLE
Observe Sites: remove

### DIFF
--- a/client/my-sites/checkout/cart/secondary-cart.jsx
+++ b/client/my-sites/checkout/cart/secondary-cart.jsx
@@ -5,8 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
-import createReactClass from 'create-react-class';
+import React, { Component } from 'react';
 import ReactDom from 'react-dom';
 import { localize } from 'i18n-calypso';
 import Dispatcher from 'dispatcher';
@@ -25,19 +24,15 @@ import CartBodyLoadingPlaceholder from 'my-sites/checkout/cart/cart-body/loading
 import { action as upgradesActionTypes } from 'lib/upgrades/constants';
 import scrollIntoViewport from 'lib/scroll-into-viewport';
 
-const SecondaryCart = createReactClass( {
-	displayName: 'SecondaryCart',
-
-	propTypes: {
+class SecondaryCart extends Component {
+	static propTypes = {
 		cart: PropTypes.object.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
-	},
+	};
 
-	getInitialState() {
-		return {
-			cartVisible: false,
-		};
-	},
+	state = {
+		cartVisible: false,
+	};
 
 	componentWillMount() {
 		this.dispatchToken = Dispatcher.register(
@@ -47,18 +42,22 @@ const SecondaryCart = createReactClass( {
 				}
 			}.bind( this )
 		);
-	},
+	}
 
 	componentWillUnmount() {
 		Dispatcher.unregister( this.dispatchToken );
-	},
+	}
 
 	componentDidUpdate( prevProps, prevState ) {
 		if ( ! prevState.cartVisible && this.state.cartVisible ) {
-			const node = ReactDom.findDOMNode( this.refs.cartBody );
+			const node = ReactDom.findDOMNode( this.cartBodyRef );
 			scrollIntoViewport( node );
 		}
-	},
+	}
+
+	setCartBodyRef = cartBody => {
+		this.cartBodyRef = cartBody;
+	};
 
 	render() {
 		const { cart, selectedSite } = this.props;
@@ -82,11 +81,16 @@ const SecondaryCart = createReactClass( {
 				<CartMessages cart={ cart } selectedSite={ selectedSite } />
 				<CartSummaryBar additionalClasses="cart-header" />
 				<CartPlanAd selectedSite={ selectedSite } cart={ cart } />
-				<CartBody ref="cartBody" cart={ cart } selectedSite={ selectedSite } showCoupon={ true } />
+				<CartBody
+					ref={ this.setCartBodyRef }
+					cart={ cart }
+					selectedSite={ selectedSite }
+					showCoupon={ true }
+				/>
 				<CartPlanDiscountAd cart={ cart } selectedSite={ selectedSite } />
 			</Sidebar>
 		);
-	},
-} );
+	}
+}
 
 export default localize( SecondaryCart );

--- a/client/my-sites/checkout/cart/secondary-cart.jsx
+++ b/client/my-sites/checkout/cart/secondary-cart.jsx
@@ -21,7 +21,6 @@ import CartSummaryBar from 'my-sites/checkout/cart/cart-summary-bar';
 import CartPlanAd from './cart-plan-ad';
 import CartPlanDiscountAd from './cart-plan-discount-ad';
 import Sidebar from 'layout/sidebar';
-import observe from 'lib/mixins/data-observe';
 import CartBodyLoadingPlaceholder from 'my-sites/checkout/cart/cart-body/loading-placeholder';
 import { action as upgradesActionTypes } from 'lib/upgrades/constants';
 import scrollIntoViewport from 'lib/scroll-into-viewport';
@@ -33,8 +32,6 @@ const SecondaryCart = createReactClass( {
 		cart: PropTypes.object.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 	},
-
-	mixins: [ observe( 'sites' ) ],
 
 	getInitialState() {
 		return {

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -64,7 +64,7 @@ import { loadTrackingTool } from 'state/analytics/actions';
 
 const Checkout = createReactClass( {
 	displayName: 'Checkout',
-	mixins: [ observe( 'sites', 'productsList' ) ],
+	mixins: [ observe( 'productsList' ) ],
 
 	propTypes: {
 		cards: PropTypes.array.isRequired,


### PR DESCRIPTION
Part of solving #19828.

`observe( 'sites' )` can be removed because sites-list was removed and this shouldn't do anything.

## Testing

On `master`, go to the `checkout` page (just try to buy a plan on a site). In dev console, type in `localStorage.debug = 'calypso:data-observe*'` and reload the page. You should see logs like `sites is not set`. That means the `sites` component doesn't exist and there's nothing to observe.

Now, switch to the branch of this PR. Go to checkout. You should not see the logs. Also, it should work as before.