### PR TITLE
Plans: Change plansLink() to accept site slug instead of object

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -375,14 +375,14 @@ export const isPlanFeaturesEnabled = () => {
 	return isEnabled( 'manage/plan-features' );
 };
 
-export function plansLink( url, site, intervalType ) {
+export function plansLink( url, siteSlug, intervalType ) {
 	const parsedUrl = urlParse( url );
 	if ( 'monthly' === intervalType ) {
 		parsedUrl.pathname += '/monthly';
 	}
 
-	if ( site && site.slug ) {
-		parsedUrl.pathname += '/' + site.slug;
+	if ( siteSlug ) {
+		parsedUrl.pathname += '/' + siteSlug;
 	}
 
 	return urlFormat( parsedUrl );

--- a/client/lib/plans/test/plans-link.js
+++ b/client/lib/plans/test/plans-link.js
@@ -14,21 +14,19 @@ describe( 'plansLink', () => {
 	} );
 
 	test( 'should append site slug if provided', () => {
-		expect( plansLink( '/plans', { slug: 'example.com' } ) ).toBe( '/plans/example.com' );
+		expect( plansLink( '/plans', 'example.com' ) ).toBe( '/plans/example.com' );
 	} );
 
 	test( 'should append monthly followed by site slug if provided', () => {
-		expect( plansLink( '/plans', { slug: 'example.com' }, 'monthly' ) ).toBe(
-			'/plans/monthly/example.com'
-		);
+		expect( plansLink( '/plans', 'example.com', 'monthly' ) ).toBe( '/plans/monthly/example.com' );
 	} );
 
 	test( 'should append site slug if provided and yearly', () => {
-		expect( plansLink( '/plans', { slug: 'example.com' }, 'yearly' ) ).toBe( '/plans/example.com' );
+		expect( plansLink( '/plans', 'example.com', 'yearly' ) ).toBe( '/plans/example.com' );
 	} );
 
 	test( 'should leave query string untouched when modifying url', () => {
-		expect( plansLink( '/plans?query-key=query-value', { slug: 'example.com' }, 'monthly' ) ).toBe(
+		expect( plansLink( '/plans?query-key=query-value', 'example.com', 'monthly' ) ).toBe(
 			'/plans/monthly/example.com?query-key=query-value'
 		);
 	} );

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -345,12 +345,12 @@ export default connect( ( state, ownProps ) => {
 	const selectedSiteId = isInSignup ? null : getSelectedSiteId( state );
 	const currentSitePlan = getCurrentPlan( state, selectedSiteId );
 	const isYearly = !! ownProps.relatedMonthlyPlan;
-	return Object.assign( {}, ownProps, {
+	return {
 		currentSitePlan,
 		isSiteAT: isSiteAutomatedTransfer( state, selectedSiteId ),
 		isYearly,
 		relatedYearlyPlan: isYearly
 			? null
 			: getPlanBySlug( state, getYearlyPlanByMonthly( ownProps.planType ) ),
-	} );
+	};
 } )( localize( PlanFeaturesHeader ) );

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -24,6 +24,7 @@ import { getYearlyPlanByMonthly, planMatches } from 'lib/plans';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getPlanBySlug } from 'state/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 import { isMobile } from 'lib/viewport';
 import { planLevelsMatch } from 'lib/plans/index';
 
@@ -277,6 +278,7 @@ export class PlanFeaturesHeader extends Component {
 			relatedMonthlyPlan,
 			relatedYearlyPlan,
 			site,
+			siteSlug,
 		} = this.props;
 		if ( site.jetpack ) {
 			const [ discountPrice, originalPrice ] = isYearly
@@ -292,7 +294,7 @@ export class PlanFeaturesHeader extends Component {
 						discountPrice={ discountPrice }
 						isYearly={ isYearly }
 						originalPrice={ originalPrice }
-						site={ site }
+						siteSlug={ siteSlug }
 					/>
 				)
 			);
@@ -317,6 +319,7 @@ PlanFeaturesHeader.propTypes = {
 	isPlaceholder: PropTypes.bool,
 	translate: PropTypes.func,
 	site: PropTypes.object,
+	siteSlug: PropTypes.string,
 	isInJetpackConnect: PropTypes.bool,
 	relatedMonthlyPlan: PropTypes.object,
 
@@ -334,6 +337,7 @@ PlanFeaturesHeader.defaultProps = {
 	bestValue: false,
 	isPlaceholder: false,
 	site: {},
+	siteSlug: '',
 	basePlansPath: null,
 	currentSitePlan: {},
 	isSiteAT: false,
@@ -348,5 +352,6 @@ export default connect( ( state, { isInSignup, planType, relatedMonthlyPlan } ) 
 		isSiteAT: isSiteAutomatedTransfer( state, selectedSiteId ),
 		isYearly,
 		relatedYearlyPlan: isYearly ? null : getPlanBySlug( state, getYearlyPlanByMonthly( planType ) ),
+		siteSlug: getSiteSlug( state, selectedSiteId ),
 	};
 } )( localize( PlanFeaturesHeader ) );

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -20,11 +20,10 @@ import PlanIntervalDiscount from 'my-sites/plan-interval-discount';
 import Ribbon from 'components/ribbon';
 import PlanIcon from 'components/plans/plan-icon';
 import { TYPE_FREE, PLANS_LIST, getPlanClass } from 'lib/plans/constants';
-import { planMatches } from 'lib/plans';
+import { getYearlyPlanByMonthly, planMatches } from 'lib/plans';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getPlanBySlug } from 'state/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getYearlyPlanByMonthly } from 'lib/plans';
 import { isMobile } from 'lib/viewport';
 import { planLevelsMatch } from 'lib/plans/index';
 

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -340,17 +340,14 @@ PlanFeaturesHeader.defaultProps = {
 	isSiteAT: false,
 };
 
-export default connect( ( state, ownProps ) => {
-	const { isInSignup } = ownProps;
+export default connect( ( state, { isInSignup, planType, relatedMonthlyPlan } ) => {
 	const selectedSiteId = isInSignup ? null : getSelectedSiteId( state );
 	const currentSitePlan = getCurrentPlan( state, selectedSiteId );
-	const isYearly = !! ownProps.relatedMonthlyPlan;
+	const isYearly = !! relatedMonthlyPlan;
 	return {
 		currentSitePlan,
 		isSiteAT: isSiteAutomatedTransfer( state, selectedSiteId ),
 		isYearly,
-		relatedYearlyPlan: isYearly
-			? null
-			: getPlanBySlug( state, getYearlyPlanByMonthly( ownProps.planType ) ),
+		relatedYearlyPlan: isYearly ? null : getPlanBySlug( state, getYearlyPlanByMonthly( planType ) ),
 	};
 } )( localize( PlanFeaturesHeader ) );

--- a/client/my-sites/plan-interval-discount/index.js
+++ b/client/my-sites/plan-interval-discount/index.js
@@ -19,7 +19,7 @@ class PlanIntervalDiscount extends Component {
 		discountPrice: PropTypes.number.isRequired,
 		isYearly: PropTypes.bool.isRequired,
 		originalPrice: PropTypes.number.isRequired,
-		site: PropTypes.object,
+		siteSlug: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -56,13 +56,13 @@ class PlanIntervalDiscount extends Component {
 		}
 
 		const price = this.getDiscountPriceObject();
-		const { site, translate } = this.props;
+		const { siteSlug, translate } = this.props;
 		return translate(
 			'Save {{b}}%(symbol)s%(integer)s%(fraction)s{{/b}} when you {{Link}}buy yearly{{/Link}}.',
 			{
 				args: price,
 				components: {
-					Link: <a href={ plansLink( basePlansPath, site, 'yearly' ) } />,
+					Link: <a href={ plansLink( basePlansPath, siteSlug, 'yearly' ) } />,
 					b: <b />,
 				},
 			}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -36,6 +36,7 @@ import SegmentedControlItem from 'components/segmented-control/item';
 import PaymentMethods from 'blocks/payment-methods';
 import HappychatConnection from 'components/happychat/connection-connected';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
+import { getSiteSlug } from 'state/sites/selectors';
 import { selectSiteId as selectHappychatSiteId } from 'state/help/actions';
 
 export class PlansFeaturesMain extends Component {
@@ -129,13 +130,13 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	constructPath( plansUrl, intervalType ) {
-		const { selectedFeature, selectedPlan, site } = this.props;
+		const { selectedFeature, selectedPlan, siteSlug } = this.props;
 		return addQueryArgs(
 			{
 				feature: selectedFeature,
 				plan: selectedPlan,
 			},
-			plansLink( plansUrl, site, intervalType )
+			plansLink( plansUrl, siteSlug, intervalType )
 		);
 	}
 
@@ -205,6 +206,7 @@ PlansFeaturesMain.propTypes = {
 	selectedPlan: PropTypes.string,
 	showFAQ: PropTypes.bool,
 	site: PropTypes.object,
+	siteSlug: PropTypes.string,
 };
 
 PlansFeaturesMain.defaultProps = {
@@ -214,11 +216,13 @@ PlansFeaturesMain.defaultProps = {
 	isChatAvailable: false,
 	showFAQ: true,
 	site: {},
+	siteSlug: '',
 };
 
 export default connect(
-	state => ( {
+	( state, { site } ) => ( {
 		isChatAvailable: isHappychatAvailable( state ),
+		siteSlug: getSiteSlug( state, get( site, [ 'ID' ] ) ),
 	} ),
 	{ selectHappychatSiteId }
 )( localize( PlansFeaturesMain ) );


### PR DESCRIPTION
For the Warmest Welcome project.

The idea is to better identify and isolate what we really need from `site` objects. Turns out that e.g. `PlanFeaturesHeader` only needs a slug (for `plansLink`), which is refactored by this PR, and an `isJetpack` bool prop (which will be done in a subsequent one).

This somewhat confirms my underlying hypotheses that we already use the plans page in a way that's not tightly coupled to site objects by conceptual design, but merely by passing needlessly rich props. I'm pretty sure we'll be able to come out with a component hierarchy for Jetpack sites that don't require any `site` properties at all.

### What this PR does

We start by changing the implementation and test in `lib/plans` to use a `siteSlug` instead of a `site` object.
Grepping then reveals that only two components use `plansLink`. From there, we move up the tree of call sites.
1. `client/my-sites/plan-features-main`. We fetch the correct site slug in `connect()`, and pass it through to `plansLink()`.
    * We're done on this branch.
1. `client/my-sites/plan-interval-discount`. We change it to pass `siteSlug` thru (instead of a `site` object)
    1. `client/my-sites/plan-interval-discount` is only rendered by `client/my-sites/plan-features/header`. We change it to fetch the correct site slug in `connect`, and pass that to `client/my-sites/plan-interval-discount`.
        * We're done on this branch.

### Testing Instructions
* Verify that the Plans page still works in various scenarios -- during signup, in `my-sites`; for WP.com sites, for Jetpack sites; etc.
* Also verify that `plansLink` and `plan-interval-discount` aren't used anywhere else, to prove that the refactor is complete.