### PR TITLE
Rewind - credentials flow: fix font size

### DIFF
--- a/client/my-sites/stats/activity-log-switch/style.scss
+++ b/client/my-sites/stats/activity-log-switch/style.scss
@@ -43,6 +43,7 @@
 .activity-log-switch__no-thanks {
 	display: inline-block;
 	margin-top: 8px;
+	font-size: 14px;
 }
 
 .activity-log-switch__features-header {

--- a/client/signup/steps/creds-confirm/style.scss
+++ b/client/signup/steps/creds-confirm/style.scss
@@ -16,7 +16,7 @@
 
 .creds-confirm__description {
 	color: $gray-text-min;
-	font-size: 1.5rem;
+	font-size: 1.35rem;
 	font-weight: 100;
 	line-height: 2.5rem;
 }


### PR DESCRIPTION
This PR fixes two inconsistent font sizes in the flow to share/add credentials for Rewind.
### The 'No thanks' link that allows a user to go back to WP Admin

#### Before

<img width="610" alt="captura de pantalla 2018-04-06 a la s 17 56 41" src="https://user-images.githubusercontent.com/1041600/38444447-8f975388-39c5-11e8-99bf-ec708ee46efe.png">

#### After

<img width="610" alt="captura de pantalla 2018-04-06 a la s 17 57 17" src="https://user-images.githubusercontent.com/1041600/38444448-8ff68394-39c5-11e8-99fc-7ed66b96d078.png">

### The paragraph in step shown to user when they skip the step to share credentials the first time

#### Before
<img width="654" alt="captura de pantalla 2018-04-06 a la s 18 04 04" src="https://user-images.githubusercontent.com/1041600/38444468-a49550a0-39c5-11e8-85f2-3b95d8957cc2.png">

#### After

<img width="654" alt="captura de pantalla 2018-04-06 a la s 18 03 35" src="https://user-images.githubusercontent.com/1041600/38444469-a4d82ca4-39c5-11e8-80e6-e847fe325b18.png">
