### PR TITLE
Implement the pending checkout page.

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -17,6 +17,8 @@ import { getOrderTransaction, getOrderTransactionError } from 'state/selectors';
 import { ORDER_TRANSACTION_STATUS } from 'state/order-transactions/constants';
 import { errorNotice } from 'state/notices/actions';
 import QueryOrderTransaction from 'components/data/query-order-transaction';
+import EmptyContent from 'components/empty-content';
+import Main from 'components/main';
 
 class CheckoutPending extends PureComponent {
 	static propTypes = {
@@ -91,15 +93,18 @@ class CheckoutPending extends PureComponent {
 	}
 
 	render() {
-		const { orderId } = this.props;
+		const { orderId, translate } = this.props;
 
-		// TODO:
-		// Replace this placeholder by the real one
 		return (
-			<div>
+			<Main className="checkout-thank-you__pending">
 				<QueryOrderTransaction orderId={ orderId } pollIntervalMs={ 5000 } />
-				<p>Waiting for the payment result of { orderId }</p>
-			</div>
+				<EmptyContent
+					illustration={ '/calypso/images/illustrations/almost-there.svg' }
+					illustrationWidth={ 500 }
+					title={ 'Processing …' }
+					line={ translate( 'Please wait while we are processing your order.' ) }
+				/>
+			</Main>
 		);
 	}
 }

--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -102,7 +102,7 @@ class CheckoutPending extends PureComponent {
 					illustration={ '/calypso/images/illustrations/almost-there.svg' }
 					illustrationWidth={ 500 }
 					title={ 'Processing…' }
-					line={ translate( "Almost there -- we're currently finalizing your order." ) }
+					line={ translate( "Almost there – we're currently finalizing your order." ) }
 				/>
 			</Main>
 		);

--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -101,7 +101,7 @@ class CheckoutPending extends PureComponent {
 				<EmptyContent
 					illustration={ '/calypso/images/illustrations/illustration-shopping-bags.svg' }
 					illustrationWidth={ 500 }
-					title={ 'Processing…' }
+					title={ translate( 'Processing…' ) }
 					line={ translate( "Almost there – we're currently finalizing your order." ) }
 				/>
 			</Main>

--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -101,8 +101,8 @@ class CheckoutPending extends PureComponent {
 				<EmptyContent
 					illustration={ '/calypso/images/illustrations/almost-there.svg' }
 					illustrationWidth={ 500 }
-					title={ 'Processing …' }
-					line={ translate( 'Please wait while we are processing your order.' ) }
+					title={ 'Processing…' }
+					line={ translate( "Almost there -- we're currently finalizing your order." ) }
 				/>
 			</Main>
 		);

--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -99,7 +99,7 @@ class CheckoutPending extends PureComponent {
 			<Main className="checkout-thank-you__pending">
 				<QueryOrderTransaction orderId={ orderId } pollIntervalMs={ 5000 } />
 				<EmptyContent
-					illustration={ '/calypso/images/illustrations/almost-there.svg' }
+					illustration={ '/calypso/images/illustrations/illustration-shopping-bags.svg' }
 					illustrationWidth={ 500 }
 					title={ 'Processing…' }
 					line={ translate( "Almost there – we're currently finalizing your order." ) }


### PR DESCRIPTION
## Summary
This PR is part of the work for #22914 , and is based on #23713.

This PR replaces the placeholder UI with the real one looks like this:
![image](https://user-images.githubusercontent.com/1842898/38021387-446ddbec-32af-11e8-92e1-e4bca53d6e2c.png)

For more context, in the future, when a user purchases something through iDEAL, Giropay, Alipay, or any other 3rd-party payment platforms that result a redirection flow, he / she will be seeing this page when he / she is redirected back after approving or rejecting the payment. After the redirection, this page will poll for the payment status, and redirect to our standard "thank you for your purchasing" page, or to the checkout page. 

## Test Plan
1. Log in as a test user.
1. Visit `http://calypso.localhost:3000/checkout/thank-you/:site-slug/pending/123`. Note that `site-slug` should be the site belonging to the test user.
1. You should see the page like the above screenshot.