### PR TITLE
Remove domain term from cart for bundled domains

### DIFF
--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -11,6 +11,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { isEnabled } from 'config';
 import { canRemoveFromCart, cartItems } from 'lib/cart-values';
 import {
 	isCredits,
@@ -21,6 +22,7 @@ import {
 	isBiennially,
 	isPlan,
 	isBundled,
+	isDomainProduct,
 } from 'lib/products-values';
 import { currentUserHasFlag } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
@@ -197,6 +199,15 @@ export class CartItem extends React.Component {
 
 	getSubscriptionLength() {
 		const { cartItem, translate } = this.props;
+		if (
+			isEnabled( 'upgrades/2-year-plans' ) &&
+			isDomainProduct( cartItem ) &&
+			isBundled( cartItem ) &&
+			cartItem.cost === 0
+		) {
+			return false;
+		}
+
 		const hasBillPeriod = cartItem.bill_period && parseInt( cartItem.bill_period ) !== -1;
 		if ( ! hasBillPeriod ) {
 			return false;

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -122,9 +122,11 @@ export class CartItem extends React.Component {
 		if ( cartItem && cartItem.product_cost ) {
 			return (
 				<span>
-					<span className="cart__free-with-plan">
-						{ cartItem.product_cost } { cartItem.currency }
-					</span>
+					{ ! ( isEnabled( 'upgrades/2-year-plans' ) && this.isDomainProductDiscountedTo0() ) ? (
+						<span className="cart__free-with-plan">
+							{ cartItem.product_cost } { cartItem.currency }
+						</span>
+					) : null }
 					<span className="cart__free-text">{ translate( 'Free with your plan' ) }</span>
 				</span>
 			);
@@ -199,12 +201,7 @@ export class CartItem extends React.Component {
 
 	getSubscriptionLength() {
 		const { cartItem, translate } = this.props;
-		if (
-			isEnabled( 'upgrades/2-year-plans' ) &&
-			isDomainProduct( cartItem ) &&
-			isBundled( cartItem ) &&
-			cartItem.cost === 0
-		) {
+		if ( isEnabled( 'upgrades/2-year-plans' ) && this.isDomainProductDiscountedTo0() ) {
 			return false;
 		}
 
@@ -222,6 +219,11 @@ export class CartItem extends React.Component {
 		}
 
 		return false;
+	}
+
+	isDomainProductDiscountedTo0() {
+		const { cartItem } = this.props;
+		return isDomainProduct( cartItem ) && isBundled( cartItem ) && cartItem.cost === 0;
 	}
 
 	getProductName() {

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -60,6 +60,10 @@
 			padding-left: 8px;
 		}
 
+		.cart__free-text:first-child {
+			padding-left: 0;
+		}
+
 		.product-monthly-price {
 			color: $gray;
 			display: block;

--- a/client/my-sites/checkout/cart/test/cart-item.js
+++ b/client/my-sites/checkout/cart/test/cart-item.js
@@ -13,8 +13,16 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import { CartItem } from '../cart-item';
-import { isPlan, isMonthly, isYearly, isBiennially } from 'lib/products-values';
+import {
+	isPlan,
+	isMonthly,
+	isYearly,
+	isBiennially,
+	isBundled,
+	isDomainProduct,
+} from 'lib/products-values';
 import {
 	PLAN_BUSINESS_2_YEARS,
 	PLAN_JETPACK_PERSONAL,
@@ -33,6 +41,11 @@ const mockPlansModule = () => {
 };
 mockPlansModule();
 
+jest.mock( 'config', () => {
+	const fn = () => {};
+	fn.isEnabled = jest.fn( () => null );
+	return fn;
+} );
 jest.mock( 'lib/format-currency', () => jest.fn() );
 jest.mock( 'lib/mixins/analytics', () => ( {} ) );
 jest.mock( 'lib/products-values', () => ( {
@@ -42,6 +55,7 @@ jest.mock( 'lib/products-values', () => ( {
 	isYearly: jest.fn( () => null ),
 	isBiennially: jest.fn( () => null ),
 	isBundled: jest.fn( () => null ),
+	isDomainProduct: jest.fn( () => null ),
 	isCredits: jest.fn( () => null ),
 	isGoogleApps: jest.fn( () => null ),
 } ) );
@@ -235,6 +249,39 @@ describe( 'cart-item', () => {
 				},
 			} );
 			expect( () => instance.calcMonthlyBillingDetails() ).toThrowError();
+		} );
+	} );
+
+	describe( 'getSubscriptionLength() - bundled domains', () => {
+		beforeAll( () => {
+			isMonthly.mockImplementation( () => false );
+			isYearly.mockImplementation( () => true );
+			isBiennially.mockImplementation( () => false );
+		} );
+
+		const instance = new CartItem( { ...props, cartItem: { cost: 0, bill_period: 1 } } );
+
+		test( 'Returns false for bundled domains - if 2 year plans are enabled', () => {
+			isEnabled.mockImplementation( () => true );
+			isDomainProduct.mockImplementation( () => true );
+			isBundled.mockImplementation( () => true );
+			expect( instance.getSubscriptionLength() ).toEqual( false );
+		} );
+
+		test( 'Returns "annual subscription" for non-bundled domains - if 2 year plans are enabled', () => {
+			isEnabled.mockImplementation( () => true );
+			isDomainProduct.mockImplementation( () => true );
+			isBundled.mockImplementation( () => false );
+
+			expect( instance.getSubscriptionLength() ).toEqual( 'annual subscription' );
+		} );
+
+		test( 'Returns "annual subscription" for bundled domains - if 2 year plans are disabled', () => {
+			isEnabled.mockImplementation( () => false );
+			isDomainProduct.mockImplementation( () => true );
+			isBundled.mockImplementation( () => true );
+
+			expect( instance.getSubscriptionLength() ).toEqual( 'annual subscription' );
 		} );
 	} );
 


### PR DESCRIPTION
After switching to a 2-year plan, users are confused why domain remains described as "annual". Since bundled domains are "free" anyway, it makes most sense to remove "annual subscription" for them altogether. Note that for non-bundled domains we still keep it in place.

Test plan:
1. Start server like `ENABLE_FEATURES=upgrades/2-year-plans npm run start`
1. Put yourself in the `show` group of `multiyearSubscriptions` AB test
1. Order any plan with a domain
1. On checkout page confirm that domain has no subscription term information, just like that:

<img width="271" alt="zrzut ekranu 2018-04-27 o 13 49 37" src="https://user-images.githubusercontent.com/205419/39361256-e4fe5e18-4a21-11e8-8e23-49c4cba364e4.png">

1. Switch to 2-year plan and confirm it looks the same
1. Order domain separately, confirm that in checkout it looks like this:

<img width="276" alt="zrzut ekranu 2018-04-24 o 11 41 05" src="https://user-images.githubusercontent.com/205419/39179349-6244c0bc-47b4-11e8-8610-512685bb3c0b.png">
