### PR TITLE
Ads: Handle the case when sites haven't been loaded yet

### DIFF
--- a/client/my-sites/ads/controller.js
+++ b/client/my-sites/ads/controller.js
@@ -55,12 +55,12 @@ export default {
 
 		context.store.dispatch( setTitle( layoutTitle ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
-		if ( ! userCan( 'manage_options', site ) ) {
+		if ( site && ! userCan( 'manage_options', site ) ) {
 			page.redirect( '/stats' + pathSuffix );
 			return;
 		}
 
-		if ( ! canAccessWordads( site ) ) {
+		if ( site && ! canAccessWordads( site ) ) {
 			page.redirect( '/stats' + pathSuffix );
 			return;
 		}

--- a/client/my-sites/ads/controller.js
+++ b/client/my-sites/ads/controller.js
@@ -14,10 +14,8 @@ import page from 'page';
 import { sectionify } from 'lib/route';
 import analytics from 'lib/analytics';
 import titlecase from 'to-title-case';
-import { canAccessWordads } from 'lib/ads/utils';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { userCan } from 'lib/site/utils';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import Ads from 'my-sites/ads/main';
 
@@ -49,21 +47,9 @@ export default {
 	},
 
 	layout: function( context, next ) {
-		const site = getSelectedSite( context.store.getState() );
-		const pathSuffix = site ? '/' + site.slug : '';
 		const layoutTitle = _getLayoutTitle( context );
 
 		context.store.dispatch( setTitle( layoutTitle ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-
-		if ( site && ! userCan( 'manage_options', site ) ) {
-			page.redirect( '/stats' + pathSuffix );
-			return;
-		}
-
-		if ( site && ! canAccessWordads( site ) ) {
-			page.redirect( '/stats' + pathSuffix );
-			return;
-		}
 
 		_recordPageView( context, layoutTitle );
 

--- a/client/my-sites/ads/main.jsx
+++ b/client/my-sites/ads/main.jsx
@@ -44,7 +44,7 @@ class AdsMain extends Component {
 		requestingWordAdsApproval: PropTypes.bool.isRequired,
 		requestWordAdsApproval: PropTypes.func.isRequired,
 		section: PropTypes.string.isRequired,
-		site: PropTypes.object.isRequired,
+		site: PropTypes.object,
 		wordAdsError: PropTypes.string,
 		wordAdsSuccess: PropTypes.bool,
 	};
@@ -191,7 +191,12 @@ class AdsMain extends Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { site, translate } = this.props;
+
+		if ( ! site ) {
+			return null;
+		}
+
 		let component = this.getComponent( this.props.section );
 		let notice = null;
 
@@ -201,10 +206,7 @@ class AdsMain extends Component {
 					{ translate( 'You have joined the WordAds program. Please review these settings:' ) }
 				</Notice>
 			);
-		} else if (
-			! this.props.site.options.wordads &&
-			isWordadsInstantActivationEligible( this.props.site )
-		) {
+		} else if ( ! site.options.wordads && isWordadsInstantActivationEligible( site ) ) {
 			component = this.renderInstantActivationToggle( component );
 		}
 

--- a/client/my-sites/ads/main.jsx
+++ b/client/my-sites/ads/main.jsx
@@ -35,6 +35,7 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import QueryWordadsStatus from 'components/data/query-wordads-status';
 import { canCurrentUser } from 'state/selectors';
+import { getSiteFragment } from 'lib/route';
 import { isSiteWordadsUnsafe, isRequestingWordadsStatus } from 'state/wordads/status/selectors';
 import { wordadsUnsafeValues } from 'state/wordads/status/schema';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -52,11 +53,11 @@ class AdsMain extends Component {
 	};
 
 	componentDidMount() {
-		this.redirectIfNoAccess();
+		this.redirectToStats();
 	}
 
 	componentDidUpdate() {
-		this.redirectIfNoAccess();
+		this.redirectToStats();
 	}
 
 	canAccess() {
@@ -64,11 +65,14 @@ class AdsMain extends Component {
 		return site && canManageOptions && canAccessWordads( site );
 	}
 
-	redirectIfNoAccess() {
+	redirectToStats() {
 		const { siteSlug } = this.props;
+		const siteFragment = getSiteFragment( page.current );
 
 		if ( ! this.canAccess() && siteSlug ) {
 			page( '/stats/' + siteSlug );
+		} else if ( ! siteFragment ) {
+			page( '/stats/' );
 		}
 	}
 


### PR DESCRIPTION
This PR updates the Ads section to properly handle cases when the site hasn't loaded yet. It basically moves the logic from the controller to the component, allowing us to wait until sites are loaded before deciding whether to redirect.

Instructions to reproduce the bug can be found [here](https://github.com/Automattic/wp-calypso/issues/22699#issuecomment-371152677).

Fixes #22699.

To test:
* Checkout this branch.
* Test the eligible case
  * Pick a Jetpack site that's eligible for WordAds (has a premium or pro plan) and make sure you're logged as an admin of the site in .com.
  * Load `http://calypso.localhost:3000/stats/day/:site` where `:site` is your Jetpack site and wait for it to load, to ensure sites have been loaded.
  * Go to `http://calypso.localhost:3000/ads/earnings/:site` where `:site` is your Jetpack site. 
  * Verify the page loads correctly.
  * Clean your Redux store (by calling `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );` in the browser console).
  * Refresh `http://calypso.localhost:3000/ads/earnings/:site`.
  * Verify it loads correctly, after a short wait until site loads.
  * Go to `http://calypso.localhost:3000/ads/settings/:site` where `:site` is your Jetpack site. 
  * Verify the page loads correctly.
  * Clean your Redux store (by calling `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );` in the browser console).
  * Refresh `http://calypso.localhost:3000/ads/settings/:site`.
  * Verify the page loads correctly, after a short wait until site loads.
* Test the non-eligible case
  * Pick a Jetpack site that's not eligible for WordAds (has a free plan) or make sure you're logged in .com as a user with role that lacks the `manage_options` capability - for example author or editor.
  * Load `http://calypso.localhost:3000/stats/day/:site` where `:site` is your Jetpack site and wait for it to load, to ensure sites have been loaded.
  * Go to `http://calypso.localhost:3000/ads/earnings/:site` where `:site` is your Jetpack site. 
  * Verify you're being redirected quickly to `/stats/:site`, ending at `/stats/day/:site`.
  * Clean your Redux store (by calling `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );` in the browser console).
  * Refresh `http://calypso.localhost:3000/ads/earnings/:site`.
  * Verify that after a short wait you're being redirected to `/stats/:site`, ending at `/stats/day/:site`.
  * Go to `http://calypso.localhost:3000/ads/settings/:site` where `:site` is your Jetpack site. 
  * Verify you're being redirected quickly to `/stats/:site`, ending at `/stats/day/:site`.
  * Clean your Redux store (by calling `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );` in the browser console).
  * Refresh `http://calypso.localhost:3000/ads/settings/:site`.
  * Verify that after a short wait you're being redirected to `/stats/:site`, ending at `/stats/day/:site`.
