### PR TITLE
Post Editor: reduxify editing SEO description

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -17,7 +17,6 @@ import AccordionSection from 'components/accordion/section';
 import CategoriesTagsAccordion from 'post-editor/editor-categories-tags/accordion';
 import AsyncLoad from 'components/async-load';
 import EditorMoreOptionsSlug from 'post-editor/editor-more-options/slug';
-import PostMetadata from 'lib/post-metadata';
 import { isBusiness, isEnterprise, isJetpackPremium } from 'lib/products-values';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import QueryPostTypes from 'components/data/query-post-types';
@@ -242,12 +241,7 @@ class EditorDrawer extends Component {
 			return;
 		}
 
-		return (
-			<AsyncLoad
-				require="post-editor/editor-seo-accordion"
-				metaDescription={ PostMetadata.metaDescription( this.props.post ) }
-			/>
-		);
+		return <AsyncLoad require="post-editor/editor-seo-accordion" />;
 	}
 
 	renderCopyPost() {


### PR DESCRIPTION
The SEO description is stored as a metadata attribute. This PR converts the editing to appropriate Redux selectors and actions.

**How to test:**
Edit the "SEO description" of a new or existing post. Verify that the change gets saved correctly, that the post is dirty when unsaved and that the dirty flag is cleared after save or publish.

Verify also that other metadata that the Post Editor can edit (geolocation, sharing/publicize) can still be edited as before.