### PR TITLE
Author Selector: migrate the SwitcherShell component to React ES6 class

### DIFF
--- a/client/blocks/author-selector/switcher-shell.jsx
+++ b/client/blocks/author-selector/switcher-shell.jsx
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import React from 'react';
-import createReactClass from 'create-react-class';
 import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
@@ -27,10 +26,8 @@ import { hasTouch } from 'lib/touch-detect';
 const debug = debugModule( 'calypso:author-selector' );
 let instance = 0;
 
-const SwitcherShell = createReactClass( {
-	displayName: 'AuthorSwitcherShell',
-
-	propTypes: {
+class AuthorSwitcherShell extends React.Component {
+	static propTypes = {
 		users: PropTypes.array,
 		fetchingUsers: PropTypes.bool,
 		numUsersFetched: PropTypes.number,
@@ -39,29 +36,27 @@ const SwitcherShell = createReactClass( {
 		allowSingleUser: PropTypes.bool,
 		popoverPosition: PropTypes.string,
 		ignoreContext: PropTypes.shape( { getDOMNode: PropTypes.func } ),
-	},
+	};
 
-	getInitialState: function() {
-		return {
-			showAuthorMenu: false,
-		};
-	},
+	state = {
+		showAuthorMenu: false,
+	};
 
-	componentWillMount: function() {
+	componentWillMount() {
 		this.instance = instance;
 		instance++;
-	},
+	}
 
-	componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps( nextProps ) {
 		if (
 			! nextProps.fetchOptions.siteId ||
 			nextProps.fetchOptions.siteId !== this.props.fetchOptions.siteId
 		) {
 			this.props.updateSearch( false );
 		}
-	},
+	}
 
-	componentDidUpdate: function( prevProps, prevState ) {
+	componentDidUpdate( prevProps, prevState ) {
 		if ( ! this.state.showAuthorMenu ) {
 			return;
 		}
@@ -69,9 +64,9 @@ const SwitcherShell = createReactClass( {
 		if ( ! prevState.showAuthorMenu && this.props.users.length > 10 && ! hasTouch() ) {
 			setTimeout( () => this.refs.authorSelectorSearch.focus(), 0 );
 		}
-	},
+	}
 
-	render: function() {
+	render() {
 		const { users, fetchNameSpace } = this.props;
 		const infiniteListKey = fetchNameSpace + this.instance;
 
@@ -132,24 +127,24 @@ const SwitcherShell = createReactClass( {
 				</Popover>
 			</span>
 		);
-	},
+	}
 
-	_isLastPage: function() {
+	_isLastPage() {
 		let usersLength = this.props.users.length;
 		if ( this.props.exclude ) {
 			usersLength += this.props.excludedUsers.length;
 		}
 
 		return this.props.totalUsers <= usersLength;
-	},
+	}
 
-	_setListContext: function( infiniteListInstance ) {
+	_setListContext = infiniteListInstance => {
 		this.setState( {
 			listContext: ReactDom.findDOMNode( infiniteListInstance ),
 		} );
-	},
+	};
 
-	_userCanSelectAuthor: function() {
+	_userCanSelectAuthor() {
 		const { users } = this.props;
 
 		if ( this.props.fetchOptions.search ) {
@@ -162,15 +157,15 @@ const SwitcherShell = createReactClass( {
 		}
 
 		return true;
-	},
+	}
 
-	_toggleShowAuthor: function() {
+	_toggleShowAuthor = () => {
 		this.setState( {
 			showAuthorMenu: ! this.state.showAuthorMenu,
 		} );
-	},
+	};
 
-	_onClose: function( event ) {
+	_onClose = event => {
 		const toggleElement = ReactDom.findDOMNode( this.refs[ 'author-selector-toggle' ] );
 
 		if ( event && toggleElement.contains( event.target ) ) {
@@ -181,9 +176,9 @@ const SwitcherShell = createReactClass( {
 			showAuthorMenu: false,
 		} );
 		this.props.updateSearch( false );
-	},
+	};
 
-	_renderAuthor: function( author ) {
+	_renderAuthor = author => {
 		const authorGUID = this._getAuthorItemGUID( author );
 		return (
 			<PopoverMenuItem
@@ -196,17 +191,17 @@ const SwitcherShell = createReactClass( {
 				<UserItem user={ author } />
 			</PopoverMenuItem>
 		);
-	},
+	};
 
-	_noUsersFound: function() {
+	_noUsersFound() {
 		return (
 			<div className="author-selector__no-users">
 				{ this.props.translate( 'No matching users found.' ) }
 			</div>
 		);
-	},
+	}
 
-	_selectAuthor: function( author ) {
+	_selectAuthor = author => {
 		debug( 'assign author:', author );
 		if ( this.props.onSelect ) {
 			this.props.onSelect( author );
@@ -215,31 +210,31 @@ const SwitcherShell = createReactClass( {
 			showAuthorMenu: false,
 		} );
 		this.props.updateSearch( false );
-	},
+	};
 
-	_fetchNextPage: function() {
+	_fetchNextPage = () => {
 		const fetchOptions = Object.assign( {}, this.props.fetchOptions, {
 			offset: this.props.users.length,
 		} );
 		debug( 'fetching next batch of authors' );
 		fetchUsers( fetchOptions );
-	},
+	};
 
-	_getAuthorItemGUID: function( author ) {
+	_getAuthorItemGUID = author => {
 		return 'author-item-' + author.ID;
-	},
+	};
 
-	_renderLoadingAuthors: function() {
+	_renderLoadingAuthors = () => {
 		return (
 			<PopoverMenuItem disabled={ true } key="author-item-placeholder">
 				<UserItem />
 			</PopoverMenuItem>
 		);
-	},
+	};
 
-	_onSearch: function( searchTerm ) {
+	_onSearch = searchTerm => {
 		this.props.updateSearch( searchTerm );
-	},
-} );
+	};
+}
 
-export default localize( SwitcherShell );
+export default localize( AuthorSwitcherShell );

--- a/client/blocks/author-selector/switcher-shell.jsx
+++ b/client/blocks/author-selector/switcher-shell.jsx
@@ -70,7 +70,7 @@ class AuthorSwitcherShell extends React.Component {
 		const { users, fetchNameSpace } = this.props;
 		const infiniteListKey = fetchNameSpace + this.instance;
 
-		if ( ! this._userCanSelectAuthor() ) {
+		if ( ! this.userCanSelectAuthor() ) {
 			return <span>{ this.props.children }</span>;
 		}
 
@@ -78,7 +78,7 @@ class AuthorSwitcherShell extends React.Component {
 			<span>
 				<span
 					className="author-selector__author-toggle"
-					onClick={ this._toggleShowAuthor }
+					onClick={ this.toggleShowAuthor }
 					tabIndex={ -1 }
 					ref="author-selector-toggle"
 				>
@@ -87,17 +87,17 @@ class AuthorSwitcherShell extends React.Component {
 				</span>
 				<Popover
 					isVisible={ this.state.showAuthorMenu }
-					onClose={ this._onClose }
+					onClose={ this.onClose }
 					position={ this.props.popoverPosition }
 					context={ this.refs && this.refs.authorSelectorChevron }
-					onKeyDown={ this._onKeyDown }
+					onKeyDown={ this.onKeyDown }
 					className="author-selector__popover popover"
 					ignoreContext={ this.props.ignoreContext }
 				>
 					{ ( this.props.fetchOptions.search || users.length > 10 ) && (
 						<Search
 							compact
-							onSearch={ this._onSearch }
+							onSearch={ this.onSearch }
 							placeholder={ this.props.translate( 'Find Author…', { context: 'search label' } ) }
 							delaySearch={ true }
 							ref="authorSelectorSearch"
@@ -107,21 +107,21 @@ class AuthorSwitcherShell extends React.Component {
 					! users.length &&
 					this.props.fetchOptions.search &&
 					! this.props.fetchingUsers ? (
-						this._noUsersFound()
+						this.noUsersFound()
 					) : (
 						<InfiniteList
 							items={ users }
 							key={ infiniteListKey }
 							className="author-selector__infinite-list"
-							ref={ this._setListContext }
+							ref={ this.setListContext }
 							context={ this.state.listContext }
 							fetchingNextPage={ this.props.fetchingUsers }
 							guessedItemHeight={ 42 }
-							lastPage={ this._isLastPage() }
-							fetchNextPage={ this._fetchNextPage }
-							getItemRef={ this._getAuthorItemGUID }
-							renderLoadingPlaceholders={ this._renderLoadingAuthors }
-							renderItem={ this._renderAuthor }
+							lastPage={ this.isLastPage() }
+							fetchNextPage={ this.fetchNextPage }
+							getItemRef={ this.getAuthorItemGUID }
+							renderLoadingPlaceholders={ this.renderLoadingAuthors }
+							renderItem={ this.renderAuthor }
 						/>
 					) }
 				</Popover>
@@ -129,7 +129,7 @@ class AuthorSwitcherShell extends React.Component {
 		);
 	}
 
-	_isLastPage() {
+	isLastPage() {
 		let usersLength = this.props.users.length;
 		if ( this.props.exclude ) {
 			usersLength += this.props.excludedUsers.length;
@@ -138,13 +138,13 @@ class AuthorSwitcherShell extends React.Component {
 		return this.props.totalUsers <= usersLength;
 	}
 
-	_setListContext = infiniteListInstance => {
+	setListContext = infiniteListInstance => {
 		this.setState( {
 			listContext: ReactDom.findDOMNode( infiniteListInstance ),
 		} );
 	};
 
-	_userCanSelectAuthor() {
+	userCanSelectAuthor() {
 		const { users } = this.props;
 
 		if ( this.props.fetchOptions.search ) {
@@ -159,17 +159,17 @@ class AuthorSwitcherShell extends React.Component {
 		return true;
 	}
 
-	_toggleShowAuthor = () => {
+	toggleShowAuthor = () => {
 		this.setState( {
 			showAuthorMenu: ! this.state.showAuthorMenu,
 		} );
 	};
 
-	_onClose = event => {
+	onClose = event => {
 		const toggleElement = ReactDom.findDOMNode( this.refs[ 'author-selector-toggle' ] );
 
 		if ( event && toggleElement.contains( event.target ) ) {
-			// let _toggleShowAuthor() handle this case
+			// let toggleShowAuthor() handle this case
 			return;
 		}
 		this.setState( {
@@ -178,12 +178,12 @@ class AuthorSwitcherShell extends React.Component {
 		this.props.updateSearch( false );
 	};
 
-	_renderAuthor = author => {
-		const authorGUID = this._getAuthorItemGUID( author );
+	renderAuthor = author => {
+		const authorGUID = this.getAuthorItemGUID( author );
 		return (
 			<PopoverMenuItem
 				className="author-selector__menu-item"
-				onClick={ this._selectAuthor.bind( this, author ) }
+				onClick={ this.selectAuthor.bind( this, author ) }
 				focusOnHover={ false }
 				key={ authorGUID }
 				tabIndex="-1"
@@ -193,7 +193,7 @@ class AuthorSwitcherShell extends React.Component {
 		);
 	};
 
-	_noUsersFound() {
+	noUsersFound() {
 		return (
 			<div className="author-selector__no-users">
 				{ this.props.translate( 'No matching users found.' ) }
@@ -201,7 +201,7 @@ class AuthorSwitcherShell extends React.Component {
 		);
 	}
 
-	_selectAuthor = author => {
+	selectAuthor = author => {
 		debug( 'assign author:', author );
 		if ( this.props.onSelect ) {
 			this.props.onSelect( author );
@@ -212,7 +212,7 @@ class AuthorSwitcherShell extends React.Component {
 		this.props.updateSearch( false );
 	};
 
-	_fetchNextPage = () => {
+	fetchNextPage = () => {
 		const fetchOptions = Object.assign( {}, this.props.fetchOptions, {
 			offset: this.props.users.length,
 		} );
@@ -220,11 +220,11 @@ class AuthorSwitcherShell extends React.Component {
 		fetchUsers( fetchOptions );
 	};
 
-	_getAuthorItemGUID = author => {
+	getAuthorItemGUID = author => {
 		return 'author-item-' + author.ID;
 	};
 
-	_renderLoadingAuthors = () => {
+	renderLoadingAuthors = () => {
 		return (
 			<PopoverMenuItem disabled={ true } key="author-item-placeholder">
 				<UserItem />
@@ -232,7 +232,7 @@ class AuthorSwitcherShell extends React.Component {
 		);
 	};
 
-	_onSearch = searchTerm => {
+	onSearch = searchTerm => {
 		this.props.updateSearch( searchTerm );
 	};
 }


### PR DESCRIPTION
The `react-create-class` codemod was previously failing because it found a `getDOMNode` identifier, mistaking it for a legacy React method. No other issues, trivial migration.

**How to test:**
- in Post Editor on a blog with multiple authors, the component is used to select the post author
- when importing a WordPress export from another blog, the component is used to select target author when mapping authors from the source and target sites
