### PR TITLE
PlansFeatures: Accept siteId instead of site object prop

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -638,7 +638,7 @@ PlanFeatures.propTypes = {
 	selectedFeature: PropTypes.string,
 	selectedPlan: PropTypes.string,
 	selectedSiteSlug: PropTypes.string,
-	site: PropTypes.object,
+	siteId: PropTypes.number,
 };
 
 PlanFeatures.defaultProps = {
@@ -647,7 +647,7 @@ PlanFeatures.defaultProps = {
 	isInSignup: false,
 	isJetpack: false,
 	selectedSiteSlug: '',
-	site: {},
+	siteId: null,
 	onUpgradeClick: noop,
 };
 
@@ -691,10 +691,10 @@ export default connect(
 			plans,
 			onUpgradeClick,
 			isLandingPage,
-			site,
+			siteId,
 			displayJetpackPlans,
 		} = ownProps;
-		const selectedSiteId = site ? site.ID : null;
+		const selectedSiteId = siteId;
 		const selectedSiteSlug = getSiteSlug( state, selectedSiteId );
 		// If no site is selected, fall back to use the `displayJetpackPlans` prop's value
 		const isJetpack = selectedSiteId ? isJetpackSite( state, selectedSiteId ) : displayJetpackPlans;

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -48,8 +48,8 @@ export class PlansFeaturesMain extends Component {
 		 *
 		 * @TODO: When happychat correctly handles site switching, remove selectHappychatSiteId action.
 		 */
-		const siteId = get( this.props, [ 'site', 'ID' ] );
-		const nextSiteId = get( nextProps, [ 'site', 'ID' ] );
+		const { siteId } = this.props;
+		const nextSiteId = nextProps.siteId;
 		if ( siteId !== nextSiteId && nextSiteId ) {
 			this.props.selectHappychatSiteId( nextSiteId );
 		}
@@ -66,7 +66,7 @@ export class PlansFeaturesMain extends Component {
 			selectedFeature,
 			selectedPlan,
 			withSaleInfo,
-			site,
+			siteId,
 		} = this.props;
 
 		return (
@@ -85,7 +85,7 @@ export class PlansFeaturesMain extends Component {
 					selectedFeature={ selectedFeature }
 					selectedPlan={ selectedPlan }
 					withSaleInfo={ withSaleInfo }
-					site={ site }
+					siteId={ siteId }
 				/>
 			</div>
 		);
@@ -170,7 +170,7 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	render() {
-		const { site, displayJetpackPlans, isInSignup } = this.props;
+		const { displayJetpackPlans, isInSignup, siteId } = this.props;
 		let faqs = null;
 
 		if ( ! isInSignup ) {
@@ -183,7 +183,7 @@ export class PlansFeaturesMain extends Component {
 				<div className="plans-features-main__notice" />
 				{ displayJetpackPlans ? this.getIntervalTypeToggle() : null }
 				<QueryPlans />
-				<QuerySitePlans siteId={ get( site, 'ID' ) } />
+				<QuerySitePlans siteId={ siteId } />
 				{ this.getPlanFeatures() }
 				<PlanFooter isInSignup={ isInSignup } isJetpack={ displayJetpackPlans } />
 				{ faqs }
@@ -204,7 +204,7 @@ PlansFeaturesMain.propTypes = {
 	selectedFeature: PropTypes.string,
 	selectedPlan: PropTypes.string,
 	showFAQ: PropTypes.bool,
-	site: PropTypes.object,
+	siteId: PropTypes.number,
 	siteSlug: PropTypes.string,
 };
 
@@ -214,13 +214,14 @@ PlansFeaturesMain.defaultProps = {
 	intervalType: 'yearly',
 	isChatAvailable: false,
 	showFAQ: true,
-	site: {},
+	siteId: null,
 	siteSlug: '',
 };
 
 export default connect(
 	( state, { site } ) => ( {
 		isChatAvailable: isHappychatAvailable( state ),
+		siteId: get( site, [ 'ID' ] ),
 		siteSlug: getSiteSlug( state, get( site, [ 'ID' ] ) ),
 	} ),
 	{ selectHappychatSiteId }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -49,7 +49,7 @@ export class PlansFeaturesMain extends Component {
 		 * @TODO: When happychat correctly handles site switching, remove selectHappychatSiteId action.
 		 */
 		const { siteId } = this.props;
-		const nextSiteId = nextProps.siteId;
+		const { siteId: nextSiteId } = nextProps;
 		if ( siteId !== nextSiteId && nextSiteId ) {
 			this.props.selectHappychatSiteId( nextSiteId );
 		}

--- a/client/signup/steps/plans-atomic-store/index.jsx
+++ b/client/signup/steps/plans-atomic-store/index.jsx
@@ -39,7 +39,7 @@ export class PlansAtomicStoreStep extends Component {
 		additionalStepData: PropTypes.object,
 		goToNextStep: PropTypes.func.isRequired,
 		hideFreePlan: PropTypes.bool,
-		selectedSite: PropTypes.object,
+		selectedSiteId: PropTypes.number,
 		stepName: PropTypes.string.isRequired,
 		stepSectionName: PropTypes.string,
 		translate: PropTypes.func.isRequired,
@@ -114,7 +114,7 @@ export class PlansAtomicStoreStep extends Component {
 	}
 
 	plansFeaturesList() {
-		const { hideFreePlan, selectedSite, designType } = this.props;
+		const { hideFreePlan, selectedSiteId, designType } = this.props;
 
 		const isPersonalPlanEnabled = isEnabled( 'plans/personal-plan' );
 
@@ -135,13 +135,13 @@ export class PlansAtomicStoreStep extends Component {
 		return (
 			<div>
 				<QueryPlans />
-				<QuerySitePlans siteId={ get( selectedSite, 'ID' ) } />
+				<QuerySitePlans siteId={ selectedSiteId } />
 
 				<PlanFeatures
 					plans={ plans }
 					onUpgradeClick={ this.onSelectPlan }
 					isInSignup={ true }
-					site={ selectedSite || {} }
+					siteId={ selectedSiteId }
 					domainName={ this.getDomainName() }
 					displayJetpackPlans={ false }
 				/>
@@ -193,6 +193,6 @@ export class PlansAtomicStoreStep extends Component {
 }
 
 export default connect( ( state, { signupDependencies: { siteSlug } } ) => ( {
-	selectedSite: siteSlug ? getSiteBySlug( state, siteSlug ) : null,
+	selectedSiteId: siteSlug ? get( getSiteBySlug( state, siteSlug ), [ 'ID' ] ) : null,
 	designType: getDesignType( state ),
 } ) )( localize( PlansAtomicStoreStep ) );

--- a/client/signup/steps/plans-atomic-store/index.jsx
+++ b/client/signup/steps/plans-atomic-store/index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import React, { Component } from 'react';
-import { isEmpty, filter, get } from 'lodash';
+import { isEmpty, filter } from 'lodash';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 
@@ -14,7 +14,7 @@ import { localize } from 'i18n-calypso';
  */
 import analytics from 'lib/analytics';
 import { cartItems } from 'lib/cart-values';
-import { getSiteBySlug } from 'state/sites/selectors';
+import { getSiteId } from 'state/selectors';
 import SignupActions from 'lib/signup/actions';
 import StepWrapper from 'signup/step-wrapper';
 import QueryPlans from 'components/data/query-plans';
@@ -193,6 +193,6 @@ export class PlansAtomicStoreStep extends Component {
 }
 
 export default connect( ( state, { signupDependencies: { siteSlug } } ) => ( {
-	selectedSiteId: siteSlug ? get( getSiteBySlug( state, siteSlug ), [ 'ID' ] ) : null,
+	selectedSiteId: getSiteId( state, siteSlug ),
 	designType: getDesignType( state ),
 } ) )( localize( PlansAtomicStoreStep ) );

--- a/client/signup/steps/plans-atomic-store/index.jsx
+++ b/client/signup/steps/plans-atomic-store/index.jsx
@@ -39,7 +39,7 @@ export class PlansAtomicStoreStep extends Component {
 		additionalStepData: PropTypes.object,
 		goToNextStep: PropTypes.func.isRequired,
 		hideFreePlan: PropTypes.bool,
-		selectedSiteId: PropTypes.number,
+		siteId: PropTypes.number,
 		stepName: PropTypes.string.isRequired,
 		stepSectionName: PropTypes.string,
 		translate: PropTypes.func.isRequired,
@@ -114,7 +114,7 @@ export class PlansAtomicStoreStep extends Component {
 	}
 
 	plansFeaturesList() {
-		const { hideFreePlan, selectedSiteId, designType } = this.props;
+		const { hideFreePlan, siteId, designType } = this.props;
 
 		const isPersonalPlanEnabled = isEnabled( 'plans/personal-plan' );
 
@@ -135,13 +135,13 @@ export class PlansAtomicStoreStep extends Component {
 		return (
 			<div>
 				<QueryPlans />
-				<QuerySitePlans siteId={ selectedSiteId } />
+				<QuerySitePlans siteId={ siteId } />
 
 				<PlanFeatures
 					plans={ plans }
 					onUpgradeClick={ this.onSelectPlan }
 					isInSignup={ true }
-					siteId={ selectedSiteId }
+					siteId={ siteId }
 					domainName={ this.getDomainName() }
 					displayJetpackPlans={ false }
 				/>
@@ -193,6 +193,6 @@ export class PlansAtomicStoreStep extends Component {
 }
 
 export default connect( ( state, { signupDependencies: { siteSlug } } ) => ( {
-	selectedSiteId: getSiteId( state, siteSlug ),
+	siteId: getSiteId( state, siteSlug ),
 	designType: getDesignType( state ),
 } ) )( localize( PlansAtomicStoreStep ) );


### PR DESCRIPTION
### Testing Instructions

Start by verifying that the only components importing and using `my-sites/plan-features` are `signup/steps/plans-atomic-store` and `my-sites/plans-features-main`.
Verify that in both cases, `site` props have been correctly changed to `siteId`s. Note that we're not (yet) propagating the `site` -> `siteId` change up the component hierarchy very far -- that's for subsequent PRs.
