### PR TITLE
Fix themes count

### DIFF
--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -32,9 +32,10 @@ export default class QueryManager {
 	/**
 	 * Constructs a new instance of QueryManager
 	 *
-	 * @param {Object} data            Initial data
-	 * @param {Object} options         Manager options
-	 * @param {String} options.itemKey Field to key items by
+	 * @param {Object} data                  Initial data
+	 * @param {Object} options               Manager options
+	 * @param {String} options.itemKey       Field to key items by
+	 * @param {Boolean} options.adjustCounts Field to key items by
 	 */
 	constructor( data, options ) {
 		this.data = Object.assign(
@@ -48,6 +49,7 @@ export default class QueryManager {
 		this.options = Object.assign(
 			{
 				itemKey: 'ID',
+				adjustCounts: true,
 			},
 			options
 		);
@@ -215,14 +217,15 @@ export default class QueryManager {
 	 * instance state. Instead, it returns a new instance of QueryManager if
 	 * the tracked items have been modified, or the current instance otherwise.
 	 *
-	 * @param  {(Array|Object)} items              Item(s) to be received
-	 * @param  {Object}         options            Options for receive
-	 * @param  {Boolean}        options.patch      Apply changes as partial
-	 * @param  {Object}         options.query      Query set to set or replace
-	 * @param  {Boolean}        options.mergeQuery Add to existing query set
-	 * @param  {Number}         options.found      Total found items for query
-	 * @return {QueryManager}                      New instance if changed, or
-	 *                                             same instance otherwise
+	 * @param  {(Array|Object)} items                Item(s) to be received
+	 * @param  {Object}         options              Options for receive
+	 * @param  {Boolean}        options.patch        Apply changes as partial
+	 * @param  {Object}         options.query        Query set to set or replace
+	 * @param  {Boolean}        options.mergeQuery   Add to existing query set
+	 * @param  {Boolean}        options.adjustCounts Field to key items by
+	 * @param  {Number}         options.found        Total found items for query
+	 * @return {QueryManager}                        New instance if changed, or
+	 *                                               same instance otherwise
 	 */
 	receive( items = [], options = {} ) {
 		// Coerce received single item to array
@@ -340,7 +343,10 @@ export default class QueryManager {
 
 				// Found counts should not be adjusted for the received query if
 				// merging into existing items
-				const shouldAdjustFoundCount = ! isReceivedQueryKey;
+				const shouldUpdateCounts = options.hasOwnProperty( 'adjustCounts' )
+					? options.adjustCounts
+					: this.options.adjustCounts;
+				const shouldAdjustFoundCount = ! isReceivedQueryKey && shouldUpdateCounts;
 
 				const query = this.constructor.QueryKey.parse( queryKey );
 				let needsSort = false;

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -35,7 +35,7 @@ export default class QueryManager {
 	 * @param {Object}  data                  Initial data
 	 * @param {Object}  options               Manager options
 	 * @param {String}  options.itemKey       Field to key items by
-	 * @param {Boolean} options.adjustCounts  Field to key items by
+	 * @param {Boolean} options.adjustCounts  Flag to disable the update of previous found counts
 	 */
 	constructor( data, options ) {
 		this.data = Object.assign(
@@ -222,7 +222,7 @@ export default class QueryManager {
 	 * @param  {Boolean}        options.patch        Apply changes as partial
 	 * @param  {Object}         options.query        Query set to set or replace
 	 * @param  {Boolean}        options.mergeQuery   Add to existing query set
-	 * @param  {Boolean}        options.adjustCounts Field to key items by
+	 * @param  {Boolean}        options.adjustCounts Flag to disable the update of found counts
 	 * @param  {Number}         options.found        Total found items for query
 	 * @return {QueryManager}                        New instance if changed, or
 	 *                                               same instance otherwise

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -32,10 +32,10 @@ export default class QueryManager {
 	/**
 	 * Constructs a new instance of QueryManager
 	 *
-	 * @param {Object} data                  Initial data
-	 * @param {Object} options               Manager options
-	 * @param {String} options.itemKey       Field to key items by
-	 * @param {Boolean} options.adjustCounts Field to key items by
+	 * @param {Object}  data                  Initial data
+	 * @param {Object}  options               Manager options
+	 * @param {String}  options.itemKey       Field to key items by
+	 * @param {Boolean} options.adjustCounts  Field to key items by
 	 */
 	constructor( data, options ) {
 		this.data = Object.assign(

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -408,6 +408,19 @@ describe( 'QueryManager', () => {
 			expect( manager.getFound( {} ) ).to.equal( 1 );
 		} );
 
+		test( 'should not replace the previous found count if flag is false', () => {
+			manager = manager.receive( [], { query: {}, found: 0 } );
+			const newManager = manager.receive( { ID: 144 }, { adjustCounts: false } );
+
+			expect( manager.getFound( {} ) ).to.equal( 0 );
+			expect( newManager.getFound( {} ) ).to.equal( 0 );
+		} );
+
+		test( 'should set the default value of `adjustCounts` to true', () => {
+			const newManager = manager.receive( { ID: 144 } );
+			expect( newManager.options.adjustCounts ).to.be.true;
+		} );
+
 		test( 'should increment found count if adding a matched item', () => {
 			manager = manager.receive( [], { query: {}, found: 0 } );
 			const newManager = manager.receive( { ID: 144 } );

--- a/client/lib/query-manager/theme/index.js
+++ b/client/lib/query-manager/theme/index.js
@@ -1,5 +1,10 @@
 /** @format */
 /**
+ * External dependencies
+ */
+import { every, flatMap, includes, intersection, reduce, uniq } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import PaginatedQueryManager from '../paginated';
@@ -12,6 +17,57 @@ import { DEFAULT_THEME_QUERY } from './constants';
 export default class ThemeQueryManager extends PaginatedQueryManager {
 	static QueryKey = ThemeQueryKey;
 	static DefaultQuery = DEFAULT_THEME_QUERY;
+
+	/**
+	 * Returns true if the theme item matches the given query, or false
+	 * otherwise.
+	 *
+	 * @param  {Object}  query Query object
+	 * @param  {Object}  theme Item to consider
+	 * @return {Boolean}       Whether theme item matches query
+	 */
+	static matches( query, theme ) {
+		return every( { ...this.DefaultQuery, ...query }, ( value, key ) => {
+			switch ( key ) {
+				case 'search':
+					if ( ! value ) {
+						return true;
+					}
+					return theme.name && includes( theme.name.toLowerCase(), value.toLowerCase() );
+
+				case 'filter':
+					if ( ! value ) {
+						return true;
+					}
+					const filters = uniq( value.split( '+' ) );
+					// create an array of taxonomy slugs from the theme taxonomies collection
+					const taxonomies = flatMap( theme.taxonomies, taxonomyGroup => {
+						return reduce(
+							taxonomyGroup,
+							( result, taxonomy ) => {
+								result.push( taxonomy.slug );
+								return result;
+							},
+							[]
+						);
+					} );
+					const matchedTaxonomies = intersection( filters, taxonomies );
+
+					// all filters should match taxonomies
+					return matchedTaxonomies.length === filters.length;
+
+				case 'tier':
+					if ( ! value ) {
+						return true;
+					}
+
+					const isFree = ( theme.cost && theme.cost.number === 0 ) || ! theme.price;
+					return 'free' === value ? isFree : ! isFree;
+			}
+
+			return true;
+		} );
+	}
 
 	/**
 	 * A sorting function that defines the sort order of items under

--- a/client/lib/query-manager/theme/test/index.js
+++ b/client/lib/query-manager/theme/test/index.js
@@ -9,7 +9,124 @@ import { expect } from 'chai';
  */
 import ThemeQueryManager from '../';
 
+/**
+ * Constants
+ */
+const DEFAULT_THEME = {
+	author: 'Automattic',
+	id: 'dara',
+	stylesheet: 'pub/dara',
+	name: 'Dara',
+	taxonomies: {
+		theme_subject: [
+			{ name: 'Blog', slug: 'blog', term_id: '273' },
+			{ name: 'Business', slug: 'business', term_id: '179' },
+		],
+		theme_style: [
+			{ name: 'Bright', slug: 'bright', term_id: '130006' },
+			{ name: 'Modern', slug: 'modern', term_id: '4690' },
+			{ name: 'Professional', slug: 'professional', term_id: '7830' },
+		],
+	},
+	cost: { currency: 'EUR', number: 0, display: '' },
+	version: '1.2.1',
+	download_url: 'https://public-api.wordpress.com/rest/v1/themes/download/dara.zip',
+	trending_rank: 6,
+	popularity_rank: 10,
+	launch_date: '2017-01-30',
+	theme_uri: 'http://wordpress.com/themes/dara/',
+	description:
+		'With bold featured images and bright, cheerful colors, Dara is ready to get to work for your business.',
+	preview_url: 'http://demiantest.com/?theme=pub/dara&hide_banners=true',
+};
+
 describe( 'ThemeQueryManager', () => {
+	describe( '#matches()', () => {
+		describe( 'query.search', () => {
+			test( 'should return false for a non-matching search', () => {
+				const isMatch = ThemeQueryManager.matches( { search: 'Cars' }, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			test( 'should return true for an empty search', () => {
+				const isMatch = ThemeQueryManager.matches( { search: '' }, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			test( 'should return true for a matching title search', () => {
+				const isMatch = ThemeQueryManager.matches( { search: 'Dara' }, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			test( 'should search case-insensitive', () => {
+				const isMatch = ThemeQueryManager.matches( { search: 'dArA' }, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.true;
+			} );
+		} );
+
+		describe( 'query.filter', () => {
+			test( 'should return true for an empty filter', () => {
+				const isMatch = ThemeQueryManager.matches( { filter: '' }, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			test( 'should return true for single matching filter', () => {
+				const isMatch = ThemeQueryManager.matches( { filter: 'blog' }, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			test( 'should return true for multiple matching filters', () => {
+				const isMatch = ThemeQueryManager.matches( { filter: 'blog+modern' }, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			test( 'should return false for single non matching filter', () => {
+				const isMatch = ThemeQueryManager.matches( { filter: 'blogs' }, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			test( 'should return false for multiple non matching filters', () => {
+				const isMatch = ThemeQueryManager.matches( { filter: 'blogs+moderns' }, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			test( 'should return false for partial non matching filters', () => {
+				const isMatch = ThemeQueryManager.matches( { filter: 'blog+moderns' }, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.false;
+			} );
+		} );
+
+		describe( 'query.tier', () => {
+			test( 'should return true if tier is empty', () => {
+				const isMatch = ThemeQueryManager.matches( { tier: '' }, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			test( 'should return true if tier matches', () => {
+				const isMatch = ThemeQueryManager.matches( { tier: 'free' }, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			test( 'should return false if tier doesnt match', () => {
+				const isMatch = ThemeQueryManager.matches( { tier: 'premium' }, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.false;
+			} );
+		} );
+	} );
+
 	describe( '#sort()', () => {
 		test( 'should leave key order unchanged', () => {
 			const originalKeys = Object.freeze( [

--- a/client/state/activity-log/log/schema.js
+++ b/client/state/activity-log/log/schema.js
@@ -85,6 +85,9 @@ export const logItemsSchema = {
 				itemKey: {
 					type: 'string',
 				},
+				adjustCounts: {
+					type: 'boolean',
+				},
 			},
 		},
 		oldestItemTs: {

--- a/client/state/activity-log/log/test/reducer.js
+++ b/client/state/activity-log/log/test/reducer.js
@@ -83,6 +83,7 @@ describe( 'reducer', () => {
 					},
 					options: {
 						itemKey: 'activityId',
+						adjustCounts: true,
 					},
 				},
 			} );

--- a/client/state/posts/schema.js
+++ b/client/state/posts/schema.js
@@ -51,6 +51,9 @@ const queryManagerSchema = {
 				itemKey: {
 					type: 'string',
 				},
+				adjustCounts: {
+					type: 'boolean',
+				},
 			},
 		},
 	},

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -608,6 +608,7 @@ describe( 'reducer', () => {
 					siteId: 2916284,
 					query: { search: 'Hello' },
 					found: 1,
+					adjustCounts: true,
 					posts: [
 						{
 							ID: 841,
@@ -641,6 +642,7 @@ describe( 'reducer', () => {
 					},
 					options: {
 						itemKey: 'ID',
+						adjustCounts: true,
 					},
 				},
 			} );
@@ -1241,7 +1243,7 @@ describe( 'reducer', () => {
 
 			expect( state ).to.be.an.instanceof( PostQueryManager );
 			expect( state.data ).to.eql( { items: {}, queries: {} } );
-			expect( state.options ).to.eql( { itemKey: 'global_ID' } );
+			expect( state.options ).to.eql( { itemKey: 'global_ID', adjustCounts: true } );
 		} );
 
 		test( 'should track post query request success', () => {
@@ -1615,6 +1617,7 @@ describe( 'reducer', () => {
 					siteId: null,
 					query: { search: 'Hello' },
 					found: 1,
+					adjustCounts: true,
 					posts: [
 						{
 							ID: 841,
@@ -1647,6 +1650,7 @@ describe( 'reducer', () => {
 				},
 				options: {
 					itemKey: 'global_ID',
+					adjustCounts: true,
 				},
 			} );
 		} );
@@ -1706,7 +1710,7 @@ describe( 'reducer', () => {
 
 			expect( state ).to.be.an.instanceof( PostQueryManager );
 			expect( state.data ).to.eql( { items: {}, queries: {} } );
-			expect( state.options ).to.eql( { itemKey: 'global_ID' } );
+			expect( state.options ).to.eql( { itemKey: 'global_ID', adjustCounts: true } );
 		} );
 	} );
 } );

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -310,14 +310,17 @@ export const queries = ( () => {
 		{
 			[ THEMES_REQUEST_SUCCESS ]: ( state, { siteId, query, themes, found } ) => {
 				return applyToManager(
-					// Always 'patch' to avoid overwriting existing fields when receiving
-					// from a less rich endpoint such as /mine
 					state,
 					siteId,
 					'receive',
 					true,
 					themes,
-					{ query, found, patch: true }
+					// Always 'patch' to avoid overwriting existing fields when receiving
+					// from a less rich endpoint such as /mine
+					// Also disable 'adjustCounts' to use the initial `founnd` counts and do not
+					// increment them when switching filters
+					// context: https://github.com/Automattic/wp-calypso/issues/15833
+					{ query, found, patch: true, adjustCounts: false }
 				);
 			},
 			[ THEME_DELETE_SUCCESS ]: ( state, { siteId, themeId } ) => {

--- a/client/state/themes/schema.js
+++ b/client/state/themes/schema.js
@@ -65,6 +65,9 @@ export const queriesSchema = {
 						itemKey: {
 							type: 'string',
 						},
+						adjustCounts: {
+							type: 'boolean',
+						},
 					},
 				},
 			},

--- a/client/state/themes/test/reducer.js
+++ b/client/state/themes/test/reducer.js
@@ -312,6 +312,7 @@ describe( 'reducer', () => {
 					siteId: 2916284,
 					query: { search: 'Sixteen' },
 					found: 1,
+					adjustCounts: false,
 					themes: [ twentysixteen ],
 				} )
 			);
@@ -336,6 +337,7 @@ describe( 'reducer', () => {
 					},
 					options: {
 						itemKey: 'id',
+						adjustCounts: true,
 					},
 				},
 			} );


### PR DESCRIPTION
## Summary
This PR fixes the counts on the themes page. They get mixed up when filters are used https://github.com/Automattic/wp-calypso/issues/15833 . In order to fix this a new flag (`adjustCounts`) was added to the `QueryManager` which lets us disable the updates of the`found` field for previous matching request. Also its `matches` method was implemented for themes section.

## Testing
The steps from https://github.com/Automattic/wp-calypso/issues/15833 should not be reproducible anymore.