### PR TITLE
Plans: Fix link to more info about plugins

### DIFF
--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -9,6 +9,7 @@ export {
 	addLocaleToWpcomUrl,
 	getLanguage,
 	getLocaleFromPath,
+	getSupportLocale,
 	isDefaultLocale,
 	isLocaleVariant,
 	canBeTranslated,

--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -15,6 +15,7 @@ export {
 	addLocaleToWpcomUrl,
 	getLanguage,
 	getLocaleFromPath,
+	getSupportLocale,
 	isDefaultLocale,
 	isLocaleVariant,
 	canBeTranslated,

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -4,6 +4,7 @@
  */
 import { find, isString } from 'lodash';
 import { parse } from 'url';
+import { getLocaleSlug } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -135,4 +136,21 @@ export function removeLocaleFromPath( path ) {
 	}
 
 	return parts.join( '/' ) + queryString;
+}
+
+/**
+ * Returns the slug for the WordPress.com support site for the current user, if
+ * any.
+ *
+ * Uses a (short) list of relatively well-updated *.support.wordpress.com
+ * support sites defined in config/_shared.json.
+ *
+ * @returns {string} A slug which is a valid subdomain of *.support.wordpress.com.
+ */
+export function getSupportLocale() {
+	const localeSlug = getLocaleSlug();
+	if ( config( 'support_locales' ).indexOf( localeSlug ) > -1 ) {
+		return localeSlug;
+	}
+	return 'en';
 }

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -5,7 +5,7 @@
  */
 
 import { find } from 'lodash';
-import { getLocaleSlug, localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import React from 'react';
 import debugModule from 'debug';
 import { connect } from 'react-redux';
@@ -29,21 +29,13 @@ import { getUserPurchases, isFetchingUserPurchases } from 'state/purchases/selec
 import { planMatches } from 'lib/plans';
 import { GROUP_WPCOM, TYPE_BUSINESS } from 'lib/plans/constants';
 import QueryUserPurchases from 'components/data/query-user-purchases';
-import config from 'config';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { getSupportLocale } from 'lib/i18n-utils';
 
 /**
  * Module variables
  */
 const debug = debugModule( 'calypso:help-search' );
-
-const getSupportLocale = () => {
-	const localeSlug = getLocaleSlug();
-	if ( config( 'support_locales' ).indexOf( localeSlug ) > -1 ) {
-		return localeSlug;
-	}
-	return 'en';
-};
 
 class Help extends React.PureComponent {
 	static displayName = 'Help';

--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -16,6 +16,7 @@ import isHappychatAvailable from 'state/happychat/selectors/is-happychat-availab
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { isEnabled } from 'config';
 import { purchasesRoot } from 'me/purchases/paths';
+import { getSupportLocale } from 'lib/i18n-utils';
 
 const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 	const helpLink =
@@ -54,7 +55,9 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 						' All plans already come with a custom set of plugins tailored just for them.' +
 						' {{a}}Find out more about plugins{{/a}}.',
 					{
-						components: { a: <a href="https://en.support.wordpress.com/plugins/" /> },
+						components: {
+							a: <a href={ 'https://' + getSupportLocale() + '.support.wordpress.com/plugins/' } />,
+						},
 					}
 				) }
 			/>

--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -56,7 +56,13 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 						' {{a}}Find out more about plugins{{/a}}.',
 					{
 						components: {
-							a: <a href={ 'https://' + getSupportLocale() + '.support.wordpress.com/plugins/' } />,
+							a: (
+								<a
+									href={ 'https://' + getSupportLocale() + '.support.wordpress.com/plugins/' }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
 						},
 					}
 				) }

--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -52,9 +52,9 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 				answer={ translate(
 					'Yes! With the WordPress.com Business plan you can search for and install external plugins.' +
 						' All plans already come with a custom set of plugins tailored just for them.' +
-						' {{a}}Check out all included plugins{{/a}}.',
+						' {{a}}Find out more about plugins{{/a}}.',
 					{
-						components: { a: <a href={ `/plugins/${ siteSlug }` } /> },
+						components: { a: <a href="https://en.support.wordpress.com/plugins/" /> },
 					}
 				) }
 			/>


### PR DESCRIPTION
The Plans page text says "All plans already come with a custom set of plugins tailored just for them. Check out all included plugins" and then links to `/plugins` within Calypso, which is only useful for Business users.

Let's fix this - there's a support page that's perfect to link to instead.  https://en.support.wordpress.com/plugins/ says:

> On WordPress.com, we include the most popular plugin functionality within our sites automatically.
>
> Additionally, the Business plan allows you to choose from many thousands of plugins, and install them on your site.

| Before | After |
|--|--|
| ![2018-05-02t15 03 07-0500](https://user-images.githubusercontent.com/227022/39546474-2622f59c-4e1a-11e8-9623-4641220c7dbb.png) | ![2018-05-02t15 01 51-0500](https://user-images.githubusercontent.com/227022/39546479-2d5597ac-4e1a-11e8-867e-6cf0beb0b79e.png) |

### Testing instructions

Visit `/help` and verify that things still work, in particular the localized links to the support site like "Get Started".

Visit `/plans/:site` and verify that the "Find out more about plugins" link (near the bottom) now points to a support page about plugins and opens in a new tab.

Change your user locale to Spanish (under `/me/account`) and note that this link appears in Spanish, with support content in Spanish.

Change locale to Brazilian Portuguese and note that this link points to https://pt-br.support.wordpress.com/plugins/ which redirects to https://br.support.wordpress.com/plugins/.  Content appears in English until this page can be updated.