### PR TITLE
Pages: Prevent deleted untitled pages to show up as "#0" or "#null" and update their style

### DIFF
--- a/client/my-sites/pages/blog-posts-page/index.jsx
+++ b/client/my-sites/pages/blog-posts-page/index.jsx
@@ -41,8 +41,8 @@ class BlogPostsPage extends React.Component {
 			return pageTitle;
 		}
 		return pageId
-			? `#${ pageId } ${ this.props.translate( '(no title)' ) }`
-			: this.props.translate( '(no title)' );
+			? `${ this.props.translate( 'Untitled' ) } (#${ pageId })`
+			: this.props.translate( 'Untitled' );
 	};
 
 	getPostsPageLink( { isStaticHomePageWithNoPostsPage, isCurrentlySetAsHomepage } ) {

--- a/client/my-sites/pages/blog-posts-page/index.jsx
+++ b/client/my-sites/pages/blog-posts-page/index.jsx
@@ -35,9 +35,15 @@ class BlogPostsPage extends React.Component {
 			.shift();
 	}
 
-	getPageTitle = pageId =>
-		this.getPageProperty( { pageId, property: 'title' } ) ||
-		`#${ pageId } ${ this.props.translate( '(no title)' ) }`;
+	getPageTitle = pageId => {
+		const pageTitle = this.getPageProperty( { pageId, property: 'title' } );
+		if ( pageTitle ) {
+			return pageTitle;
+		}
+		return pageId
+			? `#${ pageId } ${ this.props.translate( '(no title)' ) }`
+			: this.props.translate( '(no title)' );
+	};
 
 	getPostsPageLink( { isStaticHomePageWithNoPostsPage, isCurrentlySetAsHomepage } ) {
 		if ( isStaticHomePageWithNoPostsPage ) {

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -337,7 +337,7 @@ class Page extends Component {
 
 	render() {
 		const { page, site = {}, shadowStatus, translate } = this.props;
-		const title = page.title || translate( '(no title)' );
+		const title = page.title || translate( 'Untitled' );
 		const canEdit = utils.userCan( 'edit_post', page );
 		const depthIndicator = ! this.props.hierarchical && page.parent && '— ';
 
@@ -382,6 +382,7 @@ class Page extends Component {
 		const cardClasses = {
 			page: true,
 			'is-indented': this.props.hierarchical && this.props.hierarchyLevel > 0,
+			'is-untitled': ! page.title,
 		};
 
 		const hierarchyIndentClasses = {

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 // Page list
 
 .pages__page-list {
@@ -13,7 +15,7 @@
 
 .pages__page-list-header {
 	background: $gray-light;
-	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ), 0 1px 2px $gray-lighten-30;
+	box-shadow: 0 0 0 1px transparentize($gray-lighten-20, 0.5), 0 1px 2px $gray-lighten-30;
 	color: $gray;
 	font-size: 11px;
 	padding: 6px 11px;
@@ -34,7 +36,7 @@
 	.site-icon {
 		display: none;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			display: block;
 			margin-right: 10px;
 			min-width: 34px;
@@ -72,17 +74,15 @@
 			padding-left: 136px;
 		}
 	}
-
 }
 
-.page__hierarchy-indent{
+.page__hierarchy-indent {
 	background: $gray-light;
 	position: absolute;
 	top: 0;
 	left: 0;
 	height: 100%;
-	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
-		0 1px 2px $gray-lighten-30;
+	box-shadow: 0 0 0 1px transparentize($gray-lighten-20, 0.5), 0 1px 2px $gray-lighten-30;
 
 	&.is-indented {
 		width: 112px;
@@ -137,6 +137,10 @@
 		margin: 2px 8px -2px 0;
 	}
 }
+.page.is-untitled .page__title {
+	color: $gray;
+	font-style: italic;
+}
 
 .page__actions-toggle {
 	margin-left: 24px;
@@ -166,8 +170,8 @@
 	right: 0;
 	top: 0;
 	bottom: 0;
-	z-index: z-index( 'root', '.page__shadow-notice-cover' );
-	background-color: rgba( $gray-light, 0.8 );
+	z-index: z-index('root', '.page__shadow-notice-cover');
+	background-color: rgba($gray-light, 0.8);
 	display: flex;
 	align-items: center;
 	overflow: hidden;
@@ -175,16 +179,16 @@
 
 @keyframes shadow-notice-appear {
 	0% {
-		transform: translateX( 50px );
+		transform: translateX(50px);
 	}
 
 	100% {
-		transform: translateX( 0 );
+		transform: translateX(0);
 	}
 }
 
 .notice.is-compact.page__shadow-notice {
 	margin-left: auto;
 	margin-right: 24px;
-	animation: shadow-notice-appear 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 ); // http://easings.net/#easeOutBack
+	animation: shadow-notice-appear 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275); // http://easings.net/#easeOutBack
 }


### PR DESCRIPTION
Fix issue raised here: https://github.com/Automattic/wp-calypso/pull/23444#issuecomment-374755277

Guard untitled page titles to display their ID if they don't have one (e.g. they are deleted).
Also change the placeholder text from "(no title)" to "Untitled" to make it consistent with the Posts list.

| Location | Screenshot |
| --- | --- |
| Page | <img width="550" alt="screen shot 2018-03-22 at 16 21 01" src="https://user-images.githubusercontent.com/2070010/37783647-ec05af2c-2ded-11e8-8b37-2db71abbe3bc.png"> |
| Blog Posts Page | <img width="738" alt="screen shot 2018-03-22 at 16 24 19" src="https://user-images.githubusercontent.com/2070010/37783686-052b6f32-2dee-11e8-8d69-723cb1981867.png"> |
| Blog Posts Page (Deleted) | <img width="550" alt="screen shot 2018-03-22 at 16 20 53" src="https://user-images.githubusercontent.com/2070010/37783728-18e3fb3e-2dee-11e8-9856-8cb684c5a404.png"> |

### Notes

Please excuse the unnecessary CSS changes, my local Prettier is way too aggressive some times.
Anyway, my only actual changes are [lines 140-143](https://github.com/Automattic/wp-calypso/pull/23501/files#diff-c811b2b91cb1d12dc700d426f663ddb9R140).

## Testing instructions

- Create a page without a title.
- Make sure it's called `Untitled` (in gray) in the pages list.
- Head over to Customizer -> Homepage Settings, choose "A static page", and pick the untitled page in the "Posts page" selector. Publish your changes.
- Exit the Customizer and open Site Pages.
- Make sure the Blog Posts page now shows up as `Untitled (#${ pageId })`.
- Delete the page, and make sure the Blog Posts page now shows up simply as `Untitled`.