### PR TITLE
Store: Check for plugin errors when setting up or fixing a store

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -14,9 +14,10 @@ import { localize } from 'i18n-calypso';
  */
 import { activatePlugin, installPlugin, fetchPlugins } from 'state/plugins/installed/actions';
 import Button from 'components/button';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 import { fetchPluginData } from 'state/plugins/wporg/actions';
 import { getPlugin } from 'state/plugins/wporg/selectors';
-import { getPlugins } from 'state/plugins/installed/selectors';
+import { getPlugins, getStatusForSite } from 'state/plugins/installed/selectors';
 import { getRequiredPluginsList } from 'woocommerce/lib/get-required-plugins';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import ProgressBar from 'components/progress-bar';
@@ -227,7 +228,7 @@ class RequiredPluginsInstallView extends Component {
 	};
 
 	doInstallation = () => {
-		const { site, sitePlugins, wporg } = this.props;
+		const { pluginsStatus, site, sitePlugins, wporg } = this.props;
 
 		// If we are working on nothing presently, get the next thing to install and install it
 		if ( 0 === this.state.workingOn.length ) {
@@ -242,7 +243,10 @@ class RequiredPluginsInstallView extends Component {
 			}
 
 			const workingOn = toInstall.shift();
-			this.props.installPlugin( site.ID, getPlugin( wporg, workingOn ) );
+			const thisPlugin = getPlugin( wporg, workingOn );
+			// Set a default ID if needed.
+			thisPlugin.id = thisPlugin.id || thisPlugin.slug;
+			this.props.installPlugin( site.ID, thisPlugin );
 
 			this.setState( {
 				toInstall,
@@ -257,6 +261,14 @@ class RequiredPluginsInstallView extends Component {
 			this.setState( {
 				workingOn: '',
 				progress: this.state.progress + this.getPluginInstallationTime(),
+			} );
+		}
+
+		// Or, it's in the error state
+		const pluginStatus = pluginsStatus[ this.state.workingOn ];
+		if ( pluginStatus && 'error' === pluginStatus.status ) {
+			this.setState( {
+				engineState: 'DONEFAILURE',
 			} );
 		}
 	};
@@ -395,12 +407,46 @@ class RequiredPluginsInstallView extends Component {
 		return TIME_TO_PLUGIN_INSTALLATION;
 	};
 
+	renderContactSupport() {
+		const { translate, wporg } = this.props;
+		const { workingOn } = this.state;
+		const plugin = getPlugin( wporg, workingOn );
+		return (
+			<div className="dashboard__setup-wrapper setup__wrapper">
+				<div className="card dashboard__plugins-install-view">
+					<SetupHeader
+						imageSource={ '/calypso/images/extensions/woocommerce/woocommerce-store-creation.svg' }
+						imageWidth={ 160 }
+						title={ translate( "We can't update your store" ) }
+						subtitle={ translate(
+							"Your store is missing some required plugins. We can't fix this automatically due to " +
+								'a problem with the {{b}}%(plugin)s{{/b}} plugin. {{br/}}{{br/}}' +
+								"Please contact support and we'll get your store back up and running!",
+							{
+								args: { plugin: plugin.name || workingOn },
+								components: { b: <strong />, br: <br /> },
+							}
+						) }
+					>
+						<Button primary href={ CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer">
+							{ this.props.translate( 'Get in touch' ) }
+						</Button>
+					</SetupHeader>
+				</div>
+			</div>
+		);
+	}
+
 	render() {
 		const { hasPendingAT, title, translate } = this.props;
 		const { engineState, progress, totalSeconds } = this.state;
 
 		if ( ! hasPendingAT && 'CONFIRMING' === engineState ) {
 			return this.renderConfirmScreen();
+		}
+
+		if ( 'DONEFAILURE' === engineState ) {
+			return this.renderContactSupport();
 		}
 
 		return (
@@ -426,11 +472,13 @@ function mapStateToProps( state ) {
 	const siteId = site.ID;
 
 	const sitePlugins = site ? getPlugins( state, [ siteId ] ) : [];
+	const pluginsStatus = getStatusForSite( state, siteId );
 
 	return {
 		site,
 		siteId,
 		sitePlugins,
+		pluginsStatus,
 		wporg: state.plugins.wporg.items,
 		automatedTransferStatus: getAutomatedTransferStatus( state, siteId ),
 		hasPendingAT: hasSitePendingAutomatedTransfer( state, siteId ),

--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -411,6 +411,23 @@ class RequiredPluginsInstallView extends Component {
 		const { translate, wporg } = this.props;
 		const { workingOn } = this.state;
 		const plugin = getPlugin( wporg, workingOn );
+
+		const subtitle = [
+			<p key="line-1">
+				{ translate(
+					"Your store is missing some required plugins. We can't fix this automatically " +
+						'due to a problem with the {{b}}%(pluginName)s{{/b}} plugin.',
+					{
+						args: { pluginName: plugin.name || workingOn },
+						components: { b: <strong /> },
+					}
+				) }
+			</p>,
+			<p key="line-2">
+				{ translate( "Please contact support and we'll get your store back up and running!" ) }
+			</p>,
+		];
+
 		return (
 			<div className="dashboard__setup-wrapper setup__wrapper">
 				<div className="card dashboard__plugins-install-view">
@@ -418,15 +435,7 @@ class RequiredPluginsInstallView extends Component {
 						imageSource={ '/calypso/images/extensions/woocommerce/woocommerce-store-creation.svg' }
 						imageWidth={ 160 }
 						title={ translate( "We can't update your store" ) }
-						subtitle={ translate(
-							"Your store is missing some required plugins. We can't fix this automatically due to " +
-								'a problem with the {{b}}%(plugin)s{{/b}} plugin. {{br/}}{{br/}}' +
-								"Please contact support and we'll get your store back up and running!",
-							{
-								args: { plugin: plugin.name || workingOn },
-								components: { b: <strong />, br: <br /> },
-							}
-						) }
+						subtitle={ subtitle }
 					>
 						<Button primary href={ CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer">
 							{ this.props.translate( 'Get in touch' ) }

--- a/client/extensions/woocommerce/app/dashboard/setup/header.js
+++ b/client/extensions/woocommerce/app/dashboard/setup/header.js
@@ -8,18 +8,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const SetupHeader = ( { imageSource, imageWidth, subtitle, title, children } ) => {
+	const Tag = 'string' === typeof subtitle ? 'p' : 'div';
+
 	return (
 		<div className="setup__header">
 			{ imageSource && (
-				<img
-					src={ imageSource }
-					width={ imageWidth }
-					className="setup__header-image"
-					alt=""
-				/>
+				<img src={ imageSource } width={ imageWidth } className="setup__header-image" alt="" />
 			) }
 			{ <h2 className="setup__header-title form-section-heading">{ title }</h2> }
-			{ subtitle && <p className="setup__header-subtitle">{ subtitle }</p> }
+			{ subtitle && <Tag className="setup__header-subtitle">{ subtitle }</Tag> }
 			{ children }
 		</div>
 	);

--- a/client/extensions/woocommerce/app/dashboard/setup/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/setup/style.scss
@@ -15,7 +15,7 @@
 	.setup__header-subtitle {
 		color: $gray-text-min;
 		margin: 0 auto 32px;
-		max-width: 400px;
+		max-width: 520px;
 	}
 
 	.button {

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -138,6 +138,13 @@ export function getStatusForPlugin( state, siteId, pluginId ) {
 	return Object.assign( {}, status, { siteId: siteId, pluginId: pluginId } );
 }
 
+export function getStatusForSite( state, siteId ) {
+	if ( typeof state.plugins.installed.status[ siteId ] === 'undefined' ) {
+		return false;
+	}
+	return state.plugins.installed.status[ siteId ];
+}
+
 export function isPluginDoingAction( state, siteId, pluginId ) {
 	const status = getStatusForPlugin( state, siteId, pluginId );
 	return !! status && 'inProgress' === status.status;


### PR DESCRIPTION
As reported in #23899, the new "store fixer" step can get stuck in a perpetual loading state due to the `folder_exists` error (also reported in the setup flow, in #18462).

This appears to be a problem where a required plugin was removed from a site, but isn't completely gone. WordPress core is very careful to not overwrite an existing plugin, so it sees the remains of the other plugin and aborts the install. This causes an error, but also leaves the store in an inaccessible state, so now we're detecting any errors in installing, and directing the user to contact support.

We also try to let the user know which plugin had the problem, so they can pass that on to HEs.

![screen shot 2018-04-06 at 5 08 05 pm](https://user-images.githubusercontent.com/541093/38444926-4af0e81c-39bf-11e8-91fa-83aff1e49e9d.png)

[See a screen recording](https://cloudup.com/cTZL0_XlXIt)

**To test**

First, break your site 😁 

- Do this on a site where you have FTP access
- Delete one of the [required plugins](https://github.com/Automattic/wp-calypso/blob/master/client/extensions/woocommerce/lib/get-required-plugins.js), for example woocommerce-services
- Add a folder to your plugins dir, `woocommerce-services`
- Add any file to that folder (WP is smart enough to install over an empty directory)

Now you can test this branch

- Go to any store page, `/store/:site`
- It should detect that you're missing a plugin, and try to install it
- It should fail, because you broke your site, and tell you to contact support
- Remove the fake plugin folder, and reload the store
- It should install the plugin correctly, and take you on to the requested page

Theoretically this also fixes this error in the setup flow, but I don't know how to replicate this for a site that hasn't been set up yet.