### PR TITLE
Update CSP policy after gathering reports

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -392,6 +392,7 @@ function setUpCSP( req, res, next ) {
 		'object-src': [ "'none'" ],
 		'img-src': [
 			"'self'",
+			'data',
 			'*.wp.com',
 			'*.files.wordpress.com',
 			'*.gravatar.com',

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -397,6 +397,7 @@ function setUpCSP( req, res, next ) {
 			'*.gravatar.com',
 			'https://www.google-analytics.com',
 			'https://amplifypixel.outbrain.com',
+			'https://img.youtube.com',
 		],
 		'frame-src': [ "'self'", 'https://public-api.wordpress.com', 'https://accounts.google.com/' ],
 		'font-src': [

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -379,6 +379,8 @@ function setUpCSP( req, res, next ) {
 			"'report-sample'",
 			"'unsafe-eval'",
 			'stats.wp.com',
+			'https://widgets.wp.com',
+			'*.wordpress.com',
 			'https://apis.google.com',
 			`'nonce-${ req.context.inlineScriptNonce }'`,
 			`'nonce-${ req.context.analyticsScriptNonce }'`,
@@ -388,7 +390,14 @@ function setUpCSP( req, res, next ) {
 		'style-src': [ "'self'", '*.wp.com', 'https://fonts.googleapis.com' ],
 		'form-action': [ "'self'" ],
 		'object-src': [ "'none'" ],
-		'img-src': [ "'self'", '*.wp.com', 'https://www.google-analytics.com' ],
+		'img-src': [
+			"'self'",
+			'*.wp.com',
+			'*.files.wordpress.com',
+			'*.gravatar.com',
+			'https://www.google-analytics.com',
+			'https://amplifypixel.outbrain.com',
+		],
 		'frame-src': [ "'self'", 'https://public-api.wordpress.com', 'https://accounts.google.com/' ],
 		'font-src': [
 			"'self'",
@@ -397,7 +406,7 @@ function setUpCSP( req, res, next ) {
 			'data:', // should remove 'data:' ASAP
 		],
 		'media-src': [ "'self'" ],
-		'connect-src': [ "'self'", 'https://wordpress.com/' ],
+		'connect-src': [ "'self'", 'https://*.wordpress.com/', 'https://*.wp.com' ],
 		'report-uri': [ '/cspreport' ],
 	};
 


### PR DESCRIPTION
Followup to #22345

This PRs whitelists certain hosts, like `widgets.wp.com`, `amplifypixel.outbrain.com`, `*.gravatar.com`, `img.youtube.com`.

 #### Testing instructions
  
1. Run `git checkout update/csp-policy` and start your server, or open a [live branch](https://calypso.live/?branch=update/csp-policy)
2. Open the [`Login` page](http://calypso.localhost:3000/log-in)
3. Assert you get a CSP policy header in report-only mode.
  
#### Reviews
  
- [ ] Code
- [ ] Product
