### PR TITLE
 Post Edit Store: move metadata update logic from action creators to the store (try 2)

### DIFF
--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -5,7 +5,7 @@
  */
 
 import store from 'store';
-import { assign, clone, defer, fromPairs } from 'lodash';
+import { assign, clone, defer, fromPairs, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -37,40 +37,36 @@ var PostActions;
  *                                              or `delete`)
  */
 function handleMetadataOperation( key, value, operation ) {
-	var post = PostEditStore.get(),
-		metadata;
-
-	if ( 'string' === typeof key || Array.isArray( key ) ) {
-		// Normalize a string or array of string keys to an object of key value
-		// pairs. To accomodate both, we coerce the key into an array before
-		// mapping to pull the object pairs.
-		key = fromPairs( [].concat( key ).map( meta => [ meta, value ] ) );
+	// Normalize a string or array of string keys to an object of key value pairs.
+	if ( 'string' === typeof key ) {
+		// case of handleMetadataOperation( 'excerpt', 'text', 'update' )
+		key = { [ key ]: value };
+	} else if ( Array.isArray( key ) ) {
+		// case of handleMetadataOperation( [ 'geo_latitude', 'geo_longitude' ], null, 'delete' )
+		key = fromPairs( key.map( meta => [ meta, value ] ) );
 	}
 
-	// Overwrite duplicates based on key
-	metadata = ( post.metadata || [] ).filter( meta => ! key.hasOwnProperty( meta.key ) );
-
-	Object.keys( key ).forEach( function( objectKey ) {
+	const metadata = map( key, function( objectValue, objectKey ) {
 		// `update` is a sufficient operation for new metadata, as it will add
 		// the metadata if it does not already exist. Similarly, we're not
 		// concerned with deleting a key which was added during previous edits,
 		// since this will effectively noop.
-		var meta = {
+		const meta = {
 			key: objectKey,
-			operation: operation,
+			operation,
 		};
 
 		if ( 'delete' !== operation ) {
-			meta.value = key[ objectKey ];
+			meta.value = objectValue;
 		}
 
-		metadata.push( meta );
+		return meta;
 	} );
 
 	Dispatcher.handleViewAction( {
 		type: 'EDIT_POST',
 		post: {
-			metadata: metadata,
+			metadata,
 		},
 	} );
 }

--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -272,6 +272,8 @@ PostActions = {
 	saveEdited: function( site, attributes, context, callback, options ) {
 		var post, postHandle, query, changedAttributes, rawContent, mode, isNew;
 
+		// TODO: skip this edit if `attributes` are `null`. That means
+		// we don't want to do any additional edit before saving.
 		Dispatcher.handleViewAction( {
 			type: 'EDIT_POST',
 			post: attributes,

--- a/client/lib/posts/post-edit-store.js
+++ b/client/lib/posts/post-edit-store.js
@@ -145,7 +145,7 @@ function set( attributes ) {
 	};
 
 	// merge metadata with a custom function
-	if ( attributes.metadata ) {
+	if ( attributes && attributes.metadata ) {
 		updatedPost.metadata = mergeMetadataEdits( _post.metadata, attributes.metadata );
 	}
 

--- a/client/lib/posts/post-edit-store.js
+++ b/client/lib/posts/post-edit-store.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { assign, filter, get, isEqual, pickBy } from 'lodash';
+import { assign, filter, find, get, isEqual, pickBy } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:posts:post-edit-store' );
 import emitter from 'lib/mixins/emitter';
@@ -122,9 +122,14 @@ function setLoadingError( error ) {
 	_isLoading = false;
 }
 
-function set( attributes ) {
-	var updatedPost;
+function mergeMetadataEdits( metadata, edits ) {
+	// remove existing metadata that get updated in `edits`
+	const newMetadata = filter( metadata, meta => ! find( edits, { key: meta.key } ) );
+	// append the new edits at the end
+	return newMetadata.concat( edits );
+}
 
+function set( attributes ) {
 	if ( ! _post ) {
 		// ignore since post isn't currently being edited
 		return false;
@@ -134,7 +139,15 @@ function set( attributes ) {
 		_queue.push( attributes );
 	}
 
-	updatedPost = assign( {}, _post, attributes );
+	let updatedPost = {
+		..._post,
+		...attributes,
+	};
+
+	// merge metadata with a custom function
+	if ( attributes.metadata ) {
+		updatedPost.metadata = mergeMetadataEdits( _post.metadata, attributes.metadata );
+	}
 
 	updatedPost = normalize( updatedPost );
 

--- a/client/lib/posts/test/actions.js
+++ b/client/lib/posts/test/actions.js
@@ -81,87 +81,17 @@ describe( 'actions', () => {
 				} )
 			).to.be.true;
 		} );
-
-		test( 'should include metadata already existing on the post object', () => {
-			PostEditStore.get.restore();
-			sandbox.stub( PostEditStore, 'get' ).returns( {
-				metadata: [ { key: 'other', value: '1234' } ],
-			} );
-
-			PostActions.updateMetadata( 'foo', 'bar' );
-
-			expect(
-				Dispatcher.handleViewAction.calledWithMatch( {
-					type: 'EDIT_POST',
-					post: {
-						metadata: [
-							{ key: 'other', value: '1234' },
-							{ key: 'foo', value: 'bar', operation: 'update' },
-						],
-					},
-				} )
-			).to.be.true;
-		} );
-
-		test( 'should include metadata edits made previously', () => {
-			PostEditStore.get.restore();
-			sandbox.stub( PostEditStore, 'get' ).returns( {
-				metadata: [ { key: 'other', operation: 'delete' } ],
-			} );
-
-			PostActions.updateMetadata( 'foo', 'bar' );
-
-			expect(
-				Dispatcher.handleViewAction.calledWithMatch( {
-					type: 'EDIT_POST',
-					post: {
-						metadata: [
-							{ key: 'other', operation: 'delete' },
-							{ key: 'foo', value: 'bar', operation: 'update' },
-						],
-					},
-				} )
-			).to.be.true;
-		} );
-
-		test( 'should not duplicate existing metadata edits', () => {
-			PostEditStore.get.restore();
-			sandbox.stub( PostEditStore, 'get' ).returns( {
-				metadata: [
-					{ key: 'bar', value: 'foo' },
-					{ key: 'foo', value: 'baz', operation: 'delete' },
-				],
-			} );
-
-			PostActions.updateMetadata( 'foo', 'bar' );
-
-			expect(
-				Dispatcher.handleViewAction.calledWithMatch( {
-					type: 'EDIT_POST',
-					post: {
-						metadata: [
-							{ key: 'bar', value: 'foo' },
-							{ key: 'foo', value: 'bar', operation: 'update' },
-						],
-					},
-				} )
-			).to.be.true;
-		} );
 	} );
 
 	describe( '#deleteMetadata()', () => {
 		test( 'should dispatch a post edit with a deleted metadata', () => {
-			PostEditStore.get.restore();
-			sandbox.stub( PostEditStore, 'get' ).returns( {
-				metadata: [ { key: 'bar', value: 'foo' } ],
-			} );
 			PostActions.deleteMetadata( 'foo' );
 
 			expect(
 				Dispatcher.handleViewAction.calledWithMatch( {
 					type: 'EDIT_POST',
 					post: {
-						metadata: [ { key: 'bar', value: 'foo' }, { key: 'foo', operation: 'delete' } ],
+						metadata: [ { key: 'foo', operation: 'delete' } ],
 					},
 				} )
 			).to.be.true;


### PR DESCRIPTION
Second attempt to merge #24291, with an important fix.

It turns out that the previous version was throwing `TypeError`s when autosaving a new post. The `set` function is called with `attributes` arg set to `null`, because `PostActions.saveEdited` is called with a `null` arg that means "don't apply any additional edits right before saving".

**How to test:**
Requesting a full e2e run, test by creating a new post and entering some content. Wait until the first autosave and verify there are no errors in console.