### PR TITLE
Activity Log: Stop wrapping time ranges

### DIFF
--- a/client/my-sites/stats/activity-log-day/style.scss
+++ b/client/my-sites/stats/activity-log-day/style.scss
@@ -73,6 +73,7 @@
 
 .activity-log-day__day {
 	font-weight: 600;
+	white-space: nowrap;
 }
 
 .activity-log-day__rewind-button-extra-text {

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -40,6 +40,7 @@
 
 .activity-log__empty-day-title {
 	font-weight: 600;
+	white-space: nowrap;
 }
 
 .activity-log__empty-day-events {


### PR DESCRIPTION
In #22869 it was reported that on small screens the time ranges for the
activity log were being wrapped at awkward positions. This would lead
to situations where we lost context of what the range was.

```
February 27, 2018 —
Today
10 Events
```

This patch attempts to clarify by disabling wrapping for that entire
range.

**Testing**

Open the Activity Log on mobile and look for a day with a time range.

On **master** it should wrap but on this branch it shouldn't.

Look for any possible cases where the line is so long it's broken
_more_ by refusing to wrap.