### PR TITLE
Jetpack connect: Actions simplification

### DIFF
--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -172,7 +172,7 @@ export function retryAuth( url, attemptNumber ) {
 				} ),
 				{
 					type: JETPACK_CONNECT_RETRY_AUTH,
-					attemptNumber: attemptNumber,
+					attemptNumber,
 					slug: urlToSlug( url ),
 				}
 			)
@@ -337,7 +337,7 @@ export function authorize( queryObject ) {
 		dispatch(
 			withAnalytics( recordTracksEvent( 'calypso_jpc_authorize', { from, site: client_id } ), {
 				type: JETPACK_CONNECT_AUTHORIZE,
-				queryObject: queryObject,
+				queryObject,
 			} )
 		);
 		return wpcom

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -16,7 +16,7 @@ import wpcom from 'lib/wp';
 import { addQueryArgs, externalRedirect } from 'lib/route';
 import { clearPlan } from 'jetpack-connect/persistence-utils';
 import { receiveDeletedSite, receiveSite } from 'state/sites/actions';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import { REMOTE_PATH_AUTH } from 'jetpack-connect/constants';
 import { SITE_REQUEST_FIELDS, SITE_REQUEST_OPTIONS } from 'state/sites/constants';
 import { urlToSlug } from 'lib/url';
@@ -142,7 +142,7 @@ export function checkUrl( url, isUrlOnSites ) {
 				if ( errorCode ) {
 					dispatch(
 						recordTracksEvent( errorCode, {
-							url: url,
+							url,
 							type: instructionsType,
 						} )
 					);
@@ -156,11 +156,7 @@ export function checkUrl( url, isUrlOnSites ) {
 					data: null,
 					error: error,
 				} );
-				dispatch(
-					recordTracksEvent( 'calypso_jpc_error_other', {
-						url: url,
-					} )
-				);
+				dispatch( recordTracksEvent( 'calypso_jpc_error_other', { url } ) );
 			} );
 	};
 }
@@ -168,16 +164,18 @@ export function checkUrl( url, isUrlOnSites ) {
 export function retryAuth( url, attemptNumber ) {
 	return dispatch => {
 		debug( 'retrying auth', url, attemptNumber );
-		dispatch( {
-			type: JETPACK_CONNECT_RETRY_AUTH,
-			attemptNumber: attemptNumber,
-			slug: urlToSlug( url ),
-		} );
 		dispatch(
-			recordTracksEvent( 'calypso_jpc_retry_auth', {
-				url: url,
-				attempt: attemptNumber,
-			} )
+			withAnalytics(
+				recordTracksEvent( 'calypso_jpc_retry_auth', {
+					url,
+					attempt: attemptNumber,
+				} ),
+				{
+					type: JETPACK_CONNECT_RETRY_AUTH,
+					attemptNumber: attemptNumber,
+					slug: urlToSlug( url ),
+				}
+			)
 		);
 		debug( 'retryAuth', url );
 		externalRedirect(
@@ -336,11 +334,12 @@ export function authorize( queryObject ) {
 			state,
 		} = queryObject;
 		debug( 'Trying Jetpack login.', _wp_nonce, redirect_uri, scope, state );
-		dispatch( recordTracksEvent( 'calypso_jpc_authorize', { from, site: client_id } ) );
-		dispatch( {
-			type: JETPACK_CONNECT_AUTHORIZE,
-			queryObject: queryObject,
-		} );
+		dispatch(
+			withAnalytics( recordTracksEvent( 'calypso_jpc_authorize', { from, site: client_id } ), {
+				type: JETPACK_CONNECT_AUTHORIZE,
+				queryObject: queryObject,
+			} )
+		);
 		return wpcom
 			.undocumented()
 			.jetpackLogin( client_id, _wp_nonce, redirect_uri, scope, state )
@@ -374,47 +373,49 @@ export function authorize( queryObject ) {
 				} );
 			} )
 			.then( data => {
-				dispatch(
-					recordTracksEvent( 'calypso_jpc_auth_sitesrefresh', {
-						site: client_id,
-					} )
-				);
 				debug( 'Site updated', data );
-				dispatch( {
-					type: SITE_RECEIVE,
-					site: data,
-				} );
-				dispatch( {
-					type: JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST,
-				} );
-			} )
-			.then( () => {
 				dispatch(
-					recordTracksEvent( 'calypso_jpc_authorize_success', {
-						site: client_id,
-						from,
-					} )
+					withAnalytics(
+						recordTracksEvent( 'calypso_jpc_auth_sitesrefresh', {
+							site: client_id,
+						} ),
+						{
+							type: SITE_RECEIVE,
+							site: data,
+						}
+					)
+				);
+				dispatch(
+					withAnalytics(
+						recordTracksEvent( 'calypso_jpc_authorize_success', {
+							site: client_id,
+							from,
+						} ),
+						{ type: JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST }
+					)
 				);
 			} )
 			.catch( error => {
 				debug( 'Authorize error', error );
 				dispatch(
-					recordTracksEvent( 'calypso_jpc_authorize_error', {
-						error_code: error.code,
-						error_name: error.name,
-						error_message: error.message,
-						status: error.status,
-						error: JSON.stringify( error ),
-						site: client_id,
-						from,
-					} )
+					withAnalytics(
+						recordTracksEvent( 'calypso_jpc_authorize_error', {
+							error_code: error.code,
+							error_name: error.name,
+							error_message: error.message,
+							status: error.status,
+							error: JSON.stringify( error ),
+							site: client_id,
+							from,
+						} ),
+						{
+							type: JETPACK_CONNECT_AUTHORIZE_RECEIVE,
+							siteId: client_id,
+							data: null,
+							error: pick( error, [ 'error', 'status', 'message' ] ),
+						}
+					)
 				);
-				dispatch( {
-					type: JETPACK_CONNECT_AUTHORIZE_RECEIVE,
-					siteId: client_id,
-					data: null,
-					error: pick( error, [ 'error', 'status', 'message' ] ),
-				} );
 			} );
 	};
 }
@@ -431,24 +432,22 @@ export function validateSSONonce( siteId, ssoNonce ) {
 			.undocumented()
 			.jetpackValidateSSONonce( siteId, ssoNonce )
 			.then( data => {
-				dispatch( recordTracksEvent( 'calypso_jpc_validate_sso_success' ) );
-				dispatch( {
-					type: JETPACK_CONNECT_SSO_VALIDATION_SUCCESS,
-					success: data.success,
-					blogDetails: data.blog_details,
-					sharedDetails: data.shared_details,
-				} );
+				dispatch(
+					withAnalytics( recordTracksEvent( 'calypso_jpc_validate_sso_success' ), {
+						type: JETPACK_CONNECT_SSO_VALIDATION_SUCCESS,
+						success: data.success,
+						blogDetails: data.blog_details,
+						sharedDetails: data.shared_details,
+					} )
+				);
 			} )
 			.catch( error => {
 				dispatch(
-					recordTracksEvent( 'calypso_jpc_validate_sso_error', {
-						error: error,
+					withAnalytics( recordTracksEvent( 'calypso_jpc_validate_sso_error', { error } ), {
+						type: JETPACK_CONNECT_SSO_VALIDATION_ERROR,
+						error: pick( error, [ 'error', 'status', 'message' ] ),
 					} )
 				);
-				dispatch( {
-					type: JETPACK_CONNECT_SSO_VALIDATION_ERROR,
-					error: pick( error, [ 'error', 'status', 'message' ] ),
-				} );
 			} );
 	};
 }
@@ -465,23 +464,21 @@ export function authorizeSSO( siteId, ssoNonce, siteUrl ) {
 			.undocumented()
 			.jetpackAuthorizeSSONonce( siteId, ssoNonce )
 			.then( data => {
-				dispatch( recordTracksEvent( 'calypso_jpc_authorize_sso_success' ) );
-				dispatch( {
-					type: JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS,
-					ssoUrl: data.sso_url,
-					siteUrl,
-				} );
+				dispatch(
+					withAnalytics( recordTracksEvent( 'calypso_jpc_authorize_sso_success' ), {
+						type: JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS,
+						ssoUrl: data.sso_url,
+						siteUrl,
+					} )
+				);
 			} )
 			.catch( error => {
 				dispatch(
-					recordTracksEvent( 'calypso_jpc_authorize_sso_error', {
-						error: error,
+					withAnalytics( recordTracksEvent( 'calypso_jpc_authorize_sso_error', { error } ), {
+						type: JETPACK_CONNECT_SSO_AUTHORIZE_ERROR,
+						error: pick( error, [ 'error', 'status', 'message' ] ),
 					} )
 				);
-				dispatch( {
-					type: JETPACK_CONNECT_SSO_AUTHORIZE_ERROR,
-					error: pick( error, [ 'error', 'status', 'message' ] ),
-				} );
 			} );
 	};
 }

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -6,7 +6,6 @@
  * Internal dependencies
  */
 import * as actions from '../actions';
-import * as analyticsActions from 'state/analytics/actions';
 import useNock from 'test/helpers/use-nock';
 import wpcom from 'lib/wp';
 import {
@@ -56,7 +55,6 @@ describe( '#dismissUrl()', () => {
 
 describe( '#retryAuth()', () => {
 	test( 'should dispatch redirect action when called', () => {
-		jest.spyOn( analyticsActions, 'withAnalytics' ).mockImplementation( ( _, action ) => action );
 		const spy = jest.fn();
 		const { retryAuth } = actions;
 		const url = 'http://example.com';
@@ -67,6 +65,9 @@ describe( '#retryAuth()', () => {
 			type: JETPACK_CONNECT_RETRY_AUTH,
 			slug: 'example.com',
 			attemptNumber: 0,
+			meta: expect.objectContaining( {
+				analytics: expect.any( Array ),
+			} ),
 		} );
 	} );
 } );
@@ -119,7 +120,6 @@ describe( '#authorize()', () => {
 		} );
 
 		test( 'should dispatch authorize request action when thunk triggered', () => {
-			jest.spyOn( analyticsActions, 'withAnalytics' ).mockImplementation( ( _, action ) => action );
 			const spy = jest.fn();
 			const { authorize } = actions;
 
@@ -128,6 +128,9 @@ describe( '#authorize()', () => {
 			expect( spy ).toHaveBeenCalledWith( {
 				type: JETPACK_CONNECT_AUTHORIZE,
 				queryObject,
+				meta: expect.objectContaining( {
+					analytics: expect.any( Array ),
+				} ),
 			} );
 		} );
 
@@ -161,7 +164,6 @@ describe( '#authorize()', () => {
 		} );
 
 		test( 'should dispatch sites receive action when request completes', async () => {
-			jest.spyOn( analyticsActions, 'withAnalytics' ).mockImplementation( ( _, action ) => action );
 			const spy = jest.fn();
 			const { authorize } = actions;
 
@@ -169,17 +171,22 @@ describe( '#authorize()', () => {
 			expect( spy ).toHaveBeenCalledWith( {
 				type: SITE_RECEIVE,
 				site: { ID: client_id },
+				meta: expect.objectContaining( {
+					analytics: expect.any( Array ),
+				} ),
 			} );
 		} );
 
 		test( 'should dispatch authorize receive site list action when request completes', async () => {
-			jest.spyOn( analyticsActions, 'withAnalytics' ).mockImplementation( ( _, action ) => action );
 			const spy = jest.fn();
 			const { authorize } = actions;
 
 			await authorize( queryObject )( spy );
 			expect( spy ).toHaveBeenCalledWith( {
 				type: JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST,
+				meta: expect.objectContaining( {
+					analytics: expect.any( Array ),
+				} ),
 			} );
 		} );
 	} );
@@ -206,7 +213,6 @@ describe( '#authorize()', () => {
 		} );
 
 		test( 'should dispatch authorize receive action when request completes', async () => {
-			jest.spyOn( analyticsActions, 'withAnalytics' ).mockImplementation( ( _, action ) => action );
 			const spy = jest.fn();
 			const { authorize } = actions;
 
@@ -220,6 +226,9 @@ describe( '#authorize()', () => {
 					message: 'Could not verify your request.',
 					status: 400,
 				},
+				meta: expect.objectContaining( {
+					analytics: expect.any( Array ),
+				} ),
 			} );
 		} );
 	} );
@@ -283,7 +292,6 @@ describe( '#validateSSONonce()', () => {
 		} );
 
 		test( 'should dispatch receive action when request completes', async () => {
-			jest.spyOn( analyticsActions, 'withAnalytics' ).mockImplementation( ( _, action ) => action );
 			const spy = jest.fn();
 			const { validateSSONonce } = actions;
 
@@ -293,6 +301,9 @@ describe( '#validateSSONonce()', () => {
 				blogDetails: blogDetails,
 				sharedDetails: sharedDetails,
 				type: JETPACK_CONNECT_SSO_VALIDATION_SUCCESS,
+				meta: expect.objectContaining( {
+					analytics: expect.any( Array ),
+				} ),
 			} );
 		} );
 	} );
@@ -315,7 +326,6 @@ describe( '#validateSSONonce()', () => {
 		} );
 
 		test( 'should dispatch receive action when request completes', async () => {
-			jest.spyOn( analyticsActions, 'withAnalytics' ).mockImplementation( ( _, action ) => action );
 			const spy = jest.fn();
 			const { validateSSONonce } = actions;
 
@@ -327,6 +337,9 @@ describe( '#validateSSONonce()', () => {
 					status: 400,
 				},
 				type: JETPACK_CONNECT_SSO_VALIDATION_ERROR,
+				meta: expect.objectContaining( {
+					analytics: expect.any( Array ),
+				} ),
 			} );
 		} );
 	} );
@@ -359,7 +372,6 @@ describe( '#authorizeSSO()', () => {
 		} );
 
 		test( 'should dispatch receive action when request completes', async () => {
-			jest.spyOn( analyticsActions, 'withAnalytics' ).mockImplementation( ( _, action ) => action );
 			const spy = jest.fn();
 			const { authorizeSSO } = actions;
 
@@ -368,6 +380,9 @@ describe( '#authorizeSSO()', () => {
 				ssoUrl,
 				siteUrl: ssoUrl,
 				type: JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS,
+				meta: expect.objectContaining( {
+					analytics: expect.any( Array ),
+				} ),
 			} );
 		} );
 	} );
@@ -386,7 +401,6 @@ describe( '#authorizeSSO()', () => {
 		} );
 
 		test( 'should dispatch receive action when request completes', async () => {
-			jest.spyOn( analyticsActions, 'withAnalytics' ).mockImplementation( ( _, action ) => action );
 			const spy = jest.fn();
 			const { authorizeSSO } = actions;
 
@@ -398,6 +412,9 @@ describe( '#authorizeSSO()', () => {
 					status: 400,
 				},
 				type: JETPACK_CONNECT_SSO_AUTHORIZE_ERROR,
+				meta: expect.objectContaining( {
+					analytics: expect.any( Array ),
+				} ),
 			} );
 		} );
 	} );

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -6,6 +6,7 @@
  * Internal dependencies
  */
 import * as actions from '../actions';
+import * as analyticsActions from 'state/analytics/actions';
 import useNock from 'test/helpers/use-nock';
 import wpcom from 'lib/wp';
 import {
@@ -26,6 +27,8 @@ import {
 } from 'state/action-types';
 
 jest.mock( 'lib/localforage', () => require( 'lib/localforage/localforage-bypass' ) );
+
+beforeEach( jest.restoreAllMocks );
 
 describe( '#confirmJetpackInstallStatus()', () => {
 	test( 'should dispatch confirm status action when called', () => {
@@ -53,6 +56,7 @@ describe( '#dismissUrl()', () => {
 
 describe( '#retryAuth()', () => {
 	test( 'should dispatch redirect action when called', () => {
+		jest.spyOn( analyticsActions, 'withAnalytics' ).mockImplementation( ( _, action ) => action );
 		const spy = jest.fn();
 		const { retryAuth } = actions;
 		const url = 'http://example.com';
@@ -115,6 +119,7 @@ describe( '#authorize()', () => {
 		} );
 
 		test( 'should dispatch authorize request action when thunk triggered', () => {
+			jest.spyOn( analyticsActions, 'withAnalytics' ).mockImplementation( ( _, action ) => action );
 			const spy = jest.fn();
 			const { authorize } = actions;
 
@@ -156,6 +161,7 @@ describe( '#authorize()', () => {
 		} );
 
 		test( 'should dispatch sites receive action when request completes', async () => {
+			jest.spyOn( analyticsActions, 'withAnalytics' ).mockImplementation( ( _, action ) => action );
 			const spy = jest.fn();
 			const { authorize } = actions;
 
@@ -167,6 +173,7 @@ describe( '#authorize()', () => {
 		} );
 
 		test( 'should dispatch authorize receive site list action when request completes', async () => {
+			jest.spyOn( analyticsActions, 'withAnalytics' ).mockImplementation( ( _, action ) => action );
 			const spy = jest.fn();
 			const { authorize } = actions;
 
@@ -199,6 +206,7 @@ describe( '#authorize()', () => {
 		} );
 
 		test( 'should dispatch authorize receive action when request completes', async () => {
+			jest.spyOn( analyticsActions, 'withAnalytics' ).mockImplementation( ( _, action ) => action );
 			const spy = jest.fn();
 			const { authorize } = actions;
 
@@ -275,6 +283,7 @@ describe( '#validateSSONonce()', () => {
 		} );
 
 		test( 'should dispatch receive action when request completes', async () => {
+			jest.spyOn( analyticsActions, 'withAnalytics' ).mockImplementation( ( _, action ) => action );
 			const spy = jest.fn();
 			const { validateSSONonce } = actions;
 
@@ -306,6 +315,7 @@ describe( '#validateSSONonce()', () => {
 		} );
 
 		test( 'should dispatch receive action when request completes', async () => {
+			jest.spyOn( analyticsActions, 'withAnalytics' ).mockImplementation( ( _, action ) => action );
 			const spy = jest.fn();
 			const { validateSSONonce } = actions;
 
@@ -349,6 +359,7 @@ describe( '#authorizeSSO()', () => {
 		} );
 
 		test( 'should dispatch receive action when request completes', async () => {
+			jest.spyOn( analyticsActions, 'withAnalytics' ).mockImplementation( ( _, action ) => action );
 			const spy = jest.fn();
 			const { authorizeSSO } = actions;
 
@@ -375,6 +386,7 @@ describe( '#authorizeSSO()', () => {
 		} );
 
 		test( 'should dispatch receive action when request completes', async () => {
+			jest.spyOn( analyticsActions, 'withAnalytics' ).mockImplementation( ( _, action ) => action );
 			const spy = jest.fn();
 			const { authorizeSSO } = actions;
 
@@ -393,8 +405,6 @@ describe( '#authorizeSSO()', () => {
 
 describe( '#createAccount()', () => {
 	const { createAccount } = actions;
-
-	beforeEach( jest.restoreAllMocks );
 
 	test( 'should resolve with the username and bearer token', async () => {
 		const userData = { username: 'happyuser' };
@@ -426,8 +436,6 @@ describe( '#createAccount()', () => {
 
 describe( '#createSocialAccount()', () => {
 	const { createSocialAccount } = actions;
-
-	beforeEach( jest.restoreAllMocks );
 
 	test( 'should reject with the error', async () => {
 		const error = {


### PR DESCRIPTION
Jetpack connect dispatches _a lot_ of actions. Analytics do not need to be dispatched on their own, they can be batched with other action dispatches. This especially makes sense when they analytics are strongly associated with the dispatched actions.

- Use `withAnalytics` to merge analytics + action dispatches
- ~Mock `withAnalytics` in tests~
- Update tests to match `meta: { analytics: […] }`

## Testing
- `localStorage.debug = "calypso:analytics:tracks"`
- Connect a Jetpack site
- Verify that the same tracks events are dispatched during the connection flow
- Optionally verify the analytics actions are now in the `meta: analytics` part of the associated actions.