### PR TITLE
Plans: close signed-in version of the minimizedFreePlan test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -76,15 +76,6 @@ export default {
 		defaultVariation: 'group_0',
 		allowExistingUsers: true,
 	},
-	minimizedFreePlanForSignedUser: {
-		datestamp: '20180308',
-		variations: {
-			original: 50,
-			minimized: 50,
-		},
-		defaultVariation: 'original',
-		allowExistingUsers: true,
-	},
 	minimizedFreePlanForUnsignedUser: {
 		datestamp: '20180308',
 		variations: {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -781,11 +781,8 @@ export default connect(
 			} )
 		);
 
-		if ( isInSignup ) {
-			const isInTest =
-				abtest(
-					isLoggedIn ? 'minimizedFreePlanForSignedUser' : 'minimizedFreePlanForUnsignedUser'
-				) === 'minimized';
+		if ( isInSignup && ! isLoggedIn ) {
+			const isInTest = abtest( 'minimizedFreePlanForUnsignedUser' ) === 'minimized';
 			if ( isInTest ) {
 				freePlanProperties = filter( planProperties, filterFreePlan );
 				freePlanProperties = freePlanProperties[ 0 ] || null;


### PR DESCRIPTION
As the `original` has turned out a clear winner, we're closing the signed-in version of the minimizedFreePlan test. The signed-out version is still in progress.