### PR TITLE
Plans: add Upgrade button to the Advertising Removed feature card in .com plans.

### DIFF
--- a/client/blocks/product-purchase-features-list/advertising-removed.jsx
+++ b/client/blocks/product-purchase-features-list/advertising-removed.jsx
@@ -22,12 +22,12 @@ export default localize( ( { isBusinessPlan, selectedSite, translate } ) => {
 					isBusinessPlan
 						? translate( 'All WordPress.com advertising has been removed from your site.' )
 						: translate(
-								'All WordPress.com advertising has been removed from your site. ' +
-									'Upgrade to Business to remove the WordPress.com footer credit.'
+								'All WordPress.com advertising has been removed from your site. Upgrade to Business ' +
+									'to remove the WordPress.com footer credit.'
 							)
 				}
-				buttonText={ translate( 'Upgrade to Business' ) }
-				href={ '/checkout/' + selectedSite.slug + '/business' }
+				buttonText={ ! isBusinessPlan && translate( 'Upgrade to Business' ) }
+				href={ ! isBusinessPlan && '/checkout/' + selectedSite.slug + '/business' }
 			/>
 		</div>
 	);

--- a/client/blocks/product-purchase-features-list/advertising-removed.jsx
+++ b/client/blocks/product-purchase-features-list/advertising-removed.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import PurchaseDetail from 'components/purchase-detail';
 
-export default localize( ( { isBusinessPlan, translate } ) => {
+export default localize( ( { isBusinessPlan, selectedSite, translate } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
@@ -26,6 +26,8 @@ export default localize( ( { isBusinessPlan, translate } ) => {
 									'Upgrade to remove the WordPress.com footer credit.'
 							)
 				}
+				buttonText={ translate( 'Upgrade' ) }
+				href={ '/checkout/' + selectedSite.slug + '/business' }
 			/>
 		</div>
 	);

--- a/client/blocks/product-purchase-features-list/advertising-removed.jsx
+++ b/client/blocks/product-purchase-features-list/advertising-removed.jsx
@@ -23,10 +23,10 @@ export default localize( ( { isBusinessPlan, selectedSite, translate } ) => {
 						? translate( 'All WordPress.com advertising has been removed from your site.' )
 						: translate(
 								'All WordPress.com advertising has been removed from your site. ' +
-									'Upgrade to remove the WordPress.com footer credit.'
+									'Upgrade to Business to remove the WordPress.com footer credit.'
 							)
 				}
-				buttonText={ translate( 'Upgrade' ) }
+				buttonText={ translate( 'Upgrade to Business' ) }
 				href={ '/checkout/' + selectedSite.slug + '/business' }
 			/>
 		</div>

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -77,7 +77,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<JetpackSearch selectedSite={ selectedSite } />
 				<GoogleVouchers selectedSite={ selectedSite } />
 				<GoogleAnalyticsStats selectedSite={ selectedSite } />
-				<AdvertisingRemoved isBusinessPlan />
+				<AdvertisingRemoved isBusinessPlan selectedSite={ selectedSite } />
 				<CustomizeTheme selectedSite={ selectedSite } />
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
 				<FindNewTheme selectedSite={ selectedSite } />
@@ -94,7 +94,7 @@ export class ProductPurchaseFeaturesList extends Component {
 			<Fragment>
 				<HappinessSupportCard isPlaceholder={ isPlaceholder } />
 				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
-				<AdvertisingRemoved isBusinessPlan={ false } />
+				<AdvertisingRemoved isBusinessPlan={ false } selectedSite={ selectedSite } />
 				<GoogleVouchers selectedSite={ selectedSite } />
 				<CustomizeTheme selectedSite={ selectedSite } />
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
@@ -113,7 +113,7 @@ export class ProductPurchaseFeaturesList extends Component {
 			<Fragment>
 				<HappinessSupportCard isPlaceholder={ isPlaceholder } />
 				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
-				<AdvertisingRemoved isBusinessPlan={ false } />
+				<AdvertisingRemoved isBusinessPlan={ false } selectedSite={ selectedSite } />
 				<MobileApps />
 			</Fragment>
 		);

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -113,7 +113,7 @@ export class ProductPurchaseFeaturesList extends Component {
 			<Fragment>
 				<HappinessSupportCard isPlaceholder={ isPlaceholder } />
 				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
-				<AdvertisingRemoved isBusinessPlan={ false } selectedSite={ selectedSite } />
+				<AdvertisingRemoved isBusinessPlan selectedSite={ selectedSite } />
 				<MobileApps />
 			</Fragment>
 		);


### PR DESCRIPTION
Previously, there was no CTA button featured for this card. We direct the flow directly to the Business purchase flow.

Before:
No CTA button

After:
![screen shot 2018-05-03 at 21 35 35](https://user-images.githubusercontent.com/13561163/39605070-cf410f26-4f26-11e8-8733-b4400b15b49f.png)


## To test:
- use calypso.live or checkout this branch
- go to `plans/my-plan/:site` for any .com site on a paid plan
- verify the button is present and it redirects to `/checkout/:site/business`

/cc @fditrapani as this is changing .com plans content.

Note: the last part of the route above is used for firing track events.