### PR TITLE
Reader: fix gallery image classification

### DIFF
--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -102,8 +102,9 @@ export default function waitForImagesToLoad( post ) {
 		const imagesLoaded = {};
 
 		// convert to image objects to start the load process
-		// only check the first 5 images
-		let promises = map( take( imagesToCheck, 5 ), imageUrl => {
+		// only check the first x images
+		const NUMBER_OF_IMAGES_TO_CHECK = 15;
+		let promises = map( take( imagesToCheck, NUMBER_OF_IMAGES_TO_CHECK ), imageUrl => {
 			if ( imageUrl in knownImages ) {
 				return Promise.resolve( knownImages[ imageUrl ] );
 			}

--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -103,7 +103,7 @@ export default function waitForImagesToLoad( post ) {
 
 		// convert to image objects to start the load process
 		// only check the first x images
-		const NUMBER_OF_IMAGES_TO_CHECK = 15;
+		const NUMBER_OF_IMAGES_TO_CHECK = 10;
 		let promises = map( take( imagesToCheck, NUMBER_OF_IMAGES_TO_CHECK ), imageUrl => {
 			if ( imageUrl in knownImages ) {
 				return Promise.resolve( knownImages[ imageUrl ] );

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -46,7 +46,8 @@ export const READER_CONTENT_WIDTH = 800,
 	PHOTO_ONLY_MIN_WIDTH = 440,
 	PHOTO_ONLY_MAX_CHARACTER_COUNT = 85,
 	GALLERY_MIN_IMAGES = 4,
-	GALLERY_MIN_IMAGE_WIDTH = 100;
+	MIN_IMAGE_WIDTH = 144,
+	MIN_IMAGE_HEIGHT = 72;
 
 function getCharacterCount( post ) {
 	if ( ! post || ! post.content_no_html ) {
@@ -57,7 +58,7 @@ function getCharacterCount( post ) {
 }
 
 export function imageIsBigEnoughForGallery( image ) {
-	return image.width >= GALLERY_MIN_IMAGE_WIDTH;
+	return image.width >= MIN_IMAGE_WIDTH && image.height >= MIN_IMAGE_HEIGHT;
 }
 
 const hasShortContent = post => getCharacterCount( post ) <= PHOTO_ONLY_MAX_CHARACTER_COUNT;
@@ -68,10 +69,8 @@ const hasShortContent = post => getCharacterCount( post ) <= PHOTO_ONLY_MAX_CHAR
  * @return {object}            The classified post
  */
 export function classifyPost( post ) {
-	const canonicalImage = post.canonical_image;
 	const imagesForGallery = filter( post.content_images, imageIsBigEnoughForGallery );
-	let displayType = DISPLAY_TYPES.UNCLASSIFIED,
-		canonicalAspect;
+	let displayType = DISPLAY_TYPES.UNCLASSIFIED;
 
 	if ( imagesForGallery.length >= GALLERY_MIN_IMAGES ) {
 		displayType ^= DISPLAY_TYPES.GALLERY;
@@ -82,25 +81,6 @@ export function classifyPost( post ) {
 		hasShortContent( post )
 	) {
 		displayType ^= DISPLAY_TYPES.PHOTO_ONLY;
-	}
-
-	if ( canonicalImage ) {
-		// TODO do we still need aspect logic here and any of these?
-		if ( canonicalImage.width >= 600 ) {
-			displayType ^= DISPLAY_TYPES.LARGE_BANNER;
-		}
-
-		if ( canonicalImage.height && canonicalImage.width ) {
-			canonicalAspect = canonicalImage.width / canonicalImage.height;
-
-			if ( canonicalAspect >= 2 && canonicalImage.width >= 600 ) {
-				displayType ^= DISPLAY_TYPES.LANDSCAPE_BANNER;
-			} else if ( canonicalAspect < 1 && canonicalImage.height > 160 ) {
-				displayType ^= DISPLAY_TYPES.PORTRAIT_BANNER;
-			} else if ( canonicalAspect > 0.7 && canonicalAspect < 1.3 && canonicalImage.width < 200 ) {
-				displayType ^= DISPLAY_TYPES.THUMBNAIL;
-			}
-		}
 	}
 
 	if ( post.canonical_media && post.canonical_media.mediaType === 'video' ) {
@@ -153,7 +133,7 @@ export function runFastRules( post ) {
 }
 
 const slowSyncRules = flow( [
-	keepValidImages( 144, 72 ),
+	keepValidImages( MIN_IMAGE_WIDTH, MIN_IMAGE_HEIGHT ),
 	pickCanonicalImage,
 	pickCanonicalMedia,
 	classifyPost,


### PR DESCRIPTION
In p5PDj3-4ta-p2, @rossanafmenezes reported inconsistent post card display on this feed:

http://calypso.localhost:3000/read/feeds/52684332

It seemed like all of the posts had plenty of images that would be big enough for a gallery card, but not all of them were displaying that way. For example, the post "New Release Review ~ Hit Girl by Tia Louise":

http://calypso.localhost:3000/read/feeds/52684332?at=2018-03-21

After a bit of digging, I discovered that it was classified as a gallery post on the first pass of `classifyPost`, but then `keepValidImages` ran, and only 3 images were left in `post.content_images` afterwards. The card was then reclassified as standard, not gallery.

I've made two changes to fix this:
- make `waitForImagesToLoad` load more images initially (10 rather than 5) so that we have more images in `post.content_images` with a width and height to work with. `acceptValidImages` adds the width and height on successful image load.
- make minimum image dimensions match in gallery selection and `keepValidImages`, so that we don't consider 100px-144px images big enough for the gallery and then lose them in the second pass of `classifyPost`

I also removed some old classification rules that are no longer used in Reader.

### To test

Check that the first post displays as a gallery card:

http://calypso.localhost:3000/read/feeds/52684332?at=2018-03-21

<img width="851" alt="screen shot 2018-03-22 at 12 55 08 pm" src="https://user-images.githubusercontent.com/17325/37743710-4e42ebf0-2dd0-11e8-80fc-f894ec1947e3.png">
