### PR TITLE
Help: Focus contact form simple fields on label click

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -363,8 +363,9 @@ export class HelpContactForm extends React.PureComponent {
 
 				{ showSubjectField && (
 					<div className="help-contact-form__subject">
-						<FormLabel>{ translate( 'Subject' ) }</FormLabel>
+						<FormLabel htmlFor="subject">{ translate( 'Subject' ) }</FormLabel>
 						<FormTextInput
+							id="subject"
 							name="subject"
 							value={ this.state.subject }
 							onChange={ this.handleChange }
@@ -372,9 +373,10 @@ export class HelpContactForm extends React.PureComponent {
 					</div>
 				) }
 
-				<FormLabel>{ translate( 'How can we help?' ) }</FormLabel>
+				<FormLabel htmlFor="message">{ translate( 'How can we help?' ) }</FormLabel>
 				<FormTextarea
 					placeholder={ translate( 'Ask away! Help will be with you soon.' ) }
+					id="message"
 					name="message"
 					value={ this.state.message }
 					onChange={ this.handleChange }


### PR DESCRIPTION
This PR updates the subject and message fields in the Contact form to automatically focus when the user clicks the corresponding label. It is a small enhancement for users that have the habit of clicking the label in order to focus a field.

![](https://cldup.com/UxmArB9bL7.png)

To test:
* Checkout this branch.
* Go to http://calypso.localhost:3000/help/contact
* Click on the "Subject" label, verify it focuses the corresponding field (the field might be hidden for you in certain circumstances).
* Click on the "How can we help?" label, verify it focuses the corresponding field.