### PR TITLE
Security: fix jetpack-credentials in small screens

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
@@ -67,28 +67,30 @@ class CredentialsConfigured extends Component {
 		if ( canAutoconfigure ) {
 			return (
 				<CompactCard className="credentials-configured" onClick={ this.toggleRevoking } href="#">
-					<Gridicon
-						icon="checkmark-circle"
-						size={ 48 }
-						className="credentials-configured__header-gridicon"
-					/>
-					<div className="credentials-configured__header-configured-text">
-						{ translate( 'Backups and security scans are configured and active.' ) }
+					<div className="credentials-configured__info">
+						<Gridicon
+							icon="checkmark-circle"
+							size={ 48 }
+							className="credentials-configured__info-gridicon"
+						/>
+						<div className="credentials-configured__info-text">
+							{ translate( 'Backups and security scans are configured and active.' ) }
+						</div>
 					</div>
 				</CompactCard>
 			);
 		}
 
 		const header = (
-			<div className="credentials-configured__header">
+			<div className="credentials-configured__info">
 				<Gridicon
 					icon="checkmark-circle"
 					size={ 48 }
-					className="credentials-configured__header-gridicon"
+					className="credentials-configured__info-gridicon"
 				/>
-				<div className="credentials-configured__header-text">
-					<h3 className="credentials-configured__header-protocol">{ translate( 'Connected' ) }</h3>
-					<h4 className="credentials-configured__header-description">
+				<div className="credentials-configured__info-text">
+					<h3 className="credentials-configured__info-protocol">{ translate( 'Connected' ) }</h3>
+					<h4 className="credentials-configured__info-description">
 						{ translate(
 							'Your site is being backed up in real time and regularly scanned for security threats.'
 						) }

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-configured/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-configured/style.scss
@@ -2,32 +2,31 @@
 	margin-bottom: 0;
 }
 
-.credentials-configured__header {
+.credentials-configured__info {
 	align-items: center;
 	display: flex;
 }
 
-.credentials-configured__header-gridicon {
+.credentials-configured__info-gridicon {
 	display: inline-block;
 	flex-shrink: 0;
 	margin-right: 10px;
 }
 
-.credentials-configured__header-text {
+.credentials-configured__info-text {
 	display: inline-block;
-	color: $gray-dark;
 }
 
-.credentials-configured__header-gridicon {
+.credentials-configured__info-gridicon {
 	color: $alert-green;
 }
 
-.credentials-configured__header-protocol {
+.credentials-configured__info-protocol {
 	font-weight: bold;
 	font-size: 1.5rem;
 }
 
-.credentials-configured__header-description {
+.credentials-configured__info-description {
 	color: $gray;
 	font-size: 1.3rem;
 }

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-configured/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-configured/style.scss
@@ -3,20 +3,18 @@
 }
 
 .credentials-configured__header {
-	width: 85%;
+	align-items: center;
+	display: flex;
 }
 
 .credentials-configured__header-gridicon {
 	display: inline-block;
-	vertical-align: middle;
+	flex-shrink: 0;
 	margin-right: 10px;
 }
 
-.credentials-configured__header-configured-text,
 .credentials-configured__header-text {
 	display: inline-block;
-	vertical-align: middle;
-	width: 85%;
 	color: $gray-dark;
 }
 
@@ -30,7 +28,6 @@
 }
 
 .credentials-configured__header-description {
-	width: 500px;
 	color: $gray;
 	font-size: 1.3rem;
 }


### PR DESCRIPTION
Fixes visual issues in the security settings page for Jetpack credentials section.

Text would previously overflow in small screens.

# Screenshots

### 320x Before:
![image](https://user-images.githubusercontent.com/87168/37781563-9b29bccc-2df9-11e8-8ee1-eda33418f444.png)

### 320x After:
![image](https://user-images.githubusercontent.com/87168/37781548-928ababc-2df9-11e8-9281-21f77e922388.png)

(I'll address that broken too narrow notice in a more generic PR.)


### 480x Before:
![image](https://user-images.githubusercontent.com/87168/37782509-b60e9042-2dfb-11e8-9de7-fe20e41f674f.png)

### 480x After:
![image](https://user-images.githubusercontent.com/87168/37782519-ba0755d0-2dfb-11e8-82aa-077812577ed0.png)


### 680x Before:
(680 looks more narrow than 480x because sidebar is now visible) 

![image](https://user-images.githubusercontent.com/87168/37782486-a613dd3c-2dfb-11e8-9674-e947b1eef225.png)

### 680x After:
![image](https://user-images.githubusercontent.com/87168/37782496-ad53b14e-2dfb-11e8-8b4e-de27fb10d920.png)


### 1024x Before:
![image](https://user-images.githubusercontent.com/87168/37781711-e8482142-2df9-11e8-9537-c9390ac52612.png)

### 1024x After:
![image](https://user-images.githubusercontent.com/87168/37781743-faec3630-2df9-11e8-98d9-d87c651c4656.png)


# Testing
- Connect Jetpack site and see `http://calypso.localhost:3000/settings/security/:YOURSITE`
- Test in different browsers and screen sizes