### PR TITLE
[Domains] Fix domain price styling, take 2

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -41,7 +41,6 @@
 
 	@include breakpoint( '>660px' ) {
 		display: flex;
-		margin: 8px 0 0 0;
 	}
 
 	.notice.is-compact {
@@ -104,6 +103,10 @@
 			color: transparent;
 		}
 	}
+}
+
+.domain-registration-suggestion__title {
+	align-self: center;
 }
 
 .button.domain-suggestion__action {


### PR DESCRIPTION
Follow-up of #24572. 

This change fixes the slight vertical misalignment of the domain name inside the suggestion component.

## Before:
<img width="750" alt="before" src="https://user-images.githubusercontent.com/4044428/39448047-f645f058-4c80-11e8-983e-3f29faca826e.png">

## After:
<img width="740" alt="after" src="https://user-images.githubusercontent.com/4044428/39448069-03bb454e-4c81-11e8-96dc-0d318fd34695.png">
