### PR TITLE
Use static Tracks event names and put dynamic parameters in props.

### DIFF
--- a/client/lib/posts/stats.js
+++ b/client/lib/posts/stats.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import debugModule from 'debug';
-import { noop, snakeCase } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -50,7 +50,7 @@ export function recordSaveEvent( site, context ) {
 
 	const currentStatus = savedPost.status;
 	const nextStatus = post.status;
-	let tracksEventName = 'calypso_editor_' + snakeCase( post.type ) + '_';
+	let tracksEventName = 'calypso_editor_';
 	let statName = false;
 	let statEvent = false;
 	let usageAction = false;

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -127,10 +127,9 @@ class ManageMenu extends PureComponent {
 		if ( ! includes( [ 'post', 'page' ], postType ) ) {
 			analytics.mc.bumpStat( 'calypso_publish_menu_click', postType );
 		}
-		// Tracks doesn't like dashes (as in 'jetpack-portfolio', for example)
-		this.props.recordTracksEvent(
-			'calypso_mysites_sidebar_' + postType.replace( /-/g, '_' ) + '_clicked'
-		);
+		this.props.recordTracksEvent( 'calypso_mysites_sidebar_clicked', {
+			post_type: postType,
+		} );
 		this.props.onNavigate();
 	};
 
@@ -230,9 +229,9 @@ class ManageMenu extends PureComponent {
 
 	trackSidebarButtonClick = name => {
 		return () => {
-			this.props.recordTracksEvent(
-				'calypso_mysites_sidebar_' + name.replace( /-/g, '_' ) + '_sidebar_button_clicked'
-			);
+			this.props.recordTracksEvent( 'calypso_mysites_sidebar_button_clicked', {
+				post_type: name,
+			} );
 		};
 	};
 


### PR DESCRIPTION
This commit updates the following 3 "patterns":

calypso_mysites_sidebar_{button_name}_sidebar_button_clicked
-> calypso_mysites_sidebar_button_clicked { post_type: button_name }

calypso_mysites_sidebar_{post_type}_clicked
-> calypso_mysites_sidebar_clicked { post_type }

calypso_editor_{post_type}_*
-> calypso_editor_* { post_type }

This considerably reduces the number of new Tracks events created daily by Calypso, see p4qSXL-2De-p2 for more context on why this is a problem.