### PR TITLE
Jetpack: show the google button before the regular signup form

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -41,6 +41,7 @@ import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analyt
 import { createSocialUserFailed } from 'state/login/actions';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import { getSectionName } from 'state/ui/selectors';
+import { abtest } from 'lib/abtest';
 
 const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500,
 	debug = debugModule( 'calypso:signup-form:form' );
@@ -331,9 +332,13 @@ class SignupForm extends Component {
 		} );
 	};
 
+	isJetpack() {
+		return 'jetpack-connect' === this.props.sectionName;
+	}
+
 	getLoginLink() {
 		return login( {
-			isJetpack: 'jetpack-connect' === this.props.sectionName,
+			isJetpack: this.isJetpack(),
 			isNative: config.isEnabled( 'login/native-login-links' ),
 			redirectTo: this.props.redirectToAfterLoginUrl,
 			locale: this.props.locale,
@@ -597,16 +602,40 @@ class SignupForm extends Component {
 		);
 	}
 
+	isJetpackSocialABTest() {
+		return this.isJetpack() && abtest( 'jetpackSignupGoogleTop' ) === 'top';
+	}
+
 	render() {
 		if ( this.getUserExistsError( this.props ) ) {
 			return null;
 		}
 
 		return (
-			<div className={ classNames( 'signup-form', this.props.className ) }>
+			<div
+				className={ classNames(
+					'signup-form',
+					this.props.className,
+					this.isJetpackSocialABTest() && 'signup-form__social-top'
+				) }
+			>
 				{ this.getNotice() }
 
+				{ this.isJetpackSocialABTest() &&
+					this.props.isSocialSignupEnabled && (
+						<SocialSignupForm
+							showFirst={ true }
+							handleResponse={ this.props.handleSocialResponse }
+							socialService={ this.props.socialService }
+							socialServiceResponse={ this.props.socialServiceResponse }
+						/>
+					) }
+
 				<LoggedOutForm onSubmit={ this.handleSubmit } noValidate={ true }>
+					{ this.isJetpackSocialABTest() &&
+						this.props.isSocialSignupEnabled && (
+							<p>{ this.props.translate( 'Or create a new account with your email address.' ) }</p>
+						) }
 					{ this.props.formHeader && (
 						<header className="signup-form__header">{ this.props.formHeader }</header>
 					) }
@@ -616,13 +645,14 @@ class SignupForm extends Component {
 					{ this.props.formFooter || this.formFooter() }
 				</LoggedOutForm>
 
-				{ this.props.isSocialSignupEnabled && (
-					<SocialSignupForm
-						handleResponse={ this.props.handleSocialResponse }
-						socialService={ this.props.socialService }
-						socialServiceResponse={ this.props.socialServiceResponse }
-					/>
-				) }
+				{ ! this.isJetpackSocialABTest() &&
+					this.props.isSocialSignupEnabled && (
+						<SocialSignupForm
+							handleResponse={ this.props.handleSocialResponse }
+							socialService={ this.props.socialService }
+							socialServiceResponse={ this.props.socialServiceResponse }
+						/>
+					) }
 
 				{ this.props.footerLink || this.footerLink() }
 			</div>

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import GoogleLoginButton from 'components/social-buttons/google';
 import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -22,6 +23,7 @@ class SocialSignupForm extends Component {
 		translate: PropTypes.func.isRequired,
 		socialService: PropTypes.string,
 		socialServiceResponse: PropTypes.object,
+		showFirst: PropTypes.bool,
 	};
 
 	handleGoogleResponse = ( response, triggeredByUser = true ) => {
@@ -48,10 +50,17 @@ class SocialSignupForm extends Component {
 		const redirectUri = uxMode === 'redirect' ? `https://${ window.location.host }/start` : null;
 
 		return (
-			<Card className="signup-form__social">
+			<Card
+				className={ classNames(
+					'signup-form__social',
+					this.props.showFirst && 'signup-form__social-top'
+				) }
+			>
 				<p>
 					{ preventWidows(
-						this.props.translate( 'Or connect your existing profile to get started faster.' )
+						this.props.showFirst
+							? this.props.translate( 'Connect your existing profile to get started.' )
+							: this.props.translate( 'Or connect your existing profile to get started faster.' )
 					) }
 				</p>
 

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -34,6 +34,10 @@
 			margin: 10px 0 0;
 		}
 	}
+
+	&.signup-form__social-top {
+		margin-bottom: 0;
+	}
 }
 
 .signup-form__social-buttons {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -12,6 +12,15 @@
 		}
 	}
 
+	.signup-form__social-top {
+		.logged-out-form__links {
+			margin-top: 0px;
+			@include breakpoint( '>480px' ) {
+				margin-top: 0px;
+			}
+		}
+	}
+
 	.formatted-header {
 		margin-bottom: 16px;
 	}

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -100,4 +100,12 @@ export default {
 		defaultVariation: 'original',
 		allowExistingUsers: true,
 	},
+	jetpackSignupGoogleTop: {
+		datestamp: '20180427',
+		variations: {
+			original: 50,
+			top: 50,
+		},
+		defaultVariation: 'original',
+	},
 };


### PR DESCRIPTION
This PR introduces a test that moves the google signup button to the top of the signup form instead of showing it below. The current button position lets it below the fold for the majority of laptop resolutions, and we think that giving the button a more visible position could help users to create an account while connecting jetpack.

How to test
=======
1. You will need an unconnected jetpack site and not be logged in WordPress.com
2. Go to https://calypso.live/jetpack/connect/?branch=add/jetpack-social-test 
3. Open your dev console and enter `localStorage.setItem( 'ABTests', '{"jetpackSignupGoogleTop_20180427":"top"}' )` 
4. Reload the page and enter your site's url
4.5: At this point you will be redirected to wpcalypso. Change wpcalypso.wordpress.com for calypso.live in the url and keep going
5. When asked to log in, you either can be redirected to the login page or to the account creation one. If you are on the login page, click on "sign up" in the top right corner
6. Once you are on the new account page, you should see the social account creation button on top of the form
7. Repeat 1-6, but entering  `localStorage.setItem( 'ABTests', '{"jetpackSignupGoogleTop_20180427":"original"}' )`. Once you get to the new account page, the social account button should appear at the bottom

![image](https://user-images.githubusercontent.com/1554855/39360786-e6001baa-4a1f-11e8-9802-bd79a532be26.png)
