### PR TITLE
Store Dashboard: Remove MailChimp settings request

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -33,7 +33,6 @@ import {
 } from 'woocommerce/state/sites/orders/selectors';
 import { fetchOrders } from 'woocommerce/state/sites/orders/actions';
 import { fetchProducts } from 'woocommerce/state/sites/products/actions';
-import { requestSettings } from 'woocommerce/state/sites/settings/mailchimp/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import {
 	getTotalProducts,
@@ -112,7 +111,6 @@ class Dashboard extends Component {
 	fetchStoreData = () => {
 		const { siteId, productsLoaded } = this.props;
 		this.props.fetchOrders( siteId );
-		this.props.requestSettings( siteId );
 
 		if ( ! productsLoaded ) {
 			const params = { page: 1 };
@@ -301,7 +299,6 @@ function mapDispatchToProps( dispatch ) {
 		{
 			fetchOrders,
 			fetchProducts,
-			requestSettings,
 		},
 		dispatch
 	);

--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -49,7 +49,6 @@ import StoreLocationSetupView from './setup/store-location';
 import RequiredPagesSetupView from './required-pages-setup-view';
 import RequiredPluginsInstallView from './required-plugins-install-view';
 import SetupTasksView from './setup';
-import MailChimp from 'woocommerce/app/settings/email/mailchimp/index.js';
 import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
 import warn from 'lib/warn';
 
@@ -66,7 +65,6 @@ class Dashboard extends Component {
 			URL: PropTypes.string.isRequired,
 		} ),
 		siteId: PropTypes.number,
-		mailChimpConfigured: PropTypes.bool,
 		fetchOrders: PropTypes.func,
 		requestSyncStatus: PropTypes.func,
 		setupChoicesLoading: PropTypes.bool,
@@ -231,13 +229,7 @@ class Dashboard extends Component {
 			manageView = <ManageExternalView site={ selectedSite } />;
 		}
 
-		return (
-			<div>
-				{ manageView }
-				{ ! this.props.mailChimpConfigured &&
-					manageInCalypso && <MailChimp site={ selectedSite } redirectToSettings dashboardView /> }
-			</div>
-		);
+		return <div>{ manageView }</div>;
 	};
 
 	render() {


### PR DESCRIPTION
This PR removes the MailChimp code from the dashboard, following on #22352 which hides the component. Currently we send out an API request to fetch mailchimp settings, but these aren't being used. Also, since I spent about 20min trying to figure out why `props.mailChimpConfigured` was used but never set, I've also removed that (6dbfde7). This can easily be re-added once we've determined MC is OK to promote again.

**To test**

- Load the dashboard
- Watch your network requests, you can filter for "mailchimp"
- You should see no matching requests

There should be no UI changes, since this wasn't being displayed anywhere.