### PR TITLE
Site Address Changer: include blog_id / siteId in the tracks events

### DIFF
--- a/client/blocks/simple-site-rename-form/dialog.jsx
+++ b/client/blocks/simple-site-rename-form/dialog.jsx
@@ -23,6 +23,7 @@ class SiteRenamerConfirmationDialog extends PureComponent {
 		newDomainSuffix: PropTypes.string,
 		onConfirm: PropTypes.func.isRequired,
 		onClose: PropTypes.func.isRequired,
+		siteId: PropTypes.number,
 		translate: PropTypes.func.isRequired,
 	};
 
@@ -62,6 +63,7 @@ class SiteRenamerConfirmationDialog extends PureComponent {
 			isVisible,
 			newDomainName,
 			newDomainSuffix,
+			siteId,
 			translate,
 		} = this.props;
 		const buttons = [
@@ -87,7 +89,10 @@ class SiteRenamerConfirmationDialog extends PureComponent {
 			>
 				<TrackComponentView
 					eventName="calypso_siteaddresschange_areyousure_view"
-					eventProperties={ { new_domain: newDomainName } }
+					eventProperties={ {
+						blog_id: siteId,
+						new_domain: newDomainName,
+					} }
 				/>
 				<h1>{ translate( "Let's review…" ) }</h1>
 				<p>

--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -202,8 +202,10 @@ export class SimpleSiteRenameForm extends Component {
 			isAvailabilityPending,
 			isAvailable,
 			isSiteRenameRequesting,
+			siteId,
 			translate,
 		} = this.props;
+
 		const { domainFieldValue } = this.state;
 		const currentDomainName = get( currentDomain, 'name', '' );
 		const currentDomainPrefix = this.getCurrentDomainPrefix();
@@ -237,9 +239,13 @@ export class SimpleSiteRenameForm extends Component {
 					newDomainName={ domainFieldValue }
 					currentDomainName={ currentDomainPrefix }
 					onConfirm={ this.onConfirm }
+					siteId={ siteId }
 				/>
 				<form onSubmit={ this.onSubmit }>
-					<TrackComponentView eventName="calypso_siteaddresschange_form_view" />
+					<TrackComponentView
+						eventName="calypso_siteaddresschange_form_view"
+						eventProperties={ { blog_id: siteId } }
+					/>
 					<Card className="simple-site-rename-form__content">
 						<FormSectionHeading>{ translate( 'Change Site Address' ) }</FormSectionHeading>
 						<FormTextInputWithAffixes

--- a/client/state/site-rename/actions.js
+++ b/client/state/site-rename/actions.js
@@ -103,6 +103,7 @@ export const requestSiteRename = ( siteId, newBlogName, discard ) => dispatch =>
 	} );
 
 	const eventProperties = {
+		blog_id: siteId,
 		new_domain: newBlogName,
 		discard,
 	};


### PR DESCRIPTION
We were not including the ID of the current site in the Tracks events we were sending for this feature.

This adds it throughout.

## To Test

* Run `master`
* Run through the site address change flow (`Settings` | `Domains` on a `*.wordpress.com` test site), & watch the `t.gif` requests
  * Confirm that no `blog_id` query arg is present
* Run this branch
* Run through the flow again & watch the `t.gif` requests
  * Confirm that a `blog_id` query arg is present & is correct.