### PR TITLE
DevDocs: Add Chart component

### DIFF
--- a/client/components/chart/docs/example.jsx
+++ b/client/components/chart/docs/example.jsx
@@ -1,0 +1,176 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Chart from '../index';
+
+function ChartExample() {
+	const chartData = [
+		{
+			label: '2018',
+			value: 7416852578,
+			tooltipData: [
+				{
+					label: 'Global population',
+				},
+				{
+					label: '2018',
+					value: 7416852578,
+					icon: 'globe',
+				},
+			],
+		},
+		{
+			label: '2019',
+			value: 7487663656,
+			tooltipData: [
+				{
+					label: 'Global population',
+				},
+				{
+					label: '2019',
+					value: 7487663656,
+					icon: 'globe',
+				},
+			],
+		},
+		{
+			label: '2020',
+			value: 7557514266,
+			tooltipData: [
+				{
+					label: 'Global population',
+				},
+				{
+					label: '2020',
+					value: 7557514266,
+					icon: 'globe',
+				},
+			],
+		},
+		{
+			label: '2021',
+			value: 7626477056,
+			tooltipData: [
+				{
+					label: 'Global population',
+				},
+				{
+					label: '2021',
+					value: 7626477056,
+					icon: 'globe',
+				},
+			],
+		},
+		{
+			label: '2022',
+			value: 7694592508,
+			tooltipData: [
+				{
+					label: 'Global population',
+				},
+				{
+					label: '2022',
+					value: 7694592508,
+					icon: 'globe',
+				},
+			],
+		},
+		{
+			label: '2023',
+			value: 7761728812,
+			tooltipData: [
+				{
+					label: 'Global population',
+				},
+				{
+					label: '2023',
+					value: 7761728812,
+					icon: 'globe',
+				},
+			],
+		},
+		{
+			label: '2024',
+			value: 7827803562,
+			tooltipData: [
+				{
+					label: 'Global population',
+				},
+				{
+					label: '2024',
+					value: 7827803562,
+					icon: 'globe',
+				},
+			],
+		},
+		{
+			label: '2025',
+			value: 7892758722,
+			tooltipData: [
+				{
+					label: 'Global population',
+				},
+				{
+					label: '2025',
+					value: 7892758722,
+					icon: 'globe',
+				},
+			],
+		},
+		{
+			label: '2026',
+			value: 7956667160,
+			tooltipData: [
+				{
+					label: 'Global population',
+				},
+				{
+					label: '2026',
+					value: 7956667160,
+					icon: 'globe',
+				},
+			],
+		},
+		{
+			label: '2027',
+			value: 8019596128,
+			tooltipData: [
+				{
+					label: 'Global population',
+				},
+				{
+					label: '2027',
+					value: 8019596128,
+					icon: 'globe',
+				},
+			],
+		},
+		{
+			label: '2028',
+			value: 8081508492,
+			tooltipData: [
+				{
+					label: 'Global population',
+				},
+				{
+					label: '2028',
+					value: 8081508492,
+					icon: 'globe',
+				},
+			],
+		},
+	];
+
+	return <Chart loading={ false } data={ chartData } />;
+}
+
+ChartExample.displayName = 'Chart';
+
+export default ChartExample;

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -35,6 +35,7 @@ import ButtonGroups from 'components/button-group/docs/example';
 import Buttons from 'components/button/docs/example';
 import Cards from 'components/card/docs/example';
 import CardHeading from 'components/card-heading/docs/example';
+import Chart from 'components/chart/docs/example';
 import Checklist from 'components/checklist/docs/example';
 import ClipboardButtonInput from 'components/clipboard-button-input/docs/example';
 import ClipboardButtons from 'components/forms/clipboard-button/docs/example';
@@ -161,6 +162,7 @@ class DesignAssets extends React.Component {
 					<SplitButton readmeFilePath="split-button" />
 					<Cards readmeFilePath="card" />
 					<CardHeading readmeFilePath="card-heading" />
+					<Chart readmeFilePath="chart" />
 					<Checklist />
 					<ClipboardButtonInput readmeFilePath="clipboard-button-input" />
 					<ClipboardButtons readmeFilePath="forms/clipboard-button" />

--- a/client/devdocs/design/playground.jsx
+++ b/client/devdocs/design/playground.jsx
@@ -25,19 +25,20 @@ import SearchCard from 'components/search-card';
 /**
  * Docs examples
  */
-import ActionCard from 'components/action-card';
 import Accordions from 'components/accordion';
+import ActionCard from 'components/action-card';
 import BackButton from 'components/back-button';
 import Badge from 'components/badge';
 import Banner from 'components/banner';
 import BulkSelect from 'components/bulk-select';
-import ButtonGroup from 'components/button-group';
 import Button from 'components/button';
+import ButtonGroup from 'components/button-group';
 import Card from 'components/card';
 import CardHeading from 'components/card-heading';
+import Chart from 'components/chart';
 import Checklist from 'components/checklist';
-import ClipboardButtonInput from 'components/clipboard-button-input';
 import ClipboardButton from 'components/forms/clipboard-button';
+import ClipboardButtonInput from 'components/clipboard-button-input';
 import Collection from 'devdocs/design/search-collection';
 import Count from 'components/count';
 import CountedTextarea from 'components/forms/counted-textarea';
@@ -65,8 +66,8 @@ import FormLegend from 'components/forms/form-legend';
 import FormPasswordInput from 'components/forms/form-password-input';
 import FormPhoneInput from 'components/forms/form-phone-input';
 import FormRadio from 'components/forms/form-radio';
-import FormRadioWithThumbnail from 'components/forms/form-radio-with-thumbnail';
 import FormRadiosBarExample from 'components/forms/form-radios-bar/docs/example';
+import FormRadioWithThumbnail from 'components/forms/form-radio-with-thumbnail';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import FormSelect from 'components/forms/form-select';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
@@ -88,6 +89,9 @@ import JetpackColophon from 'components/jetpack-colophon';
 import JetpackLogo from 'components/jetpack-logo';
 import LanguagePicker from 'components/language-picker';
 import ListEnd from 'components/list-end';
+import NavItem from 'components/section-nav/item';
+import NavSegmented from 'components/section-nav/segmented';
+import NavTabs from 'components/section-nav/tabs';
 import Notices from 'components/notice';
 import Pagination from 'components/pagination';
 import PaymentLogo from 'components/payment-logo';
@@ -101,9 +105,6 @@ import ScreenReaderText from 'components/screen-reader-text';
 import Search from 'components/search';
 import SectionHeader from 'components/section-header';
 import SectionNav from 'components/section-nav';
-import NavTabs from 'components/section-nav/tabs';
-import NavSegmented from 'components/section-nav/segmented';
-import NavItem from 'components/section-nav/item';
 import SegmentedControl from 'components/segmented-control';
 import SelectDropdown from 'components/select-dropdown';
 import ShareButton from 'components/share-button';
@@ -154,6 +155,7 @@ class DesignAssets extends React.Component {
 			ButtonGroup,
 			Card,
 			CardHeading,
+			Chart,
 			Checklist,
 			ClipboardButton,
 			ClipboardButtonInput,


### PR DESCRIPTION
This PR partially addresses #24136 - a lot of components and blocks aren't listed in DevDocs.

* Added Chart component to DevDocs and DevDocs playground.
* Reordered import statements in playground.jsx.