### PR TITLE
Remove post editor delete button if cannot trash

### DIFF
--- a/client/post-editor/editor-delete-post/index.jsx
+++ b/client/post-editor/editor-delete-post/index.jsx
@@ -80,8 +80,8 @@ class EditorDeletePost extends React.Component {
 	};
 
 	render() {
-		const { postId, postStatus, translate } = this.props;
-		if ( ! postId || postStatus === 'trash' ) {
+		const { canDelete, postId, postStatus, translate } = this.props;
+		if ( ! canDelete || ! postId || postStatus === 'trash' ) {
 			return null;
 		}
 


### PR DESCRIPTION
Remove the post delete button when it cannot be used. This would have been a noop, so hide the button.

![candelete](https://user-images.githubusercontent.com/841763/37919833-5a2a147c-3125-11e8-8e95-dce771ff5a23.png)

Follow up to #23650

## Testing
1. Use this branch
1. Open a post in the Editor
1. Find `EditorDeletePost` in React dev tools
1. Toggle its `canDelete` prop
1. The component should be removed
1. Ensure the delete button continues to work correctly if you have permissions to delete the page/post