### PR TITLE
Jetpack Onboarding: Update copy on site type step of JPO

### DIFF
--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -46,7 +46,7 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 					<Tile
 						buttonLabel={ translate( 'Personal site' ) }
 						description={ translate(
-							'To share your ideas, stories, photographs, or creative projects with your followers.'
+							'Share your ideas, stories, photographs, or creative projects with your followers.'
 						) }
 						image={ '/calypso/images/illustrations/type-personal.svg' }
 						highlighted={ siteType === 'personal' }
@@ -57,7 +57,7 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 					<Tile
 						buttonLabel={ translate( 'Business site' ) }
 						description={ translate(
-							'To promote your business, organization, or brand, sell products or services, or connect with your audience.'
+							'Promote your business, organization, or brand, sell products or services, or connect with your audience.'
 						) }
 						image={ '/calypso/images/illustrations/type-business.svg' }
 						highlighted={ siteType === 'business' }


### PR DESCRIPTION
This super quick and easy PR updates the copy on the site type step from “To share your ideas…” and “To promote your business” to “Share your ideas…” and “Promote your business…” as suggested in p1HpG7-4WU#comment-25242.

**Before:**
"To share your ideas, stories, photographs, or creative projects with your followers."
and
"To promote your business, organization, or brand, sell products or services, or connect with your audience."
<img width="720" alt="screen shot 2018-03-23 at 11 52 59 am" src="https://user-images.githubusercontent.com/204742/37845679-dd967194-2e90-11e8-8e3c-82de2fe7e0ce.png">

**After:**
"Share your ideas, stories, photographs, or creative projects with your followers."
and
"Promote your business, organization, or brand, sell products or services, or connect with your audience."
<img width="689" alt="screen shot 2018-03-23 at 11 52 22 am" src="https://user-images.githubusercontent.com/204742/37845694-ec68ae58-2e90-11e8-8d3c-cd0bc94bfc75.png">


**Testing instructions:**
* Checkout this branch
* Pick a Jetpack site.
* Head to /wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development on the Jetpack site to start the onboarding flow.
* On Step 2, the site type step, confirm the changes match the "After" copy above.