### PR TITLE
Desktop: restrict to a single chunk named build.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,7 +87,7 @@ const webpackConfig = {
 			maxAsyncRequests: 20,
 			maxInitialRequests: 5,
 		},
-		runtimeChunk: { name: 'manifest' },
+		runtimeChunk: codeSplit ? { name: 'manifest' } : false,
 		namedModules: true,
 		namedChunks: isDevelopment,
 		minimize: shouldMinify,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,7 @@ const bundleEnv = config( 'env' );
 const isDevelopment = bundleEnv !== 'production';
 const shouldMinify = process.env.MINIFY_JS === 'true' || bundleEnv === 'production';
 const shouldEmitStats = process.env.EMIT_STATS === 'true';
+const codeSplit = config.isEnabled( 'code-splitting' );
 
 /**
  * This function scans the /client/extensions directory in order to generate a map that looks like this:
@@ -81,7 +82,7 @@ const webpackConfig = {
 	},
 	optimization: {
 		splitChunks: {
-			chunks: 'all',
+			chunks: codeSplit ? 'all' : 'async',
 			name: isDevelopment || shouldEmitStats,
 			maxAsyncRequests: 20,
 			maxInitialRequests: 5,
@@ -186,6 +187,7 @@ const webpackConfig = {
 	},
 	node: false,
 	plugins: _.compact( [
+		! codeSplit && new webpack.optimize.LimitChunkCountPlugin( { maxChunks: 1 } ),
 		new webpack.DefinePlugin( {
 			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
 			PROJECT_NAME: JSON.stringify( config( 'project' ) ),
@@ -221,6 +223,7 @@ const webpackConfig = {
 if ( calypsoEnv === 'desktop' ) {
 	// no chunks or dll here, just one big file for the desktop app
 	webpackConfig.output.filename = '[name].js';
+	webpackConfig.output.chunkFilename = '[name].js';
 } else {
 	// jquery is only needed in the build for the desktop app
 	// see electron bug: https://github.com/atom/electron/issues/254


### PR DESCRIPTION
To be paired along with work on the [wp-desktop](https://github.com/Automattic/wp-desktop) `develop-next` branch. As of webpack 4 we are generating multiple chunks even for desktop whereas we are supposed to only generate one.

**changes involved**
- Keep the manifest in build.js: `runtimeChunk: false`
- Don't split the entryChunk `chunks: 'all' --> 'async'`
- Desktop should set filename to build.js: `chunkFilename: build.js`

**open question**
- why didn't `output.filename` work? it should have taken effect over `chunkFilename`. Smells like a webpack bug

**to test**
- [ ] wp-desktop devserver via `make run`
- [ ] wp-desktop packaging for osx via:
  1. `make build-source CONFIG_ENV=release`
  2. `make package BUILD_PLATFORM=m`
- [ ] wp-calypso dev server
- [ ] wp-calypso docker image (calypso.live is fine)