### PR TITLE
Happychat: Send the current route when a session starts

### DIFF
--- a/client/state/happychat/middleware-calypso.js
+++ b/client/state/happychat/middleware-calypso.js
@@ -16,6 +16,7 @@ import {
 	EXPORT_COMPLETE,
 	EXPORT_FAILURE,
 	EXPORT_STARTED,
+	HAPPYCHAT_IO_RECEIVE_STATUS,
 	IMPORTS_IMPORT_START,
 	JETPACK_CONNECT_AUTHORIZE,
 	MEDIA_DELETE,
@@ -27,15 +28,21 @@ import {
 	PURCHASE_REMOVE_COMPLETED,
 	SITE_SETTINGS_SAVE_SUCCESS,
 } from 'state/action-types';
+import {
+	HAPPYCHAT_CHAT_STATUS_ASSIGNED,
+	HAPPYCHAT_CHAT_STATUS_PENDING,
+} from 'state/happychat/constants';
 import { sendEvent, sendLog, sendPreferences } from 'state/happychat/connection/actions';
+import getHappychatChatStatus from 'state/happychat/selectors/get-happychat-chat-status';
 import getGroups from 'state/happychat/selectors/get-groups';
 import getSkills from 'state/happychat/selectors/get-skills';
 import isHappychatChatAssigned from 'state/happychat/selectors/is-happychat-chat-assigned';
 import isHappychatClientConnected from 'state/happychat/selectors/is-happychat-client-connected';
 import { getCurrentUserLocale } from 'state/current-user/selectors';
+import { getCurrentRoute } from 'state/selectors';
 
-const getRouteSetMessage = ( state, action ) => {
-	return `Looking at https://wordpress.com${ action.path }`;
+const getRouteSetMessage = ( state, path ) => {
+	return `Looking at https://wordpress.com${ path }`;
 };
 
 export const getEventMessageFromActionData = action => {
@@ -137,6 +144,18 @@ export default store => next => action => {
 	sendActionLogsAndEvents( store, action );
 
 	switch ( action.type ) {
+		case HAPPYCHAT_IO_RECEIVE_STATUS:
+			// When the Happychat chat status transitions from "pending" to "assigned", this indicates
+			// a chat has just started. Send the current route to the operator for context on where
+			// the customer initiated their chat request from.
+			if (
+				getHappychatChatStatus( state ) === HAPPYCHAT_CHAT_STATUS_PENDING &&
+				action.status === HAPPYCHAT_CHAT_STATUS_ASSIGNED
+			) {
+				dispatch( sendEvent( getRouteSetMessage( state, getCurrentRoute( state ) ) ) );
+			}
+			break;
+
 		case HELP_CONTACT_FORM_SITE_SELECT:
 			if ( isHappychatClientConnected( state ) ) {
 				const locales = getCurrentUserLocale( state );
@@ -149,7 +168,7 @@ export default store => next => action => {
 
 		case ROUTE_SET:
 			isHappychatClientConnected( state ) && isHappychatChatAssigned( state )
-				? dispatch( sendEvent( getRouteSetMessage( state, action ) ) )
+				? dispatch( sendEvent( getRouteSetMessage( state, action.path ) ) )
 				: noop;
 			break;
 	}

--- a/client/state/happychat/test/middleware-calypso.js
+++ b/client/state/happychat/test/middleware-calypso.js
@@ -18,8 +18,9 @@ import { selectSiteId } from 'state/help/actions';
 import { setRoute } from 'state/ui/actions';
 import { getCurrentUserLocale } from 'state/current-user/selectors';
 import getGroups from 'state/happychat/selectors/get-groups';
-import { sendPreferences } from 'state/happychat/connection/actions';
+import { receiveStatus, sendPreferences } from 'state/happychat/connection/actions';
 import {
+	HAPPYCHAT_CHAT_STATUS_ABANDONED,
 	HAPPYCHAT_CHAT_STATUS_ASSIGNED,
 	HAPPYCHAT_CHAT_STATUS_DEFAULT,
 	HAPPYCHAT_CHAT_STATUS_PENDING,
@@ -95,6 +96,50 @@ describe( 'middleware', () => {
 				const action = selectSiteId( state.sites.items[ 1 ].ID );
 				actionMiddleware( action );
 				expect( store.dispatch ).not.toHaveBeenCalled();
+			} );
+		} );
+
+		describe( 'HAPPYCHAT_IO_RECEIVE_STATUS', () => {
+			let state;
+			beforeEach( () => {
+				state = {
+					happychat: {
+						chat: { status: HAPPYCHAT_CHAT_STATUS_DEFAULT },
+					},
+					ui: { route: { path: { current: '/happychat' } } },
+				};
+
+				store.getState.mockReturnValue( state );
+			} );
+
+			test( 'should dispatch an event message when going from pending to assigned chat status', () => {
+				// First set the status to pending
+				state.happychat.chat.status = HAPPYCHAT_CHAT_STATUS_PENDING;
+				// Now set the status to assigned
+				actionMiddleware( receiveStatus( HAPPYCHAT_CHAT_STATUS_ASSIGNED ) );
+				// This should have sent a routing message
+				expect( store.dispatch ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						type: HAPPYCHAT_IO_SEND_MESSAGE_EVENT,
+						payload: expect.objectContaining( {
+							text: 'Looking at https://wordpress.com/happychat',
+						} ),
+					} )
+				);
+			} );
+
+			test( 'should not dispatch an event message when going from other chat statuses to assigned chat status', () => {
+				// Set the status to assigned (from default)
+				actionMiddleware( receiveStatus( HAPPYCHAT_CHAT_STATUS_ASSIGNED ) );
+
+				// Re-set status to abandoned and then to assigned again
+				state.happychat.chat.status = HAPPYCHAT_CHAT_STATUS_ABANDONED;
+				actionMiddleware( receiveStatus( HAPPYCHAT_CHAT_STATUS_ASSIGNED ) );
+
+				// No routing event messages should have shown
+				expect( store.dispatch ).not.toHaveBeenCalledWith(
+					expect.objectContaining( { type: HAPPYCHAT_IO_SEND_MESSAGE_EVENT } )
+				);
 			} );
 		} );
 


### PR DESCRIPTION
Fixes 1202-gh-happychat.

By tracking when the chat status flips from `pending` to `assigned` we can capture when the session actually starts. This lets us send the current URL the customer is looking at to the operator — currently their URL is only sent when the customer navigates. 

This provides valuable context to help understand where a customer is starting their support chat from. This is especially useful in distinguishing Jetpack, pre-sales, and pre-cancellation entry points. It's also going to be super helpful given that the Contact Form is about to be embedded on _every_ page, so customers can be asking for help in any context.

### How to test
- Start a new chat from `/help/contact` — the operator should get a "Looking at..." message with the customer's URL. `/end` that session.
- Go to `/me/purchases` and start to cancel a paid upgrade like a Business Plan. The confirmation modal will have a "Need help? Chat with us" button — click it and type a message. The operator should get a "Looking at..." message with the customer's URL.
- Navigate around a bit, other location messages should still send as normal.