### PR TITLE
WIP: Bring back the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,145 @@
+include Makefile-utils.mk
+
+#
+# Calypso
+#
+.PHONY: pre-start
+pre-start: welcome versions
+
+versions: B = $(FG_BLUE)
+versions: R = $(FG_RED)
+versions: Z = $(FG_RESET)
+versions: PATTERN = ^v*\([0-9]*\)\(.*\)
+versions: MAJOR = `$1 | sed -n 's/$(PATTERN)/\1/p'`
+versions: COLOR = `$2 | sed -n 's/$(PATTERN)/\$1\1\$Z\2/p'`
+versions: CHECK = @\
+	export BASE=$($2); \
+	export JSON=`$(NODE) -e 'console.log(require(".$/package.json").engines.$1)'`; \
+	export WMAJ=$(call MAJOR,echo $$JSON); \
+	export HMAJ=$(call MAJOR,$$BASE -v); \
+	export WANT=$(call COLOR,$R,echo $$JSON); \
+	export HAVE=$(call COLOR,$B,$$BASE -v); \
+	[ $$WMAJ != $$HMAJ ] && echo -e "$Rx$Z need $1 major version $$WANT but have $$HAVE instead" && exit 1 || exit 0
+versions: $(NODE) $(NPM)
+	$(call CHECK,node,NODE)
+	$(call CHECK,npm,NPM)
+	$~
+
+.PHONY: welcome
+welcome:
+	@echo -e "$(FG_CYAN)"; echo $(WELCOME) | base64 -D | gzip -d; echo -e "$(TERM_RESET)"
+
+calypso-strings.pot: $(FILES_JS)
+	$(NPM_BIN)i18n-calypso --format pot --output-file ./calypso-strings.pot -e date "**/*.js" "**/*.jsx" "!build/**" "!node_modules/**" "!public/**"
+	$~
+
+#
+# Docker
+#
+docker-image: Dockerfile Makefile Makefile-utils.mk assets bin client config docs public server test $(filter %.js %.json %.sh,$(wildcard *))
+	docker build --build-arg commit_sha=$(GIT_HASH) -t wp-calypso .
+	$~
+
+.PHONY: docker
+docker: docker-image
+	docker run -it --name wp-calypso --rm -p 80:3000 wp-calypso
+
+#
+# Linting
+#
+.PHONY: lint
+lint: lint-config lint-css lint-js
+
+lint-config: config
+	$(NODE) server$/config$/validate-config-keys.js
+	$~
+
+lint-css: CHANGED = $(filter %.scss,$?)
+lint-css: ARGS = $(call when-more-than,100,client$/**$/*.scss,$(CHANGED))
+lint-css: $(FILES_SCSS) | $(call npm-deps,stylelint)
+	$(NPM_BIN)stylelint --syntax scss $(ARGS)
+	$~
+
+lint-js: CHANGED = $(filter %.js %.jsx,$?)
+lint-js: ARGS = $(call when-more-than,100,.,$(CHANGED))
+lint-js: $(FILES_JS) | $(call npm-deps,eslint-eslines)
+	$(NPM_BIN)eslint-eslines $(ARGS)
+	$~
+
+#
+# Testing
+#
+.PHONY: test
+test: test-client test-server
+
+.PHONY: test-client
+test-client: $(FILES_JS) | $(call npm-deps,jest)
+	$(NPM_BIN)jest -c=test/client/jest.config.json
+	$~
+
+.PHONY: test-server
+test-server: $(FILES_JS) | $(call npm-deps,jest)
+	$(NPM_BIN)jest -c=test/server/jest.config.json
+	$~
+
+#
+# Git
+#
+.PHONY: pre-push
+pre-push: | contribution-message
+  ifeq (master,$(GIT_BRANCH))
+	read -n 1 -p "You're about to push !!![ $(GIT_BRANCH) ]!!!, is that what you intended? " CONFIRM; \
+	echo; \
+	if [[ ! $$CONFIRM =~ ^[Yy]$$ ]]; then exit 1; fi
+  endif
+
+.PHONY: pre-commit
+.SECONDEXPANSION: pre-commit
+pre-commit: DIRTY = $(sort $(filter %.js %.jsx %.scss,$(shell git diff $1 --name-only --diff-filter=ACM)))
+pre-commit: READY = $(call list-diff,$(call DIRTY,--cached),$(DIRTY))
+pre-commit: NEWER = $(call list-same,$(sort $?),$(READY))
+pre-commit: FILES = $(call when-more-than,0,$(READY),$(NEWER))
+pre-commit: lint-config $$(READY) | $(call npm-deps,eslint-eslines prettier) contribution-message
+	$(call when-not-empty,$(NEWER), \
+		$(info Formatting unmodified files staged for commit) \
+		$(NPM_BIN)prettier --require-pragma --write $(FILES) && \
+			git add $(FILES) && \
+			$(NPM_BIN)eslint-eslints --diff=index $(filter-out %.scss,$(FILES)) \
+	)
+	$~
+
+.PHONY: contribution-message
+contribution-message:
+	$(info By contributing to this project, you license the materials you contribute)
+	$(info under the GNU General Public License v2 (or later). All materials must have)
+	$(info GPLv2 compatible licenses — see .github/CONTRIBUTING.md for details.)
+	$(info )
+
+#
+# Cleaning
+#
+.PHONY: clean
+clean: clean-build clean-devdocs clean-public
+
+.PHONY: clean-build
+clean-build:
+	$(RM) build server$/bundler$/*.json .babel-cache
+
+.PHONY: clean-devdocs
+clean-devdocs:
+	$(RM) $(addprefix server$/devdocs$/,search-index.js prototypes-index.json components-usage-stats.json)
+
+.PHONY: clean-npm
+clean-npm:
+	$(RM) node_modules npm-shrinkwrap.json
+
+.PHONY: clean-public
+clean-public:
+	$(RM) \
+		$(addprefix public$/*.,css css.map js js.map) \
+		$(addprefix public$/sections$/*.,css css.map) \
+		$(addprefix public$/sections-rtl$/*.,css css.map)
+
+.PHONY: distclean
+distclean: clean
+	$(RM) node_modules .make-cache

--- a/Makefile-utils.mk
+++ b/Makefile-utils.mk
@@ -1,0 +1,122 @@
+# Portability
+ifdef ComSpec
+	RM := del /F /Q
+    SLASH :=\\
+else
+	RM := rm -rf
+    SLASH :=/
+endif
+
+# Use $/ as the path separator
+/ := $(strip $(SLASH))
+
+# File classes
+FILES_JS := $(shell \
+	find . \
+		-not \( -path '.$/.git' -prune \) \
+		-not \( -path '.$/build' -prune \) \
+		-not \( -path '.$/node_modules' -prune \) \
+		-not \( -path '.$/public' -prune \) \
+		-type f \
+		\( -name '*.js' -or -name '*.jsx' \) \
+)
+
+FILES_SCSS := $(shell \
+	find client assets \
+		-type f \
+		-name '*.scss' \
+)
+
+# git
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+GIT_HASH   := $(shell git rev-parse HEAD)
+
+# node/npm helpers
+NODE_ENV ?= development
+NPM_BIN  := node_modules$/.bin$/
+NODE     := $(shell which node)
+NPM      := $(shell which npm)
+
+# $(call npm-deps,package-a package-b package-c)
+npm-deps = $(addprefix node_modules$/,$1) missing-modules
+
+npm-shrinkwrap.json: clean-npm
+	$(NPM) install && \
+	$(NPM) shrinkwrap
+
+.PHONY: missing-modules
+missing-modules:
+	$(RM) .make-cache$/missing-modules; \
+  # Due to a bug in npm it's removing packages on install and
+  # we can get in cycles where the installation of one package
+  # removes another and then the installation of that other
+  # package removes the first one - (╯°□°）╯︵ ┻━┻)
+  # when resolved install only the required dependencies
+	$(call when-not-empty,$(sort $(shell cat .make-cache$/missing-modules)),$(NPM) install)
+
+.SECONDEXPANSION: node_modules
+node_modules: DEPS = $(shell $(NODE) -e 'console.log(Object.keys(require(".$/package.json").dependencies).join(" "))')
+node_modules: DEVS = $(shell $(NODE) -e 'console.log(Object.keys(require(".$/package.json").devDependencies).join(" "))')
+node_modules: $$(call npm-deps,$$(DEPS) $$(DEVS))
+
+# When installing here then we're probably running a
+# build command like `eslint` and don't need to be
+# _as_ stringent on updating when the `package.json`
+# or `npm-shrinkwrap.json` files change
+.SECONDARY: node_modules%
+node_modules$/%:
+	echo "$(notdir $@)" >> .make-cache$/missing-modules
+
+# Optimizing phony targets that should
+# only run when their dependencies change
+BOOT := $(shell mkdir -p .make-cache)
+TOUCH_CACHE = touch .make-cache$/
+~ = $(strip $(TOUCH_CACHE))$(subst $/,-,$@)
+
+vpath docker-image .make-cache
+vpath lint-% .make-cache
+vpath pre-commit .make-cache
+vpath test-% .make-cache
+vpath versions .make-cache
+
+# Convenience utilities
+
+list-op = $(shell comm $3 <(echo $1 | tr " " "\n") <(echo $2 | tr " " "\n"))
+list-diff = $(call list-op,$1,$2,-23)
+list-same = $(call list-op,$1,$2,-12)
+
+# $(call when-less-than,min-size,default,list)
+when-less-than = $(if $(shell [ $(words $3) -gt $1 ] && echo gt),$3,$2)
+
+# $(call when-more-than,max-size,default,list)
+when-more-than = $(if $(shell [ $(words $3) -lt $1 ] && echo lt),$3,$2)
+
+# $(call when-not-empty,list,body)
+when-not-empty = $(if $(shell [ $(words $1) -gt 0 ] && echo gt),$2,$3)
+
+# Terminal
+FG_BLUE    = \\033[34m
+FG_CYAN    = \\033[36m
+FG_GREEN   = \\033[32m
+FG_RED     = \\033[31m
+FG_RESET   = \\033[39m
+TERM_RESET = \\033[0m
+
+# Surprise
+WELCOME=\
+	H4sIAAAAAAAA/1VMQQ7AM\
+	Ai6+wpuW5Nl/ZAJe4iPH9\
+	hk6bRgQSKwFaOZhF+haIm\
+	WbZucmfoID+rrg0jbJUIq\
+	VDi50L0mB1J3Uv5A+ZQkh\
+	YtKeCp163jJnt7NwL96o3\
+	DEC1DrkHm8AAAA
+
+# Reset make
+.POSIX:
+.SUFFIXES:
+SHELL := bash
+CONCURRENCY ?= -j6
+UNQUIET ?= --quiet
+UNQUIET :=
+MAKEFLAGS += --no-builtin-rules $(CONCURRENCY) $(UNQUIET)


### PR DESCRIPTION
See #17033

Replaces the use of `npm` scripts for dependency and build management with a portable and efficient `Makefile`

Many of us were surprised when we arrived at the MASSIVE Calypso project and it wasn't using `npm` as its build system; I'd like to let that be what it is - surprise - not inappropriate; not magical. We may have stumbled into `make` because it was familiar too (I don't know; I wasn't on that team) but it's a purpose-built tool designed for the specific task of building things and was written forty years ago and is well-established on projects of every language and widely supported on every system; it's declarative with almost no syntax and it makes running shell commands a breeze; it's also not going anywhere and it's not going to unexpectedly break syntax and make us spend two weeks updating it in order to not keep up with its updates.

Example of tab-auto-completion available in many programs which understand `make`:
![make-autocomplete mov](https://user-images.githubusercontent.com/5431237/37447246-16531b78-2819-11e8-9fb3-9bd62cebf385.gif)
