### PR TITLE
2 year plans: remove hardcoded constants from products-values

### DIFF
--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -26,12 +26,9 @@ import {
 	GROUP_JETPACK,
 } from 'lib/plans/constants';
 
-import { isBusinessPlan, isPremiumPlan, isPersonalPlan } from 'lib/plans';
-
+import { planMatches, isBusinessPlan, isPremiumPlan, isPersonalPlan } from 'lib/plans';
 import { domainProductSlugs } from 'lib/domains/constants';
-
 import schema from './schema.json';
-import { planMatches } from '../plans';
 
 const productDependencies = {
 	domain: {

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -9,7 +9,6 @@ import { assign, difference, get, isEmpty, pick } from 'lodash';
  * Internal dependencies
  */
 import {
-	JETPACK_PLANS,
 	PLAN_BUSINESS,
 	PLAN_BUSINESS_2_YEARS,
 	PLAN_PREMIUM,
@@ -18,22 +17,21 @@ import {
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_FREE,
 	PLAN_JETPACK_FREE,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PERSONAL_MONTHLY,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
 	PLAN_HOST_BUNDLE,
 	PLAN_WPCOM_ENTERPRISE,
 	PLAN_CHARGEBACK,
 	PLAN_MONTHLY_PERIOD,
 	PLAN_ANNUAL_PERIOD,
 	PLAN_BIENNIAL_PERIOD,
+	GROUP_JETPACK,
 } from 'lib/plans/constants';
+
+import { isBusinessPlan, isPremiumPlan, isPersonalPlan } from 'lib/plans';
+
 import { domainProductSlugs } from 'lib/domains/constants';
 
 import schema from './schema.json';
+import { planMatches } from '../plans';
 
 const productDependencies = {
 	domain: {
@@ -124,30 +122,24 @@ export function isFreeTrial( product ) {
 }
 
 export function isPersonal( product ) {
-	const personalProducts = [ PLAN_PERSONAL, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ];
-
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return personalProducts.indexOf( product.product_slug ) >= 0;
+	return isPersonalPlan( product.product_slug );
 }
 
 export function isPremium( product ) {
-	const premiumProducts = [ PLAN_PREMIUM, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ];
-
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return premiumProducts.indexOf( product.product_slug ) >= 0;
+	return isPremiumPlan( product.product_slug );
 }
 
 export function isBusiness( product ) {
-	const businessProducts = [ PLAN_BUSINESS, PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY ];
-
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return businessProducts.indexOf( product.product_slug ) >= 0;
+	return isBusinessPlan( product.product_slug );
 }
 
 export function isEnterprise( product ) {
@@ -161,7 +153,7 @@ export function isJetpackPlan( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return JETPACK_PLANS.indexOf( product.product_slug ) >= 0;
+	return planMatches( product.product_slug, { group: GROUP_JETPACK } );
 }
 
 export function isJetpackBusiness( product ) {

--- a/client/lib/products-values/test/index.js
+++ b/client/lib/products-values/test/index.js
@@ -7,13 +7,30 @@
 /**
  * Internal dependencies
  */
-import { isJetpackPlan, isMonthly, isYearly, isBiennially } from '..';
+import {
+	isJetpackPlan,
+	isMonthly,
+	isYearly,
+	isBiennially,
+	isPersonal,
+	isPremium,
+	isBusiness,
+} from '..';
 import {
 	JETPACK_PLANS,
-	PLAN_BUSINESS,
 	PLAN_FREE,
 	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
 	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from 'lib/plans/constants';
 
 /**
@@ -37,6 +54,48 @@ describe( 'isJetpackPlan', () => {
 		nonJetpackPlans
 			.map( makeProductFromSlug )
 			.forEach( product => expect( isJetpackPlan( product ) ).toBe( false ) );
+	} );
+} );
+
+describe( 'isPersonal', () => {
+	test( 'should return true for personal products', () => {
+		[ PLAN_PERSONAL, PLAN_PERSONAL_2_YEARS, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ]
+			.map( makeProductFromSlug )
+			.forEach( product => expect( isPersonal( product ) ).toBe( true ) );
+	} );
+
+	test( 'should return false for non-personal products', () => {
+		[ PLAN_BUSINESS, PLAN_JETPACK_PREMIUM ]
+			.map( makeProductFromSlug )
+			.forEach( product => expect( isPersonal( product ) ).toBe( false ) );
+	} );
+} );
+
+describe( 'isPremium', () => {
+	test( 'should return true for premium products', () => {
+		[ PLAN_PREMIUM, PLAN_PREMIUM_2_YEARS, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ]
+			.map( makeProductFromSlug )
+			.forEach( product => expect( isPremium( product ) ).toBe( true ) );
+	} );
+
+	test( 'should return false for non-premium products', () => {
+		[ PLAN_BUSINESS, PLAN_JETPACK_PERSONAL ]
+			.map( makeProductFromSlug )
+			.forEach( product => expect( isPremium( product ) ).toBe( false ) );
+	} );
+} );
+
+describe( 'isBusiness', () => {
+	test( 'should return true for business products', () => {
+		[ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS, PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY ]
+			.map( makeProductFromSlug )
+			.forEach( product => expect( isBusiness( product ) ).toBe( true ) );
+	} );
+
+	test( 'should return false for non-business products', () => {
+		[ PLAN_PREMIUM, PLAN_JETPACK_PERSONAL ]
+			.map( makeProductFromSlug )
+			.forEach( product => expect( isBusiness( product ) ).toBe( false ) );
 	} );
 } );
 


### PR DESCRIPTION
This PR removes usage of `PLAN_*` constants from `products-values`

Since we are adding new `2_YEAR` plan constants (p9jf6J-eR-p2), this is a good opportunity to refactor relevant places such as this one instead of just adding another constant to every if.

Test plan:
* Run unit tests, that's it