### PR TITLE
JPC: place password hide icon inside the form field in remote install flow.

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -100,7 +100,7 @@ $z-layers: (
 		'.site-indicator__button': 3,
 		'ul.module-content-list-item-actions.collapsed': 3,
 		'.auth__input-wrapper .gridicon': 3,
-		'.jetpack-connect__password-form .gridicon': 3,
+		'.jetpack-connect__password-form .gridicon-lock': 3,
 		'.auth__self-hosted-instructions': 4,
 		'.auth__form .form-password-input__toggle-visibility': 4,
 		'.site-selector': 10,

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -649,6 +649,10 @@
 .jetpack-connect__password-form {
 	position: relative;
 
+	.form-password-input {
+		position: relative;
+	}
+
 	.gridicon {
 		position: absolute;
 		z-index: z-index('root', '.jetpack-connect__password-form .gridicon');


### PR DESCRIPTION
Currently the hide icon is rendered outside of the password input field.

![screen shot 2018-03-19 at 11 53 22](https://user-images.githubusercontent.com/13561163/37593967-c947492a-2b6b-11e8-8a47-e6e3e5da8e3b.png)


## To test:


