### PR TITLE
JP Remote Install: Tracks event for manual install click

### DIFF
--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -301,11 +301,17 @@ export class OrgCredentialsForm extends Component {
 			{ url: siteToConnect },
 			'/jetpack/connect/instructions'
 		);
+		const manualInstallClick = () => {
+			this.props.recordTracksEvent( 'calypso_jpc_remoteinstall_instructionsclick', {
+				url: siteToConnect,
+			} );
+		};
 
 		return (
 			<LoggedOutFormLinks>
 				{ ( this.isInvalidCreds() || ! installError ) && (
-					<LoggedOutFormLinkItem href={ manualInstallUrl }>
+					// eslint-disable-next-line react/no-jsx-bind
+					<LoggedOutFormLinkItem href={ manualInstallUrl } onClick={ manualInstallClick }>
 						{ translate( 'Install Jetpack manually' ) }
 					</LoggedOutFormLinkItem>
 				) }


### PR DESCRIPTION
<img width="633" alt="screen shot 2018-05-04 at 13 57 56" src="https://user-images.githubusercontent.com/7767559/39629173-2c72dffe-4fa3-11e8-88bb-b990e86c12b7.png">

Add a tracks event for a click on the "Install Jetpack manually" link on the remote install credentials screen.

## Testing
* Enter in js console: `localStorage.debug = 'calypso:analytics:tracks'`
* Go to https://calypso.live/jetpack/connect?branch=update/jpc-remote-install-manual-track
* Enter URL of wporg site without jetpack plugin active
* Click on the lick and watch for the event in the console

