### PR TITLE
GDPR: Module/Feature Privacy Links

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -235,6 +235,7 @@
 @import 'components/sticky-panel/style';
 @import 'components/sub-masterbar-nav/style';
 @import 'components/suggestions/style';
+@import 'components/support-info/style';
 @import 'components/textarea-autosize/style';
 @import 'components/text-diff/style';
 @import 'components/thank-you-card/style';

--- a/client/components/support-info/README.md
+++ b/client/components/support-info/README.md
@@ -1,0 +1,27 @@
+Support Info
+=============
+
+This component is used to display a support info icon. When clicked, it displays a popover with a description, a learn more link, and a privacy info link.
+
+## Example Usage:
+
+```js
+import SupportInfo from 'components/support-info';
+
+render() {
+	const support = {
+		text: 'About this.',
+		link: 'https://example.com/',
+		privacyLink: 'https://example.com/#privacy',
+	};
+	return (
+		<SupportInfo { ...support } />
+	);
+}
+```
+
+## Props
+
+- `text` - (string) A brief description of a feature.
+- `link` - *optional* (string|bool) A URL leading to an overview of a feature. If `false`, no link will be displayed.
+- `privacyLink` - *optional* (string|bool) A URL leading to the privacy information for a feature. If empty, defaults to `[link]#privacy`. If false, no privacy link will be displayed.

--- a/client/components/support-info/index.jsx
+++ b/client/components/support-info/index.jsx
@@ -1,0 +1,61 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import InfoPopover from 'components/info-popover';
+import ExternalLink from 'components/external-link';
+
+class SupportInfo extends Component {
+	static propTypes = {
+		text: PropTypes.string,
+		link: PropTypes.string,
+		privacyLink: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
+	};
+
+	static defaultProps = {
+		text: '',
+		link: '',
+		privacyLink: '',
+	};
+
+	render() {
+		const { text, link, translate } = this.props;
+		let { privacyLink } = this.props;
+
+		if ( ! privacyLink && privacyLink !== false && link ) {
+			privacyLink = link + '#privacy';
+		}
+
+		return (
+			<div className="support-info">
+				<InfoPopover position="left" screenReaderText={ translate( 'Learn more' ) }>
+					{ text + ' ' }
+					{ link && (
+						<span className="support-info__learn-more">
+							<ExternalLink href={ link } target="_blank" rel="noopener noreferrer">
+								{ translate( 'Learn more' ) }
+							</ExternalLink>
+						</span>
+					) }
+					{ privacyLink && (
+						<span className="support-info__privacy">
+							<ExternalLink href={ privacyLink } target="_blank" rel="noopener noreferrer">
+								{ translate( 'Privacy Information' ) }
+							</ExternalLink>
+						</span>
+					) }
+				</InfoPopover>
+			</div>
+		);
+	}
+}
+
+export default localize( SupportInfo );

--- a/client/components/support-info/style.scss
+++ b/client/components/support-info/style.scss
@@ -1,0 +1,13 @@
+.support-info {
+	float: right;
+	margin: 0 0 20px 20px;
+}
+
+.popover {
+	.support-info__privacy {
+		display: block;
+		margin-top: 14px;
+		padding-top: 12px;
+		border-top: 1px solid rgba( $gray, 0.5 );
+	}
+}

--- a/client/components/support-info/test/index.js
+++ b/client/components/support-info/test/index.js
@@ -1,0 +1,36 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import SupportInfo from '../';
+
+describe( 'SupportInfo', () => {
+	const testProps = {
+		text: 'Hello world!',
+		link: 'https://foo.com/',
+		privacyLink: 'https://foo.com/privacy/',
+	};
+
+	const wrapper = shallow( <SupportInfo { ...testProps } /> ).dive();
+
+	it( 'should have a proper "Learn more" link', () => {
+		expect( wrapper.find( 'ExternalLink' ).get( 0 ).props.href ).to.be.equal( 'https://foo.com/' );
+	} );
+
+	it( 'should have a proper "Privacy Information" link', () => {
+		expect( wrapper.find( 'ExternalLink' ).get( 1 ).props.href ).to.be.equal(
+			'https://foo.com/privacy/'
+		);
+	} );
+} );

--- a/client/my-sites/site-settings/comment-display-settings/index.jsx
+++ b/client/my-sites/site-settings/comment-display-settings/index.jsx
@@ -17,8 +17,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormSelect from 'components/forms/form-select';
 import FormTextInput from 'components/forms/form-text-input';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
@@ -33,21 +32,13 @@ class CommentDisplaySettings extends Component {
 
 		return (
 			<FormFieldset className="comment-display-settings">
-				<div className="comment-display-settings__info site-settings__info-link-container">
-					<InfoPopover position="left">
-						{ translate(
-							'Replaces the standard WordPress comment form with a new comment system ' +
-								'that includes social media login options.'
-						) }{' '}
-						<ExternalLink
-							target="_blank"
-							icon={ false }
-							href="https://jetpack.com/support/comments"
-						>
-							{ translate( 'Learn more' ) }
-						</ExternalLink>
-					</InfoPopover>
-				</div>
+				<SupportInfo
+					text={ translate(
+						'Replaces the standard WordPress comment form with a new comment system ' +
+							'that includes social media login options.'
+					) }
+					link="https://jetpack.com/support/comments/"
+				/>
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }
 					moduleSlug="comments"

--- a/client/my-sites/site-settings/composing/after-the-deadline.jsx
+++ b/client/my-sites/site-settings/composing/after-the-deadline.jsx
@@ -19,8 +19,7 @@ import FormLegend from 'components/forms/form-legend';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import TokenField from 'components/token-field';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
@@ -216,22 +215,12 @@ class AfterTheDeadline extends Component {
 				<QueryJetpackConnection siteId={ selectedSiteId } />
 
 				<div className="composing__module-settings site-settings__child-settings">
-					<div className="composing__info-link-container site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate(
-								'Checks your content for correct grammar and spelling, ' +
-									'misused words, and style while you write.'
-							) }{' '}
-							<ExternalLink
-								href="https://jetpack.com/support/spelling-and-grammar/"
-								icon={ false }
-								target="_blank"
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
-
+					<SupportInfo
+						text={ translate(
+							'Checks your content for correct grammar and spelling, ' + 'misused words, and style.'
+						) }
+						link="https://jetpack.com/support/spelling-and-grammar/"
+					/>
 					{ this.renderProofreadingSection() }
 					{ this.renderAutoLanguageDetectionSection() }
 					{ this.renderEnglishOptionsSection() }

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -22,8 +22,7 @@ import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import { activateModule } from 'state/jetpack/modules/actions';
 import { isJetpackSite } from 'state/sites/selectors';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 
 class CustomContentTypes extends Component {
 	componentDidUpdate() {
@@ -162,57 +161,33 @@ class CustomContentTypes extends Component {
 		return (
 			<Card className="custom-content-types site-settings">
 				<FormFieldset>
-					<div className="custom-content-types__info-link-container site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate( 'Showcases your portfolio or displays testimonials on your site.' ) +
-								' ' }
-							<ExternalLink
-								href="https://support.wordpress.com/custom-post-types/"
-								icon={ false }
-								target="_blank"
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+					<SupportInfo
+						text={ translate( 'Showcases your portfolio or displays testimonials on your site.' ) }
+						link="https://support.wordpress.com/custom-post-types/"
+						privacyLink={ false }
+					/>
 					{ this.renderBlogPostSettings() }
 				</FormFieldset>
 
 				<FormFieldset>
-					<div className="custom-content-types__info-link-container site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate(
-								'Adds the Testimonial custom post type, allowing you to collect, organize, ' +
-									'and display testimonials on your site.'
-							) }{' '}
-							<ExternalLink
-								target="_blank"
-								icon={ false }
-								href="https://jetpack.com/support/custom-content-types/"
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+					<SupportInfo
+						text={ translate(
+							'Adds the Testimonial custom post type, allowing you to collect, organize, ' +
+								'and display testimonials on your site.'
+						) }
+						link="https://jetpack.com/support/custom-content-types/"
+					/>
 					{ this.renderTestimonialSettings() }
 				</FormFieldset>
 
 				<FormFieldset>
-					<div className="custom-content-types__info-link-container site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate(
-								'Adds the Portfolio custom post type, allowing you to ' +
-									'manage and showcase projects on your site.'
-							) }{' '}
-							<ExternalLink
-								target="_blank"
-								icon={ false }
-								href="https://jetpack.com/support/custom-content-types/"
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+					<SupportInfo
+						text={ translate(
+							'Adds the Portfolio custom post type, allowing you to ' +
+								'manage and showcase projects on your site.'
+						) }
+						link="https://jetpack.com/support/custom-content-types/"
+					/>
 					{ this.renderPortfolioSettings() }
 				</FormFieldset>
 			</Card>

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -16,6 +16,7 @@ import Card from 'components/card';
 import Button from 'components/button';
 import SectionHeader from 'components/section-header';
 import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import Banner from 'components/banner';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import { getPlugins } from 'state/plugins/installed/selectors';
@@ -179,6 +180,14 @@ export class GoogleAnalyticsForm extends Component {
 					<Card className="analytics-settings site-settings__analytics-settings">
 						{ siteIsJetpack && (
 							<fieldset>
+								<SupportInfo
+									text={ translate(
+										'Reports help you track the path visitors take' +
+											' through your site, and goal conversion lets you' +
+											' measure how visitors complete specific tasks.'
+									) }
+									link="https://jetpack.com/support/google-analytics/"
+								/>
 								<JetpackModuleToggle
 									siteId={ siteId }
 									moduleSlug="google-analytics"

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -13,6 +13,7 @@ import { flowRight, pick } from 'lodash';
  */
 import Button from 'components/button';
 import Card from 'components/card';
+import SupportInfo from 'components/support-info';
 import CommentDisplaySettings from './comment-display-settings';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -185,12 +186,28 @@ class SiteSettingsFormDiscussion extends Component {
 						'Comments should be displayed with the older comments at the top of each page'
 					) }
 				</CompactFormToggle>
+
+				{ this.props.isJetpack && (
+					<SupportInfo
+						text={ translate( 'Hovercards appear when you place your mouse over any Gravatar.' ) }
+						link="https://jetpack.com/support/gravatar-hovercards/"
+					/>
+				) }
 				<JetpackModuleToggle
 					disabled={ isRequestingSettings || isSavingSettings }
 					label={ translate( 'Enable pop-up business cards over commenters’ Gravatars' ) }
 					moduleSlug="gravatar-hovercards"
 					siteId={ siteId }
 				/>
+
+				{ this.props.isJetpack && (
+					<SupportInfo
+						text={ translate(
+							'Comment Likes are a fun, easy way to demonstrate your appreciation or agreement.'
+						) }
+						link="https://jetpack.com/support/comment-likes/"
+					/>
+				) }
 				<JetpackModuleToggle
 					disabled={ isRequestingSettings || isSavingSettings }
 					label={ translate( 'Enable comment likes' ) }

--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -17,8 +17,7 @@ import Card from 'components/card';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import SectionHeader from 'components/section-header';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import QuerySiteMonitorSettings from 'components/data/query-site-monitor-settings';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -137,18 +136,10 @@ class SiteSettingsFormJetpackMonitor extends Component {
 				<SectionHeader label={ translate( 'Downtime Monitoring' ) } />
 
 				<Card className="jetpack-monitor-settings">
-					<div className="site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate( "Notifies you when there's an issue with your site." ) }{' '}
-							<ExternalLink
-								href="https://jetpack.com/support/monitor/"
-								icon={ false }
-								target="_blank"
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+					<SupportInfo
+						text={ translate( "Notifies you when there's an issue with your site." ) }
+						link="https://jetpack.com/support/monitor/"
+					/>
 
 					<JetpackModuleToggle
 						siteId={ siteId }

--- a/client/my-sites/site-settings/jetpack-ads.jsx
+++ b/client/my-sites/site-settings/jetpack-ads.jsx
@@ -19,7 +19,7 @@ import CompactFormToggle from 'components/forms/form-toggle/compact';
 import ExternalLink from 'components/external-link';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import InfoPopover from 'components/info-popover';
+import SupportInfo from 'components/support-info';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import SectionHeader from 'components/section-header';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -81,15 +81,12 @@ class JetpackAds extends Component {
 
 		return (
 			<div>
-				<div className="site-settings__info-link-container">
-					<InfoPopover position="left">
-						{ translate( 'Displays high-quality ads on your site that allow you to earn income.' ) }{' '}
-						<ExternalLink href="https://jetpack.com/support/ads" icon={ false } target="_blank">
-							{ translate( 'Learn more' ) }
-						</ExternalLink>
-					</InfoPopover>
-				</div>
-
+				<SupportInfo
+					text={ translate(
+						'Displays high-quality ads on your site that allow you to earn income.'
+					) }
+					link="https://jetpack.com/support/ads/"
+				/>
 				<div>
 					{ translate(
 						'Show ads on the first article on your home page or at the end of every page and post. ' +

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -13,12 +13,11 @@ import { localize } from 'i18n-calypso';
  */
 import CompactCard from 'components/card/compact';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
-import ExternalLink from 'components/external-link';
 import FoldableCard from 'components/foldable-card';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import InfoPopover from 'components/info-popover';
+import SupportInfo from 'components/support-info';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import QuerySiteRoles from 'components/data/query-site-roles';
@@ -128,22 +127,13 @@ class JetpackSiteStats extends Component {
 					clickableHeader
 				>
 					<FormFieldset>
-						<div className="site-settings__info-link-container">
-							<InfoPopover position="left">
-								{ translate(
-									'Displays information on your site activity, ' +
-										'including visitors and popular posts or pages.'
-								) }{' '}
-								<ExternalLink
-									href="https://jetpack.com/support/wordpress-com-stats/"
-									icon={ false }
-									target="_blank"
-								>
-									{ translate( 'Learn more' ) }
-								</ExternalLink>
-							</InfoPopover>
-						</div>
-
+						<SupportInfo
+							text={ translate(
+								'Displays information on your site activity, ' +
+									'including visitors and popular posts or pages.'
+							) }
+							link="https://jetpack.com/support/wordpress-com-stats/"
+						/>
 						{ this.renderToggle(
 							'admin_bar',
 							translate( 'Put a chart showing 48 hours of views in the admin bar' )

--- a/client/my-sites/site-settings/masterbar.jsx
+++ b/client/my-sites/site-settings/masterbar.jsx
@@ -18,8 +18,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 
 const Masterbar = ( {
@@ -35,22 +34,13 @@ const Masterbar = ( {
 
 			<Card className="masterbar__card site-settings__security-settings">
 				<FormFieldset>
-					<div className="masterbar__info-link-container site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate(
-								'Adds a toolbar with links to all your sites, notifications, ' +
-									'your WordPress.com profile, and the Reader.'
-							) }{' '}
-							<ExternalLink
-								href="https://jetpack.com/support/masterbar/"
-								icon={ false }
-								target="_blank"
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
-
+					<SupportInfo
+						text={ translate(
+							'Adds a toolbar with links to all your sites, notifications, ' +
+								'your WordPress.com profile, and the Reader.'
+						) }
+						link="https://jetpack.com/support/masterbar/"
+					/>
 					<JetpackModuleToggle
 						siteId={ selectedSiteId }
 						moduleSlug="masterbar"

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -20,8 +20,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormSelect from 'components/forms/form-select';
 import FormLabel from 'components/forms/form-label';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import {
 	PLAN_JETPACK_PREMIUM,
 	FEATURE_VIDEO_CDN_LIMITED,
@@ -78,18 +77,10 @@ class MediaSettings extends Component {
 		return (
 			isVideoPressAvailable && (
 				<FormFieldset className="site-settings__formfieldset has-divider is-top-only">
-					<div className="site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate( 'Hosts your video files on the global WordPress.com servers.' ) }{' '}
-							<ExternalLink
-								target="_blank"
-								icon={ false }
-								href="https://jetpack.com/support/videopress/"
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+					<SupportInfo
+						text={ translate( 'Hosts your video files on the global WordPress.com servers.' ) }
+						link="https://jetpack.com/support/videopress/"
+					/>
 					<JetpackModuleToggle
 						siteId={ siteId }
 						moduleSlug="videopress"
@@ -198,18 +189,10 @@ class MediaSettings extends Component {
 					 */ }
 					{ ! jetpackVersionSupportsLazyImages && (
 						<FormFieldset>
-							<div className="site-settings__info-link-container">
-								<InfoPopover position="left">
-									{ translate( 'Hosts your image files on the global WordPress.com servers.' ) }{' '}
-									<ExternalLink
-										target="_blank"
-										icon={ false }
-										href="https://jetpack.com/support/photon"
-									>
-										{ translate( 'Learn more' ) }
-									</ExternalLink>
-								</InfoPopover>
-							</div>
+							<SupportInfo
+								text={ translate( 'Hosts your image files on the global WordPress.com servers.' ) }
+								link="https://jetpack.com/support/photon/"
+							/>
 							<JetpackModuleToggle
 								siteId={ siteId }
 								moduleSlug="photon"
@@ -220,21 +203,10 @@ class MediaSettings extends Component {
 						</FormFieldset>
 					) }
 					<FormFieldset className={ carouselFieldsetClasses }>
-						<div className="site-settings__info-link-container">
-							<InfoPopover position="left">
-								{ translate(
-									'Replaces the standard WordPress galleries with a ' +
-										'full-screen photo browsing experience, including comments and EXIF metadata.'
-								) }{' '}
-								<ExternalLink
-									target="_blank"
-									icon={ false }
-									href="https://jetpack.com/support/carousel"
-								>
-									{ translate( 'Learn more' ) }
-								</ExternalLink>
-							</InfoPopover>
-						</div>
+						<SupportInfo
+							text={ translate( 'Gorgeous full-screen photo browsing experience.' ) }
+							link="https://jetpack.com/support/carousel/"
+						/>
 						<JetpackModuleToggle
 							siteId={ siteId }
 							moduleSlug="carousel"

--- a/client/my-sites/site-settings/protect.jsx
+++ b/client/my-sites/site-settings/protect.jsx
@@ -24,8 +24,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 
 class Protect extends Component {
@@ -121,21 +120,12 @@ class Protect extends Component {
 
 				<FormFieldset>
 					<div className="protect__module-settings site-settings__child-settings">
-						<div className="protect__info-link-container site-settings__info-link-container">
-							<InfoPopover position="left">
-								{ translate(
-									'Protects your site from traditional and distributed brute force login attacks.'
-								) }{' '}
-								<ExternalLink
-									href="https://jetpack.com/support/protect"
-									icon={ false }
-									target="_blank"
-								>
-									{ translate( 'Learn more' ) }
-								</ExternalLink>
-							</InfoPopover>
-						</div>
-
+						<SupportInfo
+							text={ translate(
+								'Protects your site from traditional and distributed brute force login attacks.'
+							) }
+							link="https://jetpack.com/support/protect/"
+						/>
 						<p>
 							{ translate( 'Your current IP address: {{strong}}%(IP)s{{/strong}}{{br/}}', {
 								args: {

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -26,8 +26,7 @@ import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
 import isRegeneratingJetpackPostByEmail from 'state/selectors/is-regenerating-jetpack-post-by-email';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import ClipboardButtonInput from 'components/clipboard-button-input';
 import PressThis from '../press-this';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
@@ -116,21 +115,12 @@ class PublishingTools extends Component {
 
 		return (
 			<FormFieldset>
-				<div className="publishing-tools__info-link-container site-settings__info-link-container">
-					<InfoPopover position="left">
-						{ translate(
-							'Allows you to publish new posts by sending an email to a special address.'
-						) }{' '}
-						<ExternalLink
-							href="https://jetpack.com/support/post-by-email/"
-							icon={ false }
-							target="_blank"
-						>
-							{ translate( 'Learn more' ) }
-						</ExternalLink>
-					</InfoPopover>
-				</div>
-
+				<SupportInfo
+					text={ translate(
+						'Allows you to publish new posts by sending an email to a special address.'
+					) }
+					link="https://jetpack.com/support/post-by-email/"
+				/>
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }
 					moduleSlug="post-by-email"

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -15,8 +15,7 @@ import Card from 'components/card';
 import FormFieldset from 'components/forms/form-fieldset';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import SectionHeader from 'components/section-header';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import RelatedContentPreview from './related-content-preview';
 
 const RelatedPosts = ( {
@@ -32,18 +31,12 @@ const RelatedPosts = ( {
 
 			<Card className="related-posts__card site-settings__traffic-settings">
 				<FormFieldset>
-					<div className="related-posts__info site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate( 'Automatically displays similar content at the end of each post.' ) }{' '}
-							<ExternalLink
-								href="https://jetpack.com/support/related-posts/"
-								icon={ false }
-								target="_blank"
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+					<SupportInfo
+						text={ translate(
+							'Automatically displays similar content (related posts) at the end of each post.'
+						) }
+						link="https://jetpack.com/support/related-posts/"
+					/>
 
 					<CompactFormToggle
 						checked={ !! fields.jetpack_relatedposts_enabled }

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -18,8 +18,7 @@ import SectionHeader from 'components/section-header';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import untrailingslashit from 'lib/route/untrailingslashit';
@@ -44,20 +43,17 @@ class Search extends Component {
 		fields: PropTypes.object,
 	};
 
-	renderInfoLink( url ) {
+	renderInfoLink( link, privacyLink ) {
 		const { translate } = this.props;
 
 		return (
-			<div className="search__info-link-container site-settings__info-link-container">
-				<InfoPopover position="left">
-					{ translate(
-						'Replaces the default WordPress search with a faster, filterable search experience.'
-					) }{' '}
-					<ExternalLink href={ url } icon={ false } target="_blank">
-						{ translate( 'Learn more' ) }
-					</ExternalLink>
-				</InfoPopover>
-			</div>
+			<SupportInfo
+				text={ translate(
+					'Replaces the default WordPress search with a faster, filterable search experience.'
+				) }
+				link={ link }
+				privacyLink={ privacyLink }
+			/>
 		);
 	}
 
@@ -92,7 +88,7 @@ class Search extends Component {
 
 		return (
 			<FormFieldset>
-				{ this.renderInfoLink( 'https://jetpack.com/support/search' ) }
+				{ this.renderInfoLink( 'https://jetpack.com/support/search/' ) }
 
 				<JetpackModuleToggle
 					siteId={ siteId }

--- a/client/my-sites/site-settings/seo-settings/help.jsx
+++ b/client/my-sites/site-settings/seo-settings/help.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import SectionHeader from 'components/section-header';
+import SupportInfo from 'components/support-info';
 import { hasFeature } from 'state/sites/plans/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -50,6 +51,16 @@ const SeoSettingsHelpCard = ( {
 						) }
 					</p>
 
+					{ siteIsJetpack && (
+						<SupportInfo
+							text={ translate(
+								'To help improve your search page ranking, you can customize how the content titles' +
+									' appear for your site. You can reorder items such as ‘Site Name’ and ‘Tagline’,' +
+									' and also add custom separators between the items.'
+							) }
+							link="https://jetpack.com/support/seo-tools/"
+						/>
+					) }
 					{ siteIsJetpack && (
 						<JetpackModuleToggle
 							siteId={ siteId }

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -15,7 +15,7 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Card from 'components/card';
-import InfoPopover from 'components/info-popover';
+import SupportInfo from 'components/support-info';
 import ExternalLink from 'components/external-link';
 import FormInput from 'components/forms/form-text-input-with-affixes';
 import FormInputValidation from 'components/forms/form-input-validation';
@@ -308,22 +308,13 @@ class SiteVerification extends Component {
 				<Card>
 					{ siteIsJetpack && (
 						<FormFieldset>
-							<div className="seo-settings__info site-settings__info-link-container">
-								<InfoPopover position="left">
-									{ translate(
-										'Provides the necessary hidden tags needed to ' +
-											'verify your WordPress site with various services.'
-									) }{' '}
-									<ExternalLink
-										href="https://jetpack.com/support/site-verification-tools"
-										icon={ false }
-										target="_blank"
-									>
-										{ translate( 'Learn more' ) }
-									</ExternalLink>
-								</InfoPopover>
-							</div>
-
+							<SupportInfo
+								text={ translate(
+									'Provides hidden tags needed to verify your' +
+										' WordPress site with various services.'
+								) }
+								link="https://jetpack.com/support/site-verification-tools/"
+							/>
 							<JetpackModuleToggle
 								siteId={ siteId }
 								moduleSlug="verification-tools"

--- a/client/my-sites/site-settings/sitemaps.jsx
+++ b/client/my-sites/site-settings/sitemaps.jsx
@@ -17,7 +17,7 @@ import SectionHeader from 'components/section-header';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import InfoPopover from 'components/info-popover';
+import SupportInfo from 'components/support-info';
 import ExternalLink from 'components/external-link';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -54,20 +54,17 @@ class Sitemaps extends Component {
 		);
 	}
 
-	renderInfoLink( url ) {
+	renderInfoLink( link, privacyLink ) {
 		const { translate } = this.props;
 
 		return (
-			<div className="sitemaps__info-link-container site-settings__info-link-container">
-				<InfoPopover position="left">
-					{ translate(
-						'Automatically generates the files required for search engines to index your site.'
-					) }{' '}
-					<ExternalLink href={ url } icon={ false } target="_blank">
-						{ translate( 'Learn more' ) }
-					</ExternalLink>
-				</InfoPopover>
-			</div>
+			<SupportInfo
+				text={ translate(
+					'Automatically generates the files required for search engines to index your site.'
+				) }
+				link={ link }
+				privacyLink={ privacyLink }
+			/>
 		);
 	}
 
@@ -107,7 +104,7 @@ class Sitemaps extends Component {
 
 		return (
 			<div>
-				{ this.renderInfoLink( 'https://support.wordpress.com/sitemaps/' ) }
+				{ this.renderInfoLink( 'https://support.wordpress.com/sitemaps/', false ) }
 
 				{ this.isSitePublic() ? (
 					<div>
@@ -173,7 +170,7 @@ class Sitemaps extends Component {
 
 		return (
 			<FormFieldset>
-				{ this.renderInfoLink( 'https://jetpack.com/support/sitemaps' ) }
+				{ this.renderInfoLink( 'https://jetpack.com/support/sitemaps/' ) }
 
 				<JetpackModuleToggle
 					siteId={ siteId }

--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -20,7 +20,7 @@ import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import FormInputValidation from 'components/forms/form-input-validation';
 import Gridicon from 'gridicons';
-import InfoPopover from 'components/info-popover';
+import SupportInfo from 'components/support-info';
 import ExternalLink from 'components/external-link';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import isJetpackSettingsSaveFailure from 'state/selectors/is-jetpack-settings-save-failure';
@@ -95,18 +95,10 @@ const SpamFilteringSettings = ( {
 		>
 			<FormFieldset>
 				<div className="spam-filtering__settings site-settings__child-settings">
-					<div className="spam-filtering__info-link-container site-settings__info-link-container">
-						<InfoPopover>
-							{ translate( 'Removes spam from comments and contact forms.' ) }{' '}
-							<ExternalLink
-								target="_blank"
-								icon={ false }
-								href={ 'https://jetpack.com/features/security/spam-filtering/' }
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+					<SupportInfo
+						text={ translate( 'Removes spam from comments and contact forms.' ) }
+						link="https://jetpack.com/features/security/spam-filtering/"
+					/>
 					<FormLabel htmlFor="wordpress_api_key">{ translate( 'Your API Key' ) }</FormLabel>
 					<FormTextInput
 						name="wordpress_api_key"

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -14,12 +14,11 @@ import { connect } from 'react-redux';
 import Card from 'components/card';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
-import ExternalLink from 'components/external-link';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
-import InfoPopover from 'components/info-popover';
+import SupportInfo from 'components/support-info';
 
 class SpeedUpSiteSettings extends Component {
 	static propTypes = {
@@ -49,18 +48,10 @@ class SpeedUpSiteSettings extends Component {
 			<div className="site-settings__module-settings site-settings__speed-up-site-settings">
 				<Card>
 					<FormFieldset className="site-settings__formfieldset">
-						<div className="site-settings__info-link-container">
-							<InfoPopover position="left">
-								{ translate( 'Hosts your image files on the global WordPress.com servers.' ) }{' '}
-								<ExternalLink
-									target="_blank"
-									icon={ false }
-									href="https://jetpack.com/support/photon"
-								>
-									{ translate( 'Learn more' ) }
-								</ExternalLink>
-							</InfoPopover>
-						</div>
+						<SupportInfo
+							text={ translate( 'Hosts your image files on the global WordPress.com servers.' ) }
+							link="https://jetpack.com/support/photon/"
+						/>
 						<JetpackModuleToggle
 							siteId={ selectedSiteId }
 							moduleSlug="photon"
@@ -76,20 +67,12 @@ class SpeedUpSiteSettings extends Component {
 
 					{ jetpackVersionSupportsLazyImages && (
 						<FormFieldset className="site-settings__formfieldset has-divider is-top-only">
-							<div className="site-settings__info-link-container">
-								<InfoPopover position="left">
-									{ translate(
-										"Delays the loading of images until they are visible in the visitor's browser."
-									) }{' '}
-									<ExternalLink
-										target="_blank"
-										icon={ false }
-										href="https://jetpack.com/support/lazy-images"
-									>
-										{ translate( 'Learn more' ) }
-									</ExternalLink>
-								</InfoPopover>
-							</div>
+							<SupportInfo
+								text={ translate(
+									"Delays the loading of images until they are visible in the visitor's browser."
+								) }
+								link="https://jetpack.com/support/lazy-images/"
+							/>
 							<JetpackModuleToggle
 								siteId={ selectedSiteId }
 								moduleSlug="lazy-images"

--- a/client/my-sites/site-settings/sso.jsx
+++ b/client/my-sites/site-settings/sso.jsx
@@ -20,8 +20,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 
 const Sso = ( {
@@ -40,16 +39,12 @@ const Sso = ( {
 
 			<Card className="sso__card site-settings__security-settings">
 				<FormFieldset>
-					<div className="sso__info-link-container site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate(
-								'Allows registered users to log in to your site with their WordPress.com accounts.'
-							) }
-							<ExternalLink href="https://jetpack.com/support/sso" icon={ false } target="_blank">
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+					<SupportInfo
+						text={ translate(
+							'Allows registered users to log in to your site with their WordPress.com accounts.'
+						) }
+						link="https://jetpack.com/support/sso/"
+					/>
 
 					<JetpackModuleToggle
 						siteId={ selectedSiteId }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -415,9 +415,9 @@
 		padding: 24px;
 	}
 
-	.composing__module-settings .site-settings__info-link-container,
-	.protect__module-settings .site-settings__info-link-container,
-	.spam-filtering__settings .site-settings__info-link-container {
+	.composing__module-settings .support-info,
+	.protect__module-settings .support-info,
+	.spam-filtering__settings .support-info {
 		margin-right: -36px;
 		height: 0;
 	}
@@ -436,11 +436,7 @@
 	margin: 16px 36px 0;
 }
 
-.site-settings__info-link-container {
-	float: right;
-}
-
-.form-legend + .site-settings__info-link-container {
+.form-legend + .support-info {
 	margin-top: -21px;
 }
 

--- a/client/my-sites/site-settings/subscriptions.jsx
+++ b/client/my-sites/site-settings/subscriptions.jsx
@@ -21,8 +21,7 @@ import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 
 const Subscriptions = ( {
 	fields,
@@ -41,21 +40,13 @@ const Subscriptions = ( {
 
 			<CompactCard className="subscriptions__card site-settings__discussion-settings">
 				<FormFieldset>
-					<div className="subscriptions__info-link-container site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate(
-								'Allows readers to subscribe to your posts or comments, ' +
-									'and receive notifications of new content by email.'
-							) }{' '}
-							<ExternalLink
-								href="https://jetpack.com/support/subscriptions"
-								icon={ false }
-								target="_blank"
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+					<SupportInfo
+						text={ translate(
+							'Allows readers to subscribe to your posts or comments, ' +
+								'and receive notifications of new content by email.'
+						) }
+						link="https://jetpack.com/support/subscriptions/"
+					/>
 
 					<JetpackModuleToggle
 						siteId={ selectedSiteId }

--- a/client/my-sites/site-settings/test/form-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-analytics.jsx
@@ -1,4 +1,7 @@
-/** @format */
+/**
+ * @format
+ * @jest-environment jsdom
+ */
 
 jest.mock( 'lib/abtest', () => ( {
 	abtest: () => '',

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -25,8 +25,7 @@ import CompactFormToggle from 'components/forms/form-toggle/compact';
 import { getCustomizerUrl } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 
 class ThemeEnhancements extends Component {
 	static defaultProps = {
@@ -87,21 +86,11 @@ class ThemeEnhancements extends Component {
 		return (
 			<FormFieldset>
 				<FormLegend>{ translate( 'Infinite Scroll' ) }</FormLegend>
-
-				<div className="theme-enhancements__info-link-container site-settings__info-link-container">
-					<InfoPopover position="left">
-						{ translate( 'Control how additional posts are loaded.' ) }
-						<br />
-						<ExternalLink
-							href="https://support.wordpress.com/infinite-scroll/"
-							icon
-							target="_blank"
-						>
-							{ translate( 'Learn more' ) }
-						</ExternalLink>
-					</InfoPopover>
-				</div>
-
+				<SupportInfo
+					text={ translate( 'Control how additional posts are loaded.' ) }
+					link="https://support.wordpress.com/infinite-scroll/"
+					privacyLink={ false }
+				/>
 				{ this.renderToggle(
 					'infinite_scroll',
 					blockedByFooter,
@@ -129,22 +118,12 @@ class ThemeEnhancements extends Component {
 		return (
 			<FormFieldset>
 				<FormLegend>{ translate( 'Infinite Scroll' ) }</FormLegend>
-
-				<div className="theme-enhancements__info-link-container site-settings__info-link-container">
-					<InfoPopover position="left">
-						{ translate(
-							'Loads the next posts automatically when the reader approaches the bottom of the page.'
-						) }{' '}
-						<ExternalLink
-							href="https://jetpack.com/support/infinite-scroll"
-							icon={ false }
-							target="_blank"
-						>
-							{ translate( 'Learn more' ) }
-						</ExternalLink>
-					</InfoPopover>
-				</div>
-
+				<SupportInfo
+					text={ translate(
+						'Loads the next posts automatically when the reader approaches the bottom of the page.'
+					) }
+					link="https://jetpack.com/support/infinite-scroll/"
+				/>
 				{ this.renderRadio(
 					'infinite_scroll',
 					'default',
@@ -170,21 +149,13 @@ class ThemeEnhancements extends Component {
 
 		return (
 			<FormFieldset>
-				<div className="theme-enhancements__info-link-container site-settings__info-link-container">
-					<InfoPopover position="left">
-						{ translate(
-							'Enables a lightweight, mobile-friendly theme ' +
-								'that will be displayed to visitors on mobile devices.'
-						) }{' '}
-						<ExternalLink
-							href="https://jetpack.com/support/mobile-theme"
-							icon={ false }
-							target="_blank"
-						>
-							{ translate( 'Learn more' ) }
-						</ExternalLink>
-					</InfoPopover>
-				</div>
+				<SupportInfo
+					text={ translate(
+						'Enables a lightweight, mobile-friendly theme ' +
+							'that will be displayed to visitors on mobile devices.'
+					) }
+					link="https://jetpack.com/support/mobile-theme/"
+				/>
 
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }


### PR DESCRIPTION
Ref: p1HpG7-50l-p2

Calypso: This PR adds "Privacy Information" links into each Jetpack module/feature.

<p align="center"><img src="https://user-images.githubusercontent.com/1563559/38402702-948cb006-390a-11e8-9332-96aac556938c.png" align="center" /></p>

---

<p align="center"><img src="https://user-images.githubusercontent.com/1563559/38402703-94be18c6-390a-11e8-9f72-4fabae9771dc.png" align="center" /></p>

---

<p align="center"><img src="https://user-images.githubusercontent.com/1563559/38402704-94fbca68-390a-11e8-8181-c78975716d39.png" align="center" /></p>

---

### How to Test this PR

- In Calypso Live, under Settings in the Calypso Dashboard (https://calypso.live/?branch=add/gdpr-feature-privacy-links) check all of the icons next to Jetpack features to ensure they are working properly; i.e., that the Privacy Information link is there and that it leads to the appropriate Jetpack.com privacy section.
- Help to make sure I didn't miss any Jetpack features.

### Overview of Changes

- Adds a new `SupportInfo` component. See [README](https://github.com/Automattic/wp-calypso/tree/a92cdd900ff34d7fa702b93c7193b952cee38e92/client/components/support-info) in the [`client/components/support-info`](https://github.com/Automattic/wp-calypso/tree/a92cdd900ff34d7fa702b93c7193b952cee38e92/client/components/support-info) directory. The new component is used to display a support info icon. When clicked, it displays a popover with a description, a learn more link, and a privacy info link.

  This new component is a way of making what was `.site-settings__info-link-container` into a reusable component, and therefore easier to adjust globally.

- Removes all occurrences of `.site-settings__info-link-container` in favor of the new `SupportInfo` component.

- Updates CSS adjustments across a few components to change references from `.site-settings__info-link-container` into `.support-info`.

- Adds support info icons to all `JetpackModuleToggle` instances, covering every Jetpack module/feature. **Help:** Please make sure I didn't miss any Jetpack features.

### Also In Jetpack (`/wp-admin`)

See: https://github.com/Automattic/jetpack/pull/9199