### PR TITLE
JP Onboarding: Centralize DocumentHead

### DIFF
--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -122,7 +122,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 		return (
 			<Main className="jetpack-onboarding">
 				<DocumentHead
-					title={ concatTitle( get( STEP_TITLES, stepName ), translate( 'Jetpack Start' ) ) }
+					title={ concatTitle( translate( 'Jetpack Start' ), get( STEP_TITLES, stepName ) ) }
 				/>
 				{ /* We only allow querying of site settings once we know that we have finished
 				   * querying data for the given site. The `jpoAuth` connected prop depends on whether

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { compact, get } from 'lodash';
+import { concatTitle } from 'lib/react-helpers';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -13,6 +14,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
  * Internal dependencies
  */
 import config from 'config';
+import DocumentHead from 'components/data/document-head';
 import Main from 'components/main';
 import QueryJetpackOnboardingSettings from 'components/data/query-jetpack-onboarding-settings';
 import Wizard from 'components/wizard';
@@ -21,6 +23,7 @@ import { addQueryArgs, externalRedirect } from 'lib/route';
 import {
 	JETPACK_ONBOARDING_COMPONENTS as COMPONENTS,
 	JETPACK_ONBOARDING_STEPS as STEPS,
+	JETPACK_ONBOARDING_STEP_TITLES as STEP_TITLES,
 } from './constants';
 import {
 	getJetpackOnboardingCompletedSteps,
@@ -113,10 +116,14 @@ class JetpackOnboardingMain extends React.PureComponent {
 			siteSlug,
 			stepName,
 			steps,
+			translate,
 		} = this.props;
 
 		return (
 			<Main className="jetpack-onboarding">
+				<DocumentHead
+					title={ concatTitle( get( STEP_TITLES, stepName ), translate( 'Jetpack Start' ) ) }
+				/>
 				{ /* We only allow querying of site settings once we know that we have finished
 				   * querying data for the given site. The `jpoAuth` connected prop depends on whether
 				   * the site is a connected Jetpack site or not, and a network request that uses

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -5,7 +5,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { compact, get } from 'lodash';
-import { concatTitle } from 'lib/react-helpers';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -122,7 +121,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 		return (
 			<Main className="jetpack-onboarding">
 				<DocumentHead
-					title={ concatTitle( get( STEP_TITLES, stepName ), translate( 'Jetpack Start' ) ) }
+					title={ get( STEP_TITLES, stepName ) + ' ‹ ' + translate( 'Jetpack Start' ) }
 				/>
 				{ /* We only allow querying of site settings once we know that we have finished
 				   * querying data for the given site. The `jpoAuth` connected prop depends on whether

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -122,7 +122,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 		return (
 			<Main className="jetpack-onboarding">
 				<DocumentHead
-					title={ concatTitle( translate( 'Jetpack Start' ), get( STEP_TITLES, stepName ) ) }
+					title={ concatTitle( get( STEP_TITLES, stepName ), translate( 'Jetpack Start' ) ) }
 				/>
 				{ /* We only allow querying of site settings once we know that we have finished
 				   * querying data for the given site. The `jpoAuth` connected prop depends on whether

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -14,7 +14,6 @@ import Button from 'components/button';
 import Card from 'components/card';
 import ConnectIntro from '../connect-intro';
 import ConnectSuccess from '../connect-success';
-import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -212,7 +211,6 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 
 		return (
 			<div className="steps__main">
-				<DocumentHead title={ translate( 'Business Address ‹ Jetpack Start' ) } />
 				<PageViewTracker
 					path={ [ basePath, STEPS.BUSINESS_ADDRESS, ':site' ].join( '/' ) }
 					title="Business Address ‹ Jetpack Start"

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
  */
 import ConnectIntro from '../connect-intro';
 import ConnectSuccess from '../connect-success';
-import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import JetpackLogo from 'components/jetpack-logo';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -98,7 +97,6 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 
 		return (
 			<div className="steps__main">
-				<DocumentHead title={ translate( 'Contact Form ‹ Jetpack Start' ) } />
 				<PageViewTracker
 					path={ [ basePath, STEPS.CONTACT_FORM, ':site' ].join( '/' ) }
 					title="Contact Form ‹ Jetpack Start"

--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -10,7 +10,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import Tile from 'components/tile-grid/tile';
@@ -37,7 +36,6 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 
 		return (
 			<div className="steps__main">
-				<DocumentHead title={ translate( 'Homepage ‹ Jetpack Start' ) } />
 				<PageViewTracker
 					path={ [ basePath, STEPS.HOMEPAGE, ':site' ].join( '/' ) }
 					title="Homepage ‹ Jetpack Start"

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Card from 'components/card';
-import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import JetpackOnboardingDisclaimer from '../disclaimer';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -68,7 +67,6 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 
 		return (
 			<div className="steps__main">
-				<DocumentHead title={ translate( 'Site Title ‹ Jetpack Start' ) } />
 				<PageViewTracker
 					path={ [ basePath, STEPS.SITE_TITLE, ':site' ].join( '/' ) }
 					title="Site Title ‹ Jetpack Start"

--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -10,7 +10,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import Tile from 'components/tile-grid/tile';
@@ -36,7 +35,6 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 
 		return (
 			<div className="steps__main">
-				<DocumentHead title={ translate( 'Site Type ‹ Jetpack Start' ) } />
 				<PageViewTracker
 					path={ [ basePath, STEPS.SITE_TYPE, ':site' ].join( '/' ) }
 					title="Site Type ‹ Jetpack Start"

--- a/client/jetpack-onboarding/steps/stats.jsx
+++ b/client/jetpack-onboarding/steps/stats.jsx
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
  */
 import ConnectIntro from '../connect-intro';
 import ConnectSuccess from '../connect-success';
-import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import JetpackLogo from 'components/jetpack-logo';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -92,7 +91,6 @@ class JetpackOnboardingStatsStep extends React.Component {
 
 		return (
 			<div className="steps__main">
-				<DocumentHead title={ translate( 'Jetpack Stats ‹ Jetpack Start' ) } />
 				<PageViewTracker
 					path={ [ basePath, STEPS.STATS, ':site' ].join( '/' ) }
 					title="Jetpack Stats ‹ Jetpack Start"

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -11,7 +11,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
-import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import CompletedSteps from '../summary-completed-steps';
@@ -38,7 +37,6 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 
 		return (
 			<div className="steps__main">
-				<DocumentHead title={ translate( 'Summary ‹ Jetpack Start' ) } />
 				<PageViewTracker
 					path={ [ basePath, STEPS.SUMMARY, ':site' ].join( '/' ) }
 					title="Summary ‹ Jetpack Start"

--- a/client/jetpack-onboarding/steps/woocommerce.jsx
+++ b/client/jetpack-onboarding/steps/woocommerce.jsx
@@ -12,7 +12,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
-import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
@@ -46,7 +45,6 @@ class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 
 		return (
 			<div className="steps__main">
-				<DocumentHead title={ translate( 'WooCommerce ‹ Jetpack Start' ) } />
 				<PageViewTracker
 					path={ [ basePath, STEPS.WOOCOMMERCE, ':site' ].join( '/' ) }
 					title="WooCommerce ‹ Jetpack Start"


### PR DESCRIPTION
To test: Verify that the browser window's title is still correctly updated when switching between onboarding steps.

Fixes #23216.