### PR TITLE
Fix broken status check

### DIFF
--- a/client/blocks/post-share/connection.jsx
+++ b/client/blocks/post-share/connection.jsx
@@ -15,7 +15,13 @@ import classNames from 'classnames';
 import SocialLogo from 'social-logos';
 
 const PostShareConnection = ( { connection, isActive, onToggle } ) => {
-	const { external_display, external_profile_picture, keyring_connection_ID, service } = connection;
+	const {
+		external_display,
+		external_profile_picture,
+		keyring_connection_ID,
+		service,
+		status,
+	} = connection;
 
 	const toggle = () => onToggle( keyring_connection_ID );
 


### PR DESCRIPTION
Turns out `status` is a [global](https://developer.mozilla.org/en-US/docs/Web/API/Window/status), so eslint didn't catch this missing declaration. Wheeee.