### PR TITLE
Activity Log: Show long error message longer for readability

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -116,7 +116,7 @@ export const failure = ( { dispatch, getState }, action, error ) => {
 	};
 
 	const { translate } = i18n;
-	const baseOptions = { duration: 4000, id: action.noticeId };
+	const baseOptions = { duration: 10000, id: action.noticeId };
 
 	const announce = ( message, options ) =>
 		dispatch( errorNotice( message, options ? { ...baseOptions, ...options } : baseOptions ) );
@@ -149,7 +149,7 @@ export const failure = ( { dispatch, getState }, action, error ) => {
 					"Our service isn't working at the moment. We'll get it up and " +
 						'running as fast as we can, so please try again later.'
 				),
-				{ button: translate( 'Try again' ), duration: 20000, onClick: () => dispatch( action ) }
+				{ button: translate( 'Try again' ), onClick: () => dispatch( action ) }
 			);
 			spreadHappiness(
 				'Rewind Credentials: update request failed on timeout (could be us or remote site)'

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -149,7 +149,7 @@ export const failure = ( { dispatch, getState }, action, error ) => {
 					"Our service isn't working at the moment. We'll get it up and " +
 						'running as fast as we can, so please try again later.'
 				),
-				{ button: translate( 'Try again' ), onClick: () => dispatch( action ) }
+				{ button: translate( 'Try again' ), duration: 20000, onClick: () => dispatch( action ) }
 			);
 			spreadHappiness(
 				'Rewind Credentials: update request failed on timeout (could be us or remote site)'


### PR DESCRIPTION
Resolves #23402

The error message is long and four seconds isn't enough time to read it.

In this patch we're extending the length that the error message is
displayed to make it easier for people to read.

**Testing**

In **master** submit credentials at **My Sites** > **Settings** > **Security**
for Jetpack Rewind but make sure they are wrong. The error message should
appear and then disappear after four seconds.

In this branch they should persist for ten seconds (or until dismissed). I have
chosen ten arbitrarily because it's longer than four seconds. Please comment
on that if you think we could have a better delay, or making them persist
indefinitely until they are dismissed would be better.