### PR TITLE
DevDocs: Hide the code for devdocs playground components by default

### DIFF
--- a/client/devdocs/design/component-playground.jsx
+++ b/client/devdocs/design/component-playground.jsx
@@ -11,6 +11,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import ClipboardButton from 'components/forms/clipboard-button';
 import DocsExampleWrapper from 'devdocs/docs-example/wrapper';
 import * as playgroundScope from 'devdocs/design/playground-scope';
@@ -20,9 +21,19 @@ class ComponentPlayground extends Component {
 		code: PropTypes.string,
 	};
 
+	state = {
+		showCode: false,
+	};
+
 	handleClick() {
 		alert( 'Copied to clipboard!' );
 	}
+
+	showCode = () => {
+		this.setState( {
+			showCode: true,
+		} );
+	};
 
 	render() {
 		return (
@@ -40,21 +51,31 @@ class ComponentPlayground extends Component {
 					<LivePreview />
 				</DocsExampleWrapper>
 
-				{ this.props.component && (
-					<div className="design__component-playground-code">
-						<ClipboardButton
-							text={ this.props.code }
-							borderless
-							onClick={ this.handleClick }
-							className="design__component-playground-clipboard"
-						>
-							<Gridicon icon="clipboard" />
-						</ClipboardButton>
+				{ this.props.component &&
+					! this.state.showCode && (
+						<div className="design__component-playground-show-code">
+							<Button borderless onClick={ this.showCode }>
+								Show code <Gridicon icon="code" />
+							</Button>
+						</div>
+					) }
 
-						<LiveError />
-						<LiveEditor />
-					</div>
-				) }
+				{ this.props.component &&
+					this.state.showCode && (
+						<div className="design__component-playground-code">
+							<ClipboardButton
+								text={ this.props.code }
+								borderless
+								onClick={ this.handleClick }
+								className="design__component-playground-clipboard"
+							>
+								<Gridicon icon="clipboard" />
+							</ClipboardButton>
+
+							<LiveError />
+							<LiveEditor />
+						</div>
+					) }
 			</LiveProvider>
 		);
 	}

--- a/client/devdocs/design/component-playground.jsx
+++ b/client/devdocs/design/component-playground.jsx
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live';
 import Gridicon from 'gridicons';
@@ -31,11 +32,16 @@ class ComponentPlayground extends Component {
 
 	showCode = () => {
 		this.setState( {
-			showCode: true,
+			showCode: ! this.state.showCode,
 		} );
 	};
 
 	render() {
+		const toggleCode = this.props.code.length > 200;
+		const codeClassName = classNames( {
+			'design__component-playground-code': true,
+			'show-code': toggleCode ? this.state.showCode : true,
+		} );
 		return (
 			<LiveProvider
 				code={ this.props.code }
@@ -51,29 +57,28 @@ class ComponentPlayground extends Component {
 					<LivePreview />
 				</DocsExampleWrapper>
 
+				{ this.props.component && (
+					<div className={ codeClassName }>
+						<ClipboardButton
+							text={ this.props.code }
+							borderless
+							onClick={ this.handleClick }
+							className="design__component-playground-clipboard"
+						>
+							<Gridicon icon="clipboard" />
+						</ClipboardButton>
+
+						<LiveError />
+						<LiveEditor />
+					</div>
+				) }
+
 				{ this.props.component &&
-					! this.state.showCode && (
+					toggleCode && (
 						<div className="design__component-playground-show-code">
-							<Button borderless onClick={ this.showCode }>
-								Show code <Gridicon icon="code" />
+							<Button onClick={ this.showCode }>
+								{ this.state.showCode ? 'Hide' : 'Show' } code <Gridicon icon="code" />
 							</Button>
-						</div>
-					) }
-
-				{ this.props.component &&
-					this.state.showCode && (
-						<div className="design__component-playground-code">
-							<ClipboardButton
-								text={ this.props.code }
-								borderless
-								onClick={ this.handleClick }
-								className="design__component-playground-clipboard"
-							>
-								<Gridicon icon="clipboard" />
-							</ClipboardButton>
-
-							<LiveError />
-							<LiveEditor />
 						</div>
 					) }
 			</LiveProvider>

--- a/client/devdocs/design/style.scss
+++ b/client/devdocs/design/style.scss
@@ -69,6 +69,10 @@
 		top: 10px;
 }
 
+.design__component-playground-show-code {
+	text-align: center;
+}
+
 .design__playground-examples {
 	margin-bottom: 1em;
 	text-align: right;

--- a/client/devdocs/design/style.scss
+++ b/client/devdocs/design/style.scss
@@ -59,7 +59,13 @@
 }
 
 .design__component-playground-code {
+	max-height: 100px;
+	overflow: hidden;
 	position: relative;
+
+	&.show-code {
+		max-height: none;
+	}
 }
 
 .design__component-playground-clipboard {
@@ -70,6 +76,7 @@
 }
 
 .design__component-playground-show-code {
+	margin-top: 1em;
 	text-align: center;
 }
 

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -474,5 +474,4 @@ a.devdocs__doc-edit-link {
 	text-decoration: underline;
 	float: right;
 	position: relative;
-	top: -20px;
 }


### PR DESCRIPTION
For some components the code section is very long (like buttons). This hides the code behind a "Show Code" button:

<img width="709" alt="screen shot 2018-04-25 at 10 48 30" src="https://user-images.githubusercontent.com/275961/39238487-400dc792-4876-11e8-900b-59bf140d6061.png">

<img width="711" alt="screen shot 2018-04-25 at 10 48 37" src="https://user-images.githubusercontent.com/275961/39238486-3fe30962-4876-11e8-9f5a-c1435dbd0447.png">

To test go to /devdocs/action-card