### PR TITLE
Plans: Move 'Start with Free' button to Signup

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -27,7 +27,6 @@ import {
 import { addQueryArgs } from 'lib/url';
 import JetpackFAQ from './jetpack-faq';
 import WpcomFAQ from './wpcom-faq';
-import PlansSkipButton from 'components/plans/plans-skip-button';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { isEnabled } from 'config';
@@ -37,7 +36,6 @@ import SegmentedControlItem from 'components/segmented-control/item';
 import PlanFooter from 'blocks/plan-footer';
 import HappychatConnection from 'components/happychat/connection-connected';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
-import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { selectSiteId as selectHappychatSiteId } from 'state/help/actions';
 
@@ -176,7 +174,7 @@ export class PlansFeaturesMain extends Component {
 	};
 
 	render() {
-		const { domainName, site, displayJetpackPlans, isInSignup, isLoggedIn } = this.props;
+		const { site, displayJetpackPlans, isInSignup } = this.props;
 		let faqs = null;
 
 		if ( ! isInSignup ) {
@@ -193,9 +191,6 @@ export class PlansFeaturesMain extends Component {
 				{ this.getPlanFeatures() }
 				<PlanFooter isInSignup={ isInSignup } isJetpack={ displayJetpackPlans } />
 				{ faqs }
-				{ isInSignup &&
-					! isLoggedIn &&
-					! domainName && <PlansSkipButton onClick={ this.handleFreePlanButtonClick } /> }
 			</div>
 		);
 	}
@@ -209,7 +204,6 @@ PlansFeaturesMain.propTypes = {
 	isChatAvailable: PropTypes.bool,
 	isInSignup: PropTypes.bool,
 	isLandingPage: PropTypes.bool,
-	isLoggedIn: PropTypes.bool,
 	onUpgradeClick: PropTypes.func,
 	selectedFeature: PropTypes.string,
 	selectedPlan: PropTypes.string,
@@ -223,7 +217,6 @@ PlansFeaturesMain.defaultProps = {
 	hideFreePlan: false,
 	intervalType: 'yearly',
 	isChatAvailable: false,
-	isLoggedIn: false,
 	showFAQ: true,
 	site: {},
 	siteSlug: '',
@@ -232,7 +225,6 @@ PlansFeaturesMain.defaultProps = {
 export default connect(
 	( state, { site } ) => ( {
 		isChatAvailable: isHappychatAvailable( state ),
-		isLoggedIn: !! getCurrentUserId( state ),
 		siteSlug: getSiteSlug( state, get( site, [ 'ID' ] ) ),
 	} ),
 	{ selectHappychatSiteId }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -169,10 +169,6 @@ export class PlansFeaturesMain extends Component {
 		);
 	}
 
-	handleFreePlanButtonClick = () => {
-		this.props.onUpgradeClick( null ); // onUpgradeClick expects a cart item -- null means Free Plan.
-	};
-
 	render() {
 		const { site, displayJetpackPlans, isInSignup } = this.props;
 		let faqs = null;

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -20,6 +20,7 @@ import { getSiteBySlug } from 'state/sites/selectors';
 import SignupActions from 'lib/signup/actions';
 import StepWrapper from 'signup/step-wrapper';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
+import PlansSkipButton from 'components/plans/plans-skip-button';
 import QueryPlans from 'components/data/query-plans';
 
 class PlansStep extends Component {
@@ -94,6 +95,16 @@ class PlansStep extends Component {
 					displayJetpackPlans={ false }
 					domainName={ this.getDomainName() }
 				/>
+				{ /* The `hideFreePlan` means that we want to hide the Free Plan Info Column.
+				   * In most cases, we want to show the 'Start with Free' PlansSkipButton instead --
+				   * unless we've already selected an option that implies a paid plan.
+				   * This is in particular true for domain names. */
+				hideFreePlan &&
+					! this.getDomainName() && (
+						<PlansSkipButton
+							onClick={ this.onSelectPlan } // Called with no args, selects the Free Plan
+						/>
+					) }
 			</div>
 		);
 	}

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -24,14 +24,7 @@ import PlansSkipButton from 'components/plans/plans-skip-button';
 import QueryPlans from 'components/data/query-plans';
 
 class PlansStep extends Component {
-	constructor( props ) {
-		super( props );
-
-		this.onSelectPlan = this.onSelectPlan.bind( this );
-		this.plansFeaturesSelection = this.plansFeaturesSelection.bind( this );
-	}
-
-	onSelectPlan( cartItem ) {
+	onSelectPlan = cartItem => {
 		const {
 				additionalStepData,
 				stepSectionName,
@@ -71,7 +64,7 @@ class PlansStep extends Component {
 		SignupActions.submitSignupStep( step, [], providedDependencies );
 
 		goToNextStep();
-	}
+	};
 
 	getDomainName() {
 		return (
@@ -109,7 +102,7 @@ class PlansStep extends Component {
 		);
 	}
 
-	plansFeaturesSelection() {
+	plansFeaturesSelection = () => {
 		const { flowName, stepName, positionInFlow, signupProgress, translate } = this.props;
 
 		const headerText = translate( "Pick a plan that's right for you." );
@@ -126,7 +119,7 @@ class PlansStep extends Component {
 				stepContent={ this.plansFeaturesList() }
 			/>
 		);
-	}
+	};
 
 	render() {
 		const classes = classNames( 'plans plans-step', {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -72,6 +72,10 @@ class PlansStep extends Component {
 		);
 	}
 
+	handleFreePlanButtonClick = () => {
+		this.onSelectPlan( null ); // onUpgradeClick expects a cart item -- null means Free Plan.
+	};
+
 	plansFeaturesList() {
 		const { hideFreePlan, selectedSite } = this.props;
 
@@ -93,11 +97,7 @@ class PlansStep extends Component {
 				   * unless we've already selected an option that implies a paid plan.
 				   * This is in particular true for domain names. */
 				hideFreePlan &&
-					! this.getDomainName() && (
-						<PlansSkipButton
-							onClick={ this.onSelectPlan } // Called with no args, selects the Free Plan
-						/>
-					) }
+					! this.getDomainName() && <PlansSkipButton onClick={ this.handleFreePlanButtonClick } /> }
 			</div>
 		);
 	}


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/24426#issuecomment-383927617. For testing instructions, see that PR's description. 

Note that this PR fixes the following bug currently present in JP Connect (2 'Start with Free' buttons), which I probably caused with #24333:

https://wordpress.com/jetpack/connect/store (logged-out):

![image](https://user-images.githubusercontent.com/96308/39330458-000bd54e-49a2-11e8-8bd0-6fedafc7a226.png)

Verify that one this branch, there's only one 'Start with Free' button at http://calypso.localhost:3000/jetpack/connect/store

### Motivation:

The idea here is that the 'Start with Free' button plainly doesn't belong in the `PlanFeaturesMain` component, which is used in non-signup contexts such as https://wordpress.com/plans. Instead, it should be directly rendered from it's parent (signup specific) component, much like we're already doing for Jetpack Connect.

(Ideally, the `PlanFeaturesMain` component should arguably be ignorant about the context it's used in -- which would mean dropping the `isInSignup` prop in the long run.)