### PR TITLE
Stats: Make `PageViewTracker` aware of the the selected site

### DIFF
--- a/client/lib/analytics/page-view-tracker/index.jsx
+++ b/client/lib/analytics/page-view-tracker/index.jsx
@@ -48,8 +48,11 @@ export class PageViewTracker extends React.Component {
 		clearTimeout( this.state.timer );
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		if ( this.props.selectedSiteId !== nextProps.selectedSiteId ) {
+	componentDidUpdate( prevProps ) {
+		if (
+			prevProps.path !== this.props.path ||
+			prevProps.selectedSiteId !== this.props.selectedSiteId
+		) {
 			this.queuePageView();
 		}
 	}

--- a/client/lib/analytics/page-view-tracker/index.jsx
+++ b/client/lib/analytics/page-view-tracker/index.jsx
@@ -84,7 +84,8 @@ export class PageViewTracker extends React.Component {
 const mapStateToProps = state => {
 	const selectedSiteId = getSelectedSiteId( state );
 	const selectedSiteSlug = getSiteSlug( state, selectedSiteId );
-	const currentSlug = getSiteFragment( get( window, 'location.pathname', '' ) );
+	const currentSlug =
+		typeof window === 'undefined' ? '' : getSiteFragment( get( window, 'location.pathname', '' ) );
 	const hasSelectedSiteLoaded = ! currentSlug || currentSlug === selectedSiteSlug;
 	return {
 		hasSelectedSiteLoaded,

--- a/client/lib/analytics/page-view-tracker/index.jsx
+++ b/client/lib/analytics/page-view-tracker/index.jsx
@@ -7,7 +7,7 @@
 import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { flowRight, get, noop } from 'lodash';
+import { flowRight, get, isNumber, noop } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -86,7 +86,12 @@ const mapStateToProps = state => {
 	const selectedSiteSlug = getSiteSlug( state, selectedSiteId );
 	const currentSlug =
 		typeof window === 'undefined' ? '' : getSiteFragment( get( window, 'location.pathname', '' ) );
-	const hasSelectedSiteLoaded = ! currentSlug || currentSlug === selectedSiteSlug;
+
+	const hasSelectedSiteLoaded =
+		! currentSlug ||
+		( isNumber( currentSlug ) && currentSlug === selectedSiteId ) ||
+		currentSlug === selectedSiteSlug;
+
 	return {
 		hasSelectedSiteLoaded,
 		selectedSiteId,

--- a/client/lib/analytics/page-view-tracker/index.jsx
+++ b/client/lib/analytics/page-view-tracker/index.jsx
@@ -59,11 +59,11 @@ export class PageViewTracker extends React.Component {
 	}
 
 	queuePageView = () => {
-		const { delay = 0, path, recorder = noop, isSelectedSiteLoaded, title } = this.props;
+		const { delay = 0, path, recorder = noop, hasSelectedSiteLoaded, title } = this.props;
 
 		debug( `Queuing Page View: "${ title }" at "${ path }" with ${ delay }ms delay` );
 
-		if ( ! isSelectedSiteLoaded || this.state.timer ) {
+		if ( ! hasSelectedSiteLoaded || this.state.timer ) {
 			return;
 		}
 

--- a/client/lib/analytics/page-view-tracker/test/index.jsx
+++ b/client/lib/analytics/page-view-tracker/test/index.jsx
@@ -27,7 +27,15 @@ describe( 'PageViewTracker', () => {
 	test( 'should immediately fire off event when given no delay', () => {
 		const recorder = spy();
 
-		mount( <PageViewTracker path="/test" title="test" recorder={ recorder } /> );
+		mount(
+			<PageViewTracker
+				path="/test"
+				title="test"
+				recorder={ recorder }
+				selectSiteId={ 12345678 }
+				sitesLoaded
+			/>
+		);
 
 		expect( recorder ).to.have.been.calledOnce;
 	} );
@@ -35,7 +43,16 @@ describe( 'PageViewTracker', () => {
 	test( 'should wait for the delay before firing off the event', () => {
 		const recorder = spy();
 
-		mount( <PageViewTracker delay={ 500 } path="/test" title="test" recorder={ recorder } /> );
+		mount(
+			<PageViewTracker
+				delay={ 500 }
+				path="/test"
+				title="test"
+				recorder={ recorder }
+				selectSiteId={ 12345678 }
+				sitesLoaded
+			/>
+		);
 
 		expect( recorder ).to.not.have.been.called;
 
@@ -47,7 +64,15 @@ describe( 'PageViewTracker', () => {
 	test( 'should pass the appropriate event information', () => {
 		const recorder = spy();
 
-		mount( <PageViewTracker path="/test" title="test" recorder={ recorder } /> );
+		mount(
+			<PageViewTracker
+				path="/test"
+				title="test"
+				recorder={ recorder }
+				selectSiteId={ 12345678 }
+				sitesLoaded
+			/>
+		);
 
 		expect( recorder ).to.have.been.calledWith( '/test', 'test' );
 	} );

--- a/client/lib/analytics/page-view-tracker/test/index.jsx
+++ b/client/lib/analytics/page-view-tracker/test/index.jsx
@@ -28,13 +28,7 @@ describe( 'PageViewTracker', () => {
 		const recorder = spy();
 
 		mount(
-			<PageViewTracker
-				path="/test"
-				title="test"
-				recorder={ recorder }
-				selectSiteId={ 12345678 }
-				sitesLoaded
-			/>
+			<PageViewTracker path="/test" title="test" recorder={ recorder } hasSelectedSiteLoaded />
 		);
 
 		expect( recorder ).to.have.been.calledOnce;
@@ -49,8 +43,7 @@ describe( 'PageViewTracker', () => {
 				path="/test"
 				title="test"
 				recorder={ recorder }
-				selectSiteId={ 12345678 }
-				sitesLoaded
+				hasSelectedSiteLoaded
 			/>
 		);
 
@@ -65,13 +58,7 @@ describe( 'PageViewTracker', () => {
 		const recorder = spy();
 
 		mount(
-			<PageViewTracker
-				path="/test"
-				title="test"
-				recorder={ recorder }
-				selectSiteId={ 12345678 }
-				sitesLoaded
-			/>
+			<PageViewTracker path="/test" title="test" recorder={ recorder } hasSelectedSiteLoaded />
 		);
 
 		expect( recorder ).to.have.been.calledWith( '/test', 'test' );

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -62,6 +62,7 @@ export const siteComments = ( context, next ) => {
 
 	context.primary = (
 		<CommentsManagement
+			analyticsPath="/comments/:status/:site"
 			changePage={ changePage( path ) }
 			page={ pageNumber }
 			siteFragment={ siteFragment }
@@ -90,6 +91,7 @@ export const postComments = ( context, next ) => {
 
 	context.primary = (
 		<CommentsManagement
+			analyticsPath="/comments/:status/:site/:post"
 			changePage={ changePage( path ) }
 			page={ pageNumber }
 			postId={ postId }

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -31,6 +31,7 @@ import { NEWEST_FIRST } from './constants';
 
 export class CommentsManagement extends Component {
 	static propTypes = {
+		analyticsPath: PropTypes.string,
 		comments: PropTypes.array,
 		page: PropTypes.number,
 		postId: PropTypes.number,
@@ -61,6 +62,7 @@ export class CommentsManagement extends Component {
 
 	render() {
 		const {
+			analyticsPath,
 			changePage,
 			page,
 			postId,
@@ -78,7 +80,7 @@ export class CommentsManagement extends Component {
 		return (
 			<Main className="comments" wideLayout>
 				{ showJetpackUpdateScreen && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
-				<PageViewTracker path="/comments/:status/:site" title="Comments" />
+				<PageViewTracker path={ analyticsPath } title="Comments" />
 				<DocumentHead title={ translate( 'Comments' ) } />
 				{ showJetpackUpdateScreen && (
 					<EmptyContent


### PR DESCRIPTION
Contribute to fixing #23108 
H/t @rodrigoi for pointing me to `PageViewTracker`. 🙇 

Make `PageViewTracker` aware of the sites list and the selected site.

- If the selected site change, dispatch a new `analytics.pageView`, because the user switched site (e.g. passed from `comments/foo.wordpress.com` to `comments/bar.wordpress.com`), and requires a new page view tracking.

- Prevent dispatching a page view tracking if the sites list is empty. It means that it's too early in the loading of the page. The tracking will be automatically dispatched when the sites list updates, because the selected site will change (obtaining a value itself).

## Note

This PR is not enough for #23108.
On top of this, it will be required to replace all direct `analytics.pageView` calls with the `PageViewTracker` component.

## Context

Currently, the page view event tracking is dispatched immediately upon opening a page.
There are at least 2 cases where the tracks object contains an incorrect `blog_id` property:
- Calypso is loading uncached: the sites list is not ready yet and `selectedSiteId` is `null`.
- The user switches site: `analytics.pageView` is dispatched before the state update, and reports the previous `selectedSiteId`.

It might be possible to fix this with a centralized approach, but let's see if this is viable instead.

## Testing instructions

- Type `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );` to clear the cache.
- Type `localStorage.setItem('debug', 'calypso:analytics:tracks')` in the browser console to enable the debug.
- Load a page that uses `PageViewTracker`, for example the comments section: `comments/`.
- Make sure that there is a `calypso_page_view` event **without `blog_id`**, because the path defaulted to `comments/all`, and `blog_id: null` denotes All Sites.
- Pick a site and make sure there is a new page view event **including the correct `blog_id`**.
- Switch site and check that there is another page view event with the **new `blog_id`**.
- Now clear the cache and enable the debug again.
- Load a comments page with the site fragment (e.g. `comments/all/foo.wordpress.com`).
- Make sure the first (and only) page view event **contains the correct `blog_id`**.