### PR TITLE
Analytics: refactor Sharing page view tracking

### DIFF
--- a/client/my-sites/sharing/buttons/buttons.jsx
+++ b/client/my-sites/sharing/buttons/buttons.jsx
@@ -15,6 +15,7 @@ import { localize } from 'i18n-calypso';
  */
 import ButtonsAppearance from './appearance';
 import ButtonsOptions from './options';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import QuerySharingButtons from 'components/data/query-sharing-buttons';
@@ -137,6 +138,7 @@ class SharingButtons extends Component {
 				id="sharing-buttons"
 				className="sharing-settings sharing-buttons"
 			>
+				<PageViewTracker path="/sharing/buttons/:site" title="Sharing > Sharing Buttons" />
 				<QuerySiteSettings siteId={ siteId } />
 				<QuerySharingButtons siteId={ siteId } />
 				{ isJetpack && <QueryJetpackModules siteId={ siteId } /> }

--- a/client/my-sites/sharing/connections/connections.jsx
+++ b/client/my-sites/sharing/connections/connections.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryKeyringConnections from 'components/data/query-keyring-connections';
 import QueryKeyringServices from 'components/data/query-keyring-services';
 import QueryPublicizeConnections from 'components/data/query-publicize-connections';
@@ -19,6 +20,7 @@ import SharingServicesGroup from './services-group';
 
 const SharingConnections = ( { translate } ) => (
 	<div className="sharing-settings sharing-connections">
+		<PageViewTracker path="/sharing/:site" title="Sharing > Connections" />
 		<QueryKeyringConnections />
 		<QueryKeyringServices />
 		<QueryPublicizeConnections selectedSite />

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -12,8 +12,6 @@ import { translate } from 'i18n-calypso';
  * Internal Dependencies
  */
 import notices from 'notices';
-import { pageView } from 'lib/analytics';
-import { sectionify } from 'lib/route';
 import Sharing from './main';
 import SharingButtons from './buttons/buttons';
 import SharingConnections from './connections/connections';
@@ -27,8 +25,6 @@ import {
 } from 'state/sites/selectors';
 import versionCompare from 'lib/version-compare';
 
-const analyticsPageTitle = 'Sharing';
-
 export const layout = ( context, next ) => {
 	const { contentComponent, path } = context;
 
@@ -37,13 +33,9 @@ export const layout = ( context, next ) => {
 };
 
 export const connections = ( context, next ) => {
-	const { store, path } = context;
+	const { store } = context;
 	const state = store.getState();
-
 	const siteId = getSelectedSiteId( state );
-
-	const basePath = sectionify( path );
-	const baseAnalyticsPath = siteId ? basePath + '/:site' : basePath;
 
 	if ( siteId && ! canCurrentUser( state, siteId, 'publish_posts' ) ) {
 		notices.error(
@@ -66,8 +58,6 @@ export const connections = ( context, next ) => {
 				: '/stats'
 		);
 	} else {
-		pageView.record( baseAnalyticsPath, analyticsPageTitle + ' > Connections' );
-
 		context.contentComponent = createElement( SharingConnections );
 	}
 
@@ -75,15 +65,9 @@ export const connections = ( context, next ) => {
 };
 
 export const buttons = ( context, next ) => {
-	const { store, path } = context;
+	const { store } = context;
 	const state = store.getState();
-
 	const siteId = getSelectedSiteId( state );
-
-	const basePath = sectionify( path );
-	const baseAnalyticsPath = siteId ? basePath + '/:site' : basePath;
-
-	pageView.record( baseAnalyticsPath, analyticsPageTitle + ' > Sharing Buttons' );
 
 	if ( siteId && ! canCurrentUser( state, siteId, 'manage_options' ) ) {
 		notices.error(


### PR DESCRIPTION
Replace direct `analytics.pageView.record` calls with `PageViewTracker` in `/sharing`.

Check out the updated recommendations on page view tracking:
https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/docs/page-views.md

### Testing instructions
1. Set `localStorage.setItem( 'debug', 'calypso:analytics:tracks' )` in the browser console to enable the debug.
2. Routes to check: `/sharing`, `/sharing/:site`, `/sharing/buttons/:site`.