### PR TITLE
Plans: Componentize FAQs

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -171,7 +171,7 @@ export class PlansFeaturesMain extends Component {
 		let faqs = null;
 
 		if ( ! isInSignup ) {
-			faqs = displayJetpackPlans ? <JetpackFAQ /> : <WpcomFAQ site={ site } />;
+			faqs = displayJetpackPlans ? <JetpackFAQ /> : <WpcomFAQ />;
 		}
 
 		return (

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -25,17 +25,15 @@ import {
 	GROUP_JETPACK,
 } from 'lib/plans/constants';
 import { addQueryArgs } from 'lib/url';
+import JetpackFAQ from './jetpack-faq';
+import WpcomFAQ from './wpcom-faq';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
-import FAQ from 'components/faq';
-import FAQItem from 'components/faq/faq-item';
 import { isEnabled } from 'config';
-import { purchasesRoot } from 'me/purchases/paths';
 import { plansLink, findPlansKeys, getPlan } from 'lib/plans';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
 import PaymentMethods from 'blocks/payment-methods';
-import HappychatButton from 'components/happychat/button';
 import HappychatConnection from 'components/happychat/connection-connected';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 import { selectSiteId as selectHappychatSiteId } from 'state/help/actions';
@@ -128,214 +126,6 @@ export class PlansFeaturesMain extends Component {
 		return plans;
 	}
 
-	getJetpackFAQ() {
-		const { isChatAvailable, translate } = this.props;
-
-		const helpLink =
-			isEnabled( 'jetpack/happychat' ) && isChatAvailable ? (
-				<HappychatButton className="plans-features-main__happychat-button" />
-			) : (
-				<a href="https://jetpack.com/contact-support/" target="_blank" rel="noopener noreferrer" />
-			);
-
-		return (
-			<FAQ>
-				<FAQItem
-					question={ translate( 'I signed up and paid. What’s next?' ) }
-					answer={ translate(
-						'Our premium features are powered by a few of our other plugins. After purchasing you will' +
-							' need to install the Akismet and VaultPress plugins. Just follow the guide' +
-							' after you complete your purchase.'
-					) }
-				/>
-
-				<FAQItem
-					question={ translate( 'What are the hosting requirements?' ) }
-					answer={ translate(
-						'You should be running the latest version of WordPress and be using a web host that runs' +
-							' PHP 5 or higher. You will also need a WordPress.com account (you can register' +
-							' during the connection process) and a publicly-accessible site with XML-RPC enabled.'
-					) }
-				/>
-
-				<FAQItem
-					question={ translate( 'Does this work with a multisite network?' ) }
-					answer={ translate(
-						'Yes, Jetpack and all of its premium features are compatible with WordPress Multisite' +
-							' networks. If you manage a Multisite network you will need to make sure you have a' +
-							' subscription for each site you wish to cover with premium features.'
-					) }
-				/>
-
-				<FAQItem
-					question={ translate( 'Why do I need a WordPress.com account?' ) }
-					answer={ translate(
-						"Many of Jetpack's core features make use of the WordPress.com cloud. In order to make sure" +
-							' everything works correctly, Jetpack requires you to connect a (free) WordPress.com' +
-							" account. If you don't already have an account you can easily create one during the" +
-							' connection process.'
-					) }
-				/>
-
-				<FAQItem
-					question={ translate( 'What is the cancellation policy?' ) }
-					answer={ translate(
-						'You can request a cancellation within 30 days of purchase and receive a full refund.'
-					) }
-				/>
-
-				<FAQItem
-					question={ translate( 'Have more questions?' ) }
-					answer={ translate(
-						'No problem! Feel free to {{helpLink}}get in touch{{/helpLink}} with our Happiness Engineers.',
-						{
-							components: { helpLink },
-						}
-					) }
-				/>
-			</FAQ>
-		);
-	}
-
-	getFAQ() {
-		const { isChatAvailable, site, translate } = this.props;
-
-		const helpLink =
-			isEnabled( 'happychat' ) && isChatAvailable ? (
-				<HappychatButton className="plans-features-main__happychat-button" />
-			) : (
-				<a href="https://wordpress.com/help" target="_blank" rel="noopener noreferrer" />
-			);
-
-		return (
-			<FAQ>
-				<FAQItem
-					question={ translate( 'Do you sell domains?' ) }
-					answer={ translate(
-						'Yes! The Personal, Premium, and Business plans include a free custom domain. That includes new' +
-							' domains purchased through WordPress.com or your own existing domain that you can map' +
-							' to your WordPress.com site. Does not apply to premium domains. {{a}}Find out more about domains.{{/a}}',
-						{
-							components: {
-								a: (
-									<a
-										href="https://en.support.wordpress.com/all-about-domains/"
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							},
-						}
-					) }
-				/>
-
-				<FAQItem
-					question={ translate( 'Can I install plugins?' ) }
-					answer={ translate(
-						'Yes! With the WordPress.com Business plan you can search for and install external plugins.' +
-							' All plans already come with a custom set of plugins tailored just for them.' +
-							' {{a}}Check out all included plugins{{/a}}.',
-						{
-							components: { a: <a href={ `/plugins/${ site.slug }` } /> },
-						}
-					) }
-				/>
-
-				<FAQItem
-					question={ translate( 'Can I upload my own theme?' ) }
-					answer={ translate(
-						"Yes! With the WordPress.com Business plan you can upload any theme you'd like." +
-							' All plans give you access to our {{a}}directory of free and premium themes{{/a}}.' +
-							' These are among the highest-quality WordPress themes, hand-picked and reviewed by our team.',
-						{
-							components: { a: <a href={ `/themes/${ site.slug }` } /> },
-						}
-					) }
-				/>
-
-				<FAQItem
-					question={ translate( 'Do I need another web host?' ) }
-					answer={ translate(
-						'No. All WordPress.com sites include our specially tailored WordPress hosting to ensure' +
-							' your site stays available and secure at all times. You can even use your own domain' +
-							' when you upgrade to the Personal, Premium, or Business plan.'
-					) }
-				/>
-
-				<FAQItem
-					question={ translate( 'Do you offer email accounts?' ) }
-					answer={ translate(
-						'Yes. If you register a new domain with our Personal, Premium, or Business plans, you can' +
-							' add Google-powered G Suite. You can also set up email forwarding for any custom domain' +
-							' registered through WordPress.com. {{a}}Find out more about email{{/a}}.',
-						{
-							components: {
-								a: (
-									<a
-										href="https://en.support.wordpress.com/add-email/"
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							},
-						}
-					) }
-				/>
-
-				<FAQItem
-					question={ translate( 'What’s included with advanced custom design?' ) }
-					answer={ translate(
-						'Custom design is a toolset you can use to personalize your blog’s look and feel with' +
-							' custom colors & backgrounds, custom fonts, and even a CSS editor that you can use for' +
-							' more precise control of your site’s' +
-							' design. {{a}}Find out more about custom design{{/a}}.',
-						{
-							components: {
-								a: (
-									<a
-										href="https://en.support.wordpress.com/custom-design/"
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							},
-						}
-					) }
-				/>
-
-				<FAQItem
-					question={ translate( 'Will upgrading affect my content?' ) }
-					answer={ translate(
-						'Plans add extra features to your site, but they do not affect the content of your site' +
-							" or your site's followers."
-					) }
-				/>
-
-				<FAQItem
-					question={ translate( 'Can I cancel my subscription?' ) }
-					answer={ translate(
-						'Yes. We want you to love everything you do at WordPress.com, so we provide a 30-day' +
-							' refund on all of our plans. {{a}}Manage purchases{{/a}}.',
-						{
-							components: { a: <a href={ purchasesRoot } /> },
-						}
-					) }
-				/>
-
-				<FAQItem
-					question={ translate( 'Have more questions?' ) }
-					answer={ translate(
-						'Need help deciding which plan works for you? Our happiness engineers are available for' +
-							' any questions you may have. {{helpLink}}Get help{{/helpLink}}.',
-						{
-							components: { helpLink },
-						}
-					) }
-				/>
-			</FAQ>
-		);
-	}
-
 	constructPath( plansUrl, intervalType ) {
 		const { selectedFeature, selectedPlan, site } = this.props;
 		return addQueryArgs(
@@ -378,12 +168,10 @@ export class PlansFeaturesMain extends Component {
 
 	render() {
 		const { site, displayJetpackPlans, isInSignup } = this.props;
-
-		const renderFAQ = () => ( displayJetpackPlans ? this.getJetpackFAQ() : this.getFAQ( site ) );
 		let faqs = null;
 
 		if ( ! isInSignup ) {
-			faqs = renderFAQ();
+			faqs = displayJetpackPlans ? <JetpackFAQ /> : <WpcomFAQ site={ site } />;
 		}
 
 		return (

--- a/client/my-sites/plans-features-main/jetpack-faq.jsx
+++ b/client/my-sites/plans-features-main/jetpack-faq.jsx
@@ -1,0 +1,87 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FAQ from 'components/faq';
+import FAQItem from 'components/faq/faq-item';
+import HappychatButton from 'components/happychat/button';
+import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
+import { isEnabled } from 'config';
+
+const JetpackFAQ = ( { isChatAvailable, translate } ) => {
+	const helpLink =
+		isEnabled( 'jetpack/happychat' ) && isChatAvailable ? (
+			<HappychatButton className="plans-features-main__happychat-button" />
+		) : (
+			<a href="https://jetpack.com/contact-support/" target="_blank" rel="noopener noreferrer" />
+		);
+
+	return (
+		<FAQ>
+			<FAQItem
+				question={ translate( 'I signed up and paid. What’s next?' ) }
+				answer={ translate(
+					'Our premium features are powered by a few of our other plugins. After purchasing you will' +
+						' need to install the Akismet and VaultPress plugins. Just follow the guide' +
+						' after you complete your purchase.'
+				) }
+			/>
+
+			<FAQItem
+				question={ translate( 'What are the hosting requirements?' ) }
+				answer={ translate(
+					'You should be running the latest version of WordPress and be using a web host that runs' +
+						' PHP 5 or higher. You will also need a WordPress.com account (you can register' +
+						' during the connection process) and a publicly-accessible site with XML-RPC enabled.'
+				) }
+			/>
+
+			<FAQItem
+				question={ translate( 'Does this work with a multisite network?' ) }
+				answer={ translate(
+					'Yes, Jetpack and all of its premium features are compatible with WordPress Multisite' +
+						' networks. If you manage a Multisite network you will need to make sure you have a' +
+						' subscription for each site you wish to cover with premium features.'
+				) }
+			/>
+
+			<FAQItem
+				question={ translate( 'Why do I need a WordPress.com account?' ) }
+				answer={ translate(
+					"Many of Jetpack's core features make use of the WordPress.com cloud. In order to make sure" +
+						' everything works correctly, Jetpack requires you to connect a (free) WordPress.com' +
+						" account. If you don't already have an account you can easily create one during the" +
+						' connection process.'
+				) }
+			/>
+
+			<FAQItem
+				question={ translate( 'What is the cancellation policy?' ) }
+				answer={ translate(
+					'You can request a cancellation within 30 days of purchase and receive a full refund.'
+				) }
+			/>
+
+			<FAQItem
+				question={ translate( 'Have more questions?' ) }
+				answer={ translate(
+					'No problem! Feel free to {{helpLink}}get in touch{{/helpLink}} with our Happiness Engineers.',
+					{
+						components: { helpLink },
+					}
+				) }
+			/>
+		</FAQ>
+	);
+};
+
+export default connect( state => ( {
+	isChatAvailable: isHappychatAvailable( state ),
+} ) )( localize( JetpackFAQ ) );

--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -1,0 +1,158 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FAQ from 'components/faq';
+import FAQItem from 'components/faq/faq-item';
+import HappychatButton from 'components/happychat/button';
+import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
+import { isEnabled } from 'config';
+import { purchasesRoot } from 'me/purchases/paths';
+
+const WpcomFAQ = ( { isChatAvailable, site, translate } ) => {
+	const helpLink =
+		isEnabled( 'happychat' ) && isChatAvailable ? (
+			<HappychatButton className="plans-features-main__happychat-button" />
+		) : (
+			<a href="https://wordpress.com/help" target="_blank" rel="noopener noreferrer" />
+		);
+
+	return (
+		<FAQ>
+			<FAQItem
+				question={ translate( 'Do you sell domains?' ) }
+				answer={ translate(
+					'Yes! The Personal, Premium, and Business plans include a free custom domain. That includes new' +
+						' domains purchased through WordPress.com or your own existing domain that you can map' +
+						' to your WordPress.com site. Does not apply to premium domains. {{a}}Find out more about domains.{{/a}}',
+					{
+						components: {
+							a: (
+								<a
+									href="https://en.support.wordpress.com/all-about-domains/"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					}
+				) }
+			/>
+
+			<FAQItem
+				question={ translate( 'Can I install plugins?' ) }
+				answer={ translate(
+					'Yes! With the WordPress.com Business plan you can search for and install external plugins.' +
+						' All plans already come with a custom set of plugins tailored just for them.' +
+						' {{a}}Check out all included plugins{{/a}}.',
+					{
+						components: { a: <a href={ `/plugins/${ site.slug }` } /> },
+					}
+				) }
+			/>
+
+			<FAQItem
+				question={ translate( 'Can I upload my own theme?' ) }
+				answer={ translate(
+					"Yes! With the WordPress.com Business plan you can upload any theme you'd like." +
+						' All plans give you access to our {{a}}directory of free and premium themes{{/a}}.' +
+						' These are among the highest-quality WordPress themes, hand-picked and reviewed by our team.',
+					{
+						components: { a: <a href={ `/themes/${ site.slug }` } /> },
+					}
+				) }
+			/>
+
+			<FAQItem
+				question={ translate( 'Do I need another web host?' ) }
+				answer={ translate(
+					'No. All WordPress.com sites include our specially tailored WordPress hosting to ensure' +
+						' your site stays available and secure at all times. You can even use your own domain' +
+						' when you upgrade to the Personal, Premium, or Business plan.'
+				) }
+			/>
+
+			<FAQItem
+				question={ translate( 'Do you offer email accounts?' ) }
+				answer={ translate(
+					'Yes. If you register a new domain with our Personal, Premium, or Business plans, you can' +
+						' add Google-powered G Suite. You can also set up email forwarding for any custom domain' +
+						' registered through WordPress.com. {{a}}Find out more about email{{/a}}.',
+					{
+						components: {
+							a: (
+								<a
+									href="https://en.support.wordpress.com/add-email/"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					}
+				) }
+			/>
+
+			<FAQItem
+				question={ translate( 'What’s included with advanced custom design?' ) }
+				answer={ translate(
+					'Custom design is a toolset you can use to personalize your blog’s look and feel with' +
+						' custom colors & backgrounds, custom fonts, and even a CSS editor that you can use for' +
+						' more precise control of your site’s' +
+						' design. {{a}}Find out more about custom design{{/a}}.',
+					{
+						components: {
+							a: (
+								<a
+									href="https://en.support.wordpress.com/custom-design/"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					}
+				) }
+			/>
+
+			<FAQItem
+				question={ translate( 'Will upgrading affect my content?' ) }
+				answer={ translate(
+					'Plans add extra features to your site, but they do not affect the content of your site' +
+						" or your site's followers."
+				) }
+			/>
+
+			<FAQItem
+				question={ translate( 'Can I cancel my subscription?' ) }
+				answer={ translate(
+					'Yes. We want you to love everything you do at WordPress.com, so we provide a 30-day' +
+						' refund on all of our plans. {{a}}Manage purchases{{/a}}.',
+					{
+						components: { a: <a href={ purchasesRoot } /> },
+					}
+				) }
+			/>
+
+			<FAQItem
+				question={ translate( 'Have more questions?' ) }
+				answer={ translate(
+					'Need help deciding which plan works for you? Our happiness engineers are available for' +
+						' any questions you may have. {{helpLink}}Get help{{/helpLink}}.',
+					{
+						components: { helpLink },
+					}
+				) }
+			/>
+		</FAQ>
+	);
+};
+
+export default connect( state => ( {
+	isChatAvailable: isHappychatAvailable( state ),
+} ) )( localize( WpcomFAQ ) );

--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -13,10 +13,11 @@ import FAQ from 'components/faq';
 import FAQItem from 'components/faq/faq-item';
 import HappychatButton from 'components/happychat/button';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { isEnabled } from 'config';
 import { purchasesRoot } from 'me/purchases/paths';
 
-const WpcomFAQ = ( { isChatAvailable, site, translate } ) => {
+const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 	const helpLink =
 		isEnabled( 'happychat' ) && isChatAvailable ? (
 			<HappychatButton className="plans-features-main__happychat-button" />
@@ -53,7 +54,7 @@ const WpcomFAQ = ( { isChatAvailable, site, translate } ) => {
 						' All plans already come with a custom set of plugins tailored just for them.' +
 						' {{a}}Check out all included plugins{{/a}}.',
 					{
-						components: { a: <a href={ `/plugins/${ site.slug }` } /> },
+						components: { a: <a href={ `/plugins/${ siteSlug }` } /> },
 					}
 				) }
 			/>
@@ -65,7 +66,7 @@ const WpcomFAQ = ( { isChatAvailable, site, translate } ) => {
 						' All plans give you access to our {{a}}directory of free and premium themes{{/a}}.' +
 						' These are among the highest-quality WordPress themes, hand-picked and reviewed by our team.',
 					{
-						components: { a: <a href={ `/themes/${ site.slug }` } /> },
+						components: { a: <a href={ `/themes/${ siteSlug }` } /> },
 					}
 				) }
 			/>
@@ -155,4 +156,5 @@ const WpcomFAQ = ( { isChatAvailable, site, translate } ) => {
 
 export default connect( state => ( {
 	isChatAvailable: isHappychatAvailable( state ),
+	siteSlug: getSelectedSiteSlug( state ),
 } ) )( localize( WpcomFAQ ) );


### PR DESCRIPTION
Will come in handy for the optimistic plans page, and IMO is a good improvement anyway. 

Testing Instructions:
Verify that FAQ still work both for WP.com, and Jetpack sites. Also verify that any links found in FAQ items still work.