### PR TITLE
Replace direct usage of plan constants with a set of functions

### DIFF
--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -8,23 +8,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { includes, noop, size } from 'lodash';
+import { noop, size } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
-import {
-	PLAN_PERSONAL,
-	PLAN_PREMIUM,
-	PLAN_BUSINESS,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PERSONAL_MONTHLY,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-} from 'lib/plans/constants';
 import { addQueryArgs } from 'lib/url';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
@@ -35,6 +24,7 @@ import DismissibleCard from 'blocks/dismissible-card';
 import PlanIcon from 'components/plans/plan-icon';
 import PlanPrice from 'my-sites/plan-price';
 import TrackComponentView from 'lib/analytics/track-component-view';
+import { isBusinessPlan, isPersonalPlan, isPremiumPlan } from '../../lib/plans';
 
 class Banner extends Component {
 	static propTypes = {
@@ -205,24 +195,9 @@ class Banner extends Component {
 			'banner',
 			className,
 			{ 'has-call-to-action': callToAction },
-			{
-				'is-upgrade-personal': includes(
-					[ PLAN_PERSONAL, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ],
-					plan
-				),
-			},
-			{
-				'is-upgrade-premium': includes(
-					[ PLAN_PREMIUM, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ],
-					plan
-				),
-			},
-			{
-				'is-upgrade-business': includes(
-					[ PLAN_BUSINESS, PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY ],
-					plan
-				),
-			},
+			{ 'is-upgrade-personal': isPersonalPlan( plan ) },
+			{ 'is-upgrade-premium': isPremiumPlan( plan ) },
+			{ 'is-upgrade-business': isBusinessPlan( plan ) },
 			{ 'is-dismissible': dismissPreferenceName }
 		);
 

--- a/client/components/plans/plan-icon/README.md
+++ b/client/components/plans/plan-icon/README.md
@@ -30,15 +30,4 @@ export default function MyComponent() {
 
 ### plan
 
-Plan constant from `lib/plans/constants`. Can be one of:
-
-- PLAN_FREE,
-- PLAN_PREMIUM,
-- PLAN_BUSINESS,
-- PLAN_JETPACK_FREE,
-- PLAN_JETPACK_BUSINESS,
-- PLAN_JETPACK_BUSINESS_MONTHLY,
-- PLAN_JETPACK_PREMIUM,
-- PLAN_JETPACK_PREMIUM_MONTHLY,
-- PLAN_PERSONAL
-
+Plan constant from `lib/plans/constants` - check that file for possible values.

--- a/client/components/plans/plan-icon/index.jsx
+++ b/client/components/plans/plan-icon/index.jsx
@@ -11,20 +11,8 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import {
-	PLAN_FREE,
-	PLAN_PREMIUM,
-	PLAN_BUSINESS,
-	PLAN_JETPACK_FREE,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PERSONAL_MONTHLY,
-	PLAN_PERSONAL,
-	getPlanClass,
-} from 'lib/plans/constants';
+import { isBusinessPlan, isPersonalPlan, isPremiumPlan } from '../../../lib/plans';
+import { getPlanClass, PLANS_CONSTANTS_LIST } from '../../../lib/plans/constants';
 
 export default class PlanIcon extends Component {
 	getIcon( planName ) {
@@ -41,18 +29,14 @@ export default class PlanIcon extends Component {
 
 	render() {
 		const { plan } = this.props;
-		switch ( plan ) {
-			case PLAN_PERSONAL:
-			case PLAN_JETPACK_PERSONAL:
-			case PLAN_JETPACK_PERSONAL_MONTHLY:
+		switch ( true ) {
+			case isPersonalPlan( plan ):
 				return this.getIcon( 'personal' );
-			case PLAN_PREMIUM:
-			case PLAN_JETPACK_PREMIUM:
-			case PLAN_JETPACK_PREMIUM_MONTHLY:
+
+			case isPremiumPlan( plan ):
 				return this.getIcon( 'premium' );
-			case PLAN_BUSINESS:
-			case PLAN_JETPACK_BUSINESS:
-			case PLAN_JETPACK_BUSINESS_MONTHLY:
+
+			case isBusinessPlan( plan ):
 				return this.getIcon( 'business' );
 			default:
 				return this.getIcon( 'free' );
@@ -62,17 +46,5 @@ export default class PlanIcon extends Component {
 
 PlanIcon.propTypes = {
 	classNames: PropTypes.string,
-	plan: PropTypes.oneOf( [
-		PLAN_FREE,
-		PLAN_PREMIUM,
-		PLAN_BUSINESS,
-		PLAN_JETPACK_FREE,
-		PLAN_JETPACK_BUSINESS,
-		PLAN_JETPACK_BUSINESS_MONTHLY,
-		PLAN_JETPACK_PREMIUM,
-		PLAN_JETPACK_PREMIUM_MONTHLY,
-		PLAN_JETPACK_PERSONAL,
-		PLAN_JETPACK_PERSONAL_MONTHLY,
-		PLAN_PERSONAL,
-	] ).isRequired,
+	plan: PropTypes.oneOf( PLANS_CONSTANTS_LIST ).isRequired,
 };

--- a/client/components/plans/plan-icon/index.jsx
+++ b/client/components/plans/plan-icon/index.jsx
@@ -29,19 +29,19 @@ export default class PlanIcon extends Component {
 
 	render() {
 		const { plan } = this.props;
-		switch ( true ) {
-			case isPersonalPlan( plan ):
-				return this.getIcon( 'personal' );
-
-			case isPremiumPlan( plan ):
-				return this.getIcon( 'premium' );
-
-			case isBusinessPlan( plan ):
-				return this.getIcon( 'business' );
-
-			default:
-				return this.getIcon( 'free' );
+		if ( isPersonalPlan( plan ) ) {
+			return this.getIcon( 'personal' );
 		}
+
+		if ( isPremiumPlan( plan ) ) {
+			return this.getIcon( 'premium' );
+		}
+
+		if ( isBusinessPlan( plan ) ) {
+			return this.getIcon( 'business' );
+		}
+
+		return this.getIcon( 'free' );
 	}
 }
 

--- a/client/components/plans/plan-icon/index.jsx
+++ b/client/components/plans/plan-icon/index.jsx
@@ -38,6 +38,7 @@ export default class PlanIcon extends Component {
 
 			case isBusinessPlan( plan ):
 				return this.getIcon( 'business' );
+
 			default:
 				return this.getIcon( 'free' );
 		}

--- a/client/components/seo/preview-upgrade-nudge/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/index.jsx
@@ -87,7 +87,7 @@ SeoPreviewNudge.propTypes = {
 
 const mapStateToProps = ( state, { site } ) => {
 	return {
-		plan: getCurrentPlan( state, site.ID ),
+		currentPlan: getCurrentPlan( state, site.ID ),
 	};
 };
 

--- a/client/components/seo/preview-upgrade-nudge/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/index.jsx
@@ -16,19 +16,20 @@ import Gridicon from 'gridicons';
 import QueryPlans from 'components/data/query-plans';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { preventWidows } from 'lib/formatting';
-import { isJetpackSite } from 'state/sites/selectors';
 import FeatureExample from 'components/feature-example';
 import Banner from 'components/banner';
-import { PLAN_BUSINESS, PLAN_JETPACK_BUSINESS } from 'lib/plans/constants';
+import { findSimilarPlan } from '../../../lib/plans';
+import { TYPE_BUSINESS } from '../../../lib/plans/constants';
+import { getCurrentPlan } from '../../../state/sites/plans/selectors';
 
-const SeoPreviewNudge = ( { translate, isJetpack = false } ) => {
+const SeoPreviewNudge = ( { translate, currentPlan } ) => {
 	return (
 		<div className="preview-upgrade-nudge">
 			<QueryPlans />
 			<TrackComponentView eventName="calypso_seo_preview_upgrade_nudge_impression" />
 
 			<Banner
-				plan={ isJetpack ? PLAN_JETPACK_BUSINESS : PLAN_BUSINESS }
+				plan={ findSimilarPlan( currentPlan, { type: TYPE_BUSINESS } ) }
 				title={ translate( 'Upgrade to a Business Plan to unlock the power of our SEO tools!' ) }
 				event="site_preview_seo_plan_upgrade"
 				className="preview-upgrade-nudge__banner"
@@ -84,12 +85,9 @@ SeoPreviewNudge.propTypes = {
 	translate: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = ( state, ownProps ) => {
-	const { site } = ownProps;
-	const isJetpack = isJetpackSite( state, site.ID );
-
+const mapStateToProps = ( state, { site } ) => {
 	return {
-		isJetpack,
+		plan: getCurrentPlan( state, site.ID ),
 	};
 };
 

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -154,8 +154,8 @@ export const TYPE_PREMIUM = 'TYPE_PREMIUM';
 export const TYPE_BUSINESS = 'TYPE_BUSINESS';
 
 const getPlanPersonalDetails = () => ( {
-	getGroup: () => GROUP_WPCOM,
-	getType: () => TYPE_PERSONAL,
+	group: GROUP_WPCOM,
+	type: TYPE_PERSONAL,
 	getTitle: () => i18n.translate( 'Personal' ),
 	getAudience: () => i18n.translate( 'Best for hobbyists' ),
 	getBlogAudience: () => i18n.translate( 'Best for hobbyists' ),
@@ -209,8 +209,8 @@ const getPlanPersonalDetails = () => ( {
 } );
 
 const getPlanPremiumDetails = () => ( {
-	getGroup: () => GROUP_WPCOM,
-	getType: () => TYPE_PREMIUM,
+	group: GROUP_WPCOM,
+	type: TYPE_PREMIUM,
 	getTitle: () => i18n.translate( 'Premium' ),
 	getAudience: () => i18n.translate( 'Best for entrepreneurs' ),
 	getBlogAudience: () => i18n.translate( 'Best for professionals' ),
@@ -276,8 +276,8 @@ const getPlanPremiumDetails = () => ( {
 } );
 
 const getPlanBusinessDetails = () => ( {
-	getGroup: () => GROUP_WPCOM,
-	getType: () => TYPE_BUSINESS,
+	group: GROUP_WPCOM,
+	type: TYPE_BUSINESS,
 	getTitle: () => i18n.translate( 'Business' ),
 	getAudience: () => i18n.translate( 'Best for small businesses' ),
 	getBlogAudience: () => i18n.translate( 'Best for brands' ),
@@ -373,9 +373,9 @@ const getPlanBusinessDetails = () => ( {
 // DO NOT import. Use `getPlan` from `lib/plans` instead.
 export const PLANS_LIST = {
 	[ PLAN_FREE ]: {
-		getGroup: () => GROUP_WPCOM,
-		getType: () => TYPE_FREE,
-		getTerm: () => TERM_ANNUALLY,
+		group: GROUP_WPCOM,
+		type: TYPE_FREE,
+		term: TERM_ANNUALLY,
 		getTitle: () => i18n.translate( 'Free' ),
 		getAudience: () => i18n.translate( 'Best for students' ),
 		getBlogAudience: () => i18n.translate( 'Best for students' ),
@@ -419,7 +419,7 @@ export const PLANS_LIST = {
 
 	[ PLAN_PERSONAL ]: {
 		...getPlanPersonalDetails(),
-		getTerm: () => TERM_ANNUALLY,
+		term: TERM_ANNUALLY,
 		availableFor: plan => includes( [ PLAN_FREE ], plan ),
 		getProductId: () => 1009,
 		getStoreSlug: () => PLAN_PERSONAL,
@@ -428,7 +428,7 @@ export const PLANS_LIST = {
 
 	[ PLAN_PERSONAL_2_YEARS ]: {
 		...getPlanPersonalDetails(),
-		getTerm: () => TERM_BIENNIALLY,
+		term: TERM_BIENNIALLY,
 		availableFor: plan => includes( [ PLAN_FREE, PLAN_PERSONAL ], plan ),
 		getProductId: () => 1029,
 		getStoreSlug: () => PLAN_PERSONAL_2_YEARS,
@@ -437,7 +437,7 @@ export const PLANS_LIST = {
 
 	[ PLAN_PREMIUM ]: {
 		...getPlanPremiumDetails(),
-		getTerm: () => TERM_ANNUALLY,
+		term: TERM_ANNUALLY,
 		availableFor: plan => includes( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PERSONAL_2_YEARS ], plan ),
 		getProductId: () => 1003,
 		getStoreSlug: () => PLAN_PREMIUM,
@@ -447,7 +447,7 @@ export const PLANS_LIST = {
 
 	[ PLAN_PREMIUM_2_YEARS ]: {
 		...getPlanPremiumDetails(),
-		getTerm: () => TERM_BIENNIALLY,
+		term: TERM_BIENNIALLY,
 		availableFor: plan =>
 			includes( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM ], plan ),
 		getProductId: () => 1023,
@@ -458,7 +458,7 @@ export const PLANS_LIST = {
 
 	[ PLAN_BUSINESS ]: {
 		...getPlanBusinessDetails(),
-		getTerm: () => TERM_ANNUALLY,
+		term: TERM_ANNUALLY,
 		availableFor: plan =>
 			includes(
 				[ PLAN_FREE, PLAN_PERSONAL, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM, PLAN_PREMIUM_2_YEARS ],
@@ -472,7 +472,7 @@ export const PLANS_LIST = {
 
 	[ PLAN_BUSINESS_2_YEARS ]: {
 		...getPlanBusinessDetails(),
-		getTerm: () => TERM_BIENNIALLY,
+		term: TERM_BIENNIALLY,
 		availableFor: plan =>
 			includes(
 				[
@@ -492,9 +492,9 @@ export const PLANS_LIST = {
 	},
 
 	[ PLAN_JETPACK_FREE ]: {
-		getTerm: () => TERM_ANNUALLY,
-		getGroup: () => GROUP_JETPACK,
-		getType: () => TYPE_FREE,
+		term: TERM_ANNUALLY,
+		group: GROUP_JETPACK,
+		type: TYPE_FREE,
 		getTitle: () => i18n.translate( 'Free' ),
 		getAudience: () => i18n.translate( 'Best for students' ),
 		getProductId: () => 2002,
@@ -527,9 +527,9 @@ export const PLANS_LIST = {
 	},
 
 	[ PLAN_JETPACK_PREMIUM ]: {
-		getGroup: () => GROUP_JETPACK,
-		getType: () => TYPE_PREMIUM,
-		getTerm: () => TERM_ANNUALLY,
+		group: GROUP_JETPACK,
+		type: TYPE_PREMIUM,
+		term: TERM_ANNUALLY,
 		getTitle: () => i18n.translate( 'Premium' ),
 		getAudience: () => i18n.translate( 'Best for small businesses' ),
 		getSubtitle: () => i18n.translate( 'Protection, speed, and revenue.' ),
@@ -588,9 +588,9 @@ export const PLANS_LIST = {
 	},
 
 	[ PLAN_JETPACK_PREMIUM_MONTHLY ]: {
-		getGroup: () => GROUP_JETPACK,
-		getType: () => TYPE_PREMIUM,
-		getTerm: () => TERM_MONTHLY,
+		group: GROUP_JETPACK,
+		type: TYPE_PREMIUM,
+		term: TERM_MONTHLY,
 		getTitle: () => i18n.translate( 'Premium' ),
 		getAudience: () => i18n.translate( 'Best for small businesses' ),
 		getProductId: () => 2003,
@@ -646,9 +646,9 @@ export const PLANS_LIST = {
 	},
 
 	[ PLAN_JETPACK_PERSONAL ]: {
-		getGroup: () => GROUP_JETPACK,
-		getType: () => TYPE_PERSONAL,
-		getTerm: () => TERM_ANNUALLY,
+		group: GROUP_JETPACK,
+		type: TYPE_PERSONAL,
+		term: TERM_ANNUALLY,
 		getTitle: () => i18n.translate( 'Personal' ),
 		getAudience: () => i18n.translate( 'Best for hobbyists' ),
 		getProductId: () => 2005,
@@ -685,9 +685,9 @@ export const PLANS_LIST = {
 	},
 
 	[ PLAN_JETPACK_PERSONAL_MONTHLY ]: {
-		getGroup: () => GROUP_JETPACK,
-		getType: () => TYPE_PERSONAL,
-		getTerm: () => TERM_MONTHLY,
+		group: GROUP_JETPACK,
+		type: TYPE_PERSONAL,
+		term: TERM_MONTHLY,
 		getTitle: () => i18n.translate( 'Personal' ),
 		getAudience: () => i18n.translate( 'Best for hobbyists' ),
 		getStoreSlug: () => PLAN_JETPACK_PERSONAL_MONTHLY,
@@ -730,9 +730,9 @@ export const PLANS_LIST = {
 	},
 
 	[ PLAN_JETPACK_BUSINESS ]: {
-		getGroup: () => GROUP_JETPACK,
-		getType: () => TYPE_BUSINESS,
-		getTerm: () => TERM_ANNUALLY,
+		group: GROUP_JETPACK,
+		type: TYPE_BUSINESS,
+		term: TERM_ANNUALLY,
 		getTitle: () => i18n.translate( 'Professional' ),
 		getAudience: () => i18n.translate( 'Best for organizations' ),
 		getProductId: () => 2001,
@@ -791,9 +791,9 @@ export const PLANS_LIST = {
 	},
 
 	[ PLAN_JETPACK_BUSINESS_MONTHLY ]: {
-		getGroup: () => GROUP_JETPACK,
-		getType: () => TYPE_BUSINESS,
-		getTerm: () => TERM_MONTHLY,
+		group: GROUP_JETPACK,
+		type: TYPE_BUSINESS,
+		term: TERM_MONTHLY,
 		getTitle: () => i18n.translate( 'Professional' ),
 		getAudience: () => i18n.translate( 'Best for organizations' ),
 		getSubtitle: () => i18n.translate( 'Ultimate security and traffic tools.' ),

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -12,6 +12,7 @@ import { compact, includes } from 'lodash';
  * Internal dependencies
  */
 import { isEnabled } from 'config';
+import { isBusinessPlan, isFreePlan, isPersonalPlan, isPremiumPlan } from './index';
 
 // plans constants
 export const PLAN_BUSINESS = 'business-bundle';
@@ -1588,26 +1589,20 @@ export function isBestValue( plan ) {
 	return includes( BEST_VALUE_PLANS, plan );
 }
 
-export function getPlanClass( plan ) {
-	switch ( plan ) {
-		case PLAN_JETPACK_FREE:
-		case PLAN_FREE:
+export function getPlanClass( planKey ) {
+	switch ( true ) {
+		case isFreePlan( planKey ):
 			return 'is-free-plan';
-		case PLAN_PERSONAL:
-		case PLAN_PERSONAL_2_YEARS:
-		case PLAN_JETPACK_PERSONAL:
-		case PLAN_JETPACK_PERSONAL_MONTHLY:
+
+		case isPersonalPlan( planKey ):
 			return 'is-personal-plan';
-		case PLAN_PREMIUM:
-		case PLAN_PREMIUM_2_YEARS:
-		case PLAN_JETPACK_PREMIUM:
-		case PLAN_JETPACK_PREMIUM_MONTHLY:
+
+		case isPremiumPlan( planKey ):
 			return 'is-premium-plan';
-		case PLAN_BUSINESS:
-		case PLAN_BUSINESS_2_YEARS:
-		case PLAN_JETPACK_BUSINESS:
-		case PLAN_JETPACK_BUSINESS_MONTHLY:
+
+		case isBusinessPlan( planKey ):
 			return 'is-business-plan';
+
 		default:
 			return '';
 	}

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -1590,20 +1590,21 @@ export function isBestValue( plan ) {
 }
 
 export function getPlanClass( planKey ) {
-	switch ( true ) {
-		case isFreePlan( planKey ):
-			return 'is-free-plan';
-
-		case isPersonalPlan( planKey ):
-			return 'is-personal-plan';
-
-		case isPremiumPlan( planKey ):
-			return 'is-premium-plan';
-
-		case isBusinessPlan( planKey ):
-			return 'is-business-plan';
-
-		default:
-			return '';
+	if ( isFreePlan( planKey ) ) {
+		return 'is-free-plan';
 	}
+
+	if ( isPersonalPlan( planKey ) ) {
+		return 'is-personal-plan';
+	}
+
+	if ( isPremiumPlan( planKey ) ) {
+		return 'is-premium-plan';
+	}
+
+	if ( isBusinessPlan( planKey ) ) {
+		return 'is-business-plan';
+	}
+
+	return '';
 }

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -447,7 +447,14 @@ export const PLANS_LIST = {
 		...getPlanBusinessDetails(),
 		availableFor: plan =>
 			includes(
-				[ PLAN_FREE, PLAN_PERSONAL, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM, PLAN_PREMIUM_2_YEARS ],
+				[
+					PLAN_FREE,
+					PLAN_PERSONAL,
+					PLAN_PERSONAL_2_YEARS,
+					PLAN_PREMIUM,
+					PLAN_PREMIUM_2_YEARS,
+					PLAN_BUSINESS,
+				],
 				plan
 			),
 		getProductId: () => 1028,

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -140,7 +140,22 @@ export const FEATURE_CONCIERGE_SETUP = 'concierge-setup-jetpack';
 export const FEATURE_MARKETING_AUTOMATION = 'marketing-automation';
 export const FEATURE_SEARCH = 'search';
 
+// Meta grouping constants
+export const GROUP_WPCOM = 'GROUP_WPCOM';
+export const GROUP_JETPACK = 'GROUP_JETPACK';
+
+export const TERM_MONTHLY = 'TERM_MONTHLY';
+export const TERM_ANNUALLY = 'TERM_ANNUALLY';
+export const TERM_BIENNIALLY = 'TERM_BIENNIALLY';
+
+export const TYPE_FREE = 'TYPE_FREE';
+export const TYPE_PERSONAL = 'TYPE_PERSONAL';
+export const TYPE_PREMIUM = 'TYPE_PREMIUM';
+export const TYPE_BUSINESS = 'TYPE_BUSINESS';
+
 const getPlanPersonalDetails = () => ( {
+	getGroup: () => GROUP_WPCOM,
+	getType: () => TYPE_PERSONAL,
 	getTitle: () => i18n.translate( 'Personal' ),
 	getAudience: () => i18n.translate( 'Best for hobbyists' ),
 	getBlogAudience: () => i18n.translate( 'Best for hobbyists' ),
@@ -194,6 +209,8 @@ const getPlanPersonalDetails = () => ( {
 } );
 
 const getPlanPremiumDetails = () => ( {
+	getGroup: () => GROUP_WPCOM,
+	getType: () => TYPE_PREMIUM,
 	getTitle: () => i18n.translate( 'Premium' ),
 	getAudience: () => i18n.translate( 'Best for entrepreneurs' ),
 	getBlogAudience: () => i18n.translate( 'Best for professionals' ),
@@ -259,6 +276,8 @@ const getPlanPremiumDetails = () => ( {
 } );
 
 const getPlanBusinessDetails = () => ( {
+	getGroup: () => GROUP_WPCOM,
+	getType: () => TYPE_BUSINESS,
 	getTitle: () => i18n.translate( 'Business' ),
 	getAudience: () => i18n.translate( 'Best for small businesses' ),
 	getBlogAudience: () => i18n.translate( 'Best for brands' ),
@@ -354,6 +373,9 @@ const getPlanBusinessDetails = () => ( {
 // DO NOT import. Use `getPlan` from `lib/plans` instead.
 export const PLANS_LIST = {
 	[ PLAN_FREE ]: {
+		getGroup: () => GROUP_WPCOM,
+		getType: () => TYPE_FREE,
+		getTerm: () => TERM_ANNUALLY,
 		getTitle: () => i18n.translate( 'Free' ),
 		getAudience: () => i18n.translate( 'Best for students' ),
 		getBlogAudience: () => i18n.translate( 'Best for students' ),
@@ -397,6 +419,7 @@ export const PLANS_LIST = {
 
 	[ PLAN_PERSONAL ]: {
 		...getPlanPersonalDetails(),
+		getTerm: () => TERM_ANNUALLY,
 		availableFor: plan => includes( [ PLAN_FREE ], plan ),
 		getProductId: () => 1009,
 		getStoreSlug: () => PLAN_PERSONAL,
@@ -405,6 +428,7 @@ export const PLANS_LIST = {
 
 	[ PLAN_PERSONAL_2_YEARS ]: {
 		...getPlanPersonalDetails(),
+		getTerm: () => TERM_BIENNIALLY,
 		availableFor: plan => includes( [ PLAN_FREE, PLAN_PERSONAL ], plan ),
 		getProductId: () => 1029,
 		getStoreSlug: () => PLAN_PERSONAL_2_YEARS,
@@ -413,6 +437,7 @@ export const PLANS_LIST = {
 
 	[ PLAN_PREMIUM ]: {
 		...getPlanPremiumDetails(),
+		getTerm: () => TERM_ANNUALLY,
 		availableFor: plan => includes( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PERSONAL_2_YEARS ], plan ),
 		getProductId: () => 1003,
 		getStoreSlug: () => PLAN_PREMIUM,
@@ -422,6 +447,7 @@ export const PLANS_LIST = {
 
 	[ PLAN_PREMIUM_2_YEARS ]: {
 		...getPlanPremiumDetails(),
+		getTerm: () => TERM_BIENNIALLY,
 		availableFor: plan =>
 			includes( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM ], plan ),
 		getProductId: () => 1023,
@@ -432,6 +458,7 @@ export const PLANS_LIST = {
 
 	[ PLAN_BUSINESS ]: {
 		...getPlanBusinessDetails(),
+		getTerm: () => TERM_ANNUALLY,
 		availableFor: plan =>
 			includes(
 				[ PLAN_FREE, PLAN_PERSONAL, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM, PLAN_PREMIUM_2_YEARS ],
@@ -445,6 +472,7 @@ export const PLANS_LIST = {
 
 	[ PLAN_BUSINESS_2_YEARS ]: {
 		...getPlanBusinessDetails(),
+		getTerm: () => TERM_BIENNIALLY,
 		availableFor: plan =>
 			includes(
 				[
@@ -464,6 +492,9 @@ export const PLANS_LIST = {
 	},
 
 	[ PLAN_JETPACK_FREE ]: {
+		getTerm: () => TERM_ANNUALLY,
+		getGroup: () => GROUP_JETPACK,
+		getType: () => TYPE_FREE,
 		getTitle: () => i18n.translate( 'Free' ),
 		getAudience: () => i18n.translate( 'Best for students' ),
 		getProductId: () => 2002,
@@ -496,6 +527,9 @@ export const PLANS_LIST = {
 	},
 
 	[ PLAN_JETPACK_PREMIUM ]: {
+		getGroup: () => GROUP_JETPACK,
+		getType: () => TYPE_PREMIUM,
+		getTerm: () => TERM_ANNUALLY,
 		getTitle: () => i18n.translate( 'Premium' ),
 		getAudience: () => i18n.translate( 'Best for small businesses' ),
 		getSubtitle: () => i18n.translate( 'Protection, speed, and revenue.' ),
@@ -554,6 +588,9 @@ export const PLANS_LIST = {
 	},
 
 	[ PLAN_JETPACK_PREMIUM_MONTHLY ]: {
+		getGroup: () => GROUP_JETPACK,
+		getType: () => TYPE_PREMIUM,
+		getTerm: () => TERM_MONTHLY,
 		getTitle: () => i18n.translate( 'Premium' ),
 		getAudience: () => i18n.translate( 'Best for small businesses' ),
 		getProductId: () => 2003,
@@ -609,6 +646,9 @@ export const PLANS_LIST = {
 	},
 
 	[ PLAN_JETPACK_PERSONAL ]: {
+		getGroup: () => GROUP_JETPACK,
+		getType: () => TYPE_PERSONAL,
+		getTerm: () => TERM_ANNUALLY,
 		getTitle: () => i18n.translate( 'Personal' ),
 		getAudience: () => i18n.translate( 'Best for hobbyists' ),
 		getProductId: () => 2005,
@@ -645,6 +685,9 @@ export const PLANS_LIST = {
 	},
 
 	[ PLAN_JETPACK_PERSONAL_MONTHLY ]: {
+		getGroup: () => GROUP_JETPACK,
+		getType: () => TYPE_PERSONAL,
+		getTerm: () => TERM_MONTHLY,
 		getTitle: () => i18n.translate( 'Personal' ),
 		getAudience: () => i18n.translate( 'Best for hobbyists' ),
 		getStoreSlug: () => PLAN_JETPACK_PERSONAL_MONTHLY,
@@ -687,6 +730,9 @@ export const PLANS_LIST = {
 	},
 
 	[ PLAN_JETPACK_BUSINESS ]: {
+		getGroup: () => GROUP_JETPACK,
+		getType: () => TYPE_BUSINESS,
+		getTerm: () => TERM_ANNUALLY,
 		getTitle: () => i18n.translate( 'Professional' ),
 		getAudience: () => i18n.translate( 'Best for organizations' ),
 		getProductId: () => 2001,
@@ -745,6 +791,9 @@ export const PLANS_LIST = {
 	},
 
 	[ PLAN_JETPACK_BUSINESS_MONTHLY ]: {
+		getGroup: () => GROUP_JETPACK,
+		getType: () => TYPE_BUSINESS,
+		getTerm: () => TERM_MONTHLY,
 		getTitle: () => i18n.translate( 'Professional' ),
 		getAudience: () => i18n.translate( 'Best for organizations' ),
 		getSubtitle: () => i18n.translate( 'Ultimate security and traffic tools.' ),
@@ -807,6 +856,8 @@ export const PLANS_LIST = {
 		getSignupBillingTimeFrame: () => i18n.translate( 'per month' ),
 	},
 };
+
+export const PLANS_CONSTANTS_LIST = Object.keys( PLANS_LIST );
 
 export const FEATURES_LIST = {
 	[ FEATURE_BLANK ]: {

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -447,14 +447,7 @@ export const PLANS_LIST = {
 		...getPlanBusinessDetails(),
 		availableFor: plan =>
 			includes(
-				[
-					PLAN_FREE,
-					PLAN_PERSONAL,
-					PLAN_PERSONAL_2_YEARS,
-					PLAN_PREMIUM,
-					PLAN_PREMIUM_2_YEARS,
-					PLAN_BUSINESS,
-				],
+				[ PLAN_FREE, PLAN_PERSONAL, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM, PLAN_PREMIUM_2_YEARS ],
 				plan
 			),
 		getProductId: () => 1028,

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -38,11 +38,7 @@ export function getPlans() {
 }
 
 export function getPlan( planKey ) {
-	const plan = PLANS_LIST[ planKey ];
-	if ( ! plan ) {
-		throw new Error( `There is no such plan as "${ planKey }"` );
-	}
-	return plan;
+	return PLANS_LIST[ planKey ];
 }
 
 export function getValidFeatureKeys() {

--- a/client/lib/plans/test/plan-lookups.js
+++ b/client/lib/plans/test/plan-lookups.js
@@ -1,0 +1,180 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	GROUP_JETPACK,
+	GROUP_WPCOM,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_FREE,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	TERM_ANNUALLY,
+	TERM_BIENNIALLY,
+	TERM_MONTHLY,
+	TYPE_BUSINESS,
+	TYPE_FREE,
+	TYPE_PERSONAL,
+	TYPE_PREMIUM,
+} from '../constants';
+import { getPlan, __internal__planMatches } from '../index';
+
+describe( '__internal__planMatches', () => {
+	test( 'should return true for queries matching plans', () => {
+		[
+			[
+				PLAN_FREE,
+				[
+					{ group: GROUP_WPCOM },
+					{ type: TYPE_FREE },
+					{ term: TERM_ANNUALLY },
+					{ group: GROUP_WPCOM, type: TYPE_FREE },
+					{ group: GROUP_WPCOM, term: TERM_ANNUALLY },
+					{ term: TERM_ANNUALLY, type: TYPE_FREE },
+					{ group: GROUP_WPCOM, term: TERM_ANNUALLY, type: TYPE_FREE },
+				],
+				PLAN_BUSINESS,
+				[
+					{ group: GROUP_WPCOM },
+					{ type: TYPE_BUSINESS },
+					{ term: TERM_ANNUALLY },
+					{ group: GROUP_WPCOM, type: TYPE_BUSINESS },
+					{ group: GROUP_WPCOM, term: TERM_ANNUALLY },
+					{ term: TERM_ANNUALLY, type: TYPE_BUSINESS },
+					{ group: GROUP_WPCOM, term: TERM_ANNUALLY, type: TYPE_BUSINESS },
+				],
+				PLAN_BUSINESS_2_YEARS,
+				[
+					{ group: GROUP_WPCOM },
+					{ type: TYPE_BUSINESS },
+					{ term: TERM_BIENNIALLY },
+					{ group: GROUP_WPCOM, type: TYPE_BUSINESS },
+					{ group: GROUP_WPCOM, term: TERM_BIENNIALLY },
+					{ term: TERM_BIENNIALLY, type: TYPE_BUSINESS },
+					{ group: GROUP_WPCOM, term: TERM_BIENNIALLY, type: TYPE_BUSINESS },
+				],
+				PLAN_PREMIUM,
+				[
+					{ group: GROUP_WPCOM },
+					{ type: TYPE_PREMIUM },
+					{ term: TERM_ANNUALLY },
+					{ group: GROUP_WPCOM, type: TYPE_PREMIUM },
+					{ group: GROUP_WPCOM, term: TERM_ANNUALLY },
+					{ term: TERM_ANNUALLY, type: TYPE_PREMIUM },
+					{ group: GROUP_WPCOM, term: TERM_ANNUALLY, type: TYPE_PREMIUM },
+				],
+				PLAN_PREMIUM_2_YEARS,
+				[
+					{ group: GROUP_WPCOM },
+					{ type: TYPE_PREMIUM },
+					{ term: TERM_BIENNIALLY },
+					{ group: GROUP_WPCOM, type: TYPE_PREMIUM },
+					{ group: GROUP_WPCOM, term: TERM_BIENNIALLY },
+					{ term: TERM_BIENNIALLY, type: TYPE_PREMIUM },
+					{ group: GROUP_WPCOM, term: TERM_BIENNIALLY, type: TYPE_PREMIUM },
+				],
+				PLAN_PERSONAL,
+				[
+					{ group: GROUP_WPCOM },
+					{ type: TYPE_PERSONAL },
+					{ term: TERM_ANNUALLY },
+					{ group: GROUP_WPCOM, type: TYPE_PERSONAL },
+					{ group: GROUP_WPCOM, term: TERM_ANNUALLY },
+					{ term: TERM_ANNUALLY, type: TYPE_PERSONAL },
+					{ group: GROUP_WPCOM, term: TERM_ANNUALLY, type: TYPE_PERSONAL },
+				],
+				PLAN_PERSONAL_2_YEARS,
+				[
+					{ group: GROUP_WPCOM },
+					{ type: TYPE_PERSONAL },
+					{ term: TERM_BIENNIALLY },
+					{ group: GROUP_WPCOM, type: TYPE_PERSONAL },
+					{ group: GROUP_WPCOM, term: TERM_BIENNIALLY },
+					{ term: TERM_BIENNIALLY, type: TYPE_PERSONAL },
+					{ group: GROUP_WPCOM, term: TERM_BIENNIALLY, type: TYPE_PERSONAL },
+				],
+			],
+		].forEach( ( [ plan, queries ] ) =>
+			queries.forEach( query => {
+				const result = __internal__planMatches( getPlan( plan ), query );
+				expect( result ).to.be.true;
+			} )
+		);
+	} );
+
+	test( 'should return false for queries not matching plans', () => {
+		[
+			[
+				PLAN_FREE,
+				[
+					{ group: GROUP_JETPACK },
+					{ type: TYPE_PERSONAL },
+					{ type: TYPE_PREMIUM },
+					{ term: TERM_MONTHLY },
+					{ term: TERM_BIENNIALLY },
+				],
+				PLAN_BUSINESS,
+				[
+					{ group: GROUP_JETPACK },
+					{ type: TYPE_PERSONAL },
+					{ type: TYPE_PREMIUM },
+					{ term: TERM_MONTHLY },
+					{ term: TERM_BIENNIALLY },
+				],
+				PLAN_BUSINESS_2_YEARS,
+				[
+					{ group: GROUP_JETPACK },
+					{ type: TYPE_PERSONAL },
+					{ type: TYPE_PREMIUM },
+					{ term: TERM_ANNUALLY },
+					{ term: TERM_MONTHLY },
+				],
+				PLAN_PREMIUM,
+				[
+					{ group: GROUP_JETPACK },
+					{ type: TYPE_PERSONAL },
+					{ type: TYPE_BUSINESS },
+					{ term: TERM_MONTHLY },
+					{ term: TERM_BIENNIALLY },
+				],
+				PLAN_PREMIUM_2_YEARS,
+				[
+					{ group: GROUP_JETPACK },
+					{ type: TYPE_PERSONAL },
+					{ type: TYPE_BUSINESS },
+					{ term: TERM_ANNUALLY },
+					{ term: TERM_MONTHLY },
+				],
+				PLAN_PERSONAL,
+				[
+					{ group: GROUP_JETPACK },
+					{ type: TYPE_PREMIUM },
+					{ type: TYPE_BUSINESS },
+					{ term: TERM_MONTHLY },
+					{ term: TERM_BIENNIALLY },
+				],
+				PLAN_PERSONAL_2_YEARS,
+				[
+					{ group: GROUP_JETPACK },
+					{ type: TYPE_PREMIUM },
+					{ type: TYPE_BUSINESS },
+					{ term: TERM_ANNUALLY },
+					{ term: TERM_MONTHLY },
+				],
+			],
+		].forEach( ( [ plan, queries ] ) =>
+			queries.forEach( query => {
+				const result = __internal__planMatches( getPlan( plan ), query );
+				expect( result ).to.be.false;
+			} )
+		);
+	} );
+} );

--- a/client/lib/plans/test/plan-lookups.js
+++ b/client/lib/plans/test/plan-lookups.js
@@ -8,6 +8,8 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
+	GROUP_JETPACK,
+	GROUP_WPCOM,
 	PLAN_BUSINESS,
 	PLAN_BUSINESS_2_YEARS,
 	PLAN_FREE,
@@ -22,8 +24,13 @@ import {
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_PREMIUM,
 	PLAN_PREMIUM_2_YEARS,
+	TERM_ANNUALLY,
+	TERM_BIENNIALLY,
+	TERM_MONTHLY,
+	TYPE_BUSINESS,
+	TYPE_PERSONAL,
 } from '../constants';
-import { isBusinessPlan, isPersonalPlan, isPremiumPlan } from '../index';
+import { isBusinessPlan, isPersonalPlan, isPremiumPlan, planMatches } from '../index';
 
 describe( 'isBusinessPlan', () => {
 	test( 'should return true for all business plans', () => {
@@ -85,5 +92,87 @@ describe( 'isPersonalPlan', () => {
 		expect( isPersonalPlan( PLAN_JETPACK_PREMIUM_MONTHLY ) ).to.be.false;
 		expect( isPersonalPlan( PLAN_JETPACK_BUSINESS ) ).to.be.false;
 		expect( isPersonalPlan( PLAN_JETPACK_BUSINESS_MONTHLY ) ).to.be.false;
+	} );
+} );
+
+describe( 'planMatches - general', () => {
+	test( 'should throw an error if called with unknown query parameter', () => {
+		expect( () => planMatches( PLAN_PERSONAL, { test: 123 } ) ).to.throw();
+	} );
+} );
+
+describe( 'planMatches - personal', () => {
+	test( 'should return true for matching queries', () => {
+		expect( planMatches( PLAN_PERSONAL, { type: TYPE_PERSONAL } ) ).to.be.true;
+		expect( planMatches( PLAN_PERSONAL_2_YEARS, { type: TYPE_PERSONAL } ) ).to.be.true;
+		expect( planMatches( PLAN_JETPACK_PERSONAL, { type: TYPE_PERSONAL } ) ).to.be.true;
+		expect( planMatches( PLAN_JETPACK_PERSONAL_MONTHLY, { type: TYPE_PERSONAL } ) ).to.be.true;
+
+		expect( planMatches( PLAN_PERSONAL, { group: GROUP_WPCOM } ) ).to.be.true;
+		expect( planMatches( PLAN_PERSONAL_2_YEARS, { group: GROUP_WPCOM } ) ).to.be.true;
+		expect( planMatches( PLAN_JETPACK_PERSONAL, { group: GROUP_JETPACK } ) ).to.be.true;
+		expect( planMatches( PLAN_JETPACK_PERSONAL_MONTHLY, { group: GROUP_JETPACK } ) ).to.be.true;
+
+		expect( planMatches( PLAN_PERSONAL, { term: TERM_ANNUALLY } ) ).to.be.true;
+		expect( planMatches( PLAN_PERSONAL_2_YEARS, { term: TERM_BIENNIALLY } ) ).to.be.true;
+		expect( planMatches( PLAN_JETPACK_PERSONAL, { term: TERM_ANNUALLY } ) ).to.be.true;
+		expect( planMatches( PLAN_JETPACK_PERSONAL_MONTHLY, { term: TERM_MONTHLY } ) ).to.be.true;
+	} );
+	test( 'should return false for non-matching queries', () => {
+		expect( planMatches( PLAN_PERSONAL, { type: TYPE_BUSINESS } ) ).to.be.false;
+		expect( planMatches( PLAN_PERSONAL_2_YEARS, { type: TYPE_BUSINESS } ) ).to.be.false;
+		expect( planMatches( PLAN_JETPACK_PERSONAL, { type: TYPE_BUSINESS } ) ).to.be.false;
+		expect( planMatches( PLAN_JETPACK_PERSONAL_MONTHLY, { type: TYPE_BUSINESS } ) ).to.be.false;
+
+		expect( planMatches( PLAN_PERSONAL, { group: GROUP_JETPACK } ) ).to.be.false;
+		expect( planMatches( PLAN_PERSONAL_2_YEARS, { group: GROUP_JETPACK } ) ).to.be.false;
+		expect( planMatches( PLAN_JETPACK_PERSONAL, { group: GROUP_WPCOM } ) ).to.be.false;
+		expect( planMatches( PLAN_JETPACK_PERSONAL_MONTHLY, { group: GROUP_WPCOM } ) ).to.be.false;
+
+		expect( planMatches( PLAN_PERSONAL, { term: TERM_MONTHLY } ) ).to.be.false;
+		expect( planMatches( PLAN_PERSONAL_2_YEARS, { term: TERM_ANNUALLY } ) ).to.be.false;
+		expect( planMatches( PLAN_JETPACK_PERSONAL, { term: TERM_MONTHLY } ) ).to.be.false;
+		expect( planMatches( PLAN_JETPACK_PERSONAL_MONTHLY, { term: TERM_ANNUALLY } ) ).to.be.false;
+	} );
+} );
+
+describe( 'planMatches - business', () => {
+	test( 'should return true for matching queries', () => {
+		expect( planMatches( PLAN_BUSINESS, { type: TYPE_BUSINESS } ) ).to.be.true;
+		expect( planMatches( PLAN_BUSINESS_2_YEARS, { type: TYPE_BUSINESS } ) ).to.be.true;
+		expect( planMatches( PLAN_JETPACK_BUSINESS, { type: TYPE_BUSINESS } ) ).to.be.true;
+		expect( planMatches( PLAN_JETPACK_BUSINESS_MONTHLY, { type: TYPE_BUSINESS } ) ).to.be.true;
+
+		expect( planMatches( PLAN_BUSINESS, { group: GROUP_WPCOM } ) ).to.be.true;
+		expect( planMatches( PLAN_BUSINESS_2_YEARS, { group: GROUP_WPCOM } ) ).to.be.true;
+		expect( planMatches( PLAN_JETPACK_BUSINESS, { group: GROUP_JETPACK } ) ).to.be.true;
+		expect( planMatches( PLAN_JETPACK_BUSINESS_MONTHLY, { group: GROUP_JETPACK } ) ).to.be.true;
+
+		expect( planMatches( PLAN_BUSINESS, { term: TERM_ANNUALLY } ) ).to.be.true;
+		expect( planMatches( PLAN_BUSINESS_2_YEARS, { term: TERM_BIENNIALLY } ) ).to.be.true;
+		expect( planMatches( PLAN_JETPACK_BUSINESS, { term: TERM_ANNUALLY } ) ).to.be.true;
+		expect( planMatches( PLAN_JETPACK_BUSINESS_MONTHLY, { term: TERM_MONTHLY } ) ).to.be.true;
+
+		expect( planMatches( PLAN_BUSINESS, { type: TYPE_BUSINESS, group: GROUP_WPCOM } ) ).to.be.true;
+		expect( planMatches( PLAN_BUSINESS, { type: TYPE_BUSINESS, term: TERM_ANNUALLY } ) ).to.be.true;
+		expect(
+			planMatches( PLAN_BUSINESS, { type: TYPE_BUSINESS, group: GROUP_WPCOM, term: TERM_ANNUALLY } )
+		).to.be.true;
+	} );
+	test( 'should return false for non-matching queries', () => {
+		expect( planMatches( PLAN_BUSINESS, { type: TYPE_PERSONAL } ) ).to.be.false;
+		expect( planMatches( PLAN_BUSINESS_2_YEARS, { type: TYPE_PERSONAL } ) ).to.be.false;
+		expect( planMatches( PLAN_JETPACK_BUSINESS, { type: TYPE_PERSONAL } ) ).to.be.false;
+		expect( planMatches( PLAN_JETPACK_BUSINESS_MONTHLY, { type: TYPE_PERSONAL } ) ).to.be.false;
+
+		expect( planMatches( PLAN_BUSINESS, { group: GROUP_JETPACK } ) ).to.be.false;
+		expect( planMatches( PLAN_BUSINESS_2_YEARS, { group: GROUP_JETPACK } ) ).to.be.false;
+		expect( planMatches( PLAN_JETPACK_BUSINESS, { group: GROUP_WPCOM } ) ).to.be.false;
+		expect( planMatches( PLAN_JETPACK_BUSINESS_MONTHLY, { group: GROUP_WPCOM } ) ).to.be.false;
+
+		expect( planMatches( PLAN_BUSINESS, { term: TERM_MONTHLY } ) ).to.be.false;
+		expect( planMatches( PLAN_BUSINESS_2_YEARS, { term: TERM_ANNUALLY } ) ).to.be.false;
+		expect( planMatches( PLAN_JETPACK_BUSINESS, { term: TERM_MONTHLY } ) ).to.be.false;
+		expect( planMatches( PLAN_JETPACK_BUSINESS_MONTHLY, { term: TERM_ANNUALLY } ) ).to.be.false;
 	} );
 } );

--- a/client/lib/plans/test/plan-lookups.js
+++ b/client/lib/plans/test/plan-lookups.js
@@ -8,173 +8,82 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
-	GROUP_JETPACK,
-	GROUP_WPCOM,
 	PLAN_BUSINESS,
 	PLAN_BUSINESS_2_YEARS,
 	PLAN_FREE,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_PREMIUM,
 	PLAN_PREMIUM_2_YEARS,
-	TERM_ANNUALLY,
-	TERM_BIENNIALLY,
-	TERM_MONTHLY,
-	TYPE_BUSINESS,
-	TYPE_FREE,
-	TYPE_PERSONAL,
-	TYPE_PREMIUM,
 } from '../constants';
-import { getPlan, __internal__planMatches } from '../index';
+import { isBusinessPlan, isPersonalPlan, isPremiumPlan } from '../index';
 
-describe( '__internal__planMatches', () => {
-	test( 'should return true for queries matching plans', () => {
-		[
-			[
-				PLAN_FREE,
-				[
-					{ group: GROUP_WPCOM },
-					{ type: TYPE_FREE },
-					{ term: TERM_ANNUALLY },
-					{ group: GROUP_WPCOM, type: TYPE_FREE },
-					{ group: GROUP_WPCOM, term: TERM_ANNUALLY },
-					{ term: TERM_ANNUALLY, type: TYPE_FREE },
-					{ group: GROUP_WPCOM, term: TERM_ANNUALLY, type: TYPE_FREE },
-				],
-				PLAN_BUSINESS,
-				[
-					{ group: GROUP_WPCOM },
-					{ type: TYPE_BUSINESS },
-					{ term: TERM_ANNUALLY },
-					{ group: GROUP_WPCOM, type: TYPE_BUSINESS },
-					{ group: GROUP_WPCOM, term: TERM_ANNUALLY },
-					{ term: TERM_ANNUALLY, type: TYPE_BUSINESS },
-					{ group: GROUP_WPCOM, term: TERM_ANNUALLY, type: TYPE_BUSINESS },
-				],
-				PLAN_BUSINESS_2_YEARS,
-				[
-					{ group: GROUP_WPCOM },
-					{ type: TYPE_BUSINESS },
-					{ term: TERM_BIENNIALLY },
-					{ group: GROUP_WPCOM, type: TYPE_BUSINESS },
-					{ group: GROUP_WPCOM, term: TERM_BIENNIALLY },
-					{ term: TERM_BIENNIALLY, type: TYPE_BUSINESS },
-					{ group: GROUP_WPCOM, term: TERM_BIENNIALLY, type: TYPE_BUSINESS },
-				],
-				PLAN_PREMIUM,
-				[
-					{ group: GROUP_WPCOM },
-					{ type: TYPE_PREMIUM },
-					{ term: TERM_ANNUALLY },
-					{ group: GROUP_WPCOM, type: TYPE_PREMIUM },
-					{ group: GROUP_WPCOM, term: TERM_ANNUALLY },
-					{ term: TERM_ANNUALLY, type: TYPE_PREMIUM },
-					{ group: GROUP_WPCOM, term: TERM_ANNUALLY, type: TYPE_PREMIUM },
-				],
-				PLAN_PREMIUM_2_YEARS,
-				[
-					{ group: GROUP_WPCOM },
-					{ type: TYPE_PREMIUM },
-					{ term: TERM_BIENNIALLY },
-					{ group: GROUP_WPCOM, type: TYPE_PREMIUM },
-					{ group: GROUP_WPCOM, term: TERM_BIENNIALLY },
-					{ term: TERM_BIENNIALLY, type: TYPE_PREMIUM },
-					{ group: GROUP_WPCOM, term: TERM_BIENNIALLY, type: TYPE_PREMIUM },
-				],
-				PLAN_PERSONAL,
-				[
-					{ group: GROUP_WPCOM },
-					{ type: TYPE_PERSONAL },
-					{ term: TERM_ANNUALLY },
-					{ group: GROUP_WPCOM, type: TYPE_PERSONAL },
-					{ group: GROUP_WPCOM, term: TERM_ANNUALLY },
-					{ term: TERM_ANNUALLY, type: TYPE_PERSONAL },
-					{ group: GROUP_WPCOM, term: TERM_ANNUALLY, type: TYPE_PERSONAL },
-				],
-				PLAN_PERSONAL_2_YEARS,
-				[
-					{ group: GROUP_WPCOM },
-					{ type: TYPE_PERSONAL },
-					{ term: TERM_BIENNIALLY },
-					{ group: GROUP_WPCOM, type: TYPE_PERSONAL },
-					{ group: GROUP_WPCOM, term: TERM_BIENNIALLY },
-					{ term: TERM_BIENNIALLY, type: TYPE_PERSONAL },
-					{ group: GROUP_WPCOM, term: TERM_BIENNIALLY, type: TYPE_PERSONAL },
-				],
-			],
-		].forEach( ( [ plan, queries ] ) =>
-			queries.forEach( query => {
-				const result = __internal__planMatches( getPlan( plan ), query );
-				expect( result ).to.be.true;
-			} )
-		);
+describe( 'isBusinessPlan', () => {
+	test( 'should return true for all business plans', () => {
+		expect( isBusinessPlan( PLAN_BUSINESS ) ).to.be.true;
+		expect( isBusinessPlan( PLAN_BUSINESS_2_YEARS ) ).to.be.true;
+		expect( isBusinessPlan( PLAN_JETPACK_BUSINESS ) ).to.be.true;
+		expect( isBusinessPlan( PLAN_JETPACK_BUSINESS_MONTHLY ) ).to.be.true;
 	} );
+	test( 'should return true for all non-business plans', () => {
+		expect( isBusinessPlan( PLAN_FREE ) ).to.be.false;
+		expect( isBusinessPlan( PLAN_PERSONAL ) ).to.be.false;
+		expect( isBusinessPlan( PLAN_PERSONAL_2_YEARS ) ).to.be.false;
+		expect( isBusinessPlan( PLAN_PREMIUM ) ).to.be.false;
+		expect( isBusinessPlan( PLAN_PREMIUM_2_YEARS ) ).to.be.false;
+		expect( isBusinessPlan( PLAN_JETPACK_FREE ) ).to.be.false;
+		expect( isBusinessPlan( PLAN_JETPACK_PERSONAL ) ).to.be.false;
+		expect( isBusinessPlan( PLAN_JETPACK_PERSONAL_MONTHLY ) ).to.be.false;
+		expect( isBusinessPlan( PLAN_JETPACK_PREMIUM ) ).to.be.false;
+		expect( isBusinessPlan( PLAN_JETPACK_PREMIUM_MONTHLY ) ).to.be.false;
+	} );
+} );
 
-	test( 'should return false for queries not matching plans', () => {
-		[
-			[
-				PLAN_FREE,
-				[
-					{ group: GROUP_JETPACK },
-					{ type: TYPE_PERSONAL },
-					{ type: TYPE_PREMIUM },
-					{ term: TERM_MONTHLY },
-					{ term: TERM_BIENNIALLY },
-				],
-				PLAN_BUSINESS,
-				[
-					{ group: GROUP_JETPACK },
-					{ type: TYPE_PERSONAL },
-					{ type: TYPE_PREMIUM },
-					{ term: TERM_MONTHLY },
-					{ term: TERM_BIENNIALLY },
-				],
-				PLAN_BUSINESS_2_YEARS,
-				[
-					{ group: GROUP_JETPACK },
-					{ type: TYPE_PERSONAL },
-					{ type: TYPE_PREMIUM },
-					{ term: TERM_ANNUALLY },
-					{ term: TERM_MONTHLY },
-				],
-				PLAN_PREMIUM,
-				[
-					{ group: GROUP_JETPACK },
-					{ type: TYPE_PERSONAL },
-					{ type: TYPE_BUSINESS },
-					{ term: TERM_MONTHLY },
-					{ term: TERM_BIENNIALLY },
-				],
-				PLAN_PREMIUM_2_YEARS,
-				[
-					{ group: GROUP_JETPACK },
-					{ type: TYPE_PERSONAL },
-					{ type: TYPE_BUSINESS },
-					{ term: TERM_ANNUALLY },
-					{ term: TERM_MONTHLY },
-				],
-				PLAN_PERSONAL,
-				[
-					{ group: GROUP_JETPACK },
-					{ type: TYPE_PREMIUM },
-					{ type: TYPE_BUSINESS },
-					{ term: TERM_MONTHLY },
-					{ term: TERM_BIENNIALLY },
-				],
-				PLAN_PERSONAL_2_YEARS,
-				[
-					{ group: GROUP_JETPACK },
-					{ type: TYPE_PREMIUM },
-					{ type: TYPE_BUSINESS },
-					{ term: TERM_ANNUALLY },
-					{ term: TERM_MONTHLY },
-				],
-			],
-		].forEach( ( [ plan, queries ] ) =>
-			queries.forEach( query => {
-				const result = __internal__planMatches( getPlan( plan ), query );
-				expect( result ).to.be.false;
-			} )
-		);
+describe( 'isPremiumPlan', () => {
+	test( 'should return true for all premium plans', () => {
+		expect( isPremiumPlan( PLAN_PREMIUM ) ).to.be.true;
+		expect( isPremiumPlan( PLAN_PREMIUM_2_YEARS ) ).to.be.true;
+		expect( isPremiumPlan( PLAN_JETPACK_PREMIUM ) ).to.be.true;
+		expect( isPremiumPlan( PLAN_JETPACK_PREMIUM_MONTHLY ) ).to.be.true;
+	} );
+	test( 'should return true for all non-premium plans', () => {
+		expect( isPremiumPlan( PLAN_FREE ) ).to.be.false;
+		expect( isPremiumPlan( PLAN_BUSINESS ) ).to.be.false;
+		expect( isPremiumPlan( PLAN_BUSINESS_2_YEARS ) ).to.be.false;
+		expect( isPremiumPlan( PLAN_PERSONAL ) ).to.be.false;
+		expect( isPremiumPlan( PLAN_PERSONAL_2_YEARS ) ).to.be.false;
+		expect( isPremiumPlan( PLAN_JETPACK_FREE ) ).to.be.false;
+		expect( isPremiumPlan( PLAN_JETPACK_PERSONAL ) ).to.be.false;
+		expect( isPremiumPlan( PLAN_JETPACK_PERSONAL_MONTHLY ) ).to.be.false;
+		expect( isPremiumPlan( PLAN_JETPACK_BUSINESS ) ).to.be.false;
+		expect( isPremiumPlan( PLAN_JETPACK_BUSINESS_MONTHLY ) ).to.be.false;
+	} );
+} );
+
+describe( 'isPersonalPlan', () => {
+	test( 'should return true for all personal plans', () => {
+		expect( isPersonalPlan( PLAN_PERSONAL ) ).to.be.true;
+		expect( isPersonalPlan( PLAN_PERSONAL_2_YEARS ) ).to.be.true;
+		expect( isPersonalPlan( PLAN_JETPACK_PERSONAL ) ).to.be.true;
+		expect( isPersonalPlan( PLAN_JETPACK_PERSONAL_MONTHLY ) ).to.be.true;
+	} );
+	test( 'should return false for all non-personal plans', () => {
+		expect( isPersonalPlan( PLAN_FREE ) ).to.be.false;
+		expect( isPersonalPlan( PLAN_JETPACK_FREE ) ).to.be.false;
+		expect( isPersonalPlan( PLAN_PREMIUM ) ).to.be.false;
+		expect( isPersonalPlan( PLAN_PREMIUM_2_YEARS ) ).to.be.false;
+		expect( isPersonalPlan( PLAN_BUSINESS ) ).to.be.false;
+		expect( isPersonalPlan( PLAN_BUSINESS_2_YEARS ) ).to.be.false;
+		expect( isPersonalPlan( PLAN_JETPACK_PREMIUM ) ).to.be.false;
+		expect( isPersonalPlan( PLAN_JETPACK_PREMIUM_MONTHLY ) ).to.be.false;
+		expect( isPersonalPlan( PLAN_JETPACK_BUSINESS ) ).to.be.false;
+		expect( isPersonalPlan( PLAN_JETPACK_BUSINESS_MONTHLY ) ).to.be.false;
 	} );
 } );

--- a/client/lib/plans/test/plan-lookups.js
+++ b/client/lib/plans/test/plan-lookups.js
@@ -32,7 +32,7 @@ describe( 'isBusinessPlan', () => {
 		expect( isBusinessPlan( PLAN_JETPACK_BUSINESS ) ).to.be.true;
 		expect( isBusinessPlan( PLAN_JETPACK_BUSINESS_MONTHLY ) ).to.be.true;
 	} );
-	test( 'should return true for all non-business plans', () => {
+	test( 'should return false for all non-business plans', () => {
 		expect( isBusinessPlan( PLAN_FREE ) ).to.be.false;
 		expect( isBusinessPlan( PLAN_PERSONAL ) ).to.be.false;
 		expect( isBusinessPlan( PLAN_PERSONAL_2_YEARS ) ).to.be.false;
@@ -53,7 +53,7 @@ describe( 'isPremiumPlan', () => {
 		expect( isPremiumPlan( PLAN_JETPACK_PREMIUM ) ).to.be.true;
 		expect( isPremiumPlan( PLAN_JETPACK_PREMIUM_MONTHLY ) ).to.be.true;
 	} );
-	test( 'should return true for all non-premium plans', () => {
+	test( 'should return false for all non-premium plans', () => {
 		expect( isPremiumPlan( PLAN_FREE ) ).to.be.false;
 		expect( isPremiumPlan( PLAN_BUSINESS ) ).to.be.false;
 		expect( isPremiumPlan( PLAN_BUSINESS_2_YEARS ) ).to.be.false;

--- a/client/state/selectors/is-business-plan-user.js
+++ b/client/state/selectors/is-business-plan-user.js
@@ -6,7 +6,8 @@
 
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getUserPurchases } from 'state/purchases/selectors';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { GROUP_WPCOM, TYPE_BUSINESS } from '../../lib/plans/constants';
+import { getPlan } from '../../lib/plans/index';
 
 /**
  * Returns a boolean flag indicating if the current user is a business plan user.
@@ -27,5 +28,8 @@ export default state => {
 		return false;
 	}
 
-	return purchases.some( purchase => PLAN_BUSINESS === purchase.productSlug );
+	return purchases.some( purchase => {
+		const plan = getPlan( purchase.productSlug ) || {};
+		return plan.type === TYPE_BUSINESS && plan.group === GROUP_WPCOM;
+	} );
 };

--- a/client/state/selectors/is-business-plan-user.js
+++ b/client/state/selectors/is-business-plan-user.js
@@ -7,7 +7,7 @@
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getUserPurchases } from 'state/purchases/selectors';
 import { GROUP_WPCOM, TYPE_BUSINESS } from '../../lib/plans/constants';
-import { getPlan } from '../../lib/plans/index';
+import { planMatches } from '../../lib/plans/index';
 
 /**
  * Returns a boolean flag indicating if the current user is a business plan user.
@@ -28,8 +28,10 @@ export default state => {
 		return false;
 	}
 
-	return purchases.some( purchase => {
-		const plan = getPlan( purchase.productSlug ) || {};
-		return plan.type === TYPE_BUSINESS && plan.group === GROUP_WPCOM;
-	} );
+	return purchases.some( purchase =>
+		planMatches( purchase.productSlug, {
+			type: TYPE_BUSINESS,
+			group: GROUP_WPCOM,
+		} )
+	);
 };

--- a/client/state/selectors/is-google-my-business-stats-nudge-visible.js
+++ b/client/state/selectors/is-google-my-business-stats-nudge-visible.js
@@ -5,7 +5,8 @@
  */
 import createSelector from 'lib/create-selector';
 import { getSiteOption, getSitePlanSlug } from 'state/sites/selectors';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { TYPE_BUSINESS } from '../../lib/plans/constants';
+import { getPlan } from '../../lib/plans/index';
 
 const WEEK_IN_SECONDS = 60 * 60 * 24 * 7;
 
@@ -32,7 +33,7 @@ const siteHasPromoteGoal = createSelector(
  * @return {Boolean} True if site has business plan
  */
 const siteHasBusinessPlan = createSelector(
-	( state, siteId ) => getSitePlanSlug( state, siteId ) === PLAN_BUSINESS,
+	( state, siteId ) => getPlan( getSitePlanSlug( state, siteId ) ).type === TYPE_BUSINESS,
 	( state, siteId ) => [ getSitePlanSlug( state, siteId ) ]
 );
 

--- a/client/state/selectors/test/is-business-plan-user.js
+++ b/client/state/selectors/test/is-business-plan-user.js
@@ -11,6 +11,7 @@ import deepFreeze from 'deep-freeze';
  */
 import { isBusinessPlanUser } from 'state/selectors';
 import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { PLAN_BUSINESS_2_YEARS } from '../../../lib/plans/constants';
 
 describe( 'isBusinessPlanUser()', () => {
 	test( 'should return true if any purchase is a business plan.', () => {
@@ -27,6 +28,29 @@ describe( 'isBusinessPlanUser()', () => {
 					{
 						user_id: '123',
 						product_slug: PLAN_BUSINESS,
+					},
+				],
+				hasLoadedUserPurchasesFromServer: true,
+			},
+		} );
+
+		assert.isTrue( isBusinessPlanUser( state ) );
+	} );
+
+	test( 'should return true if any purchase is a business plan (2-years).', () => {
+		const state = deepFreeze( {
+			currentUser: {
+				id: 123,
+			},
+			purchases: {
+				data: [
+					{
+						user_id: '123',
+						product_slug: 'some-other-plan',
+					},
+					{
+						user_id: '123',
+						product_slug: PLAN_BUSINESS_2_YEARS,
 					},
 				],
 				hasLoadedUserPurchasesFromServer: true,
@@ -77,7 +101,7 @@ describe( 'isBusinessPlanUser()', () => {
 					{
 						// intentionally put a purchase that doesn't belong to the user 123 here.
 						user_id: '789',
-						product_slug: PLAN_BUSINESS,
+						product_slug: PLAN_BUSINESS_2_YEARS,
 					},
 				],
 				hasLoadedUserPurchasesFromServer: true,


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/23075 and 2-year plans in general (p9jf6J-eR-p2).

We are adding a set of plans to make 2-year subscriptions possible. Current codebase assumes that there is just one variant of each plan type (except for jetpack annual/monthly subscriptions). I can see at least the following problems off the top of my head:

1. Comparisons like `planSlug === PLAN_BUSINESS` would have to check also for `PLAN_BUSINESS_2_YEAR`
2. Code fragments like `<Banner plan={PLAN_BUSINESS} />` may need to receive `PLAN_BUSINESS_2_YEAR` if user is subscribed to a 2-year plan

This PR proposes a solution to above and similar issues. I went through all places where plan constants were used directly and sketched this code and it seems to cover all use cases I saw. Instead of using/comparing plans constants directly, we introduce some metadata to `PLANS_LIST` and also a few helper functions to encapsulate that logic.

We can get rid of some checks like `planSlug === PLAN_BUSINESS`  in favour of checking features, like here: https://github.com/Automattic/wp-calypso/pull/23076 - however this is not possible in all (most) cases.

With this PR, you can check like 
```js
planMatches(planSlug,  {type: TYPE_BUSINESS}); // or shortcut: isBusinessPlan( planSlug );
```

If you need to check just for jetpack or wp.com specific plans, you can do
```js
planMatches(planSlug, {type: TYPE_BUSINESS, group: GROUP_WPCOM})
```

Or, let's say you need a business plan with the same subscription term as active user and related to the same site (jetpack/wp) as current user's plan:
```js
findSimilarPlan(currentPlanSlug, {type: TYPE_BUSINESS})
```

Not only this would allow us to remove some boilerplate code from many components, but would also introduce a consistent way to work with plans - currently they are dealt with in a dozens of different ways.

Finally, with this PR we are able to get rid of other constants such as:
```js
export const JETPACK_PLANS = [
export const JETPACK_MONTHLY_PLANS = [
```
And have PLANS_LIST as a single source of truth allowing us to cross-reference anything in any way without other constants containing additional groupings.

Most important changes are in these two files:
* client/lib/plans/constants.js
* client/lib/plans/index.js

**Test plan:**
~~There is none, this is a prototype and I do not intend to merge this in it's current form. Some function names could be changes etc. My purpose here is to discuss if this way of approaching the problem fits everyone, or if we should take this in a different direction.~~

This change touches number of areas in Calypso:

The following components:
* client/components/banner/index.jsx
* client/components/plans/plan-icon/index.jsx
* client/components/seo/preview-upgrade-nudge/index.jsx

The following functions:
* `getPlanClass()`
* `getMonthlyPlanByYearly()`
* `getYearlyPlanByMonthly()`
* `planLevelsMatch()`

The following selectors:
* `siteHasBusinessPlan()`
* `isBusinessPlanUser()`

It doesn't break any unit tests. It would be best to test it with a full run of e2e tests. In order to test that manually, here's a proposed protocol:

1. Check if purchase/upgrade page with plans displays correct prices and looks properly.
1. Check if purchase/upgrade page with plans displays correct details about current plan and upgrade options for monthly users
1. Check if GoogleMyBusinessStatsNudge is displayed on stats page only for business customers
1. Check if ChatBusinessConciergeNotice in contact form is displayed only to business customers
1. Check if `Upgrade to yearly billing` button on billing page leads to a correct outcome for monthly customers
1. Check if upgrade nudges, such as those in Google Analytics section, have correct plan class (free/personal/premium)
1. Check if upgrade nudges specifically in SEO Preview section show correct details and have correct CSS class