### PR TITLE
Components: Fix PlanIcon.propTypes

### DIFF
--- a/client/components/plans/plan-icon/index.jsx
+++ b/client/components/plans/plan-icon/index.jsx
@@ -15,6 +15,11 @@ import { PLANS_LIST, getPlanClass } from 'lib/plans/constants';
 import { isPersonalPlan, isPremiumPlan, isBusinessPlan } from 'lib/plans';
 
 export default class PlanIcon extends Component {
+	static propTypes = {
+		classNames: PropTypes.string,
+		plan: PropTypes.oneOf( Object.keys( PLANS_LIST ).isRequired ),
+	};
+
 	getIcon( planName ) {
 		const { plan, className } = this.props;
 		const planClass = getPlanClass( plan );
@@ -44,8 +49,3 @@ export default class PlanIcon extends Component {
 		return this.getIcon( 'free' );
 	}
 }
-
-PlanIcon.propTypes = {
-	classNames: PropTypes.string,
-	plan: PropTypes.oneOf( Object.keys( PLANS_LIST ).isRequired ),
-};

--- a/client/components/plans/plan-icon/index.jsx
+++ b/client/components/plans/plan-icon/index.jsx
@@ -17,7 +17,7 @@ import { isPersonalPlan, isPremiumPlan, isBusinessPlan } from 'lib/plans';
 export default class PlanIcon extends Component {
 	static propTypes = {
 		classNames: PropTypes.string,
-		plan: PropTypes.oneOf( Object.keys( PLANS_LIST ).isRequired ),
+		plan: PropTypes.oneOf( Object.keys( PLANS_LIST ) ).isRequired,
 	};
 
 	getIcon( planName ) {


### PR DESCRIPTION
Fixes a bad `propTypes.plan` definition, misplaced `.isRequired`:

![invalid-proptypes](https://user-images.githubusercontent.com/841763/37965741-64a28c58-31c6-11e8-88fd-a57d3edcbfe0.png)

## Testing
1. Boot this branch in dev.
1. Verify you do not see the warning pictured above.