### PR TITLE
A/B test helper: fix console warning

### DIFF
--- a/client/lib/abtest/test-helper/Test.jsx
+++ b/client/lib/abtest/test-helper/Test.jsx
@@ -27,6 +27,7 @@ export default class extends React.Component {
 									className="test-helper__choice-indicator"
 									type="radio"
 									checked={ variation === currentVariation }
+									readOnly
 								/>
 								{ variation }
 							</a>


### PR DESCRIPTION
The following warning is being generated by the A/B test helper, and is shown in console sessions across Calypso:

<img width="1429" alt="screen shot 2018-05-08 at 5 23 53 pm" src="https://user-images.githubusercontent.com/17325/39739416-e06cae7e-52e4-11e8-975b-b838e9121541.png">

The click hander lives on the wrapping `li`, so the checkbox is essentially read-only in this case. I've added the `readOnly` prop to the checkbox to avoid the warning.

### To test

Load http://calypso.localhost:3000/. Ensure you can still select an A/B test variant:

<img width="464" alt="screen shot 2018-05-08 at 5 27 10 pm" src="https://user-images.githubusercontent.com/17325/39739455-1193b3f8-52e5-11e8-9331-df1bf66fce33.png">

Check that there are no errors in the console.
