### PR TITLE
Fix user settings deleting unsaved settings behavior when coming back to the original values

### DIFF
--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -38,18 +38,15 @@ function decodeUserSettingsEntities( data ) {
  * Deletes a provided unsaved setting, then calls itself recursively
  * to delete any empty parents of the setting passed to it
  */
-function deleteUnsavedSetting( settings, settingName, recursive ) {
-	if ( ! isEmpty( get( settings, settingName ) ) || recursive ) {
-		unset( settings, settingName );
-
-		const settingKeys = settingName.split( '.' );
-		if ( settingKeys.length > 1 ) {
-			settingKeys.pop();
-			const parentKey = settingKeys.join( '.' );
-			//if parent is empty, call function again
-			if ( parentKey && isEmpty( get( settings, parentKey ) ) ) {
-				deleteUnsavedSetting( settings, parentKey, true );
-			}
+function deleteUnsavedSetting( settings, settingName ) {
+	unset( settings, settingName );
+	const settingKeys = settingName.split( '.' );
+	if ( settingKeys.length > 1 ) {
+		settingKeys.pop();
+		const parentKey = settingKeys.join( '.' );
+		// if parent is empty, call function again
+		if ( parentKey && isEmpty( get( settings, parentKey ) ) ) {
+			deleteUnsavedSetting( settings, parentKey );
 		}
 	}
 }

--- a/client/lib/user-settings/test/index.js
+++ b/client/lib/user-settings/test/index.js
@@ -13,7 +13,9 @@ jest.mock( 'lib/wp', () => require( './mocks/wp' ) );
 jest.mock( 'lib/user/utils', () => require( './mocks/user-utils' ) );
 
 describe( 'User Settings', () => {
-	beforeAll( () => {
+	beforeEach( () => {
+		userSettings.settings = {};
+		userSettings.unsavedSettings = {};
 		userSettings.fetchSettings();
 	} );
 
@@ -112,5 +114,21 @@ describe( 'User Settings', () => {
 			expect( userSettings.settings.testParent.testChild ).toBe( true );
 			done();
 		}
+	} );
+
+	test( 'should clean unsaved settings if swaping back to the original value', () => {
+		expect( userSettings.settings.test ).toEqual( false );
+		expect( userSettings.updateSetting( 'test', true ) ).toBe( true );
+		expect( userSettings.unsavedSettings ).toEqual( { test: true } );
+		expect( userSettings.updateSetting( 'test', false ) ).toBe( true );
+		expect( userSettings.unsavedSettings ).toEqual( {} );
+	} );
+
+	test( 'should clean unsaved nested settings if the parent becomes empty', () => {
+		expect( userSettings.settings.testParent.testChild ).toBe( false );
+		expect( userSettings.updateSetting( 'testParent.testChild', true ) ).toBe( true );
+		expect( userSettings.unsavedSettings ).toEqual( { testParent: { testChild: true } } );
+		expect( userSettings.updateSetting( 'testParent.testChild', false ) ).toBe( true );
+		expect( userSettings.unsavedSettings ).toEqual( {} );
 	} );
 } );


### PR DESCRIPTION
This fixes a bug introduced in #17259, reverting it back to its [original intent](https://github.com/Automattic/wp-calypso/blame/5c33de5439a3ead4be6e86115427876bd544b9ad/client/lib/user-settings/index.js#L216) ( though the code is hardly the same :) )

The issue arises with boolean user settings that you double-swap so that it goes from original state A, to updated state B and then back to original state A. In the current implementation, the setting will not be removed from `unsavedSettings` because:
```
if ( ! isEmpty( get( settings, settingName ) ) || recursive ) {
```
will evaluate to false on boolean settings:
```
isEmpty( true ) === true
isEmpty( false ) === true
```
which means we never reach [the unset line](https://github.com/Automattic/wp-calypso/blob/b4cf1f8dae87b146fd24f0b596442e8a6514548a/client/lib/user-settings/index.js#L35).

**Testing**
* The unit tests way:
```
npm run test-client -- lib/user-settings
```
* The visual way by following the same instructions as #23231 and doing a double-swap on the toggle.

**Note**
* I based this branch on `add/opt-out-form` so that you can visually test that it works as expected by double-swapping the Tracks opt-out toggle, though hopefully the newly introduced unit tests are covering this.
* I updated a bit the unit tests to have a proper clear between tests
