### PR TITLE
Reader Conversations: use author.email as caterpillar key

### DIFF
--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -109,7 +109,7 @@ class ConversationCaterpillarComponent extends React.Component {
 						return (
 							<Gravatar
 								className={ gravClasses }
-								key={ author.ID }
+								key={ author.email }
 								user={ author }
 								size={ 32 }
 								aria-hidden="true"


### PR DESCRIPTION
@blowery noticed a bunch of warnings in the console on development like this:

<img width="1419" alt="screen shot 2018-04-17 at 3 09 10 pm" src="https://user-images.githubusercontent.com/17325/38846627-780801b0-4251-11e8-977e-aa6a2346fa7a.png">

This is related to https://github.com/Automattic/wp-calypso/pull/23840, in which we noticed that `author.ID` is sometimes returned as `0` from the API. This results in a duplicate author.ID of zero being used for multiple gravatars.

This PR switches the `key` to be author.email, which has already passed a uniqueness check by the time the gravatar is rendered.

### To test

Visit http://calypso.localhost:3000/read/conversations and make sure you don't see any console warnings like the above.