### PR TITLE
Analytics: Refactor /extensions/wp-job-manager page view tracking

### DIFF
--- a/client/extensions/wp-job-manager/app/controller.js
+++ b/client/extensions/wp-job-manager/app/controller.js
@@ -10,33 +10,10 @@ import { get } from 'lodash';
 /**
  * Internal Dependencies
  */
-import analytics from 'lib/analytics';
-import titlecase from 'to-title-case';
-import { getSiteFragment, sectionify } from 'lib/route';
 import Settings from '../components/settings';
 import SetupWizard from '../components/setup';
 
 export const renderTab = ( component, tab = '' ) => ( context, next ) => {
-	const siteId = getSiteFragment( context.path );
-	const basePath = sectionify( context.path );
-	let baseAnalyticsPath;
-
-	if ( siteId ) {
-		baseAnalyticsPath = `${ basePath }/:site`;
-	} else {
-		baseAnalyticsPath = basePath;
-	}
-
-	let analyticsPageTitle = 'WP Job Manager';
-
-	if ( tab.length ) {
-		analyticsPageTitle += ` > ${ titlecase( tab ) }`;
-	} else {
-		analyticsPageTitle += ' > Job Listings';
-	}
-
-	analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
-
 	context.primary = <Settings tab={ tab }>{ React.createElement( component ) }</Settings>;
 	next();
 };

--- a/client/extensions/wp-job-manager/components/settings/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/index.jsx
@@ -38,19 +38,6 @@ class Settings extends Component {
 
 	onSubmit = ( form, data ) => this.props.saveSettings( this.props.siteId, form, data );
 
-	trackPageView = () =>
-		!! this.props.tab ? (
-			<PageViewTracker
-				path={ `/extensions/wp-job-manager/${ this.props.tab }/:site` }
-				title={ `WP Job Manager > ${ titlecase( this.props.tab ) }` }
-			/>
-		) : (
-			<PageViewTracker
-				path="/extensions/wp-job-manager/:site"
-				title="WP Job Manager > Job Listings"
-			/>
-		);
-
 	render() {
 		const { children, initialValues, isFetching, siteId, tab, translate } = this.props;
 		const mainClassName = 'wp-job-manager__main';
@@ -63,7 +50,10 @@ class Settings extends Component {
 					siteId={ siteId }
 				/>
 				<SetupRedirect siteId={ siteId } />
-				{ this.trackPageView() }
+				<PageViewTracker
+					path={ `/extensions/wp-job-manager/${ tab ? tab + '/' : '' }:site` }
+					title={ `WP Job Manager > ${ tab ? titlecase( tab ) : 'Job Listings' }` }
+				/>
 				<QuerySettings siteId={ siteId } />
 				<DocumentHead title={ translate( 'WP Job Manager' ) } />
 				<Navigation activeTab={ tab } />

--- a/client/extensions/wp-job-manager/components/settings/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/index.jsx
@@ -23,6 +23,8 @@ import SetupRedirect from '../setup/setup-redirect';
 import { saveSettings } from '../../state/settings/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSettings, isFetchingSettings } from '../../state/settings/selectors';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import titlecase from 'to-title-case';
 
 class Settings extends Component {
 	static propTypes = {
@@ -36,6 +38,19 @@ class Settings extends Component {
 
 	onSubmit = ( form, data ) => this.props.saveSettings( this.props.siteId, form, data );
 
+	trackPageView = () =>
+		!! this.props.tab ? (
+			<PageViewTracker
+				path={ `/extensions/wp-job-manager/${ this.props.tab }/:site` }
+				title={ `WP Job Manager > ${ titlecase( this.props.tab ) }` }
+			/>
+		) : (
+			<PageViewTracker
+				path="/extensions/wp-job-manager/:site"
+				title="WP Job Manager > Job Listings"
+			/>
+		);
+
 	render() {
 		const { children, initialValues, isFetching, siteId, tab, translate } = this.props;
 		const mainClassName = 'wp-job-manager__main';
@@ -48,6 +63,7 @@ class Settings extends Component {
 					siteId={ siteId }
 				/>
 				<SetupRedirect siteId={ siteId } />
+				{ this.trackPageView() }
 				<QuerySettings siteId={ siteId } />
 				<DocumentHead title={ translate( 'WP Job Manager' ) } />
 				<Navigation activeTab={ tab } />

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -22,6 +22,7 @@ import PageSetup from './page-setup';
 import Wizard from 'components/wizard';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { saveSetupStatus } from '../../state/setup/actions';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 class SetupWizard extends Component {
 	static propTypes = {
@@ -72,6 +73,10 @@ class SetupWizard extends Component {
 					minimumVersion={ MinPluginVersion }
 					pluginId="wp-job-manager"
 					siteId={ siteId }
+				/>
+				<PageViewTracker
+					path={ `/extensions/wp-job-manager/setup/:site/${ stepName }` }
+					title="WP Job Manager > Setup"
 				/>
 				<DocumentHead title={ translate( 'Setup' ) } />
 				<Wizard


### PR DESCRIPTION
Replace direct `analytics.pageView.record` calls with `PageViewTracker` in `/extensions/wp-job-manager`.

Check out the updated recommendations on page view tracking:
https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/docs/page-views.md

## Testing instructions

- Install WP Job Manager (`/plugins/wp-job-manager`) and open its settings page (`/extensions/wp-job-manager`).
- Navigate around making sure that page views are recorded for each tab, with the expected path.