### PR TITLE
Purchases: Remove goToManagePurchase util

### DIFF
--- a/client/me/purchases/cancel-privacy-protection/index.jsx
+++ b/client/me/purchases/cancel-privacy-protection/index.jsx
@@ -21,14 +21,14 @@ import {
 	getPurchasesError,
 	hasLoadedUserPurchasesFromServer,
 } from 'state/purchases/selectors';
-import { getPurchase, isDataLoading, goToManagePurchase, recordPageView } from '../utils';
+import { getPurchase, isDataLoading, recordPageView } from '../utils';
 import { getSelectedSite } from 'state/ui/selectors';
 import { hasPrivacyProtection, isRefundable } from 'lib/purchases';
 import { isRequestingSites } from 'state/sites/selectors';
 import Main from 'components/main';
 import notices from 'notices';
 import Notice from 'components/notice';
-import { managePurchase, purchasesRoot } from '../paths';
+import { managePurchase, purchasesRoot } from 'me/purchases/paths';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import titles from 'me/purchases/titles';
 import userFactory from 'lib/user';
@@ -41,8 +41,10 @@ class CancelPrivacyProtection extends Component {
 	static propTypes = {
 		hasLoadedSites: PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
+		purchaseId: PropTypes.number.isRequired,
 		selectedPurchase: PropTypes.object,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
+		siteSlug: PropTypes.string.isRequired,
 	};
 
 	static initialState = {
@@ -210,7 +212,7 @@ class CancelPrivacyProtection extends Component {
 					title="Purchases > Cancel Privacy Protection"
 				/>
 				<QueryUserPurchases userId={ user.get().ID } />
-				<HeaderCake onClick={ goToManagePurchase.bind( null, this.props ) }>
+				<HeaderCake backHref={ managePurchase( this.props.siteSlug, this.props.purchaseId ) }>
 					{ titles.cancelPrivacyProtection }
 				</HeaderCake>
 				{ notice }

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -23,7 +23,7 @@ import {
 	isRefundable,
 	isSubscription,
 } from 'lib/purchases';
-import { getPurchase, goToManagePurchase, isDataLoading, recordPageView } from 'me/purchases/utils';
+import { getPurchase, isDataLoading, recordPageView } from 'me/purchases/utils';
 import {
 	getByPurchaseId,
 	hasLoadedUserPurchasesFromServer,
@@ -34,7 +34,7 @@ import HeaderCake from 'components/header-cake';
 import { isDomainRegistration, isDomainTransfer } from 'lib/products-values';
 import { isRequestingSites } from 'state/sites/selectors';
 import Main from 'components/main';
-import { managePurchase, purchasesRoot } from '../paths';
+import { managePurchase, purchasesRoot } from 'me/purchases/paths';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import ProductLink from 'me/purchases/product-link';
 import titles from 'me/purchases/titles';
@@ -46,9 +46,11 @@ class CancelPurchase extends React.Component {
 	static propTypes = {
 		hasLoadedSites: PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
-		selectedPurchase: PropTypes.object,
 		includedDomainPurchase: PropTypes.object,
+		purchaseId: PropTypes.number.isRequired,
+		selectedPurchase: PropTypes.object,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
+		siteSlug: PropTypes.string.isRequired,
 	};
 
 	state = {
@@ -177,7 +179,7 @@ class CancelPurchase extends React.Component {
 
 		return (
 			<Main className="cancel-purchase">
-				<HeaderCake onClick={ goToManagePurchase.bind( null, this.props ) }>
+				<HeaderCake backHref={ managePurchase( this.props.siteSlug, this.props.purchaseId ) }>
 					{ titles.cancelPurchase }
 				</HeaderCake>
 

--- a/client/me/purchases/components/purchase-card-details/index.jsx
+++ b/client/me/purchases/components/purchase-card-details/index.jsx
@@ -11,14 +11,13 @@ import { curry } from 'lodash';
  */
 import analytics from 'lib/analytics';
 import { createCardToken } from 'lib/store-transactions';
-import { getPurchase, goToManagePurchase, isDataLoading } from 'me/purchases/utils';
+import { getPurchase, isDataLoading } from 'me/purchases/utils';
 import { managePurchase, purchasesRoot } from 'me/purchases/paths';
 
 class PurchaseCardDetails extends Component {
 	constructor( props ) {
 		super( props );
 		this.createCardToken = curry( createCardToken )( 'card_update' );
-		this.goToManagePurchase = this.goToManagePurchase.bind( this );
 		this.recordFormSubmitEvent = this.recordFormSubmitEvent.bind( this );
 		this.successCallback = this.successCallback.bind( this );
 	}
@@ -44,10 +43,6 @@ class PurchaseCardDetails extends Component {
 		return {
 			purchaseId: getPurchase( this.props ).id,
 		};
-	}
-
-	goToManagePurchase() {
-		goToManagePurchase( this.props );
 	}
 
 	recordFormSubmitEvent() {

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -89,7 +89,12 @@ export function cancelPurchase( context, next ) {
 
 	setTitle( context, titles.cancelPurchase );
 
-	context.primary = <CancelPurchase purchaseId={ parseInt( context.params.purchaseId, 10 ) } />;
+	context.primary = (
+		<CancelPurchase
+			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+			siteSlug={ context.params.site }
+		/>
+	);
 	next();
 }
 

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -57,7 +57,12 @@ export function addCardDetails( context, next ) {
 
 	setTitle( context, titles.addCardDetails );
 
-	context.primary = <AddCardDetails purchaseId={ parseInt( context.params.purchaseId, 10 ) } />;
+	context.primary = (
+		<AddCardDetails
+			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+			siteSlug={ context.params.site }
+		/>
+	);
 	next();
 }
 

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -130,6 +130,7 @@ export function editCardDetails( context, next ) {
 		<EditCardDetails
 			cardId={ context.params.cardId }
 			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+			siteSlug={ context.params.site }
 		/>
 	);
 	next();

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -74,7 +74,10 @@ export function cancelPrivacyProtection( context, next ) {
 	setTitle( context, titles.cancelPrivacyProtection );
 
 	context.primary = (
-		<CancelPrivacyProtection purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
+		<CancelPrivacyProtection
+			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+			siteSlug={ context.params.site }
+		/>
 	);
 	next();
 }

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -25,6 +24,7 @@ import QueryUserPurchases from 'components/data/query-user-purchases';
 import titles from 'me/purchases/titles';
 import userFactory from 'lib/user';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { managePurchase } from 'me/purchases/paths';
 
 const user = userFactory();
 
@@ -33,8 +33,10 @@ class AddCardDetails extends PurchaseCardDetails {
 		clearPurchases: PropTypes.func.isRequired,
 		hasLoadedSites: PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
+		purchaseId: PropTypes.number.isRequired,
 		selectedPurchase: PropTypes.object,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
+		siteSlug: PropTypes.string.isRequired,
 	};
 
 	componentWillMount() {
@@ -66,7 +68,9 @@ class AddCardDetails extends PurchaseCardDetails {
 					path="/me/purchases/:site/:purchaseId/payment/add"
 					title="Purchases > Add Card Details"
 				/>
-				<HeaderCake onClick={ this.goToManagePurchase }>{ titles.addCardDetails }</HeaderCake>
+				<HeaderCake backHref={ managePurchase( this.props.siteSlug, this.props.purchaseId ) }>
+					{ titles.addCardDetails }
+				</HeaderCake>
 
 				<CreditCardForm
 					apiParams={ this.getApiParams() }

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -27,6 +26,7 @@ import QueryUserPurchases from 'components/data/query-user-purchases';
 import titles from 'me/purchases/titles';
 import userFactory from 'lib/user';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { managePurchase } from 'me/purchases/paths';
 
 const user = userFactory();
 
@@ -37,8 +37,10 @@ class EditCardDetails extends PurchaseCardDetails {
 		hasLoadedSites: PropTypes.bool.isRequired,
 		hasLoadedStoredCardsFromServer: PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
+		purchaseId: PropTypes.number.isRequired,
 		selectedPurchase: PropTypes.object,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
+		siteSlug: PropTypes.string.isRequired,
 	};
 
 	componentWillMount() {
@@ -72,7 +74,9 @@ class EditCardDetails extends PurchaseCardDetails {
 					path="/me/purchases/:site/:purchaseId/payment/edit/:cardId"
 					title="Purchases > Edit Card Details"
 				/>
-				<HeaderCake onClick={ this.goToManagePurchase }>{ titles.editCardDetails }</HeaderCake>
+				<HeaderCake backHref={ managePurchase( this.props.siteSlug, this.props.purchaseId ) }>
+					{ titles.editCardDetails }
+				</HeaderCake>
 
 				<CreditCardForm
 					apiParams={ this.getApiParams() }

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -10,7 +10,7 @@ import page from 'page';
  */
 import analytics from 'lib/analytics';
 import config from 'config';
-import { addCardDetails, editCardDetails, managePurchase, purchasesRoot } from './paths';
+import { addCardDetails, editCardDetails, purchasesRoot } from './paths';
 import {
 	isExpired,
 	isIncludedWithPlan,
@@ -30,13 +30,6 @@ function getSelectedSite( props ) {
 
 function goToList() {
 	page( purchasesRoot );
-}
-
-function goToManagePurchase( props ) {
-	const { id } = getPurchase( props ),
-		{ slug } = getSelectedSite( props );
-
-	page( managePurchase( slug, id ) );
 }
 
 function isDataLoading( props ) {
@@ -93,7 +86,6 @@ function getEditCardDetailsPath( siteSlug, purchase ) {
 export {
 	getPurchase,
 	goToList,
-	goToManagePurchase,
 	isDataLoading,
 	recordPageView,
 	canEditPaymentDetails,

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -24,10 +24,6 @@ function getPurchase( props ) {
 	return props.selectedPurchase;
 }
 
-function getSelectedSite( props ) {
-	return props.selectedSite;
-}
-
 function goToList() {
 	page( purchasesRoot );
 }


### PR DESCRIPTION
`goToCancelPurchase` was a tricky function when refactoring. Remove it for a simpler, clearer alternative.

Accepts props object.
Uses `page()` to navigate elsewhere.

It was used as the `onClick` handler for a `HeaderCake`. A simpler alternative is to just pass the desired url as the `backHref` prop on the `HeaderCake`, which is done in this PR.

![backlink](https://user-images.githubusercontent.com/841763/39870435-a83a3598-5461-11e8-82d5-7ea6a4d5c43c.png)

Foundational work for #24692

## Testing
Ensure the `HeaderCake` back links work correctly from:

- `/me/purchases/:SITE_SLUG/:PURCHASE_ID/cancel`
- `/me/purchases/:SITE_SLUG/:PURCHASE_ID/payment/add`
- `/me/purchases/:SITE_SLUG/:PURCHASE_ID/payment/edit/:CARD_ID`
- `/me/purchases/:SITE_SLUG/:PURCHASE_ID/cancel-privacy-protection`