### PR TITLE
Separate minimizeFreePlan into two new tests

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -85,8 +85,17 @@ export default {
 		defaultVariation: 'group_0',
 		allowExistingUsers: true,
 	},
-	minimizeFreePlan: {
-		datestamp: '20180219',
+	minimizedFreePlanForSignedUser: {
+		datestamp: '20180308',
+		variations: {
+			original: 50,
+			minimized: 50,
+		},
+		defaultVariation: 'original',
+		allowExistingUsers: true,
+	},
+	minimizedFreePlanForUnsignedUser: {
+		datestamp: '20180308',
 		variations: {
 			original: 50,
 			minimized: 50,


### PR DESCRIPTION
This PR will relaunch the `minimizeFreePlan` test with the new name `minimizeFreePlanV2` to ensure the test result not impacted by the calypso a/b test bug( see p9jf6J-gb-p2 )