### PR TITLE
Fix memoization of getEditedPost and isEditedPostDirty selectors

### DIFF
--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -333,7 +333,7 @@ export const getEditedPost = createSelector(
 
 		return mergePostEdits( post, edits );
 	},
-	state => [ state.posts.items, state.posts.edits ]
+	state => [ state.posts.queries, state.posts.edits ]
 );
 
 /**
@@ -433,7 +433,7 @@ export const isEditedPostDirty = createSelector(
 			);
 		} );
 	},
-	state => [ state.posts.items, state.posts.edits ]
+	state => [ state.posts.queries, state.posts.edits ]
 );
 
 /**


### PR DESCRIPTION
These selectors don't react to changes in `state.posts.queries` (that's where the `getSitePost` is looking) and incorrectly memoize the previous value.

The cause is that they depend on `state.posts.items`, which is just a map from `globalId` to `[ siteId, postId ]`. It's `state.posts.queries` that holds the post objects.

**How to test:**
The bugfix is covered by a few new unit tests. In a TDD style, they fail on the buggy version and pass on the fixed one.

There's also one user-visible UI issue caused by this bug:

With unfixed version of Calypso, start editing a new post draft and enter some content. Wait until the post is autosaved. Then "Close" the post editor. You should see a "Continue Editing" button in Masterbar:

<img width="414" alt="screen shot 2018-04-26 at 23 15 38" src="https://user-images.githubusercontent.com/664258/39333053-bab10e9e-49a9-11e8-9ddf-1a065100be08.png">

Click on the button, start editing again and this time click on "Move to Trash" at the bottom of the editor sidebar:

<img width="339" alt="screen shot 2018-04-26 at 23 16 10" src="https://user-images.githubusercontent.com/664258/39333077-d569d6e4-49a9-11e8-8d9b-b094dd03ff67.png">

The post is trashed and the editor is closed. The "Continue Editing" button, however, is still there, although the post was trashed. That's a bug:

<img width="451" alt="screen shot 2018-04-26 at 23 16 34" src="https://user-images.githubusercontent.com/664258/39333201-41d4b268-49aa-11e8-9471-b841fc416765.png">

Now apply the patch and go through the testing steps again. Now the "Continue Editor" button shouldn't be there:

<img width="451" alt="screen shot 2018-04-26 at 23 23 23" src="https://user-images.githubusercontent.com/664258/39333222-56fc2cd4-49aa-11e8-9379-ad35018b4386.png">



