### PR TITLE
Site Address Change: Use new endpoint base

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2446,13 +2446,13 @@ Undocumented.prototype.getFeaturedPlugins = function( fn ) {
 };
 
 /**
- * Fetch a nonce to use in the `updateSiteName` call
+ * Fetch a nonce to use in the `updateSiteAddress` call
  * @param {int}   siteId  The ID of the site for which to get a nonce.
  * @returns {Promise}     A promise
  */
-Undocumented.prototype.getRequestSiteRenameNonce = function( siteId ) {
+Undocumented.prototype.getRequestSiteAddressChangeNonce = function( siteId ) {
 	return this.wpcom.req.get( {
-		path: `/sites/${ siteId }/site-rename/nonce`,
+		path: `/sites/${ siteId }/site-address-change/nonce`,
 		apiNamespace: 'wpcom/v2',
 	} );
 };
@@ -2460,14 +2460,14 @@ Undocumented.prototype.getRequestSiteRenameNonce = function( siteId ) {
 /**
  * Request server-side validation (including an availibility check) of the given site address.
  *
- * @param {int} [siteId] The siteId for which to rename
+ * @param {int} [siteId] The siteId for which to validate
  * @param {object} [siteAddress]	The site address to validate
  * @returns {Promise}  A promise
  */
 Undocumented.prototype.checkSiteAddressValidation = function( siteId, siteAddress ) {
 	return this.wpcom.req.post(
 		{
-			path: `/sites/${ siteId }/site-rename/validate`,
+			path: `/sites/${ siteId }/site-address-change/validate`,
 			apiNamespace: 'wpcom/v2',
 		},
 		{},
@@ -2476,18 +2476,18 @@ Undocumented.prototype.checkSiteAddressValidation = function( siteId, siteAddres
 };
 
 /**
- * Request a new .wordpress.com site address change with the option to discard the current.
+ * Request a new .wordpress.com address for a site with the option to discard the current.
  *
- * @param {int} [siteId] The siteId for which to rename
+ * @param {int} [siteId] The siteId for which to change the address
  * @param {object} [blogname]	The desired new site address
  * @param {bool} [discard]			Should the old site address name be discarded?
  * @param {string} [nonce]		A nonce provided by the API
  * @returns {Promise}  A promise
  */
-Undocumented.prototype.updateSiteName = function( siteId, blogname, discard, nonce ) {
+Undocumented.prototype.updateSiteAddress = function( siteId, blogname, discard, nonce ) {
 	return this.wpcom.req.post(
 		{
-			path: `/sites/${ siteId }/site-rename`,
+			path: `/sites/${ siteId }/site-address-change`,
 			apiNamespace: 'wpcom/v2',
 		},
 		{},

--- a/client/state/site-rename/actions.js
+++ b/client/state/site-rename/actions.js
@@ -25,7 +25,7 @@ import { requestSite } from 'state/sites/actions';
 
 // @TODO proper redux data layer stuff for the nonce
 function fetchNonce( siteId ) {
-	return wpcom.undocumented().getRequestSiteRenameNonce( siteId );
+	return wpcom.undocumented().getRequestSiteAddressChangeNonce( siteId );
 }
 
 export const getErrorNotice = message =>
@@ -127,7 +127,7 @@ export const requestSiteRename = ( siteId, newBlogName, discard ) => dispatch =>
 		.then( nonce => {
 			wpcom
 				.undocumented()
-				.updateSiteName( siteId, newBlogName, discard, nonce )
+				.updateSiteAddress( siteId, newBlogName, discard, nonce )
 				.then( data => {
 					const newSlug = get( data, 'new_slug' );
 


### PR DESCRIPTION
Simply changes the endpoint path that gets called for site address changes, validation, etc. to match the updated format & updates a few pieces of inline documentation to match.

## To Test

* Sandbox the REST API
* Apply D11906
* Attempt to change a site address you own as before