### PR TITLE
WordAds: Don't run eligibility check on atomic sites (always eligible)

### DIFF
--- a/client/my-sites/ads/main.jsx
+++ b/client/my-sites/ads/main.jsx
@@ -22,6 +22,7 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import AdsEarnings from 'my-sites/ads/form-earnings';
 import AdsSettings from 'my-sites/ads/form-settings';
 import { canAccessWordads, isWordadsInstantActivationEligible } from 'lib/ads/utils';
+import { isBusiness } from 'lib/products-values';
 import FeatureExample from 'components/feature-example';
 import FormButton from 'components/forms/form-button';
 import Card from 'components/card';
@@ -146,7 +147,8 @@ class AdsMain extends Component {
 					</div>
 					{ this.props.wordAdsError && (
 						<Notice
-							status="is-error ads__activate-notice"
+							classname="ads__activate-notice"
+							status="is-error"
 							onDismissClick={ this.handleDismissWordAdsError }
 						>
 							{ this.props.wordAdsError }
@@ -154,7 +156,8 @@ class AdsMain extends Component {
 					) }
 					{ this.props.isUnsafe === 'mature' && (
 						<Notice
-							status="is-warning ads__activate-notice"
+							classname="ads__activate-notice"
+							status="is-warning"
 							showDismiss={ false }
 							text={ translate(
 								'Your site has been identified as serving mature content. ' +
@@ -171,7 +174,8 @@ class AdsMain extends Component {
 					) }
 					{ this.props.isUnsafe === 'spam' && (
 						<Notice
-							status="is-warning ads__activate-notice"
+							classname="ads__activate-notice"
+							status="is-warning"
 							showDismiss={ false }
 							text={ translate(
 								'Your site has been identified as serving automatically created or copied content. ' +
@@ -181,7 +185,8 @@ class AdsMain extends Component {
 					) }
 					{ this.props.isUnsafe === 'private' && (
 						<Notice
-							status="is-warning ads__activate-notice"
+							classname="ads__activate-notice"
+							status="is-warning"
 							showDismiss={ false }
 							text={ translate(
 								'Your site is marked as private. It needs to be public so that visitors can see the ads.'
@@ -194,7 +199,8 @@ class AdsMain extends Component {
 					) }
 					{ this.props.isUnsafe === 'other' && (
 						<Notice
-							status="is-warning ads__activate-notice"
+							classname="ads__activate-notice"
+							status="is-warning"
 							showDismiss={ false }
 							text={ translate( 'Your site cannot participate in WordAds program.' ) }
 						/>
@@ -233,7 +239,11 @@ class AdsMain extends Component {
 					{ translate( 'You have joined the WordAds program. Please review these settings:' ) }
 				</Notice>
 			);
-		} else if ( ! site.options.wordads && isWordadsInstantActivationEligible( site ) ) {
+		} else if (
+			! site.options.wordads &&
+			isWordadsInstantActivationEligible( site ) &&
+			! isBusiness( site.plan )
+		) {
 			component = this.renderInstantActivationToggle( component );
 		}
 


### PR DESCRIPTION
Atomic sites are currently seeing an ineligibility notice at the top of the WordAds earnings report, even though Atomic sites are always WordAds eligible.

This PR ads a check for business-plan sites that prevents the ineligibility notice from appearing.
I also updated the status value passed to the Notice component, which resolves some console errors.

### Testing Plan
Without this patch, login to an atomic site in calypso and visit Settings > Traffic. From this tab, click on the earnings link within the Ads component. Once you arrive at the Ads Earnings page, you should see a message at the top showing that your site is ineligible to participate in WordAds.

Apply this patch and follow the same steps above. This time you should see the earnings page appear normally without any ineligibility notice.