### PR TITLE
InlineHelp: Move RichResults dialog out of popover tree

### DIFF
--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -19,6 +19,8 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import getGlobalKeyboardShortcuts from 'lib/keyboard-shortcuts/global';
 import Button from 'components/button';
 import HappychatButton from 'components/happychat/button';
+import Dialog from 'components/dialog';
+import ResizableIframe from 'components/resizable-iframe';
 import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
 import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
 import AsyncLoad from 'components/async-load';
@@ -106,10 +108,25 @@ class InlineHelp extends Component {
 		this.inlineHelpToggle = node;
 	};
 
+	// @TODO: Instead of prop drilling this should be done via redux
+	setDialogState = ( { showDialog, videoLink } ) =>
+		this.setState( {
+			showDialog,
+			videoLink,
+		} );
+
+	closeDialog = () => this.setState( { showDialog: false } );
+
 	render() {
 		const { translate } = this.props;
-		const { showInlineHelp } = this.state;
+		const { showInlineHelp, showDialog, videoLink } = this.state;
 		const inlineHelpButtonClasses = { 'inline-help__button': true, 'is-active': showInlineHelp };
+
+		/* @TODO: This class is not valid and this tricks the linter
+		 		  fix this class and fix the linter to catch similar instances.
+		 */
+		const iframeClasses = classNames( 'inline-help__richresult__dialog__video' );
+
 		return (
 			<div className="inline-help">
 				<Button
@@ -122,10 +139,34 @@ class InlineHelp extends Component {
 					ref={ this.inlineHelpToggleRef }
 				>
 					<Gridicon icon="help-outline" size={ 36 } />
-					{ showInlineHelp && (
-						<InlineHelpPopover context={ this.inlineHelpToggle } onClose={ this.closeInlineHelp } />
-					) }
 				</Button>
+				{ showInlineHelp && (
+					<InlineHelpPopover
+						context={ this.inlineHelpToggle }
+						onClose={ this.closeInlineHelp }
+						setDialogState={ this.setDialogState }
+					/>
+				) }
+				{ showDialog && (
+					<Dialog
+						additionalClassNames="inline-help__richresult__dialog"
+						isVisible
+						onCancel={ this.closeDialog }
+						onClose={ this.closeDialog }
+					>
+						<div className={ iframeClasses }>
+							<ResizableIframe
+								src={ videoLink + '?rel=0&amp;showinfo=0&amp;autoplay=1' }
+								frameBorder="0"
+								seamless
+								allowFullScreen
+								autoPlay
+								width="640"
+								height="360"
+							/>
+						</div>
+					</Dialog>
+				) }
 				{ this.props.isHappychatButtonVisible &&
 					config.isEnabled( 'happychat' ) && (
 						<HappychatButton className="inline-help__happychat-button" allowMobileRedirect />

--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -22,8 +22,6 @@ import {
 	RESULT_VIDEO,
 } from './constants';
 import Button from 'components/button';
-import Dialog from 'components/dialog';
-import ResizableIframe from 'components/resizable-iframe';
 import { decodeEntities, preventWidows } from 'lib/formatting';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSearchQuery } from 'state/inline-help/selectors';
@@ -32,6 +30,7 @@ import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 class InlineHelpRichResult extends Component {
 	static propTypes = {
 		result: PropTypes.object,
+		setDialogState: PropTypes.func.isRequired,
 	};
 
 	state = {
@@ -60,7 +59,10 @@ class InlineHelpRichResult extends Component {
 			if ( event.metaKey ) {
 				window.open( href, '_blank' );
 			} else {
-				this.setState( { showDialog: ! this.state.showDialog } );
+				this.props.setDialogState( {
+					showDialog: true,
+					videoLink: get( this.props.result, RESULT_LINK ),
+				} );
 			}
 		} else {
 			if ( ! href ) {
@@ -76,32 +78,6 @@ class InlineHelpRichResult extends Component {
 
 	onCancel = () => {
 		this.setState( { showDialog: ! this.state.showDialog } );
-	};
-
-	renderDialog = () => {
-		const { showDialog } = this.state;
-		const link = get( this.props.result, RESULT_LINK );
-		const iframeClasses = classNames( 'inline-help__richresult__dialog__video' );
-		return (
-			<Dialog
-				additionalClassNames="inline-help__richresult__dialog"
-				isVisible={ showDialog }
-				onCancel={ this.onCancel }
-				onClose={ this.onCancel }
-			>
-				<div className={ iframeClasses }>
-					<ResizableIframe
-						src={ link + '?rel=0&amp;showinfo=0&amp;autoplay=1' }
-						frameBorder="0"
-						seamless
-						allowFullScreen
-						autoPlay
-						width="640"
-						height="360"
-					/>
-				</div>
-			</Dialog>
-		);
 	};
 
 	render() {
@@ -124,7 +100,6 @@ class InlineHelpRichResult extends Component {
 						}[ type ]
 					}
 				</Button>
-				{ type === RESULT_VIDEO && this.renderDialog() }
 			</div>
 		);
 	}

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -28,6 +28,7 @@ import { getHelpSelectedSite } from 'state/help/selectors';
 class InlineHelpPopover extends Component {
 	static propTypes = {
 		onClose: PropTypes.func.isRequired,
+		setDialogState: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
@@ -81,7 +82,12 @@ class InlineHelpPopover extends Component {
 				{
 					{
 						contact: <HelpContact compact selectedSite={ this.props.selectedSite } />,
-						richresult: <InlineHelpRichResult result={ this.props.selectedResult } />,
+						richresult: (
+							<InlineHelpRichResult
+								result={ this.props.selectedResult }
+								setDialogState={ this.props.setDialogState }
+							/>
+						),
 					}[ this.state.activeSecondaryView ]
 				}
 			</div>


### PR DESCRIPTION
### Summary

While working on adding in-modal support articles as part of the inline-help body of work I found that our previous implementation of dialogs in inline-help would close on click. This was a subtle bug given that most of the modal was filled with an embedded video and clicks on the video wouldn't propagate.
For articles however this would be quite a usability issue.
It turned out that the render tree was to blame. We had a dialog inside of a popover inside of a button:

```jsx
<Button>
  <Popover>
    <Dialog ... />
  </Popover>
<Button>
```

Besides being non-semantic, this carried with it the side effect that that 'hiding' (via conditional mounting rather than styling) the Popover component would also cause the dialog to unmount.

This PR moves the dialog in to a more semantic place in the render tree and gives us the ability to hide and show the popover and dialog independently. I also moved the popover out of the button, purely for semantic improvement:

```jsx
<Button ... />
<Popover ... />
<Dialog ... />
```

As a bonus, this'll now allow us to hide the popover on opening a video if we chose to.

Notes: 
- I'd love to take the time to handle the state setting _properly_ so I've left a TODO to explain this.
- I also noticed a subtle trick that's been used to trick the linter in to missing an invalid class name - I'll follow up on this with opening an issue to improve our linters reach to avoid such violations in the future.

### Test Plan

Everything should work as before. Please be vigilant and watch for any subtle regressions as a side effect of reordering the render tree...

- Go to `http://calypso.localhost:3000/media`
- Open inline-help using the <kbd>?</kbd> button in the bottom right of the screen.
- Being that you're in `/media` you should see "Add A Photo Gallery" as a help option
- Click that and click the link it presents
  - This should launch a dialog, with a video inside.
- Click on the white of the dialog - anywhere that is inside the dialog panel, but outside of it's content
  - Nothing should happen
- Click outside of the dialog
  - The dialog should close