### PR TITLE
Pages: Removing deprecated icons

### DIFF
--- a/client/components/update-post-status/style.scss
+++ b/client/components/update-post-status/style.scss
@@ -25,14 +25,6 @@
 		border: solid 1px $alert-green;
 		color: $alert-green;
 		transition: border-color 0.3s ease, color 0.3s ease;
-		.conf-alert_title {
-			&:after {
-				@extend %noticon;
-				content: '\f418';
-				font-size: (24 / 16) * 1em;
-				vertical-align: top;
-			}
-		}
 		hr {
 			background: #eee;
 			margin: (10 / 16) * 1em 0 0;
@@ -41,7 +33,7 @@
 			display: block;
 			font-size: (12 / 16) * 1em;
 			color: $gray;
-			padding: (10 / 12) * 1em 0 0;
+			padding: (10 / 12) * 1em 0 0 (10 / 16) * 1em;
 			&:hover {
 				cursor: pointer;
 			}
@@ -78,26 +70,6 @@
 				}
 				&:last-child {
 					animation-delay: 0.3s;
-				}
-			}
-			.conf-alert_title {
-				&:after {
-					content: '';
-				}
-			}
-		}
-		&.conf-alert--trashed {
-			.conf-alert_title {
-				&:after {
-					content: '\f407';
-				}
-			}
-		}
-		&.conf-alert--deleted,
-		&.conf-alert--error {
-			.conf-alert_title {
-				&:after {
-					content: '';
 				}
 			}
 		}


### PR DESCRIPTION
This removes icons from the post status notices that appear after
trashing a post. Icons in this case are just an enhancement, so I’m not
replacing them with Gridicons.


Ideally /pages would use the same notices as /posts but for some reason they are different.


Before

![before status](https://user-images.githubusercontent.com/618551/37367231-d14d39ee-26d0-11e8-8f31-4ae3e40e494a.gif)


After

![after status](https://user-images.githubusercontent.com/618551/37367240-d599dc78-26d0-11e8-86ff-7cb294f5a643.gif)
