### PR TITLE
Guided Tours: Get a Jetpack basic tour and have JPC redirect to it

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -98,9 +98,9 @@ class Plans extends Component {
 		const { canPurchasePlans, selectedSiteSlug } = this.props;
 
 		if ( selectedSiteSlug && canPurchasePlans ) {
-			// Redirect to "My Plan" page with the "Main Tour" guided tour enabled.
+			// Redirect to "My Plan" page with the "Jetpack Basic Tour" guided tour enabled.
 			// For more details about guided tours, see layout/guided-tours/README.md
-			return this.redirect( CALYPSO_MY_PLAN_PAGE, { tour: 'main' } );
+			return this.redirect( CALYPSO_MY_PLAN_PAGE, { tour: 'jetpack' } );
 		}
 
 		return this.redirect( CALYPSO_REDIRECTION_PAGE );

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -18,6 +18,7 @@ import { ChecklistSiteIconTour } from 'layout/guided-tours/tours/checklist-site-
 import { ChecklistSiteTaglineTour } from 'layout/guided-tours/tours/checklist-site-tagline-tour';
 import { ChecklistSiteTitleTour } from 'layout/guided-tours/tours/checklist-site-title-tour';
 import { ChecklistUserAvatarTour } from 'layout/guided-tours/tours/checklist-user-avatar-tour';
+import { JetpackBasicTour } from 'layout/guided-tours/tours/jetpack-basic-tour';
 
 export default combineTours( {
 	checklistAboutPage: ChecklistAboutPageTour,
@@ -27,6 +28,7 @@ export default combineTours( {
 	checklistSiteTagline: ChecklistSiteTaglineTour,
 	checklistSiteTitle: ChecklistSiteTitleTour,
 	checklistUserAvatar: ChecklistUserAvatarTour,
+	jetpack: JetpackBasicTour,
 	main: MainTour,
 	editorBasicsTour: EditorBasicsTour,
 	mediaBasicsTour: MediaBasicsTour,

--- a/client/layout/guided-tours/tours/jetpack-basic-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-basic-tour.js
@@ -36,7 +36,7 @@ const scrollSidebarToTop = () => scrollTo( { y: 0, container: getScrollableSideb
 // this is kept as an example, while making sure it never gets triggered
 export const JetpackBasicTour = makeTour(
 	<Tour
-		name="jetpackBasicTour"
+		name="jetpack"
 		version="20160601"
 		path="/"
 		when={ and( isNewUser, isEnabled( 'guided-tours/jetpack-basic' ) ) }

--- a/client/layout/guided-tours/tours/jetpack-basic-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-basic-tour.js
@@ -39,7 +39,7 @@ export const JetpackBasicTour = makeTour(
 		name="jetpackBasicTour"
 		version="20160601"
 		path="/"
-		when={ and( isNewUser, isEnabled( 'guided-tours/main' ) ) }
+		when={ and( isNewUser, isEnabled( 'guided-tours/jetpack-basic' ) ) }
 	>
 		<Step name="init" placement="right">
 			{ ( { translate } ) => (

--- a/client/layout/guided-tours/tours/jetpack-basic-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-basic-tour.js
@@ -1,0 +1,193 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Fragment } from 'react';
+import { overEvery as and } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	makeTour,
+	Tour,
+	Step,
+	ButtonRow,
+	Next,
+	Quit,
+	Continue,
+	Link,
+} from 'layout/guided-tours/config-elements';
+import {
+	isNewUser,
+	isEnabled,
+	isSelectedSitePreviewable,
+	isSelectedSiteCustomizable,
+} from 'state/ui/guided-tours/contexts';
+import { getScrollableSidebar } from 'layout/guided-tours/positioning';
+import scrollTo from 'lib/scroll-to';
+import { ViewSiteButton } from '../button-labels';
+
+const scrollSidebarToTop = () => scrollTo( { y: 0, container: getScrollableSidebar() } );
+
+// note that this tour checks for a non-existent feature flag.
+// this is kept as an example, while making sure it never gets triggered
+export const MainTour = makeTour(
+	<Tour
+		name="main"
+		version="20160601"
+		path="/"
+		when={ and( isNewUser, isEnabled( 'guided-tours/main' ) ) }
+	>
+		<Step name="init" placement="right">
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"{{strong}}Need a hand?{{/strong}} We'd love to show you around the place, " +
+								'and give you some ideas for what to do next.',
+							{
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="my-sites">{ translate( "Let's go!" ) }</Next>
+						<Quit>{ translate( 'No thanks.' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+
+		<Step name="my-sites" target="my-sites" placement="below" arrow="top-left">
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"{{strong}}First things first.{{/strong}} Up here, you'll find tools for managing " +
+								"your site's content and design.",
+							{
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
+					</p>
+					<Continue click icon="my-sites" step="sidebar" target="my-sites" />
+				</Fragment>
+			) }
+		</Step>
+
+		<Step name="sidebar" target="sidebar" arrow="left-middle" placement="beside">
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'This menu lets you navigate around, and will adapt to give you the tools you need when you need them.'
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="click-preview" />
+						<Quit />
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+
+		<Step
+			name="click-preview"
+			target="sitePreview"
+			arrow="top-left"
+			placement="below"
+			when={ isSelectedSitePreviewable }
+			scrollContainer=".sidebar__region"
+		>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>{ translate( 'Want to take a look at your site?' ) }</p>
+					<Continue click step="view-site" target="sitePreview">
+						{ translate( 'Click {{viewSiteButton/}} to continue.', {
+							components: {
+								viewSiteButton: <ViewSiteButton />,
+							},
+						} ) }
+					</Continue>
+					<ButtonRow>
+						<Quit />
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+
+		<Step name="view-site" placement="center" when={ isSelectedSitePreviewable }>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>{ translate( 'This is what your site looks like to visitors.' ) }</p>
+					<ButtonRow>
+						<Next step="themes" />
+						<Quit />
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+
+		<Step
+			name="themes"
+			target="themes"
+			arrow="top-left"
+			placement="below"
+			when={ isSelectedSiteCustomizable }
+			scrollContainer=".sidebar__region"
+			shouldScrollTo
+		>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Change your {{strong}}Theme{{/strong}} to choose a new layout, or {{strong}}Customize{{/strong}} ' +
+								"your theme's colors, fonts, and more.",
+							{
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="finish" />
+						<Quit />
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+
+		<Step name="finish" placement="center">
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"{{strong}}That's it!{{/strong}} Now that you know a few of the basics, feel free to wander around.",
+							{
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
+					</p>
+					<ButtonRow>
+						<Quit onClick={ scrollSidebarToTop } primary>
+							{ translate( "We're all done!" ) }
+						</Quit>
+					</ButtonRow>
+					<Link href="https://learn.wordpress.com">
+						{ translate( 'Learn more about WordPress.com' ) }
+					</Link>
+				</Fragment>
+			) }
+		</Step>
+	</Tour>
+);

--- a/client/layout/guided-tours/tours/jetpack-basic-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-basic-tour.js
@@ -34,9 +34,9 @@ const scrollSidebarToTop = () => scrollTo( { y: 0, container: getScrollableSideb
 
 // note that this tour checks for a non-existent feature flag.
 // this is kept as an example, while making sure it never gets triggered
-export const MainTour = makeTour(
+export const JetpackBasicTour = makeTour(
 	<Tour
-		name="main"
+		name="jetpackBasicTour"
 		version="20160601"
 		path="/"
 		when={ and( isNewUser, isEnabled( 'guided-tours/main' ) ) }


### PR DESCRIPTION
This PR duplicates the `Main` guided tour to a Jetpack Basic tour, and updates Jetpack connection flow to use that new tour (as recommended in #23177). Also, it removes the usage of the deprecated `main` tour, that we shouldn't be calling directly.

This will allow us to create a more specific guided tour for new Jetpack users in the future. We could also improve the contexts within which we present this guided tour, so it would be run automatically without a query parameter.

Fixes #23177.

To test:
* Checkout this branch
* Start a new Jurassic Ninja site.
* Go to http://calypso.localhost:3000/jetpack/connect
* Connect the site.
* When presented with the plans screen, go with the free plan.
* Verify you're redirected to http://calypso.localhost:3000/plans/my-plan/:site?tour=jetpack
* Verify this starts the same guided tour that was started before (it's just named differently).