### PR TITLE
Update/inline help update forum flow

### DIFF
--- a/client/blocks/inline-help/constants.js
+++ b/client/blocks/inline-help/constants.js
@@ -8,3 +8,4 @@ export const RESULT_TOUR = 'tour';
 export const RESULT_VIDEO = 'video';
 export const VIEW_CONTACT = 'contact';
 export const VIEW_RICH_RESULT = 'richresult';
+export const VIEW_FORUM = 'forums';

--- a/client/blocks/inline-help/inline-help-forum-view.jsx
+++ b/client/blocks/inline-help/inline-help-forum-view.jsx
@@ -1,0 +1,42 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { identity } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import Button from 'components/button';
+import { preventWidows } from 'lib/formatting';
+
+const FORUM_LINK = '//en.forums.wordpress.com';
+
+const InlineHelpForumView = ( { translate = identity } ) => (
+	<div className="inline-help__forum-view">
+		<h2 className="inline-help__view-heading">
+			{ preventWidows( translate( 'Find Answers In Our Public Forums' ) ) }
+		</h2>
+		<p>
+			{ preventWidows(
+				translate(
+					'Post a new question in our {{strong}}public forums{{/strong}}, ' +
+						'where it may be answered by helpful community members, ' +
+						'by following the link below.',
+					{
+						components: {
+							strong: <strong />,
+						},
+					}
+				)
+			) }
+		</p>
+		<Button href={ FORUM_LINK } target="_blank" rel="noopener noreferrer" primary>
+			{ translate( 'Support Forums' ) }
+		</Button>
+	</div>
+);
+
+export default localize( InlineHelpForumView );

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -13,7 +13,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal Dependencies
  */
-import { VIEW_CONTACT, VIEW_RICH_RESULT } from './constants';
+import { VIEW_CONTACT, VIEW_FORUM, VIEW_RICH_RESULT } from './constants';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { selectResult, resetInlineHelpContactForm } from 'state/inline-help/actions';
 import Button from 'components/button';
@@ -21,9 +21,13 @@ import Popover from 'components/popover';
 import InlineHelpSearchResults from './inline-help-search-results';
 import InlineHelpSearchCard from './inline-help-search-card';
 import InlineHelpRichResult from './inline-help-rich-result';
+import InlineHelpForumView from './inline-help-forum-view';
 import HelpContact from 'me/help/help-contact';
 import { getSearchQuery, getInlineHelpCurrentlySelectedResult } from 'state/inline-help/selectors';
 import { getHelpSelectedSite } from 'state/help/selectors';
+import getInlineHelpSupportVariation, {
+	SUPPORT_FORUM,
+} from 'state/selectors/get-inline-help-support-variation';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
@@ -68,7 +72,8 @@ class InlineHelpPopover extends Component {
 	};
 
 	openContactView = () => {
-		this.openSecondaryView( VIEW_CONTACT );
+		const showForumGuide = this.props.supportVariation === SUPPORT_FORUM;
+		this.openSecondaryView( showForumGuide ? VIEW_FORUM : VIEW_CONTACT );
 	};
 
 	renderSecondaryView = () => {
@@ -82,6 +87,7 @@ class InlineHelpPopover extends Component {
 					{
 						contact: <HelpContact compact selectedSite={ this.props.selectedSite } />,
 						richresult: <InlineHelpRichResult result={ this.props.selectedResult } />,
+						forums: <InlineHelpForumView />,
 					}[ this.state.activeSecondaryView ]
 				}
 			</div>
@@ -154,6 +160,7 @@ export default connect(
 		searchQuery: getSearchQuery( state ),
 		selectedSite: getHelpSelectedSite( state ),
 		selectedResult: getInlineHelpCurrentlySelectedResult( state ),
+		supportVariation: getInlineHelpSupportVariation( state ),
 	} ),
 	{
 		recordTracksEvent,

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -205,6 +205,13 @@
 	}
 }
 
+.inline-help__view-heading {
+	display: block;
+	font-size: 14px;
+	font-weight: 600;
+	margin-bottom: 5px;
+}
+
 .inline-help__richresult {
 	text-align: left;
 
@@ -237,6 +244,10 @@
 		width: 100%;
 		height: 100%;
 	}
+}
+
+.inline-help__forum-view {
+	text-align: left;
 }
 
 .inline-help__contact {

--- a/client/state/selectors/get-inline-help-support-variation.js
+++ b/client/state/selectors/get-inline-help-support-variation.js
@@ -4,7 +4,7 @@
  */
 import config from 'config';
 import { getCurrentUserLocale } from 'state/current-user/selectors';
-import { isDirectlyFailed } from 'state/selectors';
+import { isDirectlyReady } from 'state/selectors';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 import isHappychatUserEligible from 'state/happychat/selectors/is-happychat-user-eligible';
 import { isTicketSupportEligible } from 'state/help/ticket/selectors';
@@ -31,7 +31,7 @@ export default function getSupportVariation( state ) {
 		return SUPPORT_TICKET;
 	}
 
-	if ( getCurrentUserLocale( state ) === 'en' && ! isDirectlyFailed( state ) ) {
+	if ( getCurrentUserLocale( state ) === 'en' && isDirectlyReady( state ) ) {
 		return SUPPORT_DIRECTLY;
 	}
 


### PR DESCRIPTION
#### Note
This PR is a take-2 of #24683 - with the slight difference of an updated selector that the view depends on.
We'll now check explicitly for the readiness of directly instead of implying readiness by the absence of a failure. There are in fact two other states directly can be in (unintialized and initializing), and either of these states were implying readiness.
This was causing a false positive - telling inline-help to take the route of showing the directly flow while it was uninitialized. Then once the contact-us button was pressed it would start initializing directly. Directly would then 'fail' for customers outside of the % that see directly.

### Summary

This PR aims to add a simple flow for cases in which only the public forums can be offered as a means of support.
I've taken the approach of breaking out in to a new component so as to not thicken the already overloaded `help-contact` & `help-contact-form` components.

<img width="332" alt="screen shot 2018-05-04 at 12 40 05" src="https://user-images.githubusercontent.com/4335450/39626062-5d9ad43e-4f98-11e8-9b09-1aedc78275ac.png">


### To Test

- Either use the test plan of #24583 to achieve the forum support variation, or force `selectors/get-inline-help-support-variation` to return 'SUPPORT_FORUM'
- Open inline-help by clicking the blue ? button in the bottom right
- Click 'Contact Us'
- You should see a view that explains the forums and gives an external link to the forums as in the screen shot above.