### PR TITLE
 Post Editor: reduxify editing the post excerpt 

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -16,12 +16,8 @@ import Accordion from 'components/accordion';
 import AccordionSection from 'components/accordion/section';
 import CategoriesTagsAccordion from 'post-editor/editor-categories-tags/accordion';
 import AsyncLoad from 'components/async-load';
-import FormTextarea from 'components/forms/form-textarea';
 import EditorMoreOptionsSlug from 'post-editor/editor-more-options/slug';
 import PostMetadata from 'lib/post-metadata';
-import TrackInputChanges from 'components/track-input-changes';
-import actions from 'lib/posts/actions';
-import { recordStat, recordEvent } from 'lib/posts/stats';
 import { isBusiness, isEnterprise, isJetpackPremium } from 'lib/products-values';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import QueryPostTypes from 'components/data/query-post-types';
@@ -43,6 +39,7 @@ import EditorDrawerPageOptions from './page-options';
 import EditorDrawerLabel from './label';
 import EditorMoreOptionsCopyPost from 'post-editor/editor-more-options/copy-post';
 import EditPostStatus from 'post-editor/edit-post-status';
+import EditorExcerpt from 'post-editor/editor-excerpt';
 import { getFirstConflictingPlugin } from 'lib/seo';
 
 /**
@@ -91,11 +88,6 @@ class EditorDrawer extends Component {
 		confirmationSidebarStatus: PropTypes.string,
 	};
 
-	onExcerptChange( event ) {
-		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		actions.edit( { excerpt: event.target.value } );
-	}
-
 	currentPostTypeSupports( feature ) {
 		const { typeObject, type } = this.props;
 
@@ -110,11 +102,6 @@ class EditorDrawer extends Component {
 
 		// Default to true until post types are known
 		return true;
-	}
-
-	recordExcerptChangeStats() {
-		recordStat( 'excerpt_changed' );
-		recordEvent( 'Changed Excerpt' );
 	}
 
 	// Categories & Tags
@@ -179,8 +166,6 @@ class EditorDrawer extends Component {
 			return;
 		}
 
-		const excerpt = get( this.props.post, 'excerpt' );
-
 		return (
 			<AccordionSection>
 				<EditorDrawerLabel
@@ -190,16 +175,7 @@ class EditorDrawer extends Component {
 							"Some themes show excerpts alongside post titles on your site's homepage and archive pages."
 					) }
 				>
-					<TrackInputChanges onNewValue={ this.recordExcerptChangeStats }>
-						<FormTextarea
-							id="excerpt"
-							name="excerpt"
-							onChange={ this.onExcerptChange }
-							value={ excerpt }
-							placeholder={ translate( 'Write an excerpt…' ) }
-							aria-label={ translate( 'Write an excerpt…' ) }
-						/>
-					</TrackInputChanges>
+					<EditorExcerpt />
 				</EditorDrawerLabel>
 			</AccordionSection>
 		);

--- a/client/post-editor/editor-excerpt/index.jsx
+++ b/client/post-editor/editor-excerpt/index.jsx
@@ -1,0 +1,61 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { recordStat, recordEvent } from 'lib/posts/stats';
+import TrackInputChanges from 'components/track-input-changes';
+import FormTextarea from 'components/forms/form-textarea';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPostValue } from 'state/posts/selectors';
+import { editPost } from 'state/posts/actions';
+
+class EditorExcerpt extends React.Component {
+	recordExcerptChangeStats = () => {
+		recordStat( 'excerpt_changed' );
+		recordEvent( 'Changed Excerpt' );
+	};
+
+	onExcerptChange = event => {
+		const excerpt = event.target.value;
+		this.props.editPost( this.props.siteId, this.props.postId, { excerpt } );
+	};
+
+	render() {
+		const { excerpt, translate } = this.props;
+
+		return (
+			<TrackInputChanges onNewValue={ this.recordExcerptChangeStats }>
+				<FormTextarea
+					id="excerpt"
+					name="excerpt"
+					onChange={ this.onExcerptChange }
+					value={ excerpt }
+					placeholder={ translate( 'Write an excerpt…' ) }
+					aria-label={ translate( 'Write an excerpt…' ) }
+				/>
+			</TrackInputChanges>
+		);
+	}
+}
+
+export default connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
+		const postId = getEditorPostId( state );
+		const excerpt = getEditedPostValue( state, siteId, postId, 'excerpt' );
+
+		return { siteId, postId, excerpt };
+	},
+	{
+		editPost,
+	}
+)( localize( EditorExcerpt ) );

--- a/client/post-editor/editor-excerpt/index.jsx
+++ b/client/post-editor/editor-excerpt/index.jsx
@@ -31,6 +31,7 @@ class EditorExcerpt extends React.Component {
 
 	render() {
 		const { excerpt, translate } = this.props;
+		const placeholder = translate( 'Write an excerpt…' );
 
 		return (
 			<TrackInputChanges onNewValue={ this.recordExcerptChangeStats }>
@@ -39,8 +40,8 @@ class EditorExcerpt extends React.Component {
 					name="excerpt"
 					onChange={ this.onExcerptChange }
 					value={ excerpt }
-					placeholder={ translate( 'Write an excerpt…' ) }
-					aria-label={ translate( 'Write an excerpt…' ) }
+					placeholder={ placeholder }
+					aria-label={ placeholder }
 				/>
 			</TrackInputChanges>
 		);

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -470,10 +470,9 @@ export class PostEditor extends React.Component {
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		actions.edit( {
 			content: revision.content,
-			excerpt: revision.excerpt,
-			title: revision.title,
 		} );
 		this.props.editPost( this.props.siteId, this.props.postId, {
+			excerpt: revision.excerpt,
 			title: revision.title,
 		} );
 	};


### PR DESCRIPTION
Reduxify editing the post excerpt in Editor Drawer:

<img width="274" alt="screen shot 2018-04-19 at 14 34 39" src="https://user-images.githubusercontent.com/664258/38991713-e667d750-43de-11e8-80c8-04781a4ae7df.png">

The patch creates a standalone `EditorExcerpt` component (instead of inlining the functionality in `EditorDrawer` and uses Redux to receive the `excerpt` attribute of the post and dispatch change action.

The second commit ensures that excerpt is properly updated when restoring an older revision of the post.

**How to test:**
Edit an excerpt of a new post, draft post or a published post. Check that changes are saved correctly.

On a published post that has some history of excerpt updates, open the History dialog and load some older revision. Check that the excerpt textarea was overwritten with the correct value from that revision.
