### PR TITLE
Jetpack Onboarding: Hide forward links only on success screens

### DIFF
--- a/client/components/wizard/README.md
+++ b/client/components/wizard/README.md
@@ -73,6 +73,24 @@ to one of the values in the `steps` array (see below).
 
 Link text for navigating to the next step in the wizard.
 
+### `hideBackLink`
+
+<table>
+	<tr><td>Type</td><td>Boolean</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+Whether to intentionally hide the back link.
+
+### `hideForwardLink`
+
+<table>
+	<tr><td>Type</td><td>Boolean</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+Whether to intentionally hide the forward link.
+
 ### `hideNavigation`
 
 <table>

--- a/client/components/wizard/index.jsx
+++ b/client/components/wizard/index.jsx
@@ -21,6 +21,8 @@ class Wizard extends Component {
 		baseSuffix: PropTypes.string,
 		components: PropTypes.objectOf( PropTypes.element ).isRequired,
 		forwardText: PropTypes.string,
+		hideBackLink: PropTypes.bool,
+		hideForwardLink: PropTypes.bool,
 		hideNavigation: PropTypes.bool,
 		onBackClick: PropTypes.func,
 		onForwardClick: PropTypes.func,
@@ -31,6 +33,8 @@ class Wizard extends Component {
 	static defaultProps = {
 		basePath: '',
 		baseSuffix: '',
+		hideBackLink: false,
+		hideForwardLink: false,
 		hideNavigation: false,
 	};
 
@@ -76,6 +80,8 @@ class Wizard extends Component {
 			basePath,
 			components,
 			forwardText,
+			hideBackLink,
+			hideForwardLink,
 			hideNavigation,
 			onBackClick,
 			onForwardClick,
@@ -106,23 +112,25 @@ class Wizard extends Component {
 				{ ! hideNavigation &&
 					totalSteps > 1 && (
 						<div className="wizard__navigation-links">
-							{ stepIndex > 0 && (
-								<NavigationLink
-									direction="back"
-									href={ backUrl }
-									text={ backText }
-									onClick={ onBackClick }
-								/>
-							) }
+							{ ! hideBackLink &&
+								stepIndex > 0 && (
+									<NavigationLink
+										direction="back"
+										href={ backUrl }
+										text={ backText }
+										onClick={ onBackClick }
+									/>
+								) }
 
-							{ stepIndex < totalSteps - 1 && (
-								<NavigationLink
-									direction="forward"
-									href={ forwardUrl }
-									text={ forwardText }
-									onClick={ onForwardClick }
-								/>
-							) }
+							{ ! hideForwardLink &&
+								stepIndex < totalSteps - 1 && (
+									<NavigationLink
+										direction="forward"
+										href={ forwardUrl }
+										text={ forwardText }
+										onClick={ onForwardClick }
+									/>
+								) }
 						</div>
 					) }
 			</div>

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { compact, get } from 'lodash';
+import { compact, get, includes } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -111,13 +111,15 @@ class JetpackOnboardingMain extends React.PureComponent {
 		} );
 	};
 
-	getSkipLinkText() {
-		const { stepName, stepsCompleted, translate } = this.props;
+	shouldHideForwardLink() {
+		const { stepName, stepsCompleted } = this.props;
+		const stepsWithSuccessScreens = [ STEPS.CONTACT_FORM, STEPS.BUSINESS_ADDRESS, STEPS.STATS ];
 
-		if ( get( stepsCompleted, stepName ) ) {
-			return translate( 'Next' );
+		if ( ! includes( stepsWithSuccessScreens, stepName ) ) {
+			return false;
 		}
-		return null;
+
+		return get( stepsCompleted, stepName, false );
 	}
 
 	render() {
@@ -154,7 +156,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 						basePath="/jetpack/start"
 						baseSuffix={ siteSlug }
 						components={ COMPONENTS }
-						forwardText={ this.getSkipLinkText() }
+						hideForwardLink={ this.shouldHideForwardLink() }
 						hideNavigation={ stepName === STEPS.SUMMARY }
 						isRequestingSettings={ isRequestingSettings }
 						isRequestingWhetherConnected={ isRequestingWhetherConnected }


### PR DESCRIPTION
This PR:

* Adds features for hiding back and forward links of `Wizard` component separately.
* Reverts the forward link text back to "Skip for now"
* Hides the forward link for all success screens (on the contact form, business address and stats pages).

There has been plenty of discussion before, in #22852 (comment) and #22641, as well as in p1HpG7-4WU-p2.

Fixes #23458.

Preview:

**Displaying the skip link for a ready step without a success screen**
![](https://cldup.com/uMZ2l6MAol.png)

**Hiding the skip link for success screens**
![](https://cldup.com/cU1Bm5v7jV.png)

**Displaying the skip link for all other steps and cases**
![](https://cldup.com/yWo50Vyo3i.png)

To test:
* Start the flow here: http://yourgroovydomain.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `yourgroovydomain.com` is your Jetpack site with the latest Jetpack.
* Go through all steps in various cases.
* Verify you don't see the skip links on any of the success screen (on the contact form, business address and stats pages).
* Verify that you can see the "skip" link in all other cases but the Summary step.
* Verify you can see the updated text of the skip link.