### PR TITLE
JPC: remote install- correct error type as returned from the WP REST endpoint.

### DIFF
--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -32,7 +32,7 @@ import { getConnectingSite } from 'state/jetpack-connect/selectors';
 import { REMOTE_PATH_AUTH } from './constants';
 
 import {
-	ACTIVATION_RESPONSE_FAILURE,
+	ACTIVATION_RESPONSE_ERROR,
 	INSTALL_RESPONSE_ERROR,
 	INVALID_PERMISSIONS,
 	LOGIN_FAILURE,
@@ -112,8 +112,8 @@ export class OrgCredentialsForm extends Component {
 		if ( installError === 'LOGIN_FAILURE' ) {
 			return LOGIN_FAILURE;
 		}
-		if ( installError === 'ACTIVATION_RESPONSE_FAILURE' ) {
-			return ACTIVATION_RESPONSE_FAILURE;
+		if ( installError === 'ACTIVATION_RESPONSE_ERROR' ) {
+			return ACTIVATION_RESPONSE_ERROR;
 		}
 		if ( installError === 'INSTALL_RESPONSE_ERROR' ) {
 			return INSTALL_RESPONSE_ERROR;


### PR DESCRIPTION
Fixes regression introduced in https://github.com/Automattic/wp-calypso/pull/23571 to use the correct error type for displaying notices on activation error for Jetpack remote install.

This patch corrects the naming mistake: the WP REST endpoint returns `'ACTIVATION_RESPONSE_ERROR'`  error type, instead of `'ACTIVATION_RESPONSE_FAILURE`.

## to test:
It is not a visual change. Positive outcome is suppressed warning `"export 'ACTIVATION_RESPONSE_FAILURE' was not found in './connection-notice-types'` (or any other warning connected to notices) when compiling Calypso locally.