### PR TITLE
[Contact form] Don't make the Q&A API call if the query is empty

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -135,7 +135,13 @@ export class HelpContactForm extends React.PureComponent {
 	};
 
 	doQandASearch = () => {
-		const query = this.state.subject + ' ' + this.state.message;
+		const query = ( this.state.subject + ' ' + this.state.message ).trim();
+
+		if ( '' === query ) {
+			this.setState( { qanda: [] } );
+			return;
+		}
+
 		const areSameQuestions = ( existingQuestions, newQuestions ) => {
 			const existingIDs = existingQuestions.map( question => question.id );
 			existingIDs.sort();


### PR DESCRIPTION
If the query is empty, reset the Q&A list without making the API call.

There's still a little delay because the method is debounced, but it saves the API call which makes things much more responsive on slower networks (e.g. mobile).