### PR TITLE
Checkout: Change expiry label to 'Expiry: MM/YY'

### DIFF
--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -121,8 +121,8 @@ export class CreditCardFormFields extends React.Component {
 				<div className={ creditCardFormFieldsExtrasClassNames }>
 					{ this.createField( 'expiration-date', Input, {
 						inputMode: 'numeric',
-						label: translate( 'MM/YY', {
-							context: 'Expiry label on credit card form',
+						label: translate( 'Expiry: MM/YY', {
+							comment: 'Expiry label on credit card form',
 						} ),
 					} ) }
 


### PR DESCRIPTION
I'm splitting this out from https://github.com/Automattic/wp-calypso/pull/22738. It will fix one of the issues raised in https://github.com/Automattic/wp-calypso/issues/22659: Changing the expiration date field of the credit card form to read "Expiry: MM/YY" rather than just "MM/YY".

As per comments on the original PR, we can also now remove the translation context, because the string makes sense by itself.