### PR TITLE
Domains: Fix NUX breakage if there is a message in the state and you refresh

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -320,6 +320,23 @@ class RegisterDomainStep extends React.Component {
 
 	render() {
 		const queryObject = getQueryObject( this.props );
+		let i, ReactComponentName;
+		if ( this.state.notice ) {
+			// Fix restoring components from Redux state.
+			for ( i = 0; i < this.state.notice.length; i++ ) {
+				if (
+					typeof this.state.notice[ i ].type === 'string' &&
+					typeof this.state.notice[ i ].$$typeof === 'undefined'
+				) {
+					ReactComponentName = this.state.notice[ i ].type;
+					this.state.notice[ i ] = (
+						<ReactComponentName { ...this.state.notice[ 0 ] }>
+							{ this.state.notice[ 0 ].props.children }
+						</ReactComponentName>
+					);
+				}
+			}
+		}
 
 		return (
 			<div className="register-domain-step">


### PR DESCRIPTION
The interpolated compontents don't get restored to React components when restoring Redux state. This PR converts them into such if they come from Redux as plain objects.

Fixes #24626