### PR TITLE
Analytics: Refactor `tracks.recordEvent` to omit `blog_id` when unneeded

### DIFF
--- a/client/lib/analytics/constants.js
+++ b/client/lib/analytics/constants.js
@@ -1,0 +1,12 @@
+/** @format */
+
+export const NO_BLOG_ID_PATHS = [
+	// '/', Root path case handled manually
+	'/me',
+	'/help',
+	'/read',
+	'/following',
+	'/discover',
+	'/activities',
+	'/tag',
+];

--- a/client/lib/analytics/constants.js
+++ b/client/lib/analytics/constants.js
@@ -1,9 +1,8 @@
 /** @format */
 
 export const NO_BLOG_ID_PATHS = [
-	// '/', Root path case handled manually
-	// '/me', Me root path handled manually because conflicting with `/media`
-	'/me/',
+	'/',
+	'/me',
 	'/help',
 	'/read',
 	'/following',

--- a/client/lib/analytics/constants.js
+++ b/client/lib/analytics/constants.js
@@ -2,7 +2,8 @@
 
 export const NO_BLOG_ID_PATHS = [
 	// '/', Root path case handled manually
-	'/me',
+	// '/me', Me root path handled manually because conflicting with `/media`
+	'/me/',
 	'/help',
 	'/read',
 	'/following',

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -287,11 +287,10 @@ const analytics = {
 
 			if ( _superProps ) {
 				_dispatch && _dispatch( { type: ANALYTICS_SUPER_PROPS_UPDATE } );
-				const superProperties = _superProps.getAll( _selectedSite, _siteCount );
+				const site = shouldReportOmitBlogId( eventProperties.path ) ? null : _selectedSite;
 				actualProperties = {
 					...eventProperties,
-					..._superProps.getAll( _selectedSite, _siteCount ),
-					blog_id: shouldReportOmitBlogId( eventProperties.path ) ? null : superProperties.blog_id,
+					..._superProps.getAll( site, _siteCount ),
 				};
 			} else {
 				actualProperties = { ...eventProperties };

--- a/client/lib/analytics/test/utils.js
+++ b/client/lib/analytics/test/utils.js
@@ -1,34 +1,28 @@
 /** @format */
 /**
- * External dependencies
- */
-
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import { shouldReportOmitBlogId } from '../utils';
 
 describe( '#shouldReportOmitBlogId', () => {
 	test( 'should allow blog_id reporting for site-specific paths', () => {
-		expect( shouldReportOmitBlogId( '/stats/day/example.wordpress.com' ) ).to.be.false;
-		expect( shouldReportOmitBlogId( '/pages/example.wordpress.com' ) ).to.be.false;
-		expect( shouldReportOmitBlogId( '/posts/example.wordpress.com' ) ).to.be.false;
-		expect( shouldReportOmitBlogId( '/media/example.wordpress.com' ) ).to.be.false;
-		expect( shouldReportOmitBlogId( '/comments/all/example.wordpress.com' ) ).to.be.false;
-		expect( shouldReportOmitBlogId( '/plugins/example.wordpress.com' ) ).to.be.false;
-		expect( shouldReportOmitBlogId( '/domains/manage/example.wordpress.com' ) ).to.be.false;
-		expect( shouldReportOmitBlogId( '/settings/general/example.wordpress.com' ) ).to.be.false;
+		expect( shouldReportOmitBlogId( '/stats/day/example.wordpress.com' ) ).toBe.false;
+		expect( shouldReportOmitBlogId( '/pages/example.wordpress.com' ) ).toBe.false;
+		expect( shouldReportOmitBlogId( '/posts/example.wordpress.com' ) ).toBe.false;
+		expect( shouldReportOmitBlogId( '/media/example.wordpress.com' ) ).toBe.false;
+		expect( shouldReportOmitBlogId( '/comments/all/example.wordpress.com' ) ).toBe.false;
+		expect( shouldReportOmitBlogId( '/plugins/example.wordpress.com' ) ).toBe.false;
+		expect( shouldReportOmitBlogId( '/domains/manage/example.wordpress.com' ) ).toBe.false;
+		expect( shouldReportOmitBlogId( '/settings/general/example.wordpress.com' ) ).toBe.false;
 	} );
 	test( 'should not allow blog_id reporting for general administration paths', () => {
-		expect( shouldReportOmitBlogId( '/' ) ).to.be.true;
-		expect( shouldReportOmitBlogId( '/me' ) ).to.be.true;
-		expect( shouldReportOmitBlogId( '/help' ) ).to.be.true;
-		expect( shouldReportOmitBlogId( '/read' ) ).to.be.true;
-		expect( shouldReportOmitBlogId( '/following' ) ).to.be.true;
-		expect( shouldReportOmitBlogId( '/discover' ) ).to.be.true;
-		expect( shouldReportOmitBlogId( '/activities' ) ).to.be.true;
-		expect( shouldReportOmitBlogId( '/tag' ) ).to.be.true;
+		expect( shouldReportOmitBlogId( '/' ) ).toBe.true;
+		expect( shouldReportOmitBlogId( '/me' ) ).toBe.true;
+		expect( shouldReportOmitBlogId( '/help' ) ).toBe.true;
+		expect( shouldReportOmitBlogId( '/read' ) ).toBe.true;
+		expect( shouldReportOmitBlogId( '/following' ) ).toBe.true;
+		expect( shouldReportOmitBlogId( '/discover' ) ).toBe.true;
+		expect( shouldReportOmitBlogId( '/activities' ) ).toBe.true;
+		expect( shouldReportOmitBlogId( '/tag' ) ).toBe.true;
 	} );
 } );

--- a/client/lib/analytics/test/utils.js
+++ b/client/lib/analytics/test/utils.js
@@ -1,0 +1,34 @@
+/** @format */
+/**
+ * External dependencies
+ */
+
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { shouldReportOmitBlogId } from '../utils';
+
+describe( '#shouldReportOmitBlogId', () => {
+	test( 'should allow blog_id reporting for site-specific paths', () => {
+		expect( shouldReportOmitBlogId( '/stats/day/example.wordpress.com' ) ).to.be.false;
+		expect( shouldReportOmitBlogId( '/pages/example.wordpress.com' ) ).to.be.false;
+		expect( shouldReportOmitBlogId( '/posts/example.wordpress.com' ) ).to.be.false;
+		expect( shouldReportOmitBlogId( '/media/example.wordpress.com' ) ).to.be.false;
+		expect( shouldReportOmitBlogId( '/comments/all/example.wordpress.com' ) ).to.be.false;
+		expect( shouldReportOmitBlogId( '/plugins/example.wordpress.com' ) ).to.be.false;
+		expect( shouldReportOmitBlogId( '/domains/manage/example.wordpress.com' ) ).to.be.false;
+		expect( shouldReportOmitBlogId( '/settings/general/example.wordpress.com' ) ).to.be.false;
+	} );
+	test( 'should not allow blog_id reporting for general administration paths', () => {
+		expect( shouldReportOmitBlogId( '/' ) ).to.be.true;
+		expect( shouldReportOmitBlogId( '/me' ) ).to.be.true;
+		expect( shouldReportOmitBlogId( '/help' ) ).to.be.true;
+		expect( shouldReportOmitBlogId( '/read' ) ).to.be.true;
+		expect( shouldReportOmitBlogId( '/following' ) ).to.be.true;
+		expect( shouldReportOmitBlogId( '/discover' ) ).to.be.true;
+		expect( shouldReportOmitBlogId( '/activities' ) ).to.be.true;
+		expect( shouldReportOmitBlogId( '/tag' ) ).to.be.true;
+	} );
+} );

--- a/client/lib/analytics/test/utils.js
+++ b/client/lib/analytics/test/utils.js
@@ -6,23 +6,23 @@ import { shouldReportOmitBlogId } from '../utils';
 
 describe( '#shouldReportOmitBlogId', () => {
 	test( 'should allow blog_id reporting for site-specific paths', () => {
-		expect( shouldReportOmitBlogId( '/stats/day/example.wordpress.com' ) ).toBe.false;
-		expect( shouldReportOmitBlogId( '/pages/example.wordpress.com' ) ).toBe.false;
-		expect( shouldReportOmitBlogId( '/posts/example.wordpress.com' ) ).toBe.false;
-		expect( shouldReportOmitBlogId( '/media/example.wordpress.com' ) ).toBe.false;
-		expect( shouldReportOmitBlogId( '/comments/all/example.wordpress.com' ) ).toBe.false;
-		expect( shouldReportOmitBlogId( '/plugins/example.wordpress.com' ) ).toBe.false;
-		expect( shouldReportOmitBlogId( '/domains/manage/example.wordpress.com' ) ).toBe.false;
-		expect( shouldReportOmitBlogId( '/settings/general/example.wordpress.com' ) ).toBe.false;
+		expect( shouldReportOmitBlogId( '/stats/day/example.wordpress.com' ) ).toBe( false );
+		expect( shouldReportOmitBlogId( '/pages/example.wordpress.com' ) ).toBe( false );
+		expect( shouldReportOmitBlogId( '/posts/example.wordpress.com' ) ).toBe( false );
+		expect( shouldReportOmitBlogId( '/media/example.wordpress.com' ) ).toBe( false );
+		expect( shouldReportOmitBlogId( '/comments/all/example.wordpress.com' ) ).toBe( false );
+		expect( shouldReportOmitBlogId( '/plugins/example.wordpress.com' ) ).toBe( false );
+		expect( shouldReportOmitBlogId( '/domains/manage/example.wordpress.com' ) ).toBe( false );
+		expect( shouldReportOmitBlogId( '/settings/general/example.wordpress.com' ) ).toBe( false );
 	} );
 	test( 'should not allow blog_id reporting for general administration paths', () => {
-		expect( shouldReportOmitBlogId( '/' ) ).toBe.true;
-		expect( shouldReportOmitBlogId( '/me' ) ).toBe.true;
-		expect( shouldReportOmitBlogId( '/help' ) ).toBe.true;
-		expect( shouldReportOmitBlogId( '/read' ) ).toBe.true;
-		expect( shouldReportOmitBlogId( '/following' ) ).toBe.true;
-		expect( shouldReportOmitBlogId( '/discover' ) ).toBe.true;
-		expect( shouldReportOmitBlogId( '/activities' ) ).toBe.true;
-		expect( shouldReportOmitBlogId( '/tag' ) ).toBe.true;
+		expect( shouldReportOmitBlogId( '/' ) ).toBe( true );
+		expect( shouldReportOmitBlogId( '/me' ) ).toBe( true );
+		expect( shouldReportOmitBlogId( '/help' ) ).toBe( true );
+		expect( shouldReportOmitBlogId( '/read' ) ).toBe( true );
+		expect( shouldReportOmitBlogId( '/following' ) ).toBe( true );
+		expect( shouldReportOmitBlogId( '/discover' ) ).toBe( true );
+		expect( shouldReportOmitBlogId( '/activities' ) ).toBe( true );
+		expect( shouldReportOmitBlogId( '/tag' ) ).toBe( true );
 	} );
 } );

--- a/client/lib/analytics/utils.js
+++ b/client/lib/analytics/utils.js
@@ -5,6 +5,12 @@
  */
 
 import debugFactory from 'debug';
+import { some } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { NO_BLOG_ID_PATHS } from 'lib/analytics/constants';
 
 /**
  * Module variables
@@ -95,3 +101,16 @@ export function shouldSkipAds() {
 	debug( `Is Skipping Ads: ${ result }` );
 	return result;
 }
+
+/**
+ * Check if a path should report the currently selected site ID.
+ *
+ * Some paths should never report it because it's used
+ * to tell general admin and site-specific activities apart.
+ *
+ * @param {String} path The tracked path.
+ * @returns {Boolean} If the report should null `blog_id`.
+ */
+export const shouldReportOmitBlogId = path =>
+	'/' === path ||
+	( !! path && some( NO_BLOG_ID_PATHS, noBlogIdPath => path.indexOf( noBlogIdPath ) === 0 ) );

--- a/client/lib/analytics/utils.js
+++ b/client/lib/analytics/utils.js
@@ -112,6 +112,8 @@ export function shouldSkipAds() {
  * @returns {Boolean} If the report should null `blog_id`.
  */
 export const shouldReportOmitBlogId = path =>
-	'/' === path ||
-	'/me' === path ||
-	( !! path && some( NO_BLOG_ID_PATHS, noBlogIdPath => path.indexOf( noBlogIdPath ) === 0 ) );
+	!! path &&
+	some(
+		NO_BLOG_ID_PATHS,
+		noBlogIdPath => path === noBlogIdPath || path.indexOf( noBlogIdPath + '/' ) === 0
+	);

--- a/client/lib/analytics/utils.js
+++ b/client/lib/analytics/utils.js
@@ -113,4 +113,5 @@ export function shouldSkipAds() {
  */
 export const shouldReportOmitBlogId = path =>
 	'/' === path ||
+	'/me' === path ||
 	( !! path && some( NO_BLOG_ID_PATHS, noBlogIdPath => path.indexOf( noBlogIdPath ) === 0 ) );


### PR DESCRIPTION
Fix #16900 

Events recorded from some specific paths should not report the `blog_id` value because it's used to tell general admin and site-specific activities apart.

This PR checks if the path from where an event record is originating begins with one of the paths from the "blacklist", and in that case, `null`s the event's `blog_id` property.

## Testing instructions

- Enable tracks debugging with `localStorage.setItem('debug', 'calypso:analytics:tracks')` and filter by `page_view`.
- Try loading the following list of paths, and make sure the `blog_id` is reported as `null`.
  - `/me`
  - `/help`
  - `/` (Reader root)
  - `/read`
  - `/following`
  - `/discover`
  - `/activities`
  - `/tag`
- Try loading any other path, and make sure that the `blog_id` is reported with an actual value (unless it's an "All Sites" page: there it should be `undefined`).