### PR TITLE
Adjust mobile styles for buttons in the theme switch modal.

### DIFF
--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -4,7 +4,7 @@
 
 	@include breakpoint( "<480px" ) {
 		box-sizing: border-box;
-		width: 100%;
+		max-width: 100%;
 	}
 
 	+ .dialog__action-buttons {
@@ -12,6 +12,17 @@
 
 		.button:first-child {
 			margin-left: 0;
+		}
+
+		@include breakpoint( "<480px" ) {
+			.button, .button:first-child {
+				display: block;
+				margin: 0 auto 10px;
+			}
+
+			.button:last-child {
+				margin-bottom: 0;
+			}
 		}
 	}
 

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -18,6 +18,7 @@
 			.button, .button:first-child {
 				display: block;
 				margin: 0 auto 10px;
+				width: 100%;
 			}
 
 			.button:last-child {


### PR DESCRIPTION
Currently, the buttons in the theme switch confirmation modal are smushed together on small screens. The second button is also off-center. 

This PR addresses that by forcing the buttons onto two lines on viewports that are under 480px, and by adjusting margins to match. 

## Screenshots

Before
![button-spacing](https://user-images.githubusercontent.com/1202812/37115328-d5c651ac-2218-11e8-81e7-167c01c0e846.gif)

After
![button-spacing-fixed](https://user-images.githubusercontent.com/1202812/37115332-d8a28670-2218-11e8-9ee6-8f9422dba19d.gif)


## Testing

1. Visit a theme detail page, and activate a new theme. 
2. Verify that the buttons appear as depicted in the "After" screenshot. 