### PR TITLE
Site Language Setting: Change copy from "blog" to "site"

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -238,7 +238,7 @@ class SiteSettingsFormGeneral extends Component {
 					onClick={ eventTracker( 'Clicked Language Field' ) }
 				/>
 				<FormSettingExplanation>
-					{ translate( 'Language this blog is primarily written in.' ) }&nbsp;
+					{ translate( 'Language this site is primarily written in.' ) }&nbsp;
 					<a href={ config.isEnabled( 'me/account' ) ? '/me/account' : '/settings/account/' }>
 						{ translate( "You can also modify your interface's language in your profile." ) }
 					</a>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -238,7 +238,7 @@ class SiteSettingsFormGeneral extends Component {
 					onClick={ eventTracker( 'Clicked Language Field' ) }
 				/>
 				<FormSettingExplanation>
-					{ translate( 'Language this site is primarily written in.' ) }&nbsp;
+					{ translate( 'The site\'s primary language.' ) }&nbsp;
 					<a href={ config.isEnabled( 'me/account' ) ? '/me/account' : '/settings/account/' }>
 						{ translate( "You can also modify your interface's language in your profile." ) }
 					</a>


### PR DESCRIPTION
The remainder of the settings page at https://wordpress.com/settings/general/ says "site" & this setting is not specific to "blog" sections of peoples' sites.

<img width="648" alt="screen shot 2018-03-14 at 9 09 35 am" src="https://user-images.githubusercontent.com/1587282/37404567-a1c2ea64-2768-11e8-83df-2942f39dac24.png">

See comments for discussion on copy.