### PR TITLE
Post Editor: reduxify editing post author

### DIFF
--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -32,7 +32,6 @@ class EditorActionBar extends Component {
 		site: PropTypes.object,
 		type: PropTypes.string,
 		isPostPrivate: PropTypes.bool,
-		postAuthor: PropTypes.object,
 	};
 
 	state = {
@@ -45,7 +44,7 @@ class EditorActionBar extends Component {
 		// update based on post changes. Flux changes are passed down from parent components.
 		const multiUserSite = this.props.site && ! this.props.site.single_user_site;
 		const isPasswordProtected = utils.getVisibility( this.props.post ) === 'password';
-		const { isPostPrivate, postAuthor } = this.props;
+		const { isPostPrivate } = this.props;
 
 		return (
 			<div className="editor-action-bar">
@@ -54,12 +53,7 @@ class EditorActionBar extends Component {
 				</div>
 				<div className="editor-action-bar__cell is-center">
 					{ multiUserSite && (
-						<AsyncLoad
-							require="post-editor/editor-author"
-							post={ this.props.post }
-							isNew={ this.props.isNew }
-							postAuthor={ postAuthor }
-						/>
+						<AsyncLoad require="post-editor/editor-author" isNew={ this.props.isNew } />
 					) }
 				</div>
 				<div className="editor-action-bar__cell is-right">

--- a/client/post-editor/editor-author/index.jsx
+++ b/client/post-editor/editor-author/index.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,10 +16,13 @@ import { localize } from 'i18n-calypso';
 import Gravatar from 'components/gravatar';
 import userFactory from 'lib/user';
 import AuthorSelector from 'blocks/author-selector';
-import PostActions from 'lib/posts/actions';
 import { hasTouch } from 'lib/touch-detect';
 import * as stats from 'lib/posts/stats';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getSite } from 'state/sites/selectors';
+import { getEditedPost } from 'state/posts/selectors';
+import { editPost } from 'state/posts/actions';
 
 /**
  * Module dependencies
@@ -29,19 +33,17 @@ export class EditorAuthor extends Component {
 	static propTypes = {
 		post: PropTypes.object,
 		isNew: PropTypes.bool,
-		postAuthor: PropTypes.object,
 	};
 
 	render() {
-		// if it's not a new post and we are still loading
-		// show a placeholder component
-		const { post, translate, site, postAuthor } = this.props;
+		const { post, translate, site } = this.props;
 
+		// if it's not a new post and we are still loading, show a placeholder component
 		if ( ! post && ! this.props.isNew ) {
 			return this.renderPlaceholder();
 		}
 
-		const author = post && postAuthor ? postAuthor : user.get();
+		const author = get( post, 'author', user.get() );
 		const name = author.display_name || author.name;
 		const Wrapper = this.userCanAssignAuthor() ? AuthorSelector : 'div';
 		const popoverPosition = hasTouch() ? 'bottom right' : 'bottom left';
@@ -77,8 +79,10 @@ export class EditorAuthor extends Component {
 	onSelect = author => {
 		stats.recordStat( 'advanced_author_changed' );
 		stats.recordEvent( 'Changed Author' );
-		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		PostActions.edit( { author: author } );
+
+		const siteId = get( this.props.site, 'ID', null );
+		const postId = get( this.props.post, 'ID', null );
+		this.props.editPost( siteId, postId, { author } );
 	};
 
 	userCanAssignAuthor() {
@@ -97,6 +101,15 @@ export class EditorAuthor extends Component {
 	}
 }
 
-export default connect( state => ( {
-	site: getSelectedSite( state ),
-} ) )( localize( EditorAuthor ) );
+export default connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
+		const postId = getEditorPostId( state );
+
+		return {
+			site: getSite( state, siteId ),
+			post: getEditedPost( state, siteId, postId ),
+		};
+	},
+	{ editPost }
+)( localize( EditorAuthor ) );

--- a/client/post-editor/editor-author/index.jsx
+++ b/client/post-editor/editor-author/index.jsx
@@ -14,7 +14,6 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import Gravatar from 'components/gravatar';
-import userFactory from 'lib/user';
 import AuthorSelector from 'blocks/author-selector';
 import { hasTouch } from 'lib/touch-detect';
 import * as stats from 'lib/posts/stats';
@@ -23,11 +22,7 @@ import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getSite } from 'state/sites/selectors';
 import { getEditedPost } from 'state/posts/selectors';
 import { editPost } from 'state/posts/actions';
-
-/**
- * Module dependencies
- */
-const user = userFactory();
+import { getCurrentUser } from 'state/current-user/selectors';
 
 export class EditorAuthor extends Component {
 	static propTypes = {
@@ -36,14 +31,13 @@ export class EditorAuthor extends Component {
 	};
 
 	render() {
-		const { post, translate, site } = this.props;
+		const { post, author, translate, site } = this.props;
 
 		// if it's not a new post and we are still loading, show a placeholder component
 		if ( ! post && ! this.props.isNew ) {
 			return this.renderPlaceholder();
 		}
 
-		const author = get( post, 'author', user.get() );
 		const name = author.display_name || author.name;
 		const Wrapper = this.userCanAssignAuthor() ? AuthorSelector : 'div';
 		const popoverPosition = hasTouch() ? 'bottom right' : 'bottom left';
@@ -106,10 +100,11 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const postId = getEditorPostId( state );
 
-		return {
-			site: getSite( state, siteId ),
-			post: getEditedPost( state, siteId, postId ),
-		};
+		const site = getSite( state, siteId );
+		const post = getEditedPost( state, siteId, postId );
+		const author = get( post, 'author', getCurrentUser( state ) );
+
+		return { site, post, author };
 	},
 	{ editPost }
 )( localize( EditorAuthor ) );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -335,7 +335,6 @@ export const PostEditor = createReactClass( {
 								savedPost={ this.state.savedPost }
 								site={ site }
 								isPostPrivate={ utils.isPrivate( this.state.post ) }
-								postAuthor={ this.state.post ? this.state.post.author : null }
 							/>
 							<div className="post-editor__site">
 								<Site

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -47,8 +47,9 @@ import likes from './likes/reducer';
 import revisions from './revisions/reducer';
 import {
 	getSerializedPostsQuery,
-	isTermsEqual,
+	isAuthorEqual,
 	isDiscussionEqual,
+	isTermsEqual,
 	mergeIgnoringArrays,
 	normalizePostForState,
 } from './utils';
@@ -419,10 +420,12 @@ export function edits( state = {}, action ) {
 						[ post.site_ID, post.ID ],
 						omitBy( postEdits, ( value, key ) => {
 							switch ( key ) {
-								case 'terms':
-									return isTermsEqual( value, post[ key ] );
+								case 'author':
+									return isAuthorEqual( value, post[ key ] );
 								case 'discussion':
 									return isDiscussionEqual( value, post[ key ] );
+								case 'terms':
+									return isTermsEqual( value, post[ key ] );
 							}
 							return isEqual( post[ key ], value );
 						} )

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -15,6 +15,7 @@ import {
 	getSerializedPostsQuery,
 	getDeserializedPostsQueryDetails,
 	getSerializedPostsQueryWithoutPage,
+	isAuthorEqual,
 	isDiscussionEqual,
 	mergeIgnoringArrays,
 	normalizePostForEditing,
@@ -411,14 +412,17 @@ export const isEditedPostDirty = createSelector(
 
 			if ( post ) {
 				switch ( key ) {
+					case 'author': {
+						return ! isAuthorEqual( value, post.author );
+					}
 					case 'date': {
 						return ! moment( value ).isSame( post.date );
 					}
-					case 'parent': {
-						return get( post, 'parent.ID', 0 ) !== value;
-					}
 					case 'discussion': {
 						return ! isDiscussionEqual( value, post.discussion );
+					}
+					case 'parent': {
+						return get( post, 'parent.ID', 0 ) !== value;
 					}
 				}
 				return post[ key ] !== value;

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -1205,6 +1205,46 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		test( 'should remove author edit after it is saved and user IDs are equal', () => {
+			const state = edits(
+				deepFreeze( {
+					2916284: {
+						841: {
+							title: 'Hello World',
+							type: 'post',
+							author: {
+								ID: 123,
+								name: 'Robert Trujillo',
+							},
+						},
+					},
+				} ),
+				{
+					type: POSTS_RECEIVE,
+					posts: [
+						{
+							ID: 841,
+							site_ID: 2916284,
+							type: 'post',
+							title: 'Hello',
+							author: {
+								ID: 123,
+								name: 'Bob Trujillo',
+							},
+						},
+					],
+				}
+			);
+
+			expect( state ).to.eql( {
+				2916284: {
+					841: {
+						title: 'Hello World',
+					},
+				},
+			} );
+		} );
+
 		test( "should ignore reset edits action when discarded site doesn't exist", () => {
 			const original = deepFreeze( {} );
 			const state = edits( original, {

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -2034,6 +2034,44 @@ describe( 'selectors', () => {
 
 			expect( isDirty ).to.be.false;
 		} );
+
+		test( "should return false if author ID didn't change", () => {
+			const isDirty = isEditedPostDirty(
+				{
+					posts: {
+						queries: {
+							2916284: new PostQueryManager( {
+								items: {
+									841: {
+										ID: 841,
+										site_ID: 2916284,
+										global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+										author: {
+											ID: 123,
+											name: 'Robert Trujillo',
+										},
+									},
+								},
+							} ),
+						},
+						edits: {
+							2916284: {
+								841: {
+									author: {
+										ID: 123,
+										name: 'Bob Trujillo',
+									},
+								},
+							},
+						},
+					},
+				},
+				2916284,
+				841
+			);
+
+			expect( isDirty ).to.be.false;
+		} );
 	} );
 
 	describe( 'getPostPreviewUrl()', () => {

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -298,6 +298,18 @@ export function isDiscussionEqual( localDiscussionEdits, savedDiscussion ) {
 }
 
 /**
+ * Returns true if the locally edited author ID is equal to the saved post author's ID. Other
+ * properties of the `author` object are irrelevant.
+ *
+ * @param  {Object}  localAuthorEdit locally edited author object
+ * @param  {Object}  savedAuthor     author property returned from API POST
+ * @return {Boolean}                 are the locally edited and saved values equal?
+ */
+export function isAuthorEqual( localAuthorEdit, savedAuthor ) {
+	return get( localAuthorEdit, 'ID' ) === get( savedAuthor, 'ID' );
+}
+
+/**
  * Returns a normalized post object for sending to the API
  *
  * @param  {Object} post Raw post object


### PR DESCRIPTION
This PR migrates the `EditorAuthor` component in Post Editor to Redux.

**Step 1**
In `posts.edits` reducer and `isEditedPostDirty` selectors, compare the `author` objects only by ID and ignore other properties. The individual properties might differ slightly, or be or not be present (e.g,  `is_super_admin`), depending on whether the user object comes from REST API response, the "current user" object, or "site users" store. But the ID is always the same and is the only relevant one.

**Step 2**
Reduxify the `EditorAuthor` component. Information about the current post is retrieved from Redux in `connect` call, passing it in properties like `postAuthor` is no longer necessary, and a Redux action is dispatched on change.

**Step 3**
A drive-by change: stop using `lib/user` in `EditorAuthor` and instead get the current user from Redux.

**How to test:**
- go to a site with multiple users (any P2 should do)
- start editing a new post, or an existing post or draft (please test all variants, they are slightly different)
- select another author in the drop down above the title/content area:
<img width="730" alt="screen shot 2018-04-03 at 12 03 02" src="https://user-images.githubusercontent.com/664258/38246264-852212d4-3741-11e8-8ae9-a3564f38756f.png">

- verify that the post was detected as dirty and offers "Save" action in the "ground control" bar. (that works only on drafts)
- if you change the author back to the original one, verify that the "Save" button is not active -- the post is no longer detected as dirty
- if you're editing a brand new post, verify that the default author is you
- verify that the changes to author get actually saved/updated