### PR TITLE
Plans: Remove translatable strings that are not ready for translation

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -359,7 +359,7 @@ export const PLANS_LIST = {
 		getBlogAudience: () => i18n.translate( 'Best for students' ),
 		getPortfolioAudience: () => i18n.translate( 'Best for students' ),
 		getStoreAudience: () => i18n.translate( 'Best for students' ),
-		getPriceTitle: () => i18n.translate( 'Free for life' ), //TODO: DO NOT USE
+		getPriceTitle: () => 'Free for life', //TODO: DO NOT USE
 		getProductId: () => 1,
 		getStoreSlug: () => PLAN_FREE,
 		getPathSlug: () => 'beginner',
@@ -417,7 +417,7 @@ export const PLANS_LIST = {
 		getProductId: () => 1003,
 		getStoreSlug: () => PLAN_PREMIUM,
 		getPathSlug: () => 'premium',
-		getPriceTitle: () => i18n.translate( '$99 per year' ), //TODO: DO NOT USE
+		getPriceTitle: () => '$99 per year', //TODO: DO NOT USE
 	},
 
 	[ PLAN_PREMIUM_2_YEARS ]: {
@@ -427,7 +427,7 @@ export const PLANS_LIST = {
 		getProductId: () => 1023,
 		getStoreSlug: () => PLAN_PREMIUM_2_YEARS,
 		getPathSlug: () => 'premium-2-years',
-		getPriceTitle: () => i18n.translate( '$90 per year' ), //TODO: DO NOT USE
+		getPriceTitle: () => '$90 per year', //TODO: DO NOT USE
 	},
 
 	[ PLAN_BUSINESS ]: {
@@ -440,7 +440,7 @@ export const PLANS_LIST = {
 		getProductId: () => 1008,
 		getStoreSlug: () => PLAN_BUSINESS,
 		getPathSlug: () => 'business',
-		getPriceTitle: () => i18n.translate( '$288 per year' ), //TODO: DO NOT USE
+		getPriceTitle: () => '$288 per year', //TODO: DO NOT USE
 	},
 
 	[ PLAN_BUSINESS_2_YEARS ]: {
@@ -460,7 +460,7 @@ export const PLANS_LIST = {
 		getProductId: () => 1028,
 		getStoreSlug: () => PLAN_BUSINESS_2_YEARS,
 		getPathSlug: () => 'business-2-years',
-		getPriceTitle: () => i18n.translate( '$299 per year' ), //TODO: DO NOT USE
+		getPriceTitle: () => '$299 per year', //TODO: DO NOT USE
 	},
 
 	[ PLAN_JETPACK_FREE ]: {


### PR DESCRIPTION
In #23075 translatable strings were introduced that are not yet ready for translation. This removes them so that we don't translate them in vain.