### PR TITLE
Analytics: Remove broken and unused `site_post_count` property.

### DIFF
--- a/client/lib/analytics/super-props.js
+++ b/client/lib/analytics/super-props.js
@@ -29,7 +29,6 @@ export default {
 
 				site_id_label: selectedSite.jetpack ? 'jetpack' : 'wpcom',
 				site_plan_id: selectedSite.plan ? selectedSite.plan.product_id : null,
-				site_post_count: selectedSite.post_count,
 			};
 		}
 


### PR DESCRIPTION
The super prop `site_post_count` has been broken for almost a year (#14096). Since it's not currently in use (last Tracks funnel was run February 2106, p10gg3-8y9-p2), and adding the field back into the `/me/sites` call can [affect performance](https://github.com/Automattic/wp-calypso/pull/23609#issuecomment-377022933), let's just remove it.

![undefined](https://user-images.githubusercontent.com/349751/38103659-d6db55b8-333b-11e8-89e8-2c849a348928.png)

Fixes #23778 .

Testing
* set `localStorage.setItem('debug', 'calypso:analytics:tracks')`
* trigger a page view stat (visit any site-specific page)
* the `site_post_count` prop shouldn't be there anymore, as opposed to showing as `undefined`