### PR TITLE
Enable Serbian (latin) in Calypso

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -153,7 +153,7 @@
         { "value": 459, "langSlug": "so", "name": "Afsoomaali", "wpLocale": "so_SO", "territories": [ "002" ] },
         { "value": 66, "langSlug": "sq", "name": "Shqip", "wpLocale": "sq", "territories": [ "039" ] },
         { "value": 67, "langSlug": "sr", "name": "Српски језик", "wpLocale": "sr_RS", "territories": [ "039" ] },
-        { "value": 67, "langSlug": "sr_latin", "name": "Srpski (latinica)", "wpLocale": "sr_RS", "territories": [ "039" ] },
+        { "value": 67, "langSlug": "sr_latin", "name": "Srpski (latinica)", "wpLocale": "sr_RS", "parentLangSlug": "sr", "territories": [ "039" ] },
         { "value": 441, "langSlug": "su", "name": "Basa Sunda", "wpLocale": "su_ID", "territories": [ "035" ] },
         { "value": 68, "langSlug": "sv", "name": "Svenska", "wpLocale": "sv_SE", "popular": 17, "territories": [ "154" ] },
         { "value": 69, "langSlug": "ta", "name": "தமிழ்", "wpLocale": "ta_IN", "territories": [ "034", "035" ] },

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -153,6 +153,7 @@
         { "value": 459, "langSlug": "so", "name": "Afsoomaali", "wpLocale": "so_SO", "territories": [ "002" ] },
         { "value": 66, "langSlug": "sq", "name": "Shqip", "wpLocale": "sq", "territories": [ "039" ] },
         { "value": 67, "langSlug": "sr", "name": "Српски језик", "wpLocale": "sr_RS", "territories": [ "039" ] },
+        { "value": 67, "langSlug": "sr_latin", "name": "Srpski (latinica)", "wpLocale": "sr_RS", "territories": [ "039" ] },
         { "value": 441, "langSlug": "su", "name": "Basa Sunda", "wpLocale": "su_ID", "territories": [ "035" ] },
         { "value": 68, "langSlug": "sv", "name": "Svenska", "wpLocale": "sv_SE", "popular": 17, "territories": [ "154" ] },
         { "value": 69, "langSlug": "ta", "name": "தமிழ்", "wpLocale": "ta_IN", "territories": [ "034", "035" ] },


### PR DESCRIPTION
With the recent work on language variants, we can now serve the Serbian latin-transliterated language files in Calypso. 

It's ready for review. One known issue: translations in the community translator will be submitted for 'sr', which is problematic. We should either transliterate back on submission, or disable the translator.

Fixes #6734

**Testing:**
- Set your locale to `sr_latin: Srpski (latinica)`
- Check that the browser loads the `sr_latin.json` language files, and that the strings that are translated are indeed in Latin script rather than Cyrillic (compare with plain `sr: Српски језик` do be sure).