### PR TITLE
Removing shim that causes happychat socket connection to fail firing event handlers

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -183,7 +183,6 @@ const webpackConfig = {
 			global: 'window',
 		} ),
 		new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),
-		new webpack.NormalModuleReplacementPlugin( /^(json3|jsonify)$/, 'lib/shims/json' ),
 		new webpack.IgnorePlugin( /^props$/ ),
 		new CopyWebpackPlugin( [
 			{ from: 'node_modules/flag-icon-css/flags/4x3', to: 'images/flags' },


### PR DESCRIPTION
After #19107 was deployed happychat connections stopped allowing customers to chat.

Something about this change prevented the [`token`](https://github.com/Automattic/wp-calypso/blob/10774c5d9f2a6062906c6c3d7c096f9f5495cf9d/client/lib/happychat/connection.js#L58-L61) event from firing on the socket-io client connection. Removing restores it.

ht @mattwondra for finding it