### PR TITLE
Add option to skip the notices middleware

### DIFF
--- a/client/state/notices/actions.js
+++ b/client/state/notices/actions.js
@@ -11,6 +11,7 @@ const { uniqueId } = impureLodash;
  * Internal dependencies
  */
 import { NOTICE_CREATE, NOTICE_REMOVE } from 'state/action-types';
+import { extendAction } from 'state/utils';
 
 export function removeNotice( noticeId ) {
 	return {
@@ -44,3 +45,8 @@ export const errorNotice = createNotice.bind( null, 'is-error' );
 export const infoNotice = createNotice.bind( null, 'is-info' );
 export const warningNotice = createNotice.bind( null, 'is-warning' );
 export const plainNotice = createNotice.bind( null, 'is-plain' );
+
+// Higher-order action creator: modify the wrapped creator to return actions with the
+// `notices.skip` meta, so that it's ignored by the notices middleware.
+export const withoutNotice = actionCreator => ( ...args ) =>
+	extendAction( actionCreator( ...args ), { meta: { notices: { skip: true } } } );

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { truncate, includes } from 'lodash';
+import { get, truncate, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -358,7 +358,7 @@ export const handlers = {
  */
 
 export default ( { dispatch, getState } ) => next => action => {
-	if ( handlers.hasOwnProperty( action.type ) ) {
+	if ( ! get( action, 'meta.notices.skip' ) && handlers.hasOwnProperty( action.type ) ) {
 		handlers[ action.type ]( dispatch, action, getState );
 	}
 

--- a/client/state/notices/test/middleware.js
+++ b/client/state/notices/test/middleware.js
@@ -24,7 +24,7 @@ import {
 	POST_RESTORE_FAILURE,
 	POST_SAVE_SUCCESS,
 } from 'state/action-types';
-import { successNotice } from 'state/notices/actions';
+import { successNotice, withoutNotice } from 'state/notices/actions';
 import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'middleware', () => {
@@ -45,15 +45,21 @@ describe( 'middleware', () => {
 			delete handlers.DUMMY_TYPE;
 		} );
 
+		const dummyCreator = target => ( { type: 'DUMMY_TYPE', target } );
+
 		test( 'should trigger the observer corresponding to the dispatched action type', () => {
-			noticesMiddleware( store )( noop )( { type: 'DUMMY_TYPE', target: 'World' } );
+			noticesMiddleware( store )( noop )( dummyCreator( 'World' ) );
 
 			expect( store.dispatch ).to.have.been.calledWithMatch( {
 				type: NOTICE_CREATE,
-				notice: {
-					text: 'Hello World',
-				},
+				notice: { text: 'Hello World' },
 			} );
+		} );
+
+		test( 'should not trigger the observer when meta.notices.skip is set to true', () => {
+			noticesMiddleware( store )( noop )( withoutNotice( dummyCreator )( 'World' ) );
+
+			expect( store.dispatch ).to.not.have.been.called;
 		} );
 	} );
 


### PR DESCRIPTION
There is a notices middleware that intercepts actions like `POST_SAVE_SUCCESS` and displays a global notice about a successful post save.

Sometimes we don't want these notices displayed, because our component has its own UI for presenting this information. For example, I'm working on one such thing in #23090.

Enter the `withoutNotice` helper. It wraps any action creator and adds a `meta.notices.skip` flag to the created action. The middleware then skips the notice when it sees this flag.

`withoutNotice` is a higher-order action creator: it takes an action creator as argument and returns a new action creator. Very convenient for `connect` calls like this: 
```js
import { trashPost } from 'state/posts/actions';
import { withoutNotice } from 'state/notices/actions';

connect( null, {
  trashPost: withoutNotice( trashPost )
} )( MyComponent );
```

**How to test:**
It's not used anywhere yet, there is a unit test.