### PR TITLE
Store Dashboard: Add settings panel to low inventory widget

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/controls.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/controls.js
@@ -1,0 +1,163 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import {
+	areSettingsProductsLoaded,
+	getProductsSettingValue,
+} from 'woocommerce/state/sites/settings/products/selectors';
+import Button from 'components/button';
+import FormCheckbox from 'components/forms/form-checkbox';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormLegend from 'components/forms/form-legend';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import FormTextInput from 'components/forms/form-text-input';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import Range from 'components/forms/range';
+
+class InventoryControls extends Component {
+	static propTypes = {
+		isLoaded: PropTypes.bool.isRequired,
+		lowStockThreshold: PropTypes.number.isRequired,
+		noStockThreshold: PropTypes.number.isRequired,
+		notifyLowStockEnabled: PropTypes.bool.isRequired,
+		notifyNoStockEnabled: PropTypes.bool.isRequired,
+		site: PropTypes.shape( {
+			ID: PropTypes.number.isRequired,
+		} ),
+	};
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			lowStockThreshold: props.lowStockThreshold,
+			noStockThreshold: props.noStockThreshold,
+			notifyLowStockEnabled: props.notifyLowStockEnabled,
+			notifyNoStockEnabled: props.notifyNoStockEnabled,
+		};
+	}
+
+	setValue = name => event => {
+		this.setState( { [ name ]: event.target.value } );
+	};
+
+	setChecked = name => () => {
+		this.setState( state => ( { [ name ]: ! state[ name ] } ) );
+	};
+
+	render() {
+		const { translate } = this.props;
+		const {
+			lowStockThreshold,
+			noStockThreshold,
+			notifyLowStockEnabled,
+			notifyNoStockEnabled,
+		} = this.state;
+
+		return (
+			<div className="inventory-widget__controls">
+				<div className="inventory-widget__control">
+					<FormLabel htmlFor="low_stock_amount">{ translate( 'Low stock threshold' ) }</FormLabel>
+					<div className="inventory-widget__range-input">
+						<FormTextInput
+							id="low_stock_amount"
+							aria-describedby="low_stock_amount_help"
+							value={ lowStockThreshold }
+							onChange={ this.setValue( 'lowStockThreshold' ) }
+						/>
+						<Range
+							minContent={ <Gridicon icon="minus-small" /> }
+							maxContent={ <Gridicon icon="plus-small" /> }
+							max="100"
+							value={ lowStockThreshold }
+							onChange={ this.setValue( 'lowStockThreshold' ) }
+						/>
+					</div>
+					<FormSettingExplanation id="low_stock_amount_help">
+						{ translate(
+							'Products with stock lower than this value will be highlighted in this widget.'
+						) }
+					</FormSettingExplanation>
+				</div>
+				<div className="inventory-widget__control">
+					<FormLabel htmlFor="no_stock_amount">{ translate( 'Out of stock threshold' ) }</FormLabel>
+					<div className="inventory-widget__range-input">
+						<FormTextInput
+							id="no_stock_amount"
+							aria-describedby="no_stock_amount_help"
+							value={ noStockThreshold }
+							onChange={ this.setValue( 'noStockThreshold' ) }
+						/>
+						<Range
+							minContent={ <Gridicon icon="minus-small" /> }
+							maxContent={ <Gridicon icon="plus-small" /> }
+							max="100"
+							value={ noStockThreshold }
+							onChange={ this.setValue( 'noStockThreshold' ) }
+						/>
+					</div>
+					<FormSettingExplanation id="no_stock_amount_help">
+						{ translate(
+							'Products with stock lower than this value will be considered out of stock.'
+						) }
+					</FormSettingExplanation>
+				</div>
+
+				<FormFieldset className="inventory-widget__control">
+					<FormLegend>{ translate( 'Email me' ) }</FormLegend>
+					<FormLabel>
+						<FormCheckbox
+							checked={ notifyLowStockEnabled }
+							onChange={ this.setChecked( 'notifyLowStockEnabled' ) }
+						/>
+						<span>{ translate( 'When products are low on stock' ) }</span>
+					</FormLabel>
+
+					<FormLabel>
+						<FormCheckbox
+							checked={ notifyNoStockEnabled }
+							onChange={ this.setChecked( 'notifyNoStockEnabled' ) }
+						/>
+						<span>{ translate( 'When products are out of stock' ) }</span>
+					</FormLabel>
+				</FormFieldset>
+
+				<Button primary>{ translate( 'Save' ) }</Button>
+			</div>
+		);
+	}
+}
+
+export default connect( state => {
+	const site = getSelectedSiteWithFallback( state );
+	const isLoaded = areSettingsProductsLoaded( state );
+	const lowStockThreshold = parseInt(
+		getProductsSettingValue( state, 'woocommerce_notify_low_stock_amount' ) || 0
+	);
+	const noStockThreshold = parseInt(
+		getProductsSettingValue( state, 'woocommerce_notify_no_stock_amount' ) || 0
+	);
+	const notifyLowStockEnabled =
+		'yes' === getProductsSettingValue( state, 'woocommerce_notify_low_stock' );
+	const notifyNoStockEnabled =
+		'yes' === getProductsSettingValue( state, 'woocommerce_notify_no_stock' );
+
+	return {
+		isLoaded,
+		lowStockThreshold,
+		noStockThreshold,
+		notifyLowStockEnabled,
+		notifyNoStockEnabled,
+		site,
+	};
+} )( localize( InventoryControls ) );

--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/controls.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/controls.js
@@ -17,7 +17,7 @@ import {
 	getProductsSettingValue,
 } from 'woocommerce/state/sites/settings/products/selectors';
 import Button from 'components/button';
-import { errorNotice } from 'state/notices/actions';
+import { errorNotice, successNotice } from 'state/notices/actions';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -82,7 +82,7 @@ class InventoryControls extends Component {
 					value: this.state.notifyNoStockEnabled ? 'yes' : 'no',
 				},
 			],
-			false,
+			successNotice( translate( 'Stock notification settings saved.' ), { duration: 8000 } ),
 			errorNotice( translate( 'Unable to save settings.' ), { duration: 8000 } )
 		);
 

--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/index.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/index.js
@@ -22,6 +22,7 @@ import { fetchSettingsProducts } from 'woocommerce/state/sites/settings/products
 import { getAllProducts } from 'woocommerce/state/sites/products/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import InventoryControls from './controls';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
@@ -139,6 +140,7 @@ class InventoryWidget extends Component {
 			width: this.props.width,
 			className: this.getClasses(),
 			title: translate( 'Inventory Alerts' ),
+			settingsPanel: <InventoryControls />,
 		};
 		if ( this.shouldShowImage() ) {
 			props.image = '/calypso/images/extensions/woocommerce/woocommerce-relaxed.svg';

--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/index.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/index.js
@@ -140,7 +140,7 @@ class InventoryWidget extends Component {
 			width: this.props.width,
 			className: this.getClasses(),
 			title: translate( 'Inventory Alerts' ),
-			settingsPanel: <InventoryControls />,
+			settingsPanel: InventoryControls,
 		};
 		if ( this.shouldShowImage() ) {
 			props.image = '/calypso/images/extensions/woocommerce/woocommerce-relaxed.svg';

--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
@@ -107,11 +107,6 @@
 	.inventory-widget__control {
 		margin-bottom: 8px;
 		text-align: left;
-
-		.form-label {}
-		.form-text-input {}
-		.range {}
-		.form-setting-explanation {}
 	}
 
 	.inventory-widget__range-input {

--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
@@ -99,3 +99,28 @@
 		}
 	}
 }
+
+.inventory-widget__controls {
+	padding: 16px;
+	max-width: 300px;
+
+	.inventory-widget__control {
+		margin-bottom: 8px;
+		text-align: left;
+
+		.form-label {}
+		.form-text-input {}
+		.range {}
+		.form-setting-explanation {}
+	}
+
+	.inventory-widget__range-input {
+		display: flex;
+		align-items: center;
+
+		.form-text-input {
+			max-width: 50px;
+			margin-right: 8px;
+		}
+	}
+}

--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
@@ -118,4 +118,8 @@
 			margin-right: 8px;
 		}
 	}
+
+	.form-checkbox:checked:before {
+		margin-top: 0;
+	}
 }

--- a/client/extensions/woocommerce/components/dashboard-widget/index.js
+++ b/client/extensions/woocommerce/components/dashboard-widget/index.js
@@ -60,7 +60,6 @@ class DashboardWidget extends Component {
 			image,
 			imageFlush,
 			imagePosition,
-			settingsPanel,
 			title,
 			translate,
 			width,
@@ -69,7 +68,8 @@ class DashboardWidget extends Component {
 		const isTopImage = image && 'top' === imagePosition;
 		const imageClassName = image ? `is-${ imagePosition }` : null;
 		const widthClassName = `is-${ width }-width`;
-		const hasSettingsPanel = ! isUndefined( settingsPanel );
+		const SettingsPanel = this.props.settingsPanel;
+		const hasSettingsPanel = ! isUndefined( SettingsPanel );
 
 		const classes = classNames( 'dashboard-widget', className, imageClassName, widthClassName, {
 			'is-flush-image': imageFlush,
@@ -106,7 +106,7 @@ class DashboardWidget extends Component {
 						onClose={ this.onSettingsPanelClose }
 						position="bottom left"
 					>
-						{ settingsPanel }
+						<SettingsPanel close={ this.onSettingsPanelClose } />
 					</Popover>
 				) }
 				<div className="dashboard-widget__content">
@@ -131,7 +131,7 @@ DashboardWidget.propTypes = {
 	imagePosition: PropTypes.oneOf( [ 'bottom', 'left', 'right', 'top' ] ),
 	onSettingsClose: PropTypes.func,
 	title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
-	settingsPanel: PropTypes.element,
+	settingsPanel: PropTypes.func,
 	width: PropTypes.oneOf( [ 'half', 'full', 'third', 'two-thirds' ] ),
 };
 


### PR DESCRIPTION
This PR adds the configuration from #16732 to the Low Inventory dashboard widget. This controls the "Low stock threshold", "No stock threshold", and email notifications settings for each.

<img width="351" alt="screen shot 2018-03-19 at 11 20 36 am" src="https://user-images.githubusercontent.com/541093/37604663-de350222-2b67-11e8-8cf1-6e1e1054d130.png">

To test:

- View your store dashboard
- You should see a gear on the inventory widget
- Click the gear, see the popup
- Make changes, click save
- Check your settings in wp-admin – `/wp-admin/admin.php?page=wc-settings&tab=products&section=inventory`
- The products in the list should also immediately update to reflect your saved settings.
- Click the gear again, make changes, then click out of the popup to close it
- There should be no change to your saved settings