### PR TITLE
Individual receipts - selectors

### DIFF
--- a/client/state/selectors/get-past-billing-transaction.js
+++ b/client/state/selectors/get-past-billing-transaction.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { find } from 'lodash';
+import { find, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,15 +13,30 @@ import createSelector from 'lib/create-selector';
 import getPastBillingTransactions from './get-past-billing-transactions';
 
 /**
+ * Utility function to retrieve a transaction from individualTransactions state subtree
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {Number}  id      ID of the transaction
+ * @return {?Object}         The transaction object or null if it doesn't exist
+ */
+const getIndividualBillingTransaction = ( state, id ) =>
+	get( state, [ 'billingTransactions', 'individualTransactions', id, 'data' ], null );
+
+/**
  * Returns a past billing transaction.
+ * Looks for the transaction in the most recent billing transactions and then looks for individually-fetched transactions
  * Returns null if the billing transactions have not been fetched yet, or there is no transaction with that ID.
  *
  * @param  {Object}  state   Global state tree
- * @param  {String}  id      ID of the transaction
+ * @param  {Number}  id      ID of the transaction
  * @return {?Object}         The transaction object
  */
-const getPastBillingTransaction = createSelector( ( state, id ) => {
-	return find( getPastBillingTransactions( state ), { id } ) || null;
-}, getPastBillingTransactions );
-
-export default getPastBillingTransaction;
+export default createSelector(
+	( state, id ) =>
+		find( getPastBillingTransactions( state ), { id } ) ||
+		getIndividualBillingTransaction( state, id ),
+	( state, id ) => [
+		getPastBillingTransactions( state ),
+		getIndividualBillingTransaction( state, id ),
+	]
+);

--- a/client/state/selectors/is-past-billing-transaction-error.js
+++ b/client/state/selectors/is-past-billing-transaction-error.js
@@ -1,0 +1,17 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { get } from 'lodash';
+
+/**
+ * Returns true if the past billing transaction fetch errored out
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {Number}  id      ID of the transaction
+ * @return {Boolean}         True if transaction failed to fetch, false otherwise
+ */
+export default ( state, id ) =>
+	get( state, [ 'billingTransactions', 'individualTransactions', id, 'error' ], false );

--- a/client/state/selectors/is-requesting-billing-transaction.js
+++ b/client/state/selectors/is-requesting-billing-transaction.js
@@ -1,0 +1,28 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { isRequestingBillingTransactions } from 'state/selectors';
+
+/**
+ * Returns true if we are currently making a request to bulk fetch past billing
+ * transactions or fetching an individual transaction. False otherwise.
+ *
+ * @param  {Object}   state         Global state tree
+ * @param  {Number}   transactionId ID of the requested transaction
+ * @return {Boolean}                Whether a billing transaction is being requested
+ */
+export default ( state, transactionId ) =>
+	isRequestingBillingTransactions( state ) ||
+	get(
+		state,
+		[ 'billingTransactions', 'individualTransactions', transactionId, 'requesting' ],
+		false
+	);

--- a/client/state/selectors/test/get-past-billing-transaction.js
+++ b/client/state/selectors/test/get-past-billing-transaction.js
@@ -1,9 +1,8 @@
 /** @format */
-
 /**
  * External dependencies
  */
-import { expect } from 'chai';
+import { clone } from 'lodash';
 import { moment } from 'i18n-calypso';
 
 /**
@@ -35,7 +34,7 @@ describe( 'getPastBillingTransaction()', () => {
 
 	test( 'should return the billing transaction data for a known transaction', () => {
 		const output = getPastBillingTransaction( state, '12345678' );
-		expect( output ).to.eql( {
+		expect( output ).toEqual( {
 			...state.billingTransactions.items.past[ 0 ],
 			date: moment( '2016-12-12T11:22:33+0000' ).toDate(),
 		} );
@@ -43,7 +42,7 @@ describe( 'getPastBillingTransaction()', () => {
 
 	test( 'should return null for an unknown billing transaction', () => {
 		const output = getPastBillingTransaction( state, '87654321' );
-		expect( output ).to.be.null;
+		expect( output ).toEqual( null );
 	} );
 
 	test( 'should return null if billing transactions have not been fetched yet', () => {
@@ -55,6 +54,42 @@ describe( 'getPastBillingTransaction()', () => {
 			},
 			'12345678'
 		);
-		expect( output ).to.be.null;
+		expect( output ).toEqual( null );
+	} );
+
+	test( 'should return a billing transaction that has been fetched individually', () => {
+		const individualTransaction = {
+			id: '999999',
+			amount: '$1.23',
+			date: '2017-01-01T11:22:33+0000',
+		};
+
+		const testState = clone( state );
+		testState.billingTransactions.individualTransactions = {
+			999999: { data: individualTransaction },
+		};
+
+		const output = getPastBillingTransaction( testState, 999999 );
+		expect( output ).toEqual( individualTransaction );
+	} );
+
+	test( 'should return null for individual transaction that is being fetched', () => {
+		const testState = clone( state );
+		testState.billingTransactions.individualTransactions = {
+			999999: { requesting: true },
+		};
+
+		const output = getPastBillingTransaction( testState, 999999 );
+		expect( output ).toEqual( null );
+	} );
+
+	test( 'should return null for individual transaction that failed to fetch', () => {
+		const testState = clone( state );
+		testState.billingTransactions.individualTransactions = {
+			999999: { error: true },
+		};
+
+		const output = getPastBillingTransaction( testState, 999999 );
+		expect( output ).toEqual( null );
 	} );
 } );

--- a/client/state/selectors/test/get-past-billing-transaction.js
+++ b/client/state/selectors/test/get-past-billing-transaction.js
@@ -70,7 +70,7 @@ describe( 'getPastBillingTransaction()', () => {
 		};
 
 		const output = getPastBillingTransaction( testState, 999999 );
-		expect( output ).toEqual( individualTransaction );
+		expect( output ).toBe( individualTransaction );
 	} );
 
 	test( 'should return null for individual transaction that is being fetched', () => {

--- a/client/state/selectors/test/get-past-billing-transaction.js
+++ b/client/state/selectors/test/get-past-billing-transaction.js
@@ -42,7 +42,7 @@ describe( 'getPastBillingTransaction()', () => {
 
 	test( 'should return null for an unknown billing transaction', () => {
 		const output = getPastBillingTransaction( state, '87654321' );
-		expect( output ).toEqual( null );
+		expect( output ).toBeNull();
 	} );
 
 	test( 'should return null if billing transactions have not been fetched yet', () => {
@@ -54,7 +54,7 @@ describe( 'getPastBillingTransaction()', () => {
 			},
 			'12345678'
 		);
-		expect( output ).toEqual( null );
+		expect( output ).toBeNull();
 	} );
 
 	test( 'should return a billing transaction that has been fetched individually', () => {
@@ -80,7 +80,7 @@ describe( 'getPastBillingTransaction()', () => {
 		};
 
 		const output = getPastBillingTransaction( testState, 999999 );
-		expect( output ).toEqual( null );
+		expect( output ).toBeNull();
 	} );
 
 	test( 'should return null for individual transaction that failed to fetch', () => {
@@ -90,6 +90,6 @@ describe( 'getPastBillingTransaction()', () => {
 		};
 
 		const output = getPastBillingTransaction( testState, 999999 );
-		expect( output ).toEqual( null );
+		expect( output ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/is-past-billing-transaction-error.js
+++ b/client/state/selectors/test/is-past-billing-transaction-error.js
@@ -1,0 +1,31 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { isPastBillingTransactionError } from 'state/selectors';
+
+describe( 'getPastBillingTransactionError()', () => {
+	const state = {
+		billingTransactions: {
+			individualTransactions: {
+				123: { error: false },
+				435: { error: true },
+			},
+		},
+	};
+
+	test( 'returns false for data the fetched successfully', () => {
+		const output = isPastBillingTransactionError( state, 123 );
+		expect( output ).toEqual( false );
+	} );
+
+	test( 'returns true for data that failed to fetch', () => {
+		const output = isPastBillingTransactionError( state, 435 );
+		expect( output ).toEqual( true );
+	} );
+
+	test( 'returns false for unknown id', () => {
+		const output = isPastBillingTransactionError( state, 679 );
+		expect( output ).toEqual( false );
+	} );
+} );

--- a/client/state/selectors/test/is-past-billing-transaction-error.js
+++ b/client/state/selectors/test/is-past-billing-transaction-error.js
@@ -16,16 +16,16 @@ describe( 'getPastBillingTransactionError()', () => {
 
 	test( 'returns false for data the fetched successfully', () => {
 		const output = isPastBillingTransactionError( state, 123 );
-		expect( output ).toEqual( false );
+		expect( output ).toBe( false );
 	} );
 
 	test( 'returns true for data that failed to fetch', () => {
 		const output = isPastBillingTransactionError( state, 435 );
-		expect( output ).toEqual( true );
+		expect( output ).toBe( true );
 	} );
 
 	test( 'returns false for unknown id', () => {
 		const output = isPastBillingTransactionError( state, 679 );
-		expect( output ).toEqual( false );
+		expect( output ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-requesting-billing-transaction.js
+++ b/client/state/selectors/test/is-requesting-billing-transaction.js
@@ -1,0 +1,45 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { cloneDeep } from 'lodash';
+/**
+ * Internal dependencies
+ */
+import { isRequestingBillingTransaction } from 'state/selectors';
+
+describe( 'isRequestingBillingTransaction()', () => {
+	const state = {
+		billingTransactions: {
+			requesting: false,
+			individualTransactions: {
+				123: { requesting: false },
+				435: { requesting: true },
+			},
+		},
+	};
+
+	test( 'returns true if the transactions batch is being requested', () => {
+		const testState = cloneDeep( state );
+		testState.billingTransactions.requesting = true;
+
+		const output = isRequestingBillingTransaction( testState, '123' );
+		expect( output ).toEqual( true );
+	} );
+
+	test( 'returns false for data that is not being requested', () => {
+		const output = isRequestingBillingTransaction( state, '123' );
+		expect( output ).toEqual( false );
+	} );
+
+	test( 'returns true for data that is being requested', () => {
+		const output = isRequestingBillingTransaction( state, '435' );
+		expect( output ).toEqual( true );
+	} );
+
+	test( 'returns false for unknown id', () => {
+		const output = isRequestingBillingTransaction( state, '679' );
+		expect( output ).toEqual( false );
+	} );
+} );

--- a/client/state/selectors/test/is-requesting-billing-transaction.js
+++ b/client/state/selectors/test/is-requesting-billing-transaction.js
@@ -25,21 +25,21 @@ describe( 'isRequestingBillingTransaction()', () => {
 		testState.billingTransactions.requesting = true;
 
 		const output = isRequestingBillingTransaction( testState, '123' );
-		expect( output ).toEqual( true );
+		expect( output ).toBe( true );
 	} );
 
 	test( 'returns false for data that is not being requested', () => {
 		const output = isRequestingBillingTransaction( state, '123' );
-		expect( output ).toEqual( false );
+		expect( output ).toBe( false );
 	} );
 
 	test( 'returns true for data that is being requested', () => {
 		const output = isRequestingBillingTransaction( state, '435' );
-		expect( output ).toEqual( true );
+		expect( output ).toBe( true );
 	} );
 
 	test( 'returns false for unknown id', () => {
 		const output = isRequestingBillingTransaction( state, '679' );
-		expect( output ).toEqual( false );
+		expect( output ).toBe( false );
 	} );
 } );


### PR DESCRIPTION
Adds individual receipts selectors extracted from #22442 

Depends on #23497

Now with Jest tests

Test instructions:
* unit tests should pass and the code should have no issues
* #23500 puts all the individual receipts PRs together - the specifications listed there should be met