### PR TITLE
Always fire calypso_purchases_cancel_form_submit on submit

### DIFF
--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -268,8 +268,6 @@ class CancelPurchaseButton extends Component {
 
 		this.props.clearPurchases();
 
-		this.recordEvent( 'calypso_purchases_cancel_form_submit' );
-
 		page.redirect( purchasesRoot );
 	};
 
@@ -301,6 +299,8 @@ class CancelPurchaseButton extends Component {
 				enrichedSurveyData( surveyData, moment(), selectedSite, purchase )
 			);
 		}
+
+		this.recordEvent( 'calypso_purchases_cancel_form_submit' );
 
 		if ( refundable ) {
 			cancelAndRefundPurchase(

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -165,8 +165,6 @@ class RemovePurchase extends Component {
 		const { isDomainOnlySite, selectedSite, translate } = this.props;
 
 		if ( ! isDomainRegistration( purchase ) && config.isEnabled( 'upgrades/removal-survey' ) ) {
-			this.recordEvent( 'calypso_purchases_cancel_form_submit' );
-
 			const survey = wpcom
 				.marketing()
 				.survey( 'calypso-remove-purchase', this.props.selectedSite.ID );
@@ -196,6 +194,8 @@ class RemovePurchase extends Component {
 				} )
 				.catch( err => debug( err ) ); // shouldn't get here
 		}
+
+		this.recordEvent( 'calypso_purchases_cancel_form_submit' );
 
 		this.props.removePurchase( purchase.id, user.get().ID ).then( () => {
 			const productName = getName( purchase );


### PR DESCRIPTION
The `calypso_purchases_cancel_form_submit` tracks event is not being consistently recorded when the 'submit' button is clicked to complete the survey and initiate the backend process of actually removing/cancelling a product.

This change ensures that all three cancellation flows will result in a `calypso_purchases_cancel_form_submit event` immediately _before_ starting the backend process (ie. indicating the intention to remove regardless of whether that process is successful).

# Testing

There are three cancellation scenarios:

* remove a product purchased with credits (ie. no auto renew and not eligible for refund)
* cancel a product purchased recently with a credit card (ie. auto renew and eligible for refund)
* cancel a product purchased  less recently (ie. auto renew enabled and no longer eligible for refund)

Each of the above scenarios should result in a calypso_purchases_cancel_form_submit tracks event.