### PR TITLE
DevDocs: Link to Gridicons and Social Logos and add basic usage

### DIFF
--- a/docs/icons.md
+++ b/docs/icons.md
@@ -4,7 +4,7 @@ This document will cover how to use icons in Calypso, as well as how to create i
 
 ## Gridicons
 
-[Gridicons](https://github.com/automattic/gridicons) is the brand new icon set designed from the bottom up for Calypso. It features a consistent style. There's a gallery with all the available icons in https://automattic.github.io/gridicons/.
+[Gridicons](https://github.com/automattic/gridicons) is the icon set designed for Calypso. There's a gallery with all the available icons at https://automattic.github.io/gridicons/.
 
 Gridicons are born with a 24px base grid. Strokes are 2px thick and icons are solid. If an icon is hollow, it generally means the "inactive" version of that icon. For example an outline bookmark icon becomes solid once clicked.
 

--- a/docs/icons.md
+++ b/docs/icons.md
@@ -53,6 +53,30 @@ The tricky part is that not all icons need this `offset-adjust` hack, only some 
 - Only use 18px Gridicons if you really must, and don't use it in main navigation
 - Don't use Noticons or Dashicons (we want to phase them out)
 
+## Social Logos
+
+We have a `SocialLogos` component available for use in Calypso. Each logo was pulled from the official branding resource of each service. Branding guidelines were adhered to as much as possible.
+
+The icon grid is based on Gridicons and adheres to the same rules (see above). [View the repository on GitHub](https://github.com/Automattic/social-logos) for more information.
+
+### Usage
+
+Import the iconset and decide at run-time which icon to use:
+
+```
+import SocialLogo from 'social-logos';
+//...
+render() {
+    return <SocialLogo icon="twitter" size={ 48 } />;
+}
+```
+
+**Props**
+
+- `icon`: String - the icon name.
+- `size`: Number - (default: 24) set the size of the icon.
+- `onClick`: Function - (optional) if you need a click callback.
+
 
 ## App icons
 

--- a/docs/icons.md
+++ b/docs/icons.md
@@ -4,9 +4,27 @@ This document will cover how to use icons in Calypso, as well as how to create i
 
 ## Gridicons
 
-Gridicons is the brand new icon set designed from the bottom up for Calypso. It features a consistent style.
+[Gridicons](https://github.com/automattic/gridicons) is the brand new icon set designed from the bottom up for Calypso. It features a consistent style. There's a gallery with all the available icons in https://automattic.github.io/gridicons/.
 
 Gridicons are born with a 24px base grid. Strokes are 2px thick and icons are solid. If an icon is hollow, it generally means the "inactive" version of that icon. For example an outline bookmark icon becomes solid once clicked.
+
+### Usage
+
+Import the iconset and decide at run-time which icon to use:
+
+```
+import Gridicon from 'gridicons';
+//...
+render() {
+  return <Gridicon icon="add-image" />;
+}
+```
+
+**Props**
+
+- `icon`: String - the icon name. This is ignored when importing icons individually.
+- `size`: Number - (default: 24) set the size of the icon.
+- `onClick`: Function - (optional) if you need a click callback.
 
 Though Gridicons are vector graphics and theoretically infinitely scalable, in practice we have to work within the limitations of antialiasing so icons stay crisp. Since Gridicons are designed for 24px, they look perfect at that size. That's why by default, this is the size you should be using.
 
@@ -66,4 +84,3 @@ Finally, build the favicon. Only include 16 and 32px sizes directly in the .ico 
 
 - [Favicon Cheat Sheet](https://github.com/audreyr/favicon-cheat-sheet)
 - [Favicon Quiz](https://css-tricks.com/favicon-quiz/)
-


### PR DESCRIPTION
This addresses #24106 by updating the icons documentation to include a link to the Gridicons and Social Logos repositories. I've also added some basic usage instructions that were missing to make implementation easier.

#### Testing

* Check out this branch `update/devdocs-iconography`.
* Confirm link to the gridicons repo and usage has been added.
* Confirm information about Social Logos has been added.