### PR TITLE
Activity Log: Change the message users see in the Activity Log when they have no activity.

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -332,11 +332,7 @@ class ActivityLog extends Component {
 		// Content shown when there are no logs.
 		// The network request either finished with no events or is still ongoing.
 		const noLogsContent = requestData.logs.hasLoaded ? (
-			<EmptyContent
-				title={ translate( 'No activity for %s', {
-					args: this.getStartMoment().format( 'MMMM YYYY' ),
-				} ) }
-			/>
+			<EmptyContent title={ translate( 'No activity for your site yet' ) } />
 		) : (
 			<section className="activity-log__wrapper">
 				{ [ 1, 2, 3 ].map( i => (

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -332,7 +332,7 @@ class ActivityLog extends Component {
 		// Content shown when there are no logs.
 		// The network request either finished with no events or is still ongoing.
 		const noLogsContent = requestData.logs.hasLoaded ? (
-			<EmptyContent title={ translate( 'No activity for your site yet' ) } />
+			<EmptyContent title={ translate( 'No events recorded yet.' ) } />
 		) : (
 			<section className="activity-log__wrapper">
 				{ [ 1, 2, 3 ].map( i => (


### PR DESCRIPTION
Change the message users see in the Activity Log when they have no activity.

Fixes https://github.com/Automattic/wp-calypso/issues/24328