### PR TITLE
Remove PLAN_ constants from post-share/nudges.jsx

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -52,10 +52,8 @@ import Notice from 'components/notice';
 import {
 	hasFeature,
 	isRequestingSitePlans as siteIsRequestingPlans,
-	getSitePlanRawPrice,
-	getPlanDiscountedRawPrice,
 } from 'state/sites/plans/selectors';
-import { FEATURE_REPUBLICIZE, PLAN_PREMIUM, PLAN_JETPACK_PREMIUM } from 'lib/plans/constants';
+import { FEATURE_REPUBLICIZE } from 'lib/plans/constants';
 import { UpgradeToPremiumNudge } from 'blocks/post-share/nudges';
 import SharingPreviewModal from './sharing-preview-modal';
 import ConnectionsList, { NoConnectionsNotice } from './connections-list';
@@ -580,10 +578,6 @@ class PostShare extends Component {
 	}
 }
 
-const getDiscountedOrRegularPrice = ( state, siteId, plan ) =>
-	getPlanDiscountedRawPrice( state, siteId, plan, { isMonthly: true } ) ||
-	getSitePlanRawPrice( state, siteId, plan, { isMonthly: true } );
-
 export default connect(
 	( state, props ) => {
 		const { siteId } = props;
@@ -609,8 +603,6 @@ export default connect(
 			failed: sharePostFailure( state, siteId, postId ),
 			success: sharePostSuccessMessage( state, siteId, postId ),
 			scheduledAt: getScheduledPublicizeShareActionTime( state, siteId, postId ),
-			premiumPrice: getDiscountedOrRegularPrice( state, siteId, PLAN_PREMIUM ),
-			jetpackPremiumPrice: getDiscountedOrRegularPrice( state, siteId, PLAN_JETPACK_PREMIUM ),
 			userCurrency: getCurrentUserCurrencyCode( state ),
 			scheduledActions: getPostShareScheduledActions( state, siteId, postId ),
 			publishedActions: getPostSharePublishedActions( state, siteId, postId ),

--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -5,8 +5,6 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { getSitePlan } from 'state/sites/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * Internal dependencies
@@ -15,32 +13,22 @@ import Banner from 'components/banner';
 import { TYPE_PREMIUM, TERM_ANNUALLY } from 'lib/plans/constants';
 import { findFirstSimilarPlanKey } from 'lib/plans';
 import formatCurrency from 'lib/format-currency';
+import { getSitePlan } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSitePlanRawPrice, getPlanDiscountedRawPrice } from 'state/sites/plans/selectors';
 
 export const UpgradeToPremiumNudgePure = props => {
-	const {
-		premiumPrice,
-		jetpackPremiumPrice,
-		currentPlanSlug,
-		translate,
-		userCurrency,
-		isJetpack,
-	} = props;
+	const { price, planSlug, translate, userCurrency, isJetpack } = props;
 
-	let price, featureList, proposedPlan;
+	let featureList;
 	if ( isJetpack ) {
-		price = jetpackPremiumPrice;
 		featureList = [
 			translate( 'Schedule your social messages in advance.' ),
 			translate( 'Easy monetization options' ),
 			translate( 'VideoPress support' ),
 			translate( 'Daily Malware Scanning' ),
 		];
-		proposedPlan = findFirstSimilarPlanKey( currentPlanSlug, {
-			type: TYPE_PREMIUM,
-			term: TERM_ANNUALLY,
-		} );
 	} else {
-		price = premiumPrice;
 		featureList = [
 			translate( 'Schedule your social messages in advance.' ),
 			translate( 'Remove all advertising from your site.' ),
@@ -48,7 +36,6 @@ export const UpgradeToPremiumNudgePure = props => {
 			translate( 'Easy monetization options' ),
 			translate( 'Unlimited premium themes.' ),
 		];
-		proposedPlan = findFirstSimilarPlanKey( currentPlanSlug, { type: TYPE_PREMIUM } );
 	}
 
 	return (
@@ -59,12 +46,26 @@ export const UpgradeToPremiumNudgePure = props => {
 				comment: '%s will be replaced by a formatted price, i.e $9.99',
 			} ) }
 			list={ featureList }
-			plan={ proposedPlan }
+			plan={ planSlug }
 			title={ translate( 'Upgrade to a Premium Plan!' ) }
 		/>
 	);
 };
 
-export const UpgradeToPremiumNudge = connect( state => ( {
-	currentPlanSlug: getSitePlan( state, getSelectedSiteId( state ) ),
-} ) )( UpgradeToPremiumNudgePure );
+const getDiscountedOrRegularPrice = ( state, siteId, plan ) =>
+	getPlanDiscountedRawPrice( state, siteId, plan, { isMonthly: true } ) ||
+	getSitePlanRawPrice( state, siteId, plan, { isMonthly: true } );
+
+export const UpgradeToPremiumNudge = connect( ( state, ownProps ) => {
+	const { isJetpack, siteId } = ownProps;
+	const currentPlanSlug = ( getSitePlan( state, getSelectedSiteId( state ) ) || {} ).product_slug;
+	const proposedPlan = findFirstSimilarPlanKey( currentPlanSlug, {
+		type: TYPE_PREMIUM,
+		...( isJetpack ? { term: TERM_ANNUALLY } : {} ),
+	} );
+
+	return {
+		planSlug: proposedPlan,
+		price: getDiscountedOrRegularPrice( state, siteId, proposedPlan ),
+	};
+} )( UpgradeToPremiumNudgePure );

--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -3,18 +3,28 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
+import { connect } from 'react-redux';
+import { getSitePlan } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * Internal dependencies
  */
 import Banner from 'components/banner';
-import { PLAN_PREMIUM, PLAN_JETPACK_PREMIUM } from 'lib/plans/constants';
+import { TYPE_PREMIUM, TERM_ANNUALLY } from 'lib/plans/constants';
+import { findFirstSimilarPlanKey } from 'lib/plans';
 import formatCurrency from 'lib/format-currency';
 
-export const UpgradeToPremiumNudge = props => {
-	const { premiumPrice, jetpackPremiumPrice, translate, userCurrency, isJetpack } = props;
+export const UpgradeToPremiumNudgePure = props => {
+	const {
+		premiumPrice,
+		jetpackPremiumPrice,
+		currentPlanSlug,
+		translate,
+		userCurrency,
+		isJetpack,
+	} = props;
 
 	let price, featureList, proposedPlan;
 	if ( isJetpack ) {
@@ -25,7 +35,10 @@ export const UpgradeToPremiumNudge = props => {
 			translate( 'VideoPress support' ),
 			translate( 'Daily Malware Scanning' ),
 		];
-		proposedPlan = PLAN_JETPACK_PREMIUM;
+		proposedPlan = findFirstSimilarPlanKey( currentPlanSlug, {
+			type: TYPE_PREMIUM,
+			term: TERM_ANNUALLY,
+		} );
 	} else {
 		price = premiumPrice;
 		featureList = [
@@ -35,7 +48,7 @@ export const UpgradeToPremiumNudge = props => {
 			translate( 'Easy monetization options' ),
 			translate( 'Unlimited premium themes.' ),
 		];
-		proposedPlan = PLAN_PREMIUM;
+		proposedPlan = findFirstSimilarPlanKey( currentPlanSlug, { type: TYPE_PREMIUM } );
 	}
 
 	return (
@@ -51,3 +64,7 @@ export const UpgradeToPremiumNudge = props => {
 		/>
 	);
 };
+
+export const UpgradeToPremiumNudge = connect( state => ( {
+	currentPlanSlug: getSitePlan( state, getSelectedSiteId( state ) ),
+} ) )( UpgradeToPremiumNudgePure );

--- a/client/blocks/post-share/test/nudges.jsx
+++ b/client/blocks/post-share/test/nudges.jsx
@@ -70,30 +70,19 @@ describe( 'UpgradeToPremiumNudgePure.render()', () => {
 		PLAN_JETPACK_PREMIUM_MONTHLY,
 		PLAN_JETPACK_BUSINESS,
 		PLAN_JETPACK_BUSINESS_MONTHLY,
+		PLAN_FREE,
+		PLAN_PERSONAL,
+		PLAN_PREMIUM,
+		PLAN_BUSINESS,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_BUSINESS_2_YEARS,
 	].forEach( plan => {
-		test( `Should pass jetpack premium plan for jetpack plans ${ plan }`, () => {
-			const comp = shallow(
-				<UpgradeToPremiumNudgePure { ...props } isJetpack={ true } currentPlanSlug={ plan } />
-			);
-			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_JETPACK_PREMIUM );
-		} );
-	} );
-
-	[ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS ].forEach( plan => {
-		test( `Should pass wp.com premium plan for annual wp.com plans ${ plan }`, () => {
-			const comp = shallow(
-				<UpgradeToPremiumNudgePure { ...props } isJetpack={ false } currentPlanSlug={ plan } />
-			);
-			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_PREMIUM );
-		} );
-	} );
-
-	[ PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS, PLAN_BUSINESS_2_YEARS ].forEach( plan => {
 		test( `Should pass 2-years wp.com premium plan for 2-years plans ${ plan }`, () => {
 			const comp = shallow(
-				<UpgradeToPremiumNudgePure { ...props } isJetpack={ false } currentPlanSlug={ plan } />
+				<UpgradeToPremiumNudgePure { ...props } isJetpack={ false } planSlug={ plan } />
 			);
-			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_PREMIUM_2_YEARS );
+			expect( comp.find( 'Banner' ).props().plan ).toBe( plan );
 		} );
 	} );
 } );

--- a/client/blocks/post-share/test/nudges.jsx
+++ b/client/blocks/post-share/test/nudges.jsx
@@ -1,0 +1,99 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.mock( 'lib/analytics/index', () => ( {} ) );
+jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'lib/user', () => ( {} ) );
+jest.mock( 'components/main', () => 'MainComponent' );
+jest.mock( 'components/popover', () => 'Popover' );
+jest.mock( 'components/banner', () => 'Banner' );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Comp => props => (
+		<Comp
+			{ ...props }
+			translate={ function( x ) {
+				return x;
+			} }
+		/>
+	),
+	numberFormat: x => x,
+} ) );
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import {
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { UpgradeToPremiumNudgePure } from '../nudges';
+
+const props = {
+	translate: x => x,
+};
+
+describe( 'UpgradeToPremiumNudgePure basic tests', () => {
+	test( 'should not blow up', () => {
+		const comp = shallow( <UpgradeToPremiumNudgePure { ...props } /> );
+		expect( comp.find( 'Banner' ).length ).toBe( 1 );
+	} );
+} );
+
+describe( 'UpgradeToPremiumNudgePure.render()', () => {
+	[
+		PLAN_JETPACK_FREE,
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_PERSONAL_MONTHLY,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PREMIUM_MONTHLY,
+		PLAN_JETPACK_BUSINESS,
+		PLAN_JETPACK_BUSINESS_MONTHLY,
+	].forEach( plan => {
+		test( `Should pass jetpack premium plan for jetpack plans ${ plan }`, () => {
+			const comp = shallow(
+				<UpgradeToPremiumNudgePure { ...props } isJetpack={ true } currentPlanSlug={ plan } />
+			);
+			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_JETPACK_PREMIUM );
+		} );
+	} );
+
+	[ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS ].forEach( plan => {
+		test( `Should pass wp.com premium plan for annual wp.com plans ${ plan }`, () => {
+			const comp = shallow(
+				<UpgradeToPremiumNudgePure { ...props } isJetpack={ false } currentPlanSlug={ plan } />
+			);
+			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_PREMIUM );
+		} );
+	} );
+
+	[ PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS, PLAN_BUSINESS_2_YEARS ].forEach( plan => {
+		test( `Should pass 2-years wp.com premium plan for 2-years plans ${ plan }`, () => {
+			const comp = shallow(
+				<UpgradeToPremiumNudgePure { ...props } isJetpack={ false } currentPlanSlug={ plan } />
+			);
+			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_PREMIUM_2_YEARS );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from ` post-share/nudges.jsx`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* Go to posts page for a free wp.com and jetpack site
* Click "..." -> share
* Confirm that the sales nudge is there and the button redirects to the upgrade page
* Confirm that the price on the nudge is correct 

<img width="761" alt="zrzut ekranu 2018-04-04 o 13 46 40" src="https://user-images.githubusercontent.com/205419/38305833-a480128e-380e-11e8-9090-527a64eb72f4.png">
