### PR TITLE
DevDocs: New CardHeading component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -96,6 +96,7 @@
 @import 'components/button/style';
 @import 'components/button-group/style';
 @import 'components/card/style';
+@import 'components/card-heading/style';
 @import 'components/chart/style';
 @import 'components/checklist/style';
 @import 'components/clipboard-button-input/style';

--- a/client/components/card-heading/README.md
+++ b/client/components/card-heading/README.md
@@ -1,0 +1,26 @@
+CardHeading (JSX)
+=====================
+
+This component displays a heading for a <Card>
+
+#### How to use:
+
+```js
+import CardHeading from 'components/card-heading';
+
+render() {
+	return (
+		<CardHeading
+			tagName={ <h1 /> }
+			size={ 21 }
+		>
+			Put your heading text here
+		</CardHeading>
+	);
+}
+```
+
+#### Props
+
+* `tagName` (`string`) - The element to wrap the text in
+* `size` (`int`) - The font size of the heading

--- a/client/components/card-heading/docs/example.jsx
+++ b/client/components/card-heading/docs/example.jsx
@@ -1,0 +1,43 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { PureComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import CardHeading from 'components/card-heading';
+
+export default class CardHeadingExample extends PureComponent {
+	static displayName = 'CardHeadingExample';
+
+	render() {
+		return (
+			<Card>
+				<CardHeading>This is a default CardHeading</CardHeading>
+				<CardHeading tagName="h1" size={ 54 }>
+					This is a CardHeading, H1 at 54px
+				</CardHeading>
+				<CardHeading tagName="h2" size={ 47 }>
+					This is a CardHeading, H2 at 47px
+				</CardHeading>
+				<CardHeading tagName="h3" size={ 36 }>
+					This is a CardHeading, H3 at 36px
+				</CardHeading>
+				<CardHeading tagName="h4" size={ 32 }>
+					This is a CardHeading, H4 at 32px
+				</CardHeading>
+				<CardHeading tagName="h5" size={ 24 }>
+					This is a CardHeading, H5 at 24px
+				</CardHeading>
+				<CardHeading tagName="h6" size={ 21 }>
+					This is a CardHeading, H6 at 21px
+				</CardHeading>
+			</Card>
+		);
+	}
+}

--- a/client/components/card-heading/index.jsx
+++ b/client/components/card-heading/index.jsx
@@ -1,0 +1,31 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import { includes } from 'lodash';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { preventWidows } from 'lib/formatting';
+
+const validTypeSizes = [ 54, 47, 36, 32, 24, 21, 16, 14, 11 ];
+
+function CardHeading( { tagName = 'h1', size = 21, children } ) {
+	const classNameObject = {};
+	classNameObject[ 'card-heading-' + size ] = includes( validTypeSizes, size );
+	const classes = classNames( 'card-heading', classNameObject );
+	return React.createElement( tagName, { className: classes }, preventWidows( children, 2 ) );
+}
+
+CardHeading.propTypes = {
+	tagName: PropTypes.string,
+	size: PropTypes.number,
+};
+
+export default CardHeading;

--- a/client/components/card-heading/style.scss
+++ b/client/components/card-heading/style.scss
@@ -1,0 +1,46 @@
+.card-heading {
+	font-weight: 400;
+	margin-bottom: 5px;
+	margin-top: 5px;
+
+	@include breakpoint( '>960px' ) {
+		margin-bottom: 10px;
+		margin-top: 10px;
+	}
+}
+
+.card-heading-54 {
+	font-size: 54px;
+}
+
+.card-heading-47 {
+	font-size: 47px;
+}
+
+.card-heading-36 {
+	font-size: 36px;
+}
+
+.card-heading-32 {
+	font-size: 32px;
+}
+
+.card-heading-24 {
+	font-size: 24px;
+}
+
+.card-heading-21 {
+	font-size: 21px;
+}
+
+.card-heading-16 {
+	font-size: 16px;
+}
+
+.card-heading-14 {
+	font-size: 14px;
+}
+
+.card-heading-11 {
+	font-size: 11px;
+}

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -34,6 +34,7 @@ import BulkSelect from 'components/bulk-select/docs/example';
 import ButtonGroups from 'components/button-group/docs/example';
 import Buttons from 'components/button/docs/example';
 import Cards from 'components/card/docs/example';
+import CardHeading from 'components/card-heading/docs/example';
 import Checklist from 'components/checklist/docs/example';
 import ClipboardButtonInput from 'components/clipboard-button-input/docs/example';
 import ClipboardButtons from 'components/forms/clipboard-button/docs/example';
@@ -158,6 +159,7 @@ class DesignAssets extends React.Component {
 					<SplitButton readmeFilePath="split-button" />
 					<Badge />
 					<Cards readmeFilePath="card" />
+					<CardHeading />
 					<Checklist />
 					<ClipboardButtonInput readmeFilePath="clipboard-button-input" />
 					<ClipboardButtons readmeFilePath="forms/clipboard-button" />

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -14,6 +14,7 @@ import page from 'page';
  */
 import HeaderCake from 'components/header-cake';
 import Card from 'components/card';
+import CardHeading from 'components/card-heading';
 import ActionCard from 'components/action-card';
 import Main from 'components/main';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -66,14 +67,14 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 
 				<Card className="gmb-select-business-type__explanation">
 					<div className="gmb-select-business-type__explanation-main">
-						<h1 className="gmb-select-business-type__heading">
+						<CardHeading tagName="h1" size={ 24 }>
 							{ translate( 'Which type of business are you?' ) }
-						</h1>
+						</CardHeading>
 
 						<p>
 							{ translate(
 								'{{link}}Google My Business{{/link}} lists your local business on Google Search and Google Maps. ' +
-								'It works for businesses that have a physical location or serve a local area.',
+									'It works for businesses that have a physical location or serve a local area.',
 								{
 									components: {
 										link: (
@@ -104,7 +105,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 					} ) }
 					mainText={ translate(
 						'Your business has a physical location customers can visit, ' +
-						'or provides goods and services to local customers, or both.'
+							'or provides goods and services to local customers, or both.'
 					) }
 					buttonText={ translate( 'Create Your Listing', {
 						comment: 'Call to Action to add a business listing to Google My Business',

--- a/client/my-sites/google-my-business/style.scss
+++ b/client/my-sites/google-my-business/style.scss
@@ -1,4 +1,3 @@
-.gmb-select-business-type__heading,
 .gmb-new-account__heading {
 	font-size: 24px;
 	font-weight: 400;


### PR DESCRIPTION
This is another take on #23732.

The idea is to share styles for our Card headings so that we cut down on duplicated CSS and also have more consistency in our headings. This will encourage the use of standardized spacing and type sizes.

Here it is in DevDocs:
<img width="582" alt="screen shot 2018-04-04 at 15 09 20" src="https://user-images.githubusercontent.com/275961/38312670-3e254c78-381a-11e8-9eb0-866ede12be26.png">

Here it is in the wild:
<img width="1119" alt="screen shot 2018-04-04 at 15 10 15" src="https://user-images.githubusercontent.com/275961/38312703-51d314e4-381a-11e8-87b8-f77e135a53ce.png">
