### PR TITLE
Update/remove hardcoded constants from current plan

### DIFF
--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -38,7 +38,7 @@ export class CurrentPlanHeader extends Component {
 	};
 
 	renderPurchaseInfo() {
-		const { currentPlan, currentPlanSlug, selectedSite, isExpiring, translate } = this.props;
+		const { currentPlan, selectedSite, isExpiring, translate } = this.props;
 
 		if ( ! currentPlan || this.isJetpackFreePlan() ) {
 			return null;

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -15,38 +15,17 @@ import Button from 'components/button';
 import Card from 'components/card';
 import HappinessSupport from 'components/happiness-support';
 import PlanIcon from 'components/plans/plan-icon';
-import {
-	PLAN_PREMIUM,
-	PLAN_BUSINESS,
-	PLAN_JETPACK_FREE,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PERSONAL_MONTHLY,
-	PLAN_PERSONAL,
-} from 'lib/plans/constants';
+import { PLANS_LIST, TYPE_FREE, TYPE_BUSINESS, GROUP_JETPACK } from 'lib/plans/constants';
+import { planMatches } from 'lib/plans';
 import { managePurchase } from 'me/purchases/paths';
 
-class CurrentPlanHeader extends Component {
+export class CurrentPlanHeader extends Component {
 	static propTypes = {
 		selectedSite: PropTypes.object,
 		title: PropTypes.string,
 		tagLine: PropTypes.string,
 		isPlaceholder: PropTypes.bool,
-		currentPlanSlug: PropTypes.oneOf( [
-			PLAN_PREMIUM,
-			PLAN_BUSINESS,
-			PLAN_JETPACK_FREE,
-			PLAN_JETPACK_BUSINESS,
-			PLAN_JETPACK_BUSINESS_MONTHLY,
-			PLAN_JETPACK_PREMIUM,
-			PLAN_JETPACK_PREMIUM_MONTHLY,
-			PLAN_JETPACK_PERSONAL,
-			PLAN_JETPACK_PERSONAL_MONTHLY,
-			PLAN_PERSONAL,
-		] ).isRequired,
+		currentPlanSlug: PropTypes.oneOf( Object.keys( PLANS_LIST ) ).isRequired,
 		currentPlan: PropTypes.object,
 		isExpiring: PropTypes.bool,
 		translate: PropTypes.func,
@@ -55,13 +34,13 @@ class CurrentPlanHeader extends Component {
 
 	isEligibleForLiveChat = () => {
 		const { currentPlanSlug: planSlug } = this.props;
-		return planSlug === PLAN_JETPACK_BUSINESS || planSlug === PLAN_JETPACK_BUSINESS_MONTHLY;
+		return planMatches( planSlug, { type: TYPE_BUSINESS, group: GROUP_JETPACK } );
 	};
 
 	renderPurchaseInfo() {
 		const { currentPlan, currentPlanSlug, selectedSite, isExpiring, translate } = this.props;
 
-		if ( ! currentPlan || currentPlanSlug === PLAN_JETPACK_FREE ) {
+		if ( ! currentPlan || this.isJetpackFreePlan() ) {
 			return null;
 		}
 
@@ -144,7 +123,7 @@ class CurrentPlanHeader extends Component {
 					<div className="current-plan__header-item-content">
 						<HappinessSupport
 							isJetpack={ !! selectedSite.jetpack && ! isAutomatedTransfer }
-							isJetpackFreePlan={ currentPlanSlug === PLAN_JETPACK_FREE }
+							isJetpackFreePlan={ this.isJetpackFreePlan() }
 							isPlaceholder={ isPlaceholder }
 							showLiveChatButton={ this.isEligibleForLiveChat() }
 							liveChatButtonEventName="calypso_plans_current_plan_chat_initiated"
@@ -153,6 +132,10 @@ class CurrentPlanHeader extends Component {
 				</div>
 			</div>
 		);
+	}
+
+	isJetpackFreePlan() {
+		return planMatches( this.props.currentPlanSlug, { type: TYPE_FREE, group: GROUP_JETPACK } );
 	}
 }
 

--- a/client/my-sites/plans/current-plan/test/header.jsx
+++ b/client/my-sites/plans/current-plan/test/header.jsx
@@ -1,0 +1,182 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.mock( 'blocks/dismissible-card', () => {} );
+jest.mock( 'components/search', () => 'Search' );
+jest.mock( 'components/popover', () => 'Popover' );
+jest.mock( 'my-sites/checkout/cart/cart-item', () => 'CartItem' );
+jest.mock( 'my-sites/checkout/cart/cart-coupon', () => 'CartCoupon' );
+jest.mock( 'my-sites/checkout/cart/cart-plan-ad', () => 'CartPlanAd' );
+jest.mock( 'my-sites/checkout/checkout-thank-you/google-voucher', () => 'GoogleVoucher' );
+jest.mock( 'components/happiness-support', () => 'HappinessSupport' );
+jest.mock( 'lib/user', () => ( {} ) );
+jest.mock( 'lib/cart/store/cart-analytics', () => ( {} ) );
+jest.mock( 'lib/mixins/analytics', () => () => {} );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Comp => props => (
+		<Comp
+			{ ...props }
+			translate={ function( x ) {
+				return x;
+			} }
+		/>
+	),
+	numberFormat: x => x,
+} ) );
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import {
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { CurrentPlanHeader } from '../header';
+
+describe( 'CurrentPlanHeader basic tests', () => {
+	test( 'should not blow up and have proper CSS class', () => {
+		expect( true ).toBe( true );
+	} );
+} );
+
+const props = {
+	selectedSite: {
+		jetpack: false,
+	},
+	translate: () => {},
+};
+
+describe( 'CurrentPlanHeader basic tests', () => {
+	test( 'should not blow up and have proper CSS class', () => {
+		const comp = shallow( <CurrentPlanHeader { ...props } /> );
+		expect( comp.find( '.current-plan__header' ).length ).toBe( 1 );
+	} );
+} );
+
+describe( 'isEligibleForLiveChat', () => {
+	[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY ].forEach( currentPlanSlug => {
+		test( 'Should return true if Jetpack business plan', () => {
+			const comp = new CurrentPlanHeader( { ...props, currentPlanSlug } );
+			expect( comp.isEligibleForLiveChat() ).toBe( true );
+		} );
+	} );
+
+	[
+		PLAN_FREE,
+		PLAN_JETPACK_FREE,
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_PERSONAL_MONTHLY,
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PREMIUM_MONTHLY,
+		PLAN_BUSINESS,
+		PLAN_BUSINESS_2_YEARS,
+	].forEach( currentPlanSlug => {
+		test( 'Should return false if not Jetpack business plan', () => {
+			const comp = new CurrentPlanHeader( { ...props, currentPlanSlug } );
+			expect( comp.isEligibleForLiveChat() ).toBe( false );
+		} );
+	} );
+} );
+
+describe( '<HappinessSupport isJetpackFreePlan', () => {
+	[ PLAN_JETPACK_FREE ].forEach( currentPlanSlug => {
+		test( 'Should be true if Jetpack free plan', () => {
+			const comp = shallow(
+				<CurrentPlanHeader { ...props } currentPlanSlug={ currentPlanSlug } />
+			);
+			expect( comp.find( 'HappinessSupport' ).props().isJetpackFreePlan ).toBe( true );
+		} );
+	} );
+
+	[
+		PLAN_FREE,
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_PERSONAL_MONTHLY,
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PREMIUM_MONTHLY,
+		PLAN_BUSINESS,
+		PLAN_BUSINESS_2_YEARS,
+		PLAN_JETPACK_BUSINESS,
+		PLAN_JETPACK_BUSINESS_MONTHLY,
+	].forEach( currentPlanSlug => {
+		test( 'Should be false otherwise', () => {
+			const comp = shallow(
+				<CurrentPlanHeader { ...props } currentPlanSlug={ currentPlanSlug } />
+			);
+			expect( comp.find( 'HappinessSupport' ).props().isJetpackFreePlan ).toBe( false );
+		} );
+	} );
+} );
+
+describe( '<HappinessSupport renderPurchaseInfo', () => {
+	test( 'Should not be displayed for Jetpack free plan', () => {
+		const comp = shallow(
+			<CurrentPlanHeader { ...props } currentPlan={ {} } currentPlanSlug={ PLAN_JETPACK_FREE } />
+		);
+		expect( comp.find( '.current-plan__header-purchase-info-wrapper' ).length ).toBe( 0 );
+	} );
+
+	test( 'Should not be displayed for empty plan', () => {
+		const comp = shallow(
+			<CurrentPlanHeader
+				{ ...props }
+				currentPlan={ null }
+				currentPlanSlug={ PLAN_JETPACK_BUSINESS }
+			/>
+		);
+		expect( comp.find( '.current-plan__header-purchase-info-wrapper' ).length ).toBe( 0 );
+	} );
+
+	[
+		PLAN_FREE,
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_PERSONAL_MONTHLY,
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PREMIUM_MONTHLY,
+		PLAN_BUSINESS,
+		PLAN_BUSINESS_2_YEARS,
+		PLAN_JETPACK_BUSINESS,
+		PLAN_JETPACK_BUSINESS_MONTHLY,
+	].forEach( currentPlanSlug => {
+		test( `Should be displayed for plan ${ currentPlanSlug }`, () => {
+			const comp = shallow(
+				<CurrentPlanHeader { ...props } currentPlan={ {} } currentPlanSlug={ currentPlanSlug } />
+			);
+			expect( comp.find( '.current-plan__header-purchase-info-wrapper' ).length ).toBe( 1 );
+		} );
+	} );
+} );

--- a/client/my-sites/plans/current-plan/test/header.jsx
+++ b/client/my-sites/plans/current-plan/test/header.jsx
@@ -55,12 +55,6 @@ import {
  */
 import { CurrentPlanHeader } from '../header';
 
-describe( 'CurrentPlanHeader basic tests', () => {
-	test( 'should not blow up and have proper CSS class', () => {
-		expect( true ).toBe( true );
-	} );
-} );
-
 const props = {
 	selectedSite: {
 		jetpack: false,


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `current-plan/header.jsx`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* Go to `/plans/my-plan/` and confirm in React devtools that `isJetpackFreePlan` property here reflects how it really is:

<img width="1699" alt="zrzut ekranu 2018-03-28 o 16 49 08" src="https://user-images.githubusercontent.com/205419/38037065-61ca9088-32a8-11e8-99b0-e5ff275a4058.png">

* Go to `/plans/my-plan/` and confirm that jetpack free users can't see plan expiration date while all other users (premium, business etc) can see the expiration date:

<img width="1098" alt="zrzut ekranu 2018-03-28 o 16 49 40" src="https://user-images.githubusercontent.com/205419/38037066-61ea400e-32a8-11e8-8d79-0eb478d13725.png">
