### PR TITLE
Analytics: Add Tracks event for NPS survey submissions and dismissals.

### DIFF
--- a/client/state/nps-survey/actions.js
+++ b/client/state/nps-survey/actions.js
@@ -10,6 +10,7 @@ import wpcom from 'lib/wp';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import {
 	NPS_SURVEY_SET_ELIGIBILITY,
 	NPS_SURVEY_MARK_SHOWN_THIS_SESSION,
@@ -62,6 +63,9 @@ export function submitNpsSurvey( surveyName, score ) {
 		debug( 'Submitting NPS survey...' );
 		dispatch( submitNpsSurveyRequesting( surveyName, score ) );
 
+		analytics.mc.bumpStat( 'calypso_nps_survey', 'survey_submitted' );
+		analytics.tracks.recordEvent( 'calypso_nps_survey_submitted' );
+
 		return wpcom
 			.undocumented()
 			.submitNPSSurvey( surveyName, score )
@@ -81,6 +85,9 @@ export function submitNpsSurveyWithNoScore( surveyName ) {
 		debug( 'Submitting NPS survey with no score...' );
 		dispatch( submitNpsSurveyWithNoScoreRequesting( surveyName ) );
 
+		analytics.mc.bumpStat( 'calypso_nps_survey', 'survey_dismiseed' );
+		analytics.tracks.recordEvent( 'calypso_nps_survey_dismissed' );
+
 		return wpcom
 			.undocumented()
 			.dismissNPSSurvey( surveyName )
@@ -99,6 +106,9 @@ export function sendNpsSurveyFeedback( surveyName, feedback ) {
 	return dispatch => {
 		debug( 'Sending NPS survey feedback...' );
 		dispatch( sendNpsSurveyFeedbackRequesting( surveyName, feedback ) );
+
+		analytics.mc.bumpStat( 'calypso_nps_survey', 'feedback_submitted' );
+		analytics.tracks.recordEvent( 'calypso_nps_survey_feedback_submitted' );
 
 		return wpcom
 			.undocumented()

--- a/client/state/nps-survey/actions.js
+++ b/client/state/nps-survey/actions.js
@@ -85,7 +85,7 @@ export function submitNpsSurveyWithNoScore( surveyName ) {
 		debug( 'Submitting NPS survey with no score...' );
 		dispatch( submitNpsSurveyWithNoScoreRequesting( surveyName ) );
 
-		analytics.mc.bumpStat( 'calypso_nps_survey', 'survey_dismiseed' );
+		analytics.mc.bumpStat( 'calypso_nps_survey', 'survey_dismissed' );
 		analytics.tracks.recordEvent( 'calypso_nps_survey_dismissed' );
 
 		return wpcom

--- a/client/state/nps-survey/test/actions.js
+++ b/client/state/nps-survey/test/actions.js
@@ -77,7 +77,7 @@ describe( 'actions', () => {
 			expect( analytics.mc.bumpStat.mock.calls.length ).toBe( 1 );
 			expect( analytics.mc.bumpStat.mock.calls[ 0 ] ).toEqual( [
 				'calypso_nps_survey',
-				'survey_dismiseed',
+				'survey_dismissed',
 			] );
 
 			expect( analytics.tracks.recordEvent.mock.calls.length ).toBe( 1 );

--- a/client/state/nps-survey/test/actions.js
+++ b/client/state/nps-survey/test/actions.js
@@ -1,14 +1,13 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import {
+	submitNpsSurvey,
+	submitNpsSurveyWithNoScore,
+	sendNpsSurveyFeedback,
 	sendNpsSurveyFeedbackRequesting,
 	sendNpsSurveyFeedbackSuccess,
 	sendNpsSurveyFeedbackFailure,
@@ -19,28 +18,126 @@ import {
 	NPS_SURVEY_SEND_FEEDBACK_REQUEST_FAILURE,
 } from 'state/action-types';
 
+// mock modules
+jest.mock( 'lib/wp', () => ( {
+	undocumented: () => ( {
+		// TODO: use mockResolvedValue instead when we update jest to 22.2 or later
+		submitNPSSurvey: jest.fn().mockReturnValue( Promise.resolve() ),
+		dismissNPSSurvey: jest.fn().mockReturnValue( Promise.resolve() ),
+		sendNPSSurveyFeedback: jest.fn().mockReturnValue( Promise.resolve() ),
+	} ),
+} ) );
+jest.mock( 'lib/analytics', () => ( {
+	mc: { bumpStat: jest.fn() },
+	tracks: { recordEvent: jest.fn() },
+} ) );
+
 describe( 'actions', () => {
-	describe( 'creators functions', () => {
-		test( '#sendNpsSurveyFeedbackRequesting()', () => {
+	const dispatch = jest.fn();
+
+	describe( '#submitNpsSurvey()', () => {
+		beforeEach( () => {
+			analytics.mc.bumpStat.mockClear();
+			analytics.tracks.recordEvent.mockClear();
+			dispatch.mockClear();
+		} );
+
+		test( 'should track the successful survey submission', async () => {
+			expect( analytics.mc.bumpStat.mock.calls.length ).toBe( 0 );
+			expect( analytics.tracks.recordEvent.mock.calls.length ).toBe( 0 );
+
+			await submitNpsSurvey( 'nps_test', 10 )( dispatch );
+
+			expect( analytics.mc.bumpStat.mock.calls.length ).toBe( 1 );
+			expect( analytics.mc.bumpStat.mock.calls[ 0 ] ).toEqual( [
+				'calypso_nps_survey',
+				'survey_submitted',
+			] );
+
+			expect( analytics.tracks.recordEvent.mock.calls.length ).toBe( 1 );
+			expect( analytics.tracks.recordEvent.mock.calls[ 0 ] ).toEqual( [
+				'calypso_nps_survey_submitted',
+			] );
+		} );
+	} );
+
+	describe( '#submitNpsSurveyWithNoScore', () => {
+		beforeEach( () => {
+			analytics.mc.bumpStat.mockClear();
+			analytics.tracks.recordEvent.mockClear();
+			dispatch.mockClear();
+		} );
+
+		test( 'should track the successful survey dismissal', async () => {
+			expect( analytics.mc.bumpStat.mock.calls.length ).toBe( 0 );
+			expect( analytics.tracks.recordEvent.mock.calls.length ).toBe( 0 );
+
+			await submitNpsSurveyWithNoScore( 'nps_test' )( dispatch );
+
+			expect( analytics.mc.bumpStat.mock.calls.length ).toBe( 1 );
+			expect( analytics.mc.bumpStat.mock.calls[ 0 ] ).toEqual( [
+				'calypso_nps_survey',
+				'survey_dismiseed',
+			] );
+
+			expect( analytics.tracks.recordEvent.mock.calls.length ).toBe( 1 );
+			expect( analytics.tracks.recordEvent.mock.calls[ 0 ] ).toEqual( [
+				'calypso_nps_survey_dismissed',
+			] );
+		} );
+	} );
+
+	describe( '#sendNpsSurveyFeedback', () => {
+		beforeEach( () => {
+			analytics.mc.bumpStat.mockClear();
+			analytics.tracks.recordEvent.mockClear();
+			dispatch.mockClear();
+		} );
+
+		test( 'should track the successful feedback submission', async () => {
+			expect( analytics.mc.bumpStat.mock.calls.length ).toBe( 0 );
+			expect( analytics.tracks.recordEvent.mock.calls.length ).toBe( 0 );
+
+			await sendNpsSurveyFeedback( 'nps_test', 'dummy feedback data' )( dispatch );
+
+			expect( analytics.mc.bumpStat.mock.calls.length ).toBe( 1 );
+			expect( analytics.mc.bumpStat.mock.calls[ 0 ] ).toEqual( [
+				'calypso_nps_survey',
+				'feedback_submitted',
+			] );
+
+			expect( analytics.tracks.recordEvent.mock.calls.length ).toBe( 1 );
+			expect( analytics.tracks.recordEvent.mock.calls[ 0 ] ).toEqual( [
+				'calypso_nps_survey_feedback_submitted',
+			] );
+		} );
+	} );
+
+	describe( '#sendNpsSurveyFeedbackRequesting()', () => {
+		test( 'should create a valid NPS_SURVEY_SEND_FEEDBACK_REQUESTING action', () => {
 			const surveyName = 'dummy-nps-survey';
 			const feedback = 'dummy contextual feedback';
 			const action = sendNpsSurveyFeedbackRequesting( surveyName, feedback );
-			expect( action ).to.eql( {
+			expect( action ).toEqual( {
 				type: NPS_SURVEY_SEND_FEEDBACK_REQUESTING,
 				surveyName,
 				feedback,
 			} );
 		} );
+	} );
 
-		test( '#sendNpsSurveyFeedbackSuccess()', () => {
+	describe( '#sendNpsSurveyFeedbackSuccess()', () => {
+		test( 'should create a valid NPS_SURVEY_SEND_FEEDBACK_REQUEST_SUCCESS action', () => {
 			const action = sendNpsSurveyFeedbackSuccess();
-			expect( action ).to.eql( { type: NPS_SURVEY_SEND_FEEDBACK_REQUEST_SUCCESS } );
+			expect( action ).toEqual( { type: NPS_SURVEY_SEND_FEEDBACK_REQUEST_SUCCESS } );
 		} );
+	} );
 
-		test( '#sendNpsSurveyFeedbackFailure()', () => {
+	describe( '#sendNpsSurveyFeedbackFailure()', () => {
+		test( 'should create a valid NPS_SURVEY_SEND_FEEDBACK_REQUEST_FAILURE action', () => {
 			const error = { message: 'dummy error message' };
 			const action = sendNpsSurveyFeedbackFailure( error );
-			expect( action ).to.eql( {
+			expect( action ).toEqual( {
 				type: NPS_SURVEY_SEND_FEEDBACK_REQUEST_FAILURE,
 				error,
 			} );


### PR DESCRIPTION
This PR adds Tracks events to the NPS survey.

## Testing Instructions

- All `state/nps-survey` test cases should be passed.
- Set `localStorage.setItem( 'debug', 'calypso:analytics:tracks' )` in the browser console to enable the debug.
- Run `npsSurvey()` in the Reader page to display the NPS survey dialog.
- Click outside of the form or press the Close button to dismiss the dialog, you will see the `calypso_nps_survey_dismissed` event.
  <img width="718" alt="2018-04-12 11 44 52" src="https://user-images.githubusercontent.com/212034/38684970-db9bc92c-3eab-11e8-8b98-8046a559a11d.png">
- Select a score and click on the Submit button, `calypso_nps_survey_submitted` event should be fired.
  <img width="741" alt="2018-04-12 11 44 18" src="https://user-images.githubusercontent.com/212034/38684982-e1ee147e-3eab-11e8-9b28-e0087abba814.png">
- Enter any text into the textbox and click on the Submit button. It should trigger `calypso_nps_survey_feedback_submitted` event.
  <img width="797" alt="2018-04-12 11 45 30" src="https://user-images.githubusercontent.com/212034/38684991-e7534100-3eab-11e8-9e12-7a51e78a4092.png">
- Nothing is recorded even if you press the Close button below the textbox.

cc @sararosso 