### PR TITLE
JP Onboarding: Ensure we're fetching JPO credentials when logged-out

### DIFF
--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -142,8 +142,8 @@ class JetpackOnboardingMain extends React.PureComponent {
 				<DocumentHead
 					title={ get( STEP_TITLES, stepName ) + ' ‹ ' + translate( 'Jetpack Start' ) }
 				/>
-				{ /* It is also important to use <QuerySites siteId={ siteSlug } /> here, however wrong that seems.
-				   * The reason is that we rely on an isRequestingSite() check to tell whether we've
+				{ /* It is important to use `<QuerySites siteId={ siteSlug } />` here, however wrong that seems.
+				   * The reason is that we rely on an `isRequestingSite()` check to tell whether we've
 				   * finished fetching site details, which will tell us whether the site is connected,
 				   * which we need in turn to conditionally send JPO auth credentials (see below).
 				   * However, if we're logged out, we cannot `<QuerySites allSites />`,

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -16,6 +16,7 @@ import config from 'config';
 import DocumentHead from 'components/data/document-head';
 import Main from 'components/main';
 import QueryJetpackOnboardingSettings from 'components/data/query-jetpack-onboarding-settings';
+import QuerySites from 'components/data/query-sites';
 import Wizard from 'components/wizard';
 import WordPressLogo from 'components/wordpress-logo';
 import { addQueryArgs, externalRedirect } from 'lib/route';
@@ -141,6 +142,8 @@ class JetpackOnboardingMain extends React.PureComponent {
 				<DocumentHead
 					title={ get( STEP_TITLES, stepName ) + ' ‹ ' + translate( 'Jetpack Start' ) }
 				/>
+				{ /* If we're logged out, we cannot query "all of the user's sites" but have to be specific */ }
+				<QuerySites siteId={ siteId } />
 				{ /* We only allow querying of site settings once we know that we have finished
 				   * querying data for the given site. The `jpoAuth` connected prop depends on whether
 				   * the site is a connected Jetpack site or not, and a network request that uses

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -142,8 +142,16 @@ class JetpackOnboardingMain extends React.PureComponent {
 				<DocumentHead
 					title={ get( STEP_TITLES, stepName ) + ' ‹ ' + translate( 'Jetpack Start' ) }
 				/>
-				{ /* If we're logged out, we cannot query "all of the user's sites" but have to be specific */ }
-				<QuerySites siteId={ siteId } />
+				{ /* It is also important to use <QuerySites siteId={ siteSlug } /> here, however wrong that seems.
+				   * The reason is that we rely on an isRequestingSite() check to tell whether we've
+				   * finished fetching site details, which will tell us whether the site is connected,
+				   * which we need in turn to conditionally send JPO auth credentials (see below).
+				   * However, if we're logged out, we cannot `<QuerySites allSites />`,
+				   * since the concept of "all of a user's sites" doesn't make sense if there is no user.
+				   * We also cannot `<QuerySites siteId={ siteId } />` prior to having obtained the `siteId`
+				   * through JPO -- a Catch-22 situation.
+				   * Fortunately, querying by `siteSlug` works, since it's supported by underlying actions. */ }
+				<QuerySites siteId={ siteSlug } />
 				{ /* We only allow querying of site settings once we know that we have finished
 				   * querying data for the given site. The `jpoAuth` connected prop depends on whether
 				   * the site is a connected Jetpack site or not, and a network request that uses
@@ -191,8 +199,11 @@ export default connect(
 		const settings = getJetpackOnboardingSettings( state, siteId );
 		const isBusiness = get( settings, 'siteType' ) === 'business';
 
+		// We really want `isRequestingSite( state, siteSlug )` (not `siteId`).
+		// For the rationale, see the comment right above the `<QuerySites />` component
+		// further up in this file.
 		const isRequestingWhetherConnected =
-			isRequestingSite( state, siteId ) || isRequestingSites( state );
+			isRequestingSite( state, siteSlug ) || isRequestingSites( state );
 		const isConnected = isJetpackSite( state, siteId );
 		const selectedSiteId = getSelectedSiteId( state );
 		const isSiteSelected = selectedSiteId === siteId;


### PR DESCRIPTION
The reason we were seeing #23435 is that we rely on an `isRequestingSite()` check to tell whether we've finished fetching site details, which will tell us whether the site is connected, which we need in turn to conditionally send JPO auth credentials.
However, if we're logged out, we cannot `<QuerySites allSites />`, since the concept of "all of a user's sites" doesn't make sense if there is no user. We also cannot `<QuerySites siteId={ siteId } />` prior to having obtained the `siteId` through JPO -- a Catch-22 situation.
Fortunately, querying by `siteSlug` (which we have readily available from the route) works, since it's supported by underlying actions.

(The above explanation replicated in a code comment for posterity.)

Fixes #23435.
Fixes #23407.

I believe it's the more "correct" fix than #23437, and should fix issues @rachelmcr found with #23437:

>> Test as logged in and not connected and verify there are no behavioral changes.
>
> I saw the issue reported in #23407 (site title/tagline not prefilled) even while logged in this time. 
>> Test as logged in and connected and verify there are no behavioral changes.
>
> Again, I saw the issue reported in #23407 (site title/tagline not prefilled) even while logged in. 

### Testing instructions (stolen from @tyxla's #23437 😁):
* Log out from WP.com (or open an incognito browser window)
* Start the flow here: http://yourgroovydomain.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development
* Enter a site title.
* Select "Personal" or "Business" for the site type.
* Select "Recent news" or "Static page" for the homepage.
* Select "Add a contact form" to be taken to the Jetpack connection flow. I was logged out, so this brought me to the account signup form.
* Select the browser's back button.
* Verify you're shortly being redirected to the Jetpack site to retrieve credentials, and after that you land in the first step of the flow (site title).
* Test as logged in and not connected and verify there are no behavioral changes.
* Test as logged in and connected and verify there are no behavioral changes.
* Test all cases with a clean Redux state.