### PR TITLE
Plugins: Add a specific error for plugin api empty sections

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -164,6 +164,9 @@ export function normalizePluginData( plugin, pluginData ) {
 			case 'sections':
 				const cleanItem = {};
 				for ( const sectionKey of Object.keys( item ) ) {
+					if ( ! item[ sectionKey ] ) {
+						throw new Error( 'Section expected for key "' + sectionKey + '"' );
+					}
 					cleanItem[ sectionKey ] = sanitizeSectionContent( item[ sectionKey ] );
 				}
 				returnData.sections = cleanItem;


### PR DESCRIPTION
There are several errors being logged that point to an empty section
being passed in via API data. This more explicit error hopefully will
provide a more informative error message so the issue can be traced
further.

The errors being exhibited now point to the `sanitizeSectionContent` function.

To Test:
1. Ensure normal operation. This change shouldn't affect properly running code.

More information (see #21865 to decode minified stack trace below):
Calypso path: `/store/:siteId`
Error message: Het argument is niet optioneel
Commit: 97509f83abeb046e498390fa14fa13b09cad7d8f
Minified Stack Trace:
```[{"url":"https:\/\/wordpress.com\/calypso\/plugins.a01c2b5068cb2c717782.min.js","func":"l","args":[],"line":1,"column":110751,"context":"[\"webpackJsonp([\\\"plugins\\\"],{\\\".\/client\/blocks\/disconnect-jetpack\/dialog.jsx\\\":function(e,t,n){\\\"use strict\\\";var s=n(\\\".\/node_modules\/react\/index.js\\\"),i=n.n(s),a=n(\\\".\/node_modules\/prop-types\/index.js\\\"),r=n.n(a),o=n(\\\".\/client\/components\/dialog\/index.j"},{"url":"https:\/\/wordpress.com\/calypso\/plugins.a01c2b5068cb2c717782.min.js","func":"Anonymous function","args":[],"line":1,"column":119719,"context":"[\"webpackJsonp([\\\"plugins\\\"],{\\\".\/client\/blocks\/disconnect-jetpack\/dialog.jsx\\\":function(e,t,n){\\\"use strict\\\";var s=n(\\\".\/node_modules\/react\/index.js\\\"),i=n.n(s),a=n(\\\".\/node_modules\/prop-types\/index.js\\\"),r=n.n(a),o=n(\\\".\/client\/components\/dialog\/index.j"},{"url":"https:\/\/wordpress.com\/calypso\/vendor.6901cbde3129bb7a3658.min.js","func":"Anonymous function","args":[],"line":1,"column":302067,"context":"[\"webpackJsonp([\\\"vendor\\\"],{\\\".\/node_modules\/babel-runtime\/core-js\/object\/assign.js\\\":function(e,t,n){e.exports={default:n(\\\".\/node_modules\/core-js\/library\/fn\/object\/assign.js\\\"),__esModule:!0}},\\\".\/node_modules\/babel-runtime\/core-js\/object\/create.js\\\":fu"},{"url":"https:\/\/wordpress.com\/calypso\/vendor.6901cbde3129bb7a3658.min.js","func":"Anonymous function","args":[],"line":1,"column":274906,"context":"[\"webpackJsonp([\\\"vendor\\\"],{\\\".\/node_modules\/babel-runtime\/core-js\/object\/assign.js\\\":function(e,t,n){e.exports={default:n(\\\".\/node_modules\/core-js\/library\/fn\/object\/assign.js\\\"),__esModule:!0}},\\\".\/node_modules\/babel-runtime\/core-js\/object\/create.js\\\":fu"},{"url":"https:\/\/wordpress.com\/calypso\/vendor.6901cbde3129bb7a3658.min.js","func":"Jr","args":[],"line":1,"column":264777,"context":"[\"webpackJsonp([\\\"vendor\\\"],{\\\".\/node_modules\/babel-runtime\/core-js\/object\/assign.js\\\":function(e,t,n){e.exports={default:n(\\\".\/node_modules\/core-js\/library\/fn\/object\/assign.js\\\"),__esModule:!0}},\\\".\/node_modules\/babel-runtime\/core-js\/object\/create.js\\\":fu"},{"url":"https:\/\/wordpress.com\/calypso\/vendor.6901cbde3129bb7a3658.min.js","func":"fr.transform","args":[],"line":1,"column":302033,"context":"[\"webpackJsonp([\\\"vendor\\\"],{\\\".\/node_modules\/babel-runtime\/core-js\/object\/assign.js\\\":function(e,t,n){e.exports={default:n(\\\".\/node_modules\/core-js\/library\/fn\/object\/assign.js\\\"),__esModule:!0}},\\\".\/node_modules\/babel-runtime\/core-js\/object\/create.js\\\":fu"},{"url":"https:\/\/wordpress.com\/calypso\/plugins.a01c2b5068cb2c717782.min.js","func":"m","args":[],"line":1,"column":118843,"context":"[\"webpackJsonp([\\\"plugins\\\"],{\\\".\/client\/blocks\/disconnect-jetpack\/dialog.jsx\\\":function(e,t,n){\\\"use strict\\\";var s=n(\\\".\/node_modules\/react\/index.js\\\"),i=n.n(s),a=n(\\\".\/node_modules\/prop-types\/index.js\\\"),r=n.n(a),o=n(\\\".\/client\/components\/dialog\/index.j"},{"url":"https:\/\/wordpress.com\/calypso\/plugins.a01c2b5068cb2c717782.min.js","func":"Anonymous function","args":[],"line":1,"column":311533,"context":"[\"webpackJsonp([\\\"plugins\\\"],{\\\".\/client\/blocks\/disconnect-jetpack\/dialog.jsx\\\":function(e,t,n){\\\"use strict\\\";var s=n(\\\".\/node_modules\/react\/index.js\\\"),i=n.n(s),a=n(\\\".\/node_modules\/prop-types\/index.js\\\"),r=n.n(a),o=n(\\\".\/client\/components\/dialog\/index.j"},{"url":"https:\/\/wordpress.com\/calypso\/settings.095561cd1de13ee522ea.min.js","func":"Anonymous function","args":[],"line":1,"column":153440,"context":"[\"webpackJsonp([\\\"settings\\\"],{\\\".\/client\/blocks\/disconnect-jetpack\/index.jsx\\\":function(e,t,n){\\\"use strict\\\";var s=n(\\\".\/node_modules\/babel-runtime\/core-js\/object\/get-prototype-of.js\\\"),i=n.n(s),a=n(\\\".\/node_modules\/babel-runtime\/helpers\/classCallCheck.j"},{"url":"https:\/\/wordpress.com\/calypso\/settings.095561cd1de13ee522ea.min.js","func":"window[a]","args":[],"line":1,"column":155396,"context":"[\"webpackJsonp([\\\"settings\\\"],{\\\".\/client\/blocks\/disconnect-jetpack\/index.jsx\\\":function(e,t,n){\\\"use strict\\\";var s=n(\\\".\/node_modules\/babel-runtime\/core-js\/object\/get-prototype-of.js\\\"),i=n.n(s),a=n(\\\".\/node_modules\/babel-runtime\/helpers\/classCallCheck.j"}]```
