### PR TITLE
switch to using query string parameters for display mode in `/checklist`

### DIFF
--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -7,6 +7,7 @@ import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
+import url from 'url';
 
 /**
  * Internal dependencies
@@ -132,7 +133,9 @@ class ChecklistShow extends PureComponent {
 	}
 
 	render() {
-		const { displayMode, siteId, tasks } = this.props;
+		const { siteId, tasks } = this.props;
+		const parsedUrl = url.parse( location.href, true );
+		const displayMode = parsedUrl.query.d;
 
 		const completed = tasks && ! find( tasks, { completed: false } );
 
@@ -140,7 +143,7 @@ class ChecklistShow extends PureComponent {
 		let path = '/checklist/:site';
 		if ( displayMode ) {
 			title = 'Thank You';
-			path += `/${ displayMode }`;
+			path += `?d=${ displayMode }`;
 		}
 
 		return (

--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -7,7 +7,6 @@ import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
-import url from 'url';
 
 /**
  * Internal dependencies
@@ -133,9 +132,7 @@ class ChecklistShow extends PureComponent {
 	}
 
 	render() {
-		const { siteId, tasks } = this.props;
-		const parsedUrl = url.parse( location.href, true );
-		const displayMode = parsedUrl.query.d;
+		const { displayMode, siteId, tasks } = this.props;
 
 		const completed = tasks && ! find( tasks, { completed: false } );
 

--- a/client/my-sites/checklist/controller/index.jsx
+++ b/client/my-sites/checklist/controller/index.jsx
@@ -13,7 +13,6 @@ import React from 'react';
 import ChecklistShow from '../checklist-show';
 
 export function show( context, next ) {
-	const { params } = context;
-	context.primary = <ChecklistShow displayMode={ params.displayMode } />;
+	context.primary = <ChecklistShow />;
 	next();
 }

--- a/client/my-sites/checklist/controller/index.jsx
+++ b/client/my-sites/checklist/controller/index.jsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import { get } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -13,6 +14,7 @@ import React from 'react';
 import ChecklistShow from '../checklist-show';
 
 export function show( context, next ) {
-	context.primary = <ChecklistShow />;
+	const displayMode = get( context, 'query.d' );
+	context.primary = <ChecklistShow displayMode={ displayMode } />;
 	next();
 }

--- a/client/my-sites/checklist/index.js
+++ b/client/my-sites/checklist/index.js
@@ -17,13 +17,6 @@ import { makeLayout, render as clientRender } from 'controller';
 export default function() {
 	if ( config.isEnabled( 'onboarding-checklist' ) ) {
 		page( '/checklist', siteSelection, sites, makeLayout, clientRender );
-		page(
-			'/checklist/:site_id/:displayMode?',
-			siteSelection,
-			navigation,
-			show,
-			makeLayout,
-			clientRender
-		);
+		page( '/checklist/:site_id', siteSelection, navigation, show, makeLayout, clientRender );
 	}
 }

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -307,7 +307,7 @@ class Checkout extends React.Component {
 		if ( domainReceiptId && receiptId ) {
 			// DO NOT assign the test here.
 			if ( 'show' === getABTestVariation( 'checklistThankYouForPaidUser' ) ) {
-				return `/checklist/${ selectedSiteSlug }/gsuite`;
+				return `/checklist/${ selectedSiteSlug }?d=gsuite`;
 			}
 			return `/checkout/thank-you/${ selectedSiteSlug }/${ domainReceiptId }/with-gsuite/${ receiptId }`;
 		}
@@ -334,7 +334,7 @@ class Checkout extends React.Component {
 
 		// DO NOT assign the test here.
 		if ( 'show' === getABTestVariation( 'checklistThankYouForPaidUser' ) ) {
-			return `/checklist/${ selectedSiteSlug }/paid`;
+			return `/checklist/${ selectedSiteSlug }?d=paid`;
 		}
 
 		return this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -34,7 +34,7 @@ export class GsuiteNudge extends React.Component {
 
 		// DO NOT assign the test here.
 		if ( 'show' === getABTestVariation( 'checklistThankYouForPaidUser' ) ) {
-			page( `/checklist/${ siteSlug }/paid` );
+			page( `/checklist/${ siteSlug }?d=paid` );
 		} else {
 			page( `/checkout/thank-you/${ siteSlug }/${ receiptId }` );
 		}

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -285,7 +285,7 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	showChecklistAfterLogin = () => {
-		this.props.loginHandler( { redirectTo: `/checklist/${ this.state.siteSlug }/free` } );
+		this.props.loginHandler( { redirectTo: `/checklist/${ this.state.siteSlug }?d=free` } );
 	};
 
 	shouldShowChecklist() {


### PR DESCRIPTION
The current checklist route includes an optional `displayMode` segment in the route.

This is in the wrong position when switching sites (`/checklist/site1.com/free` will become `/checklist/free/site2.com`).

It really makes no sense to show the same extra post purchase/signup content after switching between sites so this change switches to using a query string parameter which is automatically dropped when switching between sites.

# testing

With a user with some existing sites:

- enable tracks debugging: `localStorage.setItem('debug', 'calypso:analytics:tracks');`
- set both variants for `checklistThankYouForFreeUser` and `checklistThankYouForPaidUser` ab tests to `show`
- signup for a free site
- verify that you are immediately taken to the checklist after site creation and you see the following header (`/checklist/SITE?d=free`):

<img width="751" alt="screen shot 2018-04-01 at 5 20 01 pm" src="https://user-images.githubusercontent.com/1926/38170788-044d004a-35d1-11e8-904d-7ad37e11b6dc.png">

- switch to another site
- verify that you are taken to the checklist page with the following header (`/checklist/SITE`):

<img width="744" alt="screen shot 2018-04-01 at 5 21 43 pm" src="https://user-images.githubusercontent.com/1926/38170835-ab5e2648-35d1-11e8-87e2-f9b8eb3fe452.png">

- signup for a new site with a paid plan
- verify that you are immediately taken to the checklist after site creation and you see the following header (`/checklist/SITE?d=paid`):

<img width="746" alt="screen shot 2018-04-01 at 5 22 37 pm" src="https://user-images.githubusercontent.com/1926/38170808-4cf40460-35d1-11e8-90f6-45e8a7add900.png">
tely taken to the checklist after site creation and you see the following header:

- switch to another site
- verify that you are taken to the checklist page with the following header (`/checklist/SITE`):

<img width="744" alt="screen shot 2018-04-01 at 5 21 43 pm" src="https://user-images.githubusercontent.com/1926/38170835-ab5e2648-35d1-11e8-87e2-f9b8eb3fe452.png">