### PR TITLE
Store: Fix ESLint issues in `woocommerce/app/settings` & `woocommerce/app/store-stats`

### DIFF
--- a/client/extensions/woocommerce/app/settings/email/mailchimp/getting-started.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/getting-started.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -13,66 +14,70 @@ import Card from 'components/card';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { localize } from 'i18n-calypso';
 
-const GettingStarted = localize( ( { translate, onClick, isPlaceholder, site, redirectToSettings } ) => {
-	const allow = translate( 'Allow customers to subscribe to your Email list' );
-	const send = translate( 'Send abandoned cart emails' );
-	const create = translate( 'Create purchase-based segments for targeted campaigns' );
-	const getStarted = translate( 'Get started with MailChimp' );
-	const list = [ allow, send, create ];
-	const wizardLink = getLink( 'settings/email/:site/wizard', site );
+const GettingStarted = localize(
+	( { translate, onClick, isPlaceholder, site, redirectToSettings } ) => {
+		const allow = translate( 'Allow customers to subscribe to your Email list' );
+		const send = translate( 'Send abandoned cart emails' );
+		const create = translate( 'Create purchase-based segments for targeted campaigns' );
+		const getStarted = translate( 'Get started with MailChimp' );
+		const list = [ allow, send, create ];
+		const wizardLink = getLink( 'settings/email/:site/wizard', site );
 
-	return (
-		<div>
-			<Card className="mailchimp__getting-started-title">
-				<div className="mailchimp__getting-started-title-text">MailChimp</div>
-				<div className="mailchimp__getting-started-subtitle-text">
-					{ translate( 'Allow your customers to subscribe to your MailChimp email list.' ) }
-				</div>
-			</Card>
-			{ ! isPlaceholder && <Card className="mailchimp__getting-started-content">
-				<span>
-					<img
-						src={ '/calypso/images/illustrations/illustration-layout.svg' }
-						width={ 220 }
-						className="mailchimp__getting-started-illustration"
-					/>
-				</span>
-				<span>
-					<h3 className="mailchimp__getting-started-list-header">
-						{ translate( 'Connect with your customers through MailChimp' ) }
-					</h3>
-					<ul className="mailchimp__getting-started-list">
-						{ list.map( ( item, key ) =>
-							<li key={ key }>
-								<Gridicon icon="checkmark" size={ 18 } />
-								{ item }
-							</li>
-						) }
-					</ul>
-					{ ! redirectToSettings && (
-						<Button className="mailchimp__getting-started-button" onClick={ onClick }>
-							{ getStarted }
-						</Button>
-					) }
-					{ redirectToSettings && (
-						<Button className="mailchimp__getting-started-button" href={ wizardLink }>
-							{ getStarted }
-						</Button>
-					) }
-				</span>
-			</Card> }
-			{ isPlaceholder &&
-				<Card
-					className="mailchimp__getting-started-loading-placeholder"
-				>
-					<p />
-					<p />
-					<p />
-					<p />
-				</Card> }
-		</div>
-	);
-} );
+		return (
+			<div>
+				<Card className="mailchimp__getting-started-title">
+					<div className="mailchimp__getting-started-title-text">MailChimp</div>
+					<div className="mailchimp__getting-started-subtitle-text">
+						{ translate( 'Allow your customers to subscribe to your MailChimp email list.' ) }
+					</div>
+				</Card>
+				{ ! isPlaceholder && (
+					<Card className="mailchimp__getting-started-content">
+						<span>
+							<img
+								src={ '/calypso/images/illustrations/illustration-layout.svg' }
+								width={ 220 }
+								alt=""
+								className="mailchimp__getting-started-illustration"
+							/>
+						</span>
+						<span>
+							<h3 className="mailchimp__getting-started-list-header">
+								{ translate( 'Connect with your customers through MailChimp' ) }
+							</h3>
+							<ul className="mailchimp__getting-started-list">
+								{ list.map( ( item, key ) => (
+									<li key={ key }>
+										<Gridicon icon="checkmark" size={ 18 } />
+										{ item }
+									</li>
+								) ) }
+							</ul>
+							{ ! redirectToSettings && (
+								<Button className="mailchimp__getting-started-button" onClick={ onClick }>
+									{ getStarted }
+								</Button>
+							) }
+							{ redirectToSettings && (
+								<Button className="mailchimp__getting-started-button" href={ wizardLink }>
+									{ getStarted }
+								</Button>
+							) }
+						</span>
+					</Card>
+				) }
+				{ isPlaceholder && (
+					<Card className="mailchimp__getting-started-loading-placeholder">
+						<p />
+						<p />
+						<p />
+						<p />
+					</Card>
+				) }
+			</div>
+		);
+	}
+);
 
 GettingStarted.propTypes = {
 	onClick: PropTypes.func.isRequired,

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/sync_tab.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/sync_tab.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -9,6 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import Notice from 'components/notice';
 import TooltipComponent from 'components/tooltip';
 
@@ -16,31 +18,32 @@ class Tooltip extends React.Component {
 	constructor( props ) {
 		super( props );
 		this.state = { show: false };
+		this.tooltipRef = React.createRef();
 	}
 
-	open = ( e ) => {
+	open = e => {
 		const isTruncated = e.target.offsetWidth < e.target.scrollWidth;
 		this.setState( { show: isTruncated } );
-	}
+	};
 
 	close = () => {
 		this.setState( { show: false } );
-	}
+	};
 
 	render() {
 		return (
 			<div
 				className="mailchimp__sync-notice-list"
-				ref="tooltip-reference"
 				onMouseEnter={ this.open }
 				onMouseLeave={ this.close }
+				ref={ this.tooltipRef }
 			>
 				{ this.props.children }
 				<TooltipComponent
 					isVisible={ this.state.show }
 					onClose={ this.close }
 					position={ 'top' }
-					context={ this.refs && this.refs[ 'tooltip-reference' ] }
+					context={ this.tooltipRef.current }
 				>
 					<div>{ this.props.listName }</div>
 				</TooltipComponent>
@@ -50,12 +53,18 @@ class Tooltip extends React.Component {
 }
 
 const SyncTab = localize( ( { siteId, translate, syncState, resync, isRequesting } ) => {
-	const { account_name, store_syncing, product_count, mailchimp_total_products,
-		mailchimp_total_orders, order_count } = syncState;
-	const hasProductInfo = ( undefined !== product_count ) && ( undefined !== mailchimp_total_products );
-	const products = hasProductInfo ? ( mailchimp_total_products + '/' + product_count ) : '';
-	const hasOrdersInfo = ( undefined !== order_count ) && ( undefined !== mailchimp_total_orders );
-	const orders = hasOrdersInfo ? ( mailchimp_total_orders + '/' + order_count ) : '';
+	const {
+		account_name,
+		store_syncing,
+		product_count,
+		mailchimp_total_products,
+		mailchimp_total_orders,
+		order_count,
+	} = syncState;
+	const hasProductInfo = undefined !== product_count && undefined !== mailchimp_total_products;
+	const products = hasProductInfo ? mailchimp_total_products + '/' + product_count : '';
+	const hasOrdersInfo = undefined !== order_count && undefined !== mailchimp_total_orders;
+	const orders = hasOrdersInfo ? mailchimp_total_orders + '/' + order_count : '';
 
 	const synced = () => (
 		<Notice
@@ -71,7 +80,8 @@ const SyncTab = localize( ( { siteId, translate, syncState, resync, isRequesting
 						tooltip: <Tooltip listName={ syncState.mailchimp_list_name } />,
 					},
 					args: { mailingListname: syncState.mailchimp_list_name },
-				} ) }
+				}
+			) }
 		/>
 	);
 	const syncing = () => (
@@ -89,16 +99,13 @@ const SyncTab = localize( ( { siteId, translate, syncState, resync, isRequesting
 						tooltip: <Tooltip listName={ syncState.mailchimp_list_name } />,
 					},
 					args: { mailingListname: syncState.mailchimp_list_name },
-				} ) }
+				}
+			) }
 		/>
 	);
 
 	const loadingSyncStatus = () => (
-		<Notice
-			isCompact
-			showDismiss={ false }
-			text={ translate( 'Loading sync status.' ) }
-		/>
+		<Notice isCompact showDismiss={ false } text={ translate( 'Loading sync status.' ) } />
 	);
 
 	const onResyncClick = () => {
@@ -115,21 +122,24 @@ const SyncTab = localize( ( { siteId, translate, syncState, resync, isRequesting
 	return (
 		<div>
 			<div className="mailchimp__account-info-name">
-				{ translate( '{{span_info}}MailChimp account:{{/span_info}} {{span}}%(account_name)s{{/span}}', {
-					components: {
-						span_info: <span className="mailchimp__account-info" />,
-						span: <span />,
-					},
-					args: {
-						account_name,
-					},
-				} ) }
+				{ translate(
+					'{{span_info}}MailChimp account:{{/span_info}} {{span}}%(account_name)s{{/span}}',
+					{
+						components: {
+							span_info: <span className="mailchimp__account-info" />,
+							span: <span />,
+						},
+						args: {
+							account_name,
+						},
+					}
+				) }
 			</div>
 			<span className="mailchimp__sync-status">
 				{ notice }
-				<a className="mailchimp__resync-link" onClick={ onResyncClick }>
+				<Button borderless className="mailchimp__resync-link" onClick={ onResyncClick }>
 					{ translate( 'Resync', { comment: 'to synchronize again' } ) }
-				</a>
+				</Button>
 			</span>
 			<div className="mailchimp__account-data">
 				{ translate( '{{span_info}}Products:{{/span_info}} {{span}}%(products)s{{/span}}', {

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-bacs.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-bacs.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';

--- a/client/extensions/woocommerce/app/settings/payments/stripe/payment-method-stripe-connect-account.js
+++ b/client/extensions/woocommerce/app/settings/payments/stripe/payment-method-stripe-connect-account.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { isEmpty } from 'lodash';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
@@ -12,6 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import Image from 'components/image';
 import resizeImageUrl from 'lib/resize-image-url';
 
@@ -94,9 +93,13 @@ class StripeConnectAccount extends Component {
 			);
 		} else {
 			deauthorize = (
-				<a href="#" className="stripe__connect-account-disconnect" onClick={ this.onDeauthorize }>
+				<Button
+					borderless
+					className="stripe__connect-account-disconnect"
+					onClick={ this.onDeauthorize }
+				>
 					{ translate( 'Disconnect' ) }
-				</a>
+				</Button>
 			);
 		}
 

--- a/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
@@ -60,6 +60,8 @@
 
 			.stripe__connect-account-disconnect {
 				font-size: 12px;
+				padding-top: 3px;
+				padding-bottom: 0;
 			}
 		}
 	}

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-countries.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-countries.js
@@ -1,15 +1,13 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { startsWith } from 'lodash';
+import { startsWith, uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
@@ -56,27 +54,33 @@ const ShippingZoneLocationDialogCountries = ( { continentCountries, translate, a
 			? 'shipping-zone__location-dialog-list-item is-disabled'
 			: 'shipping-zone__location-dialog-list-item';
 
+		const inputId = uniqueId( 'location-' );
+
 		return (
-			<li key={ index } className={ listItemClass } onClick={ onToggle }>
-				{ isCountry ? (
-					<FormCheckbox
-						readOnly
-						className={ checkboxClass }
-						checked={ uiSelected }
-						disabled={ disabled }
-					/>
-				) : (
-					<BulkSelect
-						totalElements={ location.countryCount }
-						selectedElements={ location.selectedCountryCount }
-						readOnly
-						className={ checkboxClass }
-						disabled={ disabled }
-					/>
-				) }
-				{ isCountry ? <LocationFlag code={ code } /> : null }
-				<span>{ decodeEntities( name ) }</span>
-				{ disabled && <small>{ translate( '(An existing zone covers this location)' ) }</small> }
+			<li key={ index } className={ listItemClass }>
+				<label htmlFor={ inputId }>
+					{ isCountry ? (
+						<FormCheckbox
+							id={ inputId }
+							onChange={ onToggle }
+							className={ checkboxClass }
+							checked={ uiSelected }
+							disabled={ disabled }
+						/>
+					) : (
+						<BulkSelect
+							id={ inputId }
+							totalElements={ location.countryCount }
+							selectedElements={ location.selectedCountryCount }
+							onToggle={ onToggle }
+							className={ checkboxClass }
+							disabled={ disabled }
+						/>
+					) }
+					{ isCountry ? <LocationFlag code={ code } /> : null }
+					<span>{ decodeEntities( name ) }</span>
+					{ disabled && <small>{ translate( '(An existing zone covers this location)' ) }</small> }
+				</label>
 			</li>
 		);
 	};

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-settings.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-settings.js
@@ -1,9 +1,4 @@
-/**
- * /* eslint wpcalypso/i18n-ellipsis: 0
- *
- * @format
- */
-
+/** @format */
 /**
  * External dependencies
  */
@@ -19,6 +14,7 @@ import FilteredList from 'woocommerce/components/filtered-list';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
+import FormLegend from 'components/forms/form-legend';
 import FormRadio from 'components/forms/form-radio';
 import FormTextInput from 'components/forms/form-text-input';
 import { bindActionCreatorsWithSiteId } from 'woocommerce/lib/redux-utils';
@@ -77,27 +73,42 @@ const ShippingZoneLocationDialogSettings = ( {
 		}
 
 		const radios = [
-			<div key={ 1 } onClick={ onPostcodeSelect }>
-				<FormRadio onChange={ onPostcodeSelect } checked={ filteredByPostcode } />
+			<label key={ 1 } htmlFor="include-postcodes">
+				<FormRadio
+					id="include-postcodes"
+					name="include"
+					onChange={ onPostcodeSelect }
+					checked={ filteredByPostcode }
+				/>
 				{ translate( 'Include specific postcodes in the zone' ) }
-			</div>,
+			</label>,
 		];
 
 		if ( ! countryOwner ) {
 			radios.unshift(
-				<div key={ 0 } onClick={ onWholeCountrySelect }>
-					<FormRadio onChange={ onWholeCountrySelect } checked={ unfiltered } />
+				<label key={ 0 } htmlFor="include-all">
+					<FormRadio
+						id="include-all"
+						name="include"
+						onChange={ onWholeCountrySelect }
+						checked={ unfiltered }
+					/>
 					{ translate( 'Include entire country in the zone' ) }
-				</div>
+				</label>
 			);
 		}
 
 		if ( canFilterByState ) {
 			radios.push(
-				<div key={ 2 } onClick={ onStateSelect }>
-					<FormRadio onChange={ onStateSelect } checked={ filteredByState } />
+				<label key={ 2 } htmlFor="include-states">
+					<FormRadio
+						id="include-states"
+						name="include"
+						onChange={ onStateSelect }
+						checked={ filteredByState }
+					/>
 					{ translate( 'Include specific states in the zone' ) }
-				</div>
+				</label>
 			);
 		}
 
@@ -115,15 +126,20 @@ const ShippingZoneLocationDialogSettings = ( {
 			actions.toggleStateSelected( code, ! selected );
 		};
 
+		const inputId = `state-${ index }`;
+
 		return (
-			<li key={ index } className="shipping-zone__location-dialog-list-item" onClick={ onToggle }>
-				<FormCheckbox
-					onChange={ onToggle }
-					className="shipping-zone__location-dialog-list-item-checkbox"
-					checked={ selected }
-					disabled={ disabled }
-				/>
-				{ decodeEntities( name ) }
+			<li key={ index } className="shipping-zone__location-dialog-list-item">
+				<label htmlFor={ inputId }>
+					<FormCheckbox
+						id={ inputId }
+						onChange={ onToggle }
+						className="shipping-zone__location-dialog-list-item-checkbox"
+						checked={ selected }
+						disabled={ disabled }
+					/>
+					{ decodeEntities( name ) }
+				</label>
 			</li>
 		);
 	};
@@ -134,8 +150,10 @@ const ShippingZoneLocationDialogSettings = ( {
 
 			return (
 				<FormFieldSet>
-					<FormLabel required>{ translate( 'Post codes' ) }</FormLabel>
-					<FormTextInput value={ postcode || '' } onChange={ onPostcodeChange } />
+					<FormLabel htmlFor="postcodes" required>
+						{ translate( 'Post codes' ) }
+					</FormLabel>
+					<FormTextInput id="postcodes" value={ postcode || '' } onChange={ onPostcodeChange } />
 					<p>
 						{ translate(
 							'Postcodes containing wildcards (e.g. CB23*) and fully numeric ranges (e.g. 90210…99000) are also supported.'
@@ -163,9 +181,9 @@ const ShippingZoneLocationDialogSettings = ( {
 	};
 
 	return (
-		<div>
+		<div className="shipping-zone__location-dialog-settings">
 			<FormFieldSet>
-				<FormLabel>{ translate( 'Shipping Zone settings' ) }</FormLabel>
+				<FormLegend>{ translate( 'Shipping Zone settings' ) }</FormLegend>
 				{ renderRadios() }
 			</FormFieldSet>
 			{ renderDetailedSettings() }

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
@@ -326,7 +326,11 @@
 	list-style: none;
 	padding: 3px 6px;
 	margin: 1px 0;
-	cursor: pointer;
+
+	label {
+		display: block;
+		cursor: pointer;
+	}
 
 	small {
 		margin-left: 4px;
@@ -365,5 +369,11 @@
 
 	&.is-country {
 		margin-left: 24px;
+	}
+}
+
+.shipping-zone__location-dialog-settings {
+	label {
+		display: block;
 	}
 }

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';

--- a/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';

--- a/client/extensions/woocommerce/app/store-stats/store-stats-period-nav/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-period-nav/index.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/store-stats/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/utils.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { find, includes, forEach, findIndex, round } from 'lodash';
 import classnames from 'classnames';
 import { moment, translate } from 'i18n-calypso';


### PR DESCRIPTION
This fixes the eslint issues in the following files:

- client/extensions/woocommerce/app/settings/email/mailchimp/getting-started.js (1 err, 0 warn)
- client/extensions/woocommerce/app/settings/email/mailchimp/sync_tab.js (6 err, 0 warn)
- client/extensions/woocommerce/app/settings/payments/payment-method-bacs.js (7 err, 0 warn)
- client/extensions/woocommerce/app/settings/payments/stripe/payment-method-stripe-connect-account.js (1 err, 0 warn)
- client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-countries.js (2 err, 0 warn)
- client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-settings.js (8 err, 0 warn)
- client/extensions/woocommerce/app/store-stats/index.js (2 err, 0 warn)
- client/extensions/woocommerce/app/store-stats/store-stats-module/index.js (4 err, 0 warn)
- client/extensions/woocommerce/app/store-stats/store-stats-period-nav/index.js (2 err, 0 warn)
- client/extensions/woocommerce/app/store-stats/utils.js (8 err, 0 warn)

Mostly these are accessibility issues, with some code-style fixes. These files also had prettier run on them, if they hadn't before. Each commit message has a short description of what changed.

To test

- Click around store settings. Specifically, I've touched these pages:
  - Email - Mailchimp settings (note: I couldn't find how to view these settings)
  - Payment - Stripe settings, disconnect button is now a real button
  - Shipping Zones, updates for keyboard accessibility- actions are now on the inputs, with labels wrapping each continent/country/state (BulkSelect updates in a following PR)
- Click around store stats, the only changes here were indentation
