### PR TITLE
Discussion: enable `Follows my blog` for Jetpack and AT sites

### DIFF
--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -395,15 +395,10 @@ class SiteSettingsFormDiscussion extends Component {
 		const {
 			fields,
 			handleAutosavingToggle,
-			isJetpack,
 			isRequestingSettings,
 			isSavingSettings,
 			translate,
 		} = this.props;
-		// follows are not supported on Jetpack sites
-		if ( isJetpack ) {
-			return null;
-		}
 
 		return (
 			<CompactFormToggle


### PR DESCRIPTION
This PR enables the `Someone follows my blog` switch to Atomic sites.

<img src="https://user-images.githubusercontent.com/77539/38205430-f72c1980-367c-11e8-9eeb-45959b17e517.png" width="300px" />
