### PR TITLE
Analytics: Refactor /extensions/zoninator page view tracking

### DIFF
--- a/client/extensions/zoninator/app/controller.js
+++ b/client/extensions/zoninator/app/controller.js
@@ -9,36 +9,10 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
-import { getSiteFragment, sectionify } from 'lib/route';
 import Settings from '../components/settings';
 
 export const renderTab = component => ( context, next ) => {
-	const siteId = getSiteFragment( context.path );
 	const zoneId = parseInt( context.params.zone, 10 ) || 0;
-
-	let baseAnalyticsPath = sectionify( context.path );
-
-	if ( siteId ) {
-		baseAnalyticsPath += '/:site';
-	}
-
-	if ( zoneId ) {
-		baseAnalyticsPath += '/:zone';
-	}
-
-	let analyticsPageTitle = 'WP Zone Manager';
-
-	if ( zoneId ) {
-		analyticsPageTitle += ' > Edit zone';
-	}
-
-	if ( baseAnalyticsPath.match( /.*\/new\/:site$/ ) ) {
-		analyticsPageTitle += ' > New Zone';
-	}
-
-	analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
-
 	context.primary = <Settings>{ React.createElement( component, { zoneId } ) }</Settings>;
 	next();
 };

--- a/client/extensions/zoninator/components/settings/zone-creator/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone-creator/index.jsx
@@ -18,6 +18,7 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import ZoneDetailsForm from '../../forms/zone-details-form';
 import { addZone } from '../../../state/zones/actions';
 import { settingsPath } from '../../../app/util';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 class ZoneCreator extends PureComponent {
 	static propTypes = {
@@ -34,6 +35,11 @@ class ZoneCreator extends PureComponent {
 
 		return (
 			<div>
+				<PageViewTracker
+					path="/extensions/zoninator/new/:site"
+					title="WP Zone Manager > New Zone"
+				/>
+
 				<HeaderCake backHref={ `${ settingsPath }/${ siteSlug }` }>
 					{ translate( 'Add a zone' ) }
 				</HeaderCake>

--- a/client/extensions/zoninator/components/settings/zone/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone/index.jsx
@@ -29,6 +29,7 @@ import { getFeed, isRequestingFeed } from '../../../state/feeds/selectors';
 import { blocked, expires } from '../../../state/locks/selectors';
 import { getZone, isRequestingZones } from '../../../state/zones/selectors';
 import { settingsPath } from '../../../app/util';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 class Zone extends Component {
 	static propTypes = {
@@ -91,6 +92,11 @@ class Zone extends Component {
 
 		return (
 			<div>
+				<PageViewTracker
+					path="/extensions/zoninator/zone/:site/:zone"
+					title="WP Zone Manager > Edit Zone"
+				/>
+
 				{ showDeleteDialog && (
 					<DeleteZoneDialog
 						zoneName={ zone.name }

--- a/client/extensions/zoninator/components/settings/zones-dashboard/index.jsx
+++ b/client/extensions/zoninator/components/settings/zones-dashboard/index.jsx
@@ -21,11 +21,14 @@ import ZoneItem from './zone-item';
 import ZonePlaceholder from './zone-placeholder';
 import { getZones, isRequestingZones } from '../../../state/zones/selectors';
 import { settingsPath } from '../../../app/util';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 const placeholderCount = 5;
 
 const ZonesDashboard = ( { isRequesting, siteSlug, translate, zones } ) => (
 	<div>
+		<PageViewTracker path="/extensions/zoninator/:site" title="WP Zone Manager" />
+
 		<HeaderCake backHref={ `/plugins/zoninator/${ siteSlug }` }>Zoninator Settings</HeaderCake>
 
 		<SectionHeader label={ translate( 'Zones' ) }>


### PR DESCRIPTION
Replace direct `analytics.pageView.record` calls with `PageViewTracker` in `/extensions/zoninator`.

Check out the updated recommendations on page view tracking:
https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/docs/page-views.md

## Testing instructions

- Install WP Zone Manager (`/plugins/zoninator`) and open its settings page (`/extensions/zoninator`).
- Navigate around, and create and edit zones, making sure that page views are recorded for each page, with the expected path.