### PR TITLE
Return wpcom request result from post action dispatch 

### DIFF
--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -256,7 +256,46 @@ export function savePost( siteId, postId = null, post ) {
  * @return {Function}        Action thunk
  */
 export function trashPost( siteId, postId ) {
-	return savePost( siteId, postId, { status: 'trash' } );
+	return dispatch => {
+		// Trashing post is almost equivalent to saving the post with status field set to `trash`
+		// and the action behaves like it was doing exactly that -- it dispatches the `POST_SAVE_*`
+		// actions with the right properties.
+		//
+		// But what we really do is to call the `wpcom.site().post().delete()` method, i.e., sending
+		// a `POST /sites/:site/posts/:post/delete` request. The difference is that an explicit delete
+		// will set a `_wp_trash_meta_status` meta property on the post and a later `restore` call
+		// can restore the original post status, i.e., `publish`. Without this, the post will be always
+		// recovered as `draft`.
+		const post = { status: 'trash' };
+
+		dispatch( {
+			type: POST_SAVE,
+			siteId,
+			postId,
+			post,
+		} );
+
+		const trashResult = wpcom
+			.site( siteId )
+			.post( postId )
+			.delete();
+
+		trashResult
+			.then( savedPost => {
+				dispatch( savePostSuccess( siteId, postId, savedPost, post ) );
+				dispatch( receivePost( savedPost ) );
+			} )
+			.catch( error => {
+				dispatch( {
+					type: POST_SAVE_FAILURE,
+					siteId,
+					postId,
+					error,
+				} );
+			} );
+
+		return trashResult;
+	};
 }
 
 /**

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -229,19 +229,20 @@ export function savePost( siteId, postId = null, post ) {
 		const method = postId ? 'update' : 'add';
 		const saveResult = postHandle[ method ]( { apiVersion: '1.2' }, normalizedPost );
 
-		saveResult
-			.then( savedPost => {
+		saveResult.then(
+			savedPost => {
 				dispatch( savePostSuccess( siteId, postId, savedPost, post ) );
 				dispatch( receivePost( savedPost ) );
-			} )
-			.catch( error => {
+			},
+			error => {
 				dispatch( {
 					type: POST_SAVE_FAILURE,
 					siteId,
 					postId,
 					error,
 				} );
-			} );
+			}
+		);
 
 		return saveResult;
 	};
@@ -280,19 +281,20 @@ export function trashPost( siteId, postId ) {
 			.post( postId )
 			.delete();
 
-		trashResult
-			.then( savedPost => {
+		trashResult.then(
+			savedPost => {
 				dispatch( savePostSuccess( siteId, postId, savedPost, post ) );
 				dispatch( receivePost( savedPost ) );
-			} )
-			.catch( error => {
+			},
+			error => {
 				dispatch( {
 					type: POST_SAVE_FAILURE,
 					siteId,
 					postId,
 					error,
 				} );
-			} );
+			}
+		);
 
 		return trashResult;
 	};
@@ -320,22 +322,23 @@ export function deletePost( siteId, postId ) {
 			.post( postId )
 			.delete();
 
-		deleteResult
-			.then( () => {
+		deleteResult.then(
+			() => {
 				dispatch( {
 					type: POST_DELETE_SUCCESS,
 					siteId,
 					postId,
 				} );
-			} )
-			.catch( error => {
+			},
+			error => {
 				dispatch( {
 					type: POST_DELETE_FAILURE,
 					siteId,
 					postId,
 					error,
 				} );
-			} );
+			}
+		);
 
 		return deleteResult;
 	};
@@ -362,23 +365,24 @@ export function restorePost( siteId, postId ) {
 			.post( postId )
 			.restore();
 
-		restoreResult
-			.then( restoredPost => {
+		restoreResult.then(
+			restoredPost => {
 				dispatch( {
 					type: POST_RESTORE_SUCCESS,
 					siteId,
 					postId,
 				} );
 				dispatch( receivePost( restoredPost ) );
-			} )
-			.catch( error => {
+			},
+			error => {
 				dispatch( {
 					type: POST_RESTORE_FAILURE,
 					siteId,
 					postId,
 					error,
 				} );
-			} );
+			}
+		);
 
 		return restoreResult;
 	};

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -216,7 +216,7 @@ export function savePostSuccess( siteId, postId = null, savedPost, post ) {
  * @return {Function}        Action thunk
  */
 export function savePost( siteId, postId = null, post ) {
-	return async dispatch => {
+	return dispatch => {
 		dispatch( {
 			type: POST_SAVE,
 			siteId,
@@ -224,10 +224,12 @@ export function savePost( siteId, postId = null, post ) {
 			post,
 		} );
 
-		let postHandle = wpcom.site( siteId ).post( postId );
+		const postHandle = wpcom.site( siteId ).post( postId );
 		const normalizedPost = normalizePostForApi( post );
-		postHandle = postHandle[ postId ? 'update' : 'add' ].bind( postHandle );
-		return postHandle( { apiVersion: '1.2' }, normalizedPost )
+		const method = postId ? 'update' : 'add';
+		const saveResult = postHandle[ method ]( { apiVersion: '1.2' }, normalizedPost );
+
+		saveResult
 			.then( savedPost => {
 				dispatch( savePostSuccess( siteId, postId, savedPost, post ) );
 				dispatch( receivePost( savedPost ) );
@@ -240,6 +242,8 @@ export function savePost( siteId, postId = null, post ) {
 					error,
 				} );
 			} );
+
+		return saveResult;
 	};
 }
 
@@ -272,10 +276,12 @@ export function deletePost( siteId, postId ) {
 			postId,
 		} );
 
-		return wpcom
+		const deleteResult = wpcom
 			.site( siteId )
 			.post( postId )
-			.delete()
+			.delete();
+
+		deleteResult
 			.then( () => {
 				dispatch( {
 					type: POST_DELETE_SUCCESS,
@@ -291,6 +297,8 @@ export function deletePost( siteId, postId ) {
 					error,
 				} );
 			} );
+
+		return deleteResult;
 	};
 }
 
@@ -310,10 +318,12 @@ export function restorePost( siteId, postId ) {
 			postId,
 		} );
 
-		return wpcom
+		const restoreResult = wpcom
 			.site( siteId )
 			.post( postId )
-			.restore()
+			.restore();
+
+		restoreResult
 			.then( restoredPost => {
 				dispatch( {
 					type: POST_RESTORE_SUCCESS,
@@ -330,6 +340,8 @@ export function restorePost( siteId, postId ) {
 					error,
 				} );
 			} );
+
+		return restoreResult;
 	};
 }
 

--- a/client/state/posts/test/actions.js
+++ b/client/state/posts/test/actions.js
@@ -4,6 +4,7 @@
  */
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -391,25 +392,29 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch failure action when error occurs while saving new post', () => {
-			return savePost( 77203074, null, { title: 'Hello World' } )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
-					type: POST_SAVE_FAILURE,
-					siteId: 77203074,
-					postId: null,
-					error: sinon.match( { message: 'User cannot edit posts' } ),
+			return savePost( 77203074, null, { title: 'Hello World' } )( spy )
+				.catch( noop )
+				.then( () => {
+					expect( spy ).to.have.been.calledWith( {
+						type: POST_SAVE_FAILURE,
+						siteId: 77203074,
+						postId: null,
+						error: sinon.match( { message: 'User cannot edit posts' } ),
+					} );
 				} );
-			} );
 		} );
 
 		test( 'should dispatch failure action when error occurs while saving existing post', () => {
-			return savePost( 77203074, 102, { title: 'Hello World' } )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
-					type: POST_SAVE_FAILURE,
-					siteId: 77203074,
-					postId: 102,
-					error: sinon.match( { message: 'User cannot edit post' } ),
+			return savePost( 77203074, 102, { title: 'Hello World' } )( spy )
+				.catch( noop )
+				.then( () => {
+					expect( spy ).to.have.been.calledWith( {
+						type: POST_SAVE_FAILURE,
+						siteId: 77203074,
+						postId: 102,
+						error: sinon.match( { message: 'User cannot edit post' } ),
+					} );
 				} );
-			} );
 		} );
 	} );
 
@@ -465,14 +470,16 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch post delete request failure action when request fails', () => {
-			return deletePost( 77203074, 102 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
-					type: POST_DELETE_FAILURE,
-					siteId: 77203074,
-					postId: 102,
-					error: sinon.match( { message: 'User cannot delete posts' } ),
+			return deletePost( 77203074, 102 )( spy )
+				.catch( noop )
+				.then( () => {
+					expect( spy ).to.have.been.calledWith( {
+						type: POST_DELETE_FAILURE,
+						siteId: 77203074,
+						postId: 102,
+						error: sinon.match( { message: 'User cannot delete posts' } ),
+					} );
 				} );
-			} );
 		} );
 	} );
 
@@ -522,14 +529,16 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch post restore request failure action when request fails', () => {
-			return restorePost( 77203074, 102 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
-					type: POST_RESTORE_FAILURE,
-					siteId: 77203074,
-					postId: 102,
-					error: sinon.match( { message: 'User cannot restore trashed posts' } ),
+			return restorePost( 77203074, 102 )( spy )
+				.catch( noop )
+				.then( () => {
+					expect( spy ).to.have.been.calledWith( {
+						type: POST_RESTORE_FAILURE,
+						siteId: 77203074,
+						postId: 102,
+						error: sinon.match( { message: 'User cannot restore trashed posts' } ),
+					} );
 				} );
-			} );
 		} );
 	} );
 

--- a/client/state/posts/test/actions.js
+++ b/client/state/posts/test/actions.js
@@ -124,16 +124,17 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should dispatch posts receive action when request completes', () => {
+		test( 'should dispatch posts receive action when request completes', done => {
 			return requestSitePosts( 2916284 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_RECEIVE,
 					posts: [ { ID: 841, title: 'Hello World' }, { ID: 413, title: 'Ribs & Chicken' } ],
 				} );
+				done();
 			} );
 		} );
 
-		test( 'should dispatch posts posts request success action when request completes', () => {
+		test( 'should dispatch success action when posts request completes', done => {
 			return requestSitePosts( 2916284 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_REQUEST_SUCCESS,
@@ -142,10 +143,11 @@ describe( 'actions', () => {
 					found: 2,
 					posts: [ { ID: 841, title: 'Hello World' }, { ID: 413, title: 'Ribs & Chicken' } ],
 				} );
+				done();
 			} );
 		} );
 
-		test( 'should dispatch posts request success action with query results', () => {
+		test( 'should dispatch posts request success action with query results', done => {
 			return requestSitePosts( 2916284, { search: 'Hello' } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_REQUEST_SUCCESS,
@@ -154,10 +156,11 @@ describe( 'actions', () => {
 					found: 1,
 					posts: [ { ID: 841, title: 'Hello World' } ],
 				} );
+				done();
 			} );
 		} );
 
-		test( 'should dispatch fail action when request fails', () => {
+		test( 'should dispatch failure action when request fails', done => {
 			return requestSitePosts( 77203074 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_REQUEST_FAILURE,
@@ -165,6 +168,7 @@ describe( 'actions', () => {
 					query: {},
 					error: sinon.match( { message: 'User cannot access this private blog.' } ),
 				} );
+				done();
 			} );
 		} );
 	} );
@@ -180,12 +184,13 @@ describe( 'actions', () => {
 				} );
 		} );
 
-		test( 'should dispatch posts receive action when request completes', () => {
+		test( 'should dispatch posts receive action when request completes', done => {
 			return requestAllSitesPosts()( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_RECEIVE,
 					posts: [ { ID: 841, title: 'Hello World' }, { ID: 413, title: 'Ribs & Chicken' } ],
 				} );
+				done();
 			} );
 		} );
 	} );
@@ -213,26 +218,28 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should dispatch posts receive action when request completes', () => {
+		test( 'should dispatch posts receive action when request completes', done => {
 			return requestSitePost( 2916284, 413 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_RECEIVE,
 					posts: [ sinon.match( { ID: 413, title: 'Ribs & Chicken' } ) ],
 				} );
+				done();
 			} );
 		} );
 
-		test( 'should dispatch posts posts request success action when request completes', () => {
+		test( 'should dispatch posts posts request success action when request completes', done => {
 			return requestSitePost( 2916284, 413 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_REQUEST_SUCCESS,
 					siteId: 2916284,
 					postId: 413,
 				} );
+				done();
 			} );
 		} );
 
-		test( 'should dispatch fail action when request fails', () => {
+		test( 'should dispatch fail action when request fails', done => {
 			return requestSitePost( 2916284, 420 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_REQUEST_FAILURE,
@@ -240,6 +247,7 @@ describe( 'actions', () => {
 					postId: 420,
 					error: sinon.match( { message: 'Unknown post' } ),
 				} );
+				done();
 			} );
 		} );
 	} );
@@ -320,7 +328,7 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should dispatch post save save success action when request completes for new post', () => {
+		test( 'should dispatch success action when saving new post succeeds', done => {
 			return savePost( 2916284, null, { title: 'Hello World' } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_SAVE_SUCCESS,
@@ -332,10 +340,11 @@ describe( 'actions', () => {
 						title: 'Hello World',
 					} ),
 				} );
+				done();
 			} );
 		} );
 
-		test( 'should dispatch received post action when request completes for new post', () => {
+		test( 'should dispatch received post action when saving new post succeeds', done => {
 			return savePost( 2916284, null, { title: 'Hello World' } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_RECEIVE,
@@ -346,6 +355,7 @@ describe( 'actions', () => {
 						} ),
 					],
 				} );
+				done();
 			} );
 		} );
 
@@ -362,7 +372,7 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should dispatch post save save success action when request completes for existing post', () => {
+		test( 'should dispatch success action when saving existing post succeeds', done => {
 			return savePost( 2916284, 13640, { title: 'Updated' } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_SAVE_SUCCESS,
@@ -374,10 +384,11 @@ describe( 'actions', () => {
 						title: 'Updated',
 					} ),
 				} );
+				done();
 			} );
 		} );
 
-		test( 'should dispatch received post action when request completes for existing post', () => {
+		test( 'should dispatch received post action when saving existing post succeeds', done => {
 			return savePost( 2916284, 13640, { title: 'Updated' } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_RECEIVE,
@@ -388,33 +399,38 @@ describe( 'actions', () => {
 						} ),
 					],
 				} );
+				done();
 			} );
 		} );
 
-		test( 'should dispatch failure action when error occurs while saving new post', () => {
-			return savePost( 77203074, null, { title: 'Hello World' } )( spy )
-				.catch( noop )
-				.then( () => {
+		test( 'should dispatch failure action when saving new post fails', done => {
+			return savePost( 77203074, null, { title: 'Hello World' } )( spy ).catch( () => {
+				// wait for catch handler within savePost()
+				setTimeout( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: POST_SAVE_FAILURE,
 						siteId: 77203074,
 						postId: null,
 						error: sinon.match( { message: 'User cannot edit posts' } ),
 					} );
+					done();
 				} );
+			} );
 		} );
 
-		test( 'should dispatch failure action when error occurs while saving existing post', () => {
-			return savePost( 77203074, 102, { title: 'Hello World' } )( spy )
-				.catch( noop )
-				.then( () => {
+		test( 'should dispatch failure action when saving existing post fails', done => {
+			return savePost( 77203074, 102, { title: 'Hello World' } )( spy ).catch( () => {
+				// wait for catch handler within savePost()
+				setTimeout( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: POST_SAVE_FAILURE,
 						siteId: 77203074,
 						postId: 102,
 						error: sinon.match( { message: 'User cannot edit post' } ),
 					} );
+					done();
 				} );
+			} );
 		} );
 	} );
 
@@ -459,27 +475,30 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should dispatch post delete request success action when request completes', () => {
+		test( 'should dispatch success action when deleting post succeeds', done => {
 			return deletePost( 2916284, 13640 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_DELETE_SUCCESS,
 					siteId: 2916284,
 					postId: 13640,
 				} );
+				done();
 			} );
 		} );
 
-		test( 'should dispatch post delete request failure action when request fails', () => {
-			return deletePost( 77203074, 102 )( spy )
-				.catch( noop )
-				.then( () => {
+		test( 'should dispatch failure action when deleting post fails', done => {
+			return deletePost( 77203074, 102 )( spy ).catch( () => {
+				// wait for catch handler within savePost()
+				setTimeout( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: POST_DELETE_FAILURE,
 						siteId: 77203074,
 						postId: 102,
 						error: sinon.match( { message: 'User cannot delete posts' } ),
 					} );
+					done();
 				} );
+			} );
 		} );
 	} );
 
@@ -509,36 +528,40 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should dispatch the received post when request completes successfully', () => {
+		test( 'should dispatch the received post when request completes successfully', done => {
 			return restorePost( 2916284, 13640 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_RECEIVE,
 					posts: [ { ID: 13640, status: 'draft' } ],
 				} );
+				done();
 			} );
 		} );
 
-		test( 'should dispatch post restore request success action when request completes', () => {
+		test( 'should dispatch success action when restoring post succeeds', done => {
 			return restorePost( 2916284, 13640 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_RESTORE_SUCCESS,
 					siteId: 2916284,
 					postId: 13640,
 				} );
+				done();
 			} );
 		} );
 
-		test( 'should dispatch post restore request failure action when request fails', () => {
-			return restorePost( 77203074, 102 )( spy )
-				.catch( noop )
-				.then( () => {
+		test( 'should dispatch failure action when restoring post fails', done => {
+			return restorePost( 77203074, 102 )( spy ).catch( () => {
+				// wait for catch handler within restorePost()
+				setTimeout( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: POST_RESTORE_FAILURE,
 						siteId: 77203074,
 						postId: 102,
 						error: sinon.match( { message: 'User cannot restore trashed posts' } ),
 					} );
+					done();
 				} );
+			} );
 		} );
 	} );
 

--- a/client/state/posts/test/actions.js
+++ b/client/state/posts/test/actions.js
@@ -124,17 +124,16 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should dispatch posts receive action when request completes', done => {
+		test( 'should dispatch posts receive action when request completes', () => {
 			return requestSitePosts( 2916284 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_RECEIVE,
 					posts: [ { ID: 841, title: 'Hello World' }, { ID: 413, title: 'Ribs & Chicken' } ],
 				} );
-				done();
 			} );
 		} );
 
-		test( 'should dispatch success action when posts request completes', done => {
+		test( 'should dispatch success action when posts request completes', () => {
 			return requestSitePosts( 2916284 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_REQUEST_SUCCESS,
@@ -143,11 +142,10 @@ describe( 'actions', () => {
 					found: 2,
 					posts: [ { ID: 841, title: 'Hello World' }, { ID: 413, title: 'Ribs & Chicken' } ],
 				} );
-				done();
 			} );
 		} );
 
-		test( 'should dispatch posts request success action with query results', done => {
+		test( 'should dispatch posts request success action with query results', () => {
 			return requestSitePosts( 2916284, { search: 'Hello' } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_REQUEST_SUCCESS,
@@ -156,11 +154,10 @@ describe( 'actions', () => {
 					found: 1,
 					posts: [ { ID: 841, title: 'Hello World' } ],
 				} );
-				done();
 			} );
 		} );
 
-		test( 'should dispatch failure action when request fails', done => {
+		test( 'should dispatch failure action when request fails', () => {
 			return requestSitePosts( 77203074 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_REQUEST_FAILURE,
@@ -168,7 +165,6 @@ describe( 'actions', () => {
 					query: {},
 					error: sinon.match( { message: 'User cannot access this private blog.' } ),
 				} );
-				done();
 			} );
 		} );
 	} );
@@ -184,13 +180,12 @@ describe( 'actions', () => {
 				} );
 		} );
 
-		test( 'should dispatch posts receive action when request completes', done => {
+		test( 'should dispatch posts receive action when request completes', () => {
 			return requestAllSitesPosts()( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_RECEIVE,
 					posts: [ { ID: 841, title: 'Hello World' }, { ID: 413, title: 'Ribs & Chicken' } ],
 				} );
-				done();
 			} );
 		} );
 	} );
@@ -218,28 +213,26 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should dispatch posts receive action when request completes', done => {
+		test( 'should dispatch posts receive action when request completes', () => {
 			return requestSitePost( 2916284, 413 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_RECEIVE,
 					posts: [ sinon.match( { ID: 413, title: 'Ribs & Chicken' } ) ],
 				} );
-				done();
 			} );
 		} );
 
-		test( 'should dispatch posts posts request success action when request completes', done => {
+		test( 'should dispatch posts posts request success action when request completes', () => {
 			return requestSitePost( 2916284, 413 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_REQUEST_SUCCESS,
 					siteId: 2916284,
 					postId: 413,
 				} );
-				done();
 			} );
 		} );
 
-		test( 'should dispatch fail action when request fails', done => {
+		test( 'should dispatch fail action when request fails', () => {
 			return requestSitePost( 2916284, 420 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_REQUEST_FAILURE,
@@ -247,7 +240,6 @@ describe( 'actions', () => {
 					postId: 420,
 					error: sinon.match( { message: 'Unknown post' } ),
 				} );
-				done();
 			} );
 		} );
 	} );
@@ -328,7 +320,7 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should dispatch success action when saving new post succeeds', done => {
+		test( 'should dispatch success action when saving new post succeeds', () => {
 			return savePost( 2916284, null, { title: 'Hello World' } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_SAVE_SUCCESS,
@@ -340,11 +332,10 @@ describe( 'actions', () => {
 						title: 'Hello World',
 					} ),
 				} );
-				done();
 			} );
 		} );
 
-		test( 'should dispatch received post action when saving new post succeeds', done => {
+		test( 'should dispatch received post action when saving new post succeeds', () => {
 			return savePost( 2916284, null, { title: 'Hello World' } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_RECEIVE,
@@ -355,7 +346,6 @@ describe( 'actions', () => {
 						} ),
 					],
 				} );
-				done();
 			} );
 		} );
 
@@ -372,7 +362,7 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should dispatch success action when saving existing post succeeds', done => {
+		test( 'should dispatch success action when saving existing post succeeds', () => {
 			return savePost( 2916284, 13640, { title: 'Updated' } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_SAVE_SUCCESS,
@@ -384,11 +374,10 @@ describe( 'actions', () => {
 						title: 'Updated',
 					} ),
 				} );
-				done();
 			} );
 		} );
 
-		test( 'should dispatch received post action when saving existing post succeeds', done => {
+		test( 'should dispatch received post action when saving existing post succeeds', () => {
 			return savePost( 2916284, 13640, { title: 'Updated' } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_RECEIVE,
@@ -399,12 +388,11 @@ describe( 'actions', () => {
 						} ),
 					],
 				} );
-				done();
 			} );
 		} );
 
 		test( 'should dispatch failure action when saving new post fails', done => {
-			return savePost( 77203074, null, { title: 'Hello World' } )( spy ).catch( () => {
+			savePost( 77203074, null, { title: 'Hello World' } )( spy ).catch( () => {
 				// wait for catch handler within savePost()
 				setTimeout( () => {
 					expect( spy ).to.have.been.calledWith( {
@@ -419,7 +407,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch failure action when saving existing post fails', done => {
-			return savePost( 77203074, 102, { title: 'Hello World' } )( spy ).catch( () => {
+			savePost( 77203074, 102, { title: 'Hello World' } )( spy ).catch( () => {
 				// wait for catch handler within savePost()
 				setTimeout( () => {
 					expect( spy ).to.have.been.calledWith( {
@@ -475,19 +463,18 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should dispatch success action when deleting post succeeds', done => {
+		test( 'should dispatch success action when deleting post succeeds', () => {
 			return deletePost( 2916284, 13640 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_DELETE_SUCCESS,
 					siteId: 2916284,
 					postId: 13640,
 				} );
-				done();
 			} );
 		} );
 
 		test( 'should dispatch failure action when deleting post fails', done => {
-			return deletePost( 77203074, 102 )( spy ).catch( () => {
+			deletePost( 77203074, 102 )( spy ).catch( () => {
 				// wait for catch handler within savePost()
 				setTimeout( () => {
 					expect( spy ).to.have.been.calledWith( {
@@ -528,29 +515,27 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should dispatch the received post when request completes successfully', done => {
+		test( 'should dispatch the received post when request completes successfully', () => {
 			return restorePost( 2916284, 13640 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_RECEIVE,
 					posts: [ { ID: 13640, status: 'draft' } ],
 				} );
-				done();
 			} );
 		} );
 
-		test( 'should dispatch success action when restoring post succeeds', done => {
+		test( 'should dispatch success action when restoring post succeeds', () => {
 			return restorePost( 2916284, 13640 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_RESTORE_SUCCESS,
 					siteId: 2916284,
 					postId: 13640,
 				} );
-				done();
 			} );
 		} );
 
 		test( 'should dispatch failure action when restoring post fails', done => {
-			return restorePost( 77203074, 102 )( spy ).catch( () => {
+			restorePost( 77203074, 102 )( spy ).catch( () => {
 				// wait for catch handler within restorePost()
 				setTimeout( () => {
 					expect( spy ).to.have.been.calledWith( {

--- a/client/state/posts/test/actions.js
+++ b/client/state/posts/test/actions.js
@@ -4,7 +4,6 @@
  */
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/state/posts/test/actions.js
+++ b/client/state/posts/test/actions.js
@@ -392,8 +392,6 @@ describe( 'actions', () => {
 
 		test( 'should dispatch failure action when saving new post fails', done => {
 			savePost( 77203074, null, { title: 'Hello World' } )( spy ).catch( () => {
-				// wait for catch handler within savePost()
-				setTimeout( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: POST_SAVE_FAILURE,
 						siteId: 77203074,
@@ -401,14 +399,11 @@ describe( 'actions', () => {
 						error: sinon.match( { message: 'User cannot edit posts' } ),
 					} );
 					done();
-				} );
 			} );
 		} );
 
 		test( 'should dispatch failure action when saving existing post fails', done => {
 			savePost( 77203074, 102, { title: 'Hello World' } )( spy ).catch( () => {
-				// wait for catch handler within savePost()
-				setTimeout( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: POST_SAVE_FAILURE,
 						siteId: 77203074,
@@ -416,7 +411,6 @@ describe( 'actions', () => {
 						error: sinon.match( { message: 'User cannot edit post' } ),
 					} );
 					done();
-				} );
 			} );
 		} );
 	} );
@@ -474,8 +468,6 @@ describe( 'actions', () => {
 
 		test( 'should dispatch failure action when deleting post fails', done => {
 			deletePost( 77203074, 102 )( spy ).catch( () => {
-				// wait for catch handler within savePost()
-				setTimeout( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: POST_DELETE_FAILURE,
 						siteId: 77203074,
@@ -483,7 +475,6 @@ describe( 'actions', () => {
 						error: sinon.match( { message: 'User cannot delete posts' } ),
 					} );
 					done();
-				} );
 			} );
 		} );
 	} );
@@ -535,8 +526,6 @@ describe( 'actions', () => {
 
 		test( 'should dispatch failure action when restoring post fails', done => {
 			restorePost( 77203074, 102 )( spy ).catch( () => {
-				// wait for catch handler within restorePost()
-				setTimeout( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: POST_RESTORE_FAILURE,
 						siteId: 77203074,
@@ -544,7 +533,6 @@ describe( 'actions', () => {
 						error: sinon.match( { message: 'User cannot restore trashed posts' } ),
 					} );
 					done();
-				} );
 			} );
 		} );
 	} );


### PR DESCRIPTION
This is a spinoff PR from #23090 with a part of the work that can be reviewed and merged independently. It improves the posts action thunks in a few ways:

**Return wpcom request result from post action dispatch**

This patch changes the `savePost`, `deletePost` and `restorePost` actions to return the `wpcom` request result from the dispatch. It allows us to chain promise handlers to the dispatch call and set local state in them:
```js
dispatch( restorePost( ... ) )
  .then( restoredPost => this.handleRestoreSuccess( restoredPost ) )
  .catch( error => this.handleRestoreError( error ) );
```

**Update the post action tests to cope with rejected promises**

The action dispatches now return both resolved and rejected promises. Update the tests so that they can cope also with rejected promises. We do that by inserting a dummy `catch( noop )` into the handler chain. An ideal solution would be to use `Promise.prototype.finally`, but that is a very new Promise feature that's not everywhere yet.

**Use wpcom.site().post().delete() to trash a post**

Trashing post is almost equivalent to saving the post with status field set to `trash` and the action behaves like it was doing exactly that -- it dispatches the `POST_SAVE_*` actions with the right properties.

But what we really do is to call the `wpcom.site().post().delete()` method, i.e., sending a `POST /sites/:site/posts/:post/delete` request. The difference is that an explicit delete will set a `_wp_trash_meta_status` meta property on the post and a later `restore` call can restore the original post status, i.e., `publish`. Without this, the post will be always recovered as `draft`.

**How to test:**
Only the changes in how a post is trashed affect the UI:
1. Go to the list of published posts or pages
2. Trash a published post or page
3. Go to the list of trashed items and restore the item you just trashed

Before this patch: the post/page is always recovered as "Draft"
After this patch: the post/page is recovered as "Published"

Similarly, recovering an item that was previously "Draft" or "Scheduled" will recover it with the original status.