### PR TITLE
2 year plans: Remove hardcoded plans constants from stepsForProductAndSurvey

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/steps-for-product-and-survey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/steps-for-product-and-survey.js
@@ -4,21 +4,27 @@
  * Internal dependencies
  */
 
-import * as plans from 'lib/plans/constants';
+import {
+	GROUP_WPCOM,
+	GROUP_JETPACK,
+	TYPE_PERSONAL,
+	TYPE_PREMIUM,
+	TYPE_BUSINESS,
+} from 'lib/plans/constants';
+import { findPlansKeys } from 'lib/plans';
 import { includesProduct } from 'lib/products-values';
 import { abtest } from 'lib/abtest';
 import * as steps from './steps';
 
-const BUSINESS_PLANS = [ plans.PLAN_BUSINESS ];
-const PERSONAL_PREMIUM_PLANS = [ plans.PLAN_PERSONAL, plans.PLAN_PREMIUM ];
-const JETPACK_PAID_PLANS = [
-	plans.PLAN_JETPACK_BUSINESS,
-	plans.PLAN_JETPACK_BUSINESS_MONTHLY,
-	plans.PLAN_JETPACK_PERSONAL,
-	plans.PLAN_JETPACK_PERSONAL_MONTHLY,
-	plans.PLAN_JETPACK_PREMIUM,
-	plans.PLAN_JETPACK_PREMIUM_MONTHLY,
-];
+const BUSINESS_PLANS = findPlansKeys( { group: GROUP_WPCOM, type: TYPE_BUSINESS } );
+const PERSONAL_PREMIUM_PLANS = []
+	.concat( findPlansKeys( { group: GROUP_WPCOM, type: TYPE_PERSONAL } ) )
+	.concat( findPlansKeys( { group: GROUP_WPCOM, type: TYPE_PREMIUM } ) );
+
+const JETPACK_PAID_PLANS = []
+	.concat( findPlansKeys( { group: GROUP_JETPACK, type: TYPE_PERSONAL } ) )
+	.concat( findPlansKeys( { group: GROUP_JETPACK, type: TYPE_PREMIUM } ) )
+	.concat( findPlansKeys( { group: GROUP_JETPACK, type: TYPE_BUSINESS } ) );
 
 export default function stepsForProductAndSurvey(
 	survey,

--- a/client/components/marketing-survey/cancel-purchase-form/test/steps-for-product-and-survey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/steps-for-product-and-survey.js
@@ -41,8 +41,22 @@ describe( 'stepsForProductAndSurvey', () => {
 			).to.deep.equal( steps.DEFAULT_STEPS_WITH_HAPPYCHAT );
 		} );
 
+		test( 'should include happychat step if product is personal plan and happychat is available (2y)', () => {
+			const product = { product_slug: plans.PLAN_PERSONAL_2_YEARS };
+			expect(
+				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
+			).to.deep.equal( steps.DEFAULT_STEPS_WITH_HAPPYCHAT );
+		} );
+
 		test( 'should not include happychat step if product is personal plan but happychat is not available', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL };
+			expect(
+				stepsForProductAndSurvey( survey, product, false, precancellationChatToggle )
+			).to.deep.equal( DEFAULT_STEPS );
+		} );
+
+		test( 'should not include happychat step if product is personal plan but happychat is not available (2y)', () => {
+			const product = { product_slug: plans.PLAN_PERSONAL_2_YEARS };
 			expect(
 				stepsForProductAndSurvey( survey, product, false, precancellationChatToggle )
 			).to.deep.equal( DEFAULT_STEPS );
@@ -55,8 +69,22 @@ describe( 'stepsForProductAndSurvey', () => {
 			).to.deep.equal( steps.DEFAULT_STEPS_WITH_HAPPYCHAT );
 		} );
 
+		test( 'should include happychat step if product is premium plan and happychat is available (2y)', () => {
+			const product = { product_slug: plans.PLAN_PREMIUM_2_YEARS };
+			expect(
+				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
+			).to.deep.equal( steps.DEFAULT_STEPS_WITH_HAPPYCHAT );
+		} );
+
 		test( 'should not include happychat step if product is premium plan but happychat is not available', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM };
+			expect(
+				stepsForProductAndSurvey( survey, product, false, precancellationChatToggle )
+			).to.deep.equal( DEFAULT_STEPS );
+		} );
+
+		test( 'should not include happychat step if product is premium plan but happychat is not available (2y)', () => {
+			const product = { product_slug: plans.PLAN_PREMIUM_2_YEARS };
 			expect(
 				stepsForProductAndSurvey( survey, product, false, precancellationChatToggle )
 			).to.deep.equal( DEFAULT_STEPS );
@@ -69,8 +97,22 @@ describe( 'stepsForProductAndSurvey', () => {
 			).to.deep.equal( steps.DEFAULT_STEPS_WITH_HAPPYCHAT );
 		} );
 
+		test( 'should include happychat step if product is business plan and happychat is available (2y)', () => {
+			const product = { product_slug: plans.PLAN_BUSINESS_2_YEARS };
+			expect(
+				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
+			).to.deep.equal( steps.DEFAULT_STEPS_WITH_HAPPYCHAT );
+		} );
+
 		test( 'should include happychat step if product is business plan but happychat is not available', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS };
+			expect(
+				stepsForProductAndSurvey( survey, product, false, precancellationChatToggle )
+			).to.deep.equal( DEFAULT_STEPS );
+		} );
+
+		test( 'should include happychat step if product is business plan but happychat is not available (2y)', () => {
+			const product = { product_slug: plans.PLAN_BUSINESS_2_YEARS };
 			expect(
 				stepsForProductAndSurvey( survey, product, false, precancellationChatToggle )
 			).to.deep.equal( DEFAULT_STEPS );
@@ -88,6 +130,13 @@ describe( 'stepsForProductAndSurvey', () => {
 			).to.deep.equal( DEFAULT_STEPS );
 		} );
 
+		test( 'should not include happychat step if product is personal plan and happychat is available (2y)', () => {
+			const product = { product_slug: plans.PLAN_PERSONAL_2_YEARS };
+			expect(
+				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
+			).to.deep.equal( DEFAULT_STEPS );
+		} );
+
 		test( 'should not include happychat step if product is premium plan and happychat is available', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM };
 			expect(
@@ -95,8 +144,22 @@ describe( 'stepsForProductAndSurvey', () => {
 			).to.deep.equal( DEFAULT_STEPS );
 		} );
 
+		test( 'should not include happychat step if product is premium plan and happychat is available (2y)', () => {
+			const product = { product_slug: plans.PLAN_PREMIUM_2_YEARS };
+			expect(
+				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
+			).to.deep.equal( DEFAULT_STEPS );
+		} );
+
 		test( 'should not include happychat step if product is business plan and happychat is available', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS };
+			expect(
+				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
+			).to.deep.equal( DEFAULT_STEPS );
+		} );
+
+		test( 'should not include happychat step if product is business plan and happychat is available (2y)', () => {
+			const product = { product_slug: plans.PLAN_BUSINESS_2_YEARS };
 			expect(
 				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
 			).to.deep.equal( DEFAULT_STEPS );
@@ -114,8 +177,22 @@ describe( 'stepsForProductAndSurvey', () => {
 			);
 		} );
 
+		test( 'should include AT upgrade step if product is personal plan and abtest variant is show (2y)', () => {
+			const product = { product_slug: plans.PLAN_PERSONAL_2_YEARS };
+			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'show' );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
+				DEFAULT_STEPS_WITH_UPGRADE_AT_STEP
+			);
+		} );
+
 		test( 'should not include AT upgrade step if product is personal plan and abtest variant is hide', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL };
+			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'hide' );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
+		} );
+
+		test( 'should not include AT upgrade step if product is personal plan and abtest variant is hide (2y)', () => {
+			const product = { product_slug: plans.PLAN_PERSONAL_2_YEARS };
 			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'hide' );
 			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
 		} );
@@ -128,8 +205,22 @@ describe( 'stepsForProductAndSurvey', () => {
 			);
 		} );
 
+		test( 'should include AT upgrade step if product is premium plan and abtest variant is show (2y)', () => {
+			const product = { product_slug: plans.PLAN_PREMIUM_2_YEARS };
+			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'show' );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
+				DEFAULT_STEPS_WITH_UPGRADE_AT_STEP
+			);
+		} );
+
 		test( 'should not include AT upgrade step if product is premium plan and abtest variant is hide', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM };
+			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'hide' );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
+		} );
+
+		test( 'should not include AT upgrade step if product is premium plan and abtest variant is hide (2y)', () => {
+			const product = { product_slug: plans.PLAN_PREMIUM_2_YEARS };
 			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'hide' );
 			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
 		} );
@@ -142,8 +233,22 @@ describe( 'stepsForProductAndSurvey', () => {
 			);
 		} );
 
+		test( 'should include business AT step if product is personal plan and abtest variant is show (2y)', () => {
+			const product = { product_slug: plans.PLAN_BUSINESS_2_YEARS };
+			abtest.withArgs( 'ATPromptOnCancel' ).returns( 'show' );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
+				DEFAULT_STEPS_WITH_BUSINESS_AT_STEP
+			);
+		} );
+
 		test( 'should not include business AT step if product is business plan and abtest variant is hide', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS };
+			abtest.withArgs( 'ATPromptOnCancel' ).returns( 'hide' );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
+		} );
+
+		test( 'should not include business AT step if product is business plan and abtest variant is hide (2y)', () => {
+			const product = { product_slug: plans.PLAN_BUSINESS_2_YEARS };
 			abtest.withArgs( 'ATPromptOnCancel' ).returns( 'hide' );
 			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
 		} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `stepsForProductAndSurvey`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* On paid site go to /plans/my-plan -> manage payment -> remove plan
* Confirm that for different plan types the survey looks the same as on wordpress.com - e.g. WP.com and Jetpack business will ask to go through happychat while premium and personal allow removal. Note that there is an a/b test in play so you may randomly run into `'New! Install Custom Plugins and Themes'` step