### PR TITLE
JP Onboarding: Add isRequestingJetpackOnboardingSettings selector

### DIFF
--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -29,17 +29,14 @@ import {
 	getJetpackOnboardingCompletedSteps,
 	getJetpackOnboardingSettings,
 	getJpoUserHash,
-	getRequest,
 	getSiteId,
 	getUnconnectedSite,
 	getUnconnectedSiteIdBySlug,
+	isRequestingJetpackOnboardingSettings,
 } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, isRequestingSite, isRequestingSites } from 'state/sites/selectors';
-import {
-	requestJetpackOnboardingSettings,
-	saveJetpackOnboardingSettings,
-} from 'state/jetpack-onboarding/actions';
+import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 import { setSelectedSiteId } from 'state/ui/actions';
 
 class JetpackOnboardingMain extends React.PureComponent {
@@ -222,10 +219,7 @@ export default connect(
 			};
 		}
 
-		const isRequestingSettings = getRequest(
-			state,
-			requestJetpackOnboardingSettings( siteId, jpoAuth )
-		).isLoading;
+		const isRequestingSettings = isRequestingJetpackOnboardingSettings( state, siteId, jpoAuth );
 
 		const userIdHashed = getJpoUserHash( state, siteId );
 

--- a/client/state/selectors/is-requesting-jetpack-onboarding-settings.js
+++ b/client/state/selectors/is-requesting-jetpack-onboarding-settings.js
@@ -13,12 +13,11 @@ import { requestJetpackOnboardingSettings } from 'state/jetpack-onboarding/actio
 
 /**
  * Returns true if we are currently making a request to fetch the Jetpack settings. False otherwise
- * Returns null if the status for the queried site is unknown.
  *
  * @param  {Object}  state       Global state tree
  * @param  {Number}  siteId      The ID of the site we're querying
  * @param  {Object}  query       An optional query to be passed to the JP settings endpoint
- * @return {?Boolean}            Whether Jetpack settings are currently being requested
+ * @return {Boolean}             Whether Jetpack settings are currently being requested
  */
 export default function isRequestingJetpackOnboardingSettings( state, siteId, query ) {
 	return get(

--- a/client/state/selectors/is-requesting-jetpack-onboarding-settings.js
+++ b/client/state/selectors/is-requesting-jetpack-onboarding-settings.js
@@ -1,0 +1,25 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getRequest } from 'state/selectors';
+import { requestJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
+
+/**
+ * Returns true if we are currently making a request to fetch the Jetpack settings. False otherwise
+ * Returns null if the status for the queried site is unknown.
+ *
+ * @param  {Object}  state       Global state tree
+ * @param  {Number}  siteId      The ID of the site we're querying
+ * @param  {Object}  query       An optional query to be passed to the JP settings endpoint
+ * @return {?Boolean}            Whether Jetpack settings are currently being requested
+ */
+export default function isRequestingJetpackOnboardingSettings( state, siteId, query ) {
+	return get( getRequest( state, requestJetpackOnboardingSettings( siteId, query ) ), 'isLoading' );
+}

--- a/client/state/selectors/is-requesting-jetpack-onboarding-settings.js
+++ b/client/state/selectors/is-requesting-jetpack-onboarding-settings.js
@@ -21,5 +21,9 @@ import { requestJetpackOnboardingSettings } from 'state/jetpack-onboarding/actio
  * @return {?Boolean}            Whether Jetpack settings are currently being requested
  */
 export default function isRequestingJetpackOnboardingSettings( state, siteId, query ) {
-	return get( getRequest( state, requestJetpackOnboardingSettings( siteId, query ) ), 'isLoading' );
+	return get(
+		getRequest( state, requestJetpackOnboardingSettings( siteId, query ) ),
+		'isLoading',
+		false
+	);
 }

--- a/client/state/selectors/test/is-requesting-jetpack-onboarding-settings.js
+++ b/client/state/selectors/test/is-requesting-jetpack-onboarding-settings.js
@@ -1,0 +1,55 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getRequestKey } from 'state/data-layer/wpcom-http/utils';
+import { isRequestingJetpackOnboardingSettings } from 'state/selectors';
+import { requestJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
+
+describe( 'isRequestingJetpackOnboardingSettings()', () => {
+	test( 'should return true if settings are currently being requested', () => {
+		const siteId = 87654321;
+		const action = requestJetpackOnboardingSettings( siteId );
+		const state = {
+			dataRequests: {
+				[ getRequestKey( action ) ]: {
+					status: 'pending',
+				},
+			},
+		};
+
+		const output = isRequestingJetpackOnboardingSettings( state, siteId );
+		expect( output ).toBe( true );
+	} );
+
+	test( 'should return false if settings are currently not being requested', () => {
+		const siteId = 87654321;
+		const action = requestJetpackOnboardingSettings( siteId );
+		const state = {
+			dataRequests: {
+				[ getRequestKey( action ) ]: {
+					status: 'success',
+				},
+			},
+		};
+
+		const output = isRequestingJetpackOnboardingSettings( state, siteId );
+		expect( output ).toBe( false );
+	} );
+
+	test( 'should return null if that site is not known', () => {
+		const siteId = 87654321;
+		const action = requestJetpackOnboardingSettings( 12345678 );
+		const state = {
+			dataRequests: {
+				[ getRequestKey( action ) ]: {
+					status: 'pending',
+				},
+			},
+		};
+
+		const output = isRequestingJetpackOnboardingSettings( state, siteId );
+		expect( output ).toBe( null );
+	} );
+} );

--- a/client/state/selectors/test/is-requesting-jetpack-onboarding-settings.js
+++ b/client/state/selectors/test/is-requesting-jetpack-onboarding-settings.js
@@ -52,4 +52,36 @@ describe( 'isRequestingJetpackOnboardingSettings()', () => {
 		const output = isRequestingJetpackOnboardingSettings( state, siteId );
 		expect( output ).toBe( false );
 	} );
+
+	test( 'should return true if settings are currently being requested for a matching site ID and query', () => {
+		const siteId = 87654321;
+		const query = { foo: 'bar' };
+		const action = requestJetpackOnboardingSettings( siteId, query );
+		const state = {
+			dataRequests: {
+				[ getRequestKey( action ) ]: {
+					status: 'pending',
+				},
+			},
+		};
+
+		const output = isRequestingJetpackOnboardingSettings( state, siteId, query );
+		expect( output ).toBe( true );
+	} );
+
+	test( 'should return false if settings are currently being requested for matching site ID and non-matching query', () => {
+		const siteId = 87654321;
+		const query = { foo: 'bar' };
+		const action = requestJetpackOnboardingSettings( siteId, { foo: 'baz' } );
+		const state = {
+			dataRequests: {
+				[ getRequestKey( action ) ]: {
+					status: 'pending',
+				},
+			},
+		};
+
+		const output = isRequestingJetpackOnboardingSettings( state, siteId, query );
+		expect( output ).toBe( false );
+	} );
 } );

--- a/client/state/selectors/test/is-requesting-jetpack-onboarding-settings.js
+++ b/client/state/selectors/test/is-requesting-jetpack-onboarding-settings.js
@@ -38,7 +38,7 @@ describe( 'isRequestingJetpackOnboardingSettings()', () => {
 		expect( output ).toBe( false );
 	} );
 
-	test( 'should return null if that site is not known', () => {
+	test( 'should return false if that site is not known', () => {
 		const siteId = 87654321;
 		const action = requestJetpackOnboardingSettings( 12345678 );
 		const state = {
@@ -50,6 +50,6 @@ describe( 'isRequestingJetpackOnboardingSettings()', () => {
 		};
 
 		const output = isRequestingJetpackOnboardingSettings( state, siteId );
-		expect( output ).toBe( null );
+		expect( output ).toBe( false );
 	} );
 } );


### PR DESCRIPTION
Modeled after `isRequestingJetpackSettings`. Will come in handy for #23393.

To test: Verify that JPO still works as before. Pay special attention to 'loading' states, e.g. while JPO is fetching site title and description data for the first step.