### PR TITLE
Import: Enable site importer in wpcalypso environment

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -61,6 +61,7 @@
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
+		"manage/import/site-importer": true,
 		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,


### PR DESCRIPTION
This PR enables the site importer in the `wpcalypso` environment to allow for easier testing.

#### To test:

1. Use Calypso.live link
2. Check if Site importer is visible and is working
3. Verify no JS errors are appearing in the console