### PR TITLE
[Domains] Polish search filters, take 2

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -194,7 +194,7 @@ class RegisterDomainStep extends React.Component {
 
 	getInitialFiltersState() {
 		return {
-			excludeDashes: true,
+			includeDashes: false,
 			maxCharacters: '',
 			showExactMatchesOnly: false,
 		};

--- a/client/components/domains/search-filters/index.jsx
+++ b/client/components/domains/search-filters/index.jsx
@@ -17,7 +17,7 @@ import MoreFiltersControl from './more-filters';
 export default class SearchFilters extends Component {
 	static propTypes = {
 		filters: PropTypes.shape( {
-			excludeDashes: PropTypes.bool,
+			includeDashes: PropTypes.bool,
 			maxCharacters: PropTypes.string,
 			showExactMatchesOnly: PropTypes.bool,
 		} ).isRequired,
@@ -45,7 +45,7 @@ export default class SearchFilters extends Component {
 			<div className="search-filters">
 				<MoreFiltersControl
 					{ ...pick( this.props.filters, [
-						'excludeDashes',
+						'includeDashes',
 						'maxCharacters',
 						'showExactMatchesOnly',
 						'onFiltersReset',

--- a/client/components/domains/search-filters/more-filters.jsx
+++ b/client/components/domains/search-filters/more-filters.jsx
@@ -126,11 +126,12 @@ export class MoreFiltersControl extends Component {
 
 		return (
 			<Popover
+				autoPosition={ false }
 				className="search-filters__popover"
 				context={ this.button }
 				isVisible={ this.state.showPopover }
-				position="bottom right"
 				onClose={ this.togglePopover }
+				position="bottom right"
 			>
 				<ValidationFieldset
 					className="search-filters__text-input-fieldset"

--- a/client/components/domains/search-filters/more-filters.jsx
+++ b/client/components/domains/search-filters/more-filters.jsx
@@ -22,7 +22,7 @@ import Button from 'components/button';
 
 export class MoreFiltersControl extends Component {
 	static propTypes = {
-		excludeDashes: PropTypes.bool,
+		includeDashes: PropTypes.bool,
 		maxCharacters: PropTypes.string,
 		onChange: PropTypes.func,
 		onFiltersReset: PropTypes.func,
@@ -32,7 +32,7 @@ export class MoreFiltersControl extends Component {
 
 	static defaultProps = {
 		maxCharacters: '',
-		excludeDashes: true,
+		includeDashes: true,
 		showExactMatchesOnly: false,
 	};
 
@@ -49,7 +49,7 @@ export class MoreFiltersControl extends Component {
 
 	getFiltercounts() {
 		return (
-			( ! this.props.excludeDashes && 1 ) +
+			( this.props.includeDashes && 1 ) +
 			( this.props.showExactMatchesOnly && 1 ) +
 			( this.props.maxCharacters !== '' && 1 )
 		);
@@ -122,7 +122,7 @@ export class MoreFiltersControl extends Component {
 	}
 
 	renderPopover() {
-		const { excludeDashes, maxCharacters, showExactMatchesOnly, translate } = this.props;
+		const { includeDashes, maxCharacters, showExactMatchesOnly, translate } = this.props;
 
 		return (
 			<Popover
@@ -169,18 +169,16 @@ export class MoreFiltersControl extends Component {
 						</span>
 					</FormLabel>
 
-					<FormLabel className="search-filters__label" htmlFor="search-filters-exclude-dashes">
+					<FormLabel className="search-filters__label" htmlFor="search-filters-include-dashes">
 						<FormInputCheckbox
 							className="search-filters__checkbox"
-							checked={ excludeDashes }
-							id="search-filters-exclude-dashes"
-							name="excludeDashes"
+							checked={ includeDashes }
+							id="search-filters-include-dashes"
+							name="includeDashes"
 							onChange={ this.handleOnChange }
-							value="excludeDashes"
+							value="includeDashes"
 						/>
-						<span className="search-filters__checkbox-label">
-							{ translate( 'Exclude dashes' ) }
-						</span>
+						<span className="search-filters__checkbox-label">{ translate( 'Enable dashes' ) }</span>
 					</FormLabel>
 				</FormFieldset>
 

--- a/client/components/domains/search-filters/more-filters.jsx
+++ b/client/components/domains/search-filters/more-filters.jsx
@@ -22,18 +22,12 @@ import Button from 'components/button';
 
 export class MoreFiltersControl extends Component {
 	static propTypes = {
-		includeDashes: PropTypes.bool,
-		maxCharacters: PropTypes.string,
-		onChange: PropTypes.func,
-		onFiltersReset: PropTypes.func,
-		onFiltersSubmit: PropTypes.func,
-		showExactMatchesOnly: PropTypes.bool,
-	};
-
-	static defaultProps = {
-		maxCharacters: '',
-		includeDashes: true,
-		showExactMatchesOnly: false,
+		includeDashes: PropTypes.bool.isRequired,
+		maxCharacters: PropTypes.string.isRequired,
+		onChange: PropTypes.func.isRequired,
+		onFiltersReset: PropTypes.func.isRequired,
+		onFiltersSubmit: PropTypes.func.isRequired,
+		showExactMatchesOnly: PropTypes.bool.isRequired,
 	};
 
 	state = {


### PR DESCRIPTION
Addresses review feedback from [here](https://github.com/Automattic/wp-calypso/pull/23381#pullrequestreview-108100924), where we suggest changing the `Exclude dashes` checkbox (default: checked) to `Enable dashes` checkbox (default: unchecked).

### Testing instructions
1. Spin up this branch locally.
2. Navigate to [`/start/domains`](http://calypso.localhost:3000/start/domains).
3. Ensure presence of the `More Filters` popover button.
4. Ensure that clicking the button spawns a popover with the following controls:
    - Exclude dashes filter, defaulting to unchecked.
5. Ensure that enacting any of the filters by clicking `Apply` refreshes the domain search with a corresponding network request. Two things to note:
    - The results will not actually be filtered since such functionality has not yet been implemented in the server.
    - In its current design, the network request will only contain filter values that are defined. Currently, that means either a true/false boolean or a lengthy string containing numbers.

![wordpress_com](https://user-images.githubusercontent.com/4044428/38338964-10751ea2-3829-11e8-9b09-76085f55d686.png)

6. Ensure that resetting the filters by clicking `Reset` refreshes the domain search results with a corresponding network request.

7. Ensure that no other behavioral changes have been introduced to the page.