### PR TITLE
Store: Fix Sparkline display on newer sites

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/index.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/index.js
@@ -149,6 +149,7 @@ class StatsWidget extends Component {
 				data={ ( orderData && orderData.data ) || [] }
 				delta={ delta }
 				date={ date }
+				unit={ unit }
 				type="number"
 			/>
 		);
@@ -168,6 +169,7 @@ class StatsWidget extends Component {
 				data={ ( orderData && orderData.data ) || [] }
 				delta={ delta }
 				date={ date }
+				unit={ unit }
 				type="currency"
 			/>
 		);
@@ -184,6 +186,7 @@ class StatsWidget extends Component {
 				data={ visitorData || [] }
 				delta={ delta }
 				date={ date }
+				unit={ unit }
 				statType="statsVisits"
 				query={ queries.visitorQuery }
 				attribute="visitors"
@@ -207,6 +210,7 @@ class StatsWidget extends Component {
 				data={ data || [] }
 				delta={ delta }
 				date={ date }
+				unit={ unit }
 				statType="statsOrders"
 				query={ queries.orderQuery }
 				attribute="conversionRate"

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/stat.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/stat.js
@@ -30,8 +30,12 @@ class StatsWidgetStat extends Component {
 		type: PropTypes.string.isRequired,
 		data: PropTypes.array.isRequired,
 		date: PropTypes.string.isRequired,
-		unit: PropTypes.string.isRequired,
+		unit: PropTypes.string,
 		delta: PropTypes.oneOfType( [ PropTypes.object, PropTypes.array ] ).isRequired,
+	};
+
+	static defaultProps = {
+		unit: 'week',
 	};
 
 	renderDelta = () => {

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/stat.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/stat.js
@@ -30,6 +30,7 @@ class StatsWidgetStat extends Component {
 		type: PropTypes.string.isRequired,
 		data: PropTypes.array.isRequired,
 		date: PropTypes.string.isRequired,
+		unit: PropTypes.string.isRequired,
 		delta: PropTypes.oneOfType( [ PropTypes.object, PropTypes.array ] ).isRequired,
 	};
 
@@ -57,7 +58,7 @@ class StatsWidgetStat extends Component {
 	};
 
 	render() {
-		const { data, site, date, attribute, label, requesting, type, labelToolTip } = this.props;
+		const { data, site, date, attribute, label, requesting, type, labelToolTip, unit } = this.props;
 
 		if ( requesting || ! site.ID || ! data || ! data.length ) {
 			return (
@@ -73,7 +74,16 @@ class StatsWidgetStat extends Component {
 		}
 
 		const value = data[ index ][ attribute ];
+
+		// Our store stats REST API endpoints return zero filled data. The visitors endpoint and conversion data
+		// have not been zero filled. This catches any missing data points and fills them in so sparklines look consistent.
 		const timeSeries = data.map( row => +row[ attribute ] );
+		const expectedDataPoints = 'month' === unit ? 12 : 30;
+		const missingDataPoints = expectedDataPoints - timeSeries.length;
+		for ( let i = missingDataPoints; i > 0; i-- ) {
+			timeSeries.unshift( 0 );
+		}
+		const highlightIndex = timeSeries.length - 1;
 
 		const labelClasses = classNames( 'stats-widget__box-label', {
 			'stats-widget__box-label-tooltip': labelToolTip,
@@ -96,7 +106,7 @@ class StatsWidgetStat extends Component {
 					<Sparkline
 						aspectRatio={ 3 }
 						data={ timeSeries }
-						highlightIndex={ index }
+						highlightIndex={ highlightIndex }
 						maxHeight={ 50 }
 					/>
 				</div>


### PR DESCRIPTION
When working on the store sign-up flow earlier, I noticed that the visitor and conversion rate Sparklines  just display as a dot on newer sites.

All of the store stats endpoints zero fill expected data points in the series, but the normal 'visitors' endpoint does not. Conversion rates are calculated using the 'visitors' data so both stats display this way. This PR zero fills missing data points.

Before:

<img width="671" alt="screen shot 2018-03-29 at 2 31 56 pm" src="https://user-images.githubusercontent.com/689165/38115450-f0fb2bce-3360-11e8-8ad0-bad271f85e1f.png">

After:

<img width="663" alt="screen shot 2018-03-29 at 2 38 33 pm" src="https://user-images.githubusercontent.com/689165/38115520-3477e9f0-3361-11e8-9073-3731e4187846.png">

Which matches what we display on the full Store stats experience:

<img width="655" alt="screen shot 2018-03-29 at 2 27 54 pm" src="https://user-images.githubusercontent.com/689165/38115535-4266c964-3361-11e8-8591-a5997a1a66a6.png">

To Test:
* On a newer store site (maybe after testing #23748 😀), view your dashboard and verify Sparkline display.

