### PR TITLE
Store: Fix breadcrumb spacing

### DIFF
--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -72,7 +72,7 @@
 		span + span::before {
 			content: ' / ';
 			color: $gray;
-			margin: 0 2px;
+			margin: 0 2px 0 4px;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #24003.

The spacing between breadcrumbs and their separators were a couple pixels off. This PR adjusts that to be more even looking:

<img width="362" alt="screen shot 2018-04-24 at 1 43 29 pm" src="https://user-images.githubusercontent.com/689165/39204597-313d6502-47c6-11e8-8282-01cb3817266b.png">

To Test:
* Verify breadcrumb display. A page like shipping zone management is a good place for this. `http://calypso.localhost:3000/store/settings/shipping/zone/:site/0`
