### PR TITLE
Editor: Align date picker chevron icon

### DIFF
--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -54,8 +54,8 @@
 	.gridicon.editor-publish-date__header-chevron {
 		fill: $gray-darken-20;
 		position: absolute;
-		top: 10px;
-		right: 13px;
+		top: 11px;
+		right: 16px;
 		vertical-align: text-bottom;
 		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 


### PR DESCRIPTION
Over in #23143 I updated the date picker to use a gridicon, but I got the alignment wrong. You can see the issue in the editor's sidebar when the date picker is shown next to a standard dropdown:

<img width="257" alt="before" src="https://user-images.githubusercontent.com/191598/37300611-c463169c-25fc-11e8-8e01-b7d6635b6a5a.png">

Here's the "after" when the gridicon is lined up:

<img width="260" alt="after" src="https://user-images.githubusercontent.com/191598/37300628-ce29542a-25fc-11e8-966f-de3a59569a18.png">
