### PR TITLE
Popover: allow custom position to be specified

### DIFF
--- a/client/components/popover/README.md
+++ b/client/components/popover/README.md
@@ -30,6 +30,17 @@ className will be always added to the instance.
 The `context` property must be set to a DOMElement or React ref to the element
 the popover should be attached to (point to).
 
+#### `customPosition { object }`
+
+Provide a custom position to render the popover at. The parent component takes all
+responsibility for moving the popover on resize and scroll.
+
+Example:
+
+`{ left: 100, top: 20, positionClass: 'bottom' }`
+
+You can specify `positionClass` to control which way the popover arrow points.
+
 #### `id { string } - optional`
 
 Use this optional property to set a Popover identifier among all of the Popover

--- a/client/components/popover/docs/example.jsx
+++ b/client/components/popover/docs/example.jsx
@@ -13,6 +13,8 @@ import Popover from 'components/popover';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 
+const customPosition = { top: 300, left: 500 };
+
 class PopoverExample extends PureComponent {
 	constructor( props ) {
 		super( props );
@@ -64,8 +66,9 @@ class PopoverExample extends PureComponent {
 					id="popover__basic-example"
 					isVisible={ this.state.showPopover }
 					onClose={ this.closePopover }
-					position={ this.state.popoverPosition }
+					position={ this.state.popoverPosition !== 'custom' ? this.state.popoverPosition : null }
 					context={ this.refs && this.refs.popoverButton }
+					customPosition={ this.state.popoverPosition === 'custom' ? customPosition : null }
 				>
 					<div style={ { padding: '10px' } }>Simple Popover Instance</div>
 				</Popover>
@@ -86,8 +89,9 @@ class PopoverExample extends PureComponent {
 					id="popover__menu-example"
 					isVisible={ this.state.showPopoverMenu }
 					onClose={ this.closePopoverMenu }
-					position={ this.state.popoverPosition }
+					position={ this.state.popoverPosition !== 'custom' ? this.state.popoverPosition : null }
 					context={ this.refs && this.refs.popoverMenuButton }
+					customPosition={ this.state.popoverPosition === 'custom' ? customPosition : null }
 				>
 					<PopoverMenuItem action="A">Item A</PopoverMenuItem>
 					<PopoverMenuItem action="B">Item B</PopoverMenuItem>
@@ -111,6 +115,7 @@ class PopoverExample extends PureComponent {
 						<option value="bottom">bottom</option>
 						<option value="bottom left">bottom left</option>
 						<option value="bottom right">bottom right</option>
+						<option value="custom">custom</option>
 					</select>
 				</label>
 

--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ReactDom from 'react-dom';
@@ -57,6 +56,12 @@ class Popover extends Component {
 		showDelay: PropTypes.number,
 		onClose: PropTypes.func,
 		onShow: PropTypes.func,
+		// Bypass position calculations and provide custom position values
+		customPosition: PropTypes.shape( {
+			top: PropTypes.number,
+			left: PropTypes.number,
+			positionClass: PropTypes.oneOf( [ 'top', 'right', 'bottom', 'left' ] ),
+		} ),
 	};
 
 	static defaultProps = {
@@ -204,10 +209,10 @@ class Popover extends Component {
 		this.close( true );
 	}
 
-	// --- cliclout side ---
+	// --- click outside ---
 	bindClickoutHandler( el = this.domContainer ) {
 		if ( ! el ) {
-			this.debug( 'no element to bind clickout side ' );
+			this.debug( 'no element to bind clickout ' );
 			return null;
 		}
 
@@ -289,7 +294,7 @@ class Popover extends Component {
 	}
 
 	/**
-	 * Adjusts positition swapping left and right values
+	 * Adjusts position swapping left and right values
 	 * when right-to-left directionality is found.
 	 *
 	 * @param  {String} position Original position
@@ -382,7 +387,22 @@ class Popover extends Component {
 
 	setPosition() {
 		this.debug( 'updating position' );
-		const position = this.computePosition();
+
+		let position;
+
+		// Do we have a custom position provided?
+		if ( this.props.customPosition ) {
+			position = Object.assign(
+				{
+					// Use the default if positionClass hasn't been provided
+					positionClass: this.getPositionClass( this.constructor.defaultProps.position ),
+				},
+				this.props.customPosition
+			);
+		} else {
+			position = this.computePosition();
+		}
+
 		if ( ! position ) {
 			return null;
 		}
@@ -411,7 +431,7 @@ class Popover extends Component {
 	}
 
 	hide() {
-		// unbind clickout-side event every time the component is hidden.
+		// unbind click outside event every time the component is hidden.
 		this.unbindClickoutHandler();
 		this.unbindDebouncedReposition();
 		this.unbindEscKeyListener();

--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
-import { over } from 'lodash';
+import { over, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,6 +22,7 @@ class PopoverMenu extends React.Component {
 		rootClassName: PropTypes.string,
 		popoverComponent: PropTypes.func,
 		popoverTitle: PropTypes.string, // used by ReaderPopover
+		customPosition: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -38,18 +39,18 @@ class PopoverMenu extends React.Component {
 	render() {
 		const children = React.Children.map( this.props.children, this._setPropsOnChild, this );
 		const PopoverComponent = this.props.popoverComponent;
+		const popoverProps = pick( this.props, [
+			'isVisible',
+			'context',
+			'autoPosition',
+			'position',
+			'className',
+			'rootClassName',
+			'popoverTitle',
+			'customPosition',
+		] );
 		return (
-			<PopoverComponent
-				isVisible={ this.props.isVisible }
-				context={ this.props.context }
-				autoPosition={ this.props.autoPosition }
-				position={ this.props.position }
-				onClose={ this._onClose }
-				onShow={ this._onShow }
-				className={ this.props.className }
-				rootClassName={ this.props.rootClassName }
-				popoverTitle={ this.props.popoverTitle }
-			>
+			<PopoverComponent onClose={ this._onClose } onShow={ this._onShow } { ...popoverProps }>
 				<div
 					ref="menu"
 					role="menu"


### PR DESCRIPTION
The Popover component currently accepts a `position` prop which is relative to the DOM element provided in `popoverContext`: top, top left, bottom, left, right, and so on.

In some unusual cases, we need the parent component to specify exactly where to put the popover. This PR adds support for a `customPosition` prop that looks like this:

`{ left: 100, top: 20, positionClass: 'bottom' }`

### Background

I'm currently working on adding @mentions to Reader (#933). The popover needs to appear directly beneath the position of the @ symbol:

<img width="254" alt="screen shot 2018-04-20 at 4 46 22 pm" src="https://user-images.githubusercontent.com/17325/39031095-64cb5fd2-44ba-11e8-959a-4f871029f51a.png">

The existing editor mentions plugin achieves this by grabbing the DOM node of the popover and adjusting the position manually:

https://github.com/Automattic/wp-calypso/blob/master/client/components/tinymce/plugins/mentions/mentions.jsx#L134

The TinyMCE plugin creates that DOM node and has ready access to it for positioning:

https://github.com/Automattic/wp-calypso/blob/master/client/components/tinymce/plugins/mentions/plugin.jsx#L32

In this case, we don't have ready access to the DOM node, so it feels better to pass the custom dimensions down to the component rather than reaching several components deep.

### To test

Head to http://calypso.localhost:3000/devdocs/design/popover and try the new 'custom' option in the dropdown. It should render the popover 300px from the top and 500px from the left. 

The existing position options should work as before.

<img width="451" alt="screen shot 2018-04-20 at 4 52 03 pm" src="https://user-images.githubusercontent.com/17325/39031276-530182da-44bb-11e8-82d8-d812bcdfa4cb.png">
