### PR TITLE
[Domains] Tweak start date for strikethrough test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -109,7 +109,7 @@ export default {
 		defaultVariation: 'original',
 	},
 	signupDomainStrikethruPrice: {
-		datestamp: '20180504',
+		datestamp: '20180507',
 		variations: {
 			enabled: 50,
 			disabled: 50,


### PR DESCRIPTION
This is a clone of #24670, since e2e tests were failing due to a branch naming error.