### PR TITLE
Community Translator: move up the button so that it is not overlapped by the new Inline Help Button

### DIFF
--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -1,7 +1,7 @@
 .community-translator {
 	position: fixed;
-		bottom: 50px;
-		right: 16px;
+	bottom: 66px;
+	right: 24px;
 	border-radius: 27px;
 	background: $blue-wordpress;
 	cursor: pointer;


### PR DESCRIPTION
As reported in #23884, the Community Translator Button is overlapped by the new Inline Help Button.

This PR is a quick fix to move up the Community Translator Button so that it's not overlapped anymore.

Before:
<img width="64" alt="screen shot 2018-05-07 at 4 38 09 pm" src="https://user-images.githubusercontent.com/681110/39693559-00c6697c-5217-11e8-8320-68f62666c627.png">

After:
<img width="65" alt="screen shot 2018-05-07 at 4 37 43 pm" src="https://user-images.githubusercontent.com/681110/39693565-0504211e-5217-11e8-95ee-e88b950028b2.png">
