### PR TITLE
Revert "Update to gridicons 3 (#23171)"

### DIFF
--- a/client/components/card/test/__snapshots__/index.js.snap
+++ b/client/components/card/test/__snapshots__/index.js.snap
@@ -5,9 +5,10 @@ exports[`Card should be linkable 1`] = `
   className="card is-card-link"
   href="/test"
 >
-  <Component
+  <t
     className="card__link-indicator"
     icon="chevron-right"
+    size={24}
   />
   This is a linked card
 </a>

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -9,7 +9,6 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { slugToCamelCase } from 'devdocs/docs-example/util';
 import { trim } from 'lodash';
-import Gridicons from 'gridicons/example';
 
 /**
  * Internal dependencies
@@ -54,6 +53,7 @@ import FormFields from 'components/forms/docs/example';
 import Gauge from 'components/gauge/docs/example';
 import GlobalNotices from 'components/global-notices/docs/example';
 import Gravatar from 'components/gravatar/docs/example';
+import Gridicons from 'gridicons/build/example';
 import HeaderButton from 'components/header-button/docs/example';
 import Headers from 'components/header-cake/docs/example';
 import ImagePreloader from 'components/image-preloader/docs/example';

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -75,7 +75,7 @@ exports[`JetpackAuthorize renders as expected 1`] = `
         <LoggedOutFormLinkItem
           href="http://an.example.site/wp-admin/admin.php?page=jetpack"
         >
-          <Component
+          <t
             icon="arrow-left"
             size={18}
           />

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -43,16 +43,16 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.0.0-beta.40",
-      "integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
+      "version": "7.0.0-beta.41",
+      "integrity": "sha512-omQT0n9EW38xfMCY7cCW/PAT55igUX9c9cMq6QN4EjxCcelcrocwMJ6H4JP4BGrQ+OHdJAQPM9/Eaa2Yce4Aug==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0-beta.40"
+        "@babel/highlight": "7.0.0-beta.41"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.40",
-      "integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
+      "version": "7.0.0-beta.41",
+      "integrity": "sha512-5RURdqgHmXdg775Dr6GIFaVatHaPtaVgMF29jvWgkm8LP/B3MjZR/TOhkpbIBChqFzTn7uQKiBR3002pGjKY7Q==",
       "dev": true,
       "requires": {
         "chalk": "2.3.2",
@@ -5493,8 +5493,8 @@
       }
     },
     "gridicons": {
-      "version": "3.0.0",
-      "integrity": "sha512-fGKzzhhwq2jL7Wz25PuUb4DEIO3xPkRO2ofspo0Xh3yiMPj/nZ051anggYjX/Z7iNvB8md1VcnEx9KZkOvdgdg==",
+      "version": "2.1.3",
+      "integrity": "sha512-3gvt0TAKUKt+BBJ0vboxuaSPriGfJP5aRIyxLPJzlVYzCd3mVHxHFMMzf9UUVb1tv/jzTicakHFo9a9YLTnZCw==",
       "requires": {
         "prop-types": "15.5.10"
       }
@@ -7446,7 +7446,7 @@
       "integrity": "sha512-eyCJB0T3hrlpFF2FqQoIB093OulP+1qvATQmD3IOgJgMGqPL6eYw8TbC5P/VCWPqKhGL51xvjIIhow5eZ2wHFw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.40",
+        "@babel/code-frame": "7.0.0-beta.41",
         "chalk": "2.3.2",
         "micromatch": "2.3.11",
         "slash": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "fuse.js": "2.6.1",
     "get-video-id": "2.1.4",
     "globby": "6.1.0",
-    "gridicons": "3.0.0",
+    "gridicons": "2.1.3",
     "happypack": "4.0.0",
     "hard-source-webpack-plugin": "0.3.12",
     "hash.js": "1.1.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -169,7 +169,6 @@ const webpackConfig = {
 		modules: [ path.join( __dirname, 'client' ), 'node_modules' ],
 		alias: Object.assign(
 			{
-				'gridicons/example': 'gridicons/dist/example',
 				'react-virtualized': 'react-virtualized/dist/commonjs',
 				'social-logos/example': 'social-logos/build/example',
 			},


### PR DESCRIPTION
This reverts commit 113841d407fd06dab3aaab2f683d2cf8ec8b1c5f.

The Gridicons React component is exported as a function, not a React.PureComponent in Gridicons v3.0.0. That seems to have caused [this](https://github.com/Automattic/wp-calypso/blob/master/client/blocks/reader-site-notification-settings/index.jsx#L132) to break as Stateless function components cannot be given refs.

### How to test

Go to http://calypso.localhost:3000/following/manage and test that the settings button work.