### PR TITLE
Importer: Move to redux currentUser from lib/user

### DIFF
--- a/client/components/gravatar/index.jsx
+++ b/client/components/gravatar/index.jsx
@@ -74,7 +74,7 @@ export class Gravatar extends Component {
 			return <span className="gravatar is-missing" />;
 		}
 
-		const altText = alt || user.display_name;
+		const altText = alt || user.display_name || user.name;
 		const avatarURL = tempImage || this.getResizedImageURL( safeImageURL( user.avatar_URL ) );
 		const classes = classnames( 'gravatar', this.props.className );
 

--- a/client/components/gravatar/test/index.jsx
+++ b/client/components/gravatar/test/index.jsx
@@ -37,6 +37,7 @@ describe( 'Gravatar', () => {
 			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
 			expect( img.prop( 'width' ) ).to.equal( 32 );
 			expect( img.prop( 'height' ) ).to.equal( 32 );
+			expect( img.prop( 'alt' ) ).to.equal( 'Bob The Tester' );
 		} );
 
 		test( 'should update the width and height when given a size attribute', () => {
@@ -48,6 +49,7 @@ describe( 'Gravatar', () => {
 			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
 			expect( img.prop( 'width' ) ).to.equal( 100 );
 			expect( img.prop( 'height' ) ).to.equal( 100 );
+			expect( img.prop( 'alt' ) ).to.equal( 'Bob The Tester' );
 		} );
 
 		test( 'should update source image when given imgSize attribute', () => {
@@ -61,6 +63,7 @@ describe( 'Gravatar', () => {
 			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
 			expect( img.prop( 'width' ) ).to.equal( 32 );
 			expect( img.prop( 'height' ) ).to.equal( 32 );
+			expect( img.prop( 'alt' ) ).to.equal( 'Bob The Tester' );
 		} );
 
 		test( 'should serve a default image if no avatar_URL available', () => {
@@ -73,6 +76,40 @@ describe( 'Gravatar', () => {
 			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
 			expect( img.prop( 'width' ) ).to.equal( 32 );
 			expect( img.prop( 'height' ) ).to.equal( 32 );
+			expect( img.prop( 'alt' ) ).to.equal( 'Bob The Tester' );
+		} );
+
+		test( 'should also pick up the default alt from the name prop', () => {
+			const userFromSiteApi = {
+				avatar_URL: avatarUrl,
+				name: 'Bob The Tester',
+			};
+			const gravatar = shallow( <Gravatar user={ userFromSiteApi } /> );
+			const img = gravatar.find( 'img' );
+
+			expect( img.length ).to.equal( 1 );
+			expect( img.prop( 'src' ) ).to.equal( avatarUrl );
+			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
+			expect( img.prop( 'width' ) ).to.equal( 32 );
+			expect( img.prop( 'height' ) ).to.equal( 32 );
+			expect( img.prop( 'alt' ) ).to.equal( 'Bob The Tester' );
+		} );
+
+		test( 'should prefer display_name for the alt', () => {
+			const userFromSiteApi = {
+				avatar_URL: avatarUrl,
+				name: 'Bob The Tester',
+				display_name: 'Bob',
+			};
+			const gravatar = shallow( <Gravatar user={ userFromSiteApi } /> );
+			const img = gravatar.find( 'img' );
+
+			expect( img.length ).to.equal( 1 );
+			expect( img.prop( 'src' ) ).to.equal( avatarUrl );
+			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
+			expect( img.prop( 'width' ) ).to.equal( 32 );
+			expect( img.prop( 'height' ) ).to.equal( 32 );
+			expect( img.prop( 'alt' ) ).to.equal( 'Bob' );
 		} );
 
 		test( 'should allow overriding the alt attribute', () => {

--- a/client/components/user/index.jsx
+++ b/client/components/user/index.jsx
@@ -21,7 +21,7 @@ export default class User extends Component {
 
 	render() {
 		const user = this.props.user || null;
-		const name = user ? user.name || user.display_name : '';
+		const name = user ? user.display_name || user.name : '';
 		return (
 			<div className="user" title={ name }>
 				<Gravatar size={ 26 } user={ user } />

--- a/client/components/user/index.jsx
+++ b/client/components/user/index.jsx
@@ -12,8 +12,8 @@ import PropTypes from 'prop-types';
  */
 import Gravatar from 'components/gravatar';
 
-export default class UserItem extends Component {
-	static displayName = 'UserItem';
+export default class User extends Component {
+	static displayName = 'User';
 
 	static propTypes = {
 		user: PropTypes.object,
@@ -21,7 +21,7 @@ export default class UserItem extends Component {
 
 	render() {
 		const user = this.props.user || null;
-		const name = user ? user.name : '';
+		const name = user ? user.name || user.display_name : '';
 		return (
 			<div className="user" title={ name }>
 				<Gravatar size={ 26 } user={ user } />

--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -35,7 +35,7 @@ class ImporterAuthorMapping extends React.Component {
 		currentUser: PropTypes.object,
 	};
 
-	componentWillMount() {
+	componentDidMount() {
 		const { hasSingleAuthor, onSelect: selectAuthor } = this.props;
 
 		if ( hasSingleAuthor ) {
@@ -52,6 +52,7 @@ class ImporterAuthorMapping extends React.Component {
 				name,
 				mappedTo: selectedAuthor = { name: /* Don't translate yet */ 'Choose an author…' },
 			},
+			currentUser,
 		} = this.props;
 
 		return (
@@ -63,13 +64,13 @@ class ImporterAuthorMapping extends React.Component {
 						<User user={ selectedAuthor } />
 					</AuthorSelector>
 				) : (
-					<User user={ this.getCurrentUser() } />
+					<User user={ currentUser } />
 				) }
 			</div>
 		);
 	}
 }
 
-export default connect( state => ( { currentUser: getCurrentUser( state ) } ) )(
-	ImporterAuthorMapping
-);
+export default connect( state => ( {
+	currentUser: getCurrentUser( state ),
+} ) )( ImporterAuthorMapping );

--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -13,7 +13,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import AuthorSelector from 'blocks/author-selector';
-import UserItem from 'components/user';
+import User from 'components/user';
 import { getCurrentUser } from 'state/current-user/selectors';
 
 class ImporterAuthorMapping extends React.Component {
@@ -32,20 +32,16 @@ class ImporterAuthorMapping extends React.Component {
 				avatar_URL: PropTypes.string.isRequired,
 			} ),
 		} ).isRequired,
+		currentUser: PropTypes.object,
 	};
 
 	componentWillMount() {
 		const { hasSingleAuthor, onSelect: selectAuthor } = this.props;
 
 		if ( hasSingleAuthor ) {
-			selectAuthor( this.getCurrentUser() );
+			selectAuthor( this.props.currentUser );
 		}
 	}
-
-	getCurrentUser = () => ( {
-		...this.props.currentUser,
-		name: this.props.currentUser.display_name,
-	} );
 
 	render() {
 		const {
@@ -64,10 +60,10 @@ class ImporterAuthorMapping extends React.Component {
 				<Gridicon className="importer__mapping-relation" icon="arrow-right" />
 				{ ! hasSingleAuthor ? (
 					<AuthorSelector siteId={ siteId } onSelect={ onSelect }>
-						<UserItem user={ selectedAuthor } />
+						<User user={ selectedAuthor } />
 					</AuthorSelector>
 				) : (
-					<UserItem user={ this.getCurrentUser() } />
+					<User user={ this.getCurrentUser() } />
 				) }
 			</div>
 		);

--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -7,15 +7,16 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import AuthorSelector from 'blocks/author-selector';
 import UserItem from 'components/user';
-import user from 'lib/user';
+import { getCurrentUser } from 'state/current-user/selectors';
 
-export default class extends React.PureComponent {
+class ImporterAuthorMapping extends React.Component {
 	static displayName = 'ImporterAuthorMapping';
 
 	static propTypes = {
@@ -41,11 +42,10 @@ export default class extends React.PureComponent {
 		}
 	}
 
-	getCurrentUser = () => {
-		const currentUser = user().get();
-
-		return Object.assign( {}, currentUser, { name: currentUser.display_name } );
-	};
+	getCurrentUser = () => ( {
+		...this.props.currentUser,
+		name: this.props.currentUser.display_name,
+	} );
 
 	render() {
 		const {
@@ -73,3 +73,7 @@ export default class extends React.PureComponent {
 		);
 	}
 }
+
+export default connect( state => ( { currentUser: getCurrentUser( state ) } ) )(
+	ImporterAuthorMapping
+);


### PR DESCRIPTION
Part of #24004 

Replaces lib/user usage with redux's current user when mapping a user during import.

To test, try to import a site using the site importer. The current user should appear in the user mapping step as a valid option with the display name filled in.