### PR TITLE
Jetpack Connect: Remove unneeded renderNotJetpackButton method

### DIFF
--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -368,19 +368,6 @@ export class JetpackConnectMain extends Component {
 			</MainWrapper>
 		);
 	}
-
-	renderNotJetpackButton() {
-		const { translate } = this.props;
-		return (
-			<a
-				className="jetpack-connect__no-jetpack-button"
-				href="#"
-				onClick={ this.confirmJetpackNotInstalled }
-			>
-				{ translate( "Don't have jetpack installed?" ) }
-			</a>
-		);
-	}
 }
 
 const connectComponent = connect(


### PR DESCRIPTION
This PR removes the `renderNotJetpackButton` method from `JetpackConnectMain` as it's not used at all (it's separately defined in `install-step`). Seems like this method has been around and unused for a while (since #7709 😱 ).

To test:
* Checkout this branch
* Verify the method indeed isn't used.
* Smoke test just a little bit (it never hurts, does it).