### PR TITLE
Docs: Add PageViewTracker to the analytics docs

### DIFF
--- a/client/lib/analytics/README.md
+++ b/client/lib/analytics/README.md
@@ -14,7 +14,7 @@ You can limit to only calls made to GA, Tracks, or MC by replacing the `*` with 
 
 ## Which analytics tool should I use?
 
-*Page Views* (`analytics.pageView.record`) should be used to record all page views (when the main content body completely changes). This will automatically record the pageview to both Google Analytics and Tracks.
+*Page Views* should be used to record all page views (when the main content body completely changes). This will automatically record the pageview to both Google Analytics and Tracks. The preferred tool to record page views is the [`PageViewTracker`](https://github.com/Automattic/wp-calypso/tree/master/client/lib/analytics/page-view-tracker) component.
 
 *Google Analytics* should be used to record all events the user performs on a page that *do not* trigger a page view (this will allow us to determine bounce rate on pages).
 
@@ -33,11 +33,28 @@ import analytics from 'lib/analytics';
 
 ```
 
-## PageView Wrapper
+## PageViewTracker
+
+Record a page view both in Google Analytics and Tracks:
+
+```js
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+
+render() {
+    return (
+        <Main>
+            <PageViewTracker path="/section/page" title="My Cool Section > My Cool Page" />
+            <MyCoolComponent>
+                <MyCoolChildren />
+            </MyCoolComponent>
+        </Main>
+    );
+);
+```
 
 ### analytics#pageView#record( pageURL, pageTitle )
 
-Record a pageview both in Google Analytics and Tracks:
+*Note: Unless you have a strong reason to directly record a pageview, you should use the `PageViewTracker` component instead*
 
 ```js
 analytics.pageView.record( '/posts/draft', 'Posts > Drafts' );
@@ -122,3 +139,16 @@ If we had instead used `calypso_add_cart_product` and `calypso_remove_cart_produ
 Finally, for consistency, the verb at the end should be in the form `add`, `remove`, `view`, `click`, etc and _not_ `adds`, `added`, `adding`, etc.
 
 With the exception of separating tokens with underscores, these rules do not apply to property names. `coupon_code` is perfectly fine.
+
+## Page Views Paths Conventions
+
+There are currently no enforced rules for page views paths reporting but, where possible, they should be normalized and the variables values replaced by placeholders.
+
+E.g. the path `/comments/all/example.wordpress.com/1234` should be reported as `/comments/all/:site/:post_id`.
+
+As a rule of thumb:
+
+- The **site fragment** should be reported simply as `:site`.
+- **IDs** should be reported as `:element_id` (notice the snake case).
+- **Non-enumerable variables** (e.g. the domain name in `/domains/manage/:domain/edit/:site`) should be reported without unnecessary qualifiers.
+- The value of **enumerable variables** should be reported instead of the placeholder where it make sense (e.g. if changing the variable value results in a page change, as it happens for the status in `/comments/spam/:site`).

--- a/client/lib/analytics/README.md
+++ b/client/lib/analytics/README.md
@@ -41,14 +41,14 @@ Record a page view both in Google Analytics and Tracks:
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 render() {
-    return (
-        <Main>
-            <PageViewTracker path="/section/page" title="My Cool Section > My Cool Page" />
-            <MyCoolComponent>
-                <MyCoolChildren />
-            </MyCoolComponent>
-        </Main>
-    );
+	return (
+		<Main>
+			<PageViewTracker path="/section/page" title="My Cool Section > My Cool Page" />
+			<MyCoolComponent>
+				<MyCoolChildren />
+			</MyCoolComponent>
+		</Main>
+	);
 );
 ```
 

--- a/client/lib/analytics/page-view-tracker/README.md
+++ b/client/lib/analytics/page-view-tracker/README.md
@@ -1,6 +1,10 @@
 # Page View Tracking Component
 
-Use this component to automatically record page views when they are loaded. There are two modes of operation: immediate and delayed. In the immediate mode, the page view tracking event will fire off as soon as the component mounts. In the delayed mode, the event will fire off no sooner than the given delay, and will not send at all if the component unmounts before that delay has expired.
+Use this component to automatically record page views when they are loaded and when the `path` changes.
+
+There are two modes of operation: immediate and delayed. In the immediate mode, the page view tracking event will fire off as soon as the component mounts. In the delayed mode, the event will fire off no sooner than the given delay, and will not send at all if the component unmounts before that delay has expired.
+
+This component is aware of the selected site and, if the current URL contains a site fragment, it will delay the page view recording until the selected site is set or updated.
 
 ## Examples
 
@@ -11,12 +15,12 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 render() {
     return (
-        <div>
-            <PageViewTracker path="/my/trackers" title="tracking_dashboard" />
+        <Main>
+            <PageViewTracker path="/section/page" title="My Cool Section > My Cool Page" />
             <MyCoolComponent>
                 <MyCoolChildren />
             </MyCoolComponent>
-        </div>
+        </Main>
     );
 );
 ```
@@ -31,16 +35,16 @@ render() {
     // accidental view and thus don't track
 
     return (
-        <div>
+        <Main>
             <PageViewTracker 
                 delay={ 500 } 
-                path="/my/trackers" 
-                title="tracking_dashboard"
+				path="/section/page"
+				title="My Cool Section > My Cool Page"
             />
             <MyCoolComponent>
                 <MyCoolChildren />
             </MyCoolComponent>
-        </div>
+        </Main>
     );
 );
 ```

--- a/client/lib/analytics/page-view-tracker/README.md
+++ b/client/lib/analytics/page-view-tracker/README.md
@@ -14,14 +14,14 @@ This component is aware of the selected site and, if the current URL contains a 
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 render() {
-    return (
-        <Main>
-            <PageViewTracker path="/section/page" title="My Cool Section > My Cool Page" />
-            <MyCoolComponent>
-                <MyCoolChildren />
-            </MyCoolComponent>
-        </Main>
-    );
+	return (
+		<Main>
+			<PageViewTracker path="/section/page" title="My Cool Section > My Cool Page" />
+			<MyCoolComponent>
+				<MyCoolChildren />
+			</MyCoolComponent>
+		</Main>
+	);
 );
 ```
 
@@ -31,20 +31,20 @@ render() {
 import PageViewTracker from 'analytics/page-view-tracker';
 
 render() {
-    // consider a view for less than 500ms as an
-    // accidental view and thus don't track
+	// consider a view for less than 500ms as an
+	// accidental view and thus don't track
 
-    return (
-        <Main>
-            <PageViewTracker 
-                delay={ 500 } 
+	return (
+		<Main>
+			<PageViewTracker 
+				delay={ 500 } 
 				path="/section/page"
 				title="My Cool Section > My Cool Page"
-            />
-            <MyCoolComponent>
-                <MyCoolChildren />
-            </MyCoolComponent>
-        </Main>
-    );
+			/>
+			<MyCoolComponent>
+				<MyCoolChildren />
+			</MyCoolComponent>
+		</Main>
+	);
 );
 ```


### PR DESCRIPTION
Update the analytics docs to state that the currently recommended tool to record page views is the `PageViewTracker` component.

Also add a section with the paths reporting conventions:

- `:site` for site fragments.
- `:element_id` for IDs.
- A placeholder for non-enumerable variables (e.g. `:domain`).
- The actual value for enumerable variables (e.g. `spam` instead of `:status`).

English/editorial reviews +t+d appreciated! 🙇 