### PR TITLE
JPC: add notice dismissal to remote install errors.

### DIFF
--- a/client/jetpack-connect/connection-notice-types.js
+++ b/client/jetpack-connect/connection-notice-types.js
@@ -5,20 +5,23 @@
  *
  * These notice types are indicators of Jetpack Connection status.
  */
-
+export const ACTIVATE_FAILURE = 'unableToActivate';
 export const ALREADY_CONNECTED = 'alreadyConnected';
 export const ALREADY_CONNECTED_BY_OTHER_USER = 'alreadyConnectedByOtherUser';
 export const ALREADY_OWNED = 'alreadyOwned';
 export const DEFAULT_AUTHORIZE_ERROR = 'defaultAuthorizeError';
+export const INSTALL_FAILURE = 'unableToInstall';
 export const IS_DOT_COM = 'isDotCom';
 export const JETPACK_IS_DISCONNECTED = 'jetpackIsDisconnected';
 export const JETPACK_IS_VALID = 'jetpackIsValid';
+export const LOGIN_FAILURE = 'credsInvalid';
 export const NOT_ACTIVE_JETPACK = 'notActiveJetpack';
 export const NOT_CONNECTED_JETPACK = 'notConnectedJetpack';
 export const NOT_EXISTS = 'notExists';
 export const NOT_JETPACK = 'notJetpack';
 export const NOT_WORDPRESS = 'notWordPress';
 export const OUTDATED_JETPACK = 'outdatedJetpack';
+export const INVALID_PERMISSIONS = 'invalidPermissions';
 export const RETRY_AUTH = 'retryAuth';
 export const RETRYING_AUTH = 'retryingAuth';
 export const SECRET_EXPIRED = 'secretExpired';

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -25,6 +25,7 @@ import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import MainWrapper from './main-wrapper';
 import Spinner from 'components/spinner';
 import { addCalypsoEnvQueryArg } from './utils';
+import { dismissUrl } from 'state/jetpack-connect/actions';
 import { externalRedirect } from 'lib/route';
 import { jetpackRemoteInstall } from 'state/jetpack-remote-install/actions';
 import { getJetpackRemoteInstallErrorCode, isJetpackRemoteInstallComplete } from 'state/selectors';
@@ -40,18 +41,11 @@ import {
 
 export class OrgCredentialsForm extends Component {
 	state = {
-		username: '',
-		password: '',
 		isSubmitting: false,
+		password: '',
+		showNotice: false,
+		username: '',
 	};
-
-	getInitialFields() {
-		return {
-			username: '',
-			password: '',
-			isSubmitting: false,
-		};
-	}
 
 	handleSubmit = event => {
 		const { siteToConnect } = this.props;
@@ -69,7 +63,10 @@ export class OrgCredentialsForm extends Component {
 		const { installError } = nextProps;
 
 		if ( installError ) {
-			this.setState( { isSubmitting: false } );
+			this.setState( {
+				isSubmitting: false,
+				showNotice: true,
+			} );
 		}
 	}
 
@@ -130,12 +127,20 @@ export class OrgCredentialsForm extends Component {
 		}
 	}
 
+	removeNotice() {
+		this.setState( { showNotice: false } );
+	}
+
 	renderNotice() {
 		const { installError } = this.props;
+
 		return (
 			<div className="jetpack-connect__notice">
 				{ installError ? (
-					<JetpackConnectNotices noticeType={ this.getError( installError ) } />
+					<JetpackConnectNotices
+						noticeType={ this.getError( installError ) }
+						onDismissClick={ this.removeNotice() }
+					/>
 				) : null }
 			</div>
 		);
@@ -274,5 +279,8 @@ export default connect(
 			siteToConnect,
 		};
 	},
-	{ jetpackRemoteInstall }
+	{
+		dismissUrl,
+		jetpackRemoteInstall,
+	}
 )( localize( OrgCredentialsForm ) );


### PR DESCRIPTION

Changes:
* 
* obsolete function removal `getInitialFields()`

## To test:
* Checkout this branch locally and go to http://calypso.localhost:3000/jetpack/connect
* Enter the URL of an .org site without Jetpack installed or activated
* Enter invalid credentials 
* Verify the relevant notice appears with the dismiss icon, which removes the notice
* Enter login details of a user with no install permissions (e.g. editor)
* Verify the relevant notice appears with the dismiss icon, which removes the notice.