### PR TITLE
Fix test for getAvailableExternalAccounts after an update on the format of external users

### DIFF
--- a/client/state/sharing/test/selectors.js
+++ b/client/state/sharing/test/selectors.js
@@ -92,6 +92,7 @@ describe( 'selectors', () => {
 					keyringConnectionId: 4,
 					name: 'John',
 					picture: undefined,
+					description: undefined,
 				},
 			] );
 		} );


### PR DESCRIPTION
A new property `description` was added in https://github.com/Automattic/wp-calypso/pull/23806 for external users.

Failing test was detected after merge.

### Testing Instructions
- Check that all tests pass with `npm run test-client -- client/state/sharing` after applying this patch