### PR TITLE
server/pages: Add rel=noopener to issues link

### DIFF
--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -91,8 +91,9 @@ class Desktop extends React.Component {
 							<a
 								className="bug-report"
 								href={ feedbackURL }
-								title="Report an issue"
+								rel="noopener"
 								target="_blank"
+								title="Report an issue"
 							>
 								<Gridicon icon="bug" size={ 18 } />
 							</a>

--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -11,10 +11,11 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import { jsonStringifyForHtml } from '../../server/sanitize';
+import ExternalLink from 'components/external-link';
 import Head from '../components/head';
 import getStylesheet from './utils/stylesheet';
 import WordPressLogo from 'components/wordpress-logo';
+import { jsonStringifyForHtml } from '../../server/sanitize';
 
 class Desktop extends React.Component {
 	render() {
@@ -88,15 +89,14 @@ class Desktop extends React.Component {
 								</span>
 							) }
 							<span className={ `environment is-${ badge } is-env` }>{ badge }</span>
-							<a
+							<ExternalLink
 								className="bug-report"
 								href={ feedbackURL }
-								rel="noopener"
 								target="_blank"
 								title="Report an issue"
 							>
 								<Gridicon icon="bug" size={ 18 } />
-							</a>
+							</ExternalLink>
 						</div>
 					) }
 

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -12,10 +12,11 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import { jsonStringifyForHtml } from '../../server/sanitize';
+import ExternalLink from 'components/external-link';
 import Head from '../components/head';
 import getStylesheet from './utils/stylesheet';
 import WordPressLogo from 'components/wordpress-logo';
+import { jsonStringifyForHtml } from '../../server/sanitize';
 
 class Document extends React.Component {
 	render() {
@@ -141,14 +142,14 @@ class Document extends React.Component {
 								</span>
 							) }
 							<span className={ `environment is-${ badge } is-env` }>{ badge }</span>
-							<a
+							<ExternalLink
 								className="bug-report"
 								href={ feedbackURL }
-								title="Report an issue"
 								target="_blank"
+								title="Report an issue"
 							>
 								<Gridicon icon="bug" size={ 18 } />
-							</a>
+							</ExternalLink>
 						</div>
 					) }
 


### PR DESCRIPTION
Lighthouse complains about this when run on https://wpcalypso.wordpress.com/themes:

![image](https://user-images.githubusercontent.com/96308/39673597-a77329c8-513f-11e8-92cb-a5b4f913ad4d.png)
