### PR TITLE
Add a second type of Subscription length option: upgrade

### DIFF
--- a/client/blocks/subscription-length-picker/docs/example.jsx
+++ b/client/blocks/subscription-length-picker/docs/example.jsx
@@ -14,7 +14,7 @@ import { PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS } from 'lib/plans/constants';
 import { SubscriptionLengthPicker } from 'blocks/subscription-length-picker';
 import PropTypes from 'prop-types';
 
-const productsWithPrices = [
+const productsWithPrices1 = [
 	{
 		planSlug: PLAN_BUSINESS,
 		plan: getPlan( PLAN_BUSINESS ),
@@ -33,12 +33,41 @@ const productsWithPrices = [
 	},
 ];
 
+const productsWithPrices2 = [
+	{
+		planSlug: PLAN_BUSINESS,
+		plan: getPlan( PLAN_BUSINESS ),
+		// These prices should not be hardcoded in real code, this is just to
+		// show how things will look like in devdocs
+		priceBeforeDiscount: 250,
+		priceFull: 200,
+		priceMonthly: 200 / 24,
+	},
+	{
+		planSlug: PLAN_BUSINESS_2_YEARS,
+		plan: getPlan( PLAN_BUSINESS_2_YEARS ),
+		// These prices should not be hardcoded in real code, this is just to
+		// show how things will look like in devdocs
+		priceBeforeDiscount: 420,
+		priceFull: 380,
+		priceMonthly: 380 / 48,
+	},
+];
+
 const SubscriptionLengthPickerExample = () => (
 	<div>
 		<SubscriptionLengthPicker
 			currencyCode="USD"
-			productsWithPrices={ productsWithPrices }
+			productsWithPrices={ productsWithPrices1 }
 			initialValue={ PLAN_BUSINESS_2_YEARS }
+			translate={ x => x }
+		/>
+		<hr />
+
+		<SubscriptionLengthPicker
+			currencyCode="USD"
+			productsWithPrices={ productsWithPrices2 }
+			initialValue={ PLAN_BUSINESS }
 			translate={ x => x }
 		/>
 	</div>

--- a/client/blocks/subscription-length-picker/index.jsx
+++ b/client/blocks/subscription-length-picker/index.jsx
@@ -44,6 +44,9 @@ export class SubscriptionLengthPicker extends React.Component {
 
 	render() {
 		const { productsWithPrices, translate } = this.props;
+		const hasDiscount = productsWithPrices.some(
+			( { priceBeforeDiscount } ) => priceBeforeDiscount
+		);
 		return (
 			<div className="subscription-length-picker">
 				{ ! productsWithPrices && (
@@ -62,21 +65,28 @@ export class SubscriptionLengthPicker extends React.Component {
 				</div>
 
 				<div className="subscription-length-picker__options">
-					{ productsWithPrices.map( ( { plan, planSlug, priceFull, priceMonthly } ) => (
-						<div className="subscription-length-picker__option-container" key={ planSlug }>
-							<SubscriptionLengthOption
-								term={ plan.term }
-								checked={ planSlug === this.state.checked }
-								price={ myFormatCurrency( priceFull, this.props.currencyCode ) }
-								pricePerMonth={ myFormatCurrency( priceMonthly, this.props.currencyCode ) }
-								savePercent={ Math.round(
-									100 * ( 1 - priceMonthly / this.getHighestMonthlyPrice() )
-								) }
-								value={ planSlug }
-								onCheck={ this.handleCheck }
-							/>
-						</div>
-					) ) }
+					{ productsWithPrices.map(
+						( { plan, planSlug, priceBeforeDiscount, priceFull, priceMonthly } ) => (
+							<div className="subscription-length-picker__option-container" key={ planSlug }>
+								<SubscriptionLengthOption
+									type={ hasDiscount ? 'upgrade' : 'new-sale' }
+									term={ plan.term }
+									checked={ planSlug === this.state.checked }
+									price={ myFormatCurrency( priceFull, this.props.currencyCode ) }
+									priceBeforeDiscount={ myFormatCurrency(
+										priceBeforeDiscount,
+										this.props.currencyCode
+									) }
+									pricePerMonth={ myFormatCurrency( priceMonthly, this.props.currencyCode ) }
+									savePercent={ Math.round(
+										100 * ( 1 - priceMonthly / this.getHighestMonthlyPrice() )
+									) }
+									value={ planSlug }
+									onCheck={ this.handleCheck }
+								/>
+							</div>
+						)
+					) }
 				</div>
 			</div>
 		);

--- a/client/blocks/subscription-length-picker/option.jsx
+++ b/client/blocks/subscription-length-picker/option.jsx
@@ -102,7 +102,7 @@ export class SubscriptionLengthOption extends React.Component {
 	}
 
 	renderUpgradeContent() {
-		const { type, price, priceBeforeDiscount, translate } = this.props;
+		const { price, priceBeforeDiscount, translate } = this.props;
 		return (
 			<React.Fragment>
 				<div className="subscription-length-picker__option-header">
@@ -117,13 +117,9 @@ export class SubscriptionLengthOption extends React.Component {
 						false
 					) }
 					<div className="subscription-length-picker__option-price">{ price }</div>
-					{ type === 'upgrade' ? (
-						<div className="subscription-length-picker__option-credit-info">
-							{ translate( 'Credit applied' ) }
-						</div>
-					) : (
-						false
-					) }
+					<div className="subscription-length-picker__option-credit-info">
+						{ translate( 'Credit applied' ) }
+					</div>
 				</div>
 			</React.Fragment>
 		);

--- a/client/blocks/subscription-length-picker/option.jsx
+++ b/client/blocks/subscription-length-picker/option.jsx
@@ -17,10 +17,16 @@ import { localize } from 'i18n-calypso';
 import Badge from 'components/badge';
 import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from 'lib/plans/constants';
 
+const TYPE_NEW_SALE = 'new-sale';
+const TYPE_UPGRADE = 'upgrade';
+
 export class SubscriptionLengthOption extends React.Component {
 	static propTypes = {
+		type: PropTypes.oneOf( [ TYPE_NEW_SALE, TYPE_UPGRADE ] ),
+
 		term: PropTypes.string.isRequired,
 		savePercent: PropTypes.number,
+		priceBeforeDiscount: PropTypes.string,
 		price: PropTypes.string.isRequired,
 		pricePerMonth: PropTypes.string.isRequired,
 		checked: PropTypes.bool,
@@ -30,6 +36,7 @@ export class SubscriptionLengthOption extends React.Component {
 	};
 
 	static defaultProps = {
+		type: TYPE_NEW_SALE,
 		checked: false,
 		savePercent: 0,
 		onCheck: () => null,
@@ -41,7 +48,7 @@ export class SubscriptionLengthOption extends React.Component {
 	}
 
 	render() {
-		const { checked, price, savePercent, term, translate } = this.props;
+		const { type, checked } = this.props;
 		const className = classnames( 'subscription-length-picker__option', {
 			'is-active': checked,
 		} );
@@ -58,30 +65,67 @@ export class SubscriptionLengthOption extends React.Component {
 				</div>
 
 				<div className="subscription-length-picker__option-content">
-					<div className="subscription-length-picker__option-header">
-						<div className="subscription-length-picker__option-term">{ this.getTermText() }</div>
-						<div className="subscription-length-picker__option-discount">
-							{ savePercent ? (
-								<Badge type={ checked ? 'success' : 'warning' }>
-									{ translate( 'Save %(percent)s%%', {
-										args: {
-											percent: savePercent,
-										},
-									} ) }
-								</Badge>
-							) : (
-								false
-							) }
-						</div>
-					</div>
-					<div className="subscription-length-picker__option-description">
-						<div className="subscription-length-picker__option-price">{ price }</div>
-						<div className="subscription-length-picker__option-side-note">
-							{ term !== TERM_MONTHLY ? this.renderPricePerMonth() : false }
-						</div>
-					</div>
+					{ type === TYPE_NEW_SALE ? this.renderNewSaleContent() : this.renderUpgradeContent() }
 				</div>
 			</label>
+		);
+	}
+
+	renderNewSaleContent() {
+		const { checked, price, savePercent, term, translate } = this.props;
+		return (
+			<React.Fragment>
+				<div className="subscription-length-picker__option-header">
+					<div className="subscription-length-picker__option-term">{ this.getTermText() }</div>
+					<div className="subscription-length-picker__option-discount">
+						{ savePercent ? (
+							<Badge type={ checked ? 'success' : 'warning' }>
+								{ translate( 'Save %(percent)s%%', {
+									args: {
+										percent: savePercent,
+									},
+								} ) }
+							</Badge>
+						) : (
+							false
+						) }
+					</div>
+				</div>
+				<div className="subscription-length-picker__option-description">
+					<div className="subscription-length-picker__option-price">{ price }</div>
+					<div className="subscription-length-picker__option-side-note">
+						{ term !== TERM_MONTHLY ? this.renderPricePerMonth() : false }
+					</div>
+				</div>
+			</React.Fragment>
+		);
+	}
+
+	renderUpgradeContent() {
+		const { type, price, priceBeforeDiscount, translate } = this.props;
+		return (
+			<React.Fragment>
+				<div className="subscription-length-picker__option-header">
+					<div className="subscription-length-picker__option-term">{ this.getTermText() }</div>
+				</div>
+				<div className="subscription-length-picker__option-description">
+					{ priceBeforeDiscount ? (
+						<div className="subscription-length-picker__option-old-price">
+							{ priceBeforeDiscount }
+						</div>
+					) : (
+						false
+					) }
+					<div className="subscription-length-picker__option-price">{ price }</div>
+					{ type === 'upgrade' ? (
+						<div className="subscription-length-picker__option-credit-info">
+							{ translate( 'Credit applied' ) }
+						</div>
+					) : (
+						false
+					) }
+				</div>
+			</React.Fragment>
 		);
 	}
 

--- a/client/blocks/subscription-length-picker/style.scss
+++ b/client/blocks/subscription-length-picker/style.scss
@@ -51,6 +51,9 @@
     }
   }
 
+  .subscription-length-picker__option-content {
+    flex-grow: 1;
+  }
   .subscription-length-picker__option-header,
   .subscription-length-picker__option-description {
     width: 100%;
@@ -60,6 +63,8 @@
   .subscription-length-picker__option-price,
   .subscription-length-picker__option-discount,
   .subscription-length-picker__option-side-note,
+  .subscription-length-picker__option-old-price,
+  .subscription-length-picker__option-credit-info,
   .subscription-length-picker__option-description {
     display: inline-block;
     vertical-align: middle;
@@ -83,7 +88,28 @@
     font-size: 16px;
   }
 
+  .subscription-length-picker__option-credit-info {
+    float: right;
+    color: $gray;
+  }
+
+  .subscription-length-picker__option-old-price {
+    position: relative;
+    display: inline-block;
+    color: $gray-dark;
+    margin-right: 5px;
+
+    &::before {
+      border-bottom: 3px solid $alert-green;
+      position: absolute;
+      content: '';
+      width: 100%;
+      height: 50%;
+    }
+  }
+
   .subscription-length-picker__option-price {
+    display: inline-block;
     color: $gray-dark;
   }
 
@@ -99,5 +125,8 @@
 
   &.is-active {
     border: 3px solid $alert-green;
+    .subscription-length-picker__option-credit-info {
+      color: $alert-green;
+    }
   }
 }


### PR DESCRIPTION
Upgrading to another plan requires a bit different design of Subscription Length picker. This PR introduces it. This is related to 2-year plans project (p9jf6J-eR-p2)

Test plan:
1. Run unit tests
2. Go to http://calypso.localhost:3000/devdocs/blocks/subscription-length-picker and confirm it looks like this:

<img width="1503" alt="zrzut ekranu 2018-04-12 o 10 09 59" src="https://user-images.githubusercontent.com/205419/38664370-acc12e48-3e39-11e8-8e87-45803b24c1fa.png">
