### PR TITLE
Plugins: Only redirect once

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -64,14 +64,9 @@ const PluginsMain = createReactClass( {
 	},
 
 	componentWillReceiveProps( nextProps ) {
-		const {
-			hasJetpackSites: hasJpSites,
-			isRequestingSites: isRequesting,
-			selectedSiteIsJetpack,
-			selectedSiteSlug,
-		} = nextProps;
+		const { hasJetpackSites: hasJpSites, selectedSiteIsJetpack, selectedSiteSlug } = nextProps;
 
-		if ( ! isRequesting ) {
+		if ( this.props.isRequestingSites && ! nextProps.isRequestingSites ) {
 			// Selected site is not a Jetpack site
 			if ( selectedSiteSlug && ! selectedSiteIsJetpack ) {
 				page.redirect( `/plugins/${ selectedSiteSlug }` );


### PR DESCRIPTION
Follow-up to #23128; fixes https://github.com/Automattic/wp-calypso/pull/23128#issuecomment-371574159.

To test: 

* Clear `localStorage` and `IndexedDb`, reload.
* Direct your browser to `wordpress.com/plugins/manage/<yourJPSite>`.
* Verify that you're _not_ being redirected to `wordpress.com/plugins`, or possibly `wordpress.com/plugins/<yourJPsite>`. 
* Yerify that you _are_ still correctly redirected to `/plugins/<yourSite>` if the selected site is not a JP site, and to `/plugins` if the current user doesn't have any JP sites at all.