### PR TITLE
Help: Use localize provided moment

### DIFF
--- a/client/me/help/chat-business-concierge-notice/index.jsx
+++ b/client/me/help/chat-business-concierge-notice/index.jsx
@@ -31,7 +31,7 @@ class ChatBusinessConciergeNotice extends Component {
 		analytics.tracks.recordEvent( 'calypso_help_concierge_offer_click' );
 	};
 
-	render = () => {
+	render() {
 		const { moment, selectedSite, translate } = this.props;
 		const fromDate = moment( this.props.from );
 		const toDate = moment( this.props.to );
@@ -60,7 +60,7 @@ class ChatBusinessConciergeNotice extends Component {
 				description={ translate( 'Click here to get one-on-one help with a Happiness Engineer.' ) }
 			/>
 		);
-	};
+	}
 }
 
 export default connect( state => ( {

--- a/client/me/help/chat-business-concierge-notice/index.jsx
+++ b/client/me/help/chat-business-concierge-notice/index.jsx
@@ -18,12 +18,10 @@ import { isBusinessPlanUser } from 'state/selectors';
 class ChatBusinessConciergeNotice extends Component {
 	static propTypes = {
 		from: PropTypes.string.isRequired,
-		selectedSite: PropTypes.object.isRequired,
-		to: PropTypes.string.isRequired,
-
-		// Connected props
 		isBusinessPlanUser: PropTypes.bool.isRequired,
 		moment: PropTypes.func.isRequired,
+		selectedSite: PropTypes.object.isRequired,
+		to: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 

--- a/client/me/help/chat-business-concierge-notice/index.jsx
+++ b/client/me/help/chat-business-concierge-notice/index.jsx
@@ -19,12 +19,14 @@ import { isBusinessPlanUser } from 'state/selectors';
 
 class ChatBusinessConciergeNotice extends Component {
 	static propTypes = {
-		translate: PropTypes.func,
-		isBusinessPlanUser: PropTypes.bool.isRequired,
 		from: PropTypes.string.isRequired,
 		selectedSite: PropTypes.object.isRequired,
 		to: PropTypes.string.isRequired,
+
+		// Connected props
+		isBusinessPlanUser: PropTypes.bool.isRequired,
 		moment: PropTypes.func,
+		translate: PropTypes.func,
 	};
 
 	static defaultProps = {

--- a/client/me/help/chat-business-concierge-notice/index.jsx
+++ b/client/me/help/chat-business-concierge-notice/index.jsx
@@ -3,12 +3,11 @@
 /**
  * External dependencies
  */
-
-import { identity } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import i18n, { localize } from 'i18n-calypso';
+import { identity } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies

--- a/client/me/help/chat-business-concierge-notice/index.jsx
+++ b/client/me/help/chat-business-concierge-notice/index.jsx
@@ -24,6 +24,7 @@ class ChatBusinessConciergeNotice extends Component {
 		from: PropTypes.string.isRequired,
 		selectedSite: PropTypes.object.isRequired,
 		to: PropTypes.string.isRequired,
+		moment: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -35,11 +36,11 @@ class ChatBusinessConciergeNotice extends Component {
 	};
 
 	render = () => {
-		const { selectedSite, translate } = this.props;
-		const fromDate = i18n.moment( this.props.from );
-		const toDate = i18n.moment( this.props.to );
+		const { moment, selectedSite, translate } = this.props;
+		const fromDate = moment( this.props.from );
+		const toDate = moment( this.props.to );
 
-		if ( ! i18n.moment().isAfter( fromDate ) || ! i18n.moment().isBefore( toDate ) ) {
+		if ( ! moment().isAfter( fromDate ) || ! moment().isBefore( toDate ) ) {
 			return null;
 		}
 

--- a/client/me/help/chat-business-concierge-notice/index.jsx
+++ b/client/me/help/chat-business-concierge-notice/index.jsx
@@ -6,7 +6,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -24,12 +23,8 @@ class ChatBusinessConciergeNotice extends Component {
 
 		// Connected props
 		isBusinessPlanUser: PropTypes.bool.isRequired,
-		moment: PropTypes.func,
-		translate: PropTypes.func,
-	};
-
-	static defaultProps = {
-		translate: identity,
+		moment: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
 	};
 
 	trackConciergeOfferClick = () => {


### PR DESCRIPTION
[`localize`](https://github.com/Automattic/i18n-calypso#localize) provides `moment` via props. Use it over `i18n.moment`.

Sort propTypes and imports.

Drops `defaultProps` for localize-provided props.

`render() {}` not `render = () => {}`

## Testing
1. No functional changes.
1. There should be no errors at [`/help/contact`](https://calypso.live/help/contact?branch=update/concierge-notice-localize-moment).

Spotted while reviewing #23828