### PR TITLE
JPC: remove NOT_ACTIVE_JETPACK notice.

### DIFF
--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -92,9 +92,8 @@ export class JetpackConnectNotices extends Component {
 				return noticeValues;
 
 			case NOT_ACTIVE_JETPACK:
-				noticeValues.icon = 'block';
-				noticeValues.text = translate( 'Jetpack is deactivated.' );
-				return noticeValues;
+				// in use in remote install, which automatically redirects to install
+				return null;
 
 			case OUTDATED_JETPACK:
 				noticeValues.icon = 'block';


### PR DESCRIPTION
The notice is shown in the Jetpack connect screen, which will be the entry point to remote install and the installation process will be handled automatically. Thus, no need to have the notice enabled.
When left as-is, it flashes when redirected to `/connect/install` creds form for installed and not-activated Jetpack.

Sequel to: https://github.com/Automattic/wp-calypso/pull/22958.

**To test:**
- go to `/jetpack/connect` with this branch checked-out,
- input site url of a site with Jetpack INSTALLED but NOT ACTIVATED,
- connect and verify that no notice is flashed when being redirected to the creds screen.