### PR TITLE
InlineHelp: Add getInlineHelpSupportVariation selector

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -63,7 +63,12 @@ import { isDefaultLocale } from 'lib/i18n-utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryLanguageNames from 'components/data/query-language-names';
-import getInlineHelpSupportVariation from 'state/selectors/get-inline-help-support-variation';
+import getInlineHelpSupportVariation, {
+	SUPPORT_DIRECTLY,
+	SUPPORT_HAPPYCHAT,
+	SUPPORT_TICKET,
+	SUPPORT_FORUM,
+} from 'state/selectors/get-inline-help-support-variation';
 
 const debug = debugFactory( 'calypso:help-contact' );
 
@@ -73,11 +78,6 @@ const debug = debugFactory( 'calypso:help-contact' );
 const defaultLanguageSlug = config( 'i18n_default_locale_slug' );
 const wpcom = wpcomLib.undocumented();
 let savedContactForm = null;
-
-const SUPPORT_DIRECTLY = 'SUPPORT_DIRECTLY';
-const SUPPORT_HAPPYCHAT = 'SUPPORT_HAPPYCHAT';
-const SUPPORT_TICKET = 'SUPPORT_TICKET';
-const SUPPORT_FORUM = 'SUPPORT_FORUM';
 
 const startShowingEaster2018ClosureNoticeAt = i18n.moment( 'Thu, 29 Mar 2018 00:00:00 +0000' );
 const stopShowingEaster2018ClosureNoticeAt = i18n.moment( 'Mon, 2 Apr 2018 00:00:00 +0000' );

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import page from 'page';
 import { connect } from 'react-redux';
 import i18n, { localize } from 'i18n-calypso';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -63,6 +64,8 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryLanguageNames from 'components/data/query-language-names';
 import getInlineHelpSupportVariation from 'state/selectors/get-inline-help-support-variation';
+
+const debug = debugFactory( 'calypso:help-contact' );
 
 /**
  * Module variables
@@ -472,6 +475,8 @@ class HelpContact extends React.Component {
 	getView = () => {
 		const { confirmation } = this.state;
 		const { compact, selectedSitePlanSlug, supportVariation, translate } = this.props;
+
+		debug( { supportVariation } );
 
 		if ( confirmation ) {
 			return <HelpContactConfirmation { ...confirmation } />;

--- a/client/state/selectors/get-inline-help-support-variation.js
+++ b/client/state/selectors/get-inline-help-support-variation.js
@@ -16,7 +16,7 @@ export const SUPPORT_FORUM = 'SUPPORT_FORUM';
 
 /**
  * @param {Object} state Global state tree
- * @return {String} True if current user is able to see the checklist after checkout
+ * @return {String} One of the exported support variation constants listed above
  */
 export default function getSupportVariation( state ) {
 	if (

--- a/client/state/selectors/get-inline-help-support-variation.js
+++ b/client/state/selectors/get-inline-help-support-variation.js
@@ -1,0 +1,39 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { getCurrentUserLocale } from 'state/current-user/selectors';
+import { isDirectlyFailed } from 'state/selectors';
+import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
+import isHappychatUserEligible from 'state/happychat/selectors/is-happychat-user-eligible';
+import { isTicketSupportEligible } from 'state/help/ticket/selectors';
+
+export const SUPPORT_DIRECTLY = 'SUPPORT_DIRECTLY';
+export const SUPPORT_HAPPYCHAT = 'SUPPORT_HAPPYCHAT';
+export const SUPPORT_TICKET = 'SUPPORT_TICKET';
+export const SUPPORT_FORUM = 'SUPPORT_FORUM';
+
+/**
+ * @param {Object} state Global state tree
+ * @return {String} True if current user is able to see the checklist after checkout
+ */
+export default function getSupportVariation( state ) {
+	if (
+		config.isEnabled( 'happychat' ) &&
+		isHappychatAvailable( state ) &&
+		isHappychatUserEligible( state )
+	) {
+		return SUPPORT_HAPPYCHAT;
+	}
+
+	if ( isTicketSupportEligible( state ) ) {
+		return SUPPORT_TICKET;
+	}
+
+	if ( getCurrentUserLocale( state ) === 'en' && ! isDirectlyFailed( state ) ) {
+		return SUPPORT_DIRECTLY;
+	}
+
+	return SUPPORT_FORUM;
+}


### PR DESCRIPTION
### Background

In the inline-help component, we show a button labeled 'Contact Us'. When a customer clicks this button they go forth to a form to fill out that'll do one of many things - most of those things are inline with the 'Contact Us' wording but not always. For instance, one of the outcomes directs the customer to the forums. For this reason I aim to change the buttons label depending on which variation of support  is available right now.

### Summary

This work is a step towards solving the above, it aims to extract the logic found in
`me/help/help-contact/index.jsx` in to a selector that will later be used to determine the label of the 'contact us' button, amongst other things.

### Test Plan

Though this PR is relatively small, testing may be a little tricky as each case depends on certain circumstances being true or false.

Before we start testing, open your terminal and set your debug to:
```js
localStorage.setItem('debug', 'calypso:help-contact');
```
So that we can look for the correct support variation key more easily.

Let's test cases in order of the methods logic...

- First, we'll test for Happychat.
  - Make sure you, or somebody else is available on `hud-staging.happychat.io` (Note: This is the `staging` environment)
  - Make sure you're using an account that is eligible for happychat
  - Click on the inline-help icon and click the 'contact us' button
    - Your console should print: `calypso:help-contact {supportVariation: "SUPPORT_HAPPYCHAT"}`
  - Now, make sure nobody is available on `hud-staging.happychat.io` and repeat the process
    - Your console should not print: `calypso:help-contact {supportVariation: "SUPPORT_HAPPYCHAT"}`
  - Make sure nobody is available on `hud-staging.happychat.io` for all future tests

- Next, lets test ticket support...
  - Log in as a user that has a paid plan of any sort
    - Click on the inline-help icon and click the 'contact us' button
    - Your console should print: `calypso:help-contact {supportVariation: "SUPPORT_TICKET"}` 
  - Log in as a user that only has a free plan
    - Click on the inline-help icon and click the 'contact us' button
    - Your console should not print: `calypso:help-contact {supportVariation: "SUPPORT_TICKET"}` 

- Next, Directly and support forums...
  - Remain Logged in as a user that only has a free plan
  - Make sure the locale is set to 'en'
  - Click on the inline-help icon and click the 'contact us' button
  - Your console should print: `calypso:help-contact {supportVariation: "SUPPORT_DIRECTLY"}` 
 
Note: In the case of the directly/forum tests, there is a 10% chance you will instead see `calypso:help-contact {supportVariation: "SUPPORT_DIRECTLY"}` - there's no good way around this than to create new accounts and re-test. For this reason it's best to look for the `SUPPORT_DIRECTLY` case and trust that the `SUPPORT_FORUM` default return value is returned where the `SUPPORT_DIRECTLY` condition is not met.
 