### PR TITLE
Activity Log: show arrow in the first day of the month when there is no activity yet

### DIFF
--- a/client/state/selectors/get-oldest-item-ts.js
+++ b/client/state/selectors/get-oldest-item-ts.js
@@ -9,8 +9,8 @@ import { get } from 'lodash';
  *
  * @param  {Object}        state  Global state tree
  * @param  {number|string} siteId The site ID
- * @return {number}               Timestamp of oldest logged event, otherwise Infinity.
+ * @return {number}               Timestamp of oldest logged event, otherwise null.
  */
 export default function getOldestItemTs( state, siteId ) {
-	return get( state, [ 'activityLog', 'oldestItemTs', siteId ], Infinity );
+	return get( state, [ 'activityLog', 'oldestItemTs', siteId ], null );
 }


### PR DESCRIPTION
Fixes #22917

This PR fixes an issue where the arrow to go to previous months is not shown if it's the first day of the month and there's no activity yet in the month.

<img width="910" alt="captura de pantalla 2018-04-01 a la s 17 27 09" src="https://user-images.githubusercontent.com/1041600/37429718-f4e866d8-27ae-11e8-9953-e2165a8e91b9.png">


#### Testing

1. launch https://calypso.live/?branch=fix/activity-log/show-arrow-first-month-day
2. set your clock to April 1st
3. go to Activity Log. Make sure you see the arrow to go back
