### PR TITLE
Store: Fix typo in dimension unit dropdown

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/shipping-units.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-units.js
@@ -55,8 +55,8 @@ const ShippingUnits = ( {
 	const dimensionsLabels = unit => {
 		const labels = {
 			m: translate( 'Meters' ),
-			cm: translate( 'Centimetres' ),
-			mm: translate( 'Milimetres' ),
+			cm: translate( 'Centimeters' ),
+			mm: translate( 'Millimeters' ),
 			in: translate( 'Inches' ),
 			yd: translate( 'Yards' ),
 		};


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/issues/21279#issuecomment-363592460.

There was a typo with `Milimetres` vs `Millimetres` - missing an `l`. 

I also updated the cm and mm strings to use US spellings (`Centimeters` and `Millimeters`). This is consistent with our use of `Meters`.

Both ways are accurate, but unless with use `Metres` instead of `Meters`, we are mixing two different spellings.

To Test:
* Go to `http://calypso.localhost:3000/store/settings/shipping/:site` and verify the dimension dropdown.
* Note that a error does show in the dev console, but it is also present in master. See #23468.