### PR TITLE
InlineHelp: Add Forum Flow

### DIFF
--- a/client/blocks/inline-help/constants.js
+++ b/client/blocks/inline-help/constants.js
@@ -8,3 +8,4 @@ export const RESULT_TOUR = 'tour';
 export const RESULT_VIDEO = 'video';
 export const VIEW_CONTACT = 'contact';
 export const VIEW_RICH_RESULT = 'richresult';
+export const VIEW_FORUM = 'forums';

--- a/client/blocks/inline-help/inline-help-forum-view.jsx
+++ b/client/blocks/inline-help/inline-help-forum-view.jsx
@@ -1,0 +1,42 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { identity } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import Button from 'components/button';
+import { preventWidows } from 'lib/formatting';
+
+const FORUM_LINK = '//en.forums.wordpress.com';
+
+const InlineHelpForumView = ( { translate = identity } ) => (
+	<div className="inline-help__forum-view">
+		<h2 className="inline-help__view-heading">
+			{ preventWidows( translate( 'Find Answers In Our Public Forums' ) ) }
+		</h2>
+		<p>
+			{ preventWidows(
+				translate(
+					'Post a new question in our {{strong}}public forums{{/strong}}, ' +
+						'where it may be answered by helpful community members, ' +
+						'by following the link below.',
+					{
+						components: {
+							strong: <strong />,
+						},
+					}
+				)
+			) }
+		</p>
+		<Button href={ FORUM_LINK } target="_blank" rel="noopener noreferrer" primary>
+			{ translate( 'Support Forums' ) }
+		</Button>
+	</div>
+);
+
+export default localize( InlineHelpForumView );

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -13,7 +13,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal Dependencies
  */
-import { VIEW_CONTACT, VIEW_RICH_RESULT } from './constants';
+import { VIEW_CONTACT, VIEW_FORUM, VIEW_RICH_RESULT } from './constants';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { selectResult, resetInlineHelpContactForm } from 'state/inline-help/actions';
 import Button from 'components/button';
@@ -21,9 +21,13 @@ import Popover from 'components/popover';
 import InlineHelpSearchResults from './inline-help-search-results';
 import InlineHelpSearchCard from './inline-help-search-card';
 import InlineHelpRichResult from './inline-help-rich-result';
+import InlineHelpForumView from './inline-help-forum-view';
 import HelpContact from 'me/help/help-contact';
 import { getSearchQuery, getInlineHelpCurrentlySelectedResult } from 'state/inline-help/selectors';
 import { getHelpSelectedSite } from 'state/help/selectors';
+import getInlineHelpSupportVariation, {
+	SUPPORT_FORUM,
+} from 'state/selectors/get-inline-help-support-variation';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
@@ -68,7 +72,8 @@ class InlineHelpPopover extends Component {
 	};
 
 	openContactView = () => {
-		this.openSecondaryView( VIEW_CONTACT );
+		const showForumGuide = this.props.supportVariation === SUPPORT_FORUM;
+		this.openSecondaryView( showForumGuide ? VIEW_FORUM : VIEW_CONTACT );
 	};
 
 	renderSecondaryView = () => {
@@ -82,6 +87,7 @@ class InlineHelpPopover extends Component {
 					{
 						contact: <HelpContact compact selectedSite={ this.props.selectedSite } />,
 						richresult: <InlineHelpRichResult result={ this.props.selectedResult } />,
+						forums: <InlineHelpForumView />,
 					}[ this.state.activeSecondaryView ]
 				}
 			</div>
@@ -154,6 +160,7 @@ export default connect(
 		searchQuery: getSearchQuery( state ),
 		selectedSite: getHelpSelectedSite( state ),
 		selectedResult: getInlineHelpCurrentlySelectedResult( state ),
+		supportVariation: getInlineHelpSupportVariation( state ),
 	} ),
 	{
 		recordTracksEvent,

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -205,6 +205,13 @@
 	}
 }
 
+.inline-help__view-heading {
+	display: block;
+	font-size: 14px;
+	font-weight: 600;
+	margin-bottom: 5px;
+}
+
 .inline-help__richresult {
 	text-align: left;
 
@@ -237,6 +244,10 @@
 		width: 100%;
 		height: 100%;
 	}
+}
+
+.inline-help__forum-view {
+	text-align: left;
 }
 
 .inline-help__contact {


### PR DESCRIPTION
### Summary

This PR aims to add a simple flow for cases in which only the public forums can be offered as a means of support.
I've taken the approach of breaking out in to a new component so as to not thicken the already overloaded `help-contact` & `help-contact-form` components.

<img width="332" alt="screen shot 2018-05-04 at 12 40 05" src="https://user-images.githubusercontent.com/4335450/39626062-5d9ad43e-4f98-11e8-9b09-1aedc78275ac.png">


### To Test

- Either use the test plan of #24583 to achieve the forum support variation, or force `selectors/get-inline-help-support-variation` to return 'SUPPORT_FORUM'
- Open inline-help by clicking the blue ? button in the bottom right
- Click 'Contact Us'
- You should see a view that explains the forums and gives an external link to the forums as in the screen shot above.