### PR TITLE
Framework: add debug capabilities to getHttpData and fix bug

### DIFF
--- a/client/state/data-layer/http-data/index.js
+++ b/client/state/data-layer/http-data/index.js
@@ -175,7 +175,7 @@ export const requestHttpData = ( requestId, fetchAction, { fromApi, freshness = 
 			type: HTTP_DATA_REQUEST,
 			id: requestId,
 			fetch: 'function' === typeof fetchAction ? fetchAction() : fetchAction,
-			fromApi: 'function' === typeof fromApi ? fromApi() : a => a,
+			fromApi: 'function' === typeof fromApi ? fromApi : () => a => a,
 		};
 
 		dispatch ? dispatch( action ) : dispatchQueue.push( action );
@@ -183,3 +183,9 @@ export const requestHttpData = ( requestId, fetchAction, { fromApi, freshness = 
 
 	return data;
 };
+
+if ( 'object' === typeof window && window.app && window.app.isDebug ) {
+	window.getHttpData = getHttpData;
+	window.httpData = httpData;
+	window.requestHttpData = requestHttpData;
+}


### PR DESCRIPTION
This code is still dormant in production:

 - when `window.app.isDebug` set then expose `httpData` functions
 - pass `fromApi` through to final handler/leave lazy

No real testing. Testing is being done in the development of #24631 