### PR TITLE
Remove hardcoded PLAN_ constants from premium popover

### DIFF
--- a/client/components/plans/premium-popover/index.jsx
+++ b/client/components/plans/premium-popover/index.jsx
@@ -18,9 +18,10 @@ import Gridicon from 'gridicons';
 import Popover from 'components/popover';
 import PlanPrice from 'components/plans/plan-price';
 import { getSitePlan } from 'state/sites/plans/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getPlanBySlug } from 'state/plans/selectors';
-import { PLAN_PREMIUM } from 'lib/plans/constants';
+import { findFirstSimilarPlanKey } from 'lib/plans';
+import { TYPE_PREMIUM } from 'lib/plans/constants';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QueryPlans from 'components/data/query-plans';
 
@@ -144,11 +145,17 @@ class PremiumPopover extends React.Component {
 	}
 }
 
-export default connect( state => {
+export const mapStateToProps = state => {
 	const selectedSiteId = getSelectedSiteId( state );
+	const selectedSite = getSelectedSite( state );
+	const selectedPlanSlug = selectedSite.plan.product_slug;
+	const premiumPlanSlug = findFirstSimilarPlanKey( selectedPlanSlug, { type: TYPE_PREMIUM } );
+
 	return {
 		selectedSiteId,
-		premiumPlan: getPlanBySlug( state, PLAN_PREMIUM ),
-		premiumSitePlan: getSitePlan( state, selectedSiteId, PLAN_PREMIUM ),
+		premiumPlan: getPlanBySlug( state, premiumPlanSlug ),
+		premiumSitePlan: getSitePlan( state, selectedSiteId, premiumPlanSlug ),
 	};
-} )( localize( PremiumPopover ) );
+};
+
+export default connect( mapStateToProps )( localize( PremiumPopover ) );

--- a/client/components/plans/premium-popover/test/index.jsx
+++ b/client/components/plans/premium-popover/test/index.jsx
@@ -1,0 +1,88 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.mock( 'lib/analytics/index', () => ( {} ) );
+jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'lib/user', () => ( {} ) );
+jest.mock( 'components/main', () => 'MainComponent' );
+jest.mock( 'components/popover', () => 'Popover' );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Comp => props => (
+		<Comp
+			{ ...props }
+			translate={ function( x ) {
+				return x;
+			} }
+		/>
+	),
+	numberFormat: x => x,
+} ) );
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import {
+	PLANS_LIST,
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { mapStateToProps } from '../index';
+
+describe( 'mapStateToProps()', () => {
+	const allPlans = ( function() {
+		const plans = {};
+		for ( const slug in PLANS_LIST ) {
+			plans[ slug ] = {
+				product_slug: slug,
+			};
+		}
+		return plans;
+	} )();
+
+	const getState = plan => ( {
+		ui: {
+			selectedSiteId: 1,
+		},
+		plans: {
+			items: allPlans,
+		},
+		sites: {
+			plans: allPlans,
+			items: {
+				1: {
+					plan: {
+						product_slug: plan,
+					},
+				},
+			},
+		},
+	} );
+
+	[ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS ].forEach( plan => {
+		test( 'Should return 1-year premium plan for other 1 year plans', () => {
+			expect( mapStateToProps( getState( plan ) ).premiumPlan.product_slug ).toBe( PLAN_PREMIUM );
+		} );
+	} );
+
+	[ PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS, PLAN_BUSINESS_2_YEARS ].forEach( plan => {
+		test( 'Should return 2-year premium plan for other 1 year plans', () => {
+			expect( mapStateToProps( getState( plan ) ).premiumPlan.product_slug ).toBe(
+				PLAN_PREMIUM_2_YEARS
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `banner`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* Go to "map your domain" step and click on "included in premium plans": <img width="764" alt="zrzut ekranu 2018-04-03 o 15 30 27" src="https://user-images.githubusercontent.com/205419/38252291-08d8d90c-3754-11e8-938c-5bc0df7580f5.png">
* **At the moment this popover is broken and a separate fix is required**
