### PR TITLE
Fix missing code for strong tag in plans grid.

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -962,7 +962,12 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_VIDEO_UPLOADS_JETPACK_PRO ]: {
 		getSlug: () => FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
-		getTitle: () => i18n.translate( '{{strong}}Unlimited{{/strong}} Video Hosting' ),
+		getTitle: () =>
+			i18n.translate( '{{strong}}Unlimited{{/strong}} Video Hosting', {
+				components: {
+					strong: <strong />,
+				},
+			} ),
 		getDescription: () =>
 			i18n.translate(
 				'Easy video uploads, and a fast, unbranded, customizable video player, ' +


### PR DESCRIPTION
This fixes the missing tag into the __() function from #23059 . While broken, it showed strong tags around the "Unlimited" word in the Premium column. This should fix that and remove those tags.

**Before:**
<img width="324" alt="screen shot 2018-03-07 at 6 10 36 pm" src="https://user-images.githubusercontent.com/204742/37127966-4c3d765a-2235-11e8-803b-61246891c4fb.png">

**After:**
<img width="379" alt="screen shot 2018-03-07 at 6 31 30 pm" src="https://user-images.githubusercontent.com/204742/37128085-c6560588-2235-11e8-80b2-d4e262f0517d.png">


**Testing instructions:**

* checkout this branch
* visit http://calypso.localhost:3000/plans/YOURTESTINGSITEURL and confirm the "Unlimited Video Hosting" looks like the "After" screenshot.