### PR TITLE
Notifications: fixes the EDIT_COMMENT target address.

### DIFF
--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -221,7 +221,7 @@ export class Notifications extends Component {
 						post_id: postId,
 						comment_id: commentId,
 					} );
-					page( `/comments/${ siteId }/${ commentId }?action=edit` );
+					page( `/comment/${ siteId }/${ commentId }?action=edit` );
 				},
 			],
 		};


### PR DESCRIPTION
Corrects the address on the notifications middleware for the edit action.

#23278 depends on this. Follow up of https://github.com/Automattic/wp-calypso/pull/22049.