### PR TITLE
Remove PLAN_ constants from is-site-on-free-plan

### DIFF
--- a/client/state/selectors/is-site-on-free-plan.js
+++ b/client/state/selectors/is-site-on-free-plan.js
@@ -2,13 +2,12 @@
 /**
  * External dependencies
  */
-import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { getCurrentPlan } from 'state/sites/plans/selectors';
-import { PLAN_FREE, PLAN_JETPACK_FREE } from 'lib/plans/constants';
+import { isFreePlan } from 'lib/plans';
 
 /**
  * Returns true if site is on a free plan, false if the site is not
@@ -25,7 +24,7 @@ const isSiteOnFreePlan = ( state, siteId ) => {
 		return false;
 	}
 
-	return includes( [ PLAN_FREE, PLAN_JETPACK_FREE ], currentPlan.productSlug );
+	return isFreePlan( currentPlan.productSlug );
 };
 
 export default isSiteOnFreePlan;


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `banner`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests - this function already has test coverage
* Go to `/settings/disconnect-site/`, choose any jetpack site, and confirm in react devtools that `isFreePlan` value for `Troubleshoot` component is correct

<img width="1694" alt="zrzut ekranu 2018-04-04 o 12 47 29" src="https://user-images.githubusercontent.com/205419/38303451-66950dec-3806-11e8-8d1f-09273d315c0c.png">
