### PR TITLE
Domains: Return to site selector if user does not have domain management permissions for selected site.

### DIFF
--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -59,7 +59,7 @@ const DomainManagementData = createReactClass( {
 		const { selectedSite: prevSite } = this.props;
 		const { selectedSite: nextSite } = nextProps;
 
-		if ( nextSite !== prevSite ) {
+		if ( nextSite && nextSite !== prevSite ) {
 			fetchDomains( nextSite.ID );
 		}
 	},

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { find, findIndex, identity, noop, times } from 'lodash';
+import { find, findIndex, get, identity, noop, times } from 'lodash';
 import Gridicon from 'gridicons';
 import page from 'page';
 import React from 'react';
@@ -462,7 +462,7 @@ const undoChangePrimary = domain =>
 
 export default connect(
 	( state, ownProps ) => {
-		const siteId = ownProps.selectedSite.ID;
+		const siteId = get( ownProps, 'selectedSite.ID', null );
 
 		return {
 			hasDomainCredit: !! ownProps.selectedSite && hasDomainCredit( state, siteId ),


### PR DESCRIPTION
Using the sidebar site selector to select a site for which the user has no domain privileges will result in a TypeError and a blank page. This is because as Calypso proceeds to switch sites, an API call to `/sites/:site/domains` will result in a 403, "User or Token does not have access to specified site.", making expected domain info unavailable. This PR patches two spots which can fatal in these cases. With this PR, the user will now end up redirected to the site selector at `/domains/manage` (the same as if loading an unauthorized site from the URL `/domains/manage/:site`).

Fixes #23255 .

**Testing**
* Log in as a user that has Admin privileges for one of their sites (`A`), and something less (say Author) on another (`B`).
* Load `/domains/manage/A`. This should work fine.
* Using the sidebar, select Switch Site, and click site B.
* This should reproduce the problem of a blank screen.
* Apply this PR, and repeat; after clicking B, you will be forwarded to `/domains/manage`.