### PR TITLE
i18n: account for `settings.locale_variant` when updating user settings

### DIFF
--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -54,6 +54,23 @@ function deleteUnsavedSetting( settings, settingName, recursive ) {
 	}
 }
 
+/*
+ * Checks if an incoming change to settings.language is a change to the existing settings
+ * Currently the assumption is that if a settings.locale_variant slug exists, then that is the current language
+ */
+function hasLanguageChanged( languageSettingValue, settings = {} ) {
+	if ( ! languageSettingValue ) {
+		false;
+	}
+	// if there is a saved variant we know that the user is changing back to the root language === setting hasn't changed
+	// but if settings.locale_variant is not empty then we assume the user is trying to switch back to the root
+	return (
+		( languageSettingValue === settings.language && isEmpty( settings.locale_variant ) ) ||
+		//if the incoming language code is the variant itself === setting hasn't changed
+		languageSettingValue === settings.locale_variant
+	);
+}
+
 /**
  * Initialize UserSettings with defaults
  *
@@ -261,25 +278,35 @@ UserSettings.prototype.updateSetting = function( settingName, value ) {
 	if ( has( this.settings, settingName ) ) {
 		set( this.unsavedSettings, settingName, value );
 
-		/*
-		 * If the two match, we don't consider the setting "changed".
-		 * user_login is a special case since the logic for validating and saving a username
-		 * is more complicated.
-		 */
+		let canDeleteUnsavedSetting = false;
+
+		// If the two match, we don't consider the setting "changed".
+		// user_login is a special case since the logic for validating and saving a username
+		// is more complicated.
 		if (
 			get( this.settings, settingName ) === get( this.unsavedSettings, settingName ) &&
-			'user_login' !== settingName
+			'user_login' !== settingName &&
+			'language' !== settingName
 		) {
+			canDeleteUnsavedSetting = true;
+		}
+
+		// language is a special case since we have to check for changes to locale_variant
+		// this might be easier if we tracked the lang_id instead as we do in client/my-sites/site-settings/form-general.jsx
+		if ( 'language' === settingName && hasLanguageChanged( value, this.settings ) ) {
+			canDeleteUnsavedSetting = true;
+		}
+
+		if ( canDeleteUnsavedSetting ) {
 			debug( 'Removing ' + settingName + ' from changed settings.' );
 			deleteUnsavedSetting( this.unsavedSettings, settingName );
 		}
 
 		this.emit( 'change' );
 		return true;
-	} else {
-		debug( settingName + ' does not exist in user-settings data module.' );
-		return false;
 	}
+	debug( settingName + ' does not exist in user-settings data module.' );
+	return false;
 };
 
 UserSettings.prototype.isSettingUnsaved = function( settingName ) {

--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -54,13 +54,17 @@ function deleteUnsavedSetting( settings, settingName, recursive ) {
 	}
 }
 
-/*
+/**
  * Checks if an incoming change to settings.language is a change to the existing settings
  * Currently the assumption is that if a settings.locale_variant slug exists, then that is the current language
+ *
+ * @param  {String}  languageSettingValue the newly-set language slug string.
+ * @param  {Object}  settings user settings object.
+ * @return {Boolean} if the language setting has been changed.
  */
 function hasLanguageChanged( languageSettingValue, settings = {} ) {
 	if ( ! languageSettingValue ) {
-		false;
+		return false;
 	}
 	// if there is a saved variant we know that the user is changing back to the root language === setting hasn't changed
 	// but if settings.locale_variant is not empty then we assume the user is trying to switch back to the root

--- a/client/lib/user-settings/test/index.js
+++ b/client/lib/user-settings/test/index.js
@@ -38,6 +38,29 @@ describe( 'User Settings', () => {
 		}
 	} );
 
+	describe( '#updateSetting', () => {
+		test( 'should treat root language langSlug as an unsaved setting when its locale variant is activated', () => {
+			userSettings.settings.language = 'de';
+			userSettings.settings.locale_variant = 'de_formal';
+			userSettings.updateSetting( 'language', 'de' );
+			expect( userSettings.unsavedSettings.language ).to.equal( 'de' );
+		} );
+
+		test( 'should treat same locale variant language as an already-saved setting', () => {
+			userSettings.settings.language = 'de';
+			userSettings.settings.locale_variant = 'de_formal';
+			userSettings.updateSetting( 'language', 'fr' );
+			expect( userSettings.unsavedSettings.language ).to.equal( 'fr' );
+		} );
+
+		test( 'should treat new root language as an unsaved setting', () => {
+			userSettings.settings.language = 'de';
+			userSettings.settings.locale_variant = 'de_formal';
+			userSettings.updateSetting( 'language', 'de_formal' );
+			expect( userSettings.unsavedSettings.language ).to.be.undefined;
+		} );
+	} );
+
 	describe( '#getOriginalSetting', () => {
 		describe( 'when a setting has a truthy value', () => {
 			beforeEach( () => {

--- a/client/lib/user-settings/test/index.js
+++ b/client/lib/user-settings/test/index.js
@@ -4,11 +4,6 @@
  */
 
 /**
- * External dependencies
- */
-import { assert, expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import userSettings from '..';
@@ -23,17 +18,16 @@ describe( 'User Settings', () => {
 	} );
 
 	test( 'should consider overridden settings as saved', done => {
-		assert.isTrue( userSettings.updateSetting( 'test', true ) );
-		assert.isTrue( userSettings.updateSetting( 'lang_id', true ) );
-
-		assert.isTrue( userSettings.unsavedSettings.test );
-		assert.isTrue( userSettings.unsavedSettings.lang_id );
+		expect( userSettings.updateSetting( 'test', true ) ).toBe( true );
+		expect( userSettings.updateSetting( 'lang_id', true ) ).toBe( true );
+		expect( userSettings.unsavedSettings.test ).toBe( true );
+		expect( userSettings.unsavedSettings.lang_id ).toBe( true );
 
 		userSettings.saveSettings( assertCorrectSettingIsRemoved, { test: true } );
 
 		function assertCorrectSettingIsRemoved() {
-			assert.isUndefined( userSettings.unsavedSettings.test );
-			assert.isTrue( userSettings.unsavedSettings.lang_id );
+			expect( userSettings.unsavedSettings.test ).toBeUndefined();
+			expect( userSettings.unsavedSettings.lang_id ).toBe( true );
 			done();
 		}
 	} );
@@ -43,21 +37,21 @@ describe( 'User Settings', () => {
 			userSettings.settings.language = 'de';
 			userSettings.settings.locale_variant = 'de_formal';
 			userSettings.updateSetting( 'language', 'de' );
-			expect( userSettings.unsavedSettings.language ).to.equal( 'de' );
+			expect( userSettings.unsavedSettings.language ).toBe( 'de' );
 		} );
 
 		test( 'should treat same locale variant language as an already-saved setting', () => {
 			userSettings.settings.language = 'de';
 			userSettings.settings.locale_variant = 'de_formal';
 			userSettings.updateSetting( 'language', 'fr' );
-			expect( userSettings.unsavedSettings.language ).to.equal( 'fr' );
+			expect( userSettings.unsavedSettings.language ).toBe( 'fr' );
 		} );
 
 		test( 'should treat new root language as an unsaved setting', () => {
 			userSettings.settings.language = 'de';
 			userSettings.settings.locale_variant = 'de_formal';
 			userSettings.updateSetting( 'language', 'de_formal' );
-			expect( userSettings.unsavedSettings.language ).to.be.undefined;
+			expect( userSettings.unsavedSettings.language ).toBeUndefined();
 		} );
 	} );
 
@@ -70,7 +64,7 @@ describe( 'User Settings', () => {
 			test( 'returns the value of that setting', () => {
 				const actual = userSettings.getOriginalSetting( 'someSetting' );
 				const expected = 'someValue';
-				expect( actual ).to.equal( expected );
+				expect( actual ).toBe( expected );
 			} );
 		} );
 
@@ -82,7 +76,7 @@ describe( 'User Settings', () => {
 			test( 'returns the value of that setting', () => {
 				const actual = userSettings.getOriginalSetting( 'someSetting' );
 				const expected = 0;
-				expect( actual ).to.equal( expected );
+				expect( actual ).toBe( expected );
 			} );
 		} );
 
@@ -94,28 +88,28 @@ describe( 'User Settings', () => {
 			test( 'returns null', () => {
 				const actual = userSettings.getOriginalSetting( 'someSetting' );
 				const expected = null;
-				expect( actual ).to.equal( expected );
+				expect( actual ).toBe( expected );
 			} );
 		} );
 	} );
 
 	test( 'should support flat and deep settings', done => {
-		assert.isFalse( userSettings.settings.lang_id );
-		assert.isFalse( userSettings.settings.testParent.testChild );
+		expect( userSettings.settings.lang_id ).toBe( false );
+		expect( userSettings.settings.testParent.testChild ).toBe( false );
 
-		assert.isTrue( userSettings.updateSetting( 'lang_id', true ) );
-		assert.isTrue( userSettings.updateSetting( 'testParent.testChild', true ) );
+		expect( userSettings.updateSetting( 'lang_id', true ) ).toBe( true );
+		expect( userSettings.updateSetting( 'testParent.testChild', true ) ).toBe( true );
 
-		assert.isTrue( userSettings.unsavedSettings.lang_id );
-		assert.isTrue( userSettings.unsavedSettings.testParent.testChild );
+		expect( userSettings.unsavedSettings.lang_id ).toBe( true );
+		expect( userSettings.unsavedSettings.testParent.testChild ).toBe( true );
 
 		userSettings.saveSettings( assertCorrectSettingIsSaved );
 
 		function assertCorrectSettingIsSaved() {
-			assert.isUndefined( userSettings.unsavedSettings.lang_id );
-			assert.isUndefined( userSettings.unsavedSettings.testParent );
-			assert.isTrue( userSettings.settings.lang_id );
-			assert.isTrue( userSettings.settings.testParent.testChild );
+			expect( userSettings.unsavedSettings.lang_id ).toBeUndefined();
+			expect( userSettings.unsavedSettings.testParent ).toBeUndefined();
+			expect( userSettings.settings.lang_id ).toBe( true );
+			expect( userSettings.settings.testParent.testChild ).toBe( true );
 			done();
 		}
 	} );

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -103,9 +103,10 @@ const Account = createReactClass( {
 	updateLanguage( event ) {
 		const { value } = event.target;
 		const originalLanguage = this.props.userSettings.getOriginalSetting( 'language' );
-
+		const originalLocaleVariant = this.props.userSettings.getOriginalSetting( 'locale_variant' );
 		this.updateUserSetting( 'language', value );
-		const redirect = value !== originalLanguage ? '/me/account' : false;
+		const redirect =
+			value !== originalLanguage || value !== originalLocaleVariant ? '/me/account' : false;
 		this.setState( { redirect } );
 	},
 
@@ -534,7 +535,9 @@ const Account = createReactClass( {
 						languages={ config( 'languages' ) }
 						onClick={ this.recordClickEvent( 'Interface Language Field' ) }
 						valueKey="langSlug"
-						value={ this.getUserSetting( 'language' ) || '' }
+						value={
+							this.getUserSetting( 'locale_variant' ) || this.getUserSetting( 'language' ) || ''
+						}
 						onChange={ this.updateLanguage }
 					/>
 					<FormSettingExplanation>

--- a/client/me/form-base/index.js
+++ b/client/me/form-base/index.js
@@ -79,7 +79,6 @@ export default {
 		this.setState( { submittingForm: true } );
 		this.props.userSettings.saveSettings(
 			function( error, response ) {
-				this.setState( { submittingForm: false } );
 				if ( error ) {
 					debug( 'Error saving settings: ' + JSON.stringify( error ) );
 
@@ -89,6 +88,7 @@ export default {
 					} else {
 						notices.error( this.props.translate( 'There was a problem saving your changes.' ) );
 					}
+					this.setState( { submittingForm: false } );
 				} else {
 					this.props.markSaved && this.props.markSaved();
 
@@ -100,8 +100,8 @@ export default {
 						} );
 						return;
 					}
-
-					this.setState( { showNotice: true } );
+					// if we set submittingForm too soon the UI updates before the response is handled
+					this.setState( { showNotice: true, submittingForm: false } );
 					this.showNotice();
 					debug( 'Settings saved successfully ' + JSON.stringify( response ) );
 				}


### PR DESCRIPTION
`udpate` Apologies for the misspelling

This PR is part of the ongoing work of splitting #23025 into smaller, shippable pieces.

It ensures that:
- if a locale variant is detected in the user's saved settings, the user can still switch back to the root language (and vice versa)
- if a language with a locale variant is selected, then the locale variant slug is sent to the server as the language to be saved

## Dependencies
Relies on #23153 in order that the correct translation json is fetched.

## Testing
We already have a locale with a variant! (Though the JSON for it won't load until the dependencies for this PR are met)

1. Head to http://calypso.localhost:3000/me/account
2. Switch to _**Español de México**_ and save

**Expection**: the page should reload and the language picker should display _**Español de México**_ (this is because `locale_variant` is saved as `es-mx` in the user settings). As mentioned, the translations won't yet load.

Also the language picker button should display _**Español de México**_ before the page reloads. This is the effect of relocating `this.state.submittingForm` in [this change](https://github.com/Automattic/wp-calypso/pull/23158/files#diff-9b84ad75033d70798510573556fcea79).

### Unit tests
`npm run test-client client/lib/user-settings`