### PR TITLE
Replace plan computation with a hardcoded constant for <Banner />

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -33,8 +33,7 @@ import Timezone from 'components/timezone';
 import SiteIconSetting from './site-icon-setting';
 import Banner from 'components/banner';
 import { isBusiness } from 'lib/products-values';
-import { findFirstSimilarPlanKey } from 'lib/plans';
-import { FEATURE_NO_BRANDING, TYPE_BUSINESS } from 'lib/plans/constants';
+import { FEATURE_NO_BRANDING, PLAN_BUSINESS } from 'lib/plans/constants';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -516,7 +515,7 @@ export class SiteSettingsFormGeneral extends Component {
 							! isBusiness( site.plan ) && (
 								<Banner
 									feature={ FEATURE_NO_BRANDING }
-									plan={ findFirstSimilarPlanKey( site.plan, { type: TYPE_BUSINESS } ) }
+									plan={ PLAN_BUSINESS }
 									title={ translate(
 										'Remove the footer credit entirely with WordPress.com Business'
 									) }

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -14,18 +14,6 @@ jest.mock( 'components/info-popover', () => 'InfoPopover' );
 jest.mock( 'components/banner', () => 'Banner' );
 jest.mock( 'components/data/query-site-settings', () => 'QuerySiteSettings' );
 
-jest.mock( 'i18n-calypso', () => ( {
-	localize: Comp => props => (
-		<Comp
-			{ ...props }
-			translate={ function( x ) {
-				return x;
-			} }
-		/>
-	),
-	numberFormat: x => x,
-} ) );
-
 /**
  * External dependencies
  */
@@ -34,7 +22,6 @@ import React from 'react';
 import {
 	PLAN_FREE,
 	PLAN_BUSINESS,
-	PLAN_BUSINESS_2_YEARS,
 	PLAN_PREMIUM,
 	PLAN_PREMIUM_2_YEARS,
 	PLAN_PERSONAL,
@@ -96,7 +83,7 @@ describe( 'SiteSettingsFormGeneral ', () => {
 					<SiteSettingsFormGeneral { ...props } siteIsJetpack={ false } site={ { plan } } />
 				);
 				expect( comp.find( 'Banner' ).length ).toBe( 1 );
-				expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_BUSINESS_2_YEARS );
+				expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_BUSINESS );
 			} );
 		} );
 


### PR DESCRIPTION
There were some problems for free plan in the computation and the `<Banner />` received a null `plan` property. It's okay to use hardcoded constants for `<Banner />` components so let's do it here.

Test plan:
1. Start with a free plan site
1. Go to `/settings/general` 
1. Confirm the footer section looks like this:

<img width="745" alt="zrzut ekranu 2018-05-02 o 11 59 04" src="https://user-images.githubusercontent.com/205419/39517469-3894b2ac-4e00-11e8-8cc6-83b89809ef13.png">
