### PR TITLE
Sites: fix non-normalized page view stats

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -310,15 +310,20 @@ export function siteSelection( context, next ) {
 	const hasOneSite = currentUser.visible_site_count === 1;
 	const allSitesPath = sectionify( context.path, siteFragment );
 
+	// See https://github.com/Automattic/wp-calypso/issues/23517
+	// Avoid recording non-normalized paths in page view stats (e.g. /post/1)
+	const pathParts = basePath.split( '/' );
+	const rootPath = pathParts.length > 2 ? `/${ pathParts[ 1 ] }` : basePath;
+
 	if ( currentUser && currentUser.site_count === 0 ) {
 		renderEmptySites( context );
-		return analytics.pageView.record( basePath, sitesPageTitleForAnalytics + ' > No Sites' );
+		return analytics.pageView.record( rootPath, sitesPageTitleForAnalytics + ' > No Sites' );
 	}
 
 	if ( currentUser && currentUser.visible_site_count === 0 ) {
 		renderNoVisibleSites( context );
 		return analytics.pageView.record(
-			basePath,
+			rootPath,
 			`${ sitesPageTitleForAnalytics } > All Sites Hidden`
 		);
 	}

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -313,7 +313,7 @@ export function siteSelection( context, next ) {
 	if ( currentUser && currentUser.site_count === 0 ) {
 		renderEmptySites( context );
 		return analytics.pageView.record( '/no-sites', sitesPageTitleForAnalytics + ' > No Sites', {
-			basePath: basePath,
+			base_path: basePath,
 		} );
 	}
 
@@ -322,7 +322,7 @@ export function siteSelection( context, next ) {
 		return analytics.pageView.record(
 			'/no-sites',
 			`${ sitesPageTitleForAnalytics } > All Sites Hidden`,
-			{ basePath: basePath }
+			{ base_path: basePath }
 		);
 	}
 

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -305,25 +305,19 @@ function getPrimarySiteSlug( state ) {
 export function siteSelection( context, next ) {
 	const { getState, dispatch } = getStore( context );
 	const siteFragment = context.params.site || getSiteFragment( context.path );
-	const basePath = sectionify( context.path, siteFragment );
 	const currentUser = user.get();
 	const hasOneSite = currentUser.visible_site_count === 1;
 	const allSitesPath = sectionify( context.path, siteFragment );
 
-	// See https://github.com/Automattic/wp-calypso/issues/23517
-	// Avoid recording non-normalized paths in page view stats (e.g. /post/1)
-	const pathParts = basePath.split( '/' );
-	const rootPath = pathParts.length > 2 ? `/${ pathParts[ 1 ] }` : basePath;
-
 	if ( currentUser && currentUser.site_count === 0 ) {
 		renderEmptySites( context );
-		return analytics.pageView.record( rootPath, sitesPageTitleForAnalytics + ' > No Sites' );
+		return analytics.pageView.record( '/sites', sitesPageTitleForAnalytics + ' > No Sites' );
 	}
 
 	if ( currentUser && currentUser.visible_site_count === 0 ) {
 		renderNoVisibleSites( context );
 		return analytics.pageView.record(
-			rootPath,
+			'/sites',
 			`${ sitesPageTitleForAnalytics } > All Sites Hidden`
 		);
 	}

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -305,20 +305,24 @@ function getPrimarySiteSlug( state ) {
 export function siteSelection( context, next ) {
 	const { getState, dispatch } = getStore( context );
 	const siteFragment = context.params.site || getSiteFragment( context.path );
+	const basePath = sectionify( context.path, siteFragment );
 	const currentUser = user.get();
 	const hasOneSite = currentUser.visible_site_count === 1;
 	const allSitesPath = sectionify( context.path, siteFragment );
 
 	if ( currentUser && currentUser.site_count === 0 ) {
 		renderEmptySites( context );
-		return analytics.pageView.record( '/sites', sitesPageTitleForAnalytics + ' > No Sites' );
+		return analytics.pageView.record( '/no-sites', sitesPageTitleForAnalytics + ' > No Sites', {
+			basePath: basePath,
+		} );
 	}
 
 	if ( currentUser && currentUser.visible_site_count === 0 ) {
 		renderNoVisibleSites( context );
 		return analytics.pageView.record(
-			'/sites',
-			`${ sitesPageTitleForAnalytics } > All Sites Hidden`
+			'/no-sites',
+			`${ sitesPageTitleForAnalytics } > All Sites Hidden`,
+			{ basePath: basePath }
 		);
 	}
 


### PR DESCRIPTION
Resolves: https://github.com/Automattic/wp-calypso/issues/23517, #23510

In case when user had no sites associated with the account or no visible sites, we would be recording anything that appeared in path except the site fragment. For example:

`/post/example.wordpress.com/123` would be recorded as `/post/123`

This is an attempt to solve this issue by keeping just the root part of the current section.
