### PR TITLE
i18n: Language picker handle lang codes with variant slugs

### DIFF
--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -18,6 +18,7 @@ import { getGeoCountryShort } from 'state/geo/selectors';
 import QueryGeo from 'components/data/query-geo';
 import LanguagePickerModal from './modal';
 import QueryLanguageNames from 'components/data/query-language-names';
+import { getLanguageCodeLabels } from './utils';
 
 export class LanguagePicker extends PureComponent {
 	static propTypes = {
@@ -135,9 +136,9 @@ export class LanguagePicker extends PureComponent {
 			return this.renderPlaceholder();
 		}
 
-		const [ langCode, langSubcode ] = language.langSlug.split( '-' );
-		const langName = language.name;
 		const { disabled, translate } = this.props;
+		const langName = language.name;
+		const langCodes = getLanguageCodeLabels( language.langSlug );
 
 		return (
 			<div
@@ -150,9 +151,9 @@ export class LanguagePicker extends PureComponent {
 			>
 				<div className="language-picker__icon">
 					<div className="language-picker__icon-inner">
-						{ langCode }
-						{ langSubcode && <br /> }
-						{ langSubcode }
+						{ langCodes.langCode }
+						{ langCodes.langSubcode && <br /> }
+						{ langCodes.langSubcode }
 					</div>
 				</div>
 				<div className="language-picker__name">

--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -138,7 +138,7 @@ export class LanguagePicker extends PureComponent {
 
 		const { disabled, translate } = this.props;
 		const langName = language.name;
-		const langCodes = getLanguageCodeLabels( language.langSlug );
+		const { langCode, langSubcode } = getLanguageCodeLabels( language.langSlug );
 
 		return (
 			<div
@@ -151,9 +151,9 @@ export class LanguagePicker extends PureComponent {
 			>
 				<div className="language-picker__icon">
 					<div className="language-picker__icon-inner">
-						{ langCodes.langCode }
-						{ langCodes.langSubcode && <br /> }
-						{ langCodes.langSubcode }
+						{ langCode }
+						{ langSubcode && <br /> }
+						{ langSubcode }
 					</div>
 				</div>
 				<div className="language-picker__name">

--- a/client/components/language-picker/test/index.jsx
+++ b/client/components/language-picker/test/index.jsx
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
 import { identity } from 'lodash';
@@ -31,6 +30,18 @@ const defaultProps = {
 			name: 'Čeština',
 			wpLocale: 'cs_CZ',
 		},
+		{
+			value: 900,
+			langSlug: 'de_formal',
+			name: 'Deutsch (Sie)',
+			wpLocale: 'de_DE_formal',
+		},
+		{
+			value: 902,
+			langSlug: 'es-mx_gringos',
+			name: 'Español de México de los Gringos',
+			wpLocale: 'es_MX_gringos',
+		},
 	],
 	translate: identity,
 	valueKey: 'langSlug',
@@ -41,7 +52,23 @@ const defaultProps = {
 describe( 'LanguagePicker', () => {
 	test( 'should render the right icon and label', () => {
 		const wrapper = shallow( <LanguagePicker { ...defaultProps } /> );
-		expect( wrapper.find( '.language-picker__icon' ) ).to.have.text( 'en' );
-		expect( wrapper.find( '.language-picker__name-label' ) ).to.have.text( 'English' );
+		expect( wrapper.find( '.language-picker__icon' ).text() ).toBe( 'en' );
+		expect( wrapper.find( '.language-picker__name-label' ).text() ).toBe( 'English' );
+	} );
+	test( 'should render the right icon and label for a language variant', () => {
+		const newProps = { ...defaultProps, value: 'de_formal' };
+		const wrapper = shallow( <LanguagePicker { ...newProps } /> );
+		expect( wrapper.find( '.language-picker__icon' ).text() ).toBe( 'de' );
+		expect( wrapper.find( '.language-picker__name-label' ).text() ).toBe( 'Deutsch (Sie)' );
+	} );
+	test( 'should render the right icon and label for a language variant with regional subcode', () => {
+		const newProps = { ...defaultProps, value: 'es-mx_gringos' };
+		const wrapper = shallow( <LanguagePicker { ...newProps } /> );
+		expect( wrapper.find( '.language-picker__icon-inner' ).html() ).toBe(
+			'<div class="language-picker__icon-inner">es<br/>mx</div>'
+		);
+		expect( wrapper.find( '.language-picker__name-label' ).text() ).toBe(
+			'Español de México de los Gringos'
+		);
 	} );
 } );

--- a/client/components/language-picker/test/utils.js
+++ b/client/components/language-picker/test/utils.js
@@ -1,57 +1,80 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import {
 	getLanguageGroupById,
 	getLanguageGroupFromTerritoryId,
 	getLanguageGroupByCountryCode,
+	getLanguageCodeLabels,
 } from '../utils';
 import { LANGUAGE_GROUPS, DEFAULT_LANGUAGE_GROUP } from '../constants';
 
 describe( 'language picker utils', () => {
 	describe( 'getLanguageGroupById()', () => {
 		test( 'should return expected territory', () => {
-			expect( getLanguageGroupById( 'eastern-europe' ) ).to.eql( LANGUAGE_GROUPS[ 4 ] );
+			expect( getLanguageGroupById( 'eastern-europe' ) ).toBe( LANGUAGE_GROUPS[ 4 ] );
 		} );
 		test( 'should return detault territory slug', () => {
-			expect( getLanguageGroupById( 'sad' ) ).to.be.undefined;
+			expect( getLanguageGroupById( 'sad' ) ).toBeUndefined();
 		} );
 	} );
 
 	describe( 'getLanguageGroupFromTerritoryId()', () => {
 		test( 'should return expected language group id for territory id `002`', () => {
-			expect( getLanguageGroupFromTerritoryId( '002' ) ).to.eql( 'africa-middle-east' );
+			expect( getLanguageGroupFromTerritoryId( '002' ) ).toBe( 'africa-middle-east' );
 		} );
 		test( 'should return expected language group id for territory id `019`', () => {
-			expect( getLanguageGroupFromTerritoryId( '019' ) ).to.eql( 'americas' );
+			expect( getLanguageGroupFromTerritoryId( '019' ) ).toBe( 'americas' );
 		} );
 		test( 'should return default language group id', () => {
-			expect( getLanguageGroupFromTerritoryId( '000' ) ).to.eql( DEFAULT_LANGUAGE_GROUP );
+			expect( getLanguageGroupFromTerritoryId( '000' ) ).toBe( DEFAULT_LANGUAGE_GROUP );
 		} );
 	} );
 
 	describe( 'getLanguageGroupByCountryCode()', () => {
 		test( 'should return expected language group id for Australia', () => {
-			expect( getLanguageGroupByCountryCode( 'AU' ) ).to.equal( 'asia-pacific' );
+			expect( getLanguageGroupByCountryCode( 'AU' ) ).toBe( 'asia-pacific' );
 		} );
 		test( 'should return expected language group id for Italy', () => {
-			expect( getLanguageGroupByCountryCode( 'PL' ) ).to.equal( 'eastern-europe' );
+			expect( getLanguageGroupByCountryCode( 'PL' ) ).toBe( 'eastern-europe' );
 		} );
 		test( 'should return expected language group id for South Africa', () => {
-			expect( getLanguageGroupByCountryCode( 'SA' ) ).to.equal( 'africa-middle-east' );
+			expect( getLanguageGroupByCountryCode( 'SA' ) ).toBe( 'africa-middle-east' );
 		} );
 		test( 'should return expected language group id for Mexico', () => {
-			expect( getLanguageGroupByCountryCode( 'MX' ) ).to.equal( 'americas' );
+			expect( getLanguageGroupByCountryCode( 'MX' ) ).toBe( 'americas' );
 		} );
 		test( 'should return default language group id', () => {
-			expect( getLanguageGroupByCountryCode( 'OOPS' ) ).to.equal( DEFAULT_LANGUAGE_GROUP );
+			expect( getLanguageGroupByCountryCode( 'OOPS' ) ).toBe( DEFAULT_LANGUAGE_GROUP );
+		} );
+	} );
+	describe( 'getLanguageCodeLabels()', () => {
+		test( 'should return empty object if no lang slug passed ', () => {
+			expect( getLanguageCodeLabels() ).toEqual( {} );
+		} );
+		test( 'should return lang code from xx', () => {
+			expect( getLanguageCodeLabels( 'xx' ) ).toEqual( {
+				langCode: 'xx',
+			} );
+		} );
+		test( 'should return lang and lang sub code from xx-yy', () => {
+			expect( getLanguageCodeLabels( 'xx-yy' ) ).toEqual( {
+				langCode: 'xx',
+				langSubcode: 'yy',
+			} );
+		} );
+		test( 'should return lang code from xx_variant', () => {
+			expect( getLanguageCodeLabels( 'xx_variant' ) ).toEqual( {
+				langCode: 'xx',
+			} );
+		} );
+		test( 'should return lang code from xx-yy_variant', () => {
+			expect( getLanguageCodeLabels( 'xx-yy_variant' ) ).toEqual( {
+				langCode: 'xx',
+				langSubcode: 'yy',
+			} );
 		} );
 	} );
 } );

--- a/client/components/language-picker/utils.js
+++ b/client/components/language-picker/utils.js
@@ -1,6 +1,5 @@
 /**
  * @format
- * @jest-environment jsdom
  */
 
 /**
@@ -69,4 +68,28 @@ export function getLanguageGroupByCountryCode(
 ) {
 	const languageGroup = find( languageGroups, t => includes( t.countries, countryCode ) );
 	return languageGroup ? languageGroup.id : defaultLanguageGroup;
+}
+
+/**
+ * Splits and returns language code labels based on langSlug
+ * Assumes the following langSlug formats: xx, xx-yy, xx-yy_variant, xx_variant
+ *
+ * @param {String} langSlug value of config.language[ langSlug ].langSlug
+ * @returns {Object} { langCode: 'xx', langSubcode: 'xx' } | {}
+ */
+export function getLanguageCodeLabels( langSlug ) {
+	const languageCodeLabels = {};
+
+	if ( ! langSlug ) {
+		return languageCodeLabels;
+	}
+
+	const languageCodes = langSlug.split( /[_-]+/ );
+
+	languageCodeLabels.langCode = languageCodes[ 0 ];
+	languageCodeLabels.langSubcode = langSlug.indexOf( '-' ) > -1 ? languageCodes[ 1 ] : undefined;
+
+	return {
+		...languageCodeLabels,
+	};
 }


### PR DESCRIPTION
This PR is part of the ongoing work of splitting #23025 into smaller, shippable pieces.

This ensures that the Language Picker button displays the correct `langSlug` based on the following formats: `xx`,` xx-yy`, `xx-yy_variant`, `xx_variant`.

Basically we ignore the `variant` portion and display only lang+langSubCode:

<img width="500" alt="screen shot 2018-03-09 at 6 22 59 pm" src="https://user-images.githubusercontent.com/6458278/37195563-79663822-23c7-11e8-9a99-313e19d49f48.png">

## Testing
`npm run test-client client/components/language-picker`
