### PR TITLE
Fix/site address changer  focus state exp2

### DIFF
--- a/client/blocks/simple-site-rename-form/style.scss
+++ b/client/blocks/simple-site-rename-form/style.scss
@@ -16,6 +16,9 @@
 
 .card.simple-site-rename-form__content {
 	margin-bottom: 0;
+	span.form-text-input-with-affixes__suffix {
+		position: static;
+	}
 }
 
 .simple-site-rename-form__info {


### PR DESCRIPTION
### Summary 

This PR fixes a form field found in the SiteAddressChanger component so that a solid, unbroken border appears when the field is focused.

<img width="73" alt="screen shot 2018-03-28 at 15 38 49" src="https://user-images.githubusercontent.com/4335450/38040059-356a3ea8-329e-11e8-8fd3-f597e0b7d6a1.png">  **>**  <img width="68" alt="screen shot 2018-03-28 at 15 36 50" src="https://user-images.githubusercontent.com/4335450/38039917-de446b76-329d-11e8-82ef-410f179d8aca.png">

Closes #23740.

### Testing

A nice & easy one to test - just select the field @ http://calypso.localhost:3000/domains/manage/your-site.wordpress.com/edit/your-site.wordpress.com