### PR TITLE
SiteAddressChanger: Update tracking event naming

### DIFF
--- a/client/blocks/simple-site-rename-form/dialog.jsx
+++ b/client/blocks/simple-site-rename-form/dialog.jsx
@@ -86,7 +86,7 @@ class SiteRenamerConfirmationDialog extends PureComponent {
 				onClose={ this.onClose }
 			>
 				<TrackComponentView
-					eventName="calypso_siterename_areyousure_view"
+					eventName="calypso_siteaddresschange_areyousure_view"
 					eventProperties={ { new_domain: newDomainName } }
 				/>
 				<h1>{ translate( "Let's review…" ) }</h1>

--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -228,7 +228,7 @@ export class SimpleSiteRenameForm extends Component {
 					onConfirm={ this.onConfirm }
 				/>
 				<form onSubmit={ this.onSubmit }>
-					<TrackComponentView eventName="calypso_siterename_form_view" />
+					<TrackComponentView eventName="calypso_siteaddresschange_form_view" />
 					<Card className="simple-site-rename-form__content">
 						<FormSectionHeading>{ translate( 'Change Site Address' ) }</FormSectionHeading>
 						<FormTextInputWithAffixes

--- a/client/state/site-rename/actions.js
+++ b/client/state/site-rename/actions.js
@@ -109,7 +109,7 @@ export const requestSiteRename = ( siteId, newBlogName, discard ) => dispatch =>
 
 	const errorHandler = error => {
 		dispatch(
-			recordTracksEvent( 'calypso_siterename_error', {
+			recordTracksEvent( 'calypso_siteaddresschange_error', {
 				...eventProperties,
 				error_code: error.code,
 			} )
@@ -122,7 +122,7 @@ export const requestSiteRename = ( siteId, newBlogName, discard ) => dispatch =>
 		} );
 	};
 
-	dispatch( recordTracksEvent( 'calypso_siterename_request', eventProperties ) );
+	dispatch( recordTracksEvent( 'calypso_siteaddresschange_request', eventProperties ) );
 
 	return fetchNonce( siteId )
 		.then( nonce => {
@@ -133,7 +133,7 @@ export const requestSiteRename = ( siteId, newBlogName, discard ) => dispatch =>
 					const newSlug = get( data, 'new_slug' );
 
 					if ( newSlug ) {
-						dispatch( recordTracksEvent( 'calypso_siterename_success', eventProperties ) );
+						dispatch( recordTracksEvent( 'calypso_siteaddresschange_success', eventProperties ) );
 
 						const newAddress = newSlug + '.wordpress.com';
 						dispatch( requestSite( siteId ) ).then( () => {


### PR DESCRIPTION
### Summary

This PR simply updates the naming of tracking labels to better match the name of the site address changer feature for the sake of clarity and consistancy.

### Testing

Follow the test plan as laid out in #22827 but ensure that all events use the new `calypso_siteaddresschange` prefix