### PR TITLE
Jetpack Onboarding: Fix request settings failure button for connected sites

### DIFF
--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -16,7 +16,7 @@ import {
 	JETPACK_ONBOARDING_SETTINGS_REQUEST,
 	JETPACK_ONBOARDING_SETTINGS_SAVE,
 } from 'state/action-types';
-import { getUnconnectedSiteUrl } from 'state/selectors';
+import { getSiteUrl, getUnconnectedSiteUrl } from 'state/selectors';
 import {
 	saveJetpackOnboardingSettingsSuccess,
 	updateJetpackOnboardingSettings,
@@ -66,7 +66,8 @@ export const requestJetpackOnboardingSettings = ( { dispatch }, action ) => {
 };
 
 export const announceRequestFailure = ( { dispatch, getState }, { siteId } ) => {
-	const url = getUnconnectedSiteUrl( getState(), siteId );
+	const state = getState();
+	const url = getSiteUrl( state, siteId ) || getUnconnectedSiteUrl( state, siteId );
 	const noticeOptions = {
 		id: `jpo-communication-error-${ siteId }`,
 	};

--- a/client/state/data-layer/wpcom/jetpack/settings/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/test/index.js
@@ -88,7 +88,7 @@ describe( 'announceRequestFailure()', () => {
 	const siteId = 12345678;
 	const siteUrl = 'http://yourgroovydomain.com';
 
-	test( 'should trigger an error notice with an action button when request fails', () => {
+	test( 'should trigger an error notice with an action button when request fails for an unconnected site', () => {
 		const getState = () => ( {
 			jetpackOnboarding: {
 				credentials: {
@@ -96,6 +96,39 @@ describe( 'announceRequestFailure()', () => {
 						siteUrl,
 						token: 'abcd1234',
 						userEmail: 'example@yourgroovydomain.com',
+					},
+				},
+			},
+			sites: {
+				items: {},
+			},
+		} );
+
+		announceRequestFailure( { dispatch, getState }, { siteId } );
+
+		expect( dispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				notice: expect.objectContaining( {
+					button: 'Visit site admin',
+					href: siteUrl + '/wp-admin/admin.php?page=jetpack',
+					noticeId: `jpo-communication-error-${ siteId }`,
+					status: 'is-error',
+					text: 'Something went wrong.',
+				} ),
+			} )
+		);
+	} );
+
+	test( 'should trigger an error notice with an action button when request fails for a connected site', () => {
+		const getState = () => ( {
+			jetpackOnboarding: {
+				credentials: {},
+			},
+			sites: {
+				items: {
+					[ siteId ]: {
+						ID: siteId,
+						URL: siteUrl,
 					},
 				},
 			},
@@ -125,6 +158,9 @@ describe( 'announceRequestFailure()', () => {
 						userEmail: 'example@yourgroovydomain.com',
 					},
 				},
+			},
+			sites: {
+				items: {},
 			},
 		} );
 


### PR DESCRIPTION
This PR updates the request failure notice button to properly retrieve the site when it's connected.

To test:
* Checkout this branch
* Verify tests pass:

```
npm run test-client client/state/data-layer/wpcom/jetpack/settings/test/index.js
```

Fixes #23298.