### PR TITLE
domains: show Atomic sites in domains selector

### DIFF
--- a/client/my-sites/current-site/domain-warnings.jsx
+++ b/client/my-sites/current-site/domain-warnings.jsx
@@ -15,6 +15,7 @@ import DomainWarnings from 'my-sites/domains/components/domain-warnings';
 import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
+import { isSiteAutomatedTransfer } from 'state/selectors';
 import QuerySiteDomains from 'components/data/query-site-domains';
 
 const ruleWhiteList = [
@@ -29,8 +30,9 @@ const ruleWhiteList = [
 	'transferStatus',
 ];
 
-const CurrentSiteDomainWarnings = ( { domains, isJetpack, selectedSite } ) => {
-	if ( ! selectedSite || isJetpack ) {
+const CurrentSiteDomainWarnings = ( { domains, isAtomic, isJetpack, selectedSite } ) => {
+	if ( ! selectedSite || ( isJetpack && ! isAtomic ) ) {
+		// Simple and Atomic sites. Not Jetpack sites.
 		return null;
 	}
 
@@ -60,6 +62,7 @@ export default connect( state => {
 	return {
 		domains: getDecoratedSiteDomains( state, selectedSiteId ),
 		isJetpack: isJetpackSite( state, selectedSiteId ),
+		isAtomic: isSiteAutomatedTransfer( state, selectedSiteId ),
 		selectedSite: getSelectedSite( state ),
 	};
 } )( CurrentSiteDomainWarnings );

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -245,15 +245,6 @@ export default {
 	},
 
 	domainManagementTransferToOtherSite( pageContext, next ) {
-		const state = pageContext.store.getState();
-		const siteId = getSelectedSiteId( state );
-		const isAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
-		if ( isAutomatedTransfer ) {
-			const siteSlug = getSelectedSiteSlug( state );
-			page.redirect( `/domains/manage/${ siteSlug }` );
-			return;
-		}
-
 		pageContext.primary = (
 			<TransferData
 				component={ DomainManagement.TransferToOtherSite }

--- a/client/my-sites/domains/domain-management/transfer/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/index.jsx
@@ -47,11 +47,10 @@ function Transfer( props ) {
 							{ translate( 'Transfer to another user' ) }
 						</VerticalNavItem>
 					) }
-				{ ! isAutomatedTransfer && (
-					<VerticalNavItem path={ domainManagementTransferToOtherSite( slug, selectedDomainName ) }>
-						{ translate( 'Transfer to another WordPress.com site' ) }
-					</VerticalNavItem>
-				) }
+
+				<VerticalNavItem path={ domainManagementTransferToOtherSite( slug, selectedDomainName ) }>
+					{ translate( 'Transfer to another WordPress.com site' ) }
+				</VerticalNavItem>
 			</VerticalNav>
 		</Main>
 	);

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -51,9 +51,12 @@ class TransferToOtherSite extends React.Component {
 	}
 
 	isSiteEligible = site => {
+		// check if it's an Atomic site from the site options
+		const isAtomic = get( site, 'options.is_automated_transfer', false );
+
 		return (
 			site.capabilities.manage_options &&
-			! site.jetpack &&
+			! ( site.jetpack && ! isAtomic ) && // Simple and Atomic sites. Not Jetpack sites.
 			! get( site, 'options.is_domain_only', false ) &&
 			! ( this.props.domainsWithPlansOnly && get( site, 'plan.product_slug' ) === PLAN_FREE ) &&
 			site.ID !== this.props.selectedSite.ID

--- a/client/state/selectors/is-primary-domain-by-site-id.js
+++ b/client/state/selectors/is-primary-domain-by-site-id.js
@@ -1,0 +1,21 @@
+/** @format */
+
+import { get } from 'lodash';
+/**
+ * Internal dependencies
+ */
+
+import { getPrimaryDomainBySiteId } from 'state/selectors';
+
+/**
+ * Return if it's the primary domainfrom state object and
+ * the given site ID and domain.
+ *
+ * @param {Object} state - current state object
+ * @param {Object} siteId - site object
+ * @param {string} domain - domian name
+ * @return {Object} primary domain
+ */
+export default function isPrimaryDomainBySiteId( state, siteId, domain ) {
+	return domain === get( getPrimaryDomainBySiteId( state, siteId ), 'domain' );
+}


### PR DESCRIPTION
This commit does not filter Atomic sites from the sites selector in the `Transfer Domain To Another Site` selector, which means that the user will be able to select an Atomic site to transfer the domain.

### How to test

1) Select a site
2) Go to `Domains` section
3) Select a registered Domain
4) Click on `Transfer Domain` option (the last one until now)
5) Click on `Transfer To Another WordPress.com Site` option (the last one until now)
6) Type an Atomic site. it should appear on the sites lists.

![image](https://user-images.githubusercontent.com/77539/37676685-5825d134-2c57-11e8-9899-9bf055318fd4.png)

Confirm that Jetpack sites aren't shown.