### PR TITLE
Add more helper functions such as isWpComFreePlan

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -18,8 +18,6 @@ import {
 	PLAN_FREE,
 	PLAN_JETPACK_FREE,
 	PLAN_PERSONAL,
-} from 'lib/plans/constants';
-import {
 	TERM_MONTHLY,
 	TERM_ANNUALLY,
 	TERM_BIENNIALLY,
@@ -27,6 +25,8 @@ import {
 	TYPE_FREE,
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
+	GROUP_WPCOM,
+	GROUP_JETPACK,
 } from './constants';
 
 /**
@@ -223,6 +223,38 @@ export function isPersonalPlan( planSlug ) {
 
 export function isFreePlan( planSlug ) {
 	return planMatches( planSlug, { type: TYPE_FREE } );
+}
+
+export function isWpComBusinessPlan( planSlug ) {
+	return planMatches( planSlug, { type: TYPE_BUSINESS, group: GROUP_WPCOM } );
+}
+
+export function isWpComPremiumPlan( planSlug ) {
+	return planMatches( planSlug, { type: TYPE_PREMIUM, group: GROUP_WPCOM } );
+}
+
+export function isWpComPersonalPlan( planSlug ) {
+	return planMatches( planSlug, { type: TYPE_PERSONAL, group: GROUP_WPCOM } );
+}
+
+export function isWpComFreePlan( planSlug ) {
+	return planMatches( planSlug, { type: TYPE_FREE, group: GROUP_WPCOM } );
+}
+
+export function isJetpackBusinessPlan( planSlug ) {
+	return planMatches( planSlug, { type: TYPE_BUSINESS, group: GROUP_JETPACK } );
+}
+
+export function isJetpackPremiumPlan( planSlug ) {
+	return planMatches( planSlug, { type: TYPE_PREMIUM, group: GROUP_JETPACK } );
+}
+
+export function isJetpackPersonalPlan( planSlug ) {
+	return planMatches( planSlug, { type: TYPE_PERSONAL, group: GROUP_JETPACK } );
+}
+
+export function isJetpackFreePlan( planSlug ) {
+	return planMatches( planSlug, { type: TYPE_FREE, group: GROUP_JETPACK } );
 }
 
 /**

--- a/client/lib/plans/test/plan-lookups.js
+++ b/client/lib/plans/test/plan-lookups.js
@@ -39,12 +39,20 @@ import {
 	isBusinessPlan,
 	isPersonalPlan,
 	isPremiumPlan,
+	isFreePlan,
+	isJetpackBusinessPlan,
+	isJetpackPersonalPlan,
+	isJetpackPremiumPlan,
+	isJetpackFreePlan,
+	isWpComBusinessPlan,
+	isWpComPersonalPlan,
+	isWpComPremiumPlan,
+	isWpComFreePlan,
 	planMatches,
 	findSimilarPlansKeys,
 	findPlansKeys,
 	getMonthlyPlanByYearly,
 	getYearlyPlanByMonthly,
-	isFreePlan,
 } from '../index';
 
 describe( 'isFreePlan', () => {
@@ -114,6 +122,146 @@ describe( 'isBusinessPlan', () => {
 		expect( isBusinessPlan( PLAN_PREMIUM ) ).to.equal( false );
 		expect( isBusinessPlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
 		expect( isBusinessPlan( 'non-existing plan' ) ).to.equal( false );
+	} );
+} );
+
+describe( 'isWpComFreePlan', () => {
+	test( 'should return true for free plans', () => {
+		expect( isWpComFreePlan( PLAN_FREE ) ).to.equal( true );
+	} );
+	test( 'should return false for non-free plans', () => {
+		expect( isWpComFreePlan( PLAN_JETPACK_FREE ) ).to.equal( false );
+		expect( isWpComFreePlan( PLAN_PERSONAL ) ).to.equal( false );
+		expect( isWpComFreePlan( PLAN_JETPACK_PERSONAL ) ).to.equal( false );
+		expect( isWpComFreePlan( PLAN_PREMIUM ) ).to.equal( false );
+		expect( isWpComFreePlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
+		expect( isWpComFreePlan( PLAN_BUSINESS ) ).to.equal( false );
+		expect( isWpComFreePlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
+		expect( isWpComFreePlan( 'non-existing plan' ) ).to.equal( false );
+	} );
+} );
+
+describe( 'isWpComPersonalPlan', () => {
+	test( 'should return true for personal plans', () => {
+		expect( isWpComPersonalPlan( PLAN_PERSONAL ) ).to.equal( true );
+		expect( isWpComPersonalPlan( PLAN_PERSONAL_2_YEARS ) ).to.equal( true );
+	} );
+	test( 'should return false for non-personal plans', () => {
+		expect( isWpComPersonalPlan( PLAN_JETPACK_PERSONAL ) ).to.equal( false );
+		expect( isWpComPersonalPlan( PLAN_JETPACK_PERSONAL_MONTHLY ) ).to.equal( false );
+		expect( isWpComPersonalPlan( PLAN_PREMIUM ) ).to.equal( false );
+		expect( isWpComPersonalPlan( PLAN_PREMIUM_2_YEARS ) ).to.equal( false );
+		expect( isWpComPersonalPlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
+		expect( isWpComPersonalPlan( PLAN_JETPACK_PREMIUM_MONTHLY ) ).to.equal( false );
+		expect( isWpComPersonalPlan( PLAN_BUSINESS ) ).to.equal( false );
+		expect( isWpComPersonalPlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
+		expect( isWpComPersonalPlan( 'non-exisWpComting plan' ) ).to.equal( false );
+	} );
+} );
+
+describe( 'isWpComPremiumPlan', () => {
+	test( 'should return true for premium plans', () => {
+		expect( isWpComPremiumPlan( PLAN_PREMIUM ) ).to.equal( true );
+		expect( isWpComPremiumPlan( PLAN_PREMIUM_2_YEARS ) ).to.equal( true );
+	} );
+	test( 'should return false for non-premium plans', () => {
+		expect( isWpComPremiumPlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
+		expect( isWpComPremiumPlan( PLAN_JETPACK_PREMIUM_MONTHLY ) ).to.equal( false );
+		expect( isWpComPremiumPlan( PLAN_PERSONAL ) ).to.equal( false );
+		expect( isWpComPremiumPlan( PLAN_PERSONAL_2_YEARS ) ).to.equal( false );
+		expect( isWpComPremiumPlan( PLAN_JETPACK_PERSONAL ) ).to.equal( false );
+		expect( isWpComPremiumPlan( PLAN_JETPACK_PERSONAL_MONTHLY ) ).to.equal( false );
+		expect( isWpComPremiumPlan( PLAN_BUSINESS ) ).to.equal( false );
+		expect( isWpComPremiumPlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
+		expect( isWpComFreePlan( 'non-existing plan' ) ).to.equal( false );
+	} );
+} );
+
+describe( 'isWpComBusinessPlan', () => {
+	test( 'should return true for business plans', () => {
+		expect( isWpComBusinessPlan( PLAN_BUSINESS ) ).to.equal( true );
+		expect( isWpComBusinessPlan( PLAN_BUSINESS_2_YEARS ) ).to.equal( true );
+	} );
+	test( 'should return false for non-business plans', () => {
+		expect( isWpComBusinessPlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
+		expect( isWpComBusinessPlan( PLAN_JETPACK_BUSINESS_MONTHLY ) ).to.equal( false );
+		expect( isWpComBusinessPlan( PLAN_PERSONAL ) ).to.equal( false );
+		expect( isWpComBusinessPlan( PLAN_PERSONAL_2_YEARS ) ).to.equal( false );
+		expect( isWpComBusinessPlan( PLAN_JETPACK_PERSONAL ) ).to.equal( false );
+		expect( isWpComBusinessPlan( PLAN_JETPACK_PERSONAL_MONTHLY ) ).to.equal( false );
+		expect( isWpComBusinessPlan( PLAN_PREMIUM ) ).to.equal( false );
+		expect( isWpComBusinessPlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
+		expect( isWpComBusinessPlan( 'non-exisWpComting plan' ) ).to.equal( false );
+	} );
+} );
+
+describe( 'isJetpackFreePlan', () => {
+	test( 'should return true for free plans', () => {
+		expect( isJetpackFreePlan( PLAN_JETPACK_FREE ) ).to.equal( true );
+	} );
+	test( 'should return false for non-free plans', () => {
+		expect( isJetpackFreePlan( PLAN_FREE ) ).to.equal( false );
+		expect( isJetpackFreePlan( PLAN_PERSONAL ) ).to.equal( false );
+		expect( isJetpackFreePlan( PLAN_JETPACK_PERSONAL ) ).to.equal( false );
+		expect( isJetpackFreePlan( PLAN_PREMIUM ) ).to.equal( false );
+		expect( isJetpackFreePlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
+		expect( isJetpackFreePlan( PLAN_BUSINESS ) ).to.equal( false );
+		expect( isJetpackFreePlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
+		expect( isJetpackFreePlan( 'non-existing plan' ) ).to.equal( false );
+	} );
+} );
+
+describe( 'isJetpackPersonalPlan', () => {
+	test( 'should return true for personal plans', () => {
+		expect( isJetpackPersonalPlan( PLAN_JETPACK_PERSONAL ) ).to.equal( true );
+		expect( isJetpackPersonalPlan( PLAN_JETPACK_PERSONAL_MONTHLY ) ).to.equal( true );
+	} );
+	test( 'should return false for non-personal plans', () => {
+		expect( isJetpackPersonalPlan( PLAN_PERSONAL ) ).to.equal( false );
+		expect( isJetpackPersonalPlan( PLAN_PERSONAL_2_YEARS ) ).to.equal( false );
+		expect( isJetpackPersonalPlan( PLAN_PREMIUM ) ).to.equal( false );
+		expect( isJetpackPersonalPlan( PLAN_PREMIUM_2_YEARS ) ).to.equal( false );
+		expect( isJetpackPersonalPlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
+		expect( isJetpackPersonalPlan( PLAN_JETPACK_PREMIUM_MONTHLY ) ).to.equal( false );
+		expect( isJetpackPersonalPlan( PLAN_BUSINESS ) ).to.equal( false );
+		expect( isJetpackPersonalPlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
+		expect( isJetpackPersonalPlan( 'non-exisJetpackting plan' ) ).to.equal( false );
+	} );
+} );
+
+describe( 'isJetpackPremiumPlan', () => {
+	test( 'should return true for premium plans', () => {
+		expect( isJetpackPremiumPlan( PLAN_JETPACK_PREMIUM ) ).to.equal( true );
+		expect( isJetpackPremiumPlan( PLAN_JETPACK_PREMIUM_MONTHLY ) ).to.equal( true );
+	} );
+	test( 'should return false for non-premium plans', () => {
+		expect( isJetpackPremiumPlan( PLAN_PREMIUM ) ).to.equal( false );
+		expect( isJetpackPremiumPlan( PLAN_PREMIUM_2_YEARS ) ).to.equal( false );
+		expect( isJetpackPremiumPlan( PLAN_PERSONAL ) ).to.equal( false );
+		expect( isJetpackPremiumPlan( PLAN_PERSONAL_2_YEARS ) ).to.equal( false );
+		expect( isJetpackPremiumPlan( PLAN_JETPACK_PERSONAL ) ).to.equal( false );
+		expect( isJetpackPremiumPlan( PLAN_JETPACK_PERSONAL_MONTHLY ) ).to.equal( false );
+		expect( isJetpackPremiumPlan( PLAN_BUSINESS ) ).to.equal( false );
+		expect( isJetpackPremiumPlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
+		expect( isJetpackFreePlan( 'non-existing plan' ) ).to.equal( false );
+	} );
+} );
+
+describe( 'isJetpackBusinessPlan', () => {
+	test( 'should return true for business plans', () => {
+		expect( isJetpackBusinessPlan( PLAN_JETPACK_BUSINESS ) ).to.equal( true );
+		expect( isJetpackBusinessPlan( PLAN_JETPACK_BUSINESS_MONTHLY ) ).to.equal( true );
+	} );
+	test( 'should return false for non-business plans', () => {
+		expect( isJetpackBusinessPlan( PLAN_BUSINESS ) ).to.equal( false );
+		expect( isJetpackBusinessPlan( PLAN_BUSINESS_2_YEARS ) ).to.equal( false );
+		expect( isJetpackBusinessPlan( PLAN_PERSONAL ) ).to.equal( false );
+		expect( isJetpackBusinessPlan( PLAN_PERSONAL_2_YEARS ) ).to.equal( false );
+		expect( isJetpackBusinessPlan( PLAN_JETPACK_PERSONAL ) ).to.equal( false );
+		expect( isJetpackBusinessPlan( PLAN_JETPACK_PERSONAL_MONTHLY ) ).to.equal( false );
+		expect( isJetpackBusinessPlan( PLAN_PREMIUM ) ).to.equal( false );
+		expect( isJetpackBusinessPlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
+		expect( isJetpackBusinessPlan( 'non-exisJetpackting plan' ) ).to.equal( false );
 	} );
 } );
 


### PR DESCRIPTION
Adds more helper functions such as isWpComFreePlan to simplify the process of removing hardcoded PLAN_ constants usage

Test plan:
None, just see if circle CI unit tests succeeded