### PR TITLE
Plans: make layout of the feature cards in My Plan fully responsive

### DIFF
--- a/client/blocks/product-purchase-features-list/style.scss
+++ b/client/blocks/product-purchase-features-list/style.scss
@@ -2,8 +2,9 @@
 
 .product-purchase-features-list {
 	@include breakpoint( '>1040px' ) {
-		column-count: 2;
-		column-gap: 12px;
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
 	}
 }
 
@@ -13,9 +14,10 @@
 	-webkit-column-break-inside: avoid; // For others
 
 	padding-top: 12px;
+	max-width: 150%;
 
-	&:empty {
-		display: none;
+	@include breakpoint( '>1040px' ) {
+		max-width: 49.5%;
 	}
 }
 

--- a/client/blocks/product-purchase-features-list/style.scss
+++ b/client/blocks/product-purchase-features-list/style.scss
@@ -25,9 +25,4 @@
 	background-color: $white;
 	border-radius: 0;
 	margin: 0;
-
-	// Chrome bug wraps shadow into next column.
-	// Remove when fixed
-	// @see https://github.com/Automattic/wp-calypso/pull/23181#issuecomment-377649871
-	margin-bottom: 1px;
 }


### PR DESCRIPTION
This is a janitorial/clean-up PR and a follow-up to #24262, a re-write of the feature card render using flexbox. This PR does not introduce visual or content changes, but improves the responsiveness and fixes the bug revealed in https://github.com/Automattic/wp-calypso/pull/23181. 

## To test:

- checkout this branch on your local Calypso or use calypso.live,
- verify that the cards are displayed correctly on a variety of canonical plans pages `http://calypso.localhost:3000/plans/:site` for both .com and JP plans, and viewports.
