### PR TITLE
Activity Log: show 'Activity' tab to wordpress.com sites on a paid plan

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import page from 'page';
 import i18n from 'i18n-calypso';
-import { find, pick } from 'lodash';
+import { find, pick, get } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -14,10 +14,12 @@ import { getSiteFragment, getStatsDefaultSitePage } from 'lib/route';
 import analytics from 'lib/analytics';
 import { recordPlaceholdersTiming } from 'lib/perfmon';
 import { savePreference } from 'state/preferences/actions';
-import { getSite, isJetpackSite, getSiteOption } from 'state/sites/selectors';
+import { getSite, getSiteOption } from 'state/sites/selectors';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { isWpComFreePlan } from 'lib/plans';
+import { getCurrentPlan } from 'state/sites/plans/selectors';
 import FollowList from 'lib/follow-list';
 import StatsInsights from './stats-insights';
 import StatsOverview from './overview';
@@ -366,12 +368,14 @@ export default {
 	activityLog: function( context, next ) {
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );
-		const isJetpack = isJetpackSite( state, siteId );
+		const siteHasWpcomFreePlan = isWpComFreePlan(
+			get( getCurrentPlan( state, siteId ), 'productSlug' )
+		);
 		const startDate = i18n.moment( context.query.startDate, 'YYYY-MM-DD' ).isValid()
 			? context.query.startDate
 			: undefined;
 
-		if ( siteId && ! isJetpack && ! config.isEnabled( 'activity-log-simple-sites' ) ) {
+		if ( siteId && ! siteHasWpcomFreePlan && ! config.isEnabled( 'activity-log-wpcom-free' ) ) {
 			page.redirect( '/stats' );
 			return next();
 		}

--- a/config/development.json
+++ b/config/development.json
@@ -29,7 +29,7 @@
 	"rebrand_cities_prefix": "rebrandcitiesdevelopmentsite",
 	"support_locales": [ "en", "es", "pt-br" ],
 	"features": {
-		"activity-log-simple-sites": true,
+		"activity-log-wpcom-free": true,
 		"account-recovery": true,
 		"ad-tracking": false,
 		"automated-transfer": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -19,7 +19,7 @@
 		"pt-br"
 	],
 	"features": {
-		"activity-log-simple-sites": true,
+		"activity-log-wpcom-free": true,
 		"ad-tracking": false,
 		"apple-pay": true,
 		"automated-transfer": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -16,7 +16,7 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"support_locales": [ "en", "es", "pt-br" ],
 	"features": {
-		"activity-log-simple-sites": true,
+		"activity-log-wpcom-free": true,
 		"ad-tracking": false,
 		"automated-transfer": true,
 		"apple-pay": true,


### PR DESCRIPTION
If applied this PR will show the Activity tab to WordPress.com sites on a paid plan in the production environment.

It will continue to show the Activity tab for WordPress.com sites on a free plan in staging, development, and wpcalypso environments.
