### PR TITLE
Remove direct usage of plan constants from source-payment-box

### DIFF
--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -11,7 +11,6 @@ import { assign, some, map } from 'lodash';
 import { localize, translate } from 'i18n-calypso';
 import CartCoupon from 'my-sites/checkout/cart/cart-coupon';
 import PaymentChatButton from './payment-chat-button';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
 import CartToggle from './cart-toggle';
 import TermsOfService from './terms-of-service';
 import Input from 'my-sites/domains/components/form/input';
@@ -22,8 +21,10 @@ import wpcom from 'lib/wp';
 import notices from 'notices';
 import FormSelect from 'components/forms/form-select';
 import FormLabel from 'components/forms/form-label';
+import { planMatches } from 'lib/plans';
+import { TYPE_BUSINESS, GROUP_WPCOM } from 'lib/plans/constants';
 
-class RedirectPaymentBox extends PureComponent {
+export class RedirectPaymentBox extends PureComponent {
 	static displayName = 'RedirectPaymentBox';
 
 	static propTypes = {
@@ -187,7 +188,12 @@ class RedirectPaymentBox extends PureComponent {
 	}
 
 	render() {
-		const hasBusinessPlanInCart = some( this.props.cart.products, { product_slug: PLAN_BUSINESS } );
+		const hasBusinessPlanInCart = some( this.props.cart.products, ( { product_slug } ) =>
+			planMatches( product_slug, {
+				type: TYPE_BUSINESS,
+				group: GROUP_WPCOM,
+			} )
+		);
 		const showPaymentChatButton = this.props.presaleChatAvailable && hasBusinessPlanInCart;
 
 		return (

--- a/client/my-sites/checkout/checkout/test/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/test/redirect-payment-box.jsx
@@ -1,0 +1,127 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { identity } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { RedirectPaymentBox } from '../redirect-payment-box';
+import {
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_FREE,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+} from 'lib/plans/constants';
+
+jest.mock( 'lib/cart-values', () => ( {
+	isPaymentMethodEnabled: jest.fn( false ),
+	paymentMethodName: jest.fn( false ),
+	cartItems: {
+		hasRenewableSubscription: jest.fn( false ),
+		hasRenewalItem: jest.fn( false ),
+	},
+} ) );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: x => x,
+	translate: x => x,
+} ) );
+
+jest.mock( '../terms-of-service', () => {
+	const react = require( 'react' );
+	return class TermsOfService extends react.Component {};
+} );
+jest.mock( '../payment-chat-button', () => {
+	const react = require( 'react' );
+	return class PaymentChatButton extends react.Component {};
+} );
+
+const defaultProps = {
+	cart: {},
+	translate: identity,
+};
+
+describe( 'RedirectPaymentBox', () => {
+	test( 'should not blow up and have proper CSS class', () => {
+		const wrapper = shallow( <RedirectPaymentBox { ...defaultProps } /> );
+		expect( wrapper.find( '.checkout__payment-box-section' ) ).toHaveLength( 1 );
+		expect( wrapper.find( '.checkout__payment-box-actions' ) ).toHaveLength( 1 );
+		expect( wrapper.find( 'TermsOfService' ) ).toHaveLength( 1 );
+	} );
+
+	const businessPlans = [ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ];
+
+	businessPlans.forEach( product_slug => {
+		test( 'should render PaymentChatButton if any WP.com business plan is in the cart', () => {
+			const props = {
+				...defaultProps,
+				presaleChatAvailable: true,
+				cart: {
+					products: [ { product_slug } ],
+				},
+			};
+			const wrapper = shallow( <RedirectPaymentBox { ...props } /> );
+			expect( wrapper.find( 'PaymentChatButton' ) ).toHaveLength( 1 );
+		} );
+	} );
+
+	businessPlans.forEach( product_slug => {
+		test( 'should not render PaymentChatButton if presaleChatAvailable is false', () => {
+			const props = {
+				...defaultProps,
+				presaleChatAvailable: false,
+				cart: {
+					products: [ { product_slug } ],
+				},
+			};
+			const wrapper = shallow( <RedirectPaymentBox { ...props } /> );
+			expect( wrapper.find( 'PaymentChatButton' ) ).toHaveLength( 0 );
+		} );
+	} );
+
+	const otherPlans = [
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_FREE,
+		PLAN_JETPACK_FREE,
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_PERSONAL_MONTHLY,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PREMIUM_MONTHLY,
+		PLAN_JETPACK_BUSINESS,
+		PLAN_JETPACK_BUSINESS_MONTHLY,
+	];
+
+	otherPlans.forEach( product_slug => {
+		test( 'should not render PaymentChatButton if only non-business plan products are in the cart', () => {
+			const props = {
+				...defaultProps,
+				cart: {
+					products: [ { product_slug } ],
+				},
+			};
+			const wrapper = shallow( <RedirectPaymentBox { ...props } /> );
+			expect( wrapper.find( 'PaymentChatButton' ) ).toHaveLength( 0 );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR removes usage of PLAN_* constants from source-payment-box

Since we are adding new 2_YEAR plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:

* Run unit tests
* HappyChat is inactive when running on localhost - unit tests are only way to test it aside of dropping a `console.log(hasBusinessPlanInCart);` in the component file (which I did and it worked fine). SourcePaymentBox is especially hard to test because it's used for alipay and other vendors like that. To test it, I added `return this.renderSourcePaymentBox( visiblePaymentBox );` in `client/my-sites/checkout/checkout/secure-payment-form.jsx` in method `renderPaymentBox()` just to make it appear.