### PR TITLE
QueryJetpackOnboardingSettings: Use new isRequestingJetpackOnboardingSettings() selector

### DIFF
--- a/client/components/data/query-jetpack-onboarding-settings/index.jsx
+++ b/client/components/data/query-jetpack-onboarding-settings/index.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { getRequest } from 'state/selectors';
+import { isRequestingJetpackOnboardingSettings } from 'state/selectors';
 import { requestJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class QueryJetpackOnboardingSettings extends Component {
@@ -47,8 +47,7 @@ class QueryJetpackOnboardingSettings extends Component {
 
 export default connect(
 	( state, { query, siteId } ) => ( {
-		requestingSettings: getRequest( state, requestJetpackOnboardingSettings( siteId, query ) )
-			.isLoading,
+		requestingSettings: isRequestingJetpackOnboardingSettings( state, siteId, query ),
 	} ),
 	{ requestJetpackOnboardingSettings }
 )( QueryJetpackOnboardingSettings );


### PR DESCRIPTION
Stoopid me missed this in #23627 🙄 

To test: Verify that JPO still works as before. Verify in particular that JPO fetches the current values for fields and pre-populates them.