### PR TITLE
Domains: Add EU address format for Spain

### DIFF
--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/constants.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/constants.js
@@ -4,8 +4,8 @@ export const CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES = [ 'GB', 'IE' ];
 // a localized list of states from the backend:
 // AU, BE, BR, CN, ES, IN, IT, JP, MX
 export const CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES = [
-	'AR', 'AT', 'BA', 'BG', 'CH', 'CL', 'CZ', 'DE',
-	'DK', 'EE', 'FI', 'FR', 'HU', 'IS', 'IL', 'LU', 'MC',
+	'AR', 'AT', 'BA', 'BG', 'CH', 'CL', 'CZ', 'DE', 'DK',
+	'EE', 'ES', 'FI', 'FR', 'HU', 'IS', 'IL', 'LU', 'MC',
 	'NL', 'NO', 'PL', 'PT', 'RO', 'SE', 'SI', 'SK', 'SV',
 	'UY', 'VE',
 ];


### PR DESCRIPTION
@ramonjd can you recall whether Spain was dropped from the list intentionally or if it was an innocent omission? In case it was the latter, this will add it.

In the other case we need to look into providing provinces vs. states (currently we have the latter in the select but we should have the former).