### PR TITLE
Signup: Improve labels for screen readers in the About step

### DIFF
--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -39,6 +39,7 @@ import Card from 'components/card';
 import Button from 'components/button';
 import FormTextInput from 'components/forms/form-text-input';
 import FormLabel from 'components/forms/form-label';
+import FormLegend from 'components/forms/form-legend';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormInputCheckbox from 'components/forms/form-checkbox';
 import SegmentedControl from 'components/segmented-control';
@@ -404,13 +405,18 @@ class AboutStep extends Component {
 
 		return (
 			<div className="about__checkboxes">
-				{ siteGoalsArray.map( item => {
+				{ siteGoalsArray.map( ( item, index ) => {
 					return (
 						<FormLabel
 							htmlFor={ options[ item ].key }
 							className="about__checkbox-option"
 							key={ options[ item ].key }
 						>
+							{ 0 === index && (
+								<span className="about__screen-reader-text screen-reader-text">
+									{ translate( 'What’s the primary goal you have for your site?' ) }
+								</span>
+							) }
 							<FormInputCheckbox
 								name="siteGoals"
 								id={ options[ item ].key }
@@ -437,7 +443,7 @@ class AboutStep extends Component {
 
 		return (
 			<FormFieldset className="about__last-fieldset">
-				<FormLabel>{ translate( 'How comfortable are you with creating a website?' ) }</FormLabel>
+				<FormLegend>{ translate( 'How comfortable are you with creating a website?' ) }</FormLegend>
 				<div className="about__segmented-control-wrapper">
 					<span
 						className="about__segment-label about__min-label"
@@ -451,7 +457,13 @@ class AboutStep extends Component {
 							selected={ this.state.userExperience === 1 }
 							onClick={ this.handleSegmentClick( 1 ) }
 						>
+							<span className="about__screen-reader-text screen-reader-text">
+								{ translate( 'How comfortable are you with creating a website?' ) }
+							</span>
 							1
+							<span className="about__screen-reader-text screen-reader-text">
+								{ translate( 'Beginner' ) }
+							</span>
 						</ControlItem>
 
 						<ControlItem
@@ -480,6 +492,9 @@ class AboutStep extends Component {
 							onClick={ this.handleSegmentClick( 5 ) }
 						>
 							5
+							<span className="about__screen-reader-text screen-reader-text">
+								{ translate( 'Expert' ) }
+							</span>
 						</ControlItem>
 					</SegmentedControl>
 					<span
@@ -539,7 +554,9 @@ class AboutStep extends Component {
 							</FormFieldset>
 
 							<FormFieldset>
-								<FormLabel>{ translate( 'What will your site be about?' ) }</FormLabel>
+								<FormLabel htmlFor="siteTopic">
+									{ translate( 'What will your site be about?' ) }
+								</FormLabel>
 								<FormTextInput
 									id="siteTopic"
 									name="siteTopic"
@@ -559,9 +576,9 @@ class AboutStep extends Component {
 							</FormFieldset>
 
 							<FormFieldset>
-								<FormLabel>
+								<FormLegend>
 									{ translate( 'What’s the primary goal you have for your site?' ) }
-								</FormLabel>
+								</FormLegend>
 								{ this.renderGoalCheckboxes() }
 							</FormFieldset>
 


### PR DESCRIPTION
Fix #21654 

Attempt at fixing the labels of the Signup's About step to make them readable from screen readers.

1. Add the `for` attribute to all `<label>`s (except those that wrap `<input>`s, which don't need it).
2. Turn `<label>`s into `<legend>`s for groups of `<input>`s.

Unfortunately this is not enough, because some screen readers (e.g. Mac's VoiceOver) don't read `<legend>` elements.
So I've followed the [WAI suggestion](https://www.w3.org/WAI/tutorials/forms/grouping/#related-fields) and added the legend as a visually hidden text inside the label of the first `<input>` of each group.

This makes the form a more verbose for users with screen readers supporting `<legend>` elements, but I'd say it's a fair tradeoff.

I've also used the same workaround for the "How comfortable are you with creating a website?" group's "Beginner" and "Expert" labels.
They are buttons (or, rather, `<span>`s with `onClick`) positioned outside the group, and are disregarded by the screen reader (at least by VoiceOver on macOS 10.13).
I've simply added the former to the first element, and the latter to the last element.

In other words, now the group is read like this:

- How comfortable are you with creating a website? 1 Beginner
- 2
- 3
- 4
- 5 Expert

By listening to it, I'm almost inclined to add a descriptor to 2-4 as well.

## Testing instructions

Open `start/about` with VoiceOver (or another screen reader) enabled.
Navigate the form with the keyboard.
Make sure all the legends and labels are read.