### PR TITLE
Reader: Move up Combined Cards text

### DIFF
--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -53,6 +53,7 @@
 	display: block;
 	font-size: 17px;
 	font-weight: 700;
+	line-height: 1.2;
 	max-height: 16px * 1.6;
 	padding-left: 1px;
 	position: relative;


### PR DESCRIPTION
Small fix to Combined Cards. Just moving text up a bit for better alignment.

**Before:**
![screenshot 2018-03-09 13 58 00](https://user-images.githubusercontent.com/4924246/37232029-2d4788c6-23a2-11e8-9854-3f779970c3da.png)

**After:**
![screenshot 2018-03-09 13 58 06](https://user-images.githubusercontent.com/4924246/37232025-27d6c294-23a2-11e8-8be0-7a98ba8b60ac.png)
