### PR TITLE
Stats: Utils: parseChartData: DRY up chart label creation

### DIFF
--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -19,6 +19,7 @@ import {
 	buildExportArray,
 	isAutoRefreshAllowedForQuery,
 	parseStoreStatsReferrers,
+	getChartLabels,
 } from '../utils';
 
 describe( 'utils', () => {
@@ -118,9 +119,6 @@ describe( 'utils', () => {
 				period: '2016-12-31',
 				orders: 0,
 				currency: 'NZD',
-				labelDay: 'Dec 31',
-				labelWeek: 'Dec 31',
-				labelMonth: 'Dec',
 				labelYear: '2016',
 				classNames: [],
 			},
@@ -128,9 +126,6 @@ describe( 'utils', () => {
 				period: '2017-12-31',
 				orders: 14,
 				currency: 'NZD',
-				labelDay: 'Dec 31',
-				labelWeek: 'Dec 31',
-				labelMonth: 'Dec',
 				labelYear: '2017',
 				classNames: [],
 			},
@@ -1832,16 +1827,14 @@ describe( 'utils', () => {
 				const parsedData = normalizers.statsVisits( {
 					fields: [ 'period', 'views', 'visitors' ],
 					data: [ [ '2016-12-22', 0, 0 ], [ '2016-12-23', 10, 6 ] ],
+					unit: 'week',
 				} );
 
 				expect( parsedData ).to.eql( [
 					{
 						classNames: [],
 						comments: null,
-						labelDay: 'Dec 22',
-						labelMonth: 'Dec',
 						labelWeek: 'Dec 22',
-						labelYear: '2016',
 						likes: null,
 						period: '2016-12-22',
 						posts: null,
@@ -1852,10 +1845,7 @@ describe( 'utils', () => {
 					{
 						classNames: [],
 						comments: null,
-						labelDay: 'Dec 23',
-						labelMonth: 'Dec',
 						labelWeek: 'Dec 23',
-						labelYear: '2016',
 						likes: null,
 						period: '2016-12-23',
 						posts: null,
@@ -1870,6 +1860,7 @@ describe( 'utils', () => {
 				const parsedData = normalizers.statsVisits( {
 					fields: [ 'period', 'views', 'visitors' ],
 					data: [ [ '2016W11W07', 0, 0 ], [ '2016W10W31', 10, 6 ] ],
+					unit: 'day',
 				} );
 
 				expect( parsedData ).to.eql( [
@@ -1877,9 +1868,6 @@ describe( 'utils', () => {
 						classNames: [],
 						comments: null,
 						labelDay: 'Nov 7',
-						labelMonth: 'Nov',
-						labelWeek: 'Nov 7',
-						labelYear: '2016',
 						likes: null,
 						period: '2016-11-07',
 						posts: null,
@@ -1891,9 +1879,6 @@ describe( 'utils', () => {
 						classNames: [],
 						comments: null,
 						labelDay: 'Oct 31',
-						labelMonth: 'Oct',
-						labelWeek: 'Oct 31',
-						labelYear: '2016',
 						likes: null,
 						period: '2016-10-31',
 						posts: null,
@@ -2011,6 +1996,61 @@ describe( 'utils', () => {
 
 				expect( firstRecord.date ).to.eql( 'monday' );
 			} );
+		} );
+	} );
+
+	describe( 'getChartLabels', () => {
+		test( 'should return empty object on missing unit parameter', () => {
+			const label = getChartLabels( undefined, moment(), moment() );
+			expect( label ).to.deep.equal( {} );
+		} );
+
+		test( 'should return empty object on missing date parameter', () => {
+			const label = getChartLabels( 'day', undefined, moment() );
+			expect( label ).to.deep.equal( {} );
+		} );
+
+		test( 'should return empty object on missing localizedDate parameter', () => {
+			const label = getChartLabels( 'day', moment(), undefined );
+			expect( label ).to.deep.equal( {} );
+		} );
+
+		test( 'should return a correct property label', () => {
+			const label = getChartLabels( 'day', moment(), moment() );
+			expect( Object.keys( label )[ 0 ] ).to.equal( 'labelDay' );
+		} );
+
+		test( 'should return an "is-weekend" className for a weekend date', () => {
+			const sunday = moment( '2018-04-08' );
+			const label = getChartLabels( 'day', sunday, sunday );
+			expect( label.classNames[ 0 ] ).to.equal( 'is-weekend' );
+		} );
+
+		test( 'should not return an "is-weekend" className a weekday', () => {
+			const monday = moment( '2018-04-09' );
+			const label = getChartLabels( 'day', monday, monday );
+			expect( label.classNames ).to.be.an( 'array' ).that.is.empty;
+		} );
+
+		test( 'should return a correctly formatted date', () => {
+			const april9 = moment( '2018-04-09' );
+			const day = getChartLabels( 'day', april9, april9.locale( 'en' ) );
+			expect( day.labelDay ).to.equal( 'Apr 9' );
+
+			const week = getChartLabels( 'week', april9, april9.locale( 'en' ) );
+			expect( week.labelWeek ).to.equal( 'Apr 9' );
+
+			const month = getChartLabels( 'month', april9, april9.locale( 'en' ) );
+			expect( month.labelMonth ).to.equal( 'Apr' );
+
+			const year = getChartLabels( 'year', april9, april9.locale( 'en' ) );
+			expect( year.labelYear ).to.equal( '2018' );
+		} );
+
+		test( 'should return a correctly formatted localized date', () => {
+			const april9 = moment( '2018-04-09' );
+			const label = getChartLabels( 'day', april9, april9.locale( 'fr' ) );
+			expect( label.labelDay ).to.equal( 'avr. 9' );
 		} );
 	} );
 } );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -173,6 +173,36 @@ export function parseOrderDeltas( payload ) {
 }
 
 /**
+ * Create the correct property and value for a label to be used in a chart
+ *
+ * @param {string} unit - day, week, month, year
+ * @param {object} date - moment object
+ * @param {object} localizedDate - moment object
+ * @return {object}
+ */
+export function getChartLabels( unit, date, localizedDate ) {
+	const validDate = moment.isMoment( date ) && date.isValid();
+	const validLocalizedDate = moment.isMoment( localizedDate ) && localizedDate.isValid();
+
+	if ( validDate && validLocalizedDate && unit ) {
+		const dayOfWeek = date.toDate().getDay();
+		const isWeekend = 'day' === unit && ( 6 === dayOfWeek || 0 === dayOfWeek );
+		const labelName = `label${ unit.charAt( 0 ).toUpperCase() + unit.slice( 1 ) }`;
+		const formats = {
+			day: 'MMM D',
+			week: 'MMM D',
+			month: 'MMM',
+			year: 'YYYY',
+		};
+		return {
+			[ labelName ]: localizedDate.format( formats[ unit ] ),
+			classNames: isWeekend ? [ 'is-weekend' ] : [],
+		};
+	}
+	return {};
+}
+
+/**
  * Return data in a format used by 'components/chart`. The fields array is matched to
  * the data in a single object.
  *
@@ -195,25 +225,10 @@ export function parseOrdersChartData( payload ) {
 			dataRecord[ payload.fields[ i ] ] = value;
 		} );
 
-		dataRecord.labelDay = '';
-		dataRecord.labelWeek = '';
-		dataRecord.labelMonth = '';
-		dataRecord.labelYear = '';
-		dataRecord.classNames = [];
-
 		if ( dataRecord.period ) {
 			const date = parseUnitPeriods( payload.unit, dataRecord.period ).locale( 'en' );
 			const localizedDate = parseUnitPeriods( payload.unit, dataRecord.period );
-			if ( date.isValid() ) {
-				const dayOfWeek = date.toDate().getDay();
-				if ( 'day' === payload.unit && ( 6 === dayOfWeek || 0 === dayOfWeek ) ) {
-					dataRecord.classNames.push( 'is-weekend' );
-				}
-				dataRecord.labelDay = localizedDate.format( 'MMM D' );
-				dataRecord.labelWeek = localizedDate.format( 'MMM D' );
-				dataRecord.labelMonth = localizedDate.format( 'MMM' );
-				dataRecord.labelYear = localizedDate.format( 'YYYY' );
-			}
+			Object.assign( dataRecord, getChartLabels( payload.unit, date, localizedDate ) );
 		}
 
 		dataRecord.period = parseUnitPeriods( payload.unit, dataRecord.period ).format( 'YYYY-MM-DD' );
@@ -251,25 +266,10 @@ function parseChartData( payload, nullAttributes = [] ) {
 			dataRecord[ payload.fields[ i ] ] = value;
 		} );
 
-		dataRecord.labelDay = '';
-		dataRecord.labelWeek = '';
-		dataRecord.labelMonth = '';
-		dataRecord.labelYear = '';
-		dataRecord.classNames = [];
-
 		if ( dataRecord.period ) {
 			const date = moment( dataRecord.period, 'YYYY-MM-DD' ).locale( 'en' );
 			const localizedDate = moment( dataRecord.period, 'YYYY-MM-DD' );
-			if ( date.isValid() ) {
-				const dayOfWeek = date.toDate().getDay();
-				if ( 'day' === payload.unit && ( 6 === dayOfWeek || 0 === dayOfWeek ) ) {
-					dataRecord.classNames.push( 'is-weekend' );
-				}
-				dataRecord.labelDay = localizedDate.format( 'MMM D' );
-				dataRecord.labelWeek = localizedDate.format( 'MMM D' );
-				dataRecord.labelMonth = localizedDate.format( 'MMM' );
-				dataRecord.labelYear = localizedDate.format( 'YYYY' );
-			}
+			Object.assign( dataRecord, getChartLabels( payload.unit, date, localizedDate ) );
 		}
 		return dataRecord;
 	} );
@@ -306,6 +306,8 @@ export function parseStoreStatsReferrers( payload ) {
 	}
 	const { fields } = payload;
 	return payload.data.map( record => {
+		const parsedDate = parseUnitPeriods( payload.unit, record.date ).locale( 'en' );
+		const parsedLocalizedDate = parseUnitPeriods( payload.unit, record.date );
 		return {
 			date: record.date,
 			data: record.data.map( referrer => {
@@ -316,6 +318,7 @@ export function parseStoreStatsReferrers( payload ) {
 				} );
 				return obj;
 			} ),
+			...getChartLabels( payload.unit, parsedDate, parsedLocalizedDate ),
 		};
 	} );
 }


### PR DESCRIPTION
In creating a main chart for Referrers (example here https://github.com/Automattic/wp-calypso/pull/23579#issuecomment-378806660) labels will need to be appended to the data in the normalizer similar to the main stats chart and Store Orders chart.

This PR DRY's up that logic by pulling it out to its own function.

### Notable Change
Previously, labels were created and persisted for every unit (day, week, month, year) instead of just for the request in question.

```js
dataRecord.labelDay = localizedDate.format( 'MMM D' );
dataRecord.labelWeek = localizedDate.format( 'MMM D' );
dataRecord.labelMonth = localizedDate.format( 'MMM' );
dataRecord.labelYear = localizedDate.format( 'YYYY' );
```
Now, only the relevant label is created and stored. Unit tests reflect this change

### Testing
* Head to http://calypso.localhost:3000/stats/day/my-site
* Make sure all the labels are correct in the Main chart across all periods
* Do the same for Store's chart http://calypso.localhost:3000/store/stats/orders/day/my-site
