### PR TITLE
Reader: Fix Back and Tag header overlap if Follow button has not loaded

### DIFF
--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -10,6 +10,7 @@
 .tag-stream__header-follow {
 	display: flex;
 	justify-content: flex-end;
+	min-height: 20px;
 }
 
 .tag-stream__header .follow-button {


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/13427

**Before:**
![screenshot 2018-03-09 14 57 05](https://user-images.githubusercontent.com/4924246/37233966-3d5be39e-23aa-11e8-89ac-35e1e77de79e.png)

**After:**
![screenshot 2018-03-09 14 57 43](https://user-images.githubusercontent.com/4924246/37233967-3d7a62b0-23aa-11e8-9b5e-e85f078050cb.png)

@bluefuton I'm unsure how to repro this, but what I did was basically just temporarily remove the Follow button from the code.
