### PR TITLE
Google My Business: Add New Account page

### DIFF
--- a/assets/stylesheets/sections/google-my-business.scss
+++ b/assets/stylesheets/sections/google-my-business.scss
@@ -1,0 +1,5 @@
+/** @format */
+@import '../shared/mixins/breakpoints';
+
+@import 'my-sites/google-my-business/style';
+@import 'my-sites/google-my-business/select-business-type/style';

--- a/assets/stylesheets/sections/google-my-business.scss
+++ b/assets/stylesheets/sections/google-my-business.scss
@@ -2,4 +2,5 @@
 @import '../shared/mixins/breakpoints';
 
 @import 'my-sites/google-my-business/style';
+@import 'my-sites/google-my-business/new-account/style';
 @import 'my-sites/google-my-business/select-business-type/style';

--- a/assets/stylesheets/sections/google-my-business.scss
+++ b/assets/stylesheets/sections/google-my-business.scss
@@ -1,6 +1,5 @@
 /** @format */
 @import '../shared/mixins/breakpoints';
 
-@import 'my-sites/google-my-business/style';
 @import 'my-sites/google-my-business/new-account/style';
 @import 'my-sites/google-my-business/select-business-type/style';

--- a/client/components/action-card/style.scss
+++ b/client/components/action-card/style.scss
@@ -30,7 +30,7 @@
 }
 
 .action-card__heading {
-	font-size: 21px;
+	font-size: 20px;
 	margin: 5px 0;
 
 	@include breakpoint( '>960px' ) {

--- a/client/components/action-card/style.scss
+++ b/client/components/action-card/style.scss
@@ -30,7 +30,7 @@
 }
 
 .action-card__heading {
-	font-size: 20px;
+	font-size: 21px;
 	margin: 5px 0;
 
 	@include breakpoint( '>960px' ) {

--- a/client/my-sites/google-my-business/controller.js
+++ b/client/my-sites/google-my-business/controller.js
@@ -8,10 +8,21 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
+import GoogleMyBusinessNewAccount from './new-account';
 import GoogleMyBusinessSelectBusinessType from './select-business-type';
+
+export function newAccount( context, next ) {
+	const { params } = context;
+
+	context.primary = <GoogleMyBusinessNewAccount siteId={ params.site_id } />;
+
+	next();
+}
 
 export function selectBusinessType( context, next ) {
 	const { params } = context;
+
 	context.primary = <GoogleMyBusinessSelectBusinessType siteId={ params.site_id } />;
+
 	next();
 }

--- a/client/my-sites/google-my-business/controller.js
+++ b/client/my-sites/google-my-business/controller.js
@@ -12,17 +12,13 @@ import GoogleMyBusinessNewAccount from './new-account';
 import GoogleMyBusinessSelectBusinessType from './select-business-type';
 
 export function newAccount( context, next ) {
-	const { params } = context;
-
-	context.primary = <GoogleMyBusinessNewAccount siteId={ params.site_id } />;
+	context.primary = <GoogleMyBusinessNewAccount />;
 
 	next();
 }
 
 export function selectBusinessType( context, next ) {
-	const { params } = context;
-
-	context.primary = <GoogleMyBusinessSelectBusinessType siteId={ params.site_id } />;
+	context.primary = <GoogleMyBusinessSelectBusinessType />;
 
 	next();
 }

--- a/client/my-sites/google-my-business/index.js
+++ b/client/my-sites/google-my-business/index.js
@@ -23,7 +23,7 @@ export default function() {
 	);
 
 	page(
-		'/google-my-business/:site_id/select-business-type',
+		'/google-my-business/:site/select-business-type',
 		siteSelection,
 		navigation,
 		selectBusinessType,
@@ -33,7 +33,7 @@ export default function() {
 
 	if ( config.isEnabled( 'google-my-business' ) ) {
 		page(
-			'/google-my-business/:site_id/new',
+			'/google-my-business/:site/new',
 			siteSelection,
 			navigation,
 			newAccount,

--- a/client/my-sites/google-my-business/index.js
+++ b/client/my-sites/google-my-business/index.js
@@ -8,12 +8,20 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
-import { selectBusinessType } from './controller';
+import { newAccount, selectBusinessType } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/google-my-business', siteSelection, sites, makeLayout, clientRender );
+	page(
+		'/google-my-business',
+		siteSelection,
+		sites,
+		makeLayout,
+		clientRender
+	);
+
 	page(
 		'/google-my-business/:site_id/select-business-type',
 		siteSelection,
@@ -22,4 +30,15 @@ export default function() {
 		makeLayout,
 		clientRender
 	);
+
+	if ( config.isEnabled( 'google-my-business' ) ) {
+		page(
+			'/google-my-business/:site_id/new',
+			siteSelection,
+			navigation,
+			newAccount,
+			makeLayout,
+			clientRender
+		);
+	}
 }

--- a/client/my-sites/google-my-business/index.js
+++ b/client/my-sites/google-my-business/index.js
@@ -23,12 +23,8 @@ export default function() {
 	);
 
 	page(
-		'/google-my-business/:site/select-business-type',
-		siteSelection,
-		navigation,
-		selectBusinessType,
-		makeLayout,
-		clientRender
+		'/google-my-business/:site',
+		context => page.redirect( `/google-my-business/${ context.params.site }/select-business-type` )
 	);
 
 	if ( config.isEnabled( 'google-my-business' ) ) {
@@ -41,4 +37,13 @@ export default function() {
 			clientRender
 		);
 	}
+
+	page(
+		'/google-my-business/:site/select-business-type',
+		siteSelection,
+		navigation,
+		selectBusinessType,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/my-sites/google-my-business/new-account/index.js
+++ b/client/my-sites/google-my-business/new-account/index.js
@@ -31,7 +31,7 @@ class GoogleMyBusinessNewAccount extends Component {
 	}
 
 	goBack = () => {
-		page.back( `/google-my-business/${ this.props.siteSlug }` );
+		page.back( `/google-my-business/${ this.props.siteSlug }/select-business-type` );
 	};
 
 	trackCreateMyListingClick = () => {

--- a/client/my-sites/google-my-business/new-account/index.js
+++ b/client/my-sites/google-my-business/new-account/index.js
@@ -49,19 +49,19 @@ class NewAccount extends Component {
 		const { translate } = this.props;
 
 		return (
-			<Main className="google-my-business new-account" wideLayout>
+			<Main className="gmb-new-account" wideLayout>
 				<HeaderCake isCompact={ false } alwaysShowActionText={ false } onClick={ this.goBack }>
 					{ translate( 'Google My Business' ) }
 				</HeaderCake>
 
-				<Card className="new-account__card">
+				<Card className="gmb-new-account__card">
 					<img
 						alt={ translate( 'Local business illustration' ) }
-						className="new-account__illustration"
+						className="gmb-new-account__illustration"
 						src="/calypso/images/google-my-business/business-local.svg"
 					/>
 
-					<h1>
+					<h1 className="gmb-new-account__heading">
 						{ translate( 'It looks like you might be new to Google My Business' ) }
 					</h1>
 
@@ -72,7 +72,7 @@ class NewAccount extends Component {
 						) }
 					</p>
 
-					<div className="new-account__actions">
+					<div className="gmb-new-account__actions">
 						<Button primary onClick={ this.trackCreateMyListingClick }>
 							{ translate( 'Create My Listing' ) }
 						</Button>

--- a/client/my-sites/google-my-business/new-account/index.js
+++ b/client/my-sites/google-my-business/new-account/index.js
@@ -16,12 +16,13 @@ import Button from 'components/button';
 import Card from 'components/card';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { recordPageViewWithClientId as recordPageView, recordTracksEvent } from 'state/analytics/actions';
 
 class GoogleMyBusinessNewAccount extends Component {
 	static propTypes = {
 		recordTracksEvent: PropTypes.func.isRequired,
-		siteId: PropTypes.string.isRequired,
+		siteSlug: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 
@@ -30,7 +31,7 @@ class GoogleMyBusinessNewAccount extends Component {
 	}
 
 	goBack = () => {
-		page.back( `/google-my-business/${ this.props.siteId }` );
+		page.back( `/google-my-business/${ this.props.siteSlug }` );
 	};
 
 	trackCreateMyListingClick = () => {
@@ -46,7 +47,7 @@ class GoogleMyBusinessNewAccount extends Component {
 	};
 
 	render() {
-		const { translate } = this.props;
+		const { siteSlug, translate } = this.props;
 
 		return (
 			<Main className="gmb-new-account" wideLayout>
@@ -77,7 +78,7 @@ class GoogleMyBusinessNewAccount extends Component {
 							{ translate( 'Create My Listing' ) }
 						</Button>
 
-						<Button href={ `/stats/${ this.props.siteId }` } onClick={ this.trackNoThanksClick }>
+						<Button href={ `/stats/${ siteSlug }` } onClick={ this.trackNoThanksClick }>
 							{ translate( 'No thanks' ) }
 						</Button>
 					</div>
@@ -87,4 +88,12 @@ class GoogleMyBusinessNewAccount extends Component {
 	}
 }
 
-export default connect( undefined, { recordPageView, recordTracksEvent } )( localize( GoogleMyBusinessNewAccount ) );
+export default connect(
+	state => ( {
+		siteSlug: getSelectedSiteSlug( state ),
+	} ),
+	{
+		recordPageView,
+		recordTracksEvent,
+	}
+)( localize( GoogleMyBusinessNewAccount ) );

--- a/client/my-sites/google-my-business/new-account/index.js
+++ b/client/my-sites/google-my-business/new-account/index.js
@@ -16,8 +16,9 @@ import Button from 'components/button';
 import Card from 'components/card';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
-import { recordPageViewWithClientId as recordPageView, recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class GoogleMyBusinessNewAccount extends Component {
 	static propTypes = {
@@ -25,10 +26,6 @@ class GoogleMyBusinessNewAccount extends Component {
 		siteSlug: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
-
-	componentDidMount() {
-		this.props.recordPageView( '/google-my-business/:site/new', 'Google My Business > New' );
-	}
 
 	goBack = () => {
 		page.back( `/google-my-business/${ this.props.siteSlug }/select-business-type` );
@@ -51,6 +48,11 @@ class GoogleMyBusinessNewAccount extends Component {
 
 		return (
 			<Main className="gmb-new-account" wideLayout>
+				<PageViewTracker
+					path="/google-my-business/:site/new"
+					title="Google My Business > New"
+				/>
+
 				<HeaderCake isCompact={ false } alwaysShowActionText={ false } onClick={ this.goBack }>
 					{ translate( 'Google My Business' ) }
 				</HeaderCake>
@@ -93,7 +95,6 @@ export default connect(
 		siteSlug: getSelectedSiteSlug( state ),
 	} ),
 	{
-		recordPageView,
 		recordTracksEvent,
 	}
 )( localize( GoogleMyBusinessNewAccount ) );

--- a/client/my-sites/google-my-business/new-account/index.js
+++ b/client/my-sites/google-my-business/new-account/index.js
@@ -1,0 +1,90 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import HeaderCake from 'components/header-cake';
+import Main from 'components/main';
+import { recordPageViewWithClientId as recordPageView, recordTracksEvent } from 'state/analytics/actions';
+
+class NewAccount extends Component {
+	static propTypes = {
+		recordTracksEvent: PropTypes.func.isRequired,
+		siteId: PropTypes.string.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	componentDidMount() {
+		this.props.recordPageView( '/google-my-business/:site/new', 'Google My Business > New' );
+	}
+
+	goBack = () => {
+		page.back( `/google-my-business/${ this.props.siteId }` );
+	};
+
+	trackCreateMyListingClick = () => {
+		this.props.recordTracksEvent(
+			'calypso_google_my_business_new_account_create_my_listing_button_click'
+		);
+	};
+
+	trackNoThanksClick = () => {
+		this.props.recordTracksEvent(
+			'calypso_google_my_business_new_account_no_thanks_button_click'
+		);
+	};
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<Main className="google-my-business new-account" wideLayout>
+				<HeaderCake isCompact={ false } alwaysShowActionText={ false } onClick={ this.goBack }>
+					{ translate( 'Google My Business' ) }
+				</HeaderCake>
+
+				<Card className="new-account__card">
+					<img
+						alt={ translate( 'Local business illustration' ) }
+						className="new-account__illustration"
+						src="/calypso/images/google-my-business/business-local.svg"
+					/>
+
+					<h1>
+						{ translate( 'It looks like you might be new to Google My Business' ) }
+					</h1>
+
+					<p>
+						{ translate(
+							'Google My Business lists your local business on Google Search and Google Maps. ' +
+							'It works for businesses that have a physical location or serve a local area'
+						) }
+					</p>
+
+					<div className="new-account__actions">
+						<Button primary onClick={ this.trackCreateMyListingClick }>
+							{ translate( 'Create My Listing' ) }
+						</Button>
+
+						<Button href={ `/stats/${ this.props.siteId }` } onClick={ this.trackNoThanksClick }>
+							{ translate( 'No thanks' ) }
+						</Button>
+					</div>
+				</Card>
+			</Main>
+		);
+	}
+}
+
+export default connect( undefined, { recordPageView, recordTracksEvent } )( localize( NewAccount ) );

--- a/client/my-sites/google-my-business/new-account/index.js
+++ b/client/my-sites/google-my-business/new-account/index.js
@@ -18,7 +18,7 @@ import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import { recordPageViewWithClientId as recordPageView, recordTracksEvent } from 'state/analytics/actions';
 
-class NewAccount extends Component {
+class GoogleMyBusinessNewAccount extends Component {
 	static propTypes = {
 		recordTracksEvent: PropTypes.func.isRequired,
 		siteId: PropTypes.string.isRequired,
@@ -87,4 +87,4 @@ class NewAccount extends Component {
 	}
 }
 
-export default connect( undefined, { recordPageView, recordTracksEvent } )( localize( NewAccount ) );
+export default connect( undefined, { recordPageView, recordTracksEvent } )( localize( GoogleMyBusinessNewAccount ) );

--- a/client/my-sites/google-my-business/new-account/style.scss
+++ b/client/my-sites/google-my-business/new-account/style.scss
@@ -1,0 +1,37 @@
+.new-account__card {
+	display: flex;
+	flex-direction: column;
+}
+
+.new-account__illustration {
+	margin-bottom: 10px;
+	max-width: 200px;
+
+	@include breakpoint( '>960px' ) {
+		max-width: 300px;
+	}
+}
+
+.new-account__actions {
+	display: flex;
+
+	@include breakpoint( '<480px' ) {
+		flex-direction: column;
+	}
+}
+
+.new-account__actions .button {
+	@include breakpoint( '<480px' ) {
+		text-align: center;
+	}
+
+	&.is-primary {
+		@include breakpoint( '<480px' ) {
+			margin-bottom: 1em;
+		}
+
+		@include breakpoint( '>480px' ) {
+			margin-right: 1em;
+		}
+	}
+}

--- a/client/my-sites/google-my-business/new-account/style.scss
+++ b/client/my-sites/google-my-business/new-account/style.scss
@@ -1,9 +1,11 @@
-.new-account__card {
+@import 'my-sites/google-my-business/style';
+
+.gmb-new-account__card {
 	display: flex;
 	flex-direction: column;
 }
 
-.new-account__illustration {
+.gmb-new-account__illustration {
 	margin-bottom: 10px;
 	max-width: 200px;
 
@@ -12,7 +14,7 @@
 	}
 }
 
-.new-account__actions {
+.gmb-new-account__actions {
 	display: flex;
 
 	@include breakpoint( '<480px' ) {
@@ -20,7 +22,7 @@
 	}
 }
 
-.new-account__actions .button {
+.gmb-new-account__actions .button {
 	@include breakpoint( '<480px' ) {
 		text-align: center;
 	}

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -20,7 +20,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import ExternalLink from 'components/external-link';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
-class SelectBusinessType extends Component {
+class GoogleMyBusinessSelectBusinessType extends Component {
 	static propTypes = {
 		recordTracksEvent: PropTypes.func.isRequired,
 		siteId: PropTypes.string.isRequired,
@@ -131,4 +131,4 @@ class SelectBusinessType extends Component {
 	}
 }
 
-export default connect( undefined, { recordTracksEvent } )( localize( SelectBusinessType ) );
+export default connect( undefined, { recordTracksEvent } )( localize( GoogleMyBusinessSelectBusinessType ) );

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -92,7 +92,7 @@ class SelectBusinessType extends Component {
 					<img
 						className="select-business-type__explanation-image"
 						src="/calypso/images/google-my-business/business-local.svg"
-						alt="Local business illustration"
+						alt={ translate( 'Local business illustration' ) }
 					/>
 				</CompactCard>
 

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -13,7 +13,7 @@ import page from 'page';
  * Internal dependencies
  */
 import HeaderCake from 'components/header-cake';
-import CompactCard from 'components/card/compact';
+import Card from 'components/card';
 import ActionCard from 'components/action-card';
 import Main from 'components/main';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -63,7 +63,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 					{ translate( 'Google My Business' ) }
 				</HeaderCake>
 
-				<CompactCard className="gmb-select-business-type__explanation">
+				<Card className="gmb-select-business-type__explanation">
 					<div className="gmb-select-business-type__explanation-main">
 						<h1 className="gmb-select-business-type__heading">
 							{ translate( 'Which type of business are you?' ) }
@@ -95,7 +95,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 						src="/calypso/images/google-my-business/business-local.svg"
 						alt={ translate( 'Local business illustration' ) }
 					/>
-				</CompactCard>
+				</Card>
 
 				<ActionCard
 					headerText={ translate( 'Physical Location or Service Area', {

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -53,7 +53,7 @@ class SelectBusinessType extends Component {
 		const { translate, siteId } = this.props;
 
 		return (
-			<Main className="google-my-business select-business-type">
+			<Main className="google-my-business select-business-type" wideLayout>
 				<PageViewTracker
 					path="/google-my-business/:site/select-business-type"
 					title="Google My Business > Select Business Type"

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -53,7 +53,7 @@ class SelectBusinessType extends Component {
 		const { translate, siteId } = this.props;
 
 		return (
-			<Main className="google-my-business select-business-type" wideLayout>
+			<Main className="gmb-select-business-type" wideLayout>
 				<PageViewTracker
 					path="/google-my-business/:site/select-business-type"
 					title="Google My Business > Select Business Type"
@@ -63,9 +63,9 @@ class SelectBusinessType extends Component {
 					{ translate( 'Google My Business' ) }
 				</HeaderCake>
 
-				<CompactCard className="select-business-type__explanation">
-					<div className="select-business-type__explanation-main">
-						<h1>
+				<CompactCard className="gmb-select-business-type__explanation">
+					<div className="gmb-select-business-type__explanation-main">
+						<h1 className="gmb-select-business-type__heading">
 							{ translate( 'Which type of business are you?' ) }
 						</h1>
 
@@ -91,7 +91,7 @@ class SelectBusinessType extends Component {
 					</div>
 
 					<img
-						className="select-business-type__explanation-image"
+						className="gmb-select-business-type__illustration"
 						src="/calypso/images/google-my-business/business-local.svg"
 						alt={ translate( 'Local business illustration' ) }
 					/>

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -53,18 +53,19 @@ class SelectBusinessType extends Component {
 		const { translate, siteId } = this.props;
 
 		return (
-			<Main className="select-business-type">
+			<Main className="google-my-business select-business-type">
 				<PageViewTracker
 					path="/google-my-business/:site/select-business-type"
 					title="Google My Business > Select Business Type"
 				/>
+
 				<HeaderCake isCompact={ false } alwaysShowActionText={ false } onClick={ this.goBack }>
 					{ translate( 'Google My Business' ) }
 				</HeaderCake>
 
 				<CompactCard className="select-business-type__explanation">
 					<div className="select-business-type__explanation-main">
-						<h1 className="select-business-type__explanation-heading">
+						<h1>
 							{ translate( 'Which type of business are you?' ) }
 						</h1>
 

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -19,11 +19,12 @@ import Main from 'components/main';
 import { recordTracksEvent } from 'state/analytics/actions';
 import ExternalLink from 'components/external-link';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 class GoogleMyBusinessSelectBusinessType extends Component {
 	static propTypes = {
 		recordTracksEvent: PropTypes.func.isRequired,
-		siteId: PropTypes.string.isRequired,
+		siteSlug: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 
@@ -46,11 +47,11 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 	};
 
 	goBack = () => {
-		page.back( `/stats/day/${ this.props.siteId }` );
+		page.back( `/stats/day/${ this.props.siteSlug }` );
 	};
 
 	render() {
-		const { translate, siteId } = this.props;
+		const { siteSlug, translate } = this.props;
 
 		return (
 			<Main className="gmb-select-business-type" wideLayout>
@@ -72,7 +73,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 						<p>
 							{ translate(
 								'{{link}}Google My Business{{/link}} lists your local business on Google Search and Google Maps. ' +
-									'It works for businesses that have a physical location or serve a local area.',
+								'It works for businesses that have a physical location or serve a local area.',
 								{
 									components: {
 										link: (
@@ -103,7 +104,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 					} ) }
 					mainText={ translate(
 						'Your business has a physical location customers can visit, ' +
-							'or provides goods and services to local customers, or both.'
+						'or provides goods and services to local customers, or both.'
 					) }
 					buttonText={ translate( 'Create Your Listing', {
 						comment: 'Call to Action to add a business listing to Google My Business',
@@ -123,7 +124,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 						"Don't provide in-person services? Learn more about reaching your customers online."
 					) }
 					buttonText={ translate( 'Optimize Your SEO', { comment: 'Call to Action button' } ) }
-					buttonHref={ '/settings/traffic/' + siteId }
+					buttonHref={ `/settings/traffic/${ siteSlug }` }
 					buttonOnClick={ this.trackOptimizeYourSEOClick }
 				/>
 			</Main>
@@ -131,4 +132,11 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 	}
 }
 
-export default connect( undefined, { recordTracksEvent } )( localize( GoogleMyBusinessSelectBusinessType ) );
+export default connect(
+	state => ( {
+		siteSlug: getSelectedSiteSlug( state ),
+	} ),
+	{
+		recordTracksEvent,
+	}
+)( localize( GoogleMyBusinessSelectBusinessType ) );

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -28,6 +28,10 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
+	goBack = () => {
+		page.back( `/stats/day/${ this.props.siteSlug }` );
+	};
+
 	trackCreateMyListingClick = () => {
 		this.props.recordTracksEvent(
 			'calypso_google_my_business_select_business_type_create_my_listing_button_click'
@@ -44,10 +48,6 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 		this.props.recordTracksEvent(
 			'calypso_google_my_business_select_business_type_google_my_business_link_click'
 		);
-	};
-
-	goBack = () => {
-		page.back( `/stats/day/${ this.props.siteSlug }` );
 	};
 
 	render() {

--- a/client/my-sites/google-my-business/select-business-type/style.scss
+++ b/client/my-sites/google-my-business/select-business-type/style.scss
@@ -15,16 +15,18 @@
 
 .select-business-type__explanation-image {
 	max-width: 200px;
-	margin-bottom: 10px;
+
+	@include breakpoint( '<960px' ) {
+		margin-bottom: 10px;
+	}
 
 	@include breakpoint( '>960px' ) {
-		align-self: center;
+		margin-left: 50px;
 		max-width: 300px;
 	}
 }
 
 .select-business-type__explanation-main {
-	margin-right: 50px;
 	max-width: 540px;
 	flex: 2 1;
 }

--- a/client/my-sites/google-my-business/select-business-type/style.scss
+++ b/client/my-sites/google-my-business/select-business-type/style.scss
@@ -13,16 +13,6 @@
 	}
 }
 
-
-.select-business-type__explanation-heading {
-	font-size: 21px;
-	margin: 5px 0;
-
-	@include breakpoint( '>960px' ) {
-		margin: 10px 0;
-	}
-}
-
 .select-business-type__explanation-image {
 	max-width: 200px;
 	margin-bottom: 10px;

--- a/client/my-sites/google-my-business/select-business-type/style.scss
+++ b/client/my-sites/google-my-business/select-business-type/style.scss
@@ -1,18 +1,17 @@
 @import 'my-sites/google-my-business/style';
 
-.gmb-select-business-type {
-	.header-cake {
-		margin-bottom: 0;
-	}
-}
-
-.gmb-select-business-type__explanation.card {
+.gmb-select-business-type__explanation {
 	display: flex;
 	margin-bottom: 16px;
 
 	@include breakpoint( '<960px' ) {
 		flex-direction: column-reverse;
 	}
+}
+
+.gmb-select-business-type__explanation-main {
+	max-width: 540px;
+	flex: 2 1;
 }
 
 .gmb-select-business-type__illustration {
@@ -26,9 +25,4 @@
 		margin-left: 50px;
 		max-width: 300px;
 	}
-}
-
-.gmb-select-business-type__explanation-main {
-	max-width: 540px;
-	flex: 2 1;
 }

--- a/client/my-sites/google-my-business/select-business-type/style.scss
+++ b/client/my-sites/google-my-business/select-business-type/style.scss
@@ -1,10 +1,12 @@
-.select-business-type {
+@import 'my-sites/google-my-business/style';
+
+.gmb-select-business-type {
 	.header-cake {
 		margin-bottom: 0;
 	}
 }
 
-.select-business-type__explanation.card {
+.gmb-select-business-type__explanation.card {
 	display: flex;
 	margin-bottom: 16px;
 
@@ -13,7 +15,7 @@
 	}
 }
 
-.select-business-type__explanation-image {
+.gmb-select-business-type__illustration {
 	max-width: 200px;
 
 	@include breakpoint( '<960px' ) {
@@ -26,7 +28,7 @@
 	}
 }
 
-.select-business-type__explanation-main {
+.gmb-select-business-type__explanation-main {
 	max-width: 540px;
 	flex: 2 1;
 }

--- a/client/my-sites/google-my-business/style.scss
+++ b/client/my-sites/google-my-business/style.scss
@@ -1,1 +1,13 @@
-@import './select-business-type/style';
+.google-my-business {
+	h1 {
+		font-size: 21px;
+		font-weight: 400;
+		margin-bottom: 5px;
+		margin-top: 5px;
+
+		@include breakpoint( '>960px' ) {
+			margin-bottom: 10px;
+			margin-top: 10px;
+		}
+	}
+}

--- a/client/my-sites/google-my-business/style.scss
+++ b/client/my-sites/google-my-business/style.scss
@@ -1,13 +1,12 @@
-.google-my-business {
-	h1 {
-		font-size: 21px;
-		font-weight: 400;
-		margin-bottom: 5px;
-		margin-top: 5px;
+.gmb-select-business-type__heading,
+.gmb-new-account__heading {
+	font-size: 24px;
+	font-weight: 400;
+	margin-bottom: 5px;
+	margin-top: 5px;
 
-		@include breakpoint( '>960px' ) {
-			margin-bottom: 10px;
-			margin-top: 10px;
-		}
+	@include breakpoint( '>960px' ) {
+		margin-bottom: 10px;
+		margin-top: 10px;
 	}
 }

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -194,6 +194,7 @@ const sections = [
 		module: 'my-sites/google-my-business',
 		secondary: true,
 		group: 'sites',
+		css: 'google-my-business',
 	},
 	// Since we're using find() and startsWith() on paths, 'themes' needs to go before 'theme',
 	// or it'll be falsely associated with the latter section.


### PR DESCRIPTION
This pull request introduces a new page that will be presented to users when they connect WordPress.com to Google My Business, and their account is empty (i.e. doesn't contain any location yet). It also creates a new CSS section in order to bundle styles from Google My Business pages in the same file (making the main CSS bundle lighter in the process).
 
Large screens | Small screens
------ | -----
<img width="502" alt="screenshot" src="https://user-images.githubusercontent.com/594356/37864724-1bdf3f98-2f73-11e8-8d3f-055e9ece3ea9.png"> | <img width="302" alt="screenshot" src="https://user-images.githubusercontent.com/594356/37864726-2f815554-2f73-11e8-865d-a1c594996cd7.png">


#### Testing instructions
 
1. Run `git checkout add/gmb-new-account-page` and start your server, or open a [live branch](https://calypso.live/?branch=add/gmb-new-account-page)
2. Open the [`New Account` page](http://calypso.localhost:3000/google-my-business/new)
3. Execute `localStorage.setItem( 'debug', 'calypso:analytics:*' )` in your browser's console
4. Reload the page, and assert that pageview events are fired
5. Assert that the page looks like the screenshots above
6. Open the [`Select Business Type` page](http://calypso.localhost:3000/google-my-business)
7. Assert that the page looks like as it was before
 
#### Additional notes
 
This new page is based on the amazing work of @scruffian at https://github.com/Automattic/wp-calypso/pull/22801.
 
#### Reviews
 
- [ ] Code
- [ ] Product