### PR TITLE
Analytics: Refactor /extensions/woocommerce page view tracking

### DIFF
--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -27,6 +27,7 @@ import Placeholder from './dashboard/placeholder';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import RequiredPluginsInstallView from 'woocommerce/app/dashboard/required-plugins-install-view';
 import WooCommerceColophon from 'woocommerce/components/woocommerce-colophon';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 class App extends Component {
 	static propTypes = {
@@ -37,6 +38,8 @@ class App extends Component {
 		hasPendingAutomatedTransfer: PropTypes.bool.isRequired,
 		isAtomicSite: PropTypes.bool.isRequired,
 		isDashboard: PropTypes.bool.isRequired,
+		analyticsPath: PropTypes.string,
+		analyticsTitle: PropTypes.string,
 	};
 
 	componentDidMount() {
@@ -120,6 +123,8 @@ class App extends Component {
 			isAtomicSite,
 			hasPendingAutomatedTransfer,
 			translate,
+			analyticsPath,
+			analyticsTitle,
 		} = this.props;
 		if ( ! siteId ) {
 			return null;
@@ -144,6 +149,7 @@ class App extends Component {
 		const className = 'woocommerce';
 		return (
 			<div className={ className }>
+				<PageViewTracker path={ analyticsPath } title={ analyticsTitle } />
 				<DocumentHead title={ documentTitle } />
 				<QueryJetpackPlugins siteIds={ [ siteId ] } />
 				{ this.maybeRenderChildren() }

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -206,7 +206,7 @@ function getAnalyticsPath( path, params ) {
 	return path
 		.replace( '?', '' )
 		.replace( ':filter', params.filter )
-		.replace( ':productId', ':product-id' );
+		.replace( ':productId', ':product_id' );
 }
 
 function addStorePage( storePage, storeNavigation ) {

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -202,10 +202,13 @@ function addStorePage( storePage, storeNavigation ) {
 				appProps.documentTitle = storePage.documentTitle;
 			}
 
-			appProps.analyticsPath = storePage.path;
-			const { filter } = context.params;
+			appProps.analyticsPath = storePage.path.replace( '?', '' );
+			const { filter, productId } = context.params;
 			if ( filter ) {
 				appProps.analyticsPath = appProps.analyticsPath.replace( ':filter', filter );
+			}
+			if ( productId ) {
+				appProps.analyticsPath = appProps.analyticsPath.replace( ':productId', ':product-id' );
 			}
 
 			appProps.analyticsTitle = 'Store';

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -188,6 +188,27 @@ const getStorePages = () => {
 	return pages;
 };
 
+function getAnalyticsPath( path, params ) {
+	if ( '/store/settings/:site' === path ) {
+		return '/store/settings/payments/:site';
+	}
+
+	if ( '/store/settings/email/:site/:setup?' === path ) {
+		return !! params.setup ? '/store/settings/email/:site/:setup' : '/store/settings/email/:site';
+	}
+
+	if ( '/store/settings/shipping/zone/:site/:zone?' === path ) {
+		return !! params.zone
+			? '/store/settings/shipping/zone/:site/:zone'
+			: '/store/settings/shipping/zone/:site';
+	}
+
+	return path
+		.replace( '?', '' )
+		.replace( ':filter', params.filter )
+		.replace( ':productId', ':product-id' );
+}
+
 function addStorePage( storePage, storeNavigation ) {
 	page(
 		storePage.path,
@@ -202,21 +223,11 @@ function addStorePage( storePage, storeNavigation ) {
 				appProps.documentTitle = storePage.documentTitle;
 			}
 
-			appProps.analyticsPath = storePage.path.replace( '?', '' );
-			const { filter, productId } = context.params;
-			if ( filter ) {
-				appProps.analyticsPath = appProps.analyticsPath.replace( ':filter', filter );
-			}
-			if ( productId ) {
-				appProps.analyticsPath = appProps.analyticsPath.replace( ':productId', ':product-id' );
-			}
+			appProps.analyticsPath = getAnalyticsPath( storePage.path, context.params );
 
-			appProps.analyticsTitle = 'Store';
-			if ( storePage.documentTitle ) {
-				appProps.analyticsTitle += ` > ${ storePage.documentTitle }`;
-			} else {
-				appProps.analyticsTitle += ' > Dashboard';
-			}
+			appProps.analyticsTitle = `Store > ${
+				storePage.documentTitle ? storePage.documentTitle : 'Dashboard'
+			}`;
 
 			context.primary = React.createElement( App, appProps, component );
 			next();

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -12,7 +12,6 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
 import App from './app';
 import Dashboard from './app/dashboard';
 import EmptyContent from 'components/empty-content';
@@ -203,20 +202,18 @@ function addStorePage( storePage, storeNavigation ) {
 				appProps.documentTitle = storePage.documentTitle;
 			}
 
-			let analyticsPath = storePage.path;
+			appProps.analyticsPath = storePage.path;
 			const { filter } = context.params;
 			if ( filter ) {
-				analyticsPath = analyticsPath.replace( ':filter', filter );
+				appProps.analyticsPath = appProps.analyticsPath.replace( ':filter', filter );
 			}
 
-			let analyticsPageTitle = 'Store';
+			appProps.analyticsTitle = 'Store';
 			if ( storePage.documentTitle ) {
-				analyticsPageTitle += ` > ${ storePage.documentTitle }`;
+				appProps.analyticsTitle += ` > ${ storePage.documentTitle }`;
 			} else {
-				analyticsPageTitle += ' > Dashboard';
+				appProps.analyticsTitle += ' > Dashboard';
 			}
-
-			analytics.pageView.record( analyticsPath, analyticsPageTitle );
 
 			context.primary = React.createElement( App, appProps, component );
 			next();


### PR DESCRIPTION
Replace direct `analytics.pageView.record` calls with `PageViewTracker` in `/extensions/woocommerce`.

Check out the updated recommendations on page view tracking:
https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/docs/page-views.md

## Testing instructions

Not sure. 🤔 