### PR TITLE
Framework: Break chunk dependency cycles

### DIFF
--- a/client/blocks/daily-post-button/index.jsx
+++ b/client/blocks/daily-post-button/index.jsx
@@ -15,7 +15,7 @@ import { connect } from 'react-redux';
  * Internal Dependencies
  */
 import { translate } from 'i18n-calypso';
-import { preload } from 'sections-preload';
+import { preload } from 'sections-info';
 import SitesPopover from 'components/sites-popover';
 import Button from 'components/button';
 import { markPostSeen } from 'state/reader/posts/actions';

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -36,7 +36,7 @@ import PostActionCounts from 'my-sites/post-type-list/post-action-counts';
 import PostActionsEllipsisMenu from 'my-sites/post-type-list/post-actions-ellipsis-menu';
 import PostTypeSiteInfo from 'my-sites/post-type-list/post-type-site-info';
 import PostTypePostAuthor from 'my-sites/post-type-list/post-type-post-author';
-import { preload } from 'sections-preload';
+import { preload } from 'sections-info';
 
 function preloadEditor() {
 	preload( 'post-editor' );

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -21,7 +21,7 @@ import ReaderPopoverMenu from 'components/reader-popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import Gridicon from 'gridicons';
 import * as stats from 'reader/stats';
-import { preload } from 'sections-preload';
+import { preload } from 'sections-info';
 import SiteSelector from 'components/site-selector';
 import { getPrimarySiteId } from 'state/selectors';
 

--- a/client/components/section-nav/item.jsx
+++ b/client/components/section-nav/item.jsx
@@ -13,7 +13,7 @@ import Gridicon from 'gridicons';
  * Internal Dependencies
  */
 import Count from 'components/count';
-import { preload } from 'sections-preload';
+import { preload } from 'sections-info';
 
 /**
  * Main

--- a/client/extensions/wp-job-manager/components/navigation/index.jsx
+++ b/client/extensions/wp-job-manager/components/navigation/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find, flowRight, get, values } from 'lodash';
+import { flowRight, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,7 +16,7 @@ import SectionNav from 'components/section-nav';
 import SectionNavTabs from 'components/section-nav/tabs';
 import SectionNavTabItem from 'components/section-nav/item';
 import { addSiteFragment } from 'lib/route';
-import { getSections } from 'sections-middleware';
+import { getSection } from 'sections-info';
 import { Tabs } from '../../constants';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -32,10 +32,8 @@ class Navigation extends Component {
 	};
 
 	getSettingsPath() {
-		const sections = getSections();
-		const section = find( sections, value => value.name === 'wp-job-manager' );
-
-		return get( section, 'settings_path' );
+		const section = getSection( 'wp-job-manager' );
+		return section && section.settings_path;
 	}
 
 	renderTabItem( { label, slug } ) {

--- a/client/extensions/zoninator/app/util.js
+++ b/client/extensions/zoninator/app/util.js
@@ -4,18 +4,14 @@
  * External dependencies
  */
 
-import { find, get } from 'lodash';
-
 /**
  * Internal dependencies
  */
-import { getSections } from 'sections-middleware';
+import { getSection } from 'sections-info';
 
 const getSettingsPath = () => {
-	const sections = getSections();
-	const section = find( sections, value => value.name === 'zoninator' );
-
-	return get( section, 'settings_path' );
+	const section = getSection( 'zoninator' );
+	return section && section.settings_path;
 };
 
 export const settingsPath = getSettingsPath();

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -17,7 +17,7 @@ import Publish from './publish';
 import Notifications from './notifications';
 import Gravatar from 'components/gravatar';
 import config from 'config';
-import { preload } from 'sections-preload';
+import { preload } from 'sections-info';
 import ResumeEditing from 'my-sites/resume-editing';
 import { getPrimarySiteId, isDomainOnlySite, isNotificationsOpen } from 'state/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -15,7 +15,7 @@ import MasterbarItem from './item';
 import SitesPopover from 'components/sites-popover';
 import { newPost } from 'lib/paths';
 import { isMobile } from 'lib/viewport';
-import { preload } from 'sections-preload';
+import { preload } from 'sections-info';
 import { getSelectedSite } from 'state/ui/selectors';
 import MasterbarDrafts from './drafts';
 import { isRtl as isRtlSelector } from 'state/selectors';

--- a/client/layout/sidebar/button.jsx
+++ b/client/layout/sidebar/button.jsx
@@ -12,7 +12,7 @@ import React from 'react';
  * Internal dependencies
  */
 import { isExternal } from 'lib/url';
-import { preload } from 'sections-preload';
+import { preload } from 'sections-info';
 
 class SidebarButton extends React.Component {
 	static propTypes = {

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -13,7 +13,7 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import { isExternal } from 'lib/url';
-import { preload } from 'sections-preload';
+import { preload } from 'sections-info';
 import TranslatableString from 'components/translatable/proptype';
 
 export default class SidebarItem extends React.Component {

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -17,7 +17,7 @@ import { flowRight, isEqual, size, without } from 'lodash';
 import ListEnd from 'components/list-end';
 import QueryPosts from 'components/data/query-posts';
 import Page from './page';
-import { preload } from 'sections-preload';
+import { preload } from 'sections-info';
 import InfiniteScroll from 'components/infinite-scroll';
 import EmptyContent from 'components/empty-content';
 import NoResults from 'my-sites/no-results';

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -26,7 +26,7 @@ import * as utils from 'lib/posts/utils';
 import classNames from 'classnames';
 import MenuSeparator from 'components/popover/menu-separator';
 import PageCardInfo from '../page-card-info';
-import { preload } from 'sections-preload';
+import { preload } from 'sections-info';
 import { getSite, hasStaticFrontPage, isSitePreviewable } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isFrontPage, isPostsPage } from 'state/pages/selectors';

--- a/client/my-sites/plugins/utils.js
+++ b/client/my-sites/plugins/utils.js
@@ -4,23 +4,25 @@
  * External dependencies
  */
 
-import { find, get, includes } from 'lodash';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import config from 'config';
-import { getSections } from 'sections-middleware';
+import { getSection } from 'sections-info';
 
 export function getExtensionSettingsPath( plugin ) {
-	const pluginSlug = get( plugin, 'slug', '' );
-	const sections = getSections();
-	const section = find( sections, value => value.name === pluginSlug );
-	const env = get( section, 'envId', [] );
-
-	if ( ! includes( env, config( 'env_id' ) ) ) {
+	const section = getSection( plugin && plugin.slug );
+	if ( ! section ) {
 		return;
 	}
 
-	return get( section, 'settings_path' );
+	const envs = section.envId;
+
+	if ( ! includes( envs, config( 'env_id' ) ) ) {
+		return;
+	}
+
+	return section.settings_path;
 }

--- a/client/my-sites/post-type-list/empty-content.jsx
+++ b/client/my-sites/post-type-list/empty-content.jsx
@@ -17,7 +17,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
 import EmptyContent from 'components/empty-content';
-import { preload } from 'sections-preload';
+import { preload } from 'sections-info';
 
 function preloadEditor() {
 	preload( 'post-editor' );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
@@ -17,7 +17,7 @@ import { bumpStatGenerator } from './utils';
 import { getPost } from 'state/posts/selectors';
 import { canCurrentUserEditPost } from 'state/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
-import { preload } from 'sections-preload';
+import { preload } from 'sections-info';
 
 function preloadEditor() {
 	preload( 'post-editor' );

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -24,7 +24,7 @@ import FeedError from 'reader/feed-error';
 import StreamComponent from 'reader/following/main';
 import { getPrettyFeedUrl, getPrettySiteUrl } from 'reader/route';
 import { recordTrack } from 'reader/stats';
-import { preload } from 'sections-preload';
+import { preload } from 'sections-info';
 import AsyncLoad from 'components/async-load';
 
 const analyticsPageTitle = 'Reader';

--- a/client/sections-info.js
+++ b/client/sections-info.js
@@ -1,14 +1,14 @@
 /**
- * sections-preload
+ * sections-info
  *
- * This is a simple eventbus that sections.js listens to, to know when to preload sections.
+ * This is a simple eventbus that exposes section information without exposing the async loads for each section.
  *
  * In days past, the preloader was part of sections.js. To preload a module you would import sections
  * and call preload directly. However, all of the require.ensure calls live in sections.js. This makes
  * webpack think that imported sections was also dependant on every other chunk. The cyclic dependencies
  * ballooned compile times and made module analysis very difficult.
  *
- * To break the dependency cycle, we introduced the dependency-free `sections-preload`.
+ * To break the dependency cycle, we introduced the dependency-free `sections-info`.
  *
  * @format
  */
@@ -16,13 +16,12 @@
 /**
  * External Dependencies
  */
-import emitter from 'lib/mixins/emitter';
+import { createHooks } from '@wordpress/hooks';
 
 /**
  * The event hub for the section preloader
  */
-export const hub = {};
-emitter( hub );
+export const hooks = createHooks();
 
 /**
  * Preload a section by name.
@@ -31,5 +30,9 @@ emitter( hub );
  * @param {String} sectionName The name of the section to load
  */
 export function preload( sectionName ) {
-	hub.emit( 'preload', sectionName );
+	hooks.doAction( 'preload', sectionName );
+}
+
+export function getSection( sectionName ) {
+	return hooks.applyFilters( 'get_section', undefined, sectionName );
 }

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -14,7 +14,7 @@ import { bumpStat } from 'state/analytics/actions';
 import * as LoadingError from 'layout/error';
 import * as controller from './controller/index.web';
 import { restoreLastSession } from 'lib/restore-last-path';
-import { hub as preloadHub } from 'sections-preload';
+import { hooks } from 'sections-info';
 import { switchCSS } from 'lib/i18n-utils/switch-locale';
 import { pathToRegExp } from './utils';
 
@@ -47,7 +47,13 @@ function preload( sectionName ) {
 	return Promise.all( filteredSections.map( section => section.load() ) );
 }
 
-preloadHub.on( 'preload', preload );
+hooks.addAction( 'preload', 'sections-middleware-preload', preload );
+
+function getSectionByName( _, sectionName ) {
+	return find( sections, { name: sectionName } );
+}
+
+hooks.addFilter( 'get_section', 'sections-middleware-get-section', getSectionByName );
 
 function activateSection( sectionDefinition, context, next ) {
 	const dispatch = context.store.dispatch;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -103,6 +103,10 @@
       "integrity": "sha512-xwlHq5DXQFRpe+u6hmmNkzYk/3oxxqDp71a/AJMupOQYmxyaBetqrVMqdNlSQfbg7XTJYD8vARjf3Op06OzdtQ==",
       "dev": true
     },
+    "@wordpress/hooks": {
+      "version": "1.1.6",
+      "integrity": "sha512-+7s5j296RTXRabaubvNK35ED/+WUYJgM8oeiHWP6RvPGd/2rkei3cI0SNwjBdaRrlNQ22vtzvCfhdDCyb9W1xQ=="
+    },
     "JSONStream": {
       "version": "0.8.4",
       "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
@@ -1675,7 +1679,7 @@
         "content-type": "1.0.4",
         "debug": "2.6.7",
         "depd": "1.1.2",
-        "http-errors": "1.6.2",
+        "http-errors": "1.6.3",
         "iconv-lite": "0.4.15",
         "on-finished": "2.3.0",
         "qs": "6.4.0",
@@ -3110,6 +3114,16 @@
       "integrity": "sha1-GK6XmmoMqZSwYlhTkW0mYruuCxo=",
       "dev": true
     },
+    "data-urls": {
+      "version": "1.0.0",
+      "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+      "dev": true,
+      "requires": {
+        "abab": "1.0.4",
+        "whatwg-mimetype": "2.1.0",
+        "whatwg-url": "6.4.0"
+      }
+    },
     "date-now": {
       "version": "0.1.4",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
@@ -4150,8 +4164,8 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.1.1",
-      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "version": "2.2.0",
+      "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -4208,7 +4222,7 @@
         "debug": "2.6.9",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "0.3.2",
-        "eslint-module-utils": "2.1.1",
+        "eslint-module-utils": "2.2.0",
         "has": "1.0.1",
         "lodash": "4.17.5",
         "minimatch": "3.0.4",
@@ -6558,19 +6572,15 @@
       }
     },
     "http-errors": {
-      "version": "1.6.2",
-      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+      "version": "1.6.3",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "1.1.1",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
-        "setprototypeof": "1.0.3",
+        "setprototypeof": "1.1.0",
         "statuses": "1.5.0"
       },
       "dependencies": {
-        "depd": {
-          "version": "1.1.1",
-          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
-        },
         "inherits": {
           "version": "2.0.3",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
@@ -7196,7 +7206,7 @@
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
         "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
+        "whatwg-fetch": "2.0.4"
       }
     },
     "isstream": {
@@ -7767,7 +7777,7 @@
       "requires": {
         "jest-mock": "22.4.3",
         "jest-util": "22.4.3",
-        "jsdom": "11.6.2"
+        "jsdom": "11.7.0"
       }
     },
     "jest-environment-node": {
@@ -8734,18 +8744,17 @@
       }
     },
     "jsdom": {
-      "version": "11.6.2",
-      "integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
+      "version": "11.7.0",
+      "integrity": "sha512-9NzSc4Iz4gN9p4uoPbBUzro21QdgL32swaWIaWS8eEVQ2I69fRJAy/MKyvlEIk0V7HtKgfMbbOKyTZUrzR2Hsw==",
       "dev": true,
       "requires": {
         "abab": "1.0.4",
         "acorn": "5.5.3",
         "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
-        "browser-process-hrtime": "0.1.2",
-        "content-type-parser": "1.0.2",
         "cssom": "0.3.2",
         "cssstyle": "0.2.37",
+        "data-urls": "1.0.0",
         "domexception": "1.0.1",
         "escodegen": "1.9.1",
         "html-encoding-sniffer": "1.0.2",
@@ -8761,6 +8770,7 @@
         "w3c-hr-time": "1.0.1",
         "webidl-conversions": "4.0.2",
         "whatwg-encoding": "1.0.3",
+        "whatwg-mimetype": "2.1.0",
         "whatwg-url": "6.4.0",
         "ws": "4.1.0",
         "xml-name-validator": "3.0.0"
@@ -10033,7 +10043,7 @@
         "readable-stream": "2.3.5",
         "stream-browserify": "2.0.1",
         "stream-http": "2.8.1",
-        "string_decoder": "1.1.0",
+        "string_decoder": "1.1.1",
         "timers-browserify": "2.0.6",
         "tty-browserify": "0.0.0",
         "url": "0.11.0",
@@ -10072,8 +10082,8 @@
           }
         },
         "string_decoder": {
-          "version": "1.1.0",
-          "integrity": "sha512-8zQpRF6juocE69ae7CSPmYEGJe4VCXwP6S6dxUWI7i53Gwv54/ec41fiUA+X7BPGGv7fRSQJjBQVa0gomGaOgg==",
+          "version": "1.1.1",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -13822,8 +13832,8 @@
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "setprototypeof": {
-      "version": "1.0.3",
-      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+      "version": "1.1.0",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "sha.js": {
       "version": "2.4.11",
@@ -16591,7 +16601,7 @@
             "content-type": "1.0.4",
             "debug": "2.6.9",
             "depd": "1.1.2",
-            "http-errors": "1.6.2",
+            "http-errors": "1.6.3",
             "iconv-lite": "0.4.19",
             "on-finished": "2.3.0",
             "qs": "6.5.1",
@@ -16725,6 +16735,11 @@
           "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
           "dev": true
         },
+        "inherits": {
+          "version": "2.0.3",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
         "ipaddr.js": {
           "version": "1.6.0",
           "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs=",
@@ -16773,6 +16788,29 @@
             "http-errors": "1.6.2",
             "iconv-lite": "0.4.19",
             "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+              "dev": true
+            },
+            "http-errors": {
+              "version": "1.6.2",
+              "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+              "dev": true,
+              "requires": {
+                "depd": "1.1.1",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.3",
+                "statuses": "1.4.0"
+              }
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+              "dev": true
+            }
           }
         },
         "send": {
@@ -16787,7 +16825,7 @@
             "escape-html": "1.0.3",
             "etag": "1.8.1",
             "fresh": "0.5.2",
-            "http-errors": "1.6.2",
+            "http-errors": "1.6.3",
             "mime": "1.4.1",
             "ms": "2.0.0",
             "on-finished": "2.3.0",
@@ -16805,11 +16843,6 @@
             "parseurl": "1.3.2",
             "send": "0.16.2"
           }
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true
         },
         "statuses": {
           "version": "1.4.0",
@@ -16896,8 +16929,13 @@
       }
     },
     "whatwg-fetch": {
-      "version": "2.0.3",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+      "version": "2.0.4",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+    },
+    "whatwg-mimetype": {
+      "version": "2.1.0",
+      "integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
+      "dev": true
     },
     "whatwg-url": {
       "version": "6.4.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "> 1%"
   ],
   "dependencies": {
+    "@wordpress/hooks": "1.1.6",
     "assets-webpack-plugin": "3.5.1",
     "autoprefixer": "6.3.5",
     "autosize": "3.0.15",


### PR DESCRIPTION
This renames section-preloader to section-info and adds the ability to get
a section by name. This works by firing a filter hook that the
sections-middleware processes and returns. This may seem a bit obtuse, but
it lets us break a chunk dependency cycle.

Before this patch, to get access to section settings, code was importing
sections-middleware, which imports client/sections, which contains all of
the dynamic imports for our sections. This would cause the chunk that
needed the section settings to become a parent to all of our sections,
which created a cycle in the chunk dependency grath.
    
You could see this in the output of npm start. Every section chunk depended
on build, which is expected, but also plugins, wp-job-manager, and
zoninator.

This cycle slows down chunk analysis and makes optimization more difficult.