### PR TITLE
Don't send the payload to request privacy and unlocking.

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1803,17 +1803,12 @@ Undocumented.prototype.requestTransferCode = function( options, fn ) {
 	return this.wpcom.req.post( '/domains/' + domainName + '/transfer', data, fn );
 };
 
-Undocumented.prototype.cancelTransferRequest = function(
-	{ domainName, enablePrivacy, declineTransfer, lockDomain },
-	fn
-) {
+Undocumented.prototype.cancelTransferRequest = function( { domainName, declineTransfer }, fn ) {
 	const data = {
 		domainStatus: JSON.stringify( {
 			command: 'cancel-transfer-request',
 			payload: {
-				enable_privacy: enablePrivacy,
 				decline_transfer: declineTransfer,
-				lock_domain: lockDomain,
 			},
 		} ),
 	};

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1793,14 +1793,10 @@ Undocumented.prototype.fetchWapiDomainInfo = function( domainName, fn ) {
 };
 
 Undocumented.prototype.requestTransferCode = function( options, fn ) {
-	const { domainName, unlock, disablePrivacy } = options,
+	const { domainName } = options,
 		data = {
 			domainStatus: JSON.stringify( {
 				command: 'send-code',
-				payload: {
-					unlock,
-					disable_privacy: disablePrivacy,
-				},
 			} ),
 		};
 


### PR DESCRIPTION
Sometimes the `unlock` and `disable_privacy` options in the payload can be out of sync with the actual state of the domain at the registrar. We will now always check these states on the back end when this endpoint is called, so there is no longer any need to send them in the payload.

This PR is dependent on D12287-code.

Testing instructions in the diff.