### PR TITLE
Store: Stats: Interval Navigation - remove hard coded string

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/store-stats-period-nav/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-period-nav/index.js
@@ -54,7 +54,7 @@ const StoreStatsPeriodNav = ( {
 			</StatsPeriodNavigation>
 			<Intervals
 				selected={ unit }
-				pathTemplate={ `/store/stats/referrers/{{ interval }}/${ slug }` }
+				pathTemplate={ `/store/stats/${ type }/{{ interval }}/${ slug }` }
 				standalone
 			/>
 		</Fragment>


### PR DESCRIPTION
The interval navigation refactor slipped in a hard coded value. When clicking on an interval, the link is incorrectly constructed to use "referrers" instead of the type at hand, eg "products", "categories", "coupons"

![screen shot 2018-03-21 at 12 56 01 pm](https://user-images.githubusercontent.com/1922453/37688972-7af03276-2d07-11e8-83cb-f2ee0285aab3.png)
