### PR TITLE
Site Settings: Add link to podcasting details page from writing page

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -28,6 +28,7 @@ import { requestPostTypes } from 'state/post-types/actions';
 import Composing from './composing';
 import CustomContentTypes from './custom-content-types';
 import FeedSettings from 'my-sites/site-settings/feed-settings';
+import PodcastingLink from 'my-sites/site-settings/podcasting-details/link';
 import Masterbar from './masterbar';
 import MediaSettings from './media-settings';
 import ThemeEnhancements from './theme-enhancements';
@@ -168,6 +169,11 @@ class SiteSettingsFormWriting extends Component {
 					onChangeField={ onChangeField }
 				/>
 
+				{ ! siteIsJetpack &&
+					config.isEnabled( 'manage/site-settings/podcasting' ) && (
+						<PodcastingLink fields={ fields } />
+					) }
+
 				{ jetpackSettingsUI && <QueryJetpackModules siteId={ siteId } /> }
 
 				<ThemeEnhancements
@@ -269,6 +275,7 @@ const getFormSettings = settings => {
 		'time_format',
 		'timezone_string',
 		'lazy-images',
+		'podcasting_archive',
 	] );
 
 	// handling `gmt_offset` and `timezone_string` values

--- a/client/my-sites/site-settings/podcasting-details/link.jsx
+++ b/client/my-sites/site-settings/podcasting-details/link.jsx
@@ -1,0 +1,48 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+
+class PodcastingLink extends Component {
+	render() {
+		const { fields, siteSlug, translate } = this.props;
+		const podcastingEnabled = !! fields.podcasting_archive;
+		const detailsLink = `/settings/podcasting/${ siteSlug }`;
+
+		return (
+			<div className="podcasting-details__link">
+				<SectionHeader label={ translate( 'Podcasting' ) } />
+				<Card className="podcasting-details__link-card" href={ detailsLink }>
+					<div className="podcasting-details__link-title">
+						{ podcastingEnabled
+							? translate( 'Manage Podcasting' )
+							: translate( 'Enable Podcasting' ) }
+					</div>
+					<div className="podcasting-details__link-info">
+						{ translate(
+							'Publish a podcast feed to Apple Podcasts and other podcasting services'
+						) }
+					</div>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default connect( state => {
+	return {
+		siteSlug: getSelectedSiteSlug( state ),
+	};
+} )( localize( PodcastingLink ) );

--- a/client/my-sites/site-settings/podcasting-details/link.jsx
+++ b/client/my-sites/site-settings/podcasting-details/link.jsx
@@ -32,7 +32,7 @@ class PodcastingLink extends Component {
 					</div>
 					<div className="podcasting-details__link-info">
 						{ translate(
-							'Publish a podcast feed to Apple Podcasts and other podcasting services'
+							'Publish a podcast feed to Apple Podcasts and other podcasting services.'
 						) }
 					</div>
 				</Card>

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -18,3 +18,15 @@
 		width: 63%;
 	}
 }
+
+.podcasting-details__link-title {
+	color: 	$gray-dark;
+	font-weight: 600;
+}
+
+.podcasting-details__link-info {
+	color: $gray-text-min;
+	font-size: 13px;
+	font-style: italic;
+	font-weight: 400;
+}


### PR DESCRIPTION
This PR adds a link to the new settings page for managing podcast settings. This PR is intentionally incomplete. It's part of a larger epic and behind the feature flag `manage/site-settings/podcasting`. See p3Ex-32D-p2.

In this PR, it is only enabled for WPCOM non-atomic sites. It will be enabled for atomic sites in a future PR.

When podcasting has not yet been enabled (a category hasn't been selected for podcasting):

![image](https://user-images.githubusercontent.com/363749/37940571-01757a74-312f-11e8-8442-f5c87edaed8a.png)

When podcasting has been enabled:

![image](https://user-images.githubusercontent.com/363749/37940593-1fb70f16-312f-11e8-8365-50de9faf3d13.png)

To test:
* Visit the writing section of the site-settings page.
* Verify that for non-Jetpack sites the link to "Enable Podcasting" or "Manage Podcasting" is below the feed settings section. Verify that it takes you to the podcasting details page.
* The link should say "Enable" if a podcasting category hadn't been previously selected in wp-admin (under Settings > Media)
* The link should say "Manage" if a podcasting category is selected in wp-admin
* Currently it's only possible to enable / disable podcasting from wp-admin. Enabling from within the Calypso interface will come in a future PR.
