### PR TITLE
Checkout: Add form Labels to all checkout forms

### DIFF
--- a/client/components/credit-card-form-fields/style.scss
+++ b/client/components/credit-card-form-fields/style.scss
@@ -75,16 +75,6 @@
 	input[disabled] {
 		cursor: not-allowed;
 	}
-
-	label {
-		color: $gray-darken-10;
-		font-size: 11px;
-		font-weight: bold;
-		position: absolute;
-		left: -1000px;
-		top: -1000px;
-		margin: 0;
-	}
 }
 
 .credit-card-form-fields__info-text {

--- a/client/my-sites/checkout/checkout/new-card-form.jsx
+++ b/client/my-sites/checkout/checkout/new-card-form.jsx
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { defer } from 'lodash';
 import { localize } from 'i18n-calypso';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -32,9 +31,6 @@ class NewCardForm extends Component {
 
 	render() {
 		const { countriesList, hasStoredCards, translate, transaction } = this.props;
-		const classes = classNames( 'all-fields-required', {
-			'has-saved-cards': this.props.hasStoredCards,
-		} );
 
 		return (
 			<div className="checkout__new-card">
@@ -48,8 +44,6 @@ class NewCardForm extends Component {
 							{ translate( 'Use New Credit/Debit Card' ) }:
 						</h6>
 					) : null }
-
-					<span className={ classes }>{ translate( 'All fields required' ) }</span>
 
 					<CreditCardFormFields
 						card={ transaction.newCardFormFields }

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -367,26 +367,6 @@
 			font-weight: 400;
 			margin-bottom: 15px;
 		}
-
-		.all-fields-required {
-			color: $gray-lighten-10;
-			display: block;
-			font-size: 12px;
-			font-style: italic;
-
-			@include breakpoint( '>660px' ) {
-				top: 7px;
-			}
-
-			&.has-saved-cards {
-				top: 18px;
-
-				@include breakpoint( '>660px' ) {
-					position: absolute;
-						right: 18px;
-				}
-			}
-		}
 	}
 
 	.checkout__summary-toggle {

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -435,10 +435,6 @@
 			flex-basis: auto;
 			flex-grow: 3;
 			flex-shrink: 0;
-
-			label {
-				display: none;
-			}
 		}
 
 		.postal-code {
@@ -446,10 +442,6 @@
 			flex-grow: 2;
 			flex-shrink: 0;
 			margin-top: 15px;
-
-			label {
-				display: none;
-			}
 		}
 	}
 

--- a/client/state/receipts/assembler.js
+++ b/client/state/receipts/assembler.js
@@ -1,4 +1,5 @@
 /** @format */
+
 export function createReceiptObject( data ) {
 	return {
 		receiptId: data.receipt_id,


### PR DESCRIPTION
Credit Card and Pay Pal form were missing labels.

When fields have content, you have no idea what the field actually represents.