### PR TITLE
Privacy/GDPR: add a banner to record sensitive_pixel_option preference

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -41,6 +41,7 @@
 @import 'blocks/edit-gravatar/style';
 @import 'blocks/follow-button/style';
 @import 'blocks/eligibility-warnings/style';
+@import 'blocks/gdpr-banner/style';
 @import 'blocks/google-my-business-stats-nudge/style';
 @import 'blocks/image-editor/style';
 @import 'blocks/inline-help/style';

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -140,6 +140,7 @@ $z-layers: (
 		'.notices-list.is-pinned': 180,
 		'.notices-list.is-pinned .notice': 180,
 		'.masterbar': 180,
+		'.gdpr-banner': 185,
 		'.detail-page__backdrop': 190,
 		'.layout__loader': 200,
 		'.offline-status': 200,

--- a/client/blocks/gdpr-banner/index.jsx
+++ b/client/blocks/gdpr-banner/index.jsx
@@ -1,0 +1,151 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import cookie from 'cookie';
+import { identity, includes } from 'lodash';
+import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import { getSectionName } from 'state/ui/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
+import TrackComponentView from 'lib/analytics/track-component-view';
+import { decodeEntities, preventWidows } from 'lib/formatting';
+import { requestGeoLocation } from 'state/data-getters';
+
+const gdprCountries = [
+	// European Member countries
+	'AT', // Austria
+	'BE', // Belgium
+	'BG', // Bulgaria
+	'CY', // Cyprus
+	'CZ', // Czech Republic
+	'DE', // Germany
+	'DK', // Denmark
+	'EE', // Estonia
+	'ES', // Spain
+	'FI', // Finland
+	'FR', // France
+	'GR', // Greece
+	'HR', // Croatia
+	'HU', // Hungary
+	'IE', // Ireland
+	'IT', // Italy
+	'LT', // Lithuania
+	'LU', // Luxembourg
+	'LV', // Latvia
+	'MT', // Malta
+	'NL', // Netherlands
+	'PL', // Poland
+	'PT', // Portugal
+	'RO', // Romania
+	'SE', // Sweden
+	'SI', // Slovenia
+	'SK', // Slovakia
+	'GB', // United Kingdom
+	// Single Market Countries that GDPR applies to
+	'CH', // Switzerland
+	'IS', // Iceland
+	'LI', // Liechtenstein
+	'NO', // Norway
+];
+const SIX_MONTHS = 6 * 30 * 24 * 60 * 60;
+
+class GdprBanner extends Component {
+	static propTypes = {
+		translate: PropTypes.func,
+		currentSection: PropTypes.string,
+		countryCode: PropTypes.string,
+	};
+
+	static defaultProps = {
+		translate: identity,
+		currentSection: undefined,
+		countryCode: undefined,
+	};
+
+	state = {
+		showBanner: true,
+	};
+
+	acknowledgeClicked = () => {
+		document.cookie = cookie.serialize( 'sensitive_pixel_option', 'yes', {
+			path: '/',
+			maxAge: SIX_MONTHS,
+		} );
+		this.props.recordTracksEvent( 'calypso_sensitive_pixel_option_accepted' );
+		this.setState( { showBanner: false } );
+	};
+
+	shouldShowBanner() {
+		const cookies = cookie.parse( document.cookie );
+		if ( cookies.sensitive_pixel_option === 'yes' || cookies.sensitive_pixel_option === 'no' ) {
+			return false;
+		}
+		if ( ! includes( gdprCountries, this.props.countryCode ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	render() {
+		if ( ! this.shouldShowBanner() ) {
+			return null;
+		}
+		const { translate, currentSection } = this.props;
+		const copy = translate(
+			'Our websites and dashboards use cookies. By continuing, you agree to their use. ' +
+				'By using our website, you agree to our use of cookies in accordance with our cookie policy. ' +
+				'{{a}}Learn more{{/a}}, including how to control cookies.',
+			{
+				components: {
+					a: <a href="https://automattic.com/cookies" />,
+				},
+			}
+		);
+		const classes = {
+			'is-compact': true,
+			'gdpr-banner': true,
+			'gdpr-banner__hiding': ! this.state.showBanner,
+		};
+		return (
+			<Card className={ classNames( classes ) }>
+				<TrackComponentView
+					eventName="calypso_gdpr_banner_impression"
+					eventProperties={ {
+						page: currentSection,
+					} }
+					statGroup="calypso_gdpr_banner"
+					statName="impression"
+				/>
+				<div className="gdpr-banner__text-content">{ preventWidows( decodeEntities( copy ) ) }</div>
+				<div className="gdpr-banner__buttons">
+					<Button className="gdpr-banner__acknowledge-button" onClick={ this.acknowledgeClicked }>
+						{ translate( 'Got it!' ) }
+					</Button>
+				</div>
+			</Card>
+		);
+	}
+}
+
+const mapStateToProps = state => {
+	return {
+		countryCode: requestGeoLocation().data,
+		currentSection: getSectionName( state ),
+	};
+};
+
+const mapDispatchToProps = {
+	recordTracksEvent,
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( GdprBanner ) );

--- a/client/blocks/gdpr-banner/style.scss
+++ b/client/blocks/gdpr-banner/style.scss
@@ -1,0 +1,68 @@
+.card.gdpr-banner {
+	position: fixed;
+	bottom: 0;
+	width: 100%;
+	margin-bottom: 0;
+	background-color: $blue-light;
+	color: $blue-dark;
+	z-index: z-index( 'root', '.gdpr-banner' );
+
+	animation-duration: 0.5s;
+	animation-name: gdpr-banner__slideup;
+	animation-timing-function: ease-in-out;
+}
+
+@keyframes gdpr-banner__slideup {
+	0% {
+		opacity: 0;
+		pointer-events: none;
+		transform: translateY( 100% );
+	}
+
+	100% {
+		opacity: 1;
+		pointer-events: auto;
+		transform: translateY( 0 );
+	}
+}
+
+.card.gdpr-banner__hiding {
+	pointer-events: none;
+	animation-duration: 0.3s;
+	animation-name: gdpr-banner__fadeout;
+	animation-timing-function: ease-in-out;
+	animation-fill-mode: forwards;
+}
+
+@keyframes gdpr-banner__fadeout {
+	0% {
+		opacity: 1;
+		transform: translateY( 0 );
+	}
+
+	100% {
+		opacity: 0;
+		transform: translateY( 100% );
+	}
+}
+
+.gdpr-banner__text-content {
+	font-size: 12px;
+	line-height: 1.4;
+	@include breakpoint( ">660px" ) {
+		font-size: 16px;
+	}
+}
+
+.gdpr-banner__buttons {
+	margin-top: 14px;
+	text-align: center;
+}
+
+.gdpr-banner__acknowledge-button {
+	width: 100%;
+	text-align: center;
+	@include breakpoint( ">660px" ) {
+		width: auto;
+	}
+}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -43,6 +43,7 @@ import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import DocumentHead from 'components/data/document-head';
 import NpsSurveyNotice from 'layout/nps-survey-notice';
 import AppBanner from 'blocks/app-banner';
+import GdprBanner from 'blocks/gdpr-banner';
 import { getPreference } from 'state/preferences/selectors';
 import JITM from 'blocks/jitm';
 import KeyboardShortcutsMenu from 'lib/keyboard-shortcuts/menu';
@@ -159,6 +160,7 @@ const Layout = createReactClass( {
 				) }
 				<InlineHelp />
 				<AppBanner />
+				<GdprBanner />
 			</div>
 		);
 	},


### PR DESCRIPTION
This PR adds a banner to Calypso to record the `sensitive_pixel_option` preference if the user is in a GDPR country and hasn't set a value for the cookie yet. 

Screen capture:

![gdpr-banner](https://user-images.githubusercontent.com/23619/39927561-ee4f6c7a-5532-11e8-8ecc-fbf7cad47655.gif)

To test:
- Visit any page in Calypso from a GDPR country. 
- Make sure the banner shows. 
- Click OK. 
- Make sure the `sensitive_pixel_option` cookie's value is set to `yes` and a Tracks event recording this is fired. 
- Visit any page in Calypso from a non-GDPR country. 
- Make sure the banner doesn't show. 
- Reset the `sensitive_pixel_option` cookie. 
- Visit any page in Calypso from a non-GDPR country. 
- Make sure the banner doesn't show. 
