### PR TITLE
Store: Fix "All Products" not saving correctly when editing an existing promotion

### DIFF
--- a/client/extensions/woocommerce/state/sites/promotions/helpers.js
+++ b/client/extensions/woocommerce/state/sites/promotions/helpers.js
@@ -116,8 +116,15 @@ export function createCouponUpdateFromPromotion( promotion ) {
 	let freeShipping = promotion.freeShipping;
 	let discountType = promotion.type;
 	const meta = [ { key: 'promotion_type', value: promotion.type } ];
-	const productIds = ( appliesTo && appliesTo.productIds ) || undefined;
-	const productCategoryIds = ( appliesTo && appliesTo.productCategoryIds ) || undefined;
+
+	let productIds = ( appliesTo && appliesTo.productIds ) || undefined;
+	let productCategoryIds = ( appliesTo && appliesTo.productCategoryIds ) || undefined;
+
+	// If 'all' was selected, pass in empty arrays to reset product ids and category ids
+	if ( appliesTo.all ) {
+		productIds = [];
+		productCategoryIds = [];
+	}
 
 	// If end date is null, that means it was enabled but not selected, so use today as default.
 	const endDate = null === promotion.endDate ? new Date().toISOString() : promotion.endDate;


### PR DESCRIPTION
Fixes #21777, by clearing out product ids and categories when changing a promotion to a "All Products". This fix works for cart discounts as well.

To Test:

1. Create a new promotion via `http://calypso.localhost:3000/store/promotion/:store`
2. Use promotion type: Product Discount coupon
3. Under "Applies to" select a product category
4. Add the required coupon code and discount fields, Save.
5. Next edit the same promotion you just created
6. Change "Applies to" to "All Products", click UPDATE.
7. Note the screen appears correct, and save confirmation is shown.
8. Hard refresh the page, and note "Applies to" correctly shows "All Products".