### PR TITLE
Podcasting: add email address to settings whitelist

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -281,6 +281,7 @@ const getFormSettings = settings => {
 		'podcasting_category_1',
 		'podcasting_category_2',
 		'podcasting_category_3',
+		'podcasting_email',
 	] );
 };
 


### PR DESCRIPTION
This fixes an issue missed in #24425.

The `podcasting_email` setting wasn't added to the whitelist of settings loaded for the page, so saved values were not appearing correctly again in the form.

To test:
* Before this PR, entering an email address in the podcast settings form and saving the settings would correctly save the value, but reloading the page would warn that your settings hadn't been saved, and the saved value would not appear.
* Run this branch with the `manage/site-settings/podcasting feature-flag` enabled (enabled by default in dev)
* After: Saving a value and reloading the page works as expected.

Note: For Simple Sites, no patching of the API is necessary since the merge of D12286-code. Testing with Atomic sites will require patching D12286-code.