### PR TITLE
Make <SubscriptionLengthOption /> show "Credit applied" if credit was applied

### DIFF
--- a/client/blocks/subscription-length-picker/index.jsx
+++ b/client/blocks/subscription-length-picker/index.jsx
@@ -45,7 +45,7 @@ export class SubscriptionLengthPicker extends React.Component {
 	render() {
 		const { productsWithPrices, translate } = this.props;
 		const hasDiscount = productsWithPrices.some(
-			( { priceBeforeDiscount } ) => priceBeforeDiscount
+			( { priceFullBeforeDiscount, priceFull } ) => priceFull !== priceFullBeforeDiscount
 		);
 		return (
 			<div className="subscription-length-picker">
@@ -66,7 +66,7 @@ export class SubscriptionLengthPicker extends React.Component {
 
 				<div className="subscription-length-picker__options">
 					{ productsWithPrices.map(
-						( { plan, planSlug, priceBeforeDiscount, priceFull, priceMonthly } ) => (
+						( { plan, planSlug, priceFullBeforeDiscount, priceFull, priceMonthly } ) => (
 							<div className="subscription-length-picker__option-container" key={ planSlug }>
 								<SubscriptionLengthOption
 									type={ hasDiscount ? 'upgrade' : 'new-sale' }
@@ -74,7 +74,7 @@ export class SubscriptionLengthPicker extends React.Component {
 									checked={ planSlug === this.state.checked }
 									price={ myFormatCurrency( priceFull, this.props.currencyCode ) }
 									priceBeforeDiscount={ myFormatCurrency(
-										priceBeforeDiscount,
+										priceFullBeforeDiscount,
 										this.props.currencyCode
 									) }
 									pricePerMonth={ myFormatCurrency( priceMonthly, this.props.currencyCode ) }

--- a/client/blocks/subscription-length-picker/option.jsx
+++ b/client/blocks/subscription-length-picker/option.jsx
@@ -109,7 +109,7 @@ export class SubscriptionLengthOption extends React.Component {
 					<div className="subscription-length-picker__option-term">{ this.getTermText() }</div>
 				</div>
 				<div className="subscription-length-picker__option-description">
-					{ priceBeforeDiscount ? (
+					{ priceBeforeDiscount && priceBeforeDiscount !== price ? (
 						<div className="subscription-length-picker__option-old-price">
 							{ priceBeforeDiscount }
 						</div>

--- a/client/state/products-list/selectors.js
+++ b/client/state/products-list/selectors.js
@@ -85,6 +85,7 @@ export const planSlugToPlanProduct = ( products, planSlug ) => {
  * @return {Object} Object with a full and monthly price
  */
 export const computeFullAndMonthlyPricesForPlan = ( state, siteId, planObject ) => ( {
+	priceFullBeforeDiscount: getPlanRawPrice( state, planObject.getProductId(), false ),
 	priceFull: getPlanPrice( state, siteId, planObject, false ),
 	priceMonthly: getPlanPrice( state, siteId, planObject, true ),
 } );

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -136,9 +136,11 @@ describe( 'selectors', () => {
 			getPlanDiscountedRawPrice.mockImplementation(
 				( a, b, c, { isMonthly } ) => ( isMonthly ? 10 : 120 )
 			);
+			getPlanRawPrice.mockImplementation( () => 150 );
 
 			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
 			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan ) ).toEqual( {
+				priceFullBeforeDiscount: 150,
 				priceFull: 120,
 				priceMonthly: 10,
 			} );
@@ -163,7 +165,7 @@ describe( 'selectors', () => {
 		};
 
 		beforeEach( () => {
-			getPlanRawPrice.mockImplementation( () => 0 );
+			getPlanRawPrice.mockImplementation( () => 150 );
 			getPlanDiscountedRawPrice.mockImplementation( ( a, b, storeSlug, { isMonthly } ) => {
 				if ( storeSlug === 'abc' ) {
 					return isMonthly ? 10 : 120;
@@ -175,7 +177,7 @@ describe( 'selectors', () => {
 			getPlan.mockImplementation( slug => plans[ slug ] );
 		} );
 
-		test( 'Should return list of shapes { priceFull, priceMonthly, plan, product, planSlug }', () => {
+		test( 'Should return list of shapes { priceFull, priceFullBeforeDiscount, priceMonthly, plan, product, planSlug }', () => {
 			const state = {
 				productsList: {
 					items: {
@@ -190,6 +192,7 @@ describe( 'selectors', () => {
 					planSlug: 'plan1',
 					plan: plans.plan1,
 					product: state.productsList.items.plan1,
+					priceFullBeforeDiscount: 150,
 					priceFull: 120,
 					priceMonthly: 10,
 				},
@@ -197,6 +200,7 @@ describe( 'selectors', () => {
 					planSlug: 'plan2',
 					plan: plans.plan2,
 					product: state.productsList.items.plan2,
+					priceFullBeforeDiscount: 150,
 					priceFull: 240,
 					priceMonthly: 20,
 				},
@@ -218,6 +222,7 @@ describe( 'selectors', () => {
 					planSlug: 'plan1',
 					plan: plans.plan1,
 					product: state.productsList.items.plan1,
+					priceFullBeforeDiscount: 150,
 					priceFull: 120,
 					priceMonthly: 10,
 				},
@@ -238,6 +243,7 @@ describe( 'selectors', () => {
 					planSlug: 'plan1',
 					plan: plans.plan1,
 					product: state.productsList.items.plan1,
+					priceFullBeforeDiscount: 150,
 					priceFull: 120,
 					priceMonthly: 10,
 				},
@@ -248,6 +254,11 @@ describe( 'selectors', () => {
 			getPlanDiscountedRawPrice.mockImplementation( ( a, b, storeSlug, { isMonthly } ) => {
 				if ( storeSlug === 'abc' ) {
 					return isMonthly ? 10 : 120;
+				}
+			} );
+			getPlanRawPrice.mockImplementation( ( a, productId ) => {
+				if ( productId === 'def' ) {
+					return 150;
 				}
 			} );
 
@@ -265,6 +276,7 @@ describe( 'selectors', () => {
 					planSlug: 'plan1',
 					plan: plans.plan1,
 					product: state.productsList.items.plan1,
+					priceFullBeforeDiscount: 150,
 					priceFull: 120,
 					priceMonthly: 10,
 				},


### PR DESCRIPTION
Related to 2-year plans (p9jf6J-eR-p2).

This PR fixes invalid behavior of `<SubscriptionLengthPicker />` which showed discount percentages when credit was applied.

Test plan:
* Run unit tests
* As a free user, checkout any plan and confirm the subscription length picker looks like this:

<img width="760" alt="zrzut ekranu 2018-04-19 o 14 36 28" src="https://user-images.githubusercontent.com/205419/38991786-19b3a4cc-43df-11e8-9a3d-1899954c608a.png">

* As a paid user, checkout any higher plan and confirm the subscription length picker looks like this:

<img width="754" alt="zrzut ekranu 2018-04-19 o 14 36 25" src="https://user-images.githubusercontent.com/205419/38991785-1996d02c-43df-11e8-89fa-e5f897930a47.png">
