### PR TITLE
Editor: Remove warning about publish date change

### DIFF
--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -77,13 +77,6 @@ export class EditorNotice extends Component {
 		const typeLabel = get( typeObject, 'labels.singular_name', type );
 
 		switch ( key ) {
-			case 'warnPublishDateChange':
-				// This message can only appear for type === 'post'.  See
-				// PostEditor#checkForDateChange().
-				return translate(
-					'Are you sure about that? If you change the date, existing links to your post will stop working.'
-				);
-
 			case 'publishFailure':
 				return translate( 'Publishing of %(typeLabel)s failed.', {
 					args: { typeLabel: typeLabel.toLowerCase() },

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -941,48 +941,6 @@ export class PostEditor extends React.Component {
 		analytics.tracks.recordEvent( 'calypso_editor_publish_date_change', {
 			context: 'open' === this.state.confirmationSidebar ? 'confirmation-sidebar' : 'post-settings',
 		} );
-
-		this.checkForDateChange( dateValue );
-	};
-
-	checkForDateChange = date => {
-		const { savedPost } = this.state;
-
-		if ( ! savedPost ) {
-			return;
-		}
-
-		const currentDate = this.props.moment( date );
-		const modifiedDate = this.props.moment( savedPost.date );
-		const dateChange = ! (
-			currentDate.get( 'date' ) === modifiedDate.get( 'date' ) &&
-			currentDate.get( 'month' ) === modifiedDate.get( 'month' ) &&
-			currentDate.get( 'year' ) === modifiedDate.get( 'year' )
-		);
-		const diff = !! currentDate.diff( modifiedDate ) && !! dateChange;
-
-		if ( savedPost.type === 'post' && utils.isPublished( savedPost ) && diff ) {
-			this.warnPublishDateChange();
-		} else {
-			this.warnPublishDateChange( { clearWarning: true } );
-		}
-	};
-
-	// when a post that is published, modifies its date, this updates the post url
-	// we should warn users of this case
-	warnPublishDateChange = ( { clearWarning = false } = {} ) => {
-		if ( clearWarning ) {
-			if ( get( this.state, 'notice.message' ) === 'warnPublishDateChange' ) {
-				this.hideNotice();
-			}
-			return;
-		}
-		this.setState( {
-			notice: {
-				status: 'is-warning',
-				message: 'warnPublishDateChange',
-			},
-		} );
 	};
 
 	onSaveSuccess = message => {


### PR DESCRIPTION
This PR removes the warning about changing the publish date, as it's no longer necessary. Old permalinks now redirect to the updated permalink. Fixes #22191.

Before:
![image](https://user-images.githubusercontent.com/363749/39597514-3f48c9c2-4edb-11e8-9203-e65b38d6f3ce.png)

To test:
* Apply PR.
* Edit an existing post.
* Modify the date.
* Verify that no no longer receive the notice.