### PR TITLE
Domains: telephone number defaults to user GEO IP

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -80,6 +80,7 @@ export class ContactDetailsFormFields extends Component {
 		onCancel: PropTypes.func,
 		disableSubmitButton: PropTypes.bool,
 		className: PropTypes.string,
+		userCountryCode: PropTypes.string,
 		needsOnlyGoogleAppsDetails: PropTypes.bool,
 		hasCountryStates: PropTypes.bool,
 	};
@@ -102,12 +103,13 @@ export class ContactDetailsFormFields extends Component {
 		needsOnlyGoogleAppsDetails: false,
 		hasCountryStates: false,
 		translate: identity,
+		userCountryCode: 'US',
 	};
 
-	constructor() {
-		super();
+	constructor( props ) {
+		super( props );
 		this.state = {
-			phoneCountryCode: 'US',
+			phoneCountryCode: this.props.countryCode || this.props.userCountryCode,
 			form: null,
 			submissionCount: 0,
 		};

--- a/client/components/domains/contact-details-form-fields/test/index.js
+++ b/client/components/domains/contact-details-form-fields/test/index.js
@@ -181,4 +181,41 @@ describe( 'ContactDetailsFormFields', () => {
 			);
 		} );
 	} );
+
+	describe( 'Setting phone input country', () => {
+		test( 'should user address country if available', () => {
+			const newProps = {
+				...defaultProps,
+				countryCode: 'JP',
+				userCountryCode: 'NZ',
+			};
+			const wrapper = shallow( <ContactDetailsFormFields { ...newProps } /> );
+			expect( wrapper.find( 'FormPhoneMediaInput' ).props().countryCode ).toEqual( 'JP' );
+		} );
+
+		test( 'should set phone country using geo location when country code not available in contact details', () => {
+			const newProps = {
+				contactDetails: {
+					...defaultProps.contactDetails,
+					countryCode: '',
+				},
+				onSubmit: noop,
+				userCountryCode: 'FR',
+			};
+			const wrapper = shallow( <ContactDetailsFormFields { ...newProps } /> );
+			expect( wrapper.find( 'FormPhoneMediaInput' ).props().countryCode ).toEqual( 'FR' );
+		} );
+
+		test( 'should use US as fallback', () => {
+			const newProps = {
+				contactDetails: {
+					...defaultProps.contactDetails,
+					countryCode: '',
+				},
+				onSubmit: noop,
+			};
+			const wrapper = shallow( <ContactDetailsFormFields { ...newProps } /> );
+			expect( wrapper.find( 'FormPhoneMediaInput' ).props().countryCode ).toEqual( 'US' );
+		} );
+	} );
 } );

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -474,7 +474,11 @@ class Checkout extends React.Component {
 
 		if ( ! this.isLoading() && this.needsDomainDetails() ) {
 			return (
-				<DomainDetailsForm cart={ this.props.cart } productsList={ this.props.productsList } />
+				<DomainDetailsForm
+					cart={ this.props.cart }
+					productsList={ this.props.productsList }
+					userCountryCode={ this.props.userCountryCode }
+				/>
 			);
 		} else if ( this.isLoading() || this.props.cart.hasPendingServerUpdates ) {
 			// hasPendingServerUpdates is an important check here as the content we display is dependent on the content of the cart

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -179,7 +179,7 @@ export class DomainDetailsForm extends PureComponent {
 	};
 
 	renderDomainContactDetailsFields() {
-		const { contactDetails, translate } = this.props;
+		const { contactDetails, translate, userCountryCode } = this.props;
 		const labelTexts = {
 			submitButton: this.getSubmitButtonText(),
 			organization: translate(
@@ -192,6 +192,7 @@ export class DomainDetailsForm extends PureComponent {
 		};
 		return (
 			<ContactDetailsFormFields
+				userCountryCode={ userCountryCode }
 				contactDetails={ contactDetails }
 				needsFax={ this.needsFax() }
 				needsOnlyGoogleAppsDetails={ this.needsOnlyGoogleAppsDetails() }


### PR DESCRIPTION
This PR addresses #24207

<img width="731" alt="screen shot 2018-04-17 at 4 08 54 pm" src="https://user-images.githubusercontent.com/6458278/38851707-203b3be2-425a-11e8-942b-1b6fb5db6e80.png">

## Testing
1. Fire up http://calypso.localhost:3000/ and add a domain to your cart
2. Head to checkout, then execute the following in the console to reset the saved contact details:
```
dispatch({ type: 'DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_UPDATE', data: {"firstName":"Jan","lastName":"Von CurryWurst","organization":"","email":"","phone":"","address1":"Test 123","address2":"","city":"Berlin","state":"","postalCode":"","countryCode":""} })
```
3. Refresh the page

### Expectations
The empty phone input field's icon should display a flag corresponding to the value in `user_ip_country_code` in the response from https://public-api.wordpress.com/rest/v1.1/me