### PR TITLE
Domains: Show Missing-permissions Notice for domains/manage/:invalid-site

### DIFF
--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -6,7 +6,7 @@ import page from 'page';
 import { stringify } from 'qs';
 import { translate } from 'i18n-calypso';
 import React from 'react';
-import { get, noop } from 'lodash';
+import { get, includes, map, noop } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -16,7 +16,7 @@ import { sectionify } from 'lib/route';
 import Main from 'components/main';
 import { addItem } from 'lib/upgrades/actions';
 import productsFactory from 'lib/products-list';
-import { canCurrentUser } from 'state/selectors';
+import { getSites } from 'state/selectors';
 import { getSelectedSiteId, getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import CartData from 'components/data/cart';
@@ -204,9 +204,10 @@ const redirectIfNoSite = redirectTo => {
 	return ( context, next ) => {
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );
-		const userCanManageOptions = canCurrentUser( state, siteId, 'manage_options' );
+		const sites = getSites( state );
+		const siteIds = map( sites, 'ID' );
 
-		if ( ! userCanManageOptions ) {
+		if ( ! includes( siteIds, siteId ) ) {
 			const user = getCurrentUser( state );
 			const visibleSiteCount = get( user, 'visible_site_count', 0 );
 			//if only one site navigate to stats to avoid redirect loop

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -37,10 +37,10 @@ import {
 } from './constants';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+import EmptyContent from 'components/empty-content';
 import { hasDomainCredit } from 'state/sites/plans/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
-import { isDomainOnlySite, isSiteAutomatedTransfer } from 'state/selectors';
-
+import { canCurrentUser, isDomainOnlySite, isSiteAutomatedTransfer } from 'state/selectors';
 import { isPlanFeaturesEnabled } from 'lib/plans';
 import DomainToPlanNudge from 'blocks/domain-to-plan-nudge';
 import { type } from 'lib/domains/constants';
@@ -110,6 +110,18 @@ export class List extends React.Component {
 	}
 
 	render() {
+		if ( ! this.props.userCanManageOptions ) {
+			return (
+				<Main>
+					<SidebarNavigation />
+					<EmptyContent
+						title={ this.props.translate( 'You are not authorized to view this page' ) }
+						illustration={ '/calypso/images/illustrations/illustration-404.svg' }
+					/>
+				</Main>
+			);
+		}
+
 		if ( ! this.props.domains ) {
 			return null;
 		}
@@ -463,11 +475,13 @@ const undoChangePrimary = domain =>
 export default connect(
 	( state, ownProps ) => {
 		const siteId = get( ownProps, 'selectedSite.ID', null );
+		const userCanManageOptions = canCurrentUser( state, siteId, 'manage_options' );
 
 		return {
 			hasDomainCredit: !! ownProps.selectedSite && hasDomainCredit( state, siteId ),
 			isDomainOnly: isDomainOnlySite( state, siteId ),
 			isAtomicSite: isSiteAutomatedTransfer( state, siteId ),
+			userCanManageOptions,
 		};
 	},
 	dispatch => {

--- a/client/my-sites/domains/domain-management/list/test/index.js
+++ b/client/my-sites/domains/domain-management/list/test/index.js
@@ -12,6 +12,7 @@ import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import ReactDom from 'react-dom';
 import { Provider as ReduxProvider } from 'react-redux';
+import { shallow } from 'enzyme';
 
 /**
  * Internal dependencies
@@ -208,6 +209,22 @@ describe( 'index', () => {
 				);
 				assert( button === null );
 			} );
+		} );
+	} );
+
+	describe( 'when user can not manage options', () => {
+		let wrapper;
+		beforeEach( () => {
+			const props = deepFreeze( {
+				...defaultProps,
+				userCanManageOptions: false,
+			} );
+
+			wrapper = shallow( <DomainList { ...props } /> );
+		} );
+
+		test( 'shows an EmptyContent view', () => {
+			assert.equal( wrapper.find( 'EmptyContent' ).length, 1 );
 		} );
 	} );
 } );

--- a/client/my-sites/domains/domain-management/list/test/index.js
+++ b/client/my-sites/domains/domain-management/list/test/index.js
@@ -56,6 +56,7 @@ describe( 'index', () => {
 			},
 		},
 		sitePlans: {},
+		userCanManageOptions: true,
 	} );
 
 	function renderWithProps( props = defaultProps ) {


### PR DESCRIPTION
### Summary

When deep linking to `domains/manage` we see our sites list. If we select a site that we have full access to and permissions for we're taken to `domains/manage/{ that-site.wordpress.com }`.
However, if we select a site that we do not have edit privileges for we, it attempts to route to the same url but we're bounced back via a redirect to `domains/manage`. This isn't a great UX as it just feels like nothing really happened and looks buggy.
This PR aims to fix that issue by explicitly informing the customer that they lack the permissions, along with an illustration to help show that this is a whole new view.

### Test

- Starting at http://calypso.localhost:3000/domains/manage/
  - Try selecting a site that you *do* have edit permissions for.
  - You should be taken to `http://calypso.localhost:3000/domains/manage/{ that-site.wordpress.com }`
  - You should see UI for editing the domains associated with that site
- Go back to http://calypso.localhost:3000/domains/manage/
  - Try selecting a site that you *do not* have edit permissions for.
  - You should now be taken `http://calypso.localhost:3000/domains/manage/{ that-site.wordpress.com }`
  - This time, you should see a message about being unable to view this page, with an illustration
- Try to access a site that you don't have any access to at all by typing the url, for example:  http://calypso.localhost:3000/domains/manage/spentaylor.wordpress.com
  - You should be bounced back to http://calypso.localhost:3000/domains/manage/ as in the previous behaviour (this case should not have changed).

Fixes #23965 