### PR TITLE
Fix Jetpack sharing options checkbox when API returns object

### DIFF
--- a/client/state/site-settings/test/utils.js
+++ b/client/state/site-settings/test/utils.js
@@ -31,7 +31,7 @@ describe( 'utils', () => {
 			const settings = {
 				sharing_show: [ 'page', 'index', 'post' ],
 			};
-			expect( normalizeSettings( settings ) ).toEqual( settings );
+			expect( normalizeSettings( settings ).sharing_show ).toBe( settings.sharing_show );
 		} );
 
 		test( 'should convert sharing_show object to array', () => {

--- a/client/state/site-settings/test/utils.js
+++ b/client/state/site-settings/test/utils.js
@@ -1,11 +1,6 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import { normalizeSettings } from '../utils';
@@ -17,7 +12,7 @@ describe( 'utils', () => {
 				chicken_ribs: '10',
 			};
 
-			expect( normalizeSettings( settings ) ).to.eql( {
+			expect( normalizeSettings( settings ) ).toEqual( {
 				chicken_ribs: '10',
 			} );
 		} );
@@ -27,8 +22,28 @@ describe( 'utils', () => {
 				default_category: '10',
 			};
 
-			expect( normalizeSettings( settings ) ).to.eql( {
+			expect( normalizeSettings( settings ) ).toEqual( {
 				default_category: 10,
+			} );
+		} );
+
+		test( 'should not touch sharing_show array', () => {
+			const settings = {
+				sharing_show: [ 'page', 'index', 'post' ],
+			};
+			expect( normalizeSettings( settings ) ).toEqual( settings );
+		} );
+
+		test( 'should convert sharing_show object to array', () => {
+			const settings = {
+				sharing_show: {
+					0: 'page',
+					1: 'index',
+					3: 'post',
+				},
+			};
+			expect( normalizeSettings( settings ) ).toEqual( {
+				sharing_show: [ 'page', 'index', 'post' ],
 			} );
 		} );
 	} );

--- a/client/state/site-settings/utils.js
+++ b/client/state/site-settings/utils.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { values } from 'lodash';
+import { isPlainObject, values } from 'lodash';
 
 /**
  * Normalize API Settings
@@ -19,7 +19,7 @@ export function normalizeSettings( settings ) {
 				memo[ key ] = parseInt( settings[ key ] );
 				break;
 			case 'sharing_show':
-				if ( typeof settings[ key ] === 'object' ) {
+				if ( isPlainObject( settings[ key ] ) ) {
 					memo[ key ] = values( settings[ key ] );
 				} else {
 					memo[ key ] = settings[ key ];

--- a/client/state/site-settings/utils.js
+++ b/client/state/site-settings/utils.js
@@ -1,3 +1,9 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { values } from 'lodash';
+
 /**
  * Normalize API Settings
  *
@@ -11,6 +17,13 @@ export function normalizeSettings( settings ) {
 		switch ( key ) {
 			case 'default_category':
 				memo[ key ] = parseInt( settings[ key ] );
+				break;
+			case 'sharing_show':
+				if ( typeof settings[ key ] === 'object' ) {
+					memo[ key ] = values( settings[ key ] );
+				} else {
+					memo[ key ] = settings[ key ];
+				}
 				break;
 			default:
 				memo[ key ] = settings[ key ];


### PR DESCRIPTION
On jetpack sites with the _WooCommerce_ plugin active, the site settings endpoint can return an object instead of an array for the `sharing_show` field:

```
            [sharing_show] => stdClass Object
                (
                    [0] => page
                    [1] => index
                    [2] => attachment
                    [3] => post
                    [5] => product
                )
```

This object is passed through to the multi-checkbox component at https://wordpress.com/sharing/buttons/{site}, which only works with arrays, making it impossible to change the selections.

![checkboxes](https://user-images.githubusercontent.com/7767559/39363827-94a30aa2-4a23-11e8-957e-043269c4f588.gif)

This PR ensures that object returns are converted to arrays.

## Testing
* Connect a dotorg site with Jetpack and WooCommerce plugins active
* Go to https://wordpress.com/sharing/buttons/{site}
* Select every checkbox in _Show sharing buttons on_
* Save changes
* Attempt to select another checkbox
* There should be no js errors in the console, and the box should be selectable



