### PR TITLE
Revert "Post Edit Store: move metadata update logic from action creators to the store"

### DIFF
--- a/client/lib/posts/post-edit-store.js
+++ b/client/lib/posts/post-edit-store.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { assign, filter, find, get, isEqual, pickBy } from 'lodash';
+import { assign, filter, get, isEqual, pickBy } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:posts:post-edit-store' );
 import emitter from 'lib/mixins/emitter';
@@ -122,14 +122,9 @@ function setLoadingError( error ) {
 	_isLoading = false;
 }
 
-function mergeMetadataEdits( metadata, edits ) {
-	// remove existing metadata that get updated in `edits`
-	const newMetadata = filter( metadata, meta => ! find( edits, { key: meta.key } ) );
-	// append the new edits at the end
-	return newMetadata.concat( edits );
-}
-
 function set( attributes ) {
+	var updatedPost;
+
 	if ( ! _post ) {
 		// ignore since post isn't currently being edited
 		return false;
@@ -139,15 +134,7 @@ function set( attributes ) {
 		_queue.push( attributes );
 	}
 
-	let updatedPost = {
-		..._post,
-		...attributes,
-	};
-
-	// merge metadata with a custom function
-	if ( attributes.metadata ) {
-		updatedPost.metadata = mergeMetadataEdits( _post.metadata, attributes.metadata );
-	}
+	updatedPost = assign( {}, _post, attributes );
 
 	updatedPost = normalize( updatedPost );
 

--- a/client/lib/posts/test/actions.js
+++ b/client/lib/posts/test/actions.js
@@ -81,17 +81,87 @@ describe( 'actions', () => {
 				} )
 			).to.be.true;
 		} );
+
+		test( 'should include metadata already existing on the post object', () => {
+			PostEditStore.get.restore();
+			sandbox.stub( PostEditStore, 'get' ).returns( {
+				metadata: [ { key: 'other', value: '1234' } ],
+			} );
+
+			PostActions.updateMetadata( 'foo', 'bar' );
+
+			expect(
+				Dispatcher.handleViewAction.calledWithMatch( {
+					type: 'EDIT_POST',
+					post: {
+						metadata: [
+							{ key: 'other', value: '1234' },
+							{ key: 'foo', value: 'bar', operation: 'update' },
+						],
+					},
+				} )
+			).to.be.true;
+		} );
+
+		test( 'should include metadata edits made previously', () => {
+			PostEditStore.get.restore();
+			sandbox.stub( PostEditStore, 'get' ).returns( {
+				metadata: [ { key: 'other', operation: 'delete' } ],
+			} );
+
+			PostActions.updateMetadata( 'foo', 'bar' );
+
+			expect(
+				Dispatcher.handleViewAction.calledWithMatch( {
+					type: 'EDIT_POST',
+					post: {
+						metadata: [
+							{ key: 'other', operation: 'delete' },
+							{ key: 'foo', value: 'bar', operation: 'update' },
+						],
+					},
+				} )
+			).to.be.true;
+		} );
+
+		test( 'should not duplicate existing metadata edits', () => {
+			PostEditStore.get.restore();
+			sandbox.stub( PostEditStore, 'get' ).returns( {
+				metadata: [
+					{ key: 'bar', value: 'foo' },
+					{ key: 'foo', value: 'baz', operation: 'delete' },
+				],
+			} );
+
+			PostActions.updateMetadata( 'foo', 'bar' );
+
+			expect(
+				Dispatcher.handleViewAction.calledWithMatch( {
+					type: 'EDIT_POST',
+					post: {
+						metadata: [
+							{ key: 'bar', value: 'foo' },
+							{ key: 'foo', value: 'bar', operation: 'update' },
+						],
+					},
+				} )
+			).to.be.true;
+		} );
 	} );
 
 	describe( '#deleteMetadata()', () => {
 		test( 'should dispatch a post edit with a deleted metadata', () => {
+			PostEditStore.get.restore();
+			sandbox.stub( PostEditStore, 'get' ).returns( {
+				metadata: [ { key: 'bar', value: 'foo' } ],
+			} );
 			PostActions.deleteMetadata( 'foo' );
 
 			expect(
 				Dispatcher.handleViewAction.calledWithMatch( {
 					type: 'EDIT_POST',
 					post: {
-						metadata: [ { key: 'foo', operation: 'delete' } ],
+						metadata: [ { key: 'bar', value: 'foo' }, { key: 'foo', operation: 'delete' } ],
 					},
 				} )
 			).to.be.true;

--- a/client/lib/posts/test/post-edit-store.js
+++ b/client/lib/posts/test/post-edit-store.js
@@ -265,29 +265,26 @@ describe( 'post-edit-store', () => {
 		assert( PostEditStore.isDirty() );
 	} );
 
-	test( 'updates existing metadata on edit', () => {
-		// initial post
+	test( 'excludes metadata without an operation on edit', () => {
+		const postEdits = {
+				title: 'Super Duper',
+				metadata: [
+					{ key: 'super', value: 'duper', operation: 'update' },
+					{ key: 'foo', value: 'bar', operation: 'delete' },
+					{ key: 'bar', value: 'foo' },
+				],
+			},
+			expectedMetadata = [
+				{ key: 'super', value: 'duper', operation: 'update' },
+				{ key: 'foo', value: 'bar', operation: 'delete' },
+			];
+
 		dispatcherCallback( {
 			action: {
 				type: 'RECEIVE_POST_TO_EDIT',
-				post: {
-					metadata: [
-						{ key: 'keepable', value: 'constvalue' },
-						{ key: 'updatable', value: 'oldvalue' },
-						{ key: 'deletable', value: 'trashvalue' },
-					],
-				},
+				post: {},
 			},
 		} );
-
-		// apply some edits
-		const postEdits = {
-			title: 'Super Duper',
-			metadata: [
-				{ key: 'updatable', value: 'newvalue', operation: 'update' },
-				{ key: 'deletable', operation: 'delete' },
-			],
-		};
 
 		dispatcherCallback( {
 			action: {
@@ -296,113 +293,10 @@ describe( 'post-edit-store', () => {
 			},
 		} );
 
-		// check the expected values of post attributes after the edit is applied
+		assert( PostEditStore.get().metadata === postEdits.metadata );
 		assert( PostEditStore.get().title === postEdits.title );
-		assert(
-			isEqual( PostEditStore.get().metadata, [
-				{ key: 'keepable', value: 'constvalue' },
-				{ key: 'updatable', value: 'newvalue', operation: 'update' },
-				{ key: 'deletable', operation: 'delete' },
-			] )
-		);
-
-		// check the modifications sent to the API endpoint
 		assert( PostEditStore.getChangedAttributes().title === postEdits.title );
-		assert(
-			isEqual( PostEditStore.getChangedAttributes().metadata, [
-				{ key: 'updatable', value: 'newvalue', operation: 'update' },
-				{ key: 'deletable', operation: 'delete' },
-			] )
-		);
-	} );
-
-	test( 'should include metadata edits made previously', () => {
-		// initial post
-		dispatcherCallback( {
-			action: {
-				type: 'RECEIVE_POST_TO_EDIT',
-				post: {
-					metadata: [ { key: 'deletable', value: 'trashvalue' } ],
-				},
-			},
-		} );
-
-		// first edit
-		dispatcherCallback( {
-			action: {
-				type: 'EDIT_POST',
-				post: {
-					metadata: [ { key: 'deletable', operation: 'delete' } ],
-				},
-			},
-		} );
-
-		// second edit
-		dispatcherCallback( {
-			action: {
-				type: 'EDIT_POST',
-				post: {
-					metadata: [ { key: 'updatable', value: 'newvalue', operation: 'update' } ],
-				},
-			},
-		} );
-
-		assert(
-			isEqual( PostEditStore.get().metadata, [
-				{ key: 'deletable', operation: 'delete' },
-				{ key: 'updatable', value: 'newvalue', operation: 'update' },
-			] )
-		);
-	} );
-
-	test( 'should not duplicate existing metadata edits', () => {
-		// initial post
-		dispatcherCallback( {
-			action: {
-				type: 'RECEIVE_POST_TO_EDIT',
-				post: {
-					metadata: [
-						{ key: 'keepable', value: 'constvalue' },
-						{ key: 'phoenixable', value: 'fawkes' },
-					],
-				},
-			},
-		} );
-
-		// delete metadata prop
-		dispatcherCallback( {
-			action: {
-				type: 'EDIT_POST',
-				post: {
-					metadata: [ { key: 'phoenixable', operation: 'delete' } ],
-				},
-			},
-		} );
-
-		// recreate the prop
-		dispatcherCallback( {
-			action: {
-				type: 'EDIT_POST',
-				post: {
-					metadata: [ { key: 'phoenixable', value: 'newfawkes', operation: 'update' } ],
-				},
-			},
-		} );
-
-		// edited post metadata after edits
-		assert(
-			isEqual( PostEditStore.get().metadata, [
-				{ key: 'keepable', value: 'constvalue' },
-				{ key: 'phoenixable', value: 'newfawkes', operation: 'update' },
-			] )
-		);
-
-		// metadata update request sent to the API endpoint
-		assert(
-			isEqual( PostEditStore.getChangedAttributes().metadata, [
-				{ key: 'phoenixable', value: 'newfawkes', operation: 'update' },
-			] )
-		);
+		assert( isEqual( PostEditStore.getChangedAttributes().metadata, expectedMetadata ) );
 	} );
 
 	test( 'reset post after saving an edit', () => {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#24291