### PR TITLE
Components: Fix the sites dropdown hover moving

### DIFF
--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -238,9 +238,6 @@
 		.site-selector__sites {
 			max-height: 20vh;
 		}
-		.sites-dropdown__wrapper:hover {
-			border-bottom-width: 1px;
-		}
 	}
 }
 

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -34,7 +34,7 @@
 
 	.has-multiple-sites &:hover {
 		border-color: $gray-lighten-10;
-		border-bottom-width: 2px;
+		box-shadow: 0 1px $gray-lighten-10;
 	}
 }
 

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -25,7 +25,7 @@
 	overflow: hidden;
 	position: relative;
 	width: 300px;
-	transition: all .15s ease-in-out;
+	transition: all 0.2s ease-in;
 	z-index: 1;
 
 	@include breakpoint( "<660px" ) {


### PR DESCRIPTION
This PR updates the hover state of the sites dropdown wrapper to use a `box-shadow` instead of `border-bottom,`. This prevents the contents below the sites dropdown from shifting up/down when you hover in/out the sites dropdown. 

Here are the states of the block, just for clarity:

Regular state:
![](https://cldup.com/Ai_1D2tM_6.png)

Hover state:
![](https://cldup.com/7IOk3fud5T.png)

To repro the issue:
* Go to https://wpcalypso.wordpress.com/devdocs/blocks/sites-dropdown
* Hover the sites dropdown.
* Notice everything below the sites dropdown moves down by a pixel when you hover it.

It is also reproducible in `/help/contact`.

This PR:
* Changes the larger bottom border on hover to use `box-shadow` so it doesn't move the elements below.
* Removes the unnecessary declaration for the sites dropdown in the Inline Help block.
* Changes nothing visual, other than fixing the jumping elements below the sites dropdown block.

To test:
* Checkout this branch.
* Go to http://calypso.localhost:3000/devdocs/blocks/sites-dropdown
* Hover the dropdown and verify the contents below it no longer move when you hover.
* Go to http://calypso.localhost:3000/help/contact and verify the elements at the bottom are no longer shifted down/up when hovering in/out the sites dropdown
* Set the `inlineHelpWithContactForm` abtest to `inlinecontact`.
* Click the question mark in the bottom right portion of your screen.
* Click "Contact Us"
* Verify there are no visual differences with the sites dropdown there, compared to the same on wpcalypso or wordpress.com.