### PR TITLE
Editor: Prevent broken preview when editing published custom post type

### DIFF
--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -24,14 +24,17 @@ export const getEditURL = function( post, site ) {
 };
 
 export const getPreviewURL = function( site, post ) {
-	let parsed, previewUrl;
+	let parsed, parsedPostUrl, parsedPostPreview, previewUrl;
 
 	if ( ! post || ! post.URL || post.status === 'trash' ) {
 		return '';
 	}
 
 	if ( post.preview_URL ) {
-		previewUrl = post.preview_URL;
+		parsedPostUrl = url.parse( post.URL, true );
+		parsedPostPreview = url.parse( post.preview_URL, true );
+		parsedPostUrl.search = parsedPostPreview.search;
+		previewUrl = url.format( parsedPostUrl );
 	} else if ( post.status === 'publish' ) {
 		previewUrl = post.URL;
 	} else {


### PR DESCRIPTION
## This PR
- adds a client-side fix for #22645

### Note:
The changes suggested in this PR fix the symptoms, not the cause. We'd probably want to solve this on the server side. See #22645 for details/discussion.

### How to test

- Select a site with Portfolios enabled (or enable them in the Writing settings on your site).
- If you don't have any portfolio projects yet, create and publish one.
- In the list of portfolio projects, select one to open it in the editor.
- Before making any changes, select "Preview" to preview the project.
- Make any edit to the project.
- Select "Preview" again to preview your changes.
- Both times the "Preview" should work and not show a 404
