### PR TITLE
Republicize: enable this feature in desktop environment

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -87,7 +87,7 @@
 		"reader/new-post-notifications": true,
 		"reader/user-mention-suggestions": false,
 		"resume-editing": true,
-		"republicize": false,
+		"republicize": true,
 		"rubberband-scroll-disable": false,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-desktop/issues/427

Republicize is enabled in all environments except desktop. Let's enable it there too in order to be able to test it in next beta and fix the above issue.

### Testing instruction

1. Clone the https://github.com/Automattic/wp-desktop repo locally.
2. Set `republicize` feature flag to `true` in `wp-desktop/calypso/config/desktop.json`.
3. Follow the instructions in https://github.com/Automattic/wp-desktop#getting-started--running-locally to run the desktop app locally.
4. Use Jetpack test site with a premium/professional plan that has at least one Publicize connection set up.
5. Navigate to `Blog posts` and for a particular post select `Share` option from the ellipsis menu.
6. Share the post and verify that it appears on connected social profile.