### PR TITLE
Plugins State: Add test for new isLoaded selector

### DIFF
--- a/client/state/plugins/installed/test/selectors.js
+++ b/client/state/plugins/installed/test/selectors.js
@@ -125,6 +125,20 @@ describe( 'Installed plugin selectors', () => {
 		} );
 	} );
 
+	describe( 'isLoaded', () => {
+		test( 'Should get `false` if this site is not in the current state', () => {
+			expect( selectors.isLoaded( state, 'no.site' ) ).to.be.false;
+		} );
+
+		test( 'Should get `true` if this site is done being fetched', () => {
+			expect( selectors.isLoaded( state, 'site.one' ) ).to.be.true;
+		} );
+
+		test( 'Should get `false` if this site is currently being fetched', () => {
+			expect( selectors.isLoaded( state, 'site.three' ) ).to.be.false;
+		} );
+	} );
+
 	describe( 'isRequestingForSites', () => {
 		test( 'Should get `false` if no sites are being fetched', () => {
 			expect( selectors.isRequestingForSites( state, [ 'site.one', 'site.two' ] ) ).to.be.false;


### PR DESCRIPTION
This PR adds tests for a new selector introduced in #23809, `isLoaded`. This selector checks whether we've finished loading the info about installed plugins from a remote site.

**To test**

- Run the tests: `npm run test-client client/state/plugins/installed`
- There should be no changes to any UI