### PR TITLE
Sidebar: Button: Allow overriding target to treat as internal

### DIFF
--- a/client/layout/sidebar/button.jsx
+++ b/client/layout/sidebar/button.jsx
@@ -19,6 +19,11 @@ class SidebarButton extends React.Component {
 		href: PropTypes.string,
 		onClick: PropTypes.func,
 		preloadSectionName: PropTypes.string,
+		forceTargetInternal: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		forceTargetInternal: false,
 	};
 
 	_preloaded = false;
@@ -28,6 +33,14 @@ class SidebarButton extends React.Component {
 			this._preloaded = true;
 			preload( this.props.preloadSectionName );
 		}
+	};
+
+	getTarget = () => {
+		if ( this.props.forceTargetInternal ) {
+			return null;
+		}
+
+		return isExternal( this.props.href ) ? '_blank' : null;
 	};
 
 	render() {
@@ -40,7 +53,7 @@ class SidebarButton extends React.Component {
 				rel={ isExternal( this.props.href ) ? 'external' : null }
 				onClick={ this.props.onClick }
 				href={ this.props.href }
-				target={ isExternal( this.props.href ) ? '_blank' : null }
+				target={ this.getTarget() }
 				className="sidebar__button"
 				onMouseEnter={ this.preload }
 				data-tip-target={ this.props.tipTarget }

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -227,6 +227,7 @@ export class MySitesSidebar extends Component {
 					onClick={ this.trackSidebarButtonClick( 'customize' ) }
 					href={ this.props.customizeUrl }
 					preloadSectionName="customize"
+					forceTargetInternal
 				>
 					{ this.props.translate( 'Customize' ) }
 				</SidebarButton>


### PR DESCRIPTION
Fixes #15301 

In #15301, @MichaelArestad reported an issue where attempting to customize a theme for a Jetpack site would result in 2 tabs of Calypso running. 😞 

The issue here is that we opened the customizer in a separate tab since it's not hosted on WordPress.com, then when the user exited out of the customizer, they were redirected to WordPress.com in that second tab.

Since the customizer redirects the user back to WordPress.com after saving changes and exiting, it seems like we should probably just treat this similarly to an internal link, as far as the `target` property is concerned.

This PR adds the `forceTargetInternal` prop to the `SidebarButton` component. When the value of `forceTargetInternal` is truthy, we will set the `target` prop of the sidebar button to null so that we open the link in the current tab and/or window.

To test:

- Checkout branch
- Ensure that you have a connected Jetpack site
- Go to `/stats/day/$site` where `$site` is the slug of your Jetpack site
- Click the `customize` button in the sidebar
- Ensure that the customizer loads in the current tab/window
- At this point, I changed the redirect in the url from `calypso.localhost:3000` to `wordpress.com`. The customizer didn't like redirecting back to a local URL
- Exit the customizer 
- Ensure you end up on WordPress.com

cc @samouri for a review since Github suggested you. 😄 