### PR TITLE
2 year plans: Remove direct usage of plan constants from plan-features/index

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -32,6 +32,7 @@ import { planItem as getCartItemForPlan } from 'lib/cart-values/cart-items';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { retargetViewPlans } from 'lib/analytics/ad-tracking';
 import {
+	planMatches,
 	applyTestFiltersToPlansList,
 	canUpgradeToPlan,
 	getMonthlyPlanByYearly,
@@ -50,8 +51,6 @@ import {
 	isCurrentSitePlan,
 } from 'state/sites/selectors';
 import {
-	getPlanClass,
-	getPlanFeaturesObject,
 	isBestValue,
 	isMonthly,
 	isNew,
@@ -63,16 +62,6 @@ import {
 	TYPE_BUSINESS,
 	GROUP_WPCOM,
 } from 'lib/plans/constants';
-import { planMatches, getMonthlyPlanByYearly, isFreePlan } from 'lib/plans';
-import { getPlanPath, canUpgradeToPlan, applyTestFiltersToPlansList } from 'lib/plans';
-import { planItem as getCartItemForPlan } from 'lib/cart-values/cart-items';
-import Notice from 'components/notice';
-import SpinnerLine from 'components/spinner-line';
-import FoldableCard from 'components/foldable-card';
-import { recordTracksEvent } from 'state/analytics/actions';
-import formatCurrency from 'lib/format-currency';
-import { retargetViewPlans } from 'lib/analytics/ad-tracking';
-import { abtest, getABTestVariation } from 'lib/abtest';
 
 class PlanFeatures extends Component {
 	componentDidMount() {

--- a/client/my-sites/plan-features/test/index.jsx
+++ b/client/my-sites/plan-features/test/index.jsx
@@ -1,0 +1,94 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.mock( 'lib/analytics/index', () => ( {} ) );
+jest.mock( 'lib/analytics/ad-tracking', () => ( {} ) );
+jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'lib/user', () => ( {} ) );
+jest.mock( 'components/main', () => 'MainComponent' );
+jest.mock( 'components/popover', () => 'Popover' );
+jest.mock( 'components/info-popover', () => 'InfoPopover' );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Comp => props => (
+		<Comp
+			{ ...props }
+			translate={ function( x ) {
+				return x;
+			} }
+		/>
+	),
+	numberFormat: x => x,
+} ) );
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import {
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { isPrimaryUpgradeByPlanDelta } from '../index';
+
+describe( 'isPrimaryUpgradeByPlanDelta', () => {
+	test( 'Should return true when called with personal and premium plan', () => {
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_PERSONAL, PLAN_PREMIUM ) ).toBe( true );
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM ) ).toBe( true );
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_PERSONAL, PLAN_PREMIUM_2_YEARS ) ).toBe( true );
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS ) ).toBe(
+			true
+		);
+	} );
+
+	test( 'Should return true when called with premium and business plan', () => {
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_PREMIUM, PLAN_BUSINESS ) ).toBe( true );
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_PREMIUM, PLAN_BUSINESS_2_YEARS ) ).toBe( true );
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_PREMIUM_2_YEARS, PLAN_BUSINESS ) ).toBe( true );
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_PREMIUM_2_YEARS, PLAN_BUSINESS_2_YEARS ) ).toBe(
+			true
+		);
+	} );
+
+	test( 'Should return false when called with other plan combinations', () => {
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_JETPACK_FREE, PLAN_JETPACK_PREMIUM ) ).toBe( false );
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL ) ).toBe( false );
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_JETPACK_FREE, PLAN_JETPACK_BUSINESS ) ).toBe( false );
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PREMIUM ) ).toBe(
+			false
+		);
+		expect(
+			isPrimaryUpgradeByPlanDelta( PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PREMIUM_MONTHLY )
+		).toBe( false );
+		expect(
+			isPrimaryUpgradeByPlanDelta( PLAN_JETPACK_PERSONAL_MONTHLY, PLAN_JETPACK_PREMIUM_MONTHLY )
+		).toBe( false );
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_PREMIUM, PLAN_PREMIUM ) ).toBe( false );
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_PREMIUM, PLAN_PREMIUM_2_YEARS ) ).toBe( false );
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL ) ).toBe( false );
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ) ).toBe( false );
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_BUSINESS, PLAN_PREMIUM ) ).toBe( false );
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_BUSINESS, PLAN_PERSONAL ) ).toBe( false );
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_BUSINESS, PLAN_FREE ) ).toBe( false );
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_FREE, PLAN_PREMIUM ) ).toBe( false );
+		expect( isPrimaryUpgradeByPlanDelta( PLAN_FREE, PLAN_PERSONAL ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `plan-features/index`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* Go to /plans and confirm that for wp.com free/personal users, the "upgrade" button is blue only under a premium plan.
* Go to /plans and confirm that for wp.com premium users, the "upgrade" button is blue only under a business plan.
* Note that Jetpack /plans page is out of scope of this commit