### PR TITLE
Signup: Add small_screen property for AB test

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -282,7 +282,9 @@ export function plansLanding( context, next ) {
 
 	context.store.dispatch( setTitle( translate( 'Plans', { textOnly: true } ) ) );
 
-	analytics.tracks.recordEvent( 'calypso_plans_view' );
+	analytics.tracks.recordEvent( 'calypso_plans_view', {
+		small_screen: isSmallScreen(),
+	} );
 	analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
 
 	context.primary = (
@@ -322,4 +324,15 @@ export function plansSelection( context, next ) {
 		</CheckoutData>
 	);
 	next();
+}
+
+// Function to filter small screens
+// Used in AB test: mobilePlansTablesOnSignup_20180320
+// Returns 1 if screen is less than, or equal to, 660 pixels wide
+function isSmallScreen() {
+	if ( window.matchMedia( '(max-width: 660px)' ).matches ) {
+		return '1';
+	}
+
+	return '0';
 }

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -612,8 +612,21 @@ class PlanFeatures extends Component {
 		);
 	}
 
+	// Function to filter small screens
+	// Used in AB test: mobilePlansTablesOnSignup_20180320
+	// Returns 1 if screen is less than, or equal to, 660 pixels wide
+	isSmallScreen() {
+		if ( window.matchMedia( '(max-width: 660px)' ).matches ) {
+			return '1';
+		}
+
+		return '0';
+	}
+
 	componentWillMount() {
-		this.props.recordTracksEvent( 'calypso_wp_plans_test_view' );
+		this.props.recordTracksEvent( 'calypso_wp_plans_test_view', {
+			small_screen: this.isSmallScreen(),
+		} );
 		retargetViewPlans();
 	}
 }


### PR DESCRIPTION
This PR adds a `small_screen` property for the mobile plans tables AB test. This will allow us to target just mobile devices to run the correct hypothesis. More details in `#comment-4559` : p6TEKc-1V1-p2

### Changes

- WPCOM: adds property to event `calypso_wp_plans_test_view`.
- JP: adds property to event `calypso_plans_view`.

### Returns

- The returned value of this function is `'1'` if screen is less than, or equal to, 660 pixels wide.
- Otherwise it returns `'0'`.

### References

Test name: `mobilePlansTablesOnSignup`.
PR for AB test: https://github.com/Automattic/wp-calypso/pull/23454