### PR TITLE
Store Services: clarify the package max weight field.

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/packages/edit-package.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/edit-package.js
@@ -16,7 +16,6 @@ import FormDimensionsInput from 'woocommerce/components/form-dimensions-input';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 import FieldError from '../../components/field-error';
@@ -198,9 +197,6 @@ const EditPackage = props => {
 					/>
 					{ fieldInfo( 'max_weight' ) }
 				</div>
-				<FormSettingExplanation>
-					{ translate( 'Defines both the weight of the empty package and its maximum weight' ) }
-				</FormSettingExplanation>
 			</FormFieldset>
 		</div>
 	);

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/edit-package.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/edit-package.js
@@ -182,7 +182,9 @@ const EditPackage = props => {
 					{ fieldInfo( 'box_weight' ) }
 				</div>
 				<div className="packages__add-package-weight">
-					<FormLabel htmlFor="max_weight">{ translate( 'Max weight package can hold' ) }</FormLabel>
+					<FormLabel htmlFor="max_weight">
+						{ translate( 'Max weight of package and contents' ) }
+					</FormLabel>
 					<FormTextInputWithAffixes
 						id="max_weight"
 						name="max_weight"
@@ -197,9 +199,7 @@ const EditPackage = props => {
 					{ fieldInfo( 'max_weight' ) }
 				</div>
 				<FormSettingExplanation>
-					{ translate(
-						'Defines both the weight of the empty package and the max weight it can hold'
-					) }
+					{ translate( 'Defines both the weight of the empty package and its maximum weight' ) }
 				</FormSettingExplanation>
 			</FormFieldset>
 		</div>


### PR DESCRIPTION
Mention that package max weight is inclusive of the package itself and its contents.

From user feedback here: https://github.com/Automattic/woocommerce-services/issues/950#issuecomment-374615825

**Before:**

![](https://user-images.githubusercontent.com/63922/32975488-c5c74900-cbc4-11e7-80ca-e1ae25798b92.png)

**After:**

![screen shot 2018-03-21 at 9 30 26 am](https://user-images.githubusercontent.com/63922/37719386-84019192-2cea-11e8-8f40-38f93a161b0d.png)
