### PR TITLE
Checkout: add EBANX device id to CC requests

### DIFF
--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -132,6 +132,7 @@ TransactionFlow.prototype._paymentHandlers = {
 						street_number: newCardDetails[ 'street-number' ],
 						phone_number: newCardDetails[ 'phone-number' ],
 						document: newCardDetails.document,
+						device_id: gatewayData.deviceId,
 					};
 
 					paymentData = { ...paymentData, ...ebanxPaymentData };
@@ -268,7 +269,12 @@ function createEbanxToken( requestType, cardDetails, callback ) {
 					Ebanx.config.setCountry( cardDetails.country.toLowerCase() );
 
 					const parameters = getEbanxParameters( cardDetails );
-					Ebanx.card.createToken( parameters, createTokenCallback );
+					Ebanx.card.createToken( parameters, function( ebanxResponse ) {
+						Ebanx.deviceFingerprint.setup( function( deviceId ) {
+							ebanxResponse.data.deviceId = deviceId;
+							createTokenCallback( ebanxResponse );
+						} );
+					} );
 				} )
 				.catch( loaderError => {
 					callback( loaderError );


### PR DESCRIPTION
EBANX wants us to add the device ID to transactions, this does just that.

Ref: https://developers.ebanx.com/api-reference/full-api-documentation/ebanx-payment-2/ebanx-payment-guide/guide-using-device-fingerprint/

**Testing:**
- Set yourself up for an EBANX transaction. You need a WPCOM account set to BRL.
- Select Brazil as the payment country and fill in the extra form fields. Use `685.784.987-04` for the tax id. You can use `5555 5555 5555 4444` as the CC number.
- Submit and confirm that the `device_id` is part of the `/transactions` request.
