### PR TITLE
Remove direct usage of plan constants from "is-business-plan-user" selector

### DIFF
--- a/client/state/selectors/is-business-plan-user.js
+++ b/client/state/selectors/is-business-plan-user.js
@@ -6,7 +6,8 @@
 
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getUserPurchases } from 'state/purchases/selectors';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { planMatches } from 'lib/plans';
+import { GROUP_WPCOM, TYPE_BUSINESS } from 'lib/plans/constants';
 
 /**
  * Returns a boolean flag indicating if the current user is a business plan user.
@@ -27,5 +28,7 @@ export default state => {
 		return false;
 	}
 
-	return purchases.some( purchase => PLAN_BUSINESS === purchase.productSlug );
+	return purchases.some( purchase =>
+		planMatches( purchase.productSlug, { group: GROUP_WPCOM, type: TYPE_BUSINESS } )
+	);
 };

--- a/client/state/selectors/test/is-business-plan-user.js
+++ b/client/state/selectors/test/is-business-plan-user.js
@@ -3,14 +3,13 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
  */
 import { isBusinessPlanUser } from 'state/selectors';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS } from 'lib/plans/constants';
 
 describe( 'isBusinessPlanUser()', () => {
 	test( 'should return true if any purchase is a business plan.', () => {
@@ -33,7 +32,30 @@ describe( 'isBusinessPlanUser()', () => {
 			},
 		} );
 
-		assert.isTrue( isBusinessPlanUser( state ) );
+		expect( isBusinessPlanUser( state ) ).toBe( true );
+	} );
+
+	test( 'should return true if any purchase is a business plan (2y).', () => {
+		const state = deepFreeze( {
+			currentUser: {
+				id: 123,
+			},
+			purchases: {
+				data: [
+					{
+						user_id: '123',
+						product_slug: 'some-other-plan',
+					},
+					{
+						user_id: '123',
+						product_slug: PLAN_BUSINESS_2_YEARS,
+					},
+				],
+				hasLoadedUserPurchasesFromServer: true,
+			},
+		} );
+
+		expect( isBusinessPlanUser( state ) ).toBe( true );
 	} );
 
 	test( 'should return false if non of the purchases is a business plan.', () => {
@@ -56,7 +78,7 @@ describe( 'isBusinessPlanUser()', () => {
 			},
 		} );
 
-		assert.isFalse( isBusinessPlanUser( state ) );
+		expect( isBusinessPlanUser( state ) ).toBe( false );
 	} );
 
 	test( 'should return false if current user id is null.', () => {
@@ -64,7 +86,7 @@ describe( 'isBusinessPlanUser()', () => {
 			currentUser: {},
 		} );
 
-		assert.isFalse( isBusinessPlanUser( state ) );
+		expect( isBusinessPlanUser( state ) ).toBe( false );
 	} );
 
 	test( 'should return false if purchasing data is null.', () => {
@@ -84,6 +106,6 @@ describe( 'isBusinessPlanUser()', () => {
 			},
 		} );
 
-		assert.isFalse( isBusinessPlanUser( state ) );
+		expect( isBusinessPlanUser( state ) ).toBe( false );
 	} );
 } );


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `banner`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests - this selector already has coverage and we are only extending it in this PR