### PR TITLE
Jetpack Settings: Remove obsolete undocumented handlers

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -144,37 +144,6 @@ Undocumented.prototype.jetpackModuleDeactivate = function( siteId, moduleSlug, f
 	);
 };
 
-/*
- * Retrieve all Jetpack settings of a site with id siteId
- *
- * @param {int} [siteId]
- * @param {Function} fn
- * @api public
- */
-Undocumented.prototype.fetchJetpackSettings = function( siteId, fn ) {
-	return this.wpcom.req.get(
-		{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
-		{ path: '/jetpack/v4/settings/' },
-		fn
-	);
-};
-
-/*
- * Update any Jetpack settings on the site with id siteId to the specified settings
- *
- * @param {int} [siteId]
- * @param {object} [settings]
- * @param {Function} fn
- * @api public
- */
-Undocumented.prototype.updateJetpackSettings = function( siteId, settings, fn ) {
-	return this.wpcom.req.post(
-		{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
-		{ path: '/jetpack/v4/settings/', body: JSON.stringify( settings ), json: true },
-		fn
-	);
-};
-
 /**
  * Fetches settings for the Monitor module.
  *


### PR DESCRIPTION
Missed those when cleaning up after the JP Settings refactor.

No testing required, just verify that these aren't used anywhere.