### PR TITLE
HelpContact: Scope savedContactForm to the instance, not the file

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -71,7 +71,6 @@ import QueryLanguageNames from 'components/data/query-language-names';
  */
 const defaultLanguageSlug = config( 'i18n_default_locale_slug' );
 const wpcom = wpcomLib.undocumented();
-let savedContactForm = null;
 
 const SUPPORT_DIRECTLY = 'SUPPORT_DIRECTLY';
 const SUPPORT_HAPPYCHAT = 'SUPPORT_HAPPYCHAT';
@@ -96,6 +95,8 @@ class HelpContact extends React.Component {
 		wasAdditionalSupportOptionShown: false,
 	};
 
+	savedContactForm = null;
+
 	componentDidMount() {
 		this.prepareDirectlyWidget();
 	}
@@ -111,8 +112,12 @@ class HelpContact extends React.Component {
 		page( '/help' );
 	};
 
-	clearSavedContactForm = () => {
-		savedContactForm = null;
+	clearSavedContactForm() {
+		this.savedContactForm = null;
+	}
+
+	updateSavedContactForm = formValues => {
+		this.savedContactForm = formValues;
 	};
 
 	startHappychat = contactForm => {
@@ -436,8 +441,8 @@ class HelpContact extends React.Component {
 			disabled: isSubmitting,
 			showHelpLanguagePrompt: showHelpLanguagePrompt,
 			valueLink: {
-				value: savedContactForm,
-				requestChange: contactForm => ( savedContactForm = contactForm ),
+				value: this.savedContactForm,
+				requestChange: this.updateSavedContactForm,
 			},
 		};
 	};


### PR DESCRIPTION
### Summary

Currently, some contact form state is held on a variable scoped to the `help/help-contact/index` module. This causes a subtle bug where state is shared between both instances of this component - the instance found in inline-help and the instance found in `/help/contact` which can seem a little weird. When a customer has both open and starts typing in one, it is reflected in the other.

This PR seeks to move the `savedContactForm` from the global module scope to the component instance. It's not the best solution but is certainly the quickest way to fix this bug.

### Reproducing

- Open the inline-help popover by pressing the <kbd>?</kbd>
- Click on 'More help' to open up `/help`
- Go to `/help/contact` by clicking the 'Get In Touch' option
- Again, open inline-help by pressing the <kbd>?</kbd>
- Click 'Contact us' to see the inline-help contact form
- Now, try typing in the inline-help contact form 
- Click back on the main contact form input
- You should now see whatever you typed show up in the main form.

### Testing

- Patch and repeat the repro steps above.
- You should no longer see the mirroring of the form states 