### PR TITLE
Store Services: style label purchase modal for mobile devices.

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/style.scss
@@ -10,12 +10,23 @@
 .packages-step__contents {
 	display: flex;
 	padding-bottom: 24px;
+	flex-direction: column;
+
+	@include breakpoint( ">960px" ) {
+		flex-direction: row;
+	}
 }
 
 .packages-step__list {
-	width: 35%;
-	padding: 0 24px 0 0;
+	width: auto;
+	padding: 0 0 24px 0;
 	flex-shrink: 0;
+
+	@include breakpoint( ">960px" ) {
+		flex-direction: row;
+		width: 35%;
+		padding: 0 24px 0 0;
+	}
 }
 
 .packages-step__list-header {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
@@ -1,4 +1,6 @@
 .rates-step__package-container {
+	margin-bottom: 20px;
+
 	.form-fieldset:last-child {
 		margin-bottom: 0;
 	}

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -25,15 +25,6 @@
 			width: 100%;
 			max-width: 100%;
 		}
-
-		.packages-step__contents {
-			flex-direction: column;
-		}
-
-		.packages-step__list {
-			width: auto;
-			padding: 0 0 24px;
-		}
 	}
 }
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -11,6 +11,29 @@
 		flex-grow: 1;
 		display: flex;
 		flex-direction: column;
+
+		@include breakpoint( "<660px" ) {
+			padding: inherit;
+			overflow-y: scroll;
+		}
+	}
+
+	@include breakpoint( "<660px" ) {
+		&.dialog.card {
+			height: 100%;
+			max-height: 100%;
+			width: 100%;
+			max-width: 100%;
+		}
+
+		.packages-step__contents {
+			flex-direction: column;
+		}
+
+		.packages-step__list {
+			width: auto;
+			padding: 0 0 24px;
+		}
 	}
 }
 
@@ -86,11 +109,22 @@
 			display: none;
 		}
 	}
+
+	@include breakpoint( "<660px" ) {
+		.form-section-heading {
+			padding-top: 20px;
+			padding-left: 20px;
+		}
+	}
 }
 
 .label-purchase-modal__body {
 	display: flex;
 	flex-grow: 1;
+
+	@include breakpoint( "<660px" ) {
+		flex-direction: column;
+	}
 }
 
 .label-purchase-modal__main-section {


### PR DESCRIPTION
Restyle the shipping label modal to be single column and full width on narrow (<660px) viewports.

_(cc: @jameskoster @kellychoffman for feedback)_

Before:
![screen shot 2018-03-30 at 4 08 12 pm](https://user-images.githubusercontent.com/63922/38157642-07010f0c-3446-11e8-85f7-76a8574c450a.png)

After:
![screen shot 2018-03-30 at 5 56 20 pm](https://user-images.githubusercontent.com/63922/38157645-0e226a2e-3446-11e8-8ee2-d0a9bd04bfae.png)

