### PR TITLE
PostRevisions: Filter minor revisions from the revisions history

### DIFF
--- a/client/post-editor/editor-revisions/index.jsx
+++ b/client/post-editor/editor-revisions/index.jsx
@@ -1,4 +1,5 @@
 /** @format */
+
 /**
  * External dependencies
  */
@@ -13,8 +14,8 @@ import { flow, get } from 'lodash';
  */
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import {
-	getPostRevisions,
-	getPostRevisionsComparisons,
+	getPostRevisionsMajor,
+	getPostRevisionsComparisonsMajor,
 	getPostRevisionsAuthorsId,
 	getPostRevisionsSelectedRevisionId,
 } from 'state/selectors';
@@ -91,9 +92,9 @@ export default flow(
 			const postId = getEditorPostId( state );
 			const siteId = getSelectedSiteId( state );
 
-			const revisions = getPostRevisions( state, siteId, postId );
+			const revisions = getPostRevisionsMajor( state, siteId, postId );
 			const selectedRevisionId = getPostRevisionsSelectedRevisionId( state );
-			const comparisons = getPostRevisionsComparisons( state, siteId, postId );
+			const comparisons = getPostRevisionsComparisonsMajor( state, siteId, postId );
 			const selectedDiff = get( comparisons, [ selectedRevisionId, 'diff' ], {} );
 
 			return {

--- a/client/state/selectors/get-post-revisions-comparisons-major.js
+++ b/client/state/selectors/get-post-revisions-comparisons-major.js
@@ -1,0 +1,37 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { forEach, get, isEmpty, pickBy } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import { getPostRevisionsMajor, getPostRevisionsComparisons } from 'state/selectors';
+
+const getPostRevisionsComparisonsMajor = createSelector(
+	( state, siteId, postId ) => {
+		const majorRevisions = getPostRevisionsMajor( state, siteId, postId );
+		const comparisons = getPostRevisionsComparisons( state, siteId, postId );
+
+		const majorComparisons = pickBy( comparisons, comparison => {
+			const totals = get( comparison, [ 'diff', 'totals' ] );
+			return ! isEmpty( totals );
+		} );
+
+		forEach( majorRevisions, ( revision, i ) => {
+			if ( ! revision.id ) {
+				return;
+			}
+			majorComparisons[ revision.id ].nextRevisionId = get( majorRevisions, [ i - 1, 'id' ] );
+			majorComparisons[ revision.id ].prevRevisionId = get( majorRevisions, [ i + 1, 'id' ] );
+		} );
+
+		return majorComparisons;
+	},
+	state => [ state.posts.revisions.diffs ]
+);
+
+export default getPostRevisionsComparisonsMajor;

--- a/client/state/selectors/get-post-revisions-comparisons.js
+++ b/client/state/selectors/get-post-revisions-comparisons.js
@@ -1,4 +1,5 @@
 /** @format */
+
 /**
  * External dependencies
  */

--- a/client/state/selectors/get-post-revisions-major.js
+++ b/client/state/selectors/get-post-revisions-major.js
@@ -1,0 +1,29 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { filter, get, isEmpty } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import { getPostRevisions, getPostRevisionsComparisons } from 'state/selectors';
+
+const getPostRevisionsMajor = createSelector(
+	( state, siteId, postId ) => {
+		const revisions = getPostRevisions( state, siteId, postId );
+		const comparisons = getPostRevisionsComparisons( state, siteId, postId );
+
+		const majorRevisions = filter( revisions, revision => {
+			const totals = get( comparisons, [ revision.id, 'diff', 'totals' ] );
+			return ! isEmpty( totals );
+		} );
+
+		return majorRevisions;
+	},
+	state => [ state.posts.revisions.diffs ]
+);
+
+export default getPostRevisionsMajor;

--- a/client/state/selectors/get-post-revisions.js
+++ b/client/state/selectors/get-post-revisions.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import { get, orderBy, values } from 'lodash';
 
 /**

--- a/client/state/selectors/test/get-post-revisions-comparisons-major.js
+++ b/client/state/selectors/test/get-post-revisions-comparisons-major.js
@@ -1,0 +1,136 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import getPostRevisionsComparisonsMajor from 'state/selectors/get-post-revisions-comparisons-major';
+
+describe( 'getPostRevisionsComparisonsMajor', () => {
+	test( 'should return an empty object if there are no revisions in the state for `siteId, postId`', () => {
+		expect(
+			getPostRevisionsComparisonsMajor(
+				{
+					posts: {
+						revisions: {
+							12345678: {
+								10: {
+									revisions: {},
+								},
+							},
+						},
+					},
+				},
+				12345678,
+				10
+			)
+		).to.eql( {} );
+	} );
+
+	test(
+		'should return a map of revision id to its valid (sequential) comparisons for `siteId, postId`,' +
+			' omitting revisions with empty diff totals',
+		() => {
+			const selection = getPostRevisionsComparisonsMajor(
+				{
+					posts: {
+						revisions: {
+							diffs: {
+								12345678: {
+									10: {
+										'0:13': {
+											diff: {
+												post_content: [ { op: 'add', value: 'older content' } ],
+												post_title: [ { op: 'add', value: 'post title' } ],
+												totals: { add: 4 },
+											},
+											from: 0,
+											to: 13,
+										},
+										'13:22': {
+											diff: {
+												post_content: [ { op: 'copy', value: 'older content' } ],
+												post_title: [ { op: 'copy', value: 'post title' } ],
+												totals: {},
+											},
+											from: 13,
+											to: 22,
+										},
+										'22:25': {
+											diff: {
+												post_content: [
+													{ op: 'copy', value: 'older' },
+													{ op: 'del', value: ' content' },
+												],
+												post_title: [ { op: 'copy', value: 'post title' } ],
+												totals: { del: 1 },
+											},
+											from: 22,
+											to: 25,
+										},
+										revisions: {
+											13: {
+												post_date_gmt: '2017-11-15 18:13:49Z',
+												post_modified_gmt: '2017-11-15 18:13:49Z',
+												post_author: '20416304',
+												id: 13,
+												post_content: 'older content',
+												post_excerpt: '',
+												post_title: 'post title',
+											},
+											22: {
+												post_date_gmt: '2017-12-13 00:12:10Z',
+												post_modified_gmt: '2017-12-13 00:12:10Z',
+												post_author: '20416304',
+												id: 22,
+												post_content: 'older content',
+												post_excerpt: '',
+												post_title: 'post title',
+											},
+											25: {
+												post_date_gmt: '2017-12-19 02:24:09Z',
+												post_modified_gmt: '2017-12-19 02:24:09Z',
+												post_author: '20830298',
+												id: 25,
+												post_content: 'older',
+												post_excerpt: '',
+												post_title: 'post title',
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				12345678,
+				10
+			);
+
+			expect( selection ).to.eql( {
+				13: {
+					diff: {
+						post_content: [ { op: 'add', value: 'older content' } ],
+						post_title: [ { op: 'add', value: 'post title' } ],
+						totals: { add: 4 },
+					},
+					nextRevisionId: 25,
+					prevRevisionId: undefined,
+				},
+				25: {
+					diff: {
+						post_content: [ { op: 'copy', value: 'older' }, { op: 'del', value: ' content' } ],
+						post_title: [ { op: 'copy', value: 'post title' } ],
+						totals: { del: 1 },
+					},
+					nextRevisionId: undefined,
+					prevRevisionId: 13,
+				},
+			} );
+		}
+	);
+} );

--- a/client/state/selectors/test/get-post-revisions-major.js
+++ b/client/state/selectors/test/get-post-revisions-major.js
@@ -1,0 +1,223 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import getPostRevisionsMajor from 'state/selectors/get-post-revisions-major';
+
+describe( 'getPostRevisionsMajor', () => {
+	test( 'should return an empty array if there are no revisions in the state for `siteId, postId`', () => {
+		expect(
+			getPostRevisionsMajor(
+				{
+					posts: {
+						revisions: {
+							12345678: {
+								10: {
+									revisions: {},
+								},
+							},
+						},
+					},
+				},
+				12345678,
+				10
+			)
+		).to.eql( [] );
+	} );
+
+	test(
+		'should return a sorted array of revisions,' +
+			' excluding revisions with no changes to post_title or post_content',
+		() => {
+			expect(
+				getPostRevisionsMajor(
+					{
+						posts: {
+							revisions: {
+								diffs: {
+									12345678: {
+										10: {
+											revisions: {
+												168: {
+													post_date_gmt: '2017-12-12 18:24:37Z',
+													post_modified_gmt: '2017-12-12 18:24:37Z',
+													post_author: '20416304',
+													id: 168,
+													post_content: 'I must here speak by theory alone.',
+													post_excerpt: '',
+													post_title: 'In my eyes it bore a livelier image of the spirit',
+												},
+												169: {
+													post_date_gmt: '2017-12-14 18:24:37Z',
+													post_modified_gmt: '2017-12-14 18:24:37Z',
+													post_author: '20416304',
+													id: 169,
+													post_content: 'I must here speak by theory alone.',
+													post_excerpt: '',
+													post_title: 'In my eyes it bore a livelier image of the spirit',
+												},
+												170: {
+													post_date_gmt: '2018-01-02 07:01:19Z',
+													post_modified_gmt: '2018-01-02 07:01:19Z',
+													post_author: '20416304',
+													id: 170,
+													post_content: 'I must here speak by theory.',
+													post_excerpt: '',
+													post_title: 'In my eyes it bore a livelier image of the spirit',
+												},
+												172: {
+													post_date_gmt: '2018-01-03 09:01:00Z',
+													post_modified_gmt: '2018-01-03 09:01:00Z',
+													post_author: '20416304',
+													id: 172,
+													post_content: 'I must here speak by theory.',
+													post_excerpt: '',
+													post_title:
+														'In my eyes it bore a livelier and fuller image of the spirit',
+												},
+											},
+											'0:168': {
+												from: 0,
+												to: 168,
+												diff: {
+													post_content: [
+														{
+															op: 'add',
+															value: 'I must here speak by theory alone.',
+														},
+													],
+													post_title: [
+														{
+															op: 'add',
+															value: 'In my eyes it bore a livelier image of the spirit',
+														},
+													],
+													totals: {
+														add: 18,
+													},
+												},
+											},
+											'168:169': {
+												from: 168,
+												to: 169,
+												diff: {
+													post_content: [
+														{
+															op: 'copy',
+															value: 'I must here speak by theory alone.',
+														},
+													],
+													post_title: [
+														{
+															op: 'copy',
+															value: 'In my eyes it bore a livelier image of the spirit',
+														},
+													],
+													totals: {},
+												},
+											},
+											'169:170': {
+												from: 169,
+												to: 170,
+												diff: {
+													post_content: [
+														{
+															op: 'copy',
+															value: 'I must here speak by theory',
+														},
+														{
+															op: 'del',
+															value: 'alone',
+														},
+														{
+															op: 'copy',
+															value: '.',
+														},
+													],
+													post_title: [
+														{
+															op: 'copy',
+															value: 'In my eyes it bore a livelier image of the spirit',
+														},
+													],
+													totals: {
+														del: 1,
+													},
+												},
+											},
+											'170:172': {
+												from: 170,
+												to: 172,
+												diff: {
+													post_content: [
+														{
+															op: 'copy',
+															value: 'I must here speak by theory.',
+														},
+													],
+													post_title: [
+														{
+															op: 'copy',
+															value: 'In my eyes it bore a livelier ',
+														},
+														{
+															op: 'add',
+															value: 'and fuller ',
+														},
+														{
+															op: 'copy',
+															value: 'image of the spirit',
+														},
+													],
+													totals: {
+														add: 2,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					12345678,
+					10
+				)
+			).to.eql( [
+				{
+					post_date_gmt: '2018-01-03 09:01:00Z',
+					post_modified_gmt: '2018-01-03 09:01:00Z',
+					post_author: '20416304',
+					id: 172,
+					post_content: 'I must here speak by theory.',
+					post_excerpt: '',
+					post_title: 'In my eyes it bore a livelier and fuller image of the spirit',
+				},
+				{
+					post_date_gmt: '2018-01-02 07:01:19Z',
+					post_modified_gmt: '2018-01-02 07:01:19Z',
+					post_author: '20416304',
+					id: 170,
+					post_content: 'I must here speak by theory.',
+					post_excerpt: '',
+					post_title: 'In my eyes it bore a livelier image of the spirit',
+				},
+				{
+					post_date_gmt: '2017-12-12 18:24:37Z',
+					post_modified_gmt: '2017-12-12 18:24:37Z',
+					post_author: '20416304',
+					id: 168,
+					post_content: 'I must here speak by theory alone.',
+					post_excerpt: '',
+					post_title: 'In my eyes it bore a livelier image of the spirit',
+				},
+			] );
+		}
+	);
+} );


### PR DESCRIPTION
This change addresses the story

> As a Calypso Editor user, when I click History, I don't want to see entries for "minor" changes which don't involve distinct changes to the post title or content.

I've added two new selectors.

* `getPostRevisionsMajor` filters the revisions list returned from `getPostRevisions`, removing revisions with an empty `total`.
* `getPostRevisionsComparisonsMajor` returns the same diff information object as `getPostRevisionsComparisons` but with minor revisions removed, and `nextRevisionId` and `prevRevisionId` of the remaining items remapped.

The changes can't simply be merged into the existing selectors because the revisions filter depends on the full comparisons list, and the comparisons filter depends on the full revisions list, so we still need the original selectors.

## Testing

1. Starting at https://wordpress.com/posts/my/xxxxx.wordpress.com create or open a post.
2. Make a change to the post content or post title and update the post to create a new revision.
3. Make a change to the excerpt and update the post to create a new minor revision.
4. Make another change to the post content or post title and update the post again.
5. View the revisions history. You should see all three revisions.
6. With this branch checked out locally, open the post in http://calypso.localhost:3000/posts/my/xxxxx.wordpress.com.
7. View the revisions history. You should see only two of the three revisions. The minor revision should not be shown, the revisions count should show a smaller number of revisions, and the sequence of revisions should be unbroken.

![before-after](https://user-images.githubusercontent.com/1647564/37241913-ea2d9046-2458-11e8-9495-fe85d1e70f45.png)
