### PR TITLE
Store: Use sortBySales helper function and add conversion rate context

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/index.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/index.js
@@ -9,7 +9,7 @@ import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize, moment } from 'i18n-calypso';
-import { sortBy, find } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,6 +36,7 @@ import QuerySiteStats from 'components/data/query-site-stats';
 import { recordTrack } from 'woocommerce/lib/analytics';
 import { savePreference } from 'state/preferences/actions';
 import SelectDropdown from 'components/select-dropdown';
+import { sortBySales } from 'woocommerce/app/store-stats/referrers/helpers';
 import Stat from './stat';
 import { withAnalytics } from 'state/analytics/actions';
 
@@ -200,6 +201,9 @@ class StatsWidget extends Component {
 			<Stat
 				site={ site }
 				label={ translate( 'Conversion rate' ) }
+				labelToolTip={ translate( 'Number of orders by unique visitors', {
+					context: 'Conversion rate tooltip',
+				} ) }
 				data={ data || [] }
 				delta={ delta }
 				date={ date }
@@ -215,9 +219,8 @@ class StatsWidget extends Component {
 		const { site, translate, unit, referrerData, queries, viewStats } = this.props;
 		const { referrerQuery } = queries;
 
-		const row = find( referrerData, d => d.date === referrerQuery.date );
-		const fetchedData =
-			( row && sortBy( row.data, r => -r.sales ).slice( 0, dashboardListLimit ) ) || [];
+		const selectedData = find( referrerData, d => d.date === referrerQuery.date ) || { data: [] };
+		const sortedData = sortBySales( selectedData.data, dashboardListLimit );
 
 		const values = [
 			{ key: 'referrer', title: translate( 'Referrer' ), format: 'text' },
@@ -246,7 +249,7 @@ class StatsWidget extends Component {
 				viewText={ translate( 'View referrers' ) }
 				viewLink={ viewLink }
 				onViewClick={ viewStats }
-				fetchedData={ fetchedData }
+				fetchedData={ sortedData }
 				emptyMessage={ emptyMessage }
 			/>
 		);

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/stat.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/stat.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { findIndex } from 'lodash';
 import { connect } from 'react-redux';
@@ -24,6 +25,7 @@ class StatsWidgetStat extends Component {
 			slug: PropTypes.string,
 		} ),
 		label: PropTypes.string.isRequired,
+		labelToolTip: PropTypes.string,
 		attribute: PropTypes.string.isRequired,
 		type: PropTypes.string.isRequired,
 		data: PropTypes.array.isRequired,
@@ -55,7 +57,7 @@ class StatsWidgetStat extends Component {
 	};
 
 	render() {
-		const { data, site, date, attribute, label, requesting, type } = this.props;
+		const { data, site, date, attribute, label, requesting, type, labelToolTip } = this.props;
 
 		if ( requesting || ! site.ID || ! data || ! data.length ) {
 			return (
@@ -73,10 +75,16 @@ class StatsWidgetStat extends Component {
 		const value = data[ index ][ attribute ];
 		const timeSeries = data.map( row => +row[ attribute ] );
 
+		const labelClasses = classNames( 'stats-widget__box-label', {
+			'stats-widget__box-label-tooltip': labelToolTip,
+		} );
+
 		return (
 			<div className="stats-widget__box-contents stats-type-stat">
 				<div className="stats-widget__box-data">
-					<span className="stats-widget__box-label">{ label }</span>
+					<span className={ labelClasses } title={ labelToolTip }>
+						{ label }
+					</span>
 					<div className="stats-widget__box-value-and-delta">
 						<span className="stats-widget__box-value">
 							{ formatValue( value, type, data[ index ].currency ) }

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
@@ -61,6 +61,10 @@
 		white-space: nowrap;
 	}
 
+	.stats-widget__box-label-tooltip {
+		cursor: help;
+	}
+
 	.table.is-compact-table .table-item {
 		font-size: 14px;
 		color: $gray-darken-20;


### PR DESCRIPTION
This small PR makes two small adjustments to the store stats widget (#23344):

* Uses `sortBySales` for sorting referrer data and trimming data.
* Adds a title/tooltip on the conversion rate title to provide some context about how its calculated.

To Test:
* View your dashboard and make sure the referrer widget correctly pulls in referrers and orders them by sales.
* Hover over "Conversion rate" and verify you see title text.