### PR TITLE
Likes: add like_source to like requests

### DIFF
--- a/client/blocks/like-button/index.jsx
+++ b/client/blocks/like-button/index.jsx
@@ -25,6 +25,7 @@ class LikeButtonContainer extends Component {
 		onLikeToggle: PropTypes.func,
 		found: PropTypes.number,
 		iLike: PropTypes.bool,
+		likeSource: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -33,7 +34,7 @@ class LikeButtonContainer extends Component {
 
 	handleLikeToggle = liked => {
 		const toggler = liked ? this.props.like : this.props.unlike;
-		toggler( this.props.siteId, this.props.postId );
+		toggler( this.props.siteId, this.props.postId, { source: this.props.likeSource } );
 
 		this.props.onLikeToggle( liked );
 	};

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -156,10 +156,10 @@ export class FullPostView extends React.Component {
 		let liked = this.props.liked;
 
 		if ( liked ) {
-			this.props.unlikePost( siteId, postId );
+			this.props.unlikePost( siteId, postId, { source: 'reader' } );
 			liked = false;
 		} else {
-			this.props.likePost( siteId, postId );
+			this.props.likePost( siteId, postId, { source: 'reader' } );
 			liked = true;
 		}
 
@@ -383,6 +383,7 @@ export class FullPostView extends React.Component {
 									postId={ +post.ID }
 									fullPost={ true }
 									tagName="div"
+									likeSource={ 'reader' }
 								/>
 							) }
 						</div>

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -105,6 +105,7 @@ const ReaderPostActions = props => {
 						forceCounter={ true }
 						iconSize={ iconSize }
 						showZeroCount={ false }
+						likeSource={ 'reader' }
 					/>
 				</li>
 			) }

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -36,7 +36,13 @@ class ReaderLikeButton extends React.Component {
 	};
 
 	render() {
-		return <LikeButtonContainer { ...this.props } onLikeToggle={ this.recordLikeToggle } />;
+		return (
+			<LikeButtonContainer
+				{ ...this.props }
+				onLikeToggle={ this.recordLikeToggle }
+				likeSource={ 'reader' }
+			/>
+		);
 	}
 }
 

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -40,7 +40,7 @@ class ReaderLikeButton extends React.Component {
 			<LikeButtonContainer
 				{ ...this.props }
 				onLikeToggle={ this.recordLikeToggle }
-				likeSource={ 'reader' }
+				likeSource="reader"
 			/>
 		);
 	}

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -286,7 +286,7 @@ class ReaderStream extends React.Component {
 		}
 
 		const toggler = liked ? this.props.unlikePost : this.props.likePost;
-		toggler( siteId, postId );
+		toggler( siteId, postId, { source: 'reader' } );
 	}
 
 	isPostFullScreen() {

--- a/client/state/data-layer/wpcom/sites/posts/likes/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/sites/posts/likes/mine/delete/index.js
@@ -35,6 +35,7 @@ export const fetch = action => {
 			path: `/sites/${ action.siteId }/posts/${ action.postId }/likes/mine/delete`,
 			apiVersion: '1.1',
 			body: {},
+			query,
 		},
 		action
 	);

--- a/client/state/data-layer/wpcom/sites/posts/likes/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/sites/posts/likes/mine/delete/index.js
@@ -23,8 +23,13 @@ export function fromApi( response ) {
 	};
 }
 
-export const fetch = action =>
-	http(
+export const fetch = action => {
+	const query = {};
+	if ( action.source ) {
+		query.source = action.source;
+	}
+
+	return http(
 		{
 			method: 'POST',
 			path: `/sites/${ action.siteId }/posts/${ action.postId }/likes/mine/delete`,
@@ -33,6 +38,7 @@ export const fetch = action =>
 		},
 		action
 	);
+};
 
 export const onSuccess = ( { siteId, postId }, { likeCount, liker } ) =>
 	removeLiker( siteId, postId, likeCount, liker );

--- a/client/state/data-layer/wpcom/sites/posts/likes/new/index.js
+++ b/client/state/data-layer/wpcom/sites/posts/likes/new/index.js
@@ -13,16 +13,23 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { POST_LIKE } from 'state/action-types';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
-export const fetch = action =>
-	http(
+export const fetch = action => {
+	const query = {};
+	if ( action.source ) {
+		query.source = action.source;
+	}
+
+	return http(
 		{
 			method: 'POST',
 			path: `/sites/${ action.siteId }/posts/${ action.postId }/likes/new`,
 			body: {},
 			apiVersion: '1.1',
+			query,
 		},
 		action
 	);
+};
 
 export const onSuccess = ( { siteId, postId }, { likeCount, liker } ) =>
 	addLiker( siteId, postId, likeCount, liker );

--- a/client/state/posts/likes/actions.js
+++ b/client/state/posts/likes/actions.js
@@ -35,10 +35,11 @@ export function requestPostLikes( siteId, postId ) {
  * @param {Number} postId Post ID
  * @returns {Object} The like action
  */
-export const like = ( siteId, postId ) => ( {
+export const like = ( siteId, postId, { source } = {} ) => ( {
 	type: POST_LIKE,
 	siteId,
 	postId,
+	source,
 } );
 
 /**
@@ -48,10 +49,11 @@ export const like = ( siteId, postId ) => ( {
  * @param {Number} postId Post ID
  * @returns {Object} The unlike action
  */
-export const unlike = ( siteId, postId ) => ( {
+export const unlike = ( siteId, postId, { source } = {} ) => ( {
 	type: POST_UNLIKE,
 	siteId,
 	postId,
+	source,
 } );
 
 export const receiveLikes = ( siteId, postId, { likes, iLike, found } ) => ( {


### PR DESCRIPTION
With https://github.com/Automattic/wp-calypso/pull/22024 and https://github.com/Automattic/wp-calypso/pull/23570, we accidentally stopped adding the `source` query param to like requests.  

We used that for attribution to various sources.

This PR brings it back

**to test**
- open up network tools and make sure the request to like something includes a  `source=reader` in the url.  If you like something from "My Sites > Posts" there should be no source.