### PR TITLE
JP Remote Install: Log install API response to tracks

### DIFF
--- a/client/state/data-layer/wpcom/jetpack-install/index.js
+++ b/client/state/data-layer/wpcom/jetpack-install/index.js
@@ -14,6 +14,7 @@ import {
 	jetpackRemoteInstallUpdateError,
 } from 'state/jetpack-remote-install/actions';
 import { JETPACK_REMOTE_INSTALL } from 'state/action-types';
+import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 
 export const installJetpackPlugin = action =>
 	http(
@@ -29,10 +30,17 @@ export const installJetpackPlugin = action =>
 	);
 
 export const handleResponse = ( { url }, data ) => {
+	const logToTracks = withAnalytics(
+		recordTracksEvent( 'calypso_jpc_remote_install_api_response', {
+			remote_site_url: url,
+			data: JSON.stringify( data ),
+		} )
+	);
+
 	if ( data.status ) {
-		return jetpackRemoteInstallComplete( url );
+		return logToTracks( jetpackRemoteInstallComplete( url ) );
 	}
-	return jetpackRemoteInstallUpdateError( url, data.error.code, data.error.message );
+	return logToTracks( jetpackRemoteInstallUpdateError( url, data.error.code, data.error.message ) );
 };
 
 export default {

--- a/client/state/data-layer/wpcom/jetpack-install/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack-install/test/index.js
@@ -32,13 +32,15 @@ describe( 'installJetpackPlugin', () => {
 describe( 'handleResponse', () => {
 	test( 'should return jetpackRemoteInstallComplete on success', () => {
 		const result = handleResponse( { url }, SUCCESS_RESPONSE );
-		expect( result ).toEqual( jetpackRemoteInstallComplete( url ) );
+		expect( result ).toEqual( expect.objectContaining( jetpackRemoteInstallComplete( url ) ) );
 	} );
 
 	test( 'should return JetpackRemoteInstallUpdateError on failure', () => {
 		const result = handleResponse( { url }, FAILURE_RESPONSE );
 		expect( result ).toEqual(
-			jetpackRemoteInstallUpdateError( url, 'COULD_NOT_LOGIN', 'extra info' )
+			expect.objectContaining(
+				jetpackRemoteInstallUpdateError( url, 'COULD_NOT_LOGIN', 'extra info' )
+			)
 		);
 	} );
 } );


### PR DESCRIPTION
Log the API response to tracks for any remote install attempt for ease of diagnosing problems during internal testing phase.

<img width="1058" alt="screen shot 2018-03-21 at 16 40 05" src="https://user-images.githubusercontent.com/7767559/37723556-8c3dd6d6-2d26-11e8-9a6c-147165832d57.png">


## Testing
* Go to https://calypso.live/jetpack/connect?branch=add/jp-remote-install/log-api-response
* Set `localStorage.debug = 'calypso:analytics:tracks'` in browser console and refresh
* Enter URL of a .org site that does not have JP installed
* On next screen enter something (anything!) in the creds form and submit
* Verify in the console that the tracks event `calypso_jpc_remote_install_api_response` fires, and includes the .org site URL and the API response

