### PR TITLE
Simple Payments: Allow usage of different data sources in Media Library

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find, isNumber, pick, noop, get } from 'lodash';
+import { find, isNumber, pick, noop, get, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -420,7 +420,7 @@ class SimplePaymentsDialog extends Component {
 	};
 
 	getActionButtons() {
-		const { formIsValid, formIsDirty, translate } = this.props;
+		const { formIsValid, formIsDirty, translate, featuredImageId } = this.props;
 		const { activeTab, editedPaymentId, isSubmitting } = this.state;
 
 		const formCanBeSubmitted = formIsValid && formIsDirty;
@@ -450,7 +450,7 @@ class SimplePaymentsDialog extends Component {
 		// still being uploaded use strings instead (eg. 'media-41')
 		// We are relying on that here to determine if we should disable the form
 		// save button until the image is ready.
-		const isUploadingImage = ! isNumber( this.props.featuredImageId );
+		const isUploadingImage = ! isEmpty( featuredImageId ) && ! isNumber( featuredImageId );
 
 		return [
 			<Button onClick={ cancelHandler } disabled={ isSubmitting }>

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -51,6 +51,7 @@ import EmptyContent from 'components/empty-content';
 import Banner from 'components/banner';
 import config from 'config';
 import isEditedSimplePaymentsRecurring from 'state/selectors/is-edited-simple-payments-recurring';
+import { getFormValues } from 'redux-form';
 
 // Utility function for checking the state of the Payment Buttons list
 const isEmptyArray = a => Array.isArray( a ) && a.length === 0;
@@ -445,6 +446,12 @@ class SimplePaymentsDialog extends Component {
 			finishLabel = translate( 'Insert' );
 		}
 
+		// Already uploaded images have numeric ids (eg. 11) while the ones that are
+		// still being uploaded use strings instead (eg. 'media-41')
+		// We are relying on that here to determine if we should disable the form
+		// save button until the image is ready.
+		const isUploadingImage = ! isNumber( this.props.featuredImageId );
+
 		return [
 			<Button onClick={ cancelHandler } disabled={ isSubmitting }>
 				{ translate( 'Cancel' ) }
@@ -452,7 +459,7 @@ class SimplePaymentsDialog extends Component {
 			<Button
 				onClick={ finishHandler }
 				busy={ isSubmitting }
-				disabled={ isSubmitting || finishDisabled }
+				disabled={ isSubmitting || finishDisabled || isUploadingImage }
 				primary
 			>
 				{ isSubmitting ? translate( 'Saving…' ) : finishLabel }
@@ -615,5 +622,6 @@ export default connect( ( state, { siteId } ) => {
 		formIsValid: isProductFormValid( state ),
 		formIsDirty: isProductFormDirty( state ),
 		currentUserEmail: getCurrentUserEmail( state ),
+		featuredImageId: get( getFormValues( REDUX_FORM_NAME )( state ), 'featuredImageId' ),
 	};
 } )( localize( SimplePaymentsDialog ) );

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -15,16 +15,13 @@ import PropTypes from 'prop-types';
  */
 
 import AsyncLoad from 'components/async-load';
-import { getMediaItem } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import MediaActions from 'lib/media/actions';
 import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
 import EditorFeaturedImagePreviewContainer from 'post-editor/editor-featured-image/preview-container';
 import RemoveButton from 'components/remove-button';
 
 class ProductImagePicker extends Component {
 	static propTypes = {
-		featuredImage: PropTypes.object,
 		siteId: PropTypes.number,
 		translate: PropTypes.func,
 	};
@@ -34,18 +31,12 @@ class ProductImagePicker extends Component {
 	};
 
 	showMediaModal = event => {
-		const { siteId, featuredImage } = this.props;
-
 		if ( event.key && event.key !== 'Enter' ) {
 			// A11y - prevent opening Media modal with any key
 			return;
 		}
 
-		this.setState( { isSelecting: true }, () => {
-			if ( featuredImage ) {
-				MediaActions.setLibrarySelectedItems( siteId, [ featuredImage ] );
-			}
-		} );
+		this.setState( { isSelecting: true } );
 	};
 
 	setImage = value => {
@@ -135,11 +126,8 @@ class ProductImagePicker extends Component {
 	}
 }
 
-export default connect( ( state, ownProps ) => {
-	const siteId = getSelectedSiteId( state );
-
+export default connect( state => {
 	return {
-		siteId,
-		featuredImage: getMediaItem( state, siteId, ownProps.input.value ),
+		siteId: getSelectedSiteId( state ),
 	};
 } )( localize( ProductImagePicker ) );

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -126,8 +126,6 @@ class ProductImagePicker extends Component {
 	}
 }
 
-export default connect( state => {
-	return {
-		siteId: getSelectedSiteId( state ),
-	};
-} )( localize( ProductImagePicker ) );
+export default connect( state => ( { siteId: getSelectedSiteId( state ) } ) )(
+	localize( ProductImagePicker )
+);

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -93,7 +93,7 @@ class ProductImagePicker extends Component {
 				<EditorFeaturedImagePreviewContainer
 					siteId={ siteId }
 					itemId={ this.props.input.value }
-					onValueChange={ this.props.input.onChange }
+					onImageChange={ this.props.input.onChange }
 					showEditIcon
 				/>
 				<RemoveButton onRemove={ this.removeCurrentImage } />

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -19,7 +19,7 @@ import { getMediaItem } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import MediaActions from 'lib/media/actions';
 import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
-import ProductImage from './product-image';
+import EditorFeaturedImagePreviewContainer from 'post-editor/editor-featured-image/preview-container';
 import RemoveButton from 'components/remove-button';
 
 class ProductImagePicker extends Component {
@@ -90,7 +90,12 @@ class ProductImagePicker extends Component {
 				role="button"
 				tabIndex={ 0 }
 			>
-				<ProductImage siteId={ siteId } imageId={ this.props.input.value } showEditIcon />
+				<EditorFeaturedImagePreviewContainer
+					siteId={ siteId }
+					itemId={ this.props.input.value }
+					onValueChange={ this.props.input.onChange }
+					showEditIcon
+				/>
 				<RemoveButton onRemove={ this.removeCurrentImage } />
 			</div>
 		);
@@ -114,7 +119,6 @@ class ProductImagePicker extends Component {
 						enabledFilters={ [ 'images' ] }
 						visible={ isSelecting }
 						isBackdropVisible={ false }
-						disabledDataSources={ [ 'pexels', 'google_photos' ] }
 						labels={ {
 							confirm: translate( 'Add' ),
 						} }

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image.jsx
@@ -9,7 +9,6 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -18,7 +17,7 @@ import { url as mediaUrl } from 'lib/media/utils';
 import QueryMedia from 'components/data/query-media';
 import { getMediaItem } from 'state/selectors';
 
-const ProductImage = ( { siteId, imageId, image, showEditIcon } ) => {
+const ProductImage = ( { siteId, imageId, image } ) => {
 	if ( ! siteId || ! imageId ) {
 		return null;
 	}
@@ -38,7 +37,6 @@ const ProductImage = ( { siteId, imageId, image, showEditIcon } ) => {
 			<figure className="dialog__editor-simple-payments-modal-figure">
 				<img className="dialog__editor-simple-payments-modal-image" src={ url } alt="product" />
 			</figure>
-			{ showEditIcon && <Gridicon icon="pencil" className="dialog__product-image-edit-icon" /> }
 		</div>
 	);
 };

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -131,23 +131,6 @@
 		}
 	}
 
-	.dialog__product-image-edit-icon {
-		position: absolute;
-		color: $white;
-		opacity: 0.9;
-		bottom: 8px;
-		right: 8px;
-		line-height: 0;
-		padding: 4px;
-		border: none;
-		background: rgba(0, 0, 0, 0.2);
-		border-radius: 50%;
-
-		&:hover {
-			opacity: 1;
-		}
-	}
-
 	.remove-button {
 		margin-top: -7px;
 		margin-right: -7px;

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -100,8 +100,6 @@
 	}
 
 	.dialog__product-image-container {
-		width: 200px;
-		height: 200px;
 		position: relative;
 		margin-bottom: 20px;
 		margin-right: 25px;
@@ -131,11 +129,6 @@
 				box-shadow: inset 0 0 0 2px $blue-light;
 			}
 		}
-	}
-
-	.dialog__product-image {
-		max-width: 200px;
-		max-height: 200px;
 	}
 
 	.dialog__product-image-edit-icon {

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -145,9 +145,8 @@
 	}
 
 	.editor-featured-image__preview-image {
-		width: 200px;
-		height: 200px;
-		object-fit: contain;
+		max-width: 200px;
+		max-height: 200px;
 	}
 }
 

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -167,6 +167,12 @@
 	.spinner-line {
 		display: none;
 	}
+
+	.editor-featured-image__preview-image {
+		width: 200px;
+		height: 200px;
+		object-fit: contain;
+	}
 }
 
 .editor-simple-payments-modal__nudge-nudge {

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -118,6 +118,7 @@
 		background-color: $gray-light;
 		box-shadow: inset 0 0 0 1px lighten($gray, 25%);
 		font-size: 14px;
+		overflow: hidden;
 
 		&:hover {
 			cursor: pointer;
@@ -157,6 +158,14 @@
 	.remove-button {
 		margin-top: -7px;
 		margin-right: -7px;
+	}
+
+	.async-load__placeholder {
+		display: none;
+	}
+
+	.spinner-line {
+		display: none;
 	}
 }
 

--- a/client/post-editor/editor-featured-image/preview-container.jsx
+++ b/client/post-editor/editor-featured-image/preview-container.jsx
@@ -23,13 +23,13 @@ export default class extends React.Component {
 		siteId: PropTypes.number.isRequired,
 		itemId: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ).isRequired,
 		maxWidth: PropTypes.number,
-		onValueChange: PropTypes.func,
+		onImageChange: PropTypes.func,
 		showEditIcon: PropTypes.bool,
 	};
 
 	state = {
 		image: null,
-		onValueChange: noop,
+		onImageChange: noop,
 		showEditIcon: false,
 	};
 
@@ -72,11 +72,11 @@ export default class extends React.Component {
 		} );
 
 		defer( () => {
-			if ( this.props.onValueChange ) {
+			if ( this.props.onImageChange ) {
 				// When used in Simple Payments button we only want to update the
 				// ID field of parent form instead of sending post actions bellow
 				if ( image && image.ID ) {
-					this.props.onValueChange( image.ID );
+					this.props.onImageChange( image.ID );
 					MediaActions.setLibrarySelectedItems( this.props.siteId, [ image ] );
 				}
 				return;

--- a/client/post-editor/editor-featured-image/preview-container.jsx
+++ b/client/post-editor/editor-featured-image/preview-container.jsx
@@ -77,6 +77,7 @@ export default class extends React.Component {
 				// ID field of parent form instead of sending post actions bellow
 				if ( image && image.ID ) {
 					this.props.onValueChange( image.ID );
+					MediaActions.setLibrarySelectedItems( this.props.siteId, [ image ] );
 				}
 				return;
 			}

--- a/client/post-editor/editor-featured-image/preview-container.jsx
+++ b/client/post-editor/editor-featured-image/preview-container.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { defer } from 'lodash';
+import { defer, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,10 +23,14 @@ export default class extends React.Component {
 		siteId: PropTypes.number.isRequired,
 		itemId: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ).isRequired,
 		maxWidth: PropTypes.number,
+		onValueChange: PropTypes.func,
+		showEditIcon: PropTypes.bool,
 	};
 
 	state = {
 		image: null,
+		onValueChange: noop,
+		showEditIcon: false,
 	};
 
 	componentDidMount() {
@@ -68,6 +72,15 @@ export default class extends React.Component {
 		} );
 
 		defer( () => {
+			if ( this.props.onValueChange ) {
+				// When used in Simple Payments button we only want to update the
+				// ID field of parent form instead of sending post actions bellow
+				if ( image && image.ID ) {
+					this.props.onValueChange( image.ID );
+				}
+				return;
+			}
+
 			if ( image && image.ID !== this.props.itemId ) {
 				// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 				PostActions.edit( {
@@ -79,7 +92,11 @@ export default class extends React.Component {
 
 	render() {
 		return (
-			<EditorFeaturedImagePreview image={ this.state.image } maxWidth={ this.props.maxWidth } />
+			<EditorFeaturedImagePreview
+				image={ this.state.image }
+				maxWidth={ this.props.maxWidth }
+				showEditIcon
+			/>
 		);
 	}
 }

--- a/client/post-editor/editor-featured-image/preview.jsx
+++ b/client/post-editor/editor-featured-image/preview.jsx
@@ -103,7 +103,13 @@ class EditorFeaturedImagePreview extends Component {
 
 		let placeholder;
 		if ( this.state.transientSrc ) {
-			placeholder = <img src={ this.state.transientSrc } />;
+			placeholder = (
+				<img
+					src={ this.state.transientSrc }
+					className="editor-featured-image__preview-image"
+					alt="placeholder"
+				/>
+			);
 		} else {
 			placeholder = <SpinnerLine />;
 		}

--- a/client/post-editor/editor-featured-image/preview.jsx
+++ b/client/post-editor/editor-featured-image/preview.jsx
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { get, some } from 'lodash';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -23,11 +24,13 @@ class EditorFeaturedImagePreview extends Component {
 		siteId: PropTypes.number,
 		image: PropTypes.object,
 		maxWidth: PropTypes.number,
+		showEditIcon: PropTypes.bool,
 	};
 
 	static initialState = {
 		height: null,
 		transientSrc: null,
+		showEditIcon: false,
 	};
 
 	state = this.constructor.initialState;
@@ -114,6 +117,9 @@ class EditorFeaturedImagePreview extends Component {
 					onLoad={ this.clearState }
 					className="editor-featured-image__preview-image"
 				/>
+				{ this.props.showEditIcon && (
+					<Gridicon icon="pencil" className="editor-featured-image__edit-icon" />
+				) }
 			</div>
 		);
 	}

--- a/client/post-editor/editor-featured-image/style.scss
+++ b/client/post-editor/editor-featured-image/style.scss
@@ -104,3 +104,21 @@
 .editor-featured-image__preview-image {
 	display: block;
 }
+
+.editor-featured-image__preview .editor-featured-image__edit-icon {
+	position: absolute;
+	color: $white;
+	opacity: 0.9;
+	top: auto;
+	bottom: 8px;
+	right: 8px;
+	line-height: 0;
+	padding: 4px;
+	border: none;
+	background: rgba(0, 0, 0, 0.2);
+	border-radius: 50%;
+
+	&:hover {
+		opacity: 1;
+	}
+}


### PR DESCRIPTION
This is a follow up to https://github.com/Automattic/wp-calypso/pull/24659 and https://github.com/Automattic/wp-calypso/pull/24797 which enables the usage of Google Images and Free photo library with Simple Payments buttons.

Instead of using the Simple Payment's specific `ProductImage` component, this is relying on existing featured image preview from Editor, with some modifications to handle this context, in order to reuse the existing functionality as much as possible.

### Testing instructions

1. Navigate to `/post/{site}`.
2. Click on `Add` and select `Payment Button` from the dropdown menu.
3. Click on `Add New` and after that on `Add an Image`.
4. Verify that you can add images from other sources like Google photos and Free photo library (top left corner dropdown to change the images data source).
5. Verify that images persist after saving the Simple Payment.
6. Smoke test the featured image functionality in Post Editor.