### PR TITLE
Devdocs: Add links to external resources

### DIFF
--- a/client/devdocs/design/typography.jsx
+++ b/client/devdocs/design/typography.jsx
@@ -11,6 +11,7 @@ import React from 'react';
  */
 import Card from 'components/card';
 import DocumentHead from 'components/data/document-head';
+import ExternalLink from 'components/external-link';
 import Main from 'components/main';
 
 export default class Typography extends React.PureComponent {
@@ -23,6 +24,13 @@ export default class Typography extends React.PureComponent {
 
 				<div className="design__typography-content devdocs__doc-content">
 					<h1>Typography</h1>
+					<p>
+						These guidlines are based on the{' '}
+						<ExternalLink icon={ true } href="https://dotcombrand.wordpress.com/typography/">
+							WordPress.com Brand Guide
+						</ExternalLink>.
+					</p>
+
 					<h2>Interface Typography</h2>
 
 					<p>

--- a/docs/icons.md
+++ b/docs/icons.md
@@ -1,6 +1,6 @@
 # Icons
 
-This document will cover how to use icons in Calypso, as well as how to create icons for the native apps, favicons, and bookmark touch icons.
+This document will cover how to use icons in Calypso, as well as how to create icons for the native apps, favicons, and bookmark touch icons. These guidelines are based on the [WordPress.com Brand Guide](https://dotcombrand.wordpress.com/iconography/).
 
 ## Gridicons
 


### PR DESCRIPTION
This is to encourage keeping Calypso aligned with the Brand Guide. Fixes #24059