### PR TITLE
PostRevisions: Split view. Integrate view buttons and enable split diff view.

### DIFF
--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -8,7 +8,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { debounce, filter, first, flow, get, has, last, map, partial, throttle } from 'lodash';
+import { debounce, filter, first, flow, get, has, last, map, throttle } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
@@ -16,9 +16,11 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import getPostRevision from 'state/selectors/get-post-revision';
+import getPostRevisionsDiffView from 'state/selectors/get-post-revisions-diff-view';
 import TextDiff from 'components/text-diff';
 import scrollTo from 'lib/scroll-to';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { isWithinBreakpoint } from 'lib/viewport';
 
 const getCenterOffset = node => get( node, 'offsetTop', 0 ) + get( node, 'offsetHeight', 0 ) / 2;
 
@@ -32,6 +34,7 @@ class EditorDiffViewer extends PureComponent {
 			post_title: PropTypes.array,
 			totals: PropTypes.object,
 		} ).isRequired,
+		diffView: PropTypes.string,
 
 		// connected to dispatch
 		recordTracksEvent: PropTypes.func.isRequired,
@@ -46,10 +49,13 @@ class EditorDiffViewer extends PureComponent {
 		viewportHeight: 0,
 	};
 
+	isBigViewport = false;
+
 	componentDidMount() {
 		this.tryScrollingToFirstChangeOrTop();
 		if ( typeof window !== 'undefined' ) {
 			window.addEventListener( 'resize', this.debouncedRecomputeChanges );
+			this.isBigViewport = isWithinBreakpoint( '>1040px' );
 		}
 	}
 
@@ -66,6 +72,9 @@ class EditorDiffViewer extends PureComponent {
 	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.selectedRevisionId !== this.props.selectedRevisionId ) {
 			this.setState( { changeOffsets: [] } );
+		}
+		if ( nextProps.diffView !== this.props.diffView ) {
+			this.recomputeChanges( null );
 		}
 	}
 
@@ -88,7 +97,13 @@ class EditorDiffViewer extends PureComponent {
 	};
 
 	recomputeChanges = callback => {
-		const diffNodes = this.node.querySelectorAll( '.text-diff__additions, .text-diff__deletions' );
+		let selectors = '.text-diff__additions, .text-diff__deletions';
+		if ( this.isBigViewport && this.props.diffView === 'split' ) {
+			selectors =
+				'.editor-diff-viewer__secondary-pane .text-diff__additions,' +
+				' .editor-diff-viewer__main-pane .text-diff__deletions';
+		}
+		const diffNodes = this.node.querySelectorAll( selectors );
 		this.setState(
 			{
 				changeOffsets: map( diffNodes, getCenterOffset ),
@@ -99,7 +114,10 @@ class EditorDiffViewer extends PureComponent {
 		);
 	};
 
-	debouncedRecomputeChanges = debounce( partial( this.recomputeChanges, null ), 500 );
+	debouncedRecomputeChanges = debounce( () => {
+		this.isBigViewport = isWithinBreakpoint( '>1040px' );
+		this.recomputeChanges( null );
+	}, 500 );
 
 	centerScrollingOnOffset = ( offset, animated = true ) => {
 		const nextScrollTop = Math.max( 0, offset - this.state.viewportHeight / 2 );
@@ -149,9 +167,10 @@ class EditorDiffViewer extends PureComponent {
 	};
 
 	render() {
-		const { diff } = this.props;
+		const { diff, diffView } = this.props;
 		const classes = classNames( 'editor-diff-viewer', {
 			'is-loading': ! has( diff, 'post_content' ) && ! has( diff, 'post_title' ),
+			'is-split': diffView === 'split',
 		} );
 
 		const bottomBoundary = this.state.scrollTop + this.state.viewportHeight;
@@ -173,12 +192,24 @@ class EditorDiffViewer extends PureComponent {
 		return (
 			<div className={ classes }>
 				<div className="editor-diff-viewer__scrollable" ref={ this.handleScrollableRef }>
-					<h1 className="editor-diff-viewer__title">
-						<TextDiff operations={ diff.post_title } />
-					</h1>
-					<pre className="editor-diff-viewer__content">
-						<TextDiff operations={ diff.post_content } splitLines />
-					</pre>
+					<div className="editor-diff-viewer__main-pane">
+						<h1 className="editor-diff-viewer__title">
+							<TextDiff operations={ diff.post_title } />
+						</h1>
+						<pre className="editor-diff-viewer__content">
+							<TextDiff operations={ diff.post_content } splitLines />
+						</pre>
+					</div>
+					{ diffView === 'split' && (
+						<div className="editor-diff-viewer__secondary-pane">
+							<h1 className="editor-diff-viewer__title">
+								<TextDiff operations={ diff.post_title } />
+							</h1>
+							<pre className="editor-diff-viewer__content">
+								<TextDiff operations={ diff.post_content } splitLines />
+							</pre>
+						</div>
+					) }
 				</div>
 				{ showHints &&
 					countAbove > 0 && (
@@ -210,6 +241,7 @@ export default flow(
 	connect(
 		( state, { siteId, postId, selectedRevisionId } ) => ( {
 			revision: getPostRevision( state, siteId, postId, selectedRevisionId, 'display' ),
+			diffView: getPostRevisionsDiffView( state ),
 		} ),
 		{ recordTracksEvent }
 	)

--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -8,7 +8,7 @@
 	z-index: 1; // Put the viewer above the action-buttons:before overlay gradient. -shaun
 
 	.editor-diff-viewer__scrollable {
-		padding: 24px 32px 32px 32px;
+		padding: 24px 32px 32px;
 		height: 100%;
 		overflow-y: auto;
 		box-sizing: border-box;
@@ -20,10 +20,37 @@
 		font-size: 32px;
 		color: $gray-dark;
 		font-weight: 600;
-		margin: 0 0 24px 0;
+		margin: 0 0 24px;
 		height: auto;
 		line-height: 1.425;
 	}
+
+	@include breakpoint( '>1040px' ) {
+		&.is-split {
+			.editor-diff-viewer__scrollable {
+				display: flex;
+			}
+			.editor-diff-viewer__main-pane {
+				width: 50%;
+				padding-right: 16px;
+				.text-diff__additions {
+					display: none;
+				}
+			}
+			.editor-diff-viewer__secondary-pane {
+				display: block;
+				width: 50%;
+				padding-left: 16px;
+				.text-diff__deletions {
+					display: none;
+				}
+			}
+		}
+	}
+}
+
+.editor-diff-viewer__secondary-pane {
+	display: none;
 }
 
 .editor-diff-viewer__hint-above,
@@ -74,7 +101,7 @@
 	word-wrap: break-word;
 	padding: 0;
 	background: transparent;
-	overflow-y: hidden;
+	overflow: hidden;
 }
 
 .editor-diff-viewer.is-loading .editor-diff-viewer__content {

--- a/client/post-editor/editor-revisions-list/header.jsx
+++ b/client/post-editor/editor-revisions-list/header.jsx
@@ -11,11 +11,13 @@ import { localize } from 'i18n-calypso';
 const EditorRevisionsListHeader = ( { numRevisions, translate } ) => {
 	return (
 		<div className="editor-revisions-list__header">
-			{ !! numRevisions &&
-				translate( '%(revisions)d revision', '%(revisions)d revisions', {
-					count: numRevisions,
-					args: { revisions: numRevisions },
-				} ) }
+			<span className="editor-revisions-list__count">
+				{ !! numRevisions &&
+					translate( '%(revisions)d revision', '%(revisions)d revisions', {
+						count: numRevisions,
+						args: { revisions: numRevisions },
+					} ) }
+			</span>
 		</div>
 	);
 };

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -14,6 +14,7 @@ import { get, head, isEmpty, last, map } from 'lodash';
  * Internal dependencies
  */
 import EditorRevisionsListHeader from './header';
+import EditorRevisionsListViewButtons from './view-buttons';
 import EditorRevisionsListNavigation from './navigation';
 import EditorRevisionsListItem from './item';
 import { selectPostRevision } from 'state/posts/revisions/actions';
@@ -147,6 +148,7 @@ class EditorRevisionsList extends PureComponent {
 		return (
 			<div className={ classes }>
 				<EditorRevisionsListHeader numRevisions={ revisions.length } />
+				<EditorRevisionsListViewButtons />
 				<EditorRevisionsListNavigation
 					nextIsDisabled={ nextIsDisabled }
 					prevIsDisabled={ prevIsDisabled }

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -36,28 +36,64 @@
 }
 
 .editor-revisions-list__header {
-	$editor-revisions-list-header-height: 46px;
 	$editor-revisions-list-header-font-size: 16px;
+	display: flex;
 	padding: 0 16px;
-	height: $editor-revisions-list-header-height;
-	line-height: $editor-revisions-list-header-height;
+	height: 48px;
+	box-sizing: border-box;
 	color: $gray-text-min;
 	background: $white;
-	border-bottom: 1px solid darken( $sidebar-bg-color, 5% );
+	border-bottom: 1px solid darken($sidebar-bg-color, 5%);
+
+	@include breakpoint( '>1040px' ) {
+		height: 40px;
+		border-bottom: 0;
+	}
 
 	.editor-revisions-list.is-loading & {
-		position: relative;
-
-		&:before {
+		&::before {
 			content: '';
 			display: block;
-			position: absolute;
-			top: ( $editor-revisions-list-header-height - $editor-revisions-list-header-font-size ) / 2;
 			width: 50%;
 			height: $editor-revisions-list-header-font-size;
-			@include placeholder( 23% );
+			align-self: center;
+			@include placeholder(23%);
 		}
 	}
+}
+
+.editor-revisions-list__count {
+	align-self: center;
+}
+
+@include breakpoint ('>1040px') {
+	.editor-revisions-list.is-loading {
+		.editor-revisions-list__header::before {
+			align-self: flex-end;
+		}
+	}
+	.editor-revisions-list__count {
+		align-self: flex-end;
+	}
+}
+
+// Diff View Buttons
+.editor-revisions-list__view-buttons {
+	display: none;
+	@include breakpoint( '>1040px' ) {
+		display: flex;
+		height: 60px;
+		align-items: center;
+		padding: 0 16px;
+		box-sizing: border-box;
+		background: #fff;
+		border-bottom: 1px solid #d9e3ea;
+	}
+}
+
+.editor-revisions-list__unified-button,
+.editor-revisions-list__split-button {
+	width: 50%;
 }
 
 // Revision Navigation Buttons
@@ -65,8 +101,9 @@
 	display: flex;
 	flex-direction: row-reverse;
 	height: 40px;
+	box-sizing: border-box;
 	color: $gray-text-min;
-	border-bottom: 1px solid darken( $sidebar-bg-color, 5% );
+	border-bottom: 1px solid darken($sidebar-bg-color, 5%);
 	.button:first-child,
 	.button:last-child {
 		border-radius: 0;
@@ -90,11 +127,11 @@
 	&.button[disabled],
 	&.button.disabled {
 		background: transparent;
-		color: lighten( $gray-text-min, 30% );
-		border-color: darken( $sidebar-bg-color, 5% );
+		color: lighten($gray-text-min, 30%);
+		border-color: darken($sidebar-bg-color, 5%);
 	}
 	.gridicon {
-		transform: rotate( -90deg );
+		transform: rotate(-90deg);
 	}
 
 	@include breakpoint( '>660px' ) {
@@ -159,6 +196,10 @@
 	@include breakpoint( '<660px' ) {
 		top: 88px;
 		overflow-y: hidden;
+	}
+
+	@include breakpoint( '>1040px' ) {
+		top: 124px;
 	}
 }
 


### PR DESCRIPTION
Part 4 of a change adding the option for a split view to the revisions diff viewer on larger viewports. The other three branches are already shipped.

### Background

WordPress keeps a history of the different versions of a post so authors can keep track of the changes they've made to the content over time. The revisions diff view shows the content changes that were made in any one revision. 

This change addresses the story

> As an Author or Editor I would like to have the ability to view the revisions diff for a post side by side as well as in the current unified view.

There's only space to render this view on desktop, so we'll only do it on viewports over 1040.

![split-view](https://user-images.githubusercontent.com/1647564/38148134-14ea8c72-344d-11e8-9bfe-8ae392940e6d.gif)

### Changes

* Integrates the new `EditorRevisionsListViewButtons` component added in https://github.com/Automattic/wp-calypso/pull/24354 into the `EditorRevisionsList` component.
* Enables the `EditorDiffViewer` component to display a split diff view. The viewer does this by rendering an additional pair of `TextDiff` components and using CSS to hide the additions in the left pane and the deletions in the right pane. 

### Testing

* ~~This PR requires the changes introduced in the first three PRs in this series to be merged first.~~
* Open a post which has some revisions in the Post Editor.
* Click the History button to review the revisions history. On the right you'll see a list of revisions of the post. On the left you'll see a diff view showing the various changes made in the selected revision.
* The diff view compares the title and content of the selected version of the post with the one that came before it in the history. Select a new revision in the list, and the diff will change to show the set of changes that happened in that revision.
* On a viewport over 1040px wide, you should see buttons at the top of the revisions list allowing you to choose "split" or "unified" view. The unified view is the default.
* Clicking the "split" button should split the diff into two panes. On the left, you should see the post content with any pieces of text you deleted from the previous version of the post. On the right, you should see pieces of text you added to create the version of the post you're currently viewing.

### PRs in this change:

- [x] https://github.com/Automattic/wp-calypso/pull/24352 - 1. Add breakpoints to `isWithinBreakpoint` 
- [x] https://github.com/Automattic/wp-calypso/pull/24353 - 2. Add actions and selector
- [x] https://github.com/Automattic/wp-calypso/pull/24354 - 3. Add button component
- [ ] https://github.com/Automattic/wp-calypso/pull/24355 - 4. Integrate buttons and split view

(The original PR for this was #23811 - it was too big, so I've closed it.)