### PR TITLE
Reader: fix follow button misalignment

### DIFF
--- a/client/blocks/follow-button/style.scss
+++ b/client/blocks/follow-button/style.scss
@@ -100,8 +100,12 @@ button.follow-button {
 }
 
 .follow-button__label {
-
 	@include breakpoint( "<660px" ) {
 		display: none;
 	}
+}
+
+// Override .button style
+.button.follow-button .gridicon:not(:last-child) {
+	margin-right: 0;
 }


### PR DESCRIPTION
This style on the button component was bumping our follow button a few pixels out of place.

```
.gridicon {
  &:not(:last-child) {
    margin-right: 4px;
  }
}
```
This PR overrides the `.button` style and fixes the follow button alignment.

Before:

<img width="124" alt="screen shot 2018-05-11 at 5 56 03 pm" src="https://user-images.githubusercontent.com/17325/39909034-fa429126-5544-11e8-9bef-94e60e2b5e79.png">

After:

<img width="130" alt="screen shot 2018-05-11 at 5 54 58 pm" src="https://user-images.githubusercontent.com/17325/39909038-fef24f22-5544-11e8-8f8a-0bae649d481b.png">

### To test

Visit Manage Following http://calypso.localhost:3000/following/manage and a site stream like http://calypso.localhost:3000/read/feeds/77012965. Check the alignment of the follow button and settings button.