### PR TITLE
Pages: Adding "make homepage" option to ellipse popover menu

### DIFF
--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -306,12 +306,6 @@ class Page extends Component {
 		pageRouter( editLinkForPage( this.props.page, this.props.site ) );
 	};
 
-	// // making new homepage function
-	// makeHomepage = () => {
-	// 	this.props.recordHomepage();
-	// 	pageRouter( homepageLinkForPage( this.props.page, this.props.site) );
-	// }
-
 	getPageStatusInfo() {
 		if ( this.props.page.status === 'publish' ) {
 			return null;

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 
- 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
@@ -74,6 +73,8 @@ class Page extends Component {
 		recordMoreOptions: PropTypes.func.isRequired,
 		recordPageTitle: PropTypes.func.isRequired,
 		recordEditPage: PropTypes.func.isRequired,
+		//adding new make homepage item
+		recordMakeHomepage: PropTypes.func.isRequired,
 		recordViewPage: PropTypes.func.isRequired,
 		recordStatsPage: PropTypes.func.isRequired,
 	};
@@ -204,6 +205,24 @@ class Page extends Component {
 		);
 	}
 
+	//// inserting new Make Homepage item to popover menu
+	getHomepageItem() {
+		if ( this.props.hasStaticFrontPage && this.props.isPostsPage ) {
+			return null;
+		}
+
+		if ( ! utils.userCan( 'edit_post', this.props.page ) ) {
+			return null;
+		}
+
+		return (
+			<PopoverMenuItem onClick={ this.makeHomepage }>
+				<Gridicon icon="house" size={ 18 } />
+				{ this.props.translate( 'Make Homepage' ) }
+			</PopoverMenuItem>
+		);
+	}
+
 	getSendToTrashItem() {
 		if ( ( this.props.hasStaticFrontPage && this.props.isPostsPage ) || this.props.isFrontPage ) {
 			return null;
@@ -287,6 +306,12 @@ class Page extends Component {
 		pageRouter( editLinkForPage( this.props.page, this.props.site ) );
 	};
 
+	// // making new homepage function
+	// makeHomepage = () => {
+	// 	this.props.recordHomepage();
+	// 	pageRouter( homepageLinkForPage( this.props.page, this.props.site) );
+	// }
+
 	getPageStatusInfo() {
 		if ( this.props.page.status === 'publish' ) {
 			return null;
@@ -345,6 +370,8 @@ class Page extends Component {
 		const viewItem = this.getViewItem();
 		const publishItem = this.getPublishItem();
 		const editItem = this.getEditItem();
+		//adding homepage item
+		const homepageItem = this.getHomepageItem();
 		const restoreItem = this.getRestoreItem();
 		const sendToTrashItem = this.getSendToTrashItem();
 		const copyItem = this.getCopyItem();
@@ -354,6 +381,8 @@ class Page extends Component {
 			viewItem ||
 			publishItem ||
 			editItem ||
+			//adding new homepage item
+			homepageItem ||
 			statsItem ||
 			restoreItem ||
 			sendToTrashItem ||
@@ -366,6 +395,7 @@ class Page extends Component {
 				onToggle={ this.handleMenuToggle }
 			>
 				{ editItem }
+				{ homepageItem }
 				{ publishItem }
 				{ viewItem }
 				{ statsItem }
@@ -606,6 +636,8 @@ const mapDispatch = {
 	recordMoreOptions: partial( recordEvent, 'Clicked More Options Menu' ),
 	recordPageTitle: partial( recordEvent, 'Clicked Page Title' ),
 	recordEditPage: partial( recordEvent, 'Clicked Edit Page' ),
+	//adding homepage item
+	recordHomepage: partial( recordEvent, 'Clicked Make Homepage' ),
 	recordViewPage: partial( recordEvent, 'Clicked View Page' ),
 	recordStatsPage: partial( recordEvent, 'Clicked Stats Page' ),
 };

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -73,7 +73,7 @@ class Page extends Component {
 		recordMoreOptions: PropTypes.func.isRequired,
 		recordPageTitle: PropTypes.func.isRequired,
 		recordEditPage: PropTypes.func.isRequired,
-		//adding new make homepage item
+		// Adding new make homepage item
 		recordMakeHomepage: PropTypes.func.isRequired,
 		recordViewPage: PropTypes.func.isRequired,
 		recordStatsPage: PropTypes.func.isRequired,
@@ -205,7 +205,7 @@ class Page extends Component {
 		);
 	}
 
-	//// inserting new Make Homepage item to popover menu
+	// Inserting new Make Homepage item to popover menu.
 	getHomepageItem() {
 		if ( this.props.hasStaticFrontPage && this.props.isPostsPage ) {
 			return null;
@@ -364,7 +364,7 @@ class Page extends Component {
 		const viewItem = this.getViewItem();
 		const publishItem = this.getPublishItem();
 		const editItem = this.getEditItem();
-		//adding homepage item
+		// Adding homepage item
 		const homepageItem = this.getHomepageItem();
 		const restoreItem = this.getRestoreItem();
 		const sendToTrashItem = this.getSendToTrashItem();
@@ -375,7 +375,7 @@ class Page extends Component {
 			viewItem ||
 			publishItem ||
 			editItem ||
-			//adding new homepage item
+			// Adding new homepage item
 			homepageItem ||
 			statsItem ||
 			restoreItem ||
@@ -630,7 +630,7 @@ const mapDispatch = {
 	recordMoreOptions: partial( recordEvent, 'Clicked More Options Menu' ),
 	recordPageTitle: partial( recordEvent, 'Clicked Page Title' ),
 	recordEditPage: partial( recordEvent, 'Clicked Edit Page' ),
-	//adding homepage item
+	// Adding homepage item
 	recordHomepage: partial( recordEvent, 'Clicked Make Homepage' ),
 	recordViewPage: partial( recordEvent, 'Clicked View Page' ),
 	recordStatsPage: partial( recordEvent, 'Clicked Stats Page' ),

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 
+ 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';


### PR DESCRIPTION
Write a detailed description of the problem you are solving, the part of Calypso it affects, and how you plan on going about solving it.

This PR is in reference to open issue #23576. Found [here](https://github.com/Automattic/wp-calypso/issues/23576#issuecomment-376677154). As @jancavan explains, once a user is at https://wpcalypso.wordpress.com/page/[site], there is no straight-forward way for a user to change their homepage. One would expect the option to exist in the ellipses menu, but this option doesn't currently exist. My PR creates this desired "Make Homepage" menu item.

Please note that this PR is pushing code that creates a new menu item button that says "Make Homepage". However, this code does **not** make this feature actually work upon clicking "Make Homepage" menu item. That functionality will hopefully come in another PR!

Here's what the popover menu looks like currently:
![before](https://user-images.githubusercontent.com/19803726/38646324-23678f98-3dad-11e8-8036-05c476ab01aa.png)

Here's what it looks like with my changes:
![after](https://user-images.githubusercontent.com/19803726/38646329-274d5232-3dad-11e8-92db-cac2940bef4b.png)