### PR TITLE
[Domains] Remove extended copy for domain price

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -25,7 +25,6 @@ class DomainProductPrice extends React.Component {
 		freeWithPlan: PropTypes.bool,
 		requiresPlan: PropTypes.bool,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
-		showExpandedPrice: PropTypes.bool,
 	};
 
 	renderFreeWithPlan() {
@@ -63,14 +62,12 @@ class DomainProductPrice extends React.Component {
 	}
 
 	renderIncludedInPremium() {
-		const { translate, showExpandedPrice } = this.props;
+		const { translate } = this.props;
 
 		// TODO: When removing this flag, remember to remove PremiumPopover component
 		//       from the codebase.
 		const isKrackenUi = config.isEnabled( 'domains/kracken-ui' );
-		const includedInPlanText = showExpandedPrice
-			? translate( 'Price included in paid plans' )
-			: translate( 'Included in paid plans' );
+		const includedInPlanText = translate( 'Included in paid plans' );
 
 		return (
 			<div className="domain-product-price is-with-plans-only">

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -262,7 +262,6 @@ class DomainRegistrationSuggestion extends React.Component {
 				domain={ domain }
 				domainsWithPlansOnly={ domainsWithPlansOnly }
 				onButtonClick={ this.onButtonClick }
-				showExpandedPrice={ isFeatured }
 				{ ...this.getButtonProps() }
 			>
 				{ this.renderDomain() }

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -27,7 +27,6 @@ class DomainSuggestion extends React.Component {
 		domain: PropTypes.string,
 		hidePrice: PropTypes.bool,
 		showChevron: PropTypes.bool,
-		showExpandedPrice: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -35,19 +34,10 @@ class DomainSuggestion extends React.Component {
 			? { primary: true }
 			: { borderless: true },
 		showChevron: ! config.isEnabled( 'domains/kracken-ui' ),
-		showExpandedPrice: false,
 	};
 
 	render() {
-		const {
-			children,
-			extraClasses,
-			hidePrice,
-			isAdded,
-			price,
-			priceRule,
-			showExpandedPrice,
-		} = this.props;
+		const { children, extraClasses, hidePrice, isAdded, price, priceRule } = this.props;
 		const classes = classNames(
 			'domain-suggestion',
 			'card',
@@ -70,13 +60,7 @@ class DomainSuggestion extends React.Component {
 			>
 				<div className="domain-suggestion__content">
 					{ children }
-					{ ! hidePrice && (
-						<DomainProductPrice
-							price={ price }
-							rule={ priceRule }
-							showExpandedPrice={ showExpandedPrice }
-						/>
-					) }
+					{ ! hidePrice && <DomainProductPrice price={ price } rule={ priceRule } /> }
 				</div>
 				<Button className="domain-suggestion__action" { ...this.props.buttonProps }>
 					{ this.props.buttonContent }


### PR DESCRIPTION
This replaces the extended copy `Price included in paid plans` from featured suggestions with the copy `Included in paid plans`. `Included in paid plans` is now used for all domain suggestions.

### Test instructions
1. Spin up this branch locally.
2. Navigate to `/start/domains` and enter a query.
3. Ensure that you see `Included in paid plans` for featured suggestions like so:

<img width="980" alt="wordpress_com" src="https://user-images.githubusercontent.com/4044428/38895535-8c9a3ebc-424d-11e8-91af-6c0315575837.png">