### PR TITLE
Reader: Fix tab and text input overlap in Search

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -17,7 +17,7 @@
 	background-color: $white;
 	position: fixed;
 	top: 0;
-	margin-top: 47px; // masterbar is exactly 47px
+	margin-top: 47px; // Masterbar is exactly 47px
 	padding-top: 30px;
 	z-index: 20;
 	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements text aliasing in Safari
@@ -30,6 +30,15 @@
 .search-stream .search-stream__input-card.card {
 	box-shadow: 0 0 0 2px $gray-lighten-20, 0 1px 2px $gray-lighten-20;
 	margin-bottom: 0;
+
+	.search__input-fade .search__input {
+		width: calc( 100% - 135px );
+	}
+
+	.search__input-fade::before {
+		right: 135px;
+		width: 35px;
+	}
 }
 
 .search-stream__input-card.card {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/12821

**Before:**

This isn't great UX because I am unable to see what I'm typing.
![screenshot 2018-03-06 20 24 32](https://user-images.githubusercontent.com/4924246/37073543-6b32ac74-217c-11e8-974e-e83bc55a29b9.png)

**After:**

We shorten the text input field so it doesn't extend past to where the sorter tabs are and you can still see the text you're typing.
![screenshot 2018-03-06 20 24 39](https://user-images.githubusercontent.com/4924246/37073544-6b4f221e-217c-11e8-8732-b1fc7a8597a4.png)

But I ran into an issue where the fade gets moved to the end of the placeholder text: /cc @bluefuton 
![screenshot 2018-03-06 20 27 14](https://user-images.githubusercontent.com/4924246/37073603-c812f688-217c-11e8-8d92-0dd76757dae1.png)

Possible solutions:

- Add a `is-active` to `search__input-fade` class so the narrower text input is only applied when it's active or,
- Move `search-stream__sort-picker` right after `search__input-fade`. This way, the sorter doesn't need to be absolutely positioned:

![screenshot 2018-03-06 20 30 30](https://user-images.githubusercontent.com/4924246/37073674-3bd03ae0-217d-11e8-9c58-d16786c9e454.png)

