### PR TITLE
Me: Use named exports from section controllers

### DIFF
--- a/client/me/account/controller.js
+++ b/client/me/account/controller.js
@@ -16,24 +16,23 @@ import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import AccountComponent from 'me/account/main';
 import username from 'lib/username';
 
-export default {
-	account( context, next ) {
-		let showNoticeInitially = false;
+export function account( context, next ) {
+	let showNoticeInitially = false;
 
-		context.store.dispatch( setTitle( i18n.translate( 'Account Settings', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	context.store.dispatch( setTitle( i18n.translate( 'Account Settings', { textOnly: true } ) ) );
 
-		// Update the url and show the notice after a redirect
-		if ( context.query && context.query.updated === 'success' ) {
-			showNoticeInitially = true;
-			page.replace( context.pathname );
-		}
+	// Update the url and show the notice after a redirect
+	if ( context.query && context.query.updated === 'success' ) {
+		showNoticeInitially = true;
+		page.replace( context.pathname );
+	}
 
-		context.primary = React.createElement( AccountComponent, {
-			userSettings: userSettings,
-			path: context.path,
-			username: username,
-			showNoticeInitially: showNoticeInitially,
-		} );
-		next();
-	},
-};
+	context.primary = React.createElement( AccountComponent, {
+		userSettings: userSettings,
+		path: context.path,
+		username: username,
+		showNoticeInitially: showNoticeInitially,
+	} );
+	next();
+}

--- a/client/me/account/index.js
+++ b/client/me/account/index.js
@@ -3,16 +3,15 @@
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**
  * Internal dependencies
  */
-import meController from 'me/controller';
+import { sidebar } from 'me/controller';
 import { account } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/me/account', meController.sidebar, account, makeLayout, clientRender );
+	page( '/me/account', sidebar, account, makeLayout, clientRender );
 }

--- a/client/me/account/index.js
+++ b/client/me/account/index.js
@@ -10,9 +10,9 @@ import page from 'page';
  * Internal dependencies
  */
 import meController from 'me/controller';
-import controller from './controller';
+import { account } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/me/account', meController.sidebar, controller.account, makeLayout, clientRender );
+	page( '/me/account', meController.sidebar, account, makeLayout, clientRender );
 }

--- a/client/me/account/index.js
+++ b/client/me/account/index.js
@@ -8,9 +8,9 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { sidebar } from 'me/controller';
 import { account } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
+import { sidebar } from 'me/controller';
 
 export default function() {
 	page( '/me/account', sidebar, account, makeLayout, clientRender );

--- a/client/me/billing-history/controller.js
+++ b/client/me/billing-history/controller.js
@@ -8,18 +8,16 @@ import React from 'react';
 import BillingHistoryComponent from './main';
 import Receipt from './receipt';
 
-export default {
-	billingHistory( context, next ) {
-		context.primary = React.createElement( BillingHistoryComponent );
-		next();
-	},
+export function billingHistory( context, next ) {
+	context.primary = React.createElement( BillingHistoryComponent );
+	next();
+}
 
-	transaction( context, next ) {
-		const receiptId = context.params.receiptId;
+export function transaction( context, next ) {
+	const receiptId = context.params.receiptId;
 
-		if ( receiptId ) {
-			context.primary = React.createElement( Receipt, { transactionId: receiptId } );
-		}
-		next();
-	},
-};
+	if ( receiptId ) {
+		context.primary = React.createElement( Receipt, { transactionId: receiptId } );
+	}
+	next();
+}

--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -16,46 +16,46 @@ import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import SidebarComponent from 'me/sidebar';
 import AppsComponent from 'me/get-apps';
 
-export default {
-	sidebar( context, next ) {
-		context.secondary = React.createElement( SidebarComponent, {
-			context: context,
-		} );
+export function sidebar( context, next ) {
+	context.secondary = React.createElement( SidebarComponent, {
+		context: context,
+	} );
 
-		next();
-	},
+	next();
+}
 
-	profile( context, next ) {
-		context.store.dispatch( setTitle( i18n.translate( 'My Profile', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+export function profile( context, next ) {
+	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	context.store.dispatch( setTitle( i18n.translate( 'My Profile', { textOnly: true } ) ) );
 
-		const ProfileComponent = require( 'me/profile' ).default;
+	const ProfileComponent = require( 'me/profile' ).default;
 
-		context.primary = React.createElement( ProfileComponent, {
-			userSettings: userSettings,
-			path: context.path,
-		} );
-		next();
-	},
+	context.primary = React.createElement( ProfileComponent, {
+		userSettings: userSettings,
+		path: context.path,
+	} );
+	next();
+}
 
-	apps( context, next ) {
-		context.store.dispatch( setTitle( i18n.translate( 'Get Apps', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+export function apps( context, next ) {
+	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	context.store.dispatch( setTitle( i18n.translate( 'Get Apps', { textOnly: true } ) ) );
 
-		context.primary = React.createElement( AppsComponent, {
-			userSettings: userSettings,
-			path: context.path,
-		} );
-		next();
-	},
+	context.primary = React.createElement( AppsComponent, {
+		userSettings: userSettings,
+		path: context.path,
+	} );
+	next();
+}
 
-	profileRedirect() {
-		page.redirect( '/me' );
-	},
+export function profileRedirect() {
+	page.redirect( '/me' );
+}
 
-	trophiesRedirect() {
-		page.redirect( '/me' );
-	},
+export function trophiesRedirect() {
+	page.redirect( '/me' );
+}
 
-	findFriendsRedirect() {
-		page.redirect( '/me' );
-	},
-};
+export function findFriendsRedirect() {
+	page.redirect( '/me' );
+}

--- a/client/me/happychat/index.jsx
+++ b/client/me/happychat/index.jsx
@@ -10,7 +10,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import config from 'config';
-import controller from 'me/controller';
+import { sidebar } from 'me/controller';
 import Happychat from './main';
 import { setDocumentHeadTitle } from 'state/document-head/actions';
 import { makeLayout, render as clientRender } from 'controller';
@@ -29,6 +29,6 @@ const renderChat = ( context, next ) => {
 
 export default () => {
 	if ( config.isEnabled( 'happychat' ) ) {
-		page( '/me/chat', controller.sidebar, renderChat, makeLayout, clientRender );
+		page( '/me/chat', sidebar, renderChat, makeLayout, clientRender );
 	}
 };

--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -19,48 +19,46 @@ import ContactComponent from './help-contact';
 import { CONTACT, SUPPORT_ROOT } from 'lib/url/support';
 import userUtils from 'lib/user/utils';
 
-export default {
-	loggedOut( context, next ) {
-		if ( userUtils.isLoggedIn() ) {
-			return next();
-		}
+export function loggedOut( context, next ) {
+	if ( userUtils.isLoggedIn() ) {
+		return next();
+	}
 
-		let url;
-		switch ( context.path ) {
-			case '/help':
-				url = SUPPORT_ROOT;
-				break;
-			case '/help/contact':
-				url = CONTACT;
-				break;
-			default:
-				url = login( { redirectTo: window.location.href } );
-		}
+	let url;
+	switch ( context.path ) {
+		case '/help':
+			url = SUPPORT_ROOT;
+			break;
+		case '/help/contact':
+			url = CONTACT;
+			break;
+		default:
+			url = login( { redirectTo: window.location.href } );
+	}
 
-		// Not using the page library here since this is an external URL
-		window.location.href = url;
-	},
+	// Not using the page library here since this is an external URL
+	window.location.href = url;
+}
 
-	help( context, next ) {
-		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( i18n.translate( 'Help', { textOnly: true } ) ) );
+export function help( context, next ) {
+	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	context.store.dispatch( setTitle( i18n.translate( 'Help', { textOnly: true } ) ) );
 
-		context.primary = <HelpComponent isCoursesEnabled={ config.isEnabled( 'help/courses' ) } />;
-		next();
-	},
+	context.primary = <HelpComponent isCoursesEnabled={ config.isEnabled( 'help/courses' ) } />;
+	next();
+}
 
-	courses( context, next ) {
-		context.primary = <CoursesComponent />;
-		next();
-	},
+export function courses( context, next ) {
+	context.primary = <CoursesComponent />;
+	next();
+}
 
-	contact( context, next ) {
-		// Scroll to the top
-		if ( typeof window !== 'undefined' ) {
-			window.scrollTo( 0, 0 );
-		}
+export function contact( context, next ) {
+	// Scroll to the top
+	if ( typeof window !== 'undefined' ) {
+		window.scrollTo( 0, 0 );
+	}
 
-		context.primary = <ContactComponent clientSlug={ config( 'client_slug' ) } />;
-		next();
-	},
-};
+	context.primary = <ContactComponent clientSlug={ config( 'client_slug' ) } />;
+	next();
+}

--- a/client/me/help/index.js
+++ b/client/me/help/index.js
@@ -6,7 +6,7 @@
 
 import page from 'page';
 import config from 'config';
-import meController from 'me/controller';
+import { sidebar } from 'me/controller';
 import * as helpController from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
@@ -15,7 +15,7 @@ export default function() {
 		page(
 			'/help',
 			helpController.loggedOut,
-			meController.sidebar,
+			sidebar,
 			helpController.help,
 			makeLayout,
 			clientRender
@@ -23,7 +23,7 @@ export default function() {
 		page(
 			'/help/contact',
 			helpController.loggedOut,
-			meController.sidebar,
+			sidebar,
 			helpController.contact,
 			makeLayout,
 			clientRender
@@ -34,7 +34,7 @@ export default function() {
 		page(
 			'/help/courses',
 			helpController.loggedOut,
-			meController.sidebar,
+			sidebar,
 			helpController.courses,
 			makeLayout,
 			clientRender

--- a/client/me/help/index.js
+++ b/client/me/help/index.js
@@ -3,12 +3,11 @@
 /**
  * Internal dependencies
  */
-
-import page from 'page';
-import config from 'config';
-import { sidebar } from 'me/controller';
 import * as helpController from './controller';
+import config from 'config';
+import page from 'page';
 import { makeLayout, render as clientRender } from 'controller';
+import { sidebar } from 'me/controller';
 
 export default function() {
 	if ( config.isEnabled( 'help' ) ) {

--- a/client/me/help/index.js
+++ b/client/me/help/index.js
@@ -7,7 +7,7 @@
 import page from 'page';
 import config from 'config';
 import meController from 'me/controller';
-import helpController from './controller';
+import * as helpController from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {

--- a/client/me/index.js
+++ b/client/me/index.js
@@ -10,7 +10,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import controller from './controller';
+import * as controller from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {

--- a/client/me/notification-settings/controller.js
+++ b/client/me/notification-settings/controller.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import i18n from 'i18n-calypso';
 
@@ -17,50 +16,48 @@ import CommentSettingsComponent from 'me/notification-settings/comment-settings'
 import WPcomSettingsComponent from 'me/notification-settings/wpcom-settings';
 import NotificationSubscriptions from 'me/notification-settings/reader-subscriptions';
 
-export default {
-	notifications( context, next ) {
-		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( i18n.translate( 'Notifications', { textOnly: true } ) ) );
+export function notifications( context, next ) {
+	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	context.store.dispatch( setTitle( i18n.translate( 'Notifications', { textOnly: true } ) ) );
 
-		context.primary = React.createElement( NotificationsComponent, {
-			userSettings: userSettings,
-			path: context.path,
-		} );
-		next();
-	},
+	context.primary = React.createElement( NotificationsComponent, {
+		userSettings: userSettings,
+		path: context.path,
+	} );
+	next();
+}
 
-	comments( context, next ) {
-		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch(
-			setTitle( i18n.translate( 'Comments on other sites', { textOnly: true } ) )
-		);
+export function comments( context, next ) {
+	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	context.store.dispatch(
+		setTitle( i18n.translate( 'Comments on other sites', { textOnly: true } ) )
+	);
 
-		context.primary = React.createElement( CommentSettingsComponent, {
-			path: context.path,
-		} );
-		next();
-	},
+	context.primary = React.createElement( CommentSettingsComponent, {
+		path: context.path,
+	} );
+	next();
+}
 
-	updates( context, next ) {
-		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch(
-			setTitle( i18n.translate( 'Updates from WordPress.com', { textOnly: true } ) )
-		);
+export function updates( context, next ) {
+	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	context.store.dispatch(
+		setTitle( i18n.translate( 'Updates from WordPress.com', { textOnly: true } ) )
+	);
 
-		context.primary = React.createElement( WPcomSettingsComponent, {
-			path: context.path,
-		} );
-		next();
-	},
+	context.primary = React.createElement( WPcomSettingsComponent, {
+		path: context.path,
+	} );
+	next();
+}
 
-	notificationSubscriptions( context, next ) {
-		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( i18n.translate( 'Notifications', { textOnly: true } ) ) );
+export function notificationSubscriptions( context, next ) {
+	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	context.store.dispatch( setTitle( i18n.translate( 'Notifications', { textOnly: true } ) ) );
 
-		context.primary = React.createElement( NotificationSubscriptions, {
-			userSettings: userSettings,
-			path: context.path,
-		} );
-		next();
-	},
-};
+	context.primary = React.createElement( NotificationSubscriptions, {
+		userSettings: userSettings,
+		path: context.path,
+	} );
+	next();
+}

--- a/client/me/notification-settings/index.js
+++ b/client/me/notification-settings/index.js
@@ -3,41 +3,25 @@
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**
  * Internal dependencies
  */
-import meController from 'me/controller';
+import { sidebar } from 'me/controller';
 import * as controller from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page(
-		'/me/notifications',
-		meController.sidebar,
-		controller.notifications,
-		makeLayout,
-		clientRender
-	);
-	page(
-		'/me/notifications/comments',
-		meController.sidebar,
-		controller.comments,
-		makeLayout,
-		clientRender
-	);
-	page(
-		'/me/notifications/updates',
-		meController.sidebar,
-		controller.updates,
-		makeLayout,
-		clientRender
-	);
+	page( '/me/notifications', sidebar, controller.notifications, makeLayout, clientRender );
+
+	page( '/me/notifications/comments', sidebar, controller.comments, makeLayout, clientRender );
+
+	page( '/me/notifications/updates', sidebar, controller.updates, makeLayout, clientRender );
+
 	page(
 		'/me/notifications/subscriptions',
-		meController.sidebar,
+		sidebar,
 		controller.notificationSubscriptions,
 		makeLayout,
 		clientRender

--- a/client/me/notification-settings/index.js
+++ b/client/me/notification-settings/index.js
@@ -8,9 +8,9 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { sidebar } from 'me/controller';
 import * as controller from './controller';
 import { makeLayout, render as clientRender } from 'controller';
+import { sidebar } from 'me/controller';
 
 export default function() {
 	page( '/me/notifications', sidebar, controller.notifications, makeLayout, clientRender );

--- a/client/me/notification-settings/index.js
+++ b/client/me/notification-settings/index.js
@@ -10,7 +10,7 @@ import page from 'page';
  * Internal dependencies
  */
 import meController from 'me/controller';
-import controller from './controller';
+import * as controller from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {

--- a/client/me/privacy/controller.js
+++ b/client/me/privacy/controller.js
@@ -13,7 +13,7 @@ import config from 'config';
 import userSettings from 'lib/user-settings';
 import PrivacyComponent from 'me/privacy/main';
 
-export default function privacyController( context, next ) {
+export function privacy( context, next ) {
 	if ( ! config.isEnabled( 'me/privacy' ) ) {
 		return page.redirect( '/me' );
 	}

--- a/client/me/privacy/index.js
+++ b/client/me/privacy/index.js
@@ -9,10 +9,10 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import meController from 'me/controller';
-import privacyController from './controller';
+import { sidebar } from 'me/controller';
+import { privacy } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/me/privacy', meController.sidebar, privacyController, makeLayout, clientRender );
+	page( '/me/privacy', sidebar, privacy, makeLayout, clientRender );
 }

--- a/client/me/privacy/index.js
+++ b/client/me/privacy/index.js
@@ -9,9 +9,9 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { sidebar } from 'me/controller';
-import { privacy } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
+import { privacy } from './controller';
+import { sidebar } from 'me/controller';
 
 export default function() {
 	page( '/me/privacy', sidebar, privacy, makeLayout, clientRender );

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -50,100 +50,98 @@ function noSites( context, analyticsPath ) {
 	clientRender( context );
 }
 
-export default {
-	addCardDetails( context, next ) {
-		if ( userHasNoSites() ) {
-			return noSites( context, '/me/purchases/:site/:purchaseId/payment/add' );
-		}
+export function addCardDetails( context, next ) {
+	if ( userHasNoSites() ) {
+		return noSites( context, '/me/purchases/:site/:purchaseId/payment/add' );
+	}
 
-		setTitle( context, titles.addCardDetails );
+	setTitle( context, titles.addCardDetails );
 
-		context.primary = <AddCardDetails purchaseId={ parseInt( context.params.purchaseId, 10 ) } />;
-		next();
-	},
+	context.primary = <AddCardDetails purchaseId={ parseInt( context.params.purchaseId, 10 ) } />;
+	next();
+}
 
-	addCreditCard( context, next ) {
-		context.primary = <AddCreditCard />;
-		next();
-	},
+export function addCreditCard( context, next ) {
+	context.primary = <AddCreditCard />;
+	next();
+}
 
-	cancelPrivacyProtection( context, next ) {
-		if ( userHasNoSites() ) {
-			return noSites( context, '/me/purchases/:site/:purchaseId/cancel-privacy-protection' );
-		}
+export function cancelPrivacyProtection( context, next ) {
+	if ( userHasNoSites() ) {
+		return noSites( context, '/me/purchases/:site/:purchaseId/cancel-privacy-protection' );
+	}
 
-		setTitle( context, titles.cancelPrivacyProtection );
+	setTitle( context, titles.cancelPrivacyProtection );
 
-		context.primary = (
-			<CancelPrivacyProtection purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
-		);
-		next();
-	},
+	context.primary = (
+		<CancelPrivacyProtection purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
+	);
+	next();
+}
 
-	cancelPurchase( context, next ) {
-		if ( userHasNoSites() ) {
-			return noSites( context, '/me/purchases/:site/:purchaseId/cancel' );
-		}
+export function cancelPurchase( context, next ) {
+	if ( userHasNoSites() ) {
+		return noSites( context, '/me/purchases/:site/:purchaseId/cancel' );
+	}
 
-		setTitle( context, titles.cancelPurchase );
+	setTitle( context, titles.cancelPurchase );
 
-		context.primary = <CancelPurchase purchaseId={ parseInt( context.params.purchaseId, 10 ) } />;
-		next();
-	},
+	context.primary = <CancelPurchase purchaseId={ parseInt( context.params.purchaseId, 10 ) } />;
+	next();
+}
 
-	confirmCancelDomain( context, next ) {
-		if ( userHasNoSites() ) {
-			return noSites( context, '/me/purchases/:site/:purchaseId/confirm-cancel-domain' );
-		}
+export function confirmCancelDomain( context, next ) {
+	if ( userHasNoSites() ) {
+		return noSites( context, '/me/purchases/:site/:purchaseId/confirm-cancel-domain' );
+	}
 
-		setTitle( context, titles.confirmCancelDomain );
+	setTitle( context, titles.confirmCancelDomain );
 
-		context.primary = (
-			<ConfirmCancelDomain purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
-		);
-		next();
-	},
+	context.primary = (
+		<ConfirmCancelDomain purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
+	);
+	next();
+}
 
-	editCardDetails( context, next ) {
-		if ( userHasNoSites() ) {
-			return noSites( context, '/me/purchases/:site/:purchaseId/payment/edit/:cardId' );
-		}
+export function editCardDetails( context, next ) {
+	if ( userHasNoSites() ) {
+		return noSites( context, '/me/purchases/:site/:purchaseId/payment/edit/:cardId' );
+	}
 
-		setTitle( context, titles.editCardDetails );
+	setTitle( context, titles.editCardDetails );
 
-		context.primary = (
-			<EditCardDetails
-				cardId={ context.params.cardId }
-				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-			/>
-		);
-		next();
-	},
+	context.primary = (
+		<EditCardDetails
+			cardId={ context.params.cardId }
+			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+		/>
+	);
+	next();
+}
 
-	list( context, next ) {
-		if ( userHasNoSites() ) {
-			return noSites( context, '/me/purchases' );
-		}
+export function list( context, next ) {
+	if ( userHasNoSites() ) {
+		return noSites( context, '/me/purchases' );
+	}
 
-		setTitle( context );
+	setTitle( context );
 
-		context.primary = <PurchasesList noticeType={ context.params.noticeType } />;
-		next();
-	},
+	context.primary = <PurchasesList noticeType={ context.params.noticeType } />;
+	next();
+}
 
-	managePurchase( context, next ) {
-		if ( userHasNoSites() ) {
-			return noSites( context, '/me/purchases/:site/:purchaseId' );
-		}
+export function managePurchase( context, next ) {
+	if ( userHasNoSites() ) {
+		return noSites( context, '/me/purchases/:site/:purchaseId' );
+	}
 
-		setTitle( context, titles.managePurchase );
+	setTitle( context, titles.managePurchase );
 
-		context.primary = (
-			<ManagePurchase
-				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-				destinationType={ context.params.destinationType }
-			/>
-		);
-		next();
-	},
-};
+	context.primary = (
+		<ManagePurchase
+			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+			destinationType={ context.params.destinationType }
+		/>
+	);
+	next();
+}

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -12,7 +12,7 @@ import page from 'page';
 import billingController from 'me/billing-history/controller';
 import meController from 'me/controller';
 import { siteSelection } from 'my-sites/controller';
-import controller from './controller';
+import * as controller from './controller';
 import * as paths from './paths';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -10,7 +10,7 @@ import page from 'page';
  * Internal Dependencies
  */
 import * as billingController from 'me/billing-history/controller';
-import meController from 'me/controller';
+import { sidebar } from 'me/controller';
 import { siteSelection } from 'my-sites/controller';
 import * as controller from './controller';
 import * as paths from './paths';
@@ -21,7 +21,7 @@ export default function( router ) {
 		router(
 			paths.addCreditCard,
 			redirectLoggedOut,
-			meController.sidebar,
+			sidebar,
 			controller.addCreditCard,
 			makeLayout,
 			clientRender
@@ -34,7 +34,7 @@ export default function( router ) {
 	router(
 		paths.billingHistory,
 		redirectLoggedOut,
-		meController.sidebar,
+		sidebar,
 		billingController.billingHistory,
 		makeLayout,
 		clientRender
@@ -43,7 +43,7 @@ export default function( router ) {
 	router(
 		paths.billingHistoryReceipt(),
 		redirectLoggedOut,
-		meController.sidebar,
+		sidebar,
 		billingController.transaction,
 		makeLayout,
 		clientRender
@@ -52,7 +52,7 @@ export default function( router ) {
 	router(
 		paths.purchasesRoot,
 		redirectLoggedOut,
-		meController.sidebar,
+		sidebar,
 		controller.list,
 		makeLayout,
 		clientRender
@@ -61,7 +61,7 @@ export default function( router ) {
 	router(
 		paths.managePurchase(),
 		redirectLoggedOut,
-		meController.sidebar,
+		sidebar,
 		siteSelection,
 		controller.managePurchase,
 		makeLayout,
@@ -71,7 +71,7 @@ export default function( router ) {
 	router(
 		paths.cancelPurchase(),
 		redirectLoggedOut,
-		meController.sidebar,
+		sidebar,
 		siteSelection,
 		controller.cancelPurchase,
 		makeLayout,
@@ -81,7 +81,7 @@ export default function( router ) {
 	router(
 		paths.cancelPrivacyProtection(),
 		redirectLoggedOut,
-		meController.sidebar,
+		sidebar,
 		siteSelection,
 		controller.cancelPrivacyProtection,
 		makeLayout,
@@ -91,7 +91,7 @@ export default function( router ) {
 	router(
 		paths.confirmCancelDomain(),
 		redirectLoggedOut,
-		meController.sidebar,
+		sidebar,
 		siteSelection,
 		controller.confirmCancelDomain,
 		makeLayout,
@@ -101,7 +101,7 @@ export default function( router ) {
 	router(
 		paths.addCardDetails(),
 		redirectLoggedOut,
-		meController.sidebar,
+		sidebar,
 		siteSelection,
 		controller.addCardDetails,
 		makeLayout,
@@ -111,7 +111,7 @@ export default function( router ) {
 	router(
 		paths.editCardDetails(),
 		redirectLoggedOut,
-		meController.sidebar,
+		sidebar,
 		siteSelection,
 		controller.editCardDetails,
 		makeLayout,

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -9,7 +9,7 @@ import page from 'page';
 /**
  * Internal Dependencies
  */
-import billingController from 'me/billing-history/controller';
+import * as billingController from 'me/billing-history/controller';
 import meController from 'me/controller';
 import { siteSelection } from 'my-sites/controller';
 import * as controller from './controller';

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -10,11 +10,11 @@ import page from 'page';
  * Internal Dependencies
  */
 import * as billingController from 'me/billing-history/controller';
-import { sidebar } from 'me/controller';
-import { siteSelection } from 'my-sites/controller';
 import * as controller from './controller';
 import * as paths from './paths';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
+import { sidebar } from 'me/controller';
+import { siteSelection } from 'my-sites/controller';
 
 export default function( router ) {
 	if ( config.isEnabled( 'manage/payment-methods' ) ) {

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -10,34 +10,22 @@ import page from 'page';
  * Internal dependencies
  */
 import config from 'config';
-import meController from 'me/controller';
+import { sidebar } from 'me/controller';
 import * as controller from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/me/security', meController.sidebar, controller.password, makeLayout, clientRender );
+	page( '/me/security', sidebar, controller.password, makeLayout, clientRender );
 
 	if ( config.isEnabled( 'signup/social-management' ) ) {
-		page(
-			'/me/security/social-login',
-			meController.sidebar,
-			controller.socialLogin,
-			makeLayout,
-			clientRender
-		);
+		page( '/me/security/social-login', sidebar, controller.socialLogin, makeLayout, clientRender );
 	}
 
-	page(
-		'/me/security/two-step',
-		meController.sidebar,
-		controller.twoStep,
-		makeLayout,
-		clientRender
-	);
+	page( '/me/security/two-step', sidebar, controller.twoStep, makeLayout, clientRender );
 
 	page(
 		'/me/security/connected-applications',
-		meController.sidebar,
+		sidebar,
 		controller.connectedApplications,
 		makeLayout,
 		clientRender
@@ -45,7 +33,7 @@ export default function() {
 
 	page(
 		'/me/security/account-recovery',
-		meController.sidebar,
+		sidebar,
 		controller.accountRecovery,
 		makeLayout,
 		clientRender

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -3,16 +3,15 @@
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**
  * Internal dependencies
  */
-import config from 'config';
-import { sidebar } from 'me/controller';
 import * as controller from './controller';
+import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
+import { sidebar } from 'me/controller';
 
 export default function() {
 	page( '/me/security', sidebar, controller.password, makeLayout, clientRender );


### PR DESCRIPTION
Used named import/export from the purchases controller.

No functional changes.

This should warn on build if the (non-existent) default export is imported similar to the following. Why doesn't this error?

> WARNING in ./client/me/purchases/index.js
> 31:52-64 "export 'default' (imported as 'meController') was not found in 'me/controller'

**Note:**
Security is being handled separately (#24727) because it appears to include a bug uncovered by this work.

## Testing
1. Verify all imports have been updated correctly.
1. Builds correctly
1. Tests pass
1. Canaries pass
1. E2E passes
1. Smoke `/me` section (https://calypso.live/me?branch=update/purchase-controller-named-exports)