### PR TITLE
Reduxify: Remove lib/user from Signup about step

### DIFF
--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -26,11 +26,10 @@ import { getThemeForSiteGoals, getSiteTypeForSiteGoals } from 'signup/utils';
 import { setSurvey } from 'state/signup/steps/survey/actions';
 import { getSurveyVertical } from 'state/signup/steps/survey/selectors';
 import { hints } from 'lib/signup/hint-data';
-import userFactory from 'lib/user';
-const user = userFactory();
 import { DESIGN_TYPE_STORE } from 'signup/constants';
 import PressableStoreStep from '../design-type-with-store/pressable-store';
 import { abtest } from 'lib/abtest';
+import { isUserLoggedIn } from 'state/current-user/selectors';
 
 //Form components
 import Card from 'components/card';
@@ -296,7 +295,7 @@ class AboutStep extends Component {
 		} );
 
 		//User Experience
-		if ( ! user.get() && userExperienceInput !== '' ) {
+		if ( ! this.props.isLoggedIn && userExperienceInput !== '' ) {
 			this.props.setUserExperience( userExperienceInput );
 			eventAttributes.user_experience = userExperienceInput;
 		}
@@ -409,9 +408,9 @@ class AboutStep extends Component {
 	}
 
 	renderExperienceOptions() {
-		const { translate } = this.props;
+		const { translate, isLoggedIn } = this.props;
 
-		if ( user.get() ) {
+		if ( isLoggedIn ) {
 			return null;
 		}
 
@@ -594,6 +593,7 @@ export default connect(
 		siteGoals: getSiteGoals( state ),
 		siteTopic: getSurveyVertical( state ),
 		userExperience: getUserExperience( state ),
+		isLoggedIn: isUserLoggedIn( state ),
 	} ),
 	{
 		setSiteTitle,

--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -22,6 +22,16 @@ export function getCurrentUserId( state ) {
 }
 
 /**
+ * Is the current user logged in?
+ *
+ * @param {Object} state Global state tree
+ * @return {Boolean}	True if logged in, False if not
+ */
+export function isUserLoggedIn( state ) {
+	return getCurrentUserId( state ) !== null;
+}
+
+/**
  * Returns the user object for the current user.
  *
  * @param  {Object}  state  Global state tree

--- a/client/state/current-user/test/selectors.js
+++ b/client/state/current-user/test/selectors.js
@@ -14,6 +14,7 @@ import {
 	getCurrentUserLocale,
 	getCurrentUserLocaleVariant,
 	getCurrentUserDate,
+	isUserLoggedIn,
 	isValidCapability,
 	getCurrentUserCurrencyCode,
 	getCurrentUserEmail,
@@ -32,6 +33,23 @@ describe( 'selectors', () => {
 		} );
 	} );
 
+	describe( 'isUserLoggedIn', () => {
+		test( 'should return true if we have a non-null user id', () => {
+			expect(
+				isUserLoggedIn( {
+					currentUser: { id: 1234 },
+				} )
+			).to.be.true;
+		} );
+
+		test( 'should return false if we have a null user id', () => {
+			expect(
+				isUserLoggedIn( {
+					currentUser: { id: null },
+				} )
+			).to.be.false;
+		} );
+	} );
 	describe( '#getCurrentUser()', () => {
 		test( 'should return null if no current user', () => {
 			const selected = getCurrentUser( {


### PR DESCRIPTION
Adds a new selector (isUserLoggedIn) and uses it place of lib/user.

Testing:
* visit http://calypso.localhost:3000/start both logged in and logged out
* when logged out, you should see a question at the bottom about `How comfortable are you with creating a website?` 
* when logged in, you should not see the question
* filling out the form should get you past the question

Part of #24004 