### PR TITLE
DevDocs: Remove PropTypes definition for unused translate prop in ActionCard example

### DIFF
--- a/client/components/action-card/docs/example.jsx
+++ b/client/components/action-card/docs/example.jsx
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import React from 'react';
-import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -16,10 +15,6 @@ ActionCard.displayName = 'ActionCard';
 function ActionCardExample( props ) {
 	return props.exampleCode;
 }
-
-ActionCardExample.propTypes = {
-	translate: PropTypes.func.isRequired,
-};
 
 ActionCardExample.displayName = 'ActionCard';
 


### PR DESCRIPTION
The `ActionCard` example had `translate` defined as a required prop, but `translate` wasn't passed to it or used. This was causing a warning, so I've removed the `propTypes` definition from the example.

cc @scruffian