### PR TITLE
Notices: Add to logged out layout

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -13,8 +13,10 @@ import { includes } from 'lodash';
 /**
  * Internal dependencies
  */
+import GlobalNotices from 'components/global-notices';
 import MasterbarLoggedOut from 'layout/masterbar/logged-out';
 import { getSection, masterbarIsVisible } from 'state/ui/selectors';
+import notices from 'notices';
 import OauthClientMasterbar from 'layout/masterbar/oauth-client';
 import { getCurrentOAuth2Client, showOAuth2Layout } from 'state/ui/oauth2-clients/selectors';
 
@@ -68,6 +70,12 @@ const LayoutLoggedOut = ( {
 			{ masterbar }
 
 			<div id="content" className="layout__content">
+				<GlobalNotices
+					id="notices"
+					notices={ notices.list }
+					forcePinned={ 'post' === section.name }
+				/>
+
 				<div id="primary" className="layout__primary">
 					{ primary }
 				</div>

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -15,10 +15,10 @@ import { includes } from 'lodash';
  */
 import GlobalNotices from 'components/global-notices';
 import MasterbarLoggedOut from 'layout/masterbar/logged-out';
-import { getSection, masterbarIsVisible } from 'state/ui/selectors';
 import notices from 'notices';
 import OauthClientMasterbar from 'layout/masterbar/oauth-client';
 import { getCurrentOAuth2Client, showOAuth2Layout } from 'state/ui/oauth2-clients/selectors';
+import { getSection, masterbarIsVisible } from 'state/ui/selectors';
 
 // Returns true if given section should display sidebar for logged out users.
 const hasSidebar = section => {

--- a/client/layout/test/index.js
+++ b/client/layout/test/index.js
@@ -33,6 +33,10 @@ describe( 'index', () => {
 							dispatch: () => {},
 							getState: () => ( {
 								ui: {},
+								notices: {
+									items: {},
+									lastTimeShown: {},
+								},
 							} ),
 							subscribe: () => {},
 						} }

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -15,12 +15,10 @@ import { startCase } from 'lodash';
  */
 import DocumentHead from 'components/data/document-head';
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
-import GlobalNotices from 'components/global-notices';
 import LocaleSuggestions from 'components/locale-suggestions';
 import LoginBlock from 'blocks/login';
 import LoginLinks from './login-links';
 import Main from 'components/main';
-import notices from 'notices';
 import PrivateSite from './private-site';
 import { addLocaleToWpcomUrl } from 'lib/i18n-utils';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
@@ -177,8 +175,6 @@ export class Login extends React.Component {
 						title={ translate( 'Log In' ) }
 						link={ [ { rel: 'canonical', href: canonicalUrl } ] }
 					/>
-
-					<GlobalNotices id="notices" notices={ notices.list } />
 
 					<div>
 						<div className="wp-login__container">{ this.renderContent() }</div>


### PR DESCRIPTION
Add `GlobalNotices` to the logged-out layout. This allows notices to be displayed on logged-out pages.

Remove `GlobalNotices` from the `login` component to avoid duplication when viewing `login` while… logged in. (https://github.com/Automattic/wp-calypso/pull/13700/files#r179679601)

Add relevant state mock for renderToString layout tests.

## Background

I was looking for evidence that `GlobalNotices` was intentionally removed or omitted from the logged-out layout but could not find any. Here's what I was able to uncover:

1. Many ~moons~ commits ago, there were logged-in and logged-out layouts that both included `GlobalNotices`:
   https://github.com/Automattic/wp-calypso/blob/7fdca82f1b8c0e1d0533c718f8a629b6a5222ebf/client/layout/index.jsx#L136
   https://github.com/Automattic/wp-calypso/blob/7fdca82f1b8c0e1d0533c718f8a629b6a5222ebf/client/layout/logged-out.jsx#L25
1. A design-specific logged-out layout also existed, it's creation was described in part as:
   > It also ES6ifies the other logged-out layouts, from which it is copied (and slightly modified). This is meant to fix #1325.

   This omitted `GlobalNotices`. Was that intentional? (cc: @ockham @ehg)
1. The logged-out layout was removed, with the exception of a design-specific version (#2964)
1. The design-specific version became the generic logged-out layout (#3516). This maintains the omission of `GlobalNotices`, which continues in the logged-out layout that we know and love today.

It appears the `GlobalNotices` was likely lost in the shuffle. It may have been deemed unnecessary for the design layout, then overlooked when it became the generic logged-out layout.

After all this, the login view needed to show notices (#13700).

It also appears that notices will be needed in other logged-out views (#23846).

## Testing
1. Smoke test
1. Try dispatching notices from logged out views:
   ```js
   dispatch({"type":"NOTICE_CREATE","notice":{"showDismiss":true,"status":"is-error","text":"Danger, Will Robinson!"}})
   ```
1. Visit `/log-in` while logged in, you should see exactly _one_ instance of the `NoticesList` component in the React tree.
1. #13700 appears to use local notices now. These instructions appear invalid.
   ~Try notice-related instructions from #13700~
   > Assert that an error notice is displayed when clicking either recovery code link twice in under a minute.