### PR TITLE
Domains: Add domain_name to the `calypso_domain_registration` tracks event

### DIFF
--- a/client/my-sites/checkout/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/checkout/checkout/transaction-steps-mixin.jsx
@@ -130,6 +130,7 @@ const TransactionStepsMixin = {
 
 		cartItems.getDomainRegistrations( cart ).forEach( function( cartItem ) {
 			analytics.tracks.recordEvent( 'calypso_domain_registration', {
+				domain_name: cartItem.meta,
 				domain_tld: getTld( cartItem.meta ),
 				success: success,
 			} );


### PR DESCRIPTION
It turned out that we don't track the actual domain name via `calypso_domain_registration` tracks event, and we need that so we can assemble a list of domains registered using a certain suggestion API.

We will use another event in order to do that for the current running tests but let's track the domain_name in case we need to do that in the future.