### PR TITLE
Store: Stats: Referrer widget: add links for each referrer

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -46,12 +46,12 @@ export default function StatsController( context, next ) {
 	);
 
 	const props = {
-		querystring: context.querystring,
 		type: context.params.type,
 		unit: context.params.unit,
 		path: context.pathname,
 		queryDate: getQueryDate( context ),
 		selectedDate: context.query.startDate || moment().format( 'YYYY-MM-DD' ),
+		queryParams: context.query,
 	};
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( translate( 'Stats', { textOnly: true } ) ) );

--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -51,7 +51,7 @@ export default function StatsController( context, next ) {
 		path: context.pathname,
 		queryDate: getQueryDate( context ),
 		selectedDate: context.query.startDate || moment().format( 'YYYY-MM-DD' ),
-		queryParams: context.query,
+		queryParams: context.query || {},
 	};
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( translate( 'Stats', { textOnly: true } ) ) );
@@ -104,7 +104,6 @@ export default function StatsController( context, next ) {
 					placeholder={ placeholder }
 					require="extensions/woocommerce/app/store-stats/referrers"
 					query={ referrerQuery }
-					referrer={ context.query.referrer }
 					{ ...props }
 				/>
 			);

--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -104,6 +104,7 @@ export default function StatsController( context, next ) {
 					placeholder={ placeholder }
 					require="extensions/woocommerce/app/store-stats/referrers"
 					query={ referrerQuery }
+					referrer={ context.query.referrer }
 					{ ...props }
 				/>
 			);

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -30,7 +30,7 @@ import {
 	topCategories,
 	topCoupons,
 } from 'woocommerce/app/store-stats/constants';
-import { getUnitPeriod, getEndPeriod, getQueries } from './utils';
+import { getUnitPeriod, getEndPeriod, getQueries, getWidgetPath } from './utils';
 import QuerySiteStats from 'components/data/query-site-stats';
 import config from 'config';
 import StoreStatsReferrerWidget from './store-stats-referrer-widget';
@@ -39,21 +39,20 @@ class StoreStats extends Component {
 	static propTypes = {
 		path: PropTypes.string.isRequired,
 		queryDate: PropTypes.string,
-		querystring: PropTypes.string,
+		queryParams: PropTypes.object.isRequired,
 		selectedDate: PropTypes.string,
 		siteId: PropTypes.number,
 		unit: PropTypes.string.isRequired,
 	};
 
 	render() {
-		const { path, queryDate, selectedDate, siteId, slug, unit, querystring } = this.props;
+		const { path, queryDate, selectedDate, siteId, slug, unit, queryParams } = this.props;
 		const unitSelectedDate = getUnitPeriod( selectedDate, unit );
 		const endSelectedDate = getEndPeriod( selectedDate, unit );
 		const { orderQuery, referrerQuery } = getQueries( unit, queryDate );
 		const { topListQuery } = getQueries( unit, selectedDate );
 		const topWidgets = [ topProducts, topCategories, topCoupons ];
-		const slugAndQuery = `/${ slug }${ querystring ? '?' + querystring : '' }`;
-		const widgetPath = `/${ unit }${ slugAndQuery }`;
+		const widgetPath = getWidgetPath( unit, slug, queryParams );
 
 		return (
 			<Main className="store-stats woocommerce" wideLayout={ true }>
@@ -119,13 +118,12 @@ class StoreStats extends Component {
 						>
 							<StoreStatsReferrerWidget
 								unit={ unit }
-								querystring={ querystring }
+								queryParams={ queryParams }
 								slug={ slug }
 								siteId={ siteId }
 								query={ referrerQuery }
 								statType="statsStoreReferrers"
 								selectedDate={ unitSelectedDate }
-								slugAndQuery={ slugAndQuery }
 							/>
 						</Module>
 					</div>

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -118,6 +118,9 @@ class StoreStats extends Component {
 							}
 						>
 							<StoreStatsReferrerWidget
+								unit={ unit }
+								querystring={ querystring }
+								slug={ slug }
 								siteId={ siteId }
 								query={ referrerQuery }
 								statType="statsStoreReferrers"

--- a/client/extensions/woocommerce/app/store-stats/listview.js
+++ b/client/extensions/woocommerce/app/store-stats/listview.js
@@ -32,7 +32,6 @@ class StoreStatsListView extends Component {
 		path: PropTypes.string.isRequired,
 		selectedDate: PropTypes.string,
 		siteId: PropTypes.number,
-		querystring: PropTypes.string,
 		type: PropTypes.string.isRequired,
 		unit: PropTypes.string.isRequired,
 		slug: PropTypes.string.isRequired,

--- a/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget/index.js
@@ -30,6 +30,9 @@ class StoreStatsReferrerWidget extends Component {
 		siteId: PropTypes.number,
 		statType: PropTypes.string.isRequired,
 		selectedDate: PropTypes.string.isRequired,
+		unit: PropTypes.string.isRequired,
+		querystring: PropTypes.string,
+		slug: PropTypes.string,
 	};
 
 	isPreCollection( selectedData ) {
@@ -66,7 +69,8 @@ class StoreStatsReferrerWidget extends Component {
 	}
 
 	render() {
-		const { data, selectedDate, translate } = this.props;
+		const { data, selectedDate, translate, unit, slug, querystring } = this.props;
+		const basePath = `/store/stats/referrers/${ unit }/${ slug }`;
 		const selectedData = find( data, d => d.date === selectedDate ) || { data: [] };
 		if ( selectedData.data.length === 0 ) {
 			const messages = this.getEmptyDataMessage( selectedData );
@@ -89,9 +93,14 @@ class StoreStatsReferrerWidget extends Component {
 		return (
 			<Table className="store-stats-referrer-widget" header={ header } compact>
 				{ sortedAndTrimmedData.map( d => {
+					const refQuery = `referrer=${ d.referrer }`;
+					const fullQuery = querystring ? `?${ querystring }&${ refQuery }` : `?${ refQuery }`;
+					const href = `${ basePath }${ fullQuery }`;
 					return (
 						<TableRow key={ d.referrer }>
-							<TableItem isTitle>{ d.referrer }</TableItem>
+							<TableItem isTitle>
+								<a href={ href }>{ d.referrer }</a>
+							</TableItem>
 							<TableItem>
 								<HorizontalBar
 									extent={ extent }

--- a/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget/index.js
@@ -22,6 +22,7 @@ import HorizontalBar from 'woocommerce/components/d3/horizontal-bar';
 import Card from 'components/card';
 import ErrorPanel from 'my-sites/stats/stats-error';
 import { sortBySales } from 'woocommerce/app/store-stats/referrers/helpers';
+import { getWidgetPath } from 'woocommerce/app/store-stats/utils';
 
 class StoreStatsReferrerWidget extends Component {
 	static propTypes = {
@@ -31,7 +32,7 @@ class StoreStatsReferrerWidget extends Component {
 		statType: PropTypes.string.isRequired,
 		selectedDate: PropTypes.string.isRequired,
 		unit: PropTypes.string.isRequired,
-		querystring: PropTypes.string,
+		queryParams: PropTypes.object.isRequired,
 		slug: PropTypes.string,
 	};
 
@@ -69,8 +70,8 @@ class StoreStatsReferrerWidget extends Component {
 	}
 
 	render() {
-		const { data, selectedDate, translate, unit, slug, querystring } = this.props;
-		const basePath = `/store/stats/referrers/${ unit }/${ slug }`;
+		const { data, selectedDate, translate, unit, slug, queryParams } = this.props;
+		const basePath = '/store/stats/referrers';
 		const selectedData = find( data, d => d.date === selectedDate ) || { data: [] };
 		if ( selectedData.data.length === 0 ) {
 			const messages = this.getEmptyDataMessage( selectedData );
@@ -93,9 +94,12 @@ class StoreStatsReferrerWidget extends Component {
 		return (
 			<Table className="store-stats-referrer-widget" header={ header } compact>
 				{ sortedAndTrimmedData.map( d => {
-					const refQuery = `referrer=${ d.referrer }`;
-					const fullQuery = querystring ? `?${ querystring }&${ refQuery }` : `?${ refQuery }`;
-					const href = `${ basePath }${ fullQuery }`;
+					const widgetPath = getWidgetPath(
+						unit,
+						slug,
+						Object.assign( {}, { referrer: d.referrer }, queryParams )
+					);
+					const href = `${ basePath }${ widgetPath }`;
 					return (
 						<TableRow key={ d.referrer }>
 							<TableItem isTitle>

--- a/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget/index.js
@@ -50,9 +50,9 @@ class StoreStatsReferrerWidget extends Component {
 	}
 
 	getEmptyDataMessage( selectedData ) {
-		const { slugAndQuery, translate } = this.props;
+		const { translate, slug, queryParams } = this.props;
 		if ( ! this.hasNosaraJobRun( selectedData ) ) {
-			const href = `/store/stats/orders/week${ slugAndQuery }`;
+			const href = `/store/stats/orders${ getWidgetPath( 'week', slug, queryParams ) }`;
 			const primary = translate( 'Data is being processed – check back soon' );
 			const secondary = translate(
 				'Expand to a {{a}}wider{{/a}} view to see your latest referrers',

--- a/client/extensions/woocommerce/app/store-stats/test/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/test/utils.js
@@ -21,6 +21,7 @@ import {
 	getStartPeriod,
 	getQueryDate,
 	getUnitPeriod,
+	getWidgetPath,
 } from '../utils';
 
 describe( 'calculateDelta', () => {
@@ -455,5 +456,27 @@ describe( 'getConversionRateData', () => {
 				conversionRate: 0,
 			},
 		] );
+	} );
+} );
+
+describe( 'getWidgetPath', () => {
+	test( 'should return a string', () => {
+		const widgetPath = getWidgetPath( 'unit', 'slug', {} );
+		assert.isString( widgetPath );
+	} );
+
+	test( 'should return a correct string', () => {
+		const widgetPath = getWidgetPath( 'unit', 'slug', {} );
+		assert.strictEqual( '/unit/slug', widgetPath );
+	} );
+
+	test( 'should return a correct string with one query param', () => {
+		const widgetPath = getWidgetPath( 'unit', 'slug', { param1: 1 } );
+		assert.strictEqual( '/unit/slug?param1=1', widgetPath );
+	} );
+
+	test( 'should return a correct string with two query params', () => {
+		const widgetPath = getWidgetPath( 'unit', 'slug', { param1: 1, param2: 2 } );
+		assert.strictEqual( '/unit/slug?param1=1&param2=2', widgetPath );
 	} );
 } );

--- a/client/extensions/woocommerce/app/store-stats/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/utils.js
@@ -279,3 +279,24 @@ export function getQueries( unit, baseDate, overrides = {} ) {
 		visitorQuery,
 	};
 }
+
+/**
+ * Create the common Store Stats url ending used for links to widgets and lists. Url query parameters
+ * persist from view to view (ie, startDate) and should be reflected in the url.
+ * Url's have this basic shape:
+ *
+ * /store/stats/<page>/<unit>/<slug>?param1=1&param2=2
+ *
+ * this util is for constructing the /<unit>/<slug>?param1=1&param2=2
+ *
+ * @param {string} unit - day, week, month, or year
+ * @param {string} slug - site slug
+ * @param {Object} urlQuery - url query params represented as an object
+ * @return {string} - widget path url portion
+ */
+export function getWidgetPath( unit, slug, urlQuery ) {
+	const query = Object.keys( urlQuery ).reduce( ( querystring, param, index ) => {
+		return `${ querystring }${ index === 0 ? '?' : '&' }${ param }=${ urlQuery[ param ] }`;
+	}, '' );
+	return `/${ unit }/${ slug }${ query }`;
+}


### PR DESCRIPTION
Each referrer in the widget is a quick link to the All Referrers page with that particular referrer selected. The value is persisted as a url query parameter

![screen shot 2018-03-21 at 2 42 29 pm](https://user-images.githubusercontent.com/1922453/37691353-28538d6a-2d16-11e8-873d-2bf60536700f.png)

### Test
Hover over links in the Referrer Widget:
* Make sure the referrer shows up in the query parameters
* Make sure the url is correct and query is constructed correctly