### PR TITLE
Components & DevDocs: dont make the `altText` a required prop for PaymentLogo

### DIFF
--- a/client/components/payment-logo/README.md
+++ b/client/components/payment-logo/README.md
@@ -6,25 +6,53 @@ PaymentLogo
 ```js
 import PaymentLogo from 'components/payment-logo';
 
+<PaymentLogo type="alipay" />
+
 <PaymentLogo type="amex" />
+
+<PaymentLogo type="bancontact" />
+
+<PaymentLogo type="diners" />
 
 <PaymentLogo type="discover" />
 
+<PaymentLogo type="eps" />
+
+<PaymentLogo type="giropay" />
+
+<PaymentLogo type="ideal" />
+
+<PaymentLogo type="jcb" />
+
 <PaymentLogo type="mastercard" />
 
-<PaymentLogo type="visa" />
+<PaymentLogo type="p24" />
 
 <PaymentLogo type="paypal" />
 <PaymentLogo type="paypal" isCompact />
+
+<PaymentLogo type="unionpay" />
+
+<PaymentLogo type="visa" />
 
 ```
 
 ## Required props
 
 * `type` – String that determines which type of logo is displayed. Currently accepts:
+   * `alipay`
    * `amex`
+   * `bancontact`
+   * `diners`
    * `discover`
+   * `eps`
+   * `giropay`
+   * `ideal`
+   * `jcb`
    * `mastercard`
-   * `visa`
+   * `p24`
    * `paypal`
+   * `placeholder`
+   * `unionpay`
+   * `visa`
 * `isCompact` (optional) – Boolean that determines if the compact PayPal logo is rendered.

--- a/client/components/payment-logo/README.md
+++ b/client/components/payment-logo/README.md
@@ -8,8 +8,13 @@ import PaymentLogo from 'components/payment-logo';
 
 <PaymentLogo type="amex" />
 
-<PaymentLogo type="paypal" />
+<PaymentLogo type="discover" />
 
+<PaymentLogo type="mastercard" />
+
+<PaymentLogo type="visa" />
+
+<PaymentLogo type="paypal" />
 <PaymentLogo type="paypal" isCompact />
 
 ```
@@ -17,9 +22,9 @@ import PaymentLogo from 'components/payment-logo';
 ## Required props
 
 * `type` – String that determines which type of logo is displayed. Currently accepts:
-   * amex
-   * discover
-   * mastercard
-   * visa
-   * paypal
+   * `amex`
+   * `discover`
+   * `mastercard`
+   * `visa`
+   * `paypal`
 * `isCompact` (optional) – Boolean that determines if the compact PayPal logo is rendered.

--- a/client/components/payment-logo/README.md
+++ b/client/components/payment-logo/README.md
@@ -6,6 +6,12 @@ PaymentLogo
 ```js
 import PaymentLogo from 'components/payment-logo';
 
+<p>Empty Placeholder</p>
+
+<PaymentLogo type="placeholder" />
+
+<p>Supported Vendors</p>
+
 <PaymentLogo type="alipay" />
 
 <PaymentLogo type="amex" />
@@ -34,7 +40,6 @@ import PaymentLogo from 'components/payment-logo';
 <PaymentLogo type="unionpay" />
 
 <PaymentLogo type="visa" />
-
 ```
 
 ## Required props

--- a/client/components/payment-logo/docs/example.jsx
+++ b/client/components/payment-logo/docs/example.jsx
@@ -5,11 +5,27 @@
  */
 
 import React from 'react';
+import concat from 'lodash/fp/concat';
+import filter from 'lodash/fp/filter';
+import flow from 'lodash/fp/flow';
+import map from 'lodash/fp/map';
+import sortBy from 'lodash/fp/sortBy';
 
 /**
  * Internal dependencies
  */
-import PaymentLogo from '../index';
+import PaymentLogo, { POSSIBLE_TYPES } from '../index';
+
+const genVendors = flow(
+	// 'placeholder' is a special case that needs to be demonstrated separately
+	filter( type => type !== 'placeholder' ),
+
+	map( type => ( { type, isCompact: false } ) ),
+	concat( [ { type: 'paypal', isCompact: true } ] ),
+	sortBy( [ 'type', 'isCompact' ] )
+);
+
+const VENDORS = genVendors( POSSIBLE_TYPES );
 
 class PaymentLogoExamples extends React.PureComponent {
 	static displayName = 'PaymentLogo';
@@ -17,12 +33,11 @@ class PaymentLogoExamples extends React.PureComponent {
 	render() {
 		return (
 			<div>
-				<PaymentLogo type="alipay" /> <PaymentLogo type="amex" /> <PaymentLogo type="bancontact" />{' '}
-				<PaymentLogo type="diners" /> <PaymentLogo type="discover" /> <PaymentLogo type="eps" />{' '}
-				<PaymentLogo type="giropay" /> <PaymentLogo type="ideal" /> <PaymentLogo type="jcb" />{' '}
-				<PaymentLogo type="mastercard" /> <PaymentLogo type="p24" /> <PaymentLogo type="paypal" />
-				<PaymentLogo type="paypal" isCompact /> <PaymentLogo type="unionpay" />{' '}
-				<PaymentLogo type="visa" />
+				{ VENDORS.map( ( { type, isCompact } ) => (
+					<div key={ [ type, isCompact ].join( '_' ) }>
+						<PaymentLogo type={ type } isCompact={ isCompact } />
+					</div>
+				) ) }
 			</div>
 		);
 	}

--- a/client/components/payment-logo/docs/example.jsx
+++ b/client/components/payment-logo/docs/example.jsx
@@ -33,6 +33,12 @@ class PaymentLogoExamples extends React.PureComponent {
 	render() {
 		return (
 			<div className="payment-logo-example">
+				<p>Empty Placeholder</p>
+
+				<PaymentLogo type="placeholder" />
+
+				<p>Supported Vendors</p>
+
 				{ VENDORS.map( ( { type, isCompact } ) => (
 					<div key={ [ type, isCompact ].join( '_' ) }>
 						<PaymentLogo type={ type } isCompact={ isCompact } />

--- a/client/components/payment-logo/docs/example.jsx
+++ b/client/components/payment-logo/docs/example.jsx
@@ -32,7 +32,7 @@ class PaymentLogoExamples extends React.PureComponent {
 
 	render() {
 		return (
-			<div>
+			<div className="payment-logo-example">
 				{ VENDORS.map( ( { type, isCompact } ) => (
 					<div key={ [ type, isCompact ].join( '_' ) }>
 						<PaymentLogo type={ type } isCompact={ isCompact } />

--- a/client/components/payment-logo/docs/example.jsx
+++ b/client/components/payment-logo/docs/example.jsx
@@ -17,9 +17,12 @@ class PaymentLogoExamples extends React.PureComponent {
 	render() {
 		return (
 			<div>
-				<PaymentLogo type="amex" /> <PaymentLogo type="discover" /> {' '}
-				<PaymentLogo type="mastercard" /> <PaymentLogo type="visa" /> {' '}
-				<PaymentLogo type="paypal" isCompact /> <PaymentLogo type="paypal" />
+				<PaymentLogo type="alipay" /> <PaymentLogo type="amex" /> <PaymentLogo type="bancontact" />{' '}
+				<PaymentLogo type="diners" /> <PaymentLogo type="discover" /> <PaymentLogo type="eps" />{' '}
+				<PaymentLogo type="giropay" /> <PaymentLogo type="ideal" /> <PaymentLogo type="jcb" />{' '}
+				<PaymentLogo type="mastercard" /> <PaymentLogo type="p24" /> <PaymentLogo type="paypal" />
+				<PaymentLogo type="paypal" isCompact /> <PaymentLogo type="unionpay" />{' '}
+				<PaymentLogo type="visa" />
 			</div>
 		);
 	}

--- a/client/components/payment-logo/index.jsx
+++ b/client/components/payment-logo/index.jsx
@@ -15,6 +15,7 @@ const ALT_TEXT = {
 	mastercard: 'MasterCard',
 	visa: 'VISA',
 	paypal: 'PayPal',
+	placeholder: '',
 };
 
 const POSSIBLE_TYPES = keys( ALT_TEXT );

--- a/client/components/payment-logo/index.jsx
+++ b/client/components/payment-logo/index.jsx
@@ -27,7 +27,7 @@ const ALT_TEXT = {
 	visa: 'VISA',
 };
 
-const POSSIBLE_TYPES = keys( ALT_TEXT );
+export const POSSIBLE_TYPES = keys( ALT_TEXT );
 
 class PaymentLogo extends React.Component {
 	static propTypes = {

--- a/client/components/payment-logo/index.jsx
+++ b/client/components/payment-logo/index.jsx
@@ -10,12 +10,21 @@ import React from 'react';
 import { keys } from 'lodash';
 
 const ALT_TEXT = {
+	alipay: 'Alipay',
 	amex: 'American Express',
+	bancontact: 'Bancontact',
+	diners: 'Diners Club',
 	discover: 'Discover',
+	eps: 'eps',
+	giropay: 'Giropay',
+	ideal: 'iDEAL',
+	jcb: 'JCB',
 	mastercard: 'MasterCard',
-	visa: 'VISA',
+	p24: 'Przelewy24',
 	paypal: 'PayPal',
 	placeholder: '',
+	unionpay: 'UnionPay',
+	visa: 'VISA',
 };
 
 const POSSIBLE_TYPES = keys( ALT_TEXT );

--- a/client/components/payment-logo/index.jsx
+++ b/client/components/payment-logo/index.jsx
@@ -31,17 +31,21 @@ export const POSSIBLE_TYPES = keys( ALT_TEXT );
 
 class PaymentLogo extends React.Component {
 	static propTypes = {
+		className: PropTypes.string,
 		type: PropTypes.oneOf( POSSIBLE_TYPES ),
 		altText: PropTypes.string,
 		isCompact: PropTypes.bool,
 	};
 
 	render() {
-		const { altText, isCompact, type } = this.props;
+		const { altText, className, isCompact, type } = this.props;
 
-		const classes = classNames( 'payment-logo', `is-${ type }`, {
-			'is-compact': isCompact,
-		} );
+		const classes = classNames(
+			'payment-logo',
+			`is-${ type }`,
+			{ 'is-compact': isCompact },
+			className
+		);
 
 		return <div className={ classes } aria-label={ altText || ALT_TEXT[ type ] || '' } />;
 	}

--- a/client/components/payment-logo/index.jsx
+++ b/client/components/payment-logo/index.jsx
@@ -10,7 +10,7 @@ import React from 'react';
 
 class PaymentLogo extends React.Component {
 	static propTypes = {
-		type: PropTypes.string.isRequired,
+		type: PropTypes.oneOf( [ 'amex', 'discover', 'mastercard', 'visa', 'paypal' ] ),
 		altText: PropTypes.string.isRequired,
 		isCompact: PropTypes.bool,
 	};

--- a/client/components/payment-logo/index.jsx
+++ b/client/components/payment-logo/index.jsx
@@ -7,20 +7,33 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { keys } from 'lodash';
+
+const ALT_TEXT = {
+	amex: 'American Express',
+	discover: 'Discover',
+	mastercard: 'MasterCard',
+	visa: 'VISA',
+	paypal: 'PayPal',
+};
+
+const POSSIBLE_TYPES = keys( ALT_TEXT );
 
 class PaymentLogo extends React.Component {
 	static propTypes = {
-		type: PropTypes.oneOf( [ 'amex', 'discover', 'mastercard', 'visa', 'paypal' ] ),
-		altText: PropTypes.string.isRequired,
+		type: PropTypes.oneOf( POSSIBLE_TYPES ),
+		altText: PropTypes.string,
 		isCompact: PropTypes.bool,
 	};
 
 	render() {
-		const classes = classNames( 'payment-logo', `is-${ this.props.type }`, {
-			'is-compact': this.props.isCompact,
+		const { altText, isCompact, type } = this.props;
+
+		const classes = classNames( 'payment-logo', `is-${ type }`, {
+			'is-compact': isCompact,
 		} );
 
-		return <div className={ classes } aria-label={ this.props.altText } />;
+		return <div className={ classes } aria-label={ altText || ALT_TEXT[ type ] || '' } />;
 	}
 }
 


### PR DESCRIPTION
When visiting the README of PaymentLogo (http://calypso.localhost:3000/devdocs/design/payment-logo), I saw the following warning in dev console:

```
index.jsx:101 Warning: Failed prop type: The prop `altText` is marked as required in `PaymentLogo`, but its value is `undefined`.
    in PaymentLogo (created by PaymentLogo)
    in PaymentLogo (created by DesignAssets)
    in span (created by DocsExampleWrapper)
    in div (created by DocsExampleWrapper)
    in div (created by DocsExampleWrapper)
    in DocsExampleWrapper (created by Collection)
    in div (created by Collection)
    in div (created by LazilyRender)
    in LazilyRender (created by Collection)
    in div (created by Collection)
    in Collection (created by DesignAssets)
    in main (created by Main)
    in Main (created by DesignAssets)
    in DesignAssets (created by AsyncLoad)
    in AsyncLoad (created by DevdocsAsyncLoad)
    in DevdocsAsyncLoad
    in div (created by Layout)
    in div (created by Layout)
    in div (created by Layout)
    in Layout (created by Connect(Layout))
    in Connect(Layout) (created by ReduxWrappedLayout)
    in Provider (created by ReduxWrappedLayout)
    in ReduxWrappedLayout
```

I searched through the whole repository and found that most of the usages of `PaymentLogo` do not pass anything to the `altText` prop. Since the possible values of the `type` prop are limited (according to the README of `PaymentLogo`), I think it makes sense to infer `PaymentLogo`'s `altText` from its `type` when `altText` is not given. We can achieve this by maintaining a mapping from `type` to `altText`. 

In addition, I found that the possible values of `type` in `PaymentLogo` are far more than those documented on README when I looked into `PaymentLogo`'s `style.scss`. I've updated README and examples accordingly.

Fixes #24775.