### PR TITLE
Plans: update My Plan feature card copy content

### DIFF
--- a/client/blocks/product-purchase-features-list/advertising-removed.jsx
+++ b/client/blocks/product-purchase-features-list/advertising-removed.jsx
@@ -20,12 +20,10 @@ export default localize( ( { isBusinessPlan, translate } ) => {
 				title={ translate( 'Advertising removed' ) }
 				description={
 					isBusinessPlan
-						? translate(
-								'All WordPress.com advertising has been removed from your site.'
-							)
+						? translate( 'All WordPress.com advertising has been removed from your site.' )
 						: translate(
 								'All WordPress.com advertising has been removed from your site. ' +
-									' Upgrade to remove the WordPress.com footer credit.'
+									'Upgrade to remove the WordPress.com footer credit.'
 							)
 				}
 			/>

--- a/client/blocks/product-purchase-features-list/advertising-removed.jsx
+++ b/client/blocks/product-purchase-features-list/advertising-removed.jsx
@@ -24,8 +24,8 @@ export default localize( ( { isBusinessPlan, translate } ) => {
 								'All WordPress.com advertising has been removed from your site.'
 							)
 						: translate(
-								'All WordPress.com advertising has been removed from your site.' +
-									'Upgrade to remove the WordPress.com footer credit.'
+								'All WordPress.com advertising has been removed from your site. ' +
+									' Upgrade to remove the WordPress.com footer credit.'
 							)
 				}
 			/>

--- a/client/blocks/product-purchase-features-list/advertising-removed.jsx
+++ b/client/blocks/product-purchase-features-list/advertising-removed.jsx
@@ -21,11 +21,11 @@ export default localize( ( { isBusinessPlan, translate } ) => {
 				description={
 					isBusinessPlan
 						? translate(
-								'With your plan, all WordPress.com advertising has been removed from your site.'
+								'All WordPress.com advertising has been removed from your site.'
 							)
 						: translate(
-								'With your plan, all WordPress.com advertising has been removed from your site.' +
-									' You can upgrade to a Business plan to also remove the WordPress.com footer credit.'
+								'All WordPress.com advertising has been removed from your site.' +
+									'Upgrade to remove the WordPress.com footer credit.'
 							)
 				}
 			/>

--- a/client/blocks/product-purchase-features-list/business-onboarding.jsx
+++ b/client/blocks/product-purchase-features-list/business-onboarding.jsx
@@ -18,10 +18,10 @@ export default localize( ( { translate, link, onClick = noop } ) => {
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon="help"
-				title={ translate( 'Get personalized help' ) }
+				title={ translate( 'Concierge orientation' ) }
 				description={ translate(
-					'Schedule a one-on-one orientation with a Happiness Engineer ' +
-						'to set up your site and learn more about WordPress.com.'
+					'Schedule a one-on-one orientation session to set up your site ' +
+						'and learn more about WordPress.com.'
 				) }
 				buttonText={ translate( 'Schedule a session' ) }
 				href={ link }

--- a/client/blocks/product-purchase-features-list/customize-theme.jsx
+++ b/client/blocks/product-purchase-features-list/customize-theme.jsx
@@ -32,8 +32,8 @@ export default localize( ( { selectedSite, translate } ) => {
 				icon={ <img alt="" src="/calypso/images/upgrades/customize-theme.svg" /> }
 				title={ translate( 'Advanced customization' ) }
 				description={ translate(
-					"Change your site’s appearance in a few clicks, with an expanded selection" +
-						"of fonts and colors, and access to custom CSS."
+					"Change your site's appearance in a few clicks, with an expanded " +
+						'selection of fonts and colors, and access to custom CSS.'
 				) }
 				buttonText={ translate( 'Start customizing' ) }
 				href={ getCustomizeLink( selectedSite ) }

--- a/client/blocks/product-purchase-features-list/customize-theme.jsx
+++ b/client/blocks/product-purchase-features-list/customize-theme.jsx
@@ -30,10 +30,10 @@ export default localize( ( { selectedSite, translate } ) => {
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon={ <img alt="" src="/calypso/images/upgrades/customize-theme.svg" /> }
-				title={ translate( 'Customize your theme' ) }
+				title={ translate( 'Advanced customization' ) }
 				description={ translate(
-					"You now have direct control over your site's fonts and colors in the customizer. " +
-						"Change your site's entire look in a few clicks."
+					"Change your site’s appearance in a few clicks, with an expanded selection" +
+						"of fonts and colors, and access to custom CSS."
 				) }
 				buttonText={ translate( 'Start customizing' ) }
 				href={ getCustomizeLink( selectedSite ) }

--- a/client/blocks/product-purchase-features-list/find-new-theme.jsx
+++ b/client/blocks/product-purchase-features-list/find-new-theme.jsx
@@ -17,9 +17,9 @@ export default localize( ( { selectedSite, translate } ) => {
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon={ <img alt="" src="/calypso/images/upgrades/customize-theme.svg" /> }
-				title={ translate( 'Try a New Theme' ) }
+				title={ translate( 'Premium themes' ) }
 				description={ translate(
-					"You've now got access to every premium theme, at no extra cost - that's hundreds of new options. Give one a try!"
+					'Access hundreds of beautifully designed premium themes at no extra cost.'
 				) }
 				buttonText={ translate( 'Browse premium themes' ) }
 				href={ '/themes/' + selectedSite.slug }

--- a/client/blocks/product-purchase-features-list/google-analytics-stats.jsx
+++ b/client/blocks/product-purchase-features-list/google-analytics-stats.jsx
@@ -17,7 +17,7 @@ export default localize( ( { selectedSite, translate } ) => {
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon={ <img alt="" src="/calypso/images/upgrades/adwords.svg" /> }
-				title={ translate( 'Connect to Google Analytics' ) }
+				title={ translate( 'Google Analytics' ) }
 				description={ translate(
 					"Complement WordPress.com's stats with Google's in-depth look at your visitors and traffic patterns."
 				) }

--- a/client/blocks/product-purchase-features-list/jetpack-anti-spam.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-anti-spam.jsx
@@ -18,7 +18,7 @@ export default localize( ( { translate } ) => {
 			<PurchaseDetail
 				icon="comment"
 				title={ translate( 'Spam Filtering' ) }
-				description={ translate( 'Spam is being automatically filtered.' ) }
+				description={ translate( 'Spam is automatically blocked from your comments.' ) }
 			/>
 		</div>
 	);

--- a/client/blocks/product-purchase-features-list/jetpack-backup-security.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-backup-security.jsx
@@ -21,7 +21,7 @@ const JetpackBackupSecurity = ( { backupEngine, site, siteId, translate } ) => (
 			icon="flag"
 			title={ translate( 'Site Security' ) }
 			description={ translate(
-				'Your site is being securely backed up and scanned with real-time sync.'
+				'Your site is safe with secure backups and real-time scans.'
 			) }
 			buttonText={
 				backupEngine === 'rewind'

--- a/client/blocks/product-purchase-features-list/jetpack-publicize.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-publicize.jsx
@@ -19,7 +19,7 @@ export default localize( ( { translate } ) => {
 				icon="comment"
 				title={ translate( 'Marketing Automation' ) }
 				description={ translate(
-					'Schedule tweets, Facebook posts, and other social posts in advance. ' + 'No limits.'
+					'Schedule unlimited tweets, Facebook posts, and other social posts in advance.'
 				) }
 			/>
 		</div>

--- a/client/blocks/product-purchase-features-list/jetpack-return-to-dashboard.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-return-to-dashboard.jsx
@@ -25,6 +25,9 @@ export default localize( ( { selectedSite, translate, onClick = noop } ) => {
 			<PurchaseDetail
 				icon="house"
 				title={ translate( 'Return to your Jetpack dashboard' ) }
+				description={ translate(
+					'Access your Jetpack Dashboard from your self-hosted WordPress site’s wp-admin.'
+				) }
 				buttonText={ translate( 'Go back to %(site)s', { args: { site: selectedSite.name } } ) }
 				href={ adminURL }
 				onClick={ onClick }

--- a/client/blocks/product-purchase-features-list/jetpack-search.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-search.jsx
@@ -17,10 +17,10 @@ export default localize( ( { selectedSite, translate } ) => {
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon="search"
-				title={ translate( 'Search' ) }
+				title={ translate( 'Jetpack search' ) }
 				description={ translate(
 					'Replace the default WordPress search with better results ' +
-						'and filtering that will help your users find what they are looking for.'
+						'and filtering powered by Elasticsearch.'
 				) }
 				buttonText={ translate( 'Enable Search in Traffic Settings' ) }
 				href={ '/settings/traffic/' + selectedSite.slug }

--- a/client/blocks/product-purchase-features-list/jetpack-video.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-video.jsx
@@ -19,8 +19,7 @@ export default localize( ( { translate } ) => {
 				icon="image-multiple"
 				title={ translate( 'Video Hosting' ) }
 				description={ translate(
-					'High-speed, high-definition video hosting that uses your server space efficiently, ' + 
-						' and comes with no third-party ads.'
+					'High-speed, high-definition video hosting that uses your server space efficiently, and comes with no third-party ads.'
 				) }
 			/>
 		</div>

--- a/client/blocks/product-purchase-features-list/jetpack-video.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-video.jsx
@@ -19,8 +19,8 @@ export default localize( ( { translate } ) => {
 				icon="image-multiple"
 				title={ translate( 'Video Hosting' ) }
 				description={ translate(
-					"High-speed video hosting that doesn't eat up your server space. " +
-						'High-definition and no third-party ads.'
+					'High-speed, high-definition video hosting that uses your server space efficiently, ' + 
+						' and comes with no third-party ads.'
 				) }
 			/>
 		</div>

--- a/client/blocks/product-purchase-features-list/jetpack-wordpress-com.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-wordpress-com.jsx
@@ -19,13 +19,7 @@ export default localize( ( { selectedSite, translate } ) => {
 				icon="plugins"
 				title={ translate( 'Automatic Updates' ) }
 				description={ translate(
-					'Keep your plugins securely updated and manage your site from ' +
-						'{{a}}mobile apps{{/a}}.',
-					{
-						components: {
-							a: <a href="https://apps.wordpress.com/" />,
-						},
-					}
+					'Keep your plugins up-to-date, hassle-free.',
 				) }
 				buttonText={ translate( 'Configure auto updates' ) }
 				href={ `/plugins/manage/${ selectedSite.slug }` }

--- a/client/blocks/product-purchase-features-list/monetize-site.jsx
+++ b/client/blocks/product-purchase-features-list/monetize-site.jsx
@@ -20,10 +20,9 @@ export default localize( ( { selectedSite, translate } ) => {
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon={ <img alt="" src="/calypso/images/upgrades/word-ads.svg" /> }
-				title={ translate( 'Easily monetize your site' ) }
+				title={ translate( 'Monetize your site with ads' ) }
 				description={ translate(
-					'Take advantage of WordAds instant activation on your upgraded site. ' +
-						'WordAds lets you earn money by displaying promotional content.'
+					'WordAds lets you earn money by displaying promotional content. Start earning today. '
 				) }
 				buttonText={ translate( 'Start earning' ) }
 				href={ adSettingsUrl }

--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -47,8 +47,8 @@ export class HappinessSupport extends Component {
 	getHeadingText() {
 		const { isJetpackFreePlan, translate } = this.props;
 		return isJetpackFreePlan
-			? translate( 'Find answers in our documentation' )
-			: translate( 'Enjoy priority support from our Happiness Engineers' );
+			? translate( 'Support documentation' )
+			: translate( 'Priority support' );
 	}
 
 	getSupportText() {
@@ -58,11 +58,11 @@ export class HappinessSupport extends Component {
 		};
 		return isJetpackFreePlan
 			? translate(
-					'{{strong}}Need help?{{/strong}} Search our support site to find out more about how to make the most of your Jetpack site.', // eslint-disable-line max-len
+					'{{strong}}Need help?{{/strong}} Search our support site to find out about your site, your account, and how to make the most of WordPress.', // eslint-disable-line max-len
 					{ components }
 				)
 			: translate(
-					'{{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site, your account, or how to do just about anything.', // eslint-disable-line max-len
+					'{{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site and your account.', // eslint-disable-line max-len
 					{ components }
 				);
 	}

--- a/client/components/happiness-support/test/index.jsx
+++ b/client/components/happiness-support/test/index.jsx
@@ -32,16 +32,14 @@ describe( 'HappinessSupport', () => {
 	test( 'should render translated heading content', () => {
 		const heading = wrapper.find( 'h3' );
 		expect( heading ).to.have.length( 1 );
-		expect( heading.props().children ).to.equal(
-			'Translated: Enjoy priority support from our Happiness Engineers'
-		);
+		expect( heading.props().children ).to.equal( 'Translated: Priority support' );
 	} );
 
 	test( 'should render translated help content', () => {
 		const content = wrapper.find( 'p.happiness-support__text' );
 		expect( content ).to.have.length( 1 );
 		expect( content.props().children ).to.equal(
-			'Translated: {{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site, your account, or how to do just about anything.' // eslint-disable-line max-len
+			'Translated: {{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site and your account.' // eslint-disable-line max-len
 		);
 	} );
 

--- a/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -21,12 +21,7 @@ const CustomDomainPurchaseDetail = ( { selectedSite, hasDomainCredit, translate 
 				icon={ <img src="/calypso/images/upgrades/custom-domain.svg" /> }
 				title={ translate( 'Select your custom domain' ) }
 				description={ translate(
-					'Your plan includes a free custom domain. Replace {{em}}%(siteDomain)s{{/em}} ' +
-						'with a custom domain to personalize your site. Does not apply to premium domains.',
-					{
-						args: { siteDomain: selectedSite.domain },
-						components: { em: <em /> },
-					}
+					'Your plan includes a free custom domain, which gives your site a more professional, branded feel.'
 				) }
 				buttonText={ translate( 'Claim your free domain' ) }
 				href={ `/domains/add/${ selectedSite.slug }` }

--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
@@ -238,12 +238,7 @@ class GoogleVoucherDetails extends Component {
 					icon={ <img src="/calypso/images/upgrades/adwords.svg" /> }
 					title={ translate( 'Google AdWords credit' ) }
 					description={ translate(
-						'Use your {{strong}}$100{{/strong}} in credit with Google to bring the right traffic to your most important Posts and Pages.',
-						{
-							components: {
-								strong: <strong />,
-							},
-						}
+						'Use a $100 credit with Google to bring traffic to your most important Posts and Pages.'
 					) }
 					body={ body }
 				/>

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -75,7 +75,7 @@ class CurrentPlanHeader extends Component {
 				<div className={ classes }>
 					<span className="current-plan__header-expires-in">
 						{ hasAutoRenew && currentPlan.autoRenewDateMoment
-							? translate( 'Set to Auto Renew on %s.', {
+							? translate( 'Set to auto-renew on %s.', {
 									args: invoke( currentPlan, 'autoRenewDateMoment.format', 'LL' ),
 								} )
 							: translate( 'Expires on %s.', {


### PR DESCRIPTION
This PR updates _copy content only_ in the feature cards on the My Plan page. 

ref: p6TEKc-1SF

**Jetpack Before/After:**

Free
<img width="1395" alt="screen shot 2018-03-16 at 4 55 01 pm" src="https://user-images.githubusercontent.com/204742/37548111-4e039cbe-293b-11e8-9688-7ff8381c2e24.png">

Personal
<img width="1392" alt="screen shot 2018-03-16 at 4 55 09 pm" src="https://user-images.githubusercontent.com/204742/37548113-514ddd12-293b-11e8-9126-316e7e449ce3.png">

Premium 
<img width="1391" alt="screen shot 2018-03-16 at 4 55 18 pm" src="https://user-images.githubusercontent.com/204742/37548115-54588bec-293b-11e8-84aa-9e858fb8df5c.png">

Professional
<img width="1234" alt="screen shot 2018-03-16 at 4 55 31 pm" src="https://user-images.githubusercontent.com/204742/37548162-ac0c21aa-293b-11e8-88e2-13e51f6aa96f.png">


**WordPress.com Before/After:**

Free (UNCHANGED)

Personal
<img width="1378" alt="screen shot 2018-03-16 at 4 57 34 pm" src="https://user-images.githubusercontent.com/204742/37548167-b71233f0-293b-11e8-85ba-e83393aa475b.png">

Premium
<img width="1386" alt="screen shot 2018-03-16 at 4 57 53 pm" src="https://user-images.githubusercontent.com/204742/37548172-bbcc3bb6-293b-11e8-87d5-c3db2827d403.png">

Business
<img width="1144" alt="screen shot 2018-03-16 at 4 58 05 pm" src="https://user-images.githubusercontent.com/204742/37548180-c32ccf9c-293b-11e8-9fb6-ba5d8172b407.png">


**NOT INCLUDED IN THIS PR** (to come in subsequent PRs): 
1. Adding CTA buttons to cards that don't yet have it 
2. Styling to match final mockups (ref: p6TEKc-1SF). 
3. Adding new cards for mobile apps and simple payments (PayPal).

Testing instructions:
* checkout this branch
* go to http://calypso.localhost:3000/plans/my-plan/:site for Jetpack and WPcom sites on different plans
* confirm the changes look like the "After" views for all plan levels across Jetpack and WPcom sites.