### PR TITLE
Store: Make the navigation & action bar sticky on mobile

### DIFF
--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -9,6 +9,11 @@
 	.section-nav {
 		margin-top: 8px;
 	}
+
+	.search,
+	.search .search__open-icon {
+		z-index: initial;
+	}
 }
 
 .reviews__list {

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -166,9 +166,3 @@
 		}
 	}
 }
-
-@include breakpoint( "<660px" ) {
-	.section-nav {
-		margin-top: 72px;
-	}
-}

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -35,6 +35,13 @@
 		top: 47px;
 		left: 229px;
 	}
+
+	@include breakpoint( "<660px" ) {
+		position: fixed;
+		z-index: z-index( 'root', '.sticky-panel.is-sticky .sticky-panel__content' );
+		width: 100%;
+		top: 47px;
+	}
 }
 
 .action-header__back-to-sidebar {
@@ -157,5 +164,11 @@
 				color: $white;
 			}
 		}
+	}
+}
+
+@include breakpoint( "<660px" ) {
+	.section-nav {
+		margin-top: 72px;
 	}
 }

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -62,8 +62,9 @@
 	@import 'woocommerce-services/style';
 
 	.main {
-		@include breakpoint( ">660px" ) {
-			padding-top: 35px;
+		padding-top: 35px;
+		@include breakpoint( "<660px" ) {
+			padding-top: 72px;
 		}
 	}
 


### PR DESCRIPTION
Fixes #16733.

This PR makes the navigation/action bar sticky on mobile, so that it scrolls with the rest of the page. We were already doing this for screen sizes above `660px`. It also makes a minor fix to the reviews search icon, which would bleed over the action bar when scrolling (including on desktop).

To Test:
* Navigate to different store pages with your browser below 660px. Make sure the nav bar sticks, and that other content is not covered.