### PR TITLE
JP Remote Install: Enable on wpcalypso environment

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -44,6 +44,7 @@
 		"help/courses": true,
 		"jetpack/api-cache": true,
 		"jetpack/connect/mobile-app-flow": true,
+		"jetpack/connect/remote-install": true,
 		"jetpack/happychat": true,
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,


### PR DESCRIPTION
Enable the Jetpack Connect Remote Install feature on the wpcalypso environment for easier testing. 

This feature will install the jetpack plugin on a remote .org site after asking a Calypso user for credentials. For more information see p7rd6c-1dS-p2.

## Testing
* This feature can currently be tested in development environment at /jetpack/connect
