### PR TITLE
Page List: fix a few bugs in search

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -333,7 +333,9 @@ class Pages extends Component {
 	}
 
 	renderChronological( { pages, site } ) {
-		if ( ! this.props.query.search ) {
+		const { search, status } = this.props.query;
+
+		if ( ! search ) {
 			// we're listing in reverse chrono. use the markers.
 			pages = this._insertTimeMarkers( pages );
 		}
@@ -357,15 +359,14 @@ class Pages extends Component {
 			this.addLoadingRows( rows, 1 );
 		}
 
-		const blogPostsPage = site &&
-			this.props.query.status === 'publish,private' && (
-				<BlogPostsPage key="blog-posts-page" site={ site } pages={ pages } />
-			);
+		const showBlogPostsPage = site && status === 'publish,private' && ! search;
 
 		return (
 			<div id="pages" className="pages__page-list">
 				<InfiniteScroll nextPageMethod={ this.fetchPages } />
-				{ blogPostsPage }
+				{ showBlogPostsPage && (
+					<BlogPostsPage key="blog-posts-page" site={ site } pages={ pages } />
+				) }
 				{ rows }
 				{ this.props.lastPage && pages.length ? <ListEnd /> : null }
 			</div>

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -199,8 +199,8 @@ class Pages extends Component {
 		);
 
 	getNoContentMessage() {
-		const { query = {}, translate, site, siteId } = this.props;
-		const { search, status = 'published' } = query;
+		const { query, translate, site, siteId } = this.props;
+		const { search, status } = query;
 
 		if ( search ) {
 			return (
@@ -291,16 +291,20 @@ class Pages extends Component {
 
 	renderPagesList( { pages } ) {
 		const { site, lastPage, query } = this.props;
-		const status = this.props.status || 'published';
 
 		// Pages only display hierarchically for published pages on single-sites when
 		// there are 100 or fewer pages and no more pages to load (last page).
 		// Pages are not displayed hierarchically for search.
-		if ( site && status === 'published' && lastPage && pages.length <= 100 && ! query.search ) {
-			return this.renderHierarchical( { pages, site } );
-		}
+		const showHierarchical =
+			site &&
+			query.status === 'publish,private' &&
+			lastPage &&
+			pages.length <= 100 &&
+			! query.search;
 
-		return this.renderChronological( { pages, site } );
+		return showHierarchical
+			? this.renderHierarchical( { pages, site } )
+			: this.renderChronological( { pages, site } );
 	}
 
 	renderHierarchical( { pages, site } ) {
@@ -354,7 +358,7 @@ class Pages extends Component {
 		}
 
 		const blogPostsPage = site &&
-			status === 'published' && (
+			this.props.query.status === 'publish,private' && (
 				<BlogPostsPage key="blog-posts-page" site={ site } pages={ pages } />
 			);
 

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -108,6 +108,7 @@ class Pages extends Component {
 		page: 0,
 		pages: [],
 		trackScrollPage: function() {},
+		query: {},
 	};
 
 	state = {
@@ -289,19 +290,13 @@ class Pages extends Component {
 	}
 
 	renderPagesList( { pages } ) {
-		const { site } = this.props;
+		const { site, lastPage, query } = this.props;
 		const status = this.props.status || 'published';
 
 		// Pages only display hierarchically for published pages on single-sites when
 		// there are 100 or fewer pages and no more pages to load (last page).
 		// Pages are not displayed hierarchically for search.
-		if (
-			site &&
-			status === 'published' &&
-			this.props.lastPage &&
-			pages.length <= 100 &&
-			! this.props.search
-		) {
+		if ( site && status === 'published' && lastPage && pages.length <= 100 && ! query.search ) {
 			return this.renderHierarchical( { pages, site } );
 		}
 
@@ -334,7 +329,7 @@ class Pages extends Component {
 	}
 
 	renderChronological( { pages, site } ) {
-		if ( ! this.props.search ) {
+		if ( ! this.props.query.search ) {
 			// we're listing in reverse chrono. use the markers.
 			pages = this._insertTimeMarkers( pages );
 		}


### PR DESCRIPTION
This PR fixes several small bugs when displaying the Page List search results or non-published pages. The root cause of all of them is getting the `this.props.query.status` and `this.props.query.search` values from incorrect sources (like `this.props.status` or even `window.status`).

**How to test:**
When searching in the page list, the list of results should be always in chronological order without time markers and without the "Blog Posts" page.

When displaying the "Published" list, you should always see the "Blog Posts" item at the top, and you should never see it on any other list, e.g., "Trashed".

Here are several examples with screenshot that show **wrong** behavior:

You should never see search results in a hierarchical view (the "Blog Posts" item is also bad):
<img width="464" alt="screen shot 2018-03-20 at 11 55 27" src="https://user-images.githubusercontent.com/664258/37650607-b44c598c-2c35-11e8-8ccd-76ecc656c4aa.png">

Or as a chronological view with time markers:
<img width="465" alt="screen shot 2018-03-20 at 11 54 38" src="https://user-images.githubusercontent.com/664258/37650631-c374e000-2c35-11e8-859a-534afc90732e.png">

When displaying "Published" pages and the list is in chronological order, you should see the "Blog Posts" page. Here it's missing:
<img width="727" alt="screen shot 2018-03-20 at 11 28 35" src="https://user-images.githubusercontent.com/664258/37651474-86e19d4c-2c38-11e8-8b98-db2736898be4.png">

When displaying "Trashed" pages, you should never see a hierarchical list and/or the "Blog Posts" item like this:
<img width="727" alt="screen shot 2018-03-20 at 11 22 16" src="https://user-images.githubusercontent.com/664258/37651549-c28ca792-2c38-11e8-9d33-c779d6a68f9b.png">

The "Domains University" site is a very good one for testing: it has many pages organized in a hierarchy.

To test the chronological and hierarchical views, it helps to know that the hierarchical view is shown only for fully loaded lists, i.e., after infinite-scrolling down to the very last page.