### PR TITLE
Add SubscriptionLengthOption component as part of subscription-length-picker block

### DIFF
--- a/client/blocks/subscription-length-picker/README.md
+++ b/client/blocks/subscription-length-picker/README.md
@@ -1,0 +1,22 @@
+Subscription Length Option
+==========
+
+Represents a term that user could pick when choosing his plan (monthly, yearly, biennially)
+
+### `index.jsx`
+
+Given basic information, this component creates a representation of given term.
+
+#### Props
+
+* `term`: string - TERM_* constant from lib/plans/constants.jsx
+* `savePercent` number ( optional ) - e.g. 60 for 60% - when displayed with other terms,
+                                      if may be useful to say that one option is 40% cheaper
+                                      then the other.
+* `price`: string - e.g. $60 - a formatted full price that is going to be charged to the user
+* `pricePerMonth`: string - e.g. $5 - a formatted effective price per month
+* `checked`: bool - if this option should be checked (selected)
+* `value`: any - value that is going to be passed to onChecked callback
+* `onCheck`: function({value}) => void ( optional ) A callback called when this term is checked (selected)
+
+For a complete list of props along with their types, please refer to the `SubscriptionLengthOption` component's `propTypes` member.

--- a/client/blocks/subscription-length-picker/README.md
+++ b/client/blocks/subscription-length-picker/README.md
@@ -9,14 +9,14 @@ Given basic information, this component creates a representation of given term.
 
 #### Props
 
-* `term`: string - TERM_* constant from lib/plans/constants.jsx
+* `checked`: bool - if this option should be checked (selected)
+* `onCheck`: function({value}) => void ( optional ) A callback called when this term is checked (selected)
+* `price`: string - e.g. $60 - a formatted full price that is going to be charged to the user
+* `pricePerMonth`: string - e.g. $5 - a formatted effective price per month
 * `savePercent` number ( optional ) - e.g. 60 for 60% - when displayed with other terms,
                                       if may be useful to say that one option is 40% cheaper
                                       then the other.
-* `price`: string - e.g. $60 - a formatted full price that is going to be charged to the user
-* `pricePerMonth`: string - e.g. $5 - a formatted effective price per month
-* `checked`: bool - if this option should be checked (selected)
+* `term`: string - TERM_* constant from lib/plans/constants.jsx
 * `value`: any - value that is going to be passed to onChecked callback
-* `onCheck`: function({value}) => void ( optional ) A callback called when this term is checked (selected)
 
 For a complete list of props along with their types, please refer to the `SubscriptionLengthOption` component's `propTypes` member.

--- a/client/blocks/subscription-length-picker/option.jsx
+++ b/client/blocks/subscription-length-picker/option.jsx
@@ -1,0 +1,126 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { uniqueId } from 'lodash';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+
+import Badge from 'components/badge';
+import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from 'lib/plans/constants';
+
+export class SubscriptionLengthOption extends React.Component {
+	static propTypes = {
+		term: PropTypes.string.isRequired,
+		savePercent: PropTypes.number.isRequired,
+		price: PropTypes.string.isRequired,
+		pricePerMonth: PropTypes.string.isRequired,
+		checked: PropTypes.bool.isRequired,
+		value: PropTypes.any.isRequired,
+		onCheck: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		checked: false,
+		savePercent: 0,
+		onCheck: () => null,
+	};
+
+	constructor( props ) {
+		super( props );
+		this.htmlId = uniqueId( 'subscription-option-' );
+	}
+
+	render() {
+		const { savePercent, price, term, checked } = this.props;
+		const className = classnames( 'subscription-length-picker__option', {
+			'is-active': checked,
+		} );
+		return (
+			<label className={ className } htmlFor={ this.htmlId }>
+				<div className="subscription-length-picker__option-radio-wrapper">
+					<input
+						id={ this.htmlId }
+						type="radio"
+						className="subscription-length-picker__option-radio"
+						checked={ checked }
+						onChange={ this.handleChange }
+					/>
+				</div>
+
+				<div className="subscription-length-picker__option-content">
+					<div className="subscription-length-picker__option-header">
+						<div className="subscription-length-picker__option-term">{ this.getTermText() }</div>
+						<div className="subscription-length-picker__option-discount">
+							{ savePercent ? this.renderSaveBadge() : false }
+						</div>
+					</div>
+					<div className="subscription-length-picker__option-description">
+						<div className="subscription-length-picker__option-price">{ price }</div>
+						<div className="subscription-length-picker__option-side-note">
+							{ term !== TERM_MONTHLY ? this.renderPricePerMonth() : false }
+						</div>
+					</div>
+				</div>
+			</label>
+		);
+	}
+
+	getTermText() {
+		const { term, translate } = this.props;
+		switch ( term ) {
+			case TERM_BIENNIALLY:
+				return translate( '%s year', '%s years', { count: 2, args: '2' } );
+
+			case TERM_ANNUALLY:
+				return translate( '%s year', '%s years', { count: 1, args: '1' } );
+
+			case TERM_MONTHLY:
+				return translate( '%s month', '%s months', { count: 1, args: '1' } );
+		}
+	}
+
+	renderSaveBadge() {
+		const { savePercent, checked, translate } = this.props;
+		return (
+			<Badge type={ checked ? 'success' : 'warning' }>
+				{ translate( 'Save %(percent)s%%', {
+					args: {
+						percent: savePercent,
+					},
+				} ) }
+			</Badge>
+		);
+	}
+
+	renderPricePerMonth() {
+		const { savePercent, pricePerMonth, translate } = this.props;
+
+		let retval;
+		if ( savePercent ) {
+			retval = translate( 'only %(price)s / month', { args: { price: pricePerMonth } } );
+		} else {
+			retval = translate( '%(price)s / month', { args: { price: pricePerMonth } } );
+		}
+		return retval;
+	}
+
+	handleChange = e => {
+		if ( e.target.checked ) {
+			this.props.onCheck( {
+				value: this.props.value,
+			} );
+		}
+	};
+}
+
+export default localize( SubscriptionLengthOption );

--- a/client/blocks/subscription-length-picker/option.jsx
+++ b/client/blocks/subscription-length-picker/option.jsx
@@ -23,7 +23,7 @@ export class SubscriptionLengthOption extends React.Component {
 		savePercent: PropTypes.number,
 		price: PropTypes.string.isRequired,
 		pricePerMonth: PropTypes.string.isRequired,
-		checked: PropTypes.bool.isRequired,
+		checked: PropTypes.bool,
 		value: PropTypes.any.isRequired,
 		onCheck: PropTypes.func,
 		translate: PropTypes.func.isRequired,

--- a/client/blocks/subscription-length-picker/option.jsx
+++ b/client/blocks/subscription-length-picker/option.jsx
@@ -20,12 +20,12 @@ import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from 'lib/plans/constant
 export class SubscriptionLengthOption extends React.Component {
 	static propTypes = {
 		term: PropTypes.string.isRequired,
-		savePercent: PropTypes.number.isRequired,
+		savePercent: PropTypes.number,
 		price: PropTypes.string.isRequired,
 		pricePerMonth: PropTypes.string.isRequired,
 		checked: PropTypes.bool.isRequired,
 		value: PropTypes.any.isRequired,
-		onCheck: PropTypes.func.isRequired,
+		onCheck: PropTypes.func,
 		translate: PropTypes.func.isRequired,
 	};
 
@@ -41,7 +41,7 @@ export class SubscriptionLengthOption extends React.Component {
 	}
 
 	render() {
-		const { savePercent, price, term, checked } = this.props;
+		const { checked, price, savePercent, term, translate } = this.props;
 		const className = classnames( 'subscription-length-picker__option', {
 			'is-active': checked,
 		} );
@@ -61,7 +61,15 @@ export class SubscriptionLengthOption extends React.Component {
 					<div className="subscription-length-picker__option-header">
 						<div className="subscription-length-picker__option-term">{ this.getTermText() }</div>
 						<div className="subscription-length-picker__option-discount">
-							{ savePercent ? this.renderSaveBadge() : false }
+							{ savePercent && (
+								<Badge type={ checked ? 'success' : 'warning' }>
+									{ translate( 'Save %(percent)s%%', {
+										args: {
+											percent: savePercent,
+										},
+									} ) }
+								</Badge>
+							) }
 						</div>
 					</div>
 					<div className="subscription-length-picker__option-description">
@@ -89,29 +97,13 @@ export class SubscriptionLengthOption extends React.Component {
 		}
 	}
 
-	renderSaveBadge() {
-		const { savePercent, checked, translate } = this.props;
-		return (
-			<Badge type={ checked ? 'success' : 'warning' }>
-				{ translate( 'Save %(percent)s%%', {
-					args: {
-						percent: savePercent,
-					},
-				} ) }
-			</Badge>
-		);
-	}
-
 	renderPricePerMonth() {
 		const { savePercent, pricePerMonth, translate } = this.props;
 
-		let retval;
-		if ( savePercent ) {
-			retval = translate( 'only %(price)s / month', { args: { price: pricePerMonth } } );
-		} else {
-			retval = translate( '%(price)s / month', { args: { price: pricePerMonth } } );
-		}
-		return retval;
+		const args = { args: { price: pricePerMonth } };
+		return savePercent
+			? translate( 'only %(price)s / month', args )
+			: translate( '%(price)s / month', args );
 	}
 
 	handleChange = e => {

--- a/client/blocks/subscription-length-picker/style.scss
+++ b/client/blocks/subscription-length-picker/style.scss
@@ -1,0 +1,77 @@
+.subscription-length-picker__option {
+  $padding-size: 18px;
+
+  display: flex;
+  width: 100%;
+  cursor: pointer;
+
+  padding: $padding-size;
+  border-radius: 5px;
+
+  background: $white;
+
+  .subscription-length-picker__option-radio-wrapper {
+    width: 21px;
+    margin-right: 12px;
+  }
+
+  .subscription-length-picker__option-radio {
+    width: 21px;
+    height: 21px;
+
+    &:checked:before {
+      width: 13px;
+      height: 13px;
+    }
+  }
+
+  .subscription-length-picker__option-header,
+  .subscription-length-picker__option-description {
+    width: 100%;
+  }
+
+  .subscription-length-picker__option-term,
+  .subscription-length-picker__option-price,
+  .subscription-length-picker__option-discount,
+  .subscription-length-picker__option-side-note,
+  .subscription-length-picker__option-description {
+    display: inline-block;
+    vertical-align: middle;
+  }
+
+  .subscription-length-picker__option-header {
+    line-height: 24px;
+  }
+
+  .subscription-length-picker__option-term {
+    display: inline-block;
+    font-size: 24px;
+    line-height: 24px;
+  }
+
+  .subscription-length-picker__option-discount {
+    margin-left: 10px;
+  }
+
+  .subscription-length-picker__option-description {
+    font-size: 16px;
+  }
+
+  .subscription-length-picker__option-price {
+    color: $gray-dark;
+  }
+
+  .subscription-length-picker__option-side-note {
+    color: $gray-text-min;
+    margin-left: 5px;
+  }
+
+  &:not( .is-active ) {
+    border: 1px solid $gray;
+    padding: $padding-size + 2px;
+  }
+
+  &.is-active {
+    border: 3px solid $alert-green;
+  }
+}

--- a/client/blocks/subscription-length-picker/test/option.js
+++ b/client/blocks/subscription-length-picker/test/option.js
@@ -1,0 +1,72 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+const translate = x => x;
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import { TERM_1_YEAR } from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { SubscriptionLengthOption } from '../option';
+
+describe( 'TermPickerOpton basic tests', () => {
+	test( 'should have term-picker-picker__option class', () => {
+		const option = shallow(
+			<SubscriptionLengthOption
+				term={ TERM_1_YEAR }
+				price={ 120 }
+				pricePerMonth={ 10 }
+				translate={ translate }
+			/>
+		);
+		expect( option.find( '.subscription-length-picker__option' ).length ).toBe( 1 );
+	} );
+	test( 'should display save badge if savePercent is specified', () => {
+		const option = shallow(
+			<SubscriptionLengthOption
+				term={ TERM_1_YEAR }
+				price={ 120 }
+				pricePerMonth={ 10 }
+				savePercent={ 65 }
+				translate={ translate }
+			/>
+		);
+		expect( option.find( 'Badge' ).length ).toBe( 1 );
+	} );
+	test( 'should say "{price} / month" if savePercent is not specified', () => {
+		const option = shallow(
+			<SubscriptionLengthOption
+				term={ TERM_1_YEAR }
+				price={ 120 }
+				pricePerMonth={ 10 }
+				translate={ translate }
+			/>
+		);
+		expect( option.find( '.subscription-length-picker__option-side-note' ).text() ).toEqual(
+			'%(price)s / month'
+		);
+	} );
+	test( 'should say "only {price} / month" if savePercent is specified', () => {
+		const option = shallow(
+			<SubscriptionLengthOption
+				term={ TERM_1_YEAR }
+				price={ 120 }
+				pricePerMonth={ 10 }
+				savePercent={ 65 }
+				translate={ translate }
+			/>
+		);
+		expect( option.find( '.subscription-length-picker__option-side-note' ).text() ).toEqual(
+			'only %(price)s / month'
+		);
+	} );
+} );


### PR DESCRIPTION
This is a part of series of PRs related to subscription length for 2-year plans (p9jf6J-eR-p2). In particular, it adds the option component of this picker:

<img width="765" alt="37955211-4385cfa8-31a8-11e8-945e-461f7307a5e4" src="https://user-images.githubusercontent.com/205419/38500487-d7a79d08-3c0a-11e8-8d67-2df55e001764.png">

This is WIP, it only adds a block and does not connect it anywhere. This PR is an attempt to split this into smaller chunks:
 
https://github.com/Automattic/wp-calypso/pull/23590

Test plan:
* Run unit tests
* That's it