### PR TITLE
Analytics: add Yahoo Gemini pixel

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -34,6 +34,7 @@ const isAdwordsEnabled = true;
 const isFacebookEnabled = true;
 const isBingEnabled = true;
 const isYahooEnabled = true;
+const isGeminiEnabled = true;
 const isQuantcastEnabled = true;
 const isTwitterEnabled = true;
 const isAolEnabled = true;
@@ -66,6 +67,7 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 	CRITEO_TRACKING_SCRIPT_URL = 'https://static.criteo.net/js/ld/ld.js',
 	ADWORDS_CONVERSION_ID = config( 'google_adwords_conversion_id' ),
 	ADWORDS_CONVERSION_ID_JETPACK = config( 'google_adwords_conversion_id_jetpack' ),
+	YAHOO_GEMINI_PIXEL_URL = 'https://sp.analytics.yahoo.com/spp.pl?a=10000&.yp=10014088',
 	ONE_BY_AOL_CONVERSION_PIXEL_URL =
 		'https://secure.ace-tag.advertising.com/action/type=132958/bins=1/rich=0/Mnum=1516/',
 	ONE_BY_AOL_AUDIENCE_BUILDING_PIXEL_URL =
@@ -459,6 +461,11 @@ function only_retarget() {
 		}
 	}
 
+	// Yahoo Gemini
+	if ( isGeminiEnabled ) {
+		new Image().src = YAHOO_GEMINI_PIXEL_URL;
+	}
+
 	// One by AOL
 	if ( isAolEnabled ) {
 		new Image().src = ONE_BY_AOL_AUDIENCE_BUILDING_PIXEL_URL;
@@ -601,6 +608,11 @@ export function recordOrder( cart, orderId ) {
 	// Experian / One 2 One Media
 	if ( isExperianEnabled ) {
 		new Image().src = EXPERIAN_CONVERSION_PIXEL_URL;
+	}
+
+	// Yahoo Gemini
+	if ( isGeminiEnabled ) {
+		new Image().src = YAHOO_GEMINI_PIXEL_URL;
 	}
 
 	if ( isAolEnabled ) {


### PR DESCRIPTION
Adds Yahoo Gemini pixel.

# Test

- localStorage.setItem( 'debug', 'calypso:analytics:*' );
- in `config/development.json` set `"ad-tracking": true`
- restart Calypso
- Open "Developer tools" in Chrome
- By filtering by "yahoo" in the Network tab you should see the following entry 
https://sp.analytics.yahoo.com/spp.pl?a=10000&.yp=10014088

The pixel is fire only once after user loads Calypso and when a user purchases something.
