### PR TITLE
Reduxify setting the post geolocation

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -171,13 +171,14 @@ function startEditingPostCopy( site, postToCopyId, context ) {
 			 */
 			const metadataWhitelist = [ 'geo_latitude', 'geo_longitude' ];
 
-			// Filter the post metadata to include only the ones we want to copy and add
-			// an `operation` field to the copied values.
+			// Filter the post metadata to include only the ones we want to copy,
+			// use only the `key` and `value` properties (and, most importantly exclude `id`),
+			// and add an `operation` field to the copied values.
 			const copiedMetadata = reduce(
 				postToCopy.metadata,
-				( copiedMeta, meta ) => {
-					if ( includes( metadataWhitelist, meta.key ) ) {
-						copiedMeta.push( { ...meta, operation: 'update' } );
+				( copiedMeta, { key, value } ) => {
+					if ( includes( metadataWhitelist, key ) ) {
+						copiedMeta.push( { key, value, operation: 'update' } );
 					}
 					return copiedMeta;
 				},

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -10,7 +10,7 @@ import i18n from 'i18n-calypso';
 import page from 'page';
 import { stringify } from 'qs';
 import { isWebUri as isValidUrl } from 'valid-url';
-import { map, pick, reduce, startsWith } from 'lodash';
+import { includes, map, pick, reduce, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -137,6 +137,13 @@ function startEditingPostCopy( site, postToCopyId, context ) {
 			postAttributes.title = decodeEntities( postAttributes.title );
 			postAttributes.featured_image = getFeaturedImageId( postToCopy );
 
+			actions.startEditingNew( site, {
+				content: postToCopy.content,
+				title: postToCopy.title,
+				type: postToCopy.type,
+			} );
+			actions.edit( postAttributes );
+
 			/**
 			 * A post attributes whitelist for Redux's `editPost()` action.
 			 *
@@ -147,41 +154,41 @@ function startEditingPostCopy( site, postToCopyId, context ) {
 			 * @see https://github.com/Automattic/wp-calypso/pull/13933
 			 */
 			const reduxPostAttributes = pick( postAttributes, [
+				'excerpt',
 				'featured_image',
 				'format',
 				'terms',
 				'title',
 			] );
 
-			actions.startEditingNew( site, {
-				content: postToCopy.content,
-				title: postToCopy.title,
-				type: postToCopy.type,
-			} );
-			context.store.dispatch( editPost( site.ID, null, reduxPostAttributes ) );
-			actions.edit( postAttributes );
-
 			/**
-			 * A post metadata whitelist for Flux's `updateMetadata()` action.
+			 * A post metadata whitelist for the `updatePostMetadata()` action.
 			 *
-			 * This is needed because blindly passing all post metadata to `updateMetadata()`
+			 * This is needed because blindly passing all post metadata to `editPost()`
 			 * causes unforeseeable issues, such as Publicize not triggering on the copied post.
 			 *
 			 * @see https://github.com/Automattic/wp-calypso/issues/14840
 			 */
 			const metadataWhitelist = [ 'geo_latitude', 'geo_longitude' ];
 
-			// Convert the metadata array into a metadata object, needed because `updateMetadata()` expects an object.
-			const metadata = reduce(
+			// Filter the post metadata to include only the ones we want to copy and add
+			// an `operation` field to the copied values.
+			const copiedMetadata = reduce(
 				postToCopy.metadata,
-				( newMetadata, { key, value } ) => {
-					newMetadata[ key ] = value;
-					return newMetadata;
+				( copiedMeta, meta ) => {
+					if ( includes( metadataWhitelist, meta.key ) ) {
+						copiedMeta.push( { ...meta, operation: 'update' } );
+					}
+					return copiedMeta;
 				},
-				{}
+				[]
 			);
 
-			actions.updateMetadata( pick( metadata, metadataWhitelist ) );
+			if ( copiedMetadata.length > 0 ) {
+				reduxPostAttributes.metadata = copiedMetadata;
+			}
+
+			context.store.dispatch( editPost( site.ID, null, reduxPostAttributes ) );
 		} )
 		.catch( error => {
 			Dispatcher.handleServerAction( {

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -195,10 +195,7 @@ class EditorDrawer extends Component {
 		return (
 			<AccordionSection>
 				<EditorDrawerLabel labelText={ translate( 'Location' ) } />
-				<AsyncLoad
-					require="post-editor/editor-location"
-					coordinates={ PostMetadata.geoCoordinates( this.props.post ) }
-				/>
+				<AsyncLoad require="post-editor/editor-location" />
 			</AccordionSection>
 		);
 	}

--- a/client/post-editor/editor-location/index.jsx
+++ b/client/post-editor/editor-location/index.jsx
@@ -29,6 +29,11 @@ import { getEditedPost } from 'state/posts/selectors';
  */
 const GOOGLE_MAPS_BASE_URL = 'https://maps.google.com/maps/api/staticmap?';
 
+// Convert a float coordinate to formatted string with 7 decimal places.
+// Ensures correct equality comparison with values returned from WP.com API
+// that formats float metadata values exactly this way.
+const toGeoString = coord => String( Number( coord ).toFixed( 7 ) );
+
 class EditorLocation extends React.Component {
 	static displayName = 'EditorLocation';
 
@@ -55,8 +60,8 @@ class EditorLocation extends React.Component {
 		} );
 
 		this.props.updatePostMetadata( this.props.siteId, this.props.postId, {
-			geo_latitude: position.coords.latitude,
-			geo_longitude: position.coords.longitude,
+			geo_latitude: toGeoString( position.coords.latitude ),
+			geo_longitude: toGeoString( position.coords.longitude ),
 		} );
 
 		recordStat( 'location_geolocate_success' );
@@ -100,8 +105,8 @@ class EditorLocation extends React.Component {
 
 	onSearchSelect = result => {
 		this.props.updatePostMetadata( this.props.siteId, this.props.postId, {
-			geo_latitude: result.geometry.location.lat,
-			geo_longitude: result.geometry.location.lng,
+			geo_latitude: toGeoString( result.geometry.location.lat ),
+			geo_longitude: toGeoString( result.geometry.location.lng ),
 		} );
 	};
 

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { isNumber, toArray } from 'lodash';
+import { isNumber, map, toArray } from 'lodash';
 
 /**
  * Internal dependencies
@@ -184,6 +184,40 @@ export function editPost( siteId, postId = null, post ) {
 		post,
 		siteId,
 		postId,
+	};
+}
+
+export function updatePostMetadata( siteId, postId = null, metaKey, metaValue ) {
+	if ( typeof metaKey === 'string' ) {
+		metaKey = { [ metaKey ]: metaValue };
+	}
+
+	return {
+		type: POST_EDIT,
+		siteId,
+		postId,
+		post: {
+			metadata: map( metaKey, ( value, key ) => ( {
+				key,
+				value,
+				operation: 'update',
+			} ) ),
+		},
+	};
+}
+
+export function deletePostMetadata( siteId, postId = null, metaKeys ) {
+	if ( ! Array.isArray( metaKeys ) ) {
+		metaKeys = [ metaKeys ];
+	}
+
+	return {
+		type: POST_EDIT,
+		siteId,
+		postId,
+		post: {
+			metadata: map( metaKeys, key => ( { key, operation: 'delete' } ) ),
+		},
 	};
 }
 

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -47,6 +47,7 @@ import likes from './likes/reducer';
 import revisions from './revisions/reducer';
 import {
 	getSerializedPostsQuery,
+	getUnappliedMetadataEdits,
 	isAuthorEqual,
 	isDiscussionEqual,
 	isTermsEqual,
@@ -433,11 +434,26 @@ export function edits( state = {}, action ) {
 								return isDiscussionEqual( value, post[ key ] );
 							case 'featured_image':
 								return value === getFeaturedImageId( post );
+							case 'metadata':
+								// omit from unappliedPostEdits, metadata edits will be merged
+								return true;
 							case 'terms':
 								return isTermsEqual( value, post[ key ] );
 						}
 						return isEqual( post[ key ], value );
 					} );
+
+					// remove edits that are already applied in the incoming metadata values and
+					// leave only the unapplied ones.
+					if ( postEdits.metadata ) {
+						const unappliedMetadataEdits = getUnappliedMetadataEdits(
+							postEdits.metadata,
+							post.metadata
+						);
+						if ( unappliedMetadataEdits.length > 0 ) {
+							unappliedPostEdits.metadata = unappliedMetadataEdits;
+						}
+					}
 
 					return set( memoState, [ post.site_ID, post.ID ], unappliedPostEdits );
 				},

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -17,7 +17,8 @@ import {
 	getSerializedPostsQueryWithoutPage,
 	isAuthorEqual,
 	isDiscussionEqual,
-	mergePostEdits,
+	areAllMetadataEditsApplied,
+	applyPostEdits,
 	normalizePostForEditing,
 	normalizePostForDisplay,
 } from './utils';
@@ -331,7 +332,7 @@ export const getEditedPost = createSelector(
 			return post;
 		}
 
-		return mergePostEdits( post, edits );
+		return applyPostEdits( post, edits );
 	},
 	state => [ state.posts.queries, state.posts.edits ]
 );
@@ -420,6 +421,9 @@ export const isEditedPostDirty = createSelector(
 					}
 					case 'featured_image': {
 						return value !== getFeaturedImageId( post );
+					}
+					case 'metadata': {
+						return ! areAllMetadataEditsApplied( value, post.metadata );
 					}
 					case 'parent': {
 						return get( post, 'parent.ID', 0 ) !== value;

--- a/client/state/posts/test/actions.js
+++ b/client/state/posts/test/actions.js
@@ -21,6 +21,8 @@ import {
 	deletePost,
 	restorePost,
 	addTermForPost,
+	updatePostMetadata,
+	deletePostMetadata,
 } from '../actions';
 import PostQueryManager from 'lib/query-manager/post';
 import {
@@ -560,7 +562,7 @@ describe( 'actions', () => {
 			};
 		};
 
-		test( 'should dispatch a EDIT_POST event with the new term', () => {
+		test( 'should dispatch a POST_EDIT event with the new term', () => {
 			addTermForPost( 2916284, 'jetpack-portfolio', { ID: 123, name: 'ribs' }, 841 )(
 				spy,
 				getState
@@ -598,6 +600,74 @@ describe( 'actions', () => {
 		test( 'should not dispatch anything if the term is temporary', () => {
 			addTermForPost( 2916284, 'jetpack-portfolio', { id: 'temporary' }, 841 )( spy, getState );
 			expect( spy ).not.to.have.been.called;
+		} );
+	} );
+
+	describe( '#updateMetadata()', () => {
+		const siteId = 1;
+		const postId = 2;
+
+		test( 'should dispatch a post edit with a new metadata value', () => {
+			const action = updatePostMetadata( siteId, postId, 'foo', 'bar' );
+
+			expect( action ).to.eql( {
+				type: 'POST_EDIT',
+				siteId,
+				postId,
+				post: {
+					metadata: [ { key: 'foo', value: 'bar', operation: 'update' } ],
+				},
+			} );
+		} );
+
+		test( 'accepts an object of key value pairs', () => {
+			const action = updatePostMetadata( siteId, postId, {
+				foo: 'bar',
+				baz: 'qux',
+			} );
+
+			expect( action ).to.eql( {
+				type: 'POST_EDIT',
+				siteId,
+				postId,
+				post: {
+					metadata: [
+						{ key: 'foo', value: 'bar', operation: 'update' },
+						{ key: 'baz', value: 'qux', operation: 'update' },
+					],
+				},
+			} );
+		} );
+	} );
+
+	describe( '#deleteMetadata()', () => {
+		const siteId = 1;
+		const postId = 2;
+
+		test( 'should dispatch a post edit with a deleted metadata', () => {
+			const action = deletePostMetadata( siteId, postId, 'foo' );
+
+			expect( action ).to.eql( {
+				type: 'POST_EDIT',
+				siteId,
+				postId,
+				post: {
+					metadata: [ { key: 'foo', operation: 'delete' } ],
+				},
+			} );
+		} );
+
+		test( 'should accept an array of metadata keys to delete', () => {
+			const action = deletePostMetadata( siteId, postId, [ 'foo', 'bar' ] );
+
+			expect( action ).to.eql( {
+				type: 'POST_EDIT',
+				siteId,
+				postId,
+				post: {
+					metadata: [ { key: 'foo', operation: 'delete' }, { key: 'bar', operation: 'delete' } ],
+				},
+			} );
 		} );
 	} );
 } );

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -1277,6 +1277,53 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		test( 'should remove metadata edits after they are saved', () => {
+			const state = edits(
+				deepFreeze( {
+					2916284: {
+						841: {
+							metadata: [
+								{ key: 'tobeupdated', value: 'newvalue', operation: 'update' },
+								{ key: 'tobedeleted', operation: 'delete' },
+								{
+									key: 'notyetupdated',
+									value: 'newvalue',
+									operation: 'update',
+								},
+								{ key: 'notyetdeleted', operation: 'delete' },
+							],
+						},
+					},
+				} ),
+				{
+					type: POSTS_RECEIVE,
+					posts: [
+						{
+							ID: 841,
+							site_ID: 2916284,
+							type: 'post',
+							metadata: [
+								{ key: 'tobeupdated', value: 'newvalue' },
+								{ key: 'notyetupdated', value: 'oldvalue' },
+								{ key: 'notyetdeleted', value: 'value' },
+							],
+						},
+					],
+				}
+			);
+
+			expect( state ).to.eql( {
+				2916284: {
+					841: {
+						metadata: [
+							{ key: 'notyetupdated', value: 'newvalue', operation: 'update' },
+							{ key: 'notyetdeleted', operation: 'delete' },
+						],
+					},
+				},
+			} );
+		} );
+
 		test( "should ignore reset edits action when discarded site doesn't exist", () => {
 			const original = deepFreeze( {} );
 			const state = edits( original, {

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -2278,6 +2278,108 @@ describe( 'selectors', () => {
 			expect( isDirty ).to.be.false;
 		} );
 
+		test( 'should return true if there are unapplied metadata edits', () => {
+			const queries = {
+				2916284: new PostQueryManager( {
+					items: {
+						841: {
+							ID: 841,
+							site_ID: 2916284,
+							metadata: [ { key: 'seo_description', value: 'Hello' } ],
+						},
+					},
+				} ),
+			};
+
+			// check unapplied metadata update
+			const updateEdits = {
+				2916284: {
+					841: {
+						metadata: [
+							{
+								key: 'seo_description',
+								value: 'Hello World',
+								operation: 'update',
+							},
+						],
+					},
+				},
+			};
+
+			expect(
+				isEditedPostDirty(
+					{
+						posts: {
+							queries,
+							edits: updateEdits,
+						},
+					},
+					2916284,
+					841
+				)
+			).to.be.true;
+
+			// check unapplied metadata delete
+			const deleteEdits = {
+				2916284: {
+					841: {
+						metadata: [ { key: 'seo_description', operation: 'delete' } ],
+					},
+				},
+			};
+
+			expect(
+				isEditedPostDirty(
+					{
+						posts: {
+							queries,
+							edits: deleteEdits,
+						},
+					},
+					2916284,
+					841
+				)
+			).to.be.true;
+		} );
+
+		test( 'should return false if all metadata edits are already applied', () => {
+			expect(
+				isEditedPostDirty(
+					{
+						posts: {
+							queries: {
+								2916284: new PostQueryManager( {
+									items: {
+										841: {
+											ID: 841,
+											site_ID: 2916284,
+											metadata: [ { key: 'seo_description', value: 'Hello World' } ],
+										},
+									},
+								} ),
+							},
+							edits: {
+								2916284: {
+									841: {
+										metadata: [
+											{
+												key: 'seo_description',
+												value: 'Hello World',
+												operation: 'update',
+											},
+											{ key: 'geo_latitude', operation: 'delete' },
+										],
+									},
+								},
+							},
+						},
+					},
+					2916284,
+					841
+				)
+			).to.be.false;
+		} );
+
 		test( 'should start returning false after update to original post makes the edits noop', () => {
 			// items key will not change
 			const items = {

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -5,9 +5,11 @@
  */
 
 import {
+	concat,
 	get,
 	isEmpty,
 	isPlainObject,
+	filter,
 	flow,
 	map,
 	mapValues,
@@ -22,6 +24,8 @@ import {
 	every,
 	unset,
 	xor,
+	find,
+	reject,
 } from 'lodash';
 
 /**
@@ -116,17 +120,84 @@ export function getSerializedPostsQueryWithoutPage( query, siteId ) {
 	return getSerializedPostsQuery( omit( query, 'page' ), siteId );
 }
 
+/*
+ * Applies a metadata edit operation (either update or delete) to an existing array of
+ * metadata values.
+ */
+function applyMetadataEdit( metadata, edit ) {
+	switch ( edit.operation ) {
+		case 'update': {
+			// Either update existing key's value or append a new one at the end
+			const { key, value } = edit;
+			if ( find( metadata, { key } ) ) {
+				return map( metadata, m => ( m.key === key ? { key, value } : m ) );
+			}
+			return concat( metadata || [], { key, value } );
+		}
+		case 'delete': {
+			// Remove a value from the metadata array. If the key is not present,
+			// return unmodified original value.
+			const { key } = edit;
+			if ( find( metadata, { key } ) ) {
+				return reject( metadata, { key } );
+			}
+			return metadata;
+		}
+	}
+
+	return metadata;
+}
+
+function applyMetadataEdits( metadata, edits ) {
+	return reduce( edits, applyMetadataEdit, metadata );
+}
+
 /**
- * Merges two post edits objects into one or a post edit into a post object. Essentially
- * performs a deep merge of two objects, except that arrays are treated as atomic values
- * and overwritten rather than merged. That's important especially for term removals.
+ * Merges edits into a post object. Essentially performs a deep merge of two objects,
+ * except that arrays are treated as atomic values and overwritten rather than merged.
+ * That's important especially for term removals.
+ *
+ * @param  {Object} post  Destination post for merge
+ * @param  {Object} edits Objects with edits
+ * @return {Object}       Merged post with applied edits
+ */
+export function applyPostEdits( post, edits ) {
+	return mergeWith( cloneDeep( post ), edits, ( objValue, srcValue, key, obj, src, stack ) => {
+		// Merge metadata specially. Only a `metadata` key at top level gets special treatment,
+		// keys with the same name in nested objects do not.
+		if ( key === 'metadata' && stack.size === 0 ) {
+			return applyMetadataEdits( objValue, srcValue );
+		}
+
+		if ( Array.isArray( srcValue ) ) {
+			return srcValue;
+		}
+	} );
+}
+
+function mergeMetadataEdits( edits, nextEdits ) {
+	// remove existing edits that get updated in `nextEdits`
+	const newEdits = reject( edits, edit => find( nextEdits, { key: edit.key } ) );
+	// append the new edits at the end
+	return concat( newEdits, nextEdits );
+}
+
+/**
+ * Merges two post edits objects into one. Essentially performs a deep merge of two objects,
+ * except that arrays are treated as atomic values and overwritten rather than merged.
+ * That's important especially for term removals.
  *
  * @param  {Object} edits     Destination edits object for merge
  * @param  {Object} nextEdits Edits object to be merged
  * @return {Object}           Merged edits object with changes from both sources
  */
 export function mergePostEdits( edits, nextEdits ) {
-	return mergeWith( cloneDeep( edits ), nextEdits, ( objValue, srcValue ) => {
+	return mergeWith( cloneDeep( edits ), nextEdits, ( objValue, srcValue, key, obj, src, stack ) => {
+		if ( key === 'metadata' && stack.size === 0 ) {
+			// merge metadata specially
+			return mergeMetadataEdits( objValue, srcValue );
+		}
+
 		if ( Array.isArray( srcValue ) ) {
 			return srcValue;
 		}
@@ -307,6 +378,35 @@ export function isDiscussionEqual( localDiscussionEdits, savedDiscussion ) {
  */
 export function isAuthorEqual( localAuthorEdit, savedAuthor ) {
 	return get( localAuthorEdit, 'ID' ) === get( savedAuthor, 'ID' );
+}
+
+function isUnappliedMetadataEdit( edit, savedMetadata ) {
+	const savedRecord = find( savedMetadata, { key: edit.key } );
+
+	// is an update already performed?
+	if ( edit.operation === 'update' ) {
+		return ! savedRecord || savedRecord.value !== edit.value;
+	}
+
+	// is a property already deleted?
+	if ( edit.operation === 'delete' ) {
+		return !! savedRecord;
+	}
+
+	return false;
+}
+
+/*
+ * Returns edits that are not yet applied, i.e.:
+ * - when updating, the property doesn't already have the desired value in `savedMetadata`
+ * - when deleting, the property is still present in `savedMetadata`
+ */
+export function getUnappliedMetadataEdits( edits, savedMetadata ) {
+	return filter( edits, edit => isUnappliedMetadataEdit( edit, savedMetadata ) );
+}
+
+export function areAllMetadataEditsApplied( edits, savedMetadata ) {
+	return every( edits, edit => ! isUnappliedMetadataEdit( edit, savedMetadata ) );
 }
 
 /**


### PR DESCRIPTION
Quite a big PR, the main one in the "Post Metadata R12n" series. Several commits:

**Add Redux logic for editing post metadata**

Add two new actions creators, `updatePostMetadata` and `deletePostMetadata` that produce `POST_EDIT` actions with the appropriate properties. Equivalent to the `updateMetadata` and `deleteMetadata` Flux actions.

The `state.posts.edits` reducer now correctly merges the incoming post updates into the metadata edits, leaving only the unapplied ones.

The `isEditedPostDirty` selector compares the outstanding edits to the original post metadata values and determines if the edits are noops or not, affecting the return values of the selector.

The `getEditedPost` selector merges the original saved post object with the outstanding edits and returns a post object will most recent metadata.

All new Redux logic is covered by unit tests.

**Use Redux to store copied metadata when starting to edit a post copy**

When starting to edit a post copy, we copy some attributes to the Flux store and some to the Redux store, depending on how exactly editing of that particular attribute is implemented at the moment.

This patch moves the copied metadata to Redux. The only metadata we copy right now are the geolocation fields, and these are being moved to Redux in the next patch.

**Reduxify setting the post geolocation**

Use the new Redux metadata logic to edit post geolocation: get data from Redux selectors and do edits with Redux action dispatches.

**Send geolocation updates as formatted strings to ensure correct comparison**

Fixes a bug I found during testing. The float values of geo coordinates should be formatted as strings with 7 decimal digits before sending them as metadata values to REST API. This ensures correct comparison between the values in the edits and the values returned by REST API responses. The responses use the string format described above.

Without this patch, geolocation updates are never marked as "saved", because the values are different.

**How to test:**
On both new and existing posts, test the following:

1. Can you set the geolocation of a post, change it and unset it? Do the geolocation data get correctly saved? After changing the geolocation, does the editor show the post as "dirty"? After save or autosave, is the "dirty" flag reset? Watch for the "Save" button in the masterbar for drafts. For published posts, try to close the editor without saving. Do and don't you get a confirmation dialog for "dirty" and "non-dirty" posts?

2. Can you still edit metadata-powered fields that are not Redux yet? These are "SEO Description" and "Sharing" sections (Publicize). Do these sections still work? Do "SEO Description", "Sharing" and "Location" edits work together well?

3. When editing post copy as a new post, does the geolocation info get properly copied over?
