### PR TITLE
WPCOM endpoints expect locale as a query argument

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1484,13 +1484,11 @@ Undocumented.prototype.usersNew = function( query, fn ) {
  * @return {Promise} A promise for the request
  */
 Undocumented.prototype.usersSocialNew = function( query, fn ) {
-	query.locale = getLocaleSlug();
-
 	// This API call is restricted to these OAuth keys
 	restrictByOauthKeys( query );
 
 	const args = {
-		path: '/users/social/new',
+		path: '/users/social/new?locale=' + encodeURIComponent( getLocaleSlug() ),
 		body: query,
 	};
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1487,12 +1487,7 @@ Undocumented.prototype.usersSocialNew = function( query, fn ) {
 	// This API call is restricted to these OAuth keys
 	restrictByOauthKeys( query );
 
-	const args = {
-		path: '/users/social/new?locale=' + encodeURIComponent( getLocaleSlug() ),
-		body: query,
-	};
-
-	return this.wpcom.req.post( args, fn );
+	return this.wpcom.req.post( '/users/social/new', { locale: getLocaleSlug() }, query, fn );
 };
 
 /**


### PR DESCRIPTION
This PR moves the `locale` argument from body request to query string,
that how the WPCOM endpoint(s) expect it to be.

Some endpoints also take `locale` in body request, but that is usually used for different purposes.
See p1521137763000035-slack-amber-dev for example.
