### PR TITLE
Store: Start using the counts data for the sidebar & dashboard

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
@@ -15,17 +15,19 @@ import page from 'page';
 import Button from 'components/button';
 import DashboardWidget from 'woocommerce/components/dashboard-widget';
 import DashboardWidgetRow from 'woocommerce/components/dashboard-widget/row';
+import { getCountProducts } from 'woocommerce/state/sites/data/counts/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
-import { getTotalProducts } from 'woocommerce/state/sites/products/selectors';
+import { getProductsSettingValue } from 'woocommerce/state/sites/settings/products/selectors';
 import InventoryWidget from './widgets/inventory-widget';
+import QuerySettingsProducts from 'woocommerce/components/query-settings-products';
+import { recordTrack } from 'woocommerce/lib/analytics';
 import ShareWidget from 'woocommerce/components/share-widget';
 import StatsWidget from './widgets/stats-widget';
-import { recordTrack } from 'woocommerce/lib/analytics';
-import QuerySettingsProducts from 'woocommerce/components/query-settings-products';
-import { getProductsSettingValue } from 'woocommerce/state/sites/settings/products/selectors';
 
 class ManageNoOrdersView extends Component {
 	static propTypes = {
+		hasProducts: PropTypes.bool.isRequired,
+		shopPageId: PropTypes.string,
 		site: PropTypes.shape( {
 			slug: PropTypes.string.isRequired,
 			URL: PropTypes.string.isRequired,
@@ -135,6 +137,6 @@ class ManageNoOrdersView extends Component {
 }
 
 export default connect( state => ( {
-	hasProducts: getTotalProducts( state ) > 0,
+	hasProducts: getCountProducts( state ) > 0,
 	shopPageId: getProductsSettingValue( state, 'woocommerce_shop_page_id' ),
 } ) )( localize( ManageNoOrdersView ) );

--- a/client/extensions/woocommerce/state/data-layer/orders/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/index.js
@@ -22,6 +22,7 @@ import {
 	updateOrders,
 } from 'woocommerce/state/sites/orders/actions';
 import { errorNotice, successNotice } from 'state/notices/actions';
+import { fetchCounts } from 'woocommerce/state/sites/data/counts/actions';
 import { navigate } from 'state/ui/actions';
 import request from 'woocommerce/state/sites/http-request';
 import {
@@ -48,6 +49,7 @@ const onDeleteError = ( action, error ) => dispatch => {
 const onDeleteSuccess = action => dispatch => {
 	const { siteId, siteSlug, orderId } = action;
 	dispatch( deleteOrderSuccess( siteId, orderId ) );
+	dispatch( fetchCounts( siteId ) );
 	dispatch( navigate( `/store/orders/${ siteSlug }` ) );
 	dispatch( successNotice( translate( 'Order deleted.' ), { duration: 8000 } ) );
 };
@@ -119,6 +121,7 @@ export function onOrderSaveSuccess( { dispatch }, action, { data } ) {
 	if ( 'function' === typeof action.onSuccess && 'undefined' !== typeof data.id ) {
 		action.onSuccess( dispatch, data.id );
 	}
+	dispatch( fetchCounts( siteId ) );
 	dispatch( saveOrderSuccess( siteId, orderId, data ) );
 }
 

--- a/client/extensions/woocommerce/state/data-layer/products/index.js
+++ b/client/extensions/woocommerce/state/data-layer/products/index.js
@@ -12,15 +12,16 @@ import warn from 'lib/warn';
  */
 import { dispatchWithProps } from 'woocommerce/state/helpers';
 import { dispatchRequest } from 'woocommerce/state/wc-api/utils';
-import { get, post, put } from 'woocommerce/state/data-layer/request/actions';
-import { setError } from 'woocommerce/state/sites/status/wc-api/actions';
+import { fetchCounts } from 'woocommerce/state/sites/data/counts/actions';
 import {
 	fetchProducts,
 	fetchProductsFailure,
 	productUpdated,
 	productsUpdated,
 } from 'woocommerce/state/sites/products/actions';
+import { get, post, put } from 'woocommerce/state/data-layer/request/actions';
 import request from 'woocommerce/state/sites/http-request';
+import { setError } from 'woocommerce/state/sites/status/wc-api/actions';
 import {
 	WOOCOMMERCE_PRODUCT_CREATE,
 	WOOCOMMERCE_PRODUCT_UPDATE,
@@ -60,6 +61,7 @@ export function apiError( { dispatch }, action, error ) {
 function updatedAction( siteId, originatingAction, successAction, sentData ) {
 	return ( dispatch, getState, { data: receivedData } ) => {
 		dispatch( productUpdated( siteId, receivedData, originatingAction ) );
+		dispatch( fetchCounts( siteId ) );
 
 		const props = { sentData, receivedData };
 		dispatchWithProps( dispatch, getState, successAction, props );

--- a/client/extensions/woocommerce/state/data-layer/products/index.js
+++ b/client/extensions/woocommerce/state/data-layer/products/index.js
@@ -12,7 +12,6 @@ import warn from 'lib/warn';
  */
 import { dispatchWithProps } from 'woocommerce/state/helpers';
 import { dispatchRequest } from 'woocommerce/state/wc-api/utils';
-import { fetchCounts } from 'woocommerce/state/sites/data/counts/actions';
 import {
 	fetchProducts,
 	fetchProductsFailure,
@@ -61,7 +60,6 @@ export function apiError( { dispatch }, action, error ) {
 function updatedAction( siteId, originatingAction, successAction, sentData ) {
 	return ( dispatch, getState, { data: receivedData } ) => {
 		dispatch( productUpdated( siteId, receivedData, originatingAction ) );
-		dispatch( fetchCounts( siteId ) );
 
 		const props = { sentData, receivedData };
 		dispatchWithProps( dispatch, getState, successAction, props );

--- a/client/extensions/woocommerce/state/sites/data/counts/reducer.js
+++ b/client/extensions/woocommerce/state/sites/data/counts/reducer.js
@@ -2,24 +2,34 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import {
 	WOOCOMMERCE_COUNT_REQUEST,
 	WOOCOMMERCE_COUNT_REQUEST_SUCCESS,
 	WOOCOMMERCE_COUNT_REQUEST_FAILURE,
 } from 'woocommerce/state/action-types';
-import { LOADING } from 'woocommerce/state/constants';
 
-export default createReducer( null, {
-	[ WOOCOMMERCE_COUNT_REQUEST ]: () => {
-		return LOADING;
-	},
+export function isLoading( state = {}, action ) {
+	switch ( action.type ) {
+		case WOOCOMMERCE_COUNT_REQUEST:
+		case WOOCOMMERCE_COUNT_REQUEST_SUCCESS:
+		case WOOCOMMERCE_COUNT_REQUEST_FAILURE:
+			return WOOCOMMERCE_COUNT_REQUEST === action.type;
+		default:
+			return state;
+	}
+}
 
-	[ WOOCOMMERCE_COUNT_REQUEST_SUCCESS ]: ( state, { counts } ) => {
-		return counts;
-	},
+export function items( state = {}, action ) {
+	switch ( action.type ) {
+		case WOOCOMMERCE_COUNT_REQUEST_SUCCESS:
+			return action.counts;
+		default:
+			return state;
+	}
+}
 
-	[ WOOCOMMERCE_COUNT_REQUEST_FAILURE ]: () => {
-		return false;
-	},
+export default combineReducers( {
+	isLoading,
+	items,
 } );

--- a/client/extensions/woocommerce/state/sites/data/counts/selectors.js
+++ b/client/extensions/woocommerce/state/sites/data/counts/selectors.js
@@ -8,18 +8,7 @@ import { get, reduce } from 'lodash';
  * Internal dependencies
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { LOADING } from 'woocommerce/state/constants';
 import { statusWaitingPayment, statusWaitingFulfillment } from 'woocommerce/lib/order-status';
-
-/**
- * @param {Object} state Whole Redux state tree
- * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
- * @return {Array} The count data, as retrieved from the server. It can also be the string "LOADING" if the
- * counts are currently being fetched, or a "falsy" value if that haven't been fetched at all.
- */
-const getRawData = ( state, siteId = getSelectedSiteId( state ) ) => {
-	return get( state, `extensions.woocommerce.sites[${ siteId }].data.counts` );
-};
 
 /**
  * @param {Object} state Whole Redux state tree
@@ -27,8 +16,8 @@ const getRawData = ( state, siteId = getSelectedSiteId( state ) ) => {
  * @return {boolean} Whether the count data is already loaded for this site
  */
 export const areCountsLoaded = ( state, siteId = getSelectedSiteId( state ) ) => {
-	const counts = getRawData( state, siteId );
-	return 'not-loaded' !== get( counts, 'products', 'not-loaded' );
+	const isLoading = get( state, `extensions.woocommerce.sites[${ siteId }].data.counts.isLoading` );
+	return false === isLoading;
 };
 
 /**
@@ -37,7 +26,8 @@ export const areCountsLoaded = ( state, siteId = getSelectedSiteId( state ) ) =>
  * @return {boolean} Whether the count data is currently being retrieved from the server
  */
 export const areCountsLoading = ( state, siteId = getSelectedSiteId( state ) ) => {
-	return LOADING === getRawData( state, siteId );
+	const isLoading = get( state, `extensions.woocommerce.sites[${ siteId }].data.counts.isLoading` );
+	return true === isLoading;
 };
 
 /**
@@ -46,8 +36,8 @@ export const areCountsLoading = ( state, siteId = getSelectedSiteId( state ) ) =
  * @return {Number} The total number of products on this site
  */
 export const getCountProducts = ( state, siteId = getSelectedSiteId( state ) ) => {
-	const counts = getRawData( state, siteId );
-	return get( counts, 'products.all', 0 );
+	const items = get( state, `extensions.woocommerce.sites[${ siteId }].data.counts.items`, {} );
+	return get( items, 'products.all', 0 );
 };
 
 /**
@@ -56,9 +46,9 @@ export const getCountProducts = ( state, siteId = getSelectedSiteId( state ) ) =
  * @return {Number} The total number of not-finished orders (awaiting payment & fulfullment) on this site
  */
 export const getCountNewOrders = ( state, siteId = getSelectedSiteId( state ) ) => {
-	const counts = getRawData( state, siteId );
+	const items = get( state, `extensions.woocommerce.sites[${ siteId }].data.counts.items`, {} );
 	const statuses = [ ...statusWaitingPayment, ...statusWaitingFulfillment ].map( s => `wc-${ s }` );
-	return reduce( statuses, ( total, s ) => total + get( counts, `orders.${ s }`, 0 ), 0 );
+	return reduce( statuses, ( total, s ) => total + get( items, `orders.${ s }`, 0 ), 0 );
 };
 
 /**
@@ -67,6 +57,6 @@ export const getCountNewOrders = ( state, siteId = getSelectedSiteId( state ) ) 
  * @return {Number} The number of pending reviews on this site
  */
 export const getCountPendingReviews = ( state, siteId = getSelectedSiteId( state ) ) => {
-	const counts = getRawData( state, siteId );
-	return get( counts, 'reviews.awaiting_moderation', 0 );
+	const items = get( state, `extensions.woocommerce.sites[${ siteId }].data.counts.items`, {} );
+	return get( items, 'reviews.awaiting_moderation', 0 );
 };

--- a/client/extensions/woocommerce/state/sites/data/counts/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/data/counts/test/reducer.js
@@ -12,7 +12,6 @@ import {
 	WOOCOMMERCE_COUNT_REQUEST,
 	WOOCOMMERCE_COUNT_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
-import { LOADING } from 'woocommerce/state/constants';
 import reducer from 'woocommerce/state/sites/reducer';
 
 describe( 'reducer', () => {
@@ -24,7 +23,7 @@ describe( 'reducer', () => {
 		};
 
 		const newSiteData = reducer( {}, action );
-		expect( newSiteData[ siteId ].data.counts ).to.eql( LOADING );
+		expect( newSiteData[ siteId ].data.counts.isLoading ).to.be.true;
 	} );
 
 	test( 'should store data from the action', () => {
@@ -51,6 +50,6 @@ describe( 'reducer', () => {
 		};
 		const newState = reducer( {}, action );
 		expect( newState[ siteId ] ).to.exist;
-		expect( newState[ siteId ].data.counts ).to.deep.equal( counts );
+		expect( newState[ siteId ].data.counts.items ).to.deep.equal( counts );
 	} );
 } );

--- a/client/extensions/woocommerce/state/sites/data/counts/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/data/counts/test/selectors.js
@@ -14,14 +14,13 @@ import {
 	getCountPendingReviews,
 } from '../selectors';
 import count from './fixtures/count';
-import { LOADING } from 'woocommerce/state/constants';
 
-const stateWithCounts = counts => ( {
+const stateWithCounts = ( isLoading, items ) => ( {
 	extensions: {
 		woocommerce: {
 			sites: {
 				123: {
-					data: { counts },
+					data: { counts: { isLoading, items } },
 				},
 			},
 		},
@@ -34,45 +33,45 @@ const stateWithCounts = counts => ( {
 describe( 'selectors', () => {
 	describe( '#areCountsLoading', () => {
 		test( 'should return false when woocommerce state is not available.', () => {
-			expect( areCountsLoading( stateWithCounts( null ), 123 ) ).to.be.false;
+			expect( areCountsLoading( stateWithCounts( null, null ), 123 ) ).to.be.false;
 		} );
 
 		test( 'should return false when counts are loaded.', () => {
-			expect( areCountsLoading( stateWithCounts( count ), 123 ) ).to.be.false;
+			expect( areCountsLoading( stateWithCounts( false, count ), 123 ) ).to.be.false;
 		} );
 
 		test( 'should return true when counts are currently being fetched.', () => {
-			expect( areCountsLoading( stateWithCounts( LOADING ), 123 ) ).to.be.true;
+			expect( areCountsLoading( stateWithCounts( true, null ), 123 ) ).to.be.true;
 		} );
 	} );
 
 	describe( '#getCountProducts', () => {
 		test( 'should return 0 when counts are currently being fetched.', () => {
-			expect( getCountProducts( stateWithCounts( LOADING ), 123 ) ).to.eql( 0 );
+			expect( getCountProducts( stateWithCounts( true, null ), 123 ) ).to.eql( 0 );
 		} );
 
 		test( 'should return product count when counts are loaded.', () => {
-			expect( getCountProducts( stateWithCounts( count ), 123 ) ).to.eql( 5 );
+			expect( getCountProducts( stateWithCounts( false, count ), 123 ) ).to.eql( 5 );
 		} );
 	} );
 
 	describe( '#getCountNewOrders', () => {
 		test( 'should return 0 when counts are currently being fetched.', () => {
-			expect( getCountNewOrders( stateWithCounts( LOADING ), 123 ) ).to.eql( 0 );
+			expect( getCountNewOrders( stateWithCounts( true, null ), 123 ) ).to.eql( 0 );
 		} );
 
 		test( 'should return total of all non-finished orders when counts are loaded.', () => {
-			expect( getCountNewOrders( stateWithCounts( count ), 123 ) ).to.eql( 6 );
+			expect( getCountNewOrders( stateWithCounts( false, count ), 123 ) ).to.eql( 6 );
 		} );
 	} );
 
 	describe( '#getCountPendingReviews', () => {
 		test( 'should return 0 when counts are currently being fetched.', () => {
-			expect( getCountPendingReviews( stateWithCounts( LOADING ), 123 ) ).to.eql( 0 );
+			expect( getCountPendingReviews( stateWithCounts( true, null ), 123 ) ).to.eql( 0 );
 		} );
 
 		test( 'should return pending review count when counts are loaded.', () => {
-			expect( getCountPendingReviews( stateWithCounts( count ), 123 ) ).to.eql( 1 );
+			expect( getCountPendingReviews( stateWithCounts( false, count ), 123 ) ).to.eql( 1 );
 		} );
 	} );
 } );

--- a/client/extensions/woocommerce/state/sites/reviews/handlers.js
+++ b/client/extensions/woocommerce/state/sites/reviews/handlers.js
@@ -15,6 +15,7 @@ import { bypassDataLayer } from 'state/data-layer/utils';
 import { DEFAULT_QUERY } from './utils';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
+import { fetchCounts } from 'woocommerce/state/sites/data/counts/actions';
 import { fetchReviews } from 'woocommerce/state/sites/reviews/actions';
 import {
 	getReviewsCurrentPage,
@@ -131,6 +132,7 @@ export function handleChangeReviewStatusSuccess( { dispatch, getState }, action 
 	};
 	const defaultMessage = translate( 'Review status updated' );
 
+	dispatch( fetchCounts( siteId ) );
 	dispatch(
 		successNotice( get( message, newStatus, defaultMessage ), {
 			duration: 5000,


### PR DESCRIPTION
This PR builds on #23597, #23599, and woocommerce/wc-api-dev#100, to remove calls to the `orders`, `products`, and `reviews` endpoints on the sidebar & dashboard. This data was only used to display counts, and can be replaced with a single API call using the new `/data/counts` endpoint in woocommerce/wc-api-dev#100.

This PR _does_ remove the total pending revenue count from the manage orders view, which should be OK once the stats widget is launched.

<img width="955" alt="screen shot 2018-03-23 at 11 52 02 am" src="https://user-images.githubusercontent.com/541093/37839405-be43d994-2e90-11e8-8ee0-9fd303b2eef9.png">

_Note:_ This updates the counts reducer, so that the loading state does not blow away the existing count information – otherwise, re-fetching after orders/reviews changes makes the count disappear/reappear, rather than seamlessly update.

**To test**

- Load up any store page, `/store/settings/:site` is a good test
- Check that the sidebar renders the correct counts
- Check that there were no requests to the remote site's orders, products, or reviews endpoint
- Load the dashboard
- The correct widgets for your store's state should be showing:
  - If you have orders pending, you'll see the right number in "X ✨New order"
  - If you have reviews pending, you'll see the right number in "X pending review"
  - If you have neither, you'll see the "Your store is ready, the world awaits!" dashboard
- Make a change that should affect the orders or reviews count
  - If you have pending orders, fulfill one – you should see the sidebar number go down after the order successfully updates
  - If you have reviews pending, approve one – you should see the review count go down
