### PR TITLE
Plugin Notices: fix plurals on RECEIVE_PLUGINS error notice

### DIFF
--- a/client/lib/plugins/notices.jsx
+++ b/client/lib/plugins/notices.jsx
@@ -759,9 +759,14 @@ export default {
 				}
 				break;
 			case 'RECEIVE_PLUGINS':
-				return this.props.translate( 'Error fetching plugins on %(numberOfSites)d sites.', {
-					args: translateArg,
-				} );
+				return i18n.translate(
+					'Error fetching plugins on %(numberOfSites)d site.',
+					'Error fetching plugins on %(numberOfSites)d sites.',
+					{
+						count: translateArg.numberOfSites,
+						args: translateArg,
+					}
+				);
 		}
 	},
 


### PR DESCRIPTION
Correct plural arguments to `i18n.translate`.

Also changes `this.props.translate` to `i18n.translate`. Referencing `this.props` accidentally worked, too, because the module is a React mixin that gets mixed into a localized React component, but it's a small miracle that it did :wink: