### PR TITLE
Devdocs: fix Combined Card example

### DIFF
--- a/client/blocks/reader-combined-card/docs/example.jsx
+++ b/client/blocks/reader-combined-card/docs/example.jsx
@@ -3,13 +3,12 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 
 /**
  * Internal dependencies
  */
-import ReaderCombinedCardBlock from 'blocks/reader-combined-card';
+import { ReaderCombinedCard, combinedCardPostKeyToKeys } from 'blocks/reader-combined-card';
 import { posts, feed, site } from 'blocks/reader-post-card/docs/fixtures';
 
 const postKey = {
@@ -17,14 +16,20 @@ const postKey = {
 	postIds: posts.map( ( { global_ID } ) => global_ID ),
 };
 
-const ReaderCombinedCard = () => (
+const ReaderCombinedCardExample = () => (
 	<div className="design-assets__group">
 		<div>
-			<ReaderCombinedCardBlock postKey={ postKey } posts={ posts } feed={ feed } site={ site } />
+			<ReaderCombinedCard
+				postKey={ postKey }
+				postKeys={ combinedCardPostKeyToKeys( postKey ) }
+				posts={ posts }
+				feed={ feed }
+				site={ site }
+			/>
 		</div>
 	</div>
 );
 
-ReaderCombinedCard.displayName = 'ReaderCombinedCard';
+ReaderCombinedCardExample.displayName = 'ReaderCombinedCard';
 
-export default ReaderCombinedCard;
+export default ReaderCombinedCardExample;

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -176,8 +176,14 @@ function combinedCardPostKeyToKeys( postKey ) {
 export default connect( ( state, ownProps ) => {
 	const postKeys = combinedCardPostKeyToKeys( ownProps.postKey );
 
+	// Posts are directly supplied in Devdocs
+	let posts = ownProps.posts;
+	if ( ! posts ) {
+		posts = getPostsByKeys( state, postKeys );
+	}
+
 	return {
-		posts: getPostsByKeys( state, postKeys ),
+		posts,
 		postKeys,
 	};
 } )( localize( ReaderCombinedCard ) );

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -26,7 +26,7 @@ import { getPostsByKeys } from 'state/reader/posts/selectors';
 import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
 import PostBlocked from 'blocks/reader-post-card/blocked';
 
-class ReaderCombinedCard extends React.Component {
+class ReaderCombinedCardComponent extends React.Component {
 	static propTypes = {
 		posts: PropTypes.array.isRequired,
 		site: PropTypes.object,
@@ -163,7 +163,7 @@ class ReaderCombinedCard extends React.Component {
 	}
 }
 
-function combinedCardPostKeyToKeys( postKey ) {
+export function combinedCardPostKeyToKeys( postKey ) {
 	if ( ! postKey || ! postKey.postIds ) {
 		return [];
 	}
@@ -173,17 +173,13 @@ function combinedCardPostKeyToKeys( postKey ) {
 	return postKey.postIds.map( postId => ( { feedId, blogId, postId } ) );
 }
 
+export const ReaderCombinedCard = localize( ReaderCombinedCardComponent );
+
 export default connect( ( state, ownProps ) => {
 	const postKeys = combinedCardPostKeyToKeys( ownProps.postKey );
 
-	// Posts are directly supplied in Devdocs
-	let posts = ownProps.posts;
-	if ( ! posts ) {
-		posts = getPostsByKeys( state, postKeys );
-	}
-
 	return {
-		posts,
+		posts: getPostsByKeys( state, postKeys ),
 		postKeys,
 	};
-} )( localize( ReaderCombinedCard ) );
+} )( ReaderCombinedCard );

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -148,6 +148,11 @@ class ReaderPostOptionsMenu extends React.Component {
 
 	render() {
 		const { post, site, feed, teams, translate, position } = this.props;
+
+		if ( ! post ) {
+			return null;
+		}
+
 		const { ID: postId, site_ID: siteId } = post;
 		const isEditPossible = PostUtils.userCan( 'edit_post', post );
 		const isDiscoverPost = DiscoverHelper.isDiscoverPost( post );
@@ -251,8 +256,8 @@ class ReaderPostOptionsMenu extends React.Component {
 
 export default connect(
 	( state, ownProps ) => {
-		const feedId = ownProps.post.feed_ID;
-		const siteId = ownProps.post.is_external ? null : ownProps.post.site_ID;
+		const feedId = ownProps.post && ownProps.post.feed_ID;
+		const siteId = ownProps.post && ( ownProps.post.is_external ? null : ownProps.post.site_ID );
 		return {
 			feed: feedId && feedId > 0 ? getFeed( state, feedId ) : undefined,
 			site: siteId && siteId > 0 ? getSite( state, siteId ) : undefined,

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -255,14 +255,14 @@ class ReaderPostOptionsMenu extends React.Component {
 }
 
 export default connect(
-	( state, ownProps ) => {
-		const feedId = ownProps.post && ownProps.post.feed_ID;
-		const siteId = ownProps.post && ( ownProps.post.is_external ? null : ownProps.post.site_ID );
-		return {
-			feed: feedId && feedId > 0 ? getFeed( state, feedId ) : undefined,
-			site: siteId && siteId > 0 ? getSite( state, siteId ) : undefined,
-			teams: getReaderTeams( state ),
-		};
+	( state, { post: { feed_ID: feedId, is_external, site_ID } = {} } ) => {
+		const siteId = is_external ? null : site_ID;
+
+		return Object.assign(
+			{ teams: getReaderTeams( state ) },
+			feedId > 0 && { feed: getFeed( state, feedId ) },
+			siteId > 0 && { site: getSite( state, siteId ) }
+		);
 	},
 	{
 		blockSite,


### PR DESCRIPTION
clone of https://github.com/Automattic/wp-calypso/pull/23166 but with less slashes in the branch name

> We recently added an ellipsis menu to Combined Cards in https://github.com/Automattic/wp-calypso/pull/22990. This relies on a valid post object for each post in the combined card.

> The Devdocs example was attempting and failing to pull posts from Discover, which caused the post options menu to bail. 

> This is currently breaking the blocks view at http://calypso.localhost:3000/devdocs/blocks.

> This PR updates the combined card example to use the unconnected component, and makes ReaderPostOptionsMenu more resilient when the post is missing.

### To test

> Make sure https://wpcalypso.wordpress.com/devdocs/blocks and https://wpcalypso.wordpress.com/devdocs/blocks/reader-combined-card load successfully.

> ![screen shot 2018-03-09 at 10 24 43](https://user-images.githubusercontent.com/17325/37202977-1f59535c-2384-11e8-9f48-ba1efe7c7100.png)

> Make sure combined cards look correct in Reader streams:

> ![screen shot 2018-03-09 at 10 24 15](https://user-images.githubusercontent.com/17325/37202982-228dac30-2384-11e8-91fb-f0b7549c070d.png)
