### PR TITLE
Store: Update CSS for ImageThumb to properly handle tall or wide product images

### DIFF
--- a/client/extensions/woocommerce/components/image-thumb/index.js
+++ b/client/extensions/woocommerce/components/image-thumb/index.js
@@ -32,7 +32,7 @@ const ImageThumb = ( { width, height, src, alt, placeholder, ...props } ) => {
 
 	return (
 		<div className={ imageClasses } style={ style }>
-			<img src={ src } style={ style } alt={ alt } { ...props } />
+			<img src={ src } alt={ alt } { ...props } />
 		</div>
 	);
 };

--- a/client/extensions/woocommerce/components/image-thumb/style.scss
+++ b/client/extensions/woocommerce/components/image-thumb/style.scss
@@ -5,20 +5,24 @@
 }
 
 .image-thumb {
-	display: inline-block;
+	display: inline-flex;
 	position: relative;
-	
+	justify-content: center;
+	align-items: center;
+
 	&.hasImage {
 		overflow: hidden;
 	}
 
 	img {
 		position: absolute;
-		left: 50%;
-		top: 50%;
-		height: 100%;
-		width: auto;
-		-webkit-transform: translate( -50%, -50% );
-		transform: translate( -50%, -50% );
+		bottom: 0;
+		left: 0;
+		right: 0;
+		top: 0;
+		flex: 1;
+		margin: auto;
+		max-width: 100%;
+		max-height: 100%;
 	}
 }


### PR DESCRIPTION
Fixes #22264

To test:

- add a product with a wide image
- add a product with a tall image
- add a product with a square-ish image
- go to Store > Products and make sure the images maintain their aspect ratio
- go to Store > Products > Product and make sure the images maintain their aspect ratio
- go to Orders > New > Add Product and make sure the images maintain their aspect ratio there too

Useful test images:

<img width="135" alt="3x3" src="https://user-images.githubusercontent.com/1595739/37681566-49681bec-2c44-11e8-9852-797a7d009ceb.png">

<img width="140" alt="3x6" src="https://user-images.githubusercontent.com/1595739/37681567-49832914-2c44-11e8-86bc-5bce61f78557.png">

<img width="273" alt="6x3" src="https://user-images.githubusercontent.com/1595739/37681568-49a2dd04-2c44-11e8-97f9-51ba51929fb7.png">
