### PR TITLE
State: Jetpack Connect: Add partner ID and slug selectors

### DIFF
--- a/client/state/selectors/get-partner-id-from-query.js
+++ b/client/state/selectors/get-partner-id-from-query.js
@@ -1,0 +1,24 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get, toNumber, isInteger } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getInitialQueryArguments } from 'state/selectors';
+
+/**
+ * Returns the partner_id query param if present or null.
+ *
+ * @param {object}   state Global state tree
+ * @return {?number}       The partner ID as an integer or null
+ */
+export const getPartnerIdFromQuery = function( state ) {
+	const partnerId = toNumber( get( getInitialQueryArguments( state ), 'partner_id' ) );
+	return isInteger( partnerId ) ? partnerId : null;
+};
+
+export default getPartnerIdFromQuery;

--- a/client/state/selectors/get-partner-slug-from-query.js
+++ b/client/state/selectors/get-partner-slug-from-query.js
@@ -1,0 +1,54 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getPartnerIdFromQuery } from 'state/selectors';
+
+/**
+ * Returns the partner slug when partner_id is present is the query and the
+ * value maps to a known host.
+ *
+ * @param {object}   state Global state tree
+ * @return {?string}       The partner slug or null
+ */
+export const getPartnerSlugFromQuery = function( state ) {
+	switch ( getPartnerIdFromQuery( state ) ) {
+		case 51945:
+		case 51946:
+			return 'dreamhost';
+		case 49615:
+		case 49640:
+			return 'pressable';
+		case 57152:
+		case 57733:
+			return 'milesweb';
+		case 41986:
+		case 42000:
+			return 'bluehost';
+		case 51652: // Clients used for testing.
+			return 'dreamhost';
+		case 57039:
+			return 'a2hosting';
+		case 57304:
+		case 57306:
+			return 'exabytes';
+		case 57836:
+			return 'inmotion';
+		case 57916:
+		case 57917:
+			return 'quickclick';
+		case 57900:
+		case 57901:
+			return 'whogohost';
+		case 57264:
+			return 'wppronto';
+		case 57752:
+		case 57753:
+			return 'wpwebhost';
+		default:
+			return null;
+	}
+};
+
+export default getPartnerSlugFromQuery;

--- a/client/state/selectors/test/get-partner-id-from-query.js
+++ b/client/state/selectors/test/get-partner-id-from-query.js
@@ -1,0 +1,62 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getPartnerIdFromQuery } from 'state/selectors';
+
+describe( '#getPartnerIdFromQuery', () => {
+	test( 'should return null when no argument', () => {
+		expect( getPartnerIdFromQuery() ).toBeNull();
+	} );
+
+	test( 'should return null if no partner_id query present', () => {
+		const state = {
+			ui: {
+				route: {
+					query: {
+						initial: {
+							email_address: 'user@wordpress.com',
+						},
+					},
+				},
+			},
+		};
+		expect( getPartnerIdFromQuery( state ) ).toBeNull();
+	} );
+
+	test( 'should return null when partner_id present but not integer', () => {
+		const state = {
+			ui: {
+				route: {
+					query: {
+						initial: {
+							email_address: 'user@wordpress.com',
+							partner_id: 'meh',
+						},
+					},
+				},
+			},
+		};
+
+		expect( getPartnerIdFromQuery( state ) ).toBeNull();
+	} );
+
+	test( 'should return partner ID as integer when partner_id query present', () => {
+		const state = {
+			ui: {
+				route: {
+					query: {
+						initial: {
+							email_address: 'user@wordpress.com',
+							partner_id: '49640',
+						},
+					},
+				},
+			},
+		};
+
+		// toBe is a strict equality check here.
+		expect( getPartnerIdFromQuery( state ) ).toBe( 49640 );
+	} );
+} );

--- a/client/state/selectors/test/get-partner-slug-from-query.js
+++ b/client/state/selectors/test/get-partner-slug-from-query.js
@@ -1,0 +1,61 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getPartnerSlugFromQuery } from 'state/selectors';
+
+describe( '#getPartnerSlugFromQuery', () => {
+	test( 'should return null when no argument', () => {
+		expect( getPartnerSlugFromQuery() ).toBeNull();
+	} );
+
+	test( 'should return null if no partner_id query present', () => {
+		const state = {
+			ui: {
+				route: {
+					query: {
+						initial: {
+							email_address: 'user@wordpress.com',
+						},
+					},
+				},
+			},
+		};
+		expect( getPartnerSlugFromQuery( state ) ).toBeNull();
+	} );
+
+	test( 'should return null when partner_id present but not integer', () => {
+		const state = {
+			ui: {
+				route: {
+					query: {
+						initial: {
+							email_address: 'user@wordpress.com',
+							partner_id: 'meh',
+						},
+					},
+				},
+			},
+		};
+
+		expect( getPartnerSlugFromQuery( state ) ).toBeNull();
+	} );
+
+	test( 'should return pressable when partner_id is 49640', () => {
+		const state = {
+			ui: {
+				route: {
+					query: {
+						initial: {
+							email_address: 'user@wordpress.com',
+							partner_id: '49640',
+						},
+					},
+				},
+			},
+		};
+
+		expect( getPartnerSlugFromQuery( state ) ).toBe( 'pressable' );
+	} );
+} );


### PR DESCRIPTION
This selector will prove useful for getting the partner ID from the query so that we can cobrand the Jetpack connection flow for our hosting partners.

See #24605 for feedback for a prior approach and a suggestion to move forward with this path.

I manually tested that the query is in state by importing `getPartnerIdFromQuery` into the `blocks/login/index.jsx` component and testing by going to `http://calypso.localhost:3000/log-in/jetpack?&partner_id=49640`.

I'll follow this PR with another PR to add the cobranded Jetpack header logo block as suggested by @sirreal.