### PR TITLE
Store: Improve display of stats widget on smaller screens

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
@@ -23,6 +23,7 @@
 
 	.dashboard-widget__title {
 		border-bottom: 1px solid $gray-lighten-30;
+		white-space: nowrap;
 
 		p {
 			margin-top: 16px;
@@ -81,6 +82,10 @@
 		padding: 32px;
 		text-align: left;
 
+		@include breakpoint( '<480px' ) {
+			padding: 16px;
+		}
+
 		&.stats-type-stat {
 			display: flex;
 			height: 120px;
@@ -99,9 +104,17 @@
 		&.stats-type-list {
 			height: 200px;
 
+			@include breakpoint( '<480px' ) {
+				height: 175px;
+			}
+
 			@include breakpoint( '<960px' ) {
 				max-width: 100%;
 				min-width: 100%;
+
+				.is-error {
+					text-align: left;
+				}
 			}
 		}
 
@@ -123,6 +136,12 @@
 
 		.store-stats-module, .stats-widget__more {
 			margin-left: -16px;
+		}
+
+		.stats-widget__more {
+			@include breakpoint( '<480px' ) {
+				margin-top: -8px;
+			}
 		}
 	}
 

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
@@ -34,6 +34,14 @@
 		justify-content: space-between;
 		align-items: center;
 
+		@include breakpoint( '<1040px' ) {
+			flex-direction: column;
+
+			a {
+				margin-top: 8px;
+			}
+		}
+
 		span {
 			color: $gray-text-min;
 			font-size: 14px;
@@ -49,6 +57,7 @@
 	.stats-widget__box-label, .table-heading .table-item__cell-title, .table.is-compact-table .table-heading {
 		font-size: 16px;
 		font-weight: 600;
+		white-space: nowrap;
 	}
 
 	.table.is-compact-table .table-item {
@@ -57,7 +66,11 @@
 	}
 
 	.table.is-compact-table .table-heading:nth-child(3), .table.is-compact-table .table-item:nth-child(3) {
-		margin-left: 32px;
+		padding-left: 32px;
+
+		@include breakpoint( '<960px' ) {
+			padding-left: 48px;
+		}
 	}
 
 	.stats-widget__box-contents {
@@ -72,6 +85,11 @@
 			display: flex;
 			height: 120px;
 
+			@include breakpoint( '<960px' ) {
+				flex-direction: column;
+				height: 140px;
+			}
+
 			.stats-module__placeholder {
 				margin: 0 auto;
 				margin-top: -40px;
@@ -80,6 +98,11 @@
 
 		&.stats-type-list {
 			height: 200px;
+
+			@include breakpoint( '<960px' ) {
+				max-width: 100%;
+				min-width: 100%;
+			}
 		}
 
 


### PR DESCRIPTION
As a follow-up to #23344, this improves the display of the stats widget on smaller screens.

The following takes place on screens smaller than 960px.

* Moves the sparkline down so it won't run into the label and number display
* Makes the lists (products purchased and referrers) full width
* Moves the view all button onto its own line.

<img width="705" alt="screen shot 2018-03-19 at 1 18 46 pm" src="https://user-images.githubusercontent.com/689165/37620315-1d67f1e6-2b79-11e8-8aa8-a5945c3df0c6.png">

To Test:
* Visit your dashboard.
* Make your screen smaller than 960px and make sure things look OK.
