### PR TITLE
Store: Display warning notice upon failure to retrieve payment methods

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/label-settings/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/label-settings/selectors.js
@@ -101,6 +101,11 @@ export const getPaymentMethods = ( state, siteId = getSelectedSiteId( state ) ) 
 		.sort( ( a, b ) => b.payment_method_id - a.payment_method_id );
 };
 
+export const getPaymentMethodsWarning = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const meta = getLabelSettingsFormMeta( state, siteId );
+	return meta && meta.warnings && meta.warnings.payment_methods;
+};
+
 export const getMasterUserInfo = ( state, siteId = getSelectedSiteId( state ) ) => {
 	const meta = getLabelSettingsFormMeta( state, siteId );
 	return {

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -36,6 +36,7 @@ import {
 	getMasterUserInfo,
 	getPaperSize,
 	getPaymentMethods,
+	getPaymentMethodsWarning,
 	getSelectedPaymentMethodId,
 	isPristine,
 	userCanEditSettings,
@@ -109,6 +110,14 @@ class ShippingLabels extends Component {
 				) }
 			</Notice>
 		);
+	};
+
+	renderPaymentWarningNotice = () => {
+		const { paymentMethodsWarning } = this.props;
+
+		if ( paymentMethodsWarning ) {
+			return <Notice status="is-error" showDismiss={ false } text={ paymentMethodsWarning } />;
+		}
 	};
 
 	renderSettingsPermissionNotice = () => {
@@ -235,6 +244,7 @@ class ShippingLabels extends Component {
 			<div>
 				{ this.renderPaymentPermissionNotice() }
 				<p className="label-settings__credit-card-description">{ description }</p>
+				{ this.renderPaymentWarningNotice() }
 
 				<QueryStoredCards />
 				{ isReloading ? (
@@ -359,6 +369,7 @@ export default connect(
 			isReloading: areSettingsFetching( state, siteId ) && areSettingsLoaded( state, siteId ),
 			pristine: isPristine( state, siteId ),
 			paymentMethods: getPaymentMethods( state, siteId ),
+			paymentMethodsWarning: getPaymentMethodsWarning( state, siteId ),
 			selectedPaymentMethod: getSelectedPaymentMethodId( state, siteId ),
 			paperSize: getPaperSize( state, siteId ),
 			storeOptions: getLabelSettingsStoreOptions( state, siteId ),

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -116,7 +116,7 @@ class ShippingLabels extends Component {
 		const { paymentMethodsWarning } = this.props;
 
 		if ( paymentMethodsWarning ) {
-			return <Notice status="is-error" showDismiss={ false } text={ paymentMethodsWarning } />;
+			return <Notice status="is-warning" showDismiss={ false } text={ paymentMethodsWarning } />;
 		}
 	};
 

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -22,6 +22,7 @@ import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
 import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
 import PaymentMethod, { getPaymentMethodTitle } from './label-payment-method';
 import { getOrigin } from 'woocommerce/lib/nav-utils';
 import {
@@ -112,12 +113,21 @@ class ShippingLabels extends Component {
 		);
 	};
 
+	refetchSettings = () => {
+		this.props.fetchSettings( this.props.siteId );
+	};
+
 	renderPaymentWarningNotice = () => {
 		const { paymentMethodsWarning } = this.props;
-
-		if ( paymentMethodsWarning ) {
-			return <Notice status="is-warning" showDismiss={ false } text={ paymentMethodsWarning } />;
+		if ( ! paymentMethodsWarning ) {
+			return;
 		}
+
+		return (
+			<Notice status="is-warning" showDismiss={ false } text={ paymentMethodsWarning }>
+				<NoticeAction onClick={ this.refetchSettings }>Retry</NoticeAction>
+			</Notice>
+		);
 	};
 
 	renderSettingsPermissionNotice = () => {
@@ -144,7 +154,7 @@ class ShippingLabels extends Component {
 
 	onVisibilityChange = () => {
 		if ( ! document.hidden ) {
-			this.props.fetchSettings( this.props.siteId );
+			this.refetchSettings();
 		}
 		if ( this.addCreditCardWindow && this.addCreditCardWindow.closed ) {
 			document.removeEventListener( 'visibilitychange', this.onVisibilityChange );
@@ -244,7 +254,7 @@ class ShippingLabels extends Component {
 			<div>
 				{ this.renderPaymentPermissionNotice() }
 				<p className="label-settings__credit-card-description">{ description }</p>
-				{ this.renderPaymentWarningNotice() }
+				{ ! isReloading && this.renderPaymentWarningNotice() }
 
 				<QueryStoredCards />
 				{ isReloading ? (

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -118,14 +118,14 @@ class ShippingLabels extends Component {
 	};
 
 	renderPaymentWarningNotice = () => {
-		const { paymentMethodsWarning } = this.props;
+		const { paymentMethodsWarning, translate } = this.props;
 		if ( ! paymentMethodsWarning ) {
 			return;
 		}
 
 		return (
 			<Notice status="is-warning" showDismiss={ false } text={ paymentMethodsWarning }>
-				<NoticeAction onClick={ this.refetchSettings }>Retry</NoticeAction>
+				<NoticeAction onClick={ this.refetchSettings }>{ translate( 'Retry' ) }</NoticeAction>
 			</Notice>
 		);
 	};


### PR DESCRIPTION
Shows a notice in the event that the payment method list was not successfully updated:

<img width="690" alt="screen shot 2018-03-14 at 2 01 32 pm" src="https://user-images.githubusercontent.com/1867547/37421659-3ce9f2f4-2790-11e8-8480-13cd14d23837.png">

Inert until warning message string is passed back in https://github.com/Automattic/woocommerce-services/pull/1338

Fixes or helps to address https://github.com/Automattic/woocommerce-services/issues/616