### PR TITLE
Components: remove redundancy in tests of the ProductPurchaseFeaturesList

### DIFF
--- a/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
+++ b/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
@@ -1,26 +1,6 @@
 /** @format */
-
-jest.mock( 'lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
-jest.mock( '../google-vouchers', () => ( {} ) );
-jest.mock( '../video-audio-posts', () => {
-	const React = require( 'react' );
-	return class VideoAudioPosts extends React.Component {};
-} );
-
-jest.mock( 'i18n-calypso', () => ( {
-	localize: Comp => props => (
-		<Comp
-			{ ...props }
-			translate={ function( x ) {
-				return x;
-			} }
-		/>
-	),
-	numberFormat: x => x,
-} ) );
+jest.mock( '../google-vouchers', () => 'GoogleVouchers' );
+jest.mock( '../video-audio-posts', () => 'VideoAudioPosts' );
 
 /**
  * External dependencies


### PR DESCRIPTION
Janitorial PR which:
- removes obsolete definitions, 
- refactors definition of the component mocks to return string instead of an empty object (suppresses warnings)

## to test: 
- run unit tests
