### PR TITLE
Activity Log: ensure that plugin data is available before using it

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -108,7 +108,8 @@ class ActivityLogItem extends Component {
 
 		forEach( nextProps.pluginsToUpdate, ( plugin, key ) => {
 			if (
-				this.props.pluginsToUpdate[ key ].updateStatus.status === plugin.updateStatus.status ||
+				get( this.props.pluginsToUpdate, [ key, 'updateStatus', 'status' ], false ) ===
+					plugin.updateStatus.status ||
 				'inProgress' === plugin.updateStatus.status
 			) {
 				return;
@@ -231,6 +232,7 @@ class ActivityLogItem extends Component {
 					return null;
 				}
 				return (
+					plugin &&
 					plugin.update && (
 						<Button
 							primary

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -614,8 +614,8 @@ class ActivityLog extends Component {
 			<Main wideLayout>
 				<PageViewTracker path="/stats/activity/:site" title="Stats > Activity" />
 				<DocumentHead title={ translate( 'Stats' ) } />
-				<QueryRewindState siteId={ siteId } />
-				<QueryJetpackPlugins siteIds={ [ siteId ] } />
+				{ siteId && <QueryRewindState siteId={ siteId } /> }
+				{ siteId && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
 				{ '' !== rewindNoThanks && rewindIsNotReady
 					? siteId && <ActivityLogSwitch siteId={ siteId } redirect={ rewindNoThanks } />
 					: this.getActivityLog() }


### PR DESCRIPTION
Follow up to #22459
Solves a blank page caused by plugin data not available.

### Testing
Using Chrome's Dev Tools, clear Calypso's local storage and indexed DB.

<img width="291" alt="captura de pantalla 2018-04-13 a la s 18 25 27" src="https://user-images.githubusercontent.com/1041600/38758600-17cdaf54-3f48-11e8-8e9b-0488368c66eb.png">
<img width="785" alt="captura de pantalla 2018-04-13 a la s 18 25 53" src="https://user-images.githubusercontent.com/1041600/38758601-17f92a76-3f48-11e8-935d-3f8202178e11.png">

Go to Activity Log. Previously, this caused a frozen blank page. With this PR, AL should be working fine.