### PR TITLE
Signup: show a 30 day money back guarantee on the Plans step

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -49,6 +49,7 @@
 @import 'blocks/plan-storage/style';
 @import 'blocks/login/style';
 @import 'blocks/payment-methods/style';
+@import 'blocks/plan-footer/style';
 @import 'blocks/plan-thank-you-card/style';
 @import 'blocks/post-edit-button/style';
 @import 'blocks/post-item/style';

--- a/client/blocks/plan-footer/index.jsx
+++ b/client/blocks/plan-footer/index.jsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { abtest } from 'lib/abtest';
+import Gridicon from 'gridicons';
+import PaymentMethods from 'blocks/payment-methods';
+
+class PlanFooter extends Component {
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			showMoneyBackGuarantee: abtest( 'showMoneyBackGuarantee' ) === 'yes',
+		};
+	}
+
+	render() {
+		if ( ! this.props.isInSignup || ! this.state.showMoneyBackGuarantee ) {
+			return (
+				<PaymentMethods />
+			);
+		}
+		return (
+			<div className="plan-footer">
+				<div className="plan-footer__guarantee">
+					<Gridicon icon="checkmark-circle" />
+					{ translate( '30 day money back guarantee*', {
+						comment: '* is for a footnote to follow',
+					} ) }
+				</div>
+				<PaymentMethods />
+				<div className="plan-footer__fineprint">
+					{ translate( '* Domains purchased with a plan are only refundable for 48 hours.', {
+						comment: '* is a leading footnote indicator',
+					} ) }
+				</div>
+			</div>
+		);
+	}
+}
+PlanFooter.propTypes = {
+	isInSignup: PropTypes.bool,
+};
+
+PlanFooter.defaultProps = {
+	isInSignup: false,
+};
+
+export default PlanFooter;

--- a/client/blocks/plan-footer/style.scss
+++ b/client/blocks/plan-footer/style.scss
@@ -1,0 +1,30 @@
+.plan-footer {
+	margin: 10px 10px 20px;
+	display: block;
+	text-align: center;
+	/*display: flex;
+		width: 100%;
+		justify-content: center;
+		align-items: center;
+		flex-wrap: wrap;
+		flex-direction: column;
+		*/
+
+	small {
+		font-style: italic;
+	}
+
+	.gridicons-checkmark-circle {
+		color: $alert-green;
+		vertical-align: bottom;
+		margin-right: 6px;
+	}
+}
+.plan-footer__guarantee {
+	margin-bottom: 30px;
+}
+.plan-footer__fineprint {
+	font-size: 11px;
+	font-style: italic;
+	line-height: 1.1;
+}

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -102,4 +102,12 @@ export default {
 		defaultVariation: 'group_0',
 		allowExistingUsers: true,
 	},
+	showMoneyBackGuarantee: {
+		datestamp: '20180409',
+		variations: {
+			no: 1,
+			yes: 1,
+		},
+		defaultVariation: 'no',
+	},
 };

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -34,7 +34,7 @@ import { purchasesRoot } from 'me/purchases/paths';
 import { plansLink, findPlansKeys, getPlan } from 'lib/plans';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
-import PaymentMethods from 'blocks/payment-methods';
+import PlanFooter from 'blocks/plan-footer';
 import HappychatButton from 'components/happychat/button';
 import HappychatConnection from 'components/happychat/connection-connected';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
@@ -394,7 +394,7 @@ export class PlansFeaturesMain extends Component {
 				<QueryPlans />
 				<QuerySitePlans siteId={ get( site, 'ID' ) } />
 				{ this.getPlanFeatures() }
-				<PaymentMethods />
+				<PlanFooter isInSignup={ isInSignup } />
 				{ faqs }
 				<div className="plans-features-main__bottom" />
 			</div>


### PR DESCRIPTION
Adds a new AB test to evaluate the performance of calling out our 30 day money back guarantee on the plans step during signup.

AB test name: `showMoneyBackGuarantee`
Allocations: `50/50`

e2e test PR forthcoming

## To Test

Run `localStorage.setItem( 'ABTests', '{"showMoneyBackGuarantee_20180409":"yes"}' );` in your console before entering signup.

## In Test

<img width="1118" alt="screen shot 2018-04-10 at 10 38 53" src="https://user-images.githubusercontent.com/195089/38573652-5ffab666-3cbc-11e8-8e11-c5fc75b4d27f.png">
<img width="320" alt="screen shot 2018-04-10 at 10 39 42" src="https://user-images.githubusercontent.com/195089/38573653-6020cbc6-3cbc-11e8-8a49-fb7b79ed3582.png">

## Default

<img width="1121" alt="screen shot 2018-04-10 at 12 52 23" src="https://user-images.githubusercontent.com/195089/38574342-3958177c-3cbe-11e8-826a-b898333916d5.png">
<img width="323" alt="screen shot 2018-04-10 at 12 52 43" src="https://user-images.githubusercontent.com/195089/38574343-39793d9e-3cbe-11e8-90bb-8271bd447b6f.png">

