### PR TITLE
Themes: Use photon on screenshots

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -236,7 +236,7 @@ class ThemeSheet extends React.Component {
 		const screenshotFull = isWpcomTheme ? this.getFullLengthScreenshot() : this.props.screenshot;
 		const width = 735;
 		// Photon may return null, allow fallbacks
-		const photonSrc = photon( screenshotFull, { width } );
+		const photonSrc = screenshotFull && photon( screenshotFull, { width } );
 		const img = screenshotFull && (
 			<img
 				className="theme__sheet-img"

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -16,6 +16,7 @@ import i18n from 'i18n-calypso';
 import classNames from 'classnames';
 import titlecase from 'to-title-case';
 import Gridicon from 'gridicons';
+import { head, split } from 'lodash';
 
 /**
  * Internal dependencies
@@ -193,7 +194,9 @@ class ThemeSheet extends React.Component {
 
 	getFullLengthScreenshot() {
 		if ( this.isLoaded() ) {
-			return this.props.screenshots[ 0 ];
+			// Results are being returned with photon params like `?w=…`. This makes the photon
+			// module abort and return null. Strip query string.
+			return head( split( head( this.props.screenshots ), '?', 1 ) );
 		}
 		return null;
 	}

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -47,6 +47,7 @@ import {
 	isThemePremium,
 	isPremiumThemeAvailable,
 	isWpcomTheme as isThemeWpcom,
+	getCanonicalTheme,
 	getPremiumThemePrice,
 	getThemeDetailsUrl,
 	getThemeRequestErrors,
@@ -56,7 +57,6 @@ import { getBackPath } from 'state/themes/themes-ui/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
 import { decodeEntities } from 'lib/formatting';
-import { getCanonicalTheme } from 'state/themes/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { setThemePreviewOptions } from 'state/themes/actions';
 import ThemeNotFoundError from './theme-not-found-error';

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -191,12 +191,12 @@ class ThemeSheet extends React.Component {
 		);
 	};
 
-	getFullLengthScreenshot = () => {
+	getFullLengthScreenshot() {
 		if ( this.isLoaded() ) {
 			return this.props.screenshots[ 0 ];
 		}
 		return null;
-	};
+	}
 
 	previewAction = event => {
 		if ( event.altKey || event.ctrlKey || event.metaKey || event.shiftKey ) {
@@ -209,7 +209,7 @@ class ThemeSheet extends React.Component {
 		return preview.action( this.props.id );
 	};
 
-	renderPreviewButton = demo_uri => {
+	renderPreviewButton( demo_uri ) {
 		return (
 			<a
 				className="theme__sheet-preview-link"
@@ -225,9 +225,9 @@ class ThemeSheet extends React.Component {
 				</span>
 			</a>
 		);
-	};
+	}
 
-	renderScreenshot = () => {
+	renderScreenshot() {
 		const { demo_uri, retired, isActive, isWpcomTheme } = this.props;
 		const screenshotFull = isWpcomTheme ? this.getFullLengthScreenshot() : this.props.screenshot;
 		const img = screenshotFull && (
@@ -244,7 +244,7 @@ class ThemeSheet extends React.Component {
 		}
 
 		return <div className="theme__sheet-screenshot">{ img }</div>;
-	};
+	}
 
 	renderSectionNav = currentSection => {
 		const filterStrings = {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -17,6 +17,7 @@ import classNames from 'classnames';
 import titlecase from 'to-title-case';
 import Gridicon from 'gridicons';
 import { head, split } from 'lodash';
+import photon from 'photon';
 
 /**
  * Internal dependencies
@@ -233,8 +234,15 @@ class ThemeSheet extends React.Component {
 	renderScreenshot() {
 		const { demo_uri, retired, isActive, isWpcomTheme } = this.props;
 		const screenshotFull = isWpcomTheme ? this.getFullLengthScreenshot() : this.props.screenshot;
+		const width = 735;
+		// Photon may return null, allow fallbacks
+		const photonSrc = photon( screenshotFull, { width } );
 		const img = screenshotFull && (
-			<img className="theme__sheet-img" src={ screenshotFull + '?w=680' } />
+			<img
+				className="theme__sheet-img"
+				src={ photonSrc || screenshotFull }
+				srcSet={ photonSrc && `${ photon( screenshotFull, { width, zoom: 2 } ) } 2x` }
+			/>
 		);
 
 		if ( demo_uri && ! retired ) {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -232,13 +232,16 @@ class ThemeSheet extends React.Component {
 	}
 
 	renderScreenshot() {
-		const { demo_uri, retired, isActive, isWpcomTheme } = this.props;
+		const { demo_uri, retired, isActive, isWpcomTheme, name: themeName } = this.props;
 		const screenshotFull = isWpcomTheme ? this.getFullLengthScreenshot() : this.props.screenshot;
 		const width = 735;
 		// Photon may return null, allow fallbacks
 		const photonSrc = screenshotFull && photon( screenshotFull, { width } );
 		const img = screenshotFull && (
 			<img
+				alt={ i18n.translate( 'Screenshot of the %(themeName)s theme', {
+					args: { themeName },
+				} ) }
 				className="theme__sheet-img"
 				src={ photonSrc || screenshotFull }
 				srcSet={ photonSrc && `${ photon( screenshotFull, { width, zoom: 2 } ) } 2x` }


### PR DESCRIPTION
We were loading huge images in the theme view. Reduce the size by using Photon.
Also adds `srcset` with 2x images.

This should be viable for `wporg` themes as well, but the the screenshot urls that appear fine in state are having `?ver=…` appended to them, it's unclear why. In this case the non-photon url is used as a fallback..

Related: #19893 #20009

## Screens

## Before

Note the mismatch native/actual sizes:

![before](https://user-images.githubusercontent.com/841763/37786771-bd5daf0c-2dfd-11e8-8fde-2fd3f1aee8d5.png)

Note the bad query (`?w=2880?w=680`)
![before-html](https://user-images.githubusercontent.com/841763/37786772-bd8749c0-2dfd-11e8-9b92-04f5361da7c5.png)

## After
![after-html](https://user-images.githubusercontent.com/841763/37786768-bd0896d4-2dfd-11e8-9f56-0e0394ece19c.png)
![after](https://user-images.githubusercontent.com/841763/37786769-bd32aa78-2dfd-11e8-8f02-cc46da445710.png)

## Testing
1. Test logged-in and logged-out
1. Test WordPress.com and Jetpack sites
1. On a single theme page (`/theme/THEME_SLUG/MAYBE_JETPACK_SITE_SLUG`), verify everything works and displays correctly and there are no errors or warnings on the console.

