### PR TITLE
JP Remote Install: Disable feature for mobile apps

### DIFF
--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -106,6 +106,8 @@ export class JetpackConnectMain extends Component {
 	}
 
 	componentDidUpdate() {
+		const { isMobileAppFlow } = this.props;
+
 		if (
 			this.getStatus() === NOT_CONNECTED_JETPACK &&
 			this.isCurrentUrlFetched() &&
@@ -114,7 +116,7 @@ export class JetpackConnectMain extends Component {
 			return this.goToRemoteAuth( this.state.currentUrl );
 		}
 		if ( this.getStatus() === ALREADY_OWNED && ! this.state.redirecting ) {
-			if ( this.props.isMobileAppFlow ) {
+			if ( isMobileAppFlow ) {
 				return this.redirectToMobileApp( 'already-connected' );
 			}
 			return this.goToPlans( this.state.currentUrl );
@@ -127,7 +129,7 @@ export class JetpackConnectMain extends Component {
 		}
 
 		if ( includes( [ NOT_JETPACK, NOT_ACTIVE_JETPACK ], this.getStatus() ) ) {
-			if ( config.isEnabled( 'jetpack/connect/remote-install' ) ) {
+			if ( config.isEnabled( 'jetpack/connect/remote-install' ) && ! isMobileAppFlow ) {
 				this.goToRemoteInstall( JPC_PATH_REMOTE_INSTALL );
 			} else {
 				this.goToInstallInstructions( '/jetpack/connect/instructions' );


### PR DESCRIPTION
Don't send mobile app flows through the remote install flow. The apps store user credentials, so won't want users to have to enter creds again for remote installs.

We can work with the mobile app teams to develop a solution for this flow, possibly involving calling
API from the app.

## Testing
 * Start the jetpack connect mobile app flow (using the `?mobile_redirect` query) by clicking here: https://calypso.live/jetpack/connect?branch=update/jp-remote-install/disable-mobile-app&mobile_redirect=wordpress://jetpack-connection
* Enter the URL of a wporg site without jetpack installed
* Check that the next screen is the manual install instructions, and not the credentials entry screen
