### PR TITLE
Plans: Fix non-Jetpack monthly redirect

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -53,10 +53,15 @@ class Plans extends React.Component {
 		this.redirectIfNonJetpackMonthly();
 	}
 
-	redirectIfNonJetpackMonthly = () => {
+	isNonJetpackMonthly() {
 		const { displayJetpackPlans, intervalType, selectedSite } = this.props;
+		return selectedSite && ! displayJetpackPlans && intervalType === 'monthly';
+	}
 
-		if ( selectedSite && ! displayJetpackPlans && intervalType === 'monthly' ) {
+	redirectIfNonJetpackMonthly = () => {
+		const { selectedSite } = this.props;
+
+		if ( this.isNonJetpackMonthly() ) {
 			page.redirect( '/plans/' + selectedSite.slug );
 		}
 	};
@@ -77,7 +82,7 @@ class Plans extends React.Component {
 	render() {
 		const { selectedSite, translate, displayJetpackPlans } = this.props;
 
-		if ( ! selectedSite ) {
+		if ( ! selectedSite || this.isNonJetpackMonthly() ) {
 			return this.renderPlaceholder();
 		}
 

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -58,13 +58,13 @@ class Plans extends React.Component {
 		return selectedSite && ! displayJetpackPlans && intervalType === 'monthly';
 	}
 
-	redirectIfNonJetpackMonthly = () => {
+	redirectIfNonJetpackMonthly() {
 		const { selectedSite } = this.props;
 
 		if ( this.isNonJetpackMonthly() ) {
 			page.redirect( '/plans/' + selectedSite.slug );
 		}
-	};
+	}
 
 	renderPlaceholder = () => {
 		return (


### PR DESCRIPTION
While testing #24289, I noticed that the redirect we had placed when going from a monthly JP plans page to a .com plans page doesn't work properly.

To repro:
* Visit `https://wordpress.com/plans/monthly/:site` where `:site` is a .com site.

or:

* Go to `https://wordpress.com/plans/monthly/:site`, where `:site is a Jetpack site.
* Click on "Switch site" in the sidebar.
* Select a .com site.
* Witness an error.

This PR fixes the issue by preventing unexpected rendering for the case where we're trying to render a monthly plans page for a non-Jetpack site.

To test:
1. Checkout this branch.
2. Visit `http://calypso.localhost:3000/plans/monthly/:site` where `:site` is a .com site.
3. Verify you're redirected to `http://calypso.localhost:3000/plans/:site` and the page loads correctly.
4. Visit `http://calypso.localhost:3000/plans/monthly/:site`, where `:site is a Jetpack site.
5. Click on "Switch site" in the sidebar.
6. Select a .com site.
7. Verify you're redirected to `http://calypso.localhost:3000/plans/:site` and the page loads correctly.
8. Verify Jetpack plans pages still load correctly like before (both monthly and yearly).
8. Try each of the above sets of steps (2, 3-7, 8) with a clean Redux store.