### PR TITLE
Fix Automatic Redirect on Google My Business Connect

### DIFF
--- a/client/blocks/keyring-connect-button/index.js
+++ b/client/blocks/keyring-connect-button/index.js
@@ -149,7 +149,8 @@ class KeyringConnectButton extends Component {
 	didKeyringConnectionSucceed( keyringConnections ) {
 		const hasAnyConnectionOptions = some(
 			keyringConnections,
-			e => e.isConnected === false || e.isConnected === undefined
+			keyringConnection =>
+				keyringConnection.isConnected === false || keyringConnection.isConnected === undefined
 		);
 
 		if ( keyringConnections.length === 0 ) {

--- a/client/blocks/keyring-connect-button/index.js
+++ b/client/blocks/keyring-connect-button/index.js
@@ -147,7 +147,10 @@ class KeyringConnectButton extends Component {
 	 * @return {Boolean} Whether the Keyring authorization attempt succeeded
 	 */
 	didKeyringConnectionSucceed( keyringConnections ) {
-		const hasAnyConnectionOptions = some( keyringConnections, { isConnected: false } );
+		const hasAnyConnectionOptions = some(
+			keyringConnections,
+			e => e.isConnected === false || e.isConnected === undefined
+		);
 
 		if ( keyringConnections.length === 0 ) {
 			this.setState( { isConnecting: false } );


### PR DESCRIPTION
## Specs
<img width="1031" alt="screen shot 2018-05-09 at 2 00 01 pm" src="https://user-images.githubusercontent.com/2810519/39839533-48c6f130-5391-11e8-9fbc-3b53b3b1e988.png">

Clicking "Create Your Listing" and successfully connecting to a Google My Business account should now redirect to the Google My Business Select Location page.

Fixes #24704 

## Testing

1. Find a previously unconnected site or use instructions to unconnected a connected site ( see p9j7e4-eC )
2. Navigate to `/google-my-business/select-business-type/:site`
3. Click "Create Your Listing"
4. Connect to an account with  Google My Business locations
5. You should be taken to `google-my-business/select-location/:site` automatically

## Review
- [ ] Code
- [ ] Product
