### PR TITLE
Components: remove redundancy in tests of the ProductPurchaseFeaturesList

### DIFF
--- a/client/blocks/product-purchase-features-list/test/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/test/video-audio-posts.jsx
@@ -1,23 +1,6 @@
 /** @format */
-
-jest.mock( 'lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 jest.mock( 'components/purchase-detail', () => 'PurchaseDetail' );
-jest.mock( '../google-vouchers', () => ( {} ) );
-
-jest.mock( 'i18n-calypso', () => ( {
-	localize: Comp => props => (
-		<Comp
-			{ ...props }
-			translate={ function( x ) {
-				return x;
-			} }
-		/>
-	),
-	numberFormat: x => x,
-} ) );
+jest.mock( '../google-vouchers', () => 'GoogleVouchers' );
 
 /**
  * External dependencies


### PR DESCRIPTION
Sequel to https://github.com/Automattic/wp-calypso/pull/24430.

Janitorial PR which:
- removes obsolete definitions, 
- refactors definition of the component mocks to return string instead of an empty object (as per warnings)

## to test: 
- run unit tests
