### PR TITLE
Checkout: Remove productsList factory and use Redux

### DIFF
--- a/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
+++ b/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
@@ -26,6 +26,8 @@ import {
 import { getAnnualPrice, getMonthlyPrice } from 'lib/google-apps';
 import { recordTracksEvent, recordGoogleEvent, composeAnalytics } from 'state/analytics/actions';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import QueryProducts from 'components/data/query-products-list';
+import { getProductsList } from 'state/products-list/selectors';
 
 class GoogleAppsDialog extends React.Component {
 	static propTypes = {
@@ -55,14 +57,14 @@ class GoogleAppsDialog extends React.Component {
 	}
 
 	render() {
-		const productsList = this.props.productsList && this.props.productsList.get();
-		const { currencyCode } = this.props;
+		const { currencyCode, productsList } = this.props;
 		const price = get( productsList, [ 'gapps', 'prices', currencyCode ], 0 );
 		const annualPrice = getAnnualPrice( price, currencyCode );
 		const monthlyPrice = getMonthlyPrice( price, currencyCode );
 
 		return (
 			<form className="google-apps-dialog" onSubmit={ this.handleFormSubmit }>
+				<QueryProducts />
 				<CompactCard>{ this.header() }</CompactCard>
 				<CompactCard>
 					<GoogleAppsProductDetails
@@ -257,6 +259,7 @@ const recordFormSubmit = section =>
 export default connect(
 	state => ( {
 		currencyCode: getCurrentUserCurrencyCode( state ),
+		productsList: getProductsList( state ),
 	} ),
 	{
 		recordAddEmailButtonClick,

--- a/client/components/upgrades/google-apps/google-apps-dialog/users-form.jsx
+++ b/client/components/upgrades/google-apps/google-apps-dialog/users-form.jsx
@@ -56,7 +56,7 @@ class GoogleAppsUsersForm extends React.Component {
 						name="email"
 						value={ get( user, 'email.value', '' ) }
 						suffix={ '@' + domain }
-						isError={ emailError }
+						isError={ !! emailError }
 						onChange={ this.updateInputField }
 						onBlur={ onBlur }
 						onClick={ this.recordInputFocusEmail }
@@ -70,7 +70,7 @@ class GoogleAppsUsersForm extends React.Component {
 						name="firstName"
 						value={ get( user, 'firstName.value', '' ) }
 						maxLength={ 60 }
-						isError={ firstNameError }
+						isError={ !! firstNameError }
 						onChange={ this.updateInputField }
 						onBlur={ onBlur }
 						onClick={ this.recordInputFocusFirstName }
@@ -86,7 +86,7 @@ class GoogleAppsUsersForm extends React.Component {
 						name="lastName"
 						value={ get( user, 'lastName.value', '' ) }
 						maxLength={ 60 }
-						isError={ lastNameError }
+						isError={ !! lastNameError }
 						onChange={ this.updateInputField }
 						onBlur={ onBlur }
 						onClick={ this.recordInputFocusLastName }

--- a/client/components/upgrades/google-apps/google-apps-dialog/users.jsx
+++ b/client/components/upgrades/google-apps/google-apps-dialog/users.jsx
@@ -55,11 +55,12 @@ class GoogleAppsUsers extends React.Component {
 		return (
 			<GoogleAppsUsersForm
 				domain={ this.props.domain }
-				onBlur={ this.props.onBlur }
-				user={ user }
 				index={ index }
-				updateField={ this.updateField }
+				key={ `google-apps-user-form-${ index }` }
+				onBlur={ this.props.onBlur }
 				recordInputFocus={ this.recordInputFocus }
+				user={ user }
+				updateField={ this.updateField }
 			/>
 		);
 	};

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -103,7 +103,6 @@ class CheckoutThankYou extends React.Component {
 	static propTypes = {
 		domainOnlySiteFlow: PropTypes.bool.isRequired,
 		failedPurchases: PropTypes.array,
-		productsList: PropTypes.object.isRequired,
 		receiptId: PropTypes.number,
 		gsuiteReceiptId: PropTypes.number,
 		selectedFeature: PropTypes.string,

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -8,7 +8,6 @@ import i18n, { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 
 /**
  * Internal dependencies
@@ -61,27 +60,23 @@ import { loadTrackingTool } from 'state/analytics/actions';
 import { getProductsList, isProductsListFetching } from 'state/products-list/selectors';
 import QueryProducts from 'components/data/query-products-list';
 
-const Checkout = createReactClass( {
-	displayName: 'Checkout',
-
-	propTypes: {
+class Checkout extends React.Component {
+	static propTypes = {
 		cards: PropTypes.array.isRequired,
 		couponCode: PropTypes.string,
 		selectedFeature: PropTypes.string,
-	},
+	};
 
-	getInitialState: function() {
-		return {
-			previousCart: null,
-		};
-	},
+	state = {
+		previousCart: null,
+	};
 
-	componentWillMount: function() {
+	componentWillMount() {
 		resetTransaction();
 		this.props.recordApplePayStatus();
-	},
+	}
 
-	componentDidMount: function() {
+	componentDidMount() {
 		if ( this.redirectIfEmptyCart() ) {
 			return;
 		}
@@ -96,9 +91,9 @@ const Checkout = createReactClass( {
 
 		window.scrollTo( 0, 0 );
 		this.props.loadTrackingTool( 'HotJar' );
-	},
+	}
 
-	componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps( nextProps ) {
 		if ( ! this.props.cart.hasLoadedFromServer && nextProps.cart.hasLoadedFromServer ) {
 			if ( this.props.product ) {
 				this.addProductToCart();
@@ -106,15 +101,15 @@ const Checkout = createReactClass( {
 
 			this.trackPageView();
 		}
-	},
+	}
 
-	componentDidUpdate: function() {
+	componentDidUpdate() {
 		if ( ! this.props.cart.hasLoadedFromServer ) {
 			return false;
 		}
 
-		const previousCart = this.state.previousCart,
-			nextCart = this.props.cart;
+		const previousCart = this.state.previousCart;
+		const nextCart = this.props.cart;
 
 		if ( ! isEqual( previousCart, nextCart ) ) {
 			this.redirectIfEmptyCart();
@@ -129,7 +124,7 @@ const Checkout = createReactClass( {
 		) {
 			this.setDomainDetailsForGsuiteCart();
 		}
-	},
+	}
 
 	setDomainDetailsForGsuiteCart() {
 		const { contactDetails, cart } = this.props;
@@ -142,9 +137,9 @@ const Checkout = createReactClass( {
 		if ( domainReceiptId ) {
 			setDomainDetails( contactDetails );
 		}
-	},
+	}
 
-	trackPageView: function( props ) {
+	trackPageView( props ) {
 		props = props || this.props;
 
 		analytics.tracks.recordEvent( 'calypso_checkout_page_view', {
@@ -153,14 +148,14 @@ const Checkout = createReactClass( {
 		} );
 
 		recordViewCheckout( props.cart );
-	},
+	}
 
 	getProductSlugFromSynonym( slug ) {
 		if ( 'no-ads' === slug ) {
 			return 'no-adverts/no-adverts.php';
 		}
 		return slug;
-	},
+	}
 
 	addProductToCart() {
 		if ( this.props.purchaseId ) {
@@ -171,7 +166,7 @@ const Checkout = createReactClass( {
 		if ( this.props.couponCode ) {
 			applyCoupon( this.props.couponCode );
 		}
-	},
+	}
 
 	addRenewItemToCart() {
 		const { product, purchaseId, selectedSiteSlug } = this.props;
@@ -194,7 +189,7 @@ const Checkout = createReactClass( {
 		);
 
 		addItem( cartItem );
-	},
+	}
 
 	addNewItemToCart() {
 		const planSlug = getUpgradePlanSlugFromPath( this.props.product, this.props.selectedSite );
@@ -218,9 +213,9 @@ const Checkout = createReactClass( {
 		if ( cartItem ) {
 			addItem( cartItem );
 		}
-	},
+	}
 
-	redirectIfEmptyCart: function() {
+	redirectIfEmptyCart() {
 		const { selectedSiteSlug, transaction } = this.props;
 		let redirectTo = '/plans/';
 
@@ -254,7 +249,7 @@ const Checkout = createReactClass( {
 		page.redirect( redirectTo );
 
 		return true;
-	},
+	}
 
 	/**
 	 * Purchases are of the format { [siteId]: [ { productId: ... } ] }
@@ -263,9 +258,9 @@ const Checkout = createReactClass( {
 	 * @param {Object} purchases keyed by siteId { [siteId]: [ { productId: ... } ] }
 	 * @returns {Array} of product objects [ { productId: ... }, ... ]
 	 */
-	flattenPurchases: function( purchases ) {
+	flattenPurchases( purchases ) {
 		return flatten( Object.values( purchases ) );
-	},
+	}
 
 	getEligibleDomainFromCart() {
 		const domainRegistrations = cartItems.getDomainRegistrations( this.props.cart );
@@ -275,9 +270,9 @@ const Checkout = createReactClass( {
 		);
 
 		return domainsForGSuite;
-	},
+	}
 
-	getCheckoutCompleteRedirectPath() {
+	getCheckoutCompleteRedirectPath = () => {
 		let renewalItem;
 		const { cart, selectedSiteSlug, transaction: { step: { data: receipt } } } = this.props;
 		const domainReceiptId = get(
@@ -347,9 +342,9 @@ const Checkout = createReactClass( {
 					this.props.selectedFeature
 				}/${ selectedSiteSlug }/${ receiptId }`
 			: `/checkout/thank-you/${ selectedSiteSlug }/${ receiptId }`;
-	},
+	};
 
-	handleCheckoutCompleteRedirect: function() {
+	handleCheckoutCompleteRedirect = () => {
 		let product, purchasedProducts, renewalItem;
 
 		const {
@@ -454,9 +449,9 @@ const Checkout = createReactClass( {
 		}
 
 		page( redirectPath );
-	},
+	};
 
-	content: function() {
+	content() {
 		const { selectedSite } = this.props;
 
 		if ( ! this.isLoading() && this.needsDomainDetails() ) {
@@ -481,25 +476,25 @@ const Checkout = createReactClass( {
 				handleCheckoutCompleteRedirect={ this.handleCheckoutCompleteRedirect }
 			/>
 		);
-	},
+	}
 
-	paymentMethodsAbTestFilter: function() {
+	paymentMethodsAbTestFilter() {
 		// This methods can be used to filter payment methods
 		// For example, for the purpose of AB tests.
 
 		return this.props.paymentMethods;
-	},
+	}
 
-	isLoading: function() {
-		const isLoadingCart = ! this.props.cart.hasLoadedFromServer,
-			isLoadingProducts = this.props.isProductsListFetching;
+	isLoading() {
+		const isLoadingCart = ! this.props.cart.hasLoadedFromServer;
+		const isLoadingProducts = this.props.isProductsListFetching;
 
 		return isLoadingCart || isLoadingProducts;
-	},
+	}
 
 	needsDomainDetails() {
-		const cart = this.props.cart,
-			transaction = this.props.transaction;
+		const cart = this.props.cart;
+		const transaction = this.props.transaction;
 
 		if ( cart && cartItems.hasOnlyRenewalItems( cart ) ) {
 			return false;
@@ -512,7 +507,7 @@ const Checkout = createReactClass( {
 				cartItems.hasGoogleApps( cart ) ||
 				cartItems.hasTransferProduct( cart ) )
 		);
-	},
+	}
 
 	render() {
 		return (
@@ -527,8 +522,8 @@ const Checkout = createReactClass( {
 				</div>
 			</div>
 		);
-	},
-} );
+	}
+}
 
 export default connect(
 	( state, props ) => {

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -14,7 +14,6 @@ import analytics from 'lib/analytics';
 import { sectionifyWithRoutes } from 'lib/route';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { setSection } from 'state/ui/actions';
-import productsFactory from 'lib/products-list';
 import { getSiteBySlug } from 'state/sites/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import GsuiteNudge from 'my-sites/checkout/gsuite-nudge';
@@ -23,11 +22,6 @@ import CheckoutData from 'components/data/checkout';
 import CartData from 'components/data/cart';
 import SecondaryCart from './cart/secondary-cart';
 import CheckoutThankYouComponent from './checkout-thank-you';
-
-/**
- * Module variables
- */
-const productsList = productsFactory();
 
 const checkoutRoutes = [
 	new Route( '/checkout/features/:feature/:site/:plan' ),
@@ -127,7 +121,6 @@ export default {
 
 		context.primary = (
 			<CheckoutThankYouComponent
-				productsList={ productsList }
 				receiptId={ receiptId }
 				gsuiteReceiptId={ gsuiteReceiptId }
 				domainOnlySiteFlow={ isEmpty( context.params.site ) }
@@ -161,7 +154,6 @@ export default {
 			<CartData>
 				<GsuiteNudge
 					domain={ domain }
-					productsList={ productsList }
 					receiptId={ Number( receiptId ) }
 					selectedSiteId={ selectedSite.ID }
 				/>

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -27,7 +26,6 @@ export class GsuiteNudge extends React.Component {
 	static propTypes = {
 		domain: PropTypes.string.isRequired,
 		receiptId: PropTypes.number.isRequired,
-		productsList: PropTypes.object.isRequired,
 		selectedSiteId: PropTypes.number.isRequired,
 	};
 
@@ -76,7 +74,6 @@ export class GsuiteNudge extends React.Component {
 				<QuerySites siteId={ selectedSiteId } />
 				<GoogleAppsDialog
 					domain={ this.props.domain }
-					productsList={ this.props.productsList }
 					onClickSkip={ this.handleClickSkip }
 					onAddGoogleApps={ this.handleAddGoogleApps }
 				/>


### PR DESCRIPTION
- Remove the productsList factory from the controller
- Update components to use `QueryComponents` for the `productsList`
- Minor refactoring, assigning unique keys to GApps component, and passing booleans properly
- ES6ify Checkout component

Test:
- Successfully get through checkout, and buy a domain
- Test the GSuite Nudge (not sure anymore if it's still an A/B test, but can hit it directly after checkout `/checkout/:site/with-gsuite/:domain`)
- Try to add a G Suite email through Domains -> Add and see no warnings in console. :)