### PR TITLE
Google My Business: Design refinments

### DIFF
--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -65,7 +65,7 @@ class GoogleMyBusinessStatsNudge extends Component {
 				/>
 				<SectionHeader
 					className="google-my-business-stats-nudge__header"
-					label={ this.props.translate( 'Recommendation from WordPress.com' ) }
+					label={ this.props.translate( 'Recommendations from WordPress' ) }
 				/>
 
 				<div className="google-my-business-stats-nudge__body">

--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -65,7 +65,7 @@ class GoogleMyBusinessStatsNudge extends Component {
 				/>
 				<SectionHeader
 					className="google-my-business-stats-nudge__header"
-					label={ this.props.translate( 'Recommendations from WordPress' ) }
+					label={ this.props.translate( 'Recommendations from WordPress.com' ) }
 				/>
 
 				<div className="google-my-business-stats-nudge__body">

--- a/client/blocks/google-my-business-stats-nudge/style.scss
+++ b/client/blocks/google-my-business-stats-nudge/style.scss
@@ -48,8 +48,10 @@
 	flex-direction: row;
 	margin: 20px 0;
 	.button {
-		// space out buttons
-		margin-right: 16px;
+		@include breakpoint( "<480px" ) {
+			width: 100%;
+			text-align: center;
+		}
 	}
 }
 

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -38,10 +38,8 @@ class SelectBusinessType extends Component {
 	};
 
 	trackGoogleMyBusinessLinkClick = () => {
-		this.props.recordTracksEvent(
-			'calypso_google_my_business_select_business_type_link_click'
-		);
-	}
+		this.props.recordTracksEvent( 'calypso_google_my_business_select_business_type_link_click' );
+	};
 
 	goBack = () => {
 		page.back( `/stats/day/${ this.props.siteId }` );
@@ -68,12 +66,14 @@ class SelectBusinessType extends Component {
 									'It works for businesses that have a physical location or serve a local area.',
 								{
 									components: {
-										a: <a
-											href="https://www.google.com/business/"
-											target="_blank"
-											rel="noopener noreferrer"
-											onClick={ this.trackGoogleMyBusinessLinkClick }
-										/>,
+										a: (
+											<a
+												href="https://www.google.com/business/"
+												target="_blank"
+												rel="noopener noreferrer"
+												onClick={ this.trackGoogleMyBusinessLinkClick }
+											/>
+										),
 									},
 								}
 							) }
@@ -92,10 +92,10 @@ class SelectBusinessType extends Component {
 						comment: 'In the context of a business activity, brick and mortar or online service',
 					} ) }
 					mainText={ translate(
-						'My business has a physical location customers can visit, ' +
+						'Your business has a physical location customers can visit, ' +
 							'or provides goods and services to local customers, or both.'
 					) }
-					buttonText={ translate( 'Create My Listing', {
+					buttonText={ translate( 'Create Your Listing', {
 						comment: 'Call to Action to add a business listing to Google My Business',
 					} ) }
 					buttonIcon="external"

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -17,6 +17,7 @@ import CompactCard from 'components/card/compact';
 import CTACard from './cta-card';
 import Main from 'components/main';
 import { recordTracksEvent } from 'state/analytics/actions';
+import ExternalLink from 'components/external-link';
 
 class SelectBusinessType extends Component {
 	static propTypes = {
@@ -38,7 +39,9 @@ class SelectBusinessType extends Component {
 	};
 
 	trackGoogleMyBusinessLinkClick = () => {
-		this.props.recordTracksEvent( 'calypso_google_my_business_select_business_type_link_click' );
+		this.props.recordTracksEvent(
+			'calypso_google_my_business_select_business_type_google_my_business_link_click'
+		);
 	};
 
 	goBack = () => {
@@ -62,15 +65,16 @@ class SelectBusinessType extends Component {
 
 						<p>
 							{ translate(
-								'{{a}}Google My Business{{/a}} lists your local business on Google Search and Google Maps. ' +
+								'{{link}}Google My Business{{/link}} lists your local business on Google Search and Google Maps. ' +
 									'It works for businesses that have a physical location or serve a local area.',
 								{
 									components: {
-										a: (
-											<a
+										link: (
+											<ExternalLink
 												href="https://www.google.com/business/"
 												target="_blank"
 												rel="noopener noreferrer"
+												icon={ true }
 												onClick={ this.trackGoogleMyBusinessLinkClick }
 											/>
 										),

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -37,6 +37,12 @@ class SelectBusinessType extends Component {
 		);
 	};
 
+	trackGoogleMyBusinessLinkClick = () => {
+		this.props.recordTracksEvent(
+			'calypso_google_my_business_select_business_type_link_click'
+		);
+	}
+
 	goBack = () => {
 		page.back( `/stats/day/${ this.props.siteId }` );
 	};
@@ -58,8 +64,18 @@ class SelectBusinessType extends Component {
 
 						<p>
 							{ translate(
-								'Google My Business lists your local business on Google Search and Google Maps. ' +
-									'It works for businesses that have a physical location or serve a local area.'
+								'{{a}}Google My Business{{/a}} lists your local business on Google Search and Google Maps. ' +
+									'It works for businesses that have a physical location or serve a local area.',
+								{
+									components: {
+										a: <a
+											href="https://www.google.com/business/"
+											target="_blank"
+											rel="noopener noreferrer"
+											onClick={ this.trackGoogleMyBusinessLinkClick }
+										/>,
+									},
+								}
 							) }
 						</p>
 					</div>


### PR DESCRIPTION
This PR:

- Makes Google My Business clickable on Select Business Type page:
![screen shot 2018-03-19 at 11 41 03](https://user-images.githubusercontent.com/326402/37588346-a4e42810-2b6a-11e8-9d87-f66d7b3456f1.png)

With tracking `calypso_google_my_business_select_business_type_link_click` on click:
![screen shot 2018-03-19 at 11 28 19](https://user-images.githubusercontent.com/326402/37588375-b740d8c8-2b6a-11e8-9242-9dbd00328663.png)


- Chanages perspective from "my" to "your" business:
![screen shot 2018-03-19 at 10 12 57](https://user-images.githubusercontent.com/326402/37588339-9ff6f1f2-2b6a-11e8-99f3-be14b4300a4e.png)

- Changes the caption on the nudge from `Recommendation from WordPress.com` to `Recommendations from WordPress` and makes button take 100% width on small devices:
![screen shot 2018-03-19 at 11 37 32](https://user-images.githubusercontent.com/326402/37588391-c3f72f04-2b6a-11e8-8443-9186ae371ad8.png)

  
#### Testing instructions
  
1. Run `git checkout update/gmb-select-biz-type` and start your server, or open a [live branch](https://calypso.live/?branch=update/gmb-select-biz-type)
2. Open the stats page of some eligible GMB site `http://calypso.localhost:3000/stats/day/gmb-site.wordpress.com` to check the nudge as described above
3. Run in console: `localStorage.setItem( 'debug', 'calypso:analytics:tracks' );` and open the select my business type page ( can be for any site ): `http://calypso.localhost:3000/google-my-business/somesite.wordpress.com` and check the page is as described above
  
 
#### Reviews
  
- [x] Code
- [x] Product


