### PR TITLE
Make billing timeframe indicate only biennial billing for biennial plans

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -170,6 +170,14 @@ const WPComGetBillingTimeframe = abtest => {
 	return i18n.translate( 'per month, billed yearly' );
 };
 
+const WPComGetBiennialBillingTimeframe = abtest => {
+	if ( isEnabled( 'upgrades/2-year-plans' ) ) {
+		return i18n.translate( '/month, billed biennially' );
+	}
+
+	return WPComGetBillingTimeframe( abtest );
+};
+
 const getPlanPersonalDetails = () => ( {
 	group: GROUP_WPCOM,
 	type: TYPE_PERSONAL,
@@ -216,7 +224,6 @@ const getPlanPersonalDetails = () => ( {
 		FEATURE_EMAIL_LIVE_CHAT_SUPPORT_SIGNUP,
 		FEATURE_ALL_FREE_FEATURES,
 	],
-	getBillingTimeFrame: WPComGetBillingTimeframe,
 } );
 
 const getPlanPremiumDetails = () => ( {
@@ -277,7 +284,6 @@ const getPlanPremiumDetails = () => ( {
 		FEATURE_PREMIUM_THEMES,
 		FEATURE_ALL_PERSONAL_FEATURES,
 	],
-	getBillingTimeFrame: WPComGetBillingTimeframe,
 } );
 
 const getPlanBusinessDetails = () => ( {
@@ -366,7 +372,6 @@ const getPlanBusinessDetails = () => ( {
 		FEATURE_UNLIMITED_STORAGE_SIGNUP,
 		FEATURE_ALL_PREMIUM_FEATURES,
 	],
-	getBillingTimeFrame: WPComGetBillingTimeframe,
 } );
 
 // DO NOT import. Use `getPlan` from `lib/plans` instead.
@@ -419,6 +424,7 @@ export const PLANS_LIST = {
 	[ PLAN_PERSONAL ]: {
 		...getPlanPersonalDetails(),
 		term: TERM_ANNUALLY,
+		getBillingTimeFrame: WPComGetBillingTimeframe,
 		availableFor: plan => includes( [ PLAN_FREE ], plan ),
 		getProductId: () => 1009,
 		getStoreSlug: () => PLAN_PERSONAL,
@@ -428,6 +434,7 @@ export const PLANS_LIST = {
 	[ PLAN_PERSONAL_2_YEARS ]: {
 		...getPlanPersonalDetails(),
 		term: TERM_BIENNIALLY,
+		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
 		availableFor: plan => includes( [ PLAN_FREE, PLAN_PERSONAL ], plan ),
 		getProductId: () => 1029,
 		getStoreSlug: () => PLAN_PERSONAL_2_YEARS,
@@ -437,6 +444,7 @@ export const PLANS_LIST = {
 	[ PLAN_PREMIUM ]: {
 		...getPlanPremiumDetails(),
 		term: TERM_ANNUALLY,
+		getBillingTimeFrame: WPComGetBillingTimeframe,
 		availableFor: plan => includes( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PERSONAL_2_YEARS ], plan ),
 		getProductId: () => 1003,
 		getStoreSlug: () => PLAN_PREMIUM,
@@ -447,6 +455,7 @@ export const PLANS_LIST = {
 	[ PLAN_PREMIUM_2_YEARS ]: {
 		...getPlanPremiumDetails(),
 		term: TERM_BIENNIALLY,
+		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
 		availableFor: plan =>
 			includes( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM ], plan ),
 		getProductId: () => 1023,
@@ -458,6 +467,7 @@ export const PLANS_LIST = {
 	[ PLAN_BUSINESS ]: {
 		...getPlanBusinessDetails(),
 		term: TERM_ANNUALLY,
+		getBillingTimeFrame: WPComGetBillingTimeframe,
 		availableFor: plan =>
 			includes(
 				[ PLAN_FREE, PLAN_PERSONAL, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM, PLAN_PREMIUM_2_YEARS ],
@@ -472,6 +482,7 @@ export const PLANS_LIST = {
 	[ PLAN_BUSINESS_2_YEARS ]: {
 		...getPlanBusinessDetails(),
 		term: TERM_BIENNIALLY,
+		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
 		availableFor: plan =>
 			includes(
 				[


### PR DESCRIPTION
This PR is related to 2-year plans (p9jf6J-eR-p2). It makes plans headers look like this when user is on 2-year plan:
<img width="1068" alt="zrzut ekranu 2018-04-17 o 16 10 12" src="https://user-images.githubusercontent.com/205419/38875047-d5a22136-4259-11e8-9248-b6164f35b823.png">

Test plan:
* Run unit tests
* Enable store sandbox on your sandbox
* Go to /plans and confirm that headers look like they used to (`/month, billed annually or biennially`)
* Run ENABLE_FEATURES=upgrades/2-year-plans npm run start
* Buy a 2-year plan (like usually, but choose "2-years" in checkout)
* Go to /plans and confirm that headers look like on the screenshot above