### PR TITLE
Guided Tours: Fix steps positioning of Simple Payments Email Tour

### DIFF
--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -36,7 +36,7 @@ export const SimplePaymentsEmailTour = makeTour(
 			target="side-menu-page"
 			placement="beside"
 			arrow="left-top"
-			style={ { animationDelay: '2s' } }
+			style={ { animationDelay: '2s', marginTop: '-5px' } }
 			onTargetDisappear={ handleTargetDisappear }
 		>
 			{ ( { translate } ) => (
@@ -68,7 +68,7 @@ export const SimplePaymentsEmailTour = makeTour(
 			arrow="top-left"
 			target=".editor-html-toolbar__button-insert-content-dropdown, .mce-wpcom-insert-menu button"
 			placement="below"
-			style={ { marginLeft: '-10px', zIndex: 'auto' } }
+			style={ { marginLeft: '-7px', zIndex: 'auto' } }
 		>
 			{ ( { translate } ) => (
 				<Fragment>


### PR DESCRIPTION
Fix issue raised in https://github.com/Automattic/wp-calypso/pull/24680#issuecomment-387272198

Fine tune the Simple Payments Email Tour's steps positioning.

| Before | After |
| --- | --- |
| <img width="685" alt="screen shot 2018-05-08 at 17 45 48" src="https://user-images.githubusercontent.com/2070010/39770892-4abc92b4-52e8-11e8-9a22-9328e98a385b.png"> | <img width="683" alt="screen shot 2018-05-08 at 17 45 56" src="https://user-images.githubusercontent.com/2070010/39770898-4fe37dc0-52e8-11e8-8ce6-6ab8fc6e87e9.png"> |
| <img width="428" alt="screen shot 2018-05-08 at 17 46 14" src="https://user-images.githubusercontent.com/2070010/39770957-7dba3fc2-52e8-11e8-90f6-23a532b5993d.png"> | <img width="432" alt="screen shot 2018-05-08 at 17 46 07" src="https://user-images.githubusercontent.com/2070010/39770965-81c2028a-52e8-11e8-8c34-3e178f4344ae.png"> |

CC @jancavan @apeatling (did you have any other suggestions for this?)