### PR TITLE
Remove direct usage of plan constants

### DIFF
--- a/client/lib/automated-transfer/index.js
+++ b/client/lib/automated-transfer/index.js
@@ -9,7 +9,8 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import config, { isEnabled } from 'config';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { planMatches } from 'lib/plans';
+import { TYPE_BUSINESS, GROUP_WPCOM } from 'lib/plans/constants';
 import { userCan } from 'lib/site/utils';
 
 /**
@@ -40,7 +41,7 @@ export function isATEnabled( site ) {
 
 	// Site has Business plan
 	const planSlug = get( site, 'plan.product_slug' );
-	if ( planSlug !== PLAN_BUSINESS ) {
+	if ( ! planMatches( planSlug, { type: TYPE_BUSINESS, group: GROUP_WPCOM } ) ) {
 		return false;
 	}
 

--- a/client/lib/automated-transfer/test/index.js
+++ b/client/lib/automated-transfer/test/index.js
@@ -1,0 +1,142 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.mock( 'config', () => {
+	const defaultExport = jest.fn();
+	defaultExport.isEnabled = jest.fn();
+	defaultExport.default = jest.fn();
+	return defaultExport;
+} );
+
+jest.mock( 'lib/site/utils', () => ( {
+	userCan: jest.fn(),
+} ) );
+
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+import {
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { isATEnabled } from '../index';
+
+const config = require( 'config' );
+const utils = require( 'lib/site/utils' );
+
+const site = {
+	options: {
+		is_automated_transfer: false,
+	},
+	plan: {
+		product_slug: PLAN_FREE,
+	},
+};
+
+const site_at = {
+	options: {
+		is_automated_transfer: true,
+	},
+};
+
+describe( 'isATEnabled basic tests', () => {
+	let beforeWindow;
+	beforeAll( function() {
+		beforeWindow = global.window;
+		global.window = {};
+	} );
+
+	afterAll( function() {
+		global.window = beforeWindow;
+	} );
+
+	beforeEach( () => {
+		config.mockImplementation( () => 'some_env' );
+		config.isEnabled.mockImplementation( () => true );
+		utils.userCan.mockImplementation( () => true );
+	} );
+
+	test( 'should not blow up', () => {
+		assert.equal( isATEnabled( site ), false );
+	} );
+
+	test( 'should return false if window is undefined', () => {
+		delete global.window;
+		assert.equal( isATEnabled( site_at ), false );
+		global.window = {};
+	} );
+
+	test( 'should return true if AT option is enabled', () => {
+		assert.equal( isATEnabled( site_at ), true );
+	} );
+
+	test( 'should return false if AT feature is disabled', () => {
+		config.isEnabled.mockImplementation( () => false );
+		assert.equal( isATEnabled( site ), false );
+	} );
+
+	test( 'should return true if env is wpcalypso', () => {
+		config.mockImplementation( () => 'wpcalypso' );
+		config.isEnabled.mockImplementation( () => true );
+		assert.equal( isATEnabled( site ), true );
+	} );
+
+	test( 'should return false if site does not have a business plan', () => {
+		const plans = [
+			PLAN_FREE,
+			PLAN_PREMIUM,
+			PLAN_PREMIUM_2_YEARS,
+			PLAN_PERSONAL,
+			PLAN_PERSONAL_2_YEARS,
+			PLAN_JETPACK_PERSONAL,
+			PLAN_JETPACK_PERSONAL_MONTHLY,
+			PLAN_JETPACK_PREMIUM,
+			PLAN_JETPACK_PREMIUM_MONTHLY,
+			PLAN_JETPACK_BUSINESS,
+			PLAN_JETPACK_BUSINESS_MONTHLY,
+		];
+
+		plans.forEach( product_slug => {
+			const mySite = {
+				...site,
+				plan: { product_slug },
+			};
+			assert.equal( isATEnabled( mySite ), false );
+		} );
+	} );
+
+	test( "should return false if user can't manage site", () => {
+		utils.userCan.mockImplementation( () => false );
+		assert.equal( isATEnabled( site ), false );
+	} );
+
+	test( 'should return true otherwise', () => {
+		const plans = [ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ];
+		plans.forEach( product_slug => {
+			const mySite = {
+				...site,
+				plan: { product_slug },
+			};
+			assert.equal( isATEnabled( mySite ), true );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `isATEnabled`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* Go to http://calypso.localhost:3000/plugins/advanced-database-cleaner/ and confirm that `Incompatible plugin: This plugin is not supported on WordPress.com.` is visible only for AT sites (you may need to refresh the page each time you change a site in the sidebar)