### PR TITLE
Rewind: add option to flag that a migration was opt-in

### DIFF
--- a/client/my-sites/stats/activity-log/activity-log-rewind-toggle.jsx
+++ b/client/my-sites/stats/activity-log/activity-log-rewind-toggle.jsx
@@ -14,13 +14,14 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
-import { activateRewind as activateRewindAction } from 'state/activity-log/actions';
+import { activateRewind } from 'state/activity-log/actions';
 import { isRewindActivating } from 'state/selectors';
 
 class ActivityLogRewindToggle extends Component {
 	static propTypes = {
 		siteId: PropTypes.number,
 		label: PropTypes.string,
+		isVpMigrate: PropTypes.bool,
 
 		// mappedSelectors
 		isActivating: PropTypes.bool.isRequired,
@@ -35,13 +36,10 @@ class ActivityLogRewindToggle extends Component {
 	static defaultProps = {
 		isActivating: false,
 		label: '',
+		isVpMigrate: false,
 	};
 
-	activateRewind = () => {
-		const { activateRewind, siteId } = this.props;
-
-		activateRewind( siteId );
-	};
+	activateRewind = () => this.props.activateRewind( this.props.siteId, this.props.isVpMigrate );
 
 	render() {
 		const { isActivating, siteId, translate, label } = this.props;
@@ -68,6 +66,6 @@ export default connect(
 		isActivating: isRewindActivating( state, siteId ),
 	} ),
 	{
-		activateRewind: activateRewindAction,
+		activateRewind,
 	}
 )( localize( ActivityLogRewindToggle ) );

--- a/client/signup/steps/rewind-migrate/index.jsx
+++ b/client/signup/steps/rewind-migrate/index.jsx
@@ -70,6 +70,7 @@ class RewindMigrate extends Component {
 					<ActivityLogRewindToggle
 						siteId={ siteId }
 						label={ translate( 'Migrate your credentials' ) }
+						isVpMigrate={ true }
 					/>
 				</Card>
 				<div className="rewind-migrate__warning">

--- a/client/state/activity-log/actions.js
+++ b/client/state/activity-log/actions.js
@@ -30,13 +30,15 @@ import {
 /**
  * Turn the 'rewind' feature on for a site.
  *
- * @param {String|number} siteId site ID
- * @return {Object} action object
+ * @param  {String|number} siteId      Site ID
+ * @param  {bool}          isVpMigrate Whether this is a VaultPress migration.
+ * @return {Object}        Action object
  */
-export function activateRewind( siteId ) {
+export function activateRewind( siteId, isVpMigrate ) {
 	return {
 		type: REWIND_ACTIVATE_REQUEST,
 		siteId,
+		isVpMigrate,
 	};
 }
 

--- a/client/state/data-layer/wpcom/activity-log/activate/index.js
+++ b/client/state/data-layer/wpcom/activity-log/activate/index.js
@@ -18,16 +18,15 @@ import { errorNotice } from 'state/notices/actions';
 import { transformApi } from 'state/data-layer/wpcom/sites/rewind/api-transformer';
 
 const activateRewind = ( { dispatch }, action ) => {
-	dispatch(
-		http(
-			{
-				method: 'POST',
-				path: `/activity-log/${ action.siteId }/rewind/activate`,
-				apiVersion: '1',
-			},
-			action
-		)
-	);
+	const params = {
+		method: 'POST',
+		path: `/activity-log/${ action.siteId }/rewind/activate`,
+		apiVersion: '1',
+	};
+	if ( action.isVpMigrate ) {
+		params.body = { rewindOptIn: true };
+	}
+	dispatch( http( params, action ) );
 };
 
 export const activateSucceeded = ( { dispatch }, action ) => {


### PR DESCRIPTION
This PR introduces a new parameter to send to the endpoint used to activate Rewind. In practice, this will only be done when the user is in the flow to migrate VaultPress and clicks the button to do so.