### PR TITLE
Checkout: only use the checklist option for the return url if the receipt is set

### DIFF
--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -294,6 +294,7 @@ class Checkout extends React.Component {
 			0
 		);
 
+		// Note: this function is called early on for redirect-type payment methods, when the receipt isn't set yet.
 		// The `:receiptId` string is filled in by our callback page after the PayPal checkout
 		const receiptId = receipt ? receipt.receipt_id : ':receiptId';
 
@@ -347,7 +348,7 @@ class Checkout extends React.Component {
 		}
 
 		// DO NOT assign the test here.
-		if ( 'show' === getABTestVariation( 'checklistThankYouForPaidUser' ) ) {
+		if ( receipt && 'show' === getABTestVariation( 'checklistThankYouForPaidUser' ) ) {
 			return `/checklist/${ selectedSiteSlug }?d=paid`;
 		}
 


### PR DESCRIPTION
For redirect payments, we need the redirect URL to be the default `checkout/thank-you/{site_id}/:receiptId` type - the checklist type thank you URL won't work. (cc @taggon if we decide to use the checklist one by default).

Since we call `Checkout.getCheckoutCompleteRedirectPath` early, we can use the fact that `receipt` is not set to bypass the abtest for the checklis version.

*Testing*
- Set `localStorage.setItem( 'ABTests', '{ "checklistThankYouForPaidUser_20171204": "show" }' );`
- Use a redirect payment method (like Giropay/iDEA etc)
- Make sure that after a succssfull payment, you are redirect back to the `checkout/thank-you/{site_id}/:receiptId` url (which should take you to then pending page if the purchase hasn't been confirmed by webhook.


