### PR TITLE
Tighten line-height on recommended domain names in signup

### DIFF
--- a/client/components/domains/domain-registration-suggestion/style.scss
+++ b/client/components/domains/domain-registration-suggestion/style.scss
@@ -21,6 +21,8 @@
 		order: 0;
 		font-size: 2em;
 		font-weight: 600;
+		line-height: 1.2;
+		margin-bottom: 0.25em;
 		flex-grow: 0;
 	}
 


### PR DESCRIPTION
See also #24546

**Steps to test:**

* Switch to this branch
* Go to http://calypso.localhost:3000/start/
* Go to the Domains step of signup and type in a longish domain name
* Check the recommended domain names for line-height/spacing/margin issues at different screen sizes, particularly when the names span multiple lines.

**Screenshots**

Original

![lineheight](https://user-images.githubusercontent.com/2124984/39378983-e2f3427c-4a27-11e8-8857-9b4ad15f9179.jpg)

This PR

![screen shot 2018-04-27 at 2 22 18 pm](https://user-images.githubusercontent.com/2124984/39379098-42faaee4-4a28-11e8-9c7f-d9fac3f65dcb.jpg)
