### PR TITLE
Add Color section to DevDocs sidebar

### DIFF
--- a/client/devdocs/sidebar.jsx
+++ b/client/devdocs/sidebar.jsx
@@ -65,6 +65,13 @@ export default class DevdocsSidebar extends React.PureComponent {
 						/>
 						<SidebarItem
 							className="devdocs__navigation-item"
+							icon="ink"
+							label="Color"
+							link="https://dotcombrand.wordpress.com/color/"
+							selected={ this.isItemSelected( 'https://dotcombrand.wordpress.com/color/' ) }
+						/>
+						<SidebarItem
+							className="devdocs__navigation-item"
 							icon="heading"
 							label="Typography"
 							link="/devdocs/typography"


### PR DESCRIPTION
See #24132 . The new Color sidebar item links to the WP.com Brand Guide.

**Testing**

* Switch to this PR
* Navigate to http://calypso.localhost:3000/devdocs/
* Check for the presence of the Color sidebar item
* Confirm the link goes to the Brand Guide as expected.

<img width="355" alt="screen shot 2018-04-17 at 7 59 17 pm" src="https://user-images.githubusercontent.com/618551/38906023-d637284c-4279-11e8-8436-dd64ac70e0a1.png">
