### PR TITLE
Reader: Update x-post active state style

### DIFF
--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -45,13 +45,18 @@
 		margin-bottom: 24px;
 
 		&.is-selected,
-		&:hover,
 		&.is-x-post.is-selected,
-		&.is-x-post:hover,
-		&.tag-afk.is-selected,
-		&.tag-afk:hover {
-			box-shadow: 0 0 0 1px $gray,
-						0 2px 4px $gray-lighten-20;
+		&.tag-afk.is-selected {
+
+			&::before {
+				background: $blue-wordpress;
+				content: "";
+				position: absolute;
+					bottom: 0;
+					left: -8px;
+					top: 0;
+				width: 2px;
+			}
 		}
 	}
 
@@ -88,7 +93,6 @@
 
 	// Loading Placeholders
 	&.is-placeholder {
-
 		pointer-events: none;
 		user-select: none;
 
@@ -132,6 +136,7 @@
 	}
 
 	.post-excerpt-only {
+
 		p {
 			margin-bottom: 1em;
 		}
@@ -221,7 +226,6 @@
 }
 
 // X-Posts
-
 .is-reader-page {
 
 	.reader__card.card.is-x-post {
@@ -358,7 +362,6 @@
 }
 
 // P2 cross-posts (x-posts), which is Automattic-only.
-
 .reader__x-post-author {
 	font-weight: 600;
 }
@@ -407,12 +410,6 @@
 }
 
 // In-stream Recommendations
-
-// Custom breakpoints needed to match Related Posts
-
-$reader-related-card-breakpoint-medium: "( min-width: 661px ) and ( max-width: 730px )";
-$reader-related-card-breakpoint-small: "( max-width: 535px )";
-
 .reader-stream__recommended-posts {
 	border-bottom: 1px solid $gray-lighten-20;
 	padding-bottom: 12px;

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -238,10 +238,6 @@
 			padding: 20px 42px;
 		}
 
-		&:hover {
-			box-shadow: none; // Disables hover for now until we implement hover in all card types
-		}
-
 		.reader__post-title-link,
 		.reader__post-title-link:visited {
 			color: $gray-darken-20;

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -40,24 +40,24 @@
 	transition: all 0.1s ease-in-out;
 	margin-bottom: 15px;
 
+	&.is-selected,
+	&.is-x-post.is-selected,
+	&.tag-afk.is-selected {
+
+		&::before {
+			background: $blue-wordpress;
+			content: "";
+			position: absolute;
+				bottom: 0;
+				left: -8px;
+				top: 0;
+			width: 2px;
+		}
+	}
+
 	@include breakpoint( ">480px" ) {
 		padding: 16px 24px 24px;
 		margin-bottom: 24px;
-
-		&.is-selected,
-		&.is-x-post.is-selected,
-		&.tag-afk.is-selected {
-
-			&::before {
-				background: $blue-wordpress;
-				content: "";
-				position: absolute;
-					bottom: 0;
-					left: -8px;
-					top: 0;
-				width: 2px;
-			}
-		}
 	}
 
 	.site {
@@ -230,8 +230,13 @@
 
 	.reader__card.card.is-x-post {
 		border-bottom: 1px solid $gray-lighten-20;
-		margin: 0;
-		padding: 20px 42px;
+		margin: 0 15px;
+		padding: 20px;
+
+		@include breakpoint( ">660px" ) {
+			margin: 0;
+			padding: 20px 42px;
+		}
 
 		&:hover {
 			box-shadow: none; // Disables hover for now until we implement hover in all card types


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/10668

Our x-posts active state needs to be consistent with the rest of the cards.

**Before:**
![screenshot 2018-03-12 10 58 38](https://user-images.githubusercontent.com/4924246/37301706-9ee128c0-25e6-11e8-9384-b371d51db15e.png)

**After:**
![screenshot 2018-03-12 11 11 49](https://user-images.githubusercontent.com/4924246/37301719-a53dbbc0-25e6-11e8-9a35-077e5fd0a23d.png)


