### PR TITLE
Reader: move single feed fetches to the data layer (/read/feed/:feed_id)

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1236,12 +1236,6 @@ Undocumented.prototype.readA8cConversations = function( query, fn ) {
 	return this.wpcom.req.get( '/read/conversations', params, fn );
 };
 
-Undocumented.prototype.readFeed = function( query, fn ) {
-	var params = omit( query, 'ID' );
-	debug( '/read/feed' );
-	return this.wpcom.req.get( '/read/feed/' + encodeURIComponent( query.ID ), params, fn );
-};
-
 Undocumented.prototype.discoverFeed = function( query, fn ) {
 	debug( '/read/feed' );
 	return this.wpcom.req.get( '/read/feed/', query, fn );

--- a/client/state/data-layer/wpcom/read/feed/index.js
+++ b/client/state/data-layer/wpcom/read/feed/index.js
@@ -74,7 +74,7 @@ export function requestReadFeed( action ) {
 		{
 			apiVersion: '1.1',
 			method: 'GET',
-			path: `/read/feed/${ action.payload.ID }`,
+			path: `/read/feed/${ encodeURIComponent( action.payload.ID ) }`,
 			retryPolicy: noRetry(),
 		},
 		action
@@ -86,7 +86,7 @@ export function receiveReadFeedSuccess( action, response ) {
 }
 
 export function receiveReadFeedError( action, response ) {
-	return receiveReaderFeedRequestFailure( action, response );
+	return receiveReaderFeedRequestFailure( action.payload.ID, response );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/read/feed/test/index.js
+++ b/client/state/data-layer/wpcom/read/feed/test/index.js
@@ -12,9 +12,17 @@ import {
 	receiveReadFeedSearchSuccess,
 	receiveReadFeedSearchError,
 	fromApi,
+	requestReadFeed,
+	receiveReadFeedSuccess,
+	receiveReadFeedError,
 } from '../';
-import { NOTICE_CREATE } from 'state/action-types';
+import {
+	NOTICE_CREATE,
+	READER_FEED_REQUEST_SUCCESS,
+	READER_FEED_REQUEST_FAILURE,
+} from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import { requestFeed } from 'state/reader/feeds/actions';
 import { requestFeedSearch, receiveFeedSearch } from 'state/reader/feed-searches/actions';
 import queryKey from 'state/reader/feed-searches/query-key';
 
@@ -101,6 +109,52 @@ describe( 'wpcom-api', () => {
 
 				expect( receiveReadFeedSearchError( action ) ).toMatchObject( {
 					type: NOTICE_CREATE,
+				} );
+			} );
+		} );
+	} );
+
+	describe( 'request a single feed', () => {
+		const feedId = 123;
+
+		describe( '#requestReadFeed', () => {
+			test( 'should dispatch a http request', () => {
+				const action = requestFeed( feedId );
+
+				expect( requestReadFeed( action ) ).toMatchObject(
+					http(
+						{
+							apiVersion: '1.1',
+							method: 'GET',
+							path: `/read/feed/${ feedId }`,
+						},
+						action
+					)
+				);
+			} );
+		} );
+
+		describe( '#receiveReadFeedSuccess', () => {
+			test( 'should dispatch an action with the feed results', () => {
+				const action = requestFeed( feedId );
+				const apiResponse = { feed_ID: 123 };
+
+				expect( receiveReadFeedSuccess( action, apiResponse ) ).toMatchObject( {
+					type: READER_FEED_REQUEST_SUCCESS,
+					payload: { feed_ID: 123 },
+				} );
+			} );
+		} );
+
+		describe( '#receiveReadFeedError', () => {
+			test( 'should dispatch an error action', () => {
+				const action = requestFeed( feedId );
+				const apiResponse = { error: '417' };
+
+				expect( receiveReadFeedError( action, apiResponse ) ).toMatchObject( {
+					type: READER_FEED_REQUEST_FAILURE,
+					payload: { ID: 123 },
+					error: apiResponse,
 				} );
 			} );
 		} );

--- a/client/state/data-layer/wpcom/read/feed/test/index.js
+++ b/client/state/data-layer/wpcom/read/feed/test/index.js
@@ -153,7 +153,7 @@ describe( 'wpcom-api', () => {
 
 				expect( receiveReadFeedError( action, apiResponse ) ).toMatchObject( {
 					type: READER_FEED_REQUEST_FAILURE,
-					payload: { ID: 123 },
+					payload: { feed_ID: 123 },
 					error: apiResponse,
 				} );
 			} );

--- a/client/state/reader/feeds/actions.js
+++ b/client/state/reader/feeds/actions.js
@@ -30,10 +30,10 @@ export function receiveReaderFeedRequestSuccess( data ) {
 	};
 }
 
-export function receiveReaderFeedRequestFailure( action, error ) {
+export function receiveReaderFeedRequestFailure( feedId, error ) {
 	return {
 		type: READER_FEED_REQUEST_FAILURE,
-		payload: action.payload,
+		payload: { feed_ID: feedId },
 		error,
 	};
 }

--- a/client/state/reader/feeds/actions.js
+++ b/client/state/reader/feeds/actions.js
@@ -7,7 +7,6 @@ import { isArray } from 'lodash';
 /**
  * Internal dependencies
  */
-import wpcom from 'lib/wp';
 import {
 	READER_FEED_REQUEST,
 	READER_FEED_REQUEST_SUCCESS,
@@ -16,35 +15,26 @@ import {
 } from 'state/action-types';
 
 export function requestFeed( feedId ) {
-	return function( dispatch ) {
-		dispatch( {
-			type: READER_FEED_REQUEST,
-			payload: {
-				feed_ID: feedId,
-			},
-		} );
-		return wpcom
-			.undocumented()
-			.readFeed( { ID: feedId } )
-			.then(
-				function success( data ) {
-					dispatch( {
-						type: READER_FEED_REQUEST_SUCCESS,
-						payload: data,
-					} );
-					return data;
-				},
-				function failure( err ) {
-					dispatch( {
-						type: READER_FEED_REQUEST_FAILURE,
-						payload: {
-							feed_ID: feedId,
-						},
-						error: err,
-					} );
-					throw err;
-				}
-			);
+	return {
+		type: READER_FEED_REQUEST,
+		payload: {
+			ID: feedId,
+		},
+	};
+}
+
+export function receiveReaderFeedRequestSuccess( data ) {
+	return {
+		type: READER_FEED_REQUEST_SUCCESS,
+		payload: data,
+	};
+}
+
+export function receiveReaderFeedRequestFailure( action, error ) {
+	return {
+		type: READER_FEED_REQUEST_FAILURE,
+		payload: action.payload,
+		error,
 	};
 }
 
@@ -52,6 +42,7 @@ export function updateFeeds( feeds ) {
 	if ( ! isArray( feeds ) ) {
 		feeds = [ feeds ];
 	}
+
 	return {
 		type: READER_FEED_UPDATE,
 		payload: feeds,

--- a/client/state/reader/feeds/test/actions.js
+++ b/client/state/reader/feeds/test/actions.js
@@ -1,100 +1,50 @@
 /** @format */
 /**
- * External dependencies
- */
-import { assert, expect } from 'chai';
-import sinon from 'sinon';
-
-/**
  * Internal dependencies
  */
-import { requestFeed } from '../actions';
+import {
+	requestFeed,
+	receiveReaderFeedRequestSuccess,
+	receiveReaderFeedRequestFailure,
+} from '../actions';
 import {
 	READER_FEED_REQUEST,
 	READER_FEED_REQUEST_SUCCESS,
 	READER_FEED_REQUEST_FAILURE,
 } from 'state/action-types';
-import useNock from 'test/helpers/use-nock';
 
 describe( 'actions', () => {
-	describe( 'a valid fetch', () => {
-		const spy = sinon.spy();
-		let request;
-
-		useNock( nock => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.get( '/rest/v1.1/read/feed/1' )
-				.reply( 200, {
-					feed_ID: 1,
-					name: 'My test feed',
-				} );
-			request = requestFeed( 1 )( spy );
-		} );
-
-		test( 'should dispatch request sync', () => {
-			expect( spy ).to.have.been.calledWith( {
+	describe( '#requestFeed', () => {
+		test( 'should return an action when a feed is requested', () => {
+			const action = requestFeed( 123 );
+			expect( action ).toEqual( {
 				type: READER_FEED_REQUEST,
-				payload: {
-					feed_ID: 1,
-				},
+				payload: { ID: 123 },
 			} );
-		} );
-
-		test( 'should dispatch success, eventually', () => {
-			return request.then(
-				() => {
-					expect( spy ).to.have.been.calledWith( {
-						type: READER_FEED_REQUEST_SUCCESS,
-						payload: {
-							feed_ID: 1,
-							name: 'My test feed',
-						},
-					} );
-				},
-				err => {
-					assert.fail( 'Errback should not be invoked!', err );
-					return err;
-				}
-			);
 		} );
 	} );
 
-	describe( 'a request for a feed that does not exist', () => {
-		const spy = sinon.spy();
-		let request;
-
-		useNock( nock => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.get( '/rest/v1.1/read/feed/1' )
-				.reply( 404 );
-			request = requestFeed( 1 )( spy );
-		} );
-
-		test( 'should dispatch request sync', () => {
-			expect( spy ).to.have.been.calledWith( {
-				type: READER_FEED_REQUEST,
-				payload: {
-					feed_ID: 1,
-				},
+	describe( '#receiveReaderFeedRequestSuccess', () => {
+		test( 'should return an action when a feed request succeeds', () => {
+			const action = receiveReaderFeedRequestSuccess( { feed_ID: 123 } );
+			expect( action ).toEqual( {
+				type: READER_FEED_REQUEST_SUCCESS,
+				payload: { feed_ID: 123 },
 			} );
 		} );
+	} );
 
-		test( 'should dispatch error, eventually', () => {
-			return request.then(
-				() => {
-					assert.fail( 'callback should not be invoked!', arguments );
-					throw new Error( 'errback should have been invoked' );
-				},
-				() => {
-					expect( spy ).to.have.been.calledWithMatch( {
-						type: READER_FEED_REQUEST_FAILURE,
-						payload: {
-							feed_ID: 1,
-						},
-						error: sinon.match.instanceOf( Error ),
-					} );
-				}
+	describe( '#receiveReaderFeedRequestFailure', () => {
+		test( 'should return an action when a feed request fails', () => {
+			const action = receiveReaderFeedRequestFailure(
+				{ payload: { feed_ID: 123 } },
+				{ statusCode: 410 }
 			);
+			expect( action ).toEqual( {
+				type: READER_FEED_REQUEST_FAILURE,
+				payload: { feed_ID: 123 },
+				error: { statusCode: 410 },
+			} );
 		} );
 	} );
 } );

--- a/client/state/reader/feeds/test/actions.js
+++ b/client/state/reader/feeds/test/actions.js
@@ -36,10 +36,7 @@ describe( 'actions', () => {
 
 	describe( '#receiveReaderFeedRequestFailure', () => {
 		test( 'should return an action when a feed request fails', () => {
-			const action = receiveReaderFeedRequestFailure(
-				{ payload: { feed_ID: 123 } },
-				{ statusCode: 410 }
-			);
+			const action = receiveReaderFeedRequestFailure( 123, { statusCode: 410 } );
 			expect( action ).toEqual( {
 				type: READER_FEED_REQUEST_FAILURE,
 				payload: { feed_ID: 123 },


### PR DESCRIPTION
This PR moves requests for feed information (`/read/feed/:feed_id`) to the data layer.

I've tried to keep the shape and type of actions we were previously using so that no reducer changes are required at this stage.

### To test

Load the Reader at http://calypso.localhost:3000/ and check that requests to /read/feed/:feed_id are being fired. 

Ensure that the correct feed information is shown for an individual feed like http://calypso.localhost:3000/read/feeds/36149739 or http://calypso.localhost:3000/read/feeds/194107.