### PR TITLE
Activity Log: follow A8c's writing guidelines and use sentence case

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -133,7 +133,7 @@ class ActivityLogItem extends Component {
 			onClick={ this.handleTrackHelp }
 		>
 			<Gridicon icon="chat" size={ 18 } />
-			{ this.props.translate( 'Get Help' ) }
+			{ this.props.translate( 'Get help' ) }
 		</HappychatButton>
 	);
 
@@ -146,7 +146,7 @@ class ActivityLogItem extends Component {
 	 */
 	renderFixCredsAction = () => (
 		<Button
-			className="activity-log-item__fix-creds"
+			className="activity-log-item__quick-action"
 			primary
 			compact
 			href={ `/start/rewind-setup/?siteId=${ this.props.siteId }&siteSlug=${

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -295,11 +295,10 @@
 
 .activity-log-item__help-action {
 	color: $gray;
-	width: 117px;
-	height: 29px;
-	font-weight: normal;
-	font-size: 1.3rem;
-	padding-top: 2px;
+	font-weight: 400;
+	font-size: 13px;
+	white-space: nowrap;
+	padding: 2px 7px 3px;
 
 	@include breakpoint( '<480px' ) {
 		display: block;
@@ -311,6 +310,12 @@
 	margin-right: 5px;
 }
 
-.activity-log-item__fix-creds {
+.button.activity-log-item__quick-action {
+	font-size: 13px;
 	white-space: nowrap;
+
+	@include breakpoint( '<480px' ) {
+		display: table;
+		margin-top: 1.5rem;
+	}
 }


### PR DESCRIPTION
This PR:
- changes `Get Help` to `Get help`, that is, to use sentence case instead of title case for the button label
- updates visual style fo Get help button and makes it consistent with the buttons to take quick actions, like fix credentials. The font size is now 13px, similar to the Rewind button.
- fixes issues with the quick action button in small screens

### Before

<img width="799" alt="captura de pantalla 2018-04-04 a la s 16 30 47" src="https://user-images.githubusercontent.com/1041600/38330023-dcdf7054-3825-11e8-8ccf-4a978232135c.png">

<img width="457" alt="captura de pantalla 2018-04-04 a la s 16 28 02" src="https://user-images.githubusercontent.com/1041600/38330022-dcb3cdfa-3825-11e8-8327-4e42b230a1a0.png">

### After

<img width="705" alt="captura de pantalla 2018-04-04 a la s 16 07 43" src="https://user-images.githubusercontent.com/1041600/38330019-dc5c5b92-3825-11e8-80d2-72cef8fe49bf.png">

<img width="460" alt="captura de pantalla 2018-04-04 a la s 16 27 44" src="https://user-images.githubusercontent.com/1041600/38330021-dc89c71c-3825-11e8-9fd7-c9dc7f55e7f1.png">


For context, please see p9rlnk-cT-activitylog-p2