### PR TITLE
Analytics: Refactor Post Editor page view tracking

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -191,6 +191,32 @@ function startEditingPostCopy( site, postToCopyId, context ) {
 		} );
 }
 
+const getAnalyticsPathAndTitle = ( postType, postId, postToCopyId ) => {
+	const isPost = 'post' === postType;
+	const isPage = 'page' === postType;
+	const isNew = postToCopyId || ! postId;
+	const isEdit = !! postId;
+
+	if ( isPost && isNew ) {
+		return [ '/post/:site', 'Post > New' ];
+	}
+	if ( isPost && isEdit ) {
+		return [ '/post/:site/:post_id', 'Post > Edit' ];
+	}
+	if ( isPage && isNew ) {
+		return [ '/page/:site', 'Page > New' ];
+	}
+	if ( isPage && isEdit ) {
+		return [ '/page/:site/:post_id', 'Page > Edit' ];
+	}
+	if ( isNew ) {
+		return [ `/edit/${ postType }/:site`, 'Custom Post Type > New' ];
+	}
+	if ( isEdit ) {
+		return [ `/edit/${ postType }/:site/:post_id`, 'Custom Post Type > Edit' ];
+	}
+};
+
 export default {
 	post: function( context, next ) {
 		const postType = determinePostType( context );
@@ -260,29 +286,11 @@ export default {
 			unsubscribe = context.store.subscribe( startEditingOnSiteSelected );
 		}
 
-		let analyticsPath, analyticsTitle;
-		switch ( postType ) {
-			case 'post':
-				analyticsPath = '/post/:site';
-				analyticsTitle = 'Post > ';
-				break;
-			case 'page':
-				analyticsPath = '/page/:site';
-				analyticsTitle = 'Page > ';
-				break;
-			default:
-				analyticsPath = `/edit/${ postType }/:site`;
-				analyticsTitle = 'Custom Post Type > ';
-		}
-		if ( postToCopyId ) {
-			analyticsTitle += 'New';
-		} else if ( postID ) {
-			analyticsPath += '/:post_id';
-			analyticsTitle += 'Edit';
-		} else {
-			analyticsTitle += 'New';
-		}
-
+		const [ analyticsPath, analyticsTitle ] = getAnalyticsPathAndTitle(
+			postType,
+			postID,
+			postToCopyId
+		);
 		renderEditor( context, { analyticsPath, analyticsTitle } );
 
 		next();

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -69,6 +69,7 @@ import { isSitePreviewable } from 'state/sites/selectors';
 import { removep } from 'lib/formatting';
 import QuickSaveButtons from 'post-editor/editor-ground-control/quick-save-buttons';
 import EditorRevisionsDialog from 'post-editor/editor-revisions/dialog';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 export class PostEditor extends React.Component {
 	static propTypes = {
@@ -86,6 +87,8 @@ export class PostEditor extends React.Component {
 		hasBrokenPublicizeConnection: PropTypes.bool,
 		editPost: PropTypes.func,
 		type: PropTypes.string,
+		analyticsPath: PropTypes.string,
+		analyticsTitle: PropTypes.string,
 	};
 
 	state = this.getDefaultState();
@@ -284,6 +287,7 @@ export class PostEditor extends React.Component {
 		} );
 		return (
 			<div className={ classes }>
+				<PageViewTracker path={ this.props.analyticsPath } title={ this.props.analyticsTitle } />
 				<QueryPreferences />
 				<EditorConfirmationSidebar
 					handlePreferenceChange={ this.handleConfirmationSidebarPreferenceChange }


### PR DESCRIPTION
Replace direct `analytics.pageView.record` calls with `PageViewTracker` in Post Editor.

Check out the updated recommendations on page view tracking:
https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/docs/page-views.md

## Testing instructions

- Open the post editor (to create a page/post/custom post type, or to edit one of those) and navigate around making sure that page views are recorded for each page, with the expected path.