### PR TITLE
2 year plans: Checkout page should be in "loading" state until cart items are known

### DIFF
--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -73,7 +73,7 @@ import QueryProducts from 'components/data/query-products-list';
 import { isRequestingSitePlans } from 'state/sites/plans/selectors';
 import { isRequestingPlans } from 'state/plans/selectors';
 
-class Checkout extends React.Component {
+export class Checkout extends React.Component {
 	static propTypes = {
 		cards: PropTypes.array.isRequired,
 		couponCode: PropTypes.string,
@@ -82,6 +82,7 @@ class Checkout extends React.Component {
 
 	state = {
 		previousCart: null,
+		cartSettled: false,
 	};
 
 	componentWillMount() {
@@ -113,6 +114,12 @@ class Checkout extends React.Component {
 			}
 
 			this.trackPageView();
+		}
+
+		if ( ! this.state.cartSettled && ! nextProps.cart.hasPendingServerUpdates ) {
+			this.setState( {
+				cartSettled: true,
+			} );
 		}
 	}
 
@@ -568,8 +575,11 @@ class Checkout extends React.Component {
 		const isLoadingProducts = this.props.isProductsListFetching;
 		const isLoadingPlans = this.props.isPlansListFetching;
 		const isLoadingSitePlans = this.props.isSitePlansListFetching;
+		const isCartSettled = this.state.cartSettled;
 
-		return isLoadingCart || isLoadingProducts || isLoadingPlans || isLoadingSitePlans;
+		return (
+			isLoadingCart || isLoadingProducts || isLoadingPlans || isLoadingSitePlans || ! isCartSettled
+		);
 	}
 
 	needsDomainDetails() {

--- a/client/my-sites/checkout/checkout/test/checkout.js
+++ b/client/my-sites/checkout/checkout/test/checkout.js
@@ -1,0 +1,111 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { identity } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { Checkout } from '../checkout';
+
+jest.mock( 'lib/countries-list', () => ( {} ) );
+jest.mock( 'lib/user', () => ( {} ) );
+jest.mock( 'lib/upgrades/actions', () => ( {
+	resetTransaction: jest.fn(),
+} ) );
+jest.mock( 'lib/signup/step-actions', () => ( {} ) );
+jest.mock( 'lib/analytics', () => ( {
+	tracks: {
+		recordEvent: jest.fn(),
+	},
+} ) );
+jest.mock( 'lib/analytics/ad-tracking', () => ( {
+	recordViewCheckout: jest.fn(),
+} ) );
+jest.mock( 'lib/store-transactions', () => ( {
+	hasDomainDetails: jest.fn(),
+} ) );
+jest.mock( 'page', () => ( {
+	redirect: jest.fn(),
+} ) );
+jest.mock( 'lib/abtest', () => ( {} ) );
+jest.mock( 'lib/abtest/active-tests', () => ( {} ) );
+jest.mock( 'lib/cart-values', () => ( {
+	cartItems: {
+		getAll: jest.fn( false ),
+		hasFreeTrial: jest.fn( false ),
+		hasGoogleApps: jest.fn( false ),
+		hasDomainRegistration: jest.fn( false ),
+		hasRenewalItem: jest.fn( false ),
+		hasOnlyRenewalItems: jest.fn( false ),
+		hasTransferProduct: jest.fn( false ),
+	},
+	isPaymentMethodEnabled: jest.fn( false ),
+	paymentMethodName: jest.fn( false ),
+} ) );
+
+describe( 'Checkout', () => {
+	const defaultProps = {
+		cards: [],
+		cart: {},
+		translate: identity,
+		loadTrackingTool: identity,
+		recordApplePayStatus: identity,
+		transaction: {
+			step: {},
+		},
+	};
+
+	beforeAll( () => {
+		global.window = {
+			scrollTo: identity,
+			document: {
+				documentElement: {},
+			},
+		};
+	} );
+
+	test( 'should render and not blow up', () => {
+		const checkout = shallow( <Checkout { ...defaultProps } /> );
+		expect( checkout.find( '.checkout' ) ).toHaveLength( 1 );
+	} );
+
+	test( 'should set state.cartSettled to false', () => {
+		let checkout;
+
+		checkout = shallow( <Checkout { ...defaultProps } cart={ { hasLoadedFromServer: false } } /> );
+		expect( checkout.state().cartSettled ).toBe( false );
+
+		checkout = shallow( <Checkout { ...defaultProps } cart={ { hasLoadedFromServer: true } } /> );
+		expect( checkout.state().cartSettled ).toBe( false );
+	} );
+
+	test( 'should set state.cartSettled to true after cart has loaded', () => {
+		const checkout = shallow(
+			<Checkout { ...defaultProps } cart={ { hasLoadedFromServer: false } } />
+		);
+		expect( checkout.state().cartSettled ).toBe( false );
+
+		checkout.setProps( { cart: { hasLoadedFromServer: true } } );
+		expect( checkout.state().cartSettled ).toBe( true );
+	} );
+
+	test( 'should keep state.cartSettled as true even after cart reloads', () => {
+		const checkout = shallow(
+			<Checkout { ...defaultProps } cart={ { hasLoadedFromServer: false } } />
+		);
+		expect( checkout.state().cartSettled ).toBe( false );
+
+		checkout.setProps( { cart: { hasLoadedFromServer: true } } );
+		expect( checkout.state().cartSettled ).toBe( true );
+
+		checkout.setProps( { cart: { hasLoadedFromServer: false } } );
+		expect( checkout.state().cartSettled ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
Test plan:

1. Start server like this: `ENABLE_FEATURES=upgrades/2-year-plans npm run start`
1. Open calypso as a personal plan user
1. Go to "plans" page and click on a business plan
1. Confirm checkout looks like this with proper `1 year` plan being selected:

<img width="737" alt="zrzut ekranu 2018-04-25 o 15 17 02" src="https://user-images.githubusercontent.com/205419/39248194-b976f5a2-489b-11e8-8dcc-f147936b7303.png">

1. Click on calypso logo at the top to go back to dashboard (make sure you DON'T refresh the page)
1. Go to "plans" page again and click on a premium plan
1. Confirm checkout looks like this:

<img width="731" alt="zrzut ekranu 2018-04-25 o 15 17 42" src="https://user-images.githubusercontent.com/205419/39248245-d15cb986-489b-11e8-9494-e50574970662.png">

And that it doesn't look like this:

<img width="730" alt="zrzut ekranu 2018-04-25 o 15 18 16" src="https://user-images.githubusercontent.com/205419/39248272-e3c03f94-489b-11e8-96fa-04fdd0568a02.png">

1. Click on a 2-year plan and repeat last 3 steps with a business plan