### PR TITLE
Reader: allow scribd.com iframes

### DIFF
--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -172,6 +172,7 @@ export function iframeIsWhitelisted( iframe ) {
 		'player.theplatform.com',
 		'embed.radiopublic.com',
 		'gfycat.com',
+		'scribd.com',
 	];
 	const hostName = iframe.src && url.parse( iframe.src ).hostname;
 	const iframeSrc = hostName && hostName.toLowerCase();


### PR DESCRIPTION
Allow embeds from scribd.com.

Fixes #15375.

### To test

Try:

http://calypso.localhost:3000/read/feeds/18743358/posts/1502915554

Make sure the Scribd document loads as below:

<img width="1023" alt="screen shot 2018-04-23 at 12 44 13 pm" src="https://user-images.githubusercontent.com/17325/39101996-0d3492fc-46f4-11e8-9e82-d7a7aa6c7714.png">
