### PR TITLE
Plans. Allow horizontal scrolling of plan cards on smaller desktop viewports

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -442,6 +442,7 @@ $plan-features-sidebar-width: 272px;
 	margin: 0 auto;
 	padding: 20px 0 10px;
 	transform: translateY(-20px);
+	overflow-x: auto;
 }
 
 .touch {


### PR DESCRIPTION
Fixing issue identified in https://github.com/Automattic/wp-calypso/pull/23979#issuecomment-381450530 - plan cards are not scrollable on smaller desktop viewports.

cc @fditrapani @keoshi 