### PR TITLE
Jetpack connect: Remove unused param and route

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -210,22 +210,9 @@ export function signupForm( context, next ) {
 		const transformedQuery = authQueryTransformer( query );
 		context.store.dispatch( startAuthorizeStep( transformedQuery.clientId ) );
 
-		let interval = context.params.interval;
-		let locale = context.params.locale;
-		if ( context.params.localeOrInterval ) {
-			if ( [ 'monthly', 'yearly' ].indexOf( context.params.localeOrInterval ) >= 0 ) {
-				interval = context.params.localeOrInterval;
-			} else {
-				locale = context.params.localeOrInterval;
-			}
-		}
+		const { locale } = context.params;
 		context.primary = (
-			<JetpackSignup
-				path={ context.path }
-				interval={ interval }
-				locale={ locale }
-				authQuery={ transformedQuery }
-			/>
+			<JetpackSignup path={ context.path } locale={ locale } authQuery={ transformedQuery } />
 		);
 	} else {
 		context.primary = <NoDirectAccessError />;

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -58,16 +58,7 @@ export default function() {
 
 	if ( isLoggedOut ) {
 		page(
-			'/jetpack/connect/authorize/:localeOrInterval?',
-			controller.maybeOnboard,
-			controller.setMasterbar,
-			controller.signupForm,
-			makeLayout,
-			clientRender
-		);
-
-		page(
-			'/jetpack/connect/authorize/:interval/:locale',
+			'/jetpack/connect/authorize/:locale?',
 			controller.maybeOnboard,
 			controller.setMasterbar,
 			controller.signupForm,
@@ -76,17 +67,7 @@ export default function() {
 		);
 	} else {
 		page(
-			'/jetpack/connect/authorize/:localeOrInterval?',
-			controller.maybeOnboard,
-			controller.redirectWithoutLocaleIfLoggedIn,
-			controller.setMasterbar,
-			controller.authorizeForm,
-			makeLayout,
-			clientRender
-		);
-
-		page(
-			'/jetpack/connect/authorize/:interval/:locale',
+			'/jetpack/connect/authorize/:locale?',
 			controller.maybeOnboard,
 			controller.redirectWithoutLocaleIfLoggedIn,
 			controller.setMasterbar,


### PR DESCRIPTION
Remove unused routes with interval
- `/jetpack/connect/authorize/:localeOrInterval?`
- `/jetpack/connect/authorize/:interval/:locale`
Drop unused interval handling in controller

Verify usage with hue and this query: 1d9b9-pb

## Testing
Ensure used routes continue to work (`/jetpack/connect/authorize/:locale?`)
You can manually add a local when testing with Jurassic ninja, for example `es`.