### PR TITLE
Documentation: Reword parts of CreateSelector readme to improve understanding

### DIFF
--- a/client/lib/create-selector/README.md
+++ b/client/lib/create-selector/README.md
@@ -7,11 +7,11 @@ This module exports a single function which creates a memoized state selector fo
 
 `createSelector` accepts the following arguments:
 
-- A function which calculates the cached result given a state object and any number of variable arguments necessary to calculate the result
-- A function or array of functions which return array of dependent state, given the state and the same arguments as the selector
+- A function which selects data from the state. Given a state object and any number of other arguments it calculates a result, which is cached for later reuse.
+- A function which returns the parts of the state tree the selector depends on. This can be a function or array of functions which returns an array of state values.
 - _(Optional)_ A function to customize the cache key used by the inner memoized function
 
-For example, we might consider that our state contains post objects, each of which are assigned to a particular site. Retrieving an array of posts for a specific site would require us to filter over all of the known posts. While this would normally be an expensive operation, we can use `createSelector` to create a memoized function:
+For example, our state contains post objects, each of which is assigned to a particular site. To retrieve an array of posts for a specific site, we'd have to filter all of the known posts. This is an expensive operation. Using `createSelector`, we can create a memoized function which saves us from having to make that expensive computation over and over:
 
 ```js
 export const getSitePosts = createSelector(
@@ -20,7 +20,7 @@ export const getSitePosts = createSelector(
 );
 ```
 
-In using the selector, we only need to consider the signature of the first function argument. In this case, we'll need to pass a state object and site ID.
+To use the selector created with `createSelector`, we only need to consider the signature of the function we passed as the first argument. In this case, we'll need to pass a state object and site ID.
 
 ```js
 const sitePosts = getSitePosts( state, siteId );
@@ -32,7 +32,7 @@ This result would only be calculated once, so long as `state.posts` remains the 
 
 ### What is a memoized selector?
 
-We strive to keep redundant data out of our Redux state tree, but this can come at the cost of performance if our selectors are time-consuming in how they evaluate and filter over the minimal state.
+We strive to keep redundant data out of our Redux state tree, but this can come at the cost of performance if our selectors are time-consuming in how they evaluate and filter the minimal state.
 
 A memoized selector can alleviate this concern by storing a cached result, skipping these expensive derivations when we know that the result has already been computed once before from the same state.
 
@@ -63,7 +63,7 @@ createSelector(
 );
 ```
 
-Since this is a reoccurring pattern, there is a shorthand for this situation. You can reduce the above to an array just the selectors:
+Since this is a recurring pattern, there is a shorthand for this situation. You can reduce the above to an array just the selectors:
 
 ```js
 createSelector(


### PR DESCRIPTION
Reading up on `createSelector` this week, there were a couple things in the doc which took me a while to understand. I've suggested a few tweaks which might make it easier for people.

* In the description of the function's arguments, the first argument's role as the function that selects data from the state could do with more emphasis. I didn't get the idea from the phrase "calculates the cached result" straight away.
* "Given the state and the same arguments as the selector" confused me a bit - I wasn't sure if "given" meant "passed" or "assuming". The second function isn't passed the same arguments as the first, so I think it makes things clearer to delete that phrase. It also helps to say explicitly that the selector depends on the state this function returns.
* I've suggested a more active construction and more informal language in the example.
* "The signature of the first function argument" might confuse some people at first, because the first function has arguments and is itself an argument, so I've tried to clarify what we're talking about.
* IMHO "recurring" is more usual for a pattern that crops up often, because it implies "happens repeatedly".

cc @aduth @benhuberman 