### PR TITLE
Store: download return label PDFs instead of printing

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/lib/utils/pdf-support.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/utils/pdf-support.js
@@ -13,6 +13,8 @@ import { get, includes, memoize } from 'lodash';
  * PDFs at all.
  */
 export default memoize( download => {
+	// If downloading, we can rely on the "native" download attribute if it's available, but if
+	// it isn't, proceed with the fallback strategy for manual downloading.
 	if ( download && 'download' in document.createElement( 'a' ) ) {
 		return 'native';
 	}
@@ -35,6 +37,7 @@ export default memoize( download => {
 		return 'addon';
 	}
 
+	// If printing, reaching this point means we can rely on native PDF support
 	if ( ! download && navigator.mimeTypes[ 'application/pdf' ] ) {
 		return 'native';
 	}

--- a/client/extensions/woocommerce/woocommerce-services/lib/utils/pdf-support.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/utils/pdf-support.js
@@ -12,7 +12,11 @@ import { get, includes, memoize } from 'lodash';
  * no guarantee that they will respond to a DOM-like API. false if the browser can't display
  * PDFs at all.
  */
-export default memoize( () => {
+export default memoize( download => {
+	if ( download && 'download' in document.createElement( 'a' ) ) {
+		return 'native';
+	}
+
 	if ( get( window, 'navigator.msSaveOrOpenBlob' ) ) {
 		// IE & Edge, they don't support opening a Blob in an iframe/window
 		return 'ie';
@@ -31,7 +35,7 @@ export default memoize( () => {
 		return 'addon';
 	}
 
-	if ( navigator.mimeTypes[ 'application/pdf' ] ) {
+	if ( ! download && navigator.mimeTypes[ 'application/pdf' ] ) {
 		return 'native';
 	}
 

--- a/client/extensions/woocommerce/woocommerce-services/lib/utils/print-document.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/utils/print-document.js
@@ -61,6 +61,7 @@ export default ( { b64Content, mimeType }, fileName, download = false ) => {
 
 	switch ( getPDFSupport( download ) ) {
 		case 'native':
+			// Browsers other than IE and Mobile Safari will prompt for download or start it automatically.
 			if ( download ) {
 				// Adapted from https://gist.github.com/rudiedirkx/2623261
 				const link = document.createElement( 'a' );
@@ -74,7 +75,7 @@ export default ( { b64Content, mimeType }, fileName, download = false ) => {
 				return Promise.resolve();
 			}
 
-			// Happy case where everything can happen automatically. Supported in Chrome and Safari
+			// Happy case where loading and printing can happen automatically. Supported in Chrome and Safari
 			return loadDocumentInFrame( blobUrl )
 				.then( () => {
 					iframe.contentWindow.print();

--- a/client/extensions/woocommerce/woocommerce-services/lib/utils/print-document.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/utils/print-document.js
@@ -62,6 +62,7 @@ export default ( { b64Content, mimeType }, fileName, download = false ) => {
 	switch ( getPDFSupport( download ) ) {
 		case 'native':
 			if ( download ) {
+				// Adapted from https://gist.github.com/rudiedirkx/2623261
 				const link = document.createElement( 'a' );
 				link.setAttribute( 'href', blobUrl );
 				link.setAttribute( 'download', fileName );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -913,7 +913,7 @@ export const confirmReprint = ( orderId, siteId ) => ( dispatch, getState ) => {
 	const state = getShippingLabel( getState(), orderId, siteId );
 
 	const label = find( state.labels, { label_id: state.reprintDialog.labelId } );
-	const isReturn = label.returning_label_id != null;
+	const isReturn = Boolean( label.returning_label_id );
 
 	printDocument( state.reprintDialog.fileData, getPDFFileName( orderId, isReturn ? 'return-reprint' : 'reprint' ), isReturn )
 		.catch( ( error ) => {
@@ -932,7 +932,7 @@ export const updatePaperSize = ( orderId, siteId, value ) => ( dispatch, getStat
 	} );
 
 	const shippingLabel = getShippingLabel( getState(), orderId, siteId );
-	if ( shippingLabel.reprintDialog != null ) {
+	if ( shippingLabel.reprintDialog ) {
 		dispatch( openReprintDialog( orderId, siteId, shippingLabel.reprintDialog.labelId ) );
 	}
 };

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -63,7 +63,7 @@ class LabelItem extends Component {
 			<span>
 				<ReprintDialog siteId={ siteId } orderId={ orderId } download={ label.returningLabelIndex != null } { ...label } />
 				<a href="#" onClick={ openDialog } >
-					{ label.returningLabelIndex == null ? translate( 'Reprint' ) : translate( 'Download' ) }
+					{ label.returningLabelIndex ? translate( 'Download' ) : translate( 'Reprint' ) }
 				</a>
 			</span>
 		);

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -63,7 +63,7 @@ class LabelItem extends Component {
 			<span>
 				<ReprintDialog siteId={ siteId } orderId={ orderId } download={ label.returningLabelIndex != null } { ...label } />
 				<a href="#" onClick={ openDialog } >
-					{ label.returningLabelIndex == null ? translate( 'Reprint' ) : translate( 'Redownload' ) }
+					{ label.returningLabelIndex == null ? translate( 'Reprint' ) : translate( 'Download' ) }
 				</a>
 			</span>
 		);

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -61,8 +61,10 @@ class LabelItem extends Component {
 
 		return (
 			<span>
-				<ReprintDialog siteId={ siteId } orderId={ orderId } { ...label } />
-				<a href="#" onClick={ openDialog } >{ translate( 'Reprint' ) }</a>
+				<ReprintDialog siteId={ siteId } orderId={ orderId } download={ label.returningLabelIndex != null } { ...label } />
+				<a href="#" onClick={ openDialog } >
+					{ label.returningLabelIndex == null ? translate( 'Reprint' ) : translate( 'Redownload' ) }
+				</a>
 			</span>
 		);
 	};

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/buy-and-print-button.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/buy-and-print-button.js
@@ -30,13 +30,14 @@ class BuyAndPrintButton extends React.Component {
 	static propTypes = {
 		siteId: PropTypes.number.isRequired,
 		orderId: PropTypes.number.isRequired,
+		download: PropTypes.bool,
 	};
 
 	getPurchaseButtonLabel = () => {
-		const { form, ratesTotal, translate } = this.props;
+		const { form, ratesTotal, translate, download } = this.props;
 
 		if ( form.needsPrintConfirmation ) {
-			return translate( 'Print' );
+			return download ? translate( 'Download' ) : translate( 'Print' );
 		}
 
 		if ( form.isSubmitting ) {
@@ -46,18 +47,22 @@ class BuyAndPrintButton extends React.Component {
 		const noNativePDFSupport = 'addon' === getPDFSupport();
 
 		if ( this.props.canPurchase ) {
+			const translateOptions = { args: [ formatCurrency( ratesTotal, 'USD' ) ] };
+
 			if ( noNativePDFSupport ) {
-				return translate( 'Buy (%s)', { args: [ formatCurrency( ratesTotal, 'USD' ) ] } );
+				return translate( 'Buy (%s)', translateOptions );
 			}
 
-			return translate( 'Buy & Print (%s)', { args: [ formatCurrency( ratesTotal, 'USD' ) ] } );
+			return download
+				? translate( 'Buy & Download (%s)', translateOptions )
+				: translate( 'Buy & Print (%s)', translateOptions );
 		}
 
 		if ( noNativePDFSupport ) {
 			return translate( 'Buy' );
 		}
 
-		return translate( 'Buy & Print' );
+		return download ? translate( 'Buy & Download' ) : translate( 'Buy & Print' );
 	};
 
 	getPurchaseButtonAction = () => {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-reprint-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-reprint-modal.js
@@ -44,7 +44,7 @@ const ReprintDialog = ( props ) => {
 			buttons={ buttons }
 			additionalClassNames="label-reprint-modal woocommerce wcc-root">
 			<FormSectionHeading>
-				{ download ? translate( 'Redownload shipping label' ) : translate( 'Reprint shipping label' ) }
+				{ download ? translate( 'Download shipping label' ) : translate( 'Reprint shipping label' ) }
 			</FormSectionHeading>
 			<p>
 				{ download

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-reprint-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-reprint-modal.js
@@ -18,7 +18,8 @@ import { closeReprintDialog, confirmReprint, updatePaperSize } from 'woocommerce
 import { isLoaded, getShippingLabel } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 
 const ReprintDialog = ( props ) => {
-	const { orderId, siteId, reprintDialog, paperSize, storeOptions, labelId, translate } = props;
+	const { orderId, siteId, reprintDialog, paperSize, storeOptions, labelId, translate, download } = props;
+	const { labelId: reprintLabelId, isFetching } = reprintDialog || {};
 
 	const onClose = () => props.closeReprintDialog( orderId, siteId );
 	const onConfirm = () => props.confirmReprint( orderId, siteId );
@@ -30,23 +31,26 @@ const ReprintDialog = ( props ) => {
 			action: 'confirm',
 			onClick: onConfirm,
 			isPrimary: true,
-			disabled: reprintDialog && reprintDialog.isFetching,
-			additionalClassNames: reprintDialog && reprintDialog.isFetching ? 'is-busy' : '',
-			label: translate( 'Print' ),
+			disabled: isFetching,
+			additionalClassNames: isFetching ? 'is-busy' : '',
+			label: download ? translate( 'Download' ) : translate( 'Print' ),
 		},
 	];
 
 	return (
 		<Dialog
-			isVisible={ Boolean( reprintDialog && reprintDialog.labelId === labelId ) }
+			isVisible={ reprintLabelId === labelId }
 			onClose={ onClose }
 			buttons={ buttons }
 			additionalClassNames="label-reprint-modal woocommerce wcc-root">
 			<FormSectionHeading>
-				{ translate( 'Reprint shipping label' ) }
+				{ download ? translate( 'Redownload shipping label' ) : translate( 'Reprint shipping label' ) }
 			</FormSectionHeading>
 			<p>
-				{ translate( 'If there was a printing error when you purchased the label, you can print it again.' ) }
+				{ download
+					? translate( 'If there was a download error when you purchased the label, you can download it again.' )
+					: translate( 'If there was a printing error when you purchased the label, you can print it again.' )
+				}
 			</p>
 			<p className="shipping-label__reprint-modal-notice">
 				{ translate( 'NOTE: If you already used the label in a package, printing and using it again ' +
@@ -72,6 +76,7 @@ ReprintDialog.propTypes = {
 	closeReprintDialog: PropTypes.func.isRequired,
 	confirmReprint: PropTypes.func.isRequired,
 	updatePaperSize: PropTypes.func.isRequired,
+	download: PropTypes.bool,
 };
 
 const mapStateToProps = ( state, { orderId, siteId } ) => {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-return-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-return-modal.js
@@ -35,12 +35,7 @@ const ReturnDialog = props => {
 
 	const buttons = [
 		{ action: 'cancel', label: translate( 'Cancel' ), onClick: onClose },
-		<BuyAndPrintButton
-			key="purchase"
-			siteId={ props.siteId }
-			orderId={ props.orderId }
-			download={ true }
-		/>,
+		<BuyAndPrintButton key="purchase" siteId={ props.siteId } orderId={ props.orderId } download />,
 	];
 
 	return (

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-return-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-return-modal.js
@@ -35,7 +35,12 @@ const ReturnDialog = props => {
 
 	const buttons = [
 		{ action: 'cancel', label: translate( 'Cancel' ), onClick: onClose },
-		<BuyAndPrintButton key="purchase" siteId={ props.siteId } orderId={ props.orderId } />,
+		<BuyAndPrintButton
+			key="purchase"
+			siteId={ props.siteId }
+			orderId={ props.orderId }
+			download={ true }
+		/>,
 	];
 
 	return (


### PR DESCRIPTION
The merchant's customer is the one who will typically use the pre-paid return label, rather than the merchant themselves, so the merchant will want to deliver the label to the customer electronically.

This PR branches off of https://github.com/Automattic/wp-calypso/pull/23183 to download return labels after purchase, instead of printing them.

It checks for "native" file download functionality via the anchor tag's `download` attribute, and if that isn't there, falls back using the existing label printing compatibility mechanism.

<img width="479" alt="screen shot 2018-03-16 at 3 52 59 pm" src="https://user-images.githubusercontent.com/1867547/37541760-29423600-2932-11e8-85b5-fa230ef8a835.png">

<img width="294" alt="screen shot 2018-03-16 at 3 52 31 pm" src="https://user-images.githubusercontent.com/1867547/37541798-472b15a6-2932-11e8-8973-ca1e52c2ebfc.png">

<img width="972" alt="screen shot 2018-03-16 at 3 52 39 pm" src="https://user-images.githubusercontent.com/1867547/37541769-309b5620-2932-11e8-8197-3ebe054dd64f.png">

An alternative to adjusting the text to "Download" / "Redownload" might be to leave it as "Print" / "Reprint" but then have a checkbox (checked by default) labelled "Print to PDF and download" or similar.