### PR TITLE
Cart: Use export * to re-export named exports

### DIFF
--- a/client/lib/upgrades/actions/index.js
+++ b/client/lib/upgrades/actions/index.js
@@ -2,63 +2,9 @@
 /**
  * Internal dependencies
  */
-// @TODO update when no longer compiling to CommonJS
-// export * from './cart';
-// export * from './checkout';
-// etc…
-export {
-	addDomainToCart,
-	addGoogleAppsRegistrationData,
-	addItem,
-	addItems,
-	addPrivacyToAllDomains,
-	applyCoupon,
-	closeCartPopup,
-	disableCart,
-	openCartPopup,
-	removeDomainFromCart,
-	removeItem,
-	removePrivacyFromAllDomains,
-	showCartOnMobile,
-} from './cart';
-
-export {
-	resetTransaction,
-	setDomainDetails,
-	setNewCreditCardDetails,
-	setPayment,
-	submitTransaction,
-} from './checkout';
-
-export {
-	acceptTransfer,
-	addDns,
-	addEmailForwarding,
-	applyDnsTemplate,
-	cancelTransferRequest,
-	closeSiteRedirectNotice,
-	declineTransfer,
-	deleteDns,
-	deleteEmailForwarding,
-	enablePrivacyProtection,
-	fetchDns,
-	fetchDomains,
-	fetchEmailForwarding,
-	fetchNameservers,
-	fetchSiteRedirect,
-	fetchWapiDomainInfo,
-	fetchWhois,
-	requestTransferCode,
-	resendIcannVerification,
-	resendVerificationEmailForwarding,
-	setPrimaryDomain,
-	updateNameservers,
-	updateSiteRedirect,
-	updateWhois,
-} from './domain-management';
-
-export { goToDomainCheckout } from './domain-search';
-
-export { startFreeTrial } from './free-trials';
-
-export { cancelAndRefundPurchase, cancelPurchase, submitSurvey } from './purchases';
+export * from './cart';
+export * from './checkout';
+export * from './domain-management';
+export * from './domain-search';
+export * from './free-trials';
+export * from './purchases';


### PR DESCRIPTION
Give using `export * from aPlace` a shot to cut down on all the noise.

Works in webpack. Babel / tests get angry.