### PR TITLE
Store: Fix activity log icon display

### DIFF
--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -7,6 +7,10 @@
 		box-sizing: border-box;
 	}
 
+	.order-activity-log__note-meta .gridicon {
+		box-sizing: unset;
+	}
+
 	@include breakpoint( '>960px' ) {
 		display: flex;
 		flex-wrap: wrap;


### PR DESCRIPTION
Fixes #22915.

This very tiny PR adjusts the display of the activity log icons on any order page. They are appearing very tiny at the moment. 

Before:

<img width="758" alt="screen shot 2018-03-28 at 10 33 08 am" src="https://user-images.githubusercontent.com/689165/38046357-5bd1b9d8-3274-11e8-9589-0d79799d7ecf.png">

After:

<img width="757" alt="screen shot 2018-03-28 at 10 37 24 am" src="https://user-images.githubusercontent.com/689165/38046365-5f99c5e2-3274-11e8-986d-f73c284247e8.png">

To Test:

* Load up an order page and verify the icons are visible per the after image above.