### PR TITLE
PlanFeaturesSummary: Accept isJetpackSite instead of site prop

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -225,11 +225,11 @@ class PlanFeatures extends Component {
 						currencyCode={ currencyCode }
 						current={ current }
 						discountPrice={ discountPrice }
+						isJetpackSite={ site.jetpack }
 						planTitle={ planConstantObj.getTitle() }
 						planType={ planName }
 						rawPrice={ rawPrice }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
-						site={ site }
 					/>
 				</td>
 			);

--- a/client/my-sites/plan-features/summary.jsx
+++ b/client/my-sites/plan-features/summary.jsx
@@ -18,10 +18,10 @@ class PlanFeaturesSummary extends Component {
 		available: PropTypes.bool.isRequired,
 		currencyCode: PropTypes.string,
 		current: PropTypes.bool,
+		isJetpackSite: PropTypes.bool.isRequired,
 		planTitle: PropTypes.string.isRequired,
 		rawPrice: PropTypes.number,
 		relatedMonthlyPlan: PropTypes.object,
-		site: PropTypes.object.isRequired,
 	};
 
 	renderWPCOMSummary() {
@@ -97,13 +97,13 @@ class PlanFeaturesSummary extends Component {
 	}
 
 	render() {
-		const { available, current, site } = this.props;
+		const { available, current, isJetpackSite } = this.props;
 
 		if ( current || ! available ) {
 			return null;
 		}
 
-		const summary = site.jetpack ? this.renderJetpackSummary() : this.renderWPCOMSummary();
+		const summary = isJetpackSite ? this.renderJetpackSummary() : this.renderWPCOMSummary();
 		if ( ! summary ) {
 			return null;
 		}


### PR DESCRIPTION
(For more background, see #24266.)

I opted to pass it as a prop here rather than adding a `connect()` to `PlanFeaturesSummary`.

### Testing Instructions
* Verify that the Plans page still works in various scenarios -- during signup, in `my-sites`; for WP.com sites, for Jetpack sites; etc.