### PR TITLE
Checkout: allow ebanx payments in Mexico

### DIFF
--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -18,7 +18,7 @@ import PaymentCountrySelect from 'components/payment-country-select';
 import { StateSelect, Input, HiddenInput } from 'my-sites/domains/components/form';
 import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
 import { maskField, unmaskField, getCreditCardType } from 'lib/credit-card-details';
-import { isEbanxEnabledForCountry } from 'lib/credit-card-details/ebanx';
+import { shouldRenderAdditionalEbanxFields } from 'lib/credit-card-details/ebanx';
 
 export class CreditCardFormFields extends React.Component {
 	static propTypes = {
@@ -106,7 +106,7 @@ export class CreditCardFormFields extends React.Component {
 	};
 
 	shouldRenderEbanx() {
-		return isEbanxEnabledForCountry( this.getFieldValue( 'country' ) );
+		return shouldRenderAdditionalEbanxFields( this.getFieldValue( 'country' ) );
 	}
 
 	renderEbanxFields() {

--- a/client/components/credit-card-form-fields/test/index.js
+++ b/client/components/credit-card-form-fields/test/index.js
@@ -14,7 +14,7 @@ import { identity, noop } from 'lodash';
  * Internal dependencies
  */
 import { CreditCardFormFields } from '../';
-import { isEbanxEnabledForCountry } from 'lib/credit-card-details/ebanx';
+import { shouldRenderAdditionalEbanxFields } from 'lib/credit-card-details/ebanx';
 import mockCountriesList from './mocks/mock-countries-list';
 
 jest.mock( 'i18n-calypso', () => ( {
@@ -23,7 +23,7 @@ jest.mock( 'i18n-calypso', () => ( {
 
 jest.mock( 'lib/credit-card-details/ebanx', () => {
 	return {
-		isEbanxEnabledForCountry: jest.fn( false ),
+		shouldRenderAdditionalEbanxFields: jest.fn( false ),
 	};
 } );
 
@@ -44,10 +44,10 @@ describe( 'CreditCardFormFields', () => {
 
 	describe( 'with ebanx activated', () => {
 		beforeAll( () => {
-			isEbanxEnabledForCountry.mockReturnValue( true );
+			shouldRenderAdditionalEbanxFields.mockReturnValue( true );
 		} );
 		afterAll( () => {
-			isEbanxEnabledForCountry.mockReturnValue( false );
+			shouldRenderAdditionalEbanxFields.mockReturnValue( false );
 		} );
 
 		test( 'should display Ebanx fields when an Ebanx payment country is selected', () => {

--- a/client/lib/credit-card-details/constants.js
+++ b/client/lib/credit-card-details/constants.js
@@ -8,4 +8,7 @@ export const PAYMENT_PROCESSOR_EBANX_COUNTRIES = {
 	BR: {
 		requiredFields: [ 'document', 'street-number', 'address-1', 'state', 'city', 'phone-number' ],
 	},
+	MX: {
+		requiredFields: [],
+	},
 };

--- a/client/lib/credit-card-details/ebanx.js
+++ b/client/lib/credit-card-details/ebanx.js
@@ -3,7 +3,7 @@
  *
  * @format
  */
-import { isUndefined } from 'lodash';
+import { isUndefined, isEmpty } from 'lodash';
 import i18n from 'i18n-calypso';
 import { CPF } from 'cpf_cnpj';
 
@@ -23,6 +23,18 @@ export function isEbanxEnabledForCountry( countryCode = '' ) {
 	return (
 		! isUndefined( PAYMENT_PROCESSOR_EBANX_COUNTRIES[ countryCode ] ) &&
 		isPaymentMethodEnabled( CartStore.get(), 'ebanx' )
+	);
+}
+
+/**
+ *
+ * @param {String} countryCode - a two-letter country code, e.g., 'DE', 'BR'
+ * @returns {Boolean} Whether the country requires additional fields
+ */
+export function shouldRenderAdditionalEbanxFields( countryCode = '' ) {
+	return (
+		! isUndefined( PAYMENT_PROCESSOR_EBANX_COUNTRIES[ countryCode ] ) &&
+		! isEmpty( PAYMENT_PROCESSOR_EBANX_COUNTRIES[ countryCode ].requiredFields )
 	);
 }
 

--- a/client/lib/credit-card-details/test/ebanx.js
+++ b/client/lib/credit-card-details/test/ebanx.js
@@ -10,7 +10,7 @@
 /**
  * Internal dependencies
  */
-import { isEbanxEnabledForCountry, isValidCPF } from '../ebanx';
+import { isEbanxEnabledForCountry, isValidCPF, shouldRenderAdditionalEbanxFields } from '../ebanx';
 import { isPaymentMethodEnabled } from 'lib/cart-values';
 
 jest.mock( 'lib/cart-values', () => {
@@ -46,6 +46,25 @@ describe( 'Ebanx payment processing methods', () => {
 		test( 'should return false for invalid CPF', () => {
 			expect( isValidCPF( '85384484612' ) ).toEqual( false );
 			expect( isValidCPF( '853.844.846.12' ) ).toEqual( false );
+		} );
+	} );
+
+	describe( 'shouldRenderAdditionalEbanxFields', () => {
+		beforeAll( () => {
+			isPaymentMethodEnabled.mockReturnValue( true );
+		} );
+		afterAll( () => {
+			isPaymentMethodEnabled.mockReturnValue( false );
+		} );
+
+		test( 'should return false for non-ebanx country', () => {
+			expect( shouldRenderAdditionalEbanxFields( 'AU' ) ).toEqual( false );
+		} );
+		test( 'should return true for ebanx country that requires additional fields', () => {
+			expect( shouldRenderAdditionalEbanxFields( 'BR' ) ).toEqual( true );
+		} );
+		test( 'should return false for ebanx country that does not requires additional fields', () => {
+			expect( shouldRenderAdditionalEbanxFields( 'MX' ) ).toEqual( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
We're going to test EBANX payments in Mexico.

- By enabling `MX` in ` client/lib/credit-card-details/constants.js` we're making EBANX available.
- I added the `shouldRenderAdditionalEbanxFields` helper method because EBANX doesn't require the additional fields in Mexico.

The actual use of EBANX for MXN payments is going to be controlled by the backend, see D11270-code

