### PR TITLE
Framework: Add a utility to forward actions from flux to redux

### DIFF
--- a/client/lib/redux-bridge/index.js
+++ b/client/lib/redux-bridge/index.js
@@ -1,4 +1,10 @@
 /** @format */
+
+/**
+ * Internal Dependencies
+ */
+import Dispatcher from 'dispatcher';
+
 let reduxStore = null;
 
 export function setReduxStore( store ) {
@@ -25,3 +31,21 @@ export function reduxDispatch( ...args ) {
 	}
 	reduxStore.dispatch( ...args );
 }
+
+function markedFluxAction( action ) {
+	return Object.assign( {}, action, { type: `FLUX_${ action.type }` } );
+}
+
+// this is a Map<ActionType:string, transform:action=>action
+const forwardActionMap = new Map();
+forwardActionMap.set( 'RECEIVE_MEDIA_ITEM', markedFluxAction );
+forwardActionMap.set( 'RECEIVE_MEDIA_ITEMS', markedFluxAction );
+
+function forwardAction( { action = {} } ) {
+	const transform = forwardActionMap.get( action.type );
+	if ( transform ) {
+		reduxDispatch( transform( action ) );
+	}
+}
+
+Dispatcher.register( forwardAction );

--- a/client/lib/redux-bridge/index.js
+++ b/client/lib/redux-bridge/index.js
@@ -43,6 +43,10 @@ export function registerActionForward( actionName ) {
 	actionsToForward.add( actionName );
 }
 
+export function clearActionForwards() {
+	actionsToForward.clear();
+}
+
 function forwardAction( { action = {} } ) {
 	if ( actionsToForward.has( action.type ) ) {
 		reduxDispatch( markedFluxAction( action ) );

--- a/client/lib/redux-bridge/index.js
+++ b/client/lib/redux-bridge/index.js
@@ -37,14 +37,15 @@ function markedFluxAction( action ) {
 }
 
 // this is a Map<ActionType:string, transform:action=>action
-const forwardActionMap = new Map();
-forwardActionMap.set( 'RECEIVE_MEDIA_ITEM', markedFluxAction );
-forwardActionMap.set( 'RECEIVE_MEDIA_ITEMS', markedFluxAction );
+const actionsToForward = new Set();
+
+export function registerActionForward( actionName ) {
+	actionsToForward.add( actionName );
+}
 
 function forwardAction( { action = {} } ) {
-	const transform = forwardActionMap.get( action.type );
-	if ( transform ) {
-		reduxDispatch( transform( action ) );
+	if ( actionsToForward.has( action.type ) ) {
+		reduxDispatch( markedFluxAction( action ) );
 	}
 }
 

--- a/client/lib/redux-bridge/test/index.js
+++ b/client/lib/redux-bridge/test/index.js
@@ -8,7 +8,7 @@
  * Internal Dependencies
  */
 import Dispatcher from 'dispatcher';
-import { setReduxStore } from '../';
+import { setReduxStore, registerActionForward } from '../';
 
 describe( 'redux-bridge', () => {
 	let fakeStore;
@@ -24,7 +24,8 @@ describe( 'redux-bridge', () => {
 		setReduxStore( null );
 	} );
 	test( 'flux actions that match the dispatch map get forwarded to the redux store', () => {
-		Dispatcher.handleServerAction( { type: 'RECEIVE_MEDIA_ITEM' } );
-		expect( fakeStore.dispatch ).toHaveBeenLastCalledWith( { type: 'FLUX_RECEIVE_MEDIA_ITEM' } );
+		registerActionForward( 'MY_ACTION' );
+		Dispatcher.handleServerAction( { type: 'MY_ACTION' } );
+		expect( fakeStore.dispatch ).toHaveBeenLastCalledWith( { type: 'FLUX_MY_ACTION' } );
 	} );
 } );

--- a/client/lib/redux-bridge/test/index.js
+++ b/client/lib/redux-bridge/test/index.js
@@ -11,13 +11,13 @@ import Dispatcher from 'dispatcher';
 import { setReduxStore, registerActionForward, clearActionForwards } from '../';
 
 describe( 'redux-bridge', () => {
-	let fakeStore;
+	let mockReduxStore;
 	beforeEach( () => {
-		fakeStore = {
+		mockReduxStore = {
 			dispatch: jest.fn(),
 			getState: jest.fn(),
 		};
-		setReduxStore( fakeStore );
+		setReduxStore( mockReduxStore );
 	} );
 
 	afterEach( () => {
@@ -27,16 +27,16 @@ describe( 'redux-bridge', () => {
 	test( 'flux actions that match the dispatch map get forwarded to the redux store', () => {
 		registerActionForward( 'MY_ACTION' );
 		Dispatcher.handleServerAction( { type: 'MY_ACTION' } );
-		expect( fakeStore.dispatch ).toHaveBeenLastCalledWith( { type: 'FLUX_MY_ACTION' } );
+		expect( mockReduxStore.dispatch ).toHaveBeenLastCalledWith( { type: 'FLUX_MY_ACTION' } );
 	} );
 
 	test( 'flux actions that DO NOT match the dispatch map DO NOT get forwarded to the redux store', () => {
 		registerActionForward( 'MY_OTHER_ACTION' );
 		Dispatcher.handleServerAction( { type: 'MY_ACTION' } );
-		expect( fakeStore.dispatch ).not.toHaveBeenCalled();
+		expect( mockReduxStore.dispatch ).not.toHaveBeenCalled();
 	} );
 
 	test( 'if nothing is registered nothing breaks', () => {
-		expect( fakeStore.dispatch ).not.toHaveBeenCalled();
+		expect( mockReduxStore.dispatch ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/lib/redux-bridge/test/index.js
+++ b/client/lib/redux-bridge/test/index.js
@@ -1,0 +1,30 @@
+/**
+ * External Dependencies
+ *
+ * @format
+ */
+
+/**
+ * Internal Dependencies
+ */
+import Dispatcher from 'dispatcher';
+import { setReduxStore } from '../';
+
+describe( 'redux-bridge', () => {
+	let fakeStore;
+	beforeAll( () => {
+		fakeStore = {
+			dispatch: jest.fn(),
+			getState: jest.fn(),
+		};
+		setReduxStore( fakeStore );
+	} );
+
+	afterAll( () => {
+		setReduxStore( null );
+	} );
+	test( 'flux actions that match the dispatch map get forwarded to the redux store', () => {
+		Dispatcher.handleServerAction( { type: 'RECEIVE_MEDIA_ITEM' } );
+		expect( fakeStore.dispatch ).toHaveBeenLastCalledWith( { type: 'FLUX_RECEIVE_MEDIA_ITEM' } );
+	} );
+} );

--- a/client/lib/redux-bridge/test/index.js
+++ b/client/lib/redux-bridge/test/index.js
@@ -8,11 +8,11 @@
  * Internal Dependencies
  */
 import Dispatcher from 'dispatcher';
-import { setReduxStore, registerActionForward } from '../';
+import { setReduxStore, registerActionForward, clearActionForwards } from '../';
 
 describe( 'redux-bridge', () => {
 	let fakeStore;
-	beforeAll( () => {
+	beforeEach( () => {
 		fakeStore = {
 			dispatch: jest.fn(),
 			getState: jest.fn(),
@@ -20,12 +20,23 @@ describe( 'redux-bridge', () => {
 		setReduxStore( fakeStore );
 	} );
 
-	afterAll( () => {
+	afterEach( () => {
 		setReduxStore( null );
+		clearActionForwards();
 	} );
 	test( 'flux actions that match the dispatch map get forwarded to the redux store', () => {
 		registerActionForward( 'MY_ACTION' );
 		Dispatcher.handleServerAction( { type: 'MY_ACTION' } );
 		expect( fakeStore.dispatch ).toHaveBeenLastCalledWith( { type: 'FLUX_MY_ACTION' } );
+	} );
+
+	test( 'flux actions that DO NOT match the dispatch map DO NOT get forwarded to the redux store', () => {
+		registerActionForward( 'MY_OTHER_ACTION' );
+		Dispatcher.handleServerAction( { type: 'MY_ACTION' } );
+		expect( fakeStore.dispatch ).not.toHaveBeenCalled();
+	} );
+
+	test( 'if nothing is registered nothing breaks', () => {
+		expect( fakeStore.dispatch ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
This adds a proxy for flux actions over to redux. Only actions that are in a Map are forwarded over the bridge.

This is handy when porting flux stores over to redux and the flux store consumes actions from a number of different sources, like media.