### PR TITLE
Implement "Load More" buttons for domain registration step

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -18,6 +18,9 @@
 	&.is-clickable {
 		cursor: pointer;
 
+		// NOTE: easeOutExpo easing function from http://easings.net/#easeOutExpo
+		transition: box-shadow 0.25s cubic-bezier(0.19, 1, 0.22, 1);
+
 		&:hover {
 			box-shadow: 0 0 0 1px $gray;
 			z-index: z-index('root', '.domain-suggestion.is-clickable:hover');
@@ -119,6 +122,12 @@
 		padding-left: 3em;
 		padding-right: 3em;
 		margin-left: 1em;
+		transition: all 0.1s linear;
+
+		&:hover {
+			background-color: lighten($blue-medium, 4%);
+			border-color: darken($blue-medium, 4%);
+		}
 	}
 
 	.is-placeholder & {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -311,10 +311,10 @@ class RegisterDomainStep extends React.Component {
 
 	render() {
 		const queryObject = getQueryObject( this.props );
-		const isKrackenUI = config.isEnabled( 'domains/kracken-ui' );
+		const isKrackenUi = config.isEnabled( 'domains/kracken-ui' );
 
 		return (
-			<div className={ `register-domain-step ${ isKrackenUI ? 'is-kracken-ui' : '' }` }>
+			<div className={ `register-domain-step ${ isKrackenUi ? 'is-kracken-ui' : '' }` }>
 				<div className="register-domain-step__search">
 					<SearchCard
 						ref={ this.bindSearchCardReference }
@@ -332,7 +332,7 @@ class RegisterDomainStep extends React.Component {
 						maxLength={ 60 }
 					/>
 				</div>
-				{ isKrackenUI && (
+				{ isKrackenUi && (
 					<div className="register-domain-step__filter">
 						<SearchFilters
 							filters={ this.state.filters }
@@ -358,8 +358,8 @@ class RegisterDomainStep extends React.Component {
 	}
 
 	renderPaginationControls() {
-		const isKrackenUI = config.isEnabled( 'domains/kracken-ui' );
-		if ( ! isKrackenUI || this.state.searchResults === null ) {
+		const isKrackenUi = config.isEnabled( 'domains/kracken-ui' );
+		if ( ! isKrackenUi || this.state.searchResults === null ) {
 			return null;
 		}
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -406,7 +406,7 @@ class RegisterDomainStep extends React.Component {
 		this.props.onSave( this.state );
 	};
 
-	repeatSearch = ( stateOverride = {} ) => {
+	repeatSearch = ( stateOverride = {}, { shouldQuerySubdomains = true } = {} ) => {
 		const nextState = {
 			exactMatchDomain: null,
 			lastDomainSearched: null,
@@ -417,7 +417,7 @@ class RegisterDomainStep extends React.Component {
 		};
 		debug( 'Repeating a search with the following input for setState', nextState );
 		this.setState( nextState, () => {
-			this.onSearch( this.state.lastQuery );
+			this.onSearch( this.state.lastQuery, { shouldQuerySubdomains } );
 		} );
 	};
 
@@ -703,7 +703,7 @@ class RegisterDomainStep extends React.Component {
 		} );
 	};
 
-	onSearch = searchQuery => {
+	onSearch = ( searchQuery, { shouldQuerySubdomains = true } = {} ) => {
 		debug( 'onSearch handler was triggered with query', searchQuery );
 		const domain = getFixedDomainSearch( searchQuery );
 
@@ -712,8 +712,7 @@ class RegisterDomainStep extends React.Component {
 			this.save
 		);
 
-		if ( ! domain || ( typeof domain === 'string' && domain.trim() === '' ) ) {
-			// the search was cleared or the domain contained only spaces
+		if ( domain === '' ) {
 			debug( 'onSearch handler was terminated by an empty domain input' );
 			return;
 		}
@@ -740,7 +739,10 @@ class RegisterDomainStep extends React.Component {
 			.catch( () => [] ) // handle the error and return an empty list
 			.then( this.handleDomainSuggestions( domain ) );
 
-		if ( this.props.includeWordPressDotCom || this.props.includeDotBlogSubdomain ) {
+		if (
+			shouldQuerySubdomains &&
+			( this.props.includeWordPressDotCom || this.props.includeDotBlogSubdomain )
+		) {
 			this.getSubdomainSuggestions( domain, timestamp );
 		}
 	};
@@ -748,12 +750,15 @@ class RegisterDomainStep extends React.Component {
 	showNextPage = () => {
 		debug( 'showNextPage was triggered' );
 
-		this.repeatSearch( {
-			loadingNextPageResults: true,
-			loadingResults: false,
-			loadingSubdomainResults: false,
-			pageNumber: this.state.pageNumber + 1,
-		} );
+		this.repeatSearch(
+			{
+				loadingNextPageResults: true,
+				loadingResults: false,
+				loadingSubdomainResults: false,
+				pageNumber: this.state.pageNumber + 1,
+			},
+			{ shouldQuerySubdomains: false }
+		);
 	};
 
 	initialSuggestions() {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -338,7 +338,7 @@ class RegisterDomainStep extends React.Component {
 							filters={ this.state.filters }
 							onChange={ this.onFiltersChange }
 							onFiltersReset={ this.onFiltersReset }
-							onFiltersSubmit={ this.repeatSearch }
+							onFiltersSubmit={ this.onFiltersSubmit }
 						/>
 					</div>
 				) }
@@ -444,6 +444,10 @@ class RegisterDomainStep extends React.Component {
 			},
 			this.repeatSearch
 		);
+	};
+
+	onFiltersSubmit = () => {
+		this.repeatSearch( { pageNumber: 1 } );
 	};
 
 	onSearchChange = ( searchQuery, callback = noop ) => {

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 .register-domain-step__search {
 	padding-bottom: 20px;
 
@@ -5,13 +7,12 @@
 		margin-bottom: 0;
 
 		&.is-refocused {
-			animation: shake .5s both;
-			box-shadow: 0 0 0 1px $gray,
-				0 2px 4px lighten( $gray, 20 );
+			animation: shake 0.5s both;
+			box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten($gray, 20);
 		}
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		padding-bottom: 30px;
 	}
 
@@ -36,15 +37,23 @@
 }
 
 @keyframes shake {
-	0%, 100% {
-	    transform: translate3d( 0, 0, 0 );
+	0%,
+	100% {
+		transform: translate3d(0, 0, 0);
 	}
 
-	10%, 60% {
-	    transform: translate3d( -5px, 0, 0 );
+	10%,
+	60% {
+		transform: translate3d(-5px, 0, 0);
 	}
 
 	30% {
-	    transform: translate3d( 5px, 0, 0 );
+		transform: translate3d(5px, 0, 0);
 	}
+}
+
+.register-domain-step__next-page {
+	color: $blue-medium;
+	font-weight: 500;
+	width: 100%;
 }

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -56,4 +56,58 @@
 	color: $blue-medium;
 	font-weight: 500;
 	width: 100%;
+	position: relative;
+
+	border: 0;
+	border-radius: 0;
+
+	// from components/card/style.scss
+	box-shadow: 0 0 0 1px transparentize($gray-lighten-20, 0.5), 0 1px 2px $gray-lighten-30;
+
+	&:hover {
+		color: $blue-medium;
+
+		// from components/domains/domain-suggestion/style
+		box-shadow: 0 0 0 1px $gray;
+	}
+
+	.spinner {
+		margin-left: 0.5em;
+
+		.spinner__outer {
+			border-width: 0.15em;
+			animation-duration: 2s;
+		}
+
+		.spinner__inner {
+			border-color: transparent;
+		}
+	}
+
+	.register-domain-step__next-page-loader,
+	.register-domain-step__next-page-content {
+		transition: 0.1s linear opacity;
+
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.register-domain-step__next-page-loader {
+		position: absolute;
+		left: 50%;
+		top: 50%;
+		transform: translate(-50%, -50%);
+		opacity: 0;
+	}
+
+	&.register-domain-step__next-page--is-loading {
+		.register-domain-step__next-page-loader {
+			opacity: 1;
+		}
+
+		.register-domain-step__next-page-content {
+			opacity: 0.3;
+		}
+	}
 }

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -64,6 +64,10 @@
 	// from components/card/style.scss
 	box-shadow: 0 0 0 1px transparentize($gray-lighten-20, 0.5), 0 1px 2px $gray-lighten-30;
 
+	// from components/domains/domain-suggestion/style
+	// NOTE: easeOutExpo easing function from http://easings.net/#easeOutExpo
+	transition: box-shadow 0.25s cubic-bezier(0.19, 1, 0.22, 1);
+
 	&:hover {
 		color: $blue-medium;
 


### PR DESCRIPTION
This adds a link button labeled `Show more results` at the bottom of the suggestions list, like so: 

<img width="986" alt="Show more results" src="https://user-images.githubusercontent.com/4044428/38272249-f1957916-3745-11e8-88de-b107f6275da7.png">

Clicking this will append more results below the existing results (once this feature is supported in the API). Currently, no new suggestions are added.

This feature is implemented like so:

- When the user initially loads suggestions, we assume that page to be `page 1`.
- When the user clicks `Show more results`, we make a request for more suggestions with the `page_number` parameter set to `2`.
- Upon receiving the domain suggestion response, we append it to the existing list of search results and show it to the user.


# Testing Instructions
1. Spin up your environment locally, which has `domains/kracken-ui` feature flag enabled.
2. Navigate to [`/start/domains`](calypso.localhost:3000/start/domains).
3. Set your localStorage debug like so: `localStorage.debug = 'calypso:domains:register-domain-step'`.
4. Enter a query and ensure that you see a corresponding debug line in the console. (You can also double check with your network panel.)
5. Click `Show more results` and ensure that you see a corresponding debug line containing `page_number: 2` in the request parameter. (Likewise, this will also show up in the network panel.)