### PR TITLE
Domains: Show filter reset notice when too few results are suggested

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -981,13 +981,13 @@ class RegisterDomainStep extends React.Component {
 			}
 		}
 
-		if ( suggestions.length === 0 && ! this.state.loadingResults ) {
-			// the search returned no results
-			if ( this.props.showExampleSuggestions ) {
-				return this.renderExampleSuggestions();
-			}
-
-			suggestions = this.props.defaultSuggestions || [];
+		// the search returned no results
+		if (
+			suggestions.length === 0 &&
+			! this.state.loadingResults &&
+			this.props.showExampleSuggestions
+		) {
+			return this.renderExampleSuggestions();
 		}
 
 		return (

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -48,6 +48,7 @@ import DomainSuggestion from 'components/domains/domain-suggestion';
 import DomainSearchResults from 'components/domains/domain-search-results';
 import ExampleDomainSuggestions from 'components/domains/example-domain-suggestions';
 import DropdownFilters from 'components/domains/search-filters/dropdown-filters';
+import FilterResetNotice from 'components/domains/search-filters/filter-reset-notice';
 import { getCurrentUser } from 'state/current-user/selectors';
 import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
 import QueryDomainsSuggestions from 'components/data/query-domains-suggestions';
@@ -359,6 +360,7 @@ class RegisterDomainStep extends React.Component {
 					/>
 				) }
 				{ this.renderContent() }
+				{ this.renderFilterResetNotice() }
 				{ this.renderPaginationControls() }
 				{ queryObject && <QueryDomainsSuggestions { ...queryObject } /> }
 				<QueryContactDetailsCache />
@@ -408,6 +410,18 @@ class RegisterDomainStep extends React.Component {
 					) ) }
 				</CompactCard>
 			)
+		);
+	}
+
+	renderFilterResetNotice() {
+		return (
+			<FilterResetNotice
+				className="register-domain-step__filter-reset-notice"
+				isLoading={ this.state.loadingResults }
+				lastFilters={ this.state.lastFilters }
+				onReset={ this.onFiltersReset }
+				suggestions={ this.state.searchResults }
+			/>
 		);
 	}
 
@@ -538,7 +552,9 @@ class RegisterDomainStep extends React.Component {
 			{
 				filters: {
 					...this.state.filters,
-					...pick( this.getInitialFiltersState(), keysToReset ),
+					...( Array.isArray( keysToReset ) && keysToReset.length > 0
+						? pick( this.getInitialFiltersState(), keysToReset )
+						: this.getInitialFiltersState() ),
 				},
 			},
 			() => {

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -18,10 +18,6 @@
 		}
 	}
 
-	@include breakpoint( '>660px' ) {
-		padding-bottom: 30px;
-	}
-
 	&.disabled {
 		border-bottom: none; // so that bottom border is not there during google app dialog animation
 		opacity: 0.7;
@@ -49,11 +45,13 @@
 	}
 }
 
+.register-domain-step__filter-reset-notice,
 .register-domain-step__next-page {
 	color: $blue-medium;
 	font-weight: 500;
 	width: 100%;
 	position: relative;
+	margin-bottom: 0;
 
 	border: 0;
 	border-radius: 0;
@@ -71,7 +69,9 @@
 		// from components/domains/domain-suggestion/style
 		box-shadow: 0 0 0 1px $gray;
 	}
+}
 
+.register-domain-step__next-page {
 	.spinner {
 		margin-left: 0.5em;
 

--- a/client/components/domains/search-filters/filter-reset-notice.jsx
+++ b/client/components/domains/search-filters/filter-reset-notice.jsx
@@ -54,7 +54,7 @@ export class FilterResetNotice extends Component {
 					onClick={ this.onReset }
 					tagName="button"
 				>
-					{ this.props.translate( 'Disable filters to see more results' ) }
+					{ this.props.translate( 'Click here to disable filters for more results' ) }
 				</Card>
 			)
 		);

--- a/client/components/domains/search-filters/filter-reset-notice.jsx
+++ b/client/components/domains/search-filters/filter-reset-notice.jsx
@@ -19,7 +19,7 @@ export class FilterResetNotice extends Component {
 		lastFilters: PropTypes.shape( {
 			includeDashes: PropTypes.bool,
 			maxCharacters: PropTypes.string,
-			showExactMatchesOnly: PropTypes.bool,
+			exactSldMatchesOnly: PropTypes.bool,
 			tlds: PropTypes.arrayOf( PropTypes.string ),
 		} ).isRequired,
 		suggestions: PropTypes.arrayOf( PropTypes.object ),
@@ -28,7 +28,7 @@ export class FilterResetNotice extends Component {
 	hasActiveFilters() {
 		return (
 			( this.props.lastFilters.includeDashes && 1 ) ||
-			( this.props.lastFilters.showExactMatchesOnly && 1 ) ||
+			( this.props.lastFilters.exactSldMatchesOnly && 1 ) ||
 			( this.props.lastFilters.maxCharacters !== '' && 1 ) ||
 			this.props.lastFilters.tlds.length > 0
 		);

--- a/client/components/domains/search-filters/filter-reset-notice.jsx
+++ b/client/components/domains/search-filters/filter-reset-notice.jsx
@@ -1,0 +1,64 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import Card from 'components/card';
+
+export class FilterResetNotice extends Component {
+	static propTypes = {
+		isLoading: PropTypes.bool.isRequired,
+		lastFilters: PropTypes.shape( {
+			includeDashes: PropTypes.bool,
+			maxCharacters: PropTypes.string,
+			showExactMatchesOnly: PropTypes.bool,
+			tlds: PropTypes.arrayOf( PropTypes.string ),
+		} ).isRequired,
+		suggestions: PropTypes.arrayOf( PropTypes.object ),
+	};
+
+	hasActiveFilters() {
+		return (
+			( this.props.lastFilters.includeDashes && 1 ) ||
+			( this.props.lastFilters.showExactMatchesOnly && 1 ) ||
+			( this.props.lastFilters.maxCharacters !== '' && 1 ) ||
+			this.props.lastFilters.tlds.length > 0
+		);
+	}
+
+	hasTooFewSuggestions() {
+		const { suggestions } = this.props;
+		return Array.isArray( suggestions ) && suggestions.length < 10;
+	}
+
+	onReset = () => {
+		this.props.onReset();
+	};
+
+	render() {
+		return (
+			config.isEnabled( 'domains/kracken-ui/pagination' ) &&
+			this.hasActiveFilters() &&
+			this.hasTooFewSuggestions() && (
+				<Card
+					className={ this.props.className }
+					disabled={ this.props.isLoading }
+					onClick={ this.onReset }
+					tagName="button"
+				>
+					{ this.props.translate( 'Disable filters to see more results' ) }
+				</Card>
+			)
+		);
+	}
+}
+
+export default localize( FilterResetNotice );


### PR DESCRIPTION
Suggested by @delputnam in #24718.

This feature will show a call-to-action card below the suggestions when the filters have been set too restrictively. Clicking on this notice will remove all set filters from the search.

<img width="991" alt="restrictive_filters" src="https://user-images.githubusercontent.com/4044428/39896913-5bd048d0-546d-11e8-8d06-8cf0fac8dddf.png">

# Test instructions
1. Check out this branch locally.
2. Navigate to `/start/domains/`. I like to enable the `domains/kracken-ui/filters` feature flag like [so](http://calypso.localhost:3000/start/domains?flags=domains/kracken-ui/filters) to see the TLD filters.
3. Enter a query, enable the exact match filter and the `.com` TLD filter. 
4. Ensure that the `Disable filters to see more results` appear below the suggestions.