### PR TITLE
Enable 2-year subscriptions in certain environments

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -169,7 +169,7 @@
 		"try/single-cdn": true,
 		"ui/first-view": true,
 		"ui/first-view/reset-route": true,
-		"upgrades/2-year-plans": false,
+		"upgrades/2-year-plans": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/config/test.json
+++ b/config/test.json
@@ -96,7 +96,7 @@
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": false,
-		"upgrades/2-year-plans": false,
+		"upgrades/2-year-plans": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -141,7 +141,7 @@
 		"try/single-cdn": true,
 		"ui/first-view": true,
 		"ui/first-view/reset-route": true,
-		"upgrades/2-year-plans": false,
+		"upgrades/2-year-plans": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,


### PR DESCRIPTION
This PR is related to 2-year plans (p9jf6J-eR-p2). We are moving closer to testing and it's time to enable the feature in the following environments:
* development
* test
* wpcalypso