### PR TITLE
Analytics: hash user data before firing trackers

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -16,7 +16,7 @@ import config from 'config';
 import productsValues from 'lib/products-values';
 import userModule from 'lib/user';
 import { loadScript as loadScriptCallback } from 'lib/load-script';
-import { shouldSkipAds } from 'lib/analytics/utils';
+import { shouldSkipAds, hashPii } from 'lib/analytics/utils';
 import { promisify } from '../../utils';
 
 /**
@@ -644,7 +644,7 @@ function recordProduct( product, orderId ) {
 	}
 
 	const currentUser = user.get();
-	const userId = currentUser ? currentUser.ID : 0;
+	const userId = currentUser ? hashPii( currentUser.ID ) : 0;
 
 	try {
 		// Google Analytics
@@ -791,7 +791,7 @@ function recordOrderInAtlas( cart, orderId ) {
 		product_slugs: cart.products.map( product => product.product_slug ).join( ', ' ),
 		revenue: cart.total_cost,
 		currency_code: cart.currency,
-		user_id: currentUser ? currentUser.ID : 0,
+		user_id: currentUser ? hashPii( currentUser.ID ) : 0,
 		order_id: orderId,
 	};
 
@@ -972,7 +972,7 @@ function floodlightUserParams() {
 
 	const currentUser = user.get();
 	if ( currentUser ) {
-		params.u4 = currentUser.ID.toString();
+		params.u4 = hashPii( currentUser.ID );
 	}
 
 	const anonymousUserId = tracksAnonymousUserId();
@@ -1142,7 +1142,7 @@ function recordInCriteo( eventName, eventProps ) {
 	events.push( { event: 'setSiteType', type: criteoSiteType() } );
 
 	if ( user.get() ) {
-		events.push( { event: 'setEmail', email: [ user.get().email ] } );
+		events.push( { event: 'setEmail', email: [ hashPii( user.get().email ) ] } );
 	}
 
 	const conversionEvent = clone( eventProps );

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -16,7 +16,7 @@ import { assign, isObjectLike, isUndefined, omit, pickBy, startsWith, times } fr
 import config from 'config';
 import emitter from 'lib/mixins/emitter';
 import { ANALYTICS_SUPER_PROPS_UPDATE } from 'state/action-types';
-import { doNotTrack, isPiiUrl, shouldReportOmitBlogId } from 'lib/analytics/utils';
+import { doNotTrack, isPiiUrl, shouldReportOmitBlogId, hashPii } from 'lib/analytics/utils';
 import { loadScript } from 'lib/load-script';
 import {
 	retarget,
@@ -433,11 +433,10 @@ const analytics = {
 			const parameters = {};
 			if ( ! analytics.ga.initialized ) {
 				if ( _user && _user.get() ) {
-					parameters.userId = 'u-' + _user.get().ID;
+					parameters.userId = hashPii( _user.get().ID );
 				}
 
 				window.ga( 'create', config( 'google_analytics_key' ), 'auto', parameters );
-
 				analytics.ga.initialized = true;
 			}
 		},

--- a/client/lib/analytics/utils.js
+++ b/client/lib/analytics/utils.js
@@ -32,7 +32,7 @@ export function doNotTrack() {
 /**
  * Hashes users' Personally Identifiable Information using SHA256
  *
- * @param {String|Number} Data to be hashed
+ * @param {String|Number} data Data to be hashed
  * @returns {String} SHA256 in hex string format
  */
 export function hashPii( data ) {

--- a/client/lib/analytics/utils.js
+++ b/client/lib/analytics/utils.js
@@ -5,6 +5,7 @@
  */
 
 import debugFactory from 'debug';
+import sha256 from 'hash.js/lib/hash/sha/256';
 
 /**
  * Module variables
@@ -26,6 +27,12 @@ export function doNotTrack() {
 	);
 	debug( `Do Not Track: ${ result }` );
 	return result;
+}
+
+export function hashPii( data ) {
+	return sha256()
+		.update( data.toString() )
+		.digest( 'hex' );
 }
 
 // If this list catches things that are not necessarily forbidden we're ok with

--- a/client/lib/analytics/utils.js
+++ b/client/lib/analytics/utils.js
@@ -29,6 +29,12 @@ export function doNotTrack() {
 	return result;
 }
 
+/**
+ * Hashes users' Personally Identifiable Information using SHA256
+ *
+ * @param {String|Number} Data to be hashed
+ * @returns {String} SHA256 in hex string format
+ */
 export function hashPii( data ) {
 	return sha256()
 		.update( data.toString() )


### PR DESCRIPTION
In order to be compliant with GDPR we need to hash our users' PII (personally identifiable information) before attaching it to events fired by the various marketing related scripts.

This PR simply hashes the user ID and email before sending it across.

At the moment we're using SHA256 since it has less known issues compared to MD5, SHA-0 and SHA-1, it's also the one recommended by Nanigans which we'll be using soon and the one recommended by Facebook here https://developers.facebook.com/docs/facebook-pixel/pixel-with-ads/conversion-tracking.

# Testing

Test live with https://calypso.live/?branch=add/gdpr-hash-marketing-user-data&flags=google-analytics,ad-tracking

- Enable logging in the JS console: `localStorage.setItem( 'debug', 'calypso:analytics:*' );`
- Network Tab: filter by `google-analytics.com/r/` you should see a URL with a `uid` parameter. The value of this parameter should be the sha256() of your wpcom user ID. You can check using for example: http://www.xorbin.com/tools/sha256-hash-calculator. Example:

![ga-hash](https://user-images.githubusercontent.com/10284338/39433251-414f9df4-4c8d-11e8-8692-6a62ea961ba5.png)

- If you buy something like an upgrade to a test sites using free credits and filter the network tab by your wpcom user ID sha256() you will see the Floodlight, AdWords and Facebook pixels firing using the hashed data, example:

- **Floodlight:** https://6355556.fls.doubleclick.net/activityi;dc_pre=CK_R7_yc4toCFTIh0wodFQMPQQ;type=wpsal0;cat=wpsale;qty=1;cost=36;u2=WordPress.com%20Personal;u3=GBP;ord=29292384;u4=aaa8042f194d97480cb68b064fcaad6b8e93464c583ea92d1fe37abd519f467c;src=6355556? (note `u4=aaa8042f194d97480cb68b064fcaad6b8e93464c583ea92d1fe37abd519f467c`)

- **AdWords:** https://www.googleadservices.com/pagead/conversion/1067250390/?random=1525099124710&cv=9&fst=1525099124710&num=1&value=36&currency_code=GBP&label=MznpCMGHr2MQ1uXz_AM&guid=ON&resp=GooglemKTybQhCsO&u_h=864&u_w=1536&u_ah=824&u_aw=1536&u_cd=24&u_his=4&u_tz=60&u_java=false&u_nplug=4&u_nmime=5&data=product_slug%3Dpersonal-bundle%3Buser_id%3Daaa8042f194d97480cb68b064fcaad6b8e93464c583ea92d1fe37abd519f467c%3Border_id%3D29292384&sendb=1&frm=0&url=https%3A%2F%2Fcalypso.live%2Fcheckout%2Fmicbosi.wordpress.com%2Fpersonal&ref=https%3A%2F%2Fgithub.com%2FAutomattic%2Fwp-calypso%2Fpull%2F24543&tiba=Checkout%20%E2%80%B9%20MicBosi%20%E2%80%94%20WordPress.com&async=1&rfmt=3&fmt=4 (note the **data** field = `product_slug=personal-bundle;user_id=aaa8042f194d97480cb68b064fcaad6b8e93464c583ea92d1fe37abd519f467c;order_id=29292384`)

- **Facebook:** https://www.facebook.com/tr/?id=823166884443641&ev=Purchase&dl=https%3A%2F%2Fcalypso.live%2Fcheckout%2Fmicbosi.wordpress.com%2Fpersonal&rl=https%3A%2F%2Fgithub.com%2FAutomattic%2Fwp-calypso%2Fpull%2F24543&if=false&ts=1525099124713&cd[currency]=GBP&cd[product_slug]=personal-bundle&cd[value]=36&cd[user_id]=aaa8042f194d97480cb68b064fcaad6b8e93464c583ea92d1fe37abd519f467c&cd[order_id]=29292384&sw=1536&sh=864&v=2.8.14&r=stable&ec=8&o=28&it=1525099051105 (note the `cd[user_id]=aaa8042f194d97480cb68b064fcaad6b8e93464c583ea92d1fe37abd519f467c`)

Note I've updated Atlas and Criteo too even if they are disabled / about to be removed.