### PR TITLE
Remove PLAN_* constants from transfer-to-other-site

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -27,12 +27,12 @@ import SectionHeader from 'components/section-header';
 import TransferConfirmationDialog from './confirmation-dialog';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import wp from 'lib/wp';
-import { PLAN_FREE } from 'lib/plans/constants';
+import { isWpComFreePlan } from 'lib/plans';
 import { requestSites } from 'state/sites/actions';
 
 const wpcom = wp.undocumented();
 
-class TransferToOtherSite extends React.Component {
+export class TransferToOtherSite extends React.Component {
 	static propTypes = {
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSite: PropTypes.object.isRequired,
@@ -58,7 +58,9 @@ class TransferToOtherSite extends React.Component {
 			site.capabilities.manage_options &&
 			! ( site.jetpack && ! isAtomic ) && // Simple and Atomic sites. Not Jetpack sites.
 			! get( site, 'options.is_domain_only', false ) &&
-			! ( this.props.domainsWithPlansOnly && get( site, 'plan.product_slug' ) === PLAN_FREE ) &&
+			! (
+				this.props.domainsWithPlansOnly && isWpComFreePlan( get( site, 'plan.product_slug' ) )
+			) &&
 			site.ID !== this.props.selectedSite.ID
 		);
 	};

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/test/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/test/index.jsx
@@ -1,0 +1,97 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.mock( 'lib/analytics/index', () => ( {} ) );
+jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'lib/user', () => ( {} ) );
+jest.mock( 'components/main', () => 'MainComponent' );
+jest.mock( 'components/popover', () => 'Popover' );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Comp => props => (
+		<Comp
+			{ ...props }
+			translate={ function( x ) {
+				return x;
+			} }
+		/>
+	),
+	numberFormat: x => x,
+} ) );
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import {
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { TransferToOtherSite } from '../index';
+
+const site = {
+	options: {
+		is_automated_transfer: false,
+	},
+	capabilities: {
+		manage_options: true,
+	},
+	jetpack: false,
+	ID: 2,
+};
+
+const props = {
+	domainsWithPlansOnly: true,
+	selectedSite: {
+		ID: 1,
+	},
+};
+
+describe( 'TransferToOtherSite.isSiteEligible()', () => {
+	[ PLAN_FREE ].forEach( plan => {
+		test( `Should return false for plan ${ plan }`, () => {
+			const instance = new TransferToOtherSite( props );
+			expect( instance.isSiteEligible( { ...site, plan: { product_slug: plan } } ) ).toBe( false );
+		} );
+	} );
+
+	[
+		PLAN_JETPACK_FREE,
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_PERSONAL_MONTHLY,
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PREMIUM_MONTHLY,
+		PLAN_JETPACK_BUSINESS,
+		PLAN_JETPACK_BUSINESS_MONTHLY,
+		PLAN_BUSINESS,
+		PLAN_BUSINESS_2_YEARS,
+	].forEach( plan => {
+		test( `Should return false for plan ${ plan }`, () => {
+			const instance = new TransferToOtherSite( props );
+			expect( instance.isSiteEligible( { ...site, plan: { product_slug: plan } } ) ).toBe( true );
+		} );
+	} );
+} );

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/test/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/test/index.jsx
@@ -89,7 +89,7 @@ describe( 'TransferToOtherSite.isSiteEligible()', () => {
 		PLAN_BUSINESS,
 		PLAN_BUSINESS_2_YEARS,
 	].forEach( plan => {
-		test( `Should return false for plan ${ plan }`, () => {
+		test( `Should return true for plan ${ plan }`, () => {
 			const instance = new TransferToOtherSite( props );
 			expect( instance.isSiteEligible( { ...site, plan: { product_slug: plan } } ) ).toBe( true );
 		} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `transfer-to-other-site`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* Make sure there are enough unit tests and that they make sense
* Trigger domain transfer flow (domains -> pick a domain -> transfer -> to another wp.com site) and confirm it does not blow up