### PR TITLE
Display Google My Business nudge only for eligible Jetpack sites

### DIFF
--- a/client/state/selectors/is-google-my-business-stats-nudge-visible.js
+++ b/client/state/selectors/is-google-my-business-stats-nudge-visible.js
@@ -39,7 +39,7 @@ export default function isGoogleMyBusinessStatsNudgeVisible( state, siteId ) {
 
 	if (
 		isJetpackSite( state, siteId ) &&
-		! versionCompare( siteOptions.jetpack_version, '6.2', '>=' )
+		! versionCompare( siteOptions.jetpack_version, '6.1.1', '>=' )
 	) {
 		return false;
 	}

--- a/client/state/selectors/is-google-my-business-stats-nudge-visible.js
+++ b/client/state/selectors/is-google-my-business-stats-nudge-visible.js
@@ -39,7 +39,7 @@ export default function isGoogleMyBusinessStatsNudgeVisible( state, siteId ) {
 
 	if (
 		isJetpackSite( state, siteId ) &&
-		! versionCompare( siteOptions.jetpack_version, '6.1', '>=' )
+		! versionCompare( siteOptions.jetpack_version, '6.2', '>=' )
 	) {
 		return false;
 	}

--- a/client/state/selectors/is-google-my-business-stats-nudge-visible.js
+++ b/client/state/selectors/is-google-my-business-stats-nudge-visible.js
@@ -6,8 +6,11 @@
 import {
 	isGoogleMyBusinessLocationConnected,
 	isSiteGoogleMyBusinessEligible,
+	getSiteOptions,
 } from 'state/selectors';
 import { isRequestingSiteSettings, getSiteSettings } from 'state/site-settings/selectors';
+import versionCompare from 'lib/version-compare';
+import { isJetpackSite } from 'state/sites/selectors';
 
 /**
  * Returns true if the Google My Business (GMB) nudge should be visible in stats
@@ -28,6 +31,16 @@ export default function isGoogleMyBusinessStatsNudgeVisible( state, siteId ) {
 	}
 
 	if ( isGoogleMyBusinessLocationConnected( state, siteId ) ) {
+		return false;
+	}
+
+	// Jetpack site needs to be at least version 6.1 for us to be able to modify site settings
+	const siteOptions = getSiteOptions( state, siteId );
+
+	if (
+		isJetpackSite( state, siteId ) &&
+		! versionCompare( siteOptions.jetpack_version, '6.1', '>=' )
+	) {
 		return false;
 	}
 

--- a/client/state/selectors/is-site-google-my-business-eligible.js
+++ b/client/state/selectors/is-site-google-my-business-eligible.js
@@ -52,7 +52,7 @@ export const siteHasBusinessPlan = createSelector(
  * @param  {String}  siteId The Site ID
  * @return {Boolean} True if site has business plan
  */
-export const siteHasJetpackPlan = createSelector(
+export const siteHasEligibleJetpackPlan = createSelector(
 	( state, siteId ) => {
 		const slug = getSitePlanSlug( state, siteId );
 
@@ -68,9 +68,7 @@ export const siteHasJetpackPlan = createSelector(
  * Returns true if the site is eliglbe to  use Google My Business (GMB)
  *
  * It should be visible if:
- * - site is older than 1 week,
- * - site has a business plan
- * - site has a promote goal
+ * - site has a business plan on wpcom or jetpack premium/business
  * @param  {Object}  state  Global state tree
  * @param  {String}  siteId The Site ID
  * @return {Boolean} True if we should show the nudge
@@ -78,11 +76,11 @@ export const siteHasJetpackPlan = createSelector(
 export default function isSiteGoogleMyBusinessEligible( state, siteId ) {
 	// call-for-testing condition, remove on launch
 	if ( config.isEnabled( 'google-my-business' ) ) {
-		return siteHasBusinessPlan( state, siteId ) || siteHasJetpackPlan( state, siteId );
+		return siteHasBusinessPlan( state, siteId ) || siteHasEligibleJetpackPlan( state, siteId );
 	}
 
 	return (
 		( siteHasBusinessPlan( state, siteId ) && siteHasPromoteGoal( state, siteId ) ) ||
-		siteHasJetpackPlan( state, siteId )
+		siteHasEligibleJetpackPlan( state, siteId )
 	);
 }

--- a/client/state/selectors/is-site-google-my-business-eligible.js
+++ b/client/state/selectors/is-site-google-my-business-eligible.js
@@ -46,7 +46,7 @@ export const siteHasBusinessPlan = createSelector(
 );
 
 /**
- * Returns true if site has business plan
+ * Returns true if site has jetpack premium/business plan
  *
  * @param  {Object}  state  Global state tree
  * @param  {String}  siteId The Site ID

--- a/client/state/selectors/is-site-google-my-business-eligible.js
+++ b/client/state/selectors/is-site-google-my-business-eligible.js
@@ -11,7 +11,7 @@ import config from 'config';
 import createSelector from 'lib/create-selector';
 import { getSiteOption, getSitePlanSlug } from 'state/sites/selectors';
 import { planMatches } from 'lib/plans';
-import { TYPE_BUSINESS, GROUP_WPCOM } from 'lib/plans/constants';
+import { TYPE_BUSINESS, GROUP_WPCOM, GROUP_JETPACK, TYPE_PREMIUM } from 'lib/plans/constants';
 
 /**
  * Returns true if site has promote goal set
@@ -46,6 +46,25 @@ export const siteHasBusinessPlan = createSelector(
 );
 
 /**
+ * Returns true if site has business plan
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {String}  siteId The Site ID
+ * @return {Boolean} True if site has business plan
+ */
+export const siteHasJetpackPlan = createSelector(
+	( state, siteId ) => {
+		const slug = getSitePlanSlug( state, siteId );
+
+		return (
+			planMatches( slug, { group: GROUP_JETPACK, type: TYPE_PREMIUM } ) ||
+			planMatches( slug, { group: GROUP_JETPACK, type: TYPE_BUSINESS } )
+		);
+	},
+	( state, siteId ) => [ getSitePlanSlug( state, siteId ) ]
+);
+
+/**
  * Returns true if the site is eliglbe to  use Google My Business (GMB)
  *
  * It should be visible if:
@@ -59,8 +78,11 @@ export const siteHasBusinessPlan = createSelector(
 export default function isSiteGoogleMyBusinessEligible( state, siteId ) {
 	// call-for-testing condition, remove on launch
 	if ( config.isEnabled( 'google-my-business' ) ) {
-		return siteHasBusinessPlan( state, siteId );
+		return siteHasBusinessPlan( state, siteId ) || siteHasJetpackPlan( state, siteId );
 	}
 
-	return siteHasBusinessPlan( state, siteId ) && siteHasPromoteGoal( state, siteId );
+	return (
+		( siteHasBusinessPlan( state, siteId ) && siteHasPromoteGoal( state, siteId ) ) ||
+		siteHasJetpackPlan( state, siteId )
+	);
 }


### PR DESCRIPTION
This PR limits displaying the nudge to:
* Jetpack version >=6.1.1 && Jetpack plan Premium or Business
* WPCOM with Business plan

#### Testing instructions
  
1. Run `git checkout update/gmb-jetpack` and start your server, or open a [live branch](https://calypso.live/?branch=update/gmb-jetpack)
2. Open the [`Stats` page](http://calypso.localhost:3000/) of an eligible site ( see above )
3. Assert you see the GMB nudge 
4. Repeat steps 1-3 with non eligible site and assert you don't see the nudge.
   
#### Reviews
  
- [ ] Code
- [x] Product
