### PR TITLE
WordAds: display WordAds card on plans page for atomic sites

### DIFF
--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -32,8 +32,7 @@ export function canAccessWordads( site ) {
 export function isWordadsInstantActivationEligible( site ) {
 	if (
 		( isBusiness( site.plan ) || isPremium( site.plan ) ) &&
-		userCan( 'activate_wordads', site ) &&
-		! site.jetpack
+		userCan( 'activate_wordads', site )
 	) {
 		return true;
 	}


### PR DESCRIPTION
The WordAds card on the My Plan page is currently missing for Atomic sites.

This code was originally written pre-atomic sites.
Now we need to remove the check that excludes Jetpack sites from being instant activation eligible (which controls whether this card is displayed).

**Testing:**
The WordAds card is titled "Easily monetize your site".
Visit the My Plan page (`http://calypso.localhost:3000/plans/my-plan/`)

1. Without the patch, the WordAds card should not be visible on atomic sites.
2. With the patch, the WordAds card _should_ be visible :)
