### PR TITLE
Activity Log: add legend indicating the update type

### DIFF
--- a/client/my-sites/stats/activity-log-tasklist/index.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/index.jsx
@@ -314,28 +314,30 @@ class ActivityLogTasklist extends Component {
 								}
 							)
 						: translate( 'You have one update available' ) }
-					<SplitButton
-						compact
-						primary
-						label={ translate( 'Update all' ) }
-						onClick={ this.updateAll }
-						disabled={ 0 < queuedPlugins.length }
-					>
-						<PopoverMenuItem
-							onClick={ this.goManagePlugins }
-							className="activity-log-tasklist__menu-item"
-							icon="cog"
+					{ 1 < numberOfPluginUpdates && (
+						<SplitButton
+							compact
+							primary
+							label={ translate( 'Update all' ) }
+							onClick={ this.updateAll }
+							disabled={ 0 < queuedPlugins.length }
 						>
-							<span>{ translate( 'Manage plugins' ) }</span>
-						</PopoverMenuItem>
-						<PopoverMenuItem
-							onClick={ this.dismissPlugins }
-							className="activity-log-tasklist__menu-item"
-							icon="trash"
-						>
-							<span>{ translate( 'Dismiss all' ) }</span>
-						</PopoverMenuItem>
-					</SplitButton>
+							<PopoverMenuItem
+								onClick={ this.goManagePlugins }
+								className="activity-log-tasklist__menu-item"
+								icon="cog"
+							>
+								<span>{ translate( 'Manage plugins' ) }</span>
+							</PopoverMenuItem>
+							<PopoverMenuItem
+								onClick={ this.dismissPlugins }
+								className="activity-log-tasklist__menu-item"
+								icon="trash"
+							>
+								<span>{ translate( 'Dismiss all' ) }</span>
+							</PopoverMenuItem>
+						</SplitButton>
+					) }
 				</div>
 				{ // Show if plugin update didn't start, is still running or errored,
 				// but hide plugin if it was updated successfully.

--- a/client/my-sites/stats/activity-log-tasklist/style.scss
+++ b/client/my-sites/stats/activity-log-tasklist/style.scss
@@ -4,7 +4,7 @@
 
 	.activity-log-tasklist__heading {
 		display: flex;
-		font-weight: 500;
+		font-weight: 600;
 		justify-content: space-between;
 		margin-bottom: 16px;
 
@@ -34,24 +34,31 @@
 
 .activity-log-tasklist__update-item {
 	flex-grow: 1;
+
+	& > div {
+		line-height: 100%;
+	}
 }
 
 .activity-log-tasklist__update-text {
+	font-weight: 500;
+
 	.button.is-borderless {
 		vertical-align: middle;
 		line-height: 1;
 	}
 }
 
-.activity-log-tasklist__update-version {
-	color: $gray-text-min;
+.activity-log-tasklist__update-version,
+.activity-log-tasklist__update-type,
+.activity-log-tasklist__update-bullet {
+	color: $gray;
 }
 
 .activity-log-tasklist__update-bullet {
-	color: $gray-text-min;
-	font-size: 10px;
-	margin: 0 8px;
-	vertical-align: text-bottom;
+	font-size: 7px;
+	margin: 0 7px;
+	vertical-align: middle;
 }
 
 .activity-log-tasklist__update-action {

--- a/client/my-sites/stats/activity-log-tasklist/update.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/update.jsx
@@ -45,21 +45,26 @@ class ActivityLogTaskUpdate extends Component {
 			<Card className="activity-log-tasklist__task" compact>
 				<ActivityIcon activityIcon="plugins" activityStatus="warning" />
 				<span className="activity-log-tasklist__update-item">
-					<span className="activity-log-tasklist__update-text">
-						{ translate( 'Update available for {{plugin/}}', {
-							components: {
-								plugin: (
-									<Button onClick={ this.handlePluginNameClick } borderless>
-										{ plugin.name }
-									</Button>
-								),
-							},
-						} ) }
-					</span>
-					<span className="activity-log-tasklist__update-bullet">&bull;</span>
-					<span className="activity-log-tasklist__update-version">
-						{ plugin.update.new_version }
-					</span>
+					<div>
+						<span className="activity-log-tasklist__update-text">
+							{ translate( 'Update available for {{plugin/}}', {
+								components: {
+									plugin: (
+										<Button borderless onClick={ this.handlePluginNameClick }>
+											{ plugin.name }
+										</Button>
+									),
+								},
+							} ) }
+						</span>
+						<span className="activity-log-tasklist__update-bullet">&bull;</span>
+						<span className="activity-log-tasklist__update-version">
+							{ plugin.update.new_version }
+						</span>
+					</div>
+					<div className="activity-log-tasklist__update-type">
+						{ translate( 'Plugin update available' ) }
+					</div>
 				</span>
 				<span className="activity-log-tasklist__update-action">
 					<SplitButton


### PR DESCRIPTION
Fixes #24766

An update for a plugin now looks like this

<img width="771" alt="captura de pantalla 2018-05-10 a la s 12 51 09" src="https://user-images.githubusercontent.com/1041600/39879295-dbc83682-5450-11e8-8f03-0f9401a6225f.png">

and when there's only one update, the Update all button is hidden

<img width="775" alt="captura de pantalla 2018-05-10 a la s 12 49 32" src="https://user-images.githubusercontent.com/1041600/39879225-a2a77afc-5450-11e8-8c86-8a2a766ad1a2.png">
