### PR TITLE
Purchases: Remove getSelectedSite util

### DIFF
--- a/client/me/purchases/cancel-privacy-protection/index.jsx
+++ b/client/me/purchases/cancel-privacy-protection/index.jsx
@@ -22,7 +22,7 @@ import {
 	hasLoadedUserPurchasesFromServer,
 } from 'state/purchases/selectors';
 import { getPurchase, isDataLoading, goToManagePurchase, recordPageView } from '../utils';
-import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import { hasPrivacyProtection, isRefundable } from 'lib/purchases';
 import { isRequestingSites } from 'state/sites/selectors';
 import Main from 'components/main';
@@ -235,7 +235,7 @@ export default connect(
 		hasLoadedSites: ! isRequestingSites( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		selectedPurchase: getByPurchaseId( state, props.purchaseId ),
-		selectedSite: getSelectedSiteSelector( state ),
+		selectedSite: getSelectedSite( state ),
 	} ),
 	{ cancelPrivacyProtection }
 )( localize( CancelPrivacyProtection ) );

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -23,13 +23,7 @@ import {
 	isRefundable,
 	isSubscription,
 } from 'lib/purchases';
-import {
-	getPurchase,
-	getSelectedSite,
-	goToManagePurchase,
-	isDataLoading,
-	recordPageView,
-} from 'me/purchases/utils';
+import { getPurchase, goToManagePurchase, isDataLoading, recordPageView } from 'me/purchases/utils';
 import {
 	getByPurchaseId,
 	hasLoadedUserPurchasesFromServer,
@@ -86,7 +80,7 @@ class CancelPurchase extends React.Component {
 		}
 
 		const purchase = getPurchase( props );
-		const selectedSite = getSelectedSite( props );
+		const selectedSite = props.selectedSite;
 
 		// For domain transfers, we only allow cancel if it's also refundable
 		const isDomainTransferCancelable = isRefundable( purchase ) || ! isDomainTransfer( purchase );
@@ -96,7 +90,7 @@ class CancelPurchase extends React.Component {
 
 	redirect = props => {
 		const purchase = getPurchase( props );
-		const selectedSite = getSelectedSite( props );
+		const selectedSite = props.selectedSite;
 		let redirectPath = purchasesRoot;
 
 		if (

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -29,7 +29,7 @@ import {
 	hasLoadedUserPurchasesFromServer,
 	getIncludedDomainPurchase,
 } from 'state/purchases/selectors';
-import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import HeaderCake from 'components/header-cake';
 import { isDomainRegistration, isDomainTransfer } from 'lib/products-values';
 import { isRequestingSites } from 'state/sites/selectors';
@@ -222,6 +222,6 @@ export default connect( ( state, props ) => {
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		selectedPurchase: purchase,
 		includedDomainPurchase: getIncludedDomainPurchase( state, purchase ),
-		selectedSite: getSelectedSiteSelector( state ),
+		selectedSite: getSelectedSite( state ),
 	};
 } )( localize( CancelPurchase ) );

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -27,7 +27,7 @@ import { isDomainOnlySite as isDomainOnly } from 'state/selectors';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getName as getDomainName } from 'lib/purchases';
 import { getPurchase, isDataLoading, recordPageView } from '../utils';
-import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import { isDomainRegistration } from 'lib/products-values';
 import { isRequestingSites } from 'state/sites/selectors';
 import Main from 'components/main';
@@ -302,7 +302,7 @@ class ConfirmCancelDomain extends React.Component {
 
 export default connect(
 	( state, props ) => {
-		const selectedSite = getSelectedSiteSelector( state );
+		const selectedSite = getSelectedSite( state );
 
 		return {
 			hasLoadedSites: ! isRequestingSites( state ),

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -270,7 +270,7 @@ class ConfirmCancelDomain extends React.Component {
 					{ titles.confirmCancelDomain }
 				</HeaderCake>
 				<Card>
-					<FormSectionHeading className="is-primary">
+					<FormSectionHeading>
 						{ this.props.translate( 'Canceling %(domain)s', { args: { domain } } ) }
 					</FormSectionHeading>
 					<p>

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -47,7 +47,7 @@ import {
 } from '../utils';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getCanonicalTheme } from 'state/themes/selectors';
-import { getSelectedSite as getSelectedSiteSelector, getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isSiteAutomatedTransfer as isSiteAtomic } from 'state/selectors';
 import Gridicon from 'gridicons';
 import HeaderCake from 'components/header-cake';
@@ -483,7 +483,7 @@ export default connect( ( state, props ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	const isPurchasePlan = selectedPurchase && isPlan( selectedPurchase );
 	const isPurchaseTheme = selectedPurchase && isTheme( selectedPurchase );
-	const selectedSite = getSelectedSiteSelector( state );
+	const selectedSite = getSelectedSite( state );
 	return {
 		hasLoadedSites: ! isRequestingSites( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -42,7 +42,6 @@ import {
 	isDataLoading,
 	getEditCardDetailsPath,
 	getPurchase,
-	getSelectedSite,
 	goToList,
 	recordPageView,
 } from '../utils';
@@ -163,7 +162,7 @@ class ManagePurchase extends Component {
 			! isRenewable( purchase ) ||
 			isExpired( purchase ) ||
 			isExpiring( purchase ) ||
-			! getSelectedSite( this.props )
+			! this.props.selectedSite
 		) {
 			return null;
 		}
@@ -188,7 +187,7 @@ class ManagePurchase extends Component {
 		const purchase = getPurchase( this.props );
 		const { translate } = this.props;
 
-		if ( ! getSelectedSite( this.props ) ) {
+		if ( ! this.props.selectedSite ) {
 			return null;
 		}
 
@@ -217,7 +216,7 @@ class ManagePurchase extends Component {
 			{ id } = purchase;
 		const { translate, isAtomicSite } = this.props;
 
-		if ( ! isCancelable( purchase ) || ! getSelectedSite( this.props ) ) {
+		if ( ! isCancelable( purchase ) || ! this.props.selectedSite ) {
 			return null;
 		}
 
@@ -281,7 +280,7 @@ class ManagePurchase extends Component {
 		if (
 			isExpired( purchase ) ||
 			! hasPrivacyProtection( purchase ) ||
-			! getSelectedSite( this.props )
+			! this.props.selectedSite
 		) {
 			return null;
 		}

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -28,7 +28,7 @@ import {
 	subscribedWithinPastWeek,
 } from 'lib/purchases';
 import { isDomainTransfer } from 'lib/products-values';
-import { getPurchase, getSelectedSite } from '../utils';
+import { getPurchase } from '../utils';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import { isMonthly } from 'lib/plans/constants';
@@ -100,7 +100,7 @@ class PurchaseNotice extends Component {
 		const purchase = getPurchase( this.props );
 		const { editCardDetailsPath, translate } = this.props;
 
-		if ( ! config.isEnabled( 'upgrades/checkout' ) || ! getSelectedSite( this.props ) ) {
+		if ( ! config.isEnabled( 'upgrades/checkout' ) || ! this.props.selectedSite ) {
 			return null;
 		}
 
@@ -179,7 +179,7 @@ class PurchaseNotice extends Component {
 			isExpired( purchase ) ||
 			isOneTimePurchase( purchase ) ||
 			isIncludedWithPlan( purchase ) ||
-			! getSelectedSite( this.props )
+			! this.props.selectedSite
 		) {
 			return null;
 		}

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -42,7 +42,6 @@ import {
 	isDataLoading,
 	getEditCardDetailsPath,
 	getPurchase,
-	getSelectedSite,
 } from '../utils';
 
 class PurchaseMeta extends Component {
@@ -231,7 +230,7 @@ class PurchaseMeta extends Component {
 			! canEditPaymentDetails( purchase ) ||
 			! isPaidWithCreditCard( purchase ) ||
 			! cardProcessorSupportsUpdates( purchase ) ||
-			! getSelectedSite( this.props )
+			! this.props.selectedSite
 		) {
 			return <li>{ paymentDetails }</li>;
 		}
@@ -249,7 +248,7 @@ class PurchaseMeta extends Component {
 		const purchase = getPurchase( this.props );
 		const { translate } = this.props;
 
-		if ( getSelectedSite( this.props ) ) {
+		if ( this.props.selectedSite ) {
 			return null;
 		}
 

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -31,7 +31,7 @@ import { isMonthly } from 'lib/plans/constants';
 import { isDomainRegistration, isDomainTransfer } from 'lib/products-values';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { isRequestingSites } from 'state/sites/selectors';
-import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import { getUser } from 'state/users/selectors';
 import { managePurchase } from '../paths';
 import PaymentLogo from 'components/payment-logo';
@@ -346,7 +346,7 @@ export default connect( ( state, props ) => {
 		hasLoadedSites: ! isRequestingSites( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		selectedPurchase: purchase,
-		selectedSite: getSelectedSiteSelector( state ),
+		selectedSite: getSelectedSite( state ),
 		owner: purchase ? getUser( state, purchase.userId ) : null,
 	};
 } )( localize( PurchaseMeta ) );

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -15,7 +15,7 @@ import { clearPurchases } from 'state/purchases/actions';
 import CreditCardForm from 'blocks/credit-card-form';
 import CreditCardFormLoadingPlaceholder from 'blocks/credit-card-form/loading-placeholder';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
-import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import HeaderCake from 'components/header-cake';
 import { isDataLoading, recordPageView } from 'me/purchases/utils';
 import { isRequestingSites } from 'state/sites/selectors';
@@ -84,7 +84,7 @@ const mapStateToProps = ( state, { purchaseId } ) => {
 		hasLoadedSites: ! isRequestingSites( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		selectedPurchase: getByPurchaseId( state, purchaseId ),
-		selectedSite: getSelectedSiteSelector( state ),
+		selectedSite: getSelectedSite( state ),
 	};
 };
 

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -15,7 +15,7 @@ import { clearPurchases } from 'state/purchases/actions';
 import CreditCardForm from 'blocks/credit-card-form';
 import CreditCardFormLoadingPlaceholder from 'blocks/credit-card-form/loading-placeholder';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
-import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import { getStoredCardById, hasLoadedStoredCardsFromServer } from 'state/stored-cards/selectors';
 import HeaderCake from 'components/header-cake';
 import { isDataLoading, recordPageView } from 'me/purchases/utils';
@@ -93,7 +93,7 @@ const mapStateToProps = ( state, { cardId, purchaseId } ) => {
 		hasLoadedStoredCardsFromServer: hasLoadedStoredCardsFromServer( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		selectedPurchase: getByPurchaseId( state, purchaseId ),
-		selectedSite: getSelectedSiteSelector( state ),
+		selectedSite: getSelectedSite( state ),
 	};
 };
 

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -92,7 +92,6 @@ function getEditCardDetailsPath( siteSlug, purchase ) {
 
 export {
 	getPurchase,
-	getSelectedSite,
 	goToList,
 	goToManagePurchase,
 	isDataLoading,


### PR DESCRIPTION
Remove export. This allows a less invasive change as it can continue to be used internally in the utils module. Internal functions depending on `getSelectedSite` are being removed (#24799) and the function can be removed in a follow-up.

Replace usage with direct property access.
Remove selector (of the same name) aliases.

The implementation is: https://github.com/Automattic/wp-calypso/blob/96c675458281367692181270b1284e22a008b4c0/client/me/purchases/utils.js#L33-L35

Trivially replace with property access.

Foundational work for #24692

I also noticed a redundant class that is an eslint error, I've removed that. Confirm no visual differences on `/me/purchases/:site/:purchaseId/confirm-cancel-domain`. I don't know how to navigate to this route. I opened `/me/purchases`, viewed a domain purchase, and added confirm-cancel-domain to the path. (part of #24504)

## Screens

### Before (`is-primary`)

![before](https://user-images.githubusercontent.com/841763/39910787-1c15d1ce-54f9-11e8-863a-c67426649c24.png)

### After (removed)

![after](https://user-images.githubusercontent.com/841763/39910790-1f0b9198-54f9-11e8-9a9f-fb53a386ab25.png)

## Testing
1. https://calypso.live/me/purchases?branch=remove/purchases-getselectedsite-util
1. Smoke test
1. Verify that the replacement is correct:
   ```js
   getSelectedSite( arg ) // becomes
   arg.selectedSite
   ```
  