### PR TITLE
Add product slugs to cart items

### DIFF
--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -185,7 +185,9 @@ export class CartItem extends React.Component {
 		return (
 			<li className="cart-item">
 				<div className="primary-details">
-					<span className="product-name">{ name || translate( 'Loading…' ) }</span>
+					<span className="product-name" data-e2e-product-slug={ cartItem.product_slug }>
+						{ name || translate( 'Loading…' ) }
+					</span>
 					<span className="product-domain">{ this.getProductInfo() }</span>
 				</div>
 


### PR DESCRIPTION
This is required for automated e2e testing to verify we are buying the correct things

No functional changes

**Testing Instructions**

Either during sign up, or on an existing site, add a product or products to the cart and verify in the DOM that the product slug is displayed as a data attribute