### PR TITLE
JP Remote Install: Link to Calypso manual install

### DIFF
--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -24,7 +24,7 @@ import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import MainWrapper from './main-wrapper';
 import Spinner from 'components/spinner';
 import { addCalypsoEnvQueryArg } from './utils';
-import { externalRedirect } from 'lib/route';
+import { addQueryArgs, externalRedirect } from 'lib/route';
 import { jetpackRemoteInstall } from 'state/jetpack-remote-install/actions';
 import { getJetpackRemoteInstallErrorCode, isJetpackRemoteInstallComplete } from 'state/selectors';
 import { getConnectingSite } from 'state/jetpack-connect/selectors';
@@ -183,10 +183,15 @@ export class OrgCredentialsForm extends Component {
 	}
 
 	footerLink() {
-		const { translate } = this.props;
+		const { siteToConnect, translate } = this.props;
+		const manualInstallUrl = addQueryArgs(
+			{ url: siteToConnect },
+			'/jetpack/connect/instructions'
+		);
+
 		return (
 			<LoggedOutFormLinks>
-				<LoggedOutFormLinkItem href="https://jetpack.com/support/installing-jetpack/">
+				<LoggedOutFormLinkItem href={ manualInstallUrl }>
 					{ translate( 'Install Jetpack manually' ) }
 				</LoggedOutFormLinkItem>
 				<HelpButton label={ 'Get help connecting your site' } />


### PR DESCRIPTION
Change the "Install Jetpack Manually" link to point to /jetpack/connect/instructions, giving specific instructions for the connecting site, rather than the generic instructions at jetpack.com.

## Testing

* Build this branch locally and visit http://calypso.localhost:3000/jetpack/connect
* Enter the URL of a .org site without Jetpack installed
* On the credentials entering screen, click the "Install Jetpack manually" link
* You should be taken to the Calypso instructions, and the instructions should link properly to the .org site
