### PR TITLE
Store: Fix ESLint errors in `woocommerce/app`

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/index.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/index.js
@@ -1,5 +1,4 @@
 /** @format */
-
 /**
  * External dependencies
  */

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/list.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/list.js
@@ -1,5 +1,4 @@
 /** @format */
-
 /**
  * External dependencies
  */
@@ -29,6 +28,17 @@ const StatsWidgetList = ( {
 		}
 	};
 
+	let viewMarkup;
+	if ( viewLink && fetchedData && Array.isArray( fetchedData ) && fetchedData.length ) {
+		viewMarkup = (
+			<div className="stats-widget__more">
+				<a href={ viewLink } onClick={ onView }>
+					{ viewText }
+				</a>
+			</div>
+		);
+	}
+
 	return (
 		<div className="stats-widget__box-contents stats-type-list">
 			<Module
@@ -47,17 +57,7 @@ const StatsWidgetList = ( {
 				/>
 			</Module>
 
-			{ ( viewLink &&
-				fetchedData &&
-				Array.isArray( fetchedData ) &&
-				fetchedData.length && (
-					<div className="stats-widget__more">
-						<a href={ viewLink } onClick={ onView }>
-							{ viewText }
-						</a>
-					</div>
-				) ) ||
-				null }
+			{ viewMarkup }
 		</div>
 	);
 };

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -152,11 +152,12 @@ class OrderDetailsTable extends Component {
 		if ( isEditing ) {
 			return (
 				<Fragment>
-					<ScreenReaderText>
-						<label htmlFor={ inputId }>
+					<label htmlFor={ inputId }>
+						<ScreenReaderText>
 							{ translate( 'Quantity of %(item)s', { args: { item: item.name } } ) }
-						</label>
-					</ScreenReaderText>
+						</ScreenReaderText>
+					</label>
+
 					<FormTextInput
 						type="number"
 						id={ inputId }

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -155,11 +155,12 @@ class OrderRefundTable extends Component {
 		const inputId = `quantity-${ item.id }`;
 		return (
 			<OrderLineItem key={ item.id } isEditing item={ item } order={ order } site={ site }>
-				<ScreenReaderText>
-					<label htmlFor={ inputId }>
+				<label htmlFor={ inputId }>
+					<ScreenReaderText>
 						{ translate( 'Quantity of %(item)s', { args: { item: item.name } } ) }
-					</label>
-				</ScreenReaderText>
+					</ScreenReaderText>
+				</label>
+
 				<FormTextInput
 					type="number"
 					id={ inputId }
@@ -190,11 +191,11 @@ class OrderRefundTable extends Component {
 					</span>
 				</TableItem>
 				<TableItem colSpan="2" className="order-payment__item-total order-details__item-total">
-					<ScreenReaderText>
-						<label htmlFor={ inputId }>
+					<label htmlFor={ inputId }>
+						<ScreenReaderText>
 							{ translate( 'Value of fee %(item)s', { args: { item: item.name } } ) }
-						</label>
-					</ScreenReaderText>
+						</ScreenReaderText>
+					</label>
 					<PriceInput
 						id={ inputId }
 						currency={ order.currency }

--- a/client/extensions/woocommerce/app/product-categories/form.js
+++ b/client/extensions/woocommerce/app/product-categories/form.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -167,6 +165,7 @@ class ProductCategoryForm extends Component {
 
 	renderImage = () => {
 		const { src, placeholder, isUploading } = this.state;
+		const { translate } = this.props;
 
 		let image = null;
 		if ( src && ! isUploading ) {
@@ -174,14 +173,15 @@ class ProductCategoryForm extends Component {
 				<figure>
 					<ImagePreloader
 						src={ src }
-						placeholder={ ( placeholder && <img src={ placeholder } /> ) || <span /> }
+						alt={ translate( 'Category thumbnail' ) }
+						placeholder={ placeholder ? <img src={ placeholder } alt="" /> : <span /> }
 					/>
 				</figure>
 			);
 		} else if ( isUploading ) {
 			image = (
 				<figure>
-					<img src={ placeholder || null } />
+					<img src={ placeholder || '' } alt="" />
 					<Spinner />
 				</figure>
 			);
@@ -196,6 +196,7 @@ class ProductCategoryForm extends Component {
 			<Button
 				compact
 				onClick={ this.removeImage }
+				aria-label={ translate( 'Remove image' ) }
 				className="product-categories__form-image-remove"
 			>
 				<Gridicon icon="cross" size={ 24 } className="product-categories__form-image-remove-icon" />

--- a/client/extensions/woocommerce/app/products/product-form-images.js
+++ b/client/extensions/woocommerce/app/products/product-form-images.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -117,19 +115,21 @@ class ProductFormImages extends Component {
 		const { placeholder } = image;
 		return (
 			<figure>
-				<img src={ placeholder || <span /> } />
+				<img src={ placeholder || '' } alt="" />
 				<Spinner />
 			</figure>
 		);
 	};
 
-	renderUploaded = image => {
-		const { src, placeholder } = image;
+	renderUploaded = ( { src, placeholder }, thumb ) => {
+		const { translate } = this.props;
+
 		return (
 			<figure>
 				<ImagePreloader
 					src={ src }
-					placeholder={ ( placeholder && <img src={ placeholder } /> ) || <span /> }
+					alt={ thumb ? translate( 'Product thumbnail' ) : translate( 'Featured product image' ) }
+					placeholder={ placeholder ? <img src={ placeholder } alt="" /> : <span /> }
 				/>
 			</figure>
 		);
@@ -137,6 +137,7 @@ class ProductFormImages extends Component {
 
 	renderImage = ( image, thumb = true ) => {
 		const { src } = image;
+		const { translate } = this.props;
 		const id = image.id || image.transientId;
 
 		const removeImage = () => {
@@ -150,10 +151,11 @@ class ProductFormImages extends Component {
 
 		return (
 			<div className={ classes } key={ id }>
-				{ ( src && this.renderUploaded( image ) ) || this.renderPlaceholder( image ) }
+				{ src ? this.renderUploaded( image, thumb ) : this.renderPlaceholder( image ) }
 				<Button
 					onClick={ removeImage }
 					compact
+					aria-label={ translate( 'Remove image' ) }
 					className="products__product-form-images-item-remove"
 				>
 					<Gridicon

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -126,6 +124,7 @@ class ProductFormVariationsRow extends Component {
 
 	renderImage = () => {
 		const { src, placeholder, isUploading } = this.state;
+		const { translate } = this.props;
 
 		let image = null;
 		if ( src && ! isUploading ) {
@@ -133,14 +132,15 @@ class ProductFormVariationsRow extends Component {
 				<figure>
 					<ImagePreloader
 						src={ src }
-						placeholder={ ( placeholder && <img src={ placeholder } /> ) || <span /> }
+						alt={ translate( 'Variation thumbnail' ) }
+						placeholder={ placeholder ? <img src={ placeholder } alt="" /> : <span /> }
 					/>
 				</figure>
 			);
 		} else if ( isUploading ) {
 			image = (
 				<figure>
-					<img src={ placeholder || <span /> } />
+					<img src={ placeholder || '' } alt="" />
 					<Spinner />
 				</figure>
 			);
@@ -155,6 +155,7 @@ class ProductFormVariationsRow extends Component {
 			<Button
 				compact
 				onClick={ this.removeImage }
+				aria-label={ translate( 'Remove image' ) }
 				className="products__product-form-variation-image-remove"
 			>
 				<Gridicon

--- a/client/extensions/woocommerce/app/reviews/review-card.js
+++ b/client/extensions/woocommerce/app/reviews/review-card.js
@@ -1,15 +1,12 @@
+/** @format */
 /**
- * External depedencies
- *
- * @format
+ * External dependencies
  */
-
 import React, { Component } from 'react';
 import Gridicon from 'gridicons';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -54,11 +51,14 @@ class ReviewCard extends Component {
 
 	renderToggle() {
 		const { isExpanded } = this.state;
+		const { translate } = this.props;
 		return (
 			<Button
 				borderless
 				className="reviews__action-collapse"
-				onClick={ isExpanded ? this.toggleExpanded : noop }
+				aria-label={ isExpanded ? translate( 'Collapse review' ) : translate( 'Expand review' ) }
+				aria-expanded={ isExpanded }
+				onClick={ this.toggleExpanded }
 			>
 				<Gridicon icon="chevron-down" />
 			</Button>
@@ -83,10 +83,7 @@ class ReviewCard extends Component {
 	renderPreview() {
 		const { review } = this.props;
 		return (
-			<div
-				className={ classNames( 'reviews__header', 'is-preview' ) }
-				onClick={ this.toggleExpanded }
-			>
+			<div className={ classNames( 'reviews__header', 'is-preview' ) }>
 				<div className="reviews__header-content">
 					<div className="reviews__author-gravatar">
 						<Gravatar object={ review } forType="review" />

--- a/client/extensions/woocommerce/app/reviews/review-replies.js
+++ b/client/extensions/woocommerce/app/reviews/review-replies.js
@@ -1,9 +1,7 @@
+/** @format */
 /**
- * External depedencies
- *
- * @format
+ * External dependencies
  */
-
 import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -45,14 +43,14 @@ class ReviewReplies extends Component {
 		}
 	}
 
-	renderReply = ( replyId, i ) => {
+	renderReply = ( reply, i ) => {
 		const { siteId, review } = this.props;
-		return <ReviewReply siteId={ siteId } key={ i } reviewId={ review.id } replyId={ replyId } />;
+		return <ReviewReply siteId={ siteId } key={ i } reviewId={ review.id } replyId={ reply.id } />;
 	};
 
 	render() {
-		const { siteId, replyIds, review } = this.props;
-		const repliesOutput = ( replyIds.length && replyIds.map( this.renderReply ) ) || null;
+		const { siteId, replies, review } = this.props;
+		const repliesOutput = replies.map( this.renderReply );
 		return (
 			<div className="reviews__replies">
 				{ repliesOutput }
@@ -67,11 +65,10 @@ export default connect(
 	( state, props ) => {
 		const site = getSelectedSiteWithFallback( state );
 		const siteId = site ? site.ID : false;
-		const replies = getReviewReplies( state, props.review.id );
-		const replyIds = ( replies && replies.map( reply => reply.id ) ) || [];
+		const replies = getReviewReplies( state, props.review.id ) || [];
 		return {
 			siteId,
-			replyIds,
+			replies,
 		};
 	},
 	dispatch => bindActionCreators( { fetchReviewReplies }, dispatch )

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -82,10 +82,6 @@
 		display: flex;
 		align-items: center;
 
-		&.is-preview {
-			cursor: pointer;
-		}
-
 		.reviews__action-collapse .gridicon {
 			fill: $gray;
 			transform: rotate( 180deg );
@@ -389,6 +385,11 @@
 		}
 		&.is-visible.has-scrollbar {
 			transform: translate3d( -84px, 0, 0 );
+		}
+
+		.accessible-focus &:focus {
+			border-color: $blue-medium;
+			box-shadow: 0 0 0 2px $blue-light;
 		}
 	}
 }


### PR DESCRIPTION
This fixes the eslint issues in the following files:

- client/extensions/woocommerce/app/dashboard/widgets/stats-widget/index.js (2 err, 0 warn)
- client/extensions/woocommerce/app/dashboard/widgets/stats-widget/list.js (6 err, 0 warn)
- client/extensions/woocommerce/app/order/order-details/table.js (1 err, 0 warn)
- client/extensions/woocommerce/app/order/order-payment/table.js (2 err, 0 warn)
- client/extensions/woocommerce/app/product-categories/form.js (2 err, 0 warn)
- client/extensions/woocommerce/app/products/product-form-images.js (2 err, 0 warn)
- client/extensions/woocommerce/app/products/product-form-variations-row.js (2 err, 0 warn)
- client/extensions/woocommerce/app/reviews/review-card.js (2 err, 0 warn)
- client/extensions/woocommerce/app/reviews/review-replies.js (1 err, 0 warn)

Mostly these are accessibility issues, with some code-style fixes. Each commit message has a short description of what changed.

**To test**

- Click around a store. Specifically, I've touched these pages:
  - Dashboard stats widget
  - Editing order details, quantity label for screen readers
  - Refunding an order, quantity & fee labels for screen readers
  - Image uploader on product category, product featured image, additional product images, and product variation image (this now has alt text and the "X" button has a readable label)
  - Review replies & review card, removed onClick from unfocusable element, add aria tags to the toggle button