### PR TITLE
Tracks: Cleanup invalid property names

### DIFF
--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -248,7 +248,7 @@ export class EditGravatar extends Component {
 
 const recordClickButtonEvent = ( { isVerified } ) =>
 	composeAnalytics(
-		recordTracksEvent( 'calypso_edit_gravatar_click', { userVerified: isVerified } ),
+		recordTracksEvent( 'calypso_edit_gravatar_click', { user_verified: isVerified } ),
 		recordGoogleEvent( 'Me', 'Clicked on Edit Gravatar Button in Profile' )
 	);
 

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -117,7 +117,7 @@ const Account = createReactClass( {
 		// TODO: the API should provide a default value, which would make this line obsolete
 		update( this.props.userSettings.settings, colorSchemeKey, value => value || 'default' );
 
-		this.props.recordTracksEvent( 'calypso_color_schemes_select', { colorScheme } );
+		this.props.recordTracksEvent( 'calypso_color_schemes_select', { color_scheme: colorScheme } );
 		this.updateUserSetting( colorSchemeKey, colorScheme );
 	},
 
@@ -266,7 +266,7 @@ const Account = createReactClass( {
 		this.recordClickEvent( 'Save Account Settings Button' );
 		if ( has( unsavedSettings, colorSchemeKey ) ) {
 			this.props.recordTracksEvent( 'calypso_color_schemes_save', {
-				colorScheme: get( unsavedSettings, colorSchemeKey ),
+				color_scheme: get( unsavedSettings, colorSchemeKey ),
 			} );
 		}
 	},

--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -68,7 +68,7 @@ class SuccessBanner extends PureComponent {
 
 	trackDownload = () =>
 		this.props.recordTracksEvent( 'calypso_activitylog_backup_download', {
-			downloadCount: this.props.downloadCount,
+			download_count: this.props.downloadCount,
 		} );
 
 	render() {

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -264,7 +264,7 @@ const mapDispatchToProps = ( dispatch, { activityId, siteId } ) => ( {
 		scrollTo( { x: 0, y: 0, duration: 250 } ),
 		dispatch(
 			withAnalytics(
-				recordTracksEvent( 'calypso_activitylog_backup_confirm', { actionId: rewindId } ),
+				recordTracksEvent( 'calypso_activitylog_backup_confirm', { action_id: rewindId } ),
 				rewindBackup( siteId, rewindId )
 			)
 		)
@@ -273,13 +273,15 @@ const mapDispatchToProps = ( dispatch, { activityId, siteId } ) => ( {
 		scrollTo( { x: 0, y: 0, duration: 250 } ),
 		dispatch(
 			withAnalytics(
-				recordTracksEvent( 'calypso_activitylog_restore_confirm', { actionId: rewindId } ),
+				recordTracksEvent( 'calypso_activitylog_restore_confirm', { action_id: rewindId } ),
 				rewindRestore( siteId, rewindId )
 			)
 		)
 	),
 	trackHelp: activityName =>
-		dispatch( recordTracksEvent( 'calypso_activitylog_event_get_help', { activityName } ) ),
+		dispatch(
+			recordTracksEvent( 'calypso_activitylog_event_get_help', { activity_name: activityName } )
+		),
 } );
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( ActivityLogItem ) );

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -646,7 +646,7 @@ export default connect(
 			} ),
 		createBackup: ( siteId, actionId ) =>
 			withAnalytics(
-				recordTracksEvent( 'calypso_activitylog_backup_confirm', { actionId } ),
+				recordTracksEvent( 'calypso_activitylog_backup_confirm', { action_id: actionId } ),
 				rewindBackup( siteId, actionId )
 			),
 		dismissBackup: siteId =>
@@ -661,7 +661,7 @@ export default connect(
 			),
 		rewindRestore: ( siteId, actionId ) =>
 			withAnalytics(
-				recordTracksEvent( 'calypso_activitylog_restore_confirm', { actionId } ),
+				recordTracksEvent( 'calypso_activitylog_restore_confirm', { action_id: actionId } ),
 				rewindRestore( siteId, actionId )
 			),
 	}

--- a/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
@@ -43,7 +43,7 @@ export const receiveRestoreSuccess = ( { siteId, timestamp }, restoreId ) => [
 export const receiveRestoreError = ( { siteId, timestamp }, error ) =>
 	error.hasOwnProperty( 'schemaErrors' )
 		? withAnalytics(
-				recordTracksEvent( 'calypso_rewind_to_missing_restore_id', { siteId, timestamp } ),
+				recordTracksEvent( 'calypso_rewind_to_missing_restore_id', { site_id: siteId, timestamp } ),
 				errorNotice(
 					translate(
 						"Oops, something went wrong. We've been notified and are working on resolving this issue."

--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -101,7 +101,7 @@ export const continuePolling = ( { dispatch, getState }, action ) => {
 	if ( undefined !== error ) {
 		pollingSites.delete( siteId );
 
-		dispatch( recordTracksEvent( 'calypso_activity_log_polling_fail', { siteId } ) );
+		dispatch( recordTracksEvent( 'calypso_activity_log_polling_fail', { site_id: siteId } ) );
 		return;
 	}
 


### PR DESCRIPTION
Tracks won't allow camelCase names for event properties.
This patch fixes a number of places where we are sending
thos invalid property names and thus the events end up
rejected by the Tracks server.