### PR TITLE
Revert "Reader: follow by url placeholder should not live forever"

### DIFF
--- a/client/components/reader-infinite-stream/index.js
+++ b/client/components/reader-infinite-stream/index.js
@@ -30,6 +30,7 @@ class ReaderInfiniteStream extends Component {
 		windowScrollerRef: PropTypes.func,
 		extraRenderItemProps: PropTypes.object,
 		minHeight: PropTypes.number,
+		passthroughProp: PropTypes.any, // https://github.com/bvaughn/react-virtualized#pure-components. For use with things like sort etc.
 	};
 
 	static defaultProps = {
@@ -119,7 +120,7 @@ class ReaderInfiniteStream extends Component {
 	}
 
 	render() {
-		const { hasNextPage, width } = this.props;
+		const { hasNextPage, width, passthroughProp } = this.props;
 		const rowCount = hasNextPage( this.props.items.length )
 			? this.props.items.length + 10
 			: this.props.items.length;
@@ -143,7 +144,7 @@ class ReaderInfiniteStream extends Component {
 								ref={ this.handleListMounted( registerChild ) }
 								scrollTop={ scrollTop }
 								width={ width }
-								items={ this.props.items } // passthrough-prop unused by the component except to signal a rerender
+								passthroughProp={ passthroughProp }
 							/>
 						) }
 					</WindowScroller>

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -136,6 +136,7 @@ class FollowingManageSubscriptions extends Component {
 								followSource: READER_SUBSCRIPTIONS,
 							} }
 							width={ width }
+							passthroughProp={ sortOrder }
 							totalCount={ sortedFollows.length }
 							windowScrollerRef={ this.props.windowScrollerRef }
 							rowRenderer={ siteRowRenderer }

--- a/client/reader/search-stream/site-results.jsx
+++ b/client/reader/search-stream/site-results.jsx
@@ -54,6 +54,7 @@ class SiteResults extends React.Component {
 					fetchNextPage={ this.fetchNextPage }
 					hasNextPage={ this.hasNextPage }
 					rowRenderer={ siteRowRenderer }
+					passthroughProp={ this.props.sort }
 					extraRenderItemProps={ { showLastUpdatedDate, followSource: SEARCH_RESULTS_SITES } }
 				/>
 			</div>


### PR DESCRIPTION
Reverts Automattic/wp-calypso#23287

Seeing reports of broken settings links in reader/manage