### PR TITLE
Jetpack Onboarding: Always show stats step, display different copy if already activated

### DIFF
--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -176,7 +176,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 	}
 }
 export default connect(
-	( state, { action, siteSlug } ) => {
+	( state, { siteSlug } ) => {
 		let siteId = getUnconnectedSiteIdBySlug( state, siteSlug );
 		if ( ! siteId ) {
 			// We rely on the fact that all sites are being requested automatically early in <Layout />.
@@ -213,12 +213,6 @@ export default connect(
 
 		const userIdHashed = getUnconnectedSiteUserHash( state, siteId );
 
-		// Only show the Stats Step either if we aren't connected to WP.com yet,
-		// or if we're just being redirected back to JP Onboarding right after
-		// going through JP Connect, in which case the `action` query arg will be
-		// set to `activate_stats`.
-		const showStatsStep = ! isConnected || action === 'activate_stats';
-
 		const steps = compact( [
 			STEPS.SITE_TITLE,
 			STEPS.SITE_TYPE,
@@ -226,7 +220,7 @@ export default connect(
 			STEPS.CONTACT_FORM,
 			isBusiness && STEPS.BUSINESS_ADDRESS,
 			isBusiness && STEPS.WOOCOMMERCE,
-			showStatsStep && STEPS.STATS,
+			STEPS.STATS,
 			STEPS.SUMMARY,
 		] );
 		const stepsCompleted = getJetpackOnboardingCompletedSteps( state, siteId, steps );

--- a/client/jetpack-onboarding/steps/stats.jsx
+++ b/client/jetpack-onboarding/steps/stats.jsx
@@ -22,6 +22,10 @@ import { isJetpackSite } from 'state/sites/selectors';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
 class JetpackOnboardingStatsStep extends React.Component {
+	state = {
+		justActivatedStats: false,
+	};
+
 	componentDidUpdate() {
 		this.maybeActivateStats();
 	}
@@ -59,6 +63,20 @@ class JetpackOnboardingStatsStep extends React.Component {
 		this.props.saveJpoSettings( this.props.siteId, {
 			stats: true,
 		} );
+
+		this.setState( {
+			justActivatedStats: true,
+		} );
+	}
+
+	getSuccessTitle() {
+		const { translate } = this.props;
+
+		if ( this.state.justActivatedStats ) {
+			return translate( 'Success! Jetpack is now collecting valuable stats.' );
+		}
+
+		return translate( 'Jetpack also provides you with helpful stats about your site visitors.' );
 	}
 
 	renderActionTile() {
@@ -87,7 +105,7 @@ class JetpackOnboardingStatsStep extends React.Component {
 	}
 
 	render() {
-		const { activatedStats, basePath, getForwardUrl, siteId, translate } = this.props;
+		const { activatedStats, basePath, getForwardUrl, siteId } = this.props;
 
 		return (
 			<div className="steps__main">
@@ -104,7 +122,7 @@ class JetpackOnboardingStatsStep extends React.Component {
 						href={ getForwardUrl() }
 						illustration="/calypso/images/illustrations/jetpack-stats.svg"
 						onClick={ this.handleStatsNextButton }
-						title={ translate( 'Success! Jetpack is now collecting valuable stats.' ) }
+						title={ this.getSuccessTitle() }
 					/>
 				) : (
 					this.renderActionTile()

--- a/client/jetpack-onboarding/steps/stats.jsx
+++ b/client/jetpack-onboarding/steps/stats.jsx
@@ -76,7 +76,7 @@ class JetpackOnboardingStatsStep extends React.Component {
 			return translate( 'Success! Jetpack is now collecting valuable stats.' );
 		}
 
-		return translate( 'Jetpack also provides you with helpful stats about your site visitors.' );
+		return translate( "Jetpack provides you with detailed stats about your site's reach." );
 	}
 
 	renderActionTile() {


### PR DESCRIPTION
As @rickybanister suggested in p1HpG7-4WU-p2 #comment-25088 after @rachelmcr and @bsessions85 reported some confusion when hiding the stats step, this PR proposes that we:

* Always show the stats step
* Display a different copy if the Stats module has already been activated.

Also cc @benhuberman for copy review of the new string we're introducing - **Jetpack also provides you with helpful stats about your site visitors.**.

Preview:

**When stats module already activated:**
![](https://cldup.com/Z39lLxHonz.png)

**When stats module was just activated**
![](https://cldup.com/_VBRsa5TwI.png)

To test:
* Checkout this branch
* Make sure your site is **not** connected to WP.com and has the latest Jetpack.
* Start the flow here: http://yourgroovydomain.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `yourgroovydomain.com` is your Jetpack site.
* Skip to the Stats step. 
* Click the button to activate Stats.
* Go through the connection flow. 
* After connecting verify you can see the "Success!..." message.
* Disable the stats module by running the following WP CLI command: `wp jetpack module deactivate stats`
* Restart the flow, skip to the Stats page again.
* Click the button to activate Stats.
* Verify you can immediately see the "Success!..." message.
* Start a new JN site and initiate the JPO flow for it.
* Skip to the contact form step and connect there to insert a form.
* Skip to the stats page and verify you can see the "Jetpack also provides you with helpful stats about your site visitors." message as the module was previously activated upon connecting.
* Go to other steps, refresh the flow, etc. and verify that in all cases where your site is connected and stats module is activated, you can see the "Jetpack also provides you with helpful stats about your site visitors." message.