### PR TITLE
Store: Show an "already exists" message when creating a duplicate coupon code

### DIFF
--- a/client/extensions/woocommerce/app/promotions/promotion-create.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-create.js
@@ -30,6 +30,7 @@ import {
 	getPromotionEdits,
 	getPromotionWithLocalEdits,
 } from 'woocommerce/state/selectors/promotions';
+import { getSaveErrorMessage } from './save-error-message';
 import PromotionHeader from './promotion-header';
 import PromotionForm from './promotion-form';
 import { ProtectFormGuard } from 'lib/protect-form';
@@ -145,15 +146,13 @@ class PromotionCreate extends React.Component {
 			page.redirect( getLink( '/store/promotions/:site', site ) );
 		};
 
-		const failureAction = dispatch => {
-			dispatch(
-				errorNotice(
-					translate( 'There was a problem saving the %(promotion)s promotion. Please try again.', {
-						args: { promotion: promotion.name },
-					} )
-				)
-			);
+		const failureAction = error => {
 			this.setState( () => ( { busy: false } ) );
+			const errorSlug = ( error && error.error ) || undefined;
+
+			return errorNotice( getSaveErrorMessage( errorSlug, promotion.name, translate ), {
+				duration: 8000,
+			} );
 		};
 
 		this.props.createPromotion( site.ID, promotion, successAction, failureAction );

--- a/client/extensions/woocommerce/app/promotions/promotion-update.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-update.js
@@ -35,6 +35,7 @@ import {
 	getPromotionEdits,
 	getPromotionWithLocalEdits,
 } from 'woocommerce/state/selectors/promotions';
+import { getSaveErrorMessage } from './save-error-message';
 import PromotionHeader from './promotion-header';
 import PromotionForm from './promotion-form';
 import { ProtectFormGuard } from 'lib/protect-form';
@@ -180,15 +181,13 @@ class PromotionUpdate extends React.Component {
 			this.setState( () => ( { busy: false, saveAttempted: false } ) );
 		};
 
-		const failureAction = dispatch => {
-			dispatch(
-				errorNotice(
-					translate( 'There was a problem saving the %(promotion)s promotion. Please try again.', {
-						args: { promotion: promotion.name },
-					} )
-				)
-			);
+		const failureAction = error => {
 			this.setState( () => ( { busy: false } ) );
+			const errorSlug = ( error && error.error ) || undefined;
+
+			return errorNotice( getSaveErrorMessage( errorSlug, promotion.name, translate ), {
+				duration: 8000,
+			} );
 		};
 
 		this.props.updatePromotion( site.ID, promotion, successAction, failureAction );

--- a/client/extensions/woocommerce/app/promotions/save-error-message.js
+++ b/client/extensions/woocommerce/app/promotions/save-error-message.js
@@ -1,0 +1,12 @@
+export function getSaveErrorMessage( slug, promotionName, translate ) {
+	switch ( slug ) {
+		case 'woocommerce_rest_coupon_code_already_exists':
+			return translate( 'There was a problem saving the %(promotion)s promotion. A coupon with this code already exists.', {
+				args: { promotion: promotionName },
+			} );
+		default:
+			return translate( 'There was a problem saving the %(promotion)s promotion. Please try again.', {
+				args: { promotion: promotionName },
+			} );
+	}
+}

--- a/client/extensions/woocommerce/state/sites/coupons/handlers.js
+++ b/client/extensions/woocommerce/state/sites/coupons/handlers.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { trim } from 'lodash';
+import { trim, isFunction } from 'lodash';
 import warn from 'lib/warn';
 import debugFactory from 'debug';
 
@@ -104,8 +104,15 @@ export function couponDeleteSuccess( { dispatch }, action ) {
 function apiError( { dispatch }, action, error ) {
 	warn( 'Coupon API Error: ', error );
 
-	if ( action.failureAction ) {
-		dispatch( action.failureAction );
+	const { failureAction } = action;
+	if ( ! failureAction ) {
+		return;
+	}
+
+	if ( isFunction( failureAction ) ) {
+		dispatch( failureAction( error ) );
+	} else {
+		dispatch( failureAction );
 	}
 }
 


### PR DESCRIPTION
Fixes #19762. This PR displays a more specific error message when a update/create fails due to a duplicate coupon code. We do this for product categories and products already as well.

To Test:
* Run `npm run test-client client/extensions/woocommerce` and make sure all tests pass.
* Go to `http://calypso.localhost:3000/store/promotions/:site` and click `Add promotion`
* Create a coupon promotion with a code that already exists.
* Verify you see the "A coupon with this code already exists" message.
* Choose a unique name and verify the product saves.
* Edit an existing coupon promotion and try to rename it to a coupon code that already exists. Verify the error message.