### PR TITLE
Domains: Remove noticon from G Suite

### DIFF
--- a/client/components/upgrades/google-apps/google-apps-dialog/style.scss
+++ b/client/components/upgrades/google-apps/google-apps-dialog/style.scss
@@ -142,6 +142,10 @@ form.google-apps-dialog {
 		position: relative;
 		text-align: left;
 		width: 100%;
+
+		.gridicon {
+			margin-right: 8px;
+		}
 	}
 }
 

--- a/client/components/upgrades/google-apps/google-apps-dialog/style.scss
+++ b/client/components/upgrades/google-apps/google-apps-dialog/style.scss
@@ -135,18 +135,13 @@ form.google-apps-dialog {
 		border: 2px dashed $gray-lighten-20;
 		color: $gray;
 		cursor: pointer;
+		display: flex;
+		align-items: center;
 		margin: 0 0 30px;
-		padding: 12px 18px 12px 45px;
+		padding: 12px;
 		position: relative;
 		text-align: left;
 		width: 100%;
-
-		&:before {
-			position: absolute;
-				left: 10px;
-				top: 7px;
-			@include noticon( '\f510', 30px );
-		}
 	}
 }
 

--- a/client/components/upgrades/google-apps/google-apps-dialog/users.jsx
+++ b/client/components/upgrades/google-apps/google-apps-dialog/users.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { clone } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -45,6 +46,7 @@ class GoogleAppsUsers extends React.Component {
 				{ allUserInputs }
 
 				<button className="google-apps-dialog__add-another-user-button" onClick={ this.addUser }>
+					<Gridicon icon="plus" />
 					{ translate( 'Add Another User' ) }
 				</button>
 			</div>

--- a/client/me/notification-settings/settings-form/style.scss
+++ b/client/me/notification-settings/settings-form/style.scss
@@ -59,10 +59,6 @@
 	.form-select {
 		max-width: 125px;
 	}
-
-	.noticon {
-		margin-right: 5px;
-	}
 }
 
 .notification-settings-form-stream {


### PR DESCRIPTION
This removes the plus noticon from the G Suite registration flow for
new domains.

To test: 

- Go to Domains and add a domain.
- Click on any of the domain suggestions.
- Click "Yes, add email"
- Notice the + Add Another User button.

I also snuck in another noticon removal from the notification settings css.

Before
![screen shot 2018-03-14 at 3 38 13 pm](https://user-images.githubusercontent.com/618551/37429575-c053402a-279d-11e8-834e-8da6fc759f48.png)


After
![screen shot 2018-03-14 at 3 33 01 pm](https://user-images.githubusercontent.com/618551/37429533-a068cd5c-279d-11e8-9d23-c94113f80fed.png)
