### PR TITLE
Checkout: remove noticons

### DIFF
--- a/client/my-sites/checkout/checkout/credits-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credits-payment-box.jsx
@@ -11,6 +11,7 @@ import { some } from 'lodash';
 /**
  * Internal dependencies
  */
+import WordPressLogo from 'components/wordpress-logo';
 import PayButton from './pay-button';
 import PaymentBox from './payment-box';
 import TermsOfService from './terms-of-service';
@@ -28,6 +29,7 @@ class CreditsPaymentBox extends React.Component {
 		return (
 			<form onSubmit={ this.props.onSubmit }>
 				<div className="payment-box-section">
+					<WordPressLogo size={ 52 } />
 					<div className="checkout__payment-box-section-content">
 						<h6>{ this.props.translate( 'WordPress.com Credits' ) }</h6>
 

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -463,10 +463,9 @@
 			min-height: 91px;
 			padding: 20px 20px 20px 0;
 
-			&::before {
-				color: $blue-medium;
+			.wordpress-logo {
+				fill: $blue-medium;
 				margin: 0 10px;
-				@include noticon( '\f205', 60px );
 				@include breakpoint( '>660px' ) {
 					margin: 0 20px;
 				}

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -145,11 +145,6 @@
 		font-weight: 600;
 		opacity: 0.7;
 		text-transform: uppercase;
-
-		::after {
-			@include noticon( '\f470', (13 / 12) * 1em );
-			float: right;
-		}
 	}
 
 	.checkout__box-padding {


### PR DESCRIPTION
This removes noticon in 2 places:

1. Credits payment screen
2. Payment box

## 1 Credits payment screen

This is a screen used when a user can pay for something with credits. It's using a noticon to display the W logo. Now it uses the WordPressLogo component.

To test, add enough credits to purchase a plan, then go to checkout like you are purchasing a plan.

Before
![before](https://user-images.githubusercontent.com/618551/37221350-3354bb20-238f-11e8-8cae-12bd598e4a1b.png)


After
![after](https://user-images.githubusercontent.com/618551/37221352-35d448c0-238f-11e8-9ff7-d1f40ae01513.png)

## 2 Payment box

This is the normal payment screen where you input your CC info. The lock noticon is being applied to an h5 in `checkout__payment-box-container`. `checkout__payment-box-container` is only being used in [one place](https://github.com/Automattic/wp-calypso/blob/665da4a723d16a44111ca0a4affa0caefa2c2347/client/my-sites/checkout/checkout/payment-box.jsx#L109), and there is no h5, so I just removed the noticon. No visual changes.

![screen shot 2018-03-09 at 11 47 02 am](https://user-images.githubusercontent.com/618551/37221447-a72ba14e-238f-11e8-9299-2e898bcb05f0.png)



cc @shaunandrews