### PR TITLE
Jetpack Settings: Remove obsolete `updateSettings` imports

### DIFF
--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -39,7 +39,6 @@ import {
 } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSitePlanSlug, getSiteSlug } from 'state/sites/selectors';
-import { updateSettings } from 'state/jetpack/settings/actions';
 import QueryMediaStorage from 'components/data/query-media-storage';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import PlanStorageBar from 'blocks/plan-storage/bar';
@@ -263,34 +262,29 @@ class MediaSettings extends Component {
 	}
 }
 
-export default connect(
-	state => {
-		const selectedSiteId = getSelectedSiteId( state );
-		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
-		const sitePlanSlug = getSitePlanSlug( state, selectedSiteId );
-		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
-			state,
-			selectedSiteId,
-			'photon'
-		);
-		const isVideoPressAvailable =
-			hasFeature( state, selectedSiteId, FEATURE_VIDEO_UPLOADS ) ||
-			hasFeature( state, selectedSiteId, FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM ) ||
-			hasFeature( state, selectedSiteId, FEATURE_VIDEO_UPLOADS_JETPACK_PRO );
+export default connect( state => {
+	const selectedSiteId = getSelectedSiteId( state );
+	const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
+	const sitePlanSlug = getSitePlanSlug( state, selectedSiteId );
+	const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
+		state,
+		selectedSiteId,
+		'photon'
+	);
+	const isVideoPressAvailable =
+		hasFeature( state, selectedSiteId, FEATURE_VIDEO_UPLOADS ) ||
+		hasFeature( state, selectedSiteId, FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM ) ||
+		hasFeature( state, selectedSiteId, FEATURE_VIDEO_UPLOADS_JETPACK_PRO );
 
-		return {
-			carouselActive: !! isJetpackModuleActive( state, selectedSiteId, 'carousel' ),
-			isVideoPressActive: isJetpackModuleActive( state, selectedSiteId, 'videopress' ),
-			isVideoPressAvailable,
-			mediaStorageLimit: getMediaStorageLimit( state, selectedSiteId ),
-			mediaStorageUsed: getMediaStorageUsed( state, selectedSiteId ),
-			photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
-			selectedSiteId,
-			sitePlanSlug,
-			siteSlug: getSiteSlug( state, selectedSiteId ),
-		};
-	},
-	{
-		updateSettings,
-	}
-)( localize( MediaSettings ) );
+	return {
+		carouselActive: !! isJetpackModuleActive( state, selectedSiteId, 'carousel' ),
+		isVideoPressActive: isJetpackModuleActive( state, selectedSiteId, 'videopress' ),
+		isVideoPressAvailable,
+		mediaStorageLimit: getMediaStorageLimit( state, selectedSiteId ),
+		mediaStorageUsed: getMediaStorageUsed( state, selectedSiteId ),
+		photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
+		selectedSiteId,
+		sitePlanSlug,
+		siteSlug: getSiteSlug( state, selectedSiteId ),
+	};
+} )( localize( MediaSettings ) );

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -20,7 +20,6 @@ import {
 	isJetpackSiteInDevelopmentMode,
 } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { updateSettings } from 'state/jetpack/settings/actions';
 import { getSiteSlug } from 'state/sites/selectors';
 import InfoPopover from 'components/info-popover';
 
@@ -100,23 +99,18 @@ class SpeedUpSiteSettings extends Component {
 	}
 }
 
-export default connect(
-	state => {
-		const selectedSiteId = getSelectedSiteId( state );
-		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
-		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
-			state,
-			selectedSiteId,
-			'photon'
-		);
+export default connect( state => {
+	const selectedSiteId = getSelectedSiteId( state );
+	const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
+	const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
+		state,
+		selectedSiteId,
+		'photon'
+	);
 
-		return {
-			photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
-			selectedSiteId,
-			siteSlug: getSiteSlug( state, selectedSiteId ),
-		};
-	},
-	{
-		updateSettings,
-	}
-)( localize( SpeedUpSiteSettings ) );
+	return {
+		photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
+		selectedSiteId,
+		siteSlug: getSiteSlug( state, selectedSiteId ),
+	};
+} )( localize( SpeedUpSiteSettings ) );


### PR DESCRIPTION
Best viewed ignoring whitespace changes: https://github.com/Automattic/wp-calypso/pull/23692/files?w=1

These are imported and `connect()`ed, but seem otherwise unused (I also checked if they're e.g. passed down to child components thru, say `{ ...props }`, but they don't seem to).

First introduced by #9802 and #22053, respectively. AFAICS, they weren't ever needed from their inception. Copy-pasta at work? 😄

Testing instructions: Verify that for a JP site
* Media settings still work
* 'Speed up' settings still work

Prep for #23393.