### PR TITLE
Search: update refs to functions

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -103,6 +103,12 @@ class Search extends Component {
 		};
 	}
 
+	setOpenIconRef = openIcon => ( this.openIcon = openIcon );
+
+	setSearchInputRef = input => ( this.searchInput = input );
+
+	setOverlayRef = overlay => ( this.overlay = overlay );
+
 	componentWillMount() {
 		this.setState( {
 			instanceId: ++Search.instances,
@@ -214,9 +220,7 @@ class Search extends Component {
 
 	blur = () => this.searchInput.blur();
 
-	clear = () => {
-		this.setState( { keyword: '' } );
-	};
+	clear = () => this.setState( { keyword: '' } );
 
 	onBlur = event => {
 		if ( this.props.onBlur ) {
@@ -340,7 +344,7 @@ class Search extends Component {
 				<Spinner />
 				<div
 					className="search__icon-navigation"
-					ref={ openIcon => ( this.openIcon = openIcon ) } // eslint-disable-line react/jsx-no-bind
+					ref={ this.setOpenIconRef }
 					onClick={ enableOpenIcon ? this.openSearch : this.focus }
 					tabIndex={ enableOpenIcon ? '0' : null }
 					onKeyDown={ enableOpenIcon ? this.openListener : null }
@@ -357,7 +361,7 @@ class Search extends Component {
 						placeholder={ placeholder }
 						role="search"
 						value={ searchValue }
-						ref={ input => ( this.searchInput = input ) } //eslint-disable-line react/jsx-no-bind
+						ref={ this.setSearchInputRef }
 						onChange={ this.onChange }
 						onKeyUp={ this.keyUp }
 						onKeyDown={ this.keyDown }
@@ -381,10 +385,7 @@ class Search extends Component {
 
 	renderStylingDiv = () => {
 		return (
-			<div
-				className="search__text-overlay"
-				ref={ overlay => ( this.overlay = overlay ) } //eslint-disable-line react/jsx-no-bind
-			>
+			<div className="search__text-overlay" ref={ this.setOverlayRef }>
 				{ this.props.overlayStyling( this.state.keyword ) }
 			</div>
 		);

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -101,6 +101,9 @@ class Search extends Component {
 			isOpen: !! this.props.isOpen,
 			hasFocus: false,
 		};
+
+		this.closeListener = keyListener.bind( this, 'closeSearch' );
+		this.openListener = keyListener.bind( this, 'openSearch' );
 	}
 
 	setOpenIconRef = openIcon => ( this.openIcon = openIcon );
@@ -108,15 +111,6 @@ class Search extends Component {
 	setSearchInputRef = input => ( this.searchInput = input );
 
 	setOverlayRef = overlay => ( this.overlay = overlay );
-
-	componentWillMount() {
-		this.setState( {
-			instanceId: ++Search.instances,
-		} );
-
-		this.closeListener = keyListener.bind( this, 'closeSearch' );
-		this.openListener = keyListener.bind( this, 'openSearch' );
-	}
 
 	componentWillReceiveProps( nextProps ) {
 		if (

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { debounce, noop } from 'lodash';
+import { debounce, noop, uniqueId } from 'lodash';
 import i18n from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
@@ -23,7 +23,6 @@ import TranslatableString from 'components/translatable/proptype';
  * Internal variables
  */
 const SEARCH_DEBOUNCE_MS = 300;
-let instanceCount = 0;
 
 function keyListener( methodToCall, event ) {
 	switch ( event.key ) {
@@ -93,8 +92,7 @@ class Search extends Component {
 	constructor( props ) {
 		super( props );
 
-		instanceCount++;
-		this.instanceId = instanceCount;
+		this.instanceId = uniqueId();
 
 		this.state = {
 			keyword: this.props.initialValue || '',

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import wrapWithClickOutside from 'react-click-outside';
 import { connect } from 'react-redux';
-import { debounce, intersection, difference, includes } from 'lodash';
+import { debounce, intersection, difference, includes, partial } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
@@ -40,6 +40,8 @@ class ThemesMagicSearchCard extends React.Component {
 	constructor( props ) {
 		super( props );
 
+		this.suggestionComponentsRefs = {};
+
 		this.state = {
 			isMobile: isMobile(),
 			searchIsOpen: false,
@@ -48,6 +50,11 @@ class ThemesMagicSearchCard extends React.Component {
 			searchInput: this.props.search,
 		};
 	}
+
+	setSuggestionsRefs = ( key, suggestionComponent ) =>
+		( this.suggestionComponentsRefs[ key ] = suggestionComponent );
+
+	setSearchItemRef = search => ( this.searchInput = search );
 
 	componentWillMount() {
 		this.onResize = debounce( () => {
@@ -80,15 +87,15 @@ class ThemesMagicSearchCard extends React.Component {
 		//We need this logic because we are working togheter with different modules.
 		//that provide suggestions to the input depending on what is currently in input
 		const target = this.state.editedSearchElement !== '' ? 'suggestions' : 'welcome';
-		if ( this.refs[ target ] ) {
+		if ( this.suggestionComponentsRefs[ target ] ) {
 			// handleKeyEvent functions return bool that infroms if suggestion was picked
 			// We need that because we cannot rely on input state because it is updated
 			// asynchronously and we are not able to observe what was changed during handleKeyEvent
-			inputUpdated = this.refs[ target ].handleKeyEvent( event );
+			inputUpdated = this.suggestionComponentsRefs[ target ].handleKeyEvent( event );
 		}
 
 		if ( event.key === 'Enter' && ! inputUpdated && this.isPreviousCharWhitespace() ) {
-			this.refs[ 'url-search' ].blur();
+			this.searchInput.blur();
 			this.setState( { searchIsOpen: false } );
 		}
 	};
@@ -99,7 +106,7 @@ class ThemesMagicSearchCard extends React.Component {
 
 	// Check if char before cursor in input is a space.
 	isPreviousCharWhitespace = () => {
-		const { value, selectionStart } = this.refs[ 'url-search' ].refs.searchInput;
+		const { value, selectionStart } = this.searchInput;
 		const cursorPosition = value.slice( 0, selectionStart ).length;
 		return value[ cursorPosition - 1 ] === ' ';
 	};
@@ -139,8 +146,7 @@ class ThemesMagicSearchCard extends React.Component {
 		const val = input;
 		window.requestAnimationFrame( () => {
 			this.setState( {
-				cursorPosition: val.slice( 0, this.refs[ 'url-search' ].refs.searchInput.selectionStart )
-					.length,
+				cursorPosition: val.slice( 0, this.searchInput.selectionStart ).length,
 			} );
 			const tokens = input.split( /(\s+)/ );
 
@@ -219,7 +225,7 @@ class ThemesMagicSearchCard extends React.Component {
 
 	updateInput = updatedInput => {
 		this.setState( { searchInput: updatedInput } );
-		this.refs[ 'url-search' ].clear();
+		this.searchInput.clear();
 	};
 
 	suggest = suggestion => {
@@ -233,7 +239,7 @@ class ThemesMagicSearchCard extends React.Component {
 	};
 
 	focusOnInput = () => {
-		this.refs[ 'url-search' ].focus();
+		this.searchInput.focus();
 	};
 
 	clearSearch = () => {
@@ -269,7 +275,7 @@ class ThemesMagicSearchCard extends React.Component {
 				onSearch={ this.props.onSearch }
 				initialValue={ this.state.searchInput }
 				value={ this.state.searchInput }
-				ref="url-search"
+				ref={ this.setSearchItemRef }
 				placeholder={ translate(
 					"I'm creating a site for a: portfolio, magazine, business, wedding, blog, or…"
 				) }
@@ -331,7 +337,7 @@ class ThemesMagicSearchCard extends React.Component {
 				<div onClick={ this.handleClickInside }>
 					{ renderSuggestions && (
 						<KeyedSuggestions
-							ref="suggestions"
+							ref={ partial( this.setSuggestionsRefs, 'suggestions' ) }
 							terms={ this.props.filters }
 							input={ this.state.editedSearchElement }
 							suggest={ this.suggest }
@@ -339,7 +345,7 @@ class ThemesMagicSearchCard extends React.Component {
 					) }
 					{ ! renderSuggestions && (
 						<MagicSearchWelcome
-							ref="welcome"
+							ref={ partial( this.setSuggestionsRefs, 'welcome' ) }
 							taxonomies={ filtersKeys }
 							topSearches={ [] }
 							suggestionsCallback={ this.insertTextInInput }

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -40,7 +40,7 @@ class ThemesMagicSearchCard extends React.Component {
 	constructor( props ) {
 		super( props );
 
-		this.suggestionComponentsRefs = {};
+		this.suggestionsRefs = {};
 
 		this.state = {
 			isMobile: isMobile(),
@@ -52,9 +52,9 @@ class ThemesMagicSearchCard extends React.Component {
 	}
 
 	setSuggestionsRefs = ( key, suggestionComponent ) =>
-		( this.suggestionComponentsRefs[ key ] = suggestionComponent );
+		( this.suggestionsRefs[ key ] = suggestionComponent );
 
-	setSearchItemRef = search => ( this.searchInput = search );
+	setSearchInputRef = search => ( this.searchInputRef = search );
 
 	componentWillMount() {
 		this.onResize = debounce( () => {
@@ -87,15 +87,15 @@ class ThemesMagicSearchCard extends React.Component {
 		//We need this logic because we are working togheter with different modules.
 		//that provide suggestions to the input depending on what is currently in input
 		const target = this.state.editedSearchElement !== '' ? 'suggestions' : 'welcome';
-		if ( this.suggestionComponentsRefs[ target ] ) {
+		if ( this.suggestionsRefs[ target ] ) {
 			// handleKeyEvent functions return bool that infroms if suggestion was picked
 			// We need that because we cannot rely on input state because it is updated
 			// asynchronously and we are not able to observe what was changed during handleKeyEvent
-			inputUpdated = this.suggestionComponentsRefs[ target ].handleKeyEvent( event );
+			inputUpdated = this.suggestionsRefs[ target ].handleKeyEvent( event );
 		}
 
 		if ( event.key === 'Enter' && ! inputUpdated && this.isPreviousCharWhitespace() ) {
-			this.searchInput.blur();
+			this.searchInputRef.blur();
 			this.setState( { searchIsOpen: false } );
 		}
 	};
@@ -106,7 +106,7 @@ class ThemesMagicSearchCard extends React.Component {
 
 	// Check if char before cursor in input is a space.
 	isPreviousCharWhitespace = () => {
-		const { value, selectionStart } = this.searchInput;
+		const { value, selectionStart } = this.searchInputRef.searchInput;
 		const cursorPosition = value.slice( 0, selectionStart ).length;
 		return value[ cursorPosition - 1 ] === ' ';
 	};
@@ -146,7 +146,7 @@ class ThemesMagicSearchCard extends React.Component {
 		const val = input;
 		window.requestAnimationFrame( () => {
 			this.setState( {
-				cursorPosition: val.slice( 0, this.searchInput.selectionStart ).length,
+				cursorPosition: val.slice( 0, this.searchInputRef.searchInput.selectionStart ).length,
 			} );
 			const tokens = input.split( /(\s+)/ );
 
@@ -225,7 +225,7 @@ class ThemesMagicSearchCard extends React.Component {
 
 	updateInput = updatedInput => {
 		this.setState( { searchInput: updatedInput } );
-		this.searchInput.clear();
+		this.searchInputRef.clear();
 	};
 
 	suggest = suggestion => {
@@ -239,7 +239,7 @@ class ThemesMagicSearchCard extends React.Component {
 	};
 
 	focusOnInput = () => {
-		this.searchInput.focus();
+		this.searchInputRef.focus();
 	};
 
 	clearSearch = () => {
@@ -275,7 +275,7 @@ class ThemesMagicSearchCard extends React.Component {
 				onSearch={ this.props.onSearch }
 				initialValue={ this.state.searchInput }
 				value={ this.state.searchInput }
-				ref={ this.setSearchItemRef }
+				ref={ this.setSearchInputRef }
 				placeholder={ translate(
 					"I'm creating a site for a: portfolio, magazine, business, wedding, blog, or…"
 				) }


### PR DESCRIPTION
This is a retale of #23531, after a bug that broke the theme search was found (#23561), and was reverted on #23562.

This PR extract some changes on the `Search` component from https://github.com/Automattic/wp-calypso/pull/23368 to remove some outdated patterns and update the code to current use of `Component`:

- Removes dependency on `ReactDom`.
- Update `refs` to functions.
- Instance tracking is now a module variable and it's no longer tracked using `state`.
- Removes `componentWillMount` in favor of using a `constructor`.

It also updates the `ThemesMagicSearchCard`, that needs access to the internal reference of the search `<input/>` element. It still does...

There should be no regressions where this component is used (Domains, SiteSelector, SectionNav), #23561 should also be fixed.

This requires full end-to-end testing.