### PR TITLE
Happychat: Add protection for null users

### DIFF
--- a/client/state/happychat/test/utils.js
+++ b/client/state/happychat/test/utils.js
@@ -78,4 +78,17 @@ describe( 'auth promise', () => {
 			} );
 		} );
 	} );
+
+	test( 'should return a rejected promise if there is no current user', () => {
+		const noUserState = {
+			currentUser: {},
+			users: {},
+			ui: {
+				section: {
+					name: 'jetpack-connect',
+				},
+			},
+		};
+		expect( getHappychatAuth( noUserState )() ).rejects.toThrow();
+	} );
 } );

--- a/client/state/happychat/test/utils.js
+++ b/client/state/happychat/test/utils.js
@@ -43,17 +43,15 @@ describe( 'auth promise', () => {
 		} );
 
 		test( 'should return a fulfilled Promise', () => {
-			getHappychatAuth( state )().then( user => {
-				expect( user ).toMatchObject( {
-					url: config( 'happychat_url' ),
-					user: {
-						signer_user_id: state.users.items[ 3 ].ID,
-						locale: state.users.items[ 3 ].localeSlug,
-						groups: [ 'jpop' ],
-						jwt: 'jwt',
-						geoLocation: { city: 'Lugo' },
-					},
-				} );
+			expect( getHappychatAuth( state )() ).resolves.toMatchObject( {
+				url: config( 'happychat_url' ),
+				user: {
+					signer_user_id: state.users.items[ 3 ].ID,
+					locale: state.users.items[ 3 ].localeSlug,
+					groups: [ 'jpop' ],
+					jwt: 'jwt',
+					geoLocation: { city: 'Lugo' },
+				},
 			} );
 		} );
 	} );
@@ -71,11 +69,9 @@ describe( 'auth promise', () => {
 		} );
 
 		test( 'should return a rejected Promise', () => {
-			getHappychatAuth( state )().catch( error => {
-				expect( error ).toBe(
-					'Failed to start an authenticated Happychat session: failed request'
-				);
-			} );
+			expect( getHappychatAuth( state )() ).rejects.toThrow(
+				'Failed to start an authenticated Happychat session: failed request'
+			);
 		} );
 	} );
 

--- a/client/state/happychat/utils.js
+++ b/client/state/happychat/utils.js
@@ -50,6 +50,12 @@ export const getHappychatAuth = state => () => {
 
 	const user = getCurrentUser( state );
 
+	if ( ! user ) {
+		return Promise.reject(
+			'Failed to start an authenticated Happychat session: No current user found'
+		);
+	}
+
 	const happychatUser = {
 		signer_user_id: user.ID,
 		locale,


### PR DESCRIPTION
Add some protection against a null user to ensure `null.ID` does not cause an error.
Add tests for this case
Update promise tests to user [`resolves`](https://facebook.github.io/jest/docs/en/expect.html#resolves)/[`rejects`](https://facebook.github.io/jest/docs/en/expect.html#rejects) rather than manipulate promises within tests. Feel free to revert if there's any opposition.

The `getCurrentUser` selector may return `null`:

https://github.com/Automattic/wp-calypso/blob/a29a153c917a840f0dc46d02224ef8c335f56564/client/state/current-user/selectors.js#L28-L37

This seemed a reasonable way to fix the error, but I'm not familiar with this code. Please feel free to take over and _do the right thing_ ™️ 😁 

This caused canary errors during signup with changes in #22988 (and later in #23538)


## Testing

Try e2e locally against #23538 (which includes this change). If you revert the selector changes, canaries fail. (https://wp.me/p4TIVU-8Qw)

```sh
./run.sh -R -C -s desktop
```

I've also added tests for a no current user case.