### PR TITLE
Activity: updates the copy to accurately report the error

### DIFF
--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -76,8 +76,10 @@ class ErrorBanner extends PureComponent {
 					details: translate( 'We came across a problem while trying to restore your site.' ),
 				}
 			: {
-					title: translate( 'Problem creating a backup' ),
-					details: translate( 'We came across a problem creating a backup for your site.' ),
+					title: translate( 'Problem creating a file' ),
+					details: translate(
+						'There was a problem building your backup into a downloadable file.'
+					),
 				};
 
 		return (

--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -76,7 +76,7 @@ class ErrorBanner extends PureComponent {
 					details: translate( 'We came across a problem while trying to restore your site.' ),
 				}
 			: {
-					title: translate( 'Problem preparing your backup' ),
+					title: translate( 'Problem preparing your file' ),
 					details: translate( 'There was a problem preparing your backup for downloading.' ),
 				};
 

--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -76,10 +76,8 @@ class ErrorBanner extends PureComponent {
 					details: translate( 'We came across a problem while trying to restore your site.' ),
 				}
 			: {
-					title: translate( 'Problem creating a file' ),
-					details: translate(
-						'There was a problem building your backup into a downloadable file.'
-					),
+					title: translate( 'Problem preparing your backup' ),
+					details: translate( 'There was a problem preparing your backup for downloading.' ),
 				};
 
 		return (


### PR DESCRIPTION
This message refers to a failed downloadable backup and not a failed
backup, and this causes understandable confusion with costumers.

This PR updates the copy so that the message is clear and the exact
error is reported accurately.

Props to @rcoll for bringing this up!