### PR TITLE
Add Location Count to Gmb Location Connect Event

### DIFF
--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -9,6 +9,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Gridicon from 'gridicons';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -27,10 +28,13 @@ import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { canCurrentUser, getGoogleMyBusinessLocations } from 'state/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
+import QuerySiteSettings from 'components/data/query-site-settings';
+import QueryKeyringConnections from 'components/data/query-keyring-connections';
 
 class GoogleMyBusinessSelectBusinessType extends Component {
 	static propTypes = {
 		recordTracksEvent: PropTypes.func.isRequired,
+		siteId: PropTypes.number,
 		siteSlug: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 	};
@@ -42,7 +46,17 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 	handleConnect = () => {
 		const { googleMyBusinessLocations, siteSlug } = this.props;
 
-		if ( googleMyBusinessLocations.length === 0 ) {
+		const locationCount = googleMyBusinessLocations.length;
+		const verifiedLocationCount = googleMyBusinessLocations.filter( location => {
+			return get( location, 'meta.state.isVerified', false );
+		} ).length;
+
+		this.props.recordTracksEvent( 'calypso_google_my_business_select_business_type_connect', {
+			location_count: locationCount,
+			verified_location_count: verifiedLocationCount,
+		} );
+
+		if ( locationCount === 0 ) {
 			page.redirect( `/google-my-business/new/${ siteSlug }` );
 		} else {
 			page.redirect( `/google-my-business/select-location/${ siteSlug }` );
@@ -134,7 +148,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { siteId, translate } = this.props;
 
 		return (
 			<Main className="gmb-select-business-type" wideLayout>
@@ -144,6 +158,9 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 				/>
 
 				<DocumentHead title={ translate( 'Google My Business' ) } />
+
+				<QuerySiteSettings siteId={ siteId } />
+				<QueryKeyringConnections />
 
 				<HeaderCake isCompact={ false } alwaysShowActionText={ false } onClick={ this.goBack }>
 					{ translate( 'Google My Business' ) }
@@ -197,6 +214,7 @@ export default connect(
 		return {
 			googleMyBusinessLocations: getGoogleMyBusinessLocations( state, siteId ),
 			canUserManageOptions: canCurrentUser( state, siteId, 'manage_options' ),
+			siteId,
 			siteSlug: getSelectedSiteSlug( state ),
 		};
 	},


### PR DESCRIPTION

## Specs

Add the available location count to the `calypso_google_my_business_select_location_connect_location_button_click` event.

## Testing

1. Load up branch locally
2. Run `localStorage.setItem('debug', 'calypso:analytics:tracks');` in the console
3. Link a Google My Business account to a site
4. Navigate to http://calypso.localhost:3000/google-my-business/select-location/:site
5. Note the number of businesses and the numbers of verified locations that are listed
6. Connect to one of the locations
7. Verify that the `calypso_google_my_business_select_location_connect_location_button_click` event was logged
8. Verify that the `location_count` property of the event corresponds to the total number of locations
9. Verify that the `verified_location_count` property of the event corresponds to the number of verified locations