### PR TITLE
Ad Tracking: Facebook Advanced Matching - email

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -324,7 +324,7 @@ async function loadTrackingScripts( callback ) {
 
 	// init Facebook
 	if ( isFacebookEnabled ) {
-		window.fbq( 'init', TRACKING_IDS.facebookInit );
+		initFacebook();
 	}
 
 	// init Bing
@@ -1239,6 +1239,38 @@ function costToUSD( cost, currency ) {
  */
 function isSupportedCurrency( currency ) {
 	return Object.keys( EXCHANGE_RATES ).indexOf( currency ) !== -1;
+}
+
+/**
+ * Initializes the Facebook pixel.
+ *
+ * When the user is logged in, additional hashed data is being forwarded.
+ */
+function initFacebook() {
+	if ( user.get() ) {
+		initFacebookAdvancedMatching();
+	} else {
+		window.fbq( 'init', TRACKING_IDS.facebookInit ); // simple data set, no advanced matching
+	}
+}
+
+/**
+ * See https://developers.facebook.com/docs/facebook-pixel/pixel-with-ads/conversion-tracking#advanced_match
+ */
+function initFacebookAdvancedMatching() {
+	// All data must be in lowercase. Remove all spaces.
+	const fbRequirementsFormatter = function( str ) {
+		return str.toLowerCase().replace( / /g, '' );
+	};
+
+	const currentUser = user.get();
+	const advancedMatching = {
+		em: fbRequirementsFormatter( currentUser.email ),
+	};
+
+	debug( 'FB Advanced Matching', advancedMatching );
+
+	window.fbq( 'init', TRACKING_IDS.facebookInit, advancedMatching );
 }
 
 /**


### PR DESCRIPTION
This commit adds the hashed e-mail to the data that is being sent to Facebook, such that ads can be better targeted. The hashing happens before exiting the user's browser (handled internally by the FB library).

There are multiple fields that could be submitted to FB (email, first name, last name, zip), but it seems that email may be sufficient for an initial implementation. Obtaining first name and last name proves to be more difficult due to the fact that this data is only avaialble using `userSettings` module, which requires an async API call that may end up with an invalid order of events (i.e. a Purchase event may happen before an Init event). The e-mail is always available with the user, so going deeper on the path of obtaining additional data is not yet necessary.

For documentation, you may also see: https://developers.facebook.com/docs/facebook-pixel/pixel-with-ads/conversion-tracking#advanced_match

## Testing
1. https://calypso.live/?branch=add/tracking-facebook-advanced-matching-email&flags=ad-tracking (Make sure the ad-tracking flag is set for any URL that you access).
2. Open the browser console and enable debugging `localStorage.setItem( 'debug', 'calypso:analytics:*' );`
3. Refresh the page, such that the event is fired again. 
4. Filter the console by the keyword FB which should show you something like `FB Advanced Matching: {em: "emailaddress@domainnamedotsomething"}`
