### PR TITLE
NUX: Checking truthiness of `domain` before using it in the block

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -75,6 +75,7 @@ class DomainSearchResults extends React.Component {
 		let availabilityElement, domainSuggestionElement, offer;
 
 		if (
+			domain &&
 			suggestions.length !== 0 &&
 			includes(
 				[ TRANSFERRABLE, MAPPABLE, MAPPED, TLD_NOT_SUPPORTED, UNKNOWN ],


### PR DESCRIPTION
## What is PR does

`getTld( domain )` throws an error between prop updates if `this.props.lastDomainSearched` is `null`. 

![may-08-2018 12-29-51](https://user-images.githubusercontent.com/6458278/39735224-fa6680e2-52bd-11e8-977d-29ac3336d014.gif)

The error breakpoint: https://github.com/Automattic/wp-calypso/blob/e930e16/client/lib/domains/index.js#L234

`getTld( domain )` is triggered when the [last domain searched for is an unsupported domain](https://github.com/Automattic/wp-calypso/blob/e930e16/client/components/domains/domain-search-results/index.jsx#L109).

This PR ensures that we only enter the if block, in which we rely upon domain, when domain is truthy.

## Testing
1. Fire up the branch and head to `/start` in an incognito tab (or logged-out state)
2. Continue to the next step and enter an unsupported domain, e.g., `test.xxx`
3. Select the text a type in another string

_Tip:_ If you're trying to reproduce the error on https://wordpress.com/start, you have to be faster than React's prop machine. Repeat steps 2-3 after ☕️.

### Expectations

**At 3:** The browser will not throw the above error since we avoid calling `getTld( domain )` 
