### PR TITLE
Devdocs: Fix page change lag in devdocs (fix #22756)

### DIFF
--- a/client/devdocs/delay-render/index.js
+++ b/client/devdocs/delay-render/index.js
@@ -1,0 +1,33 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import LazyRender from 'react-lazily-render';
+import PropTypes from 'prop-types';
+
+// This component exists to delay rendering and mounting of components
+// until after the page has loaded; this results in less browser lag/thrashing.
+// Technically the content will appear either when it is scrolled into view
+// or once the delay time has passed (defaults to 20ms).
+export default class DelayRender extends LazyRender {
+	static propTypes = {
+		delay: PropTypes.number,
+	};
+
+	static defaultProps = {
+		delay: 20,
+	};
+
+	componentDidMount = () => {
+		this.timeout = setTimeout( () => {
+			this.stopListening();
+			this.setState( { hasBeenScrolledIntoView: true } );
+		}, this.props.delay );
+	};
+
+	componentWillUnmout = () => {
+		clearTimeout( this.timeout );
+	};
+}

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -5,12 +5,11 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
-import LazyRender from 'react-lazily-render';
 
 /**
  * Internal dependencies
  */
+import DelayRender from 'devdocs/delay-render';
 import DocsExampleWrapper from 'devdocs/docs-example/wrapper';
 import { camelCaseToSlug, getComponentName } from 'devdocs/docs-example/util';
 import ReadmeViewer from 'devdocs/docs-example/readme-viewer';
@@ -34,106 +33,78 @@ const shouldShowInstance = ( example, filter, component ) => {
 	return ! filter || searchPattern.toLowerCase().indexOf( filter ) > -1;
 };
 
-class Collection extends React.PureComponent {
-	static propTypes = {
-		children: PropTypes.node,
-		component: PropTypes.string,
-		examplesToMount: PropTypes.number,
-		filter: PropTypes.string,
-		section: PropTypes.string,
-	};
+const Collection = ( {
+	children,
+	component,
+	examplesToMount = 20,
+	filter,
+	section = 'design',
+} ) => {
+	let showCounter = 0;
+	const summary = [];
 
-	static defaultProps = {
-		examplesToMount: 7,
-		section: 'design',
-	};
+	const examples = React.Children.map( children, example => {
+		if ( ! example || ! shouldShowInstance( example, filter, component ) ) {
+			return null;
+		}
 
-	_setLazyRenderRef = ref => {
-		this._lazyRender = ref;
-	};
+		const exampleName = getComponentName( example );
+		const exampleLink = `/devdocs/${ section }/${ camelCaseToSlug( exampleName ) }`;
 
-	componentDidMount = () => {
-		this._lazyRenderTimeout = setTimeout( () => {
-			// HACK: Reach into the <LazyRender> component and force all
-			// examples to be mounted after a few seconds of the component
-			// being mounted. This means if the user loads the page and
-			// changes context the rest of the content won't wait to load
-			// until they scroll down.
-			this._lazyRender.stopListening();
-			this._lazyRender.setState( { hasBeenScrolledIntoView: true } );
-		}, 2000 );
-	};
+		showCounter++;
 
-	componentWillUnmout = () => {
-		clearTimeout( this._lazyRenderTimeout );
-	};
-
-	render() {
-		const { children, component, examplesToMount, filter, section } = this.props;
-
-		let showCounter = 0;
-		const summary = [];
-
-		const examples = React.Children.map( children, example => {
-			if ( ! example || ! shouldShowInstance( example, filter, component ) ) {
-				return null;
-			}
-
-			const exampleName = getComponentName( example );
-			const exampleLink = `/devdocs/${ section }/${ camelCaseToSlug( exampleName ) }`;
-
-			showCounter++;
-
-			if ( filter ) {
-				summary.push(
-					<span key={ `instance-link-${ showCounter }` } className="design__instance-link">
-						<a href={ exampleLink }>{ exampleName }</a>
-						,&nbsp;
-					</span>
-				);
-			}
-
-			return (
-				<DocsExampleWrapper name={ exampleName } unique={ !! component } url={ exampleLink }>
-					{ example }
-					{ component && <ReadmeViewer readmeFilePath={ example.props.readmeFilePath } /> }
-				</DocsExampleWrapper>
+		if ( filter ) {
+			summary.push(
+				<span key={ `instance-link-${ showCounter }` } className="design__instance-link">
+					<a href={ exampleLink }>{ exampleName }</a>
+					,&nbsp;
+				</span>
 			);
-		} );
+		}
 
 		return (
-			<div className="design__collection">
-				{ showCounter > 1 &&
-					filter && (
-						<div className="design__instance-links">
-							<span>Showing </span>
-							{ summary }...
-						</div>
-					) }
-				{ /*
-					The entire list of examples for `/devdocs/blocks` and
-					`/devdocs/design` takes a long time to mount, even when
-					loaded, so we render just the first few components so
-					the page change feels faster. The rest of the components
-					are loaded either once scrolled to or in a few seconds
-					after `componentDidMount()` is called.
-				*/ }
-				{ examples.length <= examplesToMount ? (
-					examples
-				) : (
-					<React.Fragment>
-						{ examples.slice( 0, examplesToMount ) }
-
-						<LazyRender ref={ this._setLazyRenderRef }>
-							{ shouldRender =>
-								shouldRender ? examples.slice( examplesToMount ) : <Placeholder count={ 10 } />
-							}
-						</LazyRender>
-					</React.Fragment>
-				) }
-			</div>
+			<DocsExampleWrapper name={ exampleName } unique={ !! component } url={ exampleLink }>
+				{ example }
+				{ component && <ReadmeViewer readmeFilePath={ example.props.readmeFilePath } /> }
+			</DocsExampleWrapper>
 		);
-	}
-}
+	} );
+
+	return (
+		<div className="design__collection">
+			{ showCounter > 1 &&
+				filter && (
+					<div className="design__instance-links">
+						<span>Showing </span>
+						{ summary }...
+					</div>
+				) }
+			{ /*
+				The entire list of examples for `/devdocs/blocks` and
+				`/devdocs/design` takes a long time to mount, so we use
+				`DelayRender` to render just the first few components.
+				This means the page change feels a lot faster, especially
+				on lower-end machines and on Firefox.
+			*/ }
+			{ examples.length <= examplesToMount ? (
+				examples
+			) : (
+				<React.Fragment>
+					{ examples.slice( 0, examplesToMount ) }
+
+					<DelayRender>
+						{ shouldRender =>
+							shouldRender ? (
+								examples.slice( examplesToMount )
+							) : (
+								<Placeholder count={ examplesToMount } />
+							)
+						}
+					</DelayRender>
+				</React.Fragment>
+			) }
+		</div>
+	);
+};
 
 export default Collection;

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -5,6 +5,8 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
+import LazyRender from 'react-lazily-render';
 
 /**
  * Internal dependencies
@@ -12,6 +14,7 @@ import React from 'react';
 import DocsExampleWrapper from 'devdocs/docs-example/wrapper';
 import { camelCaseToSlug, getComponentName } from 'devdocs/docs-example/util';
 import ReadmeViewer from 'devdocs/docs-example/readme-viewer';
+import Placeholder from 'devdocs/devdocs-async-load/placeholder';
 
 const shouldShowInstance = ( example, filter, component ) => {
 	const name = getComponentName( example );
@@ -31,49 +34,106 @@ const shouldShowInstance = ( example, filter, component ) => {
 	return ! filter || searchPattern.toLowerCase().indexOf( filter ) > -1;
 };
 
-const Collection = ( { children, filter, section = 'design', component } ) => {
-	let showCounter = 0;
-	const summary = [];
+class Collection extends React.PureComponent {
+	static propTypes = {
+		children: PropTypes.node,
+		component: PropTypes.string,
+		examplesToMount: PropTypes.number,
+		filter: PropTypes.string,
+		section: PropTypes.string,
+	};
 
-	const examples = React.Children.map( children, example => {
-		if ( ! example || ! shouldShowInstance( example, filter, component ) ) {
-			return null;
-		}
+	static defaultProps = {
+		examplesToMount: 7,
+		section: 'design',
+	};
 
-		const exampleName = getComponentName( example );
-		const exampleLink = `/devdocs/${ section }/${ camelCaseToSlug( exampleName ) }`;
+	_setLazyRenderRef = ref => {
+		this._lazyRender = ref;
+	};
 
-		showCounter++;
+	componentDidMount = () => {
+		this._lazyRenderTimeout = setTimeout( () => {
+			// HACK: Reach into the <LazyRender> component and force all
+			// examples to be mounted after a few seconds of the component
+			// being mounted. This means if the user loads the page and
+			// changes context the rest of the content won't wait to load
+			// until they scroll down.
+			this._lazyRender.stopListening();
+			this._lazyRender.setState( { hasBeenScrolledIntoView: true } );
+		}, 2000 );
+	};
 
-		if ( filter ) {
-			summary.push(
-				<span key={ `instance-link-${ showCounter }` } className="design__instance-link">
-					<a href={ exampleLink }>{ exampleName }</a>
-					,&nbsp;
-				</span>
+	componentWillUnmout = () => {
+		clearTimeout( this._lazyRenderTimeout );
+	};
+
+	render() {
+		const { children, component, examplesToMount, filter, section } = this.props;
+
+		let showCounter = 0;
+		const summary = [];
+
+		const examples = React.Children.map( children, example => {
+			if ( ! example || ! shouldShowInstance( example, filter, component ) ) {
+				return null;
+			}
+
+			const exampleName = getComponentName( example );
+			const exampleLink = `/devdocs/${ section }/${ camelCaseToSlug( exampleName ) }`;
+
+			showCounter++;
+
+			if ( filter ) {
+				summary.push(
+					<span key={ `instance-link-${ showCounter }` } className="design__instance-link">
+						<a href={ exampleLink }>{ exampleName }</a>
+						,&nbsp;
+					</span>
+				);
+			}
+
+			return (
+				<DocsExampleWrapper name={ exampleName } unique={ !! component } url={ exampleLink }>
+					{ example }
+					{ component && <ReadmeViewer readmeFilePath={ example.props.readmeFilePath } /> }
+				</DocsExampleWrapper>
 			);
-		}
+		} );
 
 		return (
-			<DocsExampleWrapper name={ exampleName } unique={ !! component } url={ exampleLink }>
-				{ example }
-				{ component && <ReadmeViewer readmeFilePath={ example.props.readmeFilePath } /> }
-			</DocsExampleWrapper>
-		);
-	} );
+			<div className="design__collection">
+				{ showCounter > 1 &&
+					filter && (
+						<div className="design__instance-links">
+							<span>Showing </span>
+							{ summary }...
+						</div>
+					) }
+				{ /*
+					The entire list of examples for `/devdocs/blocks` and
+					`/devdocs/design` takes a long time to mount, even when
+					loaded, so we render just the first few components so
+					the page change feels faster. The rest of the components
+					are loaded either once scrolled to or in a few seconds
+					after `componentDidMount()` is called.
+				*/ }
+				{ examples.length <= examplesToMount ? (
+					examples
+				) : (
+					<React.Fragment>
+						{ examples.slice( 0, examplesToMount ) }
 
-	return (
-		<div className="design__collection">
-			{ showCounter > 1 &&
-				filter && (
-					<div className="design__instance-links">
-						<span>Showing </span>
-						{ summary }...
-					</div>
+						<LazyRender ref={ this._setLazyRenderRef }>
+							{ shouldRender =>
+								shouldRender ? examples.slice( examplesToMount ) : <Placeholder count={ 10 } />
+							}
+						</LazyRender>
+					</React.Fragment>
 				) }
-			{ examples }
-		</div>
-	);
-};
+			</div>
+		);
+	}
+}
 
 export default Collection;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -158,12 +158,12 @@
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.0"
+        "acorn": "5.5.3"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.5.0",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
+          "version": "5.5.3",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
           "dev": true
         }
       }
@@ -325,12 +325,12 @@
       "dev": true,
       "requires": {
         "ast-types-flow": "0.0.7",
-        "commander": "2.14.1"
+        "commander": "2.15.0"
       },
       "dependencies": {
         "commander": {
-          "version": "2.14.1",
-          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+          "version": "2.15.0",
+          "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg==",
           "dev": true
         }
       }
@@ -529,7 +529,7 @@
       "integrity": "sha1-a8vQOKM3xwYn5/zkQ4+lgYjwk3s=",
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000812",
+        "caniuse-db": "1.0.30000813",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -1385,8 +1385,8 @@
           "version": "2.11.3",
           "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
           "requires": {
-            "caniuse-lite": "1.0.30000812",
-            "electron-to-chromium": "1.3.35"
+            "caniuse-lite": "1.0.30000813",
+            "electron-to-chromium": "1.3.36"
           }
         },
         "semver": {
@@ -1900,7 +1900,7 @@
       "version": "1.3.6",
       "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
       "requires": {
-        "caniuse-db": "1.0.30000812"
+        "caniuse-db": "1.0.30000813"
       }
     },
     "bser": {
@@ -1944,7 +1944,7 @@
         "chownr": "1.0.1",
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
-        "lru-cache": "4.1.1",
+        "lru-cache": "4.1.2",
         "mississippi": "2.0.0",
         "mkdirp": "0.5.1",
         "move-concurrently": "1.0.1",
@@ -2046,12 +2046,12 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000812",
-      "integrity": "sha1-KcKN1pJ+5D6MKrZI5SNqyRbJfWk="
+      "version": "1.0.30000813",
+      "integrity": "sha1-4KHGA/iICteHsqNWUrJzPzKl4po="
     },
     "caniuse-lite": {
-      "version": "1.0.30000812",
-      "integrity": "sha512-j+l55ayQ9BO4Sy9iVfbf99+G+4ddAmkXoiEt73WCW4vJ83usrlHzDkFEnNXe5/swkVqE7YBm5i8M2uRXlx9vWg=="
+      "version": "1.0.30000813",
+      "integrity": "sha512-A8ITSmH5SFdMFdC704ggjg+x2z5PzQmVlG8tavwnfvbC33Q1UYrj0+G+Xm0SNAnd4He36fwUE/KEWytOEchw+A=="
     },
     "cardinal": {
       "version": "1.0.0",
@@ -2586,7 +2586,7 @@
       "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
       "dev": true,
       "requires": {
-        "commander": "2.14.1",
+        "commander": "2.15.0",
         "detective": "4.7.1",
         "glob": "5.0.15",
         "graceful-fs": "4.1.11",
@@ -2598,8 +2598,8 @@
       },
       "dependencies": {
         "commander": {
-          "version": "2.14.1",
-          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+          "version": "2.15.0",
+          "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg==",
           "dev": true
         },
         "glob": {
@@ -2961,7 +2961,7 @@
       "version": "5.1.0",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "4.1.1",
+        "lru-cache": "4.1.2",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
       }
@@ -3405,13 +3405,13 @@
       "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.0",
+        "acorn": "5.5.3",
         "defined": "1.0.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.5.0",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
+          "version": "5.5.3",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
           "dev": true
         }
       }
@@ -3448,7 +3448,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000812",
+        "caniuse-db": "1.0.30000813",
         "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
         "jsonfilter": "1.1.2",
@@ -3604,7 +3604,7 @@
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",
-        "commander": "2.14.1",
+        "commander": "2.15.0",
         "lru-cache": "3.2.0",
         "semver": "5.1.0",
         "sigmund": "1.0.1"
@@ -3616,8 +3616,8 @@
           "dev": true
         },
         "commander": {
-          "version": "2.14.1",
-          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+          "version": "2.15.0",
+          "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg==",
           "dev": true
         },
         "lru-cache": {
@@ -3645,8 +3645,8 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.35",
-      "integrity": "sha1-aTwXz7k4QdOMtZuN8BnRfjVphfA="
+      "version": "1.3.36",
+      "integrity": "sha1-Dqv3Gp6+qQE/scw1o5DgaGJPJ+g="
     },
     "elliptic": {
       "version": "6.4.0",
@@ -4427,13 +4427,13 @@
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.0",
+        "acorn": "5.5.3",
         "acorn-jsx": "3.0.1"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.5.0",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
+          "version": "5.5.3",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
           "dev": true
         }
       }
@@ -4815,7 +4815,7 @@
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.1",
+            "lru-cache": "4.1.2",
             "which": "1.3.0"
           }
         },
@@ -4989,8 +4989,8 @@
       "dev": true
     },
     "flow-parser": {
-      "version": "0.66.0",
-      "integrity": "sha1-vlg/77ARkqpRZEFdMaYkGzVxiYM=",
+      "version": "0.67.1",
+      "integrity": "sha1-GR/tVsz9jQl9ydSH8to7Da50WEk=",
       "dev": true
     },
     "flush-write-stream": {
@@ -5103,8 +5103,8 @@
       }
     },
     "formidable": {
-      "version": "1.1.1",
-      "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak="
+      "version": "1.2.0",
+      "integrity": "sha512-hr9aT30rAi7kf8Q2aaTpSP7xGMhlJ+MdrUDVZs3rxbD3L/K46A86s2VY7qC2D2kGYGBtiT/3j6wTx1eeUq5xAQ=="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -6621,8 +6621,8 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.5.0",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+      "version": "2.6.0",
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
     },
     "html": {
       "version": "1.0.0",
@@ -6834,7 +6834,7 @@
       "integrity": "sha512-vAEAmvbuytZEs/2d0M4WJYCKtzuCt4L2R7jMg57yO50kCmm5uPIj/9EJadum+MBPU7JgyWzDHH5J8PDr7deW4A==",
       "requires": {
         "async": "1.5.2",
-        "commander": "2.14.1",
+        "commander": "2.15.0",
         "create-react-class": "15.6.2",
         "debug": "2.2.0",
         "globby": "6.1.0",
@@ -6854,8 +6854,8 @@
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "commander": {
-          "version": "2.14.1",
-          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+          "version": "2.15.0",
+          "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg=="
         },
         "lodash.assign": {
           "version": "4.2.0",
@@ -8730,7 +8730,7 @@
         "babylon": "6.18.0",
         "colors": "1.1.2",
         "es6-promise": "3.3.1",
-        "flow-parser": "0.66.0",
+        "flow-parser": "0.67.1",
         "lodash": "4.17.5",
         "micromatch": "2.3.11",
         "node-dir": "0.1.8",
@@ -8916,7 +8916,7 @@
       "dev": true,
       "requires": {
         "abab": "1.0.4",
-        "acorn": "5.5.0",
+        "acorn": "5.5.3",
         "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
         "browser-process-hrtime": "0.1.2",
@@ -8944,8 +8944,8 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.5.0",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
+          "version": "5.5.3",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
           "dev": true
         },
         "parse5": {
@@ -9291,8 +9291,8 @@
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "lodash-es": {
-      "version": "4.17.5",
-      "integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw=="
+      "version": "4.17.7",
+      "integrity": "sha512-jzqTi3vk4J5Dxq43cNjB0ekfCjPLHixoY2Sc0WHTo+0r928taLqe/VCt02vY5uQBvg0rdXgL3xWkK4X0MCmZcw=="
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
@@ -9605,8 +9605,8 @@
       }
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "version": "4.1.2",
+      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -10030,11 +10030,6 @@
         "moment": "2.21.0"
       }
     },
-    "moo": {
-      "version": "0.4.3",
-      "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
-      "dev": true
-    },
     "morgan": {
       "version": "1.2.0",
       "integrity": "sha1-jcF6V1mVmPgM16fh47VOcsaJkQ0=",
@@ -10171,11 +10166,10 @@
       }
     },
     "nearley": {
-      "version": "2.12.1",
-      "integrity": "sha512-FQyYKOKm5DgqzJkR6C9GhlRoYdrcRKXJF2qi9Y/4K4Cd2BN4Sglven0LO3dR8w1BQ72Ty5s+/XzA/FtN9Gx50w==",
+      "version": "2.13.0",
+      "integrity": "sha512-ioYYogSaZhFlCpRizQgY3UT3G1qFXmHGY/5ozoFE3dMfiCRAeJfh+IPE3/eh9gCZvqLhPCWb4bLt7Bqzo+1mLQ==",
       "dev": true,
       "requires": {
-        "moo": "0.4.3",
         "nomnom": "1.6.2",
         "railroad-diagrams": "1.0.0",
         "randexp": "0.4.6",
@@ -10359,7 +10353,7 @@
         "readable-stream": "2.3.5",
         "stream-browserify": "2.0.1",
         "stream-http": "2.8.0",
-        "string_decoder": "1.0.3",
+        "string_decoder": "1.1.0",
         "timers-browserify": "2.0.6",
         "tty-browserify": "0.0.0",
         "url": "0.11.0",
@@ -10382,11 +10376,20 @@
             "safe-buffer": "5.1.1",
             "string_decoder": "1.0.3",
             "util-deprecate": "1.0.2"
+          },
+          "dependencies": {
+            "string_decoder": {
+              "version": "1.0.3",
+              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            }
           }
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "version": "1.1.0",
+          "integrity": "sha512-8zQpRF6juocE69ae7CSPmYEGJe4VCXwP6S6dxUWI7i53Gwv54/ec41fiUA+X7BPGGv7fRSQJjBQVa0gomGaOgg==",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -10455,7 +10458,7 @@
           "version": "3.0.1",
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "requires": {
-            "lru-cache": "4.1.1",
+            "lru-cache": "4.1.2",
             "which": "1.3.0"
           }
         },
@@ -10594,7 +10597,7 @@
       "version": "2.4.0",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "2.5.0",
+        "hosted-git-info": "2.6.0",
         "is-builtin-module": "1.0.0",
         "semver": "5.1.0",
         "validate-npm-package-license": "3.0.3"
@@ -12863,6 +12866,13 @@
         }
       }
     },
+    "react-lazily-render": {
+      "version": "1.0.1",
+      "integrity": "sha512-qLGAqO04hoiALBDzRd82sLzZIeoRpUaLTbA9wxL8gfdlzyqQ25oj6uuaMe600UictgFxX395tYaRXsoBUGZXPQ==",
+      "requires": {
+        "scrollparent": "2.0.1"
+      }
+    },
     "react-modal": {
       "version": "3.1.11",
       "integrity": "sha512-Pm4QAc+sWYrfRC+WRERV+JGeGZIfodZGdbvWmjPzeSWqP+EW5ATK4N1U/btNHZWFzKL1UOmkmNtozEQlEg7c+A==",
@@ -12906,7 +12916,7 @@
         "hoist-non-react-statics": "2.5.0",
         "invariant": "2.2.3",
         "lodash": "4.17.5",
-        "lodash-es": "4.17.5",
+        "lodash-es": "4.17.7",
         "loose-envify": "1.3.1",
         "prop-types": "15.5.10"
       },
@@ -13184,7 +13194,7 @@
         "invariant": "2.2.3",
         "is-promise": "2.1.0",
         "lodash": "4.17.5",
-        "lodash-es": "4.17.5",
+        "lodash-es": "4.17.7",
         "prop-types": "15.5.10"
       },
       "dependencies": {
@@ -13580,7 +13590,7 @@
       "dev": true,
       "requires": {
         "lodash.flattendeep": "4.4.0",
-        "nearley": "2.12.1"
+        "nearley": "2.13.0"
       }
     },
     "rtlcss": {
@@ -13781,6 +13791,10 @@
           }
         }
       }
+    },
+    "scrollparent": {
+      "version": "2.0.1",
+      "integrity": "sha1-cV1bnMV3YPsivczDvvtb/gaxoxc="
     },
     "scss-tokenizer": {
       "version": "0.2.3",
@@ -14916,7 +14930,7 @@
         "debug": "2.2.0",
         "extend": "3.0.1",
         "form-data": "1.0.0-rc4",
-        "formidable": "1.1.1",
+        "formidable": "1.2.0",
         "methods": "1.1.2",
         "mime": "1.3.4",
         "qs": "6.5.1",
@@ -16422,7 +16436,7 @@
       "version": "3.10.0",
       "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
       "requires": {
-        "acorn": "5.5.0",
+        "acorn": "5.5.3",
         "acorn-dynamic-import": "2.0.2",
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
@@ -16447,8 +16461,8 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.5.0",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g=="
+          "version": "5.5.3",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
         },
         "ajv-keywords": {
           "version": "2.1.1",
@@ -16669,9 +16683,9 @@
       "integrity": "sha1-Y+2G63HMTNqG9o5oWoRTC6ASZEk=",
       "dev": true,
       "requires": {
-        "acorn": "5.5.0",
+        "acorn": "5.5.3",
         "chalk": "1.1.3",
-        "commander": "2.14.1",
+        "commander": "2.15.0",
         "ejs": "2.5.7",
         "express": "4.16.2",
         "filesize": "3.6.0",
@@ -16692,8 +16706,8 @@
           }
         },
         "acorn": {
-          "version": "5.5.0",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
+          "version": "5.5.3",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
           "dev": true
         },
         "body-parser": {
@@ -16731,8 +16745,8 @@
           }
         },
         "commander": {
-          "version": "2.14.1",
-          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+          "version": "2.15.0",
+          "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg==",
           "dev": true
         },
         "content-disposition": {

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "react-day-picker": "6.2.1",
     "react-dom": "16.2.0",
     "react-hot-loader": "1.3.1",
+    "react-lazily-render": "1.0.1",
     "react-modal": "3.1.11",
     "react-pure-render": "1.0.2",
     "react-redux": "5.0.6",


### PR DESCRIPTION
This aims to fix #22756 by reducing the delay in page changes on the devdocs pages. Especially `/devdocs/blocks` and `/devdocs/design`.

------

Originally posted in #22756:

I talked to @nb about this but it seems the main issue is around the (very large) number of components mounted inside these pages (`/devdocs/blocks` and `/devdocs/design`). Pagination through the components wouldn't be a good UX so continuing to load all of the examples on the page is what I aimed to keep.

First off I tried using something like [`react-virtualized`](https://github.com/bvaughn/react-virtualized) to load only the content on screen but because the components are of varying heights that lead to only a ~10-20% reduction in mounting time and a worse scrolling UX. It also meant the entire page would never be mounted at once so in-browser "find" UX was ruined.

Using [`react-lazily-render`](https://github.com/jameslnewell/react-lazily-render) turned out to work much better, and using it means we can load the first X number of components immediately (basically enough to fill the viewport) so the component mounts in a fraction of the time it did in the past (for reference, it mounts faster using React development environment with the change than it currently does in production with the old "mount everything at once" approach). We can then load the rest of the components either: onScroll or after a few seconds with a timeout. The underlying code used is a bit gnarly but the API of the Devdocs `Collection` remains the same with the heavy-lifting/lazy-loading happening transparently, so this approach will scale if more components/pages are added.