### PR TITLE
Signup: Hide 'Start with Free' button if a Domain has been selected

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -37,7 +37,6 @@ import SegmentedControlItem from 'components/segmented-control/item';
 import PlanFooter from 'blocks/plan-footer';
 import HappychatConnection from 'components/happychat/connection-connected';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
-import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { selectSiteId as selectHappychatSiteId } from 'state/help/actions';
 
@@ -176,7 +175,7 @@ export class PlansFeaturesMain extends Component {
 	};
 
 	render() {
-		const { domainName, site, displayJetpackPlans, isInSignup, isLoggedIn } = this.props;
+		const { domainName, site, displayJetpackPlans, hideFreePlan, isInSignup } = this.props;
 		let faqs = null;
 
 		if ( ! isInSignup ) {
@@ -193,8 +192,11 @@ export class PlansFeaturesMain extends Component {
 				{ this.getPlanFeatures() }
 				<PlanFooter isInSignup={ isInSignup } isJetpack={ displayJetpackPlans } />
 				{ faqs }
-				{ isInSignup &&
-					! isLoggedIn &&
+				{ /* The `hideFreePlan` means that we want to hide the Free Plan Info Column.
+				   * In most cases, we want to show the 'Start with Free' PlansSkipButton instead --
+				   * unless we've already selected an option that implies a paid plan.
+				   * This is in particular true for domain names. */
+				hideFreePlan &&
 					! domainName && <PlansSkipButton onClick={ this.handleFreePlanButtonClick } /> }
 			</div>
 		);
@@ -209,7 +211,6 @@ PlansFeaturesMain.propTypes = {
 	isChatAvailable: PropTypes.bool,
 	isInSignup: PropTypes.bool,
 	isLandingPage: PropTypes.bool,
-	isLoggedIn: PropTypes.bool,
 	onUpgradeClick: PropTypes.func,
 	selectedFeature: PropTypes.string,
 	selectedPlan: PropTypes.string,
@@ -223,7 +224,6 @@ PlansFeaturesMain.defaultProps = {
 	hideFreePlan: false,
 	intervalType: 'yearly',
 	isChatAvailable: false,
-	isLoggedIn: false,
 	showFAQ: true,
 	site: {},
 	siteSlug: '',
@@ -232,7 +232,6 @@ PlansFeaturesMain.defaultProps = {
 export default connect(
 	( state, { site } ) => ( {
 		isChatAvailable: isHappychatAvailable( state ),
-		isLoggedIn: !! getCurrentUserId( state ),
 		siteSlug: getSiteSlug( state, get( site, [ 'ID' ] ) ),
 	} ),
 	{ selectHappychatSiteId }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -176,7 +176,7 @@ export class PlansFeaturesMain extends Component {
 	};
 
 	render() {
-		const { site, displayJetpackPlans, isInSignup, isLoggedIn } = this.props;
+		const { domainName, site, displayJetpackPlans, isInSignup, isLoggedIn } = this.props;
 		let faqs = null;
 
 		if ( ! isInSignup ) {
@@ -194,7 +194,8 @@ export class PlansFeaturesMain extends Component {
 				<PlanFooter isInSignup={ isInSignup } isJetpack={ displayJetpackPlans } />
 				{ faqs }
 				{ isInSignup &&
-					! isLoggedIn && <PlansSkipButton onClick={ this.handleFreePlanButtonClick } /> }
+					! isLoggedIn &&
+					! domainName && <PlansSkipButton onClick={ this.handleFreePlanButtonClick } /> }
 			</div>
 		);
 	}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -37,6 +37,7 @@ import SegmentedControlItem from 'components/segmented-control/item';
 import PlanFooter from 'blocks/plan-footer';
 import HappychatConnection from 'components/happychat/connection-connected';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
+import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { selectSiteId as selectHappychatSiteId } from 'state/help/actions';
 
@@ -175,7 +176,7 @@ export class PlansFeaturesMain extends Component {
 	};
 
 	render() {
-		const { domainName, site, displayJetpackPlans, hideFreePlan, isInSignup } = this.props;
+		const { domainName, site, displayJetpackPlans, isInSignup, isLoggedIn } = this.props;
 		let faqs = null;
 
 		if ( ! isInSignup ) {
@@ -192,11 +193,8 @@ export class PlansFeaturesMain extends Component {
 				{ this.getPlanFeatures() }
 				<PlanFooter isInSignup={ isInSignup } isJetpack={ displayJetpackPlans } />
 				{ faqs }
-				{ /* The `hideFreePlan` means that we want to hide the Free Plan Info Column.
-				   * In most cases, we want to show the 'Start with Free' PlansSkipButton instead --
-				   * unless we've already selected an option that implies a paid plan.
-				   * This is in particular true for domain names. */
-				hideFreePlan &&
+				{ isInSignup &&
+					! isLoggedIn &&
 					! domainName && <PlansSkipButton onClick={ this.handleFreePlanButtonClick } /> }
 			</div>
 		);
@@ -211,6 +209,7 @@ PlansFeaturesMain.propTypes = {
 	isChatAvailable: PropTypes.bool,
 	isInSignup: PropTypes.bool,
 	isLandingPage: PropTypes.bool,
+	isLoggedIn: PropTypes.bool,
 	onUpgradeClick: PropTypes.func,
 	selectedFeature: PropTypes.string,
 	selectedPlan: PropTypes.string,
@@ -224,6 +223,7 @@ PlansFeaturesMain.defaultProps = {
 	hideFreePlan: false,
 	intervalType: 'yearly',
 	isChatAvailable: false,
+	isLoggedIn: false,
 	showFAQ: true,
 	site: {},
 	siteSlug: '',
@@ -232,6 +232,7 @@ PlansFeaturesMain.defaultProps = {
 export default connect(
 	( state, { site } ) => ( {
 		isChatAvailable: isHappychatAvailable( state ),
+		isLoggedIn: !! getCurrentUserId( state ),
 		siteSlug: getSiteSlug( state, get( site, [ 'ID' ] ) ),
 	} ),
 	{ selectHappychatSiteId }


### PR DESCRIPTION
As pointed out to me by @lucasartoni via DM, I broke this with #24333.

This PR adds a criterion that checks whether we've selected a domain to the conditional that shows or hides the 'Start with Free' button.

### To repro:
* In a fresh incognito window, navigate to https://wordpress.com/start/
* Click on 'Proceed' to get to the Domain step
* Enter some random domain, and pick a non-free option from the list (e.g. a `.blog` one)
* Landing at https://wordpress.com/start/plans, you'll see a screen like the following:

![image](https://user-images.githubusercontent.com/96308/39187752-643aadf4-47ce-11e8-82a2-508787e57dd5.png)

Note the 'Start with Free' button -- which doesn't make sense here, since we already picked a non-free domain.

Now follow the same steps as above with this branch (using `calypso.localhost:3000` instead of wordpress.com, obviously :wink: Verify that the button is no longer shown:

![image](https://user-images.githubusercontent.com/96308/39187900-c0dcc970-47ce-11e8-8239-10b84588c940.png)

Furthermore, go thru the flow, this time selecting a free `.wordpress.com` subdomain. Verify that in this case, the 'Start with Free' button is still visible.

Finally, verify that other places that involve a Plans page still work as before, such as the logged-in one at calypso.localhost:3000/plans, or the one that's shown to the user during Jetpack Connect.