### PR TITLE
Preserve domainToBundle information when updating a plan from a subscription length picker

### DIFF
--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -42,13 +42,7 @@ import {
 	RECEIVED_WPCOM_RESPONSE,
 	SUBMITTING_WPCOM_REQUEST,
 } from 'lib/store-transactions/step-types';
-import {
-	addItem,
-	removeItem,
-	applyCoupon,
-	resetTransaction,
-	setDomainDetails,
-} from 'lib/upgrades/actions';
+import { addItem, applyCoupon, resetTransaction, setDomainDetails } from 'lib/upgrades/actions';
 import {
 	getContactDetailsCache,
 	getCurrentUserPaymentMethods,
@@ -545,9 +539,10 @@ class Checkout extends React.Component {
 	}
 
 	handleTermChange = ( { value: planSlug } ) => {
-		this.getPlanProducts().forEach( removeItem );
-
-		const cartItem = getCartItemForPlan( planSlug );
+		const products = this.getPlanProducts();
+		const cartItem = getCartItemForPlan( planSlug, {
+			domainToBundle: get( products, '[0].extra.domain_to_bundle', '' ),
+		} );
 		analytics.tracks.recordEvent( 'calypso_signup_plan_select', {
 			product_slug: cartItem.product_slug,
 			free_trial: cartItem.free_trial,

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -42,7 +42,13 @@ import {
 	RECEIVED_WPCOM_RESPONSE,
 	SUBMITTING_WPCOM_REQUEST,
 } from 'lib/store-transactions/step-types';
-import { addItem, applyCoupon, resetTransaction, setDomainDetails } from 'lib/upgrades/actions';
+import {
+	addItem,
+	removeItem,
+	applyCoupon,
+	resetTransaction,
+	setDomainDetails,
+} from 'lib/upgrades/actions';
 import {
 	getContactDetailsCache,
 	getCurrentUserPaymentMethods,
@@ -543,6 +549,7 @@ class Checkout extends React.Component {
 		const cartItem = getCartItemForPlan( planSlug, {
 			domainToBundle: get( products, '[0].extra.domain_to_bundle', '' ),
 		} );
+		products.forEach( removeItem );
 		analytics.tracks.recordEvent( 'calypso_signup_plan_select', {
 			product_slug: cartItem.product_slug,
 			free_trial: cartItem.free_trial,


### PR DESCRIPTION
Make sure that information about "domainToBundle" is preserved when choosing new plan from subscription length picker in checkout.

Test plan:
1. Follow instructions in https://github.com/Automattic/wp-calypso/pull/22867 and get to the following state: 

<img width="273" alt="zrzut ekranu 2018-04-25 o 12 58 50" src="https://user-images.githubusercontent.com/205419/39243068-90305800-488c-11e8-862d-b8f9bf5dc3c6.png">

1. Switch to a 2 year plan and confirm the Domain renewal fee is still there
