### PR TITLE
Checkout: Normalizing top padding of the credit card form

### DIFF
--- a/client/components/credit-card-form-fields/style.scss
+++ b/client/components/credit-card-form-fields/style.scss
@@ -38,7 +38,9 @@
 .credit-card-form-fields__field {
 	margin-top: 15px;
 	position: relative;
-
+	&.name {
+		margin-top: 0;
+	}
 	select {
 		font-size: 15px;
 		width: 100%;

--- a/client/components/credit-card-form-fields/style.scss
+++ b/client/components/credit-card-form-fields/style.scss
@@ -38,9 +38,11 @@
 .credit-card-form-fields__field {
 	margin-top: 15px;
 	position: relative;
+
 	&.name {
 		margin-top: 0;
 	}
+
 	select {
 		font-size: 15px;
 		width: 100%;

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -318,7 +318,6 @@
 		.payment-box-section.selected:not( .no-stored-cards ) {
 			.payment-box-section-inner {
 				border-left: 3px solid $alert-green;
-				padding-top: 15px;
 			}
 			.checkout__new-card-fields {
 				background-color: #fafdf6;
@@ -348,6 +347,7 @@
 		.payment-box-section.selected .checkout__new-card-fields {
 			max-height: 100%;
 			margin-bottom: 0;
+			padding-top: 15px;
 		}
 
 		.checkout__new-card-toggle {


### PR DESCRIPTION
This PR  fixes a UI regression that #24294 introduced.

![apr-26-2018 11-04-32](https://user-images.githubusercontent.com/6458278/39280622-bfcec7c4-4943-11e8-8568-905101ea6b7c.gif)

Props to @dechov 

## Testing

1. Visit checkout with saved cards
2. Go through the checkout with no saved cards
3. Visit 'Add card' page: `/me/purchases/add-credit-card`

### Expectations

**At 1:**
There should be no extra padding in selected saved cards

<img width="229" alt="screen shot 2018-04-26 at 11 13 34 am" src="https://user-images.githubusercontent.com/6458278/39280680-11672158-4944-11e8-98b0-612d138e9321.png">


**At 2 and 3:** 
There should be no extra padding above the first field (name field)
<img width="483" alt="screen shot 2018-04-26 at 11 14 11 am" src="https://user-images.githubusercontent.com/6458278/39280674-0f58e270-4944-11e8-9a8e-c2daf9848f1f.png">
