### PR TITLE
Simple Payments: Fix a "non-boolean attribute" warning.

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
@@ -53,7 +53,7 @@ class SimplePaymentsDialogNavigation extends Component {
 				label={ translate( 'Payment Buttons' ) }
 				count={ paymentButtons.length }
 			>
-				<Button compact icon onClick={ this.onChangeTabs( 'form' ) }>
+				<Button compact onClick={ this.onChangeTabs( 'form' ) }>
 					<Gridicon icon="plus-small" /> { translate( 'Add New' ) }
 				</Button>
 			</SectionHeader>


### PR DESCRIPTION
This PR removes an invalid `Button` prop to fix a "non-boolean attribute" warning. This was most likely a typo/artifact introduced in #16623. This introduces no visual changes.

![screen shot 2018-03-19 at 3 11 39 pm](https://user-images.githubusercontent.com/349751/37625115-e148d892-2b87-11e8-81e1-e516bb9a18b3.png)

**Testing**
* On a site with Simple Payments (Premium or Business plan), edit a post and click Add > Payment button. Notice the warning in the console.
* Apply this PR and repeat; the warning should not be present.