### PR TITLE
Tests: Update query manager tests to Jest expect

### DIFF
--- a/client/lib/query-manager/activity/test/index.js
+++ b/client/lib/query-manager/activity/test/index.js
@@ -1,8 +1,8 @@
 /** @format */
+
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -44,7 +44,7 @@ describe( 'ActivityQueryManager', () => {
 					DEFAULT_ACTIVITY
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true if activity is after the specified time', () => {
@@ -55,7 +55,7 @@ describe( 'ActivityQueryManager', () => {
 					DEFAULT_ACTIVITY
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return false if activity is before the specified time', () => {
@@ -66,7 +66,7 @@ describe( 'ActivityQueryManager', () => {
 					DEFAULT_ACTIVITY
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 		} );
 
@@ -79,7 +79,7 @@ describe( 'ActivityQueryManager', () => {
 					DEFAULT_ACTIVITY
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return false if activity is after the specified time', () => {
@@ -90,7 +90,7 @@ describe( 'ActivityQueryManager', () => {
 					DEFAULT_ACTIVITY
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if activity is before the specified time', () => {
@@ -101,7 +101,7 @@ describe( 'ActivityQueryManager', () => {
 					DEFAULT_ACTIVITY
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 		} );
 
@@ -115,7 +115,7 @@ describe( 'ActivityQueryManager', () => {
 					DEFAULT_ACTIVITY
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return false if activity is before a range of dates', () => {
@@ -127,7 +127,7 @@ describe( 'ActivityQueryManager', () => {
 					DEFAULT_ACTIVITY
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return false if activity is after a range of dates', () => {
@@ -139,7 +139,7 @@ describe( 'ActivityQueryManager', () => {
 					DEFAULT_ACTIVITY
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should be impossible to match if dateStart is after dateEnd', () => {
@@ -151,7 +151,7 @@ describe( 'ActivityQueryManager', () => {
 					DEFAULT_ACTIVITY
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 		} );
 	} );
@@ -162,7 +162,7 @@ describe( 'ActivityQueryManager', () => {
 			const activityA = { activityId: 'a', activityTs: 100000 };
 			const activityB = { activityId: 'b', activityTs: 200000 };
 
-			expect( [ activityA, activityB ].sort( sortFunc ) ).to.eql( [ activityB, activityA ] );
+			expect( [ activityA, activityB ].sort( sortFunc ) ).toEqual( [ activityB, activityA ] );
 		} );
 
 		test( 'should include simultaneous events (in any order, sort is unstable)', () => {
@@ -170,10 +170,9 @@ describe( 'ActivityQueryManager', () => {
 			const activityA = { activityId: 'a', activityTs: 100000 };
 			const activityB = { activityId: 'b', activityTs: 100000 };
 
-			expect( [ activityA, activityB ].sort( sortFunc ) ).to.include.members( [
-				activityA,
-				activityB,
-			] );
+			expect( [ activityA, activityB ].sort( sortFunc ) ).toEqual(
+				expect.arrayContaining( [ activityA, activityB ] )
+			);
 		} );
 	} );
 } );

--- a/client/lib/query-manager/media/test/index.js
+++ b/client/lib/query-manager/media/test/index.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -46,7 +42,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true for an empty search', () => {
@@ -57,7 +53,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true for a matching title search', () => {
@@ -68,7 +64,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should search case-insensitive', () => {
@@ -79,7 +75,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 		} );
 
@@ -92,7 +88,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true an exact match', () => {
@@ -103,7 +99,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true for mime subgroup exact match', () => {
@@ -114,7 +110,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true for mime subgroup exact match with trailing slash', () => {
@@ -125,7 +121,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return false for mime subgroup partial match', () => {
@@ -136,7 +132,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return false for mime group partial match', () => {
@@ -147,7 +143,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true for wildcard match', () => {
@@ -158,7 +154,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return false for mime subgroup wildcard match', () => {
@@ -169,7 +165,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true for mime group wildcard match', () => {
@@ -180,7 +176,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return false for mime subgroup partial wildcard match', () => {
@@ -191,7 +187,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return false for mime group partial wildcard match', () => {
@@ -202,7 +198,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 		} );
 
@@ -215,7 +211,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if post ID matches', () => {
@@ -226,7 +222,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 		} );
 
@@ -239,7 +235,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return false if media is not before date', () => {
@@ -250,7 +246,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if media is before date', () => {
@@ -261,7 +257,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 		} );
 
@@ -274,7 +270,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return false if media is not after date', () => {
@@ -285,7 +281,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if media is after date', () => {
@@ -296,7 +292,7 @@ describe( 'MediaQueryManager', () => {
 					DEFAULT_MEDIA
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 		} );
 	} );
@@ -310,7 +306,7 @@ describe( 'MediaQueryManager', () => {
 					} )
 				);
 
-				expect( sorted ).to.eql( [ { ID: 400 }, { ID: 200 } ] );
+				expect( sorted ).toEqual( [ { ID: 400 }, { ID: 200 } ] );
 			} );
 
 			test( 'should reverse order when specified as ascending', () => {
@@ -321,7 +317,7 @@ describe( 'MediaQueryManager', () => {
 					} )
 				);
 
-				expect( sorted ).to.eql( [ { ID: 200 }, { ID: 400 } ] );
+				expect( sorted ).toEqual( [ { ID: 200 }, { ID: 400 } ] );
 			} );
 		} );
 
@@ -341,7 +337,7 @@ describe( 'MediaQueryManager', () => {
 				test( 'should order by date', () => {
 					const sorted = [ olderMedia, newerMedia ].sort( makeComparator( {} ) );
 
-					expect( sorted ).to.eql( [ newerMedia, olderMedia ] );
+					expect( sorted ).toEqual( [ newerMedia, olderMedia ] );
 				} );
 			} );
 
@@ -364,7 +360,7 @@ describe( 'MediaQueryManager', () => {
 						} )
 					);
 
-					expect( sorted ).to.eql( [ abMedia, aaMedia ] );
+					expect( sorted ).toEqual( [ abMedia, aaMedia ] );
 				} );
 			} );
 
@@ -376,7 +372,7 @@ describe( 'MediaQueryManager', () => {
 						} )
 					);
 
-					expect( sorted ).to.eql( [ { ID: 400 }, { ID: 200 } ] );
+					expect( sorted ).toEqual( [ { ID: 400 }, { ID: 200 } ] );
 				} );
 			} );
 		} );

--- a/client/lib/query-manager/paginated/test/index.js
+++ b/client/lib/query-manager/paginated/test/index.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -36,7 +32,7 @@ describe( 'PaginatedQueryManager', () => {
 		test( 'should return false if not passed a query', () => {
 			const hasKeys = PaginatedQueryManager.hasQueryPaginationKeys();
 
-			expect( hasKeys ).to.be.false;
+			expect( hasKeys ).toBe( false );
 		} );
 
 		test( 'should return false if query has no pagination keys', () => {
@@ -44,7 +40,7 @@ describe( 'PaginatedQueryManager', () => {
 				search: 'title',
 			} );
 
-			expect( hasKeys ).to.be.false;
+			expect( hasKeys ).toBe( false );
 		} );
 
 		test( 'should return true if query has pagination keys', () => {
@@ -53,7 +49,7 @@ describe( 'PaginatedQueryManager', () => {
 				number: 2,
 			} );
 
-			expect( hasKeys ).to.be.true;
+			expect( hasKeys ).toBe( true );
 		} );
 	} );
 
@@ -62,30 +58,30 @@ describe( 'PaginatedQueryManager', () => {
 			manager = manager.receive( { ID: 144 } );
 			manager = manager.receive( { ID: 152 }, { query: {} } );
 
-			expect( manager.getItems() ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
+			expect( manager.getItems() ).toEqual( [ { ID: 144 }, { ID: 152 } ] );
 		} );
 
 		test( 'should return null if query is unknown', () => {
 			manager = manager.receive( { ID: 144 } );
 
-			expect( manager.getItems( {} ) ).to.be.null;
+			expect( manager.getItems( {} ) ).toBeNull();
 		} );
 
 		test( 'should return a page subset of query items', () => {
 			manager = manager.receive( { ID: 144 }, { query: { number: 1 } } );
 			manager = manager.receive( { ID: 152 }, { query: { number: 1, page: 2 } } );
 
-			expect( manager.getItems( { number: 1, page: 1 } ) ).to.eql( [ { ID: 144 } ] );
-			expect( manager.getItems( { number: 1, page: 2 } ) ).to.eql( [ { ID: 152 } ] );
-			expect( manager.getItems( { number: 2, page: 1 } ) ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
-			expect( manager.getItems( { number: 2, page: 2 } ) ).to.eql( [] );
+			expect( manager.getItems( { number: 1, page: 1 } ) ).toEqual( [ { ID: 144 } ] );
+			expect( manager.getItems( { number: 1, page: 2 } ) ).toEqual( [ { ID: 152 } ] );
+			expect( manager.getItems( { number: 2, page: 1 } ) ).toEqual( [ { ID: 144 }, { ID: 152 } ] );
+			expect( manager.getItems( { number: 2, page: 2 } ) ).toEqual( [] );
 		} );
 
 		test( 'should return page subset for non-sequentially received query', () => {
 			manager = manager.receive( { ID: 152 }, { query: { page: 2, number: 1 } } );
 
-			expect( manager.getItems( { number: 1, page: 1 } ) ).to.eql( [ undefined ] );
-			expect( manager.getItems( { number: 1, page: 2 } ) ).to.eql( [ { ID: 152 } ] );
+			expect( manager.getItems( { number: 1, page: 1 } ) ).toEqual( [ undefined ] );
+			expect( manager.getItems( { number: 1, page: 2 } ) ).toEqual( [ { ID: 152 } ] );
 		} );
 	} );
 
@@ -93,32 +89,32 @@ describe( 'PaginatedQueryManager', () => {
 		test( 'should return null if not passed a query', () => {
 			manager = manager.receive( { ID: 144 } );
 
-			expect( manager.getItemsIgnoringPage() ).to.be.null;
+			expect( manager.getItemsIgnoringPage() ).toBeNull();
 		} );
 
 		test( 'should return null if query is unknown', () => {
 			manager = manager.receive( { ID: 144 } );
 
-			expect( manager.getItemsIgnoringPage( {} ) ).to.be.null;
+			expect( manager.getItemsIgnoringPage( {} ) ).toBeNull();
 		} );
 
 		test( 'should return all pages of query items', () => {
 			manager = manager.receive( { ID: 144 }, { query: { number: 1 } } );
 			manager = manager.receive( { ID: 152 }, { query: { number: 1, page: 2 } } );
 
-			expect( manager.getItemsIgnoringPage( {} ) ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
+			expect( manager.getItemsIgnoringPage( {} ) ).toEqual( [ { ID: 144 }, { ID: 152 } ] );
 		} );
 
 		test( 'should exclude undefined items by default', () => {
 			manager = manager.receive( { ID: 144 }, { query: { number: 1 }, found: 2 } );
 
-			expect( manager.getItemsIgnoringPage( {} ) ).to.eql( [ { ID: 144 } ] );
+			expect( manager.getItemsIgnoringPage( {} ) ).toEqual( [ { ID: 144 } ] );
 		} );
 
 		test( 'should include undefined items when opting to includeFiller argument', () => {
 			manager = manager.receive( { ID: 144 }, { query: { number: 1 }, found: 2 } );
 
-			expect( manager.getItemsIgnoringPage( {}, true ) ).to.eql( [ { ID: 144 }, undefined ] );
+			expect( manager.getItemsIgnoringPage( {}, true ) ).toEqual( [ { ID: 144 }, undefined ] );
 		} );
 	} );
 
@@ -126,25 +122,25 @@ describe( 'PaginatedQueryManager', () => {
 		test( 'should return null if the query is unknown', () => {
 			manager = manager.receive( { ID: 144 } );
 
-			expect( manager.getNumberOfPages( {} ) ).to.be.null;
+			expect( manager.getNumberOfPages( {} ) ).toBeNull();
 		} );
 
 		test( 'should return null if the query is known, but found was not provided', () => {
 			manager = manager.receive( { ID: 144 }, { query: {} } );
 
-			expect( manager.getNumberOfPages( {} ) ).to.be.null;
+			expect( manager.getNumberOfPages( {} ) ).toBeNull();
 		} );
 
 		test( 'should return the number of pages assuming the default query number per page', () => {
 			manager = manager.receive( { ID: 144 }, { query: {}, found: 30 } );
 
-			expect( manager.getNumberOfPages( {} ) ).to.equal( 2 );
+			expect( manager.getNumberOfPages( {} ) ).toBe( 2 );
 		} );
 
 		test( 'should return the number of pages with an explicit number per page', () => {
 			manager = manager.receive( { ID: 144 }, { query: {}, found: 30 } );
 
-			expect( manager.getNumberOfPages( { number: 7 } ) ).to.equal( 5 );
+			expect( manager.getNumberOfPages( { number: 7 } ) ).toBe( 5 );
 		} );
 	} );
 
@@ -153,7 +149,7 @@ describe( 'PaginatedQueryManager', () => {
 			manager = manager.receive( { ID: 144 } );
 			const newManager = manager.receive( { ID: 144 } );
 
-			expect( manager ).to.equal( newManager );
+			expect( manager ).toBe( newManager );
 		} );
 
 		test( 'should update a single changed item', () => {
@@ -163,7 +159,7 @@ describe( 'PaginatedQueryManager', () => {
 				{ query: { search: 'title', number: 1 } }
 			);
 
-			expect( manager.getItems( { search: 'title', number: 1 } ) ).to.eql( [
+			expect( manager.getItems( { search: 'title', number: 1 } ) ).toEqual( [
 				{ ID: 144, changed: true },
 			] );
 		} );
@@ -172,8 +168,8 @@ describe( 'PaginatedQueryManager', () => {
 			manager = manager.receive( { ID: 144 }, { query: { search: 'title', number: 1 } } );
 			manager = manager.receive( { ID: 152 }, { query: { search: 'title', number: 1, page: 2 } } );
 
-			expect( manager.getItems( { search: 'title', number: 1 } ) ).to.eql( [ { ID: 144 } ] );
-			expect( manager.getItemsIgnoringPage( { search: 'title', number: 1 } ) ).to.eql( [
+			expect( manager.getItems( { search: 'title', number: 1 } ) ).toEqual( [ { ID: 144 } ] );
+			expect( manager.getItemsIgnoringPage( { search: 'title', number: 1 } ) ).toEqual( [
 				{ ID: 144 },
 				{ ID: 152 },
 			] );
@@ -185,12 +181,14 @@ describe( 'PaginatedQueryManager', () => {
 			} );
 			manager = manager.receive( { ID: 144, changed: true }, { query: { number: 1 } } );
 
-			expect( manager.getItemsIgnoringPage( {} ) ).to.eql( [
+			expect( manager.getItemsIgnoringPage( {} ) ).toEqual( [
 				{ ID: 144, changed: true },
 				{ ID: 152 },
 			] );
-			expect( manager.getItems( { number: 1, page: 1 } ) ).to.eql( [ { ID: 144, changed: true } ] );
-			expect( manager.getItems( { number: 1, page: 2 } ) ).to.eql( [ { ID: 152 } ] );
+			expect( manager.getItems( { number: 1, page: 1 } ) ).toEqual( [
+				{ ID: 144, changed: true },
+			] );
+			expect( manager.getItems( { number: 1, page: 2 } ) ).toEqual( [ { ID: 152 } ] );
 		} );
 
 		test( 'should include filler undefined entries for yet-to-be-received items', () => {
@@ -199,7 +197,7 @@ describe( 'PaginatedQueryManager', () => {
 				found: 4,
 			} );
 
-			expect( manager.getItemsIgnoringPage( { number: 1 }, true ) ).to.eql( [
+			expect( manager.getItemsIgnoringPage( { number: 1 }, true ) ).toEqual( [
 				undefined,
 				{ ID: 144 },
 				undefined,
@@ -213,7 +211,7 @@ describe( 'PaginatedQueryManager', () => {
 				found: 2,
 			} );
 
-			expect( manager.getItems( { number: 20 } ) ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
+			expect( manager.getItems( { number: 20 } ) ).toEqual( [ { ID: 144 }, { ID: 152 } ] );
 		} );
 
 		test( 'should replace the existing page subset of a received query', () => {
@@ -224,12 +222,12 @@ describe( 'PaginatedQueryManager', () => {
 			manager = manager.receive( { ID: 160 }, { query: { search: 'title', number: 1, page: 3 } } );
 			manager = manager.receive( { ID: 154 }, { query: { search: 'title', number: 1, page: 2 } } );
 
-			expect( manager.getItemsIgnoringPage( { search: 'title' } ) ).to.eql( [
+			expect( manager.getItemsIgnoringPage( { search: 'title' } ) ).toEqual( [
 				{ ID: 144 },
 				{ ID: 154 },
 				{ ID: 160 },
 			] );
-			expect( manager.getFound( { search: 'title' } ) ).to.equal( 3 );
+			expect( manager.getFound( { search: 'title' } ) ).toBe( 3 );
 		} );
 
 		test( 'should de-dupe if receiving a page includes existing item key', () => {
@@ -246,10 +244,10 @@ describe( 'PaginatedQueryManager', () => {
 				{ query: { search: 'title', number: 1, page: 1 }, found: 1 }
 			);
 
-			expect( manager.getItems( { search: 'title', number: 1 } ) ).to.eql( [ { ID: 152 } ] );
-			expect( manager.getItems( { search: 'title', number: 1, page: 2 } ) ).to.eql( [] );
-			expect( manager.getFound( { search: 'title' } ) ).to.equal( 1 );
-			expect( manager.getNumberOfPages( { search: 'title' } ) ).to.equal( 1 );
+			expect( manager.getItems( { search: 'title', number: 1 } ) ).toEqual( [ { ID: 152 } ] );
+			expect( manager.getItems( { search: 'title', number: 1, page: 2 } ) ).toEqual( [] );
+			expect( manager.getFound( { search: 'title' } ) ).toBe( 1 );
+			expect( manager.getNumberOfPages( { search: 'title' } ) ).toBe( 1 );
 		} );
 
 		test( 'should adjust for the difference in found after an item is removed', () => {
@@ -269,12 +267,12 @@ describe( 'PaginatedQueryManager', () => {
 			sandbox.stub( PaginatedQueryManager, 'matches' ).returns( false );
 			manager = manager.receive( { ID: 160, changed: true } );
 
-			expect( manager.getFound( { search: 'title' } ) ).to.equal( 5 );
-			expect( manager.getItems( { search: 'title', number: 2, page: 2 } ) ).to.eql( [
+			expect( manager.getFound( { search: 'title' } ) ).toBe( 5 );
+			expect( manager.getItems( { search: 'title', number: 2, page: 2 } ) ).toEqual( [
 				{ ID: 168 },
 				{ ID: 176 },
 			] );
-			expect( manager.getItems( { search: 'title', number: 2, page: 3 } ) ).to.eql( [
+			expect( manager.getItems( { search: 'title', number: 2, page: 3 } ) ).toEqual( [
 				{ ID: 184 },
 			] );
 		} );
@@ -295,21 +293,21 @@ describe( 'PaginatedQueryManager', () => {
 			} );
 			manager = manager.receive( { ID: 154 } );
 
-			expect( manager.getFound( { search: 'title' } ) ).to.equal( 7 );
-			expect( manager.getNumberOfPages( { search: 'title', number: 2 } ) ).to.equal( 4 );
-			expect( manager.getItems( { search: 'title', number: 2, page: 1 } ) ).to.eql( [
+			expect( manager.getFound( { search: 'title' } ) ).toBe( 7 );
+			expect( manager.getNumberOfPages( { search: 'title', number: 2 } ) ).toBe( 4 );
+			expect( manager.getItems( { search: 'title', number: 2, page: 1 } ) ).toEqual( [
 				{ ID: 144 },
 				{ ID: 152 },
 			] );
-			expect( manager.getItems( { search: 'title', number: 2, page: 2 } ) ).to.eql( [
+			expect( manager.getItems( { search: 'title', number: 2, page: 2 } ) ).toEqual( [
 				{ ID: 154 },
 				{ ID: 160 },
 			] );
-			expect( manager.getItems( { search: 'title', number: 2, page: 3 } ) ).to.eql( [
+			expect( manager.getItems( { search: 'title', number: 2, page: 3 } ) ).toEqual( [
 				{ ID: 168 },
 				{ ID: 176 },
 			] );
-			expect( manager.getItems( { search: 'title', number: 2, page: 4 } ) ).to.eql( [
+			expect( manager.getItems( { search: 'title', number: 2, page: 4 } ) ).toEqual( [
 				{ ID: 184 },
 			] );
 		} );
@@ -347,8 +345,8 @@ describe( 'PaginatedQueryManager', () => {
 				],
 				{ query: { page: 1 }, found: 28 }
 			);
-			expect( customizedManager.getNumberOfPages( {} ) ).to.equal( 2 );
-			expect( customizedManager.getItems( { page: 1 } ) ).eql( [
+			expect( customizedManager.getNumberOfPages( {} ) ).toBe( 2 );
+			expect( customizedManager.getItems( { page: 1 } ) ).toEqual( [
 				{ ID: 144 },
 				{ ID: 152 },
 				{ ID: 162 },
@@ -386,12 +384,12 @@ describe( 'PaginatedQueryManager', () => {
 				found: 4,
 			} );
 
-			expect( manager.getFound( { search: 'title' } ) ).to.equal( 4 );
-			expect( manager.getItems( { search: 'title', number: 2, page: 1 } ) ).to.eql( [
+			expect( manager.getFound( { search: 'title' } ) ).toBe( 4 );
+			expect( manager.getItems( { search: 'title', number: 2, page: 1 } ) ).toEqual( [
 				{ ID: 144 },
 				{ ID: 152 },
 			] );
-			expect( manager.getItemsIgnoringPage( { search: 'title' } ) ).to.eql( [
+			expect( manager.getItemsIgnoringPage( { search: 'title' } ) ).toEqual( [
 				{ ID: 144 },
 				{ ID: 152 },
 			] );
@@ -400,16 +398,16 @@ describe( 'PaginatedQueryManager', () => {
 				query: { search: 'title', number: 2, page: 2 },
 			} );
 
-			expect( manager.getFound( { search: 'title' } ) ).to.equal( 4 );
-			expect( manager.getItems( { search: 'title', number: 2, page: 1 } ) ).to.eql( [
+			expect( manager.getFound( { search: 'title' } ) ).toBe( 4 );
+			expect( manager.getItems( { search: 'title', number: 2, page: 1 } ) ).toEqual( [
 				{ ID: 144 },
 				{ ID: 152 },
 			] );
-			expect( manager.getItems( { search: 'title', number: 2, page: 2 } ) ).to.eql( [
+			expect( manager.getItems( { search: 'title', number: 2, page: 2 } ) ).toEqual( [
 				{ ID: 160 },
 				undefined,
 			] );
-			expect( manager.getItemsIgnoringPage( { search: 'title' } ) ).to.eql( [
+			expect( manager.getItemsIgnoringPage( { search: 'title' } ) ).toEqual( [
 				{ ID: 144 },
 				{ ID: 152 },
 				{ ID: 160 },
@@ -424,13 +422,13 @@ describe( 'PaginatedQueryManager', () => {
 
 			// We would like for "found" to be 6, but at this point we don't
 			// have this information yet.
-			expect( manager.getFound( { search: 'title' } ) ).to.equal( 5 );
-			expect( manager.getItems( { search: 'title', number: 3, page: 1 } ) ).to.eql( [
+			expect( manager.getFound( { search: 'title' } ) ).toBe( 5 );
+			expect( manager.getItems( { search: 'title', number: 3, page: 1 } ) ).toEqual( [
 				{ ID: 1 },
 				{ ID: 3 },
 				undefined,
 			] );
-			expect( manager.getItemsIgnoringPage( { search: 'title' } ) ).to.eql( [
+			expect( manager.getItemsIgnoringPage( { search: 'title' } ) ).toEqual( [
 				{ ID: 1 },
 				{ ID: 3 },
 			] );
@@ -440,18 +438,18 @@ describe( 'PaginatedQueryManager', () => {
 				found: 6,
 			} );
 
-			expect( manager.getFound( { search: 'title' } ) ).to.equal( 6 );
-			expect( manager.getItems( { search: 'title', number: 3, page: 1 } ) ).to.eql( [
+			expect( manager.getFound( { search: 'title' } ) ).toBe( 6 );
+			expect( manager.getItems( { search: 'title', number: 3, page: 1 } ) ).toEqual( [
 				{ ID: 1 },
 				{ ID: 3 },
 				undefined,
 			] );
-			expect( manager.getItems( { search: 'title', number: 3, page: 2 } ) ).to.eql( [
+			expect( manager.getItems( { search: 'title', number: 3, page: 2 } ) ).toEqual( [
 				{ ID: 4 },
 				{ ID: 5 },
 				{ ID: 6 },
 			] );
-			expect( manager.getItemsIgnoringPage( { search: 'title' } ) ).to.eql( [
+			expect( manager.getItemsIgnoringPage( { search: 'title' } ) ).toEqual( [
 				{ ID: 1 },
 				{ ID: 3 },
 				{ ID: 4 },
@@ -468,13 +466,13 @@ describe( 'PaginatedQueryManager', () => {
 
 			// We would like for "found" to be 9, but at this point we don't
 			// have this information yet.
-			expect( manager.getFound( { search: 'title' } ) ).to.equal( 8 );
-			expect( manager.getItems( { search: 'title', number: 3, page: 1 } ) ).to.eql( [
+			expect( manager.getFound( { search: 'title' } ) ).toBe( 8 );
+			expect( manager.getItems( { search: 'title', number: 3, page: 1 } ) ).toEqual( [
 				{ ID: 1 },
 				{ ID: 3 },
 				undefined,
 			] );
-			expect( manager.getItemsIgnoringPage( { search: 'title' } ) ).to.eql( [
+			expect( manager.getItemsIgnoringPage( { search: 'title' } ) ).toEqual( [
 				{ ID: 1 },
 				{ ID: 3 },
 			] );
@@ -484,18 +482,18 @@ describe( 'PaginatedQueryManager', () => {
 				found: 9,
 			} );
 
-			expect( manager.getFound( { search: 'title' } ) ).to.equal( 9 );
-			expect( manager.getItems( { search: 'title', number: 3, page: 1 } ) ).to.eql( [
+			expect( manager.getFound( { search: 'title' } ) ).toBe( 9 );
+			expect( manager.getItems( { search: 'title', number: 3, page: 1 } ) ).toEqual( [
 				{ ID: 1 },
 				{ ID: 3 },
 				undefined,
 			] );
-			expect( manager.getItems( { search: 'title', number: 3, page: 2 } ) ).to.eql( [
+			expect( manager.getItems( { search: 'title', number: 3, page: 2 } ) ).toEqual( [
 				{ ID: 4 },
 				{ ID: 5 },
 				{ ID: 6 },
 			] );
-			expect( manager.getItemsIgnoringPage( { search: 'title' } ) ).to.eql( [
+			expect( manager.getItemsIgnoringPage( { search: 'title' } ) ).toEqual( [
 				{ ID: 1 },
 				{ ID: 3 },
 				{ ID: 4 },
@@ -511,27 +509,27 @@ describe( 'PaginatedQueryManager', () => {
 			// We should remember the previous, higher "found" count of 9.  For
 			// the purpose of determining the total number of pages, it is more
 			// accurate.
-			expect( manager.getFound( { search: 'title' } ) ).to.equal( 9 );
+			expect( manager.getFound( { search: 'title' } ) ).toBe( 9 );
 			// TODO - Pagination split has changed by this point (the
 			// `undefined` item has moved to the end of page 2).  Not sure why,
 			// and it is unlikely to cause problems in practice since we call
 			// `getItemsIgnoringPage`.
-			expect( manager.getItems( { search: 'title', number: 3, page: 1 } ) ).to.eql( [
+			expect( manager.getItems( { search: 'title', number: 3, page: 1 } ) ).toEqual( [
 				{ ID: 1 },
 				{ ID: 3 },
 				{ ID: 4 },
 			] );
-			expect( manager.getItems( { search: 'title', number: 3, page: 2 } ) ).to.eql( [
+			expect( manager.getItems( { search: 'title', number: 3, page: 2 } ) ).toEqual( [
 				{ ID: 5 },
 				{ ID: 6 },
 				undefined,
 			] );
-			expect( manager.getItems( { search: 'title', number: 3, page: 3 } ) ).to.eql( [
+			expect( manager.getItems( { search: 'title', number: 3, page: 3 } ) ).toEqual( [
 				{ ID: 7 },
 				{ ID: 9 },
 				undefined,
 			] );
-			expect( manager.getItemsIgnoringPage( { search: 'title' } ) ).to.eql( [
+			expect( manager.getItemsIgnoringPage( { search: 'title' } ) ).toEqual( [
 				{ ID: 1 },
 				{ ID: 3 },
 				{ ID: 4 },

--- a/client/lib/query-manager/paginated/test/index.js
+++ b/client/lib/query-manager/paginated/test/index.js
@@ -4,7 +4,6 @@
  * Internal dependencies
  */
 import PaginatedQueryManager from '../';
-import { useSandbox } from 'test/helpers/use-sinon';
 
 /**
  * Provide subclass with compare method implementation for testing
@@ -16,16 +15,10 @@ class TestCustomQueryManager extends PaginatedQueryManager {
 }
 
 describe( 'PaginatedQueryManager', () => {
-	let sandbox, manager;
-
-	useSandbox( _sandbox => ( sandbox = _sandbox ) );
-
+	let manager;
 	beforeEach( () => {
 		manager = new TestCustomQueryManager();
-	} );
-
-	afterEach( () => {
-		sandbox.restore();
+		jest.restoreAllMocks();
 	} );
 
 	describe( '.hasQueryPaginationKeys()', () => {
@@ -264,7 +257,7 @@ describe( 'PaginatedQueryManager', () => {
 			manager = manager.receive( [ { ID: 176 }, { ID: 184 } ], {
 				query: { search: 'title', number: 2, page: 3 },
 			} );
-			sandbox.stub( PaginatedQueryManager, 'matches' ).returns( false );
+			jest.spyOn( PaginatedQueryManager, 'matches' ).mockImplementation( () => false );
 			manager = manager.receive( { ID: 160, changed: true } );
 
 			expect( manager.getFound( { search: 'title' } ) ).toBe( 5 );

--- a/client/lib/query-manager/paginated/test/index.js
+++ b/client/lib/query-manager/paginated/test/index.js
@@ -407,7 +407,7 @@ describe( 'PaginatedQueryManager', () => {
 			] );
 		} );
 
-		it( 'handles items missing from the first page', () => {
+		test( 'handles items missing from the first page', () => {
 			manager = manager.receive( [ { ID: 1 }, { ID: 3 } ], {
 				query: { search: 'title', number: 3 },
 				found: 5, // The API found 6 results and decremented 1.
@@ -451,7 +451,7 @@ describe( 'PaginatedQueryManager', () => {
 			] );
 		} );
 
-		it( 'handles items missing from the first and last pages', () => {
+		test( 'handles items missing from the first and last pages', () => {
 			manager = manager.receive( [ { ID: 1 }, { ID: 3 } ], {
 				query: { search: 'title', number: 3 },
 				found: 8, // The API found 9 results and decremented 1.

--- a/client/lib/query-manager/paginated/test/key.js
+++ b/client/lib/query-manager/paginated/test/key.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -14,13 +10,13 @@ describe( 'PaginatedQueryKey', () => {
 		test( 'should return a JSON string of the object', () => {
 			const key = PaginatedQueryKey.stringify( { ok: true } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).toBe( '[["ok",true]]' );
 		} );
 
 		test( 'should omit pagination query parameters', () => {
 			const key = PaginatedQueryKey.stringify( { ok: true, page: 2 } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).toBe( '[["ok",true]]' );
 		} );
 	} );
 
@@ -28,13 +24,13 @@ describe( 'PaginatedQueryKey', () => {
 		test( 'should return an object of the JSON string', () => {
 			const query = PaginatedQueryKey.parse( '[["ok",true]]' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 
 		test( 'should omit pagination query parameters', () => {
 			const query = PaginatedQueryKey.parse( '[["ok",true],["page",2]]' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 	} );
 } );

--- a/client/lib/query-manager/post/test/index.js
+++ b/client/lib/query-manager/post/test/index.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -98,7 +94,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true for a matching title search', () => {
@@ -109,7 +105,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true for a falsey title search', () => {
@@ -120,7 +116,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true for a matching content search', () => {
@@ -131,7 +127,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should search case-insensitive', () => {
@@ -142,7 +138,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should separately test title and content fields', () => {
@@ -153,7 +149,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 		} );
 
@@ -166,7 +162,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return false if post is not after date', () => {
@@ -177,7 +173,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if post is after date', () => {
@@ -188,7 +184,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 		} );
 
@@ -201,7 +197,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return false if post is not before date', () => {
@@ -212,7 +208,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if post is before date', () => {
@@ -223,7 +219,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 		} );
 
@@ -236,7 +232,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return false if post is not modified after date', () => {
@@ -247,7 +243,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if post is modified after date', () => {
@@ -258,7 +254,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 		} );
 
@@ -271,7 +267,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return false if post is not modified before date', () => {
@@ -282,7 +278,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if post is modified before date', () => {
@@ -293,7 +289,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 		} );
 
@@ -306,7 +302,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return false on a partial match', () => {
@@ -317,7 +313,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if post includes tag by name', () => {
@@ -328,7 +324,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true if post includes tag by slug', () => {
@@ -339,7 +335,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should search case-insensitive', () => {
@@ -350,7 +346,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 		} );
 
@@ -363,7 +359,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return false on a partial match', () => {
@@ -374,7 +370,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if post includes category by name', () => {
@@ -385,7 +381,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true if post includes category by slug', () => {
@@ -396,7 +392,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should search case-insensitive', () => {
@@ -407,7 +403,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 		} );
 
@@ -422,7 +418,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return false if one but not both term slug queries match', () => {
@@ -436,7 +432,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if post includes term by slug', () => {
@@ -449,7 +445,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true if post includes one of comma-separated term slugs', () => {
@@ -462,7 +458,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true if post includes both of comma-separated term slugs', () => {
@@ -475,7 +471,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 		} );
 
@@ -491,7 +487,7 @@ describe( 'PostQueryManager', () => {
 					post
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return false if type does not match', () => {
@@ -502,7 +498,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if type matches', () => {
@@ -513,7 +509,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 		} );
 
@@ -526,7 +522,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if numeric parent matches', () => {
@@ -540,7 +536,7 @@ describe( 'PostQueryManager', () => {
 					post
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true if object parent matches', () => {
@@ -556,7 +552,7 @@ describe( 'PostQueryManager', () => {
 					post
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 		} );
 
@@ -569,7 +565,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return false if ID matches array of excludes', () => {
@@ -580,7 +576,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if ID does not match single exclude', () => {
@@ -591,7 +587,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true if ID does not match array of excludes', () => {
@@ -602,7 +598,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 		} );
 
@@ -619,7 +615,7 @@ describe( 'PostQueryManager', () => {
 					stickyPost
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true if "include" and not sticky', () => {
@@ -630,7 +626,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true if "require" and sticky', () => {
@@ -641,7 +637,7 @@ describe( 'PostQueryManager', () => {
 					stickyPost
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return false if "require" and not sticky', () => {
@@ -652,7 +648,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return false if "exclude" and sticky', () => {
@@ -663,7 +659,7 @@ describe( 'PostQueryManager', () => {
 					stickyPost
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if "exclude" and not sticky', () => {
@@ -674,7 +670,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 		} );
 
@@ -691,7 +687,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if author matches by nested object', () => {
@@ -702,7 +698,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return false if author does not match by scalar value', () => {
@@ -713,7 +709,7 @@ describe( 'PostQueryManager', () => {
 					postWithScalarAuthor
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if author matches by scalar value', () => {
@@ -724,7 +720,7 @@ describe( 'PostQueryManager', () => {
 					postWithScalarAuthor
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 		} );
 
@@ -737,7 +733,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return false if status does not match', () => {
@@ -748,7 +744,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if status matches', () => {
@@ -759,7 +755,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return false if none of comma-separated values match', () => {
@@ -770,7 +766,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if one of comma-separated values match', () => {
@@ -781,7 +777,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should gracefully handle non-string search values', () => {
@@ -792,7 +788,7 @@ describe( 'PostQueryManager', () => {
 					DEFAULT_POST
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 		} );
 	} );
@@ -806,7 +802,7 @@ describe( 'PostQueryManager', () => {
 					} )
 				);
 
-				expect( sorted ).to.eql( [ { ID: 400 }, { ID: 200 } ] );
+				expect( sorted ).toEqual( [ { ID: 400 }, { ID: 200 } ] );
 			} );
 
 			test( 'should reverse order when specified as ascending', () => {
@@ -817,7 +813,7 @@ describe( 'PostQueryManager', () => {
 					} )
 				);
 
-				expect( sorted ).to.eql( [ { ID: 200 }, { ID: 400 } ] );
+				expect( sorted ).toEqual( [ { ID: 200 }, { ID: 400 } ] );
 			} );
 		} );
 
@@ -835,7 +831,7 @@ describe( 'PostQueryManager', () => {
 				test( 'should order by date', () => {
 					const sorted = [ olderPost, newerPost ].sort( makeComparator( {} ) );
 
-					expect( sorted ).to.eql( [ newerPost, olderPost ] );
+					expect( sorted ).toEqual( [ newerPost, olderPost ] );
 				} );
 			} );
 
@@ -856,7 +852,7 @@ describe( 'PostQueryManager', () => {
 						} )
 					);
 
-					expect( sorted ).to.eql( [ newerPost, olderPost ] );
+					expect( sorted ).toEqual( [ newerPost, olderPost ] );
 				} );
 			} );
 
@@ -877,7 +873,7 @@ describe( 'PostQueryManager', () => {
 						} )
 					);
 
-					expect( sorted ).to.eql( [ zPost, aPost ] );
+					expect( sorted ).toEqual( [ zPost, aPost ] );
 				} );
 			} );
 
@@ -902,7 +898,7 @@ describe( 'PostQueryManager', () => {
 						} )
 					);
 
-					expect( sorted ).to.eql( [ popularPost, unpopularPost ] );
+					expect( sorted ).toEqual( [ popularPost, unpopularPost ] );
 				} );
 			} );
 
@@ -914,7 +910,7 @@ describe( 'PostQueryManager', () => {
 						} )
 					);
 
-					expect( sorted ).to.eql( [ { ID: 400 }, { ID: 200 } ] );
+					expect( sorted ).toEqual( [ { ID: 400 }, { ID: 200 } ] );
 				} );
 			} );
 		} );

--- a/client/lib/query-manager/post/test/key.js
+++ b/client/lib/query-manager/post/test/key.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -14,25 +10,25 @@ describe( 'PostQueryKey', () => {
 		test( 'should return a JSON string of the object', () => {
 			const key = PostQueryKey.stringify( { ok: true } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).toBe( '[["ok",true]]' );
 		} );
 
 		test( 'should omit default post query parameters', () => {
 			const key = PostQueryKey.stringify( { ok: true, type: 'post' } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).toBe( '[["ok",true]]' );
 		} );
 
 		test( 'should omit null query values', () => {
 			const key = PostQueryKey.stringify( { ok: true, search: null } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).toBe( '[["ok",true]]' );
 		} );
 
 		test( 'should omit undefined query values', () => {
 			const key = PostQueryKey.stringify( { ok: true, search: undefined } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).toBe( '[["ok",true]]' );
 		} );
 	} );
 
@@ -40,19 +36,19 @@ describe( 'PostQueryKey', () => {
 		test( 'should return an object of the JSON string', () => {
 			const query = PostQueryKey.parse( '[["ok",true]]' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 
 		test( 'should omit default post query parameters', () => {
 			const query = PostQueryKey.parse( '[["ok",true],["type","post"]]' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 
 		test( 'should omit null query values', () => {
 			const query = PostQueryKey.parse( '[["ok",true],["search",null]]' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 	} );
 } );

--- a/client/lib/query-manager/term/test/index.js
+++ b/client/lib/query-manager/term/test/index.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -33,7 +29,7 @@ describe( 'TermQueryManager', () => {
 					DEFAULT_TERM
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true for an empty search', () => {
@@ -44,7 +40,7 @@ describe( 'TermQueryManager', () => {
 					DEFAULT_TERM
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true for a matching name search', () => {
@@ -55,7 +51,7 @@ describe( 'TermQueryManager', () => {
 					DEFAULT_TERM
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true for a matching slug search', () => {
@@ -66,7 +62,7 @@ describe( 'TermQueryManager', () => {
 					DEFAULT_TERM
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should search case-insensitive', () => {
@@ -77,7 +73,7 @@ describe( 'TermQueryManager', () => {
 					DEFAULT_TERM
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 		} );
 	} );
@@ -91,7 +87,7 @@ describe( 'TermQueryManager', () => {
 					} )
 				);
 
-				expect( sorted ).to.eql( [ { name: 'Cars' }, { name: 'Food' } ] );
+				expect( sorted ).toEqual( [ { name: 'Cars' }, { name: 'Food' } ] );
 			} );
 
 			test( 'should reverse order when specified as descending', () => {
@@ -102,7 +98,7 @@ describe( 'TermQueryManager', () => {
 					} )
 				);
 
-				expect( sorted ).to.eql( [ { name: 'Food' }, { name: 'Cars' } ] );
+				expect( sorted ).toEqual( [ { name: 'Food' }, { name: 'Cars' } ] );
 			} );
 		} );
 
@@ -115,7 +111,7 @@ describe( 'TermQueryManager', () => {
 						} )
 					);
 
-					expect( sorted ).to.eql( [ { name: 'Cars' }, { name: 'Food' } ] );
+					expect( sorted ).toEqual( [ { name: 'Cars' }, { name: 'Food' } ] );
 				} );
 			} );
 
@@ -132,7 +128,7 @@ describe( 'TermQueryManager', () => {
 						} )
 					);
 
-					expect( sorted ).to.eql( [ unusedTerm, DEFAULT_TERM ] );
+					expect( sorted ).toEqual( [ unusedTerm, DEFAULT_TERM ] );
 				} );
 			} );
 		} );

--- a/client/lib/query-manager/term/test/key.js
+++ b/client/lib/query-manager/term/test/key.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -14,25 +10,25 @@ describe( 'TermQueryKey', () => {
 		test( 'should return a JSON string of the object', () => {
 			const key = TermQueryKey.stringify( { ok: true } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).toBe( '[["ok",true]]' );
 		} );
 
 		test( 'should omit default post query parameters', () => {
 			const key = TermQueryKey.stringify( { ok: true, search: '' } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).toBe( '[["ok",true]]' );
 		} );
 
 		test( 'should omit null query values', () => {
 			const key = TermQueryKey.stringify( { ok: true, search: null } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).toBe( '[["ok",true]]' );
 		} );
 
 		test( 'should omit undefined query values', () => {
 			const key = TermQueryKey.stringify( { ok: true, search: undefined } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).toBe( '[["ok",true]]' );
 		} );
 	} );
 
@@ -40,19 +36,19 @@ describe( 'TermQueryKey', () => {
 		test( 'should return an object of the JSON string', () => {
 			const query = TermQueryKey.parse( '[["ok",true]]' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 
 		test( 'should omit default post query parameters', () => {
 			const query = TermQueryKey.parse( '[["ok",true],["search",""]]' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 
 		test( 'should omit null query values', () => {
 			const query = TermQueryKey.parse( '[["ok",true],["search",null]]' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 	} );
 } );

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -38,15 +34,15 @@ describe( 'QueryManager', () => {
 				},
 			} );
 
-			expect( manager.getItems() ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
-			expect( manager.getItems( {} ) ).to.eql( [ { ID: 152 } ] );
+			expect( manager.getItems() ).toEqual( [ { ID: 144 }, { ID: 152 } ] );
+			expect( manager.getItems( {} ) ).toEqual( [ { ID: 152 } ] );
 		} );
 
 		test( 'should allow customization of item key', () => {
 			manager = new QueryManager( null, { itemKey: 'name' } );
 			manager = manager.receive( { name: 'foo' } );
 
-			expect( manager.data.items ).to.have.keys( [ 'foo' ] );
+			expect( manager.data.items ).toHaveProperty( 'foo' );
 		} );
 	} );
 
@@ -54,50 +50,50 @@ describe( 'QueryManager', () => {
 		test( 'should return the revised item by default', () => {
 			const merged = QueryManager.mergeItem( { ID: 144 }, { ID: 152 } );
 
-			expect( merged ).to.eql( { ID: 152 } );
+			expect( merged ).toEqual( { ID: 152 } );
 		} );
 
 		test( 'should return a merged item when patching', () => {
 			const merged = QueryManager.mergeItem( { ID: 144 }, { changed: true }, true );
 
-			expect( merged ).to.eql( { ID: 144, changed: true } );
+			expect( merged ).toEqual( { ID: 144, changed: true } );
 		} );
 
 		test( 'should not mutate the original copy', () => {
 			const original = Object.freeze( { ID: 144 } );
 			const merged = QueryManager.mergeItem( original, { changed: true }, true );
 
-			expect( merged ).to.not.equal( original );
+			expect( merged ).not.toBe( original );
 		} );
 
 		test( 'should return undefined if revised item includes delete key and patching', () => {
 			const merged = QueryManager.mergeItem( { ID: 144 }, { [ DELETE_PATCH_KEY ]: true }, true );
 
-			expect( merged ).to.be.undefined;
+			expect( merged ).toBeUndefined();
 		} );
 	} );
 
 	describe( '#matches()', () => {
 		test( 'should return false if item is not truthy', () => {
-			expect( QueryManager.matches() ).to.be.false;
+			expect( QueryManager.matches() ).toBe( false );
 		} );
 
 		test( 'should return true if item is truthy', () => {
-			expect( QueryManager.matches( {}, {} ) ).to.be.true;
+			expect( QueryManager.matches( {}, {} ) ).toBe( true );
 		} );
 	} );
 
 	describe( '#compare()', () => {
 		test( 'should return 0 for equal items', () => {
-			expect( QueryManager.compare( {}, 40, 40 ) ).to.equal( 0 );
+			expect( QueryManager.compare( {}, 40, 40 ) ).toBe( 0 );
 		} );
 
 		test( 'should return a number less than zero if the first argument is larger', () => {
-			expect( QueryManager.compare( {}, 50, 40 ) ).to.be.lt( 0 );
+			expect( QueryManager.compare( {}, 50, 40 ) ).toBeLessThan( 0 );
 		} );
 
 		test( 'should return a number greater than zero if the first argument is smaller', () => {
-			expect( QueryManager.compare( {}, 30, 40 ) ).to.be.gt( 0 );
+			expect( QueryManager.compare( {}, 30, 40 ) ).toBeGreaterThan( 0 );
 		} );
 	} );
 
@@ -106,7 +102,7 @@ describe( 'QueryManager', () => {
 			const item = { ID: 144 };
 			manager = manager.receive( item );
 
-			expect( manager.getItem( 144 ) ).to.equal( item );
+			expect( manager.getItem( 144 ) ).toBe( item );
 		} );
 	} );
 
@@ -115,20 +111,20 @@ describe( 'QueryManager', () => {
 			manager = manager.receive( { ID: 144 } );
 			manager = manager.receive( { ID: 152 }, { query: {} } );
 
-			expect( manager.getItems() ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
+			expect( manager.getItems() ).toEqual( [ { ID: 144 }, { ID: 152 } ] );
 		} );
 
 		test( 'should return items specific to query', () => {
 			manager = manager.receive( { ID: 144 } );
 			manager = manager.receive( { ID: 152 }, { query: {} } );
 
-			expect( manager.getItems( {} ) ).to.eql( [ { ID: 152 } ] );
+			expect( manager.getItems( {} ) ).toEqual( [ { ID: 152 } ] );
 		} );
 
 		test( 'should return null if query is unknown', () => {
 			manager = manager.receive( { ID: 144 } );
 
-			expect( manager.getItems( {} ) ).to.be.null;
+			expect( manager.getItems( {} ) ).toBeNull();
 		} );
 	} );
 
@@ -136,19 +132,19 @@ describe( 'QueryManager', () => {
 		test( 'should return null if the query is unknown', () => {
 			manager = manager.receive( { ID: 144 } );
 
-			expect( manager.getFound( {} ) ).to.be.null;
+			expect( manager.getFound( {} ) ).toBeNull();
 		} );
 
 		test( 'should return null if the query is known, but found was not provided', () => {
 			manager = manager.receive( { ID: 144 }, { query: {} } );
 
-			expect( manager.getFound( {} ) ).to.be.null;
+			expect( manager.getFound( {} ) ).toBeNull();
 		} );
 
 		test( 'should return the found count associated with a query', () => {
 			manager = manager.receive( { ID: 144 }, { query: {}, found: 1 } );
 
-			expect( manager.getFound( {} ) ).to.equal( 1 );
+			expect( manager.getFound( {} ) ).toBe( 1 );
 		} );
 	} );
 
@@ -157,16 +153,16 @@ describe( 'QueryManager', () => {
 			manager = manager.receive( { ID: 144 } );
 			const newManager = manager.removeItem( 144 );
 
-			expect( manager ).to.not.equal( newManager );
-			expect( manager.getItems() ).to.eql( [ { ID: 144 } ] );
-			expect( newManager.getItems() ).to.eql( [] );
+			expect( manager ).not.toBe( newManager );
+			expect( manager.getItems() ).toEqual( [ { ID: 144 } ] );
+			expect( newManager.getItems() ).toEqual( [] );
 		} );
 
 		test( 'should return the same instance if no items removed', () => {
 			manager = manager.receive( { ID: 144 } );
 			const newManager = manager.removeItem( 152 );
 
-			expect( manager ).to.equal( newManager );
+			expect( manager ).toBe( newManager );
 		} );
 	} );
 
@@ -175,16 +171,16 @@ describe( 'QueryManager', () => {
 			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ] );
 			const newManager = manager.removeItems( [ 144, 152 ] );
 
-			expect( manager ).to.not.equal( newManager );
-			expect( manager.getItems() ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
-			expect( newManager.getItems() ).to.eql( [] );
+			expect( manager ).not.toBe( newManager );
+			expect( manager.getItems() ).toEqual( [ { ID: 144 }, { ID: 152 } ] );
+			expect( newManager.getItems() ).toEqual( [] );
 		} );
 
 		test( 'should return the same instance if no items removed', () => {
 			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ] );
 			const newManager = manager.removeItems( [ 160, 168 ] );
 
-			expect( manager ).to.equal( newManager );
+			expect( manager ).toBe( newManager );
 		} );
 	} );
 
@@ -192,82 +188,82 @@ describe( 'QueryManager', () => {
 		test( 'should receive an item', () => {
 			manager = manager.receive( { ID: 144 } );
 
-			expect( manager.getItems() ).to.eql( [ { ID: 144 } ] );
+			expect( manager.getItems() ).toEqual( [ { ID: 144 } ] );
 		} );
 
 		test( 'should receive an array of items', () => {
 			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ] );
 
-			expect( manager.getItems() ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
+			expect( manager.getItems() ).toEqual( [ { ID: 144 }, { ID: 152 } ] );
 		} );
 
 		test( 'should return a new instance on changes', () => {
 			const newManager = manager.receive( { ID: 144 } );
 
-			expect( manager ).to.not.equal( newManager );
+			expect( manager ).not.toBe( newManager );
 		} );
 
 		test( 'should return a new instance when receiving a different query result', () => {
 			manager = manager.receive( { ID: 144 } );
 			const newManager = manager.receive( { ID: 144 }, { query: { changed: true } } );
 
-			expect( manager ).to.not.equal( newManager );
+			expect( manager ).not.toBe( newManager );
 		} );
 
 		test( 'should return a new instance when receiving only items', () => {
 			manager = manager.receive( { ID: 144 } );
 			const newManager = manager.receive( { ID: 152 } );
 
-			expect( manager ).to.not.equal( newManager );
+			expect( manager ).not.toBe( newManager );
 		} );
 
 		test( 'should return the same instance if no items received', () => {
 			manager = manager.receive( { ID: 144 } );
 			const newManager = manager.receive( [] );
 
-			expect( manager ).to.equal( newManager );
+			expect( manager ).toBe( newManager );
 		} );
 
 		test( 'should return the same instance if no changes', () => {
 			manager = manager.receive( { ID: 144 } );
 			const newManager = manager.receive( { ID: 144 } );
 
-			expect( manager ).to.equal( newManager );
+			expect( manager ).toBe( newManager );
 		} );
 
 		test( 'should return the same instance only order changes, but not associated with query', () => {
 			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ] );
 			const newManager = manager.receive( [ { ID: 152 }, { ID: 144 } ] );
 
-			expect( manager ).to.equal( newManager );
+			expect( manager ).toBe( newManager );
 		} );
 
 		test( 'should return a new instance when receiving an existing query changes its results', () => {
 			manager = manager.receive( { ID: 144 }, { query: {} } );
 			const newManager = manager.receive( { ID: 152 }, { query: {} } );
 
-			expect( manager ).to.not.equal( newManager );
+			expect( manager ).not.toBe( newManager );
 		} );
 
 		test( 'should return a new instance when receiving an existing query changes its order', () => {
 			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ], { query: {} } );
 			const newManager = manager.receive( [ { ID: 152 }, { ID: 144 } ], { query: {} } );
 
-			expect( manager ).to.not.equal( newManager );
+			expect( manager ).not.toBe( newManager );
 		} );
 
 		test( 'should return the same instance when receiving an existing query with no changes', () => {
 			manager = manager.receive( { ID: 144 }, { query: {} } );
 			const newManager = manager.receive( { ID: 144 }, { query: {} } );
 
-			expect( manager ).to.equal( newManager );
+			expect( manager ).toBe( newManager );
 		} );
 
 		test( 'should return the same instance when receiving an existing query with no changes and merging', () => {
 			manager = manager.receive( { ID: 144 }, { query: {}, mergeQuery: true } );
 			const newManager = manager.receive( { ID: 144 }, { query: {}, mergeQuery: true } );
 
-			expect( manager ).to.equal( newManager );
+			expect( manager ).toBe( newManager );
 		} );
 
 		test( 'should omit an item that returns undefined from #mergeItem()', () => {
@@ -275,8 +271,8 @@ describe( 'QueryManager', () => {
 			sandbox.stub( QueryManager, 'mergeItem' ).returns( undefined );
 			const newManager = manager.receive( { ID: 144 } );
 
-			expect( manager.getItems() ).to.eql( [ { ID: 144 } ] );
-			expect( newManager.getItems() ).to.eql( [] );
+			expect( manager.getItems() ).toEqual( [ { ID: 144 } ] );
+			expect( newManager.getItems() ).toEqual( [] );
 		} );
 
 		test( "should do nothing if #mergeItem() returns undefined but the item didn't exist", () => {
@@ -284,48 +280,48 @@ describe( 'QueryManager', () => {
 			sandbox.stub( QueryManager, 'mergeItem' ).returns( undefined );
 			const newManager = manager.receive( { ID: 144 } );
 
-			expect( manager ).to.equal( newManager );
+			expect( manager ).toBe( newManager );
 		} );
 
 		test( 'should replace a received item when key already exists', () => {
 			manager = manager.receive( { ID: 144, exists: true } );
 			manager = manager.receive( { ID: 144, changed: true } );
 
-			expect( manager.getItems() ).to.eql( [ { ID: 144, changed: true } ] );
+			expect( manager.getItems() ).toEqual( [ { ID: 144, changed: true } ] );
 		} );
 
 		test( 'should patch a received patch item when key already exists', () => {
 			manager = manager.receive( { ID: 144, exists: true } );
 			manager = manager.receive( { ID: 144, changed: true }, { patch: true } );
 
-			expect( manager.getItems() ).to.eql( [ { ID: 144, exists: true, changed: true } ] );
+			expect( manager.getItems() ).toEqual( [ { ID: 144, exists: true, changed: true } ] );
 		} );
 
 		test( 'should track a query set', () => {
 			manager = manager.receive( { ID: 144 }, { query: {} } );
 
-			expect( manager.getItems( {} ) ).to.eql( [ { ID: 144 } ] );
+			expect( manager.getItems( {} ) ).toEqual( [ { ID: 144 } ] );
 		} );
 
 		test( 'should replace the query set when a query updates', () => {
 			manager = manager.receive( { ID: 144 }, { query: {} } );
 			manager = manager.receive( { ID: 152 }, { query: {} } );
 
-			expect( manager.getItems( {} ) ).to.eql( [ { ID: 152 } ] );
+			expect( manager.getItems( {} ) ).toEqual( [ { ID: 152 } ] );
 		} );
 
 		test( 'should merge received items into query set if mergeQuery option specified', () => {
 			manager = manager.receive( { ID: 144 }, { query: {}, mergeQuery: true } );
 			manager = manager.receive( { ID: 152 }, { query: {}, mergeQuery: true } );
 
-			expect( manager.getItems( {} ) ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
+			expect( manager.getItems( {} ) ).toEqual( [ { ID: 144 }, { ID: 152 } ] );
 		} );
 
 		test( 'should de-dupe received items into query set when merging', () => {
 			manager = manager.receive( { ID: 144 }, { query: {}, mergeQuery: true } );
 			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ], { query: {}, mergeQuery: true } );
 
-			expect( manager.getItems( {} ) ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
+			expect( manager.getItems( {} ) ).toEqual( [ { ID: 144 }, { ID: 152 } ] );
 		} );
 
 		test( 'should remove a tracked query item when it no longer matches', () => {
@@ -333,17 +329,17 @@ describe( 'QueryManager', () => {
 			sandbox.stub( QueryManager, 'matches' ).returns( false );
 			const newManager = manager.receive( { ID: 144, changed: true } );
 
-			expect( manager.getItems() ).to.eql( [ { ID: 144 } ] );
-			expect( manager.getItems( {} ) ).to.eql( [ { ID: 144 } ] );
-			expect( newManager.getItems() ).to.eql( [ { ID: 144, changed: true } ] );
-			expect( newManager.getItems( {} ) ).to.eql( [] );
+			expect( manager.getItems() ).toEqual( [ { ID: 144 } ] );
+			expect( manager.getItems( {} ) ).toEqual( [ { ID: 144 } ] );
+			expect( newManager.getItems() ).toEqual( [ { ID: 144, changed: true } ] );
+			expect( newManager.getItems( {} ) ).toEqual( [] );
 		} );
 
 		test( 'should be order sensitive to tracked query items', () => {
 			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ], { query: {} } );
 			manager = manager.receive( [ { ID: 152 }, { ID: 144 } ], { query: {} } );
 
-			expect( manager.getItems( {} ) ).to.eql( [ { ID: 152 }, { ID: 144 } ] );
+			expect( manager.getItems( {} ) ).toEqual( [ { ID: 152 }, { ID: 144 } ] );
 		} );
 
 		test( 'should remove a tracked query item when it is omitted from items', () => {
@@ -351,18 +347,18 @@ describe( 'QueryManager', () => {
 			sandbox.stub( QueryManager, 'mergeItem' ).returns( undefined );
 			const newManager = manager.receive( { ID: 144 } );
 
-			expect( manager.getItems() ).to.eql( [ { ID: 144 } ] );
-			expect( manager.getItems( {} ) ).to.eql( [ { ID: 144 } ] );
-			expect( newManager.getItems() ).to.eql( [] );
-			expect( newManager.getItems( {} ) ).to.eql( [] );
+			expect( manager.getItems() ).toEqual( [ { ID: 144 } ] );
+			expect( manager.getItems( {} ) ).toEqual( [ { ID: 144 } ] );
+			expect( newManager.getItems() ).toEqual( [] );
+			expect( newManager.getItems( {} ) ).toEqual( [] );
 		} );
 
 		test( 'should track an item that previous did not match', () => {
 			manager = manager.receive( [], { query: {} } );
 			manager = manager.receive( { ID: 144 } );
 
-			expect( manager.getItems() ).to.eql( [ { ID: 144 } ] );
-			expect( manager.getItems( {} ) ).to.eql( [ { ID: 144 } ] );
+			expect( manager.getItems() ).toEqual( [ { ID: 144 } ] );
+			expect( manager.getItems( {} ) ).toEqual( [ { ID: 144 } ] );
 		} );
 
 		test( 'should compare items appended to query set', () => {
@@ -370,50 +366,50 @@ describe( 'QueryManager', () => {
 			sandbox.stub( QueryManager, 'compare', ( query, a, b ) => a.ID - b.ID );
 			manager = manager.receive( { ID: 150 } );
 
-			expect( manager.getItems( {} ) ).to.eql( [ { ID: 140 }, { ID: 150 }, { ID: 160 } ] );
+			expect( manager.getItems( {} ) ).toEqual( [ { ID: 140 }, { ID: 150 }, { ID: 160 } ] );
 		} );
 
 		test( 'should accept an optional total found count', () => {
 			manager = manager.receive( { ID: 144 }, { query: {}, found: 1 } );
 
-			expect( manager.getFound( {} ) ).to.equal( 1 );
+			expect( manager.getFound( {} ) ).toBe( 1 );
 		} );
 
 		test( 'should return a new instance when associating found with a query', () => {
 			manager = manager.receive( { ID: 144 }, { query: {} } );
 			const newManager = manager.receive( { ID: 144 }, { query: {}, found: 1 } );
 
-			expect( manager ).to.not.equal( newManager );
+			expect( manager ).not.toBe( newManager );
 		} );
 
 		test( 'should return the same instance when found has not changed', () => {
 			manager = manager.receive( { ID: 144 }, { query: {}, found: 1 } );
 			const newManager = manager.receive( { ID: 144 }, { query: {}, found: 1 } );
 
-			expect( manager ).to.equal( newManager );
+			expect( manager ).toBe( newManager );
 		} );
 
 		test( 'should return a new instance when changing found for a query', () => {
 			manager = manager.receive( { ID: 144 }, { query: {}, found: 1 } );
 			const newManager = manager.receive( { ID: 144 }, { query: {}, found: 2 } );
 
-			expect( manager ).to.not.equal( newManager );
+			expect( manager ).not.toBe( newManager );
 		} );
 
 		test( 'should not replace the previous found count if omitted in next received query', () => {
 			manager = manager.receive( { ID: 144 }, { query: {}, found: 1 } );
 			manager = manager.receive( { ID: 144, changed: true }, { query: {} } );
 
-			expect( manager.getItems( {} ) ).to.eql( [ { ID: 144, changed: true } ] );
-			expect( manager.getFound( {} ) ).to.equal( 1 );
+			expect( manager.getItems( {} ) ).toEqual( [ { ID: 144, changed: true } ] );
+			expect( manager.getFound( {} ) ).toBe( 1 );
 		} );
 
 		test( 'should increment found count if adding a matched item', () => {
 			manager = manager.receive( [], { query: {}, found: 0 } );
 			const newManager = manager.receive( { ID: 144 } );
 
-			expect( manager.getFound( {} ) ).to.equal( 0 );
-			expect( newManager.getFound( {} ) ).to.equal( 1 );
+			expect( manager.getFound( {} ) ).toBe( 0 );
+			expect( newManager.getFound( {} ) ).toBe( 1 );
 		} );
 
 		test( 'should decrement found count if removing an unmatched item', () => {
@@ -421,17 +417,17 @@ describe( 'QueryManager', () => {
 			sandbox.stub( QueryManager, 'matches' ).returns( false );
 			const newManager = manager.receive( { ID: 144, changed: true } );
 
-			expect( manager.getFound( {} ) ).to.equal( 1 );
-			expect( newManager.getFound( {} ) ).to.equal( 0 );
+			expect( manager.getFound( {} ) ).toBe( 1 );
+			expect( newManager.getFound( {} ) ).toBe( 0 );
 		} );
 
 		test( 'should not change found count if merging items into existing query', () => {
 			manager = manager.receive( { ID: 144 }, { query: {}, found: 2 } );
 			const newManager = manager.receive( { ID: 152 }, { query: {}, mergeQuery: true } );
 
-			expect( manager.getFound( {} ) ).to.equal( 2 );
-			expect( newManager.getFound( {} ) ).to.equal( 2 );
-			expect( newManager.getItems( {} ) ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
+			expect( manager.getFound( {} ) ).toBe( 2 );
+			expect( newManager.getFound( {} ) ).toBe( 2 );
+			expect( newManager.getItems( {} ) ).toEqual( [ { ID: 144 }, { ID: 152 } ] );
 		} );
 
 		it( 'should sort items when merging queries', () => {
@@ -444,7 +440,7 @@ describe( 'QueryManager', () => {
 					} ) )
 			);
 			// console.log( manager.data.queries );
-			expect( manager.getItems( {} ) ).to.eql( [ { ID: 2 }, { ID: 3 }, { ID: 4 } ] );
+			expect( manager.getItems( {} ) ).toEqual( [ { ID: 2 }, { ID: 3 }, { ID: 4 } ] );
 		} );
 
 		it( 'should sort when extended using subclassed static compare', () => {
@@ -461,17 +457,17 @@ describe( 'QueryManager', () => {
 					} ) )
 			);
 			// console.log( sortingManager.data.queries );
-			expect( sortingManager.getItems( {} ) ).to.eql( [ { ID: 2 }, { ID: 3 }, { ID: 4 } ] );
+			expect( sortingManager.getItems( {} ) ).toEqual( [ { ID: 2 }, { ID: 3 }, { ID: 4 } ] );
 		} );
 	} );
 
 	describe( '.QueryKey', () => {
 		test( 'should include a .stringify() method', () => {
-			expect( QueryManager.QueryKey.stringify ).to.be.a( 'function' );
+			expect( typeof QueryManager.QueryKey.stringify ).toBe( 'function' );
 		} );
 
 		test( 'should include a .parse() method', () => {
-			expect( QueryManager.QueryKey.parse ).to.be.a( 'function' );
+			expect( typeof QueryManager.QueryKey.parse ).toBe( 'function' );
 		} );
 	} );
 } );

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -4,19 +4,13 @@
  * Internal dependencies
  */
 import QueryManager, { DELETE_PATCH_KEY } from '../';
-import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'QueryManager', () => {
-	let sandbox, manager;
-
-	useSandbox( _sandbox => ( sandbox = _sandbox ) );
+	let manager;
 
 	beforeEach( () => {
 		manager = new QueryManager();
-	} );
-
-	afterEach( () => {
-		sandbox.restore();
+		jest.restoreAllMocks();
 	} );
 
 	describe( '#constructor()', () => {
@@ -268,7 +262,7 @@ describe( 'QueryManager', () => {
 
 		test( 'should omit an item that returns undefined from #mergeItem()', () => {
 			manager = manager.receive( { ID: 144 } );
-			sandbox.stub( QueryManager, 'mergeItem' ).returns( undefined );
+			jest.spyOn( QueryManager, 'mergeItem' ).mockImplementation( () => undefined );
 			const newManager = manager.receive( { ID: 144 } );
 
 			expect( manager.getItems() ).toEqual( [ { ID: 144 } ] );
@@ -277,7 +271,7 @@ describe( 'QueryManager', () => {
 
 		test( "should do nothing if #mergeItem() returns undefined but the item didn't exist", () => {
 			manager = manager.receive();
-			sandbox.stub( QueryManager, 'mergeItem' ).returns( undefined );
+			jest.spyOn( QueryManager, 'mergeItem' ).mockImplementation( () => undefined );
 			const newManager = manager.receive( { ID: 144 } );
 
 			expect( manager ).toBe( newManager );
@@ -326,7 +320,7 @@ describe( 'QueryManager', () => {
 
 		test( 'should remove a tracked query item when it no longer matches', () => {
 			manager = manager.receive( { ID: 144 }, { query: {} } );
-			sandbox.stub( QueryManager, 'matches' ).returns( false );
+			jest.spyOn( QueryManager, 'matches' ).mockImplementation( () => false );
 			const newManager = manager.receive( { ID: 144, changed: true } );
 
 			expect( manager.getItems() ).toEqual( [ { ID: 144 } ] );
@@ -344,7 +338,7 @@ describe( 'QueryManager', () => {
 
 		test( 'should remove a tracked query item when it is omitted from items', () => {
 			manager = manager.receive( { ID: 144 }, { query: {} } );
-			sandbox.stub( QueryManager, 'mergeItem' ).returns( undefined );
+			jest.spyOn( QueryManager, 'mergeItem' ).mockImplementation( () => undefined );
 			const newManager = manager.receive( { ID: 144 } );
 
 			expect( manager.getItems() ).toEqual( [ { ID: 144 } ] );
@@ -363,7 +357,7 @@ describe( 'QueryManager', () => {
 
 		test( 'should compare items appended to query set', () => {
 			manager = manager.receive( [ { ID: 140 }, { ID: 160 } ], { query: {} } );
-			sandbox.stub( QueryManager, 'compare', ( query, a, b ) => a.ID - b.ID );
+			jest.spyOn( QueryManager, 'compare' ).mockImplementation( ( query, a, b ) => a.ID - b.ID );
 			manager = manager.receive( { ID: 150 } );
 
 			expect( manager.getItems( {} ) ).toEqual( [ { ID: 140 }, { ID: 150 }, { ID: 160 } ] );
@@ -414,7 +408,7 @@ describe( 'QueryManager', () => {
 
 		test( 'should decrement found count if removing an unmatched item', () => {
 			manager = manager.receive( { ID: 144 }, { query: {}, found: 1 } );
-			sandbox.stub( QueryManager, 'matches' ).returns( false );
+			jest.spyOn( QueryManager, 'matches' ).mockImplementation( () => false );
 			const newManager = manager.receive( { ID: 144, changed: true } );
 
 			expect( manager.getFound( {} ) ).toBe( 1 );
@@ -431,7 +425,7 @@ describe( 'QueryManager', () => {
 		} );
 
 		it( 'should sort items when merging queries', () => {
-			sandbox.stub( QueryManager, 'compare', ( query, a, b ) => a.ID - b.ID );
+			jest.spyOn( QueryManager, 'compare' ).mockImplementation( ( query, a, b ) => a.ID - b.ID );
 			[ { ID: 4 }, { ID: 2 }, { ID: 3 } ].forEach(
 				item =>
 					( manager = manager.receive( item, {
@@ -439,7 +433,6 @@ describe( 'QueryManager', () => {
 						query: {},
 					} ) )
 			);
-			// console.log( manager.data.queries );
 			expect( manager.getItems( {} ) ).toEqual( [ { ID: 2 }, { ID: 3 }, { ID: 4 } ] );
 		} );
 
@@ -456,7 +449,6 @@ describe( 'QueryManager', () => {
 						query: {},
 					} ) )
 			);
-			// console.log( sortingManager.data.queries );
 			expect( sortingManager.getItems( {} ) ).toEqual( [ { ID: 2 }, { ID: 3 }, { ID: 4 } ] );
 		} );
 	} );

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -424,7 +424,7 @@ describe( 'QueryManager', () => {
 			expect( newManager.getItems( {} ) ).toEqual( [ { ID: 144 }, { ID: 152 } ] );
 		} );
 
-		it( 'should sort items when merging queries', () => {
+		test( 'should sort items when merging queries', () => {
 			jest.spyOn( QueryManager, 'compare' ).mockImplementation( ( query, a, b ) => a.ID - b.ID );
 			[ { ID: 4 }, { ID: 2 }, { ID: 3 } ].forEach(
 				item =>
@@ -436,7 +436,7 @@ describe( 'QueryManager', () => {
 			expect( manager.getItems( {} ) ).toEqual( [ { ID: 2 }, { ID: 3 }, { ID: 4 } ] );
 		} );
 
-		it( 'should sort when extended using subclassed static compare', () => {
+		test( 'should sort when extended using subclassed static compare', () => {
 			let sortingManager = new class extends QueryManager {
 				static compare( query, a, b ) {
 					return a.ID - b.ID;

--- a/client/lib/query-manager/test/key.js
+++ b/client/lib/query-manager/test/key.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -16,7 +15,7 @@ describe( 'QueryKey', () => {
 			const original = deepFreeze( { ok: true } );
 			const pruned = QueryKey.omit( original );
 
-			expect( pruned ).to.equal( original );
+			expect( pruned ).toBe( original );
 		} );
 
 		test( 'should omit values matching default query of extending class', () => {
@@ -26,7 +25,7 @@ describe( 'QueryKey', () => {
 
 			const pruned = QueryKeyWithDefaults.omit( { ok: true, foo: null } );
 
-			expect( pruned ).to.eql( { foo: null } );
+			expect( pruned ).toEqual( { foo: null } );
 		} );
 
 		test( 'should omit null values if configured by extending class', () => {
@@ -36,7 +35,7 @@ describe( 'QueryKey', () => {
 
 			const pruned = QueryKeyWithNullOmission.omit( { ok: true, foo: null } );
 
-			expect( pruned ).to.eql( { ok: true } );
+			expect( pruned ).toEqual( { ok: true } );
 		} );
 	} );
 
@@ -44,7 +43,7 @@ describe( 'QueryKey', () => {
 		test( 'should return a JSON string of the object', () => {
 			const key = QueryKey.stringify( { ok: true } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).toBe( '[["ok",true]]' );
 		} );
 
 		test( 'should prune by omission behavior', () => {
@@ -55,14 +54,14 @@ describe( 'QueryKey', () => {
 
 			const key = QueryKeyWithOmission.stringify( { ok: true, foo: null } );
 
-			expect( key ).to.equal( '[]' );
+			expect( key ).toBe( '[]' );
 		} );
 
 		test( 'should return the same string for two objects with different property creation order', () => {
 			const original = QueryKey.stringify( { a: 1, b: 2 } );
 			const reversed = QueryKey.stringify( { b: 2, a: 1 } );
 
-			expect( original ).to.equal( reversed );
+			expect( original ).toBe( reversed );
 		} );
 	} );
 
@@ -70,7 +69,7 @@ describe( 'QueryKey', () => {
 		test( 'should return an object of the JSON string', () => {
 			const query = QueryKey.parse( '[["ok",true]]' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 
 		test( 'should prune by omission behavior', () => {
@@ -81,7 +80,7 @@ describe( 'QueryKey', () => {
 
 			const query = QueryKeyWithOmission.parse( '[["ok",true],["foo",null]]' );
 
-			expect( query ).to.eql( {} );
+			expect( query ).toEqual( {} );
 		} );
 	} );
 } );

--- a/client/lib/query-manager/theme/test/index.js
+++ b/client/lib/query-manager/theme/test/index.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -28,7 +24,7 @@ describe( 'ThemeQueryManager', () => {
 			const keys = [ ...originalKeys ];
 
 			ThemeQueryManager.sort( keys );
-			expect( keys ).to.deep.equal( originalKeys );
+			expect( keys ).toEqual( originalKeys );
 		} );
 	} );
 } );

--- a/client/lib/query-manager/theme/test/key.js
+++ b/client/lib/query-manager/theme/test/key.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -14,25 +10,25 @@ describe( 'ThemeQueryKey', () => {
 		test( 'should return a JSON string of the object', () => {
 			const key = ThemeQueryKey.stringify( { ok: true } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).toBe( '[["ok",true]]' );
 		} );
 
 		test( 'should omit default theme query parameters', () => {
 			const key = ThemeQueryKey.stringify( { ok: true, tier: '' } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).toBe( '[["ok",true]]' );
 		} );
 
 		test( 'should omit null query values', () => {
 			const key = ThemeQueryKey.stringify( { ok: true, search: null } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).toBe( '[["ok",true]]' );
 		} );
 
 		test( 'should omit undefined query values', () => {
 			const key = ThemeQueryKey.stringify( { ok: true, search: undefined } );
 
-			expect( key ).to.equal( '[["ok",true]]' );
+			expect( key ).toBe( '[["ok",true]]' );
 		} );
 	} );
 
@@ -40,19 +36,19 @@ describe( 'ThemeQueryKey', () => {
 		test( 'should return an object of the JSON string', () => {
 			const query = ThemeQueryKey.parse( '[["ok",true]]' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 
 		test( 'should omit default theme query parameters', () => {
 			const query = ThemeQueryKey.parse( '[["ok",true],["tier",""]]' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 
 		test( 'should omit null query values', () => {
 			const query = ThemeQueryKey.parse( '[["ok",true],["search",null]]' );
 
-			expect( query ).to.eql( { ok: true } );
+			expect( query ).toEqual( { ok: true } );
 		} );
 	} );
 } );

--- a/client/state/themes/test/reducer.js
+++ b/client/state/themes/test/reducer.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -43,7 +42,6 @@ import {
 	SERIALIZE,
 	DESERIALIZE,
 } from 'state/action-types';
-import { useSandbox } from 'test/helpers/use-sinon';
 
 const twentysixteen = {
 	id: 'twentysixteen',
@@ -68,36 +66,34 @@ const mood = {
 };
 
 describe( 'reducer', () => {
-	useSandbox( sandbox => {
-		sandbox.stub( console, 'warn' );
-	} );
-
 	test( 'should include expected keys in return value', () => {
-		expect( reducer( undefined, {} ) ).to.have.keys( [
-			'queries',
-			'queryRequests',
-			'queryRequestErrors',
-			'lastQuery',
-			'themeInstalls',
-			'themeRequests',
-			'themeRequestErrors',
-			'activeThemes',
-			'activeThemeRequests',
-			'activationRequests',
-			'completedActivationRequests',
-			'themesUI',
-			'uploadTheme',
-			'themePreviewOptions',
-			'themePreviewVisibility',
-			'themeFilters',
-		] );
+		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(
+			expect.arrayContaining( [
+				'activationRequests',
+				'activeThemeRequests',
+				'activeThemes',
+				'completedActivationRequests',
+				'lastQuery',
+				'queries',
+				'queryRequestErrors',
+				'queryRequests',
+				'themeFilters',
+				'themeInstalls',
+				'themePreviewOptions',
+				'themePreviewVisibility',
+				'themeRequestErrors',
+				'themeRequests',
+				'themesUI',
+				'uploadTheme',
+			] )
+		);
 	} );
 
 	describe( '#queryRequests()', () => {
 		test( 'should default to an empty object', () => {
 			const state = queryRequests( undefined, {} );
 
-			expect( state ).to.deep.equal( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		// TODO: Delete test? no site-specific search?
@@ -108,7 +104,7 @@ describe( 'reducer', () => {
 				query: { search: 'Hello' },
 			} );
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				'2916284:{"search":"Hello"}': true,
 			} );
 		} );
@@ -119,7 +115,7 @@ describe( 'reducer', () => {
 				query: { search: 'Hello' },
 			} );
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				'{"search":"Hello"}': true,
 			} );
 		} );
@@ -135,7 +131,7 @@ describe( 'reducer', () => {
 				query: { search: 'Hello W' },
 			} );
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				'2916284:{"search":"Hello"}': true,
 				'2916284:{"search":"Hello W"}': true,
 			} );
@@ -150,7 +146,7 @@ describe( 'reducer', () => {
 				themes: [ mood ],
 			} );
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				'2916284:{"search":"Mood"}': false,
 			} );
 		} );
@@ -163,7 +159,7 @@ describe( 'reducer', () => {
 				error: new Error(),
 			} );
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				'2916284:{"search":"Hello"}': false,
 			} );
 		} );
@@ -173,7 +169,7 @@ describe( 'reducer', () => {
 		test( 'should default to an empty object', () => {
 			const state = queryRequestErrors( undefined, {} );
 
-			expect( state ).to.deep.equal( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should create empty mapping on success if previous state was empty', () => {
@@ -183,7 +179,7 @@ describe( 'reducer', () => {
 				query: { search: 'Twenty' },
 			} );
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: {},
 			} );
 		} );
@@ -196,7 +192,7 @@ describe( 'reducer', () => {
 				error: 'Request error',
 			} );
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: {
 					'2916284:{"search":"Twenty"}': 'Request error',
 				},
@@ -217,7 +213,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: {},
 			} );
 		} );
@@ -237,7 +233,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: {
 					'2916284:{"blerch":"Twenty"}': 'Invalid query!',
 					'2916284:{"search":"Twenty"}': 'System error',
@@ -250,7 +246,7 @@ describe( 'reducer', () => {
 		test( 'should default to an empty object', () => {
 			const state = queries( undefined, {} );
 
-			expect( state ).to.deep.equal( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should track theme query request success', () => {
@@ -262,9 +258,9 @@ describe( 'reducer', () => {
 				themes: [ mood ],
 			} );
 
-			expect( state ).to.have.keys( [ '2916284' ] );
-			expect( state[ 2916284 ] ).to.be.an.instanceof( ThemeQueryManager );
-			expect( state[ 2916284 ].getItems( { search: 'Mood' } ) ).to.deep.equal( [ mood ] );
+			expect( state ).toHaveProperty( '2916284' );
+			expect( state[ 2916284 ] ).toBeInstanceOf( ThemeQueryManager );
+			expect( state[ 2916284 ].getItems( { search: 'Mood' } ) ).toEqual( [ mood ] );
 		} );
 
 		test( 'should accumulate query request success', () => {
@@ -285,10 +281,10 @@ describe( 'reducer', () => {
 				themes: [ twentysixteen ],
 			} );
 
-			expect( state ).to.have.keys( [ '2916284' ] );
-			expect( state[ 2916284 ] ).to.be.an.instanceof( ThemeQueryManager );
-			expect( state[ 2916284 ].getItems( { search: 'Twenty' } ) ).to.have.length( 1 );
-			expect( state[ 2916284 ].getItems( { search: 'Twenty Six' } ) ).to.have.length( 1 );
+			expect( state ).toHaveProperty( '2916284' );
+			expect( state[ 2916284 ] ).toBeInstanceOf( ThemeQueryManager );
+			expect( state[ 2916284 ].getItems( { search: 'Twenty' } ) ).toHaveLength( 1 );
+			expect( state[ 2916284 ].getItems( { search: 'Twenty Six' } ) ).toHaveLength( 1 );
 		} );
 
 		test( 'should return the same state if successful request has no changes', () => {
@@ -302,7 +298,7 @@ describe( 'reducer', () => {
 			const original = deepFreeze( queries( deepFreeze( {} ), action ) );
 			const state = queries( original, action );
 
-			expect( state ).to.equal( original );
+			expect( state ).toBe( original );
 		} );
 
 		test( 'should persist state', () => {
@@ -321,7 +317,7 @@ describe( 'reducer', () => {
 			// _timestamp is not part of the data
 			delete state._timestamp;
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: {
 					data: {
 						items: {
@@ -363,7 +359,7 @@ describe( 'reducer', () => {
 
 			const state = queries( original, { type: DESERIALIZE } );
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: new ThemeQueryManager(
 					{
 						items: {
@@ -382,13 +378,17 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should not load invalid persisted state', () => {
+			jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
 			const original = deepFreeze( {
 				2916284: '{INVALID',
 			} );
 
 			const state = queries( original, { type: DESERIALIZE } );
 
-			expect( state ).to.deep.equal( {} );
+			expect( state ).toEqual( {} );
+
+			// eslint-disable-next-line no-console
+			console.warn.mockReset();
 		} );
 	} );
 
@@ -396,7 +396,7 @@ describe( 'reducer', () => {
 		test( 'should default to an empty object', () => {
 			const state = lastQuery( undefined, {} );
 
-			expect( state ).to.deep.equal( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should store last query', () => {
@@ -406,8 +406,8 @@ describe( 'reducer', () => {
 				query: { search: 'Sixteen' },
 			} );
 
-			expect( state ).to.have.keys( [ '2916284' ] );
-			expect( state ).to.deep.equal( {
+			expect( state ).toHaveProperty( '2916284' );
+			expect( state ).toEqual( {
 				2916284: {
 					search: 'Sixteen',
 				},
@@ -428,8 +428,8 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.have.keys( [ '2916284' ] );
-			expect( state ).to.deep.equal( {
+			expect( state ).toHaveProperty( '2916284' );
+			expect( state ).toEqual( {
 				2916284: {
 					search: 'orange color',
 				},
@@ -441,7 +441,7 @@ describe( 'reducer', () => {
 		test( 'should default to an empty object', () => {
 			const state = themeRequests( undefined, {} );
 
-			expect( state ).to.deep.equal( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should map site ID, theme ID to true value if request in progress', () => {
@@ -451,7 +451,7 @@ describe( 'reducer', () => {
 				themeId: 841,
 			} );
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: {
 					841: true,
 				},
@@ -472,7 +472,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: {
 					841: true,
 					413: true,
@@ -494,7 +494,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: {
 					841: false,
 				},
@@ -515,7 +515,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: {
 					841: false,
 				},
@@ -541,7 +541,7 @@ describe( 'reducer', () => {
 		test( 'should default to an empty object', () => {
 			const state = themeRequestErrors( undefined, {} );
 
-			expect( state ).to.deep.equal( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should create empyt mapping on success if previous state was empty', () => {
@@ -551,7 +551,7 @@ describe( 'reducer', () => {
 				themeId: 'twentysixteen',
 			} );
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: {},
 			} );
 		} );
@@ -564,7 +564,7 @@ describe( 'reducer', () => {
 				error: 'Request error',
 			} );
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: {
 					vivaro: 'Request error',
 				},
@@ -585,7 +585,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: {},
 			} );
 		} );
@@ -605,7 +605,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: {
 					twentysixteennnnn: 'No such theme!',
 					twentysixteen: 'System error',
@@ -618,7 +618,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.deep.equal( themeError );
+			expect( state ).toEqual( themeError );
 		} );
 
 		test( 'loads persisted state', () => {
@@ -626,7 +626,7 @@ describe( 'reducer', () => {
 				type: DESERIALIZE,
 			} );
 
-			expect( state ).to.deep.equal( themeError );
+			expect( state ).toEqual( themeError );
 		} );
 	} );
 
@@ -634,7 +634,7 @@ describe( 'reducer', () => {
 		test( 'should default to an empty object', () => {
 			const state = activeThemes( undefined, {} );
 
-			expect( state ).to.deep.equal( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should track active theme request success', () => {
@@ -652,8 +652,8 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			expect( state ).to.have.keys( [ '2211667' ] );
-			expect( state ).to.deep.equal( { 2211667: 'rebalance' } );
+			expect( state ).toHaveProperty( '2211667' );
+			expect( state ).toEqual( { 2211667: 'rebalance' } );
 		} );
 
 		test( 'should track active theme request success and overwrite old theme', () => {
@@ -671,8 +671,8 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			expect( state ).to.have.keys( [ '2211667' ] );
-			expect( state ).to.deep.equal( { 2211667: 'twentysixteen' } );
+			expect( state ).toHaveProperty( '2211667' );
+			expect( state ).toEqual( { 2211667: 'twentysixteen' } );
 		} );
 
 		test( 'should track theme activate request success', () => {
@@ -682,14 +682,14 @@ describe( 'reducer', () => {
 				siteId: 2211888,
 			} );
 
-			expect( state ).to.have.keys( [ '2211888' ] );
-			expect( state ).to.deep.equal( { 2211888: 'twentysixteen' } );
+			expect( state ).toHaveProperty( '2211888' );
+			expect( state ).toEqual( { 2211888: 'twentysixteen' } );
 		} );
 
 		test( 'should persist state', () => {
 			const state = activeThemes( { 2211888: 'twentysixteen' }, { type: SERIALIZE } );
 
-			expect( state ).to.deep.equal( { 2211888: 'twentysixteen' } );
+			expect( state ).toEqual( { 2211888: 'twentysixteen' } );
 		} );
 
 		test( 'should load valid persisted state', () => {
@@ -698,23 +698,27 @@ describe( 'reducer', () => {
 			} );
 
 			const state = activeThemes( original, { type: DESERIALIZE } );
-			expect( state ).to.deep.equal( { 2211888: 'twentysixteen' } );
+			expect( state ).toEqual( { 2211888: 'twentysixteen' } );
 		} );
 
 		test( 'should not load invalid persisted state', () => {
+			jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
 			const original = deepFreeze( {
 				2916284: 1234,
 			} );
 
 			const state = activeThemes( original, { type: DESERIALIZE } );
-			expect( state ).to.deep.equal( {} );
+			expect( state ).toEqual( {} );
+
+			// eslint-disable-next-line no-console
+			console.warn.mockReset();
 		} );
 	} );
 
 	describe( '#activationRequests', () => {
 		test( 'should default to an empty object', () => {
 			const state = activationRequests( undefined, {} );
-			expect( state ).to.deep.equal( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should map site ID to true value if request in progress', () => {
@@ -723,7 +727,7 @@ describe( 'reducer', () => {
 				siteId: 2916284,
 			} );
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: true,
 			} );
 		} );
@@ -739,7 +743,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: true,
 				2916285: true,
 			} );
@@ -757,7 +761,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: false,
 			} );
 		} );
@@ -775,7 +779,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: false,
 			} );
 		} );
@@ -785,7 +789,7 @@ describe( 'reducer', () => {
 		test( 'should default to an empty object', () => {
 			const state = themeInstalls( undefined, {} );
 
-			expect( state ).to.deep.equal( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should map site ID, theme ID to true value if request in progress', () => {
@@ -795,7 +799,7 @@ describe( 'reducer', () => {
 				themeId: 'karuna',
 			} );
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2211667: {
 					karuna: true,
 				},
@@ -816,7 +820,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2211667: {
 					karuna: true,
 				},
@@ -840,7 +844,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2211667: {
 					karuna: false,
 				},
@@ -862,7 +866,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2211667: {
 					karuna: false,
 				},
@@ -874,7 +878,7 @@ describe( 'reducer', () => {
 		test( 'should default to an empty object', () => {
 			const state = completedActivationRequests( undefined, {} );
 
-			expect( state ).to.deep.equal( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should track theme activate request success', () => {
@@ -883,8 +887,8 @@ describe( 'reducer', () => {
 				siteId: 2211667,
 			} );
 
-			expect( state ).to.have.keys( [ '2211667' ] );
-			expect( state ).to.deep.equal( { 2211667: true } );
+			expect( state ).toHaveProperty( '2211667' );
+			expect( state ).toEqual( { 2211667: true } );
 		} );
 
 		test( 'should track theme clear activated', () => {
@@ -893,15 +897,15 @@ describe( 'reducer', () => {
 				siteId: 2211667,
 			} );
 
-			expect( state ).to.have.keys( [ '2211667' ] );
-			expect( state ).to.deep.equal( { 2211667: false } );
+			expect( state ).toHaveProperty( '2211667' );
+			expect( state ).toEqual( { 2211667: false } );
 		} );
 	} );
 
 	describe( '#activeThemeRequests', () => {
 		test( 'should default to an empty object', () => {
 			const state = activeThemeRequests( undefined, {} );
-			expect( state ).to.deep.equal( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should map site ID to true value if request in progress', () => {
@@ -910,7 +914,7 @@ describe( 'reducer', () => {
 				siteId: 2916284,
 			} );
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: true,
 			} );
 		} );
@@ -926,7 +930,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: true,
 				2916285: true,
 			} );
@@ -944,7 +948,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: false,
 			} );
 		} );
@@ -961,7 +965,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.deep.equal( {
+			expect( state ).toEqual( {
 				2916284: false,
 			} );
 		} );


### PR DESCRIPTION
Update query-manager related tests to use Jest. Mostly `lib/query-manager`, but also a state test that was migrated while working on #23361 

Cherry-picks dd28689, 7f0fa15 from #23361

## Testing
1. Tests pass?
1. Have a look at tricky rewrites. These `chai` expect methods are so handily named 🙄 
   - `.to[.deep].eql` -> `.toEqual`
   - `.to.equal` -> `.toBe`