### PR TITLE
Simple Payments: replace image uploader with media library

### DIFF
--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -10,11 +10,11 @@ import classnames from 'classnames';
 class DialogBase extends Component {
 	static propTypes = {
 		additionalClassNames: PropTypes.oneOfType( [ PropTypes.object, PropTypes.string ] ),
-		additionalBackdropClassNames: PropTypes.oneOfType( [ PropTypes.object, PropTypes.string ] ),
 		autoFocus: PropTypes.bool,
 		baseClassName: PropTypes.string,
 		buttons: PropTypes.array,
 		className: PropTypes.string,
+		isBackdropVisible: PropTypes.bool,
 		isFullScreen: PropTypes.bool,
 		isVisible: PropTypes.bool,
 		label: PropTypes.string,
@@ -25,7 +25,7 @@ class DialogBase extends Component {
 
 	static defaultProps = {
 		baseClassName: 'dialog',
-		additionalBackdropClassNames: '',
+		isBackdropVisible: true,
 		isFullScreen: true,
 		autoFocus: true,
 		label: '',
@@ -34,7 +34,7 @@ class DialogBase extends Component {
 	render() {
 		const {
 				additionalClassNames,
-				additionalBackdropClassNames,
+				isBackdropVisible,
 				baseClassName,
 				isFullScreen,
 				shouldCloseOnEsc,
@@ -42,8 +42,9 @@ class DialogBase extends Component {
 			contentClassName = baseClassName + '__content',
 			// Previous implementation used a `<Card />`, styling still relies on the 'card' class being present
 			dialogClassName = classnames( baseClassName, 'card', additionalClassNames ),
-			backdropClassName = classnames( baseClassName + '__backdrop', additionalBackdropClassNames, {
+			backdropClassName = classnames( baseClassName + '__backdrop', {
 				'is-full-screen': !! isFullScreen,
+				'is-hidden': ! isBackdropVisible,
 			} );
 
 		return (

--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -10,6 +10,7 @@ import classnames from 'classnames';
 class DialogBase extends Component {
 	static propTypes = {
 		additionalClassNames: PropTypes.oneOfType( [ PropTypes.object, PropTypes.string ] ),
+		additionalBackdropClassNames: PropTypes.oneOfType( [ PropTypes.object, PropTypes.string ] ),
 		autoFocus: PropTypes.bool,
 		baseClassName: PropTypes.string,
 		buttons: PropTypes.array,
@@ -24,17 +25,24 @@ class DialogBase extends Component {
 
 	static defaultProps = {
 		baseClassName: 'dialog',
+		additionalBackdropClassNames: '',
 		isFullScreen: true,
 		autoFocus: true,
 		label: '',
 	};
 
 	render() {
-		const { additionalClassNames, baseClassName, isFullScreen, shouldCloseOnEsc } = this.props,
+		const {
+				additionalClassNames,
+				additionalBackdropClassNames,
+				baseClassName,
+				isFullScreen,
+				shouldCloseOnEsc,
+			} = this.props,
 			contentClassName = baseClassName + '__content',
 			// Previous implementation used a `<Card />`, styling still relies on the 'card' class being present
 			dialogClassName = classnames( baseClassName, 'card', additionalClassNames ),
-			backdropClassName = classnames( baseClassName + '__backdrop', {
+			backdropClassName = classnames( baseClassName + '__backdrop', additionalBackdropClassNames, {
 				'is-full-screen': !! isFullScreen,
 			} );
 

--- a/client/components/dialog/style.scss
+++ b/client/components/dialog/style.scss
@@ -27,6 +27,10 @@
 	}
 }
 
+.dialog__backdrop.is-hidden {
+	background-color: rgba( white, 0 );
+}
+
 .dialog.card {
 	position: relative;
 	display: flex;

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -21,7 +21,6 @@ import FormCurrencyInput from 'components/forms/form-currency-input';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import ReduxFormFieldset, { FieldsetRenderer } from 'components/redux-forms/redux-form-fieldset';
 import FormSelect from 'components/forms/form-select';
-import UploadImage from 'blocks/upload-image';
 import { getCurrencyDefaults } from 'lib/format-currency';
 import QueryMembershipsConnectedAccounts from 'components/data/query-memberships-connected-accounts';
 import config from 'config';
@@ -30,6 +29,7 @@ import { authorizeStripeAccount } from 'state/memberships/connected-accounts/act
 import isEditedSimplePaymentsRecurring from 'state/selectors/is-edited-simple-payments-recurring';
 import getEditedSimplePaymentsStripeAccount from 'state/selectors/get-edited-simple-payments-stripe-account';
 import getMembershipsConnectedAccounts from 'state/selectors/get-memberships-connected-accounts';
+import ProductImagePicker from './product-image-picker';
 
 export const REDUX_FORM_NAME = 'simplePaymentsForm';
 
@@ -134,10 +134,6 @@ const validate = ( values, props ) => {
 		} );
 	}
 
-	if ( values.featuredImageId && values.featuredImageId === 'uploading' ) {
-		errors.featuredImageId = 'uploading';
-	}
-
 	// Checks for 'Memberships' only
 	if ( props.isRecurringSubscription ) {
 		if ( ! values.renewal_schedule ) {
@@ -178,38 +174,13 @@ const renderPriceField = ( { price, currency, ...props } ) => {
 	);
 };
 
-// helper to render UploadImage as a form field
-class UploadImageField extends Component {
-	handleImageEditorDone = () => this.props.input.onChange( 'uploading' );
-	handleImageUploadDone = uploadedImage => this.props.input.onChange( uploadedImage.ID );
-	handleImageRemove = () => this.props.input.onChange( null );
-
-	render() {
-		return (
-			<UploadImage
-				defaultImage={ this.props.input.value }
-				onImageEditorDone={ this.handleImageEditorDone }
-				onImageUploadDone={ this.handleImageUploadDone }
-				onImageRemove={ this.handleImageRemove }
-				onError={ this.props.onError }
-			/>
-		);
-	}
-}
-
 class ProductForm extends Component {
-	handleUploadImageError = ( errorCode, errorMessage ) => this.props.showError( errorMessage );
-
 	render() {
 		const { translate } = this.props;
 
 		return (
 			<form className="editor-simple-payments-modal__form">
-				<Field
-					name="featuredImageId"
-					onError={ this.handleUploadImageError }
-					component={ UploadImageField }
-				/>
+				<Field name="featuredImageId" component={ ProductImagePicker } />
 				<div className="editor-simple-payments-modal__form-fields">
 					<ReduxFormFieldset
 						name="title"

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -1,0 +1,130 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+
+import AsyncLoad from 'components/async-load';
+import { getMediaItem } from 'state/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import MediaActions from 'lib/media/actions';
+import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
+import ProductImage from './product-image';
+import RemoveButton from 'components/remove-button';
+
+class ProductImagePicker extends Component {
+	static propTypes = {
+		featuredImage: PropTypes.object,
+		siteId: PropTypes.number,
+		translate: PropTypes.func,
+	};
+
+	state = {
+		isSelecting: false,
+	};
+
+	showMediaModal = () => {
+		const { siteId, featuredImage } = this.props;
+
+		if ( featuredImage ) {
+			MediaActions.setLibrarySelectedItems( siteId, [ featuredImage ] );
+		}
+
+		this.setState( { isSelecting: true } );
+	};
+
+	hideMediaModal = () => this.setState( { isSelecting: false } );
+
+	setImage = value => {
+		this.hideMediaModal();
+
+		if ( ! value ) {
+			return;
+		}
+
+		this.props.input.onChange( value.items[ 0 ].ID );
+	};
+
+	removeCurrentImage = event => {
+		event.stopPropagation();
+
+		this.props.input.onChange( false );
+	};
+
+	getImagePlaceholder() {
+		return (
+			<div className="dialog__product-image-placeholder">
+				<Gridicon icon="add-image" size={ 36 } />
+				{ this.props.translate( 'Add an Image' ) }
+			</div>
+		);
+	}
+
+	getCurrentImage() {
+		const { siteId } = this.props;
+
+		return (
+			<div className="dialog__product-image">
+				<ProductImage siteId={ siteId } imageId={ this.props.input.value } />
+				<RemoveButton onRemove={ this.removeCurrentImage } />
+				<Gridicon icon="pencil" className="dialog__product-image-edit-icon" />
+			</div>
+		);
+	}
+
+	render() {
+		const { siteId, translate } = this.props;
+
+		if ( ! siteId ) {
+			return;
+		}
+
+		return (
+			<div>
+				<MediaLibrarySelectedData siteId={ siteId }>
+					<AsyncLoad
+						require="post-editor/media-modal"
+						siteId={ siteId }
+						onClose={ this.setImage }
+						enabledFilters={ [ 'images' ] }
+						visible={ this.state.isSelecting }
+						labels={ {
+							confirm: translate( 'Add' ),
+						} }
+						single
+					/>
+				</MediaLibrarySelectedData>
+
+				<div
+					className="dialog__product-image-container"
+					onClick={ this.showMediaModal }
+					onKeyDown={ this.showMediaModal }
+					role="button"
+					tabIndex={ 0 }
+				>
+					{ this.props.input.value && this.getCurrentImage() }
+					{ ! this.props.input.value && this.getImagePlaceholder() }
+				</div>
+			</div>
+		);
+	}
+}
+
+export default connect( ( state, ownProps ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteId,
+		featuredImage: getMediaItem( state, siteId, ownProps.input.value ),
+	};
+} )( localize( ProductImagePicker ) );

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -94,7 +94,7 @@ class ProductImagePicker extends Component {
 		}
 
 		return (
-			<div>
+			<div className="dialog__product-image-picker">
 				<MediaLibrarySelectedData siteId={ siteId }>
 					<AsyncLoad
 						require="post-editor/media-modal"

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -41,23 +41,21 @@ class ProductImagePicker extends Component {
 			return;
 		}
 
-		if ( featuredImage ) {
-			MediaActions.setLibrarySelectedItems( siteId, [ featuredImage ] );
-		}
-
-		this.setState( { isSelecting: true } );
+		this.setState( { isSelecting: true }, () => {
+			if ( featuredImage ) {
+				MediaActions.setLibrarySelectedItems( siteId, [ featuredImage ] );
+			}
+		} );
 	};
 
-	hideMediaModal = () => this.setState( { isSelecting: false } );
-
 	setImage = value => {
-		this.hideMediaModal();
+		this.setState( { isSelecting: false }, () => {
+			if ( ! value ) {
+				return;
+			}
 
-		if ( ! value ) {
-			return;
-		}
-
-		this.props.input.onChange( value.items[ 0 ].ID );
+			this.props.input.onChange( value.items[ 0 ].ID );
+		} );
 	};
 
 	removeCurrentImage = event => {
@@ -100,6 +98,7 @@ class ProductImagePicker extends Component {
 
 	render() {
 		const { siteId, translate } = this.props;
+		const { isSelecting } = this.state;
 
 		if ( ! siteId ) {
 			return;
@@ -113,7 +112,7 @@ class ProductImagePicker extends Component {
 						siteId={ siteId }
 						onClose={ this.setImage }
 						enabledFilters={ [ 'images' ] }
-						visible={ this.state.isSelecting }
+						visible={ isSelecting }
 						isBackdropVisible={ false }
 						labels={ {
 							confirm: translate( 'Add' ),

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -102,6 +102,7 @@ class ProductImagePicker extends Component {
 						onClose={ this.setImage }
 						enabledFilters={ [ 'images' ] }
 						visible={ this.state.isSelecting }
+						additionalBackdropClassNames="remove-backdrop-background"
 						labels={ {
 							confirm: translate( 'Add' ),
 						} }

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -68,7 +68,13 @@ class ProductImagePicker extends Component {
 
 	getImagePlaceholder() {
 		return (
-			<div className="dialog__product-image-placeholder">
+			<div
+				className="dialog__product-image-placeholder"
+				onClick={ this.showMediaModal }
+				onKeyDown={ this.showMediaModal }
+				role="button"
+				tabIndex={ 0 }
+			>
 				<Gridicon icon="add-image" size={ 36 } />
 				{ this.props.translate( 'Add an Image' ) }
 			</div>
@@ -79,7 +85,13 @@ class ProductImagePicker extends Component {
 		const { siteId } = this.props;
 
 		return (
-			<div className="dialog__product-image">
+			<div
+				className="dialog__product-image"
+				onClick={ this.showMediaModal }
+				onKeyDown={ this.showMediaModal }
+				role="button"
+				tabIndex={ 0 }
+			>
 				<ProductImage siteId={ siteId } imageId={ this.props.input.value } showEditIcon={ true } />
 				<RemoveButton onRemove={ this.removeCurrentImage } />
 			</div>
@@ -110,13 +122,7 @@ class ProductImagePicker extends Component {
 					/>
 				</MediaLibrarySelectedData>
 
-				<div
-					className="dialog__product-image-container"
-					onClick={ this.showMediaModal }
-					onKeyDown={ this.showMediaModal }
-					role="button"
-					tabIndex={ 0 }
-				>
+				<div className="dialog__product-image-container">
 					{ this.props.input.value && this.getCurrentImage() }
 					{ ! this.props.input.value && this.getImagePlaceholder() }
 				</div>

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -114,7 +114,7 @@ class ProductImagePicker extends Component {
 						onClose={ this.setImage }
 						enabledFilters={ [ 'images' ] }
 						visible={ this.state.isSelecting }
-						additionalBackdropClassNames="remove-backdrop-background"
+						isBackdropVisible={ false }
 						labels={ {
 							confirm: translate( 'Add' ),
 						} }

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -33,8 +33,13 @@ class ProductImagePicker extends Component {
 		isSelecting: false,
 	};
 
-	showMediaModal = () => {
+	showMediaModal = event => {
 		const { siteId, featuredImage } = this.props;
+
+		if ( event.key && event.key !== 'Enter' ) {
+			// A11y - prevent opening Media modal with any key
+			return;
+		}
 
 		if ( featuredImage ) {
 			MediaActions.setLibrarySelectedItems( siteId, [ featuredImage ] );

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -75,9 +75,8 @@ class ProductImagePicker extends Component {
 
 		return (
 			<div className="dialog__product-image">
-				<ProductImage siteId={ siteId } imageId={ this.props.input.value } />
+				<ProductImage siteId={ siteId } imageId={ this.props.input.value } showEditIcon={ true } />
 				<RemoveButton onRemove={ this.removeCurrentImage } />
-				<Gridicon icon="pencil" className="dialog__product-image-edit-icon" />
 			</div>
 		);
 	}

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image.jsx
@@ -9,6 +9,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -17,14 +18,14 @@ import { url as mediaUrl } from 'lib/media/utils';
 import QueryMedia from 'components/data/query-media';
 import { getMediaItem } from 'state/selectors';
 
-const ProductImage = ( { siteId, imageId, image } ) => {
+const ProductImage = ( { siteId, imageId, image, showEditIcon } ) => {
 	if ( ! siteId || ! imageId ) {
 		return null;
 	}
 
 	if ( ! image ) {
 		return (
-			<figure className="editor-simple-payments-modal__figure is-placeholder">
+			<figure className="dialog__editor-simple-payments-modal-figure is-placeholder">
 				<QueryMedia siteId={ siteId } mediaId={ imageId } />
 			</figure>
 		);
@@ -33,9 +34,12 @@ const ProductImage = ( { siteId, imageId, image } ) => {
 	const url = mediaUrl( image, { size: 'medium' } );
 
 	return (
-		<figure className="editor-simple-payments-modal__figure">
-			<img className="editor-simple-payments-modal__image" src={ url } />
-		</figure>
+		<div className="dialog__editor-simple-payments-modal-figure-container">
+			<figure className="dialog__editor-simple-payments-modal-figure">
+				<img className="dialog__editor-simple-payments-modal-image" src={ url } alt="product" />
+			</figure>
+			{ showEditIcon && <Gridicon icon="pencil" className="dialog__product-image-edit-icon" /> }
+		</div>
 	);
 };
 

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -92,6 +92,47 @@
 			text-decoration: none;
 		}
 	}
+
+	.dialog__product-image-container {
+		position: relative;
+		margin-bottom: 20px;
+		margin-right: 25px;
+		box-sizing: border-box;
+
+		&:focus {
+			outline: none;
+
+			.accessible-focus & {
+				box-shadow: inset 0 0 0 2px $blue-light;
+			}
+		}
+	}
+
+	.dialog__product-image-placeholder, .dialog__product-image {
+		width: 200px;
+		height: 200px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-direction: column;
+		background-color: $gray-light;
+		box-shadow: inset 0 0 0 1px lighten( $gray, 25% );
+		font-size: 14px;
+
+		&:hover {
+			cursor: pointer;
+		}
+	}
+
+	.dialog__product-image-edit-icon {
+		position: absolute;
+		top: auto;
+		bottom: 8px;
+		right: 8px;
+		padding: 0;
+		color: $white;
+		opacity: 0.9;
+	}
 }
 
 .editor-simple-payments-modal__nudge-nudge {

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -1,3 +1,5 @@
+/** @format **/
+
 .editor-simple-payments-modal {
 	&.dialog.card {
 		position: absolute;
@@ -10,7 +12,7 @@
 		flex-direction: column;
 		max-width: none;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			top: 5%;
 			bottom: 5%;
 			left: 5%;
@@ -18,7 +20,7 @@
 			width: 90%;
 		}
 
-		@include breakpoint( ">960px" ) {
+		@include breakpoint( '>960px' ) {
 			left: 12.5%;
 			right: 12.5%;
 			width: 75%;
@@ -26,7 +28,7 @@
 	}
 
 	.header-cake.card {
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			margin-top: 0;
 		}
 	}
@@ -59,7 +61,7 @@
 		overflow-y: auto;
 		padding: 16px;
 
-		@include breakpoint( ">480px" ) {
+		@include breakpoint( '>480px' ) {
 			padding: 24px;
 		}
 	}
@@ -94,7 +96,7 @@
 	}
 
 	.dialog__editor-simple-payments-modal-figure-container {
-		position:relative;
+		position: relative;
 	}
 
 	.dialog__product-image-container {
@@ -113,7 +115,8 @@
 		}
 	}
 
-	.dialog__product-image-placeholder, .dialog__product-image {
+	.dialog__product-image-placeholder,
+	.dialog__product-image {
 		width: 200px;
 		height: 200px;
 		display: flex;
@@ -121,7 +124,7 @@
 		justify-content: center;
 		flex-direction: column;
 		background-color: $gray-light;
-		box-shadow: inset 0 0 0 1px lighten( $gray, 25% );
+		box-shadow: inset 0 0 0 1px lighten($gray, 25%);
 		font-size: 14px;
 
 		&:hover {
@@ -173,11 +176,11 @@
 	flex: auto;
 	overflow-y: auto;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		padding: 24px;
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		display: flex;
 
 		.upload-image {
@@ -203,16 +206,16 @@
 	justify-content: center;
 	margin-bottom: 24px;
 	background-color: $gray-light;
-	box-shadow: inset 0 0 0 1px lighten( $gray, 25% );
+	box-shadow: inset 0 0 0 1px lighten($gray, 25%);
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		flex: none;
 		margin-right: 24px;
 	}
 }
 
 .editor-simple-payments-modal__form-fields {
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		flex: auto;
 	}
 }

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -1,5 +1,11 @@
 /** @format **/
 
+.remove-backdrop-background.dialog__backdrop {
+	// prevent stacking multiple dialog backdrops since we have
+	// simple payments and media library dialog open at the same time
+	background-color: rgba(white, 0);
+}
+
 .editor-simple-payments-modal {
 	&.dialog.card {
 		position: absolute;

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -129,6 +129,11 @@
 		}
 	}
 
+	.dialog__product-image {
+		max-width: 200px;
+		max-height: 200px;
+	}
+
 	.dialog__product-image-edit-icon {
 		position: absolute;
 		color: $white;
@@ -177,6 +182,11 @@
 
 	.upload-image {
 		margin-bottom: 20px;
+	}
+
+	.dialog__editor-simple-payments-modal-image {
+		max-width: 200px;
+		max-height: 200px;
 	}
 }
 
@@ -264,7 +274,6 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	border: 1px solid $gray-lighten-10;
 	background-color: $gray-lighten-30;
 
 	&.is-placeholder {

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -111,14 +111,6 @@
 		position: relative;
 		margin-bottom: 20px;
 		margin-right: 25px;
-
-		&:focus {
-			outline: none;
-
-			.accessible-focus & {
-				box-shadow: inset 0 0 0 2px $blue-light;
-			}
-		}
 	}
 
 	.dialog__product-image-placeholder,
@@ -135,6 +127,14 @@
 
 		&:hover {
 			cursor: pointer;
+		}
+
+		&:focus {
+			outline: none;
+
+			.accessible-focus & {
+				box-shadow: inset 0 0 0 2px $blue-light;
+			}
 		}
 	}
 

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -150,6 +150,11 @@
 			opacity: 1;
 		}
 	}
+
+	.remove-button {
+		margin-top: -7px;
+		margin-right: -7px;
+	}
 }
 
 .editor-simple-payments-modal__nudge-nudge {

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -93,11 +93,16 @@
 		}
 	}
 
+	.dialog__editor-simple-payments-modal-figure-container {
+		position:relative;
+	}
+
 	.dialog__product-image-container {
+		width: 200px;
+		height: 200px;
 		position: relative;
 		margin-bottom: 20px;
 		margin-right: 25px;
-		box-sizing: border-box;
 
 		&:focus {
 			outline: none;
@@ -126,12 +131,19 @@
 
 	.dialog__product-image-edit-icon {
 		position: absolute;
-		top: auto;
-		bottom: 8px;
-		right: 8px;
-		padding: 0;
 		color: $white;
 		opacity: 0.9;
+		bottom: 8px;
+		right: 8px;
+		line-height: 0;
+		padding: 4px;
+		border: none;
+		background: rgba(0, 0, 0, 0.2);
+		border-radius: 50%;
+
+		&:hover {
+			opacity: 1;
+		}
 	}
 }
 
@@ -205,7 +217,7 @@
 		margin-right: 24px;
 	}
 
-	.editor-simple-payments-modal__figure {
+	.dialog__editor-simple-payments-modal-figure {
 		flex: none;
 		margin-left: 16px;
 		height: 40px;
@@ -248,7 +260,7 @@
 	margin-left: 16px;
 }
 
-.editor-simple-payments-modal__figure {
+.dialog__editor-simple-payments-modal-figure {
 	display: flex;
 	justify-content: center;
 	align-items: center;
@@ -260,7 +272,7 @@
 	}
 }
 
-.editor-simple-payments-modal__image {
+.dialog__editor-simple-payments-modal-image {
 	max-width: 100%;
 	max-height: 100%;
 }

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -1,11 +1,5 @@
 /** @format **/
 
-.remove-backdrop-background.dialog__backdrop {
-	// prevent stacking multiple dialog backdrops since we have
-	// simple payments and media library dialog open at the same time
-	background-color: rgba(white, 0);
-}
-
 .editor-simple-payments-modal {
 	&.dialog.card {
 		position: absolute;

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -66,10 +66,10 @@ function areMediaActionsDisabled( modalView, mediaItems, isParentReady ) {
 
 export class EditorMediaModal extends Component {
 	static propTypes = {
-		additionalBackdropClassNames: PropTypes.oneOfType( [ PropTypes.object, PropTypes.string ] ),
 		visible: PropTypes.bool,
 		mediaLibrarySelectedItems: PropTypes.arrayOf( PropTypes.object ),
 		onClose: PropTypes.func,
+		isBackdropVisible: PropTypes.bool,
 		isParentReady: PropTypes.func,
 		site: PropTypes.object,
 		siteId: PropTypes.number,
@@ -85,10 +85,10 @@ export class EditorMediaModal extends Component {
 	};
 
 	static defaultProps = {
-		additionalBackdropClassNames: '',
 		visible: false,
 		mediaLibrarySelectedItems: Object.freeze( [] ),
 		onClose: noop,
+		isBackdropVisible: true,
 		isParentReady: () => true,
 		labels: Object.freeze( {} ),
 		setView: noop,
@@ -626,7 +626,7 @@ export class EditorMediaModal extends Component {
 				buttons={ this.getModalButtons() }
 				onClose={ this.onClose }
 				additionalClassNames="editor-media-modal"
-				additionalBackdropClassNames={ this.props.additionalBackdropClassNames }
+				isBackdropVisible={ this.props.isBackdropVisible }
 				shouldCloseOnOverlayClick={ this.shouldClose() }
 				shouldCloseOnEsc={ false }
 			>

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -66,6 +66,7 @@ function areMediaActionsDisabled( modalView, mediaItems, isParentReady ) {
 
 export class EditorMediaModal extends Component {
 	static propTypes = {
+		additionalBackdropClassNames: PropTypes.oneOfType( [ PropTypes.object, PropTypes.string ] ),
 		visible: PropTypes.bool,
 		mediaLibrarySelectedItems: PropTypes.arrayOf( PropTypes.object ),
 		onClose: PropTypes.func,
@@ -84,6 +85,7 @@ export class EditorMediaModal extends Component {
 	};
 
 	static defaultProps = {
+		additionalBackdropClassNames: '',
 		visible: false,
 		mediaLibrarySelectedItems: Object.freeze( [] ),
 		onClose: noop,
@@ -133,7 +135,6 @@ export class EditorMediaModal extends Component {
 		if ( ! isEmpty( mediaLibrarySelectedItems ) && ( view === ModalViews.LIST || single ) ) {
 			MediaActions.setLibrarySelectedItems( site.ID, [] );
 		}
-
 	}
 
 	componentWillUnmount() {
@@ -625,6 +626,7 @@ export class EditorMediaModal extends Component {
 				buttons={ this.getModalButtons() }
 				onClose={ this.onClose }
 				additionalClassNames="editor-media-modal"
+				additionalBackdropClassNames={ this.props.additionalBackdropClassNames }
 				shouldCloseOnOverlayClick={ this.shouldClose() }
 				shouldCloseOnEsc={ false }
 			>


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/24588

Design post: p9Jlb4-7j-p2
Master thread: p3fqKv-6vq-p2

So far we've been using the image uploder which prevented users from easily reusing images from their media library or free photo library.

### Testing instructions

1. Navigate to `/post/{site}`.
2. Click on `+Add` > `Simple Payment Button`.
3. Verify that Media Library opens and that you can save the image with it.
4. Try removing the existing image and saving.
5. Try various operations and attempt to break it. :)
6. Make sure that Simple Payments form fields are now accessible.
7. Make sure that performance issue documented [here](https://github.com/Automattic/wp-calypso/pull/24659#issuecomment-386874337) is no longer present.

### Proposed changes

1. Replaces the file upload prompt with Media Library in Simple Payments dialog.
2. Adds focus styles and keyboard events in order to improve the accessibility of Simple Payments dialog.