### PR TITLE
Form State: Option to skip validate/sanitize on field change

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -124,13 +124,14 @@ export class ContactDetailsFormFields extends Component {
 
 	componentWillMount() {
 		this.formStateController = formState.Controller( {
+			debounceWait: 500,
 			fieldNames: CONTACT_DETAILS_FORM_FIELDS,
 			loadFunction: this.loadFormState,
-			sanitizerFunction: this.sanitize,
-			validatorFunction: this.validate,
 			onNewState: this.setFormState,
 			onError: this.handleFormControllerError,
-			debounceWait: 500,
+			sanitizerFunction: this.sanitize,
+			skipSanitizeAndValidateOnFieldChange: true,
+			validatorFunction: this.validate,
 		} );
 	}
 
@@ -176,6 +177,11 @@ export class ContactDetailsFormFields extends Component {
 		} else {
 			onComplete( sanitizedFieldValues );
 		}
+	};
+
+	handleBlur = () => {
+		this.formStateController.sanitize();
+		this.formStateController.validate();
 	};
 
 	validate = ( fieldValues, onComplete ) =>
@@ -297,6 +303,7 @@ export class ContactDetailsFormFields extends Component {
 				'\n'
 			),
 			onChange: this.handleFieldChange,
+			onBlur: this.handleBlur,
 			value: formState.getFieldValue( form, name ) || '',
 			name,
 			eventFormName,

--- a/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
+++ b/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
@@ -18,6 +18,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
       label="First Name"
       labelClass="contact-details-form-fields__label"
       name="first-name"
+      onBlur={[Function]}
       onChange={[Function]}
       value="Osso"
     />
@@ -36,6 +37,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
       label="Last Name"
       labelClass="contact-details-form-fields__label"
       name="last-name"
+      onBlur={[Function]}
       onChange={[Function]}
       value="Buco"
     />
@@ -56,6 +58,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
         label="Organization"
         labelClass="contact-details-form-fields__label"
         name="organization"
+        onBlur={[Function]}
         onChange={[Function]}
         text="+ Add organization name"
         value="Il pagliaccio del comune"
@@ -75,6 +78,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
         label="Email"
         labelClass="contact-details-form-fields__label"
         name="email"
+        onBlur={[Function]}
         onChange={[Function]}
         value="osso@buco.com"
       />
@@ -98,6 +102,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
         label="Phone"
         labelClass="contact-details-form-fields__label"
         name="phone"
+        onBlur={[Function]}
         onChange={[Function]}
         value="+3398067382"
       />
@@ -121,6 +126,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
         label="Country"
         labelClass="contact-details-form-fields__label"
         name="country-code"
+        onBlur={[Function]}
         onChange={[Function]}
         value="IT"
       />

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -42,6 +42,7 @@ function Controller( options ) {
 
 	this._sanitizerFunction = options.sanitizerFunction;
 	this._validatorFunction = options.validatorFunction;
+	this._skipSanitizeAndValidateOnFieldChange = options.skipSanitizeAndValidateOnFieldChange;
 	this._loadFunction = options.loadFunction;
 	this._onNewState = options.onNewState;
 	this._onError = options.onError;
@@ -87,8 +88,13 @@ assign( Controller.prototype, {
 			hideError = this._hideFieldErrorsOnChange || change.hideError;
 
 		this._setState( changeFieldValue( formState, name, value, hideError ) );
-		this._debouncedSanitize();
-		this._debouncedValidate();
+
+		// If we want to handle sanitize/validate differently in the component (e.g. onBlur)
+		// Form Stat will sanitize/validate pre-submit always
+		if ( ! this._skipSanitizeAndValidateOnFieldChange ) {
+			this._debouncedSanitize();
+			this._debouncedValidate();
+		}
 	},
 
 	handleSubmit: function( onComplete ) {

--- a/client/my-sites/domains/components/form/input.jsx
+++ b/client/my-sites/domains/components/form/input.jsx
@@ -96,6 +96,7 @@ export default class extends React.Component {
 					autoComplete={ this.props.autoComplete }
 					disabled={ this.props.disabled }
 					maxLength={ this.props.maxLength }
+					onBlur={ this.props.onBlur }
 					onChange={ this.props.onChange }
 					onClick={ this.recordFieldClick }
 					isError={ this.props.isError }


### PR DESCRIPTION
We want to be able to skip validate/sanitize on field change,
and allow running these onBlur instead.

Added onBlur prop to the <Input /> component.

Add onBlur handler that just runs formController.sanitize/validate.

Test:
- Go to Domains
- Pick a domain registration
- Edit Contact Info
- Start typing a UK postal code
- Use spaces, make sure it doesn't run validate/sanitize before the user selects something else on the screen
- Make sure the onBlur works for all the other fields