### PR TITLE
Make a standalone connect button for Google My Business

### DIFF
--- a/client/components/action-card/README.md
+++ b/client/components/action-card/README.md
@@ -24,6 +24,8 @@ render() {
 }
 ```
 
+Optionally, children can be provided to be rendered instead the call to action Button.
+
 ## Props
 
 ### `headerText`

--- a/client/components/action-card/README.md
+++ b/client/components/action-card/README.md
@@ -6,6 +6,7 @@ This is a [`Card` component](../../components/card) that has a call-to-action bu
 ## Usage
 
 ```es6
+import { noop } from 'lodash';
 import ActionCard from 'blocks/action-card';
 
 render() {
@@ -24,59 +25,73 @@ render() {
 }
 ```
 
-Optionally, children can be provided to be rendered instead the call to action Button.
-
 ## Props
 
+### `children`
+
+  - **Type:** `React node`
+  - **Required:** `no`
+  - **Default:** `undefined`
+
+If a child is passed, it will be used in place of the button (hence rendering button props useless).
+
 ### `headerText`
+
   - **Type:** `String`
   - **Required:** `yes`
 
-Header text of the card
+Header text of the card.
 
 ### `mainText`
+
   - **Type:** `String`
   - **Required:** `yes`
 
-Text that describes the header
+Text appearing below the header.
 
 ### `buttonText`
+
   - **Type:** `String`
   - **Required:** `yes`
 
-Label for the call to action button
+Label of the button.
 
 ### `buttonIcon`
+
   - **Type:** `String`
   - **Required:** `no`
   - **Default:** `undefined`
 
-GridIcon name to place on the button
+Name of the GridIcon icon to place on the button.
 
 ### `buttonPrimary`
+
   - **Type:** `bool`
   - **Required:** `no`
   - **Default:** `undefined`
 
-Whether pass true to the button's primary attribute
+Flag indicating if the button is primary or not.
 
 ### `buttonHref`
+
   - **Type:** `String`
   - **Required:** `no`
   - **Default:** `undefined`
 
-Href to pass to the button
+Button `href` attribute.
 
 ### `buttonTarget`
+
   - **Type:** `String`
   - **Required:** `no`
   - **Default:** `undefined`
 
-Button target, to use in conjunction with `buttonHref`
+Button `target` attribute, to use in conjunction with the `buttonHref` prop.
 
 ### `buttonOnClick`
+
   - **Type:** `Function`
   - **Required:** `no`
   - **Default:** `undefined`
 
-Button onClick handler
+Button click event handler.

--- a/client/components/action-card/index.jsx
+++ b/client/components/action-card/index.jsx
@@ -22,6 +22,7 @@ const ActionCard = ( {
 	buttonTarget,
 	buttonHref,
 	buttonOnClick,
+	children
 } ) => (
 	<CompactCard className="action-card">
 		<div className="action-card__main">
@@ -29,14 +30,14 @@ const ActionCard = ( {
 			<p>{ mainText }</p>
 		</div>
 		<div className="action-card__button-container">
-			<Button
+			{ children || <Button
 				primary={ buttonPrimary }
 				href={ buttonHref }
 				target={ buttonTarget }
 				onClick={ buttonOnClick }
 			>
 				{ buttonText } { buttonIcon && <Gridicon icon={ buttonIcon } /> }
-			</Button>
+			</Button> }
 		</div>
 	</CompactCard>
 );

--- a/client/components/action-card/index.jsx
+++ b/client/components/action-card/index.jsx
@@ -22,7 +22,7 @@ const ActionCard = ( {
 	buttonTarget,
 	buttonHref,
 	buttonOnClick,
-	children
+	children,
 } ) => (
 	<CompactCard className="action-card">
 		<div className="action-card__main">
@@ -30,14 +30,16 @@ const ActionCard = ( {
 			<p>{ mainText }</p>
 		</div>
 		<div className="action-card__button-container">
-			{ children || <Button
-				primary={ buttonPrimary }
-				href={ buttonHref }
-				target={ buttonTarget }
-				onClick={ buttonOnClick }
-			>
-				{ buttonText } { buttonIcon && <Gridicon icon={ buttonIcon } /> }
-			</Button> }
+			{ children || (
+				<Button
+					primary={ buttonPrimary }
+					href={ buttonHref }
+					target={ buttonTarget }
+					onClick={ buttonOnClick }
+				>
+					{ buttonText } { buttonIcon && <Gridicon icon={ buttonIcon } /> }
+				</Button>
+			) }
 		</div>
 	</CompactCard>
 );
@@ -46,11 +48,12 @@ ActionCard.propTypes = {
 	headerText: PropTypes.string.isRequired,
 	mainText: PropTypes.string.isRequired,
 	buttonPrimary: PropTypes.bool,
-	buttonText: PropTypes.string.isRequired,
+	buttonText: PropTypes.string,
 	buttonIcon: PropTypes.string,
 	buttonOnClick: PropTypes.func,
 	buttonHref: PropTypes.string,
 	buttonTarget: PropTypes.string,
+	children: PropTypes.any,
 };
 
 export default ActionCard;

--- a/client/my-sites/google-my-business/connect-button/index.js
+++ b/client/my-sites/google-my-business/connect-button/index.js
@@ -1,0 +1,135 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { last, isEqual } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import { deleteStoredKeyringConnection } from 'state/sharing/keyring/actions';
+import { SharingService, connectFor } from 'my-sites/sharing/connections/service';
+import { getKeyringServiceByName } from 'state/sharing/services/selectors';
+import QueryKeyringServices from 'components/data/query-keyring-services';
+
+class GoogleMyBusinessConnectButton extends SharingService {
+	static propTypes = {
+		...SharingService.propTypes,
+		deleteStoredKeyringConnection: PropTypes.func,
+		onClick: PropTypes.func,
+		onConnect: PropTypes.func,
+	};
+
+	static defaultProps = {
+		...SharingService.defaultProps,
+		deleteStoredKeyringConnection: () => {},
+		onClick: () => {},
+		onConnect: () => {},
+	};
+
+	// override `createOrUpdateConnection` to ignore connection update, this is only useful for publicize services
+	createOrUpdateConnection = () => {};
+
+	// override `removeConnection` to remove the keyring connection instead of the publicize one
+	removeConnection = () => {
+		this.setState( { isDisconnecting: true } );
+		this.props.deleteStoredKeyringConnection( last( this.props.keyringConnections ) );
+	};
+
+	onClick = () => {
+		this.performAction();
+		this.props.onClick();
+	};
+
+	componentWillReceiveProps( nextProps ) {
+		if ( ! isEqual( this.props.availableExternalAccounts, nextProps.availableExternalAccounts ) ) {
+			this.setState( {
+				isConnecting: false,
+				isDisconnecting: false,
+			} );
+		}
+
+		if ( ! this.state.isAwaitingConnections ) {
+			return;
+		}
+
+		this.setState( {
+			isAwaitingConnections: false,
+			isRefreshing: false,
+		} );
+
+		if ( this.didKeyringConnectionSucceed( nextProps.availableExternalAccounts ) ) {
+			this.setState( { isConnecting: false } );
+			this.props.onConnect();
+		}
+	}
+
+	render() {
+		const { service, translate } = this.props;
+		const { isConnecting, isRefreshing, isDisconnecting } = this.state;
+		const status = this.getConnectionStatus( service.ID );
+		let primary = false,
+			warning = false,
+			label;
+
+		const isPending = 'unknown' === status || isDisconnecting || isRefreshing || isConnecting;
+
+		if ( 'unknown' === status ) {
+			label = translate( 'Loading…' );
+		} else if ( isDisconnecting ) {
+			label = translate( 'Disconnecting…' );
+		} else if ( isRefreshing ) {
+			label = translate( 'Reconnecting…' );
+			warning = true;
+		} else if ( isConnecting ) {
+			label = translate( 'Connecting…' );
+		} else if ( 'connected' === status ) {
+			label = translate( 'Disconnect' );
+		} else {
+			label = this.props.children;
+			primary = true;
+		}
+
+		return (
+			<Button primary={ primary } scary={ warning } onClick={ this.onClick } disabled={ isPending }>
+				{ label }
+			</Button>
+		);
+	}
+}
+
+// `connectFor` HOC requires the `service` props to be passed
+// Therefore we need to wrap the resulting component into a parent component
+const GoogleMyBusinessConnectButtonConnected = connectFor(
+	GoogleMyBusinessConnectButton,
+	( state, props ) => {
+		return {
+			...props,
+			removableConnections: props.keyringConnections,
+			fetchConnection: props.requestKeyringConnections,
+			service: getKeyringServiceByName( state, 'google_my_business' ),
+			siteUserConnections: props.keyringConnections.map( connection => ( {
+				...connection,
+				keyring_connection_ID: connection.ID,
+			} ) ),
+		};
+	},
+	{
+		deleteStoredKeyringConnection,
+	}
+);
+
+export default connect( state => ( {
+	service: getKeyringServiceByName( state, 'google_my_business' ),
+} ) )( props => (
+	<div>
+		<QueryKeyringServices />
+		{ props.service && <GoogleMyBusinessConnectButtonConnected { ...props } /> }
+		{ ! props.service && <Button disabled={ true }>{ props.children }</Button> }
+	</div>
+) );

--- a/client/my-sites/google-my-business/connect-button/index.js
+++ b/client/my-sites/google-my-business/connect-button/index.js
@@ -20,10 +20,10 @@ import QueryKeyringServices from 'components/data/query-keyring-services';
 class GoogleMyBusinessConnectButton extends SharingService {
 	static propTypes = {
 		...SharingService.propTypes,
+		children: PropTypes.node.isRequired,
 		deleteStoredKeyringConnection: PropTypes.func,
 		onClick: PropTypes.func,
 		onConnect: PropTypes.func,
-		children: PropTypes.node.isRequired,
 	};
 
 	static defaultProps = {
@@ -42,7 +42,7 @@ class GoogleMyBusinessConnectButton extends SharingService {
 		this.props.deleteStoredKeyringConnection( last( this.props.keyringConnections ) );
 	};
 
-	onClick = () => {
+	handleClick = () => {
 		this.performAction();
 		this.props.onClick();
 	};
@@ -97,7 +97,7 @@ class GoogleMyBusinessConnectButton extends SharingService {
 		}
 
 		return (
-			<Button primary={ primary } scary={ warning } onClick={ this.onClick } disabled={ isPending }>
+			<Button primary={ primary } scary={ warning } onClick={ this.handleClick } disabled={ isPending }>
 				{ label }
 			</Button>
 		);

--- a/client/my-sites/google-my-business/connect-button/index.js
+++ b/client/my-sites/google-my-business/connect-button/index.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { last, isEqual, memoize } from 'lodash';
+import { last, isEqual, memoize, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,13 +28,13 @@ class GoogleMyBusinessConnectButton extends SharingService {
 
 	static defaultProps = {
 		...SharingService.defaultProps,
-		deleteStoredKeyringConnection: () => {},
-		onClick: () => {},
-		onConnect: () => {},
+		deleteStoredKeyringConnection: noop,
+		onClick: noop,
+		onConnect: noop,
 	};
 
 	// override `createOrUpdateConnection` to ignore connection update, this is only useful for publicize services
-	createOrUpdateConnection = () => {};
+	createOrUpdateConnection = noop;
 
 	// override `removeConnection` to remove the keyring connection instead of the publicize one
 	removeConnection = () => {

--- a/client/my-sites/google-my-business/connect-button/index.js
+++ b/client/my-sites/google-my-business/connect-button/index.js
@@ -23,6 +23,7 @@ class GoogleMyBusinessConnectButton extends SharingService {
 		deleteStoredKeyringConnection: PropTypes.func,
 		onClick: PropTypes.func,
 		onConnect: PropTypes.func,
+		children: PropTypes.node.isRequired,
 	};
 
 	static defaultProps = {

--- a/client/my-sites/google-my-business/connect-button/index.js
+++ b/client/my-sites/google-my-business/connect-button/index.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { last, isEqual } from 'lodash';
+import { last, isEqual, memoize } from 'lodash';
 
 /**
  * Internal dependencies
@@ -103,6 +103,13 @@ class GoogleMyBusinessConnectButton extends SharingService {
 	}
 }
 
+const addKeyringConnectionIdToConnections = memoize( connections =>
+	connections.map( connection => ( {
+		...connection,
+		keyring_connection_ID: connection.ID,
+	} ) )
+);
+
 // `connectFor` HOC requires the `service` props to be passed
 // Therefore we need to wrap the resulting component into a parent component
 const GoogleMyBusinessConnectButtonConnected = connectFor(
@@ -113,10 +120,7 @@ const GoogleMyBusinessConnectButtonConnected = connectFor(
 			removableConnections: props.keyringConnections,
 			fetchConnection: props.requestKeyringConnections,
 			service: getKeyringServiceByName( state, 'google_my_business' ),
-			siteUserConnections: props.keyringConnections.map( connection => ( {
-				...connection,
-				keyring_connection_ID: connection.ID,
-			} ) ),
+			siteUserConnections: addKeyringConnectionIdToConnections( props.keyringConnections ),
 		};
 	},
 	{

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -3,23 +3,28 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
+import Gridicon from 'gridicons';
 import page from 'page';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import HeaderCake from 'components/header-cake';
+import ActionCard from 'components/action-card';
+import Button from 'components/button';
 import Card from 'components/card';
 import CardHeading from 'components/card-heading';
-import ActionCard from 'components/action-card';
-import Main from 'components/main';
-import { recordTracksEvent } from 'state/analytics/actions';
+import config from 'config';
 import ExternalLink from 'components/external-link';
+import GoogleMyBusinessConnectButton from 'my-sites/google-my-business/connect-button';
+import HeaderCake from 'components/header-cake';
+import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { canCurrentUser } from 'state/selectors';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 class GoogleMyBusinessSelectBusinessType extends Component {
@@ -51,9 +56,43 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 		);
 	};
 
-	render() {
-		const { siteSlug, translate } = this.props;
+	handleConnect = () => {
+		/* eslint-disable no-console */
+		console.log( 'connected' );
+		// TODO: handle redirect to the "Create My Listings" page here
+	};
 
+	render() {
+		const { canUserManageOptions, siteSlug, translate } = this.props;
+
+		let connectButton;
+
+		if ( config.isEnabled( 'google-my-business' ) && canUserManageOptions ) {
+			connectButton = (
+				<GoogleMyBusinessConnectButton
+					onClick={ this.trackCreateMyListingClick }
+					onConnect={ this.handleConnect }
+				>
+					{ translate( 'Create Your Listing', {
+						comment: 'Call to Action to add a business listing to Google My Business',
+					} ) }
+				</GoogleMyBusinessConnectButton>
+			);
+		} else {
+			connectButton = (
+				<Button
+					primary
+					href="https://www.google.com/business/"
+					target="_blank"
+					onClick={ this.trackCreateMyListingClick }
+				>
+					{ translate( 'Create Your Listing', {
+						comment: 'Call to Action to add a business listing to Google My Business',
+					} ) }{ ' ' }
+					<Gridicon icon="external" />
+				</Button>
+			);
+		}
 		return (
 			<Main className="gmb-select-business-type" wideLayout>
 				<PageViewTracker
@@ -74,7 +113,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 						<p>
 							{ translate(
 								'{{link}}Google My Business{{/link}} lists your local business on Google Search and Google Maps. ' +
-									'It works for businesses that have a physical location or serve a local area.',
+								'It works for businesses that have a physical location or serve a local area.',
 								{
 									components: {
 										link: (
@@ -105,17 +144,11 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 					} ) }
 					mainText={ translate(
 						'Your business has a physical location customers can visit, ' +
-							'or provides goods and services to local customers, or both.'
+						'or provides goods and services to local customers, or both.'
 					) }
-					buttonText={ translate( 'Create Your Listing', {
-						comment: 'Call to Action to add a business listing to Google My Business',
-					} ) }
-					buttonIcon="external"
-					buttonPrimary={ true }
-					buttonHref="https://www.google.com/business/"
-					buttonTarget="_blank"
-					buttonOnClick={ this.trackCreateMyListingClick }
-				/>
+				>
+					{ connectButton }
+				</ActionCard>
 
 				<ActionCard
 					headerText={ translate( 'Online Only', {
@@ -135,6 +168,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 
 export default connect(
 	state => ( {
+		canUserManageOptions: canCurrentUser( state, getSelectedSiteSlug( state ), 'manage_options' ),
 		siteSlug: getSelectedSiteSlug( state ),
 	} ),
 	{


### PR DESCRIPTION
This is a follow up of https://github.com/Automattic/wp-calypso/pull/23560 and thus requires server side patch D11178 as well.

This PR adds a standalone button to connect to Google My Business from anywhere.
It was tempting to make a generic button to connect to any keyring services from anywhere in calypso but given all the different cases to handle (multiple accounts to handle, reconnecting...)  I decided that it was out of scope of this PR.

### Testing Instructions
- Boot this branch locally or use calypso.live
- Go to http://calypso.localhost:3000/google-my-business and select a site that you can manage 
- Check that you can connect and disconnect

### TODO
- [x] Prevent users from connecting their google my business account if they don't have manage access to the site.