### PR TITLE
Contact Form: Update closure notice for Easter 2018

### DIFF
--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -192,6 +192,12 @@
 		display: block;
 	}
 
+	.help-contact-form {
+		button {
+			width: 100%;
+		}
+	}
+
 	.help-contact__form {
 		margin: 0;
 		padding: 16px;
@@ -205,10 +211,6 @@
 			.site__content {
 				padding: 8px;
 			}
-		}
-
-		button {
-			width: 100%;
 		}
 
 		.help-contact-confirmation {

--- a/client/me/help/help-contact-closed/index.jsx
+++ b/client/me/help/help-contact-closed/index.jsx
@@ -38,7 +38,7 @@ const HelpContactClosed = ( { compact, translate } ) => {
 	if ( compact ) {
 		return (
 			<FoldableCard
-				className="help-contact-closed is-comTpact"
+				className="help-contact-closed"
 				clickableHeader={ true }
 				compact={ true }
 				header={ closureHeading }

--- a/client/me/help/help-contact-closed/index.jsx
+++ b/client/me/help/help-contact-closed/index.jsx
@@ -7,45 +7,43 @@
 import React from 'react';
 import i18n, { localize } from 'i18n-calypso';
 
-const christmas2017ClosureStartsAt = i18n.moment( 'Sun, 24 Dec 2017 00:00:00 +0000' );
-const newYear2018NoticeStartsAt = i18n.moment( 'Fri, 29 Dec 2017 00:00:00 +0000' );
-const newYear2018ClosureStartsAt = i18n.moment( 'Sun, 31 Dec 2017 00:00:00 +0000' );
-
 /**
  * Internal dependencies
  */
+import FoldableCard from 'components/foldable-card';
 import FormSectionHeading from 'components/forms/form-section-heading';
 
-const HelpContactClosed = ( { translate } ) => {
+const easter2018ClosureStartsAt = i18n.moment( 'Sun, 1 Apr 2018 00:00:00 +0000' );
+
+const HelpContactClosed = ( { compact, translate } ) => {
 	const currentDate = i18n.moment();
 	let closureHeading;
 	let closureMessage;
 
-	if ( currentDate >= newYear2018ClosureStartsAt ) {
-		closureHeading = translate( "Limited Support New Year's Day" );
+	if ( currentDate <= easter2018ClosureStartsAt ) {
+		closureHeading = translate( 'Limited Support over Easter' );
 		closureMessage = translate(
-			"Live chat is closed today for the New Year's Day holiday. If you need to get in touch with us, submit " +
-				"a support request below and we'll respond by email. Live chat will reopen on January 2nd. Thank you!"
-		);
-	} else if ( currentDate >= newYear2018NoticeStartsAt ) {
-		closureHeading = translate( "Limited Support New Year's Day" );
-		closureMessage = translate(
-			"Live chat will be closed on Monday, January 1, 2018 for the New Year's Day holiday. If you need " +
-				"to get in touch with us, you’ll be able to submit a support request from this page and we'll " +
-				'respond by email. Live chat will reopen on January 2nd. Thank you!'
-		);
-	} else if ( currentDate >= christmas2017ClosureStartsAt ) {
-		closureHeading = translate( 'Limited Support over Christmas' );
-		closureMessage = translate(
-			'Live chat is closed today for the Christmas holiday. If you need to get in touch with us, submit ' +
-				"a support request below and we'll respond by email. Live chat will reopen on December 26. Thank you!"
+			'Live chat will be closed on Sunday, April 1, 2018 for the Easter Sunday holiday. ' +
+				'If you need to get in touch with us, you’ll be able to submit a support request ' +
+				"from this page and we'll respond by email. Live chat will reopen on April 2nd. Thank you!"
 		);
 	} else {
-		closureHeading = translate( 'Limited Support over Christmas' );
+		closureHeading = translate( 'Limited Support over Easter' );
 		closureMessage = translate(
-			'Live chat will be closed on Sunday, December 24th and Monday, December 25th for the Christmas holiday. ' +
-				'If you need to get in touch with us, you’ll be able to submit a support request from this page and ' +
-				"we'll respond by email. Live chat will reopen on December 26th. Thank you!"
+			'Live chat is closed today for the Easter Sunday holiday. If you need to get in touch with us, submit a support ' +
+				"request below and we'll respond by email. Live chat will reopen on April 2nd. Thank you!"
+		);
+	}
+
+	if ( compact ) {
+		return (
+			<FoldableCard
+				className="help-contact-closed is-comTpact"
+				compact={ true }
+				header={ closureHeading }
+			>
+				{ closureMessage }
+			</FoldableCard>
 		);
 	}
 

--- a/client/me/help/help-contact-closed/index.jsx
+++ b/client/me/help/help-contact-closed/index.jsx
@@ -39,6 +39,7 @@ const HelpContactClosed = ( { compact, translate } ) => {
 		return (
 			<FoldableCard
 				className="help-contact-closed is-comTpact"
+				clickableHeader={ true }
 				compact={ true }
 				header={ closureHeading }
 			>

--- a/client/me/help/help-contact-closed/style.scss
+++ b/client/me/help/help-contact-closed/style.scss
@@ -1,6 +1,12 @@
+/** @format */
+
 .help-contact-closed {
 	color: $gray-dark;
 	font-size: 14px;
+	&.card.is-compact {
+		margin: 0 0 16px;
+		font-size: 12px;
+	}
 }
 
 .help-contact-closed__detail {

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -75,7 +75,7 @@ const SUPPORT_HAPPYCHAT = 'SUPPORT_HAPPYCHAT';
 const SUPPORT_TICKET = 'SUPPORT_TICKET';
 const SUPPORT_FORUM = 'SUPPORT_FORUM';
 
-const startShowingEaster2018ClosureNoticeAt = i18n.moment( 'Thu, 22 Mar 2018 00:00:00 +0000' );
+const startShowingEaster2018ClosureNoticeAt = i18n.moment( 'Thu, 29 Mar 2018 00:00:00 +0000' );
 const stopShowingEaster2018ClosureNoticeAt = i18n.moment( 'Mon, 2 Apr 2018 00:00:00 +0000' );
 
 class HelpContact extends React.Component {

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -75,10 +75,8 @@ const SUPPORT_HAPPYCHAT = 'SUPPORT_HAPPYCHAT';
 const SUPPORT_TICKET = 'SUPPORT_TICKET';
 const SUPPORT_FORUM = 'SUPPORT_FORUM';
 
-const startShowingChristmas2017ClosureNoticeAt = i18n.moment( 'Sun, 17 Dec 2017 00:00:00 +0000' );
-const stopShowingChristmas2017ClosureNoticeAt = i18n.moment( 'Tue, 26 Dec 2017 00:00:00 +0000' );
-const startShowingNewYear2018ClosureNoticeAt = i18n.moment( 'Fri, 29 Dec 2017 00:00:00 +0000' );
-const stopShowingNewYear2018ClosureNoticeAt = i18n.moment( 'Tue, 2 Jan 2018 00:00:00 +0000' );
+const startShowingEaster2018ClosureNoticeAt = i18n.moment( 'Thu, 22 Mar 2018 00:00:00 +0000' );
+const stopShowingEaster2018ClosureNoticeAt = i18n.moment( 'Mon, 2 Apr 2018 00:00:00 +0000' );
 
 class HelpContact extends React.Component {
 	static propTypes = {
@@ -486,7 +484,7 @@ class HelpContact extends React.Component {
 	 */
 	getView = () => {
 		const { confirmation } = this.state;
-		const { translate, selectedSitePlanSlug } = this.props;
+		const { compact, translate, selectedSitePlanSlug } = this.props;
 
 		if ( confirmation ) {
 			return <HelpContactConfirmation { ...confirmation } />;
@@ -538,25 +536,22 @@ class HelpContact extends React.Component {
 
 		const currentDate = i18n.moment();
 
-		// Customers sent to Directly and Forum are not affected by the Christmas closures
-		const isUserAffectedByChristmas2017Closure =
+		// Customers sent to Directly and Forum are not affected by live chat closures
+		const isUserAffectedByLiveChatClosure =
 			supportVariation !== SUPPORT_DIRECTLY && supportVariation !== SUPPORT_FORUM;
 
-		const isClosureNoticeInEffect =
-			currentDate.isBetween(
-				startShowingChristmas2017ClosureNoticeAt,
-				stopShowingChristmas2017ClosureNoticeAt
-			) ||
-			currentDate.isBetween(
-				startShowingNewYear2018ClosureNoticeAt,
-				stopShowingNewYear2018ClosureNoticeAt
-			);
+		const isClosureNoticeInEffect = currentDate.isBetween(
+			startShowingEaster2018ClosureNoticeAt,
+			stopShowingEaster2018ClosureNoticeAt
+		);
 
-		const shouldShowClosureNotice = isUserAffectedByChristmas2017Closure && isClosureNoticeInEffect;
+		const shouldShowClosureNotice = isUserAffectedByLiveChatClosure && isClosureNoticeInEffect;
 
 		return (
 			<div>
-				{ shouldShowClosureNotice && <HelpContactClosed sitePlanSlug={ selectedSitePlanSlug } /> }
+				{ shouldShowClosureNotice && (
+					<HelpContactClosed compact={ compact } sitePlanSlug={ selectedSitePlanSlug } />
+				) }
 				{ this.shouldShowTicketRequestErrorNotice( supportVariation ) && (
 					<Notice
 						status="is-warning"


### PR DESCRIPTION
See 613-gh-hg

**This closure was a last-minute request and quick review is required — thanks for the help!**

We've never had closure notices with the inline help form present. I added the notice as a `FoldableCard` in that context, and here's what it looks like:

![chat notice](https://user-images.githubusercontent.com/518059/38006780-08222560-320c-11e8-93ba-caa9650bc0ac.gif)

This may not be the best long-term way to present this information, but we needed a quick solution for this last-minute closure notice request.

### How to test
Test using an account with paid upgrades.

#### Test before the closure notice should appear
- Open `/help/contact` — no notice should appear
- Open the inline help popover, and select "Contact Us" — no notice should appear

#### Test the pre-closure notice
- Change [`startShowingEaster2018ClosureNoticeAt`](https://github.com/Automattic/wp-calypso/pull/23708/files#diff-bfbe01f0a66b1aa6a6708379328f1d66R78) to `i18n.moment( 'Thu, 22 Mar 2018 00:00:00 +0000' );`
- Open `/help/contact` — you should see the notice starting with "Live chat will be closed on Sunday..."
- Open the inline help popover, and select "Contact Us" — you should see the notice starting with "Live chat will be closed on Sunday..."

#### Test the during-closure notice
- Change [`easter2018ClosureStartsAt`](https://github.com/Automattic/wp-calypso/pull/23708/files#diff-ea632e3aa8f084af5d3709ae52253ae1R16) to `i18n.moment( 'Sun, 25 Mar 2018 00:00:00 +0000' );`
- Open `/help/contact` — you should see the notice starting with "Live chat is closed today..."
- Open the inline help popover, and select "Contact Us" — you should see the notice starting with "Live chat is closed today..."

#### Test after the closure
- Change [`stopShowingEaster2018ClosureNoticeAt`](https://github.com/Automattic/wp-calypso/pull/23708/files#diff-bfbe01f0a66b1aa6a6708379328f1d66R79) to `i18n.moment( 'Mon, 26 Mar 2018 00:00:00 +0000' );`
- Open `/help/contact` — no notice should appear
- Open the inline help popover, and select "Contact Us" — no notice should appear