### PR TITLE
Devdocs: warn about slashes in branch names

### DIFF
--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -15,7 +15,7 @@ Branches use the following naming conventions:
 
 For example, you can run: `git checkout master` and then `git checkout -b fix/whatsits` to create a new `fix/whatsits` branch off of `origin/master`.
 
-**warning**: Do not use two slashes in the name of a branch. It can too-easily [cause issues](https://stackoverflow.com/questions/2527355/using-the-slash-character-in-git-branch-name).
+**warning**: Using multiple slashes causes problems with Calypso Live testing. See: [Git branches with multiple slashes](https://stackoverflow.com/questions/2527355/using-the-slash-character-in-git-branch-name). Stick to a single slash.
 
 Short Branches: Merge Early and Often
 -------------------------------------

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -15,7 +15,7 @@ Branches use the following naming conventions:
 
 For example, you can run: `git checkout master` and then `git checkout -b fix/whatsits` to create a new `fix/whatsits` branch off of `origin/master`.
 
-*warning*: Do not use two slashes in the name of a branch. It can too-easily [cause issues](https://stackoverflow.com/questions/2527355/using-the-slash-character-in-git-branch-name).
+**warning**: Do not use two slashes in the name of a branch. It can too-easily [cause issues](https://stackoverflow.com/questions/2527355/using-the-slash-character-in-git-branch-name).
 
 Short Branches: Merge Early and Often
 -------------------------------------


### PR DESCRIPTION
I attempted to create a PR adding a warning against two slashes in the branch name but ended up accidentally [committing directly to master](https://github.com/Automattic/wp-calypso/commit/9db041336f0a477d29474cc51e2085bc228eec59) through the GitHub UI.

This PR is about whether or not we should have a warning against two slashes in branch names.
