### PR TITLE
Google Apps: Make the `google-site-verification` token verification less strict

### DIFF
--- a/client/my-sites/domains/domain-management/name-servers/dns-templates.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/dns-templates.jsx
@@ -38,7 +38,7 @@ class DnsTemplates extends React.Component {
 						}
 					),
 					placeholder: 'google-site-verification=...',
-					validationPattern: /^google-site-verification=\w{43}$/,
+					validationPattern: /^google-site-verification=[A-Za-z0-9_-]{43}$/,
 					dnsTemplateProvider: dnsTemplates.G_SUITE.PROVIDER,
 					dnsTemplateService: dnsTemplates.G_SUITE.SERVICE,
 				},


### PR DESCRIPTION
As reported by @dcoleonline in p2MSmN-6ro-p2, our validation of `google-site-verification` is too strict. Apparently  dashes and underscores can be used in the token as well.
I can't find any documentation or specification for this token, but on the other hand it seems like a legit request.

### Testing
Go to Domains -> example.com (domain registration) -> Name Servers and DNS -> G Suite:
<img width="744" alt="screen shot 2018-03-20 at 12 50 48" src="https://user-images.githubusercontent.com/3392497/37652901-561af1b8-2c3d-11e8-9f3f-60704b3912c4.png">

Verify that a "valid" token works:
* `google-site-verification=1234567890123456789012345678901234567890123`
* `google-site-verification=1234567D901a3456_890123-5678901234567890123`

Verify that an invalid token is rejected:
* `google-site-verification=1234567890123456789012345678901234567890` (too short)
* `google-site-verification=1234567890123456789012345678901234567890ążć` (invalid characters)
* `google-site-verification=1234567890123456789012345678901234567890$%#` (invalid characters)