### PR TITLE
Happychat: Add tracks analytics chat start

### DIFF
--- a/client/state/happychat/middleware-calypso.js
+++ b/client/state/happychat/middleware-calypso.js
@@ -40,6 +40,7 @@ import isHappychatChatAssigned from 'state/happychat/selectors/is-happychat-chat
 import isHappychatClientConnected from 'state/happychat/selectors/is-happychat-client-connected';
 import { getCurrentUserLocale } from 'state/current-user/selectors';
 import { getCurrentRoute } from 'state/selectors';
+import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 
 const getRouteSetMessage = ( state, path ) => {
 	return `Looking at https://wordpress.com${ path }`;
@@ -152,7 +153,12 @@ export default store => next => action => {
 				getHappychatChatStatus( state ) === HAPPYCHAT_CHAT_STATUS_PENDING &&
 				action.status === HAPPYCHAT_CHAT_STATUS_ASSIGNED
 			) {
-				dispatch( sendEvent( getRouteSetMessage( state, getCurrentRoute( state ) ) ) );
+				dispatch(
+					withAnalytics(
+						recordTracksEvent( 'calypso_happychat_start' ),
+						sendEvent( getRouteSetMessage( state, getCurrentRoute( state ) ) )
+					)
+				);
 			}
 			break;
 


### PR DESCRIPTION
Add tracks analytics for Happychat start.

See pbg9X-cDn-p2 #comment-51943 via @lettergrade 

Blocks #22988

## Testing

Note: Testing Happychat in development requires booting locally and ensuring there is an available and eligible operator in the Happychat staging environment (PCYsg-b99-p2 for details).

1. Ensure there is an available eligible Happychat operator.
1. Boot this branch in development.
1. Run in the browser console: `localStorage.debug = 'calypso:analytics:tracks'`
1. Refresh
1. Open a new Happychat window.
1. Send a message
1. After sending the first message, you should see a debug message in the console for `calypso_happychat_start` (see screenshot)
1. Opening and closing the Happychat window should not produce these events, it will only be sent when a new chat is started
1. Ensure the Happychat session works as before (no regressions).

## Screens

![event](https://user-images.githubusercontent.com/841763/37649669-c8905180-2c32-11e8-8b27-3278f2c598f7.png)
