### PR TITLE
Post Editor: reduxify editing post sharing options 

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -142,13 +142,7 @@ class EditorDrawer extends Component {
 	}
 
 	renderSharing() {
-		return (
-			<AsyncLoad
-				require="post-editor/editor-sharing/accordion"
-				site={ this.props.site }
-				post={ this.props.post }
-			/>
-		);
+		return <AsyncLoad require="post-editor/editor-sharing/accordion" />;
 	}
 
 	renderFeaturedImage() {

--- a/client/post-editor/editor-sharing/accordion.jsx
+++ b/client/post-editor/editor-sharing/accordion.jsx
@@ -25,17 +25,17 @@ import QueryPublicizeConnections from 'components/data/query-publicize-connectio
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
-import { getEditedPostValue } from 'state/posts/selectors';
-import { isJetpackModuleActive } from 'state/sites/selectors';
+import { getEditedPost, getEditedPostValue } from 'state/posts/selectors';
+import { getSiteSlug, isJetpackModuleActive } from 'state/sites/selectors';
 import { getSiteUserConnections } from 'state/sharing/publicize/selectors';
 import { hasBrokenSiteUserConnection, isPublicizeEnabled } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 class EditorSharingAccordion extends React.Component {
 	static propTypes = {
-		site: PropTypes.object,
+		siteId: PropTypes.number,
+		siteSlug: PropTypes.string,
 		post: PropTypes.object,
-		isNew: PropTypes.bool,
 		connections: PropTypes.array,
 		hasBrokenConnection: PropTypes.bool,
 		isPublicizeEnabled: PropTypes.bool,
@@ -43,9 +43,9 @@ class EditorSharingAccordion extends React.Component {
 		isLikesActive: PropTypes.bool,
 	};
 
-	getSubtitle = () => {
-		const { isPublicizeEnabled, post, connections } = this.props;
-		if ( ! isPublicizeEnabled || ! post || ! connections ) {
+	getSubtitle() {
+		const { post, connections } = this.props;
+		if ( ! this.props.isPublicizeEnabled || ! post || ! connections ) {
 			return;
 		}
 
@@ -63,9 +63,9 @@ class EditorSharingAccordion extends React.Component {
 			},
 			[]
 		).join( ', ' );
-	};
+	}
 
-	renderShortUrl = () => {
+	renderShortUrl() {
 		const classes = classNames( 'editor-sharing__shortlink', {
 			'is-standalone': this.hideSharing(),
 		} );
@@ -89,12 +89,13 @@ class EditorSharingAccordion extends React.Component {
 				/>
 			</div>
 		);
-	};
+	}
 
-	hideSharing = () => {
-		const { isSharingActive, isLikesActive, isPublicizeEnabled } = this.props;
-		return ! isSharingActive && ! isLikesActive && ! isPublicizeEnabled;
-	};
+	hideSharing() {
+		return (
+			! this.props.isSharingActive && ! this.props.isLikesActive && ! this.props.isPublicizeEnabled
+		);
+	}
 
 	render() {
 		const hideSharing = this.hideSharing();
@@ -115,7 +116,7 @@ class EditorSharingAccordion extends React.Component {
 				text: this.props.translate( 'A broken connection requires repair', {
 					comment: 'Publicize connection deauthorized, needs user action to fix',
 				} ),
-				url: `/sharing/${ this.props.site.slug }`,
+				url: `/sharing/${ this.props.siteSlug }`,
 				position: isMobile() ? 'top left' : 'top',
 				onClick: this.props.onStatusClick,
 			};
@@ -129,9 +130,9 @@ class EditorSharingAccordion extends React.Component {
 				className={ classes }
 				e2eTitle="sharing"
 			>
-				{ this.props.site && <QueryPublicizeConnections siteId={ this.props.site.ID } /> }
+				{ this.props.siteId && <QueryPublicizeConnections siteId={ this.props.siteId } /> }
 				<AccordionSection>
-					{ ! hideSharing && <Sharing site={ this.props.site } post={ this.props.post } /> }
+					{ ! hideSharing && <Sharing /> }
 					{ this.renderShortUrl() }
 				</AccordionSection>
 			</Accordion>
@@ -144,11 +145,15 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const userId = getCurrentUserId( state );
 		const postId = getEditorPostId( state );
+		const post = getEditedPost( state, siteId, postId );
 		const postType = getEditedPostValue( state, siteId, postId, 'type' );
 		const isSharingActive = false !== isJetpackModuleActive( state, siteId, 'sharedaddy' );
 		const isLikesActive = false !== isJetpackModuleActive( state, siteId, 'likes' );
 
 		return {
+			siteId,
+			siteSlug: getSiteSlug( state, siteId ),
+			post,
 			connections: getSiteUserConnections( state, siteId, userId ),
 			hasBrokenConnection: hasBrokenSiteUserConnection( state, siteId, userId ),
 			isSharingActive,

--- a/client/post-editor/editor-sharing/index.jsx
+++ b/client/post-editor/editor-sharing/index.jsx
@@ -3,8 +3,6 @@
 /**
  * External dependencies
  */
-
-import PropTypes from 'prop-types';
 import React from 'react';
 
 /**
@@ -13,16 +11,11 @@ import React from 'react';
 import PublicizeOptions from './publicize-options';
 import SharingLikeOptions from './sharing-like-options';
 
-export default function EditorSharing( { post, site } ) {
+export default function EditorSharing() {
 	return (
 		<div className="editor-sharing">
-			<PublicizeOptions post={ post } site={ site } />
-			<SharingLikeOptions post={ post } site={ site } />
+			<PublicizeOptions />
+			<SharingLikeOptions />
 		</div>
 	);
 }
-
-EditorSharing.propTypes = {
-	site: PropTypes.object,
-	post: PropTypes.object,
-};

--- a/client/post-editor/editor-sharing/publicize-connection.jsx
+++ b/client/post-editor/editor-sharing/publicize-connection.jsx
@@ -7,6 +7,7 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
+import { connect } from 'react-redux';
 import { includes } from 'lodash';
 import Gridicon from 'gridicons';
 
@@ -15,10 +16,13 @@ import Gridicon from 'gridicons';
  */
 import FormCheckbox from 'components/forms/form-checkbox';
 import PostMetadata from 'lib/post-metadata';
-import PostActions from 'lib/posts/actions';
 import * as PostStats from 'lib/posts/stats';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { updatePostMetadata, deletePostMetadata } from 'state/posts/actions';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPost } from 'state/posts/selectors';
 
 export class EditorSharingPublicizeConnection extends React.Component {
 	static propTypes = {
@@ -62,13 +66,20 @@ export class EditorSharingPublicizeConnection extends React.Component {
 		}
 
 		if ( event.target.checked ) {
-			// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-			PostActions.deleteMetadata( '_wpas_skip_' + connection.keyring_connection_ID );
+			this.props.deletePostMetadata(
+				this.props.siteId,
+				this.props.postId,
+				'_wpas_skip_' + connection.keyring_connection_ID
+			);
 			PostStats.recordStat( 'sharing_enabled_' + connection.service );
 			PostStats.recordEvent( 'Publicize Service', connection.service, 'enabled' );
 		} else {
-			// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-			PostActions.updateMetadata( '_wpas_skip_' + connection.keyring_connection_ID, 1 );
+			this.props.updatePostMetadata(
+				this.props.siteId,
+				this.props.postId,
+				'_wpas_skip_' + connection.keyring_connection_ID,
+				1
+			);
 			PostStats.recordStat( 'sharing_disabled_' + connection.service );
 			PostStats.recordEvent( 'Publicize Service', connection.service, 'disabled' );
 		}
@@ -116,4 +127,16 @@ export class EditorSharingPublicizeConnection extends React.Component {
 	}
 }
 
-export default localize( EditorSharingPublicizeConnection );
+export default connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
+		const postId = getEditorPostId( state );
+		const post = getEditedPost( state, siteId, postId );
+
+		return { siteId, postId, post };
+	},
+	{
+		updatePostMetadata,
+		deletePostMetadata,
+	}
+)( localize( EditorSharingPublicizeConnection ) );

--- a/client/post-editor/editor-sharing/publicize-message.jsx
+++ b/client/post-editor/editor-sharing/publicize-message.jsx
@@ -40,12 +40,10 @@ class PublicizeMessage extends Component {
 		preFilledMessage: '',
 	};
 
-	state = {
-		userHasEditedMessage: false,
-	};
+	userHasEditedMessage = false;
 
 	onChange = event => {
-		this.setState( { userHasEditedMessage: true } );
+		this.userHasEditedMessage = true;
 		this.props.onChange( event.target.value );
 	};
 
@@ -55,7 +53,7 @@ class PublicizeMessage extends Component {
 	};
 
 	shouldPreFillMessage() {
-		return ! this.state.userHasEditedMessage && '' === this.props.message;
+		return ! this.userHasEditedMessage && '' === this.props.message;
 	}
 
 	getMessage() {

--- a/client/post-editor/editor-sharing/publicize-message.jsx
+++ b/client/post-editor/editor-sharing/publicize-message.jsx
@@ -7,6 +7,7 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,7 +16,6 @@ import CountedTextarea from 'components/forms/counted-textarea';
 import FormTextarea from 'components/forms/form-textarea';
 import InfoPopover from 'components/info-popover';
 import TrackInputChanges from 'components/track-input-changes';
-import PostActions from 'lib/posts/actions';
 import * as stats from 'lib/posts/stats';
 
 class PublicizeMessage extends Component {
@@ -36,23 +36,17 @@ class PublicizeMessage extends Component {
 		acceptableLength: 280,
 		requireCount: false,
 		displayMessageHeading: true,
+		onChange: noop,
 		preFilledMessage: '',
 	};
-	constructor() {
-		super( ...arguments );
-		this.state = {
-			userHasEditedMessage: false,
-		};
-	}
+
+	state = {
+		userHasEditedMessage: false,
+	};
 
 	onChange = event => {
-		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		this.setState( { userHasEditedMessage: true } );
-		if ( this.props.onChange ) {
-			this.props.onChange( event.target.value );
-		} else {
-			PostActions.updateMetadata( '_wpas_mess', event.target.value );
-		}
+		this.props.onChange( event.target.value );
 	};
 
 	recordStats = () => {

--- a/client/post-editor/editor-sharing/publicize-options.jsx
+++ b/client/post-editor/editor-sharing/publicize-options.jsx
@@ -22,12 +22,14 @@ import PopupMonitor from 'lib/popup-monitor';
 import Button from 'components/button';
 import { recordStat, recordEvent } from 'lib/posts/stats';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSite } from 'state/sites/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
-import { getEditedPostValue } from 'state/posts/selectors';
+import { getEditedPost, getEditedPostValue } from 'state/posts/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSiteUserConnections } from 'state/sharing/publicize/selectors';
 import { fetchConnections as requestConnections } from 'state/sharing/publicize/actions';
 import { canCurrentUser, isPublicizeEnabled } from 'state/selectors';
+import { updatePostMetadata } from 'state/posts/actions';
 
 class EditorSharingPublicizeOptions extends React.Component {
 	static propTypes = {
@@ -81,9 +83,7 @@ class EditorSharingPublicizeOptions extends React.Component {
 			return;
 		}
 
-		return (
-			<PublicizeServices post={ this.props.post } newConnectionPopup={ this.newConnectionPopup } />
-		);
+		return <PublicizeServices newConnectionPopup={ this.newConnectionPopup } />;
 	};
 
 	renderMessage = () => {
@@ -104,11 +104,16 @@ class EditorSharingPublicizeOptions extends React.Component {
 		return (
 			<PublicizeMessage
 				message={ PostMetadata.publicizeMessage( this.props.post ) || '' }
+				onChange={ this.onMessageChange }
 				requireCount={ requireCount }
 				acceptableLength={ acceptableLength }
 				preFilledMessage={ preFilledMessage }
 			/>
 		);
+	};
+
+	onMessageChange = message => {
+		this.props.updatePostMetadata( this.props.siteId, this.props.postId, '_wpas_mess', message );
 	};
 
 	renderAddNewButton = () => {
@@ -170,16 +175,24 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const userId = getCurrentUserId( state );
 		const postId = getEditorPostId( state );
+		const site = getSite( state, siteId );
+		const post = getEditedPost( state, siteId, postId );
 		const postType = getEditedPostValue( state, siteId, postId, 'type' );
 
 		const canUserPublishPosts = canCurrentUser( state, siteId, 'publish_posts' );
 
 		return {
 			siteId,
+			postId,
+			site,
+			post,
 			isPublicizeEnabled: isPublicizeEnabled( state, siteId, postType ),
 			canUserPublishPosts,
 			connections: getSiteUserConnections( state, siteId, userId ),
 		};
 	},
-	{ requestConnections }
+	{
+		requestConnections,
+		updatePostMetadata,
+	}
 )( localize( EditorSharingPublicizeOptions ) );

--- a/client/post-editor/editor-sharing/publicize-services.jsx
+++ b/client/post-editor/editor-sharing/publicize-services.jsx
@@ -17,7 +17,7 @@ import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteUserConnections } from 'state/sharing/publicize/selectors';
 
-export const EditorSharingPublicizeServices = ( { connections, post, newConnectionPopup } ) => (
+export const EditorSharingPublicizeServices = ( { connections, newConnectionPopup } ) => (
 	<ul className="editor-sharing__publicize-services">
 		{ map( groupBy( connections, 'label' ), ( groupedConnections, label ) => (
 			<li key={ label } className="editor-sharing__publicize-service">
@@ -25,7 +25,6 @@ export const EditorSharingPublicizeServices = ( { connections, post, newConnecti
 				{ groupedConnections.map( connection => (
 					<EditorSharingPublicizeConnection
 						key={ connection.ID }
-						post={ post }
 						connection={ connection }
 						onRefresh={ newConnectionPopup }
 						label={ label }
@@ -38,7 +37,6 @@ export const EditorSharingPublicizeServices = ( { connections, post, newConnecti
 
 EditorSharingPublicizeServices.propTypes = {
 	connections: PropTypes.array.isRequired,
-	post: PropTypes.object,
 	newConnectionPopup: PropTypes.func.isRequired,
 };
 

--- a/client/post-editor/editor-sharing/test/publicize-connection.jsx
+++ b/client/post-editor/editor-sharing/test/publicize-connection.jsx
@@ -15,11 +15,6 @@ import React from 'react';
  */
 import { EditorSharingPublicizeConnection as PublicizeConnection } from '../publicize-connection';
 
-jest.mock( 'lib/posts/actions', () => ( {
-	recordEvent: () => {},
-	deleteMetadata: () => {},
-	updateMetadata: () => {},
-} ) );
 jest.mock( 'lib/posts/stats', () => ( {
 	recordEvent: () => {},
 	recordState: () => {},


### PR DESCRIPTION
All components in the `editor-sharing` folder are now self-sufficient when it comes to getting the `site` and `post` object. Instead of passing them down as props, they get them from Redux in their `connect` calls.

Most changes are quite straightforward, except the ones in `PublicizeMessage`.

Here, there is additional change that the component itself doesn't dispatch any metadata update actions, but always relies on the `onChange` handler passed from above: the action dispatch is moved to the parent.

Also, we fix a subtle bug where Redux update of the `message` prop (which is a value of a controlled input) interacts badly with the `setState( { userHasEditedMessage } )` call. That `setState` leads to two rerenders of the component: first with new `userHasEditedMessage` value and old value of `message`, the second with new value of `message`.

There is the following sequence of events:
1. The textarea has value "a"
2. User types "b"
3. The DOM value of the textarea becomes "ab"
4. First rerender happens and sets the value back to "a"
5. Second rerender happens and sets the value to "ab"

This back-and-forth value setting resets the position of cursor:
![screen capture on 2018-05-03 at 14-07-07](https://user-images.githubusercontent.com/664258/39575631-87c9eafa-4edb-11e8-9041-773ae60d8abc.gif)

Fixed by using an object instance field instead of state.

**How to test:**
Edit a new or existing post and try to edit its sharing options:
<img width="275" alt="screen shot 2018-05-02 at 23 27 19" src="https://user-images.githubusercontent.com/664258/39575702-ca6e37bc-4edb-11e8-8cb4-3d7c9babd963.png">

- check and uncheck the sharing connection where you want to publicize the post. Check that metadata keys `_wpas_skip_*` are set or unset.
- edit the custom message. Check that the `_wpas_mess` metadata key gets updated.
- check and uncheck the "Sharing Buttons & Likes" checkboxes. Verify that post attributes `sharing_enabled` and `likes_enabled` are modified (no metadata here, just plain old post attributes)