### PR TITLE
Remove signup from the build to reduce the build size

### DIFF
--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -21,7 +21,6 @@ import WordPressWordmark from 'components/wordpress-wordmark';
 import { addQueryArgs } from 'lib/route';
 import { getCurrentQueryArguments, getCurrentRoute } from 'state/selectors';
 import { login } from 'lib/paths';
-import flows from 'signup/config/flows';
 
 class MasterbarLoggedOut extends PureComponent {
 	static propTypes = {
@@ -120,7 +119,7 @@ class MasterbarLoggedOut extends PureComponent {
 			}
 		} else if ( 'jetpack-connect' === sectionName ) {
 			signupUrl = '/jetpack/new';
-		} else if ( signupFlow && flows.isValidFlow( signupFlow ) ) {
+		} else if ( signupFlow ) {
 			signupUrl += '/' + signupFlow;
 		}
 


### PR DESCRIPTION
This PR removes the signup bundle from the build, reducing the build size.

This means we no longer check if the signup flow specified in the query string is valid before redirecting the user. However this check is still done by the flow itself, so users won't hit a dead end.
  
#### Testing instructions
  
1. Run `git checkout fix/reduce-build-size` and start your server
2. Open the [`Login` page](http://calypso.localhost:3000/log-in?signup_flow=account) with a valid query string for signup flow
3. Check that the Sign Up button links to the account signup flow
4. Open the [`Login` page](http://calypso.localhost:3000/log-in?signup_flow=account123) with an invalid query string for signup flow
5. Check that the Sign Up button links to the standard signup flow  

