### PR TITLE
Sidebar: Switching the customize and theme links around in the sidebar.

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -215,21 +215,21 @@ export class MySitesSidebar extends Component {
 
 		return (
 			<SidebarItem
-				label={ translate( 'Themes' ) }
-				tipTarget="themes"
-				selected={ itemLinkMatches( '/themes', path ) }
-				link={ themesLink }
-				onNavigate={ this.trackThemesClick }
-				icon="themes"
-				preloadSectionName="themes"
+				label={ translate( 'Customize' ) }
+				tipTarget="customize"
+				selected={ itemLinkMatches( '/customize', path ) }
+				link={ this.props.customizeUrl }
+				//onNavigate={ this.trackThemesClick }
+				icon="customize"
+				preloadSectionName="customize"
 			>
 				<SidebarButton
-					onClick={ this.trackSidebarButtonClick( 'customize' ) }
-					href={ this.props.customizeUrl }
-					preloadSectionName="customize"
+					//onClick={ this.trackSidebarButtonClick( 'customize' ) }
+					href={ themesLink }
+					preloadSectionName="themes"
 					forceTargetInternal
 				>
-					{ this.props.translate( 'Customize' ) }
+					{ this.props.translate( 'Themes' ) }
 				</SidebarButton>
 			</SidebarItem>
 		);

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -222,6 +222,7 @@ export class MySitesSidebar extends Component {
 				onNavigate={ this.trackCustomizeClick }
 				icon="customize"
 				preloadSectionName="customize"
+				forceInternalLink
 			>
 				<SidebarButton
 					onClick={ this.trackSidebarButtonClick( 'themes' ) }

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -187,8 +187,8 @@ export class MySitesSidebar extends Component {
 		);
 	}
 
-	trackThemesClick = () => {
-		this.trackMenuItemClick( 'themes' );
+	trackCustomizeClick = () => {
+		this.trackMenuItemClick( 'customize' );
 		this.onNavigate();
 	};
 
@@ -219,12 +219,12 @@ export class MySitesSidebar extends Component {
 				tipTarget="themes"
 				selected={ itemLinkMatches( '/customize', path ) }
 				link={ this.props.customizeUrl }
-				//onNavigate={ this.trackThemesClick }
+				onNavigate={ this.trackCustomizeClick }
 				icon="customize"
 				preloadSectionName="customize"
 			>
 				<SidebarButton
-					//onClick={ this.trackSidebarButtonClick( 'customize' ) }
+					onClick={ this.trackSidebarButtonClick( 'themes' ) }
 					href={ themesLink }
 					preloadSectionName="themes"
 					forceTargetInternal

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -216,7 +216,7 @@ export class MySitesSidebar extends Component {
 		return (
 			<SidebarItem
 				label={ translate( 'Customize' ) }
-				tipTarget="customize"
+				tipTarget="themes"
 				selected={ itemLinkMatches( '/customize', path ) }
 				link={ this.props.customizeUrl }
 				//onNavigate={ this.trackThemesClick }


### PR DESCRIPTION
Context: let's switch the Customize and Themes buttons in the sidebar.

(From Lance: This was planned for a future navigation rework, but we'd like to pull this one change out sooner and do it now.)

Here's the before:
<img width="273" alt="screen shot 2018-05-01 at 9 55 09 am" src="https://user-images.githubusercontent.com/191598/39475309-ccd264cc-4d25-11e8-8763-f73f1f7ded0a.png">

And here's the after:
<img width="275" alt="screen shot 2018-05-01 at 9 54 58 am" src="https://user-images.githubusercontent.com/191598/39475318-d2790b4c-4d25-11e8-877b-5daf090dac50.png">
