### PR TITLE
State: Support auth error objects in JPC schema

### DIFF
--- a/client/state/jetpack-connect/reducer/schema.js
+++ b/client/state/jetpack-connect/reducer/schema.js
@@ -12,7 +12,20 @@ export const jetpackConnectAuthorizeSchema = {
 			required: [ 'timestamp' ],
 			properties: {
 				authorizationCode: { type: 'string' },
-				authorizeError: { type: [ 'boolean', 'null' ] },
+				authorizeError: {
+					anyOf: [
+						{
+							type: 'object',
+							properties: {
+								error: { type: 'string' },
+								message: { type: 'string' },
+								status: { type: 'integer' },
+							},
+						},
+						{ type: 'boolean' },
+						{ type: 'null' },
+					],
+				},
 				authorizeSuccess: { type: 'boolean' },
 				clientId: { type: 'integer' },
 				clientNotResponding: { type: 'boolean' },


### PR DESCRIPTION
In #24254 I've been playing with XMLRPC errors in JPC authorization, and they seem to not be expected by our reducer's validation mechanism. If you manage to reproduce an XMLRPC error during JPC authorization, you should see a schema validation error.

![](https://cldup.com/1uhiTqZofB.png)

This PR aims to fix that error by supporting an error in the `authorizeError` of the reducer schema, in addition to what we're already supporting. It's pretty difficult to witness such an error these days, because of the backup mechanisms that we have in place.

To test:
* Checkout this branch
* Follow the testing instructions from #24254.
* Verify the validation error doesn't appear in the console anymore.