### PR TITLE
Atomic: add temporary service notification notice

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -82,7 +82,7 @@ class InlineHelpPopover extends Component {
 				context={ this.props.context }
 				className={ classNames( 'inline-help__popover', popoverClasses ) }
 			>
-				<Notice status="is-error" isCompact={ true }>
+				<Notice status="is-error" isCompact={ true } showDismiss={ false }>
 					{ this.props.translate(
 						'Some WordPress.com Business Sites are having connectivity problems. We are investigating the problem now.'
 					) }

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -84,7 +84,7 @@ class InlineHelpPopover extends Component {
 			>
 				<Notice status="is-error" isCompact={ true } showDismiss={ false }>
 					{ this.props.translate(
-						'Some WordPress.com Business Sites are having connectivity problems. We are investigating the problem now.'
+						'Some WordPress.com Business Sites are having connectivity problems. We are investigating the the issue now.'
 					) }
 				</Notice>
 				<div className="inline-help__search">

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -21,6 +21,7 @@ import InlineHelpSearchCard from './inline-help-search-card';
 import HelpContact from 'me/help/help-contact';
 import { getSearchQuery } from 'state/inline-help/selectors';
 import { getHelpSelectedSite } from 'state/help/selectors';
+import Notice from 'components/notice';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
@@ -81,6 +82,11 @@ class InlineHelpPopover extends Component {
 				context={ this.props.context }
 				className={ classNames( 'inline-help__popover', popoverClasses ) }
 			>
+				<Notice status="is-error" isCompact={ true }>
+					{ this.props.translate(
+						'Some WordPress.com Business Sites are having connectivity problems. We are investigating the problem now.'
+					) }
+				</Notice>
 				<div className="inline-help__search">
 					<InlineHelpSearchCard openResult={ this.openResult } query={ this.props.searchQuery } />
 					<InlineHelpSearchResults

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -572,6 +572,11 @@ class HelpContact extends React.Component {
 		const content = (
 			<Fragment>
 				<PageViewTracker path="/help/contact" title="Help > Contact" />
+				<Notice status="is-error" isCompact={ this.props.compact }>
+					{ this.props.translate(
+						'Some WordPress.com Business Sites are having connectivity problems. We are investigating the problem now.'
+					) }
+				</Notice>
 				{ ! this.props.compact && (
 					<HeaderCake onClick={ this.backToHelp } isCompact={ true }>
 						{ this.props.translate( 'Contact Us' ) }

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -574,7 +574,7 @@ class HelpContact extends React.Component {
 				<PageViewTracker path="/help/contact" title="Help > Contact" />
 				<Notice status="is-error" isCompact={ this.props.compact }>
 					{ this.props.translate(
-						'Some WordPress.com Business Sites are having connectivity problems. We are investigating the problem now.'
+						'Some WordPress.com Business Sites are having connectivity problems. We are investigating the issue now.'
 					) }
 				</Notice>
 				{ ! this.props.compact && (

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -573,7 +573,7 @@ class HelpContact extends React.Component {
 			<Fragment>
 				<PageViewTracker path="/help/contact" title="Help > Contact" />
 				{ ! this.props.compact && (
-					<Notice status="is-error">
+					<Notice status="is-error" showDismiss={ false }>
 						{ this.props.translate(
 							'Some WordPress.com Business Sites are having connectivity problems. We are investigating the issue now.'
 						) }

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -572,11 +572,13 @@ class HelpContact extends React.Component {
 		const content = (
 			<Fragment>
 				<PageViewTracker path="/help/contact" title="Help > Contact" />
-				<Notice status="is-error" isCompact={ this.props.compact }>
-					{ this.props.translate(
-						'Some WordPress.com Business Sites are having connectivity problems. We are investigating the issue now.'
-					) }
-				</Notice>
+				{ ! this.props.compact && (
+					<Notice status="is-error">
+						{ this.props.translate(
+							'Some WordPress.com Business Sites are having connectivity problems. We are investigating the issue now.'
+						) }
+					</Notice>
+				) }
 				{ ! this.props.compact && (
 					<HeaderCake onClick={ this.backToHelp } isCompact={ true }>
 						{ this.props.translate( 'Contact Us' ) }

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -31,6 +31,7 @@ import { GROUP_WPCOM, TYPE_BUSINESS } from 'lib/plans/constants';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import config from 'config';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import Notice from 'components/notice';
 
 /**
  * Module variables
@@ -229,7 +230,7 @@ class Help extends React.PureComponent {
 	};
 
 	render() {
-		const { isEmailVerified, userId, isLoading } = this.props;
+		const { isEmailVerified, userId, isLoading, translate } = this.props;
 
 		if ( isLoading ) {
 			return this.getPlaceholders();
@@ -239,6 +240,11 @@ class Help extends React.PureComponent {
 			<Main className="help">
 				<PageViewTracker path="/help" title="Help" />
 				<MeSidebarNavigation />
+				<Notice status="is-error">
+					{ translate(
+						'Some WordPress.com Business Sites are having connectivity problems. We are investigating the problem now.'
+					) }
+				</Notice>
 				<HelpSearch />
 				{ ! isEmailVerified && <HelpUnverifiedWarning /> }
 				{ this.getCoursesTeaser() }

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -240,7 +240,7 @@ class Help extends React.PureComponent {
 			<Main className="help">
 				<PageViewTracker path="/help" title="Help" />
 				<MeSidebarNavigation />
-				<Notice status="is-error">
+				<Notice status="is-error" showDismiss={ false }>
 					{ translate(
 						'Some WordPress.com Business Sites are having connectivity problems. We are investigating the problem now.'
 					) }

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -242,7 +242,7 @@ class Help extends React.PureComponent {
 				<MeSidebarNavigation />
 				<Notice status="is-error" showDismiss={ false }>
 					{ translate(
-						'Some WordPress.com Business Sites are having connectivity problems. We are investigating the problem now.'
+						'Some WordPress.com Business Sites are having connectivity problems. We are investigating the issue now.'
 					) }
 				</Notice>
 				<HelpSearch />


### PR DESCRIPTION
Add a notice to /help about service issues. We should remove this once, all is well. 

<img width="826" alt="screen shot 2018-04-18 at 12 20 14 pm" src="https://user-images.githubusercontent.com/1270189/38953234-f510be16-4302-11e8-9f11-d255483608e5.png">

<img width="822" alt="screen shot 2018-04-18 at 12 20 39 pm" src="https://user-images.githubusercontent.com/1270189/38953246-fb9ae7c0-4302-11e8-9f8b-f25db09e6f5a.png">

Testing Instructions
====
- Navigate to /help
- The above notice renders without errors
- Navigate to /help/contact
- The related notices are visible.
