### PR TITLE
Simple Payments: disallow creating a payment item with 0 price

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -87,7 +87,7 @@ const validate = ( values, props ) => {
 		);
 	}
 
-	if ( ! values.price ) {
+	if ( ! values.price || parseFloat( values.price ) === 0 ) {
 		errors.price = translate( 'Everything comes with a price tag these days. Add yours here.' );
 	} else if ( parseFloat( values.price ) === NaN ) {
 		errors.price = translate( 'Invalid price' );
@@ -138,8 +138,8 @@ const validate = ( values, props ) => {
 // `Fields` is receiving to `{ input, meta }` that `Field` expects.
 const renderPriceField = ( { price, currency, ...props } ) => {
 	const { precision } = getCurrencyDefaults( currency.input.value );
-	// Tune the placeholder to the precision value: 0 -> '0', 1 -> '0.0', 2 -> '0.00'
-	const placeholder = precision > 0 ? padEnd( '0.', precision + 2, '0' ) : '0';
+	// Tune the placeholder to the precision value: 0 -> '1', 1 -> '1.0', 2 -> '1.00'
+	const placeholder = precision > 0 ? padEnd( '1.', precision + 2, '0' ) : '1';
 	return (
 		<FieldsetRenderer
 			inputComponent={ FormCurrencyInput }


### PR DESCRIPTION
Fixes #23211 

Stops allowing zero value payment buttons, and updates the placeholder to reflect this

**Testing Instructions**

1. Add a payment button 
2. Note placeholders
3. Try to enter a zero value
4. Make sure there is an error message
5. Try some other currencies that don't allow decimals

**New**

<img width="1522" alt="after 1" src="https://user-images.githubusercontent.com/128826/37260335-c0526bd0-25dd-11e8-8212-2aa29ecef56f.png">
<img width="1520" alt="after 2" src="https://user-images.githubusercontent.com/128826/37260339-c78a834c-25dd-11e8-8b49-1ccc289c7ce9.png">

**Previously**

<img width="1527" alt="before 1" src="https://user-images.githubusercontent.com/128826/37260345-ce7a3af8-25dd-11e8-8bc6-9495d21d0299.png">
<img width="1526" alt="before 2" src="https://user-images.githubusercontent.com/128826/37260347-d1d6ec50-25dd-11e8-8ce8-d0053647388f.png">


