### PR TITLE
Media: fix filter item prop name

### DIFF
--- a/client/my-sites/media-library/filter-item.jsx
+++ b/client/my-sites/media-library/filter-item.jsx
@@ -17,10 +17,10 @@ class FilterItem extends Component {
 	};
 
 	render() {
-		const { isDisabled, selected } = this.props;
+		const { disabled, selected } = this.props;
 
 		return (
-			<SectionNavTabItem selected={ selected } onClick={ this.activate } disabled={ isDisabled }>
+			<SectionNavTabItem selected={ selected } onClick={ this.activate } disabled={ disabled }>
 				{ this.props.children }
 			</SectionNavTabItem>
 		);


### PR DESCRIPTION
Fixes #24595 where media library tabs weren't being properly disabled for 2 cases:
- Selection of a Site Icon
- Selection of a featured image

In master we can select any other media type such as videos or documents. The regression happened from a previous janitorial, and I missed it in review

<img width="943" alt="screen shot 2018-05-02 at 12 48 12 pm" src="https://user-images.githubusercontent.com/1270189/39519638-e0b6db98-4e07-11e8-8f8b-1a3a381dcccf.png">

<img width="933" alt="screen shot 2018-05-02 at 12 50 39 pm" src="https://user-images.githubusercontent.com/1270189/39519650-e8fbae5a-4e07-11e8-9a7a-5b531f5dcd08.png">


### Testing Instructions

#### Site Icon
- Navigate to http://calypso.localhost:3000/settings/general/
- Select a site
- Under Site Icon click "Change"
- Verify that only the image tab in the media modal is enabled
- Verify that a site icon may be updated

#### Featured Image
- Navigate to  http://calypso.localhost:3000/post/
- Select a site
- Click on the "Featured Image" Section in the right sidebar
- Verify that only the image tab in the media modal is enabled
- Verify that a featured image may be set

#### No regressions
- All tabs are enabled in other sections such as the http://calypso.localhost:3000/media/ or adding media to a new post or page.