### PR TITLE
Update/remove hardcoded constants product purchase features list

### DIFF
--- a/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
+++ b/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
@@ -31,8 +31,11 @@ import React from 'react';
 import {
 	PLAN_FREE,
 	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
 	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
 	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
 	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
@@ -102,6 +105,18 @@ describe( 'ProductPurchaseFeaturesList getFeatures() tests', () => {
 		assert.notEqual( comp.find( '.product-purchase-features-list' ).children().length, 0 );
 	} );
 
+	test( 'should render WP personal features for WP personal plans - 2y', () => {
+		spy = jest.spyOn( ProductPurchaseFeaturesList.prototype, 'getPersonalFeatures' );
+		spyWrong = jest.spyOn( ProductPurchaseFeaturesList.prototype, 'getBusinessFeatures' );
+
+		const comp = shallow(
+			<ProductPurchaseFeaturesList { ...props } plan={ PLAN_PERSONAL_2_YEARS } />
+		);
+		expect( spy ).toHaveBeenCalled();
+		expect( spyWrong ).not.toHaveBeenCalled();
+		assert.notEqual( comp.find( '.product-purchase-features-list' ).children().length, 0 );
+	} );
+
 	test( 'should render WP premium features for WP premium plans - 1y', () => {
 		spy = jest.spyOn( ProductPurchaseFeaturesList.prototype, 'getPremiumFeatures' );
 		spyWrong = jest.spyOn( ProductPurchaseFeaturesList.prototype, 'getBusinessFeatures' );
@@ -112,11 +127,35 @@ describe( 'ProductPurchaseFeaturesList getFeatures() tests', () => {
 		assert.notEqual( comp.find( '.product-purchase-features-list' ).children().length, 0 );
 	} );
 
+	test( 'should render WP premium features for WP premium plans - 2y', () => {
+		spy = jest.spyOn( ProductPurchaseFeaturesList.prototype, 'getPremiumFeatures' );
+		spyWrong = jest.spyOn( ProductPurchaseFeaturesList.prototype, 'getBusinessFeatures' );
+
+		const comp = shallow(
+			<ProductPurchaseFeaturesList { ...props } plan={ PLAN_PREMIUM_2_YEARS } />
+		);
+		expect( spy ).toHaveBeenCalled();
+		expect( spyWrong ).not.toHaveBeenCalled();
+		assert.notEqual( comp.find( '.product-purchase-features-list' ).children().length, 0 );
+	} );
+
 	test( 'should render WP business features for WP business plans - 1y', () => {
 		spy = jest.spyOn( ProductPurchaseFeaturesList.prototype, 'getBusinessFeatures' );
 		spyWrong = jest.spyOn( ProductPurchaseFeaturesList.prototype, 'getPersonalFeatures' );
 
 		const comp = shallow( <ProductPurchaseFeaturesList { ...props } plan={ PLAN_BUSINESS } /> );
+		expect( spy ).toHaveBeenCalled();
+		expect( spyWrong ).not.toHaveBeenCalled();
+		assert.notEqual( comp.find( '.product-purchase-features-list' ).children().length, 0 );
+	} );
+
+	test( 'should render WP business features for WP business plans - 2y', () => {
+		spy = jest.spyOn( ProductPurchaseFeaturesList.prototype, 'getBusinessFeatures' );
+		spyWrong = jest.spyOn( ProductPurchaseFeaturesList.prototype, 'getPersonalFeatures' );
+
+		const comp = shallow(
+			<ProductPurchaseFeaturesList { ...props } plan={ PLAN_BUSINESS_2_YEARS } />
+		);
 		expect( spy ).toHaveBeenCalled();
 		expect( spyWrong ).not.toHaveBeenCalled();
 		assert.notEqual( comp.find( '.product-purchase-features-list' ).children().length, 0 );
@@ -202,5 +241,38 @@ describe( 'ProductPurchaseFeaturesList getFeatures() tests', () => {
 		expect( spy ).toHaveBeenCalled();
 		expect( spyWrong ).not.toHaveBeenCalled();
 		assert.notEqual( comp.find( '.product-purchase-features-list' ).children().length, 0 );
+	} );
+} );
+
+describe( 'ProductPurchaseFeaturesList feature functions', () => {
+	const props = {
+		plan: PLAN_FREE,
+		isPlaceholder: false,
+		selectedSite: {
+			plan: PLAN_FREE,
+		},
+	};
+
+	test( 'getBusinessFeatures() should pass proper plan type to VideoAudioPosts child component', () => {
+		const comp = shallow( <ProductPurchaseFeaturesList { ...props } plan={ PLAN_BUSINESS } /> );
+		const audioPosts = comp.find( 'VideoAudioPosts' );
+		assert.lengthOf( audioPosts, 1 );
+		assert.equal( audioPosts.props().plan, PLAN_BUSINESS );
+	} );
+
+	test( 'getBusinessFeatures() should pass proper plan type to VideoAudioPosts child component', () => {
+		const comp = shallow(
+			<ProductPurchaseFeaturesList { ...props } plan={ PLAN_BUSINESS_2_YEARS } />
+		);
+		const audioPosts = comp.find( 'VideoAudioPosts' );
+		assert.lengthOf( audioPosts, 1 );
+		assert.equal( audioPosts.props().plan, PLAN_BUSINESS_2_YEARS );
+	} );
+
+	test( 'getPremiumFeatures() should pass proper plan type to VideoAudioPosts child component', () => {
+		const comp = shallow( <ProductPurchaseFeaturesList { ...props } plan={ PLAN_PREMIUM } /> );
+		const audioPosts = comp.find( 'VideoAudioPosts' );
+		assert.lengthOf( audioPosts, 1 );
+		assert.equal( audioPosts.props().plan, PLAN_PREMIUM );
 	} );
 } );

--- a/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
+++ b/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
@@ -260,7 +260,7 @@ describe( 'ProductPurchaseFeaturesList feature functions', () => {
 		assert.equal( audioPosts.props().plan, PLAN_BUSINESS );
 	} );
 
-	test( 'getBusinessFeatures() should pass proper plan type to VideoAudioPosts child component', () => {
+	test( 'getBusinessFeatures() should pass proper plan type to VideoAudioPosts child component when 2-years plan is used', () => {
 		const comp = shallow(
 			<ProductPurchaseFeaturesList { ...props } plan={ PLAN_BUSINESS_2_YEARS } />
 		);


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `product-purchase-features-list`.

Since we are adding new 2_YEAR plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every `if`.

Test plan:
* Run unit tests
* Go to `/plans/my-plan` on local calypso and on `wordpress.com` and confirm the list of features is the same for each plan