### PR TITLE
Guided Tours: improve references to UI buttons

### DIFF
--- a/client/layout/guided-tours/button-labels.jsx
+++ b/client/layout/guided-tours/button-labels.jsx
@@ -1,0 +1,40 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+import { identity } from 'lodash';
+
+// Returns React component with a localized label and optional icon
+function button( label, icon ) {
+	return localize( ( { translate: tr } ) => (
+		<strong>
+			{ icon }
+			{ icon && '\u00A0' /* NBSP between icon and label */ }
+			{ tr( label ) }
+		</strong>
+	) );
+}
+
+// Localized texts need to be wrapped in a `translate` function to be found by the l10n bot
+const translate = identity;
+
+export const AddMediaButton = button( translate( 'Add Media' ) );
+export const AddNewButton = button( translate( 'Add New' ), <Gridicon icon="add-image" /> );
+export const AllThemesButton = button( translate( 'All Themes' ) );
+export const ChangeButton = button( translate( 'Change' ) );
+export const ContinueButton = button( translate( 'Continue' ) );
+export const DoneButton = button( translate( 'Done' ) );
+export const EditButton = button( translate( 'Edit' ) );
+export const EditImageButton = button( translate( 'Edit Image' ), <Gridicon icon="pencil" /> );
+export const PublishButton = button( translate( 'Publish' ) );
+export const SaveSettingsButton = button( translate( 'Save Settings' ) );
+export const SetFeaturedImageButton = button( translate( 'Set Featured Image' ) );
+export const SettingsButton = button( translate( 'Settings' ), <Gridicon icon="cog" /> );
+export const SiteTaglineButton = button( translate( 'Site Tagline' ) );
+export const SiteTitleButton = button( translate( 'Site Title' ) );
+export const UpdateButton = button( translate( 'Update' ) );
+export const ViewSiteButton = button( translate( 'View Site' ) );

--- a/client/layout/guided-tours/tours/checklist-about-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-about-page-tour.js
@@ -20,9 +20,7 @@ import {
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
-
-const SET_FEATURED_IMAGE_BUTTON_LABEL = translate( 'Set Featured Image' );
-const UPDATE_BUTTON_LABEL = translate( 'Update' );
+import { SetFeaturedImageButton, UpdateButton } from '../button-labels';
 
 export const ChecklistAboutPageTour = makeTour(
 	<Tour name="checklistAboutPage" version="20171205" path="/non-existent-route" when={ noop }>
@@ -90,7 +88,7 @@ export const ChecklistAboutPageTour = makeTour(
 					'We’re all set, press {{setFeaturedImageButton/}} to add this image to your page.',
 					{
 						components: {
-							setFeaturedImageButton: <strong>{ SET_FEATURED_IMAGE_BUTTON_LABEL }</strong>,
+							setFeaturedImageButton: <SetFeaturedImageButton />,
 						},
 					}
 				) }
@@ -100,7 +98,7 @@ export const ChecklistAboutPageTour = makeTour(
 		<Step name="click-update" target="editor-publish-button" arrow="right-top" placement="beside">
 			<Continue target="editor-publish-button" step="finish" click>
 				{ translate( 'Almost done, press the {{updateButton/}} button to save your changes.', {
-					components: { updateButton: <strong>{ UPDATE_BUTTON_LABEL }</strong> },
+					components: { updateButton: <UpdateButton /> },
 				} ) }
 			</Continue>
 		</Step>

--- a/client/layout/guided-tours/tours/checklist-contact-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-contact-page-tour.js
@@ -22,13 +22,11 @@ import {
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
+import { SetFeaturedImageButton, UpdateButton } from '../button-labels';
 
 function isPostEditorSection( state ) {
 	return getSectionName( state ) === 'post-editor';
 }
-
-const SET_FEATURED_IMAGE_BUTTON_LABEL = translate( 'Set Featured Image' );
-const UPDATE_BUTTON_LABEL = translate( 'Update' );
 
 export const ChecklistContactPageTour = makeTour(
 	<Tour name="checklistContactPage" version="20171205" path="/non-existent-route" when={ noop }>
@@ -98,7 +96,7 @@ export const ChecklistContactPageTour = makeTour(
 					'We’re all set, press {{setFeaturedImageButton/}} to add this image to your page.',
 					{
 						components: {
-							setFeaturedImageButton: <strong>{ SET_FEATURED_IMAGE_BUTTON_LABEL }</strong>,
+							setFeaturedImageButton: <SetFeaturedImageButton />,
 						},
 					}
 				) }
@@ -114,7 +112,7 @@ export const ChecklistContactPageTour = makeTour(
 		>
 			<Continue target="editor-publish-button" step="finish" click>
 				{ translate( 'Almost done, press the {{updateButton/}} button to save your changes.', {
-					components: { updateButton: <strong>{ UPDATE_BUTTON_LABEL }</strong> },
+					components: { updateButton: <UpdateButton /> },
 				} ) }
 			</Continue>
 		</Step>

--- a/client/layout/guided-tours/tours/checklist-site-icon-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-icon-tour.js
@@ -21,10 +21,7 @@ import {
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
-
-const CHANGE_BUTTON_LABEL = translate( 'Change' );
-const CONTINUE_BUTTON_LABEL = translate( 'Continue' );
-const DONE_BUTTON_LABEL = translate( 'Done' );
+import { ChangeButton, ContinueButton, DoneButton } from '../button-labels';
 
 function handleTargetDisappear( { quit, next } ) {
 	const dialog = document.querySelector( '.editor-media-modal' );
@@ -51,7 +48,7 @@ export const ChecklistSiteIconTour = makeTour(
 				{ translate(
 					'Press {{changeButton/}} to upload your own image or icon that can help people identify your site in the browser.',
 					{
-						components: { changeButton: <strong>{ CHANGE_BUTTON_LABEL }</strong> },
+						components: { changeButton: <ChangeButton /> },
 					}
 				) }
 			</p>
@@ -90,7 +87,7 @@ export const ChecklistSiteIconTour = makeTour(
 		>
 			<Continue target="dialog-base-action-confirm" step="click-done" click>
 				{ translate( 'Good choice, press {{continueButton/}} to use it as your Site Icon.', {
-					components: { continueButton: <strong>{ CONTINUE_BUTTON_LABEL }</strong> },
+					components: { continueButton: <ContinueButton /> },
 				} ) }
 			</Continue>
 		</Step>
@@ -105,7 +102,7 @@ export const ChecklistSiteIconTour = makeTour(
 			<Continue target="image-editor-button-done" step="finish" click>
 				{ translate(
 					'Let’s make sure it looks right before you press {{doneButton/}} to save your changes.',
-					{ components: { doneButton: <strong>{ DONE_BUTTON_LABEL }</strong> } }
+					{ components: { doneButton: <DoneButton /> } }
 				) }
 			</Continue>
 		</Step>

--- a/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
@@ -21,9 +21,7 @@ import {
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
-
-const SITE_TAG_LINE_BUTTON_LABEL = translate( 'Site Tagline' );
-const SAVE_SETTINGS_BUTTON_LABEL = translate( 'Save Settings' );
+import { SiteTaglineButton, SaveSettingsButton } from '../button-labels';
 
 export const ChecklistSiteTaglineTour = makeTour(
 	<Tour name="checklistSiteTagline" version="20171205" path="/non-existent-route" when={ noop }>
@@ -41,7 +39,7 @@ export const ChecklistSiteTaglineTour = makeTour(
 					'First impressions last - a tagline tells visitors what your site is all about without ' +
 						'having to read all your content. Enter a short descriptive phrase about your site into ' +
 						'the {{siteTaglineButton/}} field.',
-					{ components: { siteTaglineButton: <strong>{ SITE_TAG_LINE_BUTTON_LABEL }</strong> } }
+					{ components: { siteTaglineButton: <SiteTaglineButton /> } }
 				) }
 			</p>
 			<ButtonRow>
@@ -55,7 +53,7 @@ export const ChecklistSiteTaglineTour = makeTour(
 			<Continue target="settings-site-profile-save" step="finish" click>
 				{ translate(
 					'Almost done — press {{saveSettingsButton/}} to save your changes and then see what’s next on our list.',
-					{ components: { saveSettingsButton: <strong>{ SAVE_SETTINGS_BUTTON_LABEL }</strong> } }
+					{ components: { saveSettingsButton: <SaveSettingsButton /> } }
 				) }
 			</Continue>
 		</Step>

--- a/client/layout/guided-tours/tours/checklist-site-title-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour.js
@@ -21,8 +21,7 @@ import {
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
-
-const SITE_TITLE_BUTTON_LABEL = translate( 'Site Title' );
+import { SiteTitleButton } from '../button-labels';
 
 export const ChecklistSiteTitleTour = makeTour(
 	<Tour name="checklistSiteTitle" version="20171205" path="/non-existent-route" when={ noop }>
@@ -39,7 +38,7 @@ export const ChecklistSiteTitleTour = makeTour(
 				{ translate(
 					'Update the {{siteTitleButton/}} field with a descriptive name to let your visitors know which site they’re visiting.',
 					{
-						components: { siteTitleButton: <strong>{ SITE_TITLE_BUTTON_LABEL }</strong> },
+						components: { siteTitleButton: <SiteTitleButton /> },
 					}
 				) }
 			</p>

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -24,8 +24,7 @@ import {
 import { isNewUser } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
 import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
-
-const PUBLISH_BUTTON_LABEL = translate( 'Publish' );
+import { PublishButton } from '../button-labels';
 
 export const EditorBasicsTour = makeTour(
 	<Tour
@@ -122,7 +121,7 @@ export const EditorBasicsTour = makeTour(
 						'Click {{publishButton/}} to share your work with the world!',
 					{
 						components: {
-							publishButton: <strong>{ PUBLISH_BUTTON_LABEL }</strong>,
+							publishButton: <PublishButton />,
 						},
 					}
 				) }

--- a/client/layout/guided-tours/tours/editor-insert-menu-tour.js
+++ b/client/layout/guided-tours/tours/editor-insert-menu-tour.js
@@ -16,6 +16,7 @@ import { ButtonRow, makeTour, Step, Tour, Quit } from 'layout/guided-tours/confi
 import { hasUserRegisteredBefore } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
 import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
+import { AddMediaButton } from '../button-labels';
 
 class RepositioningStep extends Step {
 	componentDidMount() {
@@ -30,8 +31,6 @@ class RepositioningStep extends Step {
 		clearInterval( this.interval );
 	}
 }
-
-const ADD_MEDIA_BUTTON_LABEL = translate( 'Add Media' );
 
 export const EditorInsertMenuTour = makeTour(
 	<Tour
@@ -57,7 +56,7 @@ export const EditorInsertMenuTour = makeTour(
 		>
 			<p>
 				{ translate( '{{addMediaButton/}} has moved to a new button.', {
-					components: { addMediaButton: <strong>{ ADD_MEDIA_BUTTON_LABEL }</strong> },
+					components: { addMediaButton: <AddMediaButton /> },
 				} ) }
 			</p>
 			<p>

--- a/client/layout/guided-tours/tours/main-tour.js
+++ b/client/layout/guided-tours/tours/main-tour.js
@@ -29,9 +29,9 @@ import {
 } from 'state/ui/guided-tours/contexts';
 import { getScrollableSidebar } from 'layout/guided-tours/positioning';
 import scrollTo from 'lib/scroll-to';
+import { ViewSiteButton } from '../button-labels';
 
 const scrollSidebarToTop = () => scrollTo( { y: 0, container: getScrollableSidebar() } );
-const VIEW_SITE_BUTTON_LABEL = translate( 'View Site' );
 
 // note that this tour checks for a non-existent feature flag.
 // this is kept as an example, while making sure it never gets triggered
@@ -99,7 +99,7 @@ export const MainTour = makeTour(
 			<Continue click step="view-site" target="sitePreview">
 				{ translate( 'Click {{viewSiteButton/}} to continue.', {
 					components: {
-						viewSiteButton: <strong>{ VIEW_SITE_BUTTON_LABEL }</strong>,
+						viewSiteButton: <ViewSiteButton />,
 					},
 				} ) }
 			</Continue>

--- a/client/layout/guided-tours/tours/media-basics-tour.js
+++ b/client/layout/guided-tours/tours/media-basics-tour.js
@@ -7,7 +7,6 @@
 import React from 'react';
 import { translate } from 'i18n-calypso';
 import { overEvery as and } from 'lodash';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -23,11 +22,7 @@ import {
 } from 'layout/guided-tours/config-elements';
 import { doesSelectedSiteHaveMediaFiles, isNewUser } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
-
-const ADD_NEW_BUTTON_LABEL = translate( 'Add New' );
-const EDIT_BUTTON_LABEL = translate( 'Edit' );
-const EDIT_IMAGE_BUTTON_LABEL = translate( 'Edit Image' );
-const DONE_BUTTON_LABEL = translate( 'Done' );
+import { AddNewButton, EditButton, EditImageButton, DoneButton } from '../button-labels';
 
 export const MediaBasicsTour = makeTour(
 	<Tour
@@ -41,11 +36,10 @@ export const MediaBasicsTour = makeTour(
 			<p>
 				{ translate(
 					'Upload media — photos, documents, audio files, and more — ' +
-						'by clicking the {{icon/}} {{addNewButton/}} button.',
+						'by clicking the {{addNewButton/}} button.',
 					{
 						components: {
-							icon: <Gridicon icon="add-image" />,
-							addNewButton: <strong>{ ADD_NEW_BUTTON_LABEL }</strong>,
+							addNewButton: <AddNewButton />,
 						},
 					}
 				) }
@@ -106,7 +100,7 @@ export const MediaBasicsTour = makeTour(
 			<Continue click step="launch-modal" target=".editor-media-modal__secondary-action">
 				{ translate( 'Now click the {{editButton/}} button.', {
 					components: {
-						editButton: <strong>{ EDIT_BUTTON_LABEL }</strong>,
+						editButton: <EditButton />,
 					},
 				} ) }
 			</Continue>
@@ -127,11 +121,10 @@ export const MediaBasicsTour = makeTour(
 		<Step name="done" placement="center">
 			<p>
 				{ translate(
-					'Need to adjust your image? Click {{icon/}} {{editImageButton/}} to perform basic tweaks.',
+					'Need to adjust your image? Click {{editImageButton/}} to perform basic tweaks.',
 					{
 						components: {
-							icon: <Gridicon icon="pencil" />,
-							editImageButton: <strong>{ EDIT_IMAGE_BUTTON_LABEL }</strong>,
+							editImageButton: <EditImageButton />,
 						},
 					}
 				) }
@@ -139,7 +132,7 @@ export const MediaBasicsTour = makeTour(
 			<p>
 				{ translate( 'Click {{doneButton /}} to go back to your full library. Happy uploading!', {
 					components: {
-						doneButton: <strong>{ DONE_BUTTON_LABEL }</strong>,
+						doneButton: <DoneButton />,
 					},
 				} ) }
 			</p>

--- a/client/layout/guided-tours/tours/site-title-tour.js
+++ b/client/layout/guided-tours/tours/site-title-tour.js
@@ -7,7 +7,6 @@
 import React from 'react';
 import { translate } from 'i18n-calypso';
 import { overEvery as and } from 'lodash';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -30,14 +29,9 @@ import {
 	isAbTestInVariant,
 } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
+import { SettingsButton } from '../button-labels';
 
 const TWO_DAYS_IN_MILLISECONDS = 2 * 1000 * 3600 * 24;
-
-const SETTINGS_BUTTON_LABEL = translate( '{{icon/}} Settings', {
-	components: {
-		icon: <Gridicon icon="cog" />,
-	},
-} );
 
 export const SiteTitleTour = makeTour(
 	<Tour
@@ -81,7 +75,7 @@ export const SiteTitleTour = makeTour(
 			<Continue target="settings" step="site-title-input" click>
 				{ translate( 'Click {{settingsButton/}} to continue.', {
 					components: {
-						settingsButton: <strong>{ SETTINGS_BUTTON_LABEL }</strong>,
+						settingsButton: <SettingsButton />,
 					},
 				} ) }
 			</Continue>

--- a/client/layout/guided-tours/tours/theme-sheet-welcome-tour.js
+++ b/client/layout/guided-tours/tours/theme-sheet-welcome-tour.js
@@ -24,8 +24,7 @@ import {
 import { isAbTestInVariant, isEnabled, isNewUser } from 'state/ui/guided-tours/contexts';
 import { isPreviewShowing } from 'state/ui/selectors';
 import { isDesktop } from 'lib/viewport';
-
-const ALL_THEMES_BUTTON_LABEL = translate( 'All Themes' );
+import { AllThemesButton } from '../button-labels';
 
 export const ThemeSheetWelcomeTour = makeTour(
 	<Tour
@@ -132,7 +131,7 @@ export const ThemeSheetWelcomeTour = makeTour(
 					"That's it! " +
 						'You can click on {{allThemesButton/}} at any time to return to our design showcase.',
 					{
-						components: { allThemesButton: <strong>{ ALL_THEMES_BUTTON_LABEL }</strong> },
+						components: { allThemesButton: <AllThemesButton /> },
 					}
 				) }
 			</p>

--- a/client/layout/guided-tours/tours/tutorial-site-preview-tour.js
+++ b/client/layout/guided-tours/tours/tutorial-site-preview-tour.js
@@ -20,8 +20,7 @@ import {
 	Continue,
 } from 'layout/guided-tours/config-elements';
 import { isNewUser, isEnabled, isSelectedSitePreviewable } from 'state/ui/guided-tours/contexts';
-
-const VIEW_SITE_BUTTON_LABEL = translate( 'View Site' );
+import { ViewSiteButton } from '../button-labels';
 
 export const TutorialSitePreviewTour = makeTour(
 	<Tour
@@ -46,7 +45,7 @@ export const TutorialSitePreviewTour = makeTour(
 					'{{viewSiteButton/}} shows you what your site looks like to visitors. Click it to continue.',
 					{
 						components: {
-							viewSiteButton: <strong>{ VIEW_SITE_BUTTON_LABEL }</strong>,
+							viewSiteButton: <ViewSiteButton />,
 						},
 					}
 				) }


### PR DESCRIPTION
Solves issues raised in https://github.com/Automattic/wp-calypso/pull/20989#discussion_r174123123

Avoids static strings translations at module top level: achieves better initial load performance and makes the strings actually localized (due to async loading of translation files).

Also improves how icons are added to the button labels: no more `{{icon/}}` markup in translated strings, the icon is now part of the label React component.

I worked on this because it blocks further progress of #22862.

@akirk A few messages changed from `"{{icon/} Settings"` to `"Settings"` or from `"press the {{icon/}} {{editButton/}}"` to `"press the {{editButton/}"`. Should this PR have a "String Freeze" label then?

**How to test:**
Run a guided tour by going, for example, to `/media/your.blog?tour=mediaBasicsTour`. When going through the tour, verify that references to buttons (Add New, Edit, Edit Image) are displayed correctly and have the same icons as the referenced UI buttons.