### PR TITLE
 Store: Update URL params to match the expected analytics format

### DIFF
--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -25,22 +25,26 @@ import { isLoaded as arePluginsLoaded } from 'state/plugins/installed/selectors'
 import { isStoreSetupComplete } from 'woocommerce/state/sites/setup-choices/selectors';
 import Main from 'components/main';
 import Placeholder from './dashboard/placeholder';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import RequiredPluginsInstallView from 'woocommerce/app/dashboard/required-plugins-install-view';
 import WooCommerceColophon from 'woocommerce/components/woocommerce-colophon';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 class App extends Component {
 	static propTypes = {
-		siteId: PropTypes.number,
+		allRequiredPluginsActive: PropTypes.bool,
+		analyticsPath: PropTypes.string,
+		analyticsTitle: PropTypes.string,
 		canUserManageOptions: PropTypes.bool.isRequired,
 		children: PropTypes.element.isRequired,
 		documentTitle: PropTypes.string,
+		fetchSetupChoices: PropTypes.func.isRequired,
 		hasPendingAutomatedTransfer: PropTypes.bool.isRequired,
 		isAtomicSite: PropTypes.bool.isRequired,
 		isDashboard: PropTypes.bool.isRequired,
-		analyticsPath: PropTypes.string,
-		analyticsTitle: PropTypes.string,
+		pluginsLoaded: PropTypes.bool.isRequired,
+		siteId: PropTypes.number,
+		translate: PropTypes.func.isRequired,
 	};
 
 	componentDidMount() {
@@ -123,13 +127,13 @@ class App extends Component {
 
 	render = () => {
 		const {
-			siteId,
-			canUserManageOptions,
-			isAtomicSite,
-			hasPendingAutomatedTransfer,
-			translate,
 			analyticsPath,
 			analyticsTitle,
+			canUserManageOptions,
+			hasPendingAutomatedTransfer,
+			isAtomicSite,
+			siteId,
+			translate,
 		} = this.props;
 		if ( ! siteId ) {
 			return null;
@@ -176,13 +180,13 @@ function mapStateToProps( state ) {
 	const isSetupComplete = isStoreSetupComplete( state, siteId );
 
 	return {
-		siteId,
 		allRequiredPluginsActive,
 		canUserManageOptions: siteId ? canUserManageOptions : false,
 		isAtomicSite: siteId ? isAtomicSite : false,
 		isSetupComplete,
 		hasPendingAutomatedTransfer: siteId ? hasPendingAutomatedTransfer : false,
 		pluginsLoaded,
+		siteId,
 	};
 }
 

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -88,7 +88,7 @@ export default connect(
 	( state, props ) => {
 		const site = getSelectedSiteWithFallback( state );
 		const siteId = site ? site.ID : false;
-		const orderId = parseInt( props.params.order );
+		const orderId = parseInt( props.params.order_id );
 		const isEditing = isCurrentlyEditingOrder( state );
 		const order = isEditing ? getOrderWithEdits( state ) : getOrder( state, orderId );
 		const hasOrder = ! isEmpty( order );

--- a/client/extensions/woocommerce/app/product-categories/update.js
+++ b/client/extensions/woocommerce/app/product-categories/update.js
@@ -63,7 +63,7 @@ class ProductCategoryUpdate extends React.Component {
 
 	componentDidMount() {
 		const { params, site, category } = this.props;
-		const categoryId = Number( params.category );
+		const categoryId = Number( params.category_id );
 
 		if ( site && site.ID ) {
 			if ( ! category ) {
@@ -75,7 +75,7 @@ class ProductCategoryUpdate extends React.Component {
 
 	componentWillReceiveProps( newProps ) {
 		const { params, site } = this.props;
-		const categoryId = Number( params.category );
+		const categoryId = Number( params.category_id );
 		const newSiteId = ( newProps.site && newProps.site.ID ) || null;
 		const oldSiteId = ( site && site.ID ) || null;
 		if ( oldSiteId !== newSiteId ) {
@@ -199,7 +199,7 @@ class ProductCategoryUpdate extends React.Component {
 }
 
 function mapStateToProps( state, ownProps ) {
-	const categoryId = Number( ownProps.params.category );
+	const categoryId = Number( ownProps.params.category_id );
 
 	const site = getSelectedSiteWithFallback( state );
 	const category = getProductCategoryWithLocalEdits( state, categoryId );

--- a/client/extensions/woocommerce/app/products/product-update.js
+++ b/client/extensions/woocommerce/app/products/product-update.js
@@ -75,7 +75,7 @@ class ProductUpdate extends React.Component {
 
 	componentDidMount() {
 		const { params, product, site, variations } = this.props;
-		const productId = Number( params.product );
+		const productId = Number( params.product_id );
 
 		if ( site && site.ID ) {
 			if ( ! product ) {
@@ -91,7 +91,7 @@ class ProductUpdate extends React.Component {
 
 	componentWillReceiveProps( newProps ) {
 		const { params, site } = this.props;
-		const productId = Number( params.product );
+		const productId = Number( params.product_id );
 		const newSiteId = ( newProps.site && newProps.site.ID ) || null;
 		const oldSiteId = ( site && site.ID ) || null;
 		if ( oldSiteId !== newSiteId ) {
@@ -233,7 +233,7 @@ class ProductUpdate extends React.Component {
 }
 
 function mapStateToProps( state, ownProps ) {
-	const productId = Number( ownProps.params.product );
+	const productId = Number( ownProps.params.product_id );
 
 	const site = getSelectedSiteWithFallback( state );
 	const product = getProductWithLocalEdits( state, productId );

--- a/client/extensions/woocommerce/app/promotions/promotion-update.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-update.js
@@ -244,7 +244,7 @@ function mapStateToProps( state, ownProps ) {
 	const site = getSelectedSiteWithFallback( state );
 	const currencySettings = getPaymentCurrencySettings( state );
 	const currency = currencySettings ? currencySettings.value : null;
-	const promotionId = ownProps.params.promotion;
+	const promotionId = ownProps.params.promotion_id;
 	const promotion = promotionId ? getPromotionWithLocalEdits( state, promotionId, site.ID ) : null;
 	const productsLoading = areProductsLoading( state, site.ID );
 	const products = productsLoading ? null : getAllProducts( state, site.ID );

--- a/client/extensions/woocommerce/app/reviews/index.js
+++ b/client/extensions/woocommerce/app/reviews/index.js
@@ -33,7 +33,7 @@ class Reviews extends Component {
 			<Main className={ classes } wideLayout>
 				<ActionHeader breadcrumbs={ <span>{ translate( 'Reviews' ) }</span> } />
 				<ReviewsList
-					productId={ params && params.productId && Number( params.productId ) }
+					productId={ params && params.product_id && Number( params.product_id ) }
 					currentStatus={ params && params.filter }
 				/>
 			</Main>

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -67,7 +67,7 @@ const getStorePages = () => {
 			container: ProductUpdate,
 			configKey: 'woocommerce/extension-products',
 			documentTitle: translate( 'Edit Product' ),
-			path: '/store/product/:site/:product',
+			path: '/store/product/:site/:product_id',
 		},
 		{
 			container: ProductCategories,
@@ -79,7 +79,7 @@ const getStorePages = () => {
 			container: ProductCategoryUpdate,
 			configKey: 'woocommerce/extension-product-categories',
 			documentTitle: translate( 'Edit Product Category' ),
-			path: '/store/products/category/:site/:category',
+			path: '/store/products/category/:site/:category_id',
 		},
 		{
 			container: ProductCategoryCreate,
@@ -103,7 +103,7 @@ const getStorePages = () => {
 			container: Order,
 			configKey: 'woocommerce/extension-orders',
 			documentTitle: translate( 'Order Details' ),
-			path: '/store/order/:site/:order',
+			path: '/store/order/:site/:order_id',
 		},
 		{
 			container: OrderCreate,
@@ -127,7 +127,7 @@ const getStorePages = () => {
 			container: PromotionUpdate,
 			configKey: 'woocommerce/extension-promotions',
 			documentTitle: translate( 'Edit Promotion' ),
-			path: '/store/promotion/:site/:promotion',
+			path: '/store/promotion/:site/:promotion_id',
 		},
 		{
 			container: Reviews,
@@ -145,7 +145,7 @@ const getStorePages = () => {
 			container: Reviews,
 			configKey: 'woocommerce/extension-reviews',
 			documentTitle: translate( 'Reviews' ),
-			path: '/store/reviews/:productId/:filter/:site',
+			path: '/store/reviews/:product_id/:filter/:site',
 		},
 		{
 			container: SettingsPayments,
@@ -203,10 +203,7 @@ function getAnalyticsPath( path, params ) {
 			: '/store/settings/shipping/zone/:site';
 	}
 
-	return path
-		.replace( '?', '' )
-		.replace( ':filter', params.filter )
-		.replace( ':productId', ':product_id' );
+	return path.replace( '?', '' ).replace( ':filter', params.filter );
 }
 
 function addStorePage( storePage, storeNavigation ) {
@@ -217,14 +214,10 @@ function addStorePage( storePage, storeNavigation ) {
 		( context, next ) => {
 			const component = React.createElement( storePage.container, { params: context.params } );
 			const appProps = {
+				documentTitle: storePage.documentTitle || null,
 				isDashboard: '/store/:site' === storePage.path,
 			};
-			if ( storePage.documentTitle ) {
-				appProps.documentTitle = storePage.documentTitle;
-			}
-
 			appProps.analyticsPath = getAnalyticsPath( storePage.path, context.params );
-
 			appProps.analyticsTitle = `Store > ${
 				storePage.documentTitle ? storePage.documentTitle : 'Dashboard'
 			}`;


### PR DESCRIPTION
According to [the documentation](https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/docs/page-views.md), we should be using the `<PageViewTracker />` component to track page views, not `analytics.pageView.record` - this component is aware of the current site, and will track once the site is set.

~This PR adds that component to our store App container, so that any page change will trigger a page view.~ Edit: This was already done in #23998.

Now, the change here is updating our parameter names to follow [this naming convention](https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/docs/page-views.md#paths-conventions), where all object IDs in URLs should be of the format `object_id`. I've updated the paths & components where this applies, `order_id`, `product_id`, `promotion_id`, & `category_id`. (there's also some props & imports reorganizing, to follow our "alphabetize everything" approach)

**To test**

- View your store: `/store/:site`
- Watch your network requests for `t.gif`, or turn on debug messages with `localStorage.setItem('debug', 'calypso:analytics:*')`
- Click around different store pages, make sure the analytics calls fire as expected
- Make sure changing parameter names didn't break anything:
  - Click into an order
  - Click into a product
  - Click into a promotion
  - Click into a category
