### PR TITLE
JITM: Use Jetpack branding for JITM messages

### DIFF
--- a/client/blocks/jitm/index.jsx
+++ b/client/blocks/jitm/index.jsx
@@ -36,6 +36,7 @@ export const JITM = ( {
 			onDismiss={ onDismiss( currentSite.ID, id, featureClass ) }
 			event={ `jitm_nudge_click_${ id }` }
 			href={ `https://jetpack.com/redirect/?source=jitm-${ id }&site=${ currentSite.domain }` }
+			isJetpack
 			target={ '_blank' }
 		/>
 	);

--- a/client/components/banner/README.md
+++ b/client/components/banner/README.md
@@ -22,6 +22,7 @@ render() {
 			feature={ FEATURE_ADVANCED_SEO }
 			href="https://wordpress.com/"
 			icon="star"
+			isJetpack={ false }
 			list={ [ 'A feature', 'Another feature' ] }
 			onClick={ someFunction }
 			plan={ PLAN_BUSINESS }
@@ -47,6 +48,7 @@ render() {
 | `feature` | `string` | null | Slug of the feature to highlight in the plans compare card. |
 | `href` | `string` | null | The component target URL. |
 | `icon` | `string` | null | The component icon. |
+| `isJetpack` | `bool` | false | When true, banner is branded with Jetpack colours and if the icon is undefined, with jetpack icon. |
 | `list` | `string` | null | A list of the upgrade features. |
 | `onClick` | `string` | null | A function associated to the click on the whole banner or just the CTA or dismiss button. |
 | `plan` | `string` | null | PlanSlug of the plan that upgrade leads to. |
@@ -58,5 +60,3 @@ render() {
 * If `href` is not provided, `feature` can auto-generate it.
 * If `callToAction` is provided, `href` and `onClick` are not applied to the whole banner, but to the `callToAction` button only.
 * If `dismissPreferenceName` is provided, `href` is only applied if `callToAction` is provided.
-
-

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -14,13 +14,13 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import { isPersonalPlan, isPremiumPlan, isBusinessPlan } from 'lib/plans';
+import { getValidFeatureKeys, isPersonalPlan, isPremiumPlan, isBusinessPlan } from 'lib/plans';
 import { addQueryArgs } from 'lib/url';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
-import { getValidFeatureKeys } from 'lib/plans';
 import Button from 'components/button';
 import Card from 'components/card';
+import JetpackLogo from 'components/jetpack-logo';
 import DismissibleCard from 'blocks/dismissible-card';
 import PlanIcon from 'components/plans/plan-icon';
 import PlanPrice from 'my-sites/plan-price';
@@ -38,6 +38,7 @@ export class Banner extends Component {
 		feature: PropTypes.oneOf( getValidFeatureKeys() ),
 		href: PropTypes.string,
 		icon: PropTypes.string,
+		isJetpack: PropTypes.bool,
 		list: PropTypes.arrayOf( PropTypes.string ),
 		onClick: PropTypes.func,
 		onDismiss: PropTypes.func,
@@ -102,7 +103,15 @@ export class Banner extends Component {
 	};
 
 	getIcon() {
-		const { icon, plan } = this.props;
+		const { icon, isJetpack, plan } = this.props;
+
+		if ( isJetpack && ! icon ) {
+			return (
+				<div className="banner__icon-jetpack">
+					<JetpackLogo size={ 32 } />
+				</div>
+			);
+		}
 
 		if ( plan && ! icon ) {
 			return (
@@ -188,6 +197,7 @@ export class Banner extends Component {
 			disableHref,
 			dismissPreferenceName,
 			dismissTemporary,
+			isJetpack,
 			plan,
 		} = this.props;
 
@@ -195,9 +205,10 @@ export class Banner extends Component {
 			'banner',
 			className,
 			{ 'has-call-to-action': callToAction },
-			{ 'is-upgrade-personal': plan && isPersonalPlan( plan ) },
-			{ 'is-upgrade-premium': plan && isPremiumPlan( plan ) },
-			{ 'is-upgrade-business': plan && isBusinessPlan( plan ) },
+			{ 'is-jetpack': isJetpack },
+			{ 'is-upgrade-personal': ! isJetpack && plan && isPersonalPlan( plan ) },
+			{ 'is-upgrade-premium': ! isJetpack && plan && isPremiumPlan( plan ) },
+			{ 'is-upgrade-business': ! isJetpack && plan && isBusinessPlan( plan ) },
 			{ 'is-dismissible': dismissPreferenceName }
 		);
 

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -49,7 +49,7 @@
 		}
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( ">1280px" ) {
 		padding: 12px 16px;
 		&.is-dismissible {
 			padding-right: 16px;
@@ -124,7 +124,7 @@
 	flex-grow: 1;
 	flex-wrap: wrap;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( ">1280px" ) {
 		flex-wrap: nowrap;
 	}
 }
@@ -163,9 +163,11 @@
 		}
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( ">1280px" ) {
 		width: auto;
+	}
 
+	@include breakpoint( ">480px" ) {
 		.banner__list li .gridicon {
 			display: inline;
 			margin-right: 12px;
@@ -199,7 +201,7 @@
 		}
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( ">1280px" ) {
 		margin: 0 -6px 0 8px;
 		text-align: center;
 		width: auto;

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -29,6 +29,9 @@
 	&.is-upgrade-business {
 		@include banner-color( $alert-purple );
 	}
+	&.is-jetpack {
+		@include banner-color( $green-jetpack );
+	}
 
 	.card__link-indicator {
 		align-items: center;
@@ -89,6 +92,15 @@
 		.banner__icon-circle {
 			display: flex;
 		}
+	}
+}
+
+.banner__icon-jetpack {
+	display: flex;
+	margin-right: 16px;
+
+	@include breakpoint( ">480px" ) {
+		align-items: center;
 	}
 }
 

--- a/client/components/banner/test/test.jsx
+++ b/client/components/banner/test/test.jsx
@@ -160,6 +160,41 @@ describe( 'Banner basic tests', () => {
 		const comp = shallow( <Banner { ...props } /> );
 		assert.lengthOf( comp.find( 'TrackComponentView' ), 0 );
 	} );
+
+	test( 'should not render with is-jetpack class when isJetpack is undefined', () => {
+		const comp = shallow( <Banner { ...props } description="test" /> );
+		assert.lengthOf( comp.find( '.is-jetpack' ), 0 );
+	} );
+
+	test( 'should render with is-jetpack class when isJetpack is true', () => {
+		const comp = shallow( <Banner { ...props } isJetpack={ true } description="test" /> );
+		assert.lengthOf( comp.find( '.is-jetpack' ), 1 );
+	} );
+
+	test( 'should not render Jetpack logo when isJetpack is undefined', () => {
+		const comp = shallow( <Banner { ...props } description="test" /> );
+		assert.lengthOf( comp.find( 'JetpackLogo' ), 0 );
+	} );
+
+	test( 'should render Jetpack logo when isJetpack is true', () => {
+		const comp = shallow( <Banner { ...props } isJetpack={ true } description="test" /> );
+		assert.lengthOf( comp.find( 'JetpackLogo' ), 1 );
+	} );
+
+	test( 'should render Jetpack logo when isJetpack is true and plan is defined', () => {
+		const comp = shallow(
+			<Banner { ...props } isJetpack={ true } plan={ PLAN_PERSONAL } description="test" />
+		);
+		assert.lengthOf( comp.find( 'JetpackLogo' ), 1 );
+		assert.lengthOf( comp.find( 'PlanIcon' ), 0 );
+	} );
+
+	test( 'should not render plan class name when isJetpack is true', () => {
+		const comp = shallow(
+			<Banner { ...props } isJetpack={ true } plan={ PLAN_PERSONAL } description="test" />
+		);
+		assert.lengthOf( comp.find( '.is-upgrade-personal' ), 0 );
+	} );
 } );
 
 describe( 'Banner should have a class name corresponding to appropriate plan', () => {


### PR DESCRIPTION
Partly resolves 1781-gh-jpop-issues (does not include changes for call-to-action)

- Updates Banner component:
  - to support Jetpack branding (colours + logo).
  - Jetpack branding takes precedence over plan upgrade styles and icon.
  - Defined icon takes precedence over Jetpack logo.
- Changes all JITMs use Jetpack branding

Feature description change isn't included in this PR (see D12184-code)

I noticed we also have WooCommerce JITMs (and not only Jetpack), so JITM styling should probably be set via API and not default to Jetpack. 
That'll need changes at the API, although it kinda looks like we could re-use the "icon" key already present in the API. These changes should be fine to do in next PRs.

### Before
![screen shot 2018-04-23 at 16 54 37](https://user-images.githubusercontent.com/87168/39131388-f9417c1e-4717-11e8-9d2c-d8ce2d758075.png)


### After
Small screens
![screen shot 2018-04-23 at 15 21 12](https://user-images.githubusercontent.com/87168/39130137-0b04da2a-4715-11e8-9d2a-8b480a394456.png)
Medium screens
![screen shot 2018-04-23 at 15 21 48](https://user-images.githubusercontent.com/87168/39130136-0ae26594-4715-11e8-8c2b-61cb2a8656b3.png)
Large screens
![screen shot 2018-04-23 at 15 13 37](https://user-images.githubusercontent.com/87168/39130138-0b256e66-4715-11e8-84fb-6f20931f1f2f.png)

## Testing

- See instructions how to activate JITM: 1781-gh-jpop-issues#issuecomment-381226556
 - Test it works well on different screen sizes
