### PR TITLE
Add badge component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -90,6 +90,7 @@
 @import 'components/animate/style';
 @import 'components/async-load/style';
 @import 'components/back-button/style';
+@import 'components/badge/style';
 @import 'components/banner/style';
 @import 'components/bulk-select/style';
 @import 'components/button/style';

--- a/client/components/badge/README.md
+++ b/client/components/badge/README.md
@@ -1,0 +1,21 @@
+Badge
+=======
+
+Badge is a component used to render a short piece of information that
+should stand out from the rest.
+
+## Usage
+
+```jsx
+
+import React from 'react';
+import Badge from 'components/badge';
+
+class MyComponent extends React.Component {
+	render() {
+		return (
+			<Badge type="warning">Only 6MB left!</Badge>
+		);
+	}
+}
+```

--- a/client/components/badge/docs/example.jsx
+++ b/client/components/badge/docs/example.jsx
@@ -1,0 +1,27 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Badge from 'components/badge';
+
+const BadgeExample = () => (
+	<div>
+		<div className="docs__design-badge-row">
+			<Badge type="success">Success Badge</Badge>
+		</div>
+		<div className="docs__design-badge-row">
+			<Badge type="warning">Warning Badge</Badge>
+		</div>
+	</div>
+);
+
+BadgeExample.displayName = 'Badge';
+
+export default BadgeExample;

--- a/client/components/badge/index.jsx
+++ b/client/components/badge/index.jsx
@@ -1,0 +1,23 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class Badge extends React.Component {
+	static propTypes = {
+		type: PropTypes.oneOf( [ 'warning', 'success' ] ).isRequired,
+	};
+
+	static defaultProps = {
+		type: 'warning',
+	};
+
+	render() {
+		const { type } = this.props;
+		return <div className={ `badge badge--${ type }` }>{ this.props.children }</div>;
+	}
+}

--- a/client/components/badge/style.scss
+++ b/client/components/badge/style.scss
@@ -1,0 +1,22 @@
+.badge {
+	display: inline-block;
+	border-radius: 100px;
+	padding: 2px 11px;
+	text-align: center;
+	font-size: 14px;
+	line-height: 18px;
+}
+
+.badge--warning {
+	color: #535d56;
+	background-color: #fcd56d;
+}
+
+.badge--success {
+	color: #fff;
+	background-color: #19b76e;
+}
+
+.docs__design-badge-row {
+	margin-bottom: 20px;
+}

--- a/client/components/badge/test/index.js
+++ b/client/components/badge/test/index.js
@@ -1,0 +1,44 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Badge from '../index';
+
+describe( 'Badge', () => {
+	test( 'should have badge class', () => {
+		const featureExample = shallow( <Badge /> );
+		assert.lengthOf( featureExample.find( '.badge' ), 1 );
+	} );
+
+	test( 'should have proper type class (warning)', () => {
+		const badge = shallow( <Badge type="warning" /> );
+		assert.lengthOf( badge.find( '.badge.badge--warning' ), 1 );
+	} );
+
+	test( 'should have proper type class (success)', () => {
+		const badge = shallow( <Badge type="success" /> );
+		assert.lengthOf( badge.find( '.badge.badge--success' ), 1 );
+	} );
+
+	test( 'should have proper type class (default)', () => {
+		const badge = shallow( <Badge /> );
+		assert.lengthOf( badge.find( '.badge.badge--warning' ), 1 );
+	} );
+
+	test( 'should contains the passed children wrapped by a feature-example div', () => {
+		const featureExample = shallow(
+			<Badge>
+				<div>test</div>
+			</Badge>
+		);
+		assert.isTrue( featureExample.contains( <div>test</div> ) );
+	} );
+} );

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -28,6 +28,7 @@ import SearchCard from 'components/search-card';
 import ActionCard from 'components/action-card/docs/example';
 import Accordions from 'components/accordion/docs/example';
 import BackButton from 'components/back-button/docs/example';
+import Badge from 'components/badge/docs/example';
 import Banner from 'components/banner/docs/example';
 import BulkSelect from 'components/bulk-select/docs/example';
 import ButtonGroups from 'components/button-group/docs/example';
@@ -155,6 +156,7 @@ class DesignAssets extends React.Component {
 					<ButtonGroups readmeFilePath="button-group" />
 					<Buttons componentUsageStats={ componentsUsageStats.button } readmeFilePath="button" />
 					<SplitButton readmeFilePath="split-button" />
+					<Badge />
 					<Cards readmeFilePath="card" />
 					<Checklist />
 					<ClipboardButtonInput readmeFilePath="clipboard-button-input" />


### PR DESCRIPTION
This is a part of series of PRs related to term picker for 2-year plans. In particular, it's this component:

<img width="101" alt="zrzut ekranu 2018-03-23 o 13 12 20" src="https://user-images.githubusercontent.com/205419/37828520-dbabd8d2-2e9b-11e8-8830-678609af4bbb.png">

Test plan:
* Go to http://calypso.localhost:3000/devdocs/design and make sure the "Badge" component is displayed correctly