### PR TITLE
More readable test picker

### DIFF
--- a/client/lib/abtest/test-helper/Test.jsx
+++ b/client/lib/abtest/test-helper/Test.jsx
@@ -23,6 +23,11 @@ export default class extends React.Component {
 									'test-helper__current-variation': variation === currentVariation,
 								} ) }
 							>
+								<input
+									className="test-helper__choice-indicator"
+									type="radio"
+									checked={ variation === currentVariation }
+								/>
 								{ variation }
 							</a>
 						</li>

--- a/client/lib/abtest/test-helper/style.scss
+++ b/client/lib/abtest/test-helper/style.scss
@@ -6,11 +6,11 @@
 	font-weight: normal;
 	cursor: pointer;
 	text-transform: initial;
+}
 
-	&.test-helper__current-variation {
-		text-decoration: underline;
-		color: $orange-jazzy;
-	}
+.environment-badge .environment.is-tests .test-helper__choice-indicator {
+	margin-top: -2px;
+	transform: scale(0.8);
 }
 
 .test-helper__test-header {
@@ -25,11 +25,14 @@
 	overflow-y: scroll;
 	position: absolute;
 	bottom: 100%;
-	right: 0px;
+	right: 0;
 	margin: 0;
 	font-size: 11px;
 }
 
 .test-helper__list {
 	margin: 5px 0 8px 20px;
+	list-style-type: none;
+	padding-left: 0;
 }
+


### PR DESCRIPTION
In our test picker, I always get confused which option is the active one:

<img width="243" alt="zrzut ekranu 2018-04-27 o 17 25 47" src="https://user-images.githubusercontent.com/205419/39370780-128a81e0-4a40-11e8-8bc1-3755fa9200d6.png">

This PR updates the look of AB test picker to make it super clear:

<img width="232" alt="zrzut ekranu 2018-04-27 o 17 24 29" src="https://user-images.githubusercontent.com/205419/39370785-19d4102e-4a40-11e8-9cc3-3151a2eda560.png">
