### PR TITLE
Layout: Fix missing border on sidebar in View Site section

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -48,7 +48,7 @@
 	@include clear-fix;
 	position: relative;
 	margin: 0;
-	padding: 79px 32px 32px ( $sidebar-width-max + 32px );
+	padding: 79px 32px 32px ( $sidebar-width-max + 32px + 1px );
 	box-sizing: border-box;
 	overflow: hidden;
 
@@ -73,12 +73,12 @@
 	// displays at full height.
 	.is-section-preview & {
 		height: 100%;
-		padding: 47px 0 0 $sidebar-width-max;
+		padding: 47px 0 0 ( $sidebar-width-max + 1px );
 	}
 
 	// Tablets
 	@include breakpoint( "<960px" ) {
-		padding: 71px 24px 24px ( $sidebar-width-min + 24px );
+		padding: 71px 24px 24px ( $sidebar-width-min + 24px + 1px );
 
 		.has-no-sidebar & {
 			padding-left: 24px;
@@ -91,7 +91,7 @@
 		}
 
 		.is-section-preview & {
-			padding: 47px 0px 0px 228px;
+			padding: 47px 0px 0px ( 228px + 1px );
 		}
 	}
 


### PR DESCRIPTION
This PR adds an extra pixel to the layout padding to accommodate the right border on sidebar. Here's the before:

<img width="421" alt="screen shot 2018-03-14 at 4 29 43 pm" src="https://user-images.githubusercontent.com/191598/37429233-1d0a5392-27a5-11e8-9782-2f534e2f6a93.png">

And the after:

<img width="449" alt="screen shot 2018-03-14 at 4 29 53 pm" src="https://user-images.githubusercontent.com/191598/37429242-20aadc24-27a5-11e8-92e3-44d1b6ffb990.png">

Fixing #23267