### PR TITLE
Post Edit Store: remove unused actions update, trash and restore

### DIFF
--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -363,58 +363,6 @@ PostActions = {
 			callback( error, data );
 		} );
 	},
-
-	/**
-	 * Calls out to API to update Post object with any changed attributes
-	 *
-	 * @param {Object} site Site object
-	 * @param {object} post to be changed
-	 * @param {object} attributes only send the attributes to be changed
-	 * @param {function} callback callback receives ( err, post ) arguments
-
-	 */
-	update: function( site, post, attributes, callback ) {
-		const postHandle = wpcom.site( post.site_ID ).post( post.ID );
-
-		postHandle.update( attributes, PostActions.receiveUpdate.bind( null, site, callback ) );
-	},
-
-	/**
-	 * Sends `delete` request to the API. The first request
-	 * updates status to `trash`, the second request deletes the post.
-	 *
-	 * @param {Object} site Site object
-	 * @param {object} post to be trashed
-	 * @param {function} callback that receives ( err, post ) arguments
-	 */
-	trash: function( site, post, callback ) {
-		const postHandle = wpcom.site( post.site_ID ).post( post.ID );
-
-		postHandle.delete( PostActions.receiveUpdate.bind( null, site, callback ) );
-	},
-
-	/**
-	 * Restores post/page from trash
-	 *
-	 * @param {object} post to be trashed
-	 * @param {function} callback that receives ( err, post ) arguments
-	 * @param {Object} site Site object
-	 */
-	restore: function( site, post, callback ) {
-		const postHandle = wpcom.site( post.site_ID ).post( post.ID );
-
-		postHandle.restore( PostActions.receiveUpdate.bind( null, site, callback ) );
-	},
-
-	receiveUpdate: function( site, callback, error, data ) {
-		Dispatcher.handleServerAction( {
-			type: 'RECEIVE_UPDATED_POST',
-			error: error,
-			post: data,
-			site,
-		} );
-		callback( error, data );
-	},
 };
 
 export default PostActions;

--- a/client/lib/posts/post-edit-store.js
+++ b/client/lib/posts/post-edit-store.js
@@ -256,18 +256,6 @@ function dispatcherCallback( payload ) {
 			_queueChanges = true;
 			break;
 
-		// called by post changes elsewhere e.g. drafts drawer
-		case 'RECEIVE_UPDATED_POST':
-			if ( ! action.error ) {
-				if ( _post && action.post.ID === _post.ID ) {
-					updatePost( action.site, action.post );
-					PostEditStore.emit( 'change' );
-				}
-			}
-			_queueChanges = false;
-			_queue = [];
-			break;
-
 		case 'RECEIVE_POST_BEING_EDITED':
 			if ( ! action.error ) {
 				updatePost( action.site, action.post );

--- a/client/my-sites/resume-editing/index.jsx
+++ b/client/my-sites/resume-editing/index.jsx
@@ -23,7 +23,6 @@ import {
 import { isRequestingSitePost } from 'state/posts/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
 import { getSectionName } from 'state/ui/selectors';
-import { getSite } from 'state/sites/selectors';
 import { decodeEntities } from 'lib/formatting';
 import analytics from 'lib/analytics';
 import QueryPosts from 'components/data/query-posts';
@@ -54,7 +53,7 @@ class ResumeEditing extends React.Component {
 	};
 
 	render() {
-		const { siteId, postId, requesting, draft, editPath, section, site, translate } = this.props;
+		const { siteId, postId, requesting, draft, editPath, section, translate } = this.props;
 		if ( ! draft || 'post-editor' === section ) {
 			return null;
 		}
@@ -68,7 +67,7 @@ class ResumeEditing extends React.Component {
 				<QueryPosts siteId={ siteId } postId={ postId } />
 				<span className="resume-editing__label">{ translate( 'Continue Editing' ) }</span>
 				<span className="resume-editing__post-title">
-					<SiteIcon size={ 16 } site={ site } />
+					<SiteIcon size={ 16 } siteId={ siteId } />
 					{ draft.title ? decodeEntities( draft.title ) : translate( 'Untitled' ) }
 				</span>
 			</a>
@@ -88,7 +87,6 @@ export default connect(
 			draft: getEditorLastDraftPost( state ),
 			editPath: getEditorPath( state, siteId, postId ),
 			section: getSectionName( state ),
-			site: getSite( state, siteId ),
 		};
 	},
 	{ resetEditorLastDraft }


### PR DESCRIPTION
All usages of these actions (and the `RECEIVE_POST_UPDATE` action type) has been completely converted to Redux. The last PR to do so was #23377, which converted trashing the currently edited post to Redux.

There are two changes to the `ResumeEditing` component, one is on-topic, the second is a drive-by improvement:

**Stop listening for Flux post updates**
The `ResumeEditing` component doesn't need to listen to the `RECEIVE_UPDATED_POST` Flux action: nobody is dispatching that any more and all updates are Redux.

**Pass `siteId` to `SiteIcon` instead of the full `site` object**
Pass only a `siteId` prop to the `SiteIcon` component -- it has its own `connect`call that retrieves the full site. `getSite` can be completely removed from `ResumeEditing` now.
