### PR TITLE
Remove direct usage of plan constants from plugins-browser

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -42,12 +42,13 @@ import NonSupportedJetpackVersionNotice from 'my-sites/plugins/not-supported-jet
 import NoPermissionsError from 'my-sites/plugins/no-permissions-error';
 import HeaderButton from 'components/header-button';
 import { isBusiness, isEnterprise, isPremium } from 'lib/products-values';
-import { PLAN_BUSINESS, FEATURE_UPLOAD_PLUGINS } from 'lib/plans/constants';
+import { TYPE_BUSINESS, FEATURE_UPLOAD_PLUGINS } from 'lib/plans/constants';
+import { findFirstSimilarPlanKey } from 'lib/plans';
 import Banner from 'components/banner';
 import { isEnabled } from 'config';
 import wpcomFeaturesAsPlugins from './wpcom-features-as-plugins';
 
-const PluginsBrowser = createReactClass( {
+export const PluginsBrowser = createReactClass( {
 	displayName: 'PluginsBrowser',
 	_SHORT_LIST_LENGTH: 6,
 	visibleCategories: [ 'new', 'popular', 'featured' ],
@@ -479,7 +480,12 @@ const PluginsBrowser = createReactClass( {
 	},
 
 	renderUpgradeNudge() {
-		if ( ! this.props.selectedSiteId || this.props.isJetpackSite || this.props.hasBusinessPlan ) {
+		if (
+			! this.props.selectedSiteId ||
+			! this.props.sitePlan ||
+			this.props.isJetpackSite ||
+			this.props.hasBusinessPlan
+		) {
 			return null;
 		}
 
@@ -487,7 +493,9 @@ const PluginsBrowser = createReactClass( {
 			<Banner
 				feature={ FEATURE_UPLOAD_PLUGINS }
 				event={ 'calypso_plugins_browser_upgrade_nudge' }
-				plan={ PLAN_BUSINESS }
+				plan={ findFirstSimilarPlanKey( this.props.sitePlan.product_slug, {
+					type: TYPE_BUSINESS,
+				} ) }
 				title={ this.props.translate( 'Upgrade to the Business plan to install plugins.' ) }
 			/>
 		);

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -49,6 +49,7 @@ import { isEnabled } from 'config';
 import wpcomFeaturesAsPlugins from './wpcom-features-as-plugins';
 
 export const PluginsBrowser = createReactClass( {
+	// eslint-disable-line react/prefer-es6-class
 	displayName: 'PluginsBrowser',
 	_SHORT_LIST_LENGTH: 6,
 	visibleCategories: [ 'new', 'popular', 'featured' ],

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -48,8 +48,8 @@ import Banner from 'components/banner';
 import { isEnabled } from 'config';
 import wpcomFeaturesAsPlugins from './wpcom-features-as-plugins';
 
+// eslint-disable-next-line react/prefer-es6-class
 export const PluginsBrowser = createReactClass( {
-	// eslint-disable-line react/prefer-es6-class
 	displayName: 'PluginsBrowser',
 	_SHORT_LIST_LENGTH: 6,
 	visibleCategories: [ 'new', 'popular', 'featured' ],

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -1,0 +1,161 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.mock( 'lib/analytics/index', () => ( {} ) );
+jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'lib/user', () => ( {} ) );
+jest.mock( 'lib/plugins/wporg-data/list-store', () => ( {
+	getShortList: () => {},
+	getFullList: () => {},
+	getSearchList: () => {},
+	on: () => {},
+} ) );
+jest.mock( 'lib/plugins/wporg-data/actions', () => ( {} ) );
+jest.mock( 'components/main', () => 'MainComponent' );
+jest.mock( 'components/banner', () => 'Banner' );
+jest.mock( 'components/notice', () => 'Notice' );
+jest.mock( 'components/notice/notice-action', () => 'NoticeAction' );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Comp => props => (
+		<Comp
+			{ ...props }
+			translate={ function( x ) {
+				return x;
+			} }
+		/>
+	),
+	numberFormat: x => x,
+} ) );
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import {
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { PluginsBrowser } from '../';
+
+const props = {
+	site: {
+		plan: PLAN_FREE,
+	},
+	selectedSite: {},
+	selectedSiteId: 123,
+	translate: x => x,
+};
+
+describe( 'PluginsBrowser basic tests', () => {
+	test( 'should not blow up and have proper CSS class', () => {
+		const comp = shallow( <PluginsBrowser { ...props } /> );
+		expect( comp.find( 'MainComponent' ).length ).toBe( 1 );
+	} );
+	test( 'should show upgrade nudge when appropriate', () => {
+		const comp = shallow(
+			<PluginsBrowser
+				{ ...props }
+				selectedSiteId={ 12 }
+				sitePlan={ PLAN_PREMIUM }
+				isJetpackSite={ false }
+				hasBusinessPlan={ false }
+			/>
+		);
+		expect( comp.find( 'Banner[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe( 1 );
+	} );
+	test( 'should not show upgrade nudge if no site is selected', () => {
+		const comp = shallow(
+			<PluginsBrowser
+				{ ...props }
+				selectedSiteId={ null }
+				sitePlan={ { product_slug: PLAN_PREMIUM } }
+				isJetpackSite={ false }
+				hasBusinessPlan={ false }
+			/>
+		);
+		expect( comp.find( 'Banner[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe( 0 );
+	} );
+	test( 'should not show upgrade nudge if no sitePlan', () => {
+		const comp = shallow(
+			<PluginsBrowser
+				{ ...props }
+				selectedSiteId={ 10 }
+				sitePlan={ null }
+				isJetpackSite={ true }
+				hasBusinessPlan={ false }
+			/>
+		);
+		expect( comp.find( 'Banner[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe( 0 );
+	} );
+	test( 'should not show upgrade nudge if jetpack site', () => {
+		const comp = shallow(
+			<PluginsBrowser
+				{ ...props }
+				selectedSiteId={ 10 }
+				sitePlan={ { product_slug: PLAN_PREMIUM } }
+				isJetpackSite={ true }
+				hasBusinessPlan={ false }
+			/>
+		);
+		expect( comp.find( 'Banner[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe( 0 );
+	} );
+	test( 'should not show upgrade nudge has business plan', () => {
+		const comp = shallow(
+			<PluginsBrowser
+				{ ...props }
+				selectedSiteId={ 10 }
+				sitePlan={ { product_slug: PLAN_PREMIUM } }
+				isJetpackSite={ false }
+				hasBusinessPlan={ true }
+			/>
+		);
+		expect( comp.find( 'Banner[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe( 0 );
+	} );
+} );
+
+describe( 'Upsell Banner should get appropriate plan constant', () => {
+	const myProps = {
+		...props,
+		showUpgradeNudge: true,
+		isJetpackSite: false,
+		hasBusinessPlan: false,
+	};
+
+	[ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM ].forEach( product_slug => {
+		test( `Business 1 year for (${ product_slug })`, () => {
+			const comp = shallow( <PluginsBrowser { ...myProps } sitePlan={ { product_slug } } /> );
+			expect( comp.find( 'Banner[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe(
+				1
+			);
+			expect(
+				comp.find( 'Banner[event="calypso_plugins_browser_upgrade_nudge"]' ).props().plan
+			).toBe( PLAN_BUSINESS );
+		} );
+	} );
+
+	[ PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS ].forEach( product_slug => {
+		test( `Business 2 year for (${ product_slug })`, () => {
+			const comp = shallow( <PluginsBrowser { ...myProps } sitePlan={ { product_slug } } /> );
+			expect( comp.find( 'Banner[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe(
+				1
+			);
+			expect(
+				comp.find( 'Banner[event="calypso_plugins_browser_upgrade_nudge"]' ).props().plan
+			).toBe( PLAN_BUSINESS_2_YEARS );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `plugins-browser`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* Go to `/plugins` and confirm that this nudge looks the same and is only visible for non-business plan users:
<img width="1055" alt="zrzut ekranu 2018-03-28 o 14 50 01" src="https://user-images.githubusercontent.com/205419/38029879-5309fd60-3297-11e8-8899-31ba92e30258.png">

