### PR TITLE
Activity Log: Show existing Rewind operations

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -41,6 +41,7 @@ import { getSiteSlug, getSiteTitle } from 'state/sites/selectors';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import {
 	activityLogRequest,
+	getRewindRestoreProgress,
 	rewindRequestDismiss,
 	rewindRestore,
 	rewindBackupDismiss,
@@ -228,7 +229,20 @@ class ActivityLog extends Component {
 
 	componentDidMount() {
 		window.scrollTo( 0, 0 );
+		this.findExistingRewind( this.props );
 	}
+
+	componentDidUpdate( prevProps ) {
+		if ( ! prevProps.rewindState.rewind && this.props.rewindState.rewind ) {
+			this.findExistingRewind( this.props );
+		}
+	}
+
+	findExistingRewind = ( { siteId, rewindState } ) => {
+		if ( rewindState.rewind ) {
+			this.props.getRewindRestoreProgress( siteId, rewindState.rewind.restoreId );
+		}
+	};
 
 	getStartMoment() {
 		const { gmtOffset, startDate, timezone } = this.props;
@@ -663,6 +677,7 @@ export default connect(
 				recordTracksEvent( 'calypso_activitylog_backup_cancel' ),
 				rewindBackupDismiss( siteId )
 			),
+		getRewindRestoreProgress,
 		rewindRequestDismiss: siteId =>
 			withAnalytics(
 				recordTracksEvent( 'calypso_activitylog_restore_cancel' ),

--- a/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
+++ b/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
@@ -46,6 +46,7 @@ const makeRewindDismisser = data =>
 const transformRewind = data =>
 	Object.assign(
 		{
+			restoreId: data.restore_id,
 			rewindId: data.rewind_id,
 			startedAt: new Date( data.started_at ),
 			status: data.status,

--- a/client/state/data-layer/wpcom/sites/rewind/schema.js
+++ b/client/state/data-layer/wpcom/sites/rewind/schema.js
@@ -45,13 +45,14 @@ export const rewind = {
 	type: 'object',
 	properties: {
 		links: { type: 'object' },
+		restore_id: { type: 'integer' },
 		rewind_id: { type: 'string' },
 		status: { type: 'string', enum: [ 'failed', 'finished', 'queued', 'running' ] },
 		started_at: { type: 'string' },
 		progress: { type: 'integer' },
 		reason: { type: 'string' },
 	},
-	required: [ 'rewind_id', 'status' ],
+	required: [ 'restore_id', 'rewind_id', 'status' ],
 };
 
 export const unavailable = stateSchema( 'unavailable', {


### PR DESCRIPTION
Calypso is using two systems to gather information about running
Rewind operations. Once it kicks off a Rewind session it starts
hitting the `restore-status` API endpoint and displays info about
that endpoint in a banner.

We're also relying on the Rewind "State machine" endpoint to gather
information about the entire Rewind system. This API endpoint
already provides information on active Rewind sessions.

One problem we've had is that Rewind operations don't show their
banners after page refreshes and in other sessions. If you visit
a page on a site where a Rewind is already going on it will look
like you can't start a Rewind operation and there will be no
explanation.

In this patch we're using the response from the Rewind API to kick
off a request to the `restore-status` API so that if there is a
Rewind operation going on we can see it immediately.

**Testing**

Start a Rewind operation on a site; reload the browser and make sure
that the banner comes back.