### PR TITLE
Plans: Create canUpgradeToPlan() selector

### DIFF
--- a/client/state/selectors/can-upgrade-to-plan.js
+++ b/client/state/selectors/can-upgrade-to-plan.js
@@ -1,0 +1,27 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { PLAN_FREE, PLAN_JETPACK_FREE } from 'lib/plans/constants';
+import { getCurrentPlan } from 'state/sites/plans/selectors';
+import { getPlan } from 'lib/plans';
+import { isJetpackSite } from 'state/sites/selectors';
+import { isSiteAutomatedTransfer } from 'state/selectors';
+
+export default function( state, siteId, planKey ) {
+	// Which "free plan" should we use to test
+	const freePlan =
+		isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId )
+			? PLAN_JETPACK_FREE
+			: PLAN_FREE;
+	const plan = getCurrentPlan( state, siteId );
+	const planSlug = get( plan, 'expired', false ) ? freePlan : get( plan, 'productSlug', freePlan );
+
+	return get( getPlan( planKey ), 'availableFor', () => false )( planSlug );
+}

--- a/client/state/selectors/can-upgrade-to-plan.js
+++ b/client/state/selectors/can-upgrade-to-plan.js
@@ -14,6 +14,14 @@ import { getPlan } from 'lib/plans';
 import { isJetpackSite } from 'state/sites/selectors';
 import { isSiteAutomatedTransfer } from 'state/selectors';
 
+/**
+ * Whether a given site can be upgraded to a specific plan.
+ *
+ * @param  {Object}   state      Global state tree
+ * @param  {Number}   siteId     The site we're interested in upgrading
+ * @param  {String}   planKey    The plan we want to upgrade to
+ * @return {Boolean}             True if the site can be upgraded
+ */
 export default function( state, siteId, planKey ) {
 	// Which "free plan" should we use to test
 	const freePlan =

--- a/client/state/selectors/can-upgrade-to-plan.js
+++ b/client/state/selectors/can-upgrade-to-plan.js
@@ -21,7 +21,9 @@ export default function( state, siteId, planKey ) {
 			? PLAN_JETPACK_FREE
 			: PLAN_FREE;
 	const plan = getCurrentPlan( state, siteId );
-	const planSlug = get( plan, 'expired', false ) ? freePlan : get( plan, 'productSlug', freePlan );
+	const planSlug = get( plan, [ 'expired' ], false )
+		? freePlan
+		: get( plan, [ 'productSlug' ], freePlan );
 
-	return get( getPlan( planKey ), 'availableFor', () => false )( planSlug );
+	return get( getPlan( planKey ), [ 'availableFor' ], () => false )( planSlug );
 }

--- a/client/state/selectors/test/can-upgrade-to-plan.js
+++ b/client/state/selectors/test/can-upgrade-to-plan.js
@@ -7,7 +7,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { canUpgradeToPlan } from '..';
+import { canUpgradeToPlan } from 'state/selectors';
 import {
 	PLAN_BUSINESS,
 	PLAN_BUSINESS_2_YEARS,
@@ -23,7 +23,7 @@ import {
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_PREMIUM,
 	PLAN_PREMIUM_2_YEARS,
-} from '../constants';
+} from 'lib/plans/constants';
 
 describe( 'canUpgradeToPlan', () => {
 	const makeSite = productSlug => ( {

--- a/client/state/selectors/test/can-upgrade-to-plan.js
+++ b/client/state/selectors/test/can-upgrade-to-plan.js
@@ -26,8 +26,20 @@ import {
 } from 'lib/plans/constants';
 
 describe( 'canUpgradeToPlan', () => {
-	const makeSite = productSlug => ( {
-		plan: { product_slug: productSlug },
+	const siteId = 1234567;
+	const makeState = ( s, productSlug ) => ( {
+		sites: {
+			plans: {
+				[ s ]: {
+					data: [
+						{
+							currentPlan: true,
+							productSlug,
+						},
+					],
+				},
+			},
+		},
 	} );
 
 	test( 'should return true from lower-tier plans to higher-tier plans', () => {
@@ -70,7 +82,8 @@ describe( 'canUpgradeToPlan', () => {
 			[ PLAN_PREMIUM_2_YEARS, PLAN_BUSINESS_2_YEARS ],
 		].forEach(
 			( [ planOwned, planToPurchase ] ) =>
-				expect( canUpgradeToPlan( planToPurchase, makeSite( planOwned ) ) ).to.be.true
+				expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).to.be
+					.true
 		);
 	} );
 
@@ -81,7 +94,8 @@ describe( 'canUpgradeToPlan', () => {
 			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_BUSINESS ],
 		].forEach(
 			( [ planOwned, planToPurchase ] ) =>
-				expect( canUpgradeToPlan( planToPurchase, makeSite( planOwned ) ) ).to.be.true
+				expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).to.be
+					.true
 		);
 	} );
 
@@ -92,7 +106,8 @@ describe( 'canUpgradeToPlan', () => {
 			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY ],
 		].forEach(
 			( [ planOwned, planToPurchase ] ) =>
-				expect( canUpgradeToPlan( planToPurchase, makeSite( planOwned ) ) ).to.be.false
+				expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).to.be
+					.false
 		);
 	} );
 
@@ -103,7 +118,8 @@ describe( 'canUpgradeToPlan', () => {
 			[ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ],
 		].forEach(
 			( [ planOwned, planToPurchase ] ) =>
-				expect( canUpgradeToPlan( planToPurchase, makeSite( planOwned ) ) ).to.be.true
+				expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).to.be
+					.true
 		);
 	} );
 
@@ -114,7 +130,8 @@ describe( 'canUpgradeToPlan', () => {
 			[ PLAN_BUSINESS_2_YEARS, PLAN_BUSINESS ],
 		].forEach(
 			( [ planOwned, planToPurchase ] ) =>
-				expect( canUpgradeToPlan( planToPurchase, makeSite( planOwned ) ) ).to.be.false
+				expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).to.be
+					.false
 		);
 	} );
 
@@ -155,21 +172,36 @@ describe( 'canUpgradeToPlan', () => {
 			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL_2_YEARS ],
 		].forEach(
 			( [ planOwned, planToPurchase ] ) =>
-				expect( canUpgradeToPlan( planToPurchase, makeSite( planOwned ) ) ).to.be.false
+				expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).to.be
+					.false
 		);
 	} );
 
 	test( 'should return true from high-tier expired plans to lower-tier plans', () => {
-		const makeComplexSite = ( productSlug, isJetpack, isAtomic ) => ( {
-			jetpack: isJetpack || isAtomic,
-			options: {
-				is_automated_transfer: isAtomic,
-			},
-			plan: {
-				product_slug: productSlug,
-				expired: true,
+		const makeComplexState = ( s, productSlug, isJetpack, isAtomic ) => ( {
+			sites: {
+				items: {
+					[ s ]: {
+						jetpack: isJetpack || isAtomic,
+						options: {
+							is_automated_transfer: isAtomic,
+						},
+					},
+				},
+				plans: {
+					[ s ]: {
+						data: [
+							{
+								currentPlan: true,
+								expired: true,
+								productSlug,
+							},
+						],
+					},
+				},
 			},
 		} );
+
 		[
 			[ PLAN_BUSINESS, PLAN_PERSONAL, false, false ],
 			[ PLAN_BUSINESS, PLAN_PERSONAL, false, true ],
@@ -201,11 +233,14 @@ describe( 'canUpgradeToPlan', () => {
 			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL, false, true ],
 			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL_2_YEARS, false, false ],
 			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL_2_YEARS, false, true ],
-		].forEach(
-			( [ planOwned, planToPurchase, isJetpack, isAtomic ] ) =>
-				expect(
-					canUpgradeToPlan( planToPurchase, makeComplexSite( planOwned, isJetpack, isAtomic ) )
-				).to.be.true
-		);
+		].forEach( ( [ planOwned, planToPurchase, isJetpack, isAtomic ] ) => {
+			expect(
+				canUpgradeToPlan(
+					makeComplexState( siteId, planOwned, isJetpack, isAtomic ),
+					siteId,
+					planToPurchase
+				)
+			).to.be.true;
+		} );
 	} );
 } );

--- a/client/state/selectors/test/can-upgrade-to-plan.js
+++ b/client/state/selectors/test/can-upgrade-to-plan.js
@@ -1,0 +1,211 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { canUpgradeToPlan } from '..';
+import {
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_FREE,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+} from '../constants';
+
+describe( 'canUpgradeToPlan', () => {
+	const makeSite = productSlug => ( {
+		plan: { product_slug: productSlug },
+	} );
+
+	test( 'should return true from lower-tier plans to higher-tier plans', () => {
+		[
+			[ PLAN_FREE, PLAN_BUSINESS ],
+			[ PLAN_FREE, PLAN_BUSINESS_2_YEARS ],
+			[ PLAN_FREE, PLAN_PERSONAL ],
+			[ PLAN_FREE, PLAN_PERSONAL_2_YEARS ],
+			[ PLAN_FREE, PLAN_PREMIUM ],
+			[ PLAN_FREE, PLAN_PREMIUM_2_YEARS ],
+			[ PLAN_JETPACK_FREE, PLAN_JETPACK_BUSINESS ],
+			[ PLAN_JETPACK_FREE, PLAN_JETPACK_BUSINESS_MONTHLY ],
+			[ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL ],
+			[ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL_MONTHLY ],
+			[ PLAN_JETPACK_FREE, PLAN_JETPACK_PREMIUM ],
+			[ PLAN_JETPACK_FREE, PLAN_JETPACK_PREMIUM_MONTHLY ],
+			[ PLAN_JETPACK_PERSONAL, PLAN_JETPACK_BUSINESS ],
+			[ PLAN_JETPACK_PERSONAL, PLAN_JETPACK_BUSINESS_MONTHLY ],
+			[ PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PREMIUM ],
+			[ PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PREMIUM_MONTHLY ],
+			[ PLAN_JETPACK_PERSONAL_MONTHLY, PLAN_JETPACK_BUSINESS ],
+			[ PLAN_JETPACK_PERSONAL_MONTHLY, PLAN_JETPACK_BUSINESS_MONTHLY ],
+			[ PLAN_JETPACK_PERSONAL_MONTHLY, PLAN_JETPACK_PREMIUM ],
+			[ PLAN_JETPACK_PERSONAL_MONTHLY, PLAN_JETPACK_PREMIUM_MONTHLY ],
+			[ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_BUSINESS ],
+			[ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_BUSINESS_MONTHLY ],
+			[ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_BUSINESS ],
+			[ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_BUSINESS_MONTHLY ],
+			[ PLAN_PERSONAL, PLAN_BUSINESS ],
+			[ PLAN_PERSONAL, PLAN_BUSINESS_2_YEARS ],
+			[ PLAN_PERSONAL, PLAN_PREMIUM ],
+			[ PLAN_PERSONAL, PLAN_PREMIUM_2_YEARS ],
+			[ PLAN_PERSONAL_2_YEARS, PLAN_BUSINESS ],
+			[ PLAN_PERSONAL_2_YEARS, PLAN_BUSINESS_2_YEARS ],
+			[ PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM ],
+			[ PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS ],
+			[ PLAN_PREMIUM, PLAN_BUSINESS ],
+			[ PLAN_PREMIUM, PLAN_BUSINESS_2_YEARS ],
+			[ PLAN_PREMIUM_2_YEARS, PLAN_BUSINESS ],
+			[ PLAN_PREMIUM_2_YEARS, PLAN_BUSINESS_2_YEARS ],
+		].forEach(
+			( [ planOwned, planToPurchase ] ) =>
+				expect( canUpgradeToPlan( planToPurchase, makeSite( planOwned ) ) ).to.be.true
+		);
+	} );
+
+	test( 'should return true from monthly plans to yearly plans', () => {
+		[
+			[ PLAN_JETPACK_PERSONAL_MONTHLY, PLAN_JETPACK_PERSONAL ],
+			[ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_PREMIUM ],
+			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_BUSINESS ],
+		].forEach(
+			( [ planOwned, planToPurchase ] ) =>
+				expect( canUpgradeToPlan( planToPurchase, makeSite( planOwned ) ) ).to.be.true
+		);
+	} );
+
+	test( 'should return false from yearly plans to monthly plans', () => {
+		[
+			[ PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ],
+			[ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY ],
+		].forEach(
+			( [ planOwned, planToPurchase ] ) =>
+				expect( canUpgradeToPlan( planToPurchase, makeSite( planOwned ) ) ).to.be.false
+		);
+	} );
+
+	test( 'should return true from 1-year plans to 2-year plans', () => {
+		[
+			[ PLAN_PERSONAL, PLAN_PERSONAL_2_YEARS ],
+			[ PLAN_PREMIUM, PLAN_PREMIUM_2_YEARS ],
+			[ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ],
+		].forEach(
+			( [ planOwned, planToPurchase ] ) =>
+				expect( canUpgradeToPlan( planToPurchase, makeSite( planOwned ) ) ).to.be.true
+		);
+	} );
+
+	test( 'should return false from 2-year plans to 1-year plans', () => {
+		[
+			[ PLAN_PERSONAL_2_YEARS, PLAN_PERSONAL ],
+			[ PLAN_PREMIUM_2_YEARS, PLAN_PREMIUM ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_BUSINESS ],
+		].forEach(
+			( [ planOwned, planToPurchase ] ) =>
+				expect( canUpgradeToPlan( planToPurchase, makeSite( planOwned ) ) ).to.be.false
+		);
+	} );
+
+	test( 'should return false from high-tier plans to lower-tier plans', () => {
+		[
+			[ PLAN_BUSINESS, PLAN_FREE ],
+			[ PLAN_BUSINESS, PLAN_PERSONAL ],
+			[ PLAN_BUSINESS, PLAN_PREMIUM ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_FREE ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PERSONAL ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PERSONAL_2_YEARS ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PREMIUM ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PREMIUM_2_YEARS ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_FREE ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PERSONAL ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PERSONAL_MONTHLY ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PREMIUM ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PREMIUM_MONTHLY ],
+			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_FREE ],
+			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_PERSONAL ],
+			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_PERSONAL_MONTHLY ],
+			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_PREMIUM ],
+			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_PREMIUM_MONTHLY ],
+			[ PLAN_JETPACK_PERSONAL, PLAN_JETPACK_FREE ],
+			[ PLAN_JETPACK_PERSONAL_MONTHLY, PLAN_JETPACK_FREE ],
+			[ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_FREE ],
+			[ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PERSONAL ],
+			[ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PERSONAL_MONTHLY ],
+			[ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_FREE ],
+			[ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_PERSONAL ],
+			[ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_PERSONAL_MONTHLY ],
+			[ PLAN_PERSONAL, PLAN_FREE ],
+			[ PLAN_PERSONAL_2_YEARS, PLAN_FREE ],
+			[ PLAN_PREMIUM, PLAN_FREE ],
+			[ PLAN_PREMIUM, PLAN_PERSONAL ],
+			[ PLAN_PREMIUM_2_YEARS, PLAN_FREE ],
+			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL ],
+			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL_2_YEARS ],
+		].forEach(
+			( [ planOwned, planToPurchase ] ) =>
+				expect( canUpgradeToPlan( planToPurchase, makeSite( planOwned ) ) ).to.be.false
+		);
+	} );
+
+	test( 'should return true from high-tier expired plans to lower-tier plans', () => {
+		const makeComplexSite = ( productSlug, isJetpack, isAtomic ) => ( {
+			jetpack: isJetpack || isAtomic,
+			options: {
+				is_automated_transfer: isAtomic,
+			},
+			plan: {
+				product_slug: productSlug,
+				expired: true,
+			},
+		} );
+		[
+			[ PLAN_BUSINESS, PLAN_PERSONAL, false, false ],
+			[ PLAN_BUSINESS, PLAN_PERSONAL, false, true ],
+			[ PLAN_BUSINESS, PLAN_PREMIUM, false, false ],
+			[ PLAN_BUSINESS, PLAN_PREMIUM, false, true ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PERSONAL, false, false ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PERSONAL, false, true ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PERSONAL_2_YEARS, false, false ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PERSONAL_2_YEARS, false, true ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PREMIUM, false, false ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PREMIUM, false, true ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PREMIUM_2_YEARS, false, false ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PREMIUM_2_YEARS, false, true ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PERSONAL, true, false ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PERSONAL_MONTHLY, true, false ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PREMIUM, true, false ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PREMIUM_MONTHLY, true, false ],
+			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_PERSONAL, true, false ],
+			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_PERSONAL_MONTHLY, true, false ],
+			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_PREMIUM, true, false ],
+			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_PREMIUM_MONTHLY, true, false ],
+			[ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PERSONAL, true, false ],
+			[ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PERSONAL_MONTHLY, true, false ],
+			[ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_PERSONAL, true, false ],
+			[ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_PERSONAL_MONTHLY, true, false ],
+			[ PLAN_PREMIUM, PLAN_PERSONAL, false, false ],
+			[ PLAN_PREMIUM, PLAN_PERSONAL, false, true ],
+			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL, false, false ],
+			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL, false, true ],
+			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL_2_YEARS, false, false ],
+			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL_2_YEARS, false, true ],
+		].forEach(
+			( [ planOwned, planToPurchase, isJetpack, isAtomic ] ) =>
+				expect(
+					canUpgradeToPlan( planToPurchase, makeComplexSite( planOwned, isJetpack, isAtomic ) )
+				).to.be.true
+		);
+	} );
+} );

--- a/client/state/selectors/test/can-upgrade-to-plan.js
+++ b/client/state/selectors/test/can-upgrade-to-plan.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -80,10 +76,10 @@ describe( 'canUpgradeToPlan', () => {
 			[ PLAN_PREMIUM, PLAN_BUSINESS_2_YEARS ],
 			[ PLAN_PREMIUM_2_YEARS, PLAN_BUSINESS ],
 			[ PLAN_PREMIUM_2_YEARS, PLAN_BUSINESS_2_YEARS ],
-		].forEach(
-			( [ planOwned, planToPurchase ] ) =>
-				expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).to.be
-					.true
+		].forEach( ( [ planOwned, planToPurchase ] ) =>
+			expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).toBe(
+				true
+			)
 		);
 	} );
 
@@ -92,10 +88,10 @@ describe( 'canUpgradeToPlan', () => {
 			[ PLAN_JETPACK_PERSONAL_MONTHLY, PLAN_JETPACK_PERSONAL ],
 			[ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_PREMIUM ],
 			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_BUSINESS ],
-		].forEach(
-			( [ planOwned, planToPurchase ] ) =>
-				expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).to.be
-					.true
+		].forEach( ( [ planOwned, planToPurchase ] ) =>
+			expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).toBe(
+				true
+			)
 		);
 	} );
 
@@ -104,10 +100,10 @@ describe( 'canUpgradeToPlan', () => {
 			[ PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ],
 			[ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ],
 			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY ],
-		].forEach(
-			( [ planOwned, planToPurchase ] ) =>
-				expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).to.be
-					.false
+		].forEach( ( [ planOwned, planToPurchase ] ) =>
+			expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).toBe(
+				false
+			)
 		);
 	} );
 
@@ -116,10 +112,10 @@ describe( 'canUpgradeToPlan', () => {
 			[ PLAN_PERSONAL, PLAN_PERSONAL_2_YEARS ],
 			[ PLAN_PREMIUM, PLAN_PREMIUM_2_YEARS ],
 			[ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ],
-		].forEach(
-			( [ planOwned, planToPurchase ] ) =>
-				expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).to.be
-					.true
+		].forEach( ( [ planOwned, planToPurchase ] ) =>
+			expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).toBe(
+				true
+			)
 		);
 	} );
 
@@ -128,10 +124,10 @@ describe( 'canUpgradeToPlan', () => {
 			[ PLAN_PERSONAL_2_YEARS, PLAN_PERSONAL ],
 			[ PLAN_PREMIUM_2_YEARS, PLAN_PREMIUM ],
 			[ PLAN_BUSINESS_2_YEARS, PLAN_BUSINESS ],
-		].forEach(
-			( [ planOwned, planToPurchase ] ) =>
-				expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).to.be
-					.false
+		].forEach( ( [ planOwned, planToPurchase ] ) =>
+			expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).toBe(
+				false
+			)
 		);
 	} );
 
@@ -170,10 +166,10 @@ describe( 'canUpgradeToPlan', () => {
 			[ PLAN_PREMIUM_2_YEARS, PLAN_FREE ],
 			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL ],
 			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL_2_YEARS ],
-		].forEach(
-			( [ planOwned, planToPurchase ] ) =>
-				expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).to.be
-					.false
+		].forEach( ( [ planOwned, planToPurchase ] ) =>
+			expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).toBe(
+				false
+			)
 		);
 	} );
 
@@ -240,7 +236,7 @@ describe( 'canUpgradeToPlan', () => {
 					siteId,
 					planToPurchase
 				)
-			).to.be.true;
+			).toBe( true );
 		} );
 	} );
 } );

--- a/client/state/selectors/test/can-upgrade-to-plan.js
+++ b/client/state/selectors/test/can-upgrade-to-plan.js
@@ -3,6 +3,11 @@
 /**
  * Internal dependencies
  */
+import { includes } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
 import { canUpgradeToPlan } from 'state/selectors';
 import {
 	PLAN_BUSINESS,
@@ -174,13 +179,13 @@ describe( 'canUpgradeToPlan', () => {
 	} );
 
 	test( 'should return true from high-tier expired plans to lower-tier plans', () => {
-		const makeComplexState = ( s, productSlug, isJetpack, isAtomic ) => ( {
+		const makeComplexState = ( s, productSlug, siteType ) => ( {
 			sites: {
 				items: {
 					[ s ]: {
-						jetpack: isJetpack || isAtomic,
+						jetpack: includes( [ 'jetpack', 'atomic' ], siteType ),
 						options: {
-							is_automated_transfer: isAtomic,
+							is_automated_transfer: siteType === 'atomic',
 						},
 					},
 				},
@@ -199,43 +204,39 @@ describe( 'canUpgradeToPlan', () => {
 		} );
 
 		[
-			[ PLAN_BUSINESS, PLAN_PERSONAL, false, false ],
-			[ PLAN_BUSINESS, PLAN_PERSONAL, false, true ],
-			[ PLAN_BUSINESS, PLAN_PREMIUM, false, false ],
-			[ PLAN_BUSINESS, PLAN_PREMIUM, false, true ],
-			[ PLAN_BUSINESS_2_YEARS, PLAN_PERSONAL, false, false ],
-			[ PLAN_BUSINESS_2_YEARS, PLAN_PERSONAL, false, true ],
-			[ PLAN_BUSINESS_2_YEARS, PLAN_PERSONAL_2_YEARS, false, false ],
-			[ PLAN_BUSINESS_2_YEARS, PLAN_PERSONAL_2_YEARS, false, true ],
-			[ PLAN_BUSINESS_2_YEARS, PLAN_PREMIUM, false, false ],
-			[ PLAN_BUSINESS_2_YEARS, PLAN_PREMIUM, false, true ],
-			[ PLAN_BUSINESS_2_YEARS, PLAN_PREMIUM_2_YEARS, false, false ],
-			[ PLAN_BUSINESS_2_YEARS, PLAN_PREMIUM_2_YEARS, false, true ],
-			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PERSONAL, true, false ],
-			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PERSONAL_MONTHLY, true, false ],
-			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PREMIUM, true, false ],
-			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PREMIUM_MONTHLY, true, false ],
-			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_PERSONAL, true, false ],
-			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_PERSONAL_MONTHLY, true, false ],
-			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_PREMIUM, true, false ],
-			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_PREMIUM_MONTHLY, true, false ],
-			[ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PERSONAL, true, false ],
-			[ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PERSONAL_MONTHLY, true, false ],
-			[ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_PERSONAL, true, false ],
-			[ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_PERSONAL_MONTHLY, true, false ],
-			[ PLAN_PREMIUM, PLAN_PERSONAL, false, false ],
-			[ PLAN_PREMIUM, PLAN_PERSONAL, false, true ],
-			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL, false, false ],
-			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL, false, true ],
-			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL_2_YEARS, false, false ],
-			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL_2_YEARS, false, true ],
-		].forEach( ( [ planOwned, planToPurchase, isJetpack, isAtomic ] ) => {
+			[ PLAN_BUSINESS, PLAN_PERSONAL, 'simple' ],
+			[ PLAN_BUSINESS, PLAN_PERSONAL, 'atomic' ],
+			[ PLAN_BUSINESS, PLAN_PREMIUM, 'simple' ],
+			[ PLAN_BUSINESS, PLAN_PREMIUM, 'atomic' ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PERSONAL, 'simple' ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PERSONAL, 'atomic' ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PERSONAL_2_YEARS, 'simple' ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PERSONAL_2_YEARS, 'atomic' ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PREMIUM, 'simple' ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PREMIUM, 'atomic' ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PREMIUM_2_YEARS, 'simple' ],
+			[ PLAN_BUSINESS_2_YEARS, PLAN_PREMIUM_2_YEARS, 'atomic' ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PERSONAL, 'jetpack' ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PERSONAL_MONTHLY, 'jetpack' ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PREMIUM, 'jetpack' ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PREMIUM_MONTHLY, 'jetpack' ],
+			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_PERSONAL, 'jetpack' ],
+			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_PERSONAL_MONTHLY, 'jetpack' ],
+			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_PREMIUM, 'jetpack' ],
+			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_PREMIUM_MONTHLY, 'jetpack' ],
+			[ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PERSONAL, 'jetpack' ],
+			[ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PERSONAL_MONTHLY, 'jetpack' ],
+			[ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_PERSONAL, 'jetpack' ],
+			[ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_PERSONAL_MONTHLY, 'jetpack' ],
+			[ PLAN_PREMIUM, PLAN_PERSONAL, 'simple' ],
+			[ PLAN_PREMIUM, PLAN_PERSONAL, 'atomic' ],
+			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL, 'simple' ],
+			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL, 'atomic' ],
+			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL_2_YEARS, 'simple' ],
+			[ PLAN_PREMIUM_2_YEARS, PLAN_PERSONAL_2_YEARS, 'atomic' ],
+		].forEach( ( [ planOwned, planToPurchase, siteType ] ) => {
 			expect(
-				canUpgradeToPlan(
-					makeComplexState( siteId, planOwned, isJetpack, isAtomic ),
-					siteId,
-					planToPurchase
-				)
+				canUpgradeToPlan( makeComplexState( siteId, planOwned, siteType ), siteId, planToPurchase )
 			).toBe( true );
 		} );
 	} );


### PR DESCRIPTION
Will eventually replace the `canUpgradeToPlan()` helper that's now in `client/lib/plans`. Not used yet.

To test: Verify that unit tests pass. Yay for @sirreal's unit tests that I was able to copy over (and modify as needed in terms of signature and fixtures).