### PR TITLE
Checkout: Replace domain contact information Page View with Tracks

### DIFF
--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -50,7 +50,9 @@ export class DomainDetailsForm extends PureComponent {
 	}
 
 	componentDidMount() {
-		this.props.recordTracksEvent( 'calypso_checkout_domain_contact_information_view' );
+		if ( this.props.recordTracksEvent ) {
+			this.props.recordTracksEvent( 'calypso_checkout_domain_contact_information_view' );
+		}
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -16,7 +16,6 @@ import QueryContactDetailsCache from 'components/data/query-contact-details-cach
 import QueryTldValidationSchemas from 'components/data/query-tld-validation-schemas';
 import PrivacyProtection from './privacy-protection';
 import PaymentBox from './payment-box';
-import analytics from 'lib/analytics';
 import FormButton from 'components/forms/form-button';
 import SecurePaymentFormPlaceholder from './secure-payment-form-placeholder.jsx';
 import wp from 'lib/wp';
@@ -34,6 +33,7 @@ import {
 import { cartItems } from 'lib/cart-values';
 import { getContactDetailsCache } from 'state/selectors';
 import { updateContactDetailsCache } from 'state/domains/management/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 const debug = debugFactory( 'calypso:my-sites:upgrades:checkout:domain-details' );
 const wpcom = wp.undocumented();
@@ -50,9 +50,7 @@ export class DomainDetailsForm extends PureComponent {
 	}
 
 	componentDidMount() {
-		if ( analytics ) {
-			analytics.tracks.recordEvent( 'calypso_checkout_domain_contact_information_view' );
-		}
+		this.props.recordTracksEvent( 'calypso_checkout_domain_contact_information_view' );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -305,5 +303,6 @@ export class DomainDetailsFormContainer extends PureComponent {
 }
 
 export default connect( state => ( { contactDetails: getContactDetailsCache( state ) } ), {
+	recordTracksEvent,
 	updateContactDetailsCache,
 } )( localize( DomainDetailsFormContainer ) );

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -51,10 +51,7 @@ export class DomainDetailsForm extends PureComponent {
 
 	componentDidMount() {
 		if ( analytics ) {
-			analytics.pageView.record(
-				'/checkout/domain-contact-information',
-				'Checkout > Domain Contact Information'
-			);
+			analytics.tracks.recordEvent( 'calypso_checkout_domain_contact_information_view' );
 		}
 	}
 


### PR DESCRIPTION
Context https://github.com/Automattic/wp-calypso/pull/24538#issuecomment-385432549 and p99Zz8-gk-p2
Required for #24538 

We are currently tracking `DomainDetailsForm` with a [page view](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/checkout/checkout/domain-details-form.jsx#L54), which is a bit of a stretch of the page view definition, considering it's just a component in a `/checkout` page.

This PR replaces:
```es6
analytics.pageView.record( '/checkout/domain-contact-information', 'Checkout > Domain Contact Information' );
```
(which records a `calypso_page_view` event with the `{ path: '/checkout/domain-contact-information' }` property)

with:

```es6
analytics.tracks.recordEvent( 'calypso_checkout_domain_contact_information_view' );
```
(which records a `calypso_checkout_domain_contact_information_view` event)

The outcome should be the same, but of course have to be analyzed and funneled in a different way.