### PR TITLE
Remove direct usage of plan constants from settings general form

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -34,13 +34,14 @@ import Timezone from 'components/timezone';
 import SiteIconSetting from './site-icon-setting';
 import Banner from 'components/banner';
 import { isBusiness } from 'lib/products-values';
-import { FEATURE_NO_BRANDING, PLAN_BUSINESS } from 'lib/plans/constants';
+import { findFirstSimilarPlanKey } from 'lib/plans';
+import { FEATURE_NO_BRANDING, TYPE_BUSINESS } from 'lib/plans/constants';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { preventWidows } from 'lib/formatting';
 
-class SiteSettingsFormGeneral extends Component {
+export class SiteSettingsFormGeneral extends Component {
 	componentWillMount() {
 		this._showWarning( this.props.site );
 	}
@@ -238,7 +239,7 @@ class SiteSettingsFormGeneral extends Component {
 					onClick={ eventTracker( 'Clicked Language Field' ) }
 				/>
 				<FormSettingExplanation>
-					{ translate( 'The site\'s primary language.' ) }&nbsp;
+					{ translate( "The site's primary language." ) }&nbsp;
 					<a href={ config.isEnabled( 'me/account' ) ? '/me/account' : '/settings/account/' }>
 						{ translate( "You can also modify your interface's language in your profile." ) }
 					</a>
@@ -557,7 +558,7 @@ class SiteSettingsFormGeneral extends Component {
 							! isBusiness( site.plan ) && (
 								<Banner
 									feature={ FEATURE_NO_BRANDING }
-									plan={ PLAN_BUSINESS }
+									plan={ findFirstSimilarPlanKey( site.plan, { type: TYPE_BUSINESS } ) }
 									title={ translate(
 										'Remove the footer credit entirely with WordPress.com Business'
 									) }

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -1,0 +1,108 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.mock( 'store/store', () => ( {
+	get: () => {},
+	User: () => {},
+} ) );
+jest.mock( 'components/language-picker', () => 'LanguagePicker' );
+jest.mock( 'components/popover', () => 'Popover' );
+jest.mock( 'components/info-popover', () => 'InfoPopover' );
+jest.mock( 'components/banner', () => 'Banner' );
+jest.mock( 'components/data/query-site-settings', () => 'QuerySiteSettings' );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Comp => props => (
+		<Comp
+			{ ...props }
+			translate={ function( x ) {
+				return x;
+			} }
+		/>
+	),
+	numberFormat: x => x,
+} ) );
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import {
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { SiteSettingsFormGeneral } from '../form-general';
+
+import moment from 'moment';
+
+moment.tz = {
+	guess: () => moment(),
+};
+
+const props = {
+	site: {
+		plan: PLAN_FREE,
+	},
+	selectedSite: {},
+	translate: x => x,
+	onChangeField: x => x,
+	eventTracker: x => x,
+	uniqueEventTracker: x => x,
+	fields: {},
+	moment,
+};
+
+describe( 'SiteSettingsFormGeneral ', () => {
+	afterAll( () => {
+		global.window = {};
+	} );
+
+	afterAll( () => {
+		delete global.window;
+	} );
+
+	test( 'should not blow up and have proper CSS class', () => {
+		const comp = shallow( <SiteSettingsFormGeneral { ...props } /> );
+		expect( comp.find( '.site-settings__site-options' ).length ).toBe( 1 );
+	} );
+
+	describe( 'Upsell Banner should get appropriate plan constant', () => {
+		[ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM ].forEach( plan => {
+			test( `Business 1 year for (${ plan })`, () => {
+				const comp = shallow(
+					<SiteSettingsFormGeneral { ...props } siteIsJetpack={ false } site={ { plan } } />
+				);
+				expect( comp.find( 'Banner' ).length ).toBe( 1 );
+				expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_BUSINESS );
+			} );
+		} );
+
+		[ PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS ].forEach( plan => {
+			test( `Business 2 year for (${ plan })`, () => {
+				const comp = shallow(
+					<SiteSettingsFormGeneral { ...props } siteIsJetpack={ false } site={ { plan } } />
+				);
+				expect( comp.find( 'Banner' ).length ).toBe( 1 );
+				expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_BUSINESS_2_YEARS );
+			} );
+		} );
+
+		test( 'No banner for jetpack plans', () => {
+			const comp = shallow( <SiteSettingsFormGeneral { ...props } siteIsJetpack={ true } /> );
+			expect( comp.find( 'Banner' ).length ).toBe( 0 );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `site-settings/form-general`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* Go to /settings/general and confirm that business users can see this:
<img width="755" alt="zrzut ekranu 2018-03-28 o 12 47 11" src="https://user-images.githubusercontent.com/205419/38024811-54aabb3e-3286-11e8-93a5-e0b4b107a42b.png">
* Go to /settings/general and confirm that non-business users can see this:
<img width="734" alt="zrzut ekranu 2018-03-28 o 12 46 45" src="https://user-images.githubusercontent.com/205419/38024801-4beb1796-3286-11e8-8ccc-b5173e6206c2.png">
* Go to /settings/general and confirm that jetpack users see none of the above
