### PR TITLE
JP Onboarding: Rename actions and data layer stuff to drop `Onboarding` from name

### DIFF
--- a/client/components/data/query-jetpack-onboarding-settings/index.jsx
+++ b/client/components/data/query-jetpack-onboarding-settings/index.jsx
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { isRequestingJetpackOnboardingSettings } from 'state/selectors';
-import { requestJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
+import { requestJetpackSettings } from 'state/jetpack-onboarding/actions';
 
 class QueryJetpackOnboardingSettings extends Component {
 	static propTypes = {
@@ -19,7 +19,7 @@ class QueryJetpackOnboardingSettings extends Component {
 		siteId: PropTypes.number,
 		// Connected props
 		requestingSettings: PropTypes.bool,
-		requestJetpackOnboardingSettings: PropTypes.func,
+		requestJetpackSettings: PropTypes.func,
 	};
 
 	componentWillMount() {
@@ -37,7 +37,7 @@ class QueryJetpackOnboardingSettings extends Component {
 			return;
 		}
 
-		props.requestJetpackOnboardingSettings( props.siteId, props.query );
+		props.requestJetpackSettings( props.siteId, props.query );
 	}
 
 	render() {
@@ -49,5 +49,5 @@ export default connect(
 	( state, { query, siteId } ) => ( {
 		requestingSettings: isRequestingJetpackOnboardingSettings( state, siteId, query ),
 	} ),
-	{ requestJetpackOnboardingSettings }
+	{ requestJetpackSettings }
 )( QueryJetpackOnboardingSettings );

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -36,7 +36,7 @@ import {
 } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, isRequestingSite, isRequestingSites } from 'state/sites/selectors';
-import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
+import { saveJetpackSettings } from 'state/jetpack-onboarding/actions';
 import { setSelectedSiteId } from 'state/ui/actions';
 
 class JetpackOnboardingMain extends React.PureComponent {
@@ -249,12 +249,12 @@ export default connect(
 			userIdHashed,
 		};
 	},
-	{ recordTracksEvent, saveJetpackOnboardingSettings, setSelectedSiteId },
+	{ recordTracksEvent, saveJetpackSettings, setSelectedSiteId },
 	(
 		{ siteId, jpoAuth, userIdHashed, ...stateProps },
 		{
 			recordTracksEvent: recordTracksEventAction,
-			saveJetpackOnboardingSettings: saveJetpackOnboardingSettingsAction,
+			saveJetpackSettings: saveJetpackSettingsAction,
 			...dispatchProps
 		},
 		ownProps
@@ -271,7 +271,7 @@ export default connect(
 				...additionalProperties,
 			} ),
 		saveJpoSettings: ( s, settings ) =>
-			saveJetpackOnboardingSettingsAction( s, {
+			saveJetpackSettingsAction( s, {
 				onboarding: { ...settings, ...get( jpoAuth, 'onboarding' ) },
 			} ),
 		...dispatchProps,

--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -45,7 +45,7 @@ const receiveJetpackOnboardingSettings = ( { dispatch }, { siteId }, settings ) 
  * @param   {Object}   action         Redux action
  * @returns {Object}   Dispatched http action
  */
-export const requestJetpackOnboardingSettings = ( { dispatch }, action ) => {
+export const requestJetpackSettings = ( { dispatch }, action ) => {
 	const { siteId, query } = action;
 
 	return dispatch(
@@ -159,7 +159,7 @@ export const retryOrAnnounceSaveFailure = ( { dispatch }, action, { message: err
 export default {
 	[ JETPACK_ONBOARDING_SETTINGS_REQUEST ]: [
 		dispatchRequest(
-			requestJetpackOnboardingSettings,
+			requestJetpackSettings,
 			receiveJetpackOnboardingSettings,
 			announceRequestFailure,
 			{

--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -18,7 +18,7 @@ import {
 } from 'state/action-types';
 import { getSiteUrl, getUnconnectedSiteUrl } from 'state/selectors';
 import {
-	saveJetpackOnboardingSettingsSuccess,
+	saveJetpackSettingsSuccess,
 	updateJetpackOnboardingSettings,
 } from 'state/jetpack-onboarding/actions';
 import { trailingslashit } from 'lib/route';
@@ -86,7 +86,7 @@ export const announceRequestFailure = ( { dispatch, getState }, { siteId } ) => 
  * @param   {Object} action Redux action
  * @returns {Object} Dispatched http action
  */
-export const saveJetpackOnboardingSettings = ( { dispatch }, action ) => {
+export const saveJetpackSettings = ( { dispatch }, action ) => {
 	const { settings, siteId } = action;
 
 	// We don't want Jetpack Onboarding credentials in our Jetpack Settings Redux state.
@@ -115,7 +115,7 @@ export const saveJetpackOnboardingSettings = ( { dispatch }, action ) => {
 // the save request has finished. Tracking those requests is necessary for
 // displaying an up to date progress indicator for some steps.
 export const handleSaveSuccess = ( { dispatch }, { siteId, settings } ) =>
-	dispatch( saveJetpackOnboardingSettingsSuccess( siteId, settings ) );
+	dispatch( saveJetpackSettingsSuccess( siteId, settings ) );
 
 export const announceSaveFailure = ( { dispatch }, { siteId } ) =>
 	dispatch(
@@ -168,6 +168,6 @@ export default {
 		),
 	],
 	[ JETPACK_ONBOARDING_SETTINGS_SAVE ]: [
-		dispatchRequest( saveJetpackOnboardingSettings, handleSaveSuccess, retryOrAnnounceSaveFailure ),
+		dispatchRequest( saveJetpackSettings, handleSaveSuccess, retryOrAnnounceSaveFailure ),
 	],
 };

--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -19,7 +19,7 @@ import {
 import { getSiteUrl, getUnconnectedSiteUrl } from 'state/selectors';
 import {
 	saveJetpackSettingsSuccess,
-	updateJetpackOnboardingSettings,
+	updateJetpackSettings,
 } from 'state/jetpack-onboarding/actions';
 import { trailingslashit } from 'lib/route';
 
@@ -34,7 +34,7 @@ export const fromApi = response => {
 };
 
 const receiveJetpackOnboardingSettings = ( { dispatch }, { siteId }, settings ) => {
-	dispatch( updateJetpackOnboardingSettings( siteId, settings ) );
+	dispatch( updateJetpackSettings( siteId, settings ) );
 };
 
 /**
@@ -91,7 +91,7 @@ export const saveJetpackSettings = ( { dispatch }, action ) => {
 
 	// We don't want Jetpack Onboarding credentials in our Jetpack Settings Redux state.
 	const settingsWithoutCredentials = omit( settings, [ 'onboarding.jpUser', 'onboarding.token' ] );
-	dispatch( updateJetpackOnboardingSettings( siteId, settingsWithoutCredentials ) );
+	dispatch( updateJetpackSettings( siteId, settingsWithoutCredentials ) );
 
 	return dispatch(
 		http(

--- a/client/state/data-layer/wpcom/jetpack/settings/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/test/index.js
@@ -6,7 +6,7 @@
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
 	MAX_WOOCOMMERCE_INSTALL_RETRIES,
-	requestJetpackOnboardingSettings,
+	requestJetpackSettings,
 	saveJetpackOnboardingSettings,
 	handleSaveSuccess,
 	announceRequestFailure,
@@ -23,7 +23,7 @@ import {
 	updateJetpackOnboardingSettings,
 } from 'state/jetpack-onboarding/actions';
 
-describe( 'requestJetpackOnboardingSettings()', () => {
+describe( 'requestJetpackSettings()', () => {
 	const dispatch = jest.fn();
 	const token = 'abcd1234';
 	const userEmail = 'example@yourgroovydomain.com';
@@ -35,7 +35,7 @@ describe( 'requestJetpackOnboardingSettings()', () => {
 	};
 
 	test( 'should dispatch an action for a GET HTTP request to fetch Jetpack settings', () => {
-		requestJetpackOnboardingSettings( { dispatch }, action );
+		requestJetpackSettings( { dispatch }, action );
 
 		expect( dispatch ).toHaveBeenCalledWith(
 			http(
@@ -63,7 +63,7 @@ describe( 'requestJetpackOnboardingSettings()', () => {
 		};
 		const actionWithAuth = { ...action, query };
 
-		requestJetpackOnboardingSettings( { dispatch }, actionWithAuth );
+		requestJetpackSettings( { dispatch }, actionWithAuth );
 
 		expect( dispatch ).toHaveBeenCalledWith(
 			http(

--- a/client/state/data-layer/wpcom/jetpack/settings/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/test/index.js
@@ -7,7 +7,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import {
 	MAX_WOOCOMMERCE_INSTALL_RETRIES,
 	requestJetpackSettings,
-	saveJetpackOnboardingSettings,
+	saveJetpackSettings,
 	handleSaveSuccess,
 	announceRequestFailure,
 	announceSaveFailure,
@@ -19,7 +19,7 @@ import {
 	JETPACK_ONBOARDING_SETTINGS_UPDATE,
 } from 'state/action-types';
 import {
-	saveJetpackOnboardingSettingsSuccess,
+	saveJetpackSettingsSuccess,
 	updateJetpackOnboardingSettings,
 } from 'state/jetpack-onboarding/actions';
 
@@ -178,7 +178,7 @@ describe( 'announceRequestFailure()', () => {
 	} );
 } );
 
-describe( 'saveJetpackOnboardingSettings()', () => {
+describe( 'saveJetpackSettings()', () => {
 	const dispatch = jest.fn();
 	const token = 'abcd1234';
 	const userEmail = 'example@yourgroovydomain.com';
@@ -202,7 +202,7 @@ describe( 'saveJetpackOnboardingSettings()', () => {
 	};
 
 	test( 'should dispatch an action for POST HTTP request to save Jetpack settings, omitting JPO credentials', () => {
-		saveJetpackOnboardingSettings( { dispatch }, action );
+		saveJetpackSettings( { dispatch }, action );
 
 		expect( dispatch ).toHaveBeenCalledWith(
 			http(
@@ -237,7 +237,7 @@ describe( 'handleSaveSuccess()', () => {
 		handleSaveSuccess( { dispatch }, { siteId, settings } );
 
 		expect( dispatch ).toHaveBeenCalledWith(
-			expect.objectContaining( saveJetpackOnboardingSettingsSuccess( siteId, settings ) )
+			expect.objectContaining( saveJetpackSettingsSuccess( siteId, settings ) )
 		);
 	} );
 } );
@@ -285,7 +285,7 @@ describe( 'retryOrAnnounceSaveFailure()', () => {
 		message: 'cURL error 28: Operation timed out after 5001 milliseconds with 0 bytes received',
 	};
 
-	test( 'should trigger saveJetpackOnboardingSettings upon first WooCommerce install timeout', () => {
+	test( 'should trigger saveJetpackSettings upon first WooCommerce install timeout', () => {
 		retryOrAnnounceSaveFailure( { dispatch }, action, error );
 
 		expect( dispatch ).toHaveBeenCalledWith(

--- a/client/state/data-layer/wpcom/jetpack/settings/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/test/index.js
@@ -20,7 +20,7 @@ import {
 } from 'state/action-types';
 import {
 	saveJetpackSettingsSuccess,
-	updateJetpackOnboardingSettings,
+	updateJetpackSettings,
 } from 'state/jetpack-onboarding/actions';
 
 describe( 'requestJetpackSettings()', () => {
@@ -220,7 +220,7 @@ describe( 'saveJetpackSettings()', () => {
 			)
 		);
 		expect( dispatch ).toHaveBeenCalledWith(
-			updateJetpackOnboardingSettings( siteId, { onboarding: onboardingSettings } )
+			updateJetpackSettings( siteId, { onboarding: onboardingSettings } )
 		);
 	} );
 } );

--- a/client/state/jetpack-onboarding/actions.js
+++ b/client/state/jetpack-onboarding/actions.js
@@ -17,7 +17,7 @@ export const receiveJetpackOnboardingCredentials = ( siteId, credentials ) => ( 
 	credentials,
 } );
 
-export const requestJetpackOnboardingSettings = ( siteId, query ) => ( {
+export const requestJetpackSettings = ( siteId, query ) => ( {
 	type: JETPACK_ONBOARDING_SETTINGS_REQUEST,
 	siteId,
 	query,

--- a/client/state/jetpack-onboarding/actions.js
+++ b/client/state/jetpack-onboarding/actions.js
@@ -28,7 +28,7 @@ export const requestJetpackSettings = ( siteId, query ) => ( {
 	},
 } );
 
-export const saveJetpackOnboardingSettings = ( siteId, settings ) => ( {
+export const saveJetpackSettings = ( siteId, settings ) => ( {
 	type: JETPACK_ONBOARDING_SETTINGS_SAVE,
 	siteId,
 	settings,
@@ -39,7 +39,7 @@ export const saveJetpackOnboardingSettings = ( siteId, settings ) => ( {
 	},
 } );
 
-export const saveJetpackOnboardingSettingsSuccess = ( siteId, settings ) => ( {
+export const saveJetpackSettingsSuccess = ( siteId, settings ) => ( {
 	type: JETPACK_ONBOARDING_SETTINGS_SAVE_SUCCESS,
 	siteId,
 	settings,

--- a/client/state/jetpack-onboarding/actions.js
+++ b/client/state/jetpack-onboarding/actions.js
@@ -45,7 +45,7 @@ export const saveJetpackSettingsSuccess = ( siteId, settings ) => ( {
 	settings,
 } );
 
-export const updateJetpackOnboardingSettings = ( siteId, settings ) => ( {
+export const updateJetpackSettings = ( siteId, settings ) => ( {
 	type: JETPACK_ONBOARDING_SETTINGS_UPDATE,
 	siteId,
 	settings,

--- a/client/state/jetpack-onboarding/test/actions.js
+++ b/client/state/jetpack-onboarding/test/actions.js
@@ -5,7 +5,7 @@
  */
 import {
 	receiveJetpackOnboardingCredentials,
-	requestJetpackOnboardingSettings,
+	requestJetpackSettings,
 	saveJetpackOnboardingSettings,
 	saveJetpackOnboardingSettingsSuccess,
 	updateJetpackOnboardingSettings,
@@ -37,10 +37,10 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( 'requestJetpackOnboardingSettings()', () => {
+	describe( 'requestJetpackSettings()', () => {
 		test( 'should return a jetpack settings request action object', () => {
 			const siteId = 12345678;
-			const action = requestJetpackOnboardingSettings( siteId );
+			const action = requestJetpackSettings( siteId );
 
 			expect( action ).toEqual( {
 				type: JETPACK_ONBOARDING_SETTINGS_REQUEST,

--- a/client/state/jetpack-onboarding/test/actions.js
+++ b/client/state/jetpack-onboarding/test/actions.js
@@ -6,8 +6,8 @@
 import {
 	receiveJetpackOnboardingCredentials,
 	requestJetpackSettings,
-	saveJetpackOnboardingSettings,
-	saveJetpackOnboardingSettingsSuccess,
+	saveJetpackSettings,
+	saveJetpackSettingsSuccess,
 	updateJetpackOnboardingSettings,
 } from '../actions';
 import {
@@ -54,14 +54,14 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( 'saveJetpackOnboardingSettings()', () => {
+	describe( 'saveJetpackSettings()', () => {
 		test( 'should return a jetpack settings save action object', () => {
 			const settings = {
 				siteTitle: 'My awesome site title',
 				siteDescription: 'Not just another WordPress site',
 			};
 			const siteId = 12345678;
-			const action = saveJetpackOnboardingSettings( siteId, settings );
+			const action = saveJetpackSettings( siteId, settings );
 
 			expect( action ).toEqual( {
 				type: JETPACK_ONBOARDING_SETTINGS_SAVE,
@@ -76,14 +76,14 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( 'saveJetpackOnboardingSettingsSuccess()', () => {
+	describe( 'saveJetpackSettingsSuccess()', () => {
 		test( 'should return a jetpack onboarding settings save action success object', () => {
 			const settings = {
 				siteTitle: 'My awesome site title',
 				siteDescription: 'Not just another WordPress site',
 			};
 			const siteId = 12345678;
-			const action = saveJetpackOnboardingSettingsSuccess( siteId, settings );
+			const action = saveJetpackSettingsSuccess( siteId, settings );
 
 			expect( action ).toEqual( {
 				type: JETPACK_ONBOARDING_SETTINGS_SAVE_SUCCESS,

--- a/client/state/jetpack-onboarding/test/actions.js
+++ b/client/state/jetpack-onboarding/test/actions.js
@@ -8,7 +8,7 @@ import {
 	requestJetpackSettings,
 	saveJetpackSettings,
 	saveJetpackSettingsSuccess,
-	updateJetpackOnboardingSettings,
+	updateJetpackSettings,
 } from '../actions';
 import {
 	JETPACK_ONBOARDING_CREDENTIALS_RECEIVE,
@@ -93,14 +93,14 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( 'updateJetpackOnboardingSettings()', () => {
+	describe( 'updateJetpackSettings()', () => {
 		test( 'should return a jetpack settings update action object', () => {
 			const settings = {
 				siteTitle: 'My awesome site title',
 				siteDescription: 'Not just another WordPress site',
 			};
 			const siteId = 12345678;
-			const action = updateJetpackOnboardingSettings( siteId, settings );
+			const action = updateJetpackSettings( siteId, settings );
 
 			expect( action ).toEqual( {
 				type: JETPACK_ONBOARDING_SETTINGS_UPDATE,

--- a/client/state/selectors/get-jetpack-onboarding-pending-steps.js
+++ b/client/state/selectors/get-jetpack-onboarding-pending-steps.js
@@ -9,7 +9,7 @@ import { reduce } from 'lodash';
  * Internal dependencies
  */
 import { JETPACK_ONBOARDING_STEPS as STEPS } from 'jetpack-onboarding/constants';
-import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
+import { saveJetpackSettings } from 'state/jetpack-onboarding/actions';
 import { getRequest } from 'state/selectors';
 
 export default function getJetpackOnboardingPendingSteps( state, siteId, steps ) {
@@ -30,7 +30,7 @@ export default function getJetpackOnboardingPendingSteps( state, siteId, steps )
 		( result, stepName ) => {
 			result[ stepName ] = getRequest(
 				state,
-				saveJetpackOnboardingSettings( siteId, { onboarding: stepActionsMap[ stepName ] } )
+				saveJetpackSettings( siteId, { onboarding: stepActionsMap[ stepName ] } )
 			).isLoading;
 			return result;
 		},

--- a/client/state/selectors/is-requesting-jetpack-onboarding-settings.js
+++ b/client/state/selectors/is-requesting-jetpack-onboarding-settings.js
@@ -9,7 +9,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import { getRequest } from 'state/selectors';
-import { requestJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
+import { requestJetpackSettings } from 'state/jetpack-onboarding/actions';
 
 /**
  * Returns true if we are currently making a request to fetch the Jetpack settings. False otherwise
@@ -20,9 +20,5 @@ import { requestJetpackOnboardingSettings } from 'state/jetpack-onboarding/actio
  * @return {Boolean}             Whether Jetpack settings are currently being requested
  */
 export default function isRequestingJetpackOnboardingSettings( state, siteId, query ) {
-	return get(
-		getRequest( state, requestJetpackOnboardingSettings( siteId, query ) ),
-		'isLoading',
-		false
-	);
+	return get( getRequest( state, requestJetpackSettings( siteId, query ) ), 'isLoading', false );
 }

--- a/client/state/selectors/test/get-jetpack-onboarding-pending-steps.js
+++ b/client/state/selectors/test/get-jetpack-onboarding-pending-steps.js
@@ -6,12 +6,12 @@
 import { JETPACK_ONBOARDING_STEPS as STEPS } from 'jetpack-onboarding/constants';
 import { getJetpackOnboardingPendingSteps } from 'state/selectors';
 import { getRequestKey } from 'state/data-layer/wpcom-http/utils';
-import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
+import { saveJetpackSettings } from 'state/jetpack-onboarding/actions';
 
 describe( 'getJetpackOnboardingPendingSteps()', () => {
 	test( 'should return pending status for the contact form step', () => {
 		const siteId = 2916284;
-		const action = saveJetpackOnboardingSettings( siteId, {
+		const action = saveJetpackSettings( siteId, {
 			onboarding: {
 				addContactForm: true,
 			},
@@ -44,7 +44,7 @@ describe( 'getJetpackOnboardingPendingSteps()', () => {
 
 	test( 'should return pending status for the woocommerce step', () => {
 		const siteId = 2916284;
-		const action = saveJetpackOnboardingSettings( siteId, {
+		const action = saveJetpackSettings( siteId, {
 			onboarding: {
 				installWooCommerce: true,
 			},
@@ -77,7 +77,7 @@ describe( 'getJetpackOnboardingPendingSteps()', () => {
 
 	test( 'should return pending status for the stats step', () => {
 		const siteId = 2916284;
-		const action = saveJetpackOnboardingSettings( siteId, {
+		const action = saveJetpackSettings( siteId, {
 			onboarding: {
 				stats: true,
 			},

--- a/client/state/selectors/test/is-requesting-jetpack-onboarding-settings.js
+++ b/client/state/selectors/test/is-requesting-jetpack-onboarding-settings.js
@@ -5,12 +5,12 @@
  */
 import { getRequestKey } from 'state/data-layer/wpcom-http/utils';
 import { isRequestingJetpackOnboardingSettings } from 'state/selectors';
-import { requestJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
+import { requestJetpackSettings } from 'state/jetpack-onboarding/actions';
 
 describe( 'isRequestingJetpackOnboardingSettings()', () => {
 	test( 'should return true if settings are currently being requested', () => {
 		const siteId = 87654321;
-		const action = requestJetpackOnboardingSettings( siteId );
+		const action = requestJetpackSettings( siteId );
 		const state = {
 			dataRequests: {
 				[ getRequestKey( action ) ]: {
@@ -25,7 +25,7 @@ describe( 'isRequestingJetpackOnboardingSettings()', () => {
 
 	test( 'should return false if settings are currently not being requested', () => {
 		const siteId = 87654321;
-		const action = requestJetpackOnboardingSettings( siteId );
+		const action = requestJetpackSettings( siteId );
 		const state = {
 			dataRequests: {
 				[ getRequestKey( action ) ]: {
@@ -40,7 +40,7 @@ describe( 'isRequestingJetpackOnboardingSettings()', () => {
 
 	test( 'should return false if that site is not known', () => {
 		const siteId = 87654321;
-		const action = requestJetpackOnboardingSettings( 12345678 );
+		const action = requestJetpackSettings( 12345678 );
 		const state = {
 			dataRequests: {
 				[ getRequestKey( action ) ]: {
@@ -56,7 +56,7 @@ describe( 'isRequestingJetpackOnboardingSettings()', () => {
 	test( 'should return true if settings are currently being requested for a matching site ID and query', () => {
 		const siteId = 87654321;
 		const query = { foo: 'bar' };
-		const action = requestJetpackOnboardingSettings( siteId, query );
+		const action = requestJetpackSettings( siteId, query );
 		const state = {
 			dataRequests: {
 				[ getRequestKey( action ) ]: {
@@ -72,7 +72,7 @@ describe( 'isRequestingJetpackOnboardingSettings()', () => {
 	test( 'should return false if settings are currently being requested for matching site ID and non-matching query', () => {
 		const siteId = 87654321;
 		const query = { foo: 'bar' };
-		const action = requestJetpackOnboardingSettings( siteId, { foo: 'baz' } );
+		const action = requestJetpackSettings( siteId, { foo: 'baz' } );
 		const state = {
 			dataRequests: {
 				[ getRequestKey( action ) ]: {


### PR DESCRIPTION
More prep for #23393 -- that PR would grow beyond bounds otherwise.

Rename:
* `requestJetpackOnboardingSettings` to `requestJetpackSettings`
* `saveJetpackOnboardingSettings` to `saveJetpackSettings`
* `updateJetpackOnboardingSettings` to `updateJetpackSettings`

which is adequate, since they're all not JPO specific, but work generically with JP settings.

### Testing and Reviewing Instructions
* I'd recommend reviewing each commit separately.
* Verify that there are no naming collisions:
  * On `master`, verify by grepping that neither the `requestJetpackSettings` nor `saveJetpackSettings` strings anywhere in the source.
  * `updateJetpackSettings` _is_ present on `master`, but it's a wpcom lib object property (used twice in `jetpack/settings/actions`, so the free-standing function won't collide with it
* Verify that JPO still works, and that JP Settings also still work (some smoke testing around changing some settings should be enough for the latter).

### Notes
* This PR is not yet renaming action type name constants, since unfortunately, that _would_ lead to naming collisions -- some of these are defined for what's currently in `state/jetpack/settings`. Maybe we'll append `_LEGACY` to them to be able to split up #23393 further, but that's for another PR. Same goes for selectors.
* Replacing `saveJetpackOnboardingSettings` with `saveJetpackSettings` also changes a few strings that include that as a substring, such as `...Action`, `...Success`. All of these changes are desired.