### PR TITLE
State: Introduce a getApplicationPasswords selector

### DIFF
--- a/client/state/selectors/get-application-passwords.js
+++ b/client/state/selectors/get-application-passwords.js
@@ -1,0 +1,14 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns the application passwords of the current user.
+ *
+ * @param  {Object} state Global state tree
+ * @return {Array}        Application passwords
+ */
+export default state => get( state, [ 'applicationPasswords', 'items' ], [] );

--- a/client/state/selectors/test/get-application-passwords.js
+++ b/client/state/selectors/test/get-application-passwords.js
@@ -25,7 +25,7 @@ describe( 'getApplicationPasswords()', () => {
 			},
 		};
 		const result = getApplicationPasswords( state );
-		expect( result ).toEqual( appPasswords );
+		expect( result ).toBe( appPasswords );
 	} );
 
 	test( 'should return an empty array with an empty state', () => {

--- a/client/state/selectors/test/get-application-passwords.js
+++ b/client/state/selectors/test/get-application-passwords.js
@@ -28,16 +28,6 @@ describe( 'getApplicationPasswords()', () => {
 		expect( result ).toEqual( appPasswords );
 	} );
 
-	test( 'should return an empty array if no application passwords exist', () => {
-		const state = {
-			applicationPasswords: {
-				items: [],
-			},
-		};
-		const result = getApplicationPasswords( state );
-		expect( result ).toEqual( [] );
-	} );
-
 	test( 'should return an empty array with an empty state', () => {
 		const result = getApplicationPasswords( undefined );
 		expect( result ).toEqual( [] );

--- a/client/state/selectors/test/get-application-passwords.js
+++ b/client/state/selectors/test/get-application-passwords.js
@@ -1,0 +1,45 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getApplicationPasswords } from 'state/selectors';
+
+describe( 'getApplicationPasswords()', () => {
+	test( 'should return application passwords of the current user', () => {
+		const appPasswords = [
+			{
+				ID: 12345,
+				name: 'Example',
+				value: '2018-01-01T00:00:00+00:00',
+			},
+			{
+				ID: 23456,
+				name: 'Test',
+				value: '2018-02-01T08:10:00+00:00',
+			},
+		];
+		const state = {
+			applicationPasswords: {
+				items: appPasswords,
+			},
+		};
+		const result = getApplicationPasswords( state );
+		expect( result ).toEqual( appPasswords );
+	} );
+
+	test( 'should return an empty array if no application passwords exist', () => {
+		const state = {
+			applicationPasswords: {
+				items: [],
+			},
+		};
+		const result = getApplicationPasswords( state );
+		expect( result ).toEqual( [] );
+	} );
+
+	test( 'should return an empty array with an empty state', () => {
+		const result = getApplicationPasswords( undefined );
+		expect( result ).toEqual( [] );
+	} );
+} );


### PR DESCRIPTION
This PR is part of #22912 and introduces a simple selector to fetch the application passwords.

To test, verify the tests pass:

```
npm run test-client client/state/selectors/test/get-application-passwords.js
```