### PR TITLE
i18n: add locale variant to ui language substate

### DIFF
--- a/client/state/selectors/get-current-locale-variant.js
+++ b/client/state/selectors/get-current-locale-variant.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+
+/**
+ * Gets the current ui locale variant
+ * @param {Object} state - global redux state
+ * @return {String?} current state value
+ */
+const getCurrentLocaleVariant = createSelector(
+	state => get( state, 'ui.language.localeVariant', null ),
+	state => state.ui.language
+);
+
+export default getCurrentLocaleVariant;

--- a/client/state/selectors/test/get-current-locale-variant.js
+++ b/client/state/selectors/test/get-current-locale-variant.js
@@ -1,0 +1,36 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentLocaleVariant } from 'state/selectors';
+
+describe( 'getCurrentLocaleVariant()', () => {
+	test( 'should return null as default', () => {
+		const state = {
+			ui: {
+				language: {},
+			},
+		};
+
+		expect( getCurrentLocaleVariant( state ) ).to.be.null;
+	} );
+
+	test( 'should return the locale variant slug stored', () => {
+		const localeVariant = 'awesome_variant';
+		const state = {
+			ui: {
+				language: {
+					localeVariant,
+				},
+			},
+		};
+
+		expect( getCurrentLocaleVariant( state ) ).to.eql( localeVariant );
+	} );
+} );

--- a/client/state/ui/language/README.md
+++ b/client/state/ui/language/README.md
@@ -5,7 +5,7 @@ Language UI State
 
 ###`setLocale()`
 
-Change the locale of the application
+Change the locale of the application and, optionally, the locale variant of the application.
 
 ## Reducers
 
@@ -14,3 +14,11 @@ The included reducers add the following keys to the global state tree, under `ui
 ###`localeSlug`
 
 The value of the current locale slug ('en', 'fr'...)
+
+###`localeVariant`
+
+The locale variant refers to a subset of the locale, for example formal German (Sie) ('de_formal'). 
+
+###`isRtl`
+
+The isRtl state of the ui language.

--- a/client/state/ui/language/actions.js
+++ b/client/state/ui/language/actions.js
@@ -15,14 +15,17 @@ import { LOCALE_SET } from 'state/action-types';
 /**
  * Set the ui locale
  *
- * @param   {Object} localeSlug the locale slug to change the locale to
- * @returns {Function} Action thunk
+ * @param   {String} localeSlug the locale slug to change the locale to
+ * @param   {String?} localeVariant the slug of the vairant regarding to localeSlug
+ * @returns {Object} Action
  */
-export const setLocale = localeSlug => {
+export const setLocale = ( localeSlug, localeVariant = null ) => {
+	// TODO: pass localeVariant to switchLocale
 	switchLocale( localeSlug );
 	return {
 		type: LOCALE_SET,
 		localeSlug,
+		localeVariant,
 	};
 };
 
@@ -34,8 +37,12 @@ export const setLocale = localeSlug => {
  */
 export const setLocaleRawData = localeData => {
 	i18n.setLocale( localeData );
+
+	const { localeSlug, localeVariant = null } = localeData[ '' ];
+
 	return {
 		type: LOCALE_SET,
-		localeSlug: localeData[ '' ].localeSlug,
+		localeSlug,
+		localeVariant,
 	};
 };

--- a/client/state/ui/language/actions.js
+++ b/client/state/ui/language/actions.js
@@ -16,7 +16,7 @@ import { LOCALE_SET } from 'state/action-types';
  * Set the ui locale
  *
  * @param   {String} localeSlug the locale slug to change the locale to
- * @param   {String?} localeVariant the slug of the vairant regarding to localeSlug
+ * @param   {String?} localeVariant the slug of the variant of localeSlug
  * @returns {Object} Action
  */
 export const setLocale = ( localeSlug, localeVariant = null ) => {

--- a/client/state/ui/language/reducer.js
+++ b/client/state/ui/language/reducer.js
@@ -6,7 +6,7 @@
 
 import { combineReducers, createReducer } from 'state/utils';
 import { LOCALE_SET } from 'state/action-types';
-import { localeSlugSchema, isRtlSchema } from './schema';
+import { localeSlugSchema, localeVariantSchema, isRtlSchema } from './schema';
 import { getLanguage } from 'lib/i18n-utils/utils';
 
 /**
@@ -23,6 +23,22 @@ export const localeSlug = createReducer(
 		[ LOCALE_SET ]: ( state, action ) => action.localeSlug,
 	},
 	localeSlugSchema
+);
+
+/**
+ * Tracks the state of the ui locale variant
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated or default state
+ *
+ */
+export const localeVariant = createReducer(
+	null,
+	{
+		[ LOCALE_SET ]: ( state, action ) => action.localeVariant || state,
+	},
+	localeVariantSchema
 );
 
 /**
@@ -55,4 +71,4 @@ export const isRtl = createReducer(
 	isRtlSchema
 );
 
-export default combineReducers( { localeSlug, isRtl } );
+export default combineReducers( { localeSlug, localeVariant, isRtl } );

--- a/client/state/ui/language/schema.js
+++ b/client/state/ui/language/schema.js
@@ -1,4 +1,6 @@
 /** @format */
 export const localeSlugSchema = { type: [ 'string', 'null' ] };
 
+export const localeVariantSchema = { type: [ 'string', 'null' ] };
+
 export const isRtlSchema = { type: [ 'boolean', 'null' ] };

--- a/client/state/ui/language/test/actions.js
+++ b/client/state/ui/language/test/actions.js
@@ -17,6 +17,15 @@ describe( 'actions', () => {
 			expect( setLocale( 'he' ) ).to.eql( {
 				type: LOCALE_SET,
 				localeSlug: 'he',
+				localeVariant: null,
+			} );
+		} );
+
+		test( 'returns an action with localeVariant set', () => {
+			expect( setLocale( 'he', 'he_formal' ) ).to.eql( {
+				type: LOCALE_SET,
+				localeSlug: 'he',
+				localeVariant: 'he_formal',
 			} );
 		} );
 	} );
@@ -32,6 +41,22 @@ describe( 'actions', () => {
 			).to.eql( {
 				type: LOCALE_SET,
 				localeSlug: 'he',
+				localeVariant: null,
+			} );
+		} );
+
+		test( 'returns an action with localeVariant set', () => {
+			expect(
+				setLocaleRawData( {
+					'': {
+						localeSlug: 'he',
+						localeVariant: 'he_formal',
+					},
+				} )
+			).to.eql( {
+				type: LOCALE_SET,
+				localeSlug: 'he',
+				localeVariant: 'he_formal',
 			} );
 		} );
 	} );

--- a/client/state/ui/language/test/reducer.js
+++ b/client/state/ui/language/test/reducer.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { localeSlug, isRtl } from '../reducer';
+import { localeSlug, localeVariant, isRtl } from '../reducer';
 import { LOCALE_SET } from 'state/action-types';
 
 describe( 'reducer', () => {
@@ -34,6 +34,31 @@ describe( 'reducer', () => {
 			const action = { type: LOCALE_SET, localeSlug: 'he' };
 
 			expect( localeSlug( state, action ) ).to.eql( 'he' );
+		} );
+	} );
+
+	describe( 'localeVariant', () => {
+		test( 'returns default state with undefined state and empty action', () => {
+			expect( localeVariant( undefined, {} ) ).to.be.null;
+		} );
+
+		test( 'returns previous state with empty action', () => {
+			expect( localeVariant( 'de_formal', {} ) ).to.eql( 'de_formal' );
+		} );
+
+		test( 'returns default state with undefined state and invalid action type', () => {
+			expect( localeVariant( undefined, { type: 'foobar' } ) ).to.be.null;
+		} );
+
+		test( 'returns default state of null with undefined state and missing slug', () => {
+			expect( localeVariant( undefined, { type: LOCALE_SET } ) ).to.be.null;
+		} );
+
+		test( 'returns new state with valid slug', () => {
+			const state = 'en';
+			const action = { type: LOCALE_SET, localeVariant: 'de_formal' };
+
+			expect( localeVariant( state, action ) ).to.eql( 'de_formal' );
 		} );
 	} );
 


### PR DESCRIPTION
## Summary
This PR is part of the on-going work of splitting #23025 into smaller, shippable pieces. 

In this PR, `localeVariant` has been introduced into `ui/language` substate tree, including:
* relevant action creators
* reducers
* selectors

## Test Plan
* `npm run test-client ui/language`
* `npm run test-client get-current-locale-variant`