### PR TITLE
Reader: Fix blur in sidebar item

### DIFF
--- a/client/reader/sidebar/_style.scss
+++ b/client/reader/sidebar/_style.scss
@@ -39,7 +39,7 @@
 		}
 
 		.sidebar-streams__team {
-			margin-top: -1px; // Removes extra top border in team subs for <480px
+			border-top: 0;
 		}
 	}
 


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/15983

**Before:**
![screenshot 2018-03-09 14 31 46](https://user-images.githubusercontent.com/4924246/37233175-0148be7a-23a7-11e8-877f-37d38dbe8ee9.png)

**After:**
![screenshot 2018-03-09 14 33 59](https://user-images.githubusercontent.com/4924246/37233176-0164aefa-23a7-11e8-9d45-3aa761bbd2ab.png)

On mobile, nothing seems amiss:
![screenshot 2018-03-09 14 35 29](https://user-images.githubusercontent.com/4924246/37233224-3171ad1e-23a7-11e8-820c-3ffa00ccab6d.png)

