### PR TITLE
Sharing: Update Facebook preview

### DIFF
--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -27,6 +27,7 @@ import { getSiteUserConnections } from 'state/sharing/publicize/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+import { getSiteIconUrl } from 'state/selectors';
 
 const serviceNames = {
 	facebook: 'Facebook',
@@ -69,7 +70,16 @@ class SharingPreviewPane extends PureComponent {
 	};
 
 	renderPreview() {
-		const { post, site, message, connections, translate, siteSlug } = this.props;
+		const {
+			post,
+			site,
+			message,
+			connections,
+			translate,
+			seoTitle,
+			siteSlug,
+			siteIcon,
+		} = this.props;
 		const { selectedService } = this.state;
 		const connection = find( connections, { service: selectedService } );
 		if ( ! connection ) {
@@ -110,7 +120,9 @@ class SharingPreviewPane extends PureComponent {
 			externalProfilePicture,
 			message,
 			imageUrl,
+			seoTitle,
 			siteDomain,
+			siteIcon,
 		};
 
 		switch ( selectedService ) {
@@ -166,6 +178,7 @@ const mapStateToProps = ( state, ownProps ) => {
 	const currentUserId = getCurrentUserId( state );
 	const connections = getSiteUserConnections( state, siteId, currentUserId );
 	const siteSlug = getSiteSlug( state, siteId );
+	const siteIcon = getSiteIconUrl( state, siteId );
 
 	return {
 		site,
@@ -173,6 +186,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		seoTitle,
 		connections,
 		siteSlug,
+		siteIcon,
 	};
 };
 

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -13,7 +13,7 @@ import { get, find, map } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getPostImage, getExcerptForPost } from './utils';
+import { getPostImage, getExcerptForPost, getSummaryForPost } from './utils';
 import FacebookSharePreview from 'components/share/facebook-share-preview';
 import GooglePlusSharePreview from 'components/share/google-plus-share-preview';
 import LinkedinSharePreview from 'components/share/linkedin-share-preview';
@@ -22,8 +22,7 @@ import TumblrSharePreview from 'components/share/tumblr-share-preview';
 import VerticalMenu from 'components/vertical-menu';
 import { SocialItem } from 'components/vertical-menu/items';
 import { getSitePost } from 'state/posts/selectors';
-import { getSeoTitle, getSiteSlug } from 'state/sites/selectors';
-import { getSite } from 'state/sites/selectors';
+import { getSeoTitle, getSite, getSiteSlug } from 'state/sites/selectors';
 import { getSiteUserConnections } from 'state/sharing/publicize/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import Notice from 'components/notice';
@@ -90,6 +89,7 @@ class SharingPreviewPane extends PureComponent {
 		const articleUrl = get( post, 'URL', '' );
 		const articleTitle = get( post, 'title', '' );
 		const articleContent = getExcerptForPost( post );
+		const articleSummary = getSummaryForPost( post, translate );
 		const siteDomain = get( site, 'domain', '' );
 		const imageUrl = getPostImage( post );
 		const {
@@ -103,6 +103,7 @@ class SharingPreviewPane extends PureComponent {
 			articleUrl,
 			articleTitle,
 			articleContent,
+			articleSummary,
 			externalDisplay,
 			externalName,
 			externalProfileURL,

--- a/client/blocks/sharing-preview-pane/utils.js
+++ b/client/blocks/sharing-preview-pane/utils.js
@@ -61,13 +61,11 @@ export const getSummaryForPost = ( post, translate, maxWords = 60 ) => {
 	if ( ! post ) {
 		return null;
 	}
-
-	const content = trim( striptags( formatExcerpt( post.content ) ) );
+	const content = trim( striptags( post.content ) );
 	const words = content.split( ' ' );
-
 	return (
-		words.slice( 0, maxWords ).join( ' ' ) +
-		( words.length > maxWords
+		words.slice( 0, maxWords - 1 ).join( ' ' ) +
+		( words.length > maxWords - 1
 			? ' ' + translate( '[ more ]', { comment: 'Truncation of post content in a FB share.' } )
 			: '' )
 	);

--- a/client/blocks/sharing-preview-pane/utils.js
+++ b/client/blocks/sharing-preview-pane/utils.js
@@ -57,6 +57,15 @@ export const getExcerptForPost = post => {
 	);
 };
 
+/**
+ * Returns a summary of a post, truncated approximately at the same length as our servers
+ * and Facebook truncate it.
+ *
+ * @param {Object} post A post object.
+ * @param {Function} translate The i18n-calypso function.
+ * @param {Number} maxWords Approximation of the truncation logic performed by our servers.
+ * @returns {String} Post summary
+ */
 export const getSummaryForPost = ( post, translate, maxWords = 60 ) => {
 	if ( ! post ) {
 		return null;

--- a/client/blocks/sharing-preview-pane/utils.js
+++ b/client/blocks/sharing-preview-pane/utils.js
@@ -56,3 +56,19 @@ export const getExcerptForPost = post => {
 		)
 	);
 };
+
+export const getSummaryForPost = ( post, translate, maxWords = 60 ) => {
+	if ( ! post ) {
+		return null;
+	}
+
+	const content = trim( striptags( formatExcerpt( post.content ) ) );
+	const words = content.split( ' ' );
+
+	return (
+		words.slice( 0, maxWords ).join( ' ' ) +
+		( words.length > maxWords
+			? ' ' + translate( '[ more ]', { comment: 'Truncation of post content in a FB share.' } )
+			: '' )
+	);
+};

--- a/client/components/seo/facebook-preview/index.jsx
+++ b/client/components/seo/facebook-preview/index.jsx
@@ -13,6 +13,7 @@ const TITLE_LENGTH = 80;
 const DESCRIPTION_LENGTH = 270;
 
 const baseDomain = url =>
+	url &&
 	url
 		.replace( /^[^/]+[/]*/, '' ) // strip leading protocol
 		.replace( /\/.*$/, '' ); // strip everything after the domain

--- a/client/components/seo/facebook-preview/index.jsx
+++ b/client/components/seo/facebook-preview/index.jsx
@@ -1,6 +1,4 @@
 /** @format */
-/* eslint-disable jsx-a11y/alt-text */
-
 /**
  * External dependencies
  */
@@ -33,7 +31,9 @@ export class FacebookPreview extends PureComponent {
 		return (
 			<div className={ `facebook-preview facebook-preview__${ type }` }>
 				<div className="facebook-preview__content">
-					<div className="facebook-preview__image">{ image && <img src={ image } /> }</div>
+					<div className="facebook-preview__image">
+						{ image && <img alt="Facebook Preview Thumbnail" src={ image } /> }
+					</div>
 					<div className="facebook-preview__body">
 						<div className="facebook-preview__title">{ facebookTitle( title || '' ) }</div>
 						<div className="facebook-preview__description">

--- a/client/components/seo/facebook-preview/index.jsx
+++ b/client/components/seo/facebook-preview/index.jsx
@@ -1,4 +1,5 @@
 /** @format */
+/* eslint-disable jsx-a11y/alt-text */
 
 /**
  * External dependencies
@@ -32,11 +33,7 @@ export class FacebookPreview extends PureComponent {
 		return (
 			<div className={ `facebook-preview facebook-preview__${ type }` }>
 				<div className="facebook-preview__content">
-					{ image && (
-						<div className="facebook-preview__image">
-							<img src={ image } />
-						</div>
-					) }
+					<div className="facebook-preview__image">{ image && <img src={ image } /> }</div>
 					<div className="facebook-preview__body">
 						<div className="facebook-preview__title">{ facebookTitle( title || '' ) }</div>
 						<div className="facebook-preview__description">

--- a/client/components/seo/facebook-preview/index.jsx
+++ b/client/components/seo/facebook-preview/index.jsx
@@ -10,7 +10,7 @@ import { compact } from 'lodash';
 import { firstValid, hardTruncation, shortEnough } from '../helpers';
 
 const TITLE_LENGTH = 80;
-const DESCRIPTION_LENGTH = 270;
+const DESCRIPTION_LENGTH = 200;
 
 const baseDomain = url =>
 	url &&

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -70,8 +70,8 @@
 }
 
 .facebook-preview {
-	border: 1px solid;
-	border-color: #e9ebee #e9ebee #d1d1d1;
+	border: none;
+	box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15) inset, 0 1px 4px rgba(0, 0, 0, 0.1);
 	display: flex;
 	overflow-x: auto;
 	max-width: 527px;
@@ -100,7 +100,7 @@
 }
 
 .facebook-preview__description {
-	color: #4b4f56;
+	color: #1d2129;
 	flex-grow: 1;
 	font-family: helvetica, arial, sans-serif;
 	font-size: 12px;
@@ -109,10 +109,10 @@
 }
 
 .facebook-preview__url {
-	color: #90949c;
+	color: #606770;
 	font-family: helvetica, arial, sans-serif;
-	font-size: 11px;
-	line-height: 11px;
+	font-size: 12px;
+	line-height: 12px;
 	text-transform: uppercase;
 	text-overflow: ellipsis;
 	white-space: nowrap;

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -154,6 +154,7 @@
 
 .facebook-preview__website {
 	max-height: 158px;
+	overflow: hidden;
 
 	.facebook-preview__image {
 		flex-shrink: 0;
@@ -167,10 +168,13 @@
 			width: 100%;
 		}
 
-
 		&:after {
 			border: 1px solid;
 			border-color: rgba(0, 0, 0, .098) rgba(0, 0, 0, .149) rgba(0, 0, 0, .231);
+			content: "";
+			display: block;
+			height: 100%;
+			width: 100%;
 		}
 	}
 

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -157,7 +157,7 @@
 
 	.facebook-preview__image {
 		flex-shrink: 0;
-		height: 100%;
+		height: 158px;
 		width: 158px;
 
 		& img {
@@ -165,6 +165,12 @@
 			font-size: 14px;
 			height: auto;
 			width: 100%;
+		}
+
+
+		&:after {
+			border: 1px solid;
+			border-color: rgba(0, 0, 0, .098) rgba(0, 0, 0, .149) rgba(0, 0, 0, .231);
 		}
 	}
 

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -53,7 +53,9 @@ export class FacebookSharePreview extends PureComponent {
 								</span>
 							</div>
 							<div className="facebook-share-preview__meta-line">
-								{ translate( 'Now' ) }
+								{ translate( 'Just now', {
+									comment: 'Facebook relative time for just published posts.',
+								} ) }
 								<span> &middot; </span>
 								<a href="https://wordpress.com">{ translate( 'WordPress' ) }</a>
 							</div>

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -1,4 +1,5 @@
 /** @format */
+/* eslint-disable jsx-a11y/alt-text, jsx-a11y/anchor-is-valid */
 
 /**
  * External dependencies
@@ -18,6 +19,12 @@ export class FacebookSharePreview extends PureComponent {
 		message: PropTypes.string,
 	};
 
+	state = {
+		isProfileImageBroken: false,
+	};
+
+	setBrokenProfileImage = () => this.setState( { isProfileImageBroken: true } );
+
 	render() {
 		const {
 			articleUrl,
@@ -28,15 +35,19 @@ export class FacebookSharePreview extends PureComponent {
 			message,
 			translate,
 		} = this.props;
+		const { isProfileImageBroken } = this.state;
 		return (
 			<div className="facebook-share-preview">
 				<div className="facebook-share-preview__content">
 					<div className="facebook-share-preview__header">
 						<div className="facebook-share-preview__profile-picture-part">
-							<img
-								className="facebook-share-preview__profile-picture"
-								src={ externalProfilePicture }
-							/>
+							{ ! isProfileImageBroken && (
+								<img
+									className="facebook-share-preview__profile-picture"
+									src={ externalProfilePicture }
+									onError={ this.setBrokenProfileImage }
+								/>
+							) }
 						</div>
 
 						<div className="facebook-share-preview__profile-line-part">

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -45,7 +45,7 @@ export class FacebookSharePreview extends PureComponent {
 									{ externalDisplay }
 								</a>
 								<span>
-									{ translate( 'published an article on {{a}}WordPress{{/a}}', {
+									{ translate( 'published an article on {{a}}WordPress{{/a}}.', {
 										components: {
 											a: <a href="#" />,
 										},
@@ -53,6 +53,8 @@ export class FacebookSharePreview extends PureComponent {
 								</span>
 							</div>
 							<div className="facebook-share-preview__meta-line">
+								{ translate( 'Now' ) }
+								<span> &middot; </span>
 								<a href="https://wordpress.com">{ translate( 'WordPress' ) }</a>
 							</div>
 						</div>

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -1,6 +1,5 @@
 /** @format */
-/* eslint-disable jsx-a11y/alt-text, jsx-a11y/anchor-is-valid */
-
+/* eslint-disable jsx-a11y/anchor-is-valid */
 /**
  * External dependencies
  */
@@ -60,6 +59,7 @@ export class FacebookSharePreview extends PureComponent {
 									className="facebook-share-preview__profile-picture"
 									src={ externalProfilePicture }
 									onError={ this.setBrokenProfileImage }
+									alt={ externalDisplay }
 								/>
 							) }
 						</div>
@@ -99,7 +99,11 @@ export class FacebookSharePreview extends PureComponent {
 
 						{ ! isNull( imageUrl ) && (
 							<div className="facebook-share-preview__image-wrapper">
-								<img className="facebook-share-preview__image" src={ imageUrl } />
+								<img
+									alt="Facebook Preview Thumbnail"
+									className="facebook-share-preview__image"
+									src={ imageUrl }
+								/>
 							</div>
 						) }
 

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -1,5 +1,4 @@
 /** @format */
-/* eslint-disable jsx-a11y/anchor-is-valid */
 /**
  * External dependencies
  */
@@ -72,7 +71,7 @@ export class FacebookSharePreview extends PureComponent {
 								<span>
 									{ translate( 'published an article on {{a}}WordPress{{/a}}.', {
 										components: {
-											a: <a href="#" />,
+											a: <span className="facebook-share-preview__application-link" />,
 										},
 									} ) }
 								</span>

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -10,17 +10,23 @@ import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 import { isNull } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import FacebookPreview from 'components/seo/facebook-preview';
+
 export class FacebookSharePreview extends PureComponent {
 	static propTypes = {
 		articleContent: PropTypes.string,
 		articleSummary: PropTypes.string,
-		articleTitle: PropTypes.string,
 		articleUrl: PropTypes.string,
 		externalName: PropTypes.string,
 		externalProfilePicture: PropTypes.string,
 		externalProfileUrl: PropTypes.string,
 		imageUrl: PropTypes.string,
 		message: PropTypes.string,
+		seoTitle: PropTypes.string,
+		siteIcon: PropTypes.string,
 	};
 
 	state = {
@@ -31,13 +37,16 @@ export class FacebookSharePreview extends PureComponent {
 
 	render() {
 		const {
+			articleContent,
 			articleSummary,
 			articleUrl,
+			externalDisplay,
 			externalProfilePicture,
 			externalProfileUrl,
-			externalDisplay,
 			imageUrl,
 			message,
+			seoTitle,
+			siteIcon,
 			translate,
 		} = this.props;
 		const { isProfileImageBroken } = this.state;
@@ -78,21 +87,34 @@ export class FacebookSharePreview extends PureComponent {
 						</div>
 					</div>
 
-					{ ! isNull( imageUrl ) && (
-						<div className="facebook-share-preview__body">
-							<div className="facebook-share-preview__message">
-								{ message ? message : articleSummary }
-							</div>
-							<div className="facebook-share-preview__article-url-line">
-								<a className="facebook-share-preview__article-url" href={ articleUrl }>
-									{ articleUrl }
-								</a>
-							</div>
+					<div className="facebook-share-preview__body">
+						<div className="facebook-share-preview__message">
+							{ message ? message : articleSummary }
+						</div>
+						<div className="facebook-share-preview__article-url-line">
+							<a className="facebook-share-preview__article-url" href={ articleUrl }>
+								{ articleUrl }
+							</a>
+						</div>
+
+						{ ! isNull( imageUrl ) && (
 							<div className="facebook-share-preview__image-wrapper">
 								<img className="facebook-share-preview__image" src={ imageUrl } />
 							</div>
-						</div>
-					) }
+						) }
+
+						{ isNull( imageUrl ) && (
+							<div className="facebook-share-preview__card-wrapper">
+								<FacebookPreview
+									title={ seoTitle }
+									type="website"
+									description={ articleContent }
+									image={ siteIcon }
+									author="WORDPRESS"
+								/>
+							</div>
+						) }
+					</div>
 				</div>
 			</div>
 		);

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -8,14 +8,17 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
+import { isNull } from 'lodash';
 
 export class FacebookSharePreview extends PureComponent {
 	static propTypes = {
+		articleContent: PropTypes.string,
 		articleSummary: PropTypes.string,
+		articleTitle: PropTypes.string,
 		articleUrl: PropTypes.string,
+		externalName: PropTypes.string,
 		externalProfilePicture: PropTypes.string,
 		externalProfileUrl: PropTypes.string,
-		externalName: PropTypes.string,
 		imageUrl: PropTypes.string,
 		message: PropTypes.string,
 	};
@@ -74,21 +77,22 @@ export class FacebookSharePreview extends PureComponent {
 							</div>
 						</div>
 					</div>
-					<div className="facebook-share-preview__body">
-						<div className="facebook-share-preview__message">
-							{ message ? message : articleSummary }
-						</div>
-						<div className="facebook-share-preview__article-url-line">
-							<a className="facebook-share-preview__article-url" href={ articleUrl }>
-								{ articleUrl }
-							</a>
-						</div>
-						{ imageUrl && (
+
+					{ ! isNull( imageUrl ) && (
+						<div className="facebook-share-preview__body">
+							<div className="facebook-share-preview__message">
+								{ message ? message : articleSummary }
+							</div>
+							<div className="facebook-share-preview__article-url-line">
+								<a className="facebook-share-preview__article-url" href={ articleUrl }>
+									{ articleUrl }
+								</a>
+							</div>
 							<div className="facebook-share-preview__image-wrapper">
 								<img className="facebook-share-preview__image" src={ imageUrl } />
 							</div>
-						) }
-					</div>
+						</div>
+					) }
 				</div>
 			</div>
 		);

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 
 export class FacebookSharePreview extends PureComponent {
 	static propTypes = {
+		articleSummary: PropTypes.string,
 		articleUrl: PropTypes.string,
 		externalProfilePicture: PropTypes.string,
 		externalProfileUrl: PropTypes.string,
@@ -27,6 +28,7 @@ export class FacebookSharePreview extends PureComponent {
 
 	render() {
 		const {
+			articleSummary,
 			articleUrl,
 			externalProfilePicture,
 			externalProfileUrl,
@@ -73,7 +75,9 @@ export class FacebookSharePreview extends PureComponent {
 						</div>
 					</div>
 					<div className="facebook-share-preview__body">
-						<div className="facebook-share-preview__message">{ message }</div>
+						<div className="facebook-share-preview__message">
+							{ message ? message : articleSummary }
+						</div>
 						<div className="facebook-share-preview__article-url-line">
 							<a className="facebook-share-preview__article-url" href={ articleUrl }>
 								{ articleUrl }

--- a/client/components/share/facebook-share-preview/style.scss
+++ b/client/components/share/facebook-share-preview/style.scss
@@ -24,6 +24,7 @@
 
 .facebook-share-preview__profile-picture-part {
 	flex: 0 0 40px;
+	height: 40px;
 	margin-right: 8px;
 	position: relative;
 	width: 40px;

--- a/client/components/share/facebook-share-preview/style.scss
+++ b/client/components/share/facebook-share-preview/style.scss
@@ -54,7 +54,7 @@
 }
 
 .facebook-share-preview__profile-line {
-	color: #90949c;
+	color: #616770;
 	margin-bottom: 2px;
 }
 
@@ -64,13 +64,13 @@
 }
 
 .facebook-share-preview__meta-line {
-	color: #90949c;
+	color: #616770;
 	font-size: 12px;
 	line-height: 1.34;
 }
 
 .facebook-share-preview .facebook-share-preview__meta-line a {
-	color: #90949c;
+	color: #616770;
 }
 
 .facebook-share-preview__message p {

--- a/client/components/share/facebook-share-preview/style.scss
+++ b/client/components/share/facebook-share-preview/style.scss
@@ -59,7 +59,7 @@
 }
 
 .facebook-share-preview__profile-name {
-	font-weight: bold;
+	font-weight: 600;
 	margin-right: 5px;
 }
 

--- a/client/components/share/facebook-share-preview/style.scss
+++ b/client/components/share/facebook-share-preview/style.scss
@@ -88,4 +88,14 @@
 
 .facebook-share-preview__image-wrapper {
 	margin-top: 10px;
+	position: relative;
+	&:after {
+		border: 1px solid rgba(0, 0, 0, 0.1);
+		bottom: 0;
+		content: '';
+		left: 0;
+		position: absolute;
+		right: 0;
+		top: 0;
+	}
 }

--- a/client/components/share/facebook-share-preview/style.scss
+++ b/client/components/share/facebook-share-preview/style.scss
@@ -14,6 +14,7 @@
 
 .facebook-share-preview a {
 	color: #365899;
+	text-decoration: none;
 }
 
 .facebook-share-preview__header {

--- a/client/components/share/facebook-share-preview/style.scss
+++ b/client/components/share/facebook-share-preview/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 .facebook-share-preview {
 	background-color: $white;
 	border: 1px solid;
@@ -22,12 +24,27 @@
 .facebook-share-preview__profile-picture-part {
 	flex: 0 0 40px;
 	margin-right: 8px;
+	position: relative;
 	width: 40px;
+	&:after {
+		border: 1px solid rgba(0, 0, 0, 0.1);
+		border-radius: 50%;
+		bottom: 0;
+		content: '';
+		left: 0;
+		position: absolute;
+		right: 0;
+		top: 0;
+	}
 }
 
 .facebook-share-preview__profile-picture,
 .facebook-share-preview__image {
 	display: block;
+}
+
+.facebook-share-preview__profile-picture {
+	border-radius: 50%;
 }
 
 .facebook-share-preview__profile-line,

--- a/client/components/share/facebook-share-preview/style.scss
+++ b/client/components/share/facebook-share-preview/style.scss
@@ -104,8 +104,4 @@
 
 .facebook-share-preview__card-wrapper {
 	margin-top: 10px;
-
-	.facebook-preview__website {
-		overflow: hidden;
-	}
 }

--- a/client/components/share/facebook-share-preview/style.scss
+++ b/client/components/share/facebook-share-preview/style.scss
@@ -12,7 +12,8 @@
 	-webkit-overflow-scrolling: touch;
 }
 
-.facebook-share-preview a {
+.facebook-share-preview a,
+.facebook-share-preview__application-link {
 	color: #365899;
 	text-decoration: none;
 }

--- a/client/components/share/facebook-share-preview/style.scss
+++ b/client/components/share/facebook-share-preview/style.scss
@@ -101,3 +101,11 @@
 		top: 0;
 	}
 }
+
+.facebook-share-preview__card-wrapper {
+	margin-top: 10px;
+
+	.facebook-preview__website {
+		overflow: hidden;
+	}
+}


### PR DESCRIPTION
Fix #23656

Make Sharing's Facebook preview look as similar as possible to the current Facebook post.

## Changes

- Previews of posts _with_ images now consist of:
`[ content summary | permalink | featured image ]`

<img width="300" alt="screen-shot-2018-04-25-at-16-14-13" src="https://user-images.githubusercontent.com/2070010/39302662-4e408d2e-494b-11e8-954f-225e0190e280.png">

- Previews of post _without_ images now consist of:
`[ content summary | permalink | card using the site icon ]`

<img width="300" alt="screen-shot-2018-04-25-at-16-14-07" src="https://user-images.githubusercontent.com/2070010/39302682-5de05c78-494b-11e8-9af7-03d200e2b012.png">

- Add a border to the profile picture.
Code looks a bit weird (compared to a simple `border: 1px solid gray`), but it's how FB does it to have a semitransparent border on top of the image.

- Guard the profile picture against broken Graph API (last time it happened while I was working on this!).

- Adjust text colors and weights.

- Add a border to the preview image as well. (Same approach as the profile picture)

- Add a period after "published an article on WordPress".

- Added the "Just now" relative time string, so that the "WordPress" app name is not weirdly alone in the second meta line.

- Fix some graphic glitches of the Facebook card preview (`FacebookPreview` component), and adjust it to look as much as possible like the real thing.

## Screenshots

| Before | Facebook | After |
| --- | --- | --- |
| <img width="528" alt="screen shot 2018-04-20 at 11 13 15" src="https://user-images.githubusercontent.com/2070010/39046850-920bb62a-448f-11e8-9c86-fe3a2866ac59.png"> | <img width="530" alt="screen shot 2018-04-20 at 11 13 22" src="https://user-images.githubusercontent.com/2070010/39046856-981ae48c-448f-11e8-90b6-0618272f249f.png"> | <img width="527" alt="screen shot 2018-04-20 at 11 49 25" src="https://user-images.githubusercontent.com/2070010/39047209-f2b8d60a-4490-11e8-9bb1-c9f3bd034e5b.png"> |
| <img width="529" alt="screen shot 2018-04-26 at 12 16 35" src="https://user-images.githubusercontent.com/2070010/39302855-f2b53382-494b-11e8-8720-895e1f5fbc46.png"> | <img width="531" alt="screen shot 2018-04-26 at 12 18 00" src="https://user-images.githubusercontent.com/2070010/39302864-f67c33ee-494b-11e8-945c-be2ce025d29d.png"> | <img width="487" alt="screen shot 2018-04-26 at 12 31 11" src="https://user-images.githubusercontent.com/2070010/39303494-4ac98c42-494e-11e8-9fdf-be58a7d02196.png"> |


## Testing instructions

- Use a test site that has a Premium or Business plan and Facebook connection enabled.
- Navigate to `https://wordpress.com/posts/{site}`.
- Test for both posts with and without images.
- For an individual post, click on the more options drop-down menu and select `Share`.
- Click on `Preview` and capture a screenshot of the generated preview.
- Click on `Share post` and compare the actual results of the Facebook card with the generated Preview.

Regression checks:

- Try the Facebook (card) preview for site (`/settings/traffic/{site}`) and post editor (`/post/{site}`).
- Check if they are broken, and if they're still consistent with the Facebook real things.
