### PR TITLE
Simple Payments: removes forced Upgrade Nudge

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -441,10 +441,6 @@ class SimplePaymentsDialog extends Component {
 		);
 	}
 
-	returnTrue() {
-		return true;
-	}
-
 	render() {
 		const {
 			showDialog,
@@ -502,7 +498,6 @@ class SimplePaymentsDialog extends Component {
 							) }
 							feature={ FEATURE_SIMPLE_PAYMENTS }
 							event="editor_simple_payments_modal_nudge"
-							shouldDisplay={ this.returnTrue }
 						/>
 					}
 					secondaryAction={


### PR DESCRIPTION
Part of #20250 
Extracted from #23190 
Depends on #24039

This PR changes the behaviour of the _Simple Payments_ dialog on the _Editor_ for users that can't manage sites by removing the forced upgrade nudge. This depends on #24039 to hide the nudge.

To test this you'll need two users, one with full admin rights, and one Editor. Both on a Free sites. 

| Before | After |
| - | - |
| ![Add Payment Button](https://user-images.githubusercontent.com/233601/37222104-c1667be0-23aa-11e8-9abc-ae56af077f86.png) | ![Add Payment Button](https://user-images.githubusercontent.com/233601/37220803-78d2e188-23a6-11e8-869e-8600199ae8af.png) |
