### PR TITLE
Post Edit Store: move metadata update logic from action creators to the store

### DIFF
--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -5,7 +5,7 @@
  */
 
 import store from 'store';
-import { assign, clone, defer, fromPairs } from 'lodash';
+import { assign, clone, defer, fromPairs, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -37,40 +37,36 @@ var PostActions;
  *                                              or `delete`)
  */
 function handleMetadataOperation( key, value, operation ) {
-	var post = PostEditStore.get(),
-		metadata;
-
-	if ( 'string' === typeof key || Array.isArray( key ) ) {
-		// Normalize a string or array of string keys to an object of key value
-		// pairs. To accomodate both, we coerce the key into an array before
-		// mapping to pull the object pairs.
-		key = fromPairs( [].concat( key ).map( meta => [ meta, value ] ) );
+	// Normalize a string or array of string keys to an object of key value pairs.
+	if ( 'string' === typeof key ) {
+		// case of handleMetadataOperation( 'excerpt', 'text', 'update' )
+		key = { [ key ]: value };
+	} else if ( Array.isArray( key ) ) {
+		// case of handleMetadataOperation( [ 'geo_latitude', 'geo_longitude' ], null, 'delete' )
+		key = fromPairs( key.map( meta => [ meta, value ] ) );
 	}
 
-	// Overwrite duplicates based on key
-	metadata = ( post.metadata || [] ).filter( meta => ! key.hasOwnProperty( meta.key ) );
-
-	Object.keys( key ).forEach( function( objectKey ) {
+	const metadata = map( key, function( objectValue, objectKey ) {
 		// `update` is a sufficient operation for new metadata, as it will add
 		// the metadata if it does not already exist. Similarly, we're not
 		// concerned with deleting a key which was added during previous edits,
 		// since this will effectively noop.
-		var meta = {
+		const meta = {
 			key: objectKey,
-			operation: operation,
+			operation,
 		};
 
 		if ( 'delete' !== operation ) {
-			meta.value = key[ objectKey ];
+			meta.value = objectValue;
 		}
 
-		metadata.push( meta );
+		return meta;
 	} );
 
 	Dispatcher.handleViewAction( {
 		type: 'EDIT_POST',
 		post: {
-			metadata: metadata,
+			metadata,
 		},
 	} );
 }

--- a/client/lib/posts/post-edit-store.js
+++ b/client/lib/posts/post-edit-store.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { assign, filter, get, isEqual, pickBy } from 'lodash';
+import { assign, filter, find, get, isEqual, pickBy } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:posts:post-edit-store' );
 import emitter from 'lib/mixins/emitter';
@@ -122,9 +122,14 @@ function setLoadingError( error ) {
 	_isLoading = false;
 }
 
-function set( attributes ) {
-	var updatedPost;
+function mergeMetadataEdits( metadata, edits ) {
+	// remove existing metadata that get updated in `edits`
+	const newMetadata = filter( metadata, meta => ! find( edits, { key: meta.key } ) );
+	// append the new edits at the end
+	return newMetadata.concat( edits );
+}
 
+function set( attributes ) {
 	if ( ! _post ) {
 		// ignore since post isn't currently being edited
 		return false;
@@ -134,7 +139,15 @@ function set( attributes ) {
 		_queue.push( attributes );
 	}
 
-	updatedPost = assign( {}, _post, attributes );
+	let updatedPost = {
+		..._post,
+		...attributes,
+	};
+
+	// merge metadata with a custom function
+	if ( attributes.metadata ) {
+		updatedPost.metadata = mergeMetadataEdits( _post.metadata, attributes.metadata );
+	}
 
 	updatedPost = normalize( updatedPost );
 

--- a/client/lib/posts/test/actions.js
+++ b/client/lib/posts/test/actions.js
@@ -81,87 +81,17 @@ describe( 'actions', () => {
 				} )
 			).to.be.true;
 		} );
-
-		test( 'should include metadata already existing on the post object', () => {
-			PostEditStore.get.restore();
-			sandbox.stub( PostEditStore, 'get' ).returns( {
-				metadata: [ { key: 'other', value: '1234' } ],
-			} );
-
-			PostActions.updateMetadata( 'foo', 'bar' );
-
-			expect(
-				Dispatcher.handleViewAction.calledWithMatch( {
-					type: 'EDIT_POST',
-					post: {
-						metadata: [
-							{ key: 'other', value: '1234' },
-							{ key: 'foo', value: 'bar', operation: 'update' },
-						],
-					},
-				} )
-			).to.be.true;
-		} );
-
-		test( 'should include metadata edits made previously', () => {
-			PostEditStore.get.restore();
-			sandbox.stub( PostEditStore, 'get' ).returns( {
-				metadata: [ { key: 'other', operation: 'delete' } ],
-			} );
-
-			PostActions.updateMetadata( 'foo', 'bar' );
-
-			expect(
-				Dispatcher.handleViewAction.calledWithMatch( {
-					type: 'EDIT_POST',
-					post: {
-						metadata: [
-							{ key: 'other', operation: 'delete' },
-							{ key: 'foo', value: 'bar', operation: 'update' },
-						],
-					},
-				} )
-			).to.be.true;
-		} );
-
-		test( 'should not duplicate existing metadata edits', () => {
-			PostEditStore.get.restore();
-			sandbox.stub( PostEditStore, 'get' ).returns( {
-				metadata: [
-					{ key: 'bar', value: 'foo' },
-					{ key: 'foo', value: 'baz', operation: 'delete' },
-				],
-			} );
-
-			PostActions.updateMetadata( 'foo', 'bar' );
-
-			expect(
-				Dispatcher.handleViewAction.calledWithMatch( {
-					type: 'EDIT_POST',
-					post: {
-						metadata: [
-							{ key: 'bar', value: 'foo' },
-							{ key: 'foo', value: 'bar', operation: 'update' },
-						],
-					},
-				} )
-			).to.be.true;
-		} );
 	} );
 
 	describe( '#deleteMetadata()', () => {
 		test( 'should dispatch a post edit with a deleted metadata', () => {
-			PostEditStore.get.restore();
-			sandbox.stub( PostEditStore, 'get' ).returns( {
-				metadata: [ { key: 'bar', value: 'foo' } ],
-			} );
 			PostActions.deleteMetadata( 'foo' );
 
 			expect(
 				Dispatcher.handleViewAction.calledWithMatch( {
 					type: 'EDIT_POST',
 					post: {
-						metadata: [ { key: 'bar', value: 'foo' }, { key: 'foo', operation: 'delete' } ],
+						metadata: [ { key: 'foo', operation: 'delete' } ],
 					},
 				} )
 			).to.be.true;


### PR DESCRIPTION
Currently, the `handleMetadataOperation` function (which plays a role similar to a Redux action creator) retrieves the metadata of the edited post, applies all edits to them and dispatches a `EDIT_POST` Flux action with the updated metadata list.

This PR shuffles the logic around a bit. The `EDIT_POST` action doesn't contain the full updated `metadata` list, but only the list of edits. Then the `set` function in the `PostEditStore` applies these edits to the post.

The end result is the same, but organizing the code this way will help a lot with Redux refactoring, as it will allow the Flux and Redux implementations of metadata editing to live together for a while.

Tests were updated: some functionality that was previously tested in `PostActions` is now present in `PostEditStore` tests.

**Quick overview of how post metadata editing works**

For most post properties, editing the is a matter of straightforward property assignment. We dispatch a Flux edit action:
```js
PostActions.edit( {
  title: 'New Title'
} );
```
Then the property gets overwritten in the locally modified post:
```js
expect( PostEditStore.get() ).toMatchObject( {
  title: 'New Title'
} );
```
And when we want to send a REST API request to modify the post, it's in the list of changed properties:
```js
expect( PostEditStore.getChangedAttributes() ).toEqual( {
  title: 'New Title'
} );
```

Post metadata are different. It's an array of key/value pairs, the changes need to be merged, and we send "operations" to the REST endpoint rather than the new array value.

A typical `post.metadata` looks like this:
```js
[
  { key: 'geo_latitude', value: '123' },
  { key: 'geo_longitude', value: '456' },
]
```

To update a value, we dispatch an `updateMetadata` Flux action:
```js
updateMetadata( 'geo_longitude', '789' );
// or as an object than can have multiple props:
updateMetadata( { geo_longitude: '789' } );
```

This results in a `EDIT_POST` dispatch and the locally edited post's metadata become:
```js
[
  { key: 'geo_latitude', value: '123' },
  { key: 'geo_longitude', value: '789', operation: 'update' },
]
```
Note the new `operation` field.

When sending a modification REST request, the `PostEditStore.getChangedAttributes` method returns a `metadata` list filtered to include only items with `operation`, and unchanged items are omitted:
```js
[
  { key: 'geo_longitude', value: '789', operation: 'update' },
]
```

Similarly, there is a `deleteMetadata` action:
```js
deleteMetadata( 'geo_latitude' );
// or more props at once
deleteMetadata( [ 'geo_latitude', 'geo_longitude' ] );
```
which results in a REST API request:
```js
[
  { key: 'geo_latitude', operation: 'delete' },
]
```

All this PR does is to reshuffle the logic that takes the existing post metadata, a edit request and produces the updated list, with some properties unchanged and some modified and decorated with an `operation` field.

**How to test:**
Covered pretty well by unit test. In Calypso UI, test that editing things like post excerpt or geolocation (which can be deleted, too) works as expected and the right API requests are sent.

Part of #24281 
