### PR TITLE
SSR: Enable cache sampling in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -114,6 +114,7 @@
 		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
+		"ssr/sample-log-cache-misses": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,


### PR DESCRIPTION
Log every 1000th cache miss to logstash. This PR enables the logging that was added in #23228.

## Testing

Not really possible for this PR, but see #23228 for further details.
