### PR TITLE
[Domains] Deduplicate suggestions by merging

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -21,7 +21,6 @@ import {
 	snakeCase,
 	startsWith,
 	times,
-	uniqBy,
 } from 'lodash';
 import page from 'page';
 import { stringify } from 'qs';
@@ -615,9 +614,14 @@ class RegisterDomainStep extends React.Component {
 
 		const isKrackenUi = config.isEnabled( 'domains/kracken-ui' );
 
-		const suggestions = uniqBy( flatten( compact( results ) ), function( suggestion ) {
-			return suggestion.domain_name;
+		const suggestionMap = new Map();
+		flatten( compact( results ) ).forEach( result => {
+			const { domain_name: domainName } = result;
+			suggestionMap.has( domainName )
+				? suggestionMap.set( domainName, { ...suggestionMap.get( domainName ), ...result } )
+				: suggestionMap.set( domainName, result );
 		} );
+		const suggestions = [ ...suggestionMap.values() ];
 
 		const strippedDomainBase = getStrippedDomainBase( domain );
 		const exactMatchBeforeTld = suggestion =>


### PR DESCRIPTION
Given an exact match query (ex. `something.tld`), it’s possible to receive two suggestion objects: one with match reasons and one without.

This ensures that we preserve the match reasons when deduplicating the suggestion results by domain names.

### Testing instructions
1. Spin up this branch
2. Navigate to [`/start/domains`](http://calypso.localhost:3000/start/domains).
3. Try an exact match query, like `mygreatbestcompany.ltd`.
4. Ensure that the best match suggestion is also `mygreatbestcompany.ltd`.
5. Ensure that the best match suggestion includes appropriate match reasons. 