### PR TITLE
State: Introduce connected applications reducer

### DIFF
--- a/client/state/connected-applications/reducer.js
+++ b/client/state/connected-applications/reducer.js
@@ -1,0 +1,29 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { reject } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	CONNECTED_APPLICATION_DELETE_SUCCESS,
+	CONNECTED_APPLICATIONS_RECEIVE,
+} from 'state/action-types';
+import schema from './schema';
+
+const reducer = ( state = [], action ) => {
+	switch ( action.type ) {
+		case CONNECTED_APPLICATION_DELETE_SUCCESS:
+			return reject( state, { ID: action.appId } );
+		case CONNECTED_APPLICATIONS_RECEIVE:
+			return action.apps;
+		default:
+			return state;
+	}
+};
+reducer.schema = schema;
+
+export default reducer;

--- a/client/state/connected-applications/schema.js
+++ b/client/state/connected-applications/schema.js
@@ -1,0 +1,45 @@
+export default {
+	type: 'array',
+	items: {
+		type: 'object',
+		properties: {
+			ID: { type: 'string' },
+			URL: { type: 'string' },
+			authorized: { type: 'string' },
+			description: { type: 'string' },
+			icon: { type: 'string' },
+			permissions: {
+				type: 'array',
+				items: {
+					type: 'object',
+					properties: {
+						description: { type: 'string' },
+						name: { type: 'string' },
+					},
+					required: [ 'description', 'name' ],
+					additionalProperties: false,
+				},
+			},
+			scope: { type: 'string' },
+			site: {
+				oneOf: [
+					{
+						type: 'boolean',
+					},
+					{
+						type: 'object',
+						properties: {
+							site_ID: { type: 'string' },
+							site_URL: { type: 'string' },
+							site_name: { type: 'string' },
+						},
+						required: [ 'site_ID', 'site_URL', 'site_name' ],
+						additionalProperties: false,
+					} ],
+			},
+			title: { type: 'string' },
+		},
+		required: [ 'ID' ],
+		additionalProperties: false,
+	},
+};

--- a/client/state/connected-applications/test/reducer.js
+++ b/client/state/connected-applications/test/reducer.js
@@ -1,0 +1,97 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import reducer from '../reducer';
+import {
+	CONNECTED_APPLICATION_DELETE_SUCCESS,
+	CONNECTED_APPLICATIONS_RECEIVE,
+} from 'state/action-types';
+
+describe( 'reducer', () => {
+	const app1 = {
+		ID: '12345678',
+		URL: 'http://wordpress.com',
+		authorized: '2018-01-01T00:00:00+00:00',
+		description: 'Example description of the application here',
+		icon: 'https://wordpress.com/calypso/images/wordpress/logo-stars.svg',
+		permissions: [
+			{
+				name: 'follow',
+				description: 'Follow and unfollow blogs.',
+			},
+			{
+				name: 'posts',
+				description: 'View and manage posts including reblogs and likes.',
+			},
+		],
+		scope: 'global',
+		site: {
+			site_ID: '87654321',
+			site_URL: 'http://wordpress.com',
+			site_name: 'WordPress',
+		},
+		title: 'WordPress',
+	};
+	const app2 = {
+		...app1,
+		ID: '23456789',
+	};
+
+	const apps = [ app1, app2 ];
+	const otherApps = [
+		{
+			...app1,
+			ID: '87654321',
+		},
+	];
+
+	test( 'should default to an empty array', () => {
+		const state = reducer( undefined, {} );
+		expect( state ).toEqual( [] );
+	} );
+
+	test( 'should set connected applications to empty array when user has no connected applications', () => {
+		const state = reducer( undefined, {
+			type: CONNECTED_APPLICATIONS_RECEIVE,
+			apps: [],
+		} );
+
+		expect( state ).toEqual( [] );
+	} );
+
+	test( 'should add connected applications to the initial state', () => {
+		const state = reducer( [], {
+			type: CONNECTED_APPLICATIONS_RECEIVE,
+			apps,
+		} );
+
+		expect( state ).toEqual( apps );
+	} );
+
+	test( 'should overwrite previous connected applications in state', () => {
+		const state = deepFreeze( apps );
+		const newState = reducer( state, {
+			type: CONNECTED_APPLICATIONS_RECEIVE,
+			apps: otherApps,
+		} );
+
+		expect( newState ).toEqual( otherApps );
+	} );
+
+	test( 'should delete connected applications by ID from state', () => {
+		const state = deepFreeze( apps );
+		const newState = reducer( state, {
+			type: CONNECTED_APPLICATION_DELETE_SUCCESS,
+			appId: app1.ID,
+		} );
+
+		expect( newState ).toEqual( [ app2 ] );
+	} );
+} );

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -33,6 +33,7 @@ import checklist from './checklist/reducer';
 import comments from './comments/reducer';
 import componentsUsageStats from './components-usage-stats/reducer';
 import concierge from './concierge/reducer';
+import connectedApplications from './connected-applications/reducer';
 import consoleDispatcher from './console-dispatch';
 import countries from './countries/reducer';
 import countryStates from './country-states/reducer';
@@ -122,6 +123,7 @@ const reducers = {
 	comments,
 	componentsUsageStats,
 	concierge,
+	connectedApplications,
 	countries,
 	countryStates,
 	currentUser,


### PR DESCRIPTION
This PR introduces a reducer for connected applications, which modifies the state when one of the following actions has been dispatched:

* Connected applications have been received.
* A connected application has been deleted.

Tests are included.

For context of how the reducer would be used, you can see the full connected applications reduxification PR: #24175.

To test:
* Checkout this branch.
* Clean your Redux state.
* Run this in your browser console: `dispatch( { type: 'CONNECTED_APPLICATIONS_REQUEST' } )`
* After the request is complete, run `state.connectedApplications` in your browser console and verify it contains your connected applications.
* Refresh Calypso.
* Run `state.connectedApplications` again and verify the connected applications are persisted, and there are no schema validation errors.
* Run `dispatch( { type: 'CONNECTED_APPLICATION_DELETE', appId: '12345678' } )` in your console, where `12345678` is the ID of the connected application.
* Run `state.connectedApplications` in your browser console and verify that the removed connected application is no longer in the state.
* Verify all tests pass:

```
npm run test-client client/state/connected-applications/test/reducer.js
```
