### PR TITLE
Refactor getBillingMonthsForTerm out of calculateMonthlyPrice

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -348,18 +348,24 @@ export function calculateMonthlyPriceForPlan( planSlug, termPrice ) {
 }
 
 export function calculateMonthlyPrice( term, termPrice ) {
-	let divisor;
+	const divisor = getBillingMonthsForTerm( term );
+	return parseFloat( ( termPrice / divisor ).toFixed( 2 ) );
+}
+
+export function getBillingMonthsForPlan( planSlug ) {
+	return getBillingMonthsForTerm( getPlan( planSlug ).term );
+}
+
+export function getBillingMonthsForTerm( term ) {
 	if ( term === TERM_MONTHLY ) {
-		divisor = 1;
+		return 1;
 	} else if ( term === TERM_ANNUALLY ) {
-		divisor = 12;
+		return 12;
 	} else if ( term === TERM_BIENNIALLY ) {
-		divisor = 24;
-	} else {
-		throw new Error( `Unknown term: ${ term }` );
+		return 24;
 	}
 
-	return parseFloat( ( termPrice / divisor ).toFixed( 2 ) );
+	throw new Error( `Unknown term: ${ term }` );
 }
 
 export const isPlanFeaturesEnabled = () => {

--- a/client/lib/plans/test/plan-other.js
+++ b/client/lib/plans/test/plan-other.js
@@ -2,39 +2,53 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
  */
 import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from '../constants';
-import { calculateMonthlyPrice } from '../index';
+import { calculateMonthlyPrice, getBillingMonthsForTerm } from '../index';
 
 describe( 'calculateMonthlyPrice', () => {
 	test( 'should return same number for monthly term', () => {
-		expect( calculateMonthlyPrice( TERM_MONTHLY, 10 ) ).to.equal( 10 );
-		expect( calculateMonthlyPrice( TERM_MONTHLY, 12.32 ) ).to.equal( 12.32 );
+		expect( calculateMonthlyPrice( TERM_MONTHLY, 10 ) ).toBe( 10 );
+		expect( calculateMonthlyPrice( TERM_MONTHLY, 12.32 ) ).toBe( 12.32 );
 	} );
 	test( 'should calculate proper result for annual term', () => {
-		expect( calculateMonthlyPrice( TERM_ANNUALLY, 12 ) ).to.equal( 1.0 );
-		expect( calculateMonthlyPrice( TERM_ANNUALLY, 120 ) ).to.equal( 10.0 );
-		expect( calculateMonthlyPrice( TERM_ANNUALLY, 240 ) ).to.equal( 20.0 );
-		expect( calculateMonthlyPrice( TERM_ANNUALLY, 122 ) ).to.equal( 10.17 );
-		expect( calculateMonthlyPrice( TERM_ANNUALLY, 127 ) ).to.equal( 10.58 );
-		expect( calculateMonthlyPrice( TERM_ANNUALLY, 128 ) ).to.equal( 10.67 );
-		expect( calculateMonthlyPrice( TERM_ANNUALLY, 129 ) ).to.equal( 10.75 );
-		expect( calculateMonthlyPrice( TERM_ANNUALLY, 130 ) ).to.equal( 10.83 );
-		expect( calculateMonthlyPrice( TERM_ANNUALLY, 131 ) ).to.equal( 10.92 );
+		expect( calculateMonthlyPrice( TERM_ANNUALLY, 12 ) ).toBe( 1.0 );
+		expect( calculateMonthlyPrice( TERM_ANNUALLY, 120 ) ).toBe( 10.0 );
+		expect( calculateMonthlyPrice( TERM_ANNUALLY, 240 ) ).toBe( 20.0 );
+		expect( calculateMonthlyPrice( TERM_ANNUALLY, 122 ) ).toBe( 10.17 );
+		expect( calculateMonthlyPrice( TERM_ANNUALLY, 127 ) ).toBe( 10.58 );
+		expect( calculateMonthlyPrice( TERM_ANNUALLY, 128 ) ).toBe( 10.67 );
+		expect( calculateMonthlyPrice( TERM_ANNUALLY, 129 ) ).toBe( 10.75 );
+		expect( calculateMonthlyPrice( TERM_ANNUALLY, 130 ) ).toBe( 10.83 );
+		expect( calculateMonthlyPrice( TERM_ANNUALLY, 131 ) ).toBe( 10.92 );
 	} );
 	test( 'should calculate proper result for biennial term', () => {
-		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 12 ) ).to.equal( 0.5 );
-		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 120 ) ).to.equal( 5.0 );
-		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 240 ) ).to.equal( 10.0 );
-		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 122 ) ).to.equal( 5.08 );
-		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 127 ) ).to.equal( 5.29 );
-		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 128 ) ).to.equal( 5.33 );
-		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 129 ) ).to.equal( 5.38 );
-		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 130 ) ).to.equal( 5.42 );
-		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 131 ) ).to.equal( 5.46 );
+		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 12 ) ).toBe( 0.5 );
+		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 120 ) ).toBe( 5.0 );
+		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 240 ) ).toBe( 10.0 );
+		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 122 ) ).toBe( 5.08 );
+		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 127 ) ).toBe( 5.29 );
+		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 128 ) ).toBe( 5.33 );
+		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 129 ) ).toBe( 5.38 );
+		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 130 ) ).toBe( 5.42 );
+		expect( calculateMonthlyPrice( TERM_BIENNIALLY, 131 ) ).toBe( 5.46 );
+	} );
+} );
+
+describe( 'getBillingMonthsForTerm', () => {
+	test( 'should 1 for monthly term', () => {
+		expect( getBillingMonthsForTerm( TERM_MONTHLY ) ).toBe( 1 );
+	} );
+	test( 'should 12 annual term', () => {
+		expect( getBillingMonthsForTerm( TERM_ANNUALLY ) ).toBe( 12 );
+	} );
+	test( 'should 24 for biennial term', () => {
+		expect( getBillingMonthsForTerm( TERM_BIENNIALLY ) ).toBe( 24 );
+	} );
+	test( 'should throw an error for unknown term', () => {
+		expect( () => getBillingMonthsForTerm( 'fake' ) ).toThrowError();
 	} );
 } );


### PR DESCRIPTION
This is a part of series of PRs related to 2-year plans (p9jf6J-eR-p2).

In upcoming PR, a function `getBillingMonthsForTerm` is going to be required. This is a separate PR to keep things short and easy to review.

Test plan:
* Run unit tests
* Go to jetpack plans page and make sure the prices are displayed correctly