### PR TITLE
Fix multisite theme selection modal height

### DIFF
--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -1,6 +1,5 @@
 .sites-dropdown {
 	&.is-open {
-		height: 69px;
 		.gridicons-chevron-down {
 			transform: rotate( 180deg );
 		}

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -1,5 +1,6 @@
 .sites-dropdown {
 	&.is-open {
+		height: 69px;
 		.gridicons-chevron-down {
 			transform: rotate( 180deg );
 		}

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -75,6 +75,7 @@
 
 .themes__site-selector-modal {
 	padding-bottom: 24px;
+	overflow-y: inherit;
 
 	.site-selector-modal__content {
 		.theme {


### PR DESCRIPTION
The height of the modal wasn't expanding when the dropdown selection was open. I removed the height restriction so that the modal expands when the dropdown is open. Fixes #23244