### PR TITLE
Domains: Remove unused noticon css

### DIFF
--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -260,10 +260,6 @@ input[type=radio].domain-management-list-item__radio {
 		padding: 3px 10px 3px 5px;
 		white-space: nowrap;
 
-		.noticon {
-			margin-right: 5px;
-		}
-
 		&.is-warning {
 			cursor: pointer;
 		}
@@ -765,10 +761,6 @@ ul.email-forwarding__list {
 	}
 
 	.vertical-nav-item {
-		.noticon {
-			display: none;
-		}
-
 		span:nth-of-type( 1 ) {
 			@include placeholder();
 		}


### PR DESCRIPTION
This css is unused. We know this because ‘noticon’ is not referenced in
any jsx files. Noticons is deprecated. No visual changes.