### PR TITLE
LayoutLoggedOut: explicitly check className conditions

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -40,8 +40,8 @@ const LayoutLoggedOut = ( {
 	useOAuth2Layout,
 } ) => {
 	const classes = {
-		[ 'is-group-' + section.group ]: !! section,
-		[ 'is-section-' + section.name ]: !! section,
+		[ 'is-group-' + section.group ]: !! ( section && section.group ),
+		[ 'is-section-' + section.name ]: !! ( section && section.name ),
 		'focus-content': true,
 		'has-no-sidebar': ! hasSidebar( section ),
 		'has-no-masterbar': masterbarIsHidden,

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { includes } from 'lodash';
+import { includes, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -40,8 +40,8 @@ const LayoutLoggedOut = ( {
 	useOAuth2Layout,
 } ) => {
 	const classes = {
-		[ 'is-group-' + section.group ]: !! ( section && section.group ),
-		[ 'is-section-' + section.name ]: !! ( section && section.name ),
+		[ 'is-group-' + section.group ]: !! get( section, 'group' ),
+		[ 'is-section-' + section.name ]: !! get( section, 'name' ),
 		'focus-content': true,
 		'has-no-sidebar': ! hasSidebar( section ),
 		'has-no-masterbar': masterbarIsHidden,


### PR DESCRIPTION
We apply section related classes to the layout div but we're not explicit enough about the conditions when to apply these classes. This leads to e.g. a `is-group-undefined` class on some pages.

<img width="324" alt="screen shot 2018-03-16 at 15 22 06" src="https://user-images.githubusercontent.com/9202899/37525841-2e786b20-292e-11e8-8f0b-a589bb3cd353.png">

### testing

For the following steps it's best to disable JavaScript to make sure you actually see the server side rendered output (Open DevTools, hit F1, Debugger -> Disable JavaScript).

1. Go to https://calypso.live/log-in?branch=fix/section-group (logged out!)
2. Right-click: View Page Source
3. Make sure there is no `is-group-undefined` like mentioned above
4. Make sure there is a `is-group-*` e.g. on `/themes`