### PR TITLE
fix error in sample code of guide/hello-world.md

### DIFF
--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -83,14 +83,14 @@ import page from 'page';
  */
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection } from 'my-sites/controller';
-import Controller from './controller';
+import { helloWorld } from './controller';
 
 export default () => {
 	page(
 		'/hello-world/:domain?',
 		siteSelection,
 		navigation,
-		Controller.helloWorld,
+		helloWorld,
 		makeLayout,
 		clientRender
 	);

--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -85,14 +85,14 @@ import page from 'page';
  */
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection } from 'my-sites/controller';
-import { helloWorld } from './controller';
+import Controller from './controller';
 
 export default () => {
 	page(
 		'/hello-world/:domain?',
 		siteSelection,
 		navigation,
-		helloWorld,
+		Controller.helloWorld,
 		makeLayout,
 		clientRender
 	);

--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -53,14 +53,12 @@ touch client/my-sites/hello-world/controller.js
 There you'll write your controller with a function called `helloWorld`:
 
 ```javascript
-const Controller = {
-	helloWorld( context, next ) {
-		console.log( 'Hello, world?' );
-		next();
-	},
+export const helloWorld = ( context, next ) => {
+	console.log( 'Hello, world?' );
+	next();
 };
 
-export default Controller;
+export default helloWorld;
 ```
 
 ### 4. Set up the route
@@ -249,10 +247,10 @@ import HelloWorld from 'my-sites/hello-world/main';
 Then remove the `console.log` call and enter the following instead:
 
 ```jsx
-helloWorld( context, next ) {
+export const helloWorld = ( context, next ) => {
 	context.primary = <HelloWorld />;
 	next();
-},
+};
 ```
 
 In the `Main` constant we are getting our main jsx file for our section. We then place `HelloWorld` element in `context.primary` property, which will be eventually get placed in DOM inside `#primary` div element in `Layout` element.

--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -57,8 +57,6 @@ export const helloWorld = ( context, next ) => {
 	console.log( 'Hello, world?' );
 	next();
 };
-
-export default helloWorld;
 ```
 
 ### 4. Set up the route


### PR DESCRIPTION
While running through the guide, I found that there's an error in the sample code in `docs/guide/hello-world.md`.

Under **Adding a new section** / **4. Set up the route**, to import the `helloWorld` function in `controller.js`, the original sample: `import { helloWorld } from './controller';` would not import `helloWorld` as expected. This PR proposes one way to fix this issue.