### PR TITLE
Timezone: Suggest the user's timezone for quick selecting

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -424,7 +424,15 @@ class SiteSettingsFormGeneral extends Component {
 	}
 
 	Timezone() {
-		const { fields, isRequestingSettings, translate, supportsLanguageSelection } = this.props;
+		const {
+			fields,
+			isRequestingSettings,
+			translate,
+			supportsLanguageSelection,
+			moment,
+		} = this.props;
+		const guessedTimezone = moment.tz.guess();
+		const setGuessedTimezone = this.onTimezoneSelect.bind( this, guessedTimezone );
 
 		return (
 			<FormFieldset
@@ -439,7 +447,21 @@ class SiteSettingsFormGeneral extends Component {
 				/>
 
 				<FormSettingExplanation>
-					{ translate( 'Choose a city in your timezone.' ) }
+					{ translate( 'Choose a city in your timezone.' ) }{' '}
+					{ translate( 'We think you might be in {{timeZoneLink/}} (click to select it).', {
+						components: {
+							timeZoneLink: (
+								<Button
+									onClick={ setGuessedTimezone }
+									borderless={ true }
+									compact={ true }
+									className="site-settings__general-settings-set-guessed-timezone"
+								>
+									{ guessedTimezone }
+								</Button>
+							),
+						},
+					} ) }
 				</FormSettingExplanation>
 			</FormFieldset>
 		);

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -453,8 +453,8 @@ class SiteSettingsFormGeneral extends Component {
 							timeZoneLink: (
 								<Button
 									onClick={ setGuessedTimezone }
-									borderless={ true }
-									compact={ true }
+									borderless
+									compact
 									className="site-settings__general-settings-set-guessed-timezone"
 								>
 									{ guessedTimezone }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -448,20 +448,24 @@ class SiteSettingsFormGeneral extends Component {
 
 				<FormSettingExplanation>
 					{ translate( 'Choose a city in your timezone.' ) }{' '}
-					{ translate( 'We think you might be in {{timeZoneLink/}} (click to select it).', {
-						components: {
-							timeZoneLink: (
-								<Button
-									onClick={ setGuessedTimezone }
-									borderless
-									compact
-									className="site-settings__general-settings-set-guessed-timezone"
-								>
-									{ guessedTimezone }
-								</Button>
-							),
-						},
-					} ) }
+					{ translate(
+						'You might want to follow our guess: {{selectTimezone}}Select %(timezoneName)s{{/selectTimezone}}',
+						{
+							args: {
+								timezoneName: guessedTimezone,
+							},
+							components: {
+								selectTimezone: (
+									<Button
+										onClick={ setGuessedTimezone }
+										borderless
+										compact
+										className="site-settings__general-settings-set-guessed-timezone"
+									/>
+								),
+							},
+						}
+					) }
 				</FormSettingExplanation>
 			</FormFieldset>
 		);

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -449,13 +449,13 @@ class SiteSettingsFormGeneral extends Component {
 				<FormSettingExplanation>
 					{ translate( 'Choose a city in your timezone.' ) }{' '}
 					{ translate(
-						'You might want to follow our guess: {{selectTimezone}}Select %(timezoneName)s{{/selectTimezone}}',
+						'You might want to follow our guess: {{button}}Select %(timezoneName)s{{/button}}',
 						{
 							args: {
 								timezoneName: guessedTimezone,
 							},
 							components: {
-								selectTimezone: (
+								button: (
 									<Button
 										onClick={ setGuessedTimezone }
 										borderless

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -468,6 +468,19 @@
 	}
 }
 
+button.site-settings__general-settings-set-guessed-timezone.button.is-borderless.is-compact {
+	text-decoration: underline;
+	color: $blue-wordpress;
+	font-style: inherit;
+	font-weight: 400;
+
+	&:hover,
+	&:focus,
+	&:active {
+		color: $link-highlight;
+		box-shadow: none;
+	}
+}
 .site-settings__jetpack-dev-mode-notice .notice {
 	animation: none;
 }


### PR DESCRIPTION
In order to make it easier for users to select the timezone of their blog and to remove the need to navigate the long dropdown, this adds a link to quickly select the user's timezone from the dropdown.

![guessed-timezone](https://user-images.githubusercontent.com/203408/37283126-289ede58-25f7-11e8-80f8-e7f3da46801b.gif)

cc @mattmiklic 