### PR TITLE
Jetpack Onboarding: Retrieve missing credentials when logged out

### DIFF
--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -69,12 +69,19 @@ class JetpackOnboardingMain extends React.PureComponent {
 	}
 
 	retrieveOnboardingCredentials() {
-		const { isConnected, siteId, siteSlug } = this.props;
+		const { isConnected, isRequestingWhetherConnected, jpoAuth, siteId, siteSlug } = this.props;
 		const { hasFinishedRequestingSite } = this.state;
+		const isMissingCredentials =
+			! isRequestingWhetherConnected && ! hasFinishedRequestingSite && ! jpoAuth;
 
 		// If we are not connected and missing the Jetpack onboarding credentials,
 		// redirect back to wp-admin so we can obtain them again.
-		if ( hasFinishedRequestingSite && ! isConnected && ! siteId && siteSlug ) {
+		if (
+			( hasFinishedRequestingSite || isMissingCredentials ) &&
+			! isConnected &&
+			! siteId &&
+			siteSlug
+		) {
 			const siteDomain = siteSlug.replace( '::', '/' );
 			const url = addQueryArgs(
 				{


### PR DESCRIPTION
This PR updates the onboarding credentials retrieval mechanism to account for cases when user is not logged in and credentials are missing. It attempts to resolve #23435 and similar issues when visiting the onboarding flow without credentials as a logged out user.

Fixes #23435.

To test:

* Log out from WP.com
* Start the flow here: http://yourgroovydomain.com/wp-admin/admin.php?page=jetpack&action=onboard
* Enter a site title.
* Select "Personal" or "Business" for the site type.
* Select "Recent news" or "Static page" for the homepage.
* Select "Add a contact form" to be taken to the Jetpack connection flow. I was logged out, so this brought me to the account signup form.
* Select the browser's back button.
* Verify you're shortly being redirected to the Jetpack site to retrieve credentials, and after that you land in the first step of the flow (site title).
* Test as logged in and not connected and verify there are no behavioral changes.
* Test as logged in and connected and verify there are no behavioral changes.
* Test all cases with a clean Redux state.

Side note: it will probably be a nice enhancement to get back to the step that the user left off, but at this time we're losing this between redirects. Reported this in #23436, it can be addressed separately.