### PR TITLE
Signup: Fix SSR handling of locale for `context`.

### DIFF
--- a/client/signup/index.node.js
+++ b/client/signup/index.node.js
@@ -19,7 +19,7 @@ function setUpLocale( context, next ) {
 		stepSectionName = undefined;
 	} else if ( ! lang && stepName && getLanguage( stepName ) ) {
 		lang = stepName;
-		flowName = undefined;
+		stepName = undefined;
 	} else if ( ! lang && flowName && getLanguage( flowName ) ) {
 		lang = flowName;
 		flowName = undefined;


### PR DESCRIPTION
A typo in `setupLocale` results in `context.params.flowName` not being reset in URLs with locales.

I can't find if anything relies on these `context.params`, nor do I know of this fixing any particular problem; I stumbled upon it while investigating #23523 (#5872 is related). Signup seems to work fine either way.

**Testing**
* Add `console.log(context.params);` to `/client/signup/index.node.jsL42` and restart Calypso.
* Load http://calypso.localhost:3000/start/about/fr (or any other valid URL with a locale at the end), and get:
```js
{ flowName: undefined,
  stepName: 'fr',
  stepSectionName: undefined,
  lang: 'fr' }
```
* Apply this PR and the `console.log` statement again, and restart Calypso.
* Do a fresh page load, and the `stepName` should be reset:
```js
{ flowName: undefined,
  stepName: undefined,
  stepSectionName: undefined,
  lang: 'fr' }
```

