### PR TITLE
Individual receipts - UI changes

### DIFF
--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -17,10 +17,14 @@ import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { billingHistory } from 'me/purchases/paths';
-import QueryBillingTransactions from 'components/data/query-billing-transactions';
+import QueryBillingTransaction from 'components/data/query-billing-transaction';
 import tableRows from './table-rows';
 import { groupDomainProducts } from './utils';
-import { getPastBillingTransaction, getPastBillingTransactions } from 'state/selectors';
+import { getPastBillingTransaction, isPastBillingTransactionError } from 'state/selectors';
+import {
+	requestBillingTransaction,
+	clearBillingTransactionError,
+} from 'state/billing-transactions/individual-transactions/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 class BillingReceipt extends React.Component {
@@ -46,11 +50,14 @@ class BillingReceipt extends React.Component {
 	};
 
 	redirectIfInvalidTransaction() {
-		const { totalTransactions, transaction } = this.props;
+		const { transactionFetchError } = this.props;
 
-		if ( ! transaction && totalTransactions !== null ) {
-			page.redirect( billingHistory );
+		if ( ! transactionFetchError ) {
+			return;
 		}
+
+		this.props.clearBillingTransactionError();
+		page.redirect( billingHistory );
 	}
 
 	ref() {
@@ -204,7 +211,11 @@ class BillingReceipt extends React.Component {
 			<div>
 				<Card compact className="billing-history__receipt-card">
 					<div className="billing-history__app-overview">
-						<img src={ transaction.icon } title={ transaction.service } />
+						<img
+							src={ transaction.icon }
+							title={ transaction.service }
+							alt={ transaction.service }
+						/>
 						<h2>
 							{' '}
 							{ translate( '{{link}}%(service)s{{/link}} {{small}}by %(organization)s{{/small}}', {
@@ -241,18 +252,14 @@ class BillingReceipt extends React.Component {
 				</Card>
 
 				<Card compact className="billing-history__receipt-links">
-					<a
-						href={ transaction.support }
-						className="button is-primary"
-						onClick={ this.handleSupportLinkClick }
-					>
+					<Button href={ transaction.support } primary onClick={ this.handleSupportLinkClick }>
 						{ translate( 'Contact %(transactionService)s Support', {
 							args: {
 								transactionService: transaction.service,
 							},
 							context: 'transactionService is a website, such as WordPress.com.',
 						} ) }
-					</a>
+					</Button>
 					<Button onClick={ this.handlePrintLinkClick }>{ translate( 'Print Receipt' ) }</Button>
 				</Card>
 			</div>
@@ -260,7 +267,7 @@ class BillingReceipt extends React.Component {
 	}
 
 	render() {
-		const { transaction, translate } = this.props;
+		const { transaction, transactionId, translate } = this.props;
 
 		return (
 			<Main>
@@ -269,7 +276,7 @@ class BillingReceipt extends React.Component {
 					path="/me/purchases/billing/receipt"
 					title="Me > Billing History > Receipt"
 				/>
-				<QueryBillingTransactions />
+				<QueryBillingTransaction transactionId={ transactionId } />
 
 				{ this.renderTitle() }
 
@@ -280,15 +287,13 @@ class BillingReceipt extends React.Component {
 }
 
 export default connect(
-	( state, ownProps ) => {
-		const transactions = getPastBillingTransactions( state );
-
-		return {
-			transaction: getPastBillingTransaction( state, ownProps.transactionId ),
-			totalTransactions: transactions ? transactions.length : null,
-		};
-	},
+	( state, { transactionId } ) => ( {
+		transaction: getPastBillingTransaction( state, transactionId ),
+		transactionFetchError: isPastBillingTransactionError( state, transactionId ),
+	} ),
 	{
 		recordGoogleEvent,
+		requestBillingTransaction,
+		clearBillingTransactionError,
 	}
 )( localize( BillingReceipt ) );

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -22,8 +22,8 @@ import tableRows from './table-rows';
 import { groupDomainProducts } from './utils';
 import { getPastBillingTransaction, isPastBillingTransactionError } from 'state/selectors';
 import {
-	requestBillingTransaction,
 	clearBillingTransactionError,
+	requestBillingTransaction,
 } from 'state/billing-transactions/individual-transactions/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
@@ -50,13 +50,13 @@ class BillingReceipt extends React.Component {
 	};
 
 	redirectIfInvalidTransaction() {
-		const { transactionFetchError } = this.props;
+		const { transactionFetchError, transactionId } = this.props;
 
 		if ( ! transactionFetchError ) {
 			return;
 		}
 
-		this.props.clearBillingTransactionError();
+		this.props.clearBillingTransactionError( transactionId );
 		page.redirect( billingHistory );
 	}
 
@@ -292,8 +292,8 @@ export default connect(
 		transactionFetchError: isPastBillingTransactionError( state, transactionId ),
 	} ),
 	{
+		clearBillingTransactionError,
 		recordGoogleEvent,
 		requestBillingTransaction,
-		clearBillingTransactionError,
 	}
 )( localize( BillingReceipt ) );

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -306,7 +306,7 @@ export const onBillingTransactionRequestFailure = ( { transactionId, error } ) =
 	const id = `transaction-fetch-${ transactionId }`;
 	if ( 'invalid_receipt' === error.error ) {
 		return errorNotice(
-			translate( "Sorry, we couldn't find receipt #%s", { args: transactionId } ),
+			translate( "Sorry, we couldn't find receipt #%s.", { args: transactionId } ),
 			{
 				id,
 				displayOnNextPage,
@@ -315,7 +315,7 @@ export const onBillingTransactionRequestFailure = ( { transactionId, error } ) =
 		);
 	}
 
-	return errorNotice( translate( 'Sorry, we had a problem loading that receipt.' ), {
+	return errorNotice( translate( "Sorry, we weren't able to load the requested receipt." ), {
 		id,
 		displayOnNextPage,
 		button: translate( 'Try again' ),

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -25,6 +25,7 @@ import {
 	ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED,
 	BILLING_RECEIPT_EMAIL_SEND_FAILURE,
 	BILLING_RECEIPT_EMAIL_SEND_SUCCESS,
+	BILLING_TRANSACTION_REQUEST_FAILURE,
 	GRAVATAR_RECEIVE_IMAGE_FAILURE,
 	GRAVATAR_UPLOAD_REQUEST_FAILURE,
 	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
@@ -58,7 +59,7 @@ import {
 	THEME_DELETE_SUCCESS,
 	THEME_ACTIVATE_FAILURE,
 } from 'state/action-types';
-import { purchasesRoot } from 'me/purchases/paths';
+import { purchasesRoot, billingHistoryReceipt } from 'me/purchases/paths';
 
 import {
 	onAccountRecoverySettingsFetchFailed,
@@ -300,6 +301,26 @@ const onSiteDeleteFailure = ( { error } ) => {
 	return errorNotice( error.message );
 };
 
+const onBillingTransactionRequestFailure = ( { transactionId, error } ) => {
+	if ( 'invalid_receipt' === error.error ) {
+		return errorNotice(
+			translate( "Sorry, we couldn't find receipt #%s", { args: transactionId } ),
+			{
+				id: `transaction-fetch-${ transactionId }`,
+				displayOnNextPage: true,
+				duration: 5000,
+			}
+		);
+	}
+
+	return errorNotice( translate( 'Sorry, we had a problem loading that receipt.' ), {
+		id: `transaction-fetch-${ transactionId }`,
+		displayOnNextPage: true,
+		button: translate( 'Try again' ),
+		href: billingHistoryReceipt( transactionId ),
+	} );
+};
+
 /**
  * Handler action type mapping
  */
@@ -316,6 +337,7 @@ export const handlers = {
 	[ ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED ]: onAccountRecoveryPhoneValidationFailed,
 	[ BILLING_RECEIPT_EMAIL_SEND_FAILURE ]: onBillingReceiptEmailSendFailure,
 	[ BILLING_RECEIPT_EMAIL_SEND_SUCCESS ]: onBillingReceiptEmailSendSuccess,
+	[ BILLING_TRANSACTION_REQUEST_FAILURE ]: onBillingTransactionRequestFailure,
 	[ GRAVATAR_RECEIVE_IMAGE_FAILURE ]: onGravatarReceiveImageFailure,
 	[ GRAVATAR_UPLOAD_REQUEST_FAILURE ]: onGravatarUploadRequestFailure,
 	[ GRAVATAR_UPLOAD_REQUEST_SUCCESS ]: onGravatarUploadRequestSuccess,

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -301,21 +301,23 @@ const onSiteDeleteFailure = ( { error } ) => {
 	return errorNotice( error.message );
 };
 
-const onBillingTransactionRequestFailure = ( { transactionId, error } ) => {
+export const onBillingTransactionRequestFailure = ( { transactionId, error } ) => {
+	const displayOnNextPage = true;
+	const id = `transaction-fetch-${ transactionId }`;
 	if ( 'invalid_receipt' === error.error ) {
 		return errorNotice(
 			translate( "Sorry, we couldn't find receipt #%s", { args: transactionId } ),
 			{
-				id: `transaction-fetch-${ transactionId }`,
-				displayOnNextPage: true,
+				id,
+				displayOnNextPage,
 				duration: 5000,
 			}
 		);
 	}
 
 	return errorNotice( translate( 'Sorry, we had a problem loading that receipt.' ), {
-		id: `transaction-fetch-${ transactionId }`,
-		displayOnNextPage: true,
+		id,
+		displayOnNextPage,
 		button: translate( 'Try again' ),
 		href: billingHistoryReceipt( transactionId ),
 	} );

--- a/client/state/notices/test/middleware.js
+++ b/client/state/notices/test/middleware.js
@@ -13,12 +13,14 @@ import thunk from 'redux-thunk';
  */
 import noticesMiddleware, {
 	handlers,
+	onBillingTransactionRequestFailure,
 	onPostDeleteFailure,
 	onPostRestoreFailure,
 	onPostSaveSuccess,
 } from '../middleware';
 import PostQueryManager from 'lib/query-manager/post';
 import {
+	BILLING_TRANSACTION_REQUEST_FAILURE,
 	NOTICE_CREATE,
 	POST_DELETE_FAILURE,
 	POST_RESTORE_FAILURE,
@@ -228,6 +230,51 @@ describe( 'middleware', () => {
 					notice: {
 						status: 'is-success',
 						text: 'Post successfully published',
+					},
+				} );
+			} );
+		} );
+
+		describe( 'onBillingTransactionRequestFailure()', () => {
+			const transactionId = 1234;
+
+			test( 'should dispatch a "not found" notice for invalid_receipt error', () => {
+				const noticeAction = onBillingTransactionRequestFailure( {
+					type: BILLING_TRANSACTION_REQUEST_FAILURE,
+					transactionId,
+					error: {
+						error: 'invalid_receipt',
+					},
+				} );
+
+				expect( noticeAction ).toMatchObject( {
+					type: NOTICE_CREATE,
+					notice: {
+						status: 'is-error',
+						text: `Sorry, we couldn't find receipt #${ transactionId }`,
+						noticeId: `transaction-fetch-${ transactionId }`,
+						displayOnNextPage: true,
+						duration: 5000,
+					},
+				} );
+			} );
+
+			test( 'should dispatch a "problem" notice for errors other than invalid_receipt', () => {
+				const noticeAction = onBillingTransactionRequestFailure( {
+					type: BILLING_TRANSACTION_REQUEST_FAILURE,
+					transactionId,
+					error: {
+						error: 'http_request_failed',
+					},
+				} );
+
+				expect( noticeAction ).toMatchObject( {
+					type: NOTICE_CREATE,
+					notice: {
+						status: 'is-error',
+						text: 'Sorry, we had a problem loading that receipt.',
+						noticeId: `transaction-fetch-${ transactionId }`,
+						displayOnNextPage: true,
 					},
 				} );
 			} );

--- a/client/state/notices/test/middleware.js
+++ b/client/state/notices/test/middleware.js
@@ -251,7 +251,7 @@ describe( 'middleware', () => {
 					type: NOTICE_CREATE,
 					notice: {
 						status: 'is-error',
-						text: `Sorry, we couldn't find receipt #${ transactionId }`,
+						text: `Sorry, we couldn't find receipt #${ transactionId }.`,
 						noticeId: `transaction-fetch-${ transactionId }`,
 						displayOnNextPage: true,
 						duration: 5000,
@@ -272,7 +272,7 @@ describe( 'middleware', () => {
 					type: NOTICE_CREATE,
 					notice: {
 						status: 'is-error',
-						text: 'Sorry, we had a problem loading that receipt.',
+						text: "Sorry, we weren't able to load the requested receipt.",
 						noticeId: `transaction-fetch-${ transactionId }`,
 						displayOnNextPage: true,
 					},


### PR DESCRIPTION
Adds UI changes for fetching older individual receipts from #22442 

Depends on #23499

To test:
* attempt to load an old receipt (one that is not included in the first 200 that are fetched on the history page) by navigating directly to its URL (/me/purchases/billing/{receiptId})
  * the page should load
* attempt to load an invalid receipt ID
  * the page should redirect to the billing history page and show a notice