### PR TITLE
Fix running with DISABLE_FEATURES=code-splitting

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -583,6 +583,8 @@ module.exports = function() {
 
 					if ( config.isEnabled( 'code-splitting' ) ) {
 						req.context.chunkFiles = getFilesForChunk( section.name );
+					} else {
+						req.context.chunkFiles = [];
 					}
 
 					if ( section.secondary && req.context ) {


### PR DESCRIPTION
This is the fix suggested in Slack for running a dev environment with `DISABLE_FEATURES=code-splitting`.  I am not sure when this broke, but the fix works for me.