### PR TITLE
Fix 0 rendered to screen from isJetpackSiteInDevMode selector

### DIFF
--- a/client/state/selectors/is-jetpack-site-in-development-mode.js
+++ b/client/state/selectors/is-jetpack-site-in-development-mode.js
@@ -20,5 +20,13 @@ import { getJetpackConnectionStatus } from 'state/selectors';
  * @return {?Boolean}          Whether the site is in development mode.
  */
 export default function isJetpackSiteInDevelopmentMode( state, siteId ) {
-	return get( getJetpackConnectionStatus( state, siteId ), [ 'devMode', 'isActive' ], null );
+	const isDevMode = get(
+		getJetpackConnectionStatus( state, siteId ),
+		[ 'devMode', 'isActive' ],
+		null
+	);
+	if ( isDevMode === null ) {
+		return null;
+	}
+	return !! isDevMode;
 }

--- a/client/state/selectors/test/fixtures/jetpack-connection.js
+++ b/client/state/selectors/test/fixtures/jetpack-connection.js
@@ -20,6 +20,16 @@ export const items = {
 			filter: true,
 		},
 	},
+	987654321: {
+		isActive: true,
+		isStaging: true,
+		devMode: {
+			isActive: 0,
+			constant: false,
+			url: false,
+			filter: true,
+		},
+	},
 };
 
 export const requests = {

--- a/client/state/selectors/test/is-jetpack-site-in-development-mode.js
+++ b/client/state/selectors/test/is-jetpack-site-in-development-mode.js
@@ -38,6 +38,19 @@ describe( 'isJetpackSiteInDevelopmentMode()', () => {
 		expect( output ).to.be.false;
 	} );
 
+	test( 'should return false if the site is not in development mode with isActive: 0', () => {
+		const stateIn = {
+				jetpack: {
+					connection: {
+						items: ITEMS_FIXTURE,
+					},
+				},
+			},
+			siteId = 987654321;
+		const output = isJetpackSiteInDevelopmentMode( stateIn, siteId );
+		expect( output ).to.be.false;
+	} );
+
 	test( 'should return null if the site is not known yet', () => {
 		const stateIn = {
 				jetpack: {


### PR DESCRIPTION
A '0' is being rendered to screen as a result of the `isJetpackSiteInDevelopmentMode()` selector returning 0.

<img width="1367" alt="screen shot 2018-04-24 at 9 38 19 am" src="https://user-images.githubusercontent.com/7767559/39197546-ac560526-47dc-11e8-8ddb-a82bacd4f650.png">

This happens when state for the site is like this:
```
{
  "isActive": true,
  "isStaging": false,
  "devMode": {
    "isActive": 0,
    "constant": false,
    "url": false,
    "filter": false
  }
}
```

This change forces the selector to return a boolean or null, as per the jsdoc.

## Testing
* Unit test added

