### PR TITLE
Remove the allSitesPath property from CurrentSite component

### DIFF
--- a/client/my-sites/current-site/README.md
+++ b/client/my-sites/current-site/README.md
@@ -1,7 +1,8 @@
 Current Site (JSX)
 ==================
 
-This component displays the currently selected site. It's used in the My Sites Sidebar.
+This component displays the currently selected site. All information is received from
+Redux state and the component receives no props. It's used in the My Sites Sidebar.
 
 #### How to use:
 
@@ -10,11 +11,7 @@ import CurrentSite from 'my-sites/current-site';
 
 render() {
 	return (
-		<CurrentSite sites={ sitesListObject } />
+		<CurrentSite />
 	);
 }
 ```
-
-#### Props
-
-* `sites (object)` - (required) An instance of `sites-list`.

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -21,11 +21,10 @@ import Gridicon from 'gridicons';
 import SiteNotice from './notice';
 import CartStore from 'lib/cart/store';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSectionName, getSelectedSite } from 'state/ui/selectors';
 import { getSelectedOrAllSites, getVisibleSites } from 'state/selectors';
 import { infoNotice, removeNotice } from 'state/notices/actions';
 import { getNoticeLastTimeShown } from 'state/notices/selectors';
-import { getSectionName } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import isRtl from 'state/selectors/is-rtl';
 import { hasAllSitesList } from 'state/sites/selectors';
@@ -130,7 +129,7 @@ class CurrentSite extends Component {
 					<AllSites />
 				) }
 
-				<SiteNotice site={ selectedSite } allSitesPath={ this.props.allSitesPath } />
+				<SiteNotice site={ selectedSite } />
 				<AsyncLoad require="my-sites/current-site/domain-warnings" placeholder={ null } />
 			</Card>
 		);

--- a/client/my-sites/navigation/navigation.jsx
+++ b/client/my-sites/navigation/navigation.jsx
@@ -28,11 +28,7 @@ class MySitesNavigation extends React.Component {
 					siteBasePath={ this.props.siteBasePath }
 					onClose={ this.preventPickerDefault }
 				/>
-				<Sidebar
-					allSitesPath={ this.props.allSitesPath }
-					path={ this.props.path }
-					siteBasePath={ this.props.siteBasePath }
-				/>
+				<Sidebar path={ this.props.path } siteBasePath={ this.props.siteBasePath } />
 			</div>
 		);
 	}

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -681,7 +681,7 @@ export class MySitesSidebar extends Component {
 		return (
 			<Sidebar>
 				<SidebarRegion>
-					<CurrentSite allSitesPath={ this.props.allSitesPath } />
+					<CurrentSite />
 					{ this.renderSidebarMenus() }
 				</SidebarRegion>
 				<SidebarFooter>{ this.addNewSite() }</SidebarFooter>


### PR DESCRIPTION
I noticed this when removing `sites-list` references from components' docs: `CurrentSite` doesn't need the `allSitesPath` prop. It might have been used in the past, but the usage was refactored away at some moment.

Transitively, neither `Sidebar` nor `MySitesNavigation` components need the prop. The only component that uses it is `SitePicker`/`SiteSelector`.

**How to test:**
Review that the prop indeed isn't used and that I removed it correctly.
Test that the Sidebar in My Sites still generally works and that it's possible to switch sites.