### PR TITLE
Activity Log - Plugin update: use pluralization in i18n

### DIFF
--- a/client/my-sites/stats/activity-log-tasklist/index.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/index.jsx
@@ -305,9 +305,14 @@ class ActivityLogTasklist extends Component {
 				<div className="activity-log-tasklist__heading">
 					{ // Not using count method since we want a "one" string.
 					1 < numberOfPluginUpdates
-						? translate( 'You have %(updates)s updates available', {
-								args: { updates: numberOfPluginUpdates },
-							} )
+						? translate(
+								'You have %(updates)s update available',
+								'You have %(updates)s updates available',
+								{
+									count: numberOfPluginUpdates,
+									args: { updates: numberOfPluginUpdates },
+								}
+							)
 						: translate( 'You have one update available' ) }
 					<SplitButton
 						compact


### PR DESCRIPTION
Props @zinigor for the i18n knowledge:

> the first string with a singular update is used in Russian when you have the number 31, for instance

We won't use the pluralization for 1 because design specified a "one" word instead of a number. However, we're using it for all others to cover cases as the one pointed by Igor.