### PR TITLE
Framework: Use qs module instead of querystring

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,7 +34,7 @@ module.exports = {
 			rootFiles: [ 'index.js', 'index.jsx', 'main.js', 'main.jsx' ],
 		} ],
 		'wpcalypso/import-no-redux-combine-reducers': 2,
-		'import/no-nodejs-modules': [ 'error', { allow: [ 'querystring', 'url', 'events', 'path' ] } ],
+		'import/no-nodejs-modules': [ 'error', { allow: [ 'url', 'events', 'path' ] } ],
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: './' } ],
 	}
 };

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -6,7 +6,7 @@
 
 import debugFactory from 'debug';
 import page from 'page';
-import { parse } from 'querystring';
+import { parse } from 'qs';
 import { some, startsWith } from 'lodash';
 import url from 'url';
 

--- a/client/components/gravatar/index.jsx
+++ b/client/components/gravatar/index.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import url from 'url';
-import { parse, stringify } from 'querystring';
+import { parse, stringify } from 'qs';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import classnames from 'classnames';

--- a/client/components/tinymce/plugins/after-the-deadline/plugin.js
+++ b/client/components/tinymce/plugins/after-the-deadline/plugin.js
@@ -22,7 +22,7 @@
  * External dependencies
  */
 import tinymce from 'tinymce/tinymce';
-import { stringify } from 'querystring';
+import { stringify } from 'qs';
 import { find, throttle } from 'lodash';
 import { getLocaleSlug, translate } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/state/data-layer/orders/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/index.js
@@ -5,7 +5,7 @@
 import debugFactory from 'debug';
 import { isFinite, omitBy } from 'lodash';
 import { translate } from 'i18n-calypso';
-import { stringify } from 'querystring';
+import { stringify } from 'qs';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/state/data-layer/product-categories/index.js
+++ b/client/extensions/woocommerce/state/data-layer/product-categories/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { omitBy } from 'lodash';
-import { stringify } from 'querystring';
+import { stringify } from 'qs';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/state/data-layer/products/index.js
+++ b/client/extensions/woocommerce/state/data-layer/products/index.js
@@ -4,7 +4,7 @@
  */
 import debugFactory from 'debug';
 import { isUndefined, mapValues, omitBy } from 'lodash';
-import { stringify } from 'querystring';
+import { stringify } from 'qs';
 import warn from 'lib/warn';
 
 /**

--- a/client/extensions/woocommerce/state/sites/reviews/handlers.js
+++ b/client/extensions/woocommerce/state/sites/reviews/handlers.js
@@ -5,7 +5,7 @@
  */
 
 import { get, omitBy, omit } from 'lodash';
-import { stringify } from 'querystring';
+import { stringify } from 'qs';
 import { translate } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/woocommerce-services/lib/pdf-label-utils/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/pdf-label-utils/index.js
@@ -5,7 +5,7 @@
  */
 
 import { translate } from 'i18n-calypso';
-import { stringify } from 'querystring';
+import { stringify } from 'qs';
 import { includes, reduce, filter, map } from 'lodash';
 
 /**

--- a/client/layout/error.jsx
+++ b/client/layout/error.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 import { assign } from 'lodash';
 import React from 'react';
 import url from 'url';
-import { stringify } from 'querystring';
+import { stringify } from 'qs';
 
 /**
  * Internal dependencies

--- a/client/lib/wp/handlers/guest-sandbox-ticket.js
+++ b/client/lib/wp/handlers/guest-sandbox-ticket.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { decode, parse, stringify } from 'querystring';
+import { decode, parse, stringify } from 'qs';
 import store from 'store';
 
 export const GUEST_TICKET_LOCALFORAGE_KEY = 'guest_sandbox_ticket';

--- a/client/lib/wp/handlers/guest-sandbox-ticket.js
+++ b/client/lib/wp/handlers/guest-sandbox-ticket.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { decode, parse, stringify } from 'qs';
+import { parse, stringify } from 'qs';
 import store from 'store';
 
 export const GUEST_TICKET_LOCALFORAGE_KEY = 'guest_sandbox_ticket';
@@ -61,7 +61,7 @@ const initialize = () => {
 
 	deleteOldTicket();
 
-	const queryObject = decode( window.location.search.replace( '?', '' ) );
+	const queryObject = parse( window.location.search.replace( '?', '' ) );
 
 	if ( queryObject.guest_ticket ) {
 		store.set( GUEST_TICKET_LOCALFORAGE_KEY, {

--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { parse, stringify } from 'querystring';
+import { parse, stringify } from 'qs';
 
 /**
  * Internal dependencies

--- a/client/lib/wp/sync-handler/test/index.js
+++ b/client/lib/wp/sync-handler/test/index.js
@@ -5,7 +5,7 @@
 import { expect } from 'chai';
 import localforageMock from 'localforage';
 import { defer } from 'lodash';
-import { parse } from 'querystring';
+import { parse } from 'qs';
 import { spy } from 'sinon';
 
 /**

--- a/client/lib/wp/sync-handler/utils.js
+++ b/client/lib/wp/sync-handler/utils.js
@@ -6,7 +6,7 @@
 
 import deterministicStringify from 'json-stable-stringify';
 import sha1 from 'hash.js/lib/hash/sha/1';
-import { parse, stringify } from 'querystring';
+import { parse, stringify } from 'qs';
 
 /**
  * Internal dependencies

--- a/client/my-sites/sharing/buttons/preview-widget.js
+++ b/client/my-sites/sharing/buttons/preview-widget.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { stringify } from 'querystring';
+import { stringify } from 'qs';
 import i18n from 'i18n-calypso';
 
 var baseUrl = '//widgets.wp.com/sharing-buttons-preview/';

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -8,7 +8,7 @@ import ReactDomServer from 'react-dom/server';
 import React from 'react';
 import i18n from 'i18n-calypso';
 import page from 'page';
-import { stringify } from 'querystring';
+import { stringify } from 'qs';
 import { isWebUri as isValidUrl } from 'valid-url';
 import { map, pick, reduce, startsWith } from 'lodash';
 

--- a/client/post-editor/editor-location/index.jsx
+++ b/client/post-editor/editor-location/index.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import { stringify } from 'querystring';
+import { stringify } from 'qs';
 
 /**
  * Internal dependencies

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -529,7 +529,7 @@
       "integrity": "sha1-a8vQOKM3xwYn5/zkQ4+lgYjwk3s=",
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000813",
+        "caniuse-db": "1.0.30000814",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -855,8 +855,8 @@
       "dev": true,
       "requires": {
         "find-up": "2.1.0",
-        "istanbul-lib-instrument": "1.9.2",
-        "test-exclude": "4.2.0"
+        "istanbul-lib-instrument": "1.10.1",
+        "test-exclude": "4.2.1"
       }
     },
     "babel-plugin-jest-hoist": {
@@ -1385,7 +1385,7 @@
           "version": "2.11.3",
           "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
           "requires": {
-            "caniuse-lite": "1.0.30000813",
+            "caniuse-lite": "1.0.30000814",
             "electron-to-chromium": "1.3.37"
           }
         },
@@ -1900,7 +1900,7 @@
       "version": "1.3.6",
       "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
       "requires": {
-        "caniuse-db": "1.0.30000813"
+        "caniuse-db": "1.0.30000814"
       }
     },
     "bser": {
@@ -1950,7 +1950,7 @@
         "move-concurrently": "1.0.1",
         "promise-inflight": "1.0.1",
         "rimraf": "2.6.2",
-        "ssri": "5.2.4",
+        "ssri": "5.3.0",
         "unique-filename": "1.1.0",
         "y18n": "4.0.0"
       },
@@ -2046,12 +2046,12 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000813",
-      "integrity": "sha1-4KHGA/iICteHsqNWUrJzPzKl4po="
+      "version": "1.0.30000814",
+      "integrity": "sha1-LJ7tf7wnJAZkdMt+GpJPDqEv5KI="
     },
     "caniuse-lite": {
-      "version": "1.0.30000813",
-      "integrity": "sha512-A8ITSmH5SFdMFdC704ggjg+x2z5PzQmVlG8tavwnfvbC33Q1UYrj0+G+Xm0SNAnd4He36fwUE/KEWytOEchw+A=="
+      "version": "1.0.30000814",
+      "integrity": "sha512-Kt4dBhVlnTZ+jj+C8Bd4WT6RT4EJoX5/tlktHQfpqIMgLVrG1KBQlLf010ipMvuNrpQiAJ2A54e6MMbA0BaKxg=="
     },
     "cardinal": {
       "version": "1.0.0",
@@ -2271,8 +2271,8 @@
       }
     },
     "ci-info": {
-      "version": "1.1.2",
-      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+      "version": "1.1.3",
+      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
       "dev": true
     },
     "cipher-base": {
@@ -2620,6 +2620,11 @@
           "dev": true
         }
       }
+    },
+    "compare-versions": {
+      "version": "3.1.0",
+      "integrity": "sha512-4hAxDSBypT/yp2ySFD346So6Ragw5xmBn/e/agIGl3bZr6DLUqnoRZPusxKrXdYRZpgexO9daejmIenlq/wrIQ==",
+      "dev": true
     },
     "component-bind": {
       "version": "1.0.0",
@@ -3448,7 +3453,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000813",
+        "caniuse-db": "1.0.30000814",
         "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
         "jsonfilter": "1.1.2",
@@ -6065,7 +6070,7 @@
         "omggif": "1.0.9",
         "parse-data-uri": "0.2.0",
         "pngjs": "2.3.1",
-        "request": "2.83.0",
+        "request": "2.85.0",
         "through": "2.3.8"
       }
     },
@@ -6787,7 +6792,7 @@
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "sshpk": "1.14.1"
       }
     },
     "https-browserify": {
@@ -7099,7 +7104,7 @@
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.2"
+        "ci-info": "1.1.3"
       }
     },
     "is-data-descriptor": {
@@ -7488,18 +7493,19 @@
       }
     },
     "istanbul-api": {
-      "version": "1.2.2",
-      "integrity": "sha512-kH5YRdqdbs5hiH4/Rr1Q0cSAGgjh3jTtg8vu9NLebBAoK3adVO4jk81J+TYOkTr2+Q4NLeb1ACvmEt65iG/Vbw==",
+      "version": "1.3.1",
+      "integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
       "dev": true,
       "requires": {
         "async": "2.6.0",
+        "compare-versions": "3.1.0",
         "fileset": "2.0.3",
-        "istanbul-lib-coverage": "1.1.2",
-        "istanbul-lib-hook": "1.1.0",
-        "istanbul-lib-instrument": "1.9.2",
-        "istanbul-lib-report": "1.1.3",
-        "istanbul-lib-source-maps": "1.2.3",
-        "istanbul-reports": "1.1.4",
+        "istanbul-lib-coverage": "1.2.0",
+        "istanbul-lib-hook": "1.2.0",
+        "istanbul-lib-instrument": "1.10.1",
+        "istanbul-lib-report": "1.1.4",
+        "istanbul-lib-source-maps": "1.2.4",
+        "istanbul-reports": "1.3.0",
         "js-yaml": "3.11.0",
         "mkdirp": "0.5.1",
         "once": "1.4.0"
@@ -7512,25 +7518,55 @@
           "requires": {
             "lodash": "4.17.5"
           }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "1.2.4",
+          "integrity": "sha512-UzuK0g1wyQijiaYQxj/CdNycFhAd2TLtO2obKQMTZrZ1jzEMRY3rvpASEKkaxbRR6brvdovfA03znPa/pXcejg==",
+          "dev": true,
+          "requires": {
+            "debug": "3.1.0",
+            "istanbul-lib-coverage": "1.2.0",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "source-map": "0.5.7"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
         }
       }
     },
     "istanbul-lib-coverage": {
-      "version": "1.1.2",
-      "integrity": "sha512-tZYA0v5A7qBSsOzcebJJ/z3lk3oSzH62puG78DbBA1+zupipX2CakDyiPV3pOb8He+jBwVimuwB0dTnh38hX0w==",
+      "version": "1.2.0",
+      "integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
       "dev": true
     },
     "istanbul-lib-hook": {
-      "version": "1.1.0",
-      "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
+      "version": "1.2.0",
+      "integrity": "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
       "dev": true,
       "requires": {
         "append-transform": "0.4.0"
       }
     },
     "istanbul-lib-instrument": {
-      "version": "1.9.2",
-      "integrity": "sha512-nz8t4HQ2206a/3AXi+NHFWEa844DMpPsgbcUteJbt1j8LX1xg56H9rOMnhvcvVvPbW60qAIyrSk44H8ZDqaSSA==",
+      "version": "1.10.1",
+      "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
       "dev": true,
       "requires": {
         "babel-generator": "6.26.1",
@@ -7538,7 +7574,7 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "istanbul-lib-coverage": "1.1.2",
+        "istanbul-lib-coverage": "1.2.0",
         "semver": "5.5.0"
       },
       "dependencies": {
@@ -7550,11 +7586,11 @@
       }
     },
     "istanbul-lib-report": {
-      "version": "1.1.3",
-      "integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
+      "version": "1.1.4",
+      "integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "1.1.2",
+        "istanbul-lib-coverage": "1.2.0",
         "mkdirp": "0.5.1",
         "path-parse": "1.0.5",
         "supports-color": "3.2.3"
@@ -7566,7 +7602,7 @@
       "dev": true,
       "requires": {
         "debug": "3.1.0",
-        "istanbul-lib-coverage": "1.1.2",
+        "istanbul-lib-coverage": "1.2.0",
         "mkdirp": "0.5.1",
         "rimraf": "2.6.2",
         "source-map": "0.5.7"
@@ -7593,8 +7629,8 @@
       }
     },
     "istanbul-reports": {
-      "version": "1.1.4",
-      "integrity": "sha512-DfSTVOTkuO+kRmbO8Gk650Wqm1WRGr6lrdi2EwDK1vxpS71vdlLd613EpzOKdIFioB5f/scJTjeWBnvd1FWejg==",
+      "version": "1.3.0",
+      "integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
       "dev": true,
       "requires": {
         "handlebars": "4.0.11"
@@ -7700,9 +7736,9 @@
             "graceful-fs": "4.1.11",
             "import-local": "1.0.0",
             "is-ci": "1.1.0",
-            "istanbul-api": "1.2.2",
-            "istanbul-lib-coverage": "1.1.2",
-            "istanbul-lib-instrument": "1.9.2",
+            "istanbul-api": "1.3.1",
+            "istanbul-lib-coverage": "1.2.0",
+            "istanbul-lib-instrument": "1.10.1",
             "istanbul-lib-source-maps": "1.2.3",
             "jest-changed-files": "22.2.0",
             "jest-config": "22.4.2",
@@ -8728,7 +8764,7 @@
         "babel-preset-stage-1": "6.24.1",
         "babel-register": "6.24.1",
         "babylon": "6.18.0",
-        "colors": "1.1.2",
+        "colors": "1.2.1",
         "es6-promise": "3.3.1",
         "flow-parser": "0.67.1",
         "lodash": "4.17.5",
@@ -8811,8 +8847,8 @@
           }
         },
         "colors": {
-          "version": "1.1.2",
-          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+          "version": "1.2.1",
+          "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg==",
           "dev": true
         },
         "core-js": {
@@ -8930,7 +8966,7 @@
         "nwmatcher": "1.4.3",
         "parse5": "4.0.0",
         "pn": "1.1.0",
-        "request": "2.83.0",
+        "request": "2.85.0",
         "request-promise-native": "1.0.5",
         "sax": "1.2.4",
         "symbol-tree": "3.2.2",
@@ -10112,7 +10148,7 @@
         "kind-of": "6.0.2",
         "object.pick": "1.3.0",
         "regex-not": "1.0.2",
-        "snapdragon": "0.8.1",
+        "snapdragon": "0.8.2",
         "to-regex": "3.0.2"
       },
       "dependencies": {
@@ -10302,7 +10338,7 @@
         "nopt": "3.0.6",
         "npmlog": "4.1.2",
         "osenv": "0.1.5",
-        "request": "2.83.0",
+        "request": "2.85.0",
         "rimraf": "2.6.2",
         "semver": "5.3.0",
         "tar": "2.2.1",
@@ -10438,7 +10474,7 @@
         "nan": "2.9.2",
         "node-gyp": "3.6.2",
         "npmlog": "4.1.2",
-        "request": "2.83.0",
+        "request": "2.85.0",
         "sass-graph": "2.2.4",
         "stdout-stream": "1.4.0"
       },
@@ -11649,7 +11685,7 @@
         "npmlog": "4.1.2",
         "os-homedir": "1.0.2",
         "pump": "2.0.1",
-        "rc": "1.2.5",
+        "rc": "1.2.6",
         "simple-get": "2.7.0",
         "tar-fs": "1.16.0",
         "tunnel-agent": "0.6.0",
@@ -12144,8 +12180,8 @@
       }
     },
     "rc": {
-      "version": "1.2.5",
-      "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
+      "version": "1.2.6",
+      "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
       "requires": {
         "deep-extend": "0.4.2",
         "ini": "1.3.5",
@@ -12240,7 +12276,7 @@
           "dev": true,
           "requires": {
             "find-up": "1.1.2",
-            "istanbul-lib-instrument": "1.9.2",
+            "istanbul-lib-instrument": "1.10.1",
             "object-assign": "4.1.1",
             "test-exclude": "2.1.3"
           }
@@ -12416,9 +12452,9 @@
                 "chalk": "1.1.3",
                 "graceful-fs": "4.1.11",
                 "is-ci": "1.1.0",
-                "istanbul-api": "1.2.2",
-                "istanbul-lib-coverage": "1.1.2",
-                "istanbul-lib-instrument": "1.9.2",
+                "istanbul-api": "1.3.1",
+                "istanbul-lib-coverage": "1.2.0",
+                "istanbul-lib-instrument": "1.10.1",
                 "jest-changed-files": "17.0.2",
                 "jest-config": "17.0.3",
                 "jest-environment-jsdom": "17.0.2",
@@ -12640,7 +12676,7 @@
             "html-encoding-sniffer": "1.0.2",
             "nwmatcher": "1.4.3",
             "parse5": "1.5.1",
-            "request": "2.83.0",
+            "request": "2.85.0",
             "sax": "1.2.4",
             "symbol-tree": "3.2.2",
             "tough-cookie": "2.3.4",
@@ -13342,7 +13378,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.5"
+        "rc": "1.2.6"
       }
     },
     "regjsgen": {
@@ -13422,8 +13458,8 @@
       "dev": true
     },
     "request": {
-      "version": "2.83.0",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "version": "2.85.0",
+      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
@@ -13937,13 +13973,6 @@
       "version": "2.0.0",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
-    "set-getter": {
-      "version": "0.1.0",
-      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
-      "requires": {
-        "to-object-path": "0.3.0"
-      }
-    },
     "set-immediate-shim": {
       "version": "1.0.1",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
@@ -14084,8 +14113,8 @@
       }
     },
     "snapdragon": {
-      "version": "0.8.1",
-      "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
+      "version": "0.8.2",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "requires": {
         "base": "0.11.2",
         "debug": "2.2.0",
@@ -14094,7 +14123,7 @@
         "map-cache": "0.2.2",
         "source-map": "0.5.7",
         "source-map-resolve": "0.5.1",
-        "use": "2.0.2"
+        "use": "3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -14402,8 +14431,8 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.13.1",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "version": "1.14.1",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
@@ -14416,8 +14445,8 @@
       }
     },
     "ssri": {
-      "version": "5.2.4",
-      "integrity": "sha512-UnEAgMZa15973iH7cUi0AHjJn1ACDIkaMyZILoqwN6yzt+4P81I8tBc5Hl+qwi5auMplZtPQsHrPBR5vJLcQtQ==",
+      "version": "5.3.0",
+      "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -15196,15 +15225,262 @@
       }
     },
     "test-exclude": {
-      "version": "4.2.0",
-      "integrity": "sha512-8hMFzjxbPv6xSlwGhXSvOMJ/vTy3bkng+2pxmf6E1z6VF7I9nIyNfvHtaw+NBPgvz647gADBbMSbwLfZYppT/w==",
+      "version": "4.2.1",
+      "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
       "dev": true,
       "requires": {
         "arrify": "1.0.1",
-        "micromatch": "2.3.11",
+        "micromatch": "3.1.9",
         "object-assign": "4.1.1",
         "read-pkg-up": "1.0.1",
         "require-main-filename": "1.0.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.1",
+          "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "kind-of": "6.0.2",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.9",
+          "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.1",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "text-table": {
@@ -15845,76 +16121,15 @@
       }
     },
     "use": {
-      "version": "2.0.2",
-      "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
+      "version": "3.1.0",
+      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "requires": {
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "lazy-cache": "2.0.2"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        },
         "kind-of": {
-          "version": "5.1.0",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "0.1.0"
-          }
+          "version": "6.0.2",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -16180,7 +16395,7 @@
             "isobject": "3.0.1",
             "kind-of": "6.0.2",
             "repeat-element": "1.1.2",
-            "snapdragon": "0.8.1",
+            "snapdragon": "0.8.2",
             "snapdragon-node": "2.1.1",
             "split-string": "3.1.0",
             "to-regex": "3.0.2"
@@ -16236,7 +16451,7 @@
             "extend-shallow": "2.0.1",
             "posix-character-classes": "0.1.1",
             "regex-not": "1.0.2",
-            "snapdragon": "0.8.1",
+            "snapdragon": "0.8.2",
             "to-regex": "3.0.2"
           },
           "dependencies": {
@@ -16279,7 +16494,7 @@
             "extend-shallow": "2.0.1",
             "fragment-cache": "0.2.1",
             "regex-not": "1.0.2",
-            "snapdragon": "0.8.1",
+            "snapdragon": "0.8.2",
             "to-regex": "3.0.2"
           },
           "dependencies": {
@@ -16413,7 +16628,7 @@
             "nanomatch": "1.2.9",
             "object.pick": "1.3.0",
             "regex-not": "1.0.2",
-            "snapdragon": "0.8.1",
+            "snapdragon": "0.8.2",
             "to-regex": "3.0.2"
           }
         },
@@ -16687,7 +16902,7 @@
         "chalk": "1.1.3",
         "commander": "2.15.0",
         "ejs": "2.5.7",
-        "express": "4.16.2",
+        "express": "4.16.3",
         "filesize": "3.6.0",
         "gzip-size": "3.0.0",
         "lodash": "4.17.5",
@@ -16788,8 +17003,8 @@
           "dev": true
         },
         "express": {
-          "version": "4.16.2",
-          "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+          "version": "4.16.3",
+          "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
           "dev": true,
           "requires": {
             "accepts": "1.3.5",
@@ -16804,7 +17019,7 @@
             "encodeurl": "1.0.2",
             "escape-html": "1.0.3",
             "etag": "1.8.1",
-            "finalhandler": "1.1.0",
+            "finalhandler": "1.1.1",
             "fresh": "0.5.2",
             "merge-descriptors": "1.0.1",
             "methods": "1.1.2",
@@ -16815,10 +17030,10 @@
             "qs": "6.5.1",
             "range-parser": "1.2.0",
             "safe-buffer": "5.1.1",
-            "send": "0.16.1",
-            "serve-static": "1.13.1",
+            "send": "0.16.2",
+            "serve-static": "1.13.2",
             "setprototypeof": "1.1.0",
-            "statuses": "1.3.1",
+            "statuses": "1.4.0",
             "type-is": "1.6.16",
             "utils-merge": "1.0.1",
             "vary": "1.1.2"
@@ -16830,8 +17045,8 @@
           "dev": true
         },
         "finalhandler": {
-          "version": "1.1.0",
-          "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+          "version": "1.1.1",
+          "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
           "dev": true,
           "requires": {
             "debug": "2.6.9",
@@ -16839,7 +17054,7 @@
             "escape-html": "1.0.3",
             "on-finished": "2.3.0",
             "parseurl": "1.3.2",
-            "statuses": "1.3.1",
+            "statuses": "1.4.0",
             "unpipe": "1.0.0"
           }
         },
@@ -16909,8 +17124,8 @@
           }
         },
         "send": {
-          "version": "0.16.1",
-          "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+          "version": "0.16.2",
+          "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
           "dev": true,
           "requires": {
             "debug": "2.6.9",
@@ -16925,28 +17140,23 @@
             "ms": "2.0.0",
             "on-finished": "2.3.0",
             "range-parser": "1.2.0",
-            "statuses": "1.3.1"
+            "statuses": "1.4.0"
           }
         },
         "serve-static": {
-          "version": "1.13.1",
-          "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+          "version": "1.13.2",
+          "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
           "dev": true,
           "requires": {
             "encodeurl": "1.0.2",
             "escape-html": "1.0.3",
             "parseurl": "1.3.2",
-            "send": "0.16.1"
+            "send": "0.16.2"
           }
         },
         "setprototypeof": {
           "version": "1.1.0",
           "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true
-        },
-        "statuses": {
-          "version": "1.3.1",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
           "dev": true
         },
         "supports-color": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
     "q": "1.0.1",
     "qrcode.react": "0.7.2",
     "qs": "4.0.0",
-    "querystring": "0.2.0",
     "react": "16.2.0",
     "react-click-outside": "2.3.1",
     "react-day-picker": "6.2.1",


### PR DESCRIPTION
The [`querystring` module](https://www.npmjs.com/package/querystring)'s functionality overlaps with `qs`, but `querystring` hasn't been updated in 5 years (!) and has a big ['Maintiner Needed'](https://github.com/Gozala/querystring#status-maintiner-needed) _(sic)_ note.

To test:
* This is all over the place, so probably a bit unwieldy to test; maybe just test a few occurrences (e.g. one for `decode`, one for `parse`, one for `stringify`) to gain confidence it works.
* Let's merge, deploy, and stick around in case things go 💥?