### PR TITLE
Analytics: normalize Themes paths

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -25,12 +25,12 @@ import { getThemeFilters } from 'state/selectors';
 const debug = debugFactory( 'calypso:themes' );
 
 function getProps( context ) {
-	const { tier, filter, vertical, site_id: siteId } = context.params;
+	const { tier, filter, vertical } = context.params;
 
-	const { basePath, analyticsPageTitle } = getAnalyticsData( context.path, tier, siteId );
+	const { analyticsPath, analyticsPageTitle } = getAnalyticsData( context.path, context.params );
 
 	const boundTrackScrollPage = function() {
-		trackScrollPage( basePath, analyticsPageTitle, 'Themes' );
+		trackScrollPage( analyticsPath, analyticsPageTitle, 'Themes' );
 	};
 
 	return {
@@ -38,7 +38,7 @@ function getProps( context ) {
 		filter,
 		vertical,
 		analyticsPageTitle,
-		analyticsPath: basePath,
+		analyticsPath,
 		search: context.query.s,
 		pathName: context.pathname,
 		trackScrollPage: boundTrackScrollPage,

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -43,7 +43,7 @@ export function getAnalyticsData( path, { filter, vertical, tier, site_id } ) {
 	}
 
 	if ( site_id ) {
-		analyticsPath += '/:site_id';
+		analyticsPath += '/:site';
 		analyticsPageTitle += ' > Single Site';
 	}
 

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -6,11 +6,6 @@ import analytics from 'lib/analytics';
 import titlecase from 'to-title-case';
 import { mapValues } from 'lodash';
 
-/**
- * Internal dependencies
- */
-import { sectionify } from 'lib/route';
-
 export function trackClick( componentName, eventName, verb = 'click' ) {
 	const stat = `${ componentName } ${ eventName } ${ verb }`;
 	analytics.ga.recordEvent( 'Themes', titlecase( stat ) );
@@ -31,16 +26,24 @@ function appendActionTracking( option, name ) {
 	} );
 }
 
-export function getAnalyticsData( path, tier, site_id ) {
-	let basePath = sectionify( path );
+export function getAnalyticsData( path, { filter, vertical, tier, site_id } ) {
+	let analyticsPath = '/themes';
 	let analyticsPageTitle = 'Themes';
 
+	if ( vertical ) {
+		analyticsPath += '/:vertical';
+	}
+
 	if ( tier ) {
-		basePath += '/type/:tier';
+		analyticsPath += '/:tier';
+	}
+
+	if ( filter ) {
+		analyticsPath += '/filters/:filters';
 	}
 
 	if ( site_id ) {
-		basePath += '/:site_id';
+		analyticsPath += '/:site_id';
 		analyticsPageTitle += ' > Single Site';
 	}
 
@@ -48,5 +51,5 @@ export function getAnalyticsData( path, tier, site_id ) {
 		analyticsPageTitle += ` > Type > ${ titlecase( tier ) }`;
 	}
 
-	return { basePath, analyticsPageTitle };
+	return { analyticsPath, analyticsPageTitle };
 }

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -35,7 +35,7 @@ export function getAnalyticsData( path, { filter, vertical, tier, site_id } ) {
 	}
 
 	if ( tier ) {
-		analyticsPath += '/:tier';
+		analyticsPath += `/${ tier }`;
 	}
 
 	if ( filter ) {

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -31,7 +31,7 @@ export function getAnalyticsData( path, { filter, vertical, tier, site_id } ) {
 	let analyticsPageTitle = 'Themes';
 
 	if ( vertical ) {
-		analyticsPath += '/:vertical';
+		analyticsPath += `/${ vertical }`;
 	}
 
 	if ( tier ) {
@@ -39,7 +39,7 @@ export function getAnalyticsData( path, { filter, vertical, tier, site_id } ) {
 	}
 
 	if ( filter ) {
-		analyticsPath += '/filter/:filter';
+		analyticsPath += `/filter/${ filter }`;
 	}
 
 	if ( site_id ) {

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -39,7 +39,7 @@ export function getAnalyticsData( path, { filter, vertical, tier, site_id } ) {
 	}
 
 	if ( filter ) {
-		analyticsPath += '/filters/:filters';
+		analyticsPath += '/filter/:filter';
 	}
 
 	if ( site_id ) {


### PR DESCRIPTION
Fix #23524 

This PR normalizes the Themes paths for both authenticated and unauthenticated users. The themes section is already using `PageViewTracker`, so this PR only normalizes the parameters, but do not fix the already missing `props` on the page view call.

To test, enable debug log by running `localStorage.setItem('debug', 'calypso:analytics:tracks');` and verify that the following paths are passed as `props` on the `calypso_page_view` call.


| URL | Before | After |
| - | - | - |
| `/themes` | `/themes` | `/themes` |
| `/themes/(portfolio\|magazine\|...\|music)` | `/themes/{tier}` | `/themes/:tier` |
| `/themes/(free\|premium)` | `/themes/{tier}/type/:tier` | `/themes/:tier` |
| `/themes/filter/(feature\|layout\|...\|style)` | `/themes/filter/{filter}` | `/themes/filter/:filter` |
| `/themes/(free\|premium)/filter/(feature\|layout\|...\|style)` | `/themes/{tier}/filter/{filter}/type/:tier` | `/themes/(free\|premium)/filter/:filter` |
| `/themes/{site_id}` | `/themes/:site_id` | `/themes/:site` |
| `/themes/(free\|premium)/{site_id}` | `/themes/(free\|premium)/type/:tier/:site_id` | `/themes/(free\|premium)/:site` |
| `/themes/(free\|premium)/filter/(feature\|layout\|...\|style)/{site_id}` | `/themes/{tier}/filter/{filter}/type/:tier/:site_id` | `/themes/(free\|premium)/filter/:filter/:site` |

The non site-specific paths have to be tested on an unauthenticated session. And also on Jetpack sites.