### PR TITLE
Editor: Clarify "Clear scheduled date" action when editing post/page date

### DIFF
--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -124,7 +124,7 @@ export class EditorPublishDate extends React.Component {
 				className="editor-publish-date__immediate"
 				onClick={ this.setImmediate }
 			>
-				{ this.props.translate( 'Publish Immediately' ) }
+				{ this.props.translate( 'Clear scheduled date' ) }
 			</Button>
 		);
 	}

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -124,7 +124,7 @@ export class EditorPublishDate extends React.Component {
 				className="editor-publish-date__immediate"
 				onClick={ this.setImmediate }
 			>
-				{ this.props.translate( 'Clear scheduled date' ) }
+				{ this.props.translate( 'Cancel scheduling' ) }
 			</Button>
 		);
 	}


### PR DESCRIPTION
This PR is intended to fix #22816 by clarifying the "Clear scheduled date" action.  Currently this action is labeled "Publish Immediately", which has led users to mistake it for a Publish button.  Let's re-word it to explicitly reflect its intent.

| Before | After |
|--|--|
| ![2018-04-05t16 33 27-0500](https://user-images.githubusercontent.com/227022/38393133-82279374-38ef-11e8-9deb-429f42013b53.png) | ![2018-04-05t16 42 59-0500](https://user-images.githubusercontent.com/227022/38393439-6f3af818-38f0-11e8-9f45-e0140dd802e8.png) |

### To test

Visit the editor for a post or page and edit its date.

Verify that the text above the calendar says "Choose a date to schedule" when no date is selected, or "Clear scheduled date" when a date in the future or the past is selected.

### Open questions

Does the "Clear scheduled date" action still make sense for backdated posts?  If not, what should it say instead?