### PR TITLE
Fix CC payment failure when cart includes domain 

### DIFF
--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -334,6 +334,7 @@ class Checkout extends React.Component {
 			this.props.isNewlyCreatedSite &&
 			! cartItems.hasGoogleApps( cart ) &&
 			cartItems.hasDomainRegistration( cart ) &&
+			receipt &&
 			isEmpty( receipt.failed_purchases )
 		) {
 			const domainsForGSuite = this.getEligibleDomainFromCart();


### PR DESCRIPTION
Reported by @alisterscott  in #21905.

<strong>How did #21905 affect this?</strong>

For redirect payments, we need the redirect URL before the transaction is started, and so we call `Checkout.getCheckoutCompleteRedirectPath`. However, this method included a condition where in specific cases (new site, domain included in purchase) expects the receipt to already exist.

<strong>Testing</strong>
- Visit `/start/business` on calypso running this branch
- Navigate through sign up and choose a .live domain
- On the payment details screen - enter sandbox credit card details
- Submit details
- Check that it works




