### PR TITLE
People: Remove unnecessary class from PeopleListSectionHeader

### DIFF
--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -55,7 +55,7 @@ class PeopleListSectionHeader extends Component {
 				{ siteLink && (
 					<Button compact href={ siteLink } className="people-list-section-header__add-button">
 						<Gridicon icon="user-add" />
-						<span class="people-list-section-header__button-text">
+						<span>
 							{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
 						</span>
 					</Button>


### PR DESCRIPTION
This PR removes an unnecessary `class` from a `span` in `PeopleListSectionHeader`. We're removing the `class` for a couple of reasons:

* It's not used for anything.
* It causes a React warning because we should be using `className` instead of `class`:

![](https://cldup.com/gtKTrDkghE.png)

Seems like we introduced this in #23569.

You may ask why we're not removing the `span` altogether? Because we need it in order to apply some spacing between the icon and the text (see how this works [here](https://github.com/Automattic/wp-calypso/blob/master/client/components/button/style.scss#L108)).

To test:
* Checkout this branch
* Go to `http://calypso.localhost:3000/people/team/:site` where `:site` is one of your sites.
* Verify you don't see the warning anymore.
* Verify there are no visual changes on both desktop and mobile.