### PR TITLE
Store: Pass user through to setup flow if on the dashboard

### DIFF
--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -22,6 +22,7 @@ import DocumentHead from 'components/data/document-head';
 import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isLoaded as arePluginsLoaded } from 'state/plugins/installed/selectors';
+import { isStoreSetupComplete } from 'woocommerce/state/sites/setup-choices/selectors';
 import Main from 'components/main';
 import Placeholder from './dashboard/placeholder';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
@@ -99,9 +100,21 @@ class App extends Component {
 	}
 
 	maybeRenderChildren() {
-		const { allRequiredPluginsActive, children, pluginsLoaded, translate } = this.props;
+		const {
+			allRequiredPluginsActive,
+			children,
+			isDashboard,
+			isSetupComplete,
+			pluginsLoaded,
+			translate,
+		} = this.props;
 		if ( ! pluginsLoaded ) {
 			return this.renderPlaceholder();
+		}
+
+		// Pass through to the dashboard when setup isn't completed
+		if ( isDashboard && ! isSetupComplete ) {
+			return children;
 		}
 
 		if ( pluginsLoaded && ! allRequiredPluginsActive ) {
@@ -162,11 +175,14 @@ function mapStateToProps( state ) {
 	const pluginsLoaded = arePluginsLoaded( state, siteId );
 	const allRequiredPluginsActive = areAllRequiredPluginsActive( state, siteId );
 
+	const isSetupComplete = isStoreSetupComplete( state, siteId );
+
 	return {
 		siteId,
 		allRequiredPluginsActive,
 		canUserManageOptions: siteId ? canUserManageOptions : false,
 		isAtomicSite: siteId ? isAtomicSite : false,
+		isSetupComplete,
 		hasPendingAutomatedTransfer: siteId ? hasPendingAutomatedTransfer : false,
 		pluginsLoaded,
 	};


### PR DESCRIPTION
This should fix #24001, but as usual with me trying to create new sites, I seem to be having some trouble. This PR checks if we've finished the setup, and if not, it doesn't bother with the 'Updating…" step, instead it falls straight into the page content. We only do this on the dashboard, so the page content should be the appropriate step in the NUX flow.

I've had a few hiccups where plugins are installed but it's not communicated back well, and the process tries to activate already active plugins, or something happened where the plugin ID wasn't passed through correctly… I think we should add some content to the error page suggesting that reloading the page might clear things up. I've tried to investigate how we might be able to detect this & reload automatically, but I'm not sure it's consistent enough to debug. Does this sound like an acceptable approach?

**To test**

- Create a new site using `/start/store-nux`, so that it directs you into the store flow
- You should walk through the "Building your store" flow, and end up at the checklist step

--------

- Update an existing site to an atomic site by installing WooCommerce
- Go to Store `/store/:site`
- You should get dropped into the NUX flow like above

-----

- Reset an existing AT site using https://developer.wordpress.com/docs/api/console/ to set all values to false
- Load up the dashboard, `/store/:site`
- You should get dropped into the NUX flow like above