### PR TITLE
Activity Log: Sort events using `rewindId`

### DIFF
--- a/client/lib/query-manager/activity/index.js
+++ b/client/lib/query-manager/activity/index.js
@@ -29,8 +29,14 @@ export default class ActivityQueryManager extends QueryManager {
 	 * @return {Number}       0 if equal, less than 0 if itemA is first,
 	 *                        greater than 0 if itemB is first.
 	 */
-	static compare( query, { activityTs: tsA }, { activityTs: tsB } ) {
-		return Date.parse( tsB ) - Date.parse( tsA );
+	static compare( query, a, b ) {
+		if ( a.rewindId && b.rewindId ) {
+			return b.rewindId - a.rewindId;
+		}
+
+		// if for some reason no rewindId exists
+		// (it _should_ exist)
+		return b.activityTs - a.activityTs;
 	}
 
 	/**


### PR DESCRIPTION
Previously we have been sorting Activity Log events by the `activityTs`
value which comes from the `published` attribute in the events.

Problematic is that this timestamp is a truncated version of the
timestamp and when events happen in short succession then we can get
events out of order.

By changing to the `rewindId` we move to a canonical value that should
preserve ordering to the best ability of the remote system where the
value was first generated.

---

@eliorivero I don't think this will address any of the recent sequencing issues
we've discussed though it may touch some long-standing issues.