### PR TITLE
Site Address Change: Don't try and validate the existing site name

### DIFF
--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -161,9 +161,13 @@ export class SimpleSiteRenameForm extends Component {
 	}, VALIDATION_DEBOUNCE_MS );
 
 	debouncedValidationCheck = debounce( () => {
-		if ( ! isEmpty( this.state.domainFieldValue ) ) {
-			this.props.requestSiteAddressAvailability( this.props.siteId, this.state.domainFieldValue );
+		const { domainFieldValue } = this.state;
+
+		// Don't try and validate what we know is invalid
+		if ( isEmpty( domainFieldValue ) || domainFieldValue === this.getCurrentDomainPrefix() ) {
+			return;
 		}
+		this.props.requestSiteAddressAvailability( this.props.siteId, this.state.domainFieldValue );
 	}, VALIDATION_DEBOUNCE_MS );
 
 	shouldShowValidationMessage() {
@@ -172,6 +176,13 @@ export class SimpleSiteRenameForm extends Component {
 		const serverValidationMessage = get( validationError, 'message' );
 
 		return isAvailable || showValidationMessage || !! serverValidationMessage;
+	}
+
+	getCurrentDomainPrefix() {
+		const { currentDomain, currentDomainSuffix } = this.props;
+
+		const currentDomainName = get( currentDomain, 'name', '' );
+		return currentDomainName.replace( currentDomainSuffix, '' );
 	}
 
 	getValidationMessage() {
@@ -195,7 +206,7 @@ export class SimpleSiteRenameForm extends Component {
 		} = this.props;
 		const { domainFieldValue } = this.state;
 		const currentDomainName = get( currentDomain, 'name', '' );
-		const currentDomainPrefix = currentDomainName.replace( currentDomainSuffix, '' );
+		const currentDomainPrefix = this.getCurrentDomainPrefix();
 		const shouldShowValidationMessage = this.shouldShowValidationMessage();
 		const validationMessage = this.getValidationMessage();
 		const isBusy = isSiteRenameRequesting || isAvailabilityPending;

--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -167,7 +167,7 @@ export class SimpleSiteRenameForm extends Component {
 		if ( isEmpty( domainFieldValue ) || domainFieldValue === this.getCurrentDomainPrefix() ) {
 			return;
 		}
-		this.props.requestSiteAddressAvailability( this.props.siteId, this.state.domainFieldValue );
+		this.props.requestSiteAddressAvailability( this.props.siteId, domainFieldValue );
 	}, VALIDATION_DEBOUNCE_MS );
 
 	shouldShowValidationMessage() {


### PR DESCRIPTION
We already know it's invalid.

--

~~This is based on the branch in #23492 (`update/site-renamer-availability-check--second-attempt`).~~

When `domainFieldValue` is the same as the current site's address, bail from the function that would otherwise send a `validate` check.

## To Test

* Run this branch
* Visit http://calypso.localhost:3000/domains/manage/
* Select a test site with a WPCOM TLD
* Click to edit
* Attempt to enter the same site address that already exists

* No `validate` request should be issued
* The `Change Site Address` button should be disabled
* No error notice is present (TODO -- we should probably show a form validation error in this case)