### PR TITLE
JP Remote Install: CSS tweaks

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -626,7 +626,6 @@
 }
 
 .jetpack-connect__credentials-submit {
-	margin-bottom: 20px;
 	transition: none;
 
 	&.is-error,
@@ -666,7 +665,9 @@
 }
 
 .jetpack-connect__password-form-input {
-	text-indent: 27px;
+	&[type='password'] {
+		padding-left: 40px;
+	}
 }
 
 .jetpack-connect__creds-form-spinner {


### PR DESCRIPTION
* Remove the excess margin under install button
* Prevent password chars displaying under lock icon

**Before**
<img width="300" alt="screen shot 2018-03-23 at 17 29 38" src="https://user-images.githubusercontent.com/7767559/37844775-b51fe3b4-2ec0-11e8-8fe2-cc278fb3a8ee.png">

**After**
<img width="300" alt="screen shot 2018-03-23 at 17 24 28" src="https://user-images.githubusercontent.com/7767559/37844785-baaf972a-2ec0-11e8-96a1-e29c02c595db.png">

## Testing
* Go to https://calypso.live/jetpack/install?branch=update/jp-remote-install/css-fixes
* Enter URL of dotorg site without jetpack installed
* Check the spacing and password entry behaviour look good and match screenshots
