### PR TITLE
Jetpack Onboarding: Auto-select the connected site

### DIFF
--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -33,11 +33,13 @@ import {
 	getUnconnectedSiteUserHash,
 	getUnconnectedSiteIdBySlug,
 } from 'state/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, isRequestingSite, isRequestingSites } from 'state/sites/selectors';
 import {
 	requestJetpackOnboardingSettings,
 	saveJetpackOnboardingSettings,
 } from 'state/jetpack-onboarding/actions';
+import { setSelectedSiteId } from 'state/ui/actions';
 
 class JetpackOnboardingMain extends React.PureComponent {
 	static propTypes = {
@@ -52,10 +54,12 @@ class JetpackOnboardingMain extends React.PureComponent {
 
 	componentDidMount() {
 		this.retrieveOnboardingCredentials();
+		this.setSelectedSite();
 	}
 
 	componentDidUpdate() {
 		this.retrieveOnboardingCredentials();
+		this.setSelectedSite();
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -81,6 +85,20 @@ class JetpackOnboardingMain extends React.PureComponent {
 				`//${ siteDomain }/wp-admin/admin.php`
 			);
 			externalRedirect( url );
+		}
+	}
+
+	setSelectedSite() {
+		const { hasFinishedRequestingSite } = this.state;
+		const { isConnected, selectedSiteId, siteId } = this.props;
+
+		if ( ! hasFinishedRequestingSite ) {
+			return;
+		}
+
+		if ( isConnected && selectedSiteId !== siteId ) {
+			// If the site we're onboarding is connected and not selected, select it
+			this.props.setSelectedSiteId( siteId );
 		}
 	}
 
@@ -173,6 +191,7 @@ export default connect(
 		const isRequestingWhetherConnected =
 			isRequestingSite( state, siteId ) || isRequestingSites( state );
 		const isConnected = isJetpackSite( state, siteId );
+		const selectedSiteId = getSelectedSiteId( state );
 
 		let jpoAuth;
 
@@ -216,6 +235,7 @@ export default connect(
 			isConnected,
 			isRequestingSettings,
 			isRequestingWhetherConnected,
+			selectedSiteId,
 			siteId,
 			siteSlug,
 			settings,
@@ -224,12 +244,13 @@ export default connect(
 			userIdHashed,
 		};
 	},
-	{ recordTracksEvent, saveJetpackOnboardingSettings },
+	{ recordTracksEvent, saveJetpackOnboardingSettings, setSelectedSiteId },
 	(
 		{ siteId, jpoAuth, userIdHashed, ...stateProps },
 		{
 			recordTracksEvent: recordTracksEventAction,
 			saveJetpackOnboardingSettings: saveJetpackOnboardingSettingsAction,
+			...dispatchProps
 		},
 		ownProps
 	) => ( {
@@ -248,6 +269,7 @@ export default connect(
 			saveJetpackOnboardingSettingsAction( s, {
 				onboarding: { ...settings, ...get( jpoAuth, 'onboarding' ) },
 			} ),
+		...dispatchProps,
 		...ownProps,
 	} )
 )( localize( JetpackOnboardingMain ) );

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -90,13 +90,13 @@ class JetpackOnboardingMain extends React.PureComponent {
 
 	setSelectedSite() {
 		const { hasFinishedRequestingSite } = this.state;
-		const { isConnected, selectedSiteId, siteId } = this.props;
+		const { isConnected, isSiteSelected, siteId } = this.props;
 
 		if ( ! hasFinishedRequestingSite ) {
 			return;
 		}
 
-		if ( isConnected && selectedSiteId !== siteId ) {
+		if ( isConnected && isSiteSelected ) {
 			// If the site we're onboarding is connected and not selected, select it
 			this.props.setSelectedSiteId( siteId );
 		}
@@ -192,6 +192,7 @@ export default connect(
 			isRequestingSite( state, siteId ) || isRequestingSites( state );
 		const isConnected = isJetpackSite( state, siteId );
 		const selectedSiteId = getSelectedSiteId( state );
+		const isSiteSelected = selectedSiteId !== siteId;
 
 		let jpoAuth;
 
@@ -235,7 +236,7 @@ export default connect(
 			isConnected,
 			isRequestingSettings,
 			isRequestingWhetherConnected,
-			selectedSiteId,
+			isSiteSelected,
 			siteId,
 			siteSlug,
 			settings,

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -96,7 +96,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 			return;
 		}
 
-		if ( isConnected && isSiteSelected ) {
+		if ( isConnected && ! isSiteSelected ) {
 			// If the site we're onboarding is connected and not selected, select it
 			this.props.setSelectedSiteId( siteId );
 		}
@@ -192,7 +192,7 @@ export default connect(
 			isRequestingSite( state, siteId ) || isRequestingSites( state );
 		const isConnected = isJetpackSite( state, siteId );
 		const selectedSiteId = getSelectedSiteId( state );
-		const isSiteSelected = selectedSiteId !== siteId;
+		const isSiteSelected = selectedSiteId === siteId;
 
 		let jpoAuth;
 


### PR DESCRIPTION
This PR updates JPO to automatically select the current site that we're onboarding in the case when it is connected. This allows the user to continue working with the site in Calypso in case they wish to drop out of the onboarding flow.

A nice consequence from this is that it also takes care of #23218 - when we select the right site, customizer will work properly for it even without a refresh.

Fixes #23217.
Fixes #23218.

To test:
* Checkout this branch
* Start a new JN site with the latest Jetpack.
* Go through the onboarding flow by running `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development on that site`.
* Go ahead and skip to the Contact Form step.
* Click the button to add a form.
* Connect the site and have the form created, where you can see the success message.
* Verify `state.ui.selectedSiteId` returns the ID of the current site you are onboarding.
* Go back to the site title step and refresh.
* Verify `state.ui.selectedSiteId` still returns the ID of the current site you are onboarding.
* Click on My Sites and click through some menu items; verify everything works as expected.
* Click on "Customize" and verify you are presented with the remote site Customizer in a new window.