### PR TITLE
Framework: Add lib/make-json-schema-parser

### DIFF
--- a/client/lib/make-json-schema-parser/index.js
+++ b/client/lib/make-json-schema-parser/index.js
@@ -1,0 +1,134 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import schemaValidator from 'is-my-json-valid';
+import { get, identity } from 'lodash';
+
+export class SchemaError extends Error {
+	constructor( errors ) {
+		super( 'Failed to validate with JSON schema' );
+		this.schemaErrors = errors;
+	}
+}
+
+export class TransformerError extends Error {
+	constructor( error, data, transformer ) {
+		super( error.message );
+		this.inputData = data;
+		this.transformer = transformer;
+	}
+}
+
+/**
+ * @typedef {Function} Parser
+ * @param   {*}        data   Input data
+ * @return {*}                Transformed data
+ * @throws {SchemaError}      Error describing failed schema validation
+ * @throws {TransformerError} Error ocurred during transformation
+ */
+
+/**
+ * Create a parser to validate and transform data
+ *
+ * @param {Object}   schema               JSON schema
+ * @param {Object}   schemaOptions={}     Options to pass to schema validator
+ * @param {Function} transformer=identity Transformer function
+ *
+ * @return {Parser}                       Function to validate and transform data
+ */
+export function makeJsonSchemaParser( schema, schemaOptions = {}, transformer = identity ) {
+	let transform;
+	let validate;
+
+	const genParser = () => {
+		const options = Object.assign( { greedy: true, verbose: true }, schemaOptions );
+		const validator = schemaValidator( schema, options );
+
+		// filter out unwanted properties even though we may have let them slip past validation
+		// note: this property does not nest deeply into the data structure, that is, properties
+		// of a property that aren't in the schema could still come through since only the top
+		// level of properties are pruned
+		const filter = schemaValidator.filter(
+			Object.assign(
+				{},
+				schema,
+				schema.type && schema.type === 'object' && { additionalProperties: false }
+			)
+		);
+
+		validate = data => {
+			if ( ! validator( data ) ) {
+				if ( 'development' === process.env.NODE_ENV ) {
+					// eslint-disable-next-line no-console
+					console.warn( 'JSON Validation Failure' );
+
+					validator.errors.forEach( error =>
+						// eslint-disable-next-line no-console
+						console.warn( {
+							field: error.field,
+							message: error.message,
+							value: error.value,
+							actualType: error.type,
+							expectedType: get( schema, error.schemaPath ),
+						} )
+					);
+
+					if ( undefined !== window ) {
+						// eslint-disable-next-line no-console
+						console.log( 'updated `lastValidator` and `lastValidated` in console' );
+						// eslint-disable-next-line no-console
+						console.log( 'run `lastValidator( lastValidated )` to reproduce failing validation' );
+						window.lastValidator = validator;
+						window.lastValidated = data;
+					}
+				}
+
+				throw new SchemaError( validator.errors );
+			}
+
+			return filter( data );
+		};
+
+		transform = data => {
+			try {
+				return transformer( data );
+			} catch ( e ) {
+				if ( 'development' === process.env.NODE_ENV ) {
+					// eslint-disable-next-line no-console
+					console.warn( 'Data Transformation Failure' );
+
+					// eslint-disable-next-line no-console
+					console.warn( {
+						inputData: data,
+						error: e,
+					} );
+
+					if ( undefined !== window ) {
+						// eslint-disable-next-line no-console
+						console.log( 'updated `lastTransformer` and `lastTransformed` in console' );
+						// eslint-disable-next-line no-console
+						console.log(
+							'run `lastTransformer( lastTransformed )` to reproduce failing transform'
+						);
+						window.lastTransformer = transformer;
+						window.lastTransformed = data;
+					}
+				}
+
+				throw new TransformerError( e, data, transformer );
+			}
+		};
+	};
+
+	return data => {
+		if ( ! transform ) {
+			genParser();
+		}
+
+		return transform( validate( data ) );
+	};
+}
+
+export default makeJsonSchemaParser;

--- a/client/lib/make-json-schema-parser/test/index.js
+++ b/client/lib/make-json-schema-parser/test/index.js
@@ -34,6 +34,22 @@ describe( 'makeJsonSchemaParser', () => {
 		expect( parser( 0 ) ).toBe( 1 );
 	} );
 
+	test( 'should validate with additional fields', () => {
+		const schema = {
+			type: 'object',
+			properties: {
+				include: { type: 'string' },
+			},
+		};
+		const parser = makeJsonSchemaParser( schema );
+		expect( () =>
+			parser( {
+				include: 'include',
+				exclude: 'exclude',
+			} )
+		).not.toThrow();
+	} );
+
 	test( 'should filter additional fields', () => {
 		const schema = {
 			type: 'object',

--- a/client/lib/make-json-schema-parser/test/index.js
+++ b/client/lib/make-json-schema-parser/test/index.js
@@ -1,0 +1,52 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import makeJsonSchemaParser, { SchemaError, TransformerError } from '..';
+
+describe( 'makeJsonSchemaParser', () => {
+	test( 'should return a function', () => {
+		expect( () => makeJsonSchemaParser( {} )() ).not.toThrow();
+	} );
+
+	test( 'should throw SchemaError on if data does not validate', () => {
+		const parser = makeJsonSchemaParser( { type: 'null' } );
+		expect( () => parser( 0 ) ).toThrow( SchemaError );
+	} );
+
+	test( 'should throw TransformerError if error occurs during transformation', () => {
+		const transformer = () => {
+			throw Error( 'Testing error during transform' );
+		};
+		const parser = makeJsonSchemaParser( {}, {}, transformer );
+		expect( () => parser( 0 ) ).toThrow( TransformerError );
+	} );
+
+	test( 'should return input unchanged if valid and no transformer supplied', () => {
+		const parser = makeJsonSchemaParser( { type: 'integer' } );
+		expect( parser( 0 ) ).toBe( 0 );
+	} );
+
+	test( 'should return the result of transformation', () => {
+		const transformer = a => a + 1;
+		const parser = makeJsonSchemaParser( { type: 'integer' }, {}, transformer );
+		expect( parser( 0 ) ).toBe( 1 );
+	} );
+
+	test( 'should filter additional fields', () => {
+		const schema = {
+			type: 'object',
+			properties: {
+				include: { type: 'string' },
+			},
+		};
+		const parser = makeJsonSchemaParser( schema );
+		expect(
+			parser( {
+				include: 'include',
+				exclude: 'exclude',
+			} )
+		).toEqual( { include: 'include' } );
+	} );
+} );

--- a/client/state/data-layer/wpcom-http/README.md
+++ b/client/state/data-layer/wpcom-http/README.md
@@ -339,7 +339,7 @@ export default {
 		onSuccess: verifyLike, // update the Redux store if need be
 		onError: undoLike, // remove the like if we failed
 		onProgress: updateProgress, // update progress tracking UI
-		fromApi: makeParser( likeSchema, {}, toLike ), // validate and convert to internal Calypso object
+		fromApi: makeJsonSchemaParser( likeSchema, {}, toLike ), // validate and convert to internal Calypso object
 	} ) ]
 }
 ```

--- a/client/state/data-layer/wpcom-http/test/utils.js
+++ b/client/state/data-layer/wpcom-http/test/utils.js
@@ -12,7 +12,7 @@ import {
 	reducer,
 	trackRequests,
 } from '../utils.js';
-import makeJsonSchemaParser from 'lib/make-json-schema-parser';
+import { SchemaError } from 'lib/make-json-schema-parser';
 
 describe( 'WPCOM HTTP Data Layer', () => {
 	const withData = data => ( { type: 'SLUGGER', meta: { dataLayer: { data } } } );
@@ -227,26 +227,20 @@ describe( 'WPCOM HTTP Data Layer', () => {
 		} );
 
 		test( 'should validate response data', () => {
-			const schema = {
-				type: 'object',
-				properties: { count: { type: 'integer' } },
-			};
+			const fromApi = jest.fn( input => input );
 
-			const fromApi = makeJsonSchemaParser( schema );
 			dispatchRequest( initiator, onSuccess, onFailure, { fromApi } )( store, success, data );
 
+			expect( fromApi ).toHaveBeenCalledWith( data );
 			expect( initiator ).not.toHaveBeenCalled();
 			expect( onSuccess ).toHaveBeenCalled();
 			expect( onFailure ).not.toHaveBeenCalled();
 		} );
 
 		test( 'should fail-over on invalid response data', () => {
-			const schema = {
-				type: 'object',
-				properties: { count: { type: 'string' } },
+			const fromApi = () => {
+				throw new SchemaError( 'Test schema error' );
 			};
-
-			const fromApi = makeJsonSchemaParser( schema );
 			dispatchRequest( initiator, onSuccess, onFailure, { fromApi } )( store, success, data );
 
 			expect( initiator ).not.toHaveBeenCalled();
@@ -254,60 +248,14 @@ describe( 'WPCOM HTTP Data Layer', () => {
 			expect( onFailure ).toHaveBeenCalled();
 		} );
 
-		test( 'should validate with additional fields', () => {
-			const schema = {
-				type: 'object',
-				properties: { count: { type: 'integer' } },
-			};
+		test( 'should return result of fromApi', () => {
+			const fromApi = () => 'fromApi result';
 
-			const extra = { count: 15, is_active: true };
-			const action = { type: 'REFILL', meta: { dataLayer: { data: extra } } };
-
-			const fromApi = makeJsonSchemaParser( schema );
-			dispatchRequest( initiator, onSuccess, onFailure, { fromApi } )( store, action, extra );
+			const action = { type: 'REFILL', meta: { dataLayer: { data: {} } } };
+			dispatchRequest( initiator, onSuccess, onFailure, { fromApi } )( store, action, {} );
 
 			expect( initiator ).not.toHaveBeenCalled();
-			expect( onSuccess ).toHaveBeenCalled();
-			expect( onFailure ).not.toHaveBeenCalled();
-		} );
-
-		test( 'should filter out additional fields', () => {
-			const schema = {
-				type: 'object',
-				properties: { count: { type: 'integer' } },
-			};
-
-			const extra = { count: 15, is_active: true };
-			const action = { type: 'REFILL', meta: { dataLayer: { data: extra } } };
-
-			const fromApi = makeJsonSchemaParser( schema );
-			dispatchRequest( initiator, onSuccess, onFailure, { fromApi } )( store, action, extra );
-
-			expect( initiator ).not.toHaveBeenCalled();
-			expect( onSuccess ).toHaveBeenCalled();
-			expect( onSuccess ).toHaveBeenCalledWith( store, action, { count: 15 } );
-			expect( onFailure ).not.toHaveBeenCalled();
-		} );
-
-		test( 'should transform validated output', () => {
-			const schema = {
-				type: 'object',
-				properties: { count: { type: 'integer' } },
-			};
-
-			const extra = { count: 15, is_active: true };
-			const action = { type: 'REFILL', meta: { dataLayer: { data: extra } } };
-
-			const transformer = ( { count } ) => ( { tribbleCount: count * 2, haveTrouble: true } );
-
-			const fromApi = makeJsonSchemaParser( schema, {}, transformer );
-			dispatchRequest( initiator, onSuccess, onFailure, { fromApi } )( store, action, extra );
-
-			expect( initiator ).not.toHaveBeenCalled();
-			expect( onSuccess ).toHaveBeenCalledWith( store, action, {
-				tribbleCount: 30,
-				haveTrouble: true,
-			} );
+			expect( onSuccess ).toHaveBeenCalledWith( store, action, 'fromApi result' );
 			expect( onFailure ).not.toHaveBeenCalled();
 		} );
 	} );
@@ -379,20 +327,17 @@ describe( 'WPCOM HTTP Data Layer', () => {
 			} ).not.toThrow( TypeError );
 		} );
 
-		test( 'should validate response data', () => {
-			const fromApi = makeJsonSchemaParser( {
-				type: 'object',
-				properties: { count: { type: 'integer' } },
-			} );
+		test( 'should pass data to fromApi for validation', () => {
+			const fromApi = jest.fn( input => input );
 			dispatchRequestEx( { fetch, onSuccess, onError, fromApi } )( store, successHttpAction );
+			expect( fromApi ).toHaveBeenCalledWith( successHttpAction.meta.dataLayer.data );
 			expect( dispatch ).toHaveBeenCalledWith( successAction );
 		} );
 
 		test( 'should fail-over on invalid response data', () => {
-			const fromApi = makeJsonSchemaParser( {
-				type: 'object',
-				properties: { count: { type: 'string' } },
-			} );
+			const fromApi = () => {
+				throw new SchemaError( 'Test schema error' );
+			};
 			dispatchRequestEx( { fetch, onSuccess, onError, fromApi } )( store, successHttpAction );
 
 			const args = dispatch.mock.calls[ 0 ];
@@ -401,61 +346,18 @@ describe( 'WPCOM HTTP Data Layer', () => {
 			expect( args[ 0 ] ).toMatchObject( { type: 'FAILURE' } );
 		} );
 
-		test( 'should validate with additional fields', () => {
-			const fromApi = makeJsonSchemaParser( {
-				type: 'object',
-				properties: { count: { type: 'integer' } },
-			} );
-
+		test( 'should return result of fromApi', () => {
+			const fromApi = () => 'fromApi result';
 			const action = {
 				type: 'REFILL',
-				meta: { dataLayer: { data: { count: 15, is_active: true } } },
-			};
-
-			dispatchRequestEx( { fetch, onSuccess, onError, fromApi } )( store, action );
-
-			const args = dispatch.mock.calls[ 0 ];
-
-			expect( args.length ).toBe( 1 );
-			expect( args[ 0 ] ).toMatchObject( { type: 'SUCCESS' } );
-		} );
-
-		test( 'should filter out additional fields', () => {
-			const fromApi = makeJsonSchemaParser( {
-				type: 'object',
-				properties: { count: { type: 'integer' } },
-			} );
-
-			const action = {
-				type: 'REFILL',
-				meta: { dataLayer: { data: { count: 15, is_active: true } } },
-			};
-
-			dispatchRequestEx( { fetch, onSuccess, onError, fromApi } )( store, action );
-			expect( dispatch ).toHaveBeenCalledWith( { type: 'SUCCESS', data: { count: 15 } } );
-		} );
-
-		test( 'should transform validated output', () => {
-			const schema = {
-				type: 'object',
-				properties: { count: { type: 'integer' } },
-			};
-			const transformer = ( { count } ) => ( { tribbleCount: count * 2, haveTrouble: true } );
-			const fromApi = makeJsonSchemaParser( schema, {}, transformer );
-
-			const action = {
-				type: 'REFILL',
-				meta: { dataLayer: { data: { count: 15, is_active: true } } },
+				meta: { dataLayer: { data: {} } },
 			};
 
 			dispatchRequestEx( { fetch, onSuccess, onError, fromApi } )( store, action );
 
 			expect( dispatch ).toHaveBeenCalledWith( {
 				type: 'SUCCESS',
-				data: {
-					tribbleCount: 30,
-					haveTrouble: true,
-				},
+				data: 'fromApi result',
 			} );
 		} );
 	} );

--- a/client/state/data-layer/wpcom-http/test/utils.js
+++ b/client/state/data-layer/wpcom-http/test/utils.js
@@ -12,7 +12,6 @@ import {
 	reducer,
 	trackRequests,
 } from '../utils.js';
-import { SchemaError } from 'lib/make-json-schema-parser';
 
 describe( 'WPCOM HTTP Data Layer', () => {
 	const withData = data => ( { type: 'SLUGGER', meta: { dataLayer: { data } } } );
@@ -239,7 +238,7 @@ describe( 'WPCOM HTTP Data Layer', () => {
 
 		test( 'should fail-over on invalid response data', () => {
 			const fromApi = () => {
-				throw new SchemaError( 'Test schema error' );
+				throw new Error( 'Test schema error' );
 			};
 			dispatchRequest( initiator, onSuccess, onFailure, { fromApi } )( store, success, data );
 
@@ -336,7 +335,7 @@ describe( 'WPCOM HTTP Data Layer', () => {
 
 		test( 'should fail-over on invalid response data', () => {
 			const fromApi = () => {
-				throw new SchemaError( 'Test schema error' );
+				throw new Error( 'Test schema error' );
 			};
 			dispatchRequestEx( { fetch, onSuccess, onError, fromApi } )( store, successHttpAction );
 

--- a/client/state/data-layer/wpcom-http/test/utils.js
+++ b/client/state/data-layer/wpcom-http/test/utils.js
@@ -9,10 +9,10 @@ import {
 	getProgress,
 	dispatchRequest,
 	dispatchRequestEx,
-	makeParser,
 	reducer,
 	trackRequests,
 } from '../utils.js';
+import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 
 describe( 'WPCOM HTTP Data Layer', () => {
 	const withData = data => ( { type: 'SLUGGER', meta: { dataLayer: { data } } } );
@@ -232,7 +232,7 @@ describe( 'WPCOM HTTP Data Layer', () => {
 				properties: { count: { type: 'integer' } },
 			};
 
-			const fromApi = makeParser( schema );
+			const fromApi = makeJsonSchemaParser( schema );
 			dispatchRequest( initiator, onSuccess, onFailure, { fromApi } )( store, success, data );
 
 			expect( initiator ).not.toHaveBeenCalled();
@@ -246,7 +246,7 @@ describe( 'WPCOM HTTP Data Layer', () => {
 				properties: { count: { type: 'string' } },
 			};
 
-			const fromApi = makeParser( schema );
+			const fromApi = makeJsonSchemaParser( schema );
 			dispatchRequest( initiator, onSuccess, onFailure, { fromApi } )( store, success, data );
 
 			expect( initiator ).not.toHaveBeenCalled();
@@ -263,7 +263,7 @@ describe( 'WPCOM HTTP Data Layer', () => {
 			const extra = { count: 15, is_active: true };
 			const action = { type: 'REFILL', meta: { dataLayer: { data: extra } } };
 
-			const fromApi = makeParser( schema );
+			const fromApi = makeJsonSchemaParser( schema );
 			dispatchRequest( initiator, onSuccess, onFailure, { fromApi } )( store, action, extra );
 
 			expect( initiator ).not.toHaveBeenCalled();
@@ -280,7 +280,7 @@ describe( 'WPCOM HTTP Data Layer', () => {
 			const extra = { count: 15, is_active: true };
 			const action = { type: 'REFILL', meta: { dataLayer: { data: extra } } };
 
-			const fromApi = makeParser( schema );
+			const fromApi = makeJsonSchemaParser( schema );
 			dispatchRequest( initiator, onSuccess, onFailure, { fromApi } )( store, action, extra );
 
 			expect( initiator ).not.toHaveBeenCalled();
@@ -300,7 +300,7 @@ describe( 'WPCOM HTTP Data Layer', () => {
 
 			const transformer = ( { count } ) => ( { tribbleCount: count * 2, haveTrouble: true } );
 
-			const fromApi = makeParser( schema, {}, transformer );
+			const fromApi = makeJsonSchemaParser( schema, {}, transformer );
 			dispatchRequest( initiator, onSuccess, onFailure, { fromApi } )( store, action, extra );
 
 			expect( initiator ).not.toHaveBeenCalled();
@@ -380,7 +380,7 @@ describe( 'WPCOM HTTP Data Layer', () => {
 		} );
 
 		test( 'should validate response data', () => {
-			const fromApi = makeParser( {
+			const fromApi = makeJsonSchemaParser( {
 				type: 'object',
 				properties: { count: { type: 'integer' } },
 			} );
@@ -389,7 +389,7 @@ describe( 'WPCOM HTTP Data Layer', () => {
 		} );
 
 		test( 'should fail-over on invalid response data', () => {
-			const fromApi = makeParser( {
+			const fromApi = makeJsonSchemaParser( {
 				type: 'object',
 				properties: { count: { type: 'string' } },
 			} );
@@ -402,7 +402,7 @@ describe( 'WPCOM HTTP Data Layer', () => {
 		} );
 
 		test( 'should validate with additional fields', () => {
-			const fromApi = makeParser( {
+			const fromApi = makeJsonSchemaParser( {
 				type: 'object',
 				properties: { count: { type: 'integer' } },
 			} );
@@ -421,7 +421,7 @@ describe( 'WPCOM HTTP Data Layer', () => {
 		} );
 
 		test( 'should filter out additional fields', () => {
-			const fromApi = makeParser( {
+			const fromApi = makeJsonSchemaParser( {
 				type: 'object',
 				properties: { count: { type: 'integer' } },
 			} );
@@ -441,7 +441,7 @@ describe( 'WPCOM HTTP Data Layer', () => {
 				properties: { count: { type: 'integer' } },
 			};
 			const transformer = ( { count } ) => ( { tribbleCount: count * 2, haveTrouble: true } );
-			const fromApi = makeParser( schema, {}, transformer );
+			const fromApi = makeJsonSchemaParser( schema, {}, transformer );
 
 			const action = {
 				type: 'REFILL',

--- a/client/state/data-layer/wpcom-http/test/utils.js
+++ b/client/state/data-layer/wpcom-http/test/utils.js
@@ -247,14 +247,14 @@ describe( 'WPCOM HTTP Data Layer', () => {
 			expect( onFailure ).toHaveBeenCalled();
 		} );
 
-		test( 'should return result of fromApi', () => {
-			const fromApi = () => 'fromApi result';
+		test( 'should return transformed result of fromApi', () => {
+			const fromApi = input => `Hello, ${ input }!`;
 
-			const action = { type: 'REFILL', meta: { dataLayer: { data: {} } } };
+			const action = { type: 'REFILL', meta: { dataLayer: { data: 'world' } } };
 			dispatchRequest( initiator, onSuccess, onFailure, { fromApi } )( store, action, {} );
 
 			expect( initiator ).not.toHaveBeenCalled();
-			expect( onSuccess ).toHaveBeenCalledWith( store, action, 'fromApi result' );
+			expect( onSuccess ).toHaveBeenCalledWith( store, action, 'Hello, world!' );
 			expect( onFailure ).not.toHaveBeenCalled();
 		} );
 	} );
@@ -346,17 +346,17 @@ describe( 'WPCOM HTTP Data Layer', () => {
 		} );
 
 		test( 'should return result of fromApi', () => {
-			const fromApi = () => 'fromApi result';
+			const fromApi = input => `Hello, ${ input }!`;
 			const action = {
 				type: 'REFILL',
-				meta: { dataLayer: { data: {} } },
+				meta: { dataLayer: { data: 'world' } },
 			};
 
 			dispatchRequestEx( { fetch, onSuccess, onError, fromApi } )( store, action );
 
 			expect( dispatch ).toHaveBeenCalledWith( {
 				type: 'SUCCESS',
-				data: 'fromApi result',
+				data: 'Hello, world!',
 			} );
 		} );
 	} );

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -4,8 +4,12 @@
  * External dependencies
  */
 import deterministicStringify from 'json-stable-stringify';
-import schemaValidator from 'is-my-json-valid';
 import { get, identity, merge, noop } from 'lodash';
+export {
+	makeJsonSchemaParser as makeParser,
+	SchemaError,
+	TransformerError,
+} from 'lib/make-json-schema-parser';
 
 /**
  * Internal dependencies
@@ -51,114 +55,6 @@ export const getHeaders = action => get( action, 'meta.dataLayer.headers', undef
  * @returns {ProgressData}
  */
 export const getProgress = action => get( action, 'meta.dataLayer.progress', undefined );
-
-export class SchemaError extends Error {
-	constructor( errors ) {
-		super( 'Failed to validate with JSON schema' );
-		this.schemaErrors = errors;
-	}
-}
-
-export class TransformerError extends Error {
-	constructor( error, data, transformer ) {
-		super( error.message );
-		this.inputData = data;
-		this.transformer = transformer;
-	}
-}
-
-export const makeParser = ( schema, schemaOptions = {}, transformer = identity ) => {
-	let transform;
-	let validate;
-
-	const genParser = () => {
-		const options = Object.assign( { greedy: true, verbose: true }, schemaOptions );
-		const validator = schemaValidator( schema, options );
-
-		// filter out unwanted properties even though we may have let them slip past validation
-		// note: this property does not nest deeply into the data structure, that is, properties
-		// of a property that aren't in the schema could still come through since only the top
-		// level of properties are pruned
-		const filter = schemaValidator.filter(
-			Object.assign(
-				{},
-				schema,
-				schema.type && schema.type === 'object' && { additionalProperties: false }
-			)
-		);
-
-		validate = data => {
-			if ( ! validator( data ) ) {
-				if ( 'development' === process.env.NODE_ENV ) {
-					// eslint-disable-next-line no-console
-					console.warn( 'JSON Validation Failure' );
-
-					validator.errors.forEach( error =>
-						// eslint-disable-next-line no-console
-						console.warn( {
-							field: error.field,
-							message: error.message,
-							value: error.value,
-							actualType: error.type,
-							expectedType: get( schema, error.schemaPath ),
-						} )
-					);
-
-					if ( undefined !== window ) {
-						// eslint-disable-next-line no-console
-						console.log( 'updated `lastValidator` and `lastValidated` in console' );
-						// eslint-disable-next-line no-console
-						console.log( 'run `lastValidator( lastValidated )` to reproduce failing validation' );
-						window.lastValidator = validator;
-						window.lastValidated = data;
-					}
-				}
-
-				throw new SchemaError( validator.errors );
-			}
-
-			return filter( data );
-		};
-
-		transform = data => {
-			try {
-				return transformer( data );
-			} catch ( e ) {
-				if ( 'development' === process.env.NODE_ENV ) {
-					// eslint-disable-next-line no-console
-					console.warn( 'Data Transformation Failure' );
-
-					// eslint-disable-next-line no-console
-					console.warn( {
-						inputData: data,
-						error: e,
-					} );
-
-					if ( undefined !== window ) {
-						// eslint-disable-next-line no-console
-						console.log( 'updated `lastTransformer` and `lastTransformed` in console' );
-						// eslint-disable-next-line no-console
-						console.log(
-							'run `lastTransformer( lastTransformed )` to reproduce failing transform'
-						);
-						window.lastTransformer = transformer;
-						window.lastTransformed = data;
-					}
-				}
-
-				throw new TransformerError( e, data, transformer );
-			}
-		};
-	};
-
-	return data => {
-		if ( ! transform ) {
-			genParser();
-		}
-
-		return transform( validate( data ) );
-	};
-};
 
 const getRequestStatus = action => {
 	if ( undefined !== getError( action ) ) {

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -16,7 +16,7 @@ import warn from 'lib/warn';
  * Returns response data from an HTTP request success action if available
  *
  * @param {Object} action may contain HTTP response data
- * @returns {?*} response data if available
+ * @returns {*|undefined} response data if available
  */
 export const getData = action => get( action, 'meta.dataLayer.data', undefined );
 
@@ -24,30 +24,29 @@ export const getData = action => get( action, 'meta.dataLayer.data', undefined )
  * Returns error data from an HTTP request failure action if available
  *
  * @param {Object} action may contain HTTP response error data
- * @returns {?*} error data if available
+ * @returns {*|undefined} error data if available
  */
 export const getError = action => get( action, 'meta.dataLayer.error', undefined );
 
 /**
  * Returns (response) headers data from an HTTP request action if available
  *
- * @param {Object} action may contain HTTP response headers data
- * @returns {?*} headers data if available
+ * @param   {Object}      action Request action for which to retrieve HTTP response headers
+ * @returns {*|undefined}        Headers data if available
  */
 export const getHeaders = action => get( action, 'meta.dataLayer.headers', undefined );
 
 /**
  * @typedef {Object} ProgressData
- * @property {number} loaded number of bytes already transferred
- * @property {number} total total number of bytes to transfer
+ * @property {number} loaded Number of bytes already transferred
+ * @property {number} total  Total number of bytes to transfer
  */
 
 /**
  * Returns progress data from an HTTP request progress action if available
  *
- * @param {Object} action may contain HTTP progress data
- * @returns {Object|null} progress data if available
- * @returns {ProgressData}
+ * @param  {Object} action          may contain HTTP progress data
+ * @return {ProgressData|undefined} Progress data if available
  */
 export const getProgress = action => get( action, 'meta.dataLayer.progress', undefined );
 

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -5,11 +5,6 @@
  */
 import deterministicStringify from 'json-stable-stringify';
 import { get, identity, merge, noop } from 'lodash';
-export {
-	makeJsonSchemaParser as makeParser,
-	SchemaError,
-	TransformerError,
-} from 'lib/make-json-schema-parser';
 
 /**
  * Internal dependencies

--- a/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
@@ -10,10 +10,11 @@ import { translate } from 'i18n-calypso';
 import { REWIND_RESTORE } from 'state/action-types';
 import { getRewindRestoreProgress } from 'state/activity-log/actions';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
-import { SchemaError, dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { requestRewindState } from 'state/rewind/actions';
+import { SchemaError } from 'lib/make-json-schema-parser';
 
 const fromApi = data => {
 	const restoreId = parseInt( data.restore_id, 10 );

--- a/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
@@ -7,13 +7,13 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { REWIND_RESTORE } from 'state/action-types';
-import { getRewindRestoreProgress } from 'state/activity-log/actions';
-import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
+import { getRewindRestoreProgress } from 'state/activity-log/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import { requestRewindState } from 'state/rewind/actions';
+import { REWIND_RESTORE } from 'state/action-types';
 import { SchemaError } from 'lib/make-json-schema-parser';
 
 const fromApi = data => {

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/book/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/book/from-api.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
+import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import responseSchema from './schema';
-import { makeParser } from 'lib/make-json-schema-parser';
 
-export default makeParser( responseSchema, {} );
+export default makeJsonSchemaParser( responseSchema, {} );

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/book/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/book/from-api.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { makeParser } from 'state/data-layer/wpcom-http/utils';
 import responseSchema from './schema';
+import { makeParser } from 'lib/make-json-schema-parser';
 
 export default makeParser( responseSchema, {} );

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/book/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/book/test/from-api.js
@@ -3,8 +3,8 @@
 /**
  * Internal dependencies
  */
-import { SchemaError } from 'state/data-layer/wpcom-http/utils';
 import fromApi from '../from-api';
+import { SchemaError } from 'lib/make-json-schema-parser';
 
 describe( 'fromApi()', () => {
 	test( 'should validate and transform the data successfully.', () => {

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/from-api.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
+import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import responseSchema from './schema';
-import { makeParser } from 'lib/make-json-schema-parser';
 
-export default makeParser( responseSchema, {} );
+export default makeJsonSchemaParser( responseSchema, {} );

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/from-api.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { makeParser } from 'state/data-layer/wpcom-http/utils';
 import responseSchema from './schema';
+import { makeParser } from 'lib/make-json-schema-parser';
 
 export default makeParser( responseSchema, {} );

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/test/from-api.js
@@ -3,8 +3,8 @@
 /**
  * Internal dependencies
  */
-import { SchemaError } from 'state/data-layer/wpcom-http/utils';
 import fromApi from '../from-api';
+import { SchemaError } from 'lib/make-json-schema-parser';
 
 describe( 'fromApi()', () => {
 	test( 'should validate and transform the data successfully.', () => {

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/from-api.js
@@ -3,8 +3,8 @@
 /**
  * Internal dependencies
  */
+import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import responseSchema from './schema';
-import { makeParser } from 'lib/make-json-schema-parser';
 
 export const transform = ( { begin_timestamp, end_timestamp, schedule_id, ...rest } ) => ( {
 	beginTimestamp: begin_timestamp * 1000,
@@ -13,4 +13,4 @@ export const transform = ( { begin_timestamp, end_timestamp, schedule_id, ...res
 	...rest,
 } );
 
-export default makeParser( responseSchema, {}, transform );
+export default makeJsonSchemaParser( responseSchema, {}, transform );

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/from-api.js
@@ -3,8 +3,8 @@
 /**
  * Internal dependencies
  */
-import { makeParser } from 'state/data-layer/wpcom-http/utils';
 import responseSchema from './schema';
+import { makeParser } from 'lib/make-json-schema-parser';
 
 export const transform = ( { begin_timestamp, end_timestamp, schedule_id, ...rest } ) => ( {
 	beginTimestamp: begin_timestamp * 1000,

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/test/from-api.js
@@ -3,8 +3,8 @@
 /**
  * Internal dependencies
  */
-import { SchemaError } from 'state/data-layer/wpcom-http/utils';
 import fromApi from '../from-api';
+import { SchemaError } from 'lib/make-json-schema-parser';
 
 describe( 'fromApi()', () => {
 	test( 'should validate and transform the data successfully.', () => {

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/from-api.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
+import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import responseSchema from './schema';
-import { makeParser } from 'lib/make-json-schema-parser';
 
-export default makeParser( responseSchema, {} );
+export default makeJsonSchemaParser( responseSchema, {} );

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/from-api.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { makeParser } from 'state/data-layer/wpcom-http/utils';
 import responseSchema from './schema';
+import { makeParser } from 'lib/make-json-schema-parser';
 
 export default makeParser( responseSchema, {} );

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/test/from-api.js
@@ -3,8 +3,8 @@
 /**
  * Internal dependencies
  */
-import { SchemaError } from 'state/data-layer/wpcom-http/utils';
 import fromApi from '../from-api';
+import { SchemaError } from 'lib/make-json-schema-parser';
 
 describe( 'fromApi()', () => {
 	test( 'should validate and transform the data successfully.', () => {

--- a/client/state/data-layer/wpcom/concierge/schedules/available-times/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/available-times/from-api.js
@@ -3,11 +3,11 @@
 /**
  * Internal dependencies
  */
+import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import responseSchema from './schema';
-import { makeParser } from 'lib/make-json-schema-parser';
 
 export const convertToDate = timestampInSeconds => timestampInSeconds * 1000;
 
 export const transform = response => response.map( convertToDate );
 
-export default makeParser( responseSchema, {}, transform );
+export default makeJsonSchemaParser( responseSchema, {}, transform );

--- a/client/state/data-layer/wpcom/concierge/schedules/available-times/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/available-times/from-api.js
@@ -3,8 +3,8 @@
 /**
  * Internal dependencies
  */
-import { makeParser } from 'state/data-layer/wpcom-http/utils';
 import responseSchema from './schema';
+import { makeParser } from 'lib/make-json-schema-parser';
 
 export const convertToDate = timestampInSeconds => timestampInSeconds * 1000;
 

--- a/client/state/data-layer/wpcom/concierge/schedules/available-times/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/available-times/test/from-api.js
@@ -3,8 +3,8 @@
 /**
  * Internal dependencies
  */
-import { SchemaError } from 'state/data-layer/wpcom-http/utils';
 import fromApi from '../from-api';
+import { SchemaError } from 'lib/make-json-schema-parser';
 
 describe( 'fromApi()', () => {
 	test( 'should validate and transform the data successfully.', () => {

--- a/client/state/data-layer/wpcom/me/transactions/order/from-api.js
+++ b/client/state/data-layer/wpcom/me/transactions/order/from-api.js
@@ -3,8 +3,8 @@
 /**
  * Internal dependencies
  */
-import { makeParser } from 'state/data-layer/wpcom-http/utils';
 import responseSchema from './schema';
+import { makeParser } from 'lib/make-json-schema-parser';
 import { ORDER_TRANSACTION_STATUS } from 'state/order-transactions/constants';
 
 export const convertProcessingStatus = responseStatus => {

--- a/client/state/data-layer/wpcom/me/transactions/order/from-api.js
+++ b/client/state/data-layer/wpcom/me/transactions/order/from-api.js
@@ -3,8 +3,8 @@
 /**
  * Internal dependencies
  */
+import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import responseSchema from './schema';
-import { makeParser } from 'lib/make-json-schema-parser';
 import { ORDER_TRANSACTION_STATUS } from 'state/order-transactions/constants';
 
 export const convertProcessingStatus = responseStatus => {
@@ -29,4 +29,4 @@ export const transform = ( { order_id, user_id, receipt_id, processing_status } 
 	processingStatus: convertProcessingStatus( processing_status ),
 } );
 
-export default makeParser( responseSchema, {}, transform );
+export default makeJsonSchemaParser( responseSchema, {}, transform );

--- a/client/state/data-layer/wpcom/me/transactions/order/test/from-api.js
+++ b/client/state/data-layer/wpcom/me/transactions/order/test/from-api.js
@@ -3,9 +3,9 @@
 /**
  * Internal dependencies
  */
-import { SchemaError } from 'state/data-layer/wpcom-http/utils';
 import { ORDER_TRANSACTION_STATUS } from 'state/order-transactions/constants';
 import fromApi, { convertProcessingStatus } from '../from-api';
+import { SchemaError } from 'lib/make-json-schema-parser';
 
 describe( 'wpcom-api', () => {
 	describe( 'fromApi()', () => {

--- a/client/state/data-layer/wpcom/me/transactions/order/test/from-api.js
+++ b/client/state/data-layer/wpcom/me/transactions/order/test/from-api.js
@@ -3,8 +3,8 @@
 /**
  * Internal dependencies
  */
-import { ORDER_TRANSACTION_STATUS } from 'state/order-transactions/constants';
 import fromApi, { convertProcessingStatus } from '../from-api';
+import { ORDER_TRANSACTION_STATUS } from 'state/order-transactions/constants';
 import { SchemaError } from 'lib/make-json-schema-parser';
 
 describe( 'wpcom-api', () => {

--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/index.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/index.js
@@ -12,8 +12,9 @@ import deleteHandler from './delete';
 import newHandler from './new';
 import schema from './schema';
 import { APPLICATION_PASSWORDS_REQUEST } from 'state/action-types';
-import { dispatchRequestEx, makeParser } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import { makeParser } from 'lib/make-json-schema-parser';
 import { mergeHandlers } from 'state/action-watchers/utils';
 import { receiveApplicationPasswords } from 'state/application-passwords/actions';
 

--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/index.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/index.js
@@ -9,12 +9,12 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import deleteHandler from './delete';
+import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import newHandler from './new';
 import schema from './schema';
 import { APPLICATION_PASSWORDS_REQUEST } from 'state/action-types';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { makeParser } from 'lib/make-json-schema-parser';
 import { mergeHandlers } from 'state/action-watchers/utils';
 import { receiveApplicationPasswords } from 'state/application-passwords/actions';
 
@@ -52,7 +52,7 @@ const requestHandler = {
 			fetch: requestApplicationPasswords,
 			onSuccess: handleRequestSuccess,
 			onError: noop,
-			fromApi: makeParser( schema, {}, apiTransformer ),
+			fromApi: makeJsonSchemaParser( schema, {}, apiTransformer ),
 		} ),
 	],
 };

--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/new/index.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/new/index.js
@@ -45,9 +45,9 @@ export const addApplicationPassword = action =>
  * - a create application password success action
  * - a user application passwords receive action
  *
- * @param   {Object} action Redux action
- * @param   {Array}  data   Response from the endpoint
- * @returns {Array}         Dispatched actions
+ * @param   {Object} action      Redux action
+ * @param   {Array}  appPassword Response from the endpoint
+ * @returns {Array}              Dispatched actions
  */
 export const handleAddSuccess = ( action, appPassword ) => [
 	createApplicationPasswordSuccess( appPassword ),

--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/new/index.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/new/index.js
@@ -8,12 +8,12 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import schema from './schema';
 import { APPLICATION_PASSWORD_CREATE } from 'state/action-types';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { makeParser } from 'lib/make-json-schema-parser';
 import {
 	createApplicationPasswordSuccess,
 	requestApplicationPasswords,
@@ -73,7 +73,7 @@ export default {
 			fetch: addApplicationPassword,
 			onSuccess: handleAddSuccess,
 			onError: handleAddError,
-			fromApi: makeParser( schema, {}, apiTransformer ),
+			fromApi: makeJsonSchemaParser( schema, {}, apiTransformer ),
 		} ),
 	],
 };

--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/new/index.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/new/index.js
@@ -10,9 +10,10 @@ import { translate } from 'i18n-calypso';
  */
 import schema from './schema';
 import { APPLICATION_PASSWORD_CREATE } from 'state/action-types';
-import { dispatchRequestEx, makeParser } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import { makeParser } from 'lib/make-json-schema-parser';
 import {
 	createApplicationPasswordSuccess,
 	requestApplicationPasswords,

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -8,8 +8,8 @@ import { get, map } from 'lodash';
  * Internal dependencies
  */
 import { parseBlock } from 'lib/notifications/note-block-parser';
-import { makeParser } from 'state/data-layer/wpcom-http/utils';
 import apiResponseSchema from './schema';
+import { makeParser } from 'lib/make-json-schema-parser';
 
 /**
  * Module constants

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -7,9 +7,9 @@ import { get, map } from 'lodash';
 /**
  * Internal dependencies
  */
-import { parseBlock } from 'lib/notifications/note-block-parser';
 import apiResponseSchema from './schema';
 import { makeParser } from 'lib/make-json-schema-parser';
+import { parseBlock } from 'lib/notifications/note-block-parser';
 
 /**
  * Module constants

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -8,7 +8,7 @@ import { get, map } from 'lodash';
  * Internal dependencies
  */
 import apiResponseSchema from './schema';
-import { makeParser } from 'lib/make-json-schema-parser';
+import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import { parseBlock } from 'lib/notifications/note-block-parser';
 
 /**
@@ -104,4 +104,4 @@ export function processItem( item ) {
 }
 
 // fromApi default export
-export default makeParser( apiResponseSchema, {}, transformer );
+export default makeJsonSchemaParser( apiResponseSchema, {}, transformer );

--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -8,14 +8,14 @@ import { noop, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { http } from 'state/data-layer/wpcom-http/actions';
-import { isJetpackSite } from 'state/sites/selectors';
-import { SECTION_SET, SELECTED_SITE_SET, JITM_DISMISS } from 'state/action-types';
 import schema from './schema.json';
 import { clearJITM, insertJITM } from 'state/jitm/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { isJetpackSite } from 'state/sites/selectors';
 import { makeParser } from 'lib/make-json-schema-parser';
+import { SECTION_SET, SELECTED_SITE_SET, JITM_DISMISS } from 'state/action-types';
 
 /**
  * Poor man's process manager

--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -12,10 +12,10 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { isJetpackSite } from 'state/sites/selectors';
 import { SECTION_SET, SELECTED_SITE_SET, JITM_DISMISS } from 'state/action-types';
-import { makeParser } from 'state/data-layer/wpcom-http/utils';
 import schema from './schema.json';
 import { clearJITM, insertJITM } from 'state/jitm/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { makeParser } from 'lib/make-json-schema-parser';
 
 /**
  * Poor man's process manager

--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -8,13 +8,13 @@ import { noop, get } from 'lodash';
 /**
  * Internal dependencies
  */
+import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import schema from './schema.json';
 import { clearJITM, insertJITM } from 'state/jitm/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { isJetpackSite } from 'state/sites/selectors';
-import { makeParser } from 'lib/make-json-schema-parser';
 import { SECTION_SET, SELECTED_SITE_SET, JITM_DISMISS } from 'state/action-types';
 
 /**
@@ -196,12 +196,12 @@ export const failedJITM = ( { dispatch }, { siteId, site_id, messagePath } ) =>
 export default {
 	[ SECTION_SET ]: [
 		dispatchRequest( handleRouteChange, receiveJITM, failedJITM, {
-			fromApi: makeParser( schema, {}, transformApiRequest ),
+			fromApi: makeJsonSchemaParser( schema, {}, transformApiRequest ),
 		} ),
 	],
 	[ SELECTED_SITE_SET ]: [
 		dispatchRequest( handleSiteSelection, receiveJITM, failedJITM, {
-			fromApi: makeParser( schema, {}, transformApiRequest ),
+			fromApi: makeJsonSchemaParser( schema, {}, transformApiRequest ),
 		} ),
 	],
 	[ JITM_DISMISS ]: [ dispatchRequest( doDismissJITM, noop, noop, {} ) ],

--- a/client/state/data-layer/wpcom/sites/rewind/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/index.js
@@ -5,9 +5,10 @@
 import { mergeHandlers } from 'state/action-watchers/utils';
 import { REWIND_STATE_REQUEST, REWIND_STATE_UPDATE } from 'state/action-types';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx, makeParser } from 'state/data-layer/wpcom-http/utils';
 import { transformApi } from './api-transformer';
+import { makeParser } from 'lib/make-json-schema-parser';
 import { rewindStatus } from './schema';
 
 import downloads from './downloads';

--- a/client/state/data-layer/wpcom/sites/rewind/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/index.js
@@ -2,9 +2,9 @@
 /**
  * Internal dependencies
  */
+import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { makeParser } from 'lib/make-json-schema-parser';
 import { mergeHandlers } from 'state/action-watchers/utils';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import { REWIND_STATE_REQUEST, REWIND_STATE_UPDATE } from 'state/action-types';
@@ -105,7 +105,7 @@ export default mergeHandlers( downloads, {
 			fetch: fetchRewindState,
 			onSuccess: updateRewindState,
 			onError: setUnknownState,
-			fromApi: makeParser( rewindStatus, {}, transformApi ),
+			fromApi: makeJsonSchemaParser( rewindStatus, {}, transformApi ),
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/sites/rewind/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/index.js
@@ -2,14 +2,14 @@
 /**
  * Internal dependencies
  */
-import { mergeHandlers } from 'state/action-watchers/utils';
-import { REWIND_STATE_REQUEST, REWIND_STATE_UPDATE } from 'state/action-types';
-import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { transformApi } from './api-transformer';
 import { makeParser } from 'lib/make-json-schema-parser';
+import { mergeHandlers } from 'state/action-watchers/utils';
+import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
+import { REWIND_STATE_REQUEST, REWIND_STATE_UPDATE } from 'state/action-types';
 import { rewindStatus } from './schema';
+import { transformApi } from './api-transformer';
 
 import downloads from './downloads';
 

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -9,6 +9,8 @@ import { get, noop, toPairs } from 'lodash';
 /**
  * Internal dependencies
  */
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { TransformerError } from 'lib/make-json-schema-parser';
 import {
 	SIMPLE_PAYMENTS_PRODUCT_GET,
 	SIMPLE_PAYMENTS_PRODUCTS_LIST,
@@ -23,7 +25,6 @@ import {
 } from 'state/simple-payments/product-list/actions';
 import { metaKeyToSchemaKeyMap, metadataSchema } from 'state/simple-payments/product-list/schema';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx, TransformerError } from 'state/data-layer/wpcom-http/utils';
 import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants';
 import { isValidSimplePaymentsProduct } from 'lib/simple-payments/utils';
 import formatCurrency from 'lib/format-currency';

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -9,27 +9,27 @@ import { get, noop, toPairs } from 'lodash';
 /**
  * Internal dependencies
  */
+import formatCurrency from 'lib/format-currency';
+import { decodeEntities } from 'lib/formatting';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { getFeaturedImageId } from 'lib/posts/utils';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { isValidSimplePaymentsProduct } from 'lib/simple-payments/utils';
+import { metaKeyToSchemaKeyMap, metadataSchema } from 'state/simple-payments/product-list/schema';
+import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants';
 import { TransformerError } from 'lib/make-json-schema-parser';
 import {
 	SIMPLE_PAYMENTS_PRODUCT_GET,
 	SIMPLE_PAYMENTS_PRODUCTS_LIST,
 	SIMPLE_PAYMENTS_PRODUCTS_LIST_ADD,
-	SIMPLE_PAYMENTS_PRODUCTS_LIST_EDIT,
 	SIMPLE_PAYMENTS_PRODUCTS_LIST_DELETE,
+	SIMPLE_PAYMENTS_PRODUCTS_LIST_EDIT,
 } from 'state/action-types';
 import {
+	receiveDeleteProduct,
 	receiveProductsList,
 	receiveUpdateProduct,
-	receiveDeleteProduct,
 } from 'state/simple-payments/product-list/actions';
-import { metaKeyToSchemaKeyMap, metadataSchema } from 'state/simple-payments/product-list/schema';
-import { http } from 'state/data-layer/wpcom-http/actions';
-import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants';
-import { isValidSimplePaymentsProduct } from 'lib/simple-payments/utils';
-import formatCurrency from 'lib/format-currency';
-import { getFeaturedImageId } from 'lib/posts/utils';
-import { decodeEntities } from 'lib/formatting';
 
 /**
  * Convert custom post metadata array to product attributes

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -14,6 +14,7 @@ import userFactory from 'lib/user';
 import wpcom from 'lib/wp';
 import { addQueryArgs, externalRedirect } from 'lib/route';
 import { clearPlan } from 'jetpack-connect/persistence-utils';
+import { makeParser } from 'lib/make-json-schema-parser';
 import { receiveDeletedSite, receiveSite } from 'state/sites/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { REMOTE_PATH_AUTH } from 'jetpack-connect/constants';
@@ -44,7 +45,6 @@ import {
 	SITE_REQUEST_FAILURE,
 	SITE_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { makeParser } from 'state/data-layer/wpcom-http/utils';
 
 /**
  * Module constants

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -10,11 +10,11 @@ import { omit, pick } from 'lodash';
  * Internal dependencies
  */
 import config from 'config';
+import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import userFactory from 'lib/user';
 import wpcom from 'lib/wp';
 import { addQueryArgs, externalRedirect } from 'lib/route';
 import { clearPlan } from 'jetpack-connect/persistence-utils';
-import { makeParser } from 'lib/make-json-schema-parser';
 import { receiveDeletedSite, receiveSite } from 'state/sites/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { REMOTE_PATH_AUTH } from 'jetpack-connect/constants';
@@ -251,7 +251,7 @@ export function createAccount( userData ) {
 
 		try {
 			const data = await wpcom.undocumented().usersNew( userData );
-			const bearerToken = makeParser(
+			const bearerToken = makeJsonSchemaParser(
 				{
 					type: 'object',
 					required: [ 'bearer_token' ],


### PR DESCRIPTION
`makeParser` is a useful tool to validate and transform data beyond the data layer. Extract the function and related code into its own directory. Updates usage across calypso. 

Bonus:
- Update some jsdocs for improved accuracy and layout
- Sort and alphabetize imports.

This PR should include _no functional changes_.

## Testing
- Smoke test
- Check e2e results