### PR TITLE
Store: Prevent saving of payment settings if no updates have been made

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/index.js
+++ b/client/extensions/woocommerce/app/settings/payments/index.js
@@ -21,8 +21,10 @@ import { createPaymentSettingsActionList } from 'woocommerce/state/ui/payments/a
 import { errorNotice, successNotice } from 'state/notices/actions';
 import ExtendedHeader from 'woocommerce/components/extended-header';
 import { getActionList } from 'woocommerce/state/action-list/selectors';
+import { getCurrencyEdits } from 'woocommerce/state/ui/payments/currency/selectors';
 import { getFinishedInitialSetup } from 'woocommerce/state/sites/setup-choices/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
+import { getPaymentMethodsEdits } from 'woocommerce/state/ui/payments/methods/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import {
 	hasOAuthParamsInLocation,
@@ -124,7 +126,8 @@ class SettingsPayments extends Component {
 	};
 
 	render() {
-		const { isSaving, site, translate, className, finishedInitialSetup } = this.props;
+		const { isSaving, site, translate, className, finishedInitialSetup, hasEdits } = this.props;
+		const saveDisabled = isSaving || ! hasEdits;
 
 		const breadcrumbs = [
 			<a href={ getLink( '/store/settings/:site/', site ) }>{ translate( 'Settings' ) }</a>,
@@ -135,7 +138,7 @@ class SettingsPayments extends Component {
 		return (
 			<Main className={ classNames( 'settingsPayments', className ) } wideLayout>
 				<ActionHeader breadcrumbs={ breadcrumbs }>
-					<Button primary onClick={ this.onSave } busy={ isSaving } disabled={ isSaving }>
+					<Button primary onClick={ this.onSave } busy={ isSaving } disabled={ saveDisabled }>
 						{ saveMessage }
 					</Button>
 				</ActionHeader>
@@ -151,10 +154,18 @@ class SettingsPayments extends Component {
 function mapStateToProps( state ) {
 	const site = getSelectedSiteWithFallback( state );
 	const finishedInitialSetup = getFinishedInitialSetup( state );
+	const edits = site && getPaymentMethodsEdits( state, site.ID );
+	const currencyEdits = site && getCurrencyEdits( state, site.ID );
+	const hasEdits =
+		( edits && edits.updates && edits.updates.length > 0 ) ||
+		( currencyEdits && currencyEdits.length > 0 ) ||
+		false;
+
 	return {
 		isSaving: Boolean( getActionList( state ) ),
 		site,
 		finishedInitialSetup,
+		hasEdits,
 	};
 }
 

--- a/client/extensions/woocommerce/state/data-layer/ui/payments/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/payments/index.js
@@ -79,8 +79,12 @@ const getSavePaymentMethodsSteps = ( state, siteId ) => {
 
 	const actions = [];
 	const edits = getPaymentMethodsEdits( state, siteId );
-	const { updates } = edits;
-	updates.forEach( update => {
+
+	if ( ! edits || ! edits.updates ) {
+		return [];
+	}
+
+	edits.updates.forEach( update => {
 		const { id, ...settings } = update;
 
 		const method = {

--- a/client/extensions/woocommerce/state/ui/payments/currency/reducer.js
+++ b/client/extensions/woocommerce/state/ui/payments/currency/reducer.js
@@ -5,7 +5,10 @@
  */
 
 import { createReducer } from 'state/utils';
-import { WOOCOMMERCE_CURRENCY_CHANGE } from '../../../action-types';
+import {
+	WOOCOMMERCE_CURRENCY_UPDATE_SUCCESS,
+	WOOCOMMERCE_CURRENCY_CHANGE,
+} from 'woocommerce/state/action-types';
 
 export const initialState = '';
 
@@ -13,6 +16,11 @@ function changeAction( state, { currency } ) {
 	return currency;
 }
 
+function currencyUpdatedAction() {
+	return null;
+}
+
 export default createReducer( initialState, {
 	[ WOOCOMMERCE_CURRENCY_CHANGE ]: changeAction,
+	[ WOOCOMMERCE_CURRENCY_UPDATE_SUCCESS ]: currencyUpdatedAction,
 } );

--- a/client/extensions/woocommerce/state/ui/payments/currency/selectors.js
+++ b/client/extensions/woocommerce/state/ui/payments/currency/selectors.js
@@ -15,7 +15,7 @@ import {
 	areSettingsGeneralLoaded,
 } from 'woocommerce/state/sites/settings/general/selectors';
 
-const getCurrencyEdits = ( state, siteId ) => {
+export const getCurrencyEdits = ( state, siteId ) => {
 	return get( state, [ 'extensions', 'woocommerce', 'ui', 'payments', siteId, 'currency' ] );
 };
 

--- a/client/extensions/woocommerce/state/ui/payments/currency/test/reducer.js
+++ b/client/extensions/woocommerce/state/ui/payments/currency/test/reducer.js
@@ -21,4 +21,14 @@ describe( 'reducer', () => {
 			expect( newState ).to.deep.equal( { currency: 'USD' } );
 		} );
 	} );
+	describe( 'currencyUpdatedAction', () => {
+		test( 'should clear edits upon successful update', () => {
+			const action = {
+				type: 'WOOCOMMERCE_CURRENCY_UPDATE_SUCCESS',
+				siteId,
+			};
+			const newState = reducer( state, action );
+			expect( newState ).to.equal( null );
+		} );
+	} );
 } );


### PR DESCRIPTION
This PR fixes an error found in Kibana that is easily reproducible:  `Cannot read property 'updates' of undefined`. This occurs if you go to the payment settings page and hit save without making any changes.

This PR protects against the warning, and also disables the save button entirely if no updates have been made. This also matches the behavior of our other save buttons.

To Test:
* Run `npm run test-client client/extensions/woocommerce` and make sure all tests pass.
* Boot up this branch and go to `http://calypso.localhost:3000/store/settings/payments/:site`.
* Verify the save button is disabled.
* Make a change to the currency and see that the save button is enabled.
* Save and make sure your value saves, and the button disables after success.
* Make changes to your payment methods and verify the same behavior.