### PR TITLE
Analytics: Track /ads page views with normalized paths

### DIFF
--- a/client/my-sites/ads/controller.js
+++ b/client/my-sites/ads/controller.js
@@ -5,40 +5,12 @@
  */
 
 import React from 'react';
-import i18n from 'i18n-calypso';
 import page from 'page';
 
 /**
  * Internal Dependencies
  */
-import { sectionify } from 'lib/route';
-import analytics from 'lib/analytics';
-import titlecase from 'to-title-case';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
 import Ads from 'my-sites/ads/main';
-
-function _recordPageView( context, analyticsPageTitle ) {
-	const basePath = sectionify( context.path );
-	if ( 'undefined' !== typeof context.params.section ) {
-		analyticsPageTitle += ' > ' + titlecase( context.params.section );
-	}
-
-	analytics.ga.recordPageView( basePath + '/:site', analyticsPageTitle );
-}
-
-function _getLayoutTitle( context ) {
-	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
-	const title = isJetpackSite( state, siteId ) ? 'Ads' : 'WordAds';
-	switch ( context.params.section ) {
-		case 'earnings':
-			return i18n.translate( '%(wordads)s Earnings', { args: { wordads: title } } );
-		case 'settings':
-			return i18n.translate( '%(wordads)s Settings', { args: { wordads: title } } );
-	}
-}
 
 export default {
 	redirect: function( context ) {
@@ -47,12 +19,6 @@ export default {
 	},
 
 	layout: function( context, next ) {
-		const layoutTitle = _getLayoutTitle( context );
-
-		context.store.dispatch( setTitle( layoutTitle ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-
-		_recordPageView( context, layoutTitle );
-
 		// Scroll to the top
 		if ( typeof window !== 'undefined' ) {
 			window.scrollTo( 0, 0 );

--- a/client/my-sites/ads/main.jsx
+++ b/client/my-sites/ads/main.jsx
@@ -46,7 +46,7 @@ import { isJetpackSite } from 'state/sites/selectors';
 
 class AdsMain extends Component {
 	static propTypes = {
-		isJetpack: PropTypes.bool,
+		adsProgramName: PropTypes.string,
 		isRequestingWordadsStatus: PropTypes.bool.isRequired,
 		isUnsafe: PropTypes.oneOf( wordadsUnsafeValues ),
 		requestingWordAdsApproval: PropTypes.bool.isRequired,
@@ -228,7 +228,7 @@ class AdsMain extends Component {
 	}
 
 	render() {
-		const { isJetpack, section, site, translate } = this.props;
+		const { adsProgramName, section, site, translate } = this.props;
 
 		if ( ! this.canAccess() ) {
 			return null;
@@ -251,7 +251,6 @@ class AdsMain extends Component {
 			component = this.renderInstantActivationToggle( component );
 		}
 
-		const adsProgramName = isJetpack ? 'Ads' : 'WordAds';
 		const layoutTitles = {
 			earnings: translate( '%(wordads)s Earnings', { args: { wordads: adsProgramName } } ),
 			settings: translate( '%(wordads)s Settings', { args: { wordads: adsProgramName } } ),
@@ -301,7 +300,7 @@ const mapStateToProps = state => {
 		wordAdsSuccess: getWordAdsSuccessForSite( state, site ),
 		isUnsafe: isSiteWordadsUnsafe( state, siteId ),
 		isRequestingWordadsStatus: isRequestingWordadsStatus( state, siteId ),
-		isJetpack: isJetpackSite( state, siteId ),
+		adsProgramName: isJetpackSite( state, siteId ) ? 'Ads' : 'WordAds',
 	};
 };
 

--- a/client/my-sites/ads/main.jsx
+++ b/client/my-sites/ads/main.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import page from 'page';
-import { find } from 'lodash';
+import { capitalize, find } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -40,9 +40,13 @@ import { getSiteFragment } from 'lib/route';
 import { isSiteWordadsUnsafe, isRequestingWordadsStatus } from 'state/wordads/status/selectors';
 import { wordadsUnsafeValues } from 'state/wordads/status/schema';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import DocumentHead from 'components/data/document-head';
+import { isJetpackSite } from 'state/sites/selectors';
 
 class AdsMain extends Component {
 	static propTypes = {
+		isJetpack: PropTypes.bool,
 		isRequestingWordadsStatus: PropTypes.bool.isRequired,
 		isUnsafe: PropTypes.oneOf( wordadsUnsafeValues ),
 		requestingWordAdsApproval: PropTypes.bool.isRequired,
@@ -224,7 +228,7 @@ class AdsMain extends Component {
 	}
 
 	render() {
-		const { site, translate } = this.props;
+		const { isJetpack, section, site, translate } = this.props;
 
 		if ( ! this.canAccess() ) {
 			return null;
@@ -247,8 +251,19 @@ class AdsMain extends Component {
 			component = this.renderInstantActivationToggle( component );
 		}
 
+		const adsProgramName = isJetpack ? 'Ads' : 'WordAds';
+		const layoutTitles = {
+			earnings: translate( '%(wordads)s Earnings', { args: { wordads: adsProgramName } } ),
+			settings: translate( '%(wordads)s Settings', { args: { wordads: adsProgramName } } ),
+		};
+
 		return (
 			<Main className="ads">
+				<PageViewTracker
+					path={ `/ads/${ section }/:site` }
+					title={ `${ adsProgramName } ${ capitalize( section ) }` }
+				/>
+				<DocumentHead title={ layoutTitles[ section ] } />
 				<SidebarNavigation />
 				<SectionNav selectedText={ this.getSelectedText() }>
 					<NavTabs>
@@ -286,6 +301,7 @@ const mapStateToProps = state => {
 		wordAdsSuccess: getWordAdsSuccessForSite( state, site ),
 		isUnsafe: isSiteWordadsUnsafe( state, siteId ),
 		isRequestingWordadsStatus: isRequestingWordadsStatus( state, siteId ),
+		isJetpack: isJetpackSite( state, siteId ),
 	};
 };
 


### PR DESCRIPTION
Replace a direct `analytics.pageView.record` call with the `PageViewTracker` component which is aware of the selected site (no more incorrect `blog_id: undefined` reports).

Update it to track the `/ads/${ 'earnings' | 'settings' }/:site` paths.

_Also replace Flux's `setTitle` with `DocumentHead` in order to remove plenty of unnecessary leftovers from the section controller._

## Testing instructions

- Enable tracks debugging with `localStorage.setItem('debug', 'calypso:analytics:tracks')` and filter by `page_view`.
- Make sure loading `/ads/${ 'earnings' | 'settings' }/${ siteSlug }` always reports a `/ads/${ 'earnings' | 'settings' }/:site` path.
- Make sure it reports the correct site ID even when loaded from a clean cache.
- Make sure that the title is reported as "Ads" for Jetpack sites and "WordAds" for .com sites.
- Check if the page title (the actual `<title>` tag) is correct for all these cases:
  - Jetpack: `Ads Earnings`, `Ads Settings`.
  - .com: `WordAds Earnings`, `WordAds Settings`.