### PR TITLE
Data layer: move /read/feed search to use dispatchRequestEx

### DIFF
--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -198,9 +198,8 @@ class FollowingManage extends Component {
 				<MobileBackToSidebar>
 					<h1>{ translate( 'Streams' ) }</h1>
 				</MobileBackToSidebar>
-				{ ! searchResults && (
-					<QueryReaderFeedsSearch query={ sitesQuery } excludeFollowed={ true } />
-				) }
+				{ ! searchResults &&
+					sitesQuery && <QueryReaderFeedsSearch query={ sitesQuery } excludeFollowed={ true } /> }
 				{ this.shouldRequestMoreRecs() && (
 					<QueryReaderRecommendedSites
 						seed={ recommendationsSeed }

--- a/client/state/data-layer/wpcom/read/feed/index.js
+++ b/client/state/data-layer/wpcom/read/feed/index.js
@@ -14,7 +14,6 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
 import queryKey from 'state/reader/feed-searches/query-key';
-import { bypassDataLayer } from 'state/data-layer/utils';
 
 export function fromApi( apiResponse ) {
 	const feeds = map( apiResponse.feeds, feed => ( {
@@ -54,7 +53,7 @@ export function requestReadFeedSearch( action ) {
 
 export function receiveReadFeedSearchSuccess( action, data ) {
 	const { feeds, total } = data;
-	return bypassDataLayer( receiveFeedSearch( queryKey( action.payload ), feeds, total ) );
+	return receiveFeedSearch( queryKey( action.payload ), feeds, total );
 }
 
 export function receiveReadFeedSearchError( action ) {

--- a/client/state/data-layer/wpcom/read/feed/test/index.js
+++ b/client/state/data-layer/wpcom/read/feed/test/index.js
@@ -2,101 +2,91 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import freeze from 'deep-freeze';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
  */
-import { initiateFeedSearch, receiveFeeds, receiveError } from '../';
+import {
+	requestReadFeedSearch,
+	receiveReadFeedSearchSuccess,
+	receiveReadFeedSearchError,
+	fromApi,
+} from '../';
 import { NOTICE_CREATE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { requestFeedSearch, receiveFeedSearch } from 'state/reader/feed-searches/actions';
 import queryKey from 'state/reader/feed-searches/query-key';
 
-const feeds = freeze( [ { blog_ID: 'IM A BLOG', subscribe_URL: 'feedUrl' } ] );
+const feeds = freeze( [ { blog_ID: 123, subscribe_URL: 'http://example.com' } ] );
 
-const query = 'okapis r us';
+const query = 'okapis and giraffes';
 
 describe( 'wpcom-api', () => {
 	describe( 'search feeds', () => {
-		describe( '#initiateFeedSearch', () => {
+		describe( '#requestReadFeedSearch', () => {
 			test( 'should dispatch http request for feed search with followed feeds excluded by default', () => {
 				const action = requestFeedSearch( { query } );
-				const dispatch = sinon.spy();
 
-				initiateFeedSearch( { dispatch }, action );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith(
-					http( {
-						method: 'GET',
-						path: '/read/feed',
-						apiVersion: '1.1',
-						query: { q: query, offset: 0, exclude_followed: true, sort: 'relevance' },
-						onSuccess: action,
-						onFailure: action,
-					} )
+				expect( requestReadFeedSearch( action ) ).toMatchObject(
+					http(
+						{
+							method: 'GET',
+							path: '/read/feed',
+							apiVersion: '1.1',
+							query: { q: query, offset: 0, exclude_followed: true, sort: 'relevance' },
+						},
+						action
+					)
 				);
 			} );
 
 			test( 'should dispatch http request for feed search with followed feeds included if specified', () => {
 				const action = requestFeedSearch( { query, excludeFollowed: false } );
-				const dispatch = sinon.spy();
 
-				initiateFeedSearch( { dispatch }, action );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith(
-					http( {
-						method: 'GET',
-						path: '/read/feed',
-						apiVersion: '1.1',
-						query: { q: query, offset: 0, exclude_followed: false, sort: 'relevance' },
-						onSuccess: action,
-						onFailure: action,
-					} )
+				expect( requestReadFeedSearch( action ) ).toMatchObject(
+					http(
+						{
+							method: 'GET',
+							path: '/read/feed',
+							apiVersion: '1.1',
+							query: { q: query, offset: 0, exclude_followed: false, sort: 'relevance' },
+						},
+						action
+					)
 				);
 			} );
 
 			test( 'should dispatch http request for feed search with the offset specified', () => {
 				const action = requestFeedSearch( { query, offset: 10 } );
-				const dispatch = sinon.spy();
 
-				initiateFeedSearch( { dispatch }, action );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith(
-					http( {
-						method: 'GET',
-						path: '/read/feed',
-						apiVersion: '1.1',
-						query: { q: query, offset: 10, exclude_followed: true, sort: 'relevance' },
-						onSuccess: action,
-						onFailure: action,
-					} )
+				expect( requestReadFeedSearch( action ) ).toMatchObject(
+					http(
+						{
+							method: 'GET',
+							path: '/read/feed',
+							apiVersion: '1.1',
+							query: { q: query, offset: 10, exclude_followed: true, sort: 'relevance' },
+						},
+						action
+					)
 				);
 			} );
 		} );
 
-		describe( '#receiveFeeds', () => {
+		describe( '#receiveReadFeedSearchSuccess', () => {
 			test( 'should dispatch an action with the feed results', () => {
 				const action = requestFeedSearch( { query } );
-				const dispatch = sinon.spy();
-				const apiResponse = { feeds, total: 500 };
+				const apiResponse = fromApi( { feeds, total: 500 } );
 
-				receiveFeeds( { dispatch }, action, apiResponse );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith(
+				expect( receiveReadFeedSearchSuccess( action, apiResponse ) ).toMatchObject(
 					receiveFeedSearch(
 						queryKey( action.payload ),
 						[
 							{
-								blog_ID: 'IM A BLOG',
-								feed_URL: 'feedUrl',
-								subscribe_URL: 'feedUrl',
+								blog_ID: 123,
+								feed_URL: 'http://example.com',
+								subscribe_URL: 'http://example.com',
 							},
 						],
 						200
@@ -105,14 +95,11 @@ describe( 'wpcom-api', () => {
 			} );
 		} );
 
-		describe( '#receiveFeedsError', () => {
+		describe( '#receiveReadFeedSearchError', () => {
 			test( 'should dispatch error notice', () => {
 				const action = requestFeedSearch( { query } );
-				const dispatch = sinon.spy();
 
-				receiveError( { dispatch }, action );
-
-				expect( dispatch ).to.have.been.calledWithMatch( {
+				expect( receiveReadFeedSearchError( action ) ).toMatchObject( {
 					type: NOTICE_CREATE,
 				} );
 			} );


### PR DESCRIPTION
This PR updates `/read/feed/?q=something` requests in the data layer to use `dispatchRequestEx` rather than `dispatchRequest`.

This is groundwork for moving all feed fetching to the data layer.

### To test

Make sure feed search still works correctly at http://calypso.localhost:3000/following/manage.

<img width="815" alt="screen shot 2018-03-26 at 4 16 44 pm" src="https://user-images.githubusercontent.com/17325/37885328-1d85b800-3111-11e8-8b35-b9cc782bc574.png">

Give the tests a spin:

`npm run test-client client/state/data-layer/wpcom/read/feed/`

