### PR TITLE
Checkout: Try to parse some known postal codes

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -33,7 +33,7 @@ import { countries } from 'components/phone-input/data';
 import { forDomainRegistrations as countriesList } from 'lib/countries-list';
 import formState from 'lib/form-state';
 import analytics from 'lib/analytics';
-import { tryToGuessPostalCodeFormat } from 'lib/domains/utils';
+import { tryToGuessPostalCodeFormat } from 'lib/postal-code';
 import { toIcannFormat } from 'components/phone-input/phone-number';
 import NoticeErrorMessage from 'my-sites/checkout/checkout/notice-error-message';
 import GAppsFieldset from 'components/domains/contact-details-form-fields/custom-form-fieldsets/g-apps-fieldset';

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -33,10 +33,11 @@ import { countries } from 'components/phone-input/data';
 import { forDomainRegistrations as countriesList } from 'lib/countries-list';
 import formState from 'lib/form-state';
 import analytics from 'lib/analytics';
+import { tryToGuessPostalCodeFormat } from 'lib/domains/utils';
 import { toIcannFormat } from 'components/phone-input/phone-number';
 import NoticeErrorMessage from 'my-sites/checkout/checkout/notice-error-message';
-import GAppsFieldset from './custom-form-fieldsets/g-apps-fieldset';
-import RegionAddressFieldsets from './custom-form-fieldsets/region-address-fieldsets';
+import GAppsFieldset from 'components/domains/contact-details-form-fields/custom-form-fieldsets/g-apps-fieldset';
+import RegionAddressFieldsets from 'components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets';
 import notices from 'notices';
 import { CALYPSO_CONTACT } from 'lib/url/support';
 
@@ -167,7 +168,10 @@ export class ContactDetailsFormFields extends Component {
 				sanitizedFieldValues[ fieldName ] = deburr( fieldValues[ fieldName ].trim() );
 				// TODO: Do this on submit. Is it too annoying?
 				if ( fieldName === 'postalCode' ) {
-					sanitizedFieldValues[ fieldName ] = sanitizedFieldValues[ fieldName ].toUpperCase();
+					sanitizedFieldValues[ fieldName ] = tryToGuessPostalCodeFormat(
+						sanitizedFieldValues[ fieldName ].toUpperCase(),
+						get( sanitizedFieldValues, 'countryCode', null )
+					);
 				}
 			}
 		} );
@@ -181,7 +185,7 @@ export class ContactDetailsFormFields extends Component {
 
 	handleBlur = () => {
 		this.formStateController.sanitize();
-		this.formStateController.validate();
+		this.formStateController._debouncedValidate();
 	};
 
 	validate = ( fieldValues, onComplete ) =>

--- a/client/lib/domains/utils.js
+++ b/client/lib/domains/utils.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { drop, get, includes, isEmpty, join, find, split, values } from 'lodash';
+import { drop, isEmpty, join, find, split, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -98,87 +98,9 @@ function parseDomainAgainstTldList( domainFragment, tldList ) {
 	return parseDomainAgainstTldList( suffix, tldList );
 }
 
-function tryToGuessPostalCodeFormat( postalCode, countryCode ) {
-	if ( ! countryCode ) {
-		return postalCode;
-	}
-
-	const twoPartPostalCodes = {
-		BR: {
-			length: [ 8 ],
-			delimeter: '-',
-			partLength: 5,
-		},
-		CA: {
-			length: [ 6 ],
-			delimeter: ' ',
-			partLength: 3,
-		},
-		GB: {
-			length: [ 5, 6, 7 ],
-			delimeter: ' ',
-			partLength: 4,
-		},
-		IE: {
-			length: [ 7 ],
-			delimeter: ' ',
-			partLength: 3,
-		},
-		JP: {
-			length: [ 7 ],
-			delimeter: '-',
-			partLength: 3,
-		},
-		KY: {
-			length: [ 7 ],
-			delimeter: '-',
-			partLength: 3,
-		},
-		NL: {
-			length: [ 6 ],
-			delimeter: ' ',
-			partLength: 4,
-		},
-		PL: {
-			length: [ 5 ],
-			delimeter: '-',
-			partLength: 2,
-		},
-		PT: {
-			length: [ 7 ],
-			delimeter: '-',
-			partLength: 4,
-		},
-		SE: {
-			length: [ 5 ],
-			delimeter: ' ',
-			partLength: 3,
-		},
-	};
-
-	const countryCodeData = get( twoPartPostalCodes, countryCode, false );
-	if ( ! countryCodeData ) {
-		return postalCode;
-	}
-
-	if (
-		includes( countryCodeData.length, postalCode.length ) &&
-		postalCode.indexOf( countryCodeData.delimeter ) === -1
-	) {
-		return (
-			postalCode.substring( 0, countryCodeData.partLength ) +
-			countryCodeData.delimeter +
-			postalCode.substring( countryCodeData.partLength )
-		);
-	}
-
-	return postalCode;
-}
-
 export {
 	getDomainNameFromReceiptOrCart,
 	getDomainType,
 	getTransferStatus,
 	parseDomainAgainstTldList,
-	tryToGuessPostalCodeFormat,
 };

--- a/client/lib/domains/utils.js
+++ b/client/lib/domains/utils.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { drop, get, isEmpty, join, find, split, values } from 'lodash';
+import { drop, get, includes, isEmpty, join, find, split, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -105,52 +105,52 @@ function tryToGuessPostalCodeFormat( postalCode, countryCode ) {
 
 	const twoPartPostalCodes = {
 		BR: {
-			length: 8,
+			length: [ 8 ],
 			delimeter: '-',
 			partLength: 5,
 		},
 		CA: {
-			length: 6,
+			length: [ 6 ],
 			delimeter: ' ',
 			partLength: 3,
 		},
 		GB: {
-			length: 7,
+			length: [ 5, 6, 7 ],
 			delimeter: ' ',
 			partLength: 4,
 		},
 		IE: {
-			length: 7,
+			length: [ 7 ],
 			delimeter: ' ',
 			partLength: 3,
 		},
 		JP: {
-			length: 7,
+			length: [ 7 ],
 			delimeter: '-',
 			partLength: 3,
 		},
 		KY: {
-			length: 7,
+			length: [ 7 ],
 			delimeter: '-',
 			partLength: 3,
 		},
 		NL: {
-			length: 6,
+			length: [ 6 ],
 			delimeter: ' ',
 			partLength: 4,
 		},
 		PL: {
-			length: 5,
+			length: [ 5 ],
 			delimeter: '-',
 			partLength: 2,
 		},
 		PT: {
-			length: 7,
+			length: [ 7 ],
 			delimeter: '-',
 			partLength: 4,
 		},
 		SE: {
-			length: 5,
+			length: [ 5 ],
 			delimeter: ' ',
 			partLength: 3,
 		},
@@ -162,7 +162,7 @@ function tryToGuessPostalCodeFormat( postalCode, countryCode ) {
 	}
 
 	if (
-		postalCode.length === countryCodeData.length &&
+		includes( countryCodeData.length, postalCode.length ) &&
 		postalCode.indexOf( countryCodeData.delimeter ) === -1
 	) {
 		return (

--- a/client/lib/domains/utils.js
+++ b/client/lib/domains/utils.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { drop, isEmpty, join, find, split, values } from 'lodash';
+import { drop, get, isEmpty, join, find, split, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -98,9 +98,87 @@ function parseDomainAgainstTldList( domainFragment, tldList ) {
 	return parseDomainAgainstTldList( suffix, tldList );
 }
 
+function tryToGuessPostalCodeFormat( postalCode, countryCode ) {
+	if ( ! countryCode ) {
+		return postalCode;
+	}
+
+	const twoPartPostalCodes = {
+		BR: {
+			length: 8,
+			delimeter: '-',
+			partLength: 5,
+		},
+		CA: {
+			length: 6,
+			delimeter: ' ',
+			partLength: 3,
+		},
+		GB: {
+			length: 7,
+			delimeter: ' ',
+			partLength: 4,
+		},
+		IE: {
+			length: 7,
+			delimeter: ' ',
+			partLength: 3,
+		},
+		JP: {
+			length: 7,
+			delimeter: '-',
+			partLength: 3,
+		},
+		KY: {
+			length: 7,
+			delimeter: '-',
+			partLength: 3,
+		},
+		NL: {
+			length: 6,
+			delimeter: ' ',
+			partLength: 4,
+		},
+		PL: {
+			length: 5,
+			delimeter: '-',
+			partLength: 2,
+		},
+		PT: {
+			length: 7,
+			delimeter: '-',
+			partLength: 4,
+		},
+		SE: {
+			length: 5,
+			delimeter: ' ',
+			partLength: 3,
+		},
+	};
+
+	const countryCodeData = get( twoPartPostalCodes, countryCode, false );
+	if ( ! countryCodeData ) {
+		return postalCode;
+	}
+
+	if (
+		postalCode.length === countryCodeData.length &&
+		postalCode.indexOf( countryCodeData.delimeter ) === -1
+	) {
+		return (
+			postalCode.substring( 0, countryCodeData.partLength ) +
+			countryCodeData.delimeter +
+			postalCode.substring( countryCodeData.partLength )
+		);
+	}
+
+	return postalCode;
+}
+
 export {
 	getDomainNameFromReceiptOrCart,
 	getDomainType,
 	getTransferStatus,
 	parseDomainAgainstTldList,
+	tryToGuessPostalCodeFormat,
 };

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import {
 	assign,
 	camelCase,
@@ -90,7 +89,7 @@ assign( Controller.prototype, {
 		this._setState( changeFieldValue( formState, name, value, hideError ) );
 
 		// If we want to handle sanitize/validate differently in the component (e.g. onBlur)
-		// Form Stat will sanitize/validate pre-submit always
+		// FormState handleSubmit() will sanitize/validate if not done yet
 		if ( ! this._skipSanitizeAndValidateOnFieldChange ) {
 			this._debouncedSanitize();
 			this._debouncedValidate();

--- a/client/lib/postal-code/README.md
+++ b/client/lib/postal-code/README.md
@@ -1,0 +1,4 @@
+Postal Code Utils
+======
+
+This module provides utils for handling postal codes.

--- a/client/lib/postal-code/index.jsx
+++ b/client/lib/postal-code/index.jsx
@@ -5,8 +5,8 @@
  */
 import { get, includes } from 'lodash';
 
-function defaultFormatter( postalCode, delimeter, partLength ) {
-	return postalCode.substring( 0, partLength ) + delimeter + postalCode.substring( partLength );
+function defaultFormatter( postalCode, delimiter, partLength ) {
+	return postalCode.substring( 0, partLength ) + delimiter + postalCode.substring( partLength );
 }
 
 /**
@@ -24,58 +24,58 @@ export function tryToGuessPostalCodeFormat( postalCode, countryCode ) {
 	const twoPartPostalCodes = {
 		BR: {
 			length: [ 8 ],
-			delimeter: '-',
+			delimiter: '-',
 			partLength: 5,
 		},
 		CA: {
 			length: [ 6 ],
-			delimeter: ' ',
+			delimiter: ' ',
 			partLength: 3,
 		},
 		GB: {
 			length: [ 5, 6, 7 ],
-			delimeter: ' ',
-			formatter: ( postalCodeInput, delimeter ) => {
+			delimiter: ' ',
+			formatter: ( postalCodeInput, delimiter ) => {
 				return (
 					postalCodeInput.substring( 0, postalCodeInput.length - 3 ) +
-					delimeter +
+					delimiter +
 					postalCodeInput.substring( postalCodeInput.length - 3 )
 				);
 			},
 		},
 		IE: {
 			length: [ 7 ],
-			delimeter: ' ',
+			delimiter: ' ',
 			partLength: 3,
 		},
 		JP: {
 			length: [ 7 ],
-			delimeter: '-',
+			delimiter: '-',
 			partLength: 3,
 		},
 		KY: {
 			length: [ 7 ],
-			delimeter: '-',
+			delimiter: '-',
 			partLength: 3,
 		},
 		NL: {
 			length: [ 6 ],
-			delimeter: ' ',
+			delimiter: ' ',
 			partLength: 4,
 		},
 		PL: {
 			length: [ 5 ],
-			delimeter: '-',
+			delimiter: '-',
 			partLength: 2,
 		},
 		PT: {
 			length: [ 7 ],
-			delimeter: '-',
+			delimiter: '-',
 			partLength: 4,
 		},
 		SE: {
 			length: [ 5 ],
-			delimeter: ' ',
+			delimiter: ' ',
 			partLength: 3,
 		},
 	};
@@ -87,14 +87,13 @@ export function tryToGuessPostalCodeFormat( postalCode, countryCode ) {
 
 	if (
 		includes( countryCodeData.length, postalCode.length ) &&
-		postalCode.indexOf( countryCodeData.delimeter ) === -1
+		postalCode.indexOf( countryCodeData.delimiter ) === -1
 	) {
-		let formatter = defaultFormatter;
 		if ( countryCodeData.formatter ) {
-			formatter = countryCodeData.formatter;
+			return countryCodeData.formatter( postalCode, countryCodeData.delimiter );
 		}
 
-		return formatter( postalCode, countryCodeData.delimeter, countryCodeData.partLength );
+		return defaultFormatter( postalCode, countryCodeData.delimiter, countryCodeData.partLength );
 	}
 
 	return postalCode;

--- a/client/lib/postal-code/index.jsx
+++ b/client/lib/postal-code/index.jsx
@@ -1,0 +1,101 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get, includes } from 'lodash';
+
+function defaultFormatter( postalCode, delimeter, partLength ) {
+	return postalCode.substring( 0, partLength ) + delimeter + postalCode.substring( partLength );
+}
+
+/**
+ * Tries to convert given postal code based on the country code into a standardised format
+ *
+ * @param {string} postalCode user inputted postal code
+ * @param {string} countryCode user selected country
+ * @returns {string} formatted postal code
+ */
+export function tryToGuessPostalCodeFormat( postalCode, countryCode ) {
+	if ( ! countryCode ) {
+		return postalCode;
+	}
+
+	const twoPartPostalCodes = {
+		BR: {
+			length: [ 8 ],
+			delimeter: '-',
+			partLength: 5,
+		},
+		CA: {
+			length: [ 6 ],
+			delimeter: ' ',
+			partLength: 3,
+		},
+		GB: {
+			length: [ 5, 6, 7 ],
+			delimeter: ' ',
+			formatter: ( postalCodeInput, delimeter ) => {
+				return (
+					postalCodeInput.substring( 0, postalCodeInput.length - 3 ) +
+					delimeter +
+					postalCodeInput.substring( postalCodeInput.length - 3 )
+				);
+			},
+		},
+		IE: {
+			length: [ 7 ],
+			delimeter: ' ',
+			partLength: 3,
+		},
+		JP: {
+			length: [ 7 ],
+			delimeter: '-',
+			partLength: 3,
+		},
+		KY: {
+			length: [ 7 ],
+			delimeter: '-',
+			partLength: 3,
+		},
+		NL: {
+			length: [ 6 ],
+			delimeter: ' ',
+			partLength: 4,
+		},
+		PL: {
+			length: [ 5 ],
+			delimeter: '-',
+			partLength: 2,
+		},
+		PT: {
+			length: [ 7 ],
+			delimeter: '-',
+			partLength: 4,
+		},
+		SE: {
+			length: [ 5 ],
+			delimeter: ' ',
+			partLength: 3,
+		},
+	};
+
+	const countryCodeData = get( twoPartPostalCodes, countryCode, false );
+	if ( ! countryCodeData ) {
+		return postalCode;
+	}
+
+	if (
+		includes( countryCodeData.length, postalCode.length ) &&
+		postalCode.indexOf( countryCodeData.delimeter ) === -1
+	) {
+		let formatter = defaultFormatter;
+		if ( countryCodeData.formatter ) {
+			formatter = countryCodeData.formatter;
+		}
+
+		return formatter( postalCode, countryCodeData.delimeter, countryCodeData.partLength );
+	}
+
+	return postalCode;
+}

--- a/client/lib/postal-code/test/index.jsx
+++ b/client/lib/postal-code/test/index.jsx
@@ -1,0 +1,25 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { tryToGuessPostalCodeFormat } from 'lib/postal-code';
+
+describe( 'Postal Code Utils', () => {
+	test( 'should format valid GB code, length 7', () => {
+		assert.equal( tryToGuessPostalCodeFormat( 'WC1R4PF', 'GB' ), 'WC1R 4PF' );
+	} );
+
+	test( 'should format valid GB code, length 6', () => {
+		assert.equal( tryToGuessPostalCodeFormat( 'M11AA', 'GB' ), 'M1 1AA' );
+	} );
+
+	test( 'should format valid GB code, length 5', () => {
+		assert.equal( tryToGuessPostalCodeFormat( 'B338TH', 'GB' ), 'B33 8TH' );
+	} );
+} );


### PR DESCRIPTION
Users shouldn't know all of the postal code specifics. As long as
they enter the right length, we should be able to add the space/dash
or whatever else is required.

Test:
- Go to Domains
- Pick a domain registration
- Edit Contact Info
- Contry = United Kingdom
- Type a UK postal code `wc1r4pf`
- Make sure the onBlur fires after selecting another field
- Make sure the postal code is formatted properly