### PR TITLE
Checklist: use getABTestVariation instead of direct access to localStorage

### DIFF
--- a/client/my-sites/stats/checklist-banner/index.jsx
+++ b/client/my-sites/stats/checklist-banner/index.jsx
@@ -26,7 +26,7 @@ import { launchTask, onboardingTasks } from 'my-sites/checklist/onboardingCheckl
 import ChecklistShowShare from 'my-sites/checklist/checklist-show/share';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
-import { ABTEST_LOCALSTORAGE_KEY } from 'lib/abtest/utility';
+import { getABTestVariation } from 'lib/abtest';
 
 const storeKeyForNeverShow = 'sitesNeverShowChecklistBanner';
 
@@ -111,12 +111,9 @@ export class ChecklistBanner extends Component {
 			return false;
 		}
 
-		// NOTE: Accessing localStorage directly for checking A/B variation assignment
-		//       is an anti-pattern. Please use lib/abtest instead.
-		const abtests = store.get( ABTEST_LOCALSTORAGE_KEY );
 		if (
-			get( abtests, 'checklistThankYouForPaidUser_20171204' ) !== 'show' &&
-			get( abtests, 'checklistThankYouForFreeUser_20171204' ) !== 'show'
+			getABTestVariation( 'checklistThankYouForPaidUser' ) !== 'show' &&
+			getABTestVariation( 'checklistThankYouForFreeUser' ) !== 'show'
 		) {
 			return false;
 		}


### PR DESCRIPTION
This PR replace the direct access to localStorage with the `getABTestVariation` function to avoid anti-pattern.

## How to test

1. Create a new website.
2. Set either of `checklistThankYouForPaidUser` or `checklistThankYouForFreeUser` tests to `show`.
3. You should be able to see the checklist banner on the stats page as follows:
    <img width="1017" alt="2018-03-19 9 56 26" src="https://user-images.githubusercontent.com/212034/37596717-6b805c46-2bc0-11e8-8ca3-6e0fce12403a.png">
4. The banner should not be displayed when none of them are set to `show`.
