### PR TITLE
Store: Fix store-woo signup flow

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -233,7 +233,14 @@ class Dashboard extends Component {
 	};
 
 	render() {
-		const { className, isSetupComplete, loading, selectedSite, siteId } = this.props;
+		const {
+			className,
+			isSetupComplete,
+			loading,
+			selectedSite,
+			siteId,
+			finishedInstallOfRequiredPlugins,
+		} = this.props;
 
 		return (
 			<Main className={ classNames( 'dashboard', className ) } wideLayout>
@@ -242,7 +249,7 @@ class Dashboard extends Component {
 					isLoading={ loading || ! selectedSite }
 				/>
 				{ isSetupComplete ? this.renderDashboardContent() : this.renderDashboardSetupContent() }
-				<QuerySettingsGeneral siteId={ siteId } />
+				{ finishedInstallOfRequiredPlugins && <QuerySettingsGeneral siteId={ siteId } /> }
 			</Main>
 		);
 	}

--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -107,7 +107,12 @@ class Dashboard extends Component {
 	}
 
 	fetchStoreData = () => {
-		const { siteId, productsLoaded } = this.props;
+		const { siteId, productsLoaded, finishedInstallOfRequiredPlugins } = this.props;
+
+		if ( ! finishedInstallOfRequiredPlugins ) {
+			return;
+		}
+
 		this.props.fetchOrders( siteId );
 
 		if ( ! productsLoaded ) {

--- a/client/extensions/woocommerce/app/dashboard/setup/tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup/tasks.js
@@ -40,25 +40,25 @@ class SetupTasks extends Component {
 	};
 
 	componentDidMount = () => {
-		const { site } = this.props;
+		const { site, productsLoaded } = this.props;
 
 		if ( site && site.ID ) {
 			this.props.fetchPaymentMethods( site.ID );
 
-			if ( ! areProductsLoaded ) {
+			if ( ! productsLoaded ) {
 				this.props.fetchProducts( site.ID, { page: 1 } );
 			}
 		}
 	};
 
 	componentWillReceiveProps = newProps => {
-		const { site } = this.props;
+		const { site, productsLoaded } = this.props;
 
 		const newSiteId = ( newProps.site && newProps.site.ID ) || null;
 		const oldSiteId = ( site && site.ID ) || null;
 
 		if ( newSiteId && oldSiteId !== newSiteId ) {
-			if ( ! areProductsLoaded ) {
+			if ( ! productsLoaded ) {
 				this.props.fetchProducts( newSiteId, { page: 1 } );
 			}
 		}

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -27,7 +27,10 @@ import { fetchReviews } from 'woocommerce/state/sites/reviews/actions';
 import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
 import { getNewOrdersWithoutPayPalPending } from 'woocommerce/state/sites/orders/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
-import { getSetStoreAddressDuringInitialSetup } from 'woocommerce/state/sites/setup-choices/selectors';
+import {
+	getSetStoreAddressDuringInitialSetup,
+	getFinishedInstallOfRequiredPlugins,
+} from 'woocommerce/state/sites/setup-choices/selectors';
 import { getTotalProducts, areProductsLoaded } from 'woocommerce/state/sites/products/selectors';
 import { getTotalReviews } from 'woocommerce/state/sites/reviews/selectors';
 import { isStoreManagementSupportedInCalypsoForCountry } from 'woocommerce/lib/countries';
@@ -233,6 +236,7 @@ class StoreSidebar extends Component {
 	render = () => {
 		const {
 			finishedAddressSetup,
+			finishedInstallOfRequiredPlugins,
 			hasProducts,
 			path,
 			settingsGeneralLoaded,
@@ -270,7 +274,7 @@ class StoreSidebar extends Component {
 						{ showAllSidebarItems && this.settings() }
 					</ul>
 				</SidebarMenu>
-				<QuerySettingsGeneral siteId={ siteId } />
+				{ finishedInstallOfRequiredPlugins && <QuerySettingsGeneral siteId={ siteId } /> }
 			</Sidebar>
 		);
 	};
@@ -278,6 +282,7 @@ class StoreSidebar extends Component {
 
 function mapStateToProps( state ) {
 	const finishedAddressSetup = getSetStoreAddressDuringInitialSetup( state );
+	const finishedInstallOfRequiredPlugins = getFinishedInstallOfRequiredPlugins( state );
 	const hasProducts = getTotalProducts( state ) > 0;
 	const orders = getNewOrdersWithoutPayPalPending( state );
 	const productsLoaded = areProductsLoaded( state );
@@ -289,6 +294,7 @@ function mapStateToProps( state ) {
 
 	return {
 		finishedAddressSetup,
+		finishedInstallOfRequiredPlugins,
 		hasProducts,
 		orders,
 		totalPendingReviews,

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -67,8 +67,13 @@ class StoreSidebar extends Component {
 		}
 	};
 
-	fetchData = ( { siteId, productsLoaded } ) => {
+	fetchData = ( { siteId, productsLoaded, finishedInstallOfRequiredPlugins } ) => {
 		this.props.fetchSetupChoices( siteId );
+
+		if ( ! finishedInstallOfRequiredPlugins ) {
+			return;
+		}
+
 		this.props.fetchOrders( siteId );
 
 		this.props.fetchReviews( siteId, { status: 'pending' } );

--- a/client/signup/steps/plans-atomic-store/index.jsx
+++ b/client/signup/steps/plans-atomic-store/index.jsx
@@ -50,7 +50,8 @@ class PlansAtomicStoreStep extends Component {
 				stepName,
 				goToNextStep,
 				translate,
-				signupDependencies: { designType, domainItem },
+				signupDependencies: { domainItem },
+				designType,
 			} = this.props,
 			privacyItem =
 				cartItem && domainItem && cartItems.domainPrivacyProtection( { domain: domainItem.meta } );
@@ -65,7 +66,7 @@ class PlansAtomicStoreStep extends Component {
 			// If we're inside the store signup flow and the cart item is a Business Plan,
 			// set a flag on it. It will trigger Automated Transfer when the product is being
 			// activated at the end of the checkout process.
-			if ( designType === 'store' && cartItem.product_slug === PLAN_BUSINESS ) {
+			if ( designType === DESIGN_TYPE_STORE && cartItem.product_slug === PLAN_BUSINESS ) {
 				cartItem.extra = Object.assign( cartItem.extra || {}, {
 					is_store_signup: true,
 				} );


### PR DESCRIPTION
See p8eNEx-2DG-p2 #comment-2700. 

> I tried the /start/store-woo flow three times today, with the same result; a business plan site that does not have the WooCommerce plugin auto-installed. I tried /start/store-nux just now and the WooCommerce extension was immediately available.

It looks like `/start/store-woo` was not getting the store `designType` passed correctly, which is used to add some meta to the cart item that a site is an AT store. The fix I make below works for both `/start/store-woo` and `/start/store-nux` now.

Once I got to the actual store installer, I was also getting a few "your site settings cannot be queried" messages. This PR addresses those, because these should never show up before the plugins have finished installing.

To Test:
* Give yourself some WP.com credits.
* Test `http://calypso.localhost:3000/start/store-woo` and make sure you can get to the store setup screens after purchasing your business plan and getting passed the Google Apps up-sell.
* Test `http://calypso.localhost:3000/start/store-nux` and make sure you can get to the store setup screens after purchasing your business plan and getting passed the Google Apps up-sell.