### PR TITLE
Set Display Names for React Components so that they can load in DevDocs

### DIFF
--- a/client/components/accordion/docs/example.jsx
+++ b/client/components/accordion/docs/example.jsx
@@ -18,6 +18,8 @@ Gridicon.displayName = 'Gridicon';
  */
 import Accordion from 'components/accordion';
 
+Accordion.displayName = 'Accordion';
+
 export default class extends React.Component {
 	static displayName = 'Accordion';
 

--- a/client/components/action-card/docs/example.jsx
+++ b/client/components/action-card/docs/example.jsx
@@ -11,6 +11,8 @@ import PropTypes from 'prop-types';
  */
 import ActionCard from '../index';
 
+ActionCard.displayName = 'ActionCard';
+
 function ActionCardExample( props ) {
 	return props.exampleCode;
 }


### PR DESCRIPTION
In production the DevDocs playground is minified, which mean the following happens

<img width="1134" alt="screen shot 2018-04-20 at 16 27 34" src="https://user-images.githubusercontent.com/275961/39059920-c37721f4-44b7-11e8-931d-ba474c7f6d3e.png">

This PR fixes that so that it looks like this:

<img width="1135" alt="screen shot 2018-04-20 at 16 26 12" src="https://user-images.githubusercontent.com/275961/39059934-d07f1fb4-44b7-11e8-8293-9db3ae5876b3.png">
