### PR TITLE
Domains: Remove the Kraken domain suggestion test v3.1.3

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -29,7 +29,6 @@ import { getTld } from 'lib/domains';
 import { domainAvailability } from 'lib/domains/constants';
 import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { DESIGN_TYPE_STORE } from 'signup/constants';
-import { abtest } from 'lib/abtest';
 
 class DomainSearchResults extends React.Component {
 	static propTypes = {
@@ -73,32 +72,10 @@ class DomainSearchResults extends React.Component {
 		const { MAPPABLE, MAPPED, TLD_NOT_SUPPORTED, TRANSFERRABLE, UNKNOWN } = domainAvailability;
 
 		const domain = get( availableDomain, 'domain_name', lastDomainSearched );
-		const testGroup = abtest( 'domainSuggestionKrakenV313' );
-		const showExactMatch = 'group_0' === testGroup;
 
 		let availabilityElement, domainSuggestionElement, offer;
 
-		if ( availableDomain && showExactMatch ) {
-			// should use real notice component or custom class
-			availabilityElement = (
-				<Notice status="is-success" showDismiss={ false }>
-					{ translate( '%(domain)s is available!', { args: { domain } } ) }
-				</Notice>
-			);
-
-			domainSuggestionElement = (
-				<DomainRegistrationSuggestion
-					suggestion={ availableDomain }
-					key={ availableDomain.domain_name }
-					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-					buttonContent={ this.props.buttonContent }
-					selectedSite={ this.props.selectedSite }
-					cart={ this.props.cart }
-					isSignupStep={ this.props.isSignupStep }
-					onButtonClick={ this.props.onClickResult }
-				/>
-			);
-		} else if (
+		if (
 			suggestions.length !== 0 &&
 			includes(
 				[ TRANSFERRABLE, MAPPABLE, MAPPED, TLD_NOT_SUPPORTED, UNKNOWN ],

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -53,7 +53,6 @@ import {
 	getDomainsSuggestionsError,
 } from 'state/domains/suggestions/selectors';
 
-import { abtest } from 'lib/abtest';
 import {
 	getStrippedDomainBase,
 	getTldWeightOverrides,
@@ -78,7 +77,7 @@ const domains = wpcom.domains();
 const SUGGESTION_QUANTITY = 10;
 const INITIAL_SUGGESTION_QUANTITY = 2;
 
-let searchVendor = 'domainsbot';
+let searchVendor = 'group_1';
 const fetchAlgo = searchVendor + '/v1';
 
 let searchQueue = [];
@@ -729,9 +728,9 @@ class RegisterDomainStep extends React.Component {
 		} );
 
 		const timestamp = Date.now();
-		const testGroup = abtest( 'domainSuggestionKrakenV313' );
-		if ( includes( [ 'group_1', 'group_2', 'group_3', 'group_4', 'group_5' ], testGroup ) ) {
-			searchVendor = testGroup;
+
+		if ( this.props.isSignupStep ) {
+			searchVendor = 'group_2';
 		}
 
 		const domainSuggestions = Promise.all( [
@@ -837,13 +836,7 @@ class RegisterDomainStep extends React.Component {
 		const onAddMapping = domain => this.props.onAddMapping( domain, this.state );
 
 		const searchResults = this.state.searchResults || [];
-		const testGroup = abtest( 'domainSuggestionKrakenV313' );
-		let suggestions = includes(
-			[ 'group_1', 'group_2', 'group_3', 'group_4', 'group_5' ],
-			testGroup
-		)
-			? [ ...searchResults ]
-			: reject( searchResults, matchesSearchedDomain );
+		let suggestions = [ ...searchResults ];
 
 		if ( this.props.includeWordPressDotCom || this.props.includeDotBlogSubdomain ) {
 			if ( this.state.loadingSubdomainResults && ! this.state.loadingResults ) {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -89,17 +89,4 @@ export default {
 		defaultVariation: 'original',
 		allowExistingUsers: true,
 	},
-	domainSuggestionKrakenV313: {
-		datestamp: '20180329',
-		variations: {
-			group_0: 1, // Default group
-			group_1: 1000,
-			group_2: 1000,
-			group_3: 1000,
-			group_4: 1000,
-			group_5: 1000,
-		},
-		defaultVariation: 'group_0',
-		allowExistingUsers: true,
-	},
 };


### PR DESCRIPTION
We've decided ( see p8kIbR-fq-p2 ) to go with `group_1` for Calypso and `group_2` for NUX. I've also removed the exact match card we had for all non-EN users so now the suggestions are unified across all users.

Test:

1. Go to an existing site /domains/add page and check that we're sending `group_1` as `vendor` in the suggestion endpoint call
2. Go to `/start` and check that the domain suggestion vendor used is `group_2`.

Also check that the same happens if you use different locale.