### PR TITLE
JP Remote Install: Change Tracks prop name

### DIFF
--- a/client/state/data-layer/wpcom/jetpack-install/index.js
+++ b/client/state/data-layer/wpcom/jetpack-install/index.js
@@ -49,7 +49,7 @@ export const handleError = ( action, error ) => {
 		recordTracksEvent( 'calypso_jpc_remoteinstall_api_fail', {
 			url,
 			error: error.error,
-			message: error.message,
+			error_message: error.message,
 			status: error.status,
 		} )
 	);


### PR DESCRIPTION
Prop named 'message' was not being recorded, likely due to the name. Change to 'error_message'.

**Before**
<img width="899" alt="screen shot 2018-04-24 at 11 34 36" src="https://user-images.githubusercontent.com/7767559/39184626-ffdf86c0-47bb-11e8-918e-469e149884ac.png">

**After**
<img width="927" alt="screen shot 2018-04-24 at 12 35 16" src="https://user-images.githubusercontent.com/7767559/39184630-04f7697a-47bc-11e8-917d-2265878c2567.png">
