### PR TITLE
Notices: Expose notice props via redux

### DIFF
--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -86,20 +86,16 @@ const NoticesList = createReactClass( {
 		//and from the old component. When all notices are moved to redux store, this component
 		//needs to be updated.
 		noticesList = noticesList.concat(
-			this.props.storeNotices.map( function( notice ) {
+			this.props.storeNotices.map( function( { button, href, noticeId, onClick, ...notice } ) {
 				return (
 					<Notice
-						key={ 'notice-' + notice.noticeId }
-						status={ notice.status }
-						duration={ notice.duration || null }
-						showDismiss={ notice.showDismiss }
+						{ ...notice }
+						key={ `notice-${ noticeId }` }
 						onDismissClick={ this.removeReduxNotice( notice ) }
-						text={ notice.text }
-						icon={ notice.icon }
 					>
-						{ notice.button && (
-							<NoticeAction href={ notice.href } onClick={ notice.onClick }>
-								{ notice.button }
+						{ button && (
+							<NoticeAction href={ href } onClick={ onClick }>
+								{ button }
 							</NoticeAction>
 						) }
 					</Notice>

--- a/client/state/notices/actions.js
+++ b/client/state/notices/actions.js
@@ -20,28 +20,14 @@ export function removeNotice( noticeId ) {
 	};
 }
 
-export function createNotice( status, text, options = {} ) {
-	const showDismiss = typeof options.showDismiss === 'boolean' ? options.showDismiss : true;
-	const notice = {
-		button: options.button,
-		displayOnNextPage: options.displayOnNextPage || false,
-		duration: options.duration,
-		href: options.href,
-		icon: options.icon,
-		isPersistent: options.isPersistent || false,
-		noticeId: options.id || uniqueId(),
-		onClick: options.onClick,
-		showDismiss,
-		status: status,
-		text: text,
-	};
-	if ( showDismiss && typeof options.onDismissClick === 'function' ) {
-		notice.onDismissClick = options.onDismissClick;
-	}
-
+export function createNotice( status, text, { id, ...noticeOptions } = {} ) {
 	return {
 		type: NOTICE_CREATE,
-		notice: notice,
+		notice: Object.assign( { showDismiss: true }, noticeOptions, {
+			noticeId: id || uniqueId(),
+			status,
+			text,
+		} ),
 	};
 }
 

--- a/client/state/notices/test/__snapshots__/actions.js.snap
+++ b/client/state/notices/test/__snapshots__/actions.js.snap
@@ -2,14 +2,7 @@
 
 exports[`actions createNotice() should use default options when none provided 1`] = `
 Object {
-  "button": undefined,
-  "displayOnNextPage": false,
-  "duration": undefined,
-  "href": undefined,
-  "icon": undefined,
-  "isPersistent": false,
   "noticeId": "1",
-  "onClick": undefined,
   "showDismiss": true,
   "status": "is-info",
   "text": "Notice text",
@@ -19,14 +12,7 @@ Object {
 exports[`actions status helpers bound createNotice dispatches expected action 1`] = `
 Object {
   "notice": Object {
-    "button": undefined,
-    "displayOnNextPage": false,
-    "duration": undefined,
-    "href": undefined,
-    "icon": undefined,
-    "isPersistent": false,
     "noticeId": "3",
-    "onClick": undefined,
     "showDismiss": true,
     "status": "is-success",
     "text": "text",
@@ -38,14 +24,7 @@ Object {
 exports[`actions status helpers bound createNotice dispatches expected action 2`] = `
 Object {
   "notice": Object {
-    "button": undefined,
-    "displayOnNextPage": false,
-    "duration": undefined,
-    "href": undefined,
-    "icon": undefined,
-    "isPersistent": false,
     "noticeId": "4",
-    "onClick": undefined,
     "showDismiss": true,
     "status": "is-error",
     "text": "text",
@@ -57,14 +36,7 @@ Object {
 exports[`actions status helpers bound createNotice dispatches expected action 3`] = `
 Object {
   "notice": Object {
-    "button": undefined,
-    "displayOnNextPage": false,
-    "duration": undefined,
-    "href": undefined,
-    "icon": undefined,
-    "isPersistent": false,
     "noticeId": "5",
-    "onClick": undefined,
     "showDismiss": true,
     "status": "is-info",
     "text": "text",
@@ -76,14 +48,7 @@ Object {
 exports[`actions status helpers bound createNotice dispatches expected action 4`] = `
 Object {
   "notice": Object {
-    "button": undefined,
-    "displayOnNextPage": false,
-    "duration": undefined,
-    "href": undefined,
-    "icon": undefined,
-    "isPersistent": false,
     "noticeId": "6",
-    "onClick": undefined,
     "showDismiss": true,
     "status": "is-warning",
     "text": "text",
@@ -95,14 +60,7 @@ Object {
 exports[`actions status helpers bound createNotice dispatches expected action 5`] = `
 Object {
   "notice": Object {
-    "button": undefined,
-    "displayOnNextPage": false,
-    "duration": undefined,
-    "href": undefined,
-    "icon": undefined,
-    "isPersistent": false,
     "noticeId": "7",
-    "onClick": undefined,
     "showDismiss": true,
     "status": "is-plain",
     "text": "text",

--- a/client/state/notices/test/__snapshots__/actions.js.snap
+++ b/client/state/notices/test/__snapshots__/actions.js.snap
@@ -1,0 +1,112 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`actions createNotice() should use default options when none provided 1`] = `
+Object {
+  "button": undefined,
+  "displayOnNextPage": false,
+  "duration": undefined,
+  "href": undefined,
+  "icon": undefined,
+  "isPersistent": false,
+  "noticeId": "1",
+  "onClick": undefined,
+  "showDismiss": true,
+  "status": "is-info",
+  "text": "Notice text",
+}
+`;
+
+exports[`actions status helpers bound createNotice dispatches expected action 1`] = `
+Object {
+  "notice": Object {
+    "button": undefined,
+    "displayOnNextPage": false,
+    "duration": undefined,
+    "href": undefined,
+    "icon": undefined,
+    "isPersistent": false,
+    "noticeId": "3",
+    "onClick": undefined,
+    "showDismiss": true,
+    "status": "is-success",
+    "text": "text",
+  },
+  "type": "NOTICE_CREATE",
+}
+`;
+
+exports[`actions status helpers bound createNotice dispatches expected action 2`] = `
+Object {
+  "notice": Object {
+    "button": undefined,
+    "displayOnNextPage": false,
+    "duration": undefined,
+    "href": undefined,
+    "icon": undefined,
+    "isPersistent": false,
+    "noticeId": "4",
+    "onClick": undefined,
+    "showDismiss": true,
+    "status": "is-error",
+    "text": "text",
+  },
+  "type": "NOTICE_CREATE",
+}
+`;
+
+exports[`actions status helpers bound createNotice dispatches expected action 3`] = `
+Object {
+  "notice": Object {
+    "button": undefined,
+    "displayOnNextPage": false,
+    "duration": undefined,
+    "href": undefined,
+    "icon": undefined,
+    "isPersistent": false,
+    "noticeId": "5",
+    "onClick": undefined,
+    "showDismiss": true,
+    "status": "is-info",
+    "text": "text",
+  },
+  "type": "NOTICE_CREATE",
+}
+`;
+
+exports[`actions status helpers bound createNotice dispatches expected action 4`] = `
+Object {
+  "notice": Object {
+    "button": undefined,
+    "displayOnNextPage": false,
+    "duration": undefined,
+    "href": undefined,
+    "icon": undefined,
+    "isPersistent": false,
+    "noticeId": "6",
+    "onClick": undefined,
+    "showDismiss": true,
+    "status": "is-warning",
+    "text": "text",
+  },
+  "type": "NOTICE_CREATE",
+}
+`;
+
+exports[`actions status helpers bound createNotice dispatches expected action 5`] = `
+Object {
+  "notice": Object {
+    "button": undefined,
+    "displayOnNextPage": false,
+    "duration": undefined,
+    "href": undefined,
+    "icon": undefined,
+    "isPersistent": false,
+    "noticeId": "7",
+    "onClick": undefined,
+    "showDismiss": true,
+    "status": "is-plain",
+    "text": "text",
+  },
+  "type": "NOTICE_CREATE",
+}
+`;

--- a/client/state/notices/test/actions.js
+++ b/client/state/notices/test/actions.js
@@ -1,14 +1,17 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
-import { removeNotice, successNotice, errorNotice } from '../actions';
+import {
+	createNotice,
+	errorNotice,
+	infoNotice,
+	plainNotice,
+	removeNotice,
+	successNotice,
+	warningNotice,
+} from '../actions';
 import { NOTICE_CREATE, NOTICE_REMOVE } from 'state/action-types';
 
 describe( 'actions', () => {
@@ -16,43 +19,90 @@ describe( 'actions', () => {
 		test( 'should return an action object', () => {
 			const action = removeNotice( 123 );
 
-			expect( action ).to.eql( {
+			expect( action ).toEqual( {
 				type: NOTICE_REMOVE,
 				noticeId: 123,
 			} );
 		} );
 	} );
 
-	describe( 'successNotice()', () => {
-		test( 'should return action object with a proper text', () => {
-			const text = 'potato',
-				action = successNotice( text );
+	describe( 'createNotice()', () => {
+		test( 'should use default options when none provided', () => {
+			const action = createNotice( 'is-info', 'Notice text' );
 
-			expect( action.type ).to.eql( NOTICE_CREATE );
-			expect( action.notice ).to.include( {
-				text,
-				status: 'is-success',
+			expect( action ).toMatchObject( {
+				type: NOTICE_CREATE,
+				notice: {
+					noticeId: expect.anything(),
+					showDismiss: true,
+					status: 'is-info',
+					text: 'Notice text',
+				},
+			} );
+			expect( action.notice ).toMatchSnapshot();
+		} );
+
+		test( 'should return action object with a proper text', () => {
+			const text = 'potato';
+			const action = createNotice( 'is-success', text );
+
+			expect( action ).toMatchObject( {
+				type: NOTICE_CREATE,
+				notice: {
+					text,
+					status: 'is-success',
+				},
 			} );
 		} );
 
-		test( 'should use default options when none provided', () => {
-			const action = successNotice( '' );
-
-			expect( action.notice ).to.include( {
-				showDismiss: true,
+		test( 'should correctly pass received options', () => {
+			const id = 'notice-test-id';
+			const action = createNotice( 'is-success', 'Notice test text', {
+				className: 'test-notice-class',
+				duration: 200,
+				icon: 'bug',
+				id,
+				isCompact: true,
+				isLoading: true,
+				showDismiss: false,
+				someFutureNoticeOptionThatIsNotCurrentlyImplemented: 'just works.',
+			} );
+			expect( action ).toEqual( {
+				type: NOTICE_CREATE,
+				notice: {
+					status: 'is-success',
+					text: 'Notice test text',
+					className: 'test-notice-class',
+					duration: 200,
+					icon: 'bug',
+					isCompact: true,
+					isLoading: true,
+					noticeId: id,
+					showDismiss: false,
+					someFutureNoticeOptionThatIsNotCurrentlyImplemented: 'just works.',
+				},
 			} );
 		} );
 	} );
 
-	describe( 'errorNotice()', () => {
-		test( 'should return action object with a proper text', () => {
-			const text = 'potato',
-				action = errorNotice( text );
-
-			expect( action.type ).to.eql( NOTICE_CREATE );
-			expect( action.notice ).to.include( {
-				text,
-				status: 'is-error',
+	describe( 'status helpers', () => {
+		[
+			[ successNotice, 'is-success' ],
+			[ errorNotice, 'is-error' ],
+			[ infoNotice, 'is-info' ],
+			[ warningNotice, 'is-warning' ],
+			[ plainNotice, 'is-plain' ],
+		].forEach( ( [ helper, status ] ) => {
+			test( `${ helper.name } dispatches expected action`, () => {
+				const action = helper( 'text' );
+				expect( action ).toMatchObject( {
+					type: NOTICE_CREATE,
+					notice: {
+						status,
+						text: 'text',
+					},
+				} );
+				expect( action ).toMatchSnapshot();
 			} );
 		} );
 	} );

--- a/client/state/notices/test/reducer.js
+++ b/client/state/notices/test/reducer.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -16,7 +15,7 @@ describe( 'reducer', () => {
 	describe( 'items()', () => {
 		test( 'should default to an empty object', () => {
 			const state = items( undefined, {} );
-			expect( state ).to.eql( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		describe( 'NOTICE_CREATE', () => {
@@ -28,7 +27,7 @@ describe( 'reducer', () => {
 					notice: notice,
 				} );
 
-				expect( state ).to.eql( {
+				expect( state ).toEqual( {
 					1: notice,
 				} );
 			} );
@@ -46,7 +45,7 @@ describe( 'reducer', () => {
 					noticeId: 2,
 				} );
 
-				expect( state ).to.eql( {
+				expect( state ).toEqual( {
 					1: { noticeId: 1 },
 					3: { noticeId: 3 },
 				} );
@@ -62,7 +61,7 @@ describe( 'reducer', () => {
 					noticeId: 2,
 				} );
 
-				expect( state ).to.equal( original );
+				expect( state ).toBe( original );
 			} );
 		} );
 
@@ -75,7 +74,7 @@ describe( 'reducer', () => {
 					type: ROUTE_SET,
 				} );
 
-				expect( state ).to.eql( {} );
+				expect( state ).toEqual( {} );
 			} );
 
 			test( 'should preserve persistent notices on route set', () => {
@@ -87,7 +86,7 @@ describe( 'reducer', () => {
 					type: ROUTE_SET,
 				} );
 
-				expect( state ).to.eql( {
+				expect( state ).toEqual( {
 					2: { noticeId: 2, isPersistent: true },
 				} );
 			} );
@@ -101,7 +100,7 @@ describe( 'reducer', () => {
 					type: ROUTE_SET,
 				} );
 
-				expect( state ).to.eql( {
+				expect( state ).toEqual( {
 					2: { noticeId: 2, displayOnNextPage: false },
 				} );
 			} );


### PR DESCRIPTION
Only a subset of `<Notice />` props are available via [notice actions](https://github.com/Automattic/wp-calypso/blob/638a8a31af8309d46e25ac5860c8c5f98294cc14/client/state/notices/actions.js#L23-L46).

Provide future-proof access to all Notice props via redix actions and the [`GlobalNotice` component](https://github.com/Automattic/wp-calypso/blob/master/client/components/global-notices/index.jsx).

See [failing tests](https://circleci.com/gh/Automattic/wp-calypso/93187) on first branch commit (36acd5a) for example of props that are inaccessible via redux actions.

This also updates `GlobalNotices` to handle all of the props which may now be sent via the action. The redux/GlobalNotices pieces have less awareness of the Notice component props and properties 
through without modification unless necessary.

## Testing
1. Compare with current behavior
1. Current: https:wpcalypso.wordpress.com/?debug
1. Branch: https://calypso.live/?branch=update/global-notices-full-props
1. Try dispatching some actions and ensure that they behave correctly on this branch, with access to 
Notice props that don't work in production. For example, `isLoading` or `isCompact`:
   ```js
   dispatch( { type: 'NOTICE_CREATE', notice: {
   noticeId: 'testing',
   status: 'is-success',
   icon: 'thumbs-up',
   onDismissClick: () => console.log('Dismissed!'),
   showDismiss: true,
   text: 'Demo notice 💥',
   displayOnNextPage: true,
   isLoading: true,
   isCompact: true,
   } } ) 
   ```

`Notice` props for reference:

https://github.com/Automattic/wp-calypso/blob/692f4a15ad116f5850739d436f54118a572fedcd/client/components/notice/index.jsx#L27-L38