### PR TITLE
SiteAddressChanger: Try omiting spaces on typing

### DIFF
--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -103,13 +103,20 @@ export class SimpleSiteRenameForm extends Component {
 	};
 
 	onFieldChange = event => {
-		const domainFieldValue = get( event, 'target.value', '' ).toLowerCase();
+		const domainFieldValue = get( event, 'target.value', '' );
+		const formattedValue = domainFieldValue.toLowerCase().replace( / /g, '' );
 		const shouldUpdateError = ! isEmpty( this.state.domainFieldError );
 
+		// The problem here is that `formattedValue` === `domainFieldValue` when typing 'space'.
+		// This works, but doesn't give any input feedback to the form user.
+		// We can't use the regular validation pathway as the field itself _is_ valid.
+		// I think the UX could be a 'pulse' of validation,
+		// possibly with a validation message shown that toasts after a few secs
+
 		this.setState( {
-			domainFieldValue,
+			domainFieldValue: formattedValue,
 			...( shouldUpdateError && {
-				domainFieldError: this.getDomainValidationMessage( domainFieldValue ),
+				domainFieldError: this.getDomainValidationMessage( formattedValue ),
 			} ),
 		} );
 	};


### PR DESCRIPTION
One of the suggestions made during testing the Site Address Changer feature was to trim out spaces while typing.

This PR is a minimal approach to that, though I don't think that the UX is good enough as it is -- The whitespace is trimmed but there is no feedback to show that this behaviour is intentional which could be confusing to the person typing.

### Testing

- Go to `http://calypso.localhost:3000/domains/manage/{ your.wordpress.com }/edit/{ your.wordpress.com }`
- Attempt to input a string with spaces
  - Note that the space is not added to the input field.

### In Progress

As the UX is not up to scratch - I'm marking this as In Progress until either improved upon, or punted.