### PR TITLE
JP Remote Install: Improve error handling

### DIFF
--- a/client/state/data-layer/wpcom/jetpack-install/index.js
+++ b/client/state/data-layer/wpcom/jetpack-install/index.js
@@ -32,10 +32,7 @@ export const handleSuccess = ( { url }, data ) => {
 		} )
 	);
 
-	if ( data.status ) {
-		return logToTracks( jetpackRemoteInstallComplete( url ) );
-	}
-	return logToTracks( jetpackRemoteInstallUpdateError( url, 'UNKNOWN_ERROR' ) );
+	return logToTracks( jetpackRemoteInstallComplete( url ) );
 };
 
 export const handleError = ( { url }, error ) => {

--- a/client/state/data-layer/wpcom/jetpack-install/index.js
+++ b/client/state/data-layer/wpcom/jetpack-install/index.js
@@ -1,10 +1,5 @@
 /** @format */
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
@@ -29,7 +24,7 @@ export const installJetpackPlugin = action =>
 		action
 	);
 
-export const handleResponse = ( { url }, data ) => {
+export const handleSuccess = ( { url }, data ) => {
 	const logToTracks = withAnalytics(
 		recordTracksEvent( 'calypso_jpc_remote_install_api_response', {
 			remote_site_url: url,
@@ -40,15 +35,26 @@ export const handleResponse = ( { url }, data ) => {
 	if ( data.status ) {
 		return logToTracks( jetpackRemoteInstallComplete( url ) );
 	}
-	return logToTracks( jetpackRemoteInstallUpdateError( url, data.error.code, data.error.message ) );
+	return logToTracks( jetpackRemoteInstallUpdateError( url, 'UNKNOWN_ERROR' ) );
+};
+
+export const handleError = ( { url }, error ) => {
+	const logToTracks = withAnalytics(
+		recordTracksEvent( 'calypso_jpc_remote_install_api_response', {
+			remote_site_url: url,
+			data: JSON.stringify( error ),
+		} )
+	);
+
+	return logToTracks( jetpackRemoteInstallUpdateError( url, error.error, error.message ) );
 };
 
 export default {
 	[ JETPACK_REMOTE_INSTALL ]: [
 		dispatchRequestEx( {
 			fetch: installJetpackPlugin,
-			onSuccess: handleResponse,
-			onError: noop,
+			onSuccess: handleSuccess,
+			onError: handleError,
 		} ),
 	],
 };

--- a/client/state/data-layer/wpcom/jetpack-install/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack-install/test/index.js
@@ -29,7 +29,7 @@ describe( 'installJetpackPlugin', () => {
 describe( 'handleSuccess', () => {
 	test( 'should return jetpackRemoteInstallComplete', () => {
 		const result = handleSuccess( { url }, SUCCESS_RESPONSE );
-		expect( result ).toEqual( jetpackRemoteInstallComplete( url ) );
+		expect( result ).toEqual( expect.objectContaining( jetpackRemoteInstallComplete( url ) ) );
 	} );
 } );
 

--- a/client/state/data-layer/wpcom/jetpack-install/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack-install/test/index.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { handleResponse, installJetpackPlugin } from '../';
+import { handleError, handleSuccess, installJetpackPlugin } from '../';
 import {
 	jetpackRemoteInstallComplete,
 	jetpackRemoteInstallUpdateError,
@@ -15,11 +15,8 @@ const password = 'hGhrskf145kst';
 
 const SUCCESS_RESPONSE = { status: true };
 const FAILURE_RESPONSE = {
-	status: false,
-	error: {
-		code: 'COULD_NOT_LOGIN',
-		message: 'extra info',
-	},
+	error: 'COULD_NOT_LOGIN',
+	message: 'extra info',
 };
 
 describe( 'installJetpackPlugin', () => {
@@ -29,14 +26,16 @@ describe( 'installJetpackPlugin', () => {
 	} );
 } );
 
-describe( 'handleResponse', () => {
-	test( 'should return jetpackRemoteInstallComplete on success', () => {
-		const result = handleResponse( { url }, SUCCESS_RESPONSE );
-		expect( result ).toEqual( expect.objectContaining( jetpackRemoteInstallComplete( url ) ) );
+describe( 'handleSuccess', () => {
+	test( 'should return jetpackRemoteInstallComplete', () => {
+		const result = handleSuccess( { url }, SUCCESS_RESPONSE );
+		expect( result ).toEqual( jetpackRemoteInstallComplete( url ) );
 	} );
+} );
 
-	test( 'should return JetpackRemoteInstallUpdateError on failure', () => {
-		const result = handleResponse( { url }, FAILURE_RESPONSE );
+describe( 'handleError', () => {
+	test( 'should return JetpackRemoteInstallUpdateError', () => {
+		const result = handleError( { url }, FAILURE_RESPONSE );
 		expect( result ).toEqual(
 			expect.objectContaining(
 				jetpackRemoteInstallUpdateError( url, 'COULD_NOT_LOGIN', 'extra info' )


### PR DESCRIPTION
Server-side change D10986-code returns `WP_Error` objects for failure responses. This gives us non-200 response codes, so we can use the `onError` handler in the data-layer.

No visual changes.

Do not merge until D10986-code has been deployed.

## Testing
* Run the unit tests
