### PR TITLE
Media: fix wrong paths in page view analytics

### DIFF
--- a/client/my-sites/media/controller.js
+++ b/client/my-sites/media/controller.js
@@ -3,43 +3,20 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
-import i18n from 'i18n-calypso';
 
 /**
  * Internal Dependencies
  */
-import { sectionify } from 'lib/route';
-import analytics from 'lib/analytics';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { getSelectedSite } from 'state/ui/selectors';
+
 import MediaComponent from 'my-sites/media/main';
 
 export default {
 	media: function( context, next ) {
-		const filter = context.params.filter;
-		const search = context.query.s;
-		let baseAnalyticsPath = sectionify( context.path );
-
-		const state = context.store.getState();
-		const selectedSite = getSelectedSite( state );
-
-		// Analytics
-		if ( selectedSite ) {
-			baseAnalyticsPath += '/:site';
-		}
-		analytics.pageView.record( baseAnalyticsPath, 'Media' );
-
-		// Page Title
-		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( i18n.translate( 'Media', { textOnly: true } ) ) );
-
 		// Render
 		context.primary = React.createElement( MediaComponent, {
-			selectedSite,
-			filter: filter,
-			search: search,
+			filter: context.params.filter,
+			search: context.query.s,
 		} );
 		next();
 	},

--- a/client/my-sites/media/controller.js
+++ b/client/my-sites/media/controller.js
@@ -4,15 +4,26 @@
  * External dependencies
  */
 import React from 'react';
+import i18n from 'i18n-calypso';
+import page from 'page';
 
 /**
  * Internal Dependencies
  */
-
 import MediaComponent from 'my-sites/media/main';
+import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
+import { getSiteFragment } from 'lib/route';
 
 export default {
 	media: function( context, next ) {
+		if ( ! getSiteFragment( context.path ) ) {
+			return page.redirect( '/media' );
+		}
+
+		// Page Title
+		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+		context.store.dispatch( setTitle( i18n.translate( 'Media', { textOnly: true } ) ) );
+
 		// Render
 		context.primary = React.createElement( MediaComponent, {
 			filter: context.params.filter,

--- a/client/my-sites/media/index.js
+++ b/client/my-sites/media/index.js
@@ -13,17 +13,29 @@ import { navigation, siteSelection, sites } from 'my-sites/controller';
 import mediaController from './controller';
 import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
+import { getSiteFragment } from 'lib/route';
 
 export default function() {
 	if ( config.isEnabled( 'manage/media' ) ) {
 		page( '/media', siteSelection, sites, makeLayout, clientRender );
+
 		page(
-			'/media/:filter?/:domain',
+			'/media/:filter(this-post|images|documents|videos|audio)?/:domain',
 			siteSelection,
 			navigation,
 			mediaController.media,
 			makeLayout,
 			clientRender
 		);
+
+		page( '/media/*', ( { path } ) => {
+			const siteFragment = getSiteFragment( path );
+
+			if ( siteFragment ) {
+				return page.redirect( `/media/${ siteFragment }` );
+			}
+
+			return page.redirect( '/media' );
+		} );
 	}
 }

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -16,7 +16,6 @@ import { localize } from 'i18n-calypso';
 import MediaLibrary from 'my-sites/media-library';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import Dialog from 'components/dialog';
-import DocumentHead from 'components/data/document-head';
 import { EditorMediaModalDetail } from 'post-editor/media-modal/detail';
 import { getSelectedSite } from 'state/ui/selectors';
 import ImageEditor from 'blocks/image-editor';
@@ -273,26 +272,19 @@ class Media extends Component {
 	};
 
 	getAnalyticsPath = () => {
-		const { filter, selectedSite } = this.props;
-		let analyticsPath = '/media';
+		const { filter } = this.props;
 
 		if ( filter ) {
-			analyticsPath += `/${ filter }`;
+			return `/media/${ filter }/:site`;
 		}
 
-		if ( selectedSite && selectedSite.ID ) {
-			analyticsPath += '/:site';
-		}
-
-		return analyticsPath;
+		return '/media/:site';
 	};
 
 	render() {
-		const { translate } = this.props;
 		const site = this.props.selectedSite;
 		return (
 			<div ref="container" className="main main-column media" role="main">
-				<DocumentHead title={ translate( 'Media' ) } />
 				<PageViewTracker path={ this.getAnalyticsPath() } title="Media" />
 				<SidebarNavigation />
 				{ ( this.state.editedImageItem !== null ||

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -6,6 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import page from 'page';
 import { localize } from 'i18n-calypso';
 
@@ -15,7 +16,9 @@ import { localize } from 'i18n-calypso';
 import MediaLibrary from 'my-sites/media-library';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import Dialog from 'components/dialog';
+import DocumentHead from 'components/data/document-head';
 import { EditorMediaModalDetail } from 'post-editor/media-modal/detail';
+import { getSelectedSite } from 'state/ui/selectors';
 import ImageEditor from 'blocks/image-editor';
 import VideoEditor from 'blocks/video-editor';
 import MediaActions from 'lib/media/actions';
@@ -23,6 +26,7 @@ import { getMimeType } from 'lib/media/utils';
 import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
 import accept from 'lib/accept';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import searchUrl from 'lib/search-url';
 
 class Media extends Component {
@@ -268,10 +272,28 @@ class Media extends Component {
 		MediaActions.delete( site.ID, selected );
 	};
 
+	getAnalyticsPath = () => {
+		const { filter, selectedSite } = this.props;
+		let analyticsPath = '/media';
+
+		if ( filter ) {
+			analyticsPath += `/${ filter }`;
+		}
+
+		if ( selectedSite && selectedSite.ID ) {
+			analyticsPath += '/:site';
+		}
+
+		return analyticsPath;
+	};
+
 	render() {
+		const { translate } = this.props;
 		const site = this.props.selectedSite;
 		return (
 			<div ref="container" className="main main-column media" role="main">
+				<DocumentHead title={ translate( 'Media' ) } />
+				<PageViewTracker path={ this.getAnalyticsPath() } title="Media" />
 				<SidebarNavigation />
 				{ ( this.state.editedImageItem !== null ||
 					this.state.editedVideoItem !== null ||
@@ -336,4 +358,8 @@ class Media extends Component {
 	}
 }
 
-export default localize( Media );
+const mapStateToProps = state => ( {
+	selectedSite: getSelectedSite( state ),
+} );
+
+export default connect( mapStateToProps )( localize( Media ) );


### PR DESCRIPTION
Resolves: https://github.com/Automattic/wp-calypso/issues/23516

According to internal logs, some `calypso_page_view` paths coming from Media
were reported without replacing passed parameters with corresponding variables,
or removing wrong entries from the route. This was resolved by adding more
restrictive route matching for optional filter and site parameters.

### Testing instructions
1. Set `localStorage.setItem( 'debug', 'calypso:analytics:tracks' )` in the browser console to enable the debug.
2. To reproduce the issue, navigate to `/media/randomtext/{site}` or `/media/randomtext` and observe the `calypso_page_view` recorded paths in log.
3. Apply this branch and verify that `randomtext` is no longer accepted as valid media filter and recorded as such.
4. Check that there are no other valid filters that we should be matching here.
5. Try to break it with various paths that start with `/media/`.