### PR TITLE
[Domains] Translate suggestion match reasons

### DIFF
--- a/client/components/domains/domain-registration-suggestion/utility.js
+++ b/client/components/domains/domain-registration-suggestion/utility.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { includes } from 'lodash';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -84,13 +85,18 @@ function sortMatchReasons( matchReasons ) {
 
 function getMatchReasonPhrasesMap( tld ) {
 	return new Map( [
-		[ 'tld-exact', `Extension ".${ tld }" matches your query` ],
-		[ 'tld-similar', `Extension ".${ tld }" closely matches your query` ],
-		[ 'exact-match', 'Exact match' ],
-		[ 'similar-match', 'Close match' ],
+		[ 'tld-exact', translate( 'Extension ".%(tld)s" matches your query', { args: { tld } } ) ],
+		[
+			'tld-similar',
+			translate( 'Extension ".%(tld)s" closely matches your query', { args: { tld } } ),
+		],
+		[ 'exact-match', translate( 'Exact match' ) ],
+		[ 'similar-match', translate( 'Close match' ) ],
 		[
 			'tld-common',
-			tld === 'com' ? `Most common extension, ".${ tld }"` : `Common extension, ".${ tld }"`,
+			tld === 'com'
+				? translate( 'Most common extension, ".com"' )
+				: translate( 'Common extension, ".%(tld)s"', { args: { tld } } ),
 		],
 	] );
 }


### PR DESCRIPTION
Fixes #24251.

This translates domain match reasons for the new Kracken domain registration UI.

### Test instructions
1. Spin up this branch locally.
2. Navigate to `/start/domains/`.
3. Confirm that the match reasons read as expected in your interface language.
4. Try changing your [interface language](https://wordpress.com/me/account) and repeat steps 2~3.