### PR TITLE
Jetpack connect: Fix upgrade flows coming through url entry

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -74,24 +74,23 @@ class Plans extends Component {
 
 	maybeRedirect() {
 		if ( this.props.isAutomatedTransfer ) {
-			externalRedirect( this.props.selectedSite.URL + JETPACK_ADMIN_PATH );
+			return externalRedirect( this.props.selectedSite.URL + JETPACK_ADMIN_PATH );
 		}
 		if ( this.props.selectedPlan ) {
-			this.selectPlan( this.props.selectedPlan );
+			return this.selectPlan( this.props.selectedPlan );
 		}
 		if ( this.props.hasPlan || this.props.notJetpack ) {
-			this.redirect( CALYPSO_PLANS_PAGE );
+			return this.redirect( CALYPSO_PLANS_PAGE );
 		}
 		if ( ! this.props.selectedSite && this.props.isSitesInitialized ) {
 			// Invalid site
-			this.redirect( JPC_PATH_PLANS );
+			return this.redirect( JPC_PATH_PLANS );
 		}
 		if ( ! this.props.canPurchasePlans ) {
 			if ( this.props.calypsoStartedConnection ) {
-				this.redirectToCalypso();
-			} else {
-				this.redirectToWpAdmin();
+				return this.redirectToCalypso();
 			}
+			return this.redirectToWpAdmin();
 		}
 	}
 


### PR DESCRIPTION
A redirection logic flaw in the Jetpack Connect plans component meant that existing plans were taking precedence over flow-selected plans. So in practice, sites with existing plans coming through, for example, wordpress.com/jetpack/connect/pro, were being redirected to a plan selection screen instead of the checkout.

Lack of `return`s meant that the `redirecting` flag was not being checked, and existing redirects being ignored.

## Testing
* Start with a site that is already connected and **already on a plan**
* Go to https://calypso.live/jetpack/connect/pro?branch=fix/jetpack-connect/upgrade-via-connect
* Enter the site URL
* Check that you are taken to the checkout with a business plan, and not /plans as previously

