### PR TITLE
Plans: Add Happychat to sites plans page (take 2)

### DIFF
--- a/client/components/happychat/connection.jsx
+++ b/client/components/happychat/connection.jsx
@@ -9,6 +9,10 @@ import PropTypes from 'prop-types';
 export class HappychatConnection extends Component {
 	componentDidMount() {
 		if ( this.props.isHappychatEnabled && this.props.isConnectionUninitialized ) {
+			/**
+			 * @TODO: When happychat correctly handles site switching, remove manual
+			 * selectSiteId action from client/my-sites/plans-features-main/index.jsx
+			 */
 			this.props.initConnection( this.props.getAuth() );
 		}
 	}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -7,6 +7,7 @@ import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { filter, get } from 'lodash';
 import classNames from 'classnames';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -36,8 +37,27 @@ import { plansLink } from 'lib/plans';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
 import PaymentMethods from 'blocks/payment-methods';
+import HappychatButton from 'components/happychat/button';
+import HappychatConnection from 'components/happychat/connection-connected';
+import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
+import { selectSiteId } from 'state/help/actions';
 
 class PlansFeaturesMain extends Component {
+	componentWillUpdate( nextProps ) {
+		/**
+		 * Happychat does not update with the selected site right now :(
+		 * This ensures that Happychat groups are correct in case we switch sites while on the plans
+		 * page, for example between a Jetpack and Simple site.
+		 *
+		 * @TODO: When happychat correctly handles site switching, remove selectSiteId action.
+		 */
+		const siteId = get( this.props, [ 'site', 'ID' ] );
+		const nextSiteId = get( nextProps, [ 'site', 'ID' ] );
+		if ( siteId !== nextSiteId && nextSiteId ) {
+			this.props.selectSiteId( nextSiteId );
+		}
+	}
+
 	getPlanFeatures() {
 		const {
 			basePlansPath,
@@ -139,7 +159,14 @@ class PlansFeaturesMain extends Component {
 	}
 
 	getJetpackFAQ() {
-		const { translate } = this.props;
+		const { isChatAvailable, translate } = this.props;
+
+		const helpLink =
+			isEnabled( 'jetpack/happychat' ) && isChatAvailable ? (
+				<HappychatButton className="plans-features-main__happychat-button" />
+			) : (
+				<a href="https://jetpack.com/contact-support/" target="_blank" rel="noopener noreferrer" />
+			);
 
 		return (
 			<FAQ>
@@ -190,17 +217,9 @@ class PlansFeaturesMain extends Component {
 				<FAQItem
 					question={ translate( 'Have more questions?' ) }
 					answer={ translate(
-						'No problem! Feel free to {{a}}get in touch{{/a}} with our Happiness Engineers.',
+						'No problem! Feel free to {{helpLink}}get in touch{{/helpLink}} with our Happiness Engineers.',
 						{
-							components: {
-								a: (
-									<a
-										href="https://jetpack.com/contact-support/"
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							},
+							components: { helpLink },
 						}
 					) }
 				/>
@@ -209,7 +228,14 @@ class PlansFeaturesMain extends Component {
 	}
 
 	getFAQ() {
-		const { site, translate } = this.props;
+		const { isChatAvailable, site, translate } = this.props;
+
+		const helpLink =
+			isEnabled( 'happychat' ) && isChatAvailable ? (
+				<HappychatButton className="plans-features-main__happychat-button" />
+			) : (
+				<a href="https://wordpress.com/help" target="_blank" rel="noopener noreferrer" />
+			);
 
 		return (
 			<FAQ>
@@ -330,13 +356,9 @@ class PlansFeaturesMain extends Component {
 					question={ translate( 'Have more questions?' ) }
 					answer={ translate(
 						'Need help deciding which plan works for you? Our happiness engineers are available for' +
-							' any questions you may have. {{a}}Get help{{/a}}.',
+							' any questions you may have. {{helpLink}}Get help{{/helpLink}}.',
 						{
-							components: {
-								a: (
-									<a href="https://wordpress.com/help" target="_blank" rel="noopener noreferrer" />
-								),
-							},
+							components: { helpLink },
 						}
 					) }
 				/>
@@ -396,6 +418,7 @@ class PlansFeaturesMain extends Component {
 
 		return (
 			<div className="plans-features-main">
+				<HappychatConnection />
 				<div className="plans-features-main__notice" />
 				{ displayJetpackPlans ? this.getIntervalTypeToggle() : null }
 				<QueryPlans />
@@ -414,6 +437,7 @@ PlansFeaturesMain.propTypes = {
 	displayJetpackPlans: PropTypes.bool.isRequired,
 	hideFreePlan: PropTypes.bool,
 	intervalType: PropTypes.string,
+	isChatAvailable: PropTypes.bool,
 	isInSignup: PropTypes.bool,
 	isLandingPage: PropTypes.bool,
 	onUpgradeClick: PropTypes.func,
@@ -427,8 +451,14 @@ PlansFeaturesMain.defaultProps = {
 	basePlansPath: null,
 	hideFreePlan: false,
 	intervalType: 'yearly',
-	site: {},
+	isChatAvailable: false,
 	showFAQ: true,
+	site: {},
 };
 
-export default localize( PlansFeaturesMain );
+export default connect(
+	state => ( {
+		isChatAvailable: isHappychatAvailable( state ),
+	} ),
+	{ selectSiteId }
+)( localize( PlansFeaturesMain ) );

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -40,7 +40,7 @@ import PaymentMethods from 'blocks/payment-methods';
 import HappychatButton from 'components/happychat/button';
 import HappychatConnection from 'components/happychat/connection-connected';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
-import { selectSiteId } from 'state/help/actions';
+import { selectSiteId as selectHappychatSiteId } from 'state/help/actions';
 
 class PlansFeaturesMain extends Component {
 	componentWillUpdate( nextProps ) {
@@ -49,12 +49,12 @@ class PlansFeaturesMain extends Component {
 		 * This ensures that Happychat groups are correct in case we switch sites while on the plans
 		 * page, for example between a Jetpack and Simple site.
 		 *
-		 * @TODO: When happychat correctly handles site switching, remove selectSiteId action.
+		 * @TODO: When happychat correctly handles site switching, remove selectHappychatSiteId action.
 		 */
 		const siteId = get( this.props, [ 'site', 'ID' ] );
 		const nextSiteId = get( nextProps, [ 'site', 'ID' ] );
 		if ( siteId !== nextSiteId && nextSiteId ) {
-			this.props.selectSiteId( nextSiteId );
+			this.props.selectHappychatSiteId( nextSiteId );
 		}
 	}
 
@@ -460,5 +460,5 @@ export default connect(
 	state => ( {
 		isChatAvailable: isHappychatAvailable( state ),
 	} ),
-	{ selectSiteId }
+	{ selectHappychatSiteId }
 )( localize( PlansFeaturesMain ) );

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -1,9 +1,24 @@
+/** @format */
+
 .plans-features-main__group {
-	@include breakpoint( ">1040px" ) {
+	@include breakpoint( '>1040px' ) {
 		padding-top: 19px; // popular banner height adjustment
 	}
 
 	+ .faq {
 		margin-top: 20px;
+	}
+}
+
+// Required additional specificity
+.plans-features-main .plans-features-main__happychat-button {
+	color: $blue-wordpress;
+	font-weight: normal;
+	padding: 0;
+	text-decoration: underline;
+
+	&:hover,
+	&:focus {
+		color: $blue-wordpress;
 	}
 }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#23537 (revert of previous PR #22988).

This is a second attempt at Automattic/wp-calypso#22988

Happiness announcement and coordination: pbg9X-cDn-p2

✅ ~Blocked by #23540~. Thanks Canary tests for detecting issues 🎉 