### PR TITLE
Page List: show page action notices also in chronological view

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -317,7 +317,6 @@ class Pages extends Component {
 					shadowStatus={ this.state.shadowItems[ page.global_ID ] }
 					onShadowStatusChange={ this.updateShadowStatus }
 					page={ page }
-					site={ site }
 					multisite={ false }
 					hierarchical={ true }
 					hierarchyLevel={ page.indentLevel || 0 }
@@ -347,7 +346,8 @@ class Pages extends Component {
 			return (
 				<Page
 					key={ 'page-' + page.global_ID }
-					onShadow={ this.handleShadow }
+					shadowStatus={ this.state.shadowItems[ page.global_ID ] }
+					onShadowStatusChange={ this.updateShadowStatus }
 					page={ page }
 					multisite={ this.props.siteId === null }
 				/>


### PR DESCRIPTION
Fixes a bug where the page action animation wasn't shown when trashing/restoring page in the chronological view.

This wasn't caught when testing #23090. I discovered the bug after working on #23440, which switches several views from the incorrect hierarchical to the correct chronological one.

A little drive-by fix: the `Page` component doesn't need a `site` prop: it gets it in its `connect` call from `page.site_ID`.