### PR TITLE
Hide Showcase ad. Fixes #23782

### DIFF
--- a/client/my-sites/themes/themes-banner/style.scss
+++ b/client/my-sites/themes/themes-banner/style.scss
@@ -1,7 +1,7 @@
 .themes-banner {
 	$image_max_width: 410px;
 
-	display: block;
+	display: none;
 	position: relative;
 	background: no-repeat $blue-medium;
 	color: white !important;
@@ -66,5 +66,9 @@
 
 	.button.themes-banner__cta {
 		margin-top: 1em;
+	}
+
+	@media(min-width:769px) {
+		display: block;
 	}
 }


### PR DESCRIPTION
The Showcase has so many bars at the top. It's especially difficult to view on mobile devices. We're exploring ways to alleviate this with #23694 but until we get there, we can at least hide the ad for smaller screens.