### PR TITLE
Lint: fix client/blocks/reader-*

### DIFF
--- a/client/blocks/reader-combined-card/placeholders/post.jsx
+++ b/client/blocks/reader-combined-card/placeholders/post.jsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 const ReaderCombinedCardPostPlaceholder = () => {
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<li className="reader-combined-card__post is-placeholder">
 			<div className="reader-combined-card__featured-image-wrapper" />
@@ -20,6 +21,7 @@ const ReaderCombinedCardPostPlaceholder = () => {
 			</div>
 		</li>
 	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };
 
 export default ReaderCombinedCardPostPlaceholder;

--- a/client/blocks/reader-full-post/placeholders/content.jsx
+++ b/client/blocks/reader-full-post/placeholders/content.jsx
@@ -7,12 +7,14 @@
 import React from 'react';
 
 const ReaderFullPostContentPlaceholder = () => {
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div className="reader-full-post__story-content is-placeholder">
 			<p className="reader-full-post__story-content-placeholder-text" />
 			<p className="reader-full-post__story-content-placeholder-text" />
 		</div>
 	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };
 
 export default ReaderFullPostContentPlaceholder;

--- a/client/blocks/reader-full-post/placeholders/header.jsx
+++ b/client/blocks/reader-full-post/placeholders/header.jsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 const ReaderFullPostHeaderPlaceholder = () => {
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div className="reader-full-post__header is-placeholder">
 			<h1 className="reader-full-post__header-title is-placeholder">Post loading…</h1>
@@ -15,6 +16,7 @@ const ReaderFullPostHeaderPlaceholder = () => {
 			</div>
 		</div>
 	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };
 
 export default ReaderFullPostHeaderPlaceholder;

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -50,7 +50,7 @@ const ReaderPostActions = props => {
 
 	const listClassnames = classnames( 'reader-post-actions', className );
 
-	/* eslint-disable react/jsx-no-target-blank */
+	/* eslint-disable react/jsx-no-target-blank, wpcalypso/jsx-classname-namespace */
 	return (
 		<ul className={ listClassnames }>
 			{ showVisit && (
@@ -120,7 +120,7 @@ const ReaderPostActions = props => {
 			) }
 		</ul>
 	);
-	/* eslint-enable react/jsx-no-target-blank */
+	/* eslint-enable react/jsx-no-target-blank, wpcalypso/jsx-classname-namespace */
 };
 
 ReaderPostActions.propTypes = {

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -154,6 +154,7 @@ class ReaderPostCard extends React.Component {
 			);
 		}
 
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		const readerPostActions = (
 			<ReaderPostActions
 				post={ discoverPost || post }
@@ -169,6 +170,7 @@ class ReaderPostCard extends React.Component {
 				iconSize={ 18 }
 			/>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 
 		// Set up post byline
 		let postByline;


### PR DESCRIPTION
Part of the grand effort to fix all the eslint errors (#24504).

This PR covers `client/blocks/reader-*`. I'm using this to find them:

`npx eslint client/blocks/reader-* --ext js,jsx | grep -v indentation`

Todo
- [x] classnames
- [ ] refs
- [ ] a11y