### PR TITLE
Reader: set gallery image min width to 300px

### DIFF
--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -46,6 +46,7 @@ export const READER_CONTENT_WIDTH = 800,
 	PHOTO_ONLY_MIN_WIDTH = 440,
 	PHOTO_ONLY_MAX_CHARACTER_COUNT = 85,
 	GALLERY_MIN_IMAGES = 4,
+	GALLERY_MIN_IMAGE_WIDTH = 300,
 	MIN_IMAGE_WIDTH = 144,
 	MIN_IMAGE_HEIGHT = 72;
 
@@ -58,7 +59,7 @@ function getCharacterCount( post ) {
 }
 
 export function imageIsBigEnoughForGallery( image ) {
-	return image.width >= MIN_IMAGE_WIDTH && image.height >= MIN_IMAGE_HEIGHT;
+	return image.width >= GALLERY_MIN_IMAGE_WIDTH;
 }
 
 const hasShortContent = post => getCharacterCount( post ) <= PHOTO_ONLY_MAX_CHARACTER_COUNT;

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -59,7 +59,7 @@ function getCharacterCount( post ) {
 }
 
 export function imageIsBigEnoughForGallery( image ) {
-	return image.width >= GALLERY_MIN_IMAGE_WIDTH;
+	return image.width >= GALLERY_MIN_IMAGE_WIDTH && image.height >= MIN_IMAGE_HEIGHT;
 }
 
 const hasShortContent = post => getCharacterCount( post ) <= PHOTO_ONLY_MAX_CHARACTER_COUNT;


### PR DESCRIPTION
While working with this feed in a recent support issue (p5PDj3-4ta-p2):

https://wordpress.com/read/feeds/52684332

...I noticed that the gallery images weren't of particularly good quality. Admittedly the user could be using webfonts instead of image-based titles and promos, but there was nothing under the 300px wide mark that we'd really want to display.

I notice that back in 2016 we did have an issue about this (https://github.com/Automattic/wp-calypso/issues/9159) and subsequently bumped the min width up to 350px. I'm not sure why it was decreased again, but 300px seems like a reasonable lower threshold for quality images.

### To test

Visit http://calypso.localhost:3000/read/feeds/52684332 and ensure that you see fewer low-quality title images in gallery view vs. https://wordpress.com/read/feeds/52684332.

Before:

<img width="832" alt="screen shot 2018-03-29 at 2 57 47 pm" src="https://user-images.githubusercontent.com/17325/38065800-98a3b698-3361-11e8-994e-bb4d4d92aa85.png">

After:

<img width="835" alt="screen shot 2018-03-29 at 2 57 36 pm" src="https://user-images.githubusercontent.com/17325/38065801-98d148f6-3361-11e8-9f78-79264d31501b.png">
