### PR TITLE
Store: Fix product-category list & search results

### DIFF
--- a/client/extensions/woocommerce/app/product-categories/index.js
+++ b/client/extensions/woocommerce/app/product-categories/index.js
@@ -54,8 +54,12 @@ class ProductCategories extends Component {
 		const { site } = this.props;
 		const { searchQuery } = this.state;
 
-		const requestedPages = searchQuery && searchQuery.length && this.state.requestedSearchPages || this.state.requestedPages;
-		const stateName = searchQuery && searchQuery.length && 'requestedSearchPages' || 'requestedPages';
+		let stateName = 'requestedPages';
+		if ( searchQuery && searchQuery.length ) {
+			// We're viewing search results, and should use the search value
+			stateName = 'requestedSearchPages';
+		}
+		const requestedPages = this.state[ stateName ];
 
 		pages.forEach( page => {
 			if ( ! includes( requestedPages, page ) ) {

--- a/client/extensions/woocommerce/app/product-categories/list.js
+++ b/client/extensions/woocommerce/app/product-categories/list.js
@@ -15,9 +15,10 @@ import WindowScroller from 'react-virtualized/WindowScroller';
  */
 import {
 	areAnyProductCategoriesLoading,
-	getProductCategoriesLastPage,
-	getAllProductCategories,
 	areProductCategoriesLoaded,
+	getAllProductCategories,
+	getAllProductCategoriesBySearch,
+	getProductCategoriesLastPage,
 	getTotalProductCategories,
 } from 'woocommerce/state/sites/product-categories/selectors';
 import Count from 'components/count';
@@ -179,15 +180,17 @@ class ProductCategories extends Component {
 
 function mapStateToProps( state, ownProps ) {
 	const { searchQuery } = ownProps;
-	let query = {};
+	const query = {};
 	if ( searchQuery && searchQuery.length ) {
-		query = { search: searchQuery, ...query };
+		query.search = searchQuery;
 	}
 
 	const site = getSelectedSiteWithFallback( state );
-	const loading = areAnyProductCategoriesLoading( state, query );
+	const loading = areAnyProductCategoriesLoading( state );
 	const isInitialRequestLoaded = areProductCategoriesLoaded( state, query ); // first page request
-	const categories = getAllProductCategories( state, query );
+	const categories = query.search
+		? getAllProductCategoriesBySearch( state, query.search )
+		: getAllProductCategories( state );
 	const totalCategories = getTotalProductCategories( state, query );
 	const lastPage = getProductCategoriesLastPage( state, query );
 	return {

--- a/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/applies-to-filtered-list.js
+++ b/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/applies-to-filtered-list.js
@@ -289,7 +289,7 @@ function mapStateToProps( state ) {
 	const siteId = site ? site.ID : null;
 	const productsLoading = areProductsLoading( state, siteId );
 	const products = productsLoading ? null : getAllProducts( state, siteId );
-	const productCategories = getAllProductCategories( state, {}, siteId );
+	const productCategories = getAllProductCategories( state, siteId );
 
 	// TODO: This is temporary, as it's not used anymore.
 	const nonVariableProducts =

--- a/client/extensions/woocommerce/state/sites/product-categories/README.md
+++ b/client/extensions/woocommerce/state/sites/product-categories/README.md
@@ -86,6 +86,6 @@ Returns the last page number of results for a query. Optional `siteId`, will def
 
 Similar to `areProductCategoriesLoading`, this selector returns if a given request is being loaded for a query, ignoring the page parameter -- meaning this will return if there is a pending request for a certain query on any page of results. Optional `siteId`, will default to the currently selected site.
 
-### `getAllProductCategories( state, query: object, siteId: number )`
+### `getAllProductCategories( state, siteId: number )`
 
-Similar to `getProductCategories`, this selector returns all results from a particular query, across all loaded pages. Optional `siteId`, will default to the currently selected site.
+Similar to `getProductCategories`, this selector returns all results across all loaded pages. Optional `siteId`, will default to the currently selected site.

--- a/client/extensions/woocommerce/state/sites/product-categories/README.md
+++ b/client/extensions/woocommerce/state/sites/product-categories/README.md
@@ -82,9 +82,9 @@ Gets the total number of product categories available on a site for a query. Opt
 
 Returns the last page number of results for a query. Optional `siteId`, will default to the currently selected site.
 
-### `areAnyProductCategoriesLoading( state, query: object, siteId: number )`
+### `areAnyProductCategoriesLoading( state, siteId: number )`
 
-Similar to `areProductCategoriesLoading`, this selector returns if a given request is being loaded for a query, ignoring the page parameter -- meaning this will return if there is a pending request for a certain query on any page of results. Optional `siteId`, will default to the currently selected site.
+Similar to `areProductCategoriesLoading`, this selector returns if any given request is being loaded from a site -- meaning this will return if there is a pending request for any query against a site. Optional `siteId`, will default to the currently selected site.
 
 ### `getAllProductCategories( state, siteId: number )`
 

--- a/client/extensions/woocommerce/state/sites/product-categories/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/selectors.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { get, isArray, omit, range, values } from 'lodash';
+import { get, isArray, omit, some, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -56,28 +56,15 @@ export function areProductCategoriesLoading(
 }
 
 /**
- * Returns true if currently requesting product categories for a query, excluding all known
- * queried pages, or false otherwise.
+ * Returns true if currently requesting product categories for any query, or false otherwise.
  *
  * @param {Object} state Whole Redux state tree
- * @param {Object} [query] Query used to fetch product categories. If not provided, API defaults are used.
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
- * @return {Boolean}       Returns true if currently requesting product categories for a query, excluding all known queried pages.
+ * @return {Boolean}       Returns true if currently requesting product categories for any query
  */
-export function areAnyProductCategoriesLoading(
-	state,
-	query = {},
-	siteId = getSelectedSiteId( state )
-) {
-	const lastPage = getProductCategoriesLastPage( state, query, siteId );
-	if ( null === lastPage ) {
-		return false;
-	}
-
-	return range( 1, lastPage + 1 ).some( page => {
-		const catQuery = { ...query, page };
-		return areProductCategoriesLoading( state, catQuery, siteId );
-	} );
+export function areAnyProductCategoriesLoading( state, siteId = getSelectedSiteId( state ) ) {
+	const categoryState = getRawCategoryState( state, siteId );
+	return some( categoryState.isQueryLoading );
 }
 
 /**

--- a/client/extensions/woocommerce/state/sites/product-categories/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/selectors.js
@@ -122,24 +122,14 @@ export function getProductCategories( state, query = {}, siteId = getSelectedSit
 }
 
 /**
- * Gets all product categories from API data for a query, ignoring pages.
+ * Gets all product categories from API data, as currently loaded in the state (might not
+ * be all the products on the remote site, if they haven't all been requested).
  *
  * @param {Object} state Global state tree
- * @param {Object} [query] Query used to fetch product categories. If not provided, API defaults are used.
  * @param {Number} [siteId] wpcom site id, if not provided, uses the selected site id.
  * @return {Array} List of product categories
  */
-export function getAllProductCategories( state, query = {}, siteId = getSelectedSiteId( state ) ) {
-	const loading = areAnyProductCategoriesLoading( state, query, siteId );
-	if ( loading ) {
-		return [];
-	}
-
-	const lastPage = getProductCategoriesLastPage( state, query, siteId );
-	if ( null === lastPage ) {
-		return [];
-	}
-
+export function getAllProductCategories( state, siteId = getSelectedSiteId( state ) ) {
 	const categoryState = getRawCategoryState( state, siteId );
 	const items = values( categoryState.items ) || [];
 	return items.map( cat => getProductCategory( state, cat.id, siteId ) );

--- a/client/extensions/woocommerce/state/sites/product-categories/test/fixtures/categories.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/fixtures/categories.js
@@ -21,16 +21,6 @@ const site1 = {
 	totalPages: {},
 };
 
-const site4 = {
-	isQueryLoading: {
-		'{}': true,
-	},
-	items: [],
-	queries: {},
-	total: {},
-	totalPages: {},
-};
-
 const site2 = {
 	isQueryLoading: {
 		'{}': false,
@@ -69,6 +59,58 @@ const site3 = {
 	},
 };
 
+const site4 = {
+	isQueryLoading: {
+		'{}': true,
+	},
+	items: [],
+	queries: {},
+	total: {},
+	totalPages: {},
+};
+
+const site5 = {
+	isQueryLoading: {
+		'{"search":"test"}': false,
+		'{"search":"test","page":2}': false,
+	},
+	items: {
+		1: categories[ 0 ],
+		2: categories[ 1 ],
+		5: categories[ 4 ],
+		6: categories[ 5 ],
+	},
+	queries: {
+		'{"search":"test"}': [ 1, 2 ],
+		'{"search":"test","page":2}': [ 5, 6 ],
+	},
+	total: {
+		'{"search":"test"}': 4,
+	},
+	totalPages: {
+		'{"search":"test"}': 2,
+	},
+};
+
+const site6 = {
+	isQueryLoading: {
+		'{"search":"test"}': false,
+	},
+	items: {
+		1: categories[ 0 ],
+		2: categories[ 1 ],
+	},
+	queries: {
+		'{"search":"test"}': [ 1, 2 ],
+	},
+	total: {
+		'{"search":"test"}': 8,
+	},
+	totalPages: {
+		'{"search":"test"}': 4,
+	},
+};
+
 export default {
 	sites: {
 		'site.one': {
@@ -82,6 +124,12 @@ export default {
 		},
 		'site.four': {
 			productCategories: site4,
+		},
+		'site.five': {
+			productCategories: site5,
+		},
+		'site.six': {
+			productCategories: site6,
 		},
 	},
 };

--- a/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
@@ -16,6 +16,7 @@ import {
 	getProductCategory,
 	getProductCategories,
 	getAllProductCategories,
+	getAllProductCategoriesBySearch,
 	getProductCategoriesLastPage,
 	getTotalProductCategories,
 } from '../selectors';
@@ -23,11 +24,12 @@ import woocommerce from './fixtures/categories';
 const state = deepFreeze( { extensions: { woocommerce } } );
 
 /*
- * state.extensions.woocommerce.sites has four sites:
+ * state.extensions.woocommerce.sites has five sites:
  *  - site.one: nothing loaded yet
  *  - site.two: 1 page of categories loaded, 1 still loadingState
  *  - site.three: 2 pages of categories loaded
  *  - site.four: first page of categories is loading
+ *  - site.five: all results for a given search are loaded
  */
 
 describe( 'selectors', () => {
@@ -135,6 +137,29 @@ describe( 'selectors', () => {
 				{ id: 2, label: 'cat2', name: 'cat2', slug: 'cat-2', parent: 0 },
 				{ id: 3, label: 'cat2 - cat3', name: 'cat3', slug: 'cat-3', parent: 2 },
 				{ id: 4, label: 'cat2 - cat3 - cat4', name: 'cat4', slug: 'cat-4', parent: 3 },
+				{ id: 5, label: 'cat5', name: 'cat5', slug: 'cat-5', parent: 0 },
+				{ id: 6, label: 'cat6', name: 'cat6', slug: 'cat-6', parent: 0 },
+			] );
+		} );
+	} );
+
+	describe( '#getAllProductCategoriesBySearch()', () => {
+		test( 'should return an empty array if no search queries are loaded.', () => {
+			expect( getAllProductCategoriesBySearch( state, 'test', 'site.one' ) ).to.eql( [] );
+		} );
+
+		test( 'should return the existing categories as an array if more data is loading.', () => {
+			expect( getAllProductCategoriesBySearch( state, 'test', 'site.six' ) ).to.eql( [
+				{ id: 1, label: 'cat1', name: 'cat1', slug: 'cat-1', parent: 0 },
+				{ id: 2, label: 'cat2', name: 'cat2', slug: 'cat-2', parent: 0 },
+			] );
+		} );
+
+		test( 'should get all product categories from specified site', () => {
+			expect( getAllProductCategoriesBySearch( state, 'test', 'site.five' ) ).to.have.lengthOf( 4 );
+			expect( getAllProductCategoriesBySearch( state, 'test', 'site.five' ) ).to.eql( [
+				{ id: 1, label: 'cat1', name: 'cat1', slug: 'cat-1', parent: 0 },
+				{ id: 2, label: 'cat2', name: 'cat2', slug: 'cat-2', parent: 0 },
 				{ id: 5, label: 'cat5', name: 'cat5', slug: 'cat-5', parent: 0 },
 				{ id: 6, label: 'cat6', name: 'cat6', slug: 'cat-6', parent: 0 },
 			] );

--- a/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
@@ -123,16 +123,19 @@ describe( 'selectors', () => {
 
 	describe( '#getAllProductCategories()', () => {
 		test( 'should return an empty array if data is not available.', () => {
-			expect( getAllProductCategories( state, {}, 'site.one' ) ).to.eql( [] );
+			expect( getAllProductCategories( state, 'site.one' ) ).to.eql( [] );
 		} );
 
-		test( 'should return an empty array if data is still loading.', () => {
-			expect( getAllProductCategories( state, {}, 'site.two' ) ).to.eql( [] );
+		test( 'should return the existing categories as an array if more data is loading.', () => {
+			expect( getAllProductCategories( state, 'site.two' ) ).to.eql( [
+				{ id: 1, label: 'cat1', name: 'cat1', slug: 'cat-1', parent: 0 },
+				{ id: 2, label: 'cat2', name: 'cat2', slug: 'cat-2', parent: 0 },
+			] );
 		} );
 
 		test( 'should get all product categories from specified site', () => {
-			expect( getAllProductCategories( state, {}, 'site.three' ) ).to.have.lengthOf( 6 );
-			expect( getAllProductCategories( state, {}, 'site.three' ) ).to.eql( [
+			expect( getAllProductCategories( state, 'site.three' ) ).to.have.lengthOf( 6 );
+			expect( getAllProductCategories( state, 'site.three' ) ).to.eql( [
 				{ id: 1, label: 'cat1', name: 'cat1', slug: 'cat-1', parent: 0 },
 				{ id: 2, label: 'cat2', name: 'cat2', slug: 'cat-2', parent: 0 },
 				{ id: 3, label: 'cat2 - cat3', name: 'cat3', slug: 'cat-3', parent: 2 },

--- a/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
@@ -61,21 +61,16 @@ describe( 'selectors', () => {
 
 	describe( '#areAnyProductCategoriesLoading', () => {
 		test( 'should be false when state is not available.', () => {
-			expect( areAnyProductCategoriesLoading( state, {}, 'site.one' ) ).to.be.false;
+			expect( areAnyProductCategoriesLoading( state, 'site.one' ) ).to.be.false;
 		} );
 
 		test( 'should be true when any page of categories are currently being fetched.', () => {
 			// page 2 is currently being fetched, but this selector ignores page
-			expect( areAnyProductCategoriesLoading( state, {}, 'site.two' ) ).to.be.true;
-		} );
-
-		test( 'should be true when categories are currently being fetched, and passed a page parameter.', () => {
-			// page 2 is currently being fetched, but this selector ignores page
-			expect( areAnyProductCategoriesLoading( state, { page: 2 }, 'site.two' ) ).to.be.true;
+			expect( areAnyProductCategoriesLoading( state, 'site.two' ) ).to.be.true;
 		} );
 
 		test( 'should be false when categories are loaded.', () => {
-			expect( areAnyProductCategoriesLoading( state, {}, 'site.three' ) ).to.be.false;
+			expect( areAnyProductCategoriesLoading( state, 'site.three' ) ).to.be.false;
 		} );
 	} );
 

--- a/client/extensions/woocommerce/state/ui/product-categories/selectors.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/selectors.js
@@ -80,7 +80,7 @@ export function getProductCategoryWithLocalEdits(
  */
 export function getProductCategoriesWithLocalEdits( state, siteId = getSelectedSiteId( state ) ) {
 	const categoryCreates = getAllProductCategoryEdits( state, siteId ).creates || [];
-	const fetchedCategories = getAllProductCategories( state, {}, siteId );
+	const fetchedCategories = getAllProductCategories( state, siteId );
 	const categoriesWithUpdates = fetchedCategories.map( c =>
 		getProductCategoryWithLocalEdits( state, c.id, siteId )
 	);


### PR DESCRIPTION
This fixes the product category list issue caused by #24540 (not a problem in master) - I've added this as a new PR since it's a bigger change, but this will be merged into #24540 before that's merged to master. The issue:

>This is testing well everywhere except on `/store/products/categories/:site`. [...] as you scroll, the entire results disappear.

You can replicate that by reducing the per-page count in [utils.js](https://github.com/Automattic/wp-calypso/blob/master/client/extensions/woocommerce/state/sites/product-categories/utils.js#L12), then shrinking your browser height so that the VirtualList doesn't load everything. Once you scroll, VirtualList queries for the next "page" of results. Previously, this triggered the loading state, which caused the "get all" selector return an empty array. This is fixed by always returning the items we have, even when some queries are still loading.

I've removed the query param from `getAllProductCategories`, since it was ignored. I've also added a new selector to get all product categories returned for a given search term, `getAllProductCategoriesBySearch`. The tests for these selectors have been updated.

To test:

- Check that the product categories page does not disappear when scrolling
- Make sure search results return the expected categories
