### PR TITLE
Make the checkout tabs transparent at larger screen sizes

### DIFF
--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -776,6 +776,10 @@
 			.section-nav-tab__link {
 				color: $blue-wordpress;
 				background-color: $gray-light;
+
+				@include breakpoint( '>480px' ) {
+					background-color: transparent;
+				}
 			}
 		}
 


### PR DESCRIPTION
This fixes a regression introduced in #23780.

Before:
<img width="911" alt="screen shot 2018-04-09 at 10 04 36" src="https://user-images.githubusercontent.com/275961/38489141-6d6104b6-3bdd-11e8-892e-29efb943fdff.png">

After:
<img width="897" alt="screen shot 2018-04-09 at 10 02 12" src="https://user-images.githubusercontent.com/275961/38489144-6ed6d78a-3bdd-11e8-92f3-afb3e2ff902c.png">


