### PR TITLE
JPC: include notices triggered by errors in the credentials form of the remote install flow.

### DIFF
--- a/client/jetpack-connect/connection-notice-types.js
+++ b/client/jetpack-connect/connection-notice-types.js
@@ -5,20 +5,23 @@
  *
  * These notice types are indicators of Jetpack Connection status.
  */
-
+export const ACTIVATE_FAILURE = 'unableToActivate';
 export const ALREADY_CONNECTED = 'alreadyConnected';
 export const ALREADY_CONNECTED_BY_OTHER_USER = 'alreadyConnectedByOtherUser';
 export const ALREADY_OWNED = 'alreadyOwned';
 export const DEFAULT_AUTHORIZE_ERROR = 'defaultAuthorizeError';
+export const INSTALL_FAILURE = 'unableToInstall';
 export const IS_DOT_COM = 'isDotCom';
 export const JETPACK_IS_DISCONNECTED = 'jetpackIsDisconnected';
 export const JETPACK_IS_VALID = 'jetpackIsValid';
+export const LOGIN_FAILURE = 'credsInvalid';
 export const NOT_ACTIVE_JETPACK = 'notActiveJetpack';
 export const NOT_CONNECTED_JETPACK = 'notConnectedJetpack';
 export const NOT_EXISTS = 'notExists';
 export const NOT_JETPACK = 'notJetpack';
 export const NOT_WORDPRESS = 'notWordPress';
 export const OUTDATED_JETPACK = 'outdatedJetpack';
+export const INVALID_PERMISSIONS = 'invalidPermissions';
 export const RETRY_AUTH = 'retryAuth';
 export const RETRYING_AUTH = 'retryingAuth';
 export const SECRET_EXPIRED = 'secretExpired';


### PR DESCRIPTION
Remote install WP REST API endpoint returns errors upon invalid permissions, login creds or activate/install errors. This patch incorporates those via notices with hyperlinks pointing to manual instructions and support (wherever relevant), and tracking.

NOTE: notice dismiss icon and its action and its action is absent from the PR and can be added in the follow-up.

Permissions:
![screen shot 2018-03-18 at 22 39 08](https://user-images.githubusercontent.com/13561163/37572170-1e26fd22-2aff-11e8-83e8-b5572dab68ed.png)

Invalid login:
![screen shot 2018-03-18 at 22 39 29](https://user-images.githubusercontent.com/13561163/37572169-1b6bddaa-2aff-11e8-9a40-6c3de1d6f896.png)


## To test

* Checkout this branch locally and go to http://calypso.localhost:3000/jetpack/connect
* Enter the URL of an .org site without Jetpack installed or activated
* Enter invalid credentials 
* Verify the relevant notice appearing in the form
* Enter login details of a user with no install permissions (e.g. editor)
* Verify the relevant notice appearing in the form

Failed install/activation testing (without actual failure :) ) cannot be reproduced from Calypso.
