### PR TITLE
SSR: Fix Cache Key Creation

### DIFF
--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -1,9 +1,9 @@
 /** @format */
+
 /**
  * External dependencies
  */
-
-import { isEmpty, pick } from 'lodash';
+import { isEmpty } from 'lodash';
 import { stringify } from 'qs';
 
 /**
@@ -93,15 +93,10 @@ function compose( ...functions ) {
 	return functions.reduceRight( ( composed, f ) => () => f( composed ), () => {} );
 }
 
-export function getCacheKey( context ) {
-	if ( isEmpty( context.query ) || isEmpty( context.cacheQueryKeys ) ) {
-		return context.pathname;
+export function getNormalizedPath( pathname, query ) {
+	if ( isEmpty( query ) ) {
+		return pathname;
 	}
 
-	const cachedQueryParams = pick( context.query, context.cacheQueryKeys );
-	return (
-		context.pathname +
-		'?' +
-		stringify( cachedQueryParams, { sort: ( a, b ) => a.localeCompare( b ) } )
-	);
+	return pathname + '?' + stringify( query, { sort: ( a, b ) => a.localeCompare( b ) } );
 }

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -102,6 +102,6 @@ export function getCacheKey( context ) {
 	return (
 		context.pathname +
 		'?' +
-		stringify( cachedQueryParams, { sort: ( a, b ) => a.localCompare( b ) } )
+		stringify( cachedQueryParams, { sort: ( a, b ) => a.localeCompare( b ) } )
 	);
 }

--- a/server/isomorphic-routing/test/__snapshots__/index.js.snap
+++ b/server/isomorphic-routing/test/__snapshots__/index.js.snap
@@ -1,61 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 1`] = `""`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 1`] = `"/"`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 2`] = `"?a=query"`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 2`] = `"/?a=query"`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 3`] = `"?%3Ftricky%3Dquery="`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 3`] = `"/?%3Ftricky%3Dquery="`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 4`] = `"?key=%3Dtricky%26value%3D%3B%29"`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 4`] = `"/?key=%3Dtricky%26value%3D%3B%29"`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 5`] = `"?emptyValue="`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 5`] = `"/?emptyValue="`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 6`] = `"?nullValue="`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 6`] = `"/?nullValue="`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 7`] = `"/"`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 7`] = `"/shortpath"`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 8`] = `"/?a=query"`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 8`] = `"/shortpath?a=query"`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 9`] = `"/?%3Ftricky%3Dquery="`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 9`] = `"/shortpath?%3Ftricky%3Dquery="`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 10`] = `"/?key=%3Dtricky%26value%3D%3B%29"`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 10`] = `"/shortpath?key=%3Dtricky%26value%3D%3B%29"`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 11`] = `"/?emptyValue="`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 11`] = `"/shortpath?emptyValue="`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 12`] = `"/?nullValue="`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 12`] = `"/shortpath?nullValue="`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 13`] = `"/shortpath"`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 13`] = `"/a/longer/path"`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 14`] = `"/shortpath?a=query"`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 14`] = `"/a/longer/path?a=query"`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 15`] = `"/shortpath?%3Ftricky%3Dquery="`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 15`] = `"/a/longer/path?%3Ftricky%3Dquery="`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 16`] = `"/shortpath?key=%3Dtricky%26value%3D%3B%29"`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 16`] = `"/a/longer/path?key=%3Dtricky%26value%3D%3B%29"`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 17`] = `"/shortpath?emptyValue="`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 17`] = `"/a/longer/path?emptyValue="`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 18`] = `"/shortpath?nullValue="`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 18`] = `"/a/longer/path?nullValue="`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 19`] = `"/a/longer/path"`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 19`] = `"/specialchars/%2F%3F%26%3D%25"`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 20`] = `"/a/longer/path?a=query"`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 20`] = `"/specialchars/%2F%3F%26%3D%25?a=query"`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 21`] = `"/a/longer/path?%3Ftricky%3Dquery="`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 21`] = `"/specialchars/%2F%3F%26%3D%25?%3Ftricky%3Dquery="`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 22`] = `"/a/longer/path?key=%3Dtricky%26value%3D%3B%29"`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 22`] = `"/specialchars/%2F%3F%26%3D%25?key=%3Dtricky%26value%3D%3B%29"`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 23`] = `"/a/longer/path?emptyValue="`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 23`] = `"/specialchars/%2F%3F%26%3D%25?emptyValue="`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 24`] = `"/a/longer/path?nullValue="`;
-
-exports[`getNormalizedPath should return expected results for a variety of inputs 25`] = `"/specialchars/%2F%3F%26%3D%25"`;
-
-exports[`getNormalizedPath should return expected results for a variety of inputs 26`] = `"/specialchars/%2F%3F%26%3D%25?a=query"`;
-
-exports[`getNormalizedPath should return expected results for a variety of inputs 27`] = `"/specialchars/%2F%3F%26%3D%25?%3Ftricky%3Dquery="`;
-
-exports[`getNormalizedPath should return expected results for a variety of inputs 28`] = `"/specialchars/%2F%3F%26%3D%25?key=%3Dtricky%26value%3D%3B%29"`;
-
-exports[`getNormalizedPath should return expected results for a variety of inputs 29`] = `"/specialchars/%2F%3F%26%3D%25?emptyValue="`;
-
-exports[`getNormalizedPath should return expected results for a variety of inputs 30`] = `"/specialchars/%2F%3F%26%3D%25?nullValue="`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 24`] = `"/specialchars/%2F%3F%26%3D%25?nullValue="`;

--- a/server/isomorphic-routing/test/__snapshots__/index.js.snap
+++ b/server/isomorphic-routing/test/__snapshots__/index.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 1`] = `""`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 2`] = `"/?a=query"`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 3`] = `"/shortpath?=a%3Dquery"`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 4`] = `"/a/longer/path"`;

--- a/server/isomorphic-routing/test/__snapshots__/index.js.snap
+++ b/server/isomorphic-routing/test/__snapshots__/index.js.snap
@@ -2,8 +2,60 @@
 
 exports[`getNormalizedPath should return expected results for a variety of inputs 1`] = `""`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 2`] = `"/?a=query"`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 2`] = `"?a=query"`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 3`] = `"/shortpath?=a%3Dquery"`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 3`] = `"?%3Ftricky%3Dquery="`;
 
-exports[`getNormalizedPath should return expected results for a variety of inputs 4`] = `"/a/longer/path"`;
+exports[`getNormalizedPath should return expected results for a variety of inputs 4`] = `"?key=%3Dtricky%26value%3D%3B%29"`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 5`] = `"?emptyValue="`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 6`] = `"?nullValue="`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 7`] = `"/"`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 8`] = `"/?a=query"`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 9`] = `"/?%3Ftricky%3Dquery="`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 10`] = `"/?key=%3Dtricky%26value%3D%3B%29"`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 11`] = `"/?emptyValue="`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 12`] = `"/?nullValue="`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 13`] = `"/shortpath"`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 14`] = `"/shortpath?a=query"`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 15`] = `"/shortpath?%3Ftricky%3Dquery="`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 16`] = `"/shortpath?key=%3Dtricky%26value%3D%3B%29"`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 17`] = `"/shortpath?emptyValue="`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 18`] = `"/shortpath?nullValue="`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 19`] = `"/a/longer/path"`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 20`] = `"/a/longer/path?a=query"`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 21`] = `"/a/longer/path?%3Ftricky%3Dquery="`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 22`] = `"/a/longer/path?key=%3Dtricky%26value%3D%3B%29"`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 23`] = `"/a/longer/path?emptyValue="`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 24`] = `"/a/longer/path?nullValue="`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 25`] = `"/specialchars/%2F%3F%26%3D%25"`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 26`] = `"/specialchars/%2F%3F%26%3D%25?a=query"`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 27`] = `"/specialchars/%2F%3F%26%3D%25?%3Ftricky%3Dquery="`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 28`] = `"/specialchars/%2F%3F%26%3D%25?key=%3Dtricky%26value%3D%3B%29"`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 29`] = `"/specialchars/%2F%3F%26%3D%25?emptyValue="`;
+
+exports[`getNormalizedPath should return expected results for a variety of inputs 30`] = `"/specialchars/%2F%3F%26%3D%25?nullValue="`;

--- a/server/isomorphic-routing/test/index.js
+++ b/server/isomorphic-routing/test/index.js
@@ -1,0 +1,57 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getCacheKey } from '..';
+
+jest.mock( 'redux-form/es/reducer', () => require( 'lodash' ).identity );
+
+describe( 'getCacheKey', () => {
+	test( 'should return pathname for routes with no query', () => {
+		const context = {
+			pathname: '/my/path',
+			query: {},
+		};
+
+		expect( getCacheKey( context ) ).toBe( '/my/path' );
+	} );
+
+	test( 'should return cacheKey for a known query param', () => {
+		const context = {
+			pathname: '/my/path',
+			query: { cache_me: '1' },
+			cacheQueryKeys: [ 'cache_me' ],
+		};
+
+		expect( getCacheKey( context ) ).toBe( '/my/path?cache_me=1' );
+	} );
+
+	test( 'should return cacheKey for multiple known query params', () => {
+		const context = {
+			pathname: '/my/path',
+			query: { cache_me: '1', and_me: '2', me_too: '3' },
+			cacheQueryKeys: [ 'and_me', 'cache_me', 'me_too' ],
+		};
+
+		expect( getCacheKey( context ) ).toBe( '/my/path?and_me=2&cache_me=1&me_too=3' );
+	} );
+
+	test( 'should return a stable key pathname', () => {
+		const context = {
+			pathname: '/my/path',
+			query: { a: '1', b: '2' },
+		};
+		const querySwapped = {
+			pathname: '/my/path',
+			query: { b: '2', a: '1' },
+		};
+		const keysSwapped = {
+			pathname: '/my/path',
+			query: { a: '1', b: '2' },
+		};
+
+		expect( getCacheKey( context ) ).toEqual( getCacheKey( querySwapped ) );
+		expect( getCacheKey( context ) ).toEqual( getCacheKey( keysSwapped ) );
+	} );
+} );

--- a/server/isomorphic-routing/test/index.js
+++ b/server/isomorphic-routing/test/index.js
@@ -7,7 +7,7 @@ import { getNormalizedPath } from '..';
 
 describe( 'getNormalizedPath', () => {
 	test( 'should return expected results for a variety of inputs', () => {
-		const pathnames = [ '', '/', '/shortpath', '/a/longer/path', '/specialchars/%2F%3F%26%3D%25' ];
+		const pathnames = [ '/', '/shortpath', '/a/longer/path', '/specialchars/%2F%3F%26%3D%25' ];
 		const queries = [
 			{},
 			{ a: 'query' },

--- a/server/isomorphic-routing/test/index.js
+++ b/server/isomorphic-routing/test/index.js
@@ -30,14 +30,14 @@ describe( 'getNormalizedPath', () => {
 		expect( getNormalizedPath( pathname, query ) ).toBe( '/my/path' );
 	} );
 
-	test( 'should return cacheKey for a known query param', () => {
+	test( 'should return normalized path for one query param', () => {
 		const pathname = '/';
 		const query = { cache_me: '1' };
 
 		expect( getNormalizedPath( pathname, query ) ).toBe( '/?cache_me=1' );
 	} );
 
-	test( 'should return cacheKey for multiple known query params', () => {
+	test( 'should return normalized pathname for multiple query params', () => {
 		const pathname = '/';
 		const query = { cache_me: '1', and_me: '2', me_too: '3' };
 

--- a/server/isomorphic-routing/test/index.js
+++ b/server/isomorphic-routing/test/index.js
@@ -14,26 +14,45 @@ describe( 'getNormalizedPath', () => {
 	} );
 
 	test( 'should return cacheKey for a known query param', () => {
-		const pathname = '/my/path';
+		const pathname = '/';
 		const query = { cache_me: '1' };
 
-		expect( getNormalizedPath( pathname, query ) ).toBe( '/my/path?cache_me=1' );
+		expect( getNormalizedPath( pathname, query ) ).toBe( '/?cache_me=1' );
 	} );
 
 	test( 'should return cacheKey for multiple known query params', () => {
-		const pathname = '/my/path';
+		const pathname = '/';
 		const query = { cache_me: '1', and_me: '2', me_too: '3' };
 
-		expect( getNormalizedPath( pathname, query ) ).toBe( '/my/path?and_me=2&cache_me=1&me_too=3' );
+		expect( getNormalizedPath( pathname, query ) ).toBe( '/?and_me=2&cache_me=1&me_too=3' );
 	} );
 
 	test( 'should return a stable key pathname', () => {
-		const pathname = '/my/path';
+		const pathname = '/';
 		const query = { a: '1', b: '2' };
 		const querySwapped = { b: '2', a: '1' };
 
-		expect( getNormalizedPath( pathname, query ) ).toEqual(
+		expect( getNormalizedPath( pathname, query ) ).toBe(
 			getNormalizedPath( pathname, querySwapped )
+		);
+	} );
+
+	test( 'should handle "empty" query params coherently', () => {
+		expect( getNormalizedPath( '/', { empty: '' } ) ).toBe(
+			getNormalizedPath( '/', { empty: null } )
+		);
+		expect( getNormalizedPath( '/', { empty: '' } ) ).toBe(
+			getNormalizedPath( '/', { empty: undefined } )
+		);
+	} );
+
+	test( 'should produce unique results', () => {
+		expect( getNormalizedPath( '/?a=query', {} ) ).not.toBe(
+			getNormalizedPath( '/', { a: 'query' } )
+		);
+
+		expect( getNormalizedPath( '/', { key: 'val' } ) ).not.toBe(
+			getNormalizedPath( '/', { 'key=val': '' } )
 		);
 	} );
 } );

--- a/server/isomorphic-routing/test/index.js
+++ b/server/isomorphic-routing/test/index.js
@@ -3,9 +3,19 @@
 /**
  * Internal dependencies
  */
+import { zip } from 'lodash';
 import { getNormalizedPath } from '..';
 
 describe( 'getNormalizedPath', () => {
+	test( 'should return expected results for a variety of inputs', () => {
+		const paths = [ '', '/', '/shortpath', '/a/longer/path' ];
+		const queries = [ {}, { a: 'query' }, { '': 'a=query' } ];
+
+		zip( paths, queries ).forEach( ( [ pathname, query ] ) =>
+			expect( getNormalizedPath( pathname, query ) ).toMatchSnapshot()
+		);
+	} );
+
 	test( 'should return pathname for routes with no query', () => {
 		const pathname = '/my/path';
 		const query = {};

--- a/server/isomorphic-routing/test/index.js
+++ b/server/isomorphic-routing/test/index.js
@@ -3,55 +3,39 @@
 /**
  * Internal dependencies
  */
-import { getCacheKey } from '..';
+import { getNormalizedPath } from '..';
 
 jest.mock( 'redux-form/es/reducer', () => require( 'lodash' ).identity );
 
-describe( 'getCacheKey', () => {
+describe( 'getNormalizedPath', () => {
 	test( 'should return pathname for routes with no query', () => {
-		const context = {
-			pathname: '/my/path',
-			query: {},
-		};
+		const pathname = '/my/path';
+		const query = {};
 
-		expect( getCacheKey( context ) ).toBe( '/my/path' );
+		expect( getNormalizedPath( pathname, query ) ).toBe( '/my/path' );
 	} );
 
 	test( 'should return cacheKey for a known query param', () => {
-		const context = {
-			pathname: '/my/path',
-			query: { cache_me: '1' },
-			cacheQueryKeys: [ 'cache_me' ],
-		};
+		const pathname = '/my/path';
+		const query = { cache_me: '1' };
 
-		expect( getCacheKey( context ) ).toBe( '/my/path?cache_me=1' );
+		expect( getNormalizedPath( pathname, query ) ).toBe( '/my/path?cache_me=1' );
 	} );
 
 	test( 'should return cacheKey for multiple known query params', () => {
-		const context = {
-			pathname: '/my/path',
-			query: { cache_me: '1', and_me: '2', me_too: '3' },
-			cacheQueryKeys: [ 'and_me', 'cache_me', 'me_too' ],
-		};
+		const pathname = '/my/path';
+		const query = { cache_me: '1', and_me: '2', me_too: '3' };
 
-		expect( getCacheKey( context ) ).toBe( '/my/path?and_me=2&cache_me=1&me_too=3' );
+		expect( getNormalizedPath( pathname, query ) ).toBe( '/my/path?and_me=2&cache_me=1&me_too=3' );
 	} );
 
 	test( 'should return a stable key pathname', () => {
-		const context = {
-			pathname: '/my/path',
-			query: { a: '1', b: '2' },
-		};
-		const querySwapped = {
-			pathname: '/my/path',
-			query: { b: '2', a: '1' },
-		};
-		const keysSwapped = {
-			pathname: '/my/path',
-			query: { a: '1', b: '2' },
-		};
+		const pathname = '/my/path';
+		const query = { a: '1', b: '2' };
+		const querySwapped = { b: '2', a: '1' };
 
-		expect( getCacheKey( context ) ).toEqual( getCacheKey( querySwapped ) );
-		expect( getCacheKey( context ) ).toEqual( getCacheKey( keysSwapped ) );
+		expect( getNormalizedPath( pathname, query ) ).toEqual(
+			getNormalizedPath( pathname, querySwapped )
+		);
 	} );
 } );

--- a/server/isomorphic-routing/test/index.js
+++ b/server/isomorphic-routing/test/index.js
@@ -3,16 +3,23 @@
 /**
  * Internal dependencies
  */
-import { zip } from 'lodash';
 import { getNormalizedPath } from '..';
 
 describe( 'getNormalizedPath', () => {
 	test( 'should return expected results for a variety of inputs', () => {
-		const paths = [ '', '/', '/shortpath', '/a/longer/path' ];
-		const queries = [ {}, { a: 'query' }, { '': 'a=query' } ];
+		const pathnames = [ '', '/', '/shortpath', '/a/longer/path', '/specialchars/%2F%3F%26%3D%25' ];
+		const queries = [
+			{},
+			{ a: 'query' },
+			{ '?tricky=query': '' },
+			{ key: '=tricky&value=;)' },
+			{ emptyValue: '' },
+			{ nullValue: null },
+		];
 
-		zip( paths, queries ).forEach( ( [ pathname, query ] ) =>
-			expect( getNormalizedPath( pathname, query ) ).toMatchSnapshot()
+		// Cartesian product: paths * queries
+		pathnames.forEach( pathname =>
+			queries.forEach( query => expect( getNormalizedPath( pathname, query ) ).toMatchSnapshot() )
 		);
 	} );
 
@@ -51,16 +58,9 @@ describe( 'getNormalizedPath', () => {
 		expect( getNormalizedPath( '/', { empty: '' } ) ).toBe(
 			getNormalizedPath( '/', { empty: null } )
 		);
-		expect( getNormalizedPath( '/', { empty: '' } ) ).toBe(
-			getNormalizedPath( '/', { empty: undefined } )
-		);
 	} );
 
 	test( 'should produce unique results', () => {
-		expect( getNormalizedPath( '/?a=query', {} ) ).not.toBe(
-			getNormalizedPath( '/', { a: 'query' } )
-		);
-
 		expect( getNormalizedPath( '/', { key: 'val' } ) ).not.toBe(
 			getNormalizedPath( '/', { 'key=val': '' } )
 		);

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -21,7 +21,7 @@ import sanitize from 'sanitize';
 import utils from 'bundler/utils';
 import { pathToRegExp } from '../../client/utils';
 import sections from '../../client/sections';
-import { serverRouter, getCacheKey } from 'isomorphic-routing';
+import { serverRouter, getNormalizedPath } from 'isomorphic-routing';
 import { serverRender, serverRenderError, renderJsx } from 'render';
 import stateCache from 'state-cache';
 import { createReduxStore, reducer } from 'state';
@@ -174,7 +174,11 @@ function getAcceptedLanguagesFromHeader( header ) {
 function getDefaultContext( request ) {
 	let initialServerState = {};
 	const bodyClasses = [];
-	const cacheKey = getCacheKey( request );
+	// We don't compare context.query against a whitelist here. Whitelists are route-specific,
+	// i.e. they can be created by route-specific middleware. `getDefaultContext` is always
+	// called before route-specific middleware, so it's up to the cache *writes* in server
+	// render to make sure that Redux state and markup are only cached for whitelisted query args.
+	const cacheKey = getNormalizedPath( request.pathname, request.query );
 	const geoLocation = ( request.headers[ 'x-geoip-country-code' ] || '' ).toLowerCase();
 	const isDebug = calypsoEnv === 'development' || request.query.debug !== undefined;
 	let sectionCss;

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -7,7 +7,7 @@ import React from 'react';
 import ReactDomServer from 'react-dom/server';
 import superagent from 'superagent';
 import Lru from 'lru';
-import { get, pick } from 'lodash';
+import { get, isEmpty, pick } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -130,8 +130,15 @@ export function serverRender( req, res ) {
 		cacheKey = false;
 
 	if ( isSectionIsomorphic( context.store.getState() ) && ! context.user ) {
-		const cachedQueryParams = pick( context.query, context.cacheQueryKeys );
-		cacheKey = getNormalizedPath( context.pathname, cachedQueryParams );
+		if ( ! context.query ) {
+			cacheKey = context.pathname;
+		} else {
+			// If we have query args, make sure we only cache if they're whitelisted
+			const cachedQueryParams = pick( context.query, context.cacheQueryKeys );
+			if ( ! isEmpty( cachedQueryParams ) ) {
+				cacheKey = getNormalizedPath( context.pathname, cachedQueryParams );
+			}
+		}
 	}
 
 	if ( ! isDefaultLocale( context.lang ) ) {

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -130,7 +130,7 @@ export function serverRender( req, res ) {
 		cacheKey = false;
 
 	if ( isSectionIsomorphic( context.store.getState() ) && ! context.user ) {
-		if ( ! context.query ) {
+		if ( isEmpty( context.query ) ) {
 			cacheKey = context.pathname;
 		} else {
 			// If we have query args, make sure we only cache if they're whitelisted

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -7,7 +7,7 @@ import React from 'react';
 import ReactDomServer from 'react-dom/server';
 import superagent from 'superagent';
 import Lru from 'lru';
-import { every, get, includes, isEmpty, pick } from 'lodash';
+import { get, intersection, pick } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -127,15 +127,13 @@ export function render( element, key = JSON.stringify( element ), req ) {
  *
  * If any key in the query is not present in the whitelist, it is not cacheable.
  *
- * @param  {?Object}        query                Query object
- * @param  {?Array<string>} whitelistedQueryKeys Whitelisted keys
- * @return {boolean}                             True if all query keys are whitelisted
+ * @param  {Object}        query                Query object
+ * @param  {Array<string>} whitelistedQueryKeys Whitelisted keys
+ * @return {boolean}                            True if all query keys are whitelisted
  */
-export function isCacheableQuery( query = null, whitelistedQueryKeys = null ) {
-	if ( isEmpty( query ) ) {
-		return true;
-	}
-	return every( Object.keys( query ), key => includes( whitelistedQueryKeys, key ) );
+export function isCacheableQuery( query = {}, whitelistedQueryKeys = [] ) {
+	const queryKeys = Object.keys( query );
+	return queryKeys.length === intersection( queryKeys, whitelistedQueryKeys ).length;
 }
 
 export function serverRender( req, res ) {

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -162,8 +162,7 @@ export function serverRender( req, res ) {
 		context.layout &&
 		! context.user &&
 		cacheKey &&
-		isDefaultLocale( context.lang ) &&
-		! context.query.email_address // Don't do SSR when PIIs are present at the request
+		isDefaultLocale( context.lang )
 	) {
 		context.renderedLayout = render(
 			context.layout,

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -26,7 +26,7 @@ import { getCurrentLocaleSlug, getCurrentLocaleVariant } from 'state/selectors';
 import { reducer } from 'state';
 import { SERIALIZE } from 'state/action-types';
 import stateCache from 'state-cache';
-import { getCacheKey } from 'isomorphic-routing';
+import { getNormalizedPath } from 'isomorphic-routing';
 import { logToLogstash } from 'state/logstash/actions';
 
 const debug = debugFactory( 'calypso:server-render' );
@@ -130,7 +130,8 @@ export function serverRender( req, res ) {
 		cacheKey = false;
 
 	if ( isSectionIsomorphic( context.store.getState() ) && ! context.user ) {
-		cacheKey = getCacheKey( context );
+		const cachedQueryParams = pick( context.query, context.cacheQueryKeys );
+		cacheKey = getNormalizedPath( context.pathname, cachedQueryParams );
 	}
 
 	if ( ! isDefaultLocale( context.lang ) ) {

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -127,9 +127,9 @@ export function render( element, key = JSON.stringify( element ), req ) {
  *
  * If any key in the query is not present in the whitelist, it is not cacheable.
  *
- * @param  {Object}        query                Query object
- * @param  {Array<string>} whitelistedQueryKeys Whitelisted keys
- * @return {boolean}                            True if all query keys are whitelisted
+ * @param  {Object}        [query={}]                Query object
+ * @param  {Array<string>} [whitelistedQueryKeys=[]] Whitelisted keys
+ * @return {boolean}                                 True if all query keys are whitelisted
  */
 export function isCacheableQuery( query = {}, whitelistedQueryKeys = [] ) {
 	const queryKeys = Object.keys( query );

--- a/server/render/test/index.js
+++ b/server/render/test/index.js
@@ -1,0 +1,41 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+
+import { isCacheableQuery } from '..';
+
+describe( 'isCacheableQuery', () => {
+	test( 'should return true if the query is empty', () => {
+		expect( isCacheableQuery( {} ) ).toBe( true );
+	} );
+
+	test( 'should return true if the query is not provided', () => {
+		expect( isCacheableQuery() ).toBe( true );
+	} );
+
+	test( 'should return false if the query is not empty but no whitelist is provided', () => {
+		expect( isCacheableQuery( { not: 'empty' } ) ).toBe( false );
+	} );
+
+	test( 'should return false if the query is not empty and the whitelist is empty', () => {
+		expect( isCacheableQuery( { not: 'empty' }, [] ) ).toBe( false );
+	} );
+
+	test( 'should return false if the query contains not whitelisted keys', () => {
+		expect( isCacheableQuery( { key: 'value' }, [ 'different' ] ) ).toBe( false );
+	} );
+
+	test( 'should return true if query keys are a subset of whitelist', () => {
+		expect( isCacheableQuery( { a: 'a', b: 'b' }, [ 'a', 'b', 'c' ] ) ).toBe( true );
+	} );
+
+	test( 'should return true if query keys match whitelist', () => {
+		expect( isCacheableQuery( { a: 'a', b: 'b', c: '' }, [ 'a', 'b', 'c' ] ) ).toBe( true );
+	} );
+
+	test( 'should return false if any query key is not included', () => {
+		expect( isCacheableQuery( { a: 'a', b: 'b' }, [ 'a' ] ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
The cache keys that `getCacheKey()` was creating weren't stable (i.e. `/my/?a=1&b=2` and `/my/?b=2&a=1` would yield different cache keys, tho they should yield the same).

There were two reasons for that:

1. For a long time, we were using a version of the `qs` npm that wasn't supporting the `sort` option. This has been upgraded as of #23259.
2. There was a typo: We were wrongly calling `localCompare()` instead of `localeCompare()`. This is fixed by this PR. To guard against regressions, it also adds unit tests for `getCacheKey()`.

Furthermore, this PR decouples path/query string normalization from whitelisting of query args. We no longer compare against a whitelist during cache loading (which didn't work since whitelists are created by individual middleware _after_ initial Redux state is loaded from cache), but only during cache writing (i.e. at render time).

Finally, it fixes the criterion that we use to determine whether to cache our SSR-generated markup and Redux state if there are query args present: We now require *all* query args to be whitelisted in order to do so. Reading prior discussions (e.g. p7rd6c-1nt-p2), this seems to be the right thing to do.

Trying out a new strategy of fixing SSR by getting in small, properly unit-tested PRs (props @sirreal, whose unit tests I shamelessly stole from #22593).

### Testing Instructions:
* Restart Calypso, using `DEBUG='calypso:server-render' npm start`
* Verify that SSR'd pages still work (in an incognito window, try `/themes` and `/log-in`)
* In your CLI that runs Calypso, verify that subsequent hits to routes with identical query args in different order don't result in a cache miss.   