### PR TITLE
Datepicker: Adding customized, localized month navigation buttons

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -197,7 +197,8 @@ $z-layers: (
 		'.input-chrono__container .gridicons-calendar': 0,
 		'input.input-chrono': 1,
 		'.popover .popover__arrow': 1,
-		'.post-schedule__header': 1
+		'.post-schedule__header': 1,
+		'.date-picker__nav-bar': 2
 	),
 	'.search': (
 		'.search__input': 10,

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import DayItem from 'components/date-picker/day';
+import DatePickerNavBar from 'components/date-picker/nav-bar';
 
 /* Internal dependencies
  */
@@ -80,7 +81,8 @@ class DatePicker extends PureComponent {
 		const { moment } = this.props;
 		const localeData = moment().localeData();
 		const firstDayOfWeek = localeData.firstDayOfWeek();
-		const weekdays = moment.weekdaysMin();
+		const weekdaysMin = moment.weekdaysMin();
+		const weekdays = moment.weekdays();
 		const locale = {
 			formatDay: function( date ) {
 				return moment( date ).format( 'llll' );
@@ -91,17 +93,19 @@ class DatePicker extends PureComponent {
 			},
 
 			formatWeekdayShort: function( day ) {
-				return get( weekdays, day, ' ' )[ 0 ];
+				return get( weekdaysMin, day, ' ' )[ 0 ];
 			},
 
 			formatWeekdayLong: function( day ) {
-				return moment()
-					.weekday( day )
-					.format( 'dddd' );
+				return weekdays[ day ];
 			},
 
 			getFirstDayOfWeek: function() {
 				return firstDayOfWeek;
+			},
+
+			formatMonthShort: function( month ) {
+				return moment( month.toISOString() ).format( 'MMM' );
 			},
 		};
 
@@ -192,6 +196,7 @@ class DatePicker extends PureComponent {
 				onMonthChange={ this.props.onMonthChange }
 				enableOutsideDays={ this.props.enableOutsideDays }
 				onCaptionClick={ this.setCalendarMonth }
+				navbarElement={ <DatePickerNavBar /> }
 			/>
 		);
 	}

--- a/client/components/date-picker/nav-bar.jsx
+++ b/client/components/date-picker/nav-bar.jsx
@@ -1,0 +1,54 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import classNames from 'classnames';
+import { noop } from 'lodash';
+import { translate } from 'i18n-calypso';
+
+const handleMonthClick = ( onClick = noop ) => event => {
+	event.preventDefault();
+	onClick();
+};
+
+export const DatePickerNavBar = ( {
+	nextMonth,
+	previousMonth,
+	onPreviousClick,
+	onNextClick,
+	className,
+	localeUtils,
+} ) => {
+	const classes = classNames( 'date-picker__nav-bar', {
+		[ className ]: !! className,
+	} );
+	return (
+		<div className={ classes }>
+			<button
+				className="date-picker__previous-month button"
+				type="button"
+				aria-label={ translate( 'Previous month ', {
+					comment: 'Aria label for date picker controls',
+				} ) }
+				onClick={ handleMonthClick( onPreviousClick ) }
+			>
+				{ localeUtils.formatMonthShort( previousMonth ) }
+			</button>
+			<button
+				className="date-picker__next-month button"
+				type="button"
+				aria-label={ translate( 'Next month ', {
+					comment: 'Aria label for date picker controls',
+				} ) }
+				onClick={ handleMonthClick( onNextClick ) }
+			>
+				{ localeUtils.formatMonthShort( nextMonth ) }
+			</button>
+		</div>
+	);
+};
+
+export default DatePickerNavBar;

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -116,26 +116,6 @@ $date-picker_nav_button_size: 20px;
 	}
 }
 
-.DayPicker-NavButton--prev {
-	color: $gray;
-	left: 0;
-
-	&:before {
-		@include noticon( '\f431' );
-		transform: rotate( 90deg );
-	}
-}
-
-.DayPicker-NavButton--next {
-	color: $gray;
-	right: 0;
-
-	&:before {
-		@include noticon( '\f432' );
-		transform: rotate( 90deg );
-	}
-}
-
 .DayPicker-Caption {
 	display: table-caption;
 	text-align: center;

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -60,21 +60,24 @@ $date-picker_nav_button_size: 20px;
 	height: 26px;
 	text-align: center;
 	top: 11px;
+	z-index: z-index( '.popover', '.date-picker__nav-bar' );
 }
 
 .date-picker__previous-month,
 .date-picker__next-month {
 	float: right;
-	padding: 1px 4px;
+	padding: 1px 8px;
 	font-size: 12px;
 	text-transform: capitalize;
 	cursor: pointer;
 	z-index: 2;
 	order-width: 1px;
+
 	&:hover {
 		color: $blue-medium;
 	}
 }
+
 .date-picker__previous-month {
 	float: left;
 }

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -56,6 +56,33 @@ $date-picker_nav_button_size: 20px;
 	line-height: 18px;
 }
 
+.date-picker__nav-bar {
+	height: 26px;
+	text-align: center;
+	top: 11px;
+}
+
+.date-picker__previous-month,
+.date-picker__next-month {
+	float: right;
+	padding: 1px 4px;
+	font-size: 12px;
+	text-transform: capitalize;
+	cursor: pointer;
+	z-index: 2;
+	order-width: 1px;
+	&:hover {
+		color: $blue-medium;
+	}
+}
+.date-picker__previous-month {
+	float: left;
+}
+
+.date-picker__next-month {
+	float: right;
+}
+
 .DayPicker-Month {
 	display: table;
 	width: 100%;

--- a/client/components/post-schedule/header.jsx
+++ b/client/components/post-schedule/header.jsx
@@ -66,7 +66,7 @@ class PostScheduleHeader extends React.Component {
 		return (
 			<div className={ headerClasses }>
 				<span className="post-schedule__header-month" onClick={ this.setToCurrentMonth }>
-					{ this.props.date.format( 'MMMM' ) }
+					{ this.props.date.format( 'MMM' ) }
 				</span>
 
 				<div

--- a/client/components/post-schedule/style.scss
+++ b/client/components/post-schedule/style.scss
@@ -16,8 +16,8 @@
 	top: 11px;
 	font-size: 18px;
 	font-weight: 300;
-	width: 80%;
-	margin: 0 10%;
+	width: 72%;
+	margin: 0 14%;
 
 	&:first-letter {
 		text-transform: uppercase;
@@ -60,7 +60,7 @@
 	height: 20px;
 	line-height: 20px;
 	padding: 0 5px;
-	margin-left: 10px;
+	margin-left: 5px;
 	cursor: pointer;
 }
 

--- a/client/components/post-schedule/style.scss
+++ b/client/components/post-schedule/style.scss
@@ -14,10 +14,10 @@
 	position: absolute;
 	z-index: z-index( '.popover', '.post-schedule__header' );
 	top: 11px;
-	font-size: 18px;
-	font-weight: 300;
-	width: 72%;
-	margin: 0 14%;
+	font-size: 16px;
+	font-weight: 500;
+	width: 47%;
+	margin: 0 27%;
 
 	&:first-letter {
 		text-transform: uppercase;
@@ -56,7 +56,7 @@
 	display: inline-block;
 	position: relative;
 	text-align: center;
-	font-size: 12px;
+	font-weight: 300;
 	height: 20px;
 	line-height: 20px;
 	padding: 0 5px;

--- a/client/extensions/woocommerce/app/promotions/fields/style.scss
+++ b/client/extensions/woocommerce/app/promotions/fields/style.scss
@@ -23,6 +23,7 @@
 		.DayPicker-NavBar {
 			margin-left: 16px;
 			margin-right: 16px;
+			top: 26px;
 		}
 	}
 }


### PR DESCRIPTION
This PR addresses #23083 by adding localized month navigation buttons to the datepicker, and removing the associated references to noticon styles.

Here's a screen shot of what it looks like in IE11!! :trollface: 

<img width="244" alt="screen shot 2018-03-13 at 4 00 09 pm" src="https://user-images.githubusercontent.com/6458278/37324795-2c205b86-26df-11e8-9b03-55887f52414a.png">

As an added bonus I've fixed the issue whereby the wrong day name appears in the weekday title attributes for locales whose weeks begin on Monday. In German for example, the title should be _Freitag_, not _Samstag_.

<img width="634" alt="screen shot 2018-03-13 at 2 51 50 pm" src="https://user-images.githubusercontent.com/6458278/37324576-25f99322-26de-11e8-9aab-033691e9b5bc.png">

## Testing
1. Create a new post and, under _**Post Settings**_, click _**Publish Immediately**_.
2. In your settings, change your UI language

### Expectations
1. You should be able navigate through the months using the buttons, and the buttons' labels should be abbreviations of the previous/next months.
2. The abbreviated month names should be localized, and the title attributes of the weekdays should display the correct (and localized) day name.