### PR TITLE
Fix the typo: Gaelige => Gaeilge

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -86,7 +86,7 @@
         { "value": 474, "langSlug": "fr-ch", "name": "Français de Suisse", "wpLocale": "", "territories": [ "155" ] },
         { "value": 25, "langSlug": "fur", "name": "Friulian", "wpLocale": "fur", "territories": [ "039" ] },
         { "value": 26, "langSlug": "fy", "name": "Frysk", "wpLocale": "fy", "territories": [ "155" ] },
-        { "value": 27, "langSlug": "ga", "name": "Gaelige", "wpLocale": "ga", "territories": [ "154" ] },
+        { "value": 27, "langSlug": "ga", "name": "Gaeilge", "wpLocale": "ga", "territories": [ "154" ] },
         { "value": 476, "langSlug": "gd", "name": "Gàidhlig", "wpLocale": "gd", "territories": [ "154" ] },
         { "value": 457, "langSlug": "gl", "name": "Galego", "wpLocale": "gl_ES", "territories": [ "039" ] },
         { "value": 430, "langSlug": "gn", "name": "Avañe'ẽ", "wpLocale": "gn", "territories": [ "019" ] },


### PR DESCRIPTION
## Summary
This PR fixes the typo for the Irish language, Gaeilge. With this fix, it looks like this:
![image](https://user-images.githubusercontent.com/1842898/38596688-81936a42-3d85-11e8-875c-57f6bb3fdc45.png)
