### PR TITLE
Jetpack: Add a site checklist

### DIFF
--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -11,11 +11,13 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import EmptyContent from 'components/empty-content';
 import FormattedHeader from 'components/formatted-header';
 import Checklist from 'blocks/checklist';
 import Main from 'components/main';
 import DocumentHead from 'components/data/document-head';
+import { jetpackTasks } from '../jetpack-checklist';
 import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isSiteAutomatedTransfer, getSiteChecklist } from 'state/selectors';
@@ -179,11 +181,11 @@ const mapStateToProps = state => {
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSiteSlug( state, siteId );
 	const siteChecklist = getSiteChecklist( state, siteId );
-	const tasks = onboardingTasks( siteChecklist );
 	const isAtomic = isSiteAutomatedTransfer( state, siteId );
 	const isJetpack = isJetpackSite( state, siteId );
+	const tasks = isJetpack ? jetpackTasks( siteChecklist ) : onboardingTasks( siteChecklist );
 	return {
-		checklistAvailable: ! isAtomic && ! isJetpack,
+		checklistAvailable: ! isAtomic && ( config.isEnabled( 'jetpack/checklist' ) || ! isJetpack ),
 		siteId,
 		siteSlug,
 		tasks,

--- a/client/my-sites/checklist/jetpack-checklist.js
+++ b/client/my-sites/checklist/jetpack-checklist.js
@@ -21,7 +21,9 @@ const tasks = {
 			"Connect your site's server to Jetpack to perform backups, rewinds, and security scans."
 		),
 		completedTitle: translate( 'You turned on backups and scanning.' ),
+		completedButtonText: 'Change',
 		duration: translate( '2 min' ),
+		url: '/stats/activity/$siteSlug',
 	},
 	jetpack_monitor: {
 		title: translate( 'Jetpack Monitor' ),
@@ -29,7 +31,9 @@ const tasks = {
 			"Monitor your site's uptime and alert you the moment downtime is detected with instant notifications."
 		),
 		completedTitle: translate( 'You turned on Jetpack Monitor.' ),
+		completedButtonText: 'Change',
 		duration: translate( '3 min' ),
+		url: '/settings/security/$siteSlug',
 	},
 	jetpack_plugin_updates: {
 		title: translate( 'Automatic Plugin Updates' ),
@@ -37,7 +41,9 @@ const tasks = {
 			'Choose which WordPress plugins you want to keep automatically updated.'
 		),
 		completedTitle: translate( 'You turned on automatic plugin updates.' ),
+		completedButtonText: 'Change',
 		duration: translate( '3 min' ),
+		url: '/plugins/manage/$siteSlug',
 	},
 	jetpack_sign_in: {
 		title: translate( 'WordPress.com sign in' ),
@@ -45,7 +51,9 @@ const tasks = {
 			'Manage your log in preferences and two-factor authentication settings.'
 		),
 		completedTitle: translate( 'You completed your sign in preferences.' ),
+		completedButtonText: 'Change',
 		duration: translate( '3 min' ),
+		url: '/settings/security/$siteSlug',
 	},
 };
 

--- a/client/my-sites/checklist/jetpack-checklist.js
+++ b/client/my-sites/checklist/jetpack-checklist.js
@@ -4,7 +4,7 @@
  */
 import { translate } from 'i18n-calypso';
 
-export const tasks = {
+const tasks = {
 	jetpack_brute_force: {
 		completedTitle: translate(
 			"We've automatically protected you from brute force login attacks."
@@ -48,3 +48,25 @@ export const tasks = {
 		duration: translate( '3 min' ),
 	},
 };
+
+const sequence = [
+	'jetpack_brute_force',
+	'jetpack_spam_filtering',
+	'jetpack_backups',
+	'jetpack_monitor',
+	'jetpack_plugin_updates',
+	'jetpack_sign_in',
+];
+
+export function jetpackTasks( checklist ) {
+	if ( ! checklist || ! checklist.tasks ) {
+		return null;
+	}
+
+	return sequence.map( id => {
+		const task = tasks[ id ];
+		const taskFromServer = checklist.tasks[ id ];
+
+		return { id, ...task, ...taskFromServer };
+	} );
+}

--- a/client/my-sites/checklist/jetpack-checklist.js
+++ b/client/my-sites/checklist/jetpack-checklist.js
@@ -1,0 +1,50 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+export const tasks = {
+	jetpack_brute_force: {
+		completedTitle: translate(
+			"We've automatically protected you from brute force login attacks."
+		),
+		completed: true,
+	},
+	jetpack_spam_filtering: {
+		completedTitle: translate( "We've automatically turned on spam filtering." ),
+		completed: true,
+	},
+	jetpack_backups: {
+		title: translate( 'Backups & Scanning' ),
+		description: translate(
+			"Connect your site's server to Jetpack to perform backups, rewinds, and security scans."
+		),
+		completedTitle: translate( 'You turned on backups and scanning.' ),
+		duration: translate( '2 min' ),
+	},
+	jetpack_monitor: {
+		title: translate( 'Jetpack Monitor' ),
+		description: translate(
+			"Monitor your site's uptime and alert you the moment downtime is detected with instant notifications."
+		),
+		completedTitle: translate( 'You turned on Jetpack Monitor.' ),
+		duration: translate( '3 min' ),
+	},
+	jetpack_plugin_updates: {
+		title: translate( 'Automatic Plugin Updates' ),
+		description: translate(
+			'Choose which WordPress plugins you want to keep automatically updated.'
+		),
+		completedTitle: translate( 'You turned on automatic plugin updates.' ),
+		duration: translate( '3 min' ),
+	},
+	jetpack_sign_in: {
+		title: translate( 'WordPress.com sign in' ),
+		description: translate(
+			'Manage your log in preferences and two-factor authentication settings.'
+		),
+		completedTitle: translate( 'You completed your sign in preferences.' ),
+		duration: translate( '3 min' ),
+	},
+};

--- a/config/development.json
+++ b/config/development.json
@@ -62,6 +62,7 @@
 		"help/courses": true,
 		"i18n/community-translator": false,
 		"jetpack/api-cache": true,
+		"jetpack/checklist": true,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/remote-install": true,
 		"jetpack/connect/mobile-app-flow": true,

--- a/config/test.json
+++ b/config/test.json
@@ -37,6 +37,7 @@
 		"google-analytics": false,
 		"google-my-business": false,
 		"help": true,
+		"jetpack/checklist": true,
 		"jetpack/connect/remote-install": true,
 		"jetpack/happychat": true,
 		"jitms": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -45,6 +45,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/api-cache": true,
+		"jetpack/checklist": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/remote-install": true,
 		"jetpack/happychat": true,


### PR DESCRIPTION
<img width="1275" alt="screen shot 2018-05-03 at 13 58 16" src="https://user-images.githubusercontent.com/7767559/39577752-15d6d940-4eda-11e8-84df-db5a558767bf.png">

Requires D12725-code

Add a Jetpack site checklist behind a feature flag at /checklist/{site}. We will eventually want to show the list at /my-plan, but /checklist it a good first place to iterate on it, since much of the display code already exists at that route.

See design discussion at p6TEKc-1UX-p2

## Testing
* Apply D12725-code & sandbox public-api.wordpress.com
* Go to https://calypso.live/checklist?branch=add/jetpack-checklist and choose a Jetpack site

