### PR TITLE
Jetpack Connect: Fix URL form spinner

### DIFF
--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -68,8 +68,6 @@ export class JetpackConnectMain extends Component {
 		url: PropTypes.string,
 	};
 
-	redirecting = false;
-
 	/* eslint-disable indent */
 	state = this.props.url
 		? {
@@ -116,11 +114,11 @@ export class JetpackConnectMain extends Component {
 		if (
 			this.getStatus() === NOT_CONNECTED_JETPACK &&
 			this.isCurrentUrlFetched() &&
-			! this.redirecting
+			! this.state.redirecting
 		) {
 			return this.goToRemoteAuth( this.state.currentUrl );
 		}
-		if ( this.getStatus() === ALREADY_OWNED && ! this.redirecting ) {
+		if ( this.getStatus() === ALREADY_OWNED && ! this.state.redirecting ) {
 			if ( this.props.isMobileAppFlow ) {
 				return this.redirectToMobileApp( 'already-connected' );
 			}
@@ -144,8 +142,8 @@ export class JetpackConnectMain extends Component {
 
 	makeSafeRedirectionFunction( func ) {
 		return url => {
-			if ( ! this.redirecting ) {
-				this.redirecting = true;
+			if ( ! this.state.redirecting ) {
+				this.setState( { redirecting: true } );
 				func( url );
 			}
 		};
@@ -274,10 +272,6 @@ export class JetpackConnectMain extends Component {
 			this.isCurrentUrlFetched() &&
 			this.props.jetpackConnectSite.data[ propName ]
 		);
-	}
-
-	isRedirecting() {
-		return this.props.jetpackConnectSite && this.redirecting && this.isCurrentUrlFetched();
 	}
 
 	getStatus() {
@@ -460,7 +454,7 @@ export class JetpackConnectMain extends Component {
 					onSubmit={ this.handleUrlSubmit }
 					isError={ this.getStatus() }
 					isFetching={
-						this.isCurrentUrlFetching() || this.isRedirecting() || this.state.waitingForSites
+						this.isCurrentUrlFetching() || this.state.redirecting || this.state.waitingForSites
 					}
 					isInstall={ this.isInstall() }
 				/>

--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -128,7 +128,7 @@ class JetpackConnectSiteUrlInput extends PureComponent {
 						onKeyUp={ this.handleKeyPress }
 						value={ url }
 					/>
-					{ isFetching ? <Spinner duration={ 30 } /> : null }
+					{ isFetching ? <Spinner /> : null }
 				</div>
 				<Card className="jetpack-connect__connect-button-card">
 					{ this.renderTermsOfServiceLink() }

--- a/client/jetpack-connect/test/main.js
+++ b/client/jetpack-connect/test/main.js
@@ -61,9 +61,7 @@ describe( 'JetpackConnectMain', () => {
 
 	describe( 'makeSafeRedirectionFunction', () => {
 		test( 'should make a function that can calls the wrapper function', () => {
-			const component = shallow(
-				<JetpackConnectMain { ...REQUIRED_PROPS } translate={ jest.fn() } />
-			);
+			const component = shallow( <JetpackConnectMain { ...REQUIRED_PROPS } /> );
 			const innerFunc = jest.fn();
 			const wrapperFunc = component.instance().makeSafeRedirectionFunction( innerFunc );
 			expect( () => wrapperFunc() ).not.toThrow();
@@ -71,9 +69,7 @@ describe( 'JetpackConnectMain', () => {
 
 		test( 'should protect against multiple calls', () => {
 			const innerFunc = jest.fn();
-			const component = shallow(
-				<JetpackConnectMain { ...REQUIRED_PROPS } translate={ jest.fn() } />
-			);
+			const component = shallow( <JetpackConnectMain { ...REQUIRED_PROPS } /> );
 			const wrapperFunc = component.instance().makeSafeRedirectionFunction( innerFunc );
 			wrapperFunc();
 			wrapperFunc();

--- a/client/jetpack-connect/test/main.js
+++ b/client/jetpack-connect/test/main.js
@@ -7,8 +7,10 @@
  * External dependencies
  */
 import page from 'page';
+import React from 'react';
 import { externalRedirect } from 'lib/route';
 import { noop } from 'lodash';
+import { mount } from 'enzyme';
 
 /**
  * Internal dependencies
@@ -52,21 +54,21 @@ describe( 'JetpackConnectMain', () => {
 	} );
 
 	describe( 'makeSafeRedirectionFunction', () => {
-		const component = new JetpackConnectMain( REQUIRED_PROPS );
-
-		beforeEach( () => {
-			component.redirecting = false;
-		} );
-
-		test( 'should make a function that can calls the wrappe function', () => {
+		test( 'should make a function that can calls the wrapper function', () => {
+			const component = mount(
+				<JetpackConnectMain { ...REQUIRED_PROPS } translate={ jest.fn() } />
+			);
 			const innerFunc = jest.fn();
-			const wrapperFunc = component.makeSafeRedirectionFunction( innerFunc );
+			const wrapperFunc = component.instance().makeSafeRedirectionFunction( innerFunc );
 			expect( () => wrapperFunc() ).not.toThrow();
 		} );
 
 		test( 'should protect against multiple calls', () => {
 			const innerFunc = jest.fn();
-			const wrapperFunc = component.makeSafeRedirectionFunction( innerFunc );
+			const component = mount(
+				<JetpackConnectMain { ...REQUIRED_PROPS } translate={ jest.fn() } />
+			);
+			const wrapperFunc = component.instance().makeSafeRedirectionFunction( innerFunc );
 			wrapperFunc();
 			wrapperFunc();
 			wrapperFunc();
@@ -78,7 +80,6 @@ describe( 'JetpackConnectMain', () => {
 		const component = new JetpackConnectMain( REQUIRED_PROPS );
 
 		beforeEach( () => {
-			component.redirecting = false;
 			component.props.recordTracksEvent.mockReset();
 			externalRedirect.mockReset();
 		} );
@@ -103,7 +104,6 @@ describe( 'JetpackConnectMain', () => {
 		const component = new JetpackConnectMain( REQUIRED_PROPS );
 
 		beforeEach( () => {
-			component.redirecting = false;
 			component.props.recordTracksEvent.mockReset();
 			externalRedirect.mockReset();
 		} );
@@ -128,7 +128,6 @@ describe( 'JetpackConnectMain', () => {
 		const component = new JetpackConnectMain( REQUIRED_PROPS );
 
 		beforeEach( () => {
-			component.redirecting = false;
 			component.props.recordTracksEvent.mockReset();
 			externalRedirect.mockReset();
 		} );

--- a/client/jetpack-connect/test/main.js
+++ b/client/jetpack-connect/test/main.js
@@ -9,8 +9,8 @@
 import page from 'page';
 import React from 'react';
 import { externalRedirect } from 'lib/route';
-import { noop } from 'lodash';
-import { mount } from 'enzyme';
+import { identity, noop } from 'lodash';
+import { shallow } from 'enzyme';
 
 /**
  * Internal dependencies
@@ -24,7 +24,8 @@ const REQUIRED_PROPS = {
 	getJetpackSiteByUrl: noop,
 	isRequestingSites: false,
 	jetpackConnectSite: undefined,
-	recordTracksEvent: jest.fn(),
+	recordTracksEvent: noop,
+	translate: identity,
 };
 
 jest.mock( 'page', () => ( {
@@ -36,6 +37,11 @@ jest.mock( 'lib/route/path', () => ( {
 } ) );
 
 describe( 'JetpackConnectMain', () => {
+	beforeEach( () => {
+		externalRedirect.mockReset();
+		page.redirect.mockReset();
+	} );
+
 	describe( 'cleanUrl', () => {
 		test( 'should prepare entered urls for network access', () => {
 			const cleanUrl = new JetpackConnectMain( REQUIRED_PROPS ).cleanUrl;
@@ -55,7 +61,7 @@ describe( 'JetpackConnectMain', () => {
 
 	describe( 'makeSafeRedirectionFunction', () => {
 		test( 'should make a function that can calls the wrapper function', () => {
-			const component = mount(
+			const component = shallow(
 				<JetpackConnectMain { ...REQUIRED_PROPS } translate={ jest.fn() } />
 			);
 			const innerFunc = jest.fn();
@@ -65,7 +71,7 @@ describe( 'JetpackConnectMain', () => {
 
 		test( 'should protect against multiple calls', () => {
 			const innerFunc = jest.fn();
-			const component = mount(
+			const component = shallow(
 				<JetpackConnectMain { ...REQUIRED_PROPS } translate={ jest.fn() } />
 			);
 			const wrapperFunc = component.instance().makeSafeRedirectionFunction( innerFunc );
@@ -77,15 +83,9 @@ describe( 'JetpackConnectMain', () => {
 	} );
 
 	describe( 'goToPluginActivation', () => {
-		const component = new JetpackConnectMain( REQUIRED_PROPS );
-
-		beforeEach( () => {
-			component.props.recordTracksEvent.mockReset();
-			externalRedirect.mockReset();
-		} );
-
 		test( 'should fire redirect', () => {
-			component.goToPluginActivation( 'example.com' );
+			const component = shallow( <JetpackConnectMain { ...REQUIRED_PROPS } /> );
+			component.instance().goToPluginActivation( 'example.com' );
 
 			expect( externalRedirect ).toHaveBeenCalledTimes( 1 );
 			expect( externalRedirect.mock.calls[ 0 ] ).toMatchSnapshot();
@@ -93,23 +93,22 @@ describe( 'JetpackConnectMain', () => {
 
 		test( 'should dispatch analytics', () => {
 			const url = 'example.com';
-			component.goToPluginActivation( url );
+			const spy = jest.fn();
+			const component = shallow(
+				<JetpackConnectMain { ...REQUIRED_PROPS } recordTracksEvent={ spy } />
+			);
+			spy.mockReset();
+			component.instance().goToPluginActivation( url );
 
-			expect( component.props.recordTracksEvent ).toHaveBeenCalledTimes( 1 );
-			expect( component.props.recordTracksEvent.mock.calls[ 0 ] ).toMatchSnapshot();
+			expect( spy ).toHaveBeenCalledTimes( 1 );
+			expect( spy.mock.calls[ 0 ] ).toMatchSnapshot();
 		} );
 	} );
 
 	describe( 'goToPluginInstall', () => {
-		const component = new JetpackConnectMain( REQUIRED_PROPS );
-
-		beforeEach( () => {
-			component.props.recordTracksEvent.mockReset();
-			externalRedirect.mockReset();
-		} );
-
 		test( 'should fire redirect', () => {
-			component.goToPluginInstall( 'example.com' );
+			const component = shallow( <JetpackConnectMain { ...REQUIRED_PROPS } /> );
+			component.instance().goToPluginInstall( 'example.com' );
 
 			expect( externalRedirect ).toHaveBeenCalledTimes( 1 );
 			expect( externalRedirect.mock.calls[ 0 ] ).toMatchSnapshot();
@@ -117,23 +116,22 @@ describe( 'JetpackConnectMain', () => {
 
 		test( 'should dispatch analytics', () => {
 			const url = 'example.com';
-			component.goToPluginInstall( url );
+			const spy = jest.fn();
+			const component = shallow(
+				<JetpackConnectMain { ...REQUIRED_PROPS } recordTracksEvent={ spy } />
+			);
+			spy.mockReset();
+			component.instance().goToPluginInstall( url );
 
-			expect( component.props.recordTracksEvent ).toHaveBeenCalledTimes( 1 );
-			expect( component.props.recordTracksEvent.mock.calls[ 0 ] ).toMatchSnapshot();
+			expect( spy ).toHaveBeenCalledTimes( 1 );
+			expect( spy.mock.calls[ 0 ] ).toMatchSnapshot();
 		} );
 	} );
 
 	describe( 'goToRemoteAuth', () => {
-		const component = new JetpackConnectMain( REQUIRED_PROPS );
-
-		beforeEach( () => {
-			component.props.recordTracksEvent.mockReset();
-			externalRedirect.mockReset();
-		} );
-
 		test( 'should fire redirect', () => {
-			component.goToRemoteAuth( 'example.com' );
+			const component = shallow( <JetpackConnectMain { ...REQUIRED_PROPS } /> );
+			component.instance().goToRemoteAuth( 'example.com' );
 
 			expect( externalRedirect ).toHaveBeenCalledTimes( 1 );
 			expect( externalRedirect.mock.calls[ 0 ] ).toMatchSnapshot();
@@ -141,27 +139,22 @@ describe( 'JetpackConnectMain', () => {
 
 		test( 'should dispatch analytics', () => {
 			const url = 'example.com';
-			component.goToRemoteAuth( url );
+			const spy = jest.fn();
+			const component = shallow(
+				<JetpackConnectMain { ...REQUIRED_PROPS } recordTracksEvent={ spy } />
+			);
+			spy.mockReset();
+			component.instance().goToRemoteAuth( url );
 
-			expect( component.props.recordTracksEvent ).toHaveBeenCalledTimes( 1 );
-			expect( component.props.recordTracksEvent.mock.calls[ 0 ] ).toMatchSnapshot();
+			expect( spy ).toHaveBeenCalledTimes( 1 );
+			expect( spy.mock.calls[ 0 ] ).toMatchSnapshot();
 		} );
 	} );
 
 	describe( 'goToPlans', () => {
-		const component = new JetpackConnectMain( {
-			...REQUIRED_PROPS,
-			recordTracksEvent: jest.fn(),
-		} );
-
-		beforeEach( () => {
-			component.redirecting = false;
-			component.props.recordTracksEvent.mockReset();
-			page.redirect.mockReset();
-		} );
-
 		test( 'should fire redirect', () => {
-			component.goToPlans( 'example.com' );
+			const component = shallow( <JetpackConnectMain { ...REQUIRED_PROPS } /> );
+			component.instance().goToPlans( 'example.com' );
 
 			expect( page.redirect ).toHaveBeenCalledTimes( 1 );
 			expect( page.redirect ).toHaveBeenCalledWith( '/jetpack/connect/plans/example.com' );
@@ -169,7 +162,8 @@ describe( 'JetpackConnectMain', () => {
 
 		test( 'should redirect to a site slug', () => {
 			const url = 'https://example.com/sub-directory-install';
-			component.goToPlans( url );
+			const component = shallow( <JetpackConnectMain { ...REQUIRED_PROPS } /> );
+			component.instance().goToPlans( url );
 
 			expect( page.redirect ).toHaveBeenCalledWith(
 				'/jetpack/connect/plans/example.com::sub-directory-install'
@@ -178,10 +172,15 @@ describe( 'JetpackConnectMain', () => {
 
 		test( 'should dispatch analytics', () => {
 			const url = 'example.com';
-			component.goToPlans( url );
+			const spy = jest.fn();
+			const component = shallow(
+				<JetpackConnectMain { ...REQUIRED_PROPS } recordTracksEvent={ spy } />
+			);
+			spy.mockReset();
+			component.instance().goToPlans( url );
 
-			expect( component.props.recordTracksEvent ).toHaveBeenCalledTimes( 1 );
-			expect( component.props.recordTracksEvent.mock.calls[ 0 ] ).toMatchSnapshot();
+			expect( spy ).toHaveBeenCalledTimes( 1 );
+			expect( spy.mock.calls[ 0 ] ).toMatchSnapshot();
 		} );
 	} );
 } );


### PR DESCRIPTION
Ensure that the spinner is showing and the entry field is disabled during transition to the next step.

Make `redirecting` component state instead of a local variable so that child elements, specifically the URL entry form, are updated when its value changes.

**Before**
![spinner_before](https://user-images.githubusercontent.com/7767559/37099875-69b0502a-2219-11e8-8812-fdaf6cad07a1.gif) 

**After**
![spinner_after](https://user-images.githubusercontent.com/7767559/37099877-6b2040c8-2219-11e8-8d21-ad9af92477d3.gif)

Note: with this fix, the spinner will 'restart' at various points as the conditions change. To fix this we would need to make more radical changes to check props before updates, so this relatively simple PR seems like a good trade-off.

## Testing

Go to https://calypso.live//jetpack/connect?branch=fix/jetpack-connect/url-spinner, enter a URL, check that the spinner is shown at the appropriate times.



