### PR TITLE
Remove PLAN_ constants from single-site-wpcom

### DIFF
--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -6,6 +6,8 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
+import { getSitePlan } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * Internal dependencies
@@ -15,15 +17,23 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import { connectOptions } from './theme-options';
 import Banner from 'components/banner';
-import { FEATURE_UNLIMITED_PREMIUM_THEMES, PLAN_PREMIUM } from 'lib/plans/constants';
+import { FEATURE_UNLIMITED_PREMIUM_THEMES, TYPE_PREMIUM } from 'lib/plans/constants';
+import { findFirstSimilarPlanKey } from 'lib/plans';
 import { hasFeature, isRequestingSitePlans } from 'state/sites/plans/selectors';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
 import { getSiteSlug } from 'state/sites/selectors';
 
-const ConnectedSingleSiteWpcom = connectOptions( props => {
-	const { hasUnlimitedPremiumThemes, requestingSitePlans, siteId, siteSlug, translate } = props;
+export const ConnectedSingleSiteWpcom = props => {
+	const {
+		hasUnlimitedPremiumThemes,
+		requestingSitePlans,
+		currentPlanSlug,
+		siteId,
+		siteSlug,
+		translate,
+	} = props;
 
 	const upsellUrl = `/plans/${ siteSlug }`;
 	return (
@@ -33,7 +43,7 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 			{ ! requestingSitePlans &&
 				! hasUnlimitedPremiumThemes && (
 					<Banner
-						plan={ PLAN_PREMIUM }
+						plan={ findFirstSimilarPlanKey( currentPlanSlug, { type: TYPE_PREMIUM } ) }
 						title={ translate(
 							'Access all our premium themes with our Premium and Business plans!'
 						) }
@@ -51,10 +61,11 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 			</ThemeShowcase>
 		</div>
 	);
-} );
+};
 
 export default connect( ( state, { siteId } ) => ( {
 	siteSlug: getSiteSlug( state, siteId ),
+	currentPlanSlug: ( getSitePlan( state, getSelectedSiteId( state ) ) || {} ).product_slug,
 	hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
 	requestingSitePlans: isRequestingSitePlans( state, siteId ),
-} ) )( ConnectedSingleSiteWpcom );
+} ) )( connectOptions( ConnectedSingleSiteWpcom ) );

--- a/client/my-sites/themes/test/single-site-wpcom.jsx
+++ b/client/my-sites/themes/test/single-site-wpcom.jsx
@@ -1,0 +1,80 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.mock( 'lib/analytics/index', () => ( {} ) );
+jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'lib/user', () => ( {} ) );
+jest.mock( 'components/main', () => 'MainComponent' );
+jest.mock( 'components/popover', () => 'Popover' );
+jest.mock( 'components/banner', () => 'Banner' );
+jest.mock( 'components/data/query-site-purchases', () => 'QuerySitePurchases' );
+jest.mock( 'my-sites/themes/current-theme', () => ( {} ) );
+jest.mock( 'my-sites/themes/theme-options', () => ( { connectOptions: x => x } ) );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Comp => props => (
+		<Comp
+			{ ...props }
+			translate={ function( x ) {
+				return x;
+			} }
+		/>
+	),
+	numberFormat: x => x,
+} ) );
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import {
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+} from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { ConnectedSingleSiteWpcom } from '../single-site-wpcom';
+
+const props = {
+	translate: x => x,
+	requestingSitePlans: false,
+	hasUnlimitedPremiumThemes: false,
+};
+
+describe( 'ConnectedSingleSiteWpcom basic tests', () => {
+	test( 'should not blow up', () => {
+		const comp = shallow( <ConnectedSingleSiteWpcom { ...props } /> );
+		expect( comp.find( 'Banner' ).length ).toBe( 1 );
+	} );
+} );
+
+describe( 'ConnectedSingleSiteWpcom.render()', () => {
+	[ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS ].forEach( plan => {
+		test( `Should pass wp.com premium plan for annual wp.com plans ${ plan }`, () => {
+			const comp = shallow(
+				<ConnectedSingleSiteWpcom { ...props } isJetpack={ false } currentPlanSlug={ plan } />
+			);
+			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_PREMIUM );
+		} );
+	} );
+
+	[ PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS, PLAN_BUSINESS_2_YEARS ].forEach( plan => {
+		test( `Should pass 2-years wp.com premium plan for 2-years plans ${ plan }`, () => {
+			const comp = shallow(
+				<ConnectedSingleSiteWpcom { ...props } isJetpack={ false } currentPlanSlug={ plan } />
+			);
+			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_PREMIUM_2_YEARS );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `single-site-wpcom`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests
* Go to `/themes` for a free site, and confirm that the upsell banner looks like this:

<img width="1069" alt="zrzut ekranu 2018-04-04 o 13 17 38" src="https://user-images.githubusercontent.com/205419/38305040-ace38a8a-380b-11e8-80fd-3c92c5c19e13.png">
