### PR TITLE
State: Persist application passwords

### DIFF
--- a/client/state/application-passwords/reducer.js
+++ b/client/state/application-passwords/reducer.js
@@ -14,10 +14,10 @@ import {
 	APPLICATION_PASSWORD_NEW_CLEAR,
 	APPLICATION_PASSWORDS_RECEIVE,
 } from 'state/action-types';
-import { combineReducers, withSchemaValidation } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import { itemsSchema } from './schema';
 
-export const items = withSchemaValidation( itemsSchema, ( state = [], action ) => {
+export const items = ( state = [], action ) => {
 	switch ( action.type ) {
 		case APPLICATION_PASSWORD_DELETE_SUCCESS:
 			return reject( state, { ID: action.appPasswordId } );
@@ -26,7 +26,8 @@ export const items = withSchemaValidation( itemsSchema, ( state = [], action ) =
 		default:
 			return state;
 	}
-} );
+};
+items.schema = itemsSchema;
 
 export const newPassword = ( state = null, action ) => {
 	switch ( action.type ) {

--- a/client/state/application-passwords/reducer.js
+++ b/client/state/application-passwords/reducer.js
@@ -14,9 +14,10 @@ import {
 	APPLICATION_PASSWORD_NEW_CLEAR,
 	APPLICATION_PASSWORDS_RECEIVE,
 } from 'state/action-types';
-import { combineReducers } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
+import { itemsSchema } from './schema';
 
-export const items = ( state = [], action ) => {
+export const items = withSchemaValidation( itemsSchema, ( state = [], action ) => {
 	switch ( action.type ) {
 		case APPLICATION_PASSWORD_DELETE_SUCCESS:
 			return reject( state, { ID: action.appPasswordId } );
@@ -25,7 +26,7 @@ export const items = ( state = [], action ) => {
 		default:
 			return state;
 	}
-};
+} );
 
 export const newPassword = ( state = null, action ) => {
 	switch ( action.type ) {

--- a/client/state/application-passwords/schema.js
+++ b/client/state/application-passwords/schema.js
@@ -1,0 +1,13 @@
+export const itemsSchema = {
+	type: 'array',
+	items: {
+		type: 'object',
+		properties: {
+			ID: { type: 'integer' },
+			generated: { type: 'string' },
+			name: { type: 'string' },
+		},
+		required: [ 'ID', 'generated', 'name' ],
+		additionalProperties: false,
+	},
+};


### PR DESCRIPTION
This PR is part of #22912 and adds persistence to application passwords.

To test:
* Checkout this branch.
* Load http://calypso.localhost:3000/
* Add some application passwords if you don't have any (from http://calypso.localhost:3000/me/security/two-step)
* Run `state.applicationPasswords.items` in your console - should be empty.
* Run `dispatch( { type: 'APPLICATION_PASSWORDS_REQUEST' } )` in your console and wait for the request to finish.
* Run `state.applicationPasswords.items` in your console - should contain your current app passwords.
* Load http://calypso.localhost:3000/ again.
* Run `state.applicationPasswords.items` in your console - should persist your current app passwords.
* Verify you see no state validation errors.