### PR TITLE
SiteAddressChanger:  Add notification whitespace

### DIFF
--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -254,10 +254,11 @@ export class SimpleSiteRenameForm extends Component {
 							placeholder={ currentDomainPrefix }
 							isError={ shouldShowValidationMessage && ! isAvailable }
 						/>
-						{ shouldShowValidationMessage &&
-							validationMessage && (
-								<FormInputValidation isError={ ! isAvailable } text={ validationMessage } />
-							) }
+						<FormInputValidation
+							isHidden={ ! shouldShowValidationMessage }
+							isError={ ! isAvailable }
+							text={ validationMessage || '\u00A0' }
+						/>
 						<div className="simple-site-rename-form__footer">
 							<div className="simple-site-rename-form__info">
 								<Gridicon icon="info-outline" size={ 18 } />

--- a/client/blocks/simple-site-rename-form/style.scss
+++ b/client/blocks/simple-site-rename-form/style.scss
@@ -76,8 +76,6 @@
 	display: flex;
 	justify-content: space-between;
 
-	margin-top: 24px;
-
 	button {
 		flex-shrink: 0;
 		margin-left: auto;

--- a/client/components/forms/form-input-validation/index.jsx
+++ b/client/components/forms/form-input-validation/index.jsx
@@ -27,6 +27,7 @@ export default class extends React.Component {
 			'form-input-validation': true,
 			'is-warning': this.props.isWarning,
 			'is-error': this.props.isError,
+			'is-hidden': this.props.isHidden,
 		} );
 
 		const icon = this.props.isError || this.props.isWarning ? 'notice-outline' : 'checkmark';

--- a/client/components/forms/form-input-validation/style.scss
+++ b/client/components/forms/form-input-validation/style.scss
@@ -15,6 +15,11 @@
 		color: $alert-yellow;
 	}
 
+	&.is-hidden{
+		animation: none;
+		visibility: hidden;
+	}
+
 	.gridicon {
 		float: left;
 		margin-left: -34px;


### PR DESCRIPTION
### Summary

To avoid jumps in visual height in the `SiteAddressChanger` component I've added the ability to set a state of `isHidden` to the `FormInputValidation` component.

We had considered making this change only to our implementation of `FormInputValidation` but simply applying `visibility: hidden` to our instance of `FormInputValidation` causes us to miss out on the subtle `appear` animation and makes the showing of validation more abrupt.

### Testing

- Go to http://calypso.localhost:3000/domains/manage/your-site.wordpress.com/edit/your-site.wordpress.com
- Go through various validation states, ensuring that each is hidden, valid or invalid as you would expect:
  - No input - should be hidden
  - Too short (should be invalid / erroneous / red) 
  - Unavailable (should be invalid / erroneous /red ) 
  - Available (should be valid / green )
- Each change in validation should come with a subtle animation