### PR TITLE
Add selectors required for SubscriptionLengthPicker component

### DIFF
--- a/client/state/products-list/selectors.js
+++ b/client/state/products-list/selectors.js
@@ -15,7 +15,6 @@ import { getPlanDiscountedRawPrice } from 'state/sites/plans/selectors';
 import { getPlanRawPrice } from 'state/plans/selectors';
 import { getPlan, applyTestFiltersToPlansList } from 'lib/plans';
 import { TERM_MONTHLY } from 'lib/plans/constants';
-import createSelector from 'lib/create-selector';
 
 export function isProductsListFetching( state ) {
 	return state.productsList.isFetching;
@@ -53,7 +52,7 @@ export const getDiscountedOrRegularPrice = ( state, siteId, plan, isMonthlyPrefe
 	);
 };
 
-export const planSlugToPlanProduct = createSelector( ( products, planSlug ) => {
+export const planSlugToPlanProduct = ( products, planSlug ) => {
 	const plan = getPlan( planSlug );
 	const planConstantObj = applyTestFiltersToPlansList( plan, abtest );
 	return {
@@ -61,7 +60,7 @@ export const planSlugToPlanProduct = createSelector( ( products, planSlug ) => {
 		plan: planConstantObj,
 		product: products[ planSlug ],
 	};
-} );
+};
 
 export const computeFullAndMonthlyPricesForPlan = ( state, siteId, plan ) => ( {
 	priceFull: getDiscountedOrRegularPrice( state, siteId, plan, false ),

--- a/client/state/products-list/selectors.js
+++ b/client/state/products-list/selectors.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { pickBy } from 'lodash';
+import { pickBy, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,7 +14,6 @@ import { abtest } from 'lib/abtest';
 import { getPlanDiscountedRawPrice } from 'state/sites/plans/selectors';
 import { getPlanRawPrice } from 'state/plans/selectors';
 import { getPlan, applyTestFiltersToPlansList } from 'lib/plans';
-import { TERM_MONTHLY } from 'lib/plans/constants';
 
 export function isProductsListFetching( state ) {
 	return state.productsList.isFetching;
@@ -44,14 +43,29 @@ export function getProductDisplayCost( state, productSlug ) {
 	return product.cost_display;
 }
 
-export const getPlanPrice = ( state, siteId, plan, isMonthlyPreference ) => {
-	const isMonthly = isMonthlyPreference && plan.term !== TERM_MONTHLY;
+/**
+ * Computes a price based on plan slug/constant, including any discounts available.
+ *
+ * @param {Object} state Current redux state
+ * @param {Number} siteId Site ID to consider
+ * @param {Object} planObject Plan object returned by getPlan() from lib/plans
+ * @param {boolean} isMonthly Flag - should return a monthly price?
+ * @return {Number} Requested price
+ */
+export const getPlanPrice = ( state, siteId, planObject, isMonthly ) => {
 	return (
-		getPlanDiscountedRawPrice( state, siteId, plan.getStoreSlug(), { isMonthly } ) ||
-		getPlanRawPrice( state, plan.getProductId(), isMonthly )
+		getPlanDiscountedRawPrice( state, siteId, planObject.getStoreSlug(), { isMonthly } ) ||
+		getPlanRawPrice( state, planObject.getProductId(), isMonthly )
 	);
 };
 
+/**
+ * Computes a plan object and a related product object based on plan slug/constant
+ *
+ * @param {Array[]} products A list of products
+ * @param {String} planSlug Plan constant/slug
+ * @return {Object} Object with a related plan and product objects
+ */
 export const planSlugToPlanProduct = ( products, planSlug ) => {
 	const plan = getPlan( planSlug );
 	const planConstantObj = applyTestFiltersToPlansList( plan, abtest );
@@ -62,21 +76,38 @@ export const planSlugToPlanProduct = ( products, planSlug ) => {
 	};
 };
 
-export const computeFullAndMonthlyPricesForPlan = ( state, siteId, plan ) => ( {
-	priceFull: getPlanPrice( state, siteId, plan, false ),
-	priceMonthly: getPlanPrice( state, siteId, plan, true ),
+/**
+ * Computes a full and monthly price for a given plan, based on it's slug/constant
+ *
+ * @param {Object} state Current redux state
+ * @param {Number} siteId Site ID to consider
+ * @param {Object} planObject Plan object returned by getPlan() from lib/plans
+ * @return {Object} Object with a full and monthly price
+ */
+export const computeFullAndMonthlyPricesForPlan = ( state, siteId, planObject ) => ( {
+	priceFull: getPlanPrice( state, siteId, planObject, false ),
+	priceMonthly: getPlanPrice( state, siteId, planObject, true ),
 } );
 
-export const computeProductsWithPrices = ( state, siteId, plans ) => {
+/**
+ * Turns a list of plan slugs into a list of plan objects, corresponding
+ * products, and their full and monthly prices
+ *
+ * @param {Object} state Current redux state
+ * @param {Number} siteId Site ID to consider
+ * @param {String[]} planSlugs Plans constants
+ * @return {Array} A list of objects as described above
+ */
+export const computeProductsWithPrices = ( state, siteId, planSlugs ) => {
 	const products = getProductsList( state );
 
-	return plans
-		.map( p => planSlugToPlanProduct( products, p ) )
-		.filter( p => p.plan && p.product && p.product.available )
-		.map( object => ( {
-			...object,
-			...computeFullAndMonthlyPricesForPlan( state, siteId, object.plan ),
+	return planSlugs
+		.map( plan => planSlugToPlanProduct( products, plan ) )
+		.filter( planProduct => planProduct.plan && get( planProduct, [ 'product', 'available' ] ) )
+		.map( availablePlanProduct => ( {
+			...availablePlanProduct,
+			...computeFullAndMonthlyPricesForPlan( state, siteId, availablePlanProduct.plan ),
 		} ) )
-		.filter( p => p.priceFull )
+		.filter( availablePlanProduct => availablePlanProduct.priceFull )
 		.sort( ( a, b ) => b.priceMonthly - a.priceMonthly );
 };

--- a/client/state/products-list/selectors.js
+++ b/client/state/products-list/selectors.js
@@ -44,7 +44,7 @@ export function getProductDisplayCost( state, productSlug ) {
 	return product.cost_display;
 }
 
-export const getDiscountedOrRegularPrice = ( state, siteId, plan, isMonthlyPreference ) => {
+export const getPlanPrice = ( state, siteId, plan, isMonthlyPreference ) => {
 	const isMonthly = isMonthlyPreference && plan.term !== TERM_MONTHLY;
 	return (
 		getPlanDiscountedRawPrice( state, siteId, plan.getStoreSlug(), { isMonthly } ) ||
@@ -63,8 +63,8 @@ export const planSlugToPlanProduct = ( products, planSlug ) => {
 };
 
 export const computeFullAndMonthlyPricesForPlan = ( state, siteId, plan ) => ( {
-	priceFull: getDiscountedOrRegularPrice( state, siteId, plan, false ),
-	priceMonthly: getDiscountedOrRegularPrice( state, siteId, plan, true ),
+	priceFull: getPlanPrice( state, siteId, plan, false ),
+	priceMonthly: getPlanPrice( state, siteId, plan, true ),
 } );
 
 export const computeProductsWithPrices = ( state, siteId, plans ) => {

--- a/client/state/products-list/selectors.js
+++ b/client/state/products-list/selectors.js
@@ -1,10 +1,21 @@
 /** @format */
 
 /**
- * Internal dependencies
+ * External dependencies
  */
 
 import { pickBy } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+
+import { abtest } from 'lib/abtest';
+import { getPlanDiscountedRawPrice } from 'state/sites/plans/selectors';
+import { getPlanRawPrice } from 'state/plans/selectors';
+import { getPlan, applyTestFiltersToPlansList } from 'lib/plans';
+import { TERM_MONTHLY } from 'lib/plans/constants';
+import createSelector from 'lib/create-selector';
 
 export function isProductsListFetching( state ) {
 	return state.productsList.isFetching;
@@ -33,3 +44,40 @@ export function getProductDisplayCost( state, productSlug ) {
 
 	return product.cost_display;
 }
+
+export const getDiscountedOrRegularPrice = ( state, siteId, plan, isMonthlyPreference ) => {
+	const isMonthly = isMonthlyPreference && plan.term !== TERM_MONTHLY;
+	return (
+		getPlanDiscountedRawPrice( state, siteId, plan.getStoreSlug(), { isMonthly } ) ||
+		getPlanRawPrice( state, plan.getProductId(), isMonthly )
+	);
+};
+
+export const planSlugToPlanProduct = createSelector( ( products, planSlug ) => {
+	const plan = getPlan( planSlug );
+	const planConstantObj = applyTestFiltersToPlansList( plan, abtest );
+	return {
+		planSlug,
+		plan: planConstantObj,
+		product: products[ planSlug ],
+	};
+} );
+
+export const computeFullAndMonthlyPricesForPlan = ( state, siteId, plan ) => ( {
+	priceFull: getDiscountedOrRegularPrice( state, siteId, plan, false ),
+	priceMonthly: getDiscountedOrRegularPrice( state, siteId, plan, true ),
+} );
+
+export const computeProductsWithPrices = ( state, siteId, plans ) => {
+	const products = getProductsList( state );
+
+	return plans
+		.map( p => planSlugToPlanProduct( products, p ) )
+		.filter( p => p.plan && p.product && p.product.available )
+		.map( object => ( {
+			...object,
+			...computeFullAndMonthlyPricesForPlan( state, siteId, object.plan ),
+		} ) )
+		.filter( p => p.priceFull )
+		.sort( ( a, b ) => b.priceMonthly - a.priceMonthly );
+};

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -11,7 +11,7 @@ import deepFreeze from 'deep-freeze';
 import {
 	getProductDisplayCost,
 	isProductsListFetching,
-	getDiscountedOrRegularPrice,
+	getPlanPrice,
 	planSlugToPlanProduct,
 	computeFullAndMonthlyPricesForPlan,
 	computeProductsWithPrices,
@@ -40,7 +40,7 @@ jest.mock( 'state/plans/selectors', () => ( {
 } ) );
 
 describe( 'selectors', () => {
-	describe( '#getDiscountedOrRegularPrice()', () => {
+	describe( '#getPlanPrice()', () => {
 		beforeEach( () => {
 			getPlanDiscountedRawPrice.mockReset();
 			getPlanDiscountedRawPrice.mockImplementation( () => 12 );
@@ -51,12 +51,12 @@ describe( 'selectors', () => {
 
 		test( 'Should return discounted price if available', () => {
 			const plan = { getStoreSlug: () => 'abc' };
-			expect( getDiscountedOrRegularPrice( {}, 1, plan ) ).toBe( 12 );
+			expect( getPlanPrice( {}, 1, plan ) ).toBe( 12 );
 		} );
 
 		test( 'Should pass correct arguments to getPlanDiscountedRawPrice', () => {
 			const plan = { getStoreSlug: () => 'abc' };
-			getDiscountedOrRegularPrice( { state: 1 }, 1, plan, false );
+			getPlanPrice( { state: 1 }, 1, plan, false );
 			expect( getPlanDiscountedRawPrice.mock.calls[ 0 ] ).toEqual( [
 				{ state: 1 },
 				1,
@@ -69,26 +69,26 @@ describe( 'selectors', () => {
 			getPlanDiscountedRawPrice.mockImplementation( () => null );
 
 			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
-			expect( getDiscountedOrRegularPrice( {}, 1, plan, false ) ).toBe( 50 );
+			expect( getPlanPrice( {}, 1, plan, false ) ).toBe( 50 );
 		} );
 
 		test( 'Should pass correct arguments to getPlanRawPrice', () => {
 			getPlanDiscountedRawPrice.mockImplementation( () => null );
 
 			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
-			getDiscountedOrRegularPrice( { state: 1 }, 1, plan, false );
+			getPlanPrice( { state: 1 }, 1, plan, false );
 			expect( getPlanRawPrice.mock.calls[ 0 ] ).toEqual( [ { state: 1 }, 'def', false ] );
 		} );
 
 		test( 'Should pass correct isMonthly value', () => {
 			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
-			getDiscountedOrRegularPrice( {}, 1, plan, false );
+			getPlanPrice( {}, 1, plan, false );
 			expect( getPlanDiscountedRawPrice.mock.calls[ 0 ][ 3 ] ).toEqual( { isMonthly: false } );
 
-			getDiscountedOrRegularPrice( {}, 1, plan, true );
+			getPlanPrice( {}, 1, plan, true );
 			expect( getPlanDiscountedRawPrice.mock.calls[ 1 ][ 3 ] ).toEqual( { isMonthly: true } );
 
-			getDiscountedOrRegularPrice( {}, 1, { ...plan, term: TERM_MONTHLY }, true );
+			getPlanPrice( {}, 1, { ...plan, term: TERM_MONTHLY }, true );
 			expect( getPlanDiscountedRawPrice.mock.calls[ 2 ][ 3 ] ).toEqual( { isMonthly: false } );
 		} );
 	} );

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -89,7 +89,7 @@ describe( 'selectors', () => {
 			expect( getPlanDiscountedRawPrice.mock.calls[ 1 ][ 3 ] ).toEqual( { isMonthly: true } );
 
 			getPlanPrice( {}, 1, { ...plan, term: TERM_MONTHLY }, true );
-			expect( getPlanDiscountedRawPrice.mock.calls[ 2 ][ 3 ] ).toEqual( { isMonthly: false } );
+			expect( getPlanDiscountedRawPrice.mock.calls[ 2 ][ 3 ] ).toEqual( { isMonthly: true } );
 		} );
 	} );
 

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -3,20 +3,278 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
  */
-import { getProductDisplayCost, isProductsListFetching } from '../selectors';
+import {
+	getProductDisplayCost,
+	isProductsListFetching,
+	getDiscountedOrRegularPrice,
+	planSlugToPlanProduct,
+	computeFullAndMonthlyPricesForPlan,
+	computeProductsWithPrices,
+} from '../selectors';
+
+import { getPlanDiscountedRawPrice } from 'state/sites/plans/selectors';
+import { getPlanRawPrice } from 'state/plans/selectors';
+import { getPlan } from 'lib/plans';
+import { TERM_MONTHLY } from 'lib/plans/constants';
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.mock( 'state/sites/plans/selectors', () => ( {
+	getPlanDiscountedRawPrice: jest.fn(),
+} ) );
+
+jest.mock( 'lib/plans', () => ( {
+	applyTestFiltersToPlansList: jest.fn( x => x ),
+	getPlan: jest.fn(),
+} ) );
+
+jest.mock( 'state/plans/selectors', () => ( {
+	getPlanRawPrice: jest.fn(),
+} ) );
 
 describe( 'selectors', () => {
+	describe( '#getDiscountedOrRegularPrice()', () => {
+		beforeEach( () => {
+			getPlanDiscountedRawPrice.mockReset();
+			getPlanDiscountedRawPrice.mockImplementation( () => 12 );
+
+			getPlanRawPrice.mockReset();
+			getPlanRawPrice.mockImplementation( () => 50 );
+		} );
+
+		test( 'Should return discounted price if available', () => {
+			const plan = { getStoreSlug: () => 'abc' };
+			expect( getDiscountedOrRegularPrice( {}, 1, plan ) ).toBe( 12 );
+		} );
+
+		test( 'Should pass correct arguments to getPlanDiscountedRawPrice', () => {
+			const plan = { getStoreSlug: () => 'abc' };
+			getDiscountedOrRegularPrice( { state: 1 }, 1, plan, false );
+			expect( getPlanDiscountedRawPrice.mock.calls[ 0 ] ).toEqual( [
+				{ state: 1 },
+				1,
+				'abc',
+				{ isMonthly: false },
+			] );
+		} );
+
+		test( 'Should return raw price if no discount available', () => {
+			getPlanDiscountedRawPrice.mockImplementation( () => null );
+
+			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
+			expect( getDiscountedOrRegularPrice( {}, 1, plan, false ) ).toBe( 50 );
+		} );
+
+		test( 'Should pass correct arguments to getPlanRawPrice', () => {
+			getPlanDiscountedRawPrice.mockImplementation( () => null );
+
+			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
+			getDiscountedOrRegularPrice( { state: 1 }, 1, plan, false );
+			expect( getPlanRawPrice.mock.calls[ 0 ] ).toEqual( [ { state: 1 }, 'def', false ] );
+		} );
+
+		test( 'Should pass correct isMonthly value', () => {
+			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
+			getDiscountedOrRegularPrice( {}, 1, plan, false );
+			expect( getPlanDiscountedRawPrice.mock.calls[ 0 ][ 3 ] ).toEqual( { isMonthly: false } );
+
+			getDiscountedOrRegularPrice( {}, 1, plan, true );
+			expect( getPlanDiscountedRawPrice.mock.calls[ 1 ][ 3 ] ).toEqual( { isMonthly: true } );
+
+			getDiscountedOrRegularPrice( {}, 1, { ...plan, term: TERM_MONTHLY }, true );
+			expect( getPlanDiscountedRawPrice.mock.calls[ 2 ][ 3 ] ).toEqual( { isMonthly: false } );
+		} );
+	} );
+
+	describe( '#planSlugToPlanProduct()', () => {
+		test( 'Should return shape { planSlug, plan, product }', () => {
+			const products = {
+				myPlanSlug: {
+					price: 10,
+				},
+			};
+			const planSlug = 'myPlanSlug';
+			const plan = {
+				storeId: 15,
+			};
+			getPlan.mockImplementation( () => plan );
+
+			expect( planSlugToPlanProduct( products, planSlug ) ).toEqual( {
+				planSlug,
+				plan,
+				product: products.myPlanSlug,
+			} );
+		} );
+
+		test( 'Should return shape { planSlug, plan, product } with empty values if plan or product couldnt be found', () => {
+			const planSlug = 'myPlanSlug';
+			getPlan.mockImplementation( () => null );
+
+			expect( planSlugToPlanProduct( {}, planSlug ) ).toEqual( {
+				planSlug,
+				plan: null,
+				product: undefined,
+			} );
+
+			expect( planSlugToPlanProduct( { myPlanSlug: null }, planSlug ) ).toEqual( {
+				planSlug,
+				plan: null,
+				product: null,
+			} );
+		} );
+	} );
+
+	describe( '#computeFullAndMonthlyPricesForPlan()', () => {
+		test( 'Should return shape { priceFull, priceMonthly }', () => {
+			getPlanDiscountedRawPrice.mockImplementation(
+				( a, b, c, { isMonthly } ) => ( isMonthly ? 10 : 120 )
+			);
+
+			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
+			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan ) ).toEqual( {
+				priceFull: 120,
+				priceMonthly: 10,
+			} );
+		} );
+	} );
+
+	describe( '#computeProductsWithPrices()', () => {
+		const plans = {
+			plan1: {
+				id: 1,
+				getStoreSlug: () => 'abc',
+				getProductId: () => 'def',
+			},
+
+			plan2: {
+				id: 2,
+				getStoreSlug: () => 'jkl',
+				getProductId: () => 'mno',
+			},
+		};
+
+		beforeEach( () => {
+			getPlanRawPrice.mockImplementation( () => 0 );
+			getPlanDiscountedRawPrice.mockImplementation( ( a, b, storeSlug, { isMonthly } ) => {
+				if ( storeSlug === 'abc' ) {
+					return isMonthly ? 10 : 120;
+				}
+
+				return isMonthly ? 20 : 240;
+			} );
+
+			getPlan.mockImplementation( slug => plans[ slug ] );
+		} );
+
+		test( 'Should return list of shapes { priceFull, priceMonthly, plan, product, planSlug }', () => {
+			const state = {
+				productsList: {
+					items: {
+						plan1: { available: true },
+						plan2: { available: true },
+					},
+				},
+			};
+
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
+				{
+					planSlug: 'plan2',
+					plan: plans.plan2,
+					product: state.productsList.items.plan2,
+					priceFull: 240,
+					priceMonthly: 20,
+				},
+				{
+					planSlug: 'plan1',
+					plan: plans.plan1,
+					product: state.productsList.items.plan1,
+					priceFull: 120,
+					priceMonthly: 10,
+				},
+			] );
+		} );
+
+		test( 'Should filter out unavailable products', () => {
+			const state = {
+				productsList: {
+					items: {
+						plan1: { available: true },
+						plan2: { available: false },
+					},
+				},
+			};
+
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
+				{
+					planSlug: 'plan1',
+					plan: plans.plan1,
+					product: state.productsList.items.plan1,
+					priceFull: 120,
+					priceMonthly: 10,
+				},
+			] );
+		} );
+
+		test( 'Should filter out unavailable not found products', () => {
+			const state = {
+				productsList: {
+					items: {
+						plan1: { available: true },
+					},
+				},
+			};
+
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
+				{
+					planSlug: 'plan1',
+					plan: plans.plan1,
+					product: state.productsList.items.plan1,
+					priceFull: 120,
+					priceMonthly: 10,
+				},
+			] );
+		} );
+
+		test( 'Should filter out unavailable not found products with no price', () => {
+			getPlanDiscountedRawPrice.mockImplementation( ( a, b, storeSlug, { isMonthly } ) => {
+				if ( storeSlug === 'abc' ) {
+					return isMonthly ? 10 : 120;
+				}
+			} );
+
+			const state = {
+				productsList: {
+					items: {
+						plan1: { available: true },
+						plan2: { available: true },
+					},
+				},
+			};
+
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
+				{
+					planSlug: 'plan1',
+					plan: plans.plan1,
+					product: state.productsList.items.plan1,
+					priceFull: 120,
+					priceMonthly: 10,
+				},
+			] );
+		} );
+	} );
+
 	describe( '#getProductDisplayCost()', () => {
 		test( 'should return null when the products list has not been fetched', () => {
 			const state = deepFreeze( { productsList: { items: {} } } );
 
-			expect( getProductDisplayCost( state, 'guided_transfer' ) ).to.be.null;
+			expect( getProductDisplayCost( state, 'guided_transfer' ) ).toBe( null );
 		} );
 
 		test( 'should return the display cost', () => {
@@ -30,19 +288,19 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( getProductDisplayCost( state, 'guided_transfer' ) ).to.equal( 'A$169.00' );
+			expect( getProductDisplayCost( state, 'guided_transfer' ) ).toBe( 'A$169.00' );
 		} );
 	} );
 
 	describe( '#isProductsListFetching()', () => {
 		test( 'should return false when productsList.isFetching is false', () => {
 			const state = { productsList: { isFetching: false } };
-			expect( isProductsListFetching( state ) ).to.be.false;
+			expect( isProductsListFetching( state ) ).toBe( false );
 		} );
 
 		test( 'should return true when productsList.isFetching is true', () => {
 			const state = { productsList: { isFetching: true } };
-			expect( isProductsListFetching( state ) ).to.be.true;
+			expect( isProductsListFetching( state ) ).toBe( true );
 		} );
 	} );
 } );

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -388,9 +388,15 @@ describe( 'selectors', () => {
 			} );
 			expect( discountPrice ).to.equal( 10 );
 		} );
-		test( 'should return a monthly discount price - monthly term', () => {
+		test( 'should return a monthly discount price - monthly term (isMonthly: true)', () => {
 			const discountPrice = getPlanDiscountedRawPrice( state, 77203074, 'jetpack_premium_monthly', {
 				isMonthly: true,
+			} );
+			expect( discountPrice ).to.equal( 30 );
+		} );
+		test( 'should return a monthly discount price - monthly term (isMonthly: false)', () => {
+			const discountPrice = getPlanDiscountedRawPrice( state, 77203074, 'jetpack_premium_monthly', {
+				isMonthly: false,
 			} );
 			expect( discountPrice ).to.equal( 30 );
 		} );


### PR DESCRIPTION
This is a part of series of PRs related to subscription length for 2-year plans (p9jf6J-eR-p2). In particular, it adds selectors necessary for this component:

<img width="765" alt="37955211-4385cfa8-31a8-11e8-945e-461f7307a5e4" src="https://user-images.githubusercontent.com/205419/38500487-d7a79d08-3c0a-11e8-8d67-2df55e001764.png">

This is WIP, it only adds selectors and does not connect it anywhere. This PR is an attempt to split this into smaller chunks:
 
https://github.com/Automattic/wp-calypso/pull/23590

Test plan:
* Run unit tests
* That's it

@gwwar 