### PR TITLE
New Kraken domain suggestion test V3.1.3

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -70,7 +70,7 @@ class DomainSearchResults extends React.Component {
 		const { MAPPABLE, MAPPED, TLD_NOT_SUPPORTED, TRANSFERRABLE, UNKNOWN } = domainAvailability;
 
 		const domain = get( availableDomain, 'domain_name', lastDomainSearched );
-		const testGroup = abtest( 'domainSuggestionTestV6' );
+		const testGroup = abtest( 'domainSuggestionKrakenV313' );
 		const showExactMatch = 'group_0' === testGroup;
 
 		let availabilityElement, domainSuggestionElement, offer;

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -668,8 +668,8 @@ class RegisterDomainStep extends React.Component {
 		} );
 
 		const timestamp = Date.now();
-		const testGroup = abtest( 'domainSuggestionTestV6' );
-		if ( includes( [ 'group_1', 'group_2', 'group_3', 'group_4' ], testGroup ) ) {
+		const testGroup = abtest( 'domainSuggestionKrakenV313' );
+		if ( includes( [ 'group_1', 'group_2', 'group_3', 'group_4', 'group_5' ], testGroup ) ) {
 			searchVendor = testGroup;
 		}
 
@@ -768,8 +768,11 @@ class RegisterDomainStep extends React.Component {
 		const onAddMapping = domain => this.props.onAddMapping( domain, this.state );
 
 		const searchResults = this.state.searchResults || [];
-		const testGroup = abtest( 'domainSuggestionTestV6' );
-		let suggestions = includes( [ 'group_1', 'group_2', 'group_3', 'group_4' ], testGroup )
+		const testGroup = abtest( 'domainSuggestionKrakenV313' );
+		let suggestions = includes(
+			[ 'group_1', 'group_2', 'group_3', 'group_4', 'group_5' ],
+			testGroup
+		)
 			? [ ...searchResults ]
 			: reject( searchResults, matchesSearchedDomain );
 

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -64,18 +64,6 @@ export default {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
-	domainSuggestionTestV6: {
-		datestamp: '20180315',
-		variations: {
-			group_0: 1, // Default group
-			group_1: 1000,
-			group_2: 1000,
-			group_3: 1000,
-			group_4: 1000,
-		},
-		defaultVariation: 'group_0',
-		allowExistingUsers: true,
-	},
 	upgradePricingDisplayV2: {
 		datestamp: '20180305',
 		variations: {
@@ -126,6 +114,19 @@ export default {
 			mobile: 50,
 		},
 		defaultVariation: 'original',
+		allowExistingUsers: true,
+	},
+	domainSuggestionKrakenV313: {
+		datestamp: '20180329',
+		variations: {
+			group_0: 1, // Default group
+			group_1: 1000,
+			group_2: 1000,
+			group_3: 1000,
+			group_4: 1000,
+			group_5: 1000,
+		},
+		defaultVariation: 'group_0',
 		allowExistingUsers: true,
 	},
 };


### PR DESCRIPTION
We need to start the next domain suggestion test that will basically test SLD exact matches using the different domain suggestion engines we use. We also introduce a new domain suggestion engine variation called group_5. I've renamed the test name to match the iteration version - V3.1.3.

Depends on code-D11294 and code-D11293

To test change the start date of the test to todays date (it's starting from tomorrow) and check if you're assigned a random group_ for `domainSuggestionKrakenV313`.