### PR TITLE
Help: chat support button is partially localized

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -57,17 +57,18 @@ import {
 	isDirectlyFailed,
 	isDirectlyReady,
 	isDirectlyUninitialized,
+	getLocalizedLanguageNames,
 } from 'state/selectors';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import { getHelpSelectedSiteId } from 'state/help/selectors';
-import { getLanguage, isDefaultLocale } from 'lib/i18n-utils';
+import { isDefaultLocale } from 'lib/i18n-utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import QueryLanguageNames from 'components/data/query-language-names';
 
 /**
  * Module variables
  */
-const defaultLanguage = getLanguage( config( 'i18n_default_locale_slug' ) ).name;
 const wpcom = wpcomLib.undocumented();
 let savedContactForm = null;
 
@@ -303,7 +304,7 @@ class HelpContact extends React.Component {
 
 	getContactFormPropsVariation = variationSlug => {
 		const { isSubmitting } = this.state;
-		const { currentUserLocale, hasMoreThanOneSite, translate } = this.props;
+		const { currentUserLocale, hasMoreThanOneSite, translate, defaultLanguage } = this.props;
 
 		switch ( variationSlug ) {
 			case SUPPORT_HAPPYCHAT:
@@ -582,6 +583,7 @@ class HelpContact extends React.Component {
 				{ this.props.shouldStartHappychatConnection && <HappychatConnection /> }
 				<QueryTicketSupportConfiguration />
 				<QueryUserPurchases userId={ this.props.currentUser.ID } />
+				<QueryLanguageNames />
 			</Fragment>
 		);
 		if ( this.props.compact ) {
@@ -595,12 +597,16 @@ export default connect(
 	state => {
 		const helpSelectedSiteId = getHelpSelectedSiteId( state );
 		const selectedSitePlan = getSitePlan( state, helpSelectedSiteId );
+		const localizedLanguageNames = getLocalizedLanguageNames( state );
 		return {
 			currentUserLocale: getCurrentUserLocale( state ),
 			currentUser: getCurrentUser( state ),
 			getUserInfo: getHappychatUserInfo( state ),
 			hasHappychatLocalizedSupport: hasHappychatLocalizedSupport( state ),
 			hasAskedADirectlyQuestion: hasUserAskedADirectlyQuestion( state ),
+			defaultLanguage: localizedLanguageNames
+				? localizedLanguageNames[ config( 'i18n_default_locale_slug' ) ].localized
+				: localizedLanguageNames,
 			isDirectlyFailed: isDirectlyFailed( state ),
 			isDirectlyReady: isDirectlyReady( state ),
 			isDirectlyUninitialized: isDirectlyUninitialized( state ),

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -69,6 +69,7 @@ import QueryLanguageNames from 'components/data/query-language-names';
 /**
  * Module variables
  */
+const defaultLanguageSlug = config( 'i18n_default_locale_slug' );
 const wpcom = wpcomLib.undocumented();
 let savedContactForm = null;
 
@@ -304,13 +305,13 @@ class HelpContact extends React.Component {
 
 	getContactFormPropsVariation = variationSlug => {
 		const { isSubmitting } = this.state;
-		const { currentUserLocale, hasMoreThanOneSite, translate, defaultLanguage } = this.props;
+		const { currentUserLocale, hasMoreThanOneSite, translate, localizedLanguageNames } = this.props;
+		let buttonLabel = translate( 'Chat with us' );
 
 		switch ( variationSlug ) {
 			case SUPPORT_HAPPYCHAT:
 				// TEMPORARY: to collect data about the customer preferences, context 1050-happychat-gh
 				// for non english customers check if we have full support in their language
-				let buttonLabel = translate( 'Chat with us' );
 				let additionalSupportOption = { enabled: false };
 
 				if ( ! isDefaultLocale( currentUserLocale ) && ! this.props.hasHappychatLocalizedSupport ) {
@@ -323,10 +324,14 @@ class HelpContact extends React.Component {
 						this.setState( { wasAdditionalSupportOptionShown: true } );
 					}
 
-					// override chat buttons
-					buttonLabel = translate( 'Chat with us in %(defaultLanguage)s', {
-						args: { defaultLanguage },
-					} );
+					if ( localizedLanguageNames && localizedLanguageNames[ defaultLanguageSlug ] ) {
+						// override chat buttons
+						buttonLabel = translate( 'Chat with us in %(defaultLanguage)s', {
+							args: {
+								defaultLanguage: localizedLanguageNames[ defaultLanguageSlug ].localized,
+							},
+						} );
+					}
 
 					// add additional support option
 					additionalSupportOption = {
@@ -597,22 +602,19 @@ export default connect(
 	state => {
 		const helpSelectedSiteId = getHelpSelectedSiteId( state );
 		const selectedSitePlan = getSitePlan( state, helpSelectedSiteId );
-		const localizedLanguageNames = getLocalizedLanguageNames( state );
 		return {
 			currentUserLocale: getCurrentUserLocale( state ),
 			currentUser: getCurrentUser( state ),
 			getUserInfo: getHappychatUserInfo( state ),
 			hasHappychatLocalizedSupport: hasHappychatLocalizedSupport( state ),
 			hasAskedADirectlyQuestion: hasUserAskedADirectlyQuestion( state ),
-			defaultLanguage: localizedLanguageNames
-				? localizedLanguageNames[ config( 'i18n_default_locale_slug' ) ].localized
-				: localizedLanguageNames,
 			isDirectlyFailed: isDirectlyFailed( state ),
 			isDirectlyReady: isDirectlyReady( state ),
 			isDirectlyUninitialized: isDirectlyUninitialized( state ),
 			isEmailVerified: isCurrentUserEmailVerified( state ),
 			isHappychatAvailable: isHappychatAvailable( state ),
 			isHappychatUserEligible: isHappychatUserEligible( state ),
+			localizedLanguageNames: getLocalizedLanguageNames( state ),
 			ticketSupportConfigurationReady: isTicketSupportConfigurationReady( state ),
 			ticketSupportEligible: isTicketSupportEligible( state ),
 			ticketSupportRequestError: getTicketSupportRequestError( state ),


### PR DESCRIPTION
This PR address #23037. The chat button on the help/contact page contains mixed translations. So a user, whose UI is in Spanish, will see the following text:

_Chatea con nosotros en **English**_

To fix we're calling the `/i18n/language-names` API, which returns all localized language names used for the language picker.

<img width="769" alt="screen shot 2018-04-16 at 5 16 01 pm" src="https://user-images.githubusercontent.com/6458278/38794934-081ecb66-419a-11e8-89b0-682594982f9e.png">

## Testing

1. Head to https://wordpress.com/me/account
2. Change your dashboard language to a language other than English, for example, Italian
3. Go to the help page to get the chat box: https://wordpress.com/help/contact

## Expectations

The word "English" in the chat button to be localized according to the selected language, for example, _inglese_ for Italian

