### PR TITLE
Prepare for Post Editor metadata Reduxification

### DIFF
--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -435,12 +435,20 @@ export function edits( state = {}, action ) {
 				state
 			);
 
-		case POST_EDIT:
-			return mergeIgnoringArrays( {}, state, {
-				[ action.siteId ]: {
-					[ action.postId || '' ]: action.post,
+		case POST_EDIT: {
+			const siteId = action.siteId;
+			const postId = action.postId || '';
+			const postEdits = get( state, [ siteId, postId ] );
+			const mergedEdits = mergeIgnoringArrays( {}, postEdits, action.post );
+
+			return {
+				...state,
+				[ siteId ]: {
+					...state[ siteId ],
+					[ postId ]: mergedEdits,
 				},
-			} );
+			};
+		}
 
 		case EDITOR_START:
 			return Object.assign( {}, state, {

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -416,23 +416,21 @@ export function edits( state = {}, action ) {
 						memoState = merge( {}, state );
 					}
 
-					return set(
-						memoState,
-						[ post.site_ID, post.ID ],
-						omitBy( postEdits, ( value, key ) => {
-							switch ( key ) {
-								case 'author':
-									return isAuthorEqual( value, post[ key ] );
-								case 'discussion':
-									return isDiscussionEqual( value, post[ key ] );
-								case 'featured_image':
-									return value === getFeaturedImageId( post );
-								case 'terms':
-									return isTermsEqual( value, post[ key ] );
-							}
-							return isEqual( post[ key ], value );
-						} )
-					);
+					const unappliedPostEdits = omitBy( postEdits, ( value, key ) => {
+						switch ( key ) {
+							case 'author':
+								return isAuthorEqual( value, post[ key ] );
+							case 'discussion':
+								return isDiscussionEqual( value, post[ key ] );
+							case 'featured_image':
+								return value === getFeaturedImageId( post );
+							case 'terms':
+								return isTermsEqual( value, post[ key ] );
+						}
+						return isEqual( post[ key ], value );
+					} );
+
+					return set( memoState, [ post.site_ID, post.ID ], unappliedPostEdits );
 				},
 				state
 			);

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -50,7 +50,7 @@ import {
 	isAuthorEqual,
 	isDiscussionEqual,
 	isTermsEqual,
-	mergeIgnoringArrays,
+	mergePostEdits,
 	normalizePostForState,
 } from './utils';
 import { itemsSchema, queriesSchema, allSitesQueriesSchema } from './schema';
@@ -439,7 +439,7 @@ export function edits( state = {}, action ) {
 			const siteId = action.siteId;
 			const postId = action.postId || '';
 			const postEdits = get( state, [ siteId, postId ] );
-			const mergedEdits = mergeIgnoringArrays( {}, postEdits, action.post );
+			const mergedEdits = mergePostEdits( postEdits, action.post );
 
 			return {
 				...state,

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -17,7 +17,7 @@ import {
 	getSerializedPostsQueryWithoutPage,
 	isAuthorEqual,
 	isDiscussionEqual,
-	mergeIgnoringArrays,
+	applyPostEdits,
 	normalizePostForEditing,
 	normalizePostForDisplay,
 } from './utils';
@@ -331,11 +331,7 @@ export const getEditedPost = createSelector(
 			return post;
 		}
 
-		if ( ! post ) {
-			return edits;
-		}
-
-		return mergeIgnoringArrays( {}, post, edits );
+		return applyPostEdits( post, edits );
 	},
 	state => [ state.posts.items, state.posts.edits ]
 );

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -17,7 +17,7 @@ import {
 	getSerializedPostsQueryWithoutPage,
 	isAuthorEqual,
 	isDiscussionEqual,
-	applyPostEdits,
+	mergePostEdits,
 	normalizePostForEditing,
 	normalizePostForDisplay,
 } from './utils';
@@ -331,7 +331,7 @@ export const getEditedPost = createSelector(
 			return post;
 		}
 
-		return applyPostEdits( post, edits );
+		return mergePostEdits( post, edits );
 	},
 	state => [ state.posts.items, state.posts.edits ]
 );

--- a/client/state/posts/test/utils.js
+++ b/client/state/posts/test/utils.js
@@ -19,7 +19,7 @@ import {
 	getSerializedPostsQueryWithoutPage,
 	getTermIdsFromEdits,
 	isTermsEqual,
-	mergeIgnoringArrays,
+	mergePostEdits,
 } from '../utils';
 
 describe( 'utils', () => {
@@ -339,14 +339,11 @@ describe( 'utils', () => {
 		} );
 	} );
 
-	describe( 'mergeIgnoringArrays()', () => {
+	describe( 'mergePostEdits', () => {
 		test( 'should merge into an empty object', () => {
-			const merged = mergeIgnoringArrays(
-				{},
-				{
-					tags_by_id: [ 4, 5, 6 ],
-				}
-			);
+			const merged = mergePostEdits( deepFreeze( {} ), {
+				tags_by_id: [ 4, 5, 6 ],
+			} );
 
 			expect( merged ).to.eql( {
 				tags_by_id: [ 4, 5, 6 ],
@@ -354,10 +351,10 @@ describe( 'utils', () => {
 		} );
 
 		test( 'should not modify array properties in the original object', () => {
-			const merged = mergeIgnoringArrays(
-				{
+			const merged = mergePostEdits(
+				deepFreeze( {
 					tags_by_id: [ 4, 5, 6 ],
-				},
+				} ),
 				{}
 			);
 
@@ -367,11 +364,10 @@ describe( 'utils', () => {
 		} );
 
 		test( 'should allow removing array items', () => {
-			const merged = mergeIgnoringArrays(
-				{},
-				{
+			const merged = mergePostEdits(
+				deepFreeze( {
 					tags_by_id: [ 4, 5, 6 ],
-				},
+				} ),
 				{
 					tags_by_id: [ 4, 6 ],
 				}
@@ -383,11 +379,10 @@ describe( 'utils', () => {
 		} );
 
 		test( 'should replace arrays with the new value', () => {
-			const merged = mergeIgnoringArrays(
-				{},
-				{
+			const merged = mergePostEdits(
+				deepFreeze( {
 					tags_by_id: [ 4, 5, 6 ],
-				},
+				} ),
 				{
 					tags_by_id: [ 1, 2, 3, 4 ],
 				}
@@ -395,6 +390,21 @@ describe( 'utils', () => {
 
 			expect( merged ).to.eql( {
 				tags_by_id: [ 1, 2, 3, 4 ],
+			} );
+		} );
+
+		test( 'should add properties to nested objects', () => {
+			const merged = mergePostEdits(
+				deepFreeze( {
+					discussion: { comments_open: false },
+				} ),
+				{
+					discussion: { pings_open: false },
+				}
+			);
+
+			expect( merged ).to.eql( {
+				discussion: { comments_open: false, pings_open: false },
 			} );
 		} );
 	} );

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -117,16 +117,33 @@ export function getSerializedPostsQueryWithoutPage( query, siteId ) {
 }
 
 /**
- * Merges objects like Lodash `merge` but takes array values directly from the
- * source object rather than attempting to merge by index.  Used to ensure that
- * edits to post terms (especially term removals) are reflected correctly.
+ * Merges edits into a post object. Essentially performs a deep merge of two objects,
+ * except that arrays are treated as atomic values and overwritten rather than merged.
+ * That's important especially for term removals.
  *
- * @param  {Object}    object  Destination object for merge
- * @param  {...Object} sources Source objects for merge
- * @return {Object}            Merged object with values from all sources
+ * @param  {Object} post  Destination post for merge
+ * @param  {Object} edits Objects with edits
+ * @return {Object}       Merged post with applied edits
  */
-export function mergeIgnoringArrays( object, ...sources ) {
-	return mergeWith( object, ...sources, ( objValue, srcValue ) => {
+export function applyPostEdits( post, edits ) {
+	return mergeWith( cloneDeep( post ), edits, ( objValue, srcValue ) => {
+		if ( Array.isArray( srcValue ) ) {
+			return srcValue;
+		}
+	} );
+}
+
+/**
+ * Merges two post edits objects into one. Essentially performs a deep merge of two objects,
+ * except that arrays are treated as atomic values and overwritten rather than merged.
+ * That's important especially for term removals.
+ *
+ * @param  {Object} edits     Destination edits object for merge
+ * @param  {Object} nextEdits Edits object to be merged
+ * @return {Object}           Merged edits object with changes from both sources
+ */
+export function mergePostEdits( edits, nextEdits ) {
+	return mergeWith( cloneDeep( edits ), nextEdits, ( objValue, srcValue ) => {
 		if ( Array.isArray( srcValue ) ) {
 			return srcValue;
 		}

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -117,26 +117,9 @@ export function getSerializedPostsQueryWithoutPage( query, siteId ) {
 }
 
 /**
- * Merges edits into a post object. Essentially performs a deep merge of two objects,
- * except that arrays are treated as atomic values and overwritten rather than merged.
- * That's important especially for term removals.
- *
- * @param  {Object} post  Destination post for merge
- * @param  {Object} edits Objects with edits
- * @return {Object}       Merged post with applied edits
- */
-export function applyPostEdits( post, edits ) {
-	return mergeWith( cloneDeep( post ), edits, ( objValue, srcValue ) => {
-		if ( Array.isArray( srcValue ) ) {
-			return srcValue;
-		}
-	} );
-}
-
-/**
- * Merges two post edits objects into one. Essentially performs a deep merge of two objects,
- * except that arrays are treated as atomic values and overwritten rather than merged.
- * That's important especially for term removals.
+ * Merges two post edits objects into one or a post edit into a post object. Essentially
+ * performs a deep merge of two objects, except that arrays are treated as atomic values
+ * and overwritten rather than merged. That's important especially for term removals.
  *
  * @param  {Object} edits     Destination edits object for merge
  * @param  {Object} nextEdits Edits object to be merged


### PR DESCRIPTION
This PR is a series of three refactorings that don't change any behavior, but will make future PRs from the "Post Editor Metadata" series smaller and easier to review.

### Post Editor Reducer: refactor receiving post updates

Extract the code that computes unapplied edits into a separate variable assignment. It will be useful when making future changes related to metadata editing.

### Post Editor Reducer: use `mergeIgnoringArrays` only to merge actual post edits

Don't use `mergeIgnoringArrays` to do the `keyedReducer`-like job of updating the `siteId` and `postId` nested state. The function is soon going to be incompatible with that and capable only of correctly merging actual post edits.

### Post Editor: rename and split `mergeIgnoringArrays` into two functions

Rename the `mergeIgnoringArrays` to a more appropriate name: `mergePostEdits`. It's a function that merges two post edits into one. It's used by the `edits` reducer to merge existing and incoming post edits.

Also create a function called `applyPostEdits` that applies a post edits object to a post object and returns a modified post. It's used by the `getEditedPost` selector that takes an original post, a post edits object and returns a modified post.

At this moment, both implementations are identical, but that will change soon when editing post metadata is intruduced into the Post Editor Redux store.

### How to test

Covered by unit tests. In Calypso UI, test that editing posts is not broken.

Part of #24281
