### PR TITLE
Components: Update accessibility of Checklist

### DIFF
--- a/client/components/checklist/checklist-header.jsx
+++ b/client/components/checklist/checklist-header.jsx
@@ -34,7 +34,7 @@ export class ChecklistHeader extends PureComponent {
 			<Card compact className="checklist__header">
 				<div className="checklist__header-main">
 					<div className="checklist__header-progress">
-						<h4 className="checklist__header-progress-text">{ translate( 'Your setup list' ) }</h4>
+						<h2 className="checklist__header-progress-text">{ translate( 'Your setup list' ) }</h2>
 						<span className="checklist__header-progress-number">{ `${ completed }/${ total }` }</span>
 					</div>
 					<ProgressBar compact total={ total } value={ completed } />

--- a/client/components/checklist/checklist-placeholder.jsx
+++ b/client/components/checklist/checklist-placeholder.jsx
@@ -15,7 +15,7 @@ export default function ChecklistPlaceholder() {
 	return (
 		<Card compact className="checklist__task is-placeholder">
 			<div className="checklist__task-primary">
-				<h5 className="checklist__task-title">Task title</h5>
+				<h3 className="checklist__task-title">Task title</h3>
 				<p className="checklist__task-description">This is an example</p>
 				<small className="checklist__task-duration">Estimated time</small>
 			</div>

--- a/client/components/checklist/checklist-task.jsx
+++ b/client/components/checklist/checklist-task.jsx
@@ -67,11 +67,11 @@ export class ChecklistTask extends PureComponent {
 				} ) }
 			>
 				<div className="checklist__task-primary">
-					<h5 className="checklist__task-title">
+					<h3 className="checklist__task-title">
 						<Button borderless className="checklist__task-title-link" onClick={ this.handleClick }>
 							{ ( completed && completedTitle ) || title }
 						</Button>
-					</h5>
+					</h3>
 					<p className="checklist__task-description">{ description }</p>
 					{ duration && (
 						<small className="checklist__task-duration">

--- a/client/components/checklist/checklist-task.jsx
+++ b/client/components/checklist/checklist-task.jsx
@@ -22,6 +22,7 @@ export class ChecklistTask extends PureComponent {
 	static propTypes = {
 		id: PropTypes.string.isRequired,
 		title: PropTypes.string.isRequired,
+		buttonText: PropTypes.string,
 		completedTitle: PropTypes.string,
 		completedButtonText: PropTypes.string,
 		description: PropTypes.string.isRequired,
@@ -53,6 +54,7 @@ export class ChecklistTask extends PureComponent {
 			title,
 			translate,
 		} = this.props;
+		const { buttonText = translate( 'Do it!' ) } = this.props;
 		const hasActionlink = completed && completedButtonText;
 
 		return (
@@ -78,7 +80,7 @@ export class ChecklistTask extends PureComponent {
 				</div>
 				<div className="checklist__task-secondary">
 					<Button className="checklist__task-action" onClick={ this.handleClick }>
-						{ hasActionlink ? completedButtonText : translate( 'Do it!' ) }
+						{ hasActionlink ? completedButtonText : buttonText }
 					</Button>
 					{ duration && (
 						<small className="checklist__task-duration">

--- a/client/components/checklist/checklist-task.jsx
+++ b/client/components/checklist/checklist-task.jsx
@@ -68,9 +68,9 @@ export class ChecklistTask extends PureComponent {
 			>
 				<div className="checklist__task-primary">
 					<h5 className="checklist__task-title">
-						<a className="checklist__task-title-link" onClick={ this.handleClick }>
+						<Button borderless className="checklist__task-title-link" onClick={ this.handleClick }>
 							{ ( completed && completedTitle ) || title }
-						</a>
+						</Button>
 					</h5>
 					<p className="checklist__task-description">{ description }</p>
 					{ duration && (

--- a/client/components/checklist/checklist-task.jsx
+++ b/client/components/checklist/checklist-task.jsx
@@ -16,6 +16,7 @@ import Gridicon from 'gridicons';
  */
 import Button from 'components/button';
 import Card from 'components/card';
+import Focusable from 'components/focusable';
 import ScreenReaderText from 'components/screen-reader-text';
 
 export class ChecklistTask extends PureComponent {
@@ -88,18 +89,16 @@ export class ChecklistTask extends PureComponent {
 						</small>
 					) }
 				</div>
-				<span
+				<Focusable
 					className="checklist__task-icon"
 					onClick={ this.handleToggle }
-					tabIndex="0"
-					role="button"
 					aria-pressed={ completed ? 'true' : 'false' }
 				>
 					<ScreenReaderText>
 						{ completed ? translate( 'Mark as uncompleted' ) : translate( 'Mark as completed' ) }
 					</ScreenReaderText>
 					{ <Gridicon icon="checkmark" size={ 18 } /> }
-				</span>
+				</Focusable>
 			</Card>
 		);
 	}

--- a/client/components/checklist/docs/example.jsx
+++ b/client/components/checklist/docs/example.jsx
@@ -10,6 +10,7 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import Checklist from '../';
 
 export default class ChecklistExample extends Component {
@@ -99,9 +100,9 @@ export default class ChecklistExample extends Component {
 
 		return (
 			<div>
-				<a className="docs__design-toggle button" onClick={ this.togglePlaceholder }>
+				<Button className="docs__design-toggle" onClick={ this.togglePlaceholder }>
 					{ toggleText }
-				</a>
+				</Button>
 				<div style={ { clear: 'both' } } />
 				<Checklist
 					tasks={ this.state.tasks }

--- a/client/components/checklist/index.jsx
+++ b/client/components/checklist/index.jsx
@@ -72,6 +72,7 @@ export class Checklist extends Component {
 				key={ task.id }
 				id={ task.id }
 				title={ task.title }
+				buttonText={ task.buttonText }
 				completedTitle={ task.completedTitle }
 				completedButtonText={ task.completedButtonText }
 				description={ task.description }

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -69,6 +69,10 @@
 				transform: rotate(180deg);
 			}
 		}
+
+		.accessible-focus &:focus {
+			box-shadow: inset 0 0 0 2px $blue-light;
+		}
 	}
 
 	.checklist.is-expanded &-action {

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -32,19 +32,19 @@
 		display: flex;
 		flex: 1 1;
 		margin: 0;
-		color: $gray;
+		color: $gray-text-min;
 	}
 
 	&-progress-number {
 		display: flex;
-		color: $gray;
+		color: $gray-text-min;
 		padding-left: 1em;
 	}
 
 	&-summary {
 		font-size: 12px;
 		line-height: 24px;
-		color: $gray;
+		color: $gray-text-min;
 		cursor: pointer;
 	}
 
@@ -178,7 +178,7 @@
 
 	&-duration {
 		font-size: 12px;
-		color: $gray;
+		color: $gray-text-min;
 
 		.checklist__task-primary & {
 			display: inline-block;
@@ -221,7 +221,7 @@
 
 		.checklist__task-title,
 		.checklist__task-title-link {
-			color: $gray;
+			color: $gray-text-min;
 			font-size: 14px;
 			cursor: default;
 		}
@@ -247,7 +247,7 @@
 			border: 0;
 			padding: 0;
 			text-decoration: underline;
-			color: $gray;
+			color: $gray-text-min;
 			font-size: 12px;
 			font-weight: 400;
 			width: 100%;

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -127,7 +127,8 @@
 			left: 1px;
 		}
 
-		&:hover {
+		&:hover,
+		&:focus {
 			background: $alert-green;
 			border-color: $alert-green;
 

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -161,15 +161,11 @@
 		}
 	}
 
-	&-title {
+	&-title-link.button {
+		padding: 0;
 		color: $blue-wordpress;
 		font-weight: 400;
 		font-size: 16px;
-	}
-
-	&-title-link:hover {
-		cursor: pointer;
-		color: $gray-dark;
 	}
 
 	&-description {


### PR DESCRIPTION
Over in Store, we're about to use this component for our setup checklist (#23067), but there are a few accessibility issues. This PR fixes most of them - the main updates are:

- Increase contrast of all the light-grey text by using the `$gray-text-min` color
- Switch the heading levels to `h2`/`h3`, to match the site checklist page (which has just an `h1`)
- Use the Focusable component on the toggle icons so that they can be visually keyboard-accessible
- Switch the task titles to use Buttons so they can be appropriately keyboard + screen reader accessible
- This PR also fixes an issue for #23067, where we need a prop for custom button text per-task (rather than Do it! for all)

I did _not_ adjust the contrast of the blue task title text, even though that combination is not sufficiently contrasted.

| Before | After |
| --- | --- |
| ![current](https://user-images.githubusercontent.com/541093/37125256-cceea1da-2239-11e8-974c-4990c7508e32.png) | ![updated](https://user-images.githubusercontent.com/541093/37125254-ccb1765c-2239-11e8-8f4a-edf07de1f721.png) |

If this is merged, it would be great to use the new `buttonText` prop for custom button text on the Site Checklist page. As it's possible to navigate a page just by listing form controls, screen reader users will just hear a bunch of buttons that say "Do it!". The addition of the button on the task title helps this, but now there are 2 buttons for the same action, which is not ideal. If we can move over to using custom `buttonText`, maybe we can remove the button from the task title in the future.

**To test**

- Check out the checklist on `/devdocs/design/checklist` or `/checklist/:site` (for a wp.com simple site)
- Tab through the checklist items, make sure you can get to all of them
- [Try out VoiceOver + Safari](https://webaim.org/articles/voiceover/) & make sure you can get through the checklist items