### PR TITLE
WordAds: Update Monetize card CTA link on "My Plan" page for Jetpack sites

### DIFF
--- a/client/blocks/product-purchase-features-list/monetize-site.jsx
+++ b/client/blocks/product-purchase-features-list/monetize-site.jsx
@@ -13,6 +13,9 @@ import { localize } from 'i18n-calypso';
 import PurchaseDetail from 'components/purchase-detail';
 
 export default localize( ( { selectedSite, translate } ) => {
+	const adSettingsUrl = selectedSite.jetpack
+		? '/settings/traffic/' + selectedSite.slug
+		: '/ads/settings/' + selectedSite.slug;
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
@@ -23,7 +26,7 @@ export default localize( ( { selectedSite, translate } ) => {
 						'WordAds lets you earn money by displaying promotional content.'
 				) }
 				buttonText={ translate( 'Start earning' ) }
-				href={ '/ads/settings/' + selectedSite.slug }
+				href={ adSettingsUrl }
 			/>
 		</div>
 	);

--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -32,8 +32,7 @@ export function canAccessWordads( site ) {
 export function isWordadsInstantActivationEligible( site ) {
 	if (
 		( isBusiness( site.plan ) || isPremium( site.plan ) ) &&
-		userCan( 'activate_wordads', site ) &&
-		! site.jetpack
+		userCan( 'activate_wordads', site )
 	) {
 		return true;
 	}


### PR DESCRIPTION
Ads settings are in different locations for dotcom and Jetpack sites. This PR will update the card link to point to the right location for Jetpack sites.