### PR TITLE
Me: Update ApplicationPasswords to use Redux and cleanup

### DIFF
--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -13,35 +13,19 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import { errorNotice } from 'state/notices/actions';
+import { deleteApplicationPassword } from 'state/application-passwords/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 class ApplicationPasswordsItem extends React.Component {
-	state = {
-		removingPassword: false,
-	};
-
 	handleRemovePasswordButtonClick = () => {
+		const { password } = this.props;
+
 		this.props.recordGoogleEvent( 'Me', 'Clicked on Remove Application Password Button' );
-		this.removeApplicationPassword();
+		this.props.deleteApplicationPassword( parseInt( password.ID, 10 ) );
 	};
-
-	removeApplicationPassword() {
-		this.setState( { removingPassword: true } );
-
-		this.props.appPasswordsData.revoke( parseInt( this.props.password.ID, 10 ), error => {
-			if ( error && 'unknown_application_password' !== error.error ) {
-				this.setState( { removingPassword: false } );
-				this.props.errorNotice(
-					this.props.translate(
-						'The application password was not successfully deleted. Please try again.'
-					)
-				);
-			}
-		} );
-	}
 
 	render() {
-		const password = this.props.password;
+		const { password } = this.props;
 
 		return (
 			<li className="application-password-item__password" key={ password.ID }>
@@ -66,6 +50,7 @@ class ApplicationPasswordsItem extends React.Component {
 }
 
 export default connect( null, {
+	deleteApplicationPassword,
 	errorNotice,
 	recordGoogleEvent,
 } )( localize( ApplicationPasswordsItem ) );

--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -21,7 +21,7 @@ class ApplicationPasswordsItem extends React.Component {
 		const { password } = this.props;
 
 		this.props.recordGoogleEvent( 'Me', 'Clicked on Remove Application Password Button' );
-		this.props.deleteApplicationPassword( parseInt( password.ID, 10 ) );
+		this.props.deleteApplicationPassword( password.ID );
 	};
 
 	render() {

--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -25,15 +25,15 @@ class ApplicationPasswordsItem extends React.Component {
 	};
 
 	render() {
-		const { password } = this.props;
+		const { moment, password, translate } = this.props;
 
 		return (
 			<li className="application-password-item__password" key={ password.ID }>
 				<div className="application-password-item__details">
 					<h2 className="application-password-item__name">{ password.name }</h2>
 					<p className="application-password-item__generated">
-						{ this.props.translate( 'Generated on %s', {
-							args: this.props.moment( password.generated ).format( 'lll' ),
+						{ translate( 'Generated on %s', {
+							args: moment( password.generated ).format( 'lll' ),
 						} ) }
 					</p>
 				</div>

--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -12,8 +12,8 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
-import { errorNotice } from 'state/notices/actions';
 import { deleteApplicationPassword } from 'state/application-passwords/actions';
+import { errorNotice } from 'state/notices/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 class ApplicationPasswordsItem extends React.Component {

--- a/client/me/application-passwords/README.md
+++ b/client/me/application-passwords/README.md
@@ -1,4 +1,4 @@
-Application Password Item JSX
+Application Passwords JSX
 =======
 
-`application-passwords` renders a list of application passwords by interacting with the `application-passwords-data` module. It's meant to be used as a child component for the `/me/security` route component located at `me/settings/security`.
+`application-passwords` renders a list of application passwords. It's meant to be used as a child component for the `/me/security` route component located at `me/settings/security`.

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -176,9 +176,9 @@ class ApplicationPasswords extends Component {
 			<div className="application-passwords__active">
 				<FormSectionHeading>{ translate( 'Active Passwords' ) }</FormSectionHeading>
 				<ul className="application-passwords__list">
-					{ appPasswords.map( function( password ) {
-						return <AppPasswordItem password={ password } key={ password.ID } />;
-					}, this ) }
+					{ appPasswords.map( password => (
+						<AppPasswordItem password={ password } key={ password.ID } />
+					) ) }
 				</ul>
 			</div>
 		);

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -4,6 +4,8 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import classNames from 'classnames';
+import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -13,7 +15,6 @@ import { connect } from 'react-redux';
 import AppPasswordItem from 'me/application-password-item';
 import SectionHeader from 'components/section-header';
 import Button from 'components/button';
-import Gridicon from 'gridicons';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormTextInput from 'components/forms/form-text-input';
 import FormLabel from 'components/forms/form-label';
@@ -21,7 +22,6 @@ import FormButton from 'components/forms/form-button';
 import FormButtonsBar from 'components/forms/form-buttons-bar';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import Card from 'components/card';
-import classNames from 'classnames';
 import QueryApplicationPasswords from 'components/data/query-application-passwords';
 import {
 	clearNewApplicationPassword,

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -3,9 +3,7 @@
 /**
  * External dependencies
  */
-
-import React from 'react';
-import createReactClass from 'create-react-class';
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -32,24 +30,22 @@ import {
 import { getApplicationPasswords, getNewApplicationPassword } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
-const ApplicationPasswords = createReactClass( {
-	displayName: 'ApplicationPasswords',
+class ApplicationPasswords extends Component {
+	initialState = {
+		applicationName: '',
+		addingPassword: false,
+		submittingForm: false,
+	};
 
-	getInitialState: function() {
-		return {
-			applicationName: '',
-			addingPassword: false,
-			submittingForm: false,
-		};
-	},
+	state = this.initialState;
 
-	componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps( nextProps ) {
 		if ( this.state.submittingForm && ! this.props.newAppPassword && !! nextProps.newAppPassword ) {
 			this.setState( { submittingForm: false } );
 		}
-	},
+	}
 
-	getClickHandler( action, callback ) {
+	getClickHandler = ( action, callback ) => {
 		return event => {
 			this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
 
@@ -57,30 +53,34 @@ const ApplicationPasswords = createReactClass( {
 				callback( event );
 			}
 		};
-	},
+	};
 
-	handleApplicationNameFocus() {
+	handleApplicationNameFocus = () => {
 		this.props.recordGoogleEvent( 'Me', 'Focused on Application Name Field' );
-	},
+	};
 
-	createApplicationPassword: function( event ) {
+	createApplicationPassword = event => {
 		event.preventDefault();
 		this.setState( { submittingForm: true } );
-
 		this.props.createApplicationPassword( this.state.applicationName );
-	},
+	};
 
-	clearNewApplicationPassword: function() {
+	clearNewApplicationPassword = () => {
 		this.props.clearNewApplicationPassword();
-		this.setState( this.getInitialState() );
-	},
+		this.setState( this.initialState );
+	};
 
-	toggleNewPassword: function( e ) {
-		e.preventDefault();
+	toggleNewPassword = event => {
+		event.preventDefault();
 		this.setState( { addingPassword: ! this.state.addingPassword } );
-	},
+	};
 
-	renderNewAppPasswordForm: function() {
+	handleChange = event => {
+		const { name, value } = event.currentTarget;
+		this.setState( { [ name ]: value } );
+	};
+
+	renderNewAppPasswordForm() {
 		const { appPasswords } = this.props;
 		const cardClasses = classNames( 'application-passwords__add-new-card', {
 			'is-visible': this.state.addingPassword,
@@ -132,9 +132,9 @@ const ApplicationPasswords = createReactClass( {
 				</form>
 			</Card>
 		);
-	},
+	}
 
-	renderNewAppPassword: function() {
+	renderNewAppPassword() {
 		const { newAppPassword } = this.props;
 		return (
 			<Card className="application-passwords__new-password">
@@ -166,9 +166,9 @@ const ApplicationPasswords = createReactClass( {
 				</FormButtonsBar>
 			</Card>
 		);
-	},
+	}
 
-	renderApplicationPasswords: function() {
+	renderApplicationPasswords() {
 		const { appPasswords } = this.props;
 		if ( ! appPasswords.length ) {
 			return null;
@@ -184,9 +184,9 @@ const ApplicationPasswords = createReactClass( {
 				</ul>
 			</div>
 		);
-	},
+	}
 
-	render: function() {
+	render() {
 		const { newAppPassword } = this.props;
 
 		return (
@@ -222,13 +222,8 @@ const ApplicationPasswords = createReactClass( {
 				</Card>
 			</div>
 		);
-	},
-
-	handleChange( e ) {
-		const { name, value } = e.currentTarget;
-		this.setState( { [ name ]: value } );
-	},
-} );
+	}
+}
 
 export default connect(
 	state => ( {

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -81,7 +81,7 @@ class ApplicationPasswords extends Component {
 	};
 
 	renderNewAppPasswordForm() {
-		const { appPasswords } = this.props;
+		const { appPasswords, translate } = this.props;
 		const cardClasses = classNames( 'application-passwords__add-new-card', {
 			'is-visible': this.state.addingPassword,
 		} );
@@ -94,9 +94,7 @@ class ApplicationPasswords extends Component {
 					onSubmit={ this.createApplicationPassword }
 				>
 					<FormFieldset>
-						<FormLabel htmlFor="application-name">
-							{ this.props.translate( 'Application Name' ) }
-						</FormLabel>
+						<FormLabel htmlFor="application-name">{ translate( 'Application Name' ) }</FormLabel>
 						<FormTextInput
 							className="application-passwords__add-new-field"
 							disabled={ this.state.submittingForm }
@@ -114,8 +112,8 @@ class ApplicationPasswords extends Component {
 							onClick={ this.getClickHandler( 'Generate New Application Password Button' ) }
 						>
 							{ this.state.submittingForm
-								? this.props.translate( 'Generating Password…' )
-								: this.props.translate( 'Generate Password' ) }
+								? translate( 'Generating Password…' )
+								: translate( 'Generate Password' ) }
 						</FormButton>
 						{ appPasswords.length ? (
 							<FormButton
@@ -125,7 +123,7 @@ class ApplicationPasswords extends Component {
 									this.toggleNewPassword
 								) }
 							>
-								{ this.props.translate( 'Cancel' ) }
+								{ translate( 'Cancel' ) }
 							</FormButton>
 						) : null }
 					</FormButtonsBar>
@@ -135,13 +133,13 @@ class ApplicationPasswords extends Component {
 	}
 
 	renderNewAppPassword() {
-		const { newAppPassword } = this.props;
+		const { newAppPassword, translate } = this.props;
 		return (
 			<Card className="application-passwords__new-password">
 				<p className="application-passwords__new-password-display">{ newAppPassword }</p>
 
 				<p className="application-passwords__new-password-help">
-					{ this.props.translate(
+					{ translate(
 						'Use this password to log in to {{strong}}%(appName)s{{/strong}}. Note: spaces are ignored.',
 						{
 							args: {
@@ -161,7 +159,7 @@ class ApplicationPasswords extends Component {
 							this.clearNewApplicationPassword
 						) }
 					>
-						{ this.props.translate( 'Done' ) }
+						{ translate( 'Done' ) }
 					</FormButton>
 				</FormButtonsBar>
 			</Card>
@@ -169,14 +167,14 @@ class ApplicationPasswords extends Component {
 	}
 
 	renderApplicationPasswords() {
-		const { appPasswords } = this.props;
+		const { appPasswords, translate } = this.props;
 		if ( ! appPasswords.length ) {
 			return null;
 		}
 
 		return (
 			<div className="application-passwords__active">
-				<FormSectionHeading>{ this.props.translate( 'Active Passwords' ) }</FormSectionHeading>
+				<FormSectionHeading>{ translate( 'Active Passwords' ) }</FormSectionHeading>
 				<ul className="application-passwords__list">
 					{ appPasswords.map( function( password ) {
 						return <AppPasswordItem password={ password } key={ password.ID } />;
@@ -187,13 +185,13 @@ class ApplicationPasswords extends Component {
 	}
 
 	render() {
-		const { newAppPassword } = this.props;
+		const { newAppPassword, translate } = this.props;
 
 		return (
 			<div>
 				<QueryApplicationPasswords />
 
-				<SectionHeader label={ this.props.translate( 'Application Passwords' ) }>
+				<SectionHeader label={ translate( 'Application Passwords' ) }>
 					<Button
 						compact
 						onClick={ this.getClickHandler(
@@ -204,14 +202,14 @@ class ApplicationPasswords extends Component {
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 						<Gridicon icon="plus-small" size={ 16 } />
 						{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
-						{ this.props.translate( 'Add New Application Password' ) }
+						{ translate( 'Add New Application Password' ) }
 					</Button>
 				</SectionHeader>
 				<Card>
 					{ newAppPassword ? this.renderNewAppPassword() : this.renderNewAppPasswordForm() }
 
 					<p>
-						{ this.props.translate(
+						{ translate(
 							'With Two-Step Authentication active, you can generate a custom password for ' +
 								'each third-party application you authorize to use your WordPress.com account. ' +
 								'You can revoke access for an individual application here if you ever need to.'

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -31,13 +31,13 @@ import { getApplicationPasswords, getNewApplicationPassword } from 'state/select
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 class ApplicationPasswords extends Component {
-	initialState = {
+	static initialState = Object.freeze( {
 		applicationName: '',
 		addingPassword: false,
 		submittingForm: false,
-	};
+	} );
 
-	state = this.initialState;
+	state = this.constructor.initialState;
 
 	componentWillReceiveProps( nextProps ) {
 		if ( this.state.submittingForm && ! this.props.newAppPassword && !! nextProps.newAppPassword ) {
@@ -67,7 +67,7 @@ class ApplicationPasswords extends Component {
 
 	clearNewApplicationPassword = () => {
 		this.props.clearNewApplicationPassword();
-		this.setState( this.initialState );
+		this.setState( this.constructor.initialState );
 	};
 
 	toggleNewPassword = event => {

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
@@ -188,7 +188,7 @@ class ApplicationPasswords extends Component {
 		const { newAppPassword, translate } = this.props;
 
 		return (
-			<div>
+			<Fragment>
 				<QueryApplicationPasswords />
 
 				<SectionHeader label={ translate( 'Application Passwords' ) }>
@@ -218,7 +218,7 @@ class ApplicationPasswords extends Component {
 
 					{ this.renderApplicationPasswords() }
 				</Card>
-			</div>
+			</Fragment>
 		);
 	}
 }

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -6,23 +6,23 @@
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import AppPasswordItem from 'me/application-password-item';
-import SectionHeader from 'components/section-header';
 import Button from 'components/button';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormTextInput from 'components/forms/form-text-input';
-import FormLabel from 'components/forms/form-label';
+import Card from 'components/card';
 import FormButton from 'components/forms/form-button';
 import FormButtonsBar from 'components/forms/form-buttons-bar';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
 import FormSectionHeading from 'components/forms/form-section-heading';
-import Card from 'components/card';
+import FormTextInput from 'components/forms/form-text-input';
 import QueryApplicationPasswords from 'components/data/query-application-passwords';
+import SectionHeader from 'components/section-header';
 import {
 	clearNewApplicationPassword,
 	createApplicationPassword,

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -7,8 +7,6 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
-import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:application-passwords' );
 import { connect } from 'react-redux';
 
 /**
@@ -36,14 +34,6 @@ import { recordGoogleEvent } from 'state/analytics/actions';
 
 const ApplicationPasswords = createReactClass( {
 	displayName: 'ApplicationPasswords',
-
-	componentDidMount: function() {
-		debug( this.displayName + ' React component is mounted.' );
-	},
-
-	componentWillUnmount: function() {
-		debug( this.displayName + ' React component is unmounting.' );
-	},
 
 	getInitialState: function() {
 		return {

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -14,9 +14,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-/* eslint-disable no-restricted-imports */
-import observe from 'lib/mixins/data-observe';
-/* eslint-enable no-restricted-imports */
 import AppPasswordItem from 'me/application-password-item';
 import SectionHeader from 'components/section-header';
 import Button from 'components/button';
@@ -39,7 +36,6 @@ import { recordGoogleEvent } from 'state/analytics/actions';
 
 const ApplicationPasswords = createReactClass( {
 	displayName: 'ApplicationPasswords',
-	mixins: [ observe( 'appPasswordsData' ) ],
 
 	componentDidMount: function() {
 		debug( this.displayName + ' React component is mounted.' );

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -18,7 +18,6 @@ import accountPasswordData from 'lib/account-password-data';
 import SocialLoginComponent from 'me/social-login';
 import ConnectedAppsComponent from 'me/connected-applications';
 import connectedAppsData from 'lib/connected-applications-data';
-import appPasswordsData from 'lib/application-passwords-data';
 import AccountRecoveryComponent from 'me/security-account-recovery';
 
 export default {
@@ -45,7 +44,6 @@ export default {
 		context.primary = React.createElement( TwoStepComponent, {
 			userSettings: userSettings,
 			path: context.path,
-			appPasswordsData: appPasswordsData,
 		} );
 		next();
 	},

--- a/client/me/two-step/index.jsx
+++ b/client/me/two-step/index.jsx
@@ -137,7 +137,7 @@ class TwoStep extends Component {
 			return null;
 		}
 
-		return <AppPasswords appPasswordsData={ this.props.appPasswordsData } />;
+		return <AppPasswords />;
 	};
 
 	renderBackupCodes = () => {


### PR DESCRIPTION
Now that the Redux infrastructure for application passwords is laid out (see #22912), it's time to actually use it. This PR updates `ApplicationPasswords` and the child `ApplicationPasswordsItem` to use Redux. It also uses the occasion to clean up a bit, because otherwise we'd end up having a bunch of ESLint errors.

A detailed list of the refactors this PR suggests is:

* Use Redux app passwords in `ApplicationPasswords`.
* Use Redux app passwords in `ApplicationPasswordsItem`.
* Remove the `appPasswordsData` usage completely.
* Remove the last used `observe` mixin from the `ApplicationPasswords` component.
* Convert `ApplicationPasswords` to a `React.Component`.
* Clean up the unnecessary `debug` from `ApplicationPasswords`.
* Destructure props where that makes sense.
* Sort and reorder imports.
* Remove notices (these have already been implemented in the corresponding data layer).
* Remove other unnecessary code.
* Clean up the READMEs to remove any occurrences of `appPasswordsData`.

There basically shouldn't be any visual/behavioral changes to how the application passwords work for the user.

Part of #22912.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/me/security/two-step
* Verify the current app passwords are loaded properly.
* Try adding and deleting some app passwords, verify everything works properly.
* Interact with all controls in the "Application Passwords" section and try different things, verify everything works properly.