### PR TITLE
[Domains] Fix inconsistent domain price styling

### DIFF
--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -1,23 +1,22 @@
 .domain-product-price {
 	color: $gray-darken-30;
-	display: inline-block;
-	font-size: 17px;
 	font-weight: 600;
 
 	@include breakpoint( ">660px" ) {
-		min-width: 130px;
-		display: flex;
 		align-items: center;
-		margin-top: -4px;
+		display: flex;
+		flex: 0 2 280px;
+		font-size: 17px;
+		justify-content: flex-end;
+		padding-right: 2em;
 	}
 
 	@include breakpoint( "<660px" ) {
+		display: inline-block;
 		font-size: 14px;
 	}
 
 	&.is-with-plans-only:not( .is-free-domain ) {
-		flex: 1 0 280px;
-
 		small {
 			font-size: 12px;
 		}
@@ -46,12 +45,7 @@
 	}
 
 	&.is-free-domain {
-		display: block;
 		font-size: 13px;
-
-		@include breakpoint( ">960px" ) {
-			margin-top: -6px;
-		}
 
 		small {
 			font-size: 100%;
@@ -61,15 +55,6 @@
 		.domain-product-price__price {
 			opacity: .6;
 			text-decoration: line-through;
-		}
-
-		&.no-price {
-			@include breakpoint( ">660px" ) {
-				padding-top: 7px;
-			}
-			@include breakpoint( ">960px" ) {
-				padding-top: 13px;
-			}
 		}
 	}
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -9,10 +9,6 @@
 
 	@include breakpoint( '>660px' ) {
 		padding: 15px 20px;
-
-		.domain-product-price {
-			margin-left: 5%;
-		}
 	}
 
 	&.is-clickable {

--- a/client/components/domains/featured-domain-suggestions/styles/base.scss
+++ b/client/components/domains/featured-domain-suggestions/styles/base.scss
@@ -40,8 +40,7 @@
 	// .card used to increase specificity
 	&.card .domain-product-price {
 		margin: 0;
-		flex-grow: 0;
-		flex-basis: auto;
+		justify-content: flex-start;
 
 		&.is-with-plans-only,
 		&.is-free-domain {


### PR DESCRIPTION
This change removes unnecessary use of `display: block` and uses of `margin-top`s and `padding-top`s with magic numbers. This change also fixes several aesthetic anomalies, as shown below:

### Signup
<img width="990" alt="nux - before" src="https://user-images.githubusercontent.com/4044428/39441874-99015734-4c6c-11e8-875d-f71f05e34caa.png">
<img width="1001" alt="nux - after" src="https://user-images.githubusercontent.com/4044428/39441878-9abb3fb8-4c6c-11e8-85c0-8995cfce78e9.png">

### Free Domain
<img width="751" alt="free domain - before" src="https://user-images.githubusercontent.com/4044428/39441779-3c469dce-4c6c-11e8-9c96-ed6b7b7e14b5.png">
<img width="746" alt="free domain - after" src="https://user-images.githubusercontent.com/4044428/39441778-3c3418b6-4c6c-11e8-9cb0-fdd55cc67c56.png">

### Domain Purchase
<img width="748" alt="paid domain - before" src="https://user-images.githubusercontent.com/4044428/39441777-3c218476-4c6c-11e8-9a8f-fd805cc03696.png">
<img width="741" alt="paid domain - after" src="https://user-images.githubusercontent.com/4044428/39441775-3c0ee3ac-4c6c-11e8-852d-07aaaa3f7b26.png">

# Testing Instructions
1. Spin up this branch locally.
2. Try the following pages:
    1. `/start/domains`
    2. `/domains/add` for a site with domain credit via a paid plan
    3. `/domains/add` for a site without any domain credit
3. Enter a query. 
4. Verify that the styling looks appropriate.
5. Try resizing the viewport to check for new regressions. Note that our current styling already has a handful of pre-existing issues.

