### PR TITLE
framework: es6-wrapper should only warn once

### DIFF
--- a/client/lib/wrap-es6-functions/index.js
+++ b/client/lib/wrap-es6-functions/index.js
@@ -11,11 +11,15 @@ import { isFunction, partial } from 'lodash';
 
 function wrapFnWithWarning( fn, name ) {
 	const consoleFn = ( console.error || console.log ).bind( console );
+	const hasWarned = new Set();
 	return function() {
-		const err = new Error(
-			`${ name } is not supported on all browsers. You must use a replacement method from lodash.`
-		);
-		consoleFn( err );
+		if ( ! hasWarned.has( name ) ) {
+			const err = new Error(
+				`${ name } is not supported on all browsers. You must use a replacement method from lodash.`
+			);
+			consoleFn( err );
+			hasWarned.add( name );
+		}
 		return fn.apply( this, arguments );
 	};
 }


### PR DESCRIPTION
Splitting this off of https://github.com/Automattic/wp-calypso/pull/22860 since it can easily be landed in advance.

In development mode, we wrap specific non-polyfilled es6 functions so that they emit a warning when used.  Before this PR they would emit a warning on every single usage.  Afterwards only once.

**to test**
Note: this only applies to the dev server so `calypso.live` cannot be used to test this branch.

- spin up a branch of master. calling `[].find(() => {})` in the devtools console should emit a warning on each invocation
- repeat the same thing for this branch. You should only see a warning for the first call