### PR TITLE
Jetpack Connect: Clean up black friday offer code

### DIFF
--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -9,7 +9,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Banner from 'components/banner';
 import Main from 'components/main';
 import FormattedHeader from 'components/formatted-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
@@ -43,35 +42,10 @@ class JetpackPlansGrid extends Component {
 		return <FormattedHeader headerText={ headerText } subHeaderText={ subheaderText } />;
 	}
 
-	renderBlackFridayOffer() {
-		const { translate, moment } = this.props;
-
-		const startDate = new Date( 'Nov 24 2017 00:00:00 GMT' );
-		const endDate = new Date( 'Nov 27 2017 23:59:59 GMT-8' );
-
-		if ( moment().isBetween( startDate, endDate ) ) {
-			return (
-				<Banner
-					callToAction={ translate( 'Get the coupon code' ) }
-					title={ '' }
-					description={ translate(
-						'Our Black Friday sale is going on now. Take up to 60% off all plans through November 27.'
-					) }
-					dismissTemporary={ true }
-					href={ 'https://jetpack.com/black-friday/' }
-					target={ '_blank' }
-					event={ 'calypso_jpc_blackfriday_click' }
-				/>
-			);
-		}
-		return null;
-	}
-
 	render() {
 		return (
 			<Main wideLayout className="jetpack-connect__hide-plan-icons">
 				<div className="jetpack-connect__plans">
-					{ this.renderBlackFridayOffer() }
 					{ this.renderConnectHeader() }
 					<div id="plans">
 						<PlansFeaturesMain


### PR DESCRIPTION
This PR removes the black friday offer code, as the promotion hasn't been running in a while and it will take some time before we actually decide to run it again.

When we need, we can always bring it back, but for the time being, I don't think there's a good reason for it to be around, especially considering the fact that the promotion would still need manual intervention in order to be restarted again.

To test:

* Checkout this branch
* Go to http://calypso.localhost:3000/jetpack/connect/store and verify the page works well.
* Connect a site, reach the plans page and verify it works well.
* Verify there are no behavioral/visual changes on the plans pages.