### PR TITLE
DevDocs: Add information about the siteFragment position

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -75,3 +75,20 @@ This means that instead of `import`ing `page`, you just add a `router` argument 
 (In case you were wondering, the `router` argument is passed to your default-exported function by the magic code found in [`server/bundler/`](../server/bundler/).)
 
 If you're interested in single-tree rendering your section, please proceed to the [Isomorphic Routing docs](isomorphic-routing.md).
+
+## Site specific URLs
+
+When a URL in Calypso is a view that relates to a site, the `site_slug` filter should usually be the last URL fragment. This means that when you remove it you should get all sites views for the same section. For example:
+
+`/posts/drafts/:site.` - If you remove the “site” you should get a view for all sites. Use that principle to determine where the site fragment should be.
+
+
+There are some exceptions to this; if the filter is an id, which is specific to a site—in that case, the site specific resources should go after the site fragment. For example;
+
+`/comment/{ siteFragment }/{ commentId }`
+
+`/post/{ siteFragment }/{ postId }`
+
+
+Our code supports last, second to last, and for some exceptions, using a :site parameter.
+


### PR DESCRIPTION
After several discussions on Slack we realized that this isn't documented anywhere, so this is addressing that.

To test go to: http://calypso.localhost:3000/devdocs/docs/routing.md

Fixes #24071