### PR TITLE
Checkout/Billing: use a function to generate CC brands logos css

### DIFF
--- a/client/components/payment-logo/style.scss
+++ b/client/components/payment-logo/style.scss
@@ -7,12 +7,12 @@
 	vertical-align: middle;
 	width: 35px;
 
-	$cc-payment-types: 'amex', 'diners', 'discover', 'jcb', 'mastercard', 'unionpay', 'visa';
+	$payment-cc-brands: 'amex', 'diners', 'discover', 'jcb', 'mastercard', 'unionpay', 'visa';
 	$payment-types: 'alipay', 'bancontact', 'giropay', 'eps', 'ideal', 'paypal', 'p24';
 
-	@each $type in $cc-payment-types {
-		&.is-#{$type} {
-			background-image: url('/calypso/images/upgrades/cc-#{$type}.svg');
+	@each $brand in $payment-cc-brands {
+		&.is-#{$brand} {
+			background-image: url('/calypso/images/upgrades/cc-#{$brand}.svg');
 		}
 	}
 

--- a/client/components/upgrades/credit-card-number-input/style.scss
+++ b/client/components/upgrades/credit-card-number-input/style.scss
@@ -7,31 +7,12 @@
 		padding-right: 50px;
 	}
 
-	.amex input {
-		background-image: url( '/calypso/images/upgrades/cc-amex.svg' );
-	}
+	$cc-brands: 'amex', 'diners', 'discover', 'jcb', 'mastercard', 'unionpay', 'visa';
 
-	.discover input {
-		background-image: url( '/calypso/images/upgrades/cc-discover.svg' );
-	}
 
-	.mastercard input {
-		background-image: url( '/calypso/images/upgrades/cc-mastercard.svg' );
-	}
-
-	.visa input {
-		background-image: url( '/calypso/images/upgrades/cc-visa.svg' );
-	}
-
-	.diners input {
-		background-image: url( '/calypso/images/upgrades/cc-diners.svg' );
-	}
-
-	.jcb input {
-		background-image: url( '/calypso/images/upgrades/cc-jcb.svg' );
-	}
-
-	.unionpay input {
-		background-image: url( '/calypso/images/upgrades/cc-unionpay.svg' );
+	@each $brand in $cc-brands {
+		.#{$brand} input {
+			background-image: url('/calypso/images/upgrades/cc-#{$brand}.svg');
+		}
 	}
 }

--- a/client/components/upgrades/credit-card-number-input/style.scss
+++ b/client/components/upgrades/credit-card-number-input/style.scss
@@ -9,7 +9,6 @@
 
 	$cc-brands: 'amex', 'diners', 'discover', 'jcb', 'mastercard', 'unionpay', 'visa';
 
-
 	@each $brand in $cc-brands {
 		.#{$brand} input {
 			background-image: url('/calypso/images/upgrades/cc-#{$brand}.svg');

--- a/client/my-sites/checkout/checkout/stored-card.scss
+++ b/client/my-sites/checkout/checkout/stored-card.scss
@@ -29,61 +29,18 @@
 	}
 }
 
-.stored-card.visa {
-	background-image: url('/calypso/images/upgrades/cc-visa-disabled.svg');
-}
+$cc-brands: 'amex', 'diners', 'discover', 'jcb', 'mastercard', 'unionpay', 'visa';
 
-.stored-card.mastercard {
-	background-image: url('/calypso/images/upgrades/cc-mastercard-disabled.svg');
-}
-
-.stored-card.amex {
-	background-image: url('/calypso/images/upgrades/cc-amex-disabled.svg');
-}
-
-.stored-card.discover {
-	background-image: url('/calypso/images/upgrades/cc-discover-disabled.svg');
-}
-
-.stored-card.diners {
-	background-image: url('/calypso/images/upgrades/cc-diners-disabled.svg');
-}
-
-.stored-card.jcb {
-	background-image: url('/calypso/images/upgrades/cc-jcb-disabled.svg');
-}
-
-.stored-card.unionpay {
-	background-image: url('/calypso/images/upgrades/cc-unionpay-disabled.svg');
+@each $brand in $cc-brands {
+	.stored-card.#{$brand} {
+		background-image: url('/calypso/images/upgrades/cc-#{$brand}-disabled.svg');
+	}
 }
 
 .selected > .payment-box-section-inner {
-	.stored-card.visa {
-		background-image: url('/calypso/images/upgrades/cc-visa.svg');
-	}
-
-	.stored-card.mastercard {
-		background-image: url('/calypso/images/upgrades/cc-mastercard.svg');
-	}
-
-	.stored-card.amex {
-		background-image: url('/calypso/images/upgrades/cc-amex.svg');
-	}
-
-	.stored-card.discover {
-		background-image: url('/calypso/images/upgrades/cc-discover.svg');
-	}
-
-
-	.stored-card.diners {
-		background-image: url('/calypso/images/upgrades/cc-diners.svg');
-	}
-
-	.stored-card.jcb {
-		background-image: url('/calypso/images/upgrades/cc-jcb.svg');
-	}
-
-	.stored-card.unionpay {
-		background-image: url('/calypso/images/upgrades/cc-unionpay.svg');
+	@each $brand in $cc-brands {
+		.stored-card.#{$brand} {
+			background-image: url('/calypso/images/upgrades/cc-#{$brand}.svg');
+		}
 	}
 }


### PR DESCRIPTION
Reduce code repetition.
Part of this is extracted from #21928 

**Testing:**

Enter a few CC numbers in the checkout form, and make sure the logo matches what expected:

Mastercard: 5555555555554444
UnionPay: 6200000000000005
Discover: 6011000990139424
Visa: 4242424242424242
Amex: 378282246310005
JCB: 3566002020360505

If you have saved cards, make sure the logo is displayed in purchases/billing (Billing history).



