### PR TITLE
Framework: Switch to named imports from qs

### DIFF
--- a/client/account-recovery/reset-code-validation/index.js
+++ b/client/account-recovery/reset-code-validation/index.js
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
-import qs from 'qs';
+import { parse } from 'qs';
 
 /**
  * Internal dependencies
@@ -37,7 +37,7 @@ class ResetPasswordEmailValidation extends Component {
 		return queryString.slice( 1 );
 	};
 
-	parseQueryArgs = () => qs.parse( this.getQueryString() );
+	parseQueryArgs = () => parse( this.getQueryString() );
 
 	componentDidMount = () => {
 		const { user, method, key } = this.parseQueryArgs();

--- a/client/blocks/daily-post-button/index.jsx
+++ b/client/blocks/daily-post-button/index.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import classnames from 'classnames';
 import page from 'page';
 import PropTypes from 'prop-types';
-import qs from 'qs';
+import { stringify } from 'qs';
 import { get, defer } from 'lodash';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
@@ -100,7 +100,7 @@ export class DailyPostButton extends React.Component {
 
 		this.props.markPostSeen( this.props.post, this.props.site );
 
-		page( `/post/${ siteSlug }?${ qs.stringify( pingbackAttributes ) }` );
+		page( `/post/${ siteSlug }?${ stringify( pingbackAttributes ) }` );
 		return true;
 	};
 

--- a/client/blocks/daily-post-button/test/index.jsx
+++ b/client/blocks/daily-post-button/test/index.jsx
@@ -10,7 +10,7 @@ import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import { noop } from 'lodash';
 import pageSpy from 'page';
-import qs from 'qs';
+import { parse } from 'qs';
 import React from 'react';
 
 /**
@@ -130,7 +130,7 @@ describe( 'DailyPostButton', () => {
 			);
 			prompt.instance().openEditorWithSite( 'apps.wordpress.com' );
 			const pageArgs = pageSpy.lastCall.args[ 0 ];
-			const query = qs.parse( pageArgs.split( '?' )[ 1 ] );
+			const query = parse( pageArgs.split( '?' )[ 1 ] );
 			const { title, URL } = dailyPromptPost;
 			assert.deepEqual( query, { title: `Daily Prompt: ${ title }`, url: URL } );
 		} );

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -12,7 +12,7 @@ import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
-import qs from 'qs';
+import { stringify } from 'qs';
 
 /**
  * Internal dependencies
@@ -269,7 +269,7 @@ export class LoginForm extends Component {
 		if ( isOauthLogin && config.isEnabled( 'signup/wpcc' ) ) {
 			signupUrl =
 				'/start/wpcc?' +
-				qs.stringify( {
+				stringify( {
 					oauth2_client_id: oauth2Client.id,
 					oauth2_redirect: redirectTo,
 				} );

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -9,7 +9,7 @@ import { defer } from 'lodash';
 import config from 'config';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import qs from 'qs';
+import { stringify } from 'qs';
 import page from 'page';
 import SocialLogo from 'social-logos';
 import { localize } from 'i18n-calypso';
@@ -80,7 +80,7 @@ function buildQuerystringForPost( post ) {
 	args.text = post.excerpt;
 	args.url = post.URL;
 
-	return qs.stringify( args );
+	return stringify( args );
 }
 
 class ReaderShare extends React.Component {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -21,7 +21,7 @@ import {
 	uniqBy,
 } from 'lodash';
 import page from 'page';
-import qs from 'qs';
+import { stringify } from 'qs';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -748,7 +748,7 @@ class RegisterDomainStep extends React.Component {
 		if ( this.props.mapDomainUrl ) {
 			mapDomainUrl = this.props.mapDomainUrl;
 		} else {
-			const query = qs.stringify( { initialQuery: this.state.lastQuery.trim() } );
+			const query = stringify( { initialQuery: this.state.lastQuery.trim() } );
 			mapDomainUrl = `${ this.props.basePath }/mapping`;
 			if ( this.props.selectedSite ) {
 				mapDomainUrl += `/${ this.props.selectedSite.slug }?${ query }`;
@@ -764,7 +764,7 @@ class RegisterDomainStep extends React.Component {
 		if ( this.props.transferDomainUrl ) {
 			transferDomainUrl = this.props.transferDomainUrl;
 		} else {
-			const query = qs.stringify( { initialQuery: this.state.lastQuery.trim() } );
+			const query = stringify( { initialQuery: this.state.lastQuery.trim() } );
 			transferDomainUrl = `${ this.props.basePath }/transfer`;
 			if ( this.props.selectedSite ) {
 				transferDomainUrl += `/${ this.props.selectedSite.slug }?${ query }`;

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -11,7 +11,7 @@ import { localize } from 'i18n-calypso';
 import { endsWith, get, isEmpty, isFunction, noop } from 'lodash';
 import Gridicon from 'gridicons';
 import page from 'page';
-import qs from 'qs';
+import { stringify } from 'qs';
 
 /**
  * Internal dependencies
@@ -111,7 +111,7 @@ class TransferDomainStep extends React.Component {
 			? basePath.substring( 0, basePath.length - 9 )
 			: basePath;
 
-		const query = qs.stringify( { initialQuery: this.state.searchQuery.trim() } );
+		const query = stringify( { initialQuery: this.state.searchQuery.trim() } );
 		mapDomainUrl = `${ basePathForMapping }/mapping`;
 		if ( selectedSite ) {
 			mapDomainUrl += `/${ selectedSite.slug }?${ query }`;

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import qs from 'qs';
+import { stringify } from 'qs';
 import { debounce } from 'lodash';
 import page from 'page';
 import url from 'url';
@@ -53,8 +53,7 @@ const devdocs = {
 				delete query.term;
 			}
 
-			const queryString = qs
-				.stringify( query )
+			const queryString = stringify( query )
 				.replace( /%20/g, '+' )
 				.trim();
 

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -6,7 +6,7 @@
 
 import cookie from 'cookie';
 import debug from 'debug';
-import qs from 'qs';
+import { parse } from 'qs';
 import url from 'url';
 import { assign, isObjectLike, isUndefined, omit, pickBy, startsWith, times } from 'lodash';
 
@@ -318,7 +318,7 @@ const analytics = {
 			// so we can analyze their performance with our analytics tools
 			if ( window.location ) {
 				const parsedUrl = url.parse( window.location.href );
-				const urlParams = qs.parse( parsedUrl.query );
+				const urlParams = parse( parsedUrl.query );
 				const utmParams = pickBy( urlParams, function( value, key ) {
 					return startsWith( key, 'utm_' );
 				} );

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -9,7 +9,7 @@ import store from 'store';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:user' );
 import config from 'config';
-import qs from 'qs';
+import { stringify } from 'qs';
 
 /**
  * Internal dependencies
@@ -238,7 +238,7 @@ User.prototype.getAvatarUrl = function( options ) {
 	options = options || {};
 	options = Object.assign( {}, options, default_options );
 
-	return avatar + '?' + qs.stringify( options );
+	return avatar + '?' + stringify( options );
 };
 
 /**

--- a/client/lib/wp/offline-library/index.js
+++ b/client/lib/wp/offline-library/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import stringify from 'json-stable-stringify';
-import qs from 'qs';
+import { parse } from 'qs';
 
 const readCache = () => {
 	try {
@@ -37,7 +37,7 @@ const saveRequests = requests => {
 
 export const makeOffline = wpcom => {
 	// search part includes the leading `?`
-	const queryParams = qs.parse( window.location.search.substring( 1 ) );
+	const queryParams = parse( window.location.search.substring( 1 ) );
 	const offlineRequested = queryParams.wpcom_offline;
 	const primingRequested = queryParams.wpcom_priming;
 

--- a/client/lib/wp/support.js
+++ b/client/lib/wp/support.js
@@ -3,8 +3,7 @@
 /**
  * External dependencies
  */
-
-import qs from 'qs';
+import { parse, stringify } from 'qs';
 
 export default function wpcomSupport( wpcom ) {
 	let supportUser = '';
@@ -18,14 +17,14 @@ export default function wpcomSupport( wpcom ) {
 	 */
 	const addSupportData = function( params ) {
 		// Unwind the query string
-		let query = qs.parse( params.query );
+		const query = parse( params.query );
 
 		// Inject the credentials
 		query.support_user = supportUser;
 		query._support_token = supportToken;
 
 		return Object.assign( {}, params, {
-			query: qs.stringify( query ),
+			query: stringify( query ),
 		} );
 	};
 

--- a/client/lib/wporg/jsonp.js
+++ b/client/lib/wporg/jsonp.js
@@ -10,7 +10,7 @@
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'jsonp' );
-import qs from 'qs';
+import { stringify } from 'qs';
 
 /**
  * Module exports.
@@ -81,7 +81,7 @@ function jsonp( url, query, fn ) {
 	};
 
 	// add qs component
-	url += '=' + enc( id ) + '?' + qs.stringify( query );
+	url += '=' + enc( id ) + '?' + stringify( query );
 
 	debug( 'jsonp req "%s"', url );
 

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import page from 'page';
-import qs from 'qs';
+import { parse } from 'qs';
 import React from 'react';
 import { includes, map } from 'lodash';
 import { parse as parseUrl } from 'url';
@@ -59,7 +59,7 @@ export function login( context, next ) {
 		}
 
 		const parsedRedirectUrl = parseUrl( redirect_to );
-		const redirectQueryString = qs.parse( parsedRedirectUrl.query );
+		const redirectQueryString = parse( parsedRedirectUrl.query );
 
 		if ( client_id !== redirectQueryString.client_id ) {
 			recordTracksEvent( 'calypso_login_phishing_attempt', context.query );

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import url from 'url';
-import Qs from 'qs';
+import { stringify } from 'qs';
 import { cloneDeep, get, startsWith } from 'lodash';
 import { connect } from 'react-redux';
 import debugFactory from 'debug';
@@ -188,9 +188,9 @@ class Customize extends React.Component {
 
 		//needed to load the customizer correctly when su'd
 		if ( wpcom.addSupportParams ) {
-			return Qs.stringify( wpcom.addSupportParams( query ) );
+			return stringify( wpcom.addSupportParams( query ) );
 		}
-		return Qs.stringify( query );
+		return stringify( query );
 	};
 
 	listenToCustomizer = () => {

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import page from 'page';
-import qs from 'qs';
+import { stringify } from 'qs';
 import { translate } from 'i18n-calypso';
 import React from 'react';
 import { get } from 'lodash';
@@ -216,7 +216,7 @@ const redirectToAddMappingIfVipSite = () => {
 		const state = context.store.getState();
 		const selectedSite = getSelectedSite( state );
 		const domain = context.params.domain ? `/${ context.params.domain }` : '';
-		const query = qs.stringify( { initialQuery: context.params.suggestion } );
+		const query = stringify( { initialQuery: context.params.suggestion } );
 
 		if ( selectedSite && selectedSite.is_vip ) {
 			return page.redirect( `/domains/add/mapping${ domain }?${ query }` );

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -8,7 +8,7 @@ import { trim, debounce, random, take, reject, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
-import qs from 'qs';
+import { stringify } from 'qs';
 
 /**
  * Internal Dependencies
@@ -79,7 +79,7 @@ class FollowingManage extends Component {
 		) {
 			let searchUrl = '/following/manage';
 			if ( newValue ) {
-				searchUrl += '?' + qs.stringify( { q: newValue } );
+				searchUrl += '?' + stringify( { q: newValue } );
 				recordTrack( 'calypso_reader_following_manage_search_performed', {
 					query: newValue,
 				} );

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import page from 'page';
-import qs from 'qs';
+import { stringify } from 'qs';
 
 /**
  * Internal dependencies
@@ -26,7 +26,7 @@ const analyticsPageTitle = 'Reader';
 function replaceSearchUrl( newValue, sort ) {
 	let searchUrl = '/read/search';
 	if ( newValue ) {
-		searchUrl += '?' + qs.stringify( { q: newValue, sort } );
+		searchUrl += '?' + stringify( { q: newValue, sort } );
 	}
 	page.replace( searchUrl );
 }

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -4,7 +4,7 @@
  */
 
 import { isEmpty, pick } from 'lodash';
-import qs from 'qs';
+import { stringify } from 'qs';
 
 /**
  * Internal dependencies
@@ -102,6 +102,6 @@ export function getCacheKey( context ) {
 	return (
 		context.pathname +
 		'?' +
-		qs.stringify( cachedQueryParams, { sort: ( a, b ) => a.localCompare( b ) } )
+		stringify( cachedQueryParams, { sort: ( a, b ) => a.localCompare( b ) } )
 	);
 }

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -5,7 +5,7 @@
 import express from 'express';
 import fs from 'fs';
 import path from 'path';
-import qs from 'qs';
+import { stringify } from 'qs';
 import crypto from 'crypto';
 import { execSync } from 'child_process';
 import cookieParser from 'cookie-parser';
@@ -325,13 +325,13 @@ function setUpLoggedInRoute( req, res, next ) {
 
 				if ( req.query.newuseremail ) {
 					debug( 'Detected legacy email verification action. Redirecting...' );
-					res.redirect( 'https://wordpress.com/verify-email/?' + qs.stringify( req.query ) );
+					res.redirect( 'https://wordpress.com/verify-email/?' + stringify( req.query ) );
 					return;
 				}
 
 				if ( req.query.action === 'wpcom-invite-users' ) {
 					debug( 'Detected legacy invite acceptance action. Redirecting...' );
-					res.redirect( 'https://wordpress.com/accept-invite/?' + qs.stringify( req.query ) );
+					res.redirect( 'https://wordpress.com/accept-invite/?' + stringify( req.query ) );
 					return;
 				}
 			}

--- a/server/user-bootstrap/index.js
+++ b/server/user-bootstrap/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import qs from 'qs';
+import { stringify } from 'qs';
 import superagent from 'superagent';
 import debugFactory from 'debug';
 import crypto from 'crypto';
@@ -25,7 +25,7 @@ const debug = debugFactory( 'calypso:bootstrap' ),
 		meta: 'flags',
 		abtests: getActiveTestNames( { appendDatestamp: true, asCSV: true } ),
 	},
-	url = `${ API_PATH }?${ qs.stringify( apiQuery ) }`;
+	url = `${ API_PATH }?${ stringify( apiQuery ) }`;
 
 module.exports = function( authCookieValue, geoCountry, callback ) {
 	// create HTTP Request object


### PR DESCRIPTION
Mostly to give us a better grasp of what parts of `qs` we're using, for #23259.

To test:
* This is all over the place, so probably a bit unwieldy to test.
* Maybe verify that both `parse` and `stringify` work for one occurrence each.
* CircleCI going green should prove that I didn't miss any occurrences of `qs.something` in a file where I've changed the default import to a named one.
* Do a grep for `from 'qs'` to verify I've replaced all default imports by named ones.
* Let's merge, deploy, and stick around in case things go 💥?