### PR TITLE
Jetpack connect: Use global notices

### DIFF
--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -95,6 +95,7 @@ const NoticesList = createReactClass( {
 						showDismiss={ notice.showDismiss }
 						onDismissClick={ this.removeReduxNotice( notice ) }
 						text={ notice.text }
+						icon={ notice.icon }
 					>
 						{ notice.button && (
 							<NoticeAction href={ notice.href } onClick={ notice.onClick }>

--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -120,10 +120,8 @@ const NoticesList = createReactClass( {
 } );
 
 export default connect(
-	state => {
-		return {
-			storeNotices: getNotices( state ),
-		};
-	},
+	state => ( {
+		storeNotices: getNotices( state ),
+	} ),
 	{ removeNotice }
 )( NoticesList );

--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -43,10 +43,21 @@ const NoticesList = createReactClass( {
 		debug( 'Mounting Global Notices React component.' );
 	},
 
-	removeNotice( notice ) {
+	removeNoticeStoreNotice: notice => {
 		if ( notice ) {
 			notices.removeNotice( notice );
 		}
+	},
+
+	// Auto-bound by createReactClass.
+	// Migrate to arrow => when using class extends React.Component
+	removeReduxNotice( notice ) {
+		return e => {
+			if ( notice.onDismissClick ) {
+				notice.onDismissClick( e );
+			}
+			this.props.removeNotice( notice.noticeId );
+		};
 	},
 
 	render() {
@@ -59,7 +70,7 @@ const NoticesList = createReactClass( {
 					duration={ notice.duration || null }
 					text={ notice.text }
 					isCompact={ notice.isCompact }
-					onDismissClick={ this.removeNotice.bind( this, notice ) }
+					onDismissClick={ this.removeNoticeStoreNotice( notice ) }
 					showDismiss={ notice.showDismiss }
 				>
 					{ notice.button && (
@@ -82,7 +93,7 @@ const NoticesList = createReactClass( {
 						status={ notice.status }
 						duration={ notice.duration || null }
 						showDismiss={ notice.showDismiss }
-						onDismissClick={ this.props.removeNotice.bind( this, notice.noticeId ) }
+						onDismissClick={ this.removeReduxNotice( notice ) }
 						text={ notice.text }
 					>
 						{ notice.button && (

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -2,13 +2,15 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import { createNotice as createNoticeAction } from 'state/notices/actions';
 import {
 	ALREADY_CONNECTED,
 	ALREADY_CONNECTED_BY_OTHER_USER,
@@ -32,8 +34,6 @@ import {
 	WORDPRESS_DOT_COM,
 	XMLRPC_ERROR,
 } from './connection-notice-types';
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
 
 export class JetpackConnectNotices extends Component {
 	static propTypes = {
@@ -215,9 +215,11 @@ export class JetpackConnectNotices extends Component {
 		return null;
 	}
 
-	componentDidUpdate() {
+	componentDidUpdate( prevProps ) {
 		if ( this.errorIsTerminal() && this.props.onTerminalError ) {
 			this.props.onTerminalError( this.props.noticeType );
+		} else if ( prevProps.noticeType !== this.props.noticeType ) {
+			this.registerNotice();
 		}
 	}
 
@@ -225,6 +227,7 @@ export class JetpackConnectNotices extends Component {
 		if ( this.errorIsTerminal() && this.props.onTerminalError ) {
 			this.props.onTerminalError( this.props.noticeType );
 		}
+		this.registerNotice();
 	}
 
 	errorIsTerminal() {
@@ -232,31 +235,29 @@ export class JetpackConnectNotices extends Component {
 		return notice && ! notice.userCanRetry;
 	}
 
-	renderNoticeAction() {
-		const { onActionClick } = this.props;
-		const noticeActionText = this.getNoticeActionText();
-
-		if ( ! onActionClick || ! noticeActionText ) {
-			return null;
-		}
-
-		return <NoticeAction onClick={ onActionClick }>{ noticeActionText }</NoticeAction>;
-	}
-
-	render() {
-		const noticeValues = this.getNoticeValues();
+	registerNotice() {
 		if ( this.errorIsTerminal() && this.props.onTerminalError ) {
 			return null;
 		}
+		const noticeValues = this.getNoticeValues();
 		if ( noticeValues ) {
-			return (
-				<div className="jetpack-connect__notices-container">
-					<Notice { ...noticeValues }>{ this.renderNoticeAction() }</Notice>
-				</div>
-			);
+			const { createNotice, onActionClick } = this.props;
+			const { status, text, icon, showDismiss, onDismissClick } = noticeValues;
+			createNotice( status, text, {
+				button: onActionClick && this.getNoticeActionText(),
+				icon,
+				onClick: onActionClick,
+				onDismissClick,
+				showDismiss,
+			} );
 		}
+	}
+
+	render() {
 		return null;
 	}
 }
 
-export default localize( JetpackConnectNotices );
+export default connect( null, { createNotice: createNoticeAction } )(
+	localize( JetpackConnectNotices )
+);

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -65,7 +65,6 @@ export class JetpackConnectNotices extends Component {
 			XMLRPC_ERROR,
 		] ).isRequired,
 		translate: PropTypes.func.isRequired,
-		url: PropTypes.string,
 	};
 
 	getNoticeValues() {

--- a/client/state/notices/actions.js
+++ b/client/state/notices/actions.js
@@ -21,10 +21,11 @@ export function removeNotice( noticeId ) {
 }
 
 export function createNotice( status, text, options = {} ) {
+	const showDismiss = typeof options.showDismiss === 'boolean' ? options.showDismiss : true;
 	const notice = {
 		noticeId: options.id || uniqueId(),
 		duration: options.duration,
-		showDismiss: typeof options.showDismiss === 'boolean' ? options.showDismiss : true,
+		showDismiss,
 		isPersistent: options.isPersistent || false,
 		displayOnNextPage: options.displayOnNextPage || false,
 		status: status,
@@ -33,6 +34,9 @@ export function createNotice( status, text, options = {} ) {
 		href: options.href,
 		onClick: options.onClick,
 	};
+	if ( showDismiss && typeof options.onDismissClick === 'function' ) {
+		notice.onDismissClick = options.onDismissClick;
+	}
 
 	return {
 		type: NOTICE_CREATE,

--- a/client/state/notices/actions.js
+++ b/client/state/notices/actions.js
@@ -28,6 +28,7 @@ export function createNotice( status, text, options = {} ) {
 		showDismiss,
 		isPersistent: options.isPersistent || false,
 		displayOnNextPage: options.displayOnNextPage || false,
+		icon: options.icon,
 		status: status,
 		text: text,
 		button: options.button,

--- a/client/state/notices/actions.js
+++ b/client/state/notices/actions.js
@@ -23,17 +23,17 @@ export function removeNotice( noticeId ) {
 export function createNotice( status, text, options = {} ) {
 	const showDismiss = typeof options.showDismiss === 'boolean' ? options.showDismiss : true;
 	const notice = {
-		noticeId: options.id || uniqueId(),
-		duration: options.duration,
-		showDismiss,
-		isPersistent: options.isPersistent || false,
+		button: options.button,
 		displayOnNextPage: options.displayOnNextPage || false,
+		duration: options.duration,
+		href: options.href,
 		icon: options.icon,
+		isPersistent: options.isPersistent || false,
+		noticeId: options.id || uniqueId(),
+		onClick: options.onClick,
+		showDismiss,
 		status: status,
 		text: text,
-		button: options.button,
-		href: options.href,
-		onClick: options.onClick,
 	};
 	if ( showDismiss && typeof options.onDismissClick === 'function' ) {
 		notice.onDismissClick = options.onDismissClick;


### PR DESCRIPTION
Includes #24428 

This is a proof-of-concept which modifies `JetpackConnectNotices` component to dispatch redux notice actions rather than render components.

This moves notices which were previously contained inside the Jetpack Connect dialog out to be Global Notices. Here's a before/after example:

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/841763/39218505-6a4e8e5c-4825-11e8-846f-a7a70d131a85.png) | ![after](https://user-images.githubusercontent.com/841763/39218504-6a26babc-4825-11e8-9c9b-2910d733bae5.png) |

This is relevant as we work on optimistic plans rendering. It will be important to be able to show notices, such as status updates, that are not linked to container components. For example, we'll want to show connection updates, while allowing the user to select a plan.

This is just an initial implementation and I'd like to get design feedback before going any further.

Try playing with this on [calypso.live](https://calypso.live/jetpack/connect?branch=update/jpc-auth-global-notices)