### PR TITLE
Reader: Fix ellipsis menu and Combined Card title focus style

### DIFF
--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -49,20 +49,21 @@
 	width: 100%;
 }
 
+.reader-combined-card__post-title {
+	display: block;
+	font-size: 17px;
+	font-weight: 700;
+	max-height: 16px * 1.6;
+	padding-left: 1px;
+	position: relative;
+	white-space: nowrap;
+	word-wrap: break-word;
+}
+
 .reader-combined-card__post-title-link,
 .reader-combined-card__post-title-link:visited {
 	color: $gray-dark;
 	cursor: pointer;
-	display: block;
-	font-size: 17px;
-	font-weight: 700;
-	line-height: 1.4;
-	margin-top: -2px;
-	max-height: 16px * 1.4;
-	overflow: hidden;
-	position: relative;
-	white-space: nowrap;
-	word-wrap: break-word;
 
 	&:hover,
 	&:focus {
@@ -87,7 +88,8 @@
 
 // Always indent the wrapper at larger breakpoints, asset or no asset
 .reader-combined-card__featured-asset-wrapper {
-	@include breakpoint( '>660px' ) {
+
+	@include breakpoint( ">660px" ) {
 		min-width: 100px;
 		margin-right: 15px;
 	}
@@ -112,6 +114,7 @@
 	position: relative;
 
 	&.is-selected {
+
 		&::before {
 			content: '';
 			position: absolute;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -556,11 +556,6 @@
 			display: none;
 		}
 	}
-
-	.ellipsis-menu .button.is-borderless .gridicon {
-		left: 2px;
-		top: -2px;
-	}
 }
 
 // Follow button for stream cards

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -5,10 +5,18 @@
 		color: $gray;
 
 		&:hover,
-		&:focus,
 		&:active {
 			color: $blue-medium;
 		}
+
+		&:focus {
+			box-shadow: none;
+			outline: thin dotted;
+		}
+	}
+
+	.ellipsis-menu__toggle {
+		padding: 0;
 	}
 
 	&.is-menu-visible .button.is-borderless {
@@ -22,6 +30,7 @@
 }
 
 .reader-post-options-menu__popover {
+
 	.popover__menu {
 		min-width: 212px;
 	}
@@ -31,14 +40,8 @@
 		color: $blue-medium;
 		padding: 9px 16px;
 
-		.gridicon {
-			position: absolute;
-				left: 17px;
-				top: 12px;
-
-			&:hover {
-				fill: $white;
-			}
+		.gridicon:hover {
+			fill: $white;
 		}
 
 		&:hover,


### PR DESCRIPTION
## Ellipsis menu in cards:

Before:
Focus style is blue unlike the Visit link:
![screenshot 2018-03-07 21 04 06](https://user-images.githubusercontent.com/4924246/37133992-2372c746-224b-11e8-9954-624399e34e2a.png)

After:
![screenshot 2018-03-07 21 04 21](https://user-images.githubusercontent.com/4924246/37133993-238fd4bc-224b-11e8-88fe-122aa3b948f2.png)

## Combined Card post title:

Before:
![screenshot 2018-03-07 21 06 18](https://user-images.githubusercontent.com/4924246/37134045-6320486e-224b-11e8-857d-cd4c4f9928f5.png)

After:
![screenshot 2018-03-07 21 06 01](https://user-images.githubusercontent.com/4924246/37134049-665887ee-224b-11e8-9468-8174fbc7dcff.png)

**Question:** Why are the Like and Comment buttons being skipped when tabbing?