### PR TITLE
Post Editor: improve names of selectors that check if edited post is password protected

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -26,8 +26,8 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 import {
-	isEditedPostPrivate,
-	isPrivateEditedPostPasswordValid,
+	isEditedPostPasswordProtected,
+	isEditedPostPasswordProtectedWithValidPassword,
 	getEditedPost,
 } from 'state/posts/selectors';
 import { canCurrentUser } from 'state/selectors';
@@ -39,8 +39,7 @@ class EditorConfirmationSidebar extends Component {
 		onPublish: PropTypes.func,
 		post: PropTypes.object,
 		savedPost: PropTypes.object,
-		isPrivatePost: PropTypes.bool,
-		isPrivatePostPasswordValid: PropTypes.bool,
+		isPasswordProtectedWithInvalidPassword: PropTypes.bool,
 		setPostDate: PropTypes.func,
 		setStatus: PropTypes.func,
 		status: PropTypes.string,
@@ -77,7 +76,7 @@ class EditorConfirmationSidebar extends Component {
 			this.props.canUserPublishPosts
 		);
 		const buttonLabel = this.getPublishButtonLabel( publishButtonStatus );
-		const enabled = ! this.props.isPrivatePost || this.props.isPrivatePostPasswordValid;
+		const enabled = ! this.props.isPasswordProtectedWithInvalidPassword;
 
 		return (
 			<Button disabled={ ! enabled } onClick={ this.closeAndPublish }>
@@ -227,17 +226,17 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const postId = getEditorPostId( state );
 		const post = getEditedPost( state, siteId, postId );
-		const isPrivatePost = isEditedPostPrivate( state, siteId, postId );
-		const isPrivatePostPasswordValid = isPrivateEditedPostPasswordValid( state, siteId, postId );
 		const canUserPublishPosts = canCurrentUser( state, siteId, 'publish_posts' );
+		const isPasswordProtectedWithInvalidPassword =
+			isEditedPostPasswordProtected( state, siteId, postId ) &&
+			! isEditedPostPasswordProtectedWithValidPassword( state, siteId, postId );
 
 		return {
 			siteId,
 			postId,
 			post,
-			isPrivatePost,
-			isPrivatePostPasswordValid,
 			canUserPublishPosts,
+			isPasswordProtectedWithInvalidPassword,
 		};
 	},
 	{ editPost }

--- a/client/post-editor/editor-publish-button/index.jsx
+++ b/client/post-editor/editor-publish-button/index.jsx
@@ -17,8 +17,11 @@ import Button from 'components/button';
 import { localize } from 'i18n-calypso';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
-import { isEditedPostPrivate, isPrivateEditedPostPasswordValid } from 'state/posts/selectors';
 import { canCurrentUser } from 'state/selectors';
+import {
+	isEditedPostPasswordProtected,
+	isEditedPostPasswordProtectedWithValidPassword,
+} from 'state/posts/selectors';
 
 export const getPublishButtonStatus = ( post, savedPost, canUserPublishPosts ) => {
 	if (
@@ -56,8 +59,7 @@ export class EditorPublishButton extends Component {
 		isSaveBlocked: PropTypes.bool,
 		hasContent: PropTypes.bool,
 		needsVerification: PropTypes.bool,
-		privatePost: PropTypes.bool,
-		privatePostPasswordValid: PropTypes.bool,
+		isPasswordProtectedWithInvalidPassword: PropTypes.bool,
 		busy: PropTypes.bool,
 		isConfirmationSidebarEnabled: PropTypes.bool,
 	};
@@ -145,7 +147,7 @@ export class EditorPublishButton extends Component {
 			! this.props.isSaveBlocked &&
 			this.props.hasContent &&
 			! this.props.needsVerification &&
-			( ! this.props.privatePost || this.props.privatePostPasswordValid )
+			! this.props.isPasswordProtectedWithInvalidPassword
 		);
 	}
 
@@ -169,13 +171,13 @@ export class EditorPublishButton extends Component {
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const postId = getEditorPostId( state );
-	const privatePost = isEditedPostPrivate( state, siteId, postId );
-	const privatePostPasswordValid = isPrivateEditedPostPasswordValid( state, siteId, postId );
 	const canUserPublishPosts = canCurrentUser( state, siteId, 'publish_posts' );
+	const isPasswordProtectedWithInvalidPassword =
+		isEditedPostPasswordProtected( state, siteId, postId ) &&
+		! isEditedPostPasswordProtectedWithValidPassword( state, siteId, postId );
 
 	return {
-		privatePost,
-		privatePostPasswordValid,
 		canUserPublishPosts,
+		isPasswordProtectedWithInvalidPassword,
 	};
 } )( localize( EditorPublishButton ) );

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -365,27 +365,27 @@ export function getEditedPostValue( state, siteId, postId, field ) {
 }
 
 /**
- * Returns true if the edited post visibility is private.
+ * Returns true if the edited post is password protected.
  *
  * @param  {Object}  state  Global state tree
  * @param  {Number}  siteId Site ID
  * @param  {Number}  postId Post ID
- * @return {Boolean}        Whether edited post visibility is private
+ * @return {Boolean}        Result of the check
  */
-export function isEditedPostPrivate( state, siteId, postId ) {
+export function isEditedPostPasswordProtected( state, siteId, postId ) {
 	const password = getEditedPostValue( state, siteId, postId, 'password' );
 	return !! ( password && password.length > 0 );
 }
 
 /**
- * Returns true if a valid password is set for the edited post with private visibility.
+ * Returns true if the edited post is password protected and has a valid password set
  *
  * @param  {Object}  state  Global state tree
  * @param  {Number}  siteId Site ID
  * @param  {Number}  postId Post ID
- * @return {Boolean}        Whether password for the edited post with private visibility is valid
+ * @return {Boolean}        Result of the check
  */
-export function isPrivateEditedPostPasswordValid( state, siteId, postId ) {
+export function isEditedPostPasswordProtectedWithValidPassword( state, siteId, postId ) {
 	const password = getEditedPostValue( state, siteId, postId, 'password' );
 	return !! ( password && password.trim().length > 0 );
 }

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -24,8 +24,8 @@ import {
 	isPostsLastPageForQuery,
 	getPostsForQueryIgnoringPage,
 	isRequestingPostsForQueryIgnoringPage,
-	isEditedPostPrivate,
-	isPrivateEditedPostPasswordValid,
+	isEditedPostPasswordProtected,
+	isEditedPostPasswordProtectedWithValidPassword,
 	getEditedPost,
 	getPostEdits,
 	getEditedPostValue,
@@ -1544,9 +1544,9 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'isEditedPostPrivate()', () => {
+	describe( 'isEditedPostPasswordProtected()', () => {
 		test( 'should return false if the post does not exist', () => {
-			const privatePost = isEditedPostPrivate(
+			const protectedPost = isEditedPostPasswordProtected(
 				{
 					posts: {
 						items: {},
@@ -1558,7 +1558,7 @@ describe( 'selectors', () => {
 				841
 			);
 
-			expect( privatePost ).to.be.false;
+			expect( protectedPost ).to.be.false;
 		} );
 
 		test( 'should return false if post password is a zero length string', () => {
@@ -1569,7 +1569,7 @@ describe( 'selectors', () => {
 				title: 'Hello World',
 				password: 'secret',
 			};
-			const privatePost = isEditedPostPrivate(
+			const protectedPost = isEditedPostPasswordProtected(
 				{
 					posts: {
 						items: {
@@ -1593,7 +1593,7 @@ describe( 'selectors', () => {
 				841
 			);
 
-			expect( privatePost ).to.be.false;
+			expect( protectedPost ).to.be.false;
 		} );
 
 		test( 'should return true if post password is a non-zero length string', () => {
@@ -1604,7 +1604,7 @@ describe( 'selectors', () => {
 				title: 'Hello World',
 				password: '',
 			};
-			const privatePost = isEditedPostPrivate(
+			const protectedPost = isEditedPostPasswordProtected(
 				{
 					posts: {
 						items: {
@@ -1628,7 +1628,7 @@ describe( 'selectors', () => {
 				841
 			);
 
-			expect( privatePost ).to.be.true;
+			expect( protectedPost ).to.be.true;
 		} );
 
 		test( 'should return true if post password is whitespace only', () => {
@@ -1639,7 +1639,7 @@ describe( 'selectors', () => {
 				title: 'Hello World',
 				password: '',
 			};
-			const privatePost = isEditedPostPrivate(
+			const protectedPost = isEditedPostPasswordProtected(
 				{
 					posts: {
 						items: {
@@ -1663,13 +1663,13 @@ describe( 'selectors', () => {
 				841
 			);
 
-			expect( privatePost ).to.be.true;
+			expect( protectedPost ).to.be.true;
 		} );
 	} );
 
-	describe( 'isPrivateEditedPostPasswordValid()', () => {
+	describe( 'isEditedPostPasswordProtectedWithValidPassword()', () => {
 		test( 'should return false if the post does not exist', () => {
-			const isPasswordValid = isPrivateEditedPostPasswordValid(
+			const isPasswordValid = isEditedPostPasswordProtectedWithValidPassword(
 				{
 					posts: {
 						items: {},
@@ -1692,7 +1692,7 @@ describe( 'selectors', () => {
 				title: 'Hello World',
 				password: 'secret',
 			};
-			const isPasswordValid = isPrivateEditedPostPasswordValid(
+			const isPasswordValid = isEditedPostPasswordProtectedWithValidPassword(
 				{
 					posts: {
 						items: {
@@ -1727,7 +1727,7 @@ describe( 'selectors', () => {
 				title: 'Hello World',
 				password: '',
 			};
-			const isPasswordValid = isPrivateEditedPostPasswordValid(
+			const isPasswordValid = isEditedPostPasswordProtectedWithValidPassword(
 				{
 					posts: {
 						items: {
@@ -1762,7 +1762,7 @@ describe( 'selectors', () => {
 				title: 'Hello World',
 				password: '',
 			};
-			const isPasswordValid = isPrivateEditedPostPasswordValid(
+			const isPasswordValid = isEditedPostPasswordProtectedWithValidPassword(
 				{
 					posts: {
 						items: {


### PR DESCRIPTION
There are two selectors (added in #16403) that check if the edited post is password protected and if it has valid (non-empty) password set:
- `isEditedPostPrivate`
- `isPrivateEditedPostPasswordValid`

They are used to enable/disable the "Publish" button in the Post Editor UI.

Their names, however, are misleading. A "private" post (visible only to site admins and editors) is something quite different from a "password protected" post.

This PR changes the selector names to:
- `isEditedPostPasswordProtected`
- `isEditedPostPasswordProtectedWithValidPassword`

There will be soon a `isEditedPostPrivate` selector that checks for the real "private" status.

**How to test:**
Edit a post draft and set its status to "password protected". Don't set a valid password.

Verify that the password field is marked as invalid and that the "Publish" button is disabled:
<img width="310" alt="screen shot 2018-05-09 at 11 11 01" src="https://user-images.githubusercontent.com/664258/39806332-f4fd7d74-5379-11e8-90a6-0379276018e4.png">

Verify the same behavior in the editor confirmation sidebar:
<img width="276" alt="screen shot 2018-05-09 at 11 01 39" src="https://user-images.githubusercontent.com/664258/39806515-69c144f6-537a-11e8-814c-ac09fde3d633.png">

Verify also that the "Publish" button gets enabled as soon as you enter a valid password or when you switch the post status back to "Public".