### PR TITLE
JP Remote Install: Fix click tracking in error notice

### DIFF
--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -5,6 +5,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -339,9 +340,8 @@ export class JetpackConnectNotices extends Component {
 export default connect(
 	state => {
 		const jetpackConnectSite = getConnectingSite( state );
-		const siteToConnect = jetpackConnectSite.url;
 		return {
-			siteToConnect,
+			siteToConnect: get( jetpackConnectSite, 'url', '' ),
 		};
 	},
 	{ recordTracksEvent }

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -38,6 +38,7 @@ import {
 import Notice from 'components/notice';
 import { addQueryArgs } from 'lib/route';
 import { getConnectingSite } from 'state/jetpack-connect/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 export class JetpackConnectNotices extends Component {
 	static propTypes = {
@@ -86,13 +87,13 @@ export class JetpackConnectNotices extends Component {
 		}
 	}
 
-	trackManualInstallClick() {
+	trackManualInstallClick = () => {
 		this.props.recordTracksEvent( 'calypso_remote_install_manual_install_click' );
-	}
+	};
 
-	trackSupportClick() {
+	trackSupportClick = () => {
 		this.props.recordTracksEvent( 'calypso_remote_install_support_click' );
-	}
+	};
 
 	getNoticeValues() {
 		const { noticeType, onDismissClick, translate } = this.props;
@@ -335,10 +336,13 @@ export class JetpackConnectNotices extends Component {
 		return null;
 	}
 }
-export default connect( state => {
-	const jetpackConnectSite = getConnectingSite( state );
-	const siteToConnect = jetpackConnectSite.url;
-	return {
-		siteToConnect,
-	};
-} )( localize( JetpackConnectNotices ) );
+export default connect(
+	state => {
+		const jetpackConnectSite = getConnectingSite( state );
+		const siteToConnect = jetpackConnectSite.url;
+		return {
+			siteToConnect,
+		};
+	},
+	{ recordTracksEvent }
+)( localize( JetpackConnectNotices ) );


### PR DESCRIPTION
The tracks events on click in the notice UI were not firing and giving console warnings.

* Fix the tracking function bindings by using arrow functions
* Bind the recordTracksEvent action to props

## Testing

* Load https://calypso.live/?branch=fix/jp-remote-install/notice-click-tracking
* Input site URL for a site that doesn’t have Jetpack installed
* See the credentials screen
* Fill some wrong credentials.
* Click on the “install jetpack manually” link or the "contact support" link in the notice
* In the JS console, check that a tracks event fires like:
`calypso:analytics:tracks Record event "calypso_remote_install_manual_install_click" called with props {}__proto__: Object +38s`

