### PR TITLE
Ad Tracking: Facebook Advanced Matching - email, first and last name

### DIFF
--- a/client/lib/posts/test/actions.js
+++ b/client/lib/posts/test/actions.js
@@ -24,6 +24,10 @@ jest.mock( 'lib/redux-bridge', () => ( {
 	reduxGetState: () => ( { ui: { editor: { saveBlockers: [] } } } ),
 } ) );
 
+jest.mock( 'lib/user-settings', () => ( {
+	getSettings: () => [],
+} ) );
+
 const sampleSite = {
 	ID: 123,
 	jetpack: false,

--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -133,6 +133,7 @@ UserSettings.prototype.fetchSettings = function() {
 					this.settings = decodeUserSettingsEntities( data );
 					this.initialized = true;
 					this.emit( 'change' );
+					this.emit( 'postInit' );
 				}
 
 				this.fetchingSettings = false;


### PR DESCRIPTION
This commit adds the e-mail, first name and last name to the data that is being sent to Facebook. The hashing happens before existing the user's browser (handled internally by FB). 

Reference URL: https://developers.facebook.com/docs/facebook-pixel/pixel-with-ads/conversion-tracking#advanced_match

## Testing
**Happy path**:
1. https://calypso.live/?branch=add/tracking-facebook-advanced-matching&flags=ad-tracking (Make sure the ad-tracking flag is set for any URL that you access).
2. Open the browser console and enable debugging `localStorage.setItem( 'debug', 'calypso:analytics:*' );`
3. Refresh the page, such that the event is fired again. 
4. Filter the console by the keyword FB which should show you something like `FB Advanced Matching: {em: "emailaddress@domainnamedotsomething", fn: "firstnamelowercase", ln: "lastnmelowercase"}`

**Less happy path**:
1. Edit your profile, empty your first or last name: http://calypso.localhost:3000/me
2. Repeat happy path . You should not see the first name or last name (which one you emptied) in the submitted object.
