### PR TITLE
JP Settings: Implement regeneratePostByEmail() using saveJetpackSettings()

### DIFF
--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -117,10 +117,10 @@ export const saveJetpackSettings = ( { dispatch }, action ) => {
 	);
 };
 
-// Although we don't use the save success action in any of the reducers,
-// we need to dispatch some action in order to signal to the data layer that
+// We need to dispatch some action in order to signal to the data layer that
 // the save request has finished. Tracking those requests is necessary for
 // displaying an up to date progress indicator for some steps.
+// We also need this to store a regenerated post-by-email address in Redux state.
 export const handleSaveSuccess = ( { dispatch }, { siteId, settings } ) =>
 	dispatch( saveJetpackSettingsSuccess( siteId, settings ) );
 

--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -121,8 +121,11 @@ export const saveJetpackSettings = ( { dispatch }, action ) => {
 // the save request has finished. Tracking those requests is necessary for
 // displaying an up to date progress indicator for some steps.
 // We also need this to store a regenerated post-by-email address in Redux state.
-export const handleSaveSuccess = ( { dispatch }, { siteId, settings } ) =>
-	dispatch( saveJetpackSettingsSuccess( siteId, settings ) );
+export const handleSaveSuccess = (
+	{ dispatch },
+	{ siteId },
+	{ data: { code, message, ...updatedSettings } } // eslint-disable-line no-unused-vars
+) => dispatch( saveJetpackSettingsSuccess( siteId, updatedSettings ) );
 
 export const announceSaveFailure = ( { dispatch }, { siteId } ) =>
 	dispatch(

--- a/client/state/data-layer/wpcom/jetpack/settings/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/test/index.js
@@ -235,7 +235,7 @@ describe( 'handleSaveSuccess()', () => {
 	};
 
 	test( 'should dispatch a save success action upon successful save request', () => {
-		handleSaveSuccess( { dispatch }, { siteId, settings } );
+		handleSaveSuccess( { dispatch }, { siteId }, { data: settings } );
 
 		expect( dispatch ).toHaveBeenCalledWith(
 			expect.objectContaining( saveJetpackSettingsSuccess( siteId, settings ) )

--- a/client/state/jetpack-onboarding/actions.js
+++ b/client/state/jetpack-onboarding/actions.js
@@ -50,3 +50,12 @@ export const updateJetpackSettings = ( siteId, settings ) => ( {
 	siteId,
 	settings,
 } );
+
+/**
+ * Regenerate the target email of Post by Email.
+ *
+ * @param  {Int}     siteId  ID of the site.
+ * @return {Object}          Action object to regenerate the email when dispatched.
+ */
+export const regeneratePostByEmail = siteId =>
+	saveJetpackSettings( siteId, { post_by_email_address: 'regenerate' } );

--- a/client/state/jetpack-onboarding/reducer.js
+++ b/client/state/jetpack-onboarding/reducer.js
@@ -13,6 +13,7 @@ import { jetpackOnboardingCredentialsSchema, jetpackSettingsSchema } from './sch
 import {
 	JETPACK_CONNECT_AUTHORIZE_RECEIVE,
 	JETPACK_ONBOARDING_CREDENTIALS_RECEIVE,
+	JETPACK_ONBOARDING_SETTINGS_SAVE_SUCCESS,
 	JETPACK_ONBOARDING_SETTINGS_UPDATE,
 } from 'state/action-types';
 
@@ -34,6 +35,15 @@ export const settingsReducer = keyedReducer(
 	createReducer(
 		{},
 		{
+			[ JETPACK_ONBOARDING_SETTINGS_SAVE_SUCCESS ]: (
+				state,
+				{ settings: { post_by_email_address } }
+			) => {
+				if ( post_by_email_address !== state.post_by_email_address ) {
+					return { ...state, post_by_email_address };
+				}
+				return state;
+			},
 			[ JETPACK_ONBOARDING_SETTINGS_UPDATE ]: ( state, { settings } ) =>
 				merge( {}, state, settings ),
 		},

--- a/client/state/jetpack-onboarding/test/actions.js
+++ b/client/state/jetpack-onboarding/test/actions.js
@@ -5,6 +5,7 @@
  */
 import {
 	receiveJetpackOnboardingCredentials,
+	regeneratePostByEmail,
 	requestJetpackSettings,
 	saveJetpackSettings,
 	saveJetpackSettingsSuccess,
@@ -107,6 +108,17 @@ describe( 'actions', () => {
 				siteId,
 				settings,
 			} );
+		} );
+	} );
+
+	describe( 'regeneratePostByEmail()', () => {
+		test( 'should return a jetpack settings update action object with settings set to regenerate post-by-email', () => {
+			const siteId = 12345678;
+			const action = regeneratePostByEmail( siteId );
+
+			expect( action ).toEqual(
+				saveJetpackSettings( siteId, { post_by_email_address: 'regenerate' } )
+			);
 		} );
 	} );
 } );

--- a/client/state/jetpack-onboarding/test/reducer.js
+++ b/client/state/jetpack-onboarding/test/reducer.js
@@ -13,6 +13,7 @@ import {
 	DESERIALIZE,
 	JETPACK_CONNECT_AUTHORIZE_RECEIVE,
 	JETPACK_ONBOARDING_CREDENTIALS_RECEIVE,
+	JETPACK_ONBOARDING_SETTINGS_SAVE_SUCCESS,
 	JETPACK_ONBOARDING_SETTINGS_UPDATE,
 	SERIALIZE,
 } from 'state/action-types';
@@ -205,6 +206,27 @@ describe( 'reducer', () => {
 			expect( state ).toEqual( {
 				...initialState,
 				[ siteId ]: newSettings,
+			} );
+		} );
+
+		test( 'should update post-by-email address after regenerating', () => {
+			const siteId = 12345678;
+			const newSettings = {
+				post_by_email_address: 'example1234@automattic.com',
+			};
+			const initialState = deepFreeze( {
+				[ siteId ]: settings,
+				[ 87654321 ]: settings,
+			} );
+			const state = settingsReducer( initialState, {
+				type: JETPACK_ONBOARDING_SETTINGS_SAVE_SUCCESS,
+				siteId,
+				settings: newSettings,
+			} );
+
+			expect( state ).toEqual( {
+				...initialState,
+				[ siteId ]: { ...settings, ...newSettings },
 			} );
 		} );
 


### PR DESCRIPTION
More prep for #23393. This only _implements_ `regeneratePostByEmail()` using `saveJetpackSettings()`. It doesn't however yet _use_ that new action to do anything, nor does it delete the old counterpart in `state/jetpack/settings/actions` -- that latter action is continued to use for JP settings.

The reason is that JP settings state is rather deeply entangled with `wrapSettingsForm`. We'd need to add a lot of selectors (including the `isRequesting...` type) to `wrapSettingsForm` to take both the new data-layer based `regeneratePostEmail` settings, and the old, non-data-layer-based other settings into account. Hence, that is deferred to #23793.

*Note that once `saveJetpackSettings()` uses the sanitization util (#23795), we need to exempt `post_by_email_address` from being removed if it's set to `regenerate` (#23796).*

### Implementation Note

Unfortunately, in our JP Settings data-layer handler, we're calling https://github.com/Automattic/wp-calypso/blob/e1a05cebff2ace7e412d617fa0638082975b5707/client/state/data-layer/wpcom/jetpack/settings/index.js#L94

_before_ the actual network request. This will set the `post_by_email_address` setting in Redux state to `regenerate`, rather than to the actually regenerated address that is returned as part of the network response 🙁 

The solution is to have the `jetpackOnboarding` reducer react appropriately to `JETPACK_ONBOARDING_SETTINGS_SAVE_SUCCESS`.

### Testing Instructions

* Make sure that JPO still works, since the reducer is now listening to `JETPACK_ONBOARDING_SETTINGS_SAVE_SUCCESS` -- we don't want it to mess up Redux state.
* Verify that tests pass

* If you want, you can also apply

```diff
diff --git a/client/my-sites/site-settings/publishing-tools/index.jsx b/client/my-sites/site-settings/publishing-tools/index.jsx
index 1b8c9d89eb22..ef5310d33edb 100644
--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -21,7 +21,7 @@ import FormLegend from 'components/forms/form-legend';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { regeneratePostByEmail } from 'state/jetpack/settings/actions';
+import { regeneratePostByEmail } from 'state/jetpack-onboarding/actions';
 import {
 	isJetpackModuleActive,
 	isJetpackModuleUnavailableInDevelopmentMode,
```
and navigate to  `calypso.localhost:3000/settings/writing/<yourJPsite>` to click the 'Regenerate' button below the 'Publish posts by sending an email' option. You won't see the email address in the text field change, but you can check the Redux log for the `JETPACK_ONBOARDING_SETTINGS_SAVE_SUCCESS` action's diff, which will update `state.jetpackOnboarding.settings[ siteId ].post_by_email_address` to the newly generated address.