### PR TITLE
Accessibility: Announce global notices to screen reader users

### DIFF
--- a/client/components/global-notices/docs/example.jsx
+++ b/client/components/global-notices/docs/example.jsx
@@ -44,6 +44,21 @@ class GlobalNotices extends Component {
 		}
 	}
 
+	showA11yNotice = () => {
+		const message = (
+			<span>
+				This is a notice with an action in the text, for example
+				<a href="#">this is a link.</a>
+			</span>
+		);
+		const spokenMessage = 'This is screen-reader only notice text';
+		if ( this.state.useState ) {
+			this.props.createNotice( 'is-success', message, { spokenMessage } );
+		} else {
+			notices[ type ]( message, { spokenMessage } );
+		}
+	};
+
 	render() {
 		return (
 			<div>
@@ -57,6 +72,15 @@ class GlobalNotices extends Component {
 					<Button onClick={ this.showInfoNotice }>Show info notice</Button>
 					<Button onClick={ this.showWarningNotice }>Show warning notice</Button>
 				</ButtonGroup>
+
+				<hr aria-hidden />
+				<p>
+					In some cases, we want to use a different string for the visual text & what is announced
+					for screen reader users. For example, a notice with an action in the text might be
+					disruptive to the screen reader's focus flow. Instead, we can pass a simple string to
+					<code>spokenMessage</code>.
+				</p>
+				<Button onClick={ this.showA11yNotice }>Show accessible notice</Button>
 			</div>
 		);
 	}

--- a/client/components/notice/announcement.js
+++ b/client/components/notice/announcement.js
@@ -1,0 +1,39 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import ReactDOM from 'react-dom';
+
+export class NoticeAnnouncement extends Component {
+	static defaultProps = {
+		spokenMessage: null,
+		status: null,
+		text: null,
+	};
+
+	static propTypes = {
+		spokenMessage: PropTypes.string,
+		status: PropTypes.oneOf( [ 'is-error', 'is-info', 'is-success', 'is-warning', 'is-plain' ] ),
+		text: PropTypes.oneOfType( [
+			PropTypes.arrayOf( PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ) ),
+			PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
+		] ),
+	};
+
+	constructor( props ) {
+		super( props );
+		this.container = document.getElementById( 'screen-reader-notice' );
+	}
+
+	render() {
+		// @TODO use status to indicate assertiveness
+		const { text, spokenMessage } = this.props;
+		const message = spokenMessage || text;
+
+		return ReactDOM.createPortal( message, this.container );
+	}
+}
+
+export default NoticeAnnouncement;

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -12,6 +12,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+import { NoticeAnnouncement } from './announcement';
 import Button from 'components/button';
 
 export class Notice extends Component {
@@ -101,6 +102,7 @@ export class Notice extends Component {
 
 		return (
 			<div className={ classes }>
+				<NoticeAnnouncement { ...this.props } />
 				<span className="notice__icon-wrapper">
 					<Gridicon className="notice__icon" icon={ icon || this.getIcon() } size={ 24 } />
 				</span>

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -109,11 +109,13 @@ export class Notice extends Component {
 				</span>
 				{ text ? children : null }
 				{ showDismiss && (
-					<Button borderless className="notice__dismiss" onClick={ onDismissClick }>
+					<Button
+						borderless
+						className="notice__dismiss"
+						onClick={ onDismissClick }
+						aria-label={ translate( 'Dismiss' ) }
+					>
 						<Gridicon icon="cross" size={ 24 } />
-						<span className="notice__screen-reader-text screen-reader-text">
-							{ translate( 'Dismiss' ) }
-						</span>
 					</Button>
 				) }
 			</div>

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -1,15 +1,18 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
 
 export class Notice extends Component {
 	static defaultProps = {
@@ -106,12 +109,12 @@ export class Notice extends Component {
 				</span>
 				{ text ? children : null }
 				{ showDismiss && (
-					<span tabIndex="0" className="notice__dismiss" onClick={ onDismissClick }>
+					<Button borderless className="notice__dismiss" onClick={ onDismissClick }>
 						<Gridicon icon="cross" size={ 24 } />
 						<span className="notice__screen-reader-text screen-reader-text">
 							{ translate( 'Dismiss' ) }
 						</span>
-					</span>
+					</Button>
 				) }
 			</div>
 		);

--- a/client/components/notice/notice-action.jsx
+++ b/client/components/notice/notice-action.jsx
@@ -8,6 +8,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'gridicons';
 
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+
 export default class extends React.Component {
 	static displayName = 'NoticeAction';
 
@@ -24,6 +29,7 @@ export default class extends React.Component {
 
 	render() {
 		const attributes = {
+			borderless: true,
 			className: 'notice__action',
 			href: this.props.href,
 			onClick: this.props.onClick,
@@ -35,11 +41,11 @@ export default class extends React.Component {
 		}
 
 		return (
-			<a { ...attributes }>
+			<Button { ...attributes }>
 				<span>{ this.props.children }</span>
 				{ this.props.icon && <Gridicon icon={ this.props.icon } size={ 24 } /> }
 				{ this.props.external && <Gridicon icon="external" size={ 24 } /> }
-			</a>
+			</Button>
 		);
 	}
 }

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -140,7 +140,7 @@
 }
 
 // "X" for dismissing a notice
-.notice__dismiss {
+.button.notice__dismiss {
 	flex-shrink: 0;
 	padding: 12px;
 	cursor: pointer;
@@ -149,6 +149,7 @@
 	.gridicon {
 		width: 18px;
 		height: 18px;
+		top: -2px;
 	}
 
 	@include breakpoint( ">480px" ) {
@@ -172,7 +173,7 @@
 }
 
 // specificity for general `a` elements within notice is too great
-a.notice__action {
+.button.notice__action {
 	cursor: pointer;
 	font-size: 12px;
 	font-weight: 400;
@@ -202,7 +203,8 @@ a.notice__action {
 		color: $gray-lighten-10;
 	}
 
-	&:hover {
+	&:hover,
+	&:focus {
 		color: $white;
 	}
 
@@ -261,7 +263,7 @@ a.notice__action {
 		}
 	}
 
-	a.notice__action {
+	.button.notice__action {
 		background: transparent;
 		display: inline-block;
 		margin: 0;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -112,6 +112,8 @@ const Layout = createReactClass( {
 				'is-active': this.props.isLoading,
 			} );
 
+		const screenReaderClass = 'screen-reader-text';
+
 		return (
 			<div className={ sectionClass }>
 				<DocumentHead />
@@ -130,13 +132,12 @@ const Layout = createReactClass( {
 				{ this.props.isOffline && <OfflineStatus /> }
 				<div id="content" className="layout__content">
 					{ config.isEnabled( 'jitms' ) && <JITM /> }
-					<div aria-live="assertive">
-						<GlobalNotices
-							id="notices"
-							notices={ notices.list }
-							forcePinned={ 'post' === this.props.section.name }
-						/>
-					</div>
+					<div aria-live="assertive" id="screen-reader-notice" className={ screenReaderClass } />
+					<GlobalNotices
+						id="notices"
+						notices={ notices.list }
+						forcePinned={ 'post' === this.props.section.name }
+					/>
 
 					<div id="secondary" className="layout__secondary" role="navigation">
 						{ this.props.secondary }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -130,11 +130,13 @@ const Layout = createReactClass( {
 				{ this.props.isOffline && <OfflineStatus /> }
 				<div id="content" className="layout__content">
 					{ config.isEnabled( 'jitms' ) && <JITM /> }
-					<GlobalNotices
-						id="notices"
-						notices={ notices.list }
-						forcePinned={ 'post' === this.props.section.name }
-					/>
+					<div aria-live="assertive">
+						<GlobalNotices
+							id="notices"
+							notices={ notices.list }
+							forcePinned={ 'post' === this.props.section.name }
+						/>
+					</div>
 
 					<div id="secondary" className="layout__secondary" role="navigation">
 						{ this.props.secondary }

--- a/client/state/notices/actions.js
+++ b/client/state/notices/actions.js
@@ -28,6 +28,7 @@ export function createNotice( status, text, options = {} ) {
 		isPersistent: options.isPersistent || false,
 		displayOnNextPage: options.displayOnNextPage || false,
 		status: status,
+		spokenMessage: '',
 		text: text,
 		button: options.button,
 		href: options.href,


### PR DESCRIPTION
This PR adds a wrapper div around the global notice section, which tells screen readers that this is a live-updated section of the page. This means the screen reader will interrupt and announce when a notice is displayed. Currently, notices are "invisible" to screen readers.

This also updates the action & dismiss buttons on notices to use `Button`, which makes them properly keyboard-accessible. There should be no visual change, though.

Before:
![current](https://user-images.githubusercontent.com/541093/37232948-385f1ed2-23bf-11e8-8637-7b52c3da8b81.png)

After:
![updated](https://user-images.githubusercontent.com/541093/37232947-384eec60-23bf-11e8-9332-036c5fde4c50.png)

The keyboard interaction here needs some ideas - currently the user has to back-tab all the way up to the notice in order to get to the notice actions. We probably don't want to pull focus away from what the user is doing just because there's a notice, but it might be good to have some kind of shortcut into the notice… This would be for sighted keyboard users, so relying on the workaround in my testing instructions wouldn't be ideal.

To test:

- Trigger a notice on some page - save site settings, moderate a comment, etc
- The notice should appear as normal
- Now [turn on VoiceOver](https://webaim.org/articles/voiceover/), and save a setting, listen for the notice text to be read to you
- If the text has an action, you can open the form controls navigation in VoiceOver (CTRL+OPT+U, arrow-key to get to that menu), and you should now see the notice action as a button in this list.
- Select it, and then hit enter (or space) on the notice action, or tab to the dismiss and trigger that.
- Whichever you picked, that action should work as expected