### PR TITLE
Guided Tours: only show black `Quit` button if it's not a primary button

### DIFF
--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -121,7 +121,7 @@
 	.button:nth-child(1) {
 		margin-right: 4%;
 	}
-	.guided-tours__quit-button {
+	.guided-tours__quit-button:not(.is-primary) {
 		color: darken( $white, 20% );
 		background: none;
 		border: 1px rgba( $white, 0.2 ) solid;
@@ -146,7 +146,7 @@ a.config-elements__text-link,
 	.button {
 		width: 48%;
 	}
-	.guided-tours__quit-button {
+	.guided-tours__quit-button:not(.is-primary) {
 		color: darken( $white, 20% );
 		background: none;
 		border: 1px rgba( $white, 0.2 ) solid;


### PR DESCRIPTION
#23124 added a border to the Guided Tours `Quit` button, but resulted in primary `Quit` buttons also having no background color (and the wrong border color). This PR fixes this by excluding the `is-primary` CSS class from those rules. 

Previously: 

<img width="426" alt="screen shot 2018-03-08 at 8 05 09 pm" src="https://user-images.githubusercontent.com/23619/37170844-4ff1c6de-230c-11e8-8aa4-0747f789faec.png">

Now:

<img width="433" alt="screen shot 2018-03-08 at 8 04 56 pm" src="https://user-images.githubusercontent.com/23619/37170853-57552a1a-230c-11e8-818c-864a5533cebd.png">

To test:
- go through the `main` tour (e.g. at http://calypso.localhost:3000/?tour=main) and make sure that all button colors look right. 
