### PR TITLE
Analytics: Refactor People page view tracking

### DIFF
--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -11,8 +11,6 @@ import i18n from 'i18n-calypso';
  */
 import PeopleList from './main';
 import EditTeamMember from './edit-team-member-form';
-import analytics from 'lib/analytics';
-import titlecase from 'to-title-case';
 import PeopleLogStore from 'lib/people/log-store';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import InvitePeople from './invite-people';
@@ -77,7 +75,6 @@ function renderPeopleList( context, next ) {
 		filter: filter,
 		search: context.query.s,
 	} );
-	analytics.pageView.record( 'people/' + filter + '/:site', 'People > ' + titlecase( filter ) );
 	next();
 }
 

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -159,7 +159,7 @@ export class EditTeamMemberForm extends Component {
 	render() {
 		return (
 			<Main className="edit-team-member-form">
-				<PageViewTracker path="people/edit/:user_login/:site" title="View Team Member" />
+				<PageViewTracker path="people/edit/:site/:user" title="People > View Team Member" />
 				<HeaderCake onClick={ this.goBack } isCompact />
 				{ this.renderNotices() }
 				<Card className="edit-team-member-form__user-profile">

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -44,6 +44,7 @@ import { isJetpackSite } from 'state/sites/selectors';
 import { activateModule } from 'state/jetpack/modules/actions';
 import { isActivatingJetpackModule, isJetpackModuleActive } from 'state/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 /**
  * Module variables
@@ -424,6 +425,7 @@ class InvitePeople extends React.Component {
 		if ( site && ! userCan( 'promote_users', site ) ) {
 			return (
 				<Main>
+					<PageViewTracker path="/people/new/:site" title="People > Invite People" />
 					<SidebarNavigation />
 					<EmptyContent
 						title={ translate( 'Oops, only administrators can invite other people' ) }
@@ -435,6 +437,7 @@ class InvitePeople extends React.Component {
 
 		return (
 			<Main className="invite-people">
+				<PageViewTracker path="/people/new/:site" title="People > Invite People" />
 				<SidebarNavigation />
 				<HeaderCake isCompact onClick={ this.goBack }>
 					{ translate( 'Invite People' ) }

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -26,6 +26,8 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { canCurrentUser, isPrivateSite } from 'state/selectors';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import titlecase from 'to-title-case';
 
 /**
  * Module variables
@@ -82,6 +84,10 @@ export const People = createReactClass( {
 		if ( isJetpack && ! jetpackPeopleSupported ) {
 			return (
 				<Main>
+					<PageViewTracker
+						path={ `/people/${ filter }/:site` }
+						title={ `Peole > ${ titlecase( filter ) }` }
+					/>
 					<SidebarNavigation />
 					<JetpackManageErrorPage template="updateJetpack" siteId={ siteId } version="3.7" />
 				</Main>
@@ -90,6 +96,10 @@ export const People = createReactClass( {
 		if ( siteId && ! canViewPeople ) {
 			return (
 				<Main>
+					<PageViewTracker
+						path={ `/people/${ filter }/:site` }
+						title={ `Peole > ${ titlecase( filter ) }` }
+					/>
 					<SidebarNavigation />
 					<EmptyContent
 						title={ this.props.translate( 'You are not authorized to view this page' ) }
@@ -100,6 +110,10 @@ export const People = createReactClass( {
 		}
 		return (
 			<Main>
+				<PageViewTracker
+					path={ `/people/${ filter }/:site` }
+					title={ `Peole > ${ titlecase( filter ) }` }
+				/>
 				<SidebarNavigation />
 				<div>
 					{

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -86,7 +86,7 @@ export const People = createReactClass( {
 				<Main>
 					<PageViewTracker
 						path={ `/people/${ filter }/:site` }
-						title={ `Peole > ${ titlecase( filter ) }` }
+						title={ `People > ${ titlecase( filter ) }` }
 					/>
 					<SidebarNavigation />
 					<JetpackManageErrorPage template="updateJetpack" siteId={ siteId } version="3.7" />
@@ -98,7 +98,7 @@ export const People = createReactClass( {
 				<Main>
 					<PageViewTracker
 						path={ `/people/${ filter }/:site` }
-						title={ `Peole > ${ titlecase( filter ) }` }
+						title={ `People > ${ titlecase( filter ) }` }
 					/>
 					<SidebarNavigation />
 					<EmptyContent
@@ -112,7 +112,7 @@ export const People = createReactClass( {
 			<Main>
 				<PageViewTracker
 					path={ `/people/${ filter }/:site` }
-					title={ `Peole > ${ titlecase( filter ) }` }
+					title={ `People > ${ titlecase( filter ) }` }
 				/>
 				<SidebarNavigation />
 				<div>

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -31,6 +31,7 @@ import {
 } from 'state/invites/selectors';
 import { deleteInvite } from 'state/invites/actions';
 import { canCurrentUser } from 'state/selectors';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 export class PeopleInviteDetails extends React.PureComponent {
 	static propTypes = {
@@ -174,6 +175,7 @@ export class PeopleInviteDetails extends React.PureComponent {
 		if ( siteId && ! canViewPeople ) {
 			return (
 				<Main>
+					<PageViewTracker path="/people/invites/:site/:invite" title="People > Invite Details" />
 					<SidebarNavigation />
 					<EmptyContent
 						title={ this.props.translate( 'You are not authorized to view this page' ) }
@@ -185,6 +187,7 @@ export class PeopleInviteDetails extends React.PureComponent {
 
 		return (
 			<Main className="people-invite-details">
+				<PageViewTracker path="/people/invites/:site/:invite" title="People > Invite Details" />
 				{ siteId && <QuerySiteInvites siteId={ siteId } /> }
 				<SidebarNavigation />
 

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -35,6 +35,7 @@ import {
 	isDeletingAnyInvite,
 } from 'state/invites/selectors';
 import { deleteInvites } from 'state/invites/actions';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 class PeopleInvites extends React.PureComponent {
 	static propTypes = {
@@ -72,6 +73,7 @@ class PeopleInvites extends React.PureComponent {
 		if ( siteId && ! canViewPeople ) {
 			return (
 				<Main>
+					<PageViewTracker path="/people/invites/:site" title="People > Invites" />
 					<SidebarNavigation />
 					<EmptyContent
 						title={ this.props.translate( 'You are not authorized to view this page' ) }
@@ -83,6 +85,7 @@ class PeopleInvites extends React.PureComponent {
 
 		return (
 			<Main className="people-invites">
+				<PageViewTracker path="/people/invites/:site" title="People > Invites" />
 				{ siteId && <QuerySiteInvites siteId={ siteId } /> }
 				<SidebarNavigation />
 				<PeopleSectionNav


### PR DESCRIPTION
Replace direct `analytics.pageView.record` calls with `PageViewTracker` in `/people`.

Check out the updated recommendations on page view tracking:
https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/docs/page-views.md

## Testing instructions

- Open `/people` and navigate around making sure that page views are recorded for each page, with the expected path.