### PR TITLE
DevDocs: remove the unexpected whitespace from the first line of <code> blocks

### DIFF
--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -471,7 +471,7 @@ $devdocs-max-width: 720px;
 		border-radius: 3px;
 		color: $blue-dark;
 		font-size: 15px;
-		padding: 2px 6px;
+		padding: 2px 0;
 		max-width: 100px;
 	}
 


### PR DESCRIPTION
When reading DevDocs: UI Components, I noticed that there is always an unexpected "whitespace" at the beginning of the first line of sample codes, which turns out to be the horizontal padding of `<code>` blocks. This PR removes those paddings.

Before:
<img width="754" alt="before" src="https://user-images.githubusercontent.com/681110/39703703-91890d2e-523b-11e8-9d82-7d39fcf55f3c.png">

After:
<img width="761" alt="after" src="https://user-images.githubusercontent.com/681110/39703705-94cadf94-523b-11e8-9cf7-c7e2593c0e5d.png">
