### PR TITLE
Add event to track when user is created via social

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -356,6 +356,7 @@ export function createAccount(
 				if ( errors ) {
 					callback( errors );
 				} else {
+					analytics.tracks.recordEvent( 'calypso_user_registration_social_complete' );
 					callback( undefined, pick( response, [ 'username', 'bearer_token' ] ) );
 				}
 			}


### PR DESCRIPTION
We currently don't track when an account is created from the signup framework and user opted to create an account with a social option.

This PR adds an event to track that.
