### PR TITLE
Framework: update getSiteFragment to handle /me/purchases paths

### DIFF
--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -27,6 +27,20 @@ export function getSiteFragment( path ) {
 	// There are 2 URL positions where we should look for the site fragment:
 	// last (most sections) and second-to-last (post ID is last in editor)
 
+	// Though, in some`/me/purchases` paths, it could also be in third position,
+	// right after the `/me/purchases/` part.
+	// e.g. /me/purchases/example.wordpress.com/foo/bar
+	if ( 0 === basePath.indexOf( '/me/purchases/' ) ) {
+		const piece = pieces[ 3 ]; // 0 is the empty string before the first `/`
+		if ( piece && -1 !== piece.indexOf( '.' ) ) {
+			return piece;
+		}
+		const numericPiece = parseInt( piece, 10 );
+		if ( Number.isSafeInteger( numericPiece ) ) {
+			return numericPiece;
+		}
+	}
+
 	// Check last and second-to-last piece for site slug
 	for ( let i = 2; i > 0; i-- ) {
 		const piece = pieces[ pieces.length - i ];

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -206,6 +206,26 @@ describe( 'route', function() {
 				expect( route.getSiteFragment( '/stats/day/1000000000000000000000' ) ).to.be.false;
 			} );
 		} );
+		describe( 'for me paths', function() {
+			test( 'should return the correct site fragment when working with purchases', function() {
+				expect(
+					route.getSiteFragment(
+						'/me/purchases/example.wordpress.com/12345678/cancel-privacy-protection'
+					)
+				).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/me/purchases/2916284/12345678/cancel-privacy-protection' )
+				).to.equal( 2916284 );
+				expect(
+					route.getSiteFragment(
+						'/me/purchases/example.wordpress.com/12345678/payment/edit/87654321'
+					)
+				).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/me/purchases/2916284/12345678/payment/edit/87654321' )
+				).to.equal( 2916284 );
+			} );
+		} );
 	} );
 
 	describe( 'addSiteFragment', function() {

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -206,8 +206,16 @@ describe( 'route', function() {
 				expect( route.getSiteFragment( '/stats/day/1000000000000000000000' ) ).to.be.false;
 			} );
 		} );
-		describe( 'for me paths', function() {
+		describe( 'for purchases paths', function() {
 			test( 'should return the correct site fragment when working with purchases', function() {
+				expect( route.getSiteFragment( '/me/purchases/example.wordpress.com' ) ).to.equal(
+					'example.wordpress.com'
+				);
+				expect( route.getSiteFragment( '/me/purchases/2916284' ) ).to.equal( 2916284 );
+				expect( route.getSiteFragment( '/me/purchases/example.wordpress.com/cancel' ) ).to.equal(
+					'example.wordpress.com'
+				);
+				expect( route.getSiteFragment( '/me/purchases/2916284/cancel' ) ).to.equal( 2916284 );
 				expect(
 					route.getSiteFragment(
 						'/me/purchases/example.wordpress.com/12345678/cancel-privacy-protection'


### PR DESCRIPTION
While working on improving [analytics tracking for `/me/purchases` paths](https://github.com/Automattic/wp-calypso/pull/23647), we noticed that the site fragment is positioned oddly in some of those paths.

In theory, the site fragment should only be positioned as the [last or second-to-last part of the path](https://github.com/Automattic/wp-calypso/blob/master/client/lib/route/path.js#L27-L28).

Some (not all!) `/me/purchases` paths instead, put it in third position (from the beginning):
- `/me/purchases/:site/:purchaseId/cancel-privacy-protection`
- `/me/purchases/:site/:purchaseId/payment/edit/:cardId`

In these cases, `getSiteFragment` returns the incorrect value (e.g. the purchase ID or the card ID).

This PR adds an additional check to `getSiteFragment`: if the path begins with `/me/purchases`, check if the third part of the path is a site fragment before searching anywhere else.