### PR TITLE
Plans: create mobile apps feature card for My Plan tab.

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -39,6 +39,7 @@ import JetpackBackupSecurity from './jetpack-backup-security';
 import JetpackSearch from './jetpack-search';
 import JetpackReturnToDashboard from './jetpack-return-to-dashboard';
 import JetpackWordPressCom from './jetpack-wordpress-com';
+import MobileApps from './mobile-apps';
 import { isSiteAutomatedTransfer } from 'state/selectors';
 import { isEnabled } from 'config';
 import { isWordadsInstantActivationEligible } from 'lib/ads/utils';
@@ -81,6 +82,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
 				<FindNewTheme selectedSite={ selectedSite } />
 				{ isEnabled( 'manage/plugins/upload' ) && <UploadPlugins selectedSite={ selectedSite } /> }
+				<MobileApps />
 			</Fragment>
 		);
 	}
@@ -99,6 +101,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				{ isWordadsInstantActivationEligible( selectedSite ) && (
 					<MonetizeSite selectedSite={ selectedSite } />
 				) }
+				<MobileApps />
 			</Fragment>
 		);
 	}
@@ -111,6 +114,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<HappinessSupportCard isPlaceholder={ isPlaceholder } />
 				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
 				<AdvertisingRemoved isBusinessPlan={ false } />
+				<MobileApps />
 			</Fragment>
 		);
 	}
@@ -129,6 +133,7 @@ export class ProductPurchaseFeaturesList extends Component {
 					onClick={ this.props.recordReturnToDashboardClick }
 					selectedSite={ selectedSite }
 				/>
+				<MobileApps />
 			</Fragment>
 		);
 	}
@@ -148,6 +153,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<JetpackPublicize />
 				<JetpackVideo />
 				<JetpackReturnToDashboard selectedSite={ selectedSite } />
+				<MobileApps />
 			</Fragment>
 		);
 	}
@@ -165,6 +171,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<JetpackBackupSecurity />
 				<JetpackAntiSpam />
 				<JetpackReturnToDashboard selectedSite={ selectedSite } />
+				<MobileApps />
 			</Fragment>
 		);
 	}
@@ -193,6 +200,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<JetpackBackupSecurity />
 				<JetpackAntiSpam />
 				<JetpackReturnToDashboard selectedSite={ selectedSite } />
+				<MobileApps />
 			</Fragment>
 		);
 	}

--- a/client/blocks/product-purchase-features-list/mobile-apps.jsx
+++ b/client/blocks/product-purchase-features-list/mobile-apps.jsx
@@ -23,7 +23,7 @@ export default localize( ( { translate } ) => {
 						'track stats, moderate comments, and more.'
 				) }
 				buttonText={ translate( 'Get the apps' ) }
-				href={ '/themes/' }
+				href={ 'https://apps.wordpress.com/get?utm_source=calypsomyplan&utm_medium=cta&utm_campaign=calypsogetappscard' }
 			/>
 		</div>
 	);

--- a/client/blocks/product-purchase-features-list/mobile-apps.jsx
+++ b/client/blocks/product-purchase-features-list/mobile-apps.jsx
@@ -1,0 +1,30 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import PurchaseDetail from 'components/purchase-detail';
+
+export default localize( ( { translate } ) => {
+	return (
+		<div className="product-purchase-features-list__item">
+			<PurchaseDetail
+				icon={ <img alt="" src="/calypso/images/illustrations/jetpack-apps.svg" /> }
+				title={ translate( 'Download our mobile apps' ) }
+				description={ translate(
+					'Manage all your sites from a single dashboard: publish content, ' +
+						'track stats, moderate comments, and more.'
+				) }
+				buttonText={ translate( 'Get the apps' ) }
+				href={ '/themes/' }
+			/>
+		</div>
+	);
+} );

--- a/client/blocks/product-purchase-features-list/mobile-apps.jsx
+++ b/client/blocks/product-purchase-features-list/mobile-apps.jsx
@@ -23,7 +23,10 @@ export default localize( ( { translate } ) => {
 						'track stats, moderate comments, and more.'
 				) }
 				buttonText={ translate( 'Get the apps' ) }
-				href={ 'https://apps.wordpress.com/get?utm_source=calypsomyplan&utm_medium=cta&utm_campaign=calypsogetappscard' }
+				href={
+					'https://apps.wordpress.com/get?utm_source=calypsomyplan&utm_medium=cta&utm_campaign=calypsogetappscard'
+				}
+				target="_blank"
 			/>
 		</div>
 	);

--- a/client/blocks/product-purchase-features-list/mobile-apps.jsx
+++ b/client/blocks/product-purchase-features-list/mobile-apps.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import PurchaseDetail from 'components/purchase-detail';
+import { addQueryArgs } from 'lib/route';
 
 export default localize( ( { translate } ) => {
 	return (
@@ -23,9 +24,14 @@ export default localize( ( { translate } ) => {
 						'track stats, moderate comments, and more.'
 				) }
 				buttonText={ translate( 'Get the apps' ) }
-				href={
-					'https://apps.wordpress.com/get?utm_source=calypsomyplan&utm_medium=cta&utm_campaign=calypsogetappscard'
-				}
+				href={ addQueryArgs(
+					{
+						utm_source: 'calypsomyplan',
+						utm_medium: 'cta',
+						utm_campaign: 'calypsogetappscard',
+					},
+					'https://apps.wordpress.com/get?'
+				) }
 				target="_blank"
 			/>
 		</div>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/23380

This is a new card that will be included with the My Plan feature cards for all .com and JP plans.

![screen shot 2018-04-27 at 13 10 08](https://user-images.githubusercontent.com/13561163/39361817-f5e31616-4a1b-11e8-8015-ac010cf58708.png)

## To test:

- go to `plans/my-plan/:site` on local Calypso build or calypso.live
- verify that the card is present for all .com and Jetpack plans
- verify that the CTA button redirects to ...
