### PR TITLE
JP Remote Install: Add tracks events

### DIFF
--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -34,6 +34,7 @@ import {
 } from 'state/jetpack-remote-install/actions';
 import { getJetpackRemoteInstallErrorCode, isJetpackRemoteInstallComplete } from 'state/selectors';
 import { getConnectingSite } from 'state/jetpack-connect/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { REMOTE_PATH_AUTH } from './constants';
 import {
 	ACTIVATION_FAILURE,
@@ -60,6 +61,9 @@ export class OrgCredentialsForm extends Component {
 		}
 		this.setState( { isSubmitting: true } );
 
+		this.props.recordTracksEvent( 'calypso_jpc_remote_install_creds_submit', {
+			url: siteToConnect,
+		} );
 		this.props.jetpackRemoteInstall( siteToConnect, this.state.username, this.state.password );
 	};
 
@@ -79,6 +83,10 @@ export class OrgCredentialsForm extends Component {
 				page.redirect( '/jetpack/connect' );
 			}
 		}
+
+		this.props.recordTracksEvent( 'calypso_jpc_remote_install_view', {
+			url: siteToConnect,
+		} );
 	}
 
 	componentDidUpdate() {
@@ -349,5 +357,6 @@ export default connect(
 	{
 		jetpackRemoteInstall,
 		jetpackRemoteInstallUpdateError,
+		recordTracksEvent,
 	}
 )( localize( OrgCredentialsForm ) );

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -61,7 +61,7 @@ export class OrgCredentialsForm extends Component {
 		}
 		this.setState( { isSubmitting: true } );
 
-		this.props.recordTracksEvent( 'calypso_jpc_remote_install_creds_submit', {
+		this.props.recordTracksEvent( 'calypso_jpc_remoteinstall_submit', {
 			url: siteToConnect,
 		} );
 		this.props.jetpackRemoteInstall( siteToConnect, this.state.username, this.state.password );
@@ -84,7 +84,7 @@ export class OrgCredentialsForm extends Component {
 			}
 		}
 
-		this.props.recordTracksEvent( 'calypso_jpc_remote_install_view', {
+		this.props.recordTracksEvent( 'calypso_jpc_remoteinstall_view', {
 			url: siteToConnect,
 		} );
 	}

--- a/client/state/data-layer/wpcom/jetpack-install/index.js
+++ b/client/state/data-layer/wpcom/jetpack-install/index.js
@@ -47,7 +47,7 @@ export const handleError = ( action, error ) => {
 
 	const logToTracks = withAnalytics(
 		recordTracksEvent( 'calypso_jpc_remoteinstall_api_fail', {
-			url: url,
+			url,
 			error: error.error,
 			message: error.message,
 			status: error.status,

--- a/client/state/data-layer/wpcom/jetpack-install/index.js
+++ b/client/state/data-layer/wpcom/jetpack-install/index.js
@@ -31,11 +31,10 @@ export const installJetpackPlugin = action =>
 		action
 	);
 
-export const handleSuccess = ( { url }, data ) => {
+export const handleSuccess = ( { url } ) => {
 	const logToTracks = withAnalytics(
-		recordTracksEvent( 'calypso_jpc_remote_install_api_success', {
+		recordTracksEvent( 'calypso_jpc_remoteinstall_api_success', {
 			url,
-			data: JSON.stringify( data ),
 		} )
 	);
 
@@ -47,9 +46,11 @@ export const handleError = ( action, error ) => {
 	const { retryCount = 0 } = dataLayer;
 
 	const logToTracks = withAnalytics(
-		recordTracksEvent( 'calypso_jpc_remote_install_api_failure', {
+		recordTracksEvent( 'calypso_jpc_remoteinstall_api_fail', {
 			url: url,
-			data: JSON.stringify( error ),
+			error: error.error,
+			message: error.message,
+			status: error.status,
 		} )
 	);
 

--- a/client/state/data-layer/wpcom/jetpack-install/index.js
+++ b/client/state/data-layer/wpcom/jetpack-install/index.js
@@ -33,8 +33,8 @@ export const installJetpackPlugin = action =>
 
 export const handleSuccess = ( { url }, data ) => {
 	const logToTracks = withAnalytics(
-		recordTracksEvent( 'calypso_jpc_remote_install_api_response', {
-			remote_site_url: url,
+		recordTracksEvent( 'calypso_jpc_remote_install_api_success', {
+			url,
 			data: JSON.stringify( data ),
 		} )
 	);
@@ -47,8 +47,8 @@ export const handleError = ( action, error ) => {
 	const { retryCount = 0 } = dataLayer;
 
 	const logToTracks = withAnalytics(
-		recordTracksEvent( 'calypso_jpc_remote_install_api_response', {
-			remote_site_url: url,
+		recordTracksEvent( 'calypso_jpc_remote_install_api_failure', {
+			url: url,
 			data: JSON.stringify( error ),
 		} )
 	);


### PR DESCRIPTION
Add some analytics to the Jetpack Remote Install feature ahead of enabling in production. This should be enough events (combined with some existing JPC events) to track a site from first entry in the url box through to connection success (or not).

## Testing
* In your JS console, enter: `localStorage.debug = 'calypso:analytics:tracks'`
* Go to https://calypso.live/jetpack/connect?branch=add/remote-install-tracks
* Keep an eye on the console for the new tracks events as you proceed through the flow
* Enter the URL of a .org site without jetpack installed ( https://jurassic.ninja/create/?shortlived&nojetpack )
* Enter invalid credentials to cause an error response

