### PR TITLE
Guided Tours: use `min-width` for button width so single buttons don't break text unnecessarily

### DIFF
--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -119,7 +119,7 @@
 
 .guided-tours__choice-button-row, .guided-tours__single-button-row {
 	.button {
-		width: 48%;
+		min-width: 48%;
 	}
 	.guided-tours__button-link {
 		text-align: center;


### PR DESCRIPTION
This PR changes how we set the width of buttons in Guided Tours. Using `width` led to cases such as this one:

<img width="586" alt="screen shot 2018-04-04 at 6 07 33 pm" src="https://user-images.githubusercontent.com/23619/38422321-90a5313e-39aa-11e8-8ce4-1be3419ed7c9.png">

Using `min-width` avoids it:

<img width="589" alt="screen shot 2018-04-06 at 2 56 12 pm" src="https://user-images.githubusercontent.com/23619/38422340-aa72b672-39aa-11e8-8153-234842853ae0.png">

To test:
- make sure buttons look fine in different tours, e.g. try the following ones: http://calypso.localhost:3000/post/SITE_URL/POST_ID?tour=editorBasicsTour http://calypso.localhost:3000/?tour=main http://calypso.localhost:3000/media/SITE_URL?tour=mediaBasicsTour
