### PR TITLE
Checkout: Add postal code field to Ebanx fields

### DIFF
--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -140,22 +140,21 @@ export class CreditCardFormFields extends React.Component {
 						onCountrySelected: this.updateFieldValues,
 					} ) }
 
-					{ ebanxDetailsRequired && (
+					{ ebanxDetailsRequired ? (
 						<EbanxPaymentFields
 							countryCode={ this.getFieldValue( 'country' ) }
 							countriesList={ countriesList }
 							getErrorMessage={ this.props.getErrorMessage }
 							getFieldValue={ this.getFieldValue }
 							handleFieldChange={ this.updateFieldValues }
-							fieldClassName="credit-card-form-fields__field"
 						/>
+					) : (
+						this.createField( 'postal-code', Input, {
+							label: translate( 'Postal Code', {
+								context: 'Postal code on credit card form',
+							} ),
+						} )
 					) }
-
-					{ this.createField( 'postal-code', Input, {
-						label: translate( 'Postal Code', {
-							context: 'Postal code on credit card form',
-						} ),
-					} ) }
 				</div>
 			</div>
 		);

--- a/client/components/credit-card-form-fields/style.scss
+++ b/client/components/credit-card-form-fields/style.scss
@@ -11,12 +11,8 @@
 		margin-left: 15px;
 	}
 
-	.form__hidden-input a {
-		display: block;
-		font-size:  12px;
-		margin-top: -10px;
-		margin-left: 15px;
-		margin-bottom: 15px;
+	.checkout__ebanx-payment-fields {
+		margin-left: 0;
 	}
 
 	@include breakpoint( '>480px' ) {
@@ -32,34 +28,13 @@
 		.postal-code {
 			flex-basis: 8em;
 		}
-
-		&.ebanx-details-required {
-
-			.address-2,
-			.country,
-			.city {
-				flex-basis: calc( 100% - 15px );
-			}
-
-			.street-number {
-				flex-basis: calc( 33% - 15px);
-			}
-
-			.address-1 {
-				flex-basis: calc( 66% - 15px);
-			}
-
-			.document,
-			.phone,
-			.postal-code {
-				flex-basis: calc( 50% - 15px );
-			}
-		}
 	}
 }
-
-.credit-card-form-fields__field {
+.credit-card-form-fields {
 	margin-bottom: 15px;
+}
+.credit-card-form-fields__field {
+	margin-top: 15px;
 	position: relative;
 
 	select {

--- a/client/components/credit-card-form-fields/style.scss
+++ b/client/components/credit-card-form-fields/style.scss
@@ -30,9 +30,11 @@
 		}
 	}
 }
+
 .credit-card-form-fields {
 	margin-bottom: 15px;
 }
+
 .credit-card-form-fields__field {
 	margin-top: 15px;
 	position: relative;

--- a/client/lib/checkout/constants.js
+++ b/client/lib/checkout/constants.js
@@ -18,6 +18,7 @@ export const PAYMENT_PROCESSOR_EBANX_COUNTRIES = {
 			'state',
 			'city',
 			'phone-number',
+			'postal-code',
 		],
 	},
 	MX: {

--- a/client/lib/checkout/ebanx.js
+++ b/client/lib/checkout/ebanx.js
@@ -90,6 +90,11 @@ export function ebanxFieldRules( country ) {
 				description: i18n.translate( 'Phone Number' ),
 				rules: [ 'required' ],
 			},
+
+			'postal-code': {
+				description: i18n.translate( 'Postal Code' ),
+				rules: [ 'required' ],
+			},
 		},
 		ebanxFields
 	);

--- a/client/my-sites/checkout/checkout/ebanx-payment-fields.jsx
+++ b/client/my-sites/checkout/checkout/ebanx-payment-fields.jsx
@@ -36,24 +36,27 @@ export class EbanxPaymentFields extends Component {
 		const errorMessage = this.props.getErrorMessage( fieldName ) || [];
 		const isError = ! isEmpty( errorMessage );
 
-		return PAYMENT_PROCESSOR_EBANX_COUNTRIES[ this.props.countryCode ].fields.indexOf( fieldName ) > -1
+		return PAYMENT_PROCESSOR_EBANX_COUNTRIES[ this.props.countryCode ].fields.indexOf( fieldName ) >
+			-1
 			? React.createElement(
-				componentClass,
-				Object.assign(
-					{},
-					{
-						additionalClasses: `checkout__form-field ${ this.props.fieldClassName }`,
-						isError,
-						errorMessage: errorMessage[ 0 ],
-						name: fieldName,
-						onBlur: this.onFieldChange,
-						onChange: this.onFieldChange,
-						value: this.props.getFieldValue( fieldName ),
-						autoComplete: 'off',
-						labelClass: 'checkout__form-label',
-					},
-					props )
-			) : null;
+					componentClass,
+					Object.assign(
+						{},
+						{
+							additionalClasses: `checkout__checkout-field ${ this.props.fieldClassName }`,
+							isError,
+							errorMessage: errorMessage[ 0 ],
+							name: fieldName,
+							onBlur: this.onFieldChange,
+							onChange: this.onFieldChange,
+							value: this.props.getFieldValue( fieldName ),
+							autoComplete: 'off',
+							labelClass: 'checkout__form-label',
+						},
+						props
+					)
+				)
+			: null;
 	};
 
 	handlePhoneFieldChange = ( { value, countryCode } ) => {
@@ -71,7 +74,7 @@ export class EbanxPaymentFields extends Component {
 		this.props.handleFieldChange( event.target.name, event.target.value );
 	};
 
-	renderFields() {
+	render() {
 		const { translate, countriesList, countryCode } = this.props;
 		const { userSelectedPhoneCountryCode } = this.state;
 		const countryData = find( countriesList.get(), { code: countryCode } );
@@ -88,68 +91,64 @@ export class EbanxPaymentFields extends Component {
 				}
 			);
 		}
-		return [
-			<span key="ebanx-required-fields" className="checkout__form-info-text">
-				{ ebanxMessage }
-			</span>,
+		return (
+			<div className="checkout__ebanx-payment-fields">
+				<span key="ebanx-required-fields" className="checkout__form-info-text">
+					{ ebanxMessage }
+				</span>
 
-			this.createField( 'document', Input, {
-				label: translate( 'Taxpayer Identification Number', {
-					comment:
-						'Individual taxpayer registry identification required ' +
-						'for Brazilian payment methods on credit card form',
-				} ),
-				key: 'document',
-			} ),
-
-			this.createField( 'phone-number', FormPhoneMediaInput, {
-				onChange: this.handlePhoneFieldChange,
-				countriesList,
-				// If the user has manually selected a country for the phone
-				// number, use that, but otherwise default this to the same
-				// country as the billing address.
-				countryCode: userSelectedPhoneCountryCode || countryCode,
-				label: translate( 'Phone' ),
-				key: 'phone-number',
-			} ),
-
-			this.createField( 'address-1', Input, {
-				maxLength: 40,
-				label: translate( 'Address' ),
-				key: 'address-1',
-			} ),
-
-			this.createField( 'street-number', Input, {
-				inputMode: 'numeric',
-				label: translate( 'Street Number', {
-					comment: 'Street number associated with address on credit card form',
-				} ),
-				key: 'street-number',
-			} ),
-
-			this.createField( 'address-2', HiddenInput, {
-				maxLength: 40,
-				label: translate( 'Address Line 2' ),
-				text: translate( '+ Add Address Line 2' ),
-				key: 'address-2',
-			} ),
-
-			this.createField( 'city', Input, {
-				label: translate( 'City' ),
-				key: 'city',
-			} ),
-
-			<div className="checkout__form-state-field" key="state">
-				{ this.createField( 'state', StateSelect, {
-					countryCode: countryCode,
-					label: translate( 'State' ),
+				{ this.createField( 'document', Input, {
+					label: translate( 'Taxpayer Identification Number', {
+						comment:
+							'Individual taxpayer registry identification required ' +
+							'for Brazilian payment methods on credit card form',
+					} ),
 				} ) }
-			</div>,
-		];
-	}
 
-	render() {
-		return <React.Fragment>{ this.renderFields() }</React.Fragment>;
+				{ this.createField( 'phone-number', FormPhoneMediaInput, {
+					onChange: this.handlePhoneFieldChange,
+					countriesList,
+					// If the user has manually selected a country for the phone
+					// number, use that, but otherwise default this to the same
+					// country as the billing address.
+					countryCode: userSelectedPhoneCountryCode || countryCode,
+					label: translate( 'Phone' ),
+				} ) }
+
+				{ this.createField( 'address-1', Input, {
+					maxLength: 40,
+					label: translate( 'Address' ),
+				} ) }
+
+				{ this.createField( 'street-number', Input, {
+					inputMode: 'numeric',
+					label: translate( 'Street Number', {
+						comment: 'Street number associated with address on credit card form',
+					} ),
+				} ) }
+
+				{ this.createField( 'address-2', HiddenInput, {
+					maxLength: 40,
+					label: translate( 'Address Line 2' ),
+					text: translate( '+ Add Address Line 2' ),
+				} ) }
+
+				{ this.createField( 'city', Input, {
+					label: translate( 'City' ),
+				} ) }
+
+				<div className="checkout__form-state-field">
+					{ this.createField( 'state', StateSelect, {
+						countryCode: countryCode,
+						label: translate( 'State' ),
+					} ) }
+				</div>
+
+				{ this.createField( 'postal-code', Input, {
+					label: translate( 'Postal Code' ),
+				} ) }
+			</div>
+		);
 	}
 }
 

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -318,6 +318,7 @@
 		.payment-box-section.selected:not( .no-stored-cards ) {
 			.payment-box-section-inner {
 				border-left: 3px solid $alert-green;
+				padding-top: 15px;
 			}
 			.checkout__new-card-fields {
 				background-color: #fafdf6;

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -347,7 +347,6 @@
 		.payment-box-section.selected .checkout__new-card-fields {
 			max-height: 100%;
 			margin-bottom: 0;
-			padding-top: 15px;
 		}
 
 		.checkout__new-card-toggle {
@@ -882,10 +881,51 @@
 	}
 }
 
-.checkout__form-state-field {
-	flex-basis: calc( 100% );
+// Ebanx checkout fields
+// -----------------------------------
+.checkout__ebanx-payment-fields {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	margin: 15px 0 0 -15px;
+	.checkout__checkout-field,
+	.checkout__form-state-field {
+		flex-basis: calc( 100% - 15px );
+		flex-grow: 1;
+		flex-shrink: 0;
+		margin-left: 15px;
+	}
+	.checkout__form-state-field {
+		margin-left: 0;
+	}
 	@include breakpoint( '>480px' ) {
-		flex-basis: calc( 50% - 15px );
+		.address-2,
+		.city {
+			flex-basis: calc( 100% - 15px );
+		}
+
+		.street-number {
+			flex-basis: calc( 33% - 15px);
+		}
+
+		.address-1 {
+			flex-basis: calc( 66% - 15px);
+		}
+
+		.document,
+		.phone,
+		.postal-code,
+		.checkout__form-state-field {
+			flex-basis: calc( 50% - 15px );
+		}
+	}
+	.form__hidden-input a {
+		display: block;
+		font-size:  12px;
+		margin-left: 15px;
+	}
+	select {
+		width: 100%;
 	}
 }
 

--- a/client/my-sites/checkout/checkout/test/__snapshots__/ebanx-payment-fields.js.snap
+++ b/client/my-sites/checkout/checkout/test/__snapshots__/ebanx-payment-fields.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<EbanxPaymentFields /> should render 1`] = `
-<React.Fragment>
+<div
+  className="checkout__ebanx-payment-fields"
+>
   <span
     className="checkout__form-info-text"
     key="ebanx-required-fields"
@@ -9,11 +11,10 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     The following fields are also required for payments in %(countryName)s
   </span>
   <Input
-    additionalClasses="checkout__form-field ebanx-brazil"
+    additionalClasses="checkout__checkout-field ebanx-brazil"
     autoComplete="off"
     autoFocus={false}
     isError={false}
-    key="document"
     label="Taxpayer Identification Number"
     labelClass="checkout__form-label"
     name="document"
@@ -21,7 +22,7 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     onChange={[Function]}
   />
   <FormPhoneMediaInput
-    additionalClasses="checkout__form-field ebanx-brazil"
+    additionalClasses="checkout__checkout-field ebanx-brazil"
     autoComplete="off"
     countriesList={
       Object {
@@ -30,7 +31,6 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     }
     countryCode="BR"
     isError={false}
-    key="phone-number"
     label="Phone"
     labelClass="checkout__form-label"
     name="phone-number"
@@ -38,11 +38,10 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     onChange={[Function]}
   />
   <Input
-    additionalClasses="checkout__form-field ebanx-brazil"
+    additionalClasses="checkout__checkout-field ebanx-brazil"
     autoComplete="off"
     autoFocus={false}
     isError={false}
-    key="address-1"
     label="Address"
     labelClass="checkout__form-label"
     maxLength={40}
@@ -51,12 +50,11 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     onChange={[Function]}
   />
   <Input
-    additionalClasses="checkout__form-field ebanx-brazil"
+    additionalClasses="checkout__checkout-field ebanx-brazil"
     autoComplete="off"
     autoFocus={false}
     inputMode="numeric"
     isError={false}
-    key="street-number"
     label="Street Number"
     labelClass="checkout__form-label"
     name="street-number"
@@ -64,10 +62,9 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     onChange={[Function]}
   />
   <HiddenInput
-    additionalClasses="checkout__form-field ebanx-brazil"
+    additionalClasses="checkout__checkout-field ebanx-brazil"
     autoComplete="off"
     isError={false}
-    key="address-2"
     label="Address Line 2"
     labelClass="checkout__form-label"
     maxLength={40}
@@ -77,11 +74,10 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     text="+ Add Address Line 2"
   />
   <Input
-    additionalClasses="checkout__form-field ebanx-brazil"
+    additionalClasses="checkout__checkout-field ebanx-brazil"
     autoComplete="off"
     autoFocus={false}
     isError={false}
-    key="city"
     label="City"
     labelClass="checkout__form-label"
     name="city"
@@ -90,10 +86,9 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
   />
   <div
     className="checkout__form-state-field"
-    key="state"
   >
     <Connect(Localized(StateSelect))
-      additionalClasses="checkout__form-field ebanx-brazil"
+      additionalClasses="checkout__checkout-field ebanx-brazil"
       autoComplete="off"
       countryCode="BR"
       isError={false}
@@ -104,5 +99,16 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
       onChange={[Function]}
     />
   </div>
-</React.Fragment>
+  <Input
+    additionalClasses="checkout__checkout-field ebanx-brazil"
+    autoComplete="off"
+    autoFocus={false}
+    isError={false}
+    label="Postal Code"
+    labelClass="checkout__form-label"
+    name="postal-code"
+    onBlur={[Function]}
+    onChange={[Function]}
+  />
+</div>
 `;


### PR DESCRIPTION
This PR addresses an omission in #24095, whereby the abstracted Ebanx component does not contain the required postal code field.

The inevitable result is that reusing the component won't contain all the [required Ebanx fields](https://developers.ebanx.com/api-reference/full-api-documentation/ebanx-payment-2/ebanx-payment-guide/guide-create-a-payment/brazil/).

## Screenshot

<img width="748" alt="screen shot 2018-04-12 at 4 45 49 pm" src="https://user-images.githubusercontent.com/6458278/38660563-055ee0d6-3e71-11e8-8588-8374e9c6a1fb.png">

## Testing
1. Set your currency to 'BRL'
2. Add something to your cart and head to checkout
3. At the payment step, without entering any data, attempt to submit
4. Select 'Brazil' as your country
5. Without entering any data, attempt to submit
6. Fill in credit card information (use a dummy card no#) and Ebanx fields (a valid tax code is `111.444.777-35`)

### Expectations
**At 3**: You should see the normal credit card fields (including the post code field)
**At 4**: You should see the Ebanx extra fields
**At 5**: The fields should show validation messages 
**At 6**: Valid form data should permit payment attempt
