### PR TITLE
State: Add schema validation to application passwords

### DIFF
--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/index.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/index.js
@@ -10,19 +10,14 @@ import { noop } from 'lodash';
  */
 import deleteHandler from './delete';
 import newHandler from './new';
+import schema from './schema';
 import { APPLICATION_PASSWORDS_REQUEST } from 'state/action-types';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx, makeParser } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { mergeHandlers } from 'state/action-watchers/utils';
 import { receiveApplicationPasswords } from 'state/application-passwords/actions';
 
-export function fromApi( response ) {
-	if ( ! response.application_passwords ) {
-		throw new Error( 'An error has occurred while requesting application passwords.', response );
-	}
-
-	return response.application_passwords;
-}
+export const apiTransformer = data => data.application_passwords;
 
 /**
  * Dispatches a request to fetch application passwords of the current user
@@ -56,7 +51,7 @@ const requestHandler = {
 			fetch: requestApplicationPasswords,
 			onSuccess: handleRequestSuccess,
 			onError: noop,
-			fromApi,
+			fromApi: makeParser( schema, {}, apiTransformer ),
 		} ),
 	],
 };

--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/schema.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/schema.js
@@ -1,0 +1,18 @@
+export default {
+	type: 'object',
+	properties: {
+		application_passwords: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					ID: { type: 'integer' },
+					generated: { type: 'string' },
+					name: { type: 'string' },
+				},
+				required: [ 'ID', 'generated', 'name' ],
+			},
+		},
+	},
+	additionalProperties: false,
+};

--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/schema.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/schema.js
@@ -11,6 +11,7 @@ export default {
 					name: { type: 'string' },
 				},
 				required: [ 'ID', 'generated', 'name' ],
+				additionalProperties: false,
 			},
 		},
 	},

--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/test/index.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/test/index.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { fromApi, handleRequestSuccess, requestApplicationPasswords } from '../';
+import { apiTransformer, handleRequestSuccess, requestApplicationPasswords } from '../';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { receiveApplicationPasswords } from 'state/application-passwords/actions';
 
@@ -37,12 +37,8 @@ describe( 'handleRequestSuccess()', () => {
 	} );
 } );
 
-describe( 'fromApi()', () => {
-	test( 'should throw an error for an unsuccessful request', () => {
-		expect( () => fromApi( { error: 'This is some error' } ) ).toThrow();
-	} );
-
-	test( 'should return application_passwords from original response for a successful request', () => {
-		expect( fromApi( { application_passwords: appPasswords } ) ).toEqual( appPasswords );
+describe( 'apiTransformer()', () => {
+	test( 'should transform original response for a successful request', () => {
+		expect( apiTransformer( { application_passwords: appPasswords } ) ).toEqual( appPasswords );
 	} );
 } );


### PR DESCRIPTION
This PR updates the application passwords data layer to perform a stricter validation using a schema and `makeParser`, as suggested in https://github.com/Automattic/wp-calypso/pull/22913#discussion_r176391192.

Part of #22912.

To test:

* Checkout this branch
* Fire a `dispatch( { type: 'APPLICATION_PASSWORDS_REQUEST' } )` in your console and verify after the successful network request you can see a `APPLICATION_PASSWORDS_RECEIVE` action with the application passwords in there.
* Verify all tests pass:
```
npm run test-client client/state/data-layer/wpcom/me/two-step/application-passwords/test/index.js
```