### PR TITLE
Tidy up checkout styles

### DIFF
--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -747,13 +747,6 @@
 	float: right;
 }
 .checkout__payment-box-container {
-
-	.checkout__payment-box-title {
-		padding: 20px 16px 14px 20px;
-		font-weight: bold;
-		display: none;
-	}
-
 	.select-dropdown__option {
 		&:first-child {
 			display: none;
@@ -772,6 +765,7 @@
 		}
 
 		.section-nav-tab__link {
+			background: transparent;
 			color: $blue-wordpress;
 			font-weight: bold;
 		}
@@ -850,25 +844,7 @@
 		}
 	}
 
-	@media (min-width: 481px) {
-		div.section-nav {
-			.section-nav-tabs__list {
-				.checkout__payment-box-title {
-					display: block;
-				}
-			}
-			.section-nav-tab {
-				&.is-selected {
-					.section-nav-tab__link {
-						color: $blue-wordpress;
-						background-color: transparent;
-					}
-				}
-			}
-		}
-	}
-
-	@media (max-width: 480px) {
+	@include breakpoint( '<480px' ) {
 		.is-open .section-nav__panel {
 			padding-bottom: 0;
 		}


### PR DESCRIPTION
This PR removes some unused CSS from checkout and replaces a vanilla media query with our breakpoints mixin.

Checkout should look the same. To test, add something to your cart (go to /plans) and then proceed to checkout, and make your screen <480px wide:

The tabs should look like this on mobile:
<img width="278" alt="screen shot 2018-03-29 at 17 54 04" src="https://user-images.githubusercontent.com/275961/38102476-4352f1da-337b-11e8-810c-71d2812e26d3.png">

Not like this:
<img width="279" alt="screen shot 2018-03-29 at 17 53 58" src="https://user-images.githubusercontent.com/275961/38102491-4e73920e-337b-11e8-8d7c-2ab910f0846f.png">

Or this:
<img width="273" alt="screen shot 2018-03-29 at 17 53 43" src="https://user-images.githubusercontent.com/275961/38102504-5edd6372-337b-11e8-9bc7-780c5d68f649.png">