### PR TITLE
Google My Business: Fix incorrect Track events

### DIFF
--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -27,13 +27,13 @@ class SelectBusinessType extends Component {
 
 	trackCreateMyListingClick = () => {
 		this.props.recordTracksEvent(
-			'calypso_test_google_my_business_select_business_type_create_my_listing_button_click'
+			'calypso_google_my_business_select_business_type_create_my_listing_button_click'
 		);
 	};
 
 	trackOptimizeYourSEOClick = () => {
 		this.props.recordTracksEvent(
-			'calypso_test_google_my_business_select_business_type_optimize_your_seo_button_click'
+			'calypso_google_my_business_select_business_type_optimize_your_seo_button_click'
 		);
 	};
 


### PR DESCRIPTION
This pull request fixes two Track events that were forgotten in https://github.com/Automattic/wp-calypso/pull/22868. These events are fired by buttons on the new `Google My Business` page:

<img width="624" alt="screenshot" src="https://user-images.githubusercontent.com/594356/37097536-002bc758-221c-11e8-9409-e4c7d5f5dfd8.png">

#### Testing instructions

You can check that Track events are correctly triggered by executing the following command in your browser's console, and then reloading the page:

```
localStorage.setItem( 'debug', 'calypso:analytics:tracks' );
```

1. Run `git checkout fix/google-my-business-stats` and start your server, or open a [live branch](https://calypso.live/?branch=fix/google-my-business-stats)
2. Log in to an account with a site that satisfies all requirements (see list in p9j7e4-8F-p2)
2. Open the [`Stats` page](http://calypso.localhost:3000/stats)
3. Click the `Start Now` button
4. Click the `Create My Listing` button
5. Assert that a `calypso_google_my_business_select_business_type_create_my_listing_button_click` event was fired
6. Click the `Optimize Your SEO` button
7. Assert that a `calypso_google_my_business_select_business_type_optimize_your_seo_button_click` event was fired

#### Reviews

- [ ] Code
- [ ] Product
- [ ] Tests