### PR TITLE
Activity Log: Move progress dialog above monthly navigation

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -509,8 +509,8 @@ class ActivityLog extends Component {
 					/>
 				) }
 				{ this.renderErrorMessage() }
-				{ this.renderMonthNavigation() }
 				{ this.renderActionProgress() }
+				{ this.renderMonthNavigation() }
 				{ isEmpty( logs ) ? (
 					noLogsContent
 				) : (


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/22851

Currently, the rewind progress dialog falls below the month navigation. This PR moves the dialog above the month navigation in order to provide a more context-appropriate experience with the dialog.

**Testing**
Perform a restore and ensure that the dialog appears above the monthly navigation. Is anything else awry? Does the restore complete normally?