### PR TITLE
Editor: close editor on delete confirmation

### DIFF
--- a/client/post-editor/editor-delete-post/index.jsx
+++ b/client/post-editor/editor-delete-post/index.jsx
@@ -14,11 +14,14 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import actions from 'lib/posts/actions';
 import accept from 'lib/accept';
-import * as utils from 'lib/posts/utils';
 import Button from 'components/button';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPost } from 'state/posts/selectors';
+import { trashPost } from 'state/posts/actions';
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { canCurrentUser } from 'state/selectors';
 
 class EditorDeletePost extends React.Component {
 	static displayName = 'EditorDeletePost';
@@ -34,32 +37,33 @@ class EditorDeletePost extends React.Component {
 	};
 
 	sendToTrash = () => {
-		if ( ! utils.userCan( 'delete_post', this.props.post ) ) {
+		const { siteId, postId, canDelete } = this.props;
+
+		if ( ! canDelete ) {
 			return;
+		}
+
+		if ( this.props.onTrashingPost ) {
+			this.props.onTrashingPost();
 		}
 
 		this.setState( { isTrashing: true } );
 
-		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		actions.trash( this.props.site, this.props.post, error => {
-			this.setState( { isTrashing: false } );
-
-			if ( this.props.onTrashingPost ) {
-				this.props.onTrashingPost( error );
-			}
-		} );
+		this.props.trashPost( siteId, postId );
 	};
 
 	onSendToTrash = () => {
-		let message;
+		const { translate, post } = this.props;
+
 		if ( this.state.isTrashing ) {
 			return;
 		}
 
-		if ( this.props.post.type === 'page' ) {
-			message = this.props.translate( 'Are you sure you want to trash this page?' );
+		let message;
+		if ( post.type === 'page' ) {
+			message = translate( 'Are you sure you want to trash this page?' );
 		} else {
-			message = this.props.translate( 'Are you sure you want to trash this post?' );
+			message = translate( 'Are you sure you want to trash this post?' );
 		}
 
 		accept(
@@ -69,23 +73,21 @@ class EditorDeletePost extends React.Component {
 					this.sendToTrash();
 				}
 			},
-			this.props.translate( 'Move to trash' ),
-			this.props.translate( 'Back' )
+			translate( 'Move to trash' ),
+			translate( 'Back' )
 		);
 	};
 
 	render() {
-		const { post } = this.props;
-		if ( ! post || ! post.ID || post.status === 'trash' ) {
+		const { postId, postStatus, translate } = this.props;
+		if ( ! postId || postStatus === 'trash' ) {
 			return null;
 		}
 
 		const classes = classnames( 'editor-delete-post__button', {
 			'is-trashing': this.state.isTrashing,
 		} );
-		const label = this.state.isTrashing
-			? this.props.translate( 'Trashing...' )
-			: this.props.translate( 'Move to trash' );
+		const label = this.state.isTrashing ? translate( 'Trashing…' ) : translate( 'Move to trash' );
 
 		return (
 			<div className="editor-delete-post">
@@ -103,6 +105,22 @@ class EditorDeletePost extends React.Component {
 	}
 }
 
-export default connect( state => ( {
-	site: getSelectedSite( state ),
-} ) )( localize( EditorDeletePost ) );
+export default connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
+		const postId = getEditorPostId( state );
+		const post = getEditedPost( state, siteId, postId );
+
+		const userId = getCurrentUserId( state );
+		const isAuthor = post.author && post.author.ID === userId;
+
+		return {
+			siteId,
+			post,
+			postId,
+			postStatus: post.status,
+			canDelete: canCurrentUser( state, siteId, isAuthor ? 'delete_posts' : 'delete_others_posts' ),
+		};
+	},
+	{ trashPost }
+)( localize( EditorDeletePost ) );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -635,7 +635,7 @@ export const PostEditor = createReactClass( {
 		page.back( this.getAllPostsUrl() );
 	},
 
-	getAllPostsUrl: function() {
+	getAllPostsUrl: function( context ) {
 		const { type, selectedSite } = this.props;
 		const site = selectedSite;
 
@@ -655,6 +655,10 @@ export const PostEditor = createReactClass( {
 			path += '/my';
 		}
 
+		if ( context === 'trashed' ) {
+			path += '/trashed';
+		}
+
 		if ( site ) {
 			path = addSiteFragment( path, site.slug );
 		}
@@ -668,21 +672,14 @@ export const PostEditor = createReactClass( {
 		} );
 	},
 
-	onTrashingPost: function( error ) {
-		var isPage = utils.isPage( this.state.post );
+	onTrashingPost: function() {
+		const { type } = this.props;
 
-		if ( error ) {
-			this.setState( {
-				notice: {
-					status: 'is-error',
-					message: 'trashFailure',
-				},
-			} );
-		} else {
-			recordStat( isPage ? 'page_trashed' : 'post_trashed' );
-			recordEvent( isPage ? 'Clicked Trash Page Button' : 'Clicked Trash Post Button' );
-			this.props.markSaved();
-		}
+		recordStat( type + '_trashed' );
+		recordEvent( 'page' === type ? 'Clicked Trash Page Button' : 'Clicked Trash Post Button' );
+		this.props.markSaved();
+
+		page( this.getAllPostsUrl( 'trashed' ) );
 	},
 
 	onSaveTrashed: function( status, callback ) {

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -12,8 +12,6 @@ import { successNotice, errorNotice } from 'state/notices/actions';
 import { getSitePost } from 'state/posts/selectors';
 import { getSiteDomain } from 'state/sites/selectors';
 import { getInviteForSite } from 'state/invites/selectors';
-import { canCurrentUser } from 'state/selectors';
-import { getCurrentUserId } from 'state/current-user/selectors';
 import { restorePost } from 'state/posts/actions';
 import {
 	ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
@@ -152,22 +150,13 @@ export const onPostRestoreFailure = action => ( dispatch, getState ) => {
 
 const onPostRestoreSuccess = () => successNotice( translate( 'Post successfully restored' ) );
 
-export function onPostSaveSuccess( dispatch, { post, savedPost }, getState ) {
+export function onPostSaveSuccess( dispatch, { post, savedPost } ) {
 	switch ( post.status ) {
 		case 'trash':
-			const state = getState();
-			const userId = getCurrentUserId( state );
-			const isAuthor = savedPost.author && savedPost.author.ID === userId;
-			const canRestore = canCurrentUser(
-				state,
-				savedPost.site_ID,
-				isAuthor ? 'delete_posts' : 'delete_others_posts'
-			);
-
 			dispatch(
 				successNotice( translate( 'Post successfully moved to trash.' ), {
-					button: canRestore ? translate( 'Undo' ) : null,
-					onClick: restorePost( savedPost.site_ID, savedPost.ID ),
+					button: translate( 'Undo' ),
+					onClick: () => dispatch( restorePost( savedPost.site_ID, savedPost.ID ) ),
 				} )
 			);
 			break;

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -150,7 +150,7 @@ export const onPostRestoreFailure = action => ( dispatch, getState ) => {
 
 const onPostRestoreSuccess = () => successNotice( translate( 'Post successfully restored' ) );
 
-export function onPostSaveSuccess( dispatch, { post, savedPost } ) {
+export const onPostSaveSuccess = ( { post, savedPost } ) => dispatch => {
 	switch ( post.status ) {
 		case 'trash':
 			const noticeId = 'trash_' + savedPost.global_ID;
@@ -170,7 +170,7 @@ export function onPostSaveSuccess( dispatch, { post, savedPost } ) {
 			dispatch( successNotice( translate( 'Post successfully published' ) ) );
 			break;
 	}
-}
+};
 
 export const onPublicizeConnectionCreate = ( { connection } ) =>
 	successNotice(

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -8,7 +8,7 @@ import { get, truncate, includes } from 'lodash';
 /**
  * Internal dependencies
  */
-import { successNotice, errorNotice } from 'state/notices/actions';
+import { successNotice, errorNotice, removeNotice } from 'state/notices/actions';
 import { getSitePost } from 'state/posts/selectors';
 import { getSiteDomain } from 'state/sites/selectors';
 import { getInviteForSite } from 'state/invites/selectors';
@@ -153,10 +153,15 @@ const onPostRestoreSuccess = () => successNotice( translate( 'Post successfully 
 export function onPostSaveSuccess( dispatch, { post, savedPost } ) {
 	switch ( post.status ) {
 		case 'trash':
+			const noticeId = 'trash_' + savedPost.global_ID;
 			dispatch(
 				successNotice( translate( 'Post successfully moved to trash.' ), {
+					id: noticeId,
 					button: translate( 'Undo' ),
-					onClick: () => dispatch( restorePost( savedPost.site_ID, savedPost.ID ) ),
+					onClick: () => {
+						dispatch( removeNotice( noticeId ) );
+						dispatch( restorePost( savedPost.site_ID, savedPost.ID ) );
+					},
 				} )
 			);
 			break;

--- a/client/state/notices/test/middleware.js
+++ b/client/state/notices/test/middleware.js
@@ -200,13 +200,13 @@ describe( 'middleware', () => {
 			} );
 
 			test( 'should dispatch success notice for trash', () => {
-				const noticeAction = onPostSaveSuccess( {
+				onPostSaveSuccess( {
 					type: POST_SAVE_SUCCESS,
 					post: { status: 'trash' },
 					savedPost: { global_ID: 'asdfjkl' },
-				} );
+				} )( dispatch );
 
-				expect( noticeAction ).toMatchObject( {
+				sinon.assert.calledWithMatch( dispatch, {
 					type: NOTICE_CREATE,
 					notice: {
 						status: 'is-success',
@@ -218,12 +218,12 @@ describe( 'middleware', () => {
 			} );
 
 			test( 'should dispatch success notice for publish', () => {
-				const noticeAction = onPostSaveSuccess( {
+				onPostSaveSuccess( {
 					type: POST_SAVE_SUCCESS,
 					post: { status: 'publish' },
-				} );
+				} )( dispatch );
 
-				expect( noticeAction ).toMatchObject( {
+				sinon.assert.calledWithMatch( dispatch, {
 					type: NOTICE_CREATE,
 					notice: {
 						status: 'is-success',

--- a/client/state/notices/test/middleware.js
+++ b/client/state/notices/test/middleware.js
@@ -203,13 +203,16 @@ describe( 'middleware', () => {
 				const noticeAction = onPostSaveSuccess( {
 					type: POST_SAVE_SUCCESS,
 					post: { status: 'trash' },
+					savedPost: { global_ID: 'asdfjkl' },
 				} );
 
 				expect( noticeAction ).toMatchObject( {
 					type: NOTICE_CREATE,
 					notice: {
 						status: 'is-success',
-						text: 'Post successfully moved to trash',
+						noticeId: 'trash_asdfjkl',
+						text: 'Post successfully moved to trash.',
+						button: 'Undo',
 					},
 				} );
 			} );


### PR DESCRIPTION
Currently when a user clicks "Move to Trash" in the editor, they're presented with a confirmation dialog, and after confirming, are immediately presented with another dialog that encourages them to restore the post. 

This PR closes the editor after the user confirms moving it to the trash, and returns the user to the Trashed posts view.

Fixes #20663.

![delete-post](https://user-images.githubusercontent.com/942359/37542858-f226d690-2935-11e8-9e39-05bd51822dcb.gif)

_Note: I left the the deleted post messages and functionality in `EditorRestorePostDialog` because a user can still visit a deleted post from the Trashed list, and would need to restore before editing._

**To test Editor deletion/restore:**
- Create a post or custom post type.
- In the editor, click "Move to Trash".
- Verify that the editor is closed and you are redirected to the "Trashed" posts list.
- Verify that a success notice is shown with a button to "Undo".
- Verify that clicking the button removes the current trash success notice, restores the trashed item, and shows a restore success notice.

**To test Post List deletion/restore:**
- Visit your post list.
- Using the ellipsis menu for a post, trash a post.
- Verify that a success notice is shown with a button to "Undo".
- Verify that clicking the button removes the current trash success notice, restores the trashed item, and shows a restore success notice.
