### PR TITLE
Add `TracksOptOut` in layout to sync opt-out status when we get user settings

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -42,11 +42,13 @@ import SitePreview from 'blocks/site-preview';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import DocumentHead from 'components/data/document-head';
 import NpsSurveyNotice from 'layout/nps-survey-notice';
+import TracksOptOut from 'layout/tracks-opt-out';
 import AppBanner from 'blocks/app-banner';
 import { getPreference } from 'state/preferences/selectors';
 import JITM from 'blocks/jitm';
 import KeyboardShortcutsMenu from 'lib/keyboard-shortcuts/menu';
 import SupportUser from 'support/support-user';
+import userSettings from 'lib/user-settings';
 
 /* eslint-disable react/no-deprecated */
 const Layout = createReactClass( {
@@ -153,6 +155,7 @@ const Layout = createReactClass( {
 					<AsyncLoad require="components/webpack-build-monitor" placeholder={ null } />
 				) }
 				<AppBanner />
+				<TracksOptOut userSettings={ userSettings } />
 			</div>
 		);
 	},

--- a/client/layout/tracks-opt-out/README.md
+++ b/client/layout/tracks-opt-out/README.md
@@ -1,0 +1,15 @@
+Tracks Opt-out
+==============
+
+The Tracks opt out component is used in the main layout to make sure that any
+changes to user settings are taken into account as soon as possible. It should
+also handle cases when the opt-out was set outside of this Calypso session, for
+instance in the mobile apps or in another browser.
+
+### index.jsx
+
+This component subscribes to `userSettings`'s `change` events. It then sends a
+`setOptOut` command to the Tracks JS library in `w.js`.
+
+NOTE: This component does not accept any children, nor does it render any
+elements to the page.

--- a/client/layout/tracks-opt-out/index.jsx
+++ b/client/layout/tracks-opt-out/index.jsx
@@ -1,0 +1,53 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import debug from 'debug';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { setTracksOptOut } from 'state/analytics/actions';
+
+/**
+ * Module variables
+ */
+const tracksDebug = debug( 'calypso:analytics:tracks' );
+
+class TracksOptOut extends React.Component {
+	static propTypes = {
+		userSettings: PropTypes.object.isRequired,
+		setTracksOptOut: PropTypes.func.isRequired,
+	};
+
+	componentDidMount() {
+		this.props.userSettings.on( 'change', this.syncTracksOptOut );
+	}
+
+	componentWillUnmount() {
+		this.props.userSettings.off( 'change', this.syncTracksOptOut );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.userSettings !== nextProps.userSettings ) {
+			this.props.userSettings.off( 'change', this.syncTracksOptOut );
+			nextProps.userSettings.on( 'change', this.syncTracksOptOut );
+		}
+	}
+
+	syncTracksOptOut = () => {
+		const isOptedOut = this.props.userSettings.getSetting( 'tracks_opt_out' );
+		tracksDebug( `Syncing tracks opt out status to \`${ isOptedOut }\`` );
+		this.props.setTracksOptOut( isOptedOut );
+	};
+
+	render() {
+		return null;
+	}
+}
+
+export default connect( null, { setTracksOptOut } )( TracksOptOut );

--- a/client/layout/tracks-opt-out/index.jsx
+++ b/client/layout/tracks-opt-out/index.jsx
@@ -20,7 +20,9 @@ const tracksDebug = debug( 'calypso:analytics:tracks' );
 
 class TracksOptOut extends React.Component {
 	static propTypes = {
-		userSettings: PropTypes.object.isRequired,
+		userSettings: PropTypes.shape( {
+			getSetting: PropTypes.func.isRequired,
+		} ).isRequired,
 		setTracksOptOut: PropTypes.func.isRequired,
 	};
 
@@ -36,11 +38,17 @@ class TracksOptOut extends React.Component {
 		if ( this.props.userSettings !== nextProps.userSettings ) {
 			this.props.userSettings.off( 'change', this.syncTracksOptOut );
 			nextProps.userSettings.on( 'change', this.syncTracksOptOut );
+
+			// In case we get the prop AFTER it already triggered its first `change` event
+			const optOut = this.props.userSettings.getSetting( 'tracks_opt_out' );
+			const nextOptOut = nextProps.userSettings.getSetting( 'tracks_opt_out' );
+			if ( optOut !== nextOptOut && typeof nextOptOut === 'boolean' ) {
+				this.syncTracksOptOut( nextOptOut );
+			}
 		}
 	}
 
-	syncTracksOptOut = () => {
-		const isOptedOut = this.props.userSettings.getSetting( 'tracks_opt_out' );
+	syncTracksOptOut = ( isOptedOut = this.props.userSettings.getSetting( 'tracks_opt_out' ) ) => {
 		tracksDebug( `Syncing tracks opt out status to \`${ isOptedOut }\`` );
 		this.props.setTracksOptOut( isOptedOut );
 	};


### PR DESCRIPTION
Attempt at PR 4 mentioned [in this comment](https://github.com/Automattic/wp-calypso/issues/22632#issuecomment-372353596).

The idea is to listen to `userSettings` as early as possible and "sync" the logged-in user opt-out status with `w.js` as soon as possible when we have access to it. It should handle a bunch of edge cases:

1. when the user has set the opt-out status in a prior session
2. if the user has opted-in has a logged-in user but was opted-out has an anonymous one prior to logging in.
3. if the user was logged in browser A, and set the status in browser B ( or in the mobile apps ), this will sync it in browser A without having to go through log-in in browser A ( hence why it's in Layout and not just the login page )

**Testing**

1. Apply D9412-code on your sandbox and sandbox `public-api.wordpress.com` to get the new `tracks_opt_out` key in your user settings.
2. [Reload Calypso](http://calypso.localhost:3000/)
3. You can check either for `ANALYTICS_TRACKS_OPT_OUT` in Redux, or for a syncing message in debug ( namespace: `calypso:analytics:tracks` ) or if you've blocked `w.js` from loading via `window._tkq`.
4. Make sure that toggling the setting in the [Privacy settings](http://calypso.localhost:3000/me/privacy) actually syncs it as well. 

**Notes**
* I use a component in Layout but maybe there is a smarter way to get in as early as possible and bind onto `userSettings`'s `change` event?
* I don't use `observe` to not introduce yet-another mixin user but also to not dispatch the opt-out action on `render` in case we have extra unnecessary re-renders due to it being in Layout.
* As [mentioned in the early reviews](https://github.com/Automattic/wp-calypso/pull/21652#discussion_r169181631) of #21652, `setOptOut` will be pushed into `w.js` before the settings are actually saved server-side, if you think that's a big issue, [there are solutions](https://github.com/Automattic/wp-calypso/pull/21652#discussion_r169285960) but I'm not a fan of any of them tbh.
* I namespaced `debug` with `calypso:analytics:tracks` since it seems more relevant than namespacing it with something like `layout:*`
* This is piling on top of #23231 and #23232 so CI will break due to the ESLint errors introduced by #23231 