### PR TITLE
Editor: TinyMCE: Remove noticons

### DIFF
--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -761,8 +761,14 @@ div.mce-path {
 	margin: 2px 0 0 -13px #{"/*rtl:ignore*/"};
 	border: none;
 	color: $gray;
+
+	// Displaying the icon by using an svg file is a temporary solution to remove Noticons. 
 	&::before {
-		@include noticon( '\f431' , 16px );
+		display: block;
+		content: url("/calypso/images/tinymce-icons/gridicons-chevron-down.svg");
+		width: 14px;
+		height: 14px;
+		transition: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 	}
 }
 
@@ -776,7 +782,7 @@ div.mce-path {
 
 .mce-panel .mce-active i.mce-caret {
 	&::before {
-		content: '\f432';
+		transform: rotate( 180deg );
 	}
 }
 

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -766,7 +766,7 @@ div.mce-path {
 }
 
 .mce-panel .mce-btn.mce-listbox i.mce-caret {
-	margin: 4px -2px 0 0;
+	margin: 6px -2px 0 0;
 }
 
 .mce-panel .mce-btn:hover i.mce-caret {

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -570,13 +570,6 @@ div.mce-path {
 
 .mce-path .mce-divider {
 	visibility: hidden;
-
-	&::before {
-		@include noticon( '\f429', 20px );
-		color: $gray;
-		margin: 0 -8px 0 4px;
-		visibility: visible;
-	}
 }
 
 .mce-path,
@@ -762,7 +755,7 @@ div.mce-path {
 	border: none;
 	color: $gray;
 
-	// Displaying the icon by using an svg file is a temporary solution to remove Noticons. 
+	// Displaying the icon by using an svg file is a temporary solution to remove Noticons.
 	&::before {
 		display: block;
 		content: url("/calypso/images/tinymce-icons/gridicons-chevron-down.svg");

--- a/public/images/tinymce-icons/gridicons-chevron-down.svg
+++ b/public/images/tinymce-icons/gridicons-chevron-down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="0" fill="none" width="24" height="24"/><g><path d="M20 9l-8 8-8-8 1.414-1.414L12 14.172l6.586-6.586"/></g></svg>

--- a/public/images/tinymce-icons/gridicons-chevron-down.svg
+++ b/public/images/tinymce-icons/gridicons-chevron-down.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="0" fill="none" width="24" height="24"/><g><path d="M20 9l-8 8-8-8 1.414-1.414L12 14.172l6.586-6.586"/></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="0" fill="none" width="24" height="24"/><g><path fill="#2e4453" d="M20 9l-8 8-8-8 1.414-1.414L12 14.172l6.586-6.586"/></g></svg>


### PR DESCRIPTION
This PR removes the need of noticons in the editor. The only visible noticon in the editor is the chevron icon:

Before|After
---|---
![screen shot 2018-03-23 at 7 18 07 pm](https://user-images.githubusercontent.com/618551/37858131-25667ae4-2ecf-11e8-8a7a-1ffcf0a2d273.png)|![screen shot 2018-03-23 at 7 18 14 pm](https://user-images.githubusercontent.com/618551/37858128-1c010c94-2ecf-11e8-976d-386cd62b2a25.png)

TinyMCE does not provide an easy way to use custom icons in the markup of the editor. Before, the noticon was being injected via a pseudo class in the css. In order to remove the noticon, I had to export an svg of the `chevron-down` gridicon and inject it like this:

```
content: url("/calypso/images/tinymce-icons/gridicons-chevron-down.svg");
```

Even though this is not ideal, we can at least remove the noticon. This should not be a problem once Gutenberg lands.

This PR also removes a seemingly unused bit of css that added an arrow noticon to TinyMCE's "path" feature:

![screen shot 2018-03-23 at 7 15 09 pm](https://user-images.githubusercontent.com/618551/37858208-fade8054-2ecf-11e8-9242-78e42559464d.png)

Because the editor doesn't seem to use this feature, I removed the css.