### PR TITLE
JP Remote Install: Fix auth step for sub-directory sites

### DIFF
--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -104,7 +104,7 @@ export class OrgCredentialsForm extends Component {
 		const form = document.createElement( 'form' );
 		form.setAttribute( 'method', 'post' );
 
-		const redirectUrl = addCalypsoEnvQueryArg( REMOTE_PATH_AUTH );
+		const redirectUrl = addCalypsoEnvQueryArg( siteToConnect + REMOTE_PATH_AUTH );
 		const actionUrl = addQueryArgs( { redirect_to: redirectUrl }, siteToConnect + '/wp-login.php' );
 		form.setAttribute( 'action', actionUrl );
 


### PR DESCRIPTION
For WP sites in a subdirectory, like http://yourjetpack.blog/test, the authorization step after remote install was not working because were logging into the site with:

`http://yourjetpack.blog/test/wp-login.php?redirect_to=/wp-admin/admin.php?page=jetpack&connect_url_redirect=true`

The relative link in `?redirect_to` did not take the subdirectory into account.

This change uses a full link instead of relative for the redirect, like:

`http://yourjetpack.blog/test/wp-login.php?redirect_to=http://yourjetpack.blog/test/wp-admin/admin.php?page=jetpack&connect_url_redirect=true`

## Testing

Test at: https://calypso.live/jetpack/connect?branch=fix/jp-remote-install-auth-redirect
Enter URL of site without jetpack installed, then creds when prompted.

* Use a jurassic.ninja site to check that sites _not_ in a subdir still work ok
* Test with this subdir site for example: http://jetpack.sakura.ne.jp/test/
(creds are in secret store under Sakura)


