### PR TITLE
Activity Log - Failed backup event: add button to fix credentials

### DIFF
--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -310,3 +310,7 @@
 .activity-log-item__help-action .gridicon {
 	margin-right: 5px;
 }
+
+.activity-log-item__fix-creds {
+	white-space: nowrap;
+}

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -44,6 +44,8 @@ export function transformer( apiResponse ) {
  */
 export function processItem( item ) {
 	const { actor, object, published } = item;
+	const activityMeta =
+		'2' === get( item, [ 'object', 'error_code' ], '' ) ? { errorCode: 'bad_credentials' } : {};
 
 	return Object.assign(
 		{
@@ -66,6 +68,7 @@ export function processItem( item ) {
 			activityTitle: item.summary,
 			activityTs: Date.parse( published ),
 			activityDescription: parseBlock( item.content ),
+			activityMeta,
 		},
 		item.rewind_id && { rewindId: item.rewind_id },
 		item.status && { activityStatus: item.status },


### PR DESCRIPTION
This PR will display a button when a backup fails due to bad credentials. The button will take users to the flow to enter credentials.

<img width="820" alt="captura de pantalla 2018-03-27 a la s 15 07 23" src="https://user-images.githubusercontent.com/1041600/37985968-9d3e79b4-31d0-11e8-98aa-6b430cd50fc4.png">

Fixes #22137

#### Testing

Force a bad credentials error
- Verify that the button Fix credentials is there
- Verify that when clicked, it takes you to the flow to enter credentials