### PR TITLE
Site Settings: add ability to disable podcasting

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -275,7 +275,7 @@ const getFormSettings = settings => {
 		'time_format',
 		'timezone_string',
 		'lazy-images',
-		'podcasting_archive',
+		'podcasting_category_id',
 	] );
 
 	// handling `gmt_offset` and `timezone_string` values

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -281,7 +281,7 @@ const connectComponent = connect( ( state, ownProps ) => {
 
 	// The settings form wrapper gives us a string here, but inside this
 	// component, we always want to work with a number.
-	let podcastingCategoryId =
+	const podcastingCategoryId =
 		ownProps.fields &&
 		ownProps.fields.podcasting_category_id &&
 		Number( ownProps.fields.podcasting_category_id );

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -196,7 +196,13 @@ class PodcastingDetails extends Component {
 								onChange={ this.onCategorySelected }
 								addTerm={ true }
 								onAddTermSuccess={ this.onCategorySelected }
+								height={ 200 }
 							/>
+							{ isPodcastingEnabled && (
+								<Button onClick={ this.handleClearCategory } scary>
+									{ translate( 'Disable Podcast' ) }
+								</Button>
+							) }
 						</FormFieldset>
 						<div className="podcasting-details__basic-settings">
 							{ this.renderTextField( {

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -199,7 +199,7 @@ class PodcastingDetails extends Component {
 								height={ 200 }
 							/>
 							{ isPodcastingEnabled && (
-								<Button onClick={ this.handleClearCategory } scary>
+								<Button onClick={ this.onCategoryCleared } scary>
 									{ translate( 'Disable Podcast' ) }
 								</Button>
 							) }
@@ -245,6 +245,12 @@ class PodcastingDetails extends Component {
 		const event = { target: { value: category.slug } };
 
 		onChangeField( 'podcasting_archive' )( event );
+	};
+
+	onCategoryCleared = () => {
+		const { onChangeField } = this.props;
+
+		onChangeField( 'podcasting_archive' )( { target: { value: '' } } );
 	};
 }
 

--- a/client/my-sites/site-settings/podcasting-details/link.jsx
+++ b/client/my-sites/site-settings/podcasting-details/link.jsx
@@ -18,7 +18,8 @@ import { getSelectedSiteSlug } from 'state/ui/selectors';
 class PodcastingLink extends Component {
 	render() {
 		const { fields, siteSlug, translate } = this.props;
-		const podcastingEnabled = !! fields.podcasting_archive;
+		const podcastingEnabled =
+			fields && fields.podcasting_category_id && Number( fields.podcasting_category_id ) > 0;
 		const detailsLink = `/settings/podcasting/${ siteSlug }`;
 
 		return (

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -9,6 +9,10 @@
 		width: 35%;
 		padding-right: 24px;
 	}
+
+	button {
+		width: 100%;
+	}
 }
 
 .podcasting-details__basic-settings {

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -30,3 +30,10 @@
 	font-style: italic;
 	font-weight: 400;
 }
+
+.podcasting-details__wrapper {
+	&.is-disabled fieldset:not( .podcasting-details__category-selector ) label,
+	&.is-disabled fieldset:not( .podcasting-details__category-selector ) .form-setting-explanation {
+		color: $gray-lighten-10;
+	}
+}

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -241,7 +241,12 @@ export default connect(
 		const isJetpack = isJetpackSite( state, siteId );
 		return {
 			isJetpack,
-			hasPodcasts: getSiteOption( state, siteId, 'podcasting_archive' ),
+			hasPodcasts:
+				// Podcasting category slug
+				// TODO: remove when settings API is updated for new option
+				!! getSiteOption( state, siteId, 'podcasting_archive' ) ||
+				// Podcasting category ID
+				!! getSiteOption( state, siteId, 'podcasting_category_id' ),
 			isGoogleMyBusinessStatsNudgeVisible: isGoogleMyBusinessStatsNudgeVisibleSelector(
 				state,
 				siteId

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -44,6 +44,7 @@ export const SITE_REQUEST_OPTIONS = [
 	'page_on_front',
 	'page_for_posts',
 	'podcasting_archive',
+	'podcasting_category_id',
 	'publicize_permanently_disabled',
 	'show_on_front',
 	'signup_is_store',


### PR DESCRIPTION
This adds the ability to disable podcasting on sites where podcasting is enabled. It also adds a general disabled state and styles for podcasting.

See p3Ex-32D-p2.  All code is behind the `manage/site-settings/podcasting` feature flag.

**Manage Podcasting Link:**
<img width="677" alt="manage-podcasting" src="https://user-images.githubusercontent.com/942359/38150894-1aaee856-342f-11e8-9cd0-9054b379b240.png">

**Enabled State with "Disable Podcast" Button:**
![enabled-with-disable-button](https://user-images.githubusercontent.com/942359/38150913-2c5b7858-342f-11e8-96dc-3629cc31db18.png)

**Disabled State:**
<img width="677" alt="disabled-state" src="https://user-images.githubusercontent.com/942359/38150929-3c67c36e-342f-11e8-84f6-9f67bbd1f3e3.png">

**To test:**
Go to `/settings/writing/:site_id` with the `manage/site-settings/podcasting` flag enabled (it will be enabled in development on master).

- Verify that a site with podcasting enabled has a "Manage Podcasting" link - click it.
- Verify that all fields on the page are enabled and editable.
- Verify that a "Disable Podcast" button is displayed below the category selector.
- Verify that clicking "Disable Podcast" clears the category selector, hides the button, and disables all inputs except the category selector.
- Verify that clicking the back button on the page without saving, prompts the user to save.
- Click the "Save Settings" button and navigate back to the `/settings/writing/:site_id` screen.
- Verify that the Podcasting link now reads "Enable Podcasting".