### PR TITLE
People: Give a gap between the icon and the button text for the invite button

### DIFF
--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -55,7 +55,9 @@ class PeopleListSectionHeader extends Component {
 				{ siteLink && (
 					<Button compact href={ siteLink } className="people-list-section-header__add-button">
 						<Gridicon icon="user-add" />
-						{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
+						<span class="people-list-section-header__button-text">
+							{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
+						</span>
 					</Button>
 				) }
 			</SectionHeader>


### PR DESCRIPTION
Before:
<img width="728" alt="screen shot 2018-03-22 at 23 00 03" src="https://user-images.githubusercontent.com/908665/37803152-3e17b616-2e25-11e8-8000-e3250af77ce1.png">

After:
<img width="734" alt="screen shot 2018-03-22 at 22 58 03" src="https://user-images.githubusercontent.com/908665/37803159-45b0937a-2e25-11e8-823f-41b43dd1afc0.png">

Note: Since #23068, we prefer to wrap the button text to give a space between an icon and button text rather than every time add it to the icon.

