### PR TITLE
Themes: switch to valid locale in route params 

### DIFF
--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { noop } from 'lodash';
+import { map, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -72,3 +72,9 @@ export function setUpLocale( context, next ) {
 
 	loadSectionCSS( context, next );
 }
+
+// Creates valid locale options for routes containing locale slugs
+// Defining this here so it can be used by both ./index.node.js and ./index.web.js
+// We cannot export it from either of those (to import it from the other) because of
+// the way that `server/bundler/loader` expects only a default export and nothing else.
+export const langRouteParams = `:lang(${ map( config( 'languages' ), 'langSlug' ).join( '|' ) })?`;

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -21,6 +21,7 @@ import WordPressWordmark from 'components/wordpress-wordmark';
 import { addQueryArgs } from 'lib/route';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'state/selectors/get-current-route';
+import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 import { login } from 'lib/paths';
 
 class MasterbarLoggedOut extends PureComponent {
@@ -79,7 +80,7 @@ class MasterbarLoggedOut extends PureComponent {
 	}
 
 	renderSignupItem() {
-		const { currentQuery, currentRoute, sectionName, translate } = this.props;
+		const { currentQuery, currentRoute, sectionName, localeSlug, translate } = this.props;
 
 		// Hide for some sections
 		if ( includes( [ 'signup', 'jetpack-onboarding' ], sectionName ) ) {
@@ -126,6 +127,10 @@ class MasterbarLoggedOut extends PureComponent {
 			signupUrl = '/jetpack/new';
 		} else if ( signupFlow ) {
 			signupUrl += '/' + signupFlow;
+		} else if ( ! signupFlow && localeSlug ) {
+			// if a localeSlug exists in logged-out
+			// attach it to the signup url
+			signupUrl += '/' + localeSlug;
 		}
 
 		return (
@@ -159,4 +164,5 @@ class MasterbarLoggedOut extends PureComponent {
 export default connect( state => ( {
 	currentQuery: getCurrentQueryArguments( state ),
 	currentRoute: getCurrentRoute( state ),
+	localeSlug: getCurrentLocaleSlug( state ),
 } ) )( localize( MasterbarLoggedOut ) );

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -6,7 +6,7 @@
 import page from 'page';
 import { parse } from 'qs';
 import React from 'react';
-import { includes, map } from 'lodash';
+import { includes } from 'lodash';
 import { parse as parseUrl } from 'url';
 
 /**
@@ -37,11 +37,6 @@ const enhanceContextWithLogin = context => {
 		/>
 	);
 };
-
-// Defining this here so it can be used by both ./index.node.js and ./index.web.js
-// We cannot export it from either of those (to import it from the other) because of
-// the way that `server/bundler/loader` expects only a default export and nothing else.
-export const lang = `:lang(${ map( config( 'languages' ), 'langSlug' ).join( '|' ) })?`;
 
 export function login( context, next ) {
 	const { query: { client_id, redirect_to } } = context;

--- a/client/login/index.node.js
+++ b/client/login/index.node.js
@@ -6,13 +6,13 @@
 
 import config from 'config';
 import webRouter from './index.web';
-import { lang } from './controller';
 import { makeLayout, redirectLoggedIn, setUpLocale } from 'controller';
+import { langRouteParams } from 'controller/shared';
 
 export default router => {
 	if ( config.isEnabled( 'login/magic-login' ) ) {
 		// Only do the basics for layout on the server-side
-		router( `/log-in/link/use/${ lang }`, setUpLocale, redirectLoggedIn, makeLayout );
+		router( `/log-in/link/use/${ langRouteParams }`, setUpLocale, redirectLoggedIn, makeLayout );
 	}
 
 	webRouter( router );

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -5,7 +5,6 @@
  */
 import config from 'config';
 import {
-	lang,
 	login,
 	magicLogin,
 	magicLoginUse,
@@ -13,28 +12,35 @@ import {
 	redirectDefaultLocale,
 } from './controller';
 import { makeLayout, redirectLoggedIn, setUpLocale } from 'controller';
+import { langRouteParams } from 'controller/shared';
 
 export default router => {
 	if ( config.isEnabled( 'login/magic-login' ) ) {
 		router(
-			`/log-in/link/use/${ lang }`,
+			`/log-in/link/use/${ langRouteParams }`,
 			setUpLocale,
 			redirectLoggedIn,
 			magicLoginUse,
 			makeLayout
 		);
 
-		router( `/log-in/link/${ lang }`, setUpLocale, redirectLoggedIn, magicLogin, makeLayout );
+		router(
+			`/log-in/link/${ langRouteParams }`,
+			setUpLocale,
+			redirectLoggedIn,
+			magicLogin,
+			makeLayout
+		);
 	}
 
 	if ( config.isEnabled( 'login/wp-login' ) ) {
 		router(
 			[
-				`/log-in/:twoFactorAuthType(authenticator|backup|sms|push)/${ lang }`,
-				`/log-in/:flow(social-connect|private-site)/${ lang }`,
-				`/log-in/:socialService(google)/callback/${ lang }`,
-				`/log-in/:isJetpack(jetpack)/${ lang }`,
-				`/log-in/${ lang }`,
+				`/log-in/:twoFactorAuthType(authenticator|backup|sms|push)/${ langRouteParams }`,
+				`/log-in/:flow(social-connect|private-site)/${ langRouteParams }`,
+				`/log-in/:socialService(google)/callback/${ langRouteParams }`,
+				`/log-in/:isJetpack(jetpack)/${ langRouteParams }`,
+				`/log-in/${ langRouteParams }`,
 			],
 			redirectJetpack,
 			redirectDefaultLocale,

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { compact, forEach, includes, isEmpty, startsWith, endsWith } from 'lodash';
+import { compact, forEach, includes, isEmpty, startsWith } from 'lodash';
 import debugFactory from 'debug';
 import React from 'react';
 
@@ -76,15 +76,6 @@ export function loggedOut( context, next ) {
 	if ( context.isServerSide && ! isEmpty( context.query ) ) {
 		// Don't server-render URLs with query params
 		return next();
-	}
-
-	// Store previous path if it ends with a valid langSlug
-	// in order that we can return from a theme preview
-	if (
-		startsWith( context.pathname, '/themes' ) &&
-		endsWith( context.pathname, `/${ context.lang }` )
-	) {
-		context.store.dispatch( setBackPath( context.pathname ) );
 	}
 
 	const props = getProps( context );

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -171,15 +171,18 @@ export function redirectToThemeDetails( { res, params: { site, theme, section } 
 
 // Set up the locale in case it has ended up in the flow param
 export function setUpLocale( context, next ) {
-	forEach( context.params, value => {
-		const language = getLanguage( value );
-		if ( language ) {
-			context.lang = value;
-			if ( language.rtl ) {
-				context.isRTL = true;
+	// only when the page is rendered server side
+	if ( context.isServerSide ) {
+		forEach( context.params, value => {
+			const language = getLanguage( value );
+			if ( language ) {
+				context.lang = value;
+				if ( language.rtl ) {
+					context.isRTL = true;
+				}
+				return false;
 			}
-			return false;
-		}
-	} );
+		} );
+	}
 	next();
 }

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { compact, forEach, includes, isEmpty, startsWith } from 'lodash';
+import { compact, forEach, includes, isEmpty, startsWith, endsWith } from 'lodash';
 import debugFactory from 'debug';
 import React from 'react';
 
@@ -76,6 +76,15 @@ export function loggedOut( context, next ) {
 	if ( context.isServerSide && ! isEmpty( context.query ) ) {
 		// Don't server-render URLs with query params
 		return next();
+	}
+
+	// Store previous path if it ends with a valid langSlug
+	// in order that we can return from a theme preview
+	if (
+		startsWith( context.pathname, '/themes' ) &&
+		endsWith( context.pathname, `/${ context.lang }` )
+	) {
+		context.store.dispatch( setBackPath( context.pathname ) );
 	}
 
 	const props = getProps( context );

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -161,12 +161,20 @@ export function redirectToThemeDetails( { res, params: { site, theme, section } 
 	res.redirect( '/theme/' + compact( [ theme, redirectedSection, site ] ).join( '/' ) );
 }
 
-// Set up the locale in case it has ended up in the flow param
+/**
+ * Searches for a valid lang param and switches locale
+ *
+ * @param {object} context - route context object
+ * @param {function} next - page.js call to the next registered callback
+ */
 export function setUpLocale( context, next ) {
 	const language = getLanguage( context.params.lang );
 	if ( language && language.langSlug ) {
 		if ( context.isServerSide ) {
-			context.lang = language.langSlug;
+			// Ensure the html lang/dir attribute values are set
+			// prioritize parentLangSlug for locale variants
+			// See: server/render/index.js
+			context.lang = language.parentLangSlug || language.langSlug;
 			if ( language.rtl ) {
 				context.isRTL = true;
 			}

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { compact, forEach, includes, isEmpty, startsWith } from 'lodash';
+import { compact, includes, isEmpty, startsWith } from 'lodash';
 import debugFactory from 'debug';
 import React from 'react';
 
@@ -22,6 +22,7 @@ import { getThemesForQuery } from 'state/themes/selectors';
 import { getAnalyticsData } from './helpers';
 import { getLanguage } from 'lib/i18n-utils';
 import getThemeFilters from 'state/selectors/get-theme-filters';
+import { setLocale } from 'state/ui/language/actions';
 
 const debug = debugFactory( 'calypso:themes' );
 
@@ -162,18 +163,16 @@ export function redirectToThemeDetails( { res, params: { site, theme, section } 
 
 // Set up the locale in case it has ended up in the flow param
 export function setUpLocale( context, next ) {
-	// only when the page is rendered server side
-	if ( context.isServerSide ) {
-		forEach( context.params, value => {
-			const language = getLanguage( value );
-			if ( language ) {
-				context.lang = value;
-				if ( language.rtl ) {
-					context.isRTL = true;
-				}
-				return false;
+	const language = getLanguage( context.params.lang );
+	if ( language && language.langSlug ) {
+		if ( context.isServerSide ) {
+			context.lang = language.langSlug;
+			if ( language.rtl ) {
+				context.isRTL = true;
 			}
-		} );
+		} else {
+			setLocale( language.langSlug );
+		}
 	}
 	next();
 }

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { compact, includes, isEmpty, startsWith } from 'lodash';
+import { compact, forEach, includes, isEmpty, startsWith } from 'lodash';
 import debugFactory from 'debug';
 import React from 'react';
 
@@ -20,6 +20,7 @@ import { DEFAULT_THEME_QUERY } from 'state/themes/constants';
 import { requestThemes, requestThemeFilters, setBackPath } from 'state/themes/actions';
 import { getThemesForQuery } from 'state/themes/selectors';
 import { getAnalyticsData } from './helpers';
+import { getLanguage } from 'lib/i18n-utils';
 import getThemeFilters from 'state/selectors/get-theme-filters';
 
 const debug = debugFactory( 'calypso:themes' );
@@ -41,6 +42,7 @@ function getProps( context ) {
 		analyticsPath,
 		search: context.query.s,
 		pathName: context.pathname,
+		langSlug: context.lang,
 		trackScrollPage: boundTrackScrollPage,
 	};
 }
@@ -156,4 +158,19 @@ export function redirectToThemeDetails( { res, params: { site, theme, section } 
 		redirectedSection = 'setup';
 	}
 	res.redirect( '/theme/' + compact( [ theme, redirectedSection, site ] ).join( '/' ) );
+}
+
+// Set up the locale in case it has ended up in the flow param
+export function setUpLocale( context, next ) {
+	forEach( context.params, value => {
+		const language = getLanguage( value );
+		if ( language ) {
+			context.lang = value;
+			if ( language.rtl ) {
+				context.isRTL = true;
+			}
+			return false;
+		}
+	} );
+	next();
 }

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -13,6 +13,7 @@ import {
 	redirectSearchAndType,
 	redirectFilterAndType,
 	redirectToThemeDetails,
+	setUpLocale,
 } from './controller';
 import { validateFilters, validateVertical } from './validate-filters';
 
@@ -24,10 +25,11 @@ export default function( router ) {
 		} );
 
 		const showcaseRoutes = [
-			'/themes/:tier(free|premium)?',
-			'/themes/:tier(free|premium)?/filter/:filter',
-			'/themes/:vertical?/:tier(free|premium)?',
-			'/themes/:vertical?/:tier(free|premium)?/filter/:filter',
+			'/themes/:lang?',
+			'/themes/:tier(free|premium)?/:lang?',
+			'/themes/:tier(free|premium)?/filter/:filter/:lang?',
+			'/themes/:vertical?/:tier(free|premium)?/:lang?',
+			'/themes/:vertical?/:tier(free|premium)?/filter/:filter/:lang?',
 		];
 		router(
 			showcaseRoutes,
@@ -35,6 +37,7 @@ export default function( router ) {
 			validateVertical,
 			validateFilters,
 			fetchThemeData,
+			setUpLocale,
 			loggedOut,
 			makeLayout
 		);

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -25,11 +25,12 @@ export default function( router ) {
 		} );
 
 		const showcaseRoutes = [
-			'/themes/:lang?',
-			'/themes/:tier(free|premium)?/:lang?',
-			'/themes/:tier(free|premium)?/filter/:filter/:lang?',
-			'/themes/:vertical?/:tier(free|premium)?/:lang?',
-			'/themes/:vertical?/:tier(free|premium)?/filter/:filter/:lang?',
+			// currently we only want to catch redirects to /themes/{langSlug}
+			'/themes/:lang',
+			'/themes/:tier(free|premium)?',
+			'/themes/:tier(free|premium)?/filter/:filter',
+			'/themes/:vertical?/:tier(free|premium)?',
+			'/themes/:vertical?/:tier(free|premium)?/filter/:filter',
 		];
 		router(
 			showcaseRoutes,

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -26,7 +26,7 @@ export default function( router ) {
 
 		const showcaseRoutes = [
 			// currently we only want to catch redirects to /themes/{langSlug}
-			'/themes/:lang',
+			'/themes/:lang?',
 			'/themes/:tier(free|premium)?',
 			'/themes/:tier(free|premium)?/filter/:filter',
 			'/themes/:vertical?/:tier(free|premium)?',
@@ -34,11 +34,11 @@ export default function( router ) {
 		];
 		router(
 			showcaseRoutes,
+			setUpLocale,
 			fetchThemeFilters,
 			validateVertical,
 			validateFilters,
 			fetchThemeData,
-			setUpLocale,
 			loggedOut,
 			makeLayout
 		);

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -15,6 +15,7 @@ import {
 	redirectToThemeDetails,
 	setUpLocale,
 } from './controller';
+import { langRouteParams } from 'controller/shared';
 import { validateFilters, validateVertical } from './validate-filters';
 
 export default function( router ) {
@@ -25,8 +26,7 @@ export default function( router ) {
 		} );
 
 		const showcaseRoutes = [
-			// currently we only want to catch redirects to /themes/{langSlug}
-			'/themes/:lang?',
+			`/themes/${ langRouteParams }`,
 			'/themes/:tier(free|premium)?',
 			'/themes/:tier(free|premium)?/filter/:filter',
 			'/themes/:vertical?/:tier(free|premium)?',

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -8,7 +8,7 @@ import config from 'config';
 import userFactory from 'lib/user';
 import { makeLayout } from 'controller';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
-import { loggedIn, loggedOut, upload, fetchThemeFilters } from './controller';
+import { loggedIn, loggedOut, upload, fetchThemeFilters, setUpLocale } from './controller';
 import { validateFilters, validateVertical } from './validate-filters';
 
 export default function( router ) {
@@ -47,16 +47,17 @@ export default function( router ) {
 			router( '/themes/upload/*', '/themes' );
 
 			const loggedOutRoutes = [
-				'/themes/:tier(free|premium)?',
-				'/themes/:tier(free|premium)?/filter/:filter',
-				'/themes/:vertical?/:tier(free|premium)?',
-				'/themes/:vertical?/:tier(free|premium)?/filter/:filter',
+				'/themes/:tier(free|premium)?/:lang?',
+				'/themes/:tier(free|premium)?/filter/:filter/:lang?',
+				'/themes/:vertical?/:tier(free|premium)?/:lang?',
+				'/themes/:vertical?/:tier(free|premium)?/filter/:filter/:lang?',
 			];
 			router(
 				loggedOutRoutes,
 				fetchThemeFilters,
 				validateVertical,
 				validateFilters,
+				setUpLocale,
 				loggedOut,
 				makeLayout
 			);

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -1,12 +1,6 @@
 /** @format */
 
 /**
- * External dependencies
- */
-
-import page from 'page';
-
-/**
  * Internal dependencies
  */
 
@@ -32,10 +26,6 @@ export default function( router ) {
 				router( '/themes/upload/:site_id?', siteSelection, upload, navigation, makeLayout );
 			}
 
-/*			router( [ '/themes/:lang' ], () => {
-				page.redirect( '/themes' );
-			} );*/
-
 			const loggedInRoutes = [
 				'/themes/:lang',
 				`/themes/:tier(free|premium)?/:site_id(${ siteId })?`,
@@ -45,7 +35,6 @@ export default function( router ) {
 			];
 			router(
 				loggedInRoutes,
-				setUpLocale,
 				fetchThemeFilters,
 				validateVertical,
 				validateFilters,
@@ -60,6 +49,8 @@ export default function( router ) {
 			router( '/themes/upload/*', '/themes' );
 
 			const loggedOutRoutes = [
+				// currently we only want to catch redirects to /themes/{langSlug}
+				'/themes/:lang?',
 				'/themes/:tier(free|premium)?',
 				'/themes/:tier(free|premium)?/filter/:filter',
 				'/themes/:vertical?/:tier(free|premium)?',
@@ -67,6 +58,7 @@ export default function( router ) {
 			];
 			router(
 				loggedOutRoutes,
+				setUpLocale,
 				fetchThemeFilters,
 				validateVertical,
 				validateFilters,

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -1,6 +1,12 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+
+import page from 'page';
+
+/**
  * Internal dependencies
  */
 
@@ -25,7 +31,13 @@ export default function( router ) {
 				router( '/themes/upload', siteSelection, sites, makeLayout );
 				router( '/themes/upload/:site_id?', siteSelection, upload, navigation, makeLayout );
 			}
+
+/*			router( [ '/themes/:lang' ], () => {
+				page.redirect( '/themes' );
+			} );*/
+
 			const loggedInRoutes = [
+				'/themes/:lang',
 				`/themes/:tier(free|premium)?/:site_id(${ siteId })?`,
 				`/themes/:tier(free|premium)?/filter/:filter/:site_id(${ siteId })?`,
 				`/themes/:vertical?/:tier(free|premium)?/:site_id(${ siteId })?`,
@@ -33,6 +45,7 @@ export default function( router ) {
 			];
 			router(
 				loggedInRoutes,
+				setUpLocale,
 				fetchThemeFilters,
 				validateVertical,
 				validateFilters,
@@ -47,17 +60,16 @@ export default function( router ) {
 			router( '/themes/upload/*', '/themes' );
 
 			const loggedOutRoutes = [
-				'/themes/:tier(free|premium)?/:lang?',
-				'/themes/:tier(free|premium)?/filter/:filter/:lang?',
-				'/themes/:vertical?/:tier(free|premium)?/:lang?',
-				'/themes/:vertical?/:tier(free|premium)?/filter/:filter/:lang?',
+				'/themes/:tier(free|premium)?',
+				'/themes/:tier(free|premium)?/filter/:filter',
+				'/themes/:vertical?/:tier(free|premium)?',
+				'/themes/:vertical?/:tier(free|premium)?/filter/:filter',
 			];
 			router(
 				loggedOutRoutes,
 				fetchThemeFilters,
 				validateVertical,
 				validateFilters,
-				setUpLocale,
 				loggedOut,
 				makeLayout
 			);

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -10,6 +10,7 @@ import { makeLayout } from 'controller';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { loggedIn, loggedOut, upload, fetchThemeFilters, setUpLocale } from './controller';
 import { validateFilters, validateVertical } from './validate-filters';
+import { langRouteParams } from 'controller/shared';
 
 export default function( router ) {
 	const user = userFactory();
@@ -27,7 +28,6 @@ export default function( router ) {
 			}
 
 			const loggedInRoutes = [
-				'/themes/:lang',
 				`/themes/:tier(free|premium)?/:site_id(${ siteId })?`,
 				`/themes/:tier(free|premium)?/filter/:filter/:site_id(${ siteId })?`,
 				`/themes/:vertical?/:tier(free|premium)?/:site_id(${ siteId })?`,
@@ -50,7 +50,7 @@ export default function( router ) {
 
 			const loggedOutRoutes = [
 				// currently we only want to catch redirects to /themes/{langSlug}
-				'/themes/:lang?',
+				`/themes/${ langRouteParams }`,
 				'/themes/:tier(free|premium)?',
 				'/themes/:tier(free|premium)?/filter/:filter',
 				'/themes/:vertical?/:tier(free|premium)?',

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -28,6 +28,7 @@ export default function( router ) {
 			}
 
 			const loggedInRoutes = [
+				`/themes/${ langRouteParams }`,
 				`/themes/:tier(free|premium)?/:site_id(${ siteId })?`,
 				`/themes/:tier(free|premium)?/filter/:filter/:site_id(${ siteId })?`,
 				`/themes/:vertical?/:tier(free|premium)?/:site_id(${ siteId })?`,
@@ -35,6 +36,7 @@ export default function( router ) {
 			];
 			router(
 				loggedInRoutes,
+				setUpLocale,
 				fetchThemeFilters,
 				validateVertical,
 				validateFilters,
@@ -49,7 +51,6 @@ export default function( router ) {
 			router( '/themes/upload/*', '/themes' );
 
 			const loggedOutRoutes = [
-				// currently we only want to catch redirects to /themes/{langSlug}
 				`/themes/${ langRouteParams }`,
 				'/themes/:tier(free|premium)?',
 				'/themes/:tier(free|premium)?/filter/:filter',

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -27,6 +27,7 @@ import { getSiteSlug } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import ThemePreview from './theme-preview';
 import config from 'config';
+import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 import getThemeFilterTerms from 'state/selectors/get-theme-filter-terms';
 import getThemeFilterToTermTable from 'state/selectors/get-theme-filter-to-term-table';
 import getThemeShowcaseDescription from 'state/selectors/get-theme-showcase-description';
@@ -119,7 +120,7 @@ class ThemeShowcase extends React.Component {
 	 * @returns {String} Theme showcase url
 	 */
 	constructUrl = sections => {
-		const { vertical, tier, filter, siteSlug, searchString, langSlug } = {
+		const { vertical, tier, filter, siteSlug, searchString, localeSlug } = {
 			...this.props,
 			...sections,
 		};
@@ -127,7 +128,8 @@ class ThemeShowcase extends React.Component {
 		const siteIdSection = siteSlug ? `/${ siteSlug }` : '';
 		const verticalSection = vertical ? `/${ vertical }` : '';
 		const tierSection = tier && tier !== 'all' ? `/${ tier }` : '';
-		const lang = langSlug ? `/${ langSlug }` : '';
+		const lang =
+			localeSlug && localeSlug !== config( 'i18n_default_locale_slug' ) ? `/${ localeSlug }` : '';
 
 		let filterSection = filter ? `/filter/${ filter }` : '';
 		filterSection = filterSection.replace( /\s/g, '+' );
@@ -296,7 +298,7 @@ class ThemeShowcase extends React.Component {
 	}
 }
 
-const mapStateToProps = ( state, { siteId, filter, tier, vertical, langSlug } ) => ( {
+const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
 	currentThemeId: getActiveTheme( state, siteId ),
 	isLoggedIn: !! getCurrentUserId( state ),
 	siteSlug: getSiteSlug( state, siteId ),
@@ -305,7 +307,7 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical, langSlug } ) 
 	subjects: getThemeFilterTerms( state, 'subject' ) || {},
 	filterString: prependThemeFilterKeys( state, filter ),
 	filterToTermTable: getThemeFilterToTermTable( state ),
-	langSlug,
+	localeSlug: getCurrentLocaleSlug( state ),
 } );
 
 const mapDispatchToProps = {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -27,7 +27,6 @@ import { getSiteSlug } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import ThemePreview from './theme-preview';
 import config from 'config';
-import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 import getThemeFilterTerms from 'state/selectors/get-theme-filter-terms';
 import getThemeFilterToTermTable from 'state/selectors/get-theme-filter-to-term-table';
 import getThemeShowcaseDescription from 'state/selectors/get-theme-showcase-description';
@@ -120,7 +119,7 @@ class ThemeShowcase extends React.Component {
 	 * @returns {String} Theme showcase url
 	 */
 	constructUrl = sections => {
-		const { vertical, tier, filter, siteSlug, searchString, localeSlug, isLoggedIn } = {
+		const { vertical, tier, filter, siteSlug, searchString } = {
 			...this.props,
 			...sections,
 		};
@@ -128,16 +127,11 @@ class ThemeShowcase extends React.Component {
 		const siteIdSection = siteSlug ? `/${ siteSlug }` : '';
 		const verticalSection = vertical ? `/${ vertical }` : '';
 		const tierSection = tier && tier !== 'all' ? `/${ tier }` : '';
-/*
-		const lang = ! isLoggedIn && localeSlug && localeSlug !== config( 'i18n_default_locale_slug' )
-			? `/${ localeSlug }`
-			: '';
-*/
 
 		let filterSection = filter ? `/filter/${ filter }` : '';
 		filterSection = filterSection.replace( /\s/g, '+' );
 
-		const url = `/themes${ verticalSection }${ tierSection }${ filterSection }${ siteIdSection }${ lang }`;
+		const url = `/themes${ verticalSection }${ tierSection }${ filterSection }${ siteIdSection }`;
 		return buildUrl( url, searchString );
 	};
 
@@ -310,7 +304,6 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
 	subjects: getThemeFilterTerms( state, 'subject' ) || {},
 	filterString: prependThemeFilterKeys( state, filter ),
 	filterToTermTable: getThemeFilterToTermTable( state ),
-	//localeSlug: getCurrentLocaleSlug( state ),
 } );
 
 const mapDispatchToProps = {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -120,7 +120,7 @@ class ThemeShowcase extends React.Component {
 	 * @returns {String} Theme showcase url
 	 */
 	constructUrl = sections => {
-		const { vertical, tier, filter, siteSlug, searchString, localeSlug } = {
+		const { vertical, tier, filter, siteSlug, searchString, localeSlug, isLoggedIn } = {
 			...this.props,
 			...sections,
 		};
@@ -128,8 +128,11 @@ class ThemeShowcase extends React.Component {
 		const siteIdSection = siteSlug ? `/${ siteSlug }` : '';
 		const verticalSection = vertical ? `/${ vertical }` : '';
 		const tierSection = tier && tier !== 'all' ? `/${ tier }` : '';
-		const lang =
-			localeSlug && localeSlug !== config( 'i18n_default_locale_slug' ) ? `/${ localeSlug }` : '';
+/*
+		const lang = ! isLoggedIn && localeSlug && localeSlug !== config( 'i18n_default_locale_slug' )
+			? `/${ localeSlug }`
+			: '';
+*/
 
 		let filterSection = filter ? `/filter/${ filter }` : '';
 		filterSection = filterSection.replace( /\s/g, '+' );
@@ -307,7 +310,7 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
 	subjects: getThemeFilterTerms( state, 'subject' ) || {},
 	filterString: prependThemeFilterKeys( state, filter ),
 	filterToTermTable: getThemeFilterToTermTable( state ),
-	localeSlug: getCurrentLocaleSlug( state ),
+	//localeSlug: getCurrentLocaleSlug( state ),
 } );
 
 const mapDispatchToProps = {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -119,16 +119,20 @@ class ThemeShowcase extends React.Component {
 	 * @returns {String} Theme showcase url
 	 */
 	constructUrl = sections => {
-		const { vertical, tier, filter, siteSlug, searchString } = { ...this.props, ...sections };
+		const { vertical, tier, filter, siteSlug, searchString, langSlug } = {
+			...this.props,
+			...sections,
+		};
 
 		const siteIdSection = siteSlug ? `/${ siteSlug }` : '';
 		const verticalSection = vertical ? `/${ vertical }` : '';
 		const tierSection = tier && tier !== 'all' ? `/${ tier }` : '';
+		const lang = langSlug ? `/${ langSlug }` : '';
 
 		let filterSection = filter ? `/filter/${ filter }` : '';
 		filterSection = filterSection.replace( /\s/g, '+' );
 
-		const url = `/themes${ verticalSection }${ tierSection }${ filterSection }${ siteIdSection }`;
+		const url = `/themes${ verticalSection }${ tierSection }${ filterSection }${ siteIdSection }${ lang }`;
 		return buildUrl( url, searchString );
 	};
 
@@ -292,7 +296,7 @@ class ThemeShowcase extends React.Component {
 	}
 }
 
-const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
+const mapStateToProps = ( state, { siteId, filter, tier, vertical, langSlug } ) => ( {
 	currentThemeId: getActiveTheme( state, siteId ),
 	isLoggedIn: !! getCurrentUserId( state ),
 	siteSlug: getSiteSlug( state, siteId ),
@@ -301,6 +305,7 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
 	subjects: getThemeFilterTerms( state, 'subject' ) || {},
 	filterString: prependThemeFilterKeys( state, filter ),
 	filterToTermTable: getThemeFilterToTermTable( state ),
+	langSlug,
 } );
 
 const mapDispatchToProps = {

--- a/client/state/ui/language/actions.js
+++ b/client/state/ui/language/actions.js
@@ -21,6 +21,8 @@ import { LOCALE_SET } from 'state/action-types';
  */
 export const setLocale = ( localeSlug, localeVariant = null ) => {
 	switchLocale( localeSlug, localeVariant );
+	// eslint-disable-next-line
+	console.log( 'setLocale', localeSlug );
 	return {
 		type: LOCALE_SET,
 		localeSlug,

--- a/client/state/ui/language/actions.js
+++ b/client/state/ui/language/actions.js
@@ -21,8 +21,6 @@ import { LOCALE_SET } from 'state/action-types';
  */
 export const setLocale = ( localeSlug, localeVariant = null ) => {
 	switchLocale( localeSlug, localeVariant );
-	// eslint-disable-next-line
-	console.log( 'setLocale', localeSlug );
 	return {
 		type: LOCALE_SET,
 		localeSlug,


### PR DESCRIPTION
## Background 

See: `pxLjZ-4wQ-p2`

Currently we link to `/themes` from `es.wordpress.com` (and other locales). The Themes Showcase is in English.

This PR is a MVP that allows us to deliver a localized Themes Showcase page from the logged-out wordpress.com landing page, by handling any valid language slug in the **first parameter**^, for example `/themes/es`. When we detect a valid locale param in the route, we switch to that locale. See `D12715-code` for the corresponding backend changes.

<img width="838" alt="screen shot 2018-05-03 at 6 15 41 pm" src="https://user-images.githubusercontent.com/6458278/39566179-0e39d024-4efe-11e8-9f69-bdd90a8a0e9a.png">

@ockham Anything I'm doing wrong here, or could do better? I was unsure whether I should also write an e2e test. Thanks!

## What this PR does
- Ensures that we catch and switch to the langSlug sub-route when arriving at `/themes/{langSlug}`.
- Adds the locale slug (if valid and available) to the signup url `/start`
- When logged in, `/themes/{langSlug}` will also switch to the locale.

## Extended functionality
To make sure this PR isn't too chunky, another PR #24725 addresses sub routes, for example, `/themes/business/premium/filter/one-column/zh-tw` and we'll switch to that locale.

## Testing

### Logged out
| Url     | Expected language | html["lang"] | html["dir"] |
| --- | --- | --- | --- |
| http://calypso.localhost:3000/themes | English | 'en' | 'ltr' |
| http://calypso.localhost:3000/themes/es | Spanish | 'es' | 'ltr' |
| http://calypso.localhost:3000/themes/de | German | 'de' | 'ltr' |
| http://calypso.localhost:3000/themes/de_formal | Formal German | 'de' | 'ltr' |
| http://calypso.localhost:3000/themes/ar | Arabic | 'ar' | 'rtl' |

If a valid locale is found, we append it to the signup link `=>` http://calypso.localhost:3000/`{lang}`

All hits to current routes should work as normal:
http://calypso.localhost:3000/themes/xys `=>` regular 404 page
http://calypso.localhost:3000/themes/business/free/filter/blog `=>` filtered results
http://calypso.localhost:3000/themes/radcliffe-2 `->` /theme/radcliffe-2


