### PR TITLE
Community Translator: disabling for locale variants

### DIFF
--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -10,6 +10,7 @@ export {
 	getLanguage,
 	getLocaleFromPath,
 	isDefaultLocale,
+	isLocaleVariant,
 	removeLocaleFromPath,
 } from './utils';
 

--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -16,6 +16,7 @@ export {
 	getLanguage,
 	getLocaleFromPath,
 	isDefaultLocale,
+	isLocaleVariant,
 	removeLocaleFromPath,
 } from './utils';
 

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -14,6 +14,7 @@ import {
 	getLocaleFromPath,
 	isDefaultLocale,
 	removeLocaleFromPath,
+	isLocaleVariant,
 } from 'lib/i18n-utils';
 
 jest.mock( 'config', () => key => {
@@ -214,6 +215,21 @@ describe( 'utils', () => {
 
 		test( 'should return the parent slug since the given variant does not exist', () => {
 			expect( getLanguage( 'fr', 'fr_formal' ).langSlug ).to.equal( 'fr' );
+		} );
+	} );
+
+	describe( '#isLocaleVariant', () => {
+		test( 'should return false by default', () => {
+			expect( isLocaleVariant( 'lol' ) ).to.be.false;
+			expect( isLocaleVariant() ).to.be.false;
+		} );
+
+		test( 'should detect a locale variant', () => {
+			expect( isLocaleVariant( 'de_formal' ) ).to.be.true;
+		} );
+
+		test( 'should detect a root language', () => {
+			expect( isLocaleVariant( 'de' ) ).to.be.false;
 		} );
 	} );
 } );

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { find } from 'lodash';
+import { find, isString } from 'lodash';
 import { parse } from 'url';
 
 /**
@@ -33,6 +33,20 @@ function getPathParts( path ) {
  */
 export function isDefaultLocale( locale ) {
 	return locale === config( 'i18n_default_locale_slug' );
+}
+
+/**
+ * Checks if provided locale has a parentLangSlug and is therefore a locale variant
+ *
+ * @param {string} locale - locale slug (eg: 'fr')
+ * @return {boolean} true when the locale has a parentLangSlug
+ */
+export function isLocaleVariant( locale ) {
+	if ( ! isString( locale ) ) {
+		return false;
+	}
+	const language = getLanguage( locale );
+	return !! language && isString( language.parentLangSlug );
 }
 
 /**

--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -53,6 +53,11 @@ const communityTranslatorJumpstart = {
 	isEnabled() {
 		const currentUser = user.get();
 
+		// disabling the CT for locale variants until the GlotPress API can handle them
+		if ( !! currentUser.localeVariant ) {
+			return false;
+		}
+
 		if ( ! currentUser || 'en' === currentUser.localeSlug || ! currentUser.localeSlug ) {
 			return false;
 		}
@@ -127,8 +132,8 @@ const communityTranslatorJumpstart = {
 	},
 
 	init() {
-		const languageJson = i18n.getLocale() || { '': {} },
-			localeCode = languageJson[ '' ].localeSlug;
+		const languageJson = i18n.getLocale() || { '': {} };
+		const { localeSlug: localeCode } = languageJson[ '' ];
 
 		if ( localeCode && languageJson ) {
 			this.updateTranslationData( localeCode, languageJson );

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -148,7 +148,9 @@ const Account = createReactClass( {
 	},
 
 	// this is a temporary check to exclude the CT from locale variants
-	canDisplayCommunityTranslator( locale ) {
+	shouldDisplayCommunityTranslator() {
+		const locale = this.getUserSetting( 'language' );
+
 		if ( ! locale || locale === 'en' ) {
 			return false;
 		}
@@ -170,7 +172,7 @@ const Account = createReactClass( {
 	},
 
 	communityTranslator() {
-		if ( ! this.canDisplayCommunityTranslator( this.getUserSetting( 'language' ) ) ) {
+		if ( ! this.shouldDisplayCommunityTranslator() ) {
 			return;
 		}
 		const { translate } = this.props;
@@ -206,11 +208,11 @@ const Account = createReactClass( {
 	},
 
 	thankTranslationContributors() {
-		const locale = this.getUserSetting( 'language' );
-		if ( ! this.canDisplayCommunityTranslator( locale ) ) {
+		if ( ! this.shouldDisplayCommunityTranslator() ) {
 			return;
 		}
 
+		const locale = this.getUserSetting( 'language' );
 		const language = getLanguage( locale );
 		if ( ! language ) {
 			return;

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -43,7 +43,7 @@ import Main from 'components/main';
 import SitesDropdown from 'components/sites-dropdown';
 import ColorSchemePicker from 'blocks/color-scheme-picker';
 import { successNotice, errorNotice } from 'state/notices/actions';
-import { getLanguage } from 'lib/i18n-utils';
+import { getLanguage, isLocaleVariant } from 'lib/i18n-utils';
 import { isRequestingMissingSites } from 'state/selectors';
 import _user from 'lib/user';
 
@@ -105,7 +105,7 @@ const Account = createReactClass( {
 		this.updateUserSetting( 'language', value );
 		const redirect =
 			value !== originalLanguage || value !== originalLocaleVariant ? '/me/account' : false;
-		this.setState( { redirect } );
+		this.setState( { redirect, localeVariantSelected: isLocaleVariant( value ) } );
 	},
 
 	updateColorScheme( colorScheme ) {
@@ -147,47 +147,67 @@ const Account = createReactClass( {
 		return !! this.state.emailValidationError;
 	},
 
-	communityTranslator() {
-		const { translate } = this.props;
-		const userLocale = this.getUserSetting( 'language' );
-		const showTranslator = userLocale && userLocale !== 'en';
-		if ( showTranslator ) {
-			return (
-				<FormFieldset>
-					<FormLegend>{ translate( 'Community Translator' ) }</FormLegend>
-					<FormLabel>
-						<FormCheckbox
-							checked={ this.getUserSetting( 'enable_translator' ) }
-							onChange={ this.updateUserSettingCheckbox }
-							disabled={ this.getDisabledState() }
-							id="enable_translator"
-							name="enable_translator"
-							onClick={ this.getCheckboxHandler( 'Community Translator' ) }
-						/>
-						<span>
-							{ translate( 'Enable the in-page translator where available. {{a}}Learn more{{/a}}', {
-								components: {
-									a: (
-										<a
-											target="_blank"
-											rel="noopener noreferrer"
-											href="https://en.support.wordpress.com/community-translator/"
-											onClick={ this.getClickHandler( 'Community Translator Learn More Link' ) }
-										/>
-									),
-								},
-							} ) }
-						</span>
-					</FormLabel>
-				</FormFieldset>
-			);
+	// this is a temporary check to exclude the CT from locale variants
+	canDisplayCommunityTranslator( locale ) {
+		if ( ! locale || locale === 'en' ) {
+			return false;
 		}
+
+		// if the user has selected a locale variant
+		if ( this.state.localeVariantSelected ) {
+			return false;
+		}
+
+		// if the user hasn't yet selected a language, and the currently saved locale is a variant
+		if (
+			typeof this.state.localeVariantSelected !== 'boolean' &&
+			this.getUserSetting( 'locale_variant' )
+		) {
+			return false;
+		}
+
+		return true;
+	},
+
+	communityTranslator() {
+		if ( ! this.canDisplayCommunityTranslator( this.getUserSetting( 'language' ) ) ) {
+			return;
+		}
+		const { translate } = this.props;
+		return (
+			<FormFieldset>
+				<FormLegend>{ translate( 'Community Translator' ) }</FormLegend>
+				<FormLabel>
+					<FormCheckbox
+						checked={ this.getUserSetting( 'enable_translator' ) }
+						onChange={ this.updateUserSettingCheckbox }
+						disabled={ this.getDisabledState() }
+						id="enable_translator"
+						name="enable_translator"
+						onClick={ this.getCheckboxHandler( 'Community Translator' ) }
+					/>
+					<span>
+						{ translate( 'Enable the in-page translator where available. {{a}}Learn more{{/a}}', {
+							components: {
+								a: (
+									<a
+										target="_blank"
+										rel="noopener noreferrer"
+										href="https://en.support.wordpress.com/community-translator/"
+										onClick={ this.getClickHandler( 'Community Translator Learn More Link' ) }
+									/>
+								),
+							},
+						} ) }
+					</span>
+				</FormLabel>
+			</FormFieldset>
+		);
 	},
 
 	thankTranslationContributors() {
-		const { translate } = this.props;
 		const locale = this.getUserSetting( 'language' );
-		if ( ! locale || locale === 'en' ) {
+		if ( ! this.canDisplayCommunityTranslator( locale ) ) {
 			return;
 		}
 
@@ -195,7 +215,7 @@ const Account = createReactClass( {
 		if ( ! language ) {
 			return;
 		}
-
+		const { translate } = this.props;
 		const url = 'https://translate.wordpress.com/translators/?contributor_locale=' + locale;
 
 		return (

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -74,7 +74,7 @@
         { "value": 18, "langSlug": "eo", "name": "Esperanto", "wpLocale": "eo", "territories": [] },
         { "value": 19, "langSlug": "es", "name": "Español", "wpLocale": "es_ES", "popular": 2, "territories": [ "019", "039" ] },
         { "value": 484, "langSlug": "es-cl", "name": "Español de Chile", "wpLocale": "es_CL", "territories": [ "019" ] },
-        { "value": 902, "langSlug": "es-mx", "name": "Español de México", "wpLocale": "es_MX", "territories": [ "019" ] },
+        { "value": 902, "langSlug": "es-mx", "name": "Español de México", "wpLocale": "es_MX", "parentLangSlug": "es", "territories": [ "019" ] },
         { "value": 20, "langSlug": "et", "name": "Eesti", "wpLocale": "et", "territories": [ "154" ] },
         { "value": 429, "langSlug": "eu", "name": "Euskara", "wpLocale": "eu", "territories": [ "039" ] },
         { "value": 21, "langSlug": "fa", "name": "فارسی", "wpLocale": "fa_IR", "rtl": true, "territories": [ "034" ] },


### PR DESCRIPTION
This PR temporarily disables the Community Translator (CT) for locale variants, until we can modify the GlotPress API to handle them. 

We enabled locale variants such as formal German (Sie) in #23215.

![mar-15-2018 12-52-37](https://user-images.githubusercontent.com/6458278/37440244-f57db70a-284f-11e8-8314-701257d627d3.gif)

## Testing
1. Head to http://calypso.localhost:3000/me/account, and select and save **_Deutsch_** as your interface language. Also allow the CT by clicking on the checkbox.
2. Select and save **_Deutsch (Sie)_** 
3. Select, but don't save **_Deutsch_**

### Expectations
**At 1:** For root languages such as German you should see the invitation to activate the CT, as well as the activated CT

<img width="447" alt="screen shot 2018-03-15 at 12 59 28 pm" src="https://user-images.githubusercontent.com/6458278/37440444-d55564b8-2850-11e8-96c2-783d8f3260e4.png">

**At 2:** For locale variants, the CT invitation and the CT itself should be disabled

<img width="655" alt="screen shot 2018-03-15 at 12 56 33 pm" src="https://user-images.githubusercontent.com/6458278/37440454-de2784a4-2850-11e8-8674-81e94274bf13.png">

**At 3:** The CT invitation should be enabled

<img width="679" alt="screen shot 2018-03-15 at 12 56 23 pm" src="https://user-images.githubusercontent.com/6458278/37440465-e347ed2a-2850-11e8-8b6b-7c71d9d7f4ec.png">

