### PR TITLE
Search: small changes on the Search component to remove outdated patterns

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -103,6 +103,12 @@ class Search extends Component {
 		};
 	}
 
+	setOpenIconRef = openIcon => ( this.openIcon = openIcon );
+
+	setSearchInputRef = input => ( this.searchInput = input );
+
+	setOverlayRef = overlay => ( this.overlay = overlay );
+
 	componentWillMount() {
 		this.setState( {
 			instanceId: ++Search.instances,
@@ -214,9 +220,7 @@ class Search extends Component {
 
 	blur = () => this.searchInput.blur();
 
-	clear = () => {
-		this.setState( { keyword: '' } );
-	};
+	clear = () => this.setState( { keyword: '' } );
 
 	onBlur = event => {
 		if ( this.props.onBlur ) {
@@ -340,7 +344,7 @@ class Search extends Component {
 				<Spinner />
 				<div
 					className="search__icon-navigation"
-					ref={ openIcon => ( this.openIcon = openIcon ) } // eslint-disable-line react/jsx-no-bind
+					ref={ this.setOpenIconRef }
 					onClick={ enableOpenIcon ? this.openSearch : this.focus }
 					tabIndex={ enableOpenIcon ? '0' : null }
 					onKeyDown={ enableOpenIcon ? this.openListener : null }
@@ -357,7 +361,7 @@ class Search extends Component {
 						placeholder={ placeholder }
 						role="search"
 						value={ searchValue }
-						ref={ input => ( this.searchInput = input ) } //eslint-disable-line react/jsx-no-bind
+						ref={ this.setSearchInputRef }
 						onChange={ this.onChange }
 						onKeyUp={ this.keyUp }
 						onKeyDown={ this.keyDown }
@@ -381,10 +385,7 @@ class Search extends Component {
 
 	renderStylingDiv = () => {
 		return (
-			<div
-				className="search__text-overlay"
-				ref={ overlay => ( this.overlay = overlay ) } //eslint-disable-line react/jsx-no-bind
-			>
+			<div className="search__text-overlay" ref={ this.setOverlayRef }>
 				{ this.props.overlayStyling( this.state.keyword ) }
 			</div>
 		);

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -101,6 +101,9 @@ class Search extends Component {
 			isOpen: !! this.props.isOpen,
 			hasFocus: false,
 		};
+
+		this.closeListener = keyListener.bind( this, 'closeSearch' );
+		this.openListener = keyListener.bind( this, 'openSearch' );
 	}
 
 	setOpenIconRef = openIcon => ( this.openIcon = openIcon );
@@ -108,15 +111,6 @@ class Search extends Component {
 	setSearchInputRef = input => ( this.searchInput = input );
 
 	setOverlayRef = overlay => ( this.overlay = overlay );
-
-	componentWillMount() {
-		this.setState( {
-			instanceId: ++Search.instances,
-		} );
-
-		this.closeListener = keyListener.bind( this, 'closeSearch' );
-		this.openListener = keyListener.bind( this, 'openSearch' );
-	}
 
 	componentWillReceiveProps( nextProps ) {
 		if (

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { debounce, noop } from 'lodash';
+import { debounce, noop, uniqueId } from 'lodash';
 import i18n from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
@@ -23,7 +23,6 @@ import TranslatableString from 'components/translatable/proptype';
  * Internal variables
  */
 const SEARCH_DEBOUNCE_MS = 300;
-let instanceCount = 0;
 
 function keyListener( methodToCall, event ) {
 	switch ( event.key ) {
@@ -93,8 +92,7 @@ class Search extends Component {
 	constructor( props ) {
 		super( props );
 
-		instanceCount++;
-		this.instanceId = instanceCount;
+		this.instanceId = uniqueId();
 
 		this.state = {
 			keyword: this.props.initialValue || '',


### PR DESCRIPTION
This PR extract some changes on the `Search` component from https://github.com/Automattic/wp-calypso/pull/23368 to remove some outdated patterns and update the code to current use of `Component`:

- Removes dependency on `ReactDom`.
- Update `refs` to functions.
- Instance tracking is now a module variable and it's no longer tracked using `state`.
- Removes `componentWillMount` in favor of using a `constructor`.

There should be no regressions where this component is used (Domains, SiteSelector, SectionNav), so this may require full end-to-end testing.