### PR TITLE
Add spring sale notices for eligible users

### DIFF
--- a/client/components/data/query-active-promotions/index.jsx
+++ b/client/components/data/query-active-promotions/index.jsx
@@ -1,0 +1,45 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { isRequestingActivePromotions } from 'state/active-promotions/selectors';
+import { requestActivePromotions } from 'state/active-promotions/actions';
+
+class QueryActivePromotions extends Component {
+	componentWillMount() {
+		if ( ! this.props.requestingActivePromotions ) {
+			this.props.requestActivePromotions();
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QueryActivePromotions.propTypes = {
+	requestingActivePromotions: PropTypes.bool,
+	requestActivePromotions: PropTypes.func,
+};
+
+QueryActivePromotions.defaultProps = {
+	requestPlans: () => {},
+};
+
+export default connect(
+	state => {
+		return {
+			requestingPlans: isRequestingActivePromotions( state ),
+		};
+	},
+	{ requestActivePromotions }
+)( QueryActivePromotions );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,5 +1,15 @@
 /** @format */
 export default {
+	springSale30PercentOff: {
+		datestamp: '20180413',
+		variations: {
+			upsell: 50,
+			control: 50,
+		},
+		defaultVariation: 'upsell',
+		allowExistingUsers: true,
+		localeTargets: 'any',
+	},
 	signupAtomicStoreVsPressable: {
 		datestamp: '20171101',
 		variations: {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -6,9 +6,8 @@ export default {
 			upsell: 50,
 			control: 50,
 		},
-		defaultVariation: 'upsell',
+		defaultVariation: 'control',
 		allowExistingUsers: true,
-		localeTargets: 'any',
 	},
 	signupAtomicStoreVsPressable: {
 		datestamp: '20171101',

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -120,7 +120,7 @@ class SiteNotice extends React.Component {
 				ctaText={ translate( 'Upgrade' ) }
 				href={ `/plans/${ site.slug }?sale` }
 				icon="info-outline"
-				text={ translate( '30% Off All Plans' ) }
+				text={ '30% Off All Plans' } // no translate() since we're launching this just for EN audience
 			/>
 		);
 	}

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -14,11 +14,13 @@ import { localize } from 'i18n-calypso';
 import SidebarBanner from 'my-sites/current-site/sidebar-banner';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+import isEligibleForSpringDiscount from 'state/selectors/is-current-user-eligible-for-spring-discount';
 import { domainManagementList } from 'my-sites/domains/paths';
 import { hasDomainCredit } from 'state/sites/plans/selectors';
 import { canCurrentUser, isDomainOnlySite, isEligibleForFreeToPaidUpsell } from 'state/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import QuerySitePlans from 'components/data/query-site-plans';
+import QueryActivePromotions from 'components/data/query-active-promotions';
 import {
 	isStarted as isJetpackPluginsStarted,
 	isFinished as isJetpackPluginsFinished,
@@ -105,6 +107,24 @@ class SiteNotice extends React.Component {
 		);
 	}
 
+	freeToPaidPlan30PercentOffNotice() {
+		if ( ! this.props.isEligibleForFreeToPaidUpsell ) {
+			return null;
+		}
+
+		const { site, translate } = this.props;
+
+		return (
+			<SidebarBanner
+				ctaName="free-to-paid-sidebar"
+				ctaText={ translate( 'Upgrade' ) }
+				href={ `/plans/${ site.slug }?spring` }
+				icon="info-outline"
+				text={ translate( '30% Off All Plans' ) }
+			/>
+		);
+	}
+
 	jetpackPluginsSetupNotice() {
 		if (
 			! this.props.pausedJetpackPluginsSetup ||
@@ -138,7 +158,10 @@ class SiteNotice extends React.Component {
 		}
 		return (
 			<div className="site__notices">
-				{ this.freeToPaidPlanNotice() }
+				<QueryActivePromotions />
+				{ this.props.isEligibleForSpringDiscount
+					? this.freeToPaidPlan30PercentOffNotice()
+					: this.freeToPaidPlanNotice() }
 				<DomainToPaidPlanNotice />
 				{ this.getSiteRedirectNotice( site ) }
 				<QuerySitePlans siteId={ site.ID } />
@@ -155,6 +178,7 @@ export default connect(
 		return {
 			isDomainOnly: isDomainOnlySite( state, siteId ),
 			isEligibleForFreeToPaidUpsell: isEligibleForFreeToPaidUpsell( state, siteId ),
+			isEligibleForSpringDiscount: isEligibleForSpringDiscount( state, siteId ),
 			hasDomainCredit: hasDomainCredit( state, siteId ),
 			canManageOptions: canCurrentUser( state, siteId, 'manage_options' ),
 			pausedJetpackPluginsSetup:

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -112,12 +112,12 @@ class SiteNotice extends React.Component {
 			return null;
 		}
 
-		const { site, translate } = this.props;
+		const { site } = this.props;
 
 		return (
 			<SidebarBanner
 				ctaName="free-to-paid-sidebar"
-				ctaText={ translate( 'Upgrade' ) }
+				ctaText={ 'Upgrade' }
 				href={ `/plans/${ site.slug }?sale` }
 				icon="info-outline"
 				text={ '30% Off All Plans' } // no translate() since we're launching this just for EN audience

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -118,7 +118,7 @@ class SiteNotice extends React.Component {
 			<SidebarBanner
 				ctaName="free-to-paid-sidebar"
 				ctaText={ translate( 'Upgrade' ) }
-				href={ `/plans/${ site.slug }?spring` }
+				href={ `/plans/${ site.slug }?sale` }
 				icon="info-outline"
 				text={ translate( '30% Off All Plans' ) }
 			/>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -173,7 +173,6 @@ class PlanFeatures extends Component {
 		const {
 			canPurchase,
 			hasPlaceholders,
-			translate,
 			withSaleInfo,
 			isEligibleForSpringDiscount: eligible,
 		} = this.props;
@@ -194,7 +193,8 @@ class PlanFeatures extends Component {
 				icon="info-outline"
 				status="is-success"
 			>
-				{ translate( 'Enter coupon code “SPRING30” during checkout to claim your 30% discount' ) }
+				{ /* no translate() since we're launching this just for EN audience */ }
+				{ 'Enter coupon code “SPRING30” during checkout to claim your 30% discount' }
 			</Notice>,
 			bannerContainer
 		);

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -24,6 +24,7 @@ import PlanFeaturesHeader from './header';
 import PlanFeaturesItem from './item';
 import PlanFeaturesSummary from './summary';
 import SpinnerLine from 'components/spinner-line';
+import QueryActivePromotions from 'components/data/query-active-promotions';
 import { abtest, getABTestVariation } from 'lib/abtest';
 import { getCurrentUserCurrencyCode, getCurrentUserId } from 'state/current-user/selectors';
 import { getPlan, getPlanBySlug, getPlanRawPrice, getPlanSlug } from 'state/plans/selectors';
@@ -31,6 +32,7 @@ import { getSignupDependencyStore } from 'state/signup/dependency-store/selector
 import { planItem as getCartItemForPlan } from 'lib/cart-values/cart-items';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { retargetViewPlans } from 'lib/analytics/ad-tracking';
+import isEligibleForSpringDiscount from 'state/selectors/is-current-user-eligible-for-spring-discount';
 import {
 	applyTestFiltersToPlansList,
 	canUpgradeToPlan,
@@ -102,9 +104,11 @@ class PlanFeatures extends Component {
 
 		return (
 			<div className={ planWrapperClasses } ref={ this.setScrollLeft }>
+				<QueryActivePromotions />
 				{ showModifiedPricingDisplay && ! site.jetpack && this.renderCreditNotice() }
 				<div className={ planClasses }>
 					{ this.renderUpgradeDisabledNotice() }
+					{ this.render30PercentOffNotice() }
 					<div className="plan-features__content">
 						{ mobileView }
 						<table className={ tableClasses }>
@@ -160,6 +164,39 @@ class PlanFeatures extends Component {
 						},
 					}
 				) }
+			</Notice>,
+			bannerContainer
+		);
+	}
+
+	render30PercentOffNotice() {
+		const {
+			canPurchase,
+			hasPlaceholders,
+			translate,
+			isEligibleForSpringDiscount: eligible,
+		} = this.props;
+		const bannerContainer = document.querySelector( '.plans-features-main__notice' );
+		const comesFromSidebarNudge = window.location.search.indexOf( 'spring' ) !== -1;
+
+		if (
+			! eligible ||
+			! bannerContainer ||
+			! comesFromSidebarNudge ||
+			hasPlaceholders ||
+			! canPurchase
+		) {
+			return null;
+		}
+
+		return ReactDOM.createPortal(
+			<Notice
+				className="plan-features__notice-credits"
+				showDismiss={ false }
+				icon="info-outline"
+				status="is-success"
+			>
+				{ translate( 'Enter coupon code “SPRING30” during checkout to claim your 30% discount' ) }
 			</Notice>,
 			bannerContainer
 		);
@@ -823,6 +860,8 @@ export default connect(
 			showModifiedPricingDisplay,
 			sitePlan,
 			siteType,
+
+			isEligibleForSpringDiscount: isEligibleForSpringDiscount( state ),
 		};
 	},
 	{

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -174,19 +174,17 @@ class PlanFeatures extends Component {
 			canPurchase,
 			hasPlaceholders,
 			translate,
+			withSaleInfo,
 			isEligibleForSpringDiscount: eligible,
 		} = this.props;
 		const bannerContainer = document.querySelector( '.plans-features-main__notice' );
-		const comesFromSidebarNudge = window.location.search.indexOf( 'spring' ) !== -1;
 
-		if (
-			! eligible ||
-			! bannerContainer ||
-			! comesFromSidebarNudge ||
-			hasPlaceholders ||
-			! canPurchase
-		) {
-			return null;
+		if ( ! bannerContainer ) {
+			return false;
+		}
+
+		if ( ! eligible || ! withSaleInfo || hasPlaceholders || ! canPurchase ) {
+			return ReactDOM.createPortal( <div />, bannerContainer );
 		}
 
 		return ReactDOM.createPortal(

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -66,6 +66,7 @@ export class PlansFeaturesMain extends Component {
 			onUpgradeClick,
 			selectedFeature,
 			selectedPlan,
+			withSaleInfo,
 			site,
 		} = this.props;
 
@@ -84,6 +85,7 @@ export class PlansFeaturesMain extends Component {
 					plans={ this.getPlansForPlanFeatures() }
 					selectedFeature={ selectedFeature }
 					selectedPlan={ selectedPlan }
+					withSaleInfo={ withSaleInfo }
 					site={ site }
 				/>
 			</div>

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -26,6 +26,7 @@ export default {
 					destinationType={ context.params.destinationType }
 					selectedFeature={ context.query.feature }
 					selectedPlan={ context.query.plan }
+					withSaleInfo={ 'sale' in context.query }
 				/>
 			</CheckoutData>
 		);

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -102,6 +102,7 @@ class Plans extends React.Component {
 							intervalType={ this.props.intervalType }
 							selectedFeature={ this.props.selectedFeature }
 							selectedPlan={ this.props.selectedPlan }
+							withSaleInfo={ this.props.withSaleInfo }
 							site={ selectedSite }
 						/>
 					</div>

--- a/client/state/selectors/is-current-user-eligible-for-spring-discount.js
+++ b/client/state/selectors/is-current-user-eligible-for-spring-discount.js
@@ -1,0 +1,33 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { abtest } from 'lib/abtest';
+import { hasActivePromotion } from 'state/active-promotions/selectors';
+
+/**
+ * Returns info whether the site is eligible for spring discount or not.
+ *
+ * @param  {Object}  state Global state tree.
+ * @return {bool}    Whether the site is eligible for spring discount or not.
+ */
+export default state => {
+	// This is not super reliable but is fine for purposes of this test - display the
+	// upsell until we hit a certain point in time
+	const pastPromo = new Date() > new Date( Date.UTC( 2018, 3, 20, 23, 59, 59 ) );
+	if ( pastPromo ) {
+		return false;
+	}
+
+	if ( ! hasActivePromotion( state, 'spring_sale' ) ) {
+		return false;
+	}
+
+	const variant = abtest( 'springSale30PercentOff' );
+	if ( variant !== 'upsell' ) {
+		return false;
+	}
+
+	return true;
+};


### PR DESCRIPTION
This PR adds an A/B of a spring sale on a certain subset of users.

Test plan:
1. Put yourself in the "upsell" group of springSale30PercentOff test:

<img width="411" alt="zrzut ekranu 2018-04-16 o 13 54 33" src="https://user-images.githubusercontent.com/205419/38807796-0b8615e6-417e-11e8-90fb-2eb5aa12f1f0.png">

2. Go to a free site that you own in calypso
3. Confirm the sidebar banner says nothing about "30% off"
4. Go to plans page and confirm there is nothing there  about "30% off"
5. Run the following on your sandbox: 1d938-pb 
6. Refresh calypso
7. Confirm the following nudge is visible in the sidebar of your free site:

<img width="280" alt="zrzut ekranu 2018-04-16 o 14 01 15" src="https://user-images.githubusercontent.com/205419/38807947-a8ade18c-417e-11e8-8e50-253cd0cdeebe.png">

8. Click it, confirm that plans page has the following message:

<img width="1050" alt="zrzut ekranu 2018-04-16 o 14 05 26" src="https://user-images.githubusercontent.com/205419/38808106-39fd7710-417f-11e8-9087-dfd0a02393db.png">

9. Go back to dashboard
10. Go to plans page via the regular way, not via the nudge, and confirm there is no upsell-related message
11. Put yourself in the "control" group like in step 1 and refresh the page
12. Confirm the nudge in the sidebar doesn't have information about 30% discount