### PR TITLE
DocumentHead: Prevent resetting the page title at every route change

### DIFF
--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -20,6 +21,7 @@ import QueryContactDetailsCache from 'components/data/query-contact-details-cach
 import { getPlansBySite } from 'state/sites/plans/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import DocumentHead from 'components/data/document-head';
 
 const stores = [ DomainsStore, CartStore ];
 
@@ -71,6 +73,7 @@ const DomainManagementData = createReactClass( {
 		return (
 			<div>
 				<PageViewTracker path={ this.props.analyticsPath } title={ this.props.analyticsTitle } />
+				<DocumentHead title={ translate( 'Domains' ) } />
 				<StoreConnection
 					component={ this.props.component }
 					stores={ stores }

--- a/client/my-sites/domains/domain-management/email/index.jsx
+++ b/client/my-sites/domains/domain-management/email/index.jsx
@@ -28,6 +28,7 @@ import {
 import { hasGoogleApps, hasGoogleAppsSupportedDomain, getSelectedDomain } from 'lib/domains';
 import { isPlanFeaturesEnabled } from 'lib/plans';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
+import DocumentHead from 'components/data/document-head';
 
 class Email extends React.Component {
 	static propTypes = {
@@ -43,6 +44,7 @@ class Email extends React.Component {
 	render() {
 		return (
 			<Main className="domain-management-email" wideLayout={ isPlanFeaturesEnabled() }>
+				<DocumentHead title={ this.props.translate( 'Email' ) } />
 				<SidebarNavigation />
 				{ this.headerOrUpgradesNavigation() }
 				{ this.content() }

--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -23,7 +23,6 @@ export const title = createReducer(
 	'',
 	{
 		[ DOCUMENT_HEAD_TITLE_SET ]: ( state, action ) => action.title,
-		[ ROUTE_SET ]: () => '',
 	},
 	titleSchema
 );

--- a/client/state/document-head/test/reducer.js
+++ b/client/state/document-head/test/reducer.js
@@ -32,13 +32,6 @@ describe( 'reducer', () => {
 
 			expect( newState ).to.equal( 'new title' );
 		} );
-
-		it( 'should return initial state on route set action', () => {
-			const original = 'new title';
-			const state = title( original, { type: ROUTE_SET } );
-
-			expect( state ).to.equal( '' );
-		} );
 	} );
 
 	describe( '#unreadCount()', () => {


### PR DESCRIPTION
Fix #23924

## Context

The issue is a regression introduced by #8224 where, to avoid page titles remaining "dirty" across route changes, we decided to reset them at each `ROUTE_SET`, and [set them back once the `title` prop of `DocumentHead` changes](https://github.com/Automattic/wp-calypso/blob/master/client/components/data/document-head/index.jsx#L56-L58).
This didn't take into account that there are sections where a single `DocumentHead` spans several routes.

E.g. the Comments section has one single `<DocumentHead title="Comment">` for every filters, post views, etc.
- We start at `/comments/all/:site`, with the title `Comment`.
- We navigate to `/comments/spam/:site`.
- `ROUTE_SET` reset the `documentHead.title` into `""`, while `DocumentHead.title` remains `"Comment"`.
- `DocumentHead` doesn't see any changes, and doesn't dispatch a new `setDocumentHeadTitle`.
- The page title remains empty.

## Fix

This PR removes the `ROUTE_SET`'s `documentHead.title` reset.
After some tests, I can confirm that it fixes #23924 while also not breaking #8224.

## Caveat

I've found a section (at least one!) that doesn't use `DocumentHead`, or `setDocumentHeadTitle`, or even the deprecated Flux `setTitle`: **Domains**.
Some `/domains/manage` paths don't have any explicit title set, and therefore they retain the title of the previous page.

The obvious solution would be to add `DocumentHead` wherever it's needed.
Though, checking every controllers and every main components is not really my idea of a Friday afternoon. 😄 