### PR TITLE
Jetpack Connect: Move XMLRPC auth error notice to JetpackConnectNotices

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import debugModule from 'debug';
 import Gridicon from 'gridicons';
@@ -449,7 +449,7 @@ export class JetpackAuthorize extends Component {
 		}
 		if ( this.props.hasXmlrpcError ) {
 			return (
-				<div>
+				<Fragment>
 					<JetpackConnectNotices
 						noticeType={ XMLRPC_ERROR }
 						onActionClick={ this.handleResolve }
@@ -457,17 +457,17 @@ export class JetpackAuthorize extends Component {
 					/>
 					{ this.renderXmlrpcFeedback() }
 					{ this.renderErrorDetails() }
-				</div>
+				</Fragment>
 			);
 		}
 		return (
-			<div>
+			<Fragment>
 				<JetpackConnectNotices
 					noticeType={ DEFAULT_AUTHORIZE_ERROR }
 					onTerminalError={ redirectToMobileApp }
 				/>
 				{ this.renderErrorDetails() }
-			</div>
+			</Fragment>
 		);
 	}
 

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -342,29 +342,26 @@ export class JetpackAuthorize extends Component {
 
 	renderXmlrpcFeedback() {
 		const { translate } = this.props;
+
 		return (
-			<div>
-				<JetpackConnectNotices noticeType={ XMLRPC_ERROR } onActionClick={ this.handleResolve } />
-				<p>
-					{ translate(
-						'WordPress.com was unable to reach your site and approve the connection. ' +
-							'Try again by clicking the button above; ' +
-							"if that doesn't work you may need to {{link}}contact support{{/link}}.",
-						{
-							components: {
-								link: (
-									<a
-										href="https://jetpack.com/contact-support"
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							},
-						}
-					) }
-				</p>
-				{ this.renderErrorDetails() }
-			</div>
+			<p>
+				{ translate(
+					'WordPress.com was unable to reach your site and approve the connection. ' +
+						'Try again by clicking the button above; ' +
+						"if that doesn't work you may need to {{link}}contact support{{/link}}.",
+					{
+						components: {
+							link: (
+								<a
+									href="https://jetpack.com/contact-support"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					}
+				) }
+			</p>
 		);
 	}
 
@@ -451,7 +448,13 @@ export class JetpackAuthorize extends Component {
 			);
 		}
 		if ( this.props.hasXmlrpcError ) {
-			return this.renderXmlrpcFeedback();
+			return (
+				<div>
+					<JetpackConnectNotices noticeType={ XMLRPC_ERROR } onActionClick={ this.handleResolve } />
+					{ this.renderXmlrpcFeedback() }
+					{ this.renderErrorDetails() }
+				</div>
+			);
 		}
 		return (
 			<div>

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -450,7 +450,11 @@ export class JetpackAuthorize extends Component {
 		if ( this.props.hasXmlrpcError ) {
 			return (
 				<div>
-					<JetpackConnectNotices noticeType={ XMLRPC_ERROR } onActionClick={ this.handleResolve } />
+					<JetpackConnectNotices
+						noticeType={ XMLRPC_ERROR }
+						onActionClick={ this.handleResolve }
+						onTerminalError={ redirectToMobileApp }
+					/>
 					{ this.renderXmlrpcFeedback() }
 					{ this.renderErrorDetails() }
 				</div>

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -29,8 +29,6 @@ import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import MainWrapper from './main-wrapper';
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
 import QueryUserConnection from 'components/data/query-user-connection';
 import Spinner from 'components/spinner';
 import userUtilities from 'lib/user/utils';
@@ -51,6 +49,7 @@ import {
 	RETRYING_AUTH,
 	SECRET_EXPIRED,
 	USER_IS_ALREADY_CONNECTED_TO_SITE,
+	XMLRPC_ERROR,
 } from './connection-notice-types';
 import {
 	isCalypsoStartedConnection,
@@ -345,16 +344,7 @@ export class JetpackAuthorize extends Component {
 		const { translate } = this.props;
 		return (
 			<div>
-				<div className="jetpack-connect__notices-container">
-					<Notice
-						icon="notice"
-						status="is-error"
-						text={ translate( 'We had trouble connecting.' ) }
-						showDismiss={ false }
-					>
-						<NoticeAction onClick={ this.handleResolve }>{ translate( 'Try again' ) }</NoticeAction>
-					</Notice>
-				</div>
+				<JetpackConnectNotices noticeType={ XMLRPC_ERROR } onActionClick={ this.handleResolve } />
 				<p>
 					{ translate(
 						'WordPress.com was unable to reach your site and approve the connection. ' +

--- a/client/jetpack-connect/connection-notice-types.js
+++ b/client/jetpack-connect/connection-notice-types.js
@@ -29,3 +29,4 @@ export const SECRET_EXPIRED = 'secretExpired';
 export const UNKNOWN_REMOTE_INSTALL_ERROR = 'unknownRemoteInstallError';
 export const USER_IS_ALREADY_CONNECTED_TO_SITE = 'userIsAlreadyConnectedToSite';
 export const WORDPRESS_DOT_COM = 'wordpress.com';
+export const XMLRPC_ERROR = 'xmlrpcError';

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -29,13 +29,16 @@ import {
 	SECRET_EXPIRED,
 	USER_IS_ALREADY_CONNECTED_TO_SITE,
 	WORDPRESS_DOT_COM,
+	XMLRPC_ERROR,
 } from './connection-notice-types';
 import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
 
 export class JetpackConnectNotices extends Component {
 	static propTypes = {
 		// Supply a function that will be called for flow-ending error cases
 		// instead of showing a notice.
+		onActionClick: PropTypes.func,
 		onTerminalError: PropTypes.func,
 		noticeType: PropTypes.oneOf( [
 			ALREADY_CONNECTED,
@@ -57,6 +60,7 @@ export class JetpackConnectNotices extends Component {
 			SECRET_EXPIRED,
 			USER_IS_ALREADY_CONNECTED_TO_SITE,
 			WORDPRESS_DOT_COM,
+			XMLRPC_ERROR,
 		] ).isRequired,
 		translate: PropTypes.func.isRequired,
 		url: PropTypes.string,
@@ -183,7 +187,22 @@ export class JetpackConnectNotices extends Component {
 				noticeValues.status = 'is-warning';
 				noticeValues.icon = 'notice';
 				return noticeValues;
+
+			case XMLRPC_ERROR:
+				noticeValues.text = translate( 'We had trouble connecting.' );
+				return noticeValues;
 		}
+	}
+
+	getNoticeActionText() {
+		const { noticeType, translate } = this.props;
+
+		switch ( noticeType ) {
+			case XMLRPC_ERROR:
+				return translate( 'Try again' );
+		}
+
+		return null;
 	}
 
 	componentDidUpdate() {
@@ -203,6 +222,17 @@ export class JetpackConnectNotices extends Component {
 		return notice && ! notice.userCanRetry;
 	}
 
+	renderNoticeAction() {
+		const { onActionClick } = this.props;
+		const noticeActionText = this.getNoticeActionText();
+
+		if ( ! onActionClick || ! noticeActionText ) {
+			return null;
+		}
+
+		return <NoticeAction onClick={ onActionClick }>{ noticeActionText }</NoticeAction>;
+	}
+
 	render() {
 		const noticeValues = this.getNoticeValues();
 		if ( this.errorIsTerminal() && this.props.onTerminalError ) {
@@ -211,7 +241,7 @@ export class JetpackConnectNotices extends Component {
 		if ( noticeValues ) {
 			return (
 				<div className="jetpack-connect__notices-container">
-					<Notice { ...noticeValues } />
+					<Notice { ...noticeValues }>{ this.renderNoticeAction() }</Notice>
 				</div>
 			);
 		}


### PR DESCRIPTION
This PR adds support for notice actions in `JetpackConnectNotices` and moves the Jetpack Connect authorization XMLRPC error inside that component. The long term purpose of this is to have a single place component responsible for notices in the JPC auth process.

A full list of what this PR suggests:

* Introducing a new connection status for the XMLRPC error.
* Supporting notice actions in `JetpackConnectNotices`.
* Moving the XMLRPC error notice in `JetpackConnectNotices`.
* Add `onTerminalError` to the XMLRPC error.
* Use `Fragment` instead of unnecessary `div` inside `JetpackAuthorize`.

To test:
* Checkout this branch
* Spin up a Jurassic Ninja site with Jetpack.
* Rename the `xmlrpc.php` file to something else.
* In [this file](https://github.com/Automattic/jetpack/blob/33b2f8d611fe8f7255a8df192a73f7d1c2e87c7f/_inc/lib/class.core-rest-api-endpoints.php#L483), end early the `remote_authorize()` method by adding the following line in the beginning of the method:
 ```
return new WP_Error( 'remote_authorize_failed', 'An error has occurred while authorizing your site' );
```
* Go to the wp-admin.
* Copy the **Set up Jetpack** URL and add `&calypso_env=development` to it. Load it in your browser.
* You will be redirected to the JPC authorize step, asking you to approve authorization. Click the **Approve** button.
* Follow along several times when the JPC flow tries to retry, click the button every time.
* After the last retry, verify you can see the expected error notice:

![](https://cldup.com/N1SPlZP3ct.png)

Note: if you're looking at your console, you will see some state validation errors popping up:
![](https://cldup.com/1uhiTqZofB.png)

It seems that we're not expecting error objects in the JPC reducer schema, which causes the validation error. #24255 takes care of this.