### PR TITLE
Reduxify: Remove lib/users from signup main and processing screen

### DIFF
--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -28,7 +28,7 @@ export class SignupProcessingScreen extends Component {
 		hasCartItems: PropTypes.bool.isRequired,
 		loginHandler: PropTypes.func,
 		steps: PropTypes.array.isRequired,
-		user: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
+		user: PropTypes.object,
 		signupProgress: PropTypes.array,
 		flowSteps: PropTypes.array,
 		useOAuth2Layout: PropTypes.bool.isRequired,
@@ -370,5 +370,5 @@ export class SignupProcessingScreen extends Component {
 
 export default connect( state => ( {
 	useOAuth2Layout: showOAuth2Layout( state ),
-	user: getCurrentUser( state ) || false,
+	user: getCurrentUser( state ),
 } ) )( localize( SignupProcessingScreen ) );

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -21,6 +21,7 @@ import analytics from 'lib/analytics';
 import { showOAuth2Layout } from 'state/ui/oauth2-clients/selectors';
 import config from 'config';
 import { abtest } from 'lib/abtest';
+import { getCurrentUser } from 'state/current-user/selectors';
 
 export class SignupProcessingScreen extends Component {
 	static propTypes = {
@@ -369,4 +370,5 @@ export class SignupProcessingScreen extends Component {
 
 export default connect( state => ( {
 	useOAuth2Layout: showOAuth2Layout( state ),
+	user: getCurrentUser( state ) || false,
 } ) )( localize( SignupProcessingScreen ) );


### PR DESCRIPTION
This replaces lib/user usage (and passed user objects) with data from redux. 

To test, walk through the signup flow both as a logged in and an anonymous user, starting at http://calypso.localhost:3000/start

Part of #24004 