### PR TITLE
JetpackLogo - now the lightning will be white by default

### DIFF
--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -1,6 +1,6 @@
 .login {
 
-	.jetpack-logo__icon { fill: $green-jetpack }
+	.jetpack-logo__icon-circle { fill: $green-jetpack }
 	&.is-jetpack {
 		.button.is-primary {
 			background-color: $green-jetpack;

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -1,6 +1,5 @@
 .login {
 
-	.jetpack-logo__icon-circle { fill: $green-jetpack }
 	&.is-jetpack {
 		.button.is-primary {
 			background-color: $green-jetpack;

--- a/client/components/jetpack-colophon/style.scss
+++ b/client/components/jetpack-colophon/style.scss
@@ -7,6 +7,9 @@
 		display: inline-block;
 		fill: currentColor;
 	}
+	.jetpack-logo__icon-circle {
+		fill: currentColor;
+	}
 	@include breakpoint( "<660px" ) {
 		margin-bottom: 24px;
 	}

--- a/client/components/jetpack-logo/index.jsx
+++ b/client/components/jetpack-logo/index.jsx
@@ -13,6 +13,7 @@ const logoPathSize32 = (
 	<g>
 		<path
 			className="jetpack-logo__icon-circle"
+			fill="#00be28"
 			d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z"
 		/>
 		<polygon className="jetpack-logo__icon-triangle" fill="#fff" points="15,19 7,19 15,3 " />

--- a/client/components/jetpack-logo/index.jsx
+++ b/client/components/jetpack-logo/index.jsx
@@ -10,10 +10,14 @@ import PropTypes from 'prop-types';
  * Module constants
  */
 const logoPathSize32 = (
-	<path
-		className="jetpack-logo__icon"
-		d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16c8.8,0,16-7.2,16-16S24.8,0,16,0z M15.2,18.7h-8l8-15.5V18.7z M16.8,28.8 V13.3h8L16.8,28.8z"
-	/> // eslint-disable-line max-len
+	<g>
+		<path
+			className="jetpack-logo__icon-circle"
+			d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z"
+		/>
+		<polygon className="jetpack-logo__icon-triangle" fill="#fff" points="15,19 7,19 15,3 " />
+		<polygon className="jetpack-logo__icon-triangle" fill="#fff" points="17,29 17,13 25,13 " />
+	</g>
 );
 const svgLogo24 = (
 	// eslint-disable-next-line wpcalypso/jsx-classname-namespace

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -45,7 +45,7 @@
 .jetpack-connect__main-logo {
 	text-align: center;
 
-	.jetpack-logo__icon {
+	.jetpack-logo__icon-circle {
 		fill: $green-jetpack;
 	}
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -45,10 +45,6 @@
 .jetpack-connect__main-logo {
 	text-align: center;
 
-	.jetpack-logo__icon-circle {
-		fill: $green-jetpack;
-	}
-
 	@include breakpoint( '<660px' ) {
 		margin-top: 20px;
 	}

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -89,10 +89,6 @@
 	.jetpack-logo {
 		display: block;
 		margin: 20px auto;
-
-		.jetpack-logo__icon-circle {
-			fill: $green-jetpack;
-		}
 	}
 }
 

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -90,7 +90,7 @@
 		display: block;
 		margin: 20px auto;
 
-		.jetpack-logo__icon {
+		.jetpack-logo__icon-circle {
 			fill: $green-jetpack;
 		}
 	}


### PR DESCRIPTION
Fixes #23420 

* I rebuilt the icon to be a little simpler to understand. Now it is composed of basic shapes.
* I added classes for easier targeting
* I updated the three places that were targeting it via class to use the new classNames.

#### Testing
Test on:
* The login page
* https://wordpress.com/jetpack/connect
* JPO CC @joanrho 

#### Before
<img width="428" alt="image" src="https://user-images.githubusercontent.com/1123119/37718444-4adc4cf6-2ce8-11e8-89c0-4726446125c3.png">

#### After
<img width="451" alt="image" src="https://user-images.githubusercontent.com/1123119/37718250-ea540360-2ce7-11e8-9f16-d30698c5e9aa.png">