### PR TITLE
Pagination Block: Allow custom labels

### DIFF
--- a/client/components/pagination/README.md
+++ b/client/components/pagination/README.md
@@ -9,7 +9,7 @@ import Pagination from 'components/pagination';
 
 render: function() {
 	return (
-		<Pagination compact={ <Boolean> } page={ <Number> } perPage={ <Number> } total={ <Number> } pageClick={ <Function> } />;	
+		<Pagination compact={ <Boolean> } page={ <Number> } perPage={ <Number> } total={ <Number> } pageClick={ <Function> } />;
 	);
 }
 ```
@@ -23,3 +23,5 @@ render: function() {
 
 #### Optional Props
 * `compact`: Render a smaller version
+* `nextLabel`: Override for the text on the next button
+* `prevLabel`: Override for the text on the previous button

--- a/client/components/pagination/index.jsx
+++ b/client/components/pagination/index.jsx
@@ -15,11 +15,13 @@ import PaginationPage from './pagination-page';
 
 class Pagination extends Component {
 	static propTypes = {
-		page: PropTypes.number.isRequired,
-		perPage: PropTypes.number.isRequired,
-		total: PropTypes.number,
-		pageClick: PropTypes.func.isRequired,
 		compact: PropTypes.bool,
+		nextLabel: PropTypes.string,
+		page: PropTypes.number.isRequired,
+		pageClick: PropTypes.func.isRequired,
+		perPage: PropTypes.number.isRequired,
+		prevLabel: PropTypes.string,
+		total: PropTypes.number,
 	};
 
 	getPageList = ( page, pageCount ) => {
@@ -53,7 +55,7 @@ class Pagination extends Component {
 	};
 
 	render() {
-		const { page, pageClick, perPage, total, compact } = this.props;
+		const { compact, nextLabel, page, pageClick, perPage, prevLabel, total } = this.props;
 		const pageCount = Math.ceil( total / perPage );
 
 		if ( pageCount <= 1 ) {
@@ -65,11 +67,13 @@ class Pagination extends Component {
 			return (
 				<PaginationPage
 					key={ index }
-					pageNumber={ pageNumber }
-					currentPage={ page }
-					totalPages={ pageCount }
-					pageClick={ pageClick }
 					compact={ compact }
+					currentPage={ page }
+					nextLabel={ nextLabel }
+					pageClick={ pageClick }
+					pageNumber={ pageNumber }
+					prevLabel={ prevLabel }
+					totalPages={ pageCount }
 				/>
 			);
 		} );

--- a/client/components/pagination/pagination-page.jsx
+++ b/client/components/pagination/pagination-page.jsx
@@ -17,11 +17,13 @@ import Button from 'components/button';
 
 class PaginationPage extends Component {
 	static propTypes = {
-		pageNumber: PropTypes.node.isRequired,
-		currentPage: PropTypes.number.isRequired,
-		totalPages: PropTypes.number.isRequired,
-		pageClick: PropTypes.func.isRequired,
 		compact: PropTypes.bool,
+		currentPage: PropTypes.number.isRequired,
+		nextLabel: PropTypes.string,
+		pageClick: PropTypes.func.isRequired,
+		pageNumber: PropTypes.node.isRequired,
+		prevLabel: PropTypes.string,
+		totalPages: PropTypes.number.isRequired,
 	};
 
 	clickHandler = event => {
@@ -51,7 +53,16 @@ class PaginationPage extends Component {
 	};
 
 	render() {
-		const { translate, currentPage, numberFormat, pageNumber, totalPages, compact } = this.props;
+		const {
+			translate,
+			currentPage,
+			nextLabel,
+			numberFormat,
+			pageNumber,
+			prevLabel,
+			totalPages,
+			compact,
+		} = this.props;
 
 		switch ( pageNumber ) {
 			case 'more':
@@ -68,7 +79,7 @@ class PaginationPage extends Component {
 					<li className={ listClass }>
 						<Button borderless onClick={ this.clickHandler } disabled={ currentPage <= 1 }>
 							<Gridicon icon="arrow-left" size={ 18 } />
-							{ ! compact && translate( 'Previous' ) }
+							{ ! compact && ( prevLabel || translate( 'Previous' ) ) }
 						</Button>
 					</li>
 				);
@@ -80,7 +91,7 @@ class PaginationPage extends Component {
 				return (
 					<li className={ listClass }>
 						<Button borderless onClick={ this.clickHandler } disabled={ currentPage >= totalPages }>
-							{ ! compact && translate( 'Next' ) }
+							{ ! compact && ( nextLabel || translate( 'Next' ) ) }
 							<Gridicon icon="arrow-right" size={ 18 } />
 						</Button>
 					</li>


### PR DESCRIPTION
The pagination block is helpful for showing subsets of results which we
control in Javascript. We'd like to use this control with the Activity
Log but the `prev` and `next` labels don't fit our use-case as well as
`older` and `newer` do, so in this patch I'm proposing a basic
mechanism to overwrite the default labels.

**Testing**

Well I'm not actually using this yet but you can test by manually
changing some labels where this is used. For example, you can
add the `prevLabel` and `nextLabel` in the comments management
section and make sure it updates.