### PR TITLE
Billing History: Add 'Jetpack' Prefix to Jetpack Plans

### DIFF
--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -152,10 +153,17 @@ class BillingReceipt extends React.Component {
 		const groupedTransactionItems = groupDomainProducts( transaction.items, translate );
 
 		const items = groupedTransactionItems.map( item => {
+			let name = item.variation;
+			// I wish I could use lib/product-values#isJetpackPlan() here, but that always returns `false`
+			// since `transaction.product_slug` uses hyphens (e.g. `jetpack-premium`), whereas `isJetpackPlan()`
+			// internally uses `getPlan()`, which expects underscores (`jetpack_premium`). -- @ockham
+			if ( startsWith( item.product_slug, 'jetpack-' ) ) {
+				name = `Jetpack ${ name }`;
+			}
 			return (
 				<tr key={ item.id }>
 					<td className="billing-history__receipt-item-name">
-						<span>{ item.variation }</span>
+						<span>{ name }</span>
 						<small>({ item.type_localized })</small>
 						<br />
 						<em>{ item.domain }</em>

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { isEmpty } from 'lodash';
+import { isEmpty, startsWith } from 'lodash';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -81,18 +81,26 @@ class TransactionsTable extends React.Component {
 	};
 
 	serviceNameDescription = transaction => {
+		let planName = transaction.plan;
+		// I wish I could use lib/product-values#isJetpackPlan() here, but that always returns `false`
+		// since `transaction.product_slug` uses hyphens (e.g. `jetpack-premium`), whereas `isJetpackPlan()`
+		// internally uses `getPlan()`, which expects underscores (`jetpack_premium`). -- @ockham
+		if ( startsWith( transaction.product_slug, 'jetpack-' ) ) {
+			planName = `Jetpack ${ planName }`;
+		}
+
 		let description;
 		if ( transaction.domain ) {
 			description = (
 				<div>
-					<strong>{ transaction.plan }</strong>
+					<strong>{ planName }</strong>
 					<small>{ transaction.domain }</small>
 				</div>
 			);
 		} else {
 			description = (
 				<strong>
-					{ transaction.product } { transaction.plan }
+					{ transaction.product } { planName }
 				</strong>
 			);
 		}


### PR DESCRIPTION
I tried tackling this on the server side, so the REST API would only communicate prefixed plan names, see D12878-code. However, it seems to be really hard to get hold of all the instances that rely on the current behavior (some things even rely on string comparisons of plan names). So I'm doing what everyone else is doing: Prepending the 'Jetpack' string in various locations.

# Testing Instructions

Verify that in the following cases, the word 'Jetpack' is correctly prepended to Jetpack plan names. Also verify that non-Jetpack plans aren't affected.

## `/me/purchases/billing`:

### Before

![image](https://user-images.githubusercontent.com/96308/39929484-78a1e48e-5538-11e8-8ed8-2b030d990f6b.png)

### After

![image](https://user-images.githubusercontent.com/96308/39929637-d52350bc-5538-11e8-905d-9109fd89fa17.png)

## Individual Receipt:

(just click on a Jetpack one in the above list)

### Before

![image](https://user-images.githubusercontent.com/96308/39930664-98f7da42-553b-11e8-9a1b-96d1ef80ddbb.png)

### After

![image](https://user-images.githubusercontent.com/96308/39930808-fb357610-553b-11e8-939f-d93a0f9b0807.png)

Fixes what's left of #24092.