### PR TITLE
Reader: Add Simple Focus Mode to Full Post Reader

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -8,6 +8,7 @@ import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
 import classNames from 'classnames';
+import Gridicon from 'gridicons';
 import { get, startsWith } from 'lodash';
 
 /**
@@ -74,6 +75,10 @@ export class FullPostView extends React.Component {
 		referralStream: PropTypes.string,
 	};
 
+	state = {
+		showFocusMode: false,
+	};
+
 	hasScrolledToCommentAnchor = false;
 
 	componentDidMount() {
@@ -136,6 +141,15 @@ export class FullPostView extends React.Component {
 		recordTrackForPost( 'calypso_reader_article_closed', this.props.post );
 
 		this.props.onClose && this.props.onClose();
+	};
+
+	handleResizeClick = () => this.setState( { showFocusMode: ! this.state.showFocusMode } );
+
+	handleResizeKeyPress = event => {
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			event.preventDefault();
+			this.setState( { showFocusMode: ! this.state.showFocusMode } );
+		}
 	};
 
 	handleCommentClick = () => {
@@ -289,7 +303,7 @@ export class FullPostView extends React.Component {
 		}
 
 		const siteName = getSiteName( { site, post } );
-		const classes = { 'reader-full-post': true };
+		const classes = { 'reader-full-post': true, 'is-focus-mode': this.state.showFocusMode };
 		const showRelatedPosts = post && ! post.is_external && post.site_ID;
 		const relatedPostsFromOtherSitesTitle = translate(
 			'More on {{wpLink}}WordPress.com{{/wpLink}}',
@@ -377,6 +391,17 @@ export class FullPostView extends React.Component {
 									fullPost={ true }
 									tagName="div"
 								/>
+							) }
+							{ ! isLoading && (
+								<div
+									className="reader-full-post__resize-button"
+									onClick={ this.handleResizeClick }
+									onKeyPress={ this.handleResizeKeyPress }
+									role="button"
+									tabIndex="0"
+								>
+									<Gridicon icon={ this.state.showFocusMode ? 'user' : 'resize' } />
+								</div>
 							) }
 						</div>
 					</div>

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -587,3 +587,76 @@
 	margin-bottom: 16px;
 	min-height: 200px;
 }
+
+.reader-full-post .reader-full-post__resize-button {
+	display: none;
+	color: $gray;
+	cursor: pointer;
+	margin-left: 18px;
+
+	&:hover,
+	&:focus,
+	&:active {
+		color: $blue-medium;
+	}
+
+	@include breakpoint( ">660px" ) {
+		display: inline-flex;
+	}
+}
+
+// Distraction free reading mode
+
+.reader-full-post.is-focus-mode {
+
+	.reader-full-post__content {
+		@include breakpoint( ">660px" ) {
+			padding-left: 0;
+		}
+	}
+
+	.reader-full-post__story {
+		@include breakpoint( ">660px" ) {
+			margin: 0 auto;
+		}
+	}
+
+	.reader-full-post__sidebar {
+		@include breakpoint( ">660px" ) {
+			left: 20px;
+			width: 80px;
+		}
+	}
+
+	.reader-full-post__sidebar-comment-like {
+		@include breakpoint( ">660px" ) {
+			display: flex;
+			flex-direction: column;
+		}
+	}
+
+	.reader-full-post__sidebar-comment-like > div {
+		@include breakpoint( ">660px" ) {
+			margin-bottom: 5px;
+		}
+	}
+
+	.reader-full-post__sidebar-comment-like .comment-button {
+		@include breakpoint( ">660px" ) {
+			padding: 0;
+		}
+	}
+
+	.reader-full-post__resize-button {
+		@include breakpoint( ">660px" ) {
+			margin-left: 0;
+		}
+	}
+
+	.author-compact-profile {
+		@include breakpoint( ">660px" ) {
+			display: none;
+		}
+	}
+}
+


### PR DESCRIPTION
## This PR

- suggests a small step towards a more distraction-free reading experience
- is meant as a prototype to get design feedback
- is an alternate version of PR #23372

## Thoughts behind this suggested change

Currently, the default full post view in the reader puts a lot of emphasis on the author and displays the article off center. This results in an unpleasant reading experience, especially on longer posts.

A potential solution, as suggested in this PR, could be to offer the user an option to switch to a simple focus mode that removes unnecessary distractions and puts the focus on the content.

In order to not hide the author completely, the default view would always be the current full post view.

## How to test
- Visit the calypso.live link below
- Navigate to a post in the reader
- Toggle the sidebar via the resize button


## Screenshots

<img width="1207" alt="screen shot 2018-03-13 at 22 25 26" src="https://user-images.githubusercontent.com/1562646/37381855-84e5d740-270d-11e8-8f05-7f468a0e3f8b.png">

<img width="1204" alt="screen shot 2018-03-13 at 22 24 46" src="https://user-images.githubusercontent.com/1562646/37381857-87d1204a-270d-11e8-9847-f38065732c7b.png">
