### PR TITLE
Pages: Add a placeholder title for static pages with empty titles

### DIFF
--- a/client/my-sites/pages/blog-posts-page/index.jsx
+++ b/client/my-sites/pages/blog-posts-page/index.jsx
@@ -35,6 +35,10 @@ class BlogPostsPage extends React.Component {
 			.shift();
 	}
 
+	getPageTitle = pageId =>
+		this.getPageProperty( { pageId, property: 'title' } ) ||
+		`#${ pageId } ${ this.props.translate( '(no title)' ) }`;
+
 	getPostsPageLink( { isStaticHomePageWithNoPostsPage, isCurrentlySetAsHomepage } ) {
 		if ( isStaticHomePageWithNoPostsPage ) {
 			return null;
@@ -57,10 +61,7 @@ class BlogPostsPage extends React.Component {
 					{ this.props.translate( 'Not in use.' ) + ' ' }
 					{ this.props.translate( '"%(pageTitle)s" is the front page.', {
 						args: {
-							pageTitle: this.getPageProperty( {
-								pageId: this.props.frontPage,
-								property: 'title',
-							} ),
+							pageTitle: this.getPageTitle( this.props.frontPage ),
 						},
 					} ) }
 				</span>
@@ -80,7 +81,7 @@ class BlogPostsPage extends React.Component {
 			<span>
 				{ translate( '"%(pageTitle)s" page is showing your latest posts.', {
 					args: {
-						pageTitle: this.getPageProperty( { pageId: this.props.postsPage, property: 'title' } ),
+						pageTitle: this.getPageTitle( this.props.postsPage ),
 					},
 				} ) }
 			</span>


### PR DESCRIPTION
Fix #18340 

If an untitled page is selected as Posts Page, use a placeholder title in the Site Pages section.

| Before | After |
| --- | --- |
| <img width="264" alt="screen shot 2018-03-20 at 12 34 05" src="https://user-images.githubusercontent.com/2070010/37654946-c0312fec-2c3b-11e8-8fcf-2ced1053ec4b.png"> | <img width="335" alt="screen shot 2018-03-20 at 12 34 14" src="https://user-images.githubusercontent.com/2070010/37654953-c39aa8f2-2c3b-11e8-9a96-1259fe1fe62d.png"> |

## Testing instructions

- Create a page without a title.
- Head over to Customizer -> Homepage Settings, choose "A static page", and pick the untitled page in the "Posts page" selector. Publish your changes.
- Exit the Customizer and open Site Pages.
- Make sure the Blog Posts page now shows up as `#${ pageId } (no title)`.