### PR TITLE
JP Remote Install: Follow redirects on supplied url, for example http->https

### DIFF
--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -270,7 +270,8 @@ export class OrgCredentialsForm extends Component {
 export default connect(
 	state => {
 		const jetpackConnectSite = getConnectingSite( state );
-		const siteToConnect = jetpackConnectSite.url;
+		const siteData = jetpackConnectSite.data || {};
+		const siteToConnect = siteData.urlAfterRedirects || jetpackConnectSite.url;
 		const installError = getJetpackRemoteInstallErrorCode( state, siteToConnect );
 		const isResponseCompleted = isJetpackRemoteInstallComplete( state, siteToConnect );
 		return {


### PR DESCRIPTION
Fixes #23690

Take advantage of the new `urlAfterRedirects` field added to the site-info endpoint in D11529-code that returns a canonical URL for the remote site.

The remote-install endpoint does not follow redirects, so this change will allow successful installs on, for example, an https site when the user has entered an http URL.

## Testing
* Sandbox public-api.wordpress.com
* Apply patch D11529-code
* Go to https://calypso.live/jetpack/connect?branch=update/jpc-remote-install-url
* Using a jurassic.ninja site (with Jetpack deactivated) enter either the http URL or the URL with no scheme at all
* Remote install and connection should succeed


