### PR TITLE
Jetpack Connect: Cleanup the NoDirectAccessError component

### DIFF
--- a/client/jetpack-connect/no-direct-access-error.js
+++ b/client/jetpack-connect/no-direct-access-error.js
@@ -19,7 +19,6 @@ import JetpackConnectHappychatButton from './happychat-button';
 
 class NoDirectAccessError extends PureComponent {
 	static propTypes = {
-		authorizationRemoteQueryData: PropTypes.object,
 		recordTracksEvent: PropTypes.func.isRequired,
 	};
 

--- a/client/jetpack-connect/no-direct-access-error.js
+++ b/client/jetpack-connect/no-direct-access-error.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -17,7 +17,7 @@ import EmptyContent from 'components/empty-content';
 import HelpButton from './help-button';
 import JetpackConnectHappychatButton from './happychat-button';
 
-class NoDirectAccessError extends Component {
+class NoDirectAccessError extends PureComponent {
 	static propTypes = {
 		authorizationRemoteQueryData: PropTypes.object,
 		recordTracksEvent: PropTypes.func.isRequired,

--- a/client/jetpack-connect/no-direct-access-error.js
+++ b/client/jetpack-connect/no-direct-access-error.js
@@ -20,17 +20,20 @@ import JetpackConnectHappychatButton from './happychat-button';
 class NoDirectAccessError extends PureComponent {
 	static propTypes = {
 		recordTracksEvent: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
 	};
 
 	handleClickHelp = () => this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
 
 	render() {
+		const { translate } = this.props;
+
 		return (
 			<Main className="jetpack-connect__main-error">
 				<EmptyContent
 					illustration="/calypso/images/illustrations/whoops.svg"
-					title={ this.props.translate( 'Oops, this URL should not be accessed directly' ) }
-					action={ this.props.translate( 'Get back to Jetpack Connect screen' ) }
+					title={ translate( 'Oops, this URL should not be accessed directly' ) }
+					action={ translate( 'Get back to Jetpack Connect screen' ) }
 					actionURL="/jetpack/connect"
 				/>
 				<LoggedOutFormLinks>

--- a/client/jetpack-connect/no-direct-access-error.js
+++ b/client/jetpack-connect/no-direct-access-error.js
@@ -10,12 +10,12 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Main from 'components/main';
-import LoggedOutFormLinks from 'components/logged-out-form/links';
-import { recordTracksEvent } from 'state/analytics/actions';
 import EmptyContent from 'components/empty-content';
 import HelpButton from './help-button';
 import JetpackConnectHappychatButton from './happychat-button';
+import LoggedOutFormLinks from 'components/logged-out-form/links';
+import Main from 'components/main';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class NoDirectAccessError extends PureComponent {
 	static propTypes = {


### PR DESCRIPTION
This PR performs several minor cleanups in the `NoDirectAccessError` component. No behavioral or visual changes should be introduced by this PR.

A more detailed list of what this PR suggests is:

* Use a `PureComponent` instead of `Component`.
* Remove an unnecessary `propType`.
* Add a consumed `propType` to the list of expected `propTypes`.
* Destructure `translate` out of props for shorter usage.
* Sort some imports 🔤 .

To test:
* Checkout this branch.
* Directly head to http://calypso.localhost:3000/jetpack/connect/authorize
* Verify there are no visual/behavioral changes with what we have in production.