### PR TITLE
 TinyMCE: Load skin files from a new, versioned URL structure

### DIFF
--- a/client/components/tinymce/README.md
+++ b/client/components/tinymce/README.md
@@ -15,8 +15,8 @@ update the TinyMCE skin files pulled from the WP.com CDN.  Here's how:
 ```sh
 export TINYMCE_VERSION=4.x.x # this is the NEW TinyMCE version
 export SANDBOX=your.sandbox.wordpress.com
-ssh $SANDBOX mkdir -p ~/public_html/wp-content/tinymce-assets/$TINYMCE_VERSION/skins/
-scp -r node_modules/tinymce/skins/lightgray/ $SANDBOX:~/public_html/wp-content/tinymce-assets/$TINYMCE_VERSION/skins/
+ssh $SANDBOX mkdir -p public_html/wp-content/tinymce-assets/$TINYMCE_VERSION/skins/
+scp -r node_modules/tinymce/skins/lightgray/ $SANDBOX:public_html/wp-content/tinymce-assets/$TINYMCE_VERSION/skins/
 ```
 
 - Make sure the Calypso editor is loading `skin.min.css` and `content.min.css`

--- a/client/components/tinymce/README.md
+++ b/client/components/tinymce/README.md
@@ -3,6 +3,31 @@ TinyMCE
 
 The `<TinyMCE />` React component is a wrapper around the [TinyMCE](http://www.tinymce.com/) WYWIWYG editor. This folder also contains all of the TinyMCE plugins currently in use by the Calypso project. TinyMCE is relied upon by the editor page, and its implementation is heavily influenced by its usage there. Many plugins and styles have been adapted for use in Calypso from the core WordPress project.
 
+## Upgrading `tinymce`
+
+When upgrading the version of `tinymce` in `package.json`, be sure to also
+update the TinyMCE skin files pulled from the WP.com CDN.  Here's how:
+
+- Point `s1.wp.com` to your WP.com sandbox
+- Upgrade the TinyMCE package in `node_modules/tinymce`
+- Copy the skin files to your WP.com sandbox:
+
+```sh
+export TINYMCE_VERSION=4.x.x # this is the NEW TinyMCE version
+export SANDBOX=your.sandbox.wordpress.com
+ssh $SANDBOX mkdir -p ~/public_html/wp-content/tinymce-assets/$TINYMCE_VERSION/skins/
+scp -r node_modules/tinymce/skins/lightgray/ $SANDBOX:~/public_html/wp-content/tinymce-assets/$TINYMCE_VERSION/skins/
+```
+
+- Make sure the Calypso editor is loading `skin.min.css` and `content.min.css`
+  from the new folder on your sandbox (the URL should look like
+  `//s1.wp.com/wp-content/tinymce-assets/4.x.x/skins/lightgray/skin.min.css`)
+- Commit and deploy the new files from your sandbox
+- Make sure the new files are available to the production CDN (to quickly
+  verify this, you can check `s0.wp.com` and `s2.wp.com` if you don't have them
+  sandboxed).
+- Now you can deploy the new version of `tinymce` in Calypso.
+
 ## Usage
 
 ```jsx

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -257,9 +257,11 @@ export default class extends React.Component {
 
 		const ltrButton = isRtl ? 'ltr,' : '';
 
+		const tinymceVersion = tinymce.majorVersion + '.' + tinymce.minorVersion;
+
 		tinymce.init( {
 			selector: '#' + this._id,
-			skin_url: '//s1.wp.com/wp-includes/js/tinymce/skins/lightgray',
+			skin_url: '//s1.wp.com/wp-content/tinymce-assets/' + tinymceVersion + '/skins/lightgray',
 			skin: 'lightgray',
 			content_css: CONTENT_CSS,
 			language: localeSlug,

--- a/client/extensions/woocommerce/components/compact-tinymce/index.js
+++ b/client/extensions/woocommerce/components/compact-tinymce/index.js
@@ -90,9 +90,11 @@ class CompactTinyMCE extends Component {
 
 		this.localize( isRtl, localeSlug );
 
+		const tinymceVersion = tinymce.majorVersion + '.' + tinymce.minorVersion;
+
 		tinymce.init( {
 			selector: '#' + this._id,
-			skin_url: '//s1.wp.com/wp-includes/js/tinymce/skins/lightgray',
+			skin_url: '//s1.wp.com/wp-content/tinymce-assets/' + tinymceVersion + '/skins/lightgray',
 			skin: 'lightgray',
 			body_class: 'description',
 			content_css: '/calypso/tinymce/skins/woocommerce/content.css',


### PR DESCRIPTION
This PR seeks to load TinyMCE "skin" files from a different URL than the main WP.com version.  This will isolate Calypso TinyMCE upgrades from core merges on WP.com.

Later on, we can revisit the way these files are served to make this a bit easier, but for now, this approach won't change the profile of network requests from Calypso, and there is documentation for future users.

See also: p7DVsv-4CT-p2

## To test

Verify that the editor is not loading any TinyMCE-related files from unversioned  WP.com-global files like `//s1.wp.com/wp-includes/js/...`:

![2018-05-09t22 34 12-0500](https://user-images.githubusercontent.com/227022/39850895-6c60e0f4-53d9-11e8-8dbb-4de6b5abba6d.png)

Verify that the editor still works and appears correctly styled.

Verify that the same approach works in the TinyMCE fields for the WooCommerce extension.