### PR TITLE
Post Editor: move Redux action dispatches on post load/save to lib/posts/actions

### DIFF
--- a/client/lib/posts/post-edit-store.js
+++ b/client/lib/posts/post-edit-store.js
@@ -244,11 +244,7 @@ function dispatcherCallback( payload ) {
 
 		case 'RECEIVE_POST_TO_EDIT':
 			_isLoading = false;
-			if ( action.error ) {
-				setLoadingError( action.error );
-			} else {
-				startEditing( action.site, action.post );
-			}
+			startEditing( action.site, action.post );
 			PostEditStore.emit( 'change' );
 			break;
 

--- a/client/lib/posts/test/actions.js
+++ b/client/lib/posts/test/actions.js
@@ -21,6 +21,7 @@ jest.mock( 'lib/localforage', () => require( 'lib/localforage/localforage-bypass
 jest.mock( 'lib/wp', () => require( './mocks/lib/wp' ) );
 
 jest.mock( 'lib/redux-bridge', () => ( {
+	reduxDispatch: action => action,
 	reduxGetState: () => ( { ui: { editor: { saveBlockers: [] } } } ),
 } ) );
 


### PR DESCRIPTION
When the Post Editor loads a post to edit (RECEIVE_POST_TO_EDIT) or receives a response to save request (RECEIVE_POST_BEING_EDITED) then we dispatch a few Redux actions to keep Redux in sync with Flux.

This patch moves the dispatches to the action "thunks" in `lib/posts/actions` and uses the Redux bridge to perform them. Previously they were in `PostEditor` lifecycle methods, which makes the code hard to follow and reason about. Further Redux migration will also be much easier now.

**How to test:**
There should be no changes in post editor behavior. Test the following scenarios:
1. Start editing a new draft, enter some content. Verify that it autosaves correctly, that the URL changes to one that includes the assigned post ID and that the dirty flag gets correctly updated (watch the "Save", "Saving..." and "Saved" labels in masterbar) as you modify the post.
2. Edit and existing post -- do the modifications get saved correctly?
3. Publish a post
4. Edit a post copy
