### PR TITLE
i18n: Update `switchLocale` function to include `localeVariant`.

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -33,8 +33,9 @@ function setLocaleInDOM( localeSlug, isRTL ) {
 }
 
 let lastRequestedLocale = null;
-export default function switchLocale( localeSlug ) {
-	const language = getLanguage( localeSlug );
+export default function switchLocale( localeSlug, localeVariant ) {
+	// check if the language exists in config.languages
+	const language = getLanguage( localeSlug, localeVariant );
 
 	if ( ! language ) {
 		return;

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -47,13 +47,18 @@ export default function switchLocale( localeSlug, localeVariant ) {
 		return;
 	}
 
-	lastRequestedLocale = localeSlug;
+	const { langSlug: targetLocaleSlug, parentLangSlug } = language;
 
-	if ( isDefaultLocale( localeSlug ) ) {
-		i18n.configure( { defaultLocaleSlug: localeSlug } );
-		setLocaleInDOM( localeSlug, !! language.rtl );
+	// variant lang objects contain references to their parent lang, which is what we want to tell the browser we're running
+	const domLocaleSlug = parentLangSlug || targetLocaleSlug;
+
+	lastRequestedLocale = targetLocaleSlug;
+
+	if ( isDefaultLocale( targetLocaleSlug ) ) {
+		i18n.configure( { defaultLocaleSlug: targetLocaleSlug } );
+		setLocaleInDOM( domLocaleSlug, !! language.rtl );
 	} else {
-		request.get( languageFileUrl( localeSlug ) ).end( function( error, response ) {
+		request.get( languageFileUrl( targetLocaleSlug ) ).end( function( error, response ) {
 			if ( error ) {
 				debug(
 					'Encountered an error loading locale file for ' +
@@ -65,13 +70,13 @@ export default function switchLocale( localeSlug, localeVariant ) {
 
 			// Handle race condition when we're requested to switch to a different
 			// locale while we're in the middle of request, we should abondon result
-			if ( localeSlug !== lastRequestedLocale ) {
+			if ( targetLocaleSlug !== lastRequestedLocale ) {
 				return;
 			}
 
 			i18n.setLocale( response.body );
 
-			setLocaleInDOM( localeSlug, !! language.rtl );
+			setLocaleInDOM( domLocaleSlug, !! language.rtl );
 		} );
 	}
 }

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -16,6 +16,76 @@ import {
 	removeLocaleFromPath,
 } from 'lib/i18n-utils';
 
+jest.mock( 'config', () => key => {
+	if ( 'i18n_default_locale_slug' === key ) {
+		return 'en';
+	}
+
+	if ( 'languages' === key ) {
+		return [
+			{ value: 420, langSlug: 'ast', name: 'Asturianu', wpLocale: 'ast', territories: [ '039' ] },
+			{
+				value: 1,
+				langSlug: 'en',
+				name: 'English',
+				wpLocale: 'en_US',
+				popular: 1,
+				territories: [ '019' ],
+			},
+			{
+				value: 19,
+				langSlug: 'es',
+				name: 'Español',
+				wpLocale: 'es_ES',
+				popular: 2,
+				territories: [ '019', '039' ],
+			},
+			{
+				value: 24,
+				langSlug: 'fr',
+				name: 'Français',
+				wpLocale: 'fr_FR',
+				popular: 5,
+				territories: [ '155' ],
+			},
+			{
+				value: 36,
+				langSlug: 'ja',
+				name: '日本語',
+				wpLocale: 'ja',
+				popular: 7,
+				territories: [ '030' ],
+			},
+			{
+				value: 438,
+				langSlug: 'pt-br',
+				name: 'Português do Brasil',
+				wpLocale: 'pt_BR',
+				popular: 3,
+				territories: [ '019' ],
+			},
+			{
+				value: 15,
+				langSlug: 'de',
+				name: 'Deutsch',
+				wpLocale: 'de_DE',
+				popular: 4,
+				territories: [ '155' ],
+			},
+			{
+				value: 900,
+				langSlug: 'de_formal',
+				name: 'Deutsch',
+				wpLocale: 'de_DE_formal',
+				parentLangSlug: 'de',
+				popular: 4,
+				territories: [ '155' ],
+			},
+			{ value: 58, langSlug: 'pl', name: 'Polski', wpLocale: 'pl_PL', territories: [ '151' ] },
+		];
+	}
+} );
+
 describe( 'utils', () => {
 	describe( '#isDefaultLocale', () => {
 		test( 'should return false when a non-default locale provided', () => {
@@ -136,6 +206,14 @@ describe( 'utils', () => {
 
 		test( 'should return a language with a three letter country code', () => {
 			expect( getLanguage( 'ast' ).langSlug ).to.equal( 'ast' );
+		} );
+
+		test( 'should return the variant', () => {
+			expect( getLanguage( 'de', 'de_formal' ).langSlug ).to.equal( 'de_formal' );
+		} );
+
+		test( 'should return the parent slug since the given variant does not exist', () => {
+			expect( getLanguage( 'fr', 'fr_formal' ).langSlug ).to.equal( 'fr' );
 		} );
 	} );
 } );

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -35,6 +35,12 @@ export function isDefaultLocale( locale ) {
 	return locale === config( 'i18n_default_locale_slug' );
 }
 
+/**
+ * Matches and returns language from config.languages based on the given localeSlug and localeVariant
+ * @param  {String} localeSlug locale slug of the language to match
+ * @param  {String?} localeVariant local variant of the language to match. It takes precedence if exists.
+ * @return {Object|undefined} An object containing the locale data or undefined.
+ */
 export function getLanguage( localeSlug, localeVariant = null ) {
 	// if a localeVariant is given, we should use it. Otherwise, use localeSlug
 	const langSlug = localeVariant || localeSlug;

--- a/client/state/ui/language/actions.js
+++ b/client/state/ui/language/actions.js
@@ -20,8 +20,7 @@ import { LOCALE_SET } from 'state/action-types';
  * @returns {Object} Action
  */
 export const setLocale = ( localeSlug, localeVariant = null ) => {
-	// TODO: pass localeVariant to switchLocale
-	switchLocale( localeSlug );
+	switchLocale( localeSlug, localeVariant );
 	return {
 		type: LOCALE_SET,
 		localeSlug,


### PR DESCRIPTION
## Summary
This PR is part of the on-going work of splitting #23025 into smaller, shippable pieces, and it's based on  #23152 .

In this PR, we update `switchLocale()` function so that it handles locale variants. Note that `localeVariant` is treated as optional, so existing locale changing code shouldn't be broken.

## Test Plan
* `npm run test-client i18n-utils`.
* Open `http://calypso.localhost:3000/me/account` and changing locales should work as expected.