### PR TITLE
Revert "Store: Remove a few unnecessary review config checks"

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
@@ -4,6 +4,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import config from 'config';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
@@ -77,8 +78,14 @@ class ManageOrdersView extends Component {
 		if ( ! ordersLoaded ) {
 			this.props.fetchOrders( siteId );
 		}
+		// TODO This check can be removed when we launch reviews.
+		if ( config.isEnabled( 'woocommerce/extension-reviews' ) ) {
+			this.props.fetchReviews( siteId, { status: 'pending' } );
+		}
+	};
 
-		this.props.fetchReviews( siteId, { status: 'pending' } );
+	shouldShowPendingReviews = () => {
+		return config.isEnabled( 'woocommerce/extension-reviews' ) && this.props.pendingReviews;
 	};
 
 	possiblyRenderProcessOrdersWidget = () => {
@@ -91,7 +98,7 @@ class ManageOrdersView extends Component {
 			count: orders.length,
 		} );
 		const classes = classNames( 'dashboard__process-orders-container', {
-			'has-reviews': this.props.pendingReviews,
+			'has-reviews': this.shouldShowPendingReviews(),
 		} );
 		return (
 			<DashboardWidgetRow className={ classes }>
@@ -115,12 +122,11 @@ class ManageOrdersView extends Component {
 	};
 
 	possiblyRenderReviewsWidget = () => {
-		const { site, pendingReviews, translate } = this.props;
-
-		if ( ! pendingReviews ) {
+		if ( ! this.shouldShowPendingReviews() ) {
 			return null;
 		}
 
+		const { site, pendingReviews, translate } = this.props;
 		const countText = translate( '%d pending review', '%d pending reviews', {
 			args: [ pendingReviews ],
 			count: pendingReviews,

--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -5,6 +5,7 @@
  */
 
 import React, { Component } from 'react';
+import config from 'config';
 import i18n from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { trim, isNumber } from 'lodash';
@@ -116,7 +117,7 @@ export default class ProductFormDetailsCard extends Component {
 
 		let productReviewsWidget = null;
 
-		if ( isNumber( product.id ) ) {
+		if ( isNumber( product.id ) && config.isEnabled( 'woocommerce/extension-reviews' ) ) {
 			productReviewsWidget = <ProductReviewsWidget product={ product } />;
 		}
 

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -68,7 +68,10 @@ class StoreSidebar extends Component {
 		this.props.fetchSetupChoices( siteId );
 		this.props.fetchOrders( siteId );
 
-		this.props.fetchReviews( siteId, { status: 'pending' } );
+		// TODO This check can be removed when we launch reviews.
+		if ( config.isEnabled( 'woocommerce/extension-reviews' ) ) {
+			this.props.fetchReviews( siteId, { status: 'pending' } );
+		}
 
 		if ( ! productsLoaded ) {
 			this.props.fetchProducts( siteId, { page: 1 } );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#23354

I should have rebased this after merging #23344 because one of the imports is still needed.