### PR TITLE
[Domains] Add TLD filtering interface

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -41,7 +41,8 @@ button {
 		border-color: $gray-lighten-10;
 		color: $gray-dark;
 	}
-	&:active {
+	&:active,
+	&.is-active {
 		border-width: 2px 1px 1px;
 	}
 	&:visited {
@@ -55,7 +56,8 @@ button {
 		border-color: $gray-lighten-30;
 		cursor: default;
 
-		&:active {
+		&:active,
+		&.is-active {
 			border-width: 1px 1px 2px;
 		}
 	}
@@ -202,7 +204,8 @@ button {
 		color: $gray-lighten-30;
 		cursor: default;
 
-		&:active {
+		&:active,
+		&.is-active {
 			border-width: 0;
 		}
 	}
@@ -224,7 +227,8 @@ button {
 
 		&:focus,
 		&:hover,
-		&:active {
+		&:active,
+		&.is-active {
 			color: $link-highlight;
 		}
 
@@ -307,7 +311,8 @@ button {
 
 	&:hover,
 	&:focus,
-	&:active {
+	&:active,
+	&.is-active {
 		color: $link-highlight;
 		box-shadow: none;
 	}

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -249,6 +249,7 @@ class DomainSearchResults extends React.Component {
 				);
 			}
 		} else {
+			featuredSuggestionElement = <FeaturedDomainSuggestions showPlaceholders />;
 			suggestionElements = this.renderPlaceholders();
 		}
 
@@ -256,6 +257,7 @@ class DomainSearchResults extends React.Component {
 			<div className="domain-search-results__domain-suggestions">
 				{ suggestionCount }
 				{ featuredSuggestionElement }
+				{ this.props.children }
 				{ suggestionElements }
 				{ unavailableOffer }
 			</div>

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -12,6 +12,7 @@ import { pick } from 'lodash';
 /**
  * Internal dependencies
  */
+import FeaturedDomainSuggestionsPlaceholder from 'components/domains/featured-domain-suggestions/placeholder';
 import DomainRegistrationSuggestion from 'components/domains/domain-registration-suggestion';
 
 export class FeaturedDomainSuggestions extends Component {
@@ -19,6 +20,7 @@ export class FeaturedDomainSuggestions extends Component {
 		cart: PropTypes.object,
 		primarySuggestion: PropTypes.object,
 		secondarySuggestion: PropTypes.object,
+		showPlaceholders: PropTypes.bool,
 	};
 
 	getChildProps() {
@@ -85,6 +87,10 @@ export class FeaturedDomainSuggestions extends Component {
 		const { primarySuggestion, secondarySuggestion } = this.props;
 		const childProps = this.getChildProps();
 
+		if ( this.props.showPlaceholders ) {
+			return this.renderPlaceholders();
+		}
+
 		return (
 			<div className={ this.getClassNames() }>
 				{ primarySuggestion && (
@@ -101,6 +107,15 @@ export class FeaturedDomainSuggestions extends Component {
 						{ ...childProps }
 					/>
 				) }
+			</div>
+		);
+	}
+
+	renderPlaceholders() {
+		return (
+			<div className={ this.getClassNames() }>
+				<FeaturedDomainSuggestionsPlaceholder />
+				<FeaturedDomainSuggestionsPlaceholder />
 			</div>
 		);
 	}

--- a/client/components/domains/featured-domain-suggestions/placeholder.jsx
+++ b/client/components/domains/featured-domain-suggestions/placeholder.jsx
@@ -1,0 +1,22 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default function FeaturedDomainSuggestionsPlaceholder() {
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	return (
+		<div className="featured-domain-suggestion featured-domain-suggestion--is-placeholder card is-compact is-clickable">
+			<div className="domain-suggestion__content">
+				<div className="domain-registration-suggestion__title" />
+				<div className="domain-product-price" />
+				<div className="domain-registration-suggestion__progress-bar" />
+				<div className="domain-registration-suggestion__match-reasons" />
+			</div>
+			<div className="domain-suggestion__action" />
+		</div>
+	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
+}

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -47,3 +47,33 @@
 .main.domain-search-page-wrapper .featured-domain-suggestions {
 	flex-wrap: wrap;
 }
+
+.featured-domain-suggestion {
+	&.featured-domain-suggestion--is-placeholder {
+		height: 222px;
+
+		.domain-registration-suggestion__title,
+		.domain-registration-suggestion__progress-bar,
+		.domain-registration-suggestion__match-reasons,
+		.domain-suggestion__action {
+			animation: loading-fade 1.6s ease-in-out infinite;
+			background-color: $gray-lighten-30;
+			color: transparent;
+		}
+		.domain-registration-suggestion__title {
+			height: 45px;
+		}
+		.domain-product-price {
+			height: 18px;
+		}
+		.domain-registration-suggestion__progress-bar {
+			height: 22px;
+		}
+		.domain-registration-suggestion__match-reasons {
+			height: 52px;
+		}
+		.domain-suggestion__action {
+			height: 40px;
+		}
+	}
+}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -448,10 +448,13 @@ class RegisterDomainStep extends React.Component {
 		} );
 	};
 
-	onFiltersReset = () => {
+	onFiltersReset = ( ...keysToReset ) => {
 		this.setState(
 			{
-				filters: this.getInitialFiltersState(),
+				filters: {
+					...this.state.filters,
+					...pick( this.getInitialFiltersState(), keysToReset ),
+				},
 			},
 			() => {
 				this.repeatSearch();

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -357,8 +357,13 @@ class RegisterDomainStep extends React.Component {
 
 	renderSearchFilters() {
 		const isKrackenUi = config.isEnabled( 'domains/kracken-ui/filters' );
+		const isRenderingInitialSuggestions =
+			! Array.isArray( this.state.searchResults ) &&
+			! this.state.loadingResults &&
+			! this.props.showExampleSuggestions;
 		return (
-			isKrackenUi && (
+			isKrackenUi &&
+			! isRenderingInitialSuggestions && (
 				<div className="register-domain-step__filter">
 					<SearchFilters
 						availableTlds={ this.state.availableTlds }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -339,7 +339,7 @@ class RegisterDomainStep extends React.Component {
 						showDismiss={ false }
 					/>
 				) }
-				{ this.content() }
+				{ this.renderContent() }
 				{ this.renderPaginationControls() }
 				{ queryObject && <QueryDomainsSuggestions { ...queryObject } /> }
 				<QueryContactDetailsCache />
@@ -396,16 +396,16 @@ class RegisterDomainStep extends React.Component {
 		this.setState( { clickedExampleSuggestion: true } );
 	};
 
-	content() {
+	renderContent() {
 		if ( Array.isArray( this.state.searchResults ) || this.state.loadingResults ) {
-			return this.allSearchResults();
+			return this.renderSearchResults();
 		}
 
 		if ( this.props.showExampleSuggestions ) {
-			return this.getExampleSuggestions();
+			return this.renderExampleSuggestions();
 		}
 
-		return this.initialSuggestions();
+		return this.renderInitialSuggestions();
 	}
 
 	save = () => {
@@ -781,7 +781,7 @@ class RegisterDomainStep extends React.Component {
 		);
 	};
 
-	initialSuggestions() {
+	renderInitialSuggestions() {
 		let domainRegistrationSuggestions;
 		let domainUnavailableSuggestion;
 		let suggestions;
@@ -827,7 +827,7 @@ class RegisterDomainStep extends React.Component {
 		);
 	}
 
-	getExampleSuggestions() {
+	renderExampleSuggestions() {
 		return (
 			<ExampleDomainSuggestions
 				onClickExampleSuggestion={ this.handleClickExampleSuggestion }
@@ -839,7 +839,7 @@ class RegisterDomainStep extends React.Component {
 		);
 	}
 
-	allSearchResults() {
+	renderSearchResults() {
 		const {
 			exactMatchDomain,
 			lastDomainIsTransferrable,
@@ -866,7 +866,7 @@ class RegisterDomainStep extends React.Component {
 		if ( suggestions.length === 0 && ! this.state.loadingResults ) {
 			// the search returned no results
 			if ( this.props.showExampleSuggestions ) {
-				return this.getExampleSuggestions();
+				return this.renderExampleSuggestions();
 			}
 
 			suggestions = this.props.defaultSuggestions || [];

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -413,17 +413,22 @@ class RegisterDomainStep extends React.Component {
 	};
 
 	repeatSearch = ( stateOverride = {}, { shouldQuerySubdomains = true } = {} ) => {
+		this.save();
+
+		const { lastQuery } = this.state;
+		const loadingResults = Boolean( getFixedDomainSearch( lastQuery ) );
+
 		const nextState = {
 			exactMatchDomain: null,
 			lastDomainSearched: null,
-			loadingResults: true,
-			loadingSubdomainResults: true,
+			loadingResults,
+			loadingSubdomainResults: loadingResults,
 			notice: null,
 			...stateOverride,
 		};
 		debug( 'Repeating a search with the following input for setState', nextState );
 		this.setState( nextState, () => {
-			this.onSearch( this.state.lastQuery, { shouldQuerySubdomains } );
+			loadingResults && this.onSearch( lastQuery, { shouldQuerySubdomains } );
 		} );
 	};
 
@@ -448,7 +453,9 @@ class RegisterDomainStep extends React.Component {
 			{
 				filters: this.getInitialFiltersState(),
 			},
-			this.repeatSearch
+			() => {
+				this.repeatSearch();
+			}
 		);
 	};
 
@@ -474,6 +481,7 @@ class RegisterDomainStep extends React.Component {
 				pageNumber: 1,
 				searchResults: null,
 				subdomainSearchResults: null,
+				...( loadingResults ? { filters: this.getInitialFiltersState() } : {} ),
 			},
 			callback
 		);

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -541,7 +541,6 @@ class RegisterDomainStep extends React.Component {
 				pageNumber: 1,
 				searchResults: null,
 				subdomainSearchResults: null,
-				...( loadingResults ? { filters: this.getInitialFiltersState() } : {} ),
 			},
 			callback
 		);

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -28,11 +28,9 @@
 }
 
 .register-domain-step.is-kracken-ui {
-	.register-domain-step__search {
-		padding-bottom: 10px;
-	}
+	.register-domain-step__search,
 	.register-domain-step__filter {
-		padding-bottom: 20px;
+		padding-bottom: 12px;
 	}
 }
 

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -113,3 +113,23 @@
 		}
 	}
 }
+
+.register-domain-step__tld-buttons {
+	display: flex;
+	justify-content: space-between;
+
+	.button {
+		flex-grow: 1;
+		margin-right: 1em;
+
+		&:last-child {
+			margin-right: 0;
+		}
+	}
+}
+
+.register-domain-step {
+	.button.is-active {
+		background: $gray-lighten-30;
+	}
+}

--- a/client/components/domains/search-filters/index.jsx
+++ b/client/components/domains/search-filters/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { pick, noop } from 'lodash';
@@ -11,8 +10,8 @@ import { pick, noop } from 'lodash';
 /**
  * Internal dependencies
  */
-
 import MoreFiltersControl from './more-filters';
+import TldFilterControl from './tld-filter';
 
 export default class SearchFilters extends Component {
 	static propTypes = {
@@ -20,7 +19,9 @@ export default class SearchFilters extends Component {
 			includeDashes: PropTypes.bool,
 			maxCharacters: PropTypes.string,
 			showExactMatchesOnly: PropTypes.bool,
+			tlds: PropTypes.arrayOf( PropTypes.string ),
 		} ).isRequired,
+		availableTlds: PropTypes.arrayOf( PropTypes.string ),
 		onChange: PropTypes.func,
 		onFiltersReset: PropTypes.func,
 		onFiltersSubmit: PropTypes.func,
@@ -48,10 +49,14 @@ export default class SearchFilters extends Component {
 						'includeDashes',
 						'maxCharacters',
 						'showExactMatchesOnly',
-						'onFiltersReset',
 					] ) }
 					onChange={ this.updateFilterValues }
 					{ ...pick( this.props, [ 'onFiltersReset', 'onFiltersSubmit' ] ) }
+				/>
+				<TldFilterControl
+					{ ...pick( this.props.filters, [ 'tlds' ] ) }
+					onChange={ this.updateFilterValues }
+					{ ...pick( this.props, [ 'availableTlds', 'onFiltersReset', 'onFiltersSubmit' ] ) }
 				/>
 			</div>
 		);

--- a/client/components/domains/search-filters/more-filters.jsx
+++ b/client/components/domains/search-filters/more-filters.jsx
@@ -80,7 +80,7 @@ export class MoreFiltersControl extends Component {
 	handleFiltersReset = () => {
 		this.setState( { showOverallValidationError: false }, () => {
 			this.togglePopover();
-			this.props.onFiltersReset();
+			this.props.onFiltersReset( 'includeDashes', 'maxCharacters', 'showExactMatchesOnly' );
 		} );
 	};
 	handleFiltersSubmit = () => {

--- a/client/components/domains/search-filters/more-filters.jsx
+++ b/client/components/domains/search-filters/more-filters.jsx
@@ -99,7 +99,7 @@ export class MoreFiltersControl extends Component {
 		const { translate } = this.props;
 		const hasFilterValues = this.getFiltercounts() > 0;
 		return (
-			<div className="search-filters__more-filters">
+			<div className="search-filters__filter search-filters__more-filters">
 				<Button
 					primary={ hasFilterValues }
 					ref={ button => ( this.button = button ) } // eslint-disable-line react/jsx-no-bind

--- a/client/components/domains/search-filters/more-filters.jsx
+++ b/client/components/domains/search-filters/more-filters.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Gridicon from 'gridicons';
@@ -101,7 +101,7 @@ export class MoreFiltersControl extends Component {
 		return (
 			<div className="search-filters__filter search-filters__more-filters">
 				<Button
-					primary={ hasFilterValues }
+					className={ classNames( { 'is-active': hasFilterValues } ) }
 					ref={ button => ( this.button = button ) } // eslint-disable-line react/jsx-no-bind
 					onClick={ this.togglePopover }
 				>

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -92,7 +92,6 @@
 	.token-field__input-container {
 		margin-left: 0.4em;
 		margin-right: 0.4em;
-		border-bottom: 1px solid $gray-lighten-20;
 	}
 
 	input[type='text'].token-field__input {
@@ -100,6 +99,7 @@
 	}
 
 	.token-field__suggestions-list.is-expanded {
-		border-top: none;
+		padding-top: 0;
+		overflow-y: scroll;
 	}
 }

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -1,5 +1,16 @@
 /** @format */
 
+.search-filters {
+	display: flex;
+}
+
+.search-filters__filter {
+	margin-right: 1em;
+	&:last-child {
+		margin-right: 0;
+	}
+}
+
 .search-filters__popover {
 	width: 28em;
 
@@ -14,6 +25,10 @@
 
 	.form-fieldset {
 		text-align: left;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
 
 	.validation-fieldset {
@@ -47,5 +62,44 @@
 
 	&:last-of-type {
 		margin-bottom: 0;
+	}
+}
+
+.search-filters__token-field-fieldset {
+	.token-field__token {
+		&:first-child {
+			margin-left: 0;
+		}
+	}
+	.token-field__token-text,
+	.token-field__remove-token {
+		background: $white;
+		color: $gray-darken-20;
+		border: 1px solid $gray-lighten-20;
+	}
+	.token-field__token-text {
+		border-right: none;
+	}
+	.token-field__remove-token {
+		border-left: none;
+
+		&:hover {
+			background: $gray-lighten-20;
+			color: $gray-darken-20;
+		}
+	}
+
+	.token-field__input-container {
+		margin-left: 0.4em;
+		margin-right: 0.4em;
+		border-bottom: 1px solid $gray-lighten-20;
+	}
+
+	input[type='text'].token-field__input {
+		margin-left: 0;
+	}
+
+	.token-field__suggestions-list.is-expanded {
+		border-top: none;
 	}
 }

--- a/client/components/domains/search-filters/tld-filter.jsx
+++ b/client/components/domains/search-filters/tld-filter.jsx
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -58,7 +59,11 @@ export class TldFilterControl extends Component {
 		const hasFilterValue = tlds.length > 0;
 		return (
 			<div className="search-filters__filter search-filters__tld-filter">
-				<Button primary={ hasFilterValue } onClick={ this.togglePopover } ref={ this.bindButton }>
+				<Button
+					className={ classNames( { 'is-active': hasFilterValue } ) }
+					onClick={ this.togglePopover }
+					ref={ this.bindButton }
+				>
 					{ translate( 'Extensions', {
 						context: 'Refers to top level domain name extension, such as ".com"',
 					} ) }

--- a/client/components/domains/search-filters/tld-filter.jsx
+++ b/client/components/domains/search-filters/tld-filter.jsx
@@ -1,0 +1,108 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import Gridicon from 'gridicons';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { includes } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import FormFieldset from 'components/forms/form-fieldset';
+import Popover from 'components/popover';
+import TokenField from 'components/token-field';
+
+export class TldFilterControl extends Component {
+	static propTypes = {
+		availableTlds: PropTypes.arrayOf( PropTypes.string ).isRequired,
+		onChange: PropTypes.func.isRequired,
+		onFiltersReset: PropTypes.func.isRequired,
+		onFiltersSubmit: PropTypes.func.isRequired,
+		tlds: PropTypes.arrayOf( PropTypes.string ).isRequired,
+	};
+
+	state = {
+		showPopover: false,
+	};
+
+	togglePopover = () => {
+		this.setState( {
+			showPopover: ! this.state.showPopover,
+		} );
+	};
+
+	handleFiltersReset = () => {
+		this.togglePopover();
+		this.props.onFiltersReset( 'tlds' );
+	};
+	handleFiltersSubmit = () => {
+		this.togglePopover();
+		this.props.onFiltersSubmit();
+	};
+	handleOnChange = newTlds => {
+		this.props.onChange(
+			'tlds',
+			newTlds.filter( tld => includes( this.props.availableTlds, tld ) )
+		);
+	};
+
+	bindButton = button => ( this.button = button );
+
+	render() {
+		const { tlds, translate } = this.props;
+		const hasFilterValue = tlds.length > 0;
+		return (
+			<div className="search-filters__filter search-filters__tld-filter">
+				<Button primary={ hasFilterValue } onClick={ this.togglePopover } ref={ this.bindButton }>
+					{ translate( 'Extensions', {
+						context: 'Refers to top level domain name extension, such as ".com"',
+					} ) }
+					<Gridicon icon="chevron-down" size={ 24 } />
+				</Button>
+
+				{ this.state.showPopover && this.renderPopover() }
+			</div>
+		);
+	}
+
+	renderPopover() {
+		const { tlds, translate } = this.props;
+
+		return (
+			<Popover
+				autoPosition={ false }
+				className="search-filters__popover"
+				context={ this.button }
+				isVisible={ this.state.showPopover }
+				onClose={ this.togglePopover }
+				position="bottom right"
+			>
+				<FormFieldset className="search-filters__token-field-fieldset">
+					<TokenField
+						isExpanded
+						onChange={ this.handleOnChange }
+						placeholder={ translate( 'Select an extension' ) }
+						suggestions={ this.props.availableTlds }
+						tokenizeOnSpace
+						value={ tlds }
+					/>
+				</FormFieldset>
+				<FormFieldset className="search-filters__buttons-fieldset">
+					<div className="search-filters__buttons">
+						<Button onClick={ this.handleFiltersReset }>{ translate( 'Reset' ) }</Button>
+						<Button primary onClick={ this.handleFiltersSubmit }>
+							{ translate( 'Apply' ) }
+						</Button>
+					</div>
+				</FormFieldset>
+			</Popover>
+		);
+	}
+}
+
+export default localize( TldFilterControl );

--- a/client/components/token-field/README.md
+++ b/client/components/token-field/README.md
@@ -51,6 +51,7 @@ The `value` property is handled in a manner similar to controlled form component
 - `disabled` - When true, tokens are not able to be added or removed.
 - `placeholder` - If passed, the `TokenField` input will show a placeholder string if no value tokens are present.
 - `id` - the ID of the token input, should be unique.
+- `isExpanded` - If true, the `TokenField` input will always keep the suggestion list expanded.
 
 ### Example
 

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -31,6 +31,7 @@ class TokenField extends PureComponent {
 		tokenizeOnSpace: PropTypes.bool,
 		placeholder: PropTypes.string,
 		id: PropTypes.string,
+		isExpanded: PropTypes.bool,
 		value: function( props ) {
 			const value = props.value;
 			if ( ! Array.isArray( value ) ) {
@@ -62,6 +63,7 @@ class TokenField extends PureComponent {
 		isBorderless: false,
 		disabled: false,
 		tokenizeOnSpace: false,
+		isExpanded: false,
 	};
 
 	static initialState = {
@@ -121,7 +123,7 @@ class TokenField extends PureComponent {
 					suggestions={ this._getMatchingSuggestions() }
 					selectedIndex={ this.state.selectedSuggestionIndex }
 					scrollIntoView={ this.state.selectedSuggestionScroll }
-					isExpanded={ this.state.isActive }
+					isExpanded={ this.props.isExpanded || this.state.isActive }
 					onHover={ this._onSuggestionHovered }
 					onSelect={ this._onSuggestionSelected }
 				/>

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -271,6 +271,10 @@ function getDomainPrice( slug, productsList, currencyCode ) {
 	return price;
 }
 
+function getAvailableTlds() {
+	return wpcom.undocumented().getAvailableTlds();
+}
+
 export {
 	canAddGoogleApps,
 	canRedirect,
@@ -297,4 +301,5 @@ export {
 	resendInboundTransferEmail,
 	restartInboundTransfer,
 	startInboundTransfer,
+	getAvailableTlds,
 };

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -493,6 +493,17 @@ Undocumented.prototype.resendInboundTransferEmail = function( domain, fn ) {
 };
 
 /**
+ * Fetches a list of available top-level domain names ordered by popularity.
+ *
+ * @param {Function} fn The callback function
+ * @returns {Promise} A promise that resolves when the request completes
+ * @api public
+ */
+Undocumented.prototype.getAvailableTlds = function( fn ) {
+	return this.wpcom.req.get( '/domains/suggestions/tlds', fn );
+};
+
+/**
  * Determine whether a domain name can be used for Site Redirect
  *
  * @param {int|string} siteId The site ID


### PR DESCRIPTION
This change adds a TLD filtering interface for our domain registration interface, like so:

<img width="979" alt="Initial interface with TLD buttons visible" src="https://user-images.githubusercontent.com/4044428/39018858-903e1cf8-43e4-11e8-95b1-5efb7eb94a4c.png">

<img width="977" alt="Summoned Filtering Popover" src="https://user-images.githubusercontent.com/4044428/39018895-b12cdf26-43e4-11e8-952d-9fa17b4953f7.png">

# Test Instructions
1) Spin up this branch locally. *
2) Navigate to `/start/domains` and enter a query.
3) Try clicking one of the TLD buttons located below the featured results. Doing so will immediately kick off a new search. The TLDs used for these buttons are currently static.

<img width="977" alt="TLD Buttons" src="https://user-images.githubusercontent.com/4044428/39019329-2185050e-43e6-11e8-8d23-e7fe342e6d4c.png">


4) Click the `Extensions` drop-down button. Ensure that the TLD selected in step 3 has already been populated in the drop-down.

<img width="358" alt="Extensions drop-down" src="https://user-images.githubusercontent.com/4044428/39019393-60118c66-43e6-11e8-9f79-614ba7367213.png">

5) Try selecting additional TLDs from the drop-down interface and click `Apply`.
6) Ensure that the newly selected TLDs from step 5 are marked as active in the TLD buttons.
7) Try setting any of the filters from the `More Filters` drop-down. Some of the filters here have not yet been implemented in the API.

<img width="364" alt="More Filters drop-down" src="https://user-images.githubusercontent.com/4044428/39019423-7a03dba6-43e6-11e8-9b94-e0858e6bba7f.png">


8) Open the `Extensions` drop-down and click `Reset`. Ensure that your filters from the `More Filters` drop-down has been preserved.

`*` You can also spin up a local production instance with docker. If you do so, make sure to add a query string to step 2 to ensure that the necessary features have been enabled: `/start/domains?flags=domains/kracken-ui,domains/kracken-ui/filters`