### PR TITLE
Jetpack Connect: Prevent form submission when URL is empty

### DIFF
--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -51,7 +51,7 @@ class JetpackConnectSiteUrlInput extends PureComponent {
 	}
 
 	handleKeyPress = event => {
-		if ( 13 === event.keyCode ) {
+		if ( 13 === event.keyCode && ! this.isFormSubmitDisabled() ) {
 			this.props.onSubmit();
 		}
 	};

--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -75,6 +75,13 @@ class JetpackConnectSiteUrlInput extends PureComponent {
 		return 'https://' + getLocaleSlug() + '.wordpress.com/tos/';
 	}
 
+	isFormSubmitDisabled() {
+		const { isError, isFetching, url } = this.props;
+		const hasError = isError && 'notExists' !== isError;
+
+		return ! url || isFetching || hasError;
+	}
+
 	renderTermsOfServiceLink() {
 		return (
 			<p className="jetpack-connect__tos-link">
@@ -109,8 +116,7 @@ class JetpackConnectSiteUrlInput extends PureComponent {
 	}
 
 	render() {
-		const { isError, isFetching, onChange, onSubmit, translate, url, autoFocus } = this.props;
-		const hasError = isError && 'notExists' !== isError;
+		const { isFetching, onChange, onSubmit, translate, url, autoFocus } = this.props;
 
 		return (
 			<div>
@@ -135,7 +141,7 @@ class JetpackConnectSiteUrlInput extends PureComponent {
 					<Button
 						className="jetpack-connect__connect-button"
 						primary
-						disabled={ ! url || isFetching || hasError }
+						disabled={ this.isFormSubmitDisabled() }
 						onClick={ onSubmit }
 					>
 						{ this.renderButtonLabel() }


### PR DESCRIPTION
Currently, when URL is empty on `/jetpack/connect/`, the button is disabled. This prevents from submitting an empty URL, however... if one focuses the field and presses the "Enter/Return" button, we call `onSubmit` with an empty URL, and this reaches the corresponding action, resulting in an error 😱 : 

![](https://cldup.com/Wk2pI1H9Ji.png)

This PR resolves this issue by:
* Moving the "form is disabled" logic to a method for reusability.
* Using that new method in the `handleKeyPress` handler to prevent unwanted submission.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/jetpack/connect
* Make sure field is focused and with empty URL press "Enter/Return".
* Verify nothing happens.
* Try submitting some URL and verify it still works properly like it did before.