### PR TITLE
Prevent UI jumping while loading plans

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -488,6 +488,7 @@ $plan-features-sidebar-width: 272px;
 
 	.plan-features__graphic {
 		width: 100px;
+		height: 100px;
     	margin: 20px auto;
 	}
 


### PR DESCRIPTION
We didn't have an explicit height defined for plan icons in checkout so they were 0px high until fully loaded before they jumped to 100px and moved the price label down. 

They are all in square ratio so I took advantage of that and set the height.

Test: 
- /start
- proceed to plan selection step
- check if everything looks the same

If you want to dig deep, set network throttling and watch all the loading

### Before

| Nothing loaded | Some loaded
| - | - |
| <img width="698" alt="screen shot 2018-03-08 at 10 24 26" src="https://user-images.githubusercontent.com/156676/37143261-e7054dd6-22ba-11e8-9770-d871770a4528.png"> | <img width="662" alt="screen shot 2018-03-08 at 10 20 57" src="https://user-images.githubusercontent.com/156676/37143151-8d323828-22ba-11e8-871e-c342517040c3.png">

#### After, at any loading stage

<img width="686" alt="screen shot 2018-03-08 at 10 18 51" src="https://user-images.githubusercontent.com/156676/37143161-92e97b1e-22ba-11e8-9144-26af4d1f59b2.png">