### PR TITLE
Fix picture for GMB locations and connect the `isVerified` state

### DIFF
--- a/client/my-sites/google-my-business/location/index.js
+++ b/client/my-sites/google-my-business/location/index.js
@@ -8,6 +8,7 @@ import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -38,6 +39,8 @@ function GoogleMyBusinessLocation( { children, isCompact, location, translate } 
 		return <GoogleMyBusinessLocationPlaceholder isCompact={ isCompact } />;
 	}
 
+	const isLocationVerified = get( location, 'meta.state.isVerified', false );
+
 	const classes = classNames( 'gmb-location', { 'is-compact': isCompact } );
 
 	return (
@@ -64,7 +67,7 @@ function GoogleMyBusinessLocation( { children, isCompact, location, translate } 
 							.map( ( line, index ) => <p key={ index }>{ line }</p> ) }
 					</div>
 
-					{ location.verified && (
+					{ isLocationVerified && (
 						<div className="gmb-location__verified">
 							<Gridicon
 								className="gmb-location__verified-icon"

--- a/client/state/selectors/get-site-user-connections-for-google-my-business.js
+++ b/client/state/selectors/get-site-user-connections-for-google-my-business.js
@@ -43,6 +43,7 @@ export default function getSiteUserConnectionsForGoogleMyBusiness( state, siteId
 					keyring_connection_ID: keyringConnection.ID,
 					external_ID: externalUser.external_ID,
 					external_display: externalUser.external_name,
+					external_profile_picture: externalUser.external_profile_picture,
 					isConnected: isConnected( keyringConnection, externalUser, siteSettings ),
 				} );
 			} );

--- a/client/state/sharing/selectors.js
+++ b/client/state/sharing/selectors.js
@@ -53,6 +53,7 @@ export function getAvailableExternalAccounts( state, service ) {
 						name: externalUser.external_name,
 						description: externalUser.external_description,
 						picture: externalUser.external_profile_picture,
+						meta: externalUser.external_meta,
 						keyringConnectionId: keyringConnection.ID,
 						isConnected: isConnected( keyringConnection.ID, externalUser.external_ID ),
 						isExternal: true,

--- a/client/state/sharing/test/selectors.js
+++ b/client/state/sharing/test/selectors.js
@@ -93,6 +93,7 @@ describe( 'selectors', () => {
 					name: 'John',
 					picture: undefined,
 					description: undefined,
+					meta: undefined,
 				},
 			] );
 		} );


### PR DESCRIPTION
Requires server-side patch D12400.

This patch updates Google My Business to display the location image as well as the location status (whether it has been verified or not).

### Testing Instructions
- Try connecting to Google My Business on `/sharing/:site` and `/google-my-business/select-business-type/:site`.
- Location picture should be visible
- Verified state should be visible from `/google-my-business/select-location/:site` and `/google-my-business/stats/:site`

### Reviews
- [ ] Code
- [ ] Product
