### PR TITLE
Fix multiple bottom borders for nested replies

### DIFF
--- a/client/my-sites/comments/comment-replies-list/index.jsx
+++ b/client/my-sites/comments/comment-replies-list/index.jsx
@@ -32,7 +32,10 @@ export class CommentRepliesList extends Component {
 
 		const repliesToShow = showAllReplies ? replies : take( replies, 5 );
 
-		const classes = classNames( { 'comment-replies-list': depth < 2 } );
+		const classes = classNames(
+			{ 'comment-replies-list': depth < 2 },
+			{ 'is-at-max-depth': depth >= 2 }
+		);
 
 		return (
 			<div className={ classes }>

--- a/client/my-sites/comments/comment-replies-list/index.jsx
+++ b/client/my-sites/comments/comment-replies-list/index.jsx
@@ -27,15 +27,13 @@ export class CommentRepliesList extends Component {
 		this.setState( ( { showAllReplies } ) => ( { showAllReplies: ! showAllReplies } ) );
 
 	render() {
+		const maxDepth = 2;
 		const { siteId, commentParentId, depth, replies, translate } = this.props;
 		const { showAllReplies } = this.state;
 
 		const repliesToShow = showAllReplies ? replies : take( replies, 5 );
 
-		const classes = classNames(
-			{ 'comment-replies-list': depth < 2 },
-			{ 'is-at-max-depth': depth >= 2 }
-		);
+		const classes = classNames( 'comment-replies-list', { 'is-nested': depth < maxDepth } );
 
 		return (
 			<div className={ classes }>
@@ -56,9 +54,10 @@ export class CommentRepliesList extends Component {
 				{ map( repliesToShow, ( { commentId } ) => (
 					<Comment
 						commentId={ commentId }
+						isPostView={ true }
+						isAtMaxDepth={ depth >= maxDepth }
 						key={ `comment-${ siteId }-${ commentParentId }-${ commentId }` }
 						refreshCommentData={ true }
-						isPostView={ true }
 					/>
 				) ) }
 			</div>

--- a/client/my-sites/comments/comment-replies-list/index.jsx
+++ b/client/my-sites/comments/comment-replies-list/index.jsx
@@ -54,8 +54,8 @@ export class CommentRepliesList extends Component {
 				{ map( repliesToShow, ( { commentId } ) => (
 					<Comment
 						commentId={ commentId }
-						isPostView={ true }
 						isAtMaxDepth={ depth >= maxDepth }
+						isPostView={ true }
 						key={ `comment-${ siteId }-${ commentParentId }-${ commentId }` }
 						refreshCommentData={ true }
 					/>

--- a/client/my-sites/comments/comment-replies-list/style.scss
+++ b/client/my-sites/comments/comment-replies-list/style.scss
@@ -2,7 +2,10 @@
 	margin-left: 56px;
 }
 
-// Show the box shadow for the first two 2 replies
-.comment-replies-list:nth-child(n+2) {
-	margin-bottom: 10px;
+.is-at-max-depth > .comment {
+	margin-bottom: 0px;
+}
+
+.is-at-max-depth > .card {
+	box-shadow: 0 -1px transparentize( $gray-lighten-20, .5 );
 }

--- a/client/my-sites/comments/comment-replies-list/style.scss
+++ b/client/my-sites/comments/comment-replies-list/style.scss
@@ -1,11 +1,5 @@
 .comment-replies-list {
-	margin-left: 56px;
-}
-
-.is-at-max-depth > .comment {
-	margin-bottom: 0px;
-}
-
-.is-at-max-depth > .card {
-	box-shadow: 0 -1px transparentize( $gray-lighten-20, .5 );
+	&.is-nested {
+		margin-left: 56px;
+	}
 }

--- a/client/my-sites/comments/comment-replies-list/style.scss
+++ b/client/my-sites/comments/comment-replies-list/style.scss
@@ -1,3 +1,8 @@
 .comment-replies-list {
 	margin-left: 56px;
 }
+
+// Show the box shadow for the first two 2 replies
+.comment-replies-list:nth-child(n+2) {
+	margin-bottom: 10px;
+}

--- a/client/my-sites/comments/comment-replies-list/style.scss
+++ b/client/my-sites/comments/comment-replies-list/style.scss
@@ -1,3 +1,4 @@
+/** @format */
 .comment-replies-list {
 	&.is-nested {
 		margin-left: 56px;

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -33,8 +33,9 @@ export class Comment extends Component {
 		postId: PropTypes.number,
 		commentId: PropTypes.number,
 		commentsListQuery: PropTypes.object,
-		isEditMode: PropTypes.bool,
+		isAtMaxDepth: PropTypes.bool,
 		isBulkMode: PropTypes.bool,
+		isEditMode: PropTypes.bool,
 		isPostView: PropTypes.bool,
 		isSelected: PropTypes.bool,
 		redirect: PropTypes.func,
@@ -151,6 +152,7 @@ export class Comment extends Component {
 			commentId,
 			commentIsPending,
 			commentsListQuery,
+			isAtMaxDepth,
 			isBulkMode,
 			isLoading,
 			isPostView,
@@ -162,6 +164,7 @@ export class Comment extends Component {
 		const { isEditMode, isReplyVisible } = this.state;
 
 		const classes = classNames( 'comment', {
+			'is-at-max-depth': isAtMaxDepth,
 			'is-bulk-mode': isBulkMode,
 			'is-edit-mode': isEditMode,
 			'is-placeholder': isLoading,

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -23,6 +23,11 @@
 	}
 }
 
+// Hide comment tree replies bottom box-shadow by removing the margin
+.card.comment .card.comment {
+	margin-bottom: 0px;
+}
+
 // `transition` here is applied with less specificity to avoid overwriting ReactCSSTransitionGroup's animation.
 .comment {
 	transition: margin 0.15s linear;

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -23,11 +23,6 @@
 	}
 }
 
-// Hide comment tree replies bottom box-shadow by removing the margin
-.card.comment .card.comment {
-	margin-bottom: 0px;
-}
-
 // `transition` here is applied with less specificity to avoid overwriting ReactCSSTransitionGroup's animation.
 .comment {
 	transition: margin 0.15s linear;

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -678,3 +678,12 @@
 		display: none;
 	}
 }
+
+// Nested comment at max depth
+
+.card.comment {
+	&.is-at-max-depth {
+		margin-bottom: 0px;
+		box-shadow: 0 -1px transparentize($gray-lighten-20, 0.5);
+	}
+}


### PR DESCRIPTION
## Summary
Remove duplicate bottom border for nested comment replies.

Fixes https://github.com/Automattic/wp-calypso/issues/20711

Before: https://user-images.githubusercontent.com/233601/33848602-07d4c518-de8d-11e7-98fa-649b0228ba04.png
After: https://cloudup.com/c9iraQWc8rr

## Testing
1. Start Calypso with `ENABLE_FEATURES=comments/management/threaded-view npm start`
2. Navigate to a comment post view.
3. The child comments should show a single bottom border.
