### PR TITLE
Activity: revert Jetpack actor icon background to grey

### DIFF
--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -180,6 +180,10 @@
 			margin-right: 8px;
 		}
 	}
+
+	.jetpack-logo__icon-circle {
+		fill: $gray-darken-10;
+	}
 }
 
 .activity-log-item__actor-info {


### PR DESCRIPTION
When we made the default logo green, this actor icon inherited the green color.

This PR reverts back that change in the Activity log.

### Before

![image](https://user-images.githubusercontent.com/390760/38937626-8bba97b6-431b-11e8-98d1-325d4ba39e89.png)

### After

![image](https://user-images.githubusercontent.com/390760/38937663-981d4aa8-431b-11e8-8f4d-a6e9de86c881.png)
