### PR TITLE
User mentions: prevent cursor jump to new line after Enter used, and add Tab support

### DIFF
--- a/client/blocks/user-mentions/add.jsx
+++ b/client/blocks/user-mentions/add.jsx
@@ -11,7 +11,7 @@ import { escapeRegExp, findIndex, get, head, includes, throttle, pick } from 'lo
  */
 import UserMentionSuggestionList from './suggestion-list';
 
-const keys = { enter: 13, esc: 27, spaceBar: 32, upArrow: 38, downArrow: 40 };
+const keys = { tab: 9, enter: 13, esc: 27, spaceBar: 32, upArrow: 38, downArrow: 40 };
 
 /**
  * addUserMentions is a higher-order component that adds user mention support to whatever input it wraps.
@@ -83,7 +83,8 @@ export default WrappedComponent =>
 		handleKeyDown = event => {
 			const selectedIndex = this.getSelectedSuggestionIndex();
 
-			if ( includes( [ keys.enter ], event.keyCode ) && this.state.showPopover ) {
+			// Cancel Enter and Tab default actions so we can define our own in keyUp
+			if ( includes( [ keys.enter, keys.tab ], event.keyCode ) && this.state.showPopover ) {
 				event.preventDefault();
 				return false;
 			}
@@ -119,7 +120,7 @@ export default WrappedComponent =>
 				return this.hidePopover();
 			}
 
-			if ( includes( [ keys.enter ], event.keyCode ) ) {
+			if ( includes( [ keys.enter, keys.tab ], event.keyCode ) ) {
 				if ( ! this.state.showPopover || this.matchingSuggestions.length === 0 ) {
 					return;
 				}

--- a/client/blocks/user-mentions/add.jsx
+++ b/client/blocks/user-mentions/add.jsx
@@ -83,6 +83,11 @@ export default WrappedComponent =>
 		handleKeyDown = event => {
 			const selectedIndex = this.getSelectedSuggestionIndex();
 
+			if ( includes( [ keys.enter ], event.keyCode ) && this.state.showPopover ) {
+				event.preventDefault();
+				return false;
+			}
+
 			if ( ! includes( [ keys.upArrow, keys.downArrow ], event.keyCode ) || -1 === selectedIndex ) {
 				return;
 			}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/24522, whereby the cursor briefly jumped to a new line after choosing a suggestion with Enter.

Also adds support for Tab completion, which fixes #24524.

TIL: you can't cancel events from a keyUp handler, but you can from keyDown or keyPress.

### To test

Load http://calypso.localhost:3000/devdocs/blocks/user-mentions, choose a suggestion using the Enter key and make sure this doesn't happen:

![39343869-455a7c04-4a33-11e8-8f8d-27a640f84e69](https://user-images.githubusercontent.com/17325/39685741-b03698e0-5218-11e8-97d4-218c978c77df.gif)
