### PR TITLE
Plans: Fix 'Manage Plans' link

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -813,7 +813,6 @@ export default connect(
 						isMonthly: showMonthlyPrice,
 					} ),
 					features: planFeatures,
-					isJetpack,
 					isLandingPage,
 					isPlaceholder,
 					onUpgradeClick: onUpgradeClick
@@ -844,7 +843,6 @@ export default connect(
 						plans.length === 1,
 					rawPrice: getPlanRawPrice( state, planProductId, showMonthlyPrice ),
 					relatedMonthlyPlan,
-					selectedSiteSlug,
 				};
 			} )
 		);
@@ -866,8 +864,10 @@ export default connect(
 		return {
 			canPurchase,
 			freePlanProperties,
+			isJetpack,
 			maxCredits,
 			planProperties,
+			selectedSiteSlug,
 			showModifiedPricingDisplay,
 			sitePlan,
 			siteType,


### PR DESCRIPTION
Fixes #24320, reported by @simison, and brought to my attention by @rachelmcr. Thanks both!

I broke this with #24306. The embarrassing reason is that I added `selectedSiteSlug` to the wrong `return` statement in the `connect()` function's `mapStateToProps`. (Inside the `planProperties` `map`, instead of the top-level `return`.)

Testing Instructions: Verify that #24320 is fixed.