### PR TITLE
Add UserMentionSuggestions block

### DIFF
--- a/client/blocks/user-mention-suggestions/docs/example-input.jsx
+++ b/client/blocks/user-mention-suggestions/docs/example-input.jsx
@@ -1,0 +1,22 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import ExampleInput from './example-input';
+import withUserMentionSuggestions from '../with-user-mention-suggestions';
+
+class UserMentionSuggestionsExampleInput extends Component {
+	render() {
+		return <textarea onKeyPress={ this.props.onKeyPress } />;
+	}
+}
+
+export default withUserMentionSuggestions( UserMentionSuggestionsExampleInput );

--- a/client/blocks/user-mention-suggestions/docs/example-input.jsx
+++ b/client/blocks/user-mention-suggestions/docs/example-input.jsx
@@ -3,8 +3,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import React from 'react';
 
 /**
  * Internal dependencies

--- a/client/blocks/user-mention-suggestions/docs/example-input.jsx
+++ b/client/blocks/user-mention-suggestions/docs/example-input.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
@@ -13,10 +12,8 @@ import { connect } from 'react-redux';
 import ExampleInput from './example-input';
 import withUserMentionSuggestions from '../with-user-mention-suggestions';
 
-class UserMentionSuggestionsExampleInput extends Component {
-	render() {
-		return <textarea onKeyPress={ this.props.onKeyPress } />;
-	}
-}
+const UserMentionSuggestionsExampleInput = ( { onKeyPress } ) => (
+	<textarea onKeyPress={ onKeyPress } />
+);
 
 export default withUserMentionSuggestions( UserMentionSuggestionsExampleInput );

--- a/client/blocks/user-mention-suggestions/docs/example.jsx
+++ b/client/blocks/user-mention-suggestions/docs/example.jsx
@@ -6,6 +6,7 @@
 
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -16,10 +17,14 @@ class UserMentionSuggestionsExample extends Component {
 	render() {
 		return (
 			<div className="docs__design-assets-group">
+				<p>{ this.props.translate( 'Try typing an @username into the text input below.' ) }</p>
 				<UserMentionSuggestionsExampleInput />
 			</div>
 		);
 	}
 }
 
-export default UserMentionSuggestionsExample;
+const LocalizedUserMentionSuggestionsExample = localize( UserMentionSuggestionsExample );
+LocalizedUserMentionSuggestionsExample.displayName = 'UserMentionSuggestions';
+
+export default LocalizedUserMentionSuggestionsExample;

--- a/client/blocks/user-mention-suggestions/docs/example.jsx
+++ b/client/blocks/user-mention-suggestions/docs/example.jsx
@@ -3,9 +3,7 @@
 /**
  * External dependencies
  */
-
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import React from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -13,16 +11,12 @@ import { localize } from 'i18n-calypso';
  */
 import UserMentionSuggestionsExampleInput from './example-input';
 
-class UserMentionSuggestionsExample extends Component {
-	render() {
-		return (
-			<div className="docs__design-assets-group">
-				<p>{ this.props.translate( 'Try typing an @username into the text input below.' ) }</p>
-				<UserMentionSuggestionsExampleInput />
-			</div>
-		);
-	}
-}
+const UserMentionSuggestionsExample = ( { translate } ) => (
+	<div className="docs__design-assets-group">
+		<p>{ translate( 'Try typing an @username into the text input below.' ) }</p>
+		<UserMentionSuggestionsExampleInput />
+	</div>
+);
 
 const LocalizedUserMentionSuggestionsExample = localize( UserMentionSuggestionsExample );
 LocalizedUserMentionSuggestionsExample.displayName = 'UserMentionSuggestions';

--- a/client/blocks/user-mention-suggestions/docs/example.jsx
+++ b/client/blocks/user-mention-suggestions/docs/example.jsx
@@ -1,0 +1,25 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import UserMentionSuggestionsExampleInput from './example-input';
+
+class UserMentionSuggestionsExample extends Component {
+	render() {
+		return (
+			<div className="docs__design-assets-group">
+				<UserMentionSuggestionsExampleInput />
+			</div>
+		);
+	}
+}
+
+export default UserMentionSuggestionsExample;

--- a/client/blocks/user-mention-suggestions/with-user-mention-suggestions.jsx
+++ b/client/blocks/user-mention-suggestions/with-user-mention-suggestions.jsx
@@ -1,0 +1,35 @@
+/** @format */
+/**
+ * External Dependencies
+ */
+import React from 'react';
+
+/**
+ * withUserMentionSuggestions is a higher-order component that adds user mention support to whatever input it wraps.
+ *
+ * @example: withUserMentionSuggestions( Component )
+ *
+ * @param {object} EnhancedComponent - react component to wrap
+ * @returns {object} the enhanced component
+ */
+export default EnhancedComponent =>
+	class withUserMentionSuggestions extends React.Component {
+		static displayName = `withUserMentionSuggestions( ${ EnhancedComponent.displayName ||
+			EnhancedComponent.name } )`;
+		static propTypes = {};
+
+		handleKeyPress = e => {
+			if ( e.target.value[ e.target.value.length - 1 ] === '@' ) {
+				console.log( 'found @something' ); // eslint-disable-line no-console
+			}
+		};
+
+		render() {
+			return (
+				<div>
+					<strong>The following input will have @mention magic</strong>
+					<EnhancedComponent { ...this.props } onKeyPress={ this.handleKeyPress } />
+				</div>
+			);
+		}
+	};

--- a/client/blocks/user-mention-suggestions/with-user-mention-suggestions.jsx
+++ b/client/blocks/user-mention-suggestions/with-user-mention-suggestions.jsx
@@ -27,7 +27,6 @@ export default EnhancedComponent =>
 		render() {
 			return (
 				<div>
-					<strong>The following input will have @mention magic</strong>
 					<EnhancedComponent { ...this.props } onKeyPress={ this.handleKeyPress } />
 				</div>
 			);

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -189,7 +189,7 @@ export default class AppComponents extends React.Component {
 					<ConversationFollowButton />
 					<ColorSchemePicker readmeFilePath="color-scheme-picker" />
 					{ isEnabled( 'site-address-editor/devdocs' ) && <SiteRenamer /> }
-					<UserMentionSuggestions />
+					{ isEnabled( 'reader/user-mention-suggestions' ) && <UserMentionSuggestions /> }
 				</Collection>
 			</Main>
 		);

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -85,6 +85,7 @@ import ConversationCaterpillar from 'blocks/conversation-caterpillar/docs/exampl
 import ConversationFollowButton from 'blocks/conversation-follow-button/docs/example';
 import ColorSchemePicker from 'blocks/color-scheme-picker/docs/example';
 import SiteRenamer from 'blocks/simple-site-rename-form/docs/example';
+import UserMentionSuggestions from 'blocks/user-mention-suggestions/docs/example';
 
 export default class AppComponents extends React.Component {
 	static displayName = 'AppComponents';
@@ -188,6 +189,7 @@ export default class AppComponents extends React.Component {
 					<ConversationFollowButton />
 					<ColorSchemePicker readmeFilePath="color-scheme-picker" />
 					{ isEnabled( 'site-address-editor/devdocs' ) && <SiteRenamer /> }
+					<UserMentionSuggestions />
 				</Collection>
 			</Main>
 		);

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -83,6 +83,7 @@
 		"reader/search": true,
 		"reader/conversations": false,
 		"reader/new-post-notifications": true,
+		"reader/user-mention-suggestions": false,
 		"resume-editing": true,
 		"republicize": false,
 		"rubberband-scroll-disable": false,

--- a/config/development.json
+++ b/config/development.json
@@ -145,6 +145,7 @@
 		"reader/related-posts": true,
 		"reader/search": true,
 		"reader/high-watermark": true,
+		"reader/user-mention-suggestions": true,
 		"resume-editing": true,
 		"republicize": true,
 		"restore-last-location": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -93,6 +93,7 @@
 		"reader/new-post-notifications": true,
 		"reader/related-posts": true,
 		"reader/search": true,
+		"reader/user-mention-suggestions": false,
 		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,

--- a/config/production.json
+++ b/config/production.json
@@ -101,6 +101,7 @@
 		"reader/new-post-notifications": true,
 		"reader/related-posts": true,
 		"reader/search": true,
+		"reader/user-mention-suggestions": false,
 		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -104,6 +104,7 @@
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
 		"reader/search": true,
+		"reader/user-mention-suggestions": false,
 		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,

--- a/config/test.json
+++ b/config/test.json
@@ -84,7 +84,7 @@
 		"reader/full-errors": true,
 		"reader/list-management": false,
 		"reader/new-post-notifications": true,
-		"reader/user-mention-suggestions": false,
+		"reader/user-mention-suggestions": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,

--- a/config/test.json
+++ b/config/test.json
@@ -84,6 +84,7 @@
 		"reader/full-errors": true,
 		"reader/list-management": false,
 		"reader/new-post-notifications": true,
+		"reader/user-mention-suggestions": false,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -117,6 +117,7 @@
 		"reader/related-posts": true,
 		"reader/search": true,
 		"reader/high-watermark": true,
+		"reader/user-mention-suggestions": false,
 		"resume-editing": true,
 		"republicize": true,
 		"restore-last-location": false,


### PR DESCRIPTION
Adds a new block, `UserMentionSuggestions`, along with a higher-order component to wrap inputs and provide @ mention suggestions inside them.

### Background

We current have username suggestion for @mentions in the Editor only (implemented in https://github.com/Automattic/wp-calypso/pull/10142). This is the beginning of an effort to decouple that functionality from TinyMCE and make it usable anywhere in Calypso, including the Reader comments section and Conversations tool.

### To test

Visit http://calypso.localhost:3000/devdocs/blocks/user-mention-suggestions and check your console. It doesn't do much yet :-)

<img width="570" alt="screen shot 2018-04-17 at 2 53 55 pm" src="https://user-images.githubusercontent.com/17325/38846231-6cc17fa4-424f-11e8-9530-aa723f60d8ca.png">
