### PR TITLE
[Domains] Add match reasons UI for featured domains component

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -24,7 +24,12 @@ import {
 	hasDomainInCart,
 } from 'lib/cart-values/cart-items';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { isNewTld, isTestTld } from 'components/domains/domain-registration-suggestion/utility';
+import {
+	getMatchReasonPhrasesMap,
+	getTld,
+	isNewTld,
+	isTestTld,
+} from 'components/domains/domain-registration-suggestion/utility';
 import ProgressBar from 'components/progress-bar';
 
 const NOTICE_GREEN = '#4ab866';
@@ -38,6 +43,15 @@ class DomainRegistrationSuggestion extends React.Component {
 			domain_name: PropTypes.string.isRequired,
 			product_slug: PropTypes.string,
 			cost: PropTypes.string,
+			matchReasons: PropTypes.arrayOf(
+				PropTypes.oneOf( [
+					'tld-exact',
+					'tld-similar',
+					'exact-match',
+					'similar-match',
+					'tld-common',
+				] )
+			),
 		} ).isRequired,
 		onButtonClick: PropTypes.func.isRequired,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
@@ -218,6 +232,30 @@ class DomainRegistrationSuggestion extends React.Component {
 		}
 	}
 
+	renderMatchReason() {
+		const { suggestion: { domain_name: domain }, isFeatured } = this.props;
+
+		if ( ! isFeatured || ! Array.isArray( this.props.suggestion.matchReasons ) ) {
+			return null;
+		}
+
+		const matchReasonsMap = getMatchReasonPhrasesMap( getTld( domain ) );
+		const matchReasons = this.props.suggestion.matchReasons
+			.filter( matchReason => matchReasonsMap.has( matchReason ) )
+			.map( matchReason => matchReasonsMap.get( matchReason ) );
+
+		return (
+			<div className="domain-registration-suggestion__match-reasons">
+				{ matchReasons.map( ( phrase, index ) => (
+					<div className="domain-registration-suggestion__match-reason" key={ index }>
+						<Gridicon icon="checkmark" size={ 18 } />
+						{ phrase }
+					</div>
+				) ) }
+			</div>
+		);
+	}
+
 	render() {
 		const {
 			domainsWithPlansOnly,
@@ -240,6 +278,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			>
 				{ this.renderDomain() }
 				{ this.renderProgressBar() }
+				{ this.renderMatchReason() }
 			</DomainSuggestion>
 		);
 	}

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -23,10 +23,10 @@ import {
 	getDomainPriceRule,
 	hasDomainInCart,
 } from 'lib/cart-values/cart-items';
+import { getTld } from 'lib/domains';
 import { recordTracksEvent } from 'state/analytics/actions';
 import {
 	getMatchReasonPhrasesMap,
-	getTld,
 	isNewTld,
 	isTestTld,
 } from 'components/domains/domain-registration-suggestion/utility';

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -23,12 +23,12 @@ import {
 	getDomainPriceRule,
 	hasDomainInCart,
 } from 'lib/cart-values/cart-items';
-import { getTld } from 'lib/domains';
 import { recordTracksEvent } from 'state/analytics/actions';
 import {
-	getMatchReasonPhrasesMap,
 	isNewTld,
 	isTestTld,
+	parseMatchReasons,
+	VALID_MATCH_REASONS,
 } from 'components/domains/domain-registration-suggestion/utility';
 import ProgressBar from 'components/progress-bar';
 
@@ -43,15 +43,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			domain_name: PropTypes.string.isRequired,
 			product_slug: PropTypes.string,
 			cost: PropTypes.string,
-			matchReasons: PropTypes.arrayOf(
-				PropTypes.oneOf( [
-					'tld-exact',
-					'tld-similar',
-					'exact-match',
-					'similar-match',
-					'tld-common',
-				] )
-			),
+			match_reasons: PropTypes.arrayOf( PropTypes.oneOf( VALID_MATCH_REASONS ) ),
 		} ).isRequired,
 		onButtonClick: PropTypes.func.isRequired,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
@@ -235,14 +227,11 @@ class DomainRegistrationSuggestion extends React.Component {
 	renderMatchReason() {
 		const { suggestion: { domain_name: domain }, isFeatured } = this.props;
 
-		if ( ! isFeatured || ! Array.isArray( this.props.suggestion.matchReasons ) ) {
+		if ( ! isFeatured || ! Array.isArray( this.props.suggestion.match_reasons ) ) {
 			return null;
 		}
 
-		const matchReasonsMap = getMatchReasonPhrasesMap( getTld( domain ) );
-		const matchReasons = this.props.suggestion.matchReasons
-			.filter( matchReason => matchReasonsMap.has( matchReason ) )
-			.map( matchReason => matchReasonsMap.get( matchReason ) );
+		const matchReasons = parseMatchReasons( domain, this.props.suggestion.match_reasons );
 
 		return (
 			<div className="domain-registration-suggestion__match-reasons">

--- a/client/components/domains/domain-registration-suggestion/style.scss
+++ b/client/components/domains/domain-registration-suggestion/style.scss
@@ -29,7 +29,8 @@
 		margin: 0;
 		order: 1;
 		&.is-with-plans-only:not(.is-free-domain) {
-			flex-basis: auto;
+			flex-basis: 25px;
+			flex-grow: 0;
 			small {
 				font-size: 1em;
 			}

--- a/client/components/domains/domain-registration-suggestion/style.scss
+++ b/client/components/domains/domain-registration-suggestion/style.scss
@@ -2,11 +2,12 @@
 
 .featured-domain-suggestion {
 	flex-direction: column;
-	justify-content: flex-end;
 	width: 100%;
+	margin-top: 0;
 
 	.domain-suggestion__content {
 		flex-direction: column;
+		flex-grow: 2;
 	}
 
 	.domain-registration-suggestion__title,
@@ -19,15 +20,19 @@
 		order: 0;
 		font-size: 2em;
 		font-weight: 600;
+		flex-grow: 2;
 	}
 
 	// .card used to increase specificity
 	&.card .domain-product-price {
 		align-items: left;
-		margin: 0 0 0.5em 0;
+		margin: 0;
 		order: 1;
 		&.is-with-plans-only:not(.is-free-domain) {
 			flex-basis: auto;
+			small {
+				font-size: 1em;
+			}
 		}
 	}
 
@@ -36,9 +41,29 @@
 		display: flex;
 		align-items: center;
 
+		.domain-registration-suggestion__progress-bar-text {
+			text-transform: uppercase;
+		}
+
 		.progress-bar {
 			width: 25%;
 			margin-right: 1em;
+		}
+	}
+
+	.domain-registration-suggestion__match-reasons {
+		order: 3;
+	}
+
+	.domain-registration-suggestion__match-reason {
+		color: $gray-text-min;
+		padding: 0.125em 0;
+		display: flex;
+		align-items: center;
+
+		.gridicon {
+			color: $alert-green;
+			margin-right: 0.25em;
 		}
 	}
 
@@ -52,5 +77,12 @@
 			margin-left: 0;
 			flex-grow: 0;
 		}
+	}
+}
+
+.featured-domain-suggestions--has-match-reasons .featured-domain-suggestion {
+	.domain-registration-suggestion__match-reasons {
+		order: 3;
+		flex-basis: 26px;
 	}
 }

--- a/client/components/domains/domain-registration-suggestion/style.scss
+++ b/client/components/domains/domain-registration-suggestion/style.scss
@@ -8,6 +8,7 @@
 	.domain-suggestion__content {
 		flex-direction: column;
 		flex-grow: 2;
+		margin-top: 0;
 	}
 
 	.domain-registration-suggestion__title,
@@ -20,19 +21,23 @@
 		order: 0;
 		font-size: 2em;
 		font-weight: 600;
-		flex-grow: 2;
+		flex-grow: 0;
 	}
 
 	// .card used to increase specificity
 	&.card .domain-product-price {
 		align-items: left;
 		margin: 0;
+		padding: 0;
 		order: 1;
-		&.is-with-plans-only:not(.is-free-domain) {
-			flex-basis: 25px;
-			flex-grow: 0;
+		flex-grow: 0;
+		flex-basis: auto;
+
+		&.is-with-plans-only,
+		&.is-free-domain {
+			font-size: 0.9em;
 			small {
-				font-size: 1em;
+				font-size: 0.9em;
 			}
 		}
 	}
@@ -41,10 +46,6 @@
 		order: 2;
 		display: flex;
 		align-items: center;
-
-		.domain-registration-suggestion__progress-bar-text {
-			text-transform: uppercase;
-		}
 
 		.progress-bar {
 			width: 25%;

--- a/client/components/domains/domain-registration-suggestion/style.scss
+++ b/client/components/domains/domain-registration-suggestion/style.scss
@@ -76,6 +76,7 @@
 		// Increase specificity
 		&.button.is-primary {
 			width: 100%;
+			align-self: flex-start;
 			margin-left: 0;
 			flex-grow: 0;
 		}

--- a/client/components/domains/domain-registration-suggestion/utility.js
+++ b/client/components/domains/domain-registration-suggestion/utility.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { includes, last } from 'lodash';
+import { includes } from 'lodash';
 
 const newTlds = [
 	'.art',
@@ -53,10 +53,6 @@ const newTlds = [
 ];
 
 const testTlds = [ '.de' ];
-
-export function getTld( domainName = '' ) {
-	return last( domainName.split( '.' ) );
-}
 
 export function getMatchReasonPhrasesMap( tld ) {
 	return new Map( [

--- a/client/components/domains/domain-registration-suggestion/utility.js
+++ b/client/components/domains/domain-registration-suggestion/utility.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { includes } from 'lodash';
+import { includes, last } from 'lodash';
 
 const newTlds = [
 	'.art',
@@ -53,6 +53,20 @@ const newTlds = [
 ];
 
 const testTlds = [ '.de' ];
+
+export function getTld( domainName = '' ) {
+	return last( domainName.split( '.' ) );
+}
+
+export function getMatchReasonPhrasesMap( tld ) {
+	return new Map( [
+		[ 'tld-exact', `Extension ".${ tld }" matches your query` ],
+		[ 'tld-similar', `Extension ".${ tld }" closely matches your query` ],
+		[ 'exact-match', 'Exact match left of the dot' ],
+		[ 'similar-match', 'Close match left of the dot' ],
+		[ 'tld-common', `Most common extension, ".${ tld }"` ],
+	] );
+}
 
 export function isNewTld( tld ) {
 	return includes( newTlds, tld );

--- a/client/components/domains/domain-registration-suggestion/utility.js
+++ b/client/components/domains/domain-registration-suggestion/utility.js
@@ -58,8 +58,8 @@ export function getMatchReasonPhrasesMap( tld ) {
 	return new Map( [
 		[ 'tld-exact', `Extension ".${ tld }" matches your query` ],
 		[ 'tld-similar', `Extension ".${ tld }" closely matches your query` ],
-		[ 'exact-match', 'Exact match left of the dot' ],
-		[ 'similar-match', 'Close match left of the dot' ],
+		[ 'exact-match', 'Query match' ],
+		[ 'similar-match', 'Query match' ],
 		[ 'tld-common', `Most common extension, ".${ tld }"` ],
 	] );
 }

--- a/client/components/domains/domain-registration-suggestion/utility.js
+++ b/client/components/domains/domain-registration-suggestion/utility.js
@@ -5,6 +5,11 @@
  */
 import { includes } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import { getTld } from 'lib/domains';
+
 const newTlds = [
 	'.art',
 	'.bar',
@@ -54,20 +59,46 @@ const newTlds = [
 
 const testTlds = [ '.de' ];
 
-export function getMatchReasonPhrasesMap( tld ) {
-	return new Map( [
-		[ 'tld-exact', `Extension ".${ tld }" matches your query` ],
-		[ 'tld-similar', `Extension ".${ tld }" closely matches your query` ],
-		[ 'exact-match', 'Query match' ],
-		[ 'similar-match', 'Query match' ],
-		[ 'tld-common', `Most common extension, ".${ tld }"` ],
-	] );
-}
-
 export function isNewTld( tld ) {
 	return includes( newTlds, tld );
 }
 
 export function isTestTld( tld ) {
 	return includes( testTlds, tld );
+}
+
+// NOTE: This is actually a sorted list.
+export const VALID_MATCH_REASONS = [
+	'exact-match',
+	'similar-match',
+	'tld-exact',
+	'tld-similar',
+	'tld-common',
+];
+
+function sortMatchReasons( matchReasons ) {
+	return [ ...matchReasons ].sort(
+		( a, b ) => VALID_MATCH_REASONS.indexOf( a ) - VALID_MATCH_REASONS.indexOf( b )
+	);
+}
+
+function getMatchReasonPhrasesMap( tld ) {
+	return new Map( [
+		[ 'tld-exact', `Extension ".${ tld }" matches your query` ],
+		[ 'tld-similar', `Extension ".${ tld }" closely matches your query` ],
+		[ 'exact-match', 'Exact match' ],
+		[ 'similar-match', 'Close match' ],
+		[
+			'tld-common',
+			tld === 'com' ? `Most common extension, ".${ tld }"` : `Common extension, ".${ tld }"`,
+		],
+	] );
+}
+
+export function parseMatchReasons( domain, matchReasons ) {
+	const matchReasonsMap = getMatchReasonPhrasesMap( getTld( domain ) );
+
+	return sortMatchReasons( matchReasons )
+		.filter( matchReason => matchReasonsMap.has( matchReason ) )
+		.map( matchReason => matchReasonsMap.get( matchReason ) );
 }

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
@@ -33,12 +33,23 @@ export class FeaturedDomainSuggestions extends Component {
 		return pick( this.props, childKeys );
 	}
 
+	hasMatchReasons() {
+		const { primarySuggestion, secondarySuggestion } = this.props;
+		return (
+			Array.isArray( primarySuggestion.matchReasons ) ||
+			Array.isArray( secondarySuggestion.matchReasons )
+		);
+	}
+
 	render() {
 		const { primarySuggestion, secondarySuggestion } = this.props;
 		const childProps = this.getChildProps();
+		const className = classNames( 'featured-domain-suggestions', {
+			'featured-domain-suggestions--has-match-reasons': this.hasMatchReasons(),
+		} );
 
 		return (
-			<div className="featured-domain-suggestions">
+			<div className={ className }>
 				{ primarySuggestion && (
 					<DomainRegistrationSuggestion
 						suggestion={ primarySuggestion }

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -33,8 +33,48 @@ export class FeaturedDomainSuggestions extends Component {
 		return pick( this.props, childKeys );
 	}
 
+	getMaxTitleLength() {
+		const { primarySuggestion = {}, secondarySuggestion = {} } = this.props;
+		const { domain_name: primaryDomainName = '' } = primarySuggestion;
+		const { domain_name: secondaryDomainName = '' } = secondarySuggestion;
+		const longestDomainName =
+			primaryDomainName.length >= secondaryDomainName ? primaryDomainName : secondaryDomainName;
+		return longestDomainName.length;
+	}
+
+	getTextSizeClass() {
+		const length = this.getMaxTitleLength();
+		const classNamePrefix = 'featured-domain-suggestions--title-in';
+		if ( length <= 18 ) {
+			return `${ classNamePrefix }-20em`;
+		}
+		if ( length <= 19 ) {
+			return `${ classNamePrefix }-18em`;
+		}
+		if ( length <= 22 ) {
+			return `${ classNamePrefix }-16em`;
+		}
+		if ( length <= 25 ) {
+			return `${ classNamePrefix }-14em`;
+		}
+		if ( length <= 27 ) {
+			return `${ classNamePrefix }-12em`;
+		}
+		if ( length <= 33 ) {
+			return `${ classNamePrefix }-10em`;
+		}
+
+		return 'featured-domain-suggestions--title-cases-overflow';
+	}
+
+	getClassNames() {
+		return classNames( 'featured-domain-suggestions', this.getTextSizeClass(), {
+			'featured-domain-suggestions--has-match-reasons': this.hasMatchReasons(),
+		} );
+	}
+
 	hasMatchReasons() {
-		const { primarySuggestion, secondarySuggestion } = this.props;
+		const { primarySuggestion = {}, secondarySuggestion = {} } = this.props;
 		return (
 			Array.isArray( primarySuggestion.matchReasons ) ||
 			Array.isArray( secondarySuggestion.matchReasons )
@@ -44,12 +84,9 @@ export class FeaturedDomainSuggestions extends Component {
 	render() {
 		const { primarySuggestion, secondarySuggestion } = this.props;
 		const childProps = this.getChildProps();
-		const className = classNames( 'featured-domain-suggestions', {
-			'featured-domain-suggestions--has-match-reasons': this.hasMatchReasons(),
-		} );
 
 		return (
-			<div className={ className }>
+			<div className={ this.getClassNames() }>
 				{ primarySuggestion && (
 					<DomainRegistrationSuggestion
 						suggestion={ primarySuggestion }

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -76,8 +76,8 @@ export class FeaturedDomainSuggestions extends Component {
 	hasMatchReasons() {
 		const { primarySuggestion = {}, secondarySuggestion = {} } = this.props;
 		return (
-			Array.isArray( primarySuggestion.matchReasons ) ||
-			Array.isArray( secondarySuggestion.matchReasons )
+			Array.isArray( primarySuggestion.match_reasons ) ||
+			Array.isArray( secondarySuggestion.match_reasons )
 		);
 	}
 

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -7,3 +7,35 @@
 		flex-flow: wrap;
 	}
 }
+
+@include breakpoint( '>660px' ) {
+	.domain-registration-suggestion__title {
+		.featured-domain-suggestions--title-in-18em & {
+			font-size: 1.8em;
+		}
+		.featured-domain-suggestions--title-in-16em & {
+			font-size: 1.6em;
+		}
+		.featured-domain-suggestions--title-in-14em & {
+			font-size: 1.4em;
+		}
+		.featured-domain-suggestions--title-in-12em & {
+			font-size: 1.2em;
+		}
+		.featured-domain-suggestions--title-in-10em & {
+			font-size: 1em;
+		}
+	}
+
+	.featured-domain-suggestions--title-cases-overflow {
+		flex-wrap: wrap;
+
+		.featured-domain-suggestion {
+			margin-top: 0;
+		}
+	}
+}
+
+.main.domain-search-page-wrapper .featured-domain-suggestions {
+	flex-wrap: wrap;
+}

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -5,6 +5,10 @@
 
 	@include breakpoint( '<660px' ) {
 		flex-flow: wrap;
+
+		.featured-domain-suggestion .domain-suggestion__action.button.is-primary {
+			width: initial;
+		}
 	}
 }
 
@@ -32,6 +36,10 @@
 
 		.featured-domain-suggestion {
 			margin-top: 0;
+		}
+
+		.featured-domain-suggestion .domain-suggestion__action.button.is-primary {
+			width: initial;
 		}
 	}
 }


### PR DESCRIPTION
This change adds match reason information for featured domains recommendations:

<img width="988" alt="wordpress_com" src="https://user-images.githubusercontent.com/4044428/38704269-fcce6ea4-3e62-11e8-93f7-9a0235bcd293.png">

> Note match reasons such as `Exact match` and `Common extension, ".blog"`

### Testing instructions
1. Spin up this branch locally.
2. Navigate to [`/start/domains`](http://calypso.localhost:3000/start/domains).
3. Enter a variety of queries.
    - Ensure that the font size and page layout changes with the length of the recommended domains.
4. Ensure that you can see the featured suggestions above the regular suggestions.
5. Ensure that each featured suggestion has an appropriate match reason.
6. Repeat steps 3~6 with [`/domains/add/`](http://calypso.localhost:3000/domains/add).