### PR TITLE
Stats: Replace direct analytics.pageView calls with the PageViewTracker component (Part 1)

### DIFF
--- a/client/my-sites/ads/controller.js
+++ b/client/my-sites/ads/controller.js
@@ -11,22 +11,10 @@ import page from 'page';
 /**
  * Internal Dependencies
  */
-import { sectionify } from 'lib/route';
-import analytics from 'lib/analytics';
-import titlecase from 'to-title-case';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import Ads from 'my-sites/ads/main';
-
-function _recordPageView( context, analyticsPageTitle ) {
-	const basePath = sectionify( context.path );
-	if ( 'undefined' !== typeof context.params.section ) {
-		analyticsPageTitle += ' > ' + titlecase( context.params.section );
-	}
-
-	analytics.ga.recordPageView( basePath + '/:site', analyticsPageTitle );
-}
 
 function _getLayoutTitle( context ) {
 	const state = context.store.getState();
@@ -50,8 +38,6 @@ export default {
 		const layoutTitle = _getLayoutTitle( context );
 
 		context.store.dispatch( setTitle( layoutTitle ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-
-		_recordPageView( context, layoutTitle );
 
 		// Scroll to the top
 		if ( typeof window !== 'undefined' ) {

--- a/client/my-sites/ads/controller.js
+++ b/client/my-sites/ads/controller.js
@@ -5,28 +5,12 @@
  */
 
 import React from 'react';
-import i18n from 'i18n-calypso';
 import page from 'page';
 
 /**
  * Internal Dependencies
  */
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
 import Ads from 'my-sites/ads/main';
-
-function _getLayoutTitle( context ) {
-	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
-	const title = isJetpackSite( state, siteId ) ? 'Ads' : 'WordAds';
-	switch ( context.params.section ) {
-		case 'earnings':
-			return i18n.translate( '%(wordads)s Earnings', { args: { wordads: title } } );
-		case 'settings':
-			return i18n.translate( '%(wordads)s Settings', { args: { wordads: title } } );
-	}
-}
 
 export default {
 	redirect: function( context ) {
@@ -35,10 +19,6 @@ export default {
 	},
 
 	layout: function( context, next ) {
-		const layoutTitle = _getLayoutTitle( context );
-
-		context.store.dispatch( setTitle( layoutTitle ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-
 		// Scroll to the top
 		if ( typeof window !== 'undefined' ) {
 			window.scrollTo( 0, 0 );

--- a/client/my-sites/ads/main.jsx
+++ b/client/my-sites/ads/main.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import page from 'page';
-import { find } from 'lodash';
+import { capitalize, find } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -40,6 +40,7 @@ import { getSiteFragment } from 'lib/route';
 import { isSiteWordadsUnsafe, isRequestingWordadsStatus } from 'state/wordads/status/selectors';
 import { wordadsUnsafeValues } from 'state/wordads/status/schema';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 class AdsMain extends Component {
 	static propTypes = {
@@ -224,13 +225,13 @@ class AdsMain extends Component {
 	}
 
 	render() {
-		const { site, translate } = this.props;
+		const { section, site, translate } = this.props;
 
 		if ( ! this.canAccess() ) {
 			return null;
 		}
 
-		let component = this.getComponent( this.props.section );
+		let component = this.getComponent( section );
 		let notice = null;
 
 		if ( this.props.requestingWordAdsApproval || this.props.wordAdsSuccess ) {
@@ -249,6 +250,10 @@ class AdsMain extends Component {
 
 		return (
 			<Main className="ads">
+				<PageViewTracker
+					path={ `/ads/${ section }/:site` }
+					title={ `WordAds ${ capitalize( section ) }` }
+				/>
 				<SidebarNavigation />
 				<SectionNav selectedText={ this.getSelectedText() }>
 					<NavTabs>

--- a/client/my-sites/ads/main.jsx
+++ b/client/my-sites/ads/main.jsx
@@ -41,9 +41,12 @@ import { isSiteWordadsUnsafe, isRequestingWordadsStatus } from 'state/wordads/st
 import { wordadsUnsafeValues } from 'state/wordads/status/schema';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import DocumentHead from 'components/data/document-head';
+import { isJetpackSite } from 'state/sites/selectors';
 
 class AdsMain extends Component {
 	static propTypes = {
+		isJetpack: PropTypes.bool,
 		isRequestingWordadsStatus: PropTypes.bool.isRequired,
 		isUnsafe: PropTypes.oneOf( wordadsUnsafeValues ),
 		requestingWordAdsApproval: PropTypes.bool.isRequired,
@@ -225,7 +228,7 @@ class AdsMain extends Component {
 	}
 
 	render() {
-		const { section, site, translate } = this.props;
+		const { isJetpack, section, site, translate } = this.props;
 
 		if ( ! this.canAccess() ) {
 			return null;
@@ -248,12 +251,19 @@ class AdsMain extends Component {
 			component = this.renderInstantActivationToggle( component );
 		}
 
+		const adsProgramName = isJetpack ? 'Ads' : 'WordAds';
+		const layoutTitles = {
+			earnings: translate( '%(wordads)s Earnings', { args: { wordads: adsProgramName } } ),
+			settings: translate( '%(wordads)s Settings', { args: { wordads: adsProgramName } } ),
+		};
+
 		return (
 			<Main className="ads">
 				<PageViewTracker
 					path={ `/ads/${ section }/:site` }
-					title={ `WordAds ${ capitalize( section ) }` }
+					title={ `${ adsProgramName } ${ capitalize( section ) }` }
 				/>
+				<DocumentHead title={ layoutTitles[ section ] } />
 				<SidebarNavigation />
 				<SectionNav selectedText={ this.getSelectedText() }>
 					<NavTabs>
@@ -291,6 +301,7 @@ const mapStateToProps = state => {
 		wordAdsSuccess: getWordAdsSuccessForSite( state, site ),
 		isUnsafe: isSiteWordadsUnsafe( state, siteId ),
 		isRequestingWordadsStatus: isRequestingWordadsStatus( state, siteId ),
+		isJetpack: isJetpackSite( state, siteId ),
 	};
 };
 

--- a/client/my-sites/customize/controller.js
+++ b/client/my-sites/customize/controller.js
@@ -8,16 +8,10 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
-import { sectionify } from 'lib/route';
-import analytics from 'lib/analytics';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import CustomizeComponent from 'my-sites/customize/main';
 
 export function customize( context, next ) {
-	const basePath = sectionify( context.path );
-
-	analytics.pageView.record( basePath, 'Customizer' );
-
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( i18n.translate( 'Customizer', { textOnly: true } ) ) );
 

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -264,7 +264,7 @@ class Customize extends React.Component {
 	renderErrorPage = error => {
 		return (
 			<div className="main main-column customize" role="main">
-				<PageViewTracker path="/customize/:site" title={ 'Customizer' } />
+				<PageViewTracker path="/customize/:site" title="Customizer" />
 				<SidebarNavigation />
 				<EmptyContent
 					title={ error.title }
@@ -299,7 +299,7 @@ class Customize extends React.Component {
 		if ( ! this.props.site ) {
 			return (
 				<div className="main main-column customize is-iframe" role="main">
-					<PageViewTracker path="/customize/:site" title={ 'Customizer' } />
+					<PageViewTracker path="/customize/:site" title="Customizer" />
 					<CustomizerLoadingPanel />
 				</div>
 			);
@@ -325,7 +325,7 @@ class Customize extends React.Component {
 			// waitForLoading above) then an error will be shown.
 			return (
 				<div className="main main-column customize is-iframe" role="main">
-					<PageViewTracker path="/customize/:site" title={ 'Customizer' } />
+					<PageViewTracker path="/customize/:site" title="Customizer" />
 					<CustomizerLoadingPanel isLoaded={ this.state.iframeLoaded } />
 					<iframe className={ iframeClassName } src={ iframeUrl } />
 				</div>

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -28,6 +28,7 @@ import { getMenusUrl } from 'state/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getCustomizerUrl, isJetpackSite } from 'state/sites/selectors';
 import wpcom from 'lib/wp';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 const debug = debugFactory( 'calypso:my-sites:customize' );
 
@@ -263,6 +264,7 @@ class Customize extends React.Component {
 	renderErrorPage = error => {
 		return (
 			<div className="main main-column customize" role="main">
+				<PageViewTracker path="/customize/:site" title={ 'Customizer' } />
 				<SidebarNavigation />
 				<EmptyContent
 					title={ error.title }
@@ -297,6 +299,7 @@ class Customize extends React.Component {
 		if ( ! this.props.site ) {
 			return (
 				<div className="main main-column customize is-iframe" role="main">
+					<PageViewTracker path="/customize/:site" title={ 'Customizer' } />
 					<CustomizerLoadingPanel />
 				</div>
 			);
@@ -322,6 +325,7 @@ class Customize extends React.Component {
 			// waitForLoading above) then an error will be shown.
 			return (
 				<div className="main main-column customize is-iframe" role="main">
+					<PageViewTracker path="/customize/:site" title={ 'Customizer' } />
 					<CustomizerLoadingPanel isLoaded={ this.state.iframeLoaded } />
 					<iframe className={ iframeClassName } src={ iframeUrl } />
 				</div>


### PR DESCRIPTION
WIP

| Section | Before | After |
| --- | --- | --- |
| Ads | `/ads/{ section }/:site` | `/ads/{ section }/:site` |
| Ads (title) | `{ "Ads" / "WordAds" } > { Section }` | `WordAds { Section }` |
| Customize | `/customize` | `/customize/:site` |