### PR TITLE
Notices: Add global notices tests

### DIFF
--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
@@ -22,7 +21,7 @@ import { getNotices } from 'state/notices/selectors';
 
 const debug = debugModule( 'calypso:notices' );
 
-const NoticesList = createReactClass( {
+export const NoticesList = createReactClass( {
 	displayName: 'NoticesList',
 
 	mixins: [ observe( 'notices' ) ],
@@ -30,6 +29,10 @@ const NoticesList = createReactClass( {
 	propTypes: {
 		id: PropTypes.string,
 		notices: PropTypes.oneOfType( [ PropTypes.object, PropTypes.array ] ),
+
+		// Connected props
+		removeNotice: PropTypes.func.isRequired,
+		storeNotices: PropTypes.array.isRequired,
 	},
 
 	getDefaultProps() {

--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -54,12 +54,12 @@ export const NoticesList = createReactClass( {
 
 	// Auto-bound by createReactClass.
 	// Migrate to arrow => when using class extends React.Component
-	removeReduxNotice( notice ) {
+	removeReduxNotice( noticeId, onDismissClick ) {
 		return e => {
-			if ( notice.onDismissClick ) {
-				notice.onDismissClick( e );
+			if ( onDismissClick ) {
+				onDismissClick( e );
 			}
-			this.props.removeNotice( notice.noticeId );
+			this.props.removeNotice( noticeId );
 		};
 	},
 
@@ -89,21 +89,25 @@ export const NoticesList = createReactClass( {
 		//and from the old component. When all notices are moved to redux store, this component
 		//needs to be updated.
 		noticesList = noticesList.concat(
-			this.props.storeNotices.map( function( { button, href, onClick, ...notice } ) {
-				return (
-					<Notice
-						{ ...notice }
-						key={ `notice-${ notice.noticeId }` }
-						onDismissClick={ this.removeReduxNotice( notice ) }
-					>
-						{ button && (
-							<NoticeAction href={ href } onClick={ onClick }>
-								{ button }
-							</NoticeAction>
-						) }
-					</Notice>
-				);
-			}, this )
+			this.props.storeNotices.map(
+				// Collect `<Notice />` props in rest, extract other expected props
+				function( { button, href, noticeId, onClick, ...notice } ) {
+					return (
+						<Notice
+							{ ...notice }
+							key={ `notice-${ noticeId }` }
+							onDismissClick={ this.removeReduxNotice( noticeId, notice.onDismissClick ) }
+						>
+							{ button && (
+								<NoticeAction href={ href } onClick={ onClick }>
+									{ button }
+								</NoticeAction>
+							) }
+						</Notice>
+					);
+				},
+				this
+			)
 		);
 
 		if ( ! noticesList.length ) {

--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -3,9 +3,9 @@
 /**
  * External dependencies
  */
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 
 /**
  * Internal Dependencies
@@ -13,11 +13,10 @@ import createReactClass from 'create-react-class';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import notices from 'notices';
-// eslint-disable-next-line no-restricted-imports
-import observe from 'lib/mixins/data-observe';
+import observe from 'lib/mixins/data-observe'; // eslint-disable-line no-restricted-imports
 import { connect } from 'react-redux';
-import { removeNotice } from 'state/notices/actions';
 import { getNotices } from 'state/notices/selectors';
+import { removeNotice } from 'state/notices/actions';
 
 // eslint-disable-next-line react/prefer-es6-class
 export const GlobalNotices = createReactClass( {

--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -87,12 +87,12 @@ export const NoticesList = createReactClass( {
 			);
 		}, this );
 
-		//This is an interim solution for displaying both notices from redux store
-		//and from the old component. When all notices are moved to redux store, this component
-		//needs to be updated.
+		// This is an interim solution for displaying both notices from redux store and from the old
+		// component. When all notices are moved to redux store, this component needs to be updated.
 		noticesList = noticesList.concat(
 			this.props.storeNotices.map(
-				// Collect `<Notice />` props in rest, extract other expected props
+				// We'll rest/spread props to notice so arbitrary props can be passed to `Notice`.
+				// Be sure to destructure any props that aren't for at `Notice`, e.g. `button`.
 				function( { button, href, noticeId, onClick, onDismissClick, ...notice } ) {
 					return (
 						<Notice

--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -6,7 +6,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import debugModule from 'debug';
 
 /**
  * Internal Dependencies
@@ -19,8 +18,6 @@ import observe from 'lib/mixins/data-observe';
 import { connect } from 'react-redux';
 import { removeNotice } from 'state/notices/actions';
 import { getNotices } from 'state/notices/selectors';
-
-const debug = debugModule( 'calypso:notices' );
 
 // eslint-disable-next-line react/prefer-es6-class
 export const NoticesList = createReactClass( {
@@ -42,10 +39,6 @@ export const NoticesList = createReactClass( {
 			id: 'overlay-notices',
 			notices: Object.freeze( [] ),
 		};
-	},
-
-	componentWillMount() {
-		debug( 'Mounting Global Notices React component.' );
 	},
 
 	removeNoticeStoreNotice: notice => () => {

--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -20,8 +20,8 @@ import { removeNotice } from 'state/notices/actions';
 import { getNotices } from 'state/notices/selectors';
 
 // eslint-disable-next-line react/prefer-es6-class
-export const NoticesList = createReactClass( {
-	displayName: 'NoticesList',
+export const GlobalNotices = createReactClass( {
+	displayName: 'GlobalNotices',
 
 	mixins: [ observe( 'notices' ) ],
 
@@ -122,4 +122,4 @@ export default connect(
 		storeNotices: getNotices( state ),
 	} ),
 	{ removeNotice }
-)( NoticesList );
+)( GlobalNotices );

--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -14,6 +14,7 @@ import debugModule from 'debug';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import notices from 'notices';
+// eslint-disable-next-line no-restricted-imports
 import observe from 'lib/mixins/data-observe';
 import { connect } from 'react-redux';
 import { removeNotice } from 'state/notices/actions';
@@ -21,6 +22,7 @@ import { getNotices } from 'state/notices/selectors';
 
 const debug = debugModule( 'calypso:notices' );
 
+// eslint-disable-next-line react/prefer-es6-class
 export const NoticesList = createReactClass( {
 	displayName: 'NoticesList',
 

--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -93,12 +93,12 @@ export const NoticesList = createReactClass( {
 		noticesList = noticesList.concat(
 			this.props.storeNotices.map(
 				// Collect `<Notice />` props in rest, extract other expected props
-				function( { button, href, noticeId, onClick, ...notice } ) {
+				function( { button, href, noticeId, onClick, onDismissClick, ...notice } ) {
 					return (
 						<Notice
 							{ ...notice }
 							key={ `notice-${ noticeId }` }
-							onDismissClick={ this.removeReduxNotice( noticeId, notice.onDismissClick ) }
+							onDismissClick={ this.removeReduxNotice( noticeId, onDismissClick ) }
 						>
 							{ button && (
 								<NoticeAction href={ href } onClick={ onClick }>

--- a/client/components/global-notices/test/__snapshots__/index.js.snap
+++ b/client/components/global-notices/test/__snapshots__/index.js.snap
@@ -7,7 +7,6 @@ exports[`<NoticesList /> should render notices with expected HTML 1`] = `
 >
   <Localized(Notice)
     key="notice-testing-notice"
-    noticeId="testing-notice"
     onDismissClick={[Function]}
     showDismiss={true}
     status="is-success"

--- a/client/components/global-notices/test/__snapshots__/index.js.snap
+++ b/client/components/global-notices/test/__snapshots__/index.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<NoticesList /> should render notices with expected HTML 1`] = `
+<div
+  className="global-notices"
+  id="overlay-notices"
+>
+  <Localized(Notice)
+    key="notice-testing-notice"
+    noticeId="testing-notice"
+    onDismissClick={[Function]}
+    showDismiss={true}
+    status="is-success"
+    text="A test notice"
+  />
+</div>
+`;

--- a/client/components/global-notices/test/__snapshots__/index.js.snap
+++ b/client/components/global-notices/test/__snapshots__/index.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<NoticesList /> should render notices with expected HTML 1`] = `
+exports[`<NoticesList /> should render notices with the expected structure 1`] = `
 <div
   className="global-notices"
   id="overlay-notices"

--- a/client/components/global-notices/test/__snapshots__/index.js.snap
+++ b/client/components/global-notices/test/__snapshots__/index.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<NoticesList /> should render notices with the expected structure 1`] = `
+exports[`<GlobalNotices /> should render notices with the expected structure 1`] = `
 <div
   className="global-notices"
   id="overlay-notices"

--- a/client/components/global-notices/test/index.js
+++ b/client/components/global-notices/test/index.js
@@ -1,0 +1,84 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal Dependencies
+ */
+import { NoticesList } from '..';
+import Notice from 'components/notice';
+
+const baseProps = deepFreeze( {
+	storeNotices: [],
+	removeNotice: jest.fn(),
+
+	// Stub event-emmiter notice store so data-observe doesn't break
+	notices: { on() {}, off() {} },
+} );
+
+beforeEach( jest.clearAllMocks );
+
+describe( '<NoticesList />', () => {
+	test( 'should not render without notices', () => {
+		const wrapper = shallow( <NoticesList { ...baseProps } /> );
+		expect( wrapper.type() ).toBeNull();
+	} );
+
+	test( 'should render notices with expected HTML', () => {
+		const notices = [
+			{
+				noticeId: 'testing-notice',
+				showDismiss: true,
+				status: 'is-success',
+				text: 'A test notice',
+			},
+		];
+		const wrapper = shallow( <NoticesList { ...baseProps } storeNotices={ notices } /> );
+		expect( wrapper.hasClass( 'global-notices' ) ).toBe( true );
+		expect( wrapper.prop( 'id' ) ).toBe( 'overlay-notices' );
+		expect( wrapper.find( Notice ) ).toHaveLength( 1 );
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	test( 'should use provided id', () => {
+		const notices = [
+			{
+				noticeId: 'testing-notice',
+				showDismiss: true,
+				status: 'is-success',
+				text: 'A test notice',
+			},
+		];
+		const wrapper = shallow(
+			<NoticesList { ...baseProps } storeNotices={ notices } id="test-id" />
+		);
+		expect( wrapper.prop( 'id' ) ).toBe( 'test-id' );
+	} );
+
+	test( 'should call dismissals', () => {
+		const notices = [
+			{
+				noticeId: 'testing-notice',
+				onDismissClick: jest.fn(),
+				showDismiss: true,
+				status: 'is-success',
+				text: 'A test notice',
+			},
+		];
+
+		const wrapper = shallow(
+			<NoticesList { ...baseProps } storeNotices={ notices } id="test-id" />
+		);
+
+		wrapper.find( Notice ).prop( 'onDismissClick' )();
+
+		expect( notices[ 0 ].onDismissClick ).toHaveBeenCalledTimes( 1 );
+		expect( baseProps.removeNotice ).toHaveBeenCalledTimes( 1 );
+		expect( baseProps.removeNotice ).toHaveBeenCalledWith( 'testing-notice' );
+	} );
+} );

--- a/client/components/global-notices/test/index.js
+++ b/client/components/global-notices/test/index.js
@@ -29,7 +29,7 @@ describe( '<NoticesList />', () => {
 		expect( wrapper.type() ).toBeNull();
 	} );
 
-	test( 'should render notices with expected HTML', () => {
+	test( 'should render notices with the expected structure', () => {
 		const notices = [
 			{
 				noticeId: 'testing-notice',

--- a/client/components/global-notices/test/index.js
+++ b/client/components/global-notices/test/index.js
@@ -10,7 +10,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal Dependencies
  */
-import { NoticesList } from '..';
+import { GlobalNotices } from '..';
 import Notice from 'components/notice';
 
 const baseProps = deepFreeze( {
@@ -23,9 +23,9 @@ const baseProps = deepFreeze( {
 
 beforeEach( jest.clearAllMocks );
 
-describe( '<NoticesList />', () => {
+describe( '<GlobalNotices />', () => {
 	test( 'should not render without notices', () => {
-		const wrapper = shallow( <NoticesList { ...baseProps } /> );
+		const wrapper = shallow( <GlobalNotices { ...baseProps } /> );
 		expect( wrapper.type() ).toBeNull();
 	} );
 
@@ -38,7 +38,7 @@ describe( '<NoticesList />', () => {
 				text: 'A test notice',
 			},
 		];
-		const wrapper = shallow( <NoticesList { ...baseProps } storeNotices={ notices } /> );
+		const wrapper = shallow( <GlobalNotices { ...baseProps } storeNotices={ notices } /> );
 		expect( wrapper.hasClass( 'global-notices' ) ).toBe( true );
 		expect( wrapper.prop( 'id' ) ).toBe( 'overlay-notices' );
 		expect( wrapper.find( Notice ) ).toHaveLength( 1 );
@@ -55,7 +55,7 @@ describe( '<NoticesList />', () => {
 			},
 		];
 		const wrapper = shallow(
-			<NoticesList { ...baseProps } storeNotices={ notices } id="test-id" />
+			<GlobalNotices { ...baseProps } storeNotices={ notices } id="test-id" />
 		);
 		expect( wrapper.prop( 'id' ) ).toBe( 'test-id' );
 	} );
@@ -72,7 +72,7 @@ describe( '<NoticesList />', () => {
 		];
 
 		const wrapper = shallow(
-			<NoticesList { ...baseProps } storeNotices={ notices } id="test-id" />
+			<GlobalNotices { ...baseProps } storeNotices={ notices } id="test-id" />
 		);
 
 		wrapper.find( Notice ).prop( 'onDismissClick' )();


### PR DESCRIPTION
Add tests.
Small refactor changes to handle props and dismissal clearly.

Follow up to #24634
Likely would have prevented #24633

## Testing
1. Tests pass?
1. Are notices correctly dismissed? https://calypso.live/?branch=add/global-notices-tests&debug
   Clickable:
   ```js 
   dispatch( { type: 'NOTICE_CREATE', notice: {
   noticeId: 'testing',
   status: 'is-success',
   icon: 'thumbs-up',
   onDismissClick: () => console.log('Dismissed!'),
   showDismiss: true,
   text: 'Demo notice 💥',
   displayOnNextPage: true,
   isLoading: true,
   isCompact: true,
   } } ) 
   ```
   Auto-dismiss after 1s
   ```js 
   dispatch( { type: 'NOTICE_CREATE', notice: {
   noticeId: 'testing',
   status: 'is-success',
   text: 'Demo notice 💥',
   duration: 1000
   } } ) 
   ```