### PR TITLE
Analytics: Track /me/purchases page views with normalized paths

### DIFF
--- a/client/lib/react-helpers/index.js
+++ b/client/lib/react-helpers/index.js
@@ -8,17 +8,8 @@ import ReactDom from 'react-dom';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 
-/**
- * Internal dependencies
- */
-import analytics from 'lib/analytics';
-
 export function concatTitle( ...parts ) {
 	return parts.join( ' › ' );
-}
-
-export function recordPageView( path, ...title ) {
-	analytics.pageView.record( path, concatTitle( ...title ) );
 }
 
 export function renderWithReduxStore( reactElement, domContainer, reduxStore ) {

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -266,7 +266,7 @@ class BillingReceipt extends React.Component {
 			<Main>
 				<DocumentHead title={ translate( 'Billing History' ) } />
 				<PageViewTracker
-					path="/me/purchases/billing/receipt"
+					path="/me/purchases/billing/:receipt"
 					title="Me > Billing History > Receipt"
 				/>
 				<QueryBillingTransactions />

--- a/client/me/purchases/add-credit-card/index.jsx
+++ b/client/me/purchases/add-credit-card/index.jsx
@@ -21,6 +21,7 @@ import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import titles from 'me/purchases/titles';
 import { billingHistory } from 'me/purchases/paths';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 class AddCreditCard extends Component {
 	static propTypes = {
@@ -43,6 +44,7 @@ class AddCreditCard extends Component {
 	render() {
 		return (
 			<Main>
+				<PageViewTracker path="/me/purchases/add-credit-card" title="Purchases > Add Credit Card" />
 				<DocumentHead title={ concatTitle( titles.purchases, titles.addCreditCard ) } />
 
 				<HeaderCake onClick={ this.goToBillingHistory }>{ titles.addCreditCard }</HeaderCake>

--- a/client/me/purchases/cancel-privacy-protection/index.jsx
+++ b/client/me/purchases/cancel-privacy-protection/index.jsx
@@ -33,6 +33,7 @@ import QueryUserPurchases from 'components/data/query-user-purchases';
 import titles from 'me/purchases/titles';
 import userFactory from 'lib/user';
 import { CALYPSO_CONTACT } from 'lib/url/support';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 const user = userFactory();
 
@@ -204,6 +205,10 @@ class CancelPrivacyProtection extends Component {
 
 		return (
 			<Main>
+				<PageViewTracker
+					path="/me/purchases/:site/:purchaseId/cancel-privacy-protection"
+					title="Purchases > Cancel Privacy Protection"
+				/>
 				<QueryUserPurchases userId={ user.get().ID } />
 				<HeaderCake onClick={ goToManagePurchase.bind( null, this.props ) }>
 					{ titles.cancelPrivacyProtection }

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -45,7 +45,6 @@ import QueryUserPurchases from 'components/data/query-user-purchases';
 import ProductLink from 'me/purchases/product-link';
 import titles from 'me/purchases/titles';
 import userFactory from 'lib/user';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 const user = userFactory();
 
@@ -184,10 +183,6 @@ class CancelPurchase extends React.Component {
 
 		return (
 			<Main className="cancel-purchase">
-				<PageViewTracker
-					path="/me/purchases/:site/:purchaseId/cancel"
-					title="Purchases > Cancel Purchase"
-				/>
 				<HeaderCake onClick={ goToManagePurchase.bind( null, this.props ) }>
 					{ titles.cancelPurchase }
 				</HeaderCake>

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -45,6 +45,7 @@ import QueryUserPurchases from 'components/data/query-user-purchases';
 import ProductLink from 'me/purchases/product-link';
 import titles from 'me/purchases/titles';
 import userFactory from 'lib/user';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 const user = userFactory();
 
@@ -183,6 +184,10 @@ class CancelPurchase extends React.Component {
 
 		return (
 			<Main className="cancel-purchase">
+				<PageViewTracker
+					path="/me/purchases/:site/:purchaseId/cancel"
+					title="Purchases > Cancel Purchase"
+				/>
 				<HeaderCake onClick={ goToManagePurchase.bind( null, this.props ) }>
 					{ titles.cancelPurchase }
 				</HeaderCake>

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -40,6 +40,7 @@ import SelectDropdown from 'components/select-dropdown';
 import { setAllSitesSelected } from 'state/ui/actions';
 import titles from 'me/purchases/titles';
 import userFactory from 'lib/user';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 const user = userFactory();
 
@@ -265,6 +266,10 @@ class ConfirmCancelDomain extends React.Component {
 
 		return (
 			<Main className="confirm-cancel-domain">
+				<PageViewTracker
+					path="/me/purchases/:site/:purchaseId/confirm-cancel-domain"
+					title="Purchases > Confirm Cancel Domain"
+				/>
 				<HeaderCake onClick={ this.goToCancelPurchase }>{ titles.confirmCancelDomain }</HeaderCake>
 				<Card>
 					<FormSectionHeading className="is-primary">

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -40,8 +40,6 @@ export default {
 	addCardDetails( context, next ) {
 		setTitle( context, titles.addCardDetails );
 
-		recordPurchasesPageView( paths.addCardDetails(), 'Add Card Details' );
-
 		context.primary = <AddCardDetails purchaseId={ parseInt( context.params.purchaseId, 10 ) } />;
 		next();
 	},
@@ -84,8 +82,6 @@ export default {
 
 	editCardDetails( context, next ) {
 		setTitle( context, titles.editCardDetails );
-
-		recordPurchasesPageView( paths.editCardDetails(), 'Edit Card Details' );
 
 		context.primary = (
 			<EditCardDetails

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -47,8 +47,6 @@ export default {
 	},
 
 	addCreditCard( context, next ) {
-		recordPurchasesPageView( paths.addCreditCard, 'Add Credit Card' );
-
 		context.primary = <AddCreditCard />;
 		next();
 	},

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -61,8 +61,6 @@ export default {
 	cancelPurchase( context, next ) {
 		setTitle( context, titles.cancelPurchase );
 
-		recordPurchasesPageView( paths.cancelPurchase(), 'Cancel Purchase' );
-
 		context.primary = <CancelPurchase purchaseId={ parseInt( context.params.purchaseId, 10 ) } />;
 		next();
 	},

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -19,7 +19,6 @@ import EditCardDetails from './payment/edit-card-details';
 import Main from 'components/main';
 import ManagePurchase from './manage-purchase';
 import NoSitesMessage from 'components/empty-content/no-sites-message';
-import * as paths from './paths';
 import PurchasesHeader from './purchases-list/header';
 import PurchasesList from './purchases-list';
 import { concatTitle, recordPageView } from 'lib/react-helpers';
@@ -89,16 +88,12 @@ export default {
 	list( context, next ) {
 		setTitle( context );
 
-		recordPurchasesPageView( paths.purchasesRoot );
-
 		context.primary = <PurchasesList noticeType={ context.params.noticeType } />;
 		next();
 	},
 
 	managePurchase( context, next ) {
 		setTitle( context, titles.managePurchase );
-
-		recordPurchasesPageView( paths.managePurchase(), 'Manage Purchase' );
 
 		context.primary = (
 			<ManagePurchase

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -35,7 +35,7 @@ function setTitle( context, ...title ) {
 	context.store.dispatch( setDocumentHeadTitle( concatTitle( titles.purchases, ...title ) ) );
 }
 
-const userHasNoSites = user.get().site_count <= 0;
+const userHasNoSites = () => user.get().site_count <= 0;
 
 function noSites( context, analyticsPath ) {
 	setTitle( context );
@@ -52,7 +52,7 @@ function noSites( context, analyticsPath ) {
 
 export default {
 	addCardDetails( context, next ) {
-		if ( userHasNoSites ) {
+		if ( userHasNoSites() ) {
 			return noSites( context, '/me/purchases/:site/:purchaseId/payment/add' );
 		}
 
@@ -68,7 +68,7 @@ export default {
 	},
 
 	cancelPrivacyProtection( context, next ) {
-		if ( userHasNoSites ) {
+		if ( userHasNoSites() ) {
 			return noSites( context, '/me/purchases/:site/:purchaseId/cancel-privacy-protection' );
 		}
 
@@ -81,7 +81,7 @@ export default {
 	},
 
 	cancelPurchase( context, next ) {
-		if ( userHasNoSites ) {
+		if ( userHasNoSites() ) {
 			return noSites( context, '/me/purchases/:site/:purchaseId/cancel' );
 		}
 
@@ -92,7 +92,7 @@ export default {
 	},
 
 	confirmCancelDomain( context, next ) {
-		if ( userHasNoSites ) {
+		if ( userHasNoSites() ) {
 			return noSites( context, '/me/purchases/:site/:purchaseId/confirm-cancel-domain' );
 		}
 
@@ -105,7 +105,7 @@ export default {
 	},
 
 	editCardDetails( context, next ) {
-		if ( userHasNoSites ) {
+		if ( userHasNoSites() ) {
 			return noSites( context, '/me/purchases/:site/:purchaseId/payment/edit/:cardId' );
 		}
 
@@ -121,7 +121,7 @@ export default {
 	},
 
 	list( context, next ) {
-		if ( userHasNoSites ) {
+		if ( userHasNoSites() ) {
 			return noSites( context, '/me/purchases' );
 		}
 
@@ -132,7 +132,7 @@ export default {
 	},
 
 	managePurchase( context, next ) {
-		if ( userHasNoSites ) {
+		if ( userHasNoSites() ) {
 			return noSites( context, '/me/purchases/:site/:purchaseId' );
 		}
 

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -52,8 +52,6 @@ export default {
 	cancelPrivacyProtection( context, next ) {
 		setTitle( context, titles.cancelPrivacyProtection );
 
-		recordPurchasesPageView( paths.cancelPrivacyProtection(), 'Cancel Privacy Protection' );
-
 		context.primary = (
 			<CancelPrivacyProtection purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
 		);

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -68,8 +68,6 @@ export default {
 	confirmCancelDomain( context, next ) {
 		setTitle( context, titles.confirmCancelDomain );
 
-		recordPurchasesPageView( paths.confirmCancelDomain(), 'Confirm Cancel Domain' );
-
 		context.primary = (
 			<ConfirmCancelDomain purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
 		);

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -46,19 +46,11 @@ export default function() {
 		clientRender
 	);
 
-	page(
-		paths.purchasesRoot,
-		meController.sidebar,
-		controller.noSitesMessage,
-		controller.list,
-		makeLayout,
-		clientRender
-	);
+	page( paths.purchasesRoot, meController.sidebar, controller.list, makeLayout, clientRender );
 
 	page(
 		paths.managePurchase(),
 		meController.sidebar,
-		controller.noSitesMessage,
 		siteSelection,
 		controller.managePurchase,
 		makeLayout,
@@ -68,7 +60,6 @@ export default function() {
 	page(
 		paths.cancelPurchase(),
 		meController.sidebar,
-		controller.noSitesMessage,
 		siteSelection,
 		controller.cancelPurchase,
 		makeLayout,
@@ -78,7 +69,6 @@ export default function() {
 	page(
 		paths.cancelPrivacyProtection(),
 		meController.sidebar,
-		controller.noSitesMessage,
 		siteSelection,
 		controller.cancelPrivacyProtection,
 		makeLayout,
@@ -88,7 +78,6 @@ export default function() {
 	page(
 		paths.confirmCancelDomain(),
 		meController.sidebar,
-		controller.noSitesMessage,
 		siteSelection,
 		controller.confirmCancelDomain,
 		makeLayout,
@@ -98,7 +87,6 @@ export default function() {
 	page(
 		paths.addCardDetails(),
 		meController.sidebar,
-		controller.noSitesMessage,
 		siteSelection,
 		controller.addCardDetails,
 		makeLayout,
@@ -108,7 +96,6 @@ export default function() {
 	page(
 		paths.editCardDetails(),
 		meController.sidebar,
-		controller.noSitesMessage,
 		siteSelection,
 		controller.editCardDetails,
 		makeLayout,

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -82,6 +82,7 @@ import { CALYPSO_CONTACT } from 'lib/url/support';
 import titles from 'me/purchases/titles';
 import userFactory from 'lib/user';
 import { addItems } from 'lib/upgrades/actions';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 const user = userFactory();
 
@@ -458,6 +459,10 @@ class ManagePurchase extends Component {
 					<QueryCanonicalTheme siteId={ selectedSiteId } themeId={ selectedPurchase.meta } />
 				) }
 				<Main className={ classes }>
+					<PageViewTracker
+						path="/me/purchases/:site/:purchaseId"
+						title="Purchases > Manage Purchase"
+					/>
 					<HeaderCake onClick={ goToList }>{ titles.managePurchase }</HeaderCake>
 					{
 						<PurchaseNotice

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -24,6 +24,7 @@ import PurchaseCardDetails from 'me/purchases/components/purchase-card-details';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import titles from 'me/purchases/titles';
 import userFactory from 'lib/user';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 const user = userFactory();
 
@@ -61,6 +62,10 @@ class AddCardDetails extends PurchaseCardDetails {
 
 		return (
 			<Main>
+				<PageViewTracker
+					path="/me/purchases/:site/:purchaseId/payment/add"
+					title="Purchases > Add Card Details"
+				/>
 				<HeaderCake onClick={ this.goToManagePurchase }>{ titles.addCardDetails }</HeaderCake>
 
 				<CreditCardForm

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -69,7 +69,7 @@ class EditCardDetails extends PurchaseCardDetails {
 		return (
 			<Main>
 				<PageViewTracker
-					path="/me/purchases/:site/:purchaseId/payment/edit"
+					path="/me/purchases/:site/:purchaseId/payment/edit/:cardId"
 					title="Purchases > Edit Card Details"
 				/>
 				<HeaderCake onClick={ this.goToManagePurchase }>{ titles.editCardDetails }</HeaderCake>

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -26,6 +26,7 @@ import QueryStoredCards from 'components/data/query-stored-cards';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import titles from 'me/purchases/titles';
 import userFactory from 'lib/user';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 const user = userFactory();
 
@@ -67,6 +68,10 @@ class EditCardDetails extends PurchaseCardDetails {
 
 		return (
 			<Main>
+				<PageViewTracker
+					path="/me/purchases/:site/:purchaseId/payment/edit"
+					title="Purchases > Edit Card Details"
+				/>
 				<HeaderCake onClick={ this.goToManagePurchase }>{ titles.editCardDetails }</HeaderCake>
 
 				<CreditCardForm

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -28,6 +28,7 @@ import PurchasesSite from '../purchases-site';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import userFactory from 'lib/user';
 const user = userFactory();
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 class PurchasesList extends Component {
 	isDataLoading() {
@@ -76,6 +77,7 @@ class PurchasesList extends Component {
 
 		return (
 			<Main className="purchases-list">
+				<PageViewTracker path="/me/purchases" title="Purchases" />
 				<MeSidebarNavigation />
 				<PurchasesHeader section={ 'purchases' } />
 				<QueryUserPurchases userId={ user.get().ID } />


### PR DESCRIPTION
Fix #23515

Replace direct `analytics.pageView.record` calls with the `PageViewTracker` component which is aware of the selected site (no more incorrect `blog_id: undefined` reports).

Change the no sites handling.
Previously it used a `noSitesMessage` page callback in most routes, before the actual callback for the selected route.
This made it quite hard to track the page view paths in case of no sites, so I've moved the handling into each route callbacks instead.

Remove `lib/react-helpers/`'s `recordPageView` helper, which was unused after this PR changes.

## Paths Updated

- /me/purchases
- /me/purchases/add-credit-card
- /me/purchases/:site/:purchaseId
- /me/purchases/:site/:purchaseId/cancel
- /me/purchases/:site/:purchaseId/cancel-privacy-protection
- /me/purchases/:site/:purchaseId/confirm-cancel-domain
- /me/purchases/:site/:purchaseId/payment/add
- /me/purchases/:site/:purchaseId/payment/edit/:cardId
- /me/purchases/billing/:receiptId
(only updated the tracked path from `/me/purchases/billing/receipt`)

## Path not updated

- /me/purchases/billing (already used `PageViewTracker` with the correct path)

## Testing instructions

- Enable tracks debugging with `localStorage.setItem('debug', 'calypso:analytics:tracks')` and filter by `page_view`.
- Make sure loading various `/me/purchases` paths always report the normalized path as described in the list above.