### PR TITLE
Add Pie Chart Legend Component

### DIFF
--- a/client/components/pie-chart/README.md
+++ b/client/components/pie-chart/README.md
@@ -57,11 +57,13 @@ export default class Example extends Component {
 		const total = data.reduce( ( result, datum ) => result + datum.value, 0 );
 
 		return (
-			<PieChart
-				data={ data }
-				title={ translate( '%(total)s Total Searches', { args: { total } } ) }
-			/>
-			<PieChartLegend data={ data } />
+			<div>
+				<PieChart
+					data={ data }
+					title={ translate( '%(total)s Total Searches', { args: { total } } ) }
+				/>
+				<PieChartLegend data={ data } />
+			</div>
 		);
 	}
 }

--- a/client/components/pie-chart/README.md
+++ b/client/components/pie-chart/README.md
@@ -9,7 +9,6 @@ This component renders a dataset as a pie chart.
 	* **name** - (required) (String) Name to represent the datum
 	* **description** - (optional) (String) A longer description of the datum 
 * **title** — (optional) (String) Title for the chart
-* **legendBelowChart** - (optional) (Boolean) Choose between drawing the legend below or to the right of the chart. Defaults to drawing the legend below the chart, or `true`
 
 ## Usage
 

--- a/client/components/pie-chart/README.md
+++ b/client/components/pie-chart/README.md
@@ -9,6 +9,7 @@ This component renders a dataset as a pie chart.
 	* **name** - (required) (String) Name to represent the datum
 	* **description** - (optional) (String) A longer description of the datum 
 * **title** — (optional) (String) Title for the chart
+* **legendBelowChart** - (optional) (Boolean) Choose between drawing the legend below or to the right of the chart. Defaults to drawing the legend below the chart, or `true`
 
 ## Usage
 

--- a/client/components/pie-chart/README.md
+++ b/client/components/pie-chart/README.md
@@ -1,6 +1,6 @@
 # Pie Chart
 
-This component renders a dataset as a pie chart.
+This component renders a dataset as a pie chart. A separate `PieChartLegend` sub-component will render an accompanying legend.
 
 ## Props 
 

--- a/client/components/pie-chart/README.md
+++ b/client/components/pie-chart/README.md
@@ -24,6 +24,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import PieChart from 'components/pie-chart';
+import PieChartLegend from 'components/pie-chart/legend';
 
 export default class Example extends Component {
 	render() {
@@ -61,6 +62,7 @@ export default class Example extends Component {
 				data={ data }
 				title={ translate( '%(total)s Total Searches', { args: { total } } ) }
 			/>
+			<PieChartLegend data={ data } />
 		);
 	}
 }

--- a/client/components/pie-chart/data/index.js
+++ b/client/components/pie-chart/data/index.js
@@ -1,0 +1,27 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { isEqual, sortBy } from 'lodash';
+
+const NUM_COLOR_SECTIONS = 3;
+
+const assignSectionFunc = ( datum, index ) => {
+	return {
+		...datum,
+		sectionNum: index % NUM_COLOR_SECTIONS,
+	};
+};
+
+const sortDataAndAssignSections = data => {
+	return sortBy( data, datum => datum.value )
+		.reverse()
+		.map( assignSectionFunc );
+};
+
+const isDataEqual = ( currentData, newData ) => {
+	return isEqual( currentData, newData );
+};
+
+export { sortDataAndAssignSections, isDataEqual };

--- a/client/components/pie-chart/data/type.js
+++ b/client/components/pie-chart/data/type.js
@@ -1,0 +1,12 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+export default PropTypes.shape( {
+	description: PropTypes.string,
+	name: PropTypes.string.isRequired,
+	value: PropTypes.number.isRequired,
+} );

--- a/client/components/pie-chart/docs/example.js
+++ b/client/components/pie-chart/docs/example.js
@@ -26,12 +26,14 @@ class PieChartExample extends Component {
 			{
 				value: 362,
 				name: 'Discovery',
-				description: 'Customers who find your listing searching for a category, product, or service',
+				description:
+					'Customers who find your listing searching for a category, product, or service',
 			},
 			{
 				value: 122,
 				name: 'Referral',
-				description: 'Customers who find your listing by being referred from another type of search',
+				description:
+					'Customers who find your listing by being referred from another type of search',
 			},
 		];
 
@@ -46,7 +48,7 @@ class PieChartExample extends Component {
 	render() {
 		return (
 			<Card>
-				<PieChart data={ this.state.data } title={ this.state.title } />
+				<PieChart data={ this.state.data } title={ this.state.title } legendBelowChart={ false } />
 			</Card>
 		);
 	}

--- a/client/components/pie-chart/docs/example.js
+++ b/client/components/pie-chart/docs/example.js
@@ -10,6 +10,7 @@ import React, { Component } from 'react';
  */
 import Card from 'components/card';
 import PieChart from 'components/pie-chart';
+import PieChartLegend from 'components/pie-chart/legend';
 
 class PieChartExample extends Component {
 	static displayName = 'PieChart';
@@ -48,7 +49,8 @@ class PieChartExample extends Component {
 	render() {
 		return (
 			<Card>
-				<PieChart data={ this.state.data } title={ this.state.title } legendBelowChart={ false } />
+				<PieChart data={ this.state.data } title={ this.state.title } />
+				<PieChartLegend data={ this.state.data } />
 			</Card>
 		);
 	}

--- a/client/components/pie-chart/index.js
+++ b/client/components/pie-chart/index.js
@@ -26,6 +26,11 @@ class PieChart extends Component {
 			} )
 		).isRequired,
 		title: PropTypes.string,
+		legendBelowChart: PropTypes.boolean,
+	};
+
+	static defaultProps = {
+		legendBelowChart: true,
 	};
 
 	constructor( props ) {
@@ -65,12 +70,14 @@ class PieChart extends Component {
 	}
 
 	render() {
-		const { title } = this.props;
+		const { title, legendBelowChart } = this.props;
 		const { data, dataTotal } = this.state;
 
 		return (
-			<div>
-				<div className={ 'pie-chart__chart' }>
+			<div
+				className={ legendBelowChart ? 'pie-chart__chart' : 'pie-chart__chart-horizontal-layout' }
+			>
+				<div>
 					<svg
 						className={ 'pie-chart__chart-drawing' }
 						viewBox={ `0 0 ${ SVG_SIZE } ${ SVG_SIZE }` }
@@ -88,10 +95,8 @@ class PieChart extends Component {
 							} ) }
 						</g>
 					</svg>
+					{ title && <h2 className={ 'pie-chart__title' }>{ title }</h2> }
 				</div>
-
-				{ title && <h2 className={ 'pie-chart__title' }>{ title }</h2> }
-
 				<div className={ 'pie-chart__legend' }>
 					{ data.map( ( datum, index ) => {
 						return (

--- a/client/components/pie-chart/index.js
+++ b/client/components/pie-chart/index.js
@@ -6,31 +6,19 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { pie as d3Pie, arc as d3Arc } from 'd3-shape';
-import { isEqual, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import LegendItem from './legend-item';
+import DataType from './data/type';
+import { sortDataAndAssignSections, isDataEqual } from './data';
 
-const NUM_COLOR_SECTIONS = 3;
 const SVG_SIZE = 300;
 
 class PieChart extends Component {
 	static propTypes = {
-		data: PropTypes.arrayOf(
-			PropTypes.shape( {
-				description: PropTypes.string,
-				name: PropTypes.string.isRequired,
-				value: PropTypes.number.isRequired,
-			} )
-		).isRequired,
+		data: PropTypes.arrayOf( DataType ).isRequired,
 		title: PropTypes.string,
-		legendBelowChart: PropTypes.boolean,
-	};
-
-	static defaultProps = {
-		legendBelowChart: true,
 	};
 
 	constructor( props ) {
@@ -40,13 +28,13 @@ class PieChart extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if ( ! isEqual( this.props.data, nextProps.data ) ) {
+		if ( ! isDataEqual( this.props.data, nextProps.data ) ) {
 			this.setState( this.processData( nextProps.data ) );
 		}
 	}
 
 	processData( data ) {
-		const sortedData = sortBy( data, datum => datum.value ).reverse();
+		const sortedData = sortDataAndAssignSections( data );
 
 		const arcs = d3Pie()
 			.startAngle( Math.PI )
@@ -62,55 +50,35 @@ class PieChart extends Component {
 		return {
 			data: sortedData.map( ( datum, index ) => ( {
 				...datum,
-				sectionNum: index % NUM_COLOR_SECTIONS,
 				path: paths[ index ],
 			} ) ),
-			dataTotal: sortedData.reduce( ( result, datum ) => result + datum.value, 0 ),
 		};
 	}
 
 	render() {
-		const { title, legendBelowChart } = this.props;
-		const { data, dataTotal } = this.state;
+		const { title } = this.props;
+		const { data } = this.state;
 
 		return (
-			<div
-				className={ legendBelowChart ? 'pie-chart__chart' : 'pie-chart__chart-horizontal-layout' }
-			>
-				<div>
-					<svg
-						className={ 'pie-chart__chart-drawing' }
-						viewBox={ `0 0 ${ SVG_SIZE } ${ SVG_SIZE }` }
-						preserveAspectRatio={ 'xMidYMid meet' }
-					>
-						<g transform={ `translate(${ SVG_SIZE / 2 }, ${ SVG_SIZE / 2 })` }>
-							{ data.map( ( datum, index ) => {
-								return (
-									<path
-										className={ `pie-chart__chart-section-${ datum.sectionNum }` }
-										key={ index.toString() }
-										d={ datum.path }
-									/>
-								);
-							} ) }
-						</g>
-					</svg>
-					{ title && <h2 className={ 'pie-chart__title' }>{ title }</h2> }
-				</div>
-				<div className={ 'pie-chart__legend' }>
-					{ data.map( ( datum, index ) => {
-						return (
-							<LegendItem
-								key={ index.toString() }
-								name={ datum.name }
-								value={ datum.value }
-								sectionNumber={ datum.sectionNum }
-								percent={ Math.round( datum.value / dataTotal * 100 ).toString() }
-								description={ datum.description }
-							/>
-						);
-					} ) }
-				</div>
+			<div className={ 'pie-chart' }>
+				<svg
+					className={ 'pie-chart__chart-drawing' }
+					viewBox={ `0 0 ${ SVG_SIZE } ${ SVG_SIZE }` }
+					preserveAspectRatio={ 'xMidYMid meet' }
+				>
+					<g transform={ `translate(${ SVG_SIZE / 2 }, ${ SVG_SIZE / 2 })` }>
+						{ data.map( ( datum, index ) => {
+							return (
+								<path
+									className={ `pie-chart__chart-section-${ datum.sectionNum }` }
+									key={ index.toString() }
+									d={ datum.path }
+								/>
+							);
+						} ) }
+					</g>
+				</svg>
+				{ title && <h2 className={ 'pie-chart__title' }>{ title }</h2> }
 			</div>
 		);
 	}

--- a/client/components/pie-chart/legend.js
+++ b/client/components/pie-chart/legend.js
@@ -1,0 +1,63 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import DataType from './data/type';
+import LegendItem from './legend-item';
+import { sortDataAndAssignSections, isDataEqual } from './data';
+
+class PieChartLegend extends Component {
+	static propTypes = {
+		data: PropTypes.arrayOf( DataType ).isRequired,
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.state = this.processData( props.data );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( ! isDataEqual( this.props.data, nextProps.data ) ) {
+			this.setState( this.processData( nextProps.data ) );
+		}
+	}
+
+	processData( data ) {
+		const sortedData = sortDataAndAssignSections( data );
+
+		return {
+			data: sortedData,
+			dataTotal: sortedData.reduce( ( total, datum ) => total + datum.value, 0 ),
+		};
+	}
+
+	render() {
+		const { data, dataTotal } = this.state;
+		return (
+			<div className={ 'pie-chart__legend' }>
+				{ data.map( ( datum, index ) => {
+					return (
+						<LegendItem
+							key={ index.toString() }
+							name={ datum.name }
+							value={ datum.value }
+							sectionNumber={ datum.sectionNum }
+							percent={ Math.round( datum.value / dataTotal * 100 ).toString() }
+							description={ datum.description }
+						/>
+					);
+				} ) }
+			</div>
+		);
+	}
+}
+
+export default PieChartLegend;

--- a/client/components/pie-chart/style.scss
+++ b/client/components/pie-chart/style.scss
@@ -4,6 +4,19 @@
 	align-items: center;
 }
 
+.pie-chart__chart-horizontal-layout {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: space-between;
+
+	.pie-chart__chart-drawing {
+		padding-right: 30px;
+		min-width: 200px;
+		min-height: 200px;
+	}
+}
+
 .pie-chart__chart-drawing {
 	max-width: 400px;
 	max-height: 400px;

--- a/client/components/pie-chart/style.scss
+++ b/client/components/pie-chart/style.scss
@@ -1,20 +1,7 @@
-.pie-chart__chart {
+.pie-chart {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-}
-
-.pie-chart__chart-horizontal-layout {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	justify-content: space-between;
-
-	.pie-chart__chart-drawing {
-		padding-right: 30px;
-		min-width: 200px;
-		min-height: 200px;
-	}
 }
 
 .pie-chart__chart-drawing {


### PR DESCRIPTION
## Specs

Refactor the PieChart component's legend so that is is added separately and can be placed wherever is best suited in relation to the chart without the PieChart component needing specific logic for it.

## Testing

1. Navigate to https://calypso.live/devdocs/design/pie-chart?branch=add/pie-chart-legend 
2. Also navigate to https://wpcalypso.wordpress.com/devdocs/design/pie-chart
3. Verify the pie chart and legend on both pages look identical.