### PR TITLE
Plans: move Fragment to proper import in MyPlan.

### DIFF
--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -3,9 +3,8 @@
 /**
  * External dependencies
  */
-
-import PropTypes, { Fragment } from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/23264.
