### PR TITLE
CSS: Replace the 1600px breakpoint with 1400px

### DIFF
--- a/assets/stylesheets/shared/mixins/_breakpoints.scss
+++ b/assets/stylesheets/shared/mixins/_breakpoints.scss
@@ -3,7 +3,7 @@
 // See https://wpcalypso.wordpress.com/devdocs/docs/coding-guidelines/css.md#media-queries
 // ==========================================================================
 
-$breakpoints: 480px, 660px, 960px, 1040px, 1280px, 1600px; // Think very carefully before adding a new breakpoint
+$breakpoints: 480px, 660px, 960px, 1040px, 1280px, 1400px; // Think very carefully before adding a new breakpoint
 
 @mixin breakpoint( $sizes... ){
 	@each $size in $sizes {

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -250,7 +250,7 @@
 			padding: 0 16px 16px 0;
 		}
 
-		@media ( min-width: 1400px ) {
+		@include breakpoint( '>1400px' ) {
 			&.right,
 			&.alignright {
 				position: absolute;
@@ -259,7 +259,7 @@
 			}
 		}
 
-		@media ( max-width: 1400px ) {
+		@include breakpoint( '<1400px' ) {
 			&.right,
 			&.alignright,
 			&.left,

--- a/client/my-sites/themes/themes-banner/style.scss
+++ b/client/my-sites/themes/themes-banner/style.scss
@@ -59,7 +59,7 @@
 		top: 0;
 		right: 0;
 
-		@media (max-width: 1440px) {
+		@include breakpoint( '<1400px' ) {
 			opacity: 0.5;
 		}
 	}


### PR DESCRIPTION
This PR replaces the 1600px breakpoint which is never used, with one at 1400px, and then updates our media queries which target this breakpoint to use the breakpoint mixin.

To test:
1. Go to http://calypso.localhost:3000/read/blogs/53424024/posts/32956
2. Ensure that the layout looks like this at <1400px
<img width="807" alt="screen shot 2018-04-05 at 10 29 50" src="https://user-images.githubusercontent.com/275961/38358433-20468ad4-38bd-11e8-8157-59bc73c43dfa.png">
3. Ensure that the layout looks like this at >1400px
<img width="965" alt="screen shot 2018-04-05 at 10 30 43" src="https://user-images.githubusercontent.com/275961/38358453-2bf2e9fe-38bd-11e8-9db5-98cf179f2d37.png">

4. Go to http://calypso.localhost:3000/themes 

5. Ensure that the image in this banner has 50% opactity at <1400px
<img width="921" alt="screen shot 2018-04-05 at 10 23 07" src="https://user-images.githubusercontent.com/275961/38358545-6f0bf1ea-38bd-11e8-9113-42158d5e61bc.png">
