### PR TITLE
JPC: remote install- update notice failure labels.

### DIFF
--- a/client/jetpack-connect/connection-notice-types.js
+++ b/client/jetpack-connect/connection-notice-types.js
@@ -5,12 +5,12 @@
  *
  * These notice types are indicators of Jetpack Connection status.
  */
-export const ACTIVATE_FAILURE = 'unableToActivate';
+export const ACTIVATION_RESPONSE_ERROR = 'unableToActivate';
 export const ALREADY_CONNECTED = 'alreadyConnected';
 export const ALREADY_CONNECTED_BY_OTHER_USER = 'alreadyConnectedByOtherUser';
 export const ALREADY_OWNED = 'alreadyOwned';
 export const DEFAULT_AUTHORIZE_ERROR = 'defaultAuthorizeError';
-export const INSTALL_FAILURE = 'unableToInstall';
+export const INSTALL_RESPONSE_ERROR = 'unableToInstall';
 export const IS_DOT_COM = 'isDotCom';
 export const JETPACK_IS_DISCONNECTED = 'jetpackIsDisconnected';
 export const JETPACK_IS_VALID = 'jetpackIsValid';

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -12,12 +12,12 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import {
-	ACTIVATE_FAILURE,
+	ACTIVATION_RESPONSE_ERROR,
 	ALREADY_CONNECTED,
 	ALREADY_CONNECTED_BY_OTHER_USER,
 	ALREADY_OWNED,
 	DEFAULT_AUTHORIZE_ERROR,
-	INSTALL_FAILURE,
+	INSTALL_RESPONSE_ERROR,
 	IS_DOT_COM,
 	JETPACK_IS_DISCONNECTED,
 	JETPACK_IS_VALID,
@@ -47,12 +47,12 @@ export class JetpackConnectNotices extends Component {
 		// instead of showing a notice.
 		onTerminalError: PropTypes.func,
 		noticeType: PropTypes.oneOf( [
-			ACTIVATE_FAILURE,
+			ACTIVATION_RESPONSE_ERROR,
 			ALREADY_CONNECTED,
 			ALREADY_CONNECTED_BY_OTHER_USER,
 			ALREADY_OWNED,
 			DEFAULT_AUTHORIZE_ERROR,
-			INSTALL_FAILURE,
+			INSTALL_RESPONSE_ERROR,
 			IS_DOT_COM,
 			LOGIN_FAILURE,
 			JETPACK_IS_DISCONNECTED,
@@ -112,7 +112,7 @@ export class JetpackConnectNotices extends Component {
 		}
 
 		switch ( noticeType ) {
-			case ACTIVATE_FAILURE:
+			case ACTIVATION_RESPONSE_ERROR:
 				noticeValues.text = translate(
 					'We were unable to activate Jetpack. You can either {{manualInstall}}install Jetpack manually{{/manualInstall}} ' +
 						'or {{support}}contact support{{/support}} for help.',
@@ -192,7 +192,7 @@ export class JetpackConnectNotices extends Component {
 				);
 				return noticeValues;
 
-			case INSTALL_FAILURE:
+			case INSTALL_RESPONSE_ERROR:
 				noticeValues.text = translate(
 					'We were unable to install Jetpack. You can either {{manualInstall}}install Jetpack manually{{/manualInstall}} ' +
 						'or {{support}}contact support{{/support}} for help.',

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -32,8 +32,8 @@ import { getConnectingSite } from 'state/jetpack-connect/selectors';
 import { REMOTE_PATH_AUTH } from './constants';
 
 import {
-	ACTIVATE_FAILURE,
-	INSTALL_FAILURE,
+	ACTIVATION_RESPONSE_FAILURE,
+	INSTALL_RESPONSE_ERROR,
 	INVALID_PERMISSIONS,
 	LOGIN_FAILURE,
 	UNKNOWN_REMOTE_INSTALL_ERROR,
@@ -112,11 +112,11 @@ export class OrgCredentialsForm extends Component {
 		if ( installError === 'LOGIN_FAILURE' ) {
 			return LOGIN_FAILURE;
 		}
-		if ( installError === 'ACTIVATE_FAILURE' ) {
-			return ACTIVATE_FAILURE;
+		if ( installError === 'ACTIVATION_RESPONSE_FAILURE' ) {
+			return ACTIVATION_RESPONSE_FAILURE;
 		}
-		if ( installError === 'INSTALL_FAILURE' ) {
-			return INSTALL_FAILURE;
+		if ( installError === 'INSTALL_RESPONSE_ERROR' ) {
+			return INSTALL_RESPONSE_ERROR;
 		}
 		if ( installError === 'FORBIDDEN' ) {
 			return INVALID_PERMISSIONS;


### PR DESCRIPTION
Errors returned from the REST WP API has changed for the installation and activation messages.
This PR updates the notice names to reflect those changes.

No visual changes, sole renaming.