### PR TITLE
Themes: persist locales in route params

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -79,6 +79,9 @@ export function loggedOut( context, next ) {
 		return next();
 	}
 
+	// Store previous path in order that we can return from a theme preview
+	context.store.dispatch( setBackPath( context.pathname ) );
+
 	const props = getProps( context );
 
 	context.primary = <LoggedOutComponent { ...props } />;
@@ -169,17 +172,16 @@ export function redirectToThemeDetails( { res, params: { site, theme, section } 
  */
 export function setUpLocale( context, next ) {
 	const language = getLanguage( context.params.lang );
-	if ( language && language.langSlug ) {
-		if ( context.isServerSide ) {
-			// Ensure the html lang/dir attribute values are set
-			// prioritize parentLangSlug for locale variants
-			// See: server/render/index.js
-			context.lang = language.parentLangSlug || language.langSlug;
-			if ( language.rtl ) {
-				context.isRTL = true;
-			}
-		} else {
+	if ( language ) {
+		if ( ! context.isServerSide ) {
 			setLocale( language.langSlug );
+		}
+		// Ensure the html lang/dir attribute values are set
+		// prioritize parentLangSlug for locale variants
+		// See: server/render/index.js
+		context.lang = language.parentLangSlug || language.langSlug;
+		if ( language.rtl ) {
+			context.isRTL = true;
 		}
 	}
 	next();

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -172,16 +172,17 @@ export function redirectToThemeDetails( { res, params: { site, theme, section } 
  */
 export function setUpLocale( context, next ) {
 	const language = getLanguage( context.params.lang );
-	if ( language ) {
-		if ( ! context.isServerSide ) {
+	if ( language && language.langSlug ) {
+		if ( context.isServerSide ) {
+			// Ensure the html lang/dir attribute values are set
+			// prioritize parentLangSlug for locale variants
+			// See: server/render/index.js
+			context.lang = language.parentLangSlug || language.langSlug;
+			if ( language.rtl ) {
+				context.isRTL = true;
+			}
+		} else {
 			setLocale( language.langSlug );
-		}
-		// Ensure the html lang/dir attribute values are set
-		// prioritize parentLangSlug for locale variants
-		// See: server/render/index.js
-		context.lang = language.parentLangSlug || language.langSlug;
-		if ( language.rtl ) {
-			context.isRTL = true;
 		}
 	}
 	next();

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -21,8 +21,8 @@ import { requestThemes, requestThemeFilters, setBackPath } from 'state/themes/ac
 import { getThemesForQuery } from 'state/themes/selectors';
 import { getAnalyticsData } from './helpers';
 import { getLanguage } from 'lib/i18n-utils';
-import getThemeFilters from 'state/selectors/get-theme-filters';
 import { setLocale } from 'state/ui/language/actions';
+import getThemeFilters from 'state/selectors/get-theme-filters';
 
 const debug = debugFactory( 'calypso:themes' );
 

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -27,10 +27,10 @@ export default function( router ) {
 
 		const showcaseRoutes = [
 			`/themes/${ langRouteParams }`,
-			`/themes/:tier(free|premium)?/${ langRouteParams }`,
-			`/themes/:tier(free|premium)?/filter/:filter/${ langRouteParams }`,
-			`/themes/:vertical?/:tier(free|premium)?/${ langRouteParams }`,
-			`/themes/:vertical?/:tier(free|premium)?/filter/:filter/${ langRouteParams }`,
+			`/themes/${ langRouteParams }/:tier(free|premium)?`,
+			`/themes/${ langRouteParams }/:tier(free|premium)?/filter/:filter`,
+			`/themes/${ langRouteParams }/:vertical?/:tier(free|premium)?/`,
+			`/themes/${ langRouteParams }/:vertical?/:tier(free|premium)?/filter/:filter`,
 		];
 		router(
 			showcaseRoutes,

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -27,10 +27,10 @@ export default function( router ) {
 
 		const showcaseRoutes = [
 			`/themes/${ langRouteParams }`,
-			'/themes/:tier(free|premium)?',
-			'/themes/:tier(free|premium)?/filter/:filter',
-			'/themes/:vertical?/:tier(free|premium)?',
-			'/themes/:vertical?/:tier(free|premium)?/filter/:filter',
+			`/themes/:tier(free|premium)?/${ langRouteParams }`,
+			`/themes/:tier(free|premium)?/filter/:filter/${ langRouteParams }`,
+			`/themes/:vertical?/:tier(free|premium)?/${ langRouteParams }`,
+			`/themes/:vertical?/:tier(free|premium)?/filter/:filter/${ langRouteParams }`,
 		];
 		router(
 			showcaseRoutes,

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -52,10 +52,10 @@ export default function( router ) {
 
 			const loggedOutRoutes = [
 				`/themes/${ langRouteParams }`,
-				`/themes/:tier(free|premium)?/${ langRouteParams }`,
-				`/themes/:tier(free|premium)?/filter/:filter/${ langRouteParams }`,
-				`/themes/:vertical?/:tier(free|premium)?/${ langRouteParams }`,
-				`/themes/:vertical?/:tier(free|premium)?/filter/:filter/${ langRouteParams }`,
+				`/themes/${ langRouteParams }/:tier(free|premium)?`,
+				`/themes/${ langRouteParams }/:tier(free|premium)?/filter/:filter`,
+				`/themes/${ langRouteParams }/:vertical?/:tier(free|premium)?`,
+				`/themes/${ langRouteParams }/:vertical?/:tier(free|premium)?/filter/:filter`,
 			];
 			router(
 				loggedOutRoutes,

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -52,10 +52,10 @@ export default function( router ) {
 
 			const loggedOutRoutes = [
 				`/themes/${ langRouteParams }`,
-				'/themes/:tier(free|premium)?',
-				'/themes/:tier(free|premium)?/filter/:filter',
-				'/themes/:vertical?/:tier(free|premium)?',
-				'/themes/:vertical?/:tier(free|premium)?/filter/:filter',
+				`/themes/:tier(free|premium)?/${ langRouteParams }`,
+				`/themes/:tier(free|premium)?/filter/:filter/${ langRouteParams }`,
+				`/themes/:vertical?/:tier(free|premium)?/${ langRouteParams }`,
+				`/themes/:vertical?/:tier(free|premium)?/filter/:filter/${ langRouteParams }`,
 			];
 			router(
 				loggedOutRoutes,

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -136,7 +136,7 @@ class ThemeShowcase extends React.Component {
 		let filterSection = filter ? `/filter/${ filter }` : '';
 		filterSection = filterSection.replace( /\s/g, '+' );
 
-		const url = `/themes${ verticalSection }${ tierSection }${ filterSection }${ siteIdSection }${ lang }`;
+		const url = `/themes${ lang }${ verticalSection }${ tierSection }${ filterSection }${ siteIdSection }`;
 		return buildUrl( url, searchString );
 	};
 

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -27,6 +27,7 @@ import { getSiteSlug } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import ThemePreview from './theme-preview';
 import config from 'config';
+import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 import getThemeFilterTerms from 'state/selectors/get-theme-filter-terms';
 import getThemeFilterToTermTable from 'state/selectors/get-theme-filter-to-term-table';
 import getThemeShowcaseDescription from 'state/selectors/get-theme-showcase-description';
@@ -119,7 +120,7 @@ class ThemeShowcase extends React.Component {
 	 * @returns {String} Theme showcase url
 	 */
 	constructUrl = sections => {
-		const { vertical, tier, filter, siteSlug, searchString, langSlug } = {
+		const { vertical, tier, filter, siteSlug, searchString, localeSlug, isLoggedIn } = {
 			...this.props,
 			...sections,
 		};
@@ -127,8 +128,11 @@ class ThemeShowcase extends React.Component {
 		const siteIdSection = siteSlug ? `/${ siteSlug }` : '';
 		const verticalSection = vertical ? `/${ vertical }` : '';
 		const tierSection = tier && tier !== 'all' ? `/${ tier }` : '';
-		const lang = langSlug ? `/${ langSlug }` : '';
-
+		// Logged-in users will have their preferred UI lang stored in user settings
+		const lang =
+			! isLoggedIn && localeSlug && localeSlug !== config( 'i18n_default_locale_slug' )
+				? `/${ localeSlug }`
+				: '';
 		let filterSection = filter ? `/filter/${ filter }` : '';
 		filterSection = filterSection.replace( /\s/g, '+' );
 
@@ -296,7 +300,7 @@ class ThemeShowcase extends React.Component {
 	}
 }
 
-const mapStateToProps = ( state, { siteId, filter, tier, vertical, langSlug } ) => ( {
+const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
 	currentThemeId: getActiveTheme( state, siteId ),
 	isLoggedIn: !! getCurrentUserId( state ),
 	siteSlug: getSiteSlug( state, siteId ),
@@ -305,7 +309,7 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical, langSlug } ) 
 	subjects: getThemeFilterTerms( state, 'subject' ) || {},
 	filterString: prependThemeFilterKeys( state, filter ),
 	filterToTermTable: getThemeFilterToTermTable( state ),
-	langSlug,
+	localeSlug: getCurrentLocaleSlug( state ),
 } );
 
 const mapDispatchToProps = {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -119,7 +119,7 @@ class ThemeShowcase extends React.Component {
 	 * @returns {String} Theme showcase url
 	 */
 	constructUrl = sections => {
-		const { vertical, tier, filter, siteSlug, searchString } = {
+		const { vertical, tier, filter, siteSlug, searchString, langSlug } = {
 			...this.props,
 			...sections,
 		};
@@ -127,11 +127,12 @@ class ThemeShowcase extends React.Component {
 		const siteIdSection = siteSlug ? `/${ siteSlug }` : '';
 		const verticalSection = vertical ? `/${ vertical }` : '';
 		const tierSection = tier && tier !== 'all' ? `/${ tier }` : '';
+		const lang = langSlug ? `/${ langSlug }` : '';
 
 		let filterSection = filter ? `/filter/${ filter }` : '';
 		filterSection = filterSection.replace( /\s/g, '+' );
 
-		const url = `/themes${ verticalSection }${ tierSection }${ filterSection }${ siteIdSection }`;
+		const url = `/themes${ verticalSection }${ tierSection }${ filterSection }${ siteIdSection }${ lang }`;
 		return buildUrl( url, searchString );
 	};
 
@@ -295,7 +296,7 @@ class ThemeShowcase extends React.Component {
 	}
 }
 
-const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
+const mapStateToProps = ( state, { siteId, filter, tier, vertical, langSlug } ) => ( {
 	currentThemeId: getActiveTheme( state, siteId ),
 	isLoggedIn: !! getCurrentUserId( state ),
 	siteSlug: getSiteSlug( state, siteId ),
@@ -304,6 +305,7 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
 	subjects: getThemeFilterTerms( state, 'subject' ) || {},
 	filterString: prependThemeFilterKeys( state, filter ),
 	filterToTermTable: getThemeFilterToTermTable( state ),
+	langSlug,
 } );
 
 const mapDispatchToProps = {

--- a/client/state/ui/language/actions.js
+++ b/client/state/ui/language/actions.js
@@ -21,6 +21,8 @@ import { LOCALE_SET } from 'state/action-types';
  */
 export const setLocale = ( localeSlug, localeVariant = null ) => {
 	switchLocale( localeSlug, localeVariant );
+	// eslint-disable-next-line
+	console.log( 'setLocale', localeSlug );
 	return {
 		type: LOCALE_SET,
 		localeSlug,


### PR DESCRIPTION
This PR builds on the work of #24561 by:

1. Appending locale slugs to the end of logged-out sub routes on `wordpress.com/themes`. When refreshing a page the locale slug will persist, for example, `/themes/zh-tw/business/premium/filter/one-column` and we'll switch to that locale.

<img width="704" alt="screen shot 2018-04-30 at 7 27 25 pm" src="https://user-images.githubusercontent.com/6458278/39421475-8fe5da36-4cac-11e8-8c85-f834883fd165.png">

2. Saving the back path in the store so that visits to individual theme pages can back link to the sub route (including locale, if one is present)

### A note on why I set the back path for /theme/theme-name
I initially thought of constraining setting the back path to situations in which a language slug existed in the route, after all, returning back to `/themes` (the default behaviour) strips the slug and a refresh will revert the page to English, which defeats the purpose of this PR. Then I realised that it's a bit of a pain to set some filters, only to lose them on clicking the back button regardless of one's language.  

## Testing
1. In an incognito (logged out) tab, visit http://calypso.localhost:3000/themes/`{langSlug}` where {langSlug} is your language slug of choice. (`it|de|ar|es|ru...`)
2. Choose from several of the filters: blog type, style, and tier. For example: http://calypso.localhost:3000/themes/fr/blog/free/filter/artistic
3. Refresh the page
4. Visit an individual theme page, for example http://calypso.localhost:3000/theme/ryu
5. Click **'All themes'**

### Expectations
**At 2:** the locale slug should persist on the route as a param appended to the filter params

**At 3:** the page should switch to the language as represented by the locale slug 

**At 5:** you should return to the previous route, for example: http://calypso.localhost:3000/themes/fr/blog/free/filter/artistic
