### PR TITLE
Store Dashboard: Update controls in inventory widget

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/controls.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/controls.js
@@ -55,6 +55,19 @@ class InventoryControls extends Component {
 		this.setState( { [ name ]: isNaN( value ) ? 0 : value } );
 	};
 
+	increaseValue = name => () => {
+		const value = this.state[ name ];
+		this.setState( { [ name ]: value + 1 } );
+	};
+
+	decreaseValue = name => () => {
+		const value = this.state[ name ];
+		if ( value < 1 ) {
+			return;
+		}
+		this.setState( { [ name ]: value - 1 } );
+	};
+
 	setChecked = name => () => {
 		this.setState( state => ( { [ name ]: ! state[ name ] } ) );
 	};
@@ -96,6 +109,22 @@ class InventoryControls extends Component {
 		}, 150 );
 	};
 
+	renderPlus = name => {
+		return (
+			<span onClick={ this.increaseValue( name ) } tabIndex="-1" aria-hidden>
+				<Gridicon icon="plus-small" />
+			</span>
+		);
+	};
+
+	renderMinus = name => {
+		return (
+			<span onClick={ this.decreaseValue( name ) } tabIndex="-1" aria-hidden>
+				<Gridicon icon="minus-small" />
+			</span>
+		);
+	};
+
 	render() {
 		const { translate } = this.props;
 		const {
@@ -117,8 +146,9 @@ class InventoryControls extends Component {
 							onChange={ this.setValue( 'lowStockThreshold' ) }
 						/>
 						<Range
-							minContent={ <Gridicon icon="minus-small" /> }
-							maxContent={ <Gridicon icon="plus-small" /> }
+							minContent={ this.renderMinus( 'lowStockThreshold' ) }
+							maxContent={ this.renderPlus( 'lowStockThreshold' ) }
+							aria-describedby="low_stock_amount_help"
 							max="100"
 							value={ lowStockThreshold }
 							onChange={ this.setValue( 'lowStockThreshold' ) }
@@ -140,8 +170,9 @@ class InventoryControls extends Component {
 							onChange={ this.setValue( 'noStockThreshold' ) }
 						/>
 						<Range
-							minContent={ <Gridicon icon="minus-small" /> }
-							maxContent={ <Gridicon icon="plus-small" /> }
+							minContent={ this.renderMinus( 'noStockThreshold' ) }
+							maxContent={ this.renderPlus( 'noStockThreshold' ) }
+							aria-describedby="no_stock_amount_help"
 							max="100"
 							value={ noStockThreshold }
 							onChange={ this.setValue( 'noStockThreshold' ) }

--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/controls.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/controls.js
@@ -59,6 +59,10 @@ class InventoryControls extends Component {
 		this.setState( state => ( { [ name ]: ! state[ name ] } ) );
 	};
 
+	close = () => {
+		this.props.close();
+	};
+
 	saveSettings = event => {
 		event.preventDefault();
 		const { site, translate } = this.props;
@@ -88,7 +92,7 @@ class InventoryControls extends Component {
 
 		// Give a little time between "Save" & closing
 		setTimeout( () => {
-			this.props.close();
+			this.close();
 		}, 150 );
 	};
 
@@ -169,6 +173,7 @@ class InventoryControls extends Component {
 					</FormLabel>
 				</FormFieldset>
 
+				<Button onClick={ this.close }>{ translate( 'Cancel' ) }</Button>
 				<Button onClick={ this.saveSettings } primary>
 					{ translate( 'Save' ) }
 				</Button>

--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/controls.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/controls.js
@@ -57,6 +57,9 @@ class InventoryControls extends Component {
 
 	increaseValue = name => () => {
 		const value = this.state[ name ];
+		if ( value >= 99 ) {
+			return;
+		}
 		this.setState( { [ name ]: value + 1 } );
 	};
 
@@ -149,7 +152,7 @@ class InventoryControls extends Component {
 							minContent={ this.renderMinus( 'lowStockThreshold' ) }
 							maxContent={ this.renderPlus( 'lowStockThreshold' ) }
 							aria-describedby="low_stock_amount_help"
-							max="100"
+							max="99"
 							value={ lowStockThreshold }
 							onChange={ this.setValue( 'lowStockThreshold' ) }
 						/>
@@ -173,7 +176,7 @@ class InventoryControls extends Component {
 							minContent={ this.renderMinus( 'noStockThreshold' ) }
 							maxContent={ this.renderPlus( 'noStockThreshold' ) }
 							aria-describedby="no_stock_amount_help"
-							max="100"
+							max="99"
 							value={ noStockThreshold }
 							onChange={ this.setValue( 'noStockThreshold' ) }
 						/>

--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
@@ -122,4 +122,8 @@
 	.form-checkbox:checked:before {
 		margin-top: 0;
 	}
+
+	.button + .button {
+		margin-left: 8px;
+	}
 }

--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
@@ -117,6 +117,14 @@
 			max-width: 50px;
 			margin-right: 8px;
 		}
+
+		.gridicon {
+			display: block;
+		}
+
+		.range__content > span {
+			cursor: pointer;
+		}
 	}
 
 	.form-checkbox:checked:before {


### PR DESCRIPTION
This PR follows up on the remaining issues in #23410:

- Add click handlers to the +/- around the range element
- Add a cancel button into the popover

<img width="326" alt="screen shot 2018-03-21 at 11 05 43 am" src="https://user-images.githubusercontent.com/541093/37718552-56d1b080-2cf9-11e8-8b67-17760d3a0c8f.png">

The click elements are intentionally "hidden" from keyboard & screen readers, they can change the values using the text input or moving the range slider with the keyboard, adding the buttons for these users is just another thing to tab through.

**To test**

- View the dashboard: `/store/:site`
- Open the widget control panel by clicking the gear
- Click the +/- next to the range slider
- Watch the values change
- Check that they save
- Open the control panel again
- Make some changes
- Click "Cancel"
- Make sure the changes did not save