### PR TITLE
Action Card: Prevent button text breaking when card is a flexbox

### DIFF
--- a/client/components/action-card/docs/example.jsx
+++ b/client/components/action-card/docs/example.jsx
@@ -17,7 +17,7 @@ function ActionCardExample( props ) {
 		<ActionCard
 			headerText={ 'This is a header text' }
 			mainText={
-				'This is some description of the header text, that ellaborates a bit a bout it and explaning about the action we are going to call to.'
+				'This is a description of the action. It gives a bit more detail and explains what we are inviting the user to do.'
 			}
 			buttonText={ 'Call to action!' }
 			buttonIcon="external"

--- a/client/components/action-card/style.scss
+++ b/client/components/action-card/style.scss
@@ -1,8 +1,8 @@
 .card.action-card {
-	display: flex;
+	display: block;
 
-	@include breakpoint( '<960px' ) {
-		display: block;
+	@include breakpoint( '>960px' ) {
+		display: flex;
 	}
 }
 
@@ -16,9 +16,17 @@
 	margin-bottom: 16px;
 	text-align: left;
 
+	.button {
+		white-space: nowrap;
+	}
+
 	@include breakpoint( '>960px' ) {
 		margin-bottom: 0;
 		text-align: right;
+
+		.button {
+			margin-left: 8px;
+		}
 	}
 
 	@include breakpoint( '<480px' ) {


### PR DESCRIPTION
Addresses https://github.com/Automattic/wp-calypso/issues/24063. On viewports above the 960 breakpoint, when the card has `display: flex`, the text in the button is liable to break when the card is constrained to widths around 482px.

This branch adds `white-space: nowrap` to the button to prevent the text breaking in that situation. I've also switched the display rules for the card to be mobile first, and tweaked the wording in the devdocs example.

![action-bar-button-break](https://user-images.githubusercontent.com/1647564/38703124-4e8bb08a-3e9a-11e8-92c8-be295059a945.png)

![image](https://user-images.githubusercontent.com/1647564/38704513-815267ee-3e9e-11e8-946c-645ed1a390ae.png)

"Google my business" seems to be the only section currently using the component.