### PR TITLE
Purchases: add logged-out redirect to all paths

### DIFF
--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -14,12 +14,13 @@ import meController from 'me/controller';
 import { siteSelection } from 'my-sites/controller';
 import controller from './controller';
 import * as paths from './paths';
-import { makeLayout, render as clientRender } from 'controller';
+import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 
 export default function( router ) {
 	if ( config.isEnabled( 'manage/payment-methods' ) ) {
 		router(
 			paths.addCreditCard,
+			redirectLoggedOut,
 			meController.sidebar,
 			controller.addCreditCard,
 			makeLayout,
@@ -32,6 +33,7 @@ export default function( router ) {
 
 	router(
 		paths.billingHistory,
+		redirectLoggedOut,
 		meController.sidebar,
 		billingController.billingHistory,
 		makeLayout,
@@ -40,6 +42,7 @@ export default function( router ) {
 
 	router(
 		paths.billingHistoryReceipt(),
+		redirectLoggedOut,
 		meController.sidebar,
 		billingController.transaction,
 		makeLayout,
@@ -50,6 +53,7 @@ export default function( router ) {
 
 	router(
 		paths.managePurchase(),
+		redirectLoggedOut,
 		meController.sidebar,
 		siteSelection,
 		controller.managePurchase,
@@ -59,6 +63,7 @@ export default function( router ) {
 
 	router(
 		paths.cancelPurchase(),
+		redirectLoggedOut,
 		meController.sidebar,
 		siteSelection,
 		controller.cancelPurchase,
@@ -68,6 +73,7 @@ export default function( router ) {
 
 	router(
 		paths.cancelPrivacyProtection(),
+		redirectLoggedOut,
 		meController.sidebar,
 		siteSelection,
 		controller.cancelPrivacyProtection,
@@ -77,6 +83,7 @@ export default function( router ) {
 
 	router(
 		paths.confirmCancelDomain(),
+		redirectLoggedOut,
 		meController.sidebar,
 		siteSelection,
 		controller.confirmCancelDomain,
@@ -86,6 +93,7 @@ export default function( router ) {
 
 	router(
 		paths.addCardDetails(),
+		redirectLoggedOut,
 		meController.sidebar,
 		siteSelection,
 		controller.addCardDetails,
@@ -95,6 +103,7 @@ export default function( router ) {
 
 	router(
 		paths.editCardDetails(),
+		redirectLoggedOut,
 		meController.sidebar,
 		siteSelection,
 		controller.editCardDetails,

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -16,9 +16,9 @@ import controller from './controller';
 import * as paths from './paths';
 import { makeLayout, render as clientRender } from 'controller';
 
-export default function() {
+export default function( router ) {
 	if ( config.isEnabled( 'manage/payment-methods' ) ) {
-		page(
+		router(
 			paths.addCreditCard,
 			meController.sidebar,
 			controller.addCreditCard,
@@ -27,10 +27,10 @@ export default function() {
 		);
 
 		// redirect legacy urls
-		page( '/payment-methods/add-credit-card', () => page.redirect( paths.addCreditCard ) );
+		router( '/payment-methods/add-credit-card', () => page.redirect( paths.addCreditCard ) );
 	}
 
-	page(
+	router(
 		paths.billingHistory,
 		meController.sidebar,
 		billingController.billingHistory,
@@ -38,7 +38,7 @@ export default function() {
 		clientRender
 	);
 
-	page(
+	router(
 		paths.billingHistoryReceipt(),
 		meController.sidebar,
 		billingController.transaction,
@@ -46,9 +46,9 @@ export default function() {
 		clientRender
 	);
 
-	page( paths.purchasesRoot, meController.sidebar, controller.list, makeLayout, clientRender );
+	router( paths.purchasesRoot, meController.sidebar, controller.list, makeLayout, clientRender );
 
-	page(
+	router(
 		paths.managePurchase(),
 		meController.sidebar,
 		siteSelection,
@@ -57,7 +57,7 @@ export default function() {
 		clientRender
 	);
 
-	page(
+	router(
 		paths.cancelPurchase(),
 		meController.sidebar,
 		siteSelection,
@@ -66,7 +66,7 @@ export default function() {
 		clientRender
 	);
 
-	page(
+	router(
 		paths.cancelPrivacyProtection(),
 		meController.sidebar,
 		siteSelection,
@@ -75,7 +75,7 @@ export default function() {
 		clientRender
 	);
 
-	page(
+	router(
 		paths.confirmCancelDomain(),
 		meController.sidebar,
 		siteSelection,
@@ -84,7 +84,7 @@ export default function() {
 		clientRender
 	);
 
-	page(
+	router(
 		paths.addCardDetails(),
 		meController.sidebar,
 		siteSelection,
@@ -93,7 +93,7 @@ export default function() {
 		clientRender
 	);
 
-	page(
+	router(
 		paths.editCardDetails(),
 		meController.sidebar,
 		siteSelection,
@@ -103,33 +103,35 @@ export default function() {
 	);
 
 	// redirect legacy urls
-	page( '/purchases', () => page.redirect( paths.purchasesRoot ) );
-	page( '/purchases/:siteName/:purchaseId', ( { params: { siteName, purchaseId } } ) =>
+	router( '/purchases', () => page.redirect( paths.purchasesRoot ) );
+	router( '/purchases/:siteName/:purchaseId', ( { params: { siteName, purchaseId } } ) =>
 		page.redirect( paths.managePurchase( siteName, purchaseId ) )
 	);
-	page( '/purchases/:siteName/:purchaseId/cancel', ( { params: { siteName, purchaseId } } ) =>
+	router( '/purchases/:siteName/:purchaseId/cancel', ( { params: { siteName, purchaseId } } ) =>
 		page.redirect( paths.cancelPurchase( siteName, purchaseId ) )
 	);
-	page(
+	router(
 		'/purchases/:siteName/:purchaseId/cancel-private-registration',
 		( { params: { siteName, purchaseId } } ) =>
 			page.redirect( paths.cancelPrivacyProtection( siteName, purchaseId ) )
 	);
-	page(
+	router(
 		'/purchases/:siteName/:purchaseId/confirm-cancel-domain',
 		( { params: { siteName, purchaseId } } ) =>
 			page.redirect( paths.confirmCancelDomain( siteName, purchaseId ) )
 	);
-	page( '/purchases/:siteName/:purchaseId/payment/add', ( { params: { siteName, purchaseId } } ) =>
-		page.redirect( paths.addCardDetails( siteName, purchaseId ) )
+	router(
+		'/purchases/:siteName/:purchaseId/payment/add',
+		( { params: { siteName, purchaseId } } ) =>
+			page.redirect( paths.addCardDetails( siteName, purchaseId ) )
 	);
-	page(
+	router(
 		'/purchases/:siteName/:purchaseId/payment/edit/:cardId',
 		( { params: { siteName, purchaseId, cardId } } ) =>
 			page.redirect( paths.editCardDetails( siteName, purchaseId, cardId ) )
 	);
-	page( '/me/billing', () => page.redirect( paths.billingHistory ) );
-	page( '/me/billing/:receiptId', ( { params: { receiptId } } ) =>
+	router( '/me/billing', () => page.redirect( paths.billingHistory ) );
+	router( '/me/billing/:receiptId', ( { params: { receiptId } } ) =>
 		page.redirect( paths.billingHistoryReceipt( receiptId ) )
 	);
 }

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -49,7 +49,14 @@ export default function( router ) {
 		clientRender
 	);
 
-	router( paths.purchasesRoot, meController.sidebar, controller.list, makeLayout, clientRender );
+	router(
+		paths.purchasesRoot,
+		redirectLoggedOut,
+		meController.sidebar,
+		controller.list,
+		makeLayout,
+		clientRender
+	);
 
 	router(
 		paths.managePurchase(),

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -53,6 +53,7 @@ const sections = [
 		module: 'me/purchases',
 		group: 'me',
 		secondary: true,
+		enableLoggedOut: true,
 	},
 	{
 		name: 'notification-settings',


### PR DESCRIPTION
Currently if you visit a route like `/me/purchases` when logged-out, you will see a blank page (see #23785 for the general problem; this was inspired by the approach in #23548).

Before | After
------ | -----
<img width="624" alt="screenshot" src="https://user-images.githubusercontent.com/594356/37777252-5b4af16e-2de7-11e8-9026-d2a505157c32.png"> | <img width="623" alt="screenshot" src="https://user-images.githubusercontent.com/594356/37777367-a463252e-2de7-11e8-866c-18432fc3ee28.png">

This change will allow all paths in the `me/purchases` routes to redirect to the login page if logged-out, and then redirect to the page originally requested.

In other words, with this PR, visiting `/me/purchases` will instead redirect to the login page and, once logged in, to the purchases page.

props @rralian for the idea.

## Testing

1. Visit http://calypso.localhost:3000/me/purchases/ while logged-out.
1. Verify that you are redirected to a login page.
1. Log into the page.
1. Verify that you are redirected to the "Purchases" tab of the "Mange Purchases" section of Calypso.