### PR TITLE
JP Remote Install: Enable in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -37,6 +37,7 @@
 		"jetpack/api-cache": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
+		"jetpack/connect/remote-install": true,
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,
 		"jetpack/google-analytics-for-stores-enhanced": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -40,6 +40,7 @@
 		"jetpack/api-cache": true,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
+		"jetpack/connect/remote-install": true,
 		"jetpack/happychat": true,
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,


### PR DESCRIPTION
Enable the Jetpack Remote Install feature on staging and production. When connecting a wporg site to wpcom from Calypso that does not already have the Jetpack plugin installed and active, this feature will ask user for site credentials and automatically install the plugin, then continue to connect the site.

More information on the feature: p7rd6c-1dS-p2

## Testing
n/a
