### PR TITLE
Replace goToList with simpler alternative

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -42,7 +42,6 @@ import {
 	isDataLoading,
 	getEditCardDetailsPath,
 	getPurchase,
-	goToList,
 	recordPageView,
 } from '../utils';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
@@ -461,7 +460,7 @@ class ManagePurchase extends Component {
 						path="/me/purchases/:site/:purchaseId"
 						title="Purchases > Manage Purchase"
 					/>
-					<HeaderCake onClick={ goToList }>{ titles.managePurchase }</HeaderCake>
+					<HeaderCake backHref={ purchasesRoot }>{ titles.managePurchase }</HeaderCake>
 					{
 						<PurchaseNotice
 							isDataLoading={ isDataLoading( this.props ) }

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -1,16 +1,11 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import page from 'page';
-
-/**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
 import config from 'config';
-import { addCardDetails, editCardDetails, purchasesRoot } from './paths';
+import { addCardDetails, editCardDetails } from './paths';
 import {
 	isExpired,
 	isIncludedWithPlan,
@@ -22,10 +17,6 @@ import { isDomainTransfer } from 'lib/products-values';
 // TODO: Remove these property-masking functions in favor of accessing the props directly
 function getPurchase( props ) {
 	return props.selectedPurchase;
-}
-
-function goToList() {
-	page( purchasesRoot );
 }
 
 function isDataLoading( props ) {
@@ -81,7 +72,6 @@ function getEditCardDetailsPath( siteSlug, purchase ) {
 
 export {
 	getPurchase,
-	goToList,
 	isDataLoading,
 	recordPageView,
 	canEditPaymentDetails,


### PR DESCRIPTION
Simplify navigation.

Rather than invoking navigation via page.js in an onClick handler, simply provide the desired href.

![backlink](https://user-images.githubusercontent.com/841763/39870435-a83a3598-5461-11e8-82d5-7ea6a4d5c43c.png)

## Testing
1. Compare results from 
   - branch https://calypso.live/me/purchases?branch=remove/purchases-gotolist-util
   - production https://wordpress.com/me/purchases
1. Pick a purchase
1. You should see the manage page (`/me/purchases/:SITE_SLUG/:PURCHASE_ID`)
1. Use the back link in the header
1. Arrive at `/me/purchases`