### PR TITLE
Reader Search Streams: fix inconsistent margin on first row

### DIFF
--- a/client/lib/with-dimensions/index.jsx
+++ b/client/lib/with-dimensions/index.jsx
@@ -6,6 +6,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { debounce } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import afterLayoutFlush from 'lib/after-layout-flush';
+
 const OVERFLOW_BUFFER = 4; // fairly arbitrary. feel free to tweak
 
 /**
@@ -42,18 +47,22 @@ export default EnhancedComponent =>
 			height: 0,
 		};
 
-		handleResize = ( props = this.props ) => {
+		handleResize = afterLayoutFlush( ( props = this.props ) => {
 			const domElement = props.domTarget || this.setRef || this.divRef;
 
 			if ( domElement ) {
 				const dimensions = domElement.getClientRects()[ 0 ];
+				if ( ! dimensions ) {
+					return;
+				}
+
 				const { width, height } = dimensions;
 				const overflowX = domElement.scrollWidth > domElement.clientWidth + OVERFLOW_BUFFER;
 				const overflowY = domElement.scrollHeight > domElement.clientHeight + OVERFLOW_BUFFER;
 
 				this.setState( { width, height, overflowX, overflowY } );
 			}
-		};
+		} );
 
 		componentDidMount() {
 			this.resizeEventListener = window.addEventListener(
@@ -62,7 +71,7 @@ export default EnhancedComponent =>
 			);
 			this.handleResize();
 		}
-		
+
 		componentWillReceiveProps( nextProps ) {
 			this.handleResize( nextProps );
 		}
@@ -74,12 +83,12 @@ export default EnhancedComponent =>
 		handleMount = ref => {
 			this.divRef = ref;
 			this.handleResize();
-		}
+		};
 
 		setWithDimensionsRef = ref => {
 			this.setRef = ref;
 			this.handleResize();
-		}
+		};
 
 		render() {
 			return (

--- a/client/lib/with-dimensions/index.jsx
+++ b/client/lib/with-dimensions/index.jsx
@@ -62,9 +62,11 @@ export default EnhancedComponent =>
 			);
 			this.handleResize();
 		}
+		
 		componentWillReceiveProps( nextProps ) {
 			this.handleResize( nextProps );
 		}
+
 		componentWillUnmount() {
 			window.removeEventListener( 'resize', this.resizeEventListener );
 		}
@@ -72,11 +74,12 @@ export default EnhancedComponent =>
 		handleMount = ref => {
 			this.divRef = ref;
 			this.handleResize();
-		};
+		}
+
 		setWithDimensionsRef = ref => {
 			this.setRef = ref;
 			this.handleResize();
-		};
+		}
 
 		render() {
 			return (


### PR DESCRIPTION
fixes: https://github.com/Automattic/wp-calypso/issues/20936

**to test**
1. land on following stream
2. click Search
3. you should see the right amount of margin