### PR TITLE
Build: Move up to 3.0 lint config

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1000,7 +1000,7 @@
       "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
       "dev": true,
       "requires": {
-        "stable": "0.1.7"
+        "stable": "0.1.8"
       }
     },
     "amdefine": {
@@ -2590,7 +2590,7 @@
         "create-hash": "1.2.0",
         "evp_bytestokey": "1.0.3",
         "inherits": "2.0.1",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "browserify-cipher": {
@@ -3038,7 +3038,7 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
         "inherits": "2.0.1",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "circular-json": {
@@ -3331,7 +3331,7 @@
             "oauth-sign": "0.8.2",
             "performance-now": "0.2.0",
             "qs": "6.4.0",
-            "safe-buffer": "5.1.1",
+            "safe-buffer": "5.1.2",
             "stringstream": "0.0.5",
             "tough-cookie": "2.3.4",
             "tunnel-agent": "0.6.0",
@@ -3820,7 +3820,7 @@
         "create-hash": "1.2.0",
         "inherits": "2.0.1",
         "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "sha.js": "2.4.11"
       }
     },
@@ -5317,8 +5317,8 @@
       }
     },
     "eslint-config-wpcalypso": {
-      "version": "2.0.0",
-      "integrity": "sha512-m/G31U8K2U5qV/u/BOHSTNtJGOBDR7Y84rH5hRBMhg/jWcXnJCEPy1sA0tFKfPL1GMJkJOosRVGTdMqMjiZJoQ==",
+      "version": "3.0.0",
+      "integrity": "sha512-AyKNbVrITBicI9zfz5F3Y2q8DrmVvLW7NG7YEN9sYHlh08208qelBbbx6xHAcbmmeBk4N/rqLpNoEOX0bkmzvw==",
       "dev": true
     },
     "eslint-eslines": {
@@ -5650,7 +5650,7 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
         "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "exec-sh": {
@@ -7421,7 +7421,7 @@
         "lowercase-keys": "1.0.1",
         "p-cancelable": "0.3.0",
         "p-timeout": "1.2.1",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "timed-out": "4.0.1",
         "url-parse-lax": "1.0.0",
         "url-to-options": "1.0.1"
@@ -7703,7 +7703,7 @@
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
         "inherits": "2.0.1",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "hash.js": {
@@ -9231,7 +9231,7 @@
         "jest-message-util": "22.4.3",
         "jest-snapshot": "22.4.3",
         "jest-util": "22.4.3",
-        "source-map-support": "0.5.4"
+        "source-map-support": "0.5.5"
       },
       "dependencies": {
         "chalk": {
@@ -9255,10 +9255,11 @@
           "dev": true
         },
         "source-map-support": {
-          "version": "0.5.4",
-          "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
+          "version": "0.5.5",
+          "integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
           "dev": true,
           "requires": {
+            "buffer-from": "1.0.0",
             "source-map": "0.6.1"
           }
         }
@@ -10110,7 +10111,7 @@
           "dev": true,
           "requires": {
             "async-limiter": "1.0.0",
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -10669,8 +10670,8 @@
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "lodash-es": {
-      "version": "4.17.9",
-      "integrity": "sha512-5GfcrT3VfNx20lcIiQAsx2LGr/EFi+hV7NqQA2pLuAQsC3b0/Tr/E3OM5GOQct3lRSwzXjvv+2tx4ydqrC/Ohw=="
+      "version": "4.17.10",
+      "integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg=="
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
@@ -12681,7 +12682,7 @@
         "create-hash": "1.2.0",
         "create-hmac": "1.1.7",
         "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "sha.js": "2.4.11"
       }
     },
@@ -13451,7 +13452,7 @@
       "version": "2.0.6",
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "randomfill": {
@@ -13459,7 +13460,7 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "requires": {
         "randombytes": "2.0.6",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "range-parser": {
@@ -14470,7 +14471,7 @@
         "hoist-non-react-statics": "2.5.0",
         "invariant": "2.2.4",
         "lodash": "4.17.5",
-        "lodash-es": "4.17.9",
+        "lodash-es": "4.17.10",
         "loose-envify": "1.3.1",
         "prop-types": "15.6.1"
       },
@@ -14561,7 +14562,7 @@
       "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
       "requires": {
         "pify": "3.0.0",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       },
       "dependencies": {
         "pify": {
@@ -14619,7 +14620,7 @@
         "inherits": "2.0.3",
         "isarray": "1.0.0",
         "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "string_decoder": "1.1.1",
         "util-deprecate": "1.0.2"
       },
@@ -14734,7 +14735,7 @@
         "invariant": "2.2.4",
         "is-promise": "2.1.0",
         "lodash": "4.17.5",
-        "lodash-es": "4.17.9",
+        "lodash-es": "4.17.10",
         "prop-types": "15.5.10"
       },
       "dependencies": {
@@ -15012,7 +15013,7 @@
         "oauth-sign": "0.8.2",
         "performance-now": "2.1.0",
         "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.4",
         "tunnel-agent": "0.6.0",
@@ -15242,8 +15243,8 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "version": "5.1.2",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -15819,7 +15820,7 @@
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "2.0.1",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "shebang-command": {
@@ -16289,12 +16290,12 @@
       "version": "5.3.0",
       "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "stable": {
-      "version": "0.1.7",
-      "integrity": "sha512-LmxBix+nUtyihSBpxXAhRakYEy49fan2suysdS1fUZcKjI+krXmH8DCZJ3yfngfrOnIFNU8O73EgNTzO2jI53w==",
+      "version": "0.1.8",
+      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "dev": true
     },
     "stack-utils": {
@@ -16465,7 +16466,7 @@
       "version": "1.1.1",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "stringmap": {
@@ -17477,7 +17478,7 @@
       "version": "0.6.0",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -19214,6 +19215,11 @@
               "dev": true
             }
           }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+          "dev": true
         },
         "send": {
           "version": "0.16.2",

--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
     "enzyme-to-json": "3.3.0",
     "eslines": "1.1.0",
     "eslint": "4.19.1",
-    "eslint-config-wpcalypso": "2.0.0",
+    "eslint-config-wpcalypso": "3.0.0",
     "eslint-eslines": "1.0.0",
     "eslint-plugin-import": "2.9.0",
     "eslint-plugin-jest": "21.2.0",

--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -1,5 +1,6 @@
 {
 	"rules": {
-		"no-console": 0
+		"no-console": 0,
+		"import/no-nodejs-modules": 0
 	}
 }


### PR DESCRIPTION
See https://github.com/Automattic/eslint-config-wpcalypso/blob/master/CHANGELOG.md#v300-2018-04-25

* Breaking: removed the react/jsx-no-bind rule. We now allow bound functions by default.
* Updated to react/jsx-tag-spacing from react/jsx-space-before-closing, which was deprecated
* Now allow spaces in async arrow functions