### PR TITLE
UI: Add instructions to submit PRs to `notifications-panel` for any changes to the spinner.

### DIFF
--- a/client/components/spinner/index.jsx
+++ b/client/components/spinner/index.jsx
@@ -2,8 +2,8 @@
 
 /**
  * If making changes in this file, please also open a PR in
- * the Automattic/notifications-panel repo, which uses this
- * same code for its spinner.
+ * the https://github.com/Automattic/notifications-panel repo,
+ * which uses this same code for its spinner.
  * src/templates/spinner.jsx
  */
 

--- a/client/components/spinner/index.jsx
+++ b/client/components/spinner/index.jsx
@@ -1,6 +1,13 @@
 /** @format */
 
 /**
+ * If making changes in this file, please also open a PR in
+ * the Automattic/notifications-panel repo, which uses this
+ * same code for its spinner.
+ * src/templates/spinner.jsx
+ */
+
+/**
  * External dependencies
  */
 

--- a/client/components/spinner/style.scss
+++ b/client/components/spinner/style.scss
@@ -1,6 +1,6 @@
 // If making changes in this file, please also open a PR in
-// the Automattic/notifications-panel repo, which uses this
-// same code for its spinner.
+// the https://github.com/Automattic/notifications-panel repo,
+// which uses this same code for its spinner.
 // src/boot/stylesheets/spinner.scss
 
 @keyframes rotate-spinner {

--- a/client/components/spinner/style.scss
+++ b/client/components/spinner/style.scss
@@ -1,3 +1,8 @@
+// If making changes in this file, please also open a PR in
+// the Automattic/notifications-panel repo, which uses this
+// same code for its spinner.
+// src/boot/stylesheets/spinner.scss
+
 @keyframes rotate-spinner {
 	100% {
 		transform: rotate( 360deg );


### PR DESCRIPTION
The simplified spinner code introduced in https://github.com/Automattic/wp-calypso/pull/22603 is duplicated in https://github.com/Automattic/notifications-panel, for visual consistency. Any changes made to spinner code here in Calypso should also be ported over to the notifications repo; this PR adds instructions to that effect.