### PR TITLE
Jetpack: Return to Jetpack site via client_id

### DIFF
--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -132,6 +132,15 @@
 	}
 }
 
+.wp-login__site-return-link {
+	overflow: hidden;
+	position: relative;
+	white-space: nowrap;
+	&::after {
+		@include long-content-fade($color: $gray-light);
+	}
+}
+
 .two-factor-authentication__auth-code-preview {
 	width: 100%;
 	display: block;

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -21,17 +21,12 @@ import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selecto
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 
 const enhanceContextWithLogin = context => {
-	const {
-		params: { flow, isJetpack, socialService, twoFactorAuthType },
-		path,
-		query: { back_to },
-	} = context;
+	const { params: { flow, isJetpack, socialService, twoFactorAuthType }, path } = context;
 
 	context.cacheQueryKeys = [ 'client_id', 'signup_flow' ];
 
 	context.primary = (
 		<WPLogin
-			backTo={ back_to }
 			isJetpack={ isJetpack === 'jetpack' }
 			path={ path }
 			twoFactorAuthType={ twoFactorAuthType }

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -29,7 +29,6 @@ import { recordPageViewWithClientId as recordPageView } from 'state/analytics/ac
 
 export class Login extends React.Component {
 	static propTypes = {
-		backTo: PropTypes.string,
 		clientId: PropTypes.string,
 		isLoggedIn: PropTypes.bool.isRequired,
 		isJetpack: PropTypes.bool.isRequired,
@@ -166,7 +165,7 @@ export class Login extends React.Component {
 	}
 
 	render() {
-		const { backTo, locale, privateSite, socialConnect, translate, twoFactorAuthType } = this.props;
+		const { locale, privateSite, socialConnect, translate, twoFactorAuthType } = this.props;
 		const canonicalUrl = addLocaleToWpcomUrl( 'https://wordpress.com/login', locale );
 
 		return (
@@ -186,7 +185,6 @@ export class Login extends React.Component {
 
 						{ ! socialConnect && (
 							<LoginLinks
-								backTo={ backTo }
 								locale={ locale }
 								privateSite={ privateSite }
 								twoFactorAuthType={ twoFactorAuthType }

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -10,7 +10,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
-import url from 'url';
+import { parse as parseUrl } from 'url';
 
 /**
  * Internal dependencies
@@ -73,14 +73,14 @@ export class LoginLinks extends React.Component {
 		// so users can go back to their site rather than WordPress.com
 		const redirectTo = get( this.props, [ 'query', 'redirect_to' ] );
 		if ( redirectTo ) {
-			const { pathname, query: redirectToQuery } = url.parse( redirectTo, true );
+			const { pathname, query: redirectToQuery } = parseUrl( redirectTo, true );
 			if ( pathname === '/jetpack/connect/authorize' && redirectToQuery.client_id ) {
 				const returnToSiteUrl = addQueryArgs(
 					{ client_id: redirectToQuery.client_id },
 					'https://jetpack.wordpress.com/jetpack.returntosite/1/'
 				);
 
-				const { hostname } = url.parse( redirectToQuery.site_url );
+				const { hostname } = parseUrl( redirectToQuery.site_url );
 				const linkText = hostname
 					? this.props.translate( 'Back to %(hostname)s', { args: { hostname } } )
 					: this.props.translate( 'Back' );

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -3,11 +3,9 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
-import urlModule from 'url';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -26,7 +24,6 @@ import { resetMagicLoginRequestForm } from 'state/login/magic-login/actions';
 
 export class LoginLinks extends React.Component {
 	static propTypes = {
-		backTo: PropTypes.string,
 		isLoggedIn: PropTypes.bool.isRequired,
 		locale: PropTypes.string.isRequired,
 		oauth2Client: PropTypes.object,
@@ -67,26 +64,6 @@ export class LoginLinks extends React.Component {
 	};
 
 	renderBackLink() {
-		const { backTo, translate } = this.props;
-
-		// A backTo prop may be supplied, allowing the back button href to be controlled.
-		if ( backTo ) {
-			const { hostname, protocol } = urlModule.parse( backTo );
-
-			// Ensure we've got a relative URL (null) or an http[s] protocol
-			// We don't want to allow `javascript:…`
-			if ( null === protocol || 'http:' === protocol || 'https:' === protocol ) {
-				const linkText = hostname
-					? translate( 'Back to %(hostname)s', { args: { hostname } } )
-					: translate( 'Back' );
-				return (
-					<ExternalLink href={ backTo }>
-						<Gridicon icon="arrow-left" size={ 18 } />
-						{ linkText }
-					</ExternalLink>
-				);
-			}
-		}
 		return (
 			<LoggedOutFormBackLink
 				classes={ { 'logged-out-form__link-item': false } }

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -3,11 +3,14 @@
 /**
  * External dependencies
  */
+import Gridicon from 'gridicons';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
+import url from 'url';
 
 /**
  * Internal dependencies
@@ -16,6 +19,7 @@ import ExternalLink from 'components/external-link';
 import LoggedOutFormBackLink from 'components/logged-out-form/back-link';
 import { addQueryArgs } from 'lib/url';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
+import { getCurrentQueryArguments } from 'state/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { isEnabled } from 'config';
 import { login } from 'lib/paths';
@@ -28,6 +32,7 @@ export class LoginLinks extends React.Component {
 		locale: PropTypes.string.isRequired,
 		oauth2Client: PropTypes.object,
 		privateSite: PropTypes.bool,
+		query: PropTypes.object,
 		recordTracksEvent: PropTypes.func.isRequired,
 		resetMagicLoginRequestForm: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
@@ -64,6 +69,31 @@ export class LoginLinks extends React.Component {
 	};
 
 	renderBackLink() {
+		// If we seem to be in a Jetpack connection flow, provide some special handling
+		// so users can go back to their site rather than WordPress.com
+		const redirectTo = get( this.props, [ 'query', 'redirect_to' ] );
+		if ( redirectTo ) {
+			const { pathname, query: redirectToQuery } = url.parse( redirectTo, true );
+			if ( pathname === '/jetpack/connect/authorize' && redirectToQuery.client_id ) {
+				const returnToSiteUrl = addQueryArgs(
+					{ client_id: redirectToQuery.client_id },
+					'https://jetpack.wordpress.com/jetpack.returntosite/1/'
+				);
+
+				const { hostname } = url.parse( redirectToQuery.site_url );
+				const linkText = hostname
+					? this.props.translate( 'Back to %(hostname)s', { args: { hostname } } )
+					: this.props.translate( 'Back' );
+
+				return (
+					<ExternalLink href={ returnToSiteUrl }>
+						<Gridicon icon="arrow-left" size={ 18 } />
+						{ linkText }
+					</ExternalLink>
+				);
+			}
+		}
+
 		return (
 			<LoggedOutFormBackLink
 				classes={ { 'logged-out-form__link-item': false } }
@@ -161,6 +191,7 @@ export class LoginLinks extends React.Component {
 const mapState = state => ( {
 	isLoggedIn: Boolean( getCurrentUserId( state ) ),
 	oauth2Client: getCurrentOAuth2Client( state ),
+	query: getCurrentQueryArguments( state ),
 } );
 
 const mapDispatch = {

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -86,7 +86,7 @@ export class LoginLinks extends React.Component {
 					: this.props.translate( 'Back' );
 
 				return (
-					<ExternalLink href={ returnToSiteUrl }>
+					<ExternalLink className="wp-login__site-return-link" href={ returnToSiteUrl }>
 						<Gridicon icon="arrow-left" size={ 18 } />
 						{ linkText }
 					</ExternalLink>


### PR DESCRIPTION
Substitute `back_to` based linking behavior for safer redirection to Jetpack sites via `jetpack.wordpress.com` and `client_id`.

Requires D10909-code

Background: p3btAN-TA-p2

Roll back relevant changes from #22647 (4040a39871aacf1ba20be038540bfd71148cf383)

## Testing
1. Apply D10909-code and sandbox `jetpack.wordpress.com`.
1. Start connecting a new site while logged out. You should use an existing WordPress.com email.
1. When you land on the `log-in` page, test the back link. Does it send you back to the WP Admin Jetpack dashboard of your site?
1. Test other login flows, they should remain unaffected.