### PR TITLE
Activity Log: Honor site timezone settings in date header

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -364,7 +364,7 @@ class ActivityLog extends Component {
 					return (
 						<h2 className="activity-log__time-period" key={ `time-period-${ ts }` }>
 							{ ts.isSame( today, 'day' )
-								? ts.format( translate( 'LL[ — Today]' ) )
+								? ts.format( translate( 'LL[ — Today]', { context: 'moment format string' } ) )
 								: ts.format( 'LL' ) }
 						</h2>
 					);

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -363,7 +363,9 @@ class ActivityLog extends Component {
 					last = ts;
 					return (
 						<h2 className="activity-log__time-period" key={ `time-period-${ ts }` }>
-							{ ts.isSame( today, 'day' ) ? translate( 'Today' ) : ts.format( 'LL' ) }
+							{ ts.isSame( today, 'day' )
+								? ts.format( translate( 'LL[ — Today]' ) )
+								: ts.format( 'LL' ) }
 						</h2>
 					);
 				}

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -353,16 +353,17 @@ class ActivityLog extends Component {
 		);
 
 		const timePeriod = ( () => {
+			const today = this.applySiteOffset( moment.utc( Date.now() ) );
 			let last = null;
 
 			return ( { rewindId } ) => {
-				const ts = 1000 * rewindId;
+				const ts = this.applySiteOffset( moment.utc( rewindId * 1000 ) );
 
-				if ( null === last || moment( ts ).format( 'D' ) !== moment( last ).format( 'D' ) ) {
+				if ( null === last || ! ts.isSame( last, 'day' ) ) {
 					last = ts;
 					return (
 						<h2 className="activity-log__time-period" key={ `time-period-${ ts }` }>
-							{ moment( ts ).format( 'LL' ) }
+							{ ts.isSame( today, 'day' ) ? translate( 'Today' ) : ts.format( 'LL' ) }
 						</h2>
 					);
 				}


### PR DESCRIPTION
Since the introduction of the linearized view we have been showing
date headers at the top of the list of activities and whenver a
subsequent event is on a new date. We have two issues with this
first iteration:

 - We no longer show "today" when today is the date
 - We don't respect the timezone of the site

In this patch we're fixing these issues and adjusting all of the
timestamp values based on the site's offset value.

**Testing**

We want to make sure we test day boundaries. For example, I tested
with my site set to Phoenix time at UTC-7. I used a handcrafted API
response to see when exactly it would consider the time _today_ vs
not today. Further, I adjusted the values to make sure that the switch
of the dates happens when I expected it to, at `00:07:00Z` and not
before or after.

This [gist](https://gist.github.com/dmsnell/16bd20909229a07f21db9827081f7d9f) should help fake the API response in Calypso. You can
adjust it for your site id and appropriate `rewind_id`. The `rewind_id`
controls when exactly the event is displayed. These values are the
two arguments at the bottom of that gist. Copy the code, paste it into
the developer console in a local dev environment, update the site id
and time of event, then hit enter.

**master**
<img width="607" alt="screen shot 2018-04-18 at 6 06 45 pm" src="https://user-images.githubusercontent.com/5431237/38947063-4bd85832-4333-11e8-9429-0bf911bc22db.png">


**this branch**
<img width="600" alt="screen shot 2018-04-18 at 6 00 47 pm" src="https://user-images.githubusercontent.com/5431237/38946821-8aa535ae-4332-11e8-9a54-9dc731637326.png">

You may note in the screenshots that not only is _Today_ different but the date
header is moved between different events. This is due to the timezone offset of
the site and the exact time when the "date" changes.