### PR TITLE
Framework: Improve makeJsonSchemaParser params

### DIFF
--- a/client/lib/make-json-schema-parser/index.js
+++ b/client/lib/make-json-schema-parser/index.js
@@ -33,12 +33,12 @@ export class TransformerError extends Error {
  * Create a parser to validate and transform data
  *
  * @param {Object}   schema               JSON schema
- * @param {Object}   schemaOptions={}     Options to pass to schema validator
  * @param {Function} transformer=identity Transformer function
+ * @param {Object}   schemaOptions={}     Options to pass to schema validator
  *
  * @return {Parser}                       Function to validate and transform data
  */
-export function makeJsonSchemaParser( schema, schemaOptions = {}, transformer = identity ) {
+export function makeJsonSchemaParser( schema, transformer = identity, schemaOptions = {} ) {
 	let transform;
 	let validate;
 

--- a/client/lib/make-json-schema-parser/test/index.js
+++ b/client/lib/make-json-schema-parser/test/index.js
@@ -19,7 +19,7 @@ describe( 'makeJsonSchemaParser', () => {
 		const transformer = () => {
 			throw Error( 'Testing error during transform' );
 		};
-		const parser = makeJsonSchemaParser( {}, {}, transformer );
+		const parser = makeJsonSchemaParser( {}, transformer );
 		expect( () => parser( 0 ) ).toThrow( TransformerError );
 	} );
 
@@ -30,7 +30,7 @@ describe( 'makeJsonSchemaParser', () => {
 
 	test( 'should return the result of transformation', () => {
 		const transformer = a => a + 1;
-		const parser = makeJsonSchemaParser( { type: 'integer' }, {}, transformer );
+		const parser = makeJsonSchemaParser( { type: 'integer' }, transformer );
 		expect( parser( 0 ) ).toBe( 1 );
 	} );
 

--- a/client/state/data-layer/wpcom-http/README.md
+++ b/client/state/data-layer/wpcom-http/README.md
@@ -339,7 +339,7 @@ export default {
 		onSuccess: verifyLike, // update the Redux store if need be
 		onError: undoLike, // remove the like if we failed
 		onProgress: updateProgress, // update progress tracking UI
-		fromApi: makeJsonSchemaParser( likeSchema, {}, toLike ), // validate and convert to internal Calypso object
+		fromApi: makeJsonSchemaParser( likeSchema, toLike ), // validate and convert to internal Calypso object
 	} ) ]
 }
 ```

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/book/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/book/from-api.js
@@ -6,4 +6,4 @@
 import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import responseSchema from './schema';
 
-export default makeJsonSchemaParser( responseSchema, {} );
+export default makeJsonSchemaParser( responseSchema );

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/from-api.js
@@ -6,4 +6,4 @@
 import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import responseSchema from './schema';
 
-export default makeJsonSchemaParser( responseSchema, {} );
+export default makeJsonSchemaParser( responseSchema );

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/from-api.js
@@ -13,4 +13,4 @@ export const transform = ( { begin_timestamp, end_timestamp, schedule_id, ...res
 	...rest,
 } );
 
-export default makeJsonSchemaParser( responseSchema, {}, transform );
+export default makeJsonSchemaParser( responseSchema, transform );

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/from-api.js
@@ -6,4 +6,4 @@
 import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import responseSchema from './schema';
 
-export default makeJsonSchemaParser( responseSchema, {} );
+export default makeJsonSchemaParser( responseSchema );

--- a/client/state/data-layer/wpcom/concierge/schedules/available-times/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/available-times/from-api.js
@@ -10,4 +10,4 @@ export const convertToDate = timestampInSeconds => timestampInSeconds * 1000;
 
 export const transform = response => response.map( convertToDate );
 
-export default makeJsonSchemaParser( responseSchema, {}, transform );
+export default makeJsonSchemaParser( responseSchema, transform );

--- a/client/state/data-layer/wpcom/me/transactions/order/from-api.js
+++ b/client/state/data-layer/wpcom/me/transactions/order/from-api.js
@@ -29,4 +29,4 @@ export const transform = ( { order_id, user_id, receipt_id, processing_status } 
 	processingStatus: convertProcessingStatus( processing_status ),
 } );
 
-export default makeJsonSchemaParser( responseSchema, {}, transform );
+export default makeJsonSchemaParser( responseSchema, transform );

--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/index.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/index.js
@@ -52,7 +52,7 @@ const requestHandler = {
 			fetch: requestApplicationPasswords,
 			onSuccess: handleRequestSuccess,
 			onError: noop,
-			fromApi: makeJsonSchemaParser( schema, {}, apiTransformer ),
+			fromApi: makeJsonSchemaParser( schema, apiTransformer ),
 		} ),
 	],
 };

--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/new/index.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/new/index.js
@@ -73,7 +73,7 @@ export default {
 			fetch: addApplicationPassword,
 			onSuccess: handleAddSuccess,
 			onError: handleAddError,
-			fromApi: makeJsonSchemaParser( schema, {}, apiTransformer ),
+			fromApi: makeJsonSchemaParser( schema, apiTransformer ),
 		} ),
 	],
 };

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -104,4 +104,4 @@ export function processItem( item ) {
 }
 
 // fromApi default export
-export default makeJsonSchemaParser( apiResponseSchema, {}, transformer );
+export default makeJsonSchemaParser( apiResponseSchema, transformer );

--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -196,12 +196,12 @@ export const failedJITM = ( { dispatch }, { siteId, site_id, messagePath } ) =>
 export default {
 	[ SECTION_SET ]: [
 		dispatchRequest( handleRouteChange, receiveJITM, failedJITM, {
-			fromApi: makeJsonSchemaParser( schema, {}, transformApiRequest ),
+			fromApi: makeJsonSchemaParser( schema, transformApiRequest ),
 		} ),
 	],
 	[ SELECTED_SITE_SET ]: [
 		dispatchRequest( handleSiteSelection, receiveJITM, failedJITM, {
-			fromApi: makeJsonSchemaParser( schema, {}, transformApiRequest ),
+			fromApi: makeJsonSchemaParser( schema, transformApiRequest ),
 		} ),
 	],
 	[ JITM_DISMISS ]: [ dispatchRequest( doDismissJITM, noop, noop, {} ) ],

--- a/client/state/data-layer/wpcom/sites/rewind/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/index.js
@@ -105,7 +105,7 @@ export default mergeHandlers( downloads, {
 			fetch: fetchRewindState,
 			onSuccess: updateRewindState,
 			onError: setUnknownState,
-			fromApi: makeJsonSchemaParser( rewindStatus, {}, transformApi ),
+			fromApi: makeJsonSchemaParser( rewindStatus, transformApi ),
 		} ),
 	],
 } );

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -259,7 +259,6 @@ export function createAccount( userData ) {
 						bearer_token: { type: 'string' },
 					},
 				},
-				{},
 				( { bearer_token } ) => bearer_token
 			)( data );
 


### PR DESCRIPTION
`makeJsonSchemaParser` takes three arguments. The first (`schema`) is required, the second is never used, and the third (`transformer`) is used often.

Bump the second option to be the last. We could consider dropping the option param altogether.

## Testing
1. No functional changes
1. Smoke test
1.  Let e2e/canaries do their work.