### PR TITLE
Plans: roll out the variation as the winner for the unsigned version of the minimizedFreePlan test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -76,15 +76,6 @@ export default {
 		defaultVariation: 'group_0',
 		allowExistingUsers: true,
 	},
-	minimizedFreePlanForUnsignedUser: {
-		datestamp: '20180308',
-		variations: {
-			original: 50,
-			minimized: 50,
-		},
-		defaultVariation: 'original',
-		allowExistingUsers: true,
-	},
 	upgradePricingDisplayV2: {
 		datestamp: '20180305',
 		variations: {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -781,13 +781,11 @@ export default connect(
 			} )
 		);
 
+		// Minimize the free plan for the unsigned users
 		if ( isInSignup && ! isLoggedIn ) {
-			const isInTest = abtest( 'minimizedFreePlanForUnsignedUser' ) === 'minimized';
-			if ( isInTest ) {
-				freePlanProperties = filter( planProperties, filterFreePlan );
-				freePlanProperties = freePlanProperties[ 0 ] || null;
-				planProperties = reject( planProperties, filterFreePlan );
-			}
+			freePlanProperties = filter( planProperties, filterFreePlan );
+			freePlanProperties = freePlanProperties[ 0 ] || null;
+			planProperties = reject( planProperties, filterFreePlan );
 		}
 
 		const maxCredits = getMaxCredits( planProperties, ownProps.site.jetpack );


### PR DESCRIPTION
Since it turns out the `minimized` variation is the winner of the `minimizedFreePlan` test, we're closing test and rolling out the winner to 100% users.

## How to test

1. Create a new website as a signed-out user.
2. While following the signup progress, you will see the minimized free plan button at the bottom of the plans page.

cc @anneforbush 