### PR TITLE
Comments: prevent vanishing of unapproved comments

### DIFF
--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -113,7 +113,13 @@ export const getPostCommentsTree = treeSelect(
 	( [ allItems ], siteId, postId, status = 'approved', authorId ) => {
 		const items = filter( allItems, item => {
 			//only return pending comments that match the comment author
-			if ( authorId && item.status === 'unapproved' && get( item, 'author.ID' ) !== authorId ) {
+			const commentAuthorId = get( item, 'author.ID' );
+			if (
+				authorId &&
+				commentAuthorId &&
+				item.status === 'unapproved' &&
+				commentAuthorId !== authorId
+			) {
 				return false;
 			}
 			if ( status !== 'all' ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/14781.

There's a well-meaning check in the comments selector `getPostCommentsTree` that only returns unapproved comments if the current author ID matches the comment author ID.

However, when a new comment is submitted and is 'unapproved' state, sometimes `comment.author.ID` can be `0`. This PR changes the check so that it only happens if the comment author ID is truthy.

This fixes the display of unapproved comments on a moderated site in Reader full post (#14781).

### To test

Head to http://calypso.localhost:3000/read/blogs/143779275/posts/3. Make a comment, and verify that it looks like this after posting:

![screen shot 2018-03-08 at 16 56 31](https://user-images.githubusercontent.com/17325/37164254-af5858ec-22f1-11e8-864d-eb0772fe4700.png)


