### PR TITLE
Purchases: Remove bad semicolon

### DIFF
--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -255,7 +255,6 @@ class ConfirmCancelDomain extends React.Component {
 						purchaseId={ this.props.purchaseId }
 						selectedSite={ this.props.selectedSite }
 					/>
-					;
 				</div>
 			);
 		}


### PR DESCRIPTION
The placeholder at /me/purchases/:site/:purchaseId/confirm-cancel-domain contains a bad semicolon in HTML.

Remove it.

## Screens

### Before

(Note `;` in bottom left)

![before](https://user-images.githubusercontent.com/841763/39868398-abc953a4-5459-11e8-826d-e8f5ca7e29f6.gif)

### After

Removed:

![after](https://user-images.githubusercontent.com/841763/39868402-ae49311c-5459-11e8-9e3c-8356039cab8b.gif)

## Testing
1. Visit the path and verify that the semicolon placeholder is removed. No other changes.

Note: I don't know how to actually navigate to this route. I opened `/me/purchases`, viewed a purchase, and added `confirm-cancel-domain` to the path.