### PR TITLE
2 year plans: Add A/B test for multiyear subscriptions

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,5 +1,15 @@
 /** @format */
 export default {
+	multiyearSubscriptions: {
+		datestamp: '20180417',
+		variations: {
+			show: 50,
+			hide: 50,
+		},
+		defaultVariation: 'hide',
+		allowExistingUsers: true,
+		localeTargets: 'any',
+	},
 	springSale30PercentOff: {
 		datestamp: '20180413',
 		variations: {

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -11,6 +11,7 @@ import { compact, includes } from 'lodash';
 /**
  * Internal dependencies
  */
+
 import { isEnabled } from 'config';
 import { isBusinessPlan, isFreePlan, isPersonalPlan, isPremiumPlan } from './index';
 
@@ -159,13 +160,15 @@ export const TYPE_PREMIUM = 'TYPE_PREMIUM';
 export const TYPE_BUSINESS = 'TYPE_BUSINESS';
 
 const WPComGetBillingTimeframe = abtest => {
-	if ( isEnabled( 'upgrades/2-year-plans' ) ) {
-		return i18n.translate( '/month, billed annually or biennially' );
-	}
+	if ( abtest ) {
+		if ( isEnabled( 'upgrades/2-year-plans' ) && abtest( 'multiyearSubscriptions' ) === 'show' ) {
+			return i18n.translate( '/month, billed annually or biennially' );
+		}
 
-	if ( abtest && abtest( 'upgradePricingDisplayV2' ) === 'modified' ) {
-		// Note: Don't make this translatable because it's only visible to English-language users
-		return '/month, billed annually';
+		if ( abtest( 'upgradePricingDisplayV2' ) === 'modified' ) {
+			// Note: Don't make this translatable because it's only visible to English-language users
+			return '/month, billed annually';
+		}
 	}
 	return i18n.translate( 'per month, billed yearly' );
 };

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -499,7 +499,9 @@ class Checkout extends React.Component {
 				handleCheckoutCompleteRedirect={ this.handleCheckoutCompleteRedirect }
 				handleCheckoutExternalRedirect={ this.handleCheckoutExternalRedirect }
 			>
-				{ config.isEnabled( 'upgrades/2-year-plans' ) && this.renderSubscriptionLengthPicker() }
+				{ config.isEnabled( 'upgrades/2-year-plans' ) &&
+					abtest( 'multiyearSubscriptions' ) === 'show' &&
+					this.renderSubscriptionLengthPicker() }
 			</SecurePaymentForm>
 		);
 	}

--- a/client/my-sites/checkout/checkout/secure-payment-form-placeholder.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form-placeholder.jsx
@@ -10,8 +10,8 @@ import config from 'config';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import PaymentBox from './payment-box.jsx';
-import { abtest } from '../../../lib/abtest';
 
 const SecurePaymentFormPlaceholder = () => {
 	/*eslint-disable wpcalypso/jsx-classname-namespace */

--- a/client/my-sites/checkout/checkout/secure-payment-form-placeholder.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form-placeholder.jsx
@@ -11,6 +11,7 @@ import config from 'config';
  * Internal dependencies
  */
 import PaymentBox from './payment-box.jsx';
+import { abtest } from '../../../lib/abtest';
 
 const SecurePaymentFormPlaceholder = () => {
 	/*eslint-disable wpcalypso/jsx-classname-namespace */
@@ -30,16 +31,17 @@ const SecurePaymentFormPlaceholder = () => {
 				</div>
 				<div className="placeholder-row placeholder" />
 			</div>
-			{ config.isEnabled( 'upgrades/2-year-plans' ) && (
-				<div className="payment-box-section">
-					<div className="placeholder-col-narrow placeholder-inline-pad">
-						<div className="placeholder" />
+			{ config.isEnabled( 'upgrades/2-year-plans' ) &&
+				abtest( 'multiyearSubscriptions' ) === 'show' && (
+					<div className="payment-box-section">
+						<div className="placeholder-col-narrow placeholder-inline-pad">
+							<div className="placeholder" />
+						</div>
+						<div className="placeholder-col-narrow">
+							<div className="placeholder" />
+						</div>
 					</div>
-					<div className="placeholder-col-narrow">
-						<div className="placeholder" />
-					</div>
-				</div>
-			) }
+				) }
 			<div className="payment-box-hr" />
 			<div className="placeholder-button-container">
 				<div className="placeholder-col-narrow">

--- a/client/my-sites/plans/plans.js
+++ b/client/my-sites/plans/plans.js
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 /**
  * Internal Dependencies
  */
+import { abtest } from 'lib/abtest';
 import config from 'config';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import getIntervalTypeForTerm from 'lib/plans/get-interval-type-for-term';
@@ -17,7 +18,11 @@ import Plans from 'my-sites/plans/main';
 export default connect( ( state, { intervalType } ) => {
 	// For WP.com plans page, if intervalType is not explicitly specified in the URL,
 	// we want to show plans of the same term as plan that is currently active
-	if ( ! intervalType && config.isEnabled( 'upgrades/2-year-plans' ) ) {
+	if (
+		! intervalType &&
+		config.isEnabled( 'upgrades/2-year-plans' ) &&
+		abtest( 'multiyearSubscriptions' ) === 'show'
+	) {
 		const selectedSiteId = getSelectedSiteId( state );
 		intervalType = getIntervalTypeForTerm( getCurrentPlanTerm( state, selectedSiteId ) );
 	}


### PR DESCRIPTION
This PR is related to 2-year plans (p9jf6J-eR-p2), it adds an A/B test and only makes the feature available when it's enabled AND when user is qualified to the right test group.

Test plan:
* Run unit tests
* Run `ENABLE_FEATURES=upgrades/2-year-plans npm run start`
* Enter `show` group of `multiyearSubscriptions` test:

<img width="411" alt="zrzut ekranu 2018-04-16 o 13 54 33" src="https://user-images.githubusercontent.com/205419/38931250-c69fbcca-4312-11e8-8a54-2b1b3896aa88.png">

* Try to order any plan and confirm the checkout page looks like this:

<img width="793" alt="zrzut ekranu 2018-04-18 o 14 15 41" src="https://user-images.githubusercontent.com/205419/38931298-fca3208c-4312-11e8-8c1a-039e89114ddf.png">

* Enter `hide` group of `multiyearSubscriptions` test.
* Try to order any plan and confirm the checkout page looks like this:

<img width="790" alt="zrzut ekranu 2018-04-18 o 14 15 07" src="https://user-images.githubusercontent.com/205419/38931292-f57d2154-4312-11e8-94da-5733b48d92f5.png">
