### PR TITLE
Store: Put an "Add" button on the promotions menu item

### DIFF
--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -189,9 +189,8 @@ class StoreSidebar extends Component {
 
 		const { site, siteSuffix, translate } = this.props;
 		const link = '/store/promotions' + siteSuffix;
-		const validLinks = [ '/store/promotions', '/store/promotion' ];
-
-		const selected = this.isItemLinkSelected( validLinks );
+		const addLink = '/store/promotion' + siteSuffix;
+		const selected = this.isItemLinkSelected( [ link, addLink ] );
 		const classes = classNames( {
 			promotions: true,
 			'is-placeholder': ! site,
@@ -204,7 +203,11 @@ class StoreSidebar extends Component {
 				icon="gift"
 				label={ translate( 'Promotions' ) }
 				link={ link }
-			/>
+			>
+				<SidebarButton disabled={ ! site } href={ addLink }>
+					{ translate( 'Add' ) }
+				</SidebarButton>
+			</SidebarItem>
 		);
 	};
 


### PR DESCRIPTION
Fixes #20655.

This PR adds an "Add" button to the promotions menu item like we do for products and other post types in Calypso.

<img width="279" alt="screen shot 2018-03-08 at 9 22 32 am" src="https://user-images.githubusercontent.com/689165/37165755-42c4f602-22b2-11e8-832f-2792ec165def.png">

To Test:
* Go to `http://calypso.localhost:3000/store/:site`
* Verify you see an "Add" button next to promotions, and that it takes you to the add promotion form.