### PR TITLE
Plans: Pass isSiteJetpack prop to PlansFeaturesHeader

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -307,6 +307,7 @@ PlanFeaturesHeader.propTypes = {
 	available: PropTypes.bool,
 	billingTimeFrame: PropTypes.string.isRequired,
 	current: PropTypes.bool,
+	isInSignup: PropTypes.bool,
 	onClick: PropTypes.func,
 	planType: PropTypes.oneOf( Object.keys( PLANS_LIST ) ).isRequired,
 	popular: PropTypes.bool,
@@ -331,6 +332,7 @@ PlanFeaturesHeader.propTypes = {
 
 PlanFeaturesHeader.defaultProps = {
 	current: false,
+	isInSignup: false,
 	onClick: noop,
 	popular: false,
 	newPlan: false,

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -305,24 +305,24 @@ export class PlanFeaturesHeader extends Component {
 
 PlanFeaturesHeader.propTypes = {
 	available: PropTypes.bool,
+	bestValue: PropTypes.bool,
 	billingTimeFrame: PropTypes.string.isRequired,
+	currencyCode: PropTypes.string,
 	current: PropTypes.bool,
+	discountPrice: PropTypes.number,
+	isInJetpackConnect: PropTypes.bool,
 	isInSignup: PropTypes.bool,
+	isJetpack: PropTypes.bool,
+	isPlaceholder: PropTypes.bool,
+	newPlan: PropTypes.bool,
 	onClick: PropTypes.func,
 	planType: PropTypes.oneOf( Object.keys( PLANS_LIST ) ).isRequired,
 	popular: PropTypes.bool,
-	newPlan: PropTypes.bool,
-	bestValue: PropTypes.bool,
 	rawPrice: PropTypes.number,
-	discountPrice: PropTypes.number,
-	currencyCode: PropTypes.string,
-	title: PropTypes.string.isRequired,
-	isPlaceholder: PropTypes.bool,
-	translate: PropTypes.func,
-	siteSlug: PropTypes.string,
-	isInJetpackConnect: PropTypes.bool,
 	relatedMonthlyPlan: PropTypes.object,
-	isJetpack: PropTypes.bool,
+	siteSlug: PropTypes.string,
+	title: PropTypes.string.isRequired,
+	translate: PropTypes.func,
 
 	// Connected props
 	currentSitePlan: PropTypes.object,
@@ -331,18 +331,18 @@ PlanFeaturesHeader.propTypes = {
 };
 
 PlanFeaturesHeader.defaultProps = {
+	basePlansPath: null,
+	bestValue: false,
 	current: false,
+	currentSitePlan: {},
 	isInSignup: false,
+	isJetpack: false,
+	isPlaceholder: false,
+	isSiteAT: false,
+	newPlan: false,
 	onClick: noop,
 	popular: false,
-	newPlan: false,
-	bestValue: false,
-	isPlaceholder: false,
 	siteSlug: '',
-	basePlansPath: null,
-	currentSitePlan: {},
-	isSiteAT: false,
-	isJetpack: false,
 };
 
 export default connect( ( state, { isInSignup, planType, relatedMonthlyPlan } ) => {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -100,7 +100,7 @@ export class PlanFeaturesHeader extends Component {
 		const {
 			available,
 			discountPrice,
-			isSiteJetpack,
+			isJetpack,
 			rawPrice,
 			relatedMonthlyPlan,
 			showModifiedPricingDisplay,
@@ -121,7 +121,7 @@ export class PlanFeaturesHeader extends Component {
 		// Note: Don't make this translatable because it's only visible to English-language users
 		return (
 			<span className="plan-features__header-credit-label">
-				{ isSiteJetpack ? 'Discount' : 'Credit available' }
+				{ isJetpack ? 'Discount' : 'Credit available' }
 			</span>
 		);
 	}
@@ -147,7 +147,7 @@ export class PlanFeaturesHeader extends Component {
 			discountPrice,
 			isPlaceholder,
 			isSiteAT,
-			isSiteJetpack,
+			isJetpack,
 			hideMonthly,
 			isInSignup,
 		} = this.props;
@@ -168,7 +168,7 @@ export class PlanFeaturesHeader extends Component {
 
 		if (
 			isSiteAT ||
-			! isSiteJetpack ||
+			! isJetpack ||
 			planMatches( this.props.planType, { type: TYPE_FREE } ) ||
 			hideMonthly
 		) {
@@ -207,7 +207,7 @@ export class PlanFeaturesHeader extends Component {
 			discountPrice,
 			isInSignup,
 			isPlaceholder,
-			isSiteJetpack,
+			isJetpack,
 			rawPrice,
 			relatedMonthlyPlan,
 			showModifiedPricingDisplay,
@@ -215,8 +215,8 @@ export class PlanFeaturesHeader extends Component {
 
 		if ( isPlaceholder && ! isInSignup ) {
 			const classes = classNames( 'is-placeholder', {
-				'plan-features__price': ! isSiteJetpack,
-				'plan-features__price-jetpack': isSiteJetpack,
+				'plan-features__price': ! isJetpack,
+				'plan-features__price-jetpack': isJetpack,
 			} );
 
 			return <div className={ classes } />;
@@ -272,14 +272,14 @@ export class PlanFeaturesHeader extends Component {
 		const {
 			basePlansPath,
 			currencyCode,
-			isSiteJetpack,
+			isJetpack,
 			isYearly,
 			rawPrice,
 			relatedMonthlyPlan,
 			relatedYearlyPlan,
 			siteSlug,
 		} = this.props;
-		if ( isSiteJetpack ) {
+		if ( isJetpack ) {
 			const [ discountPrice, originalPrice ] = isYearly
 				? [ relatedMonthlyPlan.raw_price * 12, rawPrice ]
 				: [ rawPrice * 12, get( relatedYearlyPlan, 'raw_price' ) ];
@@ -320,7 +320,7 @@ PlanFeaturesHeader.propTypes = {
 	siteSlug: PropTypes.string,
 	isInJetpackConnect: PropTypes.bool,
 	relatedMonthlyPlan: PropTypes.object,
-	isSiteJetpack: PropTypes.bool,
+	isJetpack: PropTypes.bool,
 
 	// Connected props
 	currentSitePlan: PropTypes.object,
@@ -339,7 +339,7 @@ PlanFeaturesHeader.defaultProps = {
 	basePlansPath: null,
 	currentSitePlan: {},
 	isSiteAT: false,
-	isSiteJetpack: false,
+	isJetpack: false,
 };
 
 export default connect( ( state, { isInSignup, planType, relatedMonthlyPlan } ) => {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -24,7 +24,7 @@ import { getYearlyPlanByMonthly, planMatches } from 'lib/plans';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getPlanBySlug } from 'state/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 import { isMobile } from 'lib/viewport';
 import { planLevelsMatch } from 'lib/plans/index';
 
@@ -320,11 +320,11 @@ PlanFeaturesHeader.propTypes = {
 	siteSlug: PropTypes.string,
 	isInJetpackConnect: PropTypes.bool,
 	relatedMonthlyPlan: PropTypes.object,
+	isSiteJetpack: PropTypes.bool,
 
 	// Connected props
 	currentSitePlan: PropTypes.object,
 	isSiteAT: PropTypes.bool,
-	isSiteJetpack: PropTypes.bool,
 	relatedYearlyPlan: PropTypes.object,
 };
 
@@ -349,7 +349,6 @@ export default connect( ( state, { isInSignup, planType, relatedMonthlyPlan } ) 
 	return {
 		currentSitePlan,
 		isSiteAT: isSiteAutomatedTransfer( state, selectedSiteId ),
-		isSiteJetpack: isJetpackSite( state, selectedSiteId ),
 		isYearly,
 		relatedYearlyPlan: isYearly ? null : getPlanBySlug( state, getYearlyPlanByMonthly( planType ) ),
 		siteSlug: getSiteSlug( state, selectedSiteId ),

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -273,13 +273,14 @@ export class PlanFeaturesHeader extends Component {
 			basePlansPath,
 			currencyCode,
 			isJetpack,
+			isSiteAT,
 			isYearly,
 			rawPrice,
 			relatedMonthlyPlan,
 			relatedYearlyPlan,
 			siteSlug,
 		} = this.props;
-		if ( isJetpack ) {
+		if ( isJetpack && ! isSiteAT ) {
 			const [ discountPrice, originalPrice ] = isYearly
 				? [ relatedMonthlyPlan.raw_price * 12, rawPrice ]
 				: [ rawPrice * 12, get( relatedYearlyPlan, 'raw_price' ) ];

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -255,6 +255,7 @@ class PlanFeatures extends Component {
 			canPurchase,
 			isInSignup,
 			isLandingPage,
+			isJetpack,
 			planProperties,
 			selectedPlan,
 			translate,
@@ -299,6 +300,7 @@ class PlanFeatures extends Component {
 						available={ available }
 						current={ current }
 						currencyCode={ currencyCode }
+						isSiteJetpack={ isJetpack }
 						popular={ popular }
 						newPlan={ newPlan }
 						bestValue={ bestValue }
@@ -351,6 +353,7 @@ class PlanFeatures extends Component {
 			basePlansPath,
 			displayJetpackPlans,
 			isInSignup,
+			isJetpack,
 			planProperties,
 			selectedPlan,
 			siteType,
@@ -408,6 +411,7 @@ class PlanFeatures extends Component {
 						discountPrice={ discountPrice }
 						hideMonthly={ hideMonthly }
 						isInSignup={ isInSignup }
+						isSiteJetpack={ isJetpack }
 						isPlaceholder={ isPlaceholder }
 						newPlan={ newPlan }
 						bestValue={ bestValue }

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -694,7 +694,8 @@ export default connect(
 		} = ownProps;
 		const selectedSiteId = site ? site.ID : null;
 		const selectedSiteSlug = getSiteSlug( state, selectedSiteId );
-		const isJetpack = isJetpackSite( state, selectedSiteId );
+		// If no site is selected, fall back to use the `displayJetpackPlans` prop's value
+		const isJetpack = selectedSiteId ? isJetpackSite( state, selectedSiteId ) : displayJetpackPlans;
 		const sitePlan = getSitePlan( state, selectedSiteId );
 		const sitePlans = getPlansBySiteId( state, selectedSiteId );
 		const isPaid = isCurrentPlanPaid( state, selectedSiteId );

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -224,7 +224,7 @@ class PlanFeatures extends Component {
 						currencyCode={ currencyCode }
 						current={ current }
 						discountPrice={ discountPrice }
-						isJetpackSite={ isJetpack }
+						isJetpack={ isJetpack }
 						planTitle={ planConstantObj.getTitle() }
 						planType={ planName }
 						rawPrice={ rawPrice }
@@ -300,7 +300,7 @@ class PlanFeatures extends Component {
 						available={ available }
 						current={ current }
 						currencyCode={ currencyCode }
-						isSiteJetpack={ isJetpack }
+						isJetpack={ isJetpack }
 						popular={ popular }
 						newPlan={ newPlan }
 						bestValue={ bestValue }
@@ -411,7 +411,7 @@ class PlanFeatures extends Component {
 						discountPrice={ discountPrice }
 						hideMonthly={ hideMonthly }
 						isInSignup={ isInSignup }
-						isSiteJetpack={ isJetpack }
+						isJetpack={ isJetpack }
 						isPlaceholder={ isPlaceholder }
 						newPlan={ newPlan }
 						bestValue={ bestValue }

--- a/client/my-sites/plan-features/summary.jsx
+++ b/client/my-sites/plan-features/summary.jsx
@@ -18,7 +18,7 @@ class PlanFeaturesSummary extends Component {
 		available: PropTypes.bool.isRequired,
 		currencyCode: PropTypes.string,
 		current: PropTypes.bool,
-		isJetpackSite: PropTypes.bool.isRequired,
+		isJetpack: PropTypes.bool.isRequired,
 		planTitle: PropTypes.string.isRequired,
 		rawPrice: PropTypes.number,
 		relatedMonthlyPlan: PropTypes.object,
@@ -97,13 +97,13 @@ class PlanFeaturesSummary extends Component {
 	}
 
 	render() {
-		const { available, current, isJetpackSite } = this.props;
+		const { available, current, isJetpack } = this.props;
 
 		if ( current || ! available ) {
 			return null;
 		}
 
-		const summary = isJetpackSite ? this.renderJetpackSummary() : this.renderWPCOMSummary();
+		const summary = isJetpack ? this.renderJetpackSummary() : this.renderWPCOMSummary();
 		if ( ! summary ) {
 			return null;
 		}

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -28,6 +28,13 @@ jest.mock( 'i18n-calypso', () => ( {
  */
 import { shallow } from 'enzyme';
 import React from 'react';
+import { identity } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import PlanIntervalDiscount from 'my-sites/plan-interval-discount';
+import { PlanFeaturesHeader } from '../header';
 import {
 	PLAN_FREE,
 	PLAN_BUSINESS,
@@ -44,11 +51,6 @@ import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from 'lib/plans/constants';
-
-/**
- * Internal dependencies
- */
-import { PlanFeaturesHeader } from '../header';
 
 const props = {
 	translate: x => x,
@@ -172,5 +174,35 @@ describe( 'PlanFeaturesHeader.getBillingTimeframe()', () => {
 			const tf = shallow( comp.getBillingTimeframe() );
 			expect( tf.find( 'InfoPopover' ).length ).toBe( 0 );
 		} );
+	} );
+} );
+
+describe( 'PlanIntervalDiscount', () => {
+	const baseProps = {
+		isYearly: true,
+		rawPrice: 22,
+		relatedMonthlyPlan: { raw_price: 2 },
+		translate: identity,
+	};
+	test( 'should show interval discount for Jetpack during signup', () => {
+		const wrapper = shallow( <PlanFeaturesHeader { ...baseProps } isInSignup isJetpack /> );
+		expect( wrapper.find( PlanIntervalDiscount ) ).toHaveLength( 1 );
+	} );
+
+	test( 'should not show interval discount for Jetpack outside signup', () => {
+		const wrapper = shallow( <PlanFeaturesHeader { ...baseProps } isJetpack /> );
+		expect( wrapper.find( PlanIntervalDiscount ) ).toHaveLength( 0 );
+	} );
+
+	test( 'should not show interval discount for simple during signup', () => {
+		const wrapper = shallow( <PlanFeaturesHeader { ...baseProps } isInSignup /> );
+		expect( wrapper.find( PlanIntervalDiscount ) ).toHaveLength( 0 );
+	} );
+
+	test( 'should not show interval discount for atomic during signup', () => {
+		const wrapper = shallow(
+			<PlanFeaturesHeader { ...baseProps } isInSignup isJetpack isSiteAT />
+		);
+		expect( wrapper.find( PlanIntervalDiscount ) ).toHaveLength( 0 );
 	} );
 } );

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -26,8 +26,8 @@ jest.mock( 'i18n-calypso', () => ( {
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
 import React from 'react';
+import { shallow } from 'enzyme';
 import { identity } from 'lodash';
 
 /**
@@ -36,20 +36,20 @@ import { identity } from 'lodash';
 import PlanIntervalDiscount from 'my-sites/plan-interval-discount';
 import { PlanFeaturesHeader } from '../header';
 import {
-	PLAN_FREE,
 	PLAN_BUSINESS,
 	PLAN_BUSINESS_2_YEARS,
-	PLAN_PREMIUM,
-	PLAN_PREMIUM_2_YEARS,
-	PLAN_PERSONAL,
-	PLAN_PERSONAL_2_YEARS,
+	PLAN_FREE,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
 	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
 	PLAN_JETPACK_PREMIUM,
 	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
 } from 'lib/plans/constants';
 
 const props = {

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -54,7 +54,7 @@ const props = {
 	translate: x => x,
 	planType: PLAN_FREE,
 	currentSitePlan: { productSlug: PLAN_FREE },
-	isSiteJetpack: null,
+	isJetpack: null,
 };
 
 describe( 'PlanFeaturesHeader basic tests', () => {
@@ -106,7 +106,7 @@ describe( 'PlanFeaturesHeader.getBillingTimeframe()', () => {
 		test( `Should render InfoPopover for free plans (${ productSlug })`, () => {
 			const comp = new PlanFeaturesHeader( {
 				...myProps,
-				isSiteJetpack: true,
+				isJetpack: true,
 				planType: productSlug,
 			} );
 			const tf = shallow( comp.getBillingTimeframe() );
@@ -119,7 +119,7 @@ describe( 'PlanFeaturesHeader.getBillingTimeframe()', () => {
 			test( `Should render InfoPopover for non-jetpack sites (${ productSlug })`, () => {
 				const comp = new PlanFeaturesHeader( {
 					...myProps,
-					isSiteJetpack: false,
+					isJetpack: false,
 					planType: productSlug,
 				} );
 				const tf = shallow( comp.getBillingTimeframe() );
@@ -129,7 +129,7 @@ describe( 'PlanFeaturesHeader.getBillingTimeframe()', () => {
 			test( `Should render InfoPopover for AT sites (${ productSlug })`, () => {
 				const comp = new PlanFeaturesHeader( {
 					...myProps,
-					isSiteJetpack: true,
+					isJetpack: true,
 					isSiteAT: true,
 					planType: productSlug,
 				} );
@@ -139,7 +139,7 @@ describe( 'PlanFeaturesHeader.getBillingTimeframe()', () => {
 			test( `Should render InfoPopover when hideMonthly is true (${ productSlug })`, () => {
 				const comp = new PlanFeaturesHeader( {
 					...myProps,
-					isSiteJetpack: true,
+					isJetpack: true,
 					hideMonthly: true,
 					planType: productSlug,
 				} );
@@ -166,7 +166,7 @@ describe( 'PlanFeaturesHeader.getBillingTimeframe()', () => {
 		test( `Should not render InfoPopover for paid plans (${ productSlug })`, () => {
 			const comp = new PlanFeaturesHeader( {
 				...myProps,
-				isSiteJetpack: true,
+				isJetpack: true,
 				planType: productSlug,
 			} );
 			const tf = shallow( comp.getBillingTimeframe() );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/pull/24289#issuecomment-384657514, reported by @sirreal:

> This introduced a regression where the "mocked" site object passed here will not impact the header and the discount is not shown:
>
> https://github.com/Automattic/wp-calypso/blob/733dfc76430b10e83c9b2e94dbb3f250b60994ef/client/jetpack-connect/plans-grid.jsx#L52
>
> Discount was added here (AB challenger is new champion):
>
> https://github.com/Automattic/wp-calypso/pull/21725
> 
> You can see that no discount text is displayed here:
> 
> https://wordpress.com/jetpack/connect/store

Before (current https://wordpress.com/jetpack/connect/store):

![image](https://user-images.githubusercontent.com/96308/39333194-3dab3ff4-49aa-11e8-97a4-3ee74c16864c.png)

After (note the "Save ... over monthly" lines):

![image](https://user-images.githubusercontent.com/96308/39333174-2bc8d6a2-49aa-11e8-99f2-97645bc81369.png)

To test: See screenshots. Also, verify that the Plans page isn't broken elsewhere.
