### PR TITLE
DevDocs: Update readme for ScreenReaderText

### DIFF
--- a/client/components/screen-reader-text/README.md
+++ b/client/components/screen-reader-text/README.md
@@ -1,27 +1,25 @@
 ScreenReaderText (JSX)
 ====================
 
-ScreenReaderText is a component that is invisible on normal displays but "visible" to screen readers.
+ScreenReaderText is a component that is invisible on screen, but read out to screen readers. Use this to add context to inputs, buttons, or sections that might be obvious from visual cues but not to a screen reader user.
+
+This idea was pulled from WordPress core, for more background & technical details, see [Hiding text for screen readers with WordPress Core](https://make.wordpress.org/accessibility/2015/02/09/hiding-text-for-screen-readers-with-wordpress-core/)
 
 -------
 
 #### How to use:
 
 ```js
+import Button from 'components/button';
+import Gridicon from 'gridicons';
 import ScreenReaderText from 'components/screen-reader-text';
 
 function ScreenReaderTextExample() {
-	const srText = "I'm visible for screen readers";
 	return (
-		<div>
-			<p>
-				This text is followed by the JSX "&lt;ScreenReaderText&gt;{ srText }&lt;/ScreenReaderText&gt;".
-				It's invisible on normal displays but "visible" to screen readers. Inspect to see the
-				example.
-			</p>
-			<ScreenReaderText>{ srText }</ScreenReaderText>
-		</div>
+		<Button>
+			<Gridicon icon="cross" />
+			<ScreenReaderText>{ translate( 'Close' ) }</ScreenReaderText>
+		</Button>
 	);
 }
-
 ```

--- a/client/components/screen-reader-text/docs/example.jsx
+++ b/client/components/screen-reader-text/docs/example.jsx
@@ -17,8 +17,7 @@ export default function ScreenReaderTextExample() {
 		<div>
 			<p>
 				This text is followed by the JSX "&lt;ScreenReaderText&gt;{ srText }&lt;/ScreenReaderText&gt;".
-				It's invisible on normal displays but "visible" to screen readers. Inspect to see the
-				example.
+				It is invisible on screen, but read out to screen readers. Inspect to see the example.
 			</p>
 			<ScreenReaderText>{ srText }</ScreenReaderText>
 		</div>


### PR DESCRIPTION
Updates the readme for `<ScreenReaderText />` - adding more background, context for why someone might use the component, and updates the demo to a real example.

**To test**

- Check the readme [on github](https://github.com/Automattic/wp-calypso/blob/420fc5591179ca0fa439206b5d698986ac9f4f4b/client/components/screen-reader-text/README.md)
- Load calypso, view the readme & updated example content at `/devdocs/design/screen-reader-text`