### PR TITLE
i18n: Update/add locale variant client boot

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -29,10 +29,9 @@ import authController from 'auth/controller';
 const debug = debugFactory( 'calypso' );
 
 const switchUserLocale = ( currentUser, reduxStore ) => {
-	const localeSlug = currentUser.get().localeSlug;
-
-	if ( localeSlug ) {
-		reduxStore.dispatch( setLocale( localeSlug ) );
+	const currentUserData = currentUser.get();
+	if ( currentUserData.localeSlug ) {
+		reduxStore.dispatch( setLocale( currentUserData.localeSlug, currentUserData.localeVariant ) );
 	}
 };
 

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -29,9 +29,10 @@ import authController from 'auth/controller';
 const debug = debugFactory( 'calypso' );
 
 const switchUserLocale = ( currentUser, reduxStore ) => {
-	const currentUserData = currentUser.get();
-	if ( currentUserData.localeSlug ) {
-		reduxStore.dispatch( setLocale( currentUserData.localeSlug, currentUserData.localeVariant ) );
+	const { localeSlug, localeVariant } = currentUser.get();
+
+	if ( localeSlug ) {
+		reduxStore.dispatch( setLocale( localeSlug, localeVariant ) );
 	}
 };
 

--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -78,6 +78,7 @@ export function getComputedAttributes( attributes ) {
 	return {
 		primarySiteSlug: getSiteSlug( primaryBlogUrl ),
 		localeSlug: attributes.language,
+		localeVariant: attributes.locale_variant,
 		isRTL: !! ( language && language.rtl ),
 	};
 }

--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -56,6 +56,13 @@ export const createCurrentUserSelector = ( path, otherwise = null ) => state => 
 export const getCurrentUserLocale = createCurrentUserSelector( 'localeSlug' );
 
 /**
+ * Returns the locale variant slug for the current user.
+ * @param  {Object}  state  Global state tree
+ * @return {?String}        Current user locale variant
+ */
+export const getCurrentUserLocaleVariant = createCurrentUserSelector( 'localeVariant' );
+
+/**
  * Returns the country code for the current user.
  *
  * @param  {Object}  state  Global state tree

--- a/client/state/current-user/test/selectors.js
+++ b/client/state/current-user/test/selectors.js
@@ -12,6 +12,7 @@ import {
 	getCurrentUserId,
 	getCurrentUser,
 	getCurrentUserLocale,
+	getCurrentUserLocaleVariant,
 	getCurrentUserDate,
 	isValidCapability,
 	getCurrentUserCurrencyCode,
@@ -97,6 +98,53 @@ describe( 'selectors', () => {
 			} );
 
 			expect( locale ).to.equal( 'fr' );
+		} );
+	} );
+
+	describe( '#getCurrentUserLocaleVariant', () => {
+		test( 'should return null if the current user is not set', () => {
+			const locale = getCurrentUserLocaleVariant( {
+				currentUser: {
+					id: null,
+				},
+			} );
+
+			expect( locale ).to.be.null;
+		} );
+
+		test( 'should return null if the current user locale slug is not set', () => {
+			const locale = getCurrentUserLocaleVariant( {
+				users: {
+					items: {
+						73705554: { ID: 73705554, login: 'testonesite2014' },
+					},
+				},
+				currentUser: {
+					id: 73705554,
+				},
+			} );
+
+			expect( locale ).to.be.null;
+		} );
+
+		test( 'should return the current user locale variant slug', () => {
+			const locale = getCurrentUserLocaleVariant( {
+				users: {
+					items: {
+						73705554: {
+							ID: 73705554,
+							login: 'testonesite2014',
+							localeSlug: 'fr',
+							localeVariant: 'fr_formal',
+						},
+					},
+				},
+				currentUser: {
+					id: 73705554,
+				},
+			} );
+
+			expect( locale ).to.equal( 'fr_formal' );
 		} );
 	} );
 


### PR DESCRIPTION
This PR is part of the ongoing work of splitting #23025 into smaller, shippable pieces.

This PR adds localeVariant to the user data object so that we can pass it to `setLocale` and update `state.ui.language` when the client boots.