### PR TITLE
Stats: fix wrong paths in page view analytics

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -24,6 +24,7 @@ import EmptyContent from 'components/empty-content';
 import ErrorBanner from '../activity-log-banner/error-banner';
 import JetpackColophon from 'components/jetpack-colophon';
 import Main from 'components/main';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import ProgressBanner from '../activity-log-banner/progress-banner';
 import QueryActivityLog from 'components/data/query-activity-log';
 import QueryRewindState from 'components/data/query-rewind-state';
@@ -363,6 +364,7 @@ class ActivityLog extends Component {
 		const requestedRestoreId = this.props.requestedRestoreId || rewindId;
 		return (
 			<div key={ `end-banner-${ restoreId || downloadId }` }>
+				<PageViewTracker path="/stats/activity/:site" title="Stats > Activity" />
 				<QueryActivityLog siteId={ siteId } />
 				{ errorCode || backupError ? (
 					<ErrorBanner

--- a/client/my-sites/stats/comment-follows/index.jsx
+++ b/client/my-sites/stats/comment-follows/index.jsx
@@ -17,6 +17,7 @@ import { flowRight } from 'lodash';
 import Followers from '../stats-comment-followers-page';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import StatsFirstView from '../stats-first-view';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
@@ -54,6 +55,10 @@ class StatsCommentFollows extends Component {
 
 		return (
 			<Main wideLayout={ true }>
+				<PageViewTracker
+					path="/stats/follows/comment/:site_id"
+					title="Stats > Followers > Comment"
+				/>
 				<StatsFirstView />
 
 				<div id="my-stats-content" className="follows-detail follows-detail-comment">

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -10,10 +10,9 @@ import { find, pick } from 'lodash';
 /**
  * Internal Dependencies
  */
-import { getSiteFragment, getStatsDefaultSitePage, sectionify } from 'lib/route';
+import { getSiteFragment, getStatsDefaultSitePage } from 'lib/route';
 import analytics from 'lib/analytics';
 import { recordPlaceholdersTiming } from 'lib/perfmon';
-import titlecase from 'to-title-case';
 import { savePreference } from 'state/preferences/actions';
 import { getSite, isJetpackSite, getSiteOption } from 'state/sites/selectors';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
@@ -27,8 +26,6 @@ import StatsSummary from './summary';
 import StatsPostDetail from './stats-post-detail';
 import StatsCommentFollows from './comment-follows';
 import ActivityLog from './activity-log';
-
-const analyticsPageTitle = 'Stats';
 
 function rangeOfPeriod( period, date ) {
 	const periodRange = {
@@ -115,24 +112,16 @@ export default {
 		context.store.dispatch( savePreference( 'firstViewHistory', [] ) );
 	},
 
-	redirectToDefaultSitePage: function( context, next ) {
+	redirectToDefaultSitePage: function( context ) {
 		const siteFragment = getSiteFragment( context.path );
 
-		if ( siteFragment ) {
-			// if we are redirecting we need to retain our intended layout-focus
-			const currentLayoutFocus = getCurrentLayoutFocus( context.store.getState() );
-			context.store.dispatch( setNextLayoutFocus( currentLayoutFocus ) );
-			page.redirect( getStatsDefaultSitePage( siteFragment ) );
-		} else {
-			next();
-		}
+		// if we are redirecting we need to retain our intended layout-focus
+		const currentLayoutFocus = getCurrentLayoutFocus( context.store.getState() );
+		context.store.dispatch( setNextLayoutFocus( currentLayoutFocus ) );
+		page.redirect( getStatsDefaultSitePage( siteFragment ) );
 	},
 
 	insights: function( context, next ) {
-		const basePath = sectionify( context.path );
-
-		analytics.pageView.record( basePath, analyticsPageTitle + ' > Insights' );
-
 		context.primary = <StatsInsights followList={ new FollowList() } />;
 		next();
 	},
@@ -157,7 +146,6 @@ export default {
 				{ title: i18n.translate( 'Years' ), path: '/stats/year', id: 'stats-year', period: 'year' },
 			];
 		};
-		const basePath = sectionify( context.path );
 
 		window.scrollTo( 0, 0 );
 
@@ -174,19 +162,14 @@ export default {
 		}
 
 		analytics.mc.bumpStat( 'calypso_stats_overview_period', activeFilter.period );
-		analytics.pageView.record(
-			basePath,
-			analyticsPageTitle + ' > ' + titlecase( activeFilter.period )
-		);
 
 		context.primary = <StatsOverview period={ activeFilter.period } path={ context.pathname } />;
 		next();
 	},
 
 	site: function( context, next ) {
-		const { params: { site_id: givenSiteId }, path, query: queryOptions, store } = context;
+		const { params: { site_id: givenSiteId }, query: queryOptions, store } = context;
 		const filters = getSiteFilters( givenSiteId );
-		const basePath = sectionify( path );
 		const state = store.getState();
 		const currentSite = getSite( state, givenSiteId );
 		const siteId = currentSite ? currentSite.ID || 0 : 0;
@@ -217,13 +200,8 @@ export default {
 
 		// eslint-disable-next-line no-nested-ternary
 		const numPeriodAgo = parsedPeriod ? ( parsedPeriod > 9 ? '10plus' : '-' + parsedPeriod ) : '';
-		const baseAnalyticsPath = basePath + '/:site';
 
 		analytics.mc.bumpStat( 'calypso_stats_site_period', activeFilter.period + numPeriodAgo );
-		analytics.pageView.record(
-			baseAnalyticsPath,
-			analyticsPageTitle + ' > ' + titlecase( activeFilter.period )
-		);
 		recordPlaceholdersTiming();
 
 		context.primary = (
@@ -269,7 +247,6 @@ export default {
 			'annualstats',
 		];
 		let momentSiteZone = i18n.moment();
-		const basePath = sectionify( context.path );
 
 		const site = getSite( context.store.getState(), siteId );
 		siteId = site ? site.ID || 0 : 0;
@@ -312,15 +289,6 @@ export default {
 			statsQueryOptions.period = 'day';
 		}
 
-		analytics.pageView.record(
-			basePath,
-			analyticsPageTitle +
-				' > ' +
-				titlecase( activeFilter.period ) +
-				' > ' +
-				titlecase( context.params.module )
-		);
-
 		context.primary = (
 			<StatsSummary
 				path={ context.pathname }
@@ -338,9 +306,6 @@ export default {
 	post: function( context, next ) {
 		let siteId = context.params.site_id;
 		const postId = parseInt( context.params.post_id, 10 );
-		const pathParts = context.path.split( '/' );
-		const postOrPage = pathParts[ 2 ] === 'post' ? 'post' : 'page';
-
 		const site = getSite( context.store.getState(), siteId );
 		siteId = site ? site.ID || 0 : 0;
 
@@ -348,11 +313,6 @@ export default {
 			window.location = '/stats';
 			return next();
 		}
-
-		analytics.pageView.record(
-			'/stats/' + postOrPage + '/:post_id/:site',
-			analyticsPageTitle + ' > Single ' + titlecase( postOrPage )
-		);
 
 		context.primary = (
 			<StatsPostDetail path={ context.path } postId={ postId } context={ context } />
@@ -365,7 +325,6 @@ export default {
 		let siteId = context.params.site_id;
 		let pageNum = context.params.page_num;
 		const followList = new FollowList();
-		const basePath = sectionify( context.path );
 
 		const site = getSite( context.store.getState(), siteId );
 		siteId = site ? site.ID || 0 : 0;
@@ -383,11 +342,6 @@ export default {
 		if ( ! pageNum || pageNum < 1 ) {
 			pageNum = 1;
 		}
-
-		analytics.pageView.record(
-			basePath.replace( '/' + pageNum, '' ),
-			analyticsPageTitle + ' > Followers > Comment'
-		);
 
 		context.primary = (
 			<StatsCommentFollows
@@ -416,8 +370,6 @@ export default {
 			page.redirect( '/stats' );
 			return next();
 		}
-
-		analytics.pageView.record( '/stats/activity/:site', analyticsPageTitle + ' > Activity ' );
 
 		context.primary = (
 			<ActivityLog

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -58,6 +58,8 @@ export default function() {
 			clientRender
 		);
 
+		page( '/stats/insights', siteSelection, navigation, sites, makeLayout, clientRender );
+
 		// Stat Insights Page
 		page(
 			'/stats/insights/:site_id',
@@ -102,9 +104,22 @@ export default function() {
 			clientRender
 		);
 
+		const validModules = [
+			'posts',
+			'referrers',
+			'clicks',
+			'countryviews',
+			'authors',
+			'videoplays',
+			'videodetails',
+			'podcastdownloads',
+			'searchterms',
+			'annualstats',
+		];
+
 		// Stat Summary Pages
 		page(
-			'/stats/:module/:site_id',
+			`/stats/:module(${ validModules.join( '|' ) })/:site_id`,
 			siteSelection,
 			navigation,
 			statsController.summary,
@@ -112,7 +127,7 @@ export default function() {
 			clientRender
 		);
 		page(
-			'/stats/day/:module/:site_id',
+			`/stats/day/:module(${ validModules.join( '|' ) })/:site_id`,
 			siteSelection,
 			navigation,
 			statsController.summary,
@@ -120,7 +135,7 @@ export default function() {
 			clientRender
 		);
 		page(
-			'/stats/week/:module/:site_id',
+			`/stats/week/:module(${ validModules.join( '|' ) })/:site_id`,
 			siteSelection,
 			navigation,
 			statsController.summary,
@@ -128,7 +143,7 @@ export default function() {
 			clientRender
 		);
 		page(
-			'/stats/month/:module/:site_id',
+			`/stats/month/:module(${ validModules.join( '|' ) })/:site_id`,
 			siteSelection,
 			navigation,
 			statsController.summary,
@@ -136,7 +151,7 @@ export default function() {
 			clientRender
 		);
 		page(
-			'/stats/year/:module/:site_id',
+			`/stats/year/:module(${ validModules.join( '|' ) })/:site_id`,
 			siteSelection,
 			navigation,
 			statsController.summary,
@@ -185,14 +200,7 @@ export default function() {
 			page( '/stats/reset-first-view', statsController.resetFirstView, makeLayout, clientRender );
 		}
 
-		// Anything else should require site-selection
-		page(
-			'/stats/(.*)',
-			siteSelection,
-			statsController.redirectToDefaultSitePage,
-			sites,
-			makeLayout,
-			clientRender
-		);
+		// Anything else should redirect to default stats page
+		page( '/stats/(.*)', statsController.redirectToDefaultSitePage );
 	}
 }

--- a/client/my-sites/stats/overview.jsx
+++ b/client/my-sites/stats/overview.jsx
@@ -18,7 +18,9 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import SiteOverview from './stats-site-overview';
 import SiteOverviewPlaceholder from './stats-overview-placeholder';
 import DatePicker from './stats-date-picker';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import StatsNavigation from 'blocks/stats-navigation';
+import titlecase from 'to-title-case';
 import Main from 'components/main';
 import StatsFirstView from './stats-first-view';
 import JetpackColophon from 'components/jetpack-colophon';
@@ -98,6 +100,10 @@ class StatsOverview extends Component {
 		return (
 			<Main wideLayout>
 				<DocumentHead title={ translate( 'Stats' ) } />
+				<PageViewTracker
+					path={ `/stats/${ period }` }
+					title={ `Stats > ${ titlecase( period ) }` }
+				/>
 				<StatsFirstView />
 				<SidebarNavigation />
 				<StatsNavigation selectedItem={ 'traffic' } interval={ period } />

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -23,6 +23,7 @@ import ChartTabs from './stats-chart-tabs';
 import StatsModule from './stats-module';
 import statsStrings from './stats-strings';
 import titlecase from 'to-title-case';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import StatsFirstView from './stats-first-view';
 import StickyPanel from 'components/sticky-panel';
 import JetpackColophon from 'components/jetpack-colophon';
@@ -134,6 +135,10 @@ class StatsSite extends Component {
 		return (
 			<Main wideLayout={ true }>
 				<DocumentHead title={ translate( 'Stats' ) } />
+				<PageViewTracker
+					path={ `/stats/${ period }/:site` }
+					title={ `Stats > ${ titlecase( period ) }` }
+				/>
 				<PrivacyPolicyBanner />
 				<StatsFirstView />
 				<SidebarNavigation />

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -26,6 +26,7 @@ import MostPopular from 'my-sites/stats/most-popular';
 import LatestPostSummary from '../post-performance';
 import DomainTip from 'my-sites/domain-tip';
 import Main from 'components/main';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import StatsFirstView from '../stats-first-view';
 import SectionHeader from 'components/section-header';
 import StatsViews from '../stats-views';
@@ -55,6 +56,7 @@ const StatsInsights = props => {
 	return (
 		<Main wideLayout>
 			<DocumentHead title={ translate( 'Stats' ) } />
+			<PageViewTracker path="/stats/insights/:site" title="Stats > Insights" />
 			<StatsFirstView />
 			<SidebarNavigation />
 			<StatsNavigation selectedItem={ 'insights' } siteId={ siteId } slug={ siteSlug } />

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -23,6 +23,8 @@ import HeaderCake from 'components/header-cake';
 import { decodeEntities } from 'lib/formatting';
 import Main from 'components/main';
 import StatsFirstView from '../stats-first-view';
+import titlecase from 'to-title-case';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import PostLikes from '../stats-post-likes';
 import QueryPosts from 'components/data/query-posts';
 import QueryPostStats from 'components/data/query-post-stats';
@@ -121,6 +123,10 @@ class StatsPostDetail extends Component {
 
 		return (
 			<Main wideLayout>
+				<PageViewTracker
+					path={ `/stats/${ postType }/:post_id/:site` }
+					title={ `Stats > Single ${ titlecase( postType ) }` }
+				/>
 				{ siteId && <QueryPosts siteId={ siteId } postId={ postId } /> }
 				{ siteId && <QueryPostStats siteId={ siteId } postId={ postId } /> }
 

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -20,7 +20,9 @@ import Countries from '../stats-countries';
 import StatsVideoSummary from '../stats-video-summary';
 import VideoPlayDetails from '../stats-video-details';
 import Main from 'components/main';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import StatsFirstView from '../stats-first-view';
+import titlecase from 'to-title-case';
 import QueryMedia from 'components/data/query-media';
 import JetpackColophon from 'components/jetpack-colophon';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -221,8 +223,14 @@ class StatsSummary extends Component {
 
 		summaryViews.push( summaryView );
 
+		const { module } = this.props.context.params;
+
 		return (
 			<Main wideLayout={ true }>
+				<PageViewTracker
+					path={ `/stats/${ period }/${ module }/:site` }
+					title={ `Stats > ${ titlecase( period ) } > ${ titlecase( module ) }` }
+				/>
 				<StatsFirstView />
 				<div id="my-stats-content">
 					<HeaderCake onClick={ this.goBack }>{ title }</HeaderCake>


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/23522

According to internal logs, some `calypso_page_view` paths coming from Stats
were reported without replacing passed parameters with corresponding variables,
or removing wrong entries from the route. This was resolved by adding more
restrictive route matching for optional filter and site parameters.

### Testing instructions

1. Set `localStorage.setItem( 'debug', 'calypso:analytics:tracks' )` in the browser console to enable the debug.
2. To reproduce, navigate to `/stats/randomtext` for example.
3. Apply this branch and verify that `/stats/randomtext` is no longer recorded as valid page view path.
4. Try to break it by testing various routes that being with `/stats/`.

Routes to check:
- `/stats`
- `/stats/activity/:site`
- `/stats/day`
- `/stats/insights`
- `/stats/insights/:site`
- `/stats/day/:site`
- `/stats/:module/:site`
- `/stats/day/:module/:site`
- `/stats/post/:post_id/:site`
- `/stats/page/:post_id/:site`
- `/stats/follows/comment/:site`
- `/stats/follows/comment/:page_num/:site`