### PR TITLE
QueryManager: Allow null itemKeys

### DIFF
--- a/client/lib/query-manager/schema.js
+++ b/client/lib/query-manager/schema.js
@@ -3,49 +3,52 @@
 /**
  * External dependencies
  */
+import deepFreeze from 'deep-freeze';
 import { cloneDeepWith } from 'lodash';
 
-const queryManagerSchema = Object.freeze( {
+const queryManagerSchema = deepFreeze( {
 	additionalProperties: false,
-	required: Object.freeze( [ 'data', 'options' ] ),
+	required: [ 'data', 'options' ],
 	type: 'object',
-	properties: Object.freeze( {
-		data: Object.freeze( {
+	properties: {
+		data: {
 			additionalProperties: false,
 			type: 'object',
-			properties: Object.freeze( {
-				items: Object.freeze( { type: 'object' } ),
-				queries: Object.freeze( {
+			properties: {
+				items: { type: 'object' },
+				queries: {
 					additionalProperties: false,
 					type: 'object',
-					patternProperties: Object.freeze( {
+					patternProperties: {
 						// Stringified query objects are the keys
-						'^\\[.*\\]$': Object.freeze( {
-							required: Object.freeze( [ 'itemKeys' ] ),
+						'^\\[.*\\]$': {
+							required: [ 'itemKeys' ],
 							type: 'object',
-							properties: Object.freeze( {
-								itemKeys: Object.freeze( {
+							properties: {
+								itemKeys: {
 									type: 'array',
-									items: Object.freeze( { type: Object.freeze( [ 'string', 'integer' ] ) } ),
-								} ),
-								found: Object.freeze( {
+									items: {
+										type: [ 'string', 'integer' ],
+									},
+								},
+								found: {
 									type: 'integer',
-								} ),
-							} ),
-						} ),
-					} ),
-				} ),
-			} ),
-		} ),
-		options: Object.freeze( {
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		options: {
 			additionalProperties: true,
-			required: Object.freeze( [ 'itemKey' ] ),
+			required: [ 'itemKey' ],
 			type: 'object',
-			properties: Object.freeze( {
-				itemKey: Object.freeze( { type: 'string' } ),
-			} ),
-		} ),
-	} ),
+			properties: {
+				itemKey: { type: 'string' },
+			},
+		},
+	},
 } );
 
 /**

--- a/client/lib/query-manager/schema.js
+++ b/client/lib/query-manager/schema.js
@@ -28,7 +28,10 @@ const queryManagerSchema = deepFreeze( {
 								itemKeys: {
 									type: 'array',
 									items: {
-										type: [ 'string', 'integer' ],
+										// Typical valid object keys
+										// `null` is important for PagingQueryManager
+										// It fills array with undefined (matches null)
+										type: [ 'integer', 'null', 'string' ],
 									},
 								},
 								found: {


### PR DESCRIPTION
Use `deepFreeze` as was originally intended (#23361)
Add `null` itemKey type. `PagingQueryManager` populates an array with `null`.

## Testing

See #23361 

Ensure that PagingQueryManagers have no deserialize errors. Try WordPress.com/themes logged out, scroll to load a few pages, refresh.