### PR TITLE
Editor: Fix unsafe property access errors

### DIFF
--- a/client/post-editor/editor-delete-post/index.jsx
+++ b/client/post-editor/editor-delete-post/index.jsx
@@ -10,6 +10,7 @@ import React from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
+import { get, isNull } from 'lodash';
 
 /**
  * Internal dependencies
@@ -112,7 +113,7 @@ export default connect(
 		const post = getEditedPost( state, siteId, postId );
 
 		const userId = getCurrentUserId( state );
-		const isAuthor = post.author && post.author.ID === userId;
+		const isAuthor = ! isNull( userId ) && get( post, [ 'author', 'ID' ], null ) === userId;
 
 		return {
 			siteId,

--- a/client/post-editor/editor-delete-post/index.jsx
+++ b/client/post-editor/editor-delete-post/index.jsx
@@ -119,7 +119,7 @@ export default connect(
 			siteId,
 			post,
 			postId,
-			postStatus: post.status,
+			postStatus: get( post, 'status', null ),
 			canDelete: canCurrentUser( state, siteId, isAuthor ? 'delete_posts' : 'delete_others_posts' ),
 		};
 	},


### PR DESCRIPTION
Some unsafe property access appears to have been introduced in #23377

Use safe methods to access properties.

Fixes #23619

## Issue

When creating a new post, if you try to switch to another draft via this dropdown, an error will be thrown:

![click-for-error](https://user-images.githubusercontent.com/841763/37918971-dd23db5e-3122-11e8-848a-9803863365d1.png)

```Uncaught TypeError: Cannot read property 'author' of undefined```

## Testing
1. Create a new post
1. Ensure there are saved drafts
1. Switch to a new draft via the dropdown
1. There should be no errors on the console
1. Ensure that the delete button continues to render correctly, allowing you to delete your own posts and delete other's posts if you have permissions (for example as a site admin).