### PR TITLE
Domains: Set up redirects for bad domains/manage/edit/:site route

### DIFF
--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -39,6 +39,11 @@ function getCommonHandlers( {
 export default function() {
 	SiftScience.recordUser();
 
+	// These redirects are work-around in response to an issue where navigating back after a
+	// successful site address change shows a continuous placeholder state... #23929 for details.
+	page.redirect( '/domains/manage/edit', paths.domainManagementRoot() );
+	page.redirect( '/domains/manage/edit/:site', paths.domainManagementRoot() );
+
 	page( paths.domainManagementEmail(), siteSelection, sites, makeLayout, clientRender );
 
 	registerMultiPage( {


### PR DESCRIPTION
### Summary

After successfully making a change to your site address using the new (feature flagged) site address changer feature (/domains/manage/{ old address }/edit/{ old address }) we navigate to /domains/manage/{ new address }/edit/{ new address }.

The reason we do this is to make sure that the new address takes full effect and state items are updated accordingly to reflect the new address.

The problem this causes is that now when we navigate 'back', using the browsers back button or otherwise, we attempt to load /domains/manage/{ old address }/edit/{ old address } which is no longer a valid route.

The real issue here is that there is a redirect to `domains/manage/edit/:site-address` somewhere and that route is currently unhandled. This PR handles that route but the problem itself, that we're redirecting to this route is not yet solved - so consider this PR a work around.

### Testing

#### Deep linking flows
- Go to http://calypso.localhost:3000/domains/manage/edit
  - You should notice that you've been redirected to http://calypso.localhost:3000/domains/manage
- Go to http://calypso.localhost:3000/domains/manage/edit/:some-site-address
  - You should notice that you've been redirected to http://calypso.localhost:3000/domains/manage

#### Site Address Changer flow
- Go to http://calypso.localhost:3000/domains/manage
- Select a site with an address that you don't mind changing
- Go to the site address changer for that site and change the address
- Once the url has updated and the UI now reflects that change, hit the back button
  - You should be redirected to http://calypso.localhost:3000/domains/manage - note that there will be some funkiness with changes to the url. For now theres another redirect in effect too before eventually landing on `domains/manage`

fixes #23929 (sort of)