### PR TITLE
Domains: Blank availability status for wp.com subdomains in signup

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -384,6 +384,7 @@ class RegisterDomainStep extends React.Component {
 						return callback();
 					}
 					if ( this.props.isSignupStep && domain.match( /\.wordpress\.com$/ ) ) {
+						this.setState( { lastDomainStatus: null, lastDomainIsTransferrable: false } );
 						return callback();
 					}
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -378,12 +378,9 @@ class RegisterDomainStep extends React.Component {
 					if (
 						! domain.match(
 							/^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)*[a-z0-9]([a-z0-9-]*[a-z0-9])?\.[a-z]{2,63}$/i
-						)
+						) ||
+						( this.props.isSignupStep && domain.match( /\.wordpress\.com$/ ) )
 					) {
-						this.setState( { lastDomainStatus: null, lastDomainIsTransferrable: false } );
-						return callback();
-					}
-					if ( this.props.isSignupStep && domain.match( /\.wordpress\.com$/ ) ) {
 						this.setState( { lastDomainStatus: null, lastDomainIsTransferrable: false } );
 						return callback();
 					}


### PR DESCRIPTION
We don't blank the availability status, and we just
show the last availability message that was
shown. Nasty bug, can get some very weird results
in NUX.

Steps:
- visit wordpress.com/start
- proceed to domain step
- search for a domain like testsomethingsomething888.wordpress.co (note the .co)
- message about .co already taken - expected
- change to .com
- message now displays for .com also: