### PR TITLE
PostRevisions: Split view. Add buttons component for later inclusion in editor revisions list.

### DIFF
--- a/client/post-editor/editor-revisions-list/view-buttons.jsx
+++ b/client/post-editor/editor-revisions-list/view-buttons.jsx
@@ -1,0 +1,60 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import SegmentedControl from 'components/segmented-control';
+import ControlItem from 'components/segmented-control/item';
+import {
+	splitPostRevisionsDiffView,
+	unifyPostRevisionsDiffView,
+} from 'state/posts/revisions/actions';
+import { getPostRevisionsDiffView } from 'state/selectors';
+
+const EditorRevisionsListViewButtons = ( { translate, diffView, viewSplit, viewUnified } ) => {
+	return (
+		<SegmentedControl compact className="editor-revisions-list__view-buttons">
+			<ControlItem
+				className="editor-revisions-list__unified-button"
+				onClick={ viewUnified }
+				selected={ diffView === 'unified' }
+			>
+				{ translate( 'Unified' ) }
+			</ControlItem>
+			<ControlItem
+				className="editor-revisions-list__split-button"
+				onClick={ viewSplit }
+				selected={ diffView === 'split' }
+			>
+				{ translate( 'Split' ) }
+			</ControlItem>
+		</SegmentedControl>
+	);
+};
+
+EditorRevisionsListViewButtons.propTypes = {
+	viewSplit: PropTypes.func.isRequired,
+	viewUnified: PropTypes.func.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = state => ( {
+	diffView: getPostRevisionsDiffView( state ),
+} );
+
+const mapDispatchToProps = {
+	viewUnified: unifyPostRevisionsDiffView,
+	viewSplit: splitPostRevisionsDiffView,
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )(
+	localize( EditorRevisionsListViewButtons )
+);


### PR DESCRIPTION
Part 3 of a change adding the option for a split view to the revisions diff viewer on larger viewports. (Please see https://github.com/Automattic/wp-calypso/pull/24355#issue-183003572 for the background.)

The styles for this component will be added in https://github.com/Automattic/wp-calypso/pull/24355.

### Changes

* Creates a `SegmentedControl` component which we'll include in the `EditorRevisionsList` header in https://github.com/Automattic/wp-calypso/pull/24355.
* Depending on which button the user clicks, the component dispatches `splitPostRevisionsDiffView` or `unifyPostRevisionsDiffView` actions to set the `post.revisions.ui.diffView` state added in https://github.com/Automattic/wp-calypso/pull/24353.
* This component also uses the `getPostRevisionsDiffView` selector to set the button selected state.

### How this component will be used

In https://github.com/Automattic/wp-calypso/pull/24355, the revisions diff viewer will show a split or unified view depending on the state set here.

![image](https://user-images.githubusercontent.com/1647564/39095269-a7f35d10-4635-11e8-886e-e8ba80db1580.png)

### PRs in this change:

https://github.com/Automattic/wp-calypso/pull/24352 - 1. Add breakpoints to `isWithinBreakpoint`
https://github.com/Automattic/wp-calypso/pull/24353 - 2. Add actions and selector
https://github.com/Automattic/wp-calypso/pull/24354 - 3. Add button component
https://github.com/Automattic/wp-calypso/pull/24355 - 4. Integrate buttons and split view

(The original PR for this was #23811 - it was too big, so I've closed it.)