### PR TITLE
Components: use flexbox for rendering content of `PurchaseDetail` component.

### DIFF
--- a/client/blocks/product-purchase-features-list/style.scss
+++ b/client/blocks/product-purchase-features-list/style.scss
@@ -23,4 +23,9 @@
 	background-color: $white;
 	border-radius: 0;
 	margin: 0;
+
+	// Chrome bug wraps shadow into next column.
+	// Remove when fixed
+	// @see https://github.com/Automattic/wp-calypso/pull/23181#issuecomment-377649871
+	margin-bottom: 1px;
 }

--- a/client/components/purchase-detail/index.jsx
+++ b/client/components/purchase-detail/index.jsx
@@ -98,13 +98,11 @@ export default class PurchaseDetail extends PureComponent {
 					</div>
 				) }
 				<div className="purchase-detail__content">
-					{ this.renderIcon() }
-
 					<div className="purchase-detail__text">
 						<h3 className="purchase-detail__title">{ title }</h3>
 						<div className="purchase-detail__description">{ description }</div>
 					</div>
-
+					<div className="purchase-detail__info-icon-container">{ this.renderIcon() }</div>
 					{ this.renderBody() }
 				</div>
 			</div>

--- a/client/components/purchase-detail/index.jsx
+++ b/client/components/purchase-detail/index.jsx
@@ -98,12 +98,12 @@ export default class PurchaseDetail extends PureComponent {
 					</div>
 				) }
 				<div className="purchase-detail__content">
+					<div className="purchase-detail__image">{ this.renderIcon() }</div>
 					<div className="purchase-detail__text">
 						<h3 className="purchase-detail__title">{ title }</h3>
 						<div className="purchase-detail__description">{ description }</div>
+						{ this.renderBody() }
 					</div>
-					<div className="purchase-detail__info-icon-container">{ this.renderIcon() }</div>
-					{ this.renderBody() }
 				</div>
 			</div>
 		);

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -3,7 +3,7 @@
 		0 1px 2px $gray-lighten-30;
 	box-sizing: border-box;
 	color: $gray-text-min;
-	position: relative;
+	height: 100%;
 
 	&:last-child {
 		border-bottom: none;
@@ -52,10 +52,9 @@
 
 .purchase-detail__content {
 	padding: 32px;
-
-	@include breakpoint( ">660px" ) {
-		padding-right: 140px;
-	}
+	display: flex;
+	flex-flow: row wrap;
+	justify-content: space-between;
 }
 
 .purchase-detail__description {
@@ -70,27 +69,27 @@
 	margin: 0 auto 10px;
 	padding: 16px;
 
-	@include breakpoint( ">660px" ) {
-		margin-top: -40px;
-		position: absolute;
-			right: 32px;
-			top: 50%;
-	}
-
 	.purchase-detail__notice-icon.gridicon {
 		fill: $alert-yellow;
 		height: 24px;
-		position: relative;
 		right: -26px;
 		top: -3px;
 		width: 24px;
 
 		@include breakpoint( ">660px" ) {
-			position: relative;
-				right: -42px;
-				top: -6px;
+			right: -42px;
+			top: -6px;
 		}
 	}
+}
+
+.purchase-detail__body {
+	width: 100%;
+}
+
+.purchase-detail__text {
+	max-width: 60%;
+	max-height: 50%;
 }
 
 .purchase-detail__icon,
@@ -105,12 +104,6 @@
 }
 
 .purchase-detail.custom-icon {
-	.purchase-detail__content {
-		@include breakpoint( ">660px" ) {
-			padding-right: 210px;
-		}
-	}
-
 	.purchase-detail__icon {
 		background: transparent;
 		width: 128px;
@@ -120,7 +113,6 @@
 
 		@include breakpoint( ">660px" ) {
 			width: 150px;
-			transform: translate( 0, -50% );
 		}
 	}
 }

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -148,6 +148,9 @@
 	margin: 8px 0 16px 0;
 }
 
+.purchase-detail__text {
+	flex-grow: 1;
+}
 
 .purchase-detail__body {
 	width: 100%;

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -53,13 +53,34 @@
 .purchase-detail__content {
 	padding: 32px;
 	display: flex;
-	flex-flow: row wrap;
-	justify-content: space-between;
+	align-items: center;
+
+	@include breakpoint( "<660px" ) {
+		flex-wrap: wrap;
+	}
 }
 
-.purchase-detail__description {
-	color: $gray-text-min;
-	margin: 8px 0 16px 0;
+.purchase-detail__image {
+	width: 100%;
+	flex-shrink: 0;
+
+	@include breakpoint( ">660px" ) {
+		order: 2;
+		width: 178px;
+	}
+}
+
+.purchase-detail__button {
+	text-align: center;
+
+	&:not(.clipboard-button) {
+		width: 80%;
+	}
+
+	@include breakpoint( "<660px" ) {
+		display: block;
+		margin: 0 auto;
+	}
 }
 
 .purchase-detail__icon {
@@ -81,15 +102,6 @@
 			top: -6px;
 		}
 	}
-}
-
-.purchase-detail__body {
-	width: 100%;
-}
-
-.purchase-detail__text {
-	max-width: 60%;
-	max-height: 50%;
 }
 
 .purchase-detail__icon,
@@ -117,26 +129,25 @@
 	}
 }
 
-.purchase-detail__required-notice {
-	background-color: $alert-yellow;
-	color: $white;
-	font-size: 14px;
-	padding: 8px;
-	text-align: center;
-}
-
 .purchase-detail__title {
 	clear: none;
 	color: $gray-darken-10;
 	font-size: 21px;
 }
 
+.purchase-detail__description {
+	color: $gray-text-min;
+	margin: 8px 0 16px 0;
+}
+
+
+.purchase-detail__body {
+	width: 100%;
+}
+
 .purchase-detail__info {
-	flex: 1;
 	margin-left: 8px;
 	margin-top: 8px;
-	max-width: 260px;
-	display: inline-block;
 
 	@include breakpoint( ">660px" ) {
 		margin-top: 0;
@@ -151,15 +162,10 @@
 	height: 14px;
 }
 
-.purchase-detail__button {
+.purchase-detail__required-notice {
+	background-color: $alert-yellow;
+	color: $white;
+	font-size: 14px;
+	padding: 8px;
 	text-align: center;
-
-	&:not(.clipboard-button) {
-		width: 80%;
-	}
-
-	@include breakpoint( "<660px" ) {
-		display: block;
-		margin: 0 auto;
-	}
 }

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -89,6 +89,13 @@
 	color: $white;
 	margin: 0 auto 10px;
 	padding: 16px;
+	width: 100%;
+	flex-shrink: 0;
+
+	@include breakpoint( ">660px" ) {
+		order: 2;
+		width: 178px;
+	}
 
 	.purchase-detail__notice-icon.gridicon {
 		fill: $alert-yellow;
@@ -106,12 +113,13 @@
 
 .purchase-detail__icon,
 .purchase-detail__icon .gridicon {
-	height: 48px;
-	width: 48px;
+	width: 36px;
+	height: auto;
+	margin-top: 0;
 
-	@include breakpoint( "<660px" ) {
-		height: 36px;
-		width: 36px;
+	@include breakpoint( ">660px" ) {
+		width: 48px;
+		height: 48px;
 	}
 }
 

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -153,6 +153,13 @@
 	width: 100%;
 }
 
+.purchase-detail__button {
+	overflow-wrap: break-word;
+	word-wrap: break-word;
+	word-break: break-word;
+	hyphens: auto;
+}
+
 .purchase-detail__info {
 	margin-left: 8px;
 	margin-top: 8px;


### PR DESCRIPTION
Make the content layout of the `PurchaseDetail` component fully responsive. 
![screen shot 2018-04-19 at 21 35 04](https://user-images.githubusercontent.com/13561163/39016702-23414f00-4419-11e8-9198-1d94567eed4f.png)

No change to the content or the look of the cards is intended here.

Note: `Priority support` card will be moved away from the header in a follow-up. The seemingly extended bottom margin is not fixed in this patch.

## To test:
- checkout this branch on your local Calypso,
- on a variety of canonical plans pages `http://calypso.localhost:3000/plans/:site` for both .com and JP plans, verify that the cards are displayed correctly.