### PR TITLE
DevDocs: Add Animate component

### DIFF
--- a/client/components/animate/README.md
+++ b/client/components/animate/README.md
@@ -19,4 +19,4 @@ render() {
 
 #### Props
 
-* `type`: a string matching one of the approved transition effects.
+* `type`: (string) a string matching one of the approved transition effects (`appear` or `fade-in`).

--- a/client/components/animate/docs/example.jsx
+++ b/client/components/animate/docs/example.jsx
@@ -1,0 +1,27 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Animate from '../index';
+
+function AnimateExample( props ) {
+	return props.exampleCode;
+}
+
+AnimateExample.displayName = 'Animate';
+
+AnimateExample.defaultProps = {
+	exampleCode: (
+		<Animate type="appear">
+			This content will animate on rendering. You may have to reload the page to see the effect.
+		</Animate>
+	),
+};
+
+export default AnimateExample;

--- a/client/devdocs/design/component-examples.js
+++ b/client/devdocs/design/component-examples.js
@@ -3,6 +3,7 @@
  */
 export ActionCard from 'components/action-card/docs/example';
 export Accordions from 'components/accordion/docs/example';
+export Animate from 'components/animate/docs/example';
 export BackButton from 'components/back-button/docs/example';
 export Badge from 'components/badge/docs/example';
 export Banner from 'components/banner/docs/example';

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -27,6 +27,7 @@ import SearchCard from 'components/search-card';
  */
 import Accordions from 'components/accordion/docs/example';
 import ActionCard from 'components/action-card/docs/example';
+import Animate from 'components/animate/docs/example';
 import BackButton from 'components/back-button/docs/example';
 import Badge from 'components/badge/docs/example';
 import Banner from 'components/banner/docs/example';
@@ -155,6 +156,7 @@ class DesignAssets extends React.Component {
 						componentUsageStats={ componentsUsageStats.accordion }
 						readmeFilePath="accordion"
 					/>
+					<Animate readmeFilePath="animate" />
 					<BackButton readmeFilePath="back-button" />
 					<Badge readmeFilePath="badge" />
 					<Banner readmeFilePath="banner" />

--- a/client/devdocs/design/playground-scope.js
+++ b/client/devdocs/design/playground-scope.js
@@ -11,6 +11,7 @@ export SocialLogo from 'social-logos';
  */
 export ActionCard from 'components/action-card';
 export Accordion from 'components/accordion';
+export Animate from 'components/animate';
 export BackButton from 'components/back-button';
 export Badge from 'components/badge';
 export Banner from 'components/banner';

--- a/client/devdocs/design/playground.jsx
+++ b/client/devdocs/design/playground.jsx
@@ -17,11 +17,11 @@ import jsxToString from 'jsx-to-string';
  */
 import config from 'config';
 import * as componentExamples from 'devdocs/design/component-examples';
+import * as playgroundScope from 'devdocs/design/playground-scope';
 import DocumentHead from 'components/data/document-head';
 import fetchComponentsUsageStats from 'state/components-usage-stats/actions';
 import Main from 'components/main';
 import DropdownItem from 'components/select-dropdown/item';
-import * as playgroundScope from 'devdocs/design/playground-scope';
 import SelectDropdown from 'components/select-dropdown';
 
 class DesignAssets extends React.Component {


### PR DESCRIPTION
This PR partially addresses #24136 - a lot of components and blocks aren't listed in DevDocs.

* Added `Animate` component to DevDocs and DevDocs playground.
* Reordered import statements in `playground.jsx`.

cc @scruffian