### PR TITLE
Fix a typo - use PropType.isRequired instead of array.isRequired

### DIFF
--- a/client/components/plans/plan-icon/index.jsx
+++ b/client/components/plans/plan-icon/index.jsx
@@ -47,5 +47,5 @@ export default class PlanIcon extends Component {
 
 PlanIcon.propTypes = {
 	classNames: PropTypes.string,
-	plan: PropTypes.oneOf( Object.keys( PLANS_LIST ).isRequired ),
+	plan: PropTypes.oneOf( Object.keys( PLANS_LIST ) ).isRequired,
 };


### PR DESCRIPTION
As in the title - this is a single typo fixed