### PR TITLE
Simple Payments: Fix broken screens from invalid product prices.

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/list-item.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/list-item.jsx
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -65,6 +66,10 @@ class ProductListItem extends Component {
 			translate,
 		} = this.props;
 		const radioId = `simple-payments-list-item-radio-${ paymentId }`;
+		const labelClasses = classnames( {
+			'editor-simple-payments-modal__list-label': true,
+			'is-error': isNaN( price ),
+		} );
 
 		return (
 			<CompactCard className="editor-simple-payments-modal__list-item">
@@ -75,7 +80,7 @@ class ProductListItem extends Component {
 					checked={ isSelected }
 					onChange={ this.handleRadioChange }
 				/>
-				<label className="editor-simple-payments-modal__list-label" htmlFor={ radioId }>
+				<label className={ labelClasses } htmlFor={ radioId }>
 					<div className="editor-simple-payments-modal__list-name">{ title }</div>
 					<div>{ this.formatPrice( price, currency ) }</div>
 				</label>

--- a/client/components/tinymce/plugins/simple-payments/dialog/list-item.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/list-item.jsx
@@ -19,6 +19,7 @@ import { getCurrencyObject } from 'lib/format-currency';
 import CompactCard from 'components/card/compact';
 import EllipsisMenu from 'components/ellipsis-menu';
 import FormRadio from 'components/forms/form-radio';
+import log from 'lib/catch-js-errors/log';
 import PopoverMenuItem from 'components/popover/menu-item';
 import ProductImage from './product-image';
 
@@ -41,6 +42,11 @@ class ProductListItem extends Component {
 
 	formatPrice( price, currency = 'USD' ) {
 		if ( isNaN( price ) ) {
+			log( 'Simple Payments: invalid price value', {
+				siteId: this.props.siteId,
+				paymentId: this.props.paymentId,
+				price,
+			} );
 			return `---- ${ currency }`;
 		}
 		const { integer, fraction } = getCurrencyObject( price, currency );

--- a/client/components/tinymce/plugins/simple-payments/dialog/list-item.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/list-item.jsx
@@ -40,6 +40,9 @@ class ProductListItem extends Component {
 	handleTrashClick = () => this.props.onTrashClick( this.props.paymentId );
 
 	formatPrice( price, currency = 'USD' ) {
+		if ( isNaN( price ) ) {
+			return `---- ${ currency }`;
+		}
 		const { integer, fraction } = getCurrencyObject( price, currency );
 		return `${ integer }${ fraction } ${ currency }`;
 	}

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -186,6 +186,10 @@
 	min-width: 0;
 	font-family: $serif;
 	font-weight: bold;
+
+	&.is-error {
+		color: $alert-red;
+	}
 }
 
 .editor-simple-payments-modal__list-name {


### PR DESCRIPTION
This PR allows us to avoid fatals if invalid prices cause `getCurrencyObject` to return null. It will display the invalid price as `----`, hopefully prompting the user to edit the price. At some point, some users were able to somehow enter strings of text for the price; this is no longer possible, at least with the Simple Payments form validation.

<img width="514" alt="screen shot 2018-03-16 at 4 50 57 pm" src="https://user-images.githubusercontent.com/349751/37549108-48f9b754-293a-11e8-9d7c-17f65f1ddf60.png">


It's a very quick, shallow approach to larger issues. The price (and other Simple Payment data) are stored as post meta on their CPT posts, and intentionally stored as `string`s – this is a requirement for the server-side calls to the PayPal API, but problematic once in Calypso (or presumably any other client).

Further PRs that should happen include defining and improving behaviour; I'm thinking that if a product has an invalid price, we should:
* inform the user viewing the product list to go into the ellipsis menu to edit the product's price,
* identify the invalid price in the content editor ("invalid price – please correct"),
* ensure that any products with pricing issues are not displayed on the front-end.

Fixes #23213 .