### PR TITLE
[Domains] Enable wide layout on `/domains/add`

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -189,30 +189,26 @@ class DomainSearchResults extends React.Component {
 				</div>
 			);
 
-			let regularSuggestions = suggestions;
-
-			if ( this.props.isSignupStep ) {
-				regularSuggestions = suggestions.filter(
-					suggestion => ! suggestion.isRecommended && ! suggestion.isBestAlternative
-				);
-				const bestMatchSuggestions = suggestions.filter( suggestion => suggestion.isRecommended );
-				const bestAlternativeSuggestions = suggestions.filter(
-					suggestion => suggestion.isBestAlternative
-				);
-				featuredSuggestionElement = (
-					<FeaturedDomainSuggestions
-						cart={ this.props.cart }
-						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-						isSignupStep={ this.props.isSignupStep }
-						key="featured"
-						onButtonClick={ this.props.onClickResult }
-						primarySuggestion={ first( bestMatchSuggestions ) }
-						query={ this.props.lastDomainSearched }
-						secondarySuggestion={ first( bestAlternativeSuggestions ) }
-						selectedSite={ this.props.selectedSite }
-					/>
-				);
-			}
+			const regularSuggestions = suggestions.filter(
+				suggestion => ! suggestion.isRecommended && ! suggestion.isBestAlternative
+			);
+			const bestMatchSuggestions = suggestions.filter( suggestion => suggestion.isRecommended );
+			const bestAlternativeSuggestions = suggestions.filter(
+				suggestion => suggestion.isBestAlternative
+			);
+			featuredSuggestionElement = (
+				<FeaturedDomainSuggestions
+					cart={ this.props.cart }
+					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+					isSignupStep={ this.props.isSignupStep }
+					key="featured"
+					onButtonClick={ this.props.onClickResult }
+					primarySuggestion={ first( bestMatchSuggestions ) }
+					query={ this.props.lastDomainSearched }
+					secondarySuggestion={ first( bestAlternativeSuggestions ) }
+					selectedSite={ this.props.selectedSite }
+				/>
+			);
 
 			suggestionElements = regularSuggestions.map( ( suggestion, i ) => {
 				if ( suggestion.is_placeholder ) {
@@ -247,9 +243,7 @@ class DomainSearchResults extends React.Component {
 				);
 			}
 		} else {
-			featuredSuggestionElement = this.props.isSignupStep && (
-				<FeaturedDomainSuggestions showPlaceholders />
-			);
+			featuredSuggestionElement = <FeaturedDomainSuggestions showPlaceholders />;
 			suggestionElements = this.renderPlaceholders();
 		}
 

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -74,6 +74,7 @@ export class FeaturedDomainSuggestions extends Component {
 
 	getClassNames() {
 		return classNames( 'featured-domain-suggestions', this.getTextSizeClass(), {
+			'featured-domain-suggestions__is-domain-management': ! this.props.isSignupStep,
 			'featured-domain-suggestions--has-match-reasons': this.hasMatchReasons(),
 		} );
 	}

--- a/client/components/domains/featured-domain-suggestions/styles/base.scss
+++ b/client/components/domains/featured-domain-suggestions/styles/base.scss
@@ -8,6 +8,12 @@
 			min-height: 26px;
 		}
 	}
+
+	&.featured-domain-suggestions__is-domain-management .featured-domain-suggestion {
+		.domain-suggestion__action {
+			font-size: 16px;
+		}
+	}
 }
 
 .featured-domain-suggestion {

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -71,7 +71,7 @@ const domainSearch = ( context, next ) => {
 	}
 
 	context.primary = (
-		<Main>
+		<Main wideLayout>
 			<PageViewTracker path="/domains/add/:site" title="Domain Search > Domain Registration" />
 			<DocumentHead title={ translate( 'Domain Search' ) } />
 			<CartData>
@@ -113,7 +113,7 @@ const mapDomain = ( context, next ) => {
 
 const transferDomain = ( context, next ) => {
 	context.primary = (
-		<Main>
+		<Main wideLayout>
 			<PageViewTracker
 				path={ domainTransferIn( ':site' ) }
 				title="Domain Search > Domain Transfer"

--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -162,7 +162,7 @@ class DomainSearch extends Component {
 		}
 
 		return (
-			<Main className={ classes }>
+			<Main className={ classes } wideLayout>
 				<QueryProductsList />
 				<SidebarNavigation />
 				{ content }


### PR DESCRIPTION
This enables featured suggestions by enabling a wide layout on the [domains management page](https://wordpress.com/domains/add/).

<img width="1060" alt="domain_search_ _testing_ _wordpress_com" src="https://user-images.githubusercontent.com/4044428/39496525-0e50eef6-4d5c-11e8-9acb-18aadefc0a16.png">

# Testing instructions
1. Spin up this branch locally.
2. Navigate to `/domains/add` and select a site that has a domain credit.
3. Enter a query. Verify that you get a page like the above screenshot; you may want to add a query string like `?flags=-domains/kracken-ui/filters` to disable the filters.
4. Repeat steps 2~3 with a site that doesn't have any domain credit.
