### PR TITLE
Use withoutNotice over one-off notice disabling

### DIFF
--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -19,6 +19,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { REMOTE_PATH_AUTH } from 'jetpack-connect/constants';
 import { SITE_REQUEST_FIELDS, SITE_REQUEST_OPTIONS } from 'state/sites/constants';
 import { urlToSlug } from 'lib/url';
+import { withoutNotice } from 'state/notices/actions';
 import {
 	JETPACK_CONNECT_AUTHORIZE,
 	JETPACK_CONNECT_AUTHORIZE_LOGIN_COMPLETE,
@@ -262,7 +263,7 @@ export function isUserConnected( siteId, siteIsOnSitesList ) {
 				debug( 'user is not connected from', error );
 				if ( siteIsOnSitesList ) {
 					debug( 'removing site from sites list', siteId );
-					dispatch( receiveDeletedSite( siteId, true ) );
+					dispatch( withoutNotice( receiveDeletedSite )( siteId ) );
 				}
 			} );
 	};

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -271,11 +271,7 @@ const onSiteDelete = ( { siteId } ) => ( dispatch, getState ) => {
 	);
 };
 
-const onSiteDeleteReceive = ( { siteId, silent } ) => ( dispatch, getState ) => {
-	if ( silent ) {
-		return;
-	}
-
+const onSiteDeleteReceive = ( { siteId } ) => ( dispatch, getState ) => {
 	const siteDomain = getSiteDomain( getState(), siteId );
 
 	dispatch(

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -33,14 +33,12 @@ import { SITE_REQUEST_FIELDS, SITE_REQUEST_OPTIONS } from 'state/sites/constants
  * deleted.
  *
  * @param  {Number} siteId  ID of deleted site
- * @param  {Boolean} silent Indicates to not show the global notice after the site is removed from the state.
  * @return {Object}         Action object
  */
-export function receiveDeletedSite( siteId, silent = false ) {
+export function receiveDeletedSite( siteId ) {
 	return {
 		type: SITE_DELETE_RECEIVE,
 		siteId,
-		silent,
 	};
 }
 


### PR DESCRIPTION
Replaces specific approach from #17410 with a generalized framework-provided approach for disabling a particular notice.

## Testing
1. See #17410 :trollface: 