### PR TITLE
Add <QuerySitePlans /> to checkout page - the data is needed there

### DIFF
--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -33,6 +33,7 @@ import SubscriptionLengthPicker from 'blocks/subscription-length-picker';
 import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
 import QueryStoredCards from 'components/data/query-stored-cards';
 import QueryGeo from 'components/data/query-geo';
+import QuerySitePlans from 'components/data/query-site-plans';
 import SecurePaymentForm from './secure-payment-form';
 import SecurePaymentFormPlaceholder from './secure-payment-form-placeholder';
 import { AUTO_RENEWAL } from 'lib/url/support';
@@ -589,6 +590,7 @@ class Checkout extends React.Component {
 		return (
 			<div className="main main-column" role="main">
 				<div className="checkout">
+					<QuerySitePlans siteId={ this.props.selectedSiteId } />
 					<QueryProducts />
 					<QueryContactDetailsCache />
 					<QueryStoredCards />


### PR DESCRIPTION
As in the title.

Test plan:
* Start server like this: `ENABLE_FEATURES=upgrades/2-year-plans npm run start`
* As a free site, go to plans upgrade and choose a business plan
* When on /checkout page, refresh
* Confirm that discount is visible for a 1-year plan 