### PR TITLE
Analytics: Track page views on URL change

### DIFF
--- a/client/lib/analytics/page-view-tracker/index.jsx
+++ b/client/lib/analytics/page-view-tracker/index.jsx
@@ -51,6 +51,7 @@ export class PageViewTracker extends React.Component {
 
 	componentDidUpdate( prevProps ) {
 		if (
+			prevProps.currentUrl !== this.props.currentUrl ||
 			prevProps.path !== this.props.path ||
 			prevProps.selectedSiteId !== this.props.selectedSiteId
 		) {
@@ -92,7 +93,10 @@ const mapStateToProps = state => {
 		( isNumber( currentSlug ) && currentSlug === selectedSiteId ) ||
 		currentSlug === selectedSiteSlug;
 
+	const currentUrl = 'undefined' !== typeof window && get( window, 'location.pathname', false );
+
 	return {
+		currentUrl,
 		hasSelectedSiteLoaded,
 		selectedSiteId,
 	};


### PR DESCRIPTION
Fix an unexpected behaviour raised here by @vindl: https://github.com/Automattic/wp-calypso/pull/23583#discussion_r177424839

The [latest `PageViewTracker` changes](https://github.com/Automattic/wp-calypso/pull/23338) aimed to trigger a new page view record every time the path changed.
Though, I didn't consider the fact that most analytics paths are "normalized", which roughly means that their variable values are replaced by variable names placeholders.

E.g.
The path `/comments/approved/foo.wordpress.com` tracks as `/comments/:status/:site`.
Changing filter to list spam comments updates the path into `/comments/spam/foo.wordpress.com` which also tracks as `/comments/:status/:site`.
Therefore the analytics path doesn't change, and the second page view is not tracked.

The proposed change here is to keep track of `window.location.pathname` and also record a new page view whenever it changes.

## Testing instructions

- Set `localStorage.setItem( 'debug', 'calypso:analytics:tracks' )` in the browser console to enable the debug.
- Open the Comments section, and observe that a page view event is tracked.
- Change status filter.
- Make sure another page view event is tracked (with the same path: most likely `/comments/:status/:site`).