### PR TITLE
Post Editor: reduxify editing discussion options 

### DIFF
--- a/client/post-editor/editor-discussion/index.jsx
+++ b/client/post-editor/editor-discussion/index.jsx
@@ -8,15 +8,20 @@ import { get, identity, pick } from 'lodash';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import EditorFieldset from 'post-editor/editor-fieldset';
 import FormCheckbox from 'components/forms/form-checkbox';
-import PostActions from 'lib/posts/actions';
 import InfoPopover from 'components/info-popover';
 import { recordEvent, recordStat } from 'lib/posts/stats';
+import { editPost } from 'state/posts/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getSite } from 'state/sites/selectors';
+import { getEditedPost } from 'state/posts/selectors';
 
 function booleanToStatus( bool ) {
 	return bool ? 'open' : 'closed';
@@ -39,7 +44,7 @@ export class EditorDiscussion extends React.Component {
 		translate: identity,
 	};
 
-	getDiscussionSetting = () => {
+	getDiscussionSetting() {
 		if ( this.props.post && this.props.post.discussion ) {
 			return this.props.post.discussion;
 		}
@@ -57,18 +62,18 @@ export class EditorDiscussion extends React.Component {
 		}
 
 		return {};
-	};
+	}
 
 	onChange = event => {
-		var discussion = pick( this.getDiscussionSetting(), 'comment_status', 'ping_status' ),
-			newStatus = booleanToStatus( event.target.checked ),
-			discussionType = event.target.name,
-			statName,
-			gaEvent;
+		const discussion = pick( this.getDiscussionSetting(), 'comment_status', 'ping_status' );
+		const newStatus = booleanToStatus( event.target.checked );
+		const discussionType = event.target.name;
+		let statName, gaEvent;
 
 		discussion[ discussionType ] = newStatus;
 
-		// There are other ways to construct these strings, but keeping them exactly as they are displayed in mc/ga aids in discovery via grok
+		// There are other ways to construct these strings, but keeping them exactly as they are
+		// displayed in mc/ga aids in discovery via grok
 		if ( 'comment_status' === discussionType ) {
 			statName = event.target.checked
 				? 'advanced_comments_open_enabled'
@@ -84,14 +89,13 @@ export class EditorDiscussion extends React.Component {
 		recordStat( statName );
 		recordEvent( gaEvent, newStatus );
 
-		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		PostActions.edit( {
-			discussion: discussion,
-		} );
+		const siteId = get( this.props.site, 'ID', null );
+		const postId = get( this.props.post, 'ID', null );
+		this.props.editPost( siteId, postId, { discussion } );
 	};
 
 	render() {
-		var discussion = this.getDiscussionSetting();
+		const discussion = this.getDiscussionSetting();
 
 		return (
 			<EditorFieldset legend={ this.props.translate( 'Discussion' ) }>
@@ -130,4 +134,15 @@ export class EditorDiscussion extends React.Component {
 	}
 }
 
-export default localize( EditorDiscussion );
+export default connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
+		const postId = getEditorPostId( state );
+
+		return {
+			site: getSite( state, siteId ),
+			post: getEditedPost( state, siteId, postId ),
+		};
+	},
+	{ editPost }
+)( localize( EditorDiscussion ) );

--- a/client/post-editor/editor-discussion/test/index.jsx
+++ b/client/post-editor/editor-discussion/test/index.jsx
@@ -7,6 +7,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import sinon from 'sinon';
 import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import ReactDom from 'react-dom';
@@ -15,12 +16,8 @@ import ReactDom from 'react-dom';
  * Internal dependencies
  */
 import { EditorDiscussion } from '../';
-import { edit as editPost } from 'lib/posts/actions';
 
 jest.mock( 'components/info-popover', () => require( 'components/empty-component' ) );
-jest.mock( 'lib/posts/actions', () => ( {
-	edit: require( 'sinon' ).spy(),
-} ) );
 jest.mock( 'lib/posts/stats', () => ( {
 	recordEvent: () => {},
 	recordStat: () => {},
@@ -30,6 +27,7 @@ jest.mock( 'lib/posts/stats', () => ( {
  * Module variables
  */
 const DUMMY_SITE = {
+	ID: 1,
 	options: {
 		default_comment_status: true,
 		default_ping_status: false,
@@ -49,18 +47,12 @@ describe( 'EditorDiscussion', function() {
 		} );
 
 		test( 'should return the site default comments open if site exists and post is new', () => {
-			const site = {
-					options: {
-						default_comment_status: true,
-						default_ping_status: false,
-					},
-				},
-				post = {
-					type: 'post',
-				};
+			const post = {
+				type: 'post',
+			};
 
 			const tree = TestUtils.renderIntoDocument(
-				<EditorDiscussion site={ site } post={ post } isNew />
+				<EditorDiscussion site={ DUMMY_SITE } post={ post } isNew />
 			);
 
 			expect( tree.getDiscussionSetting() ).to.eql( {
@@ -138,12 +130,9 @@ describe( 'EditorDiscussion', function() {
 		};
 
 		test( 'should include modified comment status on the post object', () => {
+			const editPost = sinon.spy();
 			const tree = TestUtils.renderIntoDocument(
-				<EditorDiscussion
-					post={ post }
-					site={ DUMMY_SITE }
-					setDiscussionSettings={ function() {} }
-				/>
+				<EditorDiscussion post={ post } site={ DUMMY_SITE } editPost={ editPost } />
 			);
 			const checkbox = ReactDom.findDOMNode( tree ).querySelector( '[name=ping_status]' );
 			TestUtils.Simulate.change( checkbox, {
@@ -153,7 +142,7 @@ describe( 'EditorDiscussion', function() {
 				},
 			} );
 
-			expect( editPost ).to.have.been.calledWith( {
+			expect( editPost ).to.have.been.calledWith( DUMMY_SITE.ID, null, {
 				discussion: {
 					comment_status: 'open',
 					ping_status: 'open',
@@ -162,12 +151,9 @@ describe( 'EditorDiscussion', function() {
 		} );
 
 		test( 'should include modified ping status on the post object', () => {
+			const editPost = sinon.spy();
 			const tree = TestUtils.renderIntoDocument(
-				<EditorDiscussion
-					post={ post }
-					site={ DUMMY_SITE }
-					setDiscussionSettings={ function() {} }
-				/>
+				<EditorDiscussion post={ post } site={ DUMMY_SITE } editPost={ editPost } />
 			);
 			const checkbox = ReactDom.findDOMNode( tree ).querySelector( '[name=ping_status]' );
 			TestUtils.Simulate.change( checkbox, {
@@ -177,7 +163,7 @@ describe( 'EditorDiscussion', function() {
 				},
 			} );
 
-			expect( editPost ).to.have.been.calledWith( {
+			expect( editPost ).to.have.been.calledWith( DUMMY_SITE.ID, null, {
 				discussion: {
 					comment_status: 'closed',
 					ping_status: 'closed',

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -237,12 +237,7 @@ class EditorDrawer extends Component {
 
 		return (
 			<AccordionSection>
-				<AsyncLoad
-					require="post-editor/editor-discussion"
-					site={ this.props.site }
-					post={ this.props.post }
-					isNew={ this.props.isNew }
-				/>
+				<AsyncLoad require="post-editor/editor-discussion" isNew={ this.props.isNew } />
 			</AccordionSection>
 		);
 	}

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -48,6 +48,7 @@ import revisions from './revisions/reducer';
 import {
 	getSerializedPostsQuery,
 	isTermsEqual,
+	isDiscussionEqual,
 	mergeIgnoringArrays,
 	normalizePostForState,
 } from './utils';
@@ -417,8 +418,11 @@ export function edits( state = {}, action ) {
 						memoState,
 						[ post.site_ID, post.ID ],
 						omitBy( postEdits, ( value, key ) => {
-							if ( key === 'terms' ) {
-								return isTermsEqual( value, post[ key ] );
+							switch ( key ) {
+								case 'terms':
+									return isTermsEqual( value, post[ key ] );
+								case 'discussion':
+									return isDiscussionEqual( value, post[ key ] );
 							}
 							return isEqual( post[ key ], value );
 						} )

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -15,6 +15,7 @@ import {
 	getSerializedPostsQuery,
 	getDeserializedPostsQueryDetails,
 	getSerializedPostsQueryWithoutPage,
+	isDiscussionEqual,
 	mergeIgnoringArrays,
 	normalizePostForEditing,
 	normalizePostForDisplay,
@@ -415,6 +416,9 @@ export const isEditedPostDirty = createSelector(
 					}
 					case 'parent': {
 						return get( post, 'parent.ID', 0 ) !== value;
+					}
+					case 'discussion': {
+						return ! isDiscussionEqual( value, post.discussion );
 					}
 				}
 				return post[ key ] !== value;

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -1117,6 +1117,94 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		test( 'should remove discussion edits after they are saved', () => {
+			const state = edits(
+				deepFreeze( {
+					2916284: {
+						841: {
+							title: 'Hello World',
+							type: 'post',
+							discussion: {
+								comment_status: 'open',
+								ping_status: 'open',
+							},
+						},
+					},
+				} ),
+				{
+					type: POSTS_RECEIVE,
+					posts: [
+						{
+							ID: 841,
+							site_ID: 2916284,
+							type: 'post',
+							title: 'Hello',
+							discussion: {
+								comment_status: 'open',
+								comments_open: true,
+								ping_status: 'open',
+								pings_open: true,
+							},
+						},
+					],
+				}
+			);
+
+			expect( state ).to.eql( {
+				2916284: {
+					841: {
+						title: 'Hello World',
+					},
+				},
+			} );
+		} );
+
+		test( 'should keep discussion edits if they are not yet present in the saved post', () => {
+			const state = edits(
+				deepFreeze( {
+					2916284: {
+						841: {
+							title: 'Hello World',
+							type: 'post',
+							discussion: {
+								comment_status: 'closed',
+								ping_status: 'open',
+							},
+						},
+					},
+				} ),
+				{
+					type: POSTS_RECEIVE,
+					posts: [
+						{
+							ID: 841,
+							site_ID: 2916284,
+							type: 'post',
+							title: 'Hello',
+							discussion: {
+								comment_status: 'open',
+								comments_open: true,
+								ping_status: 'open',
+								pings_open: true,
+							},
+						},
+					],
+				}
+			);
+
+			expect( state ).to.eql( {
+				2916284: {
+					841: {
+						title: 'Hello World',
+						discussion: {
+							comment_status: 'closed',
+							ping_status: 'open',
+						},
+					},
+				},
+			} );
+		} );
+
 		test( "should ignore reset edits action when discarded site doesn't exist", () => {
 			const original = deepFreeze( {} );
 			const state = edits( original, {

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -1954,6 +1954,86 @@ describe( 'selectors', () => {
 
 			expect( isDirty ).to.be.false;
 		} );
+
+		test( 'should return true if discussion options change', () => {
+			const isDirty = isEditedPostDirty(
+				{
+					posts: {
+						queries: {
+							2916284: new PostQueryManager( {
+								items: {
+									841: {
+										ID: 841,
+										site_ID: 2916284,
+										global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+										discussion: {
+											comment_status: 'open',
+											comments_open: true,
+											ping_status: 'open',
+											pings_open: true,
+										},
+									},
+								},
+							} ),
+						},
+						edits: {
+							2916284: {
+								841: {
+									discussion: {
+										comment_status: 'closed',
+										ping_status: 'open',
+									},
+								},
+							},
+						},
+					},
+				},
+				2916284,
+				841
+			);
+
+			expect( isDirty ).to.be.true;
+		} );
+
+		test( "should return false if discussion options didn't change", () => {
+			const isDirty = isEditedPostDirty(
+				{
+					posts: {
+						queries: {
+							2916284: new PostQueryManager( {
+								items: {
+									841: {
+										ID: 841,
+										site_ID: 2916284,
+										global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+										discussion: {
+											comment_status: 'open',
+											comments_open: true,
+											ping_status: 'open',
+											pings_open: true,
+										},
+									},
+								},
+							} ),
+						},
+						edits: {
+							2916284: {
+								841: {
+									discussion: {
+										comment_status: 'open',
+										ping_status: 'open',
+									},
+								},
+							},
+						},
+					},
+				},
+				2916284,
+				841
+			);
+
+			expect( isDirty ).to.be.false;
+		} );
 	} );
 
 	describe( 'getPostPreviewUrl()', () => {

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -5,6 +5,7 @@
  */
 
 import {
+	get,
 	isEmpty,
 	isPlainObject,
 	flow,
@@ -282,6 +283,18 @@ export function isTermsEqual( localTermEdits, savedTerms ) {
 		const normalizedSavedTerms = map( savedTerms[ taxonomy ], normalizedKey );
 		return ! xor( normalizedEditedTerms, normalizedSavedTerms ).length;
 	} );
+}
+
+/**
+ * Returns true if the modified properties in the local edit of the `discussion` object (the edited
+ * properties are a subset of the full object) are equal to the values in the saved post.
+ *
+ * @param  {Object}  localDiscussionEdits local state of discussion edits
+ * @param  {Object}  savedDiscussion      discussion property returned from API POST
+ * @return {Boolean}                      are there differences in local edits vs saved values?
+ */
+export function isDiscussionEqual( localDiscussionEdits, savedDiscussion ) {
+	return every( localDiscussionEdits, ( value, key ) => get( savedDiscussion, [ key ] ) === value );
 }
 
 /**


### PR DESCRIPTION
This PR migrates the `EditorDiscussion` component to Redux.

Before this patch, the component retrieved the edited post from the Flux `PostEditStore`. It was passed down as a `post` prop all the way from `PostEditor`, where its maintained as part of local state. And on change, it dispatched the `PostActions.edit` Flux action.

After this patch, the edited post is retrieved by Redux selectors and a Redux `editPost` action is used to make changes.

The Post Editor uses a combination of Flux and Redux to store and perform post edits: some edits are stored in Flux, some are in Redux and the process of editing and saving is carefully coordinated.

**How to test:**
Start editing either a brand new or an existing post. Try to change its discussion settings:
<img width="272" alt="post-discussion-good" src="https://user-images.githubusercontent.com/664258/38089067-775c5db2-335e-11e8-8a09-913e51034ace.png">

Verify that:
1. The changes get saved.
2. After toggling a checkbox, a "Save" button appears in the editor's top toolbar and it disappears after successful save.
3. After successful save, the "local edits" in `state.posts.edits` are cleared (no `discussion` property there any more) and that on subsequent saves (of other changes), the `discussion` property is not in the save request for a second time.
4. After toggling and untoggling a checkbox, the "Save" button should be active and then unactive again.

The proper behavior in steps 2, 3 and 4 depends on the reducer and selectors correctly updating the post edits after save and correctly determining the "dirty" state.