### PR TITLE
Jetpack Onboarding: Make primary buttons green

### DIFF
--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -103,6 +103,11 @@
 			fill: $green-jetpack;
 		}
 	}
+
+	.button.is-primary {
+		background-color: $green-jetpack;
+		border-color: darken($green-jetpack, 5%);
+	}
 }
 
 .jetpack-onboarding__disclaimer {


### PR DESCRIPTION
This PR updates the primary buttons within the Jetpack Onboarding flow to be green instead of blue, in order to make the entire experience feel a bit more like Jetpack.

Fixes #23220.

# Previews

### Site Title step

**Before**
![](https://cldup.com/10PV9upMTJ.png)

**After**
![](https://cldup.com/_nJPp3gAJy.png)

### Business Address step - form view

**Before**
![](https://cldup.com/jaRWat7Tuo.png)

**After**
![](https://cldup.com/igg5MomNbh.png)

### WooCommerce step

**Before**
![](https://cldup.com/4TYlrdpAy0.png)

**After**
![](https://cldup.com/E-pYOVRaty.png)

### Summary step

**Before**
![](https://cldup.com/QgnmSkqx_Z.png)

**After**
![](https://cldup.com/5XGZT5mNBG.png)

# Testing

* Checkout this branch
* Pick a fresh connected site with the latest Jetpack.
* Go through the onboarding flow by running `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development` on that site.
* Verify you can see the updated button on the site title step.
* Continue to the site type step.
* Select "Business".
* Skip to the Business Address step.
* Click the button to add a business address to see the form.
* Verify you can see the updated button below the form.
* Submit the form and continue to the WooCommerce step.
* Verify you can see the updated button for installing WooCommerce.
* Skip to the Summary step. 
* Verify you can see the updated button at the bottom.