### PR TITLE
Store Dashboard: Add a base route with the site selector

### DIFF
--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -8,7 +8,6 @@ import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import page from 'page';
 import PropTypes from 'prop-types';
 
 /**
@@ -24,7 +23,6 @@ import DocumentHead from 'components/data/document-head';
 import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
-import { getSiteFragment } from 'lib/route';
 import WooCommerceColophon from 'woocommerce/components/woocommerce-colophon';
 
 class App extends Component {
@@ -32,7 +30,6 @@ class App extends Component {
 		siteId: PropTypes.number,
 		documentTitle: PropTypes.string,
 		canUserManageOptions: PropTypes.bool.isRequired,
-		currentRoute: PropTypes.string.isRequired,
 		isAtomicSite: PropTypes.bool.isRequired,
 		hasPendingAutomatedTransfer: PropTypes.bool.isRequired,
 		children: PropTypes.element.isRequired,
@@ -72,18 +69,8 @@ class App extends Component {
 			canUserManageOptions,
 			isAtomicSite,
 			hasPendingAutomatedTransfer,
-			currentRoute,
 			translate,
 		} = this.props;
-
-		// TODO This is temporary, until we have a valid "all sites" path to show.
-		// Calypso will detect if a user doesn't have access to a site at all, and redirects to the 'all sites'
-		// version of that URL. We don't want to render anything right now, so continue redirecting to my-sites.
-		if ( ! getSiteFragment( currentRoute ) ) {
-			this.redirect();
-			return null;
-		}
-
 		if ( ! siteId ) {
 			return null;
 		}
@@ -129,7 +116,6 @@ function mapStateToProps( state ) {
 		canUserManageOptions,
 		isAtomicSite,
 		hasPendingAutomatedTransfer,
-		currentRoute: page.current,
 	};
 }
 

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -249,6 +249,8 @@ function addTracksContext( context, next ) {
 }
 
 export default function() {
+	page( '/store', siteSelection, sites, makeLayout, clientRender );
+
 	// Add pages that use the store navigation
 	getStorePages().forEach( function( storePage ) {
 		if ( config.isEnabled( storePage.configKey ) ) {


### PR DESCRIPTION
This PR adds the site selector dropdown to the `/store` route, in case someone visits the URL without a site set. Visiting a subpage, like `/store/settings`, redirects to the `/store` route for the site picker.

<img width="374" alt="screen shot 2018-03-30 at 11 59 47 am" src="https://user-images.githubusercontent.com/541093/38144226-e5db8502-3411-11e8-9867-3a1683c1ac3e.png">

It would be cool, if we wanted to spend some time on this, to have a site selector which only shows store-enabled sites – right now it's just the default "all your sites" selector. If you pick a non-store site, like a wp.com site, it shows you the "set up my store" flow.

**To test**

- Visit `/store`
- Click a store-enabled site, you should be redirected to your site's store dashboard.
