### PR TITLE
[Domains] Enable wide layout for domain mapping

### DIFF
--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -100,7 +100,7 @@ const siteRedirect = ( context, next ) => {
 
 const mapDomain = ( context, next ) => {
 	context.primary = (
-		<Main>
+		<Main wideLayout>
 			<PageViewTracker path={ domainMapping( ':site' ) } title="Domain Search > Domain Mapping" />
 			<DocumentHead title={ translate( 'Map a Domain' ) } />
 			<CartData>


### PR DESCRIPTION
Follow-up on #24609. This change enables a wide layout on `/domains/add/mapping/` like so:

<img width="1070" alt="map_a_domain_ _testing_ _wordpress_com" src="https://user-images.githubusercontent.com/4044428/39600414-e6e5fc2c-4edb-11e8-86f7-59409cca6ae5.png">

# Testing instructions
1. Navigate to `/domains/add/mapping/`.
2. Ensure that the layout resembles the screenshot above. You can compare this change to the current layout [live on production](https://wordpress.com/domains/add/mapping/).