### PR TITLE
DevDocs: fix React warning by adding keys when rendering LazyRender

### DIFF
--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -111,8 +111,9 @@ const Collection = ( {
 			{ examples.slice( 0, examplesToMount ) }
 
 			{ map( chunk( examples.slice( examplesToMount ), examplesToMount ), exampleGroup => {
+				const groupKey = map( exampleGroup, example => example.key ).join( '_' );
 				return (
-					<LazyRender>
+					<LazyRender key={ groupKey }>
 						{ shouldRender =>
 							shouldRender ? exampleGroup : <Placeholder count={ examplesToMount } />
 						}


### PR DESCRIPTION
When visiting the UI Component page (http://calypso.localhost:3000/devdocs/design), I saw the following warning in dev console:

```
Warning: Each child in an array or iterator should have a unique "key" prop.

Check the render method of `Collection`. See https://fb.me/react-warning-keys for more information.
    in LazilyRender (created by Collection)
    in Collection (created by DesignAssets)
    in main (created by Main)
    in Main (created by DesignAssets)
    in DesignAssets (created by AsyncLoad)
    in AsyncLoad (created by DevdocsAsyncLoad)
    in DevdocsAsyncLoad
    in div (created by Layout)
    in div (created by Layout)
    in div (created by Layout)
    in Layout (created by Connect(Layout))
    in Connect(Layout) (created by ReduxWrappedLayout)
    in Provider (created by ReduxWrappedLayout)
    in ReduxWrappedLayout
```

This PR fixes this warning by adding keys when rendering `LazyRender` in the `Collection` component, where each key is determined by joining example ids.