### PR TITLE
JPC remote install: add notices resulting from version errors.

### DIFF
--- a/client/jetpack-connect/connection-notice-types.js
+++ b/client/jetpack-connect/connection-notice-types.js
@@ -5,11 +5,13 @@
  *
  * These notice types are indicators of Jetpack Connection status.
  */
+export const ACTIVATION_FAILURE = 'unableToActivateInvalidVersion';
 export const ACTIVATION_RESPONSE_ERROR = 'unableToActivate';
 export const ALREADY_CONNECTED = 'alreadyConnected';
 export const ALREADY_CONNECTED_BY_OTHER_USER = 'alreadyConnectedByOtherUser';
 export const ALREADY_OWNED = 'alreadyOwned';
 export const DEFAULT_AUTHORIZE_ERROR = 'defaultAuthorizeError';
+export const INSTALL_FAILURE = 'unableToInstallInvalidVersion';
 export const INSTALL_RESPONSE_ERROR = 'unableToInstall';
 export const IS_DOT_COM = 'isDotCom';
 export const JETPACK_IS_DISCONNECTED = 'jetpackIsDisconnected';

--- a/client/jetpack-connect/connection-notice-types.js
+++ b/client/jetpack-connect/connection-notice-types.js
@@ -11,7 +11,6 @@ export const ALREADY_CONNECTED = 'alreadyConnected';
 export const ALREADY_CONNECTED_BY_OTHER_USER = 'alreadyConnectedByOtherUser';
 export const ALREADY_OWNED = 'alreadyOwned';
 export const DEFAULT_AUTHORIZE_ERROR = 'defaultAuthorizeError';
-export const INSTALL_FAILURE = 'unableToInstallInvalidVersion';
 export const INSTALL_RESPONSE_ERROR = 'unableToInstall';
 export const IS_DOT_COM = 'isDotCom';
 export const JETPACK_IS_DISCONNECTED = 'jetpackIsDisconnected';

--- a/client/jetpack-connect/constants.js
+++ b/client/jetpack-connect/constants.js
@@ -1,5 +1,5 @@
 /** @format */
-
+export const JETPACK_WORDPRESS_VERSION = '4.7';
 export const JPC_PATH_PLANS = '/jetpack/connect/plans';
 export const JPC_PATH_REMOTE_INSTALL = '/jetpack/connect/install';
 export const MINIMUM_JETPACK_VERSION = '3.9.6';

--- a/client/jetpack-connect/constants.js
+++ b/client/jetpack-connect/constants.js
@@ -1,5 +1,5 @@
 /** @format */
-export const JETPACK_WORDPRESS_VERSION = '4.7';
+export const JETPACK_MINIMUM_WORDPRESS_VERSION = '4.7';
 export const JPC_PATH_PLANS = '/jetpack/connect/plans';
 export const JPC_PATH_REMOTE_INSTALL = '/jetpack/connect/install';
 export const MINIMUM_JETPACK_VERSION = '3.9.6';

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -12,11 +12,13 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import {
+	ACTIVATION_FAILURE,
 	ACTIVATION_RESPONSE_ERROR,
 	ALREADY_CONNECTED,
 	ALREADY_CONNECTED_BY_OTHER_USER,
 	ALREADY_OWNED,
 	DEFAULT_AUTHORIZE_ERROR,
+	INSTALL_FAILURE,
 	INSTALL_RESPONSE_ERROR,
 	IS_DOT_COM,
 	JETPACK_IS_DISCONNECTED,
@@ -36,6 +38,7 @@ import {
 	USER_IS_ALREADY_CONNECTED_TO_SITE,
 	WORDPRESS_DOT_COM,
 } from './connection-notice-types';
+import { JETPACK_WORDPRESS_VERSION } from './constants';
 import Notice from 'components/notice';
 import { addQueryArgs } from 'lib/route';
 import { getConnectingSite } from 'state/jetpack-connect/selectors';
@@ -47,11 +50,13 @@ export class JetpackConnectNotices extends Component {
 		// instead of showing a notice.
 		onTerminalError: PropTypes.func,
 		noticeType: PropTypes.oneOf( [
+			ACTIVATION_FAILURE,
 			ACTIVATION_RESPONSE_ERROR,
 			ALREADY_CONNECTED,
 			ALREADY_CONNECTED_BY_OTHER_USER,
 			ALREADY_OWNED,
 			DEFAULT_AUTHORIZE_ERROR,
+			INSTALL_FAILURE,
 			INSTALL_RESPONSE_ERROR,
 			IS_DOT_COM,
 			LOGIN_FAILURE,
@@ -112,6 +117,18 @@ export class JetpackConnectNotices extends Component {
 		}
 
 		switch ( noticeType ) {
+			case ACTIVATION_FAILURE:
+				noticeValues.text = translate(
+					'We were unable to activate Jetpack. Please upgrade to the latest version ' +
+						'of WordPress. Jetpack needs version %(jetpackWPVersion)s or higher.',
+					{
+						args: {
+							jetpackWPVersion: JETPACK_WORDPRESS_VERSION,
+						},
+					}
+				);
+				return noticeValues;
+
 			case ACTIVATION_RESPONSE_ERROR:
 				noticeValues.text = translate(
 					'We were unable to activate Jetpack. You can either {{manualInstall}}install Jetpack manually{{/manualInstall}} ' +
@@ -187,6 +204,18 @@ export class JetpackConnectNotices extends Component {
 							support: (
 								<a href={ this.getHelperUrl( 'support' ) } onClick={ this.trackSupportClick } />
 							),
+						},
+					}
+				);
+				return noticeValues;
+
+			case INSTALL_FAILURE:
+				noticeValues.text = translate(
+					'We were unable to install Jetpack. Please upgrade to the latest version ' +
+						'of WordPress. Jetpack needs version %(jetpackWPVersion)s or higher.',
+					{
+						args: {
+							jetpackWPVersion: JETPACK_WORDPRESS_VERSION,
 						},
 					}
 				);

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -18,7 +18,6 @@ import {
 	ALREADY_CONNECTED_BY_OTHER_USER,
 	ALREADY_OWNED,
 	DEFAULT_AUTHORIZE_ERROR,
-	INSTALL_FAILURE,
 	INSTALL_RESPONSE_ERROR,
 	IS_DOT_COM,
 	JETPACK_IS_DISCONNECTED,
@@ -56,7 +55,6 @@ export class JetpackConnectNotices extends Component {
 			ALREADY_CONNECTED_BY_OTHER_USER,
 			ALREADY_OWNED,
 			DEFAULT_AUTHORIZE_ERROR,
-			INSTALL_FAILURE,
 			INSTALL_RESPONSE_ERROR,
 			IS_DOT_COM,
 			LOGIN_FAILURE,
@@ -204,18 +202,6 @@ export class JetpackConnectNotices extends Component {
 							support: (
 								<a href={ this.getHelperUrl( 'support' ) } onClick={ this.trackSupportClick } />
 							),
-						},
-					}
-				);
-				return noticeValues;
-
-			case INSTALL_FAILURE:
-				noticeValues.text = translate(
-					'We were unable to install Jetpack. Please upgrade to the latest version ' +
-						'of WordPress. Jetpack needs version %(jetpackWPVersion)s or higher.',
-					{
-						args: {
-							jetpackWPVersion: JETPACK_WORDPRESS_VERSION,
 						},
 					}
 				);

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -37,7 +37,7 @@ import {
 	USER_IS_ALREADY_CONNECTED_TO_SITE,
 	WORDPRESS_DOT_COM,
 } from './connection-notice-types';
-import { JETPACK_WORDPRESS_VERSION } from './constants';
+import { JETPACK_MINIMUM_WORDPRESS_VERSION } from './constants';
 import Notice from 'components/notice';
 import { addQueryArgs } from 'lib/route';
 import { getConnectingSite } from 'state/jetpack-connect/selectors';
@@ -121,7 +121,7 @@ export class JetpackConnectNotices extends Component {
 						'of WordPress. Jetpack needs version %(jetpackWPVersion)s or higher.',
 					{
 						args: {
-							jetpackWPVersion: JETPACK_WORDPRESS_VERSION,
+							jetpackWPVersion: JETPACK_MINIMUM_WORDPRESS_VERSION,
 						},
 					}
 				);

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -111,7 +111,7 @@ export class OrgCredentialsForm extends Component {
 	}
 
 	getError( installError ) {
-		if ( installError === 'ACTIVATION_FAILURE' ) {
+		if ( installError === 'ACTIVATION_FAILURE' || 'ACTIVATION_ON_INSTALL_FAILURE' ) {
 			return ACTIVATION_FAILURE;
 		}
 		if ( installError === 'LOGIN_FAILURE' ) {

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -34,7 +34,6 @@ import { REMOTE_PATH_AUTH } from './constants';
 import {
 	ACTIVATION_FAILURE,
 	ACTIVATION_RESPONSE_ERROR,
-	INSTALL_FAILURE,
 	INSTALL_RESPONSE_ERROR,
 	INVALID_PERMISSIONS,
 	LOGIN_FAILURE,
@@ -119,9 +118,6 @@ export class OrgCredentialsForm extends Component {
 		}
 		if ( installError === 'ACTIVATION_RESPONSE_ERROR' ) {
 			return ACTIVATION_RESPONSE_ERROR;
-		}
-		if ( installError === 'INSTALL_FAILURE' ) {
-			return INSTALL_FAILURE;
 		}
 		if ( installError === 'INSTALL_RESPONSE_ERROR' ) {
 			return INSTALL_RESPONSE_ERROR;

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -32,7 +32,9 @@ import { getConnectingSite } from 'state/jetpack-connect/selectors';
 import { REMOTE_PATH_AUTH } from './constants';
 
 import {
+	ACTIVATION_FAILURE,
 	ACTIVATION_RESPONSE_ERROR,
+	INSTALL_FAILURE,
 	INSTALL_RESPONSE_ERROR,
 	INVALID_PERMISSIONS,
 	LOGIN_FAILURE,
@@ -109,11 +111,17 @@ export class OrgCredentialsForm extends Component {
 	}
 
 	getError( installError ) {
+		if ( installError === 'ACTIVATION_FAILURE' ) {
+			return ACTIVATION_FAILURE;
+		}
 		if ( installError === 'LOGIN_FAILURE' ) {
 			return LOGIN_FAILURE;
 		}
 		if ( installError === 'ACTIVATION_RESPONSE_ERROR' ) {
 			return ACTIVATION_RESPONSE_ERROR;
+		}
+		if ( installError === 'INSTALL_FAILURE' ) {
+			return INSTALL_FAILURE;
 		}
 		if ( installError === 'INSTALL_RESPONSE_ERROR' ) {
 			return INSTALL_RESPONSE_ERROR;

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -110,7 +110,10 @@ export class OrgCredentialsForm extends Component {
 	}
 
 	getError( installError ) {
-		if ( installError === 'ACTIVATION_FAILURE' || 'ACTIVATION_ON_INSTALL_FAILURE' ) {
+		if (
+			installError === 'ACTIVATION_FAILURE' ||
+			installError === 'ACTIVATION_ON_INSTALL_FAILURE'
+		) {
 			return ACTIVATION_FAILURE;
 		}
 		if ( installError === 'LOGIN_FAILURE' ) {


### PR DESCRIPTION
WP REST API endpoint returns specific errors when responses returned from requests to .org sites contain error messages, but are successful.  For plugin installed, the case scenario we saw that happening for was WP < 4.7. We have not observed install cases as yet, but are logging it for debugging purposes. 

This PR adds a notice for the version related clash mentioned above (which might become obsolete when we add a version check at the start of the flow). For the possible install errors, we merge them with the UNKNOWN_REMOTE_INSTALL_ERROR category.

![screen shot 2018-03-26 at 12 44 50](https://user-images.githubusercontent.com/13561163/37904305-4785bb1e-30f3-11e8-9ca3-4f2c51d5fb13.png)

## To test:

- Checkout this branch on local Calypso,
- Access `calypso.localhost:3000/jetpack/connect`
- Input url of an .org site with WP < 4.7
- Input valid credentials and verify the notice
- try again with Jetpack installed and verify that the notice persists.