### PR TITLE
Me: Remove app passwords from 2-step auth success

### DIFF
--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -12,7 +12,6 @@ const debug = debugFactory( 'calypso:two-step-authorization' );
  */
 import emitter from 'lib/mixins/emitter';
 import userSettings from 'lib/user-settings';
-import applicationPasswords from 'lib/application-passwords-data';
 import connectedApplications from 'lib/connected-applications-data';
 import analytics from 'lib/analytics';
 import wp from 'lib/wp';
@@ -79,7 +78,6 @@ TwoStepAuthorization.prototype.validateCode = function( args, callback ) {
 				// data from the following modules.
 				if ( this.isReauthRequired() ) {
 					userSettings.fetchSettings();
-					applicationPasswords.fetch();
 					connectedApplications.fetch();
 					reduxDispatch( requestUserProfileLinks() );
 				}


### PR DESCRIPTION
Removes the app password fetching from 2-step auth success.

Part of #22912.

To test:
* Checkout this branch
* Make sure you're logged in as a user with 2fa enabled.
* Go to `http://calypso.localhost:3000/me/security/two-step`
* Delete your 2fa cookie (`twostep_auth`).
* Refresh the page. 
* Enter your 2fa code as requested.
* Verify app passwords are being fetched.