### PR TITLE
Update/pass subscription length to payment boxes

### DIFF
--- a/client/blocks/subscription-length-picker/index.jsx
+++ b/client/blocks/subscription-length-picker/index.jsx
@@ -46,7 +46,7 @@ export class SubscriptionLengthPicker extends React.Component {
 		const { productsWithPrices, translate } = this.props;
 		return (
 			<div className="subscription-length-picker">
-				{ ! productsWithPrices && (
+				{ ! productsWithPrices.length && (
 					<React.Fragment>
 						<QueryPlans />
 						<QueryProductsList />

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -734,6 +734,7 @@ export const PLANS_LIST = {
 		term: TERM_ANNUALLY,
 		getTitle: () => i18n.translate( 'Professional' ),
 		getAudience: () => i18n.translate( 'Best for organizations' ),
+		getStoreSlug: () => PLAN_JETPACK_BUSINESS,
 		getProductId: () => 2001,
 		availableFor: plan =>
 			includes(
@@ -797,6 +798,7 @@ export const PLANS_LIST = {
 		getAudience: () => i18n.translate( 'Best for organizations' ),
 		getSubtitle: () => i18n.translate( 'Ultimate security and traffic tools.' ),
 		getProductId: () => 2004,
+		getStoreSlug: () => PLAN_JETPACK_BUSINESS_MONTHLY,
 		getPathSlug: () => 'professional-monthly',
 		availableFor: plan =>
 			includes(

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -530,11 +530,7 @@ class Checkout extends React.Component {
 	}
 
 	handleTermChange = ( { value: planSlug } ) => {
-		// Remove all cart items that are plans
-		const selectedPlans = this.props.cart.products.filter( ( { product_slug } ) =>
-			getPlan( product_slug )
-		);
-		selectedPlans.forEach( removeItem );
+		this.getPlanProducts().forEach( removeItem );
 
 		const cartItem = getCartItemForPlan( planSlug );
 		analytics.tracks.recordEvent( 'calypso_signup_plan_select', {

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -487,12 +487,12 @@ class Checkout extends React.Component {
 				redirectTo={ this.getCheckoutCompleteRedirectPath }
 				handleCheckoutCompleteRedirect={ this.handleCheckoutCompleteRedirect }
 			>
-				{ config.isEnabled( 'upgrades/2-year-plans' ) && this.renderTermPicker() }
+				{ config.isEnabled( 'upgrades/2-year-plans' ) && this.renderSubscriptionLengthPicker() }
 			</SecurePaymentForm>
 		);
 	}
 
-	renderTermPicker() {
+	renderSubscriptionLengthPicker() {
 		const planInCart = this.getPlanProducts()[ 0 ];
 		if ( ! planInCart ) {
 			return false;
@@ -518,7 +518,7 @@ class Checkout extends React.Component {
 					onChange={ this.handleTermChange }
 					key="picker"
 				/>
-				<hr className="checkout__term-picker-separator" key="separator" />
+				<hr className="checkout__subscription-length-picker-separator" key="separator" />
 			</React.Fragment>
 		);
 	}

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -15,6 +15,7 @@ import React from 'react';
 import { abtest, getABTestVariation } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import { cartItems } from 'lib/cart-values';
+import config from 'config';
 import { clearSitePlans } from 'state/sites/plans/actions';
 import { clearPurchases } from 'state/purchases/actions';
 import DomainDetailsForm from './domain-details-form';
@@ -28,6 +29,7 @@ import { getExitCheckoutUrl } from 'lib/checkout';
 import { hasDomainDetails } from 'lib/store-transactions';
 import notices from 'notices';
 import { managePurchase } from 'me/purchases/paths';
+import SubscriptionLengthPicker from 'blocks/subscription-length-picker';
 import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
 import QueryStoredCards from 'components/data/query-stored-cards';
 import QueryGeo from 'components/data/query-geo';
@@ -38,7 +40,13 @@ import {
 	RECEIVED_WPCOM_RESPONSE,
 	SUBMITTING_WPCOM_REQUEST,
 } from 'lib/store-transactions/step-types';
-import { addItem, applyCoupon, resetTransaction, setDomainDetails } from 'lib/upgrades/actions';
+import {
+	addItem,
+	removeItem,
+	applyCoupon,
+	resetTransaction,
+	setDomainDetails,
+} from 'lib/upgrades/actions';
 import {
 	getContactDetailsCache,
 	getCurrentUserPaymentMethods,
@@ -46,7 +54,7 @@ import {
 	isEligibleForCheckoutToChecklist,
 } from 'state/selectors';
 import { getStoredCards } from 'state/stored-cards/selectors';
-import { isValidFeatureKey, getUpgradePlanSlugFromPath } from 'lib/plans';
+import { isValidFeatureKey, getUpgradePlanSlugFromPath, getPlan, findPlansKeys } from 'lib/plans';
 import { recordViewCheckout } from 'lib/analytics/ad-tracking';
 import { recordApplePayStatus } from 'lib/apple-pay';
 import { requestSite } from 'state/sites/actions';
@@ -148,6 +156,10 @@ class Checkout extends React.Component {
 		} );
 
 		recordViewCheckout( props.cart );
+	}
+
+	getPlanProducts() {
+		return this.props.cart.products.filter( ( { product_slug } ) => getPlan( product_slug ) );
 	}
 
 	getProductSlugFromSynonym( slug ) {
@@ -474,9 +486,58 @@ class Checkout extends React.Component {
 				selectedSite={ selectedSite }
 				redirectTo={ this.getCheckoutCompleteRedirectPath }
 				handleCheckoutCompleteRedirect={ this.handleCheckoutCompleteRedirect }
-			/>
+			>
+				{ config.isEnabled( 'upgrades/2-year-plans' ) && this.renderTermPicker() }
+			</SecurePaymentForm>
 		);
 	}
+
+	renderTermPicker() {
+		const planInCart = this.getPlanProducts()[ 0 ];
+		if ( ! planInCart ) {
+			return false;
+		}
+
+		const currentPlanSlug = this.props.selectedSite.plan.product_slug;
+
+		const chosenPlan = getPlan( planInCart.product_slug );
+		const availableTerms = findPlansKeys( {
+			group: chosenPlan.group,
+			type: chosenPlan.type,
+		} ).filter( planSlug => getPlan( planSlug ).availableFor( currentPlanSlug ) );
+
+		if ( availableTerms.length < 2 ) {
+			return false;
+		}
+
+		return (
+			<React.Fragment>
+				<SubscriptionLengthPicker
+					plans={ availableTerms }
+					initialValue={ planInCart.product_slug }
+					onChange={ this.handleTermChange }
+					key="picker"
+				/>
+				<hr className="checkout__term-picker-separator" key="separator" />
+			</React.Fragment>
+		);
+	}
+
+	handleTermChange = ( { value: planSlug } ) => {
+		// Remove all cart items that are plans
+		const selectedPlans = this.props.cart.products.filter( ( { product_slug } ) =>
+			getPlan( product_slug )
+		);
+		selectedPlans.forEach( removeItem );
+
+		const cartItem = getCartItemForPlan( planSlug );
+		analytics.tracks.recordEvent( 'calypso_signup_plan_select', {
+			product_slug: cartItem.product_slug,
+			free_trial: cartItem.free_trial,
+			from_section: 'checkout',
+		} );
+		addItem( cartItem );
+	};
 
 	paymentMethodsAbTestFilter() {
 		// This methods can be used to filter payment methods

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -500,12 +500,13 @@ class Checkout extends React.Component {
 		}
 
 		const currentPlanSlug = this.props.selectedSite.plan.product_slug;
-
 		const chosenPlan = getPlan( planInCart.product_slug );
+
 		// Only render this for WP.com plans
 		if ( chosenPlan.group !== GROUP_WPCOM ) {
 			return false;
 		}
+
 		const availableTerms = findPlansKeys( {
 			group: chosenPlan.group,
 			type: chosenPlan.type,

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -55,6 +55,7 @@ import {
 } from 'state/selectors';
 import { getStoredCards } from 'state/stored-cards/selectors';
 import { isValidFeatureKey, getUpgradePlanSlugFromPath, getPlan, findPlansKeys } from 'lib/plans';
+import { GROUP_WPCOM } from 'lib/plans/constants';
 import { recordViewCheckout } from 'lib/analytics/ad-tracking';
 import { recordApplePayStatus } from 'lib/apple-pay';
 import { requestSite } from 'state/sites/actions';
@@ -501,6 +502,10 @@ class Checkout extends React.Component {
 		const currentPlanSlug = this.props.selectedSite.plan.product_slug;
 
 		const chosenPlan = getPlan( planInCart.product_slug );
+		// Only render this for WP.com plans
+		if ( chosenPlan.group !== GROUP_WPCOM ) {
+			return false;
+		}
 		const availableTerms = findPlansKeys( {
 			group: chosenPlan.group,
 			type: chosenPlan.type,

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -194,6 +194,8 @@ export class CreditCardPaymentBox extends React.Component {
 					transaction={ transaction }
 				/>
 
+				{ this.props.children }
+
 				<TermsOfService
 					hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( cart ) }
 				/>

--- a/client/my-sites/checkout/checkout/credits-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credits-payment-box.jsx
@@ -56,6 +56,8 @@ export class CreditsPaymentBox extends React.Component {
 					</div>
 				</div>
 
+				{ this.props.children }
+
 				<TermsOfService />
 
 				<div className="payment-box-actions">

--- a/client/my-sites/checkout/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/paypal-payment-box.jsx
@@ -172,6 +172,8 @@ export class PaypalPaymentBox extends React.Component {
 					</div>
 				</div>
 
+				{ this.props.children }
+
 				<TermsOfService
 					hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription(
 						this.props.cart

--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -210,6 +210,8 @@ export class RedirectPaymentBox extends PureComponent {
 					{ this.renderAdditionalFields() }
 				</div>
 
+				{ this.props.children }
+
 				<TermsOfService
 					hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( this.props.cart ) } />
 

--- a/client/my-sites/checkout/checkout/secure-payment-form-placeholder.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form-placeholder.jsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -12,6 +13,7 @@ import React from 'react';
 import PaymentBox from './payment-box.jsx';
 
 const SecurePaymentFormPlaceholder = () => {
+	/*eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<PaymentBox classSet="selected is-empty" contentClassSet="selected is-empty">
 			<div className="payment-box-section">
@@ -28,6 +30,16 @@ const SecurePaymentFormPlaceholder = () => {
 				</div>
 				<div className="placeholder-row placeholder" />
 			</div>
+			{ config.isEnabled( 'upgrades/2-year-plans' ) && (
+				<div className="payment-box-section">
+					<div className="placeholder-col-narrow placeholder-inline-pad">
+						<div className="placeholder" />
+					</div>
+					<div className="placeholder-col-narrow">
+						<div className="placeholder" />
+					</div>
+				</div>
+			) }
 			<div className="payment-box-hr" />
 			<div className="placeholder-button-container">
 				<div className="placeholder-col-narrow">
@@ -36,6 +48,7 @@ const SecurePaymentFormPlaceholder = () => {
 			</div>
 		</PaymentBox>
 	);
+	/*eslint-enable wpcalypso/jsx-classname-namespace */
 };
 
 export default SecurePaymentFormPlaceholder;

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -166,7 +166,9 @@ const SecurePaymentForm = createReactClass( {
 				onSubmit={ this.handlePaymentBoxSubmit }
 				transactionStep={ this.props.transaction.step }
 				presaleChatAvailable={ this.props.presaleChatAvailable }
-			/>
+			>
+				{ this.props.children }
+			</CreditsPaymentBox>
 		);
 	},
 
@@ -211,7 +213,9 @@ const SecurePaymentForm = createReactClass( {
 					onSubmit={ this.handlePaymentBoxSubmit }
 					transactionStep={ this.props.transaction.step }
 					presaleChatAvailable={ this.props.presaleChatAvailable }
-				/>
+				>
+					{ this.props.children }
+				</CreditCardPaymentBox>
 			</PaymentBox>
 		);
 	},
@@ -232,7 +236,9 @@ const SecurePaymentForm = createReactClass( {
 					selectedSite={ this.props.selectedSite }
 					redirectTo={ this.props.redirectTo }
 					presaleChatAvailable={ this.props.presaleChatAvailable }
-				/>
+				>
+					{ this.props.children }
+				</PayPalPaymentBox>
 			</PaymentBox>
 		);
 	},
@@ -253,7 +259,9 @@ const SecurePaymentForm = createReactClass( {
 					paymentType={ paymentType }
 					redirectTo={ this.props.redirectTo }
 					presaleChatAvailable={ this.props.presaleChatAvailable }
-				/>
+				>
+					{ this.props.children }
+				</RedirectPaymentBox>
 			</PaymentBox>
 		);
 	},

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -376,6 +376,30 @@
 		}
 	}
 
+	// Term-picker rules
+	// -----------------------------------
+
+	.subscription-length-picker {
+		margin-top: 15px;
+	}
+
+	&__subscription-length-picker-separator {
+		display: none;
+		position: relative;
+		// Parent overflow is hidden, so 80px here is an arbitrary number
+		// to make sure this element will cover entire width of the parent.
+		// If it's wider, it's okay too.
+		width: calc(100% + 80px * 2);
+		left: -80px;
+		margin-top: 1.7em;
+		margin-bottom: 1.7em;
+		background: $gray-lighten-30;
+	}
+
+	.subscription-length-picker + &__subscription-length-picker-separator {
+		display: block;
+	}
+
 	// PayPal Payment Box
 	// -----------------------------------
 


### PR DESCRIPTION
Related to 2-year plans (p9jf6J-eR-p2). This PR adds `<SubscriptionLengthPicker />` component to the checkout page.

Clicking on a different term should update plan in the cart, but does not update a domain to 2-year one just yet - this will be another PR.

Test plan:
* Run unit tests
* Point public-api.wordpress.com to your sandbox
* Enable store sandbox in `0-sandbox.php` 
* Bump `$cache_key` in `store-product-list.php` in `get_from_cache()` function
* Run `ENABLE_FEATURES=upgrades/2-year-plans npm run start`
* Try to buy different plans and confirm the checkout step for wp.com looks like this:

<img width="754" alt="zrzut ekranu 2018-04-11 o 14 48 40" src="https://user-images.githubusercontent.com/205419/38617558-a336e86a-3d97-11e8-979b-992d7a911a36.png">
<img width="760" alt="zrzut ekranu 2018-04-11 o 14 48 55" src="https://user-images.githubusercontent.com/205419/38617559-a35d08a6-3d97-11e8-838d-966e7388ae13.png">

* Confirm you are able to switch plan and finish the checkout process.
* Confirm nothing changed for Jetpack checkout flow

I am aware that when credit is available, it looks more like this: 

<img width="695" alt="zrzut ekranu 2018-04-11 o 15 10 31" src="https://user-images.githubusercontent.com/205419/38619004-78963562-3d9b-11e8-8b2e-20df5bdf116b.png">

This is a separate problem we are still figuring out. It is unrelated to this PR.