### PR TITLE
Post Editor Action Bar: retrieve post and site info from Redux

### DIFF
--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -25,23 +25,22 @@ import { getEditedPost, getEditedPostValue } from 'state/posts/selectors';
 import PodcastIndicator from 'components/podcast-indicator';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import getPodcastingCategoryId from 'state/selectors/get-podcasting-category-id';
+import { isSingleUserSite } from 'state/sites/selectors';
 
 class EditorActionBar extends Component {
 	static propTypes = {
 		isNew: PropTypes.bool,
-		post: PropTypes.object,
 		savedPost: PropTypes.object,
-		site: PropTypes.object,
+		siteId: PropTypes.number,
+		multiUserSite: PropTypes.bool,
+		post: PropTypes.object,
 		type: PropTypes.string,
-		isPostPrivate: PropTypes.bool,
+		isPostPrivateOrPasswordProtected: PropTypes.bool,
 	};
 
-	constructor( props ) {
-		super( props );
-		this.state = {
-			viewLinkTooltip: false,
-		};
-	}
+	state = {
+		viewLinkTooltip: false,
+	};
 
 	showViewLinkTooltip = () => {
 		this.setState( { viewLinkTooltip: true } );
@@ -56,12 +55,15 @@ class EditorActionBar extends Component {
 	};
 
 	render() {
-		// We store privacy changes via Flux while we store password changes via Redux.
-		// This results in checking Flux for some items and Redux for others to correctly
-		// update based on post changes. Flux changes are passed down from parent components.
-		const multiUserSite = this.props.site && ! this.props.site.single_user_site;
-		const isPasswordProtected = utils.getVisibility( this.props.post ) === 'password';
-		const { isPostPrivate, siteId, isPodcastEpisode } = this.props;
+		const {
+			isPostPrivateOrPasswordProtected,
+			isPodcastEpisode,
+			multiUserSite,
+			siteId,
+			type,
+		} = this.props;
+
+		const showSticky = type === 'post' && ! isPostPrivateOrPasswordProtected;
 
 		return (
 			<div className="editor-action-bar">
@@ -76,10 +78,7 @@ class EditorActionBar extends Component {
 					) }
 				</div>
 				<div className="editor-action-bar__cell is-right">
-					{ this.props.post &&
-						this.props.type === 'post' &&
-						! isPasswordProtected &&
-						! isPostPrivate && <EditorSticky /> }
+					{ showSticky && <EditorSticky /> }
 					{ isPodcastEpisode && (
 						<PodcastIndicator
 							className="editor-action-bar__podcasting-indicator"
@@ -116,9 +115,12 @@ class EditorActionBar extends Component {
 
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
+	const multiUserSite = isSingleUserSite( state, siteId ) === false;
 	const postId = getEditorPostId( state );
 	const post = getEditedPost( state, siteId, postId );
 	const type = getEditedPostValue( state, siteId, postId, 'type' );
+	const isPostPrivateOrPasswordProtected =
+		utils.isPrivate( post ) || utils.getVisibility( post ) === 'password';
 
 	const podcastingCategoryId = getPodcastingCategoryId( state, siteId );
 	let isPodcastEpisode = false;
@@ -134,9 +136,11 @@ export default connect( state => {
 
 	return {
 		siteId,
+		multiUserSite,
 		postId,
 		post,
 		type,
+		isPostPrivateOrPasswordProtected,
 		isPodcastEpisode,
 	};
 } )( EditorActionBar );

--- a/client/post-editor/editor-sidebar/index.jsx
+++ b/client/post-editor/editor-sidebar/index.jsx
@@ -47,7 +47,7 @@ export class EditorSidebar extends Component {
 		return (
 			<div className="editor-sidebar">
 				<EditorSidebarHeader />
-				<EditorActionBar isNew={ isNew } post={ post } savedPost={ savedPost } site={ site } />
+				<EditorActionBar isNew={ isNew } savedPost={ savedPost } />
 				<EditorDrawer
 					site={ site }
 					savedPost={ savedPost }

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -328,12 +328,7 @@ export class PostEditor extends React.Component {
 					/>
 					<div className="post-editor__content">
 						<div className="post-editor__content-editor">
-							<EditorActionBar
-								isNew={ this.state.isNew }
-								savedPost={ this.state.savedPost }
-								site={ site }
-								isPostPrivate={ utils.isPrivate( this.state.post ) }
-							/>
+							<EditorActionBar isNew={ this.state.isNew } savedPost={ this.state.savedPost } />
 							<div className="post-editor__site">
 								<Site
 									compact


### PR DESCRIPTION
Stop passing `post` and `site` props to the `EditorActionBar` component and retrieve the necessary info from Redux instead. All post attributes including `status` are stored in Redux since #24698, so we can reliably retrieve the "private" or "password-protected" status from Redux.

To retrieve the `multiUserSite` flag, use the already available dedicated site selector.

**How to test:**
Verify that the Editor Action Bar still works:
<img width="676" alt="screen shot 2018-05-09 at 12 50 20" src="https://user-images.githubusercontent.com/664258/39820635-8baedd04-53a6-11e8-81b4-6d7a657dae5e.png">

- is the author selector displayed only on multi-user sites?
- The "sticky" button should be displayed only on posts and not on pages? It also shouldn't be displayed for private and password-protected posts -- only the public ones (you might need to apply or at least be aware of #24756 to test the sticky button)