### PR TITLE
Reader Conversations: prevent blank screen when pressing 'Reply'

### DIFF
--- a/client/blocks/comments/comment-edit-form.jsx
+++ b/client/blocks/comments/comment-edit-form.jsx
@@ -38,7 +38,11 @@ class PostCommentForm extends Component {
 
 	componentDidMount() {
 		// If it's a reply, give the input focus if commentText exists ( can not exist if comments are closed )
-		if ( this.props.parentCommentId && this._textareaNode ) {
+		if (
+			this.props.parentCommentId &&
+			this._textareaNode &&
+			typeof this._textareaNode.focus === 'function'
+		) {
 			this._textareaNode.focus();
 		}
 	}

--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -45,7 +45,11 @@ class PostCommentForm extends React.Component {
 
 	componentDidMount() {
 		// If it's a reply, give the input focus if commentText exists ( can not exist if comments are closed )
-		if ( this.props.parentCommentId && this._textareaNode ) {
+		if (
+			this.props.parentCommentId &&
+			this._textareaNode &&
+			typeof this._textareaNode.focus === 'function'
+		) {
 			this._textareaNode.focus();
 		}
 	}


### PR DESCRIPTION
@martinremy found that pressing reply on a Conversations thread caused a blank page to appear. 

This is because Conversations attempts to access the textarea DOM node directly, and is no longer able to now that the withUserMentions higher order component wraps it.

This is a quick fix to check whether `focus` is a function, which doesn't fix the autofocus problem, but does prevent the blank screen appearing.

### To test

Head to http://calypso.localhost:3000/read/conversations and hit 'reply' on a thread.