### PR TITLE
Analytics: Refactor /extensions/wp-super-cache page view tracking

### DIFF
--- a/client/extensions/wp-super-cache/app/controller.js
+++ b/client/extensions/wp-super-cache/app/controller.js
@@ -10,36 +10,13 @@ import i18n from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import analytics from 'lib/analytics';
-import titlecase from 'to-title-case';
-import { getSiteFragment, sectionify } from 'lib/route';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import WPSuperCache from './main';
 
 export function settings( context, next ) {
-	const siteId = getSiteFragment( context.path );
 	const { tab = '' } = context.params;
 
 	context.store.dispatch( setTitle( i18n.translate( 'WP Super Cache', { textOnly: true } ) ) );
-
-	const basePath = sectionify( context.path );
-	let baseAnalyticsPath;
-
-	if ( siteId ) {
-		baseAnalyticsPath = `${ basePath }/:site`;
-	} else {
-		baseAnalyticsPath = basePath;
-	}
-
-	let analyticsPageTitle = 'WP Super Cache';
-
-	if ( tab.length ) {
-		analyticsPageTitle += ` > ${ titlecase( tab ) }`;
-	} else {
-		analyticsPageTitle += ' > Easy';
-	}
-
-	analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
 
 	context.primary = <WPSuperCache tab={ tab } />;
 	next();

--- a/client/extensions/wp-super-cache/app/main.jsx
+++ b/client/extensions/wp-super-cache/app/main.jsx
@@ -43,16 +43,6 @@ class WPSuperCache extends Component {
 		tab: '',
 	};
 
-	trackPageView = () =>
-		!! this.props.tab ? (
-			<PageViewTracker
-				path={ `/extensions/wp-super-cache/${ this.props.tab }/:site` }
-				title={ `WP Super Cache > ${ titlecase( this.props.tab ) }` }
-			/>
-		) : (
-			<PageViewTracker path="/extensions/wp-super-cache/:site" title="WP Super Cache > Easy" />
-		);
-
 	renderTab( isReadOnly ) {
 		const { tab } = this.props;
 
@@ -104,7 +94,10 @@ class WPSuperCache extends Component {
 					redirectUrl={ redirectUrl }
 				/>
 				<QueryStatus siteId={ siteId } />
-				{ this.trackPageView() }
+				<PageViewTracker
+					path={ `/extensions/wp-super-cache/${ tab ? tab + '/' : '' }:site` }
+					title={ `WP Super Cache > ${ tab ? titlecase( tab ) : 'Easy' }` }
+				/>
 
 				{ cacheDisabled && (
 					<Notice

--- a/client/extensions/wp-super-cache/app/main.jsx
+++ b/client/extensions/wp-super-cache/app/main.jsx
@@ -29,6 +29,8 @@ import { Tabs, WPSC_MIN_VERSION } from './constants';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getStatus } from '../state/status/selectors';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import titlecase from 'to-title-case';
 
 class WPSuperCache extends Component {
 	static propTypes = {
@@ -40,6 +42,16 @@ class WPSuperCache extends Component {
 	static defaultProps = {
 		tab: '',
 	};
+
+	trackPageView = () =>
+		!! this.props.tab ? (
+			<PageViewTracker
+				path={ `/extensions/wp-super-cache/${ this.props.tab }/:site` }
+				title={ `WP Super Cache > ${ titlecase( this.props.tab ) }` }
+			/>
+		) : (
+			<PageViewTracker path="/extensions/wp-super-cache/:site" title="WP Super Cache > Easy" />
+		);
 
 	renderTab( isReadOnly ) {
 		const { tab } = this.props;
@@ -92,6 +104,7 @@ class WPSuperCache extends Component {
 					redirectUrl={ redirectUrl }
 				/>
 				<QueryStatus siteId={ siteId } />
+				{ this.trackPageView() }
 
 				{ cacheDisabled && (
 					<Notice


### PR DESCRIPTION
Replace direct `analytics.pageView.record` calls with `PageViewTracker` in `/extensions/wp-super-cache`.

Check out the updated recommendations on page view tracking:
https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/docs/page-views.md

## Testing instructions

- Install WP Super Cache (`/plugins/wp-super-cache`) and open its settings page (`/extensions/wp-super-cache`).
- Navigate around making sure that page views are recorded for each tab, with the expected path.