### PR TITLE
Jetpack connect: Use JSX in the controller

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -62,11 +62,6 @@ const analyticsPageTitleByType = {
 const removeSidebar = context =>
 	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
 
-const jetpackNewSiteSelector = context => {
-	removeSidebar( context );
-	context.primary = <JetpackNewSite path={ context.path } locale={ context.params.locale } />;
-};
-
 const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
 	const planSlugs = {
 		yearly: {
@@ -119,7 +114,8 @@ export function maybeOnboard( { query, store }, next ) {
 
 export function newSite( context, next ) {
 	analytics.pageView.record( '/jetpack/new', 'Add a new site (Jetpack)' );
-	jetpackNewSiteSelector( context );
+	removeSidebar( context );
+	context.primary = <JetpackNewSite path={ context.path } locale={ context.params.locale } />;
 	next();
 }
 

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -64,9 +64,7 @@ const removeSidebar = context =>
 
 const jetpackNewSiteSelector = context => {
 	removeSidebar( context );
-	context.primary = (
-		<JetpackNewSite path={ context.path } context={ context } locale={ context.params.locale } />
-	);
+	context.primary = <JetpackNewSite path={ context.path } locale={ context.params.locale } />;
 };
 
 const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
@@ -166,7 +164,6 @@ export function connect( context, next ) {
 
 	context.primary = (
 		<JetpackConnect
-			context={ context }
 			locale={ params.locale }
 			path={ path }
 			type={ type }

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -164,15 +164,17 @@ export function connect( context, next ) {
 
 	removeSidebar( context );
 
-	context.primary = React.createElement( JetpackConnect, {
-		context,
-		locale: params.locale,
-		path,
-		type,
-		url: query.url,
-		ctaId: query.cta_id, // origin tracking params
-		ctaFrom: query.cta_from,
-	} );
+	context.primary = (
+		<JetpackConnect
+			context={ context }
+			locale={ params.locale }
+			path={ path }
+			type={ type }
+			url={ query.url }
+			ctaId={ query.cta_id /* origin tracking params */ }
+			ctaFrom={ query.cta_from }
+		/>
+	);
 	next();
 }
 

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -64,11 +64,9 @@ const removeSidebar = context =>
 
 const jetpackNewSiteSelector = context => {
 	removeSidebar( context );
-	context.primary = React.createElement( JetpackNewSite, {
-		path: context.path,
-		context: context,
-		locale: context.params.locale,
-	} );
+	context.primary = (
+		<JetpackNewSite path={ context.path } context={ context } locale={ context.params.locale } />
+	);
 };
 
 const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -251,12 +251,14 @@ export function sso( context, next ) {
 
 	analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
 
-	context.primary = React.createElement( JetpackSsoForm, {
-		path: context.path,
-		locale: context.params.locale,
-		siteId: context.params.siteId,
-		ssoNonce: context.params.ssoNonce,
-	} );
+	context.primary = (
+		<JetpackSsoForm
+			path={ context.path }
+			locale={ context.params.locale }
+			siteId={ context.params.siteId }
+			ssoNonce={ context.params.ssoNonce }
+		/>
+	);
 	next();
 }
 

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -115,7 +115,7 @@ export function maybeOnboard( { query, store }, next ) {
 export function newSite( context, next ) {
 	analytics.pageView.record( '/jetpack/new', 'Add a new site (Jetpack)' );
 	removeSidebar( context );
-	context.primary = <JetpackNewSite path={ context.path } locale={ context.params.locale } />;
+	context.primary = <JetpackNewSite locale={ context.params.locale } path={ context.path } />;
 	next();
 }
 

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -246,8 +246,8 @@ export function sso( context, next ) {
 
 	context.primary = (
 		<JetpackSsoForm
-			path={ context.path }
 			locale={ context.params.locale }
+			path={ context.path }
 			siteId={ context.params.siteId }
 			ssoNonce={ context.params.ssoNonce }
 		/>

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -160,12 +160,12 @@ export function connect( context, next ) {
 
 	context.primary = (
 		<JetpackConnect
+			ctaFrom={ query.cta_from /* origin tracking params */ }
+			ctaId={ query.cta_id /* origin tracking params */ }
 			locale={ params.locale }
 			path={ path }
 			type={ type }
 			url={ query.url }
-			ctaId={ query.cta_id /* origin tracking params */ }
-			ctaFrom={ query.cta_from }
 		/>
 	);
 	next();


### PR DESCRIPTION
- Updates `React.createElement` calls to their JSX versions.
- Drop unused `context` prop from `JetpackNewSite` and `JetpackConnect`
- Inline a redundant function call

No functional changes.

## Testing

Verify that the affected handlers continue to work as expected:

1. JetpackNewSite: https://calypso.live/jetpack/new?branch=update/jetpack-connect-jsx-controller
1. JetpackConnect: https://calypso.live/jetpack/connect?branch=update/jetpack-connect-jsx-controller
1. JetpackSsoForm: https://calypso.live/jetpack/sso?branch=update/jetpack-connect-jsx-controller
   ⭐️ Note, this component will render an error cartoon with "Oops, this URL should not be accessed directly". This verifies the component _is_ rendered.