### PR TITLE
Signup: add AB test for domains as last step

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -106,4 +106,12 @@ export default {
 		},
 		defaultVariation: 'no',
 	},
+	domainsLastFlowOnSignup: {
+		datestamp: '20180420',
+		variations: {
+			no: 1,
+			yes: 1,
+		},
+		defaultVariation: 'no',
+	},
 };

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -11,6 +11,7 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import config from 'config';
+import { abtest } from 'lib/abtest';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
 const user = userFactory();
@@ -164,6 +165,13 @@ const flows = {
 		destination: getSiteDestination,
 		description: 'The current best performing flow in AB tests',
 		lastModified: '2018-01-24',
+	},
+
+	'domain-last': {
+		steps: [ 'about', 'plans', 'user', 'domains' ],
+		destination: getSiteDestination,
+		description: 'Take the main flow and put domains at the end',
+		lastModified: '2018-04-20',
 	},
 
 	surveystep: {
@@ -411,7 +419,11 @@ function filterDesignTypeInFlow( flowName, flow ) {
  * @return {string}          New flow name.
  */
 function filterFlowName( flowName ) {
-	// do nothing. No flows to filter at the moment.
+	if ( ! user.get() && flowName === 'main' ) {
+		if ( abtest( 'domainsLastFlowOnSignup' ) === 'yes' ) {
+			flowName = 'domain-last';
+		}
+	}
 	return flowName;
 }
 


### PR DESCRIPTION
Adds a new AB test to evaluate the performance of moving the domains step to be the last one during signup.

AB test name: `domainsLastFlowOnSignup`
Allocations: 50/50

e2e test: *forthcoming*

## To Test

### Signed out

1. visit Calypso in your test environment (eg `http://calypso.localhost:3000/`)
2. Run `localStorage.setItem( 'ABTests', '{"domainsLastFlowOnSignup_20180420":"yes"}' );` in your console
3. Visit `/start` (eg `http://calypso.localhost:3000/start`)
4. Verify that you are redirected in the `domain-last` signup flow URL (eg `http://calypso.localhost:3000/start/domain-last`)
5. Verify that domains is the last step of the signup flow
6. Verify that a new site is created properly

### Signed in

1. Repeat steps 1-3 from the **Signed out** section above
2. Verify that you are **not** redirected into the `domain-last` signup flow URL (this only pertains to new users)