### PR TITLE
HappyChat: add animation for full screen views

### DIFF
--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -159,6 +159,21 @@
 	animation: happychat-minimize-right .5s 1 forwards;
 }
 
+.layout.has-no-sidebar .happychat .happychat__container.is-open.is-minimizing {
+	animation: happychat-fade-out-right .5s 1 forwards;
+
+	> .happychat__composer,
+	> .happychat__welcome,
+	> .happychat__conversation,
+	> .happychat__title .happychat__active-toolbar * {
+		visibility: visible;
+	}
+
+	> .happychat__title {
+		animation: none;
+	}
+}
+
 @keyframes happychat-disappear {
 	0% {
 		top: 0px;
@@ -202,6 +217,17 @@
 	100% {
 		max-height: 0;
 		bottom: -34px;
+	}
+}
+
+@keyframes happychat-fade-out-right {	// for cases where the left sidebar does not exist (full page views)
+	0% {
+		opacity: 1;
+		transform: translateX(0px);
+	}
+	100% {
+		opacity: 0;
+		transform: translateX(280px);
 	}
 }
 


### PR DESCRIPTION
This PR adds a HappyChat dismiss animation for when there's no left sidebar (i.e.: full screen views).

Fixes https://github.com/Automattic/wp-calypso/issues/22737

### Before

![hc-before](https://user-images.githubusercontent.com/390760/37204269-28176034-2388-11e8-97f3-0181b931a5c7.gif)

### After

![hc-after](https://user-images.githubusercontent.com/390760/37204273-2bd89d3c-2388-11e8-8594-af70ceddc38a.gif)

### How to test

- Login to HappyChat HUD, turn chats on, select Jetpack.
- Head over to http://calypso.localhost:3000/jetpack/connect/store
- Click “Get help connecting your site”.
- Click &times; on HC to close the chat window.