### PR TITLE
Remove direct usage of plan constants from seo-settings form

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -45,9 +45,10 @@ import { getPlugins } from 'state/plugins/installed/selectors';
 import {
 	FEATURE_ADVANCED_SEO,
 	FEATURE_SEO_PREVIEW_TOOLS,
-	PLAN_BUSINESS,
-	PLAN_JETPACK_BUSINESS,
+	TYPE_BUSINESS,
+	TERM_ANNUALLY,
 } from 'lib/plans/constants';
+import { findFirstSimilarPlanKey } from 'lib/plans';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import QuerySiteSettings from 'components/data/query-site-settings';
@@ -362,14 +363,19 @@ export class SeoForm extends React.Component {
 				) }
 
 				{ ! this.props.hasSeoPreviewFeature &&
-					! this.props.hasAdvancedSEOFeature && (
+					! this.props.hasAdvancedSEOFeature &&
+					site &&
+					site.plan && (
 						<Banner
 							description={ translate(
 								'Get tools to optimize your site for improved performance in search engine results.'
 							) }
 							event={ 'calypso_seo_settings_upgrade_nudge' }
 							feature={ siteIsJetpack ? FEATURE_SEO_PREVIEW_TOOLS : FEATURE_ADVANCED_SEO }
-							plan={ siteIsJetpack ? PLAN_JETPACK_BUSINESS : PLAN_BUSINESS }
+							plan={ findFirstSimilarPlanKey( site.plan.product_slug, {
+								type: TYPE_BUSINESS,
+								...( siteIsJetpack ? { term: TERM_ANNUALLY } : {} ),
+							} ) }
 							title={ nudgeTitle }
 						/>
 					) }

--- a/client/my-sites/site-settings/seo-settings/test/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/test/form.jsx
@@ -1,0 +1,220 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'components/banner', () => 'Banner' );
+jest.mock( 'components/notice', () => 'Notice' );
+jest.mock( 'components/notice/notice-action', () => 'NoticeAction' );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Comp => props => (
+		<Comp
+			{ ...props }
+			translate={ function( x ) {
+				return x;
+			} }
+		/>
+	),
+	numberFormat: x => x,
+} ) );
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import {
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { SeoForm } from '../form';
+
+const props = {
+	site: {
+		plan: PLAN_FREE,
+	},
+	selectedSite: {},
+	translate: x => x,
+};
+
+describe( 'SeoForm basic tests', () => {
+	test( 'should not blow up and have proper CSS class', () => {
+		const comp = shallow( <SeoForm { ...props } /> );
+		expect( comp.find( '.seo-settings__seo-form' ).length ).toBe( 1 );
+	} );
+
+	test( 'should contain PageViewTracker', () => {
+		const comp = shallow( <SeoForm { ...props } /> );
+		expect( comp.find( 'PageViewTracker' ).length ).toBe( 1 );
+	} );
+
+	test( 'should render conflicted SEO notice when conflictedSeoPlugin is set', () => {
+		const comp = shallow( <SeoForm { ...props } conflictedSeoPlugin={ { name: 'test' } } /> );
+		expect( comp.find( 'Notice' ).length ).toBe( 1 );
+		expect( comp.find( 'Notice' ).props().text ).toContain( 'Your SEO settings' );
+	} );
+
+	test( 'should not render conflicted SEO notice when conflictedSeoPlugin is not set', () => {
+		const comp = shallow( <SeoForm { ...props } /> );
+		expect( comp.find( 'Notice' ).length ).toBe( 0 );
+	} );
+
+	test( 'should render Jetpack unsupported notice when is jetpack site and does not support seo', () => {
+		const comp = shallow(
+			<SeoForm { ...props } siteIsJetpack={ true } jetpackVersionSupportsSeo={ false } />
+		);
+		expect( comp.find( 'Notice' ).length ).toBe( 1 );
+		expect( comp.find( 'Notice' ).props().text ).toContain( 'require a newer version of Jetpack' );
+	} );
+
+	test( 'should not render Jetpack unsupported notice when is not jetpack site or supports seo', () => {
+		const comp = shallow( <SeoForm { ...props } /> );
+		expect( comp.find( 'Notice' ).length ).toBe( 0 );
+	} );
+
+	test( 'should render optimize SEO banner when has no SEO features', () => {
+		const comp = shallow(
+			<SeoForm { ...props } hasSeoPreviewFeature={ false } hasAdvancedSEOFeature={ false } />
+		);
+		expect( comp.find( 'Banner' ).length ).toBe( 1 );
+		expect( comp.find( 'Banner' ).props().event ).toContain( 'calypso_seo_settings_upgrade_nudge' );
+	} );
+
+	test( 'should not render Jetpack unsupported notice when has any SEO features', () => {
+		const comp = shallow( <SeoForm { ...props } hasSeoPreviewFeature={ true } /> );
+		expect( comp.find( 'Banner' ).length ).toBe( 0 );
+
+		comp.setProps( {
+			...props,
+			hasSeoPreviewFeature: false,
+			hasAdvancedSEOFeature: true,
+		} );
+		expect( comp.find( 'Banner' ).length ).toBe( 0 );
+
+		comp.setProps( {
+			...props,
+			hasSeoPreviewFeature: true,
+			hasAdvancedSEOFeature: true,
+		} );
+		expect( comp.find( 'Banner' ).length ).toBe( 0 );
+	} );
+
+	test( 'should not render Jetpack unsupported notice when has no site', () => {
+		const comp = shallow(
+			<SeoForm
+				{ ...props }
+				site={ { plan: null } }
+				hasSeoPreviewFeature={ false }
+				hasAdvancedSEOFeature={ false }
+			/>
+		);
+		expect( comp.find( 'Banner' ).length ).toBe( 0 );
+	} );
+
+	test( 'should render SEO editor when has advanced seo and there is no conflicted SEO plugin', () => {
+		const comp = shallow( <SeoForm { ...props } showAdvancedSeo={ true } /> );
+		expect( comp.find( '.seo-settings__page-title-header' ).length ).toBe( 1 );
+	} );
+
+	test( 'should not render SEO editor when doesnt have advanced seo or there is a conflicted SEO plugin', () => {
+		let comp;
+
+		comp = shallow( <SeoForm { ...props } hasAdvancedSEOFeature={ false } /> );
+		expect( comp.find( '.seo-settings__page-title-header' ).length ).toBe( 0 );
+
+		comp = shallow(
+			<SeoForm
+				{ ...props }
+				hasAdvancedSEOFeature={ true }
+				conflictedSeoPlugin={ { name: 'test' } }
+			/>
+		);
+		expect( comp.find( '.seo-settings__page-title-header' ).length ).toBe( 0 );
+	} );
+
+	test( 'should render website meta editor when appropriate', () => {
+		let comp;
+
+		comp = shallow( <SeoForm { ...props } showAdvancedSeo={ true } /> );
+		expect( comp.find( '[name="advanced_seo_front_page_description"]' ).length ).toBe( 1 );
+
+		comp = shallow( <SeoForm { ...props } showWebsiteMeta={ true } /> );
+		expect( comp.find( '[name="advanced_seo_front_page_description"]' ).length ).toBe( 1 );
+	} );
+
+	test( 'should not render SEO editor when appropriate', () => {
+		let comp;
+
+		comp = shallow( <SeoForm { ...props } conflictedSeoPlugin={ { name: 'test' } } /> );
+		expect( comp.find( '[name="advanced_seo_front_page_description"]' ).length ).toBe( 0 );
+
+		comp = shallow(
+			<SeoForm { ...props } conflictedSeoPlugin={ { name: 'test' } } showAdvancedSeo={ true } />
+		);
+		expect( comp.find( '[name="advanced_seo_front_page_description"]' ).length ).toBe( 0 );
+
+		comp = shallow(
+			<SeoForm
+				{ ...props }
+				conflictedSeoPlugin={ { name: 'test' } }
+				siteIsJetpack={ true }
+				showWebsiteMeta={ true }
+			/>
+		);
+		expect( comp.find( '[name="advanced_seo_front_page_description"]' ).length ).toBe( 0 );
+	} );
+} );
+
+describe( 'Upsell Banner should get appropriate plan constant', () => {
+	[ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM ].forEach( product_slug => {
+		test( `Business 1 year for (${ product_slug })`, () => {
+			const comp = shallow(
+				<SeoForm { ...props } siteIsJetpack={ false } site={ { plan: { product_slug } } } />
+			);
+			expect( comp.find( 'Banner' ).length ).toBe( 1 );
+			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_BUSINESS );
+		} );
+	} );
+
+	[ PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS ].forEach( product_slug => {
+		test( `Business 2 year for (${ product_slug })`, () => {
+			const comp = shallow(
+				<SeoForm { ...props } siteIsJetpack={ false } site={ { plan: { product_slug } } } />
+			);
+			expect( comp.find( 'Banner' ).length ).toBe( 1 );
+			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_BUSINESS_2_YEARS );
+		} );
+	} );
+
+	[
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_PERSONAL_MONTHLY,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PREMIUM_MONTHLY,
+	].forEach( product_slug => {
+		test( `Jetpack Business for (${ product_slug })`, () => {
+			const comp = shallow(
+				<SeoForm { ...props } siteIsJetpack={ true } site={ { plan: { product_slug } } } />
+			);
+			expect( comp.find( 'Banner' ).length ).toBe( 1 );
+			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_JETPACK_BUSINESS );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `seo-settings/form`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* Go to /settings/traffic/ and confirm that non-business plan WP.com users will be able to see the following banner:

<img width="754" alt="zrzut ekranu 2018-03-28 o 14 59 24" src="https://user-images.githubusercontent.com/205419/38030338-9f5e9a12-3298-11e8-9cea-d6cd73cd81ad.png">

* Go to /settings/traffic/ and confirm that non-business plan Jetpack users will be able to see the following banner:

<img width="745" alt="zrzut ekranu 2018-03-28 o 14 59 12" src="https://user-images.githubusercontent.com/205419/38030340-9f7da02e-3298-11e8-88b8-b015fd3952a9.png">

* All business/professional users should not see that banner

