### PR TITLE
Inline Help: escape `searchQuery` when using `get`

### DIFF
--- a/client/state/inline-help/selectors.js
+++ b/client/state/inline-help/selectors.js
@@ -33,7 +33,8 @@ export function getSelectedResult( state ) {
  * @return {Boolean}        Whether search results are being requested
  */
 export function isRequestingInlineHelpSearchResultsForQuery( state, searchQuery ) {
-	return !! get( state, 'inlineHelpSearchResults.requesting.' + searchQuery );
+	const allRequesting = get( state, 'inlineHelpSearchResults.requesting' );
+	return !! get( allRequesting, [ searchQuery ] );
 }
 
 /**
@@ -45,11 +46,8 @@ export function isRequestingInlineHelpSearchResultsForQuery( state, searchQuery 
  * @return {?Array}         List of results for a given search query
  */
 export function getInlineHelpSearchResultsForQuery( state, searchQuery ) {
-	const searchResults = get( state, 'inlineHelpSearchResults.search.items.' + searchQuery );
-	if ( ! searchResults ) {
-		return null;
-	}
-	return searchResults;
+	const allResults = get( state, 'inlineHelpSearchResults.search.items' );
+	return get( allResults, [ searchQuery ], null );
 }
 
 /**


### PR DESCRIPTION
... so special characters in the search query / key don't get interpreted. This fixes #23493. 

To test:

- Use Inline Help's search. Make sure it works well for regular queries, but also for those containing special characters — e.g., searching for '.com' or '.co.uk' should not result in no results. 

Props @jsnajdr on filling the issue and some pre-PR advice! 