### PR TITLE
Extensions – Zoninator: Fix eslint issues

### DIFF
--- a/client/extensions/zoninator/state/data-layer/feeds/util.js
+++ b/client/extensions/zoninator/state/data-layer/feeds/util.js
@@ -1,4 +1,5 @@
 /** @format */
+
 export const fromApi = ( posts, siteId ) =>
 	posts.map( post => ( {
 		id: post.ID,


### PR DESCRIPTION
See #24504

- [ ] client/extensions/zoninator/components/forms/zone-content-form/posts-list.jsx (19 err, 0 warn)
- [x] client/extensions/zoninator/state/data-layer/feeds/util.js (3 err, 0 warn)

This PR fixes the eslint errors in the zoninator extension. Technically there are two files with issues, but all of the issues in `zone-content-form/posts-list.jsx` are indent issues, which we currently have some trouble with, #24635

The fix for `utils` was just to add a new line, so that the linter would stop thinking the `@format` comment was an invalid jsdoc comment.