### PR TITLE
Store: Add parent names to product category labels

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-categories-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-categories-card.js
@@ -31,16 +31,16 @@ const ProductFormCategoriesCard = ( {
 } ) => {
 	const handleChange = categoryNames => {
 		const newCategories = compact(
-			categoryNames.map( name => {
-				const escapedCategoryName = escape( name );
+			categoryNames.map( label => {
+				const escapedCategoryName = escape( label );
 				const category = find( productCategories, cat => {
-					return escape( cat.name ) === escapedCategoryName;
+					return escape( cat.label ) === escapedCategoryName;
 				} );
 
 				if ( ! category ) {
 					// Add a new product category to the creates list.
 					const newCategoryId = generateProductCategoryId();
-					editProductCategory( siteId, { id: newCategoryId }, { name } );
+					editProductCategory( siteId, { id: newCategoryId }, { name: label, label } );
 					return { id: newCategoryId };
 				}
 
@@ -61,10 +61,10 @@ const ProductFormCategoriesCard = ( {
 	const selectedCategoryNames = compact(
 		selectedCategories.map( c => {
 			const category = find( productCategories, { id: c.id } );
-			return ( category && unescape( category.name ) ) || undefined;
+			return ( category && unescape( category.label ) ) || undefined;
 		} )
 	);
-	const productCategoryNames = productCategories.map( c => unescape( c.name ) );
+	const productCategoryNames = productCategories.map( c => unescape( c.label ) );
 
 	return (
 		<Card className="products__categories-card">

--- a/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/applies-to-filtered-list.js
+++ b/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/applies-to-filtered-list.js
@@ -6,6 +6,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import { sortBy } from 'lodash';
 import warn from 'lib/warn';
 
 /**
@@ -131,17 +132,18 @@ class AppliesToFilteredList extends React.Component {
 		const { searchFilter } = this.state;
 
 		if ( 0 === searchFilter.length ) {
-			return productCategories;
+			return sortBy( productCategories, 'label' );
 		}
 
-		return (
+		const filteredCategories =
 			productCategories &&
 			productCategories.filter(
 				category =>
 					categoryContainsString( category, searchFilter ) ||
 					isCategorySelected( value, category.id )
-			)
-		);
+			);
+
+		return sortBy( filteredCategories, 'label' );
 	}
 
 	getFilteredProducts() {
@@ -210,11 +212,11 @@ class AppliesToFilteredList extends React.Component {
 
 	renderCategoryCheckbox = category => {
 		const { value } = this.props;
-		const { name, id, image } = category;
+		const { label, id, image } = category;
 		const selected = isCategorySelected( value, id );
 		const imageSrc = image && image.src;
 
-		return renderRow( FormCheckbox, name, id, imageSrc, selected, this.onCategoryCheckbox );
+		return renderRow( FormCheckbox, label, id, imageSrc, selected, this.onCategoryCheckbox );
 	};
 
 	renderProductCheckbox = currency => product => {

--- a/client/extensions/woocommerce/state/sites/product-categories/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/selectors.js
@@ -90,7 +90,12 @@ export function areAnyProductCategoriesLoading(
  */
 export function getProductCategory( state, categoryId, siteId = getSelectedSiteId( state ) ) {
 	const categoryState = getRawCategoryState( state, siteId );
-	return ( categoryState.items && categoryState.items[ categoryId ] ) || null;
+	const category = categoryState.items && categoryState.items[ categoryId ];
+	if ( ! category ) {
+		return null;
+	}
+	const label = getProductCategoryLabel( state, categoryId, siteId );
+	return { ...category, label };
 }
 
 /**
@@ -175,4 +180,25 @@ export function getTotalProductCategories(
 	const serializedQuery = getSerializedProductCategoriesQuery( omit( query, 'page' ) );
 	const categoryState = getRawCategoryState( state, siteId );
 	return ( categoryState.total && categoryState.total[ serializedQuery ] ) || 0;
+}
+
+/*
+ * Get the label for a given product, recursively including parent names.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} categoryId ID of the starting category.
+ * @param {Number} [siteId] wpcom site id, if not provided, uses the selected site id.
+ * @return {String} Label of given category, with all parents included
+ */
+function getProductCategoryLabel( state, categoryId, siteId = getSelectedSiteId( state ) ) {
+	const categoryState = getRawCategoryState( state, siteId );
+	const categories = categoryState.items || {};
+	const category = categories[ categoryId ];
+	if ( ! category ) {
+		return '';
+	}
+	if ( ! Number( category.parent ) ) {
+		return category.name;
+	}
+	return getProductCategoryLabel( state, category.parent, siteId ) + ` - ${ category.name }`;
 }

--- a/client/extensions/woocommerce/state/sites/product-categories/test/fixtures/categories.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/fixtures/categories.js
@@ -5,12 +5,12 @@
 import { keyBy } from 'lodash';
 
 const categories = [
-	{ id: 1, name: 'cat1', slug: 'cat-1' },
-	{ id: 2, name: 'cat2', slug: 'cat-2' },
-	{ id: 3, name: 'cat3', slug: 'cat-3' },
-	{ id: 4, name: 'cat4', slug: 'cat-4' },
-	{ id: 5, name: 'cat5', slug: 'cat-5' },
-	{ id: 6, name: 'cat6', slug: 'cat-6' },
+	{ id: 1, name: 'cat1', slug: 'cat-1', parent: 0 },
+	{ id: 2, name: 'cat2', slug: 'cat-2', parent: 0 },
+	{ id: 3, name: 'cat3', slug: 'cat-3', parent: 2 },
+	{ id: 4, name: 'cat4', slug: 'cat-4', parent: 3 },
+	{ id: 5, name: 'cat5', slug: 'cat-5', parent: 0 },
+	{ id: 6, name: 'cat6', slug: 'cat-6', parent: 0 },
 ];
 
 const site1 = {

--- a/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
@@ -95,8 +95,8 @@ describe( 'selectors', () => {
 
 		test( 'should return categories that exist in fetched state', () => {
 			const categories = [
-				{ id: 1, name: 'cat1', slug: 'cat-1' },
-				{ id: 2, name: 'cat2', slug: 'cat-2' },
+				{ id: 1, label: 'cat1', name: 'cat1', slug: 'cat-1', parent: 0 },
+				{ id: 2, label: 'cat2', name: 'cat2', slug: 'cat-2', parent: 0 },
 			];
 
 			expect( getProductCategory( state, 1, 'site.three' ) ).to.eql( categories[ 0 ] );
@@ -116,7 +116,7 @@ describe( 'selectors', () => {
 		test( 'should give product categories from specified site', () => {
 			expect( getProductCategories( state, {}, 'site.three' ) ).to.have.lengthOf( 5 );
 			expect( getProductCategories( state, { page: 2 }, 'site.three' ) ).to.eql( [
-				{ id: 6, name: 'cat6', slug: 'cat-6' },
+				{ id: 6, label: 'cat6', name: 'cat6', slug: 'cat-6', parent: 0 },
 			] );
 		} );
 	} );
@@ -133,12 +133,12 @@ describe( 'selectors', () => {
 		test( 'should get all product categories from specified site', () => {
 			expect( getAllProductCategories( state, {}, 'site.three' ) ).to.have.lengthOf( 6 );
 			expect( getAllProductCategories( state, {}, 'site.three' ) ).to.eql( [
-				{ id: 1, name: 'cat1', slug: 'cat-1' },
-				{ id: 2, name: 'cat2', slug: 'cat-2' },
-				{ id: 3, name: 'cat3', slug: 'cat-3' },
-				{ id: 4, name: 'cat4', slug: 'cat-4' },
-				{ id: 5, name: 'cat5', slug: 'cat-5' },
-				{ id: 6, name: 'cat6', slug: 'cat-6' },
+				{ id: 1, label: 'cat1', name: 'cat1', slug: 'cat-1', parent: 0 },
+				{ id: 2, label: 'cat2', name: 'cat2', slug: 'cat-2', parent: 0 },
+				{ id: 3, label: 'cat2 - cat3', name: 'cat3', slug: 'cat-3', parent: 2 },
+				{ id: 4, label: 'cat2 - cat3 - cat4', name: 'cat4', slug: 'cat-4', parent: 3 },
+				{ id: 5, label: 'cat5', name: 'cat5', slug: 'cat-5', parent: 0 },
+				{ id: 6, label: 'cat6', name: 'cat6', slug: 'cat-6', parent: 0 },
 			] );
 		} );
 	} );


### PR DESCRIPTION
Fixes #20977; builds on #24274 (I wanted to split the cleanup/prettier changes). This PR adds a new step in the product category selectors, to get a `label` for each category. This is recursively generated from the category parent's name.

This PR changes the promotions selector to use the new `label`, and then sorts all the categories by the label, so that sibling categories appear nested:

<img width="226" alt="screen shot 2018-04-17 at 2 29 36 pm" src="https://user-images.githubusercontent.com/541093/38893159-7faf548a-4257-11e8-9360-cf0ee7483494.png">

This also updates the product edit screen so that the tokens use `label`, not name. This also fixes the duplicate key error when 2 children categories have the same name. 

|  Selecting a category  |  Category selected |
| --- | --- |
| <img width="364" alt="screen shot 2018-04-17 at 2 30 03 pm" src="https://user-images.githubusercontent.com/541093/38893199-9b4b27fa-4257-11e8-9d95-e4cb12c4ea25.png"> | <img width="364" alt="screen shot 2018-04-17 at 2 30 13 pm" src="https://user-images.githubusercontent.com/541093/38893200-9b5832d8-4257-11e8-932f-a75dec32a5f0.png"> |

This also supports multiply-nested categories, and you can search by parent-child:

<img width="367" alt="screen shot 2018-04-17 at 2 32 54 pm" src="https://user-images.githubusercontent.com/541093/38893270-d0c3bbd6-4257-11e8-8f92-1672f0e334ef.png">

I did not update the product list view because we don't have access to all of the categories in this component. I also didn't update the product category list because that's already using a hierarchical view.

**To test**

- Create a promotion for a product category
- Create or edit a product
  - Add an existing nested category
  - Remove a nested category
  - Create a new category (won't be nested by default, just making sure functionality remains)
- Make sure the tests pass: `npm run test-client client/extensions/woocommerce/state/sites/product-categories`
