### PR TITLE
Community Translator: breaks plan page when activated

### DIFF
--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -57,13 +57,12 @@ class CurrentPlan extends Component {
 
 	getHeaderWording( planConstObj ) {
 		const { translate } = this.props;
-
+		const planName = planConstObj.getTitle();
 		const title = translate( 'Your site is on a %(planName)s plan', {
 			args: {
-				planName: planConstObj.getTitle(),
+				planName,
 			},
 		} );
-
 		const tagLine = planConstObj.getTagline
 			? planConstObj.getTagline()
 			: translate(


### PR DESCRIPTION
On accounts with a paid plan, `/plans/my-plan/{site}` throws an error when the Community Translator is activated.

`Uncaught TypeError: Converting circular structure to JSON`

![may-03-2018 11-47-40](https://user-images.githubusercontent.com/6458278/39557307-e731dabe-4ec9-11e8-9380-60d2c72f0e9d.gif)

This PR assigns the arg value before passing it to `translation()`.

## Testing
1. Using an account with a paid plan visit `/plans/my-plan/{site}`

### Expectations
The page should load as per normal.

