### PR TITLE
State: Introduce connected applications data layer

### DIFF
--- a/client/state/data-layer/wpcom/me/connected-applications/delete/index.js
+++ b/client/state/data-layer/wpcom/me/connected-applications/delete/index.js
@@ -1,0 +1,69 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { CONNECTED_APPLICATION_DELETE } from 'state/action-types';
+import { deleteConnectedApplicationSuccess } from 'state/connected-applications/actions';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { errorNotice, successNotice } from 'state/notices/actions';
+import { http } from 'state/data-layer/wpcom-http/actions';
+
+/**
+ * Dispatches a request to delete a connected application for the current user
+ *
+ * @param   {Object} action Redux action
+ * @returns {Object} Dispatched http action
+ */
+export const removeConnectedApplication = action =>
+	http(
+		{
+			apiVersion: '1.1',
+			method: 'POST',
+			path: '/me/connected-applications/' + action.appId + '/delete',
+		},
+		action
+	);
+
+/**
+ * Dispatches a user connected application removal success action when the request succeeded.
+ *
+ * @param   {Object} action Redux action
+ * @returns {Object} Dispatched user connected applications add action
+ */
+export const handleRemoveSuccess = ( { appId } ) => [
+	deleteConnectedApplicationSuccess( appId ),
+	successNotice(
+		translate( 'This application no longer has access to your WordPress.com account.' ),
+		{
+			duration: 8000,
+			id: `connected-app-notice-success-${ appId }`,
+		}
+	),
+];
+
+/**
+ * Dispatches an error notice when the request failed.
+ *
+ * @returns {Object} Dispatched error notice action
+ */
+export const handleRemoveError = () =>
+	errorNotice( translate( 'The connected application was not disconnected. Please try again.' ), {
+		duration: 8000,
+		id: 'connected-app-notice-error',
+	} );
+
+export default {
+	[ CONNECTED_APPLICATION_DELETE ]: [
+		dispatchRequestEx( {
+			fetch: removeConnectedApplication,
+			onSuccess: handleRemoveSuccess,
+			onError: handleRemoveError,
+		} ),
+	],
+};

--- a/client/state/data-layer/wpcom/me/connected-applications/delete/index.js
+++ b/client/state/data-layer/wpcom/me/connected-applications/delete/index.js
@@ -31,7 +31,7 @@ export const removeConnectedApplication = action =>
 	);
 
 /**
- * Dispatches a user connected application removal success action when the request succeeded.
+ * Dispatches a user connected application removal success action and notice when the request succeeded.
  *
  * @param   {Object} action Redux action
  * @returns {Object} Dispatched user connected applications add action

--- a/client/state/data-layer/wpcom/me/connected-applications/delete/test/index.js
+++ b/client/state/data-layer/wpcom/me/connected-applications/delete/test/index.js
@@ -3,6 +3,7 @@
 /**
  * Internal dependencies
  */
+import { errorNotice, successNotice } from 'state/notices/actions';
 import { handleRemoveError, handleRemoveSuccess, removeConnectedApplication } from '../';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
@@ -36,14 +37,12 @@ describe( 'handleRemoveSuccess()', () => {
 
 		expect( actions ).toHaveLength( 2 );
 		expect( actions[ 0 ] ).toEqual( deleteConnectedApplicationSuccess( appId ) );
-		expect( actions[ 1 ] ).toMatchObject( {
-			notice: expect.objectContaining( {
+		expect( actions[ 1 ] ).toMatchObject(
+			successNotice( 'This application no longer has access to your WordPress.com account.', {
 				duration: 8000,
-				noticeId: `connected-app-notice-success-${ appId }`,
-				status: 'is-success',
-				text: 'This application no longer has access to your WordPress.com account.',
-			} ),
-		} );
+				id: `connected-app-notice-success-${ appId }`,
+			} )
+		);
 	} );
 } );
 
@@ -51,13 +50,11 @@ describe( 'handleRemoveError()', () => {
 	test( 'should return a connected application remove failure action', () => {
 		const action = handleRemoveError();
 
-		expect( action ).toMatchObject( {
-			notice: expect.objectContaining( {
+		expect( action ).toMatchObject(
+			errorNotice( 'The connected application was not disconnected. Please try again.', {
 				duration: 8000,
-				noticeId: 'connected-app-notice-error',
-				status: 'is-error',
-				text: 'The connected application was not disconnected. Please try again.',
-			} ),
-		} );
+				id: 'connected-app-notice-error',
+			} )
+		);
 	} );
 } );

--- a/client/state/data-layer/wpcom/me/connected-applications/delete/test/index.js
+++ b/client/state/data-layer/wpcom/me/connected-applications/delete/test/index.js
@@ -1,0 +1,63 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { handleRemoveError, handleRemoveSuccess, removeConnectedApplication } from '../';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import {
+	deleteConnectedApplication,
+	deleteConnectedApplicationSuccess,
+} from 'state/connected-applications/actions';
+
+const appId = '12345678';
+
+describe( 'removeConnectedApplication()', () => {
+	test( 'should return an action for HTTP request to remove a connected application', () => {
+		const action = deleteConnectedApplication( appId );
+		const result = removeConnectedApplication( action );
+
+		expect( result ).toEqual(
+			http(
+				{
+					apiVersion: '1.1',
+					method: 'POST',
+					path: '/me/connected-applications/' + appId + '/delete',
+				},
+				action
+			)
+		);
+	} );
+} );
+
+describe( 'handleRemoveSuccess()', () => {
+	test( 'should return a connected application remove success action and a success notice action', () => {
+		const actions = handleRemoveSuccess( { appId } );
+
+		expect( actions ).toHaveLength( 2 );
+		expect( actions[ 0 ] ).toEqual( deleteConnectedApplicationSuccess( appId ) ),
+			expect( actions[ 1 ] ).toMatchObject( {
+				notice: expect.objectContaining( {
+					duration: 8000,
+					noticeId: `connected-app-notice-success-${ appId }`,
+					status: 'is-success',
+					text: 'This application no longer has access to your WordPress.com account.',
+				} ),
+			} );
+	} );
+} );
+
+describe( 'handleRemoveError()', () => {
+	test( 'should return a connected application remove failure action', () => {
+		const action = handleRemoveError();
+
+		expect( action ).toMatchObject( {
+			notice: expect.objectContaining( {
+				duration: 8000,
+				noticeId: 'connected-app-notice-error',
+				status: 'is-error',
+				text: 'The connected application was not disconnected. Please try again.',
+			} ),
+		} );
+	} );
+} );

--- a/client/state/data-layer/wpcom/me/connected-applications/delete/test/index.js
+++ b/client/state/data-layer/wpcom/me/connected-applications/delete/test/index.js
@@ -35,15 +35,15 @@ describe( 'handleRemoveSuccess()', () => {
 		const actions = handleRemoveSuccess( { appId } );
 
 		expect( actions ).toHaveLength( 2 );
-		expect( actions[ 0 ] ).toEqual( deleteConnectedApplicationSuccess( appId ) ),
-			expect( actions[ 1 ] ).toMatchObject( {
-				notice: expect.objectContaining( {
-					duration: 8000,
-					noticeId: `connected-app-notice-success-${ appId }`,
-					status: 'is-success',
-					text: 'This application no longer has access to your WordPress.com account.',
-				} ),
-			} );
+		expect( actions[ 0 ] ).toEqual( deleteConnectedApplicationSuccess( appId ) );
+		expect( actions[ 1 ] ).toMatchObject( {
+			notice: expect.objectContaining( {
+				duration: 8000,
+				noticeId: `connected-app-notice-success-${ appId }`,
+				status: 'is-success',
+				text: 'This application no longer has access to your WordPress.com account.',
+			} ),
+		} );
 	} );
 } );
 

--- a/client/state/data-layer/wpcom/me/connected-applications/index.js
+++ b/client/state/data-layer/wpcom/me/connected-applications/index.js
@@ -1,0 +1,57 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import deleteHandler from './delete';
+import schema from './schema';
+import { CONNECTED_APPLICATIONS_REQUEST } from 'state/action-types';
+import { dispatchRequestEx, makeParser } from 'state/data-layer/wpcom-http/utils';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { mergeHandlers } from 'state/action-watchers/utils';
+import { receiveConnectedApplications } from 'state/connected-applications/actions';
+
+export const apiTransformer = data => data.connected_applications;
+
+/**
+ * Dispatches a request to fetch connected applications of the current user
+ *
+ * @param   {Object} action Redux action
+ * @returns {Object} Dispatched http action
+ */
+export const requestConnectedApplications = action =>
+	http(
+		{
+			apiVersion: '1.1',
+			method: 'GET',
+			path: '/me/connected-applications',
+		},
+		action
+	);
+
+/**
+ * Dispatches a user connected applications receive action when the request succeeded.
+ *
+ * @param   {Object} action Redux action
+ * @param   {Object} apps   Connected applications
+ * @returns {Object} Dispatched user connected applications receive action
+ */
+export const handleRequestSuccess = ( action, apps ) => receiveConnectedApplications( apps );
+
+const requestHandler = {
+	[ CONNECTED_APPLICATIONS_REQUEST ]: [
+		dispatchRequestEx( {
+			fetch: requestConnectedApplications,
+			onSuccess: handleRequestSuccess,
+			onError: noop,
+			fromApi: makeParser( schema, {}, apiTransformer ),
+		} ),
+	],
+};
+
+export default mergeHandlers( requestHandler, deleteHandler );

--- a/client/state/data-layer/wpcom/me/connected-applications/index.js
+++ b/client/state/data-layer/wpcom/me/connected-applications/index.js
@@ -9,9 +9,10 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import deleteHandler from './delete';
+import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import schema from './schema';
 import { CONNECTED_APPLICATIONS_REQUEST } from 'state/action-types';
-import { dispatchRequestEx, makeParser } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { mergeHandlers } from 'state/action-watchers/utils';
 import { receiveConnectedApplications } from 'state/connected-applications/actions';
@@ -49,7 +50,7 @@ const requestHandler = {
 			fetch: requestConnectedApplications,
 			onSuccess: handleRequestSuccess,
 			onError: noop,
-			fromApi: makeParser( schema, {}, apiTransformer ),
+			fromApi: makeJsonSchemaParser( schema, apiTransformer, {} ),
 		} ),
 	],
 };

--- a/client/state/data-layer/wpcom/me/connected-applications/schema.js
+++ b/client/state/data-layer/wpcom/me/connected-applications/schema.js
@@ -1,0 +1,51 @@
+export default {
+	type: 'object',
+	properties: {
+		connected_applications: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					ID: { type: 'string' },
+					URL: { type: 'string' },
+					authorized: { type: 'string' },
+					description: { type: 'string' },
+					icon: { type: 'string' },
+					permissions: {
+						type: 'array',
+						items: {
+							type: 'object',
+							properties: {
+								description: { type: 'string' },
+								name: { type: 'string' },
+							},
+							required: [ 'description', 'name' ],
+							additionalProperties: false,
+						},
+					},
+					scope: { type: 'string' },
+					site: {
+						oneOf: [
+							{
+								type: 'boolean',
+							},
+							{
+								type: 'object',
+								properties: {
+									site_ID: { type: 'string' },
+									site_URL: { type: 'string' },
+									site_name: { type: 'string' },
+								},
+								required: [ 'site_ID', 'site_URL', 'site_name' ],
+								additionalProperties: false,
+							} ],
+					},
+					title: { type: 'string' },
+				},
+				required: [ 'ID' ],
+				additionalProperties: false,
+			},
+		},
+	},
+	additionalProperties: false,
+};

--- a/client/state/data-layer/wpcom/me/connected-applications/test/index.js
+++ b/client/state/data-layer/wpcom/me/connected-applications/test/index.js
@@ -1,0 +1,63 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { apiTransformer, handleRequestSuccess, requestConnectedApplications } from '../';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { receiveConnectedApplications } from 'state/connected-applications/actions';
+
+const apps = [
+	{
+		ID: '12345678',
+		URL: 'http://wordpress.com',
+		authorized: '2018-01-01T00:00:00+00:00',
+		description: 'Example description of the application here',
+		icon: 'https://wordpress.com/calypso/images/wordpress/logo-stars.svg',
+		permissions: [
+			{
+				name: 'follow',
+				description: 'Follow and unfollow blogs.',
+			},
+			{
+				name: 'posts',
+				description: 'View and manage posts including reblogs and likes.',
+			},
+		],
+		scope: 'global',
+		site: {
+			site_ID: '87654321',
+			site_URL: 'http://wordpress.com',
+			site_name: 'WordPress',
+		},
+		title: 'WordPress',
+	},
+];
+
+describe( 'requestConnectedApplications()', () => {
+	test( 'should return an action for HTTP request to request the connected applications', () => {
+		const action = requestConnectedApplications();
+
+		expect( action ).toEqual(
+			http( {
+				apiVersion: '1.1',
+				method: 'GET',
+				path: '/me/connected-applications',
+			} )
+		);
+	} );
+} );
+
+describe( 'handleRequestSuccess()', () => {
+	test( 'should return a connected applications receive action', () => {
+		const action = handleRequestSuccess( null, apps );
+
+		expect( action ).toEqual( receiveConnectedApplications( apps ) );
+	} );
+} );
+
+describe( 'apiTransformer()', () => {
+	test( 'should transform original response for a successful request', () => {
+		expect( apiTransformer( { connected_applications: apps } ) ).toEqual( apps );
+	} );
+} );

--- a/client/state/data-layer/wpcom/me/index.js
+++ b/client/state/data-layer/wpcom/me/index.js
@@ -8,6 +8,7 @@
 
 import { mergeHandlers } from 'state/action-watchers/utils';
 import block from './block';
+import connectedApplications from './connected-applications';
 import devices from './devices';
 import notification from './notification';
 import settings from './settings';
@@ -18,6 +19,7 @@ import twoStep from './two-step';
 
 export default mergeHandlers(
 	block,
+	connectedApplications,
 	countries,
 	devices,
 	notification,


### PR DESCRIPTION
This PR introduces data layer for connected applications, which covers the following requests:

* Fetching user's connected applications
* Deleting an existing connected application

Tests are included.

For context of how these data layer handlers would be used, you can see the full connected applications reduxification PR: #24175.

To test:
* Checkout this branch.
* Run this in your browser console: `dispatch( { type: 'CONNECTED_APPLICATIONS_REQUEST' } )`
* Verify a `CONNECTED_APPLICATIONS_REQUEST` action is dispatched.
* Verify an HTTP request to fetch the user's connected applications is initiated.
* Verify that a `CONNECTED_APPLICATIONS_RECEIVE` action is dispatched upon successful request, and that action contains all connected applications of the current user.
* Verify there are no schema validation errors.
* Go offline (there is an "Offline" checkbox in the "Network" tab of Chrome dev tools).
* Run this again in your browser console: `dispatch( { type: 'CONNECTED_APPLICATIONS_REQUEST' } )`
* Verify nothing happens after request fails and retries several times.
* From the `CONNECTED_APPLICATIONS_RECEIVE` action, pick the ID of a connected application that you're willing to disconnect.
* Run `dispatch( { type: 'CONNECTED_APPLICATION_DELETE', appId: '12345678' } )` in your console, where `12345678` is the ID of the connected application.
* Verify that upon successful deletion you see the `This application no longer has access to your WordPress.com account. ` success notice.
* Go offline, or use the ID of an unexisting connected application for the next step.
* Run `dispatch( { type: 'CONNECTED_APPLICATION_DELETE', appId: '12345678' } )` in your console, where `12345678` is the ID of the connected application.
* Verify you can see the `The connected application was not disconnected. Please try again.` error notice.
* Verify all tests pass:

```
npm run test-client client/state/data-layer/wpcom/me/connected-applications
```
