### PR TITLE
DevDocs: Add TextareaAutosize component

### DIFF
--- a/client/components/textarea-autosize/docs/example.jsx
+++ b/client/components/textarea-autosize/docs/example.jsx
@@ -1,0 +1,31 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import TextareaAutosize from '../index';
+
+TextareaAutosizeExample.displayName = 'TextareaAutosize';
+
+function TextareaAutosizeExample( props ) {
+	return props.exampleCode;
+}
+
+TextareaAutosizeExample.defaultProps = {
+	exampleCode: (
+		<TextareaAutosize
+			rows="1"
+			defaultValue={
+				'This textarea will grow and shrink to suit its content, ' +
+				'though it keeps a minimum height.'
+			}
+		/>
+	),
+};
+
+export default TextareaAutosizeExample;

--- a/client/devdocs/design/component-examples.js
+++ b/client/devdocs/design/component-examples.js
@@ -66,6 +66,7 @@ export SpinnerButton from 'components/spinner-button/docs/example';
 export SpinnerLine from 'components/spinner-line/docs/example';
 export SplitButton from 'components/split-button/docs/example';
 export Suggestions from 'components/suggestions/docs/example';
+export TextareaAutosize from 'components/textarea-autosize/docs/example';
 export TextDiff from 'components/text-diff/docs/example';
 export TileGrid from 'components/tile-grid/docs/example';
 export TimeSince from 'components/time-since/docs/example';

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -91,6 +91,7 @@ import SpinnerButton from 'components/spinner-button/docs/example';
 import SpinnerLine from 'components/spinner-line/docs/example';
 import SplitButton from 'components/split-button/docs/example';
 import Suggestions from 'components/suggestions/docs/example';
+import TextareaAutosize from 'components/textarea-autosize/docs/example';
 import TextDiff from 'components/text-diff/docs/example';
 import TileGrid from 'components/tile-grid/docs/example';
 import TimeSince from 'components/time-since/docs/example';
@@ -217,6 +218,7 @@ class DesignAssets extends React.Component {
 					<SpinnerButton searchKeywords="loading input submit" readmeFilePath="spinner-button" />
 					<SpinnerLine searchKeywords="loading" readmeFilePath="spinner-line" />
 					<Suggestions readmeFilePath="suggestions" />
+					<TextareaAutosize readmeFilePath="textarea-autosize" />
 					<TextDiff readmeFilePath="text-diff" />
 					<TileGrid readmeFilePath="tile-grid" />
 					<TimeSince readmeFilePath="time-since" />

--- a/client/devdocs/design/playground-scope.js
+++ b/client/devdocs/design/playground-scope.js
@@ -100,6 +100,7 @@ export SpinnerButton from 'components/spinner-button';
 export SpinnerLine from 'components/spinner-line';
 export SplitButton from 'components/split-button';
 export Suggestions from 'components/suggestions';
+export TextareaAutosize from 'components/textarea-autosize';
 export TextDiff from 'components/text-diff';
 export TileGrid from 'components/tile-grid';
 export TimeSince from 'components/time-since';


### PR DESCRIPTION
This PR partially addresses #24136 - a lot of components and blocks aren't listed in DevDocs.

* Added `TextareaAutosize` example to DevDocs and DevDocs playground.
* Reordered import statements in `playground.jsx`.

cc @scruffian