### PR TITLE
Pages: Remove noticon css for placeholder

### DIFF
--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -9,15 +9,6 @@
 		background-color: $gray-lighten-30;
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
-
-	.is-placeholder {
-		.noticon {
-			color: transparent;
-			background-color: $gray-lighten-30;
-			animation: loading-fade 1.6s ease-in-out infinite;
-			opacity: 0.3;
-		}
-	}
 }
 
 .pages__page-list-header {


### PR DESCRIPTION
Currently there is a reference to noticon in the pages list css. This `.noticon` class in the css is not being used because we know there there are no references to noticon in the jsx of wp-calypso (only scss).

No visual changes.

To test, view the loading state of /pages.

cc @shaunandrews 