### PR TITLE
Guided Tours: prevent Simple Payments Email Tour first step incorrect positioning

### DIFF
--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -30,7 +30,7 @@ const handleTargetDisappear = () => {
 };
 
 export const SimplePaymentsEmailTour = makeTour(
-	<Tour name="simplePaymentsEmailTour" version="20180504" path="/stats" when={ noop }>
+	<Tour name="simplePaymentsEmailTour" version="20180501" path="/" when={ noop }>
 		<Step
 			name="init"
 			target="side-menu-page"

--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -20,14 +20,24 @@ import {
 } from 'layout/guided-tours/config-elements';
 import { AddContentButton } from '../button-labels';
 
+// When moving from stats to the editor, the menu disappears, the first step
+// loses its target, and it repositions in the top left corner.
+// This function immediately moves it outside of the viewport, and, as soon
+// as the next step's target appears, the step is repositioned correctly.
+const handleTargetDisappear = () => {
+	const tourFirstStep = document.querySelector( '.guided-tours__step-first' );
+	tourFirstStep.style.left = '-9999px';
+};
+
 export const SimplePaymentsEmailTour = makeTour(
-	<Tour name="simplePaymentsEmailTour" version="20180501" path="/" when={ noop }>
+	<Tour name="simplePaymentsEmailTour" version="20180504" path="/stats" when={ noop }>
 		<Step
 			name="init"
 			target="side-menu-page"
 			placement="beside"
 			arrow="left-top"
 			style={ { animationDelay: '2s' } }
+			onTargetDisappear={ handleTargetDisappear }
 		>
 			{ ( { translate } ) => (
 				<Fragment>


### PR DESCRIPTION
Fix issue raised in https://github.com/Automattic/wp-calypso/pull/24627#issuecomment-386416627

The `simplePaymentsEmailTour` starts in `/stats` and then moves into the `/page` editor.
The first step of the tour targets a sidebar menu item, which disappears when moving from `/stats` to `/page`.
When tour steps lose their targets, they are repositioned to `0, 0`, and this caused it to flash in the top left corner of the screen while the editor's toolbar (the next steps' target) wasn't rendered yet.

![screen shot 2018-05-03 at 12 41 34 pm](https://user-images.githubusercontent.com/4924246/39599120-9c2ddb20-4ecf-11e8-8211-7305815a0457.png)

This PR adds an `handleTargetDisappear` function that, on target lost, moves the step outside of the viewport.
As soon as the next step's target appears, the step element is then updated and repositioned correctly to the new target.

See also: https://github.com/Automattic/wp-calypso/blob/master/client/layout/guided-tours/docs/API.md for the `onTargetDisappear` functioning.

## Testing instructions

- Open `/stats/day/{site}?tour=simplePaymentsEmailTour`.
- Follow the tour's first step, by clicking on the pages' Add button.
- Make sure that the tour step disappears completely while the page changes.