### PR TITLE
Jetpack Connect: Fix auto authorize in cases when sites are loading

### DIFF
--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -219,11 +219,12 @@ export class JetpackConnectMain extends Component {
 		this.props.recordTracksEvent( 'calypso_jpc_url_submit', {
 			jetpack_url: this.state.currentUrl,
 		} );
+		// Track that connection was started by button-click, so we can auto-approve at auth step.
+		persistSession( this.state.currentUrl );
+
 		if ( this.props.isRequestingSites ) {
 			this.setState( { waitingForSites: true } );
 		} else {
-			// Track that connection was started by button-click, so we can auto-approve at auth step.
-			persistSession( this.state.currentUrl );
 			this.checkUrl( this.state.currentUrl );
 		}
 	};


### PR DESCRIPTION
Addendum to #23940, which missed a case that should auto-authorize: when _Continue_ button is clicked while sites data is still loading.

This change persists the URL in that case, so that user will not need to click _Approve_ button later in the connection process.

## Testing

* Sandbox public-api.wordpress.com to slow down sites loading
* Go to https://calypso.live/?branch=fix/jetpack-connect-auto-auth
* Enter URL of a jurassic.ninja site
EXPECTED: You should not need to click an _Approve_ button to connect the site

Also check that supplying a site via the URL _does_ still require approval:
* Create a jn site
* go to URL: https://calypso.live/?branch=fix/jetpack-connect-auto-auth&url={jnsite}
EXPECTED: You should need to click an _Approve_ button to complete the connection

