### PR TITLE
Rewind - Credentials: update error messages

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -146,8 +146,7 @@ export const failure = ( { dispatch, getState }, action, error ) => {
 		case 'service_unavailable':
 			announce(
 				translate(
-					"Our service isn't working at the moment. We'll get it up and " +
-						'running as fast as we can, so please try again later.'
+					"Our service isn't working right now. We're working to restore it as soon as possible."
 				),
 				{ button: translate( 'Try again' ), onClick: () => dispatch( action ) }
 			);
@@ -176,7 +175,7 @@ export const failure = ( { dispatch, getState }, action, error ) => {
 		case 'invalid_credentials':
 			announce(
 				translate(
-					"Oops! We couldn't connect to your site with these credentials — let's give it another try."
+					"We couldn't connect to your site. Please verify your credentials and give it another try."
 				)
 			);
 			spreadHappiness( 'Rewind Credentials: invalid credentials' );


### PR DESCRIPTION
This PR seeks to shorten, simplify, and clarify the copy of error messages shown when service is unavailable or credentials are invalid. These are the new messages suggested by @benhuberman in https://github.com/Automattic/wp-calypso/pull/23628#issuecomment-376766401

### Service error

<img width="883" alt="captura de pantalla 2018-04-05 a la s 14 15 12" src="https://user-images.githubusercontent.com/1041600/38380989-c85f6cf4-38db-11e8-9b54-041994c5ac25.png">

### Invalid credentials

<img width="865" alt="captura de pantalla 2018-04-05 a la s 14 11 29" src="https://user-images.githubusercontent.com/1041600/38380831-4f01d40a-38db-11e8-8c8f-4e977ed4e044.png">