### PR TITLE
Reader Streams: fix dismissPost, forgot about it during reduxification

### DIFF
--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -15,17 +15,17 @@ import Gridicon from 'gridicons';
 import { RelatedPostCard } from 'blocks/reader-related-card';
 import { recordAction, recordTrackForPost } from 'reader/stats';
 import Button from 'components/button';
-import { dismissPost } from 'lib/feed-stream-store/actions';
+import { dismissPost } from 'state/reader/streams/actions';
+import { keyForPost } from 'reader/post-key';
 import QueryReaderPost from 'components/data/query-reader-post';
 import { getPostsByKeys } from 'state/reader/posts/selectors';
 
-function dismissRecommendation( uiIndex, storeId, post ) {
+function dismissPostAnalytics( uiIndex, storeId, post ) {
 	recordTrackForPost( 'calypso_reader_recommended_post_dismissed', post, {
 		recommendation_source: 'in-stream',
 		ui_position: uiIndex,
 	} );
 	recordAction( 'in_stream_rec_dismiss' );
-	dismissPost( storeId, post );
 }
 
 function handleSiteClick( uiIndex, post ) {
@@ -75,7 +75,13 @@ export class RecommendedPosts extends React.PureComponent {
 									<Button
 										borderless
 										title={ this.props.translate( 'Dismiss this recommendation' ) }
-										onClick={ partial( dismissRecommendation, uiIndex, this.props.storeId, post ) }
+										onClick={ () => {
+											dismissPostAnalytics( uiIndex, this.props.streamKey, post );
+											this.props.dismissPost( {
+												streamKey: this.props.streamKey,
+												postKey: keyForPost( post ),
+											} );
+										} }
 									>
 										<Gridicon icon="cross" size={ 14 } />
 									</Button>
@@ -95,6 +101,9 @@ export class RecommendedPosts extends React.PureComponent {
 	}
 }
 
-export default connect( ( state, ownProps ) => ( {
-	posts: getPostsByKeys( state, ownProps.recommendations ),
-} ) )( localize( RecommendedPosts ) );
+export default connect(
+	( state, ownProps ) => ( {
+		posts: getPostsByKeys( state, ownProps.recommendations ),
+	} ),
+	{ dismissPost }
+)( localize( RecommendedPosts ) );

--- a/client/state/reader/streams/actions.js
+++ b/client/state/reader/streams/actions.js
@@ -16,6 +16,7 @@ import {
 } from 'state/action-types';
 import { getReaderStream as getStream } from 'state/selectors';
 import { getStreamType } from 'reader/utils';
+import wpcom from 'lib/wp';
 
 /**
  * Fetch posts into a stream
@@ -105,9 +106,14 @@ export function fillGap( { streamKey, gap } ) {
 	} );
 }
 
-export function dismissPost( { streamKey, postId } ) {
+export const dismissPost = ( { streamKey, postKey } ) => {
+	wpcom
+		.undocumented()
+		.me()
+		.dismissSite( postKey.blogId );
+
 	return {
 		type: READER_STREAMS_DISMISS_POST,
-		payload: { streamKey, postId },
+		payload: { streamKey, postKey },
 	};
-}
+};

--- a/client/state/reader/streams/reducer.js
+++ b/client/state/reader/streams/reducer.js
@@ -18,6 +18,7 @@ import {
 	READER_STREAMS_SELECT_NEXT_ITEM,
 	READER_STREAMS_SELECT_PREV_ITEM,
 	READER_STREAMS_SHOW_UPDATES,
+	READER_STREAMS_DISMISS_POST,
 } from 'state/action-types';
 import { keysAreEqual } from 'reader/post-key';
 
@@ -25,9 +26,12 @@ import { keysAreEqual } from 'reader/post-key';
  * Contains a list of post-keys representing the items of a stream.
  */
 export const items = ( state = [], action ) => {
+	let streamItems;
+
 	switch ( action.type ) {
 		case READER_STREAMS_PAGE_RECEIVE:
-			const { streamItems, gap } = action.payload;
+			const { gap } = action.payload;
+			streamItems = action.payload.streamItems;
 
 			if ( gap ) {
 				const beforeGap = takeWhile( state, postKey => ! keysAreEqual( postKey, gap ) );
@@ -57,6 +61,18 @@ export const items = ( state = [], action ) => {
 
 		case READER_STREAMS_SHOW_UPDATES:
 			return [ ...action.payload.items, ...state ];
+		case READER_STREAMS_DISMISS_POST: {
+			const postKey = action.payload.postKey;
+			const indexToRemove = findIndex( state, item => keysAreEqual( item, postKey ) );
+
+			if ( indexToRemove === -1 ) {
+				return state;
+			}
+
+			const newState = [ ...state ];
+			newState[ indexToRemove ] = newState.pop(); // set the dismissed post location to the last item from the recs stream
+			return newState;
+		}
 	}
 	return state;
 };

--- a/client/state/reader/streams/test/reducer.js
+++ b/client/state/reader/streams/test/reducer.js
@@ -15,6 +15,7 @@ import {
 	selectNextItem,
 	selectPrevItem,
 	requestPage,
+	dismissPost,
 } from '../actions';
 import {
 	items,
@@ -27,6 +28,13 @@ import {
 } from '../reducer';
 
 jest.mock( 'lib/warn', () => () => {} );
+jest.mock( 'lib/wp', () => ( {
+	undocumented: () => ( {
+		me: () => ( {
+			dismissSite: () => {},
+		} ),
+	} ),
+} ) );
 
 const TIME1 = '2018-01-01T00:00:00.000Z';
 const TIME2 = '2018-01-02T00:00:00.000Z';
@@ -53,6 +61,15 @@ describe( 'streams.items reducer', () => {
 		const nextState = items( prevState, action );
 
 		expect( nextState ).toEqual( [ time2PostKey, time1PostKey ] );
+	} );
+
+	it( 'should remove a dismissed post and replace it with the last item', () => {
+		const lastKey = { ...time2PostKey, feedId: 42 };
+		const prevState = deepfreeze( [ time1PostKey, time2PostKey, lastKey ] );
+		const action = dismissPost( { postKey: time1PostKey } );
+		const nextState = items( prevState, action );
+
+		expect( nextState ).toEqual( [ lastKey, time2PostKey ] );
 	} );
 } );
 


### PR DESCRIPTION
After merging Reader Streams Reduxification PR I realized that I forgot to implement one action: `dismissPost`.  We can either deploy https://github.com/Automattic/wp-calypso/pull/24796 to revert, or here is a working implementation in redux land.

It has similar characteristics to the flux version, except this one has a unit test:

- in case of an error, it silently fails the api request but still hides it from the stream
- it uses `wpcom` instead of data-layer
- it replaces the dimissed post with the last one in the stream (which the user likely hasn't seen yet).

**to test**
- scroll through your following stream and until you see a rec. try dismissing it. this should work and the network request should succeed
- do the same thing but offline. there should be no error displayed to the user, but the post should still be dismissed in the ui.