### PR TITLE
Post Editor: Pre-fill the publicize message with the post title

### DIFF
--- a/client/post-editor/editor-sharing/publicize-message.jsx
+++ b/client/post-editor/editor-sharing/publicize-message.jsx
@@ -60,8 +60,12 @@ class PublicizeMessage extends Component {
 		stats.recordEvent( 'Publicize Sharing Message Changed' );
 	};
 
+	shouldPreFillMessage() {
+		return ! this.state.userHasEditedMessage && '' === this.props.message;
+	}
+
 	getMessage() {
-		if ( ! this.state.userHasEditedMessage ) {
+		if ( this.shouldPreFillMessage() ) {
 			return this.props.preFilledMessage;
 		}
 		return this.props.message;

--- a/client/post-editor/editor-sharing/publicize-message.jsx
+++ b/client/post-editor/editor-sharing/publicize-message.jsx
@@ -27,6 +27,7 @@ class PublicizeMessage extends Component {
 		requireCount: PropTypes.bool,
 		displayMessageHeading: PropTypes.bool,
 		onChange: PropTypes.func,
+		preFilledMessage: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -35,10 +36,18 @@ class PublicizeMessage extends Component {
 		acceptableLength: 280,
 		requireCount: false,
 		displayMessageHeading: true,
+		preFilledMessage: '',
 	};
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			userHasEditedMessage: false,
+		};
+	}
 
 	onChange = event => {
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
+		this.setState( { userHasEditedMessage: true } );
 		if ( this.props.onChange ) {
 			this.props.onChange( event.target.value );
 		} else {
@@ -50,6 +59,13 @@ class PublicizeMessage extends Component {
 		stats.recordStat( 'sharing_message_changed' );
 		stats.recordEvent( 'Publicize Sharing Message Changed' );
 	};
+
+	getMessage() {
+		if ( ! this.state.userHasEditedMessage ) {
+			return this.props.preFilledMessage;
+		}
+		return this.props.message;
+	}
 
 	renderInfoPopover() {
 		return (
@@ -70,14 +86,13 @@ class PublicizeMessage extends Component {
 	renderTextarea() {
 		const placeholder =
 			this.props.preview || this.props.translate( 'Write a message for your audience here.' );
-
 		if ( this.props.requireCount ) {
 			return (
 				<CountedTextarea
 					disabled={ this.props.disabled }
-					value={ this.props.message }
 					placeholder={ placeholder }
 					countPlaceholderLength={ true }
+					value={ this.getMessage() }
 					onChange={ this.onChange }
 					showRemainingCharacters={ true }
 					acceptableLength={ this.props.acceptableLength }
@@ -88,13 +103,15 @@ class PublicizeMessage extends Component {
 			);
 		} else {
 			return (
-				<FormTextarea
-					disabled={ this.props.disabled }
-					value={ this.props.message }
-					placeholder={ placeholder }
-					onChange={ this.onChange }
-					className="editor-sharing__message-input"
-				/>
+				<div>
+					<FormTextarea
+						disabled={ this.props.disabled }
+						value={ this.getMessage() }
+						placeholder={ placeholder }
+						onChange={ this.onChange }
+						className="editor-sharing__message-input"
+					/>
+				</div>
 			);
 		}
 	}

--- a/client/post-editor/editor-sharing/publicize-options.jsx
+++ b/client/post-editor/editor-sharing/publicize-options.jsx
@@ -94,7 +94,8 @@ class EditorSharingPublicizeOptions extends React.Component {
 					)
 				: [],
 			requireCount = includes( map( targeted, 'service' ), 'twitter' ),
-			acceptableLength = requireCount ? 280 - 23 - 23 : null;
+			acceptableLength = requireCount ? 280 - 23 - 23 : null,
+			preFilledMessage = this.props.post ? this.props.post.title : '';
 
 		if ( ! this.hasConnections() ) {
 			return;
@@ -105,6 +106,7 @@ class EditorSharingPublicizeOptions extends React.Component {
 				message={ PostMetadata.publicizeMessage( this.props.post ) || '' }
 				requireCount={ requireCount }
 				acceptableLength={ acceptableLength }
+				preFilledMessage={ preFilledMessage }
 			/>
 		);
 	};


### PR DESCRIPTION
Fixes #22762 

If applied this PR will, under certain conditions, pre-fill the Publicize message in the post editor using the post's title for the message's content.

Here's is a video demo of how this PR performs:

https://cloudup.com/cpKXMCgP4ok

To test:
- Run this branch locally or on calypso.live
- Start a new post on a site with an active Publicize connection
- Ensure the title is used to pre-fill the message
- Ensure that after customizing the message, the post's title is no longer used
