### PR TITLE
Activity Log: Address performance issues

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import scrollTo from 'lib/scroll-to';
 import { localize } from 'i18n-calypso';
-import { get, map, merge, forEach, every, includes, isEmpty } from 'lodash';
+import { get, map, forEach, every, includes, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -98,7 +98,7 @@ class ActivityLogItem extends Component {
 
 		if ( ! isEmpty( noticesToShow ) ) {
 			this.setState( {
-				pluginUpdateNotice: merge( {}, this.state.pluginUpdateNotice, noticesToShow ),
+				pluginUpdateNotice: { ...this.state.pluginUpdateNotice, ...noticesToShow },
 			} );
 		}
 	};
@@ -159,7 +159,7 @@ class ActivityLogItem extends Component {
 
 		if ( ! isEmpty( noticesToShow ) ) {
 			this.setState( {
-				pluginUpdateNotice: merge( {}, this.state.pluginUpdateNotice, noticesToShow ),
+				pluginUpdateNotice: { ...this.state.pluginUpdateNotice, ...noticesToShow },
 			} );
 		}
 	}
@@ -424,26 +424,26 @@ class ActivityLogItem extends Component {
  * 		pluginSlug string       Plugin directory
  * 		status     object|false Current update status
  * }
- * @param {array}  pluginList List of plugins that will be updated
- * @param {object} state      Progress of plugin update as found in status.plugins.installed.state.
- * @param {number} siteId     ID of the site where the plugin is installed
+ * @param {array}  plugins List of plugins that will be updated
+ * @param {object} state   Progress of plugin update as found in status.plugins.installed.state.
+ * @param {number} siteId  ID of the site where the plugin is installed
  *
  * @returns {array} List of plugins to update with their status.
  */
-const makeListPluginsToUpdate = ( pluginList, state, siteId ) =>
-	map( pluginList, plugin =>
-		merge(
-			{ updateStatus: getStatusForPlugin( state, siteId, plugin.pluginId ) },
-			getPluginOnSite( state, siteId, plugin.pluginSlug )
-		)
-	);
+const makeListPluginsToUpdate = ( plugins, state, siteId ) =>
+	plugins.map( plugin => ( {
+		updateStatus: getStatusForPlugin( state, siteId, plugin.pluginId ),
+		...getPluginOnSite( state, siteId, plugin.pluginSlug ),
+	} ) );
 
 const mapStateToProps = ( state, { activityId, siteId } ) => {
 	const rewindState = getRewindState( state, siteId );
 	const activity = getActivityLog( state, siteId, activityId );
-	const pluginSlug = get( activity.activityMeta, 'pluginSlug', {} );
-	const pluginId = get( activity.activityMeta, 'pluginId', {} );
+	const pluginSlug = activity.activityMeta.pluginSlug;
+	const pluginId = activity.activityMeta.pluginId;
+	const plugins = activity.activityMeta.pluginsToUpdate;
 	const site = getSite( state, siteId );
+
 	return {
 		activity,
 		gmtOffset: getSiteGmtOffset( state, siteId ),
@@ -454,13 +454,9 @@ const mapStateToProps = ( state, { activityId, siteId } ) => {
 		rewindIsActive: 'active' === rewindState.state || 'provisioning' === rewindState.state,
 		canAutoconfigure: rewindState.canAutoconfigure,
 		site,
-		plugin: getPluginOnSite( state, siteId, pluginSlug ),
-		pluginStatus: getStatusForPlugin( state, siteId, pluginId ),
-		pluginsToUpdate: makeListPluginsToUpdate(
-			get( activity.activityMeta, 'pluginsToUpdate', [] ),
-			state,
-			siteId
-		),
+		plugin: pluginSlug && getPluginOnSite( state, siteId, pluginSlug ),
+		pluginStatus: pluginId && getStatusForPlugin( state, siteId, pluginId ),
+		pluginsToUpdate: plugins && makeListPluginsToUpdate( plugins, state, siteId ),
 	};
 };
 

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -66,7 +66,7 @@ import {
 	getOldestItemTs,
 } from 'state/selectors';
 
-const PAGE_SIZE = 100;
+const PAGE_SIZE = 20;
 
 class ActivityLog extends Component {
 	static propTypes = {


### PR DESCRIPTION
While working in the Activity Log I was noticing that
it felt slow to render each page of events. I did some
digging around and made a couple of significant but
small changes in this patch:

 - limit the display of events to 20 (down from 100)
 - stop trying to get plugin information for non-plugin events

These changes should have no other effect other than
limiting the number of displayed events per-page to
twenty and making the page-view faster.

There are some issues I wasn't able to find causing
the underlying render of the `<ActivityLogItem />`
to slow down.

**Testing**

I have already tested this and the changes should be
minor, but we should focus on testing the plugin behavior
changes.

Start in **My Sites** > **Stats** > **Activity**

There should be 20 events max instead of 100.

Find plugin-update events, try to force a plugin to appear
as needing an update (use the console dispatcher if you want)
Make sure that the plugin update logic doesn't change.