### PR TITLE
Payment: Add the data layer handlers for the source payment info endpoint

### DIFF
--- a/client/state/data-layer/wpcom/me/index.js
+++ b/client/state/data-layer/wpcom/me/index.js
@@ -14,6 +14,7 @@ import settings from './settings';
 import sendVerificationEmail from './send-verification-email';
 import countries from './transactions/supported-countries';
 import twoStep from './two-step';
+import sourcePayment from './transactions/source-payment';
 
 export default mergeHandlers(
 	block,
@@ -22,5 +23,6 @@ export default mergeHandlers(
 	notification,
 	settings,
 	sendVerificationEmail,
-	twoStep
+	twoStep,
+	sourcePayment
 );

--- a/client/state/data-layer/wpcom/me/transactions/source-payment/from-api.js
+++ b/client/state/data-layer/wpcom/me/transactions/source-payment/from-api.js
@@ -1,5 +1,9 @@
 /** @format */
 
-export default args => {
-	return args;
-};
+/**
+ * Internal dependencies
+ */
+import { makeParser } from 'state/data-layer/wpcom-http/utils';
+import responseSchema from './schema';
+
+export default makeParser( responseSchema, {} );

--- a/client/state/data-layer/wpcom/me/transactions/source-payment/from-api.js
+++ b/client/state/data-layer/wpcom/me/transactions/source-payment/from-api.js
@@ -1,0 +1,5 @@
+/** @format */
+
+export default args => {
+	return args;
+};

--- a/client/state/data-layer/wpcom/me/transactions/source-payment/index.js
+++ b/client/state/data-layer/wpcom/me/transactions/source-payment/index.js
@@ -20,8 +20,8 @@ export const fetchSourcePaymentTransactionDetail = action =>
 		{
 			method: 'GET',
 			path: '/me/transactions/source-payment',
-			apiNamespace: 'wpcom/v1',
-			body: toApi( action ),
+			apiNamespace: 'rest/v1',
+			query: toApi( action ),
 		},
 		action
 	);

--- a/client/state/data-layer/wpcom/me/transactions/source-payment/index.js
+++ b/client/state/data-layer/wpcom/me/transactions/source-payment/index.js
@@ -1,0 +1,47 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { errorNotice } from 'state/notices/actions';
+import { SOURCE_PAYMENT_TRANSACTION_DETAIL_FETCH } from 'state/action-types';
+import fromApi from './from-api';
+import toApi from './to-api';
+
+export const fetchSourcePaymentTransactionDetail = action =>
+	http(
+		{
+			method: 'GET',
+			path: '/me/transactions/source-payment',
+			apiNamespace: 'wpcom/v1',
+			body: toApi( action ),
+		},
+		action
+	);
+
+export const onSuccess = ( action, data ) => {
+	console.log( '------------------', action, data );
+
+	return {};
+};
+
+export const onError = ( action, data ) =>
+	errorNotice( translate( 'Sorry. Something went wrong!' ) );
+
+export default {
+	[ SOURCE_PAYMENT_TRANSACTION_DETAIL_FETCH ]: [
+		dispatchRequestEx( {
+			fetch: fetchSourcePaymentTransactionDetail,
+			onSuccess,
+			onError,
+			fromApi,
+		} ),
+	],
+};

--- a/client/state/data-layer/wpcom/me/transactions/source-payment/index.js
+++ b/client/state/data-layer/wpcom/me/transactions/source-payment/index.js
@@ -26,14 +26,11 @@ export const fetchSourcePaymentTransactionDetail = action =>
 		action
 	);
 
-export const onSuccess = ( action, data ) => {
-	console.log( '------------------', action, data );
-
+export const onSuccess = () => {
 	return {};
 };
 
-export const onError = ( action, data ) =>
-	errorNotice( translate( 'Sorry. Something went wrong!' ) );
+export const onError = () => errorNotice( translate( 'Sorry. Something went wrong!' ) );
 
 export default {
 	[ SOURCE_PAYMENT_TRANSACTION_DETAIL_FETCH ]: [

--- a/client/state/data-layer/wpcom/me/transactions/source-payment/index.js
+++ b/client/state/data-layer/wpcom/me/transactions/source-payment/index.js
@@ -11,26 +11,27 @@ import { translate } from 'i18n-calypso';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
+import { setSourcePaymentTransactionDetail } from 'state/transactions/source-payment/actions';
 import { SOURCE_PAYMENT_TRANSACTION_DETAIL_FETCH } from 'state/action-types';
 import fromApi from './from-api';
-import toApi from './to-api';
 
 export const fetchSourcePaymentTransactionDetail = action =>
 	http(
 		{
 			method: 'GET',
-			path: '/me/transactions/source-payment',
+			path: `/me/transactions/source-payment/${ action.orderId }`,
 			apiNamespace: 'rest/v1',
-			query: toApi( action ),
 		},
 		action
 	);
 
-export const onSuccess = () => {
-	return {};
-};
+export const onSuccess = ( { orderId }, detail ) =>
+	setSourcePaymentTransactionDetail( orderId, detail );
 
-export const onError = () => errorNotice( translate( 'Sorry. Something went wrong!' ) );
+export const onError = () =>
+	errorNotice(
+		translate( 'We have problems fetching your payment status. Please try again later.' )
+	);
 
 export default {
 	[ SOURCE_PAYMENT_TRANSACTION_DETAIL_FETCH ]: [

--- a/client/state/data-layer/wpcom/me/transactions/source-payment/schema.json
+++ b/client/state/data-layer/wpcom/me/transactions/source-payment/schema.json
@@ -1,0 +1,7 @@
+{
+	"type": "object",
+	"required": [ "status" ],
+	"properties": {
+		"status": { "type": "string" }
+	}
+}

--- a/client/state/data-layer/wpcom/me/transactions/source-payment/test/from-api.js
+++ b/client/state/data-layer/wpcom/me/transactions/source-payment/test/from-api.js
@@ -1,0 +1,31 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { SchemaError } from 'state/data-layer/wpcom-http/utils';
+import fromApi from '../from-api';
+
+describe( 'wpcom-api', () => {
+	describe( 'fromApi()', () => {
+		test( 'should validate and return the data successfully.', () => {
+			const response = {
+				status: 'profit!',
+			};
+
+			expect( fromApi( response ) ).toEqual( response );
+		} );
+
+		test( 'should invalidate when the required field is missing.', () => {
+			const invalidateCall = () => {
+				const invalidResponse = {
+					noStatus: 'I have no status!',
+				};
+
+				fromApi( invalidResponse );
+			};
+
+			expect( invalidateCall ).toThrowError( SchemaError );
+		} );
+	} );
+} );

--- a/client/state/data-layer/wpcom/me/transactions/source-payment/test/index.js
+++ b/client/state/data-layer/wpcom/me/transactions/source-payment/test/index.js
@@ -1,0 +1,60 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { fetchSourcePaymentTransactionDetail, onSuccess, onError } from '../';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { errorNotice } from 'state/notices/actions';
+import { setSourcePaymentTransactionDetail } from 'state/transactions/source-payment/actions';
+
+// we are mocking impure-lodash here, so that conciergeShiftsFetchError() will contain the expected id in the tests
+jest.mock( 'lib/impure-lodash', () => ( {
+	uniqueId: () => 'mock-unique-id',
+} ) );
+
+describe( 'wpcom-api', () => {
+	describe( 'me/transactions/source-payment', () => {
+		describe( 'fetchSourcePaymentTransactionDetail()', () => {
+			test( 'should return the expected http request action.', () => {
+				const action = {
+					orderId: 123,
+				};
+
+				expect( fetchSourcePaymentTransactionDetail( action ) ).toEqual(
+					http(
+						{
+							method: 'GET',
+							path: `/me/transactions/source-payment/${ action.orderId }`,
+							apiNamespace: 'rest/v1',
+						},
+						action
+					)
+				);
+			} );
+		} );
+
+		describe( 'onSuccess()', () => {
+			test( 'should return the expected setting action for populating state.', () => {
+				const action = {
+					orderId: 123,
+				};
+				const detail = {
+					status: 'profit!',
+				};
+
+				expect( onSuccess( action, detail ) ).toEqual(
+					setSourcePaymentTransactionDetail( action.orderId, detail )
+				);
+			} );
+		} );
+
+		describe( 'onError()', () => {
+			test( 'should return the expected error notice action.', () => {
+				expect( onError() ).toEqual(
+					errorNotice( 'We have problems fetching your payment status. Please try again later.' )
+				);
+			} );
+		} );
+	} );
+} );

--- a/client/state/data-layer/wpcom/me/transactions/source-payment/to-api.js
+++ b/client/state/data-layer/wpcom/me/transactions/source-payment/to-api.js
@@ -1,0 +1,5 @@
+/** @format */
+
+export default ( { orderId } ) => ( {
+	order_id: orderId,
+} );

--- a/client/state/data-layer/wpcom/me/transactions/source-payment/to-api.js
+++ b/client/state/data-layer/wpcom/me/transactions/source-payment/to-api.js
@@ -1,5 +1,0 @@
-/** @format */
-
-export default ( { orderId } ) => ( {
-	order_id: orderId,
-} );


### PR DESCRIPTION
## Summary
This PR is part of the work for #22914, the data layer part, and is based on https://github.com/Automattic/wp-calypso/pull/23634. It adds the data layer handler for cooperating with the up-coming endpoint for fetching the info of a source payment transaction. The endpoint code is in D11144-code.

## Test Plan
`npm run test-client source-payment`