### PR TITLE
JPC: adjust UX to reflect data fetching action in Jetpack Remote Install.

### DIFF
--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -58,9 +58,12 @@ export class OrgCredentialsForm extends Component {
 	};
 
 	componentWillMount() {
-		if ( config.isEnabled( 'jetpack/connect/remote-install' ) ) {
-			const { siteToConnect } = this.props;
+		const { isResponseCompleted, siteToConnect } = this.props;
+		if ( isResponseCompleted ) {
+			this.setState( { isSubmitting: false } );
+		}
 
+		if ( config.isEnabled( 'jetpack/connect/remote-install' ) ) {
 			if ( ! siteToConnect ) {
 				page.redirect( '/jetpack/connect' );
 			}
@@ -148,9 +151,14 @@ export class OrgCredentialsForm extends Component {
 		const { isSubmitting } = this.state;
 		const isFetching = ! installError && ! isResponseCompleted && isSubmitting && siteToConnect;
 
+		if ( isResponseCompleted ) {
+			return translate( 'Jetpack installed' );
+		}
+
 		if ( ! isFetching ) {
 			return translate( 'Install Jetpack' );
 		}
+
 		return translate( 'Installing…' );
 	}
 

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -22,6 +22,7 @@ import HelpButton from './help-button';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import MainWrapper from './main-wrapper';
+import Spinner from 'components/spinner';
 import { addCalypsoEnvQueryArg } from './utils';
 import { externalRedirect } from 'lib/route';
 import { jetpackRemoteInstall } from 'state/jetpack-remote-install/actions';
@@ -40,7 +41,7 @@ export class OrgCredentialsForm extends Component {
 		return {
 			username: '',
 			password: '',
-			submitting: false,
+			isSubmitting: false,
 		};
 	}
 
@@ -48,10 +49,10 @@ export class OrgCredentialsForm extends Component {
 		const { siteToConnect } = this.props;
 		event.preventDefault();
 
-		if ( this.state.submitting ) {
+		if ( this.state.isSubmitting ) {
 			return;
 		}
-		this.setState( { submitting: true } );
+		this.setState( { isSubmitting: true } );
 
 		this.props.jetpackRemoteInstall( siteToConnect, this.state.username, this.state.password );
 	};
@@ -102,36 +103,41 @@ export class OrgCredentialsForm extends Component {
 	}
 
 	formFields() {
+		const { installError, isResponseCompleted, siteToConnect, translate } = this.props;
+		const { isSubmitting, password, username } = this.state;
+		const isFetching = ! installError && ! isResponseCompleted && isSubmitting && siteToConnect;
+
 		return (
 			<div>
-				<FormLabel htmlFor="username">{ this.props.translate( 'Username' ) }</FormLabel>
+				<FormLabel htmlFor="username">{ translate( 'Username' ) }</FormLabel>
 				<div className="jetpack-connect__site-address-container">
 					<Gridicon size={ 24 } icon="user" />
 					<FormTextInput
 						autoCapitalize="off"
 						autoCorrect="off"
 						className="jetpack-connect__credentials-form-input"
-						disabled={ this.state.submitting }
+						disabled={ isSubmitting }
 						id="username"
 						name="username"
 						onChange={ this.getChangeHandler( 'username' ) }
-						value={ this.state.username || '' }
+						value={ username || '' }
 					/>
 				</div>
 
 				<div className="jetpack-connect__password-container">
-					<FormLabel htmlFor="password">{ this.props.translate( 'Password' ) }</FormLabel>
+					<FormLabel htmlFor="password">{ translate( 'Password' ) }</FormLabel>
 					<div className="jetpack-connect__password-form">
 						<Gridicon size={ 24 } icon="lock" />
 						<FormPasswordInput
 							className="jetpack-connect__password-form-input"
-							disabled={ this.state.submitting }
+							disabled={ isSubmitting }
 							id="password"
 							name="password"
 							onChange={ this.getChangeHandler( 'password' ) }
-							value={ this.state.password || '' }
+							value={ password || '' }
 						/>
 					</div>
+					{ isFetching ? <Spinner /> : null }
 				</div>
 			</div>
 		);

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -34,7 +34,7 @@ export class OrgCredentialsForm extends Component {
 	state = {
 		username: '',
 		password: '',
-		submitting: false,
+		isSubmitting: false,
 	};
 
 	getInitialFields() {
@@ -143,14 +143,24 @@ export class OrgCredentialsForm extends Component {
 		);
 	}
 
+	renderButtonLabel() {
+		const { installError, isResponseCompleted, siteToConnect, translate } = this.props;
+		const { isSubmitting } = this.state;
+		const isFetching = ! installError && ! isResponseCompleted && isSubmitting && siteToConnect;
+
+		if ( ! isFetching ) {
+			return translate( 'Install Jetpack' );
+		}
+		return translate( 'Installing…' );
+	}
+
 	formFooter() {
-		const { translate } = this.props;
 		return (
 			<FormButton
 				className="jetpack-connect__credentials-submit"
 				disabled={ ! this.state.username || ! this.state.password }
 			>
-				{ translate( 'Install Jetpack' ) }
+				{ this.renderButtonLabel() }
 			</FormButton>
 		);
 	}

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -57,11 +57,16 @@ export class OrgCredentialsForm extends Component {
 		this.props.jetpackRemoteInstall( siteToConnect, this.state.username, this.state.password );
 	};
 
-	componentWillMount() {
-		const { isResponseCompleted, siteToConnect } = this.props;
-		if ( isResponseCompleted ) {
+	componentWillReceiveProps() {
+		const { installError } = this.props;
+
+		if ( installError ) {
 			this.setState( { isSubmitting: false } );
 		}
+	}
+
+	componentWillMount() {
+		const { siteToConnect } = this.props;
 
 		if ( config.isEnabled( 'jetpack/connect/remote-install' ) ) {
 			if ( ! siteToConnect ) {
@@ -106,9 +111,8 @@ export class OrgCredentialsForm extends Component {
 	}
 
 	formFields() {
-		const { installError, isResponseCompleted, siteToConnect, translate } = this.props;
+		const { translate } = this.props;
 		const { isSubmitting, password, username } = this.state;
-		const isFetching = ! installError && ! isResponseCompleted && isSubmitting && siteToConnect;
 
 		return (
 			<div>
@@ -140,22 +144,21 @@ export class OrgCredentialsForm extends Component {
 							value={ password || '' }
 						/>
 					</div>
-					{ isFetching ? <Spinner /> : null }
+					{ isSubmitting ? <Spinner /> : null }
 				</div>
 			</div>
 		);
 	}
 
 	renderButtonLabel() {
-		const { installError, isResponseCompleted, siteToConnect, translate } = this.props;
+		const { isResponseCompleted, translate } = this.props;
 		const { isSubmitting } = this.state;
-		const isFetching = ! installError && ! isResponseCompleted && isSubmitting && siteToConnect;
 
 		if ( isResponseCompleted ) {
 			return translate( 'Jetpack installed' );
 		}
 
-		if ( ! isFetching ) {
+		if ( ! isSubmitting ) {
 			return translate( 'Install Jetpack' );
 		}
 
@@ -163,10 +166,12 @@ export class OrgCredentialsForm extends Component {
 	}
 
 	formFooter() {
+		const { isSubmitting } = this.state;
+
 		return (
 			<FormButton
 				className="jetpack-connect__credentials-submit"
-				disabled={ ! this.state.username || ! this.state.password }
+				disabled={ ! this.state.username || ! this.state.password || isSubmitting }
 			>
 				{ this.renderButtonLabel() }
 			</FormButton>


### PR DESCRIPTION
Part of improved UX for remote install credentials submit: display Spinner when submitting site credentials and adjust submit Button label. Upon completion and before redirect to plans page, we update Button label again to reflect the status.

**To test:**
- Checkout this branch on local Calypso,
- Access `calypso.localhost:3000/jetpack/connect`
- Input site url
- Input credentials when redirected to  `calypso.localhost:3000/jetpack/connect/install`
- Verify that the Spinner and Button shows upon loading, and the latter updates label upon completion.

date fetching status:

![screen shot 2018-03-14 at 20 48 56](https://user-images.githubusercontent.com/13561163/37429973-ce70e948-27c8-11e8-8340-b8171aa4f407.png)

on complete ( before redirect to the plans page):

![screen shot 2018-03-14 at 14 37 44](https://user-images.githubusercontent.com/13561163/37409531-77a42f62-2796-11e8-9ce2-0ac75415c47d.png)

