### PR TITLE
Domains: Add client side pagination for the domain suggestions

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -372,15 +372,20 @@ class RegisterDomainStep extends React.Component {
 			return null;
 		}
 
-		if ( this.state.searchResults === null ) {
+		const { searchResults, pageNumber, loadingResults: isLoading } = this.state;
+
+		if ( searchResults === null ) {
 			return null;
 		}
 
-		if ( this.state.pageNumber >= MAX_PAGES ) {
+		if ( pageNumber >= MAX_PAGES ) {
 			return null;
 		}
 
-		const isLoading = this.state.loadingResults;
+		if ( searchResults.length <= pageNumber * PAGE_SIZE ) {
+			return null;
+		}
+
 		const className = classNames( 'button', 'register-domain-step__next-page', {
 			'register-domain-step__next-page--is-loading': isLoading,
 		} );

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -77,6 +77,9 @@ const domains = wpcom.domains();
 const INITIAL_SUGGESTION_QUANTITY = 2;
 const PAGE_SIZE = 10;
 const MAX_PAGES = 3;
+const SUGGESTION_QUANTITY = config.isEnabled( 'domains/kracken-ui/pagination' )
+	? PAGE_SIZE * MAX_PAGES
+	: PAGE_SIZE;
 
 let searchVendor = 'group_1';
 const fetchAlgo = searchVendor + '/v1';
@@ -87,15 +90,6 @@ let lastSearchTimestamp = null;
 let searchCount = 0;
 let recordSearchFormSubmitWithDispatch;
 
-function getSuggestionFetchQuantity() {
-	const isKrackenUi = config.isEnabled( 'domains/kracken-ui/pagination' );
-
-	if ( isKrackenUi ) {
-		return PAGE_SIZE * MAX_PAGES;
-	}
-	return PAGE_SIZE;
-}
-
 function getQueryObject( props ) {
 	if ( ! props.selectedSite || ! props.selectedSite.domain ) {
 		return null;
@@ -103,7 +97,7 @@ function getQueryObject( props ) {
 
 	return {
 		query: props.selectedSite.domain.split( '.' )[ 0 ],
-		quantity: getSuggestionFetchQuantity(),
+		quantity: SUGGESTION_QUANTITY,
 		vendor: searchVendor,
 		includeSubdomain: props.includeWordPressDotCom,
 		surveyVertical: props.surveyVertical,
@@ -553,8 +547,8 @@ class RegisterDomainStep extends React.Component {
 	getDomainsSuggestions = ( domain, timestamp ) => {
 		const suggestionQuantity =
 			this.props.includeWordPressDotCom || this.props.includeDotBlogSubdomain
-				? getSuggestionFetchQuantity() - 1
-				: getSuggestionFetchQuantity();
+				? SUGGESTION_QUANTITY - 1
+				: SUGGESTION_QUANTITY;
 
 		const query = {
 			query: domain,

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -772,7 +772,7 @@ class RegisterDomainStep extends React.Component {
 	showNextPage = () => {
 		debug( 'showNextPage was triggered' );
 
-		this.setState( { pageNumber: this.state.pageNumber + 1 } );
+		this.setState( { pageNumber: this.state.pageNumber + 1 }, this.save );
 	};
 
 	initialSuggestions() {


### PR DESCRIPTION
Add client side pagination for the suggestion results. I'm currently fetching 30 results from the suggestion engine and showing 3 pages. After that the "Show more results" button dissapears.

To test - make sure the `domains/kracken-ui/pagination` feature is enabled and search for a domain on the Calypso/NUX flow. There should be a "Show more results" button at the bottom, that should show the next 10 results.