### PR TITLE
Billing history pagination - selectors

### DIFF
--- a/client/state/selectors/get-billing-transaction-app-filter-values.js
+++ b/client/state/selectors/get-billing-transaction-app-filter-values.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { groupBy, map } from 'lodash';
+
 /**
  * Internal dependencies
  */
@@ -35,7 +36,6 @@ export default createSelector(
 		} ) );
 	},
 	( state, transactionType ) => [
-		transactionType,
 		'upcoming' === transactionType
 			? getUpcomingBillingTransactions( state )
 			: getPastBillingTransactions( state ),

--- a/client/state/selectors/get-billing-transaction-app-filter-values.js
+++ b/client/state/selectors/get-billing-transaction-app-filter-values.js
@@ -8,8 +8,7 @@ import { groupBy, map } from 'lodash';
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import getPastBillingTransactions from './get-past-billing-transactions';
-import getUpcomingBillingTransactions from './get-upcoming-billing-transactions';
+import getBillingTransactionsByType from './get-billing-transactions-by-type';
 
 /**
  * Based on the transactions list, returns metadata for rendering the app filters with counts
@@ -20,10 +19,7 @@ import getUpcomingBillingTransactions from './get-upcoming-billing-transactions'
  */
 export default createSelector(
 	( state, transactionType ) => {
-		const transactions =
-			'upcoming' === transactionType
-				? getUpcomingBillingTransactions( state )
-				: getPastBillingTransactions( state );
+		const transactions = getBillingTransactionsByType( state, transactionType );
 		if ( ! transactions ) {
 			return [];
 		}
@@ -35,9 +31,5 @@ export default createSelector(
 			count: appGroup.length,
 		} ) );
 	},
-	( state, transactionType ) => [
-		'upcoming' === transactionType
-			? getUpcomingBillingTransactions( state )
-			: getPastBillingTransactions( state ),
-	]
+	( state, transactionType ) => [ getBillingTransactionsByType( state, transactionType ) ]
 );

--- a/client/state/selectors/get-billing-transaction-app-filter-values.js
+++ b/client/state/selectors/get-billing-transaction-app-filter-values.js
@@ -1,0 +1,43 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { groupBy, map } from 'lodash';
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import getPastBillingTransactions from './get-past-billing-transactions';
+import getUpcomingBillingTransactions from './get-upcoming-billing-transactions';
+
+/**
+ * Based on the transactions list, returns metadata for rendering the app filters with counts
+ *
+ * @param  {Object}  state           Global state tree
+ * @param  {String}  transactionType Transaction type
+ * @return {Array}                   App filter metadata
+ */
+export default createSelector(
+	( state, transactionType ) => {
+		const transactions =
+			'upcoming' === transactionType
+				? getUpcomingBillingTransactions( state )
+				: getPastBillingTransactions( state );
+		if ( ! transactions ) {
+			return [];
+		}
+
+		const appGroups = groupBy( transactions, 'service' );
+		return map( appGroups, ( appGroup, app ) => ( {
+			title: app,
+			value: app,
+			count: appGroup.length,
+		} ) );
+	},
+	( state, transactionType ) => [
+		transactionType,
+		'upcoming' === transactionType
+			? getUpcomingBillingTransactions( state )
+			: getPastBillingTransactions( state ),
+	]
+);

--- a/client/state/selectors/get-billing-transaction-app-filter-values.js
+++ b/client/state/selectors/get-billing-transaction-app-filter-values.js
@@ -8,7 +8,7 @@ import { groupBy, map } from 'lodash';
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import getBillingTransactionsByType from './get-billing-transactions-by-type';
+import getBillingTransactionsByType from 'state/selectors/get-billing-transactions-by-type';
 
 /**
  * Based on the transactions list, returns metadata for rendering the app filters with counts

--- a/client/state/selectors/get-billing-transaction-date-filter-values.js
+++ b/client/state/selectors/get-billing-transaction-date-filter-values.js
@@ -9,8 +9,7 @@ import { forEach, orderBy, range } from 'lodash';
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import getPastBillingTransactions from './get-past-billing-transactions';
-import getUpcomingBillingTransactions from './get-upcoming-billing-transactions';
+import getBillingTransactionsByType from './get-billing-transactions-by-type';
 
 /**
  * Based on the transactions list, returns metadata for rendering the date filters with counts
@@ -21,10 +20,7 @@ import getUpcomingBillingTransactions from './get-upcoming-billing-transactions'
  */
 export default createSelector(
 	( state, transactionType ) => {
-		const transactions =
-			'upcoming' === transactionType
-				? getUpcomingBillingTransactions( state )
-				: getPastBillingTransactions( state );
+		const transactions = getBillingTransactionsByType( state, transactionType );
 
 		if ( ! transactions ) {
 			return [];
@@ -62,9 +58,5 @@ export default createSelector(
 
 		return orderBy( result, 'key', 'desc' );
 	},
-	( state, transactionType ) => [
-		'upcoming' === transactionType
-			? getUpcomingBillingTransactions( state )
-			: getPastBillingTransactions( state ),
-	]
+	( state, transactionType ) => [ getBillingTransactionsByType( state, transactionType ) ]
 );

--- a/client/state/selectors/get-billing-transaction-date-filter-values.js
+++ b/client/state/selectors/get-billing-transaction-date-filter-values.js
@@ -2,8 +2,9 @@
 /**
  * External dependencies
  */
-import { translate, moment } from 'i18n-calypso';
+import { moment, translate } from 'i18n-calypso';
 import { forEach, orderBy, range } from 'lodash';
+
 /**
  * Internal dependencies
  */
@@ -62,7 +63,6 @@ export default createSelector(
 		return orderBy( result, 'key', 'desc' );
 	},
 	( state, transactionType ) => [
-		transactionType,
 		'upcoming' === transactionType
 			? getUpcomingBillingTransactions( state )
 			: getPastBillingTransactions( state ),

--- a/client/state/selectors/get-billing-transaction-date-filter-values.js
+++ b/client/state/selectors/get-billing-transaction-date-filter-values.js
@@ -1,0 +1,70 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { translate, moment } from 'i18n-calypso';
+import { forEach, orderBy, range } from 'lodash';
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import getPastBillingTransactions from './get-past-billing-transactions';
+import getUpcomingBillingTransactions from './get-upcoming-billing-transactions';
+
+/**
+ * Based on the transactions list, returns metadata for rendering the date filters with counts
+ *
+ * @param  {Object}  state           Global state tree
+ * @param  {String}  transactionType Transaction type
+ * @return {Array}                   Date filter metadata
+ */
+export default createSelector(
+	( state, transactionType ) => {
+		const transactions =
+			'upcoming' === transactionType
+				? getUpcomingBillingTransactions( state )
+				: getPastBillingTransactions( state );
+
+		if ( ! transactions ) {
+			return [];
+		}
+
+		const result = range( 6 ).reduce( function( accumulator, n ) {
+			const month = moment().subtract( n, 'months' );
+			const key = month.format( 'YYYY-MM' );
+			accumulator[ key ] = {
+				title: month.format( 'MMM YYYY' ),
+				value: { month: key, operator: 'equal' },
+				count: 0,
+				key,
+			};
+			return accumulator;
+		}, {} );
+		const olderDate = moment()
+			.subtract( 6, 'months' )
+			.format( 'YYYY-MM' );
+		result.older = {
+			title: translate( 'Older' ),
+			value: { month: olderDate, operator: 'before' },
+			count: 0,
+			key: olderDate,
+		};
+
+		forEach( transactions, transaction => {
+			const transactionDate = moment( transaction.date ).format( 'YYYY-MM' );
+			if ( result[ transactionDate ] ) {
+				result[ transactionDate ].count++;
+			} else {
+				result.older.count++;
+			}
+		} );
+
+		return orderBy( result, 'key', 'desc' );
+	},
+	( state, transactionType ) => [
+		transactionType,
+		'upcoming' === transactionType
+			? getUpcomingBillingTransactions( state )
+			: getPastBillingTransactions( state ),
+	]
+);

--- a/client/state/selectors/get-billing-transaction-date-filter-values.js
+++ b/client/state/selectors/get-billing-transaction-date-filter-values.js
@@ -9,7 +9,7 @@ import { find, forEach, last, times } from 'lodash';
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import getBillingTransactionsByType from './get-billing-transactions-by-type';
+import getBillingTransactionsByType from 'state/selectors/get-billing-transactions-by-type';
 
 /**
  * Based on the transactions list, returns metadata for rendering the date filters with counts

--- a/client/state/selectors/get-billing-transaction-filters.js
+++ b/client/state/selectors/get-billing-transaction-filters.js
@@ -1,0 +1,23 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns filter for the billing transactions of the given type
+ *
+ * @param  {Object}  state           Global state tree
+ * @param  {String}  transactionType Transaction type
+ * @return {Object}                 Billing transaction filters
+ */
+export default ( state, transactionType ) => {
+	const filters = get( state, [ 'ui', 'billingTransactions', transactionType ], {} );
+	return {
+		app: '',
+		date: { month: null, operator: null },
+		page: 1,
+		query: '',
+		...filters,
+	};
+};

--- a/client/state/selectors/get-billing-transactions-by-type.js
+++ b/client/state/selectors/get-billing-transactions-by-type.js
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import getPastBillingTransactions from './get-past-billing-transactions';
+import getUpcomingBillingTransactions from './get-upcoming-billing-transactions';
+
+/**
+ * Returns billing transactions of the provided type.
+ * Returns null if the billing transactions have not been fetched yet.
+ *
+ * @param  {Object}  state           Global state tree
+ * @param  {String}  transactionType Type of transactions to retrieve
+ * @return {?Array}                  An array of past transactions
+ */
+export default ( state, transactionType ) => 'upcoming' === transactionType
+	? getUpcomingBillingTransactions( state )
+	: getPastBillingTransactions( state );

--- a/client/state/selectors/get-billing-transactions-by-type.js
+++ b/client/state/selectors/get-billing-transactions-by-type.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import getPastBillingTransactions from './get-past-billing-transactions';
-import getUpcomingBillingTransactions from './get-upcoming-billing-transactions';
+import getPastBillingTransactions from 'state/selectors/get-past-billing-transactions';
+import getUpcomingBillingTransactions from 'state/selectors/get-upcoming-billing-transactions';
 
 /**
  * Returns billing transactions of the provided type.

--- a/client/state/selectors/get-filtered-billing-transactions.js
+++ b/client/state/selectors/get-filtered-billing-transactions.js
@@ -9,8 +9,7 @@ import { flatten, isDate, omit, slice, some, values, without } from 'lodash';
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import getPastBillingTransactions from './get-past-billing-transactions';
-import getUpcomingBillingTransactions from './get-upcoming-billing-transactions';
+import getBillingTransactionsByType from './get-billing-transactions-by-type';
 import getBillingTransactionFilters from './get-billing-transaction-filters';
 
 const PAGE_SIZE = 5;
@@ -67,10 +66,7 @@ const search = ( transactions, searchQuery ) => {
  */
 export default createSelector(
 	( state, transactionType ) => {
-		const transactions =
-			'upcoming' === transactionType
-				? getUpcomingBillingTransactions( state )
-				: getPastBillingTransactions( state );
+		const transactions = getBillingTransactionsByType( state, transactionType );
 		if ( ! transactions ) {
 			return {
 				transactions,
@@ -114,9 +110,7 @@ export default createSelector(
 		const filters = getBillingTransactionFilters( state, transactionType );
 
 		return [
-			'upcoming' === transactionType
-				? getUpcomingBillingTransactions( state )
-				: getPastBillingTransactions( state ),
+			getBillingTransactionsByType( state, transactionType ),
 			filters.app,
 			filters.date,
 			filters.page,

--- a/client/state/selectors/get-filtered-billing-transactions.js
+++ b/client/state/selectors/get-filtered-billing-transactions.js
@@ -4,6 +4,7 @@
  */
 import { moment } from 'i18n-calypso';
 import { flatten, isDate, omit, slice, some, values, without } from 'lodash';
+
 /**
  * Internal dependencies
  */
@@ -113,7 +114,6 @@ export default createSelector(
 		const filters = getBillingTransactionFilters( state, transactionType );
 
 		return [
-			transactionType,
 			'upcoming' === transactionType
 				? getUpcomingBillingTransactions( state )
 				: getPastBillingTransactions( state ),

--- a/client/state/selectors/get-filtered-billing-transactions.js
+++ b/client/state/selectors/get-filtered-billing-transactions.js
@@ -1,0 +1,126 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { moment } from 'i18n-calypso';
+import { flatten, isDate, omit, slice, some, values, without } from 'lodash';
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import getPastBillingTransactions from './get-past-billing-transactions';
+import getUpcomingBillingTransactions from './get-upcoming-billing-transactions';
+import getBillingTransactionFilters from './get-billing-transaction-filters';
+
+const PAGE_SIZE = 5;
+
+/**
+ * Utility function for formatting date for text search
+ * @param {Date} date date to be formatted
+ * @returns {String}  formatted date
+ */
+const formatDate = date => {
+	return moment( date ).format( 'll' );
+};
+
+/**
+ * Utility function extracting searchable strings from a single transaction
+ * @param {Object}  transaction transaction object
+ * @returns {Array}             list of searchable strings
+ */
+const getSearchableStrings = transaction => {
+	const rootStrings = values( omit( transaction, 'items' ) ),
+		transactionItems = transaction.items || [],
+		itemStrings = flatten( transactionItems.map( values ) );
+
+	return without( rootStrings.concat( itemStrings ), null, undefined );
+};
+
+/**
+ * Utility function to search the transactions by the provided searchQuery
+ * @param {Array} transactions transactions to search
+ * @param {String} searchQuery search query
+ * @returns {Array}            search result
+ */
+const search = ( transactions, searchQuery ) => {
+	return transactions.filter( function( transaction ) {
+		return some( getSearchableStrings( transaction ), function( val ) {
+			if ( isDate( val ) ) {
+				val = formatDate( val );
+			}
+
+			const haystack = val.toString().toLowerCase();
+			const needle = searchQuery.toLowerCase();
+
+			return haystack.indexOf( needle ) !== -1;
+		} );
+	} );
+};
+
+/**
+ * Returns the billing transactions filtered by the filters defined in state.billingTransactions.transactionFilters tree
+ *
+ * @param  {Object}  state           Global state tree
+ * @param  {String}  transactionType Transaction type
+ * @return {Object}                  Filtered results in format {transactions, total, pageSize}
+ */
+export default createSelector(
+	( state, transactionType ) => {
+		const transactions =
+			'upcoming' === transactionType
+				? getUpcomingBillingTransactions( state )
+				: getPastBillingTransactions( state );
+		if ( ! transactions ) {
+			return {
+				transactions,
+				total: 0,
+				pageSize: PAGE_SIZE,
+			};
+		}
+
+		const { app, date, page, query } = getBillingTransactionFilters( state, transactionType );
+		let results = search( transactions, query );
+		if ( date && date.month && date.operator ) {
+			results = results.filter( function( transaction ) {
+				const transactionDate = moment( transaction.date );
+
+				if ( 'equal' === date.operator ) {
+					return transactionDate.isSame( date.month, 'month' );
+				} else if ( 'before' === date.operator ) {
+					return transactionDate.isBefore( date.month, 'month' );
+				}
+			} );
+		}
+
+		if ( app && app !== 'all' ) {
+			results = results.filter( function( transaction ) {
+				return transaction.service === app;
+			} );
+		}
+
+		const total = results.length;
+
+		const pageIndex = page - 1;
+		results = slice( results, pageIndex * PAGE_SIZE, pageIndex * PAGE_SIZE + PAGE_SIZE );
+
+		return {
+			transactions: results,
+			total,
+			pageSize: PAGE_SIZE,
+		};
+	},
+	( state, transactionType ) => {
+		const filters = getBillingTransactionFilters( state, transactionType );
+
+		return [
+			transactionType,
+			'upcoming' === transactionType
+				? getUpcomingBillingTransactions( state )
+				: getPastBillingTransactions( state ),
+			filters.app,
+			filters.date,
+			filters.page,
+			filters.query,
+		];
+	}
+);

--- a/client/state/selectors/get-filtered-billing-transactions.js
+++ b/client/state/selectors/get-filtered-billing-transactions.js
@@ -9,8 +9,8 @@ import { compact, flatten, isDate, omit, slice, some, values } from 'lodash';
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import getBillingTransactionsByType from './get-billing-transactions-by-type';
-import getBillingTransactionFilters from './get-billing-transaction-filters';
+import getBillingTransactionsByType from 'state/selectors/get-billing-transactions-by-type';
+import getBillingTransactionFilters from 'state/selectors/get-billing-transaction-filters';
 
 const PAGE_SIZE = 5;
 
@@ -38,7 +38,7 @@ const getSearchableStrings = transaction => {
  * Utility function to search the transactions by the provided searchQuery
  * @param {Array} transactions transactions to search
  * @param {String} searchQuery search query
- * @returns {Array}            search result
+ * @returns {Array}            search results
  */
 const search = ( transactions, searchQuery ) =>
 	transactions.filter( transaction =>

--- a/client/state/selectors/get-past-billing-transaction.js
+++ b/client/state/selectors/get-past-billing-transaction.js
@@ -10,7 +10,7 @@ import { find, get } from 'lodash';
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import getPastBillingTransactions from './get-past-billing-transactions';
+import getPastBillingTransactions from 'state/selectors/get-past-billing-transactions';
 
 /**
  * Utility function to retrieve a transaction from individualTransactions state subtree

--- a/client/state/selectors/test/get-billing-transaction-app-filter-values.js
+++ b/client/state/selectors/test/get-billing-transaction-app-filter-values.js
@@ -1,0 +1,67 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { getBillingTransactionAppFilterValues } from 'state/selectors';
+
+describe( 'getBillingTransactionAppFilterValues()', () => {
+	const state = {
+		billingTransactions: {
+			items: {
+				past: [
+					{
+						service: 'service 1',
+					},
+					{
+						service: 'service 2',
+					},
+					{
+						service: 'service 1',
+					},
+					{
+						service: 'service 3',
+					},
+					{
+						service: 'service 2',
+					},
+					{
+						service: 'service 2',
+					},
+				],
+			},
+		},
+	};
+
+	test( 'returns transaction app filter values with counts', () => {
+		const result = getBillingTransactionAppFilterValues( state, 'past' );
+		expect( result ).toEqual( [
+			{
+				title: 'service 1',
+				value: 'service 1',
+				count: 2,
+			},
+			{
+				title: 'service 2',
+				value: 'service 2',
+				count: 3,
+			},
+			{
+				title: 'service 3',
+				value: 'service 3',
+				count: 1,
+			},
+		] );
+	} );
+
+	test( 'returns an empty array when there are no transactions', () => {
+		const result = getBillingTransactionAppFilterValues(
+			{
+				billingTransactions: {
+					items: {},
+				},
+			},
+			'past'
+		);
+		expect( result ).toEqual( [] );
+	} );
+} );

--- a/client/state/selectors/test/get-billing-transaction-date-filter-values.js
+++ b/client/state/selectors/test/get-billing-transaction-date-filter-values.js
@@ -9,7 +9,7 @@ jest.mock( 'i18n-calypso', () => {
 	moment.now = () => new Date( 2018, 4, 24 ); //May 24, 2018
 	return {
 		translate: str => str,
-		moment: moment,
+		moment,
 	};
 } );
 

--- a/client/state/selectors/test/get-billing-transaction-date-filter-values.js
+++ b/client/state/selectors/test/get-billing-transaction-date-filter-values.js
@@ -58,7 +58,6 @@ describe( 'getBillingTransactionDateFilterValues()', () => {
 		expect( result ).toEqual( [
 			{
 				count: 1,
-				key: '2018-05',
 				title: 'May 2018',
 				value: {
 					month: '2018-05',
@@ -67,7 +66,6 @@ describe( 'getBillingTransactionDateFilterValues()', () => {
 			},
 			{
 				count: 1,
-				key: '2018-04',
 				title: 'Apr 2018',
 				value: {
 					month: '2018-04',
@@ -76,7 +74,6 @@ describe( 'getBillingTransactionDateFilterValues()', () => {
 			},
 			{
 				count: 3,
-				key: '2018-03',
 				title: 'Mar 2018',
 				value: {
 					month: '2018-03',
@@ -85,7 +82,6 @@ describe( 'getBillingTransactionDateFilterValues()', () => {
 			},
 			{
 				count: 0,
-				key: '2018-02',
 				title: 'Feb 2018',
 				value: {
 					month: '2018-02',
@@ -94,7 +90,6 @@ describe( 'getBillingTransactionDateFilterValues()', () => {
 			},
 			{
 				count: 1,
-				key: '2018-01',
 				title: 'Jan 2018',
 				value: {
 					month: '2018-01',
@@ -103,7 +98,6 @@ describe( 'getBillingTransactionDateFilterValues()', () => {
 			},
 			{
 				count: 2,
-				key: '2017-12',
 				title: 'Dec 2017',
 				value: {
 					month: '2017-12',
@@ -112,10 +106,9 @@ describe( 'getBillingTransactionDateFilterValues()', () => {
 			},
 			{
 				count: 2,
-				key: '2017-11',
 				title: 'Older',
 				value: {
-					month: '2017-11',
+					month: '2017-12',
 					operator: 'before',
 				},
 			},

--- a/client/state/selectors/test/get-billing-transaction-date-filter-values.js
+++ b/client/state/selectors/test/get-billing-transaction-date-filter-values.js
@@ -1,0 +1,136 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { getBillingTransactionDateFilterValues } from 'state/selectors';
+
+jest.mock( 'i18n-calypso', () => {
+	const moment = require( 'moment' );
+	moment.now = () => new Date( 2018, 4, 24 ); //May 24, 2018
+	return {
+		translate: str => str,
+		moment: moment,
+	};
+} );
+
+describe( 'getBillingTransactionDateFilterValues()', () => {
+	const state = {
+		billingTransactions: {
+			items: {
+				past: [
+					{
+						date: '2018-05-01T12:00:00+0000',
+					},
+					{
+						date: '2018-04-11T13:11:27+0000',
+					},
+					{
+						date: '2018-03-11T21:00:00+0000',
+					},
+					{
+						date: '2018-03-15T10:39:27+0000',
+					},
+					{
+						date: '2018-03-13T16:10:45+0000',
+					},
+					{
+						date: '2018-01-10T14:24:38+0000',
+					},
+					{
+						date: '2017-12-10T10:30:38+0000',
+					},
+					{
+						date: '2017-12-01T07:20:00+0000',
+					},
+					{
+						date: '2017-11-24T05:13:00+0000',
+					},
+					{
+						date: '2017-01-01T00:00:00+0000',
+					},
+				],
+			},
+		},
+	};
+
+	test( 'returns transaction app filter values with counts', () => {
+		const result = getBillingTransactionDateFilterValues( state, 'past' );
+		expect( result ).toEqual( [
+			{
+				count: 1,
+				key: '2018-05',
+				title: 'May 2018',
+				value: {
+					month: '2018-05',
+					operator: 'equal',
+				},
+			},
+			{
+				count: 1,
+				key: '2018-04',
+				title: 'Apr 2018',
+				value: {
+					month: '2018-04',
+					operator: 'equal',
+				},
+			},
+			{
+				count: 3,
+				key: '2018-03',
+				title: 'Mar 2018',
+				value: {
+					month: '2018-03',
+					operator: 'equal',
+				},
+			},
+			{
+				count: 0,
+				key: '2018-02',
+				title: 'Feb 2018',
+				value: {
+					month: '2018-02',
+					operator: 'equal',
+				},
+			},
+			{
+				count: 1,
+				key: '2018-01',
+				title: 'Jan 2018',
+				value: {
+					month: '2018-01',
+					operator: 'equal',
+				},
+			},
+			{
+				count: 2,
+				key: '2017-12',
+				title: 'Dec 2017',
+				value: {
+					month: '2017-12',
+					operator: 'equal',
+				},
+			},
+			{
+				count: 2,
+				key: '2017-11',
+				title: 'Older',
+				value: {
+					month: '2017-11',
+					operator: 'before',
+				},
+			},
+		] );
+	} );
+
+	test( 'returns an empty array when there are no transactions', () => {
+		const result = getBillingTransactionDateFilterValues(
+			{
+				billingTransactions: {
+					items: {},
+				},
+			},
+			'past'
+		);
+		expect( result ).toEqual( [] );
+	} );
+} );

--- a/client/state/selectors/test/get-billing-transaction-filters.js
+++ b/client/state/selectors/test/get-billing-transaction-filters.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { cloneDeep } from 'lodash';
+
 /**
  * Internal dependencies
  */

--- a/client/state/selectors/test/get-billing-transaction-filters.js
+++ b/client/state/selectors/test/get-billing-transaction-filters.js
@@ -1,0 +1,58 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { cloneDeep } from 'lodash';
+/**
+ * Internal dependencies
+ */
+import { getBillingTransactionFilters } from 'state/selectors';
+
+describe( 'getBillingTransactionFilters()', () => {
+	const state = {
+		ui: {
+			billingTransactions: {
+				past: {
+					app: 'test app',
+					date: { month: '2018-03', operator: 'equal' },
+					page: 3,
+					query: 'test query',
+				},
+			},
+		},
+	};
+
+	test( 'returns transaction filters', () => {
+		const output = getBillingTransactionFilters( state, 'past' );
+		expect( output ).toEqual( {
+			app: 'test app',
+			date: { month: '2018-03', operator: 'equal' },
+			page: 3,
+			query: 'test query',
+		} );
+	} );
+
+	test( 'returns default values for non-existent filters', () => {
+		const output = getBillingTransactionFilters( state, 'upcoming' );
+		expect( output ).toEqual( {
+			app: '',
+			date: { month: null, operator: null },
+			page: 1,
+			query: '',
+		} );
+	} );
+
+	test( 'fills missing values', () => {
+		const testState = cloneDeep( state );
+		testState.ui.billingTransactions.past = {
+			app: 'test app',
+		};
+		const output = getBillingTransactionFilters( testState, 'past' );
+		expect( output ).toEqual( {
+			app: 'test app',
+			date: { month: null, operator: null },
+			page: 1,
+			query: '',
+		} );
+	} );
+} );

--- a/client/state/selectors/test/get-billing-transactions-by-type.js
+++ b/client/state/selectors/test/get-billing-transactions-by-type.js
@@ -1,0 +1,68 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { moment } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getBillingTransactionsByType } from 'state/selectors';
+
+describe( 'getBillingTransactionsByType()', () => {
+	const state = {
+		billingTransactions: {
+			items: {
+				past: [
+					{
+						id: '12345678',
+						amount: '$1.23',
+						date: '2016-12-12T11:22:33+0000',
+					},
+				],
+				upcoming: [
+					{
+						id: '87654321',
+						amount: '$4.56',
+						date: '2016-10-12T11:22:33+0000',
+					},
+				],
+			},
+		},
+	};
+
+	test( 'should return the past billing transactions', () => {
+		const output = getBillingTransactionsByType( state, 'past' );
+		expect( output ).toEqual( [
+			{
+				id: '12345678',
+				amount: '$1.23',
+				date: moment( '2016-12-12T11:22:33+0000' ).toDate(),
+			},
+		] );
+	} );
+
+	test( 'should return the upcoming billing transactions', () => {
+		const output = getBillingTransactionsByType( state, 'upcoming' );
+		expect( output ).toEqual( [
+			{
+				id: '87654321',
+				amount: '$4.56',
+				date: moment( '2016-10-12T11:22:33+0000' ).toDate(),
+			},
+		] );
+	} );
+
+	test( 'should return null if billing transactions have not been fetched yet', () => {
+		const output = getBillingTransactionsByType(
+			{
+				billingTransactions: {
+					items: {},
+				},
+			},
+			'past'
+		);
+		expect( output ).toBe( null );
+	} );
+} );

--- a/client/state/selectors/test/get-filtered-billing-transactions.js
+++ b/client/state/selectors/test/get-filtered-billing-transactions.js
@@ -4,6 +4,7 @@
  */
 import { moment } from 'i18n-calypso';
 import { cloneDeep, slice } from 'lodash';
+
 /**
  * Internal dependencies
  */

--- a/client/state/selectors/test/get-filtered-billing-transactions.js
+++ b/client/state/selectors/test/get-filtered-billing-transactions.js
@@ -4,6 +4,7 @@
  */
 import { moment } from 'i18n-calypso';
 import { cloneDeep, slice } from 'lodash';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -176,7 +177,7 @@ describe( 'getBillingTransactionAppFilterValues()', () => {
 			testState.ui.billingTransactions.past = {
 				date: { month: null, operator: null },
 			};
-			const result = getFilteredBillingTransactions( testState, 'past' );
+			const result = getFilteredBillingTransactions( deepFreeze( testState ), 'past' );
 			expect( result ).toEqual( {
 				pageSize: PAGE_SIZE,
 				total: 10,
@@ -194,7 +195,7 @@ describe( 'getBillingTransactionAppFilterValues()', () => {
 			testState.ui.billingTransactions.past = {
 				date: { month: '2018-03', operator: 'equal' },
 			};
-			const result = getFilteredBillingTransactions( testState, 'past' );
+			const result = getFilteredBillingTransactions( deepFreeze( testState ), 'past' );
 			expect( result.total ).toEqual( 3 );
 			expect( result.transactions.length ).toEqual( 3 );
 			expect( result.transactions[ 0 ].date.getMonth() ).toEqual( 2 );
@@ -207,7 +208,7 @@ describe( 'getBillingTransactionAppFilterValues()', () => {
 			testState.ui.billingTransactions.past = {
 				date: { month: '2017-12', operator: 'before' },
 			};
-			const result = getFilteredBillingTransactions( testState, 'past' );
+			const result = getFilteredBillingTransactions( deepFreeze( testState ), 'past' );
 			expect( result.total ).toEqual( 2 );
 			expect( result.transactions.length ).toEqual( 2 );
 			expect( result.transactions[ 0 ].date.getMonth() ).toEqual( 10 );
@@ -217,7 +218,7 @@ describe( 'getBillingTransactionAppFilterValues()', () => {
 
 	describe( 'app filter', () => {
 		test( 'returns the first page of all transactions when the filter is empty', () => {
-			const result = getFilteredBillingTransactions( state, 'past' );
+			const result = getFilteredBillingTransactions( deepFreeze( state ), 'past' );
 			expect( result ).toEqual( {
 				pageSize: PAGE_SIZE,
 				total: 10,
@@ -235,7 +236,7 @@ describe( 'getBillingTransactionAppFilterValues()', () => {
 			testState.ui.billingTransactions.past = {
 				app: 'Store Services',
 			};
-			const result = getFilteredBillingTransactions( testState, 'past' );
+			const result = getFilteredBillingTransactions( deepFreeze( testState ), 'past' );
 			expect( result.total ).toEqual( 5 );
 			expect( result.transactions.length ).toEqual( 5 );
 			result.transactions.forEach( transaction => {
@@ -246,7 +247,7 @@ describe( 'getBillingTransactionAppFilterValues()', () => {
 
 	describe( 'search query', () => {
 		test( 'returns all transactions when the filter is empty', () => {
-			const result = getFilteredBillingTransactions( state, 'past' );
+			const result = getFilteredBillingTransactions( deepFreeze( state ), 'past' );
 			expect( result ).toEqual( {
 				pageSize: PAGE_SIZE,
 				total: 10,
@@ -264,7 +265,7 @@ describe( 'getBillingTransactionAppFilterValues()', () => {
 			testState.ui.billingTransactions.past = {
 				query: 'mastercard',
 			};
-			const result = getFilteredBillingTransactions( testState, 'past' );
+			const result = getFilteredBillingTransactions( deepFreeze( testState ), 'past' );
 			expect( result.total ).toEqual( 4 );
 			expect( result.transactions.length ).toEqual( 4 );
 			result.transactions.forEach( transaction => {
@@ -277,7 +278,7 @@ describe( 'getBillingTransactionAppFilterValues()', () => {
 			testState.ui.billingTransactions.past = {
 				query: '$3.50',
 			};
-			const result = getFilteredBillingTransactions( testState, 'past' );
+			const result = getFilteredBillingTransactions( deepFreeze( testState ), 'past' );
 			expect( result.total ).toEqual( 3 );
 			expect( result.transactions.length ).toEqual( 3 );
 			expect( result.transactions[ 0 ].items ).toMatchObject( [ { amount: '$3.50' } ] );
@@ -296,7 +297,7 @@ describe( 'getBillingTransactionAppFilterValues()', () => {
 				date: { month: '2018-03', operator: 'equal' },
 				app: 'Store Services',
 			};
-			const result = getFilteredBillingTransactions( testState, 'past' );
+			const result = getFilteredBillingTransactions( deepFreeze( testState ), 'past' );
 			expect( result.total ).toEqual( 2 );
 			expect( result.transactions.length ).toEqual( 2 );
 			expect( result.transactions[ 0 ].date.getMonth() ).toEqual( 2 );
@@ -311,7 +312,7 @@ describe( 'getBillingTransactionAppFilterValues()', () => {
 				app: 'Store Services',
 				query: '$3.50',
 			};
-			const result = getFilteredBillingTransactions( testState, 'past' );
+			const result = getFilteredBillingTransactions( deepFreeze( testState ), 'past' );
 			expect( result.total ).toEqual( 1 );
 			expect( result.transactions.length ).toEqual( 1 );
 			expect( result.transactions[ 0 ].items ).toMatchObject( [
@@ -327,7 +328,7 @@ describe( 'getBillingTransactionAppFilterValues()', () => {
 				date: { month: '2018-05', operator: 'equal' },
 				query: '$3.50',
 			};
-			const result = getFilteredBillingTransactions( testState, 'past' );
+			const result = getFilteredBillingTransactions( deepFreeze( testState ), 'past' );
 			expect( result.total ).toEqual( 1 );
 			expect( result.transactions.length ).toEqual( 1 );
 			expect( result.transactions[ 0 ].items ).toMatchObject( [ { amount: '$3.50' } ] );
@@ -341,7 +342,7 @@ describe( 'getBillingTransactionAppFilterValues()', () => {
 				query: 'visa',
 				app: 'WordPress.com',
 			};
-			const result = getFilteredBillingTransactions( testState, 'past' );
+			const result = getFilteredBillingTransactions( deepFreeze( testState ), 'past' );
 			expect( result.total ).toEqual( 1 );
 			expect( result.transactions.length ).toEqual( 1 );
 			expect( result.transactions[ 0 ].cc_type ).toEqual( 'visa' );
@@ -356,7 +357,7 @@ describe( 'getBillingTransactionAppFilterValues()', () => {
 			testState.ui.billingTransactions.past = {
 				date: { month: '2019-01', operator: 'equal' },
 			};
-			const result = getFilteredBillingTransactions( testState, 'past' );
+			const result = getFilteredBillingTransactions( deepFreeze( testState ), 'past' );
 			expect( result ).toEqual( {
 				total: 0,
 				pageSize: PAGE_SIZE,

--- a/client/state/selectors/test/get-filtered-billing-transactions.js
+++ b/client/state/selectors/test/get-filtered-billing-transactions.js
@@ -1,0 +1,366 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { moment } from 'i18n-calypso';
+import { cloneDeep, slice } from 'lodash';
+/**
+ * Internal dependencies
+ */
+import { getFilteredBillingTransactions } from 'state/selectors';
+
+describe( 'getBillingTransactionAppFilterValues()', () => {
+	const PAGE_SIZE = 5;
+
+	const state = {
+		billingTransactions: {
+			items: {
+				past: [
+					{
+						date: '2018-05-01T12:00:00+0000',
+						service: 'WordPress.com',
+						cc_name: 'name1 surname1',
+						cc_type: 'mastercard',
+						items: [
+							{
+								amount: '$3.50',
+								type: 'new purchase',
+								variation: 'Variation1',
+							},
+						],
+					},
+					{
+						date: '2018-04-11T13:11:27+0000',
+						service: 'WordPress.com',
+						cc_name: 'name2',
+						cc_type: 'visa',
+						items: [
+							{
+								amount: '$5.75',
+								type: 'new purchase',
+								variation: 'Variation2',
+							},
+							{
+								amount: '$8.00',
+								type: 'new purchase',
+								variation: 'Variation2',
+							},
+						],
+					},
+					{
+						date: '2018-03-11T21:00:00+0000',
+						service: 'Store Services',
+						cc_name: 'name1 surname1',
+						cc_type: 'visa',
+						items: [
+							{
+								amount: '$3.50',
+								type: 'new purchase',
+								variation: 'Variation2',
+							},
+							{
+								amount: '$5.00',
+								type: 'new purchase',
+								variation: 'Variation2',
+							},
+						],
+					},
+					{
+						date: '2018-03-15T10:39:27+0000',
+						service: 'Store Services',
+						cc_name: 'name2',
+						cc_type: 'mastercard',
+						items: [
+							{
+								amount: '$4.86',
+								type: 'new purchase',
+								variation: 'Variation1',
+							},
+							{
+								amount: '$1.23',
+								type: 'new purchase',
+								variation: 'Variation1',
+							},
+						],
+					},
+					{
+						date: '2018-03-13T16:10:45+0000',
+						service: 'WordPress.com',
+						cc_name: 'name1 surname1',
+						cc_type: 'visa',
+						items: [
+							{
+								amount: '$3.50',
+								type: 'new purchase',
+								variation: 'Variation1',
+							},
+						],
+					},
+					{
+						date: '2018-01-10T14:24:38+0000',
+						service: 'WordPress.com',
+						cc_name: 'name2',
+						cc_type: 'mastercard',
+						items: [
+							{
+								amount: '$4.20',
+								type: 'new purchase',
+								variation: 'Variation2',
+							},
+						],
+					},
+					{
+						date: '2017-12-10T10:30:38+0000',
+						service: 'Store Services',
+						cc_name: 'name1 surname1',
+						cc_type: 'visa',
+						items: [
+							{
+								amount: '$3.75',
+								type: 'new purchase',
+								variation: 'Variation1',
+							},
+						],
+					},
+					{
+						date: '2017-12-01T07:20:00+0000',
+						service: 'Store Services',
+						cc_name: 'name1 surname1',
+						cc_type: 'visa',
+						items: [
+							{
+								amount: '$9.50',
+								type: 'new purchase',
+								variation: 'Variation1',
+							},
+						],
+					},
+					{
+						date: '2017-11-24T05:13:00+0000',
+						service: 'WordPress.com',
+						cc_name: 'name1 surname1',
+						cc_type: 'visa',
+						items: [
+							{
+								amount: '$8.40',
+								type: 'new purchase',
+								variation: 'Variation2',
+							},
+						],
+					},
+					{
+						date: '2017-01-01T00:00:00+0000',
+						service: 'Store Services',
+						cc_name: 'name2',
+						cc_type: 'mastercard',
+						items: [
+							{
+								amount: '$2.40',
+								type: 'new purchase',
+								variation: 'Variation1',
+							},
+						],
+					},
+				],
+			},
+		},
+		ui: {
+			billingTransactions: {},
+		},
+	};
+
+	describe( 'date filter', () => {
+		test( 'returns a page from all transactions when filtering by newest', () => {
+			const testState = cloneDeep( state );
+			testState.ui.billingTransactions.past = {
+				date: { month: null, operator: null },
+			};
+			const result = getFilteredBillingTransactions( testState, 'past' );
+			expect( result ).toEqual( {
+				pageSize: PAGE_SIZE,
+				total: 10,
+				transactions: slice( state.billingTransactions.items.past, 0, PAGE_SIZE ).map(
+					transaction => ( {
+						...transaction,
+						date: moment( transaction.date ).toDate(),
+					} )
+				),
+			} );
+		} );
+
+		test( 'returns transactions filtered by month', () => {
+			const testState = cloneDeep( state );
+			testState.ui.billingTransactions.past = {
+				date: { month: '2018-03', operator: 'equal' },
+			};
+			const result = getFilteredBillingTransactions( testState, 'past' );
+			expect( result.total ).toEqual( 3 );
+			expect( result.transactions.length ).toEqual( 3 );
+			expect( result.transactions[ 0 ].date.getMonth() ).toEqual( 2 );
+			expect( result.transactions[ 1 ].date.getMonth() ).toEqual( 2 );
+			expect( result.transactions[ 2 ].date.getMonth() ).toEqual( 2 );
+		} );
+
+		test( 'returns transactions before the month set in the filter', () => {
+			const testState = cloneDeep( state );
+			testState.ui.billingTransactions.past = {
+				date: { month: '2017-12', operator: 'before' },
+			};
+			const result = getFilteredBillingTransactions( testState, 'past' );
+			expect( result.total ).toEqual( 2 );
+			expect( result.transactions.length ).toEqual( 2 );
+			expect( result.transactions[ 0 ].date.getMonth() ).toEqual( 10 );
+			expect( result.transactions[ 1 ].date.getMonth() ).toEqual( 0 );
+		} );
+	} );
+
+	describe( 'app filter', () => {
+		test( 'returns the first page of all transactions when the filter is empty', () => {
+			const result = getFilteredBillingTransactions( state, 'past' );
+			expect( result ).toEqual( {
+				pageSize: PAGE_SIZE,
+				total: 10,
+				transactions: slice( state.billingTransactions.items.past, 0, PAGE_SIZE ).map(
+					transaction => ( {
+						...transaction,
+						date: moment( transaction.date ).toDate(),
+					} )
+				),
+			} );
+		} );
+
+		test( 'returns transactions filtered by app name', () => {
+			const testState = cloneDeep( state );
+			testState.ui.billingTransactions.past = {
+				app: 'Store Services',
+			};
+			const result = getFilteredBillingTransactions( testState, 'past' );
+			expect( result.total ).toEqual( 5 );
+			expect( result.transactions.length ).toEqual( 5 );
+			result.transactions.forEach( transaction => {
+				expect( transaction.service ).toEqual( 'Store Services' );
+			} );
+		} );
+	} );
+
+	describe( 'search query', () => {
+		test( 'returns all transactions when the filter is empty', () => {
+			const result = getFilteredBillingTransactions( state, 'past' );
+			expect( result ).toEqual( {
+				pageSize: PAGE_SIZE,
+				total: 10,
+				transactions: slice( state.billingTransactions.items.past, 0, PAGE_SIZE ).map(
+					transaction => ( {
+						...transaction,
+						date: moment( transaction.date ).toDate(),
+					} )
+				),
+			} );
+		} );
+
+		test( 'query matches a field in the root transaction object', () => {
+			const testState = cloneDeep( state );
+			testState.ui.billingTransactions.past = {
+				query: 'mastercard',
+			};
+			const result = getFilteredBillingTransactions( testState, 'past' );
+			expect( result.total ).toEqual( 4 );
+			expect( result.transactions.length ).toEqual( 4 );
+			result.transactions.forEach( transaction => {
+				expect( transaction.cc_type ).toEqual( 'mastercard' );
+			} );
+		} );
+
+		test( 'query matches a field in the transaction items array', () => {
+			const testState = cloneDeep( state );
+			testState.ui.billingTransactions.past = {
+				query: '$3.50',
+			};
+			const result = getFilteredBillingTransactions( testState, 'past' );
+			expect( result.total ).toEqual( 3 );
+			expect( result.transactions.length ).toEqual( 3 );
+			expect( result.transactions[ 0 ].items ).toMatchObject( [ { amount: '$3.50' } ] );
+			expect( result.transactions[ 1 ].items ).toMatchObject( [
+				{ amount: '$3.50' },
+				{ amount: '$5.00' },
+			] );
+			expect( result.transactions[ 2 ].items ).toMatchObject( [ { amount: '$3.50' } ] );
+		} );
+	} );
+
+	describe( 'filter combinations', () => {
+		test( 'date and app filters', () => {
+			const testState = cloneDeep( state );
+			testState.ui.billingTransactions.past = {
+				date: { month: '2018-03', operator: 'equal' },
+				app: 'Store Services',
+			};
+			const result = getFilteredBillingTransactions( testState, 'past' );
+			expect( result.total ).toEqual( 2 );
+			expect( result.transactions.length ).toEqual( 2 );
+			expect( result.transactions[ 0 ].date.getMonth() ).toEqual( 2 );
+			expect( result.transactions[ 0 ].service ).toEqual( 'Store Services' );
+			expect( result.transactions[ 1 ].date.getMonth() ).toEqual( 2 );
+			expect( result.transactions[ 1 ].service ).toEqual( 'Store Services' );
+		} );
+
+		test( 'app and query filters', () => {
+			const testState = cloneDeep( state );
+			testState.ui.billingTransactions.past = {
+				app: 'Store Services',
+				query: '$3.50',
+			};
+			const result = getFilteredBillingTransactions( testState, 'past' );
+			expect( result.total ).toEqual( 1 );
+			expect( result.transactions.length ).toEqual( 1 );
+			expect( result.transactions[ 0 ].items ).toMatchObject( [
+				{ amount: '$3.50' },
+				{ amount: '$5.00' },
+			] );
+			expect( result.transactions[ 0 ].service ).toEqual( 'Store Services' );
+		} );
+
+		test( 'date and query filters', () => {
+			const testState = cloneDeep( state );
+			testState.ui.billingTransactions.past = {
+				date: { month: '2018-05', operator: 'equal' },
+				query: '$3.50',
+			};
+			const result = getFilteredBillingTransactions( testState, 'past' );
+			expect( result.total ).toEqual( 1 );
+			expect( result.transactions.length ).toEqual( 1 );
+			expect( result.transactions[ 0 ].items ).toMatchObject( [ { amount: '$3.50' } ] );
+			expect( result.transactions[ 0 ].date.getMonth() ).toEqual( 4 );
+		} );
+
+		test( 'app, date and query filters', () => {
+			const testState = cloneDeep( state );
+			testState.ui.billingTransactions.past = {
+				date: { month: '2018-03', operator: 'equal' },
+				query: 'visa',
+				app: 'WordPress.com',
+			};
+			const result = getFilteredBillingTransactions( testState, 'past' );
+			expect( result.total ).toEqual( 1 );
+			expect( result.transactions.length ).toEqual( 1 );
+			expect( result.transactions[ 0 ].cc_type ).toEqual( 'visa' );
+			expect( result.transactions[ 0 ].date.getMonth() ).toEqual( 2 );
+			expect( result.transactions[ 0 ].service ).toEqual( 'WordPress.com' );
+		} );
+	} );
+
+	describe( 'no results', () => {
+		test( 'should return all expected meta fields including an empty transactions array', () => {
+			const testState = cloneDeep( state );
+			testState.ui.billingTransactions.past = {
+				date: { month: '2019-01', operator: 'equal' },
+			};
+			const result = getFilteredBillingTransactions( testState, 'past' );
+			expect( result ).toEqual( {
+				total: 0,
+				pageSize: PAGE_SIZE,
+				transactions: [],
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
This is continuation of work started in #22883 and depends on #23798 to be shipped first.

In order to preserve the pagination and filters state after a single transaction has been opened, the state will need to be stored in Redux instead of the internal component state.

The previous PR added actions and reducers to store and manipulate the billing transaction filters. This PR adds selectors to:
* get the filter metadata required to render the filter dropdowns (titles and counts)
* get the filtered transactions
* get the values of the selected filters

The plan is to remove the `me/billing-history/table-rows.js` and move the filtering of the transactions from it and the component to Redux

To test:
* unit tests should pass
* code should look good
* #23800 ties the changes to the UI