### PR TITLE
Store Services: Add 'Cancel' button to add credit card modal, and remove header

### DIFF
--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -37,6 +37,7 @@ class CreditCardForm extends Component {
 		successCallback: PropTypes.func.isRequired,
 		showUsedForExistingPurchasesInfo: PropTypes.bool,
 		autoFocus: PropTypes.bool,
+		heading: PropTypes.string,
 		onCancel: PropTypes.func,
 	};
 
@@ -233,10 +234,11 @@ class CreditCardForm extends Component {
 	}
 
 	render() {
-		const { translate, autoFocus, onCancel } = this.props;
+		const { translate, autoFocus, heading, onCancel } = this.props;
 		return (
 			<form onSubmit={ this.onSubmit } ref={ this.storeForm }>
 				<Card className="credit-card-form__content">
+					{ heading && <div className="credit-card-form__heading">{ heading }</div> }
 					<CreditCardFormFields
 						card={ this.getCardDetails() }
 						countriesList={ countriesList }

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -37,6 +37,7 @@ class CreditCardForm extends Component {
 		successCallback: PropTypes.func.isRequired,
 		showUsedForExistingPurchasesInfo: PropTypes.bool,
 		autoFocus: PropTypes.bool,
+		onCancel: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -232,7 +233,7 @@ class CreditCardForm extends Component {
 	}
 
 	render() {
-		const { translate, autoFocus } = this.props;
+		const { translate, autoFocus, onCancel } = this.props;
 		return (
 			<form onSubmit={ this.onSubmit } ref={ this.storeForm }>
 				<Card className="credit-card-form__content">
@@ -277,6 +278,11 @@ class CreditCardForm extends Component {
 				</Card>
 				<CompactCard className="credit-card-form__footer">
 					<em>{ translate( 'All fields required' ) }</em>
+					{ onCancel && (
+						<FormButton type="button" isPrimary={ false } onClick={ onCancel }>
+							{ translate( 'Cancel' ) }
+						</FormButton>
+					) }
 					<FormButton disabled={ this.state.formSubmitting } type="submit">
 						{ this.state.formSubmitting
 							? translate( 'Saving Card…', {

--- a/client/blocks/credit-card-form/style.scss
+++ b/client/blocks/credit-card-form/style.scss
@@ -57,3 +57,8 @@
 		}
 	}
 }
+
+.credit-card-form__heading {
+	font-size: 18px;
+	padding: 0 0 16px 0;
+}

--- a/client/blocks/credit-card-form/style.scss
+++ b/client/blocks/credit-card-form/style.scss
@@ -41,7 +41,7 @@
 		color: $gray-text-min;
 	}
 
-	button {
+	button:first-of-type {
 		margin-left: auto;
 	}
 

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/add-credit-card-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/add-credit-card-modal.js
@@ -5,14 +5,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { localize } from 'i18n-calypso';
 import { curry } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Dialog from 'components/dialog';
-import HeaderCake from 'components/header-cake';
 import { closeAddCardDialog } from 'woocommerce/woocommerce-services/state/label-settings/actions';
 import { getLabelSettingsForm } from 'woocommerce/woocommerce-services/state/label-settings/selectors';
 import CreditCardForm from 'blocks/credit-card-form';
@@ -38,7 +36,7 @@ class AddCardDialog extends Component {
 	}
 
 	render() {
-		const { siteId, isVisible, translate } = this.props;
+		const { siteId, isVisible } = this.props;
 
 		const onClose = () => this.props.closeAddCardDialog( siteId );
 
@@ -48,13 +46,13 @@ class AddCardDialog extends Component {
 				isVisible={ isVisible }
 				onClose={ onClose }
 			>
-				<HeaderCake onClick={ onClose }>{ translate( 'Add Credit Card' ) }</HeaderCake>
 				<CreditCardForm
 					createCardToken={ this.createCardToken }
 					recordFormSubmitEvent={ this.recordFormSubmitEvent }
 					saveStoredCard={ this.props.addStoredCard }
 					successCallback={ onClose }
 					showUsedForExistingPurchasesInfo={ true }
+					onCancel={ onClose }
 				/>
 			</Dialog>
 		);
@@ -72,4 +70,4 @@ const mapDispatchToProps = ( dispatch ) => {
 	return bindActionCreators( { closeAddCardDialog, addStoredCard }, dispatch );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps )( localize( AddCardDialog ) );
+export default connect( mapStateToProps, mapDispatchToProps )( AddCardDialog );

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/add-credit-card-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/add-credit-card-modal.js
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { localize } from 'i18n-calypso';
 import { curry } from 'lodash';
 
 /**
@@ -36,7 +37,7 @@ class AddCardDialog extends Component {
 	}
 
 	render() {
-		const { siteId, isVisible } = this.props;
+		const { siteId, isVisible, translate } = this.props;
 
 		const onClose = () => this.props.closeAddCardDialog( siteId );
 
@@ -52,6 +53,7 @@ class AddCardDialog extends Component {
 					saveStoredCard={ this.props.addStoredCard }
 					successCallback={ onClose }
 					showUsedForExistingPurchasesInfo={ true }
+					heading={ translate( 'Add credit card' ) }
 					onCancel={ onClose }
 				/>
 			</Dialog>
@@ -70,4 +72,4 @@ const mapDispatchToProps = ( dispatch ) => {
 	return bindActionCreators( { closeAddCardDialog, addStoredCard }, dispatch );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps )( AddCardDialog );
+export default connect( mapStateToProps, mapDispatchToProps )( localize( AddCardDialog ) );

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/style.scss
@@ -103,8 +103,4 @@
 &.dialog.card.add-credit-card-modal .dialog__content {
 	max-width: 720px;
 	padding: 0;
-	
-	.header-cake {
-		margin-bottom: 0;
-	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/24459

Removes "Back"  button in the Add Credit Card modal's header, and replaces it with a "Cancel" button in the footer:

<img width="747" alt="add-credit-card-form" src="https://user-images.githubusercontent.com/1867547/39719959-cb9e4dea-5208-11e8-80f2-65a87a66a019.png">

`<HeaderCake>` couldn't be rendered without a "← Back" button, without modifying that component. I chose to omit it and lose the title, which I think is OK — now the `<CreditCardForm>` block is rendered alone in the modal — but if not, what is a good alternative?