### PR TITLE
Jetpack Settings Data Layer: Restore Previous Settings on Failure

### DIFF
--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -115,7 +115,7 @@ export const saveJetpackSettings = ( { dispatch, getState }, action ) => {
 			},
 			{
 				...action,
-				meta: { ...action.meta, settings: previousSettings },
+				meta: { ...action.meta, settings: { onboarding: previousSettings } },
 			}
 		)
 	);

--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -16,7 +16,7 @@ import {
 	JETPACK_ONBOARDING_SETTINGS_REQUEST,
 	JETPACK_ONBOARDING_SETTINGS_SAVE,
 } from 'state/action-types';
-import { getSiteUrl, getUnconnectedSiteUrl } from 'state/selectors';
+import { getJetpackOnboardingSettings, getSiteUrl, getUnconnectedSiteUrl } from 'state/selectors';
 import {
 	filterSettingsByActiveModules,
 	normalizeSettings,
@@ -93,8 +93,9 @@ export const announceRequestFailure = ( { dispatch, getState }, { siteId } ) => 
  * @param   {Object} action Redux action
  * @returns {Object} Dispatched http action
  */
-export const saveJetpackSettings = ( { dispatch }, action ) => {
+export const saveJetpackSettings = ( { dispatch, getState }, action ) => {
 	const { settings, siteId } = action;
+	const previousSettings = getJetpackOnboardingSettings( getState(), siteId );
 
 	// We don't want Jetpack Onboarding credentials in our Jetpack Settings Redux state.
 	const settingsWithoutCredentials = omit( settings, [ 'onboarding.jpUser', 'onboarding.token' ] );
@@ -112,7 +113,10 @@ export const saveJetpackSettings = ( { dispatch }, action ) => {
 					json: true,
 				},
 			},
-			action
+			{
+				...action,
+				meta: { ...action.meta, settings: previousSettings },
+			}
 		)
 	);
 };
@@ -127,13 +131,19 @@ export const handleSaveSuccess = (
 	{ data: { code, message, ...updatedSettings } } // eslint-disable-line no-unused-vars
 ) => dispatch( saveJetpackSettingsSuccess( siteId, updatedSettings ) );
 
-export const announceSaveFailure = ( { dispatch }, { siteId } ) =>
+export const announceSaveFailure = (
+	{ dispatch },
+	{ siteId },
+	{ meta: { settings: previousSettings } }
+) => {
+	dispatch( updateJetpackSettings( siteId, previousSettings ) );
 	dispatch(
 		errorNotice( translate( 'An unexpected error occurred. Please try again later.' ), {
 			id: `jpo-notice-error-${ siteId }`,
 			duration: 5000,
 		} )
 	);
+};
 
 export const retryOrAnnounceSaveFailure = ( { dispatch }, action, { message: errorMessage } ) => {
 	const { settings, siteId, type, meta: { dataLayer } } = action;
@@ -147,7 +157,7 @@ export const retryOrAnnounceSaveFailure = ( { dispatch }, action, { message: err
 		! startsWith( errorMessage, 'cURL error 28' ) || // cURL timeout
 		retryCount > MAX_WOOCOMMERCE_INSTALL_RETRIES
 	) {
-		return announceSaveFailure( { dispatch }, { siteId } );
+		return announceSaveFailure( { dispatch }, { siteId }, action );
 	}
 
 	// We cannot use `extendAction( action, ... )` here, since `meta.dataLayer` now includes error information,

--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -131,7 +131,7 @@ export const handleSaveSuccess = (
 	{ data: { code, message, ...updatedSettings } } // eslint-disable-line no-unused-vars
 ) => dispatch( saveJetpackSettingsSuccess( siteId, updatedSettings ) );
 
-export const announceSaveFailure = (
+export const handleSaveFailure = (
 	{ dispatch },
 	{ siteId },
 	{ meta: { settings: previousSettings } }
@@ -157,7 +157,7 @@ export const retryOrAnnounceSaveFailure = ( { dispatch }, action, { message: err
 		! startsWith( errorMessage, 'cURL error 28' ) || // cURL timeout
 		retryCount > MAX_WOOCOMMERCE_INSTALL_RETRIES
 	) {
-		return announceSaveFailure( { dispatch }, { siteId }, action );
+		return handleSaveFailure( { dispatch }, { siteId }, action );
 	}
 
 	// We cannot use `extendAction( action, ... )` here, since `meta.dataLayer` now includes error information,

--- a/client/state/data-layer/wpcom/jetpack/settings/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/test/index.js
@@ -202,6 +202,17 @@ describe( 'saveJetpackSettings()', () => {
 		},
 	};
 
+	const previousSettings = {
+		onboarding: {
+			siteTitle: '',
+			siteDescription: 'Just another WordPress site',
+		},
+	};
+
+	const getState = () => ( {
+		jetpackOnboarding: { settings: { [ 12345678 ]: previousSettings } },
+	} );
+
 	const action = {
 		type: JETPACK_ONBOARDING_SETTINGS_SAVE,
 		siteId,
@@ -209,7 +220,7 @@ describe( 'saveJetpackSettings()', () => {
 	};
 
 	test( 'should dispatch an action for POST HTTP request to save Jetpack settings, omitting JPO credentials', () => {
-		saveJetpackSettings( { dispatch }, action );
+		saveJetpackSettings( { dispatch, getState }, action );
 
 		expect( dispatch ).toHaveBeenCalledWith(
 			http(
@@ -223,7 +234,7 @@ describe( 'saveJetpackSettings()', () => {
 						json: true,
 					},
 				},
-				action
+				{ ...action, meta: { ...action.meta, settings: previousSettings.onboarding } }
 			)
 		);
 		expect( dispatch ).toHaveBeenCalledWith(
@@ -252,9 +263,23 @@ describe( 'handleSaveSuccess()', () => {
 describe( 'announceSaveFailure()', () => {
 	const dispatch = jest.fn();
 	const siteId = 12345678;
+	const action = {
+		type: JETPACK_ONBOARDING_SETTINGS_SAVE,
+		siteId,
+		settings: {
+			siteTitle: 'My Awesome Site',
+			siteDescription: 'Not just another WordPress Site',
+		},
+		meta: {
+			settings: {
+				siteTitle: '',
+				siteDescription: 'Just another WordPress site',
+			},
+		},
+	};
 
 	test( 'should trigger an error notice upon unsuccessful save request', () => {
-		announceSaveFailure( { dispatch }, { siteId } );
+		announceSaveFailure( { dispatch }, { siteId }, action );
 
 		expect( dispatch ).toHaveBeenCalledWith(
 			expect.objectContaining( {

--- a/client/state/data-layer/wpcom/jetpack/settings/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/test/index.js
@@ -234,7 +234,7 @@ describe( 'saveJetpackSettings()', () => {
 						json: true,
 					},
 				},
-				{ ...action, meta: { ...action.meta, settings: previousSettings.onboarding } }
+				{ ...action, meta: { ...action.meta, settings: previousSettings } }
 			)
 		);
 		expect( dispatch ).toHaveBeenCalledWith(

--- a/client/state/data-layer/wpcom/jetpack/settings/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/test/index.js
@@ -10,7 +10,7 @@ import {
 	saveJetpackSettings,
 	handleSaveSuccess,
 	announceRequestFailure,
-	announceSaveFailure,
+	handleSaveFailure,
 	retryOrAnnounceSaveFailure,
 	fromApi,
 } from '../';
@@ -260,7 +260,7 @@ describe( 'handleSaveSuccess()', () => {
 	} );
 } );
 
-describe( 'announceSaveFailure()', () => {
+describe( 'handleSaveFailure()', () => {
 	const dispatch = jest.fn();
 	const siteId = 12345678;
 	const action = {
@@ -279,7 +279,7 @@ describe( 'announceSaveFailure()', () => {
 	};
 
 	test( 'should trigger an error notice upon unsuccessful save request', () => {
-		announceSaveFailure( { dispatch }, { siteId }, action );
+		handleSaveFailure( { dispatch }, { siteId }, action );
 
 		expect( dispatch ).toHaveBeenCalledWith(
 			expect.objectContaining( {
@@ -335,7 +335,7 @@ describe( 'retryOrAnnounceSaveFailure()', () => {
 		);
 	} );
 
-	test( 'should trigger announceSaveFailure upon max number of WooCommerce install timeout', () => {
+	test( 'should trigger handleSaveFailure upon max number of WooCommerce install timeout', () => {
 		const thirdAttemptAction = {
 			...action,
 			meta: {


### PR DESCRIPTION
Needed for #23797. This stuff is needed for Akismet settings -- error handling there relies on JP settings to be reverted upon failure (which makes sense anyway for optimistic updates).

To test: Verify that JPO still works. (As of now, the JP Settings data layer is only used by JPO, so that's the only testing needed.)