### PR TITLE
Update/gmb urls

### DIFF
--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -90,7 +90,7 @@ class GoogleMyBusinessStatsNudge extends Component {
 
 						<div className="google-my-business-stats-nudge__button-row">
 							<Button
-								href={ `/google-my-business/${ this.props.siteSlug }` }
+								href={ `/google-my-business/${ this.props.siteSlug }/select-business-type` }
 								primary
 								onClick={ this.onStartNowClick }
 							>

--- a/client/my-sites/google-my-business/index.js
+++ b/client/my-sites/google-my-business/index.js
@@ -15,7 +15,7 @@ import { makeLayout, render as clientRender } from 'controller';
 export default function() {
 	page( '/google-my-business', siteSelection, sites, makeLayout, clientRender );
 	page(
-		'/google-my-business/:site_id/',
+		'/google-my-business/:site_id/select-business-type',
 		siteSelection,
 		navigation,
 		selectBusinessType,

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -18,6 +18,7 @@ import ActionCard from 'components/action-card';
 import Main from 'components/main';
 import { recordTracksEvent } from 'state/analytics/actions';
 import ExternalLink from 'components/external-link';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 class SelectBusinessType extends Component {
 	static propTypes = {
@@ -53,6 +54,10 @@ class SelectBusinessType extends Component {
 
 		return (
 			<Main className="select-business-type">
+				<PageViewTracker
+					path={ '/google-my-business/:site_id/select-business-type' }
+					title="Google My Business > Select Business Type"
+				/>
 				<HeaderCake isCompact={ false } alwaysShowActionText={ false } onClick={ this.goBack }>
 					{ translate( 'Google My Business' ) }
 				</HeaderCake>

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -55,7 +55,7 @@ class SelectBusinessType extends Component {
 		return (
 			<Main className="select-business-type">
 				<PageViewTracker
-					path={ '/google-my-business/:site_id/select-business-type' }
+					path="/google-my-business/:site/select-business-type"
 					title="Google My Business > Select Business Type"
 				/>
 				<HeaderCake isCompact={ false } alwaysShowActionText={ false } onClick={ this.goBack }>


### PR DESCRIPTION
This PR changes the URL for Select Business Type page for Google My Business
  
#### Testing instructions
0. Turn on tracks debugging, execute on console: `localStorage.setItem( 'debug', 'calypso:analytics:tracks' );` 
1. Run `git checkout update/gmb-urls` and start your server, or open a [live branch](https://calypso.live/?branch=update/gmb-urls)
2. Open the [`State` page](http://calypso.localhost:3000/stats/day/sitepromotegoal.wordpress.com) for a site that eligible for GMB ( older than a week, business plan )
3. Click on GMB nudge's button
![screen shot 2018-03-29 at 9 53 10](https://user-images.githubusercontent.com/326402/38074337-1d4829c2-3337-11e8-97f7-6156ce0ff05a.png)
4. Assert you're taken to the Select Business Type page
5. Assert the URL is `http://calypso.localhost:3000/google-my-business/sitepromotegoal.wordpress.com/select-business-type`
6. Assert that page view event `calypso_page_view` is fired for the page view.
![screen shot 2018-03-29 at 9 56 58](https://user-images.githubusercontent.com/326402/38074492-90041fd4-3337-11e8-8c4c-c72a463c43b3.png)

#### Reviews
  
- [x] Code
- [x] Product
