### PR TITLE
Replace custom logic with usage of planMatches helper in is*Plan functions

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -210,19 +210,19 @@ export function planLevelsMatch( planSlugA, planSlugB ) {
 }
 
 export function isBusinessPlan( planSlug ) {
-	return getPlan( planSlug ).type === TYPE_BUSINESS;
+	return planMatches( planSlug, { type: TYPE_BUSINESS } );
 }
 
 export function isPremiumPlan( planSlug ) {
-	return getPlan( planSlug ).type === TYPE_PREMIUM;
+	return planMatches( planSlug, { type: TYPE_PREMIUM } );
 }
 
 export function isPersonalPlan( planSlug ) {
-	return getPlan( planSlug ).type === TYPE_PERSONAL;
+	return planMatches( planSlug, { type: TYPE_PERSONAL } );
 }
 
 export function isFreePlan( planSlug ) {
-	return getPlan( planSlug ).type === TYPE_FREE;
+	return planMatches( planSlug, { type: TYPE_FREE } );
 }
 
 /**

--- a/client/lib/plans/test/plan-lookups.js
+++ b/client/lib/plans/test/plan-lookups.js
@@ -59,7 +59,7 @@ describe( 'isFreePlan', () => {
 		expect( isFreePlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
 		expect( isFreePlan( PLAN_BUSINESS ) ).to.equal( false );
 		expect( isFreePlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
-		expect( isBusinessPlan( 'non-existing plan' ) ).to.equal( false );
+		expect( isFreePlan( 'non-existing plan' ) ).to.equal( false );
 	} );
 } );
 
@@ -77,7 +77,7 @@ describe( 'isPersonalPlan', () => {
 		expect( isPersonalPlan( PLAN_JETPACK_PREMIUM_MONTHLY ) ).to.equal( false );
 		expect( isPersonalPlan( PLAN_BUSINESS ) ).to.equal( false );
 		expect( isPersonalPlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
-		expect( isBusinessPlan( 'non-existing plan' ) ).to.equal( false );
+		expect( isPersonalPlan( 'non-existing plan' ) ).to.equal( false );
 	} );
 } );
 
@@ -95,7 +95,7 @@ describe( 'isPremiumPlan', () => {
 		expect( isPremiumPlan( PLAN_JETPACK_PERSONAL_MONTHLY ) ).to.equal( false );
 		expect( isPremiumPlan( PLAN_BUSINESS ) ).to.equal( false );
 		expect( isPremiumPlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
-		expect( isBusinessPlan( 'non-existing plan' ) ).to.equal( false );
+		expect( isPremiumPlan( 'non-existing plan' ) ).to.equal( false );
 	} );
 } );
 

--- a/client/lib/plans/test/plan-lookups.js
+++ b/client/lib/plans/test/plan-lookups.js
@@ -59,6 +59,7 @@ describe( 'isFreePlan', () => {
 		expect( isFreePlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
 		expect( isFreePlan( PLAN_BUSINESS ) ).to.equal( false );
 		expect( isFreePlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
+		expect( isBusinessPlan( 'non-existing plan' ) ).to.equal( false );
 	} );
 } );
 
@@ -76,6 +77,7 @@ describe( 'isPersonalPlan', () => {
 		expect( isPersonalPlan( PLAN_JETPACK_PREMIUM_MONTHLY ) ).to.equal( false );
 		expect( isPersonalPlan( PLAN_BUSINESS ) ).to.equal( false );
 		expect( isPersonalPlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
+		expect( isBusinessPlan( 'non-existing plan' ) ).to.equal( false );
 	} );
 } );
 
@@ -93,6 +95,7 @@ describe( 'isPremiumPlan', () => {
 		expect( isPremiumPlan( PLAN_JETPACK_PERSONAL_MONTHLY ) ).to.equal( false );
 		expect( isPremiumPlan( PLAN_BUSINESS ) ).to.equal( false );
 		expect( isPremiumPlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
+		expect( isBusinessPlan( 'non-existing plan' ) ).to.equal( false );
 	} );
 } );
 
@@ -110,6 +113,7 @@ describe( 'isBusinessPlan', () => {
 		expect( isBusinessPlan( PLAN_JETPACK_PERSONAL_MONTHLY ) ).to.equal( false );
 		expect( isBusinessPlan( PLAN_PREMIUM ) ).to.equal( false );
 		expect( isBusinessPlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
+		expect( isBusinessPlan( 'non-existing plan' ) ).to.equal( false );
 	} );
 } );
 


### PR DESCRIPTION
The purpose of this PR is to add more tolerance to is*Plan helper functions. Currently `getPlan` may return null for non-existent products which will cause an error before applying this commit, but will simply return false after applying this commit as `planMatches` takes that into consideration.

Test plan:
* Confirm that circle CI tests passed