### PR TITLE
Jetpack connect: Use shared access error for SSO

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -581,7 +581,7 @@ export class JetpackAuthorize extends Component {
 				<LoggedOutFormLinkItem onClick={ this.handleSignOut }>
 					{ translate( 'Create a new account' ) }
 				</LoggedOutFormLinkItem>
-				<JetpackConnectHappychatButton eventName="calypso_jpc_authorize_chat_initiated">
+				<JetpackConnectHappychatButton>
 					<HelpButton />
 				</JetpackConnectHappychatButton>
 			</LoggedOutFormLinks>

--- a/client/jetpack-connect/happychat-button.jsx
+++ b/client/jetpack-connect/happychat-button.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
@@ -13,17 +12,12 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-
-import analytics from 'lib/analytics';
 import HappychatButton from 'components/happychat/button';
 import HappychatConnection from 'components/happychat/connection-connected';
 import { isEnabled } from 'config';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
-
-const getHappyChatButtonClickHandler = ( eventName = 'calypso_jpc_chat_initiated' ) => () =>
-	analytics.tracks.recordEvent( eventName );
 
 const JetpackConnectHappychatButton = ( {
 	children,
@@ -32,7 +26,6 @@ const JetpackConnectHappychatButton = ( {
 	isLoggedIn,
 	label,
 	translate,
-	eventName,
 } ) => {
 	if ( ! isEnabled( 'jetpack/happychat' ) || ! isLoggedIn ) {
 		return <div>{ children }</div>;
@@ -51,7 +44,6 @@ const JetpackConnectHappychatButton = ( {
 		<HappychatButton
 			borderless={ false }
 			className="logged-out-form__link-item jetpack-connect__happychat-button"
-			onClick={ getHappyChatButtonClickHandler( eventName ) }
 		>
 			<HappychatConnection />
 			<Gridicon icon="chat" size={ 18 } /> { label || translate( 'Get help setting up Jetpack' ) }
@@ -60,7 +52,6 @@ const JetpackConnectHappychatButton = ( {
 };
 
 JetpackConnectHappychatButton.propTypes = {
-	eventName: PropTypes.string,
 	label: PropTypes.string,
 };
 

--- a/client/jetpack-connect/no-direct-access-error.js
+++ b/client/jetpack-connect/no-direct-access-error.js
@@ -19,8 +19,18 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 class NoDirectAccessError extends PureComponent {
 	static propTypes = {
+		action: PropTypes.string,
+		actionURL: PropTypes.string,
+		illustration: PropTypes.string,
 		recordTracksEvent: PropTypes.func.isRequired,
+		title: PropTypes.string,
 		translate: PropTypes.func.isRequired,
+		line: PropTypes.string,
+	};
+
+	static defaultProps = {
+		illustration: '/calypso/images/illustrations/error.svg',
+		actionURL: '/jetpack/connect',
 	};
 
 	render() {
@@ -29,10 +39,13 @@ class NoDirectAccessError extends PureComponent {
 		return (
 			<Main className="jetpack-connect__main-error">
 				<EmptyContent
-					illustration="/calypso/images/illustrations/error.svg"
-					title={ translate( 'Oops, this URL should not be accessed directly' ) }
-					action={ translate( 'Get back to Jetpack Connect screen' ) }
-					actionURL="/jetpack/connect"
+					action={ this.props.action || translate( 'Go back to Jetpack Connect screen' ) }
+					actionURL={ this.props.actionURL }
+					illustration={ this.props.illustration }
+					line={ this.props.line }
+					title={
+						this.props.title || translate( 'Oops, this URL should not be accessed directly' )
+					}
 				/>
 				<LoggedOutFormLinks>
 					<JetpackConnectHappychatButton>

--- a/client/jetpack-connect/no-direct-access-error.js
+++ b/client/jetpack-connect/no-direct-access-error.js
@@ -35,7 +35,7 @@ class NoDirectAccessError extends PureComponent {
 					actionURL="/jetpack/connect"
 				/>
 				<LoggedOutFormLinks>
-					<JetpackConnectHappychatButton eventName="calypso_jpc_noqueryarguments_chat_initiated">
+					<JetpackConnectHappychatButton>
 						<HelpButton />
 					</JetpackConnectHappychatButton>
 				</LoggedOutFormLinks>

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -115,7 +115,7 @@ class PlansLanding extends Component {
 					<PlansSkipButton onClick={ this.handleSkipButtonClick } />
 					<PlansExtendedInfo recordTracks={ this.handleInfoButtonClick } />
 					<LoggedOutFormLinks>
-						<JetpackConnectHappychatButton eventName="calypso_jpc_planslanding_chat_initiated">
+						<JetpackConnectHappychatButton>
 							<HelpButton />
 						</JetpackConnectHappychatButton>
 					</LoggedOutFormLinks>

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -219,10 +219,7 @@ class Plans extends Component {
 					<PlansSkipButton onClick={ this.handleSkipButtonClick } isRtl={ isRtlLayout } />
 					<PlansExtendedInfo recordTracks={ this.handleInfoButtonClick } />
 					<LoggedOutFormLinks>
-						<JetpackConnectHappychatButton
-							label={ helpButtonLabel }
-							eventName="calypso_jpc_plans_chat_initiated"
-						>
+						<JetpackConnectHappychatButton label={ helpButtonLabel }>
 							<HelpButton label={ helpButtonLabel } />
 						</JetpackConnectHappychatButton>
 					</LoggedOutFormLinks>

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -1,4 +1,5 @@
 /** @format */
+
 /**
  * External dependencies
  */
@@ -12,7 +13,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { addQueryArgs } from 'lib/route';
 import analytics from 'lib/analytics';
 import Button from 'components/button';
 import Card from 'components/card';
@@ -20,7 +20,6 @@ import CompactCard from 'components/card/compact';
 import config from 'config';
 import Dialog from 'components/dialog';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
-import EmptyContent from 'components/empty-content';
 import FormattedHeader from 'components/formatted-header';
 import Gravatar from 'components/gravatar';
 import HelpButton from './help-button';
@@ -28,12 +27,13 @@ import JetpackConnectHappychatButton from './happychat-button';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
-import Main from 'components/main';
 import MainWrapper from './main-wrapper';
+import NoDirectAccessError from './no-direct-access-error';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import Site from 'blocks/site';
 import SitePlaceholder from 'blocks/site/placeholder';
+import { addQueryArgs } from 'lib/route';
 import { decodeEntities } from 'lib/formatting';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSSO } from 'state/jetpack-connect/selectors';
@@ -375,22 +375,18 @@ class JetpackSsoForm extends Component {
 	renderBadPathArgsError() {
 		const { translate } = this.props;
 		return (
-			<Main>
-				<EmptyContent
-					illustration="/calypso/images/illustrations/error.svg"
-					title={ translate( 'Oops, this URL should not be accessed directly' ) }
-					line={ translate(
-						'Please click the {{em}}Log in with WordPress.com button{{/em}} on your Jetpack site.',
-						{
-							components: {
-								em: <em />,
-							},
-						}
-					) }
-					action={ translate( 'Read Single Sign-On Documentation' ) }
-					actionURL="https://jetpack.com/support/sso/"
-				/>
-			</Main>
+			<NoDirectAccessError
+				line={ translate(
+					'Please click the {{em}}Log in with WordPress.com button{{/em}} on your Jetpack site.',
+					{
+						components: {
+							em: <em />,
+						},
+					}
+				) }
+				action={ translate( 'Read Single Sign-On Documentation' ) }
+				actionURL="https://jetpack.com/support/sso/"
+			/>
 		);
 	}
 

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -379,12 +379,12 @@ class JetpackSsoForm extends Component {
 		if ( ! ssoNonce || ! siteId || validationError ) {
 			return (
 				<NoDirectAccessError
+					action={ translate( 'Read Single Sign-On Documentation' ) }
+					actionURL="https://jetpack.com/support/sso/"
 					line={ translate(
 						'Please click the {{em}}Log in with WordPress.com button{{/em}} on your Jetpack site.',
 						{ components: { em: <em /> } }
 					) }
-					action={ translate( 'Read Single Sign-On Documentation' ) }
-					actionURL="https://jetpack.com/support/sso/"
 				/>
 			);
 		}

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -455,10 +455,7 @@ class JetpackSsoForm extends Component {
 						>
 							{ this.getReturnToSiteText() }
 						</LoggedOutFormLinkItem>
-						<JetpackConnectHappychatButton
-							eventName="calypso_jpc_sso_chat_initiated"
-							label={ translate( 'Chat with Jetpack support' ) }
-						>
+						<JetpackConnectHappychatButton label={ translate( 'Chat with Jetpack support' ) }>
 							<HelpButton />
 						</JetpackConnectHappychatButton>
 					</LoggedOutFormLinks>

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -372,30 +372,21 @@ class JetpackSsoForm extends Component {
 		);
 	}
 
-	renderBadPathArgsError() {
-		const { translate } = this.props;
-		return (
-			<NoDirectAccessError
-				line={ translate(
-					'Please click the {{em}}Log in with WordPress.com button{{/em}} on your Jetpack site.',
-					{
-						components: {
-							em: <em />,
-						},
-					}
-				) }
-				action={ translate( 'Read Single Sign-On Documentation' ) }
-				actionURL="https://jetpack.com/support/sso/"
-			/>
-		);
-	}
-
 	render() {
 		const { currentUser } = this.props;
 		const { ssoNonce, siteId, validationError, translate } = this.props;
 
 		if ( ! ssoNonce || ! siteId || validationError ) {
-			return this.renderBadPathArgsError();
+			return (
+				<NoDirectAccessError
+					line={ translate(
+						'Please click the {{em}}Log in with WordPress.com button{{/em}} on your Jetpack site.',
+						{ components: { em: <em /> } }
+					) }
+					action={ translate( 'Read Single Sign-On Documentation' ) }
+					actionURL="https://jetpack.com/support/sso/"
+				/>
+			);
 		}
 
 		return (


### PR DESCRIPTION
- Remove some JPC-specific Happychat events. They can use global Happychat events.
   Some events are used in funnels, I'll 🔴 them and provide suggestions.
- Parameterize `NoDirectAccess` component.
- Update `JetpackSso` to use shared `NoDirectAccess` component.

The SSO error will now include the same support link provided by at `/jetpack/connect/authorize`

The only functional change is to dispatch fewer (redundant) events. I'll provide instructions to update anything using these events:
- `calypso_jpc_authorize_chat_initiated`
- `calypso_jpc_chat_initiated`
- `calypso_jpc_noqueryarguments_chat_initiated`
- `calypso_jpc_planslanding_chat_initiated`
- `calypso_jpc_plans_chat_initiated`
- `calypso_jpc_sso_chat_initiated`

These events should all be replaceable (and more reliable) with the general chat start event: `calypso_happychat_start`

## Testing

Confirm these messages work as before:

- https://calypso.live/jetpack/sso?branch=update/jpc-sso-shared-error
- https://calypso.live/jetpack/connect/authorize?branch=update/jpc-sso-shared-error