### PR TITLE
Jetpack Connect: Fix space between instructions screen buttons

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -150,6 +150,10 @@
 	margin-top: 16px;
 }
 
+.jetpack-connect__install {
+	margin-bottom: 16px;
+}
+
 .jetpack-connect__install-steps {
 	display: flex;
 	justify-content: center;


### PR DESCRIPTION
It seems that in #23678 we introduced a subtle bug in the legacy Jetpack installation instructions page - the space between the Install button and the help button disappeared:

![](https://cldup.com/S5tWJ2ULcy.png)

This PR adds the same space in that particular case that we're adding in other cases:

![](https://cldup.com/IXpmYAfa9z.png)

Note: this can be reproduced only in staging/production, as in development/wpcalypso environments we're already presenting the new Jetpack install flow.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/jetpack/connect?flags=-jetpack/connect/remote-install
* Input a site that doesn't have Jetpack installed/activated.
* Submit the form.
* Verify the space looks as shown on the second screenshot.
* Verify no other pages/screens are affected by this change (a `grep` should be enough).