### PR TITLE
Pages: fix wrong paths in page view analytics

### DIFF
--- a/client/my-sites/pages/controller.js
+++ b/client/my-sites/pages/controller.js
@@ -10,7 +10,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import { getSiteFragment, sectionify } from 'lib/route';
+import { getSiteFragment } from 'lib/route';
 import analytics from 'lib/analytics';
 import titlecase from 'to-title-case';
 import trackScrollPage from 'lib/track-scroll-page';
@@ -22,7 +22,6 @@ const controller = {
 		const siteID = getSiteFragment( context.path );
 		let status = context.params.status;
 		const search = context.query.s;
-		const basePath = sectionify( context.path );
 		let analyticsPageTitle = 'Pages';
 		let baseAnalyticsPath;
 
@@ -31,9 +30,9 @@ const controller = {
 		context.store.dispatch( setTitle( i18n.translate( 'Site Pages', { textOnly: true } ) ) );
 
 		if ( siteID ) {
-			baseAnalyticsPath = basePath + '/:site';
+			baseAnalyticsPath = status ? `/pages/${ status }/:site` : '/pages/:site';
 		} else {
-			baseAnalyticsPath = basePath;
+			baseAnalyticsPath = status ? `/pages/${ status }` : '/pages';
 		}
 
 		if ( status.length ) {

--- a/client/my-sites/pages/controller.js
+++ b/client/my-sites/pages/controller.js
@@ -5,49 +5,17 @@
  */
 
 import React from 'react';
-import i18n from 'i18n-calypso';
 
 /**
  * Internal Dependencies
  */
-import { getSiteFragment } from 'lib/route';
-import analytics from 'lib/analytics';
-import titlecase from 'to-title-case';
-import trackScrollPage from 'lib/track-scroll-page';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import Pages from 'my-sites/pages/main';
 
 const controller = {
 	pages: function( context, next ) {
-		const siteID = getSiteFragment( context.path );
-		let status = context.params.status;
-		const search = context.query.s;
-		let analyticsPageTitle = 'Pages';
-		let baseAnalyticsPath;
-
-		status = ! status || status === siteID ? '' : status;
-		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( i18n.translate( 'Site Pages', { textOnly: true } ) ) );
-
-		if ( siteID ) {
-			baseAnalyticsPath = status ? `/pages/${ status }/:site` : '/pages/:site';
-		} else {
-			baseAnalyticsPath = status ? `/pages/${ status }` : '/pages';
-		}
-
-		if ( status.length ) {
-			analyticsPageTitle += ' > ' + titlecase( status );
-		} else {
-			analyticsPageTitle += ' > Published';
-		}
-
-		analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
-
 		context.primary = React.createElement( Pages, {
-			siteID: siteID,
-			status: status,
-			search: search,
-			trackScrollPage: trackScrollPage.bind( null, baseAnalyticsPath, analyticsPageTitle, 'Pages' ),
+			status: context.params.status,
+			search: context.query.s,
 		} );
 		next();
 	},

--- a/client/my-sites/pages/index.js
+++ b/client/my-sites/pages/index.js
@@ -11,16 +11,35 @@ import { navigation, siteSelection } from 'my-sites/controller';
 import pagesController from './controller';
 import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
+import { getSiteFragment } from 'lib/route';
 
 export default function() {
 	if ( config.isEnabled( 'manage/pages' ) ) {
 		page(
-			'/pages/:status?/:domain?',
+			'/pages/:status(published|drafts|scheduled|trashed)/:domain?',
 			siteSelection,
 			navigation,
 			pagesController.pages,
 			makeLayout,
 			clientRender
 		);
+
+		page(
+			'/pages/:domain?',
+			siteSelection,
+			navigation,
+			pagesController.pages,
+			makeLayout,
+			clientRender
+		);
+
+		page( '/pages/*', ( { path } ) => {
+			const siteFragment = getSiteFragment( path );
+			if ( siteFragment ) {
+				return page.redirect( `/pages/${ siteFragment }` );
+			}
+
+			return page.redirect( '/pages' );
+		} );
 	}
 }

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -9,18 +9,21 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
 import debugFactory from 'debug';
+import titlecase from 'to-title-case';
 
 /**
  * Internal dependencies
  */
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import config from 'config';
+import DocumentHead from 'components/data/document-head';
 import notices from 'notices';
 import urlSearch from 'lib/url-search';
 import Main from 'components/main';
 import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
 import PageList from './page-list';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import Search from 'components/search';
 import SectionNav from 'components/section-nav';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -32,7 +35,8 @@ class PagesMain extends React.Component {
 	static displayName = 'Pages';
 
 	static propTypes = {
-		trackScrollPage: PropTypes.func.isRequired,
+		status: PropTypes.string,
+		search: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -52,8 +56,26 @@ class PagesMain extends React.Component {
 	}
 
 	render() {
-		const { doSearch, search, translate } = this.props;
-		const status = this.props.status || 'published';
+		const { doSearch, search, translate, siteId } = this.props;
+		let status = this.props.status || '';
+		let analyticsPageTitle = 'Pages';
+		let baseAnalyticsPath = '/pages';
+
+		if ( status ) {
+			baseAnalyticsPath += '/:status';
+		}
+
+		if ( siteId ) {
+			baseAnalyticsPath += '/:site';
+		}
+
+		if ( status.length ) {
+			analyticsPageTitle += ' > ' + titlecase( status );
+		} else {
+			analyticsPageTitle += ' > Published';
+			status = 'published';
+		}
+
 		const filterStrings = {
 			published: translate( 'Published', { context: 'Filter label for pages list' } ),
 			drafts: translate( 'Drafts', { context: 'Filter label for pages list' } ),
@@ -80,6 +102,8 @@ class PagesMain extends React.Component {
 		};
 		return (
 			<Main classname="pages">
+				<PageViewTracker path={ baseAnalyticsPath } title={ analyticsPageTitle } />
+				<DocumentHead title={ translate( 'Site Pages' ) } />
 				<SidebarNavigation />
 				<SectionNav selectedText={ filterStrings[ status ] }>
 					<NavTabs label={ translate( 'Status', { context: 'Filter page group label for tabs' } ) }>

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -62,7 +62,7 @@ class PagesMain extends React.Component {
 		let baseAnalyticsPath = '/pages';
 
 		if ( status ) {
-			baseAnalyticsPath += '/:status';
+			baseAnalyticsPath += `/${ status }`;
 		}
 
 		if ( siteId ) {

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -55,26 +55,38 @@ class PagesMain extends React.Component {
 		this._setWarning( this.props.site );
 	}
 
-	render() {
-		const { doSearch, search, translate, siteId } = this.props;
-		let status = this.props.status || '';
-		let analyticsPageTitle = 'Pages';
-		let baseAnalyticsPath = '/pages';
+	getAnalyticsPath() {
+		const { status, siteId } = this.props;
+		const basePath = '/pages';
+
+		if ( siteId && status ) {
+			return `${ basePath }/${ status }/:site`;
+		}
 
 		if ( status ) {
-			baseAnalyticsPath += `/${ status }`;
+			return `${ basePath }/${ status }`;
 		}
 
 		if ( siteId ) {
-			baseAnalyticsPath += '/:site';
+			return `${ basePath }/:site`;
 		}
 
-		if ( status.length ) {
-			analyticsPageTitle += ' > ' + titlecase( status );
-		} else {
-			analyticsPageTitle += ' > Published';
-			status = 'published';
+		return basePath;
+	}
+
+	getAnalyticsTitle() {
+		const { status } = this.props;
+
+		if ( status && status.length ) {
+			return `Pages > ${ titlecase( status ) }`;
 		}
+
+		return 'Pages > Published';
+	}
+
+	render() {
+		const { doSearch, search, translate } = this.props;
+		const status = this.props.status || 'published';
 
 		const filterStrings = {
 			published: translate( 'Published', { context: 'Filter label for pages list' } ),
@@ -102,7 +114,7 @@ class PagesMain extends React.Component {
 		};
 		return (
 			<Main classname="pages">
-				<PageViewTracker path={ baseAnalyticsPath } title={ analyticsPageTitle } />
+				<PageViewTracker path={ this.getAnalyticsPath() } title={ this.getAnalyticsTitle() } />
 				<DocumentHead title={ translate( 'Site Pages' ) } />
 				<SidebarNavigation />
 				<SectionNav selectedText={ filterStrings[ status ] }>


### PR DESCRIPTION
Resolves: https://github.com/Automattic/wp-calypso/issues/23580

According to internal logs, some calypso_page_view paths coming from Pages
were reported without replacing passed parameters with corresponding variables,
or removing wrong entries from the route. This was resolved by adding more
restrictive route matching for status.

### Testing instructions

1. Set `localStorage.setItem( 'debug', 'calypso:analytics:tracks' )` in the browser console to enable the debug.
2. To reproduce the issue, navigate to `/pages/randomtext/{site_url}` or `/pages/randomtext` and observe the `calypso_page_view` recorded paths in log.
3. Apply this branch and verify that `randomtext` is no longer accepted as valid page status and recorded as such.
4. Check that there are no other valid page statuses that we should be matching here.
5. Try to break it with various paths that start with `/pages/`. 

You can also use this query to see the currently recorded events: 1d6cf-pb (they have much lower counts than legitimate page views). After this patch lands, we should be seeing only valid paths recorded here.