### PR TITLE
Site settings: fix section not loading

### DIFF
--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -9,7 +9,7 @@ import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { find, noop } from 'lodash';
+import { find, isString, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -62,7 +62,7 @@ export class LanguagePicker extends PureComponent {
 			return lang[ valueKey ] == value; // eslint-disable-line eqeqeq
 		} );
 		//if an unsupported language is provided return it without a display name
-		if ( value && ! language ) {
+		if ( isString( value ) && ! language ) {
 			return {
 				langSlug: value,
 				name: translate( 'Unsupported language' ),

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -152,7 +152,7 @@
         { "value": 459, "langSlug": "so", "name": "Afsoomaali", "wpLocale": "so_SO", "territories": [ "002" ] },
         { "value": 66, "langSlug": "sq", "name": "Shqip", "wpLocale": "sq", "territories": [ "039" ] },
         { "value": 67, "langSlug": "sr", "name": "Српски језик", "wpLocale": "sr_RS", "territories": [ "039" ] },
-        { "value": 67, "langSlug": "sr_latin", "name": "Srpski (latinica)", "wpLocale": "sr_RS", "parentLangSlug": "sr", "territories": [ "039" ] },
+        { "value": 901, "langSlug": "sr_latin", "name": "Srpski (latinica)", "wpLocale": "sr_RS", "parentLangSlug": "sr", "territories": [ "039" ] },
         { "value": 441, "langSlug": "su", "name": "Basa Sunda", "wpLocale": "su_ID", "territories": [ "035" ] },
         { "value": 68, "langSlug": "sv", "name": "Svenska", "wpLocale": "sv_SE", "popular": 17, "territories": [ "154" ] },
         { "value": 69, "langSlug": "ta", "name": "தமிழ்", "wpLocale": "ta_IN", "territories": [ "034", "035" ] },


### PR DESCRIPTION
## This PR
- fixes issue https://github.com/Automattic/wp-calypso/issues/24598

#### The cause of the issue

Visiting site settings on a Simple site with Serbian as the selected site language throws this error:

```
TypeError: langSlug.split is not a function
    at getLanguageCodeLabels
...
```

It turns out that the recent addition of https://github.com/Automattic/wp-calypso/pull/24562 surfaced a longstanding error where the language value for Serbian didn't match between the backend and the value used in Calypso. The error so far had just failed fairly silently as the language picker just constantly displayed the loading state.

#### The solution for the issue

First we fix the language code used for Serbian to the one that's used on the server. Then we also safeguard by testing for a string value (lang id from Jetpack) just in case there are other mismatches for Simple sites.

## How to test

- Navigate to `/wp-admin/options-general.php` on a Simple site
- Change the language to `Srpski (latinica)`
- Navigate to `settings/general/{your site}` in Calypso
- You should see the after state as shown below

## Screenshots

### Before

<img width="1208" alt="screen shot 2018-05-01 at 19 43 19" src="https://user-images.githubusercontent.com/1562646/39490532-12bbb9a6-4d81-11e8-981a-5e2ed679de94.png">

### After

<img width="1209" alt="screen shot 2018-05-01 at 20 30 48" src="https://user-images.githubusercontent.com/1562646/39490572-2dc5b0ee-4d81-11e8-9eb6-197df79dba48.png">

