### PR TITLE
Guided Tours: Add a "quit on target click" to Quit

### DIFF
--- a/client/layout/guided-tours/config-elements/quit.js
+++ b/client/layout/guided-tours/config-elements/quit.js
@@ -19,8 +19,9 @@ export default class Quit extends Component {
 	static displayName = 'Quit';
 
 	static propTypes = {
+		click: PropTypes.bool,
 		primary: PropTypes.bool,
-		subtle: PropTypes.bool,
+		target: PropTypes.string,
 	};
 
 	static contextTypes = contextTypes;

--- a/client/layout/guided-tours/config-elements/quit.js
+++ b/client/layout/guided-tours/config-elements/quit.js
@@ -12,6 +12,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
+import { targetForSlug } from '../positioning';
 import contextTypes from '../context-types';
 
 export default class Quit extends Component {
@@ -26,6 +27,42 @@ export default class Quit extends Component {
 
 	constructor( props, context ) {
 		super( props, context );
+	}
+
+	componentDidMount() {
+		this.addTargetListener();
+	}
+
+	componentWillUnmount() {
+		this.removeTargetListener();
+	}
+
+	componentWillUpdate() {
+		this.removeTargetListener();
+	}
+
+	componentDidUpdate() {
+		this.addTargetListener();
+	}
+
+	addTargetListener() {
+		const { target = false, click } = this.props;
+		const targetNode = targetForSlug( target );
+
+		if ( click && targetNode && targetNode.addEventListener ) {
+			targetNode.addEventListener( 'click', this.onClick );
+			targetNode.addEventListener( 'touchstart', this.onClick );
+		}
+	}
+
+	removeTargetListener() {
+		const { target = false, click } = this.props;
+		const targetNode = targetForSlug( target );
+
+		if ( click && targetNode && targetNode.removeEventListener ) {
+			targetNode.removeEventListener( 'click', this.onClick );
+			targetNode.removeEventListener( 'touchstart', this.onClick );
+		}
 	}
 
 	onClick = event => {

--- a/client/layout/guided-tours/config-elements/quit.js
+++ b/client/layout/guided-tours/config-elements/quit.js
@@ -19,7 +19,6 @@ export default class Quit extends Component {
 	static displayName = 'Quit';
 
 	static propTypes = {
-		click: PropTypes.bool,
 		primary: PropTypes.bool,
 		target: PropTypes.string,
 	};
@@ -47,20 +46,20 @@ export default class Quit extends Component {
 	}
 
 	addTargetListener() {
-		const { target = false, click } = this.props;
+		const { target = false } = this.props;
 		const targetNode = targetForSlug( target );
 
-		if ( click && targetNode && targetNode.addEventListener ) {
+		if ( targetNode && targetNode.addEventListener ) {
 			targetNode.addEventListener( 'click', this.onClick );
 			targetNode.addEventListener( 'touchstart', this.onClick );
 		}
 	}
 
 	removeTargetListener() {
-		const { target = false, click } = this.props;
+		const { target = false } = this.props;
 		const targetNode = targetForSlug( target );
 
-		if ( click && targetNode && targetNode.removeEventListener ) {
+		if ( targetNode && targetNode.removeEventListener ) {
 			targetNode.removeEventListener( 'click', this.onClick );
 			targetNode.removeEventListener( 'touchstart', this.onClick );
 		}

--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -91,7 +91,6 @@ export const SimplePaymentsEmailTour = makeTour(
 					<ButtonRow>
 						<Quit
 							primary
-							click
 							target=".editor-html-toolbar__button-insert-content-dropdown, .mce-wpcom-insert-menu button"
 						>
 							{ translate( 'Got it, thanks!' ) }

--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -74,6 +74,7 @@ export const SimplePaymentsEmailTour = makeTour(
 			target=".editor-html-toolbar__button-insert-content-dropdown, .mce-wpcom-insert-menu button"
 			placement="below"
 			style={ { marginLeft: '-7px', zIndex: 'auto' } }
+			onTargetDisappear={ noop }
 		>
 			{ ( { translate } ) => (
 				<Fragment>
@@ -88,7 +89,13 @@ export const SimplePaymentsEmailTour = makeTour(
 						) }
 					</p>
 					<ButtonRow>
-						<Quit primary>{ translate( 'Got it, thanks!' ) }</Quit>
+						<Quit
+							primary
+							click
+							target=".editor-html-toolbar__button-insert-content-dropdown, .mce-wpcom-insert-menu button"
+						>
+							{ translate( 'Got it, thanks!' ) }
+						</Quit>
 					</ButtonRow>
 					<Link href="https://en.support.wordpress.com/simple-payments">
 						{ translate( 'Learn more about Simple Payments.' ) }


### PR DESCRIPTION
Currently, the only Guided Tour control supporting the "on target click" is `Continue`: by adding it in a `Step`, it's possible to trigger the `next()` function by clicking on the `Continue.props.target`.

Working on the Simple Payments Email Tour, we noticed that the last step could really use a "quit on target click", because the suggested action (click on "(+) Add") would open a dropdown menu which would cover the tour step:

<img width="437" alt="screen shot 2018-05-08 at 18 25 42" src="https://user-images.githubusercontent.com/2070010/39772463-3e7b7ef2-52ed-11e8-8f59-1fc7f5f979ea.png">

This PR simply copy the `Continue` "on target click" behaviour into the `Quit` control, minus the `when` and `click` checks, because not needed in this case.

To enable a "quit on target click", it's enough to add the `target` prop, as shown in the included example.

## Testing instructions

- Open Calypso forcing the Simple Payments Email Tour: `/stats/day/{site}?tour=simplePaymentsEmailTour`.
- Proceed to the second step by clicking on "Add (Page)".
- Let the editor load and, when the tour step appears, click on "(+) Add": the tour should be dismissed for good.
- Try other tours (e.g. `?tour=main`) and make sure they can be quit correctly.