### PR TITLE
Update hasRenewableSubscription to operate based on data available offline if bill_period isn't known yet

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -53,7 +53,14 @@ import {
 import sortProducts from 'lib/products-values/sort';
 import { getTld } from 'lib/domains';
 import { domainProductSlugs } from 'lib/domains/constants';
-import { isPersonalPlan, isPremiumPlan, isBusinessPlan, isWpComFreePlan } from 'lib/plans';
+import {
+	getTermDuration,
+	getPlan,
+	isPersonalPlan,
+	isPremiumPlan,
+	isBusinessPlan,
+	isWpComFreePlan,
+} from 'lib/plans';
 
 /**
  * Adds the specified item to a shopping cart.
@@ -381,6 +388,23 @@ export function hasOnlyRenewalItems( cart ) {
 }
 
 /**
+ * Returns a bill period of given cartItem
+ *
+ * @param {Object} cartItem - cartItem
+ * @returns {Number|null} bill period of given cartItem
+ */
+export function getCartItemBillPeriod( cartItem ) {
+	let billPeriod = cartItem.bill_period;
+	if ( ! Number.isInteger( billPeriod ) ) {
+		const plan = getPlan( cartItem.product_slug );
+		if ( plan ) {
+			billPeriod = getTermDuration( plan.term );
+		}
+	}
+	return billPeriod;
+}
+
+/**
  * Determines whether any product in the specified shopping cart is a renewable subscription.
  * Will return false if the cart is empty.
  *
@@ -388,7 +412,7 @@ export function hasOnlyRenewalItems( cart ) {
  * @returns {boolean} true if any product in the cart renews
  */
 export function hasRenewableSubscription( cart ) {
-	return cart.products && some( getAll( cart ), cartItem => cartItem.bill_period > 0 );
+	return cart.products && some( getAll( cart ), cartItem => getCartItemBillPeriod( cartItem ) > 0 );
 }
 
 /**

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -18,7 +18,8 @@ import {
 } from 'lib/plans/constants';
 
 const cartItems = require( '../cart-items' );
-const { planItem, getItemForPlan } = cartItems;
+const { getTermDuration, getPlan } = require( 'lib/plans' );
+const { planItem, getItemForPlan, hasRenewableSubscription, getCartItemBillPeriod } = cartItems;
 
 /**
  * External dependencies
@@ -79,6 +80,75 @@ describe( 'getItemForPlan()', () => {
 	[ PLAN_FREE, PLAN_JETPACK_FREE ].forEach( product_slug => {
 		test( `should throw an error for plan ${ product_slug }`, () => {
 			expect( () => getItemForPlan( { product_slug } ).product_slug ).toThrow();
+		} );
+	} );
+} );
+
+describe( 'getCartItemBillPeriod()', () => {
+	test( 'if cartItem has bill_period property, it should be returned', () => {
+		expect( getCartItemBillPeriod( { bill_period: 180 } ) ).toBe( 180 );
+		expect( getCartItemBillPeriod( { bill_period: 114 } ) ).toBe( 114 );
+		expect( getCartItemBillPeriod( { bill_period: 4 } ) ).toBe( 4 );
+		expect( getCartItemBillPeriod( { bill_period: -1 } ) ).toBe( -1 );
+	} );
+
+	[
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_PERSONAL_MONTHLY,
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PREMIUM_MONTHLY,
+		PLAN_BUSINESS,
+		PLAN_BUSINESS_2_YEARS,
+		PLAN_JETPACK_BUSINESS,
+		PLAN_JETPACK_BUSINESS_MONTHLY,
+	].forEach( product_slug => {
+		test( `should return plan bill_period for any plan with product_slug ${ product_slug }`, () => {
+			const expected_bill_period = getTermDuration( getPlan( product_slug ).term );
+
+			expect(
+				getCartItemBillPeriod( {
+					product_slug,
+				} )
+			).toBe( expected_bill_period );
+		} );
+	} );
+} );
+
+describe( 'hasRenewableSubscription()', () => {
+	[
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_PERSONAL_MONTHLY,
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PREMIUM_MONTHLY,
+		PLAN_BUSINESS,
+		PLAN_BUSINESS_2_YEARS,
+		PLAN_JETPACK_BUSINESS,
+		PLAN_JETPACK_BUSINESS_MONTHLY,
+	].forEach( product_slug => {
+		test( `should return true for product with bill_period same as plan ${ product_slug }`, () => {
+			const bill_period = getTermDuration( getPlan( product_slug ).term );
+
+			expect(
+				hasRenewableSubscription( {
+					products: [ { bill_period } ],
+				} )
+			).toBe( true );
+		} );
+
+		test( `should return true for product with product_slug same as plan ${ product_slug }`, () => {
+			expect(
+				hasRenewableSubscription( {
+					products: [ { product_slug } ],
+				} )
+			).toBe( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR aims to fix the following effect of TOS message blinking, which is caused by `hasRenewableSubscription` operating on data received via an API.

![2yrplan-tos](https://user-images.githubusercontent.com/205419/39357219-7b1a5844-4a12-11e8-85cc-c3fdb1a27b1d.gif)

Test plan:
* Act as on the .gif above and confirm TOS message no longer blinks