### PR TITLE
Increase spacing above and within extra section on Jetpack Plans

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -698,9 +698,9 @@
 .jetpack-connect__plan-info {
 	text-align: center;
 	max-width: 500px;
-	margin-top: 20px;
-	padding-top: 30px;
-	padding-bottom: 30px;
+	margin-top: 40px;
+	padding-top: 40px;
+	padding-bottom: 40px;
 }
 
 .jetpack-connect__plan-info-illustration {


### PR DESCRIPTION
This PR increases the margin above and padding within the new extra section on the Jetpack Plans view. These minor visual changes add more space between the Free button and the extra section, and also more padding within the extra section box and its content.

Before/After: https://cloudup.com/cb_6CLLiSgC

### To Test:
- checkout this branch in local Calypso.
- go to JPC plans page http://calypso.localhost:3000/jetpack/connect/store and verify that the visual changes are visible and work well for all views.