### PR TITLE
People: Add a button text to the invite button

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -359,6 +359,7 @@
 @import 'my-sites/people/people-invite-details/style';
 @import 'my-sites/people/people-invites/style';
 @import 'my-sites/people/people-list-item/style';
+@import 'my-sites/people/people-list-section-header/style';
 @import 'my-sites/people/people-notices/style';
 @import 'my-sites/people/people-profile/style';
 @import 'my-sites/plan-compare-card/style';

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -198,7 +198,7 @@ class PeopleInvites extends React.PureComponent {
 				</div>
 				<Button primary={ isPrimary } href={ `/people/new/${ site.slug }` }>
 					<Gridicon icon="user-add" />
-					{ translate( 'Invite', { context: 'button label' } ) }
+					{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
 				</Button>
 			</div>
 		);

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -198,7 +198,7 @@ class PeopleInvites extends React.PureComponent {
 				</div>
 				<Button primary={ isPrimary } href={ `/people/new/${ site.slug }` }>
 					<Gridicon icon="user-add" />
-					{ translate( 'Invite People', { context: 'button label' } ) }
+					{ translate( 'Invite', { context: 'button label' } ) }
 				</Button>
 			</div>
 		);

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -198,7 +198,7 @@ class PeopleInvites extends React.PureComponent {
 				</div>
 				<Button primary={ isPrimary } href={ `/people/new/${ site.slug }` }>
 					<Gridicon icon="user-add" />
-					{ translate( 'Invite user', { context: 'button label' } ) }
+					{ translate( 'Invite People', { context: 'button label' } ) }
 				</Button>
 			</div>
 		);

--- a/client/my-sites/people/people-invites/style.scss
+++ b/client/my-sites/people/people-invites/style.scss
@@ -8,10 +8,8 @@
 	}
 
 	.button {
-		padding: 6px 16px 6px 12px;
-
 		.gridicon {
-			margin-right: 8px;
+			margin-right: 4px;
 		}
 	}
 

--- a/client/my-sites/people/people-list-section-header/README.md
+++ b/client/my-sites/people/people-list-section-header/README.md
@@ -1,7 +1,7 @@
 PeopleListSectionHeader
 =============
 
-This component is responsible for displaying the "add" button the section header above each list of people.
+This component is responsible for displaying the "invite people" button the section header above each list of people.
 
 ### Properties
 - `label` - (string) The text to be displayed as a label for the section header

--- a/client/my-sites/people/people-list-section-header/README.md
+++ b/client/my-sites/people/people-list-section-header/README.md
@@ -1,7 +1,7 @@
 PeopleListSectionHeader
 =============
 
-This component is responsible for displaying the "invite people" button the section header above each list of people.
+This component is responsible for displaying the "invite" button the section header above each list of people.
 
 ### Properties
 - `label` - (string) The text to be displayed as a label for the section header

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -17,8 +17,6 @@ import { localize } from 'i18n-calypso';
  */
 import SectionHeader from 'components/section-header';
 import Button from 'components/button';
-import ButtonGroup from 'components/button-group';
-import Tooltip from 'components/tooltip';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 
@@ -34,17 +32,6 @@ class PeopleListSectionHeader extends Component {
 	static defaultProps = {
 		isFollower: false,
 	};
-
-	constructor( props ) {
-		super( props );
-		this.state = {
-			addPeopleTooltip: false,
-		};
-	}
-
-	showAddTooltip = () => this.setState( { addPeopleTooltip: true } );
-
-	hideAddTooltip = () => this.setState( { addPeopleTooltip: false } );
 
 	getAddLink() {
 		const siteSlug = get( this.props, 'site.slug' );
@@ -66,27 +53,10 @@ class PeopleListSectionHeader extends Component {
 			<SectionHeader className={ classes } count={ count } label={ label }>
 				{ children }
 				{ siteLink && (
-					<ButtonGroup>
-						<Button
-							compact
-							href={ siteLink }
-							className="people-list-section-header__add-button"
-							onMouseEnter={ this.showAddTooltip }
-							onMouseLeave={ this.hideAddTooltip }
-							ref="addPeopleButton"
-							aria-label={ translate( 'Invite user', { context: 'button label' } ) }
-						>
-							<Gridicon icon="plus-small" size={ 18 } />
-							<Gridicon icon="user" size={ 18 } />
-							<Tooltip
-								isVisible={ this.state.addPeopleTooltip }
-								context={ this.refs && this.refs.addPeopleButton }
-								position="bottom"
-							>
-								{ translate( 'Invite user', { context: 'button tooltip' } ) }
-							</Tooltip>
-						</Button>
-					</ButtonGroup>
+					<Button compact href={ siteLink } className="people-list-section-header__add-button">
+						<Gridicon icon="user-add" />
+						{ translate( 'Invite People', { context: 'button label' } ) }
+					</Button>
 				) }
 			</SectionHeader>
 		);

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -55,7 +55,7 @@ class PeopleListSectionHeader extends Component {
 				{ siteLink && (
 					<Button compact href={ siteLink } className="people-list-section-header__add-button">
 						<Gridicon icon="user-add" />
-						{ translate( 'Invite', { context: 'button label' } ) }
+						{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
 					</Button>
 				) }
 			</SectionHeader>

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -55,7 +55,7 @@ class PeopleListSectionHeader extends Component {
 				{ siteLink && (
 					<Button compact href={ siteLink } className="people-list-section-header__add-button">
 						<Gridicon icon="user-add" />
-						{ translate( 'Invite People', { context: 'button label' } ) }
+						{ translate( 'Invite', { context: 'button label' } ) }
 					</Button>
 				) }
 			</SectionHeader>

--- a/client/my-sites/people/people-list-section-header/style.scss
+++ b/client/my-sites/people/people-list-section-header/style.scss
@@ -1,0 +1,5 @@
+.people-list-section-header__add-button.is-compact {
+	@include breakpoint( "<480px" ) {
+		font-size: 0;
+	}
+}

--- a/client/my-sites/people/people-list-section-header/style.scss
+++ b/client/my-sites/people/people-list-section-header/style.scss
@@ -1,5 +1,8 @@
 .people-list-section-header__add-button.is-compact {
 	@include breakpoint( "<480px" ) {
 		font-size: 0;
+		.gridicon {
+			margin-right: 0;
+		}
 	}
 }


### PR DESCRIPTION
The invite user button doesn't have button text even on desktop size viewport. This PR intends to add a button text of "Invite People" with an icon, "user add". The button text will be hidden with a viewport smaller than 480px.

**Before:**
<img width="728" alt="screen shot 2018-03-07 at 15 52 24" src="https://user-images.githubusercontent.com/908665/37106596-1ab02c1e-222a-11e8-9217-874ab245d178.png">

**After:**
<img width="725" alt="screen shot 2018-03-07 at 15 52 48" src="https://user-images.githubusercontent.com/908665/37106466-d182068e-2229-11e8-80b8-3a7f7fdca99f.png">

**<480px:**
<img width="469" alt="screen shot 2018-03-07 at 15 54 01" src="https://user-images.githubusercontent.com/908665/37106919-e47c4b18-222a-11e8-8d81-b81679b1d120.png">

This PR also changes a button in the invite section from "invite user" to "invite people" to be consistent.

<img width="414" alt="screen shot 2018-03-07 at 15 54 28" src="https://user-images.githubusercontent.com/908665/37106559-07df840e-222a-11e8-8d3b-af86ceed9b56.png">
 

