### PR TITLE
Settings: update content in info popovers

### DIFF
--- a/client/my-sites/site-settings/comment-display-settings/index.jsx
+++ b/client/my-sites/site-settings/comment-display-settings/index.jsx
@@ -17,6 +17,8 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormSelect from 'components/forms/form-select';
 import FormTextInput from 'components/forms/form-text-input';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
+import InfoPopover from 'components/info-popover';
+import ExternalLink from 'components/external-link';
 import { isJetpackModuleActive } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
@@ -31,6 +33,21 @@ class CommentDisplaySettings extends Component {
 
 		return (
 			<FormFieldset className="comment-display-settings">
+				<div className="comment-display-settings__info site-settings__info-link-container">
+					<InfoPopover position="left">
+						{ translate(
+							'Replaces the standard WordPress comment form with a new comment system ' +
+								'that includes social media login options.'
+						) }{' '}
+						<ExternalLink
+							target="_blank"
+							icon={ false }
+							href="https://jetpack.com/support/comments"
+						>
+							{ translate( 'Learn more' ) }
+						</ExternalLink>
+					</InfoPopover>
+				</div>
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }
 					moduleSlug="comments"

--- a/client/my-sites/site-settings/composing/after-the-deadline.jsx
+++ b/client/my-sites/site-settings/composing/after-the-deadline.jsx
@@ -220,12 +220,16 @@ class AfterTheDeadline extends Component {
 				<div className="composing__module-settings site-settings__child-settings">
 					<div className="composing__info-link-container site-settings__info-link-container">
 						<InfoPopover position="left">
+							{ translate(
+								'Checks your content for correct grammar and spelling, ' +
+									'misused words, and style while you write.'
+							) }{' '}
 							<ExternalLink
 								href="https://jetpack.com/support/spelling-and-grammar/"
-								icon
+								icon={ false }
 								target="_blank"
 							>
-								{ translate( 'Learn more about After the Deadline.' ) }
+								{ translate( 'Learn more' ) }
 							</ExternalLink>
 						</InfoPopover>
 					</div>

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -172,9 +172,44 @@ class CustomContentTypes extends Component {
 							</ExternalLink>
 						</InfoPopover>
 					</div>
-
 					{ this.renderBlogPostSettings() }
+				</FormFieldset>
+
+				<FormFieldset>
+					<div className="custom-content-types__info-link-container site-settings__info-link-container">
+						<InfoPopover position="left">
+							{ translate(
+								'Adds the Testimonial custom post type, allowing you to collect, organize, ' +
+									'and display testimonials on your site.'
+							) }{' '}
+							<ExternalLink
+								target="_blank"
+								icon
+								href="https://jetpack.com/support/custom-content-types/"
+							>
+								{ translate( 'Learn more' ) }
+							</ExternalLink>
+						</InfoPopover>
+					</div>
 					{ this.renderTestimonialSettings() }
+				</FormFieldset>
+
+				<FormFieldset>
+					<div className="custom-content-types__info-link-container site-settings__info-link-container">
+						<InfoPopover position="left">
+							{ translate(
+								'Adds the Portfolio custom post type, allowing you to ' +
+									'manage and showcase projects on your site.'
+							) }{' '}
+							<ExternalLink
+								target="_blank"
+								icon
+								href="https://jetpack.com/support/custom-content-types/"
+							>
+								{ translate( 'Learn more' ) }
+							</ExternalLink>
+						</InfoPopover>
+					</div>
 					{ this.renderPortfolioSettings() }
 				</FormFieldset>
 			</Card>

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -184,7 +184,7 @@ class CustomContentTypes extends Component {
 							) }{' '}
 							<ExternalLink
 								target="_blank"
-								icon
+								icon={ false }
 								href="https://jetpack.com/support/custom-content-types/"
 							>
 								{ translate( 'Learn more' ) }
@@ -203,7 +203,7 @@ class CustomContentTypes extends Component {
 							) }{' '}
 							<ExternalLink
 								target="_blank"
-								icon
+								icon={ false }
 								href="https://jetpack.com/support/custom-content-types/"
 							>
 								{ translate( 'Learn more' ) }

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -163,12 +163,14 @@ class CustomContentTypes extends Component {
 				<FormFieldset>
 					<div className="custom-content-types__info-link-container site-settings__info-link-container">
 						<InfoPopover position="left">
+							{ translate( 'Showcases your portfolio or displays testimonials on your site.' ) +
+								' ' }
 							<ExternalLink
 								href="https://support.wordpress.com/custom-post-types/"
-								icon
+								icon={ false }
 								target="_blank"
 							>
-								{ translate( 'Learn more about Custom Content Types.' ) }
+								{ translate( 'Learn more' ) }
 							</ExternalLink>
 						</InfoPopover>
 					</div>

--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -141,8 +141,13 @@ class SiteSettingsFormJetpackMonitor extends Component {
 				<Card className="jetpack-monitor-settings">
 					<div className="site-settings__info-link-container">
 						<InfoPopover position="left">
-							<ExternalLink href="https://jetpack.com/support/monitor/" icon target="_blank">
-								{ translate( 'Learn more about downtime monitoring' ) }
+							{ translate( "Notifies you when there's an issue with your site." ) }{' '}
+							<ExternalLink
+								href="https://jetpack.com/support/monitor/"
+								icon={ false }
+								target="_blank"
+							>
+								{ translate( 'Learn more' ) }
 							</ExternalLink>
 						</InfoPopover>
 					</div>

--- a/client/my-sites/site-settings/jetpack-ads.jsx
+++ b/client/my-sites/site-settings/jetpack-ads.jsx
@@ -83,8 +83,9 @@ class JetpackAds extends Component {
 			<div>
 				<div className="site-settings__info-link-container">
 					<InfoPopover position="left">
-						<ExternalLink href="https://jetpack.com/support/ads" icon target="_blank">
-							{ translate( 'Learn more about Ads.' ) }
+						{ translate( 'Displays high-quality ads on your site that allow you to earn income.' ) }{' '}
+						<ExternalLink href="https://jetpack.com/support/ads" icon={ false } target="_blank">
+							{ translate( 'Learn more' ) }
 						</ExternalLink>
 					</InfoPopover>
 				</div>

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -132,11 +132,15 @@ class JetpackSiteStats extends Component {
 					<FormFieldset>
 						<div className="site-settings__info-link-container">
 							<InfoPopover position="left">
+								{ translate(
+									'Displays information on your site activity, ' +
+										'including visitors and popular posts or pages.'
+								) }{' '}
 								<ExternalLink
 									href="https://jetpack.com/support/wordpress-com-stats/"
 									target="_blank"
 								>
-									{ translate( 'Learn more about WordPress.com Stats' ) }
+									{ translate( 'Learn more' ) }
 								</ExternalLink>
 							</InfoPopover>
 						</div>

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -138,6 +138,7 @@ class JetpackSiteStats extends Component {
 								) }{' '}
 								<ExternalLink
 									href="https://jetpack.com/support/wordpress-com-stats/"
+									icon={ false }
 									target="_blank"
 								>
 									{ translate( 'Learn more' ) }

--- a/client/my-sites/site-settings/masterbar.jsx
+++ b/client/my-sites/site-settings/masterbar.jsx
@@ -39,8 +39,16 @@ const Masterbar = ( {
 				<FormFieldset>
 					<div className="masterbar__info-link-container site-settings__info-link-container">
 						<InfoPopover position="left">
-							<ExternalLink href="https://jetpack.com/support/masterbar/" icon target="_blank">
-								{ translate( 'Learn more about the WordPress.com Toolbar.' ) }
+							{ translate(
+								'Adds a toolbar with links to all your sites, notifications, ' +
+									'your WordPress.com profile, and the Reader.'
+							) }{' '}
+							<ExternalLink
+								href="https://jetpack.com/support/masterbar/"
+								icon={ false }
+								target="_blank"
+							>
+								{ translate( 'Learn more' ) }
 							</ExternalLink>
 						</InfoPopover>
 					</div>

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -82,8 +82,13 @@ class MediaSettings extends Component {
 				<FormFieldset className="site-settings__formfieldset has-divider is-top-only">
 					<div className="site-settings__info-link-container">
 						<InfoPopover position="left">
-							<ExternalLink target="_blank" icon href="https://jetpack.com/support/videopress/">
-								{ translate( 'Learn more about VideoPress.' ) }
+							{ translate( 'Hosts your video files on the global WordPress.com servers.' ) }{' '}
+							<ExternalLink
+								target="_blank"
+								icon={ false }
+								href="https://jetpack.com/support/videopress/"
+							>
+								{ translate( 'Learn more' ) }
 							</ExternalLink>
 						</InfoPopover>
 					</div>
@@ -197,7 +202,12 @@ class MediaSettings extends Component {
 						<FormFieldset>
 							<div className="site-settings__info-link-container">
 								<InfoPopover position="left">
-									<ExternalLink target="_blank" icon href="https://jetpack.com/support/photon">
+									{ translate( 'Hosts your image files on the global WordPress.com servers.' ) }{' '}
+									<ExternalLink
+										target="_blank"
+										icon={ false }
+										href="https://jetpack.com/support/photon"
+									>
 										{ translate( 'Learn more' ) }
 									</ExternalLink>
 								</InfoPopover>
@@ -214,8 +224,16 @@ class MediaSettings extends Component {
 					<FormFieldset className={ carouselFieldsetClasses }>
 						<div className="site-settings__info-link-container">
 							<InfoPopover position="left">
-								<ExternalLink target="_blank" icon href="https://jetpack.com/support/carousel">
-									{ translate( 'Learn more about Carousel.' ) }
+								{ translate(
+									'Replaces the standard WordPress galleries with a ' +
+										'full-screen photo browsing experience, including comments and EXIF metadata.'
+								) }{' '}
+								<ExternalLink
+									target="_blank"
+									icon={ false }
+									href="https://jetpack.com/support/carousel"
+								>
+									{ translate( 'Learn more' ) }
 								</ExternalLink>
 							</InfoPopover>
 						</div>

--- a/client/my-sites/site-settings/protect.jsx
+++ b/client/my-sites/site-settings/protect.jsx
@@ -125,8 +125,15 @@ class Protect extends Component {
 					<div className="protect__module-settings site-settings__child-settings">
 						<div className="protect__info-link-container site-settings__info-link-container">
 							<InfoPopover position="left">
-								<ExternalLink href="https://jetpack.com/support/protect" target="_blank">
-									{ translate( 'Learn more about Jetpack protect' ) }
+								{ translate(
+									'Protects your site from traditional and distributed brute force login attacks.'
+								) }{' '}
+								<ExternalLink
+									href="https://jetpack.com/support/protect"
+									icon={ false }
+									target="_blank"
+								>
+									{ translate( 'Learn more' ) }
 								</ExternalLink>
 							</InfoPopover>
 						</div>

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -120,8 +120,15 @@ class PublishingTools extends Component {
 			<FormFieldset>
 				<div className="publishing-tools__info-link-container site-settings__info-link-container">
 					<InfoPopover position="left">
-						<ExternalLink href="https://jetpack.com/support/post-by-email/" icon target="_blank">
-							{ translate( 'Learn more about Post by Email.' ) }
+						{ translate(
+							'Allows you to publish new posts by sending an email to a special address.'
+						) }{' '}
+						<ExternalLink
+							href="https://jetpack.com/support/post-by-email/"
+							icon={ false }
+							target="_blank"
+						>
+							{ translate( 'Learn more' ) }
 						</ExternalLink>
 					</InfoPopover>
 				</div>

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -15,6 +15,8 @@ import Card from 'components/card';
 import FormFieldset from 'components/forms/form-fieldset';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import SectionHeader from 'components/section-header';
+import InfoPopover from 'components/info-popover';
+import ExternalLink from 'components/external-link';
 import RelatedContentPreview from './related-content-preview';
 
 const RelatedPosts = ( {
@@ -30,6 +32,19 @@ const RelatedPosts = ( {
 
 			<Card className="related-posts__card site-settings__traffic-settings">
 				<FormFieldset>
+					<div className="related-posts__info site-settings__info-link-container">
+						<InfoPopover position="left">
+							{ translate( 'Automatically displays similar content at the end of each post.' ) }{' '}
+							<ExternalLink
+								href="https://jetpack.com/support/related-posts/"
+								icon={ false }
+								target="_blank"
+							>
+								{ translate( 'Learn more' ) }
+							</ExternalLink>
+						</InfoPopover>
+					</div>
+
 					<CompactFormToggle
 						checked={ !! fields.jetpack_relatedposts_enabled }
 						disabled={ isRequestingSettings || isSavingSettings }

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -52,8 +52,11 @@ class Search extends Component {
 		return (
 			<div className="search__info-link-container site-settings__info-link-container">
 				<InfoPopover position="left">
-					<ExternalLink href={ url } icon target="_blank">
-						{ translate( 'Learn more about Search.' ) }
+					{ translate(
+						'Replaces the default WordPress search with a faster, filterable search experience.'
+					) }{' '}
+					<ExternalLink href={ url } icon={ false } target="_blank">
+						{ translate( 'Learn more' ) }
 					</ExternalLink>
 				</InfoPopover>
 			</div>

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -15,6 +15,7 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Card from 'components/card';
+import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 import FormInput from 'components/forms/form-text-input-with-affixes';
 import FormInputValidation from 'components/forms/form-input-validation';
@@ -307,6 +308,22 @@ class SiteVerification extends Component {
 				<Card>
 					{ siteIsJetpack && (
 						<FormFieldset>
+							<div className="seo-settings__info site-settings__info-link-container">
+								<InfoPopover position="left">
+									{ translate(
+										'Provides the necessary hidden tags needed to ' +
+											'verify your WordPress site with various services.'
+									) }{' '}
+									<ExternalLink
+										href="https://jetpack.com/support/site-verification-tools"
+										icon={ false }
+										target="_blank"
+									>
+										{ translate( 'Learn more' ) }
+									</ExternalLink>
+								</InfoPopover>
+							</div>
+
 							<JetpackModuleToggle
 								siteId={ siteId }
 								moduleSlug="verification-tools"

--- a/client/my-sites/site-settings/sitemaps.jsx
+++ b/client/my-sites/site-settings/sitemaps.jsx
@@ -62,8 +62,11 @@ class Sitemaps extends Component {
 		return (
 			<div className="sitemaps__info-link-container site-settings__info-link-container">
 				<InfoPopover position="left">
-					<ExternalLink href={ url } icon target="_blank">
-						{ translate( 'Learn more about Sitemaps.' ) }
+					{ translate(
+						'Automatically generates the files required for search engines to index your site.'
+					) }{' '}
+					<ExternalLink href={ url } icon={ false } target="_blank">
+						{ translate( 'Learn more' ) }
 					</ExternalLink>
 				</InfoPopover>
 			</div>

--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -97,12 +97,13 @@ const SpamFilteringSettings = ( {
 				<div className="spam-filtering__settings site-settings__child-settings">
 					<div className="spam-filtering__info-link-container site-settings__info-link-container">
 						<InfoPopover>
+							{ translate( 'Removes spam from comments and contact forms.' ) }{' '}
 							<ExternalLink
 								target="_blank"
-								icon
+								icon={ false }
 								href={ 'https://jetpack.com/features/security/spam-filtering/' }
 							>
-								{ translate( 'Learn more about spam filtering.' ) }
+								{ translate( 'Learn more' ) }
 							</ExternalLink>
 						</InfoPopover>
 					</div>

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -53,6 +53,7 @@ class SpeedUpSiteSettings extends Component {
 					<FormFieldset className="site-settings__formfieldset">
 						<div className="site-settings__info-link-container">
 							<InfoPopover position="left">
+								{ translate( 'Hosts your image files on the global WordPress.com servers.' ) }{' '}
 								<ExternalLink target="_blank" icon href="https://jetpack.com/support/photon">
 									{ translate( 'Learn more' ) }
 								</ExternalLink>
@@ -75,6 +76,9 @@ class SpeedUpSiteSettings extends Component {
 						<FormFieldset className="site-settings__formfieldset has-divider is-top-only">
 							<div className="site-settings__info-link-container">
 								<InfoPopover position="left">
+									{ translate(
+										"Delays the loading of images until they are visible in the visitor's browser."
+									) }{' '}
 									<ExternalLink target="_blank" icon href="https://jetpack.com/support/lazy-images">
 										{ translate( 'Learn more' ) }
 									</ExternalLink>

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -54,7 +54,11 @@ class SpeedUpSiteSettings extends Component {
 						<div className="site-settings__info-link-container">
 							<InfoPopover position="left">
 								{ translate( 'Hosts your image files on the global WordPress.com servers.' ) }{' '}
-								<ExternalLink target="_blank" icon href="https://jetpack.com/support/photon">
+								<ExternalLink
+									target="_blank"
+									icon={ false }
+									href="https://jetpack.com/support/photon"
+								>
 									{ translate( 'Learn more' ) }
 								</ExternalLink>
 							</InfoPopover>
@@ -79,7 +83,11 @@ class SpeedUpSiteSettings extends Component {
 									{ translate(
 										"Delays the loading of images until they are visible in the visitor's browser."
 									) }{' '}
-									<ExternalLink target="_blank" icon href="https://jetpack.com/support/lazy-images">
+									<ExternalLink
+										target="_blank"
+										icon={ false }
+										href="https://jetpack.com/support/lazy-images"
+									>
 										{ translate( 'Learn more' ) }
 									</ExternalLink>
 								</InfoPopover>

--- a/client/my-sites/site-settings/sso.jsx
+++ b/client/my-sites/site-settings/sso.jsx
@@ -44,8 +44,11 @@ const Sso = ( {
 				<FormFieldset>
 					<div className="sso__info-link-container site-settings__info-link-container">
 						<InfoPopover position="left">
-							<ExternalLink href="https://jetpack.com/support/sso" icon target="_blank">
-								{ translate( 'Learn more about WordPress.com Secure Sign On.' ) }
+							{ translate(
+								'Allows registered users to log in to your site with their WordPress.com accounts.'
+							) }
+							<ExternalLink href="https://jetpack.com/support/sso" icon={ false } target="_blank">
+								{ translate( 'Learn more' ) }
 							</ExternalLink>
 						</InfoPopover>
 					</div>

--- a/client/my-sites/site-settings/subscriptions.jsx
+++ b/client/my-sites/site-settings/subscriptions.jsx
@@ -45,8 +45,16 @@ const Subscriptions = ( {
 				<FormFieldset>
 					<div className="subscriptions__info-link-container site-settings__info-link-container">
 						<InfoPopover position="left">
-							<ExternalLink href="https://jetpack.com/support/subscriptions" icon target="_blank">
-								{ translate( 'Learn more about Subscriptions.' ) }
+							{ translate(
+								'Allows readers to subscribe to your posts or comments, ' +
+									'and receive notifications of new content by email.'
+							) }{' '}
+							<ExternalLink
+								href="https://jetpack.com/support/subscriptions"
+								icon={ false }
+								target="_blank"
+							>
+								{ translate( 'Learn more' ) }
 							</ExternalLink>
 						</InfoPopover>
 					</div>

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -132,8 +132,15 @@ class ThemeEnhancements extends Component {
 
 				<div className="theme-enhancements__info-link-container site-settings__info-link-container">
 					<InfoPopover position="left">
-						<ExternalLink href="https://jetpack.com/support/infinite-scroll" icon target="_blank">
-							{ translate( 'Learn more about Infinite Scroll.' ) }
+						{ translate(
+							'Loads the next posts automatically when the reader approaches the bottom of the page.'
+						) }{' '}
+						<ExternalLink
+							href="https://jetpack.com/support/infinite-scroll"
+							icon={ false }
+							target="_blank"
+						>
+							{ translate( 'Learn more' ) }
 						</ExternalLink>
 					</InfoPopover>
 				</div>
@@ -165,8 +172,16 @@ class ThemeEnhancements extends Component {
 			<FormFieldset>
 				<div className="theme-enhancements__info-link-container site-settings__info-link-container">
 					<InfoPopover position="left">
-						<ExternalLink href="https://jetpack.com/support/mobile-theme" icon target="_blank">
-							{ translate( 'Learn more about Mobile Theme.' ) }
+						{ translate(
+							'Enables a lightweight, mobile-friendly theme ' +
+								'that will be displayed to visitors on mobile devices.'
+						) }{' '}
+						<ExternalLink
+							href="https://jetpack.com/support/mobile-theme"
+							icon={ false }
+							target="_blank"
+						>
+							{ translate( 'Learn more' ) }
 						</ExternalLink>
 					</InfoPopover>
 				</div>


### PR DESCRIPTION
Follow up of https://github.com/Automattic/jetpack/issues/8922 and https://github.com/Automattic/jetpack/pull/9137

This PR updates the popovers to add a short text, in addition to the usual Learn More link. It also introduces a popover in some setting groups that didn't have it, so they're consistent with Jetpack:
- Comments
- Related posts
- Site verification

<img width="734" alt="captura de pantalla 2018-03-23 a la s 17 07 49" src="https://user-images.githubusercontent.com/1041600/37852406-377ae174-2ec1-11e8-9c10-610932f43be3.png">
