### PR TITLE
NUX: create notice JSX element in render()

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -62,7 +62,6 @@ class DomainProductPrice extends React.Component {
 
 	renderIncludedInPremium() {
 		const { translate } = this.props;
-
 		const shouldShowStrikethrough = abtest( 'signupDomainStrikethruPrice' ) === 'enabled';
 
 		return (
@@ -74,7 +73,11 @@ class DomainProductPrice extends React.Component {
 						} ) }
 					</span>
 				) }
-				<span className={ shouldShowStrikethrough && 'domain-product-price__included-in-plan' }>
+				<span
+					className={ classnames( {
+						'domain-product-price__included-in-plan': shouldShowStrikethrough,
+					} ) }
+				>
 					{ translate( 'Included in paid plans' ) }
 				</span>
 			</div>

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -475,6 +475,7 @@ class RegisterDomainStep extends React.Component {
 
 		const nextState = {
 			error: null,
+			errorData: null,
 			exactMatchDomain: null,
 			lastDomainSearched: null,
 			loadingResults,
@@ -565,6 +566,7 @@ class RegisterDomainStep extends React.Component {
 		this.setState(
 			{
 				error: null,
+				errorData: null,
 				exactMatchDomain: null,
 				lastQuery: searchQuery,
 				lastDomainSearched: null,
@@ -616,7 +618,11 @@ class RegisterDomainStep extends React.Component {
 						lastDomainIsTransferrable: isDomainTransferrable,
 					} );
 					if ( isDomainAvailable ) {
-						this.setState( { showNotice: false, error: null } );
+						this.setState( {
+							showNotice: false,
+							error: null,
+							errorData: null,
+						} );
 					} else {
 						this.showValidationErrorMessage( domain, status, {
 							site: get( result, 'other_site_domain', null ),
@@ -1075,11 +1081,6 @@ class RegisterDomainStep extends React.Component {
 		const { TRANSFERRABLE } = domainAvailability;
 		if ( TRANSFERRABLE === error && this.state.lastDomainIsTransferrable ) {
 			return;
-		}
-
-		let site = get( errorData, 'site', null );
-		if ( ! site ) {
-			site = get( this.props, 'selectedSite.slug', null );
 		}
 		this.setState( { showNotice: true, error, errorData } );
 	}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -198,6 +198,8 @@ class RegisterDomainStep extends React.Component {
 		return {
 			availableTlds: [],
 			clickedExampleSuggestion: false,
+			error: null,
+			errorData: null,
 			filters: this.getInitialFiltersState(),
 			lastFilters: this.getInitialFiltersState(),
 			lastQuery: suggestion,
@@ -206,7 +208,7 @@ class RegisterDomainStep extends React.Component {
 			lastDomainIsTransferrable: false,
 			loadingResults,
 			loadingSubdomainResults: this.props.includeWordPressDotCom && loadingResults,
-			notice: null,
+			showNotice: false,
 			pageNumber: 1,
 			searchResults: null,
 			subdomainSearchResults: null,
@@ -331,7 +333,10 @@ class RegisterDomainStep extends React.Component {
 
 	render() {
 		const queryObject = getQueryObject( this.props );
-
+		const { errorData, error, lastDomainSearched, showNotice } = this.state;
+		const { message, severity } = showNotice
+			? getAvailabilityNotice( lastDomainSearched, error, errorData )
+			: {};
 		return (
 			<div className="register-domain-step">
 				<StickyPanel className="register-domain-step__search">
@@ -354,12 +359,8 @@ class RegisterDomainStep extends React.Component {
 						{ this.renderSearchFilters() }
 					</CompactCard>
 				</StickyPanel>
-				{ this.state.notice && (
-					<Notice
-						text={ this.state.notice }
-						status={ `is-${ this.state.noticeSeverity }` }
-						showDismiss={ false }
-					/>
+				{ message && (
+					<Notice text={ message } status={ `is-${ severity }` } showDismiss={ false } />
 				) }
 				{ this.renderContent() }
 				{ this.renderFilterResetNotice() }
@@ -473,11 +474,12 @@ class RegisterDomainStep extends React.Component {
 		const loadingResults = Boolean( getFixedDomainSearch( lastQuery ) );
 
 		const nextState = {
+			error: null,
 			exactMatchDomain: null,
 			lastDomainSearched: null,
 			loadingResults,
 			loadingSubdomainResults: loadingResults,
-			notice: null,
+			showNotice: false,
 			...stateOverride,
 		};
 		debug( 'Repeating a search with the following input for setState', nextState );
@@ -562,12 +564,13 @@ class RegisterDomainStep extends React.Component {
 
 		this.setState(
 			{
+				error: null,
 				exactMatchDomain: null,
 				lastQuery: searchQuery,
 				lastDomainSearched: null,
 				loadingResults,
 				loadingSubdomainResults: loadingResults,
-				notice: null,
+				showNotice: false,
 				pageNumber: 1,
 				searchResults: null,
 				subdomainSearchResults: null,
@@ -613,7 +616,7 @@ class RegisterDomainStep extends React.Component {
 						lastDomainIsTransferrable: isDomainTransferrable,
 					} );
 					if ( isDomainAvailable ) {
-						this.setState( { notice: null } );
+						this.setState( { showNotice: false, error: null } );
 					} else {
 						this.showValidationErrorMessage( domain, status, {
 							site: get( result, 'other_site_domain', null ),
@@ -1078,9 +1081,7 @@ class RegisterDomainStep extends React.Component {
 		if ( ! site ) {
 			site = get( this.props, 'selectedSite.slug', null );
 		}
-
-		const { message, severity } = getAvailabilityNotice( domain, error, errorData );
-		this.setState( { notice: message, noticeSeverity: severity } );
+		this.setState( { showNotice: true, error, errorData } );
 	}
 }
 


### PR DESCRIPTION
## What this PR does

Builds on the discussion in PR #24681 to address issue #24626 

Passing a return value of `translate()` that includes JSX elements to `<Notice />` triggers the following error:

<img width="1482" alt="screen shot 2018-05-08 at 10 51 21 am" src="https://user-images.githubusercontent.com/6458278/39732826-cf08b2f4-52b2-11e8-97c3-48e91513975f.png">

This PR alters the way the error notice JSX – currently stored in `this.state.notice` – is rendered after a hard refresh by storing the primitive data values (domain, site, error) required to construct it, and using them to build the error notice JSX inside the render method.

Props to @akirk and @jsnajdr 

I've also taken the opportunity to fix `non-boolean attribute` warning in `<DomainProductPrice />`:

<img width="1003" alt="screen shot 2018-05-04 at 5 12 29 pm" src="https://user-images.githubusercontent.com/6458278/39733111-652ed636-52b4-11e8-9523-88f2fd274032.png">

## Testing
1. Fire up the branch and head to `/start` in an incognito tab (or logged-out state)
2. Continue to the next step and enter a domain name that is already registered and mapped with wordpress.com (e.g., illustratedshorts.com)
3. Refresh the page
4. Enter an unsupported domain, e.g., `test.xxx`

### Expectations

**At 2 and 3:** 
1. The page should render normally, maintain state and display the 'already connected' error:
<img width="527" alt="screen shot 2018-05-08 at 11 26 45 am" src="https://user-images.githubusercontent.com/6458278/39732817-c69cc20e-52b2-11e8-81d4-29806006248e.png">

2. No `Received `false` for a non-boolean attribute `className`.` should display

**At 4:** Only a warning should show:
<img width="586" alt="screen shot 2018-05-08 at 12 32 32 pm" src="https://user-images.githubusercontent.com/6458278/39734758-ee3b211c-52bb-11e8-9f32-842f337d9302.png">

