### PR TITLE
Data Layer: Add retry policy for POST request

### DIFF
--- a/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/index.jsx
+++ b/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/index.jsx
@@ -3,12 +3,12 @@
 /**
  * External dependencies
  */
-
-import { get, merge } from 'lodash';
+import { get, includes, merge } from 'lodash';
 import { decorrelatedJitter as defaultDelay } from './delays';
 import { default as defaultPolicy } from './policies';
 
-const isGetRequest = request => 'GET' === get( request, 'method', '' ).toUpperCase();
+const isAllowedRequest = ( request, allowedMethods ) =>
+	includes( allowedMethods, get( request, 'method', '' ).toUpperCase() );
 
 export const retryOnFailure = ( getDelay = defaultDelay ) => inboundData => {
 	const { nextError, originalRequest, store: { dispatch } } = inboundData;
@@ -20,16 +20,16 @@ export const retryOnFailure = ( getDelay = defaultDelay ) => inboundData => {
 		return inboundData;
 	}
 
-	// otherwise check if we should try again
-	if ( ! isGetRequest( originalRequest ) ) {
-		return inboundData;
-	}
-
 	const { options: { retryPolicy: policy = defaultPolicy } = {} } = originalRequest;
-	const { delay, maxAttempts, name } = policy;
+	const { allowedMethods, delay, maxAttempts, name } = policy;
+
 	const retryCount = get( originalRequest, 'meta.dataLayer.retryCount', 0 ) + 1;
 
-	if ( 'NO_RETRY' === name || retryCount > maxAttempts ) {
+	if (
+		'NO_RETRY' === name ||
+		! isAllowedRequest( originalRequest, allowedMethods ) ||
+		retryCount > maxAttempts
+	) {
 		return inboundData;
 	}
 

--- a/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/policies.js
+++ b/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/policies.js
@@ -6,14 +6,9 @@ export const exponentialBackoff = ( { delay = 1000, maxAttempts = 3 } = {} ) => 
 	allowedMethods: [ 'GET' ],
 } );
 
-export const explicitPost = () => ( {
-	name: 'EXPLICITY_POST',
-	allowedMethods: [ 'POST' ],
-} );
-
 export const exponentialBackoffExplicitPost = ( { delay, maxAttempts } = {} ) => ( {
 	...exponentialBackoff( delay, maxAttempts ),
-	...explicitPost(),
+	allowedMethods: [ 'POST' ],
 	name: 'EXPONENTIAL_BACKOFF_EXPLICIT_POST',
 } );
 

--- a/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/policies.js
+++ b/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/policies.js
@@ -1,4 +1,5 @@
 /** @format */
+
 export const exponentialBackoff = ( { delay = 1000, maxAttempts = 3 } = {} ) => ( {
 	name: 'EXPONENTIAL_BACKOFF',
 	delay: Math.max( 500, delay ),

--- a/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/policies.js
+++ b/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/policies.js
@@ -3,6 +3,18 @@ export const exponentialBackoff = ( { delay = 1000, maxAttempts = 3 } = {} ) => 
 	name: 'EXPONENTIAL_BACKOFF',
 	delay: Math.max( 500, delay ),
 	maxAttempts: Math.min( 5, maxAttempts ),
+	allowedMethods: [ 'GET' ],
+} );
+
+export const explicitPost = () => ( {
+	name: 'EXPLICITY_POST',
+	allowedMethods: [ 'POST' ],
+} );
+
+export const exponentialBackoffExplicitPost = ( { delay, maxAttempts } = {} ) => ( {
+	...exponentialBackoff( delay, maxAttempts ),
+	...explicitPost(),
+	name: 'EXPONENTIAL_BACKOFF_EXPLICIT_POST',
 } );
 
 export const noRetry = () => ( {

--- a/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/test/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/test/index.js
@@ -87,7 +87,10 @@ describe( '#retryOnFailure', () => {
 	} );
 
 	test( 'should requeue only up to `maxAttempts`', () => {
-		const originalRequest = { ...getSites, options: { retryPolicy: { maxAttempts: 3 } } };
+		const originalRequest = {
+			...getSites,
+			options: { retryPolicy: { maxAttempts: 3, allowedMethods: [ 'GET' ] } },
+		};
 		const inbound = { nextError, originalRequest, store };
 		const retryIt = retryWithDelay( 1337 );
 


### PR DESCRIPTION
WIP. Follow-up to https://github.com/Automattic/wp-calypso/pull/22454#issuecomment-367136834, now also needed for JP Install.

TODO: 
* Fix/Add tests?
* Pass policy to request (different PR)

example for Jetpack remote install:
```diff
diff --git a/client/state/data-layer/wpcom/jetpack-install/index.js b/client/state/data-layer/wpcom/jetpack-install/index.js
index a7ee6b5..08a6db8 100644
--- a/client/state/data-layer/wpcom/jetpack-install/index.js
+++ b/client/state/data-layer/wpcom/jetpack-install/index.js
@@ -9,6 +9,7 @@ import { noop } from 'lodash';
  */
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import { exponentialBackoffExplicitPost } from 'state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 import {
        jetpackRemoteInstallComplete,
        jetpackRemoteInstallUpdateError,
@@ -25,6 +26,7 @@ export const installJetpackPlugin = action =>
                                user: action.user,
                                password: action.password,
                        },
+                       retryPolicy: exponentialBackoffExplicitPost(),
                },
                action
        );
```

cc @dmsnell 