### PR TITLE
Jetpack Connect: Log-in: Move co-branding to JetpackLogo; Add co-branding to log-in

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -37,6 +37,7 @@ import PushNotificationApprovalPoller from './two-factor-authentication/push-not
 import userFactory from 'lib/user';
 import SocialConnectPrompt from './social-connect-prompt';
 import JetpackLogo from 'components/jetpack-logo';
+import { getPartnerSlugFromCurrentUrl } from 'jetpack-connect/utils';
 
 const user = userFactory();
 
@@ -193,7 +194,7 @@ class Login extends Component {
 			headerText = translate( 'Log in to your WordPress.com account to set up Jetpack.' );
 			preHeader = (
 				<div className="login__jetpack-logo">
-					<JetpackLogo full size={ 45 } />
+					<JetpackLogo full size={ 45 } partnerSlug={ getPartnerSlugFromCurrentUrl() } />
 				</div>
 			);
 		}

--- a/client/components/jetpack-logo/README.md
+++ b/client/components/jetpack-logo/README.md
@@ -23,5 +23,6 @@ export default function JetpackLogoExample() {
 
 * `full` : (bool) Whether or not to show the Jetpack text alongside the icon
 * `size` : (number) The height of the SVG
+* `partnerSlug`: (string) If the slug is for a known partner, will return a cobranded logo
 
 All other props are passed to the underlying `Button`.

--- a/client/components/jetpack-logo/index.jsx
+++ b/client/components/jetpack-logo/index.jsx
@@ -3,8 +3,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
 
 /**
  * Module constants
@@ -30,34 +31,108 @@ const svgLogo24 = (
 	</svg>
 );
 
-const JetpackLogo = ( { full = false, size = 32 } ) => {
-	if ( full === true ) {
+export class JetpackLogo extends PureComponent {
+	static propTypes = {
+		full: PropTypes.bool,
+		size: PropTypes.number,
+		partnerSlug: PropTypes.string,
+		translate: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		full: false,
+		partnerSlug: '',
+	};
+
+	renderSvg() {
+		const { full, size } = this.props;
+
+		if ( full === true ) {
+			return (
+				<svg height={ size } className="jetpack-logo" viewBox="0 0 118 32">
+					<title>Jetpack</title>
+					{ logoPathSize32 }
+					{
+						// eslint-disable-next-line max-len
+						<path d="M41.3 26.6c-.5-.7-.9-1.4-1.3-2.1 2.3-1.4 3-2.5 3-4.6V8h-3V6h6v13.4C46 22.8 45 24.8 41.3 26.6zM58.5 21.3c-1.5.5-2.7.6-4.2.6-3.6 0-5.8-1.8-5.8-6 0-3.1 1.9-5.9 5.5-5.9s4.9 2.5 4.9 4.9c0 .8 0 1.5-.1 2h-7.3c.1 2.5 1.5 2.8 3.6 2.8 1.1 0 2.2-.3 3.4-.7C58.5 19 58.5 21.3 58.5 21.3zM56 15c0-1.4-.5-2.9-2-2.9-1.4 0-2.3 1.3-2.4 2.9C51.6 15 56 15 56 15zM65 18.4c0 1.1.8 1.3 1.4 1.3.5 0 2-.2 2.6-.4v2.1c-.9.3-2.5.5-3.7.5-1.5 0-3.2-.5-3.2-3.1V12H60v-2h2.1V7.1H65V10h4v2h-4V18.4zM71 10h3v1.3c1.1-.8 1.9-1.3 3.3-1.3 2.5 0 4.5 1.8 4.5 5.6s-2.2 6.3-5.8 6.3c-.9 0-1.3-.1-2-.3V28h-3V10zM76.5 12.3c-.8 0-1.6.4-2.5 1.2v5.9c.6.1.9.2 1.8.2 2 0 3.2-1.3 3.2-3.9C79 13.4 78.1 12.3 76.5 12.3zM93 22h-3v-1.5c-.9.7-1.9 1.5-3.5 1.5-1.5 0-3.1-1.1-3.1-3.2 0-2.9 2.5-3.4 4.2-3.7l2.4-.3v-.3c0-1.5-.5-2.3-2-2.3-.7 0-2.3.5-3.7 1.1L84 11c1.2-.4 3-1 4.4-1 2.7 0 4.6 1.4 4.6 4.7L93 22zM90 16.4l-2.2.4c-.7.1-1.4.5-1.4 1.6 0 .9.5 1.4 1.3 1.4s1.5-.5 2.3-1V16.4zM104.5 21.3c-1.1.4-2.2.6-3.5.6-4.2 0-5.9-2.4-5.9-5.9 0-3.7 2.3-6 6.1-6 1.4 0 2.3.2 3.2.5V13c-.8-.3-2-.6-3.2-.6-1.7 0-3.2.9-3.2 3.6 0 2.9 1.5 3.8 3.3 3.8.9 0 1.9-.2 3.2-.7V21.3zM110 15.2c.2-.3.2-.8 3.8-5.2h3.7l-4.6 5.7 5 6.3h-3.7l-4.2-5.8V22h-3V6h3V15.2z" />
+					}
+				</svg>
+			);
+		}
+
+		if ( 24 === size ) {
+			return svgLogo24;
+		}
+
 		return (
-			<svg height={ size } className="jetpack-logo" viewBox="0 0 118 32">
-				<title>Jetpack</title>
+			<svg className="jetpack-logo" height={ size } width={ size } viewBox="0 0 32 32">
 				{ logoPathSize32 }
-				{
-					// eslint-disable-next-line max-len
-					<path d="M41.3 26.6c-.5-.7-.9-1.4-1.3-2.1 2.3-1.4 3-2.5 3-4.6V8h-3V6h6v13.4C46 22.8 45 24.8 41.3 26.6zM58.5 21.3c-1.5.5-2.7.6-4.2.6-3.6 0-5.8-1.8-5.8-6 0-3.1 1.9-5.9 5.5-5.9s4.9 2.5 4.9 4.9c0 .8 0 1.5-.1 2h-7.3c.1 2.5 1.5 2.8 3.6 2.8 1.1 0 2.2-.3 3.4-.7C58.5 19 58.5 21.3 58.5 21.3zM56 15c0-1.4-.5-2.9-2-2.9-1.4 0-2.3 1.3-2.4 2.9C51.6 15 56 15 56 15zM65 18.4c0 1.1.8 1.3 1.4 1.3.5 0 2-.2 2.6-.4v2.1c-.9.3-2.5.5-3.7.5-1.5 0-3.2-.5-3.2-3.1V12H60v-2h2.1V7.1H65V10h4v2h-4V18.4zM71 10h3v1.3c1.1-.8 1.9-1.3 3.3-1.3 2.5 0 4.5 1.8 4.5 5.6s-2.2 6.3-5.8 6.3c-.9 0-1.3-.1-2-.3V28h-3V10zM76.5 12.3c-.8 0-1.6.4-2.5 1.2v5.9c.6.1.9.2 1.8.2 2 0 3.2-1.3 3.2-3.9C79 13.4 78.1 12.3 76.5 12.3zM93 22h-3v-1.5c-.9.7-1.9 1.5-3.5 1.5-1.5 0-3.1-1.1-3.1-3.2 0-2.9 2.5-3.4 4.2-3.7l2.4-.3v-.3c0-1.5-.5-2.3-2-2.3-.7 0-2.3.5-3.7 1.1L84 11c1.2-.4 3-1 4.4-1 2.7 0 4.6 1.4 4.6 4.7L93 22zM90 16.4l-2.2.4c-.7.1-1.4.5-1.4 1.6 0 .9.5 1.4 1.3 1.4s1.5-.5 2.3-1V16.4zM104.5 21.3c-1.1.4-2.2.6-3.5.6-4.2 0-5.9-2.4-5.9-5.9 0-3.7 2.3-6 6.1-6 1.4 0 2.3.2 3.2.5V13c-.8-.3-2-.6-3.2-.6-1.7 0-3.2.9-3.2 3.6 0 2.9 1.5 3.8 3.3 3.8.9 0 1.9-.2 3.2-.7V21.3zM110 15.2c.2-.3.2-.8 3.8-5.2h3.7l-4.6 5.7 5 6.3h-3.7l-4.2-5.8V22h-3V6h3V15.2z" />
-				}
 			</svg>
 		);
 	}
 
-	if ( 24 === size ) {
-		return svgLogo24;
+	renderCoBrandedLogo() {
+		const { partnerSlug, translate } = this.props;
+		const baseCobrandedAttributes = {
+			width: '662.5',
+			height: '85',
+			className: 'jetpack-connect__main-partner-logo',
+		};
+
+		let image;
+
+		switch ( partnerSlug ) {
+			case 'dreamhost':
+				image = (
+					<img
+						{ ...baseCobrandedAttributes }
+						src="/calypso/images/jetpack/jetpack-dreamhost-connection.png"
+						alt={ translate( 'Co-branded Jetpack and DreamHost logo' ) }
+					/>
+				);
+				break;
+
+			case 'pressable':
+				image = (
+					<img
+						{ ...baseCobrandedAttributes }
+						src="/calypso/images/jetpack/jetpack-pressable-connection.png"
+						alt={ translate( 'Co-branded Jetpack and Pressable logo' ) }
+					/>
+				);
+				break;
+
+			case 'milesweb':
+				image = (
+					<img
+						{ ...baseCobrandedAttributes }
+						src="/calypso/images/jetpack/jetpack-milesweb-connection.png"
+						alt={ translate( 'Co-branded Jetpack and MilesWeb logo' ) }
+					/>
+				);
+				break;
+
+			case 'bluehost':
+				image = (
+					<img
+						{ ...baseCobrandedAttributes }
+						src="/calypso/images/jetpack/jetpack-bluehost-connection.png"
+						alt={ translate( 'Co-branded Jetpack and Bluehost logo' ) }
+					/>
+				);
+				break;
+		}
+
+		if ( ! image ) {
+			return null;
+		}
+
+		return <div className="jetpack-logo">{ image }</div>;
 	}
 
-	return (
-		<svg className="jetpack-logo" height={ size } width={ size } viewBox="0 0 32 32">
-			{ logoPathSize32 }
-		</svg>
-	);
-};
+	render() {
+		return this.renderCoBrandedLogo() || this.renderSvg();
+	}
+}
 
-JetpackLogo.propTypes = {
-	full: PropTypes.bool,
-	size: PropTypes.number,
-};
-
-export default JetpackLogo;
+export default localize( JetpackLogo );

--- a/client/components/jetpack-logo/index.jsx
+++ b/client/components/jetpack-logo/index.jsx
@@ -49,6 +49,7 @@ export class JetpackLogo extends PureComponent {
 
 		if ( full === true ) {
 			return (
+				// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 				<svg height={ size } className="jetpack-logo" viewBox="0 0 118 32">
 					<title>Jetpack</title>
 					{ logoPathSize32 }
@@ -65,6 +66,7 @@ export class JetpackLogo extends PureComponent {
 		}
 
 		return (
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 			<svg className="jetpack-logo" height={ size } width={ size } viewBox="0 0 32 32">
 				{ logoPathSize32 }
 			</svg>
@@ -127,6 +129,7 @@ export class JetpackLogo extends PureComponent {
 			return null;
 		}
 
+		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 		return <div className="jetpack-logo">{ image }</div>;
 	}
 

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -6,7 +6,6 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -19,64 +18,14 @@ export class JetpackConnectMainWrapper extends PureComponent {
 	static propTypes = {
 		isWide: PropTypes.bool,
 		partnerSlug: PropTypes.string,
-		translate: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
 		isWide: false,
 	};
 
-	getHeaderImage() {
-		const { partnerSlug, translate } = this.props;
-		const baseCobrandedAttributes = {
-			width: '662.5',
-			height: '85',
-			className: 'jetpack-connect__main-partner-logo',
-		};
-
-		switch ( partnerSlug ) {
-			case 'dreamhost':
-				return (
-					<img
-						{ ...baseCobrandedAttributes }
-						src="/calypso/images/jetpack/jetpack-dreamhost-connection.png"
-						alt={ translate( 'Co-branded Jetpack and DreamHost logo' ) }
-					/>
-				);
-
-			case 'pressable':
-				return (
-					<img
-						{ ...baseCobrandedAttributes }
-						src="/calypso/images/jetpack/jetpack-pressable-connection.png"
-						alt={ translate( 'Co-branded Jetpack and Pressable logo' ) }
-					/>
-				);
-
-			case 'milesweb':
-				return (
-					<img
-						{ ...baseCobrandedAttributes }
-						src="/calypso/images/jetpack/jetpack-milesweb-connection.png"
-						alt={ translate( 'Co-branded Jetpack and MilesWeb logo' ) }
-					/>
-				);
-
-			case 'bluehost':
-				return (
-					<img
-						{ ...baseCobrandedAttributes }
-						src="/calypso/images/jetpack/jetpack-bluehost-connection.png"
-						alt={ translate( 'Co-branded Jetpack and Bluehost logo' ) }
-					/>
-				);
-		}
-
-		return <JetpackLogo full size={ 45 } />;
-	}
-
 	render() {
-		const { isWide, className, children } = this.props;
+		const { isWide, className, children, partnerSlug } = this.props;
 		const wrapperClassName = classNames( 'jetpack-connect__main', {
 			'is-wide': isWide,
 			'is-mobile-app-flow': !! retrieveMobileRedirect(),
@@ -84,11 +33,13 @@ export class JetpackConnectMainWrapper extends PureComponent {
 
 		return (
 			<Main className={ classNames( className, wrapperClassName ) }>
-				<div className="jetpack-connect__main-logo">{ this.getHeaderImage() }</div>
+				<div className="jetpack-connect__main-logo">
+					<JetpackLogo full size={ 45 } partnerSlug={ partnerSlug } />
+				</div>
 				{ children }
 			</Main>
 		);
 	}
 }
 
-export default localize( JetpackConnectMainWrapper );
+export default JetpackConnectMainWrapper;

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`JetpackAuthorize renders as expected 1`] = `
-<Localized(JetpackConnectMainWrapper)>
+<JetpackConnectMainWrapper
+  isWide={false}
+>
   <div
     className="jetpack-connect__authorize-form"
   >
@@ -75,7 +77,7 @@ exports[`JetpackAuthorize renders as expected 1`] = `
             icon="arrow-left"
             size={18}
           />
-           
+
           Return to %(sitename)s
         </LoggedOutFormLinkItem>
         <LoggedOutFormLinkItem
@@ -98,5 +100,5 @@ exports[`JetpackAuthorize renders as expected 1`] = `
       </LoggedOutFormLinks>
     </div>
   </div>
-</Localized(JetpackConnectMainWrapper)>
+</JetpackConnectMainWrapper>
 `;

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -77,7 +77,7 @@ exports[`JetpackAuthorize renders as expected 1`] = `
             icon="arrow-left"
             size={18}
           />
-
+           
           Return to %(sitename)s
         </LoggedOutFormLinkItem>
         <LoggedOutFormLinkItem

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`JetpackSignup should render 1`] = `
-<Localized(JetpackConnectMainWrapper)>
+<JetpackConnectMainWrapper
+  isWide={false}
+>
   <div
     className="jetpack-connect__authorize-form"
   >
@@ -51,11 +53,13 @@ exports[`JetpackSignup should render 1`] = `
       suggestedUsername=""
     />
   </div>
-</Localized(JetpackConnectMainWrapper)>
+</JetpackConnectMainWrapper>
 `;
 
 exports[`JetpackSignup should render with locale suggestions 1`] = `
-<Localized(JetpackConnectMainWrapper)>
+<JetpackConnectMainWrapper
+  isWide={false}
+>
   <div
     className="jetpack-connect__authorize-form"
   >
@@ -110,5 +114,5 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
       suggestedUsername=""
     />
   </div>
-</Localized(JetpackConnectMainWrapper)>
+</JetpackConnectMainWrapper>
 `;

--- a/client/jetpack-connect/test/main-wrapper.jsx
+++ b/client/jetpack-connect/test/main-wrapper.jsx
@@ -8,7 +8,6 @@
  */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,14 +17,14 @@ import Main from 'components/main';
 
 describe( 'JetpackConnectMainWrapper', () => {
 	test( 'should render a <Main> instance', () => {
-		const wrapper = shallow( <JetpackConnectMainWrapper translate={ identity } /> );
+		const wrapper = shallow( <JetpackConnectMainWrapper /> );
 
 		expect( wrapper.find( Main ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render the passed children as children of the component', () => {
 		const wrapper = shallow(
-			<JetpackConnectMainWrapper translate={ identity }>
+			<JetpackConnectMainWrapper>
 				<span className="test__child" />
 			</JetpackConnectMainWrapper>
 		).render();
@@ -34,41 +33,39 @@ describe( 'JetpackConnectMainWrapper', () => {
 	} );
 
 	test( 'should always specify the jetpack-connect__main class', () => {
-		const wrapper = shallow( <JetpackConnectMainWrapper translate={ identity } /> );
+		const wrapper = shallow( <JetpackConnectMainWrapper /> );
 
 		expect( wrapper.hasClass( 'jetpack-connect__main' ) ).toBe( true );
 	} );
 
 	test( 'should allow more classes to be added', () => {
-		const wrapper = shallow(
-			<JetpackConnectMainWrapper className="test__class" translate={ identity } />
-		);
+		const wrapper = shallow( <JetpackConnectMainWrapper className="test__class" /> );
 
 		expect( wrapper.hasClass( 'jetpack-connect__main' ) ).toBe( true );
 		expect( wrapper.hasClass( 'test__class' ) ).toBe( true );
 	} );
 
 	test( 'should not contain the is-wide modifier class by default', () => {
-		const wrapper = shallow( <JetpackConnectMainWrapper translate={ identity } /> );
+		const wrapper = shallow( <JetpackConnectMainWrapper /> );
 
 		expect( wrapper.hasClass( 'is-wide' ) ).toBe( false );
 	} );
 
 	test( 'should contain the is-wide modifier class if prop is specified', () => {
-		const wrapper = shallow( <JetpackConnectMainWrapper isWide translate={ identity } /> );
+		const wrapper = shallow( <JetpackConnectMainWrapper isWide /> );
 
 		expect( wrapper.hasClass( 'is-wide' ) ).toBe( true );
 	} );
 
 	test( 'should not contain the is-mobile-app-flow modifier class by default', () => {
-		const wrapper = shallow( <JetpackConnectMainWrapper translate={ identity } /> );
+		const wrapper = shallow( <JetpackConnectMainWrapper /> );
 
 		expect( wrapper.hasClass( 'is-mobile-app-flow' ) ).toBe( false );
 	} );
 
 	test( 'should contain the is-mobile-app-flow modifier if cookie is set', () => {
 		document.cookie = 'jetpack_connect_mobile_redirect=some url';
-		const wrapper = shallow( <JetpackConnectMainWrapper isWide translate={ identity } /> );
+		const wrapper = shallow( <JetpackConnectMainWrapper isWide /> );
 
 		expect( wrapper.hasClass( 'is-mobile-app-flow' ) ).toBe( true );
 	} );

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -7,6 +7,7 @@ import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import PropTypes from 'prop-types';
 import { authorizeQueryDataSchema } from './schema';
 import { head, includes, isEmpty, split } from 'lodash';
+import urls from 'url';
 
 /**
  * Internal dependencies
@@ -146,4 +147,13 @@ export function getPartnerSlugFromId( partnerId ) {
 		default:
 			return null;
 	}
+}
+
+export function getPartnerSlugFromCurrentUrl() {
+	const parsed = urls.parse( window.location.href, true );
+	if ( ! parsed || ! parsed.query || ! parsed.query.partner_id ) {
+		return null;
+	}
+
+	return getPartnerSlugFromId( parseInt( parsed.query.partner_id, 10 ) );
 }


### PR DESCRIPTION
In #24506, we made some changes to how we cobrand the Jetpack Connection flow. After further testing, I became aware that we weren't cobranding the logged out connection flow where a user's email was associated with a WordPress.com user. In that flow, we show the user the login prompt instead of a prompt to create an account.

This PR begins cobranding the log-in connection flow, with just a cobranded logo for now, primarily by moving the logic for the cobranded partner logos into the `JetpackLogo` component itself. This seems like a decent place to add that logic since the component is already used in both places and when we show the cobranded logo, we want to do that in place of the Jetpack logo.

To test:

- Checkout this branch
- Go to a Jetpack site and click the green "Set up Jetpack" button to connect to WordPress.com
- Once on WordPress.com, copy the connection URL
- Replace WordPress.com with `calypso.localhost:3000`
- To test the various co-branded screens you'll add `&partner_id=$ID` where `$ID` represents one of the hosts below:
    - `51945` or `51946` for DreamHost
    - `49615` or `49640` for Pressable
    - `57152` or `57733` for MilesWeb
    - `41986` or `42000` for Bluehost
- Go to `http://calypso.localhost:3000/log-in/jetpack?partner_id=$ID` where `$ID` represents one of the partner IDs above
- Ensure that this `log-in` flow is co-branded as well
- While going through the various flows, ensure there are no errors

To fully test the logged out with a known email flow, you should be able to disconnect a site with an existing connection, logout from WordPress.com, and then reconnect. This will get you to `/log-in/jetpack`. Next, you'll just add the `?partner_id=$ID` as mentioned above.

Here are some after PRs:

![logged-out-email-unknown-mobile](https://user-images.githubusercontent.com/1126811/39494036-81ec95ec-4d5a-11e8-9f62-85aa8f24391d.png)
![logged-out-email-unknown-desktop](https://user-images.githubusercontent.com/1126811/39494037-8201653a-4d5a-11e8-9009-21daaa9a9179.png)
![logged-out-email-known-mobile](https://user-images.githubusercontent.com/1126811/39494038-821e5ae6-4d5a-11e8-9bb7-49c258cd20d6.png)
![logged-in-mobile](https://user-images.githubusercontent.com/1126811/39494039-8230fd04-4d5a-11e8-9c72-d7d840dcc11d.png)
![logged-in-desktop](https://user-images.githubusercontent.com/1126811/39494040-82495584-4d5a-11e8-8398-b7b45baabf4f.png)
![logged-out-email-known-desktop](https://user-images.githubusercontent.com/1126811/39494041-825b5b30-4d5a-11e8-80f5-c1d525e64579.png)
