### PR TITLE
Guided Tours: remove default 2s animation delay on first step

### DIFF
--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -71,7 +71,6 @@
 	animation-duration: 0.25s;
 	animation-name: guided-tours__step-slidein;
 	animation-timing-function: ease-out;
-	animation-delay: 2s;
 	animation-fill-mode: both;
 }
 

--- a/client/layout/guided-tours/tours/design-showcase-welcome-tour.js
+++ b/client/layout/guided-tours/tours/design-showcase-welcome-tour.js
@@ -46,7 +46,7 @@ export const DesignShowcaseWelcomeTour = makeTour(
 			isAbTestInVariant( 'designShowcaseWelcomeTour', 'enabled' )
 		) }
 	>
-		<Step name="init" placement="right" next="search">
+		<Step name="init" placement="right" next="search" style={ { animationDelay: '2s' } }>
 			{ ( { translate } ) => (
 				<Fragment>
 					<p>

--- a/client/layout/guided-tours/tours/gdocs-integration-tour.js
+++ b/client/layout/guided-tours/tours/gdocs-integration-tour.js
@@ -33,7 +33,7 @@ export const GDocsIntegrationTour = makeTour(
 		path="/post"
 		when={ and( isCurrentUserEmailVerified, hasUserPastedFromGoogleDocs ) }
 	>
-		<Step name="init" placement="right">
+		<Step name="init" placement="right" style={ { animationDelay: '2s' } }>
 			{ ( { translate } ) => (
 				<Fragment>
 					<p>{ translate( 'Did you know you can create drafts from Google Docs?' ) }</p>

--- a/client/layout/guided-tours/tours/jetpack-basic-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-basic-tour.js
@@ -41,7 +41,7 @@ export const JetpackBasicTour = makeTour(
 		path="/"
 		when={ and( isNewUser, isEnabled( 'guided-tours/jetpack-basic' ) ) }
 	>
-		<Step name="init" placement="right">
+		<Step name="init" placement="right" style={ { animationDelay: '2s' } }>
 			{ ( { translate } ) => (
 				<Fragment>
 					<p>

--- a/client/layout/guided-tours/tours/main-tour.js
+++ b/client/layout/guided-tours/tours/main-tour.js
@@ -41,7 +41,7 @@ export const MainTour = makeTour(
 		path="/"
 		when={ and( isNewUser, isEnabled( 'guided-tours/main' ) ) }
 	>
-		<Step name="init" placement="right">
+		<Step name="init" placement="right" style={ { animationDelay: '2s' } }>
 			{ ( { translate } ) => (
 				<Fragment>
 					<p>

--- a/client/layout/guided-tours/tours/media-basics-tour.js
+++ b/client/layout/guided-tours/tours/media-basics-tour.js
@@ -30,7 +30,13 @@ export const MediaBasicsTour = makeTour(
 		path="/media"
 		when={ and( isDesktop, isNewUser ) }
 	>
-		<Step name="init" arrow="top-left" target=".media-library__upload-buttons" placement="below">
+		<Step
+			name="init"
+			arrow="top-left"
+			target=".media-library__upload-buttons"
+			placement="below"
+			style={ { animationDelay: '2s' } }
+		>
 			{ ( { translate } ) => (
 				<Fragment>
 					<p>{ translate( 'Welcome to your media libary!' ) }</p>

--- a/client/layout/guided-tours/tours/simple-payments-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-tour.js
@@ -27,7 +27,7 @@ export const SimplePaymentsTour = makeTour(
 			arrow="top-left"
 			target=".editor-html-toolbar__button-insert-content-dropdown, .mce-wpcom-insert-menu button"
 			placement="below"
-			style={ { marginLeft: '-10px', zIndex: 'auto' } }
+			style={ { animationDelay: '2s', marginLeft: '-10px', zIndex: 'auto' } }
 		>
 			{ ( { translate } ) => (
 				<Fragment>

--- a/client/layout/guided-tours/tours/site-title-tour.js
+++ b/client/layout/guided-tours/tours/site-title-tour.js
@@ -46,7 +46,7 @@ export const SiteTitleTour = makeTour(
 			isAbTestInVariant( 'siteTitleTour', 'enabled' )
 		) }
 	>
-		<Step name="init" placement="right" next="click-settings">
+		<Step name="init" placement="right" next="click-settings" style={ { animationDelay: '2s' } }>
 			{ ( { translate } ) => (
 				<Fragment>
 					<p>

--- a/client/layout/guided-tours/tours/theme-sheet-welcome-tour.js
+++ b/client/layout/guided-tours/tours/theme-sheet-welcome-tour.js
@@ -37,7 +37,7 @@ export const ThemeSheetWelcomeTour = makeTour(
 			isAbTestInVariant( 'themeSheetWelcomeTour', 'enabled' )
 		) }
 	>
-		<Step name="init" placement="right" next="live-preview">
+		<Step name="init" placement="right" next="live-preview" style={ { animationDelay: '2s' } }>
 			{ ( { translate } ) => (
 				<Fragment>
 					<p>

--- a/client/layout/guided-tours/tours/tutorial-site-preview-tour.js
+++ b/client/layout/guided-tours/tours/tutorial-site-preview-tour.js
@@ -38,6 +38,7 @@ export const TutorialSitePreviewTour = makeTour(
 			arrow="top-left"
 			placement="below"
 			scrollContainer=".sidebar__region"
+			style={ { animationDelay: '2s' } }
 		>
 			{ ( { translate } ) => (
 				<Fragment>


### PR DESCRIPTION
By default, every Guided Tour's first step slides in after a two second delay. This is useful when we automatically trigger the tour based on route and other context parameters, as we might want to allow the page and its resources to load. 

This becomes less useful when triggering tours through the Redux action. We're already on the page. We click a button and want to start the tour immediately. The default to trigger a tour seems to be moving towards this use case (also see #20914), which is why this PR turns things around by making tours default to no delay and adding the previous two second delay to tours who previously relied on the default — excluding those triggered through the Redux action (e.g., the checklist tours). 

To test:

- Make sure tours still trigger properly. Make sure tours that trigger automatically have the same delay as before. Make sure tours that trigger through the Redux action don't have a delay. 

How to trigger tours:

- To trigger a tour based on user context, register a new user and visit the media gallery. The `mediaBasicsTour` should be triggered. 
- To trigger a tour using the query argument, go to https://wordpress.com/?tour=main — this should start the `main` tour that we don't show to users but use to experiment. 
- To trigger a tour using Redux, register a new user, go to [the checklist](https://wordpress.com/checklist), choose your site, and choose "Do it" from, e.g., "Give your site a name". The `checklistSiteTitle` tour should start (the checklist tours move to a different page before starting the tour so the delay wouldn't be super unwarranted, but since Calypso has loaded and no large media need to load — as, e.g., with the `editorBasicsTour` which loads in the editor which can contain featured images, galleries, etc. — it seems fine to me as is). 
