### PR TITLE
JP Settings Sanitization: Don't remove post_by_email_address if it's set to 'regenerate'

### DIFF
--- a/client/state/jetpack/settings/test/utils.js
+++ b/client/state/jetpack/settings/test/utils.js
@@ -163,6 +163,18 @@ describe( 'utils', () => {
 			} );
 		} );
 
+		test( 'should include post_by_email_address in sanitized settings if it equals "regenerate"', () => {
+			const settings = {
+				some_other_setting: 123,
+				post_by_email_address: 'regenerate',
+			};
+
+			expect( sanitizeSettings( settings ) ).to.eql( {
+				some_other_setting: 123,
+				post_by_email_address: 'regenerate',
+			} );
+		} );
+
 		test( 'should omit akismet from sanitized settings', () => {
 			const settings = {
 				some_other_setting: 123,

--- a/client/state/jetpack/settings/utils.js
+++ b/client/state/jetpack/settings/utils.js
@@ -66,6 +66,9 @@ export const sanitizeSettings = settings => {
 			case 'jetpack_testimonial_posts_per_page':
 			case 'jetpack_portfolio_posts_per_page':
 			case 'post_by_email_address':
+				if ( settings[ key ] === 'regenerate' ) {
+					memo[ key ] = settings[ key ];
+				}
 				break;
 			case 'infinite_scroll':
 				if ( settings[ key ] === 'default' ) {


### PR DESCRIPTION
This will allow us to implement `regeneratePostByEmail()` thru `saveJetpackSettings()`, _even_ if the latter uses the sanitization util.

To test: 
* Make sure that JP Settings still work.