### PR TITLE
Analytics: Add last resort in PageViewTracker to figure out if the selected site has loaded

### DIFF
--- a/client/lib/analytics/page-view-tracker/index.jsx
+++ b/client/lib/analytics/page-view-tracker/index.jsx
@@ -17,6 +17,7 @@ import { getSiteFragment } from 'lib/route';
 import { recordPageView } from 'state/analytics/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
+import { hasInitializedSites } from 'state/selectors';
 
 /**
  * Module variables
@@ -90,7 +91,8 @@ const mapStateToProps = state => {
 	const hasSelectedSiteLoaded =
 		! currentSlug ||
 		( isNumber( currentSlug ) && currentSlug === selectedSiteId ) ||
-		currentSlug === selectedSiteSlug;
+		currentSlug === selectedSiteSlug ||
+		hasInitializedSites( state );
 
 	return {
 		hasSelectedSiteLoaded,


### PR DESCRIPTION
Issue reported in https://github.com/Automattic/wp-calypso/pull/23647#issuecomment-376703612

In order to report an accurate `blog_id` value, when the path contains a site fragment, `PageViewTracker` defers the page view recording until the selected site has been initialized and matches the fragment.

This works for most cases, but fails when the site fragment is not in its canonical position.
`getSiteFragment` only recognizes it as last or second-to-last in a path, and for cases such as:
```
/me/purchases/:site/:purchaseId/cancel-privacy-protection
```
the site fragment is not in a canonical position, and `getSiteFragment` incorrectly returns the `purchaseId` instead.