### PR TITLE
Store: Stats: Referrer: Add ability to search and select

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -123,7 +123,9 @@ class StoreStats extends Component {
 								siteId={ siteId }
 								query={ referrerQuery }
 								statType="statsStoreReferrers"
-								selectedDate={ unitSelectedDate }
+								unitSelectedDate={ unitSelectedDate }
+								limit={ 5 }
+								pageType="orders"
 							/>
 						</Module>
 					</div>

--- a/client/extensions/woocommerce/app/store-stats/referrers/helpers.js
+++ b/client/extensions/woocommerce/app/store-stats/referrers/helpers.js
@@ -15,6 +15,5 @@ export function sortBySales( data, limit ) {
 	if ( ! Array.isArray( data ) ) {
 		throw new Error( 'Incorrect data structure applied to "sortBySales". Input must be an array' );
 	}
-	const computedLimit = limit || data.length;
-	return sortBy( data, d => -d.sales ).slice( 0, computedLimit );
+	return sortBy( data, d => -d.sales ).slice( 0, limit || data.length );
 }

--- a/client/extensions/woocommerce/app/store-stats/referrers/index.js
+++ b/client/extensions/woocommerce/app/store-stats/referrers/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { find } from 'lodash';
@@ -14,74 +14,174 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import QuerySiteStats from 'components/data/query-site-stats';
-import { getSiteStatsNormalizedData } from 'state/stats/lists/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getUnitPeriod } from 'woocommerce/app/store-stats/utils';
 import StoreStatsPeriodNav from 'woocommerce/app/store-stats/store-stats-period-nav';
 import JetpackColophon from 'components/jetpack-colophon';
 import Main from 'components/main';
 import Module from 'woocommerce/app/store-stats/store-stats-module';
-import { sortBySales } from './helpers';
+import SearchCard from 'components/search-card';
+import StoreStatsReferrerWidget from 'woocommerce/app/store-stats/store-stats-referrer-widget';
+import { sortBySales } from 'woocommerce/app/store-stats/referrers/helpers';
+import { getStoreReferrers } from 'state/selectors';
 
 const STAT_TYPE = 'statsStoreReferrers';
+const LIMIT = 10;
 
-const Referrers = ( { siteId, query, data, selectedDate, unit, slug, translate, queryParams } ) => {
-	const unitSelectedDate = getUnitPeriod( selectedDate, unit );
-	const selectedData = find( data, d => d.date === unitSelectedDate ) || { data: [] };
-	const sortedData = sortBySales( selectedData.data );
-	return (
-		<Main wideLayout>
-			{ siteId && <QuerySiteStats statType={ STAT_TYPE } siteId={ siteId } query={ query } /> }
-			<StoreStatsPeriodNav
-				type="referrers"
-				selectedDate={ selectedDate }
-				unit={ unit }
-				slug={ slug }
-				query={ query }
-				statType={ STAT_TYPE }
-				title={ translate( 'Store Referrers' ) }
-				queryParams={ queryParams }
-			/>
-			<Module
-				siteId={ siteId }
-				emptyMessage={ translate( 'No referrers found' ) }
-				query={ query }
-				statType={ STAT_TYPE }
-			>
-				<table>
-					<tbody>
-						{ sortedData.map( d => (
-							<tr key={ d.referrer }>
-								<td>{ d.date }</td>
-								<td>{ d.referrer }</td>
-								<td>{ d.product_views }</td>
-								<td>{ d.add_to_carts }</td>
-								<td>{ d.product_purchases }</td>
-								<td>${ d.sales }</td>
+class Referrers extends Component {
+	static propTypes = {
+		siteId: PropTypes.number,
+		query: PropTypes.object.isRequired,
+		data: PropTypes.array.isRequired,
+		selectedDate: PropTypes.string,
+		unit: PropTypes.oneOf( [ 'day', 'week', 'month', 'year' ] ),
+		slug: PropTypes.string,
+		limit: PropTypes.number,
+	};
+
+	state = {
+		filter: '',
+	};
+
+	componentWillReceiveProps( nextProps ) {
+		this.setData( nextProps, this.state.filter );
+	}
+
+	componentWillMount() {
+		this.setData( this.props, this.state.filter );
+	}
+
+	onSearch = str => {
+		this.setData( this.props, str );
+	};
+
+	getFilteredData = ( filter, { data } ) => {
+		const filteredData = filter ? data.filter( d => d.referrer.match( filter ) ) : data;
+		return {
+			filteredSortedData: sortBySales( filteredData ),
+			unfilteredDataLength: data.length,
+		};
+	};
+
+	getSelectedReferrer = ( filteredSortedData, { queryParams } ) => {
+		let selectedReferrerIndex = null;
+		const selectedReferrer = find( filteredSortedData, ( d, idx ) => {
+			if ( queryParams.referrer && queryParams.referrer === d.referrer ) {
+				selectedReferrerIndex = idx;
+				return true;
+			}
+			return false;
+		} );
+		return {
+			selectedReferrer,
+			selectedReferrerIndex,
+		};
+	};
+
+	setData( props, filter ) {
+		const { filteredSortedData, unfilteredDataLength } = this.getFilteredData( filter, props );
+		const { selectedReferrer, selectedReferrerIndex } = this.getSelectedReferrer(
+			filteredSortedData,
+			props
+		);
+		this.setState( {
+			filter,
+			filteredSortedData,
+			unfilteredDataLength,
+			selectedReferrer,
+			selectedReferrerIndex,
+		} );
+	}
+
+	render() {
+		const { siteId, query, selectedDate, unit, slug, translate, queryParams } = this.props;
+		const {
+			filter,
+			filteredSortedData,
+			unfilteredDataLength,
+			selectedReferrer,
+			selectedReferrerIndex,
+		} = this.state;
+		const unitSelectedDate = getUnitPeriod( selectedDate, unit );
+		const showSearch = unfilteredDataLength > LIMIT;
+		const title = `${ translate( 'Store Referrers' ) }${
+			queryParams.referrer ? ' - ' + queryParams.referrer : ''
+		}`;
+		return (
+			<Main className="referrers woocommerce" wideLayout>
+				{ siteId && <QuerySiteStats statType={ STAT_TYPE } siteId={ siteId } query={ query } /> }
+				<StoreStatsPeriodNav
+					type="referrers"
+					selectedDate={ selectedDate }
+					unit={ unit }
+					slug={ slug }
+					query={ query }
+					statType={ STAT_TYPE }
+					title={ title }
+					queryParams={ queryParams }
+				/>
+				<Module
+					className="referrers__search"
+					siteId={ siteId }
+					emptyMessage={ translate( 'No data found' ) }
+					query={ query }
+					statType={ STAT_TYPE }
+				>
+					{ showSearch && (
+						<SearchCard
+							className={ 'referrers__search-filter' }
+							onSearch={ this.onSearch }
+							placeholder="Filter Referrers"
+							value={ filter }
+							initialValue={ filter }
+						/>
+					) }
+					<StoreStatsReferrerWidget
+						fetchedData={ filteredSortedData }
+						unit={ unit }
+						siteId={ siteId }
+						query={ query }
+						statType={ STAT_TYPE }
+						unitSelectedDate={ unitSelectedDate }
+						queryParams={ queryParams }
+						slug={ slug }
+						limit={ LIMIT }
+						pageType="referrers"
+						paginate
+						selectedIndex={ selectedReferrerIndex }
+						selectedReferrer={ selectedReferrer && selectedReferrer.referrer }
+					/>
+				</Module>
+				{ selectedReferrer && (
+					<table>
+						<tbody>
+							<tr key={ selectedReferrer.referrer }>
+								<td>{ selectedReferrer.date }</td>
+								<td>{ selectedReferrer.referrer }</td>
+								<td>{ selectedReferrer.product_views }</td>
+								<td>{ selectedReferrer.add_to_carts }</td>
+								<td>{ selectedReferrer.product_purchases }</td>
+								<td>${ selectedReferrer.sales }</td>
 							</tr>
-						) ) }
-					</tbody>
-				</table>
-			</Module>
-			<JetpackColophon />
-		</Main>
-	);
-};
+						</tbody>
+					</table>
+				) }
+				<JetpackColophon />
+			</Main>
+		);
+	}
+}
 
-Referrers.propTypes = {
-	siteId: PropTypes.number,
-	query: PropTypes.object.isRequired,
-	data: PropTypes.array.isRequired,
-	selectedDate: PropTypes.string,
-	unit: PropTypes.oneOf( [ 'day', 'week', 'month', 'year' ] ),
-	slug: PropTypes.string,
-};
-
-export default connect( ( state, { query } ) => {
+export default connect( ( state, { query, selectedDate, unit } ) => {
 	const siteId = getSelectedSiteId( state );
 	return {
 		slug: getSelectedSiteSlug( state ),
 		siteId,
-		data: getSiteStatsNormalizedData( state, siteId, STAT_TYPE, query ),
+		data: getStoreReferrers( state, {
+			query,
+			siteId,
+			statType: STAT_TYPE,
+			unitSelectedDate: getUnitPeriod( selectedDate, unit ),
+		} ),
 	};
 } )( localize( Referrers ) );

--- a/client/extensions/woocommerce/app/store-stats/referrers/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/referrers/style.scss
@@ -1,0 +1,11 @@
+&.referrers {
+	.pagination {
+		padding: 0.5em 0;
+	}
+
+	.referrers__search {
+		max-width: 100%;
+		margin: 0 auto;
+	}
+}
+

--- a/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
@@ -8,6 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { isEqual } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -29,6 +30,7 @@ class StoreStatsModule extends Component {
 		statType: PropTypes.string,
 		query: PropTypes.object,
 		fetchedData: PropTypes.oneOfType( [ PropTypes.array, PropTypes.object ] ),
+		className: PropTypes.string,
 	};
 
 	state = {
@@ -46,13 +48,13 @@ class StoreStatsModule extends Component {
 	}
 
 	render() {
-		const { header, children, data, emptyMessage } = this.props;
+		const { header, children, data, emptyMessage, className } = this.props;
 		const { loaded } = this.state;
 		const isLoading = ! loaded && ! ( data && data.length );
 		const hasEmptyData = loaded && data && data.length === 0;
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<div className="store-stats-module">
+			<div className={ classnames( 'store-stats-module', className ) }>
 				{ header }
 				{ isLoading && (
 					<Card>

--- a/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget/index.js
@@ -7,22 +7,20 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { find } from 'lodash';
-import { max as d3Max } from 'd3-array';
 import { localize } from 'i18n-calypso';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import { getSiteStatsNormalizedData } from 'state/stats/lists/selectors';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
-import HorizontalBar from 'woocommerce/components/d3/horizontal-bar';
 import Card from 'components/card';
 import ErrorPanel from 'my-sites/stats/stats-error';
-import { sortBySales } from 'woocommerce/app/store-stats/referrers/helpers';
-import { getWidgetPath } from 'woocommerce/app/store-stats/utils';
+import { getWidgetPath, formatValue } from 'woocommerce/app/store-stats/utils';
+import Pagination from 'components/pagination';
+import { getStoreReferrers } from 'state/selectors';
 
 class StoreStatsReferrerWidget extends Component {
 	static propTypes = {
@@ -30,29 +28,37 @@ class StoreStatsReferrerWidget extends Component {
 		query: PropTypes.object.isRequired,
 		siteId: PropTypes.number,
 		statType: PropTypes.string.isRequired,
-		selectedDate: PropTypes.string.isRequired,
+		unitSelectedDate: PropTypes.string.isRequired,
 		unit: PropTypes.string.isRequired,
 		queryParams: PropTypes.object.isRequired,
-		slug: PropTypes.string,
+		slug: PropTypes.string.isRequired,
+		pageType: PropTypes.string.isRequired,
+		paginate: PropTypes.bool,
+		selectedIndex: PropTypes.number,
+		selectedReferrer: PropTypes.string,
 	};
 
-	isPreCollection( selectedData ) {
+	state = {
+		page: 1,
+	};
+
+	isPreCollection( date ) {
 		const { moment } = this.props;
-		return moment( selectedData.date ).isBefore( moment( '2018-02-01' ) );
+		return moment( date ).isBefore( moment( '2018-02-01' ) );
 	}
 
-	hasNosaraJobRun( selectedData ) {
+	hasNosaraJobRun( date ) {
 		const { moment } = this.props;
 		const nowUtc = moment().utc();
 		const daysOffsetFromUtc = nowUtc.hour() >= 10 ? 1 : 2;
 		const lastValidDay = nowUtc.subtract( daysOffsetFromUtc, 'days' );
-		return lastValidDay.isAfter( moment( selectedData.date ) );
+		return lastValidDay.isAfter( moment( date ) );
 	}
 
-	getEmptyDataMessage( selectedData ) {
-		const { translate, slug, queryParams } = this.props;
-		if ( ! this.hasNosaraJobRun( selectedData ) ) {
-			const href = `/store/stats/orders${ getWidgetPath( 'week', slug, queryParams ) }`;
+	getEmptyDataMessage( date ) {
+		const { translate, slug, queryParams, pageType } = this.props;
+		if ( ! this.hasNosaraJobRun( date ) ) {
+			const href = `/store/stats/${ pageType }${ getWidgetPath( 'week', slug, queryParams ) }`;
 			const primary = translate( 'Data is being processed – check back soon' );
 			const secondary = translate(
 				'Expand to a {{a}}wider{{/a}} view to see your latest referrers',
@@ -64,25 +70,67 @@ class StoreStatsReferrerWidget extends Component {
 			);
 			return [ primary, <p key="link">{ secondary }</p> ];
 		}
-		return this.isPreCollection( selectedData )
+		return this.isPreCollection( date )
 			? [ translate( 'Referral data isn’t available before Jetpack v5.9 (March 2018)' ) ]
 			: [ translate( 'No referral activity on this date' ) ];
 	}
 
+	paginate = data => {
+		const { paginate, limit } = this.props;
+		if ( ! paginate ) {
+			return data.slice( 0, limit || data.length );
+		}
+		const { page } = this.state;
+		const start = ( page - 1 ) * limit;
+		const end = start + limit;
+		return data.slice( start, end );
+	};
+
+	onPageClick = pageNumber => {
+		this.setState( {
+			page: pageNumber,
+		} );
+	};
+
+	setPage( { selectedIndex, limit } ) {
+		if ( this.props.paginate ) {
+			this.setState( {
+				page: Math.floor( selectedIndex / limit ) + 1,
+			} );
+		}
+	}
+
+	componentWillMount() {
+		this.setPage( this.props );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		this.setPage( nextProps );
+	}
+
 	render() {
-		const { data, selectedDate, translate, unit, slug, queryParams } = this.props;
+		const {
+			data,
+			unitSelectedDate,
+			translate,
+			unit,
+			slug,
+			queryParams,
+			limit,
+			paginate,
+			selectedReferrer,
+		} = this.props;
+		const { page } = this.state;
 		const basePath = '/store/stats/referrers';
-		const selectedData = find( data, d => d.date === selectedDate ) || { data: [] };
-		if ( selectedData.data.length === 0 ) {
-			const messages = this.getEmptyDataMessage( selectedData );
+		if ( data.length === 0 ) {
+			const messages = this.getEmptyDataMessage( unitSelectedDate );
 			return (
 				<Card className="store-stats-referrer-widget stats-module is-showing-error has-no-data">
 					<ErrorPanel message={ messages.shift() }>{ messages }</ErrorPanel>
 				</Card>
 			);
 		}
-		const sortedAndTrimmedData = sortBySales( selectedData.data, 5 );
-		const extent = [ 0, d3Max( sortedAndTrimmedData.map( d => d.sales ) ) ];
+		const paginatedData = this.paginate( data );
 		const header = (
 			<TableRow isHeader>
 				<TableItem isHeader isTitle>
@@ -92,37 +140,46 @@ class StoreStatsReferrerWidget extends Component {
 			</TableRow>
 		);
 		return (
-			<Table className="store-stats-referrer-widget" header={ header } compact>
-				{ sortedAndTrimmedData.map( d => {
-					const widgetPath = getWidgetPath(
-						unit,
-						slug,
-						Object.assign( {}, { referrer: d.referrer }, queryParams )
-					);
-					const href = `${ basePath }${ widgetPath }`;
-					return (
-						<TableRow key={ d.referrer }>
-							<TableItem isTitle>
-								<a href={ href }>{ d.referrer }</a>
-							</TableItem>
-							<TableItem>
-								<HorizontalBar
-									extent={ extent }
-									data={ d.sales }
-									currency={ d.currency }
-									height={ 20 }
-								/>
-							</TableItem>
-						</TableRow>
-					);
-				} ) }
-			</Table>
+			<Card className="store-stats-referrer-widget">
+				<Table header={ header } compact>
+					{ paginatedData.map( d => {
+						const widgetPath = getWidgetPath(
+							unit,
+							slug,
+							Object.assign( {}, queryParams, { referrer: d.referrer } )
+						);
+						const href = `${ basePath }${ widgetPath }`;
+						return (
+							<TableRow
+								key={ d.referrer }
+								href={ href }
+								className={ classnames( {
+									'is-selected': selectedReferrer === d.referrer,
+								} ) }
+							>
+								<TableItem isTitle>{ d.referrer }</TableItem>
+								<TableItem>{ formatValue( d.sales, 'currency', d.currency ) }</TableItem>
+							</TableRow>
+						);
+					} ) }
+				</Table>
+				{ paginate && (
+					<Pagination
+						compact
+						page={ page }
+						perPage={ limit }
+						total={ data.length }
+						pageClick={ this.onPageClick }
+					/>
+				) }
+			</Card>
 		);
 	}
 }
 
-export default connect( ( state, { siteId, statType, query } ) => {
+export default connect( ( state, ownProps ) => {
+	const { fetchedData } = ownProps;
 	return {
-		data: getSiteStatsNormalizedData( state, siteId, statType, query ),
+		data: fetchedData || getStoreReferrers( state, ownProps ),
 	};
 } )( localize( StoreStatsReferrerWidget ) );

--- a/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget/style.scss
@@ -1,9 +1,18 @@
-.store-stats-referrer-widget  {
-	&.table.is-compact-table th.table-heading.is-title-cell,
-	&.table.is-compact-table td.table-item.is-title-cell {
-		width: 30%;
-	}
-	&.table.is-compact-table th.table-heading {
-		text-align: left;
+.store-stats-referrer-widget.card  {
+		padding: 0;
+
+		.table {
+			box-shadow: none;
+			margin-bottom: 0;
+		}
+
+	.table-row.is-selected,
+	.table-row.is-selected:hover {
+		color: $white;
+		background-color: $blue-wordpress;
+
+		.table-item__cell-title::after {
+			background-image: linear-gradient(to right, rgba(255,255,255,0) 0%, $blue-wordpress 90%);
+		}
 	}
 }

--- a/client/extensions/woocommerce/components/d3/horizontal-bar/index.js
+++ b/client/extensions/woocommerce/components/d3/horizontal-bar/index.js
@@ -35,7 +35,8 @@ const HorizontalBar = ( { className, data, extent, currency, height, width } ) =
 			.attr( 'fill', 'white' )
 			.text( formatValue( data, numberFormat, currency ) );
 		const textMargin = data === 0 ? 0 : 5;
-		const isOffsetText = xPos - ( text.node().getBoundingClientRect().width + textMargin ) <= 0;
+		const isOffsetText =
+			xPos + ( text.node().getBoundingClientRect().width + textMargin * 2 ) <= scale( extent[ 1 ] );
 		text
 			.attr( 'class', isOffsetText ? 'is-offset-text' : '' )
 			.attr( 'text-anchor', isOffsetText ? 'start' : 'end' )

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -27,6 +27,7 @@
 	@import 'app/store-stats/store-stats-chart/style';
 	@import 'app/store-stats/store-stats-module/style';
 	@import 'app/store-stats/store-stats-referrer-widget/style';
+	@import 'app/store-stats/referrers/style';
 	@import 'app/store-stats/store-stats-widget-list/style';
 	@import 'app/store-stats/style';
 

--- a/client/state/selectors/get-store-referrers.js
+++ b/client/state/selectors/get-store-referrers.js
@@ -1,0 +1,19 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { find } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+
+import { getSiteStatsNormalizedData } from 'state/stats/lists/selectors';
+import { sortBySales } from 'woocommerce/app/store-stats/referrers/helpers';
+
+export default function( state, { siteId, statType, query, unitSelectedDate, limit, paginate } ) {
+	const rawData = getSiteStatsNormalizedData( state, siteId, statType, query );
+	const selectedData = find( rawData, d => d.date === unitSelectedDate ) || { data: [] };
+	return sortBySales( selectedData.data, limit && ! paginate ? limit : null );
+}


### PR DESCRIPTION
Allow user to select a referrer from
1. A select box if there are greater than 5 referrers
![refs-long](https://user-images.githubusercontent.com/1922453/37885216-797c6470-3110-11e8-9f36-1ad7d771257b.gif)

2. Quick links if there are less than 5 referrers
![refs-short](https://user-images.githubusercontent.com/1922453/37885208-73e62938-3110-11e8-8157-4a228fedaed2.gif)

### Testing
Head to `/store/stats/referrers/day/my-cool-site` and navigate to a date with referrers and test out the selection process. Check periods with greater than 5 and less than 5 referrers.

### Feeback Requested
How is the experience? Anything not working or could be improved? Should we handle a long list of search results with some kind of pagination?