### PR TITLE
Analytics: refactor Plugins page view tracking

### DIFF
--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -26,6 +26,7 @@ import Button from 'components/button';
 import Card from 'components/card';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import HoldList from './hold-list';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import WarningList from './warning-list';
 
 export const EligibilityWarnings = ( {
@@ -55,6 +56,7 @@ export const EligibilityWarnings = ( {
 
 	return (
 		<div className={ classes }>
+			<PageViewTracker path="plugins/:plugin/eligibility/:site" title="Plugins > Eligibility" />
 			<QueryEligibility siteId={ siteId } />
 			<TrackComponentView
 				eventName="calypso_automated_transfer_eligibility_show_warnings"

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import page from 'page';
-import { capitalize, includes, some } from 'lodash';
+import { includes, some } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -31,16 +31,6 @@ let lastPluginsListVisited, lastPluginsQuerystring;
 
 function renderSinglePlugin( context, siteUrl ) {
 	const pluginSlug = decodeURIComponent( context.params.plugin );
-	const site = getSelectedSite( context.store.getState() );
-	const analyticsPageTitle = 'Plugins';
-
-	let baseAnalyticsPath = 'plugins/:plugin';
-
-	if ( site ) {
-		baseAnalyticsPath += '/:site';
-	}
-
-	analytics.pageView.record( baseAnalyticsPath, `${ analyticsPageTitle } > Plugin Details` );
 
 	// Scroll to the top
 	window.scrollTo( 0, 0 );
@@ -87,16 +77,6 @@ function renderPluginList( context, basePath ) {
 	if ( search ) {
 		analytics.ga.recordEvent( 'Plugins', 'Search', 'Search term', search );
 	}
-
-	const analyticsPageTitle =
-		'Plugins' +
-		( context.params.pluginFilter ? ' ' + capitalize( context.params.pluginFilter ) : '' );
-
-	let baseAnalyticsPath = 'plugins/manage';
-	if ( site ) {
-		baseAnalyticsPath += '/:site';
-	}
-	analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
 }
 
 // The plugin browser can be rendered by the `/plugins/:plugin/:site_id?` route. In that case,
@@ -116,14 +96,6 @@ function renderPluginsBrowser( context ) {
 
 	lastPluginsListVisited = getPathWithoutSiteSlug( context, site );
 	lastPluginsQuerystring = context.querystring;
-
-	const analyticsPageTitle = 'Plugin Browser' + ( category ? ': ' + category : '' );
-	let baseAnalyticsPath = 'plugins' + ( category ? '/' + category : '' );
-	if ( site ) {
-		baseAnalyticsPath += '/:site';
-	}
-
-	analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
 
 	context.primary = React.createElement( PluginBrowser, {
 		path: context.path,
@@ -146,14 +118,8 @@ function renderPluginWarnings( context ) {
 function renderProvisionPlugins( context ) {
 	const state = context.store.getState();
 	const section = getSection( state );
-	const site = getSelectedSite( state );
-	context.store.dispatch( setSection( Object.assign( {}, section, { secondary: false } ) ) );
-	let baseAnalyticsPath = 'plugins/setup';
-	if ( site ) {
-		baseAnalyticsPath += '/:site';
-	}
 
-	analytics.pageView.record( baseAnalyticsPath, 'Jetpack Plugins Setup' );
+	context.store.dispatch( setSection( Object.assign( {}, section, { secondary: false } ) ) );
 
 	context.primary = React.createElement( PlanSetup, {
 		whitelist: context.query.only || false,

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -499,10 +499,6 @@ class PlansSetup extends React.Component {
 		);
 	};
 
-	renderPageViewTracker = () => {
-		return <PageViewTracker path="/plugins/setup/:site" title="Jetpack Plugins Setup" />;
-	};
-
 	render() {
 		const { sitesInitialized, translate } = this.props;
 		const site = this.props.selectedSite;
@@ -553,7 +549,7 @@ class PlansSetup extends React.Component {
 
 		return (
 			<div className="jetpack-plugins-setup">
-				{ this.renderPageViewTracker() }
+				<PageViewTracker path="/plugins/setup/:site" title="Jetpack Plugins Setup" />;
 				<QueryPluginKeys siteId={ site.ID } />
 				<h1 className="jetpack-plugins-setup__header">
 					{ translate( 'Setting up your %(plan)s Plan', {

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -22,6 +22,7 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import Spinner from 'components/spinner';
 import QueryPluginKeys from 'components/data/query-plugin-keys';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import PluginItem from 'my-sites/plugins/plugin-item/plugin-item';
@@ -498,6 +499,10 @@ class PlansSetup extends React.Component {
 		);
 	};
 
+	renderPageViewTracker = () => {
+		return <PageViewTracker path="/plugins/setup/:site" title="Jetpack Plugins Setup" />;
+	};
+
 	render() {
 		const { sitesInitialized, translate } = this.props;
 		const site = this.props.selectedSite;
@@ -548,6 +553,7 @@ class PlansSetup extends React.Component {
 
 		return (
 			<div className="jetpack-plugins-setup">
+				{ this.renderPageViewTracker() }
 				<QueryPluginKeys siteId={ site.ID } />
 				<h1 className="jetpack-plugins-setup__header">
 					{ translate( 'Setting up your %(plan)s Plan', {

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
-import { find, flow, isEmpty, some } from 'lodash';
+import { capitalize, find, flow, isEmpty, some } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -24,6 +24,7 @@ import EmptyContent from 'components/empty-content';
 import PluginsStore from 'lib/plugins/store';
 import { fetchPluginData as wporgFetchPluginData } from 'state/plugins/wporg/actions';
 import { getPlugin } from 'state/plugins/wporg/selectors';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import PluginsList from './plugins-list';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
@@ -285,6 +286,16 @@ export class PluginsMain extends Component {
 		return <DocumentHead title={ this.props.translate( 'Plugins', { textOnly: true } ) } />;
 	}
 
+	renderPageViewTracking() {
+		const { selectedSiteId, filter } = this.props;
+
+		const analyticsPageTitle = filter ? 'Plugins > ' + capitalize( filter ) : 'Plugins';
+
+		const analyticsPath = selectedSiteId ? '/plugins/manage/:site' : '/plugins/manage';
+
+		return <PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />;
+	}
+
 	renderPluginsContent() {
 		const { plugins = [] } = this.state;
 		const { filter, search } = this.props;
@@ -442,6 +453,7 @@ export class PluginsMain extends Component {
 			return (
 				<Main>
 					{ this.renderDocumentHead() }
+					{ this.renderPageViewTracking() }
 					<SidebarNavigation />
 					<JetpackManageErrorPage
 						template="optInManage"
@@ -475,6 +487,7 @@ export class PluginsMain extends Component {
 			<Main wideLayout>
 				<NonSupportedJetpackVersionNotice />
 				{ this.renderDocumentHead() }
+				{ this.renderPageViewTracking() }
 				<SidebarNavigation />
 				<div className="plugins__header">
 					<SectionNav selectedText={ this.getSelectedText() }>

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -291,7 +291,13 @@ export class PluginsMain extends Component {
 
 		const analyticsPageTitle = filter ? `Plugins > ${ capitalize( filter ) }` : 'Plugins';
 
-		const analyticsPath = selectedSiteId ? '/plugins/manage/:site' : '/plugins/manage';
+		// 'All' view corresponds to '/plugins/manage' path.
+		// Other filters appear unchanged in path (eg. Active -> /plugins/active)
+		const currentFilter = filter === 'all' ? 'manage' : filter;
+
+		const analyticsPath = selectedSiteId
+			? `/plugins/${ currentFilter }/:site`
+			: `/plugins/${ currentFilter }`;
 
 		if ( selectedSiteId && ! selectedSiteIsJetpack ) {
 			return null;

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -287,11 +287,15 @@ export class PluginsMain extends Component {
 	}
 
 	renderPageViewTracking() {
-		const { selectedSiteId, filter } = this.props;
+		const { selectedSiteId, filter, selectedSiteIsJetpack } = this.props;
 
-		const analyticsPageTitle = filter ? 'Plugins > ' + capitalize( filter ) : 'Plugins';
+		const analyticsPageTitle = filter ? `Plugins > ${ capitalize( filter ) }` : 'Plugins';
 
 		const analyticsPath = selectedSiteId ? '/plugins/manage/:site' : '/plugins/manage';
+
+		if ( selectedSiteId && ! selectedSiteIsJetpack ) {
+			return null;
+		}
 
 		return <PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />;
 	}
@@ -347,6 +351,7 @@ export class PluginsMain extends Component {
 				path={ this.props.context.path }
 				search={ search }
 				searchTitle={ searchTitle }
+				trackPageViews={ false }
 			/>
 		);
 

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -21,6 +21,7 @@ import UploadDropZone from 'blocks/upload-drop-zone';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import EligibilityWarnings from 'blocks/eligibility-warnings';
 import EmptyContent from 'components/empty-content';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import { uploadPlugin, clearPluginUpload } from 'state/plugins/upload/actions';
 import { initiateAutomatedTransferWithPluginZip } from 'state/automated-transfer/actions';
@@ -147,6 +148,7 @@ class PluginUpload extends React.Component {
 
 		return (
 			<Main>
+				<PageViewTracker path="/plugins/upload/:site" title="Plugins > Upload" />
 				<QueryEligibility siteId={ siteId } />
 				<HeaderCake onClick={ this.back }>{ translate( 'Upload plugin' ) }</HeaderCake>
 				{ upgradeJetpack && (

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -25,6 +25,7 @@ import PluginNotices from 'lib/plugins/notices';
 import MainComponent from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import PluginSections from 'my-sites/plugins/plugin-sections';
 import PluginSectionsCustom from 'my-sites/plugins/plugin-sections/custom';
 import DocumentHead from 'components/data/document-head';
@@ -224,6 +225,12 @@ const SinglePlugin = createReactClass( {
 		return <DocumentHead title={ this.getPageTitle() } />;
 	},
 
+	renderPageViewTracker() {
+		const analyticsPath = this.props.selectedSite ? '/plugins/:plugin/:site' : '/plugins/:plugin';
+
+		return <PageViewTracker path={ analyticsPath } title="Plugins > Plugin Details" />;
+	},
+
 	renderSitesList( plugin ) {
 		if ( this.props.siteUrl || this.isFetching() ) {
 			return;
@@ -343,6 +350,7 @@ const SinglePlugin = createReactClass( {
 			return (
 				<MainComponent>
 					{ this.renderDocumentHead() }
+					{ this.renderPageViewTracker() }
 					<SidebarNavigation />
 					<JetpackManageErrorPage
 						template="optInManage"
@@ -365,6 +373,7 @@ const SinglePlugin = createReactClass( {
 			<MainComponent>
 				<NonSupportedJetpackVersionNotice />
 				{ this.renderDocumentHead() }
+				{ this.renderPageViewTracker() }
 				<SidebarNavigation />
 				<div className="plugin__page">
 					{ this.displayHeader() }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -19,6 +19,7 @@ import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import InfiniteScroll from 'components/infinite-scroll';
 import NoResults from 'my-sites/no-results';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import PluginsBrowserList from 'my-sites/plugins/plugins-browser-list';
 import PluginsListStore from 'lib/plugins/wporg-data/list-store';
 import PluginsActions from 'lib/plugins/wporg-data/actions';
@@ -501,6 +502,19 @@ export class PluginsBrowser extends Component {
 		);
 	}
 
+	renderPageViewTracker() {
+		const { category, selectedSiteId } = this.props;
+
+		const analyticsPageTitle = 'Plugin Browser' + category ? ` > ${ category }` : '';
+		let analyticsPath = category ? `/plugins/${ category }` : '/plugins';
+
+		if ( selectedSiteId ) {
+			analyticsPath += '/:site';
+		}
+
+		return <PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />;
+	}
+
 	render() {
 		if ( ! this.props.isRequestingSites && this.props.noPermissionsError ) {
 			return (
@@ -516,6 +530,7 @@ export class PluginsBrowser extends Component {
 
 		return (
 			<MainComponent wideLayout>
+				{ this.renderPageViewTracker() }
 				<InfiniteScroll nextPageMethod={ this.fetchNextPagePlugins } />
 				<NonSupportedJetpackVersionNotice />
 				{ this.renderDocumentHead() }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { concat, find, flow, get, flatMap, includes } from 'lodash';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -56,6 +57,14 @@ const visibleCategories = [ 'new', 'popular', 'featured' ];
 
 export class PluginsBrowser extends Component {
 	static displayName = 'PluginsBrowser';
+
+	static propTypes = {
+		trackPageView: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		trackPageViews: true,
+	};
 
 	state = this.getPluginsLists( this.props.search );
 
@@ -503,7 +512,7 @@ export class PluginsBrowser extends Component {
 	}
 
 	renderPageViewTracker() {
-		const { category, selectedSiteId } = this.props;
+		const { category, selectedSiteId, trackPageViews } = this.props;
 
 		const analyticsPageTitle = 'Plugin Browser' + category ? ` > ${ category }` : '';
 		let analyticsPath = category ? `/plugins/${ category }` : '/plugins';
@@ -512,7 +521,11 @@ export class PluginsBrowser extends Component {
 			analyticsPath += '/:site';
 		}
 
-		return <PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />;
+		if ( trackPageViews ) {
+			return <PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />;
+		}
+
+		return null;
 	}
 
 	render() {


### PR DESCRIPTION
Replace direct `analytics.pageView.record` calls with `PageViewTracker` in `/plugins`.

Check out the updated recommendations on page view tracking:
https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/docs/page-views.md

### Testing instructions

1. Set `localStorage.setItem( 'debug', 'calypso:analytics:tracks' )` in the browser console to enable the debug.
2. Routes to check:
  - `/plugins`
  - `/plugins/:plugin`
  - `/plugins/:site`
  - `/plugins/:plugin/:site`
  - `plugins/manage`
  - `plugins/manage/:site`
  - `/plugins/new/:site`
  - `/plugins/popular/:site`
  - `/plugins/featured/:site`
  - `/plugins/setup/:site` (Jetpack only)

