### PR TITLE
[Domain] Prevent flex-shrink to fix Safari layout

### DIFF
--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -16,7 +16,7 @@
 	}
 
 	&.is-with-plans-only:not( .is-free-domain ) {
-		flex: 1 1 280px;
+		flex: 1 0 280px;
 
 		small {
 			font-size: 12px;

--- a/client/components/domains/domain-registration-suggestion/style.scss
+++ b/client/components/domains/domain-registration-suggestion/style.scss
@@ -14,7 +14,7 @@
 	.domain-registration-suggestion__title,
 	.domain-registration-suggestion__progress-bar,
 	.domain-product-price {
-		width: 100%;
+		flex-shrink: 0;
 	}
 
 	.domain-registration-suggestion__title {


### PR DESCRIPTION
Due to how Safari handles shrunk flex items, our featured domain suggestions can look exceptionally strange:

<img width="982" alt="Incorrect layout" src="https://user-images.githubusercontent.com/4044428/38896527-2d2a5522-4250-11e8-827b-fec7fddab1c0.png">

This PR fixes this aberration.

### Test instructions
1) Spin up this branch locally.
2) Navigate to `/start/domains` in Safari and enter a query.
3) Ensure that the layout looks correct, like so:

<img width="977" alt="Correct layout" src="https://user-images.githubusercontent.com/4044428/38896593-5403a54a-4250-11e8-853b-857e0fc7e655.png">

