### PR TITLE
Activity Log: add persistent notices

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -425,6 +425,7 @@
 @import 'my-sites/stats/activity-log-confirm-dialog/style';
 @import 'my-sites/stats/activity-log-item/style';
 @import 'my-sites/stats/activity-log-switch/style';
+@import 'my-sites/stats/activity-log-tasklist/style';
 @import 'my-sites/stats/all-time/style';
 @import 'my-sites/stats/annual-site-stats/style';
 @import 'my-sites/stats/checklist-banner/style';

--- a/client/my-sites/stats/activity-log-tasklist/index.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/index.jsx
@@ -1,0 +1,309 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { isEmpty, get, merge, each, omit, keyBy, union, some } from 'lodash';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import ActivityLogTaskUpdate from './update';
+import WithPluginsToUpdate from './plugins-to-update';
+import Card from 'components/card';
+import PopoverMenuItem from 'components/popover/menu-item';
+import EllipsisMenu from 'components/ellipsis-menu';
+import TrackComponentView from 'lib/analytics/track-component-view';
+import PluginNotices from 'lib/plugins/notices';
+import { getSite } from 'state/sites/selectors';
+import { updatePlugin } from 'state/plugins/installed/actions';
+import { getStatusForPlugin } from 'state/plugins/installed/selectors';
+import { errorNotice, infoNotice, successNotice } from 'state/notices/actions';
+import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
+
+/**
+ * Checks if the supplied plugin or plugins are currently updating.
+ *
+ * @param {array} plugins List of plugin object to check their update status.
+ * @returns {bool}        True if one or more plugins are updating.
+ */
+const isPluginUpdating = plugins =>
+	some( plugins, plugin => 'inProgress' === get( plugin, 'updateStatus.status' ) );
+
+class ActivityLogTasklist extends Component {
+	static propTypes = {
+		siteId: PropTypes.number,
+		plugins: PropTypes.arrayOf( PropTypes.object ), // Plugins updated and those with pending updates
+
+		// Connected props
+		siteName: PropTypes.string.isRequired,
+		// Plugins already updated + those with pending updates.
+		// This extends plugins with the plugin update status.
+		pluginsWithUpdate: PropTypes.object.isRequired,
+
+		// Localize
+		translate: PropTypes.func.isRequired,
+		updateSinglePlugin: PropTypes.func.isRequired,
+		showErrorNotice: PropTypes.func.isRequired,
+		showInfoNotice: PropTypes.func.isRequired,
+		showSuccessNotice: PropTypes.func.isRequired,
+	};
+
+	state = {
+		pluginUpdateNotice: null, // keyed by plugin id, like "hello-dolly/hello"
+		dismissedPlugins: [],
+	};
+
+	/**
+	 * Adds a single or multiple plugin slugs to a list of dismissed plugins.
+	 * If it receives a string, it assumes it's a valid plugin slug and adds it to the dismissed list.
+	 * When it doesn't receive a string, it adds all the plugin slugs to the dismissed list.
+	 *
+	 * @param {string|void} pluginSlug Slug of a plugin or nothing.
+	 */
+	dismissPlugins = pluginSlug => {
+		// ToDo: this should update some record in the tasklist API
+		const { pluginsWithUpdate, trackDismissPlugin, trackDismissPluginAll } = this.props;
+		let plugins;
+
+		if ( 'string' === typeof pluginSlug ) {
+			plugins = [ pluginSlug ];
+			trackDismissPlugin( pluginSlug );
+		} else {
+			plugins = Object.keys( pluginsWithUpdate );
+			trackDismissPluginAll();
+		}
+
+		this.setState( {
+			dismissedPlugins: union( this.state.dismissedPlugins, plugins ),
+		} );
+	};
+
+	/**
+	 * Starts the update process for a specified plugin. Displays an informational notice.
+	 *
+	 * @param {object} singlePlugin Plugin information that includes
+	 * {
+	 * 		{string} id   Plugin id, like "hello-dolly/hello".
+	 * 		{string} slug Plugin slug, like "hello-dolly".
+	 * 		{string} name Plugin name, like "Hello Dolly".
+	 * }
+	 * @param {string} location Send 'from_task' when this is called a row in the task list,
+	 *                          'from_notice' when it's called from error notice.
+	 */
+	updatePlugin = ( singlePlugin, location = 'from_task' ) => {
+		const { showInfoNotice, siteName, updateSinglePlugin } = this.props;
+
+		updateSinglePlugin( singlePlugin, location );
+
+		this.setState( {
+			pluginUpdateNotice: merge( this.state.pluginUpdateNotice, {
+				[ singlePlugin.slug ]: showInfoNotice(
+					PluginNotices.inProgressMessage( 'UPDATE_PLUGIN', '1 site 1 plugin', {
+						plugin: singlePlugin.name,
+						site: siteName,
+					} ),
+					{
+						id: singlePlugin.slug,
+						showDismiss: false,
+					}
+				),
+			} ),
+		} );
+	};
+
+	componentDidUpdate( prevProps, prevState ) {
+		if ( isEmpty( this.props.pluginsWithUpdate ) ) {
+			return;
+		}
+
+		const {
+			showErrorNotice,
+			showSuccessNotice,
+			siteName,
+			translate,
+			pluginsWithUpdate,
+		} = this.props;
+		const newState = {};
+		const noticesToShow = {};
+		const pluginsCompleted = [];
+
+		each( Object.values( pluginsWithUpdate ), plugin => {
+			const pluginSlug = plugin.slug;
+
+			if ( false === get( prevProps.pluginsWithUpdate, [ pluginSlug, 'updateStatus' ], false ) ) {
+				return;
+			}
+
+			if (
+				get( prevProps.pluginsWithUpdate, [ pluginSlug, 'updateStatus', 'status' ], false ) ===
+					get( plugin.updateStatus, 'status', false ) ||
+				isPluginUpdating( plugin )
+			) {
+				return;
+			}
+
+			const updateStatus = plugin.updateStatus;
+			const updateNoticeId = get(
+				prevState.pluginUpdateNotice,
+				[ pluginSlug, 'notice', 'noticeId' ],
+				null
+			);
+
+			// If there is no notice displayed
+			if ( ! updateNoticeId ) {
+				return;
+			}
+
+			noticesToShow[ pluginSlug ] = null;
+
+			// If it errored, clear and show error notice
+			const pluginData = {
+				plugin: plugin.name,
+				site: siteName,
+			};
+
+			switch ( updateStatus.status ) {
+				case 'error':
+					noticesToShow[ pluginSlug ] = showErrorNotice(
+						PluginNotices.singleErrorMessage( 'UPDATE_PLUGIN', pluginData, {
+							error: updateStatus,
+						} ),
+						{
+							id: pluginSlug,
+							button: translate( 'Try again' ),
+							onClick: () => this.updatePlugin( plugin, 'from_notice' ),
+						}
+					);
+					break;
+				case 'completed':
+					noticesToShow[ pluginSlug ] = showSuccessNotice(
+						PluginNotices.successMessage( 'UPDATE_PLUGIN', '1 site 1 plugin', pluginData ),
+						{
+							id: pluginSlug,
+							duration: 5555,
+						}
+					);
+					pluginsCompleted.push( pluginSlug );
+					break;
+			}
+		} );
+
+		if ( ! isEmpty( noticesToShow ) ) {
+			newState.pluginUpdateNotice = merge( {}, prevState.pluginUpdateNotice, noticesToShow );
+		}
+
+		if ( ! isEmpty( pluginsCompleted ) ) {
+			newState.dismissedPlugins = union( prevState.dismissedPlugins, pluginsCompleted );
+		}
+
+		return isEmpty( newState ) ? null : newState;
+	}
+
+	render() {
+		const pluginsToUpdate = Object.values(
+			omit( this.props.pluginsWithUpdate, this.state.dismissedPlugins )
+		);
+		if ( isEmpty( pluginsToUpdate ) ) {
+			return null;
+		}
+
+		const { translate } = this.props;
+		const numberOfPluginUpdates = pluginsToUpdate.length;
+		const isSomePluginUpdating = isPluginUpdating( pluginsToUpdate );
+
+		return (
+			<Card className="activity-log-tasklist" highlight="warning">
+				<TrackComponentView eventName={ 'calypso_activitylog_tasklist_update_impression' } />
+				<div className="activity-log-tasklist__heading">
+					{ // Not using count method since we want a "one" string.
+					1 < numberOfPluginUpdates
+						? translate( 'You have %(updates)s updates available', {
+								args: { updates: numberOfPluginUpdates },
+							} )
+						: translate( 'You have one update available' ) }
+					<EllipsisMenu>
+						<PopoverMenuItem
+							onClick={ this.dismissPlugins }
+							className="activity-log-tasklist__dismiss-all"
+							disabled={ isSomePluginUpdating }
+						>
+							<Gridicon icon="trash" size={ 24 } />
+							<span>{ translate( 'Dismiss all' ) }</span>
+						</PopoverMenuItem>
+					</EllipsisMenu>
+				</div>
+				{ // Show if plugin update didn't start, is still running or errored,
+				// but hide plugin if it was updated successfully.
+				pluginsToUpdate.map( plugin => (
+					<ActivityLogTaskUpdate
+						key={ plugin.id }
+						plugin={ plugin }
+						updatePlugin={ this.updatePlugin }
+						dismissPlugin={ this.dismissPlugins }
+						disable={ isSomePluginUpdating }
+					/>
+				) ) }
+			</Card>
+		);
+	}
+}
+
+/**
+ * Creates an object, keyed by plugin slug, of objects containing plugin information
+ * {
+ * 		{string}       id     Plugin directory and base file name without extension
+ * 		{string}       slug   Plugin directory
+ * 		{string}       name   Plugin name
+ * 		{object|false} status Current update status
+ * }
+ * @param {array}  pluginList List of plugins that will be updated
+ * @param {object} state      Progress of plugin update as found in status.plugins.installed.state.
+ * @param {number} siteId     ID of the site where the plugin is installed
+ *
+ * @returns {array} List of plugins to update with their status.
+ */
+const makePluginsList = ( pluginList, state, siteId ) =>
+	keyBy(
+		pluginList.map( plugin =>
+			merge( {}, plugin, { updateStatus: getStatusForPlugin( state, siteId, plugin.id ) } )
+		),
+		'slug'
+	);
+
+const mapStateToProps = ( state, { siteId, plugins } ) => {
+	const site = getSite( state, siteId );
+	return {
+		siteId,
+		siteName: site.name,
+		pluginsWithUpdate: makePluginsList( plugins, state, siteId ),
+	};
+};
+
+const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
+	updateSinglePlugin: ( plugin, location ) =>
+		dispatch(
+			withAnalytics(
+				recordTracksEvent( 'calypso_activitylog_tasklist_update_plugin', {
+					plugin_slug: plugin.slug,
+					location,
+				} ),
+				updatePlugin( siteId, plugin )
+			)
+		),
+	showErrorNotice: ( error, options ) => dispatch( errorNotice( error, options ) ),
+	showInfoNotice: ( info, options ) => dispatch( infoNotice( info, options ) ),
+	showSuccessNotice: ( success, options ) => dispatch( successNotice( success, options ) ),
+	trackDismissPluginAll: () =>
+		dispatch( recordTracksEvent( 'calypso_activitylog_tasklist_dismiss_plugin_all' ) ),
+	trackDismissPlugin: plugin_slug =>
+		dispatch( recordTracksEvent( 'calypso_activitylog_tasklist_dismiss_plugin', { plugin_slug } ) ),
+} );
+
+export default WithPluginsToUpdate(
+	connect( mapStateToProps, mapDispatchToProps )( localize( ActivityLogTasklist ) )
+);

--- a/client/my-sites/stats/activity-log-tasklist/plugins-to-update.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/plugins-to-update.jsx
@@ -1,0 +1,47 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { unionBy } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getPluginsWithUpdates } from 'state/plugins/installed/selectors';
+
+export default WrappedComponent => {
+	class PluginsToUpdate extends Component {
+		static propTypes = {
+			siteId: PropTypes.number,
+
+			// Connected
+			plugins: PropTypes.arrayOf( PropTypes.object ),
+		};
+
+		state = {
+			// Plugins already updated + those with pending updates
+			plugins: [],
+		};
+
+		static getDerivedStateFromProps( nextProps, prevState ) {
+			return { plugins: unionBy( nextProps.plugins, prevState.plugins, 'slug' ) };
+		}
+
+		render() {
+			return (
+				<WrappedComponent
+					{ ...this.props }
+					siteId={ this.props.siteId }
+					plugins={ this.state.plugins }
+				/>
+			);
+		}
+	}
+	return connect( ( state, { siteId } ) => ( {
+		plugins: getPluginsWithUpdates( state, [ siteId ] ),
+	} ) )( PluginsToUpdate );
+};

--- a/client/my-sites/stats/activity-log-tasklist/style.scss
+++ b/client/my-sites/stats/activity-log-tasklist/style.scss
@@ -37,7 +37,10 @@
 }
 
 .activity-log-tasklist__update-text {
-
+	.button.is-borderless {
+		vertical-align: middle;
+		line-height: 1;
+	}
 }
 
 .activity-log-tasklist__update-version {
@@ -55,7 +58,7 @@
 	white-space: pre;
 }
 
-.activity-log-tasklist__dismiss-all {
+.activity-log-tasklist__menu-item {
 	display: flex;
 	align-items: center;
 }

--- a/client/my-sites/stats/activity-log-tasklist/style.scss
+++ b/client/my-sites/stats/activity-log-tasklist/style.scss
@@ -1,11 +1,17 @@
 .card.activity-log-tasklist {
 	padding-bottom: 4px;
+	font-size: 14px;
 
 	.activity-log-tasklist__heading {
 		display: flex;
-		font-weight: 700;
+		font-weight: 500;
 		justify-content: space-between;
 		margin-bottom: 16px;
+
+		.ellipsis-menu {
+			position: relative;
+			top: -4px;
+		}
 
 		.ellipsis-menu__toggle {
 			padding: 0;
@@ -18,7 +24,7 @@
 	box-shadow: 0 -1px 0 transparentize( $gray-lighten-20, .5 );
 	display: flex;
 	justify-content: flex-end;
-	padding: 16px 8px;
+	padding: 16px 0;
 
 	.activity-log-item__activity-icon {
 		margin-right: 16px;
@@ -31,7 +37,7 @@
 }
 
 .activity-log-tasklist__update-text {
-	font-weight: 500;
+
 }
 
 .activity-log-tasklist__update-version {

--- a/client/my-sites/stats/activity-log-tasklist/style.scss
+++ b/client/my-sites/stats/activity-log-tasklist/style.scss
@@ -1,0 +1,55 @@
+.card.activity-log-tasklist {
+	padding-bottom: 4px;
+
+	.activity-log-tasklist__heading {
+		display: flex;
+		font-weight: 700;
+		justify-content: space-between;
+		margin-bottom: 16px;
+
+		.ellipsis-menu__toggle {
+			padding: 0;
+		}
+	}
+}
+
+.card.activity-log-tasklist__task {
+	align-items: center;
+	box-shadow: 0 -1px 0 transparentize( $gray-lighten-20, .5 );
+	display: flex;
+	justify-content: flex-end;
+	padding: 16px 8px;
+
+	.activity-log-item__activity-icon {
+		margin-right: 16px;
+		padding: 8px;
+	}
+}
+
+.activity-log-tasklist__update-item {
+	flex-grow: 1;
+}
+
+.activity-log-tasklist__update-text {
+	font-weight: 500;
+}
+
+.activity-log-tasklist__update-version {
+	color: $gray-text-min;
+}
+
+.activity-log-tasklist__update-bullet {
+	color: $gray-text-min;
+	font-size: 10px;
+	margin: 0 8px;
+	vertical-align: text-bottom;
+}
+
+.activity-log-tasklist__update-action {
+	white-space: pre;
+}
+
+.activity-log-tasklist__dismiss-all {
+	display: flex;
+	align-items: center;
+}

--- a/client/my-sites/stats/activity-log-tasklist/update.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/update.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import ActivityIcon from '../activity-log-item/activity-icon';
+import Button from 'components/button';
 import Card from 'components/card';
 import PopoverMenuItem from 'components/popover/menu-item';
 import SplitButton from 'components/split-button';
@@ -27,6 +28,7 @@ class ActivityLogTaskUpdate extends Component {
 		disable: PropTypes.bool,
 		updatePlugin: PropTypes.func,
 		dismissPlugin: PropTypes.func,
+		goToPlugin: PropTypes.func,
 
 		// Localize
 		translate: PropTypes.func.isRequired,
@@ -34,6 +36,7 @@ class ActivityLogTaskUpdate extends Component {
 
 	handlePluginUpdate = () => this.props.updatePlugin( this.props.plugin );
 	handlePluginDismiss = () => this.props.dismissPlugin( this.props.plugin.slug );
+	handlePluginNameClick = () => this.props.goToPlugin( this.props.plugin.slug );
 
 	render() {
 		const { translate, plugin, disable } = this.props;
@@ -43,8 +46,14 @@ class ActivityLogTaskUpdate extends Component {
 				<ActivityIcon activityIcon="plugins" activityStatus="warning" />
 				<span className="activity-log-tasklist__update-item">
 					<span className="activity-log-tasklist__update-text">
-						{ translate( 'Update available for %(pluginName)s', {
-							args: { pluginName: plugin.name },
+						{ translate( 'Update available for {{plugin/}}', {
+							components: {
+								plugin: (
+									<Button onClick={ this.handlePluginNameClick } borderless>
+										{ plugin.name }
+									</Button>
+								),
+							},
 						} ) }
 					</span>
 					<span className="activity-log-tasklist__update-bullet">&bull;</span>

--- a/client/my-sites/stats/activity-log-tasklist/update.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/update.jsx
@@ -26,7 +26,7 @@ class ActivityLogTaskUpdate extends Component {
 			name: PropTypes.string,
 		} ).isRequired,
 		disable: PropTypes.bool,
-		updatePlugin: PropTypes.func,
+		enqueuePlugin: PropTypes.func,
 		dismissPlugin: PropTypes.func,
 		goToPlugin: PropTypes.func,
 
@@ -34,7 +34,7 @@ class ActivityLogTaskUpdate extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
-	handlePluginUpdate = () => this.props.updatePlugin( this.props.plugin );
+	handlePluginEnqueue = () => this.props.enqueuePlugin( this.props.plugin );
 	handlePluginDismiss = () => this.props.dismissPlugin( this.props.plugin.slug );
 	handlePluginNameClick = () => this.props.goToPlugin( this.props.plugin.slug );
 
@@ -66,7 +66,7 @@ class ActivityLogTaskUpdate extends Component {
 						compact
 						primary
 						label={ translate( 'Update' ) }
-						onClick={ this.handlePluginUpdate }
+						onClick={ this.handlePluginEnqueue }
 						disabled={ disable }
 					>
 						<PopoverMenuItem icon="trash" onClick={ this.handlePluginDismiss }>

--- a/client/my-sites/stats/activity-log-tasklist/update.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/update.jsx
@@ -1,0 +1,73 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ActivityIcon from '../activity-log-item/activity-icon';
+import Card from 'components/card';
+import PopoverMenuItem from 'components/popover/menu-item';
+import SplitButton from 'components/split-button';
+
+class ActivityLogTaskUpdate extends Component {
+	static propTypes = {
+		plugin: PropTypes.shape( {
+			id: PropTypes.string,
+			slug: PropTypes.string,
+			update: PropTypes.shape( {
+				new_version: PropTypes.string,
+			} ),
+			name: PropTypes.string,
+		} ).isRequired,
+		disable: PropTypes.bool,
+		updatePlugin: PropTypes.func,
+		dismissPlugin: PropTypes.func,
+
+		// Localize
+		translate: PropTypes.func.isRequired,
+	};
+
+	handlePluginUpdate = () => this.props.updatePlugin( this.props.plugin );
+	handlePluginDismiss = () => this.props.dismissPlugin( this.props.plugin.slug );
+
+	render() {
+		const { translate, plugin, disable } = this.props;
+
+		return (
+			<Card className="activity-log-tasklist__task" compact>
+				<ActivityIcon activityIcon="plugins" activityStatus="warning" />
+				<span className="activity-log-tasklist__update-item">
+					<span className="activity-log-tasklist__update-text">
+						{ translate( 'Update available for %(pluginName)s', {
+							args: { pluginName: plugin.name },
+						} ) }
+					</span>
+					<span className="activity-log-tasklist__update-bullet">&bull;</span>
+					<span className="activity-log-tasklist__update-version">
+						{ plugin.update.new_version }
+					</span>
+				</span>
+				<span className="activity-log-tasklist__update-action">
+					<SplitButton
+						compact
+						primary
+						label={ translate( 'Update' ) }
+						onClick={ this.handlePluginUpdate }
+						disabled={ disable }
+					>
+						<PopoverMenuItem icon="trash" onClick={ this.handlePluginDismiss }>
+							{ translate( 'Dismiss' ) }
+						</PopoverMenuItem>
+					</SplitButton>
+				</span>
+			</Card>
+		);
+	}
+}
+
+export default localize( ActivityLogTaskUpdate );

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -16,6 +16,7 @@ import { get, includes, isEmpty } from 'lodash';
 import ActivityLogBanner from 'my-sites/stats/activity-log-banner';
 import ActivityLogItem from '../activity-log-item';
 import ActivityLogSwitch from '../activity-log-switch';
+import ActivityLogTasklist from '../activity-log-tasklist';
 import Banner from 'components/banner';
 import DocumentHead from 'components/data/document-head';
 import EmptyContent from 'components/empty-content';
@@ -408,6 +409,7 @@ class ActivityLog extends Component {
 						) }
 					/>
 				) }
+				{ siteId && <ActivityLogTasklist siteId={ siteId } /> }
 				{ this.renderErrorMessage() }
 				{ this.renderActionProgress() }
 				{ isEmpty( logs ) ? (


### PR DESCRIPTION
Displays the most urgent tasks that the user needs to take care of.

#### Testing

1. downgrade the version of some plugins
2. boot https://calypso.live/?branch=add/activity-log-tasklist
3. go to Activity Log

To forge the plugin update error, you need to set the permissions of the plugin directory to 555 so it's not writable and update fails.

#### Updates and dismiss of single element
(The success notice fades away on its own after 5 secs I just clicked the x for the demo)

![tasklist](https://user-images.githubusercontent.com/1041600/39223980-2cae1afe-481b-11e8-873b-fd5f8e2b4802.gif)

#### Load plugin update after page load that just become available
(I edited the plugin to downgrade its version at the same time)

![tasklist2](https://user-images.githubusercontent.com/1041600/39224048-7ff6514a-481b-11e8-956f-1f73fd684a81.gif)

<img width="785" alt="captura de pantalla 2018-04-26 a la s 17 54 22" src="https://user-images.githubusercontent.com/1041600/39331449-0183add8-497b-11e8-8278-ca56cf821a1e.png">

#### Tracking

This introduces several tracking:

When the tasklist is displayed

<img width="371" alt="captura de pantalla 2018-04-26 a la s 14 23 48" src="https://user-images.githubusercontent.com/1041600/39323505-2c400cbe-4963-11e8-98d3-1423f652e2b5.png">

When a plugin is dismissed

<img width="380" alt="captura de pantalla 2018-04-26 a la s 14 24 33" src="https://user-images.githubusercontent.com/1041600/39323506-2cd6a700-4963-11e8-9151-e626ba76a0d2.png">

When all plugins are dismissed

<img width="381" alt="captura de pantalla 2018-04-26 a la s 14 24 43" src="https://user-images.githubusercontent.com/1041600/39323508-2d70d7a8-4963-11e8-9ac4-ac18516cbd96.png">

When a plugin is updated, from a task

<img width="380" alt="captura de pantalla 2018-04-26 a la s 14 42 01" src="https://user-images.githubusercontent.com/1041600/39323509-2df07602-4963-11e8-8a8a-3e0db4720a21.png">

and from a notice

<img width="379" alt="captura de pantalla 2018-04-26 a la s 14 43 20" src="https://user-images.githubusercontent.com/1041600/39323510-2e5cfe94-4963-11e8-87aa-fbefe08859d1.png">

### Update Apr 26
When one plugin update starts, all the update buttons and the dismiss all menu are disabled

### Update Apr 27
New link Manage plugins in main ellipsis menu takes users to the plugin management screen in Calypso.
Plugin name is now linked to its section inside plugin management.
Two new event tracking:
- calypso_activitylog_tasklist_manage_plugins When user clicks the **Manage plugins** link
- calypso_activitylog_tasklist_manage_single_plugin When user clicks on the plugin name to go to its page

<img width="570" alt="captura de pantalla 2018-04-27 a la s 15 31 11" src="https://user-images.githubusercontent.com/1041600/39379359-574e3b32-4a31-11e8-9e07-0ca0b999d36a.png">

### Update May 4
New button Update all updates all plugins.
Plugin updates are now fired sequentially following a queue.
New tracking `calypso_activitylog_tasklist_update_plugin_all` when user clicks the button to update all plugins
~~New~~ (refactored from an existing one) tracking `calypso_activitylog_tasklist_update_plugin_from_error` tracks when user clicks the Try again button in the error notice. Previously this was tracked in the `calypso_activitylog_tasklist_update_plugin` passing a property location, but doing it this way is easier to get reports.
Tracking is now no longer coupled with the dispatched action `updatePlugin`, since that's now driven by the queue processing rather than user interaction. Instead, clicks are now tracked directly in the onClick method that the buttons call.