### PR TITLE
Purchases: Use siteSlug in getEditCardDetailsPath

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -194,7 +193,7 @@ class ManagePurchase extends Component {
 		}
 
 		if ( canEditPaymentDetails( purchase ) ) {
-			const path = getEditCardDetailsPath( this.props.selectedSite, purchase );
+			const path = getEditCardDetailsPath( this.props.selectedSite.slug, purchase );
 			const renewing = isRenewing( purchase );
 
 			if (
@@ -449,7 +448,7 @@ class ManagePurchase extends Component {
 			selectedSite &&
 			canEditPaymentDetails( selectedPurchase )
 		) {
-			editCardDetailsPath = getEditCardDetailsPath( selectedSite, selectedPurchase );
+			editCardDetailsPath = getEditCardDetailsPath( selectedSite.slug, selectedPurchase );
 		}
 
 		return (

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -238,7 +238,7 @@ class PurchaseMeta extends Component {
 
 		return (
 			<li>
-				<a href={ getEditCardDetailsPath( this.props.selectedSite, purchase ) }>
+				<a href={ getEditCardDetailsPath( this.props.selectedSite.slug, purchase ) }>
 					{ paymentDetails }
 				</a>
 			</li>

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -94,13 +94,13 @@ function canEditPaymentDetails( purchase ) {
 	);
 }
 
-function getEditCardDetailsPath( site, purchase ) {
+function getEditCardDetailsPath( siteSlug, purchase ) {
 	if ( isPaidWithCreditCard( purchase ) ) {
 		const { payment: { creditCard } } = purchase;
 
-		return editCardDetails( site.slug, purchase.id, creditCard.id );
+		return editCardDetails( siteSlug, purchase.id, creditCard.id );
 	}
-	return addCardDetails( site.slug, purchase.id );
+	return addCardDetails( siteSlug, purchase.id );
 }
 
 export {


### PR DESCRIPTION
Entire object is not required, only use the slug.

Foundational work for #24692 

## Testing
1. https://calypso.live/me/purchases?branch=update/purchases-edit-card-nosite
1. Open a purchase (/me/purchases/SITE_SLUG/PURCHASE_ID
1. The "Add credit card" link should work correctly
1. Add a credit card
1. Ensure links from the "payment method" and "edit payment method" work correctly
1. Remove credit card if desired

![links](https://user-images.githubusercontent.com/841763/39863267-76a36a1a-5446-11e8-954c-a9876b0d8eef.png)

