### PR TITLE
Store: Try Reports sidebar link, and change target to week

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
@@ -45,7 +45,7 @@ class ManageNoOrdersView extends Component {
 			recordTrack( 'calypso_woocommerce_dashboard_action_click', {
 				action: 'view-stats',
 			} );
-			page.redirect( getLink( '/store/stats/orders/day/:site', site ) );
+			page.redirect( getLink( '/store/stats/orders/week/:site', site ) );
 		};
 		return (
 			<DashboardWidget

--- a/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
@@ -187,7 +187,7 @@ class ManageOrdersView extends Component {
 						) }
 					</p>
 					<p>
-						<Button href={ getLink( '/store/stats/orders/day/:site', site ) }>
+						<Button href={ getLink( '/store/stats/orders/week/:site', site ) }>
 							{ orders.length ? translate( 'View full reports' ) : translate( 'View reports' ) }
 						</Button>
 					</p>

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -237,25 +237,6 @@ class StoreSidebar extends Component {
 		);
 	};
 
-	stats = () => {
-		const { site, siteSuffix, translate } = this.props;
-		const link = '/store/stats/orders/week' + siteSuffix;
-		const classes = classNames( {
-			stats: true,
-			'is-placeholder': ! site,
-			selected: false,
-		} );
-
-		return (
-			<SidebarItem
-				className={ classes }
-				icon="stats-alt"
-				label={ translate( 'Reports' ) }
-				link={ link }
-			/>
-		);
-	};
-
 	render = () => {
 		const {
 			finishedAddressSetup,
@@ -294,7 +275,6 @@ class StoreSidebar extends Component {
 						{ showAllSidebarItems && this.reviews() }
 						{ showAllSidebarItems && <SidebarSeparator /> }
 						{ showAllSidebarItems && this.settings() }
-						{ showAllSidebarItems && this.stats() }
 					</ul>
 				</SidebarMenu>
 				<QuerySettingsGeneral siteId={ siteId } />

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -250,7 +250,7 @@ class StoreSidebar extends Component {
 			<SidebarItem
 				className={ classes }
 				icon="stats-alt"
-				label={ translate( 'Stats' ) }
+				label={ translate( 'Reports' ) }
 				link={ link }
 			/>
 		);

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -237,6 +237,25 @@ class StoreSidebar extends Component {
 		);
 	};
 
+	stats = () => {
+		const { site, siteSuffix, translate } = this.props;
+		const link = '/store/stats/orders/week' + siteSuffix;
+		const classes = classNames( {
+			stats: true,
+			'is-placeholder': ! site,
+			selected: false,
+		} );
+
+		return (
+			<SidebarItem
+				className={ classes }
+				icon="stats-alt"
+				label={ translate( 'Stats' ) }
+				link={ link }
+			/>
+		);
+	};
+
 	render = () => {
 		const {
 			finishedAddressSetup,
@@ -275,6 +294,7 @@ class StoreSidebar extends Component {
 						{ showAllSidebarItems && this.reviews() }
 						{ showAllSidebarItems && <SidebarSeparator /> }
 						{ showAllSidebarItems && this.settings() }
+						{ showAllSidebarItems && this.stats() }
 					</ul>
 				</SidebarMenu>
 				<QuerySettingsGeneral siteId={ siteId } />


### PR DESCRIPTION
This branch seeks to address #22889, and make Stats/Reports a bit easier to get to from store:

<img width="1425" alt="reports-links" src="https://user-images.githubusercontent.com/22080/37115071-fa14ec68-21fe-11e8-95a1-5014317af725.png">

I had attempted to just add a `startDate` to the URL from these links for today - 8 days as described in the issue, but stats week periods in the API are kind of hard-coded to start on Sundays ( I believe ) so this doesn't work totally as expected.  I suppose we could show the current week ( like is done in this PR ) on all days after Monday, otherwise default to the prior week? Just a thought.

__To Test__
- Visit the site dashboard and click the Reports links

__To Do__
- Maybe it might be nice to have a Store link within the Store Stats page ( in addition to the sidebar link ) to make it easy to get back to Store.
