### PR TITLE
Notice: add 'isLoading' prop to show a pulsing animation on the icon

### DIFF
--- a/client/components/notice/docs/example.jsx
+++ b/client/components/notice/docs/example.jsx
@@ -7,8 +7,8 @@
 import React from 'react';
 
 /**
-* Internal dependencies
-*/
+ * Internal dependencies
+ */
 import NoticeAction from 'components/notice/notice-action';
 import Notice from 'components/notice';
 
@@ -116,6 +116,16 @@ class Notices extends React.PureComponent {
 					>
 						<NoticeAction href="#">More</NoticeAction>
 					</Notice>
+				</div>
+				<div>
+					<Notice
+						status="is-info"
+						icon="reader"
+						isLoading
+						text="I'm a notice that's loading…"
+						showDismiss={ false }
+						isCompact={ this.state.compactNotices ? true : null }
+					/>
 				</div>
 			</div>
 		);

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -17,6 +17,7 @@ export class Notice extends Component {
 		duration: 0,
 		icon: null,
 		isCompact: false,
+		isLoading: false,
 		onDismissClick: noop,
 		status: null,
 		text: null,
@@ -27,6 +28,7 @@ export class Notice extends Component {
 		duration: PropTypes.number,
 		icon: PropTypes.string,
 		isCompact: PropTypes.bool,
+		isLoading: PropTypes.bool,
 		onDismissClick: PropTypes.func,
 		showDismiss: PropTypes.bool,
 		status: PropTypes.oneOf( [ 'is-error', 'is-info', 'is-success', 'is-warning', 'is-plain' ] ),
@@ -81,6 +83,7 @@ export class Notice extends Component {
 			className,
 			icon,
 			isCompact,
+			isLoading,
 			onDismissClick,
 			showDismiss = ! isCompact, // by default, show on normal notices, don't show on compact ones
 			status,
@@ -89,6 +92,7 @@ export class Notice extends Component {
 		} = this.props;
 		const classes = classnames( 'notice', status, className, {
 			'is-compact': isCompact,
+			'is-loading': isLoading,
 			'is-dismissable': showDismiss,
 		} );
 

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -1,4 +1,4 @@
-@keyframes notice-loading-fade {
+@keyframes notice-loading-pulse {
 	0% { opacity: 0; }
 	50% { opacity: .5; }
 	100% { opacity: 0; }
@@ -48,7 +48,7 @@
 		.notice__icon-wrapper::after {
 			content: '';
 			background-color: $white;
-			animation: notice-loading-fade 1.6s ease-in-out infinite;
+			animation: notice-loading-pulse 0.8s ease-in-out infinite;
 			position: absolute;
 			top: 0;
 			bottom: 0;

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -1,3 +1,9 @@
+@keyframes notice-loading-fade {
+	0% { opacity: 0; }
+	50% { opacity: .5; }
+	100% { opacity: 0; }
+}
+
 .notice {
 	display: flex;
 	position: relative;
@@ -38,6 +44,19 @@
 		}
 	}
 
+	&.is-loading {
+		.notice__icon-wrapper::after {
+			content: '';
+			background-color: $white;
+			animation: notice-loading-fade 1.6s ease-in-out infinite;
+			position: absolute;
+			top: 0;
+			bottom: 0;
+			left: 0;
+			right: 0;
+		}
+	}
+
 	.notice__dismiss {
 		overflow: hidden;
 	}
@@ -53,6 +72,7 @@
 }
 
 .notice__icon-wrapper {
+	position: relative;
 	background: $gray-text-min;
 	color: $white;
 	display: flex;

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -55,6 +55,7 @@ const ShadowNotice = localize( ( { shadowStatus, onUndoClick, translate } ) => (
 			text={ shadowStatus.text }
 			status={ shadowStatus.status }
 			icon={ shadowStatus.icon }
+			isLoading={ shadowStatus.isLoading }
 		>
 			{ shadowStatus.undo && (
 				<NoticeAction onClick={ onUndoClick }>{ translate( 'Undo' ) }</NoticeAction>
@@ -434,7 +435,7 @@ class Page extends Component {
 	}
 
 	async performUpdate( { action, progressNotice, successNotice, errorNotice, undo } ) {
-		await this.changeShadowStatus( progressNotice );
+		await this.changeShadowStatus( { ...progressNotice, isLoading: true } );
 		try {
 			await action();
 			if ( undo === 'undo' ) {


### PR DESCRIPTION
Implements a suggestion by @shaunandrews from https://github.com/Automattic/wp-calypso/pull/23090#issuecomment-374237015

`<Notice isLoading />` will show a pulsing animation on the notice icon:
![screen capture on 2018-03-20 at 15-41-25](https://user-images.githubusercontent.com/664258/37661698-af00317c-2c55-11e8-8118-f0ed2bea625c.gif)

The CSS animation used is very similar to the `loading-fade` animation used by the `placeholder` SASS mixin.

In the second commit, the new feature is used in the Site Pages List UI.