### PR TITLE
Google My Business: Redirect logged out users to login page

### DIFF
--- a/client/my-sites/google-my-business/index.js
+++ b/client/my-sites/google-my-business/index.js
@@ -9,7 +9,7 @@ import page from 'page';
  * Internal dependencies
  */
 import config from 'config';
-import { makeLayout } from 'controller';
+import { makeLayout, redirectLoggedOut } from 'controller';
 import { navigation, sites, siteSelection } from 'my-sites/controller';
 import { newAccount, selectBusinessType, selectLocation, stats } from './controller';
 
@@ -21,6 +21,7 @@ export default function( router ) {
 
 	router(
 		'/google-my-business/select-business-type',
+		redirectLoggedOut,
 		siteSelection,
 		sites,
 		makeLayout,
@@ -28,6 +29,7 @@ export default function( router ) {
 
 	router(
 		'/google-my-business/select-business-type/:site',
+		redirectLoggedOut,
 		siteSelection,
 		selectBusinessType,
 		navigation,
@@ -37,6 +39,7 @@ export default function( router ) {
 	if ( config.isEnabled( 'google-my-business' ) ) {
 		router(
 			'/google-my-business/new',
+			redirectLoggedOut,
 			siteSelection,
 			sites,
 			makeLayout,
@@ -44,6 +47,7 @@ export default function( router ) {
 
 		router(
 			'/google-my-business/new/:site',
+			redirectLoggedOut,
 			siteSelection,
 			newAccount,
 			navigation,
@@ -52,6 +56,7 @@ export default function( router ) {
 
 		router(
 			'/google-my-business/select-location',
+			redirectLoggedOut,
 			siteSelection,
 			sites,
 			makeLayout,
@@ -59,6 +64,7 @@ export default function( router ) {
 
 		router(
 			'/google-my-business/select-location/:site',
+			redirectLoggedOut,
 			siteSelection,
 			selectLocation,
 			navigation,
@@ -67,6 +73,7 @@ export default function( router ) {
 
 		router(
 			'/google-my-business/stats',
+			redirectLoggedOut,
 			siteSelection,
 			sites,
 			makeLayout,
@@ -74,6 +81,7 @@ export default function( router ) {
 
 		router(
 			'/google-my-business/stats/:site',
+			redirectLoggedOut,
 			siteSelection,
 			stats,
 			navigation,

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -67,7 +67,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 			};
 		} else {
 			buttonProps = {
-				buttonHref: 'https://www.google.com/business/',
+				buttonHref: 'https://business.google.com/create',
 				buttonIcon: 'external',
 				buttonTarget: '_blank',
 				buttonText: translate( 'Create Your Listing', {

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -61,12 +61,18 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 		if ( config.isEnabled( 'google-my-business' ) ) {
 			buttonProps = {
 				buttonHref: `/google-my-business/new/${ siteSlug }`,
+				buttonText: translate( 'Continue With Google', {
+					comment: 'Call to Action to connect to Google My Business',
+				} ),
 			};
 		} else {
 			buttonProps = {
 				buttonHref: 'https://www.google.com/business/',
 				buttonIcon: 'external',
 				buttonTarget: '_blank',
+				buttonText: translate( 'Create Your Listing', {
+					comment: 'Call to Action to add a business listing to Google My Business',
+				} ),
 			};
 		}
 
@@ -79,9 +85,6 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 					'Your business has a physical location customers can visit, ' +
 					'or provides goods and services to local customers, or both.'
 				) }
-				buttonText={ translate( 'Create Your Listing', {
-					comment: 'Call to Action to add a business listing to Google My Business',
-				} ) }
 				buttonPrimary={ true }
 				buttonOnClick={ this.trackCreateYourListingClick }
 				{ ...buttonProps }

--- a/client/my-sites/google-my-business/select-location/index.js
+++ b/client/my-sites/google-my-business/select-location/index.js
@@ -76,7 +76,7 @@ class GoogleMyBusinessSelectLocation extends Component {
 							components: {
 								link: (
 									<ExternalLink
-										href="https://www.google.com/business/"
+										href="https://business.google.com/create"
 										target="_blank"
 										rel="noopener noreferrer"
 										icon={ true }

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -192,6 +192,7 @@ const sections = [
 		name: 'google-my-business',
 		paths: [ '/google-my-business' ],
 		module: 'my-sites/google-my-business',
+		enableLoggedOut: true,
 		secondary: true,
 		group: 'sites',
 		css: 'google-my-business',


### PR DESCRIPTION
This pull request fixes an empty page presented to **logged users** when trying to access the new [`Google My Business` page](https://wordpress.com/google-my-business). Instead, they will now be redirected to the [`Login` page](https://wordpress.com/log-in):
 
Before | After
------ | -----
<img width="624" alt="screenshot" src="https://user-images.githubusercontent.com/594356/37777252-5b4af16e-2de7-11e8-9026-d2a505157c32.png"> | <img width="623" alt="screenshot" src="https://user-images.githubusercontent.com/594356/37777367-a463252e-2de7-11e8-866c-18432fc3ee28.png">

This pull request also updates a label, and two links.

#### Testing instructions
 
1. Run `git checkout add/redirect-logged-out-users-to-login` and start your server
2. Open the [`Google My Business` page](http://calypso.localhost:3000/google-my-business) in an incognito window
3. Assert that you are redirected to the [`Login` page](http://calypso.localhost:3000/log-in)
4. Submit valid credentials, or use a magic link to log in to WordPress.com
5. Assert that you are redirected to the `Google My Business` page

You may also give a try other pages from the Google My Business flow:

* http://calypso.localhost:3000/google-my-business/select-business-type
* http://calypso.localhost:3000/google-my-business/new
* http://calypso.localhost:3000/google-my-business/select-location
* http://calypso.localhost:3000/google-my-business/stats

#### Reviews
 
- [ ] Code
- [ ] Product