### PR TITLE
Themes: Locally disable warning in theme/options about binding state in connect

### DIFF
--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -198,6 +198,7 @@ export const connectOptions = connect(
 		let mapGetUrl = identity,
 			mapHideForTheme = identity;
 
+		/* eslint-disable wpcalypso/redux-no-bound-selectors */
 		if ( siteId ) {
 			mapGetUrl = getUrl => t => getUrl( state, t, siteId );
 			mapHideForTheme = hideForTheme => t => hideForTheme( state, t, siteId, origin );
@@ -214,6 +215,7 @@ export const connectOptions = connect(
 				option.hideForTheme ? { hideForTheme: mapHideForTheme( option.hideForTheme ) } : {}
 			)
 		);
+		/* eslint-enable wpcalypso/redux-no-bound-selectors */
 	},
 	( dispatch, { siteId, source = 'unknown' } ) => {
 		const options = pickBy( ALL_THEME_OPTIONS, 'action' );


### PR DESCRIPTION
This particular one is a false flag, as state isn't actually bound to a selector and passed along.

No functional changes, just turns off an eslint error.

Part of #24504 