### PR TITLE
Fixed: clear-fix mixin may cause unnecessary scrollbar to appear in macOS

### DIFF
--- a/assets/stylesheets/shared/mixins/_clear-fix.scss
+++ b/assets/stylesheets/shared/mixins/_clear-fix.scss
@@ -10,5 +10,6 @@
 		width: 0;
 		clear: both;
 		visibility: hidden;
+		overflow: hidden;
 	}
 }


### PR DESCRIPTION
The NPS dialog always shows the scrollbar when you set system `Show Scroll Bars` option to `Always` on macOS:
<img width="668" alt="before" src="https://user-images.githubusercontent.com/212034/38558482-42cc85d4-3d0b-11e8-8a6e-9db059a7033d.png">

Since the non-zero height of the `clear-fix` mixin may cause the problem, this PR fix it by ensuring the mixin to collapse.

## How to test

1. Set the system's `Show Scroll Bars` option to `Always` on macOS following [this instruction](https://discussions.apple.com/thread/4322675).
2. Visit Readers page and run `npsSurvey()` in the browser console. The dialog has no scrollbars as follows:
<img width="668" alt="after" src="https://user-images.githubusercontent.com/212034/38558829-5de7f5e6-3d0c-11e8-95d5-d17f0f51424e.png">
