### PR TITLE
Community Translator: Bumping version of CT to bust cache

### DIFF
--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -24,7 +24,7 @@ const debug = debugModule( 'calypso:community-translator' );
 
 const user = new User(),
 	communityTranslatorBaseUrl = 'https://widgets.wp.com/community-translator/',
-	communityTranslatorVersion = '1.160728',
+	communityTranslatorVersion = '1.160729',
 	// lookup for the translation set slug on GP
 	translateSetSlugs = {
 		de_formal: 'formal',


### PR DESCRIPTION
After successfully deploying #23397 we now need to bump the version number so that Calypso loads the new file: https://widgets.wp.com/community-translator/community-translator.min.js?v=1.160729

## Testing
1. Go to http://calypso.localhost:3000/me/account, switch your language to Deutsch (Sie) and enable the Community Translator

### Expectations
You should be able to edit/add new translations, and the permalinks should take you to the correct translation (`de/formal`)

<img width="79" alt="screen shot 2018-03-21 at 5 16 50 pm" src="https://user-images.githubusercontent.com/6458278/37696561-add8eae2-2d2b-11e8-89ae-9d3b9073be72.png">
