### PR TITLE
Help: remove some unused code from Inline Help

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -36,12 +36,6 @@ class InlineHelpPopover extends Component {
 		showContactForm: false,
 	};
 
-	componentWillReceiveProps( nextProps ) {
-		if ( this.state.showContactForm && this.props.searchQuery !== nextProps.searchQuery ) {
-			this.toggleContactForm();
-		}
-	}
-
 	openResult = href => {
 		if ( ! href ) {
 			return;


### PR DESCRIPTION
This was used to hide the contact form when someone had it open but then started searching. This isn't possible anymore so I'm removing this code. 

To test: 
- Make sure Inline Help behaves the same on this branch as it does on `master`. 

Props: found by @jsnajdr in #23470. 
