### PR TITLE
Reader: Fix Settings button on Site Stream mobile

### DIFF
--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -175,32 +175,17 @@
 	}
 }
 
-.reader-feed-header__email-settings .gridicons-cog {
-	top: 2px;
-	left: 1px;
-}
+.reader-feed-header__email-settings .reader-site-notification-settings .gridicons-cog {
 
-.reader-feed-header__email-settings {
-	@include breakpoint( ">660px" ) {
-		margin-top: -1px;
-
-		.gridicons-cog {
-			left: 5px;
-			top: 3px;
-		}
+	@include breakpoint( "<660px" ) {
+		left: -4px;
 	}
 }
 
-.reader-feed-header__email-settings .reader-email-settings__button-label {
-	display: inline;
-	position: relative;
-		top: -2px;
-	margin-left: 2px;
+.reader-feed-header__email-settings .reader-site-notification-settings__button-label {
 
-	@include breakpoint( ">660px" ) {
-		top: -1px;
-		left: 2px;
-		margin-left: 4px;
+	@include breakpoint( "<660px" ) {
+		display: inline;
 	}
 
 	@include breakpoint( "<480px" ) {

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -14,6 +14,18 @@
 	}
 }
 
+.reader-site-notification-settings .gridicons-cog {
+	fill: $gray-lighten-10;
+	height: 18px;
+	position: relative;
+		top: 4px;
+		left: -4px;
+
+	@include breakpoint( "<660px" ) {
+		left: -1px;
+	}
+}
+
 .reader-popover__wrapper {
 
 	.segmented-control {
@@ -50,14 +62,6 @@
 			left: 3px;
 			top: 2px;
 	}
-}
-
-.reader-site-notification-settings .gridicons-cog {
-	fill: $gray-lighten-10;
-	height: 18px;
-	position: relative;
-		left: -4px;
-		top: 4px;
 }
 
 .reader-site-notification-settings__popout-form-toggle {

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -223,13 +223,6 @@
 	}
 }
 
-.reader-site-notification-settings .gridicons-cog {
-
-	@include breakpoint( "<660px" ) {
-		left: -1px;
-	}
-}
-
 .following-manage__search-results.is-empty {
 	margin-top: 10px;
 	word-wrap: break-word;

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -299,13 +299,6 @@
 	}
 }
 
-.search-stream .search-stream__single-column-results .reader-site-notification-settings__button-label {
-
-	@include breakpoint ( "<660px" ) {
-		display: none;
-	}
-}
-
 .search-stream__results.is-two-columns .reader-subscription-list-item__byline {
 	min-width: 180px;
 	max-width: 180px;
@@ -388,13 +381,6 @@
 
 	.reader-email-settings__button-label {
 		display: none;
-	}
-}
-
-.search-stream .reader-subscription-list-item .gridicons-cog {
-
-	@include breakpoint( "<660px" ) {
-		left: -1px;
 	}
 }
 


### PR DESCRIPTION
This PR fixes:

- Settings button missing label in `<660px`:

**Before:**
![screenshot 2018-03-08 20 24 03](https://user-images.githubusercontent.com/4924246/37190451-aceb376a-230e-11e8-8011-e902a7ea03fb.png)

**After:**
![screenshot 2018-03-08 20 24 10](https://user-images.githubusercontent.com/4924246/37190454-afefe302-230e-11e8-9674-cfefaedfc76b.png)

- Settings icon misalignment in `<480px`:

**Before:**
![screenshot 2018-03-08 20 25 00](https://user-images.githubusercontent.com/4924246/37190470-cc5b4cca-230e-11e8-9e41-800d7fb7e88f.png)

**After:**
![screenshot 2018-03-08 20 25 04](https://user-images.githubusercontent.com/4924246/37190473-cffd4432-230e-11e8-9348-022386e2e497.png)

- Cleans up/reorganizes some of the Follow and Settings buttons styles.