### PR TITLE
Editor: Fix changing the publish date of an empty post

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -948,9 +948,7 @@ export const PostEditor = createReactClass( {
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		actions.edit( { date: dateValue } );
 
-		if ( siteId && postId ) {
-			this.props.editPost( siteId, postId, { date: dateValue } );
-		}
+		this.props.editPost( siteId, postId, { date: dateValue } );
 
 		analytics.tracks.recordEvent( 'calypso_editor_publish_date_change', {
 			context: 'open' === this.state.confirmationSidebar ? 'confirmation-sidebar' : 'post-settings',


### PR DESCRIPTION
Fixes #20486.

To test, start a new post in the editor and change the publish date before writing any content or title (or at least, before the first save).  Previously, the date would not be updated in the calendar until the first save; this PR fixes the issue.

We need to dispatch the `editPost` Redux action even if we don't have a post ID.  If there is no post ID, the internal code uses `''` as the ID of the new post being edited:  https://github.com/Automattic/wp-calypso/blob/6c2317f4/client/state/posts/reducer.js#L430-L433