### PR TITLE
Plans: create sell online feature card to be included in the My Plan tab.

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -138,7 +138,6 @@ export class ProductPurchaseFeaturesList extends Component {
 					selectedSite={ selectedSite }
 				/>
 				<MobileApps />
-				<SellOnlinePaypal />
 			</Fragment>
 		);
 	}
@@ -178,7 +177,6 @@ export class ProductPurchaseFeaturesList extends Component {
 				<JetpackAntiSpam selectedSite={ selectedSite } />
 				<JetpackReturnToDashboard selectedSite={ selectedSite } />
 				<MobileApps />
-				<SellOnlinePaypal />
 			</Fragment>
 		);
 	}

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -84,7 +84,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<FindNewTheme selectedSite={ selectedSite } />
 				{ isEnabled( 'manage/plugins/upload' ) && <UploadPlugins selectedSite={ selectedSite } /> }
 				<MobileApps />
-				<SellOnlinePaypal />
+				<SellOnlinePaypal isJetpack={ false } />
 			</Fragment>
 		);
 	}
@@ -104,7 +104,7 @@ export class ProductPurchaseFeaturesList extends Component {
 					<MonetizeSite selectedSite={ selectedSite } />
 				) }
 				<MobileApps />
-				<SellOnlinePaypal />
+				<SellOnlinePaypal isJetpack={ false } />
 			</Fragment>
 		);
 	}
@@ -118,7 +118,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
 				<AdvertisingRemoved isBusinessPlan selectedSite={ selectedSite } />
 				<MobileApps />
-				<SellOnlinePaypal />
+				<SellOnlinePaypal isJetpack={ false } />
 			</Fragment>
 		);
 	}
@@ -158,7 +158,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<JetpackVideo selectedSite={ selectedSite } />
 				<JetpackReturnToDashboard selectedSite={ selectedSite } />
 				<MobileApps />
-				<SellOnlinePaypal />
+				<SellOnlinePaypal isJetpack />
 			</Fragment>
 		);
 	}
@@ -206,7 +206,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<JetpackAntiSpam selectedSite={ selectedSite } />
 				<JetpackReturnToDashboard selectedSite={ selectedSite } />
 				<MobileApps />
-				<SellOnlinePaypal />
+				<SellOnlinePaypal isJetpack />
 			</Fragment>
 		);
 	}

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -40,6 +40,7 @@ import JetpackSearch from './jetpack-search';
 import JetpackReturnToDashboard from './jetpack-return-to-dashboard';
 import JetpackWordPressCom from './jetpack-wordpress-com';
 import MobileApps from './mobile-apps';
+import SellOnlinePaypal from './sell-online-paypal';
 import { isSiteAutomatedTransfer } from 'state/selectors';
 import { isEnabled } from 'config';
 import { isWordadsInstantActivationEligible } from 'lib/ads/utils';
@@ -83,6 +84,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<FindNewTheme selectedSite={ selectedSite } />
 				{ isEnabled( 'manage/plugins/upload' ) && <UploadPlugins selectedSite={ selectedSite } /> }
 				<MobileApps />
+				<SellOnlinePaypal />
 			</Fragment>
 		);
 	}
@@ -102,6 +104,7 @@ export class ProductPurchaseFeaturesList extends Component {
 					<MonetizeSite selectedSite={ selectedSite } />
 				) }
 				<MobileApps />
+				<SellOnlinePaypal />
 			</Fragment>
 		);
 	}
@@ -115,6 +118,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
 				<AdvertisingRemoved isBusinessPlan selectedSite={ selectedSite } />
 				<MobileApps />
+				<SellOnlinePaypal />
 			</Fragment>
 		);
 	}
@@ -134,6 +138,7 @@ export class ProductPurchaseFeaturesList extends Component {
 					selectedSite={ selectedSite }
 				/>
 				<MobileApps />
+				<SellOnlinePaypal />
 			</Fragment>
 		);
 	}
@@ -154,6 +159,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<JetpackVideo selectedSite={ selectedSite } />
 				<JetpackReturnToDashboard selectedSite={ selectedSite } />
 				<MobileApps />
+				<SellOnlinePaypal />
 			</Fragment>
 		);
 	}
@@ -172,6 +178,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<JetpackAntiSpam selectedSite={ selectedSite } />
 				<JetpackReturnToDashboard selectedSite={ selectedSite } />
 				<MobileApps />
+				<SellOnlinePaypal />
 			</Fragment>
 		);
 	}
@@ -201,6 +208,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<JetpackAntiSpam selectedSite={ selectedSite } />
 				<JetpackReturnToDashboard selectedSite={ selectedSite } />
 				<MobileApps />
+				<SellOnlinePaypal />
 			</Fragment>
 		);
 	}

--- a/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
+++ b/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
@@ -1,0 +1,30 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import PurchaseDetail from 'components/purchase-detail';
+
+export default localize( ( { translate } ) => {
+	return (
+		<div className="product-purchase-features-list__item">
+			<PurchaseDetail
+				buttonText={ translate( 'Start earning' ) }
+				description={ translate(
+					'Add a PayPal payment button and start selling your goods and services.'
+				) }
+				href={ 'theme' }
+				icon={ <img alt="" src="/calypso/images/illustrations/jetpack-payments.svg" /> }
+				target={ '' }
+				title={ translate( 'Sell online with PayPal.' ) }
+			/>
+		</div>
+	);
+} );

--- a/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
+++ b/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
@@ -20,7 +20,7 @@ export default localize( ( { translate } ) => {
 				description={ translate(
 					'Add a PayPal payment button and start selling your goods and services.'
 				) }
-				href={ 'theme' }
+				href={ 'https://en.support.wordpress.com/simple-payments/' }
 				icon={ <img alt="" src="/calypso/images/illustrations/jetpack-payments.svg" /> }
 				target={ '' }
 				title={ translate( 'Sell online with PayPal.' ) }

--- a/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
+++ b/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import PurchaseDetail from 'components/purchase-detail';
 
-export default localize( ( { translate } ) => {
+export default localize( ( { isJetpack, translate } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
@@ -20,7 +20,11 @@ export default localize( ( { translate } ) => {
 				description={ translate(
 					'Add a PayPal payment button and start selling your goods and services.'
 				) }
-				href={ 'https://en.support.wordpress.com/simple-payments/' }
+				href={
+					isJetpack
+						? 'https://jetpack.com/support/simple-payment-button/'
+						: 'https://en.support.wordpress.com/simple-payments/'
+				}
 				icon={ <img alt="" src="/calypso/images/illustrations/jetpack-payments.svg" /> }
 				target="_blank"
 				title={ translate( 'Sell online with PayPal.' ) }

--- a/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
+++ b/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
@@ -22,7 +22,7 @@ export default localize( ( { translate } ) => {
 				) }
 				href={ 'https://en.support.wordpress.com/simple-payments/' }
 				icon={ <img alt="" src="/calypso/images/illustrations/jetpack-payments.svg" /> }
-				target={ '' }
+				target="_blank"
 				title={ translate( 'Sell online with PayPal.' ) }
 			/>
 		</div>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/23383

This PR adds the new card to the My Plans feature grid.

![screen shot 2018-04-27 at 13 25 47](https://user-images.githubusercontent.com/13561163/39362406-37cbd692-4a1e-11e8-96e9-b441d5523b60.png)

## To test:

- go to `plans/my-plan/:site` on local Calypso build or calypso.live
- verify that the card is present for all .com and Jetpack plans
- verify that the CTA button redirects to ...