### PR TITLE
Query component for fetching order transactions

### DIFF
--- a/client/components/data/query-order-transaction/index.jsx
+++ b/client/components/data/query-order-transaction/index.jsx
@@ -10,12 +10,14 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { fetchSourcePaymentTransactionDetail } from 'state/transactions/source-payment/actions';
-import { getSourcePaymentTransactionDetail } from 'state/selectors';
+import { fetchOrderTransaction } from 'state/order-transactions/actions';
+import { getOrderTransaction } from 'state/selectors';
 
 class QuerySourcePaymentTransactionDetail extends React.Component {
 	static propTypes = {
 		pollIntervalMs: PropTypes.number,
+		transaction: PropTypes.object.isRequired,
+		fetchTransaction: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
@@ -23,20 +25,20 @@ class QuerySourcePaymentTransactionDetail extends React.Component {
 	};
 
 	componentDidMount() {
-		const { pollIntervalMs, orderId, transactionDetail, fetchTransactionDetail } = this.props;
+		const { pollIntervalMs, orderId, transaction, fetchTransaction } = this.props;
 
 		if ( pollIntervalMs ) {
 			this.timer = setInterval( () => {
 				// no need to fetch if it's there.
-				if ( null !== transactionDetail ) {
+				if ( null !== transaction ) {
 					return;
 				}
-				fetchTransactionDetail( orderId );
+				fetchTransaction( orderId );
 			}, pollIntervalMs );
 			return;
 		}
 
-		this.props.fetchTransactionDetail( orderId );
+		fetchTransaction( orderId );
 	}
 
 	componentWillUnmount() {
@@ -52,9 +54,9 @@ class QuerySourcePaymentTransactionDetail extends React.Component {
 
 export default connect(
 	( state, props ) => ( {
-		transactionDetail: getSourcePaymentTransactionDetail( state, props.orderId ),
+		transaction: getOrderTransaction( state, props.orderId ),
 	} ),
 	{
-		fetchTransactionDetail: fetchSourcePaymentTransactionDetail,
+		fetchTransaction: fetchOrderTransaction,
 	}
 )( QuerySourcePaymentTransactionDetail );

--- a/client/components/data/query-order-transaction/index.jsx
+++ b/client/components/data/query-order-transaction/index.jsx
@@ -13,10 +13,11 @@ import { connect } from 'react-redux';
 import { fetchOrderTransaction } from 'state/order-transactions/actions';
 import { getOrderTransaction } from 'state/selectors';
 
-class QuerySourcePaymentTransactionDetail extends React.Component {
+class QueryOrderTransaction extends React.Component {
 	static propTypes = {
+		orderId: PropTypes.number.isRequired,
 		pollIntervalMs: PropTypes.number,
-		transaction: PropTypes.object.isRequired,
+		transaction: PropTypes.object,
 		fetchTransaction: PropTypes.func.isRequired,
 	};
 
@@ -59,4 +60,4 @@ export default connect(
 	{
 		fetchTransaction: fetchOrderTransaction,
 	}
-)( QuerySourcePaymentTransactionDetail );
+)( QueryOrderTransaction );

--- a/client/components/data/query-order-transaction/index.jsx
+++ b/client/components/data/query-order-transaction/index.jsx
@@ -11,17 +11,12 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { fetchOrderTransaction } from 'state/order-transactions/actions';
-import {
-	getOrderTransaction,
-	getOrderTransactionError,
-	isFetchingOrderTransaction,
-} from 'state/selectors';
+import { getOrderTransactionError, isFetchingOrderTransaction } from 'state/selectors';
 
 class QueryOrderTransaction extends React.Component {
 	static propTypes = {
 		orderId: PropTypes.number.isRequired,
 		pollIntervalMs: PropTypes.number,
-		transaction: PropTypes.object,
 		fetchTransaction: PropTypes.func.isRequired,
 		error: PropTypes.object,
 		isFetching: PropTypes.bool,
@@ -68,7 +63,6 @@ class QueryOrderTransaction extends React.Component {
 
 export default connect(
 	( state, props ) => ( {
-		transaction: getOrderTransaction( state, props.orderId ),
 		error: getOrderTransactionError( state, props.orderId ),
 		isFetching: isFetchingOrderTransaction( state, props.orderId ),
 	} ),

--- a/client/components/data/query-source-payment-transaction-detail/index.jsx
+++ b/client/components/data/query-source-payment-transaction-detail/index.jsx
@@ -4,19 +4,53 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { fetchSourcePaymentTransactionDetail } from 'state/transaction-detail/actions';
+import { getSourcePaymentTransactionDetail } from 'state/selectors';
 
 class QuerySourcePaymentTransactionDetail extends React.Component {
+	static propTypes = {
+		pollIntervalMs: PropTypes.int,
+	};
+
+	static defaultProps = {
+		pollIntervalMs: 0,
+	};
+
 	componentDidMount() {
-		this.props.fetchSourcePaymentTransactionDetail( this.props.orderId );
+		const { pollIntervalMs, orderId, transactionDetail, fetchTransactionDetail } = this.props;
+
+		if ( pollIntervalMs ) {
+			this.timer = setInterval( () => {
+				// no need to fetch if it's there.
+				if ( null !== transactionDetail ) {
+					return;
+				}
+				fetchTransactionDetail( orderId );
+			}, pollIntervalMs );
+			return;
+		}
+
+		this.props.fetchTransactionDetail( orderId );
+	}
+
+	componentWillUnmount() {
+		if ( this.timer ) {
+			clearInterval( this.timer );
+		}
 	}
 }
 
-export default connect( () => {}, {
-	fetchSourcePaymentTransactionDetail,
-} )( QuerySourcePaymentTransactionDetail );
+export default connect(
+	( state, props ) => ( {
+		transactionDetail: getSourcePaymentTransactionDetail( state, props.orderId ),
+	} ),
+	{
+		fetchTransactionDetail: fetchSourcePaymentTransactionDetail,
+	}
+)( QuerySourcePaymentTransactionDetail );

--- a/client/components/data/query-source-payment-transaction-detail/index.jsx
+++ b/client/components/data/query-source-payment-transaction-detail/index.jsx
@@ -10,12 +10,12 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { fetchSourcePaymentTransactionDetail } from 'state/transaction-detail/actions';
+import { fetchSourcePaymentTransactionDetail } from 'state/transactions/source-payment/actions';
 import { getSourcePaymentTransactionDetail } from 'state/selectors';
 
 class QuerySourcePaymentTransactionDetail extends React.Component {
 	static propTypes = {
-		pollIntervalMs: PropTypes.int,
+		pollIntervalMs: PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -43,6 +43,10 @@ class QuerySourcePaymentTransactionDetail extends React.Component {
 		if ( this.timer ) {
 			clearInterval( this.timer );
 		}
+	}
+
+	render() {
+		return null;
 	}
 }
 

--- a/client/components/data/query-source-payment-transaction-detail/index.jsx
+++ b/client/components/data/query-source-payment-transaction-detail/index.jsx
@@ -1,0 +1,22 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { fetchSourcePaymentTransactionDetail } from 'state/transaction-detail/actions';
+
+class QuerySourcePaymentTransactionDetail extends React.Component {
+	componentDidMount() {
+		this.props.fetchSourcePaymentTransactionDetail( this.props.orderId );
+	}
+}
+
+export default connect( () => {}, {
+	fetchSourcePaymentTransactionDetail,
+} )( QuerySourcePaymentTransactionDetail );

--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -16,6 +16,7 @@ import { identity } from 'lodash';
 import { getOrderTransaction, getOrderTransactionError } from 'state/selectors';
 import { ORDER_TRANSACTION_STATUS } from 'state/order-transactions/constants';
 import { errorNotice } from 'state/notices/actions';
+import QuerySourcePaymentTransactionDetail from 'components/data/query-source-payment-transaction-detail';
 
 class CheckoutPending extends PureComponent {
 	static propTypes = {
@@ -96,6 +97,7 @@ class CheckoutPending extends PureComponent {
 		// Replace this placeholder by the real one
 		return (
 			<div>
+				<QuerySourcePaymentTransactionDetail orderId={ orderId } pollIntervalMs={ 5000 } />
 				<p>Waiting for the payment result of { orderId }</p>
 			</div>
 		);

--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -16,7 +16,7 @@ import { identity } from 'lodash';
 import { getOrderTransaction, getOrderTransactionError } from 'state/selectors';
 import { ORDER_TRANSACTION_STATUS } from 'state/order-transactions/constants';
 import { errorNotice } from 'state/notices/actions';
-import QuerySourcePaymentTransactionDetail from 'components/data/query-source-payment-transaction-detail';
+import QueryOrderTransaction from 'components/data/query-order-transaction';
 
 class CheckoutPending extends PureComponent {
 	static propTypes = {
@@ -97,7 +97,7 @@ class CheckoutPending extends PureComponent {
 		// Replace this placeholder by the real one
 		return (
 			<div>
-				<QuerySourcePaymentTransactionDetail orderId={ orderId } pollIntervalMs={ 5000 } />
+				<QueryOrderTransaction orderId={ orderId } pollIntervalMs={ 5000 } />
 				<p>Waiting for the payment result of { orderId }</p>
 			</div>
 		);


### PR DESCRIPTION
## Summary
This PR is part of the work for https://github.com/Automattic/wp-calypso/issues/22914, which implements a query component for polling the order transaction info endpoint.

It implements a query component, `<QueryOrderTransaction />`, and dock it in the `<CheckoutPending />` component so that the checkout pending page will poll the endpoint when a user arrived there.

## Test Plan

1. Comment out the whole [componentWillReceiveProps()](https://github.com/Automattic/wp-calypso/blob/add/query-component-for-order-transactions/client/my-sites/checkout/checkout-thank-you/pending.jsx#L36) function so that the pending checkout page won't redirect to the other pages. That way we can verify it is polling easier.
1. Login as a test account.
1. Visit http://calypso.localhost:3000/checkout/thank-you/:site-slug/pending/199999 . Note that the `:site-slug` part should be a site belonging to the test account, or simply `no-site`. Also, 199999 is just something randomly picked.
1. Open the network inspector tab, and you should see that it is polling `/me/transactions/order/` endpoint periodically.

An example screencast of the above scenario:
![demo-polling](https://user-images.githubusercontent.com/1842898/38534864-14424efe-3cb3-11e8-9c60-380a724972b8.gif)



