### PR TITLE
Activity Log: add a button to get help when a plugin update fails

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -82,6 +82,9 @@ class ActivityLogItem extends Component {
 
 			case 'rewind__backup_error':
 				return this.renderHelpAction( this.props.trackHelpBackupFail );
+
+			case 'plugin__update_failed':
+				return this.renderHelpAction( this.props.trackHelpUpdatePluginFail );
 		}
 
 		if ( ! hideRestore && activityIsRewindable ) {
@@ -282,8 +285,11 @@ const mapDispatchToProps = ( dispatch, { activityId, siteId } ) => ( {
 			)
 		)
 	),
-	trackHelpThreat: () => recordTracksEvent( 'calypso_activitylog_threat_get_help' ),
-	trackHelpBackupFail: () => recordTracksEvent( 'calypso_activitylog_backup_fail_get_help' ),
+	trackHelpThreat: () => dispatch( recordTracksEvent( 'calypso_activitylog_threat_get_help' ) ),
+	trackHelpBackupFail: () =>
+		dispatch( recordTracksEvent( 'calypso_activitylog_backup_fail_get_help' ) ),
+	trackHelpUpdatePluginFail: () =>
+		dispatch( recordTracksEvent( 'calypso_activitylog_update_plugin_fail_get_help' ) ),
 } );
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( ActivityLogItem ) );

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -77,14 +77,10 @@ class ActivityLogItem extends Component {
 		const { hideRestore, activity: { activityIsRewindable, activityName } } = this.props;
 
 		switch ( activityName ) {
-			case 'rewind__scan_result_found':
-				return this.renderHelpAction( this.props.trackHelpThreat );
-
-			case 'rewind__backup_error':
-				return this.renderHelpAction( this.props.trackHelpBackupFail );
-
 			case 'plugin__update_failed':
-				return this.renderHelpAction( this.props.trackHelpUpdatePluginFail );
+			case 'rewind__backup_error':
+			case 'rewind__scan_result_found':
+				return this.renderHelpAction();
 		}
 
 		if ( ! hideRestore && activityIsRewindable ) {
@@ -119,25 +115,22 @@ class ActivityLogItem extends Component {
 	}
 
 	/**
-	 * Displays a button for users to get help. Tracks button click based on the function passed.
+	 * Displays a button for users to get help. Tracks button click.
 	 *
-	 * @param {function} trackHelp Method to call and track the button click.
 	 * @returns {Object} Get help button.
 	 */
-	renderHelpAction( trackHelp ) {
-		const { translate } = this.props;
+	renderHelpAction = () => (
+		<HappychatButton
+			className="activity-log-item__help-action"
+			borderless={ false }
+			onClick={ this.handleTrackHelp }
+		>
+			<Gridicon icon="chat" size={ 18 } />
+			{ this.props.translate( 'Get Help' ) }
+		</HappychatButton>
+	);
 
-		return (
-			<HappychatButton
-				className="activity-log-item__help-action"
-				borderless={ false }
-				onClick={ trackHelp }
-			>
-				<Gridicon icon="chat" size={ 18 } />
-				{ translate( 'Get Help' ) }
-			</HappychatButton>
-		);
-	}
+	handleTrackHelp = () => this.props.trackHelp( this.props.activity.activityName );
 
 	render() {
 		const {
@@ -285,11 +278,8 @@ const mapDispatchToProps = ( dispatch, { activityId, siteId } ) => ( {
 			)
 		)
 	),
-	trackHelpThreat: () => dispatch( recordTracksEvent( 'calypso_activitylog_threat_get_help' ) ),
-	trackHelpBackupFail: () =>
-		dispatch( recordTracksEvent( 'calypso_activitylog_backup_fail_get_help' ) ),
-	trackHelpUpdatePluginFail: () =>
-		dispatch( recordTracksEvent( 'calypso_activitylog_update_plugin_fail_get_help' ) ),
+	trackHelp: activityName =>
+		dispatch( recordTracksEvent( 'calypso_activitylog_event_get_help', { activityName } ) ),
 } );
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( ActivityLogItem ) );


### PR DESCRIPTION
Fixes #22721

This PR seeks to offer a way for users to get help when they found an event pointing to a failed plugin update event by adding a Happychat button in the event card.
This also fixes tracking events that were not correctly recorded.

<img width="904" alt="plugin update failed" src="https://user-images.githubusercontent.com/1041600/37425405-f99e07c6-27a1-11e8-9d11-d26e20f20060.png">

#### Testing

1. in a Jetpack site with Activity Log available, edit a plugin and downgrade its version, so you get the update available notice
2. access the plugin folder by SSH and update the plugin folder permission to 555 so it can't be written
3. launch https://calypso.live/?branch=add/activity-log/get-help-update-failed and go an update the plugin. You'll get an error
4. log in to Happychat staging, accept All Chats
5. go to the Activity Log and the event pointing to the plugin update failed and verify there's a fully functional **Get help** button