### PR TITLE
JPC: remove obsolete code from remote credentials component.

### DIFF
--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -45,14 +45,6 @@ export class OrgCredentialsForm extends Component {
 		isSubmitting: false,
 	};
 
-	getInitialFields() {
-		return {
-			username: '',
-			password: '',
-			isSubmitting: false,
-		};
-	}
-
 	handleSubmit = event => {
 		const { siteToConnect } = this.props;
 		event.preventDefault();


### PR DESCRIPTION
No visual changes. The function is not called + it is a repeat of the initial state definition.

## To test:

- verify that no regression was introduced to the remote install flow. 