### PR TITLE
Guided Tours: Only start the Simple Payments Email Tour in sections with a sidebar

### DIFF
--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -19,26 +19,10 @@ import {
 	Quit,
 } from 'layout/guided-tours/config-elements';
 import { AddContentButton } from '../button-labels';
-import { getSectionName } from 'state/ui/selectors';
+import { getSectionName, hasSidebar } from 'state/ui/selectors';
 
 const sectionHasSidebar = state =>
-	includes(
-		[
-			'stats',
-			'plans',
-			'posts-pages',
-			'media',
-			'comments',
-			'posts-custom',
-			'themes',
-			'sharing',
-			'people',
-			'plugins',
-			'domains',
-			'settings',
-		],
-		getSectionName( state )
-	);
+	hasSidebar( state ) && ! includes( [ 'customize' ], getSectionName( state ) );
 
 // When moving from stats to the editor, the menu disappears, the first step
 // loses its target, and it repositions in the top left corner.

--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -24,18 +24,18 @@ import { getSectionName } from 'state/ui/selectors';
 const hasSidebar = state =>
 	includes(
 		[
-			'/stats',
-			'/plans',
-			'/pages',
-			'/posts',
-			'/media',
-			'/comments',
-			'/types',
-			'/themes',
-			'/sharing',
-			'/people',
-			'/plugins',
-			'/settings',
+			'stats',
+			'plans',
+			'posts-pages',
+			'media',
+			'comments',
+			'posts-custom',
+			'themes',
+			'sharing',
+			'people',
+			'plugins',
+			'domains',
+			'settings',
 		],
 		getSectionName( state )
 	);

--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -4,7 +4,7 @@
  */
 
 import React, { Fragment } from 'react';
-import { noop } from 'lodash';
+import { includes, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,6 +19,9 @@ import {
 	Quit,
 } from 'layout/guided-tours/config-elements';
 import { AddContentButton } from '../button-labels';
+import { getSectionName } from 'state/ui/selectors';
+
+const hasSidebar = state => ! includes( [ 'customize', 'post-editor' ], getSectionName( state ) );
 
 // When moving from stats to the editor, the menu disappears, the first step
 // loses its target, and it repositions in the top left corner.
@@ -38,6 +41,7 @@ export const SimplePaymentsEmailTour = makeTour(
 			arrow="left-top"
 			style={ { animationDelay: '2s' } }
 			onTargetDisappear={ handleTargetDisappear }
+			when={ hasSidebar }
 		>
 			{ ( { translate } ) => (
 				<Fragment>

--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -21,7 +21,7 @@ import {
 import { AddContentButton } from '../button-labels';
 import { getSectionName } from 'state/ui/selectors';
 
-const hasSidebar = state =>
+const sectionHasSidebar = state =>
 	includes(
 		[
 			'stats',
@@ -58,7 +58,7 @@ export const SimplePaymentsEmailTour = makeTour(
 			arrow="left-top"
 			style={ { animationDelay: '2s' } }
 			onTargetDisappear={ handleTargetDisappear }
-			when={ hasSidebar }
+			when={ sectionHasSidebar }
 		>
 			{ ( { translate } ) => (
 				<Fragment>

--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -21,7 +21,24 @@ import {
 import { AddContentButton } from '../button-labels';
 import { getSectionName } from 'state/ui/selectors';
 
-const hasSidebar = state => ! includes( [ 'customize', 'post-editor' ], getSectionName( state ) );
+const hasSidebar = state =>
+	includes(
+		[
+			'/stats',
+			'/plans',
+			'/pages',
+			'/posts',
+			'/media',
+			'/comments',
+			'/types',
+			'/themes',
+			'/sharing',
+			'/people',
+			'/plugins',
+			'/settings',
+		],
+		getSectionName( state )
+	);
 
 // When moving from stats to the editor, the menu disappears, the first step
 // loses its target, and it repositions in the top left corner.


### PR DESCRIPTION
Fix issue raised in https://github.com/Automattic/wp-calypso/pull/24627#issuecomment-386416627

Limit the first step of the `simplePaymentsEmailTour` tour to only those sections that have a sidebar, in order to avoid showing it in incorrect positions.

## Testing instructions

Try opening different sections with the `?tour=simplePaymentsEmailTour` query param, and navigating from those.
Make sure that the tour only appears in sections with the sidebar (e.g. `/stats`) but not in those without it (e.g., `/customize`, or `/me`)