### PR TITLE
Components: Introduce a QueryApplicationPasswords query component

### DIFF
--- a/client/components/data/query-application-passwords/README.md
+++ b/client/components/data/query-application-passwords/README.md
@@ -1,0 +1,18 @@
+Query Application Passwords
+===========================
+
+`<QueryApplicationPasswords />` is a React component used to request the application passwords of the current user.
+
+## Usage
+
+Render the component without props. It does not accept any children, nor does it render any elements to the page.
+
+```jsx
+import QueryApplicationPasswords from 'components/data/query-application-passwords';
+
+export default () => (
+	<div>
+		<QueryApplicationPasswords />
+	</div>
+);
+```

--- a/client/components/data/query-application-passwords/index.jsx
+++ b/client/components/data/query-application-passwords/index.jsx
@@ -1,0 +1,29 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestApplicationPasswords } from 'state/application-passwords/actions';
+
+class QueryApplicationPasswords extends Component {
+	static propTypes = {
+		requestApplicationPasswords: PropTypes.func,
+	};
+
+	componentDidMount() {
+		this.props.requestApplicationPasswords();
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect( null, { requestApplicationPasswords } )( QueryApplicationPasswords );


### PR DESCRIPTION
This PR introduces a `QueryApplicationPasswords` query component that we can use to request the application passwords of the current user.

Part of #22912.

To test:
* Checkout this branch
* Drop this component somewhere
* Observe the right actions are being dispatched upon render, along with the expected network request:
  * `APPLICATION_PASSWORDS_REQUEST`
  * HTTP request to fetch the application passwords
  * `APPLICATION_PASSWORDS_RECEIVE` with the application passwords