### PR TITLE
SectionNav: Replace external noticon with gridicon

### DIFF
--- a/client/components/section-nav/item.jsx
+++ b/client/components/section-nav/item.jsx
@@ -7,6 +7,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Gridicon from 'gridicons';
 
 /**
  * Internal Dependencies
@@ -80,6 +81,7 @@ class NavItem extends PureComponent {
 							<Count count={ this.props.count } compact={ this.props.compactCount } />
 						) }
 					</span>
+					{ this.props.isExternalLink ? <Gridicon icon="external" size={ 18 } /> : null }
 				</a>
 			</li>
 		);

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -291,10 +291,9 @@
 	}
 
 	.is-external & {
-		&:after {
-			@include noticon('\f442');
-			font-size: 18px;
-			padding-left: 2px;
+		.gridicons-external {
+			vertical-align: text-bottom;
+			margin-left: 3px;
 		}
 	}
 


### PR DESCRIPTION
This adds a condition. If the link is external, display an external
gridicon. This removes the need for the noticon.

To test:
I don't think there is an instance of this in Calypso, so I just manually added `isExternalLink` to true.

Before
![screen shot 2018-03-23 at 3 17 14 pm](https://user-images.githubusercontent.com/618551/37851566-683f91ba-2ead-11e8-9af4-9a83542b2f2f.png)


After
![mar-23-2018 15-12-32](https://user-images.githubusercontent.com/618551/37851482-0c16465e-2ead-11e8-9718-07279870d281.gif)
