### PR TITLE
Analytics: Track /customize page views with normalized paths

### DIFF
--- a/client/my-sites/customize/controller.js
+++ b/client/my-sites/customize/controller.js
@@ -8,16 +8,10 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
-import { sectionify } from 'lib/route';
-import analytics from 'lib/analytics';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import CustomizeComponent from 'my-sites/customize/main';
 
 export function customize( context, next ) {
-	const basePath = sectionify( context.path );
-
-	analytics.pageView.record( basePath, 'Customizer' );
-
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( i18n.translate( 'Customizer', { textOnly: true } ) ) );
 

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -47,7 +47,7 @@ class Customize extends React.Component {
 
 	static propTypes = {
 		domain: PropTypes.string.isRequired,
-		site: PropTypes.object.isRequired,
+		site: PropTypes.object,
 		pathname: PropTypes.string.isRequired,
 		prevPath: PropTypes.string,
 		query: PropTypes.object,

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -22,6 +22,7 @@ import CustomizerLoadingPanel from 'my-sites/customize/loading-panel';
 import EmptyContent from 'components/empty-content';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import Actions from 'my-sites/customize/actions';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { themeActivated } from 'state/themes/actions';
 import { getCustomizerFocus } from './panels';
 import { getMenusUrl } from 'state/selectors';
@@ -263,6 +264,7 @@ class Customize extends React.Component {
 	renderErrorPage = error => {
 		return (
 			<div className="main main-column customize" role="main">
+				<PageViewTracker path="/customize/:site" title="Customizer" />
 				<SidebarNavigation />
 				<EmptyContent
 					title={ error.title }
@@ -297,6 +299,7 @@ class Customize extends React.Component {
 		if ( ! this.props.site ) {
 			return (
 				<div className="main main-column customize is-iframe" role="main">
+					<PageViewTracker path="/customize/:site" title="Customizer" />
 					<CustomizerLoadingPanel />
 				</div>
 			);
@@ -322,6 +325,7 @@ class Customize extends React.Component {
 			// waitForLoading above) then an error will be shown.
 			return (
 				<div className="main main-column customize is-iframe" role="main">
+					<PageViewTracker path="/customize/:site" title="Customizer" />
 					<CustomizerLoadingPanel isLoaded={ this.state.iframeLoaded } />
 					<iframe className={ iframeClassName } src={ iframeUrl } />
 				</div>


### PR DESCRIPTION
Fix #23513 

Replace a direct `analytics.pageView.record` call with the `PageViewTracker` component which is aware of the selected site (no more incorrect `blog_id: undefined` reports).

Update it to only track the `/customize/:site` path, which is the only possible path for this section.

_Also remove `.isRequired` from the `site` prop to avoid throwing a console error when loading the page from a clean cache._

## Testing instructions

- Enable tracks debugging with `localStorage.setItem('debug', 'calypso:analytics:tracks')` and filter by `page_view`.
- Make sure loading `/customize/${ siteSlug }` always reports a `/customize/:site` path.
- Make sure it reports the correct site ID even when loaded from a clean cache.