### PR TITLE
Security: update notice styles in backup section

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/index.jsx
@@ -13,8 +13,9 @@ import { some } from 'lodash';
 import CompactCard from 'components/card/compact';
 import CredentialsSetupFlow from './credentials-setup-flow';
 import CredentialsConfigured from './credentials-configured';
-import Gridicon from 'gridicons';
+import Notice from 'components/notice';
 import QueryRewindState from 'components/data/query-rewind-state';
+import SectionHeader from 'components/section-header';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getRewindState } from 'state/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
@@ -28,19 +29,16 @@ class JetpackCredentials extends Component {
 		return (
 			<div className="jetpack-credentials">
 				<QueryRewindState siteId={ siteId } />
-				<CompactCard className="jetpack-credentials__header">
-					<span>{ translate( 'Backups and security scans' ) }</span>
+				<SectionHeader label={ translate( 'Backups and security scans' ) }>
 					{ hasAuthorized && (
-						<span className="jetpack-credentials__connected">
-							<Gridicon
-								icon="checkmark"
-								size={ 18 }
-								className="jetpack-credentials__connected-checkmark"
-							/>
-							{ translate( 'Connected' ) }
-						</span>
+						<Notice
+							icon="checkmark"
+							isCompact
+							status="is-success"
+							text={ translate( 'Connected' ) }
+						/>
 					) }
-				</CompactCard>
+				</SectionHeader>
 				{ hasCredentials ? (
 					<CredentialsConfigured siteId={ siteId } />
 				) : (

--- a/client/my-sites/site-settings/jetpack-credentials/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/style.scss
@@ -5,17 +5,3 @@
 .jetpack-credentials .foldable-card.card.is-expanded {
 	margin: 0;
 }
-
-.jetpack-credentials__connected {
-	float: right;
-	background: $alert-green;
-	padding: 4px 8px;
-	border-radius: 2px;
-	font-size: 12px;
-	color: $white;
-}
-
-.jetpack-credentials__connected-checkmark {
-	vertical-align: top;
-	margin-right: 4px;
-}


### PR DESCRIPTION
1. Use `Notice` component instead of custom styles to match with other Calypso notifications, updated in https://github.com/Automattic/wp-calypso/pull/17796

2. Use `SectionHeader` component for the header instead of `CompactCard` (works better for alignment)

There's a similar PR in Jetpack open: https://github.com/Automattic/jetpack/pull/9080

The section below the header has some style issues in mobile; I'll address those in a separate PR.

## Screenshots (before & after)

### Mobile

![screen shot 2018-03-21 at 10 54 46](https://user-images.githubusercontent.com/87168/37702423-28769190-2cfb-11e8-9827-0710078308c2.png)
![screen shot 2018-03-21 at 10 54 57](https://user-images.githubusercontent.com/87168/37702422-2846ef08-2cfb-11e8-9c4b-74ff128e3151.png)

### Desktop
![screen shot 2018-03-21 at 11 29 54](https://user-images.githubusercontent.com/87168/37702508-6f97942a-2cfb-11e8-9abf-529e19c9eb41.png)
![screen shot 2018-03-21 at 11 30 00](https://user-images.githubusercontent.com/87168/37702506-6f79334a-2cfb-11e8-860b-4853a0be792e.png)

## Testing

1. Have a site connected to Rewind
2. Go to `https://wordpress.com/settings/security/:site` and see that the section works and looks good in different screen sizes.