### PR TITLE
The extendAction helper should return thunks that accept getState

### DIFF
--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -89,6 +89,37 @@ describe( 'utils', () => {
 			} );
 		} );
 
+		test( 'should return an updated action thunk, accepting also getState', () => {
+			const dispatch = spy();
+			const getState = () => ( { selectedSiteId: 42 } );
+
+			const action = extendAction(
+				( thunkDispatch, thunkGetState ) =>
+					thunkDispatch( {
+						type: 'ACTION_TEST',
+						siteId: thunkGetState().selectedSiteId,
+						meta: {
+							preserve: true,
+						},
+					} ),
+				{
+					meta: {
+						ok: true,
+					},
+				}
+			);
+
+			action( dispatch, getState );
+			expect( dispatch ).to.have.been.calledWithExactly( {
+				type: 'ACTION_TEST',
+				siteId: 42,
+				meta: {
+					preserve: true,
+					ok: true,
+				},
+			} );
+		} );
+
 		test( 'should return an updated nested action thunk, merging data on dispatch', () => {
 			const dispatch = spy();
 			const action = extendAction(

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -6,7 +6,6 @@
 
 import validator from 'is-my-json-valid';
 import {
-	flow,
 	forEach,
 	get,
 	includes,
@@ -16,7 +15,6 @@ import {
 	merge,
 	omit,
 	omitBy,
-	partialRight,
 	reduce,
 } from 'lodash';
 import { combineReducers as combine } from 'redux'; // eslint-disable-line wpcalypso/import-no-redux-combine-reducers
@@ -205,9 +203,9 @@ export function extendAction( action, data ) {
 		return merge( {}, action, data );
 	}
 
-	return dispatch => {
-		const newDispatch = flow( partialRight( extendAction, data ), dispatch );
-		return action( newDispatch );
+	return ( dispatch, getState ) => {
+		const newDispatch = a => dispatch( extendAction( a, data ) );
+		return action( newDispatch, getState );
 	};
 }
 


### PR DESCRIPTION
Thunks accept `getState` as a second parameter. `extendAction` should pass the function through, instead of passing `undefined` to the inner thunk.

I also converted the very functional point-free code with `flow` and `partialRight` to a simple arrow function -- I find that much easier to read. And it's even a few characters shorter now :tada: