### PR TITLE
SectionNav: Replace noticon with gridicon

### DIFF
--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -8,6 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { isEqual, includes } from 'lodash';
+import Gridicon from 'gridicons';
 
 /**
  * Internal Dependencies
@@ -63,6 +64,7 @@ class SectionNav extends Component {
 		return (
 			<div className="section-nav__mobile-header" onClick={ this.toggleMobileOpenState }>
 				<span className="section-nav__mobile-header-text">{ this.props.selectedText }</span>
+				<Gridicon icon="chevron-down" size={ 18 } />
 			</div>
 		);
 	};

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -53,15 +53,15 @@
 	font-weight: 600;
 	cursor: pointer;
 
-	&:after {
-		@include noticon( '\f431', 20px );
-		line-height: 16px;
-		color: rgba( $gray, 0.5 );
+	.gridicons-chevron-down {
+		fill: $gray-darken-20;
+		flex-shrink: 0;
+		transition: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 	}
 
 	.section-nav.is-open & {
-		&:after {
-			content: '\f432';
+		.gridicons-chevron-down {
+			transform: rotate( -180deg );
 		}
 	}
 
@@ -80,6 +80,7 @@
 
 .section-nav__mobile-header-text {
 	width: 0;
+	margin-right: 4px;
 	flex: 1 0 auto;
 	overflow: hidden;
 	white-space: nowrap;

--- a/client/components/section-nav/test/index.jsx
+++ b/client/components/section-nav/test/index.jsx
@@ -50,7 +50,7 @@ describe( 'section-nav', () => {
 
 			panelElem = sectionNav.props.children[ 1 ];
 			headerElem = sectionNav.props.children[ 0 ];
-			headerTextElem = headerElem.props.children;
+			headerTextElem = headerElem.props.children[ 0 ];
 			text = headerTextElem.props.children;
 		} );
 


### PR DESCRIPTION
This replaces the down chevron noticon used in the mobile section nav. It uses the same color and animation as the SelectDropdown component.

Before
![screen shot 2018-03-15 at 10 10 45 am](https://user-images.githubusercontent.com/618551/37472478-2d42dc62-283a-11e8-8446-0d3c89cdf740.png)

After 
![screen shot 2018-03-15 at 10 10 37 am](https://user-images.githubusercontent.com/618551/37472486-32ef8e80-283a-11e8-8efd-a3e8635f6b93.png)
