### PR TITLE
Simple Payments: Link from email to Guided Tour

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -184,7 +184,7 @@ export default {
 				context.store.dispatch(
 					recordTracksEvent( 'calypso_simple_payment_email_tour', { source: 'mobile' } )
 				);
-				window.location.href = 'https://en.support.wordpress.com/simple-payments/';
+				window.location.href = 'https://support.wordpress.com/simple-payments/';
 				return;
 			}
 			context.store.dispatch(

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -29,6 +29,7 @@ import StatsPostDetail from './stats-post-detail';
 import StatsCommentFollows from './comment-follows';
 import ActivityLog from './activity-log';
 import config from 'config';
+import { isDesktop } from 'lib/viewport';
 
 function rangeOfPeriod( period, date ) {
 	const periodRange = {
@@ -176,6 +177,12 @@ export default {
 
 	site: function( context, next ) {
 		const { params: { site_id: givenSiteId }, query: queryOptions, store } = context;
+
+		if ( 'simplePaymentsEmailTour' === get( queryOptions, 'tour' ) && ! isDesktop() ) {
+			window.location.href = 'https://en.support.wordpress.com/simple-payments/';
+			return;
+		}
+
 		const filters = getSiteFilters( givenSiteId );
 		const state = store.getState();
 		const currentSite = getSite( state, givenSiteId );

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -182,13 +182,13 @@ export default {
 		if ( 'simplePaymentsEmailTour' === get( queryOptions, 'tour' ) ) {
 			if ( ! isDesktop() ) {
 				context.store.dispatch(
-					recordTracksEvent( 'calypso_simple_payment_email_tour', { mobile: true } )
+					recordTracksEvent( 'calypso_simple_payment_email_tour', { source: 'mobile' } )
 				);
 				window.location.href = 'https://en.support.wordpress.com/simple-payments/';
 				return;
 			}
 			context.store.dispatch(
-				recordTracksEvent( 'calypso_simple_payment_email_tour', { mobile: false } )
+				recordTracksEvent( 'calypso_simple_payment_email_tour', { source: 'desktop' } )
 			);
 		}
 

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -30,6 +30,7 @@ import StatsCommentFollows from './comment-follows';
 import ActivityLog from './activity-log';
 import config from 'config';
 import { isDesktop } from 'lib/viewport';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 function rangeOfPeriod( period, date ) {
 	const periodRange = {
@@ -178,9 +179,17 @@ export default {
 	site: function( context, next ) {
 		const { params: { site_id: givenSiteId }, query: queryOptions, store } = context;
 
-		if ( 'simplePaymentsEmailTour' === get( queryOptions, 'tour' ) && ! isDesktop() ) {
-			window.location.href = 'https://en.support.wordpress.com/simple-payments/';
-			return;
+		if ( 'simplePaymentsEmailTour' === get( queryOptions, 'tour' ) ) {
+			if ( ! isDesktop() ) {
+				context.store.dispatch(
+					recordTracksEvent( 'calypso_simple_payment_email_tour', { mobile: true } )
+				);
+				window.location.href = 'https://en.support.wordpress.com/simple-payments/';
+				return;
+			}
+			context.store.dispatch(
+				recordTracksEvent( 'calypso_simple_payment_email_tour', { mobile: false } )
+			);
 		}
 
 		const filters = getSiteFilters( givenSiteId );


### PR DESCRIPTION
Close #24589

When a user tries to open the Stats by forcing the `simplePaymentsEmailTour` tour (which is what the Simple Payments email does) on mobile, redirects to the Simple Payments support page instead.

## Testing Instructions

- On a narrow window, open `/stats/day/{site}?tour=simplePaymentsEmailTour`.
- Make sure you are redirected to https://en.support.wordpress.com/simple-payments/ as soon as possible.

Note

To start the tour, #24627 is required.