### PR TITLE
Reader: fix edit link when post.type is missing

### DIFF
--- a/client/lib/posts/test/utils.js
+++ b/client/lib/posts/test/utils.js
@@ -22,7 +22,7 @@ describe( 'utils', () => {
 				{ ID: 123, type: 'post' },
 				{ slug: 'en.blog.wordpress.com' }
 			);
-			assert( url === '/post/en.blog.wordpress.com/123' );
+			expect( url ).toEqual( '/post/en.blog.wordpress.com/123' );
 		} );
 
 		test( 'should return correct path type=page is supplied', () => {
@@ -30,7 +30,7 @@ describe( 'utils', () => {
 				{ ID: 123, type: 'page' },
 				{ slug: 'en.blog.wordpress.com' }
 			);
-			assert( url === '/page/en.blog.wordpress.com/123' );
+			expect( url ).toEqual( '/page/en.blog.wordpress.com/123' );
 		} );
 
 		test( 'should return correct path when custom post type is supplied', () => {
@@ -38,7 +38,12 @@ describe( 'utils', () => {
 				{ ID: 123, type: 'jetpack-portfolio' },
 				{ slug: 'en.blog.wordpress.com' }
 			);
-			assert( url === '/edit/jetpack-portfolio/en.blog.wordpress.com/123' );
+			expect( url ).toEqual( '/edit/jetpack-portfolio/en.blog.wordpress.com/123' );
+		} );
+
+		test( 'should default to type=post if no post type is supplied', () => {
+			const url = postUtils.getEditURL( { ID: 123, type: '' }, { slug: 'en.blog.wordpress.com' } );
+			expect( url ).toEqual( '/post/en.blog.wordpress.com/123' );
 		} );
 	} );
 

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -15,12 +15,13 @@ import postNormalizer from 'lib/post-normalizer';
 
 export const getEditURL = function( post, site ) {
 	let basePath = '';
+	const postType = post.type || 'post';
 
-	if ( post.type && ! includes( [ 'post', 'page' ], post.type ) ) {
+	if ( ! includes( [ 'post', 'page' ], postType ) ) {
 		basePath = '/edit';
 	}
 
-	return `${ basePath }/${ post.type || 'post' }/${ site.slug }/${ post.ID }`;
+	return `${ basePath }/${ postType || 'post' }/${ site.slug }/${ post.ID }`;
 };
 
 export const getPreviewURL = function( site, post ) {

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -21,7 +21,7 @@ export const getEditURL = function( post, site ) {
 		basePath = '/edit';
 	}
 
-	return `${ basePath }/${ postType || 'post' }/${ site.slug }/${ post.ID }`;
+	return `${ basePath }/${ postType }/${ site.slug }/${ post.ID }`;
 };
 
 export const getPreviewURL = function( site, post ) {

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -16,11 +16,11 @@ import postNormalizer from 'lib/post-normalizer';
 export const getEditURL = function( post, site ) {
 	let basePath = '';
 
-	if ( ! includes( [ 'post', 'page' ], post.type ) ) {
+	if ( post.type && ! includes( [ 'post', 'page' ], post.type ) ) {
 		basePath = '/edit';
 	}
 
-	return `${ basePath }/${ post.type }/${ site.slug }/${ post.ID }`;
+	return `${ basePath }/${ post.type || 'post' }/${ site.slug }/${ post.ID }`;
 };
 
 export const getPreviewURL = function( site, post ) {


### PR DESCRIPTION
@gravityrail noticed that edit links were broken in Reader for posts on their own Jetpack site (#23644).

It appears that `post.type` can be empty in this case:

<img width="704" alt="screen shot 2018-04-05 at 12 25 23 pm" src="https://user-images.githubusercontent.com/17325/38341800-8b02f5ea-38ce-11e8-9ad9-fea584371b84.png">

The helper `getEditURL` assumes the post type is always supplied, so we get an incorrect URL.

This PR adds a sensible default to `getEditURL` - if the post.type is empty, assume the type is 'post'.

Fixes #23644.

### To test

Follow a Jetpack site that you own in Reader. Find the feed, and try the 'Edit' button in the post options menu, or on the full post:

<img width="885" alt="screen shot 2018-04-05 at 12 43 07 pm" src="https://user-images.githubusercontent.com/17325/38341871-f8d41068-38ce-11e8-8dc6-aa1be3dbd3ac.png">

<img width="779" alt="screen shot 2018-04-05 at 12 44 10 pm" src="https://user-images.githubusercontent.com/17325/38341895-1162d2ea-38cf-11e8-8dd8-be4d3353cae6.png">

On clicking the edit button, make sure you are shown the editor for the correct post:

<img width="988" alt="screen shot 2018-04-05 at 12 43 22 pm" src="https://user-images.githubusercontent.com/17325/38341909-2a58386c-38cf-11e8-8b0a-bef35b91f9d7.png">

You can also run the tests with:

`npm run test-client client/lib/posts`