### PR TITLE
Community translator: Interpolate anchor tag by components property.

### DIFF
--- a/client/components/community-translator/translated-success.jsx
+++ b/client/components/community-translator/translated-success.jsx
@@ -10,10 +10,14 @@ const TranslatedSuccess = ( { translationUrl, translate } ) => (
 		<p>{ translate( 'Thanks for contributing!' ) }</p>
 		{ translationUrl && (
 			<p>
-				{ translate( 'Your translation has been submitted. You can view it on ' ) }
-				<a href={ translationUrl } target="_blank" rel="noopener noreferrer">
-					translate.wordpress.com
-				</a>.
+				{ translate(
+					'Your translation has been submitted. You can view it on {{a}}translate.wordpress.com{{/a}}',
+					{
+						components: {
+							a: <a href={ translationUrl } target="_blank" rel="noopener noreferrer" />,
+						},
+					}
+				) }
 			</p>
 		) }
 	</div>


### PR DESCRIPTION
## Summary
This PR fixes a call of `translate()` to adhere our i18n best practices. An anchor tag in a translatable string should be interpolated by the components property, not as an individual anchor tag.

## Test Plan
1. Run calypso by `ENABLE_FEATURES=i18n/community-translator npm start`
1. Submit a random translation and the "submission succeeded" dialog should appear correctly.