### PR TITLE
Guided Tours: clean up CSS for the different `Quit` buttons

### DIFF
--- a/client/layout/guided-tours/config-elements/quit.js
+++ b/client/layout/guided-tours/config-elements/quit.js
@@ -36,9 +36,9 @@ export default class Quit extends Component {
 
 	render() {
 		const { children, primary } = this.props;
+		const classes = primary ? 'guided-tours__primary-button' : 'guided-tours__quit-button';
 		return (
-			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-			<Button className="guided-tours__quit-button" onClick={ this.onClick } primary={ primary }>
+			<Button className={ classes } onClick={ this.onClick } primary={ primary }>
 				{ children || translate( 'Quit' ) }
 			</Button>
 		);

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -111,7 +111,13 @@
 .guided-tours__choice-button-row {
 	display: flex;
 	align-items: center;
+}
 
+.guided-tours__single-button-row {
+	text-align: center;
+}
+
+.guided-tours__choice-button-row, .guided-tours__single-button-row {
 	.button {
 		width: 48%;
 	}
@@ -121,7 +127,7 @@
 	.button:nth-child(1) {
 		margin-right: 4%;
 	}
-	.guided-tours__quit-button:not(.is-primary) {
+	.guided-tours__quit-button {
 		color: darken( $white, 20% );
 		background: none;
 		border: 1px rgba( $white, 0.2 ) solid;
@@ -138,18 +144,6 @@ a.config-elements__text-link,
 
 	&:visited {
 		color: $white;
-	}
-}
-
-.guided-tours__single-button-row {
-	text-align: center;
-	.button {
-		width: 48%;
-	}
-	.guided-tours__quit-button:not(.is-primary) {
-		color: darken( $white, 20% );
-		background: none;
-		border: 1px rgba( $white, 0.2 ) solid;
 	}
 }
 


### PR DESCRIPTION
#23141 fixed an issue with the color of the `Quit` buttons, but the CSS was semantically questionable. This PR cleans up that CSS a bit. 

To test:
- go through the `main` tour (e.g. at http://calypso.localhost:3000/?tour=main) and make sure that all button colors look right. 

Reference:

![guided-tours-quit-buttons](https://user-images.githubusercontent.com/23619/37203160-0b5f7634-238d-11e8-840a-b9b3f27c46f3.gif)
