### PR TITLE
Remove direct usage of plan constants from form-analytics

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -38,17 +38,14 @@ import {
 } from 'state/sites/selectors';
 import { isJetpackModuleActive } from 'state/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import {
-	FEATURE_GOOGLE_ANALYTICS,
-	PLAN_BUSINESS,
-	PLAN_JETPACK_BUSINESS,
-} from 'lib/plans/constants';
+import { FEATURE_GOOGLE_ANALYTICS, TYPE_BUSINESS, TERM_ANNUALLY } from 'lib/plans/constants';
+import { findFirstSimilarPlanKey } from 'lib/plans';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 
 const validateGoogleAnalyticsCode = code => ! code || code.match( /^UA-\d+-\d+$/i );
 const hasBusinessPlan = overSome( isBusiness, isEnterprise, isJetpackBusiness );
 
-class GoogleAnalyticsForm extends Component {
+export class GoogleAnalyticsForm extends Component {
 	state = {
 		isCodeValid: true,
 	};
@@ -165,14 +162,17 @@ class GoogleAnalyticsForm extends Component {
 					) }
 				</SectionHeader>
 
-				{ showUpgradeNudge ? (
+				{ showUpgradeNudge && site && site.plan ? (
 					<Banner
 						description={ translate(
 							"Add your unique tracking ID to monitor your site's performance in Google Analytics."
 						) }
 						event={ 'google_analytics_settings' }
 						feature={ FEATURE_GOOGLE_ANALYTICS }
-						plan={ siteIsJetpack ? PLAN_JETPACK_BUSINESS : PLAN_BUSINESS }
+						plan={ findFirstSimilarPlanKey( site.plan.product_slug, {
+							type: TYPE_BUSINESS,
+							...( siteIsJetpack ? { term: TERM_ANNUALLY } : {} ),
+						} ) }
 						title={ nudgeTitle }
 					/>
 				) : (

--- a/client/my-sites/site-settings/test/form-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-analytics.jsx
@@ -1,0 +1,130 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'components/banner', () => 'Banner' );
+jest.mock( 'components/notice', () => 'Notice' );
+jest.mock( 'components/notice/notice-action', () => 'NoticeAction' );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Comp => props => (
+		<Comp
+			{ ...props }
+			translate={ function( x ) {
+				return x;
+			} }
+		/>
+	),
+	numberFormat: x => x,
+} ) );
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import {
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { GoogleAnalyticsForm } from '../form-analytics';
+
+const props = {
+	site: {
+		plan: PLAN_FREE,
+	},
+	selectedSite: {},
+	translate: x => x,
+	onChangeField: x => x,
+	eventTracker: x => x,
+	uniqueEventTracker: x => x,
+	fields: {},
+};
+
+describe( 'GoogleAnalyticsForm basic tests', () => {
+	test( 'should not blow up and have proper CSS class', () => {
+		const comp = shallow( <GoogleAnalyticsForm { ...props } /> );
+		expect( comp.find( '#analytics' ).length ).toBe( 1 );
+	} );
+	test( 'should not show upgrade nudge if disabled', () => {
+		const comp = shallow( <GoogleAnalyticsForm { ...props } showUpgradeNudge={ false } /> );
+		expect( comp.find( 'Banner[event="google_analytics_settings"]' ).length ).toBe( 0 );
+	} );
+} );
+
+describe( 'Upsell Banner should get appropriate plan constant', () => {
+	const myProps = {
+		...props,
+		showUpgradeNudge: true,
+	};
+
+	[ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM ].forEach( product_slug => {
+		test( `Business 1 year for (${ product_slug })`, () => {
+			const comp = shallow(
+				<GoogleAnalyticsForm
+					{ ...myProps }
+					siteIsJetpack={ false }
+					site={ { plan: { product_slug } } }
+				/>
+			);
+			expect( comp.find( 'Banner[event="google_analytics_settings"]' ).length ).toBe( 1 );
+			expect( comp.find( 'Banner[event="google_analytics_settings"]' ).props().plan ).toBe(
+				PLAN_BUSINESS
+			);
+		} );
+	} );
+
+	[ PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS ].forEach( product_slug => {
+		test( `Business 2 year for (${ product_slug })`, () => {
+			const comp = shallow(
+				<GoogleAnalyticsForm
+					{ ...myProps }
+					siteIsJetpack={ false }
+					site={ { plan: { product_slug } } }
+				/>
+			);
+			expect( comp.find( 'Banner[event="google_analytics_settings"]' ).length ).toBe( 1 );
+			expect( comp.find( 'Banner[event="google_analytics_settings"]' ).props().plan ).toBe(
+				PLAN_BUSINESS_2_YEARS
+			);
+		} );
+	} );
+
+	[
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_PERSONAL_MONTHLY,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PREMIUM_MONTHLY,
+	].forEach( product_slug => {
+		test( `Jetpack Business for (${ product_slug })`, () => {
+			const comp = shallow(
+				<GoogleAnalyticsForm
+					{ ...myProps }
+					siteIsJetpack={ true }
+					site={ { plan: { product_slug } } }
+				/>
+			);
+			expect( comp.find( 'Banner[event="google_analytics_settings"]' ).length ).toBe( 1 );
+			expect( comp.find( 'Banner[event="google_analytics_settings"]' ).props().plan ).toBe(
+				PLAN_JETPACK_BUSINESS
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `form-analytics`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* Go to `/settings/traffic/` on non-professional jetpack site and confirm you can see the following:
<img width="744" alt="zrzut ekranu 2018-03-28 o 14 55 43" src="https://user-images.githubusercontent.com/205419/38030149-1d4f55e8-3298-11e8-985a-b4fd0105ecb2.png">

* Go to `/settings/traffic/` on professional jetpack site and confirm you can see the following:
<img width="741" alt="zrzut ekranu 2018-03-28 o 14 25 39" src="https://user-images.githubusercontent.com/205419/38028669-e8c7c50c-3293-11e8-8b4a-981a91c7cee9.png">

* Go to `/settings/traffic/` on non-business WP.com site and confirm you can see the following:
<img width="738" alt="zrzut ekranu 2018-03-28 o 14 55 33" src="https://user-images.githubusercontent.com/205419/38030187-371ecb3e-3298-11e8-95f9-1d3fa7bc92a3.png">

* Go to `/settings/traffic/` on business WP.com site and confirm you can see the following:
<img width="741" alt="form ga" src="https://user-images.githubusercontent.com/205419/38028541-7f517b9a-3293-11e8-92d1-a89e8b7d0a98.png">


