### PR TITLE
Jetpack connect: Remove unused site-info filters

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2231,7 +2231,7 @@ Undocumented.prototype.getExport = function( siteId, exportId, fn ) {
 Undocumented.prototype.getSiteConnectInfo = function( targetUrl, filters ) {
 	const parsedUrl = url.parse( targetUrl );
 	let endpointUrl = `/connect/site-info/${ parsedUrl.protocol.slice( 0, -1 ) }/${ parsedUrl.host }`;
-	let params = {
+	const params = {
 		filters: filters,
 		apiVersion: '1.1',
 	};

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2237,7 +2237,6 @@ Undocumented.prototype.getSiteConnectInfo = function( targetUrl ) {
 
 	return this.wpcom.req.get( `${ endpointUrl }`, {
 		apiVersion: '1.1',
-		lockImplementation: '1',
 	} );
 };
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2225,25 +2225,20 @@ Undocumented.prototype.getExport = function( siteId, exportId, fn ) {
  * Check different info about WordPress and Jetpack status on a url
  *
  * @param {String} targetUrl - The url of the site to check
- * @param {?Array<string>} filters - Array of filters to run
  * @returns {Promise}  promise
  */
-Undocumented.prototype.getSiteConnectInfo = function( targetUrl, filters = null ) {
+Undocumented.prototype.getSiteConnectInfo = function( targetUrl ) {
 	const parsedUrl = url.parse( targetUrl );
 	let endpointUrl = `/connect/site-info/${ parsedUrl.protocol.slice( 0, -1 ) }/${ parsedUrl.host }`;
-	const params = Object.assign(
-		{
-			apiVersion: '1.1',
-			lockImplementation: '1',
-		},
-		Array.isArray( filters ) && { filters: filters.join() }
-	);
 
 	if ( parsedUrl.path && parsedUrl.path !== '/' ) {
 		endpointUrl += parsedUrl.path.replace( /\//g, '::' );
 	}
 
-	return this.wpcom.req.get( `${ endpointUrl }`, params );
+	return this.wpcom.req.get( `${ endpointUrl }`, {
+		apiVersion: '1.1',
+		lockImplementation: '1',
+	} );
 };
 
 /**

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2225,7 +2225,7 @@ Undocumented.prototype.getExport = function( siteId, exportId, fn ) {
  * Check different info about WordPress and Jetpack status on a url
  *
  * @param {String} targetUrl - The url of the site to check
- * @param {String} filters - Comma separated string with the filters to run
+ * @param {?Array<string>} filters - Array of filters to run
  * @returns {Promise}  promise
  */
 Undocumented.prototype.getSiteConnectInfo = function( targetUrl, filters = null ) {
@@ -2235,7 +2235,7 @@ Undocumented.prototype.getSiteConnectInfo = function( targetUrl, filters = null 
 		{
 			apiVersion: '1.1',
 		},
-		filters && { filters }
+		Array.isArray( filters ) && { filters: filters.join() }
 	);
 
 	if ( parsedUrl.path && parsedUrl.path !== '/' ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2235,9 +2235,7 @@ Undocumented.prototype.getSiteConnectInfo = function( targetUrl ) {
 		endpointUrl += parsedUrl.path.replace( /\//g, '::' );
 	}
 
-	return this.wpcom.req.get( `${ endpointUrl }`, {
-		apiVersion: '1.1',
-	} );
+	return this.wpcom.req.get( endpointUrl );
 };
 
 /**

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2228,13 +2228,15 @@ Undocumented.prototype.getExport = function( siteId, exportId, fn ) {
  * @param {String} filters - Comma separated string with the filters to run
  * @returns {Promise}  promise
  */
-Undocumented.prototype.getSiteConnectInfo = function( targetUrl, filters ) {
+Undocumented.prototype.getSiteConnectInfo = function( targetUrl, filters = null ) {
 	const parsedUrl = url.parse( targetUrl );
 	let endpointUrl = `/connect/site-info/${ parsedUrl.protocol.slice( 0, -1 ) }/${ parsedUrl.host }`;
-	const params = {
-		filters: filters,
-		apiVersion: '1.1',
-	};
+	const params = Object.assign(
+		{
+			apiVersion: '1.1',
+		},
+		filters && { filters }
+	);
 
 	if ( parsedUrl.path && parsedUrl.path !== '/' ) {
 		endpointUrl += parsedUrl.path.replace( /\//g, '::' );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2234,6 +2234,7 @@ Undocumented.prototype.getSiteConnectInfo = function( targetUrl, filters = null 
 	const params = Object.assign(
 		{
 			apiVersion: '1.1',
+			lockImplementation: '1',
 		},
 		Array.isArray( filters ) && { filters: filters.join() }
 	);


### PR DESCRIPTION
- `const` over `let`
- Remove `filters` argument (unused since #22139)
- ~Pass new `lockImplementation` param to API~

Splitting the implementation changes into another PR.

## Testing
1. Ensure the endpoint at `/jetpack/connect` continues to respond correctly.
1. Look at the network request to the endpoint. Verify that the request looks correct.
1. Ensure site connection is unaffected.
1. ~Use with and without D11731-code to see the param processed by the endpoint.~