### PR TITLE
Me: Hide new app password button when new password was created

### DIFF
--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -192,18 +192,20 @@ class ApplicationPasswords extends Component {
 				<QueryApplicationPasswords />
 
 				<SectionHeader label={ translate( 'Application Passwords' ) }>
-					<Button
-						compact
-						onClick={ this.getClickHandler(
-							'Create Application Password Button',
-							this.toggleNewPassword
-						) }
-					>
-						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
-						<Gridicon icon="plus-small" size={ 16 } />
-						{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
-						{ translate( 'Add New Application Password' ) }
-					</Button>
+					{ ! newAppPassword && (
+						<Button
+							compact
+							onClick={ this.getClickHandler(
+								'Create Application Password Button',
+								this.toggleNewPassword
+							) }
+						>
+							{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
+							<Gridicon icon="plus-small" size={ 16 } />
+							{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
+							{ translate( 'Add New Application Password' ) }
+						</Button>
+					) }
 				</SectionHeader>
 				<Card>
 					{ newAppPassword ? this.renderNewAppPassword() : this.renderNewAppPasswordForm() }


### PR DESCRIPTION
As @sirreal reported in https://github.com/Automattic/wp-calypso/pull/23926#pullrequestreview-110524864 the "Add New Application Password" button doesn't work right after a new password has been created. Seems like this bug has been there like... forever. 

This PR suggests that we hide the button in that case. When the user clicks "Done", the button is revealed again.

Related: #22912

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/me/security/two-step
* Verify the button "Add New Application Password" can be seen and works well.
* Create a new app password.
* Verify the "Add New Application Password" button is not displayed after the pass is created.
* Click the "Done" button.
* Verify the  "Add New Application Password" button is visible and working again.