### PR TITLE
WIP: Add support for tyche, sorta

### DIFF
--- a/tyche.json
+++ b/tyche.json
@@ -1,0 +1,149 @@
+{
+  "settings": {
+    "defaultTool": "native"
+  },
+  "tasks": [
+    {
+      "name": "clean",
+      "description": "Cleans all build artifacts from the working directory",
+      "tasks": [
+        {
+          "name": "clean-npm",
+          "description": "Remove node_modules and npm-shrinkwrap.json",
+          "tasks": [
+            {
+              "exec": {
+                "native-nix": {
+                  "command": [
+                    "rm -rf node_modules"
+                  ]
+                },
+                "native-win": {
+                  "command": [
+                    "rmdir /S /Q node_modules"
+                  ]
+                }
+              }
+            },
+            {
+              "exec": {
+                "native-nix": {
+                  "command": [
+                    "rm -rf npm-shrinkwrap.json"
+                  ]
+                },
+                "native-win": {
+                  "command": [
+                    "del /Q /F npm-shrinkwrap.json"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "clean-devdocs",
+          "description": "Clean devdocs artifacts",
+          "tasks": [
+            {
+              "exec": {
+                "native-nix": {
+                  "command": [
+                    "rm -rf server/devdocs/search-index.js"
+                  ]
+                },
+                "native-win": {
+                  "command": [
+                    "del /Q /F server/devdocs/search-index.js"
+                  ]
+                }
+              }
+            },
+            {
+              "exec": {
+                "native-nix": {
+                  "command": [
+                    "rm -rf server/devdocs/prototypes-index.json"
+                  ]
+                },
+                "native-win": {
+                  "command": [
+                    "del /Q /F server/devdocs/prototypes-index.json"
+                  ]
+                }
+              }
+            },
+            {
+              "exec": {
+                "native-nix": {
+                  "command": [
+                    "rm -rf server/devdocs/components-usage-stats.json"
+                  ]
+                },
+                "native-win": {
+                  "command": [
+                    "del /Q /F server/devdocs/components-usage-stats.json"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "clean-public",
+          "description": "clean the public file of artifacts",
+          "tasks": [
+          ]
+        }
+      ]
+    },
+    {
+      "name": "build",
+      "description": "Build Calypso",
+      "tasks": [
+        "install",
+        {
+          "name": "build-css",
+          "description": "Build the css for the client",
+          "exec": {
+            "native": {
+              "command": [
+                "npm run -s env -- node --max_old_space_size=8192 ./node_modules/webpack/bin/webpack.js --display-error-details --config webpack.config.js"
+              ]
+            }
+          }
+        },
+        {
+          "name": "all",
+          "exec": {
+            "native": {
+              "command": [
+                "./node-modules/.bin/run-p","-s build-devdocs:* build-server build-client-if-prod build-client-if-desktop"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "install",
+      "description": "Install dependencies",
+      "exec": {
+        "native": {
+          "command": [
+            "npm install"
+          ]
+        }
+      },
+      "skips": {
+        "files_not_changed": [
+          "package.json"
+        ],
+        "path_exists": [
+          "node_modules"
+        ],
+        "skip_dependencies_if_skip": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
As mentioned in the super long p2. Writing a task runner isn't a lot of code or work. I made https://github.com/withinboredom/tyche as a fairly simple one. One of the things I liked about it, for what I use it for, is being able to type `tyche --help` and not have to go digging through code to figure out what the possible commands are and what they do:

```
λ tyche --help

  Usage: index [options] [command]


  Commands:

    clean [options] [clean-npm|clean-devdocs|clean-public]  Cleans all build artifacts from the working directory
    build [options] [install|build-css|all]                 Build Calypso
    install [options]                                       Install dependencies
    init                                                    Initialize the tool in this repository
    bump [options]                                          Bump the build number +1

  Options:

    -h, --help     output usage information
    -V, --version  output the version number
    -v, --verbose  Turn on verbose logging
```
Even if you do end up digging through the massive json file (that could even have a UI to do so, honestly 🤔), you can easily see what depends on what and why. There aren't a lot of variables and functions to wrap your head around. Editor search/replace can handle that just fine. Granted, I only use this tool on personal projects ... it's not battle hardened for super huge projects...