### PR TITLE
WrapSettingsForm: Change order of Higher-Order Components

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -330,7 +330,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 		}
 	);
 
-	return flowRight( connectComponent, localize, trackForm, protectForm )( WrappedSettingsForm );
+	return flowRight( trackForm, protectForm, connectComponent, localize )( WrappedSettingsForm );
 };
 
 export default wrapSettingsForm;


### PR DESCRIPTION
Move the `trackForm` and `protectForm` HOCs before `connectComponent` and `localize`.

Needed for #23797, so the `fields` prop (which we get from the `trackForm` HOC) is available inside `connect()`'s `mapStateToProps`, which we need in order to use the re-implemented `isUpdatingJetpackSettings` selector (which needs explicit `settings`  to be passed).

More background: https://github.com/Automattic/wp-calypso/pull/23797#discussion_r179452880

AFAICS, this shouldn't break things, since `trackForm` and `protectForm` don't interact with `connectComponent` otherwise.

To test: Verify that `calypso.localhost:3000/settings/general/<yourSite>`  still works. Try with both dotcom and a JP sites.