### PR TITLE
Fix lint errors in client/reader

### DIFF
--- a/client/reader/controller-helper.js
+++ b/client/reader/controller-helper.js
@@ -70,7 +70,8 @@ export function trackUpdatesLoaded( key ) {
 }
 
 export function setPageTitle( context, title ) {
-	context.store.dispatch( setTitle( i18n.translate( '%s ‹ Reader', { args: title } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	// @todo Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	context.store.dispatch( setTitle( i18n.translate( '%s ‹ Reader', { args: title } ) ) );
 }
 
 export function userHasHistory( context ) {

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -257,6 +257,7 @@ const exported = {
 
 		setPageTitle( context, 'Automattic' );
 
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		context.primary = (
 			<AsyncLoad
 				require="reader/team/main"
@@ -275,6 +276,7 @@ const exported = {
 				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
 			/>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 		next();
 	},
 };

--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -37,6 +37,7 @@ const exported = {
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 		recordTrack( 'calypso_reader_discover_viewed' );
 
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		context.primary = (
 			<AsyncLoad
 				require="reader/site-stream"
@@ -60,6 +61,7 @@ const exported = {
 				featuredStore={ featuredStore }
 			/>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 		next();
 	},
 };

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -5,7 +5,6 @@
 import url from 'url';
 import { translate } from 'i18n-calypso';
 import { trim } from 'lodash';
-import i18n from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -56,8 +55,8 @@ export const getFeedUrl = ( { feed, site, post } = {} ) => {
 export const getSiteName = ( { feed, site, post } = {} ) => {
 	let siteName = null;
 	const isDefaultSiteTitle =
-		( site && site.name === i18n.translate( 'Site Title' ) ) ||
-		( feed && feed.name === i18n.translate( 'Site Title' ) );
+		( site && site.name === translate( 'Site Title' ) ) ||
+		( feed && feed.name === translate( 'Site Title' ) );
 
 	if ( ! isDefaultSiteTitle && site && site.title ) {
 		siteName = site.title;

--- a/client/reader/post-key.js
+++ b/client/reader/post-key.js
@@ -1,4 +1,5 @@
 /** @format */
+
 export function keyForPost( post ) {
 	if ( ! post ) {
 		return;


### PR DESCRIPTION
Helping out with @blowery's effort to fix all eslint errors in https://github.com/Automattic/wp-calypso/issues/24504.

This PR covers all lint errors in `client/reader`. No functional changes.