### PR TITLE
Remove direct usage of plan constants from checkout-thank-you

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -61,7 +61,7 @@ import PremiumPlanDetails from './premium-plan-details';
 import BusinessPlanDetails from './business-plan-details';
 import FailedPurchaseDetails from './failed-purchase-details';
 import PurchaseDetail from 'components/purchase-detail';
-import { getFeatureByKey, shouldFetchSitePlans } from 'lib/plans';
+import { planMatches, getFeatureByKey, shouldFetchSitePlans } from 'lib/plans';
 import RebrandCitiesThankYou from './rebrand-cities-thank-you';
 import SiteRedirectDetails from './site-redirect-details';
 import Notice from 'components/notice';
@@ -74,11 +74,8 @@ import {
 import config from 'config';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isRebrandCitiesSiteUrl } from 'lib/rebrand-cities';
-import {
-	PLAN_BUSINESS,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
-} from 'lib/plans/constants';
+import { GROUP_WPCOM, GROUP_JETPACK, TYPE_BUSINESS } from 'lib/plans/constants';
+
 import { hasSitePendingAutomatedTransfer, isSiteAutomatedTransfer } from 'state/selectors';
 import { recordStartTransferClickInThankYou } from 'state/domains/actions';
 
@@ -99,7 +96,7 @@ function findPurchaseAndDomain( purchases, predicate ) {
 	return [ purchase, purchase.meta ];
 }
 
-class CheckoutThankYou extends React.Component {
+export class CheckoutThankYou extends React.Component {
 	static propTypes = {
 		domainOnlySiteFlow: PropTypes.bool.isRequired,
 		failedPurchases: PropTypes.array,
@@ -254,7 +251,7 @@ class CheckoutThankYou extends React.Component {
 
 	isEligibleForLiveChat = () => {
 		const { planSlug } = this.props;
-		return planSlug === PLAN_JETPACK_BUSINESS || planSlug === PLAN_JETPACK_BUSINESS_MONTHLY;
+		return planMatches( planSlug, { type: TYPE_BUSINESS, group: GROUP_JETPACK } );
 	};
 
 	isNewUser = () => {
@@ -291,10 +288,14 @@ class CheckoutThankYou extends React.Component {
 		}
 
 		// Rebrand Cities thanks page
+
 		if (
 			this.props.selectedSite &&
 			isRebrandCitiesSiteUrl( this.props.selectedSite.slug ) &&
-			PLAN_BUSINESS === this.props.selectedSite.plan.product_slug
+			planMatches( this.props.selectedSite.plan.product_slug, {
+				type: TYPE_BUSINESS,
+				group: GROUP_WPCOM,
+			} )
 		) {
 			return <RebrandCitiesThankYou receipt={ this.props.receipt } />;
 		}

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -1,0 +1,231 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import {
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { CheckoutThankYou } from '../index';
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.unmock( 'lib/plans' );
+const plans = require( 'lib/plans' );
+plans.getFeatureByKey = () => null;
+plans.shouldFetchSitePlans = () => false;
+
+jest.unmock( 'lib/products-values' );
+const productValues = require( 'lib/products-values' );
+productValues.isDotComPlan = jest.fn( () => false );
+
+jest.mock( 'lib/analytics', () => ( {
+	tracks: {
+		recordEvent: () => null,
+	},
+} ) );
+jest.mock( '../domain-registration-details', () => 'component--domain-registration-details' );
+jest.mock( '../google-apps-details', () => 'component--google-apps-details' );
+jest.mock( '../jetpack-plan-details', () => 'component--jetpack-plan-details' );
+jest.mock( '../rebrand-cities-thank-you', () => 'component--RebrandCitiesThankYou' );
+jest.mock( '../atomic-store-thank-you-card', () => 'component--AtomicStoreThankYouCard' );
+jest.mock( 'lib/rebrand-cities', () => ( {
+	isRebrandCitiesSiteUrl: jest.fn( () => false ),
+} ) );
+
+import RebrandCities from 'lib/rebrand-cities';
+
+const translate = x => x;
+
+const defaultProps = {
+	translate,
+	receipt: {
+		data: {},
+	},
+	loadTrackingTool: () => {},
+	fetchReceipt: () => {},
+};
+
+describe( 'CheckoutThankYou', () => {
+	beforeAll( () => {
+		global.window = {
+			scrollTo: () => null,
+		};
+	} );
+	afterAll( () => {
+		delete global.window;
+	} );
+
+	describe( 'Basic tests', () => {
+		test( 'should not blow up and have proper CSS class', () => {
+			const comp = shallow( <CheckoutThankYou { ...defaultProps } /> );
+			expect( comp.find( '.checkout-thank-you' ).length ).toBe( 1 );
+		} );
+
+		test( 'Show WordPressLogo when there are no purchase but a receipt is present', () => {
+			const comp = shallow( <CheckoutThankYou { ...defaultProps } receiptId={ 12 } /> );
+			expect( comp.find( 'WordPressLogo' ).length ).toBe( 1 );
+		} );
+	} );
+
+	describe( 'Presence of <RebrandCitiesThankYou /> in render() output', () => {
+		afterAll( () => {
+			RebrandCities.isRebrandCitiesSiteUrl.mockImplementation( () => false );
+		} );
+
+		[ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ].forEach( product_slug => {
+			test( 'Should be there for a business plan', () => {
+				RebrandCities.isRebrandCitiesSiteUrl.mockImplementation( () => true );
+				const props = {
+					...defaultProps,
+					selectedSite: {
+						plan: {
+							product_slug,
+						},
+					},
+				};
+				const comp = shallow( <CheckoutThankYou { ...props } /> );
+				expect( comp.find( 'component--RebrandCitiesThankYou' ).length ).toBe( 1 );
+			} );
+		} );
+
+		[ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ].forEach( product_slug => {
+			test( 'Should not be there for a business plan if isRebrandCitiesSiteUrl is false', () => {
+				RebrandCities.isRebrandCitiesSiteUrl.mockImplementation( () => false );
+				const props = {
+					...defaultProps,
+					selectedSite: {
+						plan: {
+							product_slug,
+						},
+					},
+				};
+				const comp = shallow( <CheckoutThankYou { ...props } /> );
+				expect( comp.find( 'component--RebrandCitiesThankYou' ).length ).toBe( 0 );
+			} );
+		} );
+
+		[
+			PLAN_PERSONAL,
+			PLAN_PERSONAL_2_YEARS,
+			PLAN_JETPACK_PERSONAL,
+			PLAN_JETPACK_PERSONAL_MONTHLY,
+			PLAN_PREMIUM,
+			PLAN_PREMIUM_2_YEARS,
+			PLAN_JETPACK_PREMIUM,
+			PLAN_JETPACK_PREMIUM_MONTHLY,
+			PLAN_JETPACK_BUSINESS,
+			PLAN_JETPACK_BUSINESS_MONTHLY,
+		].forEach( product_slug => {
+			test( 'Should not be there for any no-business plan', () => {
+				RebrandCities.isRebrandCitiesSiteUrl.mockImplementation( () => true );
+				const props = {
+					...defaultProps,
+					selectedSite: {
+						plan: {
+							product_slug,
+						},
+					},
+				};
+				const comp = shallow( <CheckoutThankYou { ...props } /> );
+				expect( comp.find( 'component--RebrandCitiesThankYou' ).length ).toBe( 0 );
+			} );
+		} );
+	} );
+
+	describe( 'Presence of <AtomicStoreThankYouCard /> in render() output', () => {
+		const props = {
+			...defaultProps,
+			receiptId: 12,
+			selectedSite: {
+				ID: 12,
+			},
+			sitePlans: {
+				hasLoadedFromServer: true,
+			},
+			receipt: {
+				hasLoadedFromServer: true,
+				data: {
+					purchases: [ [], [] ],
+				},
+			},
+		};
+
+		afterAll( () => {
+			productValues.isDotComPlan.mockImplementation( () => false );
+		} );
+
+		test( 'Should be there for AT', () => {
+			productValues.isDotComPlan.mockImplementation( () => true );
+			let comp;
+			comp = shallow( <CheckoutThankYou { ...props } isAtomicSite={ true } /> );
+			expect( comp.find( 'component--AtomicStoreThankYouCard' ).length ).toBe( 1 );
+
+			comp = shallow( <CheckoutThankYou { ...props } hasPendingAT={ true } /> );
+			expect( comp.find( 'component--AtomicStoreThankYouCard' ).length ).toBe( 1 );
+		} );
+
+		test( 'Should not be there for AT', () => {
+			productValues.isDotComPlan.mockImplementation( () => false );
+			let comp;
+			comp = shallow( <CheckoutThankYou { ...props } isAtomicSite={ true } /> );
+			expect( comp.find( 'component--AtomicStoreThankYouCard' ).length ).toBe( 0 );
+
+			comp = shallow( <CheckoutThankYou { ...props } hasPendingAT={ true } /> );
+			expect( comp.find( 'component--AtomicStoreThankYouCard' ).length ).toBe( 0 );
+
+			productValues.isDotComPlan.mockImplementation( () => true );
+
+			comp = shallow( <CheckoutThankYou { ...props } /> );
+			expect( comp.find( 'component--AtomicStoreThankYouCard' ).length ).toBe( 0 );
+		} );
+	} );
+
+	describe( 'isEligibleForLiveChat', () => {
+		[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY ].forEach( planSlug => {
+			test( `Should return true for Jetpack business plans (${ planSlug })`, () => {
+				const instance = new CheckoutThankYou( { planSlug } );
+				expect( instance.isEligibleForLiveChat() ).toBe( true );
+			} );
+		} );
+
+		[
+			PLAN_FREE,
+			PLAN_PERSONAL,
+			PLAN_PERSONAL_2_YEARS,
+			PLAN_JETPACK_PERSONAL,
+			PLAN_JETPACK_PERSONAL_MONTHLY,
+			PLAN_PREMIUM,
+			PLAN_PREMIUM_2_YEARS,
+			PLAN_JETPACK_PREMIUM,
+			PLAN_JETPACK_PREMIUM_MONTHLY,
+			PLAN_BUSINESS,
+			PLAN_BUSINESS_2_YEARS,
+		].forEach( planSlug => {
+			test( `Should return false for all other plans (${ planSlug })`, () => {
+				const instance = new CheckoutThankYou( { planSlug } );
+				expect( instance.isEligibleForLiveChat() ).toBe( false );
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `checkout-thank-you`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* This one is tricky to test, you'll need to disable `plans/jetpack-config-v2` in your config, buy jetpack pro plan, and confirm in React devtools that this component has `showLiveChatButton` prop set to `true`

<img width="1073" alt="zrzut ekranu 2018-03-28 o 11 24 27" src="https://user-images.githubusercontent.com/205419/38020468-97213f44-327a-11e8-8367-af0836aee77a.png">

* The other part of this PR is updating `if` related to rebrand cities - I am not sure how to test it aside of dropping `console.log( planMatches( this.props.selectedSite.plan.product_slug, {
				type: TYPE_BUSINESS,
				group: GROUP_WPCOM,
			} ))` before the `if` and check if it logs true for business plan purchase. It is pretty well covered with unit tests though so it should be enough to just run them.


