### PR TITLE
DevDocs: fix the "failed prop type" warning in Test component

### DIFF
--- a/client/lib/abtest/test-helper/Test.jsx
+++ b/client/lib/abtest/test-helper/Test.jsx
@@ -27,6 +27,7 @@ export default class extends React.Component {
 									className="test-helper__choice-indicator"
 									type="radio"
 									checked={ variation === currentVariation }
+									readOnly
 								/>
 								{ variation }
 							</a>


### PR DESCRIPTION
When visiting the UI Component page (http://calypso.localhost:3000/devdocs/design), I saw the following warning in dev console:
```
Warning: Failed prop type: You provided a `checked` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultChecked`. Otherwise, set either `onChange` or `readOnly`.
    in input (created by Test)
    in a (created by Test)
    in li (created by Test)
    in ul (created by Test)
    in div (created by Test)
    in Test (created by TestList)
    in div (created by Card)
    in Card (created by TestList)
    in div (created by TestList)
    in TestList
```
This PR fixes this warning by adding the `readOnly` attribute.