### PR TITLE
InlineHelp: Add Tracking for forum link

### DIFF
--- a/client/blocks/inline-help/inline-help-forum-view.jsx
+++ b/client/blocks/inline-help/inline-help-forum-view.jsx
@@ -11,8 +11,11 @@ import { identity } from 'lodash';
  */
 import Button from 'components/button';
 import { preventWidows } from 'lib/formatting';
+import analytics from 'lib/analytics';
 
 const FORUM_LINK = '//en.forums.wordpress.com';
+
+const trackForumOpen = () => analytics.tracks.recordEvent( 'calypso_inlinehelp_forums_open' );
 
 const InlineHelpForumView = ( { translate = identity } ) => (
 	<div className="inline-help__forum-view">
@@ -33,7 +36,13 @@ const InlineHelpForumView = ( { translate = identity } ) => (
 				)
 			) }
 		</p>
-		<Button href={ FORUM_LINK } target="_blank" rel="noopener noreferrer" primary>
+		<Button
+			href={ FORUM_LINK }
+			target="_blank"
+			rel="noopener noreferrer"
+			primary
+			onClick={ trackForumOpen }
+		>
 			{ translate( 'Go to the Support Forums' ) }
 		</Button>
 	</div>


### PR DESCRIPTION
Adds tracking for the link in the newly added Forum View of inline help (added: #24708)

### Testing

- Either use the test plan of #24583 to achieve the forum support variation, or force selectors/get-inline-help-support-variation to return 'SUPPORT_FORUM'
- Open inline and click 'contact us' & check that you see the forum view.
- Click the "Go To The Support Forums"
- Watch for a tracking request being made in your network panel
  - a tip: Filter your requests with the name of the event you're looking for so as to hide the noise:<img width="320" alt="screen shot 2018-05-08 at 13 35 03" src="https://user-images.githubusercontent.com/4335450/39757405-a973ad66-52c4-11e8-93e8-b896bd69604f.png">
