### PR TITLE
Store: Fix plugin fetch loop.

### DIFF
--- a/client/extensions/woocommerce/app/settings/taxes/index.js
+++ b/client/extensions/woocommerce/app/settings/taxes/index.js
@@ -15,7 +15,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { fetchPlugins } from 'state/plugins/installed/actions';
 import { getPlugins, isRequesting } from 'state/plugins/installed/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Main from 'components/main';
@@ -41,26 +40,10 @@ class SettingsTaxes extends Component {
 		setCheckedTaxSetup: PropTypes.func,
 	};
 
-	maybeFetchPlugins = ( props, force = false ) => {
-		const { isRequestingSitePlugins, siteId, sitePluginsLoaded } = props;
-
-		if ( siteId && ! isRequestingSitePlugins ) {
-			if ( force || ! sitePluginsLoaded ) {
-				this.props.fetchPlugins( [ siteId ] );
-			}
-		}
-	};
-
 	componentDidMount = () => {
-		this.maybeFetchPlugins( this.props, true );
-
 		if ( this.props.setupChoicesLoaded ) {
 			this.maybeSetCheckedTaxSetup();
 		}
-	};
-
-	componentWillReceiveProps = newProps => {
-		this.maybeFetchPlugins( newProps );
 	};
 
 	componentDidUpdate = prevProps => {
@@ -127,7 +110,6 @@ function mapStateToProps( state ) {
 function mapDispatchToProps( dispatch ) {
 	return bindActionCreators(
 		{
-			fetchPlugins,
 			setCheckedTaxSetup,
 		},
 		dispatch


### PR DESCRIPTION
This branch seeks to fix a regression that appears to have been introduced in #23809. @justinshreve pointed out that the e2e tests around the Settings > Taxes page in Store were failing. Attempting to load the taxes page myself displayed what appeared to be an endless loop of requests to fetch the plugins for the site... an endless plugin loop!

The taxes page had been calling `fetchPlugins` in lifecycle methods which likely led to this endless loop, but since #23809 fetches plugins at the top level of store, I opted to just remove the calls to `fetchPlugins` from the taxes component and all is functioning well now.

__To Test__
- Open Store for a site
- Click 'Settings' in the sidebar, then click 'Taxes' in the top nav
- Verify the taxes page loads as expected, and can be interacted with / saves data