### PR TITLE
State: Persist for logged-out users

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -106,6 +106,9 @@ function isLoggedIn() {
 }
 
 function getReduxStateKey() {
+	if ( ! isLoggedIn() ) {
+		return 'redux-state-logged-out';
+	}
 	return 'redux-state-' + user.get().ID;
 }
 
@@ -114,10 +117,6 @@ export function persistOnChange( reduxStore, serializeState = serialize ) {
 
 	const throttledSaveState = throttle(
 		function() {
-			if ( ! isLoggedIn() ) {
-				return;
-			}
-
 			const nextState = reduxStore.getState();
 			if ( state && nextState === state ) {
 				return;
@@ -143,8 +142,7 @@ export function persistOnChange( reduxStore, serializeState = serialize ) {
 }
 
 export default function createReduxStoreFromPersistedInitialState( reduxStoreReady ) {
-	const shouldPersist =
-		config.isEnabled( 'persist-redux' ) && isLoggedIn() && ! isSupportUserSession();
+	const shouldPersist = config.isEnabled( 'persist-redux' ) && ! isSupportUserSession();
 
 	if ( 'development' === process.env.NODE_ENV ) {
 		window.resetState = () => localforage.clear( () => location.reload( true ) );

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -105,6 +105,10 @@ function isLoggedIn() {
 	return !! userData && userData.ID;
 }
 
+function getReduxStateKey() {
+	return 'redux-state-' + user.get().ID;
+}
+
 export function persistOnChange( reduxStore, serializeState = serialize ) {
 	let state;
 
@@ -121,11 +125,9 @@ export function persistOnChange( reduxStore, serializeState = serialize ) {
 
 			state = nextState;
 
-			localforage
-				.setItem( 'redux-state-' + user.get().ID, serializeState( state ) )
-				.catch( setError => {
-					debug( 'failed to set redux-store state', setError );
-				} );
+			localforage.setItem( getReduxStateKey(), serializeState( state ) ).catch( setError => {
+				debug( 'failed to set redux-store state', setError );
+			} );
 		},
 		SERIALIZE_THROTTLE,
 		{ leading: false, trailing: true }
@@ -164,7 +166,7 @@ export default function createReduxStoreFromPersistedInitialState( reduxStoreRea
 
 	if ( shouldPersist ) {
 		return localforage
-			.getItem( 'redux-state-' + user.get().ID )
+			.getItem( getReduxStateKey() )
 			.then( loadInitialState )
 			.catch( loadInitialStateFailed )
 			.then( persistOnChange )


### PR DESCRIPTION
Main rationale for this PR is to fix #23436: this is a logged-out flow which at one point leaves WP.com (for a Jetpack Connect redirect thru the JP site's wp-admin), which means state is lost afterwards, negatively impacting UX: If the user clicks e.g. the browser's 'Back' button, they end up at a different step than they were at (see instructions below).

Enabling persistence for logged-out users will ensure [state is persisted](https://github.com/Automattic/wp-calypso/blob/f0cfeb46c153e97d2b5b5bf05f66c1fdcf2b80a7/client/state/initial-state.js#L135) when navigating away from Calypso.

Originally _disabled_ for logged-out users in #13185, which fixed #11766. Even more context/discussion in #14238.

Note that this _shouldn't_ cause a regression wrt #11766, since we're still keying persisted state by user ID (or `logged-out` if we are, well, logged out). Overall, this seems conceptually rather clean, so I hope most potential side effects of persisting logged-out state are pre-empted by this.

However, to really avoid unwanted side effects, we should give it some thorough thought and testing. _What other parts of Calypso could possibly be affected by this?_

Steve suggested merging logged-out into per-user state upon login -- I'm not sure this is even required to retain functionality? Might be nice to have, but maybe for another iteration to keep this as atomic as possible?

### To repro the bug:

1. (Optional: Get a fresh throwaway JP site from jurassic.ninja/create?jetpack-beta -- use an incognito window.)
1. Proxy!
1. Start the flow here: http://yourgroovydomain.com/wp-admin/admin.php?page=jetpack&action=onboard
1. Enter a site title.
1. Select “Personal” or “Business” for the site type.
1. Select “Recent news” or “Static page” for the homepage.
1. Select “Add a contact form” to be taken to the Jetpack connection flow. I was logged out, so this brought me to the account signup form.
1. Select the browser’s back button.
1. _Instead of the step you were previously at, you'll be redirected to the _first_ JPO step (Site Title & Description)_

Now try the same with this branch (using http://yourgroovydomain.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development for step 3.), and verify that this time, you're taken back to the step you were previously at.

Finally, verify that this isn't causing a regression wrt #11766.