### PR TITLE
Comment: fix path for single comment page views

### DIFF
--- a/client/my-sites/comment/main.jsx
+++ b/client/my-sites/comment/main.jsx
@@ -52,7 +52,7 @@ export class CommentView extends Component {
 		return (
 			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 			<Main className="comments" wideLayout>
-				<PageViewTracker path="/comment/:site" title="Comments" />
+				<PageViewTracker path="/comment/:site/:comment_id" title="Comments" />
 				<QuerySiteCommentsTree siteId={ siteId } status={ 'all' } />
 				<DocumentHead title={ translate( 'Comment' ) } />
 				{ canModerateComments && (

--- a/client/my-sites/comment/main.jsx
+++ b/client/my-sites/comment/main.jsx
@@ -52,7 +52,7 @@ export class CommentView extends Component {
 		return (
 			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 			<Main className="comments" wideLayout>
-				<PageViewTracker path="/comment/:site/:comment_id" title="Comments" />
+				<PageViewTracker path="/comment/:site/:commentId" title="Comments" />
 				<QuerySiteCommentsTree siteId={ siteId } status={ 'all' } />
 				<DocumentHead title={ translate( 'Comment' ) } />
 				{ canModerateComments && (

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -57,12 +57,13 @@ export const siteComments = ( context, next ) => {
 	}
 
 	const status = mapPendingStatusToUnapproved( params.status );
+	const analyticsPath = `/comments/${ status }/:site`;
 
 	const pageNumber = sanitizeInt( query.page ) || 1;
 
 	context.primary = (
 		<CommentsManagement
-			analyticsPath="/comments/:status/:site"
+			analyticsPath={ analyticsPath }
 			changePage={ changePage( path ) }
 			page={ pageNumber }
 			siteFragment={ siteFragment }
@@ -82,6 +83,7 @@ export const postComments = ( context, next ) => {
 
 	const status = mapPendingStatusToUnapproved( params.status );
 	const postId = sanitizeInt( params.post );
+	const analyticsPath = `/comments/${ status }/:site/:post`;
 
 	if ( ! postId ) {
 		return page.redirect( `/comments/${ params.status }/${ siteFragment }` );
@@ -91,7 +93,7 @@ export const postComments = ( context, next ) => {
 
 	context.primary = (
 		<CommentsManagement
-			analyticsPath="/comments/:status/:site/:post"
+			analyticsPath={ analyticsPath }
 			changePage={ changePage( path ) }
 			page={ pageNumber }
 			postId={ postId }


### PR DESCRIPTION
While inspecting some of the other page view issues I noticed a minor issue with the way we are recording single comment page views. This PR adds the `:comment_id` variable to the existing `/comment/:site` path.

1. Set `localStorage.setItem( 'debug', 'calypso:analytics:tracks' )` in the browser console to enable the debug.
2. Navigate to `/comments/{site}` and open some comment in detail view.
3. Verify that `/comment/:site/:comment_id` page view is recorded.