### PR TITLE
Domains: Show price for incoming transfers

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -18,14 +18,17 @@ import { stringify } from 'qs';
 import {
 	checkDomainAvailability,
 	checkInboundTransferStatus,
+	getDomainPrice,
+	getDomainProductSlug,
 	getFixedDomainSearch,
 	getTld,
 	startInboundTransfer,
 } from 'lib/domains';
+import { getProductsList } from 'state/products-list/selectors';
 import { domainAvailability } from 'lib/domains/constants';
 import { getAvailabilityNotice } from 'lib/domains/registration/availability-messages';
 import DomainRegistrationSuggestion from 'components/domains/domain-registration-suggestion';
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUser, getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import Notice from 'components/notice';
 import Card from 'components/card';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
@@ -39,6 +42,7 @@ import TransferRestrictionMessage from 'components/domains/transfer-domain-step/
 import { fetchDomains } from 'lib/upgrades/actions';
 import { domainManagementTransferIn } from 'my-sites/domains/paths';
 import { errorNotice } from 'state/notices/actions';
+import QueryProducts from 'components/data/query-products-list';
 
 class TransferDomainStep extends React.Component {
 	static propTypes = {
@@ -131,9 +135,16 @@ class TransferDomainStep extends React.Component {
 		const { translate } = this.props;
 		const { searchQuery, submittingAvailability, submittingWhois } = this.state;
 		const submitting = submittingAvailability || submittingWhois;
+		const productSlug = getDomainProductSlug( searchQuery );
+		const domainProductPrice = getDomainPrice(
+			productSlug,
+			this.props.productsList,
+			this.props.currencyCode
+		);
 
 		return (
 			<div>
+				<QueryProducts />
 				{ this.notice() }
 				<form className="transfer-domain-step__form card" onSubmit={ this.handleFormSubmit }>
 					<div className="transfer-domain-step__domain-description">
@@ -173,6 +184,7 @@ class TransferDomainStep extends React.Component {
 							onBlur={ this.save }
 							onChange={ this.setSearchQuery }
 							onFocus={ this.recordInputFocus }
+							suffix={ domainProductPrice }
 							autoFocus
 						/>
 					</div>
@@ -530,7 +542,9 @@ const recordMapDomainButtonClick = section =>
 export default connect(
 	state => ( {
 		currentUser: getCurrentUser( state ),
+		currencyCode: getCurrentUserCurrencyCode( state ),
 		selectedSite: getSelectedSite( state ),
+		productsList: getProductsList( state ),
 	} ),
 	{
 		errorNotice,

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -14,6 +14,7 @@ import wpcom from 'lib/wp';
 import { type as domainTypes, domainAvailability } from './constants';
 import { parseDomainAgainstTldList } from './utils';
 import wpcomMultiLevelTlds from './tlds/wpcom-multi-level-tlds.json';
+import formatCurrency from 'lib/format-currency';
 
 const GOOGLE_APPS_INVALID_TLDS = [ 'in' ],
 	GOOGLE_APPS_BANNED_PHRASES = [ 'google' ];
@@ -260,11 +261,22 @@ function getDomainProductSlug( domain ) {
 	return `dot${ tldSlug }_domain`;
 }
 
+function getDomainPrice( slug, productsList, currencyCode ) {
+	let price = get( productsList, [ slug, 'cost' ], null );
+	if ( price ) {
+		price += get( productsList, [ 'domain_map', 'cost' ], 0 );
+		price = formatCurrency( price, currencyCode );
+	}
+
+	return price;
+}
+
 export {
 	canAddGoogleApps,
 	canRedirect,
 	checkDomainAvailability,
 	checkInboundTransferStatus,
+	getDomainPrice,
 	getDomainProductSlug,
 	getFixedDomainSearch,
 	getGoogleAppsSupportedDomains,

--- a/client/state/products-list/schema.js
+++ b/client/state/products-list/schema.js
@@ -20,7 +20,7 @@ export const productsListSchema = {
 				product_name: { type: 'string' },
 				product_slug: { type: 'string' },
 				description: { type: 'string' },
-				cost: { type: [ 'string', 'null' ] },
+				cost: { type: [ 'integer', 'null' ] },
 				prices: {
 					type: 'object',
 				},

--- a/client/state/products-list/test/reducer.js
+++ b/client/state/products-list/test/reducer.js
@@ -74,7 +74,7 @@ describe( 'reducer', () => {
 						prices: { USD: 129, AUD: 169 },
 						is_domain_registration: false,
 						description: 'Guided Transfer',
-						cost: '129',
+						cost: 129,
 						cost_display: '$129',
 					},
 				} );
@@ -92,7 +92,7 @@ describe( 'reducer', () => {
 						prices: { USD: 129, AUD: 169 },
 						is_domain_registration: false,
 						description: 'Guided Transfer',
-						cost: '129',
+						cost: 129,
 						cost_display: '$129',
 					},
 				} );


### PR DESCRIPTION
We want to display the price for an incoming transfer when users input the domain.

Test:
- http://calypso.localhost:3000/domains/add/transfer/
- Choose a site
- Input a valid TLD we offer
- See price as suffix

Before:
![transfer no](https://user-images.githubusercontent.com/1103398/38140320-8c26b154-3433-11e8-9207-c1f0438d837d.png)

After:
![transfer in price](https://user-images.githubusercontent.com/1103398/38140322-8f4b371a-3433-11e8-8bb4-2e99d5bdf977.png)


Dependency: D11374-code