### PR TITLE
JP Remote Install: Handle new INVALID_CREDENTIALS error from API

### DIFF
--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -168,7 +168,7 @@ export class OrgCredentialsForm extends Component {
 		) {
 			return ACTIVATION_FAILURE;
 		}
-		if ( installError === 'LOGIN_FAILURE' ) {
+		if ( installError === 'LOGIN_FAILURE' || installError === 'INVALID_CREDENTIALS' ) {
 			return LOGIN_FAILURE;
 		}
 		if ( installError === 'ACTIVATION_RESPONSE_ERROR' ) {


### PR DESCRIPTION
No visual differences.

This PR will allow server-side patch D11976-code to be deployed with breaking anything on the client-side. D11976-code introduces a new error type, INVALID_CREDENTIALS, which will allow us to improve error messages in #24298 once the patch has been deployed.

## Testing
