### PR TITLE
Store: ignore all but the most recent label rates requests

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/get-rates.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/get-rates.js
@@ -9,7 +9,7 @@ import {
 } from '../action-types';
 
 export default ( orderId, siteId, dispatch, origin, destination, packages ) => {
-	const requestData = { orderId, siteId, origin, destination, packages };
+	const requestData = { origin, destination, packages };
 	dispatch( {
 		type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_RATES_RETRIEVAL_IN_PROGRESS,
 		requestData,
@@ -46,7 +46,7 @@ export default ( orderId, siteId, dispatch, origin, destination, packages ) => {
 		};
 
 		setIsSaving( true );
-		api.post( siteId, api.url.getLabelRates( orderId ), { origin, destination, packages } )
+		api.post( siteId, api.url.getLabelRates( orderId ), requestData )
 			.then( setSuccess )
 			.catch( setError )
 			.then( () => setIsSaving( false ) );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/get-rates.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/get-rates.js
@@ -9,7 +9,14 @@ import {
 } from '../action-types';
 
 export default ( orderId, siteId, dispatch, origin, destination, packages ) => {
-	dispatch( { orderId, siteId, type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_RATES_RETRIEVAL_IN_PROGRESS } );
+	const requestData = { orderId, siteId, origin, destination, packages };
+	dispatch( {
+		type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_RATES_RETRIEVAL_IN_PROGRESS,
+		requestData,
+		siteId,
+		orderId,
+	} );
+
 	return new Promise( ( resolve, reject ) => {
 		let error = null;
 		const setError = ( err ) => error = err;
@@ -17,6 +24,7 @@ export default ( orderId, siteId, dispatch, origin, destination, packages ) => {
 			dispatch( {
 				type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_RATES,
 				rates: json.rates,
+				requestData,
 				siteId,
 				orderId,
 			} );
@@ -25,6 +33,7 @@ export default ( orderId, siteId, dispatch, origin, destination, packages ) => {
 			if ( ! saving ) {
 				dispatch( {
 					type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_RATES_RETRIEVAL_COMPLETED,
+					requestData,
 					siteId,
 					orderId,
 				} );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { each, find, findIndex, get, includes, mapValues, omit, round, sortBy, sumBy, without } from 'lodash';
+import { each, find, findIndex, get, includes, isEqual, mapValues, omit, round, sortBy, sumBy, without } from 'lodash';
 
 /**
  * Internal dependencies
@@ -604,17 +604,21 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SHOW_PRINT_CONFIRMATION ] = ( stat
 	};
 };
 
-reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_RATES_RETRIEVAL_IN_PROGRESS ] = ( state ) => {
+reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_RATES_RETRIEVAL_IN_PROGRESS ] = ( state, { requestData } ) => {
 	return { ...state,
 		form: { ...state.form,
 			rates: { ...state.form.rates,
-				retrievalInProgress: true,
+				retrievalInProgress: requestData,
 			},
 		},
 	};
 };
 
-reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_RATES ] = ( state, { rates } ) => {
+reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_RATES ] = ( state, { rates, requestData } ) => {
+	if ( ! isEqual( requestData, state.form.rates.retrievalInProgress ) ) {
+		return state;
+	}
+
 	return { ...state,
 		form: { ...state.form,
 			rates: {
@@ -637,11 +641,15 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_RATES ] = ( state, { rates } )
 	};
 };
 
-reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_RATES_RETRIEVAL_COMPLETED ] = ( state ) => {
+reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_RATES_RETRIEVAL_COMPLETED ] = ( state, { requestData } ) => {
+	if ( ! isEqual( requestData, state.form.rates.retrievalInProgress ) ) {
+		return state;
+	}
+
 	return { ...state,
 		form: { ...state.form,
 			rates: { ...state.form.rates,
-				retrievalInProgress: false,
+				retrievalInProgress: null,
 			},
 		},
 	};


### PR DESCRIPTION
Changes shipping label's `state.form.rates.retrievalInProgress` from a boolean to an object comprising the data in the rates request, to ensure it matches before going ahead with presenting the new rates, and so to avoid entering an inconsistent state due to outdated rates being fetched. Tested by simulating a high latency connection:

`master` | this PR
-- | --
![rates-request-collision](https://user-images.githubusercontent.com/1867547/37607812-68a1ce66-2b6f-11e8-9579-ab83c8825e46.gif) | ![rates-request-no-collision](https://user-images.githubusercontent.com/1867547/37607835-6c1c64ca-2b6f-11e8-8dd6-3062e37ce73d.gif)

In `master`, the $28.74 rate looks like it's ready, when actually the most recently requested $32.80 rate is still on its way. In this PR, the $28.74 wouldn't show up at all if an updated request is made before it arrives. Also, in a plausible albeit unlikely case, the first request would stall due to intermittent network conditions and come in after the second one, leaving around a broken state tree.

(Note that the dropdown still shows outdated options while the rates are being fetched — this adjacent but separate issue will be fixed in https://github.com/Automattic/wp-calypso/pull/23183 by showing a placeholder while rates are loading.)