### PR TITLE
Rewind: update styles so it follows mockups more closely

### DIFF
--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -181,7 +181,7 @@ export class RewindCredentialsForm extends Component {
 					</FormFieldset>
 				</div>
 
-				<div className="rewind-credentials-form__row">
+				<div className="rewind-credentials-form__row rewind-credentials-form__user-pass">
 					<FormFieldset className="rewind-credentials-form__username">
 						<FormLabel htmlFor="server-username">{ translate( 'Server username' ) }</FormLabel>
 						<FormTextInput

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -28,10 +28,13 @@ export class NavigationLink extends Component {
 		previousPath: PropTypes.string,
 		signupProgress: PropTypes.array,
 		stepName: PropTypes.string.isRequired,
+		// Allows to force a back button in the first step for example.
+		allowBackFirstStep: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		labelText: '',
+		allowBackFirstStep: false,
 	};
 
 	/**
@@ -104,7 +107,8 @@ export class NavigationLink extends Component {
 		if (
 			this.props.positionInFlow === 0 &&
 			this.props.direction === 'back' &&
-			! this.props.stepSectionName
+			! this.props.stepSectionName &&
+			! this.props.allowBackFirstStep
 		) {
 			return null;
 		}

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -22,6 +22,13 @@ class StepWrapper extends Component {
 		hideFormattedHeader: PropTypes.bool,
 		hideBack: PropTypes.bool,
 		hideSkip: PropTypes.bool,
+		// Allows to force a back button in the first step for example.
+		// You should only force this when you're passing a backUrl.
+		allowBackFirstStep: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		allowBackFirstStep: false,
 	};
 
 	renderBack() {
@@ -38,6 +45,7 @@ class StepWrapper extends Component {
 				backUrl={ this.props.backUrl }
 				signupProgress={ this.props.signupProgress }
 				labelText={ this.props.backLabelText }
+				allowBackFirstStep={ this.props.allowBackFirstStep }
 			/>
 		);
 	}

--- a/client/signup/steps/rewind-add-creds/index.jsx
+++ b/client/signup/steps/rewind-add-creds/index.jsx
@@ -5,6 +5,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,6 +23,9 @@ class RewindAddCreds extends Component {
 		positionInFlow: PropTypes.number,
 		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
+
+		// Connected props
+		siteSlug: PropTypes.string.isRequired,
 	};
 
 	goToCredsForm = () => {
@@ -43,9 +48,9 @@ class RewindAddCreds extends Component {
 				<img src="/calypso/images/illustrations/security.svg" alt="" />
 				<p className="rewind-add-creds__description rewind-switch__description">
 					{ translate(
-						'To switch you over to Jetpack backups and security we need you to add your site credentials. ' +
-							'This gives WordPress.com access to your site to perform automatic actions on your server—like backups. ' +
-							'It also allows us to restore your site and manually access it in case of an emergency.'
+						'To activate Jetpack backups and security, please add your site credentials. ' +
+						'WordPress.com will then be able to access your site to perform automatic backups, ' +
+						'and to restore your site in case of an emergency.'
 					) }
 				</p>
 				<Button primary onClick={ this.goToCredsForm }>
@@ -65,10 +70,16 @@ class RewindAddCreds extends Component {
 				stepContent={ this.stepContent() }
 				hideFormattedHeader={ true }
 				hideSkip={ true }
-				hideBack={ true }
+				hideBack={ false }
+				backUrl={ `/stats/activity/${ this.props.siteSlug }` }
+				allowBackFirstStep={ true }
 			/>
 		);
 	}
 }
 
-export default localize( RewindAddCreds );
+export default connect( ( state, ownProps ) => {
+	return {
+		siteSlug: get( ownProps, [ 'initialContext', 'query', 'siteSlug' ], '' ),
+	};
+}, null )( localize( RewindAddCreds ) );

--- a/client/signup/steps/rewind-form-creds/index.jsx
+++ b/client/signup/steps/rewind-form-creds/index.jsx
@@ -16,6 +16,7 @@ import Card from 'components/card';
 import SignupActions from 'lib/signup/actions';
 import RewindCredentialsForm from 'components/rewind-credentials-form';
 import { getRewindState } from 'state/selectors';
+import SetupFooter from 'my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer';
 
 class RewindFormCreds extends Component {
 	static propTypes = {
@@ -62,8 +63,8 @@ class RewindFormCreds extends Component {
 	stepContent = () => {
 		const { translate, siteId } = this.props;
 
-		return (
-			<Card className="rewind-form-creds__card rewind-switch__card rewind-switch__content">
+		return [
+			<div key="rewind-form-creds__header" className="rewind-form-creds__header">
 				<h3 className="rewind-form-creds__title rewind-switch__heading">
 					{ translate( 'Site credentials' ) }
 				</h3>
@@ -72,9 +73,18 @@ class RewindFormCreds extends Component {
 						"We'll guide you through the process of finding and entering your site's credentials."
 					) }
 				</p>
+			</div>,
+			<Card
+				key="rewind-form-creds__card"
+				className="rewind-form-creds__card rewind-switch__card rewind-switch__content"
+			>
+				<Card compact className="rewind-form-creds__legend">
+					{ translate( 'Enter your credentials' ) }
+				</Card>
 				<RewindCredentialsForm role="main" siteId={ siteId } allowCancel={ false } />
-			</Card>
-		);
+				<SetupFooter />
+			</Card>,
+		];
 	};
 
 	render() {

--- a/client/signup/steps/rewind-form-creds/index.jsx
+++ b/client/signup/steps/rewind-form-creds/index.jsx
@@ -87,7 +87,7 @@ class RewindFormCreds extends Component {
 				stepContent={ this.stepContent() }
 				hideFormattedHeader={ true }
 				hideSkip={ true }
-				hideBack={ true }
+				hideBack={ false }
 			/>
 		);
 	}

--- a/client/signup/steps/rewind-form-creds/style.scss
+++ b/client/signup/steps/rewind-form-creds/style.scss
@@ -1,4 +1,22 @@
+.rewind-form-creds__header {
+	text-align: center;
+	margin-top: 16px;
+
+	.rewind-switch__description {
+		max-width: 100%;
+	}
+}
+
 .rewind-form-creds__card {
+	margin-top: 16px;
+	padding: 0;
+
+	.rewind-form-creds__legend {
+		margin: 0 0 24px;
+		width: 100%;
+		text-align: left;
+	}
+
 	img {
 		max-width: 200px;
 		display: block;
@@ -6,6 +24,27 @@
 	}
 
 	.rewind-credentials-form {
+		text-align: left;
+		width: 90%;
+
+		.rewind-credentials-form__user-pass {
+			display: block;
+		}
+	}
+
+	.button.is-primary {
+		float: right;
+		padding-left: 32px;
+		padding-right: 32px;
+	}
+
+	.button.is-primary.rewind-credentials-form__advanced-button {
+		float: none;
+		padding: 8px 0;
+	}
+
+	.credentials-setup-flow__footer {
+		width: 100%;
 		text-align: left;
 	}
 }

--- a/client/signup/steps/rewind-migrate/style.scss
+++ b/client/signup/steps/rewind-migrate/style.scss
@@ -7,7 +7,7 @@
 .rewind-switch__card, .rewind-auto-config__card {
 	text-align: center;
 	margin: 1px auto;
-	max-width: 640px;
+	max-width: 670px;
 }
 
 .rewind-migrate__card {
@@ -23,6 +23,14 @@
 	align-items: center;
 	flex-direction: column;
 	padding: 4rem 4rem 3rem;
+	margin-top: 48px;
+
+	& + .step-wrapper__buttons .navigation-link {
+		position: absolute;
+		top: -6px;
+		left: 32px;
+		margin: 0;
+	}
 }
 
 .rewind-switch__heading {


### PR DESCRIPTION
Fixes #22858

This PR updates Rewind flow styling so they look like the mockups.

It also allows `NavigationLink`component to accept a new prop `allowBackFirstStep` that allows to display a Back arrow in the first step of a flow. It will be displayed as long as there's a proper `backUrl` prop to use.

#### Update to first step plus Back button

<img width="1021" alt="captura de pantalla 2018-03-16 a la s 19 38 09" src="https://user-images.githubusercontent.com/1041600/37547629-9d4ae5a0-2951-11e8-96f7-334339baf9b3.png">

#### Update to credentials form in flow

<img width="1153" alt="captura de pantalla 2018-03-16 a la s 19 32 41" src="https://user-images.githubusercontent.com/1041600/37547527-fdae7458-2950-11e8-9e83-aeb7423a651f.png">

#### Testing

Launch
https://calypso.live/?branch=update/rewind/switch-migrate-flow
and visit
https://calypso.live/start/rewind-setup/rewind-add-creds?siteId=%YOURSITEID%&siteSlug=%YOURSITESLUG%

1. verify that the Back button/arrow at the top left takes you back to Activity Log
2. click `Add your credentials` to continue to the form