### PR TITLE
Plugins: scroll to top on page URL change

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -242,6 +242,13 @@ const controller = {
 		lastPluginsListVisited = null;
 		lastPluginsQuerystring = null;
 	},
+
+	scrollTopIfNoHash( context, next ) {
+		if ( typeof window !== 'undefined' && ! window.location.hash ) {
+			window.scrollTo( 0, 0 );
+		}
+		next();
+	},
 };
 
 export default controller;

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -17,6 +17,7 @@ export default function() {
 	if ( config.isEnabled( 'manage/plugins/setup' ) ) {
 		page(
 			'/plugins/setup',
+			pluginsController.scrollTopIfNoHash,
 			siteSelection,
 			pluginsController.setupPlugins,
 			makeLayout,
@@ -25,6 +26,7 @@ export default function() {
 
 		page(
 			'/plugins/setup/:site',
+			pluginsController.scrollTopIfNoHash,
 			siteSelection,
 			pluginsController.setupPlugins,
 			makeLayout,
@@ -59,9 +61,17 @@ export default function() {
 		} );
 
 		if ( config.isEnabled( 'manage/plugins/upload' ) ) {
-			page( '/plugins/upload', siteSelection, sites, makeLayout, clientRender );
+			page(
+				'/plugins/upload',
+				pluginsController.scrollTopIfNoHash,
+				siteSelection,
+				sites,
+				makeLayout,
+				clientRender
+			);
 			page(
 				'/plugins/upload/:site_id',
+				pluginsController.scrollTopIfNoHash,
 				siteSelection,
 				navigation,
 				pluginsController.upload,
@@ -72,6 +82,7 @@ export default function() {
 
 		page(
 			'/plugins',
+			pluginsController.scrollTopIfNoHash,
 			siteSelection,
 			navigation,
 			pluginsController.browsePlugins,
@@ -81,6 +92,7 @@ export default function() {
 
 		page(
 			'/plugins/manage/:site?',
+			pluginsController.scrollTopIfNoHash,
 			siteSelection,
 			navigation,
 			pluginsController.plugins,
@@ -90,6 +102,7 @@ export default function() {
 
 		page(
 			'/plugins/:pluginFilter(active|inactive|updates)/:site_id?',
+			pluginsController.scrollTopIfNoHash,
 			siteSelection,
 			navigation,
 			pluginsController.jetpackCanUpdate,
@@ -100,6 +113,7 @@ export default function() {
 
 		page(
 			'/plugins/:plugin/:site_id?',
+			pluginsController.scrollTopIfNoHash,
 			siteSelection,
 			navigation,
 			pluginsController.browsePluginsOrPlugin,
@@ -109,6 +123,7 @@ export default function() {
 
 		page(
 			'/plugins/:plugin/eligibility/:site_id',
+			pluginsController.scrollTopIfNoHash,
 			siteSelection,
 			navigation,
 			pluginsController.eligibility,


### PR DESCRIPTION
Resolves #22695

Previously, if you'd be scrolled down in the page and press something that brings to Plugins section, your scroll position would remain scrolled down

With this fix, all routes under `/plugins/*` scroll to the top before rendering content.

Scrolling to the top will happen also between different plugin sections.

### Broken
![scroll-broken](https://user-images.githubusercontent.com/87168/38027147-765177b2-3297-11e8-9574-60013ed4c4aa.gif)

### Fixed
![scroll-works](https://user-images.githubusercontent.com/87168/38027148-768629b2-3297-11e8-824e-06f5824e053c.gif)

## Testing

(Test with both desktop and mobile)

- Have a Jetpack connected site
- Go to `http://calypso.localhost:3000/plans/my-plan/:site` and press _"configure autoupdates"_:
    ![image](https://user-images.githubusercontent.com/87168/38027289-d55665e2-3297-11e8-8c87-dbaa8845c905.png)
- It'll bring you to `http://calypso.localhost:3000/plugins/manage/:site` where before the fix you'd still have to scroll up.