### PR TITLE
WIP: Activity Log: Introduce display of detected threats to site

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -25,6 +25,7 @@ import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import Pagination from 'components/pagination';
 import ProgressBanner from '../activity-log-banner/progress-banner';
+import RewindAlerts from './rewind-alerts';
 import QueryActivityLog from 'components/data/query-activity-log';
 import QueryRewindState from 'components/data/query-rewind-state';
 import QuerySiteSettings from 'components/data/query-site-settings'; // For site time offset
@@ -382,6 +383,7 @@ class ActivityLog extends Component {
 				<QuerySiteSettings siteId={ siteId } />
 				<SidebarNavigation />
 				<StatsNavigation selectedItem={ 'activity' } siteId={ siteId } slug={ slug } />
+				<RewindAlerts siteId={ siteId } />
 				{ siteId &&
 					'unavailable' === rewindState.state && <UnavailabilityNotice siteId={ siteId } /> }
 				{ 'awaitingCredentials' === rewindState.state && (

--- a/client/my-sites/stats/activity-log/rewind-alerts.jsx
+++ b/client/my-sites/stats/activity-log/rewind-alerts.jsx
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getRewindAlerts } from 'state/selectors';
+
+export class RewindAlerts extends Component {
+	render() {
+		const { alerts: { threats } } = this.props;
+
+		return <Fragment>{ threats.map( threat => <div>Threat!</div> ) }</Fragment>;
+	}
+}
+
+const mapStateToProps = ( state, { siteId } ) => ( {
+	alerts: getRewindAlerts( state, siteId ),
+} );
+
+export default connect( mapStateToProps )( RewindAlerts );

--- a/client/state/selectors/get-rewind-alerts.js
+++ b/client/state/selectors/get-rewind-alerts.js
@@ -1,0 +1,29 @@
+/** @format */
+
+/**
+ * @typedef {object} RewindSiteAlerts
+ * @property {Array} threats
+ */
+
+/** @type RewindSiteAlerts */
+const emptyState = {
+	threats: [],
+};
+
+/**
+ * Gets list of loaded site alerts from the
+ * Rewind system: plugin updates, threats, and suggestions
+ *
+ * @param {object} state Rewind state
+ * @param {number} siteId site for which to get alerts
+ * @return {RewindSiteAlerts} known alerts for site
+ */
+export const getRewindAlerts = ( state, siteId ) => {
+	try {
+		return state.rewindAlerts[ siteId ] || emptyState;
+	} catch ( e ) {
+		return emptyState;
+	}
+};
+
+export default getRewindAlerts;


### PR DESCRIPTION
The Jetpack Backups system performs active monitoring of a site to determine health issues. One of those monitored bits is security threats it detects and we want to show those in a list view to site owners and administrators.

See p9rlnk-fs-p2

This PR is currently establishing a baseline visual shell absent from actual API work and is in its early stages of progress.