### PR TITLE
Store: Stats: fix period nav back btn

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/listview.js
+++ b/client/extensions/woocommerce/app/store-stats/listview.js
@@ -38,7 +38,7 @@ class StoreStatsListView extends Component {
 	};
 
 	render() {
-		const { siteId, slug, selectedDate, type, unit } = this.props;
+		const { siteId, slug, selectedDate, type, unit, queryParams } = this.props;
 		const { topListQuery } = getQueries( unit, selectedDate, { topListQuery: { limit: 100 } } );
 		const statType = listType[ type ].statType;
 		return (
@@ -54,6 +54,7 @@ class StoreStatsListView extends Component {
 					query={ topListQuery }
 					statType={ statType }
 					title={ listType[ type ].title }
+					queryParams={ queryParams }
 				/>
 				<Module
 					siteId={ siteId }

--- a/client/extensions/woocommerce/app/store-stats/referrers/index.js
+++ b/client/extensions/woocommerce/app/store-stats/referrers/index.js
@@ -25,7 +25,7 @@ import { sortBySales } from './helpers';
 
 const STAT_TYPE = 'statsStoreReferrers';
 
-const Referrers = ( { siteId, query, data, selectedDate, unit, slug, translate } ) => {
+const Referrers = ( { siteId, query, data, selectedDate, unit, slug, translate, queryParams } ) => {
 	const unitSelectedDate = getUnitPeriod( selectedDate, unit );
 	const selectedData = find( data, d => d.date === unitSelectedDate ) || { data: [] };
 	const sortedData = sortBySales( selectedData.data );
@@ -40,6 +40,7 @@ const Referrers = ( { siteId, query, data, selectedDate, unit, slug, translate }
 				query={ query }
 				statType={ STAT_TYPE }
 				title={ translate( 'Store Referrers' ) }
+				queryParams={ queryParams }
 			/>
 			<Module
 				siteId={ siteId }

--- a/client/extensions/woocommerce/app/store-stats/store-stats-period-nav/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-period-nav/index.js
@@ -7,6 +7,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -15,9 +16,18 @@ import HeaderCake from 'components/header-cake';
 import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
 import Intervals from 'blocks/stats-navigation/intervals';
 import DatePicker from 'my-sites/stats/stats-date-picker';
+import { getWidgetPath } from 'woocommerce/app/store-stats/utils';
 
-const goBack = () => {
-	window && window.history.back();
+const goBack = ( unit, slug, queryParams ) => {
+	const { startDate } = queryParams;
+	const query = startDate ? { startDate } : {};
+	const widgetPath = getWidgetPath( unit, slug, query );
+	const url = `/store/stats/orders${ widgetPath }`;
+	return () => {
+		setTimeout( () => {
+			page( url );
+		} );
+	};
 };
 
 const StoreStatsPeriodNav = ( {
@@ -29,10 +39,11 @@ const StoreStatsPeriodNav = ( {
 	query,
 	title,
 	statType,
+	queryParams,
 } ) => {
 	return (
 		<Fragment>
-			<HeaderCake onClick={ goBack }>{ title }</HeaderCake>
+			<HeaderCake onClick={ goBack( unit, slug, queryParams ) }>{ title }</HeaderCake>
 			<StatsPeriodNavigation
 				date={ selectedDate }
 				period={ unit }
@@ -69,6 +80,7 @@ StoreStatsPeriodNav.propTypes = {
 	query: PropTypes.object.isRequired,
 	title: PropTypes.string,
 	statType: PropTypes.string.isRequired,
+	queryParams: PropTypes.object,
 };
 
 export default localize( StoreStatsPeriodNav );

--- a/client/extensions/woocommerce/app/store-stats/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/utils.js
@@ -295,7 +295,7 @@ export function getQueries( unit, baseDate, overrides = {} ) {
  * @return {string} - widget path url portion
  */
 export function getWidgetPath( unit, slug, urlQuery ) {
-	const query = Object.keys( urlQuery ).reduce( ( querystring, param, index ) => {
+	const query = Object.keys( urlQuery || {} ).reduce( ( querystring, param, index ) => {
 		return `${ querystring }${ index === 0 ? '?' : '&' }${ param }=${ urlQuery[ param ] }`;
 	}, '' );
 	return `/${ unit }/${ slug }${ query }`;


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/23352#discussion_r175560101 the `goBack` function on the period navigation was replaced with more generic logic that does the same as the browser's back button.

It turns out that Back button is hard to use. On links, direct pastes into the URL or changed query parameters, it seemed not quite right. This PR changes it back to always going back to the main stats page, while keeping the `startDate` and `unit` query parameters intact.

### Testing
* Go to any listview or referrers view and ensure the "Back" button takes you back to the stats page regardless of your browser history. 
* Make sure the relevant paramteres (unit and startDate) persist while irrelevant ones (referrers or whatever) do not.