### PR TITLE
Components: fix PlanIcon warning

### DIFF
--- a/client/components/plans/plan-icon/index.jsx
+++ b/client/components/plans/plan-icon/index.jsx
@@ -47,5 +47,5 @@ export default class PlanIcon extends Component {
 
 PlanIcon.propTypes = {
 	classNames: PropTypes.string,
-	plan: PropTypes.oneOf( Object.keys( PLANS_LIST ).isRequired ),
+	plan: PropTypes.oneOf( Object.keys( PLANS_LIST ) ).isRequired,
 };


### PR DESCRIPTION
#23637 refactored the `PLAN_*` constants from `PlanIcon` and introduced a subtle issue with a wrongly bracketed `.isRequired`. This would result in a console warning whenever `PlanIcon` was displayed. This PR fixes this. 

<img width="713" alt="screen shot 2018-03-27 at 2 47 53 pm" src="https://user-images.githubusercontent.com/23619/37968500-9a813312-31ce-11e8-961b-38b9c902a1d9.png">

<img width="957" alt="screen shot 2018-03-27 at 2 48 03 pm" src="https://user-images.githubusercontent.com/23619/37968509-a25ae45c-31ce-11e8-8163-f8d5e1fbbe82.png">

To test:
- Navigate to a page that displays the `PlanIcon` and make sure the warning appear on `master` but not on this branch. 