### PR TITLE
Add remaining time to text of domain maintenance to notices.

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -213,7 +213,11 @@ class MapDomainStep extends React.Component {
 					site = get( this.props, 'selectedSite.slug', null );
 				}
 
-				const { message, severity } = getAvailabilityNotice( domain, status, site );
+				const maintenanceEndTime = get( result, 'maintenance_end_time', null );
+				const { message, severity } = getAvailabilityNotice( domain, status, {
+					site,
+					maintenanceEndTime,
+				} );
 				this.setState( { notice: message, noticeSeverity: severity } );
 			}
 		);

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -544,7 +544,7 @@ class RegisterDomainStep extends React.Component {
 						this.props.analyticsSection
 					);
 
-					this.props.onDomainsAvailabilityChange( true, 0 );
+					this.props.onDomainsAvailabilityChange( true );
 					resolve( isDomainAvailable ? result : null );
 				}
 			);

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -235,7 +235,7 @@ class RegisterDomainStep extends React.Component {
 		const error = nextProps.defaultSuggestionsError;
 
 		if ( ! error ) {
-			return nextProps.onDomainsAvailabilityChange( true, 0 );
+			return nextProps.onDomainsAvailabilityChange( true );
 		}
 		if ( error && error.statusCode === 503 ) {
 			return nextProps.onDomainsAvailabilityChange(
@@ -573,7 +573,7 @@ class RegisterDomainStep extends React.Component {
 		return domains
 			.suggestions( query )
 			.then( domainSuggestions => {
-				this.props.onDomainsAvailabilityChange( true, 0 );
+				this.props.onDomainsAvailabilityChange( true );
 				const timeDiff = Date.now() - timestamp;
 				const analyticsResults = domainSuggestions.map( suggestion => suggestion.domain_name );
 
@@ -691,7 +691,7 @@ class RegisterDomainStep extends React.Component {
 	};
 
 	handleSubdomainSuggestions = ( domain, timestamp ) => subdomainSuggestions => {
-		this.props.onDomainsAvailabilityChange( true, 0 );
+		this.props.onDomainsAvailabilityChange( true );
 		const timeDiff = Date.now() - timestamp;
 		const analyticsResults = subdomainSuggestions.map( suggestion => suggestion.domain_name );
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -716,7 +716,7 @@ class RegisterDomainStep extends React.Component {
 		const timeDiff = Date.now() - timestamp;
 
 		if ( error && error.statusCode === 503 ) {
-			this.props.onDomainsAvailabilityChange( false, 0 );
+			this.props.onDomainsAvailabilityChange( false );
 		} else if ( error && error.error ) {
 			this.showValidationErrorMessage( domain, error.error );
 		}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -589,10 +589,13 @@ class RegisterDomainStep extends React.Component {
 			} )
 			.catch( error => {
 				const timeDiff = Date.now() - timestamp;
-				if ( error && error.statusCode === 503 ) {
-					this.props.onDomainsAvailabilityChange( false, 0 );
+				if ( error && error.statusCode === 503 && ! this.props.isSignupStep ) {
+					const maintenanceEndTime = get( error, 'data.maintenance_end_time', 0 );
+					this.props.onDomainsAvailabilityChange( false, maintenanceEndTime );
 				} else if ( error && error.error ) {
-					this.showValidationErrorMessage( domain, error.error );
+					this.showValidationErrorMessage( domain, error.error, {
+						maintenanceEndTime: get( error, 'data.maintenance_end_time', null ),
+					} );
 				}
 
 				const analyticsResults = [

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -468,7 +468,11 @@ class TransferDomainStep extends React.Component {
 								site = get( this.props, 'selectedSite.slug', null );
 							}
 
-							const { message, severity } = getAvailabilityNotice( domain, status, site );
+							const maintenanceEndTime = get( result, 'maintenance_end_time', null );
+							const { message, severity } = getAvailabilityNotice( domain, status, {
+								site,
+								maintenanceEndTime,
+							} );
 							this.setState( { notice: message, noticeSeverity: severity } );
 					}
 

--- a/client/lib/domains/assembler.js
+++ b/client/lib/domains/assembler.js
@@ -48,6 +48,7 @@ export function createDomainObjects( dataTransferObject ) {
 			registrar: domain.registrar,
 			registrationMoment: domain.registration_date && i18n.moment( domain.registration_date ),
 			subscriptionId: domain.subscription_id,
+			tldMaintenanceEndTime: domain.tld_maintenance_end_time,
 			transferLockOnWhoisUpdateOptional: domain.transfer_lock_on_whois_update_optional,
 			type: getDomainType( domain ),
 			transferStatus: getTransferStatus( domain ),

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -5,6 +5,8 @@
  */
 import React from 'react';
 import { translate } from 'i18n-calypso';
+import { get } from 'lodash';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -22,11 +24,14 @@ import {
 	domainTransferIn,
 } from 'my-sites/domains/paths';
 
-function getAvailabilityNotice( domain, error, site ) {
+function getAvailabilityNotice( domain, error, errorData ) {
 	let message,
 		severity = 'error';
 
 	const tld = getTld( domain );
+
+	const site = get( errorData, 'site', null );
+	const maintenanceEndTime = get( errorData, 'maintenanceEndTime', null );
 
 	switch ( error ) {
 		case domainAvailability.REGISTERED:
@@ -146,10 +151,20 @@ function getAvailabilityNotice( domain, error, site ) {
 			break;
 		case domainAvailability.MAINTENANCE:
 			if ( tld ) {
+				let maintenanceEnd = translate( 'shortly', {
+					context: 'If a specific maintenance end time is unavailable, we will show this instead.',
+				} );
+				if ( maintenanceEndTime ) {
+					maintenanceEnd = moment.unix( maintenanceEndTime ).fromNow();
+				}
+
 				message = translate(
-					'Domains ending with {{strong}}.%(tld)s{{/strong}} are undergoing maintenance. Please check back shortly.',
+					'Domains ending with {{strong}}.%(tld)s{{/strong}} are undergoing maintenance. Please check back %(maintenanceEnd)s.',
 					{
-						args: { tld },
+						args: {
+							tld,
+							maintenanceEnd,
+						},
 						components: {
 							strong: <strong />,
 						},

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -157,7 +157,8 @@ function getAvailabilityNotice( domain, error, errorData ) {
 				}
 
 				message = translate(
-					'Domains ending with {{strong}}.%(tld)s{{/strong}} are undergoing maintenance. Please check back %(maintenanceEnd)s.',
+					'Domains ending with {{strong}}.%(tld)s{{/strong}} are undergoing maintenance. Please ' +
+						'try a different extension or check back %(maintenanceEnd)s.',
 					{
 						args: {
 							tld,

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -5,7 +5,6 @@
  */
 import React from 'react';
 import { translate } from 'i18n-calypso';
-import { get } from 'lodash';
 import moment from 'moment';
 
 /**
@@ -30,8 +29,7 @@ function getAvailabilityNotice( domain, error, errorData ) {
 
 	const tld = getTld( domain );
 
-	const site = get( errorData, 'site', null );
-	const maintenanceEndTime = get( errorData, 'maintenanceEndTime', null );
+	const { site, maintenanceEndTime } = errorData;
 
 	switch ( error ) {
 		case domainAvailability.REGISTERED:
@@ -152,7 +150,7 @@ function getAvailabilityNotice( domain, error, errorData ) {
 		case domainAvailability.MAINTENANCE:
 			if ( tld ) {
 				let maintenanceEnd = translate( 'shortly', {
-					context: 'If a specific maintenance end time is unavailable, we will show this instead.',
+					comment: 'If a specific maintenance end time is unavailable, we will show this instead.',
 				} );
 				if ( maintenanceEndTime ) {
 					maintenanceEnd = moment.unix( maintenanceEndTime ).fromNow();
@@ -173,9 +171,26 @@ function getAvailabilityNotice( domain, error, errorData ) {
 				severity = 'info';
 			}
 			break;
+		case domainAvailability.PURCHASES_DISABLED:
+			let maintenanceEnd = translate( 'shortly', {
+				comment: 'If a specific maintenance end time is unavailable, we will show this instead.',
+			} );
+			if ( maintenanceEndTime ) {
+				maintenanceEnd = moment.unix( maintenanceEndTime ).fromNow();
+			}
+
+			message = translate(
+				'Domains registration is unavailable at this time. Please select a free WordPress.com ' +
+					'domain or check back %(maintenanceEnd)s.',
+				{
+					args: { maintenanceEnd },
+				}
+			);
+			severity = 'info';
+			break;
+
 		case domainAvailability.MAPPABLE:
 		case domainAvailability.AVAILABLE:
-		case domainAvailability.PURCHASES_DISABLED:
 		case domainAvailability.TLD_NOT_SUPPORTED:
 		case domainAvailability.UNKNOWN:
 		case domainAvailability.EMPTY_RESULTS:

--- a/client/lib/domains/test/assembler.js
+++ b/client/lib/domains/test/assembler.js
@@ -57,6 +57,7 @@ describe( 'assembler', () => {
 			registrar: undefined,
 			registrationMoment: undefined,
 			subscriptionId: undefined,
+			tldMaintenanceEndTime: undefined,
 			transferLockOnWhoisUpdateOptional: undefined,
 			transferStatus: null,
 			type: domainTypes.SITE_REDIRECT,

--- a/client/my-sites/domains/domain-management/components/domain/maintenance-card.jsx
+++ b/client/my-sites/domains/domain-management/components/domain/maintenance-card.jsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -13,8 +14,23 @@ import { localize } from 'i18n-calypso';
 import { getTld } from 'lib/domains';
 import EmptyContent from 'components/empty-content';
 
-const MaintenanceCard = ( { selectedDomainName, translate } ) => {
+const MaintenanceCard = ( { selectedDomainName, translate, tldMaintenanceEndTime } ) => {
 	const tld = getTld( selectedDomainName );
+
+	let maintenanceEnd = translate( 'shortly', {
+		comment: 'If a specific maintenance end time is unavailable, we will show this instead.',
+	} );
+
+	if ( tldMaintenanceEndTime ) {
+		maintenanceEnd = moment.unix( tldMaintenanceEndTime ).fromNow();
+	}
+
+	const message = translate(
+		'No changes are allowed during that time. Please check back %(maintenanceEnd)s.',
+		{
+			args: { maintenanceEnd },
+		}
+	);
 
 	return (
 		<EmptyContent
@@ -22,7 +38,7 @@ const MaintenanceCard = ( { selectedDomainName, translate } ) => {
 				components: { strong: <strong /> },
 				args: { tld },
 			} ) }
-			line={ translate( 'No changes are allowed during that time. Please check back shortly.' ) }
+			line={ message }
 			illustration={ '/calypso/images/illustrations/whoops.svg' }
 		/>
 	);

--- a/client/my-sites/domains/domain-management/edit/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/index.jsx
@@ -73,7 +73,12 @@ class Edit extends React.Component {
 		const { REGISTERED, TRANSFER } = domainTypes;
 
 		if ( includes( [ REGISTERED, TRANSFER ], domain.type ) && domain.registrar === MAINTENANCE ) {
-			return <MaintenanceCard { ...Object.assign( {}, this.props, domain ) } />;
+			return (
+				<MaintenanceCard
+					selectedDomainName={ this.props.selectedDomainName }
+					tldMaintenanceEndTime={ domain.tldMaintenanceEndTime }
+				/>
+			);
 		}
 
 		return (

--- a/client/my-sites/domains/domain-management/edit/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/index.jsx
@@ -73,7 +73,7 @@ class Edit extends React.Component {
 		const { REGISTERED, TRANSFER } = domainTypes;
 
 		if ( includes( [ REGISTERED, TRANSFER ], domain.type ) && domain.registrar === MAINTENANCE ) {
-			return <MaintenanceCard { ...this.props } />;
+			return <MaintenanceCard { ...Object.assign( {}, this.props, domain ) } />;
 		}
 
 		return (

--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -46,7 +46,7 @@ class DomainSearch extends Component {
 		domainRegistrationMaintenanceEndTime: null,
 	};
 
-	handleDomainsAvailabilityChange = ( isAvailable, maintenanceEndTime ) => {
+	handleDomainsAvailabilityChange = ( isAvailable, maintenanceEndTime = null ) => {
 		this.setState( {
 			domainRegistrationAvailable: isAvailable,
 			domainRegistrationMaintenanceEndTime: maintenanceEndTime,

--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -42,10 +43,14 @@ class DomainSearch extends Component {
 
 	state = {
 		domainRegistrationAvailable: true,
+		domainRegistrationMaintenanceEndTime: null,
 	};
 
-	handleDomainsAvailabilityChange = isAvailable => {
-		this.setState( { domainRegistrationAvailable: isAvailable } );
+	handleDomainsAvailabilityChange = ( isAvailable, maintenanceEndTime ) => {
+		this.setState( {
+			domainRegistrationAvailable: isAvailable,
+			domainRegistrationMaintenanceEndTime: maintenanceEndTime,
+		} );
 	};
 
 	handleAddRemoveDomain = suggestion => {
@@ -111,18 +116,30 @@ class DomainSearch extends Component {
 	}
 
 	render() {
-		const { selectedSite, selectedSiteSlug, translate } = this.props,
-			classes = classnames( 'main-column', {
-				'domain-search-page-wrapper': this.state.domainRegistrationAvailable,
-			} );
+		const { selectedSite, selectedSiteSlug, translate } = this.props;
+		const classes = classnames( 'main-column', {
+			'domain-search-page-wrapper': this.state.domainRegistrationAvailable,
+		} );
+		const { domainRegistrationMaintenanceEndTime } = this.state;
 		let content;
 
 		if ( ! this.state.domainRegistrationAvailable ) {
+			let maintenanceEndTime = translate( 'shortly', {
+				context: 'If a specific maintenance end time is unavailable, we will show this instead.',
+			} );
+			if ( domainRegistrationMaintenanceEndTime ) {
+				maintenanceEndTime = moment.unix( domainRegistrationMaintenanceEndTime ).fromNow();
+			}
+
 			content = (
 				<EmptyContent
 					illustration="/calypso/images/illustrations/error.svg"
 					title={ translate( 'Domain registration is unavailable' ) }
-					line={ translate( "We're hard at work on the issue. Please check back shortly." ) }
+					line={ translate( "We're hard at work on the issue. Please check back %(timePeriod)s.", {
+						args: {
+							timePeriod: maintenanceEndTime,
+						},
+					} ) }
 					action={ translate( 'Back to Plans' ) }
 					actionURL={ '/plans/' + selectedSiteSlug }
 				/>

--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -125,7 +125,7 @@ class DomainSearch extends Component {
 
 		if ( ! this.state.domainRegistrationAvailable ) {
 			let maintenanceEndTime = translate( 'shortly', {
-				context: 'If a specific maintenance end time is unavailable, we will show this instead.',
+				comment: 'If a specific maintenance end time is unavailable, we will show this instead.',
 			} );
 			if ( domainRegistrationMaintenanceEndTime ) {
 				maintenanceEndTime = moment.unix( domainRegistrationMaintenanceEndTime ).fromNow();


### PR DESCRIPTION
Dependent on D12192-code.

Use instructions in diff to hack maintenance events and make sure that TLD and domain purchase notices are shown with appropriate times (when available).

When a all purchases are disabled, you should see this message:

<img width="737" alt="domain_search_ _a8c_test_site_ _wordpress_com" src="https://user-images.githubusercontent.com/1379730/39155894-e68d3d38-4721-11e8-87c5-c838c01c7590.png">

When a TLD is under maintenance, you should see a notice like this:

<img width="742" alt="domain_search_ _a8c_test_site_ _wordpress_com" src="https://user-images.githubusercontent.com/1379730/39155929-0b0012da-4722-11e8-9c90-98b452aba4db.png">
