### PR TITLE
Reader: Show `PostLikesPopover` when hovering over post likes

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -481,6 +481,7 @@
 @import 'reader/following/style';
 @import 'reader/following-manage/style';
 @import 'reader/stream/style';
+@import 'reader/like-button/style';
 @import 'reader/list-gap/style';
 @import 'reader/list-item/style';
 @import 'reader/list-stream/style';

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -64,6 +64,8 @@ class LikeButton extends PureComponent {
 			postId,
 			slug,
 			translate,
+			onMouseEnter,
+			onMouseLeave,
 		} = this.props;
 		const showLikeCount = likeCount > 0 || showZeroCount;
 		const isLink = containerTag === 'a';
@@ -114,6 +116,8 @@ class LikeButton extends PureComponent {
 					href,
 					className: classNames( containerClasses ),
 					onClick: ! isLink ? this.toggleLiked : null,
+					onMouseEnter,
+					onMouseLeave,
 				},
 				isNull
 			),

--- a/client/blocks/post-likes/index.jsx
+++ b/client/blocks/post-likes/index.jsx
@@ -72,7 +72,17 @@ class PostLikes extends React.PureComponent {
 	}
 
 	render() {
-		const { likeCount, likes, postId, postType, siteId, translate, showDisplayNames } = this.props;
+		const {
+			likeCount,
+			likes,
+			postId,
+			postType,
+			siteId,
+			translate,
+			showDisplayNames,
+			onMouseEnter,
+			onMouseLeave,
+		} = this.props;
 
 		let noLikesLabel;
 
@@ -85,9 +95,10 @@ class PostLikes extends React.PureComponent {
 		const isLoading = ! likes;
 
 		const classes = classnames( 'post-likes', { 'has-display-names': showDisplayNames } );
+		const extraProps = { onMouseEnter, onMouseLeave };
 
 		return (
-			<div className={ classes }>
+			<div className={ classes } { ...extraProps }>
 				<QueryPostLikes siteId={ siteId } postId={ postId } needsLikers={ true } />
 				{ isLoading && (
 					<span key="placeholder" className="post-likes__count is-loading">

--- a/client/blocks/post-likes/popover.jsx
+++ b/client/blocks/post-likes/popover.jsx
@@ -16,7 +16,17 @@ import PostLikes from './index';
 import { getPostLikes } from 'state/selectors';
 
 function PostLikesPopover( props ) {
-	const { className, siteId, postId, showDisplayNames, context, onClose, likes } = props;
+	const {
+		className,
+		siteId,
+		postId,
+		showDisplayNames,
+		context,
+		onClose,
+		likes,
+		onMouseEnter,
+		onMouseLeave,
+	} = props;
 
 	// Whenever our `Popover` content changes size (loading, complete, siteId,
 	// or postId, for example), we need to force the `Popover` to re-render and
@@ -39,9 +49,12 @@ function PostLikesPopover( props ) {
 		'showDisplayNames',
 		'context',
 		'onClose',
-		'likes'
+		'likes',
+		'onMouseEnter',
+		'onMouseLeave'
 	);
 	const classes = classnames( 'post-likes-popover', className );
+	const postLikesProps = { siteId, postId, showDisplayNames, onMouseEnter, onMouseLeave };
 
 	return (
 		<Popover
@@ -52,7 +65,7 @@ function PostLikesPopover( props ) {
 			onClose={ onClose }
 			key={ popoverKey }
 		>
-			<PostLikes siteId={ siteId } postId={ postId } showDisplayNames={ showDisplayNames } />
+			<PostLikes { ...postLikesProps } />
 		</Popover>
 	);
 }

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 
 /**
@@ -10,11 +10,27 @@ import { connect } from 'react-redux';
  */
 import { reduxGetState } from 'lib/redux-bridge';
 import LikeButtonContainer from 'blocks/like-button';
+import PostLikesPopover from 'blocks/post-likes/popover';
 import { markPostSeen } from 'state/reader/posts/actions';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 import { getPostByKey } from 'state/reader/posts/selectors';
+import { isEnabled } from 'config';
 
 class ReaderLikeButton extends React.Component {
+	constructor( props ) {
+		super( props );
+
+		this.hidePopoverTimeout = null;
+		this.state = {
+			showLikesPopover: false,
+			likesPopoverContext: null,
+		};
+	}
+
+	componentWillUnmount() {
+		clearTimeout( this.hidePopoverTimeout );
+	}
+
 	recordLikeToggle = liked => {
 		const post =
 			this.props.post ||
@@ -35,13 +51,55 @@ class ReaderLikeButton extends React.Component {
 		}
 	};
 
+	setLikesPopoverContext = element => {
+		this.setState( { likesPopoverContext: element } );
+	};
+
+	maybeShowLikesPopover = () => {
+		if ( ! isEnabled( 'reader/likes-hover' ) ) {
+			return;
+		}
+		clearTimeout( this.hidePopoverTimeout );
+		this.setState( { showLikesPopover: true } );
+	};
+
+	maybeHideLikesPopover = () => {
+		if ( ! isEnabled( 'reader/likes-hover' ) ) {
+			return;
+		}
+		this.hidePopoverTimeout = setTimeout( () => {
+			this.setState( { showLikesPopover: false } );
+		}, 500 );
+	};
+
 	render() {
+		const { siteId, postId } = this.props;
+		const { showLikesPopover, likesPopoverContext } = this.state;
+
 		return (
-			<LikeButtonContainer
-				{ ...this.props }
-				onLikeToggle={ this.recordLikeToggle }
-				likeSource="reader"
-			/>
+			<Fragment>
+				<LikeButtonContainer
+					{ ...this.props }
+					ref={ this.setLikesPopoverContext }
+					onMouseEnter={ this.maybeShowLikesPopover }
+					onMouseLeave={ this.maybeHideLikesPopover }
+					onLikeToggle={ this.recordLikeToggle }
+					likeSource="reader"
+				/>
+				{ showLikesPopover &&
+					siteId &&
+					postId && (
+						<PostLikesPopover
+							className="reader-likes-popover"
+							onMouseEnter={ this.maybeShowLikesPopover }
+							onMouseLeave={ this.maybeHideLikesPopover }
+							siteId={ siteId }
+							postId={ postId }
+							showDisplayNames={ true }
+							context={ likesPopoverContext }
+						/>
+					) }
+			</Fragment>
 		);
 	}
 }

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -90,7 +90,7 @@ class ReaderLikeButton extends React.Component {
 					siteId &&
 					postId && (
 						<PostLikesPopover
-							className="reader-likes-popover"
+							className="reader-likes-popover" // eslint-disable-line
 							onMouseEnter={ this.maybeShowLikesPopover }
 							onMouseLeave={ this.maybeHideLikesPopover }
 							siteId={ siteId }

--- a/client/reader/like-button/style.scss
+++ b/client/reader/like-button/style.scss
@@ -1,0 +1,3 @@
+.reader-likes-popover .post-likes.has-display-names {
+	max-height: 250px;
+}

--- a/config/stage.json
+++ b/config/stage.json
@@ -101,6 +101,7 @@
 		"reader/conversations": true,
 		"reader/following-intro": true,
 		"reader/full-errors": true,
+		"reader/likes-hover": true,
 		"reader/nesting-arrow": true,
 		"reader/new-post-notifications": true,
 		"reader/recommendations/posts": true,


### PR DESCRIPTION
The Reader recently replaced an internal view that shows **who** liked each post and comment in a thread.  For parity with the previous view, the list of likers should be available here too.

This PR adapts and re-uses the `PostLikesPopover` component to show likes for posts (handling comments would require a good bit more work).  To facilitate internal use in the easiest way I know how, it's only enabled in staging for now, but you can test it locally or on calypso.live with the `?flags=reader/likes-hover` query argument.

![2018-05-01t23 18 32-0500](https://user-images.githubusercontent.com/227022/39505152-26280ebc-4d96-11e8-8892-804ab340907b.png)

See also:  #17607, p5PDj3-4x7-p2