### PR TITLE
Post Editor: reduxify setting the featured image

### DIFF
--- a/client/lib/posts/post-edit-store.js
+++ b/client/lib/posts/post-edit-store.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { assign, filter, get, isEqual, pickBy, without, omit } from 'lodash';
+import { assign, filter, get, isEqual, pickBy, without } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:posts:post-edit-store' );
 import emitter from 'lib/mixins/emitter';
@@ -134,13 +134,6 @@ function set( attributes ) {
 	}
 
 	updatedPost = assign( {}, _post, attributes );
-
-	// This prevents an unsaved changes dialogue from appearing
-	// on a new post when only the featured image is added then removed.
-	// See #17701 for context.
-	if ( updatedPost.featured_image === '' && ! _savedPost.featured_image && _post.featured_image ) {
-		updatedPost = omit( updatedPost, 'featured_image' );
-	}
 
 	updatedPost = normalize( updatedPost );
 

--- a/client/lib/posts/test/utils.js
+++ b/client/lib/posts/test/utils.js
@@ -223,6 +223,16 @@ describe( 'utils', () => {
 			expect( id ).toBeNull();
 		} );
 
+		test( 'should return empty string if that is the featured_image value', () => {
+			// These values are typical for posts without a featured image
+			const id = postUtils.getFeaturedImageId( {
+				featured_image: '',
+				post_thumbnail: null,
+			} );
+
+			expect( id ).toEqual( '' );
+		} );
+
 		test( 'should fall back to post thumbnail object ID if exists, if featured_image is URL', () => {
 			const id = postUtils.getFeaturedImageId( {
 				featured_image: 'https://example.com/image.png',

--- a/client/lib/posts/test/utils.js
+++ b/client/lib/posts/test/utils.js
@@ -4,11 +4,6 @@
  */
 
 /**
- * External dependencies
- */
-import assert from 'assert'; // eslint-disable-line import/no-nodejs-modules
-
-/**
  * Internal dependencies
  */
 import * as postUtils from '../utils';
@@ -49,113 +44,115 @@ describe( 'utils', () => {
 
 	describe( '#getVisibility', () => {
 		test( 'should return undefined when no post is supplied', () => {
-			assert( postUtils.getVisibility() === undefined );
+			expect( postUtils.getVisibility() ).toBeUndefined();
 		} );
 
 		test( 'should return public when password and private are not set', () => {
-			assert( postUtils.getVisibility( {} ) === 'public' );
+			expect( postUtils.getVisibility( {} ) ).toEqual( 'public' );
 		} );
 
 		test( 'should return private when post#status is private', () => {
-			assert( postUtils.getVisibility( { status: 'private' } ) === 'private' );
+			expect( postUtils.getVisibility( { status: 'private' } ) ).toEqual( 'private' );
 		} );
 
 		test( 'should return password when post#password is set', () => {
-			assert( postUtils.getVisibility( { password: 'unicorn' } ) === 'password' );
+			expect( postUtils.getVisibility( { password: 'unicorn' } ) ).toEqual( 'password' );
 		} );
 	} );
 
 	describe( '#isPrivate', () => {
 		test( 'should return undefined when no post is supplied', () => {
-			assert( postUtils.isPrivate() === undefined );
+			expect( postUtils.isPrivate() ).toBeUndefined();
 		} );
 
 		test( 'should return true when post.status is private', () => {
-			assert( postUtils.isPrivate( { status: 'private' } ) );
+			expect( postUtils.isPrivate( { status: 'private' } ) ).toBe( true );
 		} );
 
 		test( 'should return false when post.status is not private', () => {
-			assert( ! postUtils.isPrivate( { status: 'draft' } ) );
+			expect( postUtils.isPrivate( { status: 'draft' } ) ).toBe( false );
 		} );
 	} );
 
 	describe( '#isPublished', () => {
 		test( 'should return undefined when no post is supplied', () => {
-			assert( postUtils.isPublished() === undefined );
+			expect( postUtils.isPublished() ).toBeUndefined();
 		} );
 
 		test( 'should return true when post.status is private', () => {
-			assert( postUtils.isPublished( { status: 'private' } ) );
+			expect( postUtils.isPublished( { status: 'private' } ) ).toBe( true );
 		} );
 
 		test( 'should return true when post.status is publish', () => {
-			assert( postUtils.isPublished( { status: 'publish' } ) );
+			expect( postUtils.isPublished( { status: 'publish' } ) ).toBe( true );
 		} );
 
 		test( 'should return false when post.status is not publish or private', () => {
-			assert( ! postUtils.isPublished( { status: 'draft' } ) );
+			expect( postUtils.isPublished( { status: 'draft' } ) ).toBe( false );
 		} );
 	} );
 
 	describe( '#isPending', () => {
 		test( 'should return undefined when no post is supplied', () => {
-			assert( postUtils.isPending() === undefined );
+			expect( postUtils.isPending() ).toBeUndefined();
 		} );
 
 		test( 'should return true when post.status is pending', () => {
-			assert( postUtils.isPending( { status: 'pending' } ) );
+			expect( postUtils.isPending( { status: 'pending' } ) ).toBe( true );
 		} );
 
 		test( 'should return false when post.status is not pending', () => {
-			assert( ! postUtils.isPending( { status: 'draft' } ) );
+			expect( postUtils.isPending( { status: 'draft' } ) ).toBe( false );
 		} );
 	} );
 
 	describe( '#isBackDatedPublished', () => {
 		test( 'should return false when no post is supplied', () => {
-			assert( ! postUtils.isBackDatedPublished() );
+			expect( postUtils.isBackDatedPublished() ).toBe( false );
 		} );
 
 		test( 'should return false when status !== future', () => {
-			assert( ! postUtils.isBackDatedPublished( { status: 'draft' } ) );
+			expect( postUtils.isBackDatedPublished( { status: 'draft' } ) ).toBe( false );
 		} );
 
 		test( 'should return false when status === future and date is in future', () => {
 			const tenMinutes = 1000 * 60;
 			const postDate = Date.now() + tenMinutes;
 
-			assert( ! postUtils.isBackDatedPublished( { status: 'future', date: postDate } ) );
+			expect( postUtils.isBackDatedPublished( { status: 'future', date: postDate } ) ).toBe(
+				false
+			);
 		} );
 
 		test( 'should return true when status === future and date is in the past', () => {
 			const tenMinutes = 1000 * 60;
 			const postDate = Date.now() - tenMinutes;
 
-			assert( postUtils.isBackDatedPublished( { status: 'future', date: postDate } ) );
+			expect( postUtils.isBackDatedPublished( { status: 'future', date: postDate } ) ).toBe( true );
 		} );
 	} );
 
 	describe( '#removeSlug', () => {
 		test( 'should return undefined when no path is supplied', () => {
-			assert( postUtils.removeSlug() === undefined );
+			expect( postUtils.removeSlug() ).toBeUndefined();
 		} );
 
 		test( 'should strip slug on post URL', () => {
 			const noSlug = postUtils.removeSlug(
 				'https://en.blog.wordpress.com/2015/08/26/new-action-bar/'
 			);
-			assert( noSlug === 'https://en.blog.wordpress.com/2015/08/26/' );
+			expect( noSlug ).toEqual( 'https://en.blog.wordpress.com/2015/08/26/' );
 		} );
 
 		test( 'should strip slug on page URL', () => {
 			const noSlug = postUtils.removeSlug( 'https://en.blog.wordpress.com/a-test-page/' );
-			assert( noSlug === 'https://en.blog.wordpress.com/' );
+			expect( noSlug ).toEqual( 'https://en.blog.wordpress.com/' );
 		} );
 	} );
 
 	describe( '#getPermalinkBasePath', () => {
 		test( 'should return undefined when no post is supplied', () => {
-			assert( postUtils.getPermalinkBasePath() === undefined );
+			expect( postUtils.getPermalinkBasePath() ).toBeUndefined();
 		} );
 
 		test( 'should return post.URL when post is published', () => {
@@ -163,7 +160,7 @@ describe( 'utils', () => {
 				status: 'publish',
 				URL: 'https://en.blog.wordpress.com/2015/08/26/new-action-bar/',
 			} );
-			assert( path === 'https://en.blog.wordpress.com/2015/08/26/' );
+			expect( path ).toEqual( 'https://en.blog.wordpress.com/2015/08/26/' );
 		} );
 
 		test( 'should use permalink_URL when not published and present', () => {
@@ -171,13 +168,13 @@ describe( 'utils', () => {
 				other_URLs: { permalink_URL: 'http://zo.mg/a/permalink/%post_name%/' },
 				URL: 'https://en.blog.wordpress.com/2015/08/26/new-action-bar/',
 			} );
-			assert( path === 'http://zo.mg/a/permalink/' );
+			expect( path ).toEqual( 'http://zo.mg/a/permalink/' );
 		} );
 	} );
 
 	describe( '#getPagePath', () => {
 		test( 'should return undefined when no post is supplied', () => {
-			assert( postUtils.getPagePath() === undefined );
+			expect( postUtils.getPagePath() ).toBeUndefined();
 		} );
 
 		test( 'should return post.URL without slug when page is published', () => {
@@ -185,7 +182,7 @@ describe( 'utils', () => {
 				status: 'publish',
 				URL: 'http://zo.mg/a/permalink/',
 			} );
-			assert( path === 'http://zo.mg/a/' );
+			expect( path ).toEqual( 'http://zo.mg/a/' );
 		} );
 
 		test( 'should use permalink_URL when not published and present', () => {
@@ -193,13 +190,13 @@ describe( 'utils', () => {
 				status: 'draft',
 				other_URLs: { permalink_URL: 'http://zo.mg/a/permalink/%post_name%/' },
 			} );
-			assert( path === 'http://zo.mg/a/permalink/' );
+			expect( path ).toEqual( 'http://zo.mg/a/permalink/' );
 		} );
 	} );
 
 	describe( '#getFeaturedImageId()', () => {
 		test( 'should return undefined when no post is specified', () => {
-			assert( postUtils.getFeaturedImageId() === undefined );
+			expect( postUtils.getFeaturedImageId() ).toBeUndefined();
 		} );
 
 		test( 'should return a non-URL featured_image property', () => {
@@ -210,7 +207,7 @@ describe( 'utils', () => {
 				},
 			} );
 
-			assert( id === 'media-1' );
+			expect( id ).toEqual( 'media-1' );
 		} );
 
 		test( 'should return a `null` featured_image property', () => {
@@ -223,7 +220,7 @@ describe( 'utils', () => {
 				},
 			} );
 
-			assert( id === null );
+			expect( id ).toBeNull();
 		} );
 
 		test( 'should fall back to post thumbnail object ID if exists, if featured_image is URL', () => {
@@ -234,7 +231,7 @@ describe( 'utils', () => {
 				},
 			} );
 
-			assert( id === 1 );
+			expect( id ).toEqual( 1 );
 		} );
 
 		test( "should return undefined if featured_image is URL and post thumbnail object doesn't exist", () => {
@@ -242,7 +239,7 @@ describe( 'utils', () => {
 				featured_image: 'https://example.com/image.png',
 			} );
 
-			assert( id === undefined );
+			expect( id ).toBeUndefined();
 		} );
 	} );
 } );

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -147,7 +147,12 @@ function startEditingPostCopy( site, postToCopyId, context ) {
 			 *
 			 * @see https://github.com/Automattic/wp-calypso/pull/13933
 			 */
-			const reduxPostAttributes = pick( postAttributes, [ 'format', 'terms', 'title' ] );
+			const reduxPostAttributes = pick( postAttributes, [
+				'featured_image',
+				'format',
+				'terms',
+				'title',
+			] );
 
 			actions.startEditingNew( site, {
 				content: postToCopy.content,

--- a/client/post-editor/editor-drawer/featured-image.jsx
+++ b/client/post-editor/editor-drawer/featured-image.jsx
@@ -18,12 +18,14 @@ import EditorDrawerWell from 'post-editor/editor-drawer-well';
 import FeaturedImage from 'post-editor/editor-featured-image';
 import FeaturedImageDropZone from 'post-editor/editor-featured-image/dropzone';
 import isDropZoneVisible from 'state/selectors/is-drop-zone-visible';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPost } from 'state/posts/selectors';
 
 class EditorDrawerFeaturedImage extends Component {
 	static propTypes = {
-		site: PropTypes.object,
-		post: PropTypes.object,
 		translate: PropTypes.func,
+		hasFeaturedImage: PropTypes.bool,
 		isDrawerHidden: PropTypes.bool,
 	};
 
@@ -39,7 +41,7 @@ class EditorDrawerFeaturedImage extends Component {
 	endSelecting = () => this.setState( { isSelecting: false } );
 
 	render() {
-		const { translate, site, post, isDrawerHidden } = this.props;
+		const { translate, hasFeaturedImage, isDrawerHidden } = this.props;
 
 		return (
 			<Accordion
@@ -49,7 +51,7 @@ class EditorDrawerFeaturedImage extends Component {
 			>
 				<EditorDrawerWell
 					label={ translate( 'Set Featured Image' ) }
-					empty={ ! site || ! post || ! getFeaturedImageId( post ) }
+					empty={ ! hasFeaturedImage }
 					onClick={ this.startSelecting }
 					customDropZone={ <FeaturedImageDropZone /> }
 					isHidden={ isDrawerHidden }
@@ -57,8 +59,6 @@ class EditorDrawerFeaturedImage extends Component {
 					<FeaturedImage
 						selecting={ this.state.isSelecting }
 						onImageSelected={ this.endSelecting }
-						site={ site }
-						post={ post }
 					/>
 				</EditorDrawerWell>
 			</Accordion>
@@ -66,6 +66,12 @@ class EditorDrawerFeaturedImage extends Component {
 	}
 }
 
-export default connect( state => ( {
-	isDrawerHidden: isDropZoneVisible( state, 'featuredImage' ),
-} ) )( localize( EditorDrawerFeaturedImage ) );
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+	const postId = getEditorPostId( state );
+	const post = getEditedPost( state, siteId, postId );
+	const hasFeaturedImage = !! getFeaturedImageId( post );
+	const isDrawerHidden = isDropZoneVisible( state, 'featuredImage' );
+
+	return { hasFeaturedImage, isDrawerHidden };
+} )( localize( EditorDrawerFeaturedImage ) );

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -169,9 +169,7 @@ class EditorDrawer extends Component {
 			return;
 		}
 
-		return (
-			<AsyncLoad require="./featured-image" site={ this.props.site } post={ this.props.post } />
-		);
+		return <AsyncLoad require="./featured-image" />;
 	}
 
 	renderExcerpt() {

--- a/client/post-editor/editor-featured-image/dropzone.jsx
+++ b/client/post-editor/editor-featured-image/dropzone.jsx
@@ -16,7 +16,6 @@ import DropZone from 'components/drop-zone';
 import MediaActions from 'lib/media/actions';
 import MediaStore from 'lib/media/store';
 import { filterItemsByMimePrefix, isItemBeingUploaded } from 'lib/media/utils';
-import PostActions from 'lib/posts/actions';
 import FeaturedImageDropZoneIcon from './dropzone-icon';
 
 import { receiveMedia, deleteMedia } from 'state/media/actions';
@@ -67,21 +66,7 @@ class FeaturedImageDropZone extends Component {
 				}
 			}
 
-			/**
-			 * TODO: Redux way. What's left: figure out how to properly use `editPost`
-			 * and research if the whole FeaturedImage component has to be updated to
-			 * work properly with Redux.
-			 *
-			 * Right now `PostActions.edit` seems to be the best way to approach the problem.
-			 */
-			// this.props.editPost( siteId, this.props.postId, { featured_image: media.ID } );
-
-			// Cannot dispatch an action while in a dispatched action. Temporary(tm).
-			setTimeout( () => {
-				PostActions.edit( {
-					featured_image: media.ID,
-				} );
-			}, 0 );
+			this.props.editPost( siteId, this.props.postId, { featured_image: media.ID } );
 		};
 
 		MediaStore.on( 'change', handleFeaturedImageUpload );

--- a/client/post-editor/editor-featured-image/index.jsx
+++ b/client/post-editor/editor-featured-image/index.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
-import { isNumber } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,10 +17,9 @@ import { isNumber } from 'lodash';
 import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
 import MediaModal from 'post-editor/media-modal';
 import MediaActions from 'lib/media/actions';
-import PostActions from 'lib/posts/actions';
 import * as stats from 'lib/posts/stats';
 import EditorFeaturedImagePreviewContainer from './preview-container';
-import FeaturedImageDropZone from 'post-editor/editor-featured-image/dropzone';
+import FeaturedImageDropZone from './dropzone';
 import isDropZoneVisible from 'state/selectors/is-drop-zone-visible';
 import Button from 'components/button';
 import RemoveButton from 'components/remove-button';
@@ -29,6 +28,10 @@ import { getFeaturedImageId } from 'lib/posts/utils';
 import QueryMedia from 'components/data/query-media';
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPost } from 'state/posts/selectors';
+import { editPost } from 'state/posts/actions';
 
 class EditorFeaturedImage extends Component {
 	static propTypes = {
@@ -36,8 +39,6 @@ class EditorFeaturedImage extends Component {
 		hasDropZone: PropTypes.bool,
 		isDropZoneVisible: PropTypes.bool,
 		maxWidth: PropTypes.number,
-		site: PropTypes.object,
-		post: PropTypes.object,
 		recordTracksEvent: PropTypes.func,
 		selecting: PropTypes.bool,
 		translate: PropTypes.func,
@@ -48,7 +49,7 @@ class EditorFeaturedImage extends Component {
 		hasDropZone: false,
 		isDropZoneVisible: false,
 		maxWidth: 450,
-		onImageSelected: () => {},
+		onImageSelected: noop,
 	};
 
 	state = {
@@ -56,10 +57,10 @@ class EditorFeaturedImage extends Component {
 	};
 
 	showMediaModal = () => {
-		const { featuredImage, site } = this.props;
+		const { siteId, featuredImage } = this.props;
 
 		if ( featuredImage ) {
-			MediaActions.setLibrarySelectedItems( site.ID, [ featuredImage ] );
+			MediaActions.setLibrarySelectedItems( siteId, [ featuredImage ] );
 		}
 
 		this.setState( {
@@ -81,7 +82,7 @@ class EditorFeaturedImage extends Component {
 			return;
 		}
 
-		PostActions.edit( {
+		this.props.editPost( this.props.siteId, this.props.postId, {
 			featured_image: value.items[ 0 ].ID,
 		} );
 
@@ -94,66 +95,58 @@ class EditorFeaturedImage extends Component {
 		} );
 	};
 
-	static removeImage() {
-		PostActions.edit( {
-			featured_image: '',
-		} );
+	removeImage = () => {
+		this.props.editPost( this.props.siteId, this.props.postId, { featured_image: '' } );
 
 		stats.recordStat( 'featured_image_removed' );
 		stats.recordEvent( 'Featured image removed' );
-	}
+	};
 
-	renderMediaModal = () => {
-		if ( ! this.props.site ) {
+	renderMediaModal() {
+		if ( ! this.props.siteId ) {
 			return;
 		}
 
 		return (
-			<MediaLibrarySelectedData siteId={ this.props.site.ID }>
+			<MediaLibrarySelectedData siteId={ this.props.siteId }>
 				<MediaModal
 					visible={ this.props.selecting || this.state.isSelecting }
 					onClose={ this.setImage }
-					site={ this.props.site }
+					siteId={ this.props.siteId }
 					labels={ { confirm: this.props.translate( 'Set Featured Image' ) } }
 					enabledFilters={ [ 'images' ] }
 					single
 				/>
 			</MediaLibrarySelectedData>
 		);
-	};
+	}
 
-	renderCurrentImage = () => {
-		if ( ! this.props.site || ! this.props.post ) {
-			return;
-		}
+	renderCurrentImage() {
+		const { siteId, featuredImageId } = this.props;
 
-		const itemId = getFeaturedImageId( this.props.post );
-		if ( ! itemId ) {
+		if ( ! featuredImageId ) {
 			return;
 		}
 
 		return (
 			<EditorFeaturedImagePreviewContainer
-				siteId={ this.props.site.ID }
-				itemId={ itemId }
+				siteId={ siteId }
+				itemId={ featuredImageId }
 				maxWidth={ this.props.maxWidth }
 			/>
 		);
-	};
+	}
 
 	render() {
-		const { site, post } = this.props;
-		const featuredImageId = getFeaturedImageId( post );
+		const { siteId, featuredImageId } = this.props;
 		const classes = classnames( 'editor-featured-image', {
-			'is-assigned': getFeaturedImageId( this.props.post ),
+			'is-assigned': !! featuredImageId,
 			'has-active-drop-zone': this.props.hasDropZone && this.props.isDropZoneVisible,
 		} );
 
 		return (
 			<div className={ classes }>
-				{ site && featuredImageId && isNumber( featuredImageId ) ? (
-					<QueryMedia siteId={ site.ID } mediaId={ featuredImageId } />
-				) : null }
+				{ featuredImageId && <QueryMedia siteId={ siteId } mediaId={ featuredImageId } /> }
 				{ this.renderMediaModal() }
 				<div className="editor-featured-image__inner-content">
 					<Button
@@ -166,7 +159,7 @@ class EditorFeaturedImage extends Component {
 						{ this.renderCurrentImage() }
 						<Gridicon icon="pencil" className="editor-featured-image__edit-icon" />
 					</Button>
-					{ featuredImageId && <RemoveButton onRemove={ EditorFeaturedImage.removeImage } /> }
+					{ featuredImageId && <RemoveButton onRemove={ this.removeImage } /> }
 				</div>
 
 				{ this.props.hasDropZone && <FeaturedImageDropZone /> }
@@ -176,17 +169,22 @@ class EditorFeaturedImage extends Component {
 }
 
 export default connect(
-	( state, ownProps ) => {
-		const { post, site } = ownProps;
-		const siteId = site && site.ID;
+	state => {
+		const siteId = getSelectedSiteId( state );
+		const postId = getEditorPostId( state );
+		const post = getEditedPost( state, siteId, postId );
 		const featuredImageId = getFeaturedImageId( post );
 
 		return {
+			siteId,
+			postId,
+			featuredImageId,
 			featuredImage: getMediaItem( state, siteId, featuredImageId ),
 			isDropZoneVisible: isDropZoneVisible( state, 'featuredImage' ),
 		};
 	},
 	{
+		editPost,
 		recordTracksEvent,
 	}
 )( localize( EditorFeaturedImage ) );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -360,12 +360,7 @@ export const PostEditor = createReactClass( {
 								) }
 							</div>
 							<div className="post-editor__inner-content">
-								<FeaturedImage
-									site={ site }
-									post={ this.state.post }
-									maxWidth={ 1462 }
-									hasDropZone={ true }
-								/>
+								<FeaturedImage maxWidth={ 1462 } hasDropZone />
 								<div className="post-editor__header">
 									<EditorTitle onChange={ this.onEditorTitleChange } tabIndex={ 1 } />
 									{ this.state.post && isPage && site ? (

--- a/client/state/posts/constants.js
+++ b/client/state/posts/constants.js
@@ -24,4 +24,5 @@ export const DEFAULT_NEW_POST_VALUES = {
 	type: 'post',
 	parent: 0,
 	format: 'default',
+	featured_image: '',
 };

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -54,6 +54,7 @@ import {
 	normalizePostForState,
 } from './utils';
 import { itemsSchema, queriesSchema, allSitesQueriesSchema } from './schema';
+import { getFeaturedImageId } from 'lib/posts/utils';
 
 /**
  * Tracks all known post objects, indexed by post global ID.
@@ -424,6 +425,8 @@ export function edits( state = {}, action ) {
 									return isAuthorEqual( value, post[ key ] );
 								case 'discussion':
 									return isDiscussionEqual( value, post[ key ] );
+								case 'featured_image':
+									return value === getFeaturedImageId( post );
 								case 'terms':
 									return isTermsEqual( value, post[ key ] );
 							}

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -25,6 +25,7 @@ import { decodeURIIfValid } from 'lib/url';
 import { getSite } from 'state/sites/selectors';
 import { DEFAULT_POST_QUERY, DEFAULT_NEW_POST_VALUES } from './constants';
 import { addQueryArgs } from 'lib/route';
+import { getFeaturedImageId } from 'lib/posts/utils';
 
 /**
  * Returns the PostsQueryManager from the state tree for a given site ID (or
@@ -420,6 +421,9 @@ export const isEditedPostDirty = createSelector(
 					}
 					case 'discussion': {
 						return ! isDiscussionEqual( value, post.discussion );
+					}
+					case 'featured_image': {
+						return value !== getFeaturedImageId( post );
 					}
 					case 'parent': {
 						return get( post, 'parent.ID', 0 ) !== value;

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -1245,6 +1245,38 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		test( 'should remove featured image edit after it is saved', () => {
+			const state = edits(
+				deepFreeze( {
+					2916284: {
+						841: {
+							featured_image: 123,
+						},
+					},
+				} ),
+				{
+					type: POSTS_RECEIVE,
+					posts: [
+						{
+							ID: 841,
+							site_ID: 2916284,
+							type: 'post',
+							featured_image: 'https://example.files.wordpress.com/2018/02/img_4879.jpg',
+							post_thumbnail: {
+								ID: 123,
+							},
+						},
+					],
+				}
+			);
+
+			expect( state ).to.eql( {
+				2916284: {
+					841: {},
+				},
+			} );
+		} );
+
 		test( "should ignore reset edits action when discarded site doesn't exist", () => {
 			const original = deepFreeze( {} );
 			const state = edits( original, {

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -2072,6 +2072,41 @@ describe( 'selectors', () => {
 
 			expect( isDirty ).to.be.false;
 		} );
+
+		test( "should return false if featured image ID didn't change", () => {
+			const isDirty = isEditedPostDirty(
+				{
+					posts: {
+						queries: {
+							2916284: new PostQueryManager( {
+								items: {
+									841: {
+										ID: 841,
+										site_ID: 2916284,
+										global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+										featured_image: 'https://example.files.wordpress.com/2018/02/img_4879.jpg',
+										post_thumbnail: {
+											ID: 123,
+										},
+									},
+								},
+							} ),
+						},
+						edits: {
+							2916284: {
+								841: {
+									featured_image: 123,
+								},
+							},
+						},
+					},
+				},
+				2916284,
+				841
+			);
+
+			expect( isDirty ).to.be.false;
+		} );
 	} );
 
 	describe( 'getPostPreviewUrl()', () => {


### PR DESCRIPTION
This PR reduxifies the UI to set post featured image. It can be edited at two places: the area above the text editor, and in a dedicated section in the editor drawer:

<img width="982" alt="screen shot 2018-04-09 at 15 16 27" src="https://user-images.githubusercontent.com/664258/38499890-373ad0b6-3c09-11e8-994d-48fdc580758a.png">

**How to test:**
With an existing post with a featured image, check that the featured image is shown after opening in editor.

While editing a post, try to add, change or remove a featured image. Verify that the changes get saved.

Start editing a new post, and without doing any other changes, set the feature image and then immediately remove it. Click on "Close" in the top left corner, i.e., discard the draft without saving. Verify that the editor is closed without asking if you want to save changes (there are no changes). In other words, verify that the fix #17701 has not regressed. Instead of checking inside the `set` function in Post Edit Store, we now set a correct value of `DEFAULT_NEW_POST_VALUES.featured_image` to achieve the same behavior.

Start editing a new post, and in "More Options", select a post to copy. Verify that the copied data include the featured image.