### PR TITLE
Jetpack Connect: Give footer links equal top/bottom margins

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -4,6 +4,12 @@
 
 	.logged-out-form__links {
 		max-width: 100%;
+
+		/* Move up to the Card above */
+		margin-top: -10px;
+		@include breakpoint( '>480px' ) {
+			margin-top: -16px;
+		}
 	}
 
 	.formatted-header {


### PR DESCRIPTION
**Before**
<img width="250" alt="screen shot 2018-03-27 at 13 45 39" src="https://user-images.githubusercontent.com/7767559/37968355-cb3d4346-31c5-11e8-8df3-6b9990ff6e32.png">

**After**
<img width="250" alt="screen shot 2018-03-27 at 13 45 11" src="https://user-images.githubusercontent.com/7767559/37968364-ce341674-31c5-11e8-834c-fecda31390d4.png">

Add a negative top margin to move links closer to the Card above, making top/bottom margins equal for each link.

## Testing
* Go to https://calypso.live/jetpack/connect?branch=update/jetpack-connect/footer-link-margin
* Check that the space above and below the first footer link is equal **at all widths**
* Feel free to progress through the flow by entering the URL of a wporg site
