### PR TITLE
Plugins: Move Redirect Logic to PluginsList

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -20,7 +20,7 @@ import PluginBrowser from './plugins-browser';
 import PluginUpload from './plugin-upload';
 import { setSection } from 'state/ui/actions';
 import { getSelectedSite, getSection } from 'state/ui/selectors';
-import { hasJetpackSites, getSelectedOrAllSitesWithPlugins } from 'state/selectors';
+import { getSelectedOrAllSitesWithPlugins } from 'state/selectors';
 
 /**
  * Module variables
@@ -225,24 +225,6 @@ const controller = {
 				return;
 			}
 		}
-		next();
-	},
-
-	redirectSimpleSitesToPluginBrowser( context, next ) {
-		const site = getSelectedSite( context.store.getState() );
-
-		// Selected site is not a Jetpack site
-		if ( site && ! site.jetpack ) {
-			page.redirect( `/plugins/${ site.slug }` );
-			return;
-		}
-
-		//  None of the other sites are Jetpack sites
-		if ( ! site && ! hasJetpackSites( context.store.getState() ) ) {
-			page.redirect( '/plugins' );
-			return;
-		}
-
 		next();
 	},
 

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -83,7 +83,6 @@ export default function() {
 			'/plugins/manage/:site?',
 			siteSelection,
 			navigation,
-			pluginsController.redirectSimpleSitesToPluginBrowser,
 			pluginsController.plugins,
 			makeLayout,
 			clientRender
@@ -93,7 +92,6 @@ export default function() {
 			'/plugins/:pluginFilter(active|inactive|updates)/:site_id?',
 			siteSelection,
 			navigation,
-			pluginsController.redirectSimpleSitesToPluginBrowser,
 			pluginsController.jetpackCanUpdate,
 			pluginsController.plugins,
 			makeLayout,

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -64,18 +64,25 @@ const PluginsMain = createReactClass( {
 	},
 
 	componentWillReceiveProps( nextProps ) {
-		const { hasJetpackSites: hasJpSites, selectedSiteIsJetpack, selectedSiteSlug } = nextProps;
+		const {
+			hasJetpackSites: hasJpSites,
+			isRequestingSites: isRequesting,
+			selectedSiteIsJetpack,
+			selectedSiteSlug,
+		} = nextProps;
 
-		// Selected site is not a Jetpack site
-		if ( selectedSiteSlug && ! selectedSiteIsJetpack ) {
-			page.redirect( `/plugins/${ selectedSiteSlug }` );
-			return;
-		}
+		if ( ! isRequesting ) {
+			// Selected site is not a Jetpack site
+			if ( selectedSiteSlug && ! selectedSiteIsJetpack ) {
+				page.redirect( `/plugins/${ selectedSiteSlug }` );
+				return;
+			}
 
-		//  None of the other sites are Jetpack sites
-		if ( ! selectedSiteSlug && ! hasJpSites ) {
-			page.redirect( '/plugins' );
-			return;
+			//  None of the other sites are Jetpack sites
+			if ( ! selectedSiteSlug && ! hasJpSites ) {
+				page.redirect( '/plugins' );
+				return;
+			}
 		}
 
 		this.refreshPlugins( nextProps );

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -4,6 +4,7 @@
  */
 import React from 'react';
 import createReactClass from 'create-react-class';
+import page from 'page';
 import { connect } from 'react-redux';
 import { find, isEmpty, some } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -30,7 +31,12 @@ import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import PluginsBrowser from './plugins-browser';
 import NonSupportedJetpackVersionNotice from './not-supported-jetpack-version';
 import NoPermissionsError from './no-permissions-error';
-import { canCurrentUser, canCurrentUserManagePlugins, getSelectedOrAllSitesWithPlugins } from 'state/selectors';
+import {
+	canCurrentUser,
+	canCurrentUserManagePlugins,
+	getSelectedOrAllSitesWithPlugins,
+	hasJetpackSites,
+} from 'state/selectors';
 import {
 	canJetpackSiteManage,
 	canJetpackSiteUpdateFiles,
@@ -58,6 +64,20 @@ const PluginsMain = createReactClass( {
 	},
 
 	componentWillReceiveProps( nextProps ) {
+		const { hasJetpackSites: hasJpSites, selectedSiteIsJetpack, selectedSiteSlug } = nextProps;
+
+		// Selected site is not a Jetpack site
+		if ( selectedSiteSlug && ! selectedSiteIsJetpack ) {
+			page.redirect( `/plugins/${ selectedSiteSlug }` );
+			return;
+		}
+
+		//  None of the other sites are Jetpack sites
+		if ( ! selectedSiteSlug && ! hasJpSites ) {
+			page.redirect( '/plugins' );
+			return;
+		}
+
 		this.refreshPlugins( nextProps );
 	},
 
@@ -488,7 +508,9 @@ export default connect(
 	state => {
 		const selectedSite = getSelectedSite( state );
 		const selectedSiteId = getSelectedSiteId( state );
+
 		return {
+			hasJetpackSites: hasJetpackSites( state ),
 			sites: getSelectedOrAllSitesWithPlugins( state ),
 			selectedSite,
 			selectedSiteId,

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -30,7 +30,7 @@ import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import PluginsBrowser from './plugins-browser';
 import NonSupportedJetpackVersionNotice from './not-supported-jetpack-version';
 import NoPermissionsError from './no-permissions-error';
-import { canCurrentUser, canCurrentUserManagePlugins } from 'state/selectors';
+import { canCurrentUser, canCurrentUserManagePlugins, getSelectedOrAllSitesWithPlugins } from 'state/selectors';
 import {
 	canJetpackSiteManage,
 	canJetpackSiteUpdateFiles,
@@ -38,7 +38,6 @@ import {
 	isRequestingSites,
 } from 'state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { getSelectedOrAllSitesWithPlugins } from 'state/selectors';
 import HeaderButton from 'components/header-button';
 import { isEnabled } from 'config';
 


### PR DESCRIPTION
Move the logic introduced by #20443 to  `plugin/main`'s `componentWillReceiveProps()` lifecycle method.

Rationale (from https://github.com/Automattic/wp-calypso/pull/20443#issuecomment-349050847):

> There is a general issue with relying on stuff being fetched from `state` in the controller, as opposed to inside a React component. The problem is that unlike a React component, the controller, like any other vanilla JS function, is called only once (often before the relevant data has been fetched from the network and stored in state) — as opposed to a `connect()`ed React component, which is conveniently re-rendered once state updates (when data has been fetched)…
Making sure we don’t falsely redirect can be a bit subtle, depending e.g. on whether there is an `isRequesting` type of selector, or what the default return value for the relevant selector is (before the fetch has completed). Here’s an example: https://github.com/Automattic/wp-calypso/pull/17276

The crucial change in this PR is that we wrap the redirects in an additional `if ( ! nextProps.isRequesting )` check in  `componentWillReceiveProps()`, which will ensure that we'll only redirect once we've received site data.

To reproduce the issue (e.g. in production):
* Clear `localStorage` and `IndexedDb`, reload.
* Direct your browser to `wordpress.com/plugins/manage/<yourJPSite>`.
* Verify that you're being redirected to `wordpress.com/plugins`, or possibly `wordpress.com/plugins/<yourJPsite>`. 
* This is only meant to happen when the selected site (as specified in the route) is no JP site, _and_ if the user doesn't have any JP sites at all. However, since `state` isn't guaranteed to be available at the time the controller is run (see 'Rationale' above), the controller erroneously assumes that this is the case.

To verify the fix works:
* Verify that this PR solves the issue: no more incorrect redirects.
* Also verify that you're still correctly redirected to `/plugins/<yourSite>` if the selected site is not a JP site, and to `/plugins` if the current user doesn't have any JP sites at all.