### PR TITLE
Stats: Period Navigation: Persist relevant query params

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/store-stats-period-nav/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-period-nav/index.js
@@ -8,6 +8,7 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import page from 'page';
+import qs from 'qs';
 
 /**
  * Internal dependencies
@@ -41,6 +42,9 @@ const StoreStatsPeriodNav = ( {
 	statType,
 	queryParams,
 } ) => {
+	// eslint-disable-next-line no-unused-vars
+	const { startDate, ...intervalQuery } = queryParams;
+	const intervalQueryString = qs.stringify( intervalQuery, { addQueryPrefix: true } );
 	return (
 		<Fragment>
 			<HeaderCake onClick={ goBack( unit, slug, queryParams ) }>{ title }</HeaderCake>
@@ -48,6 +52,7 @@ const StoreStatsPeriodNav = ( {
 				date={ selectedDate }
 				period={ unit }
 				url={ `/store/stats/${ type }/${ unit }/${ slug }` }
+				queryParams={ queryParams }
 			>
 				<DatePicker
 					period={ unit }
@@ -65,7 +70,7 @@ const StoreStatsPeriodNav = ( {
 			</StatsPeriodNavigation>
 			<Intervals
 				selected={ unit }
-				pathTemplate={ `/store/stats/${ type }/{{ interval }}/${ slug }` }
+				pathTemplate={ `/store/stats/${ type }/{{ interval }}/${ slug }${ intervalQueryString }` }
 				standalone
 			/>
 		</Fragment>

--- a/client/extensions/woocommerce/app/store-stats/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/utils.js
@@ -7,6 +7,7 @@
 import { find, includes, forEach, findIndex, round } from 'lodash';
 import classnames from 'classnames';
 import { moment, translate } from 'i18n-calypso';
+import qs from 'qs';
 
 /**
  * Internal dependencies
@@ -295,8 +296,6 @@ export function getQueries( unit, baseDate, overrides = {} ) {
  * @return {string} - widget path url portion
  */
 export function getWidgetPath( unit, slug, urlQuery ) {
-	const query = Object.keys( urlQuery || {} ).reduce( ( querystring, param, index ) => {
-		return `${ querystring }${ index === 0 ? '?' : '&' }${ param }=${ urlQuery[ param ] }`;
-	}, '' );
+	const query = qs.stringify( urlQuery, { addQueryPrefix: true } );
 	return `/${ unit }/${ slug }${ query }`;
 }

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import classNames from 'classnames';
+import qs from 'qs';
 
 /**
  * Internal dependencies
@@ -23,11 +24,13 @@ class StatsPeriodNavigation extends PureComponent {
 		onPeriodChange: PropTypes.func,
 		hidePreviousArrow: PropTypes.bool,
 		isRtl: PropTypes.bool,
+		queryParams: PropTypes.object,
 	};
 
 	static defaultProps = {
 		hidePreviousArrow: false,
 		isRtl: false,
+		queryParams: {},
 	};
 
 	handleClickNext = () => {
@@ -52,15 +55,31 @@ class StatsPeriodNavigation extends PureComponent {
 	};
 
 	render() {
-		const { children, date, moment, period, url, hidePreviousArrow, isRtl } = this.props;
+		const {
+			children,
+			date,
+			moment,
+			period,
+			url,
+			hidePreviousArrow,
+			isRtl,
+			queryParams,
+		} = this.props;
 
 		const isToday = moment( date ).isSame( moment(), period );
 		const previousDay = moment( date )
 			.subtract( 1, period )
 			.format( 'YYYY-MM-DD' );
+		const previousDayQuery = qs.stringify(
+			Object.assign( {}, queryParams, { startDate: previousDay } ),
+			{ addQueryPrefix: true }
+		);
 		const nextDay = moment( date )
 			.add( 1, period )
 			.format( 'YYYY-MM-DD' );
+		const nextDayQuery = qs.stringify( Object.assign( {}, queryParams, { startDate: nextDay } ), {
+			addQueryPrefix: true,
+		} );
 
 		return (
 			<div className="stats-period-navigation">
@@ -69,7 +88,7 @@ class StatsPeriodNavigation extends PureComponent {
 						className={ classNames( 'stats-period-navigation__previous', {
 							'is-disabled': hidePreviousArrow,
 						} ) }
-						href={ `${ url }?startDate=${ previousDay }` }
+						href={ `${ url }${ previousDayQuery }` }
 						onClick={ this.handleClickPrevious }
 					>
 						<Gridicon icon={ isRtl ? 'arrow-right' : 'arrow-left' } size={ 18 } />
@@ -79,7 +98,7 @@ class StatsPeriodNavigation extends PureComponent {
 				{ ! isToday && (
 					<a
 						className="stats-period-navigation__next"
-						href={ `${ url }?startDate=${ nextDay }` }
+						href={ `${ url }${ nextDayQuery }` }
 						onClick={ this.handleClickNext }
 					>
 						<Gridicon icon={ isRtl ? 'arrow-left' : 'arrow-right' } size={ 18 } />


### PR DESCRIPTION
`StatsPeriodNavigation` and `StoreStatsPeriodNav` components are now being used in screens with potential url query parameters beyond just `startDate`.

This PR persists those queryParams, if passed into those components so that navigation of the arrows and intervals as seen below reflect the current query parameters.

<img width="652" alt="screen shot 2018-04-06 at 10 45 51 pm" src="https://user-images.githubusercontent.com/1922453/38417413-4db982f2-39ec-11e8-993f-bbc3f266e604.png">

### Testing
* Perform navigation around Store Stats secondary pages (ie, Most Popular Products) using the arrows and interval buttons and make sure behaviour is as expected
* On the main page, append fake parameter `?thing=123`
* Click on Most Popular Products tab and watch it persist (along with any others)
* Use the arrows and intervals to see your fake parameter persist
* Note: Interval navigation will drop the `startDate` param, this is by design
* Note: The "Back" arrow/button will strip all but `startDate` because the main page has no other relevant parameters

Fixes https://github.com/Automattic/wp-calypso/issues/23916
