### PR TITLE
Inline Help:  Make contact us button dynamic

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -24,6 +24,9 @@ import InlineHelpRichResult from './inline-help-rich-result';
 import HelpContact from 'me/help/help-contact';
 import { getSearchQuery, getInlineHelpCurrentlySelectedResult } from 'state/inline-help/selectors';
 import { getHelpSelectedSite } from 'state/help/selectors';
+import getInlineHelpSupportVariation, {
+	SUPPORT_FORUM,
+} from 'state/selectors/get-inline-help-support-variation';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
@@ -88,9 +91,15 @@ class InlineHelpPopover extends Component {
 	};
 
 	render() {
-		const { translate } = this.props;
+		const { supportVariation, translate } = this.props;
 		const { showSecondaryView } = this.state;
 		const popoverClasses = { 'is-secondary-view-active': showSecondaryView };
+
+		const isForumSupportVariation = supportVariation === SUPPORT_FORUM;
+
+		const secondaryViewButtonLabel = isForumSupportVariation
+			? translate( 'Support Forums' )
+			: translate( 'Contact us' );
 
 		return (
 			<Popover
@@ -130,7 +139,7 @@ class InlineHelpPopover extends Component {
 						borderless
 					>
 						<Gridicon icon="chat" className="inline-help__gridicon-left" />
-						{ translate( 'Contact us' ) }
+						{ secondaryViewButtonLabel }
 						<Gridicon icon="chevron-right" className="inline-help__gridicon-right" />
 					</Button>
 
@@ -153,6 +162,7 @@ export default connect(
 		searchQuery: getSearchQuery( state ),
 		selectedSite: getHelpSelectedSite( state ),
 		selectedResult: getInlineHelpCurrentlySelectedResult( state ),
+		supportVariation: getInlineHelpSupportVariation( state ),
 	} ),
 	{
 		recordTracksEvent,

--- a/client/state/selectors/get-inline-help-support-variation.js
+++ b/client/state/selectors/get-inline-help-support-variation.js
@@ -9,10 +9,10 @@ import isHappychatAvailable from 'state/happychat/selectors/is-happychat-availab
 import isHappychatUserEligible from 'state/happychat/selectors/is-happychat-user-eligible';
 import { isTicketSupportEligible } from 'state/help/ticket/selectors';
 
-const SUPPORT_DIRECTLY = 'SUPPORT_DIRECTLY';
-const SUPPORT_HAPPYCHAT = 'SUPPORT_HAPPYCHAT';
-const SUPPORT_TICKET = 'SUPPORT_TICKET';
-const SUPPORT_FORUM = 'SUPPORT_FORUM';
+export const SUPPORT_DIRECTLY = 'SUPPORT_DIRECTLY';
+export const SUPPORT_HAPPYCHAT = 'SUPPORT_HAPPYCHAT';
+export const SUPPORT_TICKET = 'SUPPORT_TICKET';
+export const SUPPORT_FORUM = 'SUPPORT_FORUM';
 
 /**
  * @param {Object} state Global state tree


### PR DESCRIPTION
_Note: This PR is pointed at #24583, once #24583 this PR should point to master_

### Summary

In the inline-help component, we show a button labeled 'Contact Us'. When a customer clicks this button they go forth to a form to fill out that'll do one of many things - most of those things are inline with the 'Contact Us' wording but not always. For instance, one of the outcomes directs the customer to the forums.
This PR aims to make the buttons label dynamic depending on which variation of support  is available right now.

### Test Plan

In order to see the dynamic button we need for the selector to return `SUPPORT_FORUM`.
The simple way is as follows:

- Change `get-inline-help-support-variation.js` to always return `SUPPORT_FORUM`
- Click on the inlin-help <kbd>?</kbd> button
  - You should see 'Forums' (copy needs to be finalised)

I'm open to hear of a better test plan though as this method requires code intervention and thus isn't really a good representation of the behaviour.
