### PR TITLE
Kracken: Fix the exact match filter to pass the correct query param

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -211,7 +211,7 @@ class RegisterDomainStep extends React.Component {
 		return {
 			includeDashes: false,
 			maxCharacters: '',
-			showExactMatchesOnly: false,
+			exactSldMatchesOnly: false,
 			tlds: [],
 		};
 	}

--- a/client/components/domains/search-filters/index.jsx
+++ b/client/components/domains/search-filters/index.jsx
@@ -18,7 +18,7 @@ export default class SearchFilters extends Component {
 		filters: PropTypes.shape( {
 			includeDashes: PropTypes.bool,
 			maxCharacters: PropTypes.string,
-			showExactMatchesOnly: PropTypes.bool,
+			exactSldMatchesOnly: PropTypes.bool,
 			tlds: PropTypes.arrayOf( PropTypes.string ),
 		} ).isRequired,
 		availableTlds: PropTypes.arrayOf( PropTypes.string ),
@@ -48,7 +48,7 @@ export default class SearchFilters extends Component {
 					{ ...pick( this.props.filters, [
 						'includeDashes',
 						'maxCharacters',
-						'showExactMatchesOnly',
+						'exactSldMatchesOnly',
 					] ) }
 					onChange={ this.updateFilterValues }
 					{ ...pick( this.props, [ 'onFiltersReset', 'onFiltersSubmit' ] ) }

--- a/client/components/domains/search-filters/more-filters.jsx
+++ b/client/components/domains/search-filters/more-filters.jsx
@@ -27,7 +27,7 @@ export class MoreFiltersControl extends Component {
 		onChange: PropTypes.func.isRequired,
 		onFiltersReset: PropTypes.func.isRequired,
 		onFiltersSubmit: PropTypes.func.isRequired,
-		showExactMatchesOnly: PropTypes.bool.isRequired,
+		exactSldMatchesOnly: PropTypes.bool.isRequired,
 	};
 
 	state = {
@@ -44,7 +44,7 @@ export class MoreFiltersControl extends Component {
 	getFiltercounts() {
 		return (
 			( this.props.includeDashes && 1 ) +
-			( this.props.showExactMatchesOnly && 1 ) +
+			( this.props.exactSldMatchesOnly && 1 ) +
 			( this.props.maxCharacters !== '' && 1 )
 		);
 	}
@@ -80,7 +80,7 @@ export class MoreFiltersControl extends Component {
 	handleFiltersReset = () => {
 		this.setState( { showOverallValidationError: false }, () => {
 			this.togglePopover();
-			this.props.onFiltersReset( 'includeDashes', 'maxCharacters', 'showExactMatchesOnly' );
+			this.props.onFiltersReset( 'includeDashes', 'maxCharacters', 'exactSldMatchesOnly' );
 		} );
 	};
 	handleFiltersSubmit = () => {
@@ -116,7 +116,7 @@ export class MoreFiltersControl extends Component {
 	}
 
 	renderPopover() {
-		const { includeDashes, maxCharacters, showExactMatchesOnly, translate } = this.props;
+		const { includeDashes, maxCharacters, exactSldMatchesOnly, translate } = this.props;
 
 		return (
 			<Popover
@@ -153,11 +153,11 @@ export class MoreFiltersControl extends Component {
 					>
 						<FormInputCheckbox
 							className="search-filters__checkbox"
-							checked={ showExactMatchesOnly }
+							checked={ exactSldMatchesOnly }
 							id="search-filters-show-exact-matches-only"
-							name="showExactMatchesOnly"
+							name="exactSldMatchesOnly"
 							onChange={ this.handleOnChange }
-							value="showExactMatchesOnly"
+							value="exactSldMatchesOnly"
 						/>
 						<span className="search-filters__checkbox-label">
 							{ translate( 'Show exact matches only' ) }


### PR DESCRIPTION
The correct suggestion API query param is called `exact_sld_matches_only`, so this PR is changing the filter name so we'll send the correct param to the suggestion endpoint.

To test apply the PR and go to http://calypso.localhost:3000/start/domains?flags=domains/kracken-ui/filters . Then try using the "Show exact matches only" filter and see if we're passing correct query param when the checkbox is enabled.

Depends on D13051-code
