### PR TITLE
Reader: Add Fullscreen Focus Mode to Full Post Reader

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -8,6 +8,7 @@ import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
 import classNames from 'classnames';
+import Gridicon from 'gridicons';
 import { get, startsWith } from 'lodash';
 
 /**
@@ -74,6 +75,10 @@ export class FullPostView extends React.Component {
 		referralStream: PropTypes.string,
 	};
 
+	state = {
+		showFocusMode: false,
+	};
+
 	hasScrolledToCommentAnchor = false;
 
 	componentDidMount() {
@@ -136,6 +141,21 @@ export class FullPostView extends React.Component {
 		recordTrackForPost( 'calypso_reader_article_closed', this.props.post );
 
 		this.props.onClose && this.props.onClose();
+	};
+
+	toggleFocusMode = () => {
+		this.setState( { showFocusMode: ! this.state.showFocusMode } );
+
+		//cutting corners as it's a prototype only for now
+		//TODO reduxify to use showFocusMode at layout level
+		document.documentElement.querySelectorAll( '.layout' )[ 0 ].classList.toggle( 'is-focus-mode' );
+	};
+
+	handleResizeKeyPress = event => {
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			event.preventDefault();
+			this.toggleFocusMode();
+		}
 	};
 
 	handleCommentClick = () => {
@@ -289,7 +309,7 @@ export class FullPostView extends React.Component {
 		}
 
 		const siteName = getSiteName( { site, post } );
-		const classes = { 'reader-full-post': true };
+		const classes = { 'reader-full-post': true, 'is-focus-mode': this.state.showFocusMode };
 		const showRelatedPosts = post && ! post.is_external && post.site_ID;
 		const relatedPostsFromOtherSitesTitle = translate(
 			'More on {{wpLink}}WordPress.com{{/wpLink}}',
@@ -377,6 +397,17 @@ export class FullPostView extends React.Component {
 									fullPost={ true }
 									tagName="div"
 								/>
+							) }
+							{ ! isLoading && (
+								<div
+									className="reader-full-post__resize-button"
+									onClick={ this.toggleFocusMode }
+									onKeyPress={ this.handleResizeKeyPress }
+									role="button"
+									tabIndex="0"
+								>
+									<Gridicon icon={ this.state.showFocusMode ? 'fullscreen-exit' : 'fullscreen' } />
+								</div>
 							) }
 						</div>
 					</div>

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -587,3 +587,235 @@
 	margin-bottom: 16px;
 	min-height: 200px;
 }
+
+// Distraction free reader mode
+
+.reader-full-post .reader-full-post__resize-button {
+	display: none;
+	color: $gray;
+	cursor: pointer;
+	margin-left: 18px;
+
+	&:hover,
+	&:focus,
+	&:active {
+		color: $blue-medium;
+	}
+
+	@include breakpoint( ">660px" ) {
+		display: inline-flex;
+	}
+}
+
+.is-focus-mode {
+
+	.masterbar {
+		display: none; // Hides masterbar in focus mode
+	}
+}
+
+.reader-full-post.is-focus-mode {
+
+	.reader-full-post__content {
+		padding-left: 0;
+	}
+
+	.reader-full-post__visit-site-container {
+		border-bottom: 1px solid $gray-light;
+		position: fixed;
+			top: 1px;
+			right: 90px;
+		z-index: z-index( '.reader-full-post__sidebar-comment-like', '.reader-full-post__visit-site-container' );
+
+		.external-link .gridicons-external {
+			top: 5px;
+		}
+
+		.external-link {
+			padding: 10px 10px 15px 6px;
+		}
+
+		.reader-full-post__visit-site-label {
+			display: none;
+		}
+	}
+
+	.reader-full-post__sidebar {
+		position: static;
+		text-align: left;
+		width: auto;
+		left: auto;
+	}
+
+	.reader-full-post__story {
+		margin-top: -35px;
+	}
+
+	.back-button {
+		background: transparent;
+		border-bottom: 0;
+		position: fixed;
+			top: 0;
+		width: 100px;
+		z-index: z-index( '.reader-full-post__sidebar-comment-like', '.reader-full-post .back-button' );
+	}
+
+	.back-button__label {
+		display: none;
+	}
+
+	.author-compact-profile {
+		margin-bottom: 35px;
+		padding-right: 10px;
+		position: relative;
+		text-overflow: clip;
+		white-space: nowrap;
+
+		&::after {
+			height: 40px;
+		}
+
+		&:not( .is-placeholder )::after {
+			@include long-content-fade( $size: 15% );
+		}
+
+		flex-direction: row;
+		margin-top: 40px;
+
+		.reader-avatar {
+			flex: 1;
+			margin: 0 0 0 -9px;
+
+			&.has-site-and-author-icon,
+			&.has-site-icon,
+			&.has-gravatar {
+				margin: 0 10px 5px 0;
+			}
+
+			&.has-gravatar {
+
+				.gravatar {
+					height: 32px!important;
+					width: 32px!important;
+					max-width: none;
+				}
+			}
+
+			&.has-site-and-author-icon.has-site-icon.has-gravatar {
+				margin-bottom: -15px;
+
+				.gravatar {
+					height: 24px!important;
+					margin-right: 1em;
+					position: relative;
+						left: 18px;
+						top: -18px;
+					vertical-align: bottom;
+					width: 24px!important;
+				}
+			}
+
+			.site-icon {
+				height: 32px!important;
+				width: 32px!important;
+				line-height: 32px!important;
+				font-size: 32px!important;
+
+				.gridicon {
+
+					height: 32px!important;
+					width: 32px!important;
+					line-height: 32px!important;
+					font-size: 32px!important;
+				}
+			}
+		}
+
+		.reader-author-link {
+			font-weight: 700;
+			display: inline;
+			margin-right: 5px;
+
+			&::after {
+				content: ',';
+				font-weight: normal;
+			}
+		}
+
+		.author-compact-profile__site-link {
+			flex: 1 0 0;
+			display: inline;
+			margin-top: 0;
+		}
+
+		.reader-author-link,
+		.author-compact-profile__site-link {
+			padding-top: 5px;
+		}
+
+		.author-compact-profile__follow .follow-button {
+			position: fixed;
+				left: calc( 100% - 296px );
+				top: 6px;
+
+			background: transparent;
+			position: fixed;
+			z-index: z-index( '.reader-full-post__sidebar-comment-like', '.author-compact-profile__follow .follow-button' );
+
+			.gridicon {
+				height: 24px;
+				top: 7px;
+				width: 24px;
+			}
+		}
+
+		.author-compact-profile__follow-count {
+			display: none;
+		}
+
+		.author-compact-profile__follow .follow-button__label {
+			display: none;
+		}
+	}
+
+	.reader-full-post__sidebar-comment-like {
+
+		align-items: flex-start;
+		background: white;
+		display: flex;
+		border-bottom: 1px solid $gray-lighten-30;
+		flex-direction: row;
+		height: 47px;
+		justify-content: flex-end;
+		position: fixed;
+			left: 0;
+			top: 0;
+		width: 100%;
+		z-index: z-index( 'root', '.reader-full-post__sidebar-comment-like' );
+	}
+
+	.reader-full-post__sidebar .like-button {
+		margin-right: 50px;
+			top: 9px;
+	}
+
+	.reader-full-post__sidebar .comment-button {
+		top: 9px;
+		margin-right: 10px;
+	}
+
+	.reader-full-post__resize-button {
+		position: relative;
+			top: 13px;
+		margin: 0 12px 0 47px;
+	}
+
+
+	.reader-full-post .has-author-link.has-author-icon {
+		margin-top: 25px;
+	}
+
+	.reader-full-post__header-title {
+		margin-top: 25px;
+	}
+}


### PR DESCRIPTION
## This PR

- suggests a small step towards a more distraction-free reading experience
- is meant as a prototype to get design feedback
- is an alternative version of PR #23289 

## Thoughts behind this suggested change

Currently, the default full post view in the reader puts a lot of emphasis on the author and displays the article off center. This results in an unpleasant reading experience, especially on longer posts.

A potential solution, as suggested in this PR, could be to offer the user an option to switch to a simple focus mode that removes unnecessary distractions and puts the focus on the content.

In order to not hide the author completely, the default view would always be the current full post view.

## How to test
- Visit the calypso.live link below
- Navigate to a post in the reader
- Toggle the sidebar via the resize button


## Screenshots

<img width="1168" alt="screen shot 2018-03-16 at 13 39 24" src="https://user-images.githubusercontent.com/1562646/37538771-a82973ba-291f-11e8-99f4-fab2691d2621.png">

<img width="1167" alt="screen shot 2018-03-16 at 13 39 40" src="https://user-images.githubusercontent.com/1562646/37538729-8b55c298-291f-11e8-8f31-7c105ee22169.png">

