### PR TITLE
Add <QueryPlans /> to checkout page - the data is needed there

### DIFF
--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -34,6 +34,7 @@ import QueryContactDetailsCache from 'components/data/query-contact-details-cach
 import QueryStoredCards from 'components/data/query-stored-cards';
 import QueryGeo from 'components/data/query-geo';
 import QuerySitePlans from 'components/data/query-site-plans';
+import QueryPlans from 'components/data/query-plans';
 import SecurePaymentForm from './secure-payment-form';
 import SecurePaymentFormPlaceholder from './secure-payment-form-placeholder';
 import { AUTO_RENEWAL } from 'lib/url/support';
@@ -591,6 +592,7 @@ class Checkout extends React.Component {
 			<div className="main main-column" role="main">
 				<div className="checkout">
 					<QuerySitePlans siteId={ this.props.selectedSiteId } />
+					<QueryPlans />
 					<QueryProducts />
 					<QueryContactDetailsCache />
 					<QueryStoredCards />


### PR DESCRIPTION
As in the title.

Test plan:
* Start server like this: `ENABLE_FEATURES=upgrades/2-year-plans npm run start`
* As a free site, go to plans upgrade and choose a business plan
* When on /checkout page, refresh *a few times* - the problem manifested itself on some requests but not on others
* Confirm that discount is visible for a 1-year plan and that 2-year plan is available to choose 