### PR TITLE
[Domains] Polish search filters

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -198,7 +198,8 @@ $z-layers: (
 		'input.input-chrono': 1,
 		'.popover .popover__arrow': 1,
 		'.post-schedule__header': 1,
-		'.date-picker__nav-bar': 2
+		'.date-picker__nav-bar': 2,
+		'.search-filters__popover': 179,
 	),
 	'.search': (
 		'.search__input': 10,

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -367,7 +367,7 @@ class RegisterDomainStep extends React.Component {
 		this.onSearchChange( this.state.lastQuery, () => this.onSearch( this.state.lastQuery ) );
 	};
 
-	getSetFiltersForAPI() {
+	getActiveFiltersForAPI() {
 		const { filters } = this.state;
 		return {
 			...mapKeys(
@@ -488,7 +488,7 @@ class RegisterDomainStep extends React.Component {
 			tld_weight_overrides: this.getTldWeightOverrides(),
 			vendor: searchVendor,
 			vertical: this.props.surveyVertical,
-			...this.getSetFiltersForAPI(),
+			...this.getActiveFiltersForAPI(),
 		};
 
 		domains
@@ -590,7 +590,7 @@ class RegisterDomainStep extends React.Component {
 			tld_weight_overrides: null,
 			vendor: 'wpcom',
 			vertical: this.props.surveyVertical,
-			...this.getSetFiltersForAPI(),
+			...this.getActiveFiltersForAPI(),
 		};
 
 		domains

--- a/client/components/domains/search-filters/more-filters.jsx
+++ b/client/components/domains/search-filters/more-filters.jsx
@@ -189,9 +189,9 @@ export class MoreFiltersControl extends Component {
 					errorMessages={ this.getOverallValidationErrors() }
 				>
 					<div className="search-filters__buttons">
-						<Button onClick={ this.handleFiltersReset }>Reset</Button>
+						<Button onClick={ this.handleFiltersReset }>{ translate( 'Reset' ) }</Button>
 						<Button primary onClick={ this.handleFiltersSubmit }>
-							Apply
+							{ translate( 'Apply' ) }
 						</Button>
 					</div>
 				</ValidationFieldset>

--- a/client/components/domains/search-filters/more-filters.jsx
+++ b/client/components/domains/search-filters/more-filters.jsx
@@ -116,7 +116,7 @@ export class MoreFiltersControl extends Component {
 					<Gridicon icon="chevron-down" size={ 24 } />
 				</Button>
 
-				{ this.renderPopover() }
+				{ this.state.showPopover && this.renderPopover() }
 			</div>
 		);
 	}

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -1,5 +1,12 @@
+/** @format */
+
 .search-filters__popover {
 	width: 28em;
+
+	// Use increased specificty to override default z-index for popovers
+	&.popover {
+		z-index: z-index('.popover', '.search-filters__popover');
+	}
 
 	.popover__inner {
 		padding: 2em;


### PR DESCRIPTION
Addresses review feedback from [here](https://github.com/Automattic/wp-calypso/pull/22965#pullrequestreview-104646213). 

Testing instructions remain identical to #22965, which I've reproduced below for your convenience:

### Testing instructions
1. Spin up this branch locally.
2. Navigate to [`/start/domains`](http://calypso.localhost:3000/start/domains).
3. Ensure presence of the `More Filters` popover button.
4. Ensure that clicking the button spawns a popover with the following controls:
    - Max characters filter, defaulting to empty.
    - Exact matches filter, defaulting to unchecked (false).
    - Exclude dashes filter, defaulting to checked (true).
5. Ensure that enacting any of the filters by clicking `Apply` refreshes the domain search with a corresponding network request. Two things to note:
    - The results will not actually be filtered since such functionality has not yet been implemented in the server.
    - In its current design, the network request will only contain filter values that are defined. Currently, that means either a true/false boolean or a lengthy string containing numbers.

![wordpress_com](https://user-images.githubusercontent.com/4044428/37430149-e71eff52-2796-11e8-8164-f91c40e5c0fd.png)

6. Ensure that resetting the filters by clicking `Reset` refreshes the domain search results with a corresponding network request.

7. Ensure that no other behavioral changes have been introduced to the page.