### PR TITLE
Components: Add gap between icon and button text

### DIFF
--- a/client/components/button/docs/example.jsx
+++ b/client/components/button/docs/example.jsx
@@ -59,7 +59,8 @@ class Buttons extends React.PureComponent {
 					<div className="docs__design-button-row">
 						<Button>Button</Button>
 						<Button>
-							<Gridicon icon="heart" /> Icon button
+							<Gridicon icon="heart" />
+							<span className="button-text">Icon button</span>
 						</Button>
 						<Button>
 							<Gridicon icon="plugins" />

--- a/client/components/button/docs/example.jsx
+++ b/client/components/button/docs/example.jsx
@@ -70,7 +70,8 @@ class Buttons extends React.PureComponent {
 					<div className="docs__design-button-row">
 						<Button scary>Scary button</Button>
 						<Button scary>
-							<Gridicon icon="globe" /> Scary icon button
+							<Gridicon icon="globe" />
+							<span className="button-text">Scary icon button</span>
 						</Button>
 						<Button scary>
 							<Gridicon icon="pencil" />
@@ -82,7 +83,8 @@ class Buttons extends React.PureComponent {
 					<div className="docs__design-button-row">
 						<Button primary>Primary button</Button>
 						<Button primary>
-							<Gridicon icon="camera" /> Primary icon button
+							<Gridicon icon="camera" />
+							<span className="button-text">Primary icon button</span>
 						</Button>
 						<Button primary>
 							<Gridicon icon="time" />
@@ -96,7 +98,8 @@ class Buttons extends React.PureComponent {
 							Primary scary button
 						</Button>
 						<Button primary scary>
-							<Gridicon icon="user-circle" /> Primary scary icon button
+							<Gridicon icon="user-circle" />
+							<span className="button-text">Primary scary icon button</span>
 						</Button>
 						<Button primary scary>
 							<Gridicon icon="cart" />
@@ -107,53 +110,65 @@ class Buttons extends React.PureComponent {
 					</div>
 					<div className="docs__design-button-row">
 						<Button borderless>
-							<Gridicon icon="cross" /> Remove
+							<Gridicon icon="cross" />
+							<span className="button-text">Remove</span>
 						</Button>
 						<Button borderless>
-							<Gridicon icon="trash" /> Trash
+							<Gridicon icon="trash" />
+							<span className="button-text">Trash</span>
 						</Button>
 						<Button borderless>
-							<Gridicon icon="link-break" /> Disconnect
+							<Gridicon icon="link-break" />
+							<span className="button-text">Disconnect</span>
 						</Button>
 						<Button borderless>
 							<Gridicon icon="trash" />
 						</Button>
 						<Button borderless disabled>
-							<Gridicon icon="cross" /> Remove
+							<Gridicon icon="cross" />
+							<span className="button-text">Remove</span>
 						</Button>
 					</div>
 					<div className="docs__design-button-row">
 						<Button borderless primary>
-							<Gridicon icon="cross" /> Remove
+							<Gridicon icon="cross" />
+							<span className="button-text">Remove</span>
 						</Button>
 						<Button borderless primary>
-							<Gridicon icon="trash" /> Trash
+							<Gridicon icon="trash" />
+							<span className="button-text">Trash</span>
 						</Button>
 						<Button borderless primary>
-							<Gridicon icon="link-break" /> Disconnect
+							<Gridicon icon="link-break" />
+							<span className="button-text">Disconnect</span>
 						</Button>
 						<Button borderless primary>
 							<Gridicon icon="trash" />
 						</Button>
 						<Button borderless primary disabled>
-							<Gridicon icon="cross" /> Remove
+							<Gridicon icon="cross" />
+							<span className="button-text">Remove</span>
 						</Button>
 					</div>
 					<div className="docs__design-button-row">
 						<Button borderless scary>
-							<Gridicon icon="cross" /> Remove
+							<Gridicon icon="cross" />
+							<span className="button-text">Remove</span>
 						</Button>
 						<Button borderless scary>
-							<Gridicon icon="trash" /> Trash
+							<Gridicon icon="trash" />
+							<span className="button-text">Trash</span>
 						</Button>
 						<Button borderless scary>
-							<Gridicon icon="link-break" /> Disconnect
+							<Gridicon icon="link-break" />
+							<span className="button-text">Disconnect</span>
 						</Button>
 						<Button borderless scary>
 							<Gridicon icon="trash" />
 						</Button>
 						<Button borderless scary disabled>
-							<Gridicon icon="cross" /> Remove
+							<Gridicon icon="cross" />
+							<span className="button-text">Remove</span>
 						</Button>
 					</div>
 					<div className="docs__design-button-row">
@@ -165,7 +180,8 @@ class Buttons extends React.PureComponent {
 							Primary busy button
 						</Button>
 						<Button primary scary busy>
-							<Gridicon icon="trash" /> Primary scary busy button
+							<Gridicon icon="trash" />
+							<span className="button-text">Primary scary busy button</span>
 						</Button>
 					</div>
 				</Card>
@@ -176,7 +192,8 @@ class Buttons extends React.PureComponent {
 					<div className="docs__design-button-row">
 						<Button compact>Compact button</Button>
 						<Button compact>
-							<Gridicon icon="heart" /> Compact icon button
+							<Gridicon icon="heart" />
+							<span className="button-text">Compact icon button</span>
 						</Button>
 						<Button compact>
 							<Gridicon icon="plugins" />
@@ -190,7 +207,8 @@ class Buttons extends React.PureComponent {
 							Compact scary button
 						</Button>
 						<Button compact scary>
-							<Gridicon icon="globe" /> Compact scary icon button
+							<Gridicon icon="globe" />
+							<span className="button-text">Compact scary icon button</span>
 						</Button>
 						<Button compact scary>
 							<Gridicon icon="pencil" />
@@ -204,7 +222,8 @@ class Buttons extends React.PureComponent {
 							Compact primary button
 						</Button>
 						<Button compact primary>
-							<Gridicon icon="camera" /> Compact primary icon button
+							<Gridicon icon="camera" />
+							<span className="button-text">Compact primary icon button</span>
 						</Button>
 						<Button compact primary>
 							<Gridicon icon="time" />
@@ -218,7 +237,8 @@ class Buttons extends React.PureComponent {
 							Compact primary scary button
 						</Button>
 						<Button compact primary scary>
-							<Gridicon icon="user-circle" /> Compact primary scary icon button
+							<Gridicon icon="user-circle" />
+							<span className="button-text">Compact primary scary icon button</span>
 						</Button>
 						<Button compact primary scary>
 							<Gridicon icon="cart" />
@@ -229,53 +249,65 @@ class Buttons extends React.PureComponent {
 					</div>
 					<div className="docs__design-button-row">
 						<Button compact borderless>
-							<Gridicon icon="cross" /> Remove
+							<Gridicon icon="cross" />
+							<span className="button-text">Remove</span>
 						</Button>
 						<Button compact borderless>
-							<Gridicon icon="trash" /> Trash
+							<Gridicon icon="trash" />
+							<span className="button-text">Trash</span>
 						</Button>
 						<Button compact borderless>
-							<Gridicon icon="link-break" /> Disconnect
+							<Gridicon icon="link-break" />
+							<span className="button-text">Disconnect</span>
 						</Button>
 						<Button compact borderless>
 							<Gridicon icon="trash" />
 						</Button>
 						<Button compact borderless disabled>
-							<Gridicon icon="cross" /> Remove
+							<Gridicon icon="cross" />
+							<span className="button-text">Remove</span>
 						</Button>
 					</div>
 					<div className="docs__design-button-row">
 						<Button compact primary borderless>
-							<Gridicon icon="cross" /> Remove
+							<Gridicon icon="cross" />
+							<span className="button-text">Remove</span>
 						</Button>
 						<Button compact primary borderless>
-							<Gridicon icon="trash" /> Trash
+							<Gridicon icon="trash" />
+							<span className="button-text">Trash</span>
 						</Button>
 						<Button compact primary borderless>
-							<Gridicon icon="link-break" /> Disconnect
+							<Gridicon icon="link-break" />
+							<span className="button-text">Disconnect</span>
 						</Button>
 						<Button compact primary borderless>
 							<Gridicon icon="trash" />
 						</Button>
 						<Button compact primary borderless disabled>
-							<Gridicon icon="cross" /> Remove
+							<Gridicon icon="cross" />
+							<span className="button-text">Remove</span>
 						</Button>
 					</div>
 					<div className="docs__design-button-row">
 						<Button compact borderless scary>
-							<Gridicon icon="cross" /> Remove
+							<Gridicon icon="cross" />
+							<span className="button-text">Remove</span>
 						</Button>
 						<Button compact borderless scary>
-							<Gridicon icon="trash" /> Trash
+							<Gridicon icon="trash" />
+							<span className="button-text">Trash</span>
 						</Button>
 						<Button compact borderless scary>
-							<Gridicon icon="link-break" /> Disconnect
+							<Gridicon icon="link-break" />
+							<span className="button-text">Disconnect</span>
 						</Button>
 						<Button compact borderless scary>
 							<Gridicon icon="trash" />
 						</Button>
 						<Button compact borderless scary disabled>
-							<Gridicon icon="cross" /> Remove
+							<Gridicon icon="cross" />
+							<span className="button-text">Remove</span>
 						</Button>
 					</div>
 					<div className="docs__design-button-row">
@@ -289,7 +321,8 @@ class Buttons extends React.PureComponent {
 							Primary busy button
 						</Button>
 						<Button compact primary scary busy>
-							<Gridicon icon="trash" /> Compact primary scary busy button
+							<Gridicon icon="trash" />
+							<span className="button-text">Compact primary scary busy button</span>
 						</Button>
 					</div>
 				</Card>

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -75,7 +75,6 @@ button {
 		.gridicon {
 			top: 5px;
 			margin-top: -8px;
-			margin-right: 4px;
 		}
 		// Make the left margin of the small plus icon visually less huge
 		.gridicons-plus-small {
@@ -105,6 +104,10 @@ button {
 		width: 18px;
 		height: 18px;
 	}
+}
+
+.button-text {
+	margin-left: 4px;
 }
 
 // Primary buttons

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -103,11 +103,11 @@ button {
 		margin-top: -2px;
 		width: 18px;
 		height: 18px;
-	}
-}
 
-.button-text {
-	margin-left: 4px;
+		&:not(:last-child) {
+			margin-right: 4px;
+		}
+	}
 }
 
 // Primary buttons

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -55,7 +55,9 @@ class PeopleListSectionHeader extends Component {
 				{ siteLink && (
 					<Button compact href={ siteLink } className="people-list-section-header__add-button">
 						<Gridicon icon="user-add" />
-						{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
+						<span className="people-list-section-header__button-text">
+							{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
+						</span>
 					</Button>
 				) }
 			</SectionHeader>

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -55,9 +55,7 @@ class PeopleListSectionHeader extends Component {
 				{ siteLink && (
 					<Button compact href={ siteLink } className="people-list-section-header__add-button">
 						<Gridicon icon="user-add" />
-						<span className="people-list-section-header__button-text">
-							{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
-						</span>
+						{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
 					</Button>
 				) }
 			</SectionHeader>


### PR DESCRIPTION
I would like to reopen the discussion in #16371 to see a consensus on how to fix this issue.

In #15387, the gap between the icon and the button text was added to the icon as a margin. As a result, the icon is no longer centre when there is no button text.

<img width="234" alt="screen shot 2018-03-07 at 03 46 08" src="https://user-images.githubusercontent.com/908665/37072572-211cb6e6-21ba-11e8-87bf-586d1065236c.png">

The lack of a tag around a button text makes this tricky to fix with just CSS.

@folletto suggested a number of ways to tackle this issue here: https://github.com/Automattic/wp-calypso/pull/16371#issuecomment-321242727

I'm leaning towards the idea of adding a `span` around a button text. What's your opinion?

cc @folletto @drw158
