### PR TITLE
Replace plan checks with feature checks

### DIFF
--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -15,9 +15,9 @@ import { connect } from 'react-redux';
 import QueryMediaStorage from 'components/data/query-media-storage';
 import { getMediaStorage } from 'state/sites/media-storage/selectors';
 import { getSitePlanSlug, getSiteSlug, isJetpackSite } from 'state/sites/selectors';
-import { planHasFeature } from 'lib/plans';
-import { FEATURE_UNLIMITED_STORAGE } from 'lib/plans/constants';
 import PlanStorageBar from './bar';
+import { planHasFeature } from '../../lib/plans';
+import { FEATURE_UNLIMITED_STORAGE } from '../../lib/plans/constants';
 
 export class PlanStorage extends Component {
 	static propTypes = {


### PR DESCRIPTION
Removes a few instances of `sitePlanSlug === PLAN_BUSINESS` in favor of checking if `planHasFeature`.

**Test plan:**
Go to Media page on sites with different plans and confirm that business plan sites have no storage counter while other plans have it