### PR TITLE
Update copy on spring sale nudge and make it last a few hours longer

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -120,7 +120,7 @@ class SiteNotice extends React.Component {
 				ctaText={ 'Upgrade' }
 				href={ `/plans/${ site.slug }?sale` }
 				icon="info-outline"
-				text={ '30% Off All Plans' } // no translate() since we're launching this just for EN audience
+				text={ '30% Off (Ends Today)' } // no translate() since we're launching this just for EN audience
 			/>
 		);
 	}

--- a/client/state/selectors/is-current-user-eligible-for-spring-discount.js
+++ b/client/state/selectors/is-current-user-eligible-for-spring-discount.js
@@ -15,7 +15,7 @@ import { hasActivePromotion } from 'state/active-promotions/selectors';
 export default state => {
 	// This is not super reliable but is fine for purposes of this test - display the
 	// upsell until we hit a certain point in time
-	const pastPromo = new Date() > new Date( Date.UTC( 2018, 3, 20, 23, 59, 59 ) );
+	const pastPromo = new Date() > new Date( Date.UTC( 2018, 3, 21, 5, 59, 59 ) );
 	if ( pastPromo ) {
 		return false;
 	}


### PR DESCRIPTION
We want to communicate that it's the last moment to benefit from the spring sale.

This change is trivial so there is no test plan.