### PR TITLE
Add Non-GMB Site Google My Business Stats Page Redirect

### DIFF
--- a/client/my-sites/google-my-business/index.js
+++ b/client/my-sites/google-my-business/index.js
@@ -14,9 +14,22 @@ import { navigation, sites, siteSelection } from 'my-sites/controller';
 import { newAccount, selectBusinessType, selectLocation, stats } from './controller';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getKeyringConnectionsByName } from 'state/sharing/keyring/selectors';
-import { isGoogleMyBusinessLocationConnected, getGoogleMyBusinessLocations } from 'state/selectors';
+import {
+	isGoogleMyBusinessLocationConnected,
+	getGoogleMyBusinessLocations,
+	isSiteGoogleMyBusinessEligible,
+} from 'state/selectors';
 import { requestSiteSettings } from 'state/site-settings/actions';
 import { requestKeyringConnections } from 'state/sharing/keyring/actions';
+
+const loadKeyringAndSettings = ( context, next ) => {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	Promise.all( [
+		context.store.dispatch( requestKeyringConnections() ),
+		context.store.dispatch( requestSiteSettings( siteId ) ),
+	] ).then( next );
+};
 
 export default function( router ) {
 	router( '/google-my-business', siteSelection, sites, navigation, makeLayout );
@@ -56,6 +69,27 @@ export default function( router ) {
 			'/google-my-business/stats/:site',
 			redirectLoggedOut,
 			siteSelection,
+			loadKeyringAndSettings,
+			( context, next ) => {
+				const state = context.store.getState();
+				const siteId = getSelectedSiteId( state );
+				const siteIsGMBEligible = isSiteGoogleMyBusinessEligible( state, siteId );
+				const hasConnectedLocation = isGoogleMyBusinessLocationConnected( state, siteId );
+				const hasLocationsAvailable = getGoogleMyBusinessLocations( state, siteId ).length > 0;
+
+				if ( ! config.isEnabled( 'google-my-business' ) ) {
+					page.redirect( `/google-my-business/select-business-type/${ context.params.site }` );
+					return;
+				}
+
+				if ( hasConnectedLocation ) {
+					next();
+				} else if ( hasLocationsAvailable && siteIsGMBEligible ) {
+					page.redirect( `/google-my-business/select-location/${ context.params.site }` );
+				} else {
+					page.redirect( `/stats/${ context.params.site }` );
+				}
+			},
 			stats,
 			navigation,
 			makeLayout
@@ -71,39 +105,26 @@ export default function( router ) {
 		makeLayout
 	);
 
-	router(
-		'/google-my-business/:site',
-		siteSelection,
-		( context, next ) => {
-			const state = context.store.getState();
-			const siteId = getSelectedSiteId( state );
-			Promise.all( [
-				context.store.dispatch( requestKeyringConnections() ),
-				context.store.dispatch( requestSiteSettings( siteId ) ),
-			] ).then( next );
-		},
-		context => {
-			const state = context.store.getState();
-			const siteId = getSelectedSiteId( state );
-			const hasConnectedLocation = isGoogleMyBusinessLocationConnected( state, siteId );
-			const hasLocationsAvailable = getGoogleMyBusinessLocations( state, siteId ).length > 0;
-			const hasAuthenticated =
-				getKeyringConnectionsByName( state, 'google-my-business' ).length > 0;
+	router( '/google-my-business/:site', siteSelection, loadKeyringAndSettings, context => {
+		const state = context.store.getState();
+		const siteId = getSelectedSiteId( state );
+		const hasConnectedLocation = isGoogleMyBusinessLocationConnected( state, siteId );
+		const hasLocationsAvailable = getGoogleMyBusinessLocations( state, siteId ).length > 0;
+		const hasAuthenticated = getKeyringConnectionsByName( state, 'google-my-business' ).length > 0;
 
-			if ( ! config.isEnabled( 'google-my-business' ) ) {
-				page.redirect( `/google-my-business/select-business-type/${ context.params.site }` );
-				return;
-			}
-
-			if ( hasConnectedLocation ) {
-				page.redirect( `/google-my-business/stats/${ context.params.site }` );
-			} else if ( hasLocationsAvailable ) {
-				page.redirect( `/google-my-business/select-location/${ context.params.site }` );
-			} else if ( hasAuthenticated ) {
-				page.redirect( `/google-my-business/new/${ context.params.site }` );
-			} else {
-				page.redirect( `/google-my-business/select-business-type/${ context.params.site }` );
-			}
+		if ( ! config.isEnabled( 'google-my-business' ) ) {
+			page.redirect( `/google-my-business/select-business-type/${ context.params.site }` );
+			return;
 		}
-	);
+
+		if ( hasConnectedLocation ) {
+			page.redirect( `/google-my-business/stats/${ context.params.site }` );
+		} else if ( hasLocationsAvailable ) {
+			page.redirect( `/google-my-business/select-location/${ context.params.site }` );
+		} else if ( hasAuthenticated ) {
+			page.redirect( `/google-my-business/new/${ context.params.site }` );
+		} else {
+			page.redirect( `/google-my-business/select-business-type/${ context.params.site }` );
+		}
+	} );
 }

--- a/client/state/selectors/is-google-my-business-stats-nudge-visible.js
+++ b/client/state/selectors/is-google-my-business-stats-nudge-visible.js
@@ -1,59 +1,23 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import config from 'config';
-
-/**
  * Internal dependencies
  */
-import createSelector from 'lib/create-selector';
-import { getSiteOption, getSitePlanSlug } from 'state/sites/selectors';
-import { isGoogleMyBusinessLocationConnected } from 'state/selectors';
-import { isRequestingSiteSettings, getSiteSettings } from 'state/site-settings/selectors';
-import { planMatches } from 'lib/plans';
-import { TYPE_BUSINESS, GROUP_WPCOM } from 'lib/plans/constants';
-
-/**
- * Returns true if site has promote goal set
- *
- * @param  {Object}  state  Global state tree
- * @param  {String}  siteId The Site ID
- * @return {Boolean} True if site has "promote" goal
- */
-const siteHasPromoteGoal = createSelector(
-	( state, siteId ) => {
-		const siteGoals = ( getSiteOption( state, siteId, 'site_goals' ) || '' ).split( ',' );
-
-		return siteGoals.indexOf( 'promote' ) !== -1;
-	},
-	( state, siteId ) => [ getSiteOption( state, siteId, 'site_goals' ) ]
-);
-
-/**
- * Returns true if site has business plan
- *
- * @param  {Object}  state  Global state tree
- * @param  {String}  siteId The Site ID
- * @return {Boolean} True if site has business plan
- */
-export const siteHasBusinessPlan = createSelector(
-	( state, siteId ) => {
-		const slug = getSitePlanSlug( state, siteId );
-
-		return planMatches( slug, { group: GROUP_WPCOM, type: TYPE_BUSINESS } );
-	},
-	( state, siteId ) => [ getSitePlanSlug( state, siteId ) ]
-);
+import {
+	isGoogleMyBusinessLocationConnected,
+	isSiteGoogleMyBusinessEligible,
+} from 'state/selectors';
+import {
+	isRequestingSiteSettings,
+	getSiteSettings,
+} from 'state/site-settings/selectors';
 
 /**
  * Returns true if the Google My Business (GMB) nudge should be visible in stats
  *
  * It should be visible if:
- * - site is older than 1 week,
- * - site has a business plan
- * - site has a promote goal
+ * - it meets the Google My Business Site Eligiblility Critera ( see isSiteGoogleMyBusinessEligible ),
+ * - site has NOT been connected to a location
  * @param  {Object}  state  Global state tree
  * @param  {String}  siteId The Site ID
  * @return {Boolean} True if we should show the nudge
@@ -70,10 +34,5 @@ export default function isGoogleMyBusinessStatsNudgeVisible( state, siteId ) {
 		return false;
 	}
 
-	// call-for-testing condition, remove on launch
-	if ( config.isEnabled( 'google-my-business' ) ) {
-		return siteHasBusinessPlan( state, siteId );
-	}
-
-	return siteHasBusinessPlan( state, siteId ) && siteHasPromoteGoal( state, siteId );
+	return isSiteGoogleMyBusinessEligible( state, siteId );
 }

--- a/client/state/selectors/is-site-google-my-business-eligible.js
+++ b/client/state/selectors/is-site-google-my-business-eligible.js
@@ -1,0 +1,69 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import { getSiteOption, getSitePlanSlug } from 'state/sites/selectors';
+import { planMatches } from 'lib/plans';
+import { TYPE_BUSINESS, GROUP_WPCOM } from 'lib/plans/constants';
+
+/**
+ * Returns true if site has promote goal set
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {String}  siteId The Site ID
+ * @return {Boolean} True if site has "promote" goal
+ */
+const siteHasPromoteGoal = createSelector(
+	( state, siteId ) => {
+		const siteGoals = ( getSiteOption( state, siteId, 'site_goals' ) || '' ).split( ',' );
+
+		return siteGoals.indexOf( 'promote' ) !== -1;
+	},
+	( state, siteId ) => [ getSiteOption( state, siteId, 'site_goals' ) ]
+);
+
+/**
+ * Returns true if site has business plan
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {String}  siteId The Site ID
+ * @return {Boolean} True if site has business plan
+ */
+export const siteHasBusinessPlan = createSelector(
+	( state, siteId ) => {
+		const slug = getSitePlanSlug( state, siteId );
+
+		return planMatches( slug, { group: GROUP_WPCOM, type: TYPE_BUSINESS } );
+	},
+	( state, siteId ) => [ getSitePlanSlug( state, siteId ) ]
+);
+
+/**
+ * Returns true if the site is eliglbe to  use Google My Business (GMB)
+ *
+ * It should be visible if:
+ * - site is older than 1 week,
+ * - site has a business plan
+ * - site has a promote goal
+ * @param  {Object}  state  Global state tree
+ * @param  {String}  siteId The Site ID
+ * @return {Boolean} True if we should show the nudge
+ */
+export default function isSiteGoogleMyBusinessEligible( state, siteId ) {
+	// call-for-testing condition, remove on launch
+	if ( config.isEnabled( 'google-my-business' ) ) {
+		return siteHasBusinessPlan( state, siteId );
+	}
+
+	return (
+		siteHasBusinessPlan( state, siteId ) &&
+		siteHasPromoteGoal( state, siteId )
+	);
+}

--- a/client/state/selectors/test/is-site-google-my-business-eligible.js
+++ b/client/state/selectors/test/is-site-google-my-business-eligible.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { siteHasBusinessPlan } from '../is-google-my-business-stats-nudge-visible';
+import { siteHasBusinessPlan } from '../is-site-google-my-business-eligible';
 
 import {
 	PLAN_FREE,


### PR DESCRIPTION
## Specs

If you are at the GMB stats page on an eligible site and then switch sites you will arrive on an empty GMB stats site. This fixes that by not letting non-GMB sites go to that page.

## Testing 

1. Navigate to the stats page on a GMB site
2. Switch sites via the left sidebar
3. Verify you have been brought to the regular stats page