### PR TITLE
Store: Fix offsetWidth JS error in Action Bar

### DIFF
--- a/client/extensions/woocommerce/components/action-header/actions.js
+++ b/client/extensions/woocommerce/components/action-header/actions.js
@@ -78,8 +78,14 @@ class ActionButtons extends Component {
 					return;
 				}
 				/* eslint-disable react/no-string-refs */
-				const buttonWidth = ReactDom.findDOMNode( this.refs[ 'button-' + index ] ).offsetWidth;
+				const node = ReactDom.findDOMNode( this.refs[ 'button-' + index ] );
 				/* eslint-enable react/no-string-refs */
+
+				if ( ! node ) {
+					return;
+				}
+
+				const buttonWidth = node.offsetWidth;
 				totalWidth += buttonWidth;
 			}.bind( this )
 		);


### PR DESCRIPTION
Fixes #23468.

It looks like `getButtonWidths` would sometimes run before the button elements were rendered, causing a JS error. I was mostly consistently able to reproduce this on the shipping settings page.

To Test:
* Go to `http://calypso.localhost:3000/store/order/:site/:order`and make your screen size smaller. Verify that the buttons in the Action Bar still convert to a dropdown button.
* Go to `http://calypso.localhost:3000/store/settings/shipping/:site` and make sure there is no JS error in the console, and that the save button still shows up.