### PR TITLE
Checkout: add phone field for EBANX payments in Mexico

### DIFF
--- a/client/lib/checkout/constants.js
+++ b/client/lib/checkout/constants.js
@@ -22,6 +22,6 @@ export const PAYMENT_PROCESSOR_EBANX_COUNTRIES = {
 		],
 	},
 	MX: {
-		fields: [],
+		fields: [ 'phone-number' ],
 	},
 };

--- a/client/lib/checkout/constants.js
+++ b/client/lib/checkout/constants.js
@@ -6,7 +6,7 @@
 
 /**
  * Object contains countries for which Ebanx payment processing is possible
- * PAYMENT_PROCESSOR_EBANX_COUNTRIES[ {countryCode} ].fields - defines form field names we can display for extra payment information
+ * PAYMENT_PROCESSOR_EBANX_COUNTRIES[ {countryCode} ].fields - defines form field names we MUST display for extra payment information
  */
 export const PAYMENT_PROCESSOR_EBANX_COUNTRIES = {
 	BR: {
@@ -22,6 +22,6 @@ export const PAYMENT_PROCESSOR_EBANX_COUNTRIES = {
 		],
 	},
 	MX: {
-		fields: [ 'phone-number' ],
+		fields: [ 'phone-number', 'postal-code' ],
 	},
 };

--- a/client/lib/checkout/ebanx.js
+++ b/client/lib/checkout/ebanx.js
@@ -33,7 +33,7 @@ export function isEbanxCreditCardProcessingEnabledForCountry( countryCode = '' )
  */
 export function shouldRenderAdditionalEbanxFields( countryCode = '' ) {
 	return (
-		! isUndefined( PAYMENT_PROCESSOR_EBANX_COUNTRIES[ countryCode ] ) &&
+		isEbanxCreditCardProcessingEnabledForCountry( countryCode ) &&
 		! isEmpty( PAYMENT_PROCESSOR_EBANX_COUNTRIES[ countryCode ].fields )
 	);
 }

--- a/client/lib/checkout/test/ebanx.js
+++ b/client/lib/checkout/test/ebanx.js
@@ -66,9 +66,7 @@ describe( 'Ebanx payment processing methods', () => {
 		} );
 		test( 'should return true for ebanx country that requires additional fields', () => {
 			expect( shouldRenderAdditionalEbanxFields( 'BR' ) ).toEqual( true );
-		} );
-		test( 'should return false for ebanx country that does not requires additional fields', () => {
-			expect( shouldRenderAdditionalEbanxFields( 'MX' ) ).toEqual( false );
+			expect( shouldRenderAdditionalEbanxFields( 'MX' ) ).toEqual( true );
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/checkout/ebanx-payment-fields.jsx
+++ b/client/my-sites/checkout/checkout/ebanx-payment-fields.jsx
@@ -4,6 +4,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { find, isEmpty, includes, get } from 'lodash';
 
@@ -39,7 +40,6 @@ export class EbanxPaymentFields extends Component {
 	componentDidUpdate( prevProps ) {
 		if ( prevProps.countryCode !== this.props.countryCode ) {
 			this.setFieldsState( this.props.countryCode );
-			return true;
 		}
 	}
 
@@ -85,9 +85,13 @@ export class EbanxPaymentFields extends Component {
 		const { userSelectedPhoneCountryCode } = this.state;
 		const countryData = find( countriesList.get(), { code: countryCode } );
 		const countryName = countryData && countryData.name ? countryData.name : '';
+		const containerClassName = classNames(
+			'checkout__ebanx-payment-fields',
+			`checkout__ebanx-${ countryCode.toLowerCase() }`
+		);
 
 		return (
-			<div className="checkout__ebanx-payment-fields">
+			<div className={ containerClassName }>
 				<span key="ebanx-required-fields" className="checkout__form-info-text">
 					{ countryName &&
 						translate( 'The following fields are also required for payments in %(countryName)s', {

--- a/client/my-sites/checkout/checkout/ebanx-payment-fields.jsx
+++ b/client/my-sites/checkout/checkout/ebanx-payment-fields.jsx
@@ -36,6 +36,19 @@ export class EbanxPaymentFields extends Component {
 		};
 	}
 
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.countryCode !== this.props.countryCode ) {
+			this.setFieldsState( this.props.countryCode );
+			return true;
+		}
+	}
+
+	setFieldsState( countryCode ) {
+		this.setState( {
+			fields: get( PAYMENT_PROCESSOR_EBANX_COUNTRIES[ countryCode ], 'fields', null ),
+		} );
+	}
+
 	createField = ( fieldName, componentClass, props ) => {
 		const errorMessage = this.props.getErrorMessage( fieldName ) || [];
 		const isError = ! isEmpty( errorMessage );
@@ -48,7 +61,7 @@ export class EbanxPaymentFields extends Component {
 				name: fieldName,
 				onBlur: this.onFieldChange,
 				onChange: this.onFieldChange,
-				value: this.props.getFieldValue( fieldName ),
+				value: this.props.getFieldValue( fieldName ) || '',
 				autoComplete: 'off',
 				labelClass: 'checkout__form-label',
 			},
@@ -61,12 +74,8 @@ export class EbanxPaymentFields extends Component {
 	};
 
 	handlePhoneFieldChange = ( { value, countryCode } ) => {
-		this.setState(
-			{
-				userSelectedPhoneCountryCode: countryCode,
-			},
-			() => this.props.handleFieldChange( 'phone-number', value )
-		);
+		this.props.handleFieldChange( 'phone-number', value );
+		this.setState( { userSelectedPhoneCountryCode: countryCode } );
 	};
 
 	onFieldChange = event => this.props.handleFieldChange( event.target.name, event.target.value );
@@ -77,21 +86,15 @@ export class EbanxPaymentFields extends Component {
 		const countryData = find( countriesList.get(), { code: countryCode } );
 		const countryName = countryData && countryData.name ? countryData.name : '';
 
-		let ebanxMessage = '';
-		if ( countryName ) {
-			ebanxMessage = translate(
-				'The following fields are also required for payments in %(countryName)s',
-				{
-					args: {
-						countryName,
-					},
-				}
-			);
-		}
 		return (
 			<div className="checkout__ebanx-payment-fields">
 				<span key="ebanx-required-fields" className="checkout__form-info-text">
-					{ ebanxMessage }
+					{ countryName &&
+						translate( 'The following fields are also required for payments in %(countryName)s', {
+							args: {
+								countryName,
+							},
+						} ) }
 				</span>
 
 				{ this.createField( 'document', Input, {
@@ -136,7 +139,7 @@ export class EbanxPaymentFields extends Component {
 
 				<div className="checkout__form-state-field">
 					{ this.createField( 'state', StateSelect, {
-						countryCode: countryCode,
+						countryCode,
 						label: translate( 'State' ),
 					} ) }
 				</div>

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -928,6 +928,9 @@
 	select {
 		width: 100%;
 	}
+	&.checkout__ebanx-mx .checkout__form-state-field {
+		display: none;
+	}
 }
 
 .checkout__form-info-text {

--- a/client/my-sites/checkout/checkout/test/__snapshots__/ebanx-payment-fields.js.snap
+++ b/client/my-sites/checkout/checkout/test/__snapshots__/ebanx-payment-fields.js.snap
@@ -20,6 +20,7 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     name="document"
     onBlur={[Function]}
     onChange={[Function]}
+    value=""
   />
   <FormPhoneMediaInput
     additionalClasses="checkout__checkout-field ebanx-brazil"
@@ -36,6 +37,7 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     name="phone-number"
     onBlur={[Function]}
     onChange={[Function]}
+    value=""
   />
   <Input
     additionalClasses="checkout__checkout-field ebanx-brazil"
@@ -48,6 +50,7 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     name="address-1"
     onBlur={[Function]}
     onChange={[Function]}
+    value=""
   />
   <Input
     additionalClasses="checkout__checkout-field ebanx-brazil"
@@ -60,6 +63,7 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     name="street-number"
     onBlur={[Function]}
     onChange={[Function]}
+    value=""
   />
   <HiddenInput
     additionalClasses="checkout__checkout-field ebanx-brazil"
@@ -72,6 +76,7 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     onBlur={[Function]}
     onChange={[Function]}
     text="+ Add Address Line 2"
+    value=""
   />
   <Input
     additionalClasses="checkout__checkout-field ebanx-brazil"
@@ -83,6 +88,7 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     name="city"
     onBlur={[Function]}
     onChange={[Function]}
+    value=""
   />
   <div
     className="checkout__form-state-field"
@@ -97,6 +103,7 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
       name="state"
       onBlur={[Function]}
       onChange={[Function]}
+      value=""
     />
   </div>
   <Input
@@ -109,6 +116,7 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     name="postal-code"
     onBlur={[Function]}
     onChange={[Function]}
+    value=""
   />
 </div>
 `;

--- a/client/my-sites/checkout/checkout/test/__snapshots__/ebanx-payment-fields.js.snap
+++ b/client/my-sites/checkout/checkout/test/__snapshots__/ebanx-payment-fields.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<EbanxPaymentFields /> should render 1`] = `
 <div
-  className="checkout__ebanx-payment-fields"
+  className="checkout__ebanx-payment-fields checkout__ebanx-br"
 >
   <span
     className="checkout__form-info-text"


### PR DESCRIPTION
This also makes sure we only show the additional fields if EBANX is enabled as a payment method.
