### PR TITLE
Analytics: Refactor WooCommerce stats page view tracking

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -14,8 +14,6 @@ import AsyncLoad from 'components/async-load';
 import StatsPagePlaceholder from 'my-sites/stats/stats-page-placeholder';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { getQueryDate, getQueries } from './utils';
-import analytics from 'lib/analytics';
-import titlecase from 'to-title-case';
 import { recordTrack } from 'woocommerce/lib/analytics';
 import config from 'config';
 
@@ -39,11 +37,6 @@ export default function StatsController( context, next ) {
 	if ( ! isValidParameters( context ) ) {
 		page.redirect( `/store/stats/orders/day/${ context.params.site }` );
 	}
-
-	analytics.pageView.record(
-		`/store/stats/${ context.params.type }/${ context.params.unit }`,
-		`Store > Stats > ${ titlecase( context.params.type ) } > ${ titlecase( context.params.unit ) }`
-	);
 
 	const props = {
 		type: context.params.type,

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -34,6 +34,8 @@ import { getUnitPeriod, getEndPeriod, getQueries, getWidgetPath } from './utils'
 import QuerySiteStats from 'components/data/query-site-stats';
 import config from 'config';
 import StoreStatsReferrerWidget from './store-stats-referrer-widget';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import titlecase from 'to-title-case';
 
 class StoreStats extends Component {
 	static propTypes = {
@@ -56,6 +58,10 @@ class StoreStats extends Component {
 
 		return (
 			<Main className="store-stats woocommerce" wideLayout={ true }>
+				<PageViewTracker
+					path={ `/store/stats/orders/${ unit }/:site` }
+					title={ `Store > Stats > Orders > ${ titlecase( unit ) }` }
+				/>
 				{ siteId && (
 					<QuerySiteStats statType="statsOrders" siteId={ siteId } query={ orderQuery } />
 				) }

--- a/client/extensions/woocommerce/app/store-stats/listview.js
+++ b/client/extensions/woocommerce/app/store-stats/listview.js
@@ -20,6 +20,8 @@ import Module from './store-stats-module';
 import { topProducts, topCategories, topCoupons } from 'woocommerce/app/store-stats/constants';
 import QuerySiteStats from 'components/data/query-site-stats';
 import StoreStatsPeriodNav from 'woocommerce/app/store-stats/store-stats-period-nav';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import titlecase from 'to-title-case';
 
 const listType = {
 	products: topProducts,
@@ -43,6 +45,10 @@ class StoreStatsListView extends Component {
 		const statType = listType[ type ].statType;
 		return (
 			<Main className="store-stats__list-view woocommerce" wideLayout>
+				<PageViewTracker
+					path={ `/store/stats/${ type }/${ unit }/:site` }
+					title={ `Store > Stats > ${ titlecase( type ) } > ${ titlecase( unit ) }` }
+				/>
 				{ siteId && (
 					<QuerySiteStats statType={ statType } siteId={ siteId } query={ topListQuery } />
 				) }

--- a/client/extensions/woocommerce/app/store-stats/referrers/index.js
+++ b/client/extensions/woocommerce/app/store-stats/referrers/index.js
@@ -24,6 +24,8 @@ import SearchCard from 'components/search-card';
 import StoreStatsReferrerWidget from 'woocommerce/app/store-stats/store-stats-referrer-widget';
 import { sortBySales } from 'woocommerce/app/store-stats/referrers/helpers';
 import { getStoreReferrers } from 'state/selectors';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import titlecase from 'to-title-case';
 
 const STAT_TYPE = 'statsStoreReferrers';
 const LIMIT = 10;
@@ -109,6 +111,10 @@ class Referrers extends Component {
 		}`;
 		return (
 			<Main className="referrers woocommerce" wideLayout>
+				<PageViewTracker
+					path={ `/store/stats/referrers/${ unit }/:site` }
+					title={ `Store > Stats > Referrers > ${ titlecase( unit ) }` }
+				/>
 				{ siteId && <QuerySiteStats statType={ STAT_TYPE } siteId={ siteId } query={ query } /> }
 				<StoreStatsPeriodNav
 					type="referrers"


### PR DESCRIPTION
Follow-up to #23998 where I completely missed this other controller contained in a subfolder of `/extensions/woocommerce`.

Replace direct `analytics.pageView.record` calls with `PageViewTracker` in WooCommerce stats.

Check out the updated recommendations on page view tracking:
https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/docs/page-views.md

## Testing instructions

Not sure how to have a store in Calypso from outside USA and Canada. 🤔 