### PR TITLE
JP Remote Install: Retry on timeout

### DIFF
--- a/client/state/data-layer/wpcom/jetpack-install/index.js
+++ b/client/state/data-layer/wpcom/jetpack-install/index.js
@@ -1,10 +1,16 @@
 /** @format */
 /**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
+	jetpackRemoteInstall,
 	jetpackRemoteInstallComplete,
 	jetpackRemoteInstallUpdateError,
 } from 'state/jetpack-remote-install/actions';
@@ -35,13 +41,19 @@ export const handleSuccess = ( { url }, data ) => {
 	return logToTracks( jetpackRemoteInstallComplete( url ) );
 };
 
-export const handleError = ( { url }, error ) => {
+export const handleError = ( { url, user, password, retries }, error ) => {
 	const logToTracks = withAnalytics(
 		recordTracksEvent( 'calypso_jpc_remote_install_api_response', {
 			remote_site_url: url,
 			data: JSON.stringify( error ),
 		} )
 	);
+
+	if ( includes( error.message, 'timed out' ) ) {
+		if ( retries > 0 ) {
+			return jetpackRemoteInstall( url, user, password, retries - 1 );
+		}
+	}
 
 	return logToTracks( jetpackRemoteInstallUpdateError( url, error.error, error.message ) );
 };

--- a/client/state/data-layer/wpcom/jetpack-install/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack-install/test/index.js
@@ -86,9 +86,10 @@ describe( 'handleError', () => {
 	} );
 
 	test( 'should trigger an error if max num retries reached', () => {
-		const installAction = Object.assign( {}, INSTALL_ACTION, {
+		const installAction = {
+			...INSTALL_ACTION,
 			meta: { dataLayer: { retryCount: JETPACK_REMOTE_INSTALL_RETRIES } },
-		} );
+		};
 		const result = handleError( installAction, TIMEOUT_RESPONSE );
 		expect( result ).toEqual(
 			expect.objectContaining( {

--- a/client/state/data-layer/wpcom/jetpack-install/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack-install/test/index.js
@@ -3,20 +3,44 @@
 /**
  * Internal dependencies
  */
-import { handleError, handleSuccess, installJetpackPlugin } from '../';
+import {
+	handleError,
+	handleSuccess,
+	installJetpackPlugin,
+	JETPACK_REMOTE_INSTALL_RETRIES,
+} from '../';
 import {
 	jetpackRemoteInstallComplete,
 	jetpackRemoteInstallUpdateError,
 } from 'state/jetpack-remote-install/actions';
+import { JETPACK_REMOTE_INSTALL, JETPACK_REMOTE_INSTALL_FAILURE } from 'state/action-types';
 
 const url = 'https://yourgroovydomain.com';
 const user = 'blah123';
 const password = 'hGhrskf145kst';
 
+const INSTALL_ACTION = {
+	type: JETPACK_REMOTE_INSTALL,
+	url,
+	user,
+	password,
+	meta: {
+		dataLayer: {
+			trackRequest: true,
+		},
+	},
+};
+
 const SUCCESS_RESPONSE = { status: true };
+
 const FAILURE_RESPONSE = {
 	error: 'COULD_NOT_LOGIN',
 	message: 'extra info',
+};
+
+const TIMEOUT_RESPONSE = {
+	error: 'http_request_failed',
+	message: 'cURL error 28: Operation timed out after 10000 milliseconds with 0 bytes received',
 };
 
 describe( 'installJetpackPlugin', () => {
@@ -34,12 +58,46 @@ describe( 'handleSuccess', () => {
 } );
 
 describe( 'handleError', () => {
-	test( 'should return JetpackRemoteInstallUpdateError', () => {
-		const result = handleError( { url }, FAILURE_RESPONSE );
+	test( 'should return JetpackRemoteInstallUpdateError if not timeout error', () => {
+		const result = handleError( INSTALL_ACTION, FAILURE_RESPONSE );
 		expect( result ).toEqual(
 			expect.objectContaining(
 				jetpackRemoteInstallUpdateError( url, 'COULD_NOT_LOGIN', 'extra info' )
 			)
+		);
+	} );
+
+	test( 'should retry on timeout error', () => {
+		const result = handleError( INSTALL_ACTION, TIMEOUT_RESPONSE );
+		expect( result ).toEqual(
+			expect.objectContaining( {
+				type: JETPACK_REMOTE_INSTALL,
+				url,
+				user,
+				password,
+				meta: {
+					dataLayer: {
+						retryCount: 1,
+						trackRequest: true,
+					},
+				},
+			} )
+		);
+	} );
+
+	test( 'should trigger an error if max num retries reached', () => {
+		const installAction = Object.assign( {}, INSTALL_ACTION, {
+			meta: { dataLayer: { retryCount: JETPACK_REMOTE_INSTALL_RETRIES } },
+		} );
+		const result = handleError( installAction, TIMEOUT_RESPONSE );
+		expect( result ).toEqual(
+			expect.objectContaining( {
+				type: JETPACK_REMOTE_INSTALL_FAILURE,
+				url,
+				errorCode: 'http_request_failed',
+				errorMessage:
+					'cURL error 28: Operation timed out after 10000 milliseconds with 0 bytes received',
+			} )
 		);
 	} );
 } );

--- a/client/state/jetpack-remote-install/actions.js
+++ b/client/state/jetpack-remote-install/actions.js
@@ -15,13 +15,15 @@ import {
  * @param {string} url - The remote site url
  * @param {string} user - username or email for remote site login
  * @param {string} password - password for remote site login
+ * @param {string} retries - number of retries to attempt on timeout
  * @return {Object} action object
  */
-export const jetpackRemoteInstall = ( url, user, password ) => ( {
+export const jetpackRemoteInstall = ( url, user, password, retries = 3 ) => ( {
 	type: JETPACK_REMOTE_INSTALL,
 	url,
 	user,
 	password,
+	retries,
 	meta: {
 		dataLayer: {
 			trackRequest: true,

--- a/client/state/jetpack-remote-install/actions.js
+++ b/client/state/jetpack-remote-install/actions.js
@@ -15,15 +15,13 @@ import {
  * @param {string} url - The remote site url
  * @param {string} user - username or email for remote site login
  * @param {string} password - password for remote site login
- * @param {string} retries - number of retries to attempt on timeout
  * @return {Object} action object
  */
-export const jetpackRemoteInstall = ( url, user, password, retries = 3 ) => ( {
+export const jetpackRemoteInstall = ( url, user, password ) => ( {
 	type: JETPACK_REMOTE_INSTALL,
 	url,
 	user,
 	password,
-	retries,
 	meta: {
 		dataLayer: {
 			trackRequest: true,


### PR DESCRIPTION
Fixes #23687

Retry installation of the jetpack plugin (up to a maximum of three times) if we receive a timeout error from the API. Follows some conventions from #22454. Possibly we can introduce some general handling for `POST` retries in the future.

## Testing
* Patch D11566-code is useful for simulating timeouts
* Go to https://calypso.live/jetpack/connect?branch=try/jp-remote-install-retries
* Enter URL of a site without jetpack activated, followed by credentials on next screen
* Observe retry behaviour in browser network tab

