### PR TITLE
Add notice for concierge sessions

### DIFF
--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import Notice from 'components/notice';
 import CompactCard from 'components/card/compact';
 import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -22,11 +23,14 @@ import Site from 'blocks/site';
 import { localize } from 'i18n-calypso';
 import { updateConciergeSignupForm } from 'state/concierge/actions';
 import { getConciergeSignupForm, getUserSettings } from 'state/selectors';
+import { getCurrentUserLocale } from 'state/current-user/selectors';
 import PrimaryHeader from '../shared/primary-header';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions'; /** @format */
+import { isDefaultLocale } from 'lib/i18n-utils';
 
 class InfoStep extends Component {
 	static propTypes = {
+		currentUserLocale: PropTypes.string.isRequired,
 		signupForm: PropTypes.object,
 		userSettings: PropTypes.object,
 		onComplete: PropTypes.func.isRequired,
@@ -66,11 +70,19 @@ class InfoStep extends Component {
 	}
 
 	render() {
-		const { signupForm: { firstname, lastname, message, timezone }, translate } = this.props;
+		const {
+			currentUserLocale,
+			signupForm: { firstname, lastname, message, timezone },
+			translate,
+		} = this.props;
+		const notice = ! isDefaultLocale( currentUserLocale )
+			? translate( 'All Concierge Sessions are in English (Spanish is not available).' )
+			: null;
 
 		return (
 			<div>
 				<PrimaryHeader />
+				{ notice && <Notice showDismiss={ false } text={ notice } /> }
 				<CompactCard className="book__info-step-site-block">
 					<Site siteId={ this.props.site.ID } />
 				</CompactCard>
@@ -120,6 +132,9 @@ class InfoStep extends Component {
 							onChange={ this.setFieldValue }
 							value={ message }
 						/>
+						<FormSettingExplanation>
+							{ translate( 'Please respond in English.' ) }
+						</FormSettingExplanation>
 					</FormFieldset>
 
 					<FormButton
@@ -138,6 +153,7 @@ class InfoStep extends Component {
 
 export default connect(
 	state => ( {
+		currentUserLocale: getCurrentUserLocale( state ),
 		signupForm: getConciergeSignupForm( state ),
 		userSettings: getUserSettings( state ),
 	} ),

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -6,6 +6,8 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import config from 'config';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,8 +27,8 @@ import { updateConciergeSignupForm } from 'state/concierge/actions';
 import { getConciergeSignupForm, getUserSettings } from 'state/selectors';
 import { getCurrentUserLocale } from 'state/current-user/selectors';
 import PrimaryHeader from '../shared/primary-header';
-import { recordTracksEvent } from 'state/analytics/actions'; /** @format */
-import { isDefaultLocale, getLanguage } from 'lib/i18n-utils';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { getLanguage } from 'lib/i18n-utils';
 
 class InfoStep extends Component {
 	static propTypes = {
@@ -76,16 +78,18 @@ class InfoStep extends Component {
 			translate,
 		} = this.props;
 		const language = getLanguage( currentUserLocale ).name;
-		const notice = ! isDefaultLocale( currentUserLocale )
-			? translate( 'All Concierge Sessions are in English (%(language)s is not available)', {
-					args: { language },
-				} )
-			: null;
+		const isEnglish = includes( config( 'english_locales' ), currentUserLocale );
+		const noticeText = translate(
+			'All Concierge Sessions are in English (%(language)s is not available)',
+			{
+				args: { language },
+			}
+		);
 
 		return (
 			<div>
 				<PrimaryHeader />
-				{ notice && <Notice showDismiss={ false } text={ notice } /> }
+				{ ! isEnglish && <Notice showDismiss={ false } text={ noticeText } /> }
 				<CompactCard className="book__info-step-site-block">
 					<Site siteId={ this.props.site.ID } />
 				</CompactCard>
@@ -135,9 +139,12 @@ class InfoStep extends Component {
 							onChange={ this.setFieldValue }
 							value={ message }
 						/>
-						<FormSettingExplanation>
-							{ translate( 'Please respond in English.' ) }
-						</FormSettingExplanation>
+
+						{ ! isEnglish && (
+							<FormSettingExplanation>
+								{ translate( 'Please respond in English.' ) }
+							</FormSettingExplanation>
+						) }
 					</FormFieldset>
 
 					<FormButton

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -26,7 +26,7 @@ import { getConciergeSignupForm, getUserSettings } from 'state/selectors';
 import { getCurrentUserLocale } from 'state/current-user/selectors';
 import PrimaryHeader from '../shared/primary-header';
 import { recordTracksEvent } from 'state/analytics/actions'; /** @format */
-import { isDefaultLocale } from 'lib/i18n-utils';
+import { isDefaultLocale, getLanguage } from 'lib/i18n-utils';
 
 class InfoStep extends Component {
 	static propTypes = {
@@ -75,8 +75,11 @@ class InfoStep extends Component {
 			signupForm: { firstname, lastname, message, timezone },
 			translate,
 		} = this.props;
+		const language = getLanguage( currentUserLocale ).name;
 		const notice = ! isDefaultLocale( currentUserLocale )
-			? translate( 'All Concierge Sessions are in English (Spanish is not available).' )
+			? translate( 'All Concierge Sessions are in English (%(language)s is not available)', {
+					args: { language },
+				} )
 			: null;
 
 		return (

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -35,7 +35,8 @@
 	"google_oauth_client_id": "108380595987-j91sm1alavcdgd81i2655kp8q1lbtvrc.apps.googleusercontent.com",
 	"facebook_app_id": "611241942420191",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"support_locales": [ "en", "es", "pt-br" ],
+    "support_locales": [ "en", "es", "pt-br" ],
+    "english_locales": [ "en", "en-gb"],
     "languages": [
         { "value": 2, "langSlug": "af", "name": "Afrikaans", "wpLocale": "af", "territories": [ "002" ] },
         { "value": 418, "langSlug": "als", "name": "Alemannisch", "wpLocale": "", "territories": [ "155" ] },


### PR DESCRIPTION
## Summary
This PR adds a more visible notice to inform customers that we only offer concierge sessions in english.

Before for `es` customers: https://cloudup.com/cCSfyghGCSc
After for `es` customers: https://cloudup.com/cvYiegaZKIs

More context: 587-hg-gh

## Testing
1. Make sure booking, rescheduling and cancelling a session works & looks as expected
2. Change your language
3. Make sure the notice is present on the first step