### PR TITLE
Adding Banner data attributes for e2e tests

### DIFF
--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -34,6 +34,7 @@ export class Banner extends Component {
 		disableHref: PropTypes.bool,
 		dismissPreferenceName: PropTypes.string,
 		dismissTemporary: PropTypes.bool,
+		e2eType: PropTypes.string,
 		event: PropTypes.string,
 		feature: PropTypes.oneOf( getValidFeatureKeys() ),
 		href: PropTypes.string,
@@ -188,6 +189,7 @@ export class Banner extends Component {
 			disableHref,
 			dismissPreferenceName,
 			dismissTemporary,
+			e2eType,
 			plan,
 		} = this.props;
 
@@ -208,6 +210,7 @@ export class Banner extends Component {
 					preferenceName={ dismissPreferenceName }
 					temporary={ dismissTemporary }
 					onClick={ this.handleDismiss }
+					data-e2e-type={ e2eType }
 				>
 					{ this.getIcon() }
 					{ this.getContent() }
@@ -220,6 +223,7 @@ export class Banner extends Component {
 				className={ classes }
 				href={ disableHref || callToAction ? null : this.getHref() }
 				onClick={ callToAction ? noop : this.handleClick }
+				data-e2e-type={ e2eType }
 			>
 				{ this.getIcon() }
 				{ this.getContent() }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -393,6 +393,7 @@ class ActivityLog extends Component {
 						description={ translate(
 							'Backups and security scans require access to your site to work properly.'
 						) }
+						e2eType="add-credentials"
 					/>
 				) }
 				{ 'provisioning' === rewindState.state && (
@@ -404,6 +405,7 @@ class ActivityLog extends Component {
 							"We're currently backing up your site for the first time, and we'll let you know when we're finished. " +
 								"After this initial backup, we'll save future changes in real time."
 						) }
+						e2eType="backup-underway"
 					/>
 				) }
 				{ this.renderErrorMessage() }


### PR DESCRIPTION
Adding data attributes for Activity Log banners to determinate if the backup is underway and if credentials are required.


To test:
1. Create a Pressable site
2. Visit Activity log page right after approving Jetpack connection. Make sure data attribute is present on "Add credentials" banner
2. Visit Activity log after adding credentials. Make sure data attribute is present on "Backup is underway" banner.
3. Check any other banner. Make sure that page is loaded correctly and data attribute is not added (e.g. upgrade banner in Settings > Security on Personal plan)

<img width="600" alt="stats e2eflowtesting1523994771134901 mystagingwebsite com at pressable wordpress com 2018-04-17 22-56-56" src="https://user-images.githubusercontent.com/5654161/38893808-1bfdb746-4294-11e8-8864-9979dec3f54e.png">

<img width="600" alt="stats qweqweqw mystagingwebsite com at pressable wordpress com 2018-04-17 23-03-57" src="https://user-images.githubusercontent.com/5654161/38893813-1ff5e0c6-4294-11e8-9a8a-747cf2c84d37.png">

