### PR TITLE
JPC Remote Install: Skip for sites with non-default login URL

### DIFF
--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -106,7 +106,7 @@ export class JetpackConnectMain extends Component {
 	}
 
 	componentDidUpdate() {
-		const { isMobileAppFlow } = this.props;
+		const { isMobileAppFlow, skipRemoteInstall } = this.props;
 
 		if (
 			this.getStatus() === NOT_CONNECTED_JETPACK &&
@@ -129,7 +129,11 @@ export class JetpackConnectMain extends Component {
 		}
 
 		if ( includes( [ NOT_JETPACK, NOT_ACTIVE_JETPACK ], this.getStatus() ) ) {
-			if ( config.isEnabled( 'jetpack/connect/remote-install' ) && ! isMobileAppFlow ) {
+			if (
+				config.isEnabled( 'jetpack/connect/remote-install' ) &&
+				! isMobileAppFlow &&
+				! skipRemoteInstall
+			) {
 				this.goToRemoteInstall( JPC_PATH_REMOTE_INSTALL );
 			} else {
 				this.goToInstallInstructions( '/jetpack/connect/instructions' );
@@ -376,6 +380,9 @@ const connectComponent = connect(
 		// so any change in value will not execute connect().
 		const mobileAppRedirect = retrieveMobileRedirect();
 		const isMobileAppFlow = !! mobileAppRedirect;
+		const jetpackConnectSite = getConnectingSite( state );
+		const siteData = jetpackConnectSite.data || {};
+		const skipRemoteInstall = siteData.skipRemoteInstall;
 
 		return {
 			// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
@@ -383,8 +390,9 @@ const connectComponent = connect(
 			isLoggedIn: !! getCurrentUserId( state ),
 			isMobileAppFlow,
 			isRequestingSites: isRequestingSites( state ),
-			jetpackConnectSite: getConnectingSite( state ),
+			jetpackConnectSite,
 			mobileAppRedirect,
+			skipRemoteInstall,
 		};
 	},
 	{


### PR DESCRIPTION
D12240-code modifies the site-info endpoint to add a check for whether the site is using the default /wp-login.php URL for logins. If that URL does not return a `200` status, the site-info endpoint returns `skipRemoteInstall: true` in the response.

This PR makes use of that new field to send users attempting to connect such a site straight to the manual install instructions, since we know that remote install will fail.

### Testing
* Use a plugin such as [WPS Hide Login](https://wordpress.org/plugins/wps-hide-login/) to change the login URL for a dotorg site that does not have Jetpack activated
* Go to https://calypso.live/jetpack/connect?branch=update/jpc-remote-install/pre-check
* Enter the dotorg site URL
* Expected: you should be redirected to the manual instructions for installing or activating Jetpack
* Try the same thing with a dotorg site with the default login URL: you should be prompted for your credentials to attempt remote install
