### PR TITLE
Animate: fixes fade-in animation name in selector

### DIFF
--- a/client/components/animate/style.scss
+++ b/client/components/animate/style.scss
@@ -14,7 +14,7 @@
 }
 
 .animate__fade-in {
-	animation: fade-in-scale 0.5s ease-out;
+	animation: fade-in 0.5s ease-out;
 	animation-fill-mode: forwards;
 }
 


### PR DESCRIPTION
This PR fixes the `fade-in` animation name in the corresponding CSS selector.

### Changes

```diff
.animate__fade-in {
+	animation: fade-in 0.5s cubic-bezier( .1, .82, .25, 1 );
-	animation: fade-in-scale 0.5s cubic-bezier( .1, .82, .25, 1 );
	animation-fill-mode: forwards;
}

@keyframes fade-in {
```