### PR TITLE
JustForFun: Selector currying?!

### DIFF
--- a/client/lib/curry-selector/index.js
+++ b/client/lib/curry-selector/index.js
@@ -1,0 +1,34 @@
+import { identity, isFunction } from 'lodash';
+
+export default function( selector ) {
+	if ( ! isFunction( selector ) ) {
+		console.warn( 'something something selector is not a function...' );
+		return selector;
+	}
+
+	const arity = selector.length;
+
+    return function () {
+		return [ ...arguments ].length === arity
+      		? selector( ...arguments )
+      		: recurse( [], [ ...arguments ] );
+    };
+
+  	function createRecurser ( accumulator, first ) {
+	    return function () {
+	      	return recurse( accumulator, [ ...arguments ] );
+	    };
+  	}
+
+  	function recurse (accumulator, args) {
+    	var nextAccumulator = accumulator.concat( args );
+    	if ( nextAccumulator.length < arity ) {
+      		return createRecurser( nextAccumulator );
+    	} else {
+			const state = [ ...nextAccumulator ].pop();
+			const rest = [ ...nextAccumulator ].slice( 0, -1);
+
+      		return selector.apply( this, [ state, ...rest ] );
+    	}
+  	}
+};

--- a/client/lib/curry-selector/index.js
+++ b/client/lib/curry-selector/index.js
@@ -1,6 +1,16 @@
+/** @format */
+/**
+ * External dependencies
+ */
 import { identity, isFunction } from 'lodash';
 
-export default function( selector ) {
+/**
+ * Internal dependencies
+ */
+import { getSiteCommentCounts } from 'state/selectors'
+import { getPreference } from 'state/preferences/selectors';
+
+const currySelector = function( selector ) {
 	if ( ! isFunction( selector ) ) {
 		console.warn( 'something something selector is not a function...' );
 		return selector;
@@ -14,21 +24,70 @@ export default function( selector ) {
       		: recurse( [], [ ...arguments ] );
     };
 
-  	function createRecurser ( accumulator, first ) {
+  	function nextRecursor( accumulator ) {
 	    return function () {
 	      	return recurse( accumulator, [ ...arguments ] );
 	    };
   	}
 
-  	function recurse (accumulator, args) {
-    	var nextAccumulator = accumulator.concat( args );
+  	function recurse( accumulator, args ) {
+    	const nextAccumulator = accumulator.concat( args );
+
     	if ( nextAccumulator.length < arity ) {
-      		return createRecurser( nextAccumulator );
+      		return nextRecursor( nextAccumulator );
     	} else {
 			const state = [ ...nextAccumulator ].pop();
-			const rest = [ ...nextAccumulator ].slice( 0, -1);
+			const rest = [ ...nextAccumulator ].slice( 0, -1 );
 
       		return selector.apply( this, [ state, ...rest ] );
     	}
   	}
 };
+
+export default currySelector;
+
+export const quickTest = () => {
+	const siteId1 = 'siteId1';
+	const postId1 = 'postId1';
+	const postId2 = 'postId2';
+	const siteId2 = 'siteId2';
+	const postId3 = 'postId3';
+	const postId4 = 'postId4';
+
+	const state = {
+		comments: {
+			counts: {
+				[ siteId1 ]: {
+					[ postId1 ]: 11,
+					[ postId2 ]: 22,
+				},
+				[ siteId2 ]: {
+					[ postId3 ]: 33,
+				},
+			},
+		},
+		preferences: {
+			localValues: {
+				'colorScheme': 'blue!',
+			}
+		}
+	};
+
+	const curriedGetPreference = currySelector( getPreference );
+	const curriedGetSiteCommentCounts = currySelector( getSiteCommentCounts );
+
+	const getColorSchemePreference = curriedGetPreference( 'colorScheme' );
+	const colorSchemePreference = getColorSchemePreference( state );
+
+
+	const siteCommentCount1 = curriedGetSiteCommentCounts( state, siteId1, postId1 );
+	const siteCommentCount2 = curriedGetSiteCommentCounts( siteId1, postId2 )( state );
+	const siteCommentCount3 = curriedGetSiteCommentCounts( siteId2 )( postId3 )( state );
+
+	return {
+		colorSchemePreference,
+		siteCommentCount1,
+		siteCommentCount2,
+		siteCommentCount3,
+	};
+}

--- a/client/lib/curry-selector/test/index.js
+++ b/client/lib/curry-selector/test/index.js
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 /**
  * Internal dependencies
  */
-import currySelector from '../';
+import currySelector, { quickTest } from '../';
 import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'index', () => {
@@ -33,12 +33,26 @@ describe( 'index', () => {
 		arity3SelectorCurried = currySelector( arity3Selector );
 	} );
 
-	test( 'allows the given selector to function as usual when arity is filled', () => {} );
+
+	// test( 'allows the given selector to function as usual when arity is filled', () => {
+	test( 'does a quick test...', () => {
+		const actual = quickTest();
+		const expected = {
+			colorSchemePreference: 'blue!',
+			siteCommentCount1: 11,
+			siteCommentCount2: 22,
+			siteCommentCount3: 33,
+		};
+
+		expect( actual.colorSchemePreference ).to.equal( 'blue!' );
+		expect( actual.siteCommentCount1 ).to.equal( 11 );
+		expect( actual.siteCommentCount2 ).to.equal( 22 );
+		expect( actual.siteCommentCount3 ).to.equal( 33 );
+	} );
 
 	test( 'treats the state arguement as the last arguement when arity -1 is given', () => {
 		const matchingPost = {
 			id: '11111',
-			title: 'Howdy World!',
 			title: 'Howdy World!',
 		};
 		const nonMatchingPost = {
@@ -57,7 +71,6 @@ describe( 'index', () => {
 	test( 'should create a function which returns the expected value when called', () => {
 		const matchingPost = {
 			id: '11111',
-			title: 'Howdy World!',
 			title: 'Howdy World!',
 		};
 		const nonMatchingPost = {

--- a/client/lib/curry-selector/test/index.js
+++ b/client/lib/curry-selector/test/index.js
@@ -1,0 +1,75 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { get, filter, first, find } from 'lodash';
+import sinon from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import currySelector from '../';
+import { useSandbox } from 'test/helpers/use-sinon';
+
+describe( 'index', () => {
+	let arity1Selector;
+	let arity2Selector;
+	let arity3Selector;
+	let arity1SelectorCurried;
+	let arity2SelectorCurried;
+	let arity3SelectorCurried;
+
+	useSandbox( sandbox => {
+		sandbox.stub( console, 'warn' );
+		arity1Selector = sandbox.spy( state => first( state.posts ) );
+		arity2Selector = sandbox.spy( ( state, id ) => find( state.posts, { id } ) );
+		arity3Selector = sandbox.spy( ( state, id, nothing ) => find( state.posts, { id } ) );
+	} );
+
+	beforeAll( () => {
+		arity1SelectorCurried = currySelector( arity1Selector );
+		arity2SelectorCurried = currySelector( arity2Selector );
+		arity3SelectorCurried = currySelector( arity3Selector );
+	} );
+
+	test( 'allows the given selector to function as usual when arity is filled', () => {} );
+
+	test( 'treats the state arguement as the last arguement when arity -1 is given', () => {
+		const matchingPost = {
+			id: '11111',
+			title: 'Howdy World!',
+			title: 'Howdy World!',
+		};
+		const nonMatchingPost = {
+			id: '22222',
+			title: 'Hello World',
+		};
+		const state = {
+			posts: [ matchingPost, nonMatchingPost ],
+		};
+		const actual = arity3SelectorCurried( '11111', 'nothing' )( state );
+		const expected = matchingPost;
+
+		expect( actual ).to.equal( expected );
+	} );
+
+	test( 'should create a function which returns the expected value when called', () => {
+		const matchingPost = {
+			id: '11111',
+			title: 'Howdy World!',
+			title: 'Howdy World!',
+		};
+		const nonMatchingPost = {
+			id: '22222',
+			title: 'Hello World',
+		};
+		const state = {
+			posts: [ matchingPost, nonMatchingPost ],
+		};
+		const actual = arity2SelectorCurried( state, '11111' );
+		const expected = matchingPost;
+
+		expect( actual ).to.equal( expected );
+	} );
+} );

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -19,6 +19,9 @@ import EditorRevisionsListItem from './item';
 import { selectPostRevision } from 'state/posts/revisions/actions';
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 
+import { getPreference } from 'state/preferences/selectors';
+import { savePreference, setPreference } from 'state/preferences/actions';
+
 class EditorRevisionsList extends PureComponent {
 	static propTypes = {
 		comparisons: PropTypes.object,
@@ -43,6 +46,7 @@ class EditorRevisionsList extends PureComponent {
 	};
 
 	componentDidMount() {
+		savePreference( 'colorScheme', 'default' );
 		// Make sure that scroll position in the editor is not preserved.
 		window.scrollTo( 0, 0 );
 
@@ -121,6 +125,7 @@ class EditorRevisionsList extends PureComponent {
 	}
 
 	selectNextRevision = () => {
+		console.log( 'selectNextRevision' );
 		const { nextRevisionId } = this.props;
 		nextRevisionId && this.selectRevision( nextRevisionId );
 	};
@@ -187,6 +192,8 @@ export default connect(
 			! latestRevisionIsSelected && get( last( revisions ), 'id' ) === selectedRevisionId;
 		const nextIsDisabled = latestRevisionIsSelected || revisions.length === 1;
 		const prevIsDisabled = earliestRevisionIsSelected || revisions.length === 1;
+
+		console.log( getPreference( state, 'colorScheme' ) );
 
 		return {
 			latestRevisionId,


### PR DESCRIPTION
I wanted to give this a try, just for fun...
Wrapping a selector with `currySelector` creates an 'auto-curried' version of that selector. It has one caveat that is very specific to selectors - when currying it expects the state to be the last argument:

```js
const siteCommentCount = curriedGetSiteCommentCounts( state, siteId, postId );
const siteCommentCount = curriedGetSiteCommentCounts( siteId, postId )( state );
const siteCommentCount = curriedGetSiteCommentCounts( siteId )( postId )( state );
```

Supplying `state` last is akin to [Ramda](http://ramdajs.com/)s approach. Without this ordering we wouldn't really benefit from the currying. That said, it does seem a bit weird to have one signature when passing the props all together and another signature when currying. It might make sense for the curried selector to always expect state last, like so:

```js
const siteCommentCount = curriedGetSiteCommentCounts( siteId, postId, state );
const siteCommentCount = curriedGetSiteCommentCounts( siteId, postId )( state );
const siteCommentCount = curriedGetSiteCommentCounts( siteId )( postId )( state );
```

Of course, the above examples don't really show off the benefits properly, here are some ideas of how we might use them:

```js
import { canCurrentUser } from state/selectors/curried;
// originally canCurrentUser( state, siteId, 'edit_theme_options' ), 
// if we turned the args completely backwards we could do:
const canEditThemeOptions = canCurrentUser( 'edit_theme_options' );
return {
  canEditThemeOptions: canEditThemeOptions( siteId, state )
  // or
  canEditThemeOptions: canEditThemeOptions( siteId )( state )
}
```

I'm still not entirely sure if it's useful enough to warrant it's addition, but figured it'd be worth exploring a little :)