### PR TITLE
Components: Connect PlansSkipButton to isRtl() selector

### DIFF
--- a/client/components/plans/plans-skip-button/README.md
+++ b/client/components/plans/plans-skip-button/README.md
@@ -4,7 +4,6 @@ Render a button that is labeled 'Start with Free', allowing a user to forego (pa
 
 ## Props 
 
-* **isRtl** — (optional) Whether the button should be rendered for a Right-to-Left locale.
 * **onClick** — (required) Function that will be called on button click.
 
 ## Usage

--- a/client/components/plans/plans-skip-button/index.jsx
+++ b/client/components/plans/plans-skip-button/index.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Gridicon from 'gridicons';
-import isRtlSelector from 'state/selectors/is-rtl';
+import { isRtl as isRtlSelector } from 'state/selectors';
 
 export const PlansSkipButton = ( { onClick, isRtl, translate = identity } ) => (
 	<div className="plans-skip-button">

--- a/client/components/plans/plans-skip-button/index.jsx
+++ b/client/components/plans/plans-skip-button/index.jsx
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -11,6 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Gridicon from 'gridicons';
+import isRtlSelector from 'state/selectors/is-rtl';
 
 export const PlansSkipButton = ( { onClick, isRtl, translate = identity } ) => (
 	<div className="plans-skip-button">
@@ -21,4 +23,6 @@ export const PlansSkipButton = ( { onClick, isRtl, translate = identity } ) => (
 	</div>
 );
 
-export default localize( PlansSkipButton );
+export default connect( state => ( {
+	isRtl: isRtlSelector( state ),
+} ) )( localize( PlansSkipButton ) );

--- a/client/jetpack-connect/test/__snapshots__/plans.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/plans.js.snap
@@ -147,7 +147,7 @@ exports[`Plans should render plans 1`] = `
       }
     }
   >
-    <Localized(PlansSkipButton)
+    <Connect(Localized(PlansSkipButton))
       isRtl={false}
       onClick={[Function]}
     />


### PR DESCRIPTION
Per review of #24324 -- see there for details.

To test: 
* Go to http://calypso.localhost:3000/devdocs/design/plans-skip-button
* Try with LTR and RTL settings, and verify that the arrow points into the right direction.