### PR TITLE
Product purchase features: Update list

### DIFF
--- a/client/blocks/product-purchase-features-list/custom-domain.jsx
+++ b/client/blocks/product-purchase-features-list/custom-domain.jsx
@@ -3,19 +3,20 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
-import { pick } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import CustomDomainPurchaseDetail from 'my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail';
 
-export default props => {
+export default function CustomDomainPurchaseDetailItem( { hasDomainCredit, selectedSite } ) {
 	return (
 		<div className="product-purchase-features-list__item">
-			<CustomDomainPurchaseDetail { ...pick( props, [ 'selectedSite', 'hasDomainCredit' ] ) } />
+			<CustomDomainPurchaseDetail
+				selectedSite={ selectedSite }
+				hasDomainCredit={ hasDomainCredit }
+			/>
 		</div>
 	);
-};
+}

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -63,12 +63,10 @@ export class ProductPurchaseFeaturesList extends Component {
 					onClick={ this.props.recordBusinessOnboardingClick }
 					link={ `/me/concierge/${ selectedSite.slug }/book` }
 				/>
-				{ isEnabled( 'manage/plugins/upload' ) ? (
-					<UploadPlugins selectedSite={ selectedSite } />
-				) : null }
-				{ isWordadsInstantActivationEligible( selectedSite ) ? (
+				{ isEnabled( 'manage/plugins/upload' ) && <UploadPlugins selectedSite={ selectedSite } /> }
+				{ isWordadsInstantActivationEligible( selectedSite ) && (
 					<MonetizeSite selectedSite={ selectedSite } />
-				) : null }
+				) }
 				<JetpackSearch selectedSite={ selectedSite } />
 				<GoogleVouchers selectedSite={ selectedSite } />
 				<GoogleAnalyticsStats selectedSite={ selectedSite } />
@@ -90,9 +88,9 @@ export class ProductPurchaseFeaturesList extends Component {
 				<GoogleVouchers selectedSite={ selectedSite } />
 				<CustomizeTheme selectedSite={ selectedSite } />
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
-				{ isWordadsInstantActivationEligible( selectedSite ) ? (
+				{ isWordadsInstantActivationEligible( selectedSite ) && (
 					<MonetizeSite selectedSite={ selectedSite } />
-				) : null }
+				) }
 			</Fragment>
 		);
 	}

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -3,9 +3,8 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { partial } from 'lodash';
 
@@ -57,123 +56,122 @@ export class ProductPurchaseFeaturesList extends Component {
 
 	getBusinessFeatures() {
 		const { selectedSite, plan, planHasDomainCredit } = this.props;
-		return [
-			<CustomDomain
-				selectedSite={ selectedSite }
-				hasDomainCredit={ planHasDomainCredit }
-				key="customDomainFeature"
-			/>,
-			<BusinessOnboarding
-				key="businessOnboarding"
-				onClick={ this.props.recordBusinessOnboardingClick }
-				link={ `/me/concierge/${ selectedSite.slug }/book` }
-			/>,
-			isEnabled( 'manage/plugins/upload' ) ? (
-				<UploadPlugins selectedSite={ selectedSite } key="uploadPluginsFeature" />
-			) : null,
-			isWordadsInstantActivationEligible( selectedSite ) ? (
-				<MonetizeSite selectedSite={ selectedSite } key="monetizeSiteFeature" />
-			) : null,
-			<JetpackSearch selectedSite={ selectedSite } key="jetpackSearch" />,
-			<GoogleVouchers selectedSite={ selectedSite } key="googleVouchersFeature" />,
-			<GoogleAnalyticsStats selectedSite={ selectedSite } key="googleAnalyticsStatsFeature" />,
-			<AdvertisingRemoved isBusinessPlan key="advertisingRemovedFeature" />,
-			<CustomizeTheme selectedSite={ selectedSite } key="customizeThemeFeature" />,
-			<VideoAudioPosts selectedSite={ selectedSite } key="videoAudioPostsFeature" plan={ plan } />,
-			<FindNewTheme selectedSite={ selectedSite } key="findNewThemeFeature" />,
-		];
+		return (
+			<Fragment>
+				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
+				<BusinessOnboarding
+					onClick={ this.props.recordBusinessOnboardingClick }
+					link={ `/me/concierge/${ selectedSite.slug }/book` }
+				/>
+				{ isEnabled( 'manage/plugins/upload' ) ? (
+					<UploadPlugins selectedSite={ selectedSite } />
+				) : null }
+				{ isWordadsInstantActivationEligible( selectedSite ) ? (
+					<MonetizeSite selectedSite={ selectedSite } />
+				) : null }
+				<JetpackSearch selectedSite={ selectedSite } />
+				<GoogleVouchers selectedSite={ selectedSite } />
+				<GoogleAnalyticsStats selectedSite={ selectedSite } />
+				<AdvertisingRemoved isBusinessPlan />
+				<CustomizeTheme selectedSite={ selectedSite } />
+				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
+				<FindNewTheme selectedSite={ selectedSite } />
+			</Fragment>
+		);
 	}
 
 	getPremiumFeatures() {
 		const { selectedSite, plan, planHasDomainCredit } = this.props;
 
-		return [
-			<CustomDomain
-				selectedSite={ selectedSite }
-				hasDomainCredit={ planHasDomainCredit }
-				key="customDomainFeature"
-			/>,
-			<AdvertisingRemoved isBusinessPlan={ false } key="advertisingRemovedFeature" />,
-			<GoogleVouchers selectedSite={ selectedSite } key="googleVouchersFeature" />,
-			<CustomizeTheme selectedSite={ selectedSite } key="customizeThemeFeature" />,
-			<VideoAudioPosts selectedSite={ selectedSite } key="videoAudioPostsFeature" plan={ plan } />,
-			isWordadsInstantActivationEligible( selectedSite ) ? (
-				<MonetizeSite selectedSite={ selectedSite } key="monetizeSiteFeature" />
-			) : null,
-		];
+		return (
+			<Fragment>
+				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
+				<AdvertisingRemoved isBusinessPlan={ false } />
+				<GoogleVouchers selectedSite={ selectedSite } />
+				<CustomizeTheme selectedSite={ selectedSite } />
+				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
+				{ isWordadsInstantActivationEligible( selectedSite ) ? (
+					<MonetizeSite selectedSite={ selectedSite } />
+				) : null }
+			</Fragment>
+		);
 	}
 
 	getPersonalFeatures() {
 		const { selectedSite, planHasDomainCredit } = this.props;
 
-		return [
-			<CustomDomain
-				selectedSite={ selectedSite }
-				hasDomainCredit={ planHasDomainCredit }
-				key="customDomainFeature"
-			/>,
-			<AdvertisingRemoved isBusinessPlan={ false } key="advertisingRemovedFeature" />,
-		];
+		return (
+			<Fragment>
+				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
+				<AdvertisingRemoved isBusinessPlan={ false } />
+			</Fragment>
+		);
 	}
 
 	getJetpackFreeFeatures() {
 		const { selectedSite } = this.props;
 
-		return [
-			<JetpackWordPressCom selectedSite={ selectedSite } key="jetpackWordPressCom" />,
-			<JetpackReturnToDashboard
-				onClick={ this.props.recordReturnToDashboardClick }
-				selectedSite={ selectedSite }
-				key="jetpackReturnToDashboard"
-			/>,
-		];
+		return (
+			<Fragment>
+				<JetpackWordPressCom selectedSite={ selectedSite } />
+				<JetpackReturnToDashboard
+					onClick={ this.props.recordReturnToDashboardClick }
+					selectedSite={ selectedSite }
+				/>
+			</Fragment>
+		);
 	}
 
 	getJetpackPremiumFeatures() {
 		const { selectedSite } = this.props;
 
-		return [
-			<MonetizeSite selectedSite={ selectedSite } key="monetizeSiteFeature" />,
-			<JetpackWordPressCom selectedSite={ selectedSite } key="jetpackWordPressCom" />,
-			<JetpackBackupSecurity key="jetpackBackupSecurity" />,
-			<JetpackAntiSpam key="jetpackAntiSpam" />,
-			<JetpackPublicize key="jetpackPublicize" />,
-			<JetpackVideo key="jetpackVideo" />,
-			<JetpackReturnToDashboard selectedSite={ selectedSite } key="jetpackReturnToDashboard" />,
-		];
+		return (
+			<Fragment>
+				<MonetizeSite selectedSite={ selectedSite } />
+				<JetpackWordPressCom selectedSite={ selectedSite } />
+				<JetpackBackupSecurity />
+				<JetpackAntiSpam />
+				<JetpackPublicize />
+				<JetpackVideo />
+				<JetpackReturnToDashboard selectedSite={ selectedSite } />
+			</Fragment>
+		);
 	}
 
 	getJetpackPersonalFeatures() {
 		const { selectedSite } = this.props;
 
-		return [
-			<JetpackWordPressCom selectedSite={ selectedSite } key="jetpackWordPressCom" />,
-			<JetpackBackupSecurity key="jetpackBackupSecurity" />,
-			<JetpackAntiSpam key="jetpackAntiSpam" />,
-			<JetpackReturnToDashboard selectedSite={ selectedSite } key="jetpackReturnToDashboard" />,
-		];
+		return (
+			<Fragment>
+				<JetpackWordPressCom selectedSite={ selectedSite } />
+				<JetpackBackupSecurity />
+				<JetpackAntiSpam />
+				<JetpackReturnToDashboard selectedSite={ selectedSite } />
+			</Fragment>
+		);
 	}
 
 	getJetpackBusinessFeatures() {
 		const { selectedSite } = this.props;
 
-		return [
-			<BusinessOnboarding
-				key="businessOnboarding"
-				onClick={ this.props.recordBusinessOnboardingClick }
-				link="https://calendly.com/jetpack/concierge"
-			/>,
-			<JetpackSearch selectedSite={ selectedSite } key="jetpackSearch" />,
-			<MonetizeSite selectedSite={ selectedSite } key="monetizeSiteFeature" />,
-			<GoogleAnalyticsStats selectedSite={ selectedSite } key="googleAnalyticsStatsFeature" />,
-			<JetpackWordPressCom selectedSite={ selectedSite } key="jetpackWordPressCom" />,
-			<FindNewTheme selectedSite={ selectedSite } key="findNewThemeFeature" />,
-			<JetpackVideo key="jetpackVideo" />,
-			<JetpackPublicize key="jetpackPublicize" />,
-			<JetpackBackupSecurity key="jetpackBackupSecurity" />,
-			<JetpackAntiSpam key="jetpackAntiSpam" />,
-			<JetpackReturnToDashboard selectedSite={ selectedSite } key="jetpackReturnToDashboard" />,
-		];
+		return (
+			<Fragment>
+				<BusinessOnboarding
+					onClick={ this.props.recordBusinessOnboardingClick }
+					link="https://calendly.com/jetpack/concierge"
+				/>
+				<JetpackSearch selectedSite={ selectedSite } />
+				<MonetizeSite selectedSite={ selectedSite } />
+				<GoogleAnalyticsStats selectedSite={ selectedSite } />
+				<JetpackWordPressCom selectedSite={ selectedSite } />
+				<FindNewTheme selectedSite={ selectedSite } />
+				<JetpackVideo />
+				<JetpackPublicize />
+				<JetpackBackupSecurity />
+				<JetpackAntiSpam />
+				<JetpackReturnToDashboard selectedSite={ selectedSite } />
+			</Fragment>
+		);
 	}
 
 	getFeatures() {

--- a/client/blocks/product-purchase-features-list/style.scss
+++ b/client/blocks/product-purchase-features-list/style.scss
@@ -1,5 +1,7 @@
+/** @format */
+
 .product-purchase-features-list {
-	@include breakpoint( ">1040px" ) {
+	@include breakpoint( '>1040px' ) {
 		column-count: 2;
 		column-gap: 12px;
 	}
@@ -11,6 +13,10 @@
 	-webkit-column-break-inside: avoid; // For others
 
 	padding-top: 12px;
+
+	&:empty {
+		display: none;
+	}
 }
 
 .product-purchase-features-list__item .purchase-detail {


### PR DESCRIPTION
This is a janitorial PR inspired by observations from #24262

- Replace arrays of React elements with Fragments
- Drop now-redundant `key`s
- Apply CSS fix for empty items from https://github.com/Automattic/wp-calypso/pull/24262#issuecomment-382359609
- Clarify, simplify and name an item component

## Testing
1. Visit `/plans/SITE_SLUG` with a variety of plans:
   - Jetpack
   - WordPress.com
1. It's a good idea to get a free site, then upgrade through all the plans and verify that everything looks correct.