### PR TITLE
Stats: Hide empty "Most Popular" content behind empty content notice

### DIFF
--- a/client/my-sites/stats/most-popular/style.scss
+++ b/client/my-sites/stats/most-popular/style.scss
@@ -1,14 +1,16 @@
+/** @format */
+
 // Most popular Day and Time section
 
 .most-popular__wrapper {
 	clear: both;
 }
 
-.stats-module.is-loading .most-popular__wrapper,
-.is-empty .stats-popular {
+.stats-module.is-empty .most-popular__wrapper,
+.stats-module.is-loading .most-popular__wrapper {
 	min-height: 150px;
 
-	.stats-popular__item {
+	.most-popular__item {
 		display: none;
 	}
 }
@@ -20,7 +22,7 @@
 	padding: 20px 0;
 	color: $gray-dark;
 
-	@include breakpoint ("<960px") {
+	@include breakpoint ('<960px') {
 		width: 100%;
 
 		&:first-child {
@@ -53,20 +55,20 @@
 
 .most-popular__empty {
 	position: absolute;
-		top: 40px;
-		right: 0;
-		left: 0;
+	top: 40px;
+	right: 0;
+	left: 0;
 	text-align: center;
 	line-height: 24px;
 	clear: both;
-	z-index: z-index( 'root', '.stats-popular__empty' );
+	z-index: z-index('root', '.stats-popular__empty');
 }
 
 .most-popular__notice {
 	top: 25px;
 	margin-bottom: 24px;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		top: 10px;
 		margin: 0 5px;
 	}


### PR DESCRIPTION
Follow up to #23148

Hide unnecessary empty content behind the empty content notice.

By looking at the code, I believe this has always been the intended behaviour and look, but it somehow fell through the cracks during some updates, because the `.stats-popular` classes don't exist (anymore?).

Note: there are also a handful of unrelated automatic Prettier fixes. Please disregard them when reviewing.

| Before | After |
| --- | --- |
| <img width="406" alt="screen shot 2018-03-12 at 11 06 27" src="https://user-images.githubusercontent.com/2070010/37280574-1121ab22-25e6-11e8-80ad-82bfd42f6e07.png"> | <img width="386" alt="screen shot 2018-03-12 at 11 08 29" src="https://user-images.githubusercontent.com/2070010/37280576-141f09b4-25e6-11e8-9eeb-b7c8e02b7ed7.png"> |

## Testing instructions

- Pick a site with no activity
- Go to `/stats/insights` and see the new notice on the "Most popular day and hour" card.
