### PR TITLE
Jetpack Onboarding: Fix visit site button for connected sites

### DIFF
--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -16,7 +16,7 @@ import FormattedHeader from 'components/formatted-header';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import CompletedSteps from '../summary-completed-steps';
 import NextSteps from '../summary-next-steps';
-import { getUnconnectedSiteUrl } from 'state/selectors';
+import { getSiteUrl, getUnconnectedSiteUrl } from 'state/selectors';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
 class JetpackOnboardingSummaryStep extends React.PureComponent {
@@ -77,5 +77,5 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 }
 
 export default connect( ( state, { siteId } ) => ( {
-	siteUrl: getUnconnectedSiteUrl( state, siteId ),
+	siteUrl: getSiteUrl( state, siteId ) || getUnconnectedSiteUrl( state, siteId ),
 } ) )( localize( JetpackOnboardingSummaryStep ) );


### PR DESCRIPTION
This PR fixes #23248, where the "Visit your site" button on the Summary page doesn't work when the site is connected.

This is caused by the fact that we're deleting the credentials after connecting, and we didn't account for that when retrieving the site URL on the summary page.

To test:
* Checkout this branch
* Start a new JN site with the latest Jetpack.
* Go through the onboarding flow by running `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development` on that site.
* Skip the steps that require connection (contact, business address, stats), and go to the summary page.
* Verify the "Visit your site" link correctly leads to the home URL of the site.
* Go back to the contact form step and click the button to insert a form.
* It will prompt you to connect - follow that flow and connect the site.
* After connecting you'll see the success message - skip and reach the summary step again.
* Verify the "Visit your site" link correctly leads to the home URL of the site.