### PR TITLE
Sharing: remove noticons

### DIFF
--- a/client/my-sites/sharing/connections/connection.jsx
+++ b/client/my-sites/sharing/connections/connection.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -124,6 +125,7 @@ class SharingConnection extends Component {
 		) {
 			return (
 				<a onClick={ this.refresh } className="sharing-connection__account-action reconnect">
+					<Gridicon icon="notice" size={ 18 } />
 					{ this.props.translate( 'Reconnect' ) }
 				</a>
 			);

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -288,18 +288,18 @@
 	}
 }
 
-.sharing-service__glyph.noticon {
-	color: $white;
-	font-size: 32px;
-	margin: 0;
-	line-height: 1;
-	width: auto;
-	height: auto;
-
-	@include breakpoint( "<660px" ) {
-		font-size: 16px;
-	}
-}
+// .sharing-service__glyph.noticon {
+// 	color: $white;
+// 	font-size: 32px;
+// 	margin: 0;
+// 	line-height: 1;
+// 	width: auto;
+// 	height: auto;
+//
+// 	@include breakpoint( "<660px" ) {
+// 		font-size: 16px;
+// 	}
+// }
 
 @mixin sharing-service( $name, $color ) {
 	.sharing-service.#{ $name } .sharing-service__icon {
@@ -521,11 +521,6 @@
 
 	.sharing-buttons-add {
 		float: right;
-
-		.noticon {
-			font-size: 32px;
-			margin: 7px -18px -2px 0  #{"/*rtl:ignore*/"};
-		}
 
 		&.inactive {
 			opacity: 0.3;

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -288,19 +288,6 @@
 	}
 }
 
-// .sharing-service__glyph.noticon {
-// 	color: $white;
-// 	font-size: 32px;
-// 	margin: 0;
-// 	line-height: 1;
-// 	width: auto;
-// 	height: auto;
-//
-// 	@include breakpoint( "<660px" ) {
-// 		font-size: 16px;
-// 	}
-// }
-
 @mixin sharing-service( $name, $color ) {
 	.sharing-service.#{ $name } .sharing-service__icon {
 		background: $color;

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -703,20 +703,10 @@
 		display: inline-flex;
 	}
 
-	&.is-edit::before {
-		@include noticon( '\f411', 16px );
-		margin-right: 4px;
-	}
-
 	&:disabled {
 		cursor: default;
 		border-color: $gray-lighten-30;
 		color: $gray-lighten-30;
-	}
-
-	&.is-add::before {
-		@include noticon( '\f510', 16px );
-		margin-right: 4px;
 	}
 
 	&.is-top::after,

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -474,9 +474,10 @@
 .sharing-connection__account-action.reconnect {
 	color: $alert-yellow;
 
-	&:before {
-		@include noticon( '\f414', 16px );
-		margin-right: 8px;
+	.gridicon {
+		margin-right: 4px;
+		position: relative;
+			top: 3px;
 	}
 }
 

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -398,10 +398,6 @@
 	width: 36px;
 	border: 1px solid $gray-light;
 	color: white;
-
-	&.is-fallback::before {
-		@include noticon( '\f304', 40px );
-	}
 }
 
 .sharing-connection__account-status {


### PR DESCRIPTION
This removes several noticons in the sharing section:

- in sharing/buttons: pencil icon (unused, **no visual changes**)
- in sharing/buttons: add icon (unused, **no visual changes**)
- in sharing: warning icon for Reconnect button
- in sharing: user icon for fallback avatar

## warning icon for Reconnect button

Before
![screen shot 2018-03-09 at 2 53 10 pm](https://user-images.githubusercontent.com/618551/37229928-570a85b0-23ab-11e8-887c-3e37b884e622.png)


After
![screen shot 2018-03-09 at 2 52 35 pm](https://user-images.githubusercontent.com/618551/37229932-5e723e4c-23ab-11e8-95a3-36e9dbc35117.png)

## user icon for fallback avatar

client/my-sites/sharing/connections/connection.jsx

Honestly, I did not know how to test this, but I just manually added the classes in the web inspector. I noticed that the icon was not even visible because it was a white icon on a white background. So, I just removed it.

cc @shaunandrews 