### PR TITLE
Update the Store dash styling after the move over to our new widget component

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
@@ -178,7 +178,7 @@ class ManageOrdersView extends Component {
 				<DashboardWidget
 					className="dashboard__reports-widget"
 					image="/calypso/images/extensions/woocommerce/woocommerce-reports.svg"
-					imagePosition="right"
+					imagePosition="left"
 					title={ translate( 'Reports' ) }
 				>
 					<p>

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -52,12 +52,23 @@
 
 	.dashboard__reports-widget .dashboard-widget__image {
 		margin-right: 10%;
-		width: calc( 30% ) !important;
+		width: calc( 40% - 8px ) !important;
+		margin-bottom: 16px;
+
+		@include breakpoint( ">660px" ) {
+			margin-bottom: 0;
+		}
 
 		@include breakpoint( "<660px" ) {
 			margin-right: auto;
 			margin-left: auto;
 			width: 80% !important;
+		}
+
+		& + .dashboard-widget__children {
+			@include breakpoint( ">660px" ) {
+				width: calc( 60% - 34px) !important;
+			}
 		}
 	}
 

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -117,6 +117,12 @@
 				color: $gray-text-min;
 			}
 		}
+
+		.dashboard__process-orders-action {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+		}
 	}
 
 	.dashboard-widget.dashboard__reviews-widget {

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -52,7 +52,7 @@
 
 	.dashboard__reports-widget .dashboard-widget__image {
 		margin-right: 10%;
-		width: calc( 40% - 8px ) !important;
+		width: calc( 35% - 8px ) !important;
 		margin-bottom: 16px;
 
 		@include breakpoint( ">660px" ) {
@@ -67,7 +67,7 @@
 
 		& + .dashboard-widget__children {
 			@include breakpoint( ">660px" ) {
-				width: calc( 60% - 34px) !important;
+				width: calc( 65% - 34px) !important;
 			}
 		}
 	}

--- a/client/extensions/woocommerce/components/share-widget/style.scss
+++ b/client/extensions/woocommerce/components/share-widget/style.scss
@@ -3,12 +3,6 @@
 		padding-top: 48px;
 	}
 
-	.dashboard-widget__title {
-		font-size: 24px;
-		line-height: 1.2em;
-		margin-bottom: 16px;
-	}
-
 	ul.share-widget__services {
 		list-style-type: none;
 		margin: 0 auto;
@@ -25,10 +19,14 @@
 				display: block;
 
 				&:hover {
-					transform: translateY( -4px ) scale( 1.05 );
+					transform: translateY( -4px );
 				}
 			}
 		}
+	}
+
+	img {
+		max-width: 600px;
 	}
 }
 


### PR DESCRIPTION
Mostly removes / tweaks from of the leftover card-specific styles for consistency.

Before | After
--- | ---
![before](https://cldup.com/MHUpk8iYq8-3000x3000.png) | ![after](https://cldup.com/wghmN0X-2g-2000x2000.png)