### PR TITLE
Inline Help: Remove getSelectedUrl (Minor/Janitorial)

### DIFF
--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -106,19 +106,6 @@ class InlineHelpSearchResults extends Component {
 		);
 	}
 
-	getSelectedUrl = () => {
-		if ( this.props.selectedResult === -1 ) {
-			return false;
-		}
-
-		const links = this.props.searchResults || this.getContextResults();
-		const selectedLink = links[ this.props.selectedResult ];
-		if ( ! selectedLink || ! selectedLink.link ) {
-			return false;
-		}
-		return selectedLink.link;
-	};
-
 	componentDidMount() {
 		this.props.setSearchResults( '', this.getContextResults() );
 	}


### PR DESCRIPTION
#### Minor / Janitorial PR: 
`getSelectedUrl` isn't used anywhere and it seems to have been superseded by `getInlineHelpCurrentlySelectedLink`. This PR thus suggests to remove it.

#### How to test:
Open Inline help and validate that searching and following results works as expected.