### PR TITLE
User mentions: when close to the window edge, shuffle the popover left so it is still visible

### DIFF
--- a/client/blocks/user-mentions/add.jsx
+++ b/client/blocks/user-mentions/add.jsx
@@ -167,15 +167,31 @@ export default WrappedComponent =>
 				caretPosition = node.selectionEnd - query.length;
 			}
 
+			// Get the line height in the textarea
+			let lineHeight;
+			const lineHeightAdjustment = 4;
+			const style = window.getComputedStyle( node );
+			const lineHeightValueWithPixels = style.getPropertyValue( 'line-height' );
+			if ( lineHeightValueWithPixels ) {
+				lineHeight = +lineHeightValueWithPixels.replace( 'px', '' ) + lineHeightAdjustment;
+			}
+
+			// Figure out where the popover should go, taking account of @ symbol position, scroll position and line height
 			const caretCoordinates = getCaretCoordinates( node, caretPosition );
 			const scrollLeft = window.pageXOffset || document.documentElement.scrollLeft;
 			const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
 			const position = {
 				left: nodeRect.left + caretCoordinates.left + scrollLeft,
-				top: nodeRect.top + caretCoordinates.top + scrollTop + 28,
+				top: nodeRect.top + caretCoordinates.top + scrollTop + lineHeight,
 			};
 
-			console.log( position ); // eslint-disable-line no-console
+			// If we're close to the window edge, shuffle the popover left so it doesn't vanish
+			const windowEdgeThreshold = 150;
+			const windowWidthDifference = window.innerWidth - position.left;
+
+			if ( windowWidthDifference < windowEdgeThreshold ) {
+				position.left = position.left - ( windowEdgeThreshold - windowWidthDifference );
+			}
 
 			return position;
 		}


### PR DESCRIPTION
Fixes #24520.

This PR adds logic to prevent the mentions popover disappearing off the side of the window. If the popover left position is within 150px of the viewport edge, we'll move the position left of the @ symbol so the suggestions can still be seen.

Before:

<img width="1150" alt="screen shot 2018-05-08 at 2 49 55 pm" src="https://user-images.githubusercontent.com/17325/39735302-1b6b46fe-52cf-11e8-8806-f415eea65e93.png">

After:

<img width="1149" alt="screen shot 2018-05-08 at 2 48 17 pm" src="https://user-images.githubusercontent.com/17325/39735267-f71d54a4-52ce-11e8-8e6a-85fe2e1316d8.png">

### To test

Using http://calypso.localhost:3000/devdocs/blocks/user-mentions, input text to take you to nearly the end of the line. Type "@b" and make sure you can see the suggestions list.