### PR TITLE
Media: Fix to enable video thumbnail selection for private sites

### DIFF
--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -80,7 +80,7 @@ export class EditorMediaModalDetailItem extends Component {
 	}
 
 	/**
-	 * This function return true if the image editor can be
+	 * This function returns true if the image editor can be
 	 * enabled/shown
 	 *
 	 * @param  {object} item - media item

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -58,7 +58,7 @@ export class EditorMediaModalDetailItem extends Component {
 	 * @param  {Object}  item Media item
 	 * @return {Boolean} Whether the video editor can be enabled
 	 */
-	enableVideoEditing( item ) {
+	shouldShowVideoEditingButtons( item ) {
 		const { isJetpack, isVideoPressEnabled, isVideoPressModuleActive } = this.props;
 
 		// Not a VideoPress video
@@ -87,7 +87,7 @@ export class EditorMediaModalDetailItem extends Component {
 	 * @param  {object} site - current site
 	 * @return {boolean} `true` if the image-editor can be enabled.
 	 */
-	enableImageEditing( item, site ) {
+	shouldShowImageEditingButtons( item, site ) {
 		const { isSitePrivate } = this.props;
 
 		// do not allow if, for some reason, there isn't a valid item yet
@@ -190,7 +190,7 @@ export class EditorMediaModalDetailItem extends Component {
 	renderImageEditorButtons( classname ) {
 		const { item, site } = this.props;
 
-		if ( ! this.enableImageEditing( item, site ) ) {
+		if ( ! this.shouldShowImageEditingButtons( item, site ) ) {
 			return null;
 		}
 
@@ -205,7 +205,7 @@ export class EditorMediaModalDetailItem extends Component {
 	}
 
 	renderVideoEditorButtons( item, classname ) {
-		if ( ! this.enableVideoEditing( item ) ) {
+		if ( ! this.shouldShowVideoEditingButtons( item ) ) {
 			return null;
 		}
 

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -88,7 +88,7 @@ export class EditorMediaModalDetailItem extends Component {
 	 * @return {boolean} `true` if the image-editor can be enabled.
 	 */
 	enableImageEditing( item, site ) {
-		const { isPrivate } = this.props;
+		const { isSitePrivate } = this.props;
 
 		// do not allow if, for some reason, there isn't a valid item yet
 		if ( ! item ) {
@@ -101,7 +101,7 @@ export class EditorMediaModalDetailItem extends Component {
 		}
 
 		// do not allow for private sites
-		if ( isPrivate ) {
+		if ( isSitePrivate ) {
 			return false;
 		}
 
@@ -125,7 +125,7 @@ export class EditorMediaModalDetailItem extends Component {
 
 		const mimePrefix = getMimePrefix( item );
 
-		if ( 'image' === mimePrefix && this.props.isPrivateSite ) {
+		if ( 'image' === mimePrefix && this.props.isSitePrivate ) {
 			return null;
 		}
 
@@ -326,7 +326,7 @@ const connectComponent = connect( state => {
 		isJetpack: isJetpackSite( state, siteId ),
 		isVideoPressEnabled: getSiteOption( state, siteId, 'videopress_enabled' ),
 		isVideoPressModuleActive: isJetpackModuleActive( state, siteId, 'videopress' ),
-		isPrivate: isPrivateSite( state, siteId ),
+		isSitePrivate: isPrivateSite( state, siteId ),
 		siteId,
 		canUserUploadFiles,
 	};

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -125,10 +125,6 @@ export class EditorMediaModalDetailItem extends Component {
 
 		const mimePrefix = getMimePrefix( item );
 
-		if ( 'image' === mimePrefix && this.props.isSitePrivate ) {
-			return null;
-		}
-
 		if ( ! includes( [ 'image', 'video' ], mimePrefix ) ) {
 			return null;
 		}

--- a/client/post-editor/media-modal/detail/test/index.jsx
+++ b/client/post-editor/media-modal/detail/test/index.jsx
@@ -77,7 +77,7 @@ describe( 'EditorMediaModalDetailItem', () => {
 			<DetailItem
 				item={ DUMMY_VIDEO_MEDIA }
 				isVideoPressEnabled={ isVideoPressEnabled }
-				isPrivateSite={ true }
+				isSitePrivate={ true }
 				{ ...SHARED_PROPS }
 			/>
 		);
@@ -97,7 +97,7 @@ describe( 'EditorMediaModalDetailItem', () => {
 
 	test( 'should not display edit button for an image on a private site', () => {
 		const tree = shallow(
-			<DetailItem item={ DUMMY_IMAGE_MEDIA } isPrivateSite={ true } { ...SHARED_PROPS } />
+			<DetailItem item={ DUMMY_IMAGE_MEDIA } isSitePrivate={ true } { ...SHARED_PROPS } />
 		);
 
 		const editButton = tree.find( '.editor-media-modal-detail__edit' );

--- a/client/post-editor/media-modal/detail/test/index.jsx
+++ b/client/post-editor/media-modal/detail/test/index.jsx
@@ -58,7 +58,7 @@ describe( 'EditorMediaModalDetailItem', () => {
 		isVideoPressEnabled = sandbox.stub().returns( true );
 	} );
 
-	test( 'should display edit button for a VideoPress video on a public site', () => {
+	test( 'should display at least one edit button for a VideoPress video on a public site', () => {
 		const tree = shallow(
 			<DetailItem
 				item={ DUMMY_VIDEO_MEDIA }
@@ -69,13 +69,10 @@ describe( 'EditorMediaModalDetailItem', () => {
 
 		const editButton = tree.find( '.editor-media-modal-detail__edit' );
 
-		// 2 Edit buttons are rendered. It's recommended te have exact value tests.
-		// Not sure whethur to change this to
-		// expect( editButton ).to.have.length(2);
 		expect( editButton ).to.have.length.at.least( 1 );
 	} );
 
-	test( 'should display edit button for a VideoPress video on a private site', () => {
+	test( 'should display at least one edit button for a VideoPress video on a private site', () => {
 		const tree = shallow(
 			<DetailItem
 				item={ DUMMY_VIDEO_MEDIA }
@@ -90,7 +87,7 @@ describe( 'EditorMediaModalDetailItem', () => {
 		expect( editButton ).to.have.length.at.least( 1 );
 	} );
 
-	test( 'should display edit button for an image on a public site', () => {
+	test( 'should display at least one edit button for an image on a public site', () => {
 		const tree = shallow( <DetailItem item={ DUMMY_IMAGE_MEDIA } { ...SHARED_PROPS } /> );
 
 		const editButton = tree.find( '.editor-media-modal-detail__edit' );

--- a/client/post-editor/media-modal/detail/test/index.jsx
+++ b/client/post-editor/media-modal/detail/test/index.jsx
@@ -1,0 +1,110 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { EditorMediaModalDetailItem as DetailItem } from '../detail-item';
+import { useSandbox } from 'test/helpers/use-sinon';
+
+jest.mock( 'post-editor/media-modal/detail/detail-fields', () =>
+	require( 'components/empty-component' )
+);
+jest.mock( 'post-editor/media-modal/detail/detail-file-info', () =>
+	require( 'components/empty-component' )
+);
+
+/**
+ * Module variables
+ */
+const DUMMY_SITE = { ID: 1 };
+
+const DUMMY_IMAGE_MEDIA = {
+	ID: 100,
+	date: '2015-06-19T11:36:09-04:00',
+	mime_type: 'image/jpeg',
+	guid: 'http://wordpress.com/test.jpg',
+	URL: 'http://wordpress.com/test.jpg',
+};
+
+const DUMMY_VIDEO_MEDIA = {
+	ID: 200,
+	date: '2015-06-19T11:36:09-04:00',
+	mime_type: 'video/mp4',
+	videopress_guid: 'testvideopressguid123',
+	guid: 'http://wordpress.com/test.mp4',
+	URL: 'http://wordpress.com/test.mp4',
+};
+
+const SHARED_PROPS = {
+	site: DUMMY_SITE,
+	canUserUploadFiles: true,
+	translate: str => str,
+};
+
+describe( 'EditorMediaModalDetailItem', () => {
+	let isVideoPressEnabled;
+
+	useSandbox( sandbox => {
+		isVideoPressEnabled = sandbox.stub().returns( true );
+	} );
+
+	test( 'should display edit button for a VideoPress video on a public site', () => {
+		const tree = shallow(
+			<DetailItem
+				item={ DUMMY_VIDEO_MEDIA }
+				isVideoPressEnabled={ isVideoPressEnabled }
+				{ ...SHARED_PROPS }
+			/>
+		);
+
+		const editButton = tree.find( '.editor-media-modal-detail__edit' );
+
+		// 2 Edit buttons are rendered. It's recommended te have exact value tests.
+		// Not sure whethur to change this to
+		// expect( editButton ).to.have.length(2);
+		expect( editButton ).to.have.length.at.least( 1 );
+	} );
+
+	test( 'should display edit button for a VideoPress video on a private site', () => {
+		const tree = shallow(
+			<DetailItem
+				item={ DUMMY_VIDEO_MEDIA }
+				isVideoPressEnabled={ isVideoPressEnabled }
+				isPrivateSite={ true }
+				{ ...SHARED_PROPS }
+			/>
+		);
+
+		const editButton = tree.find( '.editor-media-modal-detail__edit' );
+
+		expect( editButton ).to.have.length.at.least( 1 );
+	} );
+
+	test( 'should display edit button for an image on a public site', () => {
+		const tree = shallow( <DetailItem item={ DUMMY_IMAGE_MEDIA } { ...SHARED_PROPS } /> );
+
+		const editButton = tree.find( '.editor-media-modal-detail__edit' );
+
+		expect( editButton ).to.have.length.at.least( 1 );
+	} );
+
+	test( 'should not display edit button for an image on a private site', () => {
+		const tree = shallow(
+			<DetailItem item={ DUMMY_IMAGE_MEDIA } isPrivateSite={ true } { ...SHARED_PROPS } />
+		);
+
+		const editButton = tree.find( '.editor-media-modal-detail__edit' );
+
+		expect( editButton ).to.have.length( 0 );
+	} );
+} );

--- a/config/test.json
+++ b/config/test.json
@@ -76,6 +76,7 @@
 		"persist-redux": true,
 		"plans/personal-plan": true,
 		"post-editor-github-link": false,
+		"post-editor/image-editor": true,
 		"post-editor/media-advanced": true,
 		"post-editor/revisions": true,
 		"press-this": true,


### PR DESCRIPTION
A temporary fix was made (fe40f4e) to solve (#13625) an image editing problem on private sites. The fix was to hide the edit button in the media modal. This also hides the edit button for VideoPress videos which is used to change the video thumbnail.

This change only hides the button when the media item is an image and the site is private. Some tests are added to check this is the case. 

### How to test

The included unit tests will check for the correct behaviour, but to manually test. 

- Using the current live version of Calypso, go to the media section of a private site and upload or edit a video
- Observe that there is no edit thumbnail button displayed on the video element.
- Now edit the same video using a local version of Calypso. You should see a button saying 'Edit Thumbnail' that allows you to select the frame of the video to be displayed as the preview.
- Also check that there are no edit buttons displayed for images on the private site, but that they can be seen on public sites.
