### PR TITLE
[Domains] Add placeholders for featured domains

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -249,6 +249,7 @@ class DomainSearchResults extends React.Component {
 				);
 			}
 		} else {
+			featuredSuggestionElement = <FeaturedDomainSuggestions showPlaceholders />;
 			suggestionElements = this.renderPlaceholders();
 		}
 
@@ -256,6 +257,7 @@ class DomainSearchResults extends React.Component {
 			<div className="domain-search-results__domain-suggestions">
 				{ suggestionCount }
 				{ featuredSuggestionElement }
+				{ this.props.children }
 				{ suggestionElements }
 				{ unavailableOffer }
 			</div>

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -12,6 +12,7 @@ import { pick } from 'lodash';
 /**
  * Internal dependencies
  */
+import FeaturedDomainSuggestionsPlaceholder from 'components/domains/featured-domain-suggestions/placeholder';
 import DomainRegistrationSuggestion from 'components/domains/domain-registration-suggestion';
 
 export class FeaturedDomainSuggestions extends Component {
@@ -19,6 +20,7 @@ export class FeaturedDomainSuggestions extends Component {
 		cart: PropTypes.object,
 		primarySuggestion: PropTypes.object,
 		secondarySuggestion: PropTypes.object,
+		showPlaceholders: PropTypes.bool,
 	};
 
 	getChildProps() {
@@ -85,6 +87,10 @@ export class FeaturedDomainSuggestions extends Component {
 		const { primarySuggestion, secondarySuggestion } = this.props;
 		const childProps = this.getChildProps();
 
+		if ( this.props.showPlaceholders ) {
+			return this.renderPlaceholders();
+		}
+
 		return (
 			<div className={ this.getClassNames() }>
 				{ primarySuggestion && (
@@ -101,6 +107,15 @@ export class FeaturedDomainSuggestions extends Component {
 						{ ...childProps }
 					/>
 				) }
+			</div>
+		);
+	}
+
+	renderPlaceholders() {
+		return (
+			<div className={ this.getClassNames() }>
+				<FeaturedDomainSuggestionsPlaceholder />
+				<FeaturedDomainSuggestionsPlaceholder />
 			</div>
 		);
 	}

--- a/client/components/domains/featured-domain-suggestions/placeholder.jsx
+++ b/client/components/domains/featured-domain-suggestions/placeholder.jsx
@@ -1,0 +1,22 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default function FeaturedDomainSuggestionsPlaceholder() {
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	return (
+		<div className="featured-domain-suggestion featured-domain-suggestion--is-placeholder card is-compact is-clickable">
+			<div className="domain-suggestion__content">
+				<div className="domain-registration-suggestion__title" />
+				<div className="domain-product-price" />
+				<div className="domain-registration-suggestion__progress-bar" />
+				<div className="domain-registration-suggestion__match-reasons" />
+			</div>
+			<div className="domain-suggestion__action" />
+		</div>
+	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
+}

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -47,3 +47,33 @@
 .main.domain-search-page-wrapper .featured-domain-suggestions {
 	flex-wrap: wrap;
 }
+
+.featured-domain-suggestion {
+	&.featured-domain-suggestion--is-placeholder {
+		height: 222px;
+
+		.domain-registration-suggestion__title,
+		.domain-registration-suggestion__progress-bar,
+		.domain-registration-suggestion__match-reasons,
+		.domain-suggestion__action {
+			animation: loading-fade 1.6s ease-in-out infinite;
+			background-color: $gray-lighten-30;
+			color: transparent;
+		}
+		.domain-registration-suggestion__title {
+			height: 45px;
+		}
+		.domain-product-price {
+			height: 18px;
+		}
+		.domain-registration-suggestion__progress-bar {
+			height: 22px;
+		}
+		.domain-registration-suggestion__match-reasons {
+			height: 52px;
+		}
+		.domain-suggestion__action {
+			height: 40px;
+		}
+	}
+}


### PR DESCRIPTION
Fixes #24369 (I think?), commit extracted from #24340.

This adds placeholder aesthetics for featured suggestions during load:

<img width="985" alt="wordpress_com" src="https://user-images.githubusercontent.com/4044428/39072191-fea76ee8-44a6-11e8-9c4d-9acd7c8d718a.png">

# Test instructions
1) Spin up this branch locally.
2) Navigate to `/start/domains`.
3) Enter a query. Verify that the loading placeholder components for featured suggestions appear.