### PR TITLE
Activity Log: when fixing credentials, send user to autoconfig flow if it's supported

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -36,6 +36,7 @@ import {
 	getRequestedRewind,
 	getSiteGmtOffset,
 	getSiteTimezoneValue,
+	getRewindState,
 } from 'state/selectors';
 import { adjustMoment } from '../activity-log/utils';
 import { getSiteSlug } from 'state/sites/selectors';
@@ -144,19 +145,24 @@ class ActivityLogItem extends Component {
 	 *
 	 * @returns {Object} Get button to fix credentials.
 	 */
-	renderFixCredsAction = () => (
-		<Button
-			className="activity-log-item__quick-action"
-			primary
-			compact
-			href={ `/start/rewind-setup/?siteId=${ this.props.siteId }&siteSlug=${
-				this.props.siteSlug
-			}` }
-			onClick={ this.props.trackFixCreds }
-		>
-			{ this.props.translate( 'Fix credentials' ) }
-		</Button>
-	);
+	renderFixCredsAction = () => {
+		const { rewindState, siteId, siteSlug, trackFixCreds, translate } = this.props;
+		return (
+			<Button
+				className="activity-log-item__quick-action"
+				primary
+				compact
+				href={
+					rewindState.canAutoconfigure
+						? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ siteSlug }`
+						: `/start/rewind-setup/?siteId=${ siteId }&siteSlug=${ siteSlug }`
+				}
+				onClick={ trackFixCreds }
+			>
+				{ translate( 'Fix credentials' ) }
+			</Button>
+		);
+	};
 
 	render() {
 		const {
@@ -256,6 +262,7 @@ const mapStateToProps = ( state, { activityId, siteId } ) => ( {
 	mightRewind: activityId && activityId === getRequestedRewind( state, siteId ),
 	timezone: getSiteTimezoneValue( state, siteId ),
 	siteSlug: getSiteSlug( state, siteId ),
+	rewindState: getRewindState( state, siteId ),
 } );
 
 const mapDispatchToProps = ( dispatch, { activityId, siteId } ) => ( {


### PR DESCRIPTION
Follow up to #23700

Previously the button to fix credentials in a backup error event

<img width="820" alt="captura de pantalla 2018-03-27 a la s 15 07 23" src="https://user-images.githubusercontent.com/1041600/37985968-9d3e79b4-31d0-11e8-98aa-6b430cd50fc4.png">

was always sending users to the flow to add credentials even when the site could be autoconfigured. This is addressed in this PR and now sites that can be autoconfigured are sent to the proper flow.

This PR introduces a small refactor to send the Rewind state instead of the boolean to ActivityLogDay and check if Rewind is active or not. This same Rewind state is later reused and passed to ActivityLogItem because it's necessary to send the user to the correct flow based on whether the site can be autoconfigured.

#### Testing

Force a creds error and use a site that can be autoconfigured and one that can not.
If needed I can add you to a site that has this error already forced and this can be check by tweaking the props with React dev tools.

With this PR:

- this is where user is taken in a site that can be autoconfigured
    ![autoconfig](https://user-images.githubusercontent.com/1041600/38326611-98e08fc2-381c-11e8-84c0-51dcbbaa4c7b.gif)
- this is where user is taken when the site can't be autoconfigured
    ![noautoconfig](https://user-images.githubusercontent.com/1041600/38327391-7eff37d2-381e-11e8-8f2f-ebac3d50991d.gif)
