### PR TITLE
Activity Log: fix logic

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -375,7 +375,7 @@ export default {
 			? context.query.startDate
 			: undefined;
 
-		if ( siteId && ! siteHasWpcomFreePlan && ! config.isEnabled( 'activity-log-wpcom-free' ) ) {
+		if ( siteId && siteHasWpcomFreePlan && ! config.isEnabled( 'activity-log-wpcom-free' ) ) {
 			page.redirect( '/stats' );
 			return next();
 		}


### PR DESCRIPTION
currently Activity Log is not visible in production due to an error in logic introduced in:

https://github.com/Automattic/wp-calypso/pull/24258