### PR TITLE
Jetpack Connect: Move auth disclaimer to a separate component

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -18,6 +18,7 @@ import AuthFormHeader from './auth-form-header';
 import Button from 'components/button';
 import Card from 'components/card';
 import config from 'config';
+import Disclaimer from './disclaimer';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Gravatar from 'components/gravatar';
@@ -265,10 +266,6 @@ export class JetpackAuthorize extends Component {
 		// to wp-admin.
 		return partnerRedirectFlag ? partnerId && PRESSABLE_PARTNER_ID !== partnerId : partnerId;
 	}
-
-	handleClickDisclaimer = () => {
-		this.props.recordTracksEvent( 'calypso_jpc_disclaimer_link_click' );
-	};
 
 	handleClickHelp = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
@@ -518,34 +515,6 @@ export class JetpackAuthorize extends Component {
 		}
 	}
 
-	getDisclaimerText() {
-		const { blogname } = this.props.authQuery;
-
-		const detailsLink = (
-			<a
-				target="_blank"
-				rel="noopener noreferrer"
-				onClick={ this.handleClickDisclaimer }
-				href="https://jetpack.com/support/what-data-does-jetpack-sync/"
-				className="jetpack-connect__sso-actions-modal-link"
-			/>
-		);
-
-		const text = this.props.translate(
-			'By connecting your site, you agree to {{detailsLink}}share details{{/detailsLink}} between WordPress.com and %(siteName)s.',
-			{
-				components: {
-					detailsLink,
-				},
-				args: {
-					siteName: decodeEntities( blogname ),
-				},
-			}
-		);
-
-		return <p className="jetpack-connect__tos-link">{ text }</p>;
-	}
-
 	getUserText() {
 		const { translate } = this.props;
 		const { authorizeSuccess } = this.props.authorizationData;
@@ -639,9 +608,12 @@ export class JetpackAuthorize extends Component {
 				</div>
 			);
 		}
+
+		const { blogname } = this.props.authQuery;
+
 		return (
 			<LoggedOutFormFooter className="jetpack-connect__action-disclaimer">
-				{ this.getDisclaimerText() }
+				<Disclaimer siteName={ decodeEntities( blogname ) } />
 				<Button
 					primary
 					disabled={ this.isAuthorizing() || this.props.hasXmlrpcError }

--- a/client/jetpack-connect/disclaimer.jsx
+++ b/client/jetpack-connect/disclaimer.jsx
@@ -1,0 +1,56 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { recordTracksEvent } from 'state/analytics/actions';
+
+class JetpackConnectDisclaimer extends PureComponent {
+	static propTypes = {
+		siteName: PropTypes.string.isRequired,
+	};
+
+	handleClickDisclaimer = () => {
+		this.props.recordTracksEvent( 'calypso_jpc_disclaimer_link_click' );
+	};
+
+	render() {
+		const { siteName, translate } = this.props;
+
+		const detailsLink = (
+			<a
+				target="_blank"
+				rel="noopener noreferrer"
+				onClick={ this.handleClickDisclaimer }
+				href="https://jetpack.com/support/what-data-does-jetpack-sync/"
+				className="jetpack-connect__sso-actions-modal-link"
+			/>
+		);
+
+		const text = translate(
+			'By connecting your site, you agree to {{detailsLink}}share details{{/detailsLink}} between WordPress.com and %(siteName)s.',
+			{
+				components: {
+					detailsLink,
+				},
+				args: {
+					siteName,
+				},
+			}
+		);
+
+		return <p className="jetpack-connect__tos-link">{ text }</p>;
+	}
+}
+
+export default connect( null, {
+	recordTracksEvent,
+} )( localize( JetpackConnectDisclaimer ) );

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -56,11 +56,9 @@ exports[`JetpackAuthorize renders as expected 1`] = `
         <LoggedOutFormFooter
           className="jetpack-connect__action-disclaimer"
         >
-          <p
-            className="jetpack-connect__tos-link"
-          >
-            By connecting your site, you agree to {{detailsLink}}share details{{/detailsLink}} between WordPress.com and %(siteName)s.
-          </p>
+          <Connect(Localized(JetpackConnectDisclaimer))
+            siteName="Example Blog"
+          />
           <Button
             disabled={false}
             onClick={[Function]}


### PR DESCRIPTION
Some of the main components in Jetpack Connect are responsible for a lot of things happening, which results in them being large in terms of code. Further splitting them to subcomponents could help with maintaining them and introducing changes and new features.

This PR moves the Jetpack Connect authorize component disclaimer to a separate component. This helps reduce the size of the `JetpackAuthorize` component a bit (roughly 4%).

There should be no visual/behavioral changes.

![](https://cldup.com/0Bg60XzgQO.png)

To test:
* Checkout this branch.
* Start a new Jurassic Ninja site.
* Go to http://calypso.localhost:3000/jetpack/connect?url=YOURJURASSICNINJASITEHERE
* Verify the disclaimer looks the same way like before.
* Verify the link in the disclaimer works the same way and records the `calypso_jpc_disclaimer_link_click` event properly.