### PR TITLE
Checkout: redirect logged-out users to login page

### DIFF
--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -9,31 +9,15 @@ import page from 'page';
  */
 import checkoutController from './controller';
 import SiftScience from 'lib/siftscience';
-import userFactory from 'lib/user';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 import { noSite, siteSelection } from 'my-sites/controller';
 
 export default function() {
-	const user = userFactory();
-	const isLoggedOut = ! user.get();
-
 	SiftScience.recordUser();
-
-	// TODO (seear): Temporary logged-out handling. Remove when a general solution arrives in #23785.
-	if ( isLoggedOut ) {
-		page(
-			'/checkout/:domain/:product?',
-			redirectLoggedOut,
-			siteSelection,
-			checkoutController.checkout,
-			makeLayout,
-			clientRender
-		);
-		return;
-	}
 
 	page(
 		'/checkout/thank-you/no-site/pending/:orderId',
+		redirectLoggedOut,
 		siteSelection,
 		checkoutController.checkoutPending,
 		makeLayout,
@@ -42,6 +26,7 @@ export default function() {
 
 	page(
 		'/checkout/thank-you/no-site/:receiptId?',
+		redirectLoggedOut,
 		noSite,
 		checkoutController.checkoutThankYou,
 		makeLayout,
@@ -50,6 +35,7 @@ export default function() {
 
 	page(
 		'/checkout/thank-you/:site/pending/:orderId',
+		redirectLoggedOut,
 		siteSelection,
 		checkoutController.checkoutPending,
 		makeLayout,
@@ -58,6 +44,7 @@ export default function() {
 
 	page(
 		'/checkout/thank-you/:site/:receiptId?',
+		redirectLoggedOut,
 		siteSelection,
 		checkoutController.checkoutThankYou,
 		makeLayout,
@@ -66,6 +53,7 @@ export default function() {
 
 	page(
 		'/checkout/thank-you/:site/:receiptId/with-gsuite/:gsuiteReceiptId',
+		redirectLoggedOut,
 		siteSelection,
 		checkoutController.checkoutThankYou,
 		makeLayout,
@@ -74,6 +62,7 @@ export default function() {
 
 	page(
 		'/checkout/thank-you/features/:feature/:site/:receiptId?',
+		redirectLoggedOut,
 		siteSelection,
 		checkoutController.checkoutThankYou,
 		makeLayout,
@@ -82,6 +71,7 @@ export default function() {
 
 	page(
 		'/checkout/no-site',
+		redirectLoggedOut,
 		noSite,
 		checkoutController.sitelessCheckout,
 		makeLayout,
@@ -90,6 +80,7 @@ export default function() {
 
 	page(
 		'/checkout/features/:feature/:domain/:plan_name?',
+		redirectLoggedOut,
 		siteSelection,
 		checkoutController.checkout,
 		makeLayout,
@@ -98,6 +89,7 @@ export default function() {
 
 	page(
 		'/checkout/:domain/:product?',
+		redirectLoggedOut,
 		siteSelection,
 		checkoutController.checkout,
 		makeLayout,
@@ -106,6 +98,7 @@ export default function() {
 
 	page(
 		'/checkout/:product/renew/:purchaseId/:domain',
+		redirectLoggedOut,
 		siteSelection,
 		checkoutController.checkout,
 		makeLayout,
@@ -114,6 +107,7 @@ export default function() {
 
 	page(
 		'/checkout/:site/with-gsuite/:domain/:receiptId?',
+		redirectLoggedOut,
 		siteSelection,
 		checkoutController.gsuiteNudge,
 		makeLayout,


### PR DESCRIPTION
When logged-out, a blank screen is displayed on the all checkout pages but `/checkout/:domain/:product?`.
This trouble is caused by #22993 which fixed a bug filed in #22857 (see #23785 for the general problem).
For example, a Jetpack renewal email was affected by this bug (see p9jf6J-rI-p2).

This PR fixes an empty page displayed to logged-out users when they try
to access any `/checkout` pages.

Before | After
------ | -----
<img width="624" alt="screenshot" src="https://user-images.githubusercontent.com/594356/37777252-5b4af16e-2de7-11e8-9026-d2a505157c32.png"> | <img width="623" alt="screenshot" src="https://user-images.githubusercontent.com/594356/37777367-a463252e-2de7-11e8-866c-18432fc3ee28.png">

## How to Test

1. Visit a URL for subscription renewal like `/checkout/$PLAN_SLUG/renew/$PURCHASE_ID/$SITE_DOMAIN` while logged-out.
2. You should be redirected to the login page.
3. When you are successfully signed in, you should be redirected to the checkout page.

cc @dzver @mattwiebe 