### PR TITLE
Help: remove `inlineHelpWithContactForm` a/b test

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -13,7 +13,6 @@ import Gridicon from 'gridicons';
 /**
  * Internal Dependencies
  */
-import { abtest } from 'lib/abtest';
 import { recordTracksEvent } from 'state/analytics/actions';
 import Button from 'components/button';
 import Popover from 'components/popover';
@@ -67,7 +66,6 @@ class InlineHelpPopover extends Component {
 		const { translate } = this.props;
 		const { showContactForm } = this.state;
 		const popoverClasses = { 'is-help-active': showContactForm };
-		const showContactButton = abtest( 'inlineHelpWithContactForm' ) === 'inlinecontact';
 
 		return (
 			<Popover
@@ -100,17 +98,15 @@ class InlineHelpPopover extends Component {
 						{ translate( 'More help' ) }
 					</Button>
 
-					{ showContactButton && (
-						<Button
-							onClick={ this.toggleContactForm }
-							className="inline-help__contact-button"
-							borderless
-						>
-							<Gridicon icon="chat" className="inline-help__gridicon-left" />
-							{ translate( 'Contact us' ) }
-							<Gridicon icon="chevron-right" className="inline-help__gridicon-right" />
-						</Button>
-					) }
+					<Button
+						onClick={ this.toggleContactForm }
+						className="inline-help__contact-button"
+						borderless
+					>
+						<Gridicon icon="chat" className="inline-help__gridicon-left" />
+						{ translate( 'Contact us' ) }
+						<Gridicon icon="chevron-right" className="inline-help__gridicon-right" />
+					</Button>
 
 					<Button
 						onClick={ this.toggleContactForm }

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -101,15 +101,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	inlineHelpWithContactForm: {
-		datestamp: '20180306',
-		variations: {
-			original: 0,
-			inlinecontact: 100,
-		},
-		defaultVariation: 'original',
-		allowExistingUsers: true,
-	},
 	mobilePlansTablesOnSignup: {
 		datestamp: '20180320',
 		variations: {


### PR DESCRIPTION
We've been running the `inlineHelpWithContactForm` test at 100% for about two days now and didn't notice any adverse impact so far. This PR removes the test completely so that all users — even those who had gotten assigned to the `original` variation before — will see the contact form in Inline Help. 

See Automattic/wp-e2e-tests#1106 for the necessary change to the e2e tests. 