### PR TITLE
[Domains] Enable Kracken in horizon, disable in wp

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -28,6 +28,7 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"domains/cctlds/uk": true,
+		"domains/kracken-ui": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -33,7 +33,6 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"domains/cctlds/uk": true,
-		"domains/kracken-ui": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
Follow-up of #24018. 

Until [this PR](https://github.com/Automattic/wp-e2e-tests/pull/1129) is merged, we should not enable the new Kracken UI in the `wpcalypso` environment. This change disables the new UI in `wpcalypso` and enables it in `horizon` instead as per @gwwar's suggestion.