### PR TITLE
Editor: Date Picker: Replace the noticon with a gridicon

### DIFF
--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -153,6 +153,7 @@ export class EditorPublishDate extends React.Component {
 						</div>
 					) }
 				</div>
+				<Gridicon className="editor-publish-date__header-chevron" icon="chevron-down" size={ 18 } />
 			</div>
 		);
 	}

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -33,7 +33,7 @@
 	overflow: hidden;
 	cursor: pointer;
 
-	.gridicon {
+	.gridicon.editor-publish-date__header-icon {
 		margin-right: #{ ($side-margin / 2) }px;
 		vertical-align: text-bottom;
 	}
@@ -51,21 +51,17 @@
 	}
 
 	// down-arrow
-	&::after {
-		@include noticon( '\f431', 22px );
-
-		display: block;
-		width: 20px;
-		line-height: #{ $header-height - 1 }px;
-		color: rgba($gray, 0.5);
-
+	.gridicon.editor-publish-date__header-chevron {
+		fill: $gray-darken-20;
 		position: absolute;
-		right: 14px;
-		top: 0px;
+		top: 10px;
+		right: 13px;
+		vertical-align: text-bottom;
+		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 	}
 
 	// up-arrow
-	.editor-publish-date.is-open &::after {
+	.editor-publish-date.is-open & .gridicon.editor-publish-date__header-chevron {
 		transform: rotate(180deg);
 	}
 

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -50,7 +50,7 @@
 		background-color: $gray-light;
 	}
 
-	// down-arrow
+	// Chevron
 	.gridicon.editor-publish-date__header-chevron {
 		fill: $gray-darken-20;
 		position: absolute;
@@ -58,11 +58,10 @@
 		right: 13px;
 		vertical-align: text-bottom;
 		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-	}
 
-	// up-arrow
-	.editor-publish-date.is-open & .gridicon.editor-publish-date__header-chevron {
-		transform: rotate(180deg);
+		.editor-publish-date.is-open & {
+			transform: rotate(180deg);
+		}
 	}
 
 	&.is-scheduled {


### PR DESCRIPTION
When choosing the publish date for a post (or other post-type thing) the dropdown uses a deprecated Noticon:

<img width="254" alt="screen shot 2018-03-08 at 2 53 09 pm" src="https://user-images.githubusercontent.com/191598/37173090-a7bb4e7a-22e0-11e8-85d6-59aae0a7c441.png">

This PR replaces that with a Gridicon, makes it a little darker, and also adds a nice little animation when toggling:

![date dropdown](https://user-images.githubusercontent.com/191598/37173199-eeae555c-22e0-11e8-9e7b-b0e241e224ed.gif)
