### PR TITLE
Community Translator: adding locale variant support

### DIFF
--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -11,6 +11,7 @@ export {
 	getLocaleFromPath,
 	isDefaultLocale,
 	isLocaleVariant,
+	hasTranslationSet,
 	removeLocaleFromPath,
 } from './utils';
 

--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -17,6 +17,7 @@ export {
 	getLocaleFromPath,
 	isDefaultLocale,
 	isLocaleVariant,
+	hasTranslationSet,
 	removeLocaleFromPath,
 } from './utils';
 

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -15,6 +15,7 @@ import {
 	isDefaultLocale,
 	removeLocaleFromPath,
 	isLocaleVariant,
+	hasTranslationSet,
 } from 'lib/i18n-utils';
 
 jest.mock( 'config', () => key => {
@@ -230,6 +231,21 @@ describe( 'utils', () => {
 
 		test( 'should detect a root language', () => {
 			expect( isLocaleVariant( 'de' ) ).to.be.false;
+		} );
+	} );
+
+	describe( '#hasTranslationSet', () => {
+		test( 'should return false by default', () => {
+			expect( hasTranslationSet() ).to.be.false;
+		} );
+
+		test( 'should return false for elements in the exception list', () => {
+			expect( hasTranslationSet( 'en' ) ).to.be.false;
+			expect( hasTranslationSet( 'sr_latin' ) ).to.be.false;
+		} );
+
+		test( 'should return true for languages not in the exception list', () => {
+			expect( hasTranslationSet( 'de' ) ).to.be.true;
 		} );
 	} );
 } );

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -50,6 +50,19 @@ export function isLocaleVariant( locale ) {
 }
 
 /**
+ * Checks against a list of locales that don't have any GP translation sets
+ *
+ * @param {string} locale - locale slug (eg: 'fr')
+ * @return {boolean} true when the locale is a member of the exception list
+ */
+export function hasTranslationSet( locale ) {
+	if ( ! isString( locale ) ) {
+		return false;
+	}
+	return [ 'en', 'sr_latin' ].indexOf( locale ) === -1;
+}
+
+/**
  * Matches and returns language from config.languages based on the given localeSlug and localeVariant
  * @param  {String} localeSlug locale slug of the language to match
  * @param  {String?} localeVariant local variant of the language to match. It takes precedence if exists.


### PR DESCRIPTION
This PR:
- adds support for locale variants to the Community Translator
- reverts PR #23321

To work, it relies on a change waiting in the Community Translator Repo: https://github.com/Automattic/community-translator/pull/8

<img width="636" alt="screen shot 2018-03-19 at 5 41 52 pm" src="https://user-images.githubusercontent.com/6458278/37581456-da5159c8-2b9c-11e8-89d4-f996e27d23f6.png">

## Testing
1. Apply `D11046-code`
2. Go to http://calypso.localhost:3000/me/account, switch your language to Deutsch (Sie) and enable the Community Translator

### Expectations
You should be able to edit/add new translations, and the permalinks should take you to the correct translation