### PR TITLE
Post Editor: remove PostEditStore.isNew() usages

### DIFF
--- a/client/lib/posts/test/post-edit-store.js
+++ b/client/lib/posts/test/post-edit-store.js
@@ -65,22 +65,17 @@ describe( 'post-edit-store', () => {
 		assert( PostEditStore.getSavedPost().site_ID === siteId );
 		const post = PostEditStore.get();
 		assert( post.status === 'draft' );
-		assert( PostEditStore.isNew() );
 	} );
 
-	test( 'initialize existing post', () => {
-		const siteId = 12,
-			postId = 345;
-
+	test( 'reset the currently edited post and prepare to edit a new one', () => {
 		dispatcherCallback( {
 			action: {
 				type: 'START_EDITING_POST',
-				siteId: siteId,
-				postId: postId,
 			},
 		} );
 
-		assert( ! PostEditStore.isNew() );
+		assert( PostEditStore.getSavedPost() == null );
+		assert( PostEditStore.isLoading() );
 	} );
 
 	test( 'sets parent_id properly', () => {
@@ -207,7 +202,7 @@ describe( 'post-edit-store', () => {
 			},
 		} );
 
-		assert( PostEditStore.isNew() );
+		assert( PostEditStore.getSavedPost().ID === undefined );
 		assert( PostEditStore.getSavedPost().title === '' );
 		assert( PostEditStore.get().title === postEdits.title );
 		assert( PostEditStore.get().content === postEdits.content );
@@ -271,6 +266,7 @@ describe( 'post-edit-store', () => {
 			action: {
 				type: 'RECEIVE_POST_TO_EDIT',
 				post: {
+					ID: 1234,
 					metadata: [
 						{ key: 'keepable', value: 'constvalue' },
 						{ key: 'updatable', value: 'oldvalue' },
@@ -322,6 +318,7 @@ describe( 'post-edit-store', () => {
 			action: {
 				type: 'RECEIVE_POST_TO_EDIT',
 				post: {
+					ID: 1234,
 					metadata: [ { key: 'deletable', value: 'trashvalue' } ],
 				},
 			},
@@ -361,6 +358,7 @@ describe( 'post-edit-store', () => {
 			action: {
 				type: 'RECEIVE_POST_TO_EDIT',
 				post: {
+					ID: 1234,
 					metadata: [
 						{ key: 'keepable', value: 'constvalue' },
 						{ key: 'phoenixable', value: 'fawkes' },
@@ -406,11 +404,12 @@ describe( 'post-edit-store', () => {
 	} );
 
 	test( 'reset post after saving an edit', () => {
-		const siteId = 1234,
-			postEdits = {
-				title: 'hello, world!',
-				content: 'initial edit',
-			};
+		const siteId = 1234;
+		const postId = 5678;
+		const postEdits = {
+			title: 'hello, world!',
+			content: 'initial edit',
+		};
 
 		dispatcherCallback( {
 			action: {
@@ -431,11 +430,11 @@ describe( 'post-edit-store', () => {
 		dispatcherCallback( {
 			action: {
 				type: 'RECEIVE_POST_BEING_EDITED',
-				post: assign( { ID: 1234 }, postEdits ),
+				post: assign( { ID: postId }, postEdits ),
 			},
 		} );
 
-		assert( PostEditStore.isNew() === false );
+		assert( PostEditStore.getSavedPost().ID === postId );
 		assert( PostEditStore.getSavedPost().title === postEdits.title );
 		assert( PostEditStore.getSavedPost().content === postEdits.content );
 		assert( PostEditStore.get().title === postEdits.title );

--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -29,7 +29,6 @@ import { isSingleUserSite } from 'state/sites/selectors';
 
 class EditorActionBar extends Component {
 	static propTypes = {
-		isNew: PropTypes.bool,
 		savedPost: PropTypes.object,
 		siteId: PropTypes.number,
 		multiUserSite: PropTypes.bool,
@@ -71,9 +70,7 @@ class EditorActionBar extends Component {
 					<EditorStatusLabel post={ this.props.savedPost } advancedStatus />
 				</div>
 				<div className="editor-action-bar__cell is-center">
-					{ multiUserSite && (
-						<AsyncLoad require="post-editor/editor-author" isNew={ this.props.isNew } />
-					) }
+					{ multiUserSite && <AsyncLoad require="post-editor/editor-author" /> }
 				</div>
 				<div className="editor-action-bar__cell is-right">
 					{ showSticky && <EditorSticky /> }

--- a/client/post-editor/editor-author/index.jsx
+++ b/client/post-editor/editor-author/index.jsx
@@ -18,7 +18,7 @@ import AuthorSelector from 'blocks/author-selector';
 import { hasTouch } from 'lib/touch-detect';
 import * as stats from 'lib/posts/stats';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditorPostId, isEditorNewPost } from 'state/ui/editor/selectors';
 import { getSite } from 'state/sites/selectors';
 import { getEditedPost } from 'state/posts/selectors';
 import { editPost } from 'state/posts/actions';
@@ -26,7 +26,9 @@ import { getCurrentUser } from 'state/current-user/selectors';
 
 export class EditorAuthor extends Component {
 	static propTypes = {
+		site: PropTypes.object,
 		post: PropTypes.object,
+		author: PropTypes.object,
 		isNew: PropTypes.bool,
 	};
 
@@ -99,12 +101,13 @@ export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
 		const postId = getEditorPostId( state );
+		const isNew = isEditorNewPost( state );
 
 		const site = getSite( state, siteId );
 		const post = getEditedPost( state, siteId, postId );
 		const author = get( post, 'author', getCurrentUser( state ) );
 
-		return { site, post, author };
+		return { site, post, author, isNew };
 	},
 	{ editPost }
 )( localize( EditorAuthor ) );

--- a/client/post-editor/editor-discussion/index.jsx
+++ b/client/post-editor/editor-discussion/index.jsx
@@ -19,7 +19,7 @@ import InfoPopover from 'components/info-popover';
 import { recordEvent, recordStat } from 'lib/posts/stats';
 import { editPost } from 'state/posts/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditorPostId, isEditorNewPost } from 'state/ui/editor/selectors';
 import { getSite } from 'state/sites/selectors';
 import { getEditedPost } from 'state/posts/selectors';
 
@@ -138,11 +138,11 @@ export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
 		const postId = getEditorPostId( state );
+		const isNew = isEditorNewPost( state );
+		const site = getSite( state, siteId );
+		const post = getEditedPost( state, siteId, postId );
 
-		return {
-			site: getSite( state, siteId ),
-			post: getEditedPost( state, siteId, postId ),
-		};
+		return { site, post, isNew };
 	},
 	{ editPost }
 )( localize( EditorDiscussion ) );

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -79,7 +79,6 @@ class EditorDrawer extends Component {
 		post: PropTypes.object,
 		canJetpackUseTaxonomies: PropTypes.bool,
 		typeObject: PropTypes.object,
-		isNew: PropTypes.bool,
 		type: PropTypes.string,
 		setPostDate: PropTypes.func,
 		onSave: PropTypes.func,
@@ -200,7 +199,7 @@ class EditorDrawer extends Component {
 
 		return (
 			<AccordionSection>
-				<AsyncLoad require="post-editor/editor-discussion" isNew={ this.props.isNew } />
+				<AsyncLoad require="post-editor/editor-discussion" />
 			</AccordionSection>
 		);
 	}

--- a/client/post-editor/editor-sidebar/index.jsx
+++ b/client/post-editor/editor-sidebar/index.jsx
@@ -19,7 +19,6 @@ export class EditorSidebar extends Component {
 		// passed props
 		savedPost: PropTypes.object,
 		post: PropTypes.object,
-		isNew: PropTypes.bool,
 		onSave: PropTypes.func,
 		onPublish: PropTypes.func,
 		onTrashingPost: PropTypes.func,
@@ -32,7 +31,6 @@ export class EditorSidebar extends Component {
 
 	render() {
 		const {
-			isNew,
 			onTrashingPost,
 			onPublish,
 			onSave,
@@ -47,12 +45,11 @@ export class EditorSidebar extends Component {
 		return (
 			<div className="editor-sidebar">
 				<EditorSidebarHeader />
-				<EditorActionBar isNew={ isNew } savedPost={ savedPost } />
+				<EditorActionBar savedPost={ savedPost } />
 				<EditorDrawer
 					site={ site }
 					savedPost={ savedPost }
 					post={ post }
-					isNew={ isNew }
 					setPostDate={ setPostDate }
 					onPrivatePublish={ onPublish }
 					onSave={ onSave }

--- a/client/post-editor/test/post-editor.jsx
+++ b/client/post-editor/test/post-editor.jsx
@@ -75,24 +75,21 @@ describe( 'PostEditor', () => {
 	} );
 
 	describe( 'onEditedPostChange', () => {
-		test( 'should clear content when store state transitions to isNew()', () => {
+		test( 'should clear content when store state transitions to new post', () => {
 			const tree = renderIntoDocument( <PostEditor { ...defaultProps } /> );
 
-			const stub = sandbox.stub( PostEditStore, 'isNew' );
-			stub.returns( true );
-
+			sandbox.stub( PostEditStore, 'getSavedPost' ).returns( {} );
 			tree.editor = { setEditorContent: sandbox.spy() };
 			tree.onEditedPostChange();
 			expect( tree.editor.setEditorContent ).to.have.been.calledWith( '' );
 		} );
 
-		test( 'should not clear content when store state already isNew()', () => {
+		test( 'should not clear content when store state already has a new post', () => {
 			const tree = renderIntoDocument( <PostEditor { ...defaultProps } /> );
 
-			const stub = sandbox.stub( PostEditStore, 'isNew' );
-			stub.returns( true );
+			sandbox.stub( PostEditStore, 'getSavedPost' ).returns( {} );
 			tree.editor = { setEditorContent: sandbox.spy() };
-			tree.setState( { isNew: true } );
+			tree.setState( { savedPost: {} } );
 			tree.onEditedPostChange();
 			expect( tree.editor.setEditorContent ).to.not.have.been.called;
 		} );
@@ -100,8 +97,7 @@ describe( 'PostEditor', () => {
 		test( 'should clear content when loading', () => {
 			const tree = renderIntoDocument( <PostEditor { ...defaultProps } /> );
 
-			const stub = sandbox.stub( PostEditStore, 'isLoading' );
-			stub.returns( true );
+			sandbox.stub( PostEditStore, 'isLoading' ).returns( true );
 			tree.editor = { setEditorContent: sandbox.spy() };
 			tree.onEditedPostChange();
 			expect( tree.editor.setEditorContent ).to.have.been.calledWith( '' );
@@ -111,10 +107,7 @@ describe( 'PostEditor', () => {
 			const tree = renderIntoDocument( <PostEditor { ...defaultProps } /> );
 
 			const content = 'loaded post';
-			const stub = sandbox.stub( PostEditStore, 'get' );
-			stub.returns( {
-				content: content,
-			} );
+			sandbox.stub( PostEditStore, 'get' ).returns( { content } );
 			tree.editor = { setEditorContent: sandbox.spy() };
 			tree.setState( { isLoading: true } );
 			tree.onEditedPostChange();
@@ -125,10 +118,7 @@ describe( 'PostEditor', () => {
 			const tree = renderIntoDocument( <PostEditor { ...defaultProps } /> );
 
 			const content = 'new content';
-			const stub = sandbox.stub( PostEditStore, 'get' );
-			stub.returns( {
-				content: content,
-			} );
+			sandbox.stub( PostEditStore, 'get' ).returns( { content } );
 			tree.editor = { setEditorContent: sandbox.spy() };
 			tree.setState( { post: { content: 'old content' } } );
 			tree.onEditedPostChange();
@@ -141,12 +131,12 @@ describe( 'PostEditor', () => {
 
 			const content = 'copied content';
 			tree.setState( {
-				isNew: true,
+				savedPost: {},
 				hasContent: true,
 				isDirty: false,
 			} );
 
-			sandbox.stub( PostEditStore, 'get' ).returns( { content: content } );
+			sandbox.stub( PostEditStore, 'get' ).returns( { content } );
 
 			tree.editor = { setEditorContent: sandbox.spy() };
 			tree.onEditedPostChange();


### PR DESCRIPTION
At most places, usages of the Flux getter `PostEditStore.isNew()` can be replaced by the Redux selector `isEditorNewPost` that returns the same value. Namely, this patch introduces the Redux selector into the following components:

- `EditorAuthor`, where it's used to show author of a new post, which is 100% certain to be "you", even if the post to edit is still loading. If the post is not new, the component displays a placeholder while loading.

- `EditorDiscussion`, where it shows the default discussion options, as determined by site settings, for a new post that doesn't have any explicit discussion options set yet.

Then we remove `isNew` prop from a few components that just pass it to children: `EditorActionBar`, `EditorDrawer`, `EditorSidebar`.

Then there are a few usages of `PostEditStore.isNew()` in the root `PostEditor` lifecycle methods that react to changes in Flux or sync Flux changes to Redux. Here we still need to retrieve the information from Flux. To achieve this, we make use of the fact that "post is new" if and only if "there is a saved post that has an ID set". New posts don't have an ID yet.