### PR TITLE
Language Picker: enable display of languages unsupported by Calypso

### DIFF
--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -55,10 +55,21 @@ export class LanguagePicker extends PureComponent {
 	}
 
 	findLanguage( valueKey, value ) {
-		return find( this.props.languages, lang => {
+		const { translate } = this.props;
+		//check if the language provided is supported by Calypso
+		const language = find( this.props.languages, lang => {
 			// The value passed is sometimes string instead of number - need to use ==
 			return lang[ valueKey ] == value; // eslint-disable-line eqeqeq
 		} );
+		//if an unsupported language is provided return it without a display name
+		if ( value && ! language ) {
+			return {
+				langSlug: value,
+				name: translate( 'Unsupported language' ),
+			};
+		}
+		//else return either the supported language or undefined (loading state)
+		return language;
 	}
 
 	selectLanguage = languageSlug => {


### PR DESCRIPTION
## This PR
- adds a fix to the language picker to display languages unsupported by Calypso
- the issue was reported in wp-pbg9X-cDy (internal reference)

## The issue and the fix in images

If a language that is not supported by Calypso is selected in wp-admin on a Jetpack connected site the language picker would always show the loading state. We now display `Unsupported language` in the language picker instead. We keep the user's selection but also offer to change to a supported language via the language.

**Before:**
<img width="878" alt="screen shot 2018-04-30 at 12 56 34" src="https://user-images.githubusercontent.com/1562646/39426305-3c817fec-4c77-11e8-9140-493e6bbacf1a.png">

**After:**
<img width="877" alt="screen shot 2018-04-30 at 12 55 35" src="https://user-images.githubusercontent.com/1562646/39426308-3f0a05ae-4c77-11e8-99db-2b6967828b10.png">

## How to test

- Choose a Jetpack connected site
- Go to wp-admin and change the site language to `English (Australia)`
- Now navigate to `/settings/general/` in Calypso
- You should now see the `after` state as shown in the image above

