### PR TITLE
Marketing: ensure every eligible user to participate in the survey

### DIFF
--- a/client/state/nps-survey/actions.js
+++ b/client/state/nps-survey/actions.js
@@ -6,7 +6,6 @@
 
 import debugFactory from 'debug';
 import wpcom from 'lib/wp';
-import { random } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,7 +23,6 @@ import {
 	NPS_SURVEY_SEND_FEEDBACK_REQUEST_SUCCESS,
 	NPS_SURVEY_SEND_FEEDBACK_REQUEST_FAILURE,
 } from 'state/action-types';
-import { NPS_SURVEY_RAND_MAX } from './constants';
 
 const debug = debugFactory( 'calypso:nps-survey' );
 
@@ -39,22 +37,17 @@ export function setupNpsSurveyEligibility() {
 	return dispatch => {
 		debug( 'Checking NPS eligibility...' );
 
-		if ( 1 === random( 1, NPS_SURVEY_RAND_MAX ) ) {
-			return wpcom
-				.undocumented()
-				.checkNPSSurveyEligibility()
-				.then( data => {
-					debug( '...Eligibility returned from endpoint.', data );
-					dispatch( setNpsSurveyEligibility( data.display_survey ) );
-				} )
-				.catch( err => {
-					debug( '...Error querying NPS survey eligibility.', err );
-					dispatch( setNpsSurveyEligibility( false ) );
-				} );
-		}
-
-		debug( '...Session was not lucky' );
-		return dispatch( setNpsSurveyEligibility( false ) );
+		return wpcom
+			.undocumented()
+			.checkNPSSurveyEligibility()
+			.then( data => {
+				debug( '...Eligibility returned from endpoint.', data );
+				dispatch( setNpsSurveyEligibility( data.display_survey ) );
+			} )
+			.catch( err => {
+				debug( '...Error querying NPS survey eligibility.', err );
+				dispatch( setNpsSurveyEligibility( false ) );
+			} );
 	};
 }
 

--- a/client/state/nps-survey/constants.js
+++ b/client/state/nps-survey/constants.js
@@ -3,5 +3,3 @@ export const NOT_SUBMITTED = 'NOT_SUBMITTED';
 export const SUBMITTING = 'SUBMITTING';
 export const SUBMIT_FAILURE = 'SUBMIT_FAILURE';
 export const SUBMITTED = 'SUBMITTED';
-
-export const NPS_SURVEY_RAND_MAX = 2000;


### PR DESCRIPTION
This PR will remove the random selection of the sessions and always check if the current session is eligible for the NPS survey to encourage as many users as possible participate in the NPS survey. The #23769 should precede this PR to avoid making our valuable users annoying by giving them a power to easily dismiss the survey.

This is a part of the NPS v2 project. You can see more details of the project on p9jf6J-h6-p2

## How to test

1. Run `localStorage.setItem('debug', 'calypso:nps-survey');` in the browser console to track the logs.
2. Go to the Reader page and reload it.
3. You will see `Checking NPS eligibility...` followed by either message: `...Eligibility returned from endpoint` or `...Error querying NPS survey eligibility.`