### PR TITLE
Inline Help: update Sibyl styling and prevent widows in title

### DIFF
--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -342,6 +342,10 @@
 	text-align: left;
 	margin: 0;
 	padding: 8px 0;
+
+	.help-contact-form & {
+		padding: 0;
+	}
 }
 
 .inline-help__results-item {
@@ -375,6 +379,16 @@
 
 		a {
 			color: $white;
+		}
+	}
+
+	.help-contact-form & {
+		a {
+			padding-left: 0;
+
+			&:hover {
+				background: none;
+			}
 		}
 	}
 }

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -15,6 +15,7 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { preventWidows } from 'lib/formatting';
 import config from 'config';
 import FormLabel from 'components/forms/form-label';
 import SegmentedControl from 'components/segmented-control';
@@ -345,7 +346,9 @@ export class HelpContactForm extends React.PureComponent {
 		if ( showingQandAStep && hasQASuggestions ) {
 			return (
 				<div className="help-contact-form">
-					<p>{ translate( 'Did you want the answer to any of these questions?' ) }</p>
+					<h2 className="help-contact-form__title">
+						{ preventWidows( translate( 'Did you want the answer to any of these questions?' ) ) }
+					</h2>
 					<InlineHelpCompactResults
 						helpLinks={ this.state.qanda }
 						onClick={ this.trackSibylClick }

--- a/client/me/help/help-contact-form/style.scss
+++ b/client/me/help/help-contact-form/style.scss
@@ -53,3 +53,10 @@
 	font-size: 11px;
 	line-height: 16px;
 }
+
+.help-contact-form__title {
+	display: block;
+	font-size: 14px;
+	font-weight: 600;
+	margin-bottom: 5px;
+}


### PR DESCRIPTION
## This PR
- updates the styling of the Sibyl part of Inline Help (IH) to be in line with the rest of IH
- prevents widows on the Sibyl title

**Before**
<img width="348" alt="screen shot 2018-05-03 at 15 09 20" src="https://user-images.githubusercontent.com/1562646/39581658-fdf6adc8-4ee3-11e8-91c0-4e2fc8148261.png">

**After**
<img width="346" alt="screen shot 2018-05-03 at 14 54 42" src="https://user-images.githubusercontent.com/1562646/39581194-eb1a668c-4ee2-11e8-9598-5367e6d3a791.png">

## How to test
- open Inline Help on a Simple site
- click `Contact Us`
- enter `Domains` in the Textbox
- click `Continue`
- make sure it looks like the `After` image above
