### PR TITLE
Payments: scaffold the checkout pending page, the 2nd attempt.

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -3,17 +3,40 @@
 /**
  * External dependencies
  */
+import page from 'page';
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { getSourcePaymentTransactionDetail } from 'state/selectors';
 
 class CheckoutPending extends PureComponent {
 	static propTypes = {
 		orderId: PropTypes.number.isRequired,
+		siteSlug: PropTypes.string.isRequired,
 	};
+
+	componentWillReceiveProps( nextProps ) {
+		if ( 'successful' === nextProps.paymentInfo.status ) {
+			page( `/checkout/thank-you/${ this.props.siteSlug }` );
+			return;
+		}
+
+		// redirect users back to the checkout page so they can try again.
+		if ( 'failed' === nextProps.paymentInfo.status ) {
+			page( `/checkout/${ this.props.siteSlug }` );
+			return;
+		}
+	}
 
 	render() {
 		const { orderId } = this.props;
 
+		// TODO:
+		// Replace this placeholder by the real one
 		return (
 			<div>
 				<p>Waiting for the payment result of { orderId }</p>
@@ -22,4 +45,6 @@ class CheckoutPending extends PureComponent {
 	}
 }
 
-export default CheckoutPending;
+export default connect( ( state, props ) => ( {
+	paymentInfo: getSourcePaymentTransactionDetail( state, props.orderId ),
+} ) )( CheckoutPending );

--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -4,30 +4,64 @@
  * External dependencies
  */
 import page from 'page';
+import { localize } from 'i18n-calypso';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { identity } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { getOrderTransaction } from 'state/selectors';
+import { getOrderTransaction, getOrderTransactionError } from 'state/selectors';
+import { ORDER_TRANSACTION_STATUS } from 'state/order-transactions/constants';
+import { errorNotice } from 'state/notices/actions';
 
 class CheckoutPending extends PureComponent {
 	static propTypes = {
 		orderId: PropTypes.number.isRequired,
 		siteSlug: PropTypes.string.isRequired,
+		transaction: PropTypes.object,
+		localize: PropTypes.func,
+	};
+
+	static defaultProps = {
+		localize: identity,
 	};
 
 	componentWillReceiveProps( nextProps ) {
-		if ( 'successful' === nextProps.paymentInfo.status ) {
+		const { transaction: processingStatus, translate, error } = nextProps;
+
+		if ( ORDER_TRANSACTION_STATUS.SUCCESS === processingStatus ) {
 			page( `/checkout/thank-you/${ this.props.siteSlug }` );
 			return;
 		}
 
-		// redirect users back to the checkout page so they can try again.
-		if ( 'failed' === nextProps.paymentInfo.status ) {
+		// It is mostly because the user has cancelled the payment.
+		// See the explanation in https://github.com/Automattic/wp-calypso/pull/23670#issuecomment-377186515
+		if ( ORDER_TRANSACTION_STATUS.FAILURE === processingStatus ) {
+			// Bring the user back to the homepage in this case.
+			page( '/' );
+			return;
+		}
+
+		// It could be a HTTP error or the processing status indicates that there was something wrong.
+		if ( error !== null || ORDER_TRANSACTION_STATUS.ERROR === processingStatus ) {
+			errorNotice(
+				translate( 'We have problems fetching your payment status. Please try again later.' )
+			);
+
+			// redirect users back to the checkout page so they can try again.
 			page( `/checkout/${ this.props.siteSlug }` );
+			return;
+		}
+
+		// The API has responded a status string that we don't expect somehow.
+		if ( ORDER_TRANSACTION_STATUS.UNKNOWN === processingStatus ) {
+			errorNotice( translate( "We've encountered unknown. Please try again later." ) );
+
+			// Redirect users back to the homepage so that they won't be stuck here.
+			page( '/' );
 			return;
 		}
 	}
@@ -47,4 +81,5 @@ class CheckoutPending extends PureComponent {
 
 export default connect( ( state, props ) => ( {
 	transaction: getOrderTransaction( state, props.orderId ),
-} ) )( CheckoutPending );
+	transactionError: getOrderTransactionError( state, props.orderId ),
+} ) )( localize( CheckoutPending ) );

--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { getSourcePaymentTransactionDetail } from 'state/selectors';
+import { getOrderTransaction } from 'state/selectors';
 
 class CheckoutPending extends PureComponent {
 	static propTypes = {
@@ -46,5 +46,5 @@ class CheckoutPending extends PureComponent {
 }
 
 export default connect( ( state, props ) => ( {
-	paymentInfo: getSourcePaymentTransactionDetail( state, props.orderId ),
+	transaction: getOrderTransaction( state, props.orderId ),
 } ) )( CheckoutPending );

--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -40,7 +40,7 @@ class CheckoutPending extends PureComponent {
 			page( `/checkout/${ this.props.siteSlug }` );
 
 			showErrorNotice(
-				translate( 'Sorry, we failed to process your payment. Please try again later.' )
+				translate( "Sorry, we couldn't process your payment. Please try again later." )
 			);
 		};
 
@@ -73,9 +73,7 @@ class CheckoutPending extends PureComponent {
 				// Redirect users back to the homepage so that they won't be stuck here.
 				page( '/' );
 
-				showErrorNotice(
-					translate( "Sorry, we've encountered an unknown problem. Please try again later." )
-				);
+				showErrorNotice( translate( 'Oops! Something went wrong. Please try again later.' ) );
 
 				return;
 			}

--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -34,29 +34,33 @@ class CheckoutPending extends PureComponent {
 
 	componentWillReceiveProps( nextProps ) {
 		const { transaction, error } = nextProps;
-		const { translate, showErrorNotice } = this.props;
+		const { translate, showErrorNotice, siteSlug } = this.props;
 
 		const retryOnError = () => {
-			page( `/checkout/${ this.props.siteSlug }` );
+			page( `/checkout/${ siteSlug }` );
 
 			showErrorNotice(
 				translate( "Sorry, we couldn't process your payment. Please try again later." )
 			);
 		};
 
+		const planRoute = `/plans/my-plan/${ siteSlug }`;
+
 		if ( transaction ) {
 			const { processingStatus } = transaction;
 
 			if ( ORDER_TRANSACTION_STATUS.SUCCESS === processingStatus ) {
-				page( `/checkout/thank-you/${ this.props.siteSlug }` );
+				page( `/checkout/thank-you/${ siteSlug }` );
+
 				return;
 			}
 
 			// It is mostly because the user has cancelled the payment.
 			// See the explanation in https://github.com/Automattic/wp-calypso/pull/23670#issuecomment-377186515
 			if ( ORDER_TRANSACTION_STATUS.FAILURE === processingStatus ) {
-				// Bring the user back to the homepage in this case.
-				page( '/' );
+				// Bring the user back to the plan page in this case.
+				page( planRoute );
+
 				return;
 			}
 
@@ -70,8 +74,8 @@ class CheckoutPending extends PureComponent {
 
 			// The API has responded a status string that we don't expect somehow.
 			if ( ORDER_TRANSACTION_STATUS.UNKNOWN === processingStatus ) {
-				// Redirect users back to the homepage so that they won't be stuck here.
-				page( '/' );
+				// Redirect users back to the plan page so that they won't be stuck here.
+				page( planRoute );
 
 				showErrorNotice( translate( 'Oops! Something went wrong. Please try again later.' ) );
 

--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -1,0 +1,25 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+class CheckoutPending extends PureComponent {
+	static propTypes = {
+		orderId: PropTypes.number.isRequired,
+	};
+
+	render() {
+		const { orderId } = this.props;
+
+		return (
+			<div>
+				<p>Waiting for the payment result of { orderId }</p>
+			</div>
+		);
+	}
+}
+
+export default CheckoutPending;

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -113,11 +113,12 @@ export default {
 	checkoutPending: function( context, next ) {
 		const { routePath, routeParams } = sectionifyWithRoutes( context.path, checkoutPendingRoutes );
 		const orderId = Number( context.params.orderId );
+		const siteSlug = context.params.site;
 
 		analytics.pageView.record( routePath, 'Checkout Pending', routeParams );
 		context.store.dispatch( setSection( { name: 'checkout-thank-you' }, { hasSidebar: false } ) );
 
-		context.primary = <CheckoutPendingComponent orderId={ orderId } />;
+		context.primary = <CheckoutPendingComponent orderId={ orderId } siteSlug={ siteSlug } />;
 
 		next();
 	},

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -21,6 +21,7 @@ import Checkout from './checkout';
 import CheckoutData from 'components/data/checkout';
 import CartData from 'components/data/cart';
 import SecondaryCart from './cart/secondary-cart';
+import CheckoutPendingComponent from './checkout-thank-you/pending';
 import CheckoutThankYouComponent from './checkout-thank-you';
 
 const checkoutRoutes = [
@@ -34,6 +35,11 @@ const checkoutRoutes = [
 const checkoutGSuiteNudgeRoutes = [
 	new Route( '/checkout/:site/with-gsuite/:domain/:receipt' ),
 	new Route( '/checkout/:site/with-gsuite/:domain' ),
+];
+
+const checkoutPendingRoutes = [
+	new Route( '/checkout/thank-you/no-site/pending/:orderId' ),
+	new Route( '/checkout/thank-you/:site/pending/:orderId' ),
 ];
 
 const checkoutThankYouRoutes = [
@@ -101,6 +107,18 @@ export default {
 				<SecondaryCart />
 			</CartData>
 		);
+		next();
+	},
+
+	checkoutPending: function( context, next ) {
+		const { routePath, routeParams } = sectionifyWithRoutes( context.path, checkoutPendingRoutes );
+		const orderId = Number( context.params.orderId );
+
+		analytics.pageView.record( routePath, 'Checkout Pending', routeParams );
+		context.store.dispatch( setSection( { name: 'checkout-thank-you' }, { hasSidebar: false } ) );
+
+		context.primary = <CheckoutPendingComponent orderId={ orderId } />;
+
 		next();
 	},
 

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -33,9 +33,25 @@ export default function() {
 	}
 
 	page(
+		'/checkout/thank-you/no-site/pending/:orderId',
+		siteSelection,
+		checkoutController.checkoutPending,
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		'/checkout/thank-you/no-site/:receiptId?',
 		noSite,
 		checkoutController.checkoutThankYou,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/checkout/thank-you/:site/pending/:orderId',
+		siteSelection,
+		checkoutController.checkoutPending,
 		makeLayout,
 		clientRender
 	);

--- a/client/state/data-layer/wpcom/me/transactions/order/index.js
+++ b/client/state/data-layer/wpcom/me/transactions/order/index.js
@@ -3,15 +3,13 @@
 /**
  * External dependencies
  */
-import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
-import { errorNotice } from 'state/notices/actions';
-import { setOrderTransaction } from 'state/order-transactions/actions';
+import { setOrderTransaction, setOrderTransactionError } from 'state/order-transactions/actions';
 import { ORDER_TRANSACTION_FETCH } from 'state/action-types';
 import fromApi from './from-api';
 
@@ -32,10 +30,7 @@ export const fetchOrderTransaction = action =>
 
 export const onSuccess = ( { orderId }, detail ) => setOrderTransaction( orderId, detail );
 
-export const onError = () =>
-	errorNotice(
-		translate( 'We have problems fetching your payment status. Please try again later.' )
-	);
+export const onError = ( { orderId }, error ) => setOrderTransactionError( orderId, error );
 
 export default {
 	[ ORDER_TRANSACTION_FETCH ]: [

--- a/client/state/data-layer/wpcom/me/transactions/order/test/index.js
+++ b/client/state/data-layer/wpcom/me/transactions/order/test/index.js
@@ -5,20 +5,16 @@
  */
 import { fetchOrderTransaction, onSuccess, onError } from '../';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { errorNotice } from 'state/notices/actions';
-import { setOrderTransaction } from 'state/order-transactions/actions';
-
-// we are mocking impure-lodash here, so that conciergeShiftsFetchError() will contain the expected id in the tests
-jest.mock( 'lib/impure-lodash', () => ( {
-	uniqueId: () => 'mock-unique-id',
-} ) );
+import { setOrderTransaction, setOrderTransactionError } from 'state/order-transactions/actions';
 
 describe( 'wpcom-api', () => {
 	describe( 'me/transactions/order', () => {
+		const orderId = 123;
+
 		describe( 'fetchOrderTransaction()', () => {
 			test( 'should return the expected http request action.', () => {
 				const action = {
-					orderId: 123,
+					orderId,
 				};
 
 				expect( fetchOrderTransaction( action ) ).toEqual(
@@ -40,7 +36,7 @@ describe( 'wpcom-api', () => {
 		describe( 'onSuccess()', () => {
 			test( 'should return the expected setting action for populating state.', () => {
 				const action = {
-					orderId: 123,
+					orderId,
 				};
 				const detail = {
 					status: 'profit!',
@@ -54,8 +50,11 @@ describe( 'wpcom-api', () => {
 
 		describe( 'onError()', () => {
 			test( 'should return the expected error notice action.', () => {
-				expect( onError() ).toEqual(
-					errorNotice( 'We have problems fetching your payment status. Please try again later.' )
+				const error = {
+					message: 'something goes wrong!',
+				};
+				expect( onError( { orderId }, error ) ).toEqual(
+					setOrderTransactionError( orderId, error )
 				);
 			} );
 		} );


### PR DESCRIPTION
## Summary
This PR renovates #23670 so that the pending checkout page routes according to the new state tree defined in #23822.

## Test Plan
1. Access the pending checkout page URL, e.g. http://calypso.localhost:3000/checkout/thank-you/southptestcall.wordpress.com/pending/12345. Note that 12345 here is considered as the order ID, and the site slug should be the one belonging to the account that you have logged in. You should see this:
![image](https://user-images.githubusercontent.com/1842898/38193612-7630a0fc-36a5-11e8-9af6-ff8a0ce58fc3.png)
2. For the payment succeeded scenario, In the browser console. run: `dispatch( { type: 'ORDER_TRANSACTION_SET', orderId: 12345, transaction: { processingStatus: 'ORDER_TRANSACTION_STATUS_SUCCESS' } } );` and you should see:
![image](https://user-images.githubusercontent.com/1842898/38193637-91d4b99c-36a5-11e8-8d72-6ce34ecbba2c.png)
3. For the payment error scenario, go back to the pending checkout page, and run `dispatch( { type: 'ORDER_TRANSACTION_SET', orderId: 12345, transaction: { processingStatus: 'ORDER_TRANSACTION_STATUS_ERROR' } } );`. You should be redirected to the checkout page like this:
![image](https://user-images.githubusercontent.com/1842898/38193658-b32535f4-36a5-11e8-83c7-f0d69b15a262.png)
4. For the case that API responded with HTTP error, run `dispatch( { type: 'ORDER_TRANSACTION_FETCH_ERROR', orderId: 12345, error: {} } );` and you should see the same page like above.
5. For the case that a user has cancelled a payment, run `dispatch( { type: 'ORDER_TRANSACTION_SET', orderId: 12345, transaction: { processingStatus: 'ORDER_TRANSACTION_STATUS_FAILURE' }  } );` and you should be redirected back to homepage.
6. For the case that API responded with an unknown status string, run `dispatch( { type: 'ORDER_TRANSACTION_SET', orderId: 12345, transaction: { processingStatus: 'ORDER_TRANSACTION_STATUS_UKNOWN' } } );` and you should be redirected back to homepage with an error notice like this:
![image](https://user-images.githubusercontent.com/1842898/38193787-6bebce86-36a6-11e8-9f1c-f9f0966e3247.png)
