### PR TITLE
Reader: follow by url placeholder should not live forever

### DIFF
--- a/client/components/reader-infinite-stream/index.js
+++ b/client/components/reader-infinite-stream/index.js
@@ -30,7 +30,6 @@ class ReaderInfiniteStream extends Component {
 		windowScrollerRef: PropTypes.func,
 		extraRenderItemProps: PropTypes.object,
 		minHeight: PropTypes.number,
-		passthroughProp: PropTypes.any, // https://github.com/bvaughn/react-virtualized#pure-components. For use with things like sort etc.
 	};
 
 	static defaultProps = {
@@ -120,7 +119,7 @@ class ReaderInfiniteStream extends Component {
 	}
 
 	render() {
-		const { hasNextPage, width, passthroughProp } = this.props;
+		const { hasNextPage, width } = this.props;
 		const rowCount = hasNextPage( this.props.items.length )
 			? this.props.items.length + 10
 			: this.props.items.length;
@@ -144,7 +143,7 @@ class ReaderInfiniteStream extends Component {
 								ref={ this.handleListMounted( registerChild ) }
 								scrollTop={ scrollTop }
 								width={ width }
-								passthroughProp={ passthroughProp }
+								items={ this.props.items } // passthrough-prop unused by the component except to signal a rerender
 							/>
 						) }
 					</WindowScroller>

--- a/client/lib/reader-connect-site/index.js
+++ b/client/lib/reader-connect-site/index.js
@@ -11,11 +11,10 @@ import { connect } from 'react-redux';
 /*
  * Internal Dependencies
  */
-import { getSite, getSiteByFeedUrl } from 'state/reader/sites/selectors';
-import { getFeed, getFeedByFeedUrl } from 'state/reader/feeds/selectors';
+import { getSite } from 'state/reader/sites/selectors';
+import { getFeed } from 'state/reader/feeds/selectors';
 import QueryReaderSite from 'components/data/query-reader-site';
 import QueryReaderFeed from 'components/data/query-reader-feed';
-import { getReaderAliasedFollowFeedUrl } from 'state/selectors';
 
 /**
  * A HoC function that will take in reader identifiers siteId or feedId and
@@ -33,7 +32,6 @@ const connectSite = Component => {
 		static propTypes = {
 			feed: PropTypes.object,
 			site: PropTypes.object,
-			url: PropTypes.string,
 		};
 
 		render() {
@@ -61,15 +59,12 @@ const connectSite = Component => {
 			feed = !! feedId ? getFeed( state, site.feed_ID ) : undefined;
 		}
 
-		// as a last effort check if we have the site/feed by url
-		if ( ! feed && ownProps.url ) {
-			feed = getFeedByFeedUrl( state, getReaderAliasedFollowFeedUrl( state, ownProps.url ) );
-		}
-		if ( ! site && ownProps.url ) {
-			site = getSiteByFeedUrl( state, getReaderAliasedFollowFeedUrl( state, ownProps.url ) );
-		}
-
-		return { feed, site, siteId, feedId };
+		return {
+			feed,
+			site,
+			siteId,
+			feedId,
+		};
 	} )( connectSiteFetcher );
 };
 

--- a/client/lib/reader-connect-site/index.js
+++ b/client/lib/reader-connect-site/index.js
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
 /*
  * Internal Dependencies
  */
-import { getSite } from 'state/reader/sites/selectors';
+import { getSite, getSiteByFeedUrl } from 'state/reader/sites/selectors';
 import { getFeed, getFeedByFeedUrl } from 'state/reader/feeds/selectors';
 import QueryReaderSite from 'components/data/query-reader-site';
 import QueryReaderFeed from 'components/data/query-reader-feed';
@@ -60,9 +60,13 @@ const connectSite = Component => {
 			feedId = site.feed_ID;
 			feed = !! feedId ? getFeed( state, site.feed_ID ) : undefined;
 		}
-		// check if we have a url that is a known alias
+
+		// as a last effort check if we have the site/feed by url
 		if ( ! feed && ownProps.url ) {
 			feed = getFeedByFeedUrl( state, getReaderAliasedFollowFeedUrl( state, ownProps.url ) );
+		}
+		if ( ! site && ownProps.url ) {
+			site = getSiteByFeedUrl( state, getReaderAliasedFollowFeedUrl( state, ownProps.url ) );
 		}
 
 		return { feed, site, siteId, feedId };

--- a/client/lib/reader-connect-site/index.js
+++ b/client/lib/reader-connect-site/index.js
@@ -12,9 +12,10 @@ import { connect } from 'react-redux';
  * Internal Dependencies
  */
 import { getSite } from 'state/reader/sites/selectors';
-import { getFeed } from 'state/reader/feeds/selectors';
+import { getFeed, getFeedByFeedUrl } from 'state/reader/feeds/selectors';
 import QueryReaderSite from 'components/data/query-reader-site';
 import QueryReaderFeed from 'components/data/query-reader-feed';
+import { getReaderAliasedFollowFeedUrl } from 'state/selectors';
 
 /**
  * A HoC function that will take in reader identifiers siteId or feedId and
@@ -32,6 +33,7 @@ const connectSite = Component => {
 		static propTypes = {
 			feed: PropTypes.object,
 			site: PropTypes.object,
+			url: PropTypes.string,
 		};
 
 		render() {
@@ -58,13 +60,12 @@ const connectSite = Component => {
 			feedId = site.feed_ID;
 			feed = !! feedId ? getFeed( state, site.feed_ID ) : undefined;
 		}
+		// check if we have a url that is a known alias
+		if ( ! feed && ownProps.url ) {
+			feed = getFeedByFeedUrl( state, getReaderAliasedFollowFeedUrl( state, ownProps.url ) );
+		}
 
-		return {
-			feed,
-			site,
-			siteId,
-			feedId,
-		};
+		return { feed, site, siteId, feedId };
 	} )( connectSiteFetcher );
 };
 

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -136,7 +136,6 @@ class FollowingManageSubscriptions extends Component {
 								followSource: READER_SUBSCRIPTIONS,
 							} }
 							width={ width }
-							passthroughProp={ sortOrder }
 							totalCount={ sortedFollows.length }
 							windowScrollerRef={ this.props.windowScrollerRef }
 							rowRenderer={ siteRowRenderer }

--- a/client/reader/search-stream/site-results.jsx
+++ b/client/reader/search-stream/site-results.jsx
@@ -54,7 +54,6 @@ class SiteResults extends React.Component {
 					fetchNextPage={ this.fetchNextPage }
 					hasNextPage={ this.hasNextPage }
 					rowRenderer={ siteRowRenderer }
-					passthroughProp={ this.props.sort }
 					extraRenderItemProps={ { showLastUpdatedDate, followSource: SEARCH_RESULTS_SITES } }
 				/>
 			</div>


### PR DESCRIPTION
fixes https://github.com/Automattic/wp-calypso/issues/17316

~~teaches `connectSite` to look at aliased feed urls instead of just the handed feedId.  This is particularly important for cases where the `state.follows.items` only has the url and doesn't actually have any more info because it was just followed.~~

Edit: upgrading connectSite only fixed the case of following feeds.  A better fix I found was to make sure `reader-infinite-stream` re-renders at the right times.  This PR teaches it to pass its items directly to react-virtualized just as a signal for when to rerender (`List` doesn't actually use it).  Had been using strange mechanisms before like an explicit `passthroughProp` but since `items` should referentially change any time we want to update the ui, then items should be good enough.
See the react-virtualized docs on [pure components](https://github.com/bvaughn/react-virtualized#pure-components)