### PR TITLE
Podcasting: add email field to settings page

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -80,12 +80,13 @@ class PodcastingDetails extends Component {
 		);
 	}
 
-	renderTextField( { FormComponent = FormInput, key, label } ) {
+	renderTextField( { FormComponent = FormInput, key, label, explanation } ) {
 		const { fields, isRequestingSettings, onChangeField, isPodcastingEnabled } = this.props;
 
 		return (
 			<FormFieldset>
 				<FormLabel htmlFor={ key }>{ label }</FormLabel>
+				{ explanation && <FormSettingExplanation>{ explanation }</FormSettingExplanation> }
 				<FormComponent
 					id={ key }
 					name={ key }
@@ -224,6 +225,13 @@ class PodcastingDetails extends Component {
 							FormComponent: FormTextarea,
 							key: 'podcasting_summary',
 							label: translate( 'Summary' ),
+						} ) }
+						{ this.renderTextField( {
+							key: 'podcasting_email',
+							label: translate( 'Email Address' ),
+							explanation: translate(
+								'This email address will be displayed in the feed and is required for some services such as Google Play.'
+							),
 						} ) }
 						{ this.renderTextField( {
 							key: 'podcasting_copyright',


### PR DESCRIPTION
This PR adds a field for the email address to the Podcasting Settings page (Site Settings -> Writing -> Podcasting Settings).

![image](https://user-images.githubusercontent.com/363749/39184548-5ba2ad62-4789-11e8-8320-b2d01e2e8027.png)

To test:
* Run this branch with the `manage/site-settings/podcasting` feature-flag enabled (enabled by default in dev)
* Sandbox the API and make sure that D10933-code is applied.
* Visit the Podcasting Settings page. Verify that if you enter an email address, it is persisted.