### PR TITLE
Domains: Transfer-in screen improvements

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -148,16 +148,12 @@ class TransferDomainStep extends React.Component {
 				{ this.notice() }
 				<form className="transfer-domain-step__form card" onSubmit={ this.handleFormSubmit }>
 					<div className="transfer-domain-step__domain-description">
-						<img
-							className="transfer-domain-step__illustration"
-							src={ '/calypso/images/illustrations/migrating-host-diy.svg' }
-						/>
 						<div className="transfer-domain-step__domain-heading">
 							{ translate( 'Manage your domain and site together on WordPress.com.' ) }
 						</div>
 						<div>
 							{ translate(
-								'Move your domain from your current provider to WordPress.com so you can update settings, ' +
+								'Transfer your domain away from your current provider to WordPress.com so you can update settings, ' +
 									"renew your domain, and more \u2013 right in your dashboard. We'll renew it for another year " +
 									'when the transfer is successful. {{a}}Learn more{{/a}}.',
 								{

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -68,12 +68,6 @@
 .transfer-domain-step__domain-description {
 	font-size: 16px;
 	margin-bottom: 20px;
-
-	.transfer-domain-step__illustration {
-		display: block;
-		margin: 0 auto 20px;
-		max-width: 250px;
-	}
 }
 
 .transfer-domain-step__go {


### PR DESCRIPTION
The big image at the top of this view pushes the card with the domain mapping option below the fold on smaller screens.
Additionally, the copy on this screen does not mention "transferring away" a domain, instead using words like "move", which can be misinterpreted by users.

Before:
> **Move your domain from your current provider** to WordPress.com so you can update settings, renew your domain, and more – right in your dashboard. We'll renew it for another year when the transfer is successful. Learn more.

After:
> **Transfer your domain away from your current provider** to WordPress.com so you can update settings, renew your domain, and more – right in your dashboard. We'll renew it for another year when the transfer is successful. Learn more.

Before:
<img width="1005" alt="screen shot 2018-04-18 at 22 18 00" src="https://user-images.githubusercontent.com/3392497/38956113-fd6c0990-4356-11e8-95ba-f121ba8070c2.png">
<img width="327" alt="screen shot 2018-04-18 at 22 18 13" src="https://user-images.githubusercontent.com/3392497/38956114-fd91826a-4356-11e8-801a-7cab9fa0817f.png">

After:
<img width="995" alt="screen shot 2018-04-18 at 22 15 46" src="https://user-images.githubusercontent.com/3392497/38956135-07791216-4357-11e8-9e19-51ac70a1d286.png">
<img width="335" alt="screen shot 2018-04-18 at 22 17 16" src="https://user-images.githubusercontent.com/3392497/38956136-079a1f74-4357-11e8-9b76-0352c9556b5b.png">
