### PR TITLE
Editor: Update parent terms and pages selectors look and feel

### DIFF
--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -19,7 +19,7 @@ import FormInputValidation from 'components/forms/form-input-validation';
 import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
 import FormSectionHeading from 'components/forms/form-section-heading';
-import FormCheckbox from 'components/forms/form-checkbox';
+import FormToggle from 'components/forms/form-toggle';
 import FormLabel from 'components/forms/form-label';
 import FormLegend from 'components/forms/form-legend';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -248,7 +248,7 @@ class TermFormDialog extends Component {
 
 	renderParentSelector() {
 		const { labels, siteId, taxonomy, translate, terms } = this.props;
-		const { searchTerm, selectedParent } = this.state;
+		const { isTopLevel, searchTerm, selectedParent } = this.state;
 		const query = {};
 		if ( searchTerm && searchTerm.length ) {
 			query.search = searchTerm;
@@ -264,28 +264,42 @@ class TermFormDialog extends Component {
 
 		return (
 			<FormFieldset>
-				<FormLegend>{ labels.parent_item }</FormLegend>
 				<FormLabel>
-					<FormCheckbox
-						ref="topLevel"
-						checked={ this.state.isTopLevel }
-						onChange={ this.onTopLevelChange }
-					/>
+					<FormToggle checked={ isTopLevel } onChange={ this.onTopLevelChange } />
 					<span>
-						{ translate( 'Top level', { context: 'Terms: New term being created is top level' } ) }
+						{ translate( 'Top level %(term)s', {
+							args: { term: labels.singular_name },
+							context: 'Terms: New term being created is top level',
+						} ) }
 					</span>
+					{ isTopLevel && (
+						<span className="term-form-dialog__top-level-description">
+							{ translate( 'Disable to select a %(parentTerm)s', {
+								args: { parentTerm: labels.parent_item },
+							} ) }
+						</span>
+					) }
 				</FormLabel>
-				<TermTreeSelectorTerms
-					siteId={ siteId }
-					taxonomy={ taxonomy }
-					isError={ isError }
-					onSearch={ this.onSearch }
-					onChange={ this.onParentChange }
-					query={ query }
-					selected={ selectedParent }
-					hideTermAndChildren={ hideTermAndChildren }
-				/>
-				{ isError && <FormInputValidation isError text={ this.state.errors.parent } /> }
+				{ ! isTopLevel && (
+					<div className="term-form-dialog__parent-tree-selector">
+						<FormLegend>
+							{ translate( 'Choose a %(parentTerm)s', {
+								args: { parentTerm: labels.parent_item },
+							} ) }
+						</FormLegend>
+						<TermTreeSelectorTerms
+							siteId={ siteId }
+							taxonomy={ taxonomy }
+							isError={ isError }
+							onSearch={ this.onSearch }
+							onChange={ this.onParentChange }
+							query={ query }
+							selected={ selectedParent }
+							hideTermAndChildren={ hideTermAndChildren }
+						/>
+						{ isError && <FormInputValidation isError text={ this.state.errors.parent } /> }
+					</div>
+				) }
 			</FormFieldset>
 		);
 	}

--- a/client/blocks/term-form-dialog/style.scss
+++ b/client/blocks/term-form-dialog/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 .term-form-dialog .dialog__content {
 	min-width: 40vw;
 }
@@ -6,7 +8,7 @@
 	padding-bottom: 0;
 }
 
-@include breakpoint( "<660px" ) {
+@include breakpoint( '<660px' ) {
 	.term-form-dialog {
 		width: 90%;
 	}
@@ -18,4 +20,17 @@
 
 .term-form-dialog textarea {
 	resize: vertical;
+}
+
+.term-form-dialog__top-level-description {
+	color: $gray-text-min;
+	display: block;
+	font-weight: normal;
+	margin-left: 52px;
+}
+
+.term-form-dialog__parent-tree-selector {
+	border-top: 1px solid $gray-lighten-30;
+	margin-top: 20px;
+	padding-top: 20px;
 }

--- a/client/post-editor/editor-page-parent/index.jsx
+++ b/client/post-editor/editor-page-parent/index.jsx
@@ -35,8 +35,14 @@ class EditorPageParent extends Component {
 	};
 
 	state = {
-		isTopLevel: true,
+		isTopLevel: ! this.props.parentId,
 	};
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.parentId !== nextProps.parentId ) {
+			this.setState( { isTopLevel: ! nextProps.parentId } );
+		}
+	}
 
 	updatePageParent = item => {
 		const { siteId, postId } = this.props;
@@ -79,9 +85,11 @@ class EditorPageParent extends Component {
 							context: 'Editor: Page being edited is top level i.e. has no parent',
 						} ) }
 					</span>
-					<span className="editor-page-parent__top-level-description">
-						{ translate( 'Disable to select a parent page' ) }
-					</span>
+					{ isTopLevel && (
+						<span className="editor-page-parent__top-level-description">
+							{ translate( 'Disable to select a parent page' ) }
+						</span>
+					) }
 				</FormLabel>
 				{ ! isTopLevel && (
 					<div className="editor-page-parent__parent-tree-selector">

--- a/client/post-editor/editor-page-parent/style.scss
+++ b/client/post-editor/editor-page-parent/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 .editor-page-parent .post-selector {
 	margin: 8px 0 0 0;
 }
@@ -18,14 +20,19 @@
 	text-transform: uppercase;
 }
 
-.editor-page-parent__top-level-label {
+.editor-page-parent__top-level-label,
+.editor-page-parent__top-level-description,
+.editor-page-parent__parent-tree-selector .form-legend {
 	color: $gray-darken-10;
 	font-size: 13px;
-	line-height: 1.7;
 }
 
-.editor-page-parent__top-level {
-	align-content: center;
-	display: flex;
-	justify-content: space-between;
+.editor-page-parent__top-level-description {
+	display: block;
+	font-weight: normal;
+	margin-left: 36px;
+}
+
+.editor-page-parent__parent-tree-selector {
+	margin-top: 12px;
 }


### PR DESCRIPTION
Fix #8513

Make the parent term selector in the post editor and the parent page selector in the page editor as close as possible by replacing the top level checkbox with a toggle and by updating how its unchecked state is handled.

## Parent Term Selector

| Before | After |
| --- | --- |
| <img width="611" alt="screen shot 2018-03-21 at 11 27 27" src="https://user-images.githubusercontent.com/2070010/37708778-d43049e6-2cff-11e8-9058-5a3261824e1b.png"> | <img width="613" alt="screen shot 2018-03-21 at 11 27 13" src="https://user-images.githubusercontent.com/2070010/37708750-bafd757a-2cff-11e8-9881-7d455b8fba4c.png"><img width="611" alt="screen shot 2018-03-21 at 11 27 27" src="https://user-images.githubusercontent.com/2070010/37708758-c183da60-2cff-11e8-9177-31a3148d7c85.png">

### Notes

Apparently, terms labels are returned by the backend and stored in state; for this reason they are capitalized (e.g. "Choose a **P**arent **C**ategory").
I'm not exactly sure what is the best way to work around this, though.

To be fair, I think that changing how the backend creates those string is a bit overkill (from a dev standpoint), as it would require checking every single place they are used.

Probably it makes more sense to find labels that work better with capitalized words.

## Parent Page Selector

| Before | After |
| --- | --- |
| <img width="281" alt="screen shot 2018-03-21 at 11 30 00" src="https://user-images.githubusercontent.com/2070010/37708806-ec48d91c-2cff-11e8-92ea-9ba4862eb9d1.png"> | <img width="280" alt="screen shot 2018-03-21 at 11 58 07" src="https://user-images.githubusercontent.com/2070010/37708812-f131ef68-2cff-11e8-8a44-1865bab82003.png"><img width="279" alt="screen shot 2018-03-21 at 11 58 21" src="https://user-images.githubusercontent.com/2070010/37708818-f5c0287e-2cff-11e8-968e-a228f6765304.png"> |

### Notes

As you may notice by inspecting the changes, I had to pretty much rewrite this component.
The reason is that previously, the `editPost` action was dispatched every time the toggle changed and an item was selected from the tree, which was possible because you couldn't actually uncheck the top level toggle by clicking on the toggle, but only by selecting a parent page.

Now, it's possible to uncheck the top level toggle via the toggle itself, without selecting a parent page. Though, if we dispatched `editPost` now, we'd have no actual value for the parent page.

The new logic consists in the fact that unchecking the toggle **doesn't** dispatch `editPost` anymore, but simply make the parent page selector show up.
Only checking the toggle or selecting a parent page dispatches `editPost`.

## Testing instructions

For parent terms:
- Edit a post, toggle the settings sidebar, and expand the "Category & Tags" section.
- Click on "Add New Category" to open the dialog.
- Check if the top level toggle and parent selector feels good to use.

For parent pages:
- Edit a page, toggle the settings sidebar, and expand the "Page Attributes" section.
- Check if the top level toggle and parent selector feels good to use.