### PR TITLE
Plans: change feature cards CTA buttons to non-primary.

### DIFF
--- a/client/blocks/product-purchase-features-list/advertising-removed.jsx
+++ b/client/blocks/product-purchase-features-list/advertising-removed.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import PurchaseDetail from 'components/purchase-detail';
 
-export default localize( ( { isBusinessPlan, translate } ) => {
+export default localize( ( { isButtonPrimary = true, isBusinessPlan, translate } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
@@ -26,6 +26,7 @@ export default localize( ( { isBusinessPlan, translate } ) => {
 									'Upgrade to remove the WordPress.com footer credit.'
 							)
 				}
+				primary={ isButtonPrimary }
 			/>
 		</div>
 	);

--- a/client/blocks/product-purchase-features-list/business-onboarding.jsx
+++ b/client/blocks/product-purchase-features-list/business-onboarding.jsx
@@ -13,7 +13,7 @@ import { noop } from 'lodash';
  */
 import PurchaseDetail from 'components/purchase-detail';
 
-export default localize( ( { translate, link, onClick = noop } ) => {
+export default localize( ( { isButtonPrimary = true, translate, link, onClick = noop } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
@@ -26,6 +26,7 @@ export default localize( ( { translate, link, onClick = noop } ) => {
 				buttonText={ translate( 'Schedule a session' ) }
 				href={ link }
 				onClick={ onClick }
+				primary={ isButtonPrimary }
 			/>
 		</div>
 	);

--- a/client/blocks/product-purchase-features-list/custom-domain.jsx
+++ b/client/blocks/product-purchase-features-list/custom-domain.jsx
@@ -10,10 +10,15 @@ import React from 'react';
  */
 import CustomDomainPurchaseDetail from 'my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail';
 
-export default function CustomDomainPurchaseDetailItem( { hasDomainCredit, selectedSite } ) {
+export default function CustomDomainPurchaseDetailItem( {
+	hasDomainCredit,
+	isButtonPrimary,
+	selectedSite,
+} ) {
 	return (
 		<div className="product-purchase-features-list__item">
 			<CustomDomainPurchaseDetail
+				isButtonPrimary={ isButtonPrimary }
 				selectedSite={ selectedSite }
 				hasDomainCredit={ hasDomainCredit }
 			/>

--- a/client/blocks/product-purchase-features-list/custom-domain.jsx
+++ b/client/blocks/product-purchase-features-list/custom-domain.jsx
@@ -12,7 +12,7 @@ import CustomDomainPurchaseDetail from 'my-sites/checkout/checkout-thank-you/cus
 
 export default function CustomDomainPurchaseDetailItem( {
 	hasDomainCredit,
-	isButtonPrimary,
+	isButtonPrimary = true,
 	selectedSite,
 } ) {
 	return (

--- a/client/blocks/product-purchase-features-list/customize-theme.jsx
+++ b/client/blocks/product-purchase-features-list/customize-theme.jsx
@@ -25,11 +25,12 @@ function getCustomizeLink( selectedSite ) {
 	return isCustomizeEnabled() ? '/customize/' + selectedSite.slug : customizerInAdmin;
 }
 
-export default localize( ( { selectedSite, translate } ) => {
+export default localize( ( { isButtonPrimary = true, selectedSite, translate } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon={ <img alt="" src="/calypso/images/upgrades/customize-theme.svg" /> }
+				primary={ isButtonPrimary }
 				title={ translate( 'Advanced customization' ) }
 				description={ translate(
 					"Change your site's appearance in a few clicks, with an expanded " +

--- a/client/blocks/product-purchase-features-list/find-new-theme.jsx
+++ b/client/blocks/product-purchase-features-list/find-new-theme.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import PurchaseDetail from 'components/purchase-detail';
 
-export default localize( ( { selectedSite, translate } ) => {
+export default localize( ( { isButtonPrimary = true, selectedSite, translate } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
@@ -23,6 +23,7 @@ export default localize( ( { selectedSite, translate } ) => {
 				) }
 				buttonText={ translate( 'Browse premium themes' ) }
 				href={ '/themes/' + selectedSite.slug }
+				primary={ isButtonPrimary }
 			/>
 		</div>
 	);

--- a/client/blocks/product-purchase-features-list/google-analytics-stats.jsx
+++ b/client/blocks/product-purchase-features-list/google-analytics-stats.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import PurchaseDetail from 'components/purchase-detail';
 
-export default localize( ( { selectedSite, translate } ) => {
+export default localize( ( { isButtonPrimary = true, selectedSite, translate } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
@@ -23,6 +23,7 @@ export default localize( ( { selectedSite, translate } ) => {
 				) }
 				buttonText={ translate( 'Connect Google Analytics' ) }
 				href={ '/settings/analytics/' + selectedSite.slug }
+				primary={ isButtonPrimary }
 			/>
 		</div>
 	);

--- a/client/blocks/product-purchase-features-list/google-vouchers.jsx
+++ b/client/blocks/product-purchase-features-list/google-vouchers.jsx
@@ -12,11 +12,11 @@ import React from 'react';
 import GoogleVoucherDetails from 'my-sites/checkout/checkout-thank-you/google-voucher';
 import QuerySiteVouchers from 'components/data/query-site-vouchers';
 
-export default ( { selectedSite } ) => {
+export default ( { isButtonPrimary = true, selectedSite } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<QuerySiteVouchers siteId={ selectedSite.ID } />
-			<GoogleVoucherDetails selectedSite={ selectedSite } />
+			<GoogleVoucherDetails isButtonPrimary={ isButtonPrimary } selectedSite={ selectedSite } />
 		</div>
 	);
 };

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -79,13 +79,13 @@ export class ProductPurchaseFeaturesList extends Component {
 				{ isWordadsInstantActivationEligible( selectedSite ) && (
 					<MonetizeSite isButtonPrimary={ false } selectedSite={ selectedSite } />
 				) }
-				<JetpackSearch selectedSite={ selectedSite } />
-				<GoogleVouchers selectedSite={ selectedSite } />
-				<GoogleAnalyticsStats selectedSite={ selectedSite } />
-				<AdvertisingRemoved isBusinessPlan />
-				<CustomizeTheme selectedSite={ selectedSite } />
+				<JetpackSearch isButtonPrimary={ false } selectedSite={ selectedSite } />
+				<GoogleVouchers isButtonPrimary={ false } selectedSite={ selectedSite } />
+				<GoogleAnalyticsStats isButtonPrimary={ false } selectedSite={ selectedSite } />
+				<AdvertisingRemoved isBusinessPlan isButtonPrimary={ false } />
+				<CustomizeTheme isButtonPrimary={ false } selectedSite={ selectedSite } />
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
-				<FindNewTheme selectedSite={ selectedSite } />
+				<FindNewTheme isButtonPrimary={ false } selectedSite={ selectedSite } />
 			</Fragment>
 		);
 	}
@@ -101,9 +101,9 @@ export class ProductPurchaseFeaturesList extends Component {
 					selectedSite={ selectedSite }
 					hasDomainCredit={ planHasDomainCredit }
 				/>
-				<AdvertisingRemoved isButtonPrimary={ false } isBusinessPlan={ false } />
-				<GoogleVouchers selectedSite={ selectedSite } />
-				<CustomizeTheme selectedSite={ selectedSite } />
+				<AdvertisingRemoved isBusinessPlan={ false } isButtonPrimary={ false } />
+				<GoogleVouchers isButtonPrimary={ false } selectedSite={ selectedSite } />
+				<CustomizeTheme isButtonPrimary={ false } selectedSite={ selectedSite } />
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
 				{ isWordadsInstantActivationEligible( selectedSite ) && (
 					<MonetizeSite isButtonPrimary={ false } selectedSite={ selectedSite } />
@@ -123,7 +123,7 @@ export class ProductPurchaseFeaturesList extends Component {
 					selectedSite={ selectedSite }
 					hasDomainCredit={ planHasDomainCredit }
 				/>
-				<AdvertisingRemoved isButtonPrimary={ false } isBusinessPlan={ false } />
+				<AdvertisingRemoved isBusinessPlan={ false } isButtonPrimary={ false } />
 			</Fragment>
 		);
 	}
@@ -137,8 +137,9 @@ export class ProductPurchaseFeaturesList extends Component {
 					isJetpackFreePlan
 					isPlaceholder={ isPlaceholder }
 				/>
-				<JetpackWordPressCom selectedSite={ selectedSite } />
+				<JetpackWordPressCom isButtonPrimary={ false } selectedSite={ selectedSite } />
 				<JetpackReturnToDashboard
+					isButtonPrimary={ false }
 					onClick={ this.props.recordReturnToDashboardClick }
 					selectedSite={ selectedSite }
 				/>
@@ -154,13 +155,13 @@ export class ProductPurchaseFeaturesList extends Component {
 					isJetpack={ !! selectedSite.jetpack && ! isAutomatedTransfer }
 					isPlaceholder={ isPlaceholder }
 				/>
-				<MonetizeSite selectedSite={ selectedSite } />
-				<JetpackWordPressCom selectedSite={ selectedSite } />
-				<JetpackBackupSecurity />
+				<MonetizeSite isButtonPrimary={ false } selectedSite={ selectedSite } />
+				<JetpackWordPressCom isButtonPrimary={ false } selectedSite={ selectedSite } />
+				<JetpackBackupSecurity isButtonPrimary={ false } />
 				<JetpackAntiSpam />
 				<JetpackPublicize />
 				<JetpackVideo />
-				<JetpackReturnToDashboard selectedSite={ selectedSite } />
+				<JetpackReturnToDashboard isButtonPrimary={ false } selectedSite={ selectedSite } />
 			</Fragment>
 		);
 	}
@@ -174,10 +175,10 @@ export class ProductPurchaseFeaturesList extends Component {
 					isJetpack={ !! selectedSite.jetpack && ! isAutomatedTransfer }
 					isPlaceholder={ isPlaceholder }
 				/>
-				<JetpackWordPressCom selectedSite={ selectedSite } />
-				<JetpackBackupSecurity />
+				<JetpackWordPressCom isButtonPrimary={ false } selectedSite={ selectedSite } />
+				<JetpackBackupSecurity isButtonPrimary={ false } />
 				<JetpackAntiSpam />
-				<JetpackReturnToDashboard selectedSite={ selectedSite } />
+				<JetpackReturnToDashboard isButtonPrimary={ false } selectedSite={ selectedSite } />
 			</Fragment>
 		);
 	}
@@ -193,19 +194,20 @@ export class ProductPurchaseFeaturesList extends Component {
 					liveChatButtonEventName={ 'calypso_livechat_my_plan_jetpack_professsional' }
 				/>
 				<BusinessOnboarding
+					isButtonPrimary={ false }
 					onClick={ this.props.recordBusinessOnboardingClick }
 					link="https://calendly.com/jetpack/concierge"
 				/>
-				<JetpackSearch selectedSite={ selectedSite } />
-				<MonetizeSite selectedSite={ selectedSite } />
-				<GoogleAnalyticsStats selectedSite={ selectedSite } />
-				<JetpackWordPressCom selectedSite={ selectedSite } />
-				<FindNewTheme selectedSite={ selectedSite } />
+				<JetpackSearch isButtonPrimary={ false } selectedSite={ selectedSite } />
+				<MonetizeSite isButtonPrimary={ false } selectedSite={ selectedSite } />
+				<GoogleAnalyticsStats isButtonPrimary={ false } selectedSite={ selectedSite } />
+				<JetpackWordPressCom isButtonPrimary={ false } selectedSite={ selectedSite } />
+				<FindNewTheme isButtonPrimary={ false } selectedSite={ selectedSite } />
 				<JetpackVideo />
 				<JetpackPublicize />
-				<JetpackBackupSecurity />
+				<JetpackBackupSecurity isButtonPrimary={ false } />
 				<JetpackAntiSpam />
-				<JetpackReturnToDashboard selectedSite={ selectedSite } />
+				<JetpackReturnToDashboard isButtonPrimary={ false } selectedSite={ selectedSite } />
 			</Fragment>
 		);
 	}

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -75,7 +75,9 @@ export class ProductPurchaseFeaturesList extends Component {
 					onClick={ this.props.recordBusinessOnboardingClick }
 					link={ `/me/concierge/${ selectedSite.slug }/book` }
 				/>
-				{ isEnabled( 'manage/plugins/upload' ) && <UploadPlugins selectedSite={ selectedSite } /> }
+				{ isEnabled( 'manage/plugins/upload' ) && (
+					<UploadPlugins isButtonPrimary={ false } selectedSite={ selectedSite } />
+				) }
 				{ isWordadsInstantActivationEligible( selectedSite ) && (
 					<MonetizeSite isButtonPrimary={ false } selectedSite={ selectedSite } />
 				) }

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -84,7 +84,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<GoogleAnalyticsStats isButtonPrimary={ false } selectedSite={ selectedSite } />
 				<AdvertisingRemoved isBusinessPlan isButtonPrimary={ false } />
 				<CustomizeTheme isButtonPrimary={ false } selectedSite={ selectedSite } />
-				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
+				<VideoAudioPosts isButtonPrimary={ false } selectedSite={ selectedSite } plan={ plan } />
 				<FindNewTheme isButtonPrimary={ false } selectedSite={ selectedSite } />
 			</Fragment>
 		);
@@ -104,7 +104,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<AdvertisingRemoved isBusinessPlan={ false } isButtonPrimary={ false } />
 				<GoogleVouchers isButtonPrimary={ false } selectedSite={ selectedSite } />
 				<CustomizeTheme isButtonPrimary={ false } selectedSite={ selectedSite } />
-				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
+				<VideoAudioPosts isButtonPrimary={ false } selectedSite={ selectedSite } plan={ plan } />
 				{ isWordadsInstantActivationEligible( selectedSite ) && (
 					<MonetizeSite isButtonPrimary={ false } selectedSite={ selectedSite } />
 				) }

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -65,14 +65,19 @@ export class ProductPurchaseFeaturesList extends Component {
 					showLiveChatButton
 					liveChatButtonEventName={ 'calypso_livechat_my_plan_business' }
 				/>
-				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
+				<CustomDomain
+					isButtonPrimary={ false }
+					selectedSite={ selectedSite }
+					hasDomainCredit={ planHasDomainCredit }
+				/>
 				<BusinessOnboarding
+					isButtonPrimary={ false }
 					onClick={ this.props.recordBusinessOnboardingClick }
 					link={ `/me/concierge/${ selectedSite.slug }/book` }
 				/>
 				{ isEnabled( 'manage/plugins/upload' ) && <UploadPlugins selectedSite={ selectedSite } /> }
 				{ isWordadsInstantActivationEligible( selectedSite ) && (
-					<MonetizeSite selectedSite={ selectedSite } />
+					<MonetizeSite isButtonPrimary={ false } selectedSite={ selectedSite } />
 				) }
 				<JetpackSearch selectedSite={ selectedSite } />
 				<GoogleVouchers selectedSite={ selectedSite } />
@@ -91,13 +96,17 @@ export class ProductPurchaseFeaturesList extends Component {
 		return (
 			<Fragment>
 				<HappinessSupportCard isPlaceholder={ isPlaceholder } />
-				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
-				<AdvertisingRemoved isBusinessPlan={ false } />
+				<CustomDomain
+					isButtonPrimary={ false }
+					selectedSite={ selectedSite }
+					hasDomainCredit={ planHasDomainCredit }
+				/>
+				<AdvertisingRemoved isButtonPrimary={ false } isBusinessPlan={ false } />
 				<GoogleVouchers selectedSite={ selectedSite } />
 				<CustomizeTheme selectedSite={ selectedSite } />
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
 				{ isWordadsInstantActivationEligible( selectedSite ) && (
-					<MonetizeSite selectedSite={ selectedSite } />
+					<MonetizeSite isButtonPrimary={ false } selectedSite={ selectedSite } />
 				) }
 			</Fragment>
 		);
@@ -109,8 +118,12 @@ export class ProductPurchaseFeaturesList extends Component {
 		return (
 			<Fragment>
 				<HappinessSupportCard isPlaceholder={ isPlaceholder } />
-				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
-				<AdvertisingRemoved isBusinessPlan={ false } />
+				<CustomDomain
+					isButtonPrimary={ false }
+					selectedSite={ selectedSite }
+					hasDomainCredit={ planHasDomainCredit }
+				/>
+				<AdvertisingRemoved isButtonPrimary={ false } isBusinessPlan={ false } />
 			</Fragment>
 		);
 	}

--- a/client/blocks/product-purchase-features-list/jetpack-backup-security.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-backup-security.jsx
@@ -14,15 +14,19 @@ import QueryRewindState from 'components/data/query-rewind-state';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getRewindState } from 'state/selectors';
 
-const JetpackBackupSecurity = ( { backupEngine, site, siteId, translate } ) => (
+const JetpackBackupSecurity = ( {
+	backupEngine,
+	isButtonPrimary = true,
+	site,
+	siteId,
+	translate,
+} ) => (
 	<div className="product-purchase-features-list__item">
 		<QueryRewindState siteId={ siteId } />
 		<PurchaseDetail
 			icon="flag"
 			title={ translate( 'Site Security' ) }
-			description={ translate(
-				'Your site is safe with secure backups and real-time scans.'
-			) }
+			description={ translate( 'Your site is safe with secure backups and real-time scans.' ) }
 			buttonText={
 				backupEngine === 'rewind'
 					? translate( 'View Activity Log' )
@@ -33,6 +37,7 @@ const JetpackBackupSecurity = ( { backupEngine, site, siteId, translate } ) => (
 					? `/stats/activity/${ site.slug }`
 					: 'https://dashboard.vaultpress.com'
 			}
+			primary={ isButtonPrimary }
 		/>
 	</div>
 );

--- a/client/blocks/product-purchase-features-list/jetpack-return-to-dashboard.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-return-to-dashboard.jsx
@@ -14,24 +14,27 @@ import { untrailingslashit } from 'lib/route';
  */
 import PurchaseDetail from 'components/purchase-detail';
 
-export default localize( ( { selectedSite, translate, onClick = noop } ) => {
-	let adminURL = get( selectedSite, 'options.admin_url', '' );
-	if ( adminURL ) {
-		adminURL = untrailingslashit( adminURL ) + '/admin.php?page=jetpack';
-	}
+export default localize(
+	( { isButtonPrimary = true, selectedSite, translate, onClick = noop } ) => {
+		let adminURL = get( selectedSite, 'options.admin_url', '' );
+		if ( adminURL ) {
+			adminURL = untrailingslashit( adminURL ) + '/admin.php?page=jetpack';
+		}
 
-	return (
-		<div className="product-purchase-features-list__item">
-			<PurchaseDetail
-				icon="house"
-				title={ translate( 'Return to your Jetpack dashboard' ) }
-				description={ translate(
-					'Access your Jetpack Dashboard from your self-hosted WordPress site’s wp-admin.'
-				) }
-				buttonText={ translate( 'Go back to %(site)s', { args: { site: selectedSite.name } } ) }
-				href={ adminURL }
-				onClick={ onClick }
-			/>
-		</div>
-	);
-} );
+		return (
+			<div className="product-purchase-features-list__item">
+				<PurchaseDetail
+					icon="house"
+					title={ translate( 'Return to your Jetpack dashboard' ) }
+					description={ translate(
+						'Access your Jetpack Dashboard from your self-hosted WordPress site’s wp-admin.'
+					) }
+					buttonText={ translate( 'Go back to %(site)s', { args: { site: selectedSite.name } } ) }
+					href={ adminURL }
+					onClick={ onClick }
+					primary={ isButtonPrimary }
+				/>
+			</div>
+		);
+	}
+);

--- a/client/blocks/product-purchase-features-list/jetpack-search.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-search.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import PurchaseDetail from 'components/purchase-detail';
 
-export default localize( ( { selectedSite, translate } ) => {
+export default localize( ( { isButtonPrimary = true, selectedSite, translate } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
@@ -24,6 +24,7 @@ export default localize( ( { selectedSite, translate } ) => {
 				) }
 				buttonText={ translate( 'Enable Search in Traffic Settings' ) }
 				href={ '/settings/traffic/' + selectedSite.slug }
+				primary={ isButtonPrimary }
 			/>
 		</div>
 	);

--- a/client/blocks/product-purchase-features-list/jetpack-wordpress-com.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-wordpress-com.jsx
@@ -12,17 +12,16 @@ import { localize } from 'i18n-calypso';
  */
 import PurchaseDetail from 'components/purchase-detail';
 
-export default localize( ( { selectedSite, translate } ) => {
+export default localize( ( { isButtonPrimary = true, selectedSite, translate } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon="plugins"
 				title={ translate( 'Automatic Updates' ) }
-				description={ translate(
-					'Keep your plugins up-to-date, hassle-free.',
-				) }
+				description={ translate( 'Keep your plugins up-to-date, hassle-free.' ) }
 				buttonText={ translate( 'Configure auto updates' ) }
 				href={ `/plugins/manage/${ selectedSite.slug }` }
+				primary={ isButtonPrimary }
 			/>
 		</div>
 	);

--- a/client/blocks/product-purchase-features-list/monetize-site.jsx
+++ b/client/blocks/product-purchase-features-list/monetize-site.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import PurchaseDetail from 'components/purchase-detail';
 
-export default localize( ( { selectedSite, translate } ) => {
+export default localize( ( { isButtonPrimary = true, selectedSite, translate } ) => {
 	const adSettingsUrl = selectedSite.jetpack
 		? '/settings/traffic/' + selectedSite.slug
 		: '/ads/settings/' + selectedSite.slug;
@@ -26,6 +26,7 @@ export default localize( ( { selectedSite, translate } ) => {
 				) }
 				buttonText={ translate( 'Start earning' ) }
 				href={ adSettingsUrl }
+				primary={ isButtonPrimary }
 			/>
 		</div>
 	);

--- a/client/blocks/product-purchase-features-list/upload-plugins.jsx
+++ b/client/blocks/product-purchase-features-list/upload-plugins.jsx
@@ -12,18 +12,19 @@ import { localize } from 'i18n-calypso';
  */
 import PurchaseDetail from 'components/purchase-detail';
 
-export default localize( ( { selectedSite, translate } ) => {
+export default localize( ( { isButtonPrimary = true, selectedSite, translate } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
-				icon="plugins"
-				title={ translate( 'Add a Plugin' ) }
+				buttonText={ translate( 'Upload a plugin now' ) }
 				description={ translate(
 					'Search and add plugins right from your dashboard, or upload a plugin ' +
 						'from your computer with a drag-and-drop interface.'
 				) }
-				buttonText={ translate( 'Upload a plugin now' ) }
 				href={ '/plugins/upload/' + selectedSite.slug }
+				icon="plugins"
+				title={ translate( 'Add a Plugin' ) }
+				primary={ isButtonPrimary }
 			/>
 		</div>
 	);

--- a/client/blocks/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/video-audio-posts.jsx
@@ -29,15 +29,16 @@ function getDescription( plan, translate ) {
 	return '';
 }
 
-export const VideoAudioPosts = ( { selectedSite, plan, translate } ) => {
+export const VideoAudioPosts = ( { isButtonPrimary = true, selectedSite, plan, translate } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
-				icon={ <img alt="" src="/calypso/images/upgrades/media-post.svg" /> }
-				title={ translate( 'Video and audio posts' ) }
-				description={ getDescription( plan, translate ) }
 				buttonText={ translate( 'Start a new post' ) }
+				description={ getDescription( plan, translate ) }
 				href={ newPost( selectedSite ) }
+				icon={ <img alt="" src="/calypso/images/upgrades/media-post.svg" /> }
+				primary={ isButtonPrimary }
+				title={ translate( 'Video and audio posts' ) }
 			/>
 		</div>
 	);

--- a/client/components/purchase-detail/index.jsx
+++ b/client/components/purchase-detail/index.jsx
@@ -22,6 +22,7 @@ export default class PurchaseDetail extends PureComponent {
 		description: PropTypes.oneOfType( [ PropTypes.array, PropTypes.string, PropTypes.object ] ),
 		href: PropTypes.string,
 		icon: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
+		primary: PropTypes.bool,
 		isPlaceholder: PropTypes.bool,
 		isRequired: PropTypes.bool,
 		isSubmitting: PropTypes.bool,
@@ -33,11 +34,21 @@ export default class PurchaseDetail extends PureComponent {
 	};
 
 	static defaultProps = {
+		primary: true,
 		onClick: noop,
 	};
 
 	renderPurchaseButton() {
-		const { buttonText, isPlaceholder, isSubmitting, href, onClick, target, rel } = this.props;
+		const {
+			buttonText,
+			primary,
+			isPlaceholder,
+			isSubmitting,
+			href,
+			onClick,
+			target,
+			rel,
+		} = this.props;
 
 		if ( ! buttonText && ! isPlaceholder ) {
 			return null;
@@ -48,6 +59,7 @@ export default class PurchaseDetail extends PureComponent {
 				disabled={ isSubmitting }
 				href={ href }
 				onClick={ onClick }
+				primary={ primary }
 				target={ target }
 				rel={ rel }
 				text={ buttonText }

--- a/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -14,7 +14,12 @@ import { localize } from 'i18n-calypso';
 import PurchaseDetail from 'components/purchase-detail';
 import { hasCustomDomain } from 'lib/site/utils';
 
-const CustomDomainPurchaseDetail = ( { selectedSite, hasDomainCredit, translate } ) => {
+const CustomDomainPurchaseDetail = ( {
+	isButtonPrimary = true,
+	selectedSite,
+	hasDomainCredit,
+	translate,
+} ) => {
 	if ( hasDomainCredit && selectedSite.plan.user_is_owner ) {
 		return (
 			<PurchaseDetail
@@ -25,12 +30,14 @@ const CustomDomainPurchaseDetail = ( { selectedSite, hasDomainCredit, translate 
 				) }
 				buttonText={ translate( 'Claim your free domain' ) }
 				href={ `/domains/add/${ selectedSite.slug }` }
+				primary={ isButtonPrimary }
 			/>
 		);
 	} else if ( ! hasDomainCredit && hasCustomDomain( selectedSite ) ) {
 		const actionButton = {};
 		actionButton.buttonText = translate( 'Manage my domains' );
 		actionButton.href = `/domains/manage/${ selectedSite.slug }`;
+		actionButton.primary = { isButtonPrimary };
 		return (
 			<PurchaseDetail
 				icon={ <img src="/calypso/images/upgrades/custom-domain.svg" /> }
@@ -45,9 +52,8 @@ const CustomDomainPurchaseDetail = ( { selectedSite, hasDomainCredit, translate 
 				{ ...actionButton }
 			/>
 		);
-	} else {
-		return null;
 	}
+	return null;
 };
 
 CustomDomainPurchaseDetail.propTypes = {

--- a/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -37,10 +37,9 @@ const CustomDomainPurchaseDetail = ( {
 		const actionButton = {};
 		actionButton.buttonText = translate( 'Manage my domains' );
 		actionButton.href = `/domains/manage/${ selectedSite.slug }`;
-		actionButton.primary = { isButtonPrimary };
 		return (
 			<PurchaseDetail
-				icon={ <img src="/calypso/images/upgrades/custom-domain.svg" /> }
+				icon={ <img src="/calypso/images/upgrades/custom-domain.svg" alt="" /> }
 				title={ translate( 'Custom Domain' ) }
 				description={ translate(
 					'Your plan includes the custom domain {{em}}%(siteDomain)s{{/em}}, your own personal corner of the web.',
@@ -49,6 +48,7 @@ const CustomDomainPurchaseDetail = ( {
 						components: { em: <em /> },
 					}
 				) }
+				primary={ isButtonPrimary }
 				{ ...actionButton }
 			/>
 		);
@@ -57,8 +57,9 @@ const CustomDomainPurchaseDetail = ( {
 };
 
 CustomDomainPurchaseDetail.propTypes = {
-	selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ).isRequired,
 	hasDomainCredit: PropTypes.bool,
+	isButtonPrimary: PropTypes.bool,
+	selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ).isRequired,
 };
 
 export default localize( CustomDomainPurchaseDetail );

--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
@@ -112,9 +112,12 @@ class GoogleVoucherDetails extends Component {
 	}
 
 	renderInitialStep() {
+		const { isButtonPrimary } = this.props;
+
 		return (
 			<div className="google-voucher__initial-step">
 				<PurchaseButton
+					primary={ isButtonPrimary }
 					onClick={ this.onGenerateCode }
 					text={ this.props.translate( 'Generate code' ) }
 				/>
@@ -169,7 +172,9 @@ class GoogleVoucherDetails extends Component {
 	}
 
 	renderCodeRedeemed() {
+		const { isButtonPrimary } = this.props;
 		const { code } = this.getVoucher();
+
 		return (
 			<div className="google-voucher">
 				<ClipboardButtonInput value={ code } disabled={ ! code } />
@@ -196,6 +201,7 @@ class GoogleVoucherDetails extends Component {
 					<PurchaseButton
 						className="google-voucher-code__setup-google-adwords"
 						href="https://www.google.com/adwords/"
+						primary={ isButtonPrimary }
 						target="_blank"
 						rel="noopener noreferrer"
 						onClick={ this.onSetupGoogleAdWordsLink }
@@ -214,7 +220,7 @@ class GoogleVoucherDetails extends Component {
 	}
 
 	render() {
-		const { selectedSite, translate } = this.props;
+		const { isButtonPrimary, selectedSite, translate } = this.props;
 		const { step } = this.state;
 		let body;
 
@@ -235,12 +241,13 @@ class GoogleVoucherDetails extends Component {
 				<QuerySiteVouchers siteId={ selectedSite.ID } />
 				<PurchaseDetails
 					id="google-credits"
-					icon={ <img src="/calypso/images/upgrades/adwords.svg" /> }
+					icon={ <img src="/calypso/images/upgrades/adwords.svg" alt="" /> }
 					title={ translate( 'Google AdWords credit' ) }
 					description={ translate(
 						'Use a $100 credit with Google to bring traffic to your most important Posts and Pages.'
 					) }
 					body={ body }
+					primary={ isButtonPrimary }
 				/>
 			</div>
 		);
@@ -248,8 +255,13 @@ class GoogleVoucherDetails extends Component {
 }
 
 GoogleVoucherDetails.propTypes = {
-	selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ).isRequired,
 	googleAdCredits: PropTypes.array,
+	isButtonPrimary: PropTypes.bool,
+	selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ).isRequired,
+};
+
+GoogleVoucherDetails.defaultProps = {
+	isButtonPrimary: true,
 };
 
 export default connect(


### PR DESCRIPTION
As per new design, the buttons of the plans' feature cards are non-primary.
This PR adds a relevant prop to the `PurchaseDetails` component, which is the base component for the majority of the feature cards, and calls the feature components with the prop set to a relevant value.

Default value are kept to `primary`, thus the intention is to not impact design choices for other usages ( e.g. checkout thank-you cards ).

## To test:
- checkout this branch in your local Calypso or use calypso.live,
- go to `http://calypso.localhost:3000/plans/my-plan/:site` for Jetpack and WP sites on different plans,
- verify that all currently rendered button are non-primary.