### PR TITLE
Remove direct usage of plan constants from credit-card-payment-box

### DIFF
--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -26,7 +26,8 @@ import {
 } from 'lib/store-transactions/step-types';
 import CartCoupon from 'my-sites/checkout/cart/cart-coupon';
 import PaymentChatButton from './payment-chat-button';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { planMatches } from 'lib/plans';
+import { GROUP_WPCOM, TYPE_BUSINESS } from 'lib/plans/constants';
 import ProgressBar from 'components/progress-bar';
 import CartToggle from './cart-toggle';
 
@@ -129,7 +130,12 @@ export class CreditCardPaymentBox extends React.Component {
 
 	paymentButtons = () => {
 		const { cart, transactionStep, translate, presaleChatAvailable } = this.props,
-			hasBusinessPlanInCart = some( cart.products, { product_slug: PLAN_BUSINESS } ),
+			hasBusinessPlanInCart = some( cart.products, ( { product_slug } ) =>
+				planMatches( product_slug, {
+					type: TYPE_BUSINESS,
+					group: GROUP_WPCOM,
+				} )
+			),
 			showPaymentChatButton = presaleChatAvailable && hasBusinessPlanInCart,
 			paymentButtonClasses = 'payment-box__payment-buttons';
 

--- a/client/my-sites/checkout/checkout/test/credit-card-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/credit-card-payment-box.js
@@ -15,6 +15,44 @@ import React from 'react';
  */
 import { CreditCardPaymentBox } from '../credit-card-payment-box';
 import { INPUT_VALIDATION } from 'lib/store-transactions/step-types';
+import {
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_FREE,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+} from 'lib/plans/constants';
+
+jest.mock( 'lib/cart-values', () => ( {
+	isPaymentMethodEnabled: jest.fn( false ),
+	paymentMethodName: jest.fn( false ),
+	cartItems: {
+		hasRenewableSubscription: jest.fn( false ),
+		hasRenewalItem: jest.fn( false ),
+	},
+} ) );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: x => x,
+} ) );
+
+jest.mock( '../terms-of-service', () => {
+	const react = require( 'react' );
+	return class TermsOfService extends react.Component {};
+} );
+jest.mock( '../payment-chat-button', () => {
+	const react = require( 'react' );
+	return class PaymentChatButton extends react.Component {};
+} );
 
 jest.mock( 'lib/abtest', () => ( { abtest: () => {} } ) );
 jest.mock( 'lib/cart-values', () => ( {
@@ -102,5 +140,70 @@ describe( 'Credit Card Payment Box', () => {
 		expect( tickSpy.mock.calls.length ).toBe( 1 );
 		expect( setInterval.mock.calls.length ).toBe( 1 );
 		setInterval.mockClear();
+	} );
+} );
+
+describe( 'Credit Card Payment Box - PaymentChatButton', () => {
+	const defaultProps = {
+		cart: {},
+		translate: identity,
+	};
+
+	const businessPlans = [ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ];
+
+	businessPlans.forEach( product_slug => {
+		test( 'should render PaymentChatButton if any WP.com business plan is in the cart', () => {
+			const props = {
+				...defaultProps,
+				presaleChatAvailable: true,
+				cart: {
+					products: [ { product_slug } ],
+				},
+			};
+			const wrapper = shallow( <CreditCardPaymentBox { ...props } /> );
+			expect( wrapper.find( 'PaymentChatButton' ) ).toHaveLength( 1 );
+		} );
+	} );
+
+	businessPlans.forEach( product_slug => {
+		test( 'should not render PaymentChatButton if presaleChatAvailable is false', () => {
+			const props = {
+				...defaultProps,
+				presaleChatAvailable: false,
+				cart: {
+					products: [ { product_slug } ],
+				},
+			};
+			const wrapper = shallow( <CreditCardPaymentBox { ...props } /> );
+			expect( wrapper.find( 'PaymentChatButton' ) ).toHaveLength( 0 );
+		} );
+	} );
+
+	const otherPlans = [
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_FREE,
+		PLAN_JETPACK_FREE,
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_PERSONAL_MONTHLY,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PREMIUM_MONTHLY,
+		PLAN_JETPACK_BUSINESS,
+		PLAN_JETPACK_BUSINESS_MONTHLY,
+	];
+
+	otherPlans.forEach( product_slug => {
+		test( 'should not render PaymentChatButton if only non-business plan products are in the cart', () => {
+			const props = {
+				...defaultProps,
+				cart: {
+					products: [ { product_slug } ],
+				},
+			};
+			const wrapper = shallow( <CreditCardPaymentBox { ...props } /> );
+			expect( wrapper.find( 'PaymentChatButton' ) ).toHaveLength( 0 );
+		} );
 	} );
 } );


### PR DESCRIPTION
This PR removes usage of PLAN_* constants from credit-card-payment-box

Since we are adding new 2_YEAR plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:

* Run unit tests
* HappyChat is inactive when running on localhost - unit tests are only way to test it aside of dropping a few console.log statements where appropriate - which I did and it worked fine