### PR TITLE
Enable de_formal in calypso.

### DIFF
--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -29,7 +29,7 @@ import analytics from 'lib/analytics';
 import config from 'config';
 import { recordTracksEvent } from 'state/analytics/actions';
 import NotificationsPanel, { refreshNotes } from 'notifications-panel';
-import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
+import { getCurrentLocaleSlug, getCurrentLocaleVariant } from 'state/selectors';
 
 /**
  * Returns whether or not the browser session
@@ -248,7 +248,7 @@ export class Notifications extends Component {
 
 export default connect(
 	state => ( {
-		currentLocaleSlug: getCurrentLocaleSlug( state ),
+		currentLocaleSlug: getCurrentLocaleVariant( state ) || getCurrentLocaleSlug( state ),
 	} ),
 	{ recordTracksEvent }
 )( Notifications );

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -38,6 +38,7 @@
     "support_locales": [ "en", "es", "pt-br" ],
     "english_locales": [ "en", "en-gb"],
     "languages": [
+        { "value": 900, "langSlug": "de_formal", "name": "Deutsch (Sie)", "wpLocale": "de_DE_formal", "parentLangSlug": "de", "territories": [ "155" ] },
         { "value": 2, "langSlug": "af", "name": "Afrikaans", "wpLocale": "af", "territories": [ "002" ] },
         { "value": 418, "langSlug": "als", "name": "Alemannisch", "wpLocale": "", "territories": [ "155" ] },
         { "value": 481, "langSlug": "am", "name": "አማርኛ", "wpLocale": "am", "territories": [ "002" ] },

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -38,7 +38,6 @@
     "support_locales": [ "en", "es", "pt-br" ],
     "english_locales": [ "en", "en-gb"],
     "languages": [
-        { "value": 900, "langSlug": "de_formal", "name": "Deutsch (Sie)", "wpLocale": "de_DE_formal", "parentLangSlug": "de", "territories": [ "155" ] },
         { "value": 2, "langSlug": "af", "name": "Afrikaans", "wpLocale": "af", "territories": [ "002" ] },
         { "value": 418, "langSlug": "als", "name": "Alemannisch", "wpLocale": "", "territories": [ "155" ] },
         { "value": 481, "langSlug": "am", "name": "አማርኛ", "wpLocale": "am", "territories": [ "002" ] },
@@ -65,6 +64,7 @@
         { "value": 13, "langSlug": "cy", "name": "Cymraeg", "wpLocale": "cy", "territories": [ "154" ] },
         { "value": 14, "langSlug": "da", "name": "Dansk", "wpLocale": "da_DK", "territories": [ "154" ] },
         { "value": 15, "langSlug": "de", "name": "Deutsch", "wpLocale": "de_DE", "popular": 4, "territories": [ "155" ] },
+        { "value": 900, "langSlug": "de_formal", "name": "Deutsch (Sie)", "wpLocale": "de_DE_formal", "parentLangSlug": "de", "territories": [ "155" ] },
         { "value": 427, "langSlug": "dv", "name": "ދިވެހި", "wpLocale": "dv", "rtl": true, "territories": [ "034" ] },
         { "value": 16, "langSlug": "dz", "name": "ཇོང་ཁ", "wpLocale": "", "territories": [ "034" ] },
         { "value": 17, "langSlug": "el", "name": "Ελληνικά", "wpLocale": "el", "territories": [ "039" ] },


### PR DESCRIPTION
## Summary
This is the last piece of enabling Formal Germany in Calypso: WIP and most of the commentary at #23025. 

🛑 It should only be merged it after `D10642-code` has been deployed

## Testing
1. Head to http://calypso.localhost:3000/me/account and select+save **_Deutsch (Sie)_** as your interface language.

### Expectations

In the browser's network tab `de_formal.json` should be loaded from `widgets.wp.com/languages/calypso/de_formal.json` and `widgets.wp.com/languages/notifications/de_formal.json`

The HTML lang attr in the source should be `de`.

You should be able to switch to **_Deutsch_** (or any other language)

Nothing breaks :)


