### PR TITLE
Remove direct usage of plan constants from plan features main

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -5,6 +5,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -5,7 +5,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { filter, get } from 'lodash';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 
@@ -14,17 +13,15 @@ import { connect } from 'react-redux';
  */
 import PlanFeatures from 'my-sites/plan-features';
 import {
-	PLAN_FREE,
-	PLAN_JETPACK_FREE,
-	PLAN_PERSONAL,
-	PLAN_PREMIUM,
-	PLAN_BUSINESS,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
-	PLAN_JETPACK_PERSONAL_MONTHLY,
+	TYPE_FREE,
+	TYPE_PERSONAL,
+	TYPE_PREMIUM,
+	TYPE_BUSINESS,
+	TERM_MONTHLY,
+	TERM_ANNUALLY,
+	TERM_BIENNIALLY,
+	GROUP_WPCOM,
+	GROUP_JETPACK,
 } from 'lib/plans/constants';
 import { addQueryArgs } from 'lib/url';
 import QueryPlans from 'components/data/query-plans';
@@ -33,7 +30,7 @@ import FAQ from 'components/faq';
 import FAQItem from 'components/faq/faq-item';
 import { isEnabled } from 'config';
 import { purchasesRoot } from 'me/purchases/paths';
-import { plansLink } from 'lib/plans';
+import { plansLink, findPlansKeys, getPlan } from 'lib/plans';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
 import PaymentMethods from 'blocks/payment-methods';
@@ -42,7 +39,7 @@ import HappychatConnection from 'components/happychat/connection-connected';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 import { selectSiteId as selectHappychatSiteId } from 'state/help/actions';
 
-class PlansFeaturesMain extends Component {
+export class PlansFeaturesMain extends Component {
 	componentWillUpdate( nextProps ) {
 		/**
 		 * Happychat does not update with the selected site right now :(
@@ -63,8 +60,6 @@ class PlansFeaturesMain extends Component {
 			basePlansPath,
 			displayJetpackPlans,
 			domainName,
-			hideFreePlan,
-			intervalType,
 			isInSignup,
 			isLandingPage,
 			onUpgradeClick,
@@ -73,75 +68,11 @@ class PlansFeaturesMain extends Component {
 			site,
 		} = this.props;
 
-		const isPersonalPlanEnabled = isEnabled( 'plans/personal-plan' );
-		if ( displayJetpackPlans && intervalType === 'monthly' ) {
-			const jetpackPlans = [
-				PLAN_JETPACK_FREE,
-				PLAN_JETPACK_PERSONAL_MONTHLY,
-				PLAN_JETPACK_PREMIUM_MONTHLY,
-				PLAN_JETPACK_BUSINESS_MONTHLY,
-			];
-			if ( hideFreePlan ) {
-				jetpackPlans.shift();
-			}
-			return (
-				<div className="plans-features-main__group" data-e2e-plans="jetpack">
-					<PlanFeatures
-						basePlansPath={ basePlansPath }
-						displayJetpackPlans={ displayJetpackPlans }
-						domainName={ domainName }
-						isInSignup={ isInSignup }
-						isLandingPage={ isLandingPage }
-						onUpgradeClick={ onUpgradeClick }
-						plans={ jetpackPlans }
-						selectedFeature={ selectedFeature }
-						selectedPlan={ selectedPlan }
-						site={ site }
-					/>
-				</div>
-			);
-		}
-
-		if ( displayJetpackPlans ) {
-			const jetpackPlans = [
-				PLAN_JETPACK_FREE,
-				PLAN_JETPACK_PERSONAL,
-				PLAN_JETPACK_PREMIUM,
-				PLAN_JETPACK_BUSINESS,
-			];
-			if ( hideFreePlan ) {
-				jetpackPlans.shift();
-			}
-			return (
-				<div className="plans-features-main__group" data-e2e-plans="jetpack">
-					<PlanFeatures
-						basePlansPath={ basePlansPath }
-						displayJetpackPlans={ displayJetpackPlans }
-						domainName={ domainName }
-						isInSignup={ isInSignup }
-						isLandingPage={ isLandingPage }
-						onUpgradeClick={ onUpgradeClick }
-						plans={ jetpackPlans }
-						selectedFeature={ selectedFeature }
-						selectedPlan={ selectedPlan }
-						site={ site }
-					/>
-				</div>
-			);
-		}
-
-		const plans = filter(
-			[
-				hideFreePlan ? null : PLAN_FREE,
-				isPersonalPlanEnabled ? PLAN_PERSONAL : null,
-				PLAN_PREMIUM,
-				PLAN_BUSINESS,
-			],
-			value => !! value
-		);
-
 		return (
-			<div className="plans-features-main__group" data-e2e-plans="wpcom">
+			<div
+				className="plans-features-main__group"
+				data-e2e-plans={ displayJetpackPlans ? 'jetpack' : 'wpcom' }
+			>
 				<PlanFeatures
 					basePlansPath={ basePlansPath }
 					displayJetpackPlans={ displayJetpackPlans }
@@ -149,13 +80,51 @@ class PlansFeaturesMain extends Component {
 					isInSignup={ isInSignup }
 					isLandingPage={ isLandingPage }
 					onUpgradeClick={ onUpgradeClick }
-					plans={ plans }
-					selectedPlan={ selectedPlan }
+					plans={ this.getPlansForPlanFeatures() }
 					selectedFeature={ selectedFeature }
+					selectedPlan={ selectedPlan }
 					site={ site }
 				/>
 			</div>
 		);
+	}
+
+	getPlansForPlanFeatures() {
+		const { displayJetpackPlans, intervalType, selectedPlan, hideFreePlan } = this.props;
+
+		const currentPlan = getPlan( selectedPlan );
+
+		let term;
+		if ( intervalType === 'monthly' ) {
+			term = TERM_MONTHLY;
+		} else if ( intervalType === 'yearly' ) {
+			term = TERM_ANNUALLY;
+		} else if ( intervalType === '2yearly' ) {
+			term = TERM_BIENNIALLY;
+		} else if ( currentPlan ) {
+			term = currentPlan.term;
+		} else {
+			term = TERM_ANNUALLY;
+		}
+
+		const group = displayJetpackPlans ? GROUP_JETPACK : GROUP_WPCOM;
+		const personalPlan = findPlansKeys( { group, term, type: TYPE_PERSONAL } )[ 0 ];
+		const plans = [
+			findPlansKeys( { type: TYPE_FREE, group } )[ 0 ],
+			personalPlan,
+			findPlansKeys( { group, term, type: TYPE_PREMIUM } )[ 0 ],
+			findPlansKeys( { group, term, type: TYPE_BUSINESS } )[ 0 ],
+		];
+
+		if ( hideFreePlan ) {
+			plans.shift();
+		}
+
+		if ( ! isEnabled( 'plans/personal-plan' ) && ! displayJetpackPlans ) {
+			plans.splice( plans.indexOf( personalPlan ), 1 );
+		}
+
+		return plans;
 	}
 
 	getJetpackFAQ() {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -111,7 +111,7 @@ export class PlansFeaturesMain extends Component {
 		const group = displayJetpackPlans ? GROUP_JETPACK : GROUP_WPCOM;
 		const personalPlan = findPlansKeys( { group, term, type: TYPE_PERSONAL } )[ 0 ];
 		const plans = [
-			findPlansKeys( { type: TYPE_FREE, group } )[ 0 ],
+			findPlansKeys( { group, type: TYPE_FREE } )[ 0 ],
 			personalPlan,
 			findPlansKeys( { group, term, type: TYPE_PREMIUM } )[ 0 ],
 			findPlansKeys( { group, term, type: TYPE_BUSINESS } )[ 0 ],

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -1,0 +1,166 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.mock( 'lib/analytics/index', () => ( {} ) );
+jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'lib/user', () => ( {} ) );
+jest.mock( 'config', () => ( {
+	isEnabled: () => true,
+} ) );
+jest.mock( 'components/main', () => 'MainComponent' );
+jest.mock( 'components/popover', () => 'Popover' );
+jest.mock( 'my-sites/plan-features', () => 'PlanFeatures' );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Comp => props => (
+		<Comp
+			{ ...props }
+			translate={ function( x ) {
+				return x;
+			} }
+		/>
+	),
+	numberFormat: x => x,
+} ) );
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import {
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { PlansFeaturesMain } from '../index';
+
+const props = {
+	selectedPlan: PLAN_FREE,
+};
+
+describe( 'PlansFeaturesMain.getPlansForPlanFeatures()', () => {
+	test( 'Should render <PlanFeatures /> with Jetpack monthly plans when called with jetpack props', () => {
+		const instance = new PlansFeaturesMain( {
+			...props,
+			displayJetpackPlans: true,
+			intervalType: 'monthly',
+		} );
+		const plans = instance.getPlansForPlanFeatures();
+		expect( plans ).toEqual( [
+			PLAN_JETPACK_FREE,
+			PLAN_JETPACK_PERSONAL_MONTHLY,
+			PLAN_JETPACK_PREMIUM_MONTHLY,
+			PLAN_JETPACK_BUSINESS_MONTHLY,
+		] );
+	} );
+
+	test( 'Should render <PlanFeatures /> with Jetpack monthly plans without free one when requested', () => {
+		const instance = new PlansFeaturesMain( {
+			...props,
+			displayJetpackPlans: true,
+			intervalType: 'monthly',
+			hideFreePlan: true,
+		} );
+		const plans = instance.getPlansForPlanFeatures();
+		expect( plans ).toEqual( [
+			PLAN_JETPACK_PERSONAL_MONTHLY,
+			PLAN_JETPACK_PREMIUM_MONTHLY,
+			PLAN_JETPACK_BUSINESS_MONTHLY,
+		] );
+	} );
+	test( 'Should render <PlanFeatures /> with Jetpack monthly data-e2e-plans when requested', () => {
+		const instance = new PlansFeaturesMain( { ...props, displayJetpackPlans: true } );
+		const comp = shallow( instance.getPlanFeatures() );
+		expect( comp.find( '[data-e2e-plans="jetpack"]' ).length ).toBe( 1 );
+	} );
+
+	test( 'Should render <PlanFeatures /> with Jetpack plans when called with jetpack props', () => {
+		const instance = new PlansFeaturesMain( { ...props, displayJetpackPlans: true } );
+		const plans = instance.getPlansForPlanFeatures();
+		expect( plans ).toEqual( [
+			PLAN_JETPACK_FREE,
+			PLAN_JETPACK_PERSONAL,
+			PLAN_JETPACK_PREMIUM,
+			PLAN_JETPACK_BUSINESS,
+		] );
+	} );
+
+	test( 'Should render <PlanFeatures /> with Jetpack plans without free one when requested', () => {
+		const instance = new PlansFeaturesMain( {
+			...props,
+			displayJetpackPlans: true,
+			hideFreePlan: true,
+		} );
+		const plans = instance.getPlansForPlanFeatures();
+		expect( plans ).toEqual( [
+			PLAN_JETPACK_PERSONAL,
+			PLAN_JETPACK_PREMIUM,
+			PLAN_JETPACK_BUSINESS,
+		] );
+	} );
+
+	test( 'Should render <PlanFeatures /> with Jetpack data-e2e-plans when requested', () => {
+		const instance = new PlansFeaturesMain( { ...props, displayJetpackPlans: true } );
+		const comp = shallow( instance.getPlanFeatures() );
+		expect( comp.find( '[data-e2e-plans="jetpack"]' ).length ).toBe( 1 );
+	} );
+
+	test( 'Should render <PlanFeatures /> with WP.com plans when requested', () => {
+		const instance = new PlansFeaturesMain( { ...props } );
+		const plans = instance.getPlansForPlanFeatures();
+		expect( plans ).toEqual( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS ] );
+	} );
+
+	test( 'Should render <PlanFeatures /> with WP.com data-e2e-plans when requested', () => {
+		const instance = new PlansFeaturesMain( { ...props } );
+		const comp = shallow( instance.getPlanFeatures() );
+		expect( comp.find( '[data-e2e-plans="wpcom"]' ).length ).toBe( 1 );
+	} );
+
+	test( 'Should render <PlanFeatures /> with WP.com plans without free one when requested', () => {
+		const instance = new PlansFeaturesMain( { ...props, hideFreePlan: true } );
+		const plans = instance.getPlansForPlanFeatures();
+		expect( plans ).toEqual( [ PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS ] );
+	} );
+
+	test( 'Should render <PlanFeatures /> with WP.com 2-year plans when requested ( by plan )', () => {
+		const instance = new PlansFeaturesMain( { ...props, selectedPlan: PLAN_PERSONAL_2_YEARS } );
+		const plans = instance.getPlansForPlanFeatures();
+		expect( plans ).toEqual( [
+			PLAN_FREE,
+			PLAN_PERSONAL_2_YEARS,
+			PLAN_PREMIUM_2_YEARS,
+			PLAN_BUSINESS_2_YEARS,
+		] );
+	} );
+
+	test( 'Should render <PlanFeatures /> with WP.com 2-year plans when requested ( by interval )', () => {
+		const instance = new PlansFeaturesMain( { ...props, intervalType: '2yearly' } );
+		const plans = instance.getPlansForPlanFeatures();
+		expect( plans ).toEqual( [
+			PLAN_FREE,
+			PLAN_PERSONAL_2_YEARS,
+			PLAN_PREMIUM_2_YEARS,
+			PLAN_BUSINESS_2_YEARS,
+		] );
+	} );
+} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `plans-features-main`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* Go to /plans and confirm that it looks the same as on WordPress.com for:
    * WP.com
    * Jetpack sites 
    * Logged out users (you have to go to /start and click "next" a few times)
* In particular we are interested in the plans list being the same, so Free (or not), Personal, Premium, and Business. Also important thing is the ability to switch between monthly and yearly plans on jetpack plans page.