### PR TITLE
Ads: Add section title to settings and remove old buttons

### DIFF
--- a/client/my-sites/ads/form-settings.jsx
+++ b/client/my-sites/ads/form-settings.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import notices from 'notices';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
@@ -14,11 +14,10 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import Card from 'components/card';
 import StateSelector from 'components/forms/us-state-selector';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
-import FormButton from 'components/forms/form-button';
-import FormButtonsBar from 'components/forms/form-buttons-bar';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -28,6 +27,7 @@ import FormCheckbox from 'components/forms/form-checkbox';
 import FormSelect from 'components/forms/form-select';
 import FormTextInput from 'components/forms/form-text-input';
 import WordadsActions from 'lib/ads/actions';
+import SectionHeader from 'components/section-header';
 import SettingsStore from 'lib/ads/settings-store';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
@@ -522,38 +522,35 @@ class AdsFormSettings extends Component {
 
 	render() {
 		const { translate } = this.props;
+		const isPending = this.state.isLoading || this.state.isSubmitting;
 
 		return (
-			<Card>
-				<form
-					id="wordads-settings"
-					onSubmit={ this.handleSubmit }
-					onChange={ this.props.markChanged }
-				>
-					<FormButtonsBar>
-						<FormButton disabled={ this.state.isLoading || this.state.isSubmitting }>
-							{ this.state.isSubmitting ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
-						</FormButton>
-					</FormButtonsBar>
+			<Fragment>
+				<SectionHeader label={ translate( 'Ads Settings' ) }>
+					<Button compact primary onClick={ this.handleSubmit } disabled={ isPending }>
+						{ isPending ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
+					</Button>
+				</SectionHeader>
 
-					{ ! this.props.siteIsJetpack ? this.showAdsToOptions() : null }
+				<Card>
+					<form
+						id="wordads-settings"
+						onSubmit={ this.handleSubmit }
+						onChange={ this.props.markChanged }
+					>
+						{ ! this.props.siteIsJetpack ? this.showAdsToOptions() : null }
 
-					{ ! this.props.siteIsJetpack ? this.displayOptions() : null }
+						{ ! this.props.siteIsJetpack ? this.displayOptions() : null }
 
-					<FormSectionHeading>{ translate( 'Site Owner Information' ) }</FormSectionHeading>
-					{ this.siteOwnerOptions() }
-					{ this.state.us_checked ? this.taxOptions() : null }
+						<FormSectionHeading>{ translate( 'Site Owner Information' ) }</FormSectionHeading>
+						{ this.siteOwnerOptions() }
+						{ this.state.us_checked ? this.taxOptions() : null }
 
-					<FormSectionHeading>{ translate( 'Terms of Service' ) }</FormSectionHeading>
-					{ this.acceptCheckbox() }
-
-					<FormButtonsBar>
-						<FormButton disabled={ this.state.isLoading || this.state.isSubmitting }>
-							{ this.state.isSubmitting ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
-						</FormButton>
-					</FormButtonsBar>
-				</form>
-			</Card>
+						<FormSectionHeading>{ translate( 'Terms of Service' ) }</FormSectionHeading>
+						{ this.acceptCheckbox() }
+					</form>
+				</Card>
+			</Fragment>
 		);
 	}
 }


### PR DESCRIPTION
This PR updates the Ads settings page to have a section title with a save button, just like the rest of site settings; also removes the two large buttons that we used to have there. The section title gives the user some context, and together with the new button makes it more consistent with how our site settings in Calypso look and work.

Before:
![](https://cldup.com/h3RnKe3JB9.png)

After:
![](https://cldup.com/cSvn-_QW_K.png)

Part of #22696.

To test:
* Checkout this branch.
* Go to `http://calypso.localhost:3000/ads/settings/:site`, where `:site` is a Jetpack site that has WordAds enabled.
* Verify the form looks as shown on the screenshots. 
* Verify saving works, and while saving, button is disabled together with the form fields.
* Verify the save button is disabled while loading the ads settings, at the same time when the form fields are disabled.