### PR TITLE
Purchases: assembler janitorial work

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -87,15 +87,10 @@ function createPurchaseObject( purchase ) {
 	return object;
 }
 
-function createPurchasesArray( dataTransferObject ) {
+export function createPurchasesArray( dataTransferObject ) {
 	if ( ! Array.isArray( dataTransferObject ) ) {
 		return [];
 	}
 
 	return sortProducts( dataTransferObject.map( createPurchaseObject ) );
 }
-
-export default {
-	createPurchaseObject,
-	createPurchasesArray,
-};

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -10,7 +10,7 @@ import { get, find } from 'lodash';
  * Internal Dependencies
  */
 import createSelector from 'lib/create-selector';
-import purchasesAssembler from 'lib/purchases/assembler';
+import { createPurchasesArray } from 'lib/purchases/assembler';
 import { isSubscription } from 'lib/purchases';
 import { isDomainRegistration, isDomainMapping } from 'lib/products-values';
 
@@ -21,7 +21,7 @@ import { isDomainRegistration, isDomainMapping } from 'lib/products-values';
  * @return {Array} Purchases
  */
 export const getPurchases = createSelector(
-	state => purchasesAssembler.createPurchasesArray( state.purchases.data ),
+	state => createPurchasesArray( state.purchases.data ),
 	state => [ state.purchases.data ]
 );
 

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -5,12 +5,12 @@
  */
 import { createPurchasesArray } from 'lib/purchases/assembler';
 import {
-	getPurchases,
 	getByPurchaseId,
-	isFetchingUserPurchases,
-	isFetchingSitePurchases,
 	getIncludedDomainPurchase,
+	getPurchases,
 	getSitePurchases,
+	isFetchingSitePurchases,
+	isFetchingUserPurchases,
 	isUserPaid,
 } from '../selectors';
 

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -37,7 +33,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getPurchases( state ) ).to.deep.equal( createPurchasesArray( initialPurchases ) );
+			expect( getPurchases( state ) ).toEqual( createPurchasesArray( initialPurchases ) );
 
 			const newPurchases = Object.freeze( [
 				{ ID: 3, product_name: 'business plan', blog_id: 3117 },
@@ -51,7 +47,7 @@ describe( 'selectors', () => {
 						},
 					} )
 				)
-			).to.deep.equal( createPurchasesArray( newPurchases ) );
+			).toEqual( createPurchasesArray( newPurchases ) );
 		} );
 	} );
 
@@ -71,7 +67,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getByPurchaseId( state, 2 ) ).to.be.eql( {
+			expect( getByPurchaseId( state, 2 ) ).toEqual( {
 				id: 2,
 				productName: 'premium plan',
 				siteId: 1337,
@@ -132,7 +128,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isFetchingUserPurchases( state ) ).to.be.true;
+			expect( isFetchingUserPurchases( state ) ).toBe( true );
 		} );
 	} );
 
@@ -149,7 +145,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isFetchingSitePurchases( state ) ).to.be.true;
+			expect( isFetchingSitePurchases( state ) ).toBe( true );
 		} );
 	} );
 
@@ -181,9 +177,9 @@ describe( 'selectors', () => {
 
 			const result = getSitePurchases( state, 1234 );
 
-			expect( result.length ).to.equal( 2 );
-			expect( result[ 0 ].siteId ).to.equal( 1234 );
-			expect( result[ 1 ].siteId ).to.equal( 1234 );
+			expect( result.length ).toBe( 2 );
+			expect( result[ 0 ].siteId ).toBe( 1234 );
+			expect( result[ 1 ].siteId ).toBe( 1234 );
 		} );
 	} );
 
@@ -224,9 +220,7 @@ describe( 'selectors', () => {
 				purchase => purchase.productSlug === 'value_bundle'
 			);
 
-			expect( getIncludedDomainPurchase( state, subscriptionPurchase ).meta ).to.equal(
-				'dev.live'
-			);
+			expect( getIncludedDomainPurchase( state, subscriptionPurchase ).meta ).toBe( 'dev.live' );
 		} );
 	} );
 
@@ -249,7 +243,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isUserPaid( state, targetUserId ) ).to.be.false;
+			expect( isUserPaid( state, targetUserId ) ).toBe( false );
 		} );
 
 		test( 'should return true because there are purchases from the target user', () => {
@@ -264,7 +258,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isUserPaid( state, targetUserId ) ).to.be.true;
+			expect( isUserPaid( state, targetUserId ) ).toBe( true );
 		} );
 
 		test( 'should return false because there are no purchases from this user', () => {
@@ -279,7 +273,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isUserPaid( state, 65535 ) ).to.be.false;
+			expect( isUserPaid( state, 65535 ) ).toBe( false );
 		} );
 
 		test( 'should return false because the data is not ready.', () => {
@@ -294,7 +288,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isUserPaid( state, targetUserId ) ).to.be.false;
+			expect( isUserPaid( state, targetUserId ) ).toBe( false );
 		} );
 	} );
 } );

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -7,6 +7,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
+import { createPurchasesArray } from 'lib/purchases/assembler';
 import {
 	getPurchases,
 	getByPurchaseId,
@@ -16,7 +17,6 @@ import {
 	getSitePurchases,
 	isUserPaid,
 } from '../selectors';
-import purchasesAssembler from 'lib/purchases/assembler';
 
 describe( 'selectors', () => {
 	describe( 'getPurchases', () => {
@@ -37,9 +37,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getPurchases( state ) ).to.deep.equal(
-				purchasesAssembler.createPurchasesArray( initialPurchases )
-			);
+			expect( getPurchases( state ) ).to.deep.equal( createPurchasesArray( initialPurchases ) );
 
 			const newPurchases = Object.freeze( [
 				{ ID: 3, product_name: 'business plan', blog_id: 3117 },
@@ -53,7 +51,7 @@ describe( 'selectors', () => {
 						},
 					} )
 				)
-			).to.deep.equal( purchasesAssembler.createPurchasesArray( newPurchases ) );
+			).to.deep.equal( createPurchasesArray( newPurchases ) );
 		} );
 	} );
 


### PR DESCRIPTION
- Use named export/import over default object wrapper
- Update tests to Jest expect
- Alphabetize imports

No functional changes.

## Testing
- Compiles
- Tests pass
- Visit https://calypso.live/me/purchases?branch=fix/purchases-assembler-janitorial
- Can you see purchases correctly?