### PR TITLE
Notices: Allow redux notices to include a dismiss handler

### DIFF
--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -95,6 +95,7 @@ const NoticesList = createReactClass( {
 						showDismiss={ notice.showDismiss }
 						onDismissClick={ this.removeReduxNotice( notice ) }
 						text={ notice.text }
+						icon={ notice.icon }
 					>
 						{ notice.button && (
 							<NoticeAction href={ notice.href } onClick={ notice.onClick }>

--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -120,10 +120,8 @@ const NoticesList = createReactClass( {
 } );
 
 export default connect(
-	state => {
-		return {
-			storeNotices: getNotices( state ),
-		};
-	},
+	state => ( {
+		storeNotices: getNotices( state ),
+	} ),
 	{ removeNotice }
 )( NoticesList );

--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -43,10 +43,21 @@ const NoticesList = createReactClass( {
 		debug( 'Mounting Global Notices React component.' );
 	},
 
-	removeNotice( notice ) {
+	removeNoticeStoreNotice: notice => {
 		if ( notice ) {
 			notices.removeNotice( notice );
 		}
+	},
+
+	// Auto-bound by createReactClass.
+	// Migrate to arrow => when using class extends React.Component
+	removeReduxNotice( notice ) {
+		return e => {
+			if ( notice.onDismissClick ) {
+				notice.onDismissClick( e );
+			}
+			this.props.removeNotice( notice.noticeId );
+		};
 	},
 
 	render() {
@@ -59,7 +70,7 @@ const NoticesList = createReactClass( {
 					duration={ notice.duration || null }
 					text={ notice.text }
 					isCompact={ notice.isCompact }
-					onDismissClick={ this.removeNotice.bind( this, notice ) }
+					onDismissClick={ this.removeNoticeStoreNotice( notice ) }
 					showDismiss={ notice.showDismiss }
 				>
 					{ notice.button && (
@@ -82,7 +93,7 @@ const NoticesList = createReactClass( {
 						status={ notice.status }
 						duration={ notice.duration || null }
 						showDismiss={ notice.showDismiss }
-						onDismissClick={ this.props.removeNotice.bind( this, notice.noticeId ) }
+						onDismissClick={ this.removeReduxNotice( notice ) }
 						text={ notice.text }
 					>
 						{ notice.button && (

--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -43,7 +43,7 @@ const NoticesList = createReactClass( {
 		debug( 'Mounting Global Notices React component.' );
 	},
 
-	removeNoticeStoreNotice: notice => {
+	removeNoticeStoreNotice: notice => () => {
 		if ( notice ) {
 			notices.removeNotice( notice );
 		}

--- a/client/state/notices/actions.js
+++ b/client/state/notices/actions.js
@@ -21,10 +21,11 @@ export function removeNotice( noticeId ) {
 }
 
 export function createNotice( status, text, options = {} ) {
+	const showDismiss = typeof options.showDismiss === 'boolean' ? options.showDismiss : true;
 	const notice = {
 		noticeId: options.id || uniqueId(),
 		duration: options.duration,
-		showDismiss: typeof options.showDismiss === 'boolean' ? options.showDismiss : true,
+		showDismiss,
 		isPersistent: options.isPersistent || false,
 		displayOnNextPage: options.displayOnNextPage || false,
 		status: status,
@@ -33,6 +34,9 @@ export function createNotice( status, text, options = {} ) {
 		href: options.href,
 		onClick: options.onClick,
 	};
+	if ( showDismiss && typeof options.onDismissClick === 'function' ) {
+		notice.onDismissClick = options.onDismissClick;
+	}
 
 	return {
 		type: NOTICE_CREATE,

--- a/client/state/notices/actions.js
+++ b/client/state/notices/actions.js
@@ -28,6 +28,7 @@ export function createNotice( status, text, options = {} ) {
 		showDismiss,
 		isPersistent: options.isPersistent || false,
 		displayOnNextPage: options.displayOnNextPage || false,
+		icon: options.icon,
 		status: status,
 		text: text,
 		button: options.button,

--- a/client/state/notices/actions.js
+++ b/client/state/notices/actions.js
@@ -23,17 +23,17 @@ export function removeNotice( noticeId ) {
 export function createNotice( status, text, options = {} ) {
 	const showDismiss = typeof options.showDismiss === 'boolean' ? options.showDismiss : true;
 	const notice = {
-		noticeId: options.id || uniqueId(),
-		duration: options.duration,
-		showDismiss,
-		isPersistent: options.isPersistent || false,
+		button: options.button,
 		displayOnNextPage: options.displayOnNextPage || false,
+		duration: options.duration,
+		href: options.href,
 		icon: options.icon,
+		isPersistent: options.isPersistent || false,
+		noticeId: options.id || uniqueId(),
+		onClick: options.onClick,
+		showDismiss,
 		status: status,
 		text: text,
-		button: options.button,
-		href: options.href,
-		onClick: options.onClick,
 	};
 	if ( showDismiss && typeof options.onDismissClick === 'function' ) {
 		notice.onDismissClick = options.onDismissClick;


### PR DESCRIPTION
Some Notice props are inaccessible via the Redux action notices.

- Add `onDismissClick` option to handle notice dismissal. Redux notices continue to be removed by the global notices component, but the handler has the option of taking some action when the notice is dismissed.
- Add `icon`

## Testing
1. https://calypso.live/?branch=update/notices-accept-ondismiss&debug
1. Verify notice icons and `onDismissClick` perform as expected:
1. ```js
   dispatch( { type: 'NOTICE_CREATE', notice: { status: 'is-success', icon: 'thumbs-up', onDismissClick: () => console.log('Dismissed!'), showDismiss: true, text: 'Demo notice 💥' } } )
   ```
1. Verify the icon is as expected and, when dismissed, the `onDismissClick` is called (logs `Dismissed!`)