### PR TITLE
Jetpack Connect: Manual instructions copy + illustration updates

### DIFF
--- a/client/jetpack-connect/example-components/jetpack-connect.jsx
+++ b/client/jetpack-connect/example-components/jetpack-connect.jsx
@@ -45,17 +45,11 @@ const JetpackConnectExampleConnect = ( { isLegacy, url, translate, onClick } ) =
 					<div className="example-components__content-wp-admin-connect-banner">
 						{ ! isLegacy ? (
 							<div className="example-components__content-wp-admin-plugin-name" aria-hidden="true">
-								{ translate( 'Connect Jetpack to WordPress.com', {
-									context:
-										'Jetpack Connect activate plugin instructions, connection banner headline',
-								} ) }
+								{ translate( 'Connect Jetpack to WordPress.com' ) }
 							</div>
 						) : null }
 						<div className="example-components__content-wp-admin-connect-button" aria-hidden="true">
-							{ translate( 'Set up Jetpack', {
-								context:
-									'Jetpack Connect post-plugin-activation step, Connect to WordPress.com button',
-							} ) }
+							{ translate( 'Set up Jetpack' ) }
 						</div>
 					</div>
 				</div>

--- a/client/jetpack-connect/example-components/jetpack-connect.jsx
+++ b/client/jetpack-connect/example-components/jetpack-connect.jsx
@@ -45,14 +45,14 @@ const JetpackConnectExampleConnect = ( { isLegacy, url, translate, onClick } ) =
 					<div className="example-components__content-wp-admin-connect-banner">
 						{ ! isLegacy ? (
 							<div className="example-components__content-wp-admin-plugin-name" aria-hidden="true">
-								{ translate( 'Your Jetpack is almost ready!', {
+								{ translate( 'Connect Jetpack to WordPress.com', {
 									context:
 										'Jetpack Connect activate plugin instructions, connection banner headline',
 								} ) }
 							</div>
 						) : null }
 						<div className="example-components__content-wp-admin-connect-button" aria-hidden="true">
-							{ translate( 'Connect to WordPress.com', {
+							{ translate( 'Set up Jetpack', {
 								context:
 									'Jetpack Connect post-plugin-activation step, Connect to WordPress.com button',
 							} ) }

--- a/client/jetpack-connect/install-step.jsx
+++ b/client/jetpack-connect/install-step.jsx
@@ -80,18 +80,16 @@ class JetpackInstallStep extends Component {
 			installJetpack: {
 				title: translate( '1. Install Jetpack' ),
 				text: translate(
-					'Click the “Install Jetpack” button below. You will be redirected to the ' +
-						'Jetpack plugin page on your site’s wp-admin dashboard to install Jetpack. ' +
-						'Click the blue “Install Now” button.'
+					"Click the green “Install Jetpack” button below. You'll be redirected to the " +
+						"Jetpack plugin page on your site’s wp-admin dashboard. where you'll " +
+						'then click the blue “Install Now” button.'
 				),
 				action: this.renderAlreadyHaveJetpackButton(),
 				example: <JetpackExampleInstall url={ currentUrl } onClick={ onClick } />,
 			},
 			activateJetpackAfterInstall: {
 				title: translate( '2. Activate Jetpack' ),
-				text: translate(
-					"Then you'll click the blue “Activate Plugin” button to activate Jetpack."
-				),
+				text: translate( 'Next, click the blue “Activate Plugin” button to activate Jetpack.' ),
 				action: null,
 				example: (
 					<JetpackExampleActivate url={ currentUrl } isInstall={ true } onClick={ onClick } />
@@ -106,8 +104,8 @@ class JetpackInstallStep extends Component {
 			activateJetpack: {
 				title: translate( '1. Activate Jetpack' ),
 				text: translate(
-					'You will be redirected to the Plugins page on your site’s wp-admin ' +
-						'dashboard to activate Jetpack. Click the blue “Activate” link. '
+					"You'll be redirected to the Plugins page on your site’s wp-admin " +
+						"dashboard, where you'll then Click the blue “Activate” link. "
 				),
 				action: this.renderNotJetpackButton(),
 				example: (

--- a/client/jetpack-connect/install-step.jsx
+++ b/client/jetpack-connect/install-step.jsx
@@ -81,7 +81,7 @@ class JetpackInstallStep extends Component {
 				title: translate( '1. Install Jetpack' ),
 				text: translate(
 					"Click the green “Install Jetpack” button below. You'll be redirected to the " +
-						"Jetpack plugin page on your site’s wp-admin dashboard. where you'll " +
+						"Jetpack plugin page on your site’s wp-admin dashboard, where you'll " +
 						'then click the blue “Install Now” button.'
 				),
 				action: this.renderAlreadyHaveJetpackButton(),

--- a/client/jetpack-connect/install-step.jsx
+++ b/client/jetpack-connect/install-step.jsx
@@ -83,14 +83,16 @@ class JetpackInstallStep extends Component {
 				text: translate(
 					'Click the “Install Jetpack” button below. You will be redirected to the ' +
 						'Jetpack plugin page on your site’s wp-admin dashboard to install Jetpack. ' +
-						'Click the blue install button.'
+						'Click the blue “Install Now” button.'
 				),
 				action: this.renderAlreadyHaveJetpackButton(),
 				example: <JetpackExampleInstall url={ currentUrl } onClick={ onClick } />,
 			},
 			activateJetpackAfterInstall: {
 				title: translate( '2. Activate Jetpack' ),
-				text: translate( "Then you'll click the blue “Activate Plugin” link to activate Jetpack." ),
+				text: translate(
+					"Then you'll click the blue “Activate Plugin” button to activate Jetpack."
+				),
 				action: null,
 				example: (
 					<JetpackExampleActivate url={ currentUrl } isInstall={ true } onClick={ onClick } />
@@ -106,7 +108,7 @@ class JetpackInstallStep extends Component {
 				title: translate( '1. Activate Jetpack' ),
 				text: translate(
 					'You will be redirected to the Jetpack plugin page on your site’s wp-admin ' +
-						'dashboard to activate Jetpack. Click the blue “Activate Plugin” link. '
+						'dashboard to activate Jetpack. Click the blue “Activate Plugin” button. '
 				),
 				action: this.renderNotJetpackButton(),
 				example: (

--- a/client/jetpack-connect/install-step.jsx
+++ b/client/jetpack-connect/install-step.jsx
@@ -23,7 +23,6 @@ class JetpackInstallStep extends Component {
 	static propTypes = {
 		confirmJetpackInstallStatus: PropTypes.func.isRequired,
 		currentUrl: PropTypes.string,
-		isInstall: PropTypes.bool.isRequired,
 		jetpackVersion: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		onClick: PropTypes.func,
 	};

--- a/client/jetpack-connect/install-step.jsx
+++ b/client/jetpack-connect/install-step.jsx
@@ -106,8 +106,8 @@ class JetpackInstallStep extends Component {
 			activateJetpack: {
 				title: translate( '1. Activate Jetpack' ),
 				text: translate(
-					'You will be redirected to the Jetpack plugin page on your site’s wp-admin ' +
-						'dashboard to activate Jetpack. Click the blue “Activate Plugin” button. '
+					'You will be redirected to the Plugins page on your site’s wp-admin ' +
+						'dashboard to activate Jetpack. Click the blue “Activate” link. '
 				),
 				action: this.renderNotJetpackButton(),
 				example: (

--- a/client/jetpack-connect/install-step.jsx
+++ b/client/jetpack-connect/install-step.jsx
@@ -68,7 +68,7 @@ class JetpackInstallStep extends Component {
 	}
 
 	getStep( stepName ) {
-		const { currentUrl, isInstall, jetpackVersion, onClick, translate } = this.props;
+		const { currentUrl, jetpackVersion, onClick, translate } = this.props;
 
 		const isLegacyVersion =
 			jetpackVersion && versionCompare( jetpackVersion, NEW_INSTRUCTIONS_JETPACK_VERSION, '<' );
@@ -80,21 +80,17 @@ class JetpackInstallStep extends Component {
 		const steps = {
 			installJetpack: {
 				title: translate( '1. Install Jetpack' ),
-				text: isInstall
-					? translate(
-							"You will be redirected to your site's dashboard to install " +
-								'Jetpack. Click the blue "Install Now" button.'
-						)
-					: translate(
-							"You will be redirected to the Jetpack plugin page on your site's " +
-								'dashboard to install Jetpack. Click the blue install button.'
-						),
+				text: translate(
+					'Click the “Install Jetpack” button below. You will be redirected to the ' +
+						'Jetpack plugin page on your site’s wp-admin dashboard to install Jetpack. ' +
+						'Click the blue install button.'
+				),
 				action: this.renderAlreadyHaveJetpackButton(),
 				example: <JetpackExampleInstall url={ currentUrl } onClick={ onClick } />,
 			},
 			activateJetpackAfterInstall: {
 				title: translate( '2. Activate Jetpack' ),
-				text: translate( 'Then you\'ll click the blue "Activate" link to activate Jetpack.' ),
+				text: translate( "Then you'll click the blue “Activate Plugin” link to activate Jetpack." ),
 				action: null,
 				example: (
 					<JetpackExampleActivate url={ currentUrl } isInstall={ true } onClick={ onClick } />
@@ -102,17 +98,15 @@ class JetpackInstallStep extends Component {
 			},
 			connectJetpackAfterInstall: {
 				title: translate( '3. Connect Jetpack' ),
-				text: translate(
-					'Finally, click the "Connect to WordPress.com" button to finish the process.'
-				),
+				text: translate( 'Finally, click the “Set up Jetpack” button to finish the process.' ),
 				action: null,
 				example: jetpackConnectExample,
 			},
 			activateJetpack: {
 				title: translate( '1. Activate Jetpack' ),
 				text: translate(
-					"You will be redirected to your site's dashboard to activate Jetpack. " +
-						'Click the blue "Activate" link. '
+					'You will be redirected to the Jetpack plugin page on your site’s wp-admin ' +
+						'dashboard to activate Jetpack. Click the blue “Activate Plugin” link. '
 				),
 				action: this.renderNotJetpackButton(),
 				example: (
@@ -121,9 +115,7 @@ class JetpackInstallStep extends Component {
 			},
 			connectJetpack: {
 				title: translate( '2. Connect Jetpack' ),
-				text: translate(
-					'Then click the "Connect to WordPress.com" button to finish the process.'
-				),
+				text: translate( 'Then click the “Set up Jetpack” button to finish the process.' ),
 				action: null,
 				example: jetpackConnectExample,
 			},

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -523,9 +523,9 @@ export class JetpackConnectMain extends Component {
 	}
 
 	renderInstructions( instructionsData ) {
-		const jetpackVersion = this.checkProperty( 'jetpackVersion' ),
-			isInstall = this.isInstall(),
-			{ currentUrl } = this.state;
+		const jetpackVersion = this.checkProperty( 'jetpackVersion' );
+		const { currentUrl } = this.state;
+
 		return (
 			<MainWrapper isWide>
 				{ this.renderLocaleSuggestions() }
@@ -541,7 +541,6 @@ export class JetpackConnectMain extends Component {
 									key={ 'instructions-step-' + key }
 									stepName={ stepName }
 									jetpackVersion={ jetpackVersion }
-									isInstall={ isInstall }
 									currentUrl={ currentUrl }
 									confirmJetpackInstallStatus={ this.props.confirmJetpackInstallStatus }
 									onClick={ instructionsData.buttonOnClick }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -351,8 +351,13 @@
 
 .example-components__content-wp-admin-activate-link {
 	font-size: 12px;
-	color: #0073aa;
-	text-decoration: underline;
+	display: inline-block;
+	padding: 7px 14px;
+	line-height: 1;
+	color: $white;
+	background-color: #008ec2; // wp-admin button blue
+	border: 1px solid #006799;
+	border-radius: 3px;
 }
 
 .example-components__site-url-input-container

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -293,7 +293,6 @@
 		margin: 10px;
 		padding: 10px 10px 12px 10px;
 		background-color: $white;
-		border-left: 4px solid #46b450;
 	}
 
 	.example-components__content-wp-admin-connect-button {
@@ -302,9 +301,10 @@
 		padding: 7px 14px;
 		line-height: 1;
 		color: $white;
-		background-color: #008ec2; // wp-admin button blue
-		border: 1px solid #006799;
 		border-radius: 3px;
+		background-color: #00be28;
+		border: 2px #00a523 solid;
+		border-width: 1px 1px 2px;
 	}
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -225,7 +225,7 @@
 .example-components__install-plugin-header {
 	width: 100%;
 	padding-bottom: 12%;
-	background-color: #8cc258; //Jetpack Green
+	background-color: $green-jetpack;
 }
 
 .example-components__install-plugin-body {


### PR DESCRIPTION
Fixes #22919, fixes #22716.

Update manual install and activate instructions to match wp-admin.

The copy and styling updates are a combination of the suggestions from #22919, #22716, and the mockups at p7rd6c-1dS-p2.


**Install Instructions Before**

<img width="1273" alt="install_before" src="https://user-images.githubusercontent.com/7767559/37156580-578c8c18-22de-11e8-9ee0-6260a1f1d04f.png">

**Install Instructions After**

<img width="1275" alt="install_after" src="https://user-images.githubusercontent.com/7767559/37156597-62206c94-22de-11e8-8360-2da489678047.png">

**Activate Instructions Before**

<img width="1273" alt="activate_before" src="https://user-images.githubusercontent.com/7767559/37156613-699ef454-22de-11e8-8585-9a3bc1904fed.png">

**Activate Instructions After**

<img width="1273" alt="activate_after" src="https://user-images.githubusercontent.com/7767559/37156624-7181159e-22de-11e8-9907-724f4bd88ff3.png">

## Testing

**Install + Activate Instructions**
* Go to https://calypso.live/jetpack/connect?branch=update/jetpack-connect/install-instructions
* Enter the URL of a site without the Jetpack plugin installed

**Activate Instructions**
* Go to https://calypso.live/jetpack/connect?branch=update/jetpack-connect/install-instructions
* Enter the URL of a site with the Jetpack plugin installed but not activated
