### PR TITLE
Domains Checkout: Improve contact form accessibility

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -228,20 +228,6 @@ export class ContactDetailsFormFields extends Component {
 		}
 	}
 
-	focusAddressField() {
-		const inputRef = this.inputRefs[ 'address-1' ] || null;
-		if ( inputRef ) {
-			inputRef.focus();
-			return;
-		}
-		// The preference is to fire an inputRef callback
-		// when the previous and next countryCodes don't match,
-		// rather than set a flag.
-		// Multiple renders triggered by formState via `this.setFormState`
-		// prevent it.
-		this.shouldAutoFocusAddressField = true;
-	}
-
 	handleSubmitButtonClick = event => {
 		event.preventDefault();
 		this.formStateController.handleSubmit( hasErrors => {
@@ -270,7 +256,6 @@ export class ContactDetailsFormFields extends Component {
 					phoneCountryCode: value,
 				} );
 			}
-			this.focusAddressField();
 		}
 
 		this.formStateController.handleFieldChange( {

--- a/client/components/forms/form-input-validation/index.jsx
+++ b/client/components/forms/form-input-validation/index.jsx
@@ -31,7 +31,7 @@ export default class extends React.Component {
 		const icon = this.props.isError || this.props.isWarning ? 'notice-outline' : 'checkmark';
 
 		return (
-			<div className={ classes }>
+			<div className={ classes } role="alert">
 				<span>
 					<Gridicon size={ 24 } icon={ this.props.icon ? this.props.icon : icon } />{' '}
 					{ this.props.text }


### PR DESCRIPTION
Fix #21660

- Currently, upon selecting a country from the country list, the focus is automatically moved to the following field.
Even though I'm opposed to this behaviour, it could still make sense when the form is controlled via mouse or touch.
But, it makes impossible to select a country by typing its name.
E.g. If I wanted to select `Italy`, I would type `i` and then `t`. Though, `i` immediately selects the first country name starting with that letter, `Iceland`, and automatically moves the focus to the address field.
This PR removes this behaviour, making the country select field as standard as possible.

- The postal code field is validated (on change) against the country.
E.g. Italian postal codes only allow numbers, so typing `00100a` would display a validation error.
This error is not read by the screen reader, so visually impaired users do not receive any feedbacks that there are errors in the form.
This PR adds a `role="alert"` to the error, which is immediately read by the screen reader.
This change is not limited to the Domains Checkout form, but to **all** `FormInputValidation` usages.

## Note

#21660 also reported a bug with the phone field:
> This read my phone number as "five hundred fifty five" as I entered it, rather than "five five five". Not really a bug, but unexpected. Might be fixed by changing the input type?

I cannot reproduce this (VoiceOver reads my own number starting with `333` as `three three three`.
@ryelle can you confirm it? I'm using Mac's VoiceOver on macOS 10.13.3, and Chrome 64.

Though, I've found different issues related to the country code:

- The phone country code select field is not focusable via keyboard ([notice the `tabindex="-1"`](https://github.com/Automattic/wp-calypso/blob/master/client/components/phone-input/index.jsx#L254)).
- The phone country code select field overrides whatever I write in the phone text field.
In other words, if the phone country is set to "USA", the text field forces a `+1` into the text field.
This becomes very problematic keyboard users, because they can't actually change the phone country.

This is a more complicated change, which requires its own PR, so it won't be tackled here.

## Testing instructions

- Purchase a new domain for a site.
- At the checkout screen make sure that:
  - Selecting a country does not automatically move the focus to the address field.
  - Enabling VoiceOver, an error message is read by the screen reader upon entering an incorrect postal code.