### PR TITLE
Replaces hardcoded usage of PLAN_BUSINESS with planHasFeature in PlanStorageBar

### DIFF
--- a/client/blocks/plan-storage/bar.jsx
+++ b/client/blocks/plan-storage/bar.jsx
@@ -14,12 +14,13 @@ import filesize from 'filesize';
  * Internal dependencies
  */
 import ProgressBar from 'components/progress-bar';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { planHasFeature } from 'lib/plans';
+import { FEATURE_UNLIMITED_STORAGE } from 'lib/plans/constants';
 
 const ALERT_PERCENT = 80;
 const WARN_PERCENT = 60;
 
-class PlanStorageBar extends Component {
+export class PlanStorageBar extends Component {
 	static propTypes = {
 		className: PropTypes.string,
 		mediaStorage: PropTypes.object,
@@ -34,7 +35,7 @@ class PlanStorageBar extends Component {
 	render() {
 		const { className, mediaStorage, sitePlanSlug, siteSlug, translate } = this.props;
 
-		if ( sitePlanSlug === PLAN_BUSINESS ) {
+		if ( planHasFeature( sitePlanSlug, FEATURE_UNLIMITED_STORAGE ) ) {
 			return null;
 		}
 

--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -15,10 +15,11 @@ import { connect } from 'react-redux';
 import QueryMediaStorage from 'components/data/query-media-storage';
 import { getMediaStorage } from 'state/sites/media-storage/selectors';
 import { getSitePlanSlug, getSiteSlug, isJetpackSite } from 'state/sites/selectors';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { planHasFeature } from 'lib/plans';
+import { FEATURE_UNLIMITED_STORAGE } from 'lib/plans/constants';
 import PlanStorageBar from './bar';
 
-class PlanStorage extends Component {
+export class PlanStorage extends Component {
 	static propTypes = {
 		className: PropTypes.string,
 		mediaStorage: PropTypes.object,
@@ -34,7 +35,7 @@ class PlanStorage extends Component {
 			return null;
 		}
 
-		if ( sitePlanSlug === PLAN_BUSINESS ) {
+		if ( planHasFeature( sitePlanSlug, FEATURE_UNLIMITED_STORAGE ) ) {
 			return null;
 		}
 

--- a/client/blocks/plan-storage/test/bar.jsx
+++ b/client/blocks/plan-storage/test/bar.jsx
@@ -1,0 +1,121 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+const translate = x => x;
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Comp => props => (
+		<Comp
+			{ ...props }
+			translate={ function( x ) {
+				return x;
+			} }
+		/>
+	),
+	numberFormat: x => x,
+} ) );
+
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+import {
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_FREE,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { PlanStorageBar } from '../bar';
+
+describe( 'PlanStorageBar basic tests', () => {
+	const props = {
+		translate,
+		mediaStorage: {
+			storage_used_bytes: 100,
+			max_storage_bytes: 1000,
+		},
+		siteSlug: 'example.com',
+		sitePlanSlug: PLAN_FREE,
+	};
+
+	test( 'should not blow up and have class .plan-storage-bar ', () => {
+		const bar = shallow( <PlanStorageBar { ...props } /> );
+		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+	} );
+
+	test( 'should render ProgressBar', () => {
+		const bar = shallow( <PlanStorageBar { ...props } /> );
+		const progressBar = bar.find( 'ProgressBar' );
+		assert.lengthOf( progressBar, 1 );
+		assert.equal( progressBar.props().value, 10 );
+	} );
+
+	test( 'should render when storage is limited', () => {
+		let bar;
+
+		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_PREMIUM } /> );
+		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+
+		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_PREMIUM_2_YEARS } /> );
+		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+
+		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_PERSONAL } /> );
+		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+
+		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_PERSONAL_2_YEARS } /> );
+		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+
+		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_FREE } /> );
+		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+	} );
+
+	test( 'should not render when storage is unlimited', () => {
+		let bar;
+
+		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_BUSINESS } /> );
+		assert.lengthOf( bar.find( '.plan-storage__bar' ), 0 );
+
+		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_BUSINESS_2_YEARS } /> );
+		assert.lengthOf( bar.find( '.plan-storage__bar' ), 0 );
+	} );
+
+	test( 'should not render when storage has valid max_storage_bytes', () => {
+		let bar;
+
+		bar = shallow( <PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: 1 } } /> );
+		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+
+		bar = shallow( <PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: 0 } } /> );
+		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+
+		bar = shallow( <PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: 50 } } /> );
+		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+	} );
+
+	test( 'should not render when storage is falsey or -1', () => {
+		let bar;
+
+		bar = shallow( <PlanStorageBar { ...props } mediaStorage={ 0 } /> );
+		assert.lengthOf( bar.find( '.plan-storage__bar' ), 0 );
+
+		bar = shallow( <PlanStorageBar { ...props } mediaStorage={ false } /> );
+		assert.lengthOf( bar.find( '.plan-storage__bar' ), 0 );
+
+		bar = shallow( <PlanStorageBar { ...props } mediaStorage={ null } /> );
+		assert.lengthOf( bar.find( '.plan-storage__bar' ), 0 );
+
+		bar = shallow( <PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: -1 } } /> );
+		assert.lengthOf( bar.find( '.plan-storage__bar' ), 0 );
+	} );
+} );

--- a/client/blocks/plan-storage/test/plan-storage.jsx
+++ b/client/blocks/plan-storage/test/plan-storage.jsx
@@ -1,0 +1,90 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+import {
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_FREE,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { PlanStorage } from '../index';
+
+describe( 'PlanStorage basic tests', () => {
+	const props = {
+		mediaStorage: {
+			max_storage_bytes: 1000,
+		},
+		siteId: 123,
+		siteSlug: 'example.com',
+		sitePlanSlug: PLAN_FREE,
+	};
+
+	test( 'should not blow up and have class .plan-storage ', () => {
+		const storage = shallow( <PlanStorage { ...props } /> );
+		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
+	} );
+
+	test( 'should render a PlanStorageBar', () => {
+		const storage = shallow( <PlanStorage { ...props } /> );
+		const bar = storage.find( 'Localized(PlanStorageBar)' );
+		assert.lengthOf( bar, 1 );
+		assert.equal( bar.props().siteSlug, props.siteSlug );
+		assert.equal( bar.props().sitePlanSlug, props.sitePlanSlug );
+		assert.equal( bar.props().mediaStorage, props.mediaStorage );
+	} );
+
+	test( 'should render when storage is limited', () => {
+		let storage;
+
+		storage = shallow( <PlanStorage { ...props } sitePlanSlug={ PLAN_PREMIUM } /> );
+		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
+
+		storage = shallow( <PlanStorage { ...props } sitePlanSlug={ PLAN_PREMIUM_2_YEARS } /> );
+		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
+
+		storage = shallow( <PlanStorage { ...props } sitePlanSlug={ PLAN_PERSONAL } /> );
+		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
+
+		storage = shallow( <PlanStorage { ...props } sitePlanSlug={ PLAN_PERSONAL_2_YEARS } /> );
+		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
+
+		storage = shallow( <PlanStorage { ...props } sitePlanSlug={ PLAN_FREE } /> );
+		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
+	} );
+
+	test( 'should not render when storage is unlimited', () => {
+		let storage;
+
+		storage = shallow( <PlanStorage { ...props } sitePlanSlug={ PLAN_BUSINESS } /> );
+		assert.lengthOf( storage.find( '.plan-storage' ), 0 );
+
+		storage = shallow( <PlanStorage { ...props } sitePlanSlug={ PLAN_BUSINESS_2_YEARS } /> );
+		assert.lengthOf( storage.find( '.plan-storage' ), 0 );
+	} );
+
+	test( 'should not render for jetpack sites', () => {
+		const storage = shallow( <PlanStorage { ...props } jetpackSite={ true } /> );
+		assert.lengthOf( storage.find( '.plan-storage' ), 0 );
+	} );
+
+	test( 'should not render when site plan slug is empty', () => {
+		const storage = shallow( <PlanStorage { ...props } sitePlanSlug={ null } /> );
+		assert.lengthOf( storage.find( '.plan-storage' ), 0 );
+	} );
+} );


### PR DESCRIPTION
A necessary change for adding 2-year plans. The actual update is 6 lines of code and rest is tests.

Test plan:
1. Confirm that storage bar on `/media` is visible only for non-business WP users