### PR TITLE
Post Editor: add RemoveButton to EditorLocation component 

### DIFF
--- a/client/post-editor/editor-drawer-well/index.jsx
+++ b/client/post-editor/editor-drawer-well/index.jsx
@@ -7,11 +7,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { noop, identity } from 'lodash';
+import { noop } from 'lodash';
 import Gridicon from 'gridicons';
-import { localize } from 'i18n-calypso';
 
-class EditorDrawerWell extends Component {
+export default class EditorDrawerWell extends Component {
 	static propTypes = {
 		disabled: PropTypes.bool,
 		empty: PropTypes.bool,
@@ -20,14 +19,12 @@ class EditorDrawerWell extends Component {
 		label: PropTypes.node,
 		onClick: PropTypes.func,
 		customDropZone: PropTypes.node,
-		translate: PropTypes.func,
 	};
 
 	static defaultProps = {
 		disabled: false,
 		isHidden: false,
 		onClick: noop,
-		translate: identity,
 	};
 
 	render() {
@@ -56,5 +53,3 @@ class EditorDrawerWell extends Component {
 		);
 	}
 }
-
-export default localize( EditorDrawerWell );

--- a/client/post-editor/editor-location/index.jsx
+++ b/client/post-editor/editor-location/index.jsx
@@ -17,6 +17,7 @@ import EditorDrawerWell from 'post-editor/editor-drawer-well';
 import { recordEvent, recordStat } from 'lib/posts/stats';
 import EditorLocationSearch from './search';
 import Notice from 'components/notice';
+import RemoveButton from 'components/remove-button';
 
 /**
  * Module variables
@@ -143,10 +144,10 @@ class EditorLocation extends React.Component {
 					label={ buttonText }
 					empty={ ! this.props.coordinates }
 					onClick={ this.geolocate }
-					onRemove={ this.clear }
 					disabled={ this.state.locating }
 				>
 					{ this.renderCurrentLocation() }
+					<RemoveButton onRemove={ this.clear } />
 				</EditorDrawerWell>
 				<EditorLocationSearch
 					onError={ this.onGeolocateFailure }


### PR DESCRIPTION
One can add a "location" property to a post, but there is no way to remove the location once it is set. The "Remove" button was accidentally removed in #18064 when moving the button from the `EditorDrawerWell` to a standalone component.

This PR adds it back:
<img width="259" alt="screen shot 2018-04-09 at 23 20 32" src="https://user-images.githubusercontent.com/664258/38523708-ad394f02-3c4c-11e8-861a-ff839f0aae08.png">

The other commit removes the `localize` HoC from `EditorDrawerWell` component, which doesn't need to localize anything.