### PR TITLE
Kraken: Disable domain suggestions `group_2` on NUX

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -755,8 +755,6 @@ class RegisterDomainStep extends React.Component {
 
 		const timestamp = Date.now();
 
-		searchVendor = this.props.isSignupStep ? 'group_2' : 'group_1';
-
 		const domainSuggestions = Promise.all( [
 			this.checkDomainAvailability( domain, timestamp ),
 			this.getDomainsSuggestions( domain, timestamp ),


### PR DESCRIPTION
As we've discussed - we'll rollback to `group_1` for both Calypso and NUX while we prepare for our next suggestion engines test.

Testing:
Open wordpress.com/start and on the domain screen check that the `vendor` parameter to the suggestions endpoint is `group_1`