### PR TITLE
Privacy settings: Update UI Language

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -302,6 +302,7 @@
 @import 'me/notification-settings/push-notification-settings/style';
 @import 'me/notification-settings/settings-form/style';
 @import 'me/notification-settings/wpcom-settings/style';
+@import 'me/privacy/style';
 @import 'me/profile/style';
 @import 'me/profile-gravatar/style';
 @import 'me/profile-link/style';

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -14,6 +14,7 @@ import React from 'react';
  */
 import Card from 'components/card';
 import DocumentHead from 'components/data/document-head';
+import ExternalLink from 'components/external-link';
 import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormToggle from 'components/forms/form-toggle';
@@ -57,10 +58,10 @@ const Privacy = createReactClass( {
 		);
 
 		const cookiePolicyLink = (
-			<a href="https://www.automattic.com/cookies" target="_blank" rel="noopener noreferrer" />
+			<ExternalLink href="https://www.automattic.com/cookies" target="_blank" />
 		);
 		const privacyPolicyLink = (
-			<a href="https://www.automattic.com/privacy" target="_blank" rel="noopener noreferrer" />
+			<ExternalLink href="https://www.automattic.com/privacy" target="_blank" />
 		);
 
 		return (
@@ -82,10 +83,9 @@ const Privacy = createReactClass( {
 									onChange={ this.updateTracksOptOut }
 								>
 									{ translate(
-										// eslint-disable-next-line max-len
-										'Allow us to collect information about how you use your services while you ' +
-											'are logged in to your WordPress.com account through our own first-party ' +
-											'analytics tool. {{cookiePolicyLink}}Learn more{{/cookiePolicyLink}}',
+										'Share information with our analytics tool about your use of services while ' +
+											'logged in to your WordPress.com account. {{cookiePolicyLink}}Learn more' +
+											'{{/cookiePolicyLink}}',
 										{
 											components: {
 												cookiePolicyLink,
@@ -97,10 +97,9 @@ const Privacy = createReactClass( {
 
 							<p>
 								{ translate(
-									// eslint-disable-next-line max-len
-									'We use this information to improve our products, make our marketing to you more ' +
-										'relevant, personalize your experience, and for the other purposes described in ' +
-										'our {{privacyPolicyLink}}privacy policy{{/privacyPolicyLink}}.',
+									'This information helps us improve our products, make marketing to you more ' +
+										'relevant, personalize your WordPress.com experience, and more as detailed in ' +
+										'our {{privacyPolicyLink}}privacy policy{{/privacyPolicyLink}}',
 									{
 										components: {
 											privacyPolicyLink,
@@ -111,10 +110,9 @@ const Privacy = createReactClass( {
 
 							<p>
 								{ translate(
-									// eslint-disable-next-line max-len
-									'We use other tracking technologies and cookies, including some from third ' +
-										'parties. {{cookiePolicyLink}}Learn more{{/cookiePolicyLink}} about these ' +
-										'technologies and your options to control them.',
+									'We use other tracking tools, including some from third parties. ' +
+										'{{cookiePolicyLink}}Read about those{{/cookiePolicyLink}} these and how to ' +
+										'control them.',
 									{
 										components: {
 											cookiePolicyLink,

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -83,7 +83,9 @@ const Privacy = createReactClass( {
 								>
 									{ translate(
 										// eslint-disable-next-line max-len
-										'Allow us to collect information about how you use your services while you are logged in to your WordPress.com account through our own first-party analytics tool. {{cookiePolicyLink}}Learn more{{/cookiePolicyLink}}',
+										'Allow us to collect information about how you use your services while you ' +
+											'are logged in to your WordPress.com account through our own first-party ' +
+											'analytics tool. {{cookiePolicyLink}}Learn more{{/cookiePolicyLink}}',
 										{
 											components: {
 												cookiePolicyLink,
@@ -96,7 +98,9 @@ const Privacy = createReactClass( {
 							<p>
 								{ translate(
 									// eslint-disable-next-line max-len
-									'We use this information to improve our products, make our marketing to you more relevant, personalize your experience, and for the other purposes described in our {{privacyPolicyLink}}privacy policy{{/privacyPolicyLink}}.',
+									'We use this information to improve our products, make our marketing to you more ' +
+										'relevant, personalize your experience, and for the other purposes described in ' +
+										'our {{privacyPolicyLink}}privacy policy{{/privacyPolicyLink}}.',
 									{
 										components: {
 											privacyPolicyLink,
@@ -108,7 +112,9 @@ const Privacy = createReactClass( {
 							<p>
 								{ translate(
 									// eslint-disable-next-line max-len
-									'We use other tracking technologies and cookies, including some from third parties. {{cookiePolicyLink}}Learn more{{/cookiePolicyLink}} about these technologies and your options to control them.',
+									'We use other tracking technologies and cookies, including some from third ' +
+										'parties. {{cookiePolicyLink}}Learn more{{/cookiePolicyLink}} about these ' +
+										'technologies and your options to control them.',
 									{
 										components: {
 											cookiePolicyLink,

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -16,13 +16,13 @@ import Card from 'components/card';
 import DocumentHead from 'components/data/document-head';
 import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
-import FormLegend from 'components/forms/form-legend';
 import FormToggle from 'components/forms/form-toggle';
 import Main from 'components/main';
 import observe from 'lib/mixins/data-observe';
 import { protectForm } from 'lib/protect-form';
 import twoStepAuthorization from 'lib/two-step-authorization';
 import ReauthRequired from 'me/reauth-required';
+import SectionHeader from 'components/section-header';
 import formBase from 'me/form-base';
 import MeSidebarNavigation from 'me/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -56,23 +56,66 @@ const Privacy = createReactClass( {
 			TRACKS_OPT_OUT_USER_SETTINGS_KEY
 		);
 
+		const cookiePolicyLink = (
+			<a href="https://www.automattic.com/cookies" target="_blank" rel="noopener noreferrer" />
+		);
+		const privacyPolicyLink = (
+			<a href="https://www.automattic.com/privacy" target="_blank" rel="noopener noreferrer" />
+		);
+
 		return (
 			<Main className="privacy">
 				<PageViewTracker path="/me/privacy" title="Me > Privacy" />
-				<DocumentHead title={ this.props.translate( 'Privacy Settings' ) } />
+				<DocumentHead title={ translate( 'Privacy Settings' ) } />
 				<MeSidebarNavigation />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+				<SectionHeader label={ translate( 'Usage Information' ) } />
 				<Card className="privacy__settings">
 					<form onChange={ markChanged } onSubmit={ this.submitForm }>
+						<p>{ translate( 'We are committed to your privacy and security.' ) }</p>
+
 						<FormFieldset>
-							<FormLegend>{ translate( 'Usage Statistics' ) }</FormLegend>
-							<FormToggle
-								id="tracks_opt_out"
-								checked={ isSendingTracksEvent }
-								onChange={ this.updateTracksOptOut }
-							>
-								{ translate( 'Send usage statistics to help us improve our products.' ) }
-							</FormToggle>
+							<p>
+								<FormToggle
+									id="tracks_opt_out"
+									checked={ isSendingTracksEvent }
+									onChange={ this.updateTracksOptOut }
+								>
+									{ translate(
+										// eslint-disable-next-line max-len
+										'Allow us to collect information about how you use your services while you are logged in to your WordPress.com account through our own first-party analytics tool. {{cookiePolicyLink}}Learn more{{/cookiePolicyLink}}',
+										{
+											components: {
+												cookiePolicyLink,
+											},
+										}
+									) }
+								</FormToggle>
+							</p>
+
+							<p>
+								{ translate(
+									// eslint-disable-next-line max-len
+									'We use this information to improve our products, make our marketing to you more relevant, personalize your experience, and for the other purposes described in our {{privacyPolicyLink}}privacy policy{{/privacyPolicyLink}}.',
+									{
+										components: {
+											privacyPolicyLink,
+										},
+									}
+								) }
+							</p>
+
+							<p>
+								{ translate(
+									// eslint-disable-next-line max-len
+									'We use other tracking technologies and cookies, including some from third parties. {{cookiePolicyLink}}Learn more{{/cookiePolicyLink}} about these technologies and your options to control them.',
+									{
+										components: {
+											cookiePolicyLink,
+										},
+									}
+								) }
+							</p>
 						</FormFieldset>
 
 						<FormButton

--- a/client/me/privacy/style.scss
+++ b/client/me/privacy/style.scss
@@ -1,0 +1,10 @@
+.privacy__settings {
+    .form-toggle__switch {
+        width: 44px;
+        margin-top: 3px;
+    }
+
+    .form-toggle__label {
+        display: flex;
+    }
+}


### PR DESCRIPTION
This updates the language used in the Privacy settings page ( as explained in p4H3ND-DS-p2 ), it adds a proper header and also fixes an issue with the toggle if the label ends up wrapping.

Sadly I had to include "custom" CSS and couldn't port those updates directly inside the `FormToggle` styles: some parts of Calypso using those components are broken if we enable the flexbox on it ( tried in #24773 ), for instance the [Reader settings](http://calypso.localhost:3000/following/manage).

![calypso localhost_3000_me_privacy 1](https://user-images.githubusercontent.com/1145270/39914671-3a978b6e-54f5-11e8-9772-3aad6dd81f87.png)

As a side note, the plan right now would be to remove the feature flag used for `/me/privacy` on May 21th.