### PR TITLE
Log-in: Jetpack: Adds top margin above Jetpack logo

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -192,7 +192,7 @@ class Login extends Component {
 		} else if ( isJetpack ) {
 			headerText = translate( 'Log in to your WordPress.com account to set up Jetpack.' );
 			preHeader = (
-				<div>
+				<div className="login__jetpack-logo">
 					<JetpackLogo full size={ 45 } />
 				</div>
 			);

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -217,3 +217,11 @@
 .login__form-password.is-hidden {
 	display: none;
 }
+
+.login__jetpack-logo {
+	text-align: center;
+
+	@include breakpoint( '<660px' ) {
+		margin-top: 20px;
+	}
+}


### PR DESCRIPTION
Currently, there is no margin above the Jetpack logo on the `log-in/jetpack` route, which results in the Jetpack logo touching the masterbar. This PR seeks to fix that by applying the same margin-top that we use in the Jetpack connect flows.

Here's a before screenshot of the standard `/log-in` route.

![screen shot 2018-05-01 at 16 44 24-fullpage](https://user-images.githubusercontent.com/1126811/39495240-21afa566-4d5f-11e8-84e1-3dbbb1c709bb.png)

Here is the `/log-in/jetpack` route *before* this PR:

![screen shot 2018-05-01 at 16 44 32-fullpage](https://user-images.githubusercontent.com/1126811/39495263-32003174-4d5f-11e8-9b78-54743111a142.png)

Here is the `/log-jetpack/jetpack` route *after* this PR:

![screen shot 2018-05-01 at 16 45 46-fullpage](https://user-images.githubusercontent.com/1126811/39495328-7acf40e8-4d5f-11e8-9c59-bfe8d026ad85.png)

To test: 

- Go to `https://wordpress.com/log-in` and resize browser to a mobile size
- Ensure that there is padding above the header
- Navigate to `https://wordpress.com/log-in/jetpack` and ensure the browser is still at a mobile size
- Verify that there is no space between the masterbar and the Jetpack logo
- Checkout this branch
- Go to `calypso.localhost:3000/log-in/jetpack` and ensure the browser is still at a mobile size
- Verify that there is space between the masterbar and the Jetpack logo
- Go to `calypso.localhost:3000/log-in` and ensure the browser is still at a mobile size
- Ensure there is still space between the header and masterbar
