### PR TITLE
Store Dashboard: Remove the loading state from the header

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -107,7 +107,7 @@ class Dashboard extends Component {
 	}
 
 	fetchStoreData = () => {
-		const { siteId, productsLoaded, finishedInstallOfRequiredPlugins } = this.props;
+		const { finishedInstallOfRequiredPlugins, productsLoaded, siteId } = this.props;
 
 		if ( ! finishedInstallOfRequiredPlugins ) {
 			return;
@@ -238,21 +238,11 @@ class Dashboard extends Component {
 	};
 
 	render() {
-		const {
-			className,
-			isSetupComplete,
-			loading,
-			selectedSite,
-			siteId,
-			finishedInstallOfRequiredPlugins,
-		} = this.props;
+		const { className, finishedInstallOfRequiredPlugins, isSetupComplete, siteId } = this.props;
 
 		return (
 			<Main className={ classNames( 'dashboard', className ) } wideLayout>
-				<ActionHeader
-					breadcrumbs={ this.getBreadcrumb() }
-					isLoading={ loading || ! selectedSite }
-				/>
+				<ActionHeader breadcrumbs={ this.getBreadcrumb() } />
 				{ isSetupComplete ? this.renderDashboardContent() : this.renderDashboardSetupContent() }
 				{ finishedInstallOfRequiredPlugins && <QuerySettingsGeneral siteId={ siteId } /> }
 			</Main>

--- a/client/extensions/woocommerce/components/action-header/index.js
+++ b/client/extensions/woocommerce/components/action-header/index.js
@@ -4,7 +4,6 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { isArray } from 'lodash';
@@ -21,7 +20,6 @@ import SiteIcon from 'blocks/site-icon';
 class ActionHeader extends React.Component {
 	static propTypes = {
 		breadcrumbs: PropTypes.node,
-		isLoading: PropTypes.bool,
 		primaryLabel: PropTypes.string,
 		setLayoutFocus: PropTypes.func.isRequired,
 		site: PropTypes.object.isRequired,
@@ -33,16 +31,13 @@ class ActionHeader extends React.Component {
 	};
 
 	renderBreadcrumbs = () => {
-		const { breadcrumbs, isLoading = false } = this.props;
+		const { breadcrumbs } = this.props;
 		let breadcrumbsOutput = breadcrumbs;
 		if ( isArray( breadcrumbs ) ) {
 			breadcrumbsOutput = breadcrumbs.map( ( crumb, i ) => <span key={ i }>{ crumb }</span> );
 		}
-		const breadcrumbClasses = classNames( 'action-header__breadcrumbs', {
-			'is-loading': isLoading,
-		} );
 
-		return <div className={ breadcrumbClasses }>{ breadcrumbsOutput }</div>;
+		return <div className="action-header__breadcrumbs">{ breadcrumbsOutput }</div>;
 	};
 
 	render() {

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -73,10 +73,6 @@
 	.action-header__breadcrumbs {
 		font-size: 13px;
 
-		&.is-loading {
-			@include placeholder();
-		}
-
 		span {
 			display: inline-block;
 		}


### PR DESCRIPTION
I've been working on the dashboard recently, and every time I reload the page I get a placeholder for the breadcrumbs. I know we want to wait to show the correct label here, and when this was created we didn't have the same header. But now that we do, it's pretty cramped and a bit distracting:

![placeholder](https://user-images.githubusercontent.com/541093/38151858-f9e5bf38-3432-11e8-8a8b-daf7e01ca95e.png)

Once the section has loaded and we know what label to show, it looks fine:

![name](https://user-images.githubusercontent.com/541093/38151857-f9d17316-3432-11e8-9bd5-5c8197e1a1d0.png)

In this PR, I've disabled that loading state, so it always shows some text. Generally it's a split second of `Store`, before updating to the correct label. Personally I find this less distracting, but we could alternately switch to a placeholder for the entire ActionHeader (which is what it did before the ActionHeader refactor):

![](https://user-images.githubusercontent.com/22080/32080833-b3a1c5d0-ba66-11e7-9715-b2699e151e47.gif)

(gif from #19203 )

**To test**

- Load the dashboard, `/store/:site`
- Check that your breadcrumbs show the correct label for the view you see 
  - If this is the initial setup of plugins, `Store`
  - If pages have not be set up yet, `Setting Up Store Pages`
  - If address has not be added yet, `Store Location`
  - If the checklist is showing, `Store Setup`
  - For a set up store, `Dashboard`
- Do a quick check of other pages, to make sure this doesn't affect those headers