### PR TITLE
People: make delete user button scary

### DIFF
--- a/client/components/forms/form-button/index.jsx
+++ b/client/components/forms/form-button/index.jsx
@@ -18,6 +18,7 @@ class FormButton extends React.Component {
 	static defaultProps = {
 		isSubmitting: false,
 		isPrimary: true,
+		isScary: false,
 		type: 'submit',
 	};
 
@@ -28,13 +29,14 @@ class FormButton extends React.Component {
 	};
 
 	render() {
-		const { children, className, isPrimary, ...props } = this.props,
+		const { children, className, isPrimary, isScary, ...props } = this.props,
 			buttonClasses = classNames( className, 'form-button' );
 
 		return (
 			<Button
 				{ ...omit( props, [ 'isSubmitting', 'moment', 'numberFormat', 'translate' ] ) }
 				primary={ isPrimary }
+				scary={ isScary }
 				className={ buttonClasses }
 			>
 				{ Children.count( children ) ? children : this.getDefaultButtonAction() }

--- a/client/components/forms/form-button/index.jsx
+++ b/client/components/forms/form-button/index.jsx
@@ -18,7 +18,6 @@ class FormButton extends React.Component {
 	static defaultProps = {
 		isSubmitting: false,
 		isPrimary: true,
-		isScary: false,
 		type: 'submit',
 	};
 
@@ -29,14 +28,13 @@ class FormButton extends React.Component {
 	};
 
 	render() {
-		const { children, className, isPrimary, isScary, ...props } = this.props,
+		const { children, className, isPrimary, ...props } = this.props,
 			buttonClasses = classNames( className, 'form-button' );
 
 		return (
 			<Button
 				{ ...omit( props, [ 'isSubmitting', 'moment', 'numberFormat', 'translate' ] ) }
 				primary={ isPrimary }
-				scary={ isScary }
 				className={ buttonClasses }
 			>
 				{ Children.count( children ) ? children : this.getDefaultButtonAction() }

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -246,7 +246,7 @@ class DeleteUser extends React.PureComponent {
 					</FormFieldset>
 
 					<FormButtonsBar>
-						<FormButton isScary={ true } disabled={ this.isDeleteButtonDisabled() }>
+						<FormButton scary={ true } disabled={ this.isDeleteButtonDisabled() }>
 							{ translate( 'Delete user', { context: 'Button label' } ) }
 						</FormButton>
 					</FormButtonsBar>

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -246,7 +246,7 @@ class DeleteUser extends React.PureComponent {
 					</FormFieldset>
 
 					<FormButtonsBar>
-						<FormButton disabled={ this.isDeleteButtonDisabled() }>
+						<FormButton isScary={ true } disabled={ this.isDeleteButtonDisabled() }>
 							{ translate( 'Delete user', { context: 'Button label' } ) }
 						</FormButton>
 					</FormButtonsBar>


### PR DESCRIPTION
This PR sets `scary` <del>`isScary`</del> prop to `true` on this `FormButton`.

<del>For that to happen, I had to change how `FormButton` handles this:

- This component is being used in at least one scenario where the submit
action is non-reversible, such as deleting a user and assigning all
their content to another one.
- This change introduces a `isScary` prop to transfer that over to the
`Button` component, so that in situations like the above the button
reflects the severity of an action.</del>

### Before

![image](https://user-images.githubusercontent.com/390760/39521585-0742c49e-4e07-11e8-9ca3-bb193085e65b.png)


### After

![image](https://user-images.githubusercontent.com/390760/39521571-fb910dcc-4e06-11e8-85bb-0de81d921178.png)


### Testing

- Select a site that has more than one user.
- Go to People, select user, and select one of the options to enable the delete button.