### PR TITLE
Inline Help: add more Rich Results data

### DIFF
--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -667,6 +667,17 @@ const contextLinksForSection = {
 	],
 };
 
+/*
+source: https://www.youtube.com/playlist?list=PLQFhxUeNFfdKx9gO0a2mp9h8pKjb2y9la
+run this in the console to get the videos into a more helpful format (also removes duplicates):
+```JavaScript
+data = {};
+document.querySelectorAll('.yt-simple-endpoint.ytd-playlist-video-renderer').forEach( function( e ) {
+	data[ new RegExp(/v=([^&]*)&/).exec( e.href )[1] ] = e.querySelector( '#video-title' ).innerHTML.trim();
+} );
+console.log( data );
+```
+*/
 const videosForSection = {
 	sharing: [
 		{
@@ -675,12 +686,340 @@ const videosForSection = {
 			title: 'Add Social Sharing Buttons to Your Website',
 			description:
 				'Find out how to add social sharing buttons to your WordPress.com site, which you can also ' +
-				'do with a Jetpack-enabled WordPress site. Our step-by-step video will walk you through it, ' +
-				"and it's easier than you'd think!",
+				'do with a Jetpack-enabled WordPress site.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/NcCe0ozmqFM',
+			title: 'Connect Your Blog to Facebook Using Publicize',
+			description:
+				'Find out how to share blog posts directly on Facebook from your WordPress.com site, ' +
+				'which you can also do on a Jetpack-enabled WordPress site.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/f44-4TgnWTs',
+			title: 'Display Your Instagram Feed on Your Website',
+			description:
+				'Find out how to display your latest Instagram photos right on your WordPress.com site.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/3rTooGV_mlg',
+			title: 'Set Up the Social Links Menu',
+			description:
+				'Find out how to set up a social links menu on your WordPress.com or Jetpack-enabled WordPress site.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/gmrOkkqMNlc',
+			title: 'Embed a Twitter Timeline in your Sidebar',
+			description:
+				'Find out how to display your Twitter timeline on your WordPress.com or Jetpack-enabled WordPress site.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/vy-U5saqG9A',
+			title: 'Set Up a Social Media Icons Widget',
+			description:
+				'Find out how to set up the social media icons widget on your WordPress.com or Jetpack-enabled WordPress site.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/N0GRBFRkzzs',
+			title: 'Embed a Tweet from Twitter in Your Website',
+			description:
+				'Find out how to embed a Tweet in your content (including posts and pages) on your WordPress.com ' +
+				'or Jetpack-enabled WordPress website or blog.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/uVRji6bKJUE',
+			title: 'Embed an Instagram Photo in Your Website',
+			description:
+				'Find out how to embed an Instagram photo in your content (including posts and pages) on your WordPress.com ' +
+				'or Jetpack-enabled WordPress website or blog.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/sKm3Q83JxM0',
+			title: 'Embed a Facebook Update in Your Website',
+			description:
+				'Find out how to embed a Facebook update in your content (including posts, pages, and even comments) on your ' +
+				'WordPress.com or Jetpack-enabled WordPress website or blog.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/SBgNkre_b14',
+			title: 'Share Blog Posts Directly on Twitter',
+			description:
+				'Find out how to share blog posts directly on Twitter from your WordPress.com or Jetpack-enabled WordPress site.',
+		},
+	],
+	settings: [
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/0YCZ22k4SfQ',
+			title: 'Add a Site Logo',
+			description: 'Find out how to add a custom logo to your WordPress.com site.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/vucZ1uZ2NPo',
+			title: 'Update Your Website Title and Tagline',
+			description:
+				'Find out how to update the Title and Tagline of your WordPress.com site, which you can also ' +
+				'do on your Jetpack-enabled WordPress site.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/Y6iPsPwYD7g',
+			title: 'Change Your Privacy Settings',
+			description: 'Find out how to change your website privacy settings on WordPress.com.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/bjxKGxW0MRA',
+			title: 'Add a Site Icon',
+			description: 'Find out how to add a site icon on WordPress.com.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/z6fCtvLB0wM',
+			title: 'Create a Multilingual Site',
+			description: 'Find out how to create a multilingual site on WordPress.com.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/D142Edhcpaw',
+			title: 'Customize Your Content Options',
+			description: 'Find out how to customize your content options on select WordPress.com themes.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/Vyr-g5SEuIA',
+			title: 'Change Your Language Settings',
+			description:
+				'Find out how to change your blog or website language and your interface language settings on WordPress.com.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/EUuEuW_LCrc',
+			title: 'Activate Free Email Forwarding',
+			description:
+				'Find out how to activate free email forwarding from an address using a custom domain registered through WordPress.com.',
+		},
+	],
+	'post-editor': [
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/hNg1rrkiAjg',
+			title: 'Set a Featured Image for a Post or Page',
+			description:
+				'Find out how to add a featured image where available on your WordPress.com or Jetpack-enabled WordPress site.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/dAcEBKXPlyA',
+			title: 'Add a Contact Form to Your Website',
+			description: 'Find out how to add a contact form to your WordPress.com site.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/ssfHW5lwFZg',
+			title: 'Embed a YouTube Video in Your Website',
+			description:
+				'Find out how to embed a YouTube video in your content (including posts, pages, and even comments) ' +
+				'on your WordPress.com or Jetpack-enabled WordPress website or blog.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/_tpcHN6ZtKM',
+			title: 'Schedule a Post',
+			description: 'Find out how to schedule a post on your WordPress.com website or blog.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/V8UToJoSf4Q',
+			title: 'Add a Simple Payment Button',
+			description: 'Find out how to add a payment button to your WordPress.com website.',
+		},
+	],
+	account: [
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/aO-6yu3_xWQ',
+			title: 'Change Your Password',
+			description: 'Find out how to change your account password on WordPress.com.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/qhsjkqFdDZo',
+			title: 'Change Your WordPress.com Username',
+			description: 'Find out how to change your username on WordPress.com.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/Tyxu_xT6q1k',
+			title: 'Change Your WordPress.com Display Name',
+			description: 'Find out how to change your display name on WordPress.com.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/07Nf8FkjO4o',
+			title: 'Change Your Account Email Address',
+			description: 'Find out how to change your account email address WordPress.com.',
+		},
+	],
+	customizer: [
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/pf_ST7gvY8c',
+			title: 'Add a Custom Header Image',
+			description:
+				'Find out how to add a custom header image to your WordPress.com website or blog.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/CY20IAtl2Ac',
+			title: 'Create a Custom Website Menu',
+			description:
+				'Find out how to create a custom menu on your WordPress.com or Jetpack-enabled WordPress site.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/2H_Jsgh2Z3Y',
+			title: 'Add a Widget',
+			description: 'Find out how to add a widget to your WordPress.com website.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/ypFF4ONBfSQ',
+			title: 'Add a Custom Background',
+			description: 'Find out how to add a custom background to your WordPress.com site.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/b8EuJDrNeOA',
+			title: 'Change Your Site Fonts',
+			description: 'Find out how to change the fonts on your WordPress.com website or blog.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/7VPgvxV78Kc',
+			title: 'Add a Gallery Widget',
+			description:
+				'Find out how to add an image gallery widget to your WordPress.com website or blog.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/oDBuaBLrwF8',
+			title: 'Use Featured Content',
+			description:
+				'Find out how to use the Featured Content option on your WordPress.com website or blog.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/3TqRr21zyiA',
+			title: 'Add an Image Widget',
+			description: 'Find out how to add an image widget to your WordPress.com website or blog.',
+		},
+	],
+	'posts-pages': [
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/3RPidSCQ0LI',
+			title: 'Create a Landing Page',
+			description:
+				'Find out how to create a one-page website or landing page on your WordPress.com site.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/4IkFQzl5nXc',
+			title: 'Set Up a Website in 5 Steps',
+			description: 'Find out how to create a website on WordPress.com in five steps.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/mta6Y0o7yJk',
+			title: 'Set Up a Blog in 5 Steps',
+			description: 'Find out how to create a blog on WordPress.com in five steps.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/Gx7YNX1Wk5U',
+			title: 'Create a Page',
+			description: 'Find out how to create a page on your WordPress.com site.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/mCfuh5bCOwM',
+			title: 'Create a Post',
+			description: 'Find out how to create a post on WordPress.com.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/bEVHg6nopcs',
+			title: 'Use a Custom Menu in a Widget',
+			description:
+				'Find out how to use a custom menu in a widget on your WordPress.com or Jetpack-enabled WordPress site.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/nAzdUOlFoBI',
+			title: 'Configure a Static Homepage',
+			description:
+				'By default, your new WordPress.com website displays your latest posts. Find out how to create a static homepage instead.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/MPpVeMmDOhk',
+			title: 'Show Related Posts on Your WordPress Blog',
+			description:
+				'Find out how to show related posts on your WordPress.com site, which you can also do on a Jetpack-enabled WordPress blog.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/JVnltCZUKC4',
+			title: 'Add Testimonials',
+			description: 'Find out how to add testimonials to your WordPress.com website or blog.',
+		},
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/yH_gapAUGAA',
+			title: 'Change Your Post or Page Visibility Settings',
+			description: 'Find out how to change your page or post visibility settings WordPress.com.',
+		},
+	],
+	media: [
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/VjGnEHyqVqQ',
+			title: 'Add a Photo Gallery',
+			description:
+				'Find out how to add a photo gallery on your WordPress.com and Jetpack-enabled website.',
+		},
+	],
+	themes: [
+		{
+			type: RESULT_VIDEO,
+			link: 'https://www.youtube.com/embed/yOfAuOb68Hc',
+			title: 'Change Your Website Theme on WordPress.com',
+			description: 'Find out how to change your WordPress.com theme.',
 		},
 	],
 };
+
 const toursForSection = {
+	'post-editor': [
+		{
+			type: RESULT_TOUR,
+			tour: 'simplePaymentsTour',
+			key: 'tour:simplePaymentsTour',
+			title: 'Collect Payments and Donations',
+			description: "It's easy to add a button that can collect payments or donations. See how!",
+		},
+	],
 	media: [
 		{
 			type: RESULT_TOUR,


### PR DESCRIPTION
This PR adds more videos and another tour to Inline Help's Rich Results. 

To test: 
- Go through the contextual help file and ponder whether the additions make sense. Note that for now we only show a single video or tour per section — the first one. That will change in the future. 
- Navigate around sections a bit and make sure that the correct video is shown (the first one in the respective list). 