### PR TITLE
Post Editor: save post status updates to Redux

### DIFF
--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -77,13 +77,6 @@ class EditorVisibility extends React.Component {
 		return 'public';
 	};
 
-	updatePostStatus = () => {
-		const defaultVisibility = 'draft' === this.props.status ? 'draft' : 'publish';
-		const postEdits = { status: defaultVisibility };
-
-		postActions.edit( postEdits );
-	};
-
 	recordStats = newVisibility => {
 		if ( this.getVisibility() !== newVisibility ) {
 			recordStat( 'visibility-set-' + newVisibility );
@@ -95,37 +88,35 @@ class EditorVisibility extends React.Component {
 		}
 	};
 
-	updateVisibility = newVisibility => {
-		const { siteId, postId } = this.props;
-		let reduxPostEdits;
+	updateVisibility( newVisibility ) {
+		const { siteId, postId, status } = this.props;
+
+		// This is necessary for cases when the post is changed from private
+		// to another visibility since private has its own post status.
+		const newStatus = status === 'draft' ? 'draft' : 'publish';
+
+		const postEdits = { status: newStatus };
 
 		switch ( newVisibility ) {
 			case 'public':
-				reduxPostEdits = { password: '' };
+				postEdits.password = '';
 				break;
 
 			case 'password':
-				reduxPostEdits = {
-					password: this.props.savedPassword || ' ',
-					// Password protected posts cannot be sticky
-					sticky: false,
-				};
+				postEdits.password = this.props.savedPassword || ' ';
+				// Password protected posts cannot be sticky
+				postEdits.sticky = false;
 				this.setState( { passwordIsValid: true } );
 				break;
 		}
 
+		// Make sure that status edits are applied both to Flux and Redux stores
+		postActions.edit( { status: newStatus } );
+		this.props.editPost( siteId, postId, postEdits );
 		this.recordStats( newVisibility );
+	}
 
-		// This is necessary for cases when the post is changed from private to another visibility
-		// since private has its own post status.
-		this.updatePostStatus();
-
-		if ( reduxPostEdits ) {
-			this.props.editPost( siteId, postId, reduxPostEdits );
-		}
-	};
-
-	setPostToPrivate = () => {
+	setPostToPrivate() {
 		const { siteId, postId } = this.props;
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		postActions.edit( {
@@ -134,12 +125,13 @@ class EditorVisibility extends React.Component {
 
 		// Private posts cannot be sticky
 		this.props.editPost( siteId, postId, {
+			status: 'private',
 			password: '',
 			sticky: false,
 		} );
 
 		this.recordStats( 'private' );
-	};
+	}
 
 	onPrivatePublish = () => {
 		this.setPostToPrivate();

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -51,6 +51,7 @@ import {
 	isAuthorEqual,
 	isDateEqual,
 	isDiscussionEqual,
+	isStatusEqual,
 	isTermsEqual,
 	mergePostEdits,
 	normalizePostForState,
@@ -440,6 +441,8 @@ export function edits( state = {}, action ) {
 							case 'metadata':
 								// omit from unappliedPostEdits, metadata edits will be merged
 								return true;
+							case 'status':
+								return isStatusEqual( value, post[ key ] );
 							case 'terms':
 								return isTermsEqual( value, post[ key ] );
 						}

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -1353,6 +1353,48 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		test( 'should remove status edits after they are saved', () => {
+			const emptyEditsState = {
+				2916284: {
+					841: {},
+				},
+			};
+
+			const editsStateWithStatus = status =>
+				deepFreeze( {
+					2916284: {
+						841: {
+							status,
+						},
+					},
+				} );
+
+			const receivePostActionWithStatus = status => ( {
+				type: POSTS_RECEIVE,
+				posts: [
+					{
+						ID: 841,
+						site_ID: 2916284,
+						type: 'post',
+						status,
+					},
+				],
+			} );
+
+			expect(
+				edits( editsStateWithStatus( 'publish' ), receivePostActionWithStatus( 'future' ) )
+			).to.eql( emptyEditsState );
+			expect(
+				edits( editsStateWithStatus( 'publish' ), receivePostActionWithStatus( 'publish' ) )
+			).to.eql( emptyEditsState );
+			expect(
+				edits( editsStateWithStatus( 'future' ), receivePostActionWithStatus( 'publish' ) )
+			).to.eql( emptyEditsState );
+			expect(
+				edits( editsStateWithStatus( 'draft' ), receivePostActionWithStatus( 'draft' ) )
+			).to.eql( emptyEditsState );
+		} );
+
 		test( "should ignore reset edits action when discarded site doesn't exist", () => {
 			const original = deepFreeze( {} );
 			const state = edits( original, {

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -11,6 +11,7 @@ import {
 	isPlainObject,
 	filter,
 	flow,
+	includes,
 	map,
 	mapValues,
 	mergeWith,
@@ -383,6 +384,24 @@ export function isAuthorEqual( localAuthorEdit, savedAuthor ) {
 
 export function isDateEqual( localDateEdit, savedDate ) {
 	return moment( localDateEdit ).isSame( savedDate );
+}
+
+export function isStatusEqual( localStatusEdit, savedStatus ) {
+	// When receiving a request to change the `status` attribute, the server
+	// treats `publish` and `future` as synonyms. It's really the post's `date`
+	// that determines the resulting status, not the requested value.
+	// Therefore, the `status` edit is considered saved and removed from the
+	// local edits even if the value returned by server is different.
+	if ( includes( [ 'publish', 'future' ], localStatusEdit ) ) {
+		return includes( [ 'publish', 'future' ], savedStatus );
+	}
+
+	// All other statuses (draft, private, pending) are 1:1. The only possible
+	// exception is requesting `publish` and not having rights to publish new
+	// posts. Then the server sets a `pending` status. But we check for this case
+	// in the UI and request `pending` instead of `publish` if the user doesn't
+	// have the rights.
+	return localStatusEdit === savedStatus;
 }
 
 function isUnappliedMetadataEdit( edit, savedMetadata ) {


### PR DESCRIPTION
When setting the `status` field of a post, this PR will start storing the new value also in Redux `edits` in addition to the `post-edit-store` Flux store. When the value is in both stores, it doesn't matter where we read it from -- it's always in sync. This will help a lot with further refactorings. The `date` field is already handled the same way.

There are two commits:

**Post Editor: save post status updates to Redux when changing post visibility**
When the `EditorVisibility` component updates the post status, make sure that the `status` attribute edits are stored both to Flux (as they always were) and to Redux (not stored until now). That ensures that in further refactorings it doesn't matter which store we read `status` from: it's always in sync. That makes a lot of things easier.

The `updatePostStatus` method was used only at one place, so we inline it into `updateVisibility`.

**Post Edits Reducer: remove saved status edits from local edits**
When receiving a request to change the `status` attribute, the server treats `publish` and `future` as synonyms. It's really the post's `date` that determines the resulting status, not the requested value. Therefore, the `status` edit is considered saved and removed from the local edits even if the value returned by server is different.

All other statuses (draft, private, pending) are 1:1. The only possible exception is requesting `publish` and not having rights to publish new posts. Then the server sets a `pending` status. But we check for this case in the UI and request `pending` instead of `publish` if the user doesn't
have the rights.

**How to test:**
Try to set various statuses on a post:
- publish a draft
- schedule a post to future date
- set a post private
- set a post to password protected
- toggle the "pending review" flag
- revert a published post to draft

Verify that all these tasks are performed as expected and the post is not "dirty" after finished. I.e., no edits in `state.posts.edits`, no active "Save" button, no warning when leaving the editor.