### PR TITLE
Unify name for the Monitor

### DIFF
--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -84,7 +84,7 @@ class DisconnectJetpack extends PureComponent {
 				);
 				features.push(
 					translate(
-						'{{icon/}} Brute force attack protection and uptime monitoring',
+						'{{icon/}} Brute force attack protection and downtime monitoring',
 						this.getIcon( 'lock' )
 					)
 				);

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -1325,7 +1325,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Standard Security Tools' ),
 		getDescription: () =>
 			i18n.translate(
-				'Brute force protection, uptime monitoring, secure sign on, ' +
+				'Brute force protection, downtime monitoring, secure sign on, ' +
 					'and automatic updates for your plugins.'
 			),
 	},

--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -142,7 +142,7 @@ class SiteSettingsFormJetpackMonitor extends Component {
 					<div className="site-settings__info-link-container">
 						<InfoPopover position="left">
 							<ExternalLink href="https://jetpack.com/support/monitor/" icon target="_blank">
-								{ translate( 'Learn more about Monitor.' ) }
+								{ translate( 'Learn more about downtime monitoring' ) }
 							</ExternalLink>
 						</InfoPopover>
 					</div>

--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -136,7 +136,7 @@ class SiteSettingsFormJetpackMonitor extends Component {
 				<QueryJetpackModules siteId={ siteId } />
 				<QuerySiteMonitorSettings siteId={ siteId } />
 
-				<SectionHeader label={ translate( 'Jetpack Monitor' ) } />
+				<SectionHeader label={ translate( 'Downtime Monitoring' ) } />
 
 				<Card className="jetpack-monitor-settings">
 					<div className="site-settings__info-link-container">
@@ -150,7 +150,7 @@ class SiteSettingsFormJetpackMonitor extends Component {
 					<JetpackModuleToggle
 						siteId={ siteId }
 						moduleSlug="monitor"
-						label={ translate( "Monitor your site's uptime" ) }
+						label={ translate( "Monitor your site's downtime" ) }
 						disabled={ this.disableForm() }
 					/>
 


### PR DESCRIPTION
Resolves partly https://github.com/Automattic/jetpack/issues/9086

We've been using these terms all over the place:
- Jetpack Monitor
- Uptime Monitor
- Downtime Monitor

This change will unify language to use "Downtime Monitor".

Similar change in Jetpack: https://github.com/Automattic/jetpack/pull/9084

"Downtime Monitor" term is already used all over [Jetpack plans page](https://jetpack.com/pricing/) and [feature intro page](https://jetpack.com/features/security/downtime-monitoring/).

"Read more" link in Calypso settings brings users to [Monitor's support page](https://jetpack.com/support/monitor/) which still needs updating. 

## Before
![image](https://user-images.githubusercontent.com/87168/38031803-c935f1c6-32a4-11e8-9bf5-e88be256537d.png)

## After
![image](https://user-images.githubusercontent.com/87168/38045162-8c3651d8-32c4-11e8-9cd8-5e20726b9e00.png)

(Extra toggle is visible only via localhost)

## Testing

- With Jetpack connected site, open `https://wordpress.com/settings/security/YOURSITE`
- I'm not sure how to test the change in plans copy, ideas?