### PR TITLE
Stats: remove noticon from empty state

### DIFF
--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -13,6 +13,7 @@ import { noop, throttle } from 'lodash';
 import BarContainer from './bar-container';
 import { hasTouch } from 'lib/touch-detect';
 import Tooltip from 'components/tooltip';
+import Notice from 'components/notice';
 
 class Chart extends React.Component {
 	state = {
@@ -160,13 +161,16 @@ class Chart extends React.Component {
 				) }
 				{ isEmptyChart && (
 					<div className="chart__empty">
-						{ /* @todo this message needs to either use a <Notice> or make a custom "chart__notice" class */ }
-						<span className="chart__empty-notice">
-							{ translate( 'No activity this period', {
+						<Notice
+							className="chart__empty-notice"
+							status="is-warning"
+							isCompact="true"
+							text={ translate( 'No activity this period', {
 								context: 'Message on empty bar chart in Stats',
 								comment: 'Should be limited to 32 characters to prevent wrapping',
 							} ) }
-						</span>
+							showDismiss={ false }
+						/>
 					</div>
 				) }
 			</div>

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -321,34 +321,7 @@
 }
 
 .chart__empty-notice {
-	position: relative;
-		top: 97px;
-	padding: 11px 24px;
-	margin-bottom: 24px;
-	border-radius: 1px;
-	background: #fff;
-	box-sizing: border-box;
-	font-size: 14px;
-	line-height: 1.4285;
-	animation: appear .3s ease-in-out;
-	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
-		0 1px 2px $gray-lighten-30;
-
-	@include breakpoint( ">660px" ) {
-		padding: 13px 48px;
-		font-size: inherit;
-
-		&::before {
-			@include noticon-style;
-			content: '\f456';
-			position: absolute;
-				top: 23px;
-				left: 20px;
-			margin: -12px 0px 0 -8px;
-			font-size: 24px;
-			line-height: 1;
-		}
-	}
+	top: 97px;
 }
 
 // Chart tooltip

--- a/client/my-sites/stats/most-popular/index.jsx
+++ b/client/my-sites/stats/most-popular/index.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
+import Notice from 'components/notice';
 import SectionHeader from 'components/section-header';
 import QuerySiteStats from 'components/data/query-site-stats';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -70,12 +71,16 @@ class StatsMostPopular extends Component {
 						{ ! percent &&
 							! requesting && (
 								<div className="most-popular__empty">
-									<span className="most-popular__notice">
-										{ translate( 'No popular day and time recorded', {
+									<Notice
+										className="most-popular__notice"
+										status="is-warning"
+										isCompact="true"
+										text={ translate( 'No popular day and time recorded', {
 											context: 'Message on stats insights page when no most popular data exists.',
 											comment: 'Should be limited to 32 characters to prevent wrapping',
 										} ) }
-									</span>
+										showDismiss={ false }
+									/>
 								</div>
 							) }
 					</div>

--- a/client/my-sites/stats/most-popular/style.scss
+++ b/client/my-sites/stats/most-popular/style.scss
@@ -67,7 +67,6 @@
 	margin-bottom: 24px;
 
 	@include breakpoint( ">660px" ) {
-		display: inline-flex;
 		top: 10px;
 		margin: 0 5px;
 	}

--- a/client/my-sites/stats/most-popular/style.scss
+++ b/client/my-sites/stats/most-popular/style.scss
@@ -82,16 +82,5 @@
 		display: inline-flex;
 		top: 10px;
 		margin: 0 5px;
-
-		&::before {
-			@include noticon-style;
-			content: '\f456';
-			position: absolute;
-				top: 23px;
-				left: 20px;
-			margin: -12px 0px 0 -8px;
-			font-size: 24px;
-			line-height: 1;
-		}
 	}
 }

--- a/client/my-sites/stats/most-popular/style.scss
+++ b/client/my-sites/stats/most-popular/style.scss
@@ -63,22 +63,10 @@
 }
 
 .most-popular__notice {
-	position: relative;
 	top: 25px;
-	padding: 11px 24px;
 	margin-bottom: 24px;
-	border-radius: 1px;
-	background: #fff;
-	box-sizing: border-box;
-	font-size: 14px;
-	line-height: 1.4285;
-	animation: appear .3s ease-in-out;
-	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
-		0 1px 2px $gray-lighten-30;
 
 	@include breakpoint( ">660px" ) {
-		padding: 13px 48px;
-		font-size: inherit;
 		display: inline-flex;
 		top: 10px;
 		margin: 0 5px;


### PR DESCRIPTION
This removes the noticons being used in Stats by using a standard Notice component.

It affects 2 notices, one found on the main stats bar graph, and the other on the "Most popular day and hour" card on the Insights page.

To test:

- Pick a site with no activity
- Go to /stats and see the new notice on the bar graph
- Go to /stats/insights and see the new notice on the "Most popular day and hour" card.

Cc @shaunandrews 

Before

![screen shot 2018-03-08 at 6 45 20 pm](https://user-images.githubusercontent.com/618551/37184424-ec6947f0-2300-11e8-8b05-290fa735d521.png)
![screen shot 2018-03-08 at 4 46 04 pm](https://user-images.githubusercontent.com/618551/37184425-ec7a9f3c-2300-11e8-9a23-99a920587fb5.png)

After

![screen shot 2018-03-08 at 4 59 09 pm](https://user-images.githubusercontent.com/618551/37184434-f6a28ede-2300-11e8-9466-bd2c326bafc9.png)
![screen shot 2018-03-08 at 4 59 00 pm](https://user-images.githubusercontent.com/618551/37184435-f6b2d88e-2300-11e8-956a-576496ae3fbd.png)

