### PR TITLE
Remove direct usage of plan constants from products-values

### DIFF
--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -9,23 +9,15 @@ import { assign, difference, isEmpty, pick } from 'lodash';
  * Internal dependencies
  */
 import {
-	JETPACK_PLANS,
-	PLAN_BUSINESS,
-	PLAN_PREMIUM,
-	PLAN_PERSONAL,
-	PLAN_FREE,
-	PLAN_JETPACK_FREE,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PERSONAL_MONTHLY,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
 	PLAN_HOST_BUNDLE,
 	PLAN_WPCOM_ENTERPRISE,
 	PLAN_CHARGEBACK,
 	PLAN_MONTHLY_PERIOD,
+	GROUP_JETPACK,
+	GROUP_WPCOM,
+	TYPE_FREE,
 } from 'lib/plans/constants';
+import { isPersonalPlan, isPremiumPlan, isBusinessPlan, planMatches } from 'lib/plans';
 import { domainProductSlugs } from 'lib/domains/constants';
 
 import schema from './schema.json';
@@ -83,14 +75,14 @@ export function isFreePlan( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return product.product_slug === PLAN_FREE;
+	return planMatches( product.product_slug, { type: TYPE_FREE, group: GROUP_WPCOM } );
 }
 
 export function isFreeJetpackPlan( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return product.product_slug === PLAN_JETPACK_FREE;
+	return planMatches( product.product_slug, { type: TYPE_FREE, group: GROUP_JETPACK } );
 }
 
 export function isFreeTrial( product ) {
@@ -101,30 +93,24 @@ export function isFreeTrial( product ) {
 }
 
 export function isPersonal( product ) {
-	const personalProducts = [ PLAN_PERSONAL, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ];
-
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return personalProducts.indexOf( product.product_slug ) >= 0;
+	return isPersonalPlan( product.product_slug );
 }
 
 export function isPremium( product ) {
-	const premiumProducts = [ PLAN_PREMIUM, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ];
-
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return premiumProducts.indexOf( product.product_slug ) >= 0;
+	return isPremiumPlan( product.product_slug );
 }
 
 export function isBusiness( product ) {
-	const businessProducts = [ PLAN_BUSINESS, PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY ];
-
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return businessProducts.indexOf( product.product_slug ) >= 0;
+	return isBusinessPlan( product.product_slug );
 }
 
 export function isEnterprise( product ) {
@@ -138,7 +124,7 @@ export function isJetpackPlan( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return JETPACK_PLANS.indexOf( product.product_slug ) >= 0;
+	return planMatches( product.product_slug, { group: GROUP_JETPACK } );
 }
 
 export function isJetpackBusiness( product ) {

--- a/client/lib/products-values/test/index.js
+++ b/client/lib/products-values/test/index.js
@@ -1,20 +1,37 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
-import { isJetpackPlan } from '..';
+import {
+	isJetpackPlan,
+	isPersonal,
+	isPremium,
+	isBusiness,
+	isFreePlan,
+	isFreeJetpackPlan,
+} from '..';
+
 import {
 	JETPACK_PLANS,
 	PLAN_BUSINESS,
-	PLAN_FREE,
-	PLAN_PERSONAL,
+	PLAN_BUSINESS_2_YEARS,
 	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_FREE,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_HOST_BUNDLE,
+	PLAN_WPCOM_ENTERPRISE,
+	PLAN_CHARGEBACK,
+	PLAN_MONTHLY_PERIOD,
 } from 'lib/plans/constants';
 
 /**
@@ -27,8 +44,8 @@ const makeProductFromSlug = product_slug => ( { product_slug } );
 
 describe( 'isJetpackPlan', () => {
 	test( 'should return true for Jetpack products', () => {
-		JETPACK_PLANS.map( makeProductFromSlug ).forEach(
-			product => expect( isJetpackPlan( product ) ).to.be.true
+		JETPACK_PLANS.map( makeProductFromSlug ).forEach( product =>
+			expect( isJetpackPlan( product ) ).toBe( true )
 		);
 	} );
 
@@ -37,6 +54,177 @@ describe( 'isJetpackPlan', () => {
 
 		nonJetpackPlans
 			.map( makeProductFromSlug )
-			.forEach( product => expect( isJetpackPlan( product ) ).to.be.false );
+			.forEach( product => expect( isJetpackPlan( product ) ).toBe( false ) );
+	} );
+} );
+
+describe( 'isPersonal', () => {
+	test( 'should return true for personal products', () => {
+		const PERSONAL_PRODUCTS = [
+			PLAN_PERSONAL,
+			PLAN_PERSONAL_2_YEARS,
+			PLAN_JETPACK_PERSONAL,
+			PLAN_JETPACK_PERSONAL_MONTHLY,
+		];
+		PERSONAL_PRODUCTS.map( makeProductFromSlug ).forEach( product =>
+			expect( isPersonal( product ) ).toBe( true )
+		);
+	} );
+
+	test( 'should return false for non-personal products', () => {
+		const NON_PERSONAL_PRODUCTS = [
+			PLAN_BUSINESS,
+			PLAN_BUSINESS_2_YEARS,
+			PLAN_PREMIUM,
+			PLAN_PREMIUM_2_YEARS,
+			PLAN_FREE,
+			PLAN_JETPACK_FREE,
+			PLAN_JETPACK_PREMIUM,
+			PLAN_JETPACK_PREMIUM_MONTHLY,
+			PLAN_JETPACK_BUSINESS,
+			PLAN_JETPACK_BUSINESS_MONTHLY,
+			PLAN_HOST_BUNDLE,
+			PLAN_WPCOM_ENTERPRISE,
+			PLAN_CHARGEBACK,
+			PLAN_MONTHLY_PERIOD,
+		];
+
+		NON_PERSONAL_PRODUCTS.map( makeProductFromSlug ).forEach( product =>
+			expect( isPersonal( product ) ).toBe( false )
+		);
+	} );
+} );
+
+describe( 'isPremium', () => {
+	test( 'should return true for premium products', () => {
+		const PREMIUM_PRODUCTS = [
+			PLAN_PREMIUM,
+			PLAN_PREMIUM_2_YEARS,
+			PLAN_JETPACK_PREMIUM,
+			PLAN_JETPACK_PREMIUM_MONTHLY,
+		];
+		PREMIUM_PRODUCTS.map( makeProductFromSlug ).forEach( product =>
+			expect( isPremium( product ) ).toBe( true )
+		);
+	} );
+
+	test( 'should return false for non-premium products', () => {
+		const NON_PREMIUM_PRODUCTS = [
+			PLAN_BUSINESS,
+			PLAN_BUSINESS_2_YEARS,
+			PLAN_PERSONAL,
+			PLAN_PERSONAL_2_YEARS,
+			PLAN_FREE,
+			PLAN_JETPACK_FREE,
+			PLAN_JETPACK_PERSONAL,
+			PLAN_JETPACK_PERSONAL_MONTHLY,
+			PLAN_JETPACK_BUSINESS,
+			PLAN_JETPACK_BUSINESS_MONTHLY,
+			PLAN_HOST_BUNDLE,
+			PLAN_WPCOM_ENTERPRISE,
+			PLAN_CHARGEBACK,
+			PLAN_MONTHLY_PERIOD,
+		];
+
+		NON_PREMIUM_PRODUCTS.map( makeProductFromSlug ).forEach( product =>
+			expect( isPremium( product ) ).toBe( false )
+		);
+	} );
+} );
+
+describe( 'isBusiness', () => {
+	test( 'should return true for business products', () => {
+		const BUSINESS_PRODUCTS = [
+			PLAN_BUSINESS,
+			PLAN_BUSINESS_2_YEARS,
+			PLAN_JETPACK_BUSINESS,
+			PLAN_JETPACK_BUSINESS_MONTHLY,
+		];
+		BUSINESS_PRODUCTS.map( makeProductFromSlug ).forEach( product =>
+			expect( isBusiness( product ) ).toBe( true )
+		);
+	} );
+
+	test( 'should return false for non-business products', () => {
+		const NON_BUSINESS_PRODUCTS = [
+			PLAN_PREMIUM,
+			PLAN_PREMIUM_2_YEARS,
+			PLAN_PERSONAL,
+			PLAN_PERSONAL_2_YEARS,
+			PLAN_FREE,
+			PLAN_JETPACK_FREE,
+			PLAN_JETPACK_PERSONAL,
+			PLAN_JETPACK_PERSONAL_MONTHLY,
+			PLAN_JETPACK_PREMIUM,
+			PLAN_JETPACK_PREMIUM_MONTHLY,
+			PLAN_HOST_BUNDLE,
+			PLAN_WPCOM_ENTERPRISE,
+			PLAN_CHARGEBACK,
+			PLAN_MONTHLY_PERIOD,
+		];
+
+		NON_BUSINESS_PRODUCTS.map( makeProductFromSlug ).forEach( product =>
+			expect( isBusiness( product ) ).toBe( false )
+		);
+	} );
+} );
+
+describe( 'isFreePlan', () => {
+	test( 'should return true for free plan', () => {
+		expect( isFreePlan( PLAN_FREE ) ).toBe( true );
+	} );
+
+	test( 'should return false for non-business products', () => {
+		const OTHER_PLANS = [
+			PLAN_PREMIUM,
+			PLAN_PREMIUM_2_YEARS,
+			PLAN_PERSONAL,
+			PLAN_PERSONAL_2_YEARS,
+			PLAN_BUSINESS,
+			PLAN_BUSINESS_2_YEARS,
+			PLAN_JETPACK_FREE,
+			PLAN_JETPACK_PERSONAL,
+			PLAN_JETPACK_PERSONAL_MONTHLY,
+			PLAN_JETPACK_PREMIUM,
+			PLAN_JETPACK_PREMIUM_MONTHLY,
+			PLAN_HOST_BUNDLE,
+			PLAN_WPCOM_ENTERPRISE,
+			PLAN_CHARGEBACK,
+			PLAN_MONTHLY_PERIOD,
+		];
+
+		OTHER_PLANS.map( makeProductFromSlug ).forEach( product =>
+			expect( isFreePlan( product ) ).toBe( false )
+		);
+	} );
+} );
+
+describe( 'isFreeJetpackPlan', () => {
+	test( 'should return true for free plan', () => {
+		expect( isFreeJetpackPlan( PLAN_JETPACK_FREE ) ).toBe( true );
+	} );
+
+	test( 'should return false for non-business products', () => {
+		const OTHER_PLANS = [
+			PLAN_PREMIUM,
+			PLAN_PREMIUM_2_YEARS,
+			PLAN_PERSONAL,
+			PLAN_PERSONAL_2_YEARS,
+			PLAN_BUSINESS,
+			PLAN_BUSINESS_2_YEARS,
+			PLAN_FREE,
+			PLAN_JETPACK_PERSONAL,
+			PLAN_JETPACK_PERSONAL_MONTHLY,
+			PLAN_JETPACK_PREMIUM,
+			PLAN_JETPACK_PREMIUM_MONTHLY,
+			PLAN_HOST_BUNDLE,
+			PLAN_WPCOM_ENTERPRISE,
+			PLAN_CHARGEBACK,
+			PLAN_MONTHLY_PERIOD,
+		];
+
+		OTHER_PLANS.map( makeProductFromSlug ).forEach( product =>
+			expect( isFreeJetpackPlan( product ) ).toBe( false )
+		);
 	} );
 } );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `products-values`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests