### PR TITLE
Path to Section: rank matches on matched string length

### DIFF
--- a/client/lib/path-to-section/index.js
+++ b/client/lib/path-to-section/index.js
@@ -5,7 +5,7 @@
  */
 
 import config from 'config';
-import { find, startsWith } from 'lodash';
+import { last, max, sortBy, startsWith } from 'lodash';
 
 /**
  * Conditional dependency
@@ -17,15 +17,19 @@ const sections = config( 'project' ) === 'wordpress-com' ? require( 'wordpress-c
  *
  *  f( '/' ) === 'reader"
  *  f( '/me' ) === 'me"
- *  f( '/me/account' ) === 'me"
+ *  f( '/me/account' ) === 'account"
  *  f( '/read' ) === 'reader'
  */
 export const wpcomImplementation = path => {
-	const match = find( sections, section =>
-		section.paths.some( sectionPath => startsWith( path, sectionPath ) )
+	// rank matches by the number of characters that match so e.g. /media won't map to /me
+	const rankedMatches = sortBy( sections, section =>
+		max(
+			section.paths.map(
+				sectionPath => ( startsWith( path, sectionPath ) ? sectionPath.length : 0 )
+			)
+		)
 	);
-
-	return match && match.name;
+	return rankedMatches && last( rankedMatches ) && last( rankedMatches ).name;
 };
 
 /*

--- a/client/lib/path-to-section/index.js
+++ b/client/lib/path-to-section/index.js
@@ -5,7 +5,7 @@
  */
 
 import config from 'config';
-import { last, max, sortBy, startsWith } from 'lodash';
+import { filter, get, max, maxBy, startsWith } from 'lodash';
 
 /**
  * Conditional dependency
@@ -22,14 +22,24 @@ const sections = config( 'project' ) === 'wordpress-com' ? require( 'wordpress-c
  */
 export const wpcomImplementation = path => {
 	// rank matches by the number of characters that match so e.g. /media won't map to /me
-	const rankedMatches = sortBy( sections, section =>
+	const bestMatch = maxBy( sections, section =>
 		max(
 			section.paths.map(
 				sectionPath => ( startsWith( path, sectionPath ) ? sectionPath.length : 0 )
 			)
 		)
 	);
-	return rankedMatches && last( rankedMatches ) && last( rankedMatches ).name;
+
+	// sort out special case we don't want to match: matching on '/' but path isn't exactly '/'
+	const matchingPaths = filter( bestMatch.paths, sectionPath => startsWith( path, sectionPath ) );
+	if ( matchingPaths.length === 1 && matchingPaths[ 0 ] === '/' && path !== '/' ) {
+		return null;
+	}
+	// make sure the best match is actually a match (in case nothing matches)
+	if ( bestMatch.paths.some( sectionPath => startsWith( path, sectionPath ) ) ) {
+		return get( bestMatch, 'name' );
+	}
+	return null;
 };
 
 /*

--- a/client/lib/path-to-section/test/index.js
+++ b/client/lib/path-to-section/test/index.js
@@ -27,6 +27,9 @@ describe( 'pathToSection', () => {
 		test( 'should handle deep paths', () => {
 			expect( wpcomImplementation( '/me/account' ) ).to.equal( 'account' );
 		} );
+		test( 'should return null if unsuccessful', () => {
+			expect( wpcomImplementation( '/a-nonexistent-path' ) ).to.equal( null );
+		} );
 	} );
 
 	describe( 'fallbackImplementation', () => {

--- a/client/lib/path-to-section/test/index.js
+++ b/client/lib/path-to-section/test/index.js
@@ -25,7 +25,7 @@ describe( 'pathToSection', () => {
 			expect( wpcomImplementation( '/me' ) ).to.equal( 'me' );
 		} );
 		test( 'should handle deep paths', () => {
-			expect( wpcomImplementation( '/me/account' ) ).to.equal( 'me' );
+			expect( wpcomImplementation( '/me/account' ) ).to.equal( 'account' );
 		} );
 	} );
 

--- a/client/lib/path-to-section/test/index.js
+++ b/client/lib/path-to-section/test/index.js
@@ -21,6 +21,8 @@ describe( 'pathToSection', () => {
 		test( 'should correctly associate paths that start with the same string', () => {
 			expect( wpcomImplementation( '/themes' ) ).to.equal( 'themes' );
 			expect( wpcomImplementation( '/theme' ) ).to.equal( 'theme' );
+			expect( wpcomImplementation( '/media' ) ).to.equal( 'media' );
+			expect( wpcomImplementation( '/me' ) ).to.equal( 'me' );
 		} );
 		test( 'should handle deep paths', () => {
 			expect( wpcomImplementation( '/me/account' ) ).to.equal( 'me' );


### PR DESCRIPTION
The Guided Tours framework uses `pathToSection` to map a URL to a Calypso section. Previously, it failed for deeper paths (`/me/account` was matched to `me` instead of `account`) and failed for paths started with the same substring (`/media` was matched to `me` instead of `media`). 

This PR adds failing tests for both issues in ba11c42 and 213772b and fixes it in 2026aa7.

To test:
- read and run the test and make sure the result is what you'd expect (e.g. `npm run test-client client/lib/path-to-section/test/index.js`). make sure the tests fail as expected when you remove the fix. 