### PR TITLE
Update My Plan view illustrations margins and mobile layout

### DIFF
--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -77,7 +77,6 @@
 
 	@include breakpoint( "<660px" ) {
 		display: block;
-		margin: 0 auto;
 	}
 }
 
@@ -85,7 +84,6 @@
 	background: $gray-darken-20;
 	border-radius: 50%;
 	color: $white;
-	margin: 0 auto 10px;
 	padding: 16px;
 	width: 100%;
 	flex-shrink: 0;

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -84,6 +84,7 @@
 	background: $gray-darken-20;
 	border-radius: 50%;
 	color: $white;
+	margin-bottom: 10px;
 	padding: 16px;
 	width: 100%;
 	flex-shrink: 0;


### PR DESCRIPTION
This PR updates the margins of the My Plan feature cards so that they're more centered in the white space. This also updates the mobile layouts so they're left-aligned and not a mix of center/left-aligned.

**Before/after:**

<img width="848" alt="screen shot 2018-05-07 at 6 00 40 pm" src="https://user-images.githubusercontent.com/204742/39730734-94b9eace-5220-11e8-8cee-c7fe0dc42a8f.png">

<img width="846" alt="screen shot 2018-05-07 at 5 59 30 pm" src="https://user-images.githubusercontent.com/204742/39730701-6ae5e400-5220-11e8-991f-180311463922.png">

## To test:
* go to `plans/my-plan/:site` across all plan levels on Jetpack and WordPress.com (except Free) sites on local Calypso build or calypso.live
* verify that the before/after margins on both desktop and mobile and the left-aligned layout on mobile are as shown above.