### PR TITLE
Add term picker for choosing between 1-year and 2-year plans

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -223,6 +223,7 @@
 @import 'components/sub-masterbar-nav/style';
 @import 'components/suggestions/style';
 @import 'components/textarea-autosize/style';
+@import 'components/term-picker/style';
 @import 'components/term-picker-option/style';
 @import 'components/text-diff/style';
 @import 'components/thank-you-card/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -92,6 +92,7 @@
 @import 'components/back-button/style';
 @import 'components/banner/style';
 @import 'components/bulk-select/style';
+@import 'components/badge/style';
 @import 'components/button/style';
 @import 'components/button-group/style';
 @import 'components/card/style';
@@ -222,6 +223,7 @@
 @import 'components/sub-masterbar-nav/style';
 @import 'components/suggestions/style';
 @import 'components/textarea-autosize/style';
+@import 'components/term-picker-option/style';
 @import 'components/text-diff/style';
 @import 'components/thank-you-card/style';
 @import 'components/theme/style';

--- a/client/components/badge/README.md
+++ b/client/components/badge/README.md
@@ -1,0 +1,21 @@
+Badge
+=======
+
+Badge is a component used to render a short piece of information that
+should stand out from the rest.
+
+## Usage
+
+```jsx
+
+import React from 'react';
+import Badge from 'components/badge';
+
+class MyComponent extends React.Component {
+	render() {
+		return (
+			<Badge type="warning">Only 6MB left!</Badge>
+		);
+	}
+}
+```

--- a/client/components/badge/docs/example.jsx
+++ b/client/components/badge/docs/example.jsx
@@ -1,0 +1,27 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Badge from 'components/badge';
+
+const BadgeExample = () => (
+	<div>
+		<div className="docs__design-badge-row">
+			<Badge type="success">Success Badge</Badge>
+		</div>
+		<div className="docs__design-badge-row">
+			<Badge type="warning">Warning Badge</Badge>
+		</div>
+	</div>
+);
+
+BadgeExample.displayName = 'Badge';
+
+export default BadgeExample;

--- a/client/components/badge/index.jsx
+++ b/client/components/badge/index.jsx
@@ -1,0 +1,23 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class Badge extends React.Component {
+	static propTypes = {
+		type: PropTypes.oneOf( [ 'warning', 'success' ] ).isRequired,
+	};
+
+	static defaultProps = {
+		type: 'warning',
+	};
+
+	render() {
+		const { type } = this.props;
+		return <div className={ `badge badge--${ type }` }>{ this.props.children }</div>;
+	}
+}

--- a/client/components/badge/style.scss
+++ b/client/components/badge/style.scss
@@ -1,0 +1,22 @@
+.badge {
+	display: inline-block;
+	border-radius: 100px;
+	padding: 2px 10px;
+	text-align: center;
+	font-size: 14px;
+	line-height: 18px;
+}
+
+.badge--warning {
+	color: #535d56;
+	background-color: #ffd379;
+}
+
+.badge--success {
+	color: #fff;
+	background-color: #19b76e;
+}
+
+.docs__design-badge-row {
+	margin-bottom: 20px;
+}

--- a/client/components/badge/style.scss
+++ b/client/components/badge/style.scss
@@ -1,7 +1,7 @@
 .badge {
 	display: inline-block;
 	border-radius: 100px;
-	padding: 2px 10px;
+	padding: 2px 11px;
 	text-align: center;
 	font-size: 14px;
 	line-height: 18px;
@@ -9,7 +9,7 @@
 
 .badge--warning {
 	color: #535d56;
-	background-color: #ffd379;
+	background-color: #fcd56d;
 }
 
 .badge--success {

--- a/client/components/badge/test/index.js
+++ b/client/components/badge/test/index.js
@@ -1,0 +1,44 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Badge from '../index';
+
+describe( 'Badge', () => {
+	test( 'should have badge class', () => {
+		const featureExample = shallow( <Badge /> );
+		assert.lengthOf( featureExample.find( '.badge' ), 1 );
+	} );
+
+	test( 'should have proper type class (warning)', () => {
+		const badge = shallow( <Badge type="warning" /> );
+		assert.lengthOf( badge.find( '.badge.badge--warning' ), 1 );
+	} );
+
+	test( 'should have proper type class (success)', () => {
+		const badge = shallow( <Badge type="success" /> );
+		assert.lengthOf( badge.find( '.badge.badge--success' ), 1 );
+	} );
+
+	test( 'should have proper type class (default)', () => {
+		const badge = shallow( <Badge /> );
+		assert.lengthOf( badge.find( '.badge.badge--warning' ), 1 );
+	} );
+
+	test( 'should contains the passed children wrapped by a feature-example div', () => {
+		const featureExample = shallow(
+			<Badge>
+				<div>test</div>
+			</Badge>
+		);
+		assert.isTrue( featureExample.contains( <div>test</div> ) );
+	} );
+} );

--- a/client/components/term-picker-option/README.md
+++ b/client/components/term-picker-option/README.md
@@ -1,0 +1,23 @@
+Feature Example
+=======
+
+Feature Example is a component used to render an mocked example of any feature. It renders whatever children it receives. The example is covered by a layer of fading gradient that gives the user a sense of UI that they are missing.
+
+## Usage
+
+```jsx
+
+import React from 'react';
+import ExternalLink from 'components/feature-example';
+import EmptyContent from 'components/empty-content';
+
+class MyComponent extends React.Component {
+	render() {
+		return (
+			<FeatureExample>
+				<EmptyContent />
+			</FeatureExample>
+		);
+	}
+}
+```

--- a/client/components/term-picker-option/README.md
+++ b/client/components/term-picker-option/README.md
@@ -1,23 +1,23 @@
-Feature Example
-=======
+TermPickerOption
+==========
 
-Feature Example is a component used to render an mocked example of any feature. It renders whatever children it receives. The example is covered by a layer of fading gradient that gives the user a sense of UI that they are missing.
+Term picker option component: represents a term that user could pick when choosing his plan
+(monthly, yearly, biennially)
 
-## Usage
+### `index.jsx`
 
-```jsx
+Given basic information, this component creates a representation of given term.
 
-import React from 'react';
-import ExternalLink from 'components/feature-example';
-import EmptyContent from 'components/empty-content';
+#### Props
 
-class MyComponent extends React.Component {
-	render() {
-		return (
-			<FeatureExample>
-				<EmptyContent />
-			</FeatureExample>
-		);
-	}
-}
-```
+* `term`: string - TERM_* constant from lib/plans/constants.jsx
+* `savePercent` number ( optional ) - e.g. 60 for 60% - when displayed with other terms,
+                                      if may be useful to say that one option is 40% cheaper
+                                      then the other.
+* `price`: string - e.g. $60 - a formatted full price that is going to be charged to the user
+* `pricePerMonth`: string - e.g. $5 - a formatted effective price per month
+* `checked`: bool - if this option should be checked (selected)
+* `value`: any - value that is going to be passed to onChecked callback
+* `onCheck`: function({value}) => void ( optional ) A callback called when this term is checked (selected)
+
+For a complete list of props along with their types, please refer to the `TermPickerOption` component's `propTypes` member.

--- a/client/components/term-picker-option/docs/example.jsx
+++ b/client/components/term-picker-option/docs/example.jsx
@@ -1,0 +1,36 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import TermPickerOption from 'components/term-picker-option';
+
+const TermPickerOptionExample = () => (
+	<div>
+		<TermPickerOption term="1 year" price="$40" pricePerMonth="$3.33/month" isActive={ false } />
+		<TermPickerOption
+			term="2 years"
+			price="$24"
+			pricePerMonth="only $2/month"
+			savePercent={ 6 }
+			isActive={ true }
+		/>
+		<TermPickerOption
+			term="2 years"
+			price="$24"
+			pricePerMonth="only $2/month"
+			savePercent={ 6 }
+			isActive={ false }
+		/>
+	</div>
+);
+
+TermPickerOptionExample.displayName = 'TermPickerOption';
+
+export default TermPickerOptionExample;

--- a/client/components/term-picker-option/index.jsx
+++ b/client/components/term-picker-option/index.jsx
@@ -1,0 +1,62 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import Badge from '../badge';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+export default class TermPickerOption extends React.Component {
+	static propTypes = {
+		term: PropTypes.string.isRequired,
+		savePercent: PropTypes.number.isRequired,
+		price: PropTypes.string.isRequired,
+		pricePerMonth: PropTypes.string.isRequired,
+		isActive: PropTypes.bool.isRequired,
+		onChange: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		isActive: false,
+		onChange: () => null,
+	};
+
+	render() {
+		const { term, savePercent, price, pricePerMonth, isActive, onChange } = this.props;
+		const className = classnames( 'term-picker-option', {
+			'term-picker-option--active': isActive,
+		} );
+		return (
+			<label className={ className }>
+				<div className="term-picker-option__radio-wrapper">
+					<input
+						type="radio"
+						className="term-picker-option__radio"
+						checked={ isActive }
+						onChange={ onChange }
+					/>
+				</div>
+
+				<div className="term-picker-option__content">
+					<div className="term-picker-option__header">
+						<div className="term-picker-option__term">{ term }</div>
+						<div className="term-picker-option__discount">
+							{ savePercent ? (
+								<Badge type={ isActive ? 'success' : 'warning' }>Save { savePercent }%</Badge>
+							) : (
+								false
+							) }
+						</div>
+					</div>
+					<div className="term-picker-option__description">
+						<div className="term-picker-option__price">{ price }</div>
+						<div className="term-picker-option__side-note">{ pricePerMonth }</div>
+					</div>
+				</div>
+			</label>
+		);
+	}
+}

--- a/client/components/term-picker-option/index.jsx
+++ b/client/components/term-picker-option/index.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 import Badge from '../badge';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from '../../lib/plans/constants';
 
 export default class TermPickerOption extends React.Component {
 	static propTypes = {
@@ -15,19 +16,21 @@ export default class TermPickerOption extends React.Component {
 		savePercent: PropTypes.number.isRequired,
 		price: PropTypes.string.isRequired,
 		pricePerMonth: PropTypes.string.isRequired,
-		isActive: PropTypes.bool.isRequired,
-		onChange: PropTypes.func.isRequired,
+		checked: PropTypes.bool.isRequired,
+		value: PropTypes.any.isRequired,
+		onCheck: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
-		isActive: false,
-		onChange: () => null,
+		checked: false,
+		savePercent: 0,
+		onCheck: () => null,
 	};
 
 	render() {
-		const { term, savePercent, price, pricePerMonth, isActive, onChange } = this.props;
+		const { savePercent, price, pricePerMonth, checked } = this.props;
 		const className = classnames( 'term-picker-option', {
-			'term-picker-option--active': isActive,
+			'term-picker-option--active': checked,
 		} );
 		return (
 			<label className={ className }>
@@ -35,17 +38,17 @@ export default class TermPickerOption extends React.Component {
 					<input
 						type="radio"
 						className="term-picker-option__radio"
-						checked={ isActive }
-						onChange={ onChange }
+						checked={ checked }
+						onChange={ this.handleChange }
 					/>
 				</div>
 
 				<div className="term-picker-option__content">
 					<div className="term-picker-option__header">
-						<div className="term-picker-option__term">{ term }</div>
+						<div className="term-picker-option__term">{ this.getTermText() }</div>
 						<div className="term-picker-option__discount">
 							{ savePercent ? (
-								<Badge type={ isActive ? 'success' : 'warning' }>Save { savePercent }%</Badge>
+								<Badge type={ checked ? 'success' : 'warning' }>Save { savePercent }%</Badge>
 							) : (
 								false
 							) }
@@ -53,10 +56,33 @@ export default class TermPickerOption extends React.Component {
 					</div>
 					<div className="term-picker-option__description">
 						<div className="term-picker-option__price">{ price }</div>
-						<div className="term-picker-option__side-note">{ pricePerMonth }</div>
+						<div className="term-picker-option__side-note">
+							{ savePercent ? 'only ' + pricePerMonth + ' / month' : pricePerMonth + ' / month' }
+						</div>
 					</div>
 				</div>
 			</label>
 		);
+	}
+
+	handleChange = e => {
+		if ( e.target.checked ) {
+			this.props.onCheck( {
+				value: this.props.value,
+			} );
+		}
+	};
+
+	getTermText() {
+		switch ( this.props.term ) {
+			case TERM_BIENNIALLY:
+				return '2 years';
+
+			case TERM_ANNUALLY:
+				return '1 year';
+
+			case TERM_MONTHLY:
+				return 'month';
+		}
 	}
 }

--- a/client/components/term-picker-option/index.jsx
+++ b/client/components/term-picker-option/index.jsx
@@ -8,9 +8,10 @@ import React from 'react';
 import Badge from '../badge';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
 import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from '../../lib/plans/constants';
 
-export default class TermPickerOption extends React.Component {
+export class TermPickerOption extends React.Component {
 	static propTypes = {
 		term: PropTypes.string.isRequired,
 		savePercent: PropTypes.number.isRequired,
@@ -19,6 +20,7 @@ export default class TermPickerOption extends React.Component {
 		checked: PropTypes.bool.isRequired,
 		value: PropTypes.any.isRequired,
 		onCheck: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
@@ -28,7 +30,7 @@ export default class TermPickerOption extends React.Component {
 	};
 
 	render() {
-		const { savePercent, price, pricePerMonth, checked } = this.props;
+		const { savePercent, price, term, checked } = this.props;
 		const className = classnames( 'term-picker-option', {
 			'term-picker-option--active': checked,
 		} );
@@ -47,22 +49,43 @@ export default class TermPickerOption extends React.Component {
 					<div className="term-picker-option__header">
 						<div className="term-picker-option__term">{ this.getTermText() }</div>
 						<div className="term-picker-option__discount">
-							{ savePercent ? (
-								<Badge type={ checked ? 'success' : 'warning' }>Save { savePercent }%</Badge>
-							) : (
-								false
-							) }
+							{ savePercent ? this.renderSaveBadge() : false }
 						</div>
 					</div>
 					<div className="term-picker-option__description">
 						<div className="term-picker-option__price">{ price }</div>
 						<div className="term-picker-option__side-note">
-							{ savePercent ? 'only ' + pricePerMonth + ' / month' : pricePerMonth + ' / month' }
+							{ term !== TERM_MONTHLY ? this.renderPricePerMonth() : false }
 						</div>
 					</div>
 				</div>
 			</label>
 		);
+	}
+
+	renderSaveBadge() {
+		const { savePercent, checked, translate } = this.props;
+		return (
+			<Badge type={ checked ? 'success' : 'warning' }>
+				{ translate( 'Save %(percent)s%', {
+					args: {
+						percent: savePercent,
+					},
+				} ) }
+			</Badge>
+		);
+	}
+
+	renderPricePerMonth() {
+		const { savePercent, pricePerMonth, translate } = this.props;
+
+		let retval;
+		if ( savePercent ) {
+			retval = translate( 'only %(price)s / month', { args: { price: pricePerMonth } } );
+		} else {
+			retval = translate( '%(price)s / month', { args: { price: pricePerMonth } } );
+		}
+		return retval;
 	}
 
 	handleChange = e => {
@@ -74,15 +97,18 @@ export default class TermPickerOption extends React.Component {
 	};
 
 	getTermText() {
-		switch ( this.props.term ) {
+		const { term, translate } = this.props;
+		switch ( term ) {
 			case TERM_BIENNIALLY:
-				return '2 years';
+				return translate( '2 years' );
 
 			case TERM_ANNUALLY:
-				return '1 year';
+				return translate( '1 year' );
 
 			case TERM_MONTHLY:
-				return 'month';
+				return translate( '1 month' );
 		}
 	}
 }
+
+export default localize( TermPickerOption );

--- a/client/components/term-picker-option/index.jsx
+++ b/client/components/term-picker-option/index.jsx
@@ -100,13 +100,13 @@ export class TermPickerOption extends React.Component {
 		const { term, translate } = this.props;
 		switch ( term ) {
 			case TERM_BIENNIALLY:
-				return translate( '2 years' );
+				return translate( '%s year', '%s years', { count: 2, args: '2' } );
 
 			case TERM_ANNUALLY:
-				return translate( '1 year' );
+				return translate( '%s year', '%s years', { count: 1, args: '1' } );
 
 			case TERM_MONTHLY:
-				return translate( '1 month' );
+				return translate( '%s month', '%s months', { count: 1, args: '1' } );
 		}
 	}
 }

--- a/client/components/term-picker-option/index.jsx
+++ b/client/components/term-picker-option/index.jsx
@@ -75,7 +75,7 @@ export class TermPickerOption extends React.Component {
 		const { savePercent, checked, translate } = this.props;
 		return (
 			<Badge type={ checked ? 'success' : 'warning' }>
-				{ translate( 'Save %(percent)s%', {
+				{ translate( 'Save %(percent)s%%', {
 					args: {
 						percent: savePercent,
 					},

--- a/client/components/term-picker-option/index.jsx
+++ b/client/components/term-picker-option/index.jsx
@@ -11,6 +11,8 @@ import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from '../../lib/plans/constants';
 
+let componentNumber = 0;
+
 export class TermPickerOption extends React.Component {
 	static propTypes = {
 		term: PropTypes.string.isRequired,
@@ -29,15 +31,21 @@ export class TermPickerOption extends React.Component {
 		onCheck: () => null,
 	};
 
+	constructor( props ) {
+		super( props );
+		this.htmlId = 'term-option-' + ++componentNumber;
+	}
+
 	render() {
 		const { savePercent, price, term, checked } = this.props;
 		const className = classnames( 'term-picker-option', {
 			'term-picker-option--active': checked,
 		} );
 		return (
-			<label className={ className }>
+			<label className={ className } htmlFor={ this.htmlId }>
 				<div className="term-picker-option__radio-wrapper">
 					<input
+						id={ this.htmlId }
 						type="radio"
 						className="term-picker-option__radio"
 						checked={ checked }

--- a/client/components/term-picker-option/style.scss
+++ b/client/components/term-picker-option/style.scss
@@ -1,0 +1,72 @@
+.term-picker-option {
+	display: flex;
+	width: 100%;
+	padding: 17px 12px;
+	cursor: pointer;
+
+	border-radius: 5px;
+	border: 1px solid #d1e2e8;
+	margin-bottom: 20px;
+
+	background: #FFF;
+
+	.term-picker-option__radio-wrapper {
+		width: 20px;
+		margin-right: 10px;
+	}
+
+	.term-picker-option__radio {
+		width: 20px;
+		height: 20px;
+
+		&:checked:before {
+			width: 10px;
+			height: 10px;
+		}
+	}
+
+	.term-picker-option__header,
+	.term-picker-option__description {
+		width: 100%;
+	}
+
+	.term-picker-option__term,
+	.term-picker-option__price,
+	.term-picker-option__discount,
+	.term-picker-option__side-note,
+	.term-picker-option__description {
+		display: inline-block;
+		vertical-align: middle;
+	}
+
+	.term-picker-option__header {
+		line-height: 26px;
+	}
+
+	.term-picker-option__term {
+		display: inline-block;
+		font-size: 26px;
+		line-height: 26px;
+	}
+
+	.term-picker-option__discount {
+		margin-left: 10px;
+	}
+
+	.term-picker-option__description {
+		font-size: 16px;
+	}
+
+	.term-picker-option__price {
+		color: #4f646e;
+	}
+
+	.term-picker-option__side-note {
+		color: #749eaf;
+		margin-left: 5px;
+	}
+}
+
+.term-picker-option--active {
+	border: 3px solid #19b76e;
+}

--- a/client/components/term-picker-option/style.scss
+++ b/client/components/term-picker-option/style.scss
@@ -1,72 +1,78 @@
 .term-picker-option {
-	display: flex;
-	width: 100%;
-	padding: 17px 12px;
-	cursor: pointer;
+  --padding-size: 18px;
 
-	border-radius: 5px;
-	border: 1px solid #d1e2e8;
-	margin-bottom: 20px;
+  display: flex;
+  width: 100%;
+  cursor: pointer;
 
-	background: #FFF;
+  padding: var(--padding-size);
+  border-radius: 5px;
+  margin-bottom: 20px;
 
-	.term-picker-option__radio-wrapper {
-		width: 20px;
-		margin-right: 10px;
-	}
+  background: #FFF;
 
-	.term-picker-option__radio {
-		width: 20px;
-		height: 20px;
+  .term-picker-option__radio-wrapper {
+    width: 21px;
+    margin-right: 12px;
+  }
 
-		&:checked:before {
-			width: 10px;
-			height: 10px;
-		}
-	}
+  .term-picker-option__radio {
+    width: 21px;
+    height: 21px;
 
-	.term-picker-option__header,
-	.term-picker-option__description {
-		width: 100%;
-	}
+    &:checked:before {
+      width: 13px;
+      height: 13px;
+    }
+  }
 
-	.term-picker-option__term,
-	.term-picker-option__price,
-	.term-picker-option__discount,
-	.term-picker-option__side-note,
-	.term-picker-option__description {
-		display: inline-block;
-		vertical-align: middle;
-	}
+  .term-picker-option__header,
+  .term-picker-option__description {
+    width: 100%;
+  }
 
-	.term-picker-option__header {
-		line-height: 26px;
-	}
+  .term-picker-option__term,
+  .term-picker-option__price,
+  .term-picker-option__discount,
+  .term-picker-option__side-note,
+  .term-picker-option__description {
+    display: inline-block;
+    vertical-align: middle;
+  }
 
-	.term-picker-option__term {
-		display: inline-block;
-		font-size: 26px;
-		line-height: 26px;
-	}
+  .term-picker-option__header {
+    line-height: 24px;
+  }
 
-	.term-picker-option__discount {
-		margin-left: 10px;
-	}
+  .term-picker-option__term {
+    display: inline-block;
+    font-size: 24px;
+    line-height: 24px;
+  }
 
-	.term-picker-option__description {
-		font-size: 16px;
-	}
+  .term-picker-option__discount {
+    margin-left: 10px;
+  }
 
-	.term-picker-option__price {
-		color: #4f646e;
-	}
+  .term-picker-option__description {
+    font-size: 16px;
+  }
 
-	.term-picker-option__side-note {
-		color: #749eaf;
-		margin-left: 5px;
-	}
+  .term-picker-option__price {
+    color: #4f646e;
+  }
+
+  .term-picker-option__side-note {
+    color: #59849D;
+    margin-left: 5px;
+  }
+}
+
+.term-picker-option:not( .term-picker-option--active ) {
+  border: 1px solid #c5d8e2;
+  padding: calc(var(--padding-size) + 2px);
 }
 
 .term-picker-option--active {
-	border: 3px solid #19b76e;
+  border: 3px solid #4ab866;
 }

--- a/client/components/term-picker-option/style.scss
+++ b/client/components/term-picker-option/style.scss
@@ -7,7 +7,6 @@
 
   padding: var(--padding-size);
   border-radius: 5px;
-  margin-bottom: 20px;
 
   background: #FFF;
 

--- a/client/components/term-picker-option/test/index.js
+++ b/client/components/term-picker-option/test/index.js
@@ -1,0 +1,29 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import FeatureExample from '../index';
+
+describe( 'Feature Example', () => {
+	test( 'should have Feature-example class', () => {
+		const featureExample = shallow( <FeatureExample /> );
+		assert.lengthOf( featureExample.find( '.feature-example' ), 1 );
+	} );
+
+	test( 'should contains the passed children wrapped by a feature-example div', () => {
+		const featureExample = shallow(
+			<FeatureExample>
+				<div>test</div>
+			</FeatureExample>
+		);
+		assert.isTrue( featureExample.contains( <div>test</div> ) );
+	} );
+} );

--- a/client/components/term-picker-option/test/index.js
+++ b/client/components/term-picker-option/test/index.js
@@ -1,29 +1,45 @@
 /** @format */
 
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
 /**
  * External dependencies
  */
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
+import { TERM_1_YEAR } from 'lib/plans/constants';
 
 /**
  * Internal dependencies
  */
-import FeatureExample from '../index';
+import TermPickerOpton from '../index';
 
-describe( 'Feature Example', () => {
-	test( 'should have Feature-example class', () => {
-		const featureExample = shallow( <FeatureExample /> );
-		assert.lengthOf( featureExample.find( '.feature-example' ), 1 );
-	} );
-
-	test( 'should contains the passed children wrapped by a feature-example div', () => {
-		const featureExample = shallow(
-			<FeatureExample>
-				<div>test</div>
-			</FeatureExample>
+describe( 'TermPickerOpton basic tests', () => {
+	test( 'should have term-picker-option class', () => {
+		const option = shallow(
+			<TermPickerOpton term={ TERM_1_YEAR } price={ 120 } pricePerMonth={ 10 } />
 		);
-		assert.isTrue( featureExample.contains( <div>test</div> ) );
+		assert.lengthOf( option.find( '.term-picker-option' ), 1 );
+	} );
+	test( 'should display save badge if savePercent is specified', () => {
+		const option = shallow(
+			<TermPickerOpton term={ TERM_1_YEAR } price={ 120 } pricePerMonth={ 10 } savePercent={ 65 } />
+		);
+		assert.equal( option.find( 'Badge' ).length, 1 );
+	} );
+	test( 'should say "{price} / month" if savePercent is not specified', () => {
+		const option = shallow(
+			<TermPickerOpton term={ TERM_1_YEAR } price={ 120 } pricePerMonth={ 10 } />
+		);
+		assert.equal( option.find( '.term-picker-option__side-note' ).text(), '10 / month' );
+	} );
+	test( 'should say "only {price} / month" if savePercent is specified', () => {
+		const option = shallow(
+			<TermPickerOpton term={ TERM_1_YEAR } price={ 120 } pricePerMonth={ 10 } savePercent={ 65 } />
+		);
+		assert.equal( option.find( '.term-picker-option__side-note' ).text(), 'only 10 / month' );
 	} );
 } );

--- a/client/components/term-picker-option/test/index.js
+++ b/client/components/term-picker-option/test/index.js
@@ -4,6 +4,12 @@ jest.mock( 'lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
+const translate = x => x;
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Comp => props => <Comp { ...props } translate={ translate } />,
+	numberFormat: x => x,
+} ) );
+
 /**
  * External dependencies
  */
@@ -15,31 +21,56 @@ import { TERM_1_YEAR } from 'lib/plans/constants';
 /**
  * Internal dependencies
  */
-import TermPickerOpton from '../index';
+import { TermPickerOption } from '../index';
 
 describe( 'TermPickerOpton basic tests', () => {
 	test( 'should have term-picker-option class', () => {
 		const option = shallow(
-			<TermPickerOpton term={ TERM_1_YEAR } price={ 120 } pricePerMonth={ 10 } />
+			<TermPickerOption
+				term={ TERM_1_YEAR }
+				price={ 120 }
+				pricePerMonth={ 10 }
+				translate={ translate }
+			/>
 		);
 		assert.lengthOf( option.find( '.term-picker-option' ), 1 );
 	} );
 	test( 'should display save badge if savePercent is specified', () => {
 		const option = shallow(
-			<TermPickerOpton term={ TERM_1_YEAR } price={ 120 } pricePerMonth={ 10 } savePercent={ 65 } />
+			<TermPickerOption
+				term={ TERM_1_YEAR }
+				price={ 120 }
+				pricePerMonth={ 10 }
+				savePercent={ 65 }
+				translate={ translate }
+			/>
 		);
 		assert.equal( option.find( 'Badge' ).length, 1 );
 	} );
 	test( 'should say "{price} / month" if savePercent is not specified', () => {
 		const option = shallow(
-			<TermPickerOpton term={ TERM_1_YEAR } price={ 120 } pricePerMonth={ 10 } />
+			<TermPickerOption
+				term={ TERM_1_YEAR }
+				price={ 120 }
+				pricePerMonth={ 10 }
+				translate={ translate }
+			/>
 		);
-		assert.equal( option.find( '.term-picker-option__side-note' ).text(), '10 / month' );
+		assert.equal( option.find( '.term-picker-option__side-note' ).text(), '%(price)s / month' );
 	} );
 	test( 'should say "only {price} / month" if savePercent is specified', () => {
 		const option = shallow(
-			<TermPickerOpton term={ TERM_1_YEAR } price={ 120 } pricePerMonth={ 10 } savePercent={ 65 } />
+			<TermPickerOption
+				term={ TERM_1_YEAR }
+				price={ 120 }
+				pricePerMonth={ 10 }
+				savePercent={ 65 }
+				translate={ translate }
+			/>
 		);
-		assert.equal( option.find( '.term-picker-option__side-note' ).text(), 'only 10 / month' );
+		assert.equal(
+			option.find( '.term-picker-option__side-note' ).text(),
+			'only %(price)s / month'
+		);
 	} );
 } );

--- a/client/components/term-picker-option/test/index.js
+++ b/client/components/term-picker-option/test/index.js
@@ -4,9 +4,15 @@ jest.mock( 'lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
-const translate = x => x;
 jest.mock( 'i18n-calypso', () => ( {
-	localize: Comp => props => <Comp { ...props } translate={ translate } />,
+	localize: Comp => props => (
+		<Comp
+			{ ...props }
+			translate={ function( x ) {
+				return x;
+			} }
+		/>
+	),
 	numberFormat: x => x,
 } ) );
 

--- a/client/components/term-picker-option/test/index.js
+++ b/client/components/term-picker-option/test/index.js
@@ -4,6 +4,7 @@ jest.mock( 'lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
+const translate = x => x;
 jest.mock( 'i18n-calypso', () => ( {
 	localize: Comp => props => (
 		<Comp

--- a/client/components/term-picker/README.md
+++ b/client/components/term-picker/README.md
@@ -1,0 +1,19 @@
+TermPicker
+==========
+
+Term picker component: displays a list of terms (monthly, yearly, biennially).
+
+### `index.jsx`
+
+Given an array of plans, this component creates a corresponding list of TermPickerOption components to allow
+selection of desired term.
+
+Each item in the `plans` array must be a constant from lib/plans/contants.jsx`.
+
+#### Props
+
+* `plans`: string[] list of plan constants representing term options
+* `initialValue`: string ( optional ) term selected by default
+* `onChange`: function({value}) => void ( optional ) A callback called when selected term changes
+
+For a complete list of props along with their types, please refer to the `TermPicker` component's `propTypes` member.

--- a/client/components/term-picker/index.jsx
+++ b/client/components/term-picker/index.jsx
@@ -1,0 +1,162 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import React from 'react';
+import PropTypes from 'prop-types';
+import TermPickerOption from '../term-picker-option';
+import formatCurrency from 'lib/format-currency';
+import { getProductsList, isProductsListFetching } from 'state/products-list/selectors';
+import { requestProductsList } from 'state/products-list/actions';
+import { requestPlans } from 'state/plans/actions';
+import { getPlanRawPrice, isRequestingPlans } from '../../state/plans/selectors';
+import { getCurrentUserCurrencyCode } from '../../state/current-user/selectors';
+import { getPlanDiscountedRawPrice } from '../../state/sites/plans/selectors';
+import { getSelectedSiteId } from '../../state/ui/selectors';
+import { abtest } from 'lib/abtest';
+import { getPlan, applyTestFiltersToPlansList } from 'lib/plans';
+
+export class TermPicker extends React.Component {
+	static propTypes = {
+		initialValue: PropTypes.string,
+		currencyCode: PropTypes.string.isRequired,
+		productsWithPrices: PropTypes.array.isRequired,
+		onChange: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		onChange: () => null,
+	};
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			checked: props.initialValue,
+		};
+	}
+
+	render() {
+		const { productsWithPrices } = this.props;
+		if ( productsWithPrices.length <= 1 ) {
+			return false;
+		}
+
+		return (
+			<div className="term-picker">
+				<div className="term-picker__header">Choose the length of your subscription</div>
+
+				{ productsWithPrices.map( p => this.renderProduct( p ) ) }
+			</div>
+		);
+	}
+
+	renderProduct = p => {
+		const { plan, planSlug } = p;
+
+		return (
+			<div className="term-picker__option-container" key={ planSlug }>
+				<TermPickerOption
+					term={ plan.term }
+					checked={ planSlug === this.state.checked }
+					price={ myFormatCurrency( p.priceFull, this.props.currencyCode ) }
+					pricePerMonth={ myFormatCurrency( p.priceMonthly, this.props.currencyCode ) }
+					savePercent={ Math.round( 100 * ( 1 - p.priceFull / this.getHighestPrice() ) ) }
+					value={ planSlug }
+					onCheck={ this.handleCheck }
+				/>
+			</div>
+		);
+	};
+
+	getHighestPrice() {
+		return Math.max( ...this.props.productsWithPrices.map( p => Number( p.priceFull ) ) );
+	}
+
+	handleCheck = ( { value } ) => {
+		this.setState( {
+			checked: value,
+		} );
+		this.props.onChange( value );
+	};
+}
+
+class TermPickerContainer extends React.Component {
+	static defaultProps = {
+		...TermPicker.defaultProps,
+
+		fetchingPlans: PropTypes.bool.isRequired,
+		fetchingProducts: PropTypes.bool.isRequired,
+		requestProductsList: PropTypes.func.isRequired,
+		requestPlans: PropTypes.func.isRequired,
+	};
+
+	componentWillMount() {
+		if ( this.props.productsWithPrices.length === 0 ) {
+			if ( ! this.props.fetchingProducts ) {
+				this.props.requestProductsList();
+			}
+			if ( ! this.props.fetchingPlans ) {
+				this.props.requestPlans();
+			}
+		}
+	}
+
+	render() {
+		return <TermPicker { ...this.props } />;
+	}
+}
+
+const EPSILON = 0.009;
+
+function myFormatCurrency( price, code ) {
+	const hasCents = Math.abs( price % 1 ) > EPSILON;
+	return formatCurrency( price, code, {
+		precision: hasCents ? 2 : 0,
+	} );
+}
+
+const computeProductsWithPrices = ( state, plans ) => {
+	const selectedSiteId = getSelectedSiteId( state );
+	const products = getProductsList( state );
+
+	const computePrice = ( planSlug, planProductId, isMonthly ) =>
+		getPlanDiscountedRawPrice( state, selectedSiteId, planSlug, { isMonthly } ) ||
+		getPlanRawPrice( state, planProductId, isMonthly );
+
+	return plans
+		.map( planSlug => {
+			const plan = getPlan( planSlug );
+			const planConstantObj = applyTestFiltersToPlansList( plan, abtest );
+			return {
+				planSlug,
+				plan: planConstantObj,
+				product: products[ planSlug ],
+			};
+		} )
+		.filter( p => p.plan && p.product && p.product.available )
+		.map( object => {
+			const productId = object.plan.getProductId();
+			return {
+				...object,
+
+				priceFull: computePrice( object.planSlug, productId, false ),
+				priceMonthly: computePrice( object.planSlug, productId, true ),
+			};
+		} )
+		.filter( p => p.priceFull );
+};
+
+export default connect(
+	( state, { plans } ) => ( {
+		productsWithPrices: computeProductsWithPrices( state, plans ),
+		fetchingPlans: ! plans && isRequestingPlans( state ),
+		fetchingProducts: ! getProductsList( state ) && isProductsListFetching( state ),
+		currencyCode: getCurrentUserCurrencyCode( state ),
+	} ),
+	{
+		requestPlans,
+		requestProductsList,
+	}
+)( TermPickerContainer );

--- a/client/components/term-picker/index.jsx
+++ b/client/components/term-picker/index.jsx
@@ -39,10 +39,6 @@ export class TermPicker extends React.Component {
 
 	render() {
 		const { productsWithPrices } = this.props;
-		if ( productsWithPrices.length <= 1 ) {
-			return false;
-		}
-
 		return (
 			<div className="term-picker">
 				<div className="term-picker__header">Choose the length of your subscription</div>
@@ -79,7 +75,7 @@ export class TermPicker extends React.Component {
 		this.setState( {
 			checked: value,
 		} );
-		this.props.onChange( value );
+		this.props.onChange( { value } );
 	};
 }
 

--- a/client/components/term-picker/index.jsx
+++ b/client/components/term-picker/index.jsx
@@ -46,8 +46,9 @@ export class TermPicker extends React.Component {
 		return (
 			<div className="term-picker">
 				<div className="term-picker__header">Choose the length of your subscription</div>
-
-				{ productsWithPrices.map( p => this.renderProduct( p ) ) }
+				<div className="term-picker__options">
+					{ productsWithPrices.map( p => this.renderProduct( p ) ) }
+				</div>
 			</div>
 		);
 	}

--- a/client/components/term-picker/index.jsx
+++ b/client/components/term-picker/index.jsx
@@ -6,6 +6,7 @@
 import { connect } from 'react-redux';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
 import TermPickerOption from '../term-picker-option';
 import formatCurrency from 'lib/format-currency';
 import { getProductsList, isProductsListFetching } from 'state/products-list/selectors';
@@ -24,6 +25,7 @@ export class TermPicker extends React.Component {
 		currencyCode: PropTypes.string.isRequired,
 		productsWithPrices: PropTypes.array.isRequired,
 		onChange: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
@@ -38,10 +40,17 @@ export class TermPicker extends React.Component {
 	}
 
 	render() {
-		const { productsWithPrices } = this.props;
+		const { productsWithPrices, translate } = this.props;
 		return (
 			<div className="term-picker">
-				<div className="term-picker__header">Choose the length of your subscription</div>
+				<div className="term-picker__header">
+					{ translate( 'Choose the length of your subscription', {
+						comment:
+							'We offer a way to change billing term from default bill every 1 year to something ' +
+							'else like bill once every 2 years - this is related header.',
+					} ) }
+				</div>
+
 				<div className="term-picker__options">
 					{ productsWithPrices.map( p => this.renderProduct( p ) ) }
 				</div>
@@ -156,4 +165,4 @@ export default connect(
 		requestPlans,
 		requestProductsList,
 	}
-)( TermPickerContainer );
+)( localize( TermPickerContainer ) );

--- a/client/components/term-picker/index.jsx
+++ b/client/components/term-picker/index.jsx
@@ -165,12 +165,18 @@ const computeProductsWithPrices = ( state, plans ) => {
 };
 
 export default connect(
-	( state, { plans } ) => ( {
-		productsWithPrices: computeProductsWithPrices( state, plans ),
-		fetchingPlans: ! plans && isRequestingPlans( state ),
-		fetchingProducts: ! getProductsList( state ) && isProductsListFetching( state ),
-		currencyCode: getCurrentUserCurrencyCode( state ),
-	} ),
+	( state, { plans } ) => {
+		const fetchingProducts = ! getProductsList( state ) && isProductsListFetching( state );
+		const fetchingPlans = ! plans && isRequestingPlans( state );
+		const fetchingDeps = fetchingProducts || fetchingPlans;
+
+		return {
+			fetchingPlans,
+			fetchingProducts,
+			currencyCode: getCurrentUserCurrencyCode( state ),
+			productsWithPrices: fetchingDeps ? [] : computeProductsWithPrices( state, plans ),
+		};
+	},
 	{
 		requestPlans,
 		requestProductsList,

--- a/client/components/term-picker/index.jsx
+++ b/client/components/term-picker/index.jsx
@@ -3,10 +3,15 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { connect } from 'react-redux';
 import { difference } from 'lodash';
-import React from 'react';
 import PropTypes from 'prop-types';
+
+/**
+ * Internal Dependencies
+ */
+import { getPlansBySiteId, isRequestingSitePlans } from 'state/sites/plans/selectors';
 import { localize } from 'i18n-calypso';
 import TermPickerOption from '../term-picker-option';
 import formatCurrency from 'lib/format-currency';
@@ -166,9 +171,12 @@ const computeProductsWithPrices = ( state, plans ) => {
 
 export default connect(
 	( state, { plans } ) => {
+		const selectedSiteId = getSelectedSiteId( state );
 		const fetchingProducts = ! getProductsList( state ) && isProductsListFetching( state );
 		const fetchingPlans = ! plans && isRequestingPlans( state );
-		const fetchingDeps = fetchingProducts || fetchingPlans;
+		const fetchingSitePlans =
+			! getPlansBySiteId( selectedSiteId ) || isRequestingSitePlans( state, selectedSiteId );
+		const fetchingDeps = fetchingProducts || fetchingPlans || fetchingSitePlans;
 
 		return {
 			fetchingPlans,

--- a/client/components/term-picker/index.jsx
+++ b/client/components/term-picker/index.jsx
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { difference } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
@@ -131,7 +132,7 @@ const computeProductsWithPrices = ( state, plans ) => {
 		getPlanDiscountedRawPrice( state, selectedSiteId, planSlug, { isMonthly } ) ||
 		getPlanRawPrice( state, planProductId, isMonthly );
 
-	return plans
+	const retval = plans
 		.map( planSlug => {
 			const plan = getPlan( planSlug );
 			const planConstantObj = applyTestFiltersToPlansList( plan, abtest );
@@ -152,6 +153,15 @@ const computeProductsWithPrices = ( state, plans ) => {
 			};
 		} )
 		.filter( p => p.priceFull );
+
+	if ( retval.length !== plans.length ) {
+		const missing = difference( plans, retval.map( ( { planSlug } ) => planSlug ) );
+		throw new Error(
+			`price could not be computed for the following plans: ${ missing.join( ', ' ) }`
+		);
+	}
+
+	return retval;
 };
 
 export default connect(

--- a/client/components/term-picker/index.jsx
+++ b/client/components/term-picker/index.jsx
@@ -5,7 +5,6 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { difference } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -147,7 +146,7 @@ const computeProductsWithPrices = ( state, plans ) => {
 		);
 	};
 
-	const retval = plans
+	return plans
 		.map( planSlug => {
 			const plan = getPlan( planSlug );
 			const planConstantObj = applyTestFiltersToPlansList( plan, abtest );
@@ -169,15 +168,6 @@ const computeProductsWithPrices = ( state, plans ) => {
 		} )
 		.filter( p => p.priceFull )
 		.sort( ( a, b ) => b.priceMonthly - a.priceMonthly );
-
-	if ( retval.length !== plans.length ) {
-		const missing = difference( plans, retval.map( ( { planSlug } ) => planSlug ) );
-		console.error(
-			`price could not be computed for the following plans: ${ missing.join( ', ' ) }`
-		);
-	}
-
-	return retval;
 };
 
 export default connect(

--- a/client/components/term-picker/style.scss
+++ b/client/components/term-picker/style.scss
@@ -1,0 +1,16 @@
+.term-picker {
+	display: flex;
+	align-items: flex-start;
+	flex-flow: row wrap;
+	justify-content: space-between;
+
+	&__header {
+		margin-bottom: 10px;
+		flex-basis: 100%;
+	}
+
+	&__option-container {
+		flex-basis: calc(50% - 10px);
+	}
+}
+

--- a/client/components/term-picker/style.scss
+++ b/client/components/term-picker/style.scss
@@ -1,16 +1,26 @@
 .term-picker {
-	display: flex;
-	align-items: flex-start;
-	flex-flow: row wrap;
-	justify-content: space-between;
+  &__header {
+    margin-bottom: 10px;
+    flex-basis: 100%;
+    font-size: 16px;
+  }
 
-	&__header {
-		margin-bottom: 10px;
-		flex-basis: 100%;
-	}
+  &__options {
+    display: flex;
+    align-items: flex-start;
+    flex-flow: row wrap;
+    justify-content: space-between;
+  }
 
-	&__option-container {
-		flex-basis: calc(50% - 10px);
-	}
+  &__option-container {
+    flex-basis: calc(50% - 10px);
+
+    @include breakpoint('<960px') {
+      flex-basis: calc(100%);
+      &:not(:first-child) {
+        margin-top: 20px;
+      }
+    }
+  }
 }
 

--- a/client/components/term-picker/test/index.js
+++ b/client/components/term-picker/test/index.js
@@ -34,18 +34,8 @@ describe( 'TermPicker basic tests', () => {
 		},
 	];
 
-	test( 'should display nothing if no plans are specified', () => {
-		const picker = shallow( <TermPicker productsWithPrices={ [] } /> );
-		assert.lengthOf( picker.find( '*' ), 0 );
-	} );
-
-	test( 'should display nothing if a single plans is specified', () => {
-		const picker = shallow( <TermPicker productsWithPrices={ [ {} ] } /> );
-		assert.lengthOf( picker.find( '*' ), 0 );
-	} );
-
 	test( 'should have term-picker class', () => {
-		const picker = shallow( <TermPicker productsWithPrices={ productsWithPrices } /> );
+		const picker = shallow( <TermPicker productsWithPrices={ [] } /> );
 		assert.lengthOf( picker.find( '.term-picker' ), 1 );
 	} );
 

--- a/client/components/term-picker/test/index.js
+++ b/client/components/term-picker/test/index.js
@@ -1,0 +1,79 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { getPlan } from 'lib/plans';
+import { PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS } from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { TermPicker } from '../index';
+
+describe( 'TermPicker basic tests', () => {
+	const productsWithPrices = [
+		{
+			planSlug: PLAN_BUSINESS,
+			plan: getPlan( PLAN_BUSINESS ),
+			priceFull: 1200,
+			priceMonthly: 100,
+		},
+		{
+			planSlug: PLAN_BUSINESS_2_YEARS,
+			plan: getPlan( PLAN_BUSINESS_2_YEARS ),
+			priceFull: 1800,
+			priceMonthly: 150,
+		},
+	];
+
+	test( 'should display nothing if no plans are specified', () => {
+		const picker = shallow( <TermPicker productsWithPrices={ [] } /> );
+		assert.lengthOf( picker.find( '*' ), 0 );
+	} );
+
+	test( 'should display nothing if a single plans is specified', () => {
+		const picker = shallow( <TermPicker productsWithPrices={ [ {} ] } /> );
+		assert.lengthOf( picker.find( '*' ), 0 );
+	} );
+
+	test( 'should have term-picker class', () => {
+		const picker = shallow( <TermPicker productsWithPrices={ productsWithPrices } /> );
+		assert.lengthOf( picker.find( '.term-picker' ), 1 );
+	} );
+
+	test( 'should contain as many <TermPickerOption/> as products passed', () => {
+		const picker = shallow( <TermPicker productsWithPrices={ productsWithPrices } /> );
+		assert.lengthOf( picker.find( 'TermPickerOption' ), 2 );
+	} );
+
+	test( 'should mark appropriate TermPickerOption as checked', () => {
+		const picker = shallow(
+			<TermPicker
+				productsWithPrices={ productsWithPrices }
+				initialValue={ PLAN_BUSINESS_2_YEARS }
+			/>
+		);
+		assert.equal(
+			picker
+				.find( 'TermPickerOption' )
+				.first()
+				.props().checked,
+			false
+		);
+		assert.equal(
+			picker
+				.find( 'TermPickerOption' )
+				.last()
+				.props().checked,
+			true
+		);
+	} );
+} );

--- a/client/components/term-picker/test/index.js
+++ b/client/components/term-picker/test/index.js
@@ -6,7 +6,14 @@ jest.mock( 'lib/abtest', () => ( {
 
 const translate = x => x;
 jest.mock( 'i18n-calypso', () => ( {
-	localize: Comp => props => <Comp { ...props } translate={ translate } />,
+	localize: Comp => props => (
+		<Comp
+			{ ...props }
+			translate={ function( x ) {
+				return x;
+			} }
+		/>
+	),
 	numberFormat: x => x,
 } ) );
 

--- a/client/components/term-picker/test/index.js
+++ b/client/components/term-picker/test/index.js
@@ -4,6 +4,12 @@ jest.mock( 'lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
+const translate = x => x;
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Comp => props => <Comp { ...props } translate={ translate } />,
+	numberFormat: x => x,
+} ) );
+
 /**
  * External dependencies
  */
@@ -35,12 +41,21 @@ describe( 'TermPicker basic tests', () => {
 	];
 
 	test( 'should have term-picker class', () => {
-		const picker = shallow( <TermPicker productsWithPrices={ [] } /> );
+		const picker = shallow(
+			<TermPicker productsWithPrices={ [] } currencyCode={ 'USD' } translate={ translate } />
+		);
 		assert.lengthOf( picker.find( '.term-picker' ), 1 );
 	} );
 
 	test( 'should contain as many <TermPickerOption/> as products passed', () => {
-		const picker = shallow( <TermPicker productsWithPrices={ productsWithPrices } /> );
+		const picker = shallow(
+			<TermPicker
+				productsWithPrices={ productsWithPrices }
+				currencyCode={ 'USD' }
+				translate={ translate }
+			/>
+		);
+		assert.equal( picker.html(), 'abc' );
 		assert.lengthOf( picker.find( 'TermPickerOption' ), 2 );
 	} );
 
@@ -49,6 +64,8 @@ describe( 'TermPicker basic tests', () => {
 			<TermPicker
 				productsWithPrices={ productsWithPrices }
 				initialValue={ PLAN_BUSINESS_2_YEARS }
+				currencyCode={ 'USD' }
+				translate={ translate }
 			/>
 		);
 		assert.equal(

--- a/client/components/term-picker/test/index.js
+++ b/client/components/term-picker/test/index.js
@@ -84,19 +84,13 @@ describe( 'TermPicker basic tests', () => {
 				translate={ translate }
 			/>
 		);
-		assert.equal(
-			picker
-				.find( 'TermPickerOption' )
-				.first()
-				.props().checked,
-			false
-		);
-		assert.equal(
-			picker
-				.find( 'TermPickerOption' )
-				.last()
-				.props().checked,
-			true
-		);
+
+		const first = picker.find( 'TermPickerOption' ).first();
+		assert.equal( first.props().value, PLAN_BUSINESS );
+		assert.equal( first.props().checked, false );
+
+		const last = picker.find( 'TermPickerOption' ).last();
+		assert.equal( last.props().value, PLAN_BUSINESS_2_YEARS );
+		assert.equal( last.props().checked, true );
 	} );
 } );

--- a/client/components/term-picker/test/index.js
+++ b/client/components/term-picker/test/index.js
@@ -6,14 +6,24 @@ jest.mock( 'lib/abtest', () => ( {
 
 const translate = x => x;
 jest.mock( 'i18n-calypso', () => ( {
-	localize: Comp => props => (
-		<Comp
-			{ ...props }
-			translate={ function( x ) {
-				return x;
-			} }
-		/>
-	),
+	localize: ComposedComponent => {
+		const React = require( 'react' );
+		const componentName = ComposedComponent.displayName || ComposedComponent.name || '';
+		return class Wrapper extends React.Component {
+			static displayName = componentName;
+
+			render() {
+				return (
+					<ComposedComponent
+						{ ...this.props }
+						translate={ function( x ) {
+							return x;
+						} }
+					/>
+				);
+			}
+		};
+	},
 	numberFormat: x => x,
 } ) );
 
@@ -62,7 +72,6 @@ describe( 'TermPicker basic tests', () => {
 				translate={ translate }
 			/>
 		);
-		assert.equal( picker.html(), 'abc' );
 		assert.lengthOf( picker.find( 'TermPickerOption' ), 2 );
 	} );
 

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -28,6 +28,7 @@ import SearchCard from 'components/search-card';
 import ActionCard from 'components/action-card/docs/example';
 import Accordions from 'components/accordion/docs/example';
 import BackButton from 'components/back-button/docs/example';
+import Badge from 'components/badge/docs/example';
 import Banner from 'components/banner/docs/example';
 import BulkSelect from 'components/bulk-select/docs/example';
 import ButtonGroups from 'components/button-group/docs/example';
@@ -88,6 +89,7 @@ import SpinnerLine from 'components/spinner-line/docs/example';
 import SplitButton from 'components/split-button/docs/example';
 import Suggestions from 'components/suggestions/docs/example';
 import TextDiff from 'components/text-diff/docs/example';
+import TermPickerOption from 'components/term-picker-option/docs/example';
 import TileGrid from 'components/tile-grid/docs/example';
 import TimeSince from 'components/time-since/docs/example';
 import Timezone from 'components/timezone/docs/example';
@@ -154,6 +156,7 @@ class DesignAssets extends React.Component {
 					<BulkSelect readmeFilePath="bulk-select" />
 					<ButtonGroups readmeFilePath="button-group" />
 					<Buttons componentUsageStats={ componentsUsageStats.button } readmeFilePath="button" />
+					<Badge />
 					<SplitButton readmeFilePath="split-button" />
 					<Cards readmeFilePath="card" />
 					<Checklist />
@@ -211,6 +214,7 @@ class DesignAssets extends React.Component {
 					<SpinnerLine searchKeywords="loading" readmeFilePath="spinner-line" />
 					<Suggestions />
 					<TextDiff />
+					<TermPickerOption />
 					<TileGrid />
 					<TimeSince />
 					<Timezone readmeFilePath="timezone" />

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -759,6 +759,7 @@ Undocumented.prototype.getSitePlans = function( siteDomain, fn ) {
 		{
 			path: '/sites/' + siteDomain + '/plans',
 			method: 'get',
+			apiVersion: config.isEnabled( 'upgrades/2-year-plans' ) ? '1.3' : '1.1',
 		},
 		fn
 	);

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -67,8 +67,7 @@ import { fetchSitesAndUser } from 'lib/signup/step-actions';
 import { loadTrackingTool } from 'state/analytics/actions';
 import { getProductsList, isProductsListFetching } from 'state/products-list/selectors';
 import QueryProducts from 'components/data/query-products-list';
-import { PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS } from '../../../lib/plans/constants';
-import { getPlan } from '../../../lib/plans';
+import { getPlan, findPlansKeys } from '../../../lib/plans';
 
 class Checkout extends React.Component {
 	static propTypes = {
@@ -500,7 +499,15 @@ class Checkout extends React.Component {
 			return false;
 		}
 
-		const availableTerms = [ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ];
+		const currentPlan = getPlan( planInCart.product_slug );
+		const availableTerms = findPlansKeys( {
+			group: currentPlan.group,
+			type: currentPlan.type,
+		} );
+
+		if ( ! availableTerms.length ) {
+			return false;
+		}
 
 		return (
 			<React.Fragment>

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -519,7 +519,7 @@ class Checkout extends React.Component {
 					onChange={ this.handleTermChange }
 					key="picker"
 				/>
-				<hr className="term-picker-separator" key="separator" />
+				<hr className="checkout__term-picker-separator" key="separator" />
 			</React.Fragment>
 		);
 	}

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -477,10 +477,23 @@ class Checkout extends React.Component {
 				redirectTo={ this.getCheckoutCompleteRedirectPath }
 				handleCheckoutCompleteRedirect={ this.handleCheckoutCompleteRedirect }
 			>
-				<TermPicker plans={ [ PLAN_PREMIUM, PLAN_BUSINESS ] } initialValue={ PLAN_BUSINESS } />
+				{ this.renderTermPicker() }
 			</SecurePaymentForm>
 		);
 	}
+
+	renderTermPicker() {
+		return (
+			<React.Fragment>
+				<TermPicker
+					plans={ [ PLAN_PREMIUM, PLAN_BUSINESS ] }
+					initialValue={ PLAN_BUSINESS }
+					key="picker"
+				/>
+				<hr className="term-picker-separator" key="separator" />
+			</React.Fragment>
+		);
+	},
 
 	paymentMethodsAbTestFilter() {
 		// This methods can be used to filter payment methods

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -14,6 +14,7 @@ import React from 'react';
  */
 import { abtest, getABTestVariation } from 'lib/abtest';
 import analytics from 'lib/analytics';
+import config from 'config';
 import { cartItems } from 'lib/cart-values';
 import { clearSitePlans } from 'state/sites/plans/actions';
 import { clearPurchases } from 'state/purchases/actions';
@@ -488,7 +489,7 @@ class Checkout extends React.Component {
 				redirectTo={ this.getCheckoutCompleteRedirectPath }
 				handleCheckoutCompleteRedirect={ this.handleCheckoutCompleteRedirect }
 			>
-				{ this.renderTermPicker() }
+				{ config.isEnabled( 'upgrades/2-year-plans' ) && this.renderTermPicker() }
 			</SecurePaymentForm>
 		);
 	}

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -499,13 +499,13 @@ class Checkout extends React.Component {
 			return false;
 		}
 
-		const currentPlan = getPlan( this.props.selectedSite.plan.product_slug );
+		const currentPlanSlug = this.props.selectedSite.plan.product_slug;
 
 		const chosenPlan = getPlan( planInCart.product_slug );
 		const availableTerms = findPlansKeys( {
 			group: chosenPlan.group,
 			type: chosenPlan.type,
-		} ).filter( p => getPlan( p ).availableFor( currentPlan ) );
+		} ).filter( p => getPlan( p ).availableFor( currentPlanSlug ) );
 
 		if ( availableTerms.length < 2 ) {
 			return false;

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -31,6 +31,7 @@ import { managePurchase } from 'me/purchases/paths';
 import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
 import QueryStoredCards from 'components/data/query-stored-cards';
 import QueryGeo from 'components/data/query-geo';
+import TermPicker from 'components/term-picker';
 import SecurePaymentForm from './secure-payment-form';
 import SecurePaymentFormPlaceholder from './secure-payment-form-placeholder';
 import { AUTO_RENEWAL } from 'lib/url/support';
@@ -59,6 +60,7 @@ import { fetchSitesAndUser } from 'lib/signup/step-actions';
 import { loadTrackingTool } from 'state/analytics/actions';
 import { getProductsList, isProductsListFetching } from 'state/products-list/selectors';
 import QueryProducts from 'components/data/query-products-list';
+import { PLAN_PREMIUM, PLAN_BUSINESS } from '../../../lib/plans/constants';
 
 class Checkout extends React.Component {
 	static propTypes = {
@@ -474,7 +476,9 @@ class Checkout extends React.Component {
 				selectedSite={ selectedSite }
 				redirectTo={ this.getCheckoutCompleteRedirectPath }
 				handleCheckoutCompleteRedirect={ this.handleCheckoutCompleteRedirect }
-			/>
+			>
+				<TermPicker plans={ [ PLAN_PREMIUM, PLAN_BUSINESS ] } initialValue={ PLAN_BUSINESS } />
+			</SecurePaymentForm>
 		);
 	}
 

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -67,7 +67,7 @@ import { fetchSitesAndUser } from 'lib/signup/step-actions';
 import { loadTrackingTool } from 'state/analytics/actions';
 import { getProductsList, isProductsListFetching } from 'state/products-list/selectors';
 import QueryProducts from 'components/data/query-products-list';
-import { PLAN_PREMIUM, PLAN_BUSINESS } from '../../../lib/plans/constants';
+import { PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS } from '../../../lib/plans/constants';
 import { getPlan } from '../../../lib/plans';
 
 class Checkout extends React.Component {
@@ -500,7 +500,7 @@ class Checkout extends React.Component {
 			return false;
 		}
 
-		const availableTerms = [ PLAN_BUSINESS, PLAN_PREMIUM ];
+		const availableTerms = [ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ];
 
 		return (
 			<React.Fragment>

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -161,7 +161,7 @@ class Checkout extends React.Component {
 
 	getPlanProducts() {
 		return this.props.cart.products.filter( p => getPlan( p.product_slug ) );
-	},
+	}
 
 	getProductSlugFromSynonym( slug ) {
 		if ( 'no-ads' === slug ) {
@@ -522,7 +522,7 @@ class Checkout extends React.Component {
 				<hr className="term-picker-separator" key="separator" />
 			</React.Fragment>
 		);
-	},
+	}
 
 	handleTermChange( e ) {
 		// Remove all cart items that are plans
@@ -537,7 +537,7 @@ class Checkout extends React.Component {
 			from_section: 'checkout',
 		} );
 		addItem( cartItem );
-	},
+	}
 
 	paymentMethodsAbTestFilter() {
 		// This methods can be used to filter payment methods

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -499,13 +499,15 @@ class Checkout extends React.Component {
 			return false;
 		}
 
-		const currentPlan = getPlan( planInCart.product_slug );
-		const availableTerms = findPlansKeys( {
-			group: currentPlan.group,
-			type: currentPlan.type,
-		} );
+		const currentPlan = getPlan( this.props.selectedSite.plan.product_slug );
 
-		if ( ! availableTerms.length ) {
+		const chosenPlan = getPlan( planInCart.product_slug );
+		const availableTerms = findPlansKeys( {
+			group: chosenPlan.group,
+			type: chosenPlan.type,
+		} ).filter( p => getPlan( p ).availableFor( currentPlan ) );
+
+		if ( availableTerms.length < 2 ) {
 			return false;
 		}
 

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -524,7 +524,7 @@ class Checkout extends React.Component {
 		);
 	}
 
-	handleTermChange( e ) {
+	handleTermChange = e => {
 		// Remove all cart items that are plans
 		const selectedPlans = this.props.cart.products.filter( p => getPlan( p.product_slug ) );
 		selectedPlans.forEach( removeItem );
@@ -537,7 +537,7 @@ class Checkout extends React.Component {
 			from_section: 'checkout',
 		} );
 		addItem( cartItem );
-	}
+	};
 
 	paymentMethodsAbTestFilter() {
 		// This methods can be used to filter payment methods

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -188,6 +188,8 @@ export class CreditCardPaymentBox extends React.Component {
 					transaction={ transaction }
 				/>
 
+				{ this.props.children }
+
 				<TermsOfService
 					hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( cart ) }
 				/>

--- a/client/my-sites/checkout/checkout/credits-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credits-payment-box.jsx
@@ -50,6 +50,8 @@ class CreditsPaymentBox extends React.Component {
 					</div>
 				</div>
 
+				{ this.props.children }
+
 				<TermsOfService />
 
 				<div className="payment-box-actions">

--- a/client/my-sites/checkout/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/paypal-payment-box.jsx
@@ -168,6 +168,8 @@ class PaypalPaymentBox extends React.Component {
 					</div>
 				</div>
 
+				{ this.props.children }
+
 				<TermsOfService
 					hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription(
 						this.props.cart

--- a/client/my-sites/checkout/checkout/secure-payment-form-placeholder.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form-placeholder.jsx
@@ -28,6 +28,14 @@ const SecurePaymentFormPlaceholder = () => {
 				</div>
 				<div className="placeholder-row placeholder" />
 			</div>
+			<div className="payment-box-section">
+				<div className="placeholder-col-narrow placeholder-inline-pad">
+					<div className="placeholder" />
+				</div>
+				<div className="placeholder-col-narrow">
+					<div className="placeholder" />
+				</div>
+			</div>
 			<div className="payment-box-hr" />
 			<div className="placeholder-button-container">
 				<div className="placeholder-col-narrow">

--- a/client/my-sites/checkout/checkout/secure-payment-form-placeholder.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form-placeholder.jsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -28,14 +29,16 @@ const SecurePaymentFormPlaceholder = () => {
 				</div>
 				<div className="placeholder-row placeholder" />
 			</div>
-			<div className="payment-box-section">
-				<div className="placeholder-col-narrow placeholder-inline-pad">
-					<div className="placeholder" />
+			{ config.isEnabled( 'upgrades/2-year-plans' ) && (
+				<div className="payment-box-section">
+					<div className="placeholder-col-narrow placeholder-inline-pad">
+						<div className="placeholder" />
+					</div>
+					<div className="placeholder-col-narrow">
+						<div className="placeholder" />
+					</div>
 				</div>
-				<div className="placeholder-col-narrow">
-					<div className="placeholder" />
-				</div>
-			</div>
+			) }
 			<div className="payment-box-hr" />
 			<div className="placeholder-button-container">
 				<div className="placeholder-col-narrow">

--- a/client/my-sites/checkout/checkout/secure-payment-form-placeholder.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form-placeholder.jsx
@@ -13,6 +13,7 @@ import config from 'config';
 import PaymentBox from './payment-box.jsx';
 
 const SecurePaymentFormPlaceholder = () => {
+	/*eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<PaymentBox classSet="selected is-empty" contentClassSet="selected is-empty">
 			<div className="payment-box-section">
@@ -47,6 +48,7 @@ const SecurePaymentFormPlaceholder = () => {
 			</div>
 		</PaymentBox>
 	);
+	/*eslint-enable wpcalypso/jsx-classname-namespace */
 };
 
 export default SecurePaymentFormPlaceholder;

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -166,7 +166,9 @@ const SecurePaymentForm = createReactClass( {
 				onSubmit={ this.handlePaymentBoxSubmit }
 				transactionStep={ this.props.transaction.step }
 				presaleChatAvailable={ this.props.presaleChatAvailable }
-			/>
+			>
+				{ this.props.children }
+			</CreditsPaymentBox>
 		);
 	},
 
@@ -211,7 +213,9 @@ const SecurePaymentForm = createReactClass( {
 					onSubmit={ this.handlePaymentBoxSubmit }
 					transactionStep={ this.props.transaction.step }
 					presaleChatAvailable={ this.props.presaleChatAvailable }
-				/>
+				>
+					{ this.props.children }
+				</CreditCardPaymentBox>
 			</PaymentBox>
 		);
 	},
@@ -232,7 +236,9 @@ const SecurePaymentForm = createReactClass( {
 					selectedSite={ this.props.selectedSite }
 					redirectTo={ this.props.redirectTo }
 					presaleChatAvailable={ this.props.presaleChatAvailable }
-				/>
+				>
+					{ this.props.children }
+				</PayPalPaymentBox>
 			</PaymentBox>
 		);
 	},
@@ -362,7 +368,6 @@ const SecurePaymentForm = createReactClass( {
 			<div className="secure-payment-form">
 				{ this.renderGetDotBlogNotice() }
 				{ this.renderPaymentBox() }
-				{ this.props.children }
 			</div>
 		);
 	},

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -362,6 +362,7 @@ const SecurePaymentForm = createReactClass( {
 			<div className="secure-payment-form">
 				{ this.renderGetDotBlogNotice() }
 				{ this.renderPaymentBox() }
+				{ this.props.children }
 			</div>
 		);
 	},

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -376,6 +376,35 @@
 		}
 	}
 
+	// Term-picker rules
+	// -----------------------------------
+
+	.term-picker {
+		margin-top: 15px;
+	}
+
+	.term-picker-separator {
+		display: none;
+		position: relative;
+		// Parent overflow is hidden, so 80px here is an arbitrary number
+		// to make sure this element will cover entire width of the parent.
+		// If it's wider, it's okay too.
+		width: calc(100% + 80px * 2);
+		left: -80px;
+		margin-top: 1.7em;
+		margin-top: 1.7em;
+		margin-bottom: 1.7em;
+		background: #EAF1F5;
+	}
+
+	.term-picker + .term-picker-separator {
+		display: block;
+	}
+
+	.term-picker-box ~ .checkout__payment-box-actions {
+		margin-top: 0;
+	}
+
 	// PayPal Payment Box
 	// -----------------------------------
 

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -383,7 +383,7 @@
 		margin-top: 15px;
 	}
 
-	.term-picker-separator {
+	&__term-picker-separator {
 		display: none;
 		position: relative;
 		// Parent overflow is hidden, so 80px here is an arbitrary number

--- a/client/state/data-layer/wpcom/plans/index.js
+++ b/client/state/data-layer/wpcom/plans/index.js
@@ -3,6 +3,7 @@
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { PLANS_REQUEST } from 'state/action-types';
@@ -25,7 +26,7 @@ import {
 export const requestPlans = action =>
 	http(
 		{
-			apiVersion: '1.4',
+			apiVersion: config.isEnabled( 'upgrades/2-year-plans' ) ? '1.5' : '1.4',
 			method: 'GET',
 			path: '/plans',
 		},

--- a/client/state/data-layer/wpcom/plans/test/index.js
+++ b/client/state/data-layer/wpcom/plans/test/index.js
@@ -2,6 +2,7 @@
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { receivePlans, receiveError, requestPlans } from '../';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
@@ -20,7 +21,7 @@ describe( 'wpcom-api', () => {
 				expect( requestPlans( action ) ).toEqual(
 					http(
 						{
-							apiVersion: '1.4',
+							apiVersion: config.isEnabled( 'upgrades/2-year-plans' ) ? '1.5' : '1.4',
 							method: 'GET',
 							path: '/plans',
 						},

--- a/config/development.json
+++ b/config/development.json
@@ -168,6 +168,7 @@
 		"try/single-cdn": true,
 		"ui/first-view": true,
 		"ui/first-view/reset-route": true,
+		"upgrades/2-year-plans": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/config/production.json
+++ b/config/production.json
@@ -118,6 +118,7 @@
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,
+		"upgrades/2-year-plans": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -122,6 +122,7 @@
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,
+		"upgrades/2-year-plans": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/config/test.json
+++ b/config/test.json
@@ -96,6 +96,7 @@
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": false,
+		"upgrades/2-year-plans": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -140,6 +140,7 @@
 		"try/single-cdn": true,
 		"ui/first-view": true,
 		"ui/first-view/reset-route": true,
+		"upgrades/2-year-plans": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,


### PR DESCRIPTION
This is an implementation of the following feature:

<img width="976" alt="zrzut ekranu 2018-03-22 o 10 29 33" src="https://user-images.githubusercontent.com/205419/37762217-f3dcce56-2dbb-11e8-8a18-7ee4e374a667.png">

Test plan (on both desktop and mobile):

1. Pick any plan either as a first plan or as an upgrade plan
2. Go to checkout
3. Click on the another term
4. Confirm that cart was updated
5. I don't think API is ready for actually finalising the purchase so testing ends here