### PR TITLE
[Domains] Enable Kracken redesign

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -27,6 +27,7 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"domains/cctlds/uk": true,
+		"domains/kracken-ui": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
This rolls out the Kracken domain registration interface redesign out to production. It is scheduled to ship and deploy on 2018-04-25.

# Testing Instructions
1. Spin up this branch in a production docker environment.
2. Navigate to `/start/domains` and ensure that the new interface is being shown.