### PR TITLE
Rewind: track when user migrates VaultPress to Rewind

### DIFF
--- a/client/my-sites/stats/activity-log/activity-log-rewind-toggle.jsx
+++ b/client/my-sites/stats/activity-log/activity-log-rewind-toggle.jsx
@@ -16,6 +16,7 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import { activateRewind } from 'state/activity-log/actions';
 import { isRewindActivating } from 'state/selectors';
+import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 
 class ActivityLogRewindToggle extends Component {
 	static propTypes = {
@@ -66,6 +67,10 @@ export default connect(
 		isActivating: isRewindActivating( state, siteId ),
 	} ),
 	{
-		activateRewind,
+		activateRewind: ( siteId, isVpMigrate ) =>
+			withAnalytics(
+				recordTracksEvent( 'calypso_activitylog_vp_migrate_rewind', { rewindOptIn: isVpMigrate } ),
+				activateRewind( siteId, isVpMigrate )
+			),
 	}
 )( localize( ActivityLogRewindToggle ) );


### PR DESCRIPTION
This PR tracks a click in the button to migrate VP to R.

<img width="376" alt="captura de pantalla 2018-04-03 a la s 15 41 11" src="https://user-images.githubusercontent.com/1041600/38268837-6f395f2c-3755-11e8-9989-381f3a165ed3.png">

#### Testing

Verify that the http://pixel.wp.com/t.gif is requested with these options
```
rewindOptIn: true
_en: calypso_activitylog_vp_migrate_rewind
```