### PR TITLE
Community Translator: Should display checkbox after page load

### DIFF
--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -11,7 +11,7 @@ export {
 	getLocaleFromPath,
 	isDefaultLocale,
 	isLocaleVariant,
-	hasNoGlotPressTranslationSet,
+	canBeTranslated,
 	removeLocaleFromPath,
 } from './utils';
 

--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -11,7 +11,7 @@ export {
 	getLocaleFromPath,
 	isDefaultLocale,
 	isLocaleVariant,
-	hasTranslationSet,
+	hasNoGlotPressTranslationSet,
 	removeLocaleFromPath,
 } from './utils';
 

--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -17,7 +17,7 @@ export {
 	getLocaleFromPath,
 	isDefaultLocale,
 	isLocaleVariant,
-	hasTranslationSet,
+	hasNoGlotPressTranslationSet,
 	removeLocaleFromPath,
 } from './utils';
 

--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -17,7 +17,7 @@ export {
 	getLocaleFromPath,
 	isDefaultLocale,
 	isLocaleVariant,
-	hasNoGlotPressTranslationSet,
+	canBeTranslated,
 	removeLocaleFromPath,
 } from './utils';
 

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -15,7 +15,7 @@ import {
 	isDefaultLocale,
 	removeLocaleFromPath,
 	isLocaleVariant,
-	hasTranslationSet,
+	hasNoGlotPressTranslationSet,
 } from 'lib/i18n-utils';
 
 jest.mock( 'config', () => key => {
@@ -234,18 +234,18 @@ describe( 'utils', () => {
 		} );
 	} );
 
-	describe( '#hasTranslationSet', () => {
+	describe( '#hasNoGlotPressTranslationSet', () => {
 		test( 'should return false by default', () => {
-			expect( hasTranslationSet() ).to.be.false;
+			expect( hasNoGlotPressTranslationSet() ).to.be.false;
 		} );
 
-		test( 'should return false for elements in the exception list', () => {
-			expect( hasTranslationSet( 'en' ) ).to.be.false;
-			expect( hasTranslationSet( 'sr_latin' ) ).to.be.false;
+		test( 'should return true for elements in the exception list', () => {
+			expect( hasNoGlotPressTranslationSet( 'en' ) ).to.be.true;
+			expect( hasNoGlotPressTranslationSet( 'sr_latin' ) ).to.be.true;
 		} );
 
-		test( 'should return true for languages not in the exception list', () => {
-			expect( hasTranslationSet( 'de' ) ).to.be.true;
+		test( 'should return false for languages not in the exception list', () => {
+			expect( hasNoGlotPressTranslationSet( 'de' ) ).to.be.false;
 		} );
 	} );
 } );

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -15,7 +15,7 @@ import {
 	isDefaultLocale,
 	removeLocaleFromPath,
 	isLocaleVariant,
-	hasNoGlotPressTranslationSet,
+	canBeTranslated,
 } from 'lib/i18n-utils';
 
 jest.mock( 'config', () => key => {
@@ -234,18 +234,18 @@ describe( 'utils', () => {
 		} );
 	} );
 
-	describe( '#hasNoGlotPressTranslationSet', () => {
-		test( 'should return false by default', () => {
-			expect( hasNoGlotPressTranslationSet() ).to.be.false;
+	describe( '#canBeTranslated', () => {
+		test( 'should return true by default', () => {
+			expect( canBeTranslated() ).to.be.true;
 		} );
 
-		test( 'should return true for elements in the exception list', () => {
-			expect( hasNoGlotPressTranslationSet( 'en' ) ).to.be.true;
-			expect( hasNoGlotPressTranslationSet( 'sr_latin' ) ).to.be.true;
+		test( 'should return false for elements in the exception list', () => {
+			expect( canBeTranslated( 'en' ) ).to.be.false;
+			expect( canBeTranslated( 'sr_latin' ) ).to.be.false;
 		} );
 
-		test( 'should return false for languages not in the exception list', () => {
-			expect( hasNoGlotPressTranslationSet( 'de' ) ).to.be.false;
+		test( 'should return true for languages not in the exception list', () => {
+			expect( canBeTranslated( 'de' ) ).to.be.true;
 		} );
 	} );
 } );

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -51,15 +51,11 @@ export function isLocaleVariant( locale ) {
 
 /**
  * Checks against a list of locales that don't have any GP translation sets
- *
  * @param {string} locale - locale slug (eg: 'fr')
  * @return {boolean} true when the locale is a member of the exception list
  */
-export function hasTranslationSet( locale ) {
-	if ( ! isString( locale ) ) {
-		return false;
-	}
-	return [ 'en', 'sr_latin' ].indexOf( locale ) === -1;
+export function hasNoGlotPressTranslationSet( locale ) {
+	return [ 'en', 'sr_latin' ].indexOf( locale ) > -1;
 }
 
 /**

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -51,6 +51,8 @@ export function isLocaleVariant( locale ) {
 
 /**
  * Checks against a list of locales that don't have any GP translation sets
+ * A 'translation set' refers to a collection of strings to be translated see:
+ * https://glotpress.blog/the-manual/translation-sets/
  * @param {string} locale - locale slug (eg: 'fr')
  * @return {boolean} true when the locale is a member of the exception list
  */

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -54,10 +54,10 @@ export function isLocaleVariant( locale ) {
  * A 'translation set' refers to a collection of strings to be translated see:
  * https://glotpress.blog/the-manual/translation-sets/
  * @param {string} locale - locale slug (eg: 'fr')
- * @return {boolean} true when the locale is a member of the exception list
+ * @return {boolean} true when the locale is NOT a member of the exception list
  */
-export function hasNoGlotPressTranslationSet( locale ) {
-	return [ 'en', 'sr_latin' ].indexOf( locale ) > -1;
+export function canBeTranslated( locale ) {
+	return [ 'en', 'sr_latin' ].indexOf( locale ) === -1;
 }
 
 /**

--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -18,7 +18,7 @@ import User from 'lib/user';
 import userSettings from 'lib/user-settings';
 import { isMobile } from 'lib/viewport';
 import analytics from 'lib/analytics';
-import { hasNoGlotPressTranslationSet } from 'lib/i18n-utils';
+import { canBeTranslated } from 'lib/i18n-utils';
 
 const debug = debugModule( 'calypso:community-translator' );
 
@@ -63,13 +63,13 @@ const communityTranslatorJumpstart = {
 		if (
 			! currentUser ||
 			! currentUser.localeSlug ||
-			hasNoGlotPressTranslationSet( currentUser.localeSlug )
+			! canBeTranslated( currentUser.localeSlug )
 		) {
 			return false;
 		}
 
 		// disable for locale variants with no official GP translation sets
-		if ( currentUser.localeVariant && hasNoGlotPressTranslationSet( currentUser.localeVariant ) ) {
+		if ( currentUser.localeVariant && ! canBeTranslated( currentUser.localeVariant ) ) {
 			return false;
 		}
 

--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -18,7 +18,7 @@ import User from 'lib/user';
 import userSettings from 'lib/user-settings';
 import { isMobile } from 'lib/viewport';
 import analytics from 'lib/analytics';
-import { hasTranslationSet } from 'lib/i18n-utils';
+import { hasNoGlotPressTranslationSet } from 'lib/i18n-utils';
 
 const debug = debugModule( 'calypso:community-translator' );
 
@@ -63,13 +63,13 @@ const communityTranslatorJumpstart = {
 		if (
 			! currentUser ||
 			! currentUser.localeSlug ||
-			! hasTranslationSet( currentUser.localeSlug )
+			hasNoGlotPressTranslationSet( currentUser.localeSlug )
 		) {
 			return false;
 		}
 
 		// disable for locale variants with no official GP translation sets
-		if ( currentUser.localeVariant && ! hasTranslationSet( currentUser.localeVariant ) ) {
+		if ( currentUser.localeVariant && hasNoGlotPressTranslationSet( currentUser.localeVariant ) ) {
 			return false;
 		}
 

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -43,7 +43,7 @@ import Main from 'components/main';
 import SitesDropdown from 'components/sites-dropdown';
 import ColorSchemePicker from 'blocks/color-scheme-picker';
 import { successNotice, errorNotice } from 'state/notices/actions';
-import { getLanguage, isLocaleVariant, hasNoGlotPressTranslationSet } from 'lib/i18n-utils';
+import { getLanguage, isLocaleVariant, canBeTranslated } from 'lib/i18n-utils';
 import { isRequestingMissingSites } from 'state/selectors';
 import _user from 'lib/user';
 
@@ -153,14 +153,14 @@ const Account = createReactClass( {
 		const locale = this.getUserSetting( 'language' );
 
 		// disable for locales
-		if ( ! locale || hasNoGlotPressTranslationSet( locale ) ) {
+		if ( ! locale || ! canBeTranslated( locale ) ) {
 			return false;
 		}
 
 		// disable for locale variants with no official GP translation sets
 		if (
 			this.state.localeVariantSelected &&
-			hasNoGlotPressTranslationSet( this.state.localeVariantSelected )
+			! canBeTranslated( this.state.localeVariantSelected )
 		) {
 			return false;
 		}
@@ -168,7 +168,7 @@ const Account = createReactClass( {
 		// if the user hasn't yet selected a language, and the locale variants has no official GP translation set
 		if (
 			typeof this.state.localeVariantSelected !== 'string' &&
-			hasNoGlotPressTranslationSet( this.getUserSetting( 'locale_variant' ) )
+			! canBeTranslated( this.getUserSetting( 'locale_variant' ) )
 		) {
 			return false;
 		}

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -43,7 +43,7 @@ import Main from 'components/main';
 import SitesDropdown from 'components/sites-dropdown';
 import ColorSchemePicker from 'blocks/color-scheme-picker';
 import { successNotice, errorNotice } from 'state/notices/actions';
-import { getLanguage, isLocaleVariant, hasTranslationSet } from 'lib/i18n-utils';
+import { getLanguage, isLocaleVariant, hasNoGlotPressTranslationSet } from 'lib/i18n-utils';
 import { isRequestingMissingSites } from 'state/selectors';
 import _user from 'lib/user';
 
@@ -153,14 +153,14 @@ const Account = createReactClass( {
 		const locale = this.getUserSetting( 'language' );
 
 		// disable for locales
-		if ( ! locale || ! hasTranslationSet( locale ) ) {
+		if ( ! locale || hasNoGlotPressTranslationSet( locale ) ) {
 			return false;
 		}
 
 		// disable for locale variants with no official GP translation sets
 		if (
 			this.state.localeVariantSelected &&
-			! hasTranslationSet( this.state.localeVariantSelected )
+			hasNoGlotPressTranslationSet( this.state.localeVariantSelected )
 		) {
 			return false;
 		}
@@ -168,7 +168,7 @@ const Account = createReactClass( {
 		// if the user hasn't yet selected a language, and the locale variants has no official GP translation set
 		if (
 			typeof this.state.localeVariantSelected !== 'string' &&
-			! hasTranslationSet( this.getUserSetting( 'locale_variant' ) )
+			hasNoGlotPressTranslationSet( this.getUserSetting( 'locale_variant' ) )
 		) {
 			return false;
 		}


### PR DESCRIPTION
#23397 introduced a regression whereby, on page load,  the UI does not display the Community Translator activation checkbox for languages that have valid translation sets in GlotPress.

<img width="737" alt="screen shot 2018-03-23 at 11 56 57 am" src="https://user-images.githubusercontent.com/6458278/37806051-deabbe08-2e91-11e8-878e-900e66c4eca9.png">

This PR fixes that :)

## Testing
1. Go to http://calypso.localhost:3000/me/account, switch your language to a root, non-English language (Deutsch, Italian, French for example)

### Expectations
After the page reloads you should see the Community Translator activation checkbox.

<img width="762" alt="screen shot 2018-03-23 at 11 57 17 am" src="https://user-images.githubusercontent.com/6458278/37806137-845f6642-2e92-11e8-866f-7380a4336345.png">

