### PR TITLE
JP Remote Install: Add an error notice for unknown error cases

### DIFF
--- a/client/jetpack-connect/connection-notice-types.js
+++ b/client/jetpack-connect/connection-notice-types.js
@@ -25,5 +25,6 @@ export const INVALID_PERMISSIONS = 'invalidPermissions';
 export const RETRY_AUTH = 'retryAuth';
 export const RETRYING_AUTH = 'retryingAuth';
 export const SECRET_EXPIRED = 'secretExpired';
+export const UNKNOWN_REMOTE_INSTALL_ERROR = 'unknownRemoteInstallError';
 export const USER_IS_ALREADY_CONNECTED_TO_SITE = 'userIsAlreadyConnectedToSite';
 export const WORDPRESS_DOT_COM = 'wordpress.com';

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -31,6 +31,7 @@ import {
 	RETRY_AUTH,
 	RETRYING_AUTH,
 	SECRET_EXPIRED,
+	UNKNOWN_REMOTE_INSTALL_ERROR,
 	USER_IS_ALREADY_CONNECTED_TO_SITE,
 	WORDPRESS_DOT_COM,
 } from './connection-notice-types';
@@ -64,6 +65,7 @@ export class JetpackConnectNotices extends Component {
 			RETRY_AUTH,
 			RETRYING_AUTH,
 			SECRET_EXPIRED,
+			UNKNOWN_REMOTE_INSTALL_ERROR,
 			USER_IS_ALREADY_CONNECTED_TO_SITE,
 			WORDPRESS_DOT_COM,
 		] ).isRequired,
@@ -277,6 +279,26 @@ export class JetpackConnectNotices extends Component {
 				);
 				noticeValues.status = 'is-warning';
 				noticeValues.icon = 'notice';
+				return noticeValues;
+
+			case UNKNOWN_REMOTE_INSTALL_ERROR:
+				noticeValues.text = translate(
+					'Something went wrong. You can try again, {{manualInstall}}install Jetpack manually{{/manualInstall}} ' +
+						'or {{support}}contact support{{/support}} for help.',
+					{
+						components: {
+							manualInstall: (
+								<a
+									href={ this.getHelperUrl( 'manual' ) }
+									onClick={ this.trackManualInstallClick }
+								/>
+							),
+							support: (
+								<a href={ this.getHelperUrl( 'support' ) } onClick={ this.trackSupportClick } />
+							),
+						},
+					}
+				);
 				return noticeValues;
 		}
 	}

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -36,6 +36,7 @@ import {
 	INSTALL_FAILURE,
 	INVALID_PERMISSIONS,
 	LOGIN_FAILURE,
+	UNKNOWN_REMOTE_INSTALL_ERROR,
 } from './connection-notice-types';
 
 export class OrgCredentialsForm extends Component {
@@ -120,6 +121,7 @@ export class OrgCredentialsForm extends Component {
 		if ( installError === 'FORBIDDEN' ) {
 			return INVALID_PERMISSIONS;
 		}
+		return UNKNOWN_REMOTE_INSTALL_ERROR;
 	}
 
 	renderNotice() {


### PR DESCRIPTION
Add a catch-all notice for when we receive some kind of error from the install API call that we are not expecting.

<img width="659" alt="screen shot 2018-03-21 at 13 51 53" src="https://user-images.githubusercontent.com/7767559/37714339-3950105c-2d11-11e8-9aa3-33e0dc06ff67.png">

## Testing

Tricky because this covers cases we don't know how to reproduce. One way:
* Sandbox public-api.wordpress.com
* Modify the jetpack-remote-install endpoint to always return some error code we don't handle
* Start the connection process with a non-jp site at calypso.localhost:3000/jetpack/connect
* Check that the notice shows, and that the links work and that it is possible to re-submit the form
