### PR TITLE
Store: Stats: Add Referrer Page

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -13,16 +13,21 @@ import { moment, translate } from 'i18n-calypso';
 import AsyncLoad from 'components/async-load';
 import StatsPagePlaceholder from 'my-sites/stats/stats-page-placeholder';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { getQueryDate } from './utils';
+import { getQueryDate, getUnitPeriod } from './utils';
 import analytics from 'lib/analytics';
 import titlecase from 'to-title-case';
 import { recordTrack } from 'woocommerce/lib/analytics';
+import { UNITS } from './constants';
+import config from 'config';
 
 function isValidParameters( context ) {
 	const validParameters = {
 		type: [ 'orders', 'products', 'categories', 'coupons' ],
 		unit: [ 'day', 'week', 'month', 'year' ],
 	};
+	if ( config.isEnabled( 'woocommerce/extension-referrers' ) ) {
+		validParameters.type.push( 'referrers' );
+	}
 	return Object.keys( validParameters ).every( param =>
 		includes( validParameters[ param ], context.params[ param ] )
 	);
@@ -66,6 +71,9 @@ export default function StatsController( context, next ) {
 		case 'coupons':
 			tracksEvent = 'calypso_woocommerce_stats_coupons_page';
 			break;
+		case 'referrers':
+			tracksEvent = 'calypso_woocommerce_stats_referrers_page';
+			break;
 	}
 	if ( tracksEvent ) {
 		recordTrack( tracksEvent, {
@@ -75,24 +83,47 @@ export default function StatsController( context, next ) {
 		} );
 	}
 
-	const asyncComponent =
-		props.type === 'orders' ? (
-			<AsyncLoad
-				/* eslint-disable wpcalypso/jsx-classname-namespace */
-				placeholder={ <StatsPagePlaceholder className="woocommerce" /> }
-				/* eslint-enable wpcalypso/jsx-classname-namespace */
-				require="extensions/woocommerce/app/store-stats"
-				{ ...props }
-			/>
-		) : (
-			<AsyncLoad
-				/* eslint-disable wpcalypso/jsx-classname-namespace */
-				placeholder={ <StatsPagePlaceholder className="woocommerce" /> }
-				/* eslint-enable wpcalypso/jsx-classname-namespace */
-				require="extensions/woocommerce/app/store-stats/listview"
-				{ ...props }
-			/>
-		);
+	let asyncComponent;
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	const placeholder = <StatsPagePlaceholder className="woocommerce" />;
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
+
+	switch ( props.type ) {
+		case 'orders':
+			asyncComponent = (
+				<AsyncLoad
+					placeholder={ placeholder }
+					require="extensions/woocommerce/app/store-stats"
+					{ ...props }
+				/>
+			);
+			break;
+		case 'referrers':
+			const referrersQuery = {
+				unit: props.unit,
+				date: getUnitPeriod( props.queryDate, props.unit ),
+				quantity: UNITS[ props.unit ].quantity,
+			};
+			asyncComponent = (
+				<AsyncLoad
+					placeholder={ placeholder }
+					require="extensions/woocommerce/app/store-stats/referrers"
+					query={ referrersQuery }
+					{ ...props }
+				/>
+			);
+			break;
+		default:
+			asyncComponent = (
+				<AsyncLoad
+					placeholder={ placeholder }
+					require="extensions/woocommerce/app/store-stats/listview"
+					{ ...props }
+				/>
+			);
+			break;
+	}
+
 	context.primary = asyncComponent;
 	next();
 }

--- a/client/extensions/woocommerce/app/store-stats/listview.js
+++ b/client/extensions/woocommerce/app/store-stats/listview.js
@@ -6,25 +6,20 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import page from 'page';
 import { connect } from 'react-redux';
-import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import DatePicker from 'my-sites/stats/stats-date-picker';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getUnitPeriod } from './utils';
-import HeaderCake from 'components/header-cake';
 import JetpackColophon from 'components/jetpack-colophon';
 import List from './store-stats-list';
 import Main from 'components/main';
 import Module from './store-stats-module';
-import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
-import Intervals from 'blocks/stats-navigation/intervals';
 import { topProducts, topCategories, topCoupons } from 'woocommerce/app/store-stats/constants';
 import QuerySiteStats from 'components/data/query-site-stats';
+import StoreStatsPeriodNav from 'woocommerce/app/store-stats/store-stats-period-nav';
 
 const listType = {
 	products: topProducts,
@@ -43,19 +38,6 @@ class StoreStatsListView extends Component {
 		slug: PropTypes.string.isRequired,
 	};
 
-	goBack = () => {
-		const pathParts = this.props.path.split( '/' );
-		const queryString = this.props.querystring ? '?' + this.props.querystring : '';
-		const pathExtra = `${ pathParts[ pathParts.length - 2 ] }/${
-			pathParts[ pathParts.length - 1 ]
-		}${ queryString }`;
-		const defaultBack = `/store/stats/orders/${ pathExtra }`;
-
-		setTimeout( () => {
-			page.show( defaultBack );
-		} );
-	};
-
 	render() {
 		const { siteId, slug, selectedDate, type, unit } = this.props;
 		const unitSelectedDate = getUnitPeriod( selectedDate, unit );
@@ -66,34 +48,18 @@ class StoreStatsListView extends Component {
 		};
 		const statType = listType[ type ].statType;
 		return (
-			<Main className="store-stats__list-view woocommerce" wideLayout={ true }>
+			<Main className="store-stats__list-view woocommerce" wideLayout>
 				{ siteId && (
 					<QuerySiteStats statType={ statType } siteId={ siteId } query={ listviewQuery } />
 				) }
-				<HeaderCake onClick={ this.goBack }>{ listType[ type ].title }</HeaderCake>
-				<StatsPeriodNavigation
-					date={ selectedDate }
-					period={ unit }
-					url={ `/store/stats/${ type }/${ unit }/${ slug }` }
-				>
-					<DatePicker
-						period={ unit }
-						date={
-							unit === 'week'
-								? moment( selectedDate, 'YYYY-MM-DD' )
-										.subtract( 1, 'days' )
-										.format( 'YYYY-MM-DD' )
-								: selectedDate
-						}
-						query={ listviewQuery }
-						statsType={ statType }
-						showQueryDate
-					/>
-				</StatsPeriodNavigation>
-				<Intervals
-					selected={ unit }
-					pathTemplate={ `/store/stats/${ type }/{{ interval }}/${ slug }` }
-					standalone
+				<StoreStatsPeriodNav
+					type={ type }
+					selectedDate={ selectedDate }
+					unit={ unit }
+					slug={ slug }
+					query={ listviewQuery }
+					statType={ statType }
+					title={ listType[ type ].title }
 				/>
 				<Module
 					siteId={ siteId }

--- a/client/extensions/woocommerce/app/store-stats/referrers/helpers.js
+++ b/client/extensions/woocommerce/app/store-stats/referrers/helpers.js
@@ -1,0 +1,20 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { sortBy } from 'lodash';
+
+/**
+ * Sort Referrer data by sales DESC and optionally trim results
+ * @param {array} data - One unit's worth of data
+ * @param {number} [limit] - trim results to a certain length
+ * @returns {array} - The sorted and trimmed (if desired) array
+ */
+export function sortBySales( data, limit ) {
+	if ( ! Array.isArray( data ) ) {
+		throw new Error( 'Incorrect data structure applied to "sortBySales". Input must be an array' );
+	}
+	const computedLimit = limit || data.length;
+	return sortBy( data, d => -d.sales ).slice( 0, computedLimit );
+}

--- a/client/extensions/woocommerce/app/store-stats/referrers/index.js
+++ b/client/extensions/woocommerce/app/store-stats/referrers/index.js
@@ -1,0 +1,86 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { find } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import QuerySiteStats from 'components/data/query-site-stats';
+import { getSiteStatsNormalizedData } from 'state/stats/lists/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getUnitPeriod } from 'woocommerce/app/store-stats/utils';
+import StoreStatsPeriodNav from 'woocommerce/app/store-stats/store-stats-period-nav';
+import JetpackColophon from 'components/jetpack-colophon';
+import Main from 'components/main';
+import Module from 'woocommerce/app/store-stats/store-stats-module';
+import { sortBySales } from './helpers';
+
+const STAT_TYPE = 'statsStoreReferrers';
+
+const Referrers = ( { siteId, query, data, selectedDate, unit, slug, translate } ) => {
+	const unitSelectedDate = getUnitPeriod( selectedDate, unit );
+	const selectedData = find( data, d => d.date === unitSelectedDate ) || { data: [] };
+	const sortedData = sortBySales( selectedData.data );
+	return (
+		<Main wideLayout>
+			{ siteId && <QuerySiteStats statType={ STAT_TYPE } siteId={ siteId } query={ query } /> }
+			<StoreStatsPeriodNav
+				type="referrers"
+				selectedDate={ selectedDate }
+				unit={ unit }
+				slug={ slug }
+				query={ query }
+				statType={ STAT_TYPE }
+				title={ translate( 'Store Referrers' ) }
+			/>
+			<Module
+				siteId={ siteId }
+				emptyMessage={ translate( 'No referrers found' ) }
+				query={ query }
+				statType={ STAT_TYPE }
+			>
+				<table>
+					<tbody>
+						{ sortedData.map( d => (
+							<tr key={ d.referrer }>
+								<td>{ d.date }</td>
+								<td>{ d.referrer }</td>
+								<td>{ d.product_views }</td>
+								<td>{ d.add_to_carts }</td>
+								<td>{ d.product_purchases }</td>
+								<td>${ d.sales }</td>
+							</tr>
+						) ) }
+					</tbody>
+				</table>
+			</Module>
+			<JetpackColophon />
+		</Main>
+	);
+};
+
+Referrers.propTypes = {
+	siteId: PropTypes.number,
+	query: PropTypes.object.isRequired,
+	data: PropTypes.array.isRequired,
+	selectedDate: PropTypes.string,
+	unit: PropTypes.oneOf( [ 'day', 'week', 'month', 'year' ] ),
+	slug: PropTypes.string,
+};
+
+export default connect( ( state, { query } ) => {
+	const siteId = getSelectedSiteId( state );
+	return {
+		slug: getSelectedSiteSlug( state ),
+		siteId,
+		data: getSiteStatsNormalizedData( state, siteId, STAT_TYPE, query ),
+	};
+} )( localize( Referrers ) );

--- a/client/extensions/woocommerce/app/store-stats/referrers/test/helpers.js
+++ b/client/extensions/woocommerce/app/store-stats/referrers/test/helpers.js
@@ -1,0 +1,34 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { sortBySales } from '../helpers';
+
+describe( 'sortBySales', () => {
+	test( 'should return a sorted and trimmed array of referrer data', () => {
+		const data = [ { sales: 2 }, { sales: 1 }, { sales: 5 }, { sales: 4 }, { sales: 3 } ];
+		const sortedAndTrimmed = sortBySales( data, 3 );
+		assert.lengthOf( sortedAndTrimmed, 3 );
+		assert.deepEqual( sortedAndTrimmed.map( d => d.sales ), [ 5, 4, 3 ] );
+	} );
+
+	test( 'should return a sorted and untrimmed array if no limit is supplied', () => {
+		const data = [ { sales: 2 }, { sales: 1 }, { sales: 5 }, { sales: 4 }, { sales: 3 } ];
+		const sortedAndTrimmed = sortBySales( data );
+		assert.lengthOf( sortedAndTrimmed, data.length );
+	} );
+
+	test( 'should throw on an incorrect data structure input', () => {
+		const invalidData = {};
+		const fn = () => {
+			return sortBySales( invalidData );
+		};
+		assert.throws( fn );
+	} );
+} );

--- a/client/extensions/woocommerce/app/store-stats/store-stats-period-nav/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-period-nav/index.js
@@ -1,0 +1,74 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import HeaderCake from 'components/header-cake';
+import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
+import Intervals from 'blocks/stats-navigation/intervals';
+import DatePicker from 'my-sites/stats/stats-date-picker';
+
+const goBack = () => {
+	window && window.history.back();
+};
+
+const StoreStatsPeriodNav = ( {
+	type,
+	selectedDate,
+	unit,
+	slug,
+	moment,
+	query,
+	title,
+	statType,
+} ) => {
+	return (
+		<Fragment>
+			<HeaderCake onClick={ goBack }>{ title }</HeaderCake>
+			<StatsPeriodNavigation
+				date={ selectedDate }
+				period={ unit }
+				url={ `/store/stats/${ type }/${ unit }/${ slug }` }
+			>
+				<DatePicker
+					period={ unit }
+					date={
+						unit === 'week'
+							? moment( selectedDate, 'YYYY-MM-DD' )
+									.subtract( 1, 'days' )
+									.format( 'YYYY-MM-DD' )
+							: selectedDate
+					}
+					query={ query }
+					statType={ statType }
+					showQueryDate
+				/>
+			</StatsPeriodNavigation>
+			<Intervals
+				selected={ unit }
+				pathTemplate={ `/store/stats/referrers/{{ interval }}/${ slug }` }
+				standalone
+			/>
+		</Fragment>
+	);
+};
+
+StoreStatsPeriodNav.propTypes = {
+	type: PropTypes.string.isRequired,
+	selectedDate: PropTypes.string.isRequired,
+	unit: PropTypes.oneOf( [ 'day', 'week', 'month', 'year' ] ),
+	slug: PropTypes.string,
+	query: PropTypes.object.isRequired,
+	title: PropTypes.string,
+	statType: PropTypes.string.isRequired,
+};
+
+export default localize( StoreStatsPeriodNav );

--- a/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget/index.js
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { find, sortBy } from 'lodash';
+import { find } from 'lodash';
 import { max as d3Max } from 'd3-array';
 import { localize } from 'i18n-calypso';
 
@@ -21,6 +21,7 @@ import TableItem from 'woocommerce/components/table/table-item';
 import HorizontalBar from 'woocommerce/components/d3/horizontal-bar';
 import Card from 'components/card';
 import ErrorPanel from 'my-sites/stats/stats-error';
+import { sortBySales } from 'woocommerce/app/store-stats/referrers/helpers';
 
 class StoreStatsReferrerWidget extends Component {
 	static propTypes = {
@@ -75,7 +76,7 @@ class StoreStatsReferrerWidget extends Component {
 				</Card>
 			);
 		}
-		const sortedAndTrimmedData = sortBy( selectedData.data, d => -d.sales ).slice( 0, 5 );
+		const sortedAndTrimmedData = sortBySales( selectedData.data, 5 );
 		const extent = [ 0, d3Max( sortedAndTrimmedData.map( d => d.sales ) ) ];
 		const header = (
 			<TableRow isHeader>


### PR DESCRIPTION
## Add All Referrers Page 
This PR is an incremental addition to the All Referrers Page, which is behind a feature flag. None of this code will be accessible outside of development. This code adds the following:
* Route (behind a feature flag)
* Period Navigation
* Injected data to the page
* Wrap data in `<Module>` element
* Print data in a table (temporarily)

<img width="840" alt="screen shot 2018-03-19 at 1 48 57 pm" src="https://user-images.githubusercontent.com/1922453/37573396-50191e46-2b7c-11e8-8d1a-d4f015b4470a.png">

### Testing
* Test the link to Store Referrers page from Store Stats
* Make sure the navigation works (units, arrows to switch periods)
* See data loading and displayed in tabular form

### Following Pull Requests
* Create a search box to select a specific referrer
* Add a main chart


