### PR TITLE
Jetpack Connect: Optimistic plans page rendering - a hacky experiment

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -56,6 +56,7 @@ import {
 	isCalypsoStartedConnection,
 	isSsoApproved,
 	retrieveMobileRedirect,
+	retrievePlan,
 } from './persistence-utils';
 import {
 	authorize as authorizeAction,
@@ -553,6 +554,11 @@ export class JetpackAuthorize extends Component {
 		);
 	}
 
+	onPlanSelect = () => {
+		// Hack: we're storing selected plan in a cookie, and this needs to force re-render.
+		this.forceUpdate();
+	};
+
 	renderFooterLinks() {
 		const { translate } = this.props;
 		const { authorizeSuccess, isAuthorizing } = this.props.authorizationData;
@@ -625,10 +631,16 @@ export class JetpackAuthorize extends Component {
 
 	render() {
 		const { authorizeSuccess } = this.props.authorizationData;
-		const { interval } = this.props;
+		const { interval, selectedPlan } = this.props;
 
-		if ( this.isAuthorizing() || authorizeSuccess ) {
-			return <PlansStatic interval={ interval } basePlansPath={ '/jetpack/connect/authorize' } />;
+		if ( ! selectedPlan && ( this.isAuthorizing() || authorizeSuccess ) ) {
+			return (
+				<PlansStatic
+					basePlansPath={ '/jetpack/connect/authorize' }
+					interval={ interval }
+					onPlanSelect={ this.onPlanSelect }
+				/>
+			);
 		}
 
 		return (
@@ -660,6 +672,7 @@ export default connect(
 		// so any change in value will not execute connect().
 		const mobileAppRedirect = retrieveMobileRedirect();
 		const isMobileAppFlow = !! mobileAppRedirect;
+		const selectedPlan = retrievePlan();
 
 		return {
 			authAttempts: getAuthAttempts( state, urlToSlug( authQuery.site ) ),
@@ -672,6 +685,7 @@ export default connect(
 			isFetchingSites: isRequestingSites( state ),
 			isMobileAppFlow,
 			mobileAppRedirect,
+			selectedPlan,
 			user: getCurrentUser( state ),
 			userAlreadyConnected: getUserAlreadyConnected( state ),
 		};

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -29,6 +29,7 @@ import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import MainWrapper from './main-wrapper';
+import PlansStatic from './plans-static';
 import QueryUserConnection from 'components/data/query-user-connection';
 import Spinner from 'components/spinner';
 import userUtilities from 'lib/user/utils';
@@ -623,6 +624,13 @@ export class JetpackAuthorize extends Component {
 	}
 
 	render() {
+		const { authorizeSuccess } = this.props.authorizationData;
+		const { interval } = this.props;
+
+		if ( this.isAuthorizing() || authorizeSuccess ) {
+			return <PlansStatic interval={ interval } basePlansPath={ '/jetpack/connect/authorize' } />;
+		}
+
 		return (
 			<MainWrapper>
 				<div className="jetpack-connect__authorize-form">

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -631,9 +631,9 @@ export class JetpackAuthorize extends Component {
 
 	render() {
 		const { authorizeSuccess } = this.props.authorizationData;
-		const { interval, selectedPlan } = this.props;
+		const { interval, isMobileAppFlow, selectedPlan } = this.props;
 
-		if ( ! selectedPlan && ( this.isAuthorizing() || authorizeSuccess ) ) {
+		if ( ! isMobileAppFlow && ! selectedPlan && ( this.isAuthorizing() || authorizeSuccess ) ) {
 			return (
 				<PlansStatic
 					basePlansPath={ '/jetpack/connect/authorize' }

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -243,7 +243,7 @@ export function authorizeForm( context, next ) {
 
 	const { query } = context;
 	const transformedQuery = parseAuthorizationQuery( query );
-	const interval = context.params.localeOrInterval;
+	const interval = context.params.localeOrInterval || context.params.interval || 'yearly';
 
 	if ( transformedQuery ) {
 		context.store.dispatch( startAuthorizeStep( transformedQuery.clientId ) );

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -204,12 +204,26 @@ export function signupForm( context, next ) {
 
 	const { query } = context;
 	const transformedQuery = parseAuthorizationQuery( query );
+
 	if ( transformedQuery ) {
 		context.store.dispatch( startAuthorizeStep( transformedQuery.clientId ) );
 
-		const { locale } = context.params;
+		let interval = context.params.interval;
+		let locale = context.params.locale;
+		if ( context.params.localeOrInterval ) {
+			if ( [ 'monthly', 'yearly' ].indexOf( context.params.localeOrInterval ) >= 0 ) {
+				interval = context.params.localeOrInterval;
+			} else {
+				locale = context.params.localeOrInterval;
+			}
+		}
 		context.primary = (
-			<JetpackSignup path={ context.path } locale={ locale } authQuery={ transformedQuery } />
+			<JetpackSignup
+				path={ context.path }
+				interval={ interval }
+				locale={ locale }
+				authQuery={ transformedQuery }
+			/>
 		);
 	} else {
 		context.primary = <NoDirectAccessError />;
@@ -229,6 +243,8 @@ export function authorizeForm( context, next ) {
 
 	const { query } = context;
 	const transformedQuery = parseAuthorizationQuery( query );
+	const interval = context.params.localeOrInterval;
+
 	if ( transformedQuery ) {
 		context.store.dispatch( startAuthorizeStep( transformedQuery.clientId ) );
 		context.primary = <JetpackAuthorize authQuery={ transformedQuery } interval={ interval } />;

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -172,6 +172,7 @@ export function connect( context, next ) {
 		url: query.url,
 		ctaId: query.cta_id, // origin tracking params
 		ctaFrom: query.cta_from,
+		interval,
 	} );
 	next();
 }
@@ -230,7 +231,7 @@ export function authorizeForm( context, next ) {
 	const transformedQuery = parseAuthorizationQuery( query );
 	if ( transformedQuery ) {
 		context.store.dispatch( startAuthorizeStep( transformedQuery.clientId ) );
-		context.primary = <JetpackAuthorize authQuery={ transformedQuery } />;
+		context.primary = <JetpackAuthorize authQuery={ transformedQuery } interval={ interval } />;
 	} else {
 		context.primary = <NoDirectAccessError />;
 	}

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -58,7 +58,16 @@ export default function() {
 
 	if ( isLoggedOut ) {
 		page(
-			'/jetpack/connect/authorize/:locale?',
+			'/jetpack/connect/authorize/:localeOrInterval?',
+			controller.maybeOnboard,
+			controller.setMasterbar,
+			controller.signupForm,
+			makeLayout,
+			clientRender
+		);
+
+		page(
+			'/jetpack/connect/authorize/:interval/:locale',
 			controller.maybeOnboard,
 			controller.setMasterbar,
 			controller.signupForm,
@@ -67,7 +76,17 @@ export default function() {
 		);
 	} else {
 		page(
-			'/jetpack/connect/authorize/:locale?',
+			'/jetpack/connect/authorize/:localeOrInterval?',
+			controller.maybeOnboard,
+			controller.redirectWithoutLocaleIfLoggedIn,
+			controller.setMasterbar,
+			controller.authorizeForm,
+			makeLayout,
+			clientRender
+		);
+
+		page(
+			'/jetpack/connect/authorize/:interval/:locale',
 			controller.maybeOnboard,
 			controller.redirectWithoutLocaleIfLoggedIn,
 			controller.setMasterbar,

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -22,6 +22,7 @@ import LoggedOutFormLinks from 'components/logged-out-form/links';
 import MainHeader from './main-header';
 import MainWrapper from './main-wrapper';
 import page from 'page';
+import PlansStatic from './plans-static';
 import SiteUrlInput from './site-url-input';
 import versionCompare from 'lib/version-compare';
 import { addCalypsoEnvQueryArg, cleanUrl } from './utils';
@@ -353,8 +354,13 @@ export class JetpackConnectMain extends Component {
 	}
 
 	render() {
+		const { interval } = this.props;
 		const status = this.getStatus();
 		const { type } = this.props;
+
+		if ( this.isCurrentUrlFetching() || this.state.redirecting || this.state.waitingForSites ) {
+			return <PlansStatic interval={ interval } basePlansPath={ '/jetpack/connect' } />;
+		}
 
 		return (
 			<MainWrapper>

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -32,7 +32,7 @@ import { FLOW_TYPES } from 'state/jetpack-connect/constants';
 import { getConnectingSite, getJetpackSiteByUrl } from 'state/jetpack-connect/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { isRequestingSites } from 'state/sites/selectors';
-import { persistSession, retrieveMobileRedirect } from './persistence-utils';
+import { persistSession, retrieveMobileRedirect, retrievePlan } from './persistence-utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { urlToSlug } from 'lib/url';
 import {
@@ -303,6 +303,11 @@ export class JetpackConnectMain extends Component {
 		return includes( FLOW_TYPES, this.props.type );
 	}
 
+	onPlanSelect = () => {
+		// Hack: we're storing selected plan in a cookie, and this needs to force re-render.
+		this.forceUpdate();
+	};
+
 	renderFooter() {
 		const { translate } = this.props;
 		return (
@@ -354,12 +359,20 @@ export class JetpackConnectMain extends Component {
 	}
 
 	render() {
-		const { interval } = this.props;
+		const { interval, selectedPlan, type } = this.props;
 		const status = this.getStatus();
-		const { type } = this.props;
 
-		if ( this.isCurrentUrlFetching() || this.state.redirecting || this.state.waitingForSites ) {
-			return <PlansStatic interval={ interval } basePlansPath={ '/jetpack/connect' } />;
+		if (
+			! selectedPlan &&
+			( this.isCurrentUrlFetching() || this.state.redirecting || this.state.waitingForSites )
+		) {
+			return (
+				<PlansStatic
+					interval={ interval }
+					basePlansPath={ '/jetpack/connect' }
+					onPlanSelect={ this.onPlanSelect }
+				/>
+			);
 		}
 
 		return (
@@ -382,6 +395,7 @@ const connectComponent = connect(
 		// so any change in value will not execute connect().
 		const mobileAppRedirect = retrieveMobileRedirect();
 		const isMobileAppFlow = !! mobileAppRedirect;
+		const selectedPlan = retrievePlan();
 
 		return {
 			// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
@@ -391,6 +405,7 @@ const connectComponent = connect(
 			isRequestingSites: isRequestingSites( state ),
 			jetpackConnectSite: getConnectingSite( state ),
 			mobileAppRedirect,
+			selectedPlan,
 		};
 	},
 	{

--- a/client/jetpack-connect/plans-static.js
+++ b/client/jetpack-connect/plans-static.js
@@ -13,7 +13,7 @@ import HelpButton from './help-button';
 import JetpackConnectHappychatButton from './happychat-button';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import PlansGrid from './plans-grid';
-import PlansSkipButton from './plans-skip-button';
+import PlansSkipButton from 'components/plans/plans-skip-button';
 import QueryPlans from 'components/data/query-plans';
 import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
 import { recordTracksEvent } from 'state/analytics/actions';

--- a/client/jetpack-connect/plans-static.js
+++ b/client/jetpack-connect/plans-static.js
@@ -1,0 +1,79 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import HelpButton from './help-button';
+import JetpackConnectHappychatButton from './happychat-button';
+import LoggedOutFormLinks from 'components/logged-out-form/links';
+import PlansGrid from './plans-grid';
+import PlansSkipButton from './plans-skip-button';
+import QueryPlans from 'components/data/query-plans';
+import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { storePlan } from './persistence-utils';
+
+class PlansStatic extends Component {
+	static propTypes = {
+		basePlansPath: PropTypes.string,
+		interval: PropTypes.string,
+	};
+
+	static defaultProps = {
+		basePlansPath: '/jetpack/connect/store',
+	};
+
+	storeSelectedPlan = cartItem => {
+		this.props.recordTracksEvent( 'calypso_jpc_plans_store_plan', {
+			plan: cartItem ? cartItem.product_slug : 'free',
+		} );
+
+		storePlan( cartItem ? cartItem.product_slug : PLAN_JETPACK_FREE );
+	};
+
+	handleSkipButtonClick = () => {
+		this.props.recordTracksEvent( 'calypso_jpc_plans_skip_button_click' );
+
+		this.storeSelectedPlan( null );
+	};
+
+	handleHelpButtonClick = () => {
+		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
+	};
+
+	render() {
+		const { basePlansPath, interval } = this.props;
+
+		return (
+			<Fragment>
+				<QueryPlans />
+
+				<PlansGrid
+					basePlansPath={ basePlansPath }
+					calypsoStartedConnection={ true }
+					hideFreePlan={ true }
+					interval={ interval }
+					isLanding={ true }
+					onSelect={ this.storeSelectedPlan }
+				>
+					<PlansSkipButton onClick={ this.handleSkipButtonClick } />
+					<LoggedOutFormLinks>
+						<JetpackConnectHappychatButton eventName="calypso_jpc_planslanding_chat_initiated">
+							<HelpButton onClick={ this.handleHelpButtonClick } />
+						</JetpackConnectHappychatButton>
+					</LoggedOutFormLinks>
+				</PlansGrid>
+			</Fragment>
+		);
+	}
+}
+
+export default connect( null, {
+	recordTracksEvent,
+} )( PlansStatic );

--- a/client/jetpack-connect/plans-static.js
+++ b/client/jetpack-connect/plans-static.js
@@ -5,6 +5,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,10 +24,12 @@ class PlansStatic extends Component {
 	static propTypes = {
 		basePlansPath: PropTypes.string,
 		interval: PropTypes.string,
+		onPlanSelect: PropTypes.func,
 	};
 
 	static defaultProps = {
 		basePlansPath: '/jetpack/connect/store',
+		onPlanSelect: noop,
 	};
 
 	storeSelectedPlan = cartItem => {
@@ -35,6 +38,10 @@ class PlansStatic extends Component {
 		} );
 
 		storePlan( cartItem ? cartItem.product_slug : PLAN_JETPACK_FREE );
+
+		setTimeout( () => {
+			this.props.onPlanSelect();
+		}, 100 );
 	};
 
 	handleSkipButtonClick = () => {


### PR DESCRIPTION
### Purpose

This PR is an initial and hacky experiment to implement optimistic plans page rendering in the Jetpack Connect flow. This means - trying to show the plans page as early as possible in the main component and the authorize component, allowing the user to early select a plan and land in the cart page right after connection has succeeded.

**Don't merge** - the PR is in progress, needs to be polished and many things need to be considered/tested first.

### How it works / testing

**Flow A - starting in WP-admin**
* Checkout this branch
* Create a new JN site.
* Copy the URL of the 'Set up Jetpack' button and add `&calypso_env=development` to it.
* Open that URL in your browser.
* When the authorization steps starts, you will see the plans page - pick a plan quickly.
* The auth should continue loading as usual.
* After finishing connection, you should be presented with the cart page with your plan in it.
* If you didn't manage to select a plan, you should see the plans page, allowing you to select a plan.

**Flow B - starting in WP.com**
* Checkout this branch
* Create a new JN site.
* Go to /jetpack/connect.
* Submit the URL of your JN site.
* You will see the plans screen - pick a plan (or not).
* When the authorization steps starts, if you haven't yet selected a plan, you will see the plans page. If you have selected a plan initially, you won't see the plans page.
* The auth should continue loading as usual.
* After finishing connection, you should be presented with the cart page with your plan in it.
* If you didn't manage to select a plan, you should see the plans page, allowing you to select a plan.

**Flow C - starting in WP.com - with a selected plan**
* Use the instructions from Flow B, but start by pre-selecting a plan (by visiting one of the dedicated routes like `/jetpack/connect/personal`).

### What doesn't work yet or needs love
* The monthly/yearly toggle doesn't work yet. 
  * When switching between monthly/yearly plans, the segmented control items (or the `constructPath()` method to be precise) don't preserve any query string when switching intervals - that needs to be fixed.
  * This PR re-adds the auth routes that support intervals (temporarily); but since we wanted to get away from those (they're already removed in the master branch), we might want to use an alternative mechanism (like cookies) to store the current interval.
* We're not showing any updates/notices/warnings/errors that happen during the main and auth steps. These need to be displayed somewhere.
* We might end up showing the plans screen multiple times if the user selects the Free plan (because we store this as `null`).
* We should audit the cases when we show (or not show) the plans page; currently the conditions are a bit "rough". Figuring the exact conditions out might need some extensive testing of all our different JPC flows and their variations.
* Showing the plans page is interrupted as we go through the flow redirections and steps - the user might see the WordPress logo loading screen in the process before the authorization step has loaded.
* We are using `forceUpdate` because of the current way we're storing the selected plan in a cookie and we need to trigger a fresh render - this is pretty hacky and we need to reconsider it. Since storing the cookie takes some technological time, this also needs a timeout before attempting to trigger a forced update 😕 
* We're introducing a new component - `PlansStatic` that is pretty similar to the rest of the `Plans` main components. Would be nice if those could be consolidated.