### PR TITLE
Lint: Add an eslint formatter that outputs a github style list

### DIFF
--- a/bin/github-eslint-formatter.js
+++ b/bin/github-eslint-formatter.js
@@ -1,0 +1,12 @@
+/** @format */
+
+const path = require( 'path' );
+
+module.exports = function( results ) {
+	results.filter( result => result.errorCount + result.warningCount ).forEach( result => {
+		const relativePath = path.relative( path.resolve( __dirname, '..' ), result.filePath );
+		console.log(
+			`- [ ] ${ relativePath } (${ result.errorCount } err, ${ result.warningCount } warn)`
+		);
+	} );
+};


### PR DESCRIPTION
This formatter comes in handy when trying to make github lists from eslint results, like for https://github.com/Automattic/wp-calypso/issues/24504

To run eslint using this formater:

`npx eslint -f bin/github-eslint-formatter.js --ext js,jsx client/blocks`