### PR TITLE
State: Add application passwords reducer

### DIFF
--- a/client/state/application-passwords/reducer.js
+++ b/client/state/application-passwords/reducer.js
@@ -1,0 +1,21 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { reject } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	APPLICATION_PASSWORD_DELETE_SUCCESS,
+	APPLICATION_PASSWORDS_RECEIVE,
+} from 'state/action-types';
+import { createReducer } from 'state/utils';
+
+export default createReducer( [], {
+	[ APPLICATION_PASSWORD_DELETE_SUCCESS ]: ( state, { appPasswordId } ) =>
+		reject( state, { ID: appPasswordId } ),
+	[ APPLICATION_PASSWORDS_RECEIVE ]: ( state, { appPasswords } ) => appPasswords,
+} );

--- a/client/state/application-passwords/reducer.js
+++ b/client/state/application-passwords/reducer.js
@@ -12,10 +12,14 @@ import {
 	APPLICATION_PASSWORD_DELETE_SUCCESS,
 	APPLICATION_PASSWORDS_RECEIVE,
 } from 'state/action-types';
-import { createReducer } from 'state/utils';
 
-export default createReducer( [], {
-	[ APPLICATION_PASSWORD_DELETE_SUCCESS ]: ( state, { appPasswordId } ) =>
-		reject( state, { ID: appPasswordId } ),
-	[ APPLICATION_PASSWORDS_RECEIVE ]: ( state, { appPasswords } ) => appPasswords,
-} );
+export default ( state = [], action ) => {
+	switch ( action.type ) {
+		case APPLICATION_PASSWORD_DELETE_SUCCESS:
+			return reject( state, { ID: action.appPasswordId } );
+		case APPLICATION_PASSWORDS_RECEIVE:
+			return action.appPasswords;
+		default:
+			return state;
+	}
+};

--- a/client/state/application-passwords/test/reducer.js
+++ b/client/state/application-passwords/test/reducer.js
@@ -1,0 +1,80 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import reducer from '../reducer';
+import {
+	APPLICATION_PASSWORD_DELETE_SUCCESS,
+	APPLICATION_PASSWORDS_RECEIVE,
+} from 'state/action-types';
+
+describe( 'reducer', () => {
+	const appPasswords = [
+		{
+			ID: 12345,
+			name: 'Example',
+			value: '2018-01-01T00:00:00+00:00',
+		},
+		{
+			ID: 23456,
+			name: 'Test',
+			value: '2018-02-01T08:10:00+00:00',
+		},
+	];
+	const otherAppPasswords = [
+		{
+			ID: 54321,
+			name: 'Sample',
+			value: '2018-03-01T05:30:00+00:00',
+		},
+	];
+
+	test( 'should default to an empty array', () => {
+		const state = reducer( undefined, {} );
+		expect( state ).toEqual( [] );
+	} );
+
+	test( 'should set application passwords to empty array when user has no application passwords', () => {
+		const state = reducer( undefined, {
+			type: APPLICATION_PASSWORDS_RECEIVE,
+			appPasswords: [],
+		} );
+
+		expect( state ).toEqual( [] );
+	} );
+
+	test( 'should add application passwords to the initial state', () => {
+		const state = reducer( [], {
+			type: APPLICATION_PASSWORDS_RECEIVE,
+			appPasswords,
+		} );
+
+		expect( state ).toEqual( appPasswords );
+	} );
+
+	test( 'should overwrite previous application passwords in state', () => {
+		const state = deepFreeze( appPasswords );
+		const newState = reducer( state, {
+			type: APPLICATION_PASSWORDS_RECEIVE,
+			appPasswords: otherAppPasswords,
+		} );
+
+		expect( newState ).toEqual( otherAppPasswords );
+	} );
+
+	test( 'should delete application passwords by ID from state', () => {
+		const state = deepFreeze( appPasswords );
+		const newState = reducer( state, {
+			type: APPLICATION_PASSWORD_DELETE_SUCCESS,
+			appPasswordId: appPasswords[ 0 ].ID,
+		} );
+
+		expect( newState ).toEqual( [ appPasswords[ 1 ] ] );
+	} );
+} );

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -20,6 +20,7 @@ import { combineReducers } from 'state/utils';
 import actionLogger from './action-log';
 import activityLog from './activity-log/reducer';
 import analyticsTracking from './analytics/reducer';
+import applicationPasswords from './application-passwords/reducer';
 import navigationMiddleware from './navigation/middleware';
 import noticesMiddleware from './notices/middleware';
 import extensionsModule from 'extensions';
@@ -111,6 +112,7 @@ const reducers = {
 	accountRecovery,
 	activityLog,
 	application,
+	applicationPasswords,
 	automatedTransfer,
 	billingTransactions,
 	checklist,


### PR DESCRIPTION
This PR adds a simple reducer for application passwords. It basically takes care of:

* Receiving application passwords (also applicable when creating a new one)
* Removing an application password upon deletion

Part of #22912.

To test:
* Checkout this branch
* Verify all tests pass:

```
npm run test-client client/state/application-passwords/test/reducer.js
```
* Fire a `dispatch( { type: 'APPLICATION_PASSWORDS_REQUEST' } )` in your console and after the request completes, fire a `state.applicationPasswords` to verify the application passwords are there.
* Fire a `dispatch( { type: 'APPLICATION_PASSWORD_CREATE', applicationName: 'example' } )` in your console, and after receiving has completed, verify the new app password is there (by firing `state.applicationPasswords`).
* Fire a `dispatch( { type: 'APPLICATION_PASSWORD_DELETE', appPasswordId: 12345 } )` where `12345` is the ID of your app password you want to delete. After the request has finished, fire a `state.applicationPasswords` to verify that password is now gone.