### PR TITLE
Domains: Conditionally assign className

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -74,7 +74,11 @@ class DomainProductPrice extends React.Component {
 						} ) }
 					</span>
 				) }
-				<span className={ shouldShowStrikethrough && 'domain-product-price__included-in-plan' }>
+				<span
+					className={ classnames( {
+						'domain-product-price__included-in-plan': shouldShowStrikethrough,
+					} ) }
+				>
 					{ translate( 'Included in paid plans' ) }
 				</span>
 			</div>


### PR DESCRIPTION
React was displaying warnings due to false being passed as the className
prop:

`false && "string"` is often used as a shorthand, but evaluates to `false`, which is not a valid value for className. Leverage existing functionality to conditionally apply the className.

## Testing:
1. Pick a domain for purchase included in your plan. This can be for a new site, or an existing site with an available domain.
1. Set the `signupDomainStrikethruPrice` abtest to `enabled`.
1. In the cart, ensure the `domain-product-price__included-in-plan` class is applied.
1. Disable the abtest
1. In the cart, ensure the `domain-product-price__included-in-plan` class is **not** applied.