### PR TITLE
Inline Help: make the contact form available to all users

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -113,8 +113,8 @@ export default {
 	inlineHelpWithContactForm: {
 		datestamp: '20180306',
 		variations: {
-			original: 90,
-			inlinecontact: 10,
+			original: 0,
+			inlinecontact: 100,
 		},
 		defaultVariation: 'original',
 		allowExistingUsers: true,


### PR DESCRIPTION
This PR makes the contact form in Inline Help available to 100% of users. It's easy and quick to revert in case this causes issues. 