### PR TITLE
Happychat: switch time precision to ms

### DIFF
--- a/client/state/happychat/chat/reducer.js
+++ b/client/state/happychat/chat/reducer.js
@@ -25,6 +25,15 @@ import {
 import { combineReducers } from 'state/utils';
 import { timelineSchema } from './schema';
 
+// We compare incoming timestamps against a known future Unix time in seconds date
+// to determine if the timestamp is in seconds or milliseconds resolution. If the former,
+// we "upgrade" it by multiplying by 1000.
+//
+// This will all be removed once the server-side is fully converted.
+const UNIX_TIMESTAMP_2023_IN_SECONDS = 1700000000;
+export const maybeUpscaleTimePrecision = time =>
+	time < UNIX_TIMESTAMP_2023_IN_SECONDS ? time * 1000 : time;
+
 export const lastActivityTimestamp = ( state = null, action ) => {
 	switch ( action.type ) {
 		case HAPPYCHAT_IO_SEND_MESSAGE_MESSAGE:
@@ -77,7 +86,7 @@ const timelineEvent = ( state = {}, action ) => {
 				message: message.text,
 				name: message.user.name,
 				image: message.user.avatarURL,
-				timestamp: message.timestamp,
+				timestamp: maybeUpscaleTimePrecision( message.timestamp ),
 				user_id: message.user.id,
 				type: get( message, 'type', 'message' ),
 				links: get( message, 'meta.links' ),
@@ -131,7 +140,7 @@ export const timeline = ( state = [], action ) => {
 						message: message.text,
 						name: message.user.name,
 						image: message.user.picture,
-						timestamp: message.timestamp,
+						timestamp: maybeUpscaleTimePrecision( message.timestamp ),
 						user_id: message.user.id,
 						type: get( message, 'type', 'message' ),
 						links: get( message, 'meta.links' ),

--- a/client/state/happychat/selectors/test/get-happychat-timeline.js
+++ b/client/state/happychat/selectors/test/get-happychat-timeline.js
@@ -16,23 +16,17 @@ describe( '#getHappychatTimeline', () => {
 	const ONE_MINUTE = 1000 * 60;
 	const FIVE_MINUTES = ONE_MINUTE * 5;
 	const timelineAtTime1 = [
-		{ timestamp: ( NOW - FIVE_MINUTES ) / 1000, id: '1-1' },
-		{ timestamp: ( NOW - ONE_MINUTE ) / 1000, id: '1-2' },
-		{ timestamp: NOW / 1000, id: '1-3' },
+		{ timestamp: NOW - FIVE_MINUTES, id: '1-1' },
+		{ timestamp: NOW - ONE_MINUTE, id: '1-2' },
+		{ timestamp: NOW, id: '1-3' },
 	];
 	const timelineAtTime2 = [
-		{ timestamp: ( NOW - FIVE_MINUTES ) / 1000, id: '2-1' },
-		{ timestamp: ( NOW - ONE_MINUTE ) / 1000, id: '2-2' },
-		{ timestamp: NOW / 1000, id: '2-3' },
+		{ timestamp: NOW - FIVE_MINUTES, id: '2-1' },
+		{ timestamp: NOW - ONE_MINUTE, id: '2-2' },
+		{ timestamp: NOW, id: '2-3' },
 	];
-	const timelineWithoutIds1 = [
-		{ timestamp: ( NOW - FIVE_MINUTES ) / 1000 },
-		{ timestamp: NOW / 1000 },
-	];
-	const timelineWithoutIds2 = [
-		{ timestamp: ( NOW - ONE_MINUTE ) / 1000 },
-		{ timestamp: NOW / 1000 },
-	];
+	const timelineWithoutIds1 = [ { timestamp: NOW - FIVE_MINUTES }, { timestamp: NOW } ];
+	const timelineWithoutIds2 = [ { timestamp: NOW - ONE_MINUTE }, { timestamp: NOW } ];
 
 	test( 'returns the cached timeline if message do not have ids', () => {
 		const state = {


### PR DESCRIPTION
We’re converting Happychat to use ms system-wide. This change shunts a temporary handler such that the client continues working through the switch without incident.

See upstream https://github.com/Automattic/happychat-client/pull/167

Testing:
1. ensure `development.local.json` out of wp-calypso config
2. check out and run this branch

or

1. Use live link below

Then:

1. Log into Happychat HUD staging.
2. Visit help/contact in Calypso test instance.
3. Start chatting with yourself; make sure messages seem to go back and forth as expected.
4. Verify in Redux inspector that `HAPPYCHAT_IO_RECEIVE_MESSAGE` actions timestamp values come in as seconds-based but are grafted into the state tree as ms-based.