### PR TITLE
i18n: Use locale variant as query argument if any

### DIFF
--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -9,7 +9,7 @@ import qs from 'querystring';
 /**
  * Internal dependencies
  */
-import { getCurrentUserLocale } from 'state/current-user/selectors';
+import { getCurrentUserLocale, getCurrentUserLocaleVariant } from 'state/current-user/selectors';
 
 /**
  * Module variables
@@ -88,7 +88,9 @@ export function injectLocalization( wpcom ) {
  */
 export function bindState( store ) {
 	function setLocaleFromState() {
-		setLocale( getCurrentUserLocale( store.getState() ) );
+		setLocale(
+			getCurrentUserLocaleVariant( store.getState() ) || getCurrentUserLocale( store.getState() )
+		);
 	}
 
 	store.subscribe( setLocaleFromState );

--- a/client/lib/wp/localization/test/index.js
+++ b/client/lib/wp/localization/test/index.js
@@ -8,10 +8,14 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { addLocaleQueryParam, bindState, getLocale, injectLocalization, setLocale } from '../';
-import { getCurrentUserLocale as getCurrentUserLocaleMock } from 'state/current-user/selectors';
+import {
+	getCurrentUserLocale as getCurrentUserLocaleMock,
+	getCurrentUserLocaleVariant as getCurrentUserLocaleVariantMock,
+} from 'state/current-user/selectors';
 
 jest.mock( 'state/current-user/selectors', () => ( {
 	getCurrentUserLocale: jest.fn(),
+	getCurrentUserLocaleVariant: jest.fn(),
 } ) );
 
 describe( 'index', () => {
@@ -40,6 +44,12 @@ describe( 'index', () => {
 			expect( params ).to.eql( {
 				query: 'search=foo&locale=fr',
 			} );
+		} );
+
+		test( 'should prefer and set initial variant locale from state', () => {
+			getCurrentUserLocaleVariantMock.mockReturnValueOnce( 'fr_formal' );
+			bindState( { subscribe() {}, getState() {} } );
+			expect( getLocale() ).to.equal( 'fr_formal' );
 		} );
 	} );
 


### PR DESCRIPTION
## Summary
This PR is part of the on-going work of splitting #23025 into smaller, shippable pieces.

In this PR, we update the `locale` query parameter to be the set locale variant if there is any.

* This is in-progress since the function it depends will be in the other PR.

## Test Plan
`npm run test-client wp/localization`

