### PR TITLE
Jetpack: Fix onclick handler on thank you card

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -576,7 +576,7 @@ class JetpackThankYouCard extends Component {
 						className={ classNames( 'button', 'thank-you-card__button', {
 							'is-placeholder': ! buttonUrl,
 						} ) }
-						onclick={ this.onBackToYourSiteClick }
+						onClick={ this.onBackToYourSiteClick }
 						href={ buttonUrl }
 					>
 						{ translate( 'Back to your site' ) }


### PR DESCRIPTION
This just fixes a typo in the prop name `onclick` should be `onClick`.

This event fires a tracks event, which would never be produced.

## Testing
1. Connect a new Jetpack site
1. Set `localStorage.debug = 'calypso:analytics:tracks'`
1. Purchase a plan
1. You should see the related event fired when you click the button to return to your site after plan set up (from the Thank you page)