### PR TITLE
Kracken: Fix a bug with featured domains

### DIFF
--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -39,16 +39,20 @@ export class FeaturedDomainSuggestions extends Component {
 
 		return (
 			<div className="featured-domain-suggestions">
-				<DomainRegistrationSuggestion
-					suggestion={ primarySuggestion }
-					isFeatured
-					{ ...childProps }
-				/>
-				<DomainRegistrationSuggestion
-					suggestion={ secondarySuggestion }
-					isFeatured
-					{ ...childProps }
-				/>
+				{ primarySuggestion && (
+					<DomainRegistrationSuggestion
+						suggestion={ primarySuggestion }
+						isFeatured
+						{ ...childProps }
+					/>
+				) }
+				{ secondarySuggestion && (
+					<DomainRegistrationSuggestion
+						suggestion={ secondarySuggestion }
+						isFeatured
+						{ ...childProps }
+					/>
+				) }
 			</div>
 		);
 	}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -57,8 +57,9 @@ import { abtest } from 'lib/abtest';
 import {
 	getStrippedDomainBase,
 	getTldWeightOverrides,
-	isFreeOrUnknownSuggestion,
+	isFreeSuggestion,
 	isNumberString,
+	isUnknownSuggestion,
 } from 'components/domains/register-domain-step/utility';
 import {
 	recordDomainAvailabilityReceive,
@@ -606,6 +607,8 @@ class RegisterDomainStep extends React.Component {
 			return;
 		}
 
+		const isKrackenUi = config.isEnabled( 'domains/kracken-ui' );
+
 		const suggestions = uniqBy( flatten( compact( results ) ), function( suggestion ) {
 			return suggestion.domain_name;
 		} );
@@ -616,9 +619,14 @@ class RegisterDomainStep extends React.Component {
 			startsWith( suggestion.domain_name, `${ strippedDomainBase }.` );
 		const bestAlternative = suggestion =>
 			! exactMatchBeforeTld( suggestion ) && suggestion.isRecommended !== true;
-		const availableSuggestions = reject( suggestions, isFreeOrUnknownSuggestion );
+
+		let availableSuggestions = reject( suggestions, isUnknownSuggestion );
+		if ( ! isKrackenUi ) {
+			availableSuggestions = reject( suggestions, isFreeSuggestion );
+		}
 
 		const recommendedSuggestion = find( availableSuggestions, exactMatchBeforeTld );
+
 		if ( recommendedSuggestion ) {
 			recommendedSuggestion.isRecommended = true;
 		} else if ( availableSuggestions.length > 0 ) {

--- a/client/components/domains/register-domain-step/utility.js
+++ b/client/components/domains/register-domain-step/utility.js
@@ -7,8 +7,12 @@
  */
 import { domainAvailability } from 'lib/domains/constants';
 
-export function isFreeOrUnknownSuggestion( suggestion ) {
-	return suggestion.is_free === true || suggestion.status === domainAvailability.UNKNOWN;
+export function isUnknownSuggestion( suggestion ) {
+	return suggestion.status === domainAvailability.UNKNOWN;
+}
+
+export function isFreeSuggestion( suggestion ) {
+	return suggestion.is_free === true;
 }
 
 export function getStrippedDomainBase( domain ) {

--- a/config/stage.json
+++ b/config/stage.json
@@ -30,7 +30,6 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"domains/cctlds/uk": true,
-		"domains/kracken-ui": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
We would filter free domains from the suggestions,
which would fatal the FeaturedDomainSuggestion because
it always expects primarySuggestion/secondarySuggestion.
Added checks to prevent that too.

Refactored utility functions.

Test:
1. Create a site and buy a plan
2. Go to Domains -> Add
3. Search for a domain with KrackenUI on, and AB test `domainSuggestionKrakenV313` value `group_0`
4. `dfahsfdoisahfodfodasfda.co`
5. No JS error/blank screen.

Before:
Example: https://cloudup.com/cf-CkCCqrde