### PR TITLE
Devdocs: add support for readme display in block examples

### DIFF
--- a/client/blocks/reader-post-options-menu/README.md
+++ b/client/blocks/reader-post-options-menu/README.md
@@ -4,7 +4,7 @@ The button and overlay for the "ellipsis" options menu attached to a post.
 
 ## Props
 
-- `post`: A reader post object
+- `post`: A Reader post object
 - `onBlock`: a callback to invoke when a post or site is blocked
 
 ## Usage
@@ -19,18 +19,16 @@ function MyMenu() {
 
 ### `post`
 
-<table>
-	<tr><th>Type</th><td>Object</td></tr>
-	<tr><th>Required</th><td>Yes</td></tr>
-</table>
+| Type | Required |
+| ------ | ----------- |
+| object   | yes |
 
 A Reader post object.
 
 ### `onBlock`
 
-<table>
-	<tr><th>Type</th><td>Function</td></tr>
-	<tr><th>Required</th><td>No</td></tr>
-</table>
+| Type | Required |
+| ------ | ----------- |
+| function   | no |
 
 A callback to invoke when a post or site is blocked.

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -62,7 +62,7 @@ import ReaderAvatar from 'blocks/reader-avatar/docs/example';
 import ImageEditor from 'blocks/image-editor/docs/example';
 import VideoEditor from 'blocks/video-editor/docs/example';
 import ReaderPostCard from 'blocks/reader-post-card/docs/example';
-import ReaderCombinedCard from 'blocks/reader-combined-card/docs/example';
+//import ReaderCombinedCard from 'blocks/reader-combined-card/docs/example';
 import ReaderRecommendedSites from 'blocks/reader-recommended-sites/docs/example';
 import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu/docs/example';
 import DailyPostButton from 'blocks/daily-post-button/docs/example';
@@ -115,7 +115,7 @@ export default class AppComponents extends React.Component {
 				<Collection
 					component={ this.props.component }
 					filter={ this.state.filter }
-					section="blocks"
+					section={ 'blocks' }
 				>
 					<AuthorSelector />
 					<CalendarButton />
@@ -155,14 +155,14 @@ export default class AppComponents extends React.Component {
 					<ReaderFullPostHeader />
 					<AuthorCompactProfile />
 					<ReaderPostCard />
-					<ReaderCombinedCard />
+					{ /*					<ReaderCombinedCard readmeFilePath="reader-combined-card" />*/ }
 					<ReaderRecommendedSites />
 					<PlanPrice />
 					<PostShare />
 					<PlanThankYouCard />
 					<DismissibleCard />
 					<ReaderAvatar />
-					<ReaderPostOptionsMenu />
+					<ReaderPostOptionsMenu readmeFilePath="reader-post-options-menu" />
 					<DailyPostButton />
 					<PostLikes />
 					<ReaderFeaturedVideo />

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -65,7 +65,9 @@ const Collection = ( {
 		return (
 			<DocsExampleWrapper name={ exampleName } unique={ !! component } url={ exampleLink }>
 				{ example }
-				{ component && <ReadmeViewer readmeFilePath={ example.props.readmeFilePath } /> }
+				{ component && (
+					<ReadmeViewer section={ section } readmeFilePath={ example.props.readmeFilePath } />
+				) }
 			</DocsExampleWrapper>
 		);
 	} );

--- a/client/devdocs/docs-example/readme-viewer.jsx
+++ b/client/devdocs/docs-example/readme-viewer.jsx
@@ -19,21 +19,25 @@ class ReadmeViewer extends Component {
 	static propTypes = {
 		getReadme: PropTypes.func,
 		readmeFilePath: PropTypes.string,
+		section: PropTypes.string,
 	};
 
 	static defaultProps = {
-		getReadme: readmeFilePath => {
+		getReadme: ( section, readmeFilePath ) => {
+			if ( section === 'blocks' ) {
+				return htmlToReactParser.parse( require( `../../blocks/${ readmeFilePath }/README.md` ) );
+			}
 			return htmlToReactParser.parse( require( `../../components/${ readmeFilePath }/README.md` ) );
 		},
 	};
 
 	render() {
-		const readmeFilePath = this.props.readmeFilePath;
-		const readme = readmeFilePath && this.props.getReadme( readmeFilePath );
+		const { section, readmeFilePath } = this.props;
+		const readme = readmeFilePath && this.props.getReadme( section, readmeFilePath );
 		const editLink = (
 			<div className="docs-example__readme-viewer-edit-link">
 				<a
-					href={ `https://github.com/Automattic/wp-calypso/edit/master/client/components/${ readmeFilePath }/README.md` }
+					href={ `https://github.com/Automattic/wp-calypso/edit/master/client/${ section }/${ readmeFilePath }/README.md` }
 				>
 					Improve this document on GitHub
 				</a>


### PR DESCRIPTION
Thanks to some excellent prior work in https://github.com/Automattic/wp-calypso/pull/20898, Devdocs component examples now display the README inline:

![screen shot 2018-03-09 at 15 42 44](https://user-images.githubusercontent.com/17325/37215655-868c84b4-23b0-11e8-9050-b40af52b057a.png)

To activate this, you must specify `readmeFilePath` prop on the example:

`<Headers readmeFilePath="header-cake" />`

However, this did not work for Calypso blocks. This PR adds support for the same functionality in blocks.

Props to @samouri for helping me solving an issue with `require()` along the way.

**Note: block examples are currently broken and https://github.com/Automattic/wp-calypso/pull/23166 must be merged before this PR.**

### To test

Load http://calypso.localhost:3000/devdocs/blocks/reader-post-options-menu. Ensure that the README is shown. 

Check component examples like http://calypso.localhost:3000/devdocs/design/accordion and make sure the README is still shown there.