### PR TITLE
Jetpack: Site Settings: Do not render AmpJetpack when no customizerUrl

### DIFF
--- a/client/my-sites/site-settings/amp/jetpack.jsx
+++ b/client/my-sites/site-settings/amp/jetpack.jsx
@@ -55,7 +55,8 @@ const AmpJetpack = ( {
 				</p>
 			</CompactCard>
 
-			{ ! requestingPlugins && <CompactCard href={ linkUrl }>{ linkText }</CompactCard> }
+			{ ! requestingPlugins &&
+				customizerAmpPanelUrl && <CompactCard href={ linkUrl }>{ linkText }</CompactCard> }
 		</div>
 	);
 };
@@ -63,13 +64,15 @@ const AmpJetpack = ( {
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const customizerUrl = getCustomizerUrl( state, siteId );
-	const customizerAmpPanelUrl = addQueryArgs(
-		{
-			'autofocus[panel]': 'amp_panel',
-			customize_amp: 1,
-		},
-		customizerUrl
-	);
+	const customizerAmpPanelUrl = !! customizerUrl
+		? addQueryArgs(
+				{
+					'autofocus[panel]': 'amp_panel',
+					customize_amp: 1,
+				},
+				customizerUrl
+			)
+		: null;
 
 	return {
 		siteId,


### PR DESCRIPTION
It was reported by a VIP Go intern that when a super admin was connected to WordPress.com, that the traffic tab of site settings wouldn't load.

In debugging, I found that this was because `customizerUrl` returned null for the site when I was a super admin.

This PR adds a safety check so that we bail and not render anything when we need customizerAmpPanelUrl and it's `null`.

To test:

- Create multisite
- Add self as super admin 
- Connect to WordPress.com