### PR TITLE
Framework: Bump Gridicons to 2.2.0

### DIFF
--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -53,7 +53,7 @@ import FormFields from 'components/forms/docs/example';
 import Gauge from 'components/gauge/docs/example';
 import GlobalNotices from 'components/global-notices/docs/example';
 import Gravatar from 'components/gravatar/docs/example';
-import Gridicons from 'gridicons/build/example';
+import Gridicons from 'gridicons/example';
 import HeaderButton from 'components/header-button/docs/example';
 import Headers from 'components/header-cake/docs/example';
 import ImagePreloader from 'components/image-preloader/docs/example';

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -158,12 +158,12 @@
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.0"
+        "acorn": "5.5.1"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.5.0",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
+          "version": "5.5.1",
+          "integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ==",
           "dev": true
         }
       }
@@ -529,7 +529,7 @@
       "integrity": "sha1-a8vQOKM3xwYn5/zkQ4+lgYjwk3s=",
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000812",
+        "caniuse-db": "1.0.30000813",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -1385,8 +1385,8 @@
           "version": "2.11.3",
           "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
           "requires": {
-            "caniuse-lite": "1.0.30000812",
-            "electron-to-chromium": "1.3.35"
+            "caniuse-lite": "1.0.30000813",
+            "electron-to-chromium": "1.3.36"
           }
         },
         "semver": {
@@ -1900,7 +1900,7 @@
       "version": "1.3.6",
       "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
       "requires": {
-        "caniuse-db": "1.0.30000812"
+        "caniuse-db": "1.0.30000813"
       }
     },
     "bser": {
@@ -2046,12 +2046,12 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000812",
-      "integrity": "sha1-KcKN1pJ+5D6MKrZI5SNqyRbJfWk="
+      "version": "1.0.30000813",
+      "integrity": "sha1-4KHGA/iICteHsqNWUrJzPzKl4po="
     },
     "caniuse-lite": {
-      "version": "1.0.30000812",
-      "integrity": "sha512-j+l55ayQ9BO4Sy9iVfbf99+G+4ddAmkXoiEt73WCW4vJ83usrlHzDkFEnNXe5/swkVqE7YBm5i8M2uRXlx9vWg=="
+      "version": "1.0.30000813",
+      "integrity": "sha512-A8ITSmH5SFdMFdC704ggjg+x2z5PzQmVlG8tavwnfvbC33Q1UYrj0+G+Xm0SNAnd4He36fwUE/KEWytOEchw+A=="
     },
     "cardinal": {
       "version": "1.0.0",
@@ -3405,13 +3405,13 @@
       "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.0",
+        "acorn": "5.5.1",
         "defined": "1.0.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.5.0",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
+          "version": "5.5.1",
+          "integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ==",
           "dev": true
         }
       }
@@ -3448,7 +3448,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000812",
+        "caniuse-db": "1.0.30000813",
         "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
         "jsonfilter": "1.1.2",
@@ -3645,8 +3645,8 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.35",
-      "integrity": "sha1-aTwXz7k4QdOMtZuN8BnRfjVphfA="
+      "version": "1.3.36",
+      "integrity": "sha1-Dqv3Gp6+qQE/scw1o5DgaGJPJ+g="
     },
     "elliptic": {
       "version": "6.4.0",
@@ -4427,13 +4427,13 @@
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.0",
+        "acorn": "5.5.1",
         "acorn-jsx": "3.0.1"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.5.0",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
+          "version": "5.5.1",
+          "integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ==",
           "dev": true
         }
       }
@@ -4989,8 +4989,8 @@
       "dev": true
     },
     "flow-parser": {
-      "version": "0.66.0",
-      "integrity": "sha1-vlg/77ARkqpRZEFdMaYkGzVxiYM=",
+      "version": "0.67.0",
+      "integrity": "sha1-OTXa9jO7tKJxT81lIzKzHNlsDqg=",
       "dev": true
     },
     "flush-write-stream": {
@@ -5103,8 +5103,8 @@
       }
     },
     "formidable": {
-      "version": "1.1.1",
-      "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak="
+      "version": "1.2.0",
+      "integrity": "sha512-hr9aT30rAi7kf8Q2aaTpSP7xGMhlJ+MdrUDVZs3rxbD3L/K46A86s2VY7qC2D2kGYGBtiT/3j6wTx1eeUq5xAQ=="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -6273,8 +6273,8 @@
       }
     },
     "gridicons": {
-      "version": "2.1.3",
-      "integrity": "sha512-3gvt0TAKUKt+BBJ0vboxuaSPriGfJP5aRIyxLPJzlVYzCd3mVHxHFMMzf9UUVb1tv/jzTicakHFo9a9YLTnZCw==",
+      "version": "2.2.0-alpha.1",
+      "integrity": "sha512-HuTNaKECPvbQ+GL3Ud+6Y8xHi7w0AB6kIJ2XtVsEzOXPoi5rW/X1FPfzY4hqo3e/NvvIfKeC/Bd29vp563y5pw==",
       "requires": {
         "prop-types": "15.5.10"
       }
@@ -8730,7 +8730,7 @@
         "babylon": "6.18.0",
         "colors": "1.1.2",
         "es6-promise": "3.3.1",
-        "flow-parser": "0.66.0",
+        "flow-parser": "0.67.0",
         "lodash": "4.17.5",
         "micromatch": "2.3.11",
         "node-dir": "0.1.8",
@@ -8916,7 +8916,7 @@
       "dev": true,
       "requires": {
         "abab": "1.0.4",
-        "acorn": "5.5.0",
+        "acorn": "5.5.1",
         "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
         "browser-process-hrtime": "0.1.2",
@@ -8944,8 +8944,8 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.5.0",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
+          "version": "5.5.1",
+          "integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ==",
           "dev": true
         },
         "parse5": {
@@ -10030,11 +10030,6 @@
         "moment": "2.21.0"
       }
     },
-    "moo": {
-      "version": "0.4.3",
-      "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
-      "dev": true
-    },
     "morgan": {
       "version": "1.2.0",
       "integrity": "sha1-jcF6V1mVmPgM16fh47VOcsaJkQ0=",
@@ -10171,11 +10166,10 @@
       }
     },
     "nearley": {
-      "version": "2.12.1",
-      "integrity": "sha512-FQyYKOKm5DgqzJkR6C9GhlRoYdrcRKXJF2qi9Y/4K4Cd2BN4Sglven0LO3dR8w1BQ72Ty5s+/XzA/FtN9Gx50w==",
+      "version": "2.13.0",
+      "integrity": "sha512-ioYYogSaZhFlCpRizQgY3UT3G1qFXmHGY/5ozoFE3dMfiCRAeJfh+IPE3/eh9gCZvqLhPCWb4bLt7Bqzo+1mLQ==",
       "dev": true,
       "requires": {
-        "moo": "0.4.3",
         "nomnom": "1.6.2",
         "railroad-diagrams": "1.0.0",
         "randexp": "0.4.6",
@@ -10359,7 +10353,7 @@
         "readable-stream": "2.3.5",
         "stream-browserify": "2.0.1",
         "stream-http": "2.8.0",
-        "string_decoder": "1.0.3",
+        "string_decoder": "1.1.0",
         "timers-browserify": "2.0.6",
         "tty-browserify": "0.0.0",
         "url": "0.11.0",
@@ -10382,11 +10376,20 @@
             "safe-buffer": "5.1.1",
             "string_decoder": "1.0.3",
             "util-deprecate": "1.0.2"
+          },
+          "dependencies": {
+            "string_decoder": {
+              "version": "1.0.3",
+              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            }
           }
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "version": "1.1.0",
+          "integrity": "sha512-8zQpRF6juocE69ae7CSPmYEGJe4VCXwP6S6dxUWI7i53Gwv54/ec41fiUA+X7BPGGv7fRSQJjBQVa0gomGaOgg==",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -13580,7 +13583,7 @@
       "dev": true,
       "requires": {
         "lodash.flattendeep": "4.4.0",
-        "nearley": "2.12.1"
+        "nearley": "2.13.0"
       }
     },
     "rtlcss": {
@@ -14916,7 +14919,7 @@
         "debug": "2.2.0",
         "extend": "3.0.1",
         "form-data": "1.0.0-rc4",
-        "formidable": "1.1.1",
+        "formidable": "1.2.0",
         "methods": "1.1.2",
         "mime": "1.3.4",
         "qs": "6.5.1",
@@ -16422,7 +16425,7 @@
       "version": "3.10.0",
       "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
       "requires": {
-        "acorn": "5.5.0",
+        "acorn": "5.5.1",
         "acorn-dynamic-import": "2.0.2",
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
@@ -16447,8 +16450,8 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.5.0",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g=="
+          "version": "5.5.1",
+          "integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ=="
         },
         "ajv-keywords": {
           "version": "2.1.1",
@@ -16669,7 +16672,7 @@
       "integrity": "sha1-Y+2G63HMTNqG9o5oWoRTC6ASZEk=",
       "dev": true,
       "requires": {
-        "acorn": "5.5.0",
+        "acorn": "5.5.1",
         "chalk": "1.1.3",
         "commander": "2.14.1",
         "ejs": "2.5.7",
@@ -16692,8 +16695,8 @@
           }
         },
         "acorn": {
-          "version": "5.5.0",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
+          "version": "5.5.1",
+          "integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ==",
           "dev": true
         },
         "body-parser": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "fuse.js": "2.6.1",
     "get-video-id": "2.1.4",
     "globby": "6.1.0",
-    "gridicons": "2.1.3",
+    "gridicons": "2.2.0-alpha.1",
     "happypack": "4.0.0",
     "hard-source-webpack-plugin": "0.3.12",
     "hash.js": "1.1.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -168,6 +168,7 @@ const webpackConfig = {
 		modules: [ path.join( __dirname, 'client' ), 'node_modules' ],
 		alias: Object.assign(
 			{
+				'gridicons/example': 'gridicons/cjs/example',
 				'react-virtualized': 'react-virtualized/dist/commonjs',
 				'social-logos/example': 'social-logos/build/example',
 			},


### PR DESCRIPTION
Companion PR to https://github.com/Automattic/gridicons/pull/284. For now, we're not changing the way we're importing Gridicons (still transpiled CJS) code -- this is just for verifying we're not breaking that.

To test:
* `npm run distclean`
* `npm start`

Verify that Gridicons still work.