### PR TITLE
Remove direct usage of PLAN_ constants from cart-values

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -50,19 +50,9 @@ import {
 	isVideoPress,
 } from 'lib/products-values';
 import sortProducts from 'lib/products-values/sort';
-import { PLAN_PERSONAL } from 'lib/plans/constants';
 import { getTld } from 'lib/domains';
 import { domainProductSlugs } from 'lib/domains/constants';
-
-import {
-	PLAN_FREE,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
-	PLAN_JETPACK_PERSONAL_MONTHLY,
-} from 'lib/plans/constants';
+import { isPersonalPlan, isPremiumPlan, isBusinessPlan, isWpComFreePlan } from 'lib/plans';
 
 /**
  * Adds the specified item to a shopping cart.
@@ -395,7 +385,7 @@ export function hasRenewableSubscription( cart ) {
  */
 export function planItem( productSlug, isFreeTrialItem = false ) {
 	// Free plan doesn't have shopping cart.
-	if ( productSlug === PLAN_FREE ) {
+	if ( isWpComFreePlan( productSlug ) ) {
 		return null;
 	}
 
@@ -638,26 +628,19 @@ export function spaceUpgradeItem( slug ) {
 export function getItemForPlan( plan, properties ) {
 	properties = properties || {};
 
-	switch ( plan.product_slug ) {
-		case PLAN_PERSONAL:
-			return personalPlan( plan.product_slug, properties );
-		case 'value_bundle':
-		case PLAN_JETPACK_PREMIUM:
-		case PLAN_JETPACK_PREMIUM_MONTHLY:
-			return premiumPlan( plan.product_slug, properties );
-
-		case PLAN_JETPACK_PERSONAL:
-		case PLAN_JETPACK_PERSONAL_MONTHLY:
-			return premiumPlan( plan.product_slug, properties );
-
-		case 'business-bundle':
-		case PLAN_JETPACK_BUSINESS:
-		case PLAN_JETPACK_BUSINESS_MONTHLY:
-			return businessPlan( plan.product_slug, properties );
-
-		default:
-			throw new Error( 'Invalid plan product slug: ' + plan.product_slug );
+	if ( isPersonalPlan( plan.product_slug ) ) {
+		return personalPlan( plan.product_slug, properties );
 	}
+
+	if ( isPremiumPlan( plan.product_slug ) ) {
+		return premiumPlan( plan.product_slug, properties );
+	}
+
+	if ( isBusinessPlan( plan.product_slug ) ) {
+		return businessPlan( plan.product_slug, properties );
+	}
+
+	throw new Error( 'Invalid plan product slug: ' + plan.product_slug );
 }
 
 /**

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -1,0 +1,84 @@
+/** @format */
+
+import {
+	PLAN_FREE,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+} from 'lib/plans/constants';
+
+const cartItems = require( '../cart-items' );
+const { planItem, getItemForPlan } = cartItems;
+
+/**
+ * External dependencies
+ */
+
+describe( 'planItem()', () => {
+	test( 'should return null for free plan', () => {
+		expect( planItem( PLAN_FREE ) ).toBe( null );
+	} );
+
+	[
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_BUSINESS,
+		PLAN_BUSINESS_2_YEARS,
+	].forEach( product_slug => {
+		test( `should return an object for non-free plan (${ product_slug })`, () => {
+			expect( planItem( product_slug ).product_slug ).toBe( product_slug );
+		} );
+	} );
+} );
+
+describe( 'getItemForPlan()', () => {
+	[
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_PERSONAL_MONTHLY,
+	].forEach( product_slug => {
+		test( `should return personal plan item for personal plan ${ product_slug }`, () => {
+			expect( getItemForPlan( { product_slug } ).product_slug ).toBe( product_slug );
+		} );
+	} );
+	[
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PREMIUM_MONTHLY,
+	].forEach( product_slug => {
+		test( `should return personal plan item for a premium plan ${ product_slug }`, () => {
+			expect( getItemForPlan( { product_slug } ).product_slug ).toBe( product_slug );
+		} );
+	} );
+
+	[
+		PLAN_BUSINESS,
+		PLAN_BUSINESS_2_YEARS,
+		PLAN_JETPACK_BUSINESS,
+		PLAN_JETPACK_BUSINESS_MONTHLY,
+	].forEach( product_slug => {
+		test( `should return personal plan item for a business plan ${ product_slug }`, () => {
+			expect( getItemForPlan( { product_slug } ).product_slug ).toBe( product_slug );
+		} );
+	} );
+
+	[ PLAN_FREE, PLAN_JETPACK_FREE ].forEach( product_slug => {
+		test( `should throw an error for plan ${ product_slug }`, () => {
+			expect( () => getItemForPlan( { product_slug } ).product_slug ).toThrow();
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `cart-values`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* That's it - this is pretty much a dead code ATM, it seems like it was used in some a/b tests. I'm a bit afraid to remove it at the moment but we may get there in another PR