### PR TITLE
JPC: remote install- center and overlay spinner during credentials submit action.

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -101,6 +101,7 @@ $z-layers: (
 		'ul.module-content-list-item-actions.collapsed': 3,
 		'.auth__input-wrapper .gridicon': 3,
 		'.jetpack-connect__password-form .gridicon': 3,
+		'.jetpack-connect__password-container .jetpack-connect__creds-form-spinner':3,
 		'.auth__self-hosted-instructions': 4,
 		'.auth__form .form-password-input__toggle-visibility': 4,
 		'.site-selector': 10,

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -155,7 +155,7 @@ export class OrgCredentialsForm extends Component {
 					/>
 				</div>
 				<div className="jetpack-connect__password-container">
-					{ isSubmitting ? <Spinner className="jetpack-connect__creds-form-spinner" /> : null }
+					{ isSubmitting && <Spinner className="jetpack-connect__creds-form-spinner" /> }
 					<FormLabel htmlFor="password">{ translate( 'Password' ) }</FormLabel>
 					<div className="jetpack-connect__password-form">
 						<Gridicon size={ 24 } icon="lock" />

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -154,8 +154,8 @@ export class OrgCredentialsForm extends Component {
 						value={ username || '' }
 					/>
 				</div>
-
 				<div className="jetpack-connect__password-container">
+					{ isSubmitting ? <Spinner className="jetpack-connect__creds-form-spinner" /> : null }
 					<FormLabel htmlFor="password">{ translate( 'Password' ) }</FormLabel>
 					<div className="jetpack-connect__password-form">
 						<Gridicon size={ 24 } icon="lock" />
@@ -168,7 +168,6 @@ export class OrgCredentialsForm extends Component {
 							value={ password || '' }
 						/>
 					</div>
-					{ isSubmitting ? <Spinner /> : null }
 				</div>
 			</Fragment>
 		);

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -644,6 +644,13 @@
 	position: relative;
 	margin-bottom: 22px;
 	margin-top: 22px;
+
+	.spinner {
+		z-index: z-index(
+			'root',
+			'.jetpack-connect__password-container .jetpack-connect__creds-form-spinner'
+		);
+	}
 }
 
 .jetpack-connect__password-form {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -656,7 +656,7 @@
 .jetpack-connect__password-form {
 	position: relative;
 
-	.gridicon {
+	.gridicons-lock {
 		position: absolute;
 		z-index: z-index('root', '.jetpack-connect__password-form .gridicon');
 		left: 8px;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -669,6 +669,11 @@
 	text-indent: 27px;
 }
 
+.jetpack-connect__creds-form-spinner {
+	margin-top: -10px;
+	margin-bottom: -10px;
+}
+
 .jetpack-connect__navigation {
 	text-align: center;
 }


### PR DESCRIPTION
Addresses styling comment: https://github.com/Automattic/wp-calypso/pull/23286#issuecomment-372985693.
Also: fixes https://github.com/Automattic/wp-calypso/pull/23396.

## To test:
* follow the instructions in #23286  
* verify that upon form submission the spinner is positioned in the center and does not impact the size of the form. 

![screen shot 2018-03-19 at 22 28 08](https://user-images.githubusercontent.com/13561163/37626026-394732f8-2bc6-11e8-9b4b-2d46721c03e1.png)
