### PR TITLE
Remove direct usage of PLAN_* constants from PlanIcon

### DIFF
--- a/client/components/plans/plan-icon/index.jsx
+++ b/client/components/plans/plan-icon/index.jsx
@@ -11,20 +11,8 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import {
-	PLAN_FREE,
-	PLAN_PREMIUM,
-	PLAN_BUSINESS,
-	PLAN_JETPACK_FREE,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PERSONAL_MONTHLY,
-	PLAN_PERSONAL,
-	getPlanClass,
-} from 'lib/plans/constants';
+import { PLANS_LIST, getPlanClass } from 'lib/plans/constants';
+import { isPersonalPlan, isPremiumPlan, isBusinessPlan } from 'lib/plans';
 
 export default class PlanIcon extends Component {
 	getIcon( planName ) {
@@ -41,38 +29,23 @@ export default class PlanIcon extends Component {
 
 	render() {
 		const { plan } = this.props;
-		switch ( plan ) {
-			case PLAN_PERSONAL:
-			case PLAN_JETPACK_PERSONAL:
-			case PLAN_JETPACK_PERSONAL_MONTHLY:
-				return this.getIcon( 'personal' );
-			case PLAN_PREMIUM:
-			case PLAN_JETPACK_PREMIUM:
-			case PLAN_JETPACK_PREMIUM_MONTHLY:
-				return this.getIcon( 'premium' );
-			case PLAN_BUSINESS:
-			case PLAN_JETPACK_BUSINESS:
-			case PLAN_JETPACK_BUSINESS_MONTHLY:
-				return this.getIcon( 'business' );
-			default:
-				return this.getIcon( 'free' );
+		if ( isPersonalPlan( plan ) ) {
+			return this.getIcon( 'personal' );
 		}
+
+		if ( isPremiumPlan( plan ) ) {
+			return this.getIcon( 'premium' );
+		}
+
+		if ( isBusinessPlan( plan ) ) {
+			return this.getIcon( 'business' );
+		}
+
+		return this.getIcon( 'free' );
 	}
 }
 
 PlanIcon.propTypes = {
 	classNames: PropTypes.string,
-	plan: PropTypes.oneOf( [
-		PLAN_FREE,
-		PLAN_PREMIUM,
-		PLAN_BUSINESS,
-		PLAN_JETPACK_FREE,
-		PLAN_JETPACK_BUSINESS,
-		PLAN_JETPACK_BUSINESS_MONTHLY,
-		PLAN_JETPACK_PREMIUM,
-		PLAN_JETPACK_PREMIUM_MONTHLY,
-		PLAN_JETPACK_PERSONAL,
-		PLAN_JETPACK_PERSONAL_MONTHLY,
-		PLAN_PERSONAL,
-	] ).isRequired,
+	plan: PropTypes.oneOf( Object.keys( PLANS_LIST ).isRequired ),
 };

--- a/client/components/plans/plan-icon/test/test.jsx
+++ b/client/components/plans/plan-icon/test/test.jsx
@@ -1,0 +1,101 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Comp => props => (
+		<Comp
+			{ ...props }
+			translate={ function( x ) {
+				return x;
+			} }
+		/>
+	),
+	numberFormat: x => x,
+} ) );
+
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+import {
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import PlanIcon from '../index';
+
+const props = {
+	plan: PLAN_FREE,
+};
+
+describe( 'PlanIcon basic tests', () => {
+	test( 'should not blow up and have proper CSS class', () => {
+		const comp = shallow( <PlanIcon { ...props } /> );
+		assert.lengthOf( comp.find( '.plan-icon' ), 1 );
+	} );
+} );
+
+describe( 'PlanIcon should have a class name corresponding to appropriate plan', () => {
+	[
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_PERSONAL_MONTHLY,
+	].forEach( plan => {
+		test( 'Personal', () => {
+			const comp = shallow( <PlanIcon { ...props } plan={ plan } /> );
+			assert.lengthOf( comp.find( '.plan-icon__personal' ), 1 );
+		} );
+	} );
+
+	[
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PREMIUM_MONTHLY,
+	].forEach( plan => {
+		test( 'Premium', () => {
+			const comp = shallow( <PlanIcon { ...props } plan={ plan } /> );
+			assert.lengthOf( comp.find( '.plan-icon__premium' ), 1 );
+		} );
+	} );
+
+	[
+		PLAN_BUSINESS,
+		PLAN_BUSINESS_2_YEARS,
+		PLAN_JETPACK_BUSINESS,
+		PLAN_JETPACK_BUSINESS_MONTHLY,
+	].forEach( plan => {
+		test( 'Business', () => {
+			const comp = shallow( <PlanIcon { ...props } plan={ plan } /> );
+			assert.lengthOf( comp.find( '.plan-icon__business' ), 1 );
+		} );
+	} );
+
+	[ PLAN_FREE, PLAN_JETPACK_FREE ].forEach( plan => {
+		test( 'Free', () => {
+			const comp = shallow( <PlanIcon { ...props } plan={ plan } /> );
+			assert.lengthOf( comp.find( '.plan-icon__free' ), 1 );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `<PlanIcon />`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* Go to /devdocs/design/banner and confirm that plan-related banners have a children with `.plan-icon__premium/personal/business` CSS class