### PR TITLE
[Domains] Refactor helper functions out of RegisterDomainStep component

### DIFF
--- a/client/components/domains/register-domain-step/analytics.js
+++ b/client/components/domains/register-domain-step/analytics.js
@@ -1,0 +1,86 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
+
+export const recordMapDomainButtonClick = section =>
+	composeAnalytics(
+		recordGoogleEvent( 'Domain Search', 'Clicked "Map it" Button' ),
+		recordTracksEvent( 'calypso_domain_search_results_mapping_button_click', { section } )
+	);
+
+export const recordTransferDomainButtonClick = ( section, source ) =>
+	composeAnalytics(
+		recordGoogleEvent( 'Domain Search', 'Clicked "Use a Domain I own" Button' ),
+		recordTracksEvent( 'calypso_domain_search_results_transfer_button_click', { section, source } )
+	);
+
+export const recordSearchFormSubmit = (
+	searchBoxValue,
+	section,
+	timeDiffFromLastSearch,
+	count,
+	vendor
+) =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Search',
+			'Submitted Search Form',
+			'Search Box Value',
+			searchBoxValue
+		),
+		recordTracksEvent( 'calypso_domain_search', {
+			search_box_value: searchBoxValue,
+			seconds_from_last_search: timeDiffFromLastSearch,
+			search_count: count,
+			search_vendor: vendor,
+			section,
+		} )
+	);
+
+export const recordSearchFormView = section =>
+	composeAnalytics(
+		recordGoogleEvent( 'Domain Search', 'Landed on Search' ),
+		recordTracksEvent( 'calypso_domain_search_pageview', { section } )
+	);
+
+export const recordSearchResultsReceive = (
+	searchQuery,
+	searchResults,
+	responseTimeInMs,
+	resultCount,
+	section
+) =>
+	composeAnalytics(
+		recordGoogleEvent( 'Domain Search', 'Receive Results', 'Response Time', responseTimeInMs ),
+		recordTracksEvent( 'calypso_domain_search_results_suggestions_receive', {
+			search_query: searchQuery,
+			results: searchResults.join( ';' ),
+			response_time_ms: responseTimeInMs,
+			result_count: resultCount,
+			section,
+		} )
+	);
+
+export const recordDomainAvailabilityReceive = (
+	searchQuery,
+	availableStatus,
+	responseTimeInMs,
+	section
+) =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Search',
+			'Domain Availability Result',
+			'Domain Available Status',
+			availableStatus
+		),
+		recordTracksEvent( 'calypso_domain_search_results_availability_receive', {
+			search_query: searchQuery,
+			available_status: availableStatus,
+			response_time: responseTimeInMs,
+			section,
+		} )
+	);

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -50,8 +50,22 @@ import {
 	getDomainsSuggestions,
 	getDomainsSuggestionsError,
 } from 'state/domains/suggestions/selectors';
-import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
+
 import { abtest } from 'lib/abtest';
+import {
+	getStrippedDomainBase,
+	getTldWeightOverrides,
+	isFreeOrUnknownSuggestion,
+	isNumberString,
+} from 'components/domains/register-domain-step/utility';
+import {
+	recordDomainAvailabilityReceive,
+	recordMapDomainButtonClick,
+	recordSearchFormSubmit,
+	recordSearchFormView,
+	recordSearchResultsReceive,
+	recordTransferDomainButtonClick,
+} from 'components/domains/register-domain-step/analytics';
 
 const domains = wpcom.domains();
 
@@ -67,10 +81,6 @@ let searchStackTimer = null;
 let lastSearchTimestamp = null;
 let searchCount = 0;
 let recordSearchFormSubmitWithDispatch;
-
-function isNumberString( string ) {
-	return /^[0-9_]+$/.test( string );
-}
 
 function getQueryObject( props ) {
 	if ( ! props.selectedSite || ! props.selectedSite.domain ) {
@@ -223,7 +233,7 @@ class RegisterDomainStep extends React.Component {
 		}
 
 		if ( error && error.error ) {
-			//don't modify global state
+			// don't modify global state
 			const queryObject = getQueryObject( nextProps );
 			if ( queryObject ) {
 				this.showValidationErrorMessage( queryObject.query, error.error );
@@ -411,12 +421,6 @@ class RegisterDomainStep extends React.Component {
 		);
 	};
 
-	getTldWeightOverrides() {
-		const { designType } = this.props;
-
-		return designType && designType === 'blog' ? 'design_type_blog' : null;
-	}
-
 	checkDomainAvailability = ( domain, timestamp ) => {
 		if (
 			! domain.match(
@@ -482,7 +486,7 @@ class RegisterDomainStep extends React.Component {
 			quantity: suggestionQuantity,
 			include_wordpressdotcom: false,
 			include_dotblogsubdomain: false,
-			tld_weight_overrides: this.getTldWeightOverrides(),
+			tld_weight_overrides: getTldWeightOverrides( this.props.designType ),
 			vendor: searchVendor,
 			vertical: this.props.surveyVertical,
 			...this.getActiveFiltersForAPI(),
@@ -543,15 +547,13 @@ class RegisterDomainStep extends React.Component {
 			return suggestion.domain_name;
 		} );
 
-		const isFreeOrUnknown = suggestion =>
-			suggestion.is_free === true || suggestion.status === domainAvailability.UNKNOWN;
-		const strippedDomainBase = this.getStrippedDomainBase( domain );
+		const strippedDomainBase = getStrippedDomainBase( domain );
 		const exactMatchBeforeTld = suggestion =>
 			suggestion.domain_name === this.state.exactMatchDomain ||
 			startsWith( suggestion.domain_name, `${ strippedDomainBase }.` );
 		const bestAlternative = suggestion =>
 			! exactMatchBeforeTld( suggestion ) && suggestion.isRecommended !== true;
-		const availableSuggestions = reject( suggestions, isFreeOrUnknown );
+		const availableSuggestions = reject( suggestions, isFreeOrUnknownSuggestion );
 
 		const recommendedSuggestion = find( availableSuggestions, exactMatchBeforeTld );
 		if ( recommendedSuggestion ) {
@@ -683,16 +685,6 @@ class RegisterDomainStep extends React.Component {
 			this.getSubdomainSuggestions( domain, timestamp );
 		}
 	};
-
-	getStrippedDomainBase( domain ) {
-		let strippedDomainBase = domain;
-		const lastIndexOfDot = strippedDomainBase.lastIndexOf( '.' );
-
-		if ( lastIndexOfDot !== -1 ) {
-			strippedDomainBase = strippedDomainBase.substring( 0, lastIndexOfDot );
-		}
-		return strippedDomainBase.replace( /[ .]/g, '' );
-	}
 
 	initialSuggestions() {
 		let domainRegistrationSuggestions;
@@ -883,80 +875,6 @@ class RegisterDomainStep extends React.Component {
 		this.setState( { notice: message, noticeSeverity: severity } );
 	}
 }
-
-const recordMapDomainButtonClick = section =>
-	composeAnalytics(
-		recordGoogleEvent( 'Domain Search', 'Clicked "Map it" Button' ),
-		recordTracksEvent( 'calypso_domain_search_results_mapping_button_click', { section } )
-	);
-
-const recordTransferDomainButtonClick = ( section, source ) =>
-	composeAnalytics(
-		recordGoogleEvent( 'Domain Search', 'Clicked "Use a Domain I own" Button' ),
-		recordTracksEvent( 'calypso_domain_search_results_transfer_button_click', { section, source } )
-	);
-
-const recordSearchFormSubmit = ( searchBoxValue, section, timeDiffFromLastSearch, count, vendor ) =>
-	composeAnalytics(
-		recordGoogleEvent(
-			'Domain Search',
-			'Submitted Search Form',
-			'Search Box Value',
-			searchBoxValue
-		),
-		recordTracksEvent( 'calypso_domain_search', {
-			search_box_value: searchBoxValue,
-			seconds_from_last_search: timeDiffFromLastSearch,
-			search_count: count,
-			search_vendor: vendor,
-			section,
-		} )
-	);
-
-const recordSearchFormView = section =>
-	composeAnalytics(
-		recordGoogleEvent( 'Domain Search', 'Landed on Search' ),
-		recordTracksEvent( 'calypso_domain_search_pageview', { section } )
-	);
-
-const recordSearchResultsReceive = (
-	searchQuery,
-	searchResults,
-	responseTimeInMs,
-	resultCount,
-	section
-) =>
-	composeAnalytics(
-		recordGoogleEvent( 'Domain Search', 'Receive Results', 'Response Time', responseTimeInMs ),
-		recordTracksEvent( 'calypso_domain_search_results_suggestions_receive', {
-			search_query: searchQuery,
-			results: searchResults.join( ';' ),
-			response_time_ms: responseTimeInMs,
-			result_count: resultCount,
-			section,
-		} )
-	);
-
-const recordDomainAvailabilityReceive = (
-	searchQuery,
-	availableStatus,
-	responseTimeInMs,
-	section
-) =>
-	composeAnalytics(
-		recordGoogleEvent(
-			'Domain Search',
-			'Domain Availability Result',
-			'Domain Available Status',
-			availableStatus
-		),
-		recordTracksEvent( 'calypso_domain_search_results_availability_receive', {
-			search_query: searchQuery,
-			available_status: availableStatus,
-			response_time: responseTimeInMs,
-			section,
-		} )
-	);
 
 export default connect(
 	( state, props ) => {

--- a/client/components/domains/register-domain-step/utility.js
+++ b/client/components/domains/register-domain-step/utility.js
@@ -1,0 +1,30 @@
+/**
+ * @format
+ */
+
+/**
+ * Internal dependencies
+ */
+import { domainAvailability } from 'lib/domains/constants';
+
+export function isFreeOrUnknownSuggestion( suggestion ) {
+	return suggestion.is_free === true || suggestion.status === domainAvailability.UNKNOWN;
+}
+
+export function getStrippedDomainBase( domain ) {
+	let strippedDomainBase = domain;
+	const lastIndexOfDot = strippedDomainBase.lastIndexOf( '.' );
+
+	if ( lastIndexOfDot !== -1 ) {
+		strippedDomainBase = strippedDomainBase.substring( 0, lastIndexOfDot );
+	}
+	return strippedDomainBase.replace( /[ .]/g, '' );
+}
+
+export function isNumberString( string ) {
+	return /^[0-9_]+$/.test( string );
+}
+
+export function getTldWeightOverrides( designType ) {
+	return designType && designType === 'blog' ? 'design_type_blog' : null;
+}


### PR DESCRIPTION
Similar to #22897, this change is a copy/paste cleanup of the `RegisterDomainStep` component. It pulls out helper functions from the component JSX into helper JS files. My goal is to make the component easier to reason about by better modularizing parts unrelated to the actual rendering of the signup step.

For context, this PR was created in preparation for the new pagination controls to be released with the new Kracken UI.

### Testing instructions
1. Spin up this branch locally, preferably in a production docker environment. You can do this by running the following command:
```
npm run build-docker
npm run docker
```
Then, set your hosts file (`/etc/hosts`) to point `wpcalypso.wordpress.com` to `127.0.0.1` like so:
```
127.0.0.1		wpcalypso.wordpress.com
```

2. Ensure that no behavioral changes have been introduced with this change. This can be checked at [/start/domains](https://wpcalypso.wordpress.com/start/domains).