### PR TITLE
Guided Tours: improve documentation on how to trigger a tour

### DIFF
--- a/client/layout/guided-tours/README.md
+++ b/client/layout/guided-tours/README.md
@@ -22,7 +22,7 @@ The tour first asks the user whether they want to know more and then walks them 
 These are the **core use cases** we currently see for Guided Tours:
 
 - Help new users understand what they should be doing next. E.g. guide a new user who hasn't written a blog post yet through the creation of their first one.
-- Provide immersive tutorials that help semi-advanced users understand Calypso better. E.g. explain how to set up publicize. Such a tour could be triggered by certain user behavior, or could be linked to using a special URL (see e.g. the experimental `main` tour: [https://wordpress.com/?tour=main](https://wordpress.com/?tour=main)).
+- Provide immersive tutorials that help semi-advanced users understand Calypso better. E.g. explain how to set up publicize. Such a tour could be triggered by certain user behavior, or could be linked to using a special URL (see e.g. the experimental `main` tour: [https://wordpress.com/?tour=main](https://wordpress.com/?tour=main)). There's also a Redux acton to trigger a tour -- see [docs/API.md](docs/API.md) for details.
 - Tours that help address common oversights, such as the title tour mentioned above.
 - Announce new or changed features.
 

--- a/client/layout/guided-tours/docs/API.md
+++ b/client/layout/guided-tours/docs/API.md
@@ -6,6 +6,12 @@ Guided Tours are declared in JSX as a tree of elements. All of them are availabl
 
 Tour is a React component that declares the top-level of a tour. It consists of a series of Step elements and defines when a tour should start by setting appropriate props.
 
+There are three ways a tour can get triggered:
+
+1. If the user navigates to a path that matches the tour's `path` property and the tour's `when` property evaluates to true and there is no other tour that is either running or could also be triggered (in the case of multiple tours that could be triggered we just choose the first match). Every tour will be triggered only once for a user when using this mechanism. 
+2. If the user navigates to a URL that contains the tour's name in the `tour` query argument -- e.g., `?tour=editorBasicsTour`. This will ignore the `path` and `when` props as well as the user's tour history.
+3. We can dispatch the Redux action `requestGuidedTour( tour )` to trigger a tour as well. This will ignore the `path` and `when` props as well as the user's tour history.
+
 ### Props
 
 * `name`: (string) Unique name of tour in camelCase.
@@ -45,7 +51,7 @@ Step is a React component that defines a single Step of a tour. It is represente
 * `next`: (string, optional) Define this to tell Guided Tours the name of the step it should skip to when `when` evaluates to false.
 * `scrollContainer`: (string, optional) This is a CSS selector for the container that the framework should attempt to scroll in case the target isn't visible. E.g. if the target is a menu item that could be invisible because of a scrolled sidebar, we'd want the framework to scroll the sidebar until the target is visible. The CSS selector to pass would then be `.sidebar__region`. Note: there were some differences for the sidebar between desktop and tablet that don't seem to be a problem anymore, but in any case have been [documented in  this issue](https://github.com/Automattic/wp-calypso/issues/7208).
 * `children`: (component) Content of the step. Unlike most other components' children, this one takes a so called render prop as a single child. It's a component (function or class) to be rendered when the step is actually displayed. The `translate` function is passed as a prop to the child component. The content is usually a paragraph of instructions and some controls for the tour. See below for available options. Note that all text content needs to be wrapped in `<p>` so it gets proper styling.
-* `onTargetDisappear`: (function, optional) In some cases the target that a step points to will disappear after Guided Tours has rendered a step. In those cases we can end up with steps unhelpfully pointing at (0, 0). The `onTargetDisappear` prop takes a function that will be called when the framework can't find the target anymore. The function will be passed an object containing two functions: `quit` and `next`. In your callback you can decide how to handle the disappearing target and then use those functions to either quit the whole tour or proceed to the next step. This is e.g. used in `checklist-site-icon-tour.js`. 
+* `onTargetDisappear`: (function, optional) In some cases the target that a step points to will disappear after Guided Tours has rendered a step. In those cases we can end up with steps unhelpfully pointing at (0, 0). The `onTargetDisappear` prop takes a function that will be called when the framework can't find the target anymore. The function will be passed an object containing two functions: `quit` and `next`. In your callback you can decide how to handle the disappearing target and then use those functions to either quit the whole tour or proceed to the next step. This is e.g. used in `checklist-site-icon-tour.js`.
 
 ### Example
 


### PR DESCRIPTION
This PR improves the Guided Tours documentation with regards to triggering a tour. 

To test:
- Look at the updated documentation and ponder whether it's more comprehensible now. 