### PR TITLE
[Domains] Enable Kracken in stage and wpcalypso

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -30,6 +30,7 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"domains/cctlds/uk": true,
+		"domains/kracken-ui": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -33,6 +33,7 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"domains/cctlds/uk": true,
+		"domains/kracken-ui": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
This change enables the Kracken domain registration redesign in `stage` and `wpcalypso` environments in preparation for internal call-for-testing.

Currently, this UI is already enabled in `development` and `horizon`.

There is an open PR in [Automattic/wp-e2e-tests](https://github.com/Automattic/wp-e2e-tests/pull/1130) to fix the broken e2e tests corresponding to this change.