### PR TITLE
Login: Add a meta description to the page.

### DIFF
--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -174,6 +174,7 @@ export class Login extends React.Component {
 					<DocumentHead
 						title={ translate( 'Log In' ) }
 						link={ [ { rel: 'canonical', href: canonicalUrl } ] }
+						meta={ [ { name: 'description', content: 'Log in to WordPress.com' } ] }
 					/>
 
 					<div>


### PR DESCRIPTION
Checks one more check in Lighthouse.

To test, load http://calypso.localhost:3000/log-in in an incognito window. There should be a valid `<meta name="description">` tag in the server content.