### PR TITLE
Payments: Add receipt id to the route after a successful redirect checkout.

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -53,7 +53,13 @@ class CheckoutPending extends PureComponent {
 			const { processingStatus } = transaction;
 
 			if ( ORDER_TRANSACTION_STATUS.SUCCESS === processingStatus ) {
-				page( `/checkout/thank-you/${ siteSlug }/${ transaction.receiptId }` );
+				const { receiptId } = transaction;
+
+				page(
+					receiptId
+						? `/checkout/thank-you/${ siteSlug }/${ receiptId }`
+						: `/checkout/thank-you/${ siteSlug }`
+				);
 
 				return;
 			}

--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -53,7 +53,7 @@ class CheckoutPending extends PureComponent {
 			const { processingStatus } = transaction;
 
 			if ( ORDER_TRANSACTION_STATUS.SUCCESS === processingStatus ) {
-				page( `/checkout/thank-you/${ siteSlug }` );
+				page( `/checkout/thank-you/${ siteSlug }/${ transaction.receiptId }` );
 
 				return;
 			}

--- a/client/state/data-layer/wpcom/me/transactions/order/from-api.js
+++ b/client/state/data-layer/wpcom/me/transactions/order/from-api.js
@@ -22,9 +22,10 @@ export const convertProcessingStatus = responseStatus => {
 	}
 };
 
-export const transform = ( { order_id, user_id, processing_status } ) => ( {
+export const transform = ( { order_id, user_id, receipt_id, processing_status } ) => ( {
 	orderId: order_id,
 	userId: user_id,
+	receiptId: receipt_id,
 	processingStatus: convertProcessingStatus( processing_status ),
 } );
 

--- a/client/state/data-layer/wpcom/me/transactions/order/schema.json
+++ b/client/state/data-layer/wpcom/me/transactions/order/schema.json
@@ -1,6 +1,6 @@
 {
 	"type": "object",
-	"required": [ "order_id", "user_id", "receipt_id", "processing_status" ],
+	"required": [ "order_id", "user_id", "processing_status" ],
 	"properties": {
 		"order_id": { "type": "integer" },
 		"user_id": { "type": "integer" },

--- a/client/state/data-layer/wpcom/me/transactions/order/schema.json
+++ b/client/state/data-layer/wpcom/me/transactions/order/schema.json
@@ -1,9 +1,10 @@
 {
 	"type": "object",
-	"required": [ "order_id", "user_id", "processing_status" ],
+	"required": [ "order_id", "user_id", "receipt_id", "processing_status" ],
 	"properties": {
 		"order_id": { "type": "integer" },
 		"user_id": { "type": "integer" },
+		"receipt_id": { "type": "integer" },
 		"processing_status": { "type": "string" }
 	}
 }

--- a/client/state/data-layer/wpcom/me/transactions/order/test/from-api.js
+++ b/client/state/data-layer/wpcom/me/transactions/order/test/from-api.js
@@ -13,12 +13,14 @@ describe( 'wpcom-api', () => {
 			const response = {
 				user_id: 123,
 				order_id: 456,
+				receipt_id: 123456,
 				processing_status: 'success',
 			};
 
 			const expectedOutput = {
 				userId: response.user_id,
 				orderId: response.order_id,
+				receiptId: response.receipt_id,
 				processingStatus: ORDER_TRANSACTION_STATUS.SUCCESS,
 			};
 

--- a/client/state/data-layer/wpcom/me/transactions/order/test/from-api.js
+++ b/client/state/data-layer/wpcom/me/transactions/order/test/from-api.js
@@ -27,6 +27,22 @@ describe( 'wpcom-api', () => {
 			expect( fromApi( response ) ).toEqual( expectedOutput );
 		} );
 
+		test( 'should still validate since receipt id is optional.', () => {
+			const response = {
+				user_id: 123,
+				order_id: 456,
+				processing_status: 'success',
+			};
+
+			const expectedOutput = {
+				userId: response.user_id,
+				orderId: response.order_id,
+				processingStatus: ORDER_TRANSACTION_STATUS.SUCCESS,
+			};
+
+			expect( fromApi( response ) ).toEqual( expectedOutput );
+		} );
+
 		test( 'should invalidate when the required field is missing.', () => {
 			const invalidateCall = () => {
 				const invalidResponse = {


### PR DESCRIPTION
## Summary
This PR addresses the lack of receipt id issue found by @yoavf , stated in https://github.com/Automattic/wp-calypso/pull/23715#issuecomment-380009595. Together with code-D11661, the newly-added receipt id will be dispatched along with the `ORDER_TRANSACTION_SET` action, and then the pending checkout page can redirect with it correctly.

## Test Plan

### Unit test
Run `npm run test-client "transactions/order"`

### Integration test

1. Use a test account to make a plan purchase via source payments.
1. Approve the payment.
1. While you are in the pending page, confirm the purchase via the webhook.
1. After a few seconds, you should be redirected to `/checkout/thank-you/:site_url/:receipt_id`.