### PR TITLE
Remove PLAN_ constants from site-picker-submit

### DIFF
--- a/client/signup/steps/site-picker/site-picker-submit.jsx
+++ b/client/signup/steps/site-picker/site-picker-submit.jsx
@@ -10,15 +10,17 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { PLAN_FREE } from 'lib/plans/constants';
+import { isFreePlan } from 'lib/plans';
 import { getSite } from 'state/sites/selectors';
 import SignupActions from 'lib/signup/actions';
 
-class SitePickerSubmit extends React.Component {
+export const siteHasPaidPlan = selectedSite =>
+	selectedSite && selectedSite.plan && ! isFreePlan( selectedSite.plan.product_slug );
+
+export class SitePickerSubmit extends React.Component {
 	componentWillMount() {
 		const { stepSectionName, stepName, goToStep, selectedSite } = this.props,
-			hasPaidPlan =
-				selectedSite && selectedSite.plan && selectedSite.plan.product_slug !== PLAN_FREE,
+			hasPaidPlan = siteHasPaidPlan( selectedSite ),
 			{ ID: siteId, slug: siteSlug } = selectedSite;
 
 		SignupActions.submitSignupStep(

--- a/client/signup/steps/site-picker/test/site-picker-submit.jsx
+++ b/client/signup/steps/site-picker/test/site-picker-submit.jsx
@@ -1,0 +1,133 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.mock( 'lib/analytics/index', () => ( {} ) );
+jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'lib/user', () => ( {} ) );
+jest.mock( 'lib/signup/actions', () => ( {
+	submitSignupStep: () => {},
+} ) );
+jest.mock( 'components/main', () => 'MainComponent' );
+jest.mock( 'components/popover', () => 'Popover' );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Comp => props => (
+		<Comp
+			{ ...props }
+			translate={ function( x ) {
+				return x;
+			} }
+		/>
+	),
+	numberFormat: x => x,
+} ) );
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import {
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { siteHasPaidPlan, SitePickerSubmit } from '../site-picker-submit';
+
+const props = {
+	goToStep: jest.fn(),
+	selectedSite: {
+		ID: 1,
+	},
+};
+
+describe( 'siteHasPaidPlan', () => {
+	[
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_PERSONAL_MONTHLY,
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_BUSINESS,
+		PLAN_BUSINESS_2_YEARS,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PREMIUM_MONTHLY,
+		PLAN_JETPACK_BUSINESS,
+		PLAN_JETPACK_BUSINESS_MONTHLY,
+	].forEach( product_slug => {
+		test( `Should return true for plan ${ product_slug }`, () => {
+			expect( siteHasPaidPlan( { plan: { product_slug } } ) ).toBe( true );
+		} );
+	} );
+
+	[ PLAN_FREE, PLAN_JETPACK_FREE ].forEach( product_slug => {
+		test( `Should return false for plan ${ product_slug }`, () => {
+			expect( siteHasPaidPlan( { plan: { product_slug } } ) ).toBe( false );
+		} );
+	} );
+} );
+
+describe( 'SitePickerSubmit', () => {
+	beforeEach( () => {
+		props.goToStep.mockReset();
+	} );
+
+	test( 'Does not blow up', () => {
+		expect( props.goToStep ).toHaveBeenCalledTimes( 0 );
+		const comp = shallow( <SitePickerSubmit { ...props } /> );
+		expect( comp.find( '*' ).length ).toBe( 0 );
+		expect( props.goToStep ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	[
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_PERSONAL_MONTHLY,
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_BUSINESS,
+		PLAN_BUSINESS_2_YEARS,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PREMIUM_MONTHLY,
+		PLAN_JETPACK_BUSINESS,
+		PLAN_JETPACK_BUSINESS_MONTHLY,
+	].forEach( plan => {
+		test( `Goes to step "user" when paid plan is passed (${ plan })`, () => {
+			expect( props.goToStep ).toHaveBeenCalledTimes( 0 );
+			shallow(
+				<SitePickerSubmit { ...props } selectedSite={ { plan: { product_slug: plan } } } />
+			);
+			expect( props.goToStep ).toHaveBeenCalledWith( 'user' );
+		} );
+	} );
+
+	[ PLAN_FREE, PLAN_JETPACK_FREE ].forEach( plan => {
+		test( `Goes to step "plans-site-selected" when a free plan is passed (${ plan })`, () => {
+			expect( props.goToStep ).toHaveBeenCalledTimes( 0 );
+			shallow(
+				<SitePickerSubmit { ...props } selectedSite={ { plan: { product_slug: plan } } } />
+			);
+			expect( props.goToStep ).toHaveBeenCalledWith( 'plans-site-selected' );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `site-picker-submit`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* Make sure the coverage is enough
* This component is a part of a domain-first signup flow, to test if updated site picker works you have to go to `/start/domain-first/site-or-domain?new=some-domain-i-want-to-buy-12325.net`, choose "existing site", and then pick both free and paid site from site picker. Choosing a free site should redirect to plan picker while choosing paid site should redirect to checkout.