### PR TITLE
Plugin Notices: simplify the removePluginsNotices action 

### DIFF
--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -127,7 +127,7 @@ const recordEvent = ( eventType, plugin, site, error ) => {
 };
 
 const PluginsActions = {
-	removePluginsNotices: logs => {
+	removePluginsNotices: ( ...logs ) => {
 		Dispatcher.handleViewAction( {
 			type: 'REMOVE_PLUGINS_NOTICES',
 			logs: logs,

--- a/client/lib/plugins/log-store.js
+++ b/client/lib/plugins/log-store.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { clone, findIndex, indexOf, isArray, pullAt, reject } from 'lodash';
+import { clone, findIndex, indexOf, isArray, pullAt } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:my-sites:plugins:log-store' );
 
@@ -44,22 +44,19 @@ function addLog( status, action, site, plugin, error ) {
 	}
 }
 
-function removeLog( log ) {
-	debug( 'removing log:', log );
-	switch ( log.status ) {
+function clearLog( status ) {
+	debug( 'clearing log:', status );
+	switch ( status ) {
 		case 'error':
-			_errors = reject( _errors, log );
-			debug( 'current errors:', _errors );
+			_errors = [];
 			break;
 
 		case 'inProgress':
-			_inProgress = reject( _inProgress, log );
-			debug( 'current in progress:', _inProgress );
+			_inProgress = [];
 			break;
 
 		case 'completed':
-			_completed = reject( _completed, log );
-			debug( 'current completed:', _completed );
+			_completed = [];
 			break;
 	}
 }
@@ -136,7 +133,7 @@ LogStore.dispatchToken = Dispatcher.register( function( payload ) {
 	debug( 'register event Type', action.type, payload );
 	switch ( action.type ) {
 		case 'REMOVE_PLUGINS_NOTICES':
-			action.logs.forEach( removeLog );
+			action.logs.forEach( clearLog );
 			LogStore.emitChange();
 			break;
 		case 'UPDATE_PLUGIN':

--- a/client/lib/plugins/notices.jsx
+++ b/client/lib/plugins/notices.jsx
@@ -100,16 +100,13 @@ export default {
 
 		if ( logNotices.completed.length > 0 && logNotices.errors.length > 0 ) {
 			notices.warning( this.erroredAndCompletedMessage( logNotices ), {
-				onRemoveCallback: PluginsActions.removePluginsNotices.bind(
-					this,
-					logNotices.completed.concat( logNotices.errors )
-				),
+				onRemoveCallback: () => PluginsActions.removePluginsNotices( 'completed', 'error' ),
 			} );
 		} else if ( logNotices.errors.length > 0 ) {
 			notices.error( this.getMessage( logNotices.errors, this.errorMessage, 'errors' ), {
 				button: this.getErrorButton( logNotices.errors ),
 				href: this.getErrorHref( logNotices.errors ),
-				onRemoveCallback: PluginsActions.removePluginsNotices.bind( this, logNotices.errors ),
+				onRemoveCallback: () => PluginsActions.removePluginsNotices( 'error' ),
 			} );
 		} else if ( logNotices.completed.length > 0 ) {
 			const sampleLog =
@@ -124,7 +121,7 @@ export default {
 			notices.success( this.getMessage( logNotices.completed, this.successMessage, 'completed' ), {
 				button: this.getSuccessButton( logNotices.completed ),
 				href: this.getSuccessHref( logNotices.completed ),
-				onRemoveCallback: PluginsActions.removePluginsNotices.bind( this, logNotices.completed ),
+				onRemoveCallback: () => PluginsActions.removePluginsNotices( 'completed' ),
 				showDismiss,
 			} );
 		}

--- a/client/lib/plugins/notices.jsx
+++ b/client/lib/plugins/notices.jsx
@@ -103,7 +103,7 @@ export default {
 				onRemoveCallback: () => PluginsActions.removePluginsNotices( 'completed', 'error' ),
 			} );
 		} else if ( logNotices.errors.length > 0 ) {
-			notices.error( this.getMessage( logNotices.errors, this.errorMessage, 'errors' ), {
+			notices.error( this.getMessage( logNotices.errors, this.errorMessage, 'error' ), {
 				button: this.getErrorButton( logNotices.errors ),
 				href: this.getErrorHref( logNotices.errors ),
 				onRemoveCallback: () => PluginsActions.removePluginsNotices( 'error' ),
@@ -579,7 +579,7 @@ export default {
 				this.successMessage,
 				'completed'
 			),
-			errorMessage = this.getMessage( logNotices.errors, this.errorMessage, 'errors' );
+			errorMessage = this.getMessage( logNotices.errors, this.errorMessage, 'error' );
 		return ' ' + completedMessage + ' ' + errorMessage;
 	},
 

--- a/client/lib/plugins/test/fixtures/actions.js
+++ b/client/lib/plugins/test/fixtures/actions.js
@@ -310,8 +310,8 @@ export default {
 		},
 	},
 
-	removeErrorNotice: {
+	removeErrorNotices: {
 		type: 'REMOVE_PLUGINS_NOTICES',
-		logs: [ { status: 'error', action: 'UPDATE_PLUGIN', site: site, plugin: plugins[ 2 ] } ],
+		logs: [ 'error' ],
 	},
 };

--- a/client/lib/plugins/test/log-store.js
+++ b/client/lib/plugins/test/log-store.js
@@ -1,31 +1,26 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { assert } from 'chai';
-
-/**
  * Internal dependencies
  */
 import actions from './fixtures/actions';
 
 describe( 'Plugins Log Store', () => {
-	let Dispatcher, LogStore, initialErrors;
+	let Dispatcher, LogStore;
 
 	beforeEach( () => {
 		Dispatcher = require( 'dispatcher' );
 		LogStore = require( '../log-store' );
-		initialErrors = LogStore.getErrors().length;
 	} );
 
 	test( 'logs an update error', () => {
+		const initialErrors = LogStore.getErrors().length;
 		Dispatcher.handleServerAction( actions.updatedPluginError );
-		assert.lengthOf( LogStore.getErrors(), initialErrors + 1 );
+		expect( LogStore.getErrors() ).toHaveLength( initialErrors + 1 );
 	} );
 
-	test( 'removing an error notice deletes an error', () => {
-		Dispatcher.handleServerAction( actions.removeErrorNotice );
-		assert.lengthOf( LogStore.getErrors(), initialErrors - 1 );
+	test( 'removing error notices clears the error log', () => {
+		Dispatcher.handleServerAction( actions.removeErrorNotices );
+		expect( LogStore.getErrors() ).toHaveLength( 0 );
 	} );
 } );

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -25,7 +25,6 @@ export class PluginActivateToggle extends Component {
 			disabled,
 			site,
 			plugin,
-			notices,
 			recordGoogleEvent: recordGAEvent,
 			recordTracksEvent: recordEvent,
 		} = this.props;
@@ -34,7 +33,7 @@ export class PluginActivateToggle extends Component {
 		}
 
 		PluginsActions.togglePluginActivation( site, plugin );
-		PluginsActions.removePluginsNotices( notices.completed.concat( notices.errors ) );
+		PluginsActions.removePluginsNotices( 'completed', 'error' );
 
 		if ( plugin.active ) {
 			recordGAEvent( 'Plugins', 'Clicked Toggle Deactivate Plugin', 'Plugin Name', plugin.slug );
@@ -134,7 +133,6 @@ export class PluginActivateToggle extends Component {
 PluginActivateToggle.propTypes = {
 	site: PropTypes.object.isRequired,
 	plugin: PropTypes.object.isRequired,
-	notices: PropTypes.object,
 	isMock: PropTypes.bool,
 	disabled: PropTypes.bool,
 };

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -24,7 +24,6 @@ export class PluginAutoUpdateToggle extends Component {
 			disabled,
 			site,
 			plugin,
-			notices,
 			recordGoogleEvent: recordGAEvent,
 			recordTracksEvent: recordEvent,
 		} = this.props;
@@ -34,7 +33,7 @@ export class PluginAutoUpdateToggle extends Component {
 		}
 
 		PluginsActions.togglePluginAutoUpdate( site, plugin );
-		PluginsActions.removePluginsNotices( notices.completed.concat( notices.errors ) );
+		PluginsActions.removePluginsNotices( 'completed', 'error' );
 
 		if ( plugin.autoupdate ) {
 			recordGAEvent(

--- a/client/my-sites/plugins/plugin-install-button/README.md
+++ b/client/my-sites/plugins/plugin-install-button/README.md
@@ -14,7 +14,6 @@ render() {
             selectedSite={ site }
             isInstalling={ false }
             isEmbed={ false }
-            notices={ notices }
         />;
 }
 ```
@@ -25,4 +24,3 @@ render() {
 * `selectedSite`: a site object.
 * `isInstalling`: an optional boolean indicating if there's a install action for this plugin and site already going on.
 * `isEmbed`: an optional boolean indicating if the button is going to be rendered embed inside a plugin-site component.
-* `notices` : (object) Object of errored, inProgress, and completed actions.

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -29,7 +29,6 @@ export class PluginInstallButton extends Component {
 			siteId,
 			isInstalling,
 			plugin,
-			notices,
 			recordGoogleEvent: recordGAEvent,
 			recordTracksEvent: recordEvent,
 		} = this.props;
@@ -38,7 +37,7 @@ export class PluginInstallButton extends Component {
 			return;
 		}
 
-		PluginsActions.removePluginsNotices( notices.completed.concat( notices.errors ) );
+		PluginsActions.removePluginsNotices( 'completed', 'error' );
 		PluginsActions.installPlugin( selectedSite, plugin );
 
 		if ( isEmbed ) {
@@ -302,7 +301,6 @@ PluginInstallButton.propTypes = {
 	plugin: PropTypes.object.isRequired,
 	isEmbed: PropTypes.bool,
 	isInstalling: PropTypes.bool,
-	notices: PropTypes.object,
 	isMock: PropTypes.bool,
 	disabled: PropTypes.bool,
 };

--- a/client/my-sites/plugins/plugin-meta/README.md
+++ b/client/my-sites/plugins/plugin-meta/README.md
@@ -19,7 +19,6 @@ render() {
 
 #### Props
 
-* `notices` : (object) Object of errored, inProgress, and completed actions.
 * `plugin` : (object) A plugin object.
 * `siteURL` : (string) The URL of the selected site. Used to determine if this is a single or all sites view.
 * `sites` : (array) An array of the sites that current plugin is installed on.

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -52,7 +52,6 @@ export class PluginMeta extends Component {
 	static propTypes = {
 		siteURL: PropTypes.string,
 		sites: PropTypes.array,
-		notices: PropTypes.object,
 		plugin: PropTypes.object.isRequired,
 		isInstalledOnSite: PropTypes.bool,
 		isPlaceholder: PropTypes.bool,
@@ -168,7 +167,6 @@ export class PluginMeta extends Component {
 					<PluginActivateToggle
 						plugin={ this.props.plugin }
 						site={ this.props.selectedSite }
-						notices={ this.props.notices }
 						isMock={ this.props.isMock }
 					/>
 				) }
@@ -176,7 +174,6 @@ export class PluginMeta extends Component {
 					<PluginAutoupdateToggle
 						plugin={ this.props.plugin }
 						site={ this.props.selectedSite }
-						notices={ this.props.notices }
 						wporg={ this.props.plugin.wporg }
 						isMock={ this.props.isMock }
 					/>
@@ -185,7 +182,6 @@ export class PluginMeta extends Component {
 					<PluginRemoveButton
 						plugin={ this.props.plugin }
 						site={ this.props.selectedSite }
-						notices={ this.props.notices }
 						isMock={ this.props.isMock }
 					/>
 				) }
@@ -517,9 +513,7 @@ export class PluginMeta extends Component {
 				plugin.update.new_version
 			) {
 				PluginsActions.updatePlugin( site, plugin );
-				PluginsActions.removePluginsNotices(
-					this.props.notices.completed.concat( this.props.notices.errors )
-				);
+				PluginsActions.removePluginsNotices( 'completed', 'error' );
 
 				analytics.tracks.recordEvent( 'calypso_plugins_actions_update_plugin_all_sites', {
 					site: site,

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -45,9 +45,7 @@ class PluginRemoveButton extends React.Component {
 
 	processRemovalConfirmation = accepted => {
 		if ( accepted ) {
-			PluginsActions.removePluginsNotices(
-				this.props.notices.completed.concat( this.props.notices.errors )
-			);
+			PluginsActions.removePluginsNotices( 'completed', 'error' );
 			PluginsActions.removePlugin( this.props.site, this.props.plugin );
 
 			if ( this.props.isEmbed ) {

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -53,7 +53,6 @@ class PluginSiteJetpack extends React.Component {
 		return (
 			<PluginInstallButton
 				isEmbed={ true }
-				notices={ this.props.notices }
 				selectedSite={ this.props.site }
 				plugin={ this.props.plugin }
 				isInstalling={ installInProgress }
@@ -106,26 +105,17 @@ class PluginSiteJetpack extends React.Component {
 			>
 				<div>
 					{ canToggleActivation && (
-						<PluginActivateToggle
-							site={ this.props.site }
-							plugin={ this.props.site.plugin }
-							notices={ this.props.notices }
-						/>
+						<PluginActivateToggle site={ this.props.site } plugin={ this.props.site.plugin } />
 					) }
 					{ canToggleAutoupdate && (
 						<PluginAutoupdateToggle
 							site={ this.props.site }
 							plugin={ this.props.site.plugin }
-							notices={ this.props.notices }
 							wporg={ true }
 						/>
 					) }
 					{ canToggleRemove && (
-						<PluginRemoveButton
-							plugin={ this.props.site.plugin }
-							site={ this.props.site }
-							notices={ this.props.notices }
-						/>
+						<PluginRemoveButton plugin={ this.props.site.plugin } site={ this.props.site } />
 					) }
 					{ showAutoManagedMessage && (
 						<div className="plugin-site-jetpack__automanage-notice">

--- a/client/my-sites/plugins/plugin-site-network/index.jsx
+++ b/client/my-sites/plugins/plugin-site-network/index.jsx
@@ -46,7 +46,6 @@ class PluginSiteNetwork extends React.Component {
 		return (
 			<PluginInstallButton
 				isEmbed={ true }
-				notices={ this.props.notices }
 				selectedSite={ this.props.site }
 				plugin={ this.props.plugin }
 				isInstalling={ installInProgress }
@@ -92,14 +91,9 @@ class PluginSiteNetwork extends React.Component {
 				<PluginAutoupdateToggle
 					site={ this.props.site }
 					plugin={ this.props.site.plugin }
-					notices={ this.props.notices }
 					wporg={ true }
 				/>
-				<PluginRemoveButton
-					plugin={ this.props.site.plugin }
-					site={ this.props.site }
-					notices={ this.props.notices }
-				/>
+				<PluginRemoveButton plugin={ this.props.site.plugin } site={ this.props.site } />
 			</div>
 		);
 	};
@@ -160,7 +154,7 @@ class PluginSiteNetwork extends React.Component {
 		}
 		return (
 			<div className="plugin-site-network__secondary-site-actions">
-				<PluginActivateToggle site={ site } plugin={ site.plugin } notices={ this.props.notices } />
+				<PluginActivateToggle site={ site } plugin={ site.plugin } />
 			</div>
 		);
 	};

--- a/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
+++ b/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
@@ -34,9 +34,7 @@ class PluginSiteUpdateIndicator extends React.Component {
 		ev.stopPropagation();
 
 		PluginsActions.updatePlugin( this.props.site, this.props.plugin );
-		PluginsActions.removePluginsNotices(
-			this.props.notices.completed.concat( this.props.notices.errors )
-		);
+		PluginsActions.removePluginsNotices( 'completed', 'error' );
 		analytics.ga.recordEvent(
 			'Plugins',
 			'Clicked Update Single Site Plugin',

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -19,7 +19,6 @@ import PluginMeta from 'my-sites/plugins/plugin-meta';
 import PluginsStore from 'lib/plugins/store';
 import PluginsLog from 'lib/plugins/log-store';
 import { getPlugin, isFetched, isFetching } from 'state/plugins/wporg/selectors';
-import PluginsActions from 'lib/plugins/actions';
 import { fetchPluginData as wporgFetchPluginData } from 'state/plugins/wporg/actions';
 import PluginNotices from 'lib/plugins/notices';
 import MainComponent from 'components/main';
@@ -104,10 +103,6 @@ const SinglePlugin = createReactClass( {
 			textOnly: true,
 			context: 'Page title: Plugin detail',
 		} );
-	},
-
-	removeNotice( error ) {
-		PluginsActions.removePluginsNotices( error );
 	},
 
 	recordEvent( eventAction ) {
@@ -266,7 +261,6 @@ const SinglePlugin = createReactClass( {
 					{ this.displayHeader() }
 					<PluginMeta
 						isPlaceholder
-						notices={ this.state.notices }
 						isInstalledOnSite={
 							this.isFetchingSites()
 								? null
@@ -305,7 +299,6 @@ const SinglePlugin = createReactClass( {
 				<div className="plugin__page">
 					{ this.displayHeader() }
 					<PluginMeta
-						notices={ {} }
 						isInstalledOnSite={
 							!! PluginsStore.getSitePlugin( selectedSite, this.state.plugin.slug )
 						}
@@ -369,7 +362,6 @@ const SinglePlugin = createReactClass( {
 				<div className="plugin__page">
 					{ this.displayHeader() }
 					<PluginMeta
-						notices={ this.state.notices }
 						plugin={ plugin }
 						siteUrl={ this.props.siteUrl }
 						sites={ this.state.sites }

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -222,11 +222,7 @@ export const PluginsList = createReactClass( {
 	},
 
 	removePluginsNotices() {
-		const { notices: { completed, errors } = {} } = this.state;
-
-		if ( completed || errors ) {
-			PluginsActions.removePluginsNotices( [ ...completed, ...errors ] );
-		}
+		PluginsActions.removePluginsNotices( 'completed', 'error' );
 	},
 
 	doActionOverSelected( actionName, action ) {


### PR DESCRIPTION
This PR simplified a part of the Plugin Notices Log Store. It's the code that is responsible for showing smart notices when multiple plugins are being changed (updated, activated, deactivated, ...) on multiple sites at once. Watch how the notices look like in this screencast:

![plugins-notices-updates](https://user-images.githubusercontent.com/664258/38627654-c6babf60-3daf-11e8-9526-b0d73f4e862a.gif)

The Log Store has 4 records about successful updates and that information gets compressed into a "Updated 1 plugin on 4 sites" notice.

This PR simplifies the `removePluginsNotices` action. Instead of passing the array of log records to remove, we pass just the string name of a list: `completed`, `inProgress` or `error`. We always use it to remove a whole list anyway.

The benefit is that we no longer need to pass the notices logs object as a `notices` prop. That removes a lot of noise from the Plugins code, making it easier to understand during the upcoming Redux migration.

There is a second commit that does a related drive-by fix: the argument for `getMessage` function should be `'error'`, not `errors`. The `status` field of errored notices has value `'error'`. Passing the wrong argument causes a bug where you'll never see a compressed notice like this for errors:

<img width="531" alt="plugins-notices-errors" src="https://user-images.githubusercontent.com/664258/38637566-cd74e18e-3dcb-11e8-9899-75bcd54b4c7d.png">

Only one of the sites would be mentioned and the compression into "on 2 sites" would never happen.

**How to test:**
Have a few Jetpack or Atomic sites with several plugins. Make several plugin actions (activate, deactivate, update, enable/disable autoupdates) happen in parallel. For example, by clicking quickly enough on multiple "Active" toggles. Verify that the notices display the progress correctly.