### PR TITLE
Payments: Implement the query component for fetching transaction detail.

### DIFF
--- a/client/components/data/query-order-transaction/index.jsx
+++ b/client/components/data/query-order-transaction/index.jsx
@@ -10,12 +10,14 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { fetchSourcePaymentTransactionDetail } from 'state/transactions/source-payment/actions';
-import { getSourcePaymentTransactionDetail } from 'state/selectors';
+import { fetchOrderTransaction } from 'state/order-transactions/actions';
+import { getOrderTransaction } from 'state/selectors';
 
 class QuerySourcePaymentTransactionDetail extends React.Component {
 	static propTypes = {
 		pollIntervalMs: PropTypes.number,
+		transaction: PropTypes.object.isRequired,
+		fetchTransaction: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
@@ -23,20 +25,20 @@ class QuerySourcePaymentTransactionDetail extends React.Component {
 	};
 
 	componentDidMount() {
-		const { pollIntervalMs, orderId, transactionDetail, fetchTransactionDetail } = this.props;
+		const { pollIntervalMs, orderId, transaction, fetchTransaction } = this.props;
 
 		if ( pollIntervalMs ) {
 			this.timer = setInterval( () => {
 				// no need to fetch if it's there.
-				if ( null !== transactionDetail ) {
+				if ( null !== transaction ) {
 					return;
 				}
-				fetchTransactionDetail( orderId );
+				fetchTransaction( orderId );
 			}, pollIntervalMs );
 			return;
 		}
 
-		this.props.fetchTransactionDetail( orderId );
+		fetchTransaction( orderId );
 	}
 
 	componentWillUnmount() {
@@ -52,9 +54,9 @@ class QuerySourcePaymentTransactionDetail extends React.Component {
 
 export default connect(
 	( state, props ) => ( {
-		transactionDetail: getSourcePaymentTransactionDetail( state, props.orderId ),
+		transaction: getOrderTransaction( state, props.orderId ),
 	} ),
 	{
-		fetchTransactionDetail: fetchSourcePaymentTransactionDetail,
+		fetchTransaction: fetchOrderTransaction,
 	}
 )( QuerySourcePaymentTransactionDetail );

--- a/client/components/data/query-order-transaction/index.jsx
+++ b/client/components/data/query-order-transaction/index.jsx
@@ -13,10 +13,11 @@ import { connect } from 'react-redux';
 import { fetchOrderTransaction } from 'state/order-transactions/actions';
 import { getOrderTransaction } from 'state/selectors';
 
-class QuerySourcePaymentTransactionDetail extends React.Component {
+class QueryOrderTransaction extends React.Component {
 	static propTypes = {
+		orderId: PropTypes.number.isRequired,
 		pollIntervalMs: PropTypes.number,
-		transaction: PropTypes.object.isRequired,
+		transaction: PropTypes.object,
 		fetchTransaction: PropTypes.func.isRequired,
 	};
 
@@ -59,4 +60,4 @@ export default connect(
 	{
 		fetchTransaction: fetchOrderTransaction,
 	}
-)( QuerySourcePaymentTransactionDetail );
+)( QueryOrderTransaction );

--- a/client/components/data/query-source-payment-transaction-detail/index.jsx
+++ b/client/components/data/query-source-payment-transaction-detail/index.jsx
@@ -4,19 +4,53 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { fetchSourcePaymentTransactionDetail } from 'state/transaction-detail/actions';
+import { getSourcePaymentTransactionDetail } from 'state/selectors';
 
 class QuerySourcePaymentTransactionDetail extends React.Component {
+	static propTypes = {
+		pollIntervalMs: PropTypes.int,
+	};
+
+	static defaultProps = {
+		pollIntervalMs: 0,
+	};
+
 	componentDidMount() {
-		this.props.fetchSourcePaymentTransactionDetail( this.props.orderId );
+		const { pollIntervalMs, orderId, transactionDetail, fetchTransactionDetail } = this.props;
+
+		if ( pollIntervalMs ) {
+			this.timer = setInterval( () => {
+				// no need to fetch if it's there.
+				if ( null !== transactionDetail ) {
+					return;
+				}
+				fetchTransactionDetail( orderId );
+			}, pollIntervalMs );
+			return;
+		}
+
+		this.props.fetchTransactionDetail( orderId );
+	}
+
+	componentWillUnmount() {
+		if ( this.timer ) {
+			clearInterval( this.timer );
+		}
 	}
 }
 
-export default connect( () => {}, {
-	fetchSourcePaymentTransactionDetail,
-} )( QuerySourcePaymentTransactionDetail );
+export default connect(
+	( state, props ) => ( {
+		transactionDetail: getSourcePaymentTransactionDetail( state, props.orderId ),
+	} ),
+	{
+		fetchTransactionDetail: fetchSourcePaymentTransactionDetail,
+	}
+)( QuerySourcePaymentTransactionDetail );

--- a/client/components/data/query-source-payment-transaction-detail/index.jsx
+++ b/client/components/data/query-source-payment-transaction-detail/index.jsx
@@ -10,12 +10,12 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { fetchSourcePaymentTransactionDetail } from 'state/transaction-detail/actions';
+import { fetchSourcePaymentTransactionDetail } from 'state/transactions/source-payment/actions';
 import { getSourcePaymentTransactionDetail } from 'state/selectors';
 
 class QuerySourcePaymentTransactionDetail extends React.Component {
 	static propTypes = {
-		pollIntervalMs: PropTypes.int,
+		pollIntervalMs: PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -43,6 +43,10 @@ class QuerySourcePaymentTransactionDetail extends React.Component {
 		if ( this.timer ) {
 			clearInterval( this.timer );
 		}
+	}
+
+	render() {
+		return null;
 	}
 }
 

--- a/client/components/data/query-source-payment-transaction-detail/index.jsx
+++ b/client/components/data/query-source-payment-transaction-detail/index.jsx
@@ -1,0 +1,22 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { fetchSourcePaymentTransactionDetail } from 'state/transaction-detail/actions';
+
+class QuerySourcePaymentTransactionDetail extends React.Component {
+	componentDidMount() {
+		this.props.fetchSourcePaymentTransactionDetail( this.props.orderId );
+	}
+}
+
+export default connect( () => {}, {
+	fetchSourcePaymentTransactionDetail,
+} )( QuerySourcePaymentTransactionDetail );

--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { getOrderTransaction } from 'state/selectors';
-import QuerySourcePaymentTransactionDetail from 'components/data/query-source-payment-transaction-detail';
+import QueryOrderTransaction from 'components/data/query-order-transaction';
 
 class CheckoutPending extends PureComponent {
 	static propTypes = {
@@ -42,7 +42,7 @@ class CheckoutPending extends PureComponent {
 		// Replace this placeholder by the real one
 		return (
 			<div>
-				<QuerySourcePaymentTransactionDetail orderId={ orderId } pollIntervalMs={ 5000 } />
+				<QueryOrderTransaction orderId={ orderId } pollIntervalMs={ 5000 } />
 				<p>Waiting for the payment result of { orderId }</p>
 			</div>
 		);

--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -12,6 +12,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { getOrderTransaction } from 'state/selectors';
+import QuerySourcePaymentTransactionDetail from 'components/data/query-source-payment-transaction-detail';
 
 class CheckoutPending extends PureComponent {
 	static propTypes = {
@@ -20,13 +21,15 @@ class CheckoutPending extends PureComponent {
 	};
 
 	componentWillReceiveProps( nextProps ) {
-		if ( 'successful' === nextProps.paymentInfo.status ) {
+		const { processingStatus } = nextProps.paymentInfo;
+
+		if ( 'success' === processingStatus ) {
 			page( `/checkout/thank-you/${ this.props.siteSlug }` );
 			return;
 		}
 
 		// redirect users back to the checkout page so they can try again.
-		if ( 'failed' === nextProps.paymentInfo.status ) {
+		if ( 'payment-failure' === processingStatus ) {
 			page( `/checkout/${ this.props.siteSlug }` );
 			return;
 		}
@@ -39,6 +42,7 @@ class CheckoutPending extends PureComponent {
 		// Replace this placeholder by the real one
 		return (
 			<div>
+				<QuerySourcePaymentTransactionDetail orderId={ orderId } pollIntervalMs={ 5000 } />
 				<p>Waiting for the payment result of { orderId }</p>
 			</div>
 		);


### PR DESCRIPTION
## Summary
This PR is part of the work for #22914 , and is based on #23670.
It wraps the fetching and polling logic of querying transaction detail into a query component, and docks it into the pending checkout page. 

Note that it only dispatches the action for now. Once #23635 has been merged, it will poll the endpoint for real.

## Test Plan
1. Install the redux dev tool if you haven't.
1. Log in as a test account, and visit `http://calypso.localhost:3000/checkout/thank-you/:site-slug/pending/123`. Note that the site slug should be a site belonged to this account.
1. Open the redux dev tool, and make sure `FETCH_SOURCE_PAYMENT_TRANSACTION_DETAIL` is regularly dispatched with the correct order id. In the example above, it should be `123`.
