### PR TITLE
fix: Upgrade nudge in sidebar w/ fade-in effect

### DIFF
--- a/assets/stylesheets/shared/_animation.scss
+++ b/assets/stylesheets/shared/_animation.scss
@@ -264,3 +264,9 @@ html {
 	50% { opacity: 1; }
 	100% { opacity: .5; }
 }
+
+@keyframes loading-fade-out-in {
+	0% { opacity: 1; }
+	50% { opacity: 0; }
+	100% { opacity: 1; }
+}

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -111,6 +111,13 @@
 	}
 }
 
+// Fade-in used by SidebarBanner component
+.layout__primary {
+	&.fade-in {
+		animation: appear 1s ease;
+	}
+}
+
 // Setup the secondary element, which contains the sidebar and
 // the site-selector elements.
 .layout__secondary {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -111,10 +111,10 @@
 	}
 }
 
-// Fade-in used by SidebarBanner component
+// Fade-out-in used by SidebarBanner component
 .layout__primary {
-	&.fade-in {
-		animation: appear 1s ease;
+	&.fade-out-in {
+		animation: loading-fade-out-in .75s ease;
 	}
 }
 

--- a/client/my-sites/current-site/sidebar-banner/index.jsx
+++ b/client/my-sites/current-site/sidebar-banner/index.jsx
@@ -5,11 +5,13 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import { abtest } from 'lib/abtest';
+import closest from 'component-closest';
 
 /**
  * Internal dependencies
@@ -34,9 +36,31 @@ export class SidebarBanner extends Component {
 	};
 
 	onClick = () => {
+		this.maybeFadeIn();
 		const { ctaName, track } = this.props;
 		track( 'calypso_upgrade_nudge_cta_click', { cta_name: ctaName } );
 	};
+
+	maybeFadeIn() {
+		const { href } = this.props;
+		const location = window.location;
+
+		if ( href.indexOf( '/' ) !== 0 ) {
+			return; // Not a relative location.
+		} else if ( href !== location.pathname + location.search + location.hash ) {
+			return; // Location is changing, no fade-in necessary.
+		}
+
+		const thisNode = ReactDom.findDOMNode( this );
+		const layout = thisNode ? closest( thisNode, '.layout' ) : null;
+		const layoutPrimary = layout ? layout.querySelector( '.layout__primary' ) : null;
+
+		if ( layoutPrimary ) {
+			layoutPrimary.classList.remove( 'fade-in' );
+			void layoutPrimary.offsetWidth; // Force reflow.
+			layoutPrimary.classList.add( 'fade-in' );
+		}
+	}
 
 	render() {
 		const { className, ctaName, ctaText, href, icon, text } = this.props;

--- a/client/my-sites/current-site/sidebar-banner/index.jsx
+++ b/client/my-sites/current-site/sidebar-banner/index.jsx
@@ -36,12 +36,12 @@ export class SidebarBanner extends Component {
 	};
 
 	onClick = () => {
-		this.maybeFadeIn();
+		this.maybeFadeOutIn();
 		const { ctaName, track } = this.props;
 		track( 'calypso_upgrade_nudge_cta_click', { cta_name: ctaName } );
 	};
 
-	maybeFadeIn() {
+	maybeFadeOutIn() {
 		const { href } = this.props;
 		const location = window.location;
 
@@ -56,9 +56,9 @@ export class SidebarBanner extends Component {
 		const layoutPrimary = layout ? layout.querySelector( '.layout__primary' ) : null;
 
 		if ( layoutPrimary ) {
-			layoutPrimary.classList.remove( 'fade-in' );
+			layoutPrimary.classList.remove( 'fade-out-in' );
 			void layoutPrimary.offsetWidth; // Force reflow.
-			layoutPrimary.classList.add( 'fade-in' );
+			layoutPrimary.classList.add( 'fade-out-in' );
 		}
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/22700

@johnHackworth I had already started playing with the pseudo-refresh idea suggested in #22700. So maybe you could review this and decide if this approach works?

cc @richardmuscat @keoshi

## How to Test

- Starting at URL: http://calypso.localhost:3000/plans/{site-url}
- Make sure you're on a free plan
- Click the green upgrade nudge

![2018-03-08_11-15-05](https://user-images.githubusercontent.com/1563559/37174090-03c3303a-22c2-11e8-9031-dda50ce55cb7.png)


### Expectation (Please Confirm)

When any `SidebarBanner` component is clicked from the same URL it intends to take you to, then the primary right-side will flash as an indication that you're already there.