### PR TITLE
Components: Update <FoldableCard /> to inline code

### DIFF
--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -1,5 +1,4 @@
 /** @format */
-
 /**
  * External dependencies
  */
@@ -72,86 +71,72 @@ class FoldableCard extends Component {
 		}
 	};
 
-	getClickAction() {
-		if ( this.props.disabled ) {
-			return;
-		}
-		return this.onClick;
-	}
-
-	getActionButton() {
-		if ( this.state.expanded ) {
-			return this.props.actionButtonExpanded || this.props.actionButton;
-		}
-		return this.props.actionButton;
-	}
-
-	renderActionButton() {
-		const clickAction = ! this.props.clickableHeader ? this.getClickAction() : null;
-		if ( this.props.actionButton ) {
-			return (
-				<div className="foldable-card__action" onClick={ clickAction }>
-					{ this.getActionButton() }
-				</div>
-			);
-		}
-		if ( this.props.children ) {
-			const iconSize = 24;
-			const screenReaderText = this.props.screenReaderText || this.props.translate( 'More' );
-			return (
-				<button
-					disabled={ this.props.disabled }
-					type="button"
-					className="foldable-card__action foldable-card__expand"
-					onClick={ clickAction }
-				>
-					<ScreenReaderText>{ screenReaderText }</ScreenReaderText>
-					<Gridicon icon={ this.props.icon } size={ iconSize } />
-				</button>
-			);
-		}
-	}
-
-	renderContent() {
-		return <div className="foldable-card__content">{ this.props.children }</div>;
-	}
-
-	renderHeader() {
-		const summary = this.props.summary ? (
-			<span className="foldable-card__summary">{ this.props.summary } </span>
-		) : null;
-		const expandedSummary = this.props.expandedSummary ? (
-			<span className="foldable-card__summary-expanded">{ this.props.expandedSummary } </span>
-		) : null;
-		const headerClickAction = this.props.clickableHeader ? this.getClickAction() : null;
-		const headerClasses = classNames( 'foldable-card__header', {
-			'is-clickable': !! this.props.clickableHeader,
-			'has-border': !! this.props.summary,
-		} );
-		return (
-			<div className={ headerClasses } onClick={ headerClickAction }>
-				<span className="foldable-card__main">{ this.props.header } </span>
-				<span className="foldable-card__secondary">
-					{ summary }
-					{ expandedSummary }
-					{ this.renderActionButton() }
-				</span>
-			</div>
-		);
-	}
-
 	render() {
-		const Container = this.props.compact ? CompactCard : Card;
-		const itemSiteClasses = classNames( 'foldable-card', this.props.className, {
-			'is-disabled': !! this.props.disabled,
-			'is-expanded': !! this.state.expanded,
-			'has-expanded-summary': !! this.props.expandedSummary,
+		const {
+			actionButton,
+			actionButtonExpanded,
+			className,
+			clickableHeader,
+			compact,
+			disabled,
+			expanded,
+			expandedSummary,
+			header,
+			icon,
+			screenReaderText,
+			summary,
+			translate,
+		} = this.props;
+
+		const Container = compact ? CompactCard : Card;
+
+		const clickAction = ! disabled ? this.onClick : null;
+		const itemSiteClasses = classNames( 'foldable-card', className, {
+			'is-disabled': !! disabled,
+			'is-expanded': !! expanded,
+			'has-expanded-summary': !! expandedSummary,
+		} );
+
+		const headerClickAction = clickableHeader ? clickAction : null;
+		const headerClasses = classNames( 'foldable-card__header', {
+			'is-clickable': !! clickableHeader,
+			'has-border': !! summary,
 		} );
 
 		return (
 			<Container className={ itemSiteClasses }>
-				{ this.renderHeader() }
-				{ this.state.expanded && this.renderContent() }
+				<div className={ headerClasses } onClick={ headerClickAction }>
+					<span className="foldable-card__main">{ header } </span>
+					<span className="foldable-card__secondary">
+						{ summary && <span className="foldable-card__summary">{ summary } </span> }
+						{ expandedSummary && (
+							<span className="foldable-card__summary-expanded">{ expandedSummary } </span>
+						) }
+						{ actionButton ? (
+							<div
+								className="foldable-card__action"
+								onClick={ ! clickableHeader ? clickAction : null }
+							>
+								{ ( expanded && actionButtonExpanded ) || actionButton }
+							</div>
+						) : (
+							this.props.children && (
+								<button
+									disabled={ disabled }
+									type="button"
+									className="foldable-card__action foldable-card__expand"
+									onClick={ ! clickableHeader ? clickAction : null }
+								>
+									<ScreenReaderText>{ screenReaderText || translate( 'More' ) }</ScreenReaderText>
+									<Gridicon icon={ icon } size={ 24 } />
+								</button>
+							)
+						) }
+					</span>
+				</div>
+				{ this.state.expanded && (
+					<div className="foldable-card__content">{ this.props.children }</div>
+				) }
 			</Container>
 		);
 	}

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -55,6 +55,26 @@ class FoldableCard extends Component {
 		}
 	}
 
+	clickAction = () => ! this.props.clickableHeader && ! this.props.disabled && this.onClick();
+
+	clickExpander = () => ! this.props.clickableHeader && ! this.props.disabled && this.onClick();
+
+	clickHeader = () => this.props.clickableHeader && ! this.props.disabled && this.onClick();
+
+	onActionKeyPress = event => {
+		// enter press
+		if ( 13 === event.keyCode ) {
+			this.clickAction();
+		}
+	};
+
+	onHeaderKeyPress = event => {
+		// enter press
+		if ( 13 === event.keyCode ) {
+			this.clickHeader();
+		}
+	};
+
 	onClick = () => {
 		if ( this.props.children ) {
 			this.setState( { expanded: ! this.state.expanded } );
@@ -79,7 +99,6 @@ class FoldableCard extends Component {
 			clickableHeader,
 			compact,
 			disabled,
-			expanded,
 			expandedSummary,
 			header,
 			icon,
@@ -90,14 +109,12 @@ class FoldableCard extends Component {
 
 		const Container = compact ? CompactCard : Card;
 
-		const clickAction = ! disabled ? this.onClick : null;
 		const itemSiteClasses = classNames( 'foldable-card', className, {
 			'is-disabled': !! disabled,
-			'is-expanded': !! expanded,
+			'is-expanded': !! this.state.expanded,
 			'has-expanded-summary': !! expandedSummary,
 		} );
 
-		const headerClickAction = clickableHeader ? clickAction : null;
 		const headerClasses = classNames( 'foldable-card__header', {
 			'is-clickable': !! clickableHeader,
 			'has-border': !! summary,
@@ -105,7 +122,13 @@ class FoldableCard extends Component {
 
 		return (
 			<Container className={ itemSiteClasses }>
-				<div className={ headerClasses } onClick={ headerClickAction }>
+				<div
+					className={ headerClasses }
+					onKeyPress={ this.onHeaderKeyPress }
+					onClick={ this.clickHeader }
+					role="button"
+					tabIndex={ 0 }
+				>
 					<span className="foldable-card__main">{ header } </span>
 					<span className="foldable-card__secondary">
 						{ summary && <span className="foldable-card__summary">{ summary } </span> }
@@ -115,9 +138,11 @@ class FoldableCard extends Component {
 						{ actionButton ? (
 							<div
 								className="foldable-card__action"
-								onClick={ ! clickableHeader ? clickAction : null }
+								onKeyPress={ this.onActionKeyPress }
+								onClick={ this.clickAction }
+								role="button"
 							>
-								{ ( expanded && actionButtonExpanded ) || actionButton }
+								{ ( this.state.expanded && actionButtonExpanded ) || actionButton }
 							</div>
 						) : (
 							this.props.children && (
@@ -125,7 +150,7 @@ class FoldableCard extends Component {
 									disabled={ disabled }
 									type="button"
 									className="foldable-card__action foldable-card__expand"
-									onClick={ ! clickableHeader ? clickAction : null }
+									onClick={ this.clickExpander }
 								>
 									<ScreenReaderText>{ screenReaderText || translate( 'More' ) }</ScreenReaderText>
 									<Gridicon icon={ icon } size={ 24 } />

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -141,6 +141,7 @@ class FoldableCard extends Component {
 								onKeyPress={ this.onActionKeyPress }
 								onClick={ this.clickAction }
 								role="button"
+								tabIndex={ -1 }
 							>
 								{ ( this.state.expanded && actionButtonExpanded ) || actionButton }
 							</div>

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -151,6 +151,7 @@ class FoldableCard extends Component {
 									type="button"
 									className="foldable-card__action foldable-card__expand"
 									onClick={ this.clickExpander }
+									tabIndex={ -1 }
 								>
 									<ScreenReaderText>{ screenReaderText || translate( 'More' ) }</ScreenReaderText>
 									<Gridicon icon={ icon } size={ 24 } />


### PR DESCRIPTION
While doing related work I stumbled into the `<FoldableCard />`
and found its code out of style with Calypso standards, notably
that its `render()` method is split into several different
methods that can make it harder for people to see what's actually
being rendered and its lack of using destructuring to remove
noise around prop-access.

In this patch I've updated those two patterns and I personally
find the updated code easier to reason about. I was hunting a
performance issue when I came to this but I don't believe that
my changes here would impact the performance of `<FoldableCard />`

**Testing**

There should be no functional or visual changes in this patch.
Run through the various options and actions on a `<FoldableCard />`.
You can find  a suite of examples in DevDocs

https://calypso.live/devdocs/design/foldable-card?branch=components/inline-foldable-card