### PR TITLE
[Domains] Add additional spacing to CTA buttons

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 .domain-suggestion {
 	box-sizing: border-box;
 	display: flex;
@@ -5,7 +7,7 @@
 
 	@include clear-fix;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		padding: 15px 20px;
 
 		.domain-product-price {
@@ -23,10 +25,11 @@
 	}
 
 	&.is-added {
-		background-color: lighten( $gray, 35% );
+		background-color: lighten($gray, 35%);
 
 		.domain-suggestion__content {
-			h3, .domain-product-price {
+			h3,
+			.domain-product-price {
 				color: $gray;
 			}
 		}
@@ -37,7 +40,7 @@
 	width: 100%;
 	min-height: 32px;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		display: flex;
 		margin: 8px 0 0 0;
 	}
@@ -74,7 +77,7 @@
 		min-height: 44px;
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		.is-placeholder & {
 			margin-right: 50%;
 			min-height: 22px;
@@ -82,7 +85,7 @@
 			margin-bottom: 9px;
 		}
 
-		.is-placeholder:nth-of-type(2n+1) & {
+		.is-placeholder:nth-of-type(2n + 1) & {
 			margin-right: 52%;
 		}
 
@@ -94,7 +97,7 @@
 	> h3 {
 		word-break: break-all;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			width: 75%;
 		}
 
@@ -115,6 +118,7 @@
 		color: $white;
 		padding-left: 3em;
 		padding-right: 3em;
+		margin-left: 1em;
 	}
 
 	.is-placeholder & {
@@ -129,7 +133,6 @@
 }
 
 .domain-suggestion__chevron {
-
 	margin-left: 10px;
 	flex: 1 0 auto;
 	color: $gray;


### PR DESCRIPTION
Fixes #23254. 

When showing `FREE WITH YOUR PLAN` copy, the text would be too close to the button. This change adds a margin to the call-to-action buttons to create more space.

# Testing Instructions
1. Spin up your local dev server.
2. Navigate to wordpress.com/domains/add for a site with a plan and no domain.
3. Verify that everything looks visually correct, like so:

![domain_search](https://user-images.githubusercontent.com/4044428/37430803-f04f5034-2798-11e8-8de2-5985cc5dc6a8.png)