### PR TITLE
Concierge: Add Rebrand Cities flag

### DIFF
--- a/client/me/concierge/book/calendar-step.js
+++ b/client/me/concierge/book/calendar-step.js
@@ -43,6 +43,7 @@ class CalendarStep extends Component {
 			lastname: signupForm.lastname,
 			message: signupForm.message,
 			timezone: signupForm.timezone,
+			isRebrandCitiesSite: signupForm.isRebrandCitiesSite,
 		};
 
 		this.props.bookConciergeAppointment(

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -20,6 +20,7 @@ import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
+import IsRebrandCitiesSite from './is-rebrand-cities-site';
 import Timezone from 'components/timezone';
 import Site from 'blocks/site';
 import { localize } from 'i18n-calypso';
@@ -43,11 +44,19 @@ class InfoStep extends Component {
 		this.props.updateConciergeSignupForm( { ...this.props.signupForm, timezone } );
 	};
 
-	setFieldValue = ( { target } ) => {
+	updateSignupForm( name, value ) {
 		this.props.updateConciergeSignupForm( {
 			...this.props.signupForm,
-			[ target.name ]: target.value,
+			[ name ]: value,
 		} );
+	}
+
+	setRebrandCitiesValue = value => {
+		this.updateSignupForm( 'isRebrandCitiesSite', value );
+	};
+
+	setFieldValue = ( { target: { name, value } } ) => {
+		this.updateSignupForm( name, value );
 	};
 
 	canSubmitForm = () => {
@@ -74,7 +83,9 @@ class InfoStep extends Component {
 	render() {
 		const {
 			currentUserLocale,
+			onComplete,
 			signupForm: { firstname, lastname, message, timezone },
+			site,
 			translate,
 		} = this.props;
 		const language = getLanguage( currentUserLocale ).name;
@@ -88,10 +99,11 @@ class InfoStep extends Component {
 
 		return (
 			<div>
+				<IsRebrandCitiesSite onChange={ this.setRebrandCitiesValue } siteId={ site.ID } />
 				<PrimaryHeader />
 				{ ! isEnglish && <Notice showDismiss={ false } text={ noticeText } /> }
 				<CompactCard className="book__info-step-site-block">
-					<Site siteId={ this.props.site.ID } />
+					<Site siteId={ site.ID } />
 				</CompactCard>
 
 				<CompactCard>
@@ -151,7 +163,7 @@ class InfoStep extends Component {
 						disabled={ ! this.canSubmitForm() }
 						isPrimary={ true }
 						type="button"
-						onClick={ this.props.onComplete }
+						onClick={ onComplete }
 					>
 						{ translate( 'Continue to calendar' ) }
 					</FormButton>

--- a/client/me/concierge/book/is-rebrand-cities-site.js
+++ b/client/me/concierge/book/is-rebrand-cities-site.js
@@ -27,7 +27,7 @@ import PropTypes from 'prop-types';
  */
 import SiteUsersFetcher from 'components/site-users-fetcher';
 
-const REBRAND_CITIES_ACCOUNT_USERNAME = 'mwtest514';
+const REBRAND_CITIES_ACCOUNT_USERNAME = 'rebrandcities';
 
 /**
  * The <AreUsersPresent /> component takes a set of users and an onChange callback. It

--- a/client/me/concierge/book/is-rebrand-cities-site.js
+++ b/client/me/concierge/book/is-rebrand-cities-site.js
@@ -1,0 +1,101 @@
+/** @format */
+
+/**
+ * We have an initiative partnership called Rebrand Cities, where our partners help businesses
+ * set up a WordPress.com Business site. The site owners are then encouraged to book a Concierge
+ * Session to start chatting directly with our Happiness Engineers. We'd like to flag these sessions
+ * as part of the Rebrand Cities program so that the HE has more context and can give the customer
+ * a session tailored to the program.
+ *
+ * The best way to auto-identify a site as belonging to the Rebrand Cities program is by checking
+ * if the main Rebrand Cities WordPress.com account is a member of the site — this account is used
+ * to set up all of these sites.
+ *
+ * This component's purpose is to check the passed-in siteId and notify using the onChange prop
+ * whether the site is a part of the program. This information can then be passed on to the booking
+ * API call and used to customize the invitation and inform the HE that this is a Rebrand Cities session.
+ */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import SiteUsersFetcher from 'components/site-users-fetcher';
+
+const REBRAND_CITIES_ACCOUNT_USERNAME = 'mwtest514';
+
+/**
+ * The <AreUsersPresent /> component takes a set of users and an onChange callback. It
+ * passes true or false into the callback whenever the count of users changes. This is
+ * intended to be wrapped in a SiteUsersFetcher which will pass the users in.
+ *
+ * This is a helper component which isn't exported.
+ */
+class AreUsersPresent extends Component {
+	static propTypes = {
+		// onChange is passed in from the primary component
+		onChange: PropTypes.func.isRequired,
+		// users is passed from the SiteUsersFetcher
+		users: PropTypes.array,
+	};
+
+	static defaultProps = {
+		users: [],
+	};
+
+	notifyValue() {
+		this.props.onChange( this.props.users.length > 0 );
+	}
+
+	componentDidMount() {
+		this.notifyValue();
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.users.length !== this.props.users.length ) {
+			this.notifyValue();
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+/**
+ * The <IsRebrandCitiesSite /> component takes a siteId and an onChange callback. The
+ * callback is executed with true or false depending on if the passed-in site ID is owned
+ * by the Rebrand Cities account. This information can then be passed on when the concierge
+ * session is booked by the implementing component.
+ */
+class IsRebrandCitiesSite extends Component {
+	static propTypes = {
+		onChange: PropTypes.func.isRequired,
+		siteId: PropTypes.number.isRequired,
+	};
+
+	render() {
+		const { onChange, siteId } = this.props;
+
+		const siteUsersFetchOptions = {
+			siteId,
+			// By setting a search without * wildcards, we can ensure that only users
+			// on the site with an exactly-matching username will be passed through,
+			search: REBRAND_CITIES_ACCOUNT_USERNAME,
+			search_columns: [ 'display_name', 'user_login' ],
+		};
+
+		return (
+			<SiteUsersFetcher fetchOptions={ siteUsersFetchOptions }>
+				<AreUsersPresent onChange={ onChange } />
+			</SiteUsersFetcher>
+		);
+	}
+}
+
+export default IsRebrandCitiesSite;

--- a/client/state/concierge/signup-form/reducer.js
+++ b/client/state/concierge/signup-form/reducer.js
@@ -19,6 +19,10 @@ export const timezone = createReducer( moment.tz.guess(), {
 	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.timezone,
 } );
 
+export const isRebrandCitiesSite = createReducer( false, {
+	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.isRebrandCitiesSite,
+} );
+
 export const firstname = createReducer( '', {
 	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.firstname,
 } );
@@ -37,4 +41,5 @@ export default combineReducers( {
 	message,
 	timezone,
 	status,
+	isRebrandCitiesSite,
 } );

--- a/client/state/concierge/signup-form/test/reducer.js
+++ b/client/state/concierge/signup-form/test/reducer.js
@@ -8,7 +8,14 @@ import { moment } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import signupForm, { firstname, lastname, timezone, message, status } from '../reducer';
+import signupForm, {
+	firstname,
+	lastname,
+	timezone,
+	message,
+	status,
+	isRebrandCitiesSite,
+} from '../reducer';
 import { CONCIERGE_SIGNUP_FORM_UPDATE, CONCIERGE_UPDATE_BOOKING_STATUS } from 'state/action-types';
 
 describe( 'concierge/signupForm/reducer', () => {
@@ -18,6 +25,7 @@ describe( 'concierge/signupForm/reducer', () => {
 		timezone: 'UTC',
 		message: 'hello',
 		status: 'booking',
+		isRebrandCitiesSite: true,
 	};
 	const mockStatus = 'booking';
 
@@ -81,6 +89,18 @@ describe( 'concierge/signupForm/reducer', () => {
 		} );
 	} );
 
+	describe( 'isRebrandCitiesSite', () => {
+		test( 'should be defaulted as false', () => {
+			expect( isRebrandCitiesSite( undefined, {} ) ).toBe( false );
+		} );
+
+		test( 'should return isRebrandCitiesSite from the update action', () => {
+			expect( isRebrandCitiesSite( undefined, updateForm ) ).toEqual(
+				mockSignupForm.isRebrandCitiesSite
+			);
+		} );
+	} );
+
 	describe( 'signupForm', () => {
 		test( 'should combine all defaults as null.', () => {
 			expect( signupForm( undefined, {} ) ).toEqual( {
@@ -89,6 +109,7 @@ describe( 'concierge/signupForm/reducer', () => {
 				timezone: moment.tz.guess(),
 				message: '',
 				status: null,
+				isRebrandCitiesSite: false,
 			} );
 		} );
 


### PR DESCRIPTION
This PR adds an `isRebrandCitiesSite` meta flag for customers signing up for Concierge Sessions. This will let us send a customized calendar invite to these customers and identify the sessions as part of the Rebrand Cities program.

Testing instructions in 603-gh-hg