### PR TITLE
Plans: rewrite My Plans view for responsiveness.

### DIFF
--- a/client/blocks/product-purchase-features-list/style.scss
+++ b/client/blocks/product-purchase-features-list/style.scss
@@ -1,16 +1,14 @@
 .product-purchase-features-list {
 	@include breakpoint( ">1040px" ) {
-		column-count: 2;
-		column-gap: 12px;
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
 	}
 }
 
 .product-purchase-features-list__item {
-	page-break-inside: avoid; // For Firefox
-	break-inside: avoid-column; // For IE
-	-webkit-column-break-inside: avoid; // For others
-
 	padding-top: 12px;
+	max-width: 49.5%;
 }
 
 .product-purchase-features-list__item .purchase-detail {

--- a/client/components/purchase-detail/index.jsx
+++ b/client/components/purchase-detail/index.jsx
@@ -98,13 +98,11 @@ export default class PurchaseDetail extends PureComponent {
 					</div>
 				) }
 				<div className="purchase-detail__content">
-					{ this.renderIcon() }
-
 					<div className="purchase-detail__text">
 						<h3 className="purchase-detail__title">{ title }</h3>
 						<div className="purchase-detail__description">{ description }</div>
 					</div>
-
+					{ this.renderIcon() }
 					{ this.renderBody() }
 				</div>
 			</div>

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -3,7 +3,7 @@
 		0 1px 2px $gray-lighten-30;
 	box-sizing: border-box;
 	color: $gray-text-min;
-	position: relative;
+	height: 100%;
 
 	&:last-child {
 		border-bottom: none;
@@ -52,45 +52,14 @@
 
 .purchase-detail__content {
 	padding: 32px;
-
-	@include breakpoint( ">660px" ) {
-		padding-right: 140px;
-	}
+	display: flex;
+	flex-flow: row wrap;
+	justify-content: space-between;
 }
 
 .purchase-detail__description {
 	color: $gray-text-min;
 	margin: 8px 0 16px 0;
-}
-
-.purchase-detail__icon {
-	background: $gray-darken-20;
-	border-radius: 50%;
-	color: $white;
-	margin: 0 auto 10px;
-	padding: 16px;
-
-	@include breakpoint( ">660px" ) {
-		margin-top: -40px;
-		position: absolute;
-			right: 32px;
-			top: 50%;
-	}
-
-	.purchase-detail__notice-icon.gridicon {
-		fill: $alert-yellow;
-		height: 24px;
-		position: relative;
-		right: -26px;
-		top: -3px;
-		width: 24px;
-
-		@include breakpoint( ">660px" ) {
-			position: relative;
-				right: -42px;
-				top: -6px;
-		}
-	}
 }
 
 .purchase-detail__icon,
@@ -104,12 +73,31 @@
 	}
 }
 
-.purchase-detail.custom-icon {
-	.purchase-detail__content {
+.purchase-detail__icon {
+	background: $gray-darken-20;
+	border-radius: 50%;
+	color: $white;
+	margin: 0 auto 10px;
+	padding: 16px;
+
+	.purchase-detail__notice-icon.gridicon {
+		fill: $alert-yellow;
+		height: 24px;
+		right: -26px;
+		top: -3px;
+		width: 24px;
+
 		@include breakpoint( ">660px" ) {
-			padding-right: 210px;
+			right: -42px;
+			top: -6px;
 		}
 	}
+}
+
+.purchase-detail.custom-icon {
+	display: flex;
+	flex-flow: row wrap;
+	justify-content: space-between;
 
 	.purchase-detail__icon {
 		background: transparent;
@@ -118,10 +106,6 @@
 		margin-top: 0;
 		padding: 0;
 
-		@include breakpoint( ">660px" ) {
-			width: 150px;
-			transform: translate( 0, -50% );
-		}
 	}
 }
 
@@ -137,6 +121,10 @@
 	clear: none;
 	color: $gray-darken-10;
 	font-size: 21px;
+}
+
+.purchase-detail__text {
+	max-width: 50%;
 }
 
 .purchase-detail__info {


### PR DESCRIPTION
Currently the code is no fully responsive. Double-column layout has a bug in Chrome, resulting in visual glitches. `PurchaseDetail` component used for feature cards is not responsive either.

Prep work for https://github.com/Automattic/wp-calypso/pull/23181, which uncovered the bug.

This PR re-writes the cards layout on the page and `PurchaseDetail` content's layout to use flexbox for ease of manipulation.

## To test:

On a variety of canonical plans pages `http://calypso.localhost:3000/plans/:site` for both .com and JP plans, verify that the cards are displayed correctly.