### PR TITLE
On checkout page use submit button to indicate price calculation

### DIFF
--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -68,6 +68,8 @@ import { fetchSitesAndUser } from 'lib/signup/step-actions';
 import { loadTrackingTool } from 'state/analytics/actions';
 import { getProductsList, isProductsListFetching } from 'state/products-list/selectors';
 import QueryProducts from 'components/data/query-products-list';
+import { isRequestingSitePlans } from 'state/sites/plans/selectors';
+import { isRequestingPlans } from 'state/plans/selectors';
 
 class Checkout extends React.Component {
 	static propTypes = {
@@ -564,8 +566,10 @@ class Checkout extends React.Component {
 	isLoading() {
 		const isLoadingCart = ! this.props.cart.hasLoadedFromServer;
 		const isLoadingProducts = this.props.isProductsListFetching;
+		const isLoadingPlans = this.props.isPlansListFetching;
+		const isLoadingSitePlans = this.props.isSitePlansListFetching;
 
-		return isLoadingCart || isLoadingProducts;
+		return isLoadingCart || isLoadingProducts || isLoadingPlans || isLoadingSitePlans;
 	}
 
 	needsDomainDetails() {
@@ -622,6 +626,8 @@ export default connect(
 			),
 			productsList: getProductsList( state ),
 			isProductsListFetching: isProductsListFetching( state ),
+			isPlansListFetching: isRequestingPlans( state ),
+			isSitePlansListFetching: isRequestingSitePlans( state, selectedSiteId ),
 		};
 	},
 	{

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -483,9 +483,7 @@ class Checkout extends React.Component {
 					userCountryCode={ this.props.userCountryCode }
 				/>
 			);
-		} else if ( this.isLoading() || this.props.cart.hasPendingServerUpdates ) {
-			// hasPendingServerUpdates is an important check here as the content we display is dependent on the content of the cart
-
+		} else if ( this.isLoading() ) {
 			return <SecurePaymentFormPlaceholder />;
 		}
 

--- a/client/my-sites/checkout/checkout/pay-button.jsx
+++ b/client/my-sites/checkout/checkout/pay-button.jsx
@@ -128,7 +128,7 @@ class PayButton extends React.Component {
 	recalculating = () => {
 		return {
 			disabled: true,
-			text: this.props.translate( 'Recalculating' ),
+			text: this.props.translate( 'Calculating price' ),
 		};
 	};
 

--- a/client/my-sites/checkout/checkout/pay-button.jsx
+++ b/client/my-sites/checkout/checkout/pay-button.jsx
@@ -23,6 +23,10 @@ import {
 
 class PayButton extends React.Component {
 	buttonState = () => {
+		if ( this.isRecalculatingCart() ) {
+			return this.recalculating();
+		}
+
 		let state;
 
 		switch ( this.props.transactionStep.name ) {
@@ -121,6 +125,13 @@ class PayButton extends React.Component {
 		};
 	};
 
+	recalculating = () => {
+		return {
+			disabled: true,
+			text: this.props.translate( 'Recalculating' ),
+		};
+	};
+
 	sending = () => {
 		return {
 			disabled: true,
@@ -146,6 +157,10 @@ class PayButton extends React.Component {
 			text: text,
 		};
 	};
+
+	isRecalculatingCart() {
+		return this.props.cart.hasPendingServerUpdates;
+	}
 
 	render() {
 		const buttonState = this.buttonState();

--- a/client/my-sites/checkout/checkout/pay-button.jsx
+++ b/client/my-sites/checkout/checkout/pay-button.jsx
@@ -21,7 +21,7 @@ import {
 	SUBMITTING_WPCOM_REQUEST,
 } from 'lib/store-transactions/step-types';
 
-class PayButton extends React.Component {
+export class PayButton extends React.Component {
 	buttonState = () => {
 		if ( this.isRecalculatingCart() ) {
 			return this.recalculating();

--- a/client/my-sites/checkout/checkout/test/pay-button.js
+++ b/client/my-sites/checkout/checkout/test/pay-button.js
@@ -1,0 +1,57 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { identity } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { PayButton } from '../pay-button';
+import { BEFORE_SUBMIT } from 'lib/store-transactions/step-types';
+
+jest.mock( 'lib/cart-values', () => ( {
+	cartItems: {
+		hasOnlyFreeTrial: jest.fn( false ),
+		hasRenewalItem: jest.fn( false ),
+	},
+	isPaidForFullyInCredits: jest.fn( false ),
+} ) );
+
+describe( 'PaymentBox', () => {
+	const defaultProps = {
+		cart: {
+			total_cost_display: 125,
+		},
+		transactionStep: {
+			name: BEFORE_SUBMIT,
+			error: null,
+			data: {},
+		},
+		translate: identity,
+	};
+
+	test( 'should render', () => {
+		const wrapper = shallow( <PayButton { ...defaultProps } /> );
+		expect( wrapper.find( '.pay-button' ) ).toHaveLength( 1 );
+	} );
+
+	test( 'should not be busy by default', () => {
+		const wrapper = shallow( <PayButton { ...defaultProps } /> );
+		expect( wrapper.find( '.pay-button' ) ).toHaveLength( 1 );
+		expect( wrapper.find( 'Button' ).props().busy ).toBe( false );
+	} );
+
+	test( 'should be busy if cart has pending server updates', () => {
+		const wrapper = shallow(
+			<PayButton { ...defaultProps } cart={ { hasPendingServerUpdates: true } } />
+		);
+		expect( wrapper.find( 'Button' ).props().busy ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
Related to 2-year plans. When choosing a plan and going to checkout, the following picker appears:

<img width="745" alt="zrzut ekranu 2018-04-23 o 16 42 06" src="https://user-images.githubusercontent.com/205419/39134177-471aee18-4716-11e8-879c-0f69da9a5a9f.png">

Since, at the moment, Checkout page will show a placeholder whenever there is some async activity going in the cart, we get this unsettling transition after choosing another plan:

<img width="796" alt="zrzut ekranu 2018-04-23 o 16 44 46" src="https://user-images.githubusercontent.com/205419/39134218-61e1dad6-4716-11e8-8ebc-84ae8f578d26.png">

All the form fields remain filled, but this isn't the best UX anyway.

This PR makes use of the submit button to indicate price calculation:

<img width="738" alt="zrzut ekranu 2018-04-23 o 16 49 14" src="https://user-images.githubusercontent.com/205419/39134262-83e0a78e-4716-11e8-932a-bc70b31c864b.png">

Test plan:

1. Start server like `ENABLE_FEATURES=upgrades/2-year-plans npm run start`
1. Choose any plan
1. Switch to 2-year plan
1. Confirm that only submit button is updated in the process