### PR TITLE
Store State: Add tests for required plugins selector

### DIFF
--- a/client/extensions/woocommerce/state/selectors/plugins.js
+++ b/client/extensions/woocommerce/state/selectors/plugins.js
@@ -11,6 +11,11 @@ import { getPlugins, isRequestingForSites } from 'state/plugins/installed/select
 import { getRequiredPluginsForCalypso } from 'woocommerce/lib/get-required-plugins';
 import { getSelectedSiteWithFallback } from '../sites/selectors';
 
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {boolean|null} Whether the given site has woocommerce services installed & active
+ */
 export const isWcsEnabled = ( state, siteId = getSelectedSiteWithFallback( state ) ) => {
 	if ( ! config.isEnabled( 'woocommerce/extension-wcservices' ) ) {
 		return false;
@@ -26,6 +31,11 @@ export const isWcsEnabled = ( state, siteId = getSelectedSiteWithFallback( state
 	return Boolean( find( plugins, { slug: 'woocommerce-services' } ) );
 };
 
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {boolean|null} Whether the given site has all required plugins installed & active
+ */
 export const areAllRequiredPluginsActive = (
 	state,
 	siteId = getSelectedSiteWithFallback( state )

--- a/client/extensions/woocommerce/state/selectors/test/fixtures/plugins.js
+++ b/client/extensions/woocommerce/state/selectors/test/fixtures/plugins.js
@@ -1,0 +1,42 @@
+/** @format */
+const woocommerce = {
+	id: 'woocommerce/woocommerce',
+	slug: 'woocommerce',
+	active: true,
+	name: 'WooCommerce',
+	plugin_url: 'https://woocommerce.com/',
+	version: '3.3.4',
+	description: 'An eCommerce toolkit that helps you sell anything. Beautifully.',
+	author: 'Automattic',
+	author_url: 'https://woocommerce.com',
+	network: false,
+	autoupdate: true,
+};
+
+const woocommerceServices = {
+	id: 'woocommerce-services/woocommerce-services',
+	slug: 'woocommerce-services',
+	active: true,
+};
+
+const woocommerceStripe = {
+	id: 'woocommerce-gateway-stripe/woocommerce-gateway-stripe',
+	slug: 'woocommerce-gateway-stripe',
+	active: true,
+};
+
+export default {
+	installed: {
+		isRequesting: {
+			'site.one': false,
+			'site.two': false,
+			'site.three': false,
+			'site.four': true,
+		},
+		plugins: {
+			'site.one': [ woocommerce, woocommerceServices, woocommerceStripe ],
+			'site.two': [ woocommerce, woocommerceStripe, { ...woocommerceServices, active: false } ],
+			'site.three': [ woocommerce, woocommerceStripe ],
+		},
+	},
+};

--- a/client/extensions/woocommerce/state/selectors/test/plugins.js
+++ b/client/extensions/woocommerce/state/selectors/test/plugins.js
@@ -14,6 +14,14 @@ import plugins from './fixtures/plugins.js';
 
 const state = deepFreeze( { plugins } );
 
+/*
+ * state.plugins has four sites:
+ *  - site.one: all plugins installed and active
+ *  - site.two: all plugins installed, WCS inactive
+ *  - site.three: 2/3 plugins installed, WCS not installed
+ *  - site.four: plugin state is still loading
+ */
+
 describe( 'plugins', () => {
 	describe( '#areAllRequiredPluginsActive', () => {
 		it( 'should be null if the plugin list is being requested', () => {

--- a/client/extensions/woocommerce/state/selectors/test/plugins.js
+++ b/client/extensions/woocommerce/state/selectors/test/plugins.js
@@ -2,66 +2,60 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
 import sinon from 'sinon';
 
 /**
  * Internal dependencies
  */
+import { areAllRequiredPluginsActive, isWcsEnabled } from '../plugins';
 import config from 'config';
-import {
-	isWcsEnabled,
-} from '../plugins';
+import plugins from './fixtures/plugins.js';
 
-const siteId = 123;
-
-const getState = ( loaded = false, installed = false, active = false ) => {
-	const pluginArray = [];
-	if ( loaded && installed ) {
-		pluginArray.push( {
-			id: 'woocommerce-services/woocommerce-services',
-			slug: 'woocommerce-services',
-			active,
-		} );
-	}
-
-	return {
-		plugins: {
-			installed: {
-				plugins: {
-					[ siteId ]: pluginArray,
-				},
-				isRequesting: {
-					[ siteId ]: ! loaded,
-				},
-			},
-		},
-	};
-};
+const state = deepFreeze( { plugins } );
 
 describe( 'plugins', () => {
+	describe( '#areAllRequiredPluginsActive', () => {
+		it( 'should be null if the plugin list is being requested', () => {
+			expect( areAllRequiredPluginsActive( state, 'site.four' ) ).to.be.null;
+		} );
+
+		it( 'should be false if a required plugin is not installed', () => {
+			expect( areAllRequiredPluginsActive( state, 'site.three' ) ).to.be.false;
+		} );
+
+		it( 'should be false if a required plugin is not active', () => {
+			expect( areAllRequiredPluginsActive( state, 'site.two' ) ).to.be.false;
+		} );
+
+		it( 'should be true if the plugin is installed and active', () => {
+			expect( areAllRequiredPluginsActive( state, 'site.one' ) ).to.be.true;
+		} );
+	} );
+
 	describe( '#isWcsEnabled', () => {
 		it( 'should be false if WCS is disabled in the config', () => {
 			const configStub = sinon.stub( config, 'isEnabled' );
 			configStub.withArgs( 'woocommerce/extension-wcservices' ).returns( false );
 
-			expect( isWcsEnabled( getState(), siteId ) ).to.be.false;
+			expect( isWcsEnabled( state, 'site.one' ) ).to.be.false;
 			configStub.restore();
 		} );
 
 		it( 'should be null if the plugin list is being requested', () => {
-			expect( isWcsEnabled( getState( false ), siteId ) ).to.be.null;
+			expect( isWcsEnabled( state, 'site.four' ) ).to.be.null;
 		} );
 
 		it( 'should be false if the plugin is not installed', () => {
-			expect( isWcsEnabled( getState( true, false ), siteId ) ).to.be.false;
+			expect( isWcsEnabled( state, 'site.three' ) ).to.be.false;
 		} );
 
 		it( 'should be false if the plugin is not active', () => {
-			expect( isWcsEnabled( getState( true, true, false ), siteId ) ).to.be.false;
+			expect( isWcsEnabled( state, 'site.two' ) ).to.be.false;
 		} );
 
 		it( 'should be true if the plugin is installed and active', () => {
-			expect( isWcsEnabled( getState( true, true, true ), siteId ) ).to.be.true;
+			expect( isWcsEnabled( state, 'site.one' ) ).to.be.true;
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds tests for a new selector introduced in #23809, `areAllRequiredPluginsActive`. This selector checks that all the plugins listed in [the required list](https://github.com/Automattic/wp-calypso/blob/master/client/extensions/woocommerce/lib/get-required-plugins.js) are installed and active.

This PR adds the tests, and refactors the `isWcsEnabled` tests as well, so that setting up the state is abstracted out into a fixtures file.

**To test**

- Run the tests: `npm run test-client client/extensions/woocommerce/state/selectors/`
- There should be no changes to any UI