### PR TITLE
Store: Fix ESLint errors in WCS, tests, lib, and components directories

### DIFF
--- a/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
+++ b/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
@@ -77,7 +77,6 @@ class FormClickToEditInput extends Component {
 				<FormTextInput
 					{ ...omit( props, [ 'updateAriaLabel', 'editAriaLabel' ] ) }
 					onBlur={ this.editEnd }
-					autoFocus
 					className="form-click-to-edit-input__input"
 				/>
 				<Button
@@ -97,6 +96,8 @@ class FormClickToEditInput extends Component {
 			'is-empty': ! value,
 			'has-value': value,
 		} );
+		// Accessible labeled button provided. Clickable text is optional and not the only way to activate edit.
+		/* eslint-disable jsx-a11y/click-events-have-key-events */
 		return (
 			<span className={ classes }>
 				<span
@@ -113,6 +114,7 @@ class FormClickToEditInput extends Component {
 				) }
 			</span>
 		);
+		/* eslint-enable jsx-a11y/click-events-have-key-events */
 	}
 
 	render() {

--- a/client/extensions/woocommerce/components/form-location-select/countries.js
+++ b/client/extensions/woocommerce/components/form-location-select/countries.js
@@ -98,7 +98,9 @@ class FormCountrySelectFromApi extends Component {
 	}
 }
 
-const getLocationsListFromContinents = ( state, continents, siteId ) => {
+// TODO Move this to a proper selector (with tests)
+// https://github.com/Automattic/wp-calypso/pull/24571#discussion_r185268996
+const getContinentsWithCountries = ( state, continents, siteId ) => {
 	const locationsList = [];
 	continents.forEach( continent => {
 		const countries = getCountriesByContinent( state, continent.code, siteId );
@@ -122,7 +124,7 @@ export default connect(
 
 		const isLoaded = areLocationsLoaded( state, siteId );
 		const continents = getContinents( state, siteId );
-		const locationsList = getLocationsListFromContinents( state, continents, siteId );
+		const locationsList = getContinentsWithCountries( state, continents, siteId );
 
 		return {
 			areSettingsLoaded,

--- a/client/extensions/woocommerce/components/form-location-select/countries.js
+++ b/client/extensions/woocommerce/components/form-location-select/countries.js
@@ -98,6 +98,20 @@ class FormCountrySelectFromApi extends Component {
 	}
 }
 
+const getLocationsListFromContinents = ( state, continents, siteId ) => {
+	const locationsList = [];
+	continents.forEach( continent => {
+		const countries = getCountriesByContinent( state, continent.code, siteId );
+		locationsList.push(
+			...countries.map( country => ( {
+				...country,
+				continent: continent.code,
+			} ) )
+		);
+	} );
+	return locationsList;
+};
+
 export default connect(
 	( state, props ) => {
 		const site = getSelectedSiteWithFallback( state );
@@ -106,18 +120,9 @@ export default connect(
 		const areSettingsLoaded = areSettingsGeneralLoaded( state );
 		const value = ! props.value ? address.country : props.value;
 
-		const locationsList = [];
 		const isLoaded = areLocationsLoaded( state, siteId );
 		const continents = getContinents( state, siteId );
-		continents.forEach( continent => {
-			const countries = getCountriesByContinent( state, continent.code, siteId );
-			locationsList.push(
-				...countries.map( country => ( {
-					...country,
-					continent: continent.code,
-				} ) )
-			);
-		} );
+		const locationsList = getLocationsListFromContinents( state, continents, siteId );
 
 		return {
 			areSettingsLoaded,

--- a/client/extensions/woocommerce/components/location-flag/index.js
+++ b/client/extensions/woocommerce/components/location-flag/index.js
@@ -31,6 +31,7 @@ class LocationFlag extends Component {
 				className={ classNames( 'location-flag', className ) }
 				style={ style }
 				src={ `/calypso/images/flags/${ code.toLowerCase() }.svg` }
+				alt=""
 			/>
 		);
 	}

--- a/client/extensions/woocommerce/lib/generate-variations/test/index.js
+++ b/client/extensions/woocommerce/lib/generate-variations/test/index.js
@@ -102,7 +102,7 @@ describe( 'generateVariations', () => {
 			},
 		] );
 	} );
-	test( 'generates a complex cartesian of variations when passed a product with multiple variation attributes and multiple options', () => {
+	test( 'generates a complex cartesian of variations when passed a product with multiple attributes and options', () => {
 		const product = {
 			id: 1,
 			attributes: [

--- a/client/extensions/woocommerce/state/data-layer/ui/products/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/products/index.js
@@ -118,8 +118,9 @@ export function handleProductActionListCreate( store, action ) {
  * @param {Object} rootState The root calypso state.
  * @param {Number} [siteId=selected site] The siteId for the Action List (TODO: Remove this when edits have siteIds.)
  * @param {Object} [productEdits=all edits] The product edits to be included in the Action List
- * @param {Object} [successAction] Action to be dispatched upon successful action list completion.
- * @param {Object} [failureAction] Action to be dispatched upon failure of action list execution.
+ * @param {Object} [variationEdits=all edits] The variation edits to be included in the Action List
+ * @param {Object} [onSuccess] Action to be dispatched upon successful action list completion.
+ * @param {Object} [onFailure] Action to be dispatched upon failure of action list execution.
  * @return {Object} An Action List object.
  */
 export function makeProductActionList(

--- a/client/extensions/woocommerce/state/sites/payment-methods/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/payment-methods/test/reducer.js
@@ -30,7 +30,7 @@ describe( 'reducer', () => {
 		expect( newState[ siteId ].paymentMethods ).to.eql( LOADING );
 	} );
 
-	test( 'should store data from the action', () => {
+	test( 'should store data from the request action', () => {
 		const siteId = 123;
 		const state = {};
 		const action = {
@@ -47,7 +47,7 @@ describe( 'reducer', () => {
 		] );
 	} );
 
-	test( 'should store data from the action', () => {
+	test( 'should store data from the update success action', () => {
 		const siteId = 123;
 		const state = {
 			[ siteId ]: {

--- a/client/extensions/woocommerce/state/sites/review-replies/test/handlers.js
+++ b/client/extensions/woocommerce/state/sites/review-replies/test/handlers.js
@@ -28,8 +28,7 @@ import {
 	announceCreateFailure,
 } from '../handlers.js';
 import reviewReplies from './fixtures/review-replies';
-import { NOTICE_CREATE } from 'state/action-types';
-import { WPCOM_HTTP_REQUEST } from 'state/action-types';
+import { NOTICE_CREATE, WPCOM_HTTP_REQUEST } from 'state/action-types';
 import {
 	WOOCOMMERCE_REVIEW_REPLIES_UPDATED,
 	WOOCOMMERCE_REVIEW_REPLIES_REQUEST,

--- a/client/extensions/woocommerce/state/sites/reviews/test/handlers.js
+++ b/client/extensions/woocommerce/state/sites/reviews/test/handlers.js
@@ -22,8 +22,7 @@ import {
 	announceDeleteFailure,
 } from '../handlers.js';
 import reviews from './fixtures/reviews';
-import { NOTICE_CREATE } from 'state/action-types';
-import { WPCOM_HTTP_REQUEST } from 'state/action-types';
+import { NOTICE_CREATE, WPCOM_HTTP_REQUEST } from 'state/action-types';
 import {
 	WOOCOMMERCE_REVIEWS_RECEIVE,
 	WOOCOMMERCE_REVIEWS_REQUEST,

--- a/client/extensions/woocommerce/state/ui/payments/methods/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/payments/methods/test/selectors.js
@@ -48,7 +48,7 @@ describe( 'selectors', () => {
 		uiState.methods = null;
 	} );
 
-	describe( 'getPaymentMethodEdits', () => {
+	describe( 'getPaymentMethodsWithEdits', () => {
 		test( 'should return empty array when the methods are being loaded', () => {
 			siteState.paymentMethods = LOADING;
 			expect( getPaymentMethodsWithEdits( state ) ).to.deep.equal( [] );

--- a/client/extensions/woocommerce/state/ui/shipping/zones/locations/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/locations/test/selectors.js
@@ -1433,7 +1433,7 @@ describe( 'selectors', () => {
 			expect( areLocationsFilteredByPostcode( state ) ).to.be.false;
 		} );
 
-		test( 'should return true when there is a whole country selected but the it belongs to other zone and does not allow states', () => {
+		test( 'should return true when there is a whole country selected but it belongs to another zone and does not allow states', () => {
 			const state = createEditState( {
 				zoneLocations: {
 					1: {

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/selectors.js
@@ -127,15 +127,16 @@ const overlayShippingZoneMethods = ( state, zone, siteId, extraEdits ) => {
 			enabled = getShippingZoneMethod( state, method._originalId, siteId ).enabled;
 		}
 
-		// Prettier formatting indents the schema line in a way eslint doesn't like.
+		// Prettier formatting indents the following lines causing a linter error 'Expected indentation of 4 tabs but found 5'
 		/* eslint-disable indent */
 		const defaultValues = startsWith( method.methodType, 'wc_services' )
 			? getDefaultSettingsValues(
 					getShippingMethodSchema( state, method.methodType, siteId ).formSchema
 				)
 			: {};
-		return merge( {}, defaultValues, method, { enabled: false !== enabled } );
 		/* eslint-enable indent */
+
+		return merge( {}, defaultValues, method, { enabled: false !== enabled } );
 	} );
 	return sortShippingZoneMethods( state, siteId, allMethods );
 };

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/selectors.js
@@ -127,12 +127,15 @@ const overlayShippingZoneMethods = ( state, zone, siteId, extraEdits ) => {
 			enabled = getShippingZoneMethod( state, method._originalId, siteId ).enabled;
 		}
 
+		// Prettier formatting indents the schema line in a way eslint doesn't like.
+		/* eslint-disable indent */
 		const defaultValues = startsWith( method.methodType, 'wc_services' )
 			? getDefaultSettingsValues(
 					getShippingMethodSchema( state, method.methodType, siteId ).formSchema
 				)
 			: {};
 		return merge( {}, defaultValues, method, { enabled: false !== enabled } );
+		/* eslint-enable indent */
 	} );
 	return sortShippingZoneMethods( state, siteId, allMethods );
 };

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -203,9 +203,9 @@ class ShippingLabels extends Component {
 					<p className="label-settings__credit-card-description">{ summary }</p>
 					{ canEditPayments && (
 						<p className="label-settings__credit-card-description">
-							<a href="#" onClick={ expand }>
+							<Button onClick={ expand } borderless>
 								{ translate( 'Choose a different card' ) }
-							</a>
+							</Button>
 						</p>
 					) }
 				</div>

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/style.scss
@@ -2,6 +2,10 @@
 	margin-bottom: 4px;
 	color: $gray-text-min;
 	padding-bottom: 8px;
+
+	button {
+		color: $blue-wordpress;
+	}
 }
 
 .card.label-settings__card {

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/edit-package.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/edit-package.js
@@ -12,6 +12,7 @@ import { omit, trim } from 'lodash';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import FormDimensionsInput from 'woocommerce/components/form-dimensions-input';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -50,9 +51,9 @@ const OuterDimensionsToggle = ( { siteId, toggleOuterDimensions, translate } ) =
 	};
 
 	return (
-		<a href="#" className="packages__setting-explanation" onClick={ onClick }>
+		<Button className="packages__setting-explanation" onClick={ onClick } borderless>
 			{ translate( 'Add exterior dimensions' ) }
-		</a>
+		</Button>
 	);
 };
 

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
@@ -216,6 +216,8 @@
 	font-style: italic;
 	font-weight: 400;
 	margin: 5px 0 0 0;
+	color: $blue-wordpress;
+	text-decoration: underline;
 }
 
 .packages__delete {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import RefundDialog from './label-refund-modal';
 import ReprintDialog from './label-reprint-modal';
 import DetailsDialog from './label-details-modal';
@@ -38,7 +39,9 @@ class LabelItem extends Component {
 		return (
 			<span>
 				<RefundDialog siteId={ siteId } orderId={ orderId } { ...label } />
-				<a href="#" onClick={ openDialog } >{ translate( 'Request refund' ) }</a>
+				<Button onClick={ openDialog } borderless className="shipping-label__button">
+					{ translate( 'Request refund' ) }
+				</Button>
 			</span>
 		);
 	};
@@ -60,7 +63,9 @@ class LabelItem extends Component {
 		return (
 			<span>
 				<ReprintDialog siteId={ siteId } orderId={ orderId } { ...label } />
-				<a href="#" onClick={ openDialog } >{ translate( 'Reprint' ) }</a>
+				<Button onClick={ openDialog } borderless className="shipping-label__button">
+					{ translate( 'Reprint' ) }
+				</Button>
 			</span>
 		);
 	};
@@ -76,7 +81,9 @@ class LabelItem extends Component {
 		return (
 			<span>
 				<DetailsDialog siteId={ siteId } orderId={ orderId } { ...label } />
-				<a href="#" onClick={ openDialog } >{ translate( 'View details' ) }</a>
+				<Button onClick={ openDialog } borderless className="shipping-label__button">
+					{ translate( 'View details' ) }
+				</Button>
 			</span>
 		);
 	};

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
@@ -63,6 +63,8 @@
 
 .address-step__suggestion-edit {
 	margin-left: 24px;
+	color: $blue-wordpress;
+	font-weight: bold;
 }
 
 .address-step__suggestion-summary {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/suggestion.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/suggestion.js
@@ -10,6 +10,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 import Notice from 'components/notice';
@@ -92,9 +93,9 @@ const AddressSuggestion = ( {
 					<AddressSummary
 						values={ values }
 						countriesData={ countriesData } />
-					<a className="address-step__suggestion-edit" onClick={ editAddress } >
+					<Button borderless className="address-step__suggestion-edit" onClick={ editAddress } >
 						{ translate( 'Edit address' ) }
-					</a>
+					</Button>
 				</RadioButton>
 				<RadioButton
 					checked={ selectNormalized }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/list.js
@@ -12,6 +12,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import getPackageDescriptions from './get-package-descriptions';
 import { openPackage } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
 import {
@@ -42,12 +43,13 @@ const PackageList = ( props ) => {
 		const onOpenClick = () => props.openPackage( orderId, siteId, pckgId );
 		return (
 			<div className="packages-step__list-item" key={ pckgId }>
-				<div
+				<Button
+					borderless
 					className={ classNames( 'packages-step__list-package', { 'is-selected': packageId === pckgId } ) }
 					onClick={ onOpenClick } >
 					<span className="packages-step__list-package-name">{ name }</span>
 					{ renderCountOrError( isError, count ) }
-				</div>
+				</Button>
 			</div>
 		);
 	};

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/style.scss
@@ -57,6 +57,7 @@
 	text-overflow: ellipsis;
 	margin-right: 2px;
 	text-align: left;
+	color: $gray-text;
 }
 
 .packages-step__list-package-count {
@@ -67,7 +68,7 @@
 	font-size: 11px;
 	font-weight: 600;
 	line-height: 14px;
-	color: $gray;
+	color: $gray-text;
 	text-align: center;
 }
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/style.scss
@@ -39,12 +39,14 @@
 	padding: 6px 12px;
 	cursor: pointer;
 	align-items: center;
+	width: 100%;
 
 	&.is-selected {
 		background-color: $gray-light;
+	}
 
-		.packages-step__list-package-count {
-		}
+	.gridicon {
+		top: 0;
 	}
 }
 
@@ -54,6 +56,7 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	margin-right: 2px;
+	text-align: left;
 }
 
 .packages-step__list-package-count {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
@@ -24,6 +24,10 @@
 		margin-top: 16px;
 	}
 
+	.shipping-label__button {
+		color: $blue-wordpress;
+	}
+
 	.shipping-label__item-detail, .shipping-label__item-actions {
 		display: flex;
 		justify-content: space-between;


### PR DESCRIPTION
See #24504.

This fixes the eslint issues in the following files:

* client/extensions/woocommerce/components/bulk-select/index.js (2 err, 0 warn)
* client/extensions/woocommerce/components/form-click-to-edit-input/index.js (2 err, 0 warn)
* client/extensions/woocommerce/components/form-location-select/countries.js (2 err, 0 warn)
* client/extensions/woocommerce/components/location-flag/index.js (1 err, 0 warn)
* client/extensions/woocommerce/lib/generate-variations/test/index.js (1 err, 0 warn)
* client/extensions/woocommerce/state/data-layer/ui/products/index.js (3 err, 0 warn)
* client/extensions/woocommerce/state/sites/payment-methods/test/reducer.js (1 err, 0 warn)
* client/extensions/woocommerce/state/sites/review-replies/test/handlers.js (1 err, 0 warn)
* client/extensions/woocommerce/state/sites/reviews/test/handlers.js (1 err, 0 warn)
* client/extensions/woocommerce/state/ui/payments/methods/test/selectors.js (1 err, 0 warn)
* client/extensions/woocommerce/state/ui/shipping/zones/locations/test/selectors.js (1 err, 0 warn)
* client/extensions/woocommerce/state/ui/shipping/zones/methods/selectors.js (2 err, 0 warn)
* client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js (1 err, 0 warn)
* client/extensions/woocommerce/woocommerce-services/views/packages/edit-package.js (1 err, 0 warn)
* client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js (3 err, 0 warn)
* client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/suggestion.js (3 err, 0 warn)
* client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/list.js (2 err, 0 warn)

Some of these are around duplicate test descriptions, indentation, and buttons vs links. No functionality should be changed so testing can just be spot checking.

To Test:
* Run tests `npm run test-client client/extensions/woocommerce`
* Click around store. Specifically, I've touched the following pages (via components or selectors):
    * SKU Edit Component
    * Address Dialog (Country/State Selection)
    * Shipping zone & method dialogs
    * Product reviews & review replies
    * Label & package dialogs and flow