### PR TITLE
Reader: add streams back link to Reader Search

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -32,6 +32,7 @@ import { resemblesUrl, withoutHttp, addSchemeIfMissing } from 'lib/url';
 import { getReaderAliasedFollowFeedUrl } from 'state/selectors';
 import { SEARCH_RESULTS_URL_INPUT } from 'reader/follow-sources';
 import FollowButton from 'reader/follow-button';
+import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
 
 const WIDE_DISPLAY_CUTOFF = 660;
 
@@ -168,6 +169,9 @@ class SearchStream extends React.Component {
 					style={ { width: this.props.width } }
 					ref={ this.handleFixedAreaMounted }
 				>
+					<MobileBackToSidebar>
+						<h1>{ translate( 'Streams' ) }</h1>
+					</MobileBackToSidebar>
 					<CompactCard className="search-stream__input-card">
 						<SearchInput
 							onSearch={ this.updateQuery }

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -3,7 +3,6 @@
 }
 
 .search-stream__intro {
-
 	@include breakpoint( "<660px" ) {
 		margin-left: 16px;
 	}
@@ -18,9 +17,17 @@
 	position: fixed;
 	top: 0;
 	margin-top: 47px; // masterbar is exactly 47px
-	padding-top: 30px;
 	z-index: 20;
 	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements text aliasing in Safari
+
+	// Below 660px we show the MobileBackToSidebar header so no padding needed
+	@include breakpoint( ">660px") {
+		padding-top: 30px;
+	}
+
+	.mobile-back-to-sidebar {
+		margin: 0;
+	}
 }
 
 .search-stream__fixed-area .section-nav-tabs.is-dropdown {

--- a/client/reader/sidebar/_style.scss
+++ b/client/reader/sidebar/_style.scss
@@ -10,6 +10,7 @@
 		margin-bottom: 8px;
 
 		.selected {
+
 			.menu-link-icon,
 			.sidebar__menu-action .gridicon,
 			.sidebar-dynamic-menu-action-icon {
@@ -18,6 +19,22 @@
 
 			.sidebar-streams__edit-icon {
 				fill: $white;
+			}
+
+			.gridicon {
+
+				@include breakpoint( "<660px" ) {
+					fill: $blue-medium;
+				}
+			}
+
+			li > a,
+			li > a:visited,
+			:not( .sidebar__button ) {
+
+				@include breakpoint( "<660px" ) {
+					color: $blue-medium;
+				}
 			}
 		}
 


### PR DESCRIPTION
All sections of the Reader have a link back to the 'Streams' menu on mobile - except Search, I noticed.

This PR adds a Streams back link to Search too.

Before:

![screen shot 2018-03-13 at 14 42 27](https://user-images.githubusercontent.com/17325/37350131-eb54ae2c-26cf-11e8-9066-17e8621c00f0.png)

After:

![screen shot 2018-03-13 at 14 48 07](https://user-images.githubusercontent.com/17325/37350143-ef58f578-26cf-11e8-813b-612a54022167.png)
