### PR TITLE
Store: Add a link back to the orders list in the "order updated" success notice

### DIFF
--- a/client/extensions/woocommerce/app/order/create.js
+++ b/client/extensions/woocommerce/app/order/create.js
@@ -70,11 +70,19 @@ class Order extends Component {
 	saveOrder = () => {
 		const { site, siteId, order, translate } = this.props;
 		const onSuccess = ( dispatch, orderId ) => {
+			const successOpts = {
+				duration: 8000,
+				displayOnNextPage: true,
+			};
 			dispatch(
-				successNotice( translate( 'Order successfully created.' ), {
-					duration: 8000,
-					displayOnNextPage: true,
-				} )
+				successNotice(
+					translate( 'Order successfully created. {{ordersLink}}View Orders{{/ordersLink}}.', {
+						components: {
+							ordersLink: <a href={ getLink( '/store/orders/:site/', site ) } />,
+						},
+					} ),
+					successOpts
+				)
 			);
 			// Send invoice if the order is awaiting payment and there is an email
 			if ( isOrderWaitingPayment( order.status ) && get( order, 'billing.email', false ) ) {

--- a/client/extensions/woocommerce/app/order/create.js
+++ b/client/extensions/woocommerce/app/order/create.js
@@ -76,7 +76,7 @@ class Order extends Component {
 			};
 			dispatch(
 				successNotice(
-					translate( 'Order successfully created. {{ordersLink}}View Orders{{/ordersLink}}.', {
+					translate( 'Order successfully created. {{ordersLink}}View all orders{{/ordersLink}}.', {
 						components: {
 							ordersLink: <a href={ getLink( '/store/orders/:site/', site ) } />,
 						},

--- a/client/extensions/woocommerce/app/order/header.js
+++ b/client/extensions/woocommerce/app/order/header.js
@@ -88,14 +88,23 @@ class OrderActionHeader extends Component {
 
 	// Saves changes to the remote site via API
 	saveOrder = () => {
-		const { siteId, order, translate } = this.props;
+		const { siteId, order, translate, site } = this.props;
 		const successOpts = { duration: 8000 };
 		if ( isOrderWaitingPayment( order.status ) ) {
 			successOpts.button = translate( 'Send new invoice to customer' );
 			successOpts.onClick = this.triggerInvoice;
 		}
 		const onSuccess = dispatch => {
-			dispatch( successNotice( translate( 'Order successfully updated.' ), successOpts ) );
+			dispatch(
+				successNotice(
+					translate( 'Order successfully updated. {{ordersLink}}View Orders{{/ordersLink}}.', {
+						components: {
+							ordersLink: <a href={ getLink( '/store/orders/:site/', site ) } />,
+						},
+					} ),
+					successOpts
+				)
+			);
 		};
 		const onFailure = dispatch => {
 			dispatch( errorNotice( translate( 'Unable to save order.' ), { duration: 8000 } ) );

--- a/client/extensions/woocommerce/app/order/header.js
+++ b/client/extensions/woocommerce/app/order/header.js
@@ -97,7 +97,7 @@ class OrderActionHeader extends Component {
 		const onSuccess = dispatch => {
 			dispatch(
 				successNotice(
-					translate( 'Order successfully updated. {{ordersLink}}View Orders{{/ordersLink}}.', {
+					translate( 'Order successfully updated. {{ordersLink}}View all orders{{/ordersLink}}.', {
 						components: {
 							ordersLink: <a href={ getLink( '/store/orders/:site/', site ) } />,
 						},


### PR DESCRIPTION
Closes #17489.

This PR adds a "View Orders" link to the order update success notice. One note is that for payment pending orders, the additional action link for resending invoices is shown.

<img width="692" alt="screen shot 2018-03-22 at 10 13 52 am" src="https://user-images.githubusercontent.com/689165/37786491-14a0969c-2dba-11e8-96e2-1be7d9129cb3.png">

<img width="463" alt="screen shot 2018-03-22 at 10 13 36 am" src="https://user-images.githubusercontent.com/689165/37786508-1f4b6f86-2dba-11e8-9457-d2da07e713a0.png">

To Test:
* Make an update to an order, and verify the "View Orders" link shows and takes you to the orders page.
* Test create order and verify you see it as well (https://github.com/Automattic/wp-calypso/pull/23553#issuecomment-375403446)


