### PR TITLE
Analytics: PageViewTracker and event properties

### DIFF
--- a/client/lib/analytics/page-view-tracker/README.md
+++ b/client/lib/analytics/page-view-tracker/README.md
@@ -6,6 +6,13 @@ There are two modes of operation: immediate and delayed. In the immediate mode, 
 
 This component is aware of the selected site and, if the current URL contains a site fragment, it will delay the page view recording until the selected site is set or updated.
 
+## Props
+
+* `delay`: time in millisecods to delay the recording of the page view event.
+* `path`: required `String` that represents the path to report as the source of the page view event. It should follow Calypso's [Path Conventions](https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/docs/page-views.md#paths-conventions).
+* `title`: required `String` that represent the page's title. It should follow Calypso's [Title Conventions](https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/docs/page-views.md#titles-conventions).
+* `properties`: optional `Object` with aditional properties that correspond to IDs or variables present on the `path`.
+
 ## Examples
 
 ### Immediate Page View Tracking
@@ -47,4 +54,27 @@ render() {
 		</Main>
 	);
 );
+```
+
+### Reporting Variables
+
+```js
+import PageViewTracker from 'analytics/page-view-tracker';
+
+render() {
+	const { postId, postTile } = this.props;
+
+	return (
+		<Main>
+			<PageViewTracker
+				path="/comments/all/:site/:post_id"
+				title={ `Comments > ${ postTitle }` }
+				properties={ { post_id: postId } }
+			/>
+			<MyCoolComponent>
+				<MyCoolChildren />
+			</MyCoolComponent>
+		</Main>
+	);
+}
 ```

--- a/client/lib/analytics/page-view-tracker/README.md
+++ b/client/lib/analytics/page-view-tracker/README.md
@@ -62,7 +62,7 @@ render() {
 import PageViewTracker from 'analytics/page-view-tracker';
 
 render() {
-	const { postId, postTile } = this.props;
+	const { postId, postTitle } = this.props;
 
 	return (
 		<Main>

--- a/client/lib/analytics/page-view-tracker/index.jsx
+++ b/client/lib/analytics/page-view-tracker/index.jsx
@@ -33,6 +33,7 @@ export class PageViewTracker extends React.Component {
 		hasSelectedSiteLoaded: PropTypes.bool,
 		selectedSiteId: PropTypes.number,
 		title: PropTypes.string.isRequired,
+		properties: PropTypes.object,
 	};
 
 	state = {
@@ -59,7 +60,14 @@ export class PageViewTracker extends React.Component {
 	}
 
 	queuePageView = () => {
-		const { delay = 0, path, recorder = noop, hasSelectedSiteLoaded, title } = this.props;
+		const {
+			delay = 0,
+			path,
+			recorder = noop,
+			hasSelectedSiteLoaded,
+			title,
+			properties,
+		} = this.props;
 
 		debug( `Queuing Page View: "${ title }" at "${ path }" with ${ delay }ms delay` );
 
@@ -68,7 +76,7 @@ export class PageViewTracker extends React.Component {
 		}
 
 		if ( ! delay ) {
-			return recorder( path, title );
+			return recorder( path, title, undefined, properties );
 		}
 
 		this.setState( {

--- a/client/lib/analytics/page-view-tracker/index.jsx
+++ b/client/lib/analytics/page-view-tracker/index.jsx
@@ -76,7 +76,7 @@ export class PageViewTracker extends React.Component {
 		}
 
 		if ( ! delay ) {
-			return recorder( path, title, undefined, properties );
+			return recorder( path, title, 'default', properties );
 		}
 
 		this.setState( {

--- a/client/state/analytics/actions.js
+++ b/client/state/analytics/actions.js
@@ -72,7 +72,7 @@ export const loadTrackingTool = trackingTool => ( {
 		analytics: [
 			{
 				type: ANALYTICS_TRACKING_ON,
-				payload: trackingTool,
+				payload: { trackingTool },
 			},
 		],
 	},
@@ -84,7 +84,7 @@ export const setTracksOptOut = isOptingOut => ( {
 		analytics: [
 			{
 				type: ANALYTICS_TRACKS_OPT_OUT,
-				payload: isOptingOut,
+				payload: { isOptingOut },
 			},
 		],
 	},

--- a/client/state/analytics/actions.js
+++ b/client/state/analytics/actions.js
@@ -102,7 +102,7 @@ export const recordCustomFacebookConversionEvent = ( name, properties ) =>
 export const recordCustomAdWordsRemarketingEvent = properties =>
 	recordEvent( 'adwords', { properties } );
 
-export const recordPageView = ( url, title, service ) => ( {
+export const recordPageView = ( url, title, service, properties = {} ) => ( {
 	type: ANALYTICS_PAGE_VIEW_RECORD,
 	meta: {
 		analytics: [
@@ -112,6 +112,7 @@ export const recordPageView = ( url, title, service ) => ( {
 					service,
 					url,
 					title,
+					...properties,
 				},
 			},
 		],

--- a/client/state/analytics/middleware.js
+++ b/client/state/analytics/middleware.js
@@ -4,7 +4,7 @@
  * @format
  */
 
-import { has, invoke, pick } from 'lodash';
+import { has, invoke, isNil, omitBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,13 +31,10 @@ const eventServices = {
 	adwords: ( { properties } ) => trackCustomAdWordsRemarketingEvent( properties ),
 };
 
-// Whitelists specific parameters to avoid polluting page view events
-const PAGE_VIEW_SERVICES_ALLOWED_PARAMS = [ 'client_id' ];
-
 const pageViewServices = {
 	ga: ( { url, title } ) => analytics.ga.recordPageView( url, title ),
 	default: ( { url, title, ...params } ) =>
-		analytics.pageView.record( url, title, pick( params, PAGE_VIEW_SERVICES_ALLOWED_PARAMS ) ),
+		analytics.pageView.record( url, title, omitBy( params, isNil ) ),
 };
 
 const loadTrackingTool = ( trackingTool, state ) => {

--- a/client/state/analytics/middleware.js
+++ b/client/state/analytics/middleware.js
@@ -44,8 +44,6 @@ const loadTrackingTool = ( { trackingTool }, state ) => {
 
 const statBump = ( { group, name } ) => analytics.mc.bumpStat( group, name );
 
-const setAnonymousUserId = ( { anonId } ) => analytics.tracks.setAnonymousUserId( anonId );
-
 const setOptOut = ( { isOptingOut } ) => analytics.tracks.setOptOut( isOptingOut );
 
 export const dispatcher = ( { meta: { analytics: analyticsMeta } }, state ) => {

--- a/client/state/analytics/middleware.js
+++ b/client/state/analytics/middleware.js
@@ -36,13 +36,17 @@ const pageViewServices = {
 	default: ( { url, title, ...params } ) => analytics.pageView.record( url, title, params ),
 };
 
-const loadTrackingTool = ( trackingTool, state ) => {
+const loadTrackingTool = ( { trackingTool }, state ) => {
 	if ( trackingTool === 'HotJar' && ! isTracking( state, 'HotJar' ) ) {
 		analytics.hotjar.addHotJarScript();
 	}
 };
 
 const statBump = ( { group, name } ) => analytics.mc.bumpStat( group, name );
+
+const setAnonymousUserId = ( { anonId } ) => analytics.tracks.setAnonymousUserId( anonId );
+
+const setOptOut = ( { isOptingOut } ) => analytics.tracks.setOptOut( isOptingOut );
 
 export const dispatcher = ( { meta: { analytics: analyticsMeta } }, state ) => {
 	analyticsMeta.forEach( ( { type, payload } ) => {
@@ -62,7 +66,7 @@ export const dispatcher = ( { meta: { analytics: analyticsMeta } }, state ) => {
 				return loadTrackingTool( params, state );
 
 			case ANALYTICS_TRACKS_OPT_OUT:
-				return analytics.tracks.setOptOut( params );
+				return setOptOut( params );
 		}
 	} );
 };

--- a/client/state/analytics/middleware.js
+++ b/client/state/analytics/middleware.js
@@ -4,7 +4,7 @@
  * @format
  */
 
-import { flowRight, has, invoke, isNil, omit, omitBy, partialRight } from 'lodash';
+import { has, invoke } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,18 +31,9 @@ const eventServices = {
 	adwords: ( { properties } ) => trackCustomAdWordsRemarketingEvent( properties ),
 };
 
-// list of unsafe params that need to be blocked from beign passed down to the recorder.
-const PAGE_VIEW_SERVICES_BLOCKED_PARAMS = [ 'service' ];
-
-const omitUnsafeParams = flowRight(
-	partialRight( omitBy, isNil ),
-	partialRight( omit, PAGE_VIEW_SERVICES_BLOCKED_PARAMS )
-);
-
 const pageViewServices = {
 	ga: ( { url, title } ) => analytics.ga.recordPageView( url, title ),
-	default: ( { url, title, ...params } ) =>
-		analytics.pageView.record( url, title, omitUnsafeParams( params ) ),
+	default: ( { url, title, ...params } ) => analytics.pageView.record( url, title, params ),
 };
 
 const loadTrackingTool = ( trackingTool, state ) => {
@@ -55,23 +46,23 @@ const statBump = ( { group, name } ) => analytics.mc.bumpStat( group, name );
 
 export const dispatcher = ( { meta: { analytics: analyticsMeta } }, state ) => {
 	analyticsMeta.forEach( ( { type, payload } ) => {
-		const { service = 'default' } = payload;
+		const { service = 'default', ...params } = payload;
 
 		switch ( type ) {
 			case ANALYTICS_EVENT_RECORD:
-				return invoke( eventServices, service, payload );
+				return invoke( eventServices, service, params );
 
 			case ANALYTICS_PAGE_VIEW_RECORD:
-				return invoke( pageViewServices, service, payload );
+				return invoke( pageViewServices, service, params );
 
 			case ANALYTICS_STAT_BUMP:
-				return statBump( payload );
+				return statBump( params );
 
 			case ANALYTICS_TRACKING_ON:
-				return loadTrackingTool( payload, state );
+				return loadTrackingTool( params, state );
 
 			case ANALYTICS_TRACKS_OPT_OUT:
-				return analytics.tracks.setOptOut( payload );
+				return analytics.tracks.setOptOut( params );
 		}
 	} );
 };

--- a/client/state/analytics/middleware.js
+++ b/client/state/analytics/middleware.js
@@ -4,7 +4,7 @@
  * @format
  */
 
-import { has, invoke, isNil, omitBy } from 'lodash';
+import { flowRight, has, invoke, isNil, omit, omitBy, partialRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,10 +31,18 @@ const eventServices = {
 	adwords: ( { properties } ) => trackCustomAdWordsRemarketingEvent( properties ),
 };
 
+// list of unsafe params that need to be blocked from beign passed down to the recorder.
+const PAGE_VIEW_SERVICES_BLOCKED_PARAMS = [ 'service' ];
+
+const omitUnsafeParams = flowRight(
+	partialRight( omitBy, isNil ),
+	partialRight( omit, PAGE_VIEW_SERVICES_BLOCKED_PARAMS )
+);
+
 const pageViewServices = {
 	ga: ( { url, title } ) => analytics.ga.recordPageView( url, title ),
 	default: ( { url, title, ...params } ) =>
-		analytics.pageView.record( url, title, omitBy( params, isNil ) ),
+		analytics.pageView.record( url, title, omitUnsafeParams( params ) ),
 };
 
 const loadTrackingTool = ( trackingTool, state ) => {

--- a/client/state/analytics/reducer.js
+++ b/client/state/analytics/reducer.js
@@ -9,7 +9,7 @@ import { ANALYTICS_TRACKING_ON } from 'state/action-types';
 export const analyticsTracking = ( state = {}, { type, meta } ) => {
 	switch ( type ) {
 		case ANALYTICS_TRACKING_ON:
-			return meta.analytics.reduce( ( newState, { payload: trackingTool } ) => {
+			return meta.analytics.reduce( ( newState, { payload: { trackingTool } } ) => {
 				return { ...newState, [ trackingTool ]: true };
 			}, state );
 	}

--- a/client/state/analytics/test/helpers/analytics-mock.js
+++ b/client/state/analytics/test/helpers/analytics-mock.js
@@ -14,6 +14,7 @@ const analyticsMocks = [
 	'tracks.recordEvent',
 	'tracks.recordPageView',
 	'tracks.setOptOut',
+	'hotjar.addHotJarScript',
 ];
 
 const adTrackingMocks = [
@@ -21,7 +22,7 @@ const adTrackingMocks = [
 	'trackCustomFacebookConversionEvent',
 ];
 
-const mockIt = spy => mock => set( {}, mock, () => spy( mock ) );
+const mockIt = spy => mock => set( {}, mock, ( ...args ) => spy( mock, ...args ) );
 
 export const moduleMock = moduleMocks => spy =>
 	moduleMocks.map( mockIt( spy ) ).reduce( ( mocks, mock ) => merge( mocks, mock ), {} );

--- a/client/state/analytics/test/middleware.js
+++ b/client/state/analytics/test/middleware.js
@@ -17,6 +17,7 @@ import {
 	recordTracksEvent,
 	recordPageView,
 	setTracksOptOut,
+	loadTrackingTool,
 } from '../actions';
 import { dispatcher as dispatch } from '../middleware.js';
 import { spy as mockAnalytics } from 'lib/analytics';
@@ -51,55 +52,82 @@ describe( 'middleware', () => {
 		test( 'should call mc.bumpStat', () => {
 			dispatch( bumpStat( 'test', 'value' ) );
 
-			expect( mockAnalytics ).to.have.been.calledWith( 'mc.bumpStat' );
+			expect( mockAnalytics ).to.have.been.calledWithExactly( 'mc.bumpStat', 'test', 'value' );
 		} );
 
 		test( 'should call tracks.recordEvent', () => {
 			dispatch( recordTracksEvent( 'test', { name: 'value' } ) );
 
-			expect( mockAnalytics ).to.have.been.calledWith( 'tracks.recordEvent' );
+			expect( mockAnalytics ).to.have.been.calledWithExactly( 'tracks.recordEvent', 'test', {
+				name: 'value',
+			} );
 		} );
 
 		test( 'should call pageView.record', () => {
-			dispatch( recordPageView( 'path', 'title' ) );
+			dispatch( recordPageView( 'path', 'title', 'default', { name: 'value' } ) );
 
-			expect( mockAnalytics ).to.have.been.calledWith( 'pageView.record' );
+			expect( mockAnalytics ).to.have.been.calledWithExactly( 'pageView.record', 'path', 'title', {
+				name: 'value',
+			} );
 		} );
 
 		test( 'should call ga.recordEvent', () => {
-			dispatch( recordGoogleEvent( 'category', 'action' ) );
+			dispatch( recordGoogleEvent( 'category', 'action', 'label', 'value' ) );
 
-			expect( mockAnalytics ).to.have.been.calledWith( 'ga.recordEvent' );
+			expect( mockAnalytics ).to.have.been.calledWithExactly(
+				'ga.recordEvent',
+				'category',
+				'action',
+				'label',
+				'value'
+			);
 		} );
 
 		test( 'should call ga.recordPageView', () => {
 			dispatch( recordGooglePageView( 'path', 'title' ) );
 
-			expect( mockAnalytics ).to.have.been.calledWith( 'ga.recordPageView' );
+			expect( mockAnalytics ).to.have.been.calledWithExactly(
+				'ga.recordPageView',
+				'path',
+				'title'
+			);
 		} );
 
 		test( 'should call trackCustomFacebookConversionEvent', () => {
 			dispatch( recordCustomFacebookConversionEvent( 'event', { name: 'value' } ) );
 
-			expect( mockAdTracking ).to.have.been.calledWith( 'trackCustomFacebookConversionEvent' );
+			expect( mockAdTracking ).to.have.been.calledWithExactly(
+				'trackCustomFacebookConversionEvent',
+				'event',
+				{ name: 'value' }
+			);
 		} );
 
 		test( 'should call trackCustomAdWordsRemarketingEvent', () => {
 			dispatch( recordCustomAdWordsRemarketingEvent( { name: 'value' } ) );
 
-			expect( mockAdTracking ).to.have.been.calledWith( 'trackCustomAdWordsRemarketingEvent' );
+			expect( mockAdTracking ).to.have.been.calledWithExactly(
+				'trackCustomAdWordsRemarketingEvent',
+				{ name: 'value' }
+			);
 		} );
 
 		test( 'should call analytics events with wrapped actions', () => {
 			dispatch( withAnalytics( bumpStat( 'name', 'value' ), { type: 'TEST_ACTION' } ) );
 
-			expect( mockAnalytics ).to.have.been.calledWith( 'mc.bumpStat' );
+			expect( mockAnalytics ).to.have.been.calledWithExactly( 'mc.bumpStat', 'name', 'value' );
 		} );
 
 		test( 'should call `setOptOut`', () => {
 			dispatch( setTracksOptOut( false ) );
 
-			expect( mockAnalytics ).to.have.been.calledWith( 'tracks.setOptOut' );
+			expect( mockAnalytics ).to.have.been.calledWithExactly( 'tracks.setOptOut', false );
+		} );
+
+		test( 'should call hotjar.addHotJarScript', () => {
+			dispatch( loadTrackingTool( 'HotJar' ), { analyticsTracking: [] } );
+
+			expect( mockAnalytics ).to.have.been.calledWith( 'hotjar.addHotJarScript' );
 		} );
 	} );
 } );

--- a/client/state/analytics/test/reducer.js
+++ b/client/state/analytics/test/reducer.js
@@ -1,0 +1,20 @@
+/** @format */
+
+/**
+ * External Dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal Dependencies
+ */
+import reducer from '../reducer';
+import { loadTrackingTool } from '../actions';
+
+describe( 'reducer', () => {
+	test( 'should turn analytics ON for the specified tracking tool', () => {
+		const state = reducer( {}, loadTrackingTool( 'trackingToolName' ) );
+
+		expect( state ).to.eql( { trackingToolName: true } );
+	} );
+} );


### PR DESCRIPTION
One of the limitation with the `PageViewTracker` component is that it does not support sending named properties along with the `path` and the `title`. That makes using `analytics.pageView.record` the only option when we need to extract parameters from the `url` or `state` to pass for paths like `/checkout/thank-you/:receiptId`.

This PR modifies the `recordPageView` action to add a properties argument that's added to the `payload`. It also changes the handling of that `payload` on the `middleware` from a list of allowed items to a list of blocked items. The assumption is that anything extra is a parameter of the `path`.

Looking for regressions, this change the way we send `client_id` along from https://github.com/Automattic/wp-calypso/pull/20502, so ideally the login page should be tested.

Let the discussion begin.

Pendings:

- [x] Add Tests