### PR TITLE
Reader Conversations: fix conversation caterpillar displaying only one avatar

### DIFF
--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -82,7 +82,7 @@ class ConversationCaterpillarComponent extends React.Component {
 			: size( allExpandableComments );
 
 		// Only display authors with a gravatar, and only display each author once
-		const uniqueAuthors = uniqBy( map( expandableComments, 'author' ), 'ID' );
+		const uniqueAuthors = uniqBy( map( expandableComments, 'author' ), 'email' );
 		const displayedAuthors = takeRight(
 			filter( uniqueAuthors, 'avatar_URL' ),
 			MAX_GRAVATARS_TO_DISPLAY


### PR DESCRIPTION
If you visit https://wpcalypso.wordpress.com/read/conversations, you'll notice that the conversation caterpillar only ever shows one avatar:

<img width="291" alt="screen shot 2018-04-03 at 3 48 17 pm" src="https://user-images.githubusercontent.com/17325/38228228-7648a61e-3756-11e8-9437-9b6d672d34bc.png">

At some point, the `/sites/:site/posts/:post/replies` endpoint seems to have stopped handing us author IDs. We currently dedupe authors based on ID, and when you dedupe lots of authors with ID `0`, you get... one author.

This PR switches the deduping to use email instead. Every commenter with a gravatar should have an associated email address, so this should be a safe substitute.

The underlying API issue didn't look simple to fix, so I'll log a separate issue for that.

Fixes https://github.com/Automattic/wp-calypso/issues/23196.

### To test

Follow a conversation on a post with lots of commenters, like:

https://wpcalypso.wordpress.com/read/blogs/115552841/posts/2514

Visit https://wpcalypso.wordpress.com/read/conversations and see that there's only one avatar per post.

Visit http://calypso.localhost:3000/read/conversations and check that there are multiple avatars shown:

<img width="400" alt="screen shot 2018-04-03 at 3 56 43 pm" src="https://user-images.githubusercontent.com/17325/38228464-ad62912c-3757-11e8-8a6e-4aaf7f1a632a.png">

