### PR TITLE
Reader full post: fix display of post unavailable message

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -284,7 +284,7 @@ export class FullPostView extends React.Component {
 	render() {
 		const { post, site, feed, referralPost, referral, blogId, feedId, postId } = this.props;
 
-		if ( post._state === 'error' ) {
+		if ( post.is_error ) {
 			return <ReaderFullPostUnavailable post={ post } onBackClick={ this.handleBack } />;
 		}
 


### PR DESCRIPTION
@nosolosw spotted that we weren't displaying a helpful message when a post was missing (see https://github.com/Automattic/wp-calypso/issues/23606).

It looks like we used to set `post._state = 'error'` in the old Flux stores, but we use `post.is_error` in Redux to be consistent with feeds and sites.

This PR corrects the key used to check if the post is in error state.

### To test

Visit http://calypso.localhost:3000/read/feeds/72420827/posts/1728114392 and ensure that you're shown a 'Post unavailable' message rather than a blank full post view.