### PR TITLE
Happychat: start chat with any selected site if is paid customer

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -51,7 +51,7 @@ import {
 	askQuestion as askDirectlyQuestion,
 	initialize as initializeDirectly,
 } from 'state/help/directly/actions';
-import { getSitePlan, isCurrentPlanPaid, isRequestingSites } from 'state/sites/selectors';
+import { getSitePlan, isRequestingSites } from 'state/sites/selectors';
 import {
 	hasUserAskedADirectlyQuestion,
 	isDirectlyFailed,
@@ -268,11 +268,7 @@ class HelpContact extends React.Component {
 		}
 
 		// if the happychat connection is able to accept chats, use it
-		return (
-			this.props.isHappychatAvailable &&
-			this.props.isHappychatUserEligible &&
-			this.props.isSelectedHelpSiteOnPaidPlan
-		);
+		return this.props.isHappychatAvailable && this.props.isHappychatUserEligible;
 	};
 
 	shouldUseDirectly = () => {
@@ -620,7 +616,6 @@ export default connect(
 			hasMoreThanOneSite: getCurrentUserSiteCount( state ) > 1,
 			shouldStartHappychatConnection: ! isRequestingSites( state ) && helpSelectedSiteId,
 			isRequestingSites: isRequestingSites( state ),
-			isSelectedHelpSiteOnPaidPlan: isCurrentPlanPaid( state, helpSelectedSiteId ),
 			selectedSitePlanSlug: selectedSitePlan && selectedSitePlan.product_slug,
 		};
 	},


### PR DESCRIPTION
Currently, you have to select a site with paid plan before being able to start a Happychat chat. In this PR, we drop that requirement and allow to start chat for any paid customers.

## Testing

Navigate to `/help/contact` and select a free site. You should be able to start a chat. The same goes for a paid site.

Props @mattwondra for finding out what needs to be done to accomplish this.