### PR TITLE
DevDocs: Add more information about State Selectors

### DIFF
--- a/client/devdocs/docs-selectors/index.jsx
+++ b/client/devdocs/docs-selectors/index.jsx
@@ -10,6 +10,8 @@ import React, { PureComponent } from 'react';
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
+import CardHeading from 'components/card-heading';
 import Main from 'components/main';
 import DocsSelectorsSingle from './single';
 import DocsSelectorsSearch from './search';
@@ -27,6 +29,22 @@ export default class DocsSelectors extends PureComponent {
 		return (
 			<Main className="devdocs docs-selectors">
 				<DocumentHead title="State Selectors" />
+				<Card>
+					<CardHeading>State Selectors</CardHeading>
+
+					<p>
+						A selector is simply a convenience function for retrieving data out of the global state
+						tree. This page contains all available state selectors, which can be used as a helper in
+						retrieving derived data from the global state tree.
+					</p>
+
+					<p>
+						To learn more about selectors, refer to the{' '}
+						<a href="https://github.com/Automattic/wp-calypso/blob/master/docs/our-approach-to-data.md#selectors">
+							Our Approach to Data" document
+						</a>.
+					</p>
+				</Card>
 				{ selector && <DocsSelectorsSingle { ...{ selector, search } } /> }
 				{ ! selector && <DocsSelectorsSearch search={ search } /> }
 			</Main>

--- a/client/devdocs/sidebar.jsx
+++ b/client/devdocs/sidebar.jsx
@@ -85,9 +85,9 @@ export default class DevdocsSidebar extends React.PureComponent {
 							selected={ this.isItemSelected( '/devdocs/docs/icons.md' ) }
 						/>
 					</ul>
-				</SidebarMenu>
-				<SidebarHeading>Live Docs</SidebarHeading>
-				<SidebarMenu>
+
+					<SidebarHeading>Live Docs</SidebarHeading>
+
 					<ul>
 						<SidebarItem
 							className="devdocs__navigation-item"
@@ -105,17 +105,21 @@ export default class DevdocsSidebar extends React.PureComponent {
 						/>
 						<SidebarItem
 							className="devdocs__navigation-item"
-							icon="plugins"
-							label="State Selectors"
-							link="/devdocs/selectors"
-							selected={ this.isItemSelected( '/devdocs/selectors', false ) }
-						/>
-						<SidebarItem
-							className="devdocs__navigation-item"
 							icon="code"
 							label="Playground"
 							link="/devdocs/playground"
 							selected={ this.isItemSelected( '/devdocs/playground', false ) }
+						/>
+					</ul>
+
+					<SidebarHeading>Developer Tools</SidebarHeading>
+					<ul>
+						<SidebarItem
+							className="devdocs__navigation-item"
+							icon="plugins"
+							label="State Selectors"
+							link="/devdocs/selectors"
+							selected={ this.isItemSelected( '/devdocs/selectors', false ) }
 						/>
 					</ul>
 				</SidebarMenu>


### PR DESCRIPTION
This PR addresses part of #24065 by adding more detail about State Selectors. Ideally we should use the ReadmeViewerComponent to just display the README for this.