### PR TITLE
Store: Stats: combine getQueries logic to the util function

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/index.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/index.js
@@ -254,7 +254,7 @@ class StatsWidget extends Component {
 
 	renderProducts = () => {
 		const { site, translate, unit, topEarnersData, queries, viewStats } = this.props;
-		const { topEarnersQuery } = queries;
+		const { topListQuery } = queries;
 		const values = [
 			{ key: 'name', title: translate( 'Product' ), format: 'text' },
 			{ key: 'total', title: translate( 'Sales' ), format: 'currency' },
@@ -266,7 +266,7 @@ class StatsWidget extends Component {
 				statType="statsTopEarners"
 				unit={ unit }
 				values={ values }
-				query={ topEarnersQuery }
+				query={ topListQuery }
 				fetchedData={ topEarnersData }
 				viewText={ translate( 'View top products' ) }
 				viewLink={ getLink( `/store/stats/products/${ unit }/:site`, site ) }
@@ -283,12 +283,12 @@ class StatsWidget extends Component {
 			return null;
 		}
 
-		const { orderQuery, topEarnersQuery, referrerQuery, visitorQuery } = queries;
+		const { orderQuery, topListQuery, referrerQuery, visitorQuery } = queries;
 		return (
 			<Fragment>
 				<QueryPreferences />
 				<QuerySiteStats statType="statsOrders" siteId={ site.ID } query={ orderQuery } />
-				<QuerySiteStats statType="statsTopEarners" siteId={ site.ID } query={ topEarnersQuery } />
+				<QuerySiteStats statType="statsTopEarners" siteId={ site.ID } query={ topListQuery } />
 				<QuerySiteStats statType="statsStoreReferrers" siteId={ site.ID } query={ referrerQuery } />
 				<QuerySiteStats statType="statsVisits" siteId={ site.ID } query={ visitorQuery } />
 			</Fragment>
@@ -340,9 +340,9 @@ function mapStateToProps( state ) {
 
 	const queries = getQueries( unit, moment().format( 'YYYY-MM-DD' ), {
 		referrerQuery: { quantity: 1 },
-		topEarnersQuery: { limit: dashboardListLimit },
+		topListQuery: { limit: dashboardListLimit },
 	} );
-	const { orderQuery, topEarnersQuery, referrerQuery, visitorQuery } = queries;
+	const { orderQuery, topListQuery, referrerQuery, visitorQuery } = queries;
 
 	const orderData = getSiteStatsNormalizedData( state, site.ID, 'statsOrders', orderQuery );
 	const visitorData = getSiteStatsNormalizedData( state, site.ID, 'statsVisits', visitorQuery );
@@ -350,7 +350,7 @@ function mapStateToProps( state ) {
 		state,
 		site.ID,
 		'statsTopEarners',
-		topEarnersQuery
+		topListQuery
 	);
 	const referrerData = getSiteStatsNormalizedData(
 		state,

--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -13,11 +13,10 @@ import { moment, translate } from 'i18n-calypso';
 import AsyncLoad from 'components/async-load';
 import StatsPagePlaceholder from 'my-sites/stats/stats-page-placeholder';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { getQueryDate, getUnitPeriod } from './utils';
+import { getQueryDate, getQueries } from './utils';
 import analytics from 'lib/analytics';
 import titlecase from 'to-title-case';
 import { recordTrack } from 'woocommerce/lib/analytics';
-import { UNITS } from './constants';
 import config from 'config';
 
 function isValidParameters( context ) {
@@ -99,16 +98,12 @@ export default function StatsController( context, next ) {
 			);
 			break;
 		case 'referrers':
-			const referrersQuery = {
-				unit: props.unit,
-				date: getUnitPeriod( props.queryDate, props.unit ),
-				quantity: UNITS[ props.unit ].quantity,
-			};
+			const { referrerQuery } = getQueries( props.unit, props.queryDate );
 			asyncComponent = (
 				<AsyncLoad
 					placeholder={ placeholder }
 					require="extensions/woocommerce/app/store-stats/referrers"
-					query={ referrersQuery }
+					query={ referrerQuery }
 					{ ...props }
 				/>
 			);

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -29,9 +29,8 @@ import {
 	topProducts,
 	topCategories,
 	topCoupons,
-	UNITS,
 } from 'woocommerce/app/store-stats/constants';
-import { getUnitPeriod, getEndPeriod } from './utils';
+import { getUnitPeriod, getEndPeriod, getQueries } from './utils';
 import QuerySiteStats from 'components/data/query-site-stats';
 import config from 'config';
 import StoreStatsReferrerWidget from './store-stats-referrer-widget';
@@ -48,26 +47,19 @@ class StoreStats extends Component {
 
 	render() {
 		const { path, queryDate, selectedDate, siteId, slug, unit, querystring } = this.props;
-		const unitQueryDate = getUnitPeriod( queryDate, unit );
 		const unitSelectedDate = getUnitPeriod( selectedDate, unit );
 		const endSelectedDate = getEndPeriod( selectedDate, unit );
-		const query = {
-			unit,
-			date: unitQueryDate,
-			quantity: UNITS[ unit ].quantity,
-		};
-		const topQuery = {
-			unit,
-			date: unitSelectedDate,
-			limit: 10,
-		};
+		const { orderQuery, referrerQuery } = getQueries( unit, queryDate );
+		const { topListQuery } = getQueries( unit, selectedDate );
 		const topWidgets = [ topProducts, topCategories, topCoupons ];
 		const slugAndQuery = `/${ slug }${ querystring ? '?' + querystring : '' }`;
 		const widgetPath = `/${ unit }${ slugAndQuery }`;
 
 		return (
 			<Main className="store-stats woocommerce" wideLayout={ true }>
-				{ siteId && <QuerySiteStats statType="statsOrders" siteId={ siteId } query={ query } /> }
+				{ siteId && (
+					<QuerySiteStats statType="statsOrders" siteId={ siteId } query={ orderQuery } />
+				) }
 				<div className="store-stats__sidebar-nav">
 					<SidebarNavigation />
 				</div>
@@ -79,7 +71,7 @@ class StoreStats extends Component {
 				/>
 				<Chart
 					path={ path }
-					query={ query }
+					query={ orderQuery }
 					selectedDate={ endSelectedDate }
 					siteId={ siteId }
 					unit={ unit }
@@ -99,7 +91,7 @@ class StoreStats extends Component {
 										.format( 'YYYY-MM-DD' )
 								: selectedDate
 						}
-						query={ query }
+						query={ orderQuery }
 						statsType="statsOrders"
 						showQueryDate
 					/>
@@ -107,12 +99,16 @@ class StoreStats extends Component {
 				{ config.isEnabled( 'woocommerce/extension-referrers' ) && (
 					<div>
 						{ siteId && (
-							<QuerySiteStats statType="statsStoreReferrers" siteId={ siteId } query={ query } />
+							<QuerySiteStats
+								statType="statsStoreReferrers"
+								siteId={ siteId }
+								query={ referrerQuery }
+							/>
 						) }
 						<Module
 							siteId={ siteId }
 							emptyMessage={ translate( 'No data found' ) }
-							query={ query }
+							query={ referrerQuery }
 							statType="statsStoreReferrers"
 							header={
 								<SectionHeader
@@ -123,7 +119,7 @@ class StoreStats extends Component {
 						>
 							<StoreStatsReferrerWidget
 								siteId={ siteId }
-								query={ query }
+								query={ referrerQuery }
 								statType="statsStoreReferrers"
 								selectedDate={ unitSelectedDate }
 								slugAndQuery={ slugAndQuery }
@@ -137,12 +133,12 @@ class StoreStats extends Component {
 							<Module
 								siteId={ siteId }
 								emptyMessage={ translate( 'No data found' ) }
-								query={ query }
+								query={ orderQuery }
 								statType="statsOrders"
 							>
 								<WidgetList
 									siteId={ siteId }
-									query={ query }
+									query={ orderQuery }
 									selectedDate={ endSelectedDate }
 									statType="statsOrders"
 									widgets={ widget }
@@ -160,20 +156,20 @@ class StoreStats extends Component {
 									<QuerySiteStats
 										statType={ widget.statType }
 										siteId={ siteId }
-										query={ topQuery }
+										query={ topListQuery }
 									/>
 								) }
 								<Module
 									siteId={ siteId }
 									header={ header }
 									emptyMessage={ widget.empty }
-									query={ topQuery }
+									query={ topListQuery }
 									statType={ widget.statType }
 								>
 									<List
 										siteId={ siteId }
 										values={ widget.values }
-										query={ topQuery }
+										query={ topListQuery }
 										statType={ widget.statType }
 									/>
 								</Module>

--- a/client/extensions/woocommerce/app/store-stats/listview.js
+++ b/client/extensions/woocommerce/app/store-stats/listview.js
@@ -12,7 +12,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { getUnitPeriod } from './utils';
+import { getQueries } from './utils';
 import JetpackColophon from 'components/jetpack-colophon';
 import List from './store-stats-list';
 import Main from 'components/main';
@@ -40,37 +40,32 @@ class StoreStatsListView extends Component {
 
 	render() {
 		const { siteId, slug, selectedDate, type, unit } = this.props;
-		const unitSelectedDate = getUnitPeriod( selectedDate, unit );
-		const listviewQuery = {
-			unit,
-			date: unitSelectedDate,
-			limit: 100,
-		};
+		const { topListQuery } = getQueries( unit, selectedDate, { topListQuery: { limit: 100 } } );
 		const statType = listType[ type ].statType;
 		return (
 			<Main className="store-stats__list-view woocommerce" wideLayout>
 				{ siteId && (
-					<QuerySiteStats statType={ statType } siteId={ siteId } query={ listviewQuery } />
+					<QuerySiteStats statType={ statType } siteId={ siteId } query={ topListQuery } />
 				) }
 				<StoreStatsPeriodNav
 					type={ type }
 					selectedDate={ selectedDate }
 					unit={ unit }
 					slug={ slug }
-					query={ listviewQuery }
+					query={ topListQuery }
 					statType={ statType }
 					title={ listType[ type ].title }
 				/>
 				<Module
 					siteId={ siteId }
 					emptyMessage={ listType[ type ].empty }
-					query={ listviewQuery }
+					query={ topListQuery }
 					statType={ statType }
 				>
 					<List
 						siteId={ siteId }
 						values={ listType[ type ].values }
-						query={ listviewQuery }
+						query={ topListQuery }
 						statType={ statType }
 					/>
 				</Module>

--- a/client/extensions/woocommerce/app/store-stats/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/utils.js
@@ -258,11 +258,11 @@ export function getQueries( unit, baseDate, overrides = {} ) {
 		...( overrides.referrerQuery || {} ),
 	};
 
-	const topEarnersQuery = {
+	const topListQuery = {
 		...baseQuery,
 		date: getUnitPeriod( baseDate, unit ),
 		limit: 10,
-		...( overrides.topEarnersQuery || {} ),
+		...( overrides.topListQuery || {} ),
 	};
 
 	const visitorQuery = {
@@ -275,7 +275,7 @@ export function getQueries( unit, baseDate, overrides = {} ) {
 	return {
 		orderQuery,
 		referrerQuery,
-		topEarnersQuery,
+		topListQuery,
 		visitorQuery,
 	};
 }


### PR DESCRIPTION
In a [previous PR](https://github.com/Automattic/wp-calypso/pull/23423) @justinshreve extracted `getQueries` to a util function. This PR removes construction of queries in favour of simply using the util.

I changed `topEarnersQuery`  → `topListQuery` because the top lists are all the same and I can use the name for things like `topProducts.

### Testing
Click around and make sure nothing is broken in various sections of Store Stats and the Store Dashboard widgets
