### PR TITLE
Theme: normalizes the site page view parameter

### DIFF
--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -60,7 +60,12 @@ export function details( context, next ) {
 	}
 
 	context.primary = (
-		<ThemeSheetComponent id={ slug } section={ section } pathName={ context.pathname } />
+		<ThemeSheetComponent
+			id={ slug }
+			section={ section }
+			themeSlug={ slug }
+			pathName={ context.pathname }
+		/>
 	);
 	context.secondary = null; // When we're logged in, we need to remove the sidebar.
 	next();

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -60,12 +60,7 @@ export function details( context, next ) {
 	}
 
 	context.primary = (
-		<ThemeSheetComponent
-			id={ slug }
-			section={ section }
-			themeSlug={ slug }
-			pathName={ context.pathname }
-		/>
+		<ThemeSheetComponent id={ slug } section={ section } pathName={ context.pathname } />
 	);
 	context.secondary = null; // When we're logged in, we need to remove the sidebar.
 	next();

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -91,7 +91,6 @@ class ThemeSheet extends React.Component {
 		isJetpack: PropTypes.bool,
 		siteId: PropTypes.number,
 		siteSlug: PropTypes.string,
-		themeSlug: PropTypes.string,
 		backPath: PropTypes.string,
 		isWpcomTheme: PropTypes.bool,
 		defaultOption: PropTypes.shape( {
@@ -549,9 +548,9 @@ class ThemeSheet extends React.Component {
 
 	renderSheet = () => {
 		const section = this.validateSection( this.props.section );
-		const { siteId, retired, themeSlug } = this.props;
+		const { id, siteId, retired } = this.props;
 
-		const analyticsPath = `/theme/${ themeSlug }${ section ? '/' + section : '' }${
+		const analyticsPath = `/theme/${ id }${ section ? '/' + section : '' }${
 			siteId ? '/:site' : ''
 		}`;
 		const analyticsPageTitle = `Themes > Details Sheet${

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -551,7 +551,7 @@ class ThemeSheet extends React.Component {
 		const { siteId, retired } = this.props;
 
 		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${
-			siteId ? '/:site_id' : ''
+			siteId ? '/:site' : ''
 		}`;
 		const analyticsPageTitle = `Themes > Details Sheet${
 			section ? ' > ' + titlecase( section ) : ''

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -91,6 +91,7 @@ class ThemeSheet extends React.Component {
 		isJetpack: PropTypes.bool,
 		siteId: PropTypes.number,
 		siteSlug: PropTypes.string,
+		themeSlug: PropTypes.string,
 		backPath: PropTypes.string,
 		isWpcomTheme: PropTypes.bool,
 		defaultOption: PropTypes.shape( {
@@ -548,9 +549,9 @@ class ThemeSheet extends React.Component {
 
 	renderSheet = () => {
 		const section = this.validateSection( this.props.section );
-		const { siteId, retired } = this.props;
+		const { siteId, retired, themeSlug } = this.props;
 
-		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${
+		const analyticsPath = `/theme/${ themeSlug }${ section ? '/' + section : '' }${
 			siteId ? '/:site' : ''
 		}`;
 		const analyticsPageTitle = `Themes > Details Sheet${


### PR DESCRIPTION
This PR normalizes the `site` parameter for the page view events on any theme page.

To test, enable debug log by running `localStorage.setItem('debug', 'calypso:analytics:tracks');` and verify that the following paths are passed as props on the calypso_page_view call.

Like `/themes`, these views work both for authenticated and unauthenticated users.

| URL | Before | After |
| - | - | - |
| `/theme/{theme_slug}` | `/theme/:slug` | `/theme/{theme_slug}` |
| `/theme/{theme_slug}/(setup\|support)` | `/theme/:slug` | `/theme/{theme_slug}/(setup\|support)` |
| `/theme/{theme_slug}/{siteId}` | `/theme/:slug/:site_id` | `/theme/{theme_slug}/:site` |
| `/theme/{theme_slug}/(setup\|support)/{siteId}` | `/theme/:slug/:site_id` | `/theme/{theme_slug}/(setup\|support)/:site` |