### PR TITLE
[Domains] Reduce the padding on CTA buttons

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -155,13 +155,11 @@ class DomainRegistrationSuggestion extends React.Component {
 		const { domain_name: domain } = suggestion;
 		const isAdded = hasDomainInCart( cart, domain );
 
-		let buttonClasses, buttonContent;
+		let buttonContent;
 
 		if ( isAdded ) {
-			buttonClasses = 'added';
 			buttonContent = <Gridicon icon="checkmark" />;
 		} else {
-			buttonClasses = 'add is-primary';
 			buttonContent =
 				! isSignupStep &&
 				shouldBundleDomainWithPlan( domainsWithPlansOnly, selectedSite, cart, suggestion )
@@ -171,7 +169,6 @@ class DomainRegistrationSuggestion extends React.Component {
 					: translate( 'Select', { context: 'Domain mapping suggestion button' } );
 		}
 		return {
-			buttonClasses,
 			buttonContent,
 		};
 	}

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -79,8 +79,6 @@
 		.is-placeholder & {
 			margin-right: 50%;
 			min-height: 22px;
-			margin-top: 9px;
-			margin-bottom: 9px;
 		}
 
 		.is-placeholder:nth-of-type(2n + 1) & {
@@ -118,9 +116,8 @@
 	// NOTE: .is-kracken-ui can be removed once feature is deployed.
 	.is-kracken-ui &.is-primary {
 		color: $white;
-		padding-left: 3em;
-		padding-right: 3em;
 		margin-left: 1em;
+		padding: 0.25em 3em;
 		transition: all 0.1s linear;
 
 		&:hover {

--- a/client/components/domains/featured-domain-suggestions/styles/base.scss
+++ b/client/components/domains/featured-domain-suggestions/styles/base.scss
@@ -88,6 +88,7 @@
 			align-self: flex-start;
 			margin-left: 0;
 			flex-grow: 0;
+			padding: 0.5em 3em;
 		}
 	}
 }


### PR DESCRIPTION
This change reduces the vertical padding of suggestion buttons. Doing so enables us to squeeze in more suggestions on initial page load before requiring the customer to scroll down.

In addition, this spacing is closer to what the designs had specified.

## Domain Management (Before and After)
<img width="739" alt="domains_-_before" src="https://user-images.githubusercontent.com/4044428/39448685-e9f327e2-4c82-11e8-8fa9-a27515e9aff2.png">
<img width="747" alt="domains_-_after" src="https://user-images.githubusercontent.com/4044428/39448693-ec528f6e-4c82-11e8-9071-6a8ef593fd0a.png">

## Signup (Before and After)
<img width="985" alt="nux_-_before" src="https://user-images.githubusercontent.com/4044428/39448698-f02704f8-4c82-11e8-8952-4f921973b47e.png">
<img width="987" alt="nux_-_after" src="https://user-images.githubusercontent.com/4044428/39448702-f220d130-4c82-11e8-9699-980aa7db5fe1.png">

# Test Instructions
1. Spin this up locally or using a live branch.
2. Navigate to `/start/domains` or `domains/add`.
3. Verify that you see the visual changes as illustrated above. (The buttons should be shorter.)

