### PR TITLE
Store: Add footer text setting to the email settings page

### DIFF
--- a/client/extensions/woocommerce/app/settings/email/email-settings/index.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/index.js
@@ -53,6 +53,14 @@ const originNotifications = [
 		subtitle: translate( 'If recipients reply to store emails they will be sent to this address.' ),
 		checkEmail: true,
 	},
+	{
+		field: 'email',
+		option: 'woocommerce_email_footer_text',
+		title: translate( 'Footer text' ),
+		subtitle: translate(
+			"The text to appear in the footer of store emails. {site_title} can be used to show your site's name."
+		),
+	},
 ];
 
 const internalNotifications = [


### PR DESCRIPTION
This PR adds an email footer text setting to the email settings page, now that we removed the override filter from wc-calypso-bridge (see https://github.com/Automattic/wc-calypso-bridge/pull/37#issuecomment-370036604).

New stores will default to having the dynamic site title as the email footer, but older stores may have a stale value (i.e. the actual text "Site Title" which the filter was designed to fix). Adding the setting here will allow users to fix this on their own without having to dig through wp-admin to fix it.

<img width="666" alt="screen shot 2018-03-07 at 10 30 25 am" src="https://user-images.githubusercontent.com/689165/37110741-94e2c0a6-21f2-11e8-908d-3a2bd097e1ad.png">

This depends on https://github.com/Automattic/wc-calypso-bridge/pull/40. Marking as 'In Progress' until that is merged.

To Test:
* Go to `http://calypso.localhost:3000/store/settings/email/:site`
* Verify you see the `Footer text` setting and a value is present
* Test updating and saving the value