### PR TITLE
Tracks: Add an error if using a Tracks special prop name

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -35,6 +35,12 @@ const tracksDebug = debug( 'calypso:analytics:tracks' );
 
 let _superProps, _user, _selectedSite, _siteCount, _dispatch, _loadTracksError;
 
+/**
+ * Tracks uses a bunch of special query params that should not be used as property name
+ * See internal Nosara repo?
+ */
+const TRACKS_SPECIAL_PROPS_NAMES = [ 'geo', 'message', 'request', 'geocity', 'ip' ];
+
 // Load tracking scripts
 window._tkq = window._tkq || [];
 window.ga =
@@ -267,7 +273,7 @@ const analytics = {
 
 			eventProperties = eventProperties || {};
 
-			if ( process.env.NODE_ENV !== 'production' ) {
+			if ( process.env.NODE_ENV !== 'production' && typeof console !== 'undefined' ) {
 				if ( ! /^calypso(?:_[a-z]+){2,}$/.test( eventName ) ) {
 					//eslint-disable-next-line no-console
 					console.error(
@@ -278,21 +284,31 @@ const analytics = {
 				}
 
 				for ( const key in eventProperties ) {
-					if ( isObjectLike( eventProperties[ key ] ) && typeof console !== 'undefined' ) {
+					if ( isObjectLike( eventProperties[ key ] ) ) {
 						const errorMessage =
 							`Tracks: Unable to record event "${ eventName }" because nested ` +
 							`properties are not supported by Tracks. Check '${ key }' on`;
 						console.error( errorMessage, eventProperties ); //eslint-disable-line no-console
-
 						return;
 					}
 
 					if ( ! /^[a-z_][a-z0-9_]*$/.test( key ) ) {
 						//eslint-disable-next-line no-console
 						console.error(
-							'Tracks: Event property `%s` will be ignored because it does not match /^[a-z_][a-z0-9_]*$/. ' +
+							'Tracks: Event `%s` will be rejected because property name `%s` does not match /^[a-z_][a-z0-9_]*$/. ' +
 								'Please use a compliant property name.',
+							eventName,
 							key
+						);
+					}
+
+					if ( TRACKS_SPECIAL_PROPS_NAMES.indexOf( key ) !== -1 ) {
+						//eslint-disable-next-line no-console
+						console.error(
+							"Tracks: Event property `%s` will be overwritten because it uses one of Tracks' internal prop name: %s " +
+								'Please use another property name.',
+							key,
+							TRACKS_SPECIAL_PROPS_NAMES.join( ', ' )
 						);
 					}
 				}

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -305,7 +305,7 @@ const analytics = {
 					if ( TRACKS_SPECIAL_PROPS_NAMES.indexOf( key ) !== -1 ) {
 						//eslint-disable-next-line no-console
 						console.error(
-							"Tracks: Event property `%s` will be overwritten because it uses one of Tracks' internal prop name: %s " +
+							"Tracks: Event property `%s` will be overwritten because it uses one of Tracks' internal prop name: %s. " +
 								'Please use another property name.',
 							key,
 							TRACKS_SPECIAL_PROPS_NAMES.join( ', ' )


### PR DESCRIPTION
Follow-up after #23767 and #24424.

This adds another check to make sure people don't use prop names that will be silently overwritten by Tracks.

**Testing**

Dispatch actions that would trigger the Tracks warnings:

Your property name isn't accepted, your event will be rejected:
```
dispatch( {
	type: 'ANALYTICS_EVENT_RECORD',
	meta: {
		analytics: [
			{
				type: 'ANALYTICS_EVENT_RECORD',
				payload: {
					service: 'tracks',
					name: 'calypso_test_event',
					properties: {
						Message: 'coucou',
					},
				},
			},
		],
	},
} )
```

Your property name will be silently overwritten, please change it:
```
dispatch( {
	type: 'ANALYTICS_EVENT_RECORD',
	meta: {
		analytics: [
			{
				type: 'ANALYTICS_EVENT_RECORD',
				payload: {
					service: 'tracks',
					name: 'calypso_test_event',
					properties: {
						message: 'coucou',
					},
				},
			},
		],
	},
} )
```