### PR TITLE
[Domains] Add analytics for pagination

### DIFF
--- a/client/components/domains/register-domain-step/analytics.js
+++ b/client/components/domains/register-domain-step/analytics.js
@@ -84,3 +84,14 @@ export const recordDomainAvailabilityReceive = (
 			section,
 		} )
 	);
+
+export function recordShowMoreResults( searchQuery, pageNumber, section ) {
+	return composeAnalytics(
+		recordGoogleEvent( 'Domain Search', 'Show More Results' ),
+		recordTracksEvent( 'calypso_domain_search_show_more_results', {
+			search_query: searchQuery,
+			page_number: pageNumber,
+			section,
+		} )
+	);
+}


### PR DESCRIPTION
Readies the pagination feature for production release. It adds analytics tracking for Google Analytics and our internal Tracks tool.

# Test instructions
1. Spin up this branch locally.
2. Navigate to `/start/domains`.
3. Enable debugging in your browser console, like so:

```js
localStorage.debug = 'calypso:domains:register-domain-step'
```

4. Enter a query. Ensure you see the `Show more` button at the bottom of the list.

<img width="1003" alt="wordpress_com" src="https://user-images.githubusercontent.com/4044428/39606388-6becb01c-4ef2-11e8-963f-a14790ea7d3d.png">

5. Click on the `Show more` button. Ensure you see a corresponding debug line in the console.

6. Ensure you can click the `Show more` button one more time, for a total of 30 domain suggestions.