### PR TITLE
Remove PLAN_* constants from jetpack-thank-you-card

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -64,15 +64,11 @@ import {
 	FEATURE_ONE_CLICK_THREAT_RESOLUTION,
 	FEATURE_SPAM_AKISMET_PLUS,
 	FEATURES_LIST,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PERSONAL_MONTHLY,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
+	GROUP_JETPACK,
+	TYPE_FREE,
 	getPlanClass,
 } from 'lib/plans/constants';
-import { getPlan } from 'lib/plans';
+import { getPlan, planMatches } from 'lib/plans';
 
 const vpFeatures = {
 	[ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY ]: true,
@@ -89,7 +85,7 @@ const akismetFeatures = {
 	[ FEATURE_SPAM_AKISMET_PLUS ]: true,
 };
 
-class JetpackThankYouCard extends Component {
+export class JetpackThankYouCard extends Component {
 	state = {
 		completedJetpackFeatures: {},
 		installInitiatedPlugins: new Set(),
@@ -325,12 +321,8 @@ class JetpackThankYouCard extends Component {
 	isEligibleForLiveChat() {
 		const { planSlug } = this.props;
 		return (
-			planSlug === PLAN_JETPACK_BUSINESS ||
-			planSlug === PLAN_JETPACK_BUSINESS_MONTHLY ||
-			planSlug === PLAN_JETPACK_PERSONAL ||
-			planSlug === PLAN_JETPACK_PERSONAL_MONTHLY ||
-			planSlug === PLAN_JETPACK_PREMIUM ||
-			planSlug === PLAN_JETPACK_PREMIUM_MONTHLY
+			planMatches( planSlug, { group: GROUP_JETPACK } ) &&
+			! planMatches( planSlug, { type: TYPE_FREE } )
 		);
 	}
 

--- a/client/my-sites/checkout/checkout-thank-you/test/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/test/jetpack-thank-you-card.jsx
@@ -1,0 +1,85 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.mock( 'lib/analytics/index', () => ( {} ) );
+jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'lib/user', () => ( {} ) );
+jest.mock( 'components/main', () => 'MainComponent' );
+jest.mock( 'components/popover', () => 'Popover' );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Comp => props => (
+		<Comp
+			{ ...props }
+			translate={ function( x ) {
+				return x;
+			} }
+		/>
+	),
+	numberFormat: x => x,
+} ) );
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import {
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { JetpackThankYouCard } from '../jetpack-thank-you-card';
+
+describe( 'JetpackThankYouCard.isEligibleForLiveChat()', () => {
+	[
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_PERSONAL_MONTHLY,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PREMIUM_MONTHLY,
+		PLAN_JETPACK_BUSINESS,
+		PLAN_JETPACK_BUSINESS_MONTHLY,
+	].forEach( plan => {
+		test( 'Should return true for all jetpack paid plans', () => {
+			const instance = new JetpackThankYouCard( {
+				planSlug: plan,
+			} );
+			expect( instance.isEligibleForLiveChat() ).toBe( true );
+		} );
+	} );
+
+	[
+		PLAN_FREE,
+		PLAN_JETPACK_FREE,
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_BUSINESS,
+		PLAN_BUSINESS_2_YEARS,
+	].forEach( plan => {
+		test( 'Should return false for all non-jetpack or non-paid plans', () => {
+			const instance = new JetpackThankYouCard( {
+				planSlug: plan,
+			} );
+			expect( instance.isEligibleForLiveChat() ).toBe( false );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `jetpack-thank-you-card`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* Make sure there are enough unit tests and that they make sense