### PR TITLE
State: Have Locally Persisted State Override Rehydrated Server State

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -91,7 +91,7 @@ const loadInitialState = initialState => {
 	}
 	const localforageState = deserialize( initialState );
 	const serverState = getInitialServerState();
-	const mergedState = Object.assign( {}, localforageState, serverState );
+	const mergedState = Object.assign( {}, serverState, localforageState );
 	return createReduxStore( mergedState );
 };
 


### PR DESCRIPTION
Instead of vice versa, as was previously the case. Motivated by https://github.com/Automattic/wp-calypso/pull/24335#issuecomment-384319588.

The rationale here is as follows:
* As of #23640, we're persisting Redux state for logged-out users. This is useful for cases where a logged-out user navigates away from WP.com (e.g. thru a redirect, as is the case with Jetpack Connect!) and comes back later. 
* Since the state we're persisting isn't associated with any WP.com user, we're never propagating it back to the server -- it's just data fetched from the server that we're locally caching, or UI settings we're persisting (as is the case with #24335).
* In case of SSR'ed (isomorphic) sections, we have to make a choice whether to give precedence to the rehydrated state we're given by the server, or the state that's been persisted on the client side from prior visits.

Use cases like https://github.com/Automattic/wp-calypso/pull/24335#issuecomment-384319588 (and comments below) seem to suggest the latter.

### Testing instructions

Verify that SSR'ed sections still work as before: Smoke-test the logged out theme showcase and by navigating around, then reloading.