### PR TITLE
Jetpack Onboarding: Centralize PageViewTracker usage

### DIFF
--- a/client/jetpack-onboarding/constants.js
+++ b/client/jetpack-onboarding/constants.js
@@ -40,6 +40,18 @@ export const JETPACK_ONBOARDING_STEP_TITLES = {
 	[ JETPACK_ONBOARDING_STEPS.SUMMARY ]: translate( 'Summary' ),
 };
 
+// We need the non-translated version of the titles for accurately tracking page views
+export const JETPACK_ONBOARDING_ANALYTICS_TITLES = {
+	[ JETPACK_ONBOARDING_STEPS.SITE_TITLE ]: 'Site Title & Description',
+	[ JETPACK_ONBOARDING_STEPS.SITE_TYPE ]: 'Type of Site',
+	[ JETPACK_ONBOARDING_STEPS.HOMEPAGE ]: 'Type of Homepage',
+	[ JETPACK_ONBOARDING_STEPS.CONTACT_FORM ]: 'Contact Us Form',
+	[ JETPACK_ONBOARDING_STEPS.BUSINESS_ADDRESS ]: 'Business Address',
+	[ JETPACK_ONBOARDING_STEPS.WOOCOMMERCE ]: 'Add a Store',
+	[ JETPACK_ONBOARDING_STEPS.STATS ]: 'Jetpack Stats',
+	[ JETPACK_ONBOARDING_STEPS.SUMMARY ]: 'Summary',
+};
+
 export const JETPACK_ONBOARDING_COMPONENTS = {
 	[ JETPACK_ONBOARDING_STEPS.SITE_TITLE ]: <JetpackOnboardingSiteTitleStep />,
 	[ JETPACK_ONBOARDING_STEPS.SITE_TYPE ]: <JetpackOnboardingSiteTypeStep />,

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -15,6 +15,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import config from 'config';
 import DocumentHead from 'components/data/document-head';
 import Main from 'components/main';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryJetpackOnboardingSettings from 'components/data/query-jetpack-onboarding-settings';
 import QuerySites from 'components/data/query-sites';
 import Wizard from 'components/wizard';
@@ -135,12 +136,14 @@ class JetpackOnboardingMain extends React.PureComponent {
 			steps,
 			translate,
 		} = this.props;
+		const basePath = '/jetpack/start';
+		const pageTitle = get( STEP_TITLES, stepName ) + ' ‹ ' + translate( 'Jetpack Start' );
 
 		return (
 			<Main className="jetpack-onboarding">
-				<DocumentHead
-					title={ get( STEP_TITLES, stepName ) + ' ‹ ' + translate( 'Jetpack Start' ) }
-				/>
+				<DocumentHead title={ pageTitle } />
+				<PageViewTracker path={ [ basePath, stepName, ':site' ].join( '/' ) } title={ pageTitle } />
+
 				{ /* It is important to use `<QuerySites siteId={ siteSlug } />` here, however wrong that seems.
 				   * The reason is that we rely on an `isRequestingSite()` check to tell whether we've
 				   * finished fetching site details, which will tell us whether the site is connected,
@@ -161,7 +164,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 				{ siteId ? (
 					<Wizard
 						action={ action }
-						basePath="/jetpack/start"
+						basePath={ basePath }
 						baseSuffix={ siteSlug }
 						components={ COMPONENTS }
 						hideForwardLink={ this.shouldHideForwardLink() }

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -22,6 +22,7 @@ import Wizard from 'components/wizard';
 import WordPressLogo from 'components/wordpress-logo';
 import { addQueryArgs, externalRedirect } from 'lib/route';
 import {
+	JETPACK_ONBOARDING_ANALYTICS_TITLES as ANALYTICS_TITLES,
 	JETPACK_ONBOARDING_COMPONENTS as COMPONENTS,
 	JETPACK_ONBOARDING_STEPS as STEPS,
 	JETPACK_ONBOARDING_STEP_TITLES as STEP_TITLES,
@@ -138,11 +139,15 @@ class JetpackOnboardingMain extends React.PureComponent {
 		} = this.props;
 		const basePath = '/jetpack/start';
 		const pageTitle = get( STEP_TITLES, stepName ) + ' ‹ ' + translate( 'Jetpack Start' );
+		const analyticsPageTitle = get( ANALYTICS_TITLES, stepName ) + ' ‹ ' + 'Jetpack Start';
 
 		return (
 			<Main className="jetpack-onboarding">
 				<DocumentHead title={ pageTitle } />
-				<PageViewTracker path={ [ basePath, stepName, ':site' ].join( '/' ) } title={ pageTitle } />
+				<PageViewTracker
+					path={ [ basePath, stepName, ':site' ].join( '/' ) }
+					title={ analyticsPageTitle }
+				/>
 
 				{ /* It is important to use `<QuerySites siteId={ siteSlug } />` here, however wrong that seems.
 				   * The reason is that we rely on an `isRequestingSite()` check to tell whether we've

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -19,10 +19,8 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import JetpackLogo from 'components/jetpack-logo';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QuerySites from 'components/data/query-sites';
 import { isJetpackSite } from 'state/sites/selectors';
-import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
 class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 	static emptyFields = {
@@ -207,14 +205,10 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 	}
 
 	render() {
-		const { basePath, getForwardUrl, hasBusinessAddress, siteId, translate } = this.props;
+		const { getForwardUrl, hasBusinessAddress, siteId, translate } = this.props;
 
 		return (
 			<div className="steps__main">
-				<PageViewTracker
-					path={ [ basePath, STEPS.BUSINESS_ADDRESS, ':site' ].join( '/' ) }
-					title="Business Address ‹ Jetpack Start"
-				/>
 				<QuerySites siteId={ siteId } />
 
 				<JetpackLogo full size={ 45 } />

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -15,7 +15,6 @@ import ConnectIntro from '../connect-intro';
 import ConnectSuccess from '../connect-success';
 import FormattedHeader from 'components/formatted-header';
 import JetpackLogo from 'components/jetpack-logo';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QuerySites from 'components/data/query-sites';
 import { getJetpackOnboardingPendingSteps } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
@@ -93,14 +92,10 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 	}
 
 	render() {
-		const { basePath, getForwardUrl, hasContactForm, siteId, translate } = this.props;
+		const { getForwardUrl, hasContactForm, siteId, translate } = this.props;
 
 		return (
 			<div className="steps__main">
-				<PageViewTracker
-					path={ [ basePath, STEPS.CONTACT_FORM, ':site' ].join( '/' ) }
-					title="Contact Form ‹ Jetpack Start"
-				/>
 				<QuerySites siteId={ siteId } />
 
 				<JetpackLogo full size={ 45 } />

--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -11,10 +11,8 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import FormattedHeader from 'components/formatted-header';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
 import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
-import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
 class JetpackOnboardingHomepageStep extends React.PureComponent {
 	handleHomepageSelection = homepageFormat => () => {
@@ -28,7 +26,7 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 	};
 
 	render() {
-		const { basePath, getForwardUrl, settings, translate } = this.props;
+		const { getForwardUrl, settings, translate } = this.props;
 		const headerText = translate( "Let's shape your new site." );
 		const subHeaderText = translate( 'What should visitors see on your homepage?' );
 		const forwardUrl = getForwardUrl();
@@ -36,11 +34,6 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 
 		return (
 			<div className="steps__main">
-				<PageViewTracker
-					path={ [ basePath, STEPS.HOMEPAGE, ':site' ].join( '/' ) }
-					title="Homepage ‹ Jetpack Start"
-				/>
-
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<TileGrid>

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -15,9 +15,7 @@ import Button from 'components/button';
 import Card from 'components/card';
 import FormattedHeader from 'components/formatted-header';
 import JetpackOnboardingDisclaimer from '../disclaimer';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
 import SiteTitle from 'components/site-title';
-import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
 class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 	state = {
@@ -62,16 +60,11 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 	};
 
 	render() {
-		const { basePath, isRequestingSettings, isRequestingWhetherConnected, translate } = this.props;
+		const { isRequestingSettings, isRequestingWhetherConnected, translate } = this.props;
 		const headerText = translate( 'Welcome to WordPress!' );
 
 		return (
 			<div className="steps__main">
-				<PageViewTracker
-					path={ [ basePath, STEPS.SITE_TITLE, ':site' ].join( '/' ) }
-					title="Site Title ‹ Jetpack Start"
-				/>
-
 				<FormattedHeader headerText={ headerText } />
 
 				<Card className="steps__form">

--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -11,10 +11,8 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import FormattedHeader from 'components/formatted-header';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
 import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
-import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
 class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 	handleSiteTypeSelection = siteType => () => {
@@ -27,7 +25,7 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 	};
 
 	render() {
-		const { basePath, getForwardUrl, settings, translate } = this.props;
+		const { getForwardUrl, settings, translate } = this.props;
 		const headerText = translate( "Let's shape your new site." );
 		const subHeaderText = translate( 'What kind of site do you need? Choose an option below:' );
 		const forwardUrl = getForwardUrl();
@@ -35,11 +33,6 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 
 		return (
 			<div className="steps__main">
-				<PageViewTracker
-					path={ [ basePath, STEPS.SITE_TYPE, ':site' ].join( '/' ) }
-					title="Site Type ‹ Jetpack Start"
-				/>
-
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<TileGrid>

--- a/client/jetpack-onboarding/steps/stats.jsx
+++ b/client/jetpack-onboarding/steps/stats.jsx
@@ -15,7 +15,6 @@ import ConnectIntro from '../connect-intro';
 import ConnectSuccess from '../connect-success';
 import FormattedHeader from 'components/formatted-header';
 import JetpackLogo from 'components/jetpack-logo';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QuerySites from 'components/data/query-sites';
 import { getJetpackOnboardingPendingSteps } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
@@ -105,14 +104,10 @@ class JetpackOnboardingStatsStep extends React.Component {
 	}
 
 	render() {
-		const { activatedStats, basePath, getForwardUrl, siteId } = this.props;
+		const { activatedStats, getForwardUrl, siteId } = this.props;
 
 		return (
 			<div className="steps__main">
-				<PageViewTracker
-					path={ [ basePath, STEPS.STATS, ':site' ].join( '/' ) }
-					title="Jetpack Stats ‹ Jetpack Start"
-				/>
 				<QuerySites siteId={ siteId } />
 
 				<JetpackLogo full size={ 45 } />

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -13,11 +13,9 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import Card from 'components/card';
 import FormattedHeader from 'components/formatted-header';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
 import CompletedSteps from '../summary-completed-steps';
 import NextSteps from '../summary-next-steps';
 import { getSiteUrl, getUnconnectedSiteUrl } from 'state/selectors';
-import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
 class JetpackOnboardingSummaryStep extends React.PureComponent {
 	handleSummaryStepClick = ( stepName, stepType ) => () => {
@@ -38,10 +36,6 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 
 		return (
 			<div className="steps__main">
-				<PageViewTracker
-					path={ [ basePath, STEPS.SUMMARY, ':site' ].join( '/' ) }
-					title="Summary ‹ Jetpack Start"
-				/>
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<Card>

--- a/client/jetpack-onboarding/steps/woocommerce.jsx
+++ b/client/jetpack-onboarding/steps/woocommerce.jsx
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import FormattedHeader from 'components/formatted-header';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 import {
 	getJetpackOnboardingCompletedSteps,
@@ -34,7 +33,7 @@ class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 	};
 
 	render() {
-		const { basePath, getForwardUrl, stepsCompleted, stepsPending, translate } = this.props;
+		const { getForwardUrl, stepsCompleted, stepsPending, translate } = this.props;
 		const headerText = translate( 'Are you looking to sell online?' );
 		const subHeaderText = translate(
 			"We'll set you up with WooCommerce for all of your online selling needs."
@@ -45,11 +44,6 @@ class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 
 		return (
 			<div className="steps__main">
-				<PageViewTracker
-					path={ [ basePath, STEPS.WOOCOMMERCE, ':site' ].join( '/' ) }
-					title="WooCommerce ‹ Jetpack Start"
-				/>
-
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<div className="steps__button-group">


### PR DESCRIPTION
This PR centralizes the `<PageViewTracker />` usage throughout JPO. We've been manually defining it in all steps, while we can do it centrally in the main component. This is what this PR suggests - it allows us to get rid of some LoC.

To test:
* Checkout this branch
* Start the onboarding flow.
* Run the following in your console `localStorage.setItem( 'debug', 'calypso:analytics:PageViewTracker' )`
* Verify all steps record page views like they did before.