### PR TITLE
Devdocs: Disable auto-focus in `CreditCardForm` example

### DIFF
--- a/client/blocks/credit-card-form/README.md
+++ b/client/blocks/credit-card-form/README.md
@@ -27,3 +27,4 @@ render() {
 * `recordFormSubmitEvent`: Function to be executed when the user clicks the _Save Card_ button.
 * `saveStoredCard`: Optional function returning _Promise_ to be executed when a credit card token is created after the user clicked the _Save Card_ button. By default `wpcom.updateCreditCard` Redux action is executed because of legacy reasons.
 * `successCallback`: Function to be executed when a credit card is successfully stored.
+* `autoFocus`: Whether the first field (cardholder name) should steal the focus when this component is rendered.  Default `true`.

--- a/client/blocks/credit-card-form/docs/example.jsx
+++ b/client/blocks/credit-card-form/docs/example.jsx
@@ -27,6 +27,7 @@ const CreditCardFormExample = () => {
 			recordFormSubmitEvent={ noop }
 			saveStoredCard={ saveStoredCard }
 			successCallback={ noop }
+			autoFocus={ false }
 		/>
 	);
 };

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -242,6 +242,10 @@ class CreditCardForm extends Component {
 						eventFormName="Edit Card Details Form"
 						onFieldChange={ this.onFieldChange }
 						getErrorMessage={ this.getErrorMessage }
+						// "This prop can reduce usability and accessibility",
+						// but it's already enabled by default and this just
+						// provides a way to disable it, so...
+						// eslint-disable-next-line jsx-a11y/no-autofocus
 						autoFocus={ autoFocus }
 					/>
 					<div className="credit-card-form__card-terms">

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -36,6 +36,7 @@ class CreditCardForm extends Component {
 		saveStoredCard: PropTypes.func,
 		successCallback: PropTypes.func.isRequired,
 		showUsedForExistingPurchasesInfo: PropTypes.bool,
+		autoFocus: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -43,6 +44,7 @@ class CreditCardForm extends Component {
 		initialValues: {},
 		saveStoredCard: null,
 		showUsedForExistingPurchasesInfo: false,
+		autoFocus: true,
 	};
 
 	state = {
@@ -230,7 +232,7 @@ class CreditCardForm extends Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { translate, autoFocus } = this.props;
 		return (
 			<form onSubmit={ this.onSubmit } ref={ this.storeForm }>
 				<Card className="credit-card-form__content">
@@ -240,6 +242,7 @@ class CreditCardForm extends Component {
 						eventFormName="Edit Card Details Form"
 						onFieldChange={ this.onFieldChange }
 						getErrorMessage={ this.getErrorMessage }
+						autoFocus={ autoFocus }
 					/>
 					<div className="credit-card-form__card-terms">
 						<Gridicon icon="info-outline" size={ 18 } />

--- a/client/components/credit-card-form-fields/README.md
+++ b/client/components/credit-card-form-fields/README.md
@@ -63,3 +63,7 @@ A function that checks if a given field is valid or not. The function is passed 
 ### `onFieldChange`
 
 A function invoked when the value of an input field changes. This provides access to the raw value as well as the masked value if the corresponding field.
+
+### `autoFocus`
+
+Whether the first field (cardholder name) should steal the focus when this component is rendered.  Default `true`.

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -27,12 +27,14 @@ export class CreditCardFormFields extends React.Component {
 		eventFormName: PropTypes.string,
 		onFieldChange: PropTypes.func,
 		getErrorMessage: PropTypes.func,
+		autoFocus: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		eventFormName: 'Credit card input',
 		onFieldChange: noop,
 		getErrorMessage: noop,
+		autoFocus: true,
 	};
 
 	constructor( props ) {
@@ -191,7 +193,7 @@ export class CreditCardFormFields extends React.Component {
 	}
 
 	render() {
-		const { translate, countriesList } = this.props;
+		const { translate, countriesList, autoFocus } = this.props;
 		const ebanxDetailsRequired = this.shouldRenderEbanx();
 		const creditCardFormFieldsExtrasClassNames = classNames( {
 			'credit-card-form-fields__extras': true,
@@ -201,7 +203,7 @@ export class CreditCardFormFields extends React.Component {
 		return (
 			<div className="credit-card-form-fields">
 				{ this.createField( 'name', Input, {
-					autoFocus: true,
+					autoFocus,
 					label: translate( 'Name on Card', {
 						context: 'Card holder name label on credit card form',
 					} ),


### PR DESCRIPTION
There is a bug in `/devdocs/blocks`:

- Go to `/devdocs/blocks`
- Begin slowly typing `CreditCardForm` into the search bar
- You will get to about `Cr` and the `CreditCardForm` will lazy-render and steal the input focus

This PR avoids the issue by adding an optional `autoFocus` prop to `CreditCardForm` and setting it to `false` in the devdocs example.  It should have no impact on existing uses of this form, but this should probably be tested.