### PR TITLE
Update StickyPanel to use the breakpoint mixin

### DIFF
--- a/client/components/sticky-panel/style.scss
+++ b/client/components/sticky-panel/style.scss
@@ -17,7 +17,7 @@
 	z-index: z-index( 'root', '.sticky-panel.is-sticky .sticky-panel__content' );
 }
 
-@media (max-width: 960px) {
+@include breakpoint( '<960px' ) {
 	.sticky-panel.is-sticky .sticky-panel__content {
 		margin-top: 8px;
 	}


### PR DESCRIPTION
This replaces a standard @media query with our breakpoint mixin. We should use the mixin wherever possible to ensure that we keep the number of breakpoints in our code to a minimum.

To test, go to stats, make your screen less than 960px wide, scroll down and verify that there is an 8px gap above the date panel.