### PR TITLE
Store: Adjust spacing for main loading placeholder + Fix PropTypes Error

### DIFF
--- a/client/extensions/woocommerce/app/promotions/promotion-form-type-card.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-form-type-card.js
@@ -78,7 +78,7 @@ PromotionFormTypeCard.propTypes = {
 	promotion: PropTypes.shape( {
 		id: PropTypes.isRequired,
 		type: PropTypes.oneOf(
-			[ 'product_sale', 'fixed_product', 'fixed_cart', 'percent' ]
+			[ 'product_sale', 'fixed_product', 'fixed_cart', 'percent', 'free_shipping' ]
 		).isRequired,
 	} ),
 	editPromotion: PropTypes.func.isRequired,

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -71,7 +71,7 @@
 	}
 
 	.woocommerce__placeholder {
-		padding-top: 0;
+		padding-top: 32px;
 
 		@include breakpoint( "<660px" ) {
 			padding-top: 16px;


### PR DESCRIPTION
I noticed that the main shell loading indicator was overlapping the action bar a bit:

<img width="763" alt="screen shot 2018-04-25 at 3 54 09 pm" src="https://user-images.githubusercontent.com/689165/39269866-12c3e916-48a2-11e8-8386-57d046d24fec.png">

This PR adjusts the spacing.

It also makes a tiny fix for promotions where a `PropType` error was occurring:
>  Invalid prop `promotion.type` of value `free_shipping` supplied to `PromotionFormTypeCard`

To Test:
* Load any store page and make sure the initial loading indicator does not overlap the action bar.
* Create a new promotion and select free shipping. Make sure no PropType error occurs in the console.