### PR TITLE
Debreak debug

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -294,9 +294,10 @@ if ( shouldMinify ) {
 	webpackConfig.plugins.push(
 		new UglifyJsPlugin( {
 			cache: 'docker' !== process.env.CONTAINER,
+			exclude: /debug/,
 			parallel: true,
-			uglifyOptions: { ecma: 5 },
 			sourceMap: Boolean( process.env.SOURCEMAP ),
+			uglifyOptions: { ecma: 5 },
 		} )
 	);
 }


### PR DESCRIPTION
UglifyJS compress [seems to break](https://github.com/Automattic/wp-calypso/issues/21489#issuecomment-373747102) `debug` placeholders. Disabling `compress` is probably not an option, try to exclude `debug` from uglification.

[uglifyjs-webpack-plugin docs](https://github.com/webpack-contrib/uglifyjs-webpack-plugin/tree/v1.2.0#options)
[UglifyJS2 options](https://github.com/mishoo/UglifyJS2/tree/harmony#minify-options)

This doesn't work yet 😕 

Fixes #21489

/cc @ockham 