### PR TITLE
Store: Add loading placeholder while we determine plugins state

### DIFF
--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -23,6 +23,7 @@ import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isLoaded as arePluginsLoaded } from 'state/plugins/installed/selectors';
 import Main from 'components/main';
+import Placeholder from './dashboard/placeholder';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import RequiredPluginsInstallView from 'woocommerce/app/dashboard/required-plugins-install-view';
 import WooCommerceColophon from 'woocommerce/components/woocommerce-colophon';
@@ -30,11 +31,12 @@ import WooCommerceColophon from 'woocommerce/components/woocommerce-colophon';
 class App extends Component {
 	static propTypes = {
 		siteId: PropTypes.number,
-		documentTitle: PropTypes.string,
 		canUserManageOptions: PropTypes.bool.isRequired,
-		isAtomicSite: PropTypes.bool.isRequired,
-		hasPendingAutomatedTransfer: PropTypes.bool.isRequired,
 		children: PropTypes.element.isRequired,
+		documentTitle: PropTypes.string,
+		hasPendingAutomatedTransfer: PropTypes.bool.isRequired,
+		isAtomicSite: PropTypes.bool.isRequired,
+		isDashboard: PropTypes.bool.isRequired,
 	};
 
 	componentDidMount() {
@@ -80,8 +82,16 @@ class App extends Component {
 
 	renderPlaceholder() {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		if ( this.props.isDashboard ) {
+			return (
+				<Main className="dashboard" wideLayout>
+					<Placeholder />
+				</Main>
+			);
+		}
+
 		return (
-			<Main wideLayout className="woocommerce__placeholder">
+			<Main className="woocommerce__placeholder" wideLayout>
 				<Card className="woocommerce__placeholder-card" />
 			</Main>
 		);

--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -16,11 +16,13 @@ import {
 	isSiteAutomatedTransfer,
 	hasSitePendingAutomatedTransfer,
 } from 'state/selectors';
+import Card from 'components/card';
 import config from 'config';
 import DocumentHead from 'components/data/document-head';
 import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isLoaded as arePluginsLoaded } from 'state/plugins/installed/selectors';
+import Main from 'components/main';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import RequiredPluginsInstallView from 'woocommerce/app/dashboard/required-plugins-install-view';
 import WooCommerceColophon from 'woocommerce/components/woocommerce-colophon';
@@ -76,10 +78,20 @@ class App extends Component {
 		window.location.href = '/stats/day';
 	}
 
+	renderPlaceholder() {
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		return (
+			<Main wideLayout className="woocommerce__placeholder">
+				<Card className="woocommerce__placeholder-card" />
+			</Main>
+		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
+	}
+
 	maybeRenderChildren() {
 		const { allRequiredPluginsActive, children, pluginsLoaded, translate } = this.props;
 		if ( ! pluginsLoaded ) {
-			return null;
+			return this.renderPlaceholder();
 		}
 
 		if ( pluginsLoaded && ! allRequiredPluginsActive ) {

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -196,7 +196,9 @@ function addStorePage( storePage, storeNavigation ) {
 		storeNavigation,
 		( context, next ) => {
 			const component = React.createElement( storePage.container, { params: context.params } );
-			const appProps = {};
+			const appProps = {
+				isDashboard: '/store/:site' === storePage.path,
+			};
 			if ( storePage.documentTitle ) {
 				appProps.documentTitle = storePage.documentTitle;
 			}

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -63,9 +63,23 @@
 
 	.main {
 		padding-top: 35px;
+
 		@include breakpoint( "<660px" ) {
 			padding-top: 72px;
 		}
+	}
+
+	.woocommerce__placeholder {
+		padding-top: 0;
+
+		@include breakpoint( "<660px" ) {
+			padding-top: 16px;
+		}
+	}
+
+	.woocommerce__placeholder-card {
+		@include placeholder();
+		height: 70vh;
 	}
 
 	@include breakpoint( ">660px" ) {


### PR DESCRIPTION
Fixes #23882 – the new plugins check step introduced an extra delay in rendering the page contents, so this PR adds in a simple loading state. It's just one big box, but it shouldn't be shown for very long. I've also used the viewport-height unit so that the "powered by woocommerce" footer is in-view.

<img width="925" alt="screen shot 2018-04-04 at 1 23 52 pm" src="https://user-images.githubusercontent.com/541093/38323799-555ef2a8-380c-11e8-8f03-4d9dd45c638d.png">
<img width="446" alt="screen shot 2018-04-04 at 1 24 09 pm" src="https://user-images.githubusercontent.com/541093/38323800-557de32a-380c-11e8-9ae6-26e8699660d1.png">

This should only be shown on the first load of any store page, navigating between store pages shouldn't trigger this. 

**To test**

- Load any store page
- After calypso finishes loading, you'll see this placeholder before continuing on to the content of the page
- If you're missing plugins, it will show the loading placeholder, then continue into the "fixing" screen, before finally going on to the page you requested