### PR TITLE
Store: Add referrers to the list of allowed site stats data

### DIFF
--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -321,6 +321,22 @@ UndocumentedSite.prototype.statsOrders = function( query ) {
 };
 
 /**
+ * Requests Store referrer stats
+ *
+ * @param {object} query query parameters
+ * @return {Promise} A Promise to resolve when complete.
+ */
+UndocumentedSite.prototype.statsStoreReferrers = function( query ) {
+	return this.wpcom.req.get(
+		{
+			path: `/sites/${ this._id }/stats/events-by-referrer`,
+			apiNamespace: 'wpcom/v2',
+		},
+		query
+	);
+};
+
+/**
  * Requests Store top-sellers stats
  *
  * @param {object} query query parameters

--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -62,6 +62,7 @@ export function requestSiteStats( siteId, statType, query ) {
 				'statsTopCategories',
 				'statsTopCoupons',
 				'statsTopEarners',
+				'statsStoreReferrers',
 			],
 			statType
 		);

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -18,6 +18,7 @@ import {
 	rangeOfPeriod,
 	buildExportArray,
 	isAutoRefreshAllowedForQuery,
+	parseStoreStatsReferrers,
 } from '../utils';
 
 describe( 'utils', () => {
@@ -1963,6 +1964,51 @@ describe( 'utils', () => {
 						value: 3939,
 					},
 				] );
+			} );
+		} );
+		describe( 'parseStoreStatsReferrers', () => {
+			const validData = {
+				data: [
+					{ date: 'monday', data: [ [ 'green', 4 ], [ 'red', 8 ] ] },
+					{ date: 'tuesday', data: [ [ 'orange', 12 ], [ 'blue', 16 ] ] },
+				],
+				fields: [ 'color', 'age' ],
+			};
+
+			test( 'should return empty array for malformed payload', () => {
+				const noPayload = parseStoreStatsReferrers( undefined );
+				const noData = parseStoreStatsReferrers( {} );
+				const dataNotArray = parseStoreStatsReferrers( { data: {} } );
+
+				expect( Array.isArray( noPayload ) ).to.eql( true );
+				expect( noPayload.length ).to.eql( 0 );
+				expect( Array.isArray( noData ) ).to.eql( true );
+				expect( noData.length ).to.eql( 0 );
+				expect( Array.isArray( dataNotArray ) ).to.eql( true );
+				expect( dataNotArray.length ).to.eql( 0 );
+			} );
+
+			test( 'should an array of objects with all fields', () => {
+				const parsedData = parseStoreStatsReferrers( validData );
+
+				expect( parsedData.length ).to.eql( validData.data.length );
+
+				const { fields } = validData;
+				const firstRecord = parsedData[ 0 ];
+
+				// Make sure all fields are present
+				firstRecord.data.forEach( d => {
+					expect( d[ fields[ 0 ] ] ).to.not.be.undefined;
+					expect( d[ fields[ 1 ] ] ).to.not.be.undefined;
+				} );
+
+				// Make sure values are correctly lined up
+				firstRecord.data.forEach( ( d, idx ) => {
+					expect( d.color ).to.eql( validData.data[ 0 ].data[ idx ][ 0 ] );
+					expect( d.age ).to.eql( validData.data[ 0 ].data[ idx ][ 1 ] );
+				} );
+
+				expect( firstRecord.date ).to.eql( 'monday' );
 			} );
 		} );
 	} );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -301,7 +301,7 @@ export function parseUnitPeriods( unit, period ) {
 }
 
 export function parseStoreStatsReferrers( payload ) {
-	if ( ! payload || ! payload.data || ! Array.isArray( payload.data ) ) {
+	if ( ! payload || ! payload.data || ! payload.fields || ! Array.isArray( payload.data ) ) {
 		return [];
 	}
 	const { fields } = payload;

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -300,6 +300,26 @@ export function parseUnitPeriods( unit, period ) {
 	}
 }
 
+export function parseStoreStatsReferrers( payload ) {
+	if ( ! payload || ! payload.data || ! Array.isArray( payload.data ) ) {
+		return [];
+	}
+	const { fields } = payload;
+	return payload.data.map( record => {
+		return {
+			date: record.date,
+			data: record.data.map( referrer => {
+				const obj = {};
+				referrer.forEach( ( value, i ) => {
+					const key = fields[ i ];
+					obj[ key ] = value;
+				} );
+				return obj;
+			} ),
+		};
+	} );
+}
+
 export const normalizers = {
 	/**
 	 * Returns a normalized payload from `/sites/{ site }/stats`
@@ -850,6 +870,10 @@ export const normalizers = {
 			data: parseOrdersChartData( payload ),
 			deltas: parseOrderDeltas( payload ),
 		};
+	},
+
+	statsStoreReferrers( payload ) {
+		return parseStoreStatsReferrers( payload );
 	},
 
 	statsTopSellers( payload ) {


### PR DESCRIPTION
I lifted part of @psealock's PR #21752, for the `storeStatsReferrers` part. I need it for the dashboard widget work I'm doing. I figured we could both base our branches off this one / get it merged into master since we need the same method.

To Test:
* Run `npm run test-client` and make sure all tests pass.

