### PR TITLE
NPS: Do NOT show when in SU/SSP mode

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -120,8 +120,7 @@ const Layout = createReactClass( {
 				<QuerySites allSites />
 				<QueryPreferences />
 				{ <GuidedTours /> }
-				{ config.isEnabled( 'nps-survey/notice' ) &&
-					! this.props.isSupportUser && <NpsSurveyNotice /> }
+				{ config.isEnabled( 'nps-survey/notice' ) && <NpsSurveyNotice /> }
 				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
 				{ this.renderMasterbar() }
 				{ config.isEnabled( 'support-user' ) && <SupportUser /> }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -120,7 +120,8 @@ const Layout = createReactClass( {
 				<QuerySites allSites />
 				<QueryPreferences />
 				{ <GuidedTours /> }
-				{ config.isEnabled( 'nps-survey/notice' ) && <NpsSurveyNotice /> }
+				{ config.isEnabled( 'nps-survey/notice' ) &&
+					! this.props.isSupportUser && <NpsSurveyNotice /> }
 				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
 				{ this.renderMasterbar() }
 				{ config.isEnabled( 'support-user' ) && <SupportUser /> }

--- a/client/layout/nps-survey-notice/index.jsx
+++ b/client/layout/nps-survey-notice/index.jsx
@@ -6,6 +6,7 @@
 
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -70,22 +71,25 @@ class NpsSurveyNotice extends Component {
 	}
 
 	render() {
+		if ( this.props.isSupportUser || ! this.props.isSectionAndSessionEligible ) {
+			return null;
+		}
+
 		return (
-			this.props.isSectionAndSessionEligible && (
-				<Dialog
-					additionalClassNames="nps-survey-notice"
-					isVisible={ this.props.isNpsSurveyDialogShowing }
-					onClose={ this.handleDialogClose }
-				>
-					<NpsSurvey name={ SURVEY_NAME } onClose={ this.handleSurveyClose } />
-				</Dialog>
-			)
+			<Dialog
+				additionalClassNames="nps-survey-notice"
+				isVisible={ this.props.isNpsSurveyDialogShowing }
+				onClose={ this.handleDialogClose }
+			>
+				<NpsSurvey name={ SURVEY_NAME } onClose={ this.handleSurveyClose } />
+			</Dialog>
 		);
 	}
 }
 
 const mapStateToProps = state => {
 	return {
+		isSupportUser: get( state, 'support.isSupportUser', false ),
 		isNpsSurveyDialogShowing: isNpsSurveyDialogShowing( state ),
 		hasAnswered: hasAnsweredNpsSurvey( state ),
 		hasAnsweredWithNoScore: hasAnsweredNpsSurveyWithNoScore( state ),


### PR DESCRIPTION
The NPS dialog should not be displayed in SU/SSP mode.

## How to test

1. Visit Reader page using SU mode.
2. The survey form should not show even if you run `npsSurvey()` in the browser console.

Related: #23962 
