### PR TITLE
Make <CartItem /> compatible with 2-year plans

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -53,6 +53,7 @@ export const JETPACK_MONTHLY_PLANS = [
 
 export const PLAN_MONTHLY_PERIOD = 31;
 export const PLAN_ANNUAL_PERIOD = 365;
+export const PLAN_BIENNIAL_PERIOD = 730;
 
 // features constants
 export const FEATURE_WP_SUBDOMAIN = 'wordpress-subdomain';

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -348,18 +348,24 @@ export function calculateMonthlyPriceForPlan( planSlug, termPrice ) {
 }
 
 export function calculateMonthlyPrice( term, termPrice ) {
-	let divisor;
+	const divisor = getBillingMonthsForTerm( term );
+	return parseFloat( ( termPrice / divisor ).toFixed( 2 ) );
+}
+
+export function getBillingMonthsForPlan( planSlug ) {
+	return getBillingMonthsForTerm( getPlan( planSlug ).term );
+}
+
+export function getBillingMonthsForTerm( term ) {
 	if ( term === TERM_MONTHLY ) {
-		divisor = 1;
+		return 1;
 	} else if ( term === TERM_ANNUALLY ) {
-		divisor = 12;
+		return 12;
 	} else if ( term === TERM_BIENNIALLY ) {
-		divisor = 24;
-	} else {
-		throw new Error( `Unknown term: ${ term }` );
+		return 24;
 	}
 
-	return parseFloat( ( termPrice / divisor ).toFixed( 2 ) );
+	throw new Error( `Unknown term: ${ term }` );
 }
 
 export const isPlanFeaturesEnabled = () => {

--- a/client/lib/plans/test/plan-other.js
+++ b/client/lib/plans/test/plan-other.js
@@ -2,39 +2,53 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
  */
 import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from '../constants';
-import { calculateMonthlyPrice } from '../index';
+import { calculateMonthlyPrice, getBillingMonthsForTerm } from '../index';
 
 describe( 'calculateMonthlyPrice', () => {
 	test( 'should return same number for monthly term', () => {
-		expect( calculateMonthlyPrice( TERM_MONTHLY, 10 ) ).to.equal( 10 );
-		expect( calculateMonthlyPrice( TERM_MONTHLY, 12.32 ) ).to.equal( 12.32 );
+		expect( calculateMonthlyPrice( TERM_MONTHLY, 10 ) ).toBe( 10 );
+		expect( calculateMonthlyPrice( TERM_MONTHLY, 12.32 ) ).toBe( 12.32 );
 	} );
 	test( 'should calculate proper result for annual term', () => {
-		expect( calculateMonthlyPrice( TERM_ANNUALLY, 12 ) ).to.equal( 1.0 );
-		expect( calculateMonthlyPrice( TERM_ANNUALLY, 120 ) ).to.equal( 10.0 );
-		expect( calculateMonthlyPrice( TERM_ANNUALLY, 240 ) ).to.equal( 20.0 );
-		expect( calculateMonthlyPrice( TERM_ANNUALLY, 122 ) ).to.equal( 10.17 );
-		expect( calculateMonthlyPrice( TERM_ANNUALLY, 127 ) ).to.equal( 10.58 );
-		expect( calculateMonthlyPrice( TERM_ANNUALLY, 128 ) ).to.equal( 10.67 );
-		expect( calculateMonthlyPrice( TERM_ANNUALLY, 129 ) ).to.equal( 10.75 );
-		expect( calculateMonthlyPrice( TERM_ANNUALLY, 130 ) ).to.equal( 10.83 );
-		expect( calculateMonthlyPrice( TERM_ANNUALLY, 131 ) ).to.equal( 10.92 );
+		expect( calculateMonthlyPrice( TERM_ANNUALLY, 12 ) ).toBe( 1.0 );
+		expect( calculateMonthlyPrice( TERM_ANNUALLY, 120 ) ).toBe( 10.0 );
+		expect( calculateMonthlyPrice( TERM_ANNUALLY, 240 ) ).toBe( 20.0 );
+		expect( calculateMonthlyPrice( TERM_ANNUALLY, 122 ) ).toBe( 10.17 );
+		expect( calculateMonthlyPrice( TERM_ANNUALLY, 127 ) ).toBe( 10.58 );
+		expect( calculateMonthlyPrice( TERM_ANNUALLY, 128 ) ).toBe( 10.67 );
+		expect( calculateMonthlyPrice( TERM_ANNUALLY, 129 ) ).toBe( 10.75 );
+		expect( calculateMonthlyPrice( TERM_ANNUALLY, 130 ) ).toBe( 10.83 );
+		expect( calculateMonthlyPrice( TERM_ANNUALLY, 131 ) ).toBe( 10.92 );
 	} );
 	test( 'should calculate proper result for biennial term', () => {
-		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 12 ) ).to.equal( 0.5 );
-		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 120 ) ).to.equal( 5.0 );
-		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 240 ) ).to.equal( 10.0 );
-		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 122 ) ).to.equal( 5.08 );
-		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 127 ) ).to.equal( 5.29 );
-		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 128 ) ).to.equal( 5.33 );
-		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 129 ) ).to.equal( 5.38 );
-		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 130 ) ).to.equal( 5.42 );
-		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 131 ) ).to.equal( 5.46 );
+		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 12 ) ).toBe( 0.5 );
+		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 120 ) ).toBe( 5.0 );
+		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 240 ) ).toBe( 10.0 );
+		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 122 ) ).toBe( 5.08 );
+		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 127 ) ).toBe( 5.29 );
+		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 128 ) ).toBe( 5.33 );
+		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 129 ) ).toBe( 5.38 );
+		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 130 ) ).toBe( 5.42 );
+		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 131 ) ).toBe( 5.46 );
+	} );
+} );
+
+describe( 'getBillingMonthsForTerm', () => {
+	test( 'should 1 for monthly term', () => {
+		expect( getBillingMonthsForTerm( TERM_MONTHLY ) ).toBe( 1 );
+	} );
+	test( 'should 12 annual term', () => {
+		expect( getBillingMonthsForTerm( TERM_ANNUALLY ) ).toBe( 12 );
+	} );
+	test( 'should 24 for biennial term', () => {
+		expect( getBillingMonthsForTerm( TERM_BIENNIALLY ) ).toBe( 24 );
+	} );
+	test( 'should throw an error for unknown term', () => {
+		expect( () => getBillingMonthsForTerm( 'fake' ) ).toThrowError();
 	} );
 } );

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -25,8 +25,8 @@ import {
 	PLAN_WPCOM_ENTERPRISE,
 	PLAN_CHARGEBACK,
 	PLAN_MONTHLY_PERIOD,
-	PLAN_ANNUALLY_PERIOD,
-	PLAN_BIENNIALLY_PERIOD,
+	PLAN_ANNUAL_PERIOD,
+	PLAN_BIENNIAL_PERIOD,
 } from 'lib/plans/constants';
 import { domainProductSlugs } from 'lib/domains/constants';
 
@@ -179,14 +179,14 @@ export function isYearly( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return parseInt( product.bill_period, 10 ) === PLAN_ANNUALLY_PERIOD;
+	return parseInt( product.bill_period, 10 ) === PLAN_ANNUAL_PERIOD;
 }
 
-export function isBiennialy( product ) {
+export function isBiennially( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return parseInt( product.bill_period, 10 ) === PLAN_BIENNIALLY_PERIOD;
+	return parseInt( product.bill_period, 10 ) === PLAN_BIENNIAL_PERIOD;
 }
 
 export function isJpphpBundle( product ) {

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -25,6 +25,8 @@ import {
 	PLAN_WPCOM_ENTERPRISE,
 	PLAN_CHARGEBACK,
 	PLAN_MONTHLY_PERIOD,
+	PLAN_ANNUALLY_PERIOD,
+	PLAN_BIENNIALLY_PERIOD,
 } from 'lib/plans/constants';
 import { domainProductSlugs } from 'lib/domains/constants';
 
@@ -171,6 +173,20 @@ export function isMonthly( product ) {
 	assertValidProduct( product );
 
 	return parseInt( product.bill_period, 10 ) === PLAN_MONTHLY_PERIOD;
+}
+
+export function isYearly( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return parseInt( product.bill_period, 10 ) === PLAN_ANNUALLY_PERIOD;
+}
+
+export function isBiennialy( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return parseInt( product.bill_period, 10 ) === PLAN_BIENNIALLY_PERIOD;
 }
 
 export function isJpphpBundle( product ) {

--- a/client/lib/products-values/test/index.js
+++ b/client/lib/products-values/test/index.js
@@ -3,12 +3,11 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
  */
-import { isJetpackPlan } from '..';
+import { isJetpackPlan, isMonthly, isYearly, isBiennially } from '..';
 import {
 	JETPACK_PLANS,
 	PLAN_BUSINESS,
@@ -27,8 +26,8 @@ const makeProductFromSlug = product_slug => ( { product_slug } );
 
 describe( 'isJetpackPlan', () => {
 	test( 'should return true for Jetpack products', () => {
-		JETPACK_PLANS.map( makeProductFromSlug ).forEach(
-			product => expect( isJetpackPlan( product ) ).to.be.true
+		JETPACK_PLANS.map( makeProductFromSlug ).forEach( product =>
+			expect( isJetpackPlan( product ) ).toBe( true )
 		);
 	} );
 
@@ -37,6 +36,39 @@ describe( 'isJetpackPlan', () => {
 
 		nonJetpackPlans
 			.map( makeProductFromSlug )
-			.forEach( product => expect( isJetpackPlan( product ) ).to.be.false );
+			.forEach( product => expect( isJetpackPlan( product ) ).toBe( false ) );
+	} );
+} );
+
+describe( 'isMonthly', () => {
+	test( 'should return true for monthly products', () => {
+		expect( isMonthly( { bill_period: 31 } ) ).toBe( true );
+	} );
+	test( 'should return true for other products', () => {
+		expect( isMonthly( { bill_period: 30 } ) ).toBe( false );
+		expect( isMonthly( { bill_period: 32 } ) ).toBe( false );
+		expect( isMonthly( { bill_period: 365 } ) ).toBe( false );
+	} );
+} );
+
+describe( 'isYearly', () => {
+	test( 'should return true for yearly products', () => {
+		expect( isYearly( { bill_period: 365 } ) ).toBe( true );
+	} );
+	test( 'should return true for other products', () => {
+		expect( isYearly( { bill_period: 700 } ) ).toBe( false );
+		expect( isYearly( { bill_period: 31 } ) ).toBe( false );
+		expect( isYearly( { bill_period: 364 } ) ).toBe( false );
+	} );
+} );
+
+describe( 'isBiennially', () => {
+	test( 'should return true for biennial products', () => {
+		expect( isBiennially( { bill_period: 730 } ) ).toBe( true );
+	} );
+	test( 'should return true for other products', () => {
+		expect( isBiennially( { bill_period: 365 } ) ).toBe( false );
+		expect( isBiennially( { bill_period: 31 } ) ).toBe( false );
+		expect( isBiennially( { bill_period: 731 } ) ).toBe( false );
 	} );
 } );

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -22,6 +22,7 @@ import {
 import { currentUserHasFlag } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import { removeItem } from 'lib/upgrades/actions';
+import formatCurrency from 'lib/format-currency';
 import { localize } from 'i18n-calypso';
 import { calculateMonthlyPriceForPlan, getBillingMonthsForPlan } from 'lib/plans';
 
@@ -66,18 +67,18 @@ export class CartItem extends React.Component {
 
 	monthlyPrice() {
 		const { cartItem, translate } = this.props;
-		const { cost, currency } = cartItem;
+		const { currency } = cartItem;
 
 		if ( ! this.monthlyPriceApplies() ) {
 			return null;
 		}
 
-		return translate( '(%(monthlyPrice)f %(currency)s x 12 months)', {
+		const { months, monthlyPrice } = this.calcMonthlyBillingDetails();
+
+		return translate( '(%(monthlyPrice)s x %(months) months)', {
 			args: {
-				monthlyPrice: calculateMonthlyPriceForPlan( cartItem.product_slug, cost ).toFixed(
-					currency === 'JPY' ? 0 : 2
-				),
-				currency,
+				months,
+				monthlyPrice: formatCurrency( monthlyPrice, currency ),
 			},
 		} );
 	}

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -24,7 +24,6 @@ import {
 import { currentUserHasFlag } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import { removeItem } from 'lib/upgrades/actions';
-import formatCurrency from 'lib/format-currency';
 import { localize } from 'i18n-calypso';
 import { calculateMonthlyPriceForPlan, getBillingMonthsForPlan } from 'lib/plans';
 
@@ -77,10 +76,11 @@ export class CartItem extends React.Component {
 
 		const { months, monthlyPrice } = this.calcMonthlyBillingDetails();
 
-		return translate( '(%(monthlyPrice)s x %(months) months)', {
+		return translate( '(%(monthlyPrice)s %(currency)s x %(months)d months)', {
 			args: {
 				months,
-				monthlyPrice: formatCurrency( monthlyPrice, currency ),
+				currency,
+				monthlyPrice: monthlyPrice.toFixed( currency === 'JPY' ? 0 : 2 ),
 			},
 		} );
 	}

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -16,6 +16,8 @@ import {
 	isGoogleApps,
 	isTheme,
 	isMonthly,
+	isYearly,
+	isBiennially,
 	isPlan,
 	isBundled,
 } from 'lib/products-values';
@@ -162,12 +164,9 @@ export class CartItem extends React.Component {
 		const { cartItem, translate } = this.props;
 
 		let name = this.getProductName();
-		if ( cartItem.bill_period && parseInt( cartItem.bill_period ) !== -1 ) {
-			if ( isMonthly( cartItem ) ) {
-				name += ' - ' + translate( 'monthly subscription' );
-			} else {
-				name += ' - ' + translate( 'annual subscription' );
-			}
+		const subscriptionLength = this.getSubscriptionLength();
+		if ( subscriptionLength ) {
+			name += ' - ' + subscriptionLength;
 		}
 
 		if ( isTheme( cartItem ) ) {
@@ -190,6 +189,24 @@ export class CartItem extends React.Component {
 			</li>
 		);
 		/*eslint-enable wpcalypso/jsx-classname-namespace*/
+	}
+
+	getSubscriptionLength() {
+		const { cartItem, translate } = this.props;
+		const hasBillPeriod = cartItem.bill_period && parseInt( cartItem.bill_period ) !== -1;
+		if ( ! hasBillPeriod ) {
+			return false;
+		}
+
+		if ( isMonthly( cartItem ) ) {
+			return translate( 'monthly subscription' );
+		} else if ( isYearly( cartItem ) ) {
+			return translate( 'annual subscription' );
+		} else if ( isBiennially( cartItem ) ) {
+			return translate( 'biennial subscription' );
+		}
+
+		return false;
 	}
 
 	getProductName() {

--- a/client/my-sites/checkout/cart/test/cart-item.js
+++ b/client/my-sites/checkout/cart/test/cart-item.js
@@ -1,0 +1,108 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import { identity } from 'lodash';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { CartItem } from '../cart-item';
+import { isPlan, isMonthly } from 'lib/products-values';
+
+jest.mock( 'lib/mixins/analytics', () => ( {} ) );
+jest.mock( 'lib/products-values', () => ( {
+	isPlan: jest.fn( () => null ),
+	isTheme: jest.fn( () => null ),
+	isMonthly: jest.fn( () => null ),
+	isBundled: jest.fn( () => null ),
+	isCredits: jest.fn( () => null ),
+	isGoogleApps: jest.fn( () => null ),
+} ) );
+
+const cartItem = {
+	cost: 120,
+	bill_period: 1,
+	volume: 1,
+	product_name: 'name!',
+};
+
+const props = {
+	cartItem,
+	translate: identity,
+};
+
+describe( 'cart-item', () => {
+	test( 'Does not blow up', () => {
+		const comp = shallow( <CartItem { ...props } /> );
+		expect( comp.find( '.cart-item' ).length ).toBe( 1 );
+	} );
+
+	describe( 'calculates correct monthly price', () => {
+		beforeEach( () => {
+			isPlan.mockImplementation( () => true );
+			isMonthly.mockImplementation( () => false );
+		} );
+
+		test( 'Returns null if cost is undefined', () => {
+			const instance = new CartItem( {
+				...props,
+				cartItem: {
+					...cartItem,
+					cost: undefined,
+				},
+			} );
+			expect( instance.monthlyPrice() ).toBe( null );
+		} );
+
+		test( 'Returns null if cartItem is not a plan', () => {
+			isPlan.mockImplementation( () => false );
+			const instance = new CartItem( {
+				...props,
+				cartItem: {
+					...cartItem,
+				},
+			} );
+			expect( instance.monthlyPrice() ).toBe( null );
+		} );
+
+		test( 'Returns null if cost is 0', () => {
+			const instance = new CartItem( {
+				...props,
+				cartItem: {
+					...cartItem,
+					cost: 0,
+				},
+			} );
+			expect( instance.monthlyPrice() ).toBe( null );
+		} );
+
+		test( 'Returns null if cost is less than 0', () => {
+			const instance = new CartItem( {
+				...props,
+				cartItem: {
+					...cartItem,
+					cost: -1,
+				},
+			} );
+			expect( instance.monthlyPrice() ).toBe( null );
+		} );
+
+		test( 'Returns null if plan is a monthly plan', () => {
+			isMonthly.mockImplementation( () => true );
+			const instance = new CartItem( props );
+			expect( instance.monthlyPrice() ).toBe( null );
+		} );
+
+		test( 'Returns string if plan is not a monthly plan', () => {
+			const instance = new CartItem( props );
+			expect( typeof instance.monthlyPrice() ).toBe( 'string' );
+		} );
+	} );
+} );

--- a/client/my-sites/checkout/cart/test/cart-item.js
+++ b/client/my-sites/checkout/cart/test/cart-item.js
@@ -7,7 +7,7 @@
  * External dependencies
  */
 import { shallow } from 'enzyme';
-import { identity } from 'lodash';
+import { pick, identity } from 'lodash';
 import React from 'react';
 
 /**
@@ -15,6 +15,23 @@ import React from 'react';
  */
 import { CartItem } from '../cart-item';
 import { isPlan, isMonthly } from 'lib/products-values';
+import {
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+} from '../../../../lib/plans/constants';
+
+const plansModule = require( 'lib/plans' );
+const originalPlansModuleFunctions = pick( plansModule, [
+	'calculateMonthlyPriceForPlan',
+	'getBillingMonthsForPlan',
+] );
+const mockPlansModule = () => {
+	plansModule.calculateMonthlyPriceForPlan = jest.fn( () => 120 );
+	plansModule.getBillingMonthsForPlan = jest.fn( () => 10 );
+};
+mockPlansModule();
 
 jest.mock( 'lib/mixins/analytics', () => ( {} ) );
 jest.mock( 'lib/products-values', () => ( {
@@ -31,11 +48,13 @@ const cartItem = {
 	bill_period: 1,
 	volume: 1,
 	product_name: 'name!',
+	product_slug: 'plan_value_bundle',
 };
 
+const translate = jest.fn( identity );
 const props = {
 	cartItem,
-	translate: identity,
+	translate,
 };
 
 describe( 'cart-item', () => {
@@ -44,24 +63,13 @@ describe( 'cart-item', () => {
 		expect( comp.find( '.cart-item' ).length ).toBe( 1 );
 	} );
 
-	describe( 'calculates correct monthly price', () => {
+	describe( 'monthlyPriceApplies', () => {
 		beforeEach( () => {
 			isPlan.mockImplementation( () => true );
 			isMonthly.mockImplementation( () => false );
 		} );
 
-		test( 'Returns null if cost is undefined', () => {
-			const instance = new CartItem( {
-				...props,
-				cartItem: {
-					...cartItem,
-					cost: undefined,
-				},
-			} );
-			expect( instance.monthlyPrice() ).toBe( null );
-		} );
-
-		test( 'Returns null if cartItem is not a plan', () => {
+		test( 'Returns false if cartItem is not a plan', () => {
 			isPlan.mockImplementation( () => false );
 			const instance = new CartItem( {
 				...props,
@@ -69,10 +77,27 @@ describe( 'cart-item', () => {
 					...cartItem,
 				},
 			} );
-			expect( instance.monthlyPrice() ).toBe( null );
+			expect( instance.monthlyPriceApplies() ).toBe( false );
 		} );
 
-		test( 'Returns null if cost is 0', () => {
+		test( 'Returns false if plan is a monthly plan', () => {
+			isMonthly.mockImplementation( () => true );
+			const instance = new CartItem( props );
+			expect( instance.monthlyPriceApplies() ).toBe( false );
+		} );
+
+		test( 'Returns false if cost is undefined', () => {
+			const instance = new CartItem( {
+				...props,
+				cartItem: {
+					...cartItem,
+					cost: undefined,
+				},
+			} );
+			expect( instance.monthlyPriceApplies() ).toBe( false );
+		} );
+
+		test( 'Returns false if cost is 0', () => {
 			const instance = new CartItem( {
 				...props,
 				cartItem: {
@@ -80,10 +105,10 @@ describe( 'cart-item', () => {
 					cost: 0,
 				},
 			} );
-			expect( instance.monthlyPrice() ).toBe( null );
+			expect( instance.monthlyPriceApplies() ).toBe( false );
 		} );
 
-		test( 'Returns null if cost is less than 0', () => {
+		test( 'Returns false if cost is less than 0', () => {
 			const instance = new CartItem( {
 				...props,
 				cartItem: {
@@ -91,18 +116,86 @@ describe( 'cart-item', () => {
 					cost: -1,
 				},
 			} );
-			expect( instance.monthlyPrice() ).toBe( null );
+			expect( instance.monthlyPriceApplies() ).toBe( false );
 		} );
 
-		test( 'Returns null if plan is a monthly plan', () => {
-			isMonthly.mockImplementation( () => true );
+		test( 'Returns true if plan is not a monthly plan', () => {
 			const instance = new CartItem( props );
-			expect( instance.monthlyPrice() ).toBe( null );
+			expect( instance.monthlyPriceApplies() ).toBe( true );
+		} );
+	} );
+
+	describe( 'calcMonthlyBillingDetails - mocks', () => {
+		const { calculateMonthlyPriceForPlan, getBillingMonthsForPlan } = plansModule;
+		beforeEach( () => {
+			calculateMonthlyPriceForPlan.mockReset();
+			calculateMonthlyPriceForPlan.mockImplementation( () => 299 );
+
+			getBillingMonthsForPlan.mockReset();
+			getBillingMonthsForPlan.mockImplementation( () => 36 );
 		} );
 
-		test( 'Returns string if plan is not a monthly plan', () => {
+		test( 'Calls calculateMonthlyPriceForPlan to compute details', () => {
 			const instance = new CartItem( props );
-			expect( typeof instance.monthlyPrice() ).toBe( 'string' );
+			instance.calcMonthlyBillingDetails();
+			expect( calculateMonthlyPriceForPlan ).toHaveBeenCalledTimes( 1 );
+			expect( calculateMonthlyPriceForPlan ).toHaveBeenCalledWith( 'plan_value_bundle', 120 );
+
+			expect( getBillingMonthsForPlan ).toHaveBeenCalledTimes( 1 );
+			expect( getBillingMonthsForPlan ).toHaveBeenCalledWith( 'plan_value_bundle' );
+		} );
+
+		test( 'Uses values returned by calculateMonthlyPriceForPlan', () => {
+			const instance = new CartItem( props );
+			const details = instance.calcMonthlyBillingDetails();
+			expect( details ).toEqual( {
+				monthlyPrice: 299,
+				months: 36,
+			} );
+		} );
+	} );
+
+	describe( 'calcMonthlyBillingDetails - real callbacks', () => {
+		beforeAll( () => {
+			// restore original functions
+			for ( const key in originalPlansModuleFunctions ) {
+				plansModule[ key ] = originalPlansModuleFunctions[ key ];
+			}
+		} );
+
+		afterAll( () => {
+			mockPlansModule();
+		} );
+
+		const expectations = [
+			[ { product_slug: PLAN_PERSONAL, cost: 120 }, { months: 12, monthlyPrice: 10 } ],
+			[ { product_slug: PLAN_PREMIUM, cost: 180 }, { months: 12, monthlyPrice: 15 } ],
+			[ { product_slug: PLAN_BUSINESS_2_YEARS, cost: 480 }, { months: 24, monthlyPrice: 20 } ],
+			[ { product_slug: PLAN_JETPACK_PERSONAL, cost: 288 }, { months: 12, monthlyPrice: 24 } ],
+		];
+
+		expectations.forEach( ( [ input, output ] ) => {
+			test( `Returns correct values for annual plan ${ input.product_slug }`, () => {
+				const instance = new CartItem( {
+					...props,
+					cartItem: {
+						...cartItem,
+						...input,
+					},
+				} );
+				expect( instance.calcMonthlyBillingDetails() ).toEqual( output );
+			} );
+		} );
+
+		test( 'Throws an error for an unknown plan', () => {
+			const instance = new CartItem( {
+				...props,
+				cartItem: {
+					...cartItem,
+					product_slug: 'fake',
+				},
+			} );
+			expect( () => instance.calcMonthlyBillingDetails() ).toThrowError();
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/cart/test/cart-item.js
+++ b/client/my-sites/checkout/cart/test/cart-item.js
@@ -14,7 +14,7 @@ import React from 'react';
  * Internal dependencies
  */
 import { CartItem } from '../cart-item';
-import { isPlan, isMonthly } from 'lib/products-values';
+import { isPlan, isMonthly, isYearly, isBiennially } from 'lib/products-values';
 import {
 	PLAN_BUSINESS_2_YEARS,
 	PLAN_JETPACK_PERSONAL,
@@ -41,6 +41,8 @@ jest.mock( 'lib/products-values', () => ( {
 	isPlan: jest.fn( () => null ),
 	isTheme: jest.fn( () => null ),
 	isMonthly: jest.fn( () => null ),
+	isYearly: jest.fn( () => null ),
+	isBiennially: jest.fn( () => null ),
 	isBundled: jest.fn( () => null ),
 	isCredits: jest.fn( () => null ),
 	isGoogleApps: jest.fn( () => null ),
@@ -243,6 +245,64 @@ describe( 'cart-item', () => {
 				},
 			} );
 			expect( () => instance.calcMonthlyBillingDetails() ).toThrowError();
+		} );
+	} );
+
+	describe( 'getSubscriptionLength()', () => {
+		test( 'Returns false values for cart item with invalid bill_period (0)', () => {
+			const instance = new CartItem( { ...props, cartItem: { bill_period: 0 } } );
+			isMonthly.mockImplementation( () => true );
+			isYearly.mockImplementation( () => false );
+			isBiennially.mockImplementation( () => false );
+			expect( instance.getSubscriptionLength() ).toEqual( false );
+		} );
+
+		test( 'Returns false values for cart item with invalid bill_period (-1)', () => {
+			const instance = new CartItem( { ...props, cartItem: { bill_period: -1 } } );
+			isMonthly.mockImplementation( () => true );
+			isYearly.mockImplementation( () => false );
+			isBiennially.mockImplementation( () => false );
+			expect( instance.getSubscriptionLength() ).toEqual( false );
+		} );
+
+		test( 'Returns false values for cart item with invalid bill_period (4)', () => {
+			const instance = new CartItem( { ...props, cartItem: { bill_period: -1 } } );
+			isMonthly.mockImplementation( () => true );
+			isYearly.mockImplementation( () => false );
+			isBiennially.mockImplementation( () => false );
+			expect( instance.getSubscriptionLength() ).toEqual( false );
+		} );
+
+		test( 'Returns "monthly subscription" for monthly plan', () => {
+			const instance = new CartItem( props );
+			isMonthly.mockImplementation( () => true );
+			isYearly.mockImplementation( () => false );
+			isBiennially.mockImplementation( () => false );
+			expect( instance.getSubscriptionLength() ).toEqual( 'monthly subscription' );
+		} );
+
+		test( 'Returns "annual subscription" for annual plan', () => {
+			const instance = new CartItem( props );
+			isMonthly.mockImplementation( () => false );
+			isYearly.mockImplementation( () => true );
+			isBiennially.mockImplementation( () => false );
+			expect( instance.getSubscriptionLength() ).toEqual( 'annual subscription' );
+		} );
+
+		test( 'Returns "biennial subscription" for biennial plan', () => {
+			const instance = new CartItem( props );
+			isMonthly.mockImplementation( () => false );
+			isYearly.mockImplementation( () => false );
+			isBiennially.mockImplementation( () => true );
+			expect( instance.getSubscriptionLength() ).toEqual( 'biennial subscription' );
+		} );
+
+		test( 'Returns false for unknown type of plan', () => {
+			const instance = new CartItem( props );
+			isMonthly.mockImplementation( () => false );
+			isYearly.mockImplementation( () => false );
+			isBiennially.mockImplementation( () => false );
+			expect( instance.getSubscriptionLength() ).toEqual( false );
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/cart/test/cart-item.js
+++ b/client/my-sites/checkout/cart/test/cart-item.js
@@ -22,8 +22,6 @@ import {
 	PLAN_PREMIUM,
 } from 'lib/plans/constants';
 
-import formatCurrency from 'lib/format-currency';
-
 const plansModule = require( 'lib/plans' );
 const originalPlansModuleFunctions = pick( plansModule, [
 	'calculateMonthlyPriceForPlan',
@@ -71,9 +69,6 @@ describe( 'cart-item', () => {
 	describe( 'monthlyPrice', () => {
 		let myTranslate, instance;
 		beforeEach( () => {
-			formatCurrency.mockReset();
-			formatCurrency.mockImplementation( () => '133.00 AUD' );
-
 			myTranslate = jest.fn( identity );
 			instance = new CartItem( {
 				translate: myTranslate,
@@ -94,18 +89,13 @@ describe( 'cart-item', () => {
 			expect( instance.calcMonthlyBillingDetails ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		test( 'Should format currency using formatCurrency()', () => {
-			instance.monthlyPrice();
-			expect( formatCurrency ).toHaveBeenCalledTimes( 1 );
-			expect( formatCurrency ).toHaveBeenCalledWith( 133, 'AUD' );
-		} );
-
 		test( 'Should call translate() with args returned from calcMonthlyBillingDetails()', () => {
 			instance.monthlyPrice();
 			expect( myTranslate ).toHaveBeenCalledTimes( 1 );
 			expect( myTranslate.mock.calls[ 0 ][ 1 ] ).toEqual( {
 				args: {
-					monthlyPrice: '133.00 AUD',
+					monthlyPrice: '133.00',
+					currency: 'AUD',
 					months: 17,
 				},
 			} );


### PR DESCRIPTION
This PR is related to 2-year plans (p9jf6J-eR-p2).

Currently, `<CartItem />` component can only correctly display information about monthly and annual products. This PR updates it so it is able to say things like `biennial subscription` or `$13.24 x 24 months`.

Test plan:
* Run unit tests
* Add various jetpack and WP.com plans to cart, confirm that you can see correct information in cart sidebar after you co to `/checkout`, for example:

Monthly subscriptions should look similar to this:
<img width="278" alt="zrzut ekranu 2018-04-09 o 13 07 38" src="https://user-images.githubusercontent.com/205419/38494662-0bac61f6-3bf7-11e8-8056-bd72c42a732e.png">

Annual subscriptions should look similar to this:
<img width="279" alt="zrzut ekranu 2018-04-09 o 13 08 27" src="https://user-images.githubusercontent.com/205419/38494679-1af8cffa-3bf7-11e8-9cd1-ed3d513cb83a.png">
