### PR TITLE
SiteAddressChanger: Add support link to notice copy

### DIFF
--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -150,15 +150,16 @@ export class SimpleSiteRenameForm extends Component {
 								<Gridicon icon="info-outline" size={ 18 } />
 								<p>
 									{ translate(
-										'Once you change your site address, %(currentDomainName)s will no longer be available. ' +
-											'{{link}}Before you confirm the change, please read this important information.{{/link}}',
+										'Once you change your site address, %(currentDomainName)s will no longer be available.',
 										{
 											args: { currentDomainName },
-											components: {
-												link: <a href={ ADDRESS_CHANGE_SUPPORT_URL } />,
-											},
 										}
-									) }
+									) }{' '}
+									<a href={ ADDRESS_CHANGE_SUPPORT_URL }>
+										{ translate(
+											'Before you confirm the change, please read this important information.'
+										) }
+									</a>
 								</p>
 							</div>
 							<FormButton disabled={ isDisabled } busy={ isSiteRenameRequesting } type="submit">

--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -25,6 +25,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 
 const SUBDOMAIN_LENGTH_MINIMUM = 4;
 const SUBDOMAIN_LENGTH_MAXIMUM = 50;
+const ADDRESS_CHANGE_SUPPORT_URL = 'https://support.wordpress.com/changing-blog-address/';
 
 export class SimpleSiteRenameForm extends Component {
 	static propTypes = {
@@ -149,9 +150,13 @@ export class SimpleSiteRenameForm extends Component {
 								<Gridicon icon="info-outline" size={ 18 } />
 								<p>
 									{ translate(
-										'Once changed, the current site address %(currentDomainName)s will no longer be available.',
+										'Once changed, the current site address %(currentDomainName)s will no longer be available. ' +
+											'{{link}}Be sure to read our support page before making the change.{{/link}}',
 										{
 											args: { currentDomainName },
+											components: {
+												link: <a href={ ADDRESS_CHANGE_SUPPORT_URL } />,
+											},
 										}
 									) }
 								</p>

--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -150,8 +150,8 @@ export class SimpleSiteRenameForm extends Component {
 								<Gridicon icon="info-outline" size={ 18 } />
 								<p>
 									{ translate(
-										'Once changed, the current site address %(currentDomainName)s will no longer be available. ' +
-											'{{link}}Be sure to read our support page before making the change.{{/link}}',
+										'Once you change your site address, %(currentDomainName)s will no longer be available. ' +
+											'{{link}}Before you confirm the change, please read this important information.{{/link}}',
 										{
 											args: { currentDomainName },
 											components: {


### PR DESCRIPTION
### Summary

In an attempt to better inform folks who are looking to change their site address this PR adds some extra wording and a link that should draw attention to the support documentation we have around this feature/flow.
This should hopefully help avoid accidents in the process and save people from losing their site addresses.

### Testing
There's no real functional change here, so all that needs to be tested is that the link works as expected and directs to the most suitable location within our support docs.
To do so, go to: http://calypso.localhost:3000/domains/manage , choose a site, and then look for the link in the bottom left of the site address changer component, click it and take note of where you land.

Relates to: #22906, cc: @benhuberman