### PR TITLE
Importers: update wording for other platforms.

### DIFF
--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -82,7 +82,9 @@ class SiteTools extends Component {
 		);
 
 		const importTitle = translate( 'Import' );
-		const importText = translate( 'Import content from another WordPress or Medium site.' );
+		const importText = translate(
+			'Import content from another WordPress site and other platforms.'
+		);
 		const exportTitle = translate( 'Export' );
 		const exportText = translate(
 			'Export content from your site. You own your data — take it anywhere!'

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "name-all-modules-plugin": "1.0.1",
     "node-sass": "4.5.3",
     "notifications-panel": "2.1.8",
+    "npm": "5.8.0",
     "npm-run-all": "4.0.2",
     "object-path-immutable": "0.5.2",
     "objectpath": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "name-all-modules-plugin": "1.0.1",
     "node-sass": "4.5.3",
     "notifications-panel": "2.1.8",
-    "npm": "5.8.0",
     "npm-run-all": "4.0.2",
     "object-path-immutable": "0.5.2",
     "objectpath": "1.2.1",


### PR DESCRIPTION
Fixes #17631

To test:

1. Switch to the branch.
2. Navigate to Settings, General and scroll down to Import area.
3. Notice the text says `Import content from another WordPress site and other platforms.`

<img width="854" alt="screen shot 2018-04-06 at 09 07 27" src="https://user-images.githubusercontent.com/66797/38431834-6ce2a108-397a-11e8-95b3-6a6e1f447f91.png">
