### PR TITLE
Extensions – Hello Dolly: Fix eslint error

### DIFF
--- a/client/extensions/hello-dolly/hello-dolly-page.js
+++ b/client/extensions/hello-dolly/hello-dolly-page.js
@@ -32,7 +32,7 @@ class HelloDollyPage extends Component {
 
 		return (
 			<Main className="hello-dolly__main">
-				<SectionHeader label="Hello, Dolly!">🐑</SectionHeader>
+				<SectionHeader label="Hello, Dolly!"><span role="img" aria-label="sheep">🐑</span></SectionHeader>
 				<Card>
 					<p style={ { fontSize: 18, fontWeight: 300 } }>
 						This is not just an extension, it symbolizes the hope and enthusiasm of an entire


### PR DESCRIPTION
See #24504

- [x] client/extensions/hello-dolly/hello-dolly-page.js (1 err, 0 warn)

This PR fixes the eslint error in the hello-dolly extension.

The sheep emoji needs to be marked as an image & have a label, see [jsx-a11y/accessible-emoji](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/accessible-emoji.md). I've labeled it sheep, since I'm not really sure what a better contextual label should be 😆 