### PR TITLE
SignUp: Improves a11y for the select domain step.

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -22,6 +22,7 @@ import DomainSuggestion from 'components/domains/domain-suggestion';
 import { isNextDomainFree } from 'lib/cart-values/cart-items';
 import Notice from 'components/notice';
 import Card from 'components/card';
+import ScreenReaderText from 'components/screen-reader-text';
 import { getTld } from 'lib/domains';
 import { domainAvailability } from 'lib/domains/constants';
 import { getDesignType } from 'state/signup/steps/design-type/selectors';
@@ -175,7 +176,11 @@ class DomainSearchResults extends React.Component {
 		}
 
 		return (
-			<div className="domain-search-results__domain-availability">
+			<div
+				className="domain-search-results__domain-availability"
+				aria-live="polite"
+				aria-relevant="additions"
+			>
 				<div className={ availabilityElementClasses }>
 					{ availabilityElement }
 					{ domainSuggestionElement }
@@ -195,10 +200,19 @@ class DomainSearchResults extends React.Component {
 	}
 
 	renderDomainSuggestions() {
+		let suggestionCount;
 		let suggestionElements;
 		let unavailableOffer;
 
 		if ( ! this.props.isLoadingSuggestions && this.props.suggestions ) {
+			suggestionCount = (
+				<div aria-live="polite">
+					<ScreenReaderText>
+						{ this.props.translate( '%s domains found', { args: this.props.suggestions.length } ) }
+					</ScreenReaderText>
+				</div>
+			);
+
 			suggestionElements = this.props.suggestions.map( function( suggestion, i ) {
 				if ( suggestion.is_placeholder ) {
 					return <DomainSuggestion.Placeholder key={ 'suggestion-' + i } />;
@@ -237,6 +251,7 @@ class DomainSearchResults extends React.Component {
 
 		return (
 			<div className="domain-search-results__domain-suggestions">
+				{ suggestionCount }
 				{ suggestionElements }
 				{ unavailableOffer }
 			</div>
@@ -245,7 +260,7 @@ class DomainSearchResults extends React.Component {
 
 	render() {
 		return (
-			<div className="domain-search-results" aria-live="polite" aria-relevant="additions">
+			<div className="domain-search-results">
 				{ this.renderDomainAvailability() }
 				{ this.renderDomainSuggestions() }
 			</div>

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -245,7 +245,7 @@ class DomainSearchResults extends React.Component {
 
 	render() {
 		return (
-			<div className="domain-search-results">
+			<div className="domain-search-results" aria-live="polite" aria-relevant="additions">
 				{ this.renderDomainAvailability() }
 				{ this.renderDomainSuggestions() }
 			</div>

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -176,11 +176,7 @@ class DomainSearchResults extends React.Component {
 		}
 
 		return (
-			<div
-				className="domain-search-results__domain-availability"
-				aria-live="polite"
-				aria-relevant="additions"
-			>
+			<div className="domain-search-results__domain-availability">
 				<div className={ availabilityElementClasses }>
 					{ availabilityElement }
 					{ domainSuggestionElement }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -311,6 +311,7 @@ class RegisterDomainStep extends React.Component {
 						onBlur={ this.save }
 						placeholder={ this.props.translate( 'Enter a name or keyword' ) }
 						autoFocus={ true }
+						describedBy={ 'formatted-header' }
 						delaySearch={ true }
 						delayTimeout={ 1000 }
 						dir="ltr"

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -311,7 +311,7 @@ class RegisterDomainStep extends React.Component {
 						onBlur={ this.save }
 						placeholder={ this.props.translate( 'Enter a name or keyword' ) }
 						autoFocus={ true }
-						describedBy={ 'formatted-header' }
+						describedBy={ 'step-header' }
 						delaySearch={ true }
 						delayTimeout={ 1000 }
 						dir="ltr"

--- a/client/components/formatted-header/README.md
+++ b/client/components/formatted-header/README.md
@@ -20,5 +20,6 @@ render() {
 
 #### Props
 
+* `id` (`string`) - ID for the header (optional)
 * `headerText` (`string`) - The main header text
 * `subHeaderText` (`node`) - Sub header text (optional)

--- a/client/components/formatted-header/index.jsx
+++ b/client/components/formatted-header/index.jsx
@@ -19,7 +19,7 @@ function FormattedHeader( { headerText, subHeaderText } ) {
 	} );
 
 	return (
-		<header className={ classes }>
+		<header id={ 'formatted-header' } className={ classes }>
 			<h1 className="formatted-header__title">{ preventWidows( headerText, 2 ) }</h1>
 			{ subHeaderText && (
 				<p className="formatted-header__subtitle">{ preventWidows( subHeaderText, 2 ) }</p>

--- a/client/components/formatted-header/index.jsx
+++ b/client/components/formatted-header/index.jsx
@@ -13,13 +13,13 @@ import classNames from 'classnames';
  */
 import { preventWidows } from 'lib/formatting';
 
-function FormattedHeader( { headerText, subHeaderText } ) {
+function FormattedHeader( { id, headerText, subHeaderText } ) {
 	const classes = classNames( 'formatted-header', {
 		'is-without-subhead': ! subHeaderText,
 	} );
 
 	return (
-		<header id={ 'formatted-header' } className={ classes }>
+		<header id={ id } className={ classes }>
 			<h1 className="formatted-header__title">{ preventWidows( headerText, 2 ) }</h1>
 			{ subHeaderText && (
 				<p className="formatted-header__subtitle">{ preventWidows( subHeaderText, 2 ) }</p>

--- a/client/components/language-picker/test/__snapshots__/modal.js.snap
+++ b/client/components/language-picker/test/__snapshots__/modal.js.snap
@@ -78,6 +78,7 @@ exports[`LanguagePickerModal should render 1`] = `
       compact={false}
       delaySearch={false}
       delayTimeout={300}
+      describedBy={null}
       disableAutocorrect={false}
       disabled={false}
       fitsContainer={true}

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -42,6 +42,7 @@ class Search extends Component {
 		pinned: PropTypes.bool,
 		delaySearch: PropTypes.bool,
 		delayTimeout: PropTypes.number,
+		describedBy: PropTypes.string,
 		onSearch: PropTypes.func.isRequired,
 		onSearchChange: PropTypes.func,
 		onSearchOpen: PropTypes.func,
@@ -71,6 +72,7 @@ class Search extends Component {
 		delayTimeout: SEARCH_DEBOUNCE_MS,
 		autoFocus: false,
 		disabled: false,
+		describedBy: null,
 		onSearchChange: noop,
 		onSearchOpen: noop,
 		onSearchClose: noop,
@@ -342,9 +344,12 @@ class Search extends Component {
 				</div>
 				<div className={ fadeDivClass }>
 					<input
-						autoFocus={ this.props.autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
 						type="search"
 						id={ 'search-component-' + this.instanceId }
+						autoFocus={ this.props.autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
+						aria-describedBy={ this.props.describedBy }
+						aria-label={ inputLabel ? inputLabel : i18n.translate( 'Search' ) }
+						aria-hidden={ ! isOpenUnpinnedOrQueried }
 						className={ inputClass }
 						placeholder={ placeholder }
 						role="search"
@@ -357,8 +362,6 @@ class Search extends Component {
 						onFocus={ this.onFocus }
 						onBlur={ this.onBlur }
 						disabled={ this.props.disabled }
-						aria-label={ inputLabel ? inputLabel : i18n.translate( 'Search' ) }
-						aria-hidden={ ! isOpenUnpinnedOrQueried }
 						autoCapitalize="none"
 						dir={ this.props.dir }
 						maxLength={ this.props.maxLength }

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -97,9 +97,9 @@ class Search extends Component {
 		this.instanceId = uniqueId();
 
 		this.state = {
-			keyword: this.props.initialValue || '',
-			isOpen: !! this.props.isOpen,
-			hasFocus: false,
+			keyword: props.initialValue || '',
+			isOpen: !! props.isOpen,
+			hasFocus: props.autoFocus,
 		};
 
 		this.closeListener = keyListener.bind( this, 'closeSearch' );

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -347,7 +347,7 @@ class Search extends Component {
 						type="search"
 						id={ 'search-component-' + this.instanceId }
 						autoFocus={ this.props.autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
-						aria-describedBy={ this.props.describedBy }
+						aria-describedby={ this.props.describedBy }
 						aria-label={ inputLabel ? inputLabel : i18n.translate( 'Search' ) }
 						aria-hidden={ ! isOpenUnpinnedOrQueried }
 						className={ inputClass }

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -167,11 +167,6 @@ class Search extends Component {
 		this.onSearch = this.props.delaySearch
 			? debounce( this.props.onSearch, this.props.delayTimeout )
 			: this.props.onSearch;
-
-		if ( this.props.autoFocus ) {
-			// this hack makes autoFocus work correctly in Dropdown
-			setTimeout( () => this.focus(), 0 );
-		}
 	}
 
 	scrollOverlay = () => {
@@ -347,6 +342,7 @@ class Search extends Component {
 				</div>
 				<div className={ fadeDivClass }>
 					<input
+						autoFocus={ this.props.autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
 						type="search"
 						id={ 'search-component-' + this.instanceId }
 						className={ inputClass }

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -102,7 +102,11 @@ class StepWrapper extends Component {
 		return (
 			<div className={ classes }>
 				{ ! hideFormattedHeader && (
-					<FormattedHeader headerText={ this.headerText() } subHeaderText={ this.subHeaderText() }>
+					<FormattedHeader
+						id={ 'step-header' }
+						headerText={ this.headerText() }
+						subHeaderText={ this.subHeaderText() }
+					>
 						{ headerButton }
 					</FormattedHeader>
 				) }


### PR DESCRIPTION
As suggested on #21658, this PR makes the following changes to improve a11y support on the _Domains_ step of the sign up process:

- `Search` now uses `autoFocus` instead of JS, and adds `aria-describedBy` support.
- Domain search results now is defined as a `aria-live` region.

Also, `FormattedHeader` now has a `id` property and there are some minor updates on the `Search` component.

How to Test:

- navigate to `/start/`
- activate the screen reader of choice.
- click `Continue`, to access the _Domains_ step.

The _Domains_ step should load with the focus on the search bar, and the screen reader should announce the search results automatically when you finish typing.

Since this makes changes on the `Search` component, there should be no regressions on components that depend on it. Components like the `SiteSelector` and the `SectionNav` should work as expected.

Fixes #21658 