### PR TITLE
Jetpack connect: Use jetpack-connect signup flow type

### DIFF
--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -210,15 +210,9 @@ export function createSocialAccount( socialInfo ) {
 		dispatch( recordTracksEvent( 'calypso_jpc_social_createaccount' ) );
 
 		try {
-			/**
-			 * @TODO (sirreal) update to `jetpack-connect` when D11099-code lands
-			 *
-			 * The signup flow is required and affects some post signup activity.
-			 * `account` should be safe until patch lands.
-			 */
 			const { username, bearer_token } = await wpcom.undocumented().usersSocialNew( {
 				...socialInfo,
-				signup_flow_name: 'account' /* 'jetpack-connect' */,
+				signup_flow_name: 'jetpack-connect',
 			} );
 			dispatch( recordTracksEvent( 'calypso_jpc_social_createaccount_success' ) );
 			return { username, bearerToken: bearer_token };


### PR DESCRIPTION
Social signups must provide a flow name. Use `jetpack-connect`.

Related diff: ✅ D11099-code

## Testing
1. Follow the Google signup flow (see #23483)
1. Ensure you receive the expected email:
   ![no-site-email](https://user-images.githubusercontent.com/841763/38661344-c7e6d884-3e30-11e8-8f98-7ae8c885e9fb.png)
