### PR TITLE
Update FormToggle style to use flexbox by default

### DIFF
--- a/client/components/forms/form-toggle/style.scss
+++ b/client/components/forms/form-toggle/style.scss
@@ -12,13 +12,14 @@
 	border-radius: 12px;
 	box-sizing: border-box;
 	padding: 2px;
-	width: 40px;
+	width: 44px;
 	height: 24px;
 	vertical-align: middle;
 	align-self: flex-start;
 	outline: 0;
 	cursor: pointer;
 	transition: all .4s ease, box-shadow 0s;
+	margin-top: 3px;
 
 	&:before,
 	&:after {
@@ -43,6 +44,7 @@
 }
 
 .form-toggle__label {
+	display: flex;
 	cursor: pointer;
 
 	.is-disabled & {


### PR DESCRIPTION
`FormToggle` uses a bunch of flex properties but never properly create the "flex" parent box. Relying on the module using the `FormToggle` to declare its own CSS to do it:

https://github.com/Automattic/wp-calypso/blob/022ed112d829be560efbec9f8d4e31544dab479a/client/my-sites/site-settings/style.scss#L187

https://github.com/Automattic/wp-calypso/blob/022ed112d829be560efbec9f8d4e31544dab479a/client/my-sites/site-settings/style.scss#L206

