### PR TITLE
Build: match node version in circle 2.0 config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     parallelism: 4
     working_directory: ~/wp-calypso
     docker:
-      - image: circleci/node:8.9.4-browsers
+      - image: circleci/node:8.11-browsers
         environment:
           CIRCLE_ARTIFACTS: /tmp/artifacts
           CIRCLE_TEST_REPORTS: /tmp/test_results


### PR DESCRIPTION
As a follow up to https://github.com/Automattic/wp-calypso/pull/23744 this PR updates the 2.0 Circle CI config

@dmsnell if we're using 2.0, I'd also like us to remove the 1.0 config if possible.