### PR TITLE
Validate we have siteSettings and location is connected

### DIFF
--- a/client/state/selectors/is-google-my-business-stats-nudge-visible.js
+++ b/client/state/selectors/is-google-my-business-stats-nudge-visible.js
@@ -11,6 +11,7 @@ import config from 'config';
 import createSelector from 'lib/create-selector';
 import { getSiteOption, getSitePlanSlug } from 'state/sites/selectors';
 import { isGoogleMyBusinessLocationConnected } from 'state/selectors';
+import { isRequestingSiteSettings, getSiteSettings } from 'state/site-settings/selectors';
 import { planMatches } from 'lib/plans';
 import { TYPE_BUSINESS, GROUP_WPCOM } from 'lib/plans/constants';
 
@@ -58,6 +59,13 @@ export const siteHasBusinessPlan = createSelector(
  * @return {Boolean} True if we should show the nudge
  */
 export default function isGoogleMyBusinessStatsNudgeVisible( state, siteId ) {
+	// We don't want to show the nudge, and then hide it when it's obvious
+	// the site is actually already connected, therefore we must wait for the site
+	// settings to be fetched so we could verify site does not have connection connected
+	if ( getSiteSettings( state, siteId ) === null || isRequestingSiteSettings( state, siteId ) ) {
+		return false;
+	}
+
 	if ( isGoogleMyBusinessLocationConnected( state, siteId ) ) {
 		return false;
 	}


### PR DESCRIPTION
Avoid firing `calypso_google_my_business_stats_nudge_view` for hidden nudges


# Testing:
1. Open stats for a site with GMB, set analytics debugging with `localStorage.setItem('debug', 'calypso:analytics:*');`
2. if nudge not visible, make sure you don't see `calypso_google_my_business_stats_nudge_view`
3.  if nudge visible, make sure you see `calypso_google_my_business_stats_nudge_view`