### PR TITLE
Activity log: Fix null activityTargetTs schema

### DIFF
--- a/client/state/activity-log/log/schema.js
+++ b/client/state/activity-log/log/schema.js
@@ -32,9 +32,7 @@ const activityItemsSchema = {
 				activityIsDiscarded: { type: 'boolean' },
 				activityIsRewindable: { type: 'boolean' },
 				activityName: { type: 'string' },
-				activityStatus: {
-					oneOf: [ { type: 'string' }, { type: 'null' } ],
-				},
+				activityStatus: { type: [ 'null', 'string' ] },
 				activityTargetTs: { type: [ 'null', 'number' ] },
 				activityTitle: { type: 'string' },
 				activityTs: { type: 'integer' },

--- a/client/state/activity-log/log/schema.js
+++ b/client/state/activity-log/log/schema.js
@@ -35,7 +35,7 @@ const activityItemsSchema = {
 				activityStatus: {
 					oneOf: [ { type: 'string' }, { type: 'null' } ],
 				},
-				activityTargetTs: { type: 'number' },
+				activityTargetTs: { type: [ 'null', 'number' ] },
 				activityTitle: { type: 'string' },
 				activityTs: { type: 'integer' },
 				actorAvatarUrl: { type: 'string' },

--- a/client/state/activity-log/log/schema.js
+++ b/client/state/activity-log/log/schema.js
@@ -32,7 +32,7 @@ const activityItemsSchema = {
 				activityIsDiscarded: { type: 'boolean' },
 				activityIsRewindable: { type: 'boolean' },
 				activityName: { type: 'string' },
-				activityStatus: { type: [ 'null', 'string' ] },
+				activityStatus: { type: 'string' },
 				activityTargetTs: { type: 'number' },
 				activityTitle: { type: 'string' },
 				activityTs: { type: 'integer' },

--- a/client/state/activity-log/log/schema.js
+++ b/client/state/activity-log/log/schema.js
@@ -42,7 +42,7 @@ const activityItemsSchema = {
 				actorRole: { type: 'string' },
 				actorType: { type: 'string' },
 				actorWpcomId: { type: 'integer' },
-				rewindId: { type: [ 'null', 'string' ] },
+				rewindId: { type: 'string' },
 			},
 		},
 	},

--- a/client/state/activity-log/log/schema.js
+++ b/client/state/activity-log/log/schema.js
@@ -33,7 +33,7 @@ const activityItemsSchema = {
 				activityIsRewindable: { type: 'boolean' },
 				activityName: { type: 'string' },
 				activityStatus: { type: [ 'null', 'string' ] },
-				activityTargetTs: { type: [ 'null', 'number' ] },
+				activityTargetTs: { type: 'number' },
 				activityTitle: { type: 'string' },
 				activityTs: { type: 'integer' },
 				actorAvatarUrl: { type: 'string' },

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -43,33 +43,36 @@ export function transformer( apiResponse ) {
  * @return {object}       Processed Activity item ready for use in UI
  */
 export function processItem( item ) {
-	const published = item.published;
-	const actor = item.actor;
+	const { actor, object, published } = item;
 
-	return {
-		/* activity actor */
-		actorAvatarUrl: get( actor, 'icon.url', DEFAULT_GRAVATAR_URL ),
-		actorName: get( actor, 'name', '' ),
-		actorRemoteId: get( actor, 'external_user_id', 0 ),
-		actorRole: get( actor, 'role', '' ),
-		actorType: get( actor, 'type', '' ),
-		actorWpcomId: get( actor, 'wpcom_user_id', 0 ),
+	return Object.assign(
+		{
+			/* activity actor */
+			actorAvatarUrl: get( actor, 'icon.url', DEFAULT_GRAVATAR_URL ),
+			actorName: get( actor, 'name', '' ),
+			actorRemoteId: get( actor, 'external_user_id', 0 ),
+			actorRole: get( actor, 'role', '' ),
+			actorType: get( actor, 'type', '' ),
+			actorWpcomId: get( actor, 'wpcom_user_id', 0 ),
 
-		/* base activity info */
-		activityDate: published,
-		activityGroup: ( item.name || '' ).split( '__', 1 )[ 0 ], // split always returns at least one item
-		activityIcon: get( item, 'gridicon', DEFAULT_GRIDICON ),
-		activityId: item.activity_id,
-		activityIsDiscarded: item.is_discarded,
-		activityIsRewindable: item.is_rewindable,
-		rewindId: item.rewind_id,
-		activityName: item.name,
-		activityStatus: item.status,
-		activityTargetTs: get( item, 'object.target_ts', null ),
-		activityTitle: item.summary,
-		activityTs: Date.parse( published ),
-		activityDescription: parseBlock( item.content ),
-	};
+			/* base activity info */
+			activityDate: published,
+			activityGroup: ( item.name || '' ).split( '__', 1 )[ 0 ], // split always returns at least one item
+			activityIcon: get( item, 'gridicon', DEFAULT_GRIDICON ),
+			activityId: item.activity_id,
+			activityIsDiscarded: item.is_discarded,
+			activityIsRewindable: item.is_rewindable,
+			rewindId: item.rewind_id,
+			activityName: item.name,
+			activityStatus: item.status,
+			activityTitle: item.summary,
+			activityTs: Date.parse( published ),
+			activityDescription: parseBlock( item.content ),
+		},
+		object.hasOwnProperty( 'activityTargetTs' ) && {
+			activityTargetTs: object.target_ts,
+		}
+	);
 }
 
 // fromApi default export

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -69,9 +69,7 @@ export function processItem( item ) {
 			activityTs: Date.parse( published ),
 			activityDescription: parseBlock( item.content ),
 		},
-		object.hasOwnProperty( 'activityTargetTs' ) && {
-			activityTargetTs: object.target_ts,
-		}
+		object.hasOwnProperty( 'target_ts' ) && { activityTargetTs: object.target_ts }
 	);
 }
 

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -67,10 +67,9 @@ export function processItem( item ) {
 			activityTs: Date.parse( published ),
 			activityDescription: parseBlock( item.content ),
 		},
-		item.hasOwnProperty( 'rewind_id' ) && { rewindId: item.rewind_id },
-		// API may return `null` status. Do not populate with null value
+		item.rewind_id && { rewindId: item.rewind_id },
 		item.status && { activityStatus: item.status },
-		object && object.hasOwnProperty( 'target_ts' ) && { activityTargetTs: object.target_ts }
+		object && object.target_ts && { activityTargetTs: object.target_ts }
 	);
 }
 

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -68,7 +68,8 @@ export function processItem( item ) {
 			activityDescription: parseBlock( item.content ),
 		},
 		item.hasOwnProperty( 'rewind_id' ) && { rewindId: item.rewind_id },
-		item.hasOwnProperty( 'status' ) && { activityStatus: item.status },
+		// API may return `null` status. Do not populate with null value
+		item.status && { activityStatus: item.status },
 		object && object.hasOwnProperty( 'target_ts' ) && { activityTargetTs: object.target_ts }
 	);
 }

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -65,7 +65,7 @@ export function processItem( item ) {
 		rewindId: item.rewind_id,
 		activityName: item.name,
 		activityStatus: item.status,
-		activityTargetTs: get( item, 'object.target_ts', undefined ),
+		activityTargetTs: get( item, 'object.target_ts', null ),
 		activityTitle: item.summary,
 		activityTs: Date.parse( published ),
 		activityDescription: parseBlock( item.content ),

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -69,7 +69,7 @@ export function processItem( item ) {
 		},
 		item.hasOwnProperty( 'rewind_id' ) && { rewindId: item.rewind_id },
 		item.hasOwnProperty( 'status' ) && { activityStatus: item.status },
-		object.hasOwnProperty( 'target_ts' ) && { activityTargetTs: object.target_ts }
+		object && object.hasOwnProperty( 'target_ts' ) && { activityTargetTs: object.target_ts }
 	);
 }
 

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -64,11 +64,11 @@ export function processItem( item ) {
 			activityIsRewindable: item.is_rewindable,
 			rewindId: item.rewind_id,
 			activityName: item.name,
-			activityStatus: item.status,
 			activityTitle: item.summary,
 			activityTs: Date.parse( published ),
 			activityDescription: parseBlock( item.content ),
 		},
+		item.hasOwnProperty( 'status' ) && { activityStatus: item.status },
 		object.hasOwnProperty( 'target_ts' ) && { activityTargetTs: object.target_ts }
 	);
 }

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -62,12 +62,12 @@ export function processItem( item ) {
 			activityId: item.activity_id,
 			activityIsDiscarded: item.is_discarded,
 			activityIsRewindable: item.is_rewindable,
-			rewindId: item.rewind_id,
 			activityName: item.name,
 			activityTitle: item.summary,
 			activityTs: Date.parse( published ),
 			activityDescription: parseBlock( item.content ),
 		},
+		item.hasOwnProperty( 'rewind_id' ) && { rewindId: item.rewind_id },
 		item.hasOwnProperty( 'status' ) && { activityStatus: item.status },
 		object.hasOwnProperty( 'target_ts' ) && { activityTargetTs: object.target_ts }
 	);


### PR DESCRIPTION
Three atomic changes, two janitorial commits labeled as `[OPTIONAL]`

* Allow null-type values for activityTargetTs
* [OPTIONAL] Use explicit null default
* [OPTIONAL] Use simple list of types status schema

> Because of an indentation change if may be helpful to view the diff for this PR [with whitespace changes ignored](https://github.com/Automattic/wp-calypso/pull/23672/files?w=1) (`?w=1)`

## Issue

Some `activityTargetTs` were defaulting to `undefined` causing schema invalidations:

![schema-invalidation](https://user-images.githubusercontent.com/841763/37965437-6b8f8670-31c5-11e8-9de5-c5a77b89506e.png)

## Testing
1. Tests pass
1. In dev environment, ensure activity data is loaded and persisted
1. Reload and ensure that no schema invalidation warnings appear in the console