### PR TITLE
Purchases: Remove cancel navigation helper

### DIFF
--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -26,13 +26,13 @@ import HeaderCake from 'components/header-cake';
 import { isDomainOnlySite as isDomainOnly } from 'state/selectors';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getName as getDomainName } from 'lib/purchases';
-import { getPurchase, goToCancelPurchase, isDataLoading, recordPageView } from '../utils';
+import { getPurchase, isDataLoading, recordPageView } from '../utils';
 import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
 import { isDomainRegistration } from 'lib/products-values';
 import { isRequestingSites } from 'state/sites/selectors';
 import Main from 'components/main';
 import notices from 'notices';
-import { purchasesRoot } from 'me/purchases/paths';
+import { cancelPurchase, purchasesRoot } from 'me/purchases/paths';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import { receiveDeletedSite } from 'state/sites/actions';
 import { refreshSitePlans } from 'state/sites/plans/actions';
@@ -53,6 +53,7 @@ class ConfirmCancelDomain extends React.Component {
 		selectedPurchase: PropTypes.object,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 		setAllSitesSelected: PropTypes.func.isRequired,
+		siteSlug: PropTypes.string.isRequired,
 	};
 
 	state = {
@@ -94,10 +95,6 @@ class ConfirmCancelDomain extends React.Component {
 		}
 
 		return [ 'other_host', 'transfer' ].indexOf( selectedReason.value ) === -1;
-	};
-
-	goToCancelPurchase = () => {
-		goToCancelPurchase( this.props );
 	};
 
 	onSubmit = event => {
@@ -269,7 +266,9 @@ class ConfirmCancelDomain extends React.Component {
 					path="/me/purchases/:site/:purchaseId/confirm-cancel-domain"
 					title="Purchases > Confirm Cancel Domain"
 				/>
-				<HeaderCake onClick={ this.goToCancelPurchase }>{ titles.confirmCancelDomain }</HeaderCake>
+				<HeaderCake backHref={ cancelPurchase( this.props.siteSlug, this.props.purchaseId ) }>
+					{ titles.confirmCancelDomain }
+				</HeaderCake>
 				<Card>
 					<FormSectionHeading className="is-primary">
 						{ this.props.translate( 'Canceling %(domain)s', { args: { domain } } ) }

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -98,7 +98,10 @@ export function confirmCancelDomain( context, next ) {
 	setTitle( context, titles.confirmCancelDomain );
 
 	context.primary = (
-		<ConfirmCancelDomain purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
+		<ConfirmCancelDomain
+			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+			siteSlug={ context.params.site }
+		/>
 	);
 	next();
 }

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -10,13 +10,7 @@ import page from 'page';
  */
 import analytics from 'lib/analytics';
 import config from 'config';
-import {
-	addCardDetails,
-	editCardDetails,
-	cancelPurchase,
-	managePurchase,
-	purchasesRoot,
-} from './paths';
+import { addCardDetails, editCardDetails, managePurchase, purchasesRoot } from './paths';
 import {
 	isExpired,
 	isIncludedWithPlan,
@@ -32,13 +26,6 @@ function getPurchase( props ) {
 
 function getSelectedSite( props ) {
 	return props.selectedSite;
-}
-
-function goToCancelPurchase( props ) {
-	const { id } = getPurchase( props ),
-		{ slug } = getSelectedSite( props );
-
-	page( cancelPurchase( slug, id ) );
 }
 
 function goToList() {
@@ -106,7 +93,6 @@ function getEditCardDetailsPath( site, purchase ) {
 export {
 	getPurchase,
 	getSelectedSite,
-	goToCancelPurchase,
 	goToList,
 	goToManagePurchase,
 	isDataLoading,


### PR DESCRIPTION
`goToCancelPurchase` was a tricky function when refactoring. Remove it for a simpler, clearer alternative.

Accepts props object.
Uses `page()` to navigate elsewhere.

It was only used in one location, as the `onClick` handler for a `HeaderCake`. A simpler alternative is to just pass the desired url as the `backHref` prop on the `HeaderCake`, which is done in this PR.

![backlink](https://user-images.githubusercontent.com/841763/39870435-a83a3598-5461-11e8-82d5-7ea6a4d5c43c.png)

Foundational work for #24692

## Testing
1. https://calypso.live/me/purchases?branch=remove/purchases-go-to-cancel-purchase
1. You need to hit `/me/purchases/:site/:purchaseId/confirm-cancel-domain`. I don't know how to  navigate to this route. I opened `/me/purchases`, viewed a purchase, and added `confirm-cancel-domain` to the path.
1. Ensure the `<- Back` link continues to work as expected.
1. Verify behavior remains unchanged.