### PR TITLE
Showcase: Fix div padding in theme switch modal

### DIFF
--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -1,5 +1,4 @@
 .themes__thanks-modal  {
-	width: 300px;
 	min-height: 90px;
 
 	@include breakpoint( "<480px" ) {


### PR DESCRIPTION
 Fixes #23963. There was extra padding in the modal causing the text to be shifted left quite a bit. I removed the limited pixel width and seems to be working now.