### PR TITLE
Update Google My Business site settings names

### DIFF
--- a/client/state/google-my-business/actions.js
+++ b/client/state/google-my-business/actions.js
@@ -16,13 +16,13 @@ export const connectGoogleMyBusinessLocation = (
 ) => dispatch => {
 	return dispatch(
 		saveSiteSettings( siteId, {
-			google_my_business_keyring_id: keyringConnectionId,
-			google_my_business_location_id: locationId,
+			jetpack_google_my_business_keyring_id: keyringConnectionId,
+			jetpack_google_my_business_location_id: locationId,
 		} )
 	).then( ( { updated } ) => {
 		if (
-			! updated.hasOwnProperty( 'google_my_business_keyring_id' ) &&
-			! updated.hasOwnProperty( 'google_my_business_location_id' )
+			! updated.hasOwnProperty( 'jetpack_google_my_business_keyring_id' ) &&
+			! updated.hasOwnProperty( 'jetpack_google_my_business_location_id' )
 		) {
 			return Promise.reject();
 		}
@@ -33,13 +33,13 @@ export const connectGoogleMyBusinessLocation = (
 export const disconnectGoogleMyBusinessLocation = siteId => dispatch => {
 	return dispatch(
 		saveSiteSettings( siteId, {
-			google_my_business_keyring_id: false,
-			google_my_business_location_id: false,
+			jetpack_google_my_business_keyring_id: false,
+			jetpack_google_my_business_location_id: false,
 		} )
 	).then( ( { updated } ) => {
 		if (
-			! updated.hasOwnProperty( 'google_my_business_keyring_id' ) &&
-			! updated.hasOwnProperty( 'google_my_business_location_id' )
+			! updated.hasOwnProperty( 'jetpack_google_my_business_keyring_id' ) &&
+			! updated.hasOwnProperty( 'jetpack_google_my_business_location_id' )
 		) {
 			return Promise.reject();
 		}

--- a/client/state/selectors/get-google-my-business-locations.js
+++ b/client/state/selectors/get-google-my-business-locations.js
@@ -13,8 +13,8 @@ import { getAvailableExternalAccounts } from 'state/sharing/selectors';
 
 function isConnected( externalUser, siteSettings ) {
 	return (
-		externalUser.keyringConnectionId === siteSettings.google_my_business_keyring_id &&
-		externalUser.ID === siteSettings.google_my_business_location_id
+		externalUser.keyringConnectionId === siteSettings.jetpack_google_my_business_keyring_id &&
+		externalUser.ID === siteSettings.jetpack_google_my_business_location_id
 	);
 }
 

--- a/client/state/selectors/get-site-user-connections-for-google-my-business.js
+++ b/client/state/selectors/get-site-user-connections-for-google-my-business.js
@@ -13,8 +13,8 @@ import { getKeyringConnectionsByName } from 'state/sharing/keyring/selectors';
 
 function isConnected( keyringConnection, externalUser, siteSettings ) {
 	return (
-		keyringConnection.ID === siteSettings.google_my_business_keyring_id &&
-		externalUser.external_ID === siteSettings.google_my_business_location_id
+		keyringConnection.ID === siteSettings.jetpack_google_my_business_keyring_id &&
+		externalUser.external_ID === siteSettings.jetpack_google_my_business_location_id
 	);
 }
 

--- a/client/state/selectors/is-google-my-business-location-connected.js
+++ b/client/state/selectors/is-google-my-business-location-connected.js
@@ -6,7 +6,11 @@
 import { get } from 'lodash';
 
 const getGoogleMyBusinessLocationId = ( state, siteId ) => {
-	return get( state, `siteSettings.items.${ siteId }.google_my_business_location_id`, null );
+	return get(
+		state,
+		`siteSettings.items.${ siteId }.jetpack_google_my_business_location_id`,
+		null
+	);
 };
 
 export default function isGoogleMyBusinessLocationConnected( state, siteId ) {

--- a/client/state/selectors/test/is-google-my-business-location-connected.js
+++ b/client/state/selectors/test/is-google-my-business-location-connected.js
@@ -11,8 +11,8 @@ describe( 'isGoogleMyBusinessLocationConnected()', () => {
 			siteSettings: {
 				items: {
 					1234: {
-						google_my_business_keyring_id: null,
-						google_my_business_location_id: '',
+						jetpack_google_my_business_keyring_id: null,
+						jetpack_google_my_business_location_id: '',
 					},
 				},
 			},
@@ -26,8 +26,8 @@ describe( 'isGoogleMyBusinessLocationConnected()', () => {
 			siteSettings: {
 				items: {
 					1234: {
-						google_my_business_keyring_id: '234523',
-						google_my_business_location_id: '2354235',
+						jetpack_google_my_business_keyring_id: '234523',
+						jetpack_google_my_business_location_id: '2354235',
 					},
 				},
 			},


### PR DESCRIPTION
Requires serverside patch D12628.
Related jetpack PR https://github.com/Automattic/jetpack/pull/9455

This pull request updates the names of the 2 Google My Business site settings from
- `google_my_business_keyring_id`
- `google_my_business_location_id`
 to
- `jetpack_google_my_business_keyring_id`
- `jetpack_google_my_business_location_id`

So we have a uniform way to handle those options on wpcom and jetpack.

### Testing Instructions
- Apply server patch and client PR
- Try connecting and disconnecting from google my business
- Apply jetpack PR to a jetpack site
- Try connecting and disconnecting from google my business
- Extra test: trigger an AT for a site that is connected to GMB, check that you are still connected after the transfer is over

### Reviews
- [x] Code
- [ ] Product