### PR TITLE
Domains: Fix how the domain suggestion vendor is changed between NUX/Calypso

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -744,9 +744,7 @@ class RegisterDomainStep extends React.Component {
 
 		const timestamp = Date.now();
 
-		if ( this.props.isSignupStep ) {
-			searchVendor = 'group_2';
-		}
+		searchVendor = this.props.isSignupStep ? 'group_2' : 'group_1';
 
 		const domainSuggestions = Promise.all( [
 			this.checkDomainAvailability( domain, timestamp ),


### PR DESCRIPTION
The original issue is that if you go to the NUX flow it'll change the `searchVendor` to `group_2` and that will be used as suggestion engine even in case you go to Add Domain on an existing site. This diff should fix that and change the `searchVendor` accordingly to the current flow.

To test - go to the NUX flow and search for a domain, make sure the searchVendor is `group_2` (check the Network tab in Developer Tools). Then click on My Sites, choose a site and click on Domains > Add. The searchVendor should be `group_1`.