### PR TITLE
Store: Enable the store stats dashboard widget in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -128,7 +128,7 @@
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"woocommerce/extension-dashboard": true,
-		"woocommerce/extension-dashboard-stats-widget": false,
+		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-orders-create": true,
 		"woocommerce/extension-orders-edit": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -132,7 +132,7 @@
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"woocommerce/extension-dashboard": true,
-		"woocommerce/extension-dashboard-stats-widget": false,
+		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-orders-create": true,
 		"woocommerce/extension-orders-edit": true,


### PR DESCRIPTION
This PR enables the stats widget on the store dashboard in production and staging. See #23344 and p90Yrv-mi-p2.

You can see the widget in action at `http://calypso.localhost:3000/store/:site`.