### PR TITLE
Post Edit Reducer: remove date edit when receiving updated post with equal date

### DIFF
--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -49,6 +49,7 @@ import {
 	getSerializedPostsQuery,
 	getUnappliedMetadataEdits,
 	isAuthorEqual,
+	isDateEqual,
 	isDiscussionEqual,
 	isTermsEqual,
 	mergePostEdits,
@@ -430,6 +431,8 @@ export function edits( state = {}, action ) {
 						switch ( key ) {
 							case 'author':
 								return isAuthorEqual( value, post[ key ] );
+							case 'date':
+								return isDateEqual( value, post[ key ] );
 							case 'discussion':
 								return isDiscussionEqual( value, post[ key ] );
 							case 'featured_image':

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -16,6 +16,7 @@ import {
 	getDeserializedPostsQueryDetails,
 	getSerializedPostsQueryWithoutPage,
 	isAuthorEqual,
+	isDateEqual,
 	isDiscussionEqual,
 	areAllMetadataEditsApplied,
 	applyPostEdits,
@@ -414,7 +415,7 @@ export const isEditedPostDirty = createSelector(
 						return ! isAuthorEqual( value, post.author );
 					}
 					case 'date': {
-						return ! moment( value ).isSame( post.date );
+						return ! isDateEqual( value, post.date );
 					}
 					case 'discussion': {
 						return ! isDiscussionEqual( value, post.discussion );

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -1324,6 +1324,35 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		test( 'should remove date edits after they are saved', () => {
+			const state = edits(
+				deepFreeze( {
+					2916284: {
+						841: {
+							date: '2018-05-01T10:36:41+02:00',
+						},
+					},
+				} ),
+				{
+					type: POSTS_RECEIVE,
+					posts: [
+						{
+							ID: 841,
+							site_ID: 2916284,
+							type: 'post',
+							date: '2018-05-01T08:36:41+00:00',
+						},
+					],
+				}
+			);
+
+			expect( state ).to.eql( {
+				2916284: {
+					841: {},
+				},
+			} );
+		} );
+
 		test( "should ignore reset edits action when discarded site doesn't exist", () => {
 			const original = deepFreeze( {} );
 			const state = edits( original, {

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -27,6 +27,7 @@ import {
 	find,
 	reject,
 } from 'lodash';
+import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -378,6 +379,10 @@ export function isDiscussionEqual( localDiscussionEdits, savedDiscussion ) {
  */
 export function isAuthorEqual( localAuthorEdit, savedAuthor ) {
 	return get( localAuthorEdit, 'ID' ) === get( savedAuthor, 'ID' );
+}
+
+export function isDateEqual( localDateEdit, savedDate ) {
+	return moment( localDateEdit ).isSame( savedDate );
 }
 
 function isUnappliedMetadataEdit( edit, savedMetadata ) {


### PR DESCRIPTION
When we change post date, the `date` ISO string we send to the REST API can be different from the value in the response, because of timezone differences: `'2018-05-01T10:36:41+02:00'` is equal to `'2018-05-01T08:36:41+00:00'`.

This PR makes sure the `edits` reducer compares the dates correctly when receiving an updated post.

Before this PR, the post wasn't shown as dirty even when there was an outstanding `date` edit, because the `isEditedPostDirty` selector already compares the dates correctly. Only the reducer was affected.

**How to test:**
The reducer has a new unit test. To test the UI behavior:
1. Edit a draft and set a future or past date.
2. Save the draft. Verify that the REST API request sent a new `date` attribute.
3. Change some other attribute, e.g., title. Save the draft again.
4. Verify that the save request doesn't contain `date` again. Just the `title` should be there.

Also verify two special cases for publishing that are handled by [this code](https://github.com/Automattic/wp-calypso/blob/master/client/lib/posts/actions.js#L330-L346):

**Publishing a backdated post:**
1. Edit a post draft, set past publish date (backdate) and save the draft (don't publish yet).
2. Reopen the draft and publish the post, without setting the date again.
3. Verify that it really was published as backdated. The publishing REST request must have a `date` attribute when backdating, although date wasn't changed in this editing session. If it wasn't there, the publish date is reset to "now".

**Scheduling a post:**
1. Edit a post draft, set future publish date and save the draft (don't publish yet).
2. Reopen the draft and "Schedule" it.
3. Verify that it's been correctly scheduled and that the date wasn't reset.
