### PR TITLE
Components: Add Generic Query Component

### DIFF
--- a/client/components/data/query/index.jsx
+++ b/client/components/data/query/index.jsx
@@ -1,0 +1,59 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { values } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import compareProps from 'lib/compare-props';
+import { getRequest } from 'state/selectors';
+
+class Query extends PureComponent {
+	static propTypes = {
+		compareOptions: PropTypes.object,
+		requestAction: PropTypes.func.isRequired,
+		requesting: PropTypes.bool.isRequired,
+	};
+
+	componentWillMount() {
+		this.comparator = compareProps( {
+			ignore: [ 'compareOptions', 'requestAction', 'requesting' ],
+			...this.props.compareOptions,
+		} );
+		this.request( this.props );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( ! this.comparator( this.props, nextProps ) ) {
+			this.request( nextProps );
+		}
+	}
+
+	// eslint-disable-next-line no-unused-vars
+	request( { compareOptions, requestAction, requesting, ...props } ) {
+		if ( requesting ) {
+			return;
+		}
+
+		requestAction( ...values( props ) );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	// eslint-disable-next-line no-unused-vars
+	( state, { compareOptions, requestAction, ...props } ) => ( {
+		requesting: !! getRequest( state, requestAction( ...values( props ) ) ).isLoading,
+	} ),
+	( dispatch, { requestAction } ) => bindActionCreators( { requestAction }, dispatch )
+)( Query );

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -16,7 +16,7 @@ import config from 'config';
 import DocumentHead from 'components/data/document-head';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QueryJetpackOnboardingSettings from 'components/data/query-jetpack-onboarding-settings';
+import Query from 'components/data/query';
 import QuerySites from 'components/data/query-sites';
 import Wizard from 'components/wizard';
 import WordPressLogo from 'components/wordpress-logo';
@@ -38,7 +38,7 @@ import {
 } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, isRequestingSite, isRequestingSites } from 'state/sites/selectors';
-import { saveJetpackSettings } from 'state/jetpack-onboarding/actions';
+import { requestJetpackSettings, saveJetpackSettings } from 'state/jetpack-onboarding/actions';
 import { setSelectedSiteId } from 'state/ui/actions';
 
 class JetpackOnboardingMain extends React.PureComponent {
@@ -164,7 +164,12 @@ class JetpackOnboardingMain extends React.PureComponent {
 				   * the site is a connected Jetpack site or not, and a network request that uses
 				   * the wrong argument can mess up our request tracking quite badly. */
 				this.state.hasFinishedRequestingSite && (
-					<QueryJetpackOnboardingSettings query={ jpoAuth } siteId={ siteId } />
+					<Query
+						compareOptions={ { deep: [ 'query' ] } }
+						requestAction={ requestJetpackSettings }
+						siteId={ siteId }
+						query={ jpoAuth }
+					/>
 				) }
 				{ siteId ? (
 					<Wizard


### PR DESCRIPTION
New attempt at a somewhat generic, data-layer based query component. Meant to serve as another iteration on the query component pattern, possibly facilitating future migrations (easier codemodding?) WIP.

TODO:
* Test if this actually works
* Drop deprecated lifecycle methods, use new ones: https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html
* README