### PR TITLE
Jetpack: Add wp-admin link on all Jetpack sites

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -533,11 +533,6 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		// Ignore Jetpack sites as they've opted into this interface.
-		if ( this.props.isJetpack && ! this.props.isSiteAutomatedTransfer ) {
-			return null;
-		}
-
 		if ( ! this.useWPAdminFlows() && ! this.props.isSiteAutomatedTransfer ) {
 			return null;
 		}


### PR DESCRIPTION
Helps address #21058 by standardizing the wp-admin link across all sites. 

Before:
<img width="285" alt="screen shot 2018-04-06 at 1 06 29 pm" src="https://user-images.githubusercontent.com/115071/38441971-63ae0048-399b-11e8-9f67-0517d3ee6644.png">
After:
<img width="317" alt="screen shot 2018-04-06 at 1 06 12 pm" src="https://user-images.githubusercontent.com/115071/38441973-675ed190-399b-11e8-8a04-2d4d0bed38c0.png">
