### PR TITLE
[Domains] Remove domain flags

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -86,6 +86,10 @@ class DomainRegistrationSuggestion extends React.Component {
 	};
 
 	getDomainFlags() {
+		// TODO: Remove this entire function and isNewTld/isTestTld from utility.js
+		if ( config.isEnabled( 'domains/kracken-ui' ) ) {
+			return null;
+		}
 		const { suggestion, translate } = this.props;
 		const domain = suggestion.domain_name;
 		const domainFlags = [];
@@ -117,25 +121,23 @@ class DomainRegistrationSuggestion extends React.Component {
 			}
 		}
 
-		if ( ! config.isEnabled( 'domains/kracken-ui' ) ) {
-			if ( suggestion.isRecommended ) {
-				domainFlags.push(
-					<DomainSuggestionFlag
-						key={ `${ domain }-recommended` }
-						content={ translate( 'Recommended' ) }
-						status="success"
-					/>
-				);
-			}
+		if ( suggestion.isRecommended ) {
+			domainFlags.push(
+				<DomainSuggestionFlag
+					key={ `${ domain }-recommended` }
+					content={ translate( 'Recommended' ) }
+					status="success"
+				/>
+			);
+		}
 
-			if ( suggestion.isBestAlternative ) {
-				domainFlags.push(
-					<DomainSuggestionFlag
-						key={ `${ domain }-best-alternative` }
-						content={ translate( 'Best Alternative' ) }
-					/>
-				);
-			}
+		if ( suggestion.isBestAlternative ) {
+			domainFlags.push(
+				<DomainSuggestionFlag
+					key={ `${ domain }-best-alternative` }
+					content={ translate( 'Best Alternative' ) }
+				/>
+			);
 		}
 
 		return domainFlags;


### PR DESCRIPTION
As noted from our internal feedback, we will be removing all domain suggestion flags from the domain registration interfaces.

<img width="1469" alt="screen-shot-2018-04-17-at-8-27-03-am_png__2224x530_" src="https://user-images.githubusercontent.com/4044428/39022091-2aef0788-43f1-11e8-9e22-18157df3aabe.png">

# Test Instructions
1) Spin up this branch locally.
2) Navigate to `/start/domains` and try a query.
3) Ensure that no flags appear on any domain suggestions. 
    - In my experience, querying `spirityoga` resulted in suggestions that used to display a flag (ex. `spirityoga.design`). 
    - Any domain with a TLD in [this list](https://github.com/Automattic/wp-calypso/blob/e7758d9831cde0e8db9263a129f14cd386a26afa/client/components/domains/domain-registration-suggestion/utility.js#L14) were formerly tagged with a flag.