### PR TITLE
Domains: Show when a transfer is free / included in paid plans

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -147,7 +147,7 @@ class TransferDomainStep extends React.Component {
 
 		if ( isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, searchQuery ) ) {
 			domainProductPrice = translate( 'Free with your plan' );
-		} else if ( domainsWithPlansOnly && ! isPlan( selectedSite.plan ) ) {
+		} else if ( domainsWithPlansOnly && selectedSite && ! isPlan( selectedSite.plan ) ) {
 			domainProductPrice = translate( 'Included in paid plans' );
 		}
 

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -44,7 +44,7 @@ import { domainManagementTransferIn } from 'my-sites/domains/paths';
 import { errorNotice } from 'state/notices/actions';
 import QueryProducts from 'components/data/query-products-list';
 import { isPlan } from 'lib/products-values';
-import { isNextDomainFree } from 'lib/cart-values/cart-items';
+import { isDomainIncludedInPlan, isNextDomainFree } from 'lib/cart-values/cart-items';
 
 class TransferDomainStep extends React.Component {
 	static propTypes = {
@@ -145,7 +145,7 @@ class TransferDomainStep extends React.Component {
 			this.props.currencyCode
 		);
 
-		if ( isNextDomainFree( cart ) ) {
+		if ( isNextDomainFree( cart ) || isDomainIncludedInPlan( cart, searchQuery ) ) {
 			domainProductPrice = translate( 'Free with your plan' );
 		} else if ( domainsWithPlansOnly && ! isPlan( selectedSite.plan ) ) {
 			domainProductPrice = translate( 'Included in paid plans' );

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -43,6 +43,8 @@ import { fetchDomains } from 'lib/upgrades/actions';
 import { domainManagementTransferIn } from 'my-sites/domains/paths';
 import { errorNotice } from 'state/notices/actions';
 import QueryProducts from 'components/data/query-products-list';
+import { isPlan } from 'lib/products-values';
+import { isNextDomainFree } from 'lib/cart-values/cart-items';
 
 class TransferDomainStep extends React.Component {
 	static propTypes = {
@@ -132,15 +134,22 @@ class TransferDomainStep extends React.Component {
 	};
 
 	addTransfer() {
-		const { translate } = this.props;
+		const { cart, domainsWithPlansOnly, selectedSite, translate } = this.props;
 		const { searchQuery, submittingAvailability, submittingWhois } = this.state;
 		const submitting = submittingAvailability || submittingWhois;
 		const productSlug = getDomainProductSlug( searchQuery );
-		const domainProductPrice = getDomainPrice(
+
+		let domainProductPrice = getDomainPrice(
 			productSlug,
 			this.props.productsList,
 			this.props.currencyCode
 		);
+
+		if ( isNextDomainFree( cart ) ) {
+			domainProductPrice = translate( 'Free with your plan' );
+		} else if ( domainsWithPlansOnly && ! isPlan( selectedSite.plan ) ) {
+			domainProductPrice = translate( 'Included in paid plans' );
+		}
 
 		return (
 			<div>

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -134,10 +134,12 @@ class TransferDomainStep extends React.Component {
 	};
 
 	addTransfer() {
-		const { cart, domainsWithPlansOnly, selectedSite, translate } = this.props;
+		const { cart, domainsWithPlansOnly, isSignupStep, selectedSite, translate } = this.props;
 		const { searchQuery, submittingAvailability, submittingWhois } = this.state;
 		const submitting = submittingAvailability || submittingWhois;
 		const productSlug = getDomainProductSlug( searchQuery );
+		const domainsWithPlansOnlyButNoPlan =
+			domainsWithPlansOnly && ( ( selectedSite && ! isPlan( selectedSite.plan ) ) || isSignupStep );
 
 		let domainProductPrice = getDomainPrice(
 			productSlug,
@@ -147,7 +149,7 @@ class TransferDomainStep extends React.Component {
 
 		if ( isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, searchQuery ) ) {
 			domainProductPrice = translate( 'Free with your plan' );
-		} else if ( domainsWithPlansOnly && selectedSite && ! isPlan( selectedSite.plan ) ) {
+		} else if ( domainsWithPlansOnlyButNoPlan ) {
 			domainProductPrice = translate( 'Included in paid plans' );
 		}
 

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -44,7 +44,7 @@ import { domainManagementTransferIn } from 'my-sites/domains/paths';
 import { errorNotice } from 'state/notices/actions';
 import QueryProducts from 'components/data/query-products-list';
 import { isPlan } from 'lib/products-values';
-import { isDomainIncludedInPlan, isNextDomainFree } from 'lib/cart-values/cart-items';
+import { isDomainBundledWithPlan, isNextDomainFree } from 'lib/cart-values/cart-items';
 
 class TransferDomainStep extends React.Component {
 	static propTypes = {
@@ -145,7 +145,7 @@ class TransferDomainStep extends React.Component {
 			this.props.currencyCode
 		);
 
-		if ( isNextDomainFree( cart ) || isDomainIncludedInPlan( cart, searchQuery ) ) {
+		if ( isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, searchQuery ) ) {
 			domainProductPrice = translate( 'Free with your plan' );
 		} else if ( domainsWithPlansOnly && ! isPlan( selectedSite.plan ) ) {
 			domainProductPrice = translate( 'Included in paid plans' );

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -924,8 +924,10 @@ export function isNextDomainFree( cart ) {
 	return !! ( cart && cart.next_domain_is_free );
 }
 
-export function isDomainIncludedInPlan( cart, domain ) {
-	return toLower( domain ) === toLower( get( cart, 'included_domain', '' ) );
+export function isDomainBundledWithPlan( cart, domain ) {
+	const bundledDomain = get( cart, 'bundled_domain', '' );
+
+	return '' !== bundledDomain && toLower( domain ) === toLower( get( cart, 'bundled_domain', '' ) );
 }
 
 export function isDomainBeingUsedForPlan( cart, domain ) {

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import update from 'immutability-helper';
 import {
 	assign,
@@ -19,6 +18,7 @@ import {
 	merge,
 	reject,
 	some,
+	toLower,
 	uniq,
 } from 'lodash';
 
@@ -922,6 +922,10 @@ export function getIncludedDomain( cartItem ) {
 
 export function isNextDomainFree( cart ) {
 	return !! ( cart && cart.next_domain_is_free );
+}
+
+export function isDomainIncludedInPlan( cart, domain ) {
+	return toLower( domain ) === toLower( get( cart, 'included_domain', '' ) );
 }
 
 export function isDomainBeingUsedForPlan( cart, domain ) {

--- a/client/lib/cart-values/schema.json
+++ b/client/lib/cart-values/schema.json
@@ -15,7 +15,7 @@
 		"temporary": { "type": "boolean" },
 		"currency": { "type": "string" },
 		"coupon": { "type": "string" },
-		"included_domain": { "type": "string" },
+		"bundled_domain": { "type": "string" },
 		"is_coupon_applied": { "type": "boolean" },
 		"has_bundle_credit": { "type": "boolean" },
 		"next_domain_is_free": { "type": "boolean" },

--- a/client/lib/cart-values/schema.json
+++ b/client/lib/cart-values/schema.json
@@ -15,6 +15,7 @@
 		"temporary": { "type": "boolean" },
 		"currency": { "type": "string" },
 		"coupon": { "type": "string" },
+		"included_domain": { "type": "string" },
 		"is_coupon_applied": { "type": "boolean" },
 		"has_bundle_credit": { "type": "boolean" },
 		"next_domain_is_free": { "type": "boolean" },


### PR DESCRIPTION
It's confusing when we only display the transfer price but then end up adding a plan to the cart. Show "Included in Plan" in this case, and show "free with your plan" when bundle credit still not used.

Test:
- Go to a site that has unused bundle credit
- Go to transfer screen
- See "Free with your plan"
-----------------
- Go to a site that doesn't have a plan but it's not under DWPO
- Go to transfer screen
- See regular price when you input a domain
-----------------
- Go to a site that doesn't have a plan and has DWPO
- Go to transfer screen
- See "Included in paid plans"

Dependency: D13062-code