### PR TITLE
Signup: Add track events for vertical plans AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -102,7 +102,7 @@ export default {
 		datestamp: '20180320',
 		variations: {
 			original: 50,
-			mobile: 50,
+			vertical: 50,
 		},
 		defaultVariation: 'original',
 		allowExistingUsers: true,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -99,7 +99,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	mobilePlansTablesOnSignup: {
-		datestamp: '20180320',
+		datestamp: '20180330',
 		variations: {
 			original: 50,
 			vertical: 50,

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -64,7 +64,7 @@ class PlanFeatures extends Component {
 		const planClasses = classNames( 'plan-features', {
 			'plan-features--signup': isInSignup,
 			'abtest-pricing-display': showModifiedPricingDisplay,
-			'has-mobile-table': abtest( 'mobilePlansTablesOnSignup' ) === 'mobile',
+			'has-mobile-table': abtest( 'mobilePlansTablesOnSignup' ) === 'vertical',
 		} );
 		const planWrapperClasses = classNames( { 'plans-wrapper': isInSignup } );
 		let mobileView, planDescriptions;

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -55,6 +55,15 @@ import { retargetViewPlans } from 'lib/analytics/ad-tracking';
 import { abtest, getABTestVariation } from 'lib/abtest';
 
 class PlanFeatures extends Component {
+	componentDidMount() {
+		const { isInSignup } = this.props;
+		// Check if user is in signup flow & small screens
+		// Used in AB test: mobilePlansTablesOnSignup_20180330
+		if ( isInSignup && window.matchMedia( '(max-width: 660px)' ).matches ) {
+			this.props.recordTracksEvent( 'calypso_wp_plans_verticalabtest_view' );
+		}
+	}
+
 	render() {
 		const { planProperties, isInSignup, showModifiedPricingDisplay, site } = this.props;
 		const tableClasses = classNames(
@@ -74,12 +83,6 @@ class PlanFeatures extends Component {
 			planDescriptions = <tr>{ this.renderPlanDescriptions() }</tr>;
 
 			bottomButtons = <tr>{ this.renderBottomButtons() }</tr>;
-		}
-
-		// Check if user is in signup flow & small screens
-		// Used in AB test: mobilePlansTablesOnSignup_20180330
-		if ( isInSignup && window.matchMedia( '(max-width: 660px)' ).matches ) {
-			this.props.recordTracksEvent( 'calypso_wp_plans_verticalabtest_view' );
 		}
 
 		mobileView = <div className="plan-features__mobile">{ this.renderMobileView() }</div>;

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -56,11 +56,13 @@ import { abtest, getABTestVariation } from 'lib/abtest';
 
 class PlanFeatures extends Component {
 	componentDidMount() {
-		const { isInSignup } = this.props;
+		const { basePlansPath, isInSignup } = this.props;
 		// Check if user is in signup flow & small screens
 		// Used in AB test: mobilePlansTablesOnSignup_20180330
 		if ( isInSignup && window.matchMedia( '(max-width: 660px)' ).matches ) {
-			this.props.recordTracksEvent( 'calypso_wp_plans_verticalabtest_view' );
+			this.props.recordTracksEvent( 'calypso_wp_plans_verticalabtest_view', {
+				base_plans_path: basePlansPath,
+			} );
 		}
 	}
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -76,6 +76,12 @@ class PlanFeatures extends Component {
 			bottomButtons = <tr>{ this.renderBottomButtons() }</tr>;
 		}
 
+		// Check if user is in signup flow & small screens
+		// Used in AB test: mobilePlansTablesOnSignup_20180330
+		if ( isInSignup && window.matchMedia( '(max-width: 660px)' ).matches ) {
+			this.props.recordTracksEvent( 'calypso_wp_plans_verticalabtest_view' );
+		}
+
 		mobileView = <div className="plan-features__mobile">{ this.renderMobileView() }</div>;
 
 		if ( isInSignup && abtest( 'mobilePlansTablesOnSignup' ) === 'original' ) {


### PR DESCRIPTION
This PR adds new a track event to target signups and small devices.

In the previous run, we weren’t getting good enough parameters to test the hypothesis, so this change adds an isolated and accurate tracks event `calypso_wp_plans_verticalabtest_view` for this specific AB test.

Event only fires in signup flows, for screens less than, or equal to, 660 pixels wide.

Previous PR: #23454
This supersedes: #23723 
Related wp-e2e-tests PR: https://github.com/Automattic/wp-e2e-tests/pull/1110