### PR TITLE
Privacy settings: Add toggle for Tracks opt-out

### DIFF
--- a/client/me/privacy/controller.js
+++ b/client/me/privacy/controller.js
@@ -10,12 +10,15 @@ import page from 'page';
  * Internal dependencies
  */
 import config from 'config';
+import userSettings from 'lib/user-settings';
 import PrivacyComponent from 'me/privacy/main';
 
 export default function privacyController( context, next ) {
 	if ( ! config.isEnabled( 'me/privacy' ) ) {
 		return page.redirect( '/me' );
 	}
-	context.primary = React.createElement( PrivacyComponent );
+	context.primary = React.createElement( PrivacyComponent, {
+		userSettings: userSettings,
+	} );
 	next();
 }

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -3,25 +3,89 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
 import DocumentHead from 'components/data/document-head';
+import FormButton from 'components/forms/form-button';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLegend from 'components/forms/form-legend';
+import FormToggle from 'components/forms/form-toggle';
 import Main from 'components/main';
+import observe from 'lib/mixins/data-observe';
+import { protectForm } from 'lib/protect-form';
+import twoStepAuthorization from 'lib/two-step-authorization';
+import ReauthRequired from 'me/reauth-required';
+import formBase from 'me/form-base';
+import MeSidebarNavigation from 'me/sidebar-navigation';
 
-class Privacy extends Component {
+const TRACKS_OPT_OUT_USER_SETTINGS_KEY = 'tracks_opt_out';
+
+const Privacy = createReactClass( {
+	/**
+	 * `formBase` is used for `getDisabledState` and `submitForm`
+	 * `observe` is used to trigger a re-render on userSettings changes
+	 */
+	mixins: [ formBase, observe( 'userSettings' ) ],
+
+	propTypes: {
+		userSettings: PropTypes.object.isRequired,
+	},
+
+	updateTracksOptOut( isSendingTracksEvents ) {
+		this.props.userSettings.updateSetting(
+			TRACKS_OPT_OUT_USER_SETTINGS_KEY,
+			! isSendingTracksEvents
+		);
+	},
+
 	render() {
+		const { markChanged, translate, userSettings } = this.props;
+
+		const isSubmitButtonDisabled = ! userSettings.hasUnsavedSettings() || this.getDisabledState();
+
+		const isSendingTracksEvent = ! this.props.userSettings.getSetting(
+			TRACKS_OPT_OUT_USER_SETTINGS_KEY
+		);
+
 		return (
 			<Main className="privacy">
 				<DocumentHead title={ this.props.translate( 'Privacy Settings' ) } />
-				Privacy form incoming
+				<MeSidebarNavigation />
+				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+				<Card className="privacy__settings">
+					<form onChange={ markChanged } onSubmit={ this.submitForm }>
+						<FormFieldset>
+							<FormLegend>{ translate( 'Usage Statistics' ) }</FormLegend>
+							<FormToggle
+								id="tracks_opt_out"
+								checked={ isSendingTracksEvent }
+								onChange={ this.updateTracksOptOut }
+							>
+								{ translate( 'Send usage statistics to help us improve our products.' ) }
+							</FormToggle>
+						</FormFieldset>
+
+						<FormButton
+							isSubmitting={ this.state.submittingForm }
+							disabled={ isSubmitButtonDisabled }
+						>
+							{ this.state.submittingForm
+								? translate( 'Saving…' )
+								: translate( 'Save Privacy Settings' ) }
+						</FormButton>
+					</form>
+				</Card>
 			</Main>
 		);
-	}
-}
+	},
+} );
 
-export default compose( localize )( Privacy );
+export default compose( localize, protectForm )( Privacy );


### PR DESCRIPTION
Introduces a toggle to set/unset the Tracks opt out and save it server-side in the newly introduced privacy section #22632

![calypso localhost_3000_me_privacy](https://user-images.githubusercontent.com/1145270/37291659-6434a674-260f-11e8-9b5b-cfef5d463fbc.png)

**Testing**
1- Apply D9412-code on your sandbox and sandbox `public-api.wordpress.com` to get the new `tracks_opt_out` key in your user settings.
2- Go to [the Privacy section](http://calypso.localhost:3000/me/privacy)
3- Enable the opt-out, disable it, check that the success and error notices appear correctly, that the submit button is disabled while the fetch is ongoing ...

**Notes**
* The opt-out in Calypso is not done yet, another PR is coming to tie it with #21652 , this simply saves the status of the toggle server-side + adds the UI for it.
* You will note that if you do a double-toggle ( enable and then disable ) so that it comes back to its original state, the button to "Save the privacy settings" is still enabled. This is due to a bug in `user-settings` that I'll tackle in #23232
* We're going back to `create-react-class` to use the `formBase` / `observe` mixins as noted in [this comment](https://github.com/Automattic/wp-calypso/pull/22693#issuecomment-369236635).