### PR TITLE
CSS: Add a breakpoint at 800px

### DIFF
--- a/assets/stylesheets/shared/mixins/_breakpoints.scss
+++ b/assets/stylesheets/shared/mixins/_breakpoints.scss
@@ -3,7 +3,7 @@
 // See https://wpcalypso.wordpress.com/devdocs/docs/coding-guidelines/css.md#media-queries
 // ==========================================================================
 
-$breakpoints: 480px, 660px, 960px, 1040px, 1280px, 1400px; // Think very carefully before adding a new breakpoint
+$breakpoints: 480px, 660px, 800px, 960px, 1040px, 1280px, 1400px; // Think very carefully before adding a new breakpoint
 
 @mixin breakpoint( $sizes... ){
 	@each $size in $sizes {

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -38,13 +38,13 @@
 			left: inherit;
 			width: 400px;
 
-			@media screen and (max-width: 799px) {
-		    left: 0;
+			@include breakpoint( '<800px' ) {
+		    	left: 0;
 				width: auto;
 		  }
 	}
 
-	@media screen and (max-width: 799px) {
+	@include breakpoint( '<800px' ) {
 		&.wpnc__main header {
 			top: 47px;
 		}


### PR DESCRIPTION
This PR adds a new breakpoint at 800px, so that we can remove our custom media queries and replace them with the breakpoint mixin

To test, open up your notifications panel and ensure that when the screen is between 660px and 800px the single notification view looks like this:
<img width="792" alt="screen shot 2018-04-05 at 11 18 22" src="https://user-images.githubusercontent.com/275961/38360974-bd904068-38c3-11e8-9bde-98f35459f811.png">

And above 800px it looks like this:
<img width="877" alt="screen shot 2018-04-05 at 11 18 34" src="https://user-images.githubusercontent.com/275961/38360979-c4d1e138-38c3-11e8-85da-354b3361a037.png">
