### PR TITLE
Timezone: Use SelectDropdown instead of browser select

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -224,6 +224,7 @@
 @import 'components/thank-you-card/style';
 @import 'components/theme/style';
 @import 'components/themes-list/style';
+@import 'components/timezone/style';
 @import 'components/tinymce/style';
 @import 'components/tile-grid/style';
 @import 'components/title-format-editor/style';

--- a/client/components/select-dropdown/README.md
+++ b/client/components/select-dropdown/README.md
@@ -139,7 +139,7 @@ A good example for this case is a form element. You don't want to have to write 
 ```js
 import SelectDropdown from 'components/select-dropdown';
 var options = [
-	{ label: 'Post status', isLabel: true },
+	{ value: 'label-statuses', label: 'Post status', isLabel: true },
 	{ value: 'published', label: 'Published' },
 	{ value: 'scheduled', label: 'Scheduled' },
 	{ value: 'drafts', label: 'Drafts' },
@@ -203,7 +203,7 @@ Adding `isLabel` key set to `true` into the item object will create a `DropdownL
 
 ```js
 var options = [
-	{ label: 'Post status', isLabel: true },
+	{ value: 'label-statuses', label: 'Post status', isLabel: true },
 	{ value: 'published', label: 'Published' },
 	{ value: 'scheduled', label: 'Scheduled' },
 	{ value: 'drafts', label: 'Drafts' },

--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -20,7 +20,7 @@ class SelectDropdownExample extends React.PureComponent {
 
 	static defaultProps = {
 		options: [
-			{ value: 'status-options', label: 'Statuses', isLabel: true },
+			{ value: 'label-statuses', label: 'Statuses', isLabel: true },
 			{ value: 'published', label: 'Published', count: 12 },
 			{ value: 'scheduled', label: 'Scheduled' },
 			{ value: 'drafts', label: 'Drafts' },

--- a/client/components/timezone/index.jsx
+++ b/client/components/timezone/index.jsx
@@ -16,9 +16,6 @@ import { localize } from 'i18n-calypso';
 import QueryTimezones from 'components/data/query-timezones';
 import { getRawOffsets, getTimezones, getTimezonesLabel } from 'state/selectors';
 import SelectDropdown from 'components/select-dropdown';
-import DropdownItem from 'components/select-dropdown/item';
-import DropdownLabel from 'components/select-dropdown/label';
-import DropdownSeparator from 'components/select-dropdown/separator';
 
 class Timezone extends Component {
 	onSelect = option => {
@@ -34,7 +31,7 @@ class Timezone extends Component {
 				label: continent,
 				isLabel: true,
 			} ].concat(
-				map( countries, ( timezone, index ) => {
+				map( countries, timezone => {
 					const [ value, label ] = timezone;
 					return { value, label };
 				} )
@@ -43,14 +40,14 @@ class Timezone extends Component {
 	}
 
 	getManualUtcOffsets() {
-		const { rawOffsets, selectedZone, translate } = this.props;
+		const { rawOffsets, translate } = this.props;
 
 		return [ {
 			value: 'label-manual',
 			label: translate( 'Manual Offsets' ),
 			isLabel: true,
 		} ].concat(
-			map( this.props.rawOffsets, ( label, value ) => ( { label, value } ) )
+			map( rawOffsets, ( label, value ) => ( { label, value } ) )
 		);
 	}
 
@@ -61,7 +58,7 @@ class Timezone extends Component {
 			{ value: 'label-UTC', label: 'UTC', isLabel: true },
 			{ value: 'UTC', label: 'UTC' },
 		] );
-		if ( this.props.includeManualOffsets ) {
+		if ( includeManualOffsets ) {
 			options = options.concat( this.getManualUtcOffsets() );
 		}
 
@@ -69,7 +66,7 @@ class Timezone extends Component {
 			<React.Fragment>
 				<QueryTimezones />
 				<SelectDropdown
-					className='timezone-selector'
+					className="timezone__selector"
 					onSelect={ this.onSelect }
 					options={ options }
 					value={ selectedZone || '' }

--- a/client/components/timezone/index.jsx
+++ b/client/components/timezone/index.jsx
@@ -7,69 +7,75 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { map, noop } from 'lodash';
+import { map, flatMap, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import QueryTimezones from 'components/data/query-timezones';
-import { getRawOffsets, getTimezones } from 'state/selectors';
+import { getRawOffsets, getTimezones, getTimezonesLabel } from 'state/selectors';
+import SelectDropdown from 'components/select-dropdown';
+import DropdownItem from 'components/select-dropdown/item';
+import DropdownLabel from 'components/select-dropdown/label';
+import DropdownSeparator from 'components/select-dropdown/separator';
 
 class Timezone extends Component {
-	onSelect = event => {
-		this.props.onSelect( event.target.value );
+	onSelect = option => {
+		this.props.onSelect( option.value );
 	};
 
-	renderOptionsByContinent() {
-		const { timezones } = this.props;
-
-		return map( timezones, timezoneContinent => {
+	getTimezonesByContinent() {
+		return flatMap( this.props.timezones, timezoneContinent => {
 			const [ continent, countries ] = timezoneContinent;
 
-			return (
-				<optgroup label={ continent } key={ continent }>
-					{ map( countries, ( timezone, index ) => {
-						const [ value, label ] = timezone;
-
-						return (
-							<option value={ value } key={ index }>
-								{ label }
-							</option>
-						);
-					} ) }
-				</optgroup>
+			return [ {
+				value: 'label-' + continent,
+				label: continent,
+				isLabel: true,
+			} ].concat(
+				map( countries, ( timezone, index ) => {
+					const [ value, label ] = timezone;
+					return { value, label };
+				} )
 			);
 		} );
 	}
 
-	renderManualUtcOffsets() {
-		const { rawOffsets, translate } = this.props;
+	getManualUtcOffsets() {
+		const { rawOffsets, selectedZone, translate } = this.props;
 
-		return (
-			<optgroup label={ translate( 'Manual Offsets' ) }>
-				{ map( rawOffsets, ( label, value ) => {
-					return (
-						<option value={ value } key={ value }>
-							{ label }
-						</option>
-					);
-				} ) }
-			</optgroup>
+		return [ {
+			value: 'label-manual',
+			label: translate( 'Manual Offsets' ),
+			isLabel: true,
+		} ].concat(
+			map( this.props.rawOffsets, ( label, value ) => ( { label, value } ) )
 		);
 	}
 
 	render() {
-		const { selectedZone } = this.props;
+		const { includeManualOffsets, selectedZone, selectedZoneLabel } = this.props;
+
+		let options = this.getTimezonesByContinent().concat( [
+			{ value: 'label-UTC', label: 'UTC', isLabel: true },
+			{ value: 'UTC', label: 'UTC' },
+		] );
+		if ( this.props.includeManualOffsets ) {
+			options = options.concat( this.getManualUtcOffsets() );
+		}
+
 		return (
-			<select onChange={ this.onSelect } value={ selectedZone || '' }>
+			<React.Fragment>
 				<QueryTimezones />
-				{ this.renderOptionsByContinent() }
-				<optgroup label="UTC">
-					<option value="UTC">UTC</option>
-				</optgroup>
-				{ this.props.includeManualOffsets && this.renderManualUtcOffsets() }
-			</select>
+				<SelectDropdown
+					className='timezone-selector'
+					onSelect={ this.onSelect }
+					options={ options }
+					value={ selectedZone || '' }
+					selectedText={ selectedZoneLabel || selectedZone || '' }
+				/>
+			</React.Fragment>
 		);
 	}
 }
@@ -85,7 +91,8 @@ Timezone.propTypes = {
 	includeManualOffsets: PropTypes.bool,
 };
 
-export default connect( state => ( {
+export default connect( ( state, ownProps ) => ( {
 	rawOffsets: getRawOffsets( state ),
 	timezones: getTimezones( state ),
+	selectedZoneLabel: getTimezonesLabel( state, ownProps.selectedZone ),
 } ) )( localize( Timezone ) );

--- a/client/components/timezone/style.scss
+++ b/client/components/timezone/style.scss
@@ -1,0 +1,6 @@
+.timezone-selector {
+	.select-dropdown__options {
+		max-height: 300px;
+		overflow-y: scroll;
+	}
+}

--- a/client/components/timezone/style.scss
+++ b/client/components/timezone/style.scss
@@ -1,4 +1,4 @@
-.timezone-selector {
+.timezone__selector {
 	.select-dropdown__options {
 		max-height: 300px;
 		overflow-y: scroll;


### PR DESCRIPTION
Our timezone selector (in Site Settings and when booking a concierge appointment) has a ton of options.  Regrouping/simplifying them would be a significant undertaking, since ultimately they are pulled from our servers' [tz database](https://en.wikipedia.org/wiki/Tz_database) entries and each one does behave differently in at least some cases, but it would be nice to make the entries searchable.  See also:  p58i-6VK-p2

This PR explores changing the timezone dropdown to a React-rendered dropdown.  So far, it accomplishes refactoring the dropdown to use `SelectDropdown` instead of a browser-native dropdown:

| Before | After |
|--|--|
| <img src="https://user-images.githubusercontent.com/227022/37128392-93dd819e-223f-11e8-8ebc-9361710523c2.png" width="300"> | <img src="https://user-images.githubusercontent.com/227022/37128376-83b29836-223f-11e8-8fdc-0bdd90f0148c.png" width="350"> |

This is a first step along the way to making this component searchable.  It's not ready to ship, in its current state it's overall not an improvement because it just makes scrolling through this very long list harder.

There are several Calypso components that have some of the behavior of a searchable dropdown that we want, but none that have all of it.

- <a href="https://wpcalypso.wordpress.com/devdocs/design/select-dropdown">SelectDropdown</a> is a React-rendered dropdown component.  It does not have logic for mobile devices or for intelligent option box positioning, like the native browser select does.
- <a href="https://wpcalypso.wordpress.com/devdocs/blocks/sites-dropdown">SitesDropdown</a> has pretty good search among available options, but it is very specific to the list of Calypso sites.
- <a href="https://wpcalypso.wordpress.com/devdocs/design/token-fields">TokenField</a> is pretty close, but it is designed for free-form entry with optional suggestions.
- <a href="https://wpcalypso.wordpress.com/devdocs/design/suggestions">Suggestions</a>.  I am not sure exactly what this is, but it looks like a pretty minimal building block with a more complete example <a href="https://github.com/Automattic/wp-calypso/blob/01e92564/client/extensions/zoninator/components/search-autocomplete/index.jsx">here</a>.

Following up on any of these approaches to implement searching and get the behavior back to resembling a native select would involve modifying the chosen component(s) at the framework level.  Any way of doing this is probably at least a few days worth of work.