### PR TITLE
Add isYearly and isBienially functions to product-values

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -53,6 +53,7 @@ export const JETPACK_MONTHLY_PLANS = [
 
 export const PLAN_MONTHLY_PERIOD = 31;
 export const PLAN_ANNUAL_PERIOD = 365;
+export const PLAN_BIENNIAL_PERIOD = 730;
 
 // features constants
 export const FEATURE_WP_SUBDOMAIN = 'wordpress-subdomain';

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -25,6 +25,8 @@ import {
 	PLAN_WPCOM_ENTERPRISE,
 	PLAN_CHARGEBACK,
 	PLAN_MONTHLY_PERIOD,
+	PLAN_ANNUAL_PERIOD,
+	PLAN_BIENNIAL_PERIOD,
 } from 'lib/plans/constants';
 import { domainProductSlugs } from 'lib/domains/constants';
 
@@ -171,6 +173,20 @@ export function isMonthly( product ) {
 	assertValidProduct( product );
 
 	return parseInt( product.bill_period, 10 ) === PLAN_MONTHLY_PERIOD;
+}
+
+export function isYearly( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return parseInt( product.bill_period, 10 ) === PLAN_ANNUAL_PERIOD;
+}
+
+export function isBiennially( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return parseInt( product.bill_period, 10 ) === PLAN_BIENNIAL_PERIOD;
 }
 
 export function isJpphpBundle( product ) {

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -168,22 +168,22 @@ export function isJetpackMonthlyPlan( product ) {
 	return isMonthly( product ) && isJetpackPlan( product );
 }
 
-export function isMonthly( product ) {
-	product = formatProduct( product );
+export function isMonthly( rawProduct ) {
+	const product = formatProduct( rawProduct );
 	assertValidProduct( product );
 
 	return parseInt( product.bill_period, 10 ) === PLAN_MONTHLY_PERIOD;
 }
 
-export function isYearly( product ) {
-	product = formatProduct( product );
+export function isYearly( rawProduct ) {
+	const product = formatProduct( rawProduct );
 	assertValidProduct( product );
 
 	return parseInt( product.bill_period, 10 ) === PLAN_ANNUAL_PERIOD;
 }
 
-export function isBiennially( product ) {
-	product = formatProduct( product );
+export function isBiennially( rawProduct ) {
+	const product = formatProduct( rawProduct );
 	assertValidProduct( product );
 
 	return parseInt( product.bill_period, 10 ) === PLAN_BIENNIAL_PERIOD;

--- a/client/lib/products-values/test/index.js
+++ b/client/lib/products-values/test/index.js
@@ -3,12 +3,11 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
  */
-import { isJetpackPlan } from '..';
+import { isJetpackPlan, isMonthly, isYearly, isBiennially } from '..';
 import {
 	JETPACK_PLANS,
 	PLAN_BUSINESS,
@@ -27,8 +26,8 @@ const makeProductFromSlug = product_slug => ( { product_slug } );
 
 describe( 'isJetpackPlan', () => {
 	test( 'should return true for Jetpack products', () => {
-		JETPACK_PLANS.map( makeProductFromSlug ).forEach(
-			product => expect( isJetpackPlan( product ) ).to.be.true
+		JETPACK_PLANS.map( makeProductFromSlug ).forEach( product =>
+			expect( isJetpackPlan( product ) ).toBe( true )
 		);
 	} );
 
@@ -37,6 +36,39 @@ describe( 'isJetpackPlan', () => {
 
 		nonJetpackPlans
 			.map( makeProductFromSlug )
-			.forEach( product => expect( isJetpackPlan( product ) ).to.be.false );
+			.forEach( product => expect( isJetpackPlan( product ) ).toBe( false ) );
+	} );
+} );
+
+describe( 'isMonthly', () => {
+	test( 'should return true for monthly products', () => {
+		expect( isMonthly( { bill_period: 31 } ) ).toBe( true );
+	} );
+	test( 'should return true for other products', () => {
+		expect( isMonthly( { bill_period: 30 } ) ).toBe( false );
+		expect( isMonthly( { bill_period: 32 } ) ).toBe( false );
+		expect( isMonthly( { bill_period: 365 } ) ).toBe( false );
+	} );
+} );
+
+describe( 'isYearly', () => {
+	test( 'should return true for yearly products', () => {
+		expect( isYearly( { bill_period: 365 } ) ).toBe( true );
+	} );
+	test( 'should return true for other products', () => {
+		expect( isYearly( { bill_period: 700 } ) ).toBe( false );
+		expect( isYearly( { bill_period: 31 } ) ).toBe( false );
+		expect( isYearly( { bill_period: 364 } ) ).toBe( false );
+	} );
+} );
+
+describe( 'isBiennially', () => {
+	test( 'should return true for biennial products', () => {
+		expect( isBiennially( { bill_period: 730 } ) ).toBe( true );
+	} );
+	test( 'should return true for other products', () => {
+		expect( isBiennially( { bill_period: 365 } ) ).toBe( false );
+		expect( isBiennially( { bill_period: 31 } ) ).toBe( false );
+		expect( isBiennially( { bill_period: 731 } ) ).toBe( false );
 	} );
 } );


### PR DESCRIPTION
This is a part of series of PRs related to 2-year plans (p9jf6J-eR-p2). In particular, it adds `isMonthly` and `isBienially` functions that will be required in upcoming PRs.

Test plan:
* Run unit tests
* Go to jetpack plans page and make sure the prices are displayed correctly