### PR TITLE
JPC: remote install- place spinner above the CTA button.

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -100,7 +100,7 @@ $z-layers: (
 		'ul.module-content-list-item-actions.collapsed': 3,
 		'.auth__input-wrapper .gridicon': 3,
 		'.jetpack-connect__password-form .gridicon': 3,
-		'.jetpack-connect__password-container .jetpack-connect__creds-form-spinner':3,
+		'.jetpack-connect__site-url-input-container .jetpack-connect__creds-form-spinner':3,
 		'.auth__self-hosted-instructions': 4,
 		'.auth__form .form-password-input__toggle-visibility': 4,
 		'.site-selector': 10,

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -100,7 +100,7 @@ $z-layers: (
 		'ul.module-content-list-item-actions.collapsed': 3,
 		'.auth__input-wrapper .gridicon': 3,
 		'.jetpack-connect__password-form .gridicon': 3,
-		'.jetpack-connect__site-url-input-container .jetpack-connect__creds-form-spinner':3,
+		'.jetpack-connect__creds-form-footer .jetpack-connect__creds-form-spinner':3,
 		'.auth__self-hosted-instructions': 4,
 		'.auth__form .form-password-input__toggle-visibility': 4,
 		'.site-selector': 10,

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -227,12 +227,15 @@ export class OrgCredentialsForm extends Component {
 		const { isSubmitting } = this.state;
 
 		return (
-			<FormButton
-				className="jetpack-connect__credentials-submit"
-				disabled={ ! this.state.username || ! this.state.password || isSubmitting }
-			>
-				{ this.renderButtonLabel() }
-			</FormButton>
+			<div className="jetpack-connect__creds-form-footer">
+				{ isSubmitting && <Spinner className="jetpack-connect__creds-form-spinner" /> }
+				<FormButton
+					className="jetpack-connect__credentials-submit"
+					disabled={ ! this.state.username || ! this.state.password || isSubmitting }
+				>
+					{ this.renderButtonLabel() }
+				</FormButton>
+			</div>
 		);
 	}
 
@@ -278,15 +281,12 @@ export class OrgCredentialsForm extends Component {
 	}
 
 	render() {
-		const { isSubmitting } = this.state;
-
 		return (
 			<MainWrapper>
 				{ this.renderHeadersText() }
 				<Card className="jetpack-connect__site-url-input-container">
 					<form onSubmit={ this.handleSubmit }>
 						{ this.formFields() }
-						{ isSubmitting && <Spinner className="jetpack-connect__creds-form-spinner" /> }
 						{ this.formFooter() }
 					</form>
 				</Card>

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -191,7 +191,6 @@ export class OrgCredentialsForm extends Component {
 					/>
 				</div>
 				<div className="jetpack-connect__password-container">
-					{ isSubmitting && <Spinner className="jetpack-connect__creds-form-spinner" /> }
 					<FormLabel htmlFor="password">{ translate( 'Password' ) }</FormLabel>
 					<div className="jetpack-connect__password-form">
 						<Gridicon size={ 24 } icon="lock" />
@@ -279,12 +278,15 @@ export class OrgCredentialsForm extends Component {
 	}
 
 	render() {
+		const { isSubmitting } = this.state;
+
 		return (
 			<MainWrapper>
 				{ this.renderHeadersText() }
 				<Card className="jetpack-connect__site-url-input-container">
 					<form onSubmit={ this.handleSubmit }>
 						{ this.formFields() }
+						{ isSubmitting && <Spinner className="jetpack-connect__creds-form-spinner" /> }
 						{ this.formFooter() }
 					</form>
 				</Card>

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -649,8 +649,14 @@
 	.spinner {
 		z-index: z-index(
 			'root',
-			'.jetpack-connect__site-url-input-container .jetpack-connect__creds-form-spinner'
+			'.jetpack-connect__creds-form-footer .jetpack-connect__creds-form-spinner'
 		);
+	}
+}
+
+.jetpack-connect__creds-form-footer {
+	.button {
+		margin-top: 22px;
 	}
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -649,7 +649,7 @@
 	.spinner {
 		z-index: z-index(
 			'root',
-			'.jetpack-connect__password-container .jetpack-connect__creds-form-spinner'
+			'.jetpack-connect__site-url-input-container .jetpack-connect__creds-form-spinner'
 		);
 	}
 }


### PR DESCRIPTION
Currently, the Spinner displayed when submitting .org site's credentials in the remote install flow shows up in the middle of the form.

This PR improves the UX by rendering the Spinner below the form.

![screen shot 2018-04-09 at 13 58 05](https://user-images.githubusercontent.com/13561163/38498856-ab5cde96-3bfd-11e8-9cca-6111997b6636.png)


## to test:
Follow the instructions on https://github.com/Automattic/wp-calypso/pull/23286.