### PR TITLE
Store: Update header area to remove duplicate site info

### DIFF
--- a/client/extensions/woocommerce/components/action-header/index.js
+++ b/client/extensions/woocommerce/components/action-header/index.js
@@ -13,6 +13,7 @@ import { isArray } from 'lodash';
  */
 import ActionButtons from './actions';
 import Button from 'components/button';
+import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import SiteIcon from 'blocks/site-icon';
@@ -43,6 +44,8 @@ class ActionHeader extends React.Component {
 	render() {
 		const { children, primaryLabel, site } = this.props;
 
+		const link = getLink( 'https://:site/', site );
+
 		return (
 			<header className="action-header">
 				<Button
@@ -53,9 +56,15 @@ class ActionHeader extends React.Component {
 					<Gridicon icon="chevron-left" />
 				</Button>
 				<div className="action-header__content">
-					<SiteIcon site={ site } />
+					<a href={ link }>
+						<SiteIcon site={ site } />
+					</a>
 					<div className="action-header__details">
-						{ site && <p className="action-header__site-title">{ site.title }</p> }
+						{ site && (
+							<p className="action-header__site-title">
+								<a href={ link }>{ site.title }</a>
+							</p>
+						) }
 						{ this.renderBreadcrumbs() }
 					</div>
 				</div>

--- a/client/extensions/woocommerce/components/action-header/index.js
+++ b/client/extensions/woocommerce/components/action-header/index.js
@@ -13,7 +13,6 @@ import { isArray } from 'lodash';
  */
 import ActionButtons from './actions';
 import Button from 'components/button';
-import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import SiteIcon from 'blocks/site-icon';
@@ -44,8 +43,6 @@ class ActionHeader extends React.Component {
 	render() {
 		const { children, primaryLabel, site } = this.props;
 
-		const link = getLink( 'https://:site/', site );
-
 		return (
 			<header className="action-header">
 				<Button
@@ -56,15 +53,11 @@ class ActionHeader extends React.Component {
 					<Gridicon icon="chevron-left" />
 				</Button>
 				<div className="action-header__content">
-					<a href={ link }>
+					<a href={ site.URL } aria-label={ site.title }>
 						<SiteIcon site={ site } />
 					</a>
 					<div className="action-header__details">
-						{ site && (
-							<p className="action-header__site-title">
-								<a href={ link }>{ site.title }</a>
-							</p>
-						) }
+						{ site && <p className="action-header__site-title">{ site.title }</p> }
 						{ this.renderBreadcrumbs() }
 					</div>
 				</div>

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -57,6 +57,10 @@
 		font-size: 10px;
 		color: $gray-darken-10;
 		margin: 2px 0 -3px;
+
+		a, a:hover {
+			color: $gray-darken-10;
+		}
 	}
 
 	.action-header__breadcrumbs {

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -11,6 +11,10 @@
 	color: $gray-dark;
 	background: $white;
 	border-bottom: 1px solid $gray-lighten-20;
+	position: fixed;
+	z-index: z-index( 'root', '.sticky-panel.is-sticky .sticky-panel__content' );
+	top: 47px;
+	left: 0px;
 
 	@include breakpoint( ">480px" ) {
 		padding: 8px 24px 8px 0;
@@ -18,29 +22,14 @@
 
 	@include breakpoint( ">660px" ) {
 		padding: 5px 16px;
+		padding-left: 0;
 		margin: 0;
-	}
+		margin-left: 40px;
+		z-index: z-index( 'root', '.layout__secondary' );
 
-	@include breakpoint( ">960px" ) {
-		position: fixed;
-		z-index: z-index( 'root', '.sticky-panel.is-sticky .sticky-panel__content' );
-		width: calc(100% - 273px);
-		top: 47px;
-		left: 273px;
-	}
-	@include breakpoint( "660px-960px" ) {
-		position: fixed;
-		z-index: z-index( 'root', '.sticky-panel.is-sticky .sticky-panel__content' );
-		width: calc(100% - 229px);
-		top: 47px;
-		left: 229px;
-	}
-
-	@include breakpoint( "<660px" ) {
-		position: fixed;
-		z-index: z-index( 'root', '.sticky-panel.is-sticky .sticky-panel__content' );
-		width: 100%;
-		top: 47px;
+		.gridicons-chevron-left {
+			display: none;
+		}
 	}
 }
 
@@ -48,10 +37,6 @@
 	flex-grow: 0;
 	flex-shrink: 0;
 	min-width: 40px;
-
-	@include breakpoint( ">660px" ) {
-		display: none;
-	}
 }
 
 .action-header__content {
@@ -59,6 +44,10 @@
 	flex-shrink: 0;
 	display: flex;
 	justify-content: flex-start;
+
+	@include breakpoint( ">660px" ) {
+		margin-left: -32px;
+	}
 
 	.site-icon {
 		margin-right: 8px;

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -25,7 +25,6 @@
 		padding-left: 0;
 		margin: 0;
 		margin-left: 40px;
-		z-index: z-index( 'root', '.layout__secondary' );
 
 		.gridicons-chevron-left {
 			display: none;
@@ -84,6 +83,10 @@
 	// Triggers the width of the list, so ActionButtons correctly measures the space.
 	overflow: hidden;
 	text-align: right;
+
+	@include breakpoint( ">660px" ) {
+		margin-right: 40px;
+	}
 
 	.action-header__actions-list {
 		display: flex;

--- a/client/extensions/woocommerce/store-sidebar/store-ground-control.js
+++ b/client/extensions/woocommerce/store-sidebar/store-ground-control.js
@@ -28,10 +28,10 @@ const StoreGroundControl = ( { site, translate } ) => {
 				href={ backLink }
 				aria-label={ translate( 'Go back' ) }
 			>
-				<Gridicon icon="arrow-left" />
+				<Gridicon icon="chevron-left" />
 			</Button>
 			<div className="store-sidebar__ground-control-site">
-				<Site compact site={ site } indicator={ false } homeLink externalLink />
+				<Site site={ site } indicator={ false } homeLink externalLink />
 			</div>
 		</div>
 	);

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -117,7 +117,6 @@
 
 	.store-sidebar__ground-control {
 		align-items: center;
-		border-bottom: 1px solid darken( $sidebar-bg-color, 10% );
 		background-color: $white;
 		display: flex;
 		width: 100%;
@@ -126,18 +125,59 @@
 	.store-sidebar__ground-control-back {
 		flex: 0 0 auto;
 		margin-left: 7px;
-		margin-right: 7px;
 	}
 
 	.store-sidebar__ground-control-site {
-		border-left: 1px solid darken( $sidebar-bg-color, 10% );
 		display: inline-block;
 		flex-grow: 1;
-		min-height: 46px;
+		max-height: 60px;
+
+		.site__content {
+			padding: 12px;
+			padding-left: 8px;
+		}
+	}
+
+	@include breakpoint( ">660px" ) {
+		margin-top: 47px;
+		padding-top: 4px;
+
+		.store-sidebar__ground-control-site {
+			display: none;
+		}
+
+		.store-sidebar__ground-control {
+			padding-left: 7px;
+			position: fixed;
+			width: 100%;
+			top: 47px;
+			left: 0px;
+			min-height: 46px;
+			z-index: z-index( 'root', '.sticky-panel.is-sticky .sticky-panel__content' );
+			background: $white;
+			border-bottom: 1px solid $gray-lighten-20;
+		}
+	}
+
+	@include breakpoint( "<660px" ) {
+		.site__title {
+			margin-top: 8px;
+		}
+		.site__domain {
+			display: none;
+		}
 	}
 
 	.sidebar__menu {
 		margin-top: 0;
+
+		@include breakpoint( "<660px" ) {
+			border-top: 1px solid darken( $sidebar-bg-color, 10% );
+		}
+
+		@include breakpoint( ">660px" ) {
+			margin-top: -4px;
+		}
 
 		ul {
 			li:first-child {


### PR DESCRIPTION
Fixes #23343, and is a follow-up to #22541.

This PR removes the duplicate site information from displaying on desktop, and implements Jay's design. It also replaces the back arrow with a chevron as requested.

Before:

<img width="451" alt="screen shot 2018-03-27 at 2 28 32 pm" src="https://user-images.githubusercontent.com/689165/37996005-291284ae-31cb-11e8-9b59-e25843a065c9.png">

After:

<img width="447" alt="screen shot 2018-03-27 at 2 14 07 pm" src="https://user-images.githubusercontent.com/689165/37996021-3128236a-31cb-11e8-96b8-ed2054c59554.png">

To Test:

* Visit any store page and verify the header bar displays correctly.
* Click around to a few pages and verify there as well.
* Double check mobile styles/display.