### PR TITLE
Post Editor: improve featured image styles

### DIFF
--- a/client/post-editor/editor-featured-image/style.scss
+++ b/client/post-editor/editor-featured-image/style.scss
@@ -22,8 +22,9 @@
 	vertical-align: top;
 	max-width: 100%;
 
-	&.button {
-		padding-bottom: 0;
+	&.button.is-borderless {
+		padding: 0;
+		border-radius: 0;
 	}
 
 	&.button.is-borderless .editor-featured-image__edit-icon {


### PR DESCRIPTION
Removes unwanted padding and border radius on the Featured Image "button". Works in both places where the featured image is displayed: above the content editor, and in the dedicated section in the editor drawer.

Before on the left, after on the right:
<img width="609" alt="featured-image-styles" src="https://user-images.githubusercontent.com/664258/38523202-0b3be5a8-3c4b-11e8-907e-8bd7df9cf5a4.png">
