### PR TITLE
Accessibility: Add the navigation role to the sidebar

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -135,7 +135,7 @@ const Layout = createReactClass( {
 						forcePinned={ 'post' === this.props.section.name }
 					/>
 
-					<div id="secondary" className="layout__secondary">
+					<div id="secondary" className="layout__secondary" role="navigation">
 						{ this.props.secondary }
 					</div>
 					<div id="primary" className="layout__primary">


### PR DESCRIPTION
This PR adds the "navigation" [landmark role](https://www.w3.org/TR/wai-aria-1.1/#landmark_roles) to the sidebar container, which will let screen reader users navigate directly to that using the key shortcut for their screen reader. Landmark navigation is common, and we already have partial support by using the `main` tag for our content (this has an implicit main role), and the masterbar is considered a banner by using the `header` tag. ([see the HTML5 -> role mappings table on this page](https://dequeuniversity.com/assets/html/jquery-summit/html5/slides/landmarks.html))

You can now navigate by landmarks and see the "navigation" landmark:

![VoiceOver landmarks menu, with banner, navigation, and main](https://user-images.githubusercontent.com/541093/37233071-be5b4736-23bf-11e8-80b9-75815d584f63.png)

**To test**

- Nothing visual should change on any page
- On any page, [turn on VoiceOver](https://webaim.org/articles/voiceover/) and hit CTRL+OPT+U and navigate to the landmarks menu with arrow keys.
- You should hear "navigation" as an option, and selecting it will put your focus into the sidebar.

@alisterscott You're the person github suggested review this, feel free to tag anyone else if you want 🙂 