### PR TITLE
[Domains] Disable featured results outside signup

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -87,7 +87,7 @@ class DomainRegistrationSuggestion extends React.Component {
 
 	getDomainFlags() {
 		// TODO: Remove this entire function and isNewTld/isTestTld from utility.js
-		if ( config.isEnabled( 'domains/kracken-ui' ) ) {
+		if ( config.isEnabled( 'domains/kracken-ui' ) && this.props.isSignupStep ) {
 			return null;
 		}
 		const { suggestion, translate } = this.props;

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -193,7 +193,7 @@ class DomainSearchResults extends React.Component {
 			const isKrackenUI = config.isEnabled( 'domains/kracken-ui' );
 			let regularSuggestions = suggestions;
 
-			if ( isKrackenUI ) {
+			if ( isKrackenUI && this.props.isSignupStep ) {
 				regularSuggestions = suggestions.filter(
 					suggestion => ! suggestion.isRecommended && ! suggestion.isBestAlternative
 				);
@@ -249,7 +249,8 @@ class DomainSearchResults extends React.Component {
 				);
 			}
 		} else {
-			featuredSuggestionElement = <FeaturedDomainSuggestions showPlaceholders />;
+			featuredSuggestionElement = config.isEnabled( 'domains/kracken-ui' ) &&
+				this.props.isSignupStep && <FeaturedDomainSuggestions showPlaceholders />;
 			suggestionElements = this.renderPlaceholders();
 		}
 


### PR DESCRIPTION
This removes featured suggestions from `/domains/add` until we can devise a better design for the page.

This is how it currently looks:

<img width="745" alt="domain_search_ _testing_ _wordpress_com" src="https://user-images.githubusercontent.com/4044428/39262888-ef103606-487d-11e8-9b19-8958dd912ff3.png">

This is how it looks with this change:

<img width="746" alt="domain_search_ _testing_ _wordpress_com" src="https://user-images.githubusercontent.com/4044428/39263271-e7ca73ba-487e-11e8-921f-f922bb8e8798.png">

# Testing Instructions
1. Spin up this change in a [live branch](calypso.live/?branch=disable/featured-in-domains-add).
2. Navigate to `/domains/add/` and enter a query.
3. Ensure that no featured domain suggestion component is rendered as shown in the second picture above.