### PR TITLE
Site Importer: Add a site preview step.

### DIFF
--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -206,12 +206,10 @@ class SiteImporterInputPane extends React.Component {
 				) }
 				{ this.state.importStage === 'importable' && (
 					<div className="site-importer__site-importer-confirm-site-pane">
-						<SiteImporterSitePreview
-							siteURL={ this.state.importSiteURL }
-							importData={ this.state.importData }
-							isLoading={ this.state.loading }
-						/>
 						<div className="site-importer__site-importer-confirm-site-pane-container">
+							<p className="site-importer__site-importer-confirm-site-label">
+								{ this.props.translate( 'Is this your site?' ) }
+							</p>
 							<Button disabled={ this.state.loading } onClick={ this.importSite }>
 								{ this.props.translate( 'Yes! Start import' ) }
 							</Button>
@@ -223,6 +221,11 @@ class SiteImporterInputPane extends React.Component {
 								{ this.props.translate( 'No' ) }
 							</Button>
 						</div>
+						<SiteImporterSitePreview
+							siteURL={ this.state.importSiteURL }
+							importData={ this.state.importData }
+							isLoading={ this.state.loading }
+						/>
 					</div>
 				) }
 				{ this.state.error && (

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -206,25 +206,12 @@ class SiteImporterInputPane extends React.Component {
 				) }
 				{ this.state.importStage === 'importable' && (
 					<div className="site-importer__site-importer-confirm-site-pane">
-						<div className="site-importer__site-importer-confirm-site-pane-container">
-							<p className="site-importer__site-importer-confirm-site-label">
-								{ this.props.translate( 'Is this your site?' ) }
-							</p>
-							<Button disabled={ this.state.loading } onClick={ this.importSite }>
-								{ this.props.translate( 'Yes! Start import' ) }
-							</Button>
-							<Button
-								disabled={ this.state.loading }
-								isPrimary={ false }
-								onClick={ this.resetImport }
-							>
-								{ this.props.translate( 'No' ) }
-							</Button>
-						</div>
 						<SiteImporterSitePreview
 							siteURL={ this.state.importSiteURL }
 							importData={ this.state.importData }
 							isLoading={ this.state.loading }
+							resetImport={ this.resetImport }
+							startImport={ this.importSite }
 						/>
 					</div>
 				) }

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -8,11 +8,13 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import { noop, every, has, defer, get } from 'lodash';
+import request from 'superagent';
 
 /**
  * Internal dependencies
  */
 import wpLib from 'lib/wp';
+
 const wpcom = wpLib.undocumented();
 
 import { toApi, fromApi } from 'lib/importer/common';
@@ -111,6 +113,11 @@ class SiteImporterInputPane extends React.Component {
 		const siteURL = this.state.siteURLInput;
 
 		this.setState( { loading: true }, this.resetErrors );
+
+		request
+			.get( `https://s0.wp.com/mshots/v1/${ siteURL }?${ Math.random() }` )
+			.then( noop )
+			.catch( noop );
 
 		wpcom.wpcom.req
 			.get( {

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -115,7 +115,7 @@ class SiteImporterInputPane extends React.Component {
 		this.setState( { loading: true }, this.resetErrors );
 
 		request
-			.get( `https://s0.wp.com/mshots/v1/${ siteURL }?${ Math.random() }` )
+			.get( `https://s0.wp.com/mshots/v1/${ siteURL }` )
 			.then( noop )
 			.catch( noop );
 

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import { noop, every, has, defer, get } from 'lodash';
-import request from 'superagent';
 
 /**
  * Internal dependencies
@@ -29,6 +28,8 @@ import TextInput from 'components/forms/form-text-input';
 
 import SiteImporterSitePreview from './site-importer-site-preview';
 import { connectDispatcher } from '../dispatcher-converter';
+
+import { loadmShotsPreview } from './site-preview-actions';
 
 class SiteImporterInputPane extends React.Component {
 	static displayName = 'SiteImporterSitePreview';
@@ -114,10 +115,10 @@ class SiteImporterInputPane extends React.Component {
 
 		this.setState( { loading: true }, this.resetErrors );
 
-		request
-			.get( `https://s0.wp.com/mshots/v1/${ siteURL }` )
-			.then( noop )
-			.catch( noop );
+		loadmShotsPreview( {
+			url: siteURL,
+			maxRetries: 1,
+		} ).catch( noop ); // We don't care about the error, this is just a preload
 
 		wpcom.wpcom.req
 			.get( {

--- a/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
@@ -14,13 +14,15 @@ import request from 'superagent';
  * Internal dependencies
  */
 import Spinner from 'components/spinner';
-import { retry } from '../../../layout/error';
+import Button from 'components/forms/form-button';
 
 class SiteImporterSitePreview extends React.Component {
 	static propTypes = {
 		siteURL: PropTypes.string.isRequired,
 		importData: PropTypes.object,
 		isLoading: PropTypes.bool,
+		startImport: PropTypes.func,
+		resetImport: PropTypes.func,
 	};
 
 	state = {
@@ -28,9 +30,11 @@ class SiteImporterSitePreview extends React.Component {
 		siteURL: `https://s0.wp.com/mshots/v1/${ this.props.siteURL }${ Math.random() }`, // TODO remove before going to prod
 		sitePreviewImage: '',
 		sitePreviewFailed: false,
+		loadingPreviewImage: false,
 	};
 
 	componentDidMount() {
+		this.setState( { loadingPreviewImage: true } );
 		this.loadSitePreview();
 	}
 
@@ -58,7 +62,10 @@ class SiteImporterSitePreview extends React.Component {
 					// const blob = new Blob( [ ], { type: 'image/jpeg' } )
 					const fReader = new FileReader();
 					fReader.onload = ev => {
-						this.setState( { sitePreviewImage: ev.target.result } );
+						this.setState( {
+							sitePreviewImage: ev.target.result,
+							loadingPreviewImage: false,
+						} );
 					};
 					fReader.readAsDataURL( res.xhr.response );
 				}
@@ -70,40 +77,45 @@ class SiteImporterSitePreview extends React.Component {
 	};
 
 	render = () => {
+		const isLoading = this.props.isLoading || this.state.loadingPreviewImage;
+
 		const containerClass = classNames( 'site-importer__site-preview-overlay-container', {
-			isLoading: this.props.isLoading,
+			isLoading,
 		} );
 
 		return (
-			<div className={ containerClass }>
-				<div className="site-importer__site-preview-container">
-					<div className="site-importer__site-preview-site-meta">
-						<p>
-							<img
-								className="site-importer__site-preview-favicon"
-								src={ this.state.sitePreviewImage }
-								alt="Site favicon"
-							/>
-						</p>
-						<div style={ { display: 'none' } }>
-							<p>Importing:</p>
-							{ this.props.importData.supported &&
-								this.props.importData.supported.length && (
-									<ul>
-										{ map( this.props.importData.supported, ( suppApp, idx ) => (
-											<li key={ idx }>{ suppApp }</li>
-										) ) }
-										<li>Basic pages</li>
-									</ul>
-								) }
+			<div>
+				<div className="site-importer__site-importer-confirm-site-pane-container">
+					<p className="site-importer__site-importer-confirm-site-label">
+						{ this.props.translate( 'Is this your site?' ) }
+					</p>
+					<Button disabled={ isLoading } onClick={ this.props.startImport }>
+						{ this.props.translate( 'Yes! Start import' ) }
+					</Button>
+					<Button disabled={ isLoading } isPrimary={ false } onClick={ this.props.resetImport }>
+						{ this.props.translate( 'No' ) }
+					</Button>
+				</div>
+				<div className={ containerClass }>
+					<div className="site-importer__site-preview-container">
+						<div className="site-importer__site-preview-site-meta">
+							{ this.state.sitePreviewImage && (
+								<p>
+									<img
+										className="site-importer__site-preview-favicon"
+										src={ this.state.sitePreviewImage }
+										alt="Site favicon"
+									/>
+								</p>
+							) }
 						</div>
 					</div>
+					{ isLoading && (
+						<div className="site-importer__site-preview-loading-overlay">
+							<Spinner />
+						</div>
+					) }
 				</div>
-				{ this.props.isLoading && (
-					<div className="site-importer__site-preview-loading-overlay">
-						<Spinner />
-					</div>
-				) }
 			</div>
 		);
 	};

--- a/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
@@ -26,18 +26,19 @@ class SiteImporterSitePreview extends React.Component {
 
 	state = {
 		previewRetries: 0,
-		siteURL: `https://s0.wp.com/mshots/v1/${ this.props.siteURL }${ Math.random() }`, // TODO remove before going to prod
+		siteURL: `https://s0.wp.com/mshots/v1/${ this.props.siteURL }?${ Math.random() }`, // TODO remove before going to prod
 		sitePreviewImage: '',
 		sitePreviewFailed: false,
-		loadingPreviewImage: false,
+		loadingPreviewImage: true,
 	};
 
 	componentDidMount() {
-		this.setState( { loadingPreviewImage: true } );
 		this.loadSitePreview();
 	}
 
 	loadSitePreview = () => {
+		this.setState( { loadingPreviewImage: true } );
+
 		const maxRetries = 40;
 		const retryTimeout = 1500;
 		if ( this.state.previewRetries > maxRetries ) {
@@ -93,19 +94,20 @@ class SiteImporterSitePreview extends React.Component {
 					</Button>
 				</div>
 				<div className={ containerClass }>
-					<div className="site-importer__site-preview-container">
-						<div className="site-importer__site-preview-site-meta">
-							{ this.state.sitePreviewImage && (
-								<p>
-									<img
-										className="site-importer__site-preview-favicon"
-										src={ this.state.sitePreviewImage }
-										alt="Site favicon"
-									/>
-								</p>
-							) }
+					{ this.state.sitePreviewImage && (
+						<div className="site-importer__site-preview-container">
+							<div className="site-importer__site-preview-browser-chrome">
+								<span>● ● ●</span>
+							</div>
+							<div className="site-importer__site-preview-image">
+								<img
+									className="site-importer__site-preview-favicon"
+									src={ this.state.sitePreviewImage }
+									alt="Site favicon"
+								/>
+							</div>
 						</div>
-					</div>
+					) }
 					{ isLoading && (
 						<div className="site-importer__site-preview-loading-overlay">
 							<Spinner />

--- a/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
@@ -8,11 +8,13 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import { map } from 'lodash';
 import classNames from 'classnames';
+import request from 'superagent';
 
 /**
  * Internal dependencies
  */
 import Spinner from 'components/spinner';
+import { retry } from '../../../layout/error';
 
 class SiteImporterSitePreview extends React.Component {
 	static propTypes = {
@@ -20,6 +22,53 @@ class SiteImporterSitePreview extends React.Component {
 		importData: PropTypes.object,
 		isLoading: PropTypes.bool,
 	};
+
+	state = {
+		previewRetries: 0,
+		siteURL: `https://s0.wp.com/mshots/v1/${ this.props.siteURL }${ Math.random() }`, // TODO remove before going to prod
+		sitePreviewImage: '',
+		sitePreviewFailed: false,
+	};
+
+	componentDidMount() {
+		this.loadSitePreview();
+	}
+
+	loadSitePreview = () => {
+		const maxRetries = 40;
+		const retryTimeout = 1500;
+		if ( this.state.previewRetries > maxRetries ) {
+			this.setState( { sitePreviewImage: '', sitePreviewFailed: true } );
+			return;
+		}
+
+		this.setState( { previewRetries: this.state.previewRetries + 1 } );
+
+		// todo loader
+		// disable yes
+		request
+			.get( this.state.siteURL )
+			.responseType( 'blob' )
+			.then( res => {
+				if ( res.type === null || res.type === 'image/gif' ) {
+					setTimeout( this.loadSitePreview, retryTimeout );
+				} else if ( res.type === 'image/jpeg' ) {
+					// TODO end loader
+
+					// const blob = new Blob( [ ], { type: 'image/jpeg' } )
+					const fReader = new FileReader();
+					fReader.onload = ev => {
+						this.setState( { sitePreviewImage: ev.target.result } );
+					};
+					fReader.readAsDataURL( res.xhr.response );
+				}
+			} )
+			.catch( ( err, res ) => {
+				// todo error or retry?
+				debugger;
+			} );
+	};
+
 	render = () => {
 		const containerClass = classNames( 'site-importer__site-preview-overlay-container', {
 			isLoading: this.props.isLoading,
@@ -30,26 +79,13 @@ class SiteImporterSitePreview extends React.Component {
 				<div className="site-importer__site-preview-container">
 					<div className="site-importer__site-preview-site-meta">
 						<p>
-							Is this your site?
-							{ this.props.importData.favicon && (
-								<img
-									className="site-importer__site-preview-favicon"
-									src={ this.props.importData.favicon }
-									height="16px"
-									width="16px"
-									alt="Site favicon"
-								/>
-							) }
-							<a
-								className="site-importer__site-preview-siteurl"
-								href={ this.props.siteURL }
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								{ this.props.siteURL }
-							</a>
+							<img
+								className="site-importer__site-preview-favicon"
+								src={ this.state.sitePreviewImage }
+								alt="Site favicon"
+							/>
 						</p>
-						<div>
+						<div style={ { display: 'none' } }>
 							<p>Importing:</p>
 							{ this.props.importData.supported &&
 								this.props.importData.supported.length && (

--- a/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
@@ -6,7 +6,6 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import { map } from 'lodash';
 import classNames from 'classnames';
 import request from 'superagent';
 
@@ -48,8 +47,6 @@ class SiteImporterSitePreview extends React.Component {
 
 		this.setState( { previewRetries: this.state.previewRetries + 1 } );
 
-		// todo loader
-		// disable yes
 		request
 			.get( this.state.siteURL )
 			.responseType( 'blob' )
@@ -70,9 +67,8 @@ class SiteImporterSitePreview extends React.Component {
 					fReader.readAsDataURL( res.xhr.response );
 				}
 			} )
-			.catch( ( err, res ) => {
-				// todo error or retry?
-				debugger;
+			.catch( () => {
+				// todo error or retry? - test with possible 4xx, 5xx errors
 			} );
 	};
 

--- a/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
@@ -83,9 +83,9 @@ class SiteImporterSitePreview extends React.Component {
 		return (
 			<div>
 				<div className="site-importer__site-importer-confirm-site-pane-container">
-					<p className="site-importer__site-importer-confirm-site-label">
+					<div className="site-importer__site-importer-confirm-site-label">
 						{ this.props.translate( 'Is this your site?' ) }
-					</p>
+					</div>
 					<Button disabled={ isLoading } onClick={ this.props.startImport }>
 						{ this.props.translate( 'Yes! Start import' ) }
 					</Button>

--- a/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
@@ -14,6 +14,7 @@ import { map } from 'lodash';
  */
 import Spinner from 'components/spinner';
 import Button from 'components/forms/form-button';
+import ErrorPane from '../error-pane';
 
 class SiteImporterSitePreview extends React.Component {
 	static propTypes = {
@@ -28,7 +29,7 @@ class SiteImporterSitePreview extends React.Component {
 		previewRetries: 0,
 		siteURL: `https://s0.wp.com/mshots/v1/${ this.props.siteURL }`,
 		sitePreviewImage: '',
-		sitePreviewFailed: false,
+		sitePreviewFailed: true,
 		loadingPreviewImage: true,
 	};
 
@@ -84,56 +85,65 @@ class SiteImporterSitePreview extends React.Component {
 
 		return (
 			<div>
-				<div className="site-importer__site-importer-confirm-site-pane-container">
-					<div className="site-importer__site-importer-confirm-site-label">
-						{ this.props.translate( 'Is this your site?' ) }
+				{ ! isError && (
+					<div>
+						<div className="site-importer__site-importer-confirm-site-pane-container">
+							<div className="site-importer__site-importer-confirm-site-label">
+								{ this.props.translate( 'Is this your site?' ) }
+							</div>
+							<Button disabled={ isLoading } onClick={ this.props.startImport }>
+								{ this.props.translate( 'Yes! Start import' ) }
+							</Button>
+							<Button disabled={ isLoading } isPrimary={ false } onClick={ this.props.resetImport }>
+								{ this.props.translate( 'No' ) }
+							</Button>
+						</div>
+						<div className={ containerClass }>
+							{ this.state.sitePreviewImage && (
+								<div className="site-importer__site-preview-column-container">
+									<div className="site-importer__site-preview-container">
+										<div className="site-importer__site-preview-browser-chrome">
+											<span>● ● ●</span>
+										</div>
+										<div className="site-importer__site-preview-image">
+											<img
+												className="site-importer__site-preview-favicon"
+												src={ this.state.sitePreviewImage }
+												alt="Site favicon"
+											/>
+										</div>
+									</div>
+									<div className="site-importer__site-preview-import-content">
+										<p>{ this.props.translate( 'We will import:' ) }</p>
+										{ this.props.importData.supported &&
+											this.props.importData.supported.length && (
+												<ul>
+													{ map( this.props.importData.supported, ( suppApp, idx ) => (
+														<li key={ idx }>{ suppApp }</li>
+													) ) }
+												</ul>
+											) }
+									</div>
+								</div>
+							) }
+							{ isLoading && (
+								<div className="site-importer__site-preview-loading-overlay">
+									<Spinner />
+								</div>
+							) }
+						</div>
 					</div>
-					<Button disabled={ isLoading } onClick={ this.props.startImport }>
-						{ this.props.translate( 'Yes! Start import' ) }
-					</Button>
-					<Button disabled={ isLoading } isPrimary={ false } onClick={ this.props.resetImport }>
-						{ this.props.translate( 'No' ) }
-					</Button>
-				</div>
-				<div className={ containerClass }>
-					{ this.state.sitePreviewImage && (
-						<div className="site-importer__site-preview-column-container">
-							<div className="site-importer__site-preview-container">
-								<div className="site-importer__site-preview-browser-chrome">
-									<span>● ● ●</span>
-								</div>
-								<div className="site-importer__site-preview-image">
-									<img
-										className="site-importer__site-preview-favicon"
-										src={ this.state.sitePreviewImage }
-										alt="Site favicon"
-									/>
-								</div>
-							</div>
-							<div className="site-importer__site-preview-import-content">
-								<p>{ this.props.translate( 'We will import:' ) }</p>
-								{ this.props.importData.supported &&
-									this.props.importData.supported.length && (
-										<ul>
-											{ map( this.props.importData.supported, ( suppApp, idx ) => (
-												<li key={ idx }>{ suppApp }</li>
-											) ) }
-										</ul>
-									) }
-							</div>
-						</div>
-					) }
-					{ isLoading && (
-						<div className="site-importer__site-preview-loading-overlay">
-							<Spinner />
-						</div>
-					) }
-					{ isError && (
-						<div className="site-importer__site-preview-error">
-							Unable to load preview, please try again later
-						</div>
-					) }
-				</div>
+				) }
+				{ isError && (
+					<div className="site-importer__site-preview-error">
+						<ErrorPane
+							type="importError"
+							description={ this.props.translate(
+								'Unable to load site preview. Please try again later.'
+							) }
+						/>
+					</div>
+				) }
 			</div>
 		);
 	};

--- a/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
@@ -73,51 +73,57 @@ class SiteImporterSitePreview extends React.Component {
 			<div>
 				{ ! isError && (
 					<div>
-						<div className="site-importer__site-importer-confirm-site-pane-container">
-							<div className="site-importer__site-importer-confirm-site-label">
-								{ this.props.translate( 'Is this your site?' ) }
+						{ ! isLoading && (
+							<div>
+								<div className="site-importer__site-importer-confirm-site-pane-container">
+									<div className="site-importer__site-importer-confirm-site-label">
+										{ this.props.translate( 'Is this your site?' ) }
+									</div>
+									<Button disabled={ isLoading } onClick={ this.props.startImport }>
+										{ this.props.translate( 'Yes! Start import' ) }
+									</Button>
+									<Button
+										disabled={ isLoading }
+										isPrimary={ false }
+										onClick={ this.props.resetImport }
+									>
+										{ this.props.translate( 'No' ) }
+									</Button>
+								</div>
+								<div className={ containerClass }>
+									<div className="site-importer__site-preview-column-container">
+										<div className="site-importer__site-preview-container">
+											<div className="site-importer__site-preview-browser-chrome">
+												<span>● ● ●</span>
+											</div>
+											<div className="site-importer__site-preview-image">
+												<img
+													className="site-importer__site-preview-favicon"
+													src={ this.state.sitePreviewImage }
+													alt="Site favicon"
+												/>
+											</div>
+										</div>
+										<div className="site-importer__site-preview-import-content">
+											<p>{ this.props.translate( 'We will import:' ) }</p>
+											{ this.props.importData.supported &&
+												this.props.importData.supported.length && (
+													<ul>
+														{ map( this.props.importData.supported, ( suppApp, idx ) => (
+															<li key={ idx }>{ suppApp }</li>
+														) ) }
+													</ul>
+												) }
+										</div>
+									</div>
+								</div>
 							</div>
-							<Button disabled={ isLoading } onClick={ this.props.startImport }>
-								{ this.props.translate( 'Yes! Start import' ) }
-							</Button>
-							<Button disabled={ isLoading } isPrimary={ false } onClick={ this.props.resetImport }>
-								{ this.props.translate( 'No' ) }
-							</Button>
-						</div>
-						<div className={ containerClass }>
-							{ this.state.sitePreviewImage && (
-								<div className="site-importer__site-preview-column-container">
-									<div className="site-importer__site-preview-container">
-										<div className="site-importer__site-preview-browser-chrome">
-											<span>● ● ●</span>
-										</div>
-										<div className="site-importer__site-preview-image">
-											<img
-												className="site-importer__site-preview-favicon"
-												src={ this.state.sitePreviewImage }
-												alt="Site favicon"
-											/>
-										</div>
-									</div>
-									<div className="site-importer__site-preview-import-content">
-										<p>{ this.props.translate( 'We will import:' ) }</p>
-										{ this.props.importData.supported &&
-											this.props.importData.supported.length && (
-												<ul>
-													{ map( this.props.importData.supported, ( suppApp, idx ) => (
-														<li key={ idx }>{ suppApp }</li>
-													) ) }
-												</ul>
-											) }
-									</div>
-								</div>
-							) }
-							{ isLoading && (
-								<div className="site-importer__site-preview-loading-overlay">
-									<Spinner />
-								</div>
-							) }
-						</div>
+						) }
+						{ isLoading && (
+							<div className="site-importer__site-preview-loading-overlay">
+								<Spinner />
+							</div>
+						) }
 					</div>
 				) }
 				{ isError && (

--- a/client/my-sites/importer/site-importer/site-preview-actions.js
+++ b/client/my-sites/importer/site-importer/site-preview-actions.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import request from 'superagent';
+import { noop } from 'lodash';
+
+const querymShotsEndpoint = ( options ) => {
+	const maxRetries = options.maxRetries || 1;
+	const retryTimeout = options.retryTimeout || 1000;
+	const currentRetries = options.currentRetries || 0;
+	const url = options.url || '';
+
+	const resolve = options.resolve || noop;
+	const reject = options.reject || noop;
+
+
+	if ( ! url ) {
+		// TODO translate
+		reject( 'You must specify a site URL to be able to generate a preview of the site' );
+		return;
+	}
+
+	request
+		.get( `https://s0.wp.com/mshots/v1/${url}` )
+		.responseType( 'blob' )
+		.then( res => {
+			if (
+				( res.type === null || res.type === 'image/gif' ) &&
+				maxRetries > 0 &&
+				currentRetries < maxRetries
+			) {
+				// Still generating the preview or something failed in mShots
+				setTimeout( querymShotsEndpoint.bind( this, {
+					...options,
+					currentRetries: currentRetries + 1
+				} ), retryTimeout );
+			}
+			else if ( res.type === 'image/jpeg' ) {
+				// Successfully generated the preview
+				const fReader = new FileReader();
+				fReader.onload = ev => {
+					resolve( ev.target.result );
+				};
+				fReader.readAsDataURL( res.xhr.response );
+			}
+			else {
+				// TODO translate
+				reject( );
+			}
+		} )
+		.catch( reject ); // Pass through the reject notice
+};
+
+export const loadmShotsPreview = ( options = {} ) => {
+	return new Promise( ( resolve, reject ) => {
+		querymShotsEndpoint( { ...options, resolve, reject } );
+	} );
+};

--- a/client/my-sites/importer/site-importer/site-preview-actions.js
+++ b/client/my-sites/importer/site-importer/site-preview-actions.js
@@ -13,6 +13,8 @@ const querymShotsEndpoint = ( options ) => {
 	const resolve = options.resolve || noop;
 	const reject = options.reject || noop;
 
+	const mShotsEndpointUrl = `https://s0.wp.com/mshots/v1/${url}`;
+
 	if ( ! url ) {
 		// TODO translate
 		reject( 'You must specify a site URL to be able to generate a preview of the site' );
@@ -20,7 +22,7 @@ const querymShotsEndpoint = ( options ) => {
 	}
 
 	request
-		.get( `https://s0.wp.com/mshots/v1/${url}` )
+		.get( mShotsEndpointUrl )
 		.responseType( 'blob' )
 		.then( res => {
 			if (
@@ -40,7 +42,7 @@ const querymShotsEndpoint = ( options ) => {
 					resolve( window.URL.createObjectURL( res.xhr.response ) );
 				}
 				catch ( e ) {
-					reject( e );
+					resolve( mShotsEndpointUrl );
 				}
 			}
 			else {

--- a/client/my-sites/importer/site-importer/site-preview-actions.js
+++ b/client/my-sites/importer/site-importer/site-preview-actions.js
@@ -13,7 +13,6 @@ const querymShotsEndpoint = ( options ) => {
 	const resolve = options.resolve || noop;
 	const reject = options.reject || noop;
 
-
 	if ( ! url ) {
 		// TODO translate
 		reject( 'You must specify a site URL to be able to generate a preview of the site' );
@@ -37,15 +36,15 @@ const querymShotsEndpoint = ( options ) => {
 			}
 			else if ( res.type === 'image/jpeg' ) {
 				// Successfully generated the preview
-				const fReader = new FileReader();
-				fReader.onload = ev => {
-					resolve( ev.target.result );
-				};
-				fReader.readAsDataURL( res.xhr.response );
+				try {
+					resolve( window.URL.createObjectURL( res.xhr.response ) );
+				}
+				catch ( e ) {
+					reject( e );
+				}
 			}
 			else {
-				// TODO translate
-				reject( );
+				reject();
 			}
 		} )
 		.catch( reject ); // Pass through the reject notice

--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -93,10 +93,10 @@
 .importer__upload-content {
 	position: absolute;
 	top: 50%;
-		left: 0;
-		right: 0;
+	left: 0;
+	right: 0;
 	text-align: center;
-	transform: translateY( -50% );
+	transform: translateY(-50%);
 }
 
 .importer__upload-progress,
@@ -114,8 +114,8 @@
 
 .importer__import-spinner {
 	position: absolute;
-		left: 50%;
-	transform: translateX( -50% );
+	left: 50%;
+	transform: translateX(-50%);
 }
 
 .importer__start {
@@ -219,16 +219,16 @@
 		}
 	}
 
-
-
 	& .site-importer__site-importer-confirm-site-pane-container {
 		display: flex;
-		flex-direction: row;
 		align-content: center;
-		justify-content: flex-end;
+		justify-content: center;
 		width: 100%;
-		margin-bottom: 10px;
+		margin: 10px 0 10px 0;
 
+		& .site-importer__site-importer-confirm-site-label {
+			flex-grow: 1;
+		}
 		& .site-importer__site-importer-confirm-site-pane-container-text {
 			margin: inherit;
 		}
@@ -244,13 +244,15 @@
 		color: red;
 	}
 }
+
 .site-importer__site-preview-overlay-container {
 	position: relative;
 
 	& .site-importer__site-preview-container {
 		& .site-importer__site-preview-favicon {
-			margin-left: 10px;
 			vertical-align: middle;
+			border-top: 50px grey;
+			border-radius: 50px;
 		}
 
 		& .site-importer__site-preview-siteurl {

--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -228,6 +228,9 @@
 
 		& .site-importer__site-importer-confirm-site-label {
 			flex-grow: 1;
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
 		}
 		& .site-importer__site-importer-confirm-site-pane-container-text {
 			margin: inherit;

--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -224,7 +224,7 @@
 		align-content: center;
 		justify-content: center;
 		width: 100%;
-		margin: 10px 0 10px 0;
+		margin-bottom: 18px;
 
 		& .site-importer__site-importer-confirm-site-label {
 			flex-grow: 1;
@@ -247,16 +247,34 @@
 
 .site-importer__site-preview-overlay-container {
 	position: relative;
+	display: flex;
+	flex-direction: column;
 
 	& .site-importer__site-preview-container {
+		& .site-importer__site-preview-browser-chrome {
+			flex-grow: 0;
+			flex-shrink: 0;
+
+			border-top-left-radius: 10px;
+			border-top-right-radius: 10px;
+
+			background-color: #c6d7e2;
+			color: #9daeb8;
+			height: 35px;
+
+			padding-left: 12px;
+
+			font-size: 14px;
+			letter-spacing: 2px;
+
+
+			/* Used to center the dots vertically */
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+		}
 		& .site-importer__site-preview-favicon {
 			vertical-align: middle;
-			border-top: 50px grey;
-			border-radius: 50px;
-		}
-
-		& .site-importer__site-preview-siteurl {
-			margin-left: 10px;
 		}
 	}
 }

--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -273,6 +273,19 @@
 			flex-direction: column;
 			justify-content: center;
 		}
+
+		& .site-importer__site-preview-image {
+			&:after {
+				content: "";
+				position: absolute;
+				top: 0;
+				bottom: 0;
+				left: 0;
+				right: 0;
+				background: linear-gradient(to bottom, rgba(255,255,255,0), rgba(255,255,255,0) 50%, rgba(255,255,255,1));
+			}
+		}
+
 		& .site-importer__site-preview-favicon {
 			vertical-align: middle;
 		}

--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -253,7 +253,24 @@
 	display: flex;
 	flex-direction: column;
 
+	& .site-importer__site-preview-column-container {
+		display:flex;
+		flex-direction: row;
+	}
+
+	& .site-importer__site-preview-import-content {
+		flex-grow: 0;
+		flex-shrink: 1;
+
+		min-width: 30%;
+
+		padding-left: 30px;
+	}
+
 	& .site-importer__site-preview-container {
+
+		max-width: 60%;
+
 		& .site-importer__site-preview-browser-chrome {
 			flex-grow: 0;
 			flex-shrink: 0;


### PR DESCRIPTION
This PR adds a better Site Preview step to the Site importer flow.

In the step we will show a screenshot of the site to be imported, so the user can be sure that this is what they want to import.

To test:

1. Check out branch or use Calypso.live link
2. Go to Site importer
3. Try to import a site
4. Verify that on the confirmation step you see a screenshot of the site you want to import
5. Verify no JS errors are generated and the import completes properly after that