### PR TITLE
2FA: Update the media query to use the breakpoint mixin

### DIFF
--- a/client/me/security-2fa-backup-codes-list/style.scss
+++ b/client/me/security-2fa-backup-codes-list/style.scss
@@ -20,7 +20,7 @@
 	}
 }
 
-@media (max-width: 480px) {
+@include breakpoint( '<480px' ) {
 	.security-2fa-backup-codes-list__btn-group .button {
 		display: inline-block;
 	}


### PR DESCRIPTION
This replaces a standard @media query with our breakpoint mixin. We should use the mixin wherever possible to ensure that we keep the number of breakpoints in our code to a minimum.

To test, go to http://calypso.localhost:3000/me/security/two-step codes and generate new backup codes. Then check that the buttons in this section look like this, when the screen is <480 pixels.
<img width="191" alt="screen shot 2018-03-29 at 17 39 59" src="https://user-images.githubusercontent.com/275961/38101494-5a495af8-3378-11e8-9396-006a1dfaec50.png">

and not like this:

<img width="181" alt="screen shot 2018-03-29 at 17 40 05" src="https://user-images.githubusercontent.com/275961/38101496-5f67fa6c-3378-11e8-993b-ca15ea2848b3.png">
