### PR TITLE
Analytics: restructure documentation

### DIFF
--- a/client/lib/analytics/README.md
+++ b/client/lib/analytics/README.md
@@ -7,118 +7,21 @@ Turn on debugging in the JavaScript developer console to view calls being made w
 
 `localStorage.setItem('debug', 'calypso:analytics:*');`
 
-You can limit to only calls made to GA, Tracks, or MC by replacing the `*` with an appropriate suffix. `ga` for Google Analytics, `tracks` for Tracks, and `mc` for MC.
+You can limit to only calls made to Google Analytics, Tracks, or MC by replacing the `*` with an appropriate suffix. `ga` for Google Analytics, `tracks` for Tracks, and `mc` for MC.
 
 `localStorage.setItem('debug', 'calypso:analytics:tracks'); // only show debug for tracks`
 
 
 ## Which analytics tool should I use?
 
-*Page Views* (`analytics.pageView.record`) should be used to record all page views (when the main content body completely changes). This will automatically record the pageview to both Google Analytics and Tracks.
+_Note: Each tool has its own documentation with extensive usage guidelines and examples._
 
-*Google Analytics* should be used to record all events the user performs on a page that *do not* trigger a page view (this will allow us to determine bounce rate on pages).
+[**Page Views**](./docs/page-views.md) should be used to record all page views (when the main content body completely changes). This will automatically record the pageview to both Google Analytics and Tracks.
 
-We are using GA to monitor user flows through the user interface of Calypso in order learn where they succeed and fail, as well as determine usage of different sections. *Please do not ship anything that does not have GA tracking in place*, otherwise we will create big gaps in our understanding.
+[**Google Analytics**](./docs/google-analytics.md) should be used to record all events the user performs on a page that *do not* trigger a page view (this will allow us to determine bounce rate on pages).
 
-Automatticians may refer to internal documentation for more information about MC/Tracks.
+[**Tracks**](./docs/tracks.md) should be used to record events with optional properties.
 
-# Usage
+[**MC**](./docs/mc.md) should be used to bump WP.com stats.
 
-Note: In most situations it is best to use the [Analytics middleware](https://github.com/Automattic/wp-calypso/tree/master/client/state/analytics), which has no direct browser dependencies and therefore will not complicate any unit testing of the modules where it is used.
-
-If you do still want to use this library directly:
-```js
-// require the module
-import analytics from 'lib/analytics';
-
-```
-
-## PageView Wrapper
-
-### analytics#pageView#record( pageURL, pageTitle )
-
-Record a pageview both in Google Analytics and Tracks:
-
-```js
-analytics.pageView.record( '/posts/draft', 'Posts > Drafts' );
-```
-
-
-## Google Analytics API
-
-### analytics#ga#recordPageView( pageURL, pageTitle )
-
-Record a virtual pageview:
-
-```js
-analytics.ga.recordPageView( '/posts/draft', 'Posts > Drafts' );
-```
-
-*Note: Unless you have a strong reason to directly record a pageview to GA, you should use `analytics.pageView.record` instead*
-
-### analytics#ga#recordEvent( eventCategory, eventAction [, optionLabel, optionValue ] )
-
-Record an event:
-
-```js
-analytics.ga.recordEvent( 'Reader', 'Clicked Like' );
-analytics.ga.recordEvent( 'Reader', 'Loaded Next Page', 'page', 2 );
-```
-
-For more information and examples about how and when to provide the optional `optionLabel` and `optionValue` parameters, refer to the [Google Analytics Event Tracking documentation](https://developers.google.com/analytics/devguides/collection/analyticsjs/events#overview).
-
-## Tracks API
-
-### analytics#tracks#recordEvent( eventName, eventProperties )
-
-Record an event with optional properties:
-
-```js
-analytics.tracks.recordEvent( 'calypso_checkout_coupon_apply', {
-	'coupon_code': 'abc123'
-} );
-```
-
-## MC API
-
-### analytics#mc#bumpStat( group, name )
-
-Bump a single WP.com stat.
-
-```js
-analytics.mc.bumpStat( 'newdash_visits', 'sites' );
-```
-
-### analytics#mc#bumpStat( obj )
-
-Bump multiple WP.com stats:
-
-```js
-analytics.mc.bumpStat( {
-	'stat_name1': 'stat_value1',
-	'statname2': 'stat_value2'
-} );
-```
-
-## Google Analytics Naming Conventions
-
-For page view tracking, you should never pass a dynamic URL, or anything including a specific domain e.g. (/posts/example.wordpress.com). Always pass a placeholder in these instances (/posts/:site). If you do not do this, we cannot accurately track views for a specific page. Titles should always use a ` > ` to break up the hierarchy of the page title. Examples are `Posts > My > Drafts`, `Reader > Following > Edit`, `Sharing > Connections`.
-
-Events should be categorized by the section they are in. Examples are `Posts`, `Pages`, `Reader`, `Sharing`. Event actions should be written in readable form, and action centric. Good examples are `Clicked Save Button`, `Clicked Like`, `Activated Theme`.
-
-## Tracks Naming Conventions
-
-Event names should be prefixed by `calypso_` to make it easy to identify when analyzing the data with our various analytics tools.
-
-Each token in the event and property names should be separated by an underscore (`_`), not spaces or dashes.
-
-In order to keep similar events grouped together when output in an alphabetized list (as is typical with ananlytics tools), put the verb at _the end_ of the event name:
-
-* `calypso_cart_product_add`
-* `calypso_cart_product_remove`
-
-If we had instead used `calypso_add_cart_product` and `calypso_remove_cart_product` for example, then they'd likely be separated in a list of all the event names.
-
-Finally, for consistency, the verb at the end should be in the form `add`, `remove`, `view`, `click`, etc and _not_ `adds`, `added`, `adding`, etc.
-
-With the exception of separating tokens with underscores, these rules do not apply to property names. `coupon_code` is perfectly fine.
+Automatticians may refer to internal documentation for more information about MC and Tracks.

--- a/client/lib/analytics/README.md
+++ b/client/lib/analytics/README.md
@@ -16,7 +16,7 @@ You can limit to only calls made to Google Analytics, Tracks, or MC by replacing
 
 _Note: Each tool has its own documentation with extensive usage guidelines and examples._
 
-[**Page Views**](./docs/page-views.md) should be used to record all page views (when the main content body completely changes). This will automatically record the pageview to both Google Analytics and Tracks.
+[**Page Views**](./docs/page-views.md) should be used to record all page views (when the main content body completely changes). This will automatically record the page view to both Google Analytics and Tracks.
 
 [**Google Analytics**](./docs/google-analytics.md) should be used to record all events the user performs on a page that *do not* trigger a page view (this will allow us to determine bounce rate on pages).
 

--- a/client/lib/analytics/docs/google-analytics.md
+++ b/client/lib/analytics/docs/google-analytics.md
@@ -1,0 +1,38 @@
+Analytics: Google Analytics
+===========================
+
+Google Analytics should be used to record all events the user performs on a page that _do not_ trigger a page view (this will allow us to determine bounce rate on pages).
+
+We are using Google Analytics to monitor user flows through the user interface of Calypso in order learn where they succeed and fail, as well as determine usage of different sections.
+
+_Please do not ship anything that does not have Google Analytics tracking in place_, otherwise we will create big gaps in our understanding.
+
+## Usage
+
+### `analytics.ga.recordEvent( eventCategory, eventAction [, optionLabel, optionValue ] )`
+
+Record an event:
+
+```js
+analytics.ga.recordEvent( 'Reader', 'Clicked Like' );
+analytics.ga.recordEvent( 'Reader', 'Loaded Next Page', 'page', 2 );
+```
+
+For more information and examples about how and when to provide the optional `optionLabel` and `optionValue` parameters, refer to the [Google Analytics Event Tracking documentation](https://developers.google.com/analytics/devguides/collection/analyticsjs/events#overview).
+
+
+### `analytics.ga.recordPageView( url, title )`
+
+_Note: Unless you have a strong reason to directly record a page view to Google Analytics, you should use [`PageViewTracker`](./page-views.md) instead._
+
+Record a virtual page view:
+
+```js
+analytics.ga.recordPageView( '/posts/draft', 'Posts > Drafts' );
+```
+
+## Naming Conventions
+
+Events should be categorized by the section they are in. Examples are `Posts`, `Pages`, `Reader`, `Sharing`. Event actions should be written in readable form, and action centric. Good examples are `Clicked Save Button`, `Clicked Like`, `Activated Theme`.
+
+For page view tracking conventions, refer to the [Page Views](./page-views.md) documentation.

--- a/client/lib/analytics/docs/mc.md
+++ b/client/lib/analytics/docs/mc.md
@@ -1,0 +1,25 @@
+Analytics: MC
+=============
+
+Automatticians may refer to internal documentation for more information about MC.
+
+## Usage
+
+### `analytics.mc.bumpStat( group, name )`
+
+Bump a single WP.com stat.
+
+```js
+analytics.mc.bumpStat( 'newdash_visits', 'sites' );
+```
+
+### `analytics.mc.bumpStat( obj )`
+
+Bump multiple WP.com stats:
+
+```js
+analytics.mc.bumpStat( {
+	'stat_name1': 'stat_value1',
+	'statname2': 'stat_value2'
+} );
+```

--- a/client/lib/analytics/docs/page-views.md
+++ b/client/lib/analytics/docs/page-views.md
@@ -1,0 +1,78 @@
+Analytics: Page Views
+=====================
+
+Page views should be used to record all page views (when the main content body completely changes). This will automatically record the page view to both Google Analytics and Tracks.
+
+The preferred tool to record page views is the **`PageViewTracker`** component which is aware of the selected site and, if the current URL contains a site fragment, it will delay the page view recording until the selected site is set or updated.
+
+## Usage
+
+### `PageViewTracker`
+
+```js
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+
+render() {
+	return (
+		<Main>
+			<PageViewTracker path="/section/page" title="My Cool Section > My Cool Page" />
+			<MyCoolComponent>
+				<MyCoolChildren />
+			</MyCoolComponent>
+		</Main>
+	);
+);
+```
+
+For more information about `PageViewTracker`, refer to [its own documentation](https://github.com/Automattic/wp-calypso/tree/master/client/lib/analytics/page-view-tracker).
+
+### `recordPageView( url, title )`
+
+_Note: Unless you have a strong reason to record a page view with Redux, you should use the `PageViewTracker` component instead._
+
+```js
+import { recordPageView } from 'state/analytics/actions';
+
+dispatch( recordPageView( url, title ) );
+```
+
+### `analytics.pageView.record( url, title )`
+
+_Note: Unless you have a strong reason to directly record a page view, you should use the `PageViewTracker` component instead._
+
+```js
+analytics.pageView.record( '/section/page', 'My Cool Section > My Cool Page' );
+```
+
+## Paths Conventions
+
+There are currently no enforced rules for page views paths reporting but, where possible, they should be normalized and the variables values replaced by placeholders.
+
+E.g. the path `/comments/all/example.wordpress.com/1234` should be reported as `/comments/all/:site/:post_id`.
+
+As a rule of thumb:
+
+- The **site fragment** should be reported simply as `:site`.
+- **IDs** should be reported as `:element_id` (notice the snake case).
+- **Non-enumerable, infinite, or unknown variables** (e.g. the domain name in `/domains/manage/:domain/edit/:site`) should be reported without unnecessary qualifiers.
+- The value of **enumerable, finite, or known variables** should be reported instead of the placeholder where it make sense (e.g. if changing the variable value results in a page change, as it happens for the status in `/comments/spam/:site`).
+
+Where possible, paths should be set manually, without relying on helper functions (e.g. `sectionify( context.path )`) that might result in inconsistent reporting.
+
+Some examples:
+
+- `/posts/my/published/:site`
+- `/comments/all/:site/:post_id`
+- `/media/images/:site`
+- `/domains/manage/:domain/transfer/in/:site`
+- `/me/purchases/:site/:purchase_id/payment/edit/:card_id`
+
+## Titles Conventions
+
+Titles should always use a `>` to break up the hierarchy of the page title.
+
+Some examples:
+
+- `Posts > My > Drafts`
+- `Reader > Following > Edit`
+- `Sharing > Connections`

--- a/client/lib/analytics/docs/page-views.md
+++ b/client/lib/analytics/docs/page-views.md
@@ -59,13 +59,21 @@ As a rule of thumb:
 
 Where possible, paths should be set manually, without relying on helper functions (e.g. `sectionify( context.path )`) that might result in inconsistent reporting.
 
-Some examples:
+Some examples of **what to do**:
 
 - `/posts/my/published/:site`
-- `/comments/all/:site/:post_id`
 - `/media/images/:site`
+- `/comments/all/:site/:post_id`
 - `/domains/manage/:domain/transfer/in/:site`
 - `/me/purchases/:site/:purchase_id/payment/edit/:card_id`
+
+Some examples of **what not to do**:
+
+- `/posts/my/:status/:site`: different statuses should be recorded separately.
+- `/media/images/:siteSlug`: the site fragment must be always reported as `:site`.
+- `/comments/all/:site/1234`: the post ID is overspecific and results in an incorrect categorization of the path.
+- `/domains/manage/www.example.com/transfer/in/:site`: the domain is as overspecific as the post ID in the previous example.
+- `/me/purchases/:site/:purchase/payment/edit/:cardId`: the purchase is an ID, so it should be reported as `:purchase_id`; also, placeholders should be always written in snake-case, so the card ID should be reported as `:card_id`.
 
 ## Titles Conventions
 

--- a/client/lib/analytics/docs/tracks.md
+++ b/client/lib/analytics/docs/tracks.md
@@ -1,0 +1,33 @@
+Analytics: Tracks
+=================
+
+Automatticians may refer to internal documentation for more information about Tracks.
+
+## Usage
+
+### `analytics.tracks.recordEvent( eventName, eventProperties )`
+
+Record an event with optional properties:
+
+```js
+analytics.tracks.recordEvent( 'calypso_checkout_coupon_apply', {
+	'coupon_code': 'abc123'
+} );
+```
+
+## Naming Conventions
+
+Event names should be prefixed by `calypso_` to make it easy to identify when analyzing the data with our various analytics tools.
+
+Each token in the event and property names should be separated by an underscore (`_`), not spaces or dashes.
+
+In order to keep similar events grouped together when output in an alphabetized list (as is typical with ananlytics tools), put the verb at _the end_ of the event name:
+
+* `calypso_cart_product_add`
+* `calypso_cart_product_remove`
+
+If we had instead used `calypso_add_cart_product` and `calypso_remove_cart_product` for example, then they'd likely be separated in a list of all the event names.
+
+Finally, for consistency, the verb at the end should be in the form `add`, `remove`, `view`, `click`, etc and _not_ `adds`, `added`, `adding`, etc.
+
+With the exception of separating tokens with underscores, these rules do not apply to property names. `coupon_code` is perfectly fine.

--- a/client/lib/analytics/page-view-tracker/README.md
+++ b/client/lib/analytics/page-view-tracker/README.md
@@ -1,6 +1,10 @@
 # Page View Tracking Component
 
-Use this component to automatically record page views when they are loaded. There are two modes of operation: immediate and delayed. In the immediate mode, the page view tracking event will fire off as soon as the component mounts. In the delayed mode, the event will fire off no sooner than the given delay, and will not send at all if the component unmounts before that delay has expired.
+Use this component to automatically record page views when they are loaded and when the `path` changes.
+
+There are two modes of operation: immediate and delayed. In the immediate mode, the page view tracking event will fire off as soon as the component mounts. In the delayed mode, the event will fire off no sooner than the given delay, and will not send at all if the component unmounts before that delay has expired.
+
+This component is aware of the selected site and, if the current URL contains a site fragment, it will delay the page view recording until the selected site is set or updated.
 
 ## Examples
 
@@ -10,14 +14,14 @@ Use this component to automatically record page views when they are loaded. Ther
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 render() {
-    return (
-        <div>
-            <PageViewTracker path="/my/trackers" title="tracking_dashboard" />
-            <MyCoolComponent>
-                <MyCoolChildren />
-            </MyCoolComponent>
-        </div>
-    );
+	return (
+		<Main>
+			<PageViewTracker path="/section/page" title="My Cool Section > My Cool Page" />
+			<MyCoolComponent>
+				<MyCoolChildren />
+			</MyCoolComponent>
+		</Main>
+	);
 );
 ```
 
@@ -27,20 +31,20 @@ render() {
 import PageViewTracker from 'analytics/page-view-tracker';
 
 render() {
-    // consider a view for less than 500ms as an
-    // accidental view and thus don't track
+	// consider a view for less than 500ms as an
+	// accidental view and thus don't track
 
-    return (
-        <div>
-            <PageViewTracker 
-                delay={ 500 } 
-                path="/my/trackers" 
-                title="tracking_dashboard"
-            />
-            <MyCoolComponent>
-                <MyCoolChildren />
-            </MyCoolComponent>
-        </div>
-    );
+	return (
+		<Main>
+			<PageViewTracker 
+				delay={ 500 } 
+				path="/section/page"
+				title="My Cool Section > My Cool Page"
+			/>
+			<MyCoolComponent>
+				<MyCoolChildren />
+			</MyCoolComponent>
+		</Main>
+	);
 );
 ```


### PR DESCRIPTION
Different take of #23902

Restructure the Analytics documentation to improve clarity and detailing of each tool docs.
Now each tool has its own readme inside the `/analytics/docs` folder.

I think this is the only option we have to keep the Analytics docs reasonably long and readable.
This would also improve the discoverability of the naming conventions, in particular Tracks' `_` requirement, and how to write page view paths.

I've mostly just moved stuff from `/analytics/README.md` into the new files, and updated the currently recommended tool to record page views to the `PageViewTracker` component.

English/editorial reviews +t+d appreciated! 🙇