### PR TITLE
Signup: add AB test for horizontal/vertical plans table

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -128,4 +128,13 @@ export default {
 		defaultVariation: 'original',
 		allowExistingUsers: true,
 	},
+	mobilePlansTablesOnSignup: {
+		datestamp: '20180320',
+		variations: {
+			original: 50,
+			mobile: 50,
+		},
+		defaultVariation: 'original',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -64,6 +64,7 @@ class PlanFeatures extends Component {
 		const planClasses = classNames( 'plan-features', {
 			'plan-features--signup': isInSignup,
 			'abtest-pricing-display': showModifiedPricingDisplay,
+			'has-mobile-table': abtest( 'mobilePlansTablesOnSignup' ) === 'mobile',
 		} );
 		const planWrapperClasses = classNames( { 'plans-wrapper': isInSignup } );
 		let mobileView, planDescriptions;

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -70,14 +70,16 @@ class PlanFeatures extends Component {
 		let mobileView, planDescriptions;
 		let bottomButtons = null;
 
-		if ( abtest( 'mobilePlansTablesOnSignup' ) === 'mobile' ) {
-			mobileView = <div className="plan-features__mobile">{ this.renderMobileView() }</div>;
-		}
-
 		if ( ! isInSignup ) {
 			planDescriptions = <tr>{ this.renderPlanDescriptions() }</tr>;
 
 			bottomButtons = <tr>{ this.renderBottomButtons() }</tr>;
+		}
+
+		mobileView = <div className="plan-features__mobile">{ this.renderMobileView() }</div>;
+
+		if ( isInSignup && abtest( 'mobilePlansTablesOnSignup' ) === 'original' ) {
+			mobileView = '';
 		}
 
 		return (

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -69,9 +69,11 @@ class PlanFeatures extends Component {
 		let mobileView, planDescriptions;
 		let bottomButtons = null;
 
-		if ( ! isInSignup ) {
+		if ( abtest( 'mobilePlansTablesOnSignup' ) === 'mobile' ) {
 			mobileView = <div className="plan-features__mobile">{ this.renderMobileView() }</div>;
+		}
 
+		if ( ! isInSignup ) {
 			planDescriptions = <tr>{ this.renderPlanDescriptions() }</tr>;
 
 			bottomButtons = <tr>{ this.renderBottomButtons() }</tr>;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -643,3 +643,31 @@ $plan-features-sidebar-width: 272px;
 		background: darken( #44d0a3, 20% );
 	}
 }
+
+/**
+ * A/B test for horizontal vs vertical scroll
+ */
+.has-mobile-table.plan-features--signup {
+	
+	@include breakpoint( "<660px" ) {
+	
+		.signup__steps & {
+			width: auto;
+		}
+
+		.plan-features__graphic {
+			float: right;
+			width: 50px;
+			height: 50px;
+			margin: 16px 20px;
+		}
+
+		.plan-features__pricing {
+			margin: 20px 20px -12px;
+		}
+
+		.plan-features__table {
+			display: none !important;
+		}
+	}
+}

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -651,7 +651,8 @@ $plan-features-sidebar-width: 272px;
 	
 	@include breakpoint( "<660px" ) {
 	
-		.signup__steps & {
+		.signup__steps &,
+		.jetpack-connect__plans & {
 			width: auto;
 		}
 
@@ -668,6 +669,10 @@ $plan-features-sidebar-width: 272px;
 
 		.plan-features__table {
 			display: none !important;
+		}
+
+		.jetpack-connect__hide-plan-icons .jetpack-connect__plans & .plan-features__pricing {
+			padding-top: 0;
 		}
 	}
 }


### PR DESCRIPTION
Adds a new AB test to evaluate the performance of horizontal vs vertical plans tables on smaller screens.

AB test name: `mobilePlansTablesOnSignup`.
Allocations: `50/50`.

e2e tests PR: https://github.com/Automattic/wp-e2e-tests/pull/1058

Some background here: p6TEKc-1T2-p2

### Before

**WordPress.com**

![image](https://user-images.githubusercontent.com/390760/37668911-739d3190-2c5d-11e8-8f42-51ae83f50579.png)

**Jetpack**

![image](https://user-images.githubusercontent.com/390760/37679672-89ca6a2a-2c79-11e8-8526-18551e4cd09f.png)

### After (`mobile` variant)

**WordPress.com**

![image](https://user-images.githubusercontent.com/390760/37668862-5c60ee22-2c5d-11e8-89b8-336ae231bd83.png)

**Jetpack**

![image](https://user-images.githubusercontent.com/390760/37679568-2fdfb7ea-2c79-11e8-8ed7-b6d94e831f37.png)


### How to test

- Login to WP.com and using a smaller device/screen (<660px):
  - For WP.com: head to http://calypso.localhost:3000/start
  - For JP: create a site, head to http://calypso.localhost:3000/jetpack/connect
- Follow along the steps until you:
  - For WP.com: reach step 3 "Pick a plan".
  - For JP: enter the URL of your site and hit “Connect now”.
- Set up the variant in your console and refresh your browser: `localStorage.ABTests = 'localStorage.setItem( 'ABTests', '{"mobilePlansTablesOnSignup_20180320":"mobile"}' )’`.
- You should see the plans tables oriented vertically.