### PR TITLE
Security: Verify phone number given when selecting 2FA by app.

### DIFF
--- a/client/me/security-2fa-enable/buttons.jsx
+++ b/client/me/security-2fa-enable/buttons.jsx
@@ -1,0 +1,83 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import FormButton from 'components/forms/form-button';
+import FormButtonsBar from 'components/forms/form-buttons-bar';
+import analytics from 'lib/analytics';
+
+class Security2faEnableButtons extends React.Component {
+	handleEnableClick = () => {
+		analytics.ga.recordEvent( 'Me', 'Clicked On Enable 2fa Button', 'method', this.state.method );
+	};
+	handleCancelClick = () => {
+		analytics.ga.recordEvent(
+			'Me',
+			'Clicked On Step2 Cancel 2fa Button',
+			'method',
+			this.state.method
+		);
+		this.props.onCancel( event );
+	};
+	handleResendClick = () => {
+		analytics.ga.recordEvent( 'Me', 'Clicked On Resend SMS Button' );
+		this.onResendCode( event );
+	};
+	handleUseSMSClick = () => {
+		analytics.ga.recordEvent( 'Me', 'Clicked On Enable SMS Use SMS Button' );
+		this.onVerifyBySMS( event );
+	};
+	render() {
+		return (
+			<FormButtonsBar className="security-2fa-enable__buttons-bar">
+				<FormButton
+					className="security-2fa-enable__verify"
+					disabled={ this.getFormDisabled() }
+					onclick={ this.handleEnableClick }
+				>
+					{ this.state.submittingCode
+						? this.props.translate( 'Enabling…', {
+								context: 'A button label used during Two-Step setup.',
+							} )
+						: this.props.translate( 'Enable', {
+								context: 'A button label used during Two-Step setup.',
+							} ) }
+				</FormButton>
+
+				<FormButton
+					className="security-2fa-enable__cancel"
+					isPrimary={ false }
+					onclick={ this.handleCancelClick }
+				>
+					{ this.props.translate( 'Cancel' ) }
+				</FormButton>
+
+				{ 'sms' === this.state.method ? (
+					<FormButton
+						disabled={ ! this.state.smsRequestsAllowed }
+						isPrimary={ false }
+						onclick={ this.handleResendClick }
+					>
+						{ this.props.translate( 'Resend Code', {
+							context: 'A button label to let a user get the SMS code sent again.',
+						} ) }
+					</FormButton>
+				) : (
+					<FormButton isPrimary={ false } onclick={ this.handleUseSMSClick }>
+						{ this.props.translate( 'Use SMS', {
+							context: 'A button label to let a user switch to enabling Two-Step by SMS.',
+						} ) }
+					</FormButton>
+				) }
+			</FormButtonsBar>
+		);
+	}
+}
+
+export default Security2faEnableButtons;

--- a/client/me/security-2fa-sms-settings/index.jsx
+++ b/client/me/security-2fa-sms-settings/index.jsx
@@ -112,6 +112,9 @@ const Security2faSMSSettings = createReactClass( {
 			return;
 		}
 
+		// This direct setting of the phone number needs to be replaced by something like
+		// what happens in Account Recovery (SMS code is sent if number is not already saved on file):
+		// API call to POST https://public-api.wordpress.com/rest/v1.1/me/account-recovery/phone
 		this.props.userSettings.updateSetting( 'two_step_sms_phone_number', phoneNumber.phoneNumber );
 		this.props.userSettings.updateSetting( 'two_step_sms_country', phoneNumber.countryCode );
 


### PR DESCRIPTION
Even when selecting to use an app for 2FA, we require a user to give us a backup phone number. Currently, this number is simply saved straight into the user attributes, with no verification. This PR ensures that if the given number is unverified, the user has to go through the verification process, just like adding a number under Account Recovery.

Fixes #31 .