### PR TITLE
QuerySites: Allow string siteId prop (slug)

### DIFF
--- a/client/components/data/query-sites/README.md
+++ b/client/components/data/query-sites/README.md
@@ -34,11 +34,11 @@ function PrimaryAndRecentSites() {
 ### `siteId`
 
 <table>
-	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Type</th><td>Number or String</td></tr>
 	<tr><th>Required</th><td>No</td></tr>
 </table>
 
-An optional prop specifying a single site to be requested.
+An optional prop specifying a single site to be requested. Can be either a site ID or slug.
 
 ### `primaryAndRecent`
 

--- a/client/components/data/query-sites/index.jsx
+++ b/client/components/data/query-sites/index.jsx
@@ -82,7 +82,11 @@ class QuerySites extends Component {
 QuerySites.propTypes = {
 	allSites: PropTypes.bool,
 	primaryAndRecent: PropTypes.bool,
-	siteId: PropTypes.number,
+	siteId: PropTypes.oneOfType( [
+		PropTypes.number,
+		// The actions and selectors we use also work with site slugs. Needed by jetpack-onboarding/main.
+		PropTypes.string,
+	] ),
 	requestingSites: PropTypes.bool,
 	requestingSite: PropTypes.bool,
 	requestSites: PropTypes.func,

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -365,9 +365,9 @@ export function isRequestingSites( state ) {
  * Returns true if a network request is in progress to fetch the specified, or
  * false otherwise.
  *
- * @param  {Object}  state  Global state tree
- * @param  {Number}  siteId Site ID
- * @return {Boolean}        Whether request is in progress
+ * @param  {Object}           state  Global state tree
+ * @param  {(Number|String)}  siteId Site ID or slug
+ * @return {Boolean}          Whether request is in progress
  */
 export function isRequestingSite( state, siteId ) {
 	return !! state.sites.requesting[ siteId ];


### PR DESCRIPTION
Furthermore, Allow `siteId` string (slug) as `isRequestingSite()` arg.
The actions and selectors we use also work with site slugs. Needed by jetpack-onboarding/main.

Follow-up to #23472.

To test: Verify that during JPO, no `propType` error is reported.