### PR TITLE
Jetpack Connect: Only auto-auth connections started by button-click

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -220,10 +220,6 @@ export class JetpackAuthorize extends Component {
 	}
 
 	shouldAutoAuthorize() {
-		if ( this.props.isMobileAppFlow ) {
-			return false;
-		}
-
 		const { alreadyAuthorized, authApproved } = this.props.authQuery;
 
 		return (

--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -17,6 +17,8 @@ import JetpackLogo from 'components/jetpack-logo';
 import BackButton from 'components/back-button';
 import SiteUrlInput from '../site-url-input';
 import WordPressLogo from 'components/wordpress-logo';
+import { cleanUrl } from '../utils';
+import { persistSession } from '../persistence-utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 class JetpackNewSite extends Component {
@@ -32,7 +34,7 @@ class JetpackNewSite extends Component {
 		this.props.recordTracksEvent( 'calypso_jetpack_new_site_view' );
 	}
 
-	handleJetpackUrlChange = event => this.setState( { jetpackUrl: event.target.value } );
+	handleJetpackUrlChange = event => this.setState( { jetpackUrl: cleanUrl( event.target.value ) } );
 
 	getNewWpcomSiteUrl() {
 		return config( 'signup_url' ) + '?ref=calypso-selector';
@@ -40,6 +42,8 @@ class JetpackNewSite extends Component {
 
 	handleJetpackSubmit = () => {
 		this.props.recordTracksEvent( 'calypso_jetpack_new_site_connect_click' );
+		// Track that connection was started by button-click, so we can auto-approve at auth step.
+		persistSession( this.state.jetpackUrl );
 		page( '/jetpack/connect?url=' + this.state.jetpackUrl );
 	};
 

--- a/client/jetpack-connect/test/main.js
+++ b/client/jetpack-connect/test/main.js
@@ -42,23 +42,6 @@ describe( 'JetpackConnectMain', () => {
 		page.redirect.mockReset();
 	} );
 
-	describe( 'cleanUrl', () => {
-		test( 'should prepare entered urls for network access', () => {
-			const cleanUrl = new JetpackConnectMain( REQUIRED_PROPS ).cleanUrl;
-			const results = [
-				{ input: '', expected: '' },
-				{ input: 'a', expected: 'http://a' },
-				{ input: 'example.com', expected: 'http://example.com' },
-				{ input: '  example.com   ', expected: 'http://example.com' },
-				{ input: 'http://example.com/', expected: 'http://example.com' },
-				{ input: 'eXAmple.com', expected: 'http://example.com' },
-				{ input: 'example.com/wp-admin', expected: 'http://example.com' },
-			];
-
-			results.forEach( ( { input, expected } ) => expect( cleanUrl( input ) ).toBe( expected ) );
-		} );
-	} );
-
 	describe( 'makeSafeRedirectionFunction', () => {
 		test( 'should make a function that can calls the wrapper function', () => {
 			const component = shallow( <JetpackConnectMain { ...REQUIRED_PROPS } /> );

--- a/client/jetpack-connect/test/utils.js
+++ b/client/jetpack-connect/test/utils.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { addCalypsoEnvQueryArg, getRoleFromScope } from '../utils';
+import { addCalypsoEnvQueryArg, cleanUrl, getRoleFromScope } from '../utils';
 
 jest.mock( 'config', () => input => {
 	const lookupTable = {
@@ -20,6 +20,22 @@ describe( 'addCalypsoEnvQueryArg', () => {
 		expect( addCalypsoEnvQueryArg( 'http://example.com' ) ).toBe(
 			'http://example.com/?calypso_env=mocked-test-env-id'
 		);
+	} );
+} );
+
+describe( 'cleanUrl', () => {
+	test( 'should prepare entered urls for network access', () => {
+		const results = [
+			{ input: '', expected: '' },
+			{ input: 'a', expected: 'http://a' },
+			{ input: 'example.com', expected: 'http://example.com' },
+			{ input: '  example.com   ', expected: 'http://example.com' },
+			{ input: 'http://example.com/', expected: 'http://example.com' },
+			{ input: 'eXAmple.com', expected: 'http://example.com' },
+			{ input: 'example.com/wp-admin', expected: 'http://example.com' },
+		];
+
+		results.forEach( ( { input, expected } ) => expect( cleanUrl( input ) ).toBe( expected ) );
 	} );
 } );
 

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -4,8 +4,12 @@
  */
 import config from 'config';
 import PropTypes from 'prop-types';
-import { addQueryArgs } from 'lib/route';
 import { head, includes, isEmpty, split } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { addQueryArgs, untrailingslashit } from 'lib/route';
 
 export function authQueryTransformer( queryObject ) {
 	return {
@@ -62,6 +66,21 @@ export const authQueryPropTypes = PropTypes.shape( {
 
 export function addCalypsoEnvQueryArg( url ) {
 	return addQueryArgs( { calypso_env: config( 'env_id' ) }, url );
+}
+
+/**
+ * Sanitize a user-supplied URL so we can use it for network requests.
+ *
+ * @param {string} inputUrl User-supplied URL
+ * @return {string} Sanitized URL
+ */
+export function cleanUrl( inputUrl ) {
+	let url = inputUrl.trim().toLowerCase();
+	if ( url && url.substr( 0, 4 ) !== 'http' ) {
+		url = 'http://' + url;
+	}
+	url = url.replace( /wp-admin\/?$/, '' );
+	return untrailingslashit( url );
 }
 
 /**

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -13,7 +13,7 @@ import config from 'config';
 import userFactory from 'lib/user';
 import wpcom from 'lib/wp';
 import { addQueryArgs, externalRedirect } from 'lib/route';
-import { clearPlan, persistSession } from 'jetpack-connect/persistence-utils';
+import { clearPlan } from 'jetpack-connect/persistence-utils';
 import { receiveDeletedSite, receiveSite } from 'state/sites/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { REMOTE_PATH_AUTH } from 'jetpack-connect/constants';
@@ -82,7 +82,6 @@ export function checkUrl( url, isUrlOnSites ) {
 			return;
 		}
 		if ( isUrlOnSites ) {
-			persistSession( url );
 			dispatch( {
 				type: JETPACK_CONNECT_CHECK_URL,
 				url: url,
@@ -107,7 +106,6 @@ export function checkUrl( url, isUrlOnSites ) {
 		}
 		_fetching[ url ] = true;
 		setTimeout( () => {
-			persistSession( url );
 			dispatch( {
 				type: JETPACK_CONNECT_CHECK_URL,
 				url: url,


### PR DESCRIPTION
Previously it was possible to bypass the TOS and 'Approve' button in the jetpack connect process by arriving directly at a URL such as `wordpress.com/jetpack/connect?url=some-dotorg-site`.

Found during a SIRT review of the remote-install feature in p7rd6c-1dS-p2, although this problem pre-dates that feature.

Change the auto-approve logic so that only a button-click in Calypso (which acknowledges TOS) will cause the 'Approve' button to be skipped at the Authorize step.

Changes:
* Move the `persistSession` call from the action to the onClick handlers, so only a click saves a calypso session
* Move `cleanUrl()` to utils to make it available to jetpack-new-site component, so that session url can be sanitized
* Remove special handling for mobile apps (which should not auto-auth) now that arriving with `?url` query does not auto-authorize :party:

## Testing
Spin up a new jurassic.ninja site for each test.

#### Test 1: direct URL
* Arrive directly at https://calypso.live/jetpack/connect?url={jurassic-ninja-site}&branch=update/jetpack-connect-auto-auth
* Expected: You **should have to** click the _Approve_ button to complete the site connection

#### Test 2: mobile app flow
* Arrive directly at https://calypso.live/jetpack/connect?url={jurassic-ninja-site}&branch=update/jetpack-connect-auto-auth&mobile_redirect=wordpress://jetpack-connection
* Expected: You **should have to** click the _Approve_ button to complete the site connection

#### Test 3: Calypso new site page
* Calypso new site page: Go to https://calypso.live/jetpack/new?branch=update/jetpack-connect-auto-auth, and enter the site URL.
* Expected: You **should not have to** click the _Approve_ button to complete the site connection

#### Test 4: /jetpack/connect
* Go to https://calypso.live/jetpack/connect?branch=update/jetpack-connect-auto-auth, and enter the site URL.
* Expected: You **should not have to** click the _Approve_ button to complete the site connection

#### Summary
* The connection process should involve **one button click**. No more, no less.