### PR TITLE
Genericize domainAvailability NOT_REGISTERABLE message

### DIFF
--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -131,8 +131,7 @@ function getAvailabilityNotice( domain, error, site ) {
 		case domainAvailability.NOT_REGISTRABLE:
 			if ( tld ) {
 				message = translate(
-					'To use a domain ending with {{strong}}.%(tld)s{{/strong}} on your site, ' +
-						'you can register it elsewhere first and then add it here. {{a}}Learn more{{/a}}.',
+					'To use this domain on your site, you can register it elsewhere first and then add it here. {{a}}Learn more{{/a}}.',
 					{
 						args: { tld },
 						components: {


### PR DESCRIPTION
This PR updates the message for domains that can be mapped mapped but not registered to allow for specific domains with a tld to be rejected (e.g. French town names - see code-11894).

Curiously, there is a `tld_not_supported` status that the old message describes very accurately.
