### PR TITLE
Remove obsolete multiDomainRegistrationV1 AB test

### DIFF
--- a/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
+++ b/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
@@ -14,11 +14,11 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import { cartItems } from 'lib/cart-values';
 import CompactCard from 'components/card/compact';
 import GoogleAppsUsers from './users';
 import GoogleAppsProductDetails from './product-details';
-import { abtest } from 'lib/abtest';
 import {
 	validate as validateGappsUsers,
 	filter as filterUsers,
@@ -122,49 +122,6 @@ class GoogleAppsDialog extends React.Component {
 		);
 	}
 
-	maybeShowKeepSearching() {
-		const { translate } = this.props;
-
-		if ( abtest( 'multiDomainRegistrationV1' ) === 'singlePurchaseFlow' ) {
-			return null;
-		}
-		return (
-			<button
-				className="google-apps-dialog__keepsearching-button button"
-				href="#"
-				onClick={ this.handleFormKeepSearching }
-			>
-				{ translate( 'Keep Searching' ) }
-			</button>
-		);
-	}
-
-	checkoutButtonOrLink() {
-		const { translate } = this.props;
-
-		if ( this.state.isAddingEmail ) {
-			return null;
-		}
-
-		if ( abtest( 'multiDomainRegistrationV1' ) === 'singlePurchaseFlow' ) {
-			return (
-				<a className="google-apps-dialog__cancel-link" href="#" onClick={ this.handleFormCheckout }>
-					{ translate( 'No thanks, I don’t need email or I’ll use another provider.' ) }
-				</a>
-			);
-		}
-
-		return (
-			<button
-				className="google-apps-dialog__checkout-button button"
-				href="#"
-				onClick={ this.handleFormCheckout }
-			>
-				{ translate( 'Checkout' ) }
-			</button>
-		);
-	}
-
 	footer() {
 		const { translate } = this.props;
 		const continueButtonHandler = this.state.isAddingEmail
@@ -176,15 +133,21 @@ class GoogleAppsDialog extends React.Component {
 
 		return (
 			<footer className="google-apps-dialog__footer">
-				{ this.maybeShowKeepSearching() }
-				{ this.checkoutButtonOrLink() }
-				<button
-					className="google-apps-dialog__continue-button button is-primary"
-					type="submit"
+				{ ! this.state.isAddingEmail && (
+					<Button
+						className="google-apps-dialog__checkout-button"
+						onClick={ this.handleFormCheckout }
+					>
+						{ translate( 'Checkout' ) }
+					</Button>
+				) }
+				<Button
+					primary
+					className="google-apps-dialog__continue-button"
 					onClick={ continueButtonHandler }
 				>
 					{ continueButtonText }
-				</button>
+				</Button>
 			</footer>
 		);
 	}

--- a/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
+++ b/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
@@ -138,7 +138,7 @@ class GoogleAppsDialog extends React.Component {
 						className="google-apps-dialog__checkout-button"
 						onClick={ this.handleFormCheckout }
 					>
-						{ translate( 'Checkout' ) }
+						{ translate( 'Skip' ) }
 					</Button>
 				) }
 				<Button

--- a/client/components/upgrades/google-apps/google-apps-dialog/style.scss
+++ b/client/components/upgrades/google-apps/google-apps-dialog/style.scss
@@ -161,48 +161,24 @@ form.google-apps-dialog {
 }
 
 .google-apps-dialog__footer {
-	.google-apps-dialog__cancel-link {
-		color: $blue-medium;
-		display: block;
-		font-size: 13px;
-		text-align: center;
-
-		@include breakpoint( ">660px" ) {
-			float: left;
-			line-height: 38px;
-		}
-	}
-
 	.google-apps-dialog__continue-button {
-		@include breakpoint( "<660px" ) {
-			margin-bottom: 18px;
+		@include breakpoint( "<480px" ) {
 			width: 100%;
+			margin-top: 10px;
 		}
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( ">480px" ) {
 			float: right;
 		}
 	}
 
-	.button {
-		width: 100%;
-		margin-top: 10px;
-
-		@include breakpoint( ">660px" ) {
-			width: auto;
-			margin: 0 auto auto 10px;
+	.google-apps-dialog__checkout-button {
+		@include breakpoint( "<480px" ) {
+			width: 100%;
 		}
 
-		&:first-of-type {
-			margin-left: 0;
-			margin-top: 0;
-			&.is-primary {
-				margin-top: 10px;
-
-				@include breakpoint( ">660px" ) {
-					margin-top: 0;
-				}
-			}
+		@include breakpoint( ">480px" ) {
+			float: left;
 		}
 	}
 }

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,14 +1,5 @@
 /** @format */
 export default {
-	multiDomainRegistrationV1: {
-		datestamp: '20200721',
-		variations: {
-			singlePurchaseFlow: 10,
-			popupCart: 45,
-			keepSearchingInGapps: 45,
-		},
-		defaultVariation: 'singlePurchaseFlow',
-	},
 	signupAtomicStoreVsPressable: {
 		datestamp: '20171101',
 		variations: {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/15346 (in a roundabout way)

This removes a very old (pre-OSS) `multiDomainRegistrationV1` AB test that affected the G Suite checkout page. Furthermore, it's `datestamp` was `20200721`, so no user was eligible for this test and everyone was getting assigned to the default `singlePurchaseFlow` variation (at least until July of 2020 when this test would kick in).

I tried searching for it but couldn't find any relevant documentation, except for this post by @lucasartoni where its removal was requested p1v4f2-1TI-p2.

### Visual changes
- **Before**  `date < July 21, 2020`

![before](https://user-images.githubusercontent.com/1182160/37140351-adad9d9e-22b1-11e8-899e-2d85a9cf9c3a.png)

- **Before - back to the future version** `date > July 21, 2020` 90% of users would see this. Disclaimer: prices and features may vary :smile: 

![keep-searching](https://user-images.githubusercontent.com/1182160/37140369-cefe28ba-22b1-11e8-912f-09861f66301e.png)

- **After**

![just-checkout](https://user-images.githubusercontent.com/1182160/37140423-fd7b596a-22b1-11e8-8387-f455c52c7316.png)

I decided to:
- remove the `Keep searching` option because `Back` button above already covers that functionality in a more consistent way.
- leave `Checkout` button in place instead of a link because the existing usage is kind of a dark pattern, and we have an ESLint warning against usages like these anyway. As a side effect, this will also resolve layout issues mentioned in https://github.com/Automattic/wp-calypso/issues/15346.

### Testing instructions
1. Navigate to `/domains/manage/` and click on `Add domain`.
2. On next page select some suggested domain.
3. Verify that `Checkout` and `Yes, Add Email` still work as expected.
4. Verify that everything looks fine on small screen sizes.
5. Verify that issue from https://github.com/Automattic/wp-calypso/issues/15346 is no longer present.

