### PR TITLE
Store: only poll status on labels for which purchase has not yet been confirmed

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -567,7 +567,9 @@ const pollForLabelsPurchase = ( orderId, siteId, dispatch, getState, labels ) =>
 
 	if ( ! every( labels, { status: 'PURCHASED' } ) ) {
 		setTimeout( () => {
-			const statusTasks = labels.map( ( label ) => labelStatusTask( orderId, siteId, label.label_id, 0 ) );
+			const statusTasks = labels.map( ( label ) => {
+				return label.status === 'PURCHASED' ? label : labelStatusTask( orderId, siteId, label.label_id, 0 );
+			} );
 
 			Promise.all( statusTasks )
 				.then( ( pollResponse ) => pollForLabelsPurchase( orderId, siteId, dispatch, getState, pollResponse ) )


### PR DESCRIPTION
Minor optimization to avoid unnecessary network requests polling for label status when the status for an individual label already came back as `PURCHASED` in the previous request.

Tested by counting status requests (filter: `/connect\/label\/30\/\d+/`) upon triggering purchase. In `master`, it's a multiple of the number of packages (counted 16 requests for 8 labels), but in this branch, it doesn't have to be (counted 12 requests for 8 labels).