### PR TITLE
Themes: Fix test mocks reset -> restore

### DIFF
--- a/client/state/themes/test/reducer.js
+++ b/client/state/themes/test/reducer.js
@@ -66,6 +66,8 @@ const mood = {
 };
 
 describe( 'reducer', () => {
+	beforeEach( jest.restoreAllMocks );
+
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(
 			expect.arrayContaining( [
@@ -386,9 +388,6 @@ describe( 'reducer', () => {
 			const state = queries( original, { type: DESERIALIZE } );
 
 			expect( state ).toEqual( {} );
-
-			// eslint-disable-next-line no-console
-			console.warn.mockReset();
 		} );
 	} );
 
@@ -709,9 +708,6 @@ describe( 'reducer', () => {
 
 			const state = activeThemes( original, { type: DESERIALIZE } );
 			expect( state ).toEqual( {} );
-
-			// eslint-disable-next-line no-console
-			console.warn.mockReset();
 		} );
 	} );
 


### PR DESCRIPTION
Globally restore mocks, we want to restore (remove them) not reset (clear their info).

Spotted while finding suggestion for review of #23859

## Testing
- Tests pass
- No new console warnings