### PR TITLE
Jetpack connect: Add Google login to signup

### DIFF
--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -172,7 +172,9 @@ export class JetpackSignup extends Component {
 						email={ this.props.authQuery.userEmail }
 						footerLink={ this.renderFooterLink() }
 						handleSocialResponse={ this.handleSocialResponse }
-						isSocialSignupEnabled={ isEnabled( 'signup/social' ) }
+						isSocialSignupEnabled={
+							isEnabled( 'signup/social' ) && isEnabled( 'jetpack/connect/social-signup' )
+						}
 						locale={ this.props.locale }
 						redirectToAfterLoginUrl={ addQueryArgs(
 							{ auth_approved: true },

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -74,6 +74,17 @@ export class JetpackSignup extends Component {
 		} );
 	}
 
+	getLoginRoute() {
+		const emailAddress = this.props.authQuery.userEmail;
+		return login( {
+			emailAddress,
+			isJetpack: true,
+			isNative: isEnabled( 'login/native-login-links' ),
+			locale: this.props.locale,
+			redirectTo: window.location.href,
+		} );
+	}
+
 	handleSubmitSignup = ( _, userData ) => {
 		debug( 'submitting new account', userData );
 		this.setState( { isCreatingAccount: true }, () =>
@@ -157,18 +168,9 @@ export class JetpackSignup extends Component {
 	}
 
 	renderFooterLink() {
-		const emailAddress = this.props.authQuery.userEmail;
 		return (
 			<LoggedOutFormLinks>
-				<LoggedOutFormLinkItem
-					href={ login( {
-						emailAddress,
-						isJetpack: true,
-						isNative: isEnabled( 'login/native-login-links' ),
-						locale: this.props.locale,
-						redirectTo: window.location.href,
-					} ) }
-				>
+				<LoggedOutFormLinkItem href={ this.getLoginRoute() }>
 					{ this.props.translate( 'Already have an account? Sign in' ) }
 				</LoggedOutFormLinkItem>
 				<HelpButton onClick={ this.handleClickHelp } />

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -20,7 +20,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import AuthFormHeader from './auth-form-header';
-import config from 'config';
 import HelpButton from './help-button';
 import LocaleSuggestions from 'components/locale-suggestions';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
@@ -30,10 +29,14 @@ import SignupForm from 'components/signup-form';
 import WpcomLoginForm from 'signup/wpcom-login-form';
 import { addQueryArgs } from 'lib/route';
 import { authQueryPropTypes } from './utils';
-import { createAccount as createAccountAction } from 'state/jetpack-connect/actions';
+import { errorNotice as errorNoticeAction } from 'state/notices/actions';
+import { isEnabled } from 'config';
 import { login } from 'lib/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
-import { errorNotice as errorNoticeAction } from 'state/notices/actions';
+import {
+	createAccount as createAccountAction,
+	createSocialAccount as createSocialAccountAction,
+} from 'state/jetpack-connect/actions';
 
 const debug = debugFactory( 'calypso:jetpack-connect:authorize-form' );
 
@@ -72,7 +75,7 @@ export class JetpackSignup extends Component {
 	}
 
 	handleSubmitSignup = ( form, userData ) => {
-		debug( 'submiting new account', form, userData );
+		debug( 'submitting new account', form, userData );
 		this.setState(
 			{
 				isCreatingAccount: true,
@@ -96,6 +99,21 @@ export class JetpackSignup extends Component {
 					}
 				)
 		);
+	};
+
+	/**
+	 * Handle Social service authentication flow result (OAuth2 or OpenID Connect)
+	 *
+	 * @see client/signup/steps/user/index.jsx
+	 *
+	 * @param {String} service      The name of the social service
+	 * @param {String} access_token An OAuth2 acccess token
+	 * @param {String} id_token     (Optional) a JWT id_token which contains the signed user info
+	 *                              So our server doesn't have to request the user profile on its end.
+	 */
+	handleSocialResponse = ( service, access_token, id_token = null ) => {
+		debug( 'submitting new social account' );
+		this.props.createSocialAccount( { service, access_token, id_token } );
 	};
 
 	handleClickHelp = () => {
@@ -131,7 +149,7 @@ export class JetpackSignup extends Component {
 					href={ login( {
 						emailAddress,
 						isJetpack: true,
-						isNative: config.isEnabled( 'login/native-login-links' ),
+						isNative: isEnabled( 'login/native-login-links' ),
 						locale: this.props.locale,
 						redirectTo: window.location.href,
 					} ) }
@@ -153,6 +171,8 @@ export class JetpackSignup extends Component {
 						disabled={ isCreatingAccount }
 						email={ this.props.authQuery.userEmail }
 						footerLink={ this.renderFooterLink() }
+						handleSocialResponse={ this.handleSocialResponse }
+						isSocialSignupEnabled={ isEnabled( 'signup/social' ) }
 						locale={ this.props.locale }
 						redirectToAfterLoginUrl={ addQueryArgs(
 							{ auth_approved: true },
@@ -171,6 +191,7 @@ export class JetpackSignup extends Component {
 }
 export default connect( null, {
 	createAccount: createAccountAction,
+	createSocialAccount: createSocialAccountAction,
 	errorNotice: errorNoticeAction,
 	recordTracksEvent: recordTracksEventAction,
 } )( localize( JetpackSignup ) );

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -147,15 +147,21 @@ export class JetpackSignup extends Component {
 		debug( 'Signup error: %o', error );
 		this.resetState();
 		if ( error && 'user_exists' === error.code ) {
-			warningNotice(
-				translate(
-					'The email already exists. Log in to connect your accounts or choose another Google profile.'
-				),
+			const text =
+				error.data && error.data.email
+					? translate(
+							'The email address "%(email)s" is associated with a WordPress.com account. ' +
+								'Log in to connect it to your Google profile, or choose a different Google profile.',
+							{ args: { email: error.data.email } }
+						)
+					: translate(
+							'The email address is associated with a WordPress.com account. ' +
+								'Log in to connect it to your Google profile, or choose a different Google profile.'
+						);
 
-				{
-					button: <a href={ this.getLoginRoute() }>{ translate( 'Log in' ) }</a>,
-				}
-			);
+			warningNotice( text, {
+				button: <a href={ this.getLoginRoute() }>{ translate( 'Log in' ) }</a>,
+			} );
 			return;
 		}
 		errorNotice(

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -109,27 +109,27 @@ export class JetpackSignup extends Component {
 	 * @param {string} _.username    Username
 	 * @param {string} _.bearerToken Bearer token
 	 */
-	handleUserCreationSuccess( { username, bearerToken } ) {
+	handleUserCreationSuccess = ( { username, bearerToken } ) => {
 		this.setState( {
 			newUsername: username,
 			bearerToken,
 			isCreatingAccount: false,
 		} );
-	}
+	};
 
 	/**
 	 * Handle error on user creation
 	 *
 	 * @param {?Object} error Error result
 	 */
-	handleUserCreationError( error ) {
+	handleUserCreationError = error => {
 		const { errorNotice, translate } = this.props;
 		debug( 'Signup error: %o', error );
 		this.setState( { isCreatingAccount: false } );
 		errorNotice(
 			translate( 'There was a problem creating your account. Please contact support.' )
 		);
-	}
+	};
 
 	handleClickHelp = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -44,6 +44,8 @@ exports[`JetpackSignup should render 1`] = `
           />
         </LoggedOutFormLinks>
       }
+      handleSocialResponse={[Function]}
+      isSocialSignupEnabled={true}
       redirectToAfterLoginUrl="https://example.com/?auth_approved=true"
       submitButtonText="Create your account"
       submitForm={[Function]}
@@ -102,6 +104,8 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
           />
         </LoggedOutFormLinks>
       }
+      handleSocialResponse={[Function]}
+      isSocialSignupEnabled={true}
       locale="es"
       redirectToAfterLoginUrl="https://example.com/?auth_approved=true"
       submitButtonText="Create your account"

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -228,6 +228,7 @@ export function createSocialAccount( socialInfo ) {
 			const err = {
 				code: error.error,
 				message: error.message,
+				data: error.data,
 			};
 			dispatch(
 				recordTracksEvent( 'calypso_jpc_social_createaccount_error', {

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -14,7 +14,6 @@ import userFactory from 'lib/user';
 import wpcom from 'lib/wp';
 import { addQueryArgs, externalRedirect } from 'lib/route';
 import { clearPlan, persistSession } from 'jetpack-connect/persistence-utils';
-import { createSocialUser } from 'state/login/actions';
 import { receiveDeletedSite, receiveSite } from 'state/sites/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { REMOTE_PATH_AUTH } from 'jetpack-connect/constants';
@@ -219,12 +218,12 @@ export function createSocialAccount( socialInfo ) {
 			 * The signup flow is required and affects some post signup activity.
 			 * `account` should be safe until patch lands.
 			 */
-			const { username, bearerToken } = await createSocialUser(
-				socialInfo,
-				'account' /* 'jetpack-connect' */
-			)( dispatch );
+			const { username, bearer_token } = await wpcom.undocumented().usersSocialNew( {
+				...socialInfo,
+				signup_flow_name: 'account' /* 'jetpack-connect' */,
+			} );
 			dispatch( recordTracksEvent( 'calypso_jpc_social_createaccount_success' ) );
-			return { username, bearerToken };
+			return { username, bearerToken: bearer_token };
 		} catch ( error ) {
 			dispatch(
 				recordTracksEvent( 'calypso_jpc_social_createaccount_error', {

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -200,12 +200,12 @@ export function retryAuth( url, attemptNumber ) {
  *
  * !! Must have same return shape as createAccount !!
  *
- * @param  {Object} socialInfo              …
- * @param  {Object} socialInfo.service      The name of the social service
- * @param  {Object} socialInfo.access_token An OAuth2 acccess token
- * @param  {Object} socialInfo.id_token     (Optional) a JWT id_token which contains the signed user info
+ * @param  {Object}  socialInfo              …
+ * @param  {string}  socialInfo.service      The name of the social service
+ * @param  {string}  socialInfo.access_token An OAuth2 acccess token
+ * @param  {?string} socialInfo.id_token     (Optional) a JWT id_token which contains the signed user info
  *
- * @return {Promise}                  Resolves to { username, bearerToken }
+ * @return {Promise}                         Resolves to { username, bearerToken }
  */
 export function createSocialAccount( socialInfo ) {
 	return async dispatch => {
@@ -247,9 +247,9 @@ export function createSocialAccount( socialInfo ) {
  * !! Must have same return shape as createSocialAccount !!
  *
  * @param  {Object} userData          …
- * @param  {Object} userData.username Username
- * @param  {Object} userData.password Password
- * @param  {Object} userData.email    Email
+ * @param  {string} userData.username Username
+ * @param  {string} userData.password Password
+ * @param  {string} userData.email    Email
  *
  * @return {Promise}                  Resolves to { username, bearerToken }
  */

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -225,13 +225,17 @@ export function createSocialAccount( socialInfo ) {
 			dispatch( recordTracksEvent( 'calypso_jpc_social_createaccount_success' ) );
 			return { username, bearerToken: bearer_token };
 		} catch ( error ) {
+			const err = {
+				code: error.error,
+				message: error.message,
+			};
 			dispatch(
 				recordTracksEvent( 'calypso_jpc_social_createaccount_error', {
-					error: JSON.stringify( error ),
-					error_code: error.code,
+					error: JSON.stringify( err ),
+					error_code: err.code,
 				} )
 			);
-			throw error;
+			throw err;
 		}
 	};
 }

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -442,14 +442,22 @@ describe( '#createSocialAccount()', () => {
 	beforeEach( jest.restoreAllMocks );
 
 	test( 'should reject with the error', async () => {
-		const error = { message: 'An error message', code: 'an_error_code' };
+		const error = {
+			data: { email: 'email@example.com' },
+			error: 'an_error_code',
+			message: 'An error message',
+		};
 		jest.spyOn( wpcom, 'undocumented' ).mockImplementation( () => ( {
 			async usersSocialNew() {
 				throw error;
 			},
 		} ) );
 
-		await expect( createSocialAccount()( () => {} ) ).rejects.toBe( error );
+		await expect( createSocialAccount()( () => {} ) ).rejects.toEqual( {
+			code: error.error,
+			data: error.data,
+			message: error.message,
+		} );
 	} );
 
 	test( 'should resolve with the username and bearer token', async () => {

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -6,7 +6,6 @@
  * Internal dependencies
  */
 import * as actions from '../actions';
-import * as loginActions from 'state/login/actions';
 import useNock from 'test/helpers/use-nock';
 import wpcom from 'lib/wp';
 import {
@@ -445,18 +444,30 @@ describe( '#createSocialAccount()', () => {
 
 	test( 'should reject with the error', async () => {
 		const error = { message: 'An error message', code: 'an_error_code' };
-		jest.spyOn( loginActions, 'createSocialUser' ).mockImplementation( () => async () => {
-			throw error;
-		} );
+		jest.spyOn( wpcom, 'undocumented' ).mockImplementation( () => ( {
+			async usersSocialNew() {
+				throw error;
+			},
+		} ) );
 
 		await expect( createSocialAccount()( () => {} ) ).rejects.toBe( error );
 	} );
 
 	test( 'should resolve with the username and bearer token', async () => {
-		const result = { username: 'a_happy_user', bearerToken: 'foobar' };
-		// eslint-disable-next-line no-multi-spaces
-		jest.spyOn( loginActions, 'createSocialUser' ).mockImplementation( () => async () => result  );
+		const bearerToken = 'foobar';
+		const username = 'a_happy_user';
+		jest.spyOn( wpcom, 'undocumented' ).mockImplementation( () => ( {
+			async usersSocialNew() {
+				return {
+					bearer_token: bearerToken,
+					username,
+				};
+			},
+		} ) );
 
-		await expect( createSocialAccount()( () => {} ) ).resolves.toEqual( result );
+		await expect( createSocialAccount()( () => {} ) ).resolves.toEqual( {
+			bearerToken,
+			username,
+		} );
 	} );
 } );

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -417,8 +417,7 @@ describe( '#createAccount()', () => {
 			},
 		} ) );
 
-		const spy = jest.fn();
-		await expect( createAccount( userData )( spy ) ).resolves.toEqual( {
+		await expect( createAccount( userData )( () => {} ) ).resolves.toEqual( {
 			username: userData.username,
 			bearerToken: data.bearer_token,
 		} );

--- a/config/development.json
+++ b/config/development.json
@@ -64,6 +64,7 @@
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/remote-install": true,
 		"jetpack/connect/mobile-app-flow": true,
+		"jetpack/connect/social-signup": true,
 		"jetpack/happychat": true,
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,

--- a/config/test.json
+++ b/config/test.json
@@ -38,6 +38,7 @@
 		"google-my-business": true,
 		"help": true,
 		"jetpack/happychat": true,
+		"jetpack/connect/social-signup": true,
 		"jitms": true,
 		"login/native-login-links": true,
 		"login/wp-login": true,


### PR DESCRIPTION
Add Google log in to Jetpack Connect signup

## Screens

If you land here, follow "Sign Up":

![sign up](https://user-images.githubusercontent.com/841763/38095854-b9a7bdca-3371-11e8-987a-cfb39e7ca291.png)

Google on the Jetpack Connect sign up page:

![google](https://user-images.githubusercontent.com/841763/37914823-69e3804a-3118-11e8-928a-b869c3c08dac.png)

### Errors

If you try to signup with an existing, unconnected email, you'll see this warning with a link to log in:

![notice](https://user-images.githubusercontent.com/841763/38507375-a98ad946-3c1c-11e8-8642-41da034df615.png)

## Testing

1. Create a new Jetpack test site (Jurassic Ninja is a good choice)
2. Start a connection flow while logged out of WordPress.com
3. Chose to sign up a new account
4. Sign up with Google
5. Ensure user is correctly created and Jetpack connection flow continues
6. Try to sign up with a Google email that is associated with an existing account but is not connected. You should see the error and the `Log in` button should work correctly.