### PR TITLE
Fixed: sign up flows broken in IE11

### DIFF
--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -20,6 +20,7 @@ import sections from './sections';
 receiveSections( sections );
 
 const _loadedSections = {};
+let _lastSectionName = '';
 
 function activateSection( sectionDefinition, context, next ) {
 	const dispatch = context.store.dispatch;
@@ -37,9 +38,12 @@ function createPageDefinition( path, sectionDefinition ) {
 		const envId = sectionDefinition.envId;
 		const dispatch = context.store.dispatch;
 
+		_lastSectionName = sectionDefinition.name;
+
 		if ( envId && envId.indexOf( config( 'env_id' ) ) === -1 ) {
 			return next();
 		}
+
 		if ( _loadedSections[ sectionDefinition.module ] ) {
 			return activateSection( sectionDefinition, context, next );
 		}
@@ -60,7 +64,9 @@ function createPageDefinition( path, sectionDefinition ) {
 					requiredModules.forEach( mod => mod.default( controller.clientRouter ) );
 					_loadedSections[ sectionDefinition.module ] = true;
 				}
-				return activateSection( sectionDefinition, context, next );
+				return _lastSectionName === sectionDefinition.name
+					? activateSection( sectionDefinition, context, next )
+					: Promise.resolve();
 			} )
 			.catch( error => {
 				console.error( error ); // eslint-disable-line


### PR DESCRIPTION
When you try to sign up WordPress.com using IE11, you may find the broken domain step as reported in #23662. This PR will add a workaround for the problem.

## How to test

Try to sign up WordPress.com using IE11. You should not have any problems on that.