### PR TITLE
Request new API endpoints when "upgrades/2-year-plans" is enabled

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -759,6 +759,7 @@ Undocumented.prototype.getSitePlans = function( siteDomain, fn ) {
 		{
 			path: '/sites/' + siteDomain + '/plans',
 			method: 'get',
+			apiVersion: config.isEnabled( 'upgrades/2-year-plans' ) ? '1.3' : '1.1',
 		},
 		fn
 	);

--- a/client/state/data-layer/wpcom/plans/index.js
+++ b/client/state/data-layer/wpcom/plans/index.js
@@ -3,6 +3,7 @@
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { PLANS_REQUEST } from 'state/action-types';
@@ -25,7 +26,7 @@ import {
 export const requestPlans = action =>
 	http(
 		{
-			apiVersion: '1.4',
+			apiVersion: config.isEnabled( 'upgrades/2-year-plans' ) ? '1.5' : '1.4',
 			method: 'GET',
 			path: '/plans',
 		},

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -93,6 +93,7 @@
 		"signup/social-management": true,
 		"signup/wpcc": true,
 		"ui/first-view": false,
+		"upgrades/2-year-plans": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/config/development.json
+++ b/config/development.json
@@ -165,6 +165,7 @@
 		"try/single-cdn": true,
 		"ui/first-view": true,
 		"ui/first-view/reset-route": true,
+		"upgrades/2-year-plans": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -107,6 +107,7 @@
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,
+		"upgrades/2-year-plans": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/in-app-purchase": false,

--- a/config/production.json
+++ b/config/production.json
@@ -117,6 +117,7 @@
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,
+		"upgrades/2-year-plans": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -120,6 +120,7 @@
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,
+		"upgrades/2-year-plans": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/config/test.json
+++ b/config/test.json
@@ -94,6 +94,7 @@
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": false,
+		"upgrades/2-year-plans": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -138,6 +138,7 @@
 		"try/single-cdn": true,
 		"ui/first-view": true,
 		"ui/first-view/reset-route": true,
+		"upgrades/2-year-plans": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,


### PR DESCRIPTION
This is related to multiyear subscriptions project: p9jf6J-eR-p2

2 year subscriptions require data from new API endpoints prepared by @dzver, this PR makes it happen based on the value of feature flag.

Test plan:
* Run unit tests
* Run `npm run start`, go to /plans and filter devtools by /plans - you should see a requests to `/rest/v1.1/sites/<ID>/plans` and `/rest/v1.4/plans`
* Run `ENABLE_FEATURES=upgrades/2-year-plans npm run start`, go to /plans and filter devtools by 1.5 and 1.3 - you should see a requests to `/rest/v1.3/sites/<ID>/plans` and `/rest/v1.5/plans`