### PR TITLE
DevDocs: Fix typos in the Playground (take 2)

### DIFF
--- a/client/devdocs/design/playground.jsx
+++ b/client/devdocs/design/playground.jsx
@@ -252,7 +252,7 @@ class DesignAssets extends React.Component {
     <HeaderCake actionText="Fun" actionIcon="status">Welcome to the Playground</HeaderCake>
 	<Button primary onClick={
 		function() {
-			alert( 'World' )
+			alert( 'World' );
 		}
 	}>
 		<Gridicon icon="code" /> Hello
@@ -260,7 +260,7 @@ class DesignAssets extends React.Component {
 	<br /><hr /><br />
 	<ActionCard
 		headerText={ 'Change the code above' }
-		mainText={ 'The playground lets you drop in components and play with values. Its experiemental and likely will break.' }
+		mainText={ 'The playground lets you drop in components and play with values. It is experimental and likely will break.' }
 		buttonText={ 'WordPress' }
 		buttonIcon="external"
 		buttonPrimary={ false }


### PR DESCRIPTION
Fixes two typos and a missing semicolon from the [DevDocs Playground](https://wpcalypso.wordpress.com/devdocs/playground).

![screen shot 2018-04-13 at 10 04 23 am](https://user-images.githubusercontent.com/349751/38752574-8db05cd6-3f10-11e8-9ceb-e88ee6e94e12.png)

I needed to revert #24158  since the apostrophe wasn't properly escaped, causing a syntax error.

**Testing**
* Go to http://calypso.localhost:3000/devdocs/playground and notice if I've broken anything 🙃 