### PR TITLE
Components: set CTA buttons of the PurchaseDetail component as non-primary.

### DIFF
--- a/client/components/purchase-detail/README.md
+++ b/client/components/purchase-detail/README.md
@@ -32,6 +32,7 @@ export default localize( MyComponent );
 - *icon* (string) – icon slug passed as the `icon` prop of the `Gridicon`
 - *isPlaceholder* (boolean) – determines whether or not to render shimmering placeholders
 - *isRequired* (boolean) – adds a notice icon next to the main icon
+- *primaryButton* (boolean) — determines whether the CTA button is primary ( default: `false` )
 - *requiredText* (string) – adds a notice to the top, determines the text in that notice
 - *target* (string) – target passed as the `target` prop for the `Button`
 - *title* (string) – string used as the text of the heading

--- a/client/components/purchase-detail/index.jsx
+++ b/client/components/purchase-detail/index.jsx
@@ -26,6 +26,7 @@ export default class PurchaseDetail extends PureComponent {
 		isRequired: PropTypes.bool,
 		isSubmitting: PropTypes.bool,
 		onClick: PropTypes.func,
+		primaryButton: PropTypes.bool,
 		requiredText: PropTypes.string,
 		target: PropTypes.string,
 		rel: PropTypes.string,
@@ -34,10 +35,20 @@ export default class PurchaseDetail extends PureComponent {
 
 	static defaultProps = {
 		onClick: noop,
+		primaryButton: false,
 	};
 
 	renderPurchaseButton() {
-		const { buttonText, isPlaceholder, isSubmitting, href, onClick, target, rel } = this.props;
+		const {
+			buttonText,
+			isPlaceholder,
+			isSubmitting,
+			href,
+			onClick,
+			primaryButton,
+			target,
+			rel,
+		} = this.props;
 
 		if ( ! buttonText && ! isPlaceholder ) {
 			return null;
@@ -48,6 +59,7 @@ export default class PurchaseDetail extends PureComponent {
 				disabled={ isSubmitting }
 				href={ href }
 				onClick={ onClick }
+				primary={ primaryButton }
 				target={ target }
 				rel={ rel }
 				text={ buttonText }

--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
@@ -116,6 +116,7 @@ class GoogleVoucherDetails extends Component {
 			<div className="google-voucher__initial-step">
 				<PurchaseButton
 					onClick={ this.onGenerateCode }
+					primary={ false }
 					text={ this.props.translate( 'Generate code' ) }
 				/>
 
@@ -199,6 +200,7 @@ class GoogleVoucherDetails extends Component {
 						target="_blank"
 						rel="noopener noreferrer"
 						onClick={ this.onSetupGoogleAdWordsLink }
+						primary={ false }
 						text={ this.props.translate( 'Setup Google AdWords' ) }
 					/>
 				</div>


### PR DESCRIPTION
Quick alternative to https://github.com/Automattic/wp-calypso/pull/23790, which would also affect the styling of the CTA buttons of the feature cards at the checkout `thank you page` for .com plans.

![screen shot 2018-04-25 at 15 33 12](https://user-images.githubusercontent.com/13561163/39252758-40b9a576-489e-11e8-88e3-8ec01728acca.png)


Exemplary change for thank you view for .com plans: 
![screen shot 2018-04-25 at 15 14 10](https://user-images.githubusercontent.com/13561163/39252264-335001ec-489d-11e8-8a3a-bf4c513abdaf.png)
Happiness Support card has non-primary buttons set by default, so no change has been introduced here.

Those two contexts seem to be the only places the `PurchaseDetail` component is in use atm.

## To test:
- checkout this branch in your local Calypso or use calypso.live,
- go to `http://calypso.localhost:3000/plans/my-plan/:site` for Jetpack and WP sites on different plans,
- verify that all currently rendered button are non-primary.

## Follow up improvements:
* feature components defined in the `my-sites/checkout/checkout-thank-you` folder that are shared with the `My Plans` view can be directly imported from the latter (instead of being defined in two places), to cut down in code duplication and sync the updates.

