### PR TITLE
Framework: Use named imports from querystring

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -6,7 +6,7 @@
 
 import debugFactory from 'debug';
 import page from 'page';
-import qs from 'querystring';
+import { parse } from 'querystring';
 import { some, startsWith } from 'lodash';
 import url from 'url';
 
@@ -47,7 +47,7 @@ const setupContextMiddleware = reduxStore => {
 		// set `context.hash` (we have to parse manually)
 		if ( context.hashstring ) {
 			try {
-				context.hash = qs.parse( context.hashstring );
+				context.hash = parse( context.hashstring );
 			} catch ( e ) {
 				debug( 'failed to query-string parse `location.hash`', e );
 				context.hash = {};

--- a/client/components/gravatar/index.jsx
+++ b/client/components/gravatar/index.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import url from 'url';
-import qs from 'querystring';
+import { parse, stringify } from 'querystring';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import classnames from 'classnames';
@@ -47,7 +47,7 @@ export class Gravatar extends Component {
 		const { imgSize } = this.props;
 		imageURL = imageURL || 'https://www.gravatar.com/avatar/0';
 		const parsedURL = url.parse( imageURL );
-		const query = qs.parse( parsedURL.query );
+		const query = parse( parsedURL.query );
 
 		if ( /^([-a-zA-Z0-9_]+\.)*(gravatar.com)$/.test( parsedURL.hostname ) ) {
 			query.s = imgSize;
@@ -57,7 +57,7 @@ export class Gravatar extends Component {
 			query.resize = imgSize + ',' + imgSize;
 		}
 
-		parsedURL.search = qs.stringify( query );
+		parsedURL.search = stringify( query );
 		return url.format( parsedURL );
 	}
 

--- a/client/components/tinymce/plugins/after-the-deadline/plugin.js
+++ b/client/components/tinymce/plugins/after-the-deadline/plugin.js
@@ -22,7 +22,7 @@
  * External dependencies
  */
 import tinymce from 'tinymce/tinymce';
-import qs from 'querystring';
+import { stringify } from 'querystring';
 import { find, throttle } from 'lodash';
 import { getLocaleSlug, translate } from 'i18n-calypso';
 
@@ -252,7 +252,7 @@ function plugin( editor ) {
 		} );
 
 		const key = editor.getParam( 'atd_rpc_id' );
-		xhr.send( qs.stringify( { data, key } ) );
+		xhr.send( stringify( { data, key } ) );
 	}
 
 	function setAlwaysIgnore( text ) {

--- a/client/extensions/woocommerce/state/data-layer/orders/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/index.js
@@ -5,7 +5,7 @@
 import debugFactory from 'debug';
 import { isFinite, omitBy } from 'lodash';
 import { translate } from 'i18n-calypso';
-import qs from 'querystring';
+import { stringify } from 'querystring';
 
 /**
  * Internal dependencies
@@ -78,7 +78,7 @@ export function apiError( { dispatch }, action, error ) {
 
 export function requestOrders( { dispatch }, action ) {
 	const { siteId, query } = action;
-	const queryString = qs.stringify( omitBy( query, val => '' === val ) );
+	const queryString = stringify( omitBy( query, val => '' === val ) );
 	action.failureAction = failOrders( siteId, query );
 
 	dispatch( request( siteId, action ).getWithHeaders( `orders?${ queryString }` ) );

--- a/client/extensions/woocommerce/state/data-layer/product-categories/index.js
+++ b/client/extensions/woocommerce/state/data-layer/product-categories/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { omitBy } from 'lodash';
-import qs from 'querystring';
+import { stringify } from 'querystring';
 
 /**
  * Internal dependencies
@@ -124,7 +124,7 @@ export function handleProductCategoryDeleteSuccess( { dispatch }, action, catego
 export function handleProductCategoriesRequest( { dispatch }, action ) {
 	const { siteId, query } = action;
 	const requestQuery = { ...DEFAULT_QUERY, ...query };
-	const queryString = qs.stringify( omitBy( requestQuery, val => '' === val ) );
+	const queryString = stringify( omitBy( requestQuery, val => '' === val ) );
 
 	dispatch( request( siteId, action ).getWithHeaders( `products/categories?${ queryString }` ) );
 }

--- a/client/extensions/woocommerce/state/data-layer/products/index.js
+++ b/client/extensions/woocommerce/state/data-layer/products/index.js
@@ -4,7 +4,7 @@
  */
 import debugFactory from 'debug';
 import { isUndefined, mapValues, omitBy } from 'lodash';
-import qs from 'querystring';
+import { stringify } from 'querystring';
 import warn from 'lib/warn';
 
 /**
@@ -122,7 +122,7 @@ export function handleProductRequest( { dispatch }, action ) {
 
 export function productsRequest( { dispatch }, action ) {
 	const { siteId, params } = action;
-	const queryString = qs.stringify( omitBy( params, val => '' === val ) );
+	const queryString = stringify( omitBy( params, val => '' === val ) );
 
 	dispatch( request( siteId, action ).getWithHeaders( `products?${ queryString }` ) );
 }

--- a/client/extensions/woocommerce/state/sites/reviews/handlers.js
+++ b/client/extensions/woocommerce/state/sites/reviews/handlers.js
@@ -5,7 +5,7 @@
  */
 
 import { get, omitBy, omit } from 'lodash';
-import qs from 'querystring';
+import { stringify } from 'querystring';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -47,7 +47,7 @@ export default {
 export function handleReviewsRequest( { dispatch }, action ) {
 	const { siteId, query } = action;
 	const requestQuery = { ...DEFAULT_QUERY, ...query };
-	const queryString = qs.stringify( omitBy( requestQuery, val => '' === val ) );
+	const queryString = stringify( omitBy( requestQuery, val => '' === val ) );
 
 	dispatch( request( siteId, action ).get( `products/reviews?${ queryString }&_envelope` ) );
 }

--- a/client/extensions/woocommerce/woocommerce-services/lib/pdf-label-utils/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/pdf-label-utils/index.js
@@ -5,7 +5,7 @@
  */
 
 import { translate } from 'i18n-calypso';
-import querystring from 'querystring';
+import { stringify } from 'querystring';
 import { includes, reduce, filter, map } from 'lodash';
 
 /**
@@ -55,7 +55,7 @@ const _getPDFURL = ( paperSize, labels, baseUrl ) => {
 		json: true,
 	};
 
-	return baseUrl + '?' + querystring.stringify( params );
+	return baseUrl + '?' + stringify( params );
 };
 
 export const getPrintURL = ( paperSize, labels ) => {

--- a/client/layout/error.jsx
+++ b/client/layout/error.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 import { assign } from 'lodash';
 import React from 'react';
 import url from 'url';
-import qs from 'querystring';
+import { stringify } from 'querystring';
 
 /**
  * Internal dependencies
@@ -41,7 +41,7 @@ export function retry( chunkName ) {
 		analytics.mc.bumpStat( 'calypso_chunk_retry', chunkName );
 
 		// Trigger a full page load which should include script tags for the current chunk
-		window.location.search = qs.stringify( assign( parsed.query, { retry: '1' } ) );
+		window.location.search = stringify( assign( parsed.query, { retry: '1' } ) );
 	}
 }
 

--- a/client/lib/wp/handlers/guest-sandbox-ticket.js
+++ b/client/lib/wp/handlers/guest-sandbox-ticket.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import qs from 'querystring';
+import { decode, parse, stringify } from 'querystring';
 import store from 'store';
 
 export const GUEST_TICKET_LOCALFORAGE_KEY = 'guest_sandbox_ticket';
@@ -39,10 +39,10 @@ export const injectGuestSandboxTicketHandler = wpcom => {
 			const ticket = getTicket();
 
 			if ( ticket ) {
-				const query = qs.parse( params.query );
+				const query = parse( params.query );
 
 				params = Object.assign( {}, params, {
-					query: qs.stringify( Object.assign( query, { store_sandbox_ticket: ticket.value } ) ),
+					query: stringify( Object.assign( query, { store_sandbox_ticket: ticket.value } ) ),
 				} );
 			}
 
@@ -61,7 +61,7 @@ const initialize = () => {
 
 	deleteOldTicket();
 
-	const queryObject = qs.decode( window.location.search.replace( '?', '' ) );
+	const queryObject = decode( window.location.search.replace( '?', '' ) );
 
 	if ( queryObject.guest_ticket ) {
 		store.set( GUEST_TICKET_LOCALFORAGE_KEY, {

--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import qs from 'querystring';
+import { parse, stringify } from 'querystring';
 
 /**
  * Internal dependencies
@@ -47,7 +47,7 @@ export function addLocaleQueryParam( params ) {
 	}
 
 	let localeQueryParam;
-	const query = qs.parse( params.query );
+	const query = parse( params.query );
 
 	if ( params.apiNamespace ) {
 		// v2 api request
@@ -57,7 +57,7 @@ export function addLocaleQueryParam( params ) {
 	}
 
 	return Object.assign( params, {
-		query: qs.stringify( Object.assign( query, localeQueryParam ) ),
+		query: stringify( Object.assign( query, localeQueryParam ) ),
 	} );
 }
 

--- a/client/lib/wp/sync-handler/test/index.js
+++ b/client/lib/wp/sync-handler/test/index.js
@@ -5,7 +5,7 @@
 import { expect } from 'chai';
 import localforageMock from 'localforage';
 import { defer } from 'lodash';
-import querystring from 'querystring';
+import { parse } from 'querystring';
 import { spy } from 'sinon';
 
 /**
@@ -212,7 +212,7 @@ describe( 'sync-handler', () => {
 			wpcomOptOut
 				.skipLocalSyncResult()
 				.site( postListSiteId )
-				.postsList( querystring.parse( postListParams.query ), callback );
+				.postsList( parse( postListParams.query ), callback );
 
 			defer( () => {
 				expect( callback ).to.have.been.calledOnce;

--- a/client/lib/wp/sync-handler/utils.js
+++ b/client/lib/wp/sync-handler/utils.js
@@ -6,7 +6,7 @@
 
 import deterministicStringify from 'json-stable-stringify';
 import sha1 from 'hash.js/lib/hash/sha/1';
-import qs from 'querystring';
+import { parse, stringify } from 'querystring';
 
 /**
  * Internal dependencies
@@ -25,7 +25,7 @@ export const generateKey = ( params, applyHash = true ) => {
 
 	if ( params.query ) {
 		// sort parameters alphabetically
-		key += '-' + deterministicStringify( qs.parse( params.query ) );
+		key += '-' + deterministicStringify( parse( params.query ) );
 	}
 
 	if ( applyHash ) {
@@ -44,9 +44,9 @@ export const generateKey = ( params, applyHash = true ) => {
  * @return {String}        - pageSeriesKey string
  */
 export const generatePageSeriesKey = reqParams => {
-	const queryParams = qs.parse( reqParams.query );
+	const queryParams = parse( reqParams.query );
 	delete queryParams.page_handle;
-	const paramsWithoutPage = Object.assign( {}, reqParams, { query: qs.stringify( queryParams ) } );
+	const paramsWithoutPage = Object.assign( {}, reqParams, { query: stringify( queryParams ) } );
 	return generateKey( paramsWithoutPage );
 };
 
@@ -56,7 +56,7 @@ export const generatePageSeriesKey = reqParams => {
  * @return {Object} - request params in a more usable format
  */
 export const normalizeRequestParams = reqParams => {
-	const query = qs.parse( reqParams.query );
+	const query = parse( reqParams.query );
 	const normalizedParams = Object.assign( {}, reqParams, { query } );
 	delete normalizedParams.supports_args;
 	delete normalizedParams.supports_progress;

--- a/client/my-sites/sharing/buttons/preview-widget.js
+++ b/client/my-sites/sharing/buttons/preview-widget.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import qs from 'querystring';
+import { stringify } from 'querystring';
 import i18n from 'i18n-calypso';
 
 var baseUrl = '//widgets.wp.com/sharing-buttons-preview/';
@@ -35,6 +35,6 @@ export default {
 			query.more = i18n.translate( 'More' );
 		}
 
-		return baseUrl + '?' + qs.stringify( query );
+		return baseUrl + '?' + stringify( query );
 	},
 };

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -8,7 +8,7 @@ import ReactDomServer from 'react-dom/server';
 import React from 'react';
 import i18n from 'i18n-calypso';
 import page from 'page';
-import qs from 'querystring';
+import { stringify } from 'querystring';
 import { isWebUri as isValidUrl } from 'valid-url';
 import { map, pick, reduce, startsWith } from 'lodash';
 
@@ -305,7 +305,7 @@ export default {
 		}
 
 		const redirectPath = addSiteFragment( context.pathname, currentUser.primarySiteSlug );
-		const queryString = qs.stringify( context.query );
+		const queryString = stringify( context.query );
 		const redirectWithParams = [ redirectPath, queryString ].join( '?' );
 
 		page.redirect( redirectWithParams );

--- a/client/post-editor/editor-location/index.jsx
+++ b/client/post-editor/editor-location/index.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import qs from 'querystring';
+import { stringify } from 'querystring';
 
 /**
  * Internal dependencies
@@ -105,7 +105,7 @@ class EditorLocation extends React.Component {
 
 		const src =
 			GOOGLE_MAPS_BASE_URL +
-			qs.stringify( {
+			stringify( {
 				markers: this.props.coordinates.join( ',' ),
 				zoom: 8,
 				size: '400x300',


### PR DESCRIPTION
Note that this is preparatory work for another PR that will `s/from 'querystring'/from 'qs'/g`:
* The [`querystring` module](https://www.npmjs.com/package/querystring)'s functionality overlaps with `qs`, but `querystring` hasn't been updated in 5 years (!) and has a big ['Maintiner Needed'](https://github.com/Gozala/querystring#status-maintiner-needed) _(sic)_ note.

To test:
* This is all over the place, so probably a bit unwieldy to test.
* Maybe verify that both `parse` and `stringify` work for one occurrence each.
* CircleCI going green should prove that I didn't miss any occurrences of `qs.something` in a file where I've changed the default import to a named one.
* Do a grep for `from 'querystring'` to verify I've replaced all default imports by named ones.
* Let's merge, deploy, and stick around in case things go 💥?