### PR TITLE
Kraken: Switch to `group_2` for `en` locale only

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -34,7 +34,7 @@ import config from 'config';
 import wpcom from 'lib/wp';
 import Card from 'components/card';
 import Notice from 'components/notice';
-import { checkDomainAvailability, getFixedDomainSearch } from 'lib/domains';
+import { checkDomainAvailability, getFixedDomainSearch, clientMatchesLocales } from 'lib/domains';
 import { domainAvailability } from 'lib/domains/constants';
 import { getAvailabilityNotice } from 'lib/domains/registration/availability-messages';
 import SearchCard from 'components/search-card';
@@ -755,7 +755,8 @@ class RegisterDomainStep extends React.Component {
 
 		const timestamp = Date.now();
 
-		searchVendor = this.props.isSignupStep ? 'group_2' : 'group_1';
+		searchVendor =
+			this.props.isSignupStep && clientMatchesLocales( [ 'en' ] ) ? 'group_2' : 'group_1';
 
 		const domainSuggestions = Promise.all( [
 			this.checkDomainAvailability( domain, timestamp ),


### PR DESCRIPTION
We discovered that `group_2` works best for `en` locale users only. I've tried to make this work as close as possible to the `abtest` library, but I don't feel comfortable refactoring how the library works so it's more or less a code duplication.

Testing instructions:
Try that the `vendor` parameter is set to `group_2` if you're using an english locale on `/start/domain`. Then switch your locale to something else in the browser settings and try going through the NUX flow again. Now you should be assigned to`group_1`.