### PR TITLE
Remove direct usage of PLAN_* constants from isGoogleMyBusinessStatsNudgeVisible

### DIFF
--- a/client/state/selectors/is-google-my-business-stats-nudge-visible.js
+++ b/client/state/selectors/is-google-my-business-stats-nudge-visible.js
@@ -5,7 +5,8 @@
  */
 import createSelector from 'lib/create-selector';
 import { getSiteOption, getSitePlanSlug } from 'state/sites/selectors';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { TYPE_BUSINESS, GROUP_WPCOM } from 'lib/plans/constants';
+import { planMatches } from 'lib/plans';
 
 const WEEK_IN_SECONDS = 60 * 60 * 24 * 7;
 
@@ -31,8 +32,11 @@ const siteHasPromoteGoal = createSelector(
  * @param  {String}  siteId The Site ID
  * @return {Boolean} True if site has business plan
  */
-const siteHasBusinessPlan = createSelector(
-	( state, siteId ) => getSitePlanSlug( state, siteId ) === PLAN_BUSINESS,
+export const siteHasBusinessPlan = createSelector(
+	( state, siteId ) => {
+		const slug = getSitePlanSlug( state, siteId );
+		return planMatches( slug, { group: GROUP_WPCOM, type: TYPE_BUSINESS } );
+	},
 	( state, siteId ) => [ getSitePlanSlug( state, siteId ) ]
 );
 

--- a/client/state/selectors/test/is-google-my-business-stats-nudge-visible.js
+++ b/client/state/selectors/test/is-google-my-business-stats-nudge-visible.js
@@ -1,0 +1,59 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { siteHasBusinessPlan } from '../is-google-my-business-stats-nudge-visible';
+
+import {
+	PLAN_FREE,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+} from 'lib/plans/constants';
+import selectors from 'state/sites/selectors';
+
+jest.mock( 'state/sites/selectors', () => ( {
+	getSitePlanSlug: jest.fn(),
+} ) );
+
+describe( 'siteHasBusinessPlan()', () => {
+	test( 'should return true if site has WP.com business plan', () => {
+		const plans = [ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ];
+		plans.forEach( plan => {
+			selectors.getSitePlanSlug.mockImplementation( () => plan );
+			expect( siteHasBusinessPlan() ).toBe( true );
+		} );
+	} );
+
+	test( 'should return false if site does not have a WP.com business plan', () => {
+		const plans = [
+			PLAN_FREE,
+			PLAN_PERSONAL,
+			PLAN_PERSONAL_2_YEARS,
+			PLAN_PREMIUM,
+			PLAN_PREMIUM_2_YEARS,
+			PLAN_JETPACK_FREE,
+			PLAN_JETPACK_PREMIUM,
+			PLAN_JETPACK_PERSONAL,
+			PLAN_JETPACK_BUSINESS,
+			PLAN_JETPACK_PREMIUM_MONTHLY,
+			PLAN_JETPACK_BUSINESS_MONTHLY,
+			PLAN_JETPACK_PERSONAL_MONTHLY,
+		];
+		plans.forEach( plan => {
+			selectors.getSitePlanSlug.mockImplementation( () => plan );
+			expect( siteHasBusinessPlan() ).toBe( false );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `isGoogleMyBusinessStatsNudgeVisible`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* If you happen to have a business site and checked "promote" as one of the goals in the new 3-step setup, it should have a google nudge visible on `/stats/day/`, no premium site should have that nudge.