### PR TITLE
Store: Expose MailChimp settings card if plugin is active.

### DIFF
--- a/client/extensions/woocommerce/app/settings/email/mailchimp/index.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/index.js
@@ -22,7 +22,6 @@ import {
 import MailChimpGettingStarted from './getting-started';
 import MailChimpSetup from './setup-mailchimp';
 import MailChimpDashboard from './mailchimp_dashboard';
-import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import QueryMailChimpSettings from 'woocommerce/state/sites/settings/mailchimp/querySettings';
 
 class MailChimp extends React.Component {
@@ -63,21 +62,14 @@ class MailChimp extends React.Component {
 		const gettingStarted =
 			! setupWizardStarted && ! isRequestingData && ( settings && settings.active_tab !== 'sync' );
 
-		// Special case for store dashboard where we want to only show MailChimpGetingStarted in case
-		// when user has not finished settup. We show nothing in other cases.
-		if ( dashboardView ) {
-			// Disabling due to performance issues with the plugin.
-			return null;
-		}
-
-		// Disable setup view for now
-		if ( ! isRequestingData && gettingStarted ) {
+		// TODO Eventually re-implement a new dashboard widget for extension
+		// that accomodates sites without the plugin installed
+		if ( dashboardView || ! hasMailChimp ) {
 			return null;
 		}
 
 		return (
 			<div className="mailchimp">
-				<QueryJetpackPlugins siteIds={ [ siteId ] } />
 				<QueryMailChimpSettings siteId={ siteId } />
 				{ ( isRequestingData || gettingStarted ) && (
 					<MailChimpGettingStarted
@@ -125,7 +117,7 @@ function mapStateToProps( state ) {
 	const isRequestingPlugins = isRequestingForSites( state, [ siteId ] );
 	const isRequestingMailChimpSettings = isRequestingSettings( state, siteId );
 	const sitePlugins = getPlugins( state, [ siteId ] );
-	const mailChimp = filter( sitePlugins, matches( { id: mailChimpId } ) );
+	const mailChimp = filter( sitePlugins, matches( { id: mailChimpId, active: true } ) );
 	const hasMailChimp = !! mailChimp.length;
 	const settings = mailChimpSettings( state, siteId );
 	return {


### PR DESCRIPTION
In #22352 the MailChimp settings panel and "Get Started" dashboard widgets were hidden due to the issues with MailChimp sync on Atomic sites. Now that the sync issue has been resolved, this PR re-enables the MailChimp settings card on sites that have the plugin installed and activated.

Since the plugin is no longer installed by default - I have still kept the "Get Started" dashboard widget hidden for now. If we want to re-enable that in the future, the widget will need to handle sites that do not have the plugin installed - which it currently does not.

![mailchimp-card](https://user-images.githubusercontent.com/22080/39500847-4139ea42-4d6c-11e8-8dbb-7abfa8c0997f.png)

__To Test__
This branch is best tested against a site that *does not* have the MailChimp for WooCommerce plugin installed, and one that does.
- On a site *with* the plugin installed visit http://calypso.localhost:3000/store/settings/email/YOUR-SUPER-LONG-TEST-DOMAIN.blog
- Verify that the MailChimp card shown above is displayed, and you can change settings as expected
- On the site that does not have the plugin installed, verify the card is not shown