### PR TITLE
Force refetch of external users

### DIFF
--- a/client/blocks/keyring-connect-button/index.js
+++ b/client/blocks/keyring-connect-button/index.js
@@ -106,7 +106,7 @@ class KeyringConnectButton extends Component {
 			requestExternalAccess( this.props.service.connect_URL, () => {
 				// When the user has finished authorizing the connection
 				// (or otherwise closed the window), force a refresh
-				this.props.requestKeyringConnections();
+				this.props.requestKeyringConnections( true );
 
 				// In the case that a Keyring connection doesn't exist, wait for app
 				// authorization to occur, then display with the available connections

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -872,9 +872,7 @@ Undocumented.prototype.mekeyringConnections = function( forceExternalUsersRefetc
 
 	return this.wpcom.req.get(
 		'/me/keyring-connections',
-		{
-			force_external_users_refetch: forceExternalUsersRefetch,
-		},
+		forceExternalUsersRefetch ? { force_external_users_refetch: forceExternalUsersRefetch } : {},
 		fn
 	);
 };

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -871,10 +871,9 @@ Undocumented.prototype.mekeyringConnections = function( forceExternalUsersRefetc
 	}
 
 	return this.wpcom.req.get(
+		'/me/keyring-connections',
 		{
-			path: '/me/keyring-connections',
-			apiVersion: '1.1',
-			body: { force_external_users_refetch: forceExternalUsersRefetch },
+			force_external_users_refetch: forceExternalUsersRefetch,
 		},
 		fn
 	);

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -861,12 +861,20 @@ Undocumented.prototype.saveSharingButtons = function( siteId, buttons, fn ) {
  * @api public
  * @return {Promise} A Promise to resolve when complete.
  */
-Undocumented.prototype.mekeyringConnections = function( fn ) {
+Undocumented.prototype.mekeyringConnections = function( forceExternalUsersRefetch, fn ) {
 	debug( '/me/keyring-connections query' );
+
+	// set defaults, first argument is actually a callback
+	if ( typeof forceExternalUsersRefetch === 'function' ) {
+		fn = forceExternalUsersRefetch;
+		forceExternalUsersRefetch = false;
+	}
+
 	return this.wpcom.req.get(
 		{
 			path: '/me/keyring-connections',
 			apiVersion: '1.1',
+			body: { force_external_users_refetch: forceExternalUsersRefetch },
 		},
 		fn
 	);

--- a/client/my-sites/google-my-business/select-location/index.js
+++ b/client/my-sites/google-my-business/select-location/index.js
@@ -27,12 +27,14 @@ import { getGoogleMyBusinessLocations } from 'state/selectors';
 import { connectGoogleMyBusinessLocation } from 'state/google-my-business/actions';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import QueryKeyringConnections from 'components/data/query-keyring-connections';
+import { requestKeyringConnections } from 'state/sharing/keyring/actions';
 
 class GoogleMyBusinessSelectLocation extends Component {
 	static propTypes = {
 		connectedLocation: PropTypes.object,
 		locations: PropTypes.arrayOf( PropTypes.object ).isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
+		requestKeyringConnections: PropTypes.func.isRequired,
 		siteSlug: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 	};
@@ -51,6 +53,10 @@ class GoogleMyBusinessSelectLocation extends Component {
 			'calypso_google_my_business_select_location_add_your_business_link_click'
 		);
 	};
+
+	componentDidMount() {
+		this.props.requestKeyringConnections( true );
+	}
 
 	render() {
 		const { locations, siteId, translate } = this.props;
@@ -120,5 +126,6 @@ export default connect(
 	{
 		connectGoogleMyBusinessLocation,
 		recordTracksEvent,
+		requestKeyringConnections,
 	}
 )( localize( GoogleMyBusinessSelectLocation ) );

--- a/client/state/sharing/keyring/actions.js
+++ b/client/state/sharing/keyring/actions.js
@@ -19,7 +19,7 @@ import {
  *
  * @return {Function} Action thunk
  */
-export function requestKeyringConnections( forceExternalUsersRefresh = false ) {
+export function requestKeyringConnections( forceExternalUsersRefetch = false ) {
 	return dispatch => {
 		dispatch( {
 			type: KEYRING_CONNECTIONS_REQUEST,
@@ -27,7 +27,7 @@ export function requestKeyringConnections( forceExternalUsersRefresh = false ) {
 
 		return wpcom
 			.undocumented()
-			.mekeyringConnections( forceExternalUsersRefresh )
+			.mekeyringConnections( forceExternalUsersRefetch )
 			.then( ( { connections } ) => {
 				dispatch( {
 					type: KEYRING_CONNECTIONS_RECEIVE,

--- a/client/state/sharing/keyring/actions.js
+++ b/client/state/sharing/keyring/actions.js
@@ -19,7 +19,7 @@ import {
  *
  * @return {Function} Action thunk
  */
-export function requestKeyringConnections() {
+export function requestKeyringConnections( forceExternalUsersRefresh = false ) {
 	return dispatch => {
 		dispatch( {
 			type: KEYRING_CONNECTIONS_REQUEST,
@@ -27,7 +27,7 @@ export function requestKeyringConnections() {
 
 		return wpcom
 			.undocumented()
-			.mekeyringConnections()
+			.mekeyringConnections( forceExternalUsersRefresh )
 			.then( ( { connections } ) => {
 				dispatch( {
 					type: KEYRING_CONNECTIONS_RECEIVE,


### PR DESCRIPTION
Users may have updated the locations they have after they connected their google account,
so we need to refresh the "external users" on locations page.

Requires server patch code-D12569

# Testing
1. Connect Google account on `/google-my-business/select-business-type` page
2. Close calypso / go to different page
3. Add a location to your google account
4. Return to calypso, see that on `/google-my-business/select-location/` you can see the newly added location