### PR TITLE
Component BulkSelect: Fix eslint errors

### DIFF
--- a/client/components/bulk-select/index.jsx
+++ b/client/components/bulk-select/index.jsx
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import Count from 'components/count';
 
-class BulkSelect extends React.Component {
+export class BulkSelect extends React.Component {
 	static displayName = 'BulkSelect';
 
 	static propTypes = {

--- a/client/components/bulk-select/index.jsx
+++ b/client/components/bulk-select/index.jsx
@@ -53,6 +53,7 @@ export class BulkSelect extends React.Component {
 
 		return (
 			<span className="bulk-select">
+				{ /* The label + input have an implicit relationship since the input is a direct child of the label. */ }
 				{ /* eslint-disable jsx-a11y/label-has-for */ }
 				<label className="bulk-select__container">
 					<input

--- a/client/components/bulk-select/index.jsx
+++ b/client/components/bulk-select/index.jsx
@@ -1,20 +1,19 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Count from 'components/count';
 
-export default class extends React.Component {
+class BulkSelect extends React.Component {
 	static displayName = 'BulkSelect';
 
 	static propTypes = {
@@ -44,28 +43,32 @@ export default class extends React.Component {
 	};
 
 	render() {
+		const { translate, ariaLabel = translate( 'Select All' ) } = this.props;
 		const isChecked = this.hasAllElementsSelected();
 		const inputClasses = classNames( 'bulk-select__box', {
 			// We need to add this CSS class to be able to test if the input if checked,
 			// since Enzyme still doesn't support :checked pseudoselector.
 			'is-checked': isChecked,
 		} );
-		const inputProps = {
-			className: inputClasses,
-			checked: isChecked,
-		};
-		if ( this.props.id ) {
-			inputProps.id = this.props.id;
-		}
 
 		return (
 			<span className="bulk-select">
-				<span className="bulk-select__container">
-					<input type="checkbox" { ...inputProps } onChange={ this.handleToggleAll } />
+				{ /* eslint-disable jsx-a11y/label-has-for */ }
+				<label className="bulk-select__container">
+					<input
+						type="checkbox"
+						className={ inputClasses }
+						checked={ isChecked }
+						onChange={ this.handleToggleAll }
+						aria-label={ ariaLabel }
+					/>
 					<Count count={ this.props.selectedElements } />
 					{ this.getStateIcon() }
-				</span>
+				</label>
+				{ /* eslint-enable jsx-a11y/label-has-for */ }
 			</span>
 		);
 	}
 }
+
+export default localize( BulkSelect );

--- a/client/components/bulk-select/index.jsx
+++ b/client/components/bulk-select/index.jsx
@@ -18,6 +18,7 @@ export default class extends React.Component {
 	static displayName = 'BulkSelect';
 
 	static propTypes = {
+		id: PropTypes.string,
 		totalElements: PropTypes.number.isRequired,
 		selectedElements: PropTypes.number.isRequired,
 		onToggle: PropTypes.func.isRequired,
@@ -49,10 +50,18 @@ export default class extends React.Component {
 			// since Enzyme still doesn't support :checked pseudoselector.
 			'is-checked': isChecked,
 		} );
+		const inputProps = {
+			className: inputClasses,
+			checked: isChecked,
+		};
+		if ( this.props.id ) {
+			inputProps.id = this.props.id;
+		}
+
 		return (
-			<span className="bulk-select" onClick={ this.handleToggleAll }>
+			<span className="bulk-select">
 				<span className="bulk-select__container">
-					<input type="checkbox" className={ inputClasses } checked={ isChecked } readOnly />
+					<input type="checkbox" { ...inputProps } onChange={ this.handleToggleAll } />
 					<Count count={ this.props.selectedElements } />
 					{ this.getStateIcon() }
 				</span>

--- a/client/components/bulk-select/test/index.js
+++ b/client/components/bulk-select/test/index.js
@@ -52,6 +52,21 @@ describe( 'index', () => {
 		assert.equal( 1, bulkSelect.find( '.bulk-select__some-checked-icon' ).length );
 	} );
 
+	test( 'should set the passed ID prop on the input', () => {
+		const bulkSelect = shallow(
+			<BulkSelect selectedElements={ 2 } totalElements={ 3 } onToggle={ noop } id="fake-example" />
+		);
+		assert.equal( 'fake-example', bulkSelect.find( 'input' ).prop( 'id' ) );
+	} );
+
+	test( 'should not mark the input readOnly', () => {
+		const bulkSelect = shallow(
+			<BulkSelect selectedElements={ 2 } totalElements={ 3 } onToggle={ noop } />
+		);
+		// There is no prop readOnly, so this is undefined
+		assert.equal( undefined, bulkSelect.find( 'input' ).prop( 'readOnly' ) );
+	} );
+
 	test( 'should be call onToggle when clicked', () => {
 		let hasBeenCalled = false;
 		const callback = function() {
@@ -60,7 +75,7 @@ describe( 'index', () => {
 		const bulkSelect = shallow(
 			<BulkSelect selectedElements={ 0 } totalElements={ 3 } onToggle={ callback } />
 		);
-		bulkSelect.simulate( 'click' );
+		bulkSelect.find( 'input' ).simulate( 'change' );
 		assert.equal( hasBeenCalled, true );
 	} );
 
@@ -72,7 +87,7 @@ describe( 'index', () => {
 		const bulkSelect = shallow(
 			<BulkSelect selectedElements={ 0 } totalElements={ 3 } onToggle={ callback } />
 		);
-		bulkSelect.simulate( 'click' );
+		bulkSelect.find( 'input' ).simulate( 'change' );
 	} );
 
 	test( 'should be call onToggle with the new state when there are some selected elements', done => {
@@ -83,7 +98,7 @@ describe( 'index', () => {
 		const bulkSelect = shallow(
 			<BulkSelect selectedElements={ 1 } totalElements={ 3 } onToggle={ callback } />
 		);
-		bulkSelect.simulate( 'click' );
+		bulkSelect.find( 'input' ).simulate( 'change' );
 	} );
 
 	test( 'should be call onToggle with the new state when there all elements are selected', done => {
@@ -94,6 +109,6 @@ describe( 'index', () => {
 		const bulkSelect = shallow(
 			<BulkSelect selectedElements={ 3 } totalElements={ 3 } onToggle={ callback } />
 		);
-		bulkSelect.simulate( 'click' );
+		bulkSelect.find( 'input' ).simulate( 'change' );
 	} );
 } );

--- a/client/components/bulk-select/test/index.js
+++ b/client/components/bulk-select/test/index.js
@@ -8,60 +8,96 @@
  */
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
+import { identity, noop } from 'lodash';
 import React from 'react';
 
 /**
  * Internal dependencies
  */
-import BulkSelect from '../index';
+import { BulkSelect } from '../index';
 
 describe( 'index', () => {
 	test( 'should have BulkSelect class', () => {
 		const bulkSelect = shallow(
-			<BulkSelect selectedElements={ 0 } totalElements={ 3 } onToggle={ noop } />
+			<BulkSelect
+				translate={ identity }
+				selectedElements={ 0 }
+				totalElements={ 3 }
+				onToggle={ noop }
+			/>
 		);
 		assert.equal( 1, bulkSelect.find( '.bulk-select' ).length );
 	} );
 
 	test( 'should not be checked when initialized without selectedElements', () => {
 		const bulkSelect = shallow(
-			<BulkSelect selectedElements={ 0 } totalElements={ 3 } onToggle={ noop } />
+			<BulkSelect
+				translate={ identity }
+				selectedElements={ 0 }
+				totalElements={ 3 }
+				onToggle={ noop }
+			/>
 		);
 		assert.equal( 0, bulkSelect.find( '.is-checked' ).length );
 	} );
 
 	test( 'should be checked when initialized with all elements selected', () => {
 		const bulkSelect = shallow(
-			<BulkSelect selectedElements={ 3 } totalElements={ 3 } onToggle={ noop } />
+			<BulkSelect
+				translate={ identity }
+				selectedElements={ 3 }
+				totalElements={ 3 }
+				onToggle={ noop }
+			/>
 		);
 		assert.equal( 1, bulkSelect.find( '.is-checked' ).length );
 	} );
 
 	test( 'should not be checked when initialized with some elements selected', () => {
 		const bulkSelect = shallow(
-			<BulkSelect selectedElements={ 2 } totalElements={ 3 } onToggle={ noop } />
+			<BulkSelect
+				translate={ identity }
+				selectedElements={ 2 }
+				totalElements={ 3 }
+				onToggle={ noop }
+			/>
 		);
 		assert.equal( 0, bulkSelect.find( '.is-checked' ).length );
 	} );
 
 	test( 'should render line gridicon when initialized with some elements selected', () => {
 		const bulkSelect = shallow(
-			<BulkSelect selectedElements={ 2 } totalElements={ 3 } onToggle={ noop } />
+			<BulkSelect
+				translate={ identity }
+				selectedElements={ 2 }
+				totalElements={ 3 }
+				onToggle={ noop }
+			/>
 		);
 		assert.equal( 1, bulkSelect.find( '.bulk-select__some-checked-icon' ).length );
 	} );
 
 	test( 'should add the aria-label to the input', () => {
 		const bulkSelect = shallow(
-			<BulkSelect selectedElements={ 2 } totalElements={ 3 } onToggle={ noop } ariaLabel="Select All" />
+			<BulkSelect
+				translate={ identity }
+				selectedElements={ 2 }
+				totalElements={ 3 }
+				onToggle={ noop }
+				ariaLabel="Select All"
+			/>
 		);
 		assert.equal( 'Select All', bulkSelect.find( 'input' ).prop( 'aria-label' ) );
 	} );
 
 	test( 'should not mark the input readOnly', () => {
 		const bulkSelect = shallow(
-			<BulkSelect selectedElements={ 2 } totalElements={ 3 } onToggle={ noop } />
+			<BulkSelect
+				translate={ identity }
+				selectedElements={ 2 }
+				totalElements={ 3 }
+				onToggle={ noop }
+			/>
 		);
 		// There is no prop readOnly, so this is undefined
 		assert.equal( undefined, bulkSelect.find( 'input' ).prop( 'readOnly' ) );
@@ -73,7 +109,12 @@ describe( 'index', () => {
 			hasBeenCalled = true;
 		};
 		const bulkSelect = shallow(
-			<BulkSelect selectedElements={ 0 } totalElements={ 3 } onToggle={ callback } />
+			<BulkSelect
+				translate={ identity }
+				selectedElements={ 0 }
+				totalElements={ 3 }
+				onToggle={ callback }
+			/>
 		);
 		bulkSelect.find( 'input' ).simulate( 'change' );
 		assert.equal( hasBeenCalled, true );
@@ -85,7 +126,12 @@ describe( 'index', () => {
 			done();
 		};
 		const bulkSelect = shallow(
-			<BulkSelect selectedElements={ 0 } totalElements={ 3 } onToggle={ callback } />
+			<BulkSelect
+				translate={ identity }
+				selectedElements={ 0 }
+				totalElements={ 3 }
+				onToggle={ callback }
+			/>
 		);
 		bulkSelect.find( 'input' ).simulate( 'change' );
 	} );
@@ -96,7 +142,12 @@ describe( 'index', () => {
 			done();
 		};
 		const bulkSelect = shallow(
-			<BulkSelect selectedElements={ 1 } totalElements={ 3 } onToggle={ callback } />
+			<BulkSelect
+				translate={ identity }
+				selectedElements={ 1 }
+				totalElements={ 3 }
+				onToggle={ callback }
+			/>
 		);
 		bulkSelect.find( 'input' ).simulate( 'change' );
 	} );
@@ -107,7 +158,12 @@ describe( 'index', () => {
 			done();
 		};
 		const bulkSelect = shallow(
-			<BulkSelect selectedElements={ 3 } totalElements={ 3 } onToggle={ callback } />
+			<BulkSelect
+				translate={ identity }
+				selectedElements={ 3 }
+				totalElements={ 3 }
+				onToggle={ callback }
+			/>
 		);
 		bulkSelect.find( 'input' ).simulate( 'change' );
 	} );

--- a/client/components/bulk-select/test/index.js
+++ b/client/components/bulk-select/test/index.js
@@ -52,11 +52,11 @@ describe( 'index', () => {
 		assert.equal( 1, bulkSelect.find( '.bulk-select__some-checked-icon' ).length );
 	} );
 
-	test( 'should set the passed ID prop on the input', () => {
+	test( 'should add the aria-label to the input', () => {
 		const bulkSelect = shallow(
-			<BulkSelect selectedElements={ 2 } totalElements={ 3 } onToggle={ noop } id="fake-example" />
+			<BulkSelect selectedElements={ 2 } totalElements={ 3 } onToggle={ noop } ariaLabel="Select All" />
 		);
-		assert.equal( 'fake-example', bulkSelect.find( 'input' ).prop( 'id' ) );
+		assert.equal( 'Select All', bulkSelect.find( 'input' ).prop( 'aria-label' ) );
 	} );
 
 	test( 'should not mark the input readOnly', () => {

--- a/client/extensions/woocommerce/components/bulk-select/index.js
+++ b/client/extensions/woocommerce/components/bulk-select/index.js
@@ -1,21 +1,20 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
 const BulkSelect = ( {
-	totalElements,
-	selectedElements,
 	className,
 	disabled,
-	readOnly,
+	id,
 	onToggle,
+	readOnly,
+	selectedElements,
+	totalElements,
 } ) => {
 	const hasAllElementsSelected = selectedElements && selectedElements === totalElements;
 	const hasSomeElementsSelected = selectedElements && selectedElements < totalElements;
@@ -31,14 +30,15 @@ const BulkSelect = ( {
 	};
 
 	return (
-		<span className={ containerClasses } onClick={ handleToggle }>
+		<span className={ containerClasses }>
 			<span className="bulk-select__container">
 				<input
+					id={ id }
 					type="checkbox"
 					className={ inputClasses }
+					onChange={ handleToggle }
 					checked={ hasAllElementsSelected }
 					disabled={ disabled }
-					readOnly
 				/>
 				{ hasSomeElementsSelected ? (
 					<Gridicon className={ iconClasses } icon="minus-small" size={ 18 } />

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/predefined-packages.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/predefined-packages.js
@@ -34,18 +34,28 @@ const PredefinedPackages = ( {
 			event.stopPropagation();
 			toggleAll( siteId, group.serviceId, group.groupId, event.target.checked );
 		};
+		const inputId = `group-${ group.serviceId }-${ group.groupId }`;
 
+		// The onClick handler only exists to prevent the input click event from bubbling up to FoldableCard
+		// This does not affect the keyboard accessibility.
+		/* eslint-disable jsx-a11y/click-events-have-key-events */
+		/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 		return (
 			<div className="packages__group-header">
-				<BulkSelect
-					totalElements={ group.total }
-					selectedElements={ group.selected }
-					onToggle={ onToggle }
-					className="packages__group-header-checkbox"
-				/>
-				{ group.title }
+				<label htmlFor={ inputId } onClick={ event => event.stopPropagation() }>
+					<BulkSelect
+						id={ inputId }
+						totalElements={ group.total }
+						selectedElements={ group.selected }
+						onToggle={ onToggle }
+						className="packages__group-header-checkbox"
+					/>
+					{ group.title }
+				</label>
 			</div>
 		);
+		/* eslint-enable jsx-a11y/click-events-have-key-events */
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 	};
 
 	const getSelectionSummary = ( selectedCount, totalCount ) => {


### PR DESCRIPTION
See #24504

This PR fixes the eslint errors in BulkSelect & the WC-specific BulkSelect component. This also improves the accessibility of each component.

To fix the [`no-static-element-interactions`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-static-element-interactions.md) error, I've moved the onToggle action to the `onChange` event of the input, which means we can remove the readOnly attribute. [This was added just to avoid a React error](https://github.com/Automattic/wp-calypso/commit/88600fc1fbbe791d4a8142296a47b22ef63809a9).

For the WC BulkSelect component, you can now pass in an ID - this is based off the use [in the country/state selection](https://github.com/Automattic/wp-calypso/blob/054b7d20a0d85d952cdcec7c350e7bd4b968fbe1/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-countries.js#L61-L84). 

We only seem to use the core BulkSelect component on the manage plugins screen, which doesn't have a visible label - so I've added a prop to that component for an aria-label.

I've also updated the tests for BulkSelect to reflect the changes (the majority of changes here are in the tests).

It might be best to merge these two components, but that's not what I wanted to focus on 🙂 

Additionally, a good upgrade might be to build a custom checkbox so we can use the accessible [tri-state pattern](https://www.w3.org/TR/wai-aria-practices-1.1/examples/checkbox/checkbox-2/checkbox-2.html). Currently the unchecked and mixed state are both read by screen readers as "unchecked".

**To test**

- Make sure BulkSelect works as expected on the manage plugins screen
- Make sure the WC BulkSelect works as expected when editing a shipping zone (Store > Settings > Shipping, add or edit a zone, then add or edit "Zone Locations")