### PR TITLE
Share: do not query for posts

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -16,7 +16,6 @@ import { current as currentPage } from 'page';
  * Internal dependencies
  */
 import QueryPostTypes from 'components/data/query-post-types';
-import QueryPosts from 'components/data/query-posts';
 import QueryPublicizeConnections from 'components/data/query-publicize-connections';
 import QuerySitePlans from 'components/data/query-site-plans';
 import Button from 'components/button';
@@ -567,7 +566,6 @@ class PostShare extends Component {
 					{ this.renderConnectionsWarning() }
 					{ this.renderPrimarySection() }
 				</div>
-				<QueryPosts { ...{ siteId, postId } } />
 				<SharingPreviewModal
 					siteId={ siteId }
 					postId={ postId }


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/14300 we added a query component to fetch the post in the share block. This is no longer needed since the post list appears to use redux state. The way we were querying in the share block also causes a subtle bug for certain cases. If we happen to search in the post list, then click on "share", the block doesn't take into account the search query, and may wipe out local state causing the post to "disappear" from the list.

See 1563-jpop-issues for an exact example.

### Testing Instructions
- navigate to /posts
- select a site
- search for a post
- click on the three dots next to a post and click on "Share"
- No regressions from sharing immediately or scheduling
- navigate to /posts
- select a site
- click on the three dots next to a post and click on "Share"
- No regressions from sharing immediately or scheduling