### PR TITLE
Plans: remove upgrade nudges for non-administrators

### DIFF
--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { overSome } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,7 +18,6 @@ import { getEditorPath } from 'state/ui/editor/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getNormalizedPost } from 'state/posts/selectors';
 import { getSite, isSingleUserSite } from 'state/sites/selectors';
-
 import { areAllSitesSingleUser, canCurrentUserEditPost } from 'state/selectors';
 import {
 	isSharePanelOpen,
@@ -28,6 +26,7 @@ import {
 } from 'state/ui/post-type-list/selectors';
 import { hideActiveSharePanel, togglePostSelection } from 'state/ui/post-type-list/actions';
 import { bumpStat } from 'state/analytics/actions';
+import { hasFeature } from 'state/sites/plans/selectors';
 import ExternalLink from 'components/external-link';
 import FormInputCheckbox from 'components/forms/form-checkbox';
 import PostTime from 'blocks/post-time';
@@ -39,10 +38,8 @@ import PostActionsEllipsisMenu from 'my-sites/post-type-list/post-actions-ellips
 import PostTypeSiteInfo from 'my-sites/post-type-list/post-type-site-info';
 import PostTypePostAuthor from 'my-sites/post-type-list/post-type-post-author';
 import { preload } from 'sections-helper';
-import { isBusiness, isEnterprise, isJetpackPremium } from 'lib/products-values';
+import { FEATURE_REPUBLICIZE } from 'lib/plans/constants';
 import { userCan } from 'lib/site/utils';
-
-const hasSeoSupportingPlan = overSome( isBusiness, isEnterprise, isJetpackPremium );
 
 function preloadEditor() {
 	preload( 'post-editor' );
@@ -253,7 +250,7 @@ export default connect(
 		const hasExpandedContent = isSharePanelOpen( state, globalId ) || false;
 
 		const site = getSite( state, siteId );
-		const supportsSEO = site && site.plan && hasSeoSupportingPlan( site.plan );
+		const supportsPublicize = site && site.plan && hasFeature( state, siteId, FEATURE_REPUBLICIZE );
 		const userCanManageSite = userCan( 'manage_options', site );
 
 		return {
@@ -266,7 +263,7 @@ export default connect(
 			hasExpandedContent,
 			isCurrentPostSelected: isPostSelected( state, globalId ),
 			multiSelectEnabled: isMultiSelectEnabled( state ),
-			showShareAction: supportsSEO || userCanManageSite,
+			showShareAction: userCanManageSite || supportsPublicize,
 		};
 	},
 	{

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -385,10 +385,6 @@ class SimplePaymentsDialog extends Component {
 		);
 	}
 
-	returnTrue() {
-		return true;
-	}
-
 	render() {
 		const {
 			showDialog,
@@ -446,7 +442,6 @@ class SimplePaymentsDialog extends Component {
 							) }
 							feature={ FEATURE_SIMPLE_PAYMENTS }
 							event="editor_simple_payments_modal_nudge"
-							shouldDisplay={ this.returnTrue }
 						/>
 					}
 					secondaryAction={

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -6,7 +6,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { partial } from 'lodash';
+import { overSome, partial } from 'lodash';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 
@@ -18,9 +18,14 @@ import Button from 'components/button';
 import SelectDropdown from 'components/select-dropdown';
 import DropdownItem from 'components/select-dropdown/item';
 import ClipboardButtonInput from 'components/clipboard-button-input';
+import { isBusiness, isEnterprise, isJetpackPremium } from 'lib/products-values';
+import { userCan } from 'lib/site/utils';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getSelectedSite } from 'state/ui/selectors';
 
 const possibleDevices = [ 'computer', 'tablet', 'phone' ];
+
+const hasSeoSupportingPlan = overSome( isBusiness, isEnterprise, isJetpackPremium );
 
 class PreviewToolbar extends Component {
 	static propTypes = {
@@ -169,6 +174,16 @@ class PreviewToolbar extends Component {
 	}
 }
 
-export default connect( null, {
+const mapStateToProps = ( state, { showSEO } ) => {
+	const site = getSelectedSite( state );
+	const supportsSEO = site && site.plan && hasSeoSupportingPlan( site.plan );
+	const userCanManageSite = userCan( 'manage_options', site );
+
+	return {
+		showSEO: showSEO && ( supportsSEO || userCanManageSite ),
+	};
+};
+
+export default connect( mapStateToProps, {
 	recordTracksEvent,
 } )( localize( PreviewToolbar ) );

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -6,7 +6,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { overSome, partial } from 'lodash';
+import { partial } from 'lodash';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 
@@ -18,14 +18,9 @@ import Button from 'components/button';
 import SelectDropdown from 'components/select-dropdown';
 import DropdownItem from 'components/select-dropdown/item';
 import ClipboardButtonInput from 'components/clipboard-button-input';
-import { isBusiness, isEnterprise, isJetpackPremium } from 'lib/products-values';
-import { userCan } from 'lib/site/utils';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getSelectedSite } from 'state/ui/selectors';
 
 const possibleDevices = [ 'computer', 'tablet', 'phone' ];
-
-const hasSeoSupportingPlan = overSome( isBusiness, isEnterprise, isJetpackPremium );
 
 class PreviewToolbar extends Component {
 	static propTypes = {
@@ -101,7 +96,9 @@ class PreviewToolbar extends Component {
 			translate,
 		} = this.props;
 
-		const selectedDevice = this.devices[ currentDevice ];
+		const selectedDevice = this.devices[
+			! showSEO && 'seo' === currentDevice ? 'computer' : currentDevice
+		];
 		const devicesToShow = showSEO ? possibleDevices.concat( 'seo' ) : possibleDevices;
 
 		return (
@@ -174,16 +171,4 @@ class PreviewToolbar extends Component {
 	}
 }
 
-const mapStateToProps = ( state, { showSEO } ) => {
-	const site = getSelectedSite( state );
-	const supportsSEO = site && site.plan && hasSeoSupportingPlan( site.plan );
-	const userCanManageSite = userCan( 'manage_options', site );
-
-	return {
-		showSEO: showSEO && ( supportsSEO || userCanManageSite ),
-	};
-};
-
-export default connect( mapStateToProps, {
-	recordTracksEvent,
-} )( localize( PreviewToolbar ) );
+export default connect( null, { recordTracksEvent } )( localize( PreviewToolbar ) );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
@@ -5,6 +5,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Children, cloneElement } from 'react';
+import { compact } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,20 +22,27 @@ import PostActionsEllipsisMenuView from './view';
 import PostActionsEllipsisMenuRestore from './restore';
 import PostActionsEllipsisMenuDuplicate from './duplicate';
 
-export default function PostActionsEllipsisMenu( { globalId, includeDefaultActions, children } ) {
+export default function PostActionsEllipsisMenu( {
+	globalId,
+	includeDefaultActions,
+	showShareAction,
+	children,
+} ) {
 	let actions = [];
 
 	if ( includeDefaultActions ) {
 		actions.push(
-			<PostActionsEllipsisMenuEdit key="edit" />,
-			<PostActionsEllipsisMenuView key="view" />,
-			<PostActionsEllipsisMenuStats key="stats" />,
-			<PostActionsEllipsisMenuComments key="comments" />,
-			<PostActionsEllipsisMenuPublish key="publish" />,
-			<PostActionsEllipsisMenuShare key="share" />,
-			<PostActionsEllipsisMenuRestore key="restore" />,
-			<PostActionsEllipsisMenuDuplicate key="duplicate" />,
-			<PostActionsEllipsisMenuTrash key="trash" />
+			...compact( [
+				<PostActionsEllipsisMenuEdit key="edit" />,
+				<PostActionsEllipsisMenuView key="view" />,
+				<PostActionsEllipsisMenuStats key="stats" />,
+				<PostActionsEllipsisMenuComments key="comments" />,
+				<PostActionsEllipsisMenuPublish key="publish" />,
+				showShareAction && <PostActionsEllipsisMenuShare key="share" />,
+				<PostActionsEllipsisMenuRestore key="restore" />,
+				<PostActionsEllipsisMenuDuplicate key="duplicate" />,
+				<PostActionsEllipsisMenuTrash key="trash" />,
+			] )
 		);
 	}
 
@@ -59,8 +67,10 @@ export default function PostActionsEllipsisMenu( { globalId, includeDefaultActio
 PostActionsEllipsisMenu.propTypes = {
 	globalId: PropTypes.string,
 	includeDefaultActions: PropTypes.bool,
+	showShareAction: PropTypes.bool,
 };
 
 PostActionsEllipsisMenu.defaultProps = {
 	includeDefaultActions: true,
+	showShareAction: true,
 };

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -25,6 +25,9 @@ import {
 	getSiteSlug,
 	getSiteOption,
 } from 'state/sites/selectors';
+import { hasFeature } from 'state/sites/plans/selectors';
+import { FEATURE_REPUBLICIZE } from 'lib/plans/constants';
+
 import versionCompare from 'lib/version-compare';
 
 const analyticsPageTitle = 'Sharing';
@@ -107,6 +110,20 @@ export const buttons = ( context, next ) => {
 	}
 
 	context.contentComponent = createElement( SharingButtons );
+
+	next();
+};
+
+export const canUserManageSharing = ( context, next ) => {
+	const { store } = context;
+	const state = store.getState();
+	const siteId = getSelectedSiteId( state );
+	const hasRepublicizeFeature = hasFeature( state, siteId, FEATURE_REPUBLICIZE );
+	const canUserManageOptions = canCurrentUser( state, siteId, 'manage_options' );
+
+	if ( ! hasRepublicizeFeature && ! canUserManageOptions ) {
+		page.redirect( '/stats' );
+	}
 
 	next();
 };

--- a/client/my-sites/sharing/index.js
+++ b/client/my-sites/sharing/index.js
@@ -10,7 +10,7 @@ import page from 'page';
  * Internal dependencies
  */
 import { jetpackModuleActive, navigation, sites, siteSelection } from 'my-sites/controller';
-import { buttons, connections, layout } from './controller';
+import { buttons, connections, layout, canUserManageSharing } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
@@ -20,6 +20,7 @@ export default function() {
 		siteSelection,
 		navigation,
 		jetpackModuleActive( 'publicize', false ),
+		canUserManageSharing,
 		connections,
 		layout,
 		makeLayout,

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -40,6 +40,7 @@ import {
 	isSiteAutomatedTransfer,
 	hasSitePendingAutomatedTransfer,
 } from 'state/selectors';
+import { hasFeature } from 'state/sites/plans/selectors';
 import {
 	getCustomizerUrl,
 	getSite,
@@ -49,6 +50,7 @@ import {
 	isSitePreviewable,
 } from 'state/sites/selectors';
 import { getStatsPathForTab } from 'lib/route';
+import { FEATURE_REPUBLICIZE } from 'lib/plans/constants';
 import { getAutomatedTransferStatus } from 'state/automated-transfer/selectors';
 import { transferStates } from 'state/automated-transfer/constants';
 import { itemLinkMatches } from './utils';
@@ -436,10 +438,17 @@ export class MySitesSidebar extends Component {
 	};
 
 	sharing() {
-		const { isJetpack, isSharingEnabledOnJetpackSite, path, site } = this.props;
+		const {
+			isJetpack,
+			isSharingEnabledOnJetpackSite,
+			path,
+			site,
+			canUserManageOptions,
+			hasRepublicizeFeature,
+		} = this.props;
 		const sharingLink = '/sharing' + this.props.siteSuffix;
 
-		if ( site && ! this.props.canUserPublishPosts ) {
+		if ( site && ! this.props.canUserPublishPosts && ! canUserManageOptions ) {
 			return null;
 		}
 
@@ -448,6 +457,10 @@ export class MySitesSidebar extends Component {
 		}
 
 		if ( isJetpack && ! isSharingEnabledOnJetpackSite ) {
+			return null;
+		}
+
+		if ( ! hasRepublicizeFeature && ! canUserManageOptions ) {
 			return null;
 		}
 
@@ -722,6 +735,7 @@ function mapStateToProps( state ) {
 		currentUser,
 		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
 		hasJetpackSites: hasJetpackSites( state ),
+		hasRepublicizeFeature: hasFeature( state, siteId, FEATURE_REPUBLICIZE ),
 		isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 		isJetpack,
 		isPreviewable: isSitePreviewable( state, selectedSiteId ),

--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -21,6 +21,7 @@ import { hasFeature } from 'state/sites/plans/selectors';
 import { getValidFeatureKeys } from 'lib/plans';
 import { isFreePlan } from 'lib/products-values';
 import TrackComponentView from 'lib/analytics/track-component-view';
+import { userCan } from 'lib/site/utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 
@@ -68,10 +69,14 @@ class UpgradeNudge extends React.Component {
 	};
 
 	shouldDisplay() {
-		const { feature, jetpack, planHasFeature, shouldDisplay, site } = this.props;
+		const { feature, jetpack, planHasFeature, shouldDisplay, site, userCanManageSite } = this.props;
 
 		if ( shouldDisplay ) {
 			return shouldDisplay();
+		}
+
+		if ( ! userCanManageSite ) {
+			return false;
 		}
 
 		if ( ! site || typeof site !== 'object' || typeof site.jetpack !== 'boolean' ) {
@@ -166,9 +171,12 @@ class UpgradeNudge extends React.Component {
 export default connect(
 	( state, ownProps ) => {
 		const siteId = getSelectedSiteId( state );
+		const site = getSelectedSite( state );
+
 		return {
-			site: getSelectedSite( state ),
+			site,
 			planHasFeature: hasFeature( state, siteId, ownProps.feature ),
+			userCanManageSite: userCan( 'manage_options', site ),
 		};
 	},
 	{ recordTracksEvent }


### PR DESCRIPTION
Fixes #20250 

This PR removes the upgrade nudge for non-administrators, and removes the _SEO & Social_ options from the devices menu on the `WebPreview` on the _Editor_ and on _View Site_. Also removes the _Sharing_ option on the _Post Actions_ menu on the _Posts_ list.

To test you need:

- Four test sites. Two _Free_ and two either _Premium_ or _Business_. Of those four, one _Free_ and one _Premium_ or _Business_ should have a service connected and _shared with all users_ of the site.
- A full admin user, and a Editor user on all four sites.

For the full admin user there should be no regressions. For the editor user, there should be no nudges, and following the same pattern of the sidebar menu, the _Sharing_ option should not be present if the user does not have the rights to set it up.
On the Post Editor, the sharing option should be present if either the user can add a connection, or of there's a connection enabled for that user.

| Section | Editor on Free Plan  | Editor on Business | Admin on Free Plan | Admin on Business |
| - | - | - | - | - |
| Add Payment Button | ![Add Payment Button](https://user-images.githubusercontent.com/233601/37220803-78d2e188-23a6-11e8-869e-8600199ae8af.png) | ![Add Payment Button](https://user-images.githubusercontent.com/233601/37220831-9809b400-23a6-11e8-9707-66f8cd9507b6.png) | ![Add Payment Button](https://user-images.githubusercontent.com/233601/37222104-c1667be0-23aa-11e8-9abc-ae56af077f86.png) | ![Add Payment Button](https://user-images.githubusercontent.com/233601/37222174-f1c257dc-23aa-11e8-87bd-6e4bcfea9557.png) |
| Insights | ![Insights](https://user-images.githubusercontent.com/233601/37220690-1a8a6cb8-23a6-11e8-9b9e-e5af52f91136.png) | ![Insights](https://user-images.githubusercontent.com/233601/37220729-3b9d88fe-23a6-11e8-9662-4272c5a9a7e4.png) | ![Insights](https://user-images.githubusercontent.com/233601/37222237-21e8df3a-23ab-11e8-9cdf-741d91a9a877.png) | ![Insights](https://user-images.githubusercontent.com/233601/37222275-34bc7b76-23ab-11e8-991c-415189190675.png) |
| _Search & Social_ on View Site | ![Search & Social](https://user-images.githubusercontent.com/233601/37220906-d6587886-23a6-11e8-9961-787d50eb4f80.png) | ![Search & Social](https://user-images.githubusercontent.com/233601/37220955-03cd492c-23a7-11e8-8646-ad4b3fc9fc69.png) | ![Search & Social](https://user-images.githubusercontent.com/233601/37222360-8012ee5c-23ab-11e8-872e-db0515822096.png) | ![Search & Social](https://user-images.githubusercontent.com/233601/37222392-96ba092e-23ab-11e8-9748-b45a577ebfb9.png) |
| _Search & Social_ on Post Preview | ![Search & Social](https://user-images.githubusercontent.com/233601/37221036-3e049960-23a7-11e8-833e-7da4f0227803.png) | ![Search & Social](https://user-images.githubusercontent.com/233601/37221090-765eff4e-23a7-11e8-8472-5b9e30047ce2.png) | ![Search & Social](https://user-images.githubusercontent.com/233601/37222433-cbdec9be-23ab-11e8-8d7f-11519c509aac.png) | ![Search & Social](https://user-images.githubusercontent.com/233601/37222470-f7f29742-23ab-11e8-88ce-bbe402300c21.png)
| Blog Posts List | ![screen shot 2018-04-10 at 11 18 26](https://user-images.githubusercontent.com/233601/38562577-4cfe27f6-3cb1-11e8-8751-a47d66bab3b7.png) | ![screen shot 2018-04-10 at 11 19 30](https://user-images.githubusercontent.com/233601/38562604-591f3822-3cb1-11e8-8655-aa211f70dbad.png) | ![screen shot 2018-04-10 at 11 23 37](https://user-images.githubusercontent.com/233601/38562810-cd4d69e4-3cb1-11e8-89e9-790e7d546a0b.png) | ![screen shot 2018-04-10 at 11 24 15](https://user-images.githubusercontent.com/233601/38562822-d54b1790-3cb1-11e8-9e2f-30fb7796db78.png) |

