### PR TITLE
Remove unused CSS in plugins

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -84,15 +84,6 @@
 	font-size: 13px;
 }
 
-.plugins-browser-item .plugin-icon.is-placeholder,
-.plugins-browser-item .plugin-icon[style*='undefined'] {
-	&::before {
-		width: 40px;
-		height: 40px;
-		font: normal 40px/40px Noticons;
-	}
-}
-
 .plugins-browser-item .plugin-icon {
 	margin-right: 0;
 }


### PR DESCRIPTION
This removes another reference to Noticons. This CSS isn't used.

To test go to https://wordpress.com/plugins and check that the placeholders still look ok.