### PR TITLE
Jetpack Connect: Move logo down from the masterbar

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -48,6 +48,10 @@
 	.jetpack-logo__icon {
 		fill: $green-jetpack;
 	}
+
+	@include breakpoint( '<660px' ) {
+		margin-top: 20px;
+	}
 }
 
 .jetpack-connect__main.is-wide {


### PR DESCRIPTION
Add a margin above the Jetpack logo, which was touching the masterbar at mobile-widths.

**Before**

<img width="250" alt="screen shot 2018-03-08 at 17 08 52" src="https://user-images.githubusercontent.com/7767559/37165051-912ff74c-22f3-11e8-8cb2-392320a35781.png">

**After**

<img width="250" alt="screen shot 2018-03-08 at 17 07 34" src="https://user-images.githubusercontent.com/7767559/37165057-92fccf78-22f3-11e8-840d-3792897b90f6.png">

## Testing
* Go to  https://calypso.live/jetpack/connect?branch=update/jetpack-connect/logo-margin