### PR TITLE
Automated Transfers: Plugin Blacklist Update 2018-03-29

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -248,6 +248,7 @@ class PluginMeta extends Component {
 			'wp-db-backup',
 
 			// caching
+			'comet-cache',
 			'quick-cache',
 			'w3-total-cache',
 			'wp-cache',
@@ -256,8 +257,11 @@ class PluginMeta extends Component {
 			'wp-super-cache',
 
 			// sql heavy
+			'another-wordpress-classifieds-plugin',
+			'native-ads-adnow',
 			'page-visit-counter',
 			'post-views-counter',
+			'tokenad',
 			'wp-postviews',
 			'wp-statistics',
 


### PR DESCRIPTION
This PR updates list of plugins blacklisted for AT to match corresponding `wpcomsh` changes.