### PR TITLE
Pagination: vertically center the pagination arrow

### DIFF
--- a/client/components/pagination/style.scss
+++ b/client/components/pagination/style.scss
@@ -51,7 +51,11 @@
 		flex-wrap: nowrap;
 
 		.gridicon {
-			top: 0;
+			top: 1px;
+
+			.pagination.is-compact & {
+				top: 0;
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR fixes a minor misalignment with the pagination arrows. This was observed in Activity Log (top) while testing the new paginated view in https://github.com/Automattic/wp-calypso/pull/23898 and the existing Comments (bottom).

### Before

<img width="376" alt="captura de pantalla 2018-04-13 a la s 13 56 02" src="https://user-images.githubusercontent.com/1041600/38748494-a3d8ac8e-3f24-11e8-9476-bab5ee1fca0b.png">
<img width="410" alt="captura de pantalla 2018-04-13 a la s 13 55 50" src="https://user-images.githubusercontent.com/1041600/38748493-a3aac864-3f24-11e8-9d0a-5f430393e076.png">

### After

<img width="367" alt="captura de pantalla 2018-04-13 a la s 14 03 07" src="https://user-images.githubusercontent.com/1041600/38748491-a34f4476-3f24-11e8-8e37-dc7835f63caa.png">
<img width="388" alt="captura de pantalla 2018-04-13 a la s 14 03 18" src="https://user-images.githubusercontent.com/1041600/38748492-a37b8928-3f24-11e8-80aa-ab606bfb009d.png">

Compact mode remains unaffected as shown in https://github.com/Automattic/wp-calypso/pull/24159#issuecomment-381235764