### PR TITLE
Blocks: update copy of the Return to Jetpack Dashboard feature card and adjust its placement.

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -124,7 +124,12 @@ export class ProductPurchaseFeaturesList extends Component {
 	}
 
 	getJetpackFreeFeatures() {
-		const { isAutomatedTransfer, isPlaceholder, selectedSite } = this.props;
+		const {
+			isAutomatedTransfer,
+			isPlaceholder,
+			recordReturnToDashboardClick,
+			selectedSite,
+		} = this.props;
 		return (
 			<Fragment>
 				<HappinessSupportCard
@@ -133,17 +138,22 @@ export class ProductPurchaseFeaturesList extends Component {
 					isPlaceholder={ isPlaceholder }
 				/>
 				<JetpackWordPressCom selectedSite={ selectedSite } />
+				<MobileApps />
 				<JetpackReturnToDashboard
-					onClick={ this.props.recordReturnToDashboardClick }
+					onClick={ recordReturnToDashboardClick }
 					selectedSite={ selectedSite }
 				/>
-				<MobileApps />
 			</Fragment>
 		);
 	}
 
 	getJetpackPremiumFeatures() {
-		const { isAutomatedTransfer, isPlaceholder, selectedSite } = this.props;
+		const {
+			isAutomatedTransfer,
+			isPlaceholder,
+			recordReturnToDashboardClick,
+			selectedSite,
+		} = this.props;
 		return (
 			<Fragment>
 				<HappinessSupportCard
@@ -156,15 +166,23 @@ export class ProductPurchaseFeaturesList extends Component {
 				<JetpackAntiSpam selectedSite={ selectedSite } />
 				<JetpackPublicize selectedSite={ selectedSite } />
 				<JetpackVideo selectedSite={ selectedSite } />
-				<JetpackReturnToDashboard selectedSite={ selectedSite } />
 				<MobileApps />
 				<SellOnlinePaypal isJetpack />
+				<JetpackReturnToDashboard
+					onClick={ recordReturnToDashboardClick }
+					selectedSite={ selectedSite }
+				/>
 			</Fragment>
 		);
 	}
 
 	getJetpackPersonalFeatures() {
-		const { isAutomatedTransfer, isPlaceholder, selectedSite } = this.props;
+		const {
+			isAutomatedTransfer,
+			isPlaceholder,
+			recordReturnToDashboardClick,
+			selectedSite,
+		} = this.props;
 
 		return (
 			<Fragment>
@@ -175,14 +193,22 @@ export class ProductPurchaseFeaturesList extends Component {
 				<JetpackWordPressCom selectedSite={ selectedSite } />
 				<JetpackBackupSecurity />
 				<JetpackAntiSpam selectedSite={ selectedSite } />
-				<JetpackReturnToDashboard selectedSite={ selectedSite } />
 				<MobileApps />
+				<JetpackReturnToDashboard
+					onClick={ recordReturnToDashboardClick }
+					selectedSite={ selectedSite }
+				/>
 			</Fragment>
 		);
 	}
 
 	getJetpackBusinessFeatures() {
-		const { isAutomatedTransfer, isPlaceholder, selectedSite } = this.props;
+		const {
+			isAutomatedTransfer,
+			isPlaceholder,
+			selectedSite,
+			recordReturnToDashboardClick,
+		} = this.props;
 		return (
 			<Fragment>
 				<HappinessSupportCard
@@ -204,9 +230,12 @@ export class ProductPurchaseFeaturesList extends Component {
 				<JetpackPublicize selectedSite={ selectedSite } />
 				<JetpackBackupSecurity />
 				<JetpackAntiSpam selectedSite={ selectedSite } />
-				<JetpackReturnToDashboard selectedSite={ selectedSite } />
 				<MobileApps />
 				<SellOnlinePaypal isJetpack />
+				<JetpackReturnToDashboard
+					onClick={ recordReturnToDashboardClick }
+					selectedSite={ selectedSite }
+				/>
 			</Fragment>
 		);
 	}

--- a/client/blocks/product-purchase-features-list/jetpack-return-to-dashboard.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-return-to-dashboard.jsx
@@ -24,11 +24,11 @@ export default localize( ( { selectedSite, translate, onClick = noop } ) => {
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon={ <img alt="" src="/calypso/images/illustrations/jetpack-dashboard.svg" /> }
-				title={ translate( 'Return to your Jetpack dashboard' ) }
+				title={ translate( 'Return to your Jetpack Dashboard' ) }
 				description={ translate(
-					'Access your Jetpack Dashboard from your self-hosted WordPress site’s wp-admin.'
+					'Go back to your self-hosted WordPress site’s wp-admin Jetpack Dashboard.'
 				) }
-				buttonText={ translate( 'Go back to %(site)s', { args: { site: selectedSite.name } } ) }
+				buttonText={ translate( 'Jetpack Dashboard' ) }
 				href={ adminURL }
 				onClick={ onClick }
 			/>

--- a/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
+++ b/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
@@ -27,7 +27,7 @@ export default localize( ( { isJetpack, translate } ) => {
 				}
 				icon={ <img alt="" src="/calypso/images/illustrations/jetpack-payments.svg" /> }
 				target="_blank"
-				title={ translate( 'Sell online with PayPal.' ) }
+				title={ translate( 'Sell online with PayPal' ) }
 			/>
 		</div>
 	);


### PR DESCRIPTION
Previously the copy in the CTA button of the `Return to your Jetpack Dashboard ` could be too long to fit in one line. We were breaking it to fit on the card, but it was problematic due to the bottom possibly spreading over multiple lines and stretching the height of the corresponding row.
This commit changes the copy in the button, and the card overall.

Extra change included: remove '.' from PayPal feature card's title.

## To test:

- go to `plans/my-plan/:site` on local Calypso build or calypso.live
- verify that the card is present for all .com and Jetpack plans
- verify that the '.' is absent from `Sell online with Paypal` header any paid .com plans or JP premium or Professional.
