### PR TITLE
Help: experiment with contextual content for inline help

### DIFF
--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -35,48 +35,7 @@ class InlineHelpSearchResults extends Component {
 		searchQuery: '',
 	};
 
-	getContextResults = () => {
-		// going without context for now -- let's just provide the top x recommended links
-		// copied from client/me/help/main for now
-		const helpfulResults = [
-			{
-				link: 'https://en.support.wordpress.com/business-plan/',
-				title: this.props.translate( 'Uploading custom plugins and themes' ),
-				description: this.props.translate(
-					'Learn more about installing a custom theme or plugin using the Business plan.'
-				),
-			},
-			{
-				link: 'https://en.support.wordpress.com/all-about-domains/',
-				title: this.props.translate( 'All About Domains' ),
-				description: this.props.translate(
-					'Set up your domain whether it’s registered with WordPress.com or elsewhere.'
-				),
-			},
-			{
-				link: 'https://en.support.wordpress.com/start/',
-				title: this.props.translate( 'Get Started' ),
-				description: this.props.translate(
-					'No matter what kind of site you want to build, our five-step checklists will get you set up and ready to publish.'
-				),
-			},
-			{
-				link: 'https://en.support.wordpress.com/settings/privacy-settings/',
-				title: this.props.translate( 'Privacy Settings' ),
-				description: this.props.translate(
-					'Limit your site’s visibility or make it completely private.'
-				),
-			},
-		];
-		return helpfulResults;
-	};
-
 	renderSearchResults() {
-		if ( isEmpty( this.props.searchQuery ) ) {
-			// not searching
-			return this.renderContextHelp();
-		}
-
 		if ( this.props.isSearching ) {
 			// search, but no results so far
 			return <PlaceholderLines />;
@@ -87,7 +46,6 @@ class InlineHelpSearchResults extends Component {
 			return (
 				<div>
 					<p className="inline-help__empty-results">No results.</p>
-					{ this.renderContextHelp() }
 				</div>
 			);
 		}
@@ -99,29 +57,18 @@ class InlineHelpSearchResults extends Component {
 		);
 	}
 
-	renderContextHelp() {
-		const links = this.getContextResults();
-		return (
-			<ul className="inline-help__results-list">{ links && links.map( this.renderHelpLink ) }</ul>
-		);
-	}
-
 	getSelectedUrl = () => {
 		if ( this.props.selectedResult === -1 ) {
 			return false;
 		}
 
-		const links = this.props.searchResults || this.getContextResults();
+		const links = this.props.searchResults;
 		const selectedLink = links[ this.props.selectedResult ];
 		if ( ! selectedLink || ! selectedLink.link ) {
 			return false;
 		}
 		return selectedLink.link;
 	};
-
-	componentDidMount() {
-		this.props.setSearchResults( '', this.getContextResults() );
-	}
 
 	onHelpLinkClick = event => {
 		this.props.openResult( event, event.target.href );
@@ -145,6 +92,7 @@ class InlineHelpSearchResults extends Component {
 	render() {
 		return (
 			<div>
+				<h2>Search Results</h2>
 				<QueryInlineHelpSearch
 					query={ this.props.searchQuery }
 					requesting={ this.props.isSearching }

--- a/client/blocks/inline-help/inline-help-suggestions.jsx
+++ b/client/blocks/inline-help/inline-help-suggestions.jsx
@@ -1,0 +1,166 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { get, identity } from 'lodash';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
+import debugFactory from 'debug';
+
+/**
+ * Internal Dependencies
+ */
+import { recordTracksEvent } from 'state/analytics/actions';
+import pathToSection from 'lib/path-to-section';
+import QueryInlineHelpSearch from 'components/data/query-inline-help-search';
+import PlaceholderLines from './placeholder-lines';
+import { decodeEntities, preventWidows } from 'lib/formatting';
+import {
+	getInlineHelpSearchResultsForQuery,
+	getSelectedResult,
+	isRequestingInlineHelpSearchResultsForQuery,
+} from 'state/inline-help/selectors';
+import { getLastRouteAction } from 'state/ui/action-log/selectors';
+import { setSearchResults } from 'state/inline-help/actions';
+
+/**
+ * Module variables
+ */
+const debug = debugFactory( 'calypso:inline-help' );
+
+class InlineHelpSuggestions extends Component {
+	static propTypes = {
+		openResult: PropTypes.func.isRequired,
+		translate: PropTypes.func,
+	};
+
+	static defaultProps = {
+		translate: identity,
+	};
+
+	getContextResults = () => {
+		// going without context for now -- let's just provide the top x recommended links
+		// copied from client/me/help/main for now
+		const helpfulResults = [
+			{
+				link: 'https://en.support.wordpress.com/business-plan/',
+				title: this.props.translate( 'Uploading custom plugins and themes' ),
+				description: this.props.translate(
+					'Learn more about installing a custom theme or plugin using the Business plan.'
+				),
+			},
+			{
+				link: 'https://en.support.wordpress.com/all-about-domains/',
+				title: this.props.translate( 'All About Domains' ),
+				description: this.props.translate(
+					'Set up your domain whether it’s registered with WordPress.com or elsewhere.'
+				),
+			},
+			{
+				link: 'https://en.support.wordpress.com/start/',
+				title: this.props.translate( 'Get Started' ),
+				description: this.props.translate(
+					'No matter what kind of site you want to build, our five-step checklists will get you set up and ready to publish.'
+				),
+			},
+			{
+				link: 'https://en.support.wordpress.com/settings/privacy-settings/',
+				title: this.props.translate( 'Privacy Settings' ),
+				description: this.props.translate(
+					'Limit your site’s visibility or make it completely private.'
+				),
+			},
+		];
+		return helpfulResults;
+	};
+
+	renderSearchResults() {
+		if ( this.props.isSearching ) {
+			// search, but no results so far
+			return <PlaceholderLines />;
+		}
+		const links = this.getContextResults();
+		return (
+			<ul className="inline-help__results-list">{ links && links.map( this.renderHelpLink ) }</ul>
+		);
+	}
+
+	getSelectedUrl = () => {
+		if ( this.props.selectedResult === -1 ) {
+			return false;
+		}
+
+		const links = this.props.searchResults || this.getContextResults();
+		const selectedLink = links[ this.props.selectedResult ];
+		if ( ! selectedLink || ! selectedLink.link ) {
+			return false;
+		}
+		return selectedLink.link;
+	};
+
+	componentDidMount() {
+		this.props.setSearchResults( '', this.getContextResults() );
+	}
+
+	onHelpLinkClick = event => {
+		this.props.openResult( event, event.target.href );
+	};
+
+	renderHelpLink = ( link, index ) => {
+		const classes = { 'is-selected': this.props.selectedResult === index };
+		return (
+			<li key={ link.link } className={ classNames( 'inline-help__results-item', classes ) }>
+				<a
+					href={ link.link }
+					onClick={ this.onHelpLinkClick }
+					title={ decodeEntities( link.description ) }
+				>
+					{ preventWidows( decodeEntities( link.title ) ) }
+				</a>
+			</li>
+		);
+	};
+
+	getContextQuery = () => {
+		const context = {
+			path: this.props.lastRoute.path,
+			section: pathToSection( this.props.lastRoute.path ),
+		};
+		const sectionToSearchQuery = {
+			stats: 'statistics',
+			media: 'media',
+			checklist: 'getting started',
+			sharing: 'social media',
+		};
+		const searchQuery = get( sectionToSearchQuery, context.section, '' );
+		debug( 'InlineHelpSuggestions.getContextQuery', context, searchQuery );
+		return searchQuery;
+	};
+
+	render() {
+		const searchQuery = this.getContextQuery();
+		return (
+			<div>
+				<h2>Suggestions</h2>
+				<QueryInlineHelpSearch query={ searchQuery } requesting={ this.props.isSearching } />
+				{ this.renderSearchResults() }
+			</div>
+		);
+	}
+}
+
+const mapStateToProps = ( state, ownProps ) => ( {
+	lastRoute: getLastRouteAction( state ),
+	searchResults: getInlineHelpSearchResultsForQuery( state, ownProps.searchQuery ),
+	isSearching: isRequestingInlineHelpSearchResultsForQuery( state, ownProps.searchQuery ),
+	selectedResult: getSelectedResult( state ),
+} );
+const mapDispatchToProps = {
+	recordTracksEvent,
+	setSearchResults,
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( InlineHelpSuggestions ) );

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -18,6 +18,7 @@ import Button from 'components/button';
 import Popover from 'components/popover';
 import InlineHelpSearchResults from './inline-help-search-results';
 import InlineHelpSearchCard from './inline-help-search-card';
+import InlineHelpSuggestions from './inline-help-suggestions';
 import HelpContact from 'me/help/help-contact';
 import { getSearchQuery } from 'state/inline-help/selectors';
 import { getHelpSelectedSite } from 'state/help/selectors';
@@ -73,6 +74,8 @@ class InlineHelpPopover extends Component {
 		const { showContactForm } = this.state;
 		const popoverClasses = { 'is-help-active': showContactForm };
 
+		console.log( 'InlineHelpPopover.render -- this.props.searchQuery:', this.props.searchQuery );
+
 		return (
 			<Popover
 				isVisible
@@ -83,10 +86,13 @@ class InlineHelpPopover extends Component {
 			>
 				<div className="inline-help__search">
 					<InlineHelpSearchCard openResult={ this.openResult } query={ this.props.searchQuery } />
-					<InlineHelpSearchResults
-						openResult={ this.openResult }
-						searchQuery={ this.props.searchQuery }
-					/>
+					{ this.props.searchQuery && (
+						<InlineHelpSearchResults
+							openResult={ this.openResult }
+							searchQuery={ this.props.searchQuery }
+						/>
+					) }
+					{ ! this.props.searchQuery && <InlineHelpSuggestions openResult={ this.openResult } /> }
 				</div>
 
 				<div className="inline-help__contact">

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -341,7 +341,7 @@
 }
 
 .inline-help__empty-results {
-	padding: 16px 0 0 0;
+	padding: 67px 0 68px 0;
 	margin: 0;
 	font-size: 14px;
 	color: $gray;
@@ -360,7 +360,7 @@
 
 .inline-help__results-placeholder-item {
 	height: 16px;
-	margin: 16px 0;
+	margin: 18px 0;
 	border-radius: 16px;
 	background-color: lighten( $gray, 28 );
 	color: transparent;

--- a/client/components/data/query-inline-help-search/index.jsx
+++ b/client/components/data/query-inline-help-search/index.jsx
@@ -27,6 +27,7 @@ class QueryInlineHelpSearch extends Component {
 
 	request( props ) {
 		if ( props.requesting || ! props.query ) {
+			console.log( 'request returning early -- props.requesting || ! props.query', props );
 			return;
 		}
 

--- a/client/state/ui/action-log/selectors.js
+++ b/client/state/ui/action-log/selectors.js
@@ -40,6 +40,16 @@ export function getRouteHistory( state ) {
 }
 
 /**
+ * Returns the last ROUTE_SET action that had been dispatched for the current user.
+ *
+ * @param  {Object}   state      Global state tree
+ * @return {Object}              The last Redux action of type ROUTE_SET, with timestamp
+ */
+export function getLastRouteAction( state ) {
+	return last( getActionLog( state ).filter( action => action.type === ROUTE_SET ) );
+}
+
+/**
  * Returns the last item from the action log.
  *
  * @param  {Object}   state      Global state tree


### PR DESCRIPTION
EXPERIMENT; DON'T MERGE

This PR experiments with showing contextual search results as immediate suggestions when opening inline help. The screen capture below shows that it does work, but also that it has a few issues that will likely require some re-architecting, probably on a fresh branch. Opening this here to share results so far with others. 

![inline help contextual content prototype](https://user-images.githubusercontent.com/23619/38926094-c69e6d2c-4301-11e8-8aa6-4b9d069bf023.gif)
