### PR TITLE
Purchases: Use redux user over legacy lib/user

### DIFF
--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -89,6 +89,7 @@ PurchasesList.propTypes = {
 	noticeType: PropTypes.string,
 	purchases: PropTypes.oneOfType( [ PropTypes.array, PropTypes.bool ] ),
 	sites: PropTypes.array.isRequired,
+	userId: PropTypes.number.isRequired,
 };
 
 export default connect( state => {
@@ -98,5 +99,6 @@ export default connect( state => {
 		isFetchingUserPurchases: isFetchingUserPurchases( state ),
 		purchases: getUserPurchases( state, userId ),
 		sites: getSites( state ),
+		userId,
 	};
 } )( localize( PurchasesList ) );

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -99,6 +99,5 @@ export default connect( state => {
 		isFetchingUserPurchases: isFetchingUserPurchases( state ),
 		purchases: getUserPurchases( state, userId ),
 		sites: getSites( state ),
-	},
-	undefined
-)( localize( PurchasesList ) );
+	};
+} )( localize( PurchasesList ) );

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -79,7 +79,7 @@ class PurchasesList extends Component {
 				<QueryUserPurchases userId={ this.props.userId } />
 				<PageViewTracker path="/me/purchases" title="Purchases" />
 				<MeSidebarNavigation />
-				<PurchasesHeader section={ 'purchases' } />
+				<PurchasesHeader section="purchases" />
 				{ content }
 			</Main>
 		);

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -3,31 +3,30 @@
 /**
  * External dependencies
  */
-
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
  */
 import CompactCard from 'components/card';
 import EmptyContent from 'components/empty-content';
+import Main from 'components/main';
+import MeSidebarNavigation from 'me/sidebar-navigation';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import PurchasesHeader from './header';
+import PurchasesSite from '../purchases-site';
+import QueryUserPurchases from 'components/data/query-user-purchases';
 import { getCurrentUserId } from 'state/current-user/selectors';
+import { getPurchasesBySite } from 'lib/purchases';
+import { getSites } from 'state/selectors';
 import {
 	getUserPurchases,
 	hasLoadedUserPurchasesFromServer,
 	isFetchingUserPurchases,
 } from 'state/purchases/selectors';
-import { getSites } from 'state/selectors';
-import { getPurchasesBySite } from 'lib/purchases';
-import Main from 'components/main';
-import MeSidebarNavigation from 'me/sidebar-navigation';
-import PurchasesHeader from './header';
-import PurchasesSite from '../purchases-site';
-import QueryUserPurchases from 'components/data/query-user-purchases';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 class PurchasesList extends Component {
 	isDataLoading() {

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -14,6 +14,7 @@ import React, { Component } from 'react';
  */
 import CompactCard from 'components/card';
 import EmptyContent from 'components/empty-content';
+import { getCurrentUserId } from 'state/current-user/selectors';
 import {
 	getUserPurchases,
 	hasLoadedUserPurchasesFromServer,
@@ -26,8 +27,6 @@ import MeSidebarNavigation from 'me/sidebar-navigation';
 import PurchasesHeader from './header';
 import PurchasesSite from '../purchases-site';
 import QueryUserPurchases from 'components/data/query-user-purchases';
-import userFactory from 'lib/user';
-const user = userFactory();
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 class PurchasesList extends Component {
@@ -77,10 +76,10 @@ class PurchasesList extends Component {
 
 		return (
 			<Main className="purchases-list">
+				<QueryUserPurchases userId={ this.props.userId } />
 				<PageViewTracker path="/me/purchases" title="Purchases" />
 				<MeSidebarNavigation />
 				<PurchasesHeader section={ 'purchases' } />
-				<QueryUserPurchases userId={ user.get().ID } />
 				{ content }
 			</Main>
 		);
@@ -93,12 +92,13 @@ PurchasesList.propTypes = {
 	sites: PropTypes.array.isRequired,
 };
 
-export default connect(
-	state => ( {
-		purchases: getUserPurchases( state, user.get().ID ),
+export default connect( state => {
+	const userId = getCurrentUserId( state );
+	return {
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		isFetchingUserPurchases: isFetchingUserPurchases( state ),
+		purchases: getUserPurchases( state, userId ),
 		sites: getSites( state ),
-	} ),
+	},
 	undefined
 )( localize( PurchasesList ) );


### PR DESCRIPTION
Includes some cleanup as well:

- Use redux current user over legacy lib/user store
- Remove redundant connect undefined actionCreators
- Remove braces from string prop
- Sort imports

## Testing
- https://calypso.live/me/purchases?branch=update/purchase-user-id-redux
- No errors, everything continues to work as expected.