### PR TITLE
DevDocs: add doc template for components

### DIFF
--- a/client/components/button/README.md
+++ b/client/components/button/README.md
@@ -1,11 +1,12 @@
 Button
-=========
+===
 
-This component is used to implement dang sweet buttons.
+Buttons express what action will occur when the user clicks or taps it. Buttons are used to trigger an action, and they can be used for any type of action, including navigation.
 
-#### How to use:
+## Usage
 
 ```jsx
+import Gridicon from 'gridicons';
 import Button from 'components/button';
 
 export default function RockOnButton() {
@@ -17,12 +18,53 @@ export default function RockOnButton() {
 }
 ```
 
-#### Props
+### Props
 
-The following props are used to control the display of the component. Any additional props will be passed to the rendered `<a />` or `<button />` element. The presence of a `href` prop determines whether an anchor element is rendered instead of a button.
+Name | Type | Default | Description
+--- | --- | --- | ---
+`compact` | `bool` |  | Decreases the size of the button
+`primary` | `bool` |  | Provides extra visual weight and identifies the primary action in a set of buttons
+`borderless` | `bool` |  | Renders a button without borders
+`scary` | `bool` |  | Indicates a dangerous or potentially negative action
+`busy` | `bool` |  | Indicates activity while a background action is being performed
+`href` | `string` |  | If provided, renders `a` instead of `button`
 
-* `compact`: (bool) whether the button is compact or not.
-* `primary`: (bool) whether the button is styled as a primary button.
-* `scary`: (bool) whether the button has modified styling to warn users (delete, remove, etc).
-* `href`: (string) if this property is added, it will use an `a` rather than a `button` element.
-* `borderless`: (bool) whether button should be displayed without borders
+### Button types
+
+* **Primary**: Use to highlight the most important actions in any experience. Don’t use more than one primary button in a section or screen to avoid overwhelming customers.
+* **Secondary**: Used most in the interface. Only use another style if a button requires more or less visual weight.
+* **Button with icon**: When words are not enough, icons can be used in buttons to better communicate what the button does.
+* **Scary**: Use when the action will delete customer data or be otherwise difficult to recover from. Destructive buttons should trigger a confirmation dialog before the action is completed. Be thoughtful about using destructive buttons because they can feel stressful for customers.
+* **Borderless**: Use for less important or less commonly used actions since they’re less prominent.
+* **Busy**: Use when a button has been pressed and the associated action is in progress.
+
+#### Icon buttons
+
+To use an icon button, insert a Gridicon so that it displays to the left of the text (displaying the `external` icon to the right of the text is the exception). Wrap the text in a `span` with the `button-text` class. You may also create a button without text, but use sparingly because it may reduce clarity.
+
+```jsx
+import Gridicon from 'gridicons';
+import Button from 'components/button';
+
+export default function RockOnButton() {
+	return (
+		<Button>
+			<Gridicon icon="trash" />
+			<span className="button-text">Button with icon</span>
+		</Button>
+	);
+}
+```
+
+### General guidelines
+
+* Use clear and accurate labels. Use sentence-style capitalization.
+* Lead with strong, concise, and actionable verbs.
+* When the customer is confirming an action, use specific labels, such as **Save** or **Trash**, instead of using **OK** and **Cancel**.
+* Prioritize the most important actions. Too many calls to action can cause confusion and make customers unsure of what to do next.
+
+## Related components
+
+* To group buttons together, use the [ButtonGroup](./button-group) component.
+* To use a button with a secondary popover menu, use the [SplitButton](./split-button) component.
+* To display a loading spinner with a button, use the [SpinnerButton](./spinner-button) component.

--- a/client/components/button/README.md
+++ b/client/components/button/README.md
@@ -40,7 +40,7 @@ Name | Type | Default | Description
 
 #### Icon buttons
 
-To use an icon button, insert a Gridicon so that it displays to the left of the text (displaying the `external` icon to the right of the text is the exception). Wrap the text in a `span` with the `button-text` class. You may also create a button without text, but use sparingly because it may reduce clarity.
+To use an icon button, insert a Gridicon so that it displays to the left of the text (displaying the `external` icon to the right of the text is the exception). Wrap the text in a `span` or some other element for spacing purposes. You may also create an icon button without text, but use sparingly because it may reduce clarity.
 
 ```jsx
 import Gridicon from 'gridicons';
@@ -50,7 +50,7 @@ export default function RockOnButton() {
 	return (
 		<Button>
 			<Gridicon icon="trash" />
-			<span className="button-text">Button with icon</span>
+			<span>Button with icon</span>
 		</Button>
 	);
 }

--- a/client/components/button/README.md
+++ b/client/components/button/README.md
@@ -22,12 +22,12 @@ export default function RockOnButton() {
 
 Name | Type | Default | Description
 --- | --- | --- | ---
-`compact` | `bool` |  | Decreases the size of the button
-`primary` | `bool` |  | Provides extra visual weight and identifies the primary action in a set of buttons
-`borderless` | `bool` |  | Renders a button without borders
-`scary` | `bool` |  | Indicates a dangerous or potentially negative action
-`busy` | `bool` |  | Indicates activity while a background action is being performed
-`href` | `string` |  | If provided, renders `a` instead of `button`
+`compact` | `bool` | false | Decreases the size of the button
+`primary` | `bool` | false | Provides extra visual weight and identifies the primary action in a set of buttons
+`borderless` | `bool` | false | Renders a button without borders
+`scary` | `bool` | false | Indicates a dangerous or potentially negative action
+`busy` | `bool` | false | Indicates activity while a background action is being performed
+`href` | `string` | null | If provided, renders `a` instead of `button`
 
 ### Button types
 

--- a/client/components/button/docs/example.jsx
+++ b/client/components/button/docs/example.jsx
@@ -18,320 +18,182 @@ import DocsExample from 'devdocs/docs-example';
 class Buttons extends React.PureComponent {
 	static displayName = 'Buttons';
 
-	state = {
-		compactButtons: false,
+	static defaultProps = {
+		exampleCode: (
+			<Card>
+				<div className="docs__design-button-row">
+					<Button>Button</Button>
+					<Button>
+						<Gridicon icon="heart" />
+						<span className="button-text">Icon button</span>
+					</Button>
+					<Button>
+						<Gridicon icon="plugins" />
+					</Button>
+					<Button disabled>Disabled button</Button>
+				</div>
+				<div className="docs__design-button-row">
+					<Button scary>Scary button</Button>
+					<Button scary>
+						<Gridicon icon="globe" />
+						<span className="button-text">Scary icon button</span>
+					</Button>
+					<Button scary>
+						<Gridicon icon="pencil" />
+					</Button>
+					<Button scary disabled>
+						Scary disabled button
+					</Button>
+				</div>
+				<div className="docs__design-button-row">
+					<Button primary>Primary button</Button>
+					<Button primary>
+						<Gridicon icon="camera" />
+						<span className="button-text">Primary icon button</span>
+					</Button>
+					<Button primary>
+						<Gridicon icon="time" />
+					</Button>
+					<Button primary disabled>
+						Primary disabled button
+					</Button>
+				</div>
+				<div className="docs__design-button-row">
+					<Button primary scary>
+						Primary scary button
+					</Button>
+					<Button primary scary>
+						<Gridicon icon="user-circle" />
+						<span className="button-text">Primary scary icon button</span>
+					</Button>
+					<Button primary scary>
+						<Gridicon icon="cart" />
+					</Button>
+					<Button primary scary disabled>
+						Primary scary disabled button
+					</Button>
+				</div>
+				<div className="docs__design-button-row">
+					<Button borderless>
+						<Gridicon icon="cross" />
+						<span className="button-text">Remove</span>
+					</Button>
+					<Button borderless>
+						<Gridicon icon="trash" />
+						<span className="button-text">Trash</span>
+					</Button>
+					<Button borderless>
+						<Gridicon icon="link-break" />
+						<span className="button-text">Disconnect</span>
+					</Button>
+					<Button borderless>
+						<Gridicon icon="trash" />
+					</Button>
+					<Button borderless disabled>
+						<Gridicon icon="cross" />
+						<span className="button-text">Remove</span>
+					</Button>
+				</div>
+				<div className="docs__design-button-row">
+					<Button borderless primary>
+						<Gridicon icon="cross" />
+						<span className="button-text">Remove</span>
+					</Button>
+					<Button borderless primary>
+						<Gridicon icon="trash" />
+						<span className="button-text">Trash</span>
+					</Button>
+					<Button borderless primary>
+						<Gridicon icon="link-break" />
+						<span className="button-text">Disconnect</span>
+					</Button>
+					<Button borderless primary>
+						<Gridicon icon="trash" />
+					</Button>
+					<Button borderless primary disabled>
+						<Gridicon icon="cross" />
+						<span className="button-text">Remove</span>
+					</Button>
+				</div>
+				<div className="docs__design-button-row">
+					<Button borderless scary>
+						<Gridicon icon="cross" />
+						<span className="button-text">Remove</span>
+					</Button>
+					<Button borderless scary>
+						<Gridicon icon="trash" />
+						<span className="button-text">Trash</span>
+					</Button>
+					<Button borderless scary>
+						<Gridicon icon="link-break" />
+						<span className="button-text">Disconnect</span>
+					</Button>
+					<Button borderless scary>
+						<Gridicon icon="trash" />
+					</Button>
+					<Button borderless scary disabled>
+						<Gridicon icon="cross" />
+						<span className="button-text">Remove</span>
+					</Button>
+				</div>
+				<div className="docs__design-button-row">
+					<Button compact>
+						<Gridicon icon="cross" />
+						<span className="button-text">Remove</span>
+					</Button>
+					<Button compact>
+						<Gridicon icon="trash" />
+						<span className="button-text">Trash</span>
+					</Button>
+					<Button compact>
+						<Gridicon icon="link-break" />
+						<span className="button-text">Disconnect</span>
+					</Button>
+					<Button compact>
+						<Gridicon icon="trash" />
+					</Button>
+					<Button compact disabled>
+						<Gridicon icon="cross" />
+						<span className="button-text">Remove</span>
+					</Button>
+				</div>
+				<div className="docs__design-button-row">
+					<Button busy>Busy button</Button>
+					<Button primary busy>
+						<Gridicon icon="time" />
+					</Button>
+					<Button primary busy>
+						Primary busy button
+					</Button>
+					<Button primary scary busy>
+						<Gridicon icon="trash" />
+						<span className="button-text">Primary scary busy button</span>
+					</Button>
+				</div>
+			</Card>
+		),
 	};
 
 	render() {
-		var toggleText = this.state.compactButtons ? 'Normal Buttons' : 'Compact Buttons';
 		return config.isEnabled( 'devdocs/components-usage-stats' )
-			? this.renderDocsExampleWithUsageStats( toggleText )
-			: this.renderDocsExample( toggleText );
+			? this.renderDocsExampleWithUsageStats()
+			: this.renderDocsExample();
 	}
 
-	renderDocsExample = toggleText => {
-		return (
-			<div>
-				<a className="docs__design-toggle button" onClick={ this.toggleButtons }>
-					{ toggleText }
-				</a>
-				{ this.renderButtons( toggleText ) }
-			</div>
-		);
+	renderDocsExample = () => {
+		return <DocsExample>{ this.renderButtons() }</DocsExample>;
 	};
 
-	renderDocsExampleWithUsageStats = toggleText => {
+	renderDocsExampleWithUsageStats = () => {
 		return (
-			<DocsExample
-				componentUsageStats={ this.props.componentUsageStats }
-				toggleHandler={ this.toggleButtons }
-				toggleText={ toggleText }
-			>
+			<DocsExample componentUsageStats={ this.props.componentUsageStats }>
 				{ this.renderButtons() }
 			</DocsExample>
 		);
 	};
 
 	renderButtons = () => {
-		if ( ! this.state.compactButtons ) {
-			return (
-				<Card>
-					<div className="docs__design-button-row">
-						<Button>Button</Button>
-						<Button>
-							<Gridicon icon="heart" />
-							<span className="button-text">Icon button</span>
-						</Button>
-						<Button>
-							<Gridicon icon="plugins" />
-						</Button>
-						<Button disabled>Disabled button</Button>
-					</div>
-					<div className="docs__design-button-row">
-						<Button scary>Scary button</Button>
-						<Button scary>
-							<Gridicon icon="globe" />
-							<span className="button-text">Scary icon button</span>
-						</Button>
-						<Button scary>
-							<Gridicon icon="pencil" />
-						</Button>
-						<Button scary disabled>
-							Scary disabled button
-						</Button>
-					</div>
-					<div className="docs__design-button-row">
-						<Button primary>Primary button</Button>
-						<Button primary>
-							<Gridicon icon="camera" />
-							<span className="button-text">Primary icon button</span>
-						</Button>
-						<Button primary>
-							<Gridicon icon="time" />
-						</Button>
-						<Button primary disabled>
-							Primary disabled button
-						</Button>
-					</div>
-					<div className="docs__design-button-row">
-						<Button primary scary>
-							Primary scary button
-						</Button>
-						<Button primary scary>
-							<Gridicon icon="user-circle" />
-							<span className="button-text">Primary scary icon button</span>
-						</Button>
-						<Button primary scary>
-							<Gridicon icon="cart" />
-						</Button>
-						<Button primary scary disabled>
-							Primary scary disabled button
-						</Button>
-					</div>
-					<div className="docs__design-button-row">
-						<Button borderless>
-							<Gridicon icon="cross" />
-							<span className="button-text">Remove</span>
-						</Button>
-						<Button borderless>
-							<Gridicon icon="trash" />
-							<span className="button-text">Trash</span>
-						</Button>
-						<Button borderless>
-							<Gridicon icon="link-break" />
-							<span className="button-text">Disconnect</span>
-						</Button>
-						<Button borderless>
-							<Gridicon icon="trash" />
-						</Button>
-						<Button borderless disabled>
-							<Gridicon icon="cross" />
-							<span className="button-text">Remove</span>
-						</Button>
-					</div>
-					<div className="docs__design-button-row">
-						<Button borderless primary>
-							<Gridicon icon="cross" />
-							<span className="button-text">Remove</span>
-						</Button>
-						<Button borderless primary>
-							<Gridicon icon="trash" />
-							<span className="button-text">Trash</span>
-						</Button>
-						<Button borderless primary>
-							<Gridicon icon="link-break" />
-							<span className="button-text">Disconnect</span>
-						</Button>
-						<Button borderless primary>
-							<Gridicon icon="trash" />
-						</Button>
-						<Button borderless primary disabled>
-							<Gridicon icon="cross" />
-							<span className="button-text">Remove</span>
-						</Button>
-					</div>
-					<div className="docs__design-button-row">
-						<Button borderless scary>
-							<Gridicon icon="cross" />
-							<span className="button-text">Remove</span>
-						</Button>
-						<Button borderless scary>
-							<Gridicon icon="trash" />
-							<span className="button-text">Trash</span>
-						</Button>
-						<Button borderless scary>
-							<Gridicon icon="link-break" />
-							<span className="button-text">Disconnect</span>
-						</Button>
-						<Button borderless scary>
-							<Gridicon icon="trash" />
-						</Button>
-						<Button borderless scary disabled>
-							<Gridicon icon="cross" />
-							<span className="button-text">Remove</span>
-						</Button>
-					</div>
-					<div className="docs__design-button-row">
-						<Button busy>Busy button</Button>
-						<Button primary busy>
-							<Gridicon icon="time" />
-						</Button>
-						<Button primary busy>
-							Primary busy button
-						</Button>
-						<Button primary scary busy>
-							<Gridicon icon="trash" />
-							<span className="button-text">Primary scary busy button</span>
-						</Button>
-					</div>
-				</Card>
-			);
-		} else {
-			return (
-				<Card>
-					<div className="docs__design-button-row">
-						<Button compact>Compact button</Button>
-						<Button compact>
-							<Gridicon icon="heart" />
-							<span className="button-text">Compact icon button</span>
-						</Button>
-						<Button compact>
-							<Gridicon icon="plugins" />
-						</Button>
-						<Button compact disabled>
-							Compact disabled button
-						</Button>
-					</div>
-					<div className="docs__design-button-row">
-						<Button compact scary>
-							Compact scary button
-						</Button>
-						<Button compact scary>
-							<Gridicon icon="globe" />
-							<span className="button-text">Compact scary icon button</span>
-						</Button>
-						<Button compact scary>
-							<Gridicon icon="pencil" />
-						</Button>
-						<Button compact scary disabled>
-							Compact scary disabled button
-						</Button>
-					</div>
-					<div className="docs__design-button-row">
-						<Button compact primary>
-							Compact primary button
-						</Button>
-						<Button compact primary>
-							<Gridicon icon="camera" />
-							<span className="button-text">Compact primary icon button</span>
-						</Button>
-						<Button compact primary>
-							<Gridicon icon="time" />
-						</Button>
-						<Button compact primary disabled>
-							Compact primary disabled button
-						</Button>
-					</div>
-					<div className="docs__design-button-row">
-						<Button compact primary scary>
-							Compact primary scary button
-						</Button>
-						<Button compact primary scary>
-							<Gridicon icon="user-circle" />
-							<span className="button-text">Compact primary scary icon button</span>
-						</Button>
-						<Button compact primary scary>
-							<Gridicon icon="cart" />
-						</Button>
-						<Button compact primary scary disabled>
-							Compact primary scary disabled button
-						</Button>
-					</div>
-					<div className="docs__design-button-row">
-						<Button compact borderless>
-							<Gridicon icon="cross" />
-							<span className="button-text">Remove</span>
-						</Button>
-						<Button compact borderless>
-							<Gridicon icon="trash" />
-							<span className="button-text">Trash</span>
-						</Button>
-						<Button compact borderless>
-							<Gridicon icon="link-break" />
-							<span className="button-text">Disconnect</span>
-						</Button>
-						<Button compact borderless>
-							<Gridicon icon="trash" />
-						</Button>
-						<Button compact borderless disabled>
-							<Gridicon icon="cross" />
-							<span className="button-text">Remove</span>
-						</Button>
-					</div>
-					<div className="docs__design-button-row">
-						<Button compact primary borderless>
-							<Gridicon icon="cross" />
-							<span className="button-text">Remove</span>
-						</Button>
-						<Button compact primary borderless>
-							<Gridicon icon="trash" />
-							<span className="button-text">Trash</span>
-						</Button>
-						<Button compact primary borderless>
-							<Gridicon icon="link-break" />
-							<span className="button-text">Disconnect</span>
-						</Button>
-						<Button compact primary borderless>
-							<Gridicon icon="trash" />
-						</Button>
-						<Button compact primary borderless disabled>
-							<Gridicon icon="cross" />
-							<span className="button-text">Remove</span>
-						</Button>
-					</div>
-					<div className="docs__design-button-row">
-						<Button compact borderless scary>
-							<Gridicon icon="cross" />
-							<span className="button-text">Remove</span>
-						</Button>
-						<Button compact borderless scary>
-							<Gridicon icon="trash" />
-							<span className="button-text">Trash</span>
-						</Button>
-						<Button compact borderless scary>
-							<Gridicon icon="link-break" />
-							<span className="button-text">Disconnect</span>
-						</Button>
-						<Button compact borderless scary>
-							<Gridicon icon="trash" />
-						</Button>
-						<Button compact borderless scary disabled>
-							<Gridicon icon="cross" />
-							<span className="button-text">Remove</span>
-						</Button>
-					</div>
-					<div className="docs__design-button-row">
-						<Button compact busy>
-							Busy button
-						</Button>
-						<Button compact primary busy>
-							<Gridicon icon="time" />
-						</Button>
-						<Button compact primary busy>
-							Primary busy button
-						</Button>
-						<Button compact primary scary busy>
-							<Gridicon icon="trash" />
-							<span className="button-text">Compact primary scary busy button</span>
-						</Button>
-					</div>
-				</Card>
-			);
-		}
-	};
-
-	toggleButtons = () => {
-		this.setState( { compactButtons: ! this.state.compactButtons } );
+		return this.props.exampleCode;
 	};
 }
 

--- a/client/components/button/docs/example.jsx
+++ b/client/components/button/docs/example.jsx
@@ -25,7 +25,7 @@ class Buttons extends React.PureComponent {
 					<Button>Button</Button>
 					<Button>
 						<Gridicon icon="heart" />
-						<span className="button-text">Icon button</span>
+						<span>Icon button</span>
 					</Button>
 					<Button>
 						<Gridicon icon="plugins" />
@@ -36,7 +36,7 @@ class Buttons extends React.PureComponent {
 					<Button scary>Scary button</Button>
 					<Button scary>
 						<Gridicon icon="globe" />
-						<span className="button-text">Scary icon button</span>
+						<span>Scary icon button</span>
 					</Button>
 					<Button scary>
 						<Gridicon icon="pencil" />
@@ -49,7 +49,7 @@ class Buttons extends React.PureComponent {
 					<Button primary>Primary button</Button>
 					<Button primary>
 						<Gridicon icon="camera" />
-						<span className="button-text">Primary icon button</span>
+						<span>Primary icon button</span>
 					</Button>
 					<Button primary>
 						<Gridicon icon="time" />
@@ -64,7 +64,7 @@ class Buttons extends React.PureComponent {
 					</Button>
 					<Button primary scary>
 						<Gridicon icon="user-circle" />
-						<span className="button-text">Primary scary icon button</span>
+						<span>Primary scary icon button</span>
 					</Button>
 					<Button primary scary>
 						<Gridicon icon="cart" />
@@ -76,85 +76,85 @@ class Buttons extends React.PureComponent {
 				<div className="docs__design-button-row">
 					<Button borderless>
 						<Gridicon icon="cross" />
-						<span className="button-text">Remove</span>
+						<span>Remove</span>
 					</Button>
 					<Button borderless>
 						<Gridicon icon="trash" />
-						<span className="button-text">Trash</span>
+						<span>Trash</span>
 					</Button>
 					<Button borderless>
 						<Gridicon icon="link-break" />
-						<span className="button-text">Disconnect</span>
+						<span>Disconnect</span>
 					</Button>
 					<Button borderless>
 						<Gridicon icon="trash" />
 					</Button>
 					<Button borderless disabled>
 						<Gridicon icon="cross" />
-						<span className="button-text">Remove</span>
+						<span>Remove</span>
 					</Button>
 				</div>
 				<div className="docs__design-button-row">
 					<Button borderless primary>
 						<Gridicon icon="cross" />
-						<span className="button-text">Remove</span>
+						<span>Remove</span>
 					</Button>
 					<Button borderless primary>
 						<Gridicon icon="trash" />
-						<span className="button-text">Trash</span>
+						<span>Trash</span>
 					</Button>
 					<Button borderless primary>
 						<Gridicon icon="link-break" />
-						<span className="button-text">Disconnect</span>
+						<span>Disconnect</span>
 					</Button>
 					<Button borderless primary>
 						<Gridicon icon="trash" />
 					</Button>
 					<Button borderless primary disabled>
 						<Gridicon icon="cross" />
-						<span className="button-text">Remove</span>
+						<span>Remove</span>
 					</Button>
 				</div>
 				<div className="docs__design-button-row">
 					<Button borderless scary>
 						<Gridicon icon="cross" />
-						<span className="button-text">Remove</span>
+						<span>Remove</span>
 					</Button>
 					<Button borderless scary>
 						<Gridicon icon="trash" />
-						<span className="button-text">Trash</span>
+						<span>Trash</span>
 					</Button>
 					<Button borderless scary>
 						<Gridicon icon="link-break" />
-						<span className="button-text">Disconnect</span>
+						<span>Disconnect</span>
 					</Button>
 					<Button borderless scary>
 						<Gridicon icon="trash" />
 					</Button>
 					<Button borderless scary disabled>
 						<Gridicon icon="cross" />
-						<span className="button-text">Remove</span>
+						<span>Remove</span>
 					</Button>
 				</div>
 				<div className="docs__design-button-row">
 					<Button compact>
 						<Gridicon icon="cross" />
-						<span className="button-text">Remove</span>
+						<span>Remove</span>
 					</Button>
 					<Button compact>
 						<Gridicon icon="trash" />
-						<span className="button-text">Trash</span>
+						<span>Trash</span>
 					</Button>
 					<Button compact>
 						<Gridicon icon="link-break" />
-						<span className="button-text">Disconnect</span>
+						<span>Disconnect</span>
 					</Button>
 					<Button compact>
 						<Gridicon icon="trash" />
 					</Button>
 					<Button compact disabled>
 						<Gridicon icon="cross" />
-						<span className="button-text">Remove</span>
+						<span>Remove</span>
 					</Button>
 				</div>
 				<div className="docs__design-button-row">
@@ -167,7 +167,7 @@ class Buttons extends React.PureComponent {
 					</Button>
 					<Button primary scary busy>
 						<Gridicon icon="trash" />
-						<span className="button-text">Primary scary busy button</span>
+						<span>Primary scary busy button</span>
 					</Button>
 				</div>
 			</Card>

--- a/docs/component-doc-template.md
+++ b/docs/component-doc-template.md
@@ -10,7 +10,7 @@ Example:
 
 ## Usage
 
-First, display a `jsx` code block to show an example of usage, including import and render.
+First, display a `jsx` code block to show an example of usage, including import statements and a React component.
 
 ```jsx
 import Gridicon from 'gridicons';

--- a/docs/component-doc-template.md
+++ b/docs/component-doc-template.md
@@ -1,7 +1,7 @@
 Component Documentation Template
 ===
 
-_Use this template when documenting components. If you are creating a new component, you can copy and paste this entire document as a starting point. See the [Button documentation](../design/buttons) for a good example._
+_Use this as a README.md template when documenting components. If you are creating a new component, you can copy and paste this entire document as a starting point. See the [Button documentation](../design/buttons) for a good example._
 
 Write a short, high-level explanation of the component with a focus on what problem it solves in the interface. Do not include any technical information in this description.
 Example:

--- a/docs/component-doc-template.md
+++ b/docs/component-doc-template.md
@@ -63,5 +63,5 @@ General guidelines should be a list of tips and best practices. Example:
 This is an unordered list of components that are related in some way. Components are linked to the detail page of that component. Example:
 
 * To group buttons together, use the [ButtonGroup](./button-group) component.
-* To use a button with a secondary popover menu, use the [SplitButton](../split-button) component.
-* To display a loading spinner with a button, use the [SpinnerButton](./design/spinner-button) component.
+* To use a button with a secondary popover menu, use the [SplitButton](./split-button) component.
+* To display a loading spinner with a button, use the [SpinnerButton](../design/spinner-button) component.

--- a/docs/component-doc-template.md
+++ b/docs/component-doc-template.md
@@ -1,4 +1,4 @@
-Component Name
+Component Documentation Template
 ===
 
 _Use this template when documenting components. If you are creating a new component, you can copy and paste this entire document as a starting point. See the [Button documentation](../design/buttons) for a good example._

--- a/docs/component-readme-template.md
+++ b/docs/component-readme-template.md
@@ -1,7 +1,7 @@
 Component Name
 ===
 
-_Use this template when documenting components. If you are creating a new component, you can copy and paste this entire document as a starting point._
+_Use this template when documenting components. If you are creating a new component, you can copy and paste this entire document as a starting point. See the [Button documentation](../design/buttons) for a good example._
 
 Write a short, high-level explanation of the component with a focus on what problem it solves in the interface. Do not include any technical information in this description.
 Example:

--- a/docs/component-readme-template.md
+++ b/docs/component-readme-template.md
@@ -1,0 +1,67 @@
+Component Name
+===
+
+_Use this template when documenting components. If you are creating a new component, you can copy and paste this entire document as a starting point._
+
+Write a short, high-level explanation of the component with a focus on what problem it solves in the interface. Do not include any technical information in this description.
+Example:
+
+> Buttons express what action will occur when the user clicks or taps it. Buttons are used to trigger an action, and they can be used for any type of action, including navigation.
+
+## Usage
+
+First, display a `jsx` code block to show an example of usage, including import and render.
+
+```jsx
+import Gridicon from 'gridicons';
+import Button from 'components/button';
+
+export default function RockOnButton() {
+	return (
+		<Button compact primary>
+			You rock!
+		</Button>
+	);
+}
+```
+
+### Props
+
+Props are displayed as a table with Name, Type, Default, and Description as headings. Required props are marked with `*`.
+
+Name | Type | Default | Description
+--- | --- | --- | ---
+`compact` | `bool` | `0` | Decreases the size of the button
+`primary`* | `bool` | `0` | Provides extra visual weight and identifies the primary action in a set of buttons
+`borderless` | `bool` | `0` | Renders a button without borders
+`scary` | `bool` | `0` | Indicates a dangerous or potentially negative action
+`busy`* | `bool` | `0` | Indicates activity while a background action is being performed
+`href` | `string` | `0` | If provided, renders `a` instead of `button`
+
+### Additional usage information
+
+If the component has many states, or if a technical aspect needs more explanation, use this section. Example:
+
+* **Primary**: Use to highlight the most important actions in any experience. Don’t use more than one primary button in a section or screen to avoid overwhelming customers.
+* **Secondary**: Used most in the interface. Only use another style if a button requires more or less visual weight.
+* **Button with icon**: When words are not enough, icons can be used in buttons to better communicate what the button does.
+* **Scary**: Use when the action will delete customer data or be otherwise difficult to recover from. Destructive buttons should trigger a confirmation dialog before the action is completed. Be thoughtful about using destructive buttons because they can feel stressful for customers.
+* **Borderless**: Use for less important or less commonly used actions since they’re less prominent.
+* **Busy**: Use when a button has been pressed and the associated action is in progress.
+
+### General guidelines
+
+General guidelines should be a list of tips and best practices. Example:
+
+* Use clear and accurate labels. Use sentence-style capitalization.
+* Lead with strong, concise, and actionable verbs.
+* When the customer is confirming an action, use specific labels, such as **Save** or **Trash**, instead of using **OK** and **Cancel**.
+* Prioritize the most important actions. Too many calls to action can cause confusion and make customers unsure of what to do next.
+
+## Related components
+
+This is an unordered list of components that are related in some way. Components are linked to the detail page of that component. Example:
+
+* To group buttons together, use the [ButtonGroup](./button-group) component.
+* To use a button with a secondary popover menu, use the [SplitButton](../split-button) component.
+* To display a loading spinner with a button, use the [SpinnerButton](./design/spinner-button) component.

--- a/docs/new-component-checklist.md
+++ b/docs/new-component-checklist.md
@@ -42,3 +42,13 @@ Has the component visual quality and accuracy been assessed across Safari, Chrom
 ## Documentation
 
 Please use the [documentation template](component-readme-template.md) for documenting the new component.
+
+## Playground
+
+Components will appear in the [Playground](/devdocs/playground) if they have the following requirements satisfied:
+- An example Component in /components/component-name/docs/example.jsx
+- An exampleCode property on the example Component
+- An `export ComponentName from components/component-name` statement in `playground-scope.js`
+- An `export ComponentName from components/component-name/docs/example.jsx` statement in `component-examples.jsx`
+
+Components which satisfy these requirements will also have a playground appear in [Devdocs Design](/devdocs/design).

--- a/docs/new-component-checklist.md
+++ b/docs/new-component-checklist.md
@@ -38,3 +38,7 @@ Do all behaviors function as expected? For responsive tabs, are menus (for overf
 ## Browser Support
 
 Has the component visual quality and accuracy been assessed across Safari, Chrome, Firefox, IE, and other browsers across relevant devices? Please adhere to our [browser support requirements](../README.md#browser-support).
+
+## Documentation
+
+Please use the [documentation template](component-readme-template.md) for documenting the new component.


### PR DESCRIPTION
This adds a template that should be used for component documentation. This will ensure consistent documentation across all components. It also provides a starting point for new components.

fixes #24283 

I also updated the Button component to adhere to the new template.

Adding design review because there are a lot of added guidelines for the Button component there were not there previously.

I need help with:

- ~What are the default values for the Button props?~
- ~The new template is not searchable using the devdoc search bar?~
- ~Not sure if "import" and "render" are the right terms to use here:~

```First, display a jsx code block to show an example of usage, including import and render.```

---

![screen shot 2018-04-19 at 8 10 46 pm 1](https://user-images.githubusercontent.com/618551/39025613-c9877af8-440d-11e8-9585-b4313a9a4f26.png)
