### PR TITLE
State: Introduce a getNewApplicationPassword selector

### DIFF
--- a/client/state/selectors/get-new-application-password.js
+++ b/client/state/selectors/get-new-application-password.js
@@ -1,0 +1,14 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns the application password that the user just created.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {?String}       New application password
+ */
+export default state => get( state, [ 'applicationPasswords', 'newPassword' ], null );

--- a/client/state/selectors/test/get-new-application-password.js
+++ b/client/state/selectors/test/get-new-application-password.js
@@ -1,0 +1,34 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getNewApplicationPassword } from 'state/selectors';
+
+describe( 'getNewApplicationPassword()', () => {
+	test( 'should return the new application password if it exists', () => {
+		const newPassword = 'abcd 1234 efgh 5678';
+		const state = {
+			applicationPasswords: {
+				newPassword,
+			},
+		};
+		const result = getNewApplicationPassword( state );
+		expect( result ).toEqual( newPassword );
+	} );
+
+	test( 'should return null if there is currently no new application password', () => {
+		const state = {
+			applicationPasswords: {
+				newPassword: null,
+			},
+		};
+		const result = getNewApplicationPassword( state );
+		expect( result ).toBeNull();
+	} );
+
+	test( 'should return null with an empty state', () => {
+		const result = getNewApplicationPassword( undefined );
+		expect( result ).toBeNull();
+	} );
+} );

--- a/client/state/selectors/test/get-new-application-password.js
+++ b/client/state/selectors/test/get-new-application-password.js
@@ -17,16 +17,6 @@ describe( 'getNewApplicationPassword()', () => {
 		expect( result ).toBe( newPassword );
 	} );
 
-	test( 'should return null if there is currently no new application password', () => {
-		const state = {
-			applicationPasswords: {
-				newPassword: null,
-			},
-		};
-		const result = getNewApplicationPassword( state );
-		expect( result ).toBeNull();
-	} );
-
 	test( 'should return null with an empty state', () => {
 		const result = getNewApplicationPassword( undefined );
 		expect( result ).toBeNull();

--- a/client/state/selectors/test/get-new-application-password.js
+++ b/client/state/selectors/test/get-new-application-password.js
@@ -14,7 +14,7 @@ describe( 'getNewApplicationPassword()', () => {
 			},
 		};
 		const result = getNewApplicationPassword( state );
-		expect( result ).toEqual( newPassword );
+		expect( result ).toBe( newPassword );
 	} );
 
 	test( 'should return null if there is currently no new application password', () => {


### PR DESCRIPTION
This PR is part of #22912 and introduces a simple selector to fetch the new application password.

To test, verify the tests pass:

```
npm run test-client client/state/selectors/test/get-new-application-password.js
```