### PR TITLE
Update LineChart Axes

### DIFF
--- a/client/components/d3-base/index.js
+++ b/client/components/d3-base/index.js
@@ -33,6 +33,7 @@ export default class D3Base extends Component {
 		params: null,
 		drawChart: null,
 		getParams: null,
+		updateParams: false,
 	};
 
 	chartRef = React.createRef();
@@ -41,15 +42,15 @@ export default class D3Base extends Component {
 		let state = {};
 
 		if ( nextProps.data !== prevState.data ) {
-			state = { ...state, data: nextProps.data };
+			state = { ...state, data: nextProps.data, updateParams: true };
 		}
 
 		if ( nextProps.drawChart !== prevState.drawChart ) {
-			state = { ...state, drawChart: nextProps.drawChart };
+			state = { ...state, drawChart: nextProps.drawChart, updateParams: true };
 		}
 
 		if ( nextProps.getParams !== prevState.getParams ) {
-			state = { ...state, getParams: nextProps.getParams };
+			state = { ...state, getParams: nextProps.getParams, updateParams: true };
 		}
 
 		if ( ! isEmpty( state ) ) {
@@ -66,7 +67,10 @@ export default class D3Base extends Component {
 	}
 
 	shouldComponentUpdate( nextProps, nextState ) {
-		return nextState.params !== null && this.state.params !== nextState.params;
+		return (
+			( nextState.params !== null && this.state.params !== nextState.params ) ||
+			this.state.updateParams
+		);
 	}
 
 	componentDidUpdate() {
@@ -89,7 +93,7 @@ export default class D3Base extends Component {
 	 * Renders the chart, or triggers a rendering by updating the list of params.
 	 */
 	drawChart() {
-		if ( this.state.params === null ) {
+		if ( this.state.params === null || this.state.updateParams ) {
 			this.updateParams();
 		} else {
 			const svg = this.drawContainer();
@@ -117,7 +121,8 @@ export default class D3Base extends Component {
 	}
 
 	updateParams = () => {
-		this.setState( { params: this.state.getParams( this.chartRef.current ) } );
+		const params = this.state.getParams( this.chartRef.current );
+		this.setState( { params, updateParams: false } );
 	};
 
 	render() {

--- a/client/components/d3-base/index.js
+++ b/client/components/d3-base/index.js
@@ -33,7 +33,6 @@ export default class D3Base extends Component {
 		params: null,
 		drawChart: null,
 		getParams: null,
-		updateParams: false,
 	};
 
 	chartRef = React.createRef();
@@ -42,15 +41,15 @@ export default class D3Base extends Component {
 		let state = {};
 
 		if ( nextProps.data !== prevState.data ) {
-			state = { ...state, data: nextProps.data, updateParams: true };
+			state = { ...state, data: nextProps.data };
 		}
 
 		if ( nextProps.drawChart !== prevState.drawChart ) {
-			state = { ...state, drawChart: nextProps.drawChart, updateParams: true };
+			state = { ...state, drawChart: nextProps.drawChart };
 		}
 
 		if ( nextProps.getParams !== prevState.getParams ) {
-			state = { ...state, getParams: nextProps.getParams, updateParams: true };
+			state = { ...state, getParams: nextProps.getParams };
 		}
 
 		if ( ! isEmpty( state ) ) {
@@ -69,7 +68,7 @@ export default class D3Base extends Component {
 	shouldComponentUpdate( nextProps, nextState ) {
 		return (
 			( nextState.params !== null && this.state.params !== nextState.params ) ||
-			this.state.updateParams
+			this.state.data !== nextState.data
 		);
 	}
 
@@ -93,16 +92,16 @@ export default class D3Base extends Component {
 	 * Renders the chart, or triggers a rendering by updating the list of params.
 	 */
 	drawChart() {
-		if ( this.state.params === null || this.state.updateParams ) {
+		if ( ! this.state.params ) {
 			this.updateParams();
-		} else {
-			const svg = this.drawContainer();
-
-			this.props.drawChart( svg, this.state.params );
+			return;
 		}
+
+		const svg = this.getContainer();
+		this.props.drawChart( svg, this.state.params );
 	}
 
-	drawContainer() {
+	getContainer() {
 		const { className } = this.props;
 		const { width, height } = this.state.params;
 
@@ -122,7 +121,7 @@ export default class D3Base extends Component {
 
 	updateParams = () => {
 		const params = this.state.getParams( this.chartRef.current );
-		this.setState( { params, updateParams: false } );
+		this.setState( { params } );
 	};
 
 	render() {

--- a/client/components/line-chart/docs/example.js
+++ b/client/components/line-chart/docs/example.js
@@ -1,0 +1,110 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { range, random } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import LineChart from 'components/line-chart';
+
+const NUM_DATA_SERIES = 3;
+
+class LineChartExample extends Component {
+	static displayName = 'LineChart';
+
+	static createData( dataMin, dataMax, seriesLength ) {
+		return range( NUM_DATA_SERIES ).map( () => {
+			return range( seriesLength ).map( e => {
+				const date = new Date();
+				date.setDate( date.getDate() - ( seriesLength - e ) );
+				return {
+					date: date.getTime(),
+					value: random( dataMin, dataMax ),
+				};
+			} );
+		} );
+	}
+
+	state = {
+		dataMin: 1,
+		dataMax: 50,
+		seriesLength: 10,
+		showDataControls: false,
+		data: LineChartExample.createData( 1, 50, 10 ),
+	};
+
+	handleDataMinChange = event => {
+		const newMin = event.target.value;
+		this.setState( {
+			dataMin: newMin,
+			data: LineChartExample.createData( newMin, this.state.dataMax, this.state.seriesLength ),
+		} );
+	};
+
+	handleDataMaxChange = event => {
+		const newMax = event.target.value;
+		this.setState( {
+			dataMax: event.target.value,
+			data: LineChartExample.createData( this.state.dataMin, newMax, this.state.seriesLength ),
+		} );
+	};
+
+	handleSeriesLengthChange = event => {
+		const newSeriesLength = event.target.value;
+		this.setState( {
+			seriesLength: newSeriesLength,
+			data: LineChartExample.createData( this.state.dataMin, this.state.dataMax, newSeriesLength ),
+		} );
+	};
+
+	handleShowDataControlsToggle = () => {
+		this.setState( {
+			showDataControls: ! this.state.showDataControls,
+		} );
+	};
+
+	render() {
+		return (
+			<div>
+				<a className="docs__design-toggle button" onClick={ this.handleShowDataControlsToggle }>
+					{ this.state.showDataControls ? 'Hide Data Controls' : 'Show Data Controls' }
+				</a>
+				<Card>
+					<LineChart data={ this.state.data } />
+				</Card>
+				{ this.state.showDataControls && (
+					<div>
+						<label>Data Min</label>
+						<input
+							type="number"
+							value={ this.state.dataMin }
+							min={ 0 }
+							onChange={ this.handleDataMinChange }
+						/>
+						<label>Data Max</label>
+						<input
+							type="number"
+							value={ this.state.dataMax }
+							min={ 0 }
+							onChange={ this.handleDataMaxChange }
+						/>
+						<label>Series Length</label>
+						<input
+							type="number"
+							value={ this.state.seriesLength }
+							min={ 3 }
+							onChange={ this.handleSeriesLengthChange }
+						/>
+					</div>
+				) }
+			</div>
+		);
+	}
+}
+
+export default LineChartExample;

--- a/client/components/line-chart/docs/example.js
+++ b/client/components/line-chart/docs/example.js
@@ -36,6 +36,8 @@ class LineChartExample extends Component {
 		seriesLength: 10,
 		showDataControls: false,
 		data: LineChartExample.createData( 1, 50, 10 ),
+		yAxisMode: 'absolute',
+		fillArea: false,
 	};
 
 	handleDataMinChange = event => {
@@ -68,6 +70,18 @@ class LineChartExample extends Component {
 		} );
 	};
 
+	handleFillAreaToggle = () => {
+		this.setState( {
+			fillArea: ! this.state.fillArea,
+		} );
+	};
+
+	handleYAxisModeToggle = () => {
+		this.setState( {
+			yAxisMode: this.state.yAxisMode === 'absolute' ? 'relative' : 'absolute',
+		} );
+	};
+
 	render() {
 		return (
 			<div>
@@ -75,7 +89,11 @@ class LineChartExample extends Component {
 					{ this.state.showDataControls ? 'Hide Data Controls' : 'Show Data Controls' }
 				</a>
 				<Card>
-					<LineChart data={ this.state.data } />
+					<LineChart
+						data={ this.state.data }
+						yAxisMode={ this.state.yAxisMode }
+						fillArea={ this.state.fillArea }
+					/>
 				</Card>
 				{ this.state.showDataControls && (
 					<div>
@@ -100,6 +118,22 @@ class LineChartExample extends Component {
 							min={ 3 }
 							onChange={ this.handleSeriesLengthChange }
 						/>
+						<div>
+							<label>Fill Area</label>
+							<input
+								type="checkbox"
+								checked={ this.state.fillArea }
+								onChange={ this.handleFillAreaToggle }
+							/>
+						</div>
+						<div>
+							<label>Absolute Y Axis</label>
+							<input
+								type="checkbox"
+								checked={ this.state.yAxisMode === 'absolute' }
+								onChange={ this.handleYAxisModeToggle }
+							/>
+						</div>
 					</div>
 				) }
 			</div>

--- a/client/components/line-chart/docs/example.js
+++ b/client/components/line-chart/docs/example.js
@@ -41,23 +41,26 @@ class LineChartExample extends Component {
 	};
 
 	changeDataMin = event => {
-		const newMin = event.target.value;
+		const newDataMin = event.target.value;
+
 		this.setState( {
-			dataMin: newMin,
-			data: LineChartExample.createData( newMin, this.state.dataMax, this.state.seriesLength ),
+			dataMin: newDataMin,
+			data: LineChartExample.createData( newDataMin, this.state.dataMax, this.state.seriesLength ),
 		} );
 	};
 
 	changeDataMax = event => {
-		const newMax = event.target.value;
+		const newDataMax = event.target.value;
+
 		this.setState( {
-			dataMax: event.target.value,
-			data: LineChartExample.createData( this.state.dataMin, newMax, this.state.seriesLength ),
+			dataMax: newDataMax,
+			data: LineChartExample.createData( this.state.dataMin, newDataMax, this.state.seriesLength ),
 		} );
 	};
 
 	changeSeriesLength = event => {
 		const newSeriesLength = event.target.value;
+
 		this.setState( {
 			seriesLength: newSeriesLength,
 			data: LineChartExample.createData( this.state.dataMin, this.state.dataMax, newSeriesLength ),

--- a/client/components/line-chart/docs/example.js
+++ b/client/components/line-chart/docs/example.js
@@ -40,7 +40,7 @@ class LineChartExample extends Component {
 		fillArea: false,
 	};
 
-	handleDataMinChange = event => {
+	changeDataMin = event => {
 		const newMin = event.target.value;
 		this.setState( {
 			dataMin: newMin,
@@ -48,7 +48,7 @@ class LineChartExample extends Component {
 		} );
 	};
 
-	handleDataMaxChange = event => {
+	changeDataMax = event => {
 		const newMax = event.target.value;
 		this.setState( {
 			dataMax: event.target.value,
@@ -56,7 +56,7 @@ class LineChartExample extends Component {
 		} );
 	};
 
-	handleSeriesLengthChange = event => {
+	changeSeriesLength = event => {
 		const newSeriesLength = event.target.value;
 		this.setState( {
 			seriesLength: newSeriesLength,
@@ -64,19 +64,19 @@ class LineChartExample extends Component {
 		} );
 	};
 
-	handleShowDataControlsToggle = () => {
+	toggleDataControls = () => {
 		this.setState( {
 			showDataControls: ! this.state.showDataControls,
 		} );
 	};
 
-	handleFillAreaToggle = () => {
+	toggleFillArea = () => {
 		this.setState( {
 			fillArea: ! this.state.fillArea,
 		} );
 	};
 
-	handleYAxisModeToggle = () => {
+	toggleYAxisMode = () => {
 		this.setState( {
 			yAxisMode: this.state.yAxisMode === 'absolute' ? 'relative' : 'absolute',
 		} );
@@ -85,7 +85,7 @@ class LineChartExample extends Component {
 	render() {
 		return (
 			<div>
-				<a className="docs__design-toggle button" onClick={ this.handleShowDataControlsToggle }>
+				<a className="docs__design-toggle button" onClick={ this.toggleDataControls }>
 					{ this.state.showDataControls ? 'Hide Data Controls' : 'Show Data Controls' }
 				</a>
 
@@ -104,7 +104,7 @@ class LineChartExample extends Component {
 							type="number"
 							value={ this.state.dataMin }
 							min={ 0 }
-							onChange={ this.handleDataMinChange }
+							onChange={ this.changeDataMin }
 						/>
 
 						<label>Data Max</label>
@@ -112,7 +112,7 @@ class LineChartExample extends Component {
 							type="number"
 							value={ this.state.dataMax }
 							min={ 0 }
-							onChange={ this.handleDataMaxChange }
+							onChange={ this.changeDataMax }
 						/>
 
 						<label>Series Length</label>
@@ -120,7 +120,7 @@ class LineChartExample extends Component {
 							type="number"
 							value={ this.state.seriesLength }
 							min={ 3 }
-							onChange={ this.handleSeriesLengthChange }
+							onChange={ this.changeSeriesLength }
 						/>
 
 						<div>
@@ -128,7 +128,7 @@ class LineChartExample extends Component {
 								<input
 									type="checkbox"
 									checked={ this.state.fillArea }
-									onChange={ this.handleFillAreaToggle }
+									onChange={ this.toggleFillArea }
 								/>
 								Fill Area
 							</label>
@@ -139,7 +139,7 @@ class LineChartExample extends Component {
 								<input
 									type="checkbox"
 									checked={ this.state.yAxisMode === 'absolute' }
-									onChange={ this.handleYAxisModeToggle }
+									onChange={ this.toggleYAxisMode }
 								/>
 								Absolute Y Axis
 							</label>

--- a/client/components/line-chart/docs/example.js
+++ b/client/components/line-chart/docs/example.js
@@ -88,6 +88,7 @@ class LineChartExample extends Component {
 				<a className="docs__design-toggle button" onClick={ this.handleShowDataControlsToggle }>
 					{ this.state.showDataControls ? 'Hide Data Controls' : 'Show Data Controls' }
 				</a>
+
 				<Card>
 					<LineChart
 						data={ this.state.data }
@@ -95,6 +96,7 @@ class LineChartExample extends Component {
 						fillArea={ this.state.fillArea }
 					/>
 				</Card>
+
 				{ this.state.showDataControls && (
 					<div>
 						<label>Data Min</label>
@@ -104,6 +106,7 @@ class LineChartExample extends Component {
 							min={ 0 }
 							onChange={ this.handleDataMinChange }
 						/>
+
 						<label>Data Max</label>
 						<input
 							type="number"
@@ -111,6 +114,7 @@ class LineChartExample extends Component {
 							min={ 0 }
 							onChange={ this.handleDataMaxChange }
 						/>
+
 						<label>Series Length</label>
 						<input
 							type="number"
@@ -118,21 +122,27 @@ class LineChartExample extends Component {
 							min={ 3 }
 							onChange={ this.handleSeriesLengthChange }
 						/>
+
 						<div>
-							<label>Fill Area</label>
-							<input
-								type="checkbox"
-								checked={ this.state.fillArea }
-								onChange={ this.handleFillAreaToggle }
-							/>
+							<label>
+								<input
+									type="checkbox"
+									checked={ this.state.fillArea }
+									onChange={ this.handleFillAreaToggle }
+								/>
+								Fill Area
+							</label>
 						</div>
+
 						<div>
-							<label>Absolute Y Axis</label>
-							<input
-								type="checkbox"
-								checked={ this.state.yAxisMode === 'absolute' }
-								onChange={ this.handleYAxisModeToggle }
-							/>
+							<label>
+								<input
+									type="checkbox"
+									checked={ this.state.yAxisMode === 'absolute' }
+									onChange={ this.handleYAxisModeToggle }
+								/>
+								Absolute Y Axis
+							</label>
 						</div>
 					</div>
 				) }

--- a/client/components/line-chart/docs/example.js
+++ b/client/components/line-chart/docs/example.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { moment } from 'i18n-calypso';
 import { range, random } from 'lodash';
 
 /**
@@ -18,26 +19,30 @@ class LineChartExample extends Component {
 	static displayName = 'LineChart';
 
 	static createData( dataMin, dataMax, seriesLength ) {
+		const now = moment();
+
 		return range( NUM_DATA_SERIES ).map( () => {
-			return range( seriesLength ).map( e => {
-				const date = new Date();
-				date.setDate( date.getDate() - ( seriesLength - e ) );
+			let date = now.clone();
+
+			return range( seriesLength ).map( () => {
+				date = date.subtract( 1, 'days' );
+
 				return {
-					date: date.getTime(),
+					date: date.valueOf(),
 					value: random( dataMin, dataMax ),
 				};
-			} );
+			} ).reverse();
 		} );
 	}
 
 	state = {
-		dataMin: 1,
+		data: LineChartExample.createData( 1, 50, 10 ),
 		dataMax: 50,
+		dataMin: 1,
+		fillArea: false,
 		seriesLength: 10,
 		showDataControls: false,
-		data: LineChartExample.createData( 1, 50, 10 ),
 		yAxisMode: 'absolute',
-		fillArea: false,
 	};
 
 	changeDataMin = event => {

--- a/client/components/line-chart/docs/example.js
+++ b/client/components/line-chart/docs/example.js
@@ -42,7 +42,6 @@ class LineChartExample extends Component {
 		fillArea: false,
 		seriesLength: 10,
 		showDataControls: false,
-		yAxisMode: 'absolute',
 	};
 
 	changeDataMin = event => {
@@ -84,12 +83,6 @@ class LineChartExample extends Component {
 		} );
 	};
 
-	toggleYAxisMode = () => {
-		this.setState( {
-			yAxisMode: this.state.yAxisMode === 'absolute' ? 'relative' : 'absolute',
-		} );
-	};
-
 	render() {
 		return (
 			<div>
@@ -100,7 +93,6 @@ class LineChartExample extends Component {
 				<Card>
 					<LineChart
 						data={ this.state.data }
-						yAxisMode={ this.state.yAxisMode }
 						fillArea={ this.state.fillArea }
 					/>
 				</Card>
@@ -140,18 +132,6 @@ class LineChartExample extends Component {
 								/>
 
 								Fill Area
-							</label>
-						</div>
-
-						<div>
-							<label>
-								<input
-									type="checkbox"
-									checked={ this.state.yAxisMode === 'absolute' }
-									onChange={ this.toggleYAxisMode }
-								/>
-
-								Absolute Y Axis
 							</label>
 						</div>
 					</div>

--- a/client/components/line-chart/docs/example.js
+++ b/client/components/line-chart/docs/example.js
@@ -106,7 +106,7 @@ class LineChartExample extends Component {
 						<input
 							type="number"
 							value={ this.state.dataMin }
-							min={ 0 }
+							min="0"
 							onChange={ this.changeDataMin }
 						/>
 
@@ -114,7 +114,7 @@ class LineChartExample extends Component {
 						<input
 							type="number"
 							value={ this.state.dataMax }
-							min={ 0 }
+							min="0"
 							onChange={ this.changeDataMax }
 						/>
 
@@ -122,7 +122,7 @@ class LineChartExample extends Component {
 						<input
 							type="number"
 							value={ this.state.seriesLength }
-							min={ 3 }
+							min="3"
 							onChange={ this.changeSeriesLength }
 						/>
 
@@ -133,6 +133,7 @@ class LineChartExample extends Component {
 									checked={ this.state.fillArea }
 									onChange={ this.toggleFillArea }
 								/>
+
 								Fill Area
 							</label>
 						</div>
@@ -144,6 +145,7 @@ class LineChartExample extends Component {
 									checked={ this.state.yAxisMode === 'absolute' }
 									onChange={ this.toggleYAxisMode }
 								/>
+
 								Absolute Y Axis
 							</label>
 						</div>

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -22,6 +22,8 @@ const POINT_SIZE = 3;
 const END_POINT_SIZE = 1;
 const MAX_DRAW_POINTS_SIZE = 10;
 const CHART_MARGIN = 0.01;
+const MAX_LEFT_TICKS = 10;
+const MAX_BOTTOM_TICKS = 10;
 
 class LineChart extends Component {
 	static propTypes = {
@@ -51,12 +53,13 @@ class LineChart extends Component {
 	};
 
 	drawAxes = ( svg, params ) => {
-		const { yScale, xScale, height } = params;
+		const { yScale, xScale, height, leftTicks, bottomTicks } = params;
 		const { margin } = this.props;
 
 		const axisLeft = d3AxisLeft( yScale );
 		const bottomAxis = d3AxisBottom( xScale );
-		bottomAxis.ticks( 6 );
+		bottomAxis.ticks( bottomTicks );
+		axisLeft.ticks( leftTicks );
 
 		svg
 			.append( 'g' )
@@ -192,6 +195,8 @@ class LineChart extends Component {
 				] )
 				.range( [ newHeight - margin.bottom, margin.top ] )
 				.nice(),
+			leftTicks: MAX_LEFT_TICKS >= valueExtent[ 1 ] ? valueExtent[ 1 ] : MAX_LEFT_TICKS,
+			bottomTicks: MAX_BOTTOM_TICKS >= concatData.length ? concatData.length : MAX_BOTTOM_TICKS,
 		};
 	};
 

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -27,6 +27,7 @@ const X_AXIS_TICKS_MAX = 8;
 const X_AXIS_TICKS_SPACE = 70;
 const Y_AXIS_TICKS = 6;
 const Y_AXIS_TICKS_SPACE = 30;
+const APPROXIMATELY_A_MONTH_IN_MS = 31 * 24 * 60 * 60 * 1000;
 
 const dateFormatFunction = displayMonthTicksOnly => ( date, index, tickRefs ) => {
 	const everyOtherTickOnly = ! displayMonthTicksOnly && tickRefs.length > X_AXIS_TICKS_MAX;
@@ -49,6 +50,8 @@ const dateFormatFunction = displayMonthTicksOnly => ( date, index, tickRefs ) =>
 		? moment( date ).format( displayMonthTicksOnly ? 'MMM' : 'MMM D' )
 		: '';
 };
+
+const dateToAbsoluteMonth = date => date.getYear() * 12 + date.getMonth();
 
 class LineChart extends Component {
 	static propTypes = {
@@ -231,12 +234,13 @@ class LineChart extends Component {
 		const [ minTimestamp, maxTimestamp ] = d3Extent( concatData, datum => datum.date );
 
 		const timeDomainAdjustment = ( maxTimestamp - minTimestamp ) * CHART_MARGIN;
+		const displayMonthOnly = maxTimestamp - minTimestamp > APPROXIMATELY_A_MONTH_IN_MS;
+		const months =
+			dateToAbsoluteMonth( new Date( maxTimestamp ) ) -
+			dateToAbsoluteMonth( new Date( minTimestamp ) );
 
-		const displayMonthOnly =
-			new Date( maxTimestamp ).getMonth() - new Date( minTimestamp ).getMonth() >= 2;
-
-		// start out with a single ticks for each data point
-		let xTicks = concatData.length / data.length;
+		// start out with a single ticks for each data point, or the number of months if we have enough dates
+		let xTicks = displayMonthOnly ? months : concatData.length / data.length;
 
 		// reduce the number of ticks if it looks like they will be drawn too close together
 		xTicks =

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -73,6 +73,7 @@ class LineChart extends Component {
 		const axis = d3AxisBottom( xScale );
 		axis.ticks( bottomTicks );
 		axis.tickFormat( dateFormatFunction( displayMonthOnly ) );
+		axis.tickSizeOuter( 0 );
 
 		svg
 			.append( 'g' )
@@ -87,6 +88,7 @@ class LineChart extends Component {
 
 		const axis = d3AxisLeft( yScale );
 		axis.ticks( leftTicks );
+		axis.tickSizeOuter( 0 );
 
 		svg
 			.append( 'g' )

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -25,7 +25,7 @@ const POINTS_SIZE = 3;
 const POINTS_END_SIZE = 1;
 const X_AXIS_TICKS_MAX = 8;
 const X_AXIS_TICKS_SPACE = 70;
-const Y_AXIS_TICKS_MAX = 6;
+const Y_AXIS_TICKS = 6;
 const Y_AXIS_TICKS_SPACE = 30;
 
 const dateFormatFunction = displayMonthOnly => ( date, index, tickRefs ) => {
@@ -241,20 +241,24 @@ class LineChart extends Component {
 	getYAxisParams = ( concatData, margin, newHeight ) => {
 		const [ minValue, maxValue ] = d3Extent( concatData, datum => datum.value );
 
+		let maxDomain = maxValue;
+
+		// Makes sure we always use integers instead of decimal numbers for tick labels when the maximum value is less
+		// than the default number of ticks
+		if ( maxDomain < Y_AXIS_TICKS ) {
+			maxDomain = Y_AXIS_TICKS;
+		}
+
 		const valueDomainAdjustment = ( maxValue - minValue ) * CHART_MARGIN;
 
-		// if the value is less than our max ticks, use that value so that each tick is a round integer
-		const yTicks = Y_AXIS_TICKS_MAX > maxValue ? maxValue : Y_AXIS_TICKS_MAX;
+		maxDomain = maxDomain + valueDomainAdjustment;
 
 		return {
 			yScale: d3ScaleLinear()
-				.domain( [
-					0,
-					maxValue + valueDomainAdjustment,
-				] )
+				.domain( [ 0, maxDomain ] )
 				.range( [ newHeight - margin.bottom, margin.top ] )
 				.nice(),
-			yTicks,
+			yTicks: Y_AXIS_TICKS,
 		};
 	};
 

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -11,6 +11,7 @@ import { scaleLinear as d3ScaleLinear, scaleTime as d3TimeScale } from 'd3-scale
 import { axisBottom as d3AxisBottom, axisLeft as d3AxisLeft } from 'd3-axis';
 import { select as d3Select } from 'd3-selection';
 import { concat, first, last } from 'lodash';
+import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -22,7 +23,7 @@ const POINT_SIZE = 3;
 const END_POINT_SIZE = 1;
 const MAX_DRAW_POINTS_SIZE = 10;
 const CHART_MARGIN = 0.01;
-const MAX_LEFT_TICKS = 10;
+const MAX_LEFT_TICKS = 6;
 const MAX_BOTTOM_TICKS = 10;
 
 class LineChart extends Component {
@@ -59,6 +60,7 @@ class LineChart extends Component {
 		const axisLeft = d3AxisLeft( yScale );
 		const bottomAxis = d3AxisBottom( xScale );
 		bottomAxis.ticks( bottomTicks );
+		bottomAxis.tickFormat( d => moment( d ).format( 'll' ) );
 		axisLeft.ticks( leftTicks );
 
 		svg
@@ -196,7 +198,10 @@ class LineChart extends Component {
 				.range( [ newHeight - margin.bottom, margin.top ] )
 				.nice(),
 			leftTicks: MAX_LEFT_TICKS >= valueExtent[ 1 ] ? valueExtent[ 1 ] : MAX_LEFT_TICKS,
-			bottomTicks: MAX_BOTTOM_TICKS >= concatData.length ? concatData.length : MAX_BOTTOM_TICKS,
+			bottomTicks:
+				MAX_BOTTOM_TICKS >= concatData.length / data.length
+					? concatData.length / data.length
+					: MAX_BOTTOM_TICKS,
 		};
 	};
 

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -42,7 +42,6 @@ class LineChart extends Component {
 		fillArea: PropTypes.bool,
 		margin: PropTypes.object,
 		renderTooltipForDatanum: PropTypes.func,
-		yAxisMode: PropTypes.oneOf( [ 'relative', 'absolute' ] ),
 	};
 
 	static defaultProps = {
@@ -55,7 +54,6 @@ class LineChart extends Component {
 			left: 30,
 		},
 		renderTooltipForDatanum: datum => datum.value,
-		yAxisMode: 'absolute',
 	};
 
 	state = {
@@ -240,7 +238,7 @@ class LineChart extends Component {
 		};
 	};
 
-	getYAxisParams = ( concatData, margin, newHeight, yAxisMode ) => {
+	getYAxisParams = ( concatData, margin, newHeight ) => {
 		const [ minValue, maxValue ] = d3Extent( concatData, datum => datum.value );
 
 		const valueDomainAdjustment = ( maxValue - minValue ) * CHART_MARGIN;
@@ -251,7 +249,7 @@ class LineChart extends Component {
 		return {
 			yScale: d3ScaleLinear()
 				.domain( [
-					yAxisMode === 'relative' ? minValue - valueDomainAdjustment : 0,
+					0,
 					maxValue + valueDomainAdjustment,
 				] )
 				.range( [ newHeight - margin.bottom, margin.top ] )
@@ -261,7 +259,7 @@ class LineChart extends Component {
 	};
 
 	getParams = node => {
-		const { aspectRatio, margin, data, yAxisMode } = this.props;
+		const { aspectRatio, margin, data } = this.props;
 
 		const newWidth = node.offsetWidth;
 		const newHeight = newWidth / aspectRatio;
@@ -272,7 +270,7 @@ class LineChart extends Component {
 			height: newHeight,
 			width: newWidth,
 			...this.getXAxisParams( concatData, data, margin, newWidth ),
-			...this.getYAxisParams( concatData, margin, newHeight, yAxisMode ),
+			...this.getYAxisParams( concatData, margin, newHeight ),
 		};
 	};
 

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -62,26 +62,37 @@ class LineChart extends Component {
 	};
 
 	drawAxes = ( svg, params ) => {
-		const { yScale, xScale, height, leftTicks, bottomTicks, displayMonthOnly } = params;
+		this.drawBottomAxis( svg, params );
+		this.drawLeftAxis( svg, params );
+	};
+
+	drawBottomAxis = ( svg, params ) => {
+		const { bottomTicks, displayMonthOnly, height, xScale } = params;
 		const { margin } = this.props;
 
-		const axisLeft = d3AxisLeft( yScale );
-		const bottomAxis = d3AxisBottom( xScale );
-		bottomAxis.ticks( bottomTicks );
-		bottomAxis.tickFormat( dateFormatFunction( displayMonthOnly ) );
-		axisLeft.ticks( leftTicks );
-
-		svg
-			.append( 'g' )
-			.attr( 'class', 'line-chart__y-axis' )
-			.attr( 'transform', `translate(${ margin.left },0)` )
-			.call( axisLeft );
+		const axis = d3AxisBottom( xScale );
+		axis.ticks( bottomTicks );
+		axis.tickFormat( dateFormatFunction( displayMonthOnly ) );
 
 		svg
 			.append( 'g' )
 			.attr( 'class', 'line-chart__x-axis' )
 			.attr( 'transform', `translate(0,${ height - margin.bottom })` )
-			.call( bottomAxis );
+			.call( axis );
+	};
+
+	drawLeftAxis = ( svg, params ) => {
+		const { leftTicks, yScale } = params;
+		const { margin } = this.props;
+
+		const axis = d3AxisLeft( yScale );
+		axis.ticks( leftTicks );
+
+		svg
+			.append( 'g' )
+			.attr( 'class', 'line-chart__y-axis' )
+			.attr( 'transform', `translate(${ margin.left },0)` )
+			.call( axis );
 	};
 
 	drawLines = ( svg, params ) => {

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -10,7 +10,7 @@ import { line as d3Line, area as d3Area, curveMonotoneX as d3MonotoneXCurve } fr
 import { scaleLinear as d3ScaleLinear, scaleTime as d3TimeScale } from 'd3-scale';
 import { axisBottom as d3AxisBottom, axisRight as d3AxisRight } from 'd3-axis';
 import { select as d3Select } from 'd3-selection';
-import { concat, first, last } from 'lodash';
+import { concat, first, last, mean } from 'lodash';
 import { moment } from 'i18n-calypso';
 
 /**
@@ -29,10 +29,20 @@ const Y_AXIS_TICKS = 6;
 const Y_AXIS_TICKS_SPACE = 30;
 
 const dateFormatFunction = displayMonthTicksOnly => ( date, index, tickRefs ) => {
-	// this can only be figured out here, becuase D3 will decide how many ticks there should be
 	const everyOtherTickOnly = ! displayMonthTicksOnly && tickRefs.length > X_AXIS_TICKS_MAX;
+	// this can only be figured out here, becuase D3 will decide how many ticks there should be
 	const isFirstMonthTick =
-		index === 0 || tickRefs[ index - 1 ].__data__.getMonth() < date.getMonth();
+		index ===
+		Math.round(
+			mean(
+				tickRefs
+					.map(
+						( tickRef, tickRefIndex ) =>
+							tickRef.__data__.getMonth() === date.getMonth() ? tickRefIndex : null
+					)
+					.filter( e => e !== null )
+			)
+		);
 	return ( ! everyOtherTickOnly && ! displayMonthTicksOnly ) ||
 		( everyOtherTickOnly && index % 2 === 0 ) ||
 		( displayMonthTicksOnly && isFirstMonthTick )

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -174,9 +174,9 @@ class LineChart extends Component {
 	};
 
 	drawChart = ( svg, params ) => {
+		this.drawAxes( svg, params );
 		this.drawLines( svg, params );
 		this.drawPoints( svg, params );
-		this.drawAxes( svg, params );
 		this.bindEvents( svg, params );
 	};
 

--- a/client/components/line-chart/style.scss
+++ b/client/components/line-chart/style.scss
@@ -75,12 +75,20 @@
 	padding-bottom: 50%;
 }
 
+.line-chart__x-axis,
 .line-chart__y-axis {
-	font-size: 15px;
-	stroke-width: 2px;
+	font-size: 11px;
+
+	.domain,
+	line {
+		stroke: $gray-lighten-30;
+	}
 }
 
-.line-chart__x-axis {
-	font-size: 15px;
-	stroke-width: 2px;
+.line-chart__x-axis text {
+	fill: $gray-darken-30;
+}
+
+.line-chart__y-axis text {
+	fill: $gray-darken-10;
 }

--- a/client/components/line-chart/style.scss
+++ b/client/components/line-chart/style.scss
@@ -70,17 +70,16 @@
 
 .line-chart__placeholder {
 	@include placeholder();
+
 	padding-bottom: 50%;
- }
+}
 
 .line-chart__y-axis {
 	font-size: 15px;
 	stroke-width: 2px;
-	//fill: $gray-dark;
 }
 
 .line-chart__x-axis {
 	font-size: 15px;
 	stroke-width: 2px;
-	//fill: $gray-dark;
 }

--- a/client/components/line-chart/style.scss
+++ b/client/components/line-chart/style.scss
@@ -31,26 +31,27 @@
 	opacity: 0.1;
 }
 
-.line-chart__line-point-0 {
+.line-chart__line-point {
+	cursor: pointer;
+}
+
+.line-chart__line-point-0,
+.line-chart__line-point-1,
+.line-chart__line-point-2 {
 	fill: $white;
-	stroke: $blue-dark;
 	stroke-width: 3px;
+}
+
+.line-chart__line-point-0 {
+	stroke: $blue-dark;
 }
 
 .line-chart__line-point-1 {
-	fill: $white;
 	stroke: $blue-medium;
-	stroke-width: 3px;
 }
 
 .line-chart__line-point-2 {
-	fill: $white;
 	stroke: $blue-light;
-	stroke-width: 3px;
-}
-
-.line-chart__line-point {
-	cursor: pointer;
 }
 
 .line-chart__line-end-point-0 {

--- a/client/components/line-chart/style.scss
+++ b/client/components/line-chart/style.scss
@@ -72,3 +72,15 @@
 	@include placeholder();
 	padding-bottom: 50%;
  }
+
+.line-chart__y-axis {
+	font-size: 15px;
+	stroke-width: 2px;
+	//fill: $gray-dark;
+}
+
+.line-chart__x-axis {
+	font-size: 15px;
+	stroke-width: 2px;
+	//fill: $gray-dark;
+}

--- a/client/devdocs/design/component-examples.js
+++ b/client/devdocs/design/component-examples.js
@@ -45,6 +45,7 @@ export InputChrono from 'components/input-chrono/docs/example';
 export JetpackColophonExample from 'components/jetpack-colophon/docs/example';
 export JetpackLogoExample from 'components/jetpack-logo/docs/example';
 export LanguagePicker from 'components/language-picker/docs/example';
+export LineChart from 'components/line-chart/docs/example';
 export ListEnd from 'components/list-end/docs/example';
 export MarkedLinesExample from 'components/marked-lines/docs/example';
 export Notices from 'components/notice/docs/example';

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -68,6 +68,7 @@ import InputChrono from 'components/input-chrono/docs/example';
 import JetpackColophonExample from 'components/jetpack-colophon/docs/example';
 import JetpackLogoExample from 'components/jetpack-logo/docs/example';
 import LanguagePicker from 'components/language-picker/docs/example';
+import LineChart from 'components/line-chart/docs/example';
 import ListEnd from 'components/list-end/docs/example';
 import MarkedLinesExample from 'components/marked-lines/docs/example';
 import Notices from 'components/notice/docs/example';
@@ -201,6 +202,7 @@ class DesignAssets extends React.Component {
 					<JetpackColophonExample readmeFilePath="jetpack-colophon" />
 					<JetpackLogoExample readmeFilePath="jetpack-logo" />
 					<LanguagePicker readmeFilePath="language-picker" />
+					<LineChart />
 					<ListEnd readmeFilePath="list-end" />
 					<MarkedLinesExample readmeFilePath="marked-lines" />
 					<Notices readmeFilePath="notice" />

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -19,7 +19,6 @@ import GoogleMyBusinessStatsChart from 'my-sites/google-my-business/stats/chart'
 import GoogleMyBusinessStatsTip from 'my-sites/google-my-business/stats/tip';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import SectionHeader from 'components/section-header';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import StatsNavigation from 'blocks/stats-navigation';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
@@ -112,7 +111,6 @@ class GoogleMyBusinessStats extends Component {
 						} }
 						renderTooltipForDatanum={ this.renderSearchTooltipForDatanum }
 					/>
-					<SectionHeader label={ translate( 'How customers search for your business' ) } />
 				</div>
 
 				<div className="gmb-stats__metric">


### PR DESCRIPTION
This pull request refines axes of the new `LineChart` component in order to bring them closer to the ones used for bar charts on the regular `Stats` page (less tick density, integers only on the Y axis, different color scheme for tick labels ...):

Before | After
------ | -----
<img width="441" alt="screenshot" src="https://user-images.githubusercontent.com/594356/39672740-6ab1b946-5130-11e8-877f-0685c54ff37a.png"> | <img width="433" alt="screenshot" src="https://user-images.githubusercontent.com/594356/39672744-7d40caca-5130-11e8-8844-6c113d62072a.png">

Before | After
------ | -----
<img width="433" alt="screenshot" src="https://user-images.githubusercontent.com/594356/39672750-9add97b6-5130-11e8-97fc-6d97950d762c.png"> | <img width="422" alt="screenshot" src="https://user-images.githubusercontent.com/594356/39672754-a8f1d902-5130-11e8-955e-77129127330c.png">

## Testing

- Navigate to http://calypso.localhost:3000/devdocs/design/line-chart
- Click "Show Data Controls" and play around with the data. Try to create situations where the chart might misbehave and see how it handles it.
