### PR TITLE
Remove direct usage of plan constants from plugin-meta

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -36,7 +36,8 @@ import PluginAutomatedTransfer from 'my-sites/plugins/plugin-automated-transfer'
 import { getExtensionSettingsPath } from 'my-sites/plugins/utils';
 import { userCan } from 'lib/site/utils';
 import Banner from 'components/banner';
-import { PLAN_BUSINESS, FEATURE_UPLOAD_PLUGINS } from 'lib/plans/constants';
+import { TYPE_BUSINESS, FEATURE_UPLOAD_PLUGINS } from 'lib/plans/constants';
+import { findFirstSimilarPlanKey } from 'lib/plans';
 import { isBusiness, isEnterprise } from 'lib/products-values';
 import { addSiteFragment } from 'lib/route';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
@@ -45,7 +46,7 @@ import { isAutomatedTransferActive, isSiteAutomatedTransfer } from 'state/select
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import { isATEnabled } from 'lib/automated-transfer';
 
-class PluginMeta extends Component {
+export class PluginMeta extends Component {
 	static OUT_OF_DATE_YEARS = 2;
 
 	static propTypes = {
@@ -95,6 +96,13 @@ class PluginMeta extends Component {
 		return (
 			isBusiness( this.props.selectedSite.plan ) || isEnterprise( this.props.selectedSite.plan )
 		);
+	}
+
+	getPlan() {
+		if ( ! this.props.selectedSite ) {
+			return false;
+		}
+		return this.props.selectedSite.plan();
 	}
 
 	isWpcomPreinstalled = () => {
@@ -593,6 +601,7 @@ class PluginMeta extends Component {
 					this.isWpcomPreinstalled() ) && <div style={ { marginBottom: 16 } } /> }
 
 				{ this.props.selectedSite &&
+					this.props.selectedSite.plan &&
 					! get( this.props.selectedSite, 'jetpack' ) &&
 					! this.hasBusinessPlan() &&
 					! this.isWpcomPreinstalled() && (
@@ -600,7 +609,9 @@ class PluginMeta extends Component {
 							<Banner
 								feature={ FEATURE_UPLOAD_PLUGINS }
 								event={ 'calypso_plugin_detail_page_upgrade_nudge' }
-								plan={ PLAN_BUSINESS }
+								plan={ findFirstSimilarPlanKey( this.props.selectedSite.plan.product_slug, {
+									type: TYPE_BUSINESS,
+								} ) }
 								title={ this.props.translate( 'Upgrade to the Business plan to install plugins.' ) }
 							/>
 						</div>

--- a/client/my-sites/plugins/plugin-meta/test/index.js
+++ b/client/my-sites/plugins/plugin-meta/test/index.js
@@ -1,0 +1,174 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.mock( 'lib/analytics/index', () => ( {} ) );
+jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'lib/user', () => ( {} ) );
+jest.mock( 'lib/translator-jumpstart', () => ( {} ) );
+jest.mock( 'lib/plugins/wporg-data/actions', () => ( {} ) );
+jest.mock( 'lib/plugins/wporg-data/list-store', () => ( {
+	getShortList: () => {},
+	getFullList: () => {},
+	getSearchList: () => {},
+	on: () => {},
+} ) );
+jest.mock( 'state/ui/guided-tours/selectors', () => ( {} ) );
+jest.mock( 'my-sites/plugins/utils', () => ( {
+	getExtensionSettingsPath: () => '',
+} ) );
+jest.mock( 'components/main', () => 'MainComponent' );
+jest.mock( 'components/popover', () => 'Popover' );
+jest.mock( 'layout/guided-tours/positioning', () => 'Positioning' );
+jest.mock( 'layout/guided-tours/tours/main-tour', () => 'MainTour' );
+jest.mock( 'layout/guided-tours/tours/jetpack-basic-tour', () => 'JetpackBasicTour' );
+jest.mock( 'layout/masterbar/logged-in', () => 'LoggedIn' );
+jest.mock( 'layout/community-translator/launcher', () => 'Launcher' );
+jest.mock( 'components/banner', () => 'Banner' );
+jest.mock( 'components/notice', () => 'Notice' );
+jest.mock( 'components/notice/notice-action', () => 'NoticeAction' );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Comp => props => (
+		<Comp
+			{ ...props }
+			translate={ function( x ) {
+				return x;
+			} }
+		/>
+	),
+	numberFormat: x => x,
+} ) );
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import {
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { PluginMeta } from '../';
+
+const selectedSite = {
+	plan: {
+		product_slug: PLAN_FREE,
+	},
+	options: {
+		software_version: 2,
+	},
+};
+
+const props = {
+	selectedSite,
+	sites: [ [ {} ] ],
+	plugin: { active: false },
+	selectedSiteId: 123,
+	translate: x => x,
+};
+
+describe( 'PluginMeta basic tests', () => {
+	test( 'should not blow up and have proper CSS class', () => {
+		const comp = shallow( <PluginMeta { ...props } /> );
+		expect( comp.find( '.plugin-meta' ).length ).toBe( 1 );
+	} );
+	test( 'should show upgrade nudge when appropriate', () => {
+		const comp = shallow( <PluginMeta { ...props } selectedSiteId={ 12 } /> );
+		expect( comp.find( 'Banner[event="calypso_plugin_detail_page_upgrade_nudge"]' ).length ).toBe(
+			1
+		);
+	} );
+	test( 'should not show upgrade nudge if no site is selected', () => {
+		const comp = shallow(
+			<PluginMeta
+				{ ...props }
+				selectedSite={ null }
+				isJetpackSite={ false }
+				hasBusinessPlan={ false }
+			/>
+		);
+		expect( comp.find( 'Banner[event="calypso_plugin_detail_page_upgrade_nudge"]' ).length ).toBe(
+			0
+		);
+	} );
+	test( 'should not show upgrade nudge if jetpack site', () => {
+		const comp = shallow(
+			<PluginMeta { ...props } selectedSite={ { ...selectedSite, jetpack: true } } />
+		);
+		expect( comp.find( 'Banner[event="calypso_plugin_detail_page_upgrade_nudge"]' ).length ).toBe(
+			0
+		);
+	} );
+	test( 'should not show upgrade nudge has business plan', () => {
+		const comp = shallow(
+			<PluginMeta
+				{ ...props }
+				selectedSite={ { ...selectedSite, plan: { product_slug: PLAN_BUSINESS } } }
+			/>
+		);
+		expect( comp.find( 'Banner[event="calypso_plugin_detail_page_upgrade_nudge"]' ).length ).toBe(
+			0
+		);
+	} );
+} );
+
+describe( 'Upsell Banner should get appropriate plan constant', () => {
+	const myProps = {
+		...props,
+		showUpgradeNudge: true,
+		isJetpackSite: false,
+		hasBusinessPlan: false,
+	};
+
+	[ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM ].forEach( product_slug => {
+		test( `Business 1 year for (${ product_slug })`, () => {
+			const comp = shallow(
+				<PluginMeta
+					{ ...myProps }
+					selectedSite={ {
+						...selectedSite,
+						plan: { product_slug },
+					} }
+				/>
+			);
+			expect( comp.find( 'Banner[event="calypso_plugin_detail_page_upgrade_nudge"]' ).length ).toBe(
+				1
+			);
+			expect(
+				comp.find( 'Banner[event="calypso_plugin_detail_page_upgrade_nudge"]' ).props().plan
+			).toBe( PLAN_BUSINESS );
+		} );
+	} );
+
+	[ PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS ].forEach( product_slug => {
+		test( `Business 2 year for (${ product_slug })`, () => {
+			const comp = shallow(
+				<PluginMeta
+					{ ...myProps }
+					selectedSite={ {
+						...selectedSite,
+						plan: { product_slug },
+					} }
+				/>
+			);
+			expect( comp.find( 'Banner[event="calypso_plugin_detail_page_upgrade_nudge"]' ).length ).toBe(
+				1
+			);
+			expect(
+				comp.find( 'Banner[event="calypso_plugin_detail_page_upgrade_nudge"]' ).props().plan
+			).toBe( PLAN_BUSINESS_2_YEARS );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `plugin-meta`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* Go to /plugins/wordpress-seo and confirm that non-business users can see a banner that looks like this:

<img width="742" alt="zrzut ekranu 2018-03-28 o 15 32 03" src="https://user-images.githubusercontent.com/205419/38032242-6bcc9938-329d-11e8-8336-ca894d2af9a2.png">
