### PR TITLE
Relaunch the upgrade pricing display test with some tweaks.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -64,8 +64,8 @@ export default {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
-	upgradePricingDisplayV2: {
-		datestamp: '20180305',
+	upgradePricingDisplayV3: {
+		datestamp: '20180402',
 		variations: {
 			original: 50,
 			modified: 50,

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -163,7 +163,7 @@ const WPComGetBillingTimeframe = abtest => {
 		return i18n.translate( '/month, billed annually or biennially' );
 	}
 
-	if ( abtest && abtest( 'upgradePricingDisplayV2' ) === 'modified' ) {
+	if ( abtest && abtest( 'upgradePricingDisplayV3' ) === 'modified' ) {
 		// Note: Don't make this translatable because it's only visible to English-language users
 		return '/month, billed annually';
 	}
@@ -635,7 +635,7 @@ export const PLANS_LIST = {
 				FEATURE_ALL_PERSONAL_FEATURES_JETPACK,
 			] ),
 		getBillingTimeFrame: abtest => {
-			if ( abtest && abtest( 'upgradePricingDisplayV2' ) === 'modified' ) {
+			if ( abtest && abtest( 'upgradePricingDisplayV3' ) === 'modified' ) {
 				// Note: Don't make this translatable because it's only visible to English-language users
 				return '/month, billed monthly';
 			}
@@ -719,7 +719,7 @@ export const PLANS_LIST = {
 			FEATURE_ALL_FREE_FEATURES_JETPACK,
 		],
 		getBillingTimeFrame: abtest => {
-			if ( abtest && abtest( 'upgradePricingDisplayV2' ) === 'modified' ) {
+			if ( abtest && abtest( 'upgradePricingDisplayV3' ) === 'modified' ) {
 				// Note: Don't make this translatable because it's only visible to English-language users
 				return '/month, billed monthly';
 			}
@@ -846,7 +846,7 @@ export const PLANS_LIST = {
 				FEATURE_ALL_PREMIUM_FEATURES_JETPACK,
 			] ),
 		getBillingTimeFrame: abtest => {
-			if ( abtest && abtest( 'upgradePricingDisplayV2' ) === 'modified' ) {
+			if ( abtest && abtest( 'upgradePricingDisplayV3' ) === 'modified' ) {
 				// Note: Don't make this translatable because it's only visible to English-language users
 				return '/month, billed monthly';
 			}

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -133,7 +133,7 @@ class PlanFeaturesHeader extends Component {
 		// Note: Don't make this translatable because it's only visible to English-language users
 		return (
 			<span className="plan-features__header-credit-label">
-				{ site.jetpack ? 'Discount available' : 'Credit available' }
+				{ site.jetpack ? 'Discount' : 'Credit available' }
 			</span>
 		);
 	}
@@ -230,25 +230,6 @@ class PlanFeaturesHeader extends Component {
 			return <div className={ classes } />;
 		}
 
-		if ( discountPrice ) {
-			return (
-				<span className="plan-features__header-price-group">
-					<PlanPrice
-						currencyCode={ currencyCode }
-						rawPrice={ rawPrice }
-						isInSignup={ isInSignup }
-						original
-					/>
-					<PlanPrice
-						currencyCode={ currencyCode }
-						rawPrice={ discountPrice }
-						isInSignup={ isInSignup }
-						discounted
-					/>
-				</span>
-			);
-		}
-
 		if ( relatedMonthlyPlan ) {
 			const originalPrice = relatedMonthlyPlan.raw_price * 12;
 			return (
@@ -264,6 +245,25 @@ class PlanFeaturesHeader extends Component {
 					<PlanPrice
 						currencyCode={ currencyCode }
 						rawPrice={ rawPrice }
+						isInSignup={ isInSignup }
+						discounted
+					/>
+				</span>
+			);
+		}
+
+		if ( discountPrice ) {
+			return (
+				<span className="plan-features__header-price-group">
+					<PlanPrice
+						currencyCode={ currencyCode }
+						rawPrice={ rawPrice }
+						isInSignup={ isInSignup }
+						original
+					/>
+					<PlanPrice
+						currencyCode={ currencyCode }
+						rawPrice={ discountPrice }
 						isInSignup={ isInSignup }
 						discounted
 					/>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -166,7 +166,7 @@ class PlanFeatures extends Component {
 	}
 
 	renderCreditSummary() {
-		const { canPurchase, planProperties, site, sitePlan } = this.props;
+		const { canPurchase, planProperties, site } = this.props;
 
 		return map( planProperties, properties => {
 			const {
@@ -187,7 +187,6 @@ class PlanFeatures extends Component {
 						canPurchase={ canPurchase }
 						currencyCode={ currencyCode }
 						current={ current }
-						currentPlanTitle={ sitePlan.product_name_short }
 						discountPrice={ discountPrice }
 						planTitle={ planConstantObj.getTitle() }
 						planType={ planName }
@@ -813,7 +812,10 @@ export default connect(
 
 		const maxCredits = getMaxCredits( planProperties, ownProps.site.jetpack );
 		const showModifiedPricingDisplay =
-			! isInSignup && !! maxCredits.amount && abtest( 'upgradePricingDisplayV2' ) === 'modified';
+			! isInSignup &&
+			isPaid &&
+			!! maxCredits.amount &&
+			abtest( 'upgradePricingDisplayV3' ) === 'modified';
 
 		return {
 			canPurchase,


### PR DESCRIPTION
Since some errors arose during the latest test, the result is probably corrupted. So we decided to launch the test with some tweaks. This PR will show you credit/discount summaries when you subscribe any paid plan.

*Note: Discount/credits amount may be different.*

## How to test

1. Run `localStorage.setItem( 'ABTests', '{"upgradePricingDisplayV3_20180402": "modified"}' );` to activate the test.
2. Check if the summaries show up when you're on a paid plan as follows.
<img width="969" alt="wpcom-free" src="https://user-images.githubusercontent.com/212034/38322184-a9a1696e-3874-11e8-960f-e156dc06c189.png">
<img width="969" alt="wpcom-personal" src="https://user-images.githubusercontent.com/212034/38322257-e2bfb0de-3874-11e8-8754-ef7419c5b788.png">
<img width="969" alt="wpcom-premium" src="https://user-images.githubusercontent.com/212034/38322200-b40410f0-3874-11e8-96d6-4e17c02d7cf5.png">
<img width="969" alt="jetpack-free-monthly" src="https://user-images.githubusercontent.com/212034/38322286-eee10282-3874-11e8-8b66-6cd10f05fbf9.png">
<img width="969" alt="jetpack-free-yearly" src="https://user-images.githubusercontent.com/212034/38322287-ef07c016-3874-11e8-9012-8ba9ee66e698.png">
<img width="969" alt="jetpack-personal-monthly" src="https://user-images.githubusercontent.com/212034/38322318-034e7f9c-3875-11e8-9bac-39c67f216f10.png">
<img width="969" alt="jetpack-personal-yearly" src="https://user-images.githubusercontent.com/212034/38322193-aee7db06-3874-11e8-9855-314b9b813114.png">
<img width="969" alt="jetpack-premium-yearly" src="https://user-images.githubusercontent.com/212034/38322331-0c0a80b8-3875-11e8-8504-c980fa2a79cf.png">



