### PR TITLE
Checkout: prevent duplicate key warning in country select

### DIFF
--- a/client/my-sites/domains/components/form/country-select.jsx
+++ b/client/my-sites/domains/components/form/country-select.jsx
@@ -46,6 +46,7 @@ const CountrySelect = createReactClass( {
 		const countriesList = this.props.countriesList.get();
 		let options = [];
 		let { value } = this.props;
+		let dividerCount = 1;
 		value = value || '';
 
 		if ( isEmpty( countriesList ) ) {
@@ -57,13 +58,13 @@ const CountrySelect = createReactClass( {
 		} else {
 			options = options.concat( [
 				{ key: 'select-country', label: this.props.translate( 'Select Country' ), value: '' },
-				{ key: 'divider1', label: '', disabled: 'disabled', value: '-' },
+				{ key: 'divider' + dividerCount, label: '', disabled: 'disabled', value: '-' },
 			] );
 
 			options = options.concat(
 				countriesList.map( ( country, index ) => {
 					if ( isEmpty( country.code ) ) {
-						return { key: 'divider2', label: '', disabled: 'disabled', value: '-' };
+						return { key: 'divider' + ++dividerCount, label: '', disabled: 'disabled', value: '-' };
 					}
 
 					return {

--- a/client/my-sites/domains/components/form/country-select.jsx
+++ b/client/my-sites/domains/components/form/country-select.jsx
@@ -46,7 +46,6 @@ const CountrySelect = createReactClass( {
 		const countriesList = this.props.countriesList.get();
 		let options = [];
 		let { value } = this.props;
-		let dividerCount = 1;
 		value = value || '';
 
 		if ( isEmpty( countriesList ) ) {
@@ -58,17 +57,17 @@ const CountrySelect = createReactClass( {
 		} else {
 			options = options.concat( [
 				{ key: 'select-country', label: this.props.translate( 'Select Country' ), value: '' },
-				{ key: 'divider' + dividerCount, label: '', disabled: 'disabled', value: '-' },
+				{ key: 'divider1', label: '', disabled: 'disabled', value: '-' },
 			] );
 
 			options = options.concat(
 				countriesList.map( ( country, index ) => {
 					if ( isEmpty( country.code ) ) {
-						return { key: 'divider' + ++dividerCount, label: '', disabled: 'disabled', value: '-' };
+						return { key: index, label: '', disabled: 'disabled', value: '-' };
 					}
 
 					return {
-						key: `country-select-${ index }-${ country.code }`,
+						key: index,
 						label: country.name,
 						value: country.code,
 					};


### PR DESCRIPTION
This is a current warning I'm seeing from `CountrySelect` in the checkout cc form:
```
Warning: Encountered two children with the same key, `divider2`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
```

This started happening with D10369-code where we added another divider.

