### PR TITLE
Guided Tours: add a subtle border around the `Quit` button

### DIFF
--- a/client/layout/guided-tours/config-elements/quit.js
+++ b/client/layout/guided-tours/config-elements/quit.js
@@ -35,10 +35,10 @@ export default class Quit extends Component {
 	};
 
 	render() {
-		const { children, primary, subtle } = this.props;
-		const classes = subtle ? 'guided-tours__subtle-button' : '';
+		const { children, primary } = this.props;
 		return (
-			<Button className={ classes } onClick={ this.onClick } primary={ primary }>
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+			<Button className="guided-tours__quit-button" onClick={ this.onClick } primary={ primary }>
 				{ children || translate( 'Quit' ) }
 			</Button>
 		);

--- a/client/layout/guided-tours/docs/API.md
+++ b/client/layout/guided-tours/docs/API.md
@@ -11,7 +11,7 @@ Tour is a React component that declares the top-level of a tour. It consists of 
 * `name`: (string) Unique name of tour in camelCase.
 * `version` (string): Version identifier. We use date string like "20161224".
 * `path` (string or array, optional): Use this prop to limit tour only to some path prefix (or more prefixes if array). Example: `path={ [ '/stats', '/settings' ] }`
-* `when` (function, optional): This is a Redux selector function. Use this to define conditions for the tour to start. Can be overridden by adding a `tour` query argument to the URL like so: `?tour=tourName`, in which case the tour will be triggered even if `when` would evaluate to `false`. This is useful for sending along a tour via email or chat. On the other hand, the framework will try to not trigger a tour multiple times (see `toursSeen` in [ARCHITECTURE.md](./ARCHITECTURE.md)). *Note:* you can reset the tours history by adding `?tour=reset` to the URL. 
+* `when` (function, optional): This is a Redux selector function. Use this to define conditions for the tour to start. Can be overridden by adding a `tour` query argument to the URL like so: `?tour=tourName`, in which case the tour will be triggered even if `when` would evaluate to `false`. This is useful for sending along a tour via email or chat. On the other hand, the framework will try to not trigger a tour multiple times (see `toursSeen` in [ARCHITECTURE.md](./ARCHITECTURE.md)). *Note:* you can reset the tours history by adding `?tour=reset` to the URL.
 * `children` (nodes): only supported type is `<Step>`
 
 ### Example
@@ -41,7 +41,7 @@ Step is a React component that defines a single Step of a tour. It is represente
 * `wait`: (function, optional) If defined, the step will be waiting until `wait` function has done. In case of returning a `Promise`, the step starts when resolved.
 * `when`: (function, optional) This is a Redux selector that can prevent a step from showing when it evaluates to false. When using `when` you should also set the `next` prop to tell Guided Tours the name of the step it should skip to. If you omit this prop, step will be rendered as expected. Example usage would be to show a certain step only for non-mobile environments: `when={ not( isMobile ) }`
 * `next`: (string, optional) Define this to tell Guided Tours the name of the step it should skip to when `when` evaluates to false.
-* `scrollContainer`: (string, optional) This is a CSS selector for the container that the framework should attempt to scroll in case the target isn't visible. E.g. if the target is a menu item that could be invisible because of a scrolled sidebar, we'd want the framework to scroll the sidebar until the target is visible. The CSS selector to pass would then be `.sidebar__region`. Note: there were some differences for the sidebar between desktop and tablet that don't seem to be a problem anymore, but in any case have been [documented in  this issue](https://github.com/Automattic/wp-calypso/issues/7208). 
+* `scrollContainer`: (string, optional) This is a CSS selector for the container that the framework should attempt to scroll in case the target isn't visible. E.g. if the target is a menu item that could be invisible because of a scrolled sidebar, we'd want the framework to scroll the sidebar until the target is visible. The CSS selector to pass would then be `.sidebar__region`. Note: there were some differences for the sidebar between desktop and tablet that don't seem to be a problem anymore, but in any case have been [documented in  this issue](https://github.com/Automattic/wp-calypso/issues/7208).
 * `children`: (node) Contents of the step. Usually a paragraph of instructions and some controls for the tour. See below for available options. Note that all text content needs to be wrapped in `<p>` so it gets proper styling.
 
 ### Example
@@ -148,8 +148,7 @@ Quit is a React component that shows a button that allows users to quit current 
 
 ### Props
 
-* `primary` (bool, optional) If true, button will be rendered as primary. Use only if Quit is the only available action in that step.
-* `subtle` (bool, optional) If true, button will be rendered the same color as the step background. For use when we need that style but only have a single button to display.
+* `primary` (bool, optional) If true, button will be rendered as primary.
 
 ### Label
 

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -121,10 +121,10 @@
 	.button:nth-child(1) {
 		margin-right: 4%;
 	}
-	.button:nth-child(2) {
+	.guided-tours__quit-button {
 		color: darken( $white, 20% );
 		background: none;
-		border: none;
+		border: 1px darken( $white, 20% ) solid;
 	}
 }
 
@@ -142,13 +142,14 @@ a.config-elements__text-link,
 }
 
 .guided-tours__single-button-row {
+	text-align: center;
 	.button {
-		width: 100%;
+		width: 48%;
 	}
-	.guided-tours__subtle-button, {
+	.guided-tours__quit-button {
 		color: darken( $white, 20% );
 		background: none;
-		border: none;
+		border: 1px darken( $white, 20% ) solid;
 	}
 }
 

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -124,7 +124,7 @@
 	.guided-tours__quit-button {
 		color: darken( $white, 20% );
 		background: none;
-		border: 1px darken( $white, 20% ) solid;
+		border: 1px rgba( $white, 0.2 ) solid;
 	}
 }
 
@@ -149,7 +149,7 @@ a.config-elements__text-link,
 	.guided-tours__quit-button {
 		color: darken( $white, 20% );
 		background: none;
-		border: 1px darken( $white, 20% ) solid;
+		border: 1px rgba( $white, 0.2 ) solid;
 	}
 }
 

--- a/client/layout/guided-tours/tours/main-tour.js
+++ b/client/layout/guided-tours/tours/main-tour.js
@@ -103,6 +103,9 @@ export const MainTour = makeTour(
 					},
 				} ) }
 			</Continue>
+			<ButtonRow>
+				<Quit />
+			</ButtonRow>
 		</Step>
 
 		<Step name="view-site" placement="center" when={ isSelectedSitePreviewable }>


### PR DESCRIPTION
As proposed in #18619, this PR adds a subtle border around the Guided Tours `Quit` button. 

Before:

<img width="464" alt="screen shot 2018-03-08 at 3 45 09 pm" src="https://user-images.githubusercontent.com/23619/37156930-b4049860-22e7-11e8-9e3a-4e30f6981eb5.png">

After:

![quit-button](https://user-images.githubusercontent.com/23619/37164989-d308f6f2-22fb-11e8-8cbf-a0057642ef96.gif)

To test:
- go to http://calypso.localhost:3000/?tour=main or https://calypso.live/?branch=update/guided-tours-quit-button-border&tour=main and go through the tour to see the `Quit` button in two different variations: together with a primary button and individually. 

Fixes #18619. 