### PR TITLE
Analytics: Refactor /sharing page view tracking

### DIFF
--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -12,8 +12,6 @@ import { translate } from 'i18n-calypso';
  * Internal Dependencies
  */
 import notices from 'notices';
-import { pageView } from 'lib/analytics';
-import { sectionify } from 'lib/route';
 import Sharing from './main';
 import SharingButtons from './buttons/buttons';
 import SharingConnections from './connections/connections';
@@ -27,8 +25,6 @@ import {
 } from 'state/sites/selectors';
 import versionCompare from 'lib/version-compare';
 
-const analyticsPageTitle = 'Sharing';
-
 export const layout = ( context, next ) => {
 	const { contentComponent, path } = context;
 
@@ -37,13 +33,10 @@ export const layout = ( context, next ) => {
 };
 
 export const connections = ( context, next ) => {
-	const { store, path } = context;
+	const { store } = context;
 	const state = store.getState();
 
 	const siteId = getSelectedSiteId( state );
-
-	const basePath = sectionify( path );
-	const baseAnalyticsPath = siteId ? basePath + '/:site' : basePath;
 
 	if ( siteId && ! canCurrentUser( state, siteId, 'publish_posts' ) ) {
 		notices.error(
@@ -66,8 +59,6 @@ export const connections = ( context, next ) => {
 				: '/stats'
 		);
 	} else {
-		pageView.record( baseAnalyticsPath, analyticsPageTitle + ' > Connections' );
-
 		context.contentComponent = createElement( SharingConnections );
 	}
 
@@ -75,15 +66,10 @@ export const connections = ( context, next ) => {
 };
 
 export const buttons = ( context, next ) => {
-	const { store, path } = context;
+	const { store } = context;
 	const state = store.getState();
 
 	const siteId = getSelectedSiteId( state );
-
-	const basePath = sectionify( path );
-	const baseAnalyticsPath = siteId ? basePath + '/:site' : basePath;
-
-	pageView.record( baseAnalyticsPath, analyticsPageTitle + ' > Sharing Buttons' );
 
 	if ( siteId && ! canCurrentUser( state, siteId, 'manage_options' ) ) {
 		notices.error(

--- a/client/my-sites/sharing/main.jsx
+++ b/client/my-sites/sharing/main.jsx
@@ -24,6 +24,7 @@ import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import SectionNav from 'components/section-nav';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 export const Sharing = ( {
 	contentComponent,
@@ -61,6 +62,12 @@ export const Sharing = ( {
 
 	return (
 		<Main className="sharing">
+			<PageViewTracker
+				path={ `/sharing${ 0 === path.indexOf( '/sharing/buttons' ) ? '/buttons' : '' }/:site` }
+				title={ `Sharing > ${
+					0 === path.indexOf( '/sharing/buttons' ) ? 'Buttons' : 'Connections'
+				}` }
+			/>
 			<DocumentHead title={ translate( 'Sharing' ) } />
 			{ siteId && <QueryJetpackModules siteId={ siteId } /> }
 			<SidebarNavigation />

--- a/client/my-sites/sharing/main.jsx
+++ b/client/my-sites/sharing/main.jsx
@@ -60,13 +60,13 @@ export const Sharing = ( {
 
 	const selected = find( filters, { route: path } );
 
+	const isButtonsPage = 0 === path.indexOf( '/sharing/buttons' );
+
 	return (
 		<Main className="sharing">
 			<PageViewTracker
-				path={ `/sharing${ 0 === path.indexOf( '/sharing/buttons' ) ? '/buttons' : '' }/:site` }
-				title={ `Sharing > ${
-					0 === path.indexOf( '/sharing/buttons' ) ? 'Buttons' : 'Connections'
-				}` }
+				path={ `/sharing${ isButtonsPage ? '/buttons' : '' }/:site` }
+				title={ `Sharing > ${ isButtonsPage ? 'Buttons' : 'Connections' }` }
 			/>
 			<DocumentHead title={ translate( 'Sharing' ) } />
 			{ siteId && <QueryJetpackModules siteId={ siteId } /> }


### PR DESCRIPTION
Replace direct `analytics.pageView.record` calls with `PageViewTracker` in `/sharing`.

Check out the updated recommendations on page view tracking:
https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/docs/page-views.md

## Testing instructions

- Open `/sharing` and navigate around making sure that page views are recorded for each page, with the expected path.