### PR TITLE
SiteAddressChanger: Fix height issue in small viewports

### DIFF
--- a/client/blocks/simple-site-rename-form/style.scss
+++ b/client/blocks/simple-site-rename-form/style.scss
@@ -23,7 +23,7 @@
 
 .simple-site-rename-form__info {
 	color: $gray-text-min;
-	flex-basis: 400px;
+	width: 400px;
 	flex-shrink: 1;
 	margin: 5px 0 0 0;
 	padding: 0;


### PR DESCRIPTION
### Summary

While developing the `SiteAddressChanger` I mistakenly used `flex-basis` for the width of the component. The problem is, in smaller screen sizes/viewports the `flex-direction` switches to vertical and so the `flex-basis` effects the vertical height.

<img width="613" alt="screen shot 2018-04-23 at 13 25 23" src="https://user-images.githubusercontent.com/4335450/39187397-1c4dc39a-47c5-11e8-9672-41d29051cc93.png">

This PR fixes that by replacing `flex-basis` with `width` :)

### Testing

- Go to http://calypso.localhost:3000/domains/manage/your-site.wordpress.com/edit/your-site.wordpress.com
- Emulate or resize your browser so that it's width is under `660px`
- You should not see the issue shown in the screen shot above, instead, the component should show a natural height