### PR TITLE
JP Settings (data-layer based): Keep Track of Module Activation State

### DIFF
--- a/client/state/jetpack-onboarding/reducer.js
+++ b/client/state/jetpack-onboarding/reducer.js
@@ -9,8 +9,8 @@ import { mapValues, merge } from 'lodash';
  * Internal dependencies
  */
 import { createReducer, combineReducers, keyedReducer } from 'state/utils';
-import { normalizeSettings } from 'state/jetpack/settings/utils';
 import { jetpackOnboardingCredentialsSchema, jetpackSettingsSchema } from './schema';
+import { normalizeSettings } from 'state/jetpack/settings/utils';
 import {
 	JETPACK_MODULE_ACTIVATE_SUCCESS,
 	JETPACK_MODULE_DEACTIVATE_SUCCESS,

--- a/client/state/jetpack-onboarding/reducer.js
+++ b/client/state/jetpack-onboarding/reducer.js
@@ -3,14 +3,18 @@
 /**
  * External dependencies
  */
-import { merge } from 'lodash';
+import { mapValues, merge } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { createReducer, combineReducers, keyedReducer } from 'state/utils';
+import { normalizeSettings } from 'state/jetpack/settings/utils';
 import { jetpackOnboardingCredentialsSchema, jetpackSettingsSchema } from './schema';
 import {
+	JETPACK_MODULE_ACTIVATE_SUCCESS,
+	JETPACK_MODULE_DEACTIVATE_SUCCESS,
+	JETPACK_MODULES_RECEIVE,
 	JETPACK_CONNECT_AUTHORIZE_RECEIVE,
 	JETPACK_ONBOARDING_CREDENTIALS_RECEIVE,
 	JETPACK_ONBOARDING_SETTINGS_SAVE_SUCCESS,
@@ -35,6 +39,31 @@ export const settingsReducer = keyedReducer(
 	createReducer(
 		{},
 		{
+			[ JETPACK_MODULE_ACTIVATE_SUCCESS ]: ( state, { moduleSlug } ) => ( {
+				...state,
+				[ moduleSlug ]: true,
+			} ),
+			[ JETPACK_MODULE_DEACTIVATE_SUCCESS ]: ( state, { moduleSlug } ) => ( {
+				...state,
+				[ moduleSlug ]: false,
+			} ),
+			[ JETPACK_MODULES_RECEIVE ]: ( state, { modules } ) => {
+				const modulesActivationState = mapValues( modules, module => module.active );
+				// The need for flattening module options into this moduleSettings is temporary.
+				// Once https://github.com/Automattic/jetpack/pull/6002 is released,
+				// the flattening will be done on the server side for the /jetpack/v4/settings/ endpoint
+				const moduleSettings = Object.keys( modules ).reduce( ( allTheSettings, slug ) => {
+					return {
+						...allTheSettings,
+						...mapValues( modules[ slug ].options, option => option.current_value ),
+					};
+				}, {} );
+				return {
+					...state,
+					...modulesActivationState,
+					...normalizeSettings( moduleSettings ),
+				};
+			},
 			[ JETPACK_ONBOARDING_SETTINGS_SAVE_SUCCESS ]: (
 				state,
 				{ settings: { post_by_email_address } }

--- a/client/state/jetpack-onboarding/test/reducer.js
+++ b/client/state/jetpack-onboarding/test/reducer.js
@@ -159,7 +159,7 @@ describe( 'reducer', () => {
 
 		test( 'should mark the module as active upon successful module activation', () => {
 			const siteId = 12345678,
-				stateIn = {
+				initialState = {
 					12345678: {
 						setting_123: 'test',
 						'module-a': false,
@@ -170,7 +170,7 @@ describe( 'reducer', () => {
 					siteId,
 					moduleSlug: 'module-a',
 				};
-			const stateOut = settingsReducer( deepFreeze( stateIn ), action );
+			const stateOut = settingsReducer( deepFreeze( initialState ), action );
 			expect( stateOut ).toEqual( {
 				12345678: {
 					setting_123: 'test',
@@ -181,7 +181,7 @@ describe( 'reducer', () => {
 
 		test( 'should mark the module as inactive upon successful module deactivation', () => {
 			const siteId = 12345678,
-				stateIn = {
+				initialState = {
 					12345678: {
 						setting_123: 'test',
 						'module-a': true,
@@ -192,7 +192,7 @@ describe( 'reducer', () => {
 					siteId,
 					moduleSlug: 'module-a',
 				};
-			const stateOut = settingsReducer( deepFreeze( stateIn ), action );
+			const stateOut = settingsReducer( deepFreeze( initialState ), action );
 			expect( stateOut ).toEqual( {
 				12345678: {
 					setting_123: 'test',
@@ -203,7 +203,7 @@ describe( 'reducer', () => {
 
 		test( 'should update the module activation state upon receiving new modules', () => {
 			const siteId = 12345678,
-				stateIn = {
+				initialState = {
 					12345678: {
 						setting_123: 'test',
 						'module-a': true,
@@ -222,7 +222,7 @@ describe( 'reducer', () => {
 						},
 					},
 				};
-			const stateOut = settingsReducer( deepFreeze( stateIn ), action );
+			const stateOut = settingsReducer( deepFreeze( initialState ), action );
 			expect( stateOut ).toEqual( {
 				12345678: {
 					setting_123: 'test',
@@ -234,7 +234,7 @@ describe( 'reducer', () => {
 
 		test( 'should update module settings with normalized ones when receiving new modules', () => {
 			const siteId = 12345678,
-				stateIn = {
+				initialState = {
 					12345678: {
 						setting_123: 'test',
 					},
@@ -256,7 +256,7 @@ describe( 'reducer', () => {
 						},
 					},
 				};
-			const stateOut = settingsReducer( deepFreeze( stateIn ), action );
+			const stateOut = settingsReducer( deepFreeze( initialState ), action );
 			expect( stateOut ).toEqual( {
 				12345678: {
 					setting_123: 'test',

--- a/client/state/jetpack-onboarding/test/reducer.js
+++ b/client/state/jetpack-onboarding/test/reducer.js
@@ -170,8 +170,8 @@ describe( 'reducer', () => {
 					siteId,
 					moduleSlug: 'module-a',
 				};
-			const stateOut = settingsReducer( deepFreeze( initialState ), action );
-			expect( stateOut ).toEqual( {
+			const state = settingsReducer( deepFreeze( initialState ), action );
+			expect( state ).toEqual( {
 				12345678: {
 					setting_123: 'test',
 					'module-a': true,
@@ -192,8 +192,8 @@ describe( 'reducer', () => {
 					siteId,
 					moduleSlug: 'module-a',
 				};
-			const stateOut = settingsReducer( deepFreeze( initialState ), action );
-			expect( stateOut ).toEqual( {
+			const state = settingsReducer( deepFreeze( initialState ), action );
+			expect( state ).toEqual( {
 				12345678: {
 					setting_123: 'test',
 					'module-a': false,
@@ -222,8 +222,8 @@ describe( 'reducer', () => {
 						},
 					},
 				};
-			const stateOut = settingsReducer( deepFreeze( initialState ), action );
-			expect( stateOut ).toEqual( {
+			const state = settingsReducer( deepFreeze( initialState ), action );
+			expect( state ).toEqual( {
 				12345678: {
 					setting_123: 'test',
 					'module-a': false,
@@ -256,8 +256,8 @@ describe( 'reducer', () => {
 						},
 					},
 				};
-			const stateOut = settingsReducer( deepFreeze( initialState ), action );
-			expect( stateOut ).toEqual( {
+			const state = settingsReducer( deepFreeze( initialState ), action );
+			expect( state ).toEqual( {
 				12345678: {
 					setting_123: 'test',
 					minileven: true,


### PR DESCRIPTION
Prep for #23393. This part of state isn't used by selectors (yet). However, the reducer does listen to those action types.

Reducer and tests basically duplicated from `state/jetpack/settings`, with some minor modifications (to work with `keyedReducer` and Jest). This is the same strategy as with #23774 -- duplicate temporarily so stuff is readily available when switching over.

To test:
* Verify that unit tests pass.
* Go to `calypso.localhost:3000/settings/writing/<yourJPsite>`.
* Check the Redux log for `JETPACK_MODULES_RECEIVE`, 'Diff' tab.
* The changes being made to the `jetpack.onboardingSettings[ siteId ]` subtree should match those to the `jetpack.settings.items[ siteId ]` subtree. (Take this with a grain of salt since the diff depends on either subtree's respective previous state, so you might have to compare the actual subtree states in the 'State' tab.)