### PR TITLE
Replace lodash-humps with more size-efficient implementation

### DIFF
--- a/client/state/data-layer/test/utils.js
+++ b/client/state/data-layer/test/utils.js
@@ -1,14 +1,9 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
-import { bypassDataLayer } from '../utils';
+import { bypassDataLayer, convertToCamelCase } from '../utils';
 
 describe( 'Data Layer', () => {
 	describe( '#local', () => {
@@ -16,7 +11,7 @@ describe( 'Data Layer', () => {
 			const action = { type: 'ADD_SPLINE', id: 42 };
 			const localAction = bypassDataLayer( action );
 
-			expect( localAction ).to.have.deep.property( 'meta.dataLayer.doBypass', true );
+			expect( localAction ).toHaveProperty( 'meta.dataLayer.doBypass', true );
 		} );
 
 		test( 'should not destroy existing meta', () => {
@@ -31,8 +26,58 @@ describe( 'Data Layer', () => {
 			};
 			const localAction = bypassDataLayer( action );
 
-			expect( localAction ).to.have.deep.property( 'meta.oceanName', 'ARCTIC' );
-			expect( localAction ).to.have.deep.property( 'meta.dataLayer.forceRefresh', true );
+			expect( localAction ).toHaveProperty( 'meta.oceanName', 'ARCTIC' );
+			expect( localAction ).toHaveProperty( 'meta.dataLayer.forceRefresh', true );
+		} );
+	} );
+
+	describe( '#convertToCamelCase', () => {
+		const snakeObject = {
+			primitive_value: 'string_const',
+			'value_with.dot_key': null,
+			'value_with[bracket_key]': null,
+			array_value: [
+				{
+					first_first: 1,
+					first_second: 2,
+				},
+				{
+					second_first: 3,
+					second_second: 4,
+				},
+			],
+			object_value: {
+				obj_foo: {
+					obj_foo: null,
+				},
+				obj_bar: {
+					obj_bar: null,
+				},
+			},
+		};
+
+		expect( convertToCamelCase( snakeObject ) ).toEqual( {
+			primitiveValue: 'string_const',
+			valueWithDotKey: null,
+			valueWithBracketKey: null,
+			arrayValue: [
+				{
+					firstFirst: 1,
+					firstSecond: 2,
+				},
+				{
+					secondFirst: 3,
+					secondSecond: 4,
+				},
+			],
+			objectValue: {
+				objFoo: {
+					objFoo: null,
+				},
+				objBar: {
+					objBar: null,
+				},
+			},
 		} );
 	} );
 } );

--- a/client/state/data-layer/utils.js
+++ b/client/state/data-layer/utils.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import humps from 'lodash-humps';
+import { camelCase, isArray, isObjectLike, isPlainObject, map, reduce, set } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,7 +23,25 @@ export const bypassDataLayer = action => extendAction( action, doBypassDataLayer
 /**
  * Deeply converts keys from the specified object to camelCase notation.
  *
- * @param {Object} - object to convert
- * @returns a new object with all keys converted
+ * @param {Object} obj object to convert
+ * @returns {Object}   a new object with all keys converted
  */
-export { humps as convertToCamelCase };
+export function convertToCamelCase( obj ) {
+	if ( isArray( obj ) ) {
+		return map( obj, convertToCamelCase );
+	}
+
+	if ( isPlainObject( obj ) ) {
+		return reduce(
+			obj,
+			( result, value, key ) => {
+				const newKey = camelCase( key );
+				const newValue = isObjectLike( value ) ? convertToCamelCase( value ) : value;
+				return set( result, [ newKey ], newValue );
+			},
+			{}
+		);
+	}
+
+	return obj;
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10669,15 +10669,8 @@
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "lodash-es": {
-      "version": "4.17.8",
-      "integrity": "sha512-I9mjAxengFAleSThFhhAhvba6fsO0hunb9/0sQ6qQihSZsJRBofv2rYH58WXaOb/O++eUmYpCLywSQ22GfU+sA=="
-    },
-    "lodash-humps": {
-      "version": "3.1.2",
-      "integrity": "sha512-gOaZwNZk4J++Sep2KpoqnFBZe1aK8WvDUWtqyNvZIMEbjN+EUo0DdwNhoJAASeS7FESIdW0yTjtr5FwxJIUd4w==",
-      "requires": {
-        "lodash": "4.17.5"
-      }
+      "version": "4.17.9",
+      "integrity": "sha512-5GfcrT3VfNx20lcIiQAsx2LGr/EFi+hV7NqQA2pLuAQsC3b0/Tr/E3OM5GOQct3lRSwzXjvv+2tx4ydqrC/Ohw=="
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
@@ -14477,7 +14470,7 @@
         "hoist-non-react-statics": "2.5.0",
         "invariant": "2.2.4",
         "lodash": "4.17.5",
-        "lodash-es": "4.17.8",
+        "lodash-es": "4.17.9",
         "loose-envify": "1.3.1",
         "prop-types": "15.6.1"
       },
@@ -14741,7 +14734,7 @@
         "invariant": "2.2.4",
         "is-promise": "2.1.0",
         "lodash": "4.17.5",
-        "lodash-es": "4.17.8",
+        "lodash-es": "4.17.9",
         "prop-types": "15.5.10"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "keymaster": "1.6.2",
     "localforage": "1.4.3",
     "lodash": "4.17.5",
-    "lodash-humps": "3.1.2",
     "lru": "3.1.0",
     "lunr": "0.5.7",
     "markdown-loader": "2.0.1",


### PR DESCRIPTION
Fixes a bundle size regression introduced in #24124. Caused by the `lodash-humps` library.

The `lodash-humps` imports lodash function in a way not compatible with how we do things in Calypso, i.e., from individual modules like `lodash/isArray`. That results in a lot of Lodash code duplication in the base bundle.

This patch replaces `lodash-humps` with our own implementation (very inspired by `lodash-humps`) that does the imports correctly.

Bundle size impact:
```
chunk          stat_size           parsed_size           gzip_size
build             +414 B  (+0.0%)       +199 B  (+0.0%)      +63 B  (+0.0%)
manifest            +0 B                  +0 B               -10 B  (-0.2%)
vendors~build  -116977 B  (-4.5%)     -41772 B  (-3.6%)    -8004 B  (-2.7%)
```