### PR TITLE
Site Importer: Add Site Importer Beta to Calypso

### DIFF
--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -17,6 +17,7 @@ import Button from 'components/forms/form-button';
 import { appStates } from 'state/imports/constants';
 import { cancelImport, resetImport, startImport } from 'lib/importer/actions';
 import { connectDispatcher } from './dispatcher-converter';
+import SiteImporterPlaceholderLogo from './site-importer/placeholder-logo';
 
 /**
  * Module variables
@@ -82,22 +83,32 @@ class ImporterHeader extends React.PureComponent {
 		}
 	};
 
+	getLogo = icon => {
+		if ( includes( [ 'wordpress', 'medium' ], icon ) ) {
+			return <SocialLogo className="importer__service-icon" icon={ icon } size={ 48 } />;
+		}
+
+		if ( includes( [ 'site-importer' ], icon ) ) {
+			return <SiteImporterPlaceholderLogo />;
+		}
+		return (
+			<svg
+				className="importer__service-icon"
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 24 24"
+			/>
+		);
+	};
+
 	render() {
 		const { importerStatus: { importerState }, icon, isEnabled, title, description } = this.props;
 		const canCancel =
 			isEnabled && ! includes( [ appStates.UPLOADING, ...stopStates ], importerState );
 		const isScary = includes( [ ...cancelStates ], importerState );
+
 		return (
 			<header className="importer-service">
-				{ includes( [ 'wordpress', 'medium' ], icon ) ? (
-					<SocialLogo className="importer__service-icon" icon={ icon } size={ 48 } />
-				) : (
-					<svg
-						className="importer__service-icon"
-						xmlns="http://www.w3.org/2000/svg"
-						viewBox="0 0 24 24"
-					/>
-				) }
+				{ this.getLogo( icon ) }
 				<Button
 					className="importer__master-control"
 					disabled={ ! canCancel }

--- a/client/my-sites/importer/importer-site-importer.jsx
+++ b/client/my-sites/importer/importer-site-importer.jsx
@@ -17,7 +17,7 @@ import SiteImporter from './site-importer/site-importer';
  * Module variables
  */
 const importerData = {
-	title: 'Site Importer',
+	title: 'Site Importer (Beta)',
 	icon: 'site-importer',
 };
 
@@ -40,7 +40,7 @@ class ImporterSiteImporter extends React.PureComponent {
 
 	render() {
 		importerData.description = this.props.translate(
-			'Import posts, pages, and media ' + 'from your existing site!'
+			'Import posts, pages, and media from your existing site!'
 		);
 
 		importerData.uploadDescription = this.props.translate(

--- a/client/my-sites/importer/importer-site-importer.jsx
+++ b/client/my-sites/importer/importer-site-importer.jsx
@@ -1,0 +1,54 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import SiteImporter from './site-importer/site-importer';
+
+/**
+ * Module variables
+ */
+const importerData = {
+	title: 'Site Importer',
+	icon: 'site-importer',
+};
+
+class ImporterSiteImporter extends React.PureComponent {
+	static displayName = 'ImporterSiteImporter';
+
+	static propTypes = {
+		importerStatus: PropTypes.shape( {
+			filename: PropTypes.string,
+			importerState: PropTypes.string.isRequired,
+			errorData: PropTypes.shape( {
+				type: PropTypes.string.isRequired,
+				description: PropTypes.string.isRequired,
+			} ),
+			percentComplete: PropTypes.number,
+			siteTitle: PropTypes.string.isRequired,
+			statusMessage: PropTypes.string,
+		} ),
+	};
+
+	render() {
+		importerData.description = this.props.translate(
+			'Import posts, pages, and media ' + 'from your existing site!'
+		);
+
+		importerData.uploadDescription = this.props.translate(
+			'Type your existing site URL to start the import.'
+		);
+
+		return <SiteImporter importerData={ importerData } { ...this.props } />;
+	}
+}
+
+export default localize( ImporterSiteImporter );

--- a/client/my-sites/importer/importer-site-importer.jsx
+++ b/client/my-sites/importer/importer-site-importer.jsx
@@ -13,16 +13,15 @@ import React from 'react';
  */
 import SiteImporter from './site-importer/site-importer';
 
-/**
- * Module variables
- */
-const importerData = {
-	title: 'Site Importer (Beta)',
-	icon: 'site-importer',
-};
-
 class ImporterSiteImporter extends React.PureComponent {
 	static displayName = 'ImporterSiteImporter';
+
+	importerData = {
+		title: 'Site Importer (Beta)',
+		icon: 'site-importer',
+		description: this.props.translate( 'Import posts, pages, and media from your existing site!' ),
+		uploadDescription: this.props.translate( 'Type your existing site URL to start the import.' ),
+	};
 
 	static propTypes = {
 		importerStatus: PropTypes.shape( {
@@ -39,15 +38,7 @@ class ImporterSiteImporter extends React.PureComponent {
 	};
 
 	render() {
-		importerData.description = this.props.translate(
-			'Import posts, pages, and media from your existing site!'
-		);
-
-		importerData.uploadDescription = this.props.translate(
-			'Type your existing site URL to start the import.'
-		);
-
-		return <SiteImporter importerData={ importerData } { ...this.props } />;
+		return <SiteImporter importerData={ this.importerData } { ...this.props } />;
 	}
 }
 

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -256,7 +256,9 @@ class ImportingPane extends React.PureComponent {
 
 const mapDispatchToProps = dispatch => ( {
 	mapAuthorFor: importerId => ( source, target ) =>
-		dispatch( mapAuthor( importerId, source, target ) ),
+		setTimeout( () => {
+			dispatch( mapAuthor( importerId, source, target ) );
+		}, 0 ),
 } );
 
 export default connectDispatcher( null, mapDispatchToProps )( localize( ImportingPane ) );

--- a/client/my-sites/importer/site-importer/placeholder-logo.jsx
+++ b/client/my-sites/importer/site-importer/placeholder-logo.jsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default () => (
+	<svg
+		className="site-importer__placeholder-logo social-logo importer__service-icon"
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+	/>
+);

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -1,0 +1,247 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import Dispatcher from 'dispatcher';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import React from 'react';
+import { noop, every, has, defer, get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import wpLib from 'lib/wp';
+const wpcom = wpLib.undocumented();
+
+import { toApi, fromApi } from 'lib/importer/common';
+
+import { startMappingAuthors, startImporting, mapAuthor, finishUpload } from 'lib/importer/actions';
+import user from 'lib/user';
+
+import { appStates } from 'state/imports/constants';
+import Button from 'components/forms/form-button';
+import ErrorPane from '../error-pane';
+import TextInput from 'components/forms/form-text-input';
+
+import SiteImporterSitePreview from './site-importer-site-preview';
+import { connectDispatcher } from '../dispatcher-converter';
+
+class SiteImporterInputPane extends React.Component {
+	static displayName = 'SiteImporterSitePreview';
+
+	static propTypes = {
+		description: PropTypes.oneOfType( [ PropTypes.node, PropTypes.string ] ),
+		importerStatus: PropTypes.shape( {
+			importerState: PropTypes.string.isRequired,
+			percentComplete: PropTypes.number,
+		} ),
+		onStartImport: PropTypes.func,
+		disabled: PropTypes.bool,
+	};
+
+	static defaultProps = { description: null, onStartImport: noop };
+
+	state = {
+		// TODO this is bad, make it better. Both appStates and state should be unified in one.
+		importStage: 'idle',
+		error: false,
+		errorMessage: '',
+		siteURLInput: '',
+	};
+
+	componentWillUnmount() {
+		window.clearInterval( this.randomizeTimer );
+	}
+
+	// TODO This can be improved if we move to Redux.
+	componentWillReceiveProps = nextProps => {
+		// TODO test on a site without posts
+		const newImporterState = nextProps.importerStatus.importerState;
+		const oldImporterState = this.props.importerStatus.importerState;
+		const singleAuthorSite = get( this.props.site, 'single_user_site', true );
+
+		if ( newImporterState !== oldImporterState && newImporterState === appStates.UPLOAD_SUCCESS ) {
+			// WXR was uploaded, map the authors
+			if ( singleAuthorSite ) {
+				defer( props => {
+					const currentUserData = user().get();
+					const currentUser = {
+						...currentUserData,
+						name: currentUserData.display_name,
+					};
+
+					const mappingFunction = this.props.mapAuthorFor( props.importerStatus.importerId );
+
+					// map all the authors to the current user
+					props.importerStatus.customData.sourceAuthors.forEach( author => {
+						mappingFunction( author, currentUser );
+					} );
+				}, nextProps );
+			} else {
+				defer( props => startMappingAuthors( props.importerStatus.importerId ), nextProps );
+			}
+
+			// Do not continue execution of the function as the rest should be executed on the next update.
+			return;
+		}
+
+		if ( singleAuthorSite && has( this.props, 'importerStatus.customData.sourceAuthors' ) ) {
+			// Authors have been mapped, start the import
+			const oldAuthors = every( this.props.importerStatus.customData.sourceAuthors, 'mappedTo' );
+			const newAuthors = every( nextProps.importerStatus.customData.sourceAuthors, 'mappedTo' );
+
+			if ( oldAuthors === false && newAuthors === true ) {
+				defer( props => {
+					startImporting( props.importerStatus );
+				}, nextProps );
+			}
+		}
+	};
+
+	resetErrors = () => {
+		this.setState( {
+			error: false,
+			errorMessage: '',
+		} );
+	};
+
+	setUrl = event => {
+		this.setState( { siteURLInput: event.target.value } );
+	};
+
+	validateSite = () => {
+		const siteURL = this.state.siteURLInput;
+
+		this.setState( { loading: true }, this.resetErrors );
+
+		wpcom.wpcom.req
+			.get( {
+				path: `/sites/${
+					this.props.site.ID
+				}/site-importer/is-site-importable?site_url=${ siteURL }`,
+				apiNamespace: 'wpcom/v2',
+			} )
+			.then( resp => {
+				this.setState( {
+					importStage: 'importable',
+					importData: {
+						title: resp.site_title,
+						supported: resp.supported_content,
+						unsupported: resp.unsupported_content,
+						favicon: resp.favicon,
+						engine: resp.engine,
+					},
+					loading: false,
+					importSiteURL: siteURL,
+				} );
+			} )
+			.catch( err => {
+				this.setState( {
+					loading: false,
+					error: true,
+					errorMessage: `${ err.message }`,
+				} );
+			} );
+	};
+
+	importSite = () => {
+		this.setState( { loading: true }, this.resetErrors );
+
+		wpcom.wpcom.req
+			.post( {
+				path: `/sites/${ this.props.site.ID }/site-importer/import-site`,
+				apiNamespace: 'wpcom/v2',
+				formData: [
+					[ 'import_status', JSON.stringify( toApi( this.props.importerStatus ) ) ],
+					[ 'site_url', this.state.importSiteURL ],
+				],
+			} )
+			.then( resp => {
+				this.setState( { loading: false } );
+
+				const data = fromApi( resp );
+				const action = finishUpload( this.props.importerStatus.importerId )( data );
+				defer( () => {
+					Dispatcher.handleViewAction( action );
+				} );
+			} )
+			.catch( err => {
+				this.setState( {
+					loading: false,
+					error: true,
+					errorMessage: `${ err.message } (${ err.code })`,
+				} );
+			} );
+	};
+
+	resetImport = () => {
+		this.setState(
+			{
+				loading: false,
+				importStage: 'idle',
+			},
+			this.resetErrors
+		);
+	};
+
+	render() {
+		return (
+			<div className="site-importer__site-importer-pane">
+				{ this.state.importStage === 'idle' && (
+					<div>
+						<p>{ this.props.description }</p>
+						<div className="site-importer__site-importer-url-input">
+							<TextInput
+								disabled={ this.state.loading }
+								onChange={ this.setUrl }
+								value={ this.state.siteURLInput }
+							/>
+							<Button
+								disabled={ this.state.loading }
+								isPrimary={ true }
+								onClick={ this.validateSite }
+							>
+								{ this.props.translate( 'Continue' ) }
+							</Button>
+						</div>
+					</div>
+				) }
+				{ this.state.importStage === 'importable' && (
+					<div className="site-importer__site-importer-confirm-site-pane">
+						<SiteImporterSitePreview
+							siteURL={ this.state.importSiteURL }
+							importData={ this.state.importData }
+							isLoading={ this.state.loading }
+						/>
+						<div className="site-importer__site-importer-confirm-site-pane-container">
+							<Button disabled={ this.state.loading } onClick={ this.importSite }>
+								{ this.props.translate( 'Yes! Start import' ) }
+							</Button>
+							<Button
+								disabled={ this.state.loading }
+								isPrimary={ false }
+								onClick={ this.resetImport }
+							>
+								{ this.props.translate( 'No' ) }
+							</Button>
+						</div>
+					</div>
+				) }
+				{ this.state.error && (
+					<ErrorPane type="importError" description={ this.state.errorMessage } />
+				) }
+			</div>
+		);
+	}
+}
+
+const mapDispatchToProps = dispatch => ( {
+	mapAuthorFor: importerId => ( source, target ) =>
+		defer( () => {
+			dispatch( mapAuthor( importerId, source, target ) );
+		} ),
+} );
+
+export default connectDispatcher( null, mapDispatchToProps )( localize( SiteImporterInputPane ) );

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -51,10 +51,6 @@ class SiteImporterInputPane extends React.Component {
 		siteURLInput: '',
 	};
 
-	componentWillUnmount() {
-		window.clearInterval( this.randomizeTimer );
-	}
-
 	// TODO This can be improved if we move to Redux.
 	componentWillReceiveProps = nextProps => {
 		// TODO test on a site without posts

--- a/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
@@ -1,0 +1,76 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import React from 'react';
+import { map } from 'lodash';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Spinner from 'components/spinner';
+
+class SiteImporterSitePreview extends React.Component {
+	static propTypes = {
+		siteURL: PropTypes.string.isRequired,
+		importData: PropTypes.object,
+		isLoading: PropTypes.bool,
+	};
+	render = () => {
+		const containerClass = classNames( 'site-importer__site-preview-overlay-container', {
+			isLoading: this.props.isLoading,
+		} );
+
+		return (
+			<div className={ containerClass }>
+				<div className="site-importer__site-preview-container">
+					<div className="site-importer__site-preview-site-meta">
+						<p>
+							Is this your site?
+							{ this.props.importData.favicon && (
+								<img
+									className="site-importer__site-preview-favicon"
+									src={ this.props.importData.favicon }
+									height="16px"
+									width="16px"
+									alt="Site favicon"
+								/>
+							) }
+							<a
+								className="site-importer__site-preview-siteurl"
+								href={ this.props.siteURL }
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{ this.props.siteURL }
+							</a>
+						</p>
+						<div>
+							<p>Importing:</p>
+							{ this.props.importData.supported &&
+								this.props.importData.supported.length && (
+									<ul>
+										{ map( this.props.importData.supported, ( suppApp, idx ) => (
+											<li key={ idx }>{ suppApp }</li>
+										) ) }
+										<li>Basic pages</li>
+									</ul>
+								) }
+						</div>
+					</div>
+				</div>
+				{ this.props.isLoading && (
+					<div className="site-importer__site-preview-loading-overlay">
+						<Spinner />
+					</div>
+				) }
+			</div>
+		);
+	};
+}
+
+export default localize( SiteImporterSitePreview );

--- a/client/my-sites/importer/site-importer/site-importer.jsx
+++ b/client/my-sites/importer/site-importer/site-importer.jsx
@@ -22,19 +22,19 @@ import SiteImporterInputPane from './site-importer-input-pane';
 /**
  * Module variables
  */
-const compactStates = [ appStates.DISABLED, appStates.INACTIVE ],
-	importingStates = [
-		appStates.IMPORT_FAILURE,
-		appStates.IMPORT_SUCCESS,
-		appStates.IMPORTING,
-		appStates.MAP_AUTHORS,
-	],
-	uploadingStates = [
-		appStates.READY_FOR_UPLOAD,
-		appStates.UPLOAD_FAILURE,
-		appStates.UPLOAD_SUCCESS,
-		appStates.UPLOADING,
-	];
+const compactStates = [ appStates.DISABLED, appStates.INACTIVE ];
+const importingStates = [
+	appStates.IMPORT_FAILURE,
+	appStates.IMPORT_SUCCESS,
+	appStates.IMPORTING,
+	appStates.MAP_AUTHORS,
+];
+const uploadingStates = [
+	appStates.READY_FOR_UPLOAD,
+	appStates.UPLOAD_FAILURE,
+	appStates.UPLOAD_SUCCESS,
+	appStates.UPLOADING,
+];
 
 export default class extends React.PureComponent {
 	static displayName = 'SiteImporter';
@@ -62,12 +62,12 @@ export default class extends React.PureComponent {
 	render() {
 		const { title, icon, description, uploadDescription } = this.props.importerData;
 		const site = this.props.site;
-		const state = this.props.importerStatus,
-			isEnabled = appStates.DISABLED !== state.importerState,
-			cardClasses = classNames( 'importer__shell', {
-				'is-compact': includes( compactStates, state.importerState ),
-				'is-disabled': ! isEnabled,
-			} );
+		const state = this.props.importerStatus;
+		const isEnabled = appStates.DISABLED !== state.importerState;
+		const cardClasses = classNames( 'importer__shell', {
+			'is-compact': includes( compactStates, state.importerState ),
+			'is-disabled': ! isEnabled,
+		} );
 
 		return (
 			<Card className={ cardClasses }>

--- a/client/my-sites/importer/site-importer/site-importer.jsx
+++ b/client/my-sites/importer/site-importer/site-importer.jsx
@@ -1,0 +1,92 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import classNames from 'classnames';
+import { includes } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+
+import { appStates } from 'state/imports/constants';
+import Card from 'components/card';
+import ImporterHeader from '../importer-header';
+import ImportingPane from '../importing-pane';
+import SiteImporterInputPane from './site-importer-input-pane';
+
+/**
+ * Module variables
+ */
+const compactStates = [ appStates.DISABLED, appStates.INACTIVE ],
+	importingStates = [
+		appStates.IMPORT_FAILURE,
+		appStates.IMPORT_SUCCESS,
+		appStates.IMPORTING,
+		appStates.MAP_AUTHORS,
+	],
+	uploadingStates = [
+		appStates.READY_FOR_UPLOAD,
+		appStates.UPLOAD_FAILURE,
+		appStates.UPLOAD_SUCCESS,
+		appStates.UPLOADING,
+	];
+
+export default class extends React.PureComponent {
+	static displayName = 'SiteImporter';
+
+	static propTypes = {
+		importerData: PropTypes.shape( {
+			title: PropTypes.string.isRequired,
+			icon: PropTypes.string.isRequired,
+			description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ).isRequired,
+			uploadDescription: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
+		} ).isRequired,
+		importerStatus: PropTypes.shape( {
+			errorData: PropTypes.shape( {
+				type: PropTypes.string.isRequired,
+				description: PropTypes.string.isRequired,
+			} ),
+			filename: PropTypes.string,
+			importerState: PropTypes.string.isRequired,
+			percentComplete: PropTypes.number,
+			siteTitle: PropTypes.string.isRequired,
+			statusMessage: PropTypes.string,
+		} ),
+	};
+
+	render() {
+		const { title, icon, description, uploadDescription } = this.props.importerData;
+		const site = this.props.site;
+		const state = this.props.importerStatus,
+			isEnabled = appStates.DISABLED !== state.importerState,
+			cardClasses = classNames( 'importer__shell', {
+				'is-compact': includes( compactStates, state.importerState ),
+				'is-disabled': ! isEnabled,
+			} );
+
+		return (
+			<Card className={ cardClasses }>
+				<ImporterHeader
+					importerStatus={ state }
+					{ ...{ icon, title, description, isEnabled, site } }
+				/>
+				{ includes( importingStates, state.importerState ) && (
+					<ImportingPane importerStatus={ state } site={ this.props.site } />
+				) }
+				{ includes( uploadingStates, state.importerState ) && (
+					<SiteImporterInputPane
+						{ ...this.props }
+						description={ uploadDescription }
+						importerStatus={ state }
+						onStartImport={ this.validateSite }
+					/>
+				) }
+			</Card>
+		);
+	}
+}

--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -196,3 +196,83 @@
 	float: left;
 	color: $gray-lighten-10;
 }
+
+.site-importer__site-importer-pane {
+	position: relative;
+	margin-bottom: 24px;
+
+	& > div {
+		margin-bottom: 10px;
+	}
+
+	& .site-importer__site-importer-url-input {
+		display: flex;
+
+		& .form-text-input {
+			flex-grow: 1;
+			flex-shrink: 1;
+		}
+
+		& button {
+			flex-grow: 0;
+			flex-shrink: 0;
+		}
+	}
+
+
+
+	& .site-importer__site-importer-confirm-site-pane-container {
+		display: flex;
+		flex-direction: row;
+		align-content: center;
+		justify-content: flex-end;
+		width: 100%;
+		margin-bottom: 10px;
+
+		& .site-importer__site-importer-confirm-site-pane-container-text {
+			margin: inherit;
+		}
+
+		& button {
+			float: none;
+			flex-grow: 0;
+			flex-shrink: 0;
+		}
+	}
+
+	& .site-importer__error-message {
+		color: red;
+	}
+}
+.site-importer__site-preview-overlay-container {
+	position: relative;
+
+	& .site-importer__site-preview-container {
+		& .site-importer__site-preview-favicon {
+			margin-left: 10px;
+			vertical-align: middle;
+		}
+
+		& .site-importer__site-preview-siteurl {
+			margin-left: 10px;
+		}
+	}
+}
+
+.site-importer__site-preview-overlay-container.isLoading {
+	& .site-importer__site-preview-container {
+		visibility: hidden;
+	}
+
+	& .site-importer__site-preview-loading-overlay {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+}

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import config from 'config';
+import { isEnabled } from 'config';
 import { find } from 'lodash';
 
 /**
@@ -20,8 +20,9 @@ import ImporterStore, { getState as getImporterState } from 'lib/importer/store'
 import Interval, { EVERY_FIVE_SECONDS } from 'lib/interval';
 import WordPressImporter from 'my-sites/importer/importer-wordpress';
 import MediumImporter from 'my-sites/importer/importer-medium';
+import SiteImporter from 'my-sites/importer/importer-site-importer';
 import { fetchState } from 'lib/importer/actions';
-import { appStates, WORDPRESS, MEDIUM } from 'state/imports/constants';
+import { appStates, WORDPRESS, MEDIUM, SITE_IMPORTER } from 'state/imports/constants';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
 import Main from 'components/main';
@@ -109,12 +110,13 @@ class SiteSettingsImport extends Component {
 		);
 
 		const wpImports = this.getImports( WORDPRESS );
-		const mediumImports = config.isEnabled( 'manage/import/medium' )
-			? this.getImports( MEDIUM )
-			: [];
+		const mediumImports = isEnabled( 'manage/import/medium' ) ? this.getImports( MEDIUM ) : [];
+
+		const siteImporterImports = this.getImports( SITE_IMPORTER );
 
 		const hasWpActiveImports = hasActiveImports( wpImports );
 		const hasMediumActiveImports = hasActiveImports( mediumImports );
+		const hasSiteImporterActiveImports = hasActiveImports( siteImporterImports );
 
 		return (
 			<Main>
@@ -153,8 +155,13 @@ class SiteSettingsImport extends Component {
 								<MediumImporter { ...{ key, site, importerStatus } } />
 							) ) }
 
+						{ isEnabled( 'manage/import/site-importer' ) &&
+							siteImporterImports.map( ( importerStatus, key ) => (
+								<SiteImporter { ...{ key, site, importerStatus } } />
+							) ) }
 						{ ! hasWpActiveImports &&
-							! hasMediumActiveImports && (
+							! hasMediumActiveImports &&
+							! hasSiteImporterActiveImports && (
 								<CompactCard
 									href={ adminUrl + 'import.php' }
 									target="_blank"

--- a/client/state/imports/constants.js
+++ b/client/state/imports/constants.js
@@ -17,3 +17,4 @@ export const appStates = Object.freeze( {
 
 export const WORDPRESS = 'importer-type-wordpress';
 export const MEDIUM = 'importer-type-medium';
+export const SITE_IMPORTER = 'importer-type-site-importer';

--- a/config/development.json
+++ b/config/development.json
@@ -79,6 +79,7 @@
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
+		"manage/import/site-importer": true,
 		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,


### PR DESCRIPTION
This PR adds a beta version of the Site Importer interface. Currently enabled only in development mode, while we figure out bugs and issues in the UX.

