### PR TITLE
Reader: lower photo only card character limit to 85

### DIFF
--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -44,6 +44,7 @@ import makeContentLinksSafe from 'lib/post-normalizer/rule-content-make-links-sa
  */
 export const READER_CONTENT_WIDTH = 800,
 	PHOTO_ONLY_MIN_WIDTH = 440,
+	PHOTO_ONLY_MAX_CHARACTER_COUNT = 85,
 	GALLERY_MIN_IMAGES = 4,
 	GALLERY_MIN_IMAGE_WIDTH = 100;
 
@@ -59,7 +60,7 @@ export function imageIsBigEnoughForGallery( image ) {
 	return image.width >= GALLERY_MIN_IMAGE_WIDTH;
 }
 
-const hasShortContent = post => getCharacterCount( post ) <= 100;
+const hasShortContent = post => getCharacterCount( post ) <= PHOTO_ONLY_MAX_CHARACTER_COUNT;
 
 /**
  * Attempt to classify the post into a display type


### PR DESCRIPTION
In p5PDj3-4rZ-p2, a user reports that they're seeing photo cards in their stream when they'd expect standard cards.

The user has a summary-only feed, and the "miscategorised" posts are in the 85-100 character range after HTML is stripped.

This PR experiments with a slightly lower max character limit for photo cards (85 instead of 100).

Before:

![screen shot 2018-03-07 at 12 23 08](https://user-images.githubusercontent.com/17325/37092080-52f6b9b2-2202-11e8-9ec7-89566e5f4d1c.png)

After:

![screen shot 2018-03-07 at 12 22 43](https://user-images.githubusercontent.com/17325/37092084-56d81238-2202-11e8-9d4c-dc3d4526b6b3.png)

### To test

Load http://calypso.localhost:3000/read/feeds/52117030?at=2018-03-07 and ensure that the "Chicago Passed An Anti-Corruption..." post is displaying as a standard card.