### PR TITLE
Add short store NUX

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -298,6 +298,12 @@ if ( config.isEnabled( 'signup/atomic-store-flow' ) ) {
 		description: 'Signup flow for creating an online store with an Atomic site',
 		lastModified: '2018-01-24',
 	};
+	flows[ 'store-woo' ] = {
+		steps: [ 'domains-store', 'plans-store-nux', 'user' ],
+		destination: getSiteDestination,
+		description: 'Short signup flow for creating an online store with an Atomic site',
+		lastModified: '2018-03-15',
+	};
 }
 
 if ( config.isEnabled( 'signup/wpcc' ) ) {

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -36,6 +36,7 @@ export default {
 	'design-type-with-store': DesignTypeWithStoreComponent,
 	'design-type-with-store-nux': DesignTypeWithAtomicStoreComponent,
 	domains: DomainsStepComponent,
+	'domains-store': DomainsStepComponent,
 	'domain-only': DomainsStepComponent,
 	'domains-theme-preselected': DomainsStepComponent,
 	'jetpack-user': UserSignupComponent,

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -164,6 +164,17 @@ export default {
 		delayApiRequestUntilComplete: true,
 	},
 
+	'domains-store': {
+		stepName: 'domains',
+		apiRequestFunction: createSiteWithCart,
+		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
+		props: {
+			isDomainOnly: false,
+			forceDesignType: 'store',
+		},
+		delayApiRequestUntilComplete: true,
+	},
+
 	'domains-theme-preselected': {
 		stepName: 'domains-theme-preselected',
 		apiRequestFunction: createSiteWithCart,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -32,6 +32,7 @@ import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/an
 import { getCurrentUser, currentUserHasFlag } from 'state/current-user/selectors';
 import Notice from 'components/notice';
 import { getDesignType } from 'state/signup/steps/design-type/selectors';
+import { setDesignType } from 'state/signup/steps/design-type/actions';
 import { getDomainSearchPrefill } from 'state/signup/steps/domains/selectors';
 import { setDomainSearchPrefill } from 'state/signup/steps/domains/actions';
 import { abtest } from 'lib/abtest';
@@ -40,6 +41,7 @@ const productsList = productsListFactory();
 
 class DomainsStep extends React.Component {
 	static propTypes = {
+		forceDesignType: PropTypes.string,
 		domainsWithPlansOnly: PropTypes.bool,
 		flowName: PropTypes.string.isRequired,
 		goToNextStep: PropTypes.func.isRequired,
@@ -158,6 +160,7 @@ class DomainsStep extends React.Component {
 			{ domainItem }
 		);
 
+		this.props.setDesignType( this.getDesignType() );
 		this.props.goToNextStep();
 
 		// Start the username suggestion process.
@@ -225,7 +228,19 @@ class DomainsStep extends React.Component {
 	};
 
 	isDomainForAtomicSite = () => {
-		return 'store' === this.props.designType;
+		return 'store' === this.getDesignType();
+	};
+
+	getDesignType = () => {
+		if ( this.props.forceDesignType ) {
+			return this.props.forceDesignType;
+		}
+
+		if ( this.props.signupDependencies && this.props.signupDependencies.designType ) {
+			return this.props.signupDependencies.designType;
+		}
+
+		return this.props.designType;
 	};
 
 	domainForm = () => {
@@ -257,7 +272,7 @@ class DomainsStep extends React.Component {
 				showExampleSuggestions
 				surveyVertical={ this.props.surveyVertical }
 				suggestion={ suggestion }
-				designType={ this.props.signupDependencies && this.props.signupDependencies.designType }
+				designType={ this.getDesignType() }
 				onDomainSearchChange={ this.handleDomainSearchChange }
 			/>
 		);
@@ -414,5 +429,6 @@ export default connect(
 		recordAddDomainButtonClickInTransferDomain,
 		setDomainSearchPrefill,
 		submitDomainStepSelection,
+		setDesignType,
 	}
 )( localize( DomainsStep ) );


### PR DESCRIPTION
This is for users who are already logged in, and have indicated
they want a store.

To test:
1) Log in to WordPress.com.
2) Visit `/start/store-woo/`. You should see the domains NUX page.
3) Enter a domain name. The suggestions should contain only full domains -- not subdomains of WordPress.com:
<img width="1176" alt="screen shot 2018-03-15 at 4 41 38 pm" src="https://user-images.githubusercontent.com/15386509/37496454-cef2fb5c-286f-11e8-92ba-ea0bc45ceba9.png">

4) Select a domain name. You should then see the plans NUX page, with business as the only option:
<img width="1178" alt="screen shot 2018-03-15 at 4 41 49 pm" src="https://user-images.githubusercontent.com/15386509/37496460-d6668d54-286f-11e8-8dd2-7e1327d6d7d3.png">

5) Click "start with business". You will briefly see a waiting message:
<img width="1170" alt="screen shot 2018-03-15 at 4 42 57 pm" src="https://user-images.githubusercontent.com/15386509/37496485-ffddc256-286f-11e8-9a7a-aba36117a07b.png">

6) You will find yourself at the checkout page, with an itemization of what is being purchased. If you complete this process, you will find yourself looking at the store setup wizard.