### PR TITLE
Remove the 7 days oldness limit for business sites to display the GMB nudge on stats

### DIFF
--- a/client/state/selectors/is-google-my-business-stats-nudge-visible.js
+++ b/client/state/selectors/is-google-my-business-stats-nudge-visible.js
@@ -9,8 +9,6 @@ import { isGoogleMyBusinessLocationConnected } from 'state/selectors';
 import { planMatches } from 'lib/plans';
 import { TYPE_BUSINESS, GROUP_WPCOM } from 'lib/plans/constants';
 
-const WEEK_IN_SECONDS = 60 * 60 * 24 * 7;
-
 /**
  * Returns true if site has promote goal set
  *
@@ -59,12 +57,5 @@ export default function isGoogleMyBusinessStatsNudgeVisible( state, siteId ) {
 		return false;
 	}
 
-	const createdAt = getSiteOption( state, siteId, 'created_at' );
-	const isWeekPassedSinceSiteCreation = Date.parse( createdAt ) + WEEK_IN_SECONDS * 1000 < Date.now();
-
-	return (
-		isWeekPassedSinceSiteCreation &&
-		siteHasBusinessPlan( state, siteId ) &&
-		siteHasPromoteGoal( state, siteId )
-	);
+	return siteHasBusinessPlan( state, siteId ) && siteHasPromoteGoal( state, siteId );
 }


### PR DESCRIPTION
This PR removes the following condition for the GMB nudge to appear in the Stats page:
- Site must be a week old

### Testing Instructions
- Apply this branch locally
- Create a new site with a promote site goal
- Go to Stats and notice the nudge

### Reviews
- [ ] Code
- [ ] Product