### PR TITLE
Guided Tours: Add Simple Payments Email Tour

### DIFF
--- a/client/layout/guided-tours/button-labels.jsx
+++ b/client/layout/guided-tours/button-labels.jsx
@@ -22,6 +22,7 @@ function button( label, icon ) {
 // Localized texts need to be wrapped in a `translate` function to be found by the l10n bot
 const translate = identity;
 
+export const AddContentButton = button( translate( 'Add' ), <Gridicon icon="add-outline" /> );
 export const AddMediaButton = button( translate( 'Add Media' ) );
 export const AddNewButton = button( translate( 'Add New' ), <Gridicon icon="add-image" /> );
 export const AllThemesButton = button( translate( 'All Themes' ) );

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -19,6 +19,7 @@ import { ChecklistSiteTaglineTour } from 'layout/guided-tours/tours/checklist-si
 import { ChecklistSiteTitleTour } from 'layout/guided-tours/tours/checklist-site-title-tour';
 import { ChecklistUserAvatarTour } from 'layout/guided-tours/tours/checklist-user-avatar-tour';
 import { JetpackBasicTour } from 'layout/guided-tours/tours/jetpack-basic-tour';
+import { SimplePaymentsEmailTour } from 'layout/guided-tours/tours/simple-payments-email-tour';
 
 export default combineTours( {
 	checklistAboutPage: ChecklistAboutPageTour,
@@ -35,4 +36,5 @@ export default combineTours( {
 	tutorialSitePreview: TutorialSitePreviewTour,
 	gdocsIntegrationTour: GDocsIntegrationTour,
 	simplePaymentsTour: SimplePaymentsTour,
+	simplePaymentsEmailTour: SimplePaymentsEmailTour,
 } );

--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -4,7 +4,7 @@
  */
 
 import React, { Fragment } from 'react';
-import { overEvery as and } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,11 +18,10 @@ import {
 	Link,
 	Quit,
 } from 'layout/guided-tours/config-elements';
-import { isDesktop } from 'lib/viewport';
 import { AddContentButton } from '../button-labels';
 
 export const SimplePaymentsEmailTour = makeTour(
-	<Tour name="simplePaymentsEmailTour" version="20180501" path="/pages" when={ and( isDesktop ) }>
+	<Tour name="simplePaymentsEmailTour" version="20180501" path="/" when={ noop }>
 		<Step
 			name="init"
 			target="side-menu-page"

--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -23,7 +23,13 @@ import { AddContentButton } from '../button-labels';
 
 export const SimplePaymentsEmailTour = makeTour(
 	<Tour name="simplePaymentsEmailTour" version="20180501" path="/pages" when={ and( isDesktop ) }>
-		<Step name="init" target="side-menu-page" placement="beside" arrow="left-top">
+		<Step
+			name="init"
+			target="side-menu-page"
+			placement="beside"
+			arrow="left-top"
+			style={ { animationDelay: '2s' } }
+		>
 			{ ( { translate } ) => (
 				<Fragment>
 					<p>
@@ -48,7 +54,7 @@ export const SimplePaymentsEmailTour = makeTour(
 			arrow="top-left"
 			target=".editor-html-toolbar__button-insert-content-dropdown, .mce-wpcom-insert-menu button"
 			placement="below"
-			style={ { zIndex: 131000 } }
+			style={ { animationDelay: '2s', marginLeft: '-10px', zIndex: 'auto' } }
 		>
 			{ ( { translate } ) => (
 				<Fragment>
@@ -60,23 +66,6 @@ export const SimplePaymentsEmailTour = makeTour(
 					<p>
 						{ translate(
 							"You'll be able to set a price, upload a photo, and describe your product or cause."
-						) }
-					</p>
-					<Continue
-						click
-						hidden
-						step="finish"
-						target=".editor-html-toolbar__button-insert-content-dropdown, .mce-wpcom-insert-menu button"
-					/>
-				</Fragment>
-			) }
-		</Step>
-		<Step name="finish" placement="center" style={ { zIndex: 100000 } }>
-			{ ( { translate } ) => (
-				<Fragment>
-					<p>
-						{ translate(
-							"That's it! As an optional final step, feel free to complete the rest of your page and publish when ready!"
 						) }
 					</p>
 					<ButtonRow>

--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -15,28 +15,15 @@ import {
 	Step,
 	ButtonRow,
 	Continue,
+	Link,
 	Quit,
 } from 'layout/guided-tours/config-elements';
 import { isDesktop } from 'lib/viewport';
 import { AddContentButton } from '../button-labels';
 
-class RepositioningStep extends Step {
-	componentDidMount() {
-		super.componentDidMount();
-		this.interval = setInterval( () => {
-			this.onScrollOrResize();
-		}, 2000 );
-	}
-
-	componentWillUnmount() {
-		super.componentWillUnmount();
-		clearInterval( this.interval );
-	}
-}
-
 export const SimplePaymentsEmailTour = makeTour(
-	<Tour name="simplePaymentsEmailTour" version="20180501" path="/" when={ and( isDesktop ) }>
-		<RepositioningStep name="init" target="side-menu-page" placement="beside" arrow="left-top">
+	<Tour name="simplePaymentsEmailTour" version="20180501" path="/pages" when={ and( isDesktop ) }>
+		<Step name="init" target="side-menu-page" placement="beside" arrow="left-top">
 			{ ( { translate } ) => (
 				<Fragment>
 					<p>
@@ -47,7 +34,7 @@ export const SimplePaymentsEmailTour = makeTour(
 					<Continue
 						click
 						hidden
-						step="step2"
+						step="choose-payment-button"
 						target=".sidebar__menu li[data-post-type='page'] a.sidebar__button"
 					/>
 					<ButtonRow>
@@ -55,12 +42,13 @@ export const SimplePaymentsEmailTour = makeTour(
 					</ButtonRow>
 				</Fragment>
 			) }
-		</RepositioningStep>
-		<RepositioningStep
-			name="step2"
+		</Step>
+		<Step
+			name="choose-payment-button"
 			arrow="top-left"
 			target=".editor-html-toolbar__button-insert-content-dropdown, .mce-wpcom-insert-menu button"
 			placement="below"
+			style={ { zIndex: 131000 } }
 		>
 			{ ( { translate } ) => (
 				<Fragment>
@@ -74,8 +62,31 @@ export const SimplePaymentsEmailTour = makeTour(
 							"You'll be able to set a price, upload a photo, and describe your product or cause."
 						) }
 					</p>
+					<Continue
+						click
+						hidden
+						step="finish"
+						target=".editor-html-toolbar__button-insert-content-dropdown, .mce-wpcom-insert-menu button"
+					/>
 				</Fragment>
 			) }
-		</RepositioningStep>
+		</Step>
+		<Step name="finish" placement="center" style={ { zIndex: 100000 } }>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"That's it! As an optional final step, feel free to complete the rest of your page and publish when ready!"
+						) }
+					</p>
+					<ButtonRow>
+						<Quit primary>{ translate( 'Got it, thanks!' ) }</Quit>
+					</ButtonRow>
+					<Link href="https://en.support.wordpress.com/simple-payments">
+						{ translate( 'Learn more about Simple Payments.' ) }
+					</Link>
+				</Fragment>
+			) }
+		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -1,0 +1,81 @@
+/** @format */
+/**
+ * External dependencies
+ */
+
+import React, { Fragment } from 'react';
+import { overEvery as and } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	makeTour,
+	Tour,
+	Step,
+	ButtonRow,
+	Continue,
+	Quit,
+} from 'layout/guided-tours/config-elements';
+import { isDesktop } from 'lib/viewport';
+import { AddContentButton } from '../button-labels';
+
+class RepositioningStep extends Step {
+	componentDidMount() {
+		super.componentDidMount();
+		this.interval = setInterval( () => {
+			this.onScrollOrResize();
+		}, 2000 );
+	}
+
+	componentWillUnmount() {
+		super.componentWillUnmount();
+		clearInterval( this.interval );
+	}
+}
+
+export const SimplePaymentsEmailTour = makeTour(
+	<Tour name="simplePaymentsEmailTour" version="20180501" path="/" when={ and( isDesktop ) }>
+		<RepositioningStep name="init" target="side-menu-page" placement="beside" arrow="left-top">
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Start by creating a page — this is where your payment buttons will live.'
+						) }
+					</p>
+					<Continue
+						click
+						hidden
+						step="step2"
+						target=".sidebar__menu li[data-post-type='page'] a.sidebar__button"
+					/>
+					<ButtonRow>
+						<Quit>{ translate( 'Quit' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</RepositioningStep>
+		<RepositioningStep
+			name="step2"
+			arrow="top-left"
+			target=".editor-html-toolbar__button-insert-content-dropdown, .mce-wpcom-insert-menu button"
+			placement="below"
+		>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate( 'Click on {{addContentButton/}} and choose Payment Button.', {
+							components: { addContentButton: <AddContentButton /> },
+						} ) }
+					</p>
+					<p>
+						{ translate(
+							"You'll be able to set a price, upload a photo, and describe your product or cause."
+						) }
+					</p>
+				</Fragment>
+			) }
+		</RepositioningStep>
+	</Tour>
+);

--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -53,7 +53,7 @@ export const SimplePaymentsEmailTour = makeTour(
 			arrow="top-left"
 			target=".editor-html-toolbar__button-insert-content-dropdown, .mce-wpcom-insert-menu button"
 			placement="below"
-			style={ { animationDelay: '2s', marginLeft: '-10px', zIndex: 'auto' } }
+			style={ { marginLeft: '-10px', zIndex: 'auto' } }
 		>
 			{ ( { translate } ) => (
 				<Fragment>

--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -38,10 +38,15 @@ export const SimplePaymentsEmailTour = makeTour(
 					</p>
 					<Continue
 						click
-						hidden
 						step="choose-payment-button"
 						target=".sidebar__menu li[data-post-type='page'] a.sidebar__button"
-					/>
+					>
+						{ translate( 'Click {{strong}}Add{{/strong}} to continue.', {
+							components: {
+								strong: <strong />,
+							},
+						} ) }
+					</Continue>
 					<ButtonRow>
 						<Quit>{ translate( 'Quit' ) }</Quit>
 					</ButtonRow>


### PR DESCRIPTION
Close #24594

Add a new Simple Payments tour that is supposed to be triggered by a direct link (`/?tour=simplePaymentsEmailTour`) from the Simple Payments email.

## Testing Instructions

- Open `/stats/day/{site}` and make sure it doesn't open the `simplePaymentsEmailTour` guided tour.
- Open `/stats/day/{site}?tour=simplePaymentsEmailTour`.
- Make sure the first step of the tour is displayed correctly, and it points to the Add Page sidebar button.
- Add a new page, which will open the Editor.
- Make sure the second and last step of the tour is displayed correctly, and it points to the Add Content toolbar button.