### PR TITLE
Checkout: Add credit card component to replace credit card list items

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -104,6 +104,7 @@
 @import 'components/clipboard-button-input/style';
 @import 'components/domains/contact-details-form-fields/style';
 @import 'components/count/style';
+@import 'components/credit-card/style';
 @import 'components/credit-card-form-fields/style';
 @import 'components/date-picker/style';
 @import 'components/dialog/style';

--- a/client/components/credit-card/README.md
+++ b/client/components/credit-card/README.md
@@ -1,0 +1,4 @@
+CreditCard
+==============
+
+The `CreditCard` React component serves as a container for a selectable credit card list item, and can display a stored credit card (passed as `card` prop).

--- a/client/components/credit-card/index.jsx
+++ b/client/components/credit-card/index.jsx
@@ -1,0 +1,40 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import StoredCard from './stored-card';
+
+class CreditCard extends React.Component {
+	handleKeyPress = event => {
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			this.props.onClick && this.props.onClick( event );
+		}
+	};
+
+	render() {
+		const { card, selected, onClick, className, children } = this.props;
+		const classes = classNames( 'credit-card', className, { selected } );
+		const content = card ? <StoredCard card={ card } /> : children;
+		const role = onClick ? 'radio' : 'listitem';
+
+		return (
+			<div
+				className={ classes }
+				role={ role }
+				onClick={ onClick }
+				onKeyPress={ this.handleKeyPress }
+			>
+				{ content }
+			</div>
+		);
+	}
+}
+
+export default CreditCard;

--- a/client/components/credit-card/index.jsx
+++ b/client/components/credit-card/index.jsx
@@ -5,13 +5,21 @@
  */
 import React from 'react';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
-import StoredCard from './stored-card';
+import StoredCard, { cardType } from './stored-card';
 
 class CreditCard extends React.Component {
+	static propTypes = {
+		card: cardType,
+		selected: PropTypes.bool,
+		onClick: PropTypes.func,
+		className: PropTypes.string,
+	};
+
 	handleKeyPress = event => {
 		if ( event.key === 'Enter' || event.key === ' ' ) {
 			this.props.onClick && this.props.onClick( event );

--- a/client/components/credit-card/index.jsx
+++ b/client/components/credit-card/index.jsx
@@ -16,27 +16,27 @@ class CreditCard extends React.Component {
 	static propTypes = {
 		card: cardType,
 		selected: PropTypes.bool,
-		onClick: PropTypes.func,
+		onSelect: PropTypes.func,
 		className: PropTypes.string,
 	};
 
 	handleKeyPress = event => {
 		if ( event.key === 'Enter' || event.key === ' ' ) {
-			this.props.onClick && this.props.onClick( event );
+			this.props.onSelect && this.props.onSelect( event );
 		}
 	};
 
 	render() {
-		const { card, selected, onClick, className, children } = this.props;
-		const classes = classNames( 'credit-card', className, { selected, selectable: onClick } );
+		const { card, selected, onSelect, className, children } = this.props;
+		const classes = classNames( 'credit-card', className, { selected, selectable: onSelect } );
 		const content = card ? <StoredCard card={ card } /> : children;
-		const role = onClick ? 'radio' : 'listitem';
+		const role = onSelect ? 'radio' : 'listitem';
 
 		return (
 			<div
 				className={ classes }
 				role={ role }
-				onClick={ onClick }
+				onClick={ onSelect }
 				onKeyPress={ this.handleKeyPress }
 			>
 				{ content }

--- a/client/components/credit-card/index.jsx
+++ b/client/components/credit-card/index.jsx
@@ -29,17 +29,15 @@ class CreditCard extends React.Component {
 	render() {
 		const { card, selected, onSelect, className, children } = this.props;
 		const classes = classNames( 'credit-card', className, { selected, selectable: onSelect } );
-		const content = card ? <StoredCard card={ card } /> : children;
-		const role = onSelect ? 'radio' : 'listitem';
 
 		return (
 			<div
 				className={ classes }
-				role={ role }
+				role={ onSelect ? 'radio' : 'listitem' }
 				onClick={ onSelect }
 				onKeyPress={ this.handleKeyPress }
 			>
-				{ content }
+				{ card ? <StoredCard card={ card } /> : children }
 			</div>
 		);
 	}

--- a/client/components/credit-card/index.jsx
+++ b/client/components/credit-card/index.jsx
@@ -33,6 +33,7 @@ class CreditCard extends React.Component {
 		return onSelect ? (
 			<div
 				className={ classes }
+				tabIndex={ -1 }
 				role="radio"
 				aria-checked={ selected }
 				onClick={ onSelect }

--- a/client/components/credit-card/index.jsx
+++ b/client/components/credit-card/index.jsx
@@ -22,7 +22,7 @@ class CreditCard extends React.Component {
 
 	handleKeyPress = event => {
 		if ( event.key === 'Enter' || event.key === ' ' ) {
-			this.props.onSelect && this.props.onSelect( event );
+			this.props.onSelect( event );
 		}
 	};
 
@@ -30,15 +30,18 @@ class CreditCard extends React.Component {
 		const { card, selected, onSelect, className, children } = this.props;
 		const classes = classNames( 'credit-card', className, { selected, selectable: onSelect } );
 
-		return (
+		return onSelect ? (
 			<div
 				className={ classes }
-				role={ onSelect ? 'radio' : 'listitem' }
+				role="radio"
+				aria-checked={ selected }
 				onClick={ onSelect }
 				onKeyPress={ this.handleKeyPress }
 			>
 				{ card ? <StoredCard card={ card } /> : children }
 			</div>
+		) : (
+			<div className={ classes }>{ card ? <StoredCard card={ card } /> : children }</div>
 		);
 	}
 }

--- a/client/components/credit-card/index.jsx
+++ b/client/components/credit-card/index.jsx
@@ -20,7 +20,7 @@ class CreditCard extends React.Component {
 
 	render() {
 		const { card, selected, onClick, className, children } = this.props;
-		const classes = classNames( 'credit-card', className, { selected } );
+		const classes = classNames( 'credit-card', className, { selected, selectable: onClick } );
 		const content = card ? <StoredCard card={ card } /> : children;
 		const role = onClick ? 'radio' : 'listitem';
 

--- a/client/components/credit-card/stored-card.jsx
+++ b/client/components/credit-card/stored-card.jsx
@@ -5,10 +5,22 @@
  */
 
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
+export const cardType = PropTypes.shape( {
+	stored_details_id: PropTypes.string,
+	card: PropTypes.string,
+	card_type: PropTypes.string,
+	name: PropTypes.string,
+	expiry: PropTypes.string,
+} );
+
 class StoredCard extends React.Component {
+	static propTypes = {
+		card: cardType,
+	};
+
 	render() {
 		var card = this.props.card,
 			expirationDate = this.props.moment( card.expiry ).format( 'MM/YY' ),

--- a/client/components/credit-card/stored-card.jsx
+++ b/client/components/credit-card/stored-card.jsx
@@ -22,17 +22,20 @@ class StoredCard extends React.Component {
 	};
 
 	render() {
-		var card = this.props.card,
-			expirationDate = this.props.moment( card.expiry ).format( 'MM/YY' ),
-			cardClasses = classNames( 'stored-card', card.card_type && card.card_type.toLowerCase() );
+		const card = this.props.card;
+		const expirationDate = this.props.moment( card.expiry ).format( 'MM/YY' );
+		const cardClasses = classNames(
+			'credit-card__stored-card',
+			card.card_type && card.card_type.toLowerCase()
+		);
 
 		return (
 			<div className={ cardClasses }>
-				<span className="stored-card__number">
+				<span className="credit-card__stored-card-number">
 					{ card.card_type } ****{ card.card }
 				</span>
-				<span className="stored-card__name">{ card.name }</span>
-				<span className="stored-card__expiration-date">
+				<span className="credit-card__stored-card-name">{ card.name }</span>
+				<span className="credit-card__stored-card-expiration-date">
 					{ this.props.translate( 'Expires %(date)s', {
 						args: { date: expirationDate },
 						context: 'date is of the form MM/YY',

--- a/client/components/credit-card/stored-card.jsx
+++ b/client/components/credit-card/stored-card.jsx
@@ -1,0 +1,34 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+
+import { localize } from 'i18n-calypso';
+
+class StoredCard extends React.Component {
+	render() {
+		var card = this.props.card,
+			expirationDate = this.props.moment( card.expiry ).format( 'MM/YY' ),
+			cardClasses = 'stored-card ' + card.card_type.toLowerCase();
+
+		return (
+			<div className={ cardClasses }>
+				<span className="stored-card__number">
+					{ card.card_type } ****{ card.card }
+				</span>
+				<span className="stored-card__name">{ card.name }</span>
+				<span className="stored-card__expiration-date">
+					{ this.props.translate( 'Expires %(date)s', {
+						args: { date: expirationDate },
+						context: 'date is of the form MM/YY',
+					} ) }
+				</span>
+			</div>
+		);
+	}
+}
+
+export default localize( StoredCard );

--- a/client/components/credit-card/stored-card.jsx
+++ b/client/components/credit-card/stored-card.jsx
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 export const cardType = PropTypes.shape( {
-	stored_details_id: PropTypes.string,
 	card: PropTypes.string,
 	card_type: PropTypes.string,
 	name: PropTypes.string,

--- a/client/components/credit-card/stored-card.jsx
+++ b/client/components/credit-card/stored-card.jsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
@@ -24,7 +25,7 @@ class StoredCard extends React.Component {
 	render() {
 		var card = this.props.card,
 			expirationDate = this.props.moment( card.expiry ).format( 'MM/YY' ),
-			cardClasses = 'stored-card ' + card.card_type.toLowerCase();
+			cardClasses = classNames( 'stored-card', card.card_type && card.card_type.toLowerCase() );
 
 		return (
 			<div className={ cardClasses }>

--- a/client/components/credit-card/stored-card.scss
+++ b/client/components/credit-card/stored-card.scss
@@ -1,0 +1,46 @@
+// Credit Card Payment Box
+// -----------------------------------
+
+.stored-card {
+	background-image: url('/calypso/images/upgrades/cc-visa-disabled.svg');
+	background-position: 18px center;
+	background-repeat: no-repeat;
+	background-size: 60px auto;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	padding: 15px 15px 15px 95px;
+
+	.stored-card__name {
+		color: $gray-darken-10;
+	}
+
+	.stored-card__number {
+		color: $gray-dark;
+		flex-basis: 100%;
+		font-weight: 600;
+	}
+
+	.stored-card__expiration-date {
+		color: $gray-darken-10;
+		font-style: italic;
+		opacity: 0.7;
+		white-space: nowrap;
+	}
+}
+
+$cc-brands: 'amex', 'diners', 'discover', 'jcb', 'mastercard', 'unionpay', 'visa';
+
+@each $brand in $cc-brands {
+	.stored-card.#{$brand} {
+		background-image: url('/calypso/images/upgrades/cc-#{$brand}-disabled.svg');
+	}
+}
+
+.credit-card.selected {
+	@each $brand in $cc-brands {
+		.stored-card.#{$brand} {
+			background-image: url('/calypso/images/upgrades/cc-#{$brand}.svg');
+		}
+	}
+}

--- a/client/components/credit-card/stored-card.scss
+++ b/client/components/credit-card/stored-card.scss
@@ -1,7 +1,7 @@
 // Credit Card Payment Box
 // -----------------------------------
 
-.stored-card {
+.credit-card__stored-card {
 	background-image: url('/calypso/images/upgrades/cc-visa-disabled.svg');
 	background-position: 18px center;
 	background-repeat: no-repeat;
@@ -11,17 +11,17 @@
 	justify-content: space-between;
 	padding: 15px 15px 15px 95px;
 
-	.stored-card__name {
+	.credit-card__stored-card-name {
 		color: $gray-darken-10;
 	}
 
-	.stored-card__number {
+	.credit-card__stored-card-number {
 		color: $gray-dark;
 		flex-basis: 100%;
 		font-weight: 600;
 	}
 
-	.stored-card__expiration-date {
+	.credit-card__stored-card-expiration-date {
 		color: $gray-darken-10;
 		font-style: italic;
 		opacity: 0.7;
@@ -32,14 +32,14 @@
 $cc-brands: 'amex', 'diners', 'discover', 'jcb', 'mastercard', 'unionpay', 'visa';
 
 @each $brand in $cc-brands {
-	.stored-card.#{$brand} {
+	.credit-card__stored-card.#{$brand} {
 		background-image: url('/calypso/images/upgrades/cc-#{$brand}-disabled.svg');
 	}
 }
 
 .credit-card.selected {
 	@each $brand in $cc-brands {
-		.stored-card.#{$brand} {
+		.credit-card__stored-card.#{$brand} {
 			background-image: url('/calypso/images/upgrades/cc-#{$brand}.svg');
 		}
 	}

--- a/client/components/credit-card/style.scss
+++ b/client/components/credit-card/style.scss
@@ -1,7 +1,6 @@
 @import './stored-card';
 
 .credit-card {
-    cursor: pointer;
     border: 1px solid $gray-lighten-30;
     border-top: none;
     padding-left: 2px;
@@ -9,6 +8,10 @@
 
     &:first-of-type {
         border-top: 1px solid $gray-lighten-30;
+    }
+
+    &.selectable:not(.selected) {
+        cursor: pointer;
     }
 
     &.selected {

--- a/client/components/credit-card/style.scss
+++ b/client/components/credit-card/style.scss
@@ -1,6 +1,6 @@
 @import './stored-card';
 
-.credit-card {
+div.credit-card {
     border: 1px solid $gray-lighten-30;
     border-top: none;
     padding-left: 2px;

--- a/client/components/credit-card/style.scss
+++ b/client/components/credit-card/style.scss
@@ -1,0 +1,21 @@
+@import './stored-card';
+
+.credit-card {
+    cursor: pointer;
+    border: 1px solid $gray-lighten-30;
+    border-top: none;
+    padding-left: 2px;
+    min-height: 50px;
+
+    &:first-of-type {
+        border-top: 1px solid $gray-lighten-30;
+    }
+
+    &.selected {
+        cursor: default;
+        border-left: 3px solid $alert-green;
+        background-color: #fafdf6;
+        padding-top: 15px;
+        padding-left: 0;
+    }
+}


### PR DESCRIPTION
New `components/credit-card` module.

- The `<CreditCard>` component can either render a stored card (if passed a `card` prop), or wrap its `children` (such as a new card form). Thus, it serves to replace the [`section`](https://github.com/Automattic/wp-calypso/blob/24902a2c50a6b894b42951dd15a65551516d0002/client/my-sites/checkout/checkout/credit-card-selector.jsx#L56-L71) method of the `<CreditCardSelector>` component in `my-sites/checkout`.

- `<StoredCard>` (as [used](https://github.com/Automattic/wp-calypso/blob/24902a2c50a6b894b42951dd15a65551516d0002/client/me/purchases/credit-cards/credit-card-delete.jsx#L17) in the billing history view in `me/purchases`), is moved into this component directory as a child, and can continue to be imported directly into the billing history view.

Will open another PR off of these changes, to import this component into `my-sites/checkout` and `me/purchases`. (Changes in this PR taken from original WIP branch in https://github.com/Automattic/wp-calypso/pull/22840.)