### PR TITLE
Store: Table component: Expose function executed after row selection

### DIFF
--- a/client/extensions/woocommerce/components/table/README.md
+++ b/client/extensions/woocommerce/components/table/README.md
@@ -50,6 +50,7 @@ render: function() {
 * `className`: Classes added to top level element.
 * `isHeader`: Establishes row as being used for table head.
 * `href`: Optional link, if set, the row becomes clickable/focusable.
+* `afterHref`: Optional function to be executed after link has been clicked.
 
 #### Props `<TableItem/>`
 

--- a/client/extensions/woocommerce/components/table/table-row/index.js
+++ b/client/extensions/woocommerce/components/table/table-row/index.js
@@ -14,7 +14,7 @@ import page from 'page';
  */
 import getKeyboardHandler from 'woocommerce/lib/get-keyboard-handler';
 
-const TableRow = ( { className, isHeader, href, children, ...props } ) => {
+const TableRow = ( { className, isHeader, href, children, afterHref, ...props } ) => {
 	const rowClasses = classnames( 'table-row', className, {
 		'is-header': isHeader,
 	} );
@@ -29,6 +29,9 @@ const TableRow = ( { className, isHeader, href, children, ...props } ) => {
 
 	const goToHref = () => {
 		page( href );
+		if ( afterHref ) {
+			afterHref();
+		}
 	};
 
 	return (
@@ -46,6 +49,7 @@ const TableRow = ( { className, isHeader, href, children, ...props } ) => {
 };
 
 TableRow.propTypes = {
+	afterHref: PropTypes.func,
 	className: PropTypes.string,
 	href: PropTypes.string,
 	isHeader: PropTypes.bool,


### PR DESCRIPTION
Allow an optional function to be executed after a row has been selected. 

### Use Case
In https://github.com/Automattic/wp-calypso/pull/23579 I'd like to populate a dropdown of a search box with our Table component. 

![screen shot 2018-03-19 at 4 27 48 pm](https://user-images.githubusercontent.com/1922453/37823771-5839b9e8-2eef-11e8-8057-00abc0d368b7.png)

Selection of a row uses the row's `href` attribute to update the url. In this case, the page does not navigate, but parameters are updated. The purpose of the introduced `afterHref` prop will be to hide the dropdown after a row has been clicked.