### PR TITLE
Editor: Hide notice when clicking edit from preview

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -826,6 +826,8 @@ export const PostEditor = createReactClass( {
 			this.props.setNextLayoutFocus( 'sidebar' );
 		}
 
+		this.hideNotice();
+
 		this.setState( {
 			showPreview: false,
 			isPostPublishPreview: false,


### PR DESCRIPTION
Previously if you published a post and selected "Edit" from the preview pane, the confirmation remained visible:

![image](https://user-images.githubusercontent.com/363749/37312282-6ecbceba-2618-11e8-9da5-b1fab46d67fe.png)

This PR fixes #19354 by hiding the notice within `onPreviewEdit`.

To test:
* Publish a new post.
* Within the preview that appears after publishing the post, select "Edit".
* Verify that the success notice is removed upon clicking "Edit".