### PR TITLE
Add subscription length picker

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -78,6 +78,7 @@
 @import 'blocks/reader-visit-link/style';
 @import 'blocks/sharing-preview-pane/style';
 @import 'blocks/simple-site-rename-form/style';
+@import 'blocks/subscription-length-picker/style';
 @import 'blocks/taxonomy-manager/style';
 @import 'blocks/term-form-dialog/style';
 @import 'blocks/term-tree-selector/style';

--- a/client/blocks/subscription-length-picker/docs/example.jsx
+++ b/client/blocks/subscription-length-picker/docs/example.jsx
@@ -1,0 +1,49 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { getPlan } from 'lib/plans';
+import { PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS } from 'lib/plans/constants';
+import { SubscriptionLengthPicker } from 'blocks/subscription-length-picker';
+import PropTypes from 'prop-types';
+
+const productsWithPrices = [
+	{
+		planSlug: PLAN_BUSINESS,
+		plan: getPlan( PLAN_BUSINESS ),
+		// These prices should not be hardcoded in real code, this is just to
+		// show how things will look like in devdocs
+		priceFull: 200,
+		priceMonthly: 200 / 24,
+	},
+	{
+		planSlug: PLAN_BUSINESS_2_YEARS,
+		plan: getPlan( PLAN_BUSINESS_2_YEARS ),
+		// These prices should not be hardcoded in real code, this is just to
+		// show how things will look like in devdocs
+		priceFull: 380,
+		priceMonthly: 380 / 48,
+	},
+];
+
+const SubscriptionLengthPickerExample = () => (
+	<div>
+		<SubscriptionLengthPicker
+			currencyCode="USD"
+			productsWithPrices={ productsWithPrices }
+			initialValue={ PLAN_BUSINESS_2_YEARS }
+			translate={ x => x }
+		/>
+	</div>
+);
+
+SubscriptionLengthPickerExample.displayName = 'SubscriptionLengthPicker';
+
+export default SubscriptionLengthPickerExample;

--- a/client/blocks/subscription-length-picker/index.jsx
+++ b/client/blocks/subscription-length-picker/index.jsx
@@ -1,0 +1,116 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal Dependencies
+ */
+import { localize } from 'i18n-calypso';
+import formatCurrency from 'lib/format-currency';
+import { CURRENCIES } from 'lib/format-currency/currencies';
+import { computeProductsWithPrices } from 'state/products-list/selectors';
+import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { PLANS_LIST } from 'lib/plans/constants';
+import QueryPlans from 'components/data/query-plans';
+import QueryProductsList from 'components/data/query-products-list';
+import SubscriptionLengthOption from './option';
+
+export class SubscriptionLengthPicker extends React.Component {
+	static propTypes = {
+		initialValue: PropTypes.string,
+		plans: PropTypes.arrayOf( PropTypes.oneOf( Object.keys( PLANS_LIST ) ) ),
+
+		currencyCode: PropTypes.oneOf( Object.keys( CURRENCIES ) ).isRequired,
+		onChange: PropTypes.func,
+		translate: PropTypes.func.isRequired,
+
+		// Comes from connect():
+		productsWithPrices: PropTypes.array.isRequired,
+	};
+
+	static defaultProps = {
+		onChange: () => null,
+	};
+
+	state = {
+		checked: this.props.initialValue,
+	};
+
+	render() {
+		const { productsWithPrices, translate } = this.props;
+		return (
+			<div className="subscription-length-picker">
+				{ ! productsWithPrices && (
+					<React.Fragment>
+						<QueryPlans />
+						<QueryProductsList />
+					</React.Fragment>
+				) }
+
+				<div className="subscription-length-picker__header">
+					{ translate( 'Choose the length of your subscription', {
+						comment:
+							'We offer a way to change billing term from default bill every 1 year to something ' +
+							'else like bill once every 2 years - this is related header.',
+					} ) }
+				</div>
+
+				<div className="subscription-length-picker__options">
+					{ productsWithPrices.map( ( { plan, planSlug, priceFull, priceMonthly } ) => (
+						<div className="subscription-length-picker__option-container" key={ planSlug }>
+							<SubscriptionLengthOption
+								term={ plan.term }
+								checked={ planSlug === this.state.checked }
+								price={ myFormatCurrency( priceFull, this.props.currencyCode ) }
+								pricePerMonth={ myFormatCurrency( priceMonthly, this.props.currencyCode ) }
+								savePercent={ Math.round(
+									100 * ( 1 - priceMonthly / this.getHighestMonthlyPrice() )
+								) }
+								value={ planSlug }
+								onCheck={ this.handleCheck }
+							/>
+						</div>
+					) ) }
+				</div>
+			</div>
+		);
+	}
+
+	getHighestMonthlyPrice() {
+		return Math.max(
+			...this.props.productsWithPrices.map( ( { priceMonthly } ) => Number( priceMonthly ) )
+		);
+	}
+
+	handleCheck = ( { value } ) => {
+		this.setState( {
+			checked: value,
+		} );
+		this.props.onChange( { value } );
+	};
+}
+
+export function myFormatCurrency( price, code ) {
+	const precision = CURRENCIES[ code ].precision;
+	const EPSILON = Math.pow( 10, -precision ) - 0.000000001;
+
+	const hasCents = Math.abs( price % 1 ) >= EPSILON;
+	return formatCurrency( price, code, hasCents ? {} : { precision: 0 } );
+}
+
+export const mapStateToProps = ( state, { plans } ) => {
+	const selectedSiteId = getSelectedSiteId( state );
+
+	return {
+		currencyCode: getCurrentUserCurrencyCode( state ),
+		productsWithPrices: computeProductsWithPrices( state, selectedSiteId, plans ),
+	};
+};
+
+export default connect( mapStateToProps )( localize( SubscriptionLengthPicker ) );

--- a/client/blocks/subscription-length-picker/option.jsx
+++ b/client/blocks/subscription-length-picker/option.jsx
@@ -61,7 +61,7 @@ export class SubscriptionLengthOption extends React.Component {
 					<div className="subscription-length-picker__option-header">
 						<div className="subscription-length-picker__option-term">{ this.getTermText() }</div>
 						<div className="subscription-length-picker__option-discount">
-							{ savePercent && (
+							{ savePercent ? (
 								<Badge type={ checked ? 'success' : 'warning' }>
 									{ translate( 'Save %(percent)s%%', {
 										args: {
@@ -69,6 +69,8 @@ export class SubscriptionLengthOption extends React.Component {
 										},
 									} ) }
 								</Badge>
+							) : (
+								false
 							) }
 						</div>
 					</div>

--- a/client/blocks/subscription-length-picker/style.scss
+++ b/client/blocks/subscription-length-picker/style.scss
@@ -1,3 +1,29 @@
+.subscription-length-picker {
+  &__header {
+    margin-bottom: 10px;
+    flex-basis: 100%;
+    font-size: 16px;
+  }
+
+  &__options {
+    display: flex;
+    align-items: flex-start;
+    flex-flow: row wrap;
+    justify-content: space-between;
+  }
+
+  &__option-container {
+    flex-basis: calc(50% - 10px);
+
+    @include breakpoint('<960px') {
+      flex-basis: calc(100%);
+      &:not(:first-child) {
+        margin-top: 20px;
+      }
+    }
+  }
+}
+
 .subscription-length-picker__option {
   $padding-size: 18px;
 

--- a/client/blocks/subscription-length-picker/test/index.js
+++ b/client/blocks/subscription-length-picker/test/index.js
@@ -1,0 +1,137 @@
+/** @format */
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+const translate = x => x;
+jest.mock( '../option', () => 'SubscriptionLengthOption' );
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import { getPlan } from 'lib/plans';
+import { PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS } from 'lib/plans/constants';
+
+/**
+ * Internal dependencies
+ */
+import { SubscriptionLengthPicker, myFormatCurrency } from '../index';
+
+describe( 'SubscriptionLengthPicker basic tests', () => {
+	const productsWithPrices = [
+		{
+			planSlug: PLAN_BUSINESS,
+			plan: getPlan( PLAN_BUSINESS ),
+			priceFull: 1200,
+			priceMonthly: 100,
+		},
+		{
+			planSlug: PLAN_BUSINESS_2_YEARS,
+			plan: getPlan( PLAN_BUSINESS_2_YEARS ),
+			priceFull: 1800,
+			priceMonthly: 150,
+		},
+	];
+
+	test( 'should have subscription-length-picker class', () => {
+		const picker = shallow(
+			<SubscriptionLengthPicker
+				productsWithPrices={ [] }
+				currencyCode={ 'USD' }
+				translate={ translate }
+			/>
+		);
+		expect( picker.find( '.subscription-length-picker' ).length ).toBe( 1 );
+	} );
+
+	test( 'should contain as many <SubscriptionLengthOption/> as products passed', () => {
+		const picker = shallow(
+			<SubscriptionLengthPicker
+				productsWithPrices={ productsWithPrices }
+				currencyCode={ 'USD' }
+				translate={ translate }
+			/>
+		);
+		expect( picker.find( 'SubscriptionLengthOption' ).length ).toBe( 2 );
+	} );
+
+	test( 'should mark appropriate SubscriptionLengthOption as checked', () => {
+		const picker = shallow(
+			<SubscriptionLengthPicker
+				productsWithPrices={ productsWithPrices }
+				initialValue={ PLAN_BUSINESS_2_YEARS }
+				currencyCode={ 'USD' }
+				translate={ translate }
+			/>
+		);
+
+		const first = picker.find( 'SubscriptionLengthOption' ).first();
+		expect( first.props().value ).toEqual( PLAN_BUSINESS );
+		expect( first.props().checked ).toEqual( false );
+
+		const last = picker.find( 'SubscriptionLengthOption' ).last();
+		expect( last.props().value ).toEqual( PLAN_BUSINESS_2_YEARS );
+		expect( last.props().checked ).toEqual( true );
+	} );
+} );
+
+describe( 'myFormatCurrency', () => {
+	describe( 'USD - precision 2', () => {
+		const code = 'USD';
+		const symbol = '$';
+		const results = amount => myFormatCurrency( amount, code ).replace( symbol, '' );
+
+		test( 'Should return correctly formatted amount for no cents', () => {
+			expect( results( 1 ) ).toBe( '1' );
+			expect( results( 9 ) ).toBe( '9' );
+			expect( results( 12 ) ).toBe( '12' );
+		} );
+		test( 'Should return correctly formatted amount with cents', () => {
+			expect( results( 0.01 ) ).toBe( '0.01' );
+			expect( results( 0.02 ) ).toBe( '0.02' );
+			expect( results( 0.03 ) ).toBe( '0.03' );
+			expect( results( 1.11 ) ).toBe( '1.11' );
+		} );
+		test( 'Should return correctly formatted amount with fractions lower than cents', () => {
+			expect( results( 0.001 ) ).toBe( '0' );
+			expect( results( 0.002 ) ).toBe( '0' );
+			expect( results( 0.003 ) ).toBe( '0' );
+			expect( results( 0.009 ) ).toBe( '0' );
+			expect( results( 1.0099999 ) ).toBe( '1' );
+			expect( results( 1.0000000000001 ) ).toBe( '1' );
+			expect( results( 1.00010000000001 ) ).toBe( '1' );
+		} );
+	} );
+	describe( 'BHD - precision 3', () => {
+		const code = 'BHD';
+		const symbol = 'د.ب.‏';
+		const results = amount => myFormatCurrency( amount, code ).replace( symbol, '' );
+
+		test( 'Should return correctly formatted amount for no cents', () => {
+			expect( results( 1 ) ).toBe( '1' );
+			expect( results( 9 ) ).toBe( '9' );
+			expect( results( 12 ) ).toBe( '12' );
+		} );
+		test( 'Should return correctly formatted amount with cents', () => {
+			expect( results( 0.01 ) ).toBe( '0.010' );
+			expect( results( 0.02 ) ).toBe( '0.020' );
+			expect( results( 0.03 ) ).toBe( '0.030' );
+			expect( results( 1.11 ) ).toBe( '1.110' );
+
+			expect( results( 0.001 ) ).toBe( '0.001' );
+			expect( results( 0.002 ) ).toBe( '0.002' );
+			expect( results( 0.003 ) ).toBe( '0.003' );
+			expect( results( 1.111 ) ).toBe( '1.111' );
+		} );
+		test( 'Should return correctly formatted amount with fractions lower than cents', () => {
+			expect( results( 0.0001 ) ).toBe( '0' );
+			expect( results( 0.0002 ) ).toBe( '0' );
+			expect( results( 0.0003 ) ).toBe( '0' );
+			expect( results( 0.0009 ) ).toBe( '0' );
+			expect( results( 1.00099999 ) ).toBe( '1' );
+		} );
+	} );
+} );

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -60,6 +60,7 @@ import DismissibleCard from 'blocks/dismissible-card/docs/example';
 import PostEditButton from 'blocks/post-edit-button/docs/example';
 import PostComment from 'blocks/comments/docs/post-comment-example';
 import ReaderAvatar from 'blocks/reader-avatar/docs/example';
+import SubscriptionLengthPicker from 'blocks/subscription-length-picker/docs/example';
 import ImageEditor from 'blocks/image-editor/docs/example';
 import VideoEditor from 'blocks/video-editor/docs/example';
 import ReaderPostCard from 'blocks/reader-post-card/docs/example';
@@ -177,6 +178,7 @@ export default class AppComponents extends React.Component {
 					<ReaderImportButton readmeFilePath="reader-import-button" />
 					<SharingPreviewPane />
 					<SimplePaymentsDialog />
+					<SubscriptionLengthPicker />
 					<ReaderShare readmeFilePath="reader-share" />
 					<ReaderEmailSettings readmeFilePath="reader-email-settings" />
 					<UploadImage readmeFilePath="upload-image" />


### PR DESCRIPTION
This PR is related to 2 year plans (p9jf6J-eR-p2). It adds a `<SubscriptionLengthPicker />` component that allows you to choose a plan duration (1 year or 2 year).

Test plan:
* Run unit tests
* Go to /devdocs/blocks/subscription-length-picker and confirm it looks like this:

<img width="1357" alt="zrzut ekranu 2018-04-11 o 13 46 51" src="https://user-images.githubusercontent.com/205419/38614827-d4cd4116-3d8e-11e8-8f30-f51cd0ef8dca.png">

