### PR TITLE
Extensions – WP Job Manager: Fix eslint issues

### DIFF
--- a/client/extensions/wp-job-manager/state/data-layer/settings/utils.js
+++ b/client/extensions/wp-job-manager/state/data-layer/settings/utils.js
@@ -1,4 +1,5 @@
 /** @format */
+
 export const fromApi = ( {
 	job_manager_allowed_application_method,
 	job_manager_category_filter_type,


### PR DESCRIPTION
See #24504

- [x] client/extensions/wp-job-manager/state/data-layer/settings/utils.js (1 err, 0 warn)

This PR fixes the eslint error in the wp-job-manager extension.

The fix for `utils` was just to add a new line, so that the linter would stop thinking the `@format` comment was an invalid jsdoc comment.