### PR TITLE
Store Services: display shipping service group delivery estimate times.

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/group.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/group.js
@@ -38,6 +38,7 @@ const updateAll = ( event, updateValue, services ) => {
 const ShippingServiceGroup = ( props ) => {
 	const {
 		title,
+		deliveryEstimate,
 		services,
 		updateValue,
 		errors,
@@ -59,6 +60,11 @@ const ShippingServiceGroup = ( props ) => {
 				onChange={ onChange }
 				onClick={ stopPropagation } />
 			{ title }
+			{ deliveryEstimate && (
+				<small className="shipping-services__delivery-estimate">
+					({ deliveryEstimate })
+				</small>
+			) }
 		</div>;
 	};
 
@@ -104,6 +110,7 @@ const ShippingServiceGroup = ( props ) => {
 
 ShippingServiceGroup.propTypes = {
 	title: PropTypes.string.isRequired,
+	deliveryEstimate: PropTypes.string,
 	services: PropTypes.arrayOf( PropTypes.shape( {
 		id: PropTypes.string.isRequired,
 		name: PropTypes.string.isRequired,

--- a/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/index.js
@@ -45,6 +45,7 @@ const ShippingServiceGroups = ( {
 			<ShippingServiceGroup
 				key={ serviceGroup }
 				title={ serviceGroups[ serviceGroup ][ 0 ].group_name }
+				deliveryEstimate={ serviceGroups[ serviceGroup ][ 0 ].group_estimate || false }
 				services={ serviceGroups[ serviceGroup ] }
 				currencySymbol={ currencySymbol }
 				updateValue={ updateValue }

--- a/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/style.scss
@@ -112,3 +112,8 @@
 		}
 	}
 }
+
+.shipping-services__delivery-estimate {
+	color: darken( $gray, 10% );
+	margin-left: 3px;
+}


### PR DESCRIPTION
This PR is using https://github.com/Automattic/wp-calypso/tree/copy/wcs-data-friven-form as a base - it should be merged to `master` after https://github.com/Automattic/wp-calypso/pull/20908 lands.

To test:
* View a WCS-powered USPS shipping method instance
* Verify that there are no changes
* Point your store to a WCS server running `fix/wcs-963-service-group-delivery-estimates`
* Refresh the service schemas on the store
* View a WCS-powered USPS shipping method instance
* Verify that delivery estimates display next to service groups

Visual changes:
![](https://cldup.com/lIkCS8Wfk--3000x3000.png)