### PR TITLE
Inline Help: make search results play nice with Meta clicks (and `Enter`s)

### DIFF
--- a/client/blocks/inline-help/inline-help-search-card.jsx
+++ b/client/blocks/inline-help/inline-help-search-card.jsx
@@ -42,8 +42,8 @@ class InlineHelpSearchCard extends Component {
 	};
 
 	onKeyDown = event => {
-		// ignore keyboard access when manipulating a text selection in input
-		if ( event.getModifierState() ) {
+		// ignore keyboard access when manipulating a text selection in input etc.
+		if ( event.getModifierState( 'Shift' ) ) {
 			return;
 		}
 		// take over control if and only if it's one of our keys
@@ -61,7 +61,7 @@ class InlineHelpSearchCard extends Component {
 				this.props.selectNextResult();
 				break;
 			case 'Enter':
-				this.props.openResult( this.props.selectedLink );
+				this.props.openResult( event, this.props.selectedLink );
 				break;
 		}
 	};

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -124,8 +124,7 @@ class InlineHelpSearchResults extends Component {
 	}
 
 	onHelpLinkClick = event => {
-		event.preventDefault();
-		this.props.openResult( event.target.href );
+		this.props.openResult( event, event.target.href );
 	};
 
 	renderHelpLink = ( link, index ) => {

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -36,7 +36,7 @@ class InlineHelpPopover extends Component {
 		showContactForm: false,
 	};
 
-	openResult = href => {
+	openResult = ( event, href ) => {
 		if ( ! href ) {
 			return;
 		}
@@ -46,7 +46,13 @@ class InlineHelpPopover extends Component {
 			result_url: href,
 		} );
 
-		window.location = href;
+		if ( ! event.metaKey ) {
+			event.preventDefault();
+			window.location = href;
+		} else if ( event.key === 'Enter' ) {
+			event.preventDefault();
+			window.open( href, '_blank' );
+		}
 	};
 
 	moreHelpClicked = () => {


### PR DESCRIPTION
The search results in Inline Help don't respect Command+clicks. This PR fixes this and also makes Command+Enter open a new window / tab for keyboard-based navigation. 

Fixes #23804. 

To test:
- Open search results (and default links) from Inline Help using a normal click, Command-Click, enter, and Command-Enter. Make sure the link opens in a new tab or window as appropriate. Make sure the proper Tracks events still get sent in all cases. 