### PR TITLE
Components: Add compact mode to Pagination

### DIFF
--- a/client/components/pagination/README.md
+++ b/client/components/pagination/README.md
@@ -9,7 +9,7 @@ import Pagination from 'components/pagination';
 
 render: function() {
 	return (
-		<Pagination page={ <Number> } perPage={ <Number> } total={ <Number> } pageClick={ <Function> } />;	
+		<Pagination compact={ <Boolean> } page={ <Number> } perPage={ <Number> } total={ <Number> } pageClick={ <Function> } />;	
 	);
 }
 ```
@@ -20,3 +20,6 @@ render: function() {
 * `perPage`: Number of records shown per page
 * `total`: Total number of records
 * `pageClick`: Function called when a pagination item is clicked - the page clicked is provided as an argument
+
+#### Optional Props
+* `compact`: Render a smaller version

--- a/client/components/pagination/docs/example.jsx
+++ b/client/components/pagination/docs/example.jsx
@@ -9,28 +9,36 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
 import Pagination from 'components/pagination';
 
 class PaginationExample extends Component {
 	state = {
 		page: 1,
+		compact: false,
 	};
 
 	updatePage = page => {
 		this.setState( { page } );
 	};
 
+	toggleCompact = () => {
+		this.setState( { compact: ! this.state.compact } );
+	};
+
 	render() {
 		return (
-			<Card>
+			<div>
+				<a className="docs__design-toggle button" onClick={ this.toggleCompact }>
+					{ this.state.compact ? 'Normal' : 'Compact' }
+				</a>
 				<Pagination
+					compact={ this.state.compact }
 					page={ this.state.page }
 					perPage={ 10 }
 					total={ 100 }
 					pageClick={ this.updatePage }
 				/>
-			</Card>
+			</div>
 		);
 	}
 }

--- a/client/components/pagination/index.jsx
+++ b/client/components/pagination/index.jsx
@@ -6,6 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -18,6 +19,7 @@ class Pagination extends Component {
 		perPage: PropTypes.number.isRequired,
 		total: PropTypes.number,
 		pageClick: PropTypes.func.isRequired,
+		compact: PropTypes.bool,
 	};
 
 	getPageList = ( page, pageCount ) => {
@@ -51,7 +53,7 @@ class Pagination extends Component {
 	};
 
 	render() {
-		const { page, pageClick, perPage, total } = this.props;
+		const { page, pageClick, perPage, total, compact } = this.props;
 		const pageCount = Math.ceil( total / perPage );
 
 		if ( pageCount <= 1 ) {
@@ -67,12 +69,13 @@ class Pagination extends Component {
 					currentPage={ page }
 					totalPages={ pageCount }
 					pageClick={ pageClick }
+					compact={ compact }
 				/>
 			);
 		} );
 
 		return (
-			<div className="pagination">
+			<div className={ classnames( 'pagination', { 'is-compact': compact } ) }>
 				<ul className="pagination__list">{ pageListRendered }</ul>
 			</div>
 		);

--- a/client/components/pagination/pagination-page.jsx
+++ b/client/components/pagination/pagination-page.jsx
@@ -21,6 +21,7 @@ class PaginationPage extends Component {
 		currentPage: PropTypes.number.isRequired,
 		totalPages: PropTypes.number.isRequired,
 		pageClick: PropTypes.func.isRequired,
+		compact: PropTypes.bool,
 	};
 
 	clickHandler = event => {
@@ -50,7 +51,7 @@ class PaginationPage extends Component {
 	};
 
 	render() {
-		const { translate, currentPage, numberFormat, pageNumber, totalPages } = this.props;
+		const { translate, currentPage, numberFormat, pageNumber, totalPages, compact } = this.props;
 
 		switch ( pageNumber ) {
 			case 'more':
@@ -67,7 +68,7 @@ class PaginationPage extends Component {
 					<li className={ listClass }>
 						<Button borderless onClick={ this.clickHandler } disabled={ currentPage <= 1 }>
 							<Gridicon icon="arrow-left" size={ 18 } />
-							{ translate( 'Previous' ) }
+							{ ! compact && translate( 'Previous' ) }
 						</Button>
 					</li>
 				);
@@ -79,7 +80,7 @@ class PaginationPage extends Component {
 				return (
 					<li className={ listClass }>
 						<Button borderless onClick={ this.clickHandler } disabled={ currentPage >= totalPages }>
-							{ translate( 'Next' ) }
+							{ ! compact && translate( 'Next' ) }
 							<Gridicon icon="arrow-right" size={ 18 } />
 						</Button>
 					</li>

--- a/client/components/pagination/style.scss
+++ b/client/components/pagination/style.scss
@@ -3,6 +3,22 @@
 
 .pagination {
 	width: 100%;
+
+	&.is-compact .pagination__list-item  {
+		.button {
+			padding: 5px 8px;
+		}
+
+		&.pagination__ellipsis span {
+			padding: 5px 6px;
+		}
+
+		&.pagination__arrow .button {
+			padding: 6px 6px;
+		}
+
+
+	}
 }
 
 .pagination__list {


### PR DESCRIPTION
Make the Pagination component accept a `compact` mode

### Normal (unchanged)
![screen shot 2018-03-27 at 3 14 34 pm](https://user-images.githubusercontent.com/1922453/37943051-656d83ca-31d2-11e8-9393-f82b57eb56c7.png)

### Compact
![screen shot 2018-03-27 at 3 14 41 pm](https://user-images.githubusercontent.com/1922453/37943060-6d201f1a-31d2-11e8-8825-3022f4b1fd80.png)

### DevDocs
I copied the styles and methods from [segmented-control](https://wpcalypso.wordpress.com/devdocs/design/segmented-control)

### Use Case
I'd like to paginate results to be displayed in a widget. More on that in https://github.com/Automattic/wp-calypso/pull/23579#issuecomment-376364964

### Testing
* Head to http://calypso.localhost:3000/devdocs/design/pagination
* Toggle between modes and poke around to make sure nothing odd happens