### PR TITLE
Activity Log: Send specific sort order to server in polling requests

### DIFF
--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -52,6 +52,7 @@ export const togglePolling = ( { dispatch, getState }, { isWatching, siteId } ) 
 			activityLogRequest( siteId, {
 				dateStart: Date.now(),
 				number: 100,
+				sortOrder: 'asc',
 			} ),
 			{ meta: { dataLayer: { isWatching: true } } }
 		)
@@ -124,7 +125,12 @@ export const continuePolling = ( { dispatch, getState }, action ) => {
 			const searchAfter = nextAfter || thisState.nextAfter;
 
 			if ( searchAfter ) {
-				dispatch( merge( activityLogRequest( siteId, { searchAfter, number: 100 } ), meta ) );
+				dispatch(
+					merge(
+						activityLogRequest( siteId, { searchAfter, number: 100, sortOrder: 'asc' } ),
+						meta
+					)
+				);
 				return;
 			}
 
@@ -140,6 +146,7 @@ export const continuePolling = ( { dispatch, getState }, action ) => {
 					activityLogRequest( siteId, {
 						dateStart: dateStart > -Infinity ? dateStart : Date.now(),
 						number: 100,
+						sortOrder: 'asc',
 					} ),
 					meta
 				)
@@ -171,6 +178,7 @@ export const handleActivityLogRequest = action => {
 					name: params.name,
 					number: params.number,
 					search_after: JSON.stringify( params.searchAfter ),
+					sort_order: params.sortOrder,
 				},
 				a => a === undefined
 			),


### PR DESCRIPTION
This is a sequencing PR as I improve the way we issue activity log
polling updates in Calypso and on the server. When we first introduced
the `searchAfter` parameter in #22776 we were using `searchAfter` and
`searchBefore` to implicitly indicate which sort direction we wanted
for the server to fulfill.

There was a problem with this approach though in the way that
ElasticSearch's sorting works with the interaction between pages and
`search_after`.

It's my plan to make the sort order a custom requested parameter and
_only_ use `searchAfter` to fetch continuing batches of updates and
completely eliminate the use of the `page` parameter in Calypso.

That is, this PR sends a parameter that will be needed once we change
the server behavior but it doesn't change any actual behaviors yet.

**Testing**

This should need no testing since the server doesn't support the
`sort_order` parameter yet. The only test is that things don't crash
and the automated tests should catch that.