### PR TITLE
Query Manager: DeterministicStringify queries

### DIFF
--- a/client/lib/query-manager/key.js
+++ b/client/lib/query-manager/key.js
@@ -2,7 +2,8 @@
 /**
  * External dependencies
  */
-import { sortBy, toPairs, fromPairs, omitBy } from 'lodash';
+import deterministicStringify from 'json-stable-stringify';
+import { omitBy } from 'lodash';
 
 /**
  * QueryKey manages the serialization and deserialization of a query key for
@@ -66,9 +67,7 @@ export default class QueryKey {
 		// key ordering in the original object, to ensure that:
 		//
 		// QueryKey.stringify( { a: 1, b: 2 } ) === QueryKey.stringify( { b: 2, a: 1 } )
-		const stableQuery = sortBy( toPairs( prunedQuery ), pair => pair[ 0 ] );
-
-		return JSON.stringify( stableQuery );
+		return deterministicStringify( prunedQuery );
 	}
 
 	/**
@@ -78,6 +77,6 @@ export default class QueryKey {
 	 * @return {Object}     Query object
 	 */
 	static parse( key ) {
-		return this.omit( fromPairs( JSON.parse( key ) ) );
+		return this.omit( JSON.parse( key ) );
 	}
 }

--- a/client/lib/query-manager/paginated/test/key.js
+++ b/client/lib/query-manager/paginated/test/key.js
@@ -14,25 +14,25 @@ describe( 'PaginatedQueryKey', () => {
 		test( 'should return a JSON string of the object', () => {
 			const key = PaginatedQueryKey.stringify( { ok: true } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).to.equal( '{"ok":true}' );
 		} );
 
 		test( 'should omit pagination query parameters', () => {
 			const key = PaginatedQueryKey.stringify( { ok: true, page: 2 } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).to.equal( '{"ok":true}' );
 		} );
 	} );
 
 	describe( '.parse()', () => {
 		test( 'should return an object of the JSON string', () => {
-			const query = PaginatedQueryKey.parse( '[["ok",true]]' );
+			const query = PaginatedQueryKey.parse( '{"ok":true}' );
 
 			expect( query ).to.eql( { ok: true } );
 		} );
 
 		test( 'should omit pagination query parameters', () => {
-			const query = PaginatedQueryKey.parse( '[["ok",true],["page",2]]' );
+			const query = PaginatedQueryKey.parse( '{"ok":true,"page":2}' );
 
 			expect( query ).to.eql( { ok: true } );
 		} );

--- a/client/lib/query-manager/paginated/test/key.js
+++ b/client/lib/query-manager/paginated/test/key.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -14,13 +10,13 @@ describe( 'PaginatedQueryKey', () => {
 		test( 'should return a JSON string of the object', () => {
 			const key = PaginatedQueryKey.stringify( { ok: true } );
 
-			expect( key ).to.equal( '{"ok":true}' );
+			expect( key ).toBe( '{"ok":true}' );
 		} );
 
 		test( 'should omit pagination query parameters', () => {
 			const key = PaginatedQueryKey.stringify( { ok: true, page: 2 } );
 
-			expect( key ).to.equal( '{"ok":true}' );
+			expect( key ).toBe( '{"ok":true}' );
 		} );
 	} );
 
@@ -28,13 +24,13 @@ describe( 'PaginatedQueryKey', () => {
 		test( 'should return an object of the JSON string', () => {
 			const query = PaginatedQueryKey.parse( '{"ok":true}' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 
 		test( 'should omit pagination query parameters', () => {
 			const query = PaginatedQueryKey.parse( '{"ok":true,"page":2}' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 	} );
 } );

--- a/client/lib/query-manager/post/test/key.js
+++ b/client/lib/query-manager/post/test/key.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -14,25 +10,25 @@ describe( 'PostQueryKey', () => {
 		test( 'should return a JSON string of the object', () => {
 			const key = PostQueryKey.stringify( { ok: true } );
 
-			expect( key ).to.equal( '{"ok":true}' );
+			expect( key ).toBe( '{"ok":true}' );
 		} );
 
 		test( 'should omit default post query parameters', () => {
 			const key = PostQueryKey.stringify( { ok: true, type: 'post' } );
 
-			expect( key ).to.equal( '{"ok":true}' );
+			expect( key ).toBe( '{"ok":true}' );
 		} );
 
 		test( 'should omit null query values', () => {
 			const key = PostQueryKey.stringify( { ok: true, search: null } );
 
-			expect( key ).to.equal( '{"ok":true}' );
+			expect( key ).toBe( '{"ok":true}' );
 		} );
 
 		test( 'should omit undefined query values', () => {
 			const key = PostQueryKey.stringify( { ok: true, search: undefined } );
 
-			expect( key ).to.equal( '{"ok":true}' );
+			expect( key ).toBe( '{"ok":true}' );
 		} );
 	} );
 
@@ -40,19 +36,19 @@ describe( 'PostQueryKey', () => {
 		test( 'should return an object of the JSON string', () => {
 			const query = PostQueryKey.parse( '{"ok":true}' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 
 		test( 'should omit default post query parameters', () => {
 			const query = PostQueryKey.parse( '{"ok":true,"type":"post"}' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 
 		test( 'should omit null query values', () => {
 			const query = PostQueryKey.parse( '{"ok":true,"search":null}' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 	} );
 } );

--- a/client/lib/query-manager/post/test/key.js
+++ b/client/lib/query-manager/post/test/key.js
@@ -14,43 +14,43 @@ describe( 'PostQueryKey', () => {
 		test( 'should return a JSON string of the object', () => {
 			const key = PostQueryKey.stringify( { ok: true } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).to.equal( '{"ok":true}' );
 		} );
 
 		test( 'should omit default post query parameters', () => {
 			const key = PostQueryKey.stringify( { ok: true, type: 'post' } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).to.equal( '{"ok":true}' );
 		} );
 
 		test( 'should omit null query values', () => {
 			const key = PostQueryKey.stringify( { ok: true, search: null } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).to.equal( '{"ok":true}' );
 		} );
 
 		test( 'should omit undefined query values', () => {
 			const key = PostQueryKey.stringify( { ok: true, search: undefined } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).to.equal( '{"ok":true}' );
 		} );
 	} );
 
 	describe( '.parse()', () => {
 		test( 'should return an object of the JSON string', () => {
-			const query = PostQueryKey.parse( '[["ok",true]]' );
+			const query = PostQueryKey.parse( '{"ok":true}' );
 
 			expect( query ).to.eql( { ok: true } );
 		} );
 
 		test( 'should omit default post query parameters', () => {
-			const query = PostQueryKey.parse( '[["ok",true],["type","post"]]' );
+			const query = PostQueryKey.parse( '{"ok":true,"type":"post"}' );
 
 			expect( query ).to.eql( { ok: true } );
 		} );
 
 		test( 'should omit null query values', () => {
-			const query = PostQueryKey.parse( '[["ok",true],["search",null]]' );
+			const query = PostQueryKey.parse( '{"ok":true,"search":null}' );
 
 			expect( query ).to.eql( { ok: true } );
 		} );

--- a/client/lib/query-manager/term/test/key.js
+++ b/client/lib/query-manager/term/test/key.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -14,25 +10,25 @@ describe( 'TermQueryKey', () => {
 		test( 'should return a JSON string of the object', () => {
 			const key = TermQueryKey.stringify( { ok: true } );
 
-			expect( key ).to.equal( '{"ok":true}' );
+			expect( key ).toBe( '{"ok":true}' );
 		} );
 
 		test( 'should omit default post query parameters', () => {
 			const key = TermQueryKey.stringify( { ok: true, search: '' } );
 
-			expect( key ).to.equal( '{"ok":true}' );
+			expect( key ).toBe( '{"ok":true}' );
 		} );
 
 		test( 'should omit null query values', () => {
 			const key = TermQueryKey.stringify( { ok: true, search: null } );
 
-			expect( key ).to.equal( '{"ok":true}' );
+			expect( key ).toBe( '{"ok":true}' );
 		} );
 
 		test( 'should omit undefined query values', () => {
 			const key = TermQueryKey.stringify( { ok: true, search: undefined } );
 
-			expect( key ).to.equal( '{"ok":true}' );
+			expect( key ).toBe( '{"ok":true}' );
 		} );
 	} );
 
@@ -40,19 +36,19 @@ describe( 'TermQueryKey', () => {
 		test( 'should return an object of the JSON string', () => {
 			const query = TermQueryKey.parse( '{"ok":true}' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 
 		test( 'should omit default post query parameters', () => {
 			const query = TermQueryKey.parse( '{"ok":true,"search":""}' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 
 		test( 'should omit null query values', () => {
 			const query = TermQueryKey.parse( '{"ok":true,"search":null}' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 	} );
 } );

--- a/client/lib/query-manager/term/test/key.js
+++ b/client/lib/query-manager/term/test/key.js
@@ -14,43 +14,43 @@ describe( 'TermQueryKey', () => {
 		test( 'should return a JSON string of the object', () => {
 			const key = TermQueryKey.stringify( { ok: true } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).to.equal( '{"ok":true}' );
 		} );
 
 		test( 'should omit default post query parameters', () => {
 			const key = TermQueryKey.stringify( { ok: true, search: '' } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).to.equal( '{"ok":true}' );
 		} );
 
 		test( 'should omit null query values', () => {
 			const key = TermQueryKey.stringify( { ok: true, search: null } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).to.equal( '{"ok":true}' );
 		} );
 
 		test( 'should omit undefined query values', () => {
 			const key = TermQueryKey.stringify( { ok: true, search: undefined } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).to.equal( '{"ok":true}' );
 		} );
 	} );
 
 	describe( '.parse()', () => {
 		test( 'should return an object of the JSON string', () => {
-			const query = TermQueryKey.parse( '[["ok",true]]' );
+			const query = TermQueryKey.parse( '{"ok":true}' );
 
 			expect( query ).to.eql( { ok: true } );
 		} );
 
 		test( 'should omit default post query parameters', () => {
-			const query = TermQueryKey.parse( '[["ok",true],["search",""]]' );
+			const query = TermQueryKey.parse( '{"ok":true,"search":""}' );
 
 			expect( query ).to.eql( { ok: true } );
 		} );
 
 		test( 'should omit null query values', () => {
-			const query = TermQueryKey.parse( '[["ok",true],["search",null]]' );
+			const query = TermQueryKey.parse( '{"ok":true,"search":null}' );
 
 			expect( query ).to.eql( { ok: true } );
 		} );

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -31,7 +31,7 @@ describe( 'QueryManager', () => {
 					152: { ID: 152 },
 				},
 				queries: {
-					'[]': {
+					'{}': {
 						itemKeys: [ 152 ],
 						found: 1,
 					},

--- a/client/lib/query-manager/test/key.js
+++ b/client/lib/query-manager/test/key.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -16,7 +15,7 @@ describe( 'QueryKey', () => {
 			const original = deepFreeze( { ok: true } );
 			const pruned = QueryKey.omit( original );
 
-			expect( pruned ).to.equal( original );
+			expect( pruned ).toBe( original );
 		} );
 
 		test( 'should omit values matching default query of extending class', () => {
@@ -26,7 +25,7 @@ describe( 'QueryKey', () => {
 
 			const pruned = QueryKeyWithDefaults.omit( { ok: true, foo: null } );
 
-			expect( pruned ).to.eql( { foo: null } );
+			expect( pruned ).toEqual( { foo: null } );
 		} );
 
 		test( 'should omit null values if configured by extending class', () => {
@@ -36,7 +35,7 @@ describe( 'QueryKey', () => {
 
 			const pruned = QueryKeyWithNullOmission.omit( { ok: true, foo: null } );
 
-			expect( pruned ).to.eql( { ok: true } );
+			expect( pruned ).toEqual( { ok: true } );
 		} );
 	} );
 
@@ -44,7 +43,7 @@ describe( 'QueryKey', () => {
 		test( 'should return a JSON string of the object', () => {
 			const key = QueryKey.stringify( { ok: true } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).toBe( '[["ok",true]]' );
 		} );
 
 		test( 'should prune by omission behavior', () => {
@@ -55,14 +54,14 @@ describe( 'QueryKey', () => {
 
 			const key = QueryKeyWithOmission.stringify( { ok: true, foo: null } );
 
-			expect( key ).to.equal( '[]' );
+			expect( key ).toBe( '[]' );
 		} );
 
 		test( 'should return the same string for two objects with different property creation order', () => {
 			const original = QueryKey.stringify( { a: 1, b: 2 } );
 			const reversed = QueryKey.stringify( { b: 2, a: 1 } );
 
-			expect( original ).to.equal( reversed );
+			expect( original ).toBe( reversed );
 		} );
 	} );
 
@@ -70,7 +69,7 @@ describe( 'QueryKey', () => {
 		test( 'should return an object of the JSON string', () => {
 			const query = QueryKey.parse( '[["ok",true]]' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 
 		test( 'should prune by omission behavior', () => {
@@ -81,7 +80,7 @@ describe( 'QueryKey', () => {
 
 			const query = QueryKeyWithOmission.parse( '[["ok",true],["foo",null]]' );
 
-			expect( query ).to.eql( {} );
+			expect( query ).toEqual( {} );
 		} );
 	} );
 } );

--- a/client/lib/query-manager/test/key.js
+++ b/client/lib/query-manager/test/key.js
@@ -43,7 +43,7 @@ describe( 'QueryKey', () => {
 		test( 'should return a JSON string of the object', () => {
 			const key = QueryKey.stringify( { ok: true } );
 
-			expect( key ).toBe( '[["ok",true]]' );
+			expect( key ).toBe( '{"ok":true}' );
 		} );
 
 		test( 'should prune by omission behavior', () => {
@@ -54,7 +54,7 @@ describe( 'QueryKey', () => {
 
 			const key = QueryKeyWithOmission.stringify( { ok: true, foo: null } );
 
-			expect( key ).toBe( '[]' );
+			expect( key ).toBe( '{}' );
 		} );
 
 		test( 'should return the same string for two objects with different property creation order', () => {
@@ -67,7 +67,7 @@ describe( 'QueryKey', () => {
 
 	describe( '.parse()', () => {
 		test( 'should return an object of the JSON string', () => {
-			const query = QueryKey.parse( '[["ok",true]]' );
+			const query = QueryKey.parse( '{"ok":true}' );
 
 			expect( query ).toEqual( { ok: true } );
 		} );
@@ -78,7 +78,7 @@ describe( 'QueryKey', () => {
 				static OMIT_NULL_VALUES = true;
 			}
 
-			const query = QueryKeyWithOmission.parse( '[["ok",true],["foo",null]]' );
+			const query = QueryKeyWithOmission.parse( '{"foo":null,"ok":true}' );
 
 			expect( query ).toEqual( {} );
 		} );

--- a/client/lib/query-manager/theme/test/key.js
+++ b/client/lib/query-manager/theme/test/key.js
@@ -14,43 +14,43 @@ describe( 'ThemeQueryKey', () => {
 		test( 'should return a JSON string of the object', () => {
 			const key = ThemeQueryKey.stringify( { ok: true } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).to.equal( '{"ok":true}' );
 		} );
 
 		test( 'should omit default theme query parameters', () => {
 			const key = ThemeQueryKey.stringify( { ok: true, tier: '' } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).to.equal( '{"ok":true}' );
 		} );
 
 		test( 'should omit null query values', () => {
 			const key = ThemeQueryKey.stringify( { ok: true, search: null } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).to.equal( '{"ok":true}' );
 		} );
 
 		test( 'should omit undefined query values', () => {
 			const key = ThemeQueryKey.stringify( { ok: true, search: undefined } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).to.equal( '{"ok":true}' );
 		} );
 	} );
 
 	describe( '.parse()', () => {
 		test( 'should return an object of the JSON string', () => {
-			const query = ThemeQueryKey.parse( '[["ok",true]]' );
+			const query = ThemeQueryKey.parse( '{"ok":true}' );
 
 			expect( query ).to.eql( { ok: true } );
 		} );
 
 		test( 'should omit default theme query parameters', () => {
-			const query = ThemeQueryKey.parse( '[["ok",true],["tier",""]]' );
+			const query = ThemeQueryKey.parse( '{"ok":true,"tier":""}' );
 
 			expect( query ).to.eql( { ok: true } );
 		} );
 
 		test( 'should omit null query values', () => {
-			const query = ThemeQueryKey.parse( '[["ok",true],["search",null]]' );
+			const query = ThemeQueryKey.parse( '{"ok":true,"search":null}' );
 
 			expect( query ).to.eql( { ok: true } );
 		} );

--- a/client/lib/query-manager/theme/test/key.js
+++ b/client/lib/query-manager/theme/test/key.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -14,25 +10,25 @@ describe( 'ThemeQueryKey', () => {
 		test( 'should return a JSON string of the object', () => {
 			const key = ThemeQueryKey.stringify( { ok: true } );
 
-			expect( key ).to.equal( '{"ok":true}' );
+			expect( key ).toBe( '{"ok":true}' );
 		} );
 
 		test( 'should omit default theme query parameters', () => {
 			const key = ThemeQueryKey.stringify( { ok: true, tier: '' } );
 
-			expect( key ).to.equal( '{"ok":true}' );
+			expect( key ).toBe( '{"ok":true}' );
 		} );
 
 		test( 'should omit null query values', () => {
 			const key = ThemeQueryKey.stringify( { ok: true, search: null } );
 
-			expect( key ).to.equal( '{"ok":true}' );
+			expect( key ).toBe( '{"ok":true}' );
 		} );
 
 		test( 'should omit undefined query values', () => {
 			const key = ThemeQueryKey.stringify( { ok: true, search: undefined } );
 
-			expect( key ).to.equal( '{"ok":true}' );
+			expect( key ).toBe( '{"ok":true}' );
 		} );
 	} );
 
@@ -40,19 +36,19 @@ describe( 'ThemeQueryKey', () => {
 		test( 'should return an object of the JSON string', () => {
 			const query = ThemeQueryKey.parse( '{"ok":true}' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 
 		test( 'should omit default theme query parameters', () => {
 			const query = ThemeQueryKey.parse( '{"ok":true,"tier":""}' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 
 		test( 'should omit null query values', () => {
 			const query = ThemeQueryKey.parse( '{"ok":true,"search":null}' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 	} );
 } );

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -633,7 +633,7 @@ describe( 'reducer', () => {
 							},
 						},
 						queries: {
-							'[["search","Hello"]]': {
+							'{"search":"Hello"}': {
 								itemKeys: [ 841 ],
 								found: 1,
 							},
@@ -659,7 +659,7 @@ describe( 'reducer', () => {
 							},
 						},
 						queries: {
-							'[["search","Hello"]]': {
+							'{"search":"Hello"}': {
 								itemKeys: [ 841 ],
 								found: 1,
 							},
@@ -684,7 +684,7 @@ describe( 'reducer', () => {
 						},
 					},
 					queries: {
-						'[["search","Hello"]]': {
+						'{"search":"Hello"}': {
 							found: 1,
 							itemKeys: [ 841 ],
 						},
@@ -1639,7 +1639,7 @@ describe( 'reducer', () => {
 						},
 					},
 					queries: {
-						'[["search","Hello"]]': {
+						'{"search":"Hello"}': {
 							itemKeys: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ],
 							found: 1,
 						},
@@ -1663,7 +1663,7 @@ describe( 'reducer', () => {
 						},
 					},
 					queries: {
-						'[["search","Hello"]]': {
+						'{"search":"Hello"}': {
 							itemKeys: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ],
 							found: 1,
 						},
@@ -1688,7 +1688,7 @@ describe( 'reducer', () => {
 							},
 						},
 						queries: {
-							'[["search","Hello"]]': {
+							'{"search":"Hello"}': {
 								found: 1,
 								itemKeys: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ],
 							},

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -302,7 +302,7 @@ describe( 'selectors', () => {
 									},
 								},
 								queries: {
-									'[["search","Ribs"]]': {
+									'{"search":"Ribs"}': {
 										itemKeys: [ 841 ],
 									},
 								},
@@ -339,7 +339,7 @@ describe( 'selectors', () => {
 									},
 								},
 								queries: {
-									'[["search","Sweet"]]': {
+									'{"search":"Sweet"}': {
 										itemKeys: [ 1204, undefined ],
 										found: 2,
 									},
@@ -450,7 +450,7 @@ describe( 'selectors', () => {
 									},
 								},
 								queries: {
-									'[["search","Hello"]]': {
+									'{"search":"Hello"}': {
 										itemKeys: [ 841 ],
 										found: 1,
 									},
@@ -474,7 +474,7 @@ describe( 'selectors', () => {
 							2916284: new PostQueryManager( {
 								items: {},
 								queries: {
-									'[["search","Hello"]]': {
+									'{"search":"Hello"}': {
 										itemKeys: [],
 										found: 0,
 									},
@@ -521,7 +521,7 @@ describe( 'selectors', () => {
 									},
 								},
 								queries: {
-									'[["search","Hello"]]': {
+									'{"search":"Hello"}': {
 										itemKeys: [ 841 ],
 										found: 1,
 									},
@@ -552,7 +552,7 @@ describe( 'selectors', () => {
 									},
 								},
 								queries: {
-									'[["search","Hello"]]': {
+									'{"search":"Hello"}': {
 										itemKeys: [ 841 ],
 										found: 4,
 									},
@@ -576,7 +576,7 @@ describe( 'selectors', () => {
 							2916284: new PostQueryManager( {
 								items: {},
 								queries: {
-									'[["search","Hello"]]': {
+									'{"search":"Hello"}': {
 										itemKeys: [],
 										found: 0,
 									},
@@ -623,7 +623,7 @@ describe( 'selectors', () => {
 									},
 								},
 								queries: {
-									'[["search","Hello"]]': {
+									'{"search":"Hello"}': {
 										itemKeys: [ 841 ],
 										found: 4,
 									},
@@ -654,7 +654,7 @@ describe( 'selectors', () => {
 									},
 								},
 								queries: {
-									'[["search","Hello"]]': {
+									'{"search":"Hello"}': {
 										itemKeys: [ 841 ],
 										found: 4,
 									},
@@ -685,7 +685,7 @@ describe( 'selectors', () => {
 									},
 								},
 								queries: {
-									'[["search","Hello"]]': {
+									'{"search":"Hello"}': {
 										itemKeys: [ 841 ],
 										found: 1,
 									},
@@ -773,7 +773,7 @@ describe( 'selectors', () => {
 									},
 								},
 								queries: {
-									'[]': {
+									'{}': {
 										itemKeys: [ 841, 413 ],
 									},
 								},
@@ -824,7 +824,7 @@ describe( 'selectors', () => {
 									},
 								},
 								queries: {
-									'[["search","Sweet"]]': {
+									'{"search":"Sweet"}': {
 										itemKeys: [ 1204, undefined ],
 										found: 2,
 									},
@@ -2438,7 +2438,6 @@ describe( 'selectors', () => {
 
 			expect( slug ).to.eql( '🙈🙊🙉' );
 		} );
-
 		test( 'should return edited slug if post is not published', () => {
 			const slug = getEditedPostSlug(
 				{
@@ -2471,10 +2470,8 @@ describe( 'selectors', () => {
 				2916284,
 				841
 			);
-
 			expect( slug ).to.eql( 'jedi' );
 		} );
-
 		test( 'should return suggested-slug if post is not published', () => {
 			const slug = getEditedPostSlug(
 				{
@@ -2500,10 +2497,8 @@ describe( 'selectors', () => {
 				2916284,
 				841
 			);
-
 			expect( slug ).to.eql( 'chewbacca' );
 		} );
-
 		test( 'should return slug if post is not published and slug is set', () => {
 			const slug = getEditedPostSlug(
 				{
@@ -2530,10 +2525,8 @@ describe( 'selectors', () => {
 				2916284,
 				841
 			);
-
 			expect( slug ).to.eql( 'jedi' );
 		} );
-
 		test( 'should return edited slug if post is published', () => {
 			const slug = getEditedPostSlug(
 				{
@@ -2566,10 +2559,8 @@ describe( 'selectors', () => {
 				2916284,
 				841
 			);
-
 			expect( slug ).to.eql( 'ewok' );
 		} );
-
 		test( 'should return an empty edited slug if post is published', () => {
 			const slug = getEditedPostSlug(
 				{
@@ -2602,11 +2593,9 @@ describe( 'selectors', () => {
 				2916284,
 				841
 			);
-
 			expect( slug ).to.eql( '' );
 		} );
 	} );
-
 	describe( 'getSitePostsByTerm()', () => {
 		test( 'should return an array of post objects for the site matching the termId', () => {
 			const postObjects = {
@@ -2637,7 +2626,6 @@ describe( 'selectors', () => {
 					},
 				},
 			};
-
 			expect( getSitePostsByTerm( state, 2916284, 'category', 10 ) ).to.have.members( [
 				postObjects[ 2916284 ][ '3d097cb7c5473c169bba0eb8e3c6cb64' ],
 			] );

--- a/client/state/terms/test/selectors.js
+++ b/client/state/terms/test/selectors.js
@@ -109,7 +109,7 @@ describe( 'selectors', () => {
 							2916284: {
 								categories: new TermQueryManager( {
 									queries: {
-										'[["search","ribs"]]': {
+										'{"search":"ribs"}': {
 											itemKeys: [ 123, 124 ],
 											found: 2,
 										},
@@ -143,7 +143,7 @@ describe( 'selectors', () => {
 							2916284: {
 								categories: new TermQueryManager( {
 									queries: {
-										'[["search","ribs"]]': {
+										'{"search":"ribs"}': {
 											itemKeys: [ 123, 124 ],
 											found: 2,
 										},
@@ -195,7 +195,7 @@ describe( 'selectors', () => {
 								category: new TermQueryManager( {
 									items: {},
 									queries: {
-										'[["search","ribs"]]': {
+										'{"search":"ribs"}': {
 											itemKeys: [],
 										},
 									},
@@ -230,7 +230,7 @@ describe( 'selectors', () => {
 										},
 									},
 									queries: {
-										'[["search","ribs"]]': {
+										'{"search":"ribs"}': {
 											itemKeys: [ 111 ],
 										},
 									},
@@ -291,7 +291,7 @@ describe( 'selectors', () => {
 										},
 									},
 									queries: {
-										'[["search","i"]]': {
+										'{"search":"i"}': {
 											itemKeys: [ 123, 124 ],
 											found: 2,
 										},
@@ -329,7 +329,7 @@ describe( 'selectors', () => {
 										},
 									},
 									queries: {
-										'[["search","i"]]': {
+										'{"search":"i"}': {
 											itemKeys: [ 123, 124 ],
 											found: 2,
 										},
@@ -412,7 +412,7 @@ describe( 'selectors', () => {
 										},
 									},
 									queries: {
-										'[["search","i"]]': {
+										'{"search":"i"}': {
 											itemKeys: [ 123, 124 ],
 											found: 2,
 										},
@@ -450,7 +450,7 @@ describe( 'selectors', () => {
 										},
 									},
 									queries: {
-										'[["search","i"]]': {
+										'{"search":"i"}': {
 											itemKeys: [ 123, 124 ],
 											found: 2,
 										},
@@ -477,7 +477,7 @@ describe( 'selectors', () => {
 								category: new TermQueryManager( {
 									items: {},
 									queries: {
-										'[["search","unappetizing"]]': {
+										'{"search":"unappetizing"}': {
 											itemKeys: [],
 											found: 0,
 										},
@@ -693,7 +693,7 @@ describe( 'selectors', () => {
 										},
 									},
 									queries: {
-										'[["search","ribs"]]': {
+										'{"search":"ribs"}': {
 											itemKeys: [ 111 ],
 											found: 4,
 										},

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -330,7 +330,7 @@ describe( 'themes selectors', () => {
 									twentysixteen,
 								},
 								queries: {
-									'[["search","Sixteen"]]': {
+									'{"search":"Sixteen"}': {
 										itemKeys: [ 'twentysixteen' ],
 									},
 								},
@@ -355,7 +355,7 @@ describe( 'themes selectors', () => {
 									twentyfifteen,
 								},
 								queries: {
-									'[["search","Fifteen"]]': {
+									'{"search":"Fifteen"}': {
 										itemKeys: [ 'twentyfifteen', undefined ],
 										found: 2,
 									},
@@ -490,7 +490,7 @@ describe( 'themes selectors', () => {
 									twentysixteen,
 								},
 								queries: {
-									'[["search","Sixteen"]]': {
+									'{"search":"Sixteen"}': {
 										itemKeys: [ 'twentysixteen' ],
 										found: 1,
 									},
@@ -514,7 +514,7 @@ describe( 'themes selectors', () => {
 							2916284: new ThemeQueryManager( {
 								items: {},
 								queries: {
-									'[["search","Umpteen"]]': {
+									'{"search":"Umpteen"}': {
 										itemKeys: [],
 										found: 0,
 									},
@@ -562,7 +562,7 @@ describe( 'themes selectors', () => {
 									twentysixteen,
 								},
 								queries: {
-									'[["search","Sixteen"]]': {
+									'{"search":"Sixteen"}': {
 										itemKeys: [ 'sixteen' ],
 										found: 1,
 									},
@@ -591,7 +591,7 @@ describe( 'themes selectors', () => {
 									twentysixteen,
 								},
 								queries: {
-									'[["search","Twenty"]]': {
+									'{"search":"Twenty"}': {
 										itemKeys: [ 'twentysixteen' ],
 										found: 7,
 									},
@@ -618,7 +618,7 @@ describe( 'themes selectors', () => {
 							2916284: new ThemeQueryManager( {
 								items: {},
 								queries: {
-									'[["search","Umpteen"]]': {
+									'{"search":"Umpteen"}': {
 										itemKeys: [],
 										found: 0,
 									},
@@ -653,7 +653,7 @@ describe( 'themes selectors', () => {
 									twentysixteen,
 								},
 								queries: {
-									'[["search","Twenty"]]': {
+									'{"search":"Twenty"}': {
 										itemKeys: [ 'twentysixteen' ],
 										found: 7,
 									},
@@ -698,7 +698,7 @@ describe( 'themes selectors', () => {
 									twentysixteen,
 								},
 								queries: {
-									'[["search","Twenty"]]': {
+									'{"search":"Twenty"}': {
 										itemKeys: [ 'twentysixteen' ],
 										found: 7,
 									},
@@ -727,7 +727,7 @@ describe( 'themes selectors', () => {
 									twentysixteen,
 								},
 								queries: {
-									'[["search","Twenty"]]': {
+									'{"search":"Twenty"}': {
 										itemKeys: [ 'twentysixteen' ],
 										found: 7,
 									},
@@ -756,7 +756,7 @@ describe( 'themes selectors', () => {
 									twentysixteen,
 								},
 								queries: {
-									'[["search","Sixteen"]]': {
+									'{"search":"Sixteen"}': {
 										itemKeys: [ 'twentysixteen' ],
 										found: 1,
 									},
@@ -791,7 +791,7 @@ describe( 'themes selectors', () => {
 									twentysixteen,
 								},
 								queries: {
-									'[["search","Twenty"]]': {
+									'{"search":"Twenty"}': {
 										itemKeys: [ 'twentysixteen' ],
 										found: 7,
 									},
@@ -853,7 +853,7 @@ describe( 'themes selectors', () => {
 									twentysixteen,
 								},
 								queries: {
-									'[]': {
+									'{}': {
 										itemKeys: [ 'twentyfifteen', 'twentysixteen' ],
 									},
 								},
@@ -878,7 +878,7 @@ describe( 'themes selectors', () => {
 									twentysixteen,
 								},
 								queries: {
-									'[["search","Sixteen"]]': {
+									'{"search":"Sixteen"}': {
 										itemKeys: [ 'twentysixteen', undefined ],
 										found: 2,
 									},


### PR DESCRIPTION
Use `json-stable-stringify` to generate stable strings from queries. Stringified querys like `[["ok",true]]'` become `'{"ok":true}'`. See test diffs for more examples.

Update related tests to reflect updated stringified results.
Update related tests to use Jest `expect`.

## Testing
- Tests pass
- Ensure there are no regressions in Calypso