### PR TITLE
Ad Tracking: remove error handling test example

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -267,7 +267,6 @@ async function loadTrackingScripts( callback ) {
 	if ( isAdwordsEnabled ) {
 		scripts.push( GOOGLE_TRACKING_SCRIPT_URL );
 	}
-	scripts.push( 'chicken://example' );
 
 	if ( isBingEnabled ) {
 		scripts.push( BING_TRACKING_SCRIPT_URL );


### PR DESCRIPTION
When working on a prior pr that improves the error handling of loading the ad-tracking scripts, I accidentally committed a fake url.

There should have been no impact on the user experience unless they happened to open up the dev console for a funny warning:

![screen shot 2018-03-31 at 12 53 35 pm](https://user-images.githubusercontent.com/4656974/38165514-926b020e-34e2-11e8-9ed4-c9b86b9282cd.png)

**to test**
- open the calypso.live branch with ad-tracking enabled and you should no longer see the warning. https://calypso.live/?branch=remove/errant-fake-tracker&flags=ad-tracking