### PR TITLE
JP Onboarding: Hide Stats Step when Connected

### DIFF
--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -152,7 +152,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 	}
 }
 export default connect(
-	( state, { siteSlug } ) => {
+	( state, { action, siteSlug } ) => {
 		let siteId = getUnconnectedSiteIdBySlug( state, siteSlug );
 		if ( ! siteId ) {
 			// We rely on the fact that all sites are being requested automatically early in <Layout />.
@@ -186,6 +186,13 @@ export default connect(
 		).isLoading;
 
 		const userIdHashed = getUnconnectedSiteUserHash( state, siteId );
+
+		// Only show the Stats Step either if we aren't connected to WP.com yet,
+		// or if we're just being redirected back to JP Onboarding right after
+		// going through JP Connect, in which case the `action` query arg will be
+		// set to `activate_stats`.
+		const showStatsStep = ! isConnected || action === 'activate_stats';
+
 		const steps = compact( [
 			STEPS.SITE_TITLE,
 			STEPS.SITE_TYPE,
@@ -193,7 +200,7 @@ export default connect(
 			STEPS.CONTACT_FORM,
 			isBusiness && STEPS.BUSINESS_ADDRESS,
 			isBusiness && STEPS.WOOCOMMERCE,
-			STEPS.STATS,
+			showStatsStep && STEPS.STATS,
 			STEPS.SUMMARY,
 		] );
 		const stepsCompleted = getJetpackOnboardingCompletedSteps( state, siteId, steps );


### PR DESCRIPTION
Fixes #23219 -- see there for background.

To test:
* Start with a JP site that's not connected to WP.com (e.g. https://jurassic.ninja/create?jetpack-beta)
* Land at http://YourJetpackSite.me/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development
* Skip through all onboarding steps until you land at the 'Stats' step.
* Click 'Activate'
* Connect to WP.com
* Verify you're being redirected back to the 'Stats' step, which now shows a 'Success!' message, and a 'Continue' button. Verify that the 'Continue' button (or 'Skip for now' link) take you to the summary page.

Repeat now, but this time making sure you're connected by the time you would otherwise reach the 'Stats' step (e.g. by using the site you just set up above, or by using a fresh site, and choosing to add a contact form or business address during the respective onboarding steps). Verify that the 'Stats' step is skipped (as the stats module is auto-activated upon connection to WP.com).