### PR TITLE
Add New Site: streamline new site page

### DIFF
--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -30,9 +30,9 @@ class JetpackNewSite extends Component {
 		return config( 'signup_url' ) + '?ref=calypso-selector';
 	}
 
-	handleJetpackSubmit = () => {
+	handleGetNewJetpackSiteUrl = () => {
 		this.props.recordTracksEvent( 'calypso_jetpack_new_site_connect_click' );
-		page( '/jetpack/connect?url=' + this.state.jetpackUrl );
+		page( '/jetpack/connect' );
 	};
 
 	handleBack( event ) {
@@ -51,19 +51,13 @@ class JetpackNewSite extends Component {
 							{ this.props.translate( 'Add a New Site' ) }
 						</h1>
 						<p className="formatted-header__subtitle">
-							{ this.props.translate(
-								'Create a new site or add your existing self-hosted site.'
-							) }{' '}
+							{ this.props.translate( 'Create a new site or add your existing self-hosted site.' ) }{' '}
 						</p>
 					</header>
 					<div className="jetpack-new-site__content">
 						<Card className="jetpack-new-site__card">
 							<div className="jetpack-new-site__card-description">
-								<p>
-									{ this.props.translate(
-										'Create a shiny new WordPress.com site.'
-									) }
-								</p>
+								<p>{ this.props.translate( 'Create a shiny new WordPress.com site.' ) }</p>
 							</div>
 							<Button
 								className="jetpack-new-site__button button is-primary"
@@ -85,7 +79,7 @@ class JetpackNewSite extends Component {
 							</div>
 							<Button
 								className="jetpack-new-site__connect-button button is-primary"
-								onClick={ this.handleJetpackSubmit }
+								onClick={ this.handleGetNewJetpackSiteUrl }
 							>
 								{ this.props.translate( 'Add existing site' ) }
 							</Button>

--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -19,17 +19,12 @@ import { recordTracksEvent } from 'state/analytics/actions';
 class JetpackNewSite extends Component {
 	constructor() {
 		super();
-		this.handleOnClickTos = this.handleOnClickTos.bind( this );
 		this.handleBack = this.handleBack.bind( this );
 	}
-
-	state = { jetpackUrl: '' };
 
 	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_jetpack_new_site_view' );
 	}
-
-	handleJetpackUrlChange = event => this.setState( { jetpackUrl: event.target.value } );
 
 	getNewWpcomSiteUrl() {
 		return config( 'signup_url' ) + '?ref=calypso-selector';
@@ -39,10 +34,6 @@ class JetpackNewSite extends Component {
 		this.props.recordTracksEvent( 'calypso_jetpack_new_site_connect_click' );
 		page( '/jetpack/connect?url=' + this.state.jetpackUrl );
 	};
-
-	handleOnClickTos() {
-		this.props.recordTracksEvent( 'calypso_jpc_tos_link_click' );
-	}
 
 	handleBack( event ) {
 		event.preventDefault();

--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -13,10 +13,7 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import Card from 'components/card';
 import config from 'config';
-import JetpackLogo from 'components/jetpack-logo';
 import BackButton from 'components/back-button';
-import SiteUrlInput from '../site-url-input';
-import WordPressLogo from 'components/wordpress-logo';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 class JetpackNewSite extends Component {

--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import Card from 'components/card';
 import config from 'config';
+import FormattedHeader from 'components/formatted-header';
 import BackButton from 'components/back-button';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -46,14 +47,12 @@ class JetpackNewSite extends Component {
 			<div>
 				<BackButton onClick={ this.handleBack } />
 				<div className="jetpack-new-site__main jetpack-new-site">
-					<header className="formatted-header">
-						<h1 className="formatted-header__title">
-							{ this.props.translate( 'Add a New Site' ) }
-						</h1>
-						<p className="formatted-header__subtitle">
-							{ this.props.translate( 'Create a new site or add your existing self-hosted site.' ) }{' '}
-						</p>
-					</header>
+					<FormattedHeader
+						headerText={ this.props.translate( 'Add a New Site' ) }
+						subHeaderText={ this.props.translate(
+							'Create a new site or add your existing self-hosted site.'
+						) }
+					/>
 					<div className="jetpack-new-site__content">
 						<Card className="jetpack-new-site__card">
 							<div className="jetpack-new-site__card-description">

--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -58,77 +58,49 @@ class JetpackNewSite extends Component {
 			<div>
 				<BackButton onClick={ this.handleBack } />
 				<div className="jetpack-new-site__main jetpack-new-site">
-					<div className="jetpack-new-site__header">
-						<h2 className="jetpack-new-site__header-title">
+					<header className="formatted-header">
+						<h1 className="formatted-header__title">
 							{ this.props.translate( 'Add a New Site' ) }
-						</h2>
-						<div className="jetpack-new-site__header-text">
+						</h1>
+						<p className="formatted-header__subtitle">
 							{ this.props.translate(
-								'Create a new site on WordPress.com or add your existing self-hosted WordPress site with Jetpack.'
+								'Create a new site or add your existing self-hosted site.'
 							) }{' '}
-						</div>
-					</div>
+						</p>
+					</header>
 					<div className="jetpack-new-site__content">
-						<Card className="jetpack-new-site__wpcom-site">
-							<WordPressLogo />
-							<h3 className="jetpack-new-site__card-title">
-								{ this.props.translate( 'Create a shiny new WordPress.com site' ) }
-							</h3>
+						<Card className="jetpack-new-site__card">
 							<div className="jetpack-new-site__card-description">
 								<p>
 									{ this.props.translate(
-										"Tell us what type of site you need and we'll get you setup. " +
-											'If you need help we’ve got you covered with 24/7 support.'
+										'Create a shiny new WordPress.com site.'
 									) }
 								</p>
 							</div>
-							<div className="jetpack-new-site__button-holder">
-								<Button
-									className="jetpack-new-site__button button is-primary"
-									href={ this.getNewWpcomSiteUrl() }
-								>
-									{ this.props.translate( 'Start Now' ) }
-								</Button>
-							</div>
-						</Card>
-						<Card className="jetpack-new-site__jetpack-site">
-							<JetpackLogo size={ 72 } />
-							<h3 className="jetpack-new-site__card-title">
-								{ this.props.translate( 'Add an existing WordPress site with Jetpack' ) }
-							</h3>
-							<div className="jetpack-new-site__card-description">
-								{ this.props.translate(
-									'We’ll be using the Jetpack plugin to connect your site to WordPress.com.'
-								) }
-							</div>
-							<SiteUrlInput
-								onChange={ this.handleJetpackUrlChange }
-								onSubmit={ this.handleJetpackSubmit }
-								handleOnClickTos={ this.handleOnClickTos }
-								url={ this.state.jetpackUrl }
-								autoFocus={ false } // eslint-disable-line jsx-a11y/no-autofocus
-							/>
-						</Card>
-						<Card className="jetpack-new-site__mobile">
-							<div className="jetpack-new-site__mobile-wpcom-site">
-								<p>{ this.props.translate( 'Create a new shiny WordPress.com site:' ) }</p>
-								<Button primary href={ this.getNewWpcomSiteUrl() }>
-									{ this.props.translate( 'Start Now' ) }
-								</Button>
-							</div>
+							<Button
+								className="jetpack-new-site__button button is-primary"
+								href={ this.getNewWpcomSiteUrl() }
+							>
+								{ this.props.translate( 'Create a new site' ) }
+							</Button>
+
 							<div className="jetpack-new-site__divider">
 								<span>{ this.props.translate( 'or' ) }</span>
 							</div>
-							<div className="jetpack-new-site__mobile-jetpack-site">
-								<p>{ this.props.translate( 'Add an existing WordPress site with Jetpack:' ) }</p>
-								<SiteUrlInput
-									onChange={ this.handleJetpackUrlChange }
-									onSubmit={ this.handleJetpackSubmit }
-									handleOnClickTos={ this.handleOnClickTos }
-									url={ this.state.jetpackUrl }
-									autoFocus={ false } // eslint-disable-line jsx-a11y/no-autofocus
-								/>
+
+							<div className="jetpack-new-site__card-description">
+								<p>
+									{ this.props.translate(
+										'If you already have a WordPress site hosted somewhere else, we can add it for you now.'
+									) }
+								</p>
 							</div>
+							<Button
+								className="jetpack-new-site__connect-button button is-primary"
+								onClick={ this.handleJetpackSubmit }
+							>
+								{ this.props.translate( 'Add existing site' ) }
+							</Button>
 						</Card>
 					</div>
 				</div>

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -1,172 +1,57 @@
 // Structure
 .jetpack-new-site {
-	max-width: 960px;
+	max-width: 400px;
 	margin: 35px auto 0;
 	text-align: center;
-}
 
-.jetpack-new-site__header {
-	margin-bottom: 3em;
-
-	@include breakpoint( "<660px" ) {
-		margin: 0 2em 2em;
+	.formatted-header {
+		margin-bottom: 16px;
 	}
-}
-
-.jetpack-new-site__header-title {
-	margin-bottom: .35em;
-	font-size: 34px;
-	font-weight: 300;
-	color: $gray-dark;
-}
-
-.jetpack-new-site__header-text {
-	font-size: 16px;
-	color: $gray;
 }
 
 .jetpack-new-site__content {
-	display: flex;
-	align-items: stretch;
-	justify-content: center;
 	padding-bottom: 2em;
 }
 
-.jetpack-new-site__wpcom-site,
-.jetpack-new-site__jetpack-site {
-	z-index: 1;
-	display: flex;
-	flex-direction: column;
-	width: 360px;
+.jetpack-new-site__card {
+	width: 100%;
 	margin: 0px;
-	transition: transform .25s ease, box-shadow .35s ease, z-index .15s ease;
-
-	&:hover {
-		z-index: 3;
-		transform: scale(1.075);
-		box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
-		0 1px 2px $gray-lighten-30, 0 7px 18px transparentize( lighten( $gray, 15% ), .5 );
-		transition: transform .25s ease, box-shadow .35s ease, z-index .175s ease;
-	}
-
-	@include breakpoint( "<660px" ) {
-		display: none;
-	}
-}
-
-.jetpack-new-site__wpcom-site .wordpress-logo,
-.jetpack-new-site__jetpack-site .jetpack-logo {
-	flex: 1;
-	max-width: 72px;
-	max-height: 72px;
-	margin: 1.5em auto;
-	transition: .25s transform ease;
-}
-
-.jetpack-new-site__wpcom-site .wordpress-logo {
-	fill: $blue-wordpress;
-}
-
-.jetpack-new-site__jetpack-site .jetpack-logo {
-	fill: $green-jetpack;
-}
-
-.jetpack-new-site__card-title {
-	margin-bottom: .75em;
-	font-size: 24px;
-	line-height: 1.25em;
 }
 
 .jetpack-new-site__card-description {
 	margin-bottom: 1em;
 	color: lighten( $gray-dark, 25% );
+
+	&:first-of-type {
+		margin-top: 8px;
+	}
 }
 
-.jetpack-new-site__button-holder {
-	display: flex;
-	flex: 1;
-	align-self: flex-end;
-	width: 100%;
-}
-
-.jetpack-new-site__wpcom-site {
+.jetpack-new-site__card {
 	.button {
-		align-self: flex-end;
 		width: 100%;
-		margin-top: 16px;
+		margin-top: 8px;
 	}
 }
 
-.jetpack-new-site__jetpack-site,
-.jetpack-new-site__mobile-jetpack-site {
+.jetpack-new-site__connect-button.button {
+	background-color: $green-jetpack;
+	border-color: darken($green-jetpack, 5%);
 
-	.jetpack-connect__connect-button-card {
-		background: transparent;
+	&:hover,
+	&:focus {
+		border-color: darken($green-jetpack, 30%);
 	}
 
-	.jetpack-connect__site-address-container  {
-		position: relative;
-
-		.gridicon {
-			position: absolute;
-			top: 8px;
-			left: 8px;
-			color: $gray-lighten-20;
-		}
-
-		.form-text-input {
-			padding-left: 40px;
-		}
-
-		.spinner {
-			position: absolute;
-			right: 8px;
-			top: 10px;
-		}
+	&:focus {
+		box-shadow: 0 0 0 2px lighten($green-jetpack, 25%);
 	}
 
-	label {
-		display: none;
-	}
-
-	input[type=text] {
-		&:focus {
-			border-color: $green-jetpack;
-			box-shadow: 0 0 0 2px lighten( $green-jetpack, 25% );
-		}
-	}
-
-	.button {
-		background-color: $green-jetpack;
-		border-color: darken($green-jetpack, 5%);
-		margin-top: 16px;
-		width: 100%;
-
-		&:hover,
-		&:focus {
-			border-color: darken($green-jetpack, 30%);
-		}
-
-		&:focus {
-			box-shadow: 0 0 0 2px lighten($green-jetpack, 25%);
-		}
-
-		&[disabled],
-		&:disabled {
-			background: tint($green-jetpack, 50%);
-			border-color: tint($green-jetpack, 35%);
-			color: $white;
-		}
-	}
-}
-
-.jetpack-new-site__mobile {
-	display: none;
-	width: 100%;
-	padding: 36px;
-
-	@include breakpoint( "<660px" ) {
-		display: block;
+	&[disabled],
+	&:disabled {
+		background: tint($green-jetpack, 50%);
+		border-color: tint($green-jetpack, 35%);
+		color: $white;
 	}
 }
 
@@ -185,7 +70,6 @@
 }
 
 .jetpack-new-site__divider {
-	display: none;
 	position: relative;
 	margin: 32px 0;
 
@@ -204,11 +88,8 @@
 		position: relative;
 		z-index: 2;
 		padding: 8px;
+		font-style: italic;
 		color: $gray;
 		background: $white;
-	}
-
-	@include breakpoint( "<660px" ) {
-		display: block;
 	}
 }


### PR DESCRIPTION
> This PR is on-hold until we discuss a better way to offer this choice to users.

Addresses https://github.com/Automattic/wp-calypso/issues/22315

Related https://github.com/Automattic/wp-calypso/pull/23186

The changes included aim to simplify the Add New Site view by:

- Getting rid of the dual-pane look, logos, and animations.
- Simplifying copy.
- Using consistent headers: `formatted-header`.
- Reworks some of the functions used to handle JP site clicks.

### Before

![image](https://user-images.githubusercontent.com/390760/37111655-1f046074-2238-11e8-91fa-6911e00a1d61.png)

### After

![image](https://user-images.githubusercontent.com/390760/37111666-26fab5bc-2238-11e8-8a1a-fb1c94ec260a.png)

### How to test

- Go to https://calypso.live/?branch=try/simplify-add-new-site
- Click “My Sites”
- Click “Switch Site”
- Click “Add New Site” at the bottom of the site list