### PR TITLE
Post Editor: show the sticky button in action bar even if the flag is turned off

### DIFF
--- a/client/post-editor/editor-sticky/index.jsx
+++ b/client/post-editor/editor-sticky/index.jsx
@@ -64,8 +64,21 @@ class EditorSticky extends React.Component {
 		this.setState( { tooltip: false } );
 	};
 
+	stickyPostButtonRef = React.createRef();
+
 	render() {
-		const classes = classnames( 'editor-sticky', { 'is-sticky': this.props.sticky } );
+		const { sticky, translate } = this.props;
+		const classes = classnames( 'editor-sticky', { 'is-sticky': sticky } );
+		const tooltipLabel = sticky ? (
+			<span>{ translate( 'Marked as sticky' ) }</span>
+		) : (
+			<div>
+				{ translate( 'Mark as sticky' ) }
+				<span className="editor-sticky__explanation">
+					{ translate( 'Stick post to the front page' ) }
+				</span>
+			</div>
+		);
 
 		return (
 			<Button
@@ -74,20 +87,18 @@ class EditorSticky extends React.Component {
 				onClick={ this.toggleStickyStatus }
 				onMouseEnter={ this.enableTooltip }
 				onMouseLeave={ this.disableTooltip }
-				aria-label={ this.props.translate( 'Stick post to the front page' ) }
-				ref="stickyPostButton"
+				aria-label={ translate( 'Stick post to the front page' ) }
+				ref={ this.stickyPostButtonRef }
 			>
 				<Gridicon icon="bookmark" />
-				{ this.props.sticky && (
-					<Tooltip
-						className="editor-sticky__tooltip"
-						context={ this.refs && this.refs.stickyPostButton }
-						isVisible={ this.state.tooltip }
-						position="bottom left"
-					>
-						<span>{ this.props.translate( 'Marked as sticky' ) }</span>
-					</Tooltip>
-				) }
+				<Tooltip
+					className="editor-sticky__tooltip"
+					context={ this.stickyPostButtonRef.current }
+					isVisible={ this.state.tooltip }
+					position="bottom left"
+				>
+					{ tooltipLabel }
+				</Tooltip>
 			</Button>
 		);
 	}

--- a/client/post-editor/editor-sticky/style.scss
+++ b/client/post-editor/editor-sticky/style.scss
@@ -1,11 +1,12 @@
 .editor-sticky.button {
-	opacity: 0;
-	cursor: default;
 	transition: opacity 200ms;
+
+	&, &:hover, &:focus {
+		color: $gray-lighten-20;
+	}
+
 	&.is-sticky {
 		color: $orange-jazzy;
-		opacity: 1;
-		cursor: pointer;
 	}
 }
 


### PR DESCRIPTION
Makes the sticky button visible even if the post is not sticky. Before this patch, there was an invisible area that still reacted to clicks and could enable the sticky flag:

![screen capture on 2018-05-09 at 13-56-34](https://user-images.githubusercontent.com/664258/39814325-2242d990-5394-11e8-964b-042e36f0d6cf.gif)

After this patch, the clickable area is visible and has a tooltip:
![screen capture on 2018-05-09 at 14-16-54](https://user-images.githubusercontent.com/664258/39814373-4965cbcc-5394-11e8-9e0a-ffbc64301161.gif)

This PR is basically an undo of https://github.com/Automattic/wp-calypso/commit/11ea3f6835f53f6e89c6750a566a12874305c2d2 by @mtias. I'm not sure in what context that change was done a year ago. The editor UI changed a lot since then. The main reason why I'm proposing an undo is the invisible area that reacts to clicks.