### PR TITLE
Comments: fix autofocus for replies

### DIFF
--- a/client/blocks/comments/comment-edit-form.jsx
+++ b/client/blocks/comments/comment-edit-form.jsx
@@ -19,6 +19,7 @@ import AutoDirection from 'components/auto-direction';
 import Notice from 'components/notice';
 import { editComment } from 'state/comments/actions';
 import { recordAction, recordGaEvent } from 'reader/stats';
+import PostCommentFormTextarea from './form-textarea';
 
 class PostCommentForm extends Component {
 	constructor( props ) {
@@ -36,17 +37,6 @@ class PostCommentForm extends Component {
 		} );
 	}
 
-	componentDidMount() {
-		// If it's a reply, give the input focus if commentText exists ( can not exist if comments are closed )
-		if (
-			this.props.parentCommentId &&
-			this._textareaNode &&
-			typeof this._textareaNode.focus === 'function'
-		) {
-			this._textareaNode.focus();
-		}
-	}
-
 	componentDidUpdate() {
 		const commentTextNode = this.refs.commentText;
 
@@ -60,10 +50,6 @@ class PostCommentForm extends Component {
 			? Math.max( commentTextNode.scrollHeight, currentHeight ) + 'px'
 			: null;
 	}
-
-	handleTextAreaNode = textareaNode => {
-		this._textareaNode = textareaNode;
-	};
 
 	handleSubmit = event => {
 		event.preventDefault();
@@ -169,6 +155,8 @@ class PostCommentForm extends Component {
 			'expanding-area': true,
 		} );
 
+		const isReply = !! this.props.parentCommentId;
+
 		// How auto expand works for the textarea is covered in this article:
 		// http://alistapart.com/article/expanding-text-areas-made-elegant
 		return (
@@ -181,14 +169,14 @@ class PostCommentForm extends Component {
 								<br />
 							</pre>
 							<AutoDirection>
-								<textarea
+								<PostCommentFormTextarea
 									value={ this.state.commentText }
-									ref={ this.handleTextAreaNode }
 									onKeyUp={ this.handleKeyUp }
 									onKeyDown={ this.handleKeyDown }
 									onFocus={ this.handleFocus }
 									onBlur={ this.handleBlur }
 									onChange={ this.handleTextChange }
+									enableAutoFocus={ isReply }
 								/>
 							</AutoDirection>
 						</div>

--- a/client/blocks/comments/form-textarea.jsx
+++ b/client/blocks/comments/form-textarea.jsx
@@ -11,7 +11,7 @@ import React from 'react';
 import withUserMentions from 'blocks/user-mentions/index';
 import { isEnabled } from 'config';
 
-// @todo Move ref forwarding to the HOC
+/* eslint-disable jsx-a11y/no-autofocus */
 const PostCommentFormTextarea = React.forwardRef( ( props, ref ) => (
 	<textarea
 		className="comments__form-textarea"
@@ -23,8 +23,10 @@ const PostCommentFormTextarea = React.forwardRef( ( props, ref ) => (
 		onFocus={ props.onFocus }
 		onBlur={ props.onBlur }
 		onChange={ props.onChange }
+		autoFocus={ props.enableAutoFocus }
 	/>
 ) );
+/* eslint-enable jsx-a11y/no-autofocus */
 
 let component = PostCommentFormTextarea;
 if ( isEnabled( 'reader/user-mention-suggestions' ) ) {

--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -43,17 +43,6 @@ class PostCommentForm extends React.Component {
 		} );
 	}
 
-	componentDidMount() {
-		// If it's a reply, give the input focus if commentText exists ( can not exist if comments are closed )
-		if (
-			this.props.parentCommentId &&
-			this._textareaNode &&
-			typeof this._textareaNode.focus === 'function'
-		) {
-			this._textareaNode.focus();
-		}
-	}
-
 	componentDidUpdate() {
 		const commentTextNode = this.refs.commentText;
 
@@ -66,10 +55,6 @@ class PostCommentForm extends React.Component {
 		commentTextNode.style.height = commentText.length
 			? Math.max( commentTextNode.scrollHeight, currentHeight ) + 'px'
 			: null;
-	}
-
-	handleTextAreaNode( textareaNode ) {
-		this._textareaNode = textareaNode;
 	}
 
 	handleSubmit( event ) {
@@ -207,6 +192,8 @@ class PostCommentForm extends React.Component {
 			'expanding-area': true,
 		} );
 
+		const isReply = !! this.props.parentCommentId;
+
 		// How auto expand works for the textarea is covered in this article:
 		// http://alistapart.com/article/expanding-text-areas-made-elegant
 		return (
@@ -223,13 +210,13 @@ class PostCommentForm extends React.Component {
 								<PostCommentFormTextarea
 									value={ this.state.commentText }
 									placeholder={ translate( 'Enter your comment here…' ) }
-									ref={ this.handleTextAreaNode }
 									onKeyUp={ this.handleKeyUp }
 									onKeyDown={ this.handleKeyDown }
 									onFocus={ this.handleFocus }
 									onBlur={ this.handleBlur }
 									onChange={ this.handleTextChange }
 									siteId={ post.site_ID }
+									enableAutoFocus={ isReply }
 								/>
 							</AutoDirection>
 						</div>


### PR DESCRIPTION
When the `withUserMentions` higher-order component was added to the comment textarea recently, the autofocus of reply boxes failed (see also https://github.com/Automattic/wp-calypso/pull/24808). The comment form component was attempting to use `focus()` on a DOM node obtained via a ref, which was no longer working because the ref wasn't forwarded all the way down to the textarea.

As a fix, I've taken a simpler approach, and started applying the `autoFocus` prop when the reply button is clicked.

`autoFocus` is discouraged by our a11y linting rules, but I feel in this case that it's appropriate - the user has taken a specific action to choose 'Reply', and then expects to immediately start on their response. It feels jarring for the caret not to be placed ready to type after Reply is pressed.

### To test

Try hitting 'Reply' in comments sections:
- under Reader full post, e.g. http://calypso.localhost:3000/read/blogs/100938468/posts/21572
- in Reader Conversations http://calypso.localhost:3000/read/conversations
- in My Site > Comments https://wordpress.com/comments/all

Ensure that the textarea is given focus when you hit Reply.