### PR TITLE
Build: Disable uglify compress conditionals

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -285,8 +285,18 @@ if ( shouldMinify ) {
 		new UglifyJsPlugin( {
 			cache: 'docker' !== process.env.CONTAINER,
 			parallel: true,
-			uglifyOptions: { ecma: 5 },
 			sourceMap: Boolean( process.env.SOURCEMAP ),
+			uglifyOptions: {
+				compress: {
+					/**
+					 * Produces inconsistent results
+					 * Enable when the following is resolved:
+					 * https://github.com/mishoo/UglifyJS2/issues/3010
+					 */
+					conditionals: false,
+				},
+				ecma: 5,
+			},
 		} )
 	);
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -102,8 +102,8 @@ const webpackConfig = {
 	output: {
 		path: path.join( __dirname, 'public' ),
 		publicPath: '/calypso/',
-		filename: '[name].[chunkhash].min.js', // prefer the chunkhash, which depends on the chunk, not the entire build
-		chunkFilename: '[name].[chunkhash].min.js', // ditto
+		filename: '[name].[chunkhash].opt.js', // prefer the chunkhash, which depends on the chunk, not the entire build
+		chunkFilename: '[name].[chunkhash].opt.js', // ditto
 		devtoolModuleFilenameTemplate: 'app:///[resource-path]',
 	},
 	module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -293,7 +293,7 @@ if ( shouldMinify ) {
 					 * Enable when the following is resolved:
 					 * https://github.com/mishoo/UglifyJS2/issues/3010
 					 */
-					conditionals: false,
+					collapse_vars: false,
 				},
 				ecma: 5,
 			},


### PR DESCRIPTION
There is a bug affecting at least our `debug` module. Disable until the issue is resolved:

https://github.com/mishoo/UglifyJS2/issues/3010

It's difficult to know if other code may be impacted. It concerns me that production-built code may not produce the same results as source.

## Testing
1. Visit WordPress.com
1. `localStorage.debug = 'calypso:popover'
`
1. Refresh
1. Verify bad placeholder substitutions (you should see colors)
1. Use this branch ([calypso.live](https://calypso.live/?branch=fix/debug-debug))
1. `localStorage.debug = 'calypso:popover'`
1. Refresh
1. Verify correct debug output


Workaround, closes #21489 