### PR TITLE
[Domains] Add strikethrough price for signup

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 
@@ -33,7 +34,7 @@ class DomainProductPrice extends React.Component {
 				} ) }
 			>
 				{ ! this.props.domainsWithPlansOnly && this.renderFreeWithPlanPrice() }
-				<span className="domain-product-price__free-text" ref="subMessage">
+				<span className="domain-product-price__free-text">
 					{ this.props.translate( 'Free with your plan' ) }
 				</span>
 			</div>
@@ -62,11 +63,20 @@ class DomainProductPrice extends React.Component {
 	renderIncludedInPremium() {
 		const { translate } = this.props;
 
+		const shouldShowStrikethrough = abtest( 'signupDomainStrikethruPrice' ) === 'enabled';
+
 		return (
-			<div className="domain-product-price is-with-plans-only">
-				<small className="domain-product-price__premium-text" ref="subMessage">
+			<div className="domain-product-price domain-product-price__is-with-plans-only">
+				{ shouldShowStrikethrough && (
+					<span className="domain-product-price__strikethrough-price">
+						{ this.props.translate( '%(cost)s /year', {
+							args: { cost: this.props.price },
+						} ) }
+					</span>
+				) }
+				<span className={ shouldShowStrikethrough && 'domain-product-price__included-in-plan' }>
 					{ translate( 'Included in paid plans' ) }
-				</small>
+				</span>
 			</div>
 		);
 	}

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -7,7 +7,7 @@
 	@include breakpoint( '>660px' ) {
 		align-items: center;
 		display: flex;
-		flex: 0 2 280px;
+		flex: 0 2 360px;
 		font-size: 17px;
 		justify-content: flex-end;
 		padding-right: 2em;
@@ -40,7 +40,7 @@
 
 	.domain-product-price__strikethrough-price {
 		text-decoration: line-through;
-		margin-right: 0.25em;
+		margin-right: 0.75em;
 		opacity: 0.7;
 	}
 

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -1,8 +1,10 @@
+/** @format */
+
 .domain-product-price {
 	color: $gray-darken-30;
 	font-weight: 600;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		align-items: center;
 		display: flex;
 		flex: 0 2 280px;
@@ -11,26 +13,35 @@
 		padding-right: 2em;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		display: inline-block;
 		font-size: 14px;
 	}
 
-	&.is-with-plans-only:not( .is-free-domain ) {
-		small {
-			font-size: 12px;
-		}
-	}
-
 	.map-domain-step & {
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			padding-bottom: 5px;
 		}
 	}
 
 	small {
 		font-weight: 400;
-		opacity: .6;
+		opacity: 0.6;
+	}
+
+	&.domain-product-price__is-with-plans-only {
+		font-weight: 400;
+		font-size: 0.9em;
+	}
+
+	.domain-product-price__included-in-plan {
+		color: $blue-dark;
+	}
+
+	.domain-product-price__strikethrough-price {
+		text-decoration: line-through;
+		margin-right: 0.25em;
+		opacity: 0.7;
 	}
 
 	.domain-product-price__premium-text {
@@ -53,17 +64,17 @@
 		}
 
 		.domain-product-price__price {
-			opacity: .6;
+			opacity: 0.6;
 			text-decoration: line-through;
 		}
 	}
 
 	.is-placeholder & {
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			display: none;
 		}
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			animation: loading-fade 1.6s ease-in-out infinite;
 			background-color: $gray-lighten-30;
 			color: transparent;

--- a/client/components/domains/featured-domain-suggestions/styles/base.scss
+++ b/client/components/domains/featured-domain-suggestions/styles/base.scss
@@ -48,7 +48,7 @@
 		margin: 0;
 		justify-content: flex-start;
 
-		&.is-with-plans-only,
+		&.domain-product-price__is-with-plans-only,
 		&.is-free-domain {
 			font-size: 0.9em;
 			small {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -108,4 +108,12 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
+	signupDomainStrikethruPrice: {
+		datestamp: '20180504',
+		variations: {
+			enabled: 50,
+			disabled: 50,
+		},
+		defaultVariation: 'disabled',
+	},
 };


### PR DESCRIPTION
This change implements strikethrough prices for the domain registration step of the signup flow instead of hiding the prices entirely; related discussion: `p8kIbR-gE`.

<img width="983" alt="wordpress_com" src="https://user-images.githubusercontent.com/4044428/39496130-700a8afa-4d5a-11e8-97ae-b6b17fba62b9.png">

# Testing instructions
1. Spin up this branch locally.
2. Navigate to `/start/domains/`. Verify that the interface loads as expected.
3. Set your assigned group for the A/B test `signupDomainStrikethruPrice` to `enabled`.
4. Verify that the interface now shows strikethrough domain registration prices.