### PR TITLE
Posts: fix wrong paths in page view analytics

### DIFF
--- a/client/my-sites/posts/controller.js
+++ b/client/my-sites/posts/controller.js
@@ -8,6 +8,7 @@ import page from 'page';
 import React from 'react';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:my-sites:posts' );
+import i18n from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -17,6 +18,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import Posts from 'my-sites/posts/main';
+import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 
 export default {
 	posts: function( context, next ) {
@@ -52,6 +54,9 @@ export default {
 			page.redirect( context.path.replace( /\/my\b/, '' ) );
 			return;
 		}
+
+		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+		context.store.dispatch( setTitle( i18n.translate( 'Blog Posts', { textOnly: true } ) ) );
 
 		context.primary = React.createElement( Posts, {
 			context,

--- a/client/my-sites/posts/controller.js
+++ b/client/my-sites/posts/controller.js
@@ -8,16 +8,10 @@ import page from 'page';
 import React from 'react';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:my-sites:posts' );
-import i18n from 'i18n-calypso';
 
 /**
  * Internal Dependencies
  */
-import { getSiteFragment, sectionify } from 'lib/route';
-import analytics from 'lib/analytics';
-import titlecase from 'to-title-case';
-import trackScrollPage from 'lib/track-scroll-page';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { areAllSitesSingleUser } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
@@ -28,16 +22,10 @@ export default {
 	posts: function( context, next ) {
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );
-
-		const siteID = getSiteFragment( context.path );
 		const author = context.params.author === 'my' ? getCurrentUserId( state ) : null;
-		let statusSlug = author ? context.params.status : context.params.author;
 		let search = context.query.s || '';
 		const category = context.query.category;
 		const tag = context.query.tag;
-		const basePath = sectionify( context.path );
-		let analyticsPageTitle = 'Blog Posts';
-		let baseAnalyticsPath;
 
 		function shouldRedirectMyPosts() {
 			if ( ! author ) {
@@ -51,11 +39,7 @@ export default {
 			}
 		}
 
-		debug( 'siteID: `%s`', siteID );
 		debug( 'author: `%s`', author );
-
-		statusSlug = ! statusSlug || statusSlug === 'my' || statusSlug === siteID ? '' : statusSlug;
-		debug( 'statusSlug: `%s`', statusSlug );
 
 		// Disable search in all-sites mode because it doesn't work.
 		if ( ! siteId ) {
@@ -69,31 +53,13 @@ export default {
 			return;
 		}
 
-		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( i18n.translate( 'Blog Posts', { textOnly: true } ) ) );
-
-		if ( siteID ) {
-			baseAnalyticsPath = basePath + '/:site';
-		} else {
-			baseAnalyticsPath = basePath;
-		}
-
-		if ( statusSlug.length ) {
-			analyticsPageTitle += ' > ' + titlecase( statusSlug );
-		} else {
-			analyticsPageTitle += ' > Published';
-		}
-
-		analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
-
 		context.primary = React.createElement( Posts, {
 			context,
 			author,
-			statusSlug,
+			statusSlug: context.params.status,
 			search,
 			category,
 			tag,
-			trackScrollPage: trackScrollPage.bind( null, baseAnalyticsPath, analyticsPageTitle, 'Posts' ),
 		} );
 		next();
 	},

--- a/client/my-sites/posts/index.js
+++ b/client/my-sites/posts/index.js
@@ -12,6 +12,7 @@ import page from 'page';
 import { navigation, siteSelection } from 'my-sites/controller';
 import postsController from './controller';
 import { makeLayout, render as clientRender } from 'controller';
+import { getSiteFragment } from 'lib/route';
 
 export default function() {
 	page(
@@ -22,4 +23,14 @@ export default function() {
 		makeLayout,
 		clientRender
 	);
+
+	page( '/posts/*', ( { path } ) => {
+		const siteFragment = getSiteFragment( path );
+
+		if ( siteFragment ) {
+			return page.redirect( `/posts/${ siteFragment }` );
+		}
+
+		return page.redirect( '/posts' );
+	} );
 }

--- a/client/my-sites/posts/index.js
+++ b/client/my-sites/posts/index.js
@@ -15,7 +15,7 @@ import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	page(
-		'/posts/:author?/:status?/:domain?',
+		'/posts/:author(my)?/:status(published|drafts|scheduled|trashed)?/:domain?',
 		siteSelection,
 		navigation,
 		postsController.posts,

--- a/client/my-sites/posts/index.js
+++ b/client/my-sites/posts/index.js
@@ -28,9 +28,9 @@ export default function() {
 		const siteFragment = getSiteFragment( path );
 
 		if ( siteFragment ) {
-			return page.redirect( `/posts/${ siteFragment }` );
+			return page.redirect( `/posts/my/${ siteFragment }` );
 		}
 
-		return page.redirect( '/posts' );
+		return page.redirect( '/posts/my' );
 	} );
 }

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -12,7 +12,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import DocumentHead from 'components/data/document-head';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import PostTypeFilter from 'my-sites/post-type-filter';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -74,7 +73,7 @@ class PostsMain extends React.Component {
 	}
 
 	render() {
-		const { author, category, search, siteId, statusSlug, tag, translate } = this.props;
+		const { author, category, search, siteId, statusSlug, tag } = this.props;
 		const classes = classnames( 'posts', {
 			'is-multisite': ! this.props.siteId,
 			'is-single-site': this.props.siteId,
@@ -94,7 +93,6 @@ class PostsMain extends React.Component {
 
 		return (
 			<Main className={ classes }>
-				<DocumentHead title={ translate( 'Blog Posts' ) } />
 				<PageViewTracker path={ this.getAnalyticsPath() } title={ this.getAnalyticsTitle() } />
 				<SidebarNavigation />
 				<div className="posts__primary">

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -12,10 +12,13 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import DocumentHead from 'components/data/document-head';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import PostTypeFilter from 'my-sites/post-type-filter';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import PostTypeList from 'my-sites/post-type-list';
 import PostTypeBulkEditBar from 'my-sites/post-type-list/bulk-edit-bar';
+import titlecase from 'to-title-case';
 import config from 'config';
 import Main from 'components/main';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -41,8 +44,37 @@ class PostsMain extends React.Component {
 		}
 	}
 
+	getAnalyticsPath() {
+		const { siteId, statusSlug, author } = this.props;
+		let analyticsPath = '/posts';
+
+		if ( author ) {
+			analyticsPath += '/my';
+		}
+
+		if ( statusSlug ) {
+			analyticsPath += `/${ statusSlug }`;
+		}
+
+		if ( siteId ) {
+			analyticsPath += '/:site';
+		}
+
+		return analyticsPath;
+	}
+
+	getAnalyticsTitle() {
+		const { statusSlug } = this.props;
+
+		if ( statusSlug ) {
+			return 'Blog Posts > ' + titlecase( statusSlug );
+		}
+
+		return 'Blog Posts > Published';
+	}
+
 	render() {
-		const { author, category, search, siteId, statusSlug, tag } = this.props;
+		const { author, category, search, siteId, statusSlug, tag, translate } = this.props;
 		const classes = classnames( 'posts', {
 			'is-multisite': ! this.props.siteId,
 			'is-single-site': this.props.siteId,
@@ -62,6 +94,8 @@ class PostsMain extends React.Component {
 
 		return (
 			<Main className={ classes }>
+				<DocumentHead title={ translate( 'Blog Posts' ) } />
+				<PageViewTracker path={ this.getAnalyticsPath() } title={ this.getAnalyticsTitle() } />
 				<SidebarNavigation />
 				<div className="posts__primary">
 					<PostTypeFilter query={ query } siteId={ siteId } statusSlug={ statusSlug } />


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/23521

According to internal logs, some `calypso_page_view` paths coming from Posts
were reported without replacing passed parameters with corresponding variables,
or removing wrong entries from the route. This was resolved by adding more
restrictive route matching for optional status and author parameters.

### Testing instructions
1. Set `localStorage.setItem( 'debug', 'calypso:analytics:tracks' )` in the browser console to enable the debug.
2. To reproduce the issue, navigate to `/posts/randomtext/{site}` or `/posts/randomtext` and observe the `calypso_page_view` recorded paths in log.
3. Apply this branch and verify that `randomtext` is no longer accepted as valid post status and recorded as such.
4. Check that there are no other valid post statuses that we should be matching here.
5. Make sure that `my` is the only valid option for author parameter.
6. Try to break it with various paths that start with `/posts/`.