### PR TITLE
Checkout: Switch to redux from lib/user for user info

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import { connect } from 'react-redux';
 import i18n from 'i18n-calypso';
 
 /**
@@ -12,11 +13,9 @@ import i18n from 'i18n-calypso';
  */
 import { GOOGLE_APPS_LEARNING_CENTER } from 'lib/url/support';
 import PurchaseDetail from 'components/purchase-detail';
-import userFactory from 'lib/user';
+import { getCurrentUser } from 'state/current-user/selectors';
 
-const user = userFactory();
-
-const GoogleAppsDetails = () => {
+const GoogleAppsDetails = ( { user } ) => {
 	return (
 		<PurchaseDetail
 			icon="mail"
@@ -38,7 +37,7 @@ const GoogleAppsDetails = () => {
 						),
 					},
 					args: {
-						email: user.get().email,
+						email: user.email,
 					},
 				}
 			) }
@@ -48,4 +47,4 @@ const GoogleAppsDetails = () => {
 	);
 };
 
-export default GoogleAppsDetails;
+export default connect( state => ( { user: getCurrentUser( state ) } ) )( GoogleAppsDetails );

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-plan-details.jsx
@@ -10,20 +10,19 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import PurchaseDetail from 'components/purchase-detail';
-import userFactory from 'lib/user';
 import { getSiteFileModDisableReason } from 'lib/site/utils';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getCurrentUser } from 'state/current-user/selectors';
 import config from 'config';
-const user = userFactory();
 
-const BasicDetails = ( { translate } ) => (
+const BasicDetails = ( { translate, user } ) => (
 	<PurchaseDetail
 		icon="cog"
 		title={ translate( 'Set up your VaultPress and Akismet accounts' ) }
 		description={ translate(
 			'We emailed you at %(email)s with information for setting up Akismet and VaultPress on your site. ' +
 				'Follow the instructions in the email to get started.',
-			{ args: { email: user.get().email } }
+			{ args: { email: user.email } }
 		) }
 	/>
 );
@@ -135,6 +134,6 @@ const JetpackPlanDetails = config.isEnabled( 'manage/plugins/setup' )
 			null,
 			mapDispatchToProps
 	  )( EnhancedDetails )
-	: BasicDetails;
+	: connect( state => ( { user: getCurrentUser( state ) } ) )( BasicDetails );
 
 export default localize( JetpackPlanDetails );


### PR DESCRIPTION
Moves the thank you pages for jetpack and google apps from lib/user to the redux `currentUser`

I'm unsure how to test this..