### PR TITLE
Jetpack Onboarding: Gridicons is an external import

### DIFF
--- a/client/jetpack-onboarding/constants.js
+++ b/client/jetpack-onboarding/constants.js
@@ -3,12 +3,12 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import React from 'react';
 import JetpackOnboardingBusinessAddressStep from './steps/business-address';
 import JetpackOnboardingContactFormStep from './steps/contact-form';
 import JetpackOnboardingHomepageStep from './steps/homepage';

--- a/client/jetpack-onboarding/disclaimer.jsx
+++ b/client/jetpack-onboarding/disclaimer.jsx
@@ -5,12 +5,8 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
 
 class JetpackOnboardingDisclaimer extends React.PureComponent {
 	static propTypes = {

--- a/client/jetpack-onboarding/summary-completed-steps.jsx
+++ b/client/jetpack-onboarding/summary-completed-steps.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { get, map, noop, without } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -13,7 +14,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Gridicon from 'gridicons';
 import Spinner from 'components/spinner';
 import {
 	getJetpackOnboardingCompletedSteps,


### PR DESCRIPTION
Seems like in JPO we've been labeling `gridicons` as an internal import, but it's actually external. This PR sorts that out.

To test:
* Checkout this branch
* Start the onboarding flow.
* Verify the disclaimer looks good and has no visual changes.
* Verify the summary step looks good and has no visual changes.