### PR TITLE
SiteAddressChanger: Fix focus state styling on form field

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -144,6 +144,7 @@ $z-layers: (
 		'.detail-page__backdrop': 190,
 		'.layout__loader': 200,
 		'.offline-status': 200,
+		'.simple-site-rename-form__address-field': 200,
 		'.environment-badge': 999,
 		'.customizer-loading-panel__placeholder-change-theme': 999,
 		'.module-overlay': 1000,

--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -142,6 +142,7 @@ export class SimpleSiteRenameForm extends Component {
 							onChange={ this.onFieldChange }
 							placeholder={ currentDomainPrefix }
 							isError={ !! domainFieldError }
+							className="simple-site-rename-form__address-field"
 						/>
 						{ domainFieldError && <FormInputValidation isError text={ domainFieldError } /> }
 						<div className="simple-site-rename-form__footer">

--- a/client/blocks/simple-site-rename-form/style.scss
+++ b/client/blocks/simple-site-rename-form/style.scss
@@ -85,6 +85,10 @@
 	}
 }
 
+.simple-site-rename-form__address-field {
+	z-index: z-index('root', '.simple-site-rename-form__address-field');
+}
+
 .simple-site-rename-form__confirmation-detail {
 	.gridicon {
 		float: left;


### PR DESCRIPTION
### Summary 

This PR adds a `z-index` value to the form field found in the SiteAddressChanger component so that a solid, unbroken border appears when the field is focused on.

<img width="73" alt="screen shot 2018-03-28 at 15 38 49" src="https://user-images.githubusercontent.com/4335450/38040059-356a3ea8-329e-11e8-8fd3-f597e0b7d6a1.png">  **>**  <img width="68" alt="screen shot 2018-03-28 at 15 36 50" src="https://user-images.githubusercontent.com/4335450/38039917-de446b76-329d-11e8-82ef-410f179d8aca.png">

This fix does do the trick, but I wonder if it could be better addressed at the component level - that does seems logical. The reason I didn't do that is that I worry that setting a `z-index` value in a  sweeping fix might cause visual regressions in other areas. Happy to investigate if it makes sense to do so.

### Testing

A nice & easy one to test - just select the field @ http://calypso.localhost:3000/domains/manage/your-site.wordpress.com/edit/your-site.wordpress.com