### PR TITLE
DevDocs: Add a formatted card

### DIFF
--- a/client/components/card/README.md
+++ b/client/components/card/README.md
@@ -10,7 +10,6 @@ The `CompactCard` component slightly modifies the `Card` component.
 
 ```jsx
 import Card from 'components/card';
-import CompactCard from 'components/card/compact';
 
 render: function() {
   return (
@@ -19,9 +18,13 @@ render: function() {
         <span>Your stuff in a Card</span>
       </Card>
 
-      <CompactCard>
-        <span>Your stuff in a CompactCard</span>
-      </CompactCard>
+      <Card compact>
+        <span>Your stuff in a compact Card</span>
+      </Card>
+
+      <Card formatted>
+        <h1>Your stuff in a formatted Card</h1>
+      </Card>
     </div>
   );
 }
@@ -34,4 +37,5 @@ render: function() {
 * `tagName` (Optional): Allows you to control the tag name of the card wrapper (only if `href` is not specified).
 * `target` (Optional): If set and used with `href` then this controls where the link opens. It also changes the Gridicon to "external"
 * `compact` (Optional): Whether the card should be rendered as compact
+* `formatted` (Optional): Whether the card should modify child heading elements
 * `highlight` (Optional): The specific highlight of this card. Can be one of the following: `false` (no highlight, default), `info`, `success`, `error` or `warning`.

--- a/client/components/card/compact.jsx
+++ b/client/components/card/compact.jsx
@@ -3,8 +3,6 @@
  * External dependencies
  */
 import React from 'react';
-import classnames from 'classnames';
-
 /**
  * Internal dependencies
  */
@@ -12,7 +10,7 @@ import Card from 'components/card';
 
 export default function CompactCard( props ) {
 	return (
-		<Card { ...props } className={ classnames( props.className, 'is-compact' ) }>
+		<Card { ...props } className={ props.className }>
 			{ props.children }
 		</Card>
 	);

--- a/client/components/card/docs/example.jsx
+++ b/client/components/card/docs/example.jsx
@@ -47,6 +47,16 @@ class Cards extends React.Component {
 					<Card highlight="success">I am a Card, highlighted as success</Card>
 					<Card highlight="error">I am a Card, highlighted as error</Card>
 					<Card highlight="warning">I am a Card, highlighted as warning</Card>
+
+					<Card formatted>
+						<h1>I am a Heading 1 in a FormattedCard</h1>
+						<h2>I am a Heading 2 in a FormattedCard</h2>
+						<h3>I am a Heading 3 in a FormattedCard</h3>
+						<h4>I am a Heading 4 in a FormattedCard</h4>
+						<h5>I am a Heading 5 in a FormattedCard</h5>
+						<h6>I am a Heading 6 in a FormattedCard</h6>
+						<p>I am a paragraph in a FormattedCard</p>
+					</Card>
 				</div>
 			);
 		} else {
@@ -65,6 +75,16 @@ class Cards extends React.Component {
 					<CompactCard highlight="success">I am a CompactCard, highlighted as success</CompactCard>
 					<CompactCard highlight="error">I am a CompactCard, highlighted as error</CompactCard>
 					<CompactCard highlight="warning">I am a CompactCard, highlighted as warning</CompactCard>
+
+					<Card compact formatted>
+						<h1>I am a Heading 1 in a FormattedCard</h1>
+						<h2>I am a Heading 2 in a FormattedCard</h2>
+						<h3>I am a Heading 3 in a FormattedCard</h3>
+						<h4>I am a Heading 4 in a FormattedCard</h4>
+						<h5>I am a Heading 5 in a FormattedCard</h5>
+						<h6>I am a Heading 6 in a FormattedCard</h6>
+						<p>I am a paragraph in a FormattedCard</p>
+					</Card>
 				</div>
 			);
 		}

--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -16,6 +16,7 @@ class Card extends Component {
 		tagName: PropTypes.string,
 		target: PropTypes.string,
 		compact: PropTypes.bool,
+		formatted: PropTypes.bool,
 		highlight: PropTypes.oneOf( [ false, 'error', 'info', 'success', 'warning' ] ),
 	};
 
@@ -25,7 +26,7 @@ class Card extends Component {
 	};
 
 	render() {
-		const { children, compact, highlight, href, onClick, tagName, target } = this.props;
+		const { children, compact, formatted, highlight, href, onClick, tagName, target } = this.props;
 
 		const highlightClass = highlight ? 'is-' + highlight : false;
 
@@ -37,11 +38,12 @@ class Card extends Component {
 				'is-clickable': !! onClick,
 				'is-compact': compact,
 				'is-highlight': highlightClass,
+				'is-formatted': formatted,
 			},
 			highlightClass
 		);
 
-		const omitProps = [ 'compact', 'highlight', 'tagName' ];
+		const omitProps = [ 'compact', 'formatted', 'highlight', 'tagName' ];
 
 		let linkIndicator;
 		if ( href ) {

--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -85,3 +85,17 @@ a.card:focus {
 		color: $link-highlight;
 	}
 }
+
+.card.is-formatted {
+	h1, h2, h3, h4, h5, h6 {
+		font-size: 21px;
+		font-weight: 400;
+		margin-bottom: 5px;
+		margin-top: 5px;
+
+		@include breakpoint( '>960px' ) {
+			margin-bottom: 10px;
+			margin-top: 10px;
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a new prop to `<Card>` which takes care of formatting for child heading elements. This is added as a prop rather than as the default behavior, so as to avoid breaking the existing uses of `<Card>`.

It looks like this;
<img width="1110" alt="screen shot 2018-03-28 at 15 12 41" src="https://user-images.githubusercontent.com/275961/38034706-c3c46114-329a-11e8-83b3-08e081cb77ca.png">

I decided to use the same style for headers of all sizes since the choice of which header to use should be a semantic one, not a stylistic one. I am open to thoughts about this.