### PR TITLE
Store: Update product category selectors & tests, run prettier

### DIFF
--- a/client/extensions/woocommerce/app/product-categories/list.js
+++ b/client/extensions/woocommerce/app/product-categories/list.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -34,7 +35,6 @@ import ImageThumb from 'woocommerce/components/image-thumb';
 const ITEM_HEIGHT = 70;
 
 class ProductCategories extends Component {
-
 	componentWillMount() {
 		this.catIds = map( this.props.categories, 'id' );
 	}
@@ -98,10 +98,14 @@ class ProductCategories extends Component {
 
 		return (
 			<div key={ 'product-category-' + itemId } className="product-categories__list-item">
-				<CompactCard key={ itemId } className="product-categories__list-item-card" onClick={ goToLink }>
+				<CompactCard
+					key={ itemId }
+					className="product-categories__list-item-card"
+					onClick={ goToLink }
+				>
 					<div className="product-categories__list-item-wrapper">
 						<div className="product-categories__list-thumb">
-							<ImageThumb src={ item.image && item.image.src || '' } alt="" />
+							<ImageThumb src={ ( item.image && item.image.src ) || '' } alt="" />
 						</div>
 						<span className="product-categories__list-item-info">
 							<a href={ link }>{ item.name }</a>
@@ -110,11 +114,11 @@ class ProductCategories extends Component {
 						</span>
 					</div>
 				</CompactCard>
-					{ children.length > 0 && (
-						<div className="product-categories__list-nested">
-							{ children.map( child => this.renderItem( child, true ) ) }
-						</div>
-					) }
+				{ children.length > 0 && (
+					<div className="product-categories__list-nested">
+						{ children.map( child => this.renderItem( child, true ) ) }
+					</div>
+				) }
 			</div>
 		);
 	}
@@ -132,7 +136,7 @@ class ProductCategories extends Component {
 		const { loading, categories, lastPage, searchQuery } = this.props;
 		return (
 			<WindowScroller>
-				{( { height, scrollTop } ) => (
+				{ ( { height, scrollTop } ) => (
 					<VirtualList
 						items={ categories }
 						lastPage={ lastPage }
@@ -147,7 +151,7 @@ class ProductCategories extends Component {
 						height={ height }
 						scrollTop={ scrollTop }
 					/>
-				)}
+				) }
 			</WindowScroller>
 		);
 	}
@@ -164,7 +168,9 @@ class ProductCategories extends Component {
 					},
 				} );
 			}
-			return <EmptyContent title={ translate( 'No product categories found.' ) } line={ message } />;
+			return (
+				<EmptyContent title={ translate( 'No product categories found.' ) } line={ message } />
+			);
 		}
 
 		const classes = classNames( 'product-categories__list', className );
@@ -172,15 +178,13 @@ class ProductCategories extends Component {
 		return (
 			<div className="product-categories__list-container">
 				<div className={ classes }>
-					{
-						this.props.isInitialRequestLoaded && this.renderCategoryList() ||
+					{ ( this.props.isInitialRequestLoaded && this.renderCategoryList() ) || (
 						<div className="product-categories__list-placeholder" />
-					}
+					) }
 				</div>
 			</div>
 		);
 	}
-
 }
 
 function mapStateToProps( state, ownProps ) {

--- a/client/extensions/woocommerce/app/product-categories/list.js
+++ b/client/extensions/woocommerce/app/product-categories/list.js
@@ -14,9 +14,9 @@ import WindowScroller from 'react-virtualized/WindowScroller';
  * Internal dependencies
  */
 import {
-	areProductCategoriesLoadingIgnoringPage,
+	areAnyProductCategoriesLoading,
 	getProductCategoriesLastPage,
-	getProductCategoriesIgnoringPage,
+	getAllProductCategories,
 	areProductCategoriesLoaded,
 	getTotalProductCategories,
 } from 'woocommerce/state/sites/product-categories/selectors';
@@ -191,9 +191,9 @@ function mapStateToProps( state, ownProps ) {
 	}
 
 	const site = getSelectedSiteWithFallback( state );
-	const loading = areProductCategoriesLoadingIgnoringPage( state, query );
+	const loading = areAnyProductCategoriesLoading( state, query );
 	const isInitialRequestLoaded = areProductCategoriesLoaded( state, query ); // first page request
-	const categories = getProductCategoriesIgnoringPage( state, query );
+	const categories = getAllProductCategories( state, query );
 	const totalCategories = getTotalProductCategories( state, query );
 	const lastPage = getProductCategoriesLastPage( state, query );
 	return {

--- a/client/extensions/woocommerce/app/product-categories/list.js
+++ b/client/extensions/woocommerce/app/product-categories/list.js
@@ -8,7 +8,6 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { map, filter, reduce, includes } from 'lodash';
-import page from 'page';
 import WindowScroller from 'react-virtualized/WindowScroller';
 
 /**
@@ -89,20 +88,11 @@ class ProductCategories extends Component {
 		const children = this.getChildren( item.id );
 		const itemId = item.id;
 		const link = getLink( '/store/products/category/:site/' + itemId, site );
-
-		const goToLink = () => {
-			page( link );
-		};
-
 		const description = decodeEntities( stripHTML( item.description ) );
 
 		return (
 			<div key={ 'product-category-' + itemId } className="product-categories__list-item">
-				<CompactCard
-					key={ itemId }
-					className="product-categories__list-item-card"
-					onClick={ goToLink }
-				>
+				<CompactCard key={ itemId } className="product-categories__list-item-card" href={ link }>
 					<div className="product-categories__list-item-wrapper">
 						<div className="product-categories__list-thumb">
 							<ImageThumb src={ ( item.image && item.image.src ) || '' } alt="" />

--- a/client/extensions/woocommerce/app/product-categories/list.js
+++ b/client/extensions/woocommerce/app/product-categories/list.js
@@ -98,7 +98,7 @@ class ProductCategories extends Component {
 							<ImageThumb src={ ( item.image && item.image.src ) || '' } alt="" />
 						</div>
 						<span className="product-categories__list-item-info">
-							<a href={ link }>{ item.name }</a>
+							<span className="product-categories__list-item-name">{ item.name }</span>
 							<Count count={ item.count } />
 							<span className="product-categories__list-item-description">{ description }</span>
 						</span>

--- a/client/extensions/woocommerce/app/product-categories/style.scss
+++ b/client/extensions/woocommerce/app/product-categories/style.scss
@@ -48,6 +48,9 @@
 		margin: 18px 0px 0px 16px;
 	}
 
+	.product-categories__list-item-name {
+		color: $blue-wordpress;
+	}
 
 	&:hover {
 		background: lighten( $gray, 35% );

--- a/client/extensions/woocommerce/app/product-categories/style.scss
+++ b/client/extensions/woocommerce/app/product-categories/style.scss
@@ -14,12 +14,12 @@
 	background-color: $gray-light;
 }
 
-.product-categories__list-item-card {
-	cursor: pointer;
-}
-
 .product-categories__list-item-card.card.is-compact {
 	padding: 0;
+}
+
+.accessible-focus & .product-categories__list-item-card:focus {
+	border-left: 3px solid $blue-wordpress;
 }
 
 .product-categories__list-item-wrapper {
@@ -38,6 +38,7 @@
 
 	.product-categories__list-item-description {
 		margin-left: 24px;
+		color: $gray-text;
 	}
 
 	.image-thumb {
@@ -46,10 +47,6 @@
 
 	.count {
 		margin: 18px 0px 0px 16px;
-	}
-
-	.product-categories__list-item-name {
-		color: $blue-wordpress;
 	}
 
 	&:hover {

--- a/client/extensions/woocommerce/app/products/product-form-categories-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-categories-card.js
@@ -31,16 +31,16 @@ const ProductFormCategoriesCard = ( {
 } ) => {
 	const handleChange = categoryNames => {
 		const newCategories = compact(
-			categoryNames.map( name => {
-				const escapedCategoryName = escape( name );
+			categoryNames.map( label => {
+				const escapedCategoryName = escape( label );
 				const category = find( productCategories, cat => {
-					return escape( cat.name ) === escapedCategoryName;
+					return escape( cat.label ) === escapedCategoryName;
 				} );
 
 				if ( ! category ) {
 					// Add a new product category to the creates list.
 					const newCategoryId = generateProductCategoryId();
-					editProductCategory( siteId, { id: newCategoryId }, { name } );
+					editProductCategory( siteId, { id: newCategoryId }, { name: label, label } );
 					return { id: newCategoryId };
 				}
 
@@ -61,10 +61,10 @@ const ProductFormCategoriesCard = ( {
 	const selectedCategoryNames = compact(
 		selectedCategories.map( c => {
 			const category = find( productCategories, { id: c.id } );
-			return ( category && unescape( category.name ) ) || undefined;
+			return ( category && unescape( category.label ) ) || undefined;
 		} )
 	);
-	const productCategoryNames = productCategories.map( c => unescape( c.name ) );
+	const productCategoryNames = productCategories.map( c => unescape( c.label ) );
 
 	return (
 		<Card className="products__categories-card">

--- a/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/applies-to-filtered-list.js
+++ b/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/applies-to-filtered-list.js
@@ -1,4 +1,6 @@
-/** * External dependencies
+/** @format */
+/**
+ * External dependencies
  */
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -42,37 +44,37 @@ function isCategorySelected( appliesTo, categoryId ) {
 	if ( ! appliesTo || ! appliesTo.productCategoryIds ) {
 		return false;
 	}
-	return ( -1 !== appliesTo.productCategoryIds.indexOf( categoryId ) );
+	return -1 !== appliesTo.productCategoryIds.indexOf( categoryId );
 }
 
 function isProductSelected( appliesTo, productId ) {
 	if ( ! appliesTo || ! appliesTo.productIds ) {
 		return false;
 	}
-	return ( -1 !== appliesTo.productIds.indexOf( productId ) );
+	return -1 !== appliesTo.productIds.indexOf( productId );
 }
 
 function addCategoryId( appliesTo, categoryId ) {
-	const categoryIds = ( appliesTo ? appliesTo.productCategoryIds : [] );
+	const categoryIds = appliesTo ? appliesTo.productCategoryIds : [];
 	const newCategoryIds = [ ...categoryIds, categoryId ];
 	return { ...appliesTo, productCategoryIds: newCategoryIds };
 }
 
 function removeCategoryId( appliesTo, categoryId ) {
-	const categoryIds = ( appliesTo ? appliesTo.productCategoryIds : [] );
-	const newCategoryIds = categoryIds.filter( ( id ) => id !== categoryId );
+	const categoryIds = appliesTo ? appliesTo.productCategoryIds : [];
+	const newCategoryIds = categoryIds.filter( id => id !== categoryId );
 	return { ...appliesTo, productCategoryIds: newCategoryIds };
 }
 
 function addProductId( appliesTo, productId ) {
-	const productIds = ( appliesTo ? appliesTo.productIds : [] );
+	const productIds = appliesTo ? appliesTo.productIds : [];
 	const newProductIds = [ ...productIds, productId ];
 	return { ...appliesTo, productIds: newProductIds };
 }
 
 function removeProductId( appliesTo, productId ) {
-	const productIds = ( appliesTo ? appliesTo.productIds : [] );
-	const newProductIds = productIds.filter( ( id ) => id !== productId );
+	const productIds = appliesTo ? appliesTo.productIds : [];
+	const newProductIds = productIds.filter( id => id !== productId );
 	return { ...appliesTo, productIds: newProductIds };
 }
 
@@ -81,11 +83,7 @@ function renderImage( imageSrc ) {
 		'is-thumb-placeholder': ! imageSrc,
 	} );
 
-	return (
-		<span className={ imageClasses }>
-			{ imageSrc && <img src={ imageSrc } /> }
-		</span>
-	);
+	return <span className={ imageClasses }>{ imageSrc && <img src={ imageSrc } alt="" /> }</span>;
 }
 
 function renderRow( component, rowText, rowValue, imageSrc, selected, onChange ) {
@@ -129,18 +127,20 @@ class AppliesToFilteredList extends React.Component {
 	}
 
 	getFilteredCategories() {
-		const { value, productCategories } = this.props;
+		const { productCategories, value } = this.props;
 		const { searchFilter } = this.state;
 
 		if ( 0 === searchFilter.length ) {
 			return productCategories;
 		}
 
-		return productCategories && productCategories.filter(
-			( category ) => {
-				return categoryContainsString( category, searchFilter ) ||
-					isCategorySelected( value, category.id );
-			}
+		return (
+			productCategories &&
+			productCategories.filter(
+				category =>
+					categoryContainsString( category, searchFilter ) ||
+					isCategorySelected( value, category.id )
+			)
 		);
 	}
 
@@ -152,11 +152,13 @@ class AppliesToFilteredList extends React.Component {
 			return products;
 		}
 
-		return products && products.filter(
-			( product ) => {
-				return productContainsString( product, searchFilter ) ||
-					isProductSelected( value, product.id );
-			}
+		return (
+			products &&
+			products.filter( product => {
+				return (
+					productContainsString( product, searchFilter ) || isProductSelected( value, product.id )
+				);
+			} )
 		);
 	}
 
@@ -165,9 +167,7 @@ class AppliesToFilteredList extends React.Component {
 			return null;
 		}
 
-		return (
-			<Search value={ searchFilter } onSearch={ this.onSearch } />
-		);
+		return <Search value={ searchFilter } onSearch={ this.onSearch } />;
 	}
 
 	renderList( appliesToType, singular ) {
@@ -199,28 +199,25 @@ class AppliesToFilteredList extends React.Component {
 
 	renderProductList( singular, currency ) {
 		const filteredProducts = this.getFilteredProducts() || [];
-		const renderFunc = ( singular
+		const renderFunc = singular
 			? this.renderProductRadio( currency )
-			: this.renderProductCheckbox( currency )
-		);
+			: this.renderProductCheckbox( currency );
 
 		return (
-			<div className="promotion-applies-to-field__list">
-				{ filteredProducts.map( renderFunc ) }
-			</div>
+			<div className="promotion-applies-to-field__list">{ filteredProducts.map( renderFunc ) }</div>
 		);
 	}
 
-	renderCategoryCheckbox = ( category ) => {
+	renderCategoryCheckbox = category => {
 		const { value } = this.props;
 		const { name, id, image } = category;
 		const selected = isCategorySelected( value, id );
 		const imageSrc = image && image.src;
 
 		return renderRow( FormCheckbox, name, id, imageSrc, selected, this.onCategoryCheckbox );
-	}
+	};
 
-	renderProductCheckbox = ( currency ) => ( product ) => {
+	renderProductCheckbox = currency => product => {
 		const { value } = this.props;
 		const { name, regular_price, id, images } = product;
 		const nameWithPrice = name + ' - ' + formatCurrency( regular_price, currency );
@@ -229,9 +226,9 @@ class AppliesToFilteredList extends React.Component {
 		const imageSrc = image && image.src;
 
 		return renderRow( FormCheckbox, nameWithPrice, id, imageSrc, selected, this.onProductCheckbox );
-	}
+	};
 
-	renderProductRadio = ( currency ) => ( product ) => {
+	renderProductRadio = currency => product => {
 		const { value } = this.props;
 		const { name, regular_price, id, images } = product;
 		const nameWithPrice = name + ' - ' + formatCurrency( regular_price, currency );
@@ -240,39 +237,37 @@ class AppliesToFilteredList extends React.Component {
 		const imageSrc = image && image.src;
 
 		return renderRow( FormRadio, nameWithPrice, id, imageSrc, selected, this.onProductRadio );
-	}
+	};
 
-	onSearch = ( searchFilter ) => {
+	onSearch = searchFilter => {
 		this.setState( () => ( { searchFilter } ) );
-	}
+	};
 
-	onCategoryCheckbox = ( e ) => {
+	onCategoryCheckbox = e => {
 		const { value, edit } = this.props;
 		const categoryId = Number( e.target.value );
 		const selected = isCategorySelected( value, categoryId );
-		const newValue = ( selected
+		const newValue = selected
 			? removeCategoryId( value, categoryId )
-			: addCategoryId( value, categoryId )
-		);
+			: addCategoryId( value, categoryId );
 		edit( 'appliesTo', newValue );
-	}
+	};
 
-	onProductCheckbox = ( e ) => {
+	onProductCheckbox = e => {
 		const { value, edit } = this.props;
 		const productId = Number( e.target.value );
 		const selected = isProductSelected( value, productId );
-		const newValue = ( selected
+		const newValue = selected
 			? removeProductId( value, productId )
-			: addProductId( value, productId )
-		);
+			: addProductId( value, productId );
 		edit( 'appliesTo', newValue );
-	}
+	};
 
-	onProductRadio = ( e ) => {
+	onProductRadio = e => {
 		const { edit } = this.props;
 		const productId = Number( e.target.value );
 		edit( 'appliesTo', { productIds: [ productId ] } );
-	}
+	};
 
 	render() {
 		const { appliesToType, singular } = this.props;
@@ -289,15 +284,14 @@ class AppliesToFilteredList extends React.Component {
 
 function mapStateToProps( state ) {
 	const site = getSelectedSiteWithFallback( state );
-	const siteId = ( site ? site.ID : null );
+	const siteId = site ? site.ID : null;
 	const productsLoading = areProductsLoading( state, siteId );
-	const products = ( productsLoading ? null : getAllProducts( state, siteId ) );
+	const products = productsLoading ? null : getAllProducts( state, siteId );
 	const productCategories = getProductCategories( state, {}, siteId );
 
 	// TODO: This is temporary, as it's not used anymore.
-	const nonVariableProducts = ! productsLoading && products.filter(
-		( product ) => 'variable' !== product.type
-	);
+	const nonVariableProducts =
+		! productsLoading && products.filter( product => 'variable' !== product.type );
 
 	return {
 		products: nonVariableProducts,

--- a/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/applies-to-filtered-list.js
+++ b/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/applies-to-filtered-list.js
@@ -6,6 +6,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import { sortBy } from 'lodash';
 import warn from 'lib/warn';
 
 /**
@@ -131,17 +132,18 @@ class AppliesToFilteredList extends React.Component {
 		const { searchFilter } = this.state;
 
 		if ( 0 === searchFilter.length ) {
-			return productCategories;
+			return sortBy( productCategories, 'label' );
 		}
 
-		return (
+		const filteredCategories =
 			productCategories &&
 			productCategories.filter(
 				category =>
 					categoryContainsString( category, searchFilter ) ||
 					isCategorySelected( value, category.id )
-			)
-		);
+			);
+
+		return sortBy( filteredCategories, 'label' );
 	}
 
 	getFilteredProducts() {
@@ -210,11 +212,11 @@ class AppliesToFilteredList extends React.Component {
 
 	renderCategoryCheckbox = category => {
 		const { value } = this.props;
-		const { name, id, image } = category;
+		const { label, id, image } = category;
 		const selected = isCategorySelected( value, id );
 		const imageSrc = image && image.src;
 
-		return renderRow( FormCheckbox, name, id, imageSrc, selected, this.onCategoryCheckbox );
+		return renderRow( FormCheckbox, label, id, imageSrc, selected, this.onCategoryCheckbox );
 	};
 
 	renderProductCheckbox = currency => product => {

--- a/client/extensions/woocommerce/state/sites/product-categories/README.md
+++ b/client/extensions/woocommerce/state/sites/product-categories/README.md
@@ -82,10 +82,10 @@ Gets the total number of product categories available on a site for a query. Opt
 
 Returns the last page number of results for a query. Optional `siteId`, will default to the currently selected site.
 
-### `areProductCategoriesLoadingIgnoringPage( state, query: object, siteId: number )`
+### `areAnyProductCategoriesLoading( state, query: object, siteId: number )`
 
 Similar to `areProductCategoriesLoading`, this selector returns if a given request is being loaded for a query, ignoring the page parameter -- meaning this will return if there is a pending request for a certain query on any page of results. Optional `siteId`, will default to the currently selected site.
 
-### `getProductCategoriesIgnoringPage( state, query: object, siteId: number )`
+### `getAllProductCategories( state, query: object, siteId: number )`
 
 Similar to `getProductCategories`, this selector returns all results from a particular query, across all loaded pages. Optional `siteId`, will default to the currently selected site.

--- a/client/extensions/woocommerce/state/sites/product-categories/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/selectors.js
@@ -90,7 +90,12 @@ export function areAnyProductCategoriesLoading(
  */
 export function getProductCategory( state, categoryId, siteId = getSelectedSiteId( state ) ) {
 	const categoryState = getRawCategoryState( state, siteId );
-	return ( categoryState.items && categoryState.items[ categoryId ] ) || null;
+	const category = categoryState.items && categoryState.items[ categoryId ];
+	if ( ! category ) {
+		return null;
+	}
+	const label = getProductCategoryLabel( state, categoryId, siteId );
+	return { ...category, label };
 }
 
 /**
@@ -175,4 +180,25 @@ export function getTotalProductCategories(
 	const serializedQuery = getSerializedProductCategoriesQuery( omit( query, 'page' ) );
 	const categoryState = getRawCategoryState( state, siteId );
 	return ( categoryState.total && categoryState.total[ serializedQuery ] ) || 0;
+}
+
+/*
+ * Get the label for a given product, recursively including parent names.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} categoryId ID of the starting category.
+ * @param {Number} [siteId] wpcom site id, if not provided, uses the selected site id.
+ * @return {String} Label of given category, with all parents included
+ */
+function getProductCategoryLabel( state, categoryId, siteId = getSelectedSiteId( state ) ) {
+	const categoryState = getRawCategoryState( state, siteId );
+	const categories = categoryState.items || {};
+	const category = categories[ categoryId ];
+	if ( ! category ) {
+		return '';
+	}
+	if ( ! Number( category.parent ) ) {
+		return category.name;
+	}
+	return getProductCategoryLabel( state, category.parent, siteId ) + ` - ${ category.name }`;
 }

--- a/client/extensions/woocommerce/state/sites/product-categories/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/selectors.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { get, isArray, omit, range } from 'lodash';
 
 /**
@@ -14,31 +12,30 @@ import { getSerializedProductCategoriesQuery } from './utils';
 
 /**
  * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Object} State tree local to product categories reducer
+ */
+function getRawCategoryState( state, siteId = getSelectedSiteId( state ) ) {
+	return get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'productCategories' ], {} );
+}
+
+/**
+ * @param {Object} state Whole Redux state tree
  * @param {Object} [query] Query used to fetch product categories. If not provided, API defaults are used.
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {boolean} Whether product categories have been successfully loaded from the server
  */
-export const areProductCategoriesLoaded = (
+export function areProductCategoriesLoaded(
 	state,
 	query = {},
 	siteId = getSelectedSiteId( state )
-) => {
+) {
 	const serializedQuery = getSerializedProductCategoriesQuery( query );
-	const cats = get(
-		state,
-		[
-			'extensions',
-			'woocommerce',
-			'sites',
-			siteId,
-			'productCategories',
-			'queries',
-			serializedQuery,
-		],
-		false
-	);
+	const categoryState = getRawCategoryState( state, siteId );
+	const cats = categoryState.queries && categoryState.queries[ serializedQuery ];
+
 	return isArray( cats );
-};
+}
 
 /**
  * @param {Object} state Whole Redux state tree
@@ -46,66 +43,41 @@ export const areProductCategoriesLoaded = (
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {boolean} Whether product categories are currently being retrieved from the server
  */
-export const areProductCategoriesLoading = (
+export function areProductCategoriesLoading(
 	state,
 	query = {},
 	siteId = getSelectedSiteId( state )
-) => {
+) {
 	const serializedQuery = getSerializedProductCategoriesQuery( query );
-	const isLoading = get( state, [
-		'extensions',
-		'woocommerce',
-		'sites',
-		siteId,
-		'productCategories',
-		'isQueryLoading',
-		serializedQuery,
-	] );
+	const categoryState = getRawCategoryState( state, siteId );
+	const isLoading = categoryState.isQueryLoading && categoryState.isQueryLoading[ serializedQuery ];
 	// Strict check because it could also be undefined.
 	return true === isLoading;
-};
+}
 
 /**
  * Gets product categories from API data.
  *
- * @param {Object} rootState Global state tree
+ * @param {Object} state Global state tree
  * @param {Object} [query] Query used to fetch product categories. If not provided, API defaults are used.
  * @param {Number} [siteId] wpcom site id, if not provided, uses the selected site id.
  * @return {Array} List of product categories
  */
-export const getProductCategories = (
-	rootState,
-	query = {},
-	siteId = getSelectedSiteId( rootState )
-) => {
-	if ( ! areProductCategoriesLoaded( rootState, query, siteId ) ) {
+export function getProductCategories( state, query = {}, siteId = getSelectedSiteId( state ) ) {
+	if ( ! areProductCategoriesLoaded( state, query, siteId ) ) {
 		return [];
 	}
 	const serializedQuery = getSerializedProductCategoriesQuery( query );
-	const cats = get(
-		rootState,
-		[ 'extensions', 'woocommerce', 'sites', siteId, 'productCategories', 'items' ],
-		{}
-	);
-	const idsForQuery = get(
-		rootState,
-		[
-			'extensions',
-			'woocommerce',
-			'sites',
-			siteId,
-			'productCategories',
-			'queries',
-			serializedQuery,
-		],
-		[]
-	);
+	const categoryState = getRawCategoryState( state, siteId );
+	const allCategories = categoryState.items || {};
+	const idsForQuery = categoryState.queries && categoryState.queries[ serializedQuery ];
 
 	if ( idsForQuery.length ) {
-		return idsForQuery.map( id => cats[ id ] );
+		return idsForQuery.map( id => allCategories[ id ] );
 	}
+
 	return [];
-};
+}
 
 /**
  * @param {Object} state Whole Redux state tree
@@ -113,37 +85,27 @@ export const getProductCategories = (
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Number} Total number of product categories available for a query, or 0 if not loaded yet.
  */
-export const getTotalProductCategories = (
+export function getTotalProductCategories(
 	state,
 	query = {},
 	siteId = getSelectedSiteId( state )
-) => {
+) {
 	const serializedQuery = getSerializedProductCategoriesQuery( omit( query, 'page' ) );
-	return get(
-		state,
-		[ 'extensions', 'woocommerce', 'sites', siteId, 'productCategories', 'total', serializedQuery ],
-		0
-	);
-};
+	const categoryState = getRawCategoryState( state, siteId );
+	return ( categoryState.total && categoryState.total[ serializedQuery ] ) || 0;
+}
 
 /**
  * Gets product category fetched from API data.
  *
- * @param {Object} rootState Global state tree
+ * @param {Object} state Global state tree
  * @param {Number} categoryId The id of the category sought
  * @param {Number} siteId wpcom site id
  * @return {Object|null} Product category if found, otherwise null.
  */
-export function getProductCategory(
-	rootState,
-	categoryId,
-	siteId = getSelectedSiteId( rootState )
-) {
-	return get(
-		rootState,
-		[ 'extensions', 'woocommerce', 'sites', siteId, 'productCategories', 'items', categoryId ],
-		null
-	);
+export function getProductCategory( state, categoryId, siteId = getSelectedSiteId( state ) ) {
+	const categoryState = getRawCategoryState( state, siteId );
+	return ( categoryState.items && categoryState.items[ categoryId ] ) || null;
 }
 
 /**
@@ -152,26 +114,15 @@ export function getProductCategory(
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Number|Null} Total number of pages available for a query, or null if not loaded yet.
  */
-export const getProductCategoriesLastPage = (
+export function getProductCategoriesLastPage(
 	state,
 	query = {},
 	siteId = getSelectedSiteId( state )
-) => {
+) {
 	const serializedQuery = getSerializedProductCategoriesQuery( omit( query, 'page' ) );
-	return get(
-		state,
-		[
-			'extensions',
-			'woocommerce',
-			'sites',
-			siteId,
-			'productCategories',
-			'totalPages',
-			serializedQuery,
-		],
-		null
-	);
-};
+	const categoryState = getRawCategoryState( state, siteId );
+	return ( categoryState.totalPages && categoryState.totalPages[ serializedQuery ] ) || null;
+}
 
 /**
  * Returns true if currently requesting product categories for a query, excluding all known
@@ -201,51 +152,34 @@ export function areProductCategoriesLoadingIgnoringPage(
 /**
  * Gets all product categories from API data for a query, ignoring pages.
  *
- * @param {Object} rootState Global state tree
+ * @param {Object} state Global state tree
  * @param {Object} [query] Query used to fetch product categories. If not provided, API defaults are used.
  * @param {Number} [siteId] wpcom site id, if not provided, uses the selected site id.
  * @return {Array} List of product categories
  */
-export const getProductCategoriesIgnoringPage = (
-	rootState,
+export function getProductCategoriesIgnoringPage(
+	state,
 	query = {},
-	siteId = getSelectedSiteId( rootState )
-) => {
-	const lastPage = getProductCategoriesLastPage( rootState, query, siteId );
+	siteId = getSelectedSiteId( state )
+) {
+	const lastPage = getProductCategoriesLastPage( state, query, siteId );
 	if ( null === lastPage ) {
 		return [];
 	}
 
-	const cats = get(
-		rootState,
-		[ 'extensions', 'woocommerce', 'sites', siteId, 'productCategories', 'items' ],
-		{}
-	);
-
+	const categoryState = getRawCategoryState( state, siteId );
+	const categories = categoryState.items || {};
 	const result = [];
 
 	range( 1, lastPage + 1 ).some( page => {
 		const catQuery = { ...query, page };
 		const serializedQuery = getSerializedProductCategoriesQuery( catQuery );
-
-		const idsForQuery = get(
-			rootState,
-			[
-				'extensions',
-				'woocommerce',
-				'sites',
-				siteId,
-				'productCategories',
-				'queries',
-				serializedQuery,
-			],
-			[]
-		);
+		const idsForQuery = ( categoryState.queries && categoryState.queries[ serializedQuery ] ) || [];
 
 		if ( idsForQuery.length ) {
-			idsForQuery.forEach( id => result.push( cats[ id ] ) );
+			idsForQuery.forEach( id => result.push( categories[ id ] ) );
 		}
 	} );
 
 	return result;
-};
+}

--- a/client/extensions/woocommerce/state/sites/product-categories/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/selectors.js
@@ -64,7 +64,7 @@ export function areProductCategoriesLoading(
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Boolean}       Returns true if currently requesting product categories for a query, excluding all known queried pages.
  */
-export function areProductCategoriesLoadingIgnoringPage(
+export function areAnyProductCategoriesLoading(
 	state,
 	query = {},
 	siteId = getSelectedSiteId( state )
@@ -124,12 +124,8 @@ export function getProductCategories( state, query = {}, siteId = getSelectedSit
  * @param {Number} [siteId] wpcom site id, if not provided, uses the selected site id.
  * @return {Array} List of product categories
  */
-export function getProductCategoriesIgnoringPage(
-	state,
-	query = {},
-	siteId = getSelectedSiteId( state )
-) {
-	const loading = areProductCategoriesLoadingIgnoringPage( state, query, siteId );
+export function getAllProductCategories( state, query = {}, siteId = getSelectedSiteId( state ) ) {
+	const loading = areAnyProductCategoriesLoading( state, query, siteId );
 	if ( loading ) {
 		return [];
 	}

--- a/client/extensions/woocommerce/state/sites/product-categories/test/fixtures/categories.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/fixtures/categories.js
@@ -1,0 +1,87 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { keyBy } from 'lodash';
+
+const categories = [
+	{ id: 1, name: 'cat1', slug: 'cat-1' },
+	{ id: 2, name: 'cat2', slug: 'cat-2' },
+	{ id: 3, name: 'cat3', slug: 'cat-3' },
+	{ id: 4, name: 'cat4', slug: 'cat-4' },
+	{ id: 5, name: 'cat5', slug: 'cat-5' },
+	{ id: 6, name: 'cat6', slug: 'cat-6' },
+];
+
+const site1 = {
+	isQueryLoading: {},
+	items: [],
+	queries: {},
+	total: {},
+	totalPages: {},
+};
+
+const site4 = {
+	isQueryLoading: {
+		'{}': true,
+	},
+	items: [],
+	queries: {},
+	total: {},
+	totalPages: {},
+};
+
+const site2 = {
+	isQueryLoading: {
+		'{}': false,
+		'{"page":2}': true,
+	},
+	items: {
+		1: categories[ 0 ],
+		2: categories[ 1 ],
+	},
+	queries: {
+		'{}': [ 1, 2 ],
+	},
+	total: {
+		'{}': 6,
+	},
+	totalPages: {
+		'{}': 2,
+	},
+};
+
+const site3 = {
+	isQueryLoading: {
+		'{}': false,
+		'{"page":2}': false,
+	},
+	items: keyBy( categories, 'id' ),
+	queries: {
+		'{}': [ 1, 2, 3, 4, 5 ],
+		'{"page":2}': [ 6 ],
+	},
+	total: {
+		'{}': 6,
+	},
+	totalPages: {
+		'{}': 2,
+	},
+};
+
+export default {
+	sites: {
+		'site.one': {
+			productCategories: site1,
+		},
+		'site.two': {
+			productCategories: site2,
+		},
+		'site.three': {
+			productCategories: site3,
+		},
+		'site.four': {
+			productCategories: site4,
+		},
+	},
+};

--- a/client/extensions/woocommerce/state/sites/product-categories/test/fixtures/categories.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/fixtures/categories.js
@@ -5,12 +5,12 @@
 import { keyBy } from 'lodash';
 
 const categories = [
-	{ id: 1, name: 'cat1', slug: 'cat-1' },
-	{ id: 2, name: 'cat2', slug: 'cat-2' },
-	{ id: 3, name: 'cat3', slug: 'cat-3' },
-	{ id: 4, name: 'cat4', slug: 'cat-4' },
-	{ id: 5, name: 'cat5', slug: 'cat-5' },
-	{ id: 6, name: 'cat6', slug: 'cat-6' },
+	{ id: 1, name: 'cat1', slug: 'cat-1', parent: 0 },
+	{ id: 2, name: 'cat2', slug: 'cat-2', parent: 0 },
+	{ id: 3, name: 'cat3', slug: 'cat-3', parent: 2 },
+	{ id: 4, name: 'cat4', slug: 'cat-4', parent: 3 },
+	{ id: 5, name: 'cat5', slug: 'cat-5', parent: 0 },
+	{ id: 6, name: 'cat6', slug: 'cat-6', parent: 0 },
 ];
 
 const site1 = {

--- a/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
@@ -95,8 +95,8 @@ describe( 'selectors', () => {
 
 		test( 'should return categories that exist in fetched state', () => {
 			const categories = [
-				{ id: 1, name: 'cat1', slug: 'cat-1' },
-				{ id: 2, name: 'cat2', slug: 'cat-2' },
+				{ id: 1, label: 'cat1', name: 'cat1', slug: 'cat-1', parent: 0 },
+				{ id: 2, label: 'cat2', name: 'cat2', slug: 'cat-2', parent: 0 },
 			];
 
 			expect( getProductCategory( state, 1, 'site.three' ) ).to.eql( categories[ 0 ] );
@@ -116,7 +116,7 @@ describe( 'selectors', () => {
 		test( 'should give product categories from specified site', () => {
 			expect( getProductCategories( state, {}, 'site.three' ) ).to.have.lengthOf( 5 );
 			expect( getProductCategories( state, { page: 2 }, 'site.three' ) ).to.eql( [
-				{ id: 6, name: 'cat6', slug: 'cat-6' },
+				{ id: 6, label: 'cat6', name: 'cat6', slug: 'cat-6', parent: 0 },
 			] );
 		} );
 	} );
@@ -133,12 +133,12 @@ describe( 'selectors', () => {
 		test( 'should get all product categories from specified site', () => {
 			expect( getAllProductCategories( state, {}, 'site.three' ) ).to.have.lengthOf( 6 );
 			expect( getAllProductCategories( state, {}, 'site.three' ) ).to.eql( [
-				{ id: 1, name: 'cat1', slug: 'cat-1' },
-				{ id: 2, name: 'cat2', slug: 'cat-2' },
-				{ id: 3, name: 'cat3', slug: 'cat-3' },
-				{ id: 4, name: 'cat4', slug: 'cat-4' },
-				{ id: 5, name: 'cat5', slug: 'cat-5' },
-				{ id: 6, name: 'cat6', slug: 'cat-6' },
+				{ id: 1, label: 'cat1', name: 'cat1', slug: 'cat-1', parent: 0 },
+				{ id: 2, label: 'cat2', name: 'cat2', slug: 'cat-2', parent: 0 },
+				{ id: 3, label: 'cat2 - cat3', name: 'cat3', slug: 'cat-3', parent: 2 },
+				{ id: 4, label: 'cat2 - cat3 - cat4', name: 'cat4', slug: 'cat-4', parent: 3 },
+				{ id: 5, label: 'cat5', name: 'cat5', slug: 'cat-5', parent: 0 },
+				{ id: 6, label: 'cat6', name: 'cat6', slug: 'cat-6', parent: 0 },
 			] );
 		} );
 	} );

--- a/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
@@ -12,10 +12,10 @@ import { expect } from 'chai';
 import {
 	areProductCategoriesLoaded,
 	areProductCategoriesLoading,
-	areProductCategoriesLoadingIgnoringPage,
+	areAnyProductCategoriesLoading,
 	getProductCategory,
 	getProductCategories,
-	getProductCategoriesIgnoringPage,
+	getAllProductCategories,
 	getProductCategoriesLastPage,
 	getTotalProductCategories,
 } from '../selectors';
@@ -59,24 +59,23 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '#areProductCategoriesLoadingIgnoringPage', () => {
+	describe( '#areAnyProductCategoriesLoading', () => {
 		test( 'should be false when state is not available.', () => {
-			expect( areProductCategoriesLoadingIgnoringPage( state, {}, 'site.one' ) ).to.be.false;
+			expect( areAnyProductCategoriesLoading( state, {}, 'site.one' ) ).to.be.false;
 		} );
 
 		test( 'should be true when any page of categories are currently being fetched.', () => {
 			// page 2 is currently being fetched, but this selector ignores page
-			expect( areProductCategoriesLoadingIgnoringPage( state, {}, 'site.two' ) ).to.be.true;
+			expect( areAnyProductCategoriesLoading( state, {}, 'site.two' ) ).to.be.true;
 		} );
 
 		test( 'should be true when categories are currently being fetched, and passed a page parameter.', () => {
 			// page 2 is currently being fetched, but this selector ignores page
-			expect( areProductCategoriesLoadingIgnoringPage( state, { page: 2 }, 'site.two' ) ).to.be
-				.true;
+			expect( areAnyProductCategoriesLoading( state, { page: 2 }, 'site.two' ) ).to.be.true;
 		} );
 
 		test( 'should be false when categories are loaded.', () => {
-			expect( areProductCategoriesLoadingIgnoringPage( state, {}, 'site.three' ) ).to.be.false;
+			expect( areAnyProductCategoriesLoading( state, {}, 'site.three' ) ).to.be.false;
 		} );
 	} );
 
@@ -122,18 +121,18 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '#getProductCategoriesIgnoringPage()', () => {
+	describe( '#getAllProductCategories()', () => {
 		test( 'should return an empty array if data is not available.', () => {
-			expect( getProductCategoriesIgnoringPage( state, {}, 'site.one' ) ).to.eql( [] );
+			expect( getAllProductCategories( state, {}, 'site.one' ) ).to.eql( [] );
 		} );
 
 		test( 'should return an empty array if data is still loading.', () => {
-			expect( getProductCategoriesIgnoringPage( state, {}, 'site.two' ) ).to.eql( [] );
+			expect( getAllProductCategories( state, {}, 'site.two' ) ).to.eql( [] );
 		} );
 
 		test( 'should get all product categories from specified site', () => {
-			expect( getProductCategoriesIgnoringPage( state, {}, 'site.three' ) ).to.have.lengthOf( 6 );
-			expect( getProductCategoriesIgnoringPage( state, {}, 'site.three' ) ).to.eql( [
+			expect( getAllProductCategories( state, {}, 'site.three' ) ).to.have.lengthOf( 6 );
+			expect( getAllProductCategories( state, {}, 'site.three' ) ).to.eql( [
 				{ id: 1, name: 'cat1', slug: 'cat-1' },
 				{ id: 2, name: 'cat2', slug: 'cat-2' },
 				{ id: 3, name: 'cat3', slug: 'cat-3' },

--- a/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
@@ -3,295 +3,172 @@
 /**
  * External dependencies
  */
+import deepFreeze from 'deep-freeze';
 import { expect } from 'chai';
 
 /**
  * Internal dependencies
  */
 import {
-	getProductCategories,
-	getProductCategory,
 	areProductCategoriesLoaded,
 	areProductCategoriesLoading,
-	getTotalProductCategories,
-	getProductCategoriesLastPage,
 	areProductCategoriesLoadingIgnoringPage,
+	getProductCategory,
+	getProductCategories,
 	getProductCategoriesIgnoringPage,
+	getProductCategoriesLastPage,
+	getTotalProductCategories,
 } from '../selectors';
+import woocommerce from './fixtures/categories';
+const state = deepFreeze( { extensions: { woocommerce } } );
 
-const preInitializedState = {
-	extensions: {
-		woocommerce: {},
-	},
-};
-
-const loadingState = {
-	extensions: {
-		woocommerce: {
-			sites: {
-				123: {
-					productCategories: {
-						isQueryLoading: {
-							'{}': true,
-						},
-					},
-				},
-				345: {
-					productCategories: {
-						isQueryLoading: {
-							'{}': false,
-							'{"page":2}': true,
-						},
-						totalPages: {
-							'{}': 2,
-						},
-					},
-				},
-			},
-		},
-	},
-};
-
-const loadedState = {
-	extensions: {
-		woocommerce: {
-			sites: {
-				123: {
-					productCategories: {
-						isQueryLoading: {
-							'{}': false,
-						},
-						items: {
-							1: { id: 1, name: 'cat1', slug: 'cat-1' },
-							2: { id: 2, name: 'cat2', slug: 'cat-2' },
-						},
-						queries: {
-							'{}': [ 1, 2 ],
-						},
-						total: {
-							'{}': 2,
-						},
-						totalPages: {
-							'{}': 1,
-						},
-					},
-				},
-				345: {
-					productCategories: {
-						isQueryLoading: {
-							'{}': false,
-							'{"page":2}': false,
-						},
-						items: {
-							3: { id: 3, name: 'cat3', slug: 'cat-3' },
-							4: { id: 4, name: 'cat4', slug: 'cat-4' },
-							5: { id: 5, name: 'cat5', slug: 'cat-5' },
-							6: { id: 6, name: 'cat6', slug: 'cat-6' },
-						},
-						queries: {
-							'{}': [ 3, 4 ],
-							'{"page":2}': [ 5, 6 ],
-						},
-						total: {
-							'{}': 4,
-						},
-						totalPages: {
-							'{}': 2,
-						},
-					},
-				},
-			},
-		},
-	},
-};
-
-const loadedStateWithUi = { ...loadedState, ui: { selectedSiteId: 123 } };
+/*
+ * state.extensions.woocommerce.sites has four sites:
+ *  - site.one: nothing loaded yet
+ *  - site.two: 1 page of categories loaded, 1 still loadingState
+ *  - site.three: 2 pages of categories loaded
+ *  - site.four: first page of categories is loading
+ */
 
 describe( 'selectors', () => {
-	describe( '#getProductCategories()', () => {
-		test( 'should return an empty array if data is not available.', () => {
-			expect( getProductCategories( preInitializedState, {}, 123 ) ).to.eql( [] );
-		} );
-
-		test( 'should return an empty array if data is still loading.', () => {
-			expect( getProductCategories( loadingState, {}, 123 ) ).to.eql( [] );
-		} );
-
-		test( 'should give product categories from specified site', () => {
-			expect( getProductCategories( loadedState, {}, 123 ) ).to.eql( [
-				{ id: 1, name: 'cat1', slug: 'cat-1' },
-				{ id: 2, name: 'cat2', slug: 'cat-2' },
-			] );
-			expect( getProductCategories( loadedState, {}, 345 ) ).to.eql( [
-				{ id: 3, name: 'cat3', slug: 'cat-3' },
-				{ id: 4, name: 'cat4', slug: 'cat-4' },
-			] );
-		} );
-	} );
-
-	describe( '#getProductCategory', () => {
-		test( 'should return undefined if data is not available.', () => {
-			expect( getProductCategory( preInitializedState, 1, 123 ) ).to.not.exist;
-		} );
-
-		test( 'should return undefined if data is still loading.', () => {
-			expect( getProductCategory( loadingState, 1, 123 ) ).to.not.exist;
-		} );
-
-		test( 'should return null if category is not found', () => {
-			expect( getProductCategory( loadedState, 3, 123 ) ).to.equal( null );
-			expect( getProductCategory( loadedState, { index: 0 }, 123 ) ).to.equal( null );
-		} );
-
-		test( 'should return categories that exist in fetched state', () => {
-			const categories123 = [
-				{ id: 1, name: 'cat1', slug: 'cat-1' },
-				{ id: 2, name: 'cat2', slug: 'cat-2' },
-			];
-			const categories345 = [
-				{ id: 3, name: 'cat3', slug: 'cat-3' },
-				{ id: 4, name: 'cat4', slug: 'cat-4' },
-			];
-
-			expect( getProductCategory( loadedState, 1, 123 ) ).to.eql( categories123[ 0 ] );
-			expect( getProductCategory( loadedState, 2, 123 ) ).to.eql( categories123[ 1 ] );
-			expect( getProductCategory( loadedState, 3, 345 ) ).to.eql( categories345[ 0 ] );
-			expect( getProductCategory( loadedState, 4, 345 ) ).to.eql( categories345[ 1 ] );
-		} );
-	} );
 	describe( '#areProductCategoriesLoaded', () => {
 		test( 'should be false when state is not available.', () => {
-			expect( areProductCategoriesLoaded( preInitializedState, {}, 123 ) ).to.be.false;
+			expect( areProductCategoriesLoaded( state, {}, 'site.one' ) ).to.be.false;
 		} );
 
 		test( 'should be false when categories are currently being fetched.', () => {
-			expect( areProductCategoriesLoaded( loadingState, {}, 123 ) ).to.be.false;
+			expect( areProductCategoriesLoaded( state, { page: 2 }, 'site.two' ) ).to.be.false;
 		} );
 
 		test( 'should be true when categories are loaded.', () => {
-			expect( areProductCategoriesLoaded( loadedState, {}, 123 ) ).to.be.true;
-		} );
-
-		test( 'should be false when categories are loaded only for a different site.', () => {
-			expect( areProductCategoriesLoaded( loadedState, {}, 456 ) ).to.be.false;
-		} );
-
-		test( 'should get the siteId from the UI tree if not provided.', () => {
-			expect( areProductCategoriesLoaded( loadedStateWithUi, {} ) ).to.be.true;
+			expect( areProductCategoriesLoaded( state, {}, 'site.two' ) ).to.be.true;
 		} );
 	} );
 
 	describe( '#areProductCategoriesLoading', () => {
 		test( 'should be false when state is not available.', () => {
-			expect( areProductCategoriesLoading( preInitializedState, {}, 123 ) ).to.be.false;
+			expect( areProductCategoriesLoading( state, {}, 'site.one' ) ).to.be.false;
 		} );
 
 		test( 'should be true when categories are currently being fetched.', () => {
-			expect( areProductCategoriesLoading( loadingState, {}, 123 ) ).to.be.true;
+			expect( areProductCategoriesLoading( state, { page: 2 }, 'site.two' ) ).to.be.true;
 		} );
 
 		test( 'should be false when categories are loaded.', () => {
-			expect( areProductCategoriesLoading( loadedState, {}, 123 ) ).to.be.false;
-		} );
-
-		test( 'should be false when categories are loaded only for a different site.', () => {
-			expect( areProductCategoriesLoading( loadedState, {}, 456 ) ).to.be.false;
-		} );
-
-		test( 'should get the siteId from the UI tree if not provided.', () => {
-			expect( areProductCategoriesLoading( loadedStateWithUi, {} ) ).to.be.false;
-		} );
-	} );
-
-	describe( '#getTotalProductCategories', () => {
-		test( 'should be 0 (default) when woocommerce state is not available.', () => {
-			expect( getTotalProductCategories( preInitializedState, {}, 123 ) ).to.eql( 0 );
-		} );
-
-		test( 'should be 0 (default) when categories are loading.', () => {
-			expect( getTotalProductCategories( loadingState, {}, 123 ) ).to.eql( 0 );
-		} );
-
-		test( 'should be 2, the set total, if the categories are loaded.', () => {
-			expect( getTotalProductCategories( loadedState, {}, 123 ) ).to.eql( 2 );
-		} );
-
-		test( 'should be 0 (default) when categories are loaded only for a different site.', () => {
-			expect( getTotalProductCategories( loadedState, {}, 456 ) ).to.eql( 0 );
-		} );
-
-		test( 'should get the siteId from the UI tree if not provided.', () => {
-			expect( getTotalProductCategories( loadedStateWithUi ) ).to.eql( 2 );
-		} );
-	} );
-
-	describe( '#getProductCategoriesLastPage', () => {
-		test( 'should be null (default) when woocommerce state is not available.', () => {
-			expect( getProductCategoriesLastPage( preInitializedState, {}, 123 ) ).to.eql( null );
-		} );
-
-		test( 'should be null (default) when categories are loading.', () => {
-			expect( getProductCategoriesLastPage( loadingState, {}, 123 ) ).to.eql( null );
-		} );
-
-		test( 'should be 2, the set total, if the categories are loaded.', () => {
-			expect( getProductCategoriesLastPage( loadedState, {}, 345 ) ).to.eql( 2 );
-		} );
-
-		test( 'should be null (default) when categories are loaded only for a different site.', () => {
-			expect( getProductCategoriesLastPage( loadedState, {}, 456 ) ).to.eql( null );
+			expect( areProductCategoriesLoading( state, {}, 'site.three' ) ).to.be.false;
 		} );
 	} );
 
 	describe( '#areProductCategoriesLoadingIgnoringPage', () => {
 		test( 'should be false when state is not available.', () => {
-			expect( areProductCategoriesLoadingIgnoringPage( preInitializedState, {}, 123 ) ).to.be.false;
+			expect( areProductCategoriesLoadingIgnoringPage( state, {}, 'site.one' ) ).to.be.false;
 		} );
 
-		test( 'should be true when categories are currently being fetched.', () => {
-			expect( areProductCategoriesLoadingIgnoringPage( loadingState, {}, 345 ) ).to.be.true;
+		test( 'should be true when any page of categories are currently being fetched.', () => {
+			// page 2 is currently being fetched, but this selector ignores page
+			expect( areProductCategoriesLoadingIgnoringPage( state, {}, 'site.two' ) ).to.be.true;
 		} );
 
 		test( 'should be true when categories are currently being fetched, and passed a page parameter.', () => {
-			expect( areProductCategoriesLoadingIgnoringPage( loadingState, { page: 1 }, 345 ) ).to.be
+			// page 2 is currently being fetched, but this selector ignores page
+			expect( areProductCategoriesLoadingIgnoringPage( state, { page: 2 }, 'site.two' ) ).to.be
 				.true;
 		} );
 
 		test( 'should be false when categories are loaded.', () => {
-			expect( areProductCategoriesLoadingIgnoringPage( loadedState, {}, 123 ) ).to.be.false;
+			expect( areProductCategoriesLoadingIgnoringPage( state, {}, 'site.three' ) ).to.be.false;
+		} );
+	} );
+
+	describe( '#getProductCategory', () => {
+		test( 'should return undefined if data is not available.', () => {
+			expect( getProductCategory( state, 1, 'site.one' ) ).to.not.exist;
 		} );
 
-		test( 'should be false when categories are loaded only for a different site.', () => {
-			expect( areProductCategoriesLoadingIgnoringPage( loadedState, {}, 456 ) ).to.be.false;
+		test( 'should return undefined if data is still loading.', () => {
+			expect( getProductCategory( state, 3, 'site.two' ) ).to.not.exist;
+		} );
+
+		test( 'should return null if category is not found', () => {
+			expect( getProductCategory( state, 10, 'site.three' ) ).to.equal( null );
+			expect( getProductCategory( state, { index: 0 }, 'site.three' ) ).to.equal( null );
+		} );
+
+		test( 'should return categories that exist in fetched state', () => {
+			const categories = [
+				{ id: 1, name: 'cat1', slug: 'cat-1' },
+				{ id: 2, name: 'cat2', slug: 'cat-2' },
+			];
+
+			expect( getProductCategory( state, 1, 'site.three' ) ).to.eql( categories[ 0 ] );
+			expect( getProductCategory( state, 2, 'site.three' ) ).to.eql( categories[ 1 ] );
+		} );
+	} );
+
+	describe( '#getProductCategories()', () => {
+		test( 'should return an empty array if data is not available.', () => {
+			expect( getProductCategories( state, {}, 'site.one' ) ).to.eql( [] );
+		} );
+
+		test( 'should return an empty array if data is still loading.', () => {
+			expect( getProductCategories( state, { page: 2 }, 'site.two' ) ).to.eql( [] );
+		} );
+
+		test( 'should give product categories from specified site', () => {
+			expect( getProductCategories( state, {}, 'site.three' ) ).to.have.lengthOf( 5 );
+			expect( getProductCategories( state, { page: 2 }, 'site.three' ) ).to.eql( [
+				{ id: 6, name: 'cat6', slug: 'cat-6' },
+			] );
 		} );
 	} );
 
 	describe( '#getProductCategoriesIgnoringPage()', () => {
 		test( 'should return an empty array if data is not available.', () => {
-			expect( getProductCategoriesIgnoringPage( preInitializedState, {}, 123 ) ).to.eql( [] );
+			expect( getProductCategoriesIgnoringPage( state, {}, 'site.one' ) ).to.eql( [] );
 		} );
 
 		test( 'should return an empty array if data is still loading.', () => {
-			expect( getProductCategoriesIgnoringPage( loadingState, {}, 324 ) ).to.eql( [] );
+			expect( getProductCategoriesIgnoringPage( state, {}, 'site.two' ) ).to.eql( [] );
 		} );
 
 		test( 'should get all product categories from specified site', () => {
-			expect( getProductCategoriesIgnoringPage( loadedState, {}, 123 ) ).to.eql( [
+			expect( getProductCategoriesIgnoringPage( state, {}, 'site.three' ) ).to.have.lengthOf( 6 );
+			expect( getProductCategoriesIgnoringPage( state, {}, 'site.three' ) ).to.eql( [
 				{ id: 1, name: 'cat1', slug: 'cat-1' },
 				{ id: 2, name: 'cat2', slug: 'cat-2' },
-			] );
-			expect( getProductCategoriesIgnoringPage( loadedState, {}, 345 ) ).to.eql( [
 				{ id: 3, name: 'cat3', slug: 'cat-3' },
 				{ id: 4, name: 'cat4', slug: 'cat-4' },
 				{ id: 5, name: 'cat5', slug: 'cat-5' },
 				{ id: 6, name: 'cat6', slug: 'cat-6' },
 			] );
-			expect( getProductCategoriesIgnoringPage( loadedState, { page: 1 }, 345 ) ).to.eql( [
-				{ id: 3, name: 'cat3', slug: 'cat-3' },
-				{ id: 4, name: 'cat4', slug: 'cat-4' },
-				{ id: 5, name: 'cat5', slug: 'cat-5' },
-				{ id: 6, name: 'cat6', slug: 'cat-6' },
-			] );
+		} );
+	} );
+
+	describe( '#getProductCategoriesLastPage', () => {
+		test( 'should be null (default) when woocommerce state is not available.', () => {
+			expect( getProductCategoriesLastPage( state, {}, 'site.one' ) ).to.eql( null );
+		} );
+
+		test( 'should be null (default) when categories are loading.', () => {
+			expect( getProductCategoriesLastPage( state, {}, 'site.four' ) ).to.eql( null );
+		} );
+
+		test( 'should be 2, the set total, if the categories are loaded.', () => {
+			expect( getProductCategoriesLastPage( state, {}, 'site.three' ) ).to.eql( 2 );
+		} );
+	} );
+
+	describe( '#getTotalProductCategories', () => {
+		test( 'should be 0 (default) when woocommerce state is not available.', () => {
+			expect( getTotalProductCategories( state, {}, 'site.one' ) ).to.eql( 0 );
+		} );
+
+		test( 'should be 0 (default) when categories are loading.', () => {
+			expect( getTotalProductCategories( state, {}, 'site.four' ) ).to.eql( 0 );
+		} );
+
+		test( 'should be 2, the set total, if the categories are loaded.', () => {
+			expect( getTotalProductCategories( state, {}, 'site.three' ) ).to.eql( 6 );
 		} );
 	} );
 } );

--- a/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
@@ -166,7 +166,7 @@ describe( 'selectors', () => {
 			expect( getTotalProductCategories( state, {}, 'site.four' ) ).to.eql( 0 );
 		} );
 
-		test( 'should be 2, the set total, if the categories are loaded.', () => {
+		test( 'should be 6, the set total, if the categories are loaded.', () => {
 			expect( getTotalProductCategories( state, {}, 'site.three' ) ).to.eql( 6 );
 		} );
 	} );


### PR DESCRIPTION
This PR does some cleanup on the product categories components & selectors, including running prettier, sorting selectors alphabetically, and moving the product category state into a fixtures file.

The biggest change comes in the selectors:

- `areProductCategoriesLoadingIgnoringPage` has been renamed to `areAnyProductCategoriesLoading`
- `getProductCategoriesIgnoringPage` has been renamed to `getAllProductCategories`
- Added an internal-use `getRawCategoryState` helper so that we don't need to call the entire state path each time
- Switched `getProductCategories` to use `getProductCategory` for fetching each category
- Renamed `rootState` in each function to `state` to match other Calypso selectors

I've also run prettier on the product-categories list & applies-to-filtered-list. This is in preparation for another PR, so that all the "cleanup" changes live in one PR.

**To test**

- Check that there are no UI changes, specifically on
  - product categories on promotions
  - product category list view
  - product categories on product create/edit pages
- Make sure the tests pass: `npm run test-client client/extensions/woocommerce/state/sites/product-categories`
