### PR TITLE
Guided Tours: fix scrolling using `shouldScrollTo`

### DIFF
--- a/client/layout/guided-tours/config-elements/step.js
+++ b/client/layout/guided-tours/config-elements/step.js
@@ -104,6 +104,7 @@ export default class Step extends Component {
 	}
 
 	componentWillReceiveProps( nextProps, nextContext ) {
+		const shouldScrollTo = nextProps.shouldScrollTo && this.props.name !== nextProps.name;
 		this.wait( nextProps, nextContext ).then( () => {
 			this.setStepSection( nextContext );
 			this.quitIfInvalidRoute( nextProps, nextContext );
@@ -111,7 +112,6 @@ export default class Step extends Component {
 			this.scrollContainer.removeEventListener( 'scroll', this.onScrollOrResize );
 			this.scrollContainer = query( nextProps.scrollContainer )[ 0 ] || window;
 			this.scrollContainer.addEventListener( 'scroll', this.onScrollOrResize );
-			const shouldScrollTo = nextProps.shouldScrollTo && this.props.name !== nextProps.name;
 			this.setStepPosition( nextProps, shouldScrollTo );
 			this.watchTarget();
 		} );


### PR DESCRIPTION
This PR fixes scrolling in Guided Tours. Scrolling is being triggered from `componentWillReceiveProps`. The code in question was then moved into a Promise, so a comparison between `this.props` and `nextProps` would only be evaluated after those were already the same. b3543d4 moves the comparison out of the Promise. 

Fixes #23070. 

Screen capture of solution: 

![guided-tours-scrolling](https://user-images.githubusercontent.com/23619/37154541-a4120066-22e0-11e8-98f7-5ae11511422c.gif)

Previously, the scrolling would not be triggered. 

To test:
- resize your browser window to be about 800x500
- go to http://calypso.localhost:3000/?tour=main or https://calypso.live/?branch=fix/guided-tours-scrolling&tour=main
- make sure all steps work and the step pointing to "Themes" in the sidebar is being scrolled into view as in the GIF above