### PR TITLE
Rewind - Credentials: disable the button to revoke credentials when it's clicked

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
@@ -19,11 +19,15 @@ import { deleteCredentials } from 'state/jetpack/credentials/actions';
 import { getRewindState } from 'state/selectors';
 
 class CredentialsConfigured extends Component {
-	componentWillMount() {
-		this.setState( { isRevoking: false } );
-	}
+	state = {
+		isRevoking: false,
+		isDeletingCreds: false,
+	};
 
-	handleRevoke = () => this.props.deleteCredentials( this.props.siteId, 'main' );
+	handleRevoke = () =>
+		this.setState( { isDeletingCreds: true }, () =>
+			this.props.deleteCredentials( this.props.siteId, 'main' )
+		);
 
 	toggleRevoking = () => this.setState( { isRevoking: ! this.state.isRevoking } );
 
@@ -45,9 +49,10 @@ class CredentialsConfigured extends Component {
 					<div className="credentials-configured__revoke-actions">
 						<Button
 							className="credentials-configured__revoke-button"
-							borderless={ true }
+							borderless
 							onClick={ this.handleRevoke }
-							scary={ true }
+							scary
+							disabled={ this.state.isDeletingCreds }
 						>
 							<Gridicon
 								className="credentials-configured__revoke-icon"

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-configured/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-configured/style.scss
@@ -35,13 +35,21 @@
 	text-align: right;
 }
 
+.credentials-configured__revoke-icon {
+	color: $alert-red;
+	margin-right: .5rem;
+}
+
 .credentials-configured__revoke-button.is-borderless {
 	margin-right: 2rem;
 	position: relative;
 	top: -5px;
-}
 
-.credentials-configured__revoke-icon {
-	color: $alert-red;
-	margin-right: .5rem;
+	&:hover .credentials-configured__revoke-icon {
+		color: darken( $alert-red, 20% );
+	}
+
+	&:disabled .credentials-configured__revoke-icon {
+		color: lighten( $alert-red, 30% );
+	}
 }


### PR DESCRIPTION
This PR fixes a couple of issues with the Revoke credentials button in the credentials form. Previously the button wasn't disabled after it was clicked, so user could continuously click it, and this generated more credentials deleted events. Additionally, the icon wasn't following the text color on hover.

The button is now disabled after the first click. The icon follows the style of the text.

<img width="349" alt="captura de pantalla 2018-04-09 a la s 17 59 39" src="https://user-images.githubusercontent.com/1041600/38522927-6f7958c8-3c20-11e8-8e4c-683f059071d3.png">

The styles for the icon were updated so its color now follows the text color on hover.

#### Before

<img width="338" alt="captura de pantalla 2018-04-09 a la s 17 50 07" src="https://user-images.githubusercontent.com/1041600/38522936-73525792-3c20-11e8-9cd9-1fbf9e428b1b.png">

#### After

<img width="342" alt="captura de pantalla 2018-04-09 a la s 17 49 47" src="https://user-images.githubusercontent.com/1041600/38522935-72cd8b20-3c20-11e8-9360-cdb4c6135bb0.png">

