### PR TITLE
Add multiple notifications for comment status changes

### DIFF
--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -93,9 +93,7 @@ export class CommentActions extends Component {
 	setTrash = () => this.setStatus( 'trash' );
 
 	showNotice = status => {
-		const { minimumComment, translate } = this.props;
-
-		this.props.removeNotice( 'comment-notice' );
+		const { commentId, minimumComment, translate } = this.props;
 
 		const message = get(
 			{
@@ -109,7 +107,7 @@ export class CommentActions extends Component {
 
 		const noticeOptions = {
 			button: translate( 'Undo' ),
-			id: 'comment-notice',
+			id: `comment-notice-${ commentId }-${ status }`,
 			isPersistent: true,
 			onClick: this.undo( status, minimumComment ),
 		};
@@ -137,7 +135,7 @@ export class CommentActions extends Component {
 			unlike();
 		}
 
-		this.props.removeNotice( 'comment-notice' );
+		this.props.removeNotice( `comment-notice-${ commentId }-${ status }` );
 	};
 
 	toggleApproved = () => this.setStatus( this.props.commentIsApproved ? 'unapproved' : 'approved' );


### PR DESCRIPTION
## Summary
This PR adds an independent notification for each comment status action.
Fixes https://github.com/Automattic/wp-calypso/issues/22155

## Testing
0. Make sure you have few comments
1. Starting at URL: https://wordpress.com/comments
2. Make any comment update (e.g. mark as spam) for few comments at once.
3. There should be a notification for each action