### PR TITLE
Jetpack Settings (data-layer): Don't update post-by-email address if it hasn't been regenerated

### DIFF
--- a/client/state/jetpack-onboarding/reducer.js
+++ b/client/state/jetpack-onboarding/reducer.js
@@ -53,7 +53,7 @@ export const settingsReducer = keyedReducer(
 				state,
 				{ settings: { post_by_email_address } }
 			) => {
-				if ( post_by_email_address !== state.post_by_email_address ) {
+				if ( post_by_email_address && post_by_email_address !== state.post_by_email_address ) {
 					return { ...state, post_by_email_address };
 				}
 				return state;

--- a/client/state/jetpack-onboarding/test/reducer.js
+++ b/client/state/jetpack-onboarding/test/reducer.js
@@ -230,6 +230,24 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		test( "shouldn't update post-by-email address if it hasn't been regenerated", () => {
+			const siteId = 12345678;
+			const newSettings = {
+				post_by_email_address: '',
+			};
+			const initialState = deepFreeze( {
+				[ siteId ]: settings,
+				[ 87654321 ]: settings,
+			} );
+			const state = settingsReducer( initialState, {
+				type: JETPACK_ONBOARDING_SETTINGS_SAVE_SUCCESS,
+				siteId,
+				settings: newSettings,
+			} );
+
+			expect( state ).toEqual( initialState );
+		} );
+
 		test( 'should keep non-updated settings for sites', () => {
 			const siteId = 12345678;
 			const newSettings = {


### PR DESCRIPTION
Spun off #23797 to fix https://github.com/Automattic/wp-calypso/pull/23797#discussion_r180788157.

To test: Verify that JPO still works.