### PR TITLE
Reader: rename streamId to streamKey

### DIFF
--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -30,11 +30,11 @@ import { errorNotice } from 'state/notices/actions';
  * `site:1234`
  * `search:a:value` ( prefix is `search`, suffix is `a:value` )
  *
- * @param  {String} streamId The stream ID to break apart
+ * @param  {String} streamKey The stream ID to break apart
  * @return {String}          The stream ID suffix
  */
-function streamIdSuffix( streamId ) {
-	return streamId.substring( streamId.indexOf( ':' ) + 1 );
+function streamKeySuffix( streamKey ) {
+	return streamKey.substring( streamKey.indexOf( ':' ) + 1 );
 }
 
 function getSeedForQuery() {
@@ -50,21 +50,21 @@ const streamApis = {
 	},
 	search: {
 		path: () => '/read/search',
-		query: ( { query, streamId } ) => {
-			return { ...query, q: streamIdSuffix( streamId ) };
+		query: ( { query, streamKey } ) => {
+			return { ...query, q: streamKeySuffix( streamKey ) };
 		},
 	},
 	feed: {
-		path: ( { streamId } ) => `/read/feed/${ streamIdSuffix( streamId ) }/posts`,
+		path: ( { streamKey } ) => `/read/feed/${ streamKeySuffix( streamKey ) }/posts`,
 	},
 	site: {
-		path: ( { streamId } ) => `/read/sites/${ streamIdSuffix( streamId ) }/posts`,
+		path: ( { streamKey } ) => `/read/sites/${ streamKeySuffix( streamKey ) }/posts`,
 	},
 	conversations: {
 		path: () => '/read/conversations',
 	},
 	featured: {
-		path: ( { streamId } ) => `/read/sites/${ streamIdSuffix( streamId ) }/featured`,
+		path: ( { streamKey } ) => `/read/sites/${ streamKeySuffix( streamKey ) }/featured`,
 	},
 	a8c: {
 		match: /^a8c$/,
@@ -111,11 +111,11 @@ const streamApis = {
  * @returns {object} http action for data-layer to dispatch
  */
 export function requestPage( action ) {
-	const { payload: { streamId, streamType } } = action;
+	const { payload: { streamKey, streamType } } = action;
 	const api = streamApis[ streamType ];
 
 	if ( ! api ) {
-		warn( `Unable to determine api path for ${ streamId }` );
+		warn( `Unable to determine api path for ${ streamKey }` );
 		return;
 	}
 
@@ -142,8 +142,8 @@ export function fromApi( data ) {
 }
 
 export function handlePage( action, posts ) {
-	const { streamId, query } = action.payload;
-	return receivePage( { streamId, query, posts } );
+	const { streamKey, query } = action.payload;
+	return receivePage( { streamKey, query, posts } );
 }
 
 export function handleError() {

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -13,7 +13,7 @@ import { requestPage as requestPageAction, receivePage } from 'state/reader/stre
 import { errorNotice } from 'state/notices/actions';
 
 describe( 'streams', () => {
-	const action = deepfreeze( requestPageAction( { streamId: 'following', page: 2 } ) );
+	const action = deepfreeze( requestPageAction( { streamKey: 'following', page: 2 } ) );
 
 	describe( 'requestPage', () => {
 		it( 'should return an http request', () => {
@@ -154,7 +154,7 @@ describe( 'streams', () => {
 				},
 			].forEach( testCase => {
 				it( testCase.stream + ' should pass the expected params', () => {
-					const pageAction = requestPageAction( { streamId: testCase.stream } );
+					const pageAction = requestPageAction( { streamKey: testCase.stream } );
 					const expected = {
 						onSuccess: pageAction,
 						onFailure: pageAction,
@@ -170,9 +170,9 @@ describe( 'streams', () => {
 		const data = deepfreeze( { posts: [] } );
 
 		it( 'should return a receivePage action', () => {
-			const { streamId, query } = action.payload;
+			const { streamKey, query } = action.payload;
 			expect( handlePage( action, fromApi( data ) ) ).toEqual(
-				receivePage( { streamId, query, posts: data.posts } )
+				receivePage( { streamKey, query, posts: data.posts } )
 			);
 		} );
 	} );

--- a/client/state/reader/streams/actions.js
+++ b/client/state/reader/streams/actions.js
@@ -18,68 +18,68 @@ import {
  * This action will fetch a range of posts for a stream and then dispatch
  * READER_STREAM_PAGE_RECEIVE when the page returns. This is usually used to
  * fetch the next page of results, but could be used to fetch arbitrary ranges.
- * @param  {string} streamId The stream to fetch posts for
+ * @param  {string} streamKey The stream to fetch posts for
  * @param  {object} query    The query for posts. Parameters vary by stream type.
  * @return {object}          The action object
  */
-export function requestPage( { streamId, query } ) {
-	const indexOfColon = streamId.indexOf( ':' );
-	const streamType = indexOfColon === -1 ? streamId : streamId.substring( 0, indexOfColon );
+export function requestPage( { streamKey, query } ) {
+	const indexOfColon = streamKey.indexOf( ':' );
+	const streamType = indexOfColon === -1 ? streamKey : streamKey.substring( 0, indexOfColon );
 	return {
 		type: READER_STREAMS_PAGE_REQUEST,
 		payload: {
-			streamId,
+			streamKey,
 			query,
 			streamType,
 		},
 	};
 }
 
-export function receivePage( { streamId, query, posts } ) {
+export function receivePage( { streamKey, query, posts } ) {
 	return {
 		type: READER_STREAMS_PAGE_RECEIVE,
 		payload: {
-			streamId,
+			streamKey,
 			query,
 			posts,
 		},
 	};
 }
 
-export function showUpdates( { streamId } ) {
+export function showUpdates( { streamKey } ) {
 	return {
 		type: READER_STREAMS_SHOW_UPDATES,
 		payload: {
-			streamId,
+			streamKey,
 		},
 	};
 }
 
-export function selectItem( { streamId, index } ) {
+export function selectItem( { streamKey, index } ) {
 	return {
 		type: READER_STREAMS_SELECT_ITEM,
 		payload: {
-			streamId,
+			streamKey,
 			index,
 		},
 	};
 }
 
-export function fillGap( { streamId, gap } ) {
+export function fillGap( { streamKey, gap } ) {
 	return {
 		type: READER_STREAMS_FILL_GAP,
 		payload: {
-			streamId,
+			streamKey,
 			gap,
 		},
 	};
 }
 
-export function dismissPost( { streamId, postId } ) {
+export function dismissPost( { streamKey, postId } ) {
 	return {
 		type: READER_STREAMS_DISMISS_POST,
 		payload: {
-			streamId,
+			streamKey,
 			postId,
 		},
 	};

--- a/client/state/reader/streams/reducer.js
+++ b/client/state/reader/streams/reducer.js
@@ -7,7 +7,7 @@ import { keyedReducer, combineReducers } from 'state/utils';
 import { itemsSchema } from './schema';
 import { READER_STREAMS_PAGE_RECEIVE, READER_STREAMS_SELECT_ITEM } from 'state/action-types';
 
-export const items = keyedReducer( 'payload.streamId', ( state = [], action ) => {
+export const items = keyedReducer( 'payload.streamKey', ( state = [], action ) => {
 	switch ( action.type ) {
 		case READER_STREAMS_PAGE_RECEIVE:
 			const { posts } = action.payload;
@@ -30,7 +30,7 @@ export const items = keyedReducer( 'payload.streamId', ( state = [], action ) =>
 
 items.schema = itemsSchema;
 
-export const selected = keyedReducer( 'payload.streamId', ( state = [], action ) => {
+export const selected = keyedReducer( 'payload.streamKey', ( state = [], action ) => {
 	switch ( action.type ) {
 		case READER_STREAMS_SELECT_ITEM:
 			return action.payload.index;

--- a/client/state/reader/streams/test/reducer.js
+++ b/client/state/reader/streams/test/reducer.js
@@ -21,7 +21,7 @@ describe( 'streams.items reducer', () => {
 	it( 'should put a stream under the right key', () => {
 		const startState = deepfreeze( {} );
 		const action = receivePage( {
-			streamId: 'following',
+			streamKey: 'following',
 			query: {},
 			posts: [ { global_ID: 1234 } ],
 		} );
@@ -35,7 +35,7 @@ describe( 'streams.items reducer', () => {
 			following: [ { global_ID: 42 } ],
 		} );
 		const action = receivePage( {
-			streamId: 'following',
+			streamKey: 'following',
 			query: {},
 			posts: [ { global_ID: 1234 } ],
 		} );
@@ -51,14 +51,14 @@ describe( 'streams.selected reducer', () => {
 	} );
 
 	it( 'should store the index requested for nonexistent stream', () => {
-		expect( selected( undefined, selectItem( { streamId: 'following', index: 7 } ) ) ).toEqual( {
+		expect( selected( undefined, selectItem( { streamKey: 'following', index: 7 } ) ) ).toEqual( {
 			following: 7,
 		} );
 	} );
 
 	it( 'should update the index for a stream', () => {
 		const prevState = { following: 10 };
-		const action = selectItem( { streamId: 'following', index: 7 } );
+		const action = selectItem( { streamKey: 'following', index: 7 } );
 		expect( selected( prevState, action ) ).toEqual( {
 			following: 7,
 		} );

--- a/client/state/reader/watermarks/actions.js
+++ b/client/state/reader/watermarks/actions.js
@@ -11,13 +11,13 @@ import { READER_VIEW_STREAM } from 'state/action-types';
  * i.e. unexpanding all photos/videos when opening a stream.
  *
  * @param {Date} mark  - date last viewed
- * @param {String} streamId - stream being viewed
+ * @param {String} streamKey - stream being viewed
  * @returns {Object} action object for dispatch
  */
-export const viewStream = ( { mark, streamId } ) => {
+export const viewStream = ( { mark, streamKey } ) => {
 	return {
 		type: READER_VIEW_STREAM,
 		mark,
-		streamId,
+		streamKey,
 	};
 };

--- a/client/state/reader/watermarks/reducer.js
+++ b/client/state/reader/watermarks/reducer.js
@@ -13,7 +13,7 @@ import { createReducer, keyedReducer } from 'state/utils';
 import schema from './watermark-schema';
 
 export const watermarks = keyedReducer(
-	'streamId',
+	'streamKey',
 	createReducer(
 		{},
 		{

--- a/client/state/reader/watermarks/test/reducer.js
+++ b/client/state/reader/watermarks/test/reducer.js
@@ -9,7 +9,7 @@ import { DESERIALIZE, SERIALIZE } from 'state/action-types';
 
 jest.mock( 'lib/warn', () => () => {} );
 
-const streamId = 'special-chicken-stream';
+const streamKey = 'special-chicken-stream';
 const mark = Date.now();
 
 describe( '#watermarks', () => {
@@ -18,42 +18,42 @@ describe( '#watermarks', () => {
 	} );
 
 	test( 'can add a new stream to empty state', () => {
-		const action = viewStream( { streamId, mark } );
+		const action = viewStream( { streamKey, mark } );
 		expect( watermarks( {}, action ) ).toEqual( {
-			[ streamId ]: mark,
+			[ streamKey ]: mark,
 		} );
 	} );
 
 	test( 'can update an existing stream', () => {
-		const prevState = { [ streamId ]: mark };
+		const prevState = { [ streamKey ]: mark };
 		const newMark = mark + 2;
-		const action = viewStream( { streamId, mark: newMark } );
+		const action = viewStream( { streamKey, mark: newMark } );
 		expect( watermarks( prevState, action ) ).toEqual( {
-			[ streamId ]: newMark,
+			[ streamKey ]: newMark,
 		} );
 	} );
 
 	test( 'will reject an attempt to update to an older mark', () => {
-		const prevState = { [ streamId ]: mark };
+		const prevState = { [ streamKey ]: mark };
 		const newMark = mark - 2;
-		const action = viewStream( { streamId, mark: newMark } );
+		const action = viewStream( { streamKey, mark: newMark } );
 		expect( watermarks( prevState, action ) ).toEqual( {
-			[ streamId ]: mark,
+			[ streamKey ]: mark,
 		} );
 	} );
 
 	test( 'will skip deserializing invalid marks', () => {
-		const invalidState = { [ streamId ]: 'invalid' };
+		const invalidState = { [ streamKey ]: 'invalid' };
 		expect( watermarks( invalidState, { type: DESERIALIZE } ) ).toEqual( {} );
 	} );
 
 	test( 'will deserialize valid mark', () => {
-		const validState = { [ streamId ]: 42 };
+		const validState = { [ streamKey ]: 42 };
 		expect( watermarks( validState, { type: DESERIALIZE } ) ).toEqual( validState );
 	} );
 
 	test( 'will serialize', () => {
-		const validState = { [ streamId ]: 42 };
+		const validState = { [ streamKey ]: 42 };
 		expect( watermarks( validState, { type: SERIALIZE } ) ).toEqual( validState );
 	} );
 } );

--- a/client/state/selectors/get-reader-watermark.js
+++ b/client/state/selectors/get-reader-watermark.js
@@ -4,9 +4,9 @@
  * Get the high watermark for a Reader stream
  *
  * @param {Object} state -
- * @param {String} streamId -
+ * @param {String} streamKey -
  * @returns {Number} date in number form
  */
-const getReaderWatermark = ( state, streamId ) => state.reader.watermarks[ streamId ];
+const getReaderWatermark = ( state, streamKey ) => state.reader.watermarks[ streamKey ];
 
 export default getReaderWatermark;


### PR DESCRIPTION
**summary**
This PR is part of the saga to reduxify streams. One of the things I am trying to do is consolidate identifiers.  This PR has been split from https://github.com/Automattic/wp-calypso/pull/22814 and just encompasses renaming all the `streamId` identifiers to `streamKey`

**to test**
- unit tests should pass
- go to the live branch and smoke test Reader
- `git grep streamId` and ensure there are no more occurrences in the codebase