### PR TITLE
Fire calypso_checkout_page_view if cart is loaded after component mount

### DIFF
--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -101,12 +101,12 @@ const Checkout = createReactClass( {
 	},
 
 	componentWillReceiveProps: function( nextProps ) {
-		if (
-			! this.props.cart.hasLoadedFromServer &&
-			nextProps.cart.hasLoadedFromServer &&
-			this.props.product
-		) {
-			this.addProductToCart();
+		if ( ! this.props.cart.hasLoadedFromServer && nextProps.cart.hasLoadedFromServer ) {
+			if ( this.props.product ) {
+				this.addProductToCart();
+			}
+
+			this.trackPageView();
 		}
 	},
 


### PR DESCRIPTION
The calypso_checkout_page_view event is not currently fired if directly browsing to a page checkout page.  This is because the cart has not been loaded before component mount is called.

# Testing 

* enable tracks debugging (`localStorage.setItem('debug', 'calypso:analytics:tracks');`)
* Browse to `/checkout/personal-bundle/renew/<subscriptionid>/<site>` (for your own subscription and site)
* verify that the `calypso_checkout_page_view` event is fired