### PR TITLE
Plans: use 'Discount' instead of 'Credits' for Jetpack sites

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -111,8 +111,9 @@ class PlanFeaturesHeader extends Component {
 	getCreditLabel() {
 		const {
 			available,
-			showModifiedPricingDisplay,
 			discountPrice,
+			site,
+			showModifiedPricingDisplay,
 			rawPrice,
 			relatedMonthlyPlan,
 		} = this.props;
@@ -130,7 +131,11 @@ class PlanFeaturesHeader extends Component {
 		}
 
 		// Note: Don't make this translatable because it's only visible to English-language users
-		return <span className="plan-features__header-credit-label">Credit available</span>;
+		return (
+			<span className="plan-features__header-credit-label">
+				{ site.jetpack ? 'Discount available' : 'Credit available' }
+			</span>
+		);
 	}
 
 	getDiscountTooltipMessage() {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -56,7 +56,7 @@ import { abtest, getABTestVariation } from 'lib/abtest';
 
 class PlanFeatures extends Component {
 	render() {
-		const { planProperties, isInSignup, showModifiedPricingDisplay } = this.props;
+		const { planProperties, isInSignup, showModifiedPricingDisplay, site } = this.props;
 		const tableClasses = classNames(
 			'plan-features__table',
 			`has-${ planProperties.length }-cols`
@@ -79,7 +79,7 @@ class PlanFeatures extends Component {
 
 		return (
 			<div className={ planWrapperClasses } ref={ this.setScrollLeft }>
-				{ showModifiedPricingDisplay && this.renderCreditNotice() }
+				{ showModifiedPricingDisplay && ! site.jetpack && this.renderCreditNotice() }
 				<div className={ planClasses }>
 					{ this.renderUpgradeDisabledNotice() }
 					<div className="plan-features__content">

--- a/client/my-sites/plan-features/summary.jsx
+++ b/client/my-sites/plan-features/summary.jsx
@@ -25,6 +25,7 @@ class PlanFeaturesSummary extends Component {
 		site: PropTypes.object.isRequired,
 	};
 
+	// Note: Don't make this translatable because it's only visible to English-language users
 	getTitle() {
 		const { current, site } = this.props;
 		const isJetpackSite = !! site.jetpack;
@@ -82,6 +83,7 @@ class PlanFeaturesSummary extends Component {
 			return null;
 		}
 
+		// Note: Don't make this translatable because it's only visible to English-language users
 		return (
 			<div className="plan-features__summary">
 				<strong className="plan-features__summary-title">{ this.getTitle() }</strong>

--- a/client/my-sites/plan-features/summary.jsx
+++ b/client/my-sites/plan-features/summary.jsx
@@ -25,6 +25,21 @@ class PlanFeaturesSummary extends Component {
 		site: PropTypes.object.isRequired,
 	};
 
+	getTitle() {
+		const { current, site } = this.props;
+		const isJetpackSite = !! site.jetpack;
+
+		if ( current ) {
+			return 'Plan summary';
+		}
+
+		if ( isJetpackSite ) {
+			return 'Discount summary';
+		}
+
+		return 'Credit summary';
+	}
+
 	render() {
 		const {
 			available,
@@ -69,9 +84,7 @@ class PlanFeaturesSummary extends Component {
 
 		return (
 			<div className="plan-features__summary">
-				<strong className="plan-features__summary-title">
-					{ current ? 'Plan summary' : 'Credit summary' }
-				</strong>
+				<strong className="plan-features__summary-title">{ this.getTitle() }</strong>
 				<div className="plan-features__summary-price-row">
 					<span className="plan-features__summary-item">{ planTitle } plan</span>
 					<span className="plan-features__summary-price">
@@ -86,7 +99,7 @@ class PlanFeaturesSummary extends Component {
 				{ !! discountYearlyPrice && (
 					<div className="plan-features__summary-price-row plan-features__summary-discount">
 						<span className="plan-features__summary-item">
-							{ isJetpackSite ? 'Jetpack credits' : `${ currentPlanTitle } plan credits` }
+							{ isJetpackSite ? 'Jetpack discount' : `${ currentPlanTitle } plan credits` }
 						</span>
 						<span className="plan-features__summary-price">
 							{ formatCurrency( discountYearlyPrice - yearlyPrice, currencyCode ) }


### PR DESCRIPTION
The upgrade pricing display test we've recently launched (#22244) can confuse users with the language "Credits", especially in the Jetpack plans page. ( see p9jf6J-b5-p2 )

This PR will remove the top banner from the page and change "Credits" to "Discount".

## How to test

1. Activate `upgradePricingDisplayV2` test by running the following command in the browser console:
```
localStorage.setItem( 'ABTests', '{ "upgradePricingDisplayV2_20180305": "modified" }' );
```

2. Go to the plan page of a Jetpack-connected site.
3. Check if the banner is removed and the strings "Credits" are changed to "Discount".
<img width="957" alt="2018-03-14 7 34 12" src="https://user-images.githubusercontent.com/212034/37397372-c2ab2376-27be-11e8-83c5-aab7b8395100.png">
