### PR TITLE
NPS: Show the NPS survey form immediately

### DIFF
--- a/client/layout/nps-survey-notice/index.jsx
+++ b/client/layout/nps-survey-notice/index.jsx
@@ -13,12 +13,15 @@ import { connect } from 'react-redux';
 import Dialog from 'components/dialog';
 import NpsSurvey from 'blocks/nps-survey';
 import {
-	showNpsSurveyNotice,
 	setNpsSurveyDialogShowing,
 	setupNpsSurveyDevTrigger,
 } from 'state/ui/nps-survey-notice/actions';
 import { isNpsSurveyDialogShowing } from 'state/ui/nps-survey-notice/selectors';
-import { submitNpsSurveyWithNoScore, setupNpsSurveyEligibility } from 'state/nps-survey/actions';
+import {
+	submitNpsSurveyWithNoScore,
+	setupNpsSurveyEligibility,
+	markNpsSurveyShownThisSession,
+} from 'state/nps-survey/actions';
 import {
 	hasAnsweredNpsSurvey,
 	hasAnsweredNpsSurveyWithNoScore,
@@ -58,7 +61,8 @@ class NpsSurveyNotice extends Component {
 			// (1) the user gets a chance to look briefly at the uncluttered screen, and
 			// (2) the user notices the notice more, since it will cause a change to the
 			//     screen they are already looking at
-			setTimeout( this.props.showNpsSurveyNotice, 3000 );
+			this.props.setNpsSurveyDialogShowing( true );
+			this.props.markNpsSurveyShownThisSession();
 
 			analytics.mc.bumpStat( 'calypso_nps_survey', 'notice_displayed' );
 			analytics.tracks.recordEvent( 'calypso_nps_notice_displayed' );
@@ -91,9 +95,9 @@ const mapStateToProps = state => {
 };
 
 export default connect( mapStateToProps, {
-	showNpsSurveyNotice,
 	setNpsSurveyDialogShowing,
 	submitNpsSurveyWithNoScore,
 	setupNpsSurveyDevTrigger,
 	setupNpsSurveyEligibility,
+	markNpsSurveyShownThisSession,
 } )( NpsSurveyNotice );

--- a/client/state/ui/nps-survey-notice/actions.js
+++ b/client/state/ui/nps-survey-notice/actions.js
@@ -1,41 +1,11 @@
 /** @format */
 
 /**
- * External dependencies
- */
-
-import { translate } from 'i18n-calypso';
-
-/**
  * Internal dependencies
  */
 import config from 'config';
-import notices from 'notices';
 import { NPS_SURVEY_DIALOG_IS_SHOWING } from 'state/action-types';
-import { setNpsSurveyEligibility, markNpsSurveyShownThisSession } from 'state/nps-survey/actions';
-
-export function showNpsSurveyNotice() {
-	return dispatch => {
-		const options = {
-			button: translate( 'Sure!' ),
-			onClick: ( event, closeFn ) => {
-				closeFn();
-				dispatch( setNpsSurveyDialogShowing( true ) );
-			},
-		};
-
-		// NOTE: It would be nice to move to dispatching the `createNotice` action,
-		// but that currently doesn't support notices with `button` and `onClick`
-		// options.
-		notices.new(
-			translate( 'Would you mind answering a question about WordPress.com?' ),
-			options,
-			'is-info'
-		);
-
-		dispatch( markNpsSurveyShownThisSession() );
-	};
-}
+import { setNpsSurveyEligibility } from 'state/nps-survey/actions';
 
 export function setNpsSurveyDialogShowing( isShowing ) {
 	return {


### PR DESCRIPTION
This PR will show the NPS survey form immediately without user opt-in to get as many users as possible to take the survey. This is a part of the NPS v2 project. You can see more details of the project on p9jf6J-h6-p2

## Test plan

Go to the Reader page and run `npsSurvey()` in the browser console. You should be able to see the NPS survey form without any notifications.