### PR TITLE
Domains: Update postal code sanitizer

### DIFF
--- a/client/lib/postal-code/index.jsx
+++ b/client/lib/postal-code/index.jsx
@@ -85,7 +85,7 @@ export function tryToGuessPostalCodeFormat( postalCode, countryCode ) {
 		return postalCode;
 	}
 
-	const postalCodeWithoutDelimeters = replace( postalCode, /[ -]/g, '' );
+	const postalCodeWithoutDelimeters = replace( postalCode, /[\s-]/g, '' );
 
 	if ( includes( countryCodeData.length, postalCodeWithoutDelimeters.length ) ) {
 		if ( countryCodeData.formatter ) {

--- a/client/lib/postal-code/index.jsx
+++ b/client/lib/postal-code/index.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { get, includes } from 'lodash';
+import { get, includes, replace } from 'lodash';
 
 function defaultFormatter( postalCode, delimiter, partLength ) {
 	return postalCode.substring( 0, partLength ) + delimiter + postalCode.substring( partLength );
@@ -85,15 +85,18 @@ export function tryToGuessPostalCodeFormat( postalCode, countryCode ) {
 		return postalCode;
 	}
 
-	if (
-		includes( countryCodeData.length, postalCode.length ) &&
-		postalCode.indexOf( countryCodeData.delimiter ) === -1
-	) {
+	const postalCodeWithoutDelimeters = replace( postalCode, /[ -]/g, '' );
+
+	if ( includes( countryCodeData.length, postalCodeWithoutDelimeters.length ) ) {
 		if ( countryCodeData.formatter ) {
-			return countryCodeData.formatter( postalCode, countryCodeData.delimiter );
+			return countryCodeData.formatter( postalCodeWithoutDelimeters, countryCodeData.delimiter );
 		}
 
-		return defaultFormatter( postalCode, countryCodeData.delimiter, countryCodeData.partLength );
+		return defaultFormatter(
+			postalCodeWithoutDelimeters,
+			countryCodeData.delimiter,
+			countryCodeData.partLength
+		);
 	}
 
 	return postalCode;

--- a/client/lib/postal-code/test/index.jsx
+++ b/client/lib/postal-code/test/index.jsx
@@ -15,11 +15,19 @@ describe( 'Postal Code Utils', () => {
 		assert.equal( tryToGuessPostalCodeFormat( 'WC1R4PF', 'GB' ), 'WC1R 4PF' );
 	} );
 
-	test( 'should format valid GB code, length 6', () => {
+	test( 'should format valid GB code, length 5', () => {
 		assert.equal( tryToGuessPostalCodeFormat( 'M11AA', 'GB' ), 'M1 1AA' );
 	} );
 
-	test( 'should format valid GB code, length 5', () => {
+	test( 'should format valid GB code, length 6', () => {
 		assert.equal( tryToGuessPostalCodeFormat( 'B338TH', 'GB' ), 'B33 8TH' );
+	} );
+
+	test( 'should format valid GB code, spaces wrong, length 6', () => {
+		assert.equal( tryToGuessPostalCodeFormat( 'B 338T H', 'GB' ), 'B33 8TH' );
+	} );
+
+	test( 'should format valid GB code, wrong delimeter, length 6', () => {
+		assert.equal( tryToGuessPostalCodeFormat( 'B33-8TH', 'GB' ), 'B33 8TH' );
 	} );
 } );


### PR DESCRIPTION
Try to improve the postal code sanitizer. We try to strip all delimiters users might input into postal codes and then add the delimiters exactly where they should be.

Test:
- Go to Domains
- Pick a domain registration
- Edit Contact Info
- Contry = United Kingdom
- Type a UK postal code `wc1r4 pf`, `w c1 r4 pf`, `wc-1r4 pf`
- Make sure the onBlur fires after selecting another field
- Make sure the postal code is formatted properly