### PR TITLE
Guided Tours: only trigger editor-based tours if email has been verified

### DIFF
--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -23,6 +23,7 @@ import {
 } from 'layout/guided-tours/config-elements';
 import { isNewUser } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
+import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 
 const PUBLISH_BUTTON_LABEL = translate( 'Publish' );
 
@@ -31,7 +32,7 @@ export const EditorBasicsTour = makeTour(
 		name="editorBasicsTour"
 		version="20170503"
 		path={ [ '/post/', '/page/' ] }
-		when={ and( isDesktop, isNewUser ) }
+		when={ and( isDesktop, isNewUser, isCurrentUserEmailVerified ) }
 	>
 		<Step
 			name="init"

--- a/client/layout/guided-tours/tours/editor-insert-menu-tour.js
+++ b/client/layout/guided-tours/tours/editor-insert-menu-tour.js
@@ -15,6 +15,7 @@ import Gridicon from 'gridicons';
 import { ButtonRow, makeTour, Step, Tour, Quit } from 'layout/guided-tours/config-elements';
 import { hasUserRegisteredBefore } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
+import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 
 class RepositioningStep extends Step {
 	componentDidMount() {
@@ -37,7 +38,11 @@ export const EditorInsertMenuTour = makeTour(
 		name="editorInsertMenu"
 		path={ [ '/post/', '/page/' ] }
 		version="20161215"
-		when={ and( hasUserRegisteredBefore( new Date( '2016-12-15' ) ), isDesktop ) }
+		when={ and(
+			hasUserRegisteredBefore( new Date( '2016-12-15' ) ),
+			isDesktop,
+			isCurrentUserEmailVerified
+		) }
 	>
 		<RepositioningStep
 			arrow="left-top"

--- a/client/layout/guided-tours/tours/gdocs-integration-tour.js
+++ b/client/layout/guided-tours/tours/gdocs-integration-tour.js
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import { translate } from 'i18n-calypso';
+import { overEvery as and } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,6 +20,7 @@ import {
 	Quit,
 } from 'layout/guided-tours/config-elements';
 import { hasUserPastedFromGoogleDocs } from 'state/ui/guided-tours/contexts';
+import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import analytics from 'lib/analytics';
 
 const trackUserInterest = () => {
@@ -30,7 +32,7 @@ export const GDocsIntegrationTour = makeTour(
 		name="gdocsIntegrationTour"
 		version="20170227"
 		path="/post"
-		when={ hasUserPastedFromGoogleDocs }
+		when={ and( isCurrentUserEmailVerified, hasUserPastedFromGoogleDocs ) }
 	>
 		<Step name="init" placement="right">
 			<p>{ translate( 'Did you know you can create drafts from Google Docs?' ) }</p>

--- a/client/layout/guided-tours/tours/simple-payments-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-tour.js
@@ -14,13 +14,14 @@ import { overEvery as and } from 'lodash';
 import { makeTour, Tour, Step, ButtonRow, Link, Quit } from 'layout/guided-tours/config-elements';
 import { isNotNewUser } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
+import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 
 export const SimplePaymentsTour = makeTour(
 	<Tour
 		name="simplePaymentsTour"
 		version="20170816"
 		path="/post/"
-		when={ and( isDesktop, isNotNewUser ) }
+		when={ and( isDesktop, isNotNewUser, isCurrentUserEmailVerified ) }
 	>
 		<Step
 			name="init"


### PR DESCRIPTION
This PR adds the trigger condition `isCurrentUserEmailVerified` to some tours — notably those that have a chance of showing the modal in the editor mentioned in #21122. This is to avoid the suboptimal element layering mentioned there. 

To test: 
- make sure the affected tours are being triggered only when the user has a verified email address
- note: different tours have different trigger conditions — some will trigger for new users only (account age less than a week) while others will trigger only for users who are not a new user according to that definition
- pro tip: reset your user's tour history by visiting http://calypso.localhost:3000/?tour=reset

Fixes #21122.