### PR TITLE
Jetpect connect: Redirect secondary jetpack user to wp-admin not no sites found page.

### DIFF
--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -312,7 +312,9 @@ export function authorize( queryObject ) {
 					error: null,
 				} );
 				// Update the user now that we are fully connected.
-				userFactory().fetch();
+				const user = userFactory();
+				user.fetching = false;
+				user.fetch();
 				// Site may not be accessible yet, so force fetch from wpcom
 				return wpcom.site( client_id ).get( {
 					force: 'wpcom',


### PR DESCRIPTION
Fixes #17415

This fixes the issue by making sure that we actually get the latest user info and now display the blank need to create a new site page.

## To test
To test add a new user to your site. Connect the user using the code in this PR. Make sure that the user doesn't have any other sites. Notice that the user gets redirected to he proper place as expected. 

