### PR TITLE
PlanFeaturesHeader: Compute isJetpackSite() in connect(), drop site prop

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -24,7 +24,7 @@ import { getYearlyPlanByMonthly, planMatches } from 'lib/plans';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getPlanBySlug } from 'state/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug } from 'state/sites/selectors';
+import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import { isMobile } from 'lib/viewport';
 import { planLevelsMatch } from 'lib/plans/index';
 
@@ -100,10 +100,10 @@ export class PlanFeaturesHeader extends Component {
 		const {
 			available,
 			discountPrice,
-			site,
-			showModifiedPricingDisplay,
+			isSiteJetpack,
 			rawPrice,
 			relatedMonthlyPlan,
+			showModifiedPricingDisplay,
 		} = this.props;
 
 		if ( ! showModifiedPricingDisplay || ! available || this.isPlanCurrent() ) {
@@ -121,7 +121,7 @@ export class PlanFeaturesHeader extends Component {
 		// Note: Don't make this translatable because it's only visible to English-language users
 		return (
 			<span className="plan-features__header-credit-label">
-				{ site.jetpack ? 'Discount' : 'Credit available' }
+				{ isSiteJetpack ? 'Discount' : 'Credit available' }
 			</span>
 		);
 	}
@@ -146,8 +146,8 @@ export class PlanFeaturesHeader extends Component {
 			billingTimeFrame,
 			discountPrice,
 			isPlaceholder,
-			site,
 			isSiteAT,
+			isSiteJetpack,
 			hideMonthly,
 			isInSignup,
 		} = this.props;
@@ -168,7 +168,7 @@ export class PlanFeaturesHeader extends Component {
 
 		if (
 			isSiteAT ||
-			! site.jetpack ||
+			! isSiteJetpack ||
 			planMatches( this.props.planType, { type: TYPE_FREE } ) ||
 			hideMonthly
 		) {
@@ -205,19 +205,18 @@ export class PlanFeaturesHeader extends Component {
 		const {
 			currencyCode,
 			discountPrice,
-			rawPrice,
-			isPlaceholder,
-			relatedMonthlyPlan,
-			site,
 			isInSignup,
+			isPlaceholder,
+			isSiteJetpack,
+			rawPrice,
+			relatedMonthlyPlan,
 			showModifiedPricingDisplay,
 		} = this.props;
 
 		if ( isPlaceholder && ! isInSignup ) {
-			const isJetpackSite = !! site.jetpack;
 			const classes = classNames( 'is-placeholder', {
-				'plan-features__price': ! isJetpackSite,
-				'plan-features__price-jetpack': isJetpackSite,
+				'plan-features__price': ! isSiteJetpack,
+				'plan-features__price-jetpack': isSiteJetpack,
 			} );
 
 			return <div className={ classes } />;
@@ -273,14 +272,14 @@ export class PlanFeaturesHeader extends Component {
 		const {
 			basePlansPath,
 			currencyCode,
+			isSiteJetpack,
 			isYearly,
 			rawPrice,
 			relatedMonthlyPlan,
 			relatedYearlyPlan,
-			site,
 			siteSlug,
 		} = this.props;
-		if ( site.jetpack ) {
+		if ( isSiteJetpack ) {
 			const [ discountPrice, originalPrice ] = isYearly
 				? [ relatedMonthlyPlan.raw_price * 12, rawPrice ]
 				: [ rawPrice * 12, get( relatedYearlyPlan, 'raw_price' ) ];
@@ -318,7 +317,6 @@ PlanFeaturesHeader.propTypes = {
 	title: PropTypes.string.isRequired,
 	isPlaceholder: PropTypes.bool,
 	translate: PropTypes.func,
-	site: PropTypes.object,
 	siteSlug: PropTypes.string,
 	isInJetpackConnect: PropTypes.bool,
 	relatedMonthlyPlan: PropTypes.object,
@@ -326,6 +324,7 @@ PlanFeaturesHeader.propTypes = {
 	// Connected props
 	currentSitePlan: PropTypes.object,
 	isSiteAT: PropTypes.bool,
+	isSiteJetpack: PropTypes.bool,
 	relatedYearlyPlan: PropTypes.object,
 };
 
@@ -336,11 +335,11 @@ PlanFeaturesHeader.defaultProps = {
 	newPlan: false,
 	bestValue: false,
 	isPlaceholder: false,
-	site: {},
 	siteSlug: '',
 	basePlansPath: null,
 	currentSitePlan: {},
 	isSiteAT: false,
+	isSiteJetpack: false,
 };
 
 export default connect( ( state, { isInSignup, planType, relatedMonthlyPlan } ) => {
@@ -350,6 +349,7 @@ export default connect( ( state, { isInSignup, planType, relatedMonthlyPlan } ) 
 	return {
 		currentSitePlan,
 		isSiteAT: isSiteAutomatedTransfer( state, selectedSiteId ),
+		isSiteJetpack: isJetpackSite( state, selectedSiteId ),
 		isYearly,
 		relatedYearlyPlan: isYearly ? null : getPlanBySlug( state, getYearlyPlanByMonthly( planType ) ),
 		siteSlug: getSiteSlug( state, selectedSiteId ),

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -258,7 +258,6 @@ class PlanFeatures extends Component {
 			isLandingPage,
 			planProperties,
 			selectedPlan,
-			site,
 			translate,
 		} = this.props;
 
@@ -311,7 +310,6 @@ class PlanFeatures extends Component {
 						billingTimeFrame={ planConstantObj.getBillingTimeFrame( getABTestVariation ) }
 						hideMonthly={ hideMonthly }
 						isPlaceholder={ isPlaceholder }
-						site={ site }
 						basePlansPath={ basePlansPath }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
 						isInSignup={ isInSignup }
@@ -356,7 +354,6 @@ class PlanFeatures extends Component {
 			isInSignup,
 			planProperties,
 			selectedPlan,
-			site,
 			siteType,
 			showModifiedPricingDisplay,
 		} = this.props;
@@ -419,7 +416,6 @@ class PlanFeatures extends Component {
 						popular={ popular }
 						rawPrice={ rawPrice }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
-						site={ site }
 						selectedPlan={ selectedPlan }
 						title={ planConstantObj.getTitle() }
 						showModifiedPricingDisplay={ showModifiedPricingDisplay }

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -54,7 +54,7 @@ const props = {
 	translate: x => x,
 	planType: PLAN_FREE,
 	currentSitePlan: { productSlug: PLAN_FREE },
-	site: {},
+	isSiteJetpack: null,
 };
 
 describe( 'PlanFeaturesHeader basic tests', () => {
@@ -106,7 +106,7 @@ describe( 'PlanFeaturesHeader.getBillingTimeframe()', () => {
 		test( `Should render InfoPopover for free plans (${ productSlug })`, () => {
 			const comp = new PlanFeaturesHeader( {
 				...myProps,
-				site: { jetpack: true },
+				isSiteJetpack: true,
 				planType: productSlug,
 			} );
 			const tf = shallow( comp.getBillingTimeframe() );
@@ -119,7 +119,7 @@ describe( 'PlanFeaturesHeader.getBillingTimeframe()', () => {
 			test( `Should render InfoPopover for non-jetpack sites (${ productSlug })`, () => {
 				const comp = new PlanFeaturesHeader( {
 					...myProps,
-					site: { jetpack: false },
+					isSiteJetpack: false,
 					planType: productSlug,
 				} );
 				const tf = shallow( comp.getBillingTimeframe() );
@@ -129,7 +129,7 @@ describe( 'PlanFeaturesHeader.getBillingTimeframe()', () => {
 			test( `Should render InfoPopover for AT sites (${ productSlug })`, () => {
 				const comp = new PlanFeaturesHeader( {
 					...myProps,
-					site: { jetpack: true },
+					isSiteJetpack: true,
 					isSiteAT: true,
 					planType: productSlug,
 				} );
@@ -139,7 +139,7 @@ describe( 'PlanFeaturesHeader.getBillingTimeframe()', () => {
 			test( `Should render InfoPopover when hideMonthly is true (${ productSlug })`, () => {
 				const comp = new PlanFeaturesHeader( {
 					...myProps,
-					site: { jetpack: true },
+					isSiteJetpack: true,
 					hideMonthly: true,
 					planType: productSlug,
 				} );
@@ -166,7 +166,7 @@ describe( 'PlanFeaturesHeader.getBillingTimeframe()', () => {
 		test( `Should not render InfoPopover for paid plans (${ productSlug })`, () => {
 			const comp = new PlanFeaturesHeader( {
 				...myProps,
-				site: { jetpack: true },
+				isSiteJetpack: true,
 				planType: productSlug,
 			} );
 			const tf = shallow( comp.getBillingTimeframe() );


### PR DESCRIPTION
(For more background, see #24266.)

### Testing Instructions
* Verify that the Plans page still works in various scenarios -- during signup, in `my-sites`; for WP.com sites, for Jetpack sites; etc.