### PR TITLE
Add new site: adds new selection popover

### DIFF
--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -10,23 +10,90 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import Button from 'components/button';
+import PopoverMenu from 'components/popover/menu';
+import PopoverMenuItem from 'components/popover/menu-item';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 class SiteSelectorAddSite extends Component {
-	getAddNewSiteUrl() {
-		return '/jetpack/new/?ref=calypso-selector';
+	state = {
+		showPopoverMenu: false,
+	};
+
+	handleShowPopover = isShowing => {
+		const action = isShowing ? 'show' : 'hide';
+
+		this.setState( {
+			showPopoverMenu: isShowing,
+		} );
+
+		this.props.recordTracksEvent( 'calypso_add_site_popover', { action } );
+	};
+
+	onPopoverButtonClick = () => {
+		this.handleShowPopover( ! this.state.showPopoverMenu );
+	};
+
+	onClosePopover = () => {
+		this.handleShowPopover( false );
+	};
+
+	getNewWpcomSiteUrl() {
+		return config( 'signup_url' ) + '?ref=calypso-selector';
 	}
 
-	recordAddNewSite = () => {
-		this.props.recordTracksEvent( 'calypso_add_new_wordpress_click' );
+	getNewJetpackSiteUrl() {
+		return '/jetpack/connect/?ref=calypso-selector';
+	}
+
+	recordPopoverAddNewSite = () => {
+		this.props.recordTracksEvent( 'calypso_add_new_wordpress_popover_click' );
+	};
+
+	recordPopoverAddJetpackSite = () => {
+		this.props.recordTracksEvent( 'calypso_add_jetpack_site_popover_click' );
+	};
+
+	popoverToggleRef = node => {
+		this.popoverToggle = node;
 	};
 
 	render() {
 		const { translate } = this.props;
 		return (
 			<span className="site-selector__add-new-site">
-				<Button borderless href={ this.getAddNewSiteUrl() } onClick={ this.recordAddNewSite }>
+				<PopoverMenu
+					className="site-selector__popover"
+					isVisible={ this.state.showPopoverMenu }
+					onClose={ this.onClosePopover }
+					context={ this.popoverToggle }
+				>
+					<PopoverMenuItem
+						href={ this.getNewWpcomSiteUrl() }
+						onClick={ this.recordPopoverAddNewSite }
+					>
+						<span>
+							<span>{ translate( 'Create a new site' ) }</span>
+							<span className="site-selector__popover-item-details">
+								{ translate( 'Start a new WordPress.com site' ) }
+							</span>
+						</span>
+					</PopoverMenuItem>
+					<PopoverMenuItem
+						href={ this.getNewJetpackSiteUrl() }
+						onClick={ this.recordPopoverAddJetpackSite }
+					>
+						<span>
+							<span>{ translate( 'Add an existing site' ) }</span>
+							<span className="site-selector__popover-item-details">
+								{ translate( 'Add a self-hosted WordPress site' ) }
+							</span>
+						</span>
+					</PopoverMenuItem>
+				</PopoverMenu>
+
+				<Button borderless onClick={ this.onPopoverButtonClick } ref={ this.popoverToggleRef }>
 					<Gridicon icon="add-outline" /> { translate( 'Add New Site' ) }
 				</Button>
 			</span>

--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -76,7 +76,7 @@ class SiteSelectorAddSite extends Component {
 						<span>
 							<span>{ translate( 'Create a new site' ) }</span>
 							<span className="site-selector__popover-item-details">
-								{ translate( 'Start a new WordPress.com site' ) }
+								{ translate( 'Start a new site on WordPress.com' ) }
 							</span>
 						</span>
 					</PopoverMenuItem>

--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -14,6 +14,7 @@ import config from 'config';
 import Button from 'components/button';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
+import PopoverMenuSeparator from 'components/popover/menu-separator';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 class SiteSelectorAddSite extends Component {
@@ -80,6 +81,7 @@ class SiteSelectorAddSite extends Component {
 							</span>
 						</span>
 					</PopoverMenuItem>
+					<PopoverMenuSeparator />
 					<PopoverMenuItem
 						href={ this.getNewJetpackSiteUrl() }
 						onClick={ this.recordPopoverAddJetpackSite }

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -201,3 +201,34 @@
 .site-selector__no-results + .site-selector__hidden-sites-message {
 	display: none;
 }
+
+.site-selector__popover {
+	left: 16px !important;
+
+	.gridicons-my-sites {
+		color: $blue-wordpress;
+	}
+
+	.gridicons-plans {
+		color: $green-jetpack;
+	}
+
+	.popover__menu-item {
+
+		.site-selector__popover-item-details {
+			color: $gray-text-min;
+			display: block;
+			font-size: 13px;
+			font-weight: 400;
+			margin: 5px 0 0 0;
+		}
+
+		&.is-selected,
+		&:hover,
+		&:focus {
+			.site-selector__popover-item-details {
+				color: $white;
+			}
+		}
+	}
+}

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -213,6 +213,10 @@
 		color: $green-jetpack;
 	}
 
+	.popover__menu-separator {
+		margin: 4px 0;
+	}
+
 	.popover__menu-item {
 
 		.site-selector__popover-item-details {


### PR DESCRIPTION
> This PR is on-hold until we discuss a better way to offer this choice to users.

This PR adds a popover for new site selection.

Addresses https://github.com/Automattic/wp-calypso/issues/22315

Related: https://github.com/Automattic/wp-calypso/pull/23093

![image](https://user-images.githubusercontent.com/390760/37524858-099fdd0c-2923-11e8-983b-5702d258dcfa.png)

