### PR TITLE
Jetpack Connect: Move tracks to component

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -265,10 +265,6 @@ export class JetpackAuthorize extends Component {
 		return partnerRedirectFlag ? partnerSlug && 'pressable' !== partnerSlug : partnerSlug;
 	}
 
-	handleClickHelp = () => {
-		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
-	};
-
 	handleSignOut = () => {
 		const { recordTracksEvent } = this.props;
 		recordTracksEvent( 'calypso_jpc_signout_click' );
@@ -584,7 +580,7 @@ export class JetpackAuthorize extends Component {
 					{ translate( 'Create a new account' ) }
 				</LoggedOutFormLinkItem>
 				<JetpackConnectHappychatButton eventName="calypso_jpc_authorize_chat_initiated">
-					<HelpButton onClick={ this.handleClickHelp } />
+					<HelpButton />
 				</JetpackConnectHappychatButton>
 			</LoggedOutFormLinks>
 		);

--- a/client/jetpack-connect/help-button.jsx
+++ b/client/jetpack-connect/help-button.jsx
@@ -6,19 +6,19 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import { localize } from 'i18n-calypso';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 export class JetpackConnectHelpButton extends PureComponent {
-	static propTypes = {
-		onClick: PropTypes.func,
-		label: PropTypes.string,
-	};
+	static propTypes = { label: PropTypes.string };
 
+	recordClick = () => void this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
 
 	render() {
 		const { label, translate } = this.props;
@@ -28,7 +28,7 @@ export class JetpackConnectHelpButton extends PureComponent {
 				href="https://jetpack.com/contact-support"
 				target="_blank"
 				rel="noopener noreferrer"
-				onClick={ this.props.onClick }
+				onClick={ this.recordClick }
 			>
 				<Gridicon icon="help-outline" size={ 18 } />{' '}
 				{ label || translate( 'Get help setting up Jetpack' ) }
@@ -37,4 +37,4 @@ export class JetpackConnectHelpButton extends PureComponent {
 	}
 }
 
-export default localize( JetpackConnectHelpButton );
+export default connect( null, { recordTracksEvent } )( localize( JetpackConnectHelpButton ) );

--- a/client/jetpack-connect/help-button.jsx
+++ b/client/jetpack-connect/help-button.jsx
@@ -1,8 +1,9 @@
 /** @format */
+
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 
@@ -12,24 +13,28 @@ import Gridicon from 'gridicons';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import { localize } from 'i18n-calypso';
 
-const JetpackConnectHelpButton = ( { label, translate, onClick } ) => {
-	return (
-		<LoggedOutFormLinkItem
-			className="jetpack-connect__help-button"
-			href="https://jetpack.com/contact-support"
-			target="_blank"
-			rel="noopener noreferrer"
-			onClick={ onClick }
-		>
-			<Gridicon icon="help-outline" size={ 18 } />{' '}
-			{ label || translate( 'Get help setting up Jetpack' ) }
-		</LoggedOutFormLinkItem>
-	);
-};
+export class JetpackConnectHelpButton extends PureComponent {
+	static propTypes = {
+		onClick: PropTypes.func,
+		label: PropTypes.string,
+	};
 
-JetpackConnectHelpButton.propTypes = {
-	onClick: PropTypes.func,
-	label: PropTypes.string,
-};
+
+	render() {
+		const { label, translate } = this.props;
+		return (
+			<LoggedOutFormLinkItem
+				className="jetpack-connect__help-button"
+				href="https://jetpack.com/contact-support"
+				target="_blank"
+				rel="noopener noreferrer"
+				onClick={ this.props.onClick }
+			>
+				<Gridicon icon="help-outline" size={ 18 } />{' '}
+				{ label || translate( 'Get help setting up Jetpack' ) }
+			</LoggedOutFormLinkItem>
+		);
+	}
+}
 
 export default localize( JetpackConnectHelpButton );

--- a/client/jetpack-connect/no-direct-access-error.js
+++ b/client/jetpack-connect/no-direct-access-error.js
@@ -23,8 +23,6 @@ class NoDirectAccessError extends PureComponent {
 		translate: PropTypes.func.isRequired,
 	};
 
-	handleClickHelp = () => this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
-
 	render() {
 		const { translate } = this.props;
 
@@ -38,7 +36,7 @@ class NoDirectAccessError extends PureComponent {
 				/>
 				<LoggedOutFormLinks>
 					<JetpackConnectHappychatButton eventName="calypso_jpc_noqueryarguments_chat_initiated">
-						<HelpButton onClick={ this.handleClickHelp } />
+						<HelpButton />
 					</JetpackConnectHappychatButton>
 				</LoggedOutFormLinks>
 			</Main>

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -83,10 +83,6 @@ class PlansLanding extends Component {
 		this.storeSelectedPlan( null );
 	};
 
-	handleHelpButtonClick = () => {
-		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
-	};
-
 	handleInfoButtonClick = info => () => {
 		this.props.recordTracksEvent( 'calypso_jpc_external_help_click', {
 			help_type: info,
@@ -118,7 +114,7 @@ class PlansLanding extends Component {
 					<PlansExtendedInfo recordTracks={ this.handleInfoButtonClick } />
 					<LoggedOutFormLinks>
 						<JetpackConnectHappychatButton eventName="calypso_jpc_planslanding_chat_initiated">
-							<HelpButton onClick={ this.handleHelpButtonClick } />
+							<HelpButton />
 						</JetpackConnectHappychatButton>
 					</LoggedOutFormLinks>
 				</PlansGrid>

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -112,10 +112,6 @@ class Plans extends Component {
 		this.selectFreeJetpackPlan();
 	};
 
-	handleHelpButtonClick = () => {
-		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
-	};
-
 	redirectToWpAdmin() {
 		const { queryRedirect } = this.props;
 		if ( queryRedirect ) {
@@ -227,7 +223,7 @@ class Plans extends Component {
 							label={ helpButtonLabel }
 							eventName="calypso_jpc_plans_chat_initiated"
 						>
-							<HelpButton onClick={ this.handleHelpButtonClick } label={ helpButtonLabel } />
+							<HelpButton label={ helpButtonLabel } />
 						</JetpackConnectHappychatButton>
 					</LoggedOutFormLinks>
 				</PlansGrid>

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -169,10 +169,6 @@ export class JetpackSignup extends Component {
 		);
 	};
 
-	handleClickHelp = () => {
-		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
-	};
-
 	renderLoginUser() {
 		const { newUsername, bearerToken } = this.state;
 		return (
@@ -200,7 +196,7 @@ export class JetpackSignup extends Component {
 				<LoggedOutFormLinkItem href={ this.getLoginRoute() }>
 					{ this.props.translate( 'Already have an account? Sign in' ) }
 				</LoggedOutFormLinkItem>
-				<HelpButton onClick={ this.handleClickHelp } />
+				<HelpButton />
 			</LoggedOutFormLinks>
 		);
 	}

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -91,9 +91,7 @@ exports[`JetpackAuthorize renders as expected 1`] = `
         <Connect(Localized(JetpackConnectHappychatButton))
           eventName="calypso_jpc_authorize_chat_initiated"
         >
-          <Localized(JetpackConnectHelpButton)
-            onClick={[Function]}
-          />
+          <Connect(Localized(JetpackConnectHelpButton)) />
         </Connect(Localized(JetpackConnectHappychatButton))>
       </LoggedOutFormLinks>
     </div>

--- a/client/jetpack-connect/test/__snapshots__/plans.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/plans.js.snap
@@ -159,9 +159,8 @@ exports[`Plans should render plans 1`] = `
         eventName="calypso_jpc_plans_chat_initiated"
         label="Need help?"
       >
-        <Localized(JetpackConnectHelpButton)
+        <Connect(Localized(JetpackConnectHelpButton))
           label="Need help?"
-          onClick={[Function]}
         />
       </Connect(Localized(JetpackConnectHappychatButton))>
     </LoggedOutFormLinks>

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -37,9 +37,7 @@ exports[`JetpackSignup should render 1`] = `
           >
             Already have an account? Sign in
           </LoggedOutFormLinkItem>
-          <Localized(JetpackConnectHelpButton)
-            onClick={[Function]}
-          />
+          <Connect(Localized(JetpackConnectHelpButton)) />
         </LoggedOutFormLinks>
       }
       handleSocialResponse={[Function]}
@@ -95,9 +93,7 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
           >
             Already have an account? Sign in
           </LoggedOutFormLinkItem>
-          <Localized(JetpackConnectHelpButton)
-            onClick={[Function]}
-          />
+          <Connect(Localized(JetpackConnectHelpButton)) />
         </LoggedOutFormLinks>
       }
       handleSocialResponse={[Function]}

--- a/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
+++ b/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
@@ -19,7 +19,7 @@ import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import { getSiteUrl, isSiteOnFreePlan } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
-const Troubleshoot = ( { isFreePlan, siteUrl, trackDebugClick, trackSupportClick, translate } ) => (
+const Troubleshoot = ( { isFreePlan, siteUrl, trackDebugClick, translate } ) => (
 	<LoggedOutFormLinks>
 		<LoggedOutFormLinkItem
 			href={ addQueryArgs( { url: siteUrl }, 'https://jetpack.com/support/debug/' ) }
@@ -28,19 +28,13 @@ const Troubleshoot = ( { isFreePlan, siteUrl, trackDebugClick, trackSupportClick
 			<Gridicon size={ 18 } icon="offline" /> { translate( 'Diagnose a connection problem' ) }
 		</LoggedOutFormLinkItem>
 		{ isFreePlan ? (
-			<HelpButton
-				label={ translate( 'Get help from our Happiness Engineers' ) }
-				onClick={ trackSupportClick }
-			/>
+			<HelpButton label={ translate( 'Get help from our Happiness Engineers' ) } />
 		) : (
 			<JetpackConnectHappychatButton
 				label={ translate( 'Get help from our Happiness Engineers' ) }
 				eventName="calypso_jetpack_disconnect_chat_initiated"
 			>
-				<HelpButton
-					label={ translate( 'Get help from our Happiness Engineers' ) }
-					onClick={ trackSupportClick }
-				/>
+				<HelpButton label={ translate( 'Get help from our Happiness Engineers' ) } />
 			</JetpackConnectHappychatButton>
 		) }
 	</LoggedOutFormLinks>
@@ -56,8 +50,5 @@ export default connect(
 	},
 	{
 		trackDebugClick: withAnalytics( recordTracksEvent( 'calypso_jetpack_disconnect_debug_click' ) ),
-		trackSupportClick: withAnalytics(
-			recordTracksEvent( 'calypso_jetpack_disconnect_support_click' )
-		),
 	}
 )( localize( Troubleshoot ) );


### PR DESCRIPTION
The `JetpackConnectHelpButton` component is used in several places, some with the same a tracks event supplied by the handler, some without.

Move the tracks handling into the component so it is consistent across all usages and requires less code in the consumer.

![btn](https://user-images.githubusercontent.com/841763/39134490-0ae33a94-4717-11e8-9e0f-41926eb651a9.png)

## Testing
1. This component it used in several places. Verify that tracks events are fired as expected.
1. Try https://calypso.live/jetpack/connect/authorize?branch=update/jpc-helpbutton-tracks
1. `localStorage.debug = 'calypso:analytics:tracks'` and refresh
1. Click the help link.
1. You should see the tracks event `calypso_jpc_help_link_click` log in the console.

