### PR TITLE
Domains: Edit Contact Info fails if invalid state fetched

### DIFF
--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
@@ -15,10 +15,10 @@ import { localize } from 'i18n-calypso';
 import {
 	CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES,
 	CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES,
-} from './constants';
-import UsAddressFieldset from './us-address-fieldset';
-import EuAddressFieldset from './eu-address-fieldset';
-import UkAddressFieldset from './uk-address-fieldset';
+} from 'components/domains/contact-details-form-fields/custom-form-fieldsets/constants';
+import UsAddressFieldset from 'components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset';
+import EuAddressFieldset from 'components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset';
+import UkAddressFieldset from 'components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset';
 import { Input, HiddenInput } from 'my-sites/domains/components/form';
 
 export class RegionAddressFieldsets extends Component {

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -122,6 +122,7 @@ export class ContactDetailsFormFields extends Component {
 		return (
 			! isEqual( nextState.form, this.state.form ) ||
 			! isEqual( nextProps.labelTexts, this.props.labelTexts ) ||
+			! isEqual( nextProps.hasCountryStates, this.props.hasCountryStates ) ||
 			( nextProps.needsFax !== this.props.needsFax ||
 				nextProps.disableSubmitButton !== this.props.disableSubmitButton ||
 				nextProps.needsOnlyGoogleAppsDetails !== this.props.needsOnlyGoogleAppsDetails )

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -152,6 +152,7 @@ export class ContactDetailsFormFields extends Component {
 		const { countryCode, hasCountryStates } = this.props;
 		let state = mainFieldValues.state;
 
+		// domains registered according to ancient validation rules may have state set even though not required
 		if (
 			! hasCountryStates &&
 			( includes( CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES, countryCode ) ||
@@ -162,7 +163,6 @@ export class ContactDetailsFormFields extends Component {
 
 		return {
 			...mainFieldValues,
-			// domains registered according to ancient validation rules may have state set even though not required
 			state,
 			phone: toIcannFormat( mainFieldValues.phone, countries[ this.state.phoneCountryCode ] ),
 		};

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -350,7 +350,7 @@ class EditContactInfoFormCard extends React.Component {
 				<form>
 					<ContactDetailsFormFields
 						eventFormName="Edit Contact Info"
-						contactDetails={ this.contactFormFieldValues }
+						contactDetails={ this.state.newContactDetails || this.contactFormFieldValues }
 						needsFax={ this.needsFax() }
 						getIsFieldDisabled={ this.getIsFieldDisabled }
 						onContactDetailsChange={ this.handleContactDetailsChange }


### PR DESCRIPTION
- Blank the state if the country doesn't require inputting one.
- Pass the current country selected for validation on edit contact info form.

Test:
1. Go to Checkout with a domain
2. Try all kinds of stuff with state on the contact info form
3. Make sure the `validate` API call has proper state variable set
4. Finish checkout
----------------------------
1. Go to Edit Contact Info for a domain
2. Choose a state with a dropdown
3. Pick a state
4. Make sure `validate` API call has state set to what was picked
5. Save
6. Pick a state w/o a dropdown, but text input state (Serbia)
7. Input something
8. Make sure the `validate` API call has state set to what was inputted
9. Save
10. Pick Sweden
11. Make sure the `validate` API call call has blanked state
12. Save