### PR TITLE
DevDocs: Show Badges in the component playground

### DIFF
--- a/client/components/badge/docs/example.jsx
+++ b/client/components/badge/docs/example.jsx
@@ -11,17 +11,17 @@ import React from 'react';
  */
 import Badge from 'components/badge';
 
-const BadgeExample = () => (
-	<div>
-		<div className="docs__design-badge-row">
-			<Badge type="success">Success Badge</Badge>
-		</div>
-		<div className="docs__design-badge-row">
-			<Badge type="warning">Warning Badge</Badge>
-		</div>
-	</div>
-);
+const BadgeExample = () => this.props.exampleCode;
 
 BadgeExample.displayName = 'Badge';
+
+BadgeExample.defaultProps = {
+	exampleCode: (
+		<div>
+			<Badge type="success">Success Badge</Badge>
+			<Badge type="warning">Warning Badge</Badge>
+		</div>
+	),
+};
 
 export default BadgeExample;

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -288,7 +288,6 @@ $devdocs-max-width: 720px;
 
 // Some components/blocks need some space to look right
 .docs__design-button-row,
-.docs__design-badge-row,
 .design__button-row {
     margin-bottom: 20px;
 }


### PR DESCRIPTION
This adds Badges to the component playground:

<img width="709" alt="screen shot 2018-04-25 at 11 51 34" src="https://user-images.githubusercontent.com/275961/39241534-311280c6-487f-11e8-8634-7d8ce3efa8a8.png">

I also removed the .docs__design-badge-row class as I don't think we need it here.