### PR TITLE
Store: Add stats widget to the store dashboard

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
@@ -4,6 +4,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import config from 'config';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import page from 'page';
@@ -16,6 +17,7 @@ import DashboardWidget from 'woocommerce/components/dashboard-widget';
 import DashboardWidgetRow from 'woocommerce/components/dashboard-widget/row';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import ShareWidget from 'woocommerce/components/share-widget';
+import StatsWidget from './widgets/stats-widget';
 import { recordTrack } from 'woocommerce/lib/analytics';
 import QuerySettingsProducts from 'woocommerce/components/query-settings-products';
 import { getProductsSettingValue } from 'woocommerce/state/sites/settings/products/selectors';
@@ -44,6 +46,11 @@ class ManageNoOrdersView extends Component {
 
 	renderStatsWidget = () => {
 		const { site, translate } = this.props;
+
+		if ( config.isEnabled( 'woocommerce/extension-dashboard-stats-widget' ) ) {
+			return null;
+		}
+
 		const trackClick = () => {
 			recordTrack( 'calypso_woocommerce_dashboard_action_click', {
 				action: 'view-stats',
@@ -113,6 +120,7 @@ class ManageNoOrdersView extends Component {
 					{ this.renderStatsWidget() }
 					{ this.renderViewAndTestWidget() }
 				</DashboardWidgetRow>
+				{ config.isEnabled( 'woocommerce/extension-dashboard-stats-widget' ) && <StatsWidget /> }
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
@@ -33,6 +33,7 @@ import { getPaymentCurrencySettings } from 'woocommerce/state/sites/settings/gen
 import { getTotalReviews } from 'woocommerce/state/sites/reviews/selectors';
 import ShareWidget from 'woocommerce/components/share-widget';
 import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
+import StatsWidget from './widgets/stats-widget';
 
 class ManageOrdersView extends Component {
 	static propTypes = {
@@ -169,6 +170,8 @@ class ManageOrdersView extends Component {
 				</div>
 
 				<LabelsSetupNotice />
+
+				{ config.isEnabled( 'woocommerce/extension-dashboard-stats-widget' ) && <StatsWidget /> }
 
 				<DashboardWidgetRow>
 					{ this.possiblyRenderProcessOrdersWidget() }

--- a/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
@@ -153,6 +153,35 @@ class ManageOrdersView extends Component {
 		);
 	};
 
+	// TODO Remove this check once the dashboard stats widget is launched in production.
+	possiblyRenderReportsWidget = () => {
+		const { site, translate, orders } = this.props;
+
+		if ( config.isEnabled( 'woocommerce/extension-dashboard-stats-widget' ) ) {
+			return null;
+		}
+
+		return (
+			<DashboardWidget
+				className="dashboard__reports-widget"
+				image="/calypso/images/extensions/woocommerce/woocommerce-reports.svg"
+				imagePosition="left"
+				title={ translate( 'Reports' ) }
+			>
+				<p>
+					{ translate(
+						'See a detailed breakdown of how your store is doing on the stats screen.'
+					) }
+				</p>
+				<p>
+					<Button href={ getLink( '/store/stats/orders/week/:site', site ) }>
+						{ orders.length ? translate( 'View full reports' ) : translate( 'View reports' ) }
+					</Button>
+				</p>
+			</DashboardWidget>
+		);
+	};
+
 	render() {
 		const { site, translate, orders, user } = this.props;
 		return (
@@ -171,30 +200,13 @@ class ManageOrdersView extends Component {
 
 				<LabelsSetupNotice />
 
-				{ config.isEnabled( 'woocommerce/extension-dashboard-stats-widget' ) && <StatsWidget /> }
-
 				<DashboardWidgetRow>
 					{ this.possiblyRenderProcessOrdersWidget() }
 					{ this.possiblyRenderReviewsWidget() }
 				</DashboardWidgetRow>
 
-				<DashboardWidget
-					className="dashboard__reports-widget"
-					image="/calypso/images/extensions/woocommerce/woocommerce-reports.svg"
-					imagePosition="left"
-					title={ translate( 'Reports' ) }
-				>
-					<p>
-						{ translate(
-							'See a detailed breakdown of how your store is doing on the stats screen.'
-						) }
-					</p>
-					<p>
-						<Button href={ getLink( '/store/stats/orders/week/:site', site ) }>
-							{ orders.length ? translate( 'View full reports' ) : translate( 'View reports' ) }
-						</Button>
-					</p>
-				</DashboardWidget>
+				{ config.isEnabled( 'woocommerce/extension-dashboard-stats-widget' ) && <StatsWidget /> }
+				{ this.possiblyRenderReportsWidget() }
 
 				{ this.possiblyRenderShareWidget() }
 			</div>

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/index.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/index.js
@@ -1,0 +1,363 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component, Fragment } from 'react';
+import { bindActionCreators } from 'redux';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { moment, localize } from 'i18n-calypso';
+import { sortBy, find } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { dashboardListLimit } from 'woocommerce/app/store-stats/constants';
+import DashboardWidget from 'woocommerce/components/dashboard-widget';
+import { getLink } from 'woocommerce/lib/nav-utils';
+import { getPreference } from 'state/preferences/selectors';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import { getSiteStatsNormalizedData } from 'state/stats/lists/selectors';
+import { getQueries } from './queries';
+import {
+	getUnitPeriod,
+	getStartPeriod,
+	getDelta,
+	getDeltaFromData,
+	getEndPeriod,
+	getConversionRateData,
+} from 'woocommerce/app/store-stats/utils';
+import List from './list';
+import QueryPreferences from 'components/data/query-preferences';
+import QuerySiteStats from 'components/data/query-site-stats';
+import { savePreference } from 'state/preferences/actions';
+import SelectDropdown from 'components/select-dropdown';
+import Stat from './stat';
+
+class StatsWidget extends Component {
+	static propTypes = {
+		site: PropTypes.shape( {
+			name: PropTypes.string.isRequired,
+			slug: PropTypes.string.isRequired,
+		} ),
+		unit: PropTypes.string,
+		queries: PropTypes.object,
+		orderData: PropTypes.object,
+		referrerData: PropTypes.array,
+		topEarnersData: PropTypes.array,
+		visitorData: PropTypes.array,
+		productData: PropTypes.array,
+		saveDashboardUnit: PropTypes.func,
+	};
+
+	handleTimePeriodChange = option => {
+		const { saveDashboardUnit } = this.props;
+		saveDashboardUnit( option.value );
+	};
+
+	dateForDisplay = () => {
+		const { translate, unit } = this.props;
+
+		const localizedDate = moment( moment().format( 'YYYY-MM-DD' ) );
+		let formattedDate;
+		switch ( unit ) {
+			case 'week':
+				formattedDate = translate( '%(startDate)s - %(endDate)s', {
+					context: 'Date range for which stats are being displayed',
+					args: {
+						// LL is a date localized by momentjs
+						startDate: localizedDate
+							.startOf( 'week' )
+							.add( 1, 'd' )
+							.format( 'LL' ),
+						endDate: localizedDate
+							.endOf( 'week' )
+							.add( 1, 'd' )
+							.format( 'LL' ),
+					},
+				} );
+				break;
+
+			case 'month':
+				formattedDate = localizedDate.format( 'MMMM YYYY' );
+				break;
+
+			case 'year':
+				formattedDate = localizedDate.format( 'YYYY' );
+				break;
+
+			default:
+				// LL is a date localized by momentjs
+				formattedDate = localizedDate.format( 'LL' );
+		}
+
+		return formattedDate;
+	};
+
+	renderTitle = () => {
+		const { site, translate, unit } = this.props;
+
+		const options = [
+			{ value: 'day', label: 'day' },
+			{ value: 'week', label: 'week' },
+			{ value: 'month', label: 'month' },
+		];
+
+		const dateDisplay = this.dateForDisplay();
+
+		return (
+			<Fragment>
+				<span>
+					{ translate( '%(siteName)s in the last {{timePeriodSelector/}}', {
+						args: { siteName: site.name },
+						components: {
+							timePeriodSelector: (
+								<SelectDropdown
+									options={ options }
+									initialSelected={ unit }
+									onSelect={ this.handleTimePeriodChange }
+								/>
+							),
+						},
+						context:
+							'Store stats dashboard widget title. Example: "Your Site in the last day|week|month.".',
+					} ) }
+				</span>
+				<p>{ dateDisplay }</p>
+			</Fragment>
+		);
+	};
+
+	renderOrders = () => {
+		const { site, translate, unit, orderData, queries } = this.props;
+		const date = getEndPeriod( moment().format( 'YYYY-MM-DD' ), unit );
+		const delta =
+			( orderData &&
+				orderData.deltas &&
+				orderData.deltas.length &&
+				getDelta( orderData.deltas, date, 'orders' ) ) ||
+			{};
+		return (
+			<Stat
+				site={ site }
+				label={ translate( 'Orders' ) }
+				statType="statsOrders"
+				attribute="orders"
+				query={ queries.orderQuery }
+				data={ ( orderData && orderData.data ) || [] }
+				delta={ delta }
+				date={ date }
+				type="number"
+			/>
+		);
+	};
+
+	renderSales = () => {
+		const { site, translate, unit, orderData, queries } = this.props;
+		const date = getEndPeriod( moment().format( 'YYYY-MM-DD' ), unit );
+		const delta =
+			( orderData &&
+				orderData.deltas &&
+				orderData.deltas.length &&
+				getDelta( orderData.deltas, date, 'total_sales' ) ) ||
+			{};
+		return (
+			<Stat
+				site={ site }
+				label={ translate( 'Sales' ) }
+				statType="statsOrders"
+				query={ queries.orderQuery }
+				attribute="total_sales"
+				data={ ( orderData && orderData.data ) || [] }
+				delta={ delta }
+				date={ date }
+				type="currency"
+			/>
+		);
+	};
+
+	renderVisitors = () => {
+		const { site, translate, unit, visitorData, queries } = this.props;
+		const date = getStartPeriod( moment().format( 'YYYY-MM-DD' ), unit );
+		const delta = getDeltaFromData( visitorData, date, 'visitors', unit );
+		return (
+			<Stat
+				site={ site }
+				label={ translate( 'Visitors' ) }
+				data={ visitorData || [] }
+				delta={ delta }
+				date={ date }
+				statType="statsVisits"
+				query={ queries.visitorQuery }
+				attribute="visitors"
+				type="number"
+			/>
+		);
+	};
+
+	renderConversionRate = () => {
+		const { site, translate, unit, visitorData, orderData, queries } = this.props;
+		const date = getUnitPeriod( moment().format( 'YYYY-MM-DD' ), unit );
+		const data = getConversionRateData( visitorData, orderData.data, unit );
+		const delta = getDeltaFromData( data, date, 'conversionRate', unit );
+		return (
+			<Stat
+				site={ site }
+				label={ translate( 'Conversion rate' ) }
+				data={ data || [] }
+				delta={ delta }
+				date={ date }
+				statType="statsOrders"
+				query={ queries.orderQuery }
+				attribute="conversionRate"
+				type="percent"
+			/>
+		);
+	};
+
+	renderReferrers = () => {
+		const { site, translate, unit, referrerData, queries } = this.props;
+		const { referrerQuery } = queries;
+
+		const row = find( referrerData, d => d.date === referrerQuery.date );
+		const fetchedData =
+			( row && sortBy( row.data, r => -r.sales ).slice( 0, dashboardListLimit ) ) || [];
+
+		const values = [
+			{ key: 'referrer', title: translate( 'Referrer' ), format: 'text' },
+			{ key: 'product_views', title: translate( 'Referrals' ), format: 'text' },
+			{ key: 'sales', title: translate( 'Sales' ), format: 'currency' },
+		];
+
+		const emptyMessage =
+			'day' === unit
+				? translate(
+						'Data is being processed. Switch to the week or month view to see your latest referrers.'
+					)
+				: translate( 'No referral activity has been recorded for this time period.' );
+
+		return (
+			<List
+				site={ site }
+				statSlug="referrers"
+				statType="statsStoreReferrers"
+				unit={ unit }
+				values={ values }
+				query={ referrerQuery }
+				fetchedData={ fetchedData }
+				emptyMessage={ emptyMessage }
+			/>
+		);
+	};
+
+	renderProducts = () => {
+		const { site, translate, unit, topEarnersData, queries } = this.props;
+		const { topEarnersQuery } = queries;
+		const values = [
+			{ key: 'name', title: translate( 'Product' ), format: 'text' },
+			{ key: 'total', title: translate( 'Sales' ), format: 'currency' },
+		];
+
+		return (
+			<List
+				site={ site }
+				statSlug="products"
+				statType="statsTopEarners"
+				unit={ unit }
+				values={ values }
+				query={ topEarnersQuery }
+				fetchedData={ topEarnersData }
+				emptyMessage={ translate( 'No products have been sold in this time period.' ) }
+			/>
+		);
+	};
+
+	queryData = () => {
+		const { site, queries } = this.props;
+		const { orderQuery, topEarnersQuery, referrerQuery, visitorQuery } = queries;
+		return (
+			<Fragment>
+				<QueryPreferences />
+				<QuerySiteStats statType="statsOrders" siteId={ site.ID } query={ orderQuery } />
+				<QuerySiteStats statType="statsTopEarners" siteId={ site.ID } query={ topEarnersQuery } />
+				<QuerySiteStats statType="statsStoreReferrers" siteId={ site.ID } query={ referrerQuery } />
+				<QuerySiteStats statType="statsVisits" siteId={ site.ID } query={ visitorQuery } />
+			</Fragment>
+		);
+	};
+
+	render() {
+		const { site, translate } = this.props;
+		return (
+			<div className="stats-widget">
+				{ this.queryData() }
+				<DashboardWidget title={ this.renderTitle() }>
+					<div className="stats-widget__boxes">
+						{ this.renderOrders() }
+						{ this.renderSales() }
+						{ this.renderVisitors() }
+						{ this.renderConversionRate() }
+						{ this.renderReferrers() }
+						{ this.renderProducts() }
+					</div>
+
+					<div className="stats-widget__footer">
+						<span>
+							{ translate(
+								"You can view more detailed stats and reports on your site's main dashboard."
+							) }
+						</span>
+						<a href={ getLink( '/store/stats/orders/day/:site', site ) }>
+							{ translate( 'View full stats' ) }
+						</a>
+					</div>
+				</DashboardWidget>
+			</div>
+		);
+	}
+}
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+	const unit = getPreference( state, 'store-dashboardStatsWidgetUnit' );
+
+	const queries = getQueries( unit );
+	const { orderQuery, topEarnersQuery, referrerQuery, visitorQuery } = queries;
+
+	const orderData = getSiteStatsNormalizedData( state, site.ID, 'statsOrders', orderQuery );
+	const visitorData = getSiteStatsNormalizedData( state, site.ID, 'statsVisits', visitorQuery );
+	const topEarnersData = getSiteStatsNormalizedData(
+		state,
+		site.ID,
+		'statsTopEarners',
+		topEarnersQuery
+	);
+	const referrerData = getSiteStatsNormalizedData(
+		state,
+		site.ID,
+		'statsStoreReferrers',
+		referrerQuery
+	);
+
+	return {
+		site,
+		unit,
+		queries,
+		orderData,
+		referrerData,
+		topEarnersData,
+		visitorData,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			saveDashboardUnit: value => savePreference( 'store-dashboardStatsWidgetUnit', value ),
+		},
+		dispatch
+	);
+}
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( StatsWidget ) );

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/list.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/list.js
@@ -1,0 +1,71 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getLink } from 'woocommerce/lib/nav-utils';
+import List from 'woocommerce/app/store-stats/store-stats-list';
+import Module from 'woocommerce/app/store-stats/store-stats-module';
+
+const StatsWidgetList = ( {
+	site,
+	translate,
+	unit,
+	values,
+	statSlug,
+	statType,
+	emptyMessage,
+	fetchedData,
+	query,
+} ) => {
+	return (
+		<div className="stats-widget__box-contents stats-type-list">
+			<Module
+				siteId={ site.ID }
+				emptyMessage={ emptyMessage }
+				query={ query }
+				statType={ statType }
+				fetchedData={ fetchedData }
+			>
+				<List
+					siteId={ site.ID }
+					values={ values }
+					query={ query }
+					statType={ statType }
+					fetchedData={ fetchedData }
+				/>
+			</Module>
+
+			{ fetchedData.length > 0 && (
+				<div className="stats-widget__more">
+					<a href={ getLink( `/store/stats/${ statSlug }/${ unit }/:site`, site ) }>
+						{ translate( 'More' ) }
+					</a>
+				</div>
+			) }
+		</div>
+	);
+};
+
+StatsWidgetList.propTypes = {
+	site: PropTypes.shape( {
+		id: PropTypes.number,
+		slug: PropTypes.string,
+	} ),
+	unit: PropTypes.string.isRequired,
+	values: PropTypes.array.isRequired,
+	statSlug: PropTypes.string.isRequired,
+	statType: PropTypes.string.isRequired,
+	emptyMessage: PropTypes.string.isRequired,
+	query: PropTypes.object,
+	fetchedData: PropTypes.array,
+};
+
+export default localize( StatsWidgetList );

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/list.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/list.js
@@ -5,25 +5,22 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { getLink } from 'woocommerce/lib/nav-utils';
 import List from 'woocommerce/app/store-stats/store-stats-list';
 import Module from 'woocommerce/app/store-stats/store-stats-module';
 
 const StatsWidgetList = ( {
 	site,
-	translate,
-	unit,
 	values,
-	statSlug,
 	statType,
 	emptyMessage,
 	fetchedData,
 	query,
+	viewLink,
+	viewText,
 } ) => {
 	return (
 		<div className="stats-widget__box-contents stats-type-list">
@@ -43,13 +40,15 @@ const StatsWidgetList = ( {
 				/>
 			</Module>
 
-			{ fetchedData.length > 0 && (
-				<div className="stats-widget__more">
-					<a href={ getLink( `/store/stats/${ statSlug }/${ unit }/:site`, site ) }>
-						{ translate( 'More' ) }
-					</a>
-				</div>
-			) }
+			{ ( viewLink &&
+				fetchedData &&
+				Array.isArray( fetchedData ) &&
+				fetchedData.length && (
+					<div className="stats-widget__more">
+						<a href={ viewLink }>{ viewText }</a>
+					</div>
+				) ) ||
+				null }
 		</div>
 	);
 };
@@ -61,11 +60,12 @@ StatsWidgetList.propTypes = {
 	} ),
 	unit: PropTypes.string.isRequired,
 	values: PropTypes.array.isRequired,
-	statSlug: PropTypes.string.isRequired,
 	statType: PropTypes.string.isRequired,
 	emptyMessage: PropTypes.string.isRequired,
 	query: PropTypes.object,
 	fetchedData: PropTypes.array,
+	viewLink: PropTypes.string.isRequired,
+	viewText: PropTypes.string.isRequired,
 };
 
-export default localize( StatsWidgetList );
+export default StatsWidgetList;

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/queries.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/queries.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+import { moment } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getUnitPeriod, getStartDate } from 'woocommerce/app/store-stats/utils';
+import { UNITS, dashboardListLimit } from 'woocommerce/app/store-stats/constants';
+
+export const getQueries = unit => {
+	const baseQuery = {
+		unit: unit,
+		date: getUnitPeriod( getStartDate( moment().format( 'YYYY-MM-DD' ), unit ), unit ),
+	};
+
+	const orderQuery = {
+		...baseQuery,
+		quantity: UNITS[ unit ].quantity,
+	};
+
+	const referrerQuery = {
+		...baseQuery,
+		quantity: 1,
+	};
+
+	const topEarnersQuery = {
+		...baseQuery,
+		date: getUnitPeriod( moment().format( 'YYYY-MM-DD' ), unit ),
+		limit: dashboardListLimit,
+	};
+
+	const visitorQuery = {
+		...baseQuery,
+		date: moment().format( 'YYYY-MM-DD' ),
+		quantity: UNITS[ unit ].quantity,
+	};
+
+	return {
+		orderQuery,
+		referrerQuery,
+		topEarnersQuery,
+		visitorQuery,
+	};
+};

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/stat.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/stat.js
@@ -12,7 +12,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import Delta from 'woocommerce/components/delta';
-import formatCurrency from 'lib/format-currency';
+import { formatValue } from 'woocommerce/app/store-stats/utils';
 import { isRequestingSiteStatsForQuery } from 'state/stats/lists/selectors';
 import Sparkline from 'woocommerce/components/d3/sparkline';
 import StatsModulePlaceholder from 'my-sites/stats/stats-module/placeholder';
@@ -28,7 +28,7 @@ class StatsWidgetStat extends Component {
 		type: PropTypes.string.isRequired,
 		data: PropTypes.array.isRequired,
 		date: PropTypes.string.isRequired,
-		delta: PropTypes.object.isRequired,
+		delta: PropTypes.oneOfType( [ PropTypes.object, PropTypes.array ] ).isRequired,
 	};
 
 	renderDelta = () => {
@@ -54,23 +54,10 @@ class StatsWidgetStat extends Component {
 		);
 	};
 
-	renderValue = ( value, data ) => {
-		const { type } = this.props;
-		switch ( type ) {
-			case 'currency':
-				return formatCurrency( value, data.currency );
-			case 'percent':
-				return value + '%';
-			case 'number':
-			default:
-				return Math.round( value * 100 ) / 100;
-		}
-	};
-
 	render() {
-		const { data, site, date, attribute, label, requesting } = this.props;
+		const { data, site, date, attribute, label, requesting, type } = this.props;
 
-		if ( requesting || ! site.ID || ! data.length ) {
+		if ( requesting || ! site.ID || ! data || ! data.length ) {
 			return (
 				<div className="stats-widget__box-contents stats-type-stat">
 					<StatsModulePlaceholder isLoading />
@@ -92,7 +79,7 @@ class StatsWidgetStat extends Component {
 					<span className="stats-widget__box-label">{ label }</span>
 					<div className="stats-widget__box-value-and-delta">
 						<span className="stats-widget__box-value">
-							{ this.renderValue( value, data[ index ] ) }
+							{ formatValue( value, type, data[ index ].currency ) }
 						</span>
 						{ this.renderDelta() }
 					</div>

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/stat.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/stat.js
@@ -1,0 +1,117 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { findIndex } from 'lodash';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Delta from 'woocommerce/components/delta';
+import formatCurrency from 'lib/format-currency';
+import { isRequestingSiteStatsForQuery } from 'state/stats/lists/selectors';
+import Sparkline from 'woocommerce/components/d3/sparkline';
+import StatsModulePlaceholder from 'my-sites/stats/stats-module/placeholder';
+
+class StatsWidgetStat extends Component {
+	static propTypes = {
+		site: PropTypes.shape( {
+			id: PropTypes.number,
+			slug: PropTypes.string,
+		} ),
+		label: PropTypes.string.isRequired,
+		attribute: PropTypes.string.isRequired,
+		type: PropTypes.string.isRequired,
+		data: PropTypes.array.isRequired,
+		date: PropTypes.string.isRequired,
+		delta: PropTypes.object.isRequired,
+	};
+
+	renderDelta = () => {
+		const { delta } = this.props;
+		if ( ! delta || ( ! delta.classes && ! delta.direction ) ) {
+			return null;
+		}
+
+		if ( delta.classes ) {
+			return <Delta value={ delta.value } className={ delta.classes.join( ' ' ) } />;
+		}
+
+		const deltaValue =
+			delta.direction === 'is-undefined-increase'
+				? '-'
+				: Math.abs( Math.round( delta.percentage_change * 100 ) );
+
+		return (
+			<Delta
+				value={ `${ deltaValue }%` }
+				className={ `${ delta.favorable } ${ delta.direction }` }
+			/>
+		);
+	};
+
+	renderValue = ( value, data ) => {
+		const { type } = this.props;
+		switch ( type ) {
+			case 'currency':
+				return formatCurrency( value, data.currency );
+			case 'percent':
+				return value + '%';
+			case 'number':
+			default:
+				return Math.round( value * 100 ) / 100;
+		}
+	};
+
+	render() {
+		const { data, site, date, attribute, label, requesting } = this.props;
+
+		if ( requesting || ! site.ID || ! data.length ) {
+			return (
+				<div className="stats-widget__box-contents stats-type-stat">
+					<StatsModulePlaceholder isLoading />
+				</div>
+			);
+		}
+
+		const index = findIndex( data, d => d.period === date );
+		if ( ! data[ index ] ) {
+			return <div className="stats-widget__box-contents stats-type-stat" />;
+		}
+
+		const value = data[ index ][ attribute ];
+		const timeSeries = data.map( row => +row[ attribute ] );
+
+		return (
+			<div className="stats-widget__box-contents stats-type-stat">
+				<div className="stats-widget__box-data">
+					<span className="stats-widget__box-label">{ label }</span>
+					<div className="stats-widget__box-value-and-delta">
+						<span className="stats-widget__box-value">
+							{ this.renderValue( value, data[ index ] ) }
+						</span>
+						{ this.renderDelta() }
+					</div>
+				</div>
+				<div className="stats-widget__box-sparkline">
+					<Sparkline
+						aspectRatio={ 3 }
+						data={ timeSeries }
+						highlightIndex={ index }
+						maxHeight={ 50 }
+					/>
+				</div>
+			</div>
+		);
+	}
+}
+
+export default connect( ( state, { site, query, statType } ) => {
+	return {
+		requesting: isRequestingSiteStatsForQuery( state, site.ID, statType, query ),
+	};
+} )( StatsWidgetStat );

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
@@ -32,6 +32,7 @@
 	.stats-widget__footer {
 		display: flex;
 		justify-content: space-between;
+		align-items: center;
 
 		span {
 			color: $gray-text-min;

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
@@ -6,6 +6,10 @@
 		margin-left: 8px;
 	}
 
+	.select-dropdown__options {
+		text-align: left;
+	}
+
 	.card {
 		padding: 0;
 	}

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
@@ -1,0 +1,128 @@
+.stats-widget {
+
+	.select-dropdown {
+		display: inline-flex;
+		flex-direction: row;
+		margin-left: 8px;
+	}
+
+	.card {
+		padding: 0;
+	}
+
+	.dashboard-widget__title, .stats-widget__footer {
+		padding: 16px;
+		@include breakpoint( '>480px' ) {
+			padding: 24px;
+		}
+	}
+
+	.dashboard-widget__title {
+		border-bottom: 1px solid $gray-lighten-30;
+
+		p {
+			margin-top: 16px;
+		}
+	}
+
+	.stats-widget__footer {
+		display: flex;
+		justify-content: space-between;
+
+		span {
+			color: $gray-text-min;
+			font-size: 14px;
+		}
+	}
+
+	.stats-widget__boxes {
+		display: flex;
+		flex-wrap: wrap;
+		margin-top: -8px;
+	}
+
+	.stats-widget__box-label, .table-heading .table-item__cell-title, .table.is-compact-table .table-heading {
+		font-size: 16px;
+		font-weight: 600;
+	}
+
+	.table.is-compact-table .table-item {
+		font-size: 14px;
+		color: $gray-darken-20;
+	}
+
+	.table.is-compact-table .table-heading:nth-child(3), .table.is-compact-table .table-item:nth-child(3) {
+		margin-left: 32px;
+	}
+
+	.stats-widget__box-contents {
+		max-width: 50%;
+		min-width: 50%;
+		box-sizing: border-box;
+		border-bottom: 1px solid $gray-lighten-30;
+		padding: 32px;
+		text-align: left;
+
+		&.stats-type-stat {
+			display: flex;
+			height: 120px;
+
+			.stats-module__placeholder {
+				margin: 0 auto;
+				margin-top: -40px;
+			}
+		}
+
+		&.stats-type-list {
+			height: 200px;
+		}
+
+
+		.stats-widget__box-data, .stats-widget__box-sparkline {
+			width: 50%;
+		}
+
+		.stats-widget__box-value {
+			color: $gray-darken-20;
+			font-size: 2rem;
+			font-weight: 400;
+		}
+
+		.delta {
+			margin: 0x;
+			margin-left: 4px;
+		}
+
+		.store-stats-module, .stats-widget__more {
+			margin-left: -16px;
+		}
+	}
+
+	.stats-widget__box-value-and-delta {
+		display: flex;
+	}
+
+	.stats-widget__box-contents:nth-child( odd ) {
+		border-right: 1px solid $gray-lighten-30;
+	}
+
+	.store-stats-module .card {
+		box-shadow: none;
+		.table-row {
+			&:hover {
+				background: inherit;
+				.table-item__cell-title:after {
+					background: none;
+				}
+			}
+		}
+	}
+
+	.stats-widget__more {
+		text-align: left;
+		padding: 0 8px 0 16px;
+		font-size: 14px;
+		margin-top: -14px;
+	}
+
+}

--- a/client/extensions/woocommerce/app/store-stats/constants.js
+++ b/client/extensions/woocommerce/app/store-stats/constants.js
@@ -129,3 +129,5 @@ export const chartTabs = [
 	{ label: translate( 'Orders' ), attr: 'orders', type: 'number' },
 	{ label: translate( 'Average Order Value' ), attr: 'avg_order_value', type: 'currency' },
 ];
+
+export const dashboardListLimit = 3;

--- a/client/extensions/woocommerce/app/store-stats/store-stats-list/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-list/index.js
@@ -47,10 +47,14 @@ const StoreStatsList = ( { data, values } ) => {
 StoreStatsList.propTypes = {
 	data: PropTypes.array.isRequired,
 	values: PropTypes.array.isRequired,
+	fetchedData: PropTypes.oneOfType( [ PropTypes.array, PropTypes.object ] ),
 };
 
-export default connect( ( state, { siteId, statType, query } ) => {
+export default connect( ( state, { siteId, statType, query, fetchedData } ) => {
+	const data = fetchedData
+		? fetchedData
+		: getSiteStatsNormalizedData( state, siteId, statType, query );
 	return {
-		data: getSiteStatsNormalizedData( state, siteId, statType, query ),
+		data,
 	};
 } )( StoreStatsList );

--- a/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
@@ -28,6 +28,7 @@ class StoreStatsModule extends Component {
 		siteId: PropTypes.number,
 		statType: PropTypes.string,
 		query: PropTypes.object,
+		fetchedData: PropTypes.oneOfType( [ PropTypes.array, PropTypes.object ] ),
 	};
 
 	state = {
@@ -71,8 +72,10 @@ class StoreStatsModule extends Component {
 	}
 }
 
-export default connect( ( state, { siteId, statType, query } ) => {
-	const statsData = getSiteStatsNormalizedData( state, siteId, statType, query );
+export default connect( ( state, { siteId, statType, query, fetchedData } ) => {
+	const statsData = fetchedData
+		? fetchedData
+		: getSiteStatsNormalizedData( state, siteId, statType, query );
 	return {
 		data: statType === 'statsOrders' ? statsData.data : statsData,
 		requesting: isRequestingSiteStatsForQuery( state, siteId, statType, query ),

--- a/client/extensions/woocommerce/app/store-stats/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/utils.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { find, includes } from 'lodash';
+import { find, includes, forEach, findIndex, round } from 'lodash';
 import classnames from 'classnames';
 import { moment } from 'i18n-calypso';
 
@@ -64,23 +64,33 @@ export function calculateDelta( item, previousItem, attr, unit ) {
 }
 
 /**
- * Given a startDate query parameter, determine which date to send the backend on a request for data.
- * Calculate a queryDate as the first date in each block of periods counting back from today. The number
+ * Calculate a date as the first date in each block of periods counting back from today. The number
  * of periods in a block is determined in the UNITS constants config.
+ *
+ * @param {string} date - Date to calculate from
+ * @param {string} unit - Unit to use in calculation
+ * @return {string} - YYYY-MM-DD format of the date to be queried
+ */
+export function getStartDate( date, unit ) {
+	const unitConfig = UNITS[ unit ];
+	const today = moment();
+	const startDate = moment( date ); // Defaults to today if startDate undefined
+	const duration = moment.duration( today - startDate )[ unitConfig.durationFn ]();
+	const validDuration = duration > 0 ? duration : 0;
+	const unitQuantity = unitConfig.quantity;
+	const periods = Math.floor( validDuration / unitQuantity ) * unitQuantity;
+	return today.subtract( periods, unitConfig.label ).format( 'YYYY-MM-DD' );
+}
+
+/**
+ * Given a startDate query parameter, determine which date to send the backend on a request for data.
  *
  * @param {object} context - Object supplied by page function
  * @return {string} - YYYY-MM-DD format of the date to be queried
  */
 export function getQueryDate( context ) {
 	const { unit } = context.params;
-	const unitConfig = UNITS[ unit ];
-	const today = moment();
-	const startDate = moment( context.query.startDate ); // Defaults to today if startDate undefined
-	const duration = moment.duration( today - startDate )[ unitConfig.durationFn ]();
-	const validDuration = duration > 0 ? duration : 0;
-	const unitQuantity = unitConfig.quantity;
-	const periods = Math.floor( validDuration / unitQuantity ) * unitQuantity;
-	return today.subtract( periods, unitConfig.label ).format( 'YYYY-MM-DD' );
+	return getStartDate( context.query.startDate, unit );
 }
 
 /**
@@ -110,6 +120,24 @@ export function getEndPeriod( date, unit ) {
 				.format( 'YYYY-MM-DD' )
 		: moment( date )
 				.endOf( unit )
+				.format( 'YYYY-MM-DD' );
+}
+
+/**
+ * Given a full date YYYY-MM-DD and unit ('day', 'week', 'month', 'year') return the first date
+ * for the period formatted as YYYY-MM-DD
+ *
+ * @param {string} date - string date in YYYY-MM-DD format
+ * @param {string} unit - string representing unit required for API eg. ('day', 'week', 'month', 'year')
+ * @return {string} - YYYY-MM-DD format of the date to be queried
+ */
+export function getStartPeriod( date, unit ) {
+	return unit === 'week'
+		? moment( date )
+				.startOf( 'isoWeek' )
+				.format( 'YYYY-MM-DD' )
+		: moment( date )
+				.startOf( unit )
 				.format( 'YYYY-MM-DD' );
 }
 
@@ -144,4 +172,60 @@ export function formatValue( value, format, code ) {
 export function getDelta( deltas, selectedDate, stat ) {
 	const selectedDeltas = find( deltas, item => item.period === selectedDate );
 	return selectedDeltas[ stat ];
+}
+
+/**
+ * Given a date, an array of data, and a stat, return a delta object for the specific stat.
+ *
+ * @param {array} data - an array of API data, must contain at least 3 rows
+ * @param {string} selectedDate - string of date in 'YYYY-MM-DD'
+ * @param {string} stat - string of stat to be referenced
+ * @param {string} unit - unit/period format for the data provided
+ * @return {object} - Object containing data from calculateDelta
+ */
+export function getDeltaFromData( data, selectedDate, stat, unit ) {
+	if ( data.length < 3 ) {
+		return {};
+	}
+
+	let delta = {};
+	let previousItem = false;
+
+	forEach( data, function( item ) {
+		if ( previousItem ) {
+			if ( item.period === selectedDate ) {
+				delta = calculateDelta( item, previousItem, stat, unit );
+			}
+			previousItem = item;
+		} else {
+			previousItem = item;
+		}
+	} );
+
+	return delta;
+}
+
+/**
+ * Given visitor data and order data, get a list conversion rate by period.
+ *
+ * @param {array} visitorData - an array of API data from the 'visits' stat endpoint
+ * @param {array} orderData -  an array of API data from the orders endpoint
+ * @param {string} unit - unit/period format for the data provided
+ * @return {object} - Object containing data from calculateDelta
+ */
+export function getConversionRateData( visitorData, orderData, unit ) {
+	return visitorData.map( visitorRow => {
+		const datePeriod = getEndPeriod( visitorRow.period, unit );
+		const unitPeriod = getUnitPeriod( visitorRow.period, unit );
+		const index = findIndex( orderData, d => d.period === datePeriod );
+		const orders = orderData[ index ] && orderData[ index ].orders;
+
+		if ( visitorRow.visitors > 0 && orderData[ index ] ) {
+			return {
+				period: unitPeriod,
+				conversionRate: round( orders / visitorRow.visitors * 100, 2 ),
+			};
+		}
+		return { period: unitPeriod, conversionRate: 0 };
+	} );
 }

--- a/client/extensions/woocommerce/app/store-stats/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/utils.js
@@ -6,7 +6,7 @@
 
 import { find, includes, forEach, findIndex, round } from 'lodash';
 import classnames from 'classnames';
-import { moment } from 'i18n-calypso';
+import { moment, translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -155,6 +155,8 @@ export function formatValue( value, format, code ) {
 			return formatCurrency( value, code );
 		case 'number':
 			return Math.round( value * 100 ) / 100;
+		case 'percent':
+			return translate( '%(percentage)s%% ', { args: { percentage: value }, context: 'percent' } );
 		case 'text':
 		default:
 			return value;
@@ -171,7 +173,7 @@ export function formatValue( value, format, code ) {
  */
 export function getDelta( deltas, selectedDate, stat ) {
 	const selectedDeltas = find( deltas, item => item.period === selectedDate );
-	return selectedDeltas[ stat ];
+	return ( selectedDeltas && selectedDeltas[ stat ] ) || [];
 }
 
 /**
@@ -184,10 +186,9 @@ export function getDelta( deltas, selectedDate, stat ) {
  * @return {object} - Object containing data from calculateDelta
  */
 export function getDeltaFromData( data, selectedDate, stat, unit ) {
-	if ( data.length < 3 ) {
+	if ( ! data || ! Array.isArray( data ) || data.length < 3 ) {
 		return {};
 	}
-
 	let delta = {};
 	let previousItem = false;
 

--- a/client/extensions/woocommerce/components/dashboard-widget/index.js
+++ b/client/extensions/woocommerce/components/dashboard-widget/index.js
@@ -130,7 +130,7 @@ DashboardWidget.propTypes = {
 	imageFlush: PropTypes.bool,
 	imagePosition: PropTypes.oneOf( [ 'bottom', 'left', 'right', 'top' ] ),
 	onSettingsClose: PropTypes.func,
-	title: PropTypes.string,
+	title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
 	settingsPanel: PropTypes.element,
 	width: PropTypes.oneOf( [ 'half', 'full', 'third', 'two-thirds' ] ),
 };

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -53,6 +53,8 @@
 	@import 'components/store-address/style';
 	@import 'components/table/style';
 
+	@import 'app/dashboard/widgets/stats-widget/style';
+
 	@import 'woocommerce-services/style';
 
 	.main {

--- a/client/state/preferences/constants.js
+++ b/client/state/preferences/constants.js
@@ -12,4 +12,5 @@ export const DEFAULT_PREFERENCE_VALUES = {
 	editorAdvancedVisible: false,
 	editorConfirmationDisabledSites: [],
 	colorScheme: 'default',
+	'store-dashboardStatsWidgetUnit': 'week',
 };

--- a/client/state/preferences/schema.js
+++ b/client/state/preferences/schema.js
@@ -75,5 +75,9 @@ export const remoteValuesSchema = {
 			type: 'string',
 			enum: [ 'default', 'light', 'dark' ],
 		},
+		'store-dashboardStatsWidgetUnit': {
+			type: 'string',
+			enum: [ 'day', 'week', 'month' ],
+		},
 	},
 };

--- a/config/development.json
+++ b/config/development.json
@@ -179,6 +179,7 @@
 		"webpack/hot-loader": false,
 		"webpack/persistent-caching": false,
 		"woocommerce/extension-dashboard": true,
+		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-orders-create": true,
 		"woocommerce/extension-orders-edit": true,

--- a/config/production.json
+++ b/config/production.json
@@ -128,6 +128,7 @@
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"woocommerce/extension-dashboard": true,
+		"woocommerce/extension-dashboard-stats-widget": false,
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-orders-create": true,
 		"woocommerce/extension-orders-edit": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -132,6 +132,7 @@
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"woocommerce/extension-dashboard": true,
+		"woocommerce/extension-dashboard-stats-widget": false,
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-orders-create": true,
 		"woocommerce/extension-orders-edit": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -149,6 +149,7 @@
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"woocommerce/extension-dashboard": true,
+		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-orders-create": true,
 		"woocommerce/extension-orders-edit": true,


### PR DESCRIPTION
This PR implements a stats widget on the dashboard. See p90Yrv-mi-p2.

It is wrapped behind a new feature flag, enabled in development and wpcalypso. 

To Test:
* Run `npm run test-client client/extensions/woocommerce` and make sure all tests pass.
* Go to `http://calypso.localhost:3000/store/:site` on a site with some orders. Test switching the unit (day, week, month). Refresh and make sure the selection persists.
* Verify the different stats/lists load and display correctly.
* If you don’t have a test site with a lot of data, you can force the widget to display another site as an A12.
	* Find a live site by going to Live Tracks view in MC and then search for `calypso_woocommerce_order_received`.  Find an event and expand it. Copy the blogid.
	* Open `client/extensions/woocommerce/app/dashboard/widgets/stats-widget/index.js`
	* Replace `const site = getSelectedSiteWithFallback( state );` with something like `const site = { ID: BLOGID, slug: '', name: 'Test Site' };`.
	* Refresh

<img width="844" alt="screen shot 2018-03-15 at 1 26 56 am" src="https://user-images.githubusercontent.com/689165/37486137-d09c248a-284a-11e8-8aac-29b4b485aa5a.png">

Apologies for the PR size. About 200 lines are tests, and 130 CSS. I could split out the utils and tests (~300 lines) — but I figured it would be easier to review with context.