### PR TITLE
Checkout: rename 'SourcePaymentBox' to 'RedirectPaymentBox'

### DIFF
--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -23,7 +23,7 @@ import notices from 'notices';
 import FormSelect from 'components/forms/form-select';
 import FormLabel from 'components/forms/form-label';
 
-class SourcePaymentBox extends PureComponent {
+class RedirectPaymentBox extends PureComponent {
 	static propTypes = {
 		paymentType: PropTypes.string.isRequired,
 		cart: PropTypes.object.isRequired,
@@ -112,8 +112,8 @@ class SourcePaymentBox extends PureComponent {
 					info: translate( 'Redirecting you to the payment partner to complete the payment.' ),
 					disabled: true
 				} );
-				analytics.ga.recordEvent( 'Upgrades', 'Clicked Checkout With Source Payment Button' );
-				analytics.tracks.recordEvent( 'calypso_checkout_with_source_' + this.props.paymentType );
+				analytics.ga.recordEvent( 'Upgrades', 'Clicked Checkout With Redirect Payment Button' );
+				analytics.tracks.recordEvent( 'calypso_checkout_with_redirect' + this.props.paymentType );
 				location.href = result.redirect_url;
 			}
 		}.bind( this ) );
@@ -232,6 +232,6 @@ class SourcePaymentBox extends PureComponent {
 		return paymentMethodName( this.props.paymentType );
 	}
 }
-SourcePaymentBox.displayName = 'SourcePaymentBox';
+RedirectPaymentBox.displayName = 'RedirectPaymentBox';
 
-export default localize( SourcePaymentBox );
+export default localize( RedirectPaymentBox );

--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -24,6 +24,8 @@ import FormSelect from 'components/forms/form-select';
 import FormLabel from 'components/forms/form-label';
 
 class RedirectPaymentBox extends PureComponent {
+	static displayName = 'RedirectPaymentBox';
+
 	static propTypes = {
 		paymentType: PropTypes.string.isRequired,
 		cart: PropTypes.object.isRequired,
@@ -232,6 +234,5 @@ class RedirectPaymentBox extends PureComponent {
 		return paymentMethodName( this.props.paymentType );
 	}
 }
-RedirectPaymentBox.displayName = 'RedirectPaymentBox';
 
 export default localize( RedirectPaymentBox );

--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -57,7 +57,7 @@ class RedirectPaymentBox extends PureComponent {
 		}
 
 		this.setState( {
-			formDisabled: submitState.disabled
+			formDisabled: submitState.disabled,
 		} );
 	}
 
@@ -72,7 +72,7 @@ class RedirectPaymentBox extends PureComponent {
 		this.setSubmitState( {
 			info: translate( 'Setting up your %(paymentProvider)s payment', {
 				args: { paymentProvider: this.getPaymentProviderName() } } ),
-			disabled: true
+			disabled: true,
 		} );
 
 		let cancelUrl = origin + '/checkout/';
@@ -90,7 +90,7 @@ class RedirectPaymentBox extends PureComponent {
 				cancelUrl,
 			} ),
 			cart: this.props.cart,
-			domainDetails: this.props.transaction.domainDetails
+			domainDetails: this.props.transaction.domainDetails,
 		};
 
 		// get the redirect URL from rest endpoint
@@ -105,12 +105,12 @@ class RedirectPaymentBox extends PureComponent {
 
 				this.setSubmitState( {
 					error: errorMessage,
-					disabled: false
+					disabled: false,
 				} );
 			} else if ( result.redirect_url ) {
 				this.setSubmitState( {
 					info: translate( 'Redirecting you to the payment partner to complete the payment.' ),
-					disabled: true
+					disabled: true,
 				} );
 				analytics.ga.recordEvent( 'Upgrades', 'Clicked Checkout With Redirect Payment Button' );
 				analytics.tracks.recordEvent( 'calypso_checkout_with_redirect' + this.props.paymentType );
@@ -122,12 +122,12 @@ class RedirectPaymentBox extends PureComponent {
 	renderButtonText() {
 		if ( cartValues.cartItems.hasRenewalItem( this.props.cart ) ) {
 			return translate( 'Purchase %(price)s subscription with %(paymentProvider)s', {
-				args: { price: this.props.cart.total_cost_display, paymentProvider: this.getPaymentProviderName() }
+				args: { price: this.props.cart.total_cost_display, paymentProvider: this.getPaymentProviderName() },
 			} );
 		}
 
 		return translate( 'Pay %(price)s with %(paymentProvider)s', {
-			args: { price: this.props.cart.total_cost_display, paymentProvider: this.getPaymentProviderName() }
+			args: { price: this.props.cart.total_cost_display, paymentProvider: this.getPaymentProviderName() },
 		} );
 	}
 
@@ -152,7 +152,7 @@ class RedirectPaymentBox extends PureComponent {
 
 		return [
 			<option value="" key="-">{ translate( 'Please select your bank.' ) }</option>,
-			...idealBanksOptions
+			...idealBanksOptions,
 		];
 	}
 

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -18,7 +18,7 @@ import FreeTrialConfirmationBox from './free-trial-confirmation-box';
 import FreeCartPaymentBox from './free-cart-payment-box';
 import CreditCardPaymentBox from './credit-card-payment-box';
 import PayPalPaymentBox from './paypal-payment-box';
-import SourcePaymentBox from './source-payment-box';
+import RedirectPaymentBox from './redirect-payment-box';
 import { fullCreditsPayment, newCardPayment, storedCardPayment } from 'lib/store-transactions';
 import analytics from 'lib/analytics';
 import TransactionStepsMixin from './transaction-steps-mixin';
@@ -237,16 +237,16 @@ const SecurePaymentForm = createReactClass( {
 		);
 	},
 
-	renderSourcePaymentBox( paymentType ) {
+	renderRedirectPaymentBox( paymentType ) {
 		return (
 			<PaymentBox
-				classSet="source-payment-box"
+				classSet="redirect-payment-box"
 				cart={ this.props.cart }
 				paymentMethods={ this.props.paymentMethods }
 				currentPaymentMethod={ paymentType }
 				onSelectPaymentMethod={ this.selectPaymentBox }
 			>
-				<SourcePaymentBox
+				<RedirectPaymentBox
 					cart={ this.props.cart }
 					transaction={ this.props.transaction }
 					selectedSite={ this.props.selectedSite }
@@ -320,7 +320,7 @@ const SecurePaymentForm = createReactClass( {
 				return (
 					<div>
 						{ this.renderGreatChoiceHeader() }
-						{ this.renderSourcePaymentBox( visiblePaymentBox ) }
+						{ this.renderRedirectPaymentBox( visiblePaymentBox ) }
 					</div>
 				);
 


### PR DESCRIPTION
This is done in preparation for adding additional redirect-type payment methods that are not Stripe Sources.

