### PR TITLE
Reader: Make a8c tracks events compliant

### DIFF
--- a/client/reader/conversations/controller.js
+++ b/client/reader/conversations/controller.js
@@ -44,7 +44,7 @@ export function conversationsA8c( context, next ) {
 	const title = 'Reader > Conversations > Automattic';
 
 	trackPageLoad( basePath, 'Reader > Conversations > Automattic', mcKey );
-	recordTrack( 'calypso_reader_conversations_a8c_viewed' );
+	recordTrack( 'calypso_reader_conversations_automattic_viewed' );
 
 	const convoStream = feedStreamStore( 'conversations-a8c' );
 	ensureStoreLoading( convoStream, context );

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -120,7 +120,7 @@ export const ReaderSidebar = createReactClass( {
 	handleReaderSidebarA8cConversationsClicked() {
 		recordAction( 'clicked_reader_sidebar_a8c_conversations' );
 		recordGaEvent( 'Clicked Reader Sidebar A8C Conversations' );
-		recordTrack( 'calypso_reader_sidebar_a8c_conversations_clicked' );
+		recordTrack( 'calypso_reader_sidebar_automattic_conversations_clicked' );
 	},
 
 	handleReaderSidebarDiscoverClicked() {


### PR DESCRIPTION
Tracks event names cannot contain numbers. Spell it out instead.