### PR TITLE
Add 2.0 config for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,86 @@
+version: 2
+jobs:
+  build:
+    parallelism: 4
+    working_directory: ~/wp-calypso
+    docker:
+      - image: circleci/node:8.9.4-browsers
+        environment:
+          CIRCLE_ARTIFACTS: /tmp/artifacts
+          CIRCLE_TEST_REPORTS: /tmp/test_results
+
+    steps:
+      - checkout
+
+      - run:
+          name: Create Directories for Results and Artifacts
+          command: |
+            mkdir -p $CIRCLE_ARTIFACTS
+            mkdir -p $CIRCLE_TEST_REPORTS
+
+      - restore_cache:
+          key: v1-{{ .Branch }}-{{ checksum "package.json" }}
+
+      - run: npm install
+
+      - save_cache:
+          key: v1-{{ .Branch }}-{{ checksum "package.json" }}
+          paths:
+            - "node_modules"
+
+      - run: NODE_ENV=test npm run build-server
+
+      - run:
+          command: |
+            npm run translate; mkdir -p $CIRCLE_ARTIFACTS/translate
+            mv calypso-strings.pot $CIRCLE_ARTIFACTS/translate
+
+      - run:
+          command: |
+            git clone https://github.com/Automattic/gp-localci-client.git
+            bash gp-localci-client/generate-new-strings-pot.sh $CIRCLE_BRANCH $CIRCLE_SHA1 $CIRCLE_ARTIFACTS/translate
+            rm -rf gp-localci-client
+
+      - run:
+          name: Run Integration Tests
+          command: |
+            bin/run-integration $(circleci tests glob "bin/**/integration/*.js" "client/**/integration/*.js" "server/**/integration/*.js" | circleci tests split --split-by=timings)
+
+      - run:
+          name: Lint
+          command: npm run lint:config-defaults
+
+      - run:
+          name: Lint Client and Server
+          command: |
+            ./node_modules/.bin/eslint-eslines $(circleci tests glob "client/**/*.js" "client/**/*.jsx" "server/**/*.js" "server/**/*.jsx" | circleci tests split)
+
+      - run:
+          name: Run Client Tests
+          command: |
+              npm run test-client:ci $(circleci tests glob "client/**/test/*.js" "client/**/test/*.jsx" | circleci tests split --split-by=timings)
+
+      - run:
+          name: Run Server Tests
+          command: |
+              npm run test-server:ci $(circleci tests glob "server/**/test/*.js" "server/**/test/*.jsx" | circleci tests split --split-by=timings)
+
+      - run:
+          name: Gather Test Results
+          command: |
+            find . -type f -regex  ".*/test-results.*\.xml" -exec cp {} $CIRCLE_TEST_REPORTS/ \;
+          when: always
+
+      - store_test_results:
+          path: /tmp/test_results
+      - store_artifacts:
+          path: /tmp/test_results
+      - store_artifacts:
+          path: /tmp/artifacts
+
+# We need to work around this bit because
+# the notification system in 2.0 is a bit flakey
+# and is not yet working as expected.
+# notify:
+#   webhooks:
+#     - url: https://translate.wordpress.com/api/localci/-relay-new-strings-to-gh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             mkdir -p $CIRCLE_TEST_REPORTS
 
       - restore_cache:
-          key: v1-{{ .Branch }}-{{ checksum "package.json" }}
+          key: v1-{{ .Branch }}-{{ checksum "npm-shrinkwrap.json" }}
 
       - run: npm install
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - run: npm install
 
       - save_cache:
-          key: v1-{{ .Branch }}-{{ checksum "package.json" }}
+          key: v1-{{ .Branch }}-{{ checksum "npm-shrinkwrap.json" }}
           paths:
             - "node_modules"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,6 @@ jobs:
 # We need to work around this bit because
 # the notification system in 2.0 is a bit flakey
 # and is not yet working as expected.
-# notify:
-#   webhooks:
-#     - url: https://translate.wordpress.com/api/localci/-relay-new-strings-to-gh
+notify:
+  webhooks:
+    - url: https://translate.wordpress.com/api/localci/-relay-new-strings-to-gh


### PR DESCRIPTION
See #22577

Pulling #22577 into a branch created by an in-organization author so all
of our tests runs normally.

This patch updates our CircleCI configuration so that we use version 2
of the platform. Among simplifying our configuration and options to
indicate how to parallelize our builds it resolves an issue raised in
version 1 that we were working around (see #21518)

Millions of thanks to @levlaz for his amazing support and help in
creating this file, helping us understand what needs to be there, and in
making the original PR.

**Note** Please consider this a community PR and if you find something
that needs fixing please just update it with a new commit.

**Remaining Work**
I certainly don't know! Please help m know what's left. If there's something you are uncomfortable with about merging this then please leave your concern in a comment or in this comment.

Finally, please vote on your willingness to merge this PR by voting :+1: or :-1: on the PR itself. If we get enough upvotes we'll merge it. Maybe we'll just YOLO and merge it anyway once we get the `i18n` stuff worked out.