### PR TITLE
Components: remove noticon for SelectDropdown

### DIFF
--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -257,6 +257,7 @@ class SelectDropdown extends Component {
 						{ 'number' === typeof this.props.selectedCount && (
 							<Count count={ this.props.selectedCount } />
 						) }
+						<Gridicon icon="chevron-down" size={ 18 } />
 					</div>
 
 					<ul

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -72,9 +72,10 @@ $compact-header-height: 35;
 	cursor: pointer;
 
 	.gridicons-chevron-down {
-		fill: $gray;
+		fill: $gray-darken-20;
 		margin: 0;
 		flex-shrink: 0;
+		transition: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 	}
 
 	.is-compact & {
@@ -95,6 +96,10 @@ $compact-header-height: 35;
 		border-radius: 4px 4px 0 0;
 		box-shadow: none;
 		background-color: $gray-light;
+
+		.gridicons-chevron-down {
+			transform: rotate( 180deg );
+		}
 	}
 
 	.accessible-focus .select-dropdown:not(.is-open) .select-dropdown__container:focus & {

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -82,7 +82,6 @@ $compact-header-height: 35;
 		height: #{$compact-header-height }px;
 		line-height: #{$compact-header-height - 3 }px;
 		padding-right: #{ $side-margin / 2 }px;
-		color: $gray-text-min;
 		font-size: 12px;
 
 		.count {
@@ -98,7 +97,7 @@ $compact-header-height: 35;
 		background-color: $gray-light;
 
 		.gridicons-chevron-down {
-			transform: rotate( 180deg );
+			transform: rotate( -180deg );
 		}
 	}
 

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -256,7 +256,7 @@ $compact-header-height: 35;
 
 .select-dropdown__label {
 	display: block;
-	color: $gray-lighten-10;
+	color: $gray-text-min;
 	line-height: 20px;
 
 	label {

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -53,8 +53,11 @@ $compact-header-height: 35;
 .select-dropdown__header {
 	height: #{ $header-height }px;
 	line-height: #{ $header-height - 3 }px;
-	padding: 0 32px 0 #{ $side-margin }px;
+	padding: 0 #{ $side-margin }px 0 #{ $side-margin }px;
 	box-sizing: border-box;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 
 	border-style: solid;
 	border-color: $gray-lighten-20;
@@ -68,32 +71,16 @@ $compact-header-height: 35;
 	transition: background-color 0.2s ease;
 	cursor: pointer;
 
-	// down-arrow
-	&::after {
-		@include noticon('\f431', 22px);
-
-		display: block;
-		width: 20px;
-		line-height: #{ $header-height - 1 }px;
-		color: rgba( $gray, 0.5 );
-
-		position: absolute;
-			right: 14px;
-			top: 0px;
-
-		.is-compact & {
-			right: 5px;
-			line-height: #{ $compact-header-height }px;
-		}
-	}
-
-	.has-count & {
-		padding-right: 75px;
+	.gridicons-chevron-down {
+		fill: $gray;
+		margin: 0;
+		flex-shrink: 0;
 	}
 
 	.is-compact & {
 		height: #{$compact-header-height }px;
 		line-height: #{$compact-header-height - 3 }px;
+		padding-right: #{ $side-margin / 2 }px;
 		color: $gray-text-min;
 		font-size: 12px;
 
@@ -108,10 +95,6 @@ $compact-header-height: 35;
 		border-radius: 4px 4px 0 0;
 		box-shadow: none;
 		background-color: $gray-light;
-
-		&::after {
-			content: '\f432';
-		}
 	}
 
 	.accessible-focus .select-dropdown:not(.is-open) .select-dropdown__container:focus & {
@@ -123,6 +106,17 @@ $compact-header-height: 35;
 		right: 40px;
 		top: #{ ( $header-height - 18 - 2 ) / 2 }px;
 	}
+}
+
+.select-dropdown__header-text {
+	display: block;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
+
+	.has-count & {
+		padding-right: 40px;
+	}
 
 	.gridicon {
 		margin-right: #{ ( $side-margin / 2 ) }px;
@@ -133,13 +127,6 @@ $compact-header-height: 35;
 			top: 2px;
 		}
 	}
-}
-
-.select-dropdown__header-text {
-	display: block;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-	overflow: hidden;
 }
 
 .select-dropdown__options {

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -17,7 +17,6 @@
 	}
 
 	.select-dropdown__header {
-		padding: 0 #{ $side-margin + 20 }px 0 #{ $side-margin }px;
 		max-width: ( $sidebar-width-max - $accordion-padding * 2 );
 
 		@include breakpoint( "<660px" ) {


### PR DESCRIPTION
Before, the SelectDropdown component used a noticon for the chevron icon. This changes the layout quite a bit in order to include a Gridicon. The text and icons now use flexbox.

Note that this does not affect `select` elements. Those use background images to display the chevron icon.

Things to test:

- Section navs that use the select dropdown on small viewports
- compact versions
- IE

Before

![screen shot 2018-03-07 at 11 46 54 am](https://user-images.githubusercontent.com/618551/37109542-ecd8b0e2-21ff-11e8-82e1-639519aa2959.png)
![screen shot 2018-03-07 at 11 46 47 am](https://user-images.githubusercontent.com/618551/37109543-ecefe3ca-21ff-11e8-8d4b-a062652439fe.png)

After

![screen shot 2018-03-07 at 11 57 26 am](https://user-images.githubusercontent.com/618551/37109589-09795e36-2200-11e8-8ddf-408b5559833e.png)
![screen shot 2018-03-07 at 11 57 21 am](https://user-images.githubusercontent.com/618551/37109590-098c75ac-2200-11e8-8bf4-c579c75ad99c.png)
