### PR TITLE
Analytics: Add missing site fields needed for stats reporting.

### DIFF
--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -16,7 +16,6 @@ export const SITE_REQUEST_FIELDS = [
 	'single_user_site',
 	'visible',
 	'lang',
-	'post_count',
 ].join();
 
 export const SITE_REQUEST_OPTIONS = [

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -15,6 +15,8 @@ export const SITE_REQUEST_FIELDS = [
 	'plan',
 	'single_user_site',
 	'visible',
+	'lang',
+	'post_count',
 ].join();
 
 export const SITE_REQUEST_OPTIONS = [

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -56,6 +56,8 @@ export const sitesSchema = {
 						wp_version: { type: 'string' },
 					},
 				},
+				lang: { type: 'string' },
+				post_count: { type: 'number' },
 			},
 		},
 	},

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -57,7 +57,6 @@ export const sitesSchema = {
 					},
 				},
 				lang: { type: 'string' },
-				post_count: { type: 'number' },
 			},
 		},
 	},


### PR DESCRIPTION
Tracks [super-props](https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/super-props.js) have `blog_lang` and `post_count` properties that are all `undefined` at the moment; this has probably been the case since #14096.

![screen shot 2018-03-23 at 1 09 42 pm](https://user-images.githubusercontent.com/349751/37851422-05cb084a-2e9c-11e8-8ddd-c7cb7bd21a81.png)

Adding the required fields back in when fetching sites allows them to be picked up again:

![screen shot 2018-03-23 at 1 10 01 pm](https://user-images.githubusercontent.com/349751/37851416-ffc02a66-2e9b-11e8-865f-19ff1f6e419d.png)

**Testing**
* set `localStorage.setItem('debug', 'calypso:analytics:tracks')` in your console
* trigger a page view, open the "recording event" event, and notice the `undefined` props
* Apply this PR and reload Calypso
* trigger a page view again, and verify the props are now properly set

To verify the Jetpack Connect changes:
* fire up a new WP+Jetpack site at https://jurassic.ninja
* load https://calypso.localhost:3000/jetpack/connect
* enter your new JP site, complete the connection and plan process
* in the console, use `state.sites.items` to find your new site, and verify it has the `lang` and `post_count` properties