### PR TITLE
Async Removal: register-domain-step

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -6,7 +6,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import async from 'async';
 import {
 	compact,
 	find,
@@ -422,59 +421,61 @@ class RegisterDomainStep extends React.Component {
 		return designType && designType === 'blog' ? 'design_type_blog' : null;
 	}
 
-	checkDomainAvailability = ( domain, timestamp ) => callback => {
+	checkDomainAvailability = ( domain, timestamp ) => {
 		if (
 			! domain.match(
 				/^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)*[a-z0-9]([a-z0-9-]*[a-z0-9])?\.[a-z]{2,63}$/i
 			)
 		) {
 			this.setState( { lastDomainStatus: null, lastDomainIsTransferrable: false } );
-			return callback();
+			return;
 		}
 		if ( this.props.isSignupStep && domain.match( /\.wordpress\.com$/ ) ) {
-			return callback();
+			return;
 		}
 
-		checkDomainAvailability(
-			{ domainName: domain, blogId: get( this.props, 'selectedSite.ID', null ) },
-			( error, result ) => {
-				const timeDiff = Date.now() - timestamp;
-				const status = get( result, 'status', error );
-				const domainChecked = get( result, 'domain_name', domain );
+		return new Promise( resolve => {
+			checkDomainAvailability(
+				{ domainName: domain, blogId: get( this.props, 'selectedSite.ID', null ) },
+				( error, result ) => {
+					const timeDiff = Date.now() - timestamp;
+					const status = get( result, 'status', error );
+					const domainChecked = get( result, 'domain_name', domain );
 
-				const { AVAILABLE, TRANSFERRABLE, UNKNOWN } = domainAvailability;
-				const isDomainAvailable = includes( [ AVAILABLE, UNKNOWN ], status );
-				const isDomainTransferrable = TRANSFERRABLE === status;
+					const { AVAILABLE, TRANSFERRABLE, UNKNOWN } = domainAvailability;
+					const isDomainAvailable = includes( [ AVAILABLE, UNKNOWN ], status );
+					const isDomainTransferrable = TRANSFERRABLE === status;
 
-				this.setState( {
-					exactMatchDomain: domainChecked,
-					lastDomainStatus: status,
-					lastDomainIsTransferrable: isDomainTransferrable,
-				} );
-				if ( isDomainAvailable ) {
-					this.setState( { notice: null } );
-				} else {
-					this.showValidationErrorMessage(
+					this.setState( {
+						exactMatchDomain: domainChecked,
+						lastDomainStatus: status,
+						lastDomainIsTransferrable: isDomainTransferrable,
+					} );
+					if ( isDomainAvailable ) {
+						this.setState( { notice: null } );
+					} else {
+						this.showValidationErrorMessage(
+							domain,
+							status,
+							get( result, 'other_site_domain', null )
+						);
+					}
+
+					this.props.recordDomainAvailabilityReceive(
 						domain,
 						status,
-						get( result, 'other_site_domain', null )
+						timeDiff,
+						this.props.analyticsSection
 					);
+
+					this.props.onDomainsAvailabilityChange( true );
+					resolve( isDomainAvailable ? result : null );
 				}
-
-				this.props.recordDomainAvailabilityReceive(
-					domain,
-					status,
-					timeDiff,
-					this.props.analyticsSection
-				);
-
-				this.props.onDomainsAvailabilityChange( true );
-				callback( null, isDomainAvailable ? result : null );
-			}
-		);
+			);
+		} );
 	};
 
-	getDomainsSuggestions = ( domain, timestamp ) => callback => {
+	getDomainsSuggestions = ( domain, timestamp ) => {
 		const suggestionQuantity =
 			this.props.includeWordPressDotCom || this.props.includeDotBlogSubdomain
 				? SUGGESTION_QUANTITY - 1
@@ -491,7 +492,7 @@ class RegisterDomainStep extends React.Component {
 			...this.getSetFiltersForAPI(),
 		};
 
-		domains
+		return domains
 			.suggestions( query )
 			.then( domainSuggestions => {
 				this.props.onDomainsAvailabilityChange( true );
@@ -506,7 +507,7 @@ class RegisterDomainStep extends React.Component {
 					this.props.analyticsSection
 				);
 
-				callback( null, domainSuggestions );
+				return domainSuggestions;
 			} )
 			.catch( error => {
 				const timeDiff = Date.now() - timestamp;
@@ -527,11 +528,11 @@ class RegisterDomainStep extends React.Component {
 					-1,
 					this.props.analyticsSection
 				);
-				callback( error, null );
+				throw error;
 			} );
 	};
 
-	handleDomainSuggestions = domain => ( error, result ) => {
+	handleDomainSuggestions = domain => result => {
 		if (
 			! this.state.loadingResults ||
 			domain !== this.state.lastDomainSearched ||
@@ -673,13 +674,13 @@ class RegisterDomainStep extends React.Component {
 			searchVendor = testGroup;
 		}
 
-		async.parallel(
-			[
-				this.checkDomainAvailability( domain, timestamp ),
-				this.getDomainsSuggestions( domain, timestamp ),
-			],
-			this.handleDomainSuggestions( domain )
-		);
+		const domainSuggestions = Promise.all( [
+			this.checkDomainAvailability( domain, timestamp ),
+			this.getDomainsSuggestions( domain, timestamp ),
+		] );
+		domainSuggestions.then( this.handleDomainSuggestions( domain ) );
+		// errors are handled by pretending that the list of suggestions is empty
+		domainSuggestions.catch( () => this.handleDomainSuggestions( domain )( [] ) );
 
 		if ( this.props.includeWordPressDotCom || this.props.includeDotBlogSubdomain ) {
 			this.getSubdomainSuggestions( domain, timestamp );

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -428,10 +428,10 @@ class RegisterDomainStep extends React.Component {
 			)
 		) {
 			this.setState( { lastDomainStatus: null, lastDomainIsTransferrable: false } );
-			return;
+			return Promise.resolve();
 		}
 		if ( this.props.isSignupStep && domain.match( /\.wordpress\.com$/ ) ) {
-			return;
+			return Promise.resolve();
 		}
 
 		return new Promise( resolve => {


### PR DESCRIPTION
Split off from: https://github.com/Automattic/wp-calypso/pull/23578.

This PR removes the reliance upon [async](https://github.com/caolan/async) for the register domain step. Instead it converts some callbacks into promises and then uses `Promise.all` instead of `async.parallel`.

Note: this code is pretty confusing in that there are many side-effects and setState's happening in the middle of network requests.  I'm not radically improving the component here, just trying to mimic current implementation while removing async.

**to test**
test the purchase a new domain flow.  Specifically you should check that you still see suggestions properly. That when a domain is already taken it will mark it properly. Also that if you try to buy a domain like `example.com` while you are offline that Calypso will have graceful error handling similar to what is currently in prod.