### PR TITLE
Resolve a typo in ribbon component docs.

### DIFF
--- a/client/components/ribbon/README.md
+++ b/client/components/ribbon/README.md
@@ -1,9 +1,9 @@
 Ribbon (JSX)
 ====================
 
-Ribbon is a component you can slap on a Card or a similar container to ditinguish it in
+Ribbon is a component you can slap on a Card or a similar container to distinguish it in
 some way. Ribbons came to us in the early 2010s when they were put on every container on the web.
-Since then, the internet's love for ribbons have subsided, but they will always find a
+Since then, the internet’s love for ribbons have subsided, but they will always find a
 place in our hearts.
 
 -------

--- a/client/components/ribbon/docs/example.jsx
+++ b/client/components/ribbon/docs/example.jsx
@@ -21,7 +21,7 @@ export default class extends React.PureComponent {
 				<Card>
 					<Ribbon>Default</Ribbon>
 					<p>
-						Ribbon is a component you can slap on a Card or a similar container to ditinguish it in
+						Ribbon is a component you can slap on a Card or a similar container to distinguish it in
 						some way. You can just render <b>&lt;Ribbon&gt;Text&lt;/Ribbon&gt;</b> inside to have it
 						marked.
 					</p>
@@ -30,7 +30,7 @@ export default class extends React.PureComponent {
 					<Ribbon>History</Ribbon>
 					<p>
 						Ribbons came to us in the early 2010s when they were put on every container on the web.
-						Since then, the internet's love for ribbons have subsided, but they will always find a
+						Since then, the internet’s love for ribbons have subsided, but they will always find a
 						place in our hearts.
 					</p>
 				</Card>


### PR DESCRIPTION
Whoops!

<img width="615" alt="screenshot 2018-05-02 10 46 48" src="https://user-images.githubusercontent.com/376315/39516874-2164cfe0-4df6-11e8-856b-35f036ec51d1.png">

Let's fix that.
