### PR TITLE
Store: Remove a few unnecessary review config checks

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
@@ -4,7 +4,6 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import config from 'config';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
@@ -77,14 +76,8 @@ class ManageOrdersView extends Component {
 		if ( ! ordersLoaded ) {
 			this.props.fetchOrders( siteId );
 		}
-		// TODO This check can be removed when we launch reviews.
-		if ( config.isEnabled( 'woocommerce/extension-reviews' ) ) {
-			this.props.fetchReviews( siteId, { status: 'pending' } );
-		}
-	};
 
-	shouldShowPendingReviews = () => {
-		return config.isEnabled( 'woocommerce/extension-reviews' ) && this.props.pendingReviews;
+		this.props.fetchReviews( siteId, { status: 'pending' } );
 	};
 
 	possiblyRenderProcessOrdersWidget = () => {
@@ -97,7 +90,7 @@ class ManageOrdersView extends Component {
 			count: orders.length,
 		} );
 		const classes = classNames( 'dashboard__process-orders-container', {
-			'has-reviews': this.shouldShowPendingReviews(),
+			'has-reviews': this.props.pendingReviews,
 		} );
 		return (
 			<DashboardWidgetRow className={ classes }>
@@ -121,11 +114,12 @@ class ManageOrdersView extends Component {
 	};
 
 	possiblyRenderReviewsWidget = () => {
-		if ( ! this.shouldShowPendingReviews() ) {
+		const { site, pendingReviews, translate } = this.props;
+
+		if ( ! pendingReviews ) {
 			return null;
 		}
 
-		const { site, pendingReviews, translate } = this.props;
 		const countText = translate( '%d pending review', '%d pending reviews', {
 			args: [ pendingReviews ],
 			count: pendingReviews,

--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -5,7 +5,6 @@
  */
 
 import React, { Component } from 'react';
-import config from 'config';
 import i18n from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { trim, isNumber } from 'lodash';
@@ -117,7 +116,7 @@ export default class ProductFormDetailsCard extends Component {
 
 		let productReviewsWidget = null;
 
-		if ( isNumber( product.id ) && config.isEnabled( 'woocommerce/extension-reviews' ) ) {
+		if ( isNumber( product.id ) ) {
 			productReviewsWidget = <ProductReviewsWidget product={ product } />;
 		}
 

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -68,10 +68,7 @@ class StoreSidebar extends Component {
 		this.props.fetchSetupChoices( siteId );
 		this.props.fetchOrders( siteId );
 
-		// TODO This check can be removed when we launch reviews.
-		if ( config.isEnabled( 'woocommerce/extension-reviews' ) ) {
-			this.props.fetchReviews( siteId, { status: 'pending' } );
-		}
+		this.props.fetchReviews( siteId, { status: 'pending' } );
 
 		if ( ! productsLoaded ) {
 			this.props.fetchProducts( siteId, { page: 1 } );


### PR DESCRIPTION
This PR removes a few unnecessary `config` checks for the product reviews feature, now that it's been launched for awhile. I noticed some todos left over when working in the dashboard files.

To Test:
* Go to `http://calypso.localhost:3000/store/:site` with the full / hasOrders dashboard view. Make sure the pending widget displays correctly.
* Spot check the reviews menu item.
* Find a review and click through to the product. Make sure the ‘average rating’ box displays.