### PR TITLE
Jetpack connect: Use makeJsonSchemaParser

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -5,7 +5,7 @@
 import React from 'react';
 import Debug from 'debug';
 import page from 'page';
-import { get, isEmpty, some } from 'lodash';
+import { get, includes, isEmpty, some } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -235,7 +235,7 @@ export function signupForm( context, next ) {
 		let { interval, locale } = context.params;
 		const { localeOrInterval } = context.params;
 		if ( localeOrInterval ) {
-			if ( [ 'monthly', 'yearly' ].indexOf( context.params.localeOrInterval ) >= 0 ) {
+			if ( includes( [ 'monthly', 'yearly' ], localeOrInterval ) ) {
 				interval = localeOrInterval;
 			} else {
 				locale = localeOrInterval;

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -5,7 +5,7 @@
 import React from 'react';
 import Debug from 'debug';
 import page from 'page';
-import { get, includes, isEmpty, some } from 'lodash';
+import { get, isEmpty, some } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -232,13 +232,13 @@ export function signupForm( context, next ) {
 	if ( transformedQuery ) {
 		context.store.dispatch( startAuthorizeStep( transformedQuery.clientId ) );
 
-		let { interval, locale } = context.params;
-		const { localeOrInterval } = context.params;
-		if ( localeOrInterval ) {
-			if ( includes( [ 'monthly', 'yearly' ], localeOrInterval ) ) {
-				interval = localeOrInterval;
+		let interval = context.params.interval;
+		let locale = context.params.locale;
+		if ( context.params.localeOrInterval ) {
+			if ( [ 'monthly', 'yearly' ].indexOf( context.params.localeOrInterval ) >= 0 ) {
+				interval = context.params.localeOrInterval;
 			} else {
-				locale = localeOrInterval;
+				locale = context.params.localeOrInterval;
 			}
 		}
 		context.primary = (

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -20,20 +20,18 @@ import JetpackConnect from './main';
 import JetpackNewSite from './jetpack-new-site/index';
 import JetpackSignup from './signup';
 import JetpackSsoForm from './sso';
-import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import NoDirectAccessError from './no-direct-access-error';
 import OrgCredentialsForm from './remote-credentials';
 import Plans from './plans';
 import PlansLanding from './plans-landing';
 import versionCompare from 'lib/version-compare';
 import { addQueryArgs, externalRedirect, sectionify } from 'lib/route';
-import { authorizeQueryDataSchema } from './schema';
-import { authQueryTransformer } from './utils';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getLocaleFromPath, removeLocaleFromPath } from 'lib/i18n-utils';
 import { hideMasterbar, setSection, showMasterbar } from 'state/ui/actions';
 import { JPC_PATH_PLANS, MOBILE_APP_REDIRECT_URL_WHITELIST } from './constants';
 import { login } from 'lib/paths';
+import { parseAuthorizationQuery } from './utils';
 import { persistMobileRedirect, retrieveMobileRedirect, storePlan } from './persistence-utils';
 import { receiveJetpackOnboardingCredentials } from 'state/jetpack/onboarding/actions';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
@@ -87,30 +85,6 @@ const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
 
 	return get( planSlugs, [ interval, type ], '' );
 };
-
-/**
- * !! Private !!
- *
- * Lazy initialized authorization query parser.
- */
-let _authQueryParser = null;
-/**
- * Parse an authorization query
- *
- * @param  {Object}  query Authorization query
- * @return {?Object}       Query after transformation. Null if invalid or errored during transform.
- */
-function parseAuthorizationQuery( query ) {
-	if ( null === _authQueryParser ) {
-		_authQueryParser = makeJsonSchemaParser( authorizeQueryDataSchema, {}, authQueryTransformer );
-	}
-	try {
-		return _authQueryParser( query );
-	} catch ( error ) {
-		// The parser is expected to throw SchemaError or TransformerError on bad input.
-	}
-	return null;
-}
 
 export function redirectWithoutLocaleIfLoggedIn( context, next ) {
 	const isLoggedIn = !! getCurrentUserId( context.store.getState() );

--- a/client/jetpack-connect/test/__snapshots__/utils.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/utils.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parseAuthorizationQuery should return transformed data on valid input 1`] = `
+Object {
+  "alreadyAuthorized": false,
+  "authApproved": false,
+  "blogname": "Just Another WordPress.com Site",
+  "clientId": 12345,
+  "from": "[unknown]",
+  "homeUrl": "http://yourjetpack.blog",
+  "jpVersion": null,
+  "nonce": "foobar",
+  "partnerId": null,
+  "redirectAfterAuth": null,
+  "redirectUri": "http://yourjetpack.blog/wp-admin/admin.php",
+  "scope": "administrator:34579bf2a3185a47d1b31aab30125d",
+  "secret": "640fdbd69f96a8ca9e61",
+  "site": "http://yourjetpack.blog",
+  "siteIcon": null,
+  "siteUrl": "http://yourjetpack.blog",
+  "state": "1",
+  "userEmail": null,
+}
+`;

--- a/client/jetpack-connect/test/utils.js
+++ b/client/jetpack-connect/test/utils.js
@@ -3,7 +3,12 @@
 /**
  * Internal dependencies
  */
-import { addCalypsoEnvQueryArg, cleanUrl, getRoleFromScope } from '../utils';
+import {
+	addCalypsoEnvQueryArg,
+	cleanUrl,
+	getRoleFromScope,
+	parseAuthorizationQuery,
+} from '../utils';
 
 jest.mock( 'config', () => input => {
 	const lookupTable = {
@@ -58,5 +63,29 @@ describe( 'getRoleFromScope', () => {
 	test( 'should return null if scope is malformed', () => {
 		const result = getRoleFromScope( 'rolee8ae7346d1a0f800b64e' );
 		expect( result ).toBe( null );
+	} );
+} );
+
+describe( 'parseAuthorizationQuery', () => {
+	test( 'should return transformed data on valid input', () => {
+		const data = {
+			_wp_nonce: 'foobar',
+			blogname: 'Just Another WordPress.com Site',
+			client_id: '12345',
+			home_url: 'http://yourjetpack.blog',
+			redirect_uri: 'http://yourjetpack.blog/wp-admin/admin.php',
+			scope: 'administrator:34579bf2a3185a47d1b31aab30125d',
+			secret: '640fdbd69f96a8ca9e61',
+			site: 'http://yourjetpack.blog',
+			site_url: 'http://yourjetpack.blog',
+			state: '1',
+		};
+		const result = parseAuthorizationQuery( data );
+		expect( result ).not.toBeNull();
+		expect( result ).toMatchSnapshot();
+	} );
+
+	test( 'should return null data on valid input', () => {
+		expect( parseAuthorizationQuery( {} ) ).toBeNull();
 	} );
 } );

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -3,7 +3,9 @@
  * External dependencies
  */
 import config from 'config';
+import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import PropTypes from 'prop-types';
+import { authorizeQueryDataSchema } from './schema';
 import { head, includes, isEmpty, split } from 'lodash';
 
 /**
@@ -99,6 +101,28 @@ export function getRoleFromScope( scope ) {
 	const role = head( split( scope, ':', 1 ) );
 	if ( ! isEmpty( role ) ) {
 		return role;
+	}
+	return null;
+}
+
+/**
+ * Parse an authorization query
+ *
+ * @property {Function} parser Lazy-instatiated parser
+ * @param  {Object}     query  Authorization query
+ * @return {?Object}           Query after transformation. Null if invalid or errored during transform.
+ */
+export function parseAuthorizationQuery( query ) {
+	if ( ! parseAuthorizationQuery.parser ) {
+		parseAuthorizationQuery.parser = makeJsonSchemaParser(
+			authorizeQueryDataSchema,
+			authQueryTransformer
+		);
+	}
+	try {
+		return parseAuthorizationQuery.parser( query );
+	} catch ( error ) {
+		// The parser is expected to throw SchemaError or TransformerError on bad input.
 	}
 	return null;
 }


### PR DESCRIPTION
A parser was being used without using the parser lib. After #24288 ✅, we'll be able to leverage makeJsonSchemaParser, which is much nicer.

This PR also abstracts some duplicated logic into a function what wraps the parser, as well as lazy initialization for the parser.

No functional changes.

## Testing
1. Go through an authorization flow logged in and logged out. Technically a logged out flow should cover everything.
1. Everything should behave normally.
1. Ensure that you seen the warning here https://calypso.live/jetpack/connect/authorize?branch=update/jpc-make-parser