### PR TITLE
Analytics: Refactor Checkout page view tracking

### DIFF
--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -28,10 +28,17 @@ export function getSiteFragment( path ) {
 	// There are 2 URL positions where we should look for the site fragment:
 	// last (most sections) and second-to-last (post ID is last in editor)
 
-	// Though, in some`/me/purchases` paths, it could also be in third position,
-	// right after the `/me/purchases/` part.
+	// Avoid confusing the receipt ID for the site ID in domain-only checkouts.
+	if ( 0 === basePath.indexOf( '/checkout/thank-you/no-site/' ) ) {
+		return false;
+	}
+
+	// In some paths, the site fragment could also be in third position.
 	// e.g. /me/purchases/example.wordpress.com/foo/bar
-	if ( 0 === basePath.indexOf( '/me/purchases/' ) ) {
+	if (
+		0 === basePath.indexOf( '/me/purchases/' ) ||
+		0 === basePath.indexOf( '/checkout/thank-you/' )
+	) {
 		const piece = pieces[ 3 ]; // 0 is the empty string before the first `/`
 		if ( piece && -1 !== piece.indexOf( '.' ) ) {
 			return piece;

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -262,7 +262,7 @@ export class CheckoutThankYou extends React.Component {
 
 	getAnalyticsProperties = () => {
 		const { gsuiteReceiptId, receiptId, selectedFeature: feature, selectedSite } = this.props;
-		const site = selectedSite.slug;
+		const site = get( selectedSite, 'slug' );
 
 		if ( gsuiteReceiptId ) {
 			return {

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -79,6 +79,7 @@ import { GROUP_WPCOM, GROUP_JETPACK, TYPE_BUSINESS } from 'lib/plans/constants';
 import hasSitePendingAutomatedTransfer from 'state/selectors/has-site-pending-automated-transfer';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { recordStartTransferClickInThankYou } from 'state/domains/actions';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 function getPurchases( props ) {
 	return [
@@ -260,7 +261,7 @@ export class CheckoutThankYou extends React.Component {
 	};
 
 	render() {
-		const { translate } = this.props;
+		const { analyticsPath, analyticsProps, translate } = this.props;
 		let purchases = [];
 		let failedPurchases = [];
 		let wasJetpackPlanPurchased = false;
@@ -298,7 +299,13 @@ export class CheckoutThankYou extends React.Component {
 				group: GROUP_WPCOM,
 			} )
 		) {
-			return <RebrandCitiesThankYou receipt={ this.props.receipt } />;
+			return (
+				<RebrandCitiesThankYou
+					receipt={ this.props.receipt }
+					analyticsPath={ analyticsPath }
+					analyticsProps={ analyticsProps }
+				/>
+			);
 		}
 
 		const { hasPendingAT, isAtomicSite } = this.props;
@@ -306,6 +313,11 @@ export class CheckoutThankYou extends React.Component {
 		if ( wasDotcomPlanPurchased && ( hasPendingAT || isAtomicSite ) ) {
 			return (
 				<Main className="checkout-thank-you">
+					<PageViewTracker
+						path={ analyticsPath }
+						title="Checkout Thank You"
+						properties={ analyticsProps }
+					/>
 					{ this.renderConfirmationNotice() }
 					<AtomicStoreThankYouCard siteId={ this.props.selectedSite.ID } />
 				</Main>
@@ -326,6 +338,11 @@ export class CheckoutThankYou extends React.Component {
 			// streamlined paid NUX thanks page
 			return (
 				<Main className="checkout-thank-you">
+					<PageViewTracker
+						path={ analyticsPath }
+						title="Checkout Thank You"
+						properties={ analyticsProps }
+					/>
 					{ this.renderConfirmationNotice() }
 					<PlanThankYouCard siteId={ this.props.selectedSite.ID } { ...planProps } />
 				</Main>
@@ -333,6 +350,11 @@ export class CheckoutThankYou extends React.Component {
 		} else if ( wasJetpackPlanPurchased && config.isEnabled( 'plans/jetpack-config-v2' ) ) {
 			return (
 				<Main className="checkout-thank-you">
+					<PageViewTracker
+						path={ analyticsPath }
+						title="Checkout Thank You"
+						properties={ analyticsProps }
+					/>
 					{ this.renderConfirmationNotice() }
 					<JetpackThankYouCard siteId={ this.props.selectedSite.ID } />
 				</Main>
@@ -344,6 +366,11 @@ export class CheckoutThankYou extends React.Component {
 
 			return (
 				<Main className="checkout-thank-you">
+					<PageViewTracker
+						path={ analyticsPath }
+						title="Checkout Thank You"
+						properties={ analyticsProps }
+					/>
 					{ this.renderConfirmationNotice() }
 
 					<ThankYouCard
@@ -367,6 +394,11 @@ export class CheckoutThankYou extends React.Component {
 		// standard thanks page
 		return (
 			<Main className="checkout-thank-you">
+				<PageViewTracker
+					path={ analyticsPath }
+					title="Checkout Thank You"
+					properties={ analyticsProps }
+				/>
 				<HeaderCake onClick={ this.goBack } isCompact backText={ goBackText } />
 
 				<Card className="checkout-thank-you__content">{ this.productRelatedMessages() }</Card>

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -260,8 +260,51 @@ export class CheckoutThankYou extends React.Component {
 		return moment( this.props.userDate ).isAfter( moment().subtract( 2, 'hours' ) );
 	};
 
+	getAnalyticsProperties = () => {
+		const { gsuiteReceiptId, receiptId, selectedFeature: feature, selectedSite } = this.props;
+		const site = selectedSite.slug;
+
+		if ( gsuiteReceiptId ) {
+			return {
+				path: '/checkout/thank-you/:site/:receipt_id/with-gsuite/:gsuite_receipt_id',
+				properties: { gsuiteReceiptId, receiptId, site },
+			};
+		}
+		if ( feature && receiptId ) {
+			return {
+				path: '/checkout/thank-you/features/:feature/:site/:receipt_id',
+				properties: { feature, receiptId, site },
+			};
+		}
+		if ( feature && ! receiptId ) {
+			return {
+				path: '/checkout/thank-you/features/:feature/:site',
+				properties: { feature, site },
+			};
+		}
+		if ( receiptId && selectedSite ) {
+			return {
+				path: '/checkout/thank-you/:site/:receipt_id',
+				properties: { receiptId, site },
+			};
+		}
+		if ( receiptId && ! selectedSite ) {
+			return {
+				path: '/checkout/thank-you/no-site/:receipt_id',
+				properties: { receiptId },
+			};
+		}
+		if ( selectedSite ) {
+			return {
+				path: '/checkout/thank-you/:site',
+				properties: { site },
+			};
+		}
+		return { path: '/checkout/thank-you/no-site', properties: {} };
+	};
+
 	render() {
-		const { analyticsPath, analyticsProps, translate } = this.props;
+		const { translate } = this.props;
 		let purchases = [];
 		let failedPurchases = [];
 		let wasJetpackPlanPurchased = false;
@@ -302,8 +345,7 @@ export class CheckoutThankYou extends React.Component {
 			return (
 				<RebrandCitiesThankYou
 					receipt={ this.props.receipt }
-					analyticsPath={ analyticsPath }
-					analyticsProps={ analyticsProps }
+					analyticsProperties={ this.getAnalyticsProperties() }
 				/>
 			);
 		}
@@ -313,11 +355,7 @@ export class CheckoutThankYou extends React.Component {
 		if ( wasDotcomPlanPurchased && ( hasPendingAT || isAtomicSite ) ) {
 			return (
 				<Main className="checkout-thank-you">
-					<PageViewTracker
-						path={ analyticsPath }
-						title="Checkout Thank You"
-						properties={ analyticsProps }
-					/>
+					<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
 					{ this.renderConfirmationNotice() }
 					<AtomicStoreThankYouCard siteId={ this.props.selectedSite.ID } />
 				</Main>
@@ -338,11 +376,7 @@ export class CheckoutThankYou extends React.Component {
 			// streamlined paid NUX thanks page
 			return (
 				<Main className="checkout-thank-you">
-					<PageViewTracker
-						path={ analyticsPath }
-						title="Checkout Thank You"
-						properties={ analyticsProps }
-					/>
+					<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
 					{ this.renderConfirmationNotice() }
 					<PlanThankYouCard siteId={ this.props.selectedSite.ID } { ...planProps } />
 				</Main>
@@ -350,11 +384,7 @@ export class CheckoutThankYou extends React.Component {
 		} else if ( wasJetpackPlanPurchased && config.isEnabled( 'plans/jetpack-config-v2' ) ) {
 			return (
 				<Main className="checkout-thank-you">
-					<PageViewTracker
-						path={ analyticsPath }
-						title="Checkout Thank You"
-						properties={ analyticsProps }
-					/>
+					<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
 					{ this.renderConfirmationNotice() }
 					<JetpackThankYouCard siteId={ this.props.selectedSite.ID } />
 				</Main>
@@ -366,11 +396,7 @@ export class CheckoutThankYou extends React.Component {
 
 			return (
 				<Main className="checkout-thank-you">
-					<PageViewTracker
-						path={ analyticsPath }
-						title="Checkout Thank You"
-						properties={ analyticsProps }
-					/>
+					<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
 					{ this.renderConfirmationNotice() }
 
 					<ThankYouCard
@@ -394,11 +420,7 @@ export class CheckoutThankYou extends React.Component {
 		// standard thanks page
 		return (
 			<Main className="checkout-thank-you">
-				<PageViewTracker
-					path={ analyticsPath }
-					title="Checkout Thank You"
-					properties={ analyticsProps }
-				/>
+				<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
 				<HeaderCake onClick={ this.goBack } isCompact backText={ goBackText } />
 
 				<Card className="checkout-thank-you__content">{ this.productRelatedMessages() }</Card>

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -267,13 +267,13 @@ export class CheckoutThankYou extends React.Component {
 		if ( gsuiteReceiptId ) {
 			return {
 				path: '/checkout/thank-you/:site/:receipt_id/with-gsuite/:gsuite_receipt_id',
-				properties: { gsuiteReceiptId, receiptId, site },
+				properties: { gsuite_receipt_id: gsuiteReceiptId, receipt_id: receiptId, site },
 			};
 		}
 		if ( feature && receiptId ) {
 			return {
 				path: '/checkout/thank-you/features/:feature/:site/:receipt_id',
-				properties: { feature, receiptId, site },
+				properties: { feature, receipt_id: receiptId, site },
 			};
 		}
 		if ( feature && ! receiptId ) {
@@ -285,13 +285,13 @@ export class CheckoutThankYou extends React.Component {
 		if ( receiptId && selectedSite ) {
 			return {
 				path: '/checkout/thank-you/:site/:receipt_id',
-				properties: { receiptId, site },
+				properties: { receipt_id: receiptId, site },
 			};
 		}
 		if ( receiptId && ! selectedSite ) {
 			return {
 				path: '/checkout/thank-you/no-site/:receipt_id',
-				properties: { receiptId },
+				properties: { receipt_id: receiptId },
 			};
 		}
 		if ( selectedSite ) {

--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -21,6 +21,7 @@ import { errorNotice } from 'state/notices/actions';
 import QueryOrderTransaction from 'components/data/query-order-transaction';
 import EmptyContent from 'components/empty-content';
 import Main from 'components/main';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 class CheckoutPending extends PureComponent {
 	static propTypes = {
@@ -96,11 +97,20 @@ class CheckoutPending extends PureComponent {
 	}
 
 	render() {
-		const { orderId, translate } = this.props;
+		const { orderId, siteSlug, translate } = this.props;
 
 		return (
 			<Main className="checkout-thank-you__pending">
 				<QueryOrderTransaction orderId={ orderId } pollIntervalMs={ 5000 } />
+				<PageViewTracker
+					path={
+						siteSlug
+							? '/checkout/thank-you/:site/pending/:order_id'
+							: '/checkout/thank-you/no-site/pending/:order_id'
+					}
+					title="Checkout Pending"
+					properties={ { orderId, ...( siteSlug && { site: siteSlug } ) } }
+				/>
 				<EmptyContent
 					illustration={ '/calypso/images/illustrations/illustration-shopping-bags.svg' }
 					illustrationWidth={ 500 }

--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -109,7 +109,7 @@ class CheckoutPending extends PureComponent {
 							: '/checkout/thank-you/no-site/pending/:order_id'
 					}
 					title="Checkout Pending"
-					properties={ { orderId, ...( siteSlug && { site: siteSlug } ) } }
+					properties={ { order_id: orderId, ...( siteSlug && { site: siteSlug } ) } }
 				/>
 				<EmptyContent
 					illustration={ '/calypso/images/illustrations/illustration-shopping-bags.svg' }

--- a/client/my-sites/checkout/checkout-thank-you/rebrand-cities-thank-you.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/rebrand-cities-thank-you.jsx
@@ -12,6 +12,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import ThankYouCard from 'components/thank-you-card';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 class RebrandCitiesThankYou extends Component {
 	renderLogo() {
@@ -19,11 +20,16 @@ class RebrandCitiesThankYou extends Component {
 	}
 
 	render() {
-		const { receipt, translate } = this.props;
+		const { analyticsPath, analyticsProps, receipt, translate } = this.props;
 		const displayPrice = get( receipt, 'data.displayPrice' );
 
 		return (
 			<div className="plan-thank-you-card checkout-thank-you__rebrand-cities">
+				<PageViewTracker
+					path={ analyticsPath }
+					title="Checkout Thank You"
+					properties={ analyticsProps }
+				/>
 				<ThankYouCard
 					name={ translate( 'Rebrand Cities package' ) }
 					price={ displayPrice }

--- a/client/my-sites/checkout/checkout-thank-you/rebrand-cities-thank-you.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/rebrand-cities-thank-you.jsx
@@ -20,16 +20,12 @@ class RebrandCitiesThankYou extends Component {
 	}
 
 	render() {
-		const { analyticsPath, analyticsProps, receipt, translate } = this.props;
+		const { analyticsProperties, receipt, translate } = this.props;
 		const displayPrice = get( receipt, 'data.displayPrice' );
 
 		return (
 			<div className="plan-thank-you-card checkout-thank-you__rebrand-cities">
-				<PageViewTracker
-					path={ analyticsPath }
-					title="Checkout Thank You"
-					properties={ analyticsProps }
-				/>
+				<PageViewTracker { ...analyticsProperties } title="Checkout Thank You" />
 				<ThankYouCard
 					name={ translate( 'Rebrand Cities package' ) }
 					price={ displayPrice }

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -609,8 +609,8 @@ export class Checkout extends React.Component {
 
 	render() {
 		const { plan, product, purchaseId, selectedFeature, selectedSiteSlug } = this.props;
-		let analyticsPath;
-		let analyticsProps;
+		let analyticsPath = '';
+		let analyticsProps = {};
 		if ( purchaseId && product ) {
 			analyticsPath = '/checkout/:product/renew/:purchase_id/:site';
 			analyticsProps = { product, purchaseId, site: selectedSiteSlug };
@@ -623,9 +623,11 @@ export class Checkout extends React.Component {
 		} else if ( product && ! purchaseId ) {
 			analyticsPath = '/checkout/:site/:product';
 			analyticsProps = { product, site: selectedSiteSlug };
-		} else {
+		} else if ( selectedSiteSlug ) {
 			analyticsPath = '/checkout/:site';
 			analyticsProps = { site: selectedSiteSlug };
+		} else {
+			analyticsPath = '/checkout/no-site';
 		}
 
 		return (

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -613,7 +613,7 @@ export class Checkout extends React.Component {
 		let analyticsProps = {};
 		if ( purchaseId && product ) {
 			analyticsPath = '/checkout/:product/renew/:purchase_id/:site';
-			analyticsProps = { product, purchaseId, site: selectedSiteSlug };
+			analyticsProps = { product, purchase_id: purchaseId, site: selectedSiteSlug };
 		} else if ( selectedFeature && plan ) {
 			analyticsPath = '/checkout/features/:feature/:site/:plan';
 			analyticsProps = { feature: selectedFeature, plan, site: selectedSiteSlug };

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -70,6 +70,7 @@ import { getProductsList, isProductsListFetching } from 'state/products-list/sel
 import QueryProducts from 'components/data/query-products-list';
 import { isRequestingSitePlans } from 'state/sites/plans/selectors';
 import { isRequestingPlans } from 'state/plans/selectors';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 export class Checkout extends React.Component {
 	static propTypes = {
@@ -607,6 +608,26 @@ export class Checkout extends React.Component {
 	}
 
 	render() {
+		const { plan, product, purchaseId, selectedFeature, selectedSiteSlug } = this.props;
+		let analyticsPath;
+		let analyticsProps;
+		if ( purchaseId && product ) {
+			analyticsPath = '/checkout/:product/renew/:purchase_id/:site';
+			analyticsProps = { product, purchaseId, site: selectedSiteSlug };
+		} else if ( selectedFeature && plan ) {
+			analyticsPath = '/checkout/features/:feature/:site/:plan';
+			analyticsProps = { feature: selectedFeature, plan, site: selectedSiteSlug };
+		} else if ( selectedFeature && ! plan ) {
+			analyticsPath = '/checkout/features/:feature/:site';
+			analyticsProps = { feature: selectedFeature, site: selectedSiteSlug };
+		} else if ( product && ! purchaseId ) {
+			analyticsPath = '/checkout/:site/:product';
+			analyticsProps = { product, site: selectedSiteSlug };
+		} else {
+			analyticsPath = '/checkout/:site';
+			analyticsProps = { site: selectedSiteSlug };
+		}
+
 		return (
 			<div className="main main-column" role="main">
 				<div className="checkout">
@@ -615,6 +636,8 @@ export class Checkout extends React.Component {
 					<QueryProducts />
 					<QueryContactDetailsCache />
 					<QueryStoredCards />
+
+					<PageViewTracker path={ analyticsPath } title="Checkout" properties={ analyticsProps } />
 
 					{ this.content() }
 				</div>

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -80,8 +80,6 @@ export default {
 	},
 
 	sitelessCheckout: function( context, next ) {
-		analytics.pageView.record( '/checkout/no-site', 'Checkout' );
-
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
 

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -29,11 +29,6 @@ const checkoutGSuiteNudgeRoutes = [
 	new Route( '/checkout/:site/with-gsuite/:domain' ),
 ];
 
-const checkoutPendingRoutes = [
-	new Route( '/checkout/thank-you/no-site/pending/:orderId' ),
-	new Route( '/checkout/thank-you/:site/pending/:orderId' ),
-];
-
 const checkoutThankYouRoutes = [
 	new Route( '/checkout/thank-you/no-site/:receipt' ),
 	new Route( '/checkout/thank-you/no-site' ),
@@ -98,11 +93,9 @@ export default {
 	},
 
 	checkoutPending: function( context, next ) {
-		const { routePath, routeParams } = sectionifyWithRoutes( context.path, checkoutPendingRoutes );
 		const orderId = Number( context.params.orderId );
 		const siteSlug = context.params.site;
 
-		analytics.pageView.record( routePath, 'Checkout Pending', routeParams );
 		context.store.dispatch( setSection( { name: 'checkout-thank-you' }, { hasSidebar: false } ) );
 
 		context.primary = <CheckoutPendingComponent orderId={ orderId } siteSlug={ siteSlug } />;

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -23,7 +23,6 @@ import CartData from 'components/data/cart';
 import SecondaryCart from './cart/secondary-cart';
 import CheckoutPendingComponent from './checkout-thank-you/pending';
 import CheckoutThankYouComponent from './checkout-thank-you';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 const checkoutGSuiteNudgeRoutes = [
 	new Route( '/checkout/:site/with-gsuite/:domain/:receipt' ),
@@ -48,7 +47,7 @@ const checkoutThankYouRoutes = [
 
 export default {
 	checkout: function( context, next ) {
-		const { domain, feature, plan, product, purchase } = context.params;
+		const { feature, plan, product } = context.params;
 
 		const state = context.store.getState();
 		const selectedSite = getSelectedSite( state );
@@ -57,36 +56,17 @@ export default {
 			return;
 		}
 
-		let analyticsPath;
-		let analyticsProps;
-		if ( purchase && product ) {
-			analyticsPath = '/checkout/:product/renew/:purchase_id/:site';
-			analyticsProps = { product, purchaseId: purchase, site: domain };
-		} else if ( feature && plan ) {
-			analyticsPath = '/checkout/features/:feature/:site/:plan';
-			analyticsProps = { feature, plan, site: domain };
-		} else if ( feature && ! plan ) {
-			analyticsPath = '/checkout/features/:feature/:site';
-			analyticsProps = { feature, site: domain };
-		} else if ( product && ! purchase ) {
-			analyticsPath = '/checkout/:site/:product';
-			analyticsProps = { product, site: domain };
-		} else {
-			analyticsPath = '/checkout/:site';
-			analyticsProps = { site: domain };
-		}
-
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
 
 		context.primary = (
 			<CheckoutData>
-				<PageViewTracker path={ analyticsPath } title="Checkout" properties={ analyticsProps } />
 				<Checkout
 					product={ product }
 					purchaseId={ context.params.purchaseId }
 					selectedFeature={ feature }
 					couponCode={ context.query.code }
+					plan={ plan }
 				/>
 			</CheckoutData>
 		);

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -87,7 +87,6 @@ export default {
 	checkoutThankYou: function( context, next ) {
 		const receiptId = Number( context.params.receiptId );
 		const gsuiteReceiptId = Number( context.params.gsuiteReceiptId ) || 0;
-		const { feature } = context.params;
 
 		const state = context.store.getState();
 		const selectedSite = getSelectedSite( state );
@@ -97,45 +96,8 @@ export default {
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Thank You' ) ) );
 
-		let analyticsPath = '';
-		let analyticsProps = {};
-		if ( gsuiteReceiptId ) {
-			analyticsPath = '/checkout/thank-you/:site/:receipt_id/with-gsuite/:gsuite_receipt_id';
-			analyticsProps = {
-				gsuiteReceiptId: gsuiteReceiptId,
-				receiptId,
-				site: selectedSite.slug,
-			};
-		} else if ( feature && receiptId ) {
-			analyticsPath = '/checkout/thank-you/features/:feature/:site/:receipt_id';
-			analyticsProps = {
-				feature,
-				receiptId,
-				site: selectedSite.slug,
-			};
-		} else if ( feature && ! receiptId ) {
-			analyticsPath = '/checkout/thank-you/features/:feature/:site';
-			analyticsProps = {
-				feature,
-				site: selectedSite.slug,
-			};
-		} else if ( receiptId && selectedSite ) {
-			analyticsPath = '/checkout/thank-you/:site/:receipt_id';
-			analyticsProps = { receiptId, site: selectedSite.slug };
-		} else if ( receiptId && ! selectedSite ) {
-			analyticsPath = '/checkout/thank-you/no-site/:receipt_id';
-			analyticsProps = { receiptId };
-		} else if ( selectedSite ) {
-			analyticsPath = '/checkout/thank-you/:site';
-			analyticsProps = { site: selectedSite.slug };
-		} else {
-			analyticsPath = '/checkout/thank-you/no-site';
-		}
-
 		context.primary = (
 			<CheckoutThankYouComponent
-				analyticsPath={ analyticsPath }
-				analyticsProps={ analyticsProps }
 				receiptId={ receiptId }
 				gsuiteReceiptId={ gsuiteReceiptId }
 				domainOnlySiteFlow={ isEmpty( context.params.site ) }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -5,13 +5,10 @@
 import i18n from 'i18n-calypso';
 import React from 'react';
 import { isEmpty } from 'lodash';
-import { Route } from 'page';
 
 /**
  * Internal Dependencies
  */
-import analytics from 'lib/analytics';
-import { sectionifyWithRoutes } from 'lib/route';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { setSection } from 'state/ui/actions';
 import { getSiteBySlug } from 'state/sites/selectors';
@@ -23,11 +20,6 @@ import CartData from 'components/data/cart';
 import SecondaryCart from './cart/secondary-cart';
 import CheckoutPendingComponent from './checkout-thank-you/pending';
 import CheckoutThankYouComponent from './checkout-thank-you';
-
-const checkoutGSuiteNudgeRoutes = [
-	new Route( '/checkout/:site/with-gsuite/:domain/:receipt' ),
-	new Route( '/checkout/:site/with-gsuite/:domain' ),
-];
 
 export default {
 	checkout: function( context, next ) {
@@ -156,10 +148,6 @@ export default {
 	},
 
 	gsuiteNudge( context, next ) {
-		const { routePath, routeParams } = sectionifyWithRoutes(
-			context.path,
-			checkoutGSuiteNudgeRoutes
-		);
 		const { domain, site, receiptId } = context.params;
 		context.store.dispatch( setSection( { name: 'gsuite-nudge' }, { hasSidebar: false } ) );
 
@@ -170,8 +158,6 @@ export default {
 		if ( ! selectedSite ) {
 			return null;
 		}
-
-		analytics.pageView.record( routePath, 'G Suite Upsell', routeParams );
 
 		context.primary = (
 			<CartData>

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -21,6 +21,7 @@ import { addItem, removeItem } from 'lib/upgrades/actions';
 import { cartItems } from 'lib/cart-values';
 import { isDotComPlan } from 'lib/products-values';
 import { getABTestVariation } from 'lib/abtest';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 export class GsuiteNudge extends React.Component {
 	static propTypes = {
@@ -62,10 +63,19 @@ export class GsuiteNudge extends React.Component {
 	}
 
 	render() {
-		const { selectedSiteId, siteTitle, translate } = this.props;
+		const { domain, receiptId, selectedSiteId, siteSlug, siteTitle, translate } = this.props;
 
 		return (
 			<Main className="gsuite-nudge">
+				<PageViewTracker
+					path={
+						receiptId
+							? '/checkout/:site/with-gsuite/:domain/:receipt_id'
+							: '/checkout/:site/with-gsuite/:domain'
+					}
+					title="G Suite Upsell"
+					properties={ { site: siteSlug, domain, ...( receiptId && { receiptId } ) } }
+				/>
 				<DocumentHead
 					title={ translate( 'Add G Suite < %(siteTitle)s', {
 						args: { siteTitle },

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -74,7 +74,7 @@ export class GsuiteNudge extends React.Component {
 							: '/checkout/:site/with-gsuite/:domain'
 					}
 					title="G Suite Upsell"
-					properties={ { site: siteSlug, domain, ...( receiptId && { receiptId } ) } }
+					properties={ { site: siteSlug, domain, ...( receiptId && { receipt_id: receiptId } ) } }
 				/>
 				<DocumentHead
 					title={ translate( 'Add G Suite < %(siteTitle)s', {


### PR DESCRIPTION
Fix #23508

Routes to test:

- `/checkout/features/:feature/:site/:plan`
- `/checkout/features/:feature/:site`
- `/checkout/:product/renew/:purchaseId/:site`
- `/checkout/:site/:product`
- `/checkout/:site`
- `/checkout/:site/with-gsuite/:domain/:receiptId`
- `/checkout/:site/with-gsuite/:domain`
- `/checkout/thank-you/no-site/pending/:orderId`
- `/checkout/thank-you/:site/pending/:orderId`
- `/checkout/thank-you/no-site/:receiptId`
- `/checkout/thank-you/no-site`
- `/checkout/thank-you/:site/:receiptId`
- `/checkout/thank-you/:site`
- `/checkout/thank-you/:site/:receiptId/with-gsuite/:gsuiteReceiptId`
- `/checkout/thank-you/:site/:receiptId/with-gsuite`
- `/checkout/thank-you/features/:feature/:site/:receiptId`
- `/checkout/thank-you/features/:feature/:site`

### Notes

This PR removes all `sectionifyWithRoutes` calls.
It would be good as a follow-up to remove it altogether.

## Testing instructions

- Enable Tracks debugging on Calypso by executing this in the developer console:
`localStorage.setItem('debug', 'calypso:analytics:tracks')`.
- Filter the console output with `Recording event "calypso_page_view" with actual props` to make it easier to read.
- Navigate all the routes above and make sure that all of them fire a `calypso_page_view` track event.

see also p5XAZ9-1J0-p2