### PR TITLE
2 year plans: Remove direct usage of plan constants from plan-features

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -19,20 +19,8 @@ import PlanPrice from 'my-sites/plan-price';
 import PlanIntervalDiscount from 'my-sites/plan-interval-discount';
 import Ribbon from 'components/ribbon';
 import PlanIcon from 'components/plans/plan-icon';
-import {
-	PLAN_FREE,
-	PLAN_PREMIUM,
-	PLAN_BUSINESS,
-	PLAN_JETPACK_FREE,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PERSONAL_MONTHLY,
-	PLAN_PERSONAL,
-	getPlanClass,
-} from 'lib/plans/constants';
+import { TYPE_FREE, PLANS_LIST, getPlanClass } from 'lib/plans/constants';
+import { planMatches } from 'lib/plans';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getPlanBySlug } from 'state/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -40,7 +28,7 @@ import { getYearlyPlanByMonthly } from 'lib/plans';
 import { isMobile } from 'lib/viewport';
 import { planLevelsMatch } from 'lib/plans/index';
 
-class PlanFeaturesHeader extends Component {
+export class PlanFeaturesHeader extends Component {
 	render() {
 		const { isInSignup } = this.props;
 		let content = this.renderPlansHeader();
@@ -141,7 +129,7 @@ class PlanFeaturesHeader extends Component {
 	getDiscountTooltipMessage() {
 		const { currencyCode, currentSitePlan, translate, rawPrice } = this.props;
 
-		if ( currentSitePlan.productSlug === PLAN_FREE ) {
+		if ( planMatches( currentSitePlan.productSlug, { type: TYPE_FREE } ) ) {
 			return translate( 'Price for the next 12 months' );
 		}
 
@@ -178,7 +166,12 @@ class PlanFeaturesHeader extends Component {
 			);
 		}
 
-		if ( isSiteAT || ! site.jetpack || this.props.planType === PLAN_JETPACK_FREE || hideMonthly ) {
+		if (
+			isSiteAT ||
+			! site.jetpack ||
+			planMatches( this.props.planType, { type: TYPE_FREE } ) ||
+			hideMonthly
+		) {
 			return (
 				<p className={ timeframeClasses }>
 					{ ! isPlaceholder ? billingTimeFrame : '' }
@@ -314,19 +307,7 @@ PlanFeaturesHeader.propTypes = {
 	billingTimeFrame: PropTypes.string.isRequired,
 	current: PropTypes.bool,
 	onClick: PropTypes.func,
-	planType: PropTypes.oneOf( [
-		PLAN_FREE,
-		PLAN_PREMIUM,
-		PLAN_BUSINESS,
-		PLAN_JETPACK_FREE,
-		PLAN_JETPACK_BUSINESS,
-		PLAN_JETPACK_BUSINESS_MONTHLY,
-		PLAN_JETPACK_PREMIUM,
-		PLAN_JETPACK_PREMIUM_MONTHLY,
-		PLAN_JETPACK_PERSONAL,
-		PLAN_JETPACK_PERSONAL_MONTHLY,
-		PLAN_PERSONAL,
-	] ).isRequired,
+	planType: PropTypes.oneOf( Object.keys( PLANS_LIST ) ).isRequired,
 	popular: PropTypes.bool,
 	newPlan: PropTypes.bool,
 	bestValue: PropTypes.bool,

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -1,0 +1,176 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.mock( 'lib/analytics/index', () => ( {} ) );
+jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'lib/user', () => ( {} ) );
+jest.mock( 'components/main', () => 'MainComponent' );
+jest.mock( 'components/popover', () => 'Popover' );
+jest.mock( 'components/info-popover', () => 'InfoPopover' );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Comp => props => (
+		<Comp
+			{ ...props }
+			translate={ function( x ) {
+				return x;
+			} }
+		/>
+	),
+	numberFormat: x => x,
+} ) );
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import {
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { PlanFeaturesHeader } from '../header';
+
+const props = {
+	translate: x => x,
+	planType: PLAN_FREE,
+	currentSitePlan: { productSlug: PLAN_FREE },
+	site: {},
+};
+
+describe( 'PlanFeaturesHeader basic tests', () => {
+	test( 'should not blow up', () => {
+		const comp = shallow( <PlanFeaturesHeader { ...props } /> );
+		expect( comp.find( '.plan-features__header' ).length ).toBe( 1 );
+	} );
+} );
+
+describe( 'PlanFeaturesHeader.getDiscountTooltipMessage()', () => {
+	[ PLAN_FREE, PLAN_JETPACK_FREE ].forEach( productSlug => {
+		test( `Should return a particular message for free plans (${ productSlug })`, () => {
+			const comp = new PlanFeaturesHeader( { ...props, currentSitePlan: { productSlug } } );
+			expect( comp.getDiscountTooltipMessage() ).toBe( 'Price for the next 12 months' );
+		} );
+	} );
+
+	[
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_PERSONAL_MONTHLY,
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PREMIUM_MONTHLY,
+		PLAN_JETPACK_BUSINESS,
+		PLAN_JETPACK_BUSINESS_MONTHLY,
+		PLAN_BUSINESS,
+		PLAN_BUSINESS_2_YEARS,
+	].forEach( productSlug => {
+		test( `Should render different message for paid plans (${ productSlug })`, () => {
+			const comp = new PlanFeaturesHeader( { ...props, currentSitePlan: { productSlug } } );
+			expect( comp.getDiscountTooltipMessage() ).toBe(
+				"We'll deduct the cost of your current plan from the full price (%(price)s) for the next 12 months."
+			);
+		} );
+	} );
+} );
+
+describe( 'PlanFeaturesHeader.getBillingTimeframe()', () => {
+	const myProps = {
+		...props,
+		discountPrice: 12,
+		isPlaceholder: false,
+	};
+
+	[ PLAN_FREE, PLAN_JETPACK_FREE ].forEach( productSlug => {
+		test( `Should render InfoPopover for free plans (${ productSlug })`, () => {
+			const comp = new PlanFeaturesHeader( {
+				...myProps,
+				site: { jetpack: true },
+				planType: productSlug,
+			} );
+			const tf = shallow( comp.getBillingTimeframe() );
+			expect( tf.find( 'InfoPopover' ).length ).toBe( 1 );
+		} );
+	} );
+
+	[ PLAN_FREE, PLAN_JETPACK_FREE, PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_BUSINESS ].forEach(
+		productSlug => {
+			test( `Should render InfoPopover for non-jetpack sites (${ productSlug })`, () => {
+				const comp = new PlanFeaturesHeader( {
+					...myProps,
+					site: { jetpack: false },
+					planType: productSlug,
+				} );
+				const tf = shallow( comp.getBillingTimeframe() );
+				expect( tf.find( 'InfoPopover' ).length ).toBe( 1 );
+			} );
+
+			test( `Should render InfoPopover for AT sites (${ productSlug })`, () => {
+				const comp = new PlanFeaturesHeader( {
+					...myProps,
+					site: { jetpack: true },
+					isSiteAT: true,
+					planType: productSlug,
+				} );
+				const tf = shallow( comp.getBillingTimeframe() );
+				expect( tf.find( 'InfoPopover' ).length ).toBe( 1 );
+			} );
+			test( `Should render InfoPopover when hideMonthly is true (${ productSlug })`, () => {
+				const comp = new PlanFeaturesHeader( {
+					...myProps,
+					site: { jetpack: true },
+					hideMonthly: true,
+					planType: productSlug,
+				} );
+				const tf = shallow( comp.getBillingTimeframe() );
+				expect( tf.find( 'InfoPopover' ).length ).toBe( 1 );
+			} );
+		}
+	);
+
+	[
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_PERSONAL_MONTHLY,
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PREMIUM_MONTHLY,
+		PLAN_JETPACK_BUSINESS,
+		PLAN_JETPACK_BUSINESS_MONTHLY,
+		PLAN_BUSINESS,
+		PLAN_BUSINESS_2_YEARS,
+	].forEach( productSlug => {
+		test( `Should not render InfoPopover for paid plans (${ productSlug })`, () => {
+			const comp = new PlanFeaturesHeader( {
+				...myProps,
+				site: { jetpack: true },
+				planType: productSlug,
+			} );
+			const tf = shallow( comp.getBillingTimeframe() );
+			expect( tf.find( 'InfoPopover' ).length ).toBe( 0 );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `plan-features`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* Go to /plans and confirm it does not blow up
* This is pretty hard to test since we need to have a plan discount while on a free plan. I just hardcoded a discount like this for testing purposes (in `client/my-sites/plan-features/header.jsx`):

<img width="623" alt="zrzut ekranu 2018-03-29 o 13 20 24" src="https://user-images.githubusercontent.com/205419/38086275-fc3261a4-3353-11e8-8c0c-1591189c055e.png">

If this PR works, then for free plans with discounts you'll see the following popover:
<img width="352" alt="zrzut ekranu 2018-03-29 o 13 20 49" src="https://user-images.githubusercontent.com/205419/38086315-22a47944-3354-11e8-9532-45124d819f61.png">

While for all other plan types you'll see a different one:

<img width="360" alt="zrzut ekranu 2018-03-29 o 13 21 19" src="https://user-images.githubusercontent.com/205419/38086326-2c01d0e0-3354-11e8-9628-edc7948f0145.png">
