### PR TITLE
SiteAddressChanger: Remove discard option & TODO from component

### DIFF
--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -62,10 +62,8 @@ export class SimpleSiteRenameForm extends Component {
 
 	onConfirm = () => {
 		const { selectedSiteId } = this.props;
-		// @TODO: Give ability to chose whether or not to discard the original site address.
-		const discard = true;
 
-		this.props.requestSiteRename( selectedSiteId, this.state.domainFieldValue, discard );
+		this.props.requestSiteRename( selectedSiteId, this.state.domainFieldValue );
 	};
 
 	setValidationState = () => {

--- a/client/state/site-rename/actions.js
+++ b/client/state/site-rename/actions.js
@@ -95,7 +95,7 @@ export const clearValidationError = siteId => dispatch => {
 	} );
 };
 
-export const requestSiteRename = ( siteId, newBlogName, discard ) => dispatch => {
+export const requestSiteRename = ( siteId, newBlogName, discard = true ) => dispatch => {
 	dispatch( {
 		type: SITE_RENAME_REQUEST,
 		siteId,


### PR DESCRIPTION
### Summary
This PR removes reference to the `discard`option in the site address changer component as we no longer plan to allow for that extra form field & option just yet.

I have kept the option in the action side itself, though I can get rid of this too.

### Testing 
Behaviour-wise this PR should not have had any effect, though it is worth going through the flow of renaming a site address and making sure that the old site address is still `discard`ed