### PR TITLE
Post Editor: remove action bar component from sidebar

### DIFF
--- a/client/post-editor/editor-action-bar/style.scss
+++ b/client/post-editor/editor-action-bar/style.scss
@@ -7,11 +7,6 @@
 	margin-bottom: 24px;
 	padding: 12px 16px;
 
-	// This seems totally broken on mobile, and just, like an abandoned idea for a UI.
-	@include breakpoint( "<660px" ) {
-		display: none;
-	}
-
 	@include breakpoint( "<660px" ) {
 		margin-bottom: 8px;
 	}
@@ -69,12 +64,6 @@
 
 .post-editor__content .editor-action-bar {
 	@include breakpoint( "<660px" ) {
-		display: none;
-	}
-}
-
-.editor-sidebar .editor-action-bar {
-	@include breakpoint( ">660px" ) {
 		display: none;
 	}
 }

--- a/client/post-editor/editor-sidebar/index.jsx
+++ b/client/post-editor/editor-sidebar/index.jsx
@@ -11,7 +11,6 @@ import PropTypes from 'prop-types';
 import EditorDrawer from 'post-editor/editor-drawer';
 import EditorSidebarHeader from './header';
 import SidebarFooter from 'layout/sidebar/footer';
-import EditorActionBar from 'post-editor/editor-action-bar';
 import EditorDeletePost from 'post-editor/editor-delete-post';
 
 export class EditorSidebar extends Component {
@@ -45,7 +44,6 @@ export class EditorSidebar extends Component {
 		return (
 			<div className="editor-sidebar">
 				<EditorSidebarHeader />
-				<EditorActionBar savedPost={ savedPost } />
 				<EditorDrawer
 					site={ site }
 					savedPost={ savedPost }


### PR DESCRIPTION
Removing `EditorActionBar` instance from `EditorSidebar`, as it's already always hidden by CSS `display:none` in both desktop and mobile views.

The only `EditorActionBar` instance remaining is in the content area, above the post title. This instance is shown on desktop, when the window is more than 660px wide. Here is how it looks:
<img width="681" alt="screen shot 2018-05-09 at 12 50 20" src="https://user-images.githubusercontent.com/664258/39811309-8eb171c4-5388-11e8-9d1e-e646f42c9faf.png">

Here is how it used to look in the sidebar when it was active:
<img width="495" alt="screen shot 2018-05-09 at 12 21 53" src="https://user-images.githubusercontent.com/664258/39811344-a488c6be-5388-11e8-84d9-a85c340f6da7.png">

It was disabled completely by @shaunandrews in #20326. One of consequences of the action bar being hidden is that there is no way to set the post author on a mobile view.

The editor masterbar and action bar have a rather turbulent history, where major changes happened in #11536, #20326 and likely other PRs, too. It's hard to figure out what is intentional and what is a bug. Pinging involved people who might know the context: @mtias @folletto @shaunandrews @timmyc @lamosty @lsinger 



