### PR TITLE
InlineHelp: Add In-modal Support Articles

### DIFF
--- a/client/blocks/inline-help/constants.js
+++ b/client/blocks/inline-help/constants.js
@@ -9,3 +9,4 @@ export const RESULT_VIDEO = 'video';
 export const VIEW_CONTACT = 'contact';
 export const VIEW_RICH_RESULT = 'richresult';
 export const VIEW_FORUM = 'forums';
+export const SUPPORT_BLOG_ID = 9619154;

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -14,23 +14,27 @@ import { RESULT_TOUR, RESULT_VIDEO } from './constants';
  */
 const fallbackLinks = [
 	{
-		link: 'https://en.support.wordpress.com/business-plan/',
+		link: 'http://en.support.wordpress.com/business-plan/',
+		postId: 134940,
 		title: 'Uploading custom plugins and themes',
 		description: 'Learn more about installing a custom theme or plugin using the Business plan.',
 	},
 	{
-		link: 'https://en.support.wordpress.com/all-about-domains/',
+		link: 'http://en.support.wordpress.com/all-about-domains/',
+		postId: 41171,
 		title: 'All About Domains',
 		description: 'Set up your domain whether it’s registered with WordPress.com or elsewhere.',
 	},
 	{
-		link: 'https://en.support.wordpress.com/start/',
+		link: 'http://en.support.wordpress.com/start/',
+		postId: 81083,
 		title: 'Get Started',
 		description:
 			'No matter what kind of site you want to build, our five-step checklists will get you set up and ready to publish.',
 	},
 	{
-		link: 'https://en.support.wordpress.com/settings/privacy-settings/',
+		link: 'http://en.support.wordpress.com/settings/privacy-settings/',
+		postId: 1507,
 		title: 'Privacy Settings',
 		description: 'Limit your site’s visibility or make it completely private.',
 	},
@@ -40,24 +44,28 @@ const contextLinksForSection = {
 	stats: [
 		{
 			link: 'http://en.support.wordpress.com/stats/',
+			postId: 4454,
 			title: 'Stats',
 			description:
 				'Your stats page includes a bunch of nifty graphs, charts, and lists that show you how many visits your site…',
 		},
 		{
-			link: 'https://en.support.wordpress.com/getting-more-views-and-traffic/',
+			link: 'http://en.support.wordpress.com/getting-more-views-and-traffic/',
+			postId: 3307,
 			title: 'Getting More Views and Traffic',
 			description:
 				'Want more traffic? Here are some tips for attracting more visitors to your site: Tell people in your social networks…',
 		},
 		{
-			link: 'https://en.support.wordpress.com/increase-your-site-traffic/',
+			link: 'http://en.support.wordpress.com/increase-your-site-traffic/',
+			postId: 132186,
 			title: 'Increase Your Site Traffic',
 			description:
 				'One of the most frequent questions our community members ask us — and themselves — is how to get more…',
 		},
 		{
-			link: 'https://en.support.wordpress.com/grow-your-community/',
+			link: 'http://en.support.wordpress.com/grow-your-community/',
+			postId: 132190,
 			title: 'Grow Your Community',
 			description:
 				"You've worked hard on building your site, now it's time to explore the community and get noticed. On WordPress.com, we…",
@@ -66,25 +74,29 @@ const contextLinksForSection = {
 	sharing: [
 		{
 			link: 'http://en.support.wordpress.com/video-tutorials/connect-to-social-media/',
+			postId: 130825,
 			title: 'Integrate and Connect to Social Media',
 			description:
 				'Start sharing your site and attract more traffic and visitors to your content. Learn to activate and control the social…',
 		},
 		{
-			link: 'https://en.support.wordpress.com/sharing/',
+			link: 'http://en.support.wordpress.com/sharing/',
+			postId: 7499,
 			title: 'Sharing',
 			description:
 				'At the bottom of each post and page you can include sharing buttons for your readers to share your content…',
 		},
 		{
-			link: 'https://en.support.wordpress.com/instagram/',
+			link: 'http://en.support.wordpress.com/instagram/',
+			postId: 77589,
 			title: 'Instagram',
 			description:
 				'Instagram is a simple way to capture, customize, ' +
 				'and share photos and short videos using your smartphone or other mobile device…',
 		},
 		{
-			link: 'https://en.support.wordpress.com/twitter/',
+			link: 'http://en.support.wordpress.com/twitter/',
+			postId: 124,
 			title: 'Twitter',
 			description:
 				'Twitter is a service for the exchange of brief messages, commonly ' +
@@ -94,6 +106,7 @@ const contextLinksForSection = {
 	me: [
 		{
 			link: 'http://en.support.wordpress.com/manage-my-profile/',
+			postId: 19775,
 			title: 'Manage My Profile',
 			description:
 				"Your profile is the information you'd like to be shown along with your " +
@@ -101,6 +114,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/gravatars/',
+			postId: 1338,
 			title: 'The Gravatar – Your Profile Picture',
 			description:
 				'WordPress.com associates an Avatar with your email address. Gravatar ' +
@@ -109,12 +123,14 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/account-deactivation/',
+			postId: 138080,
 			title: 'Account Deactivation',
 			description:
 				'If you are finished with your WordPress.com account and would like to shut it down, please follow the steps outlined...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/change-your-username/',
+			postId: 2116,
 			title: 'Change Your Username',
 			description:
 				'You can change both your WordPress.com account username (the name you use to login) and your display name (the name...',
@@ -129,12 +145,14 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/video-tutorials/manage-your-account/',
+			postId: 130826,
 			title: 'Manage Your Account',
 			description:
 				'Learn the ins and outs of managing your WordPress.com account and site. Learn how to change your account password and...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/account-settings/',
+			postId: 80368,
 			title: 'Account Settings',
 			description:
 				'You can review and edit basic account information in Account Settings. ' +
@@ -150,24 +168,28 @@ const contextLinksForSection = {
 	security: [
 		{
 			link: 'http://en.support.wordpress.com/security/two-step-authentication/',
+			postId: 58847,
 			title: 'Two Step Authentication',
 			description:
 				"Your WordPress.com site is your home on the internet, and you want to keep that home safe. Hopefully, you've already...",
 		},
 		{
 			link: 'http://en.support.wordpress.com/account-recovery/',
+			postId: 46365,
 			title: 'Account Recovery',
 			description:
 				'At some point, you may run into a situation in which you’ve lost access to your account. We want to...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/passwords/',
+			postId: 89,
 			title: 'Passwords',
 			description:
 				'Passwords are very important to user accounts, and there may come a time when you need to change your password.',
 		},
 		{
 			link: 'http://en.support.wordpress.com/third-party-applications/',
+			postId: 17288,
 			title: 'Third Party Applications',
 			description:
 				'WordPress.com allows you to connect with third-party applications that ' +
@@ -177,6 +199,7 @@ const contextLinksForSection = {
 	purchases: [
 		{
 			link: 'http://en.support.wordpress.com/manage-purchases/',
+			postId: 111349,
 			title: 'Manage Purchases',
 			description:
 				'You can manage all of your WordPress.com purchases by navigating to the ' +
@@ -184,6 +207,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/auto-renewal/',
+			postId: 110924,
 			title: 'Subscriptions for Plans and Domains',
 			description:
 				'Your WordPress.com plans and any domains you add to your sites are based ' +
@@ -191,6 +215,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/discover-the-wordpress-com-plans/',
+			postId: 140323,
 			title: 'Discover the WordPress.com Plans',
 			description:
 				'Thank you for building your site on WordPress.com! Upgrading to a plan unlocks a ton of features.',
@@ -206,6 +231,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/email-notifications/',
+			postId: 9443,
 			title: 'Email Notifications',
 			description:
 				'Notifications from WordPress.com will be sent to the email address registered ' +
@@ -213,6 +239,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/following-comments/',
+			postId: 4576,
 			title: 'Following Comments',
 			description:
 				'When you leave a comment on a WordPress.com blog, you can choose to automatically ' +
@@ -220,6 +247,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/following/',
+			postId: 4899,
 			title: 'Following Blogs',
 			description:
 				'When you follow a blog on WordPress.com, the new posts from that site will appear in your Reader, where you...',
@@ -228,6 +256,7 @@ const contextLinksForSection = {
 	media: [
 		{
 			link: 'http://en.support.wordpress.com/media/',
+			postId: 853,
 			title: 'Media Library',
 			description:
 				'The Media Library is where you can manage your images, audio, videos, and documents ' +
@@ -235,12 +264,14 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/add-media/finding-free-images-and-other-media/',
+			postId: 78425,
 			title: 'Finding Free Images and other Media',
 			description:
 				"What do we mean by 'free media'? While much content on the internet is subject to copyright laws, there are...",
 		},
 		{
 			link: 'http://en.support.wordpress.com/add-media/',
+			postId: 38830,
 			title: 'Add Media',
 			description:
 				'Dress up your text-based posts and pages with individual images, image galleries, ' +
@@ -248,6 +279,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/videos/',
+			postId: 4744,
 			title: 'Videos',
 			description:
 				'Videos are a great way to enhance your blog posts. We use videos all the time on the WordPress.com News...',
@@ -263,6 +295,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/user-mentions/',
+			postId: 91788,
 			title: 'User Mentions',
 			description:
 				'User mentions are a great way to include other WordPress.com users within your ' +
@@ -270,12 +303,14 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/adding-users/',
+			postId: 2160,
 			title: 'Inviting Contributors, Followers, and Viewers',
 			description:
 				"On WordPress.com, you are able to add users to your website by sending invitations. To send an invitation, you'll want...",
 		},
 		{
 			link: 'http://en.support.wordpress.com/followers/',
+			postId: 5444,
 			title: 'My Followers',
 			description:
 				'When someone follows your site, each time you publish new content on your blog they receive an update in their...',
@@ -284,6 +319,7 @@ const contextLinksForSection = {
 	plugins: [
 		{
 			link: 'http://en.support.wordpress.com/plugins/',
+			postId: 2108,
 			title: 'Plugins',
 			description:
 				'On WordPress.com, we include the most popular plugin functionality within our ' +
@@ -291,12 +327,14 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/plugins/managing-plugins/',
+			postId: 134818,
 			title: 'Managing plugins',
 			description:
 				'After you install a plugin, it will appear in a list at My Sites → Plugins. This list will display any...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/plugins/adding-plugins/',
+			postId: 134719,
 			title: 'Adding plugins',
 			description:
 				'Installing and using plugins In addition to built-in plugin functionality, WordPress.com ' +
@@ -312,6 +350,7 @@ const contextLinksForSection = {
 	'posts-pages': [
 		{
 			link: 'http://en.support.wordpress.com/five-step-website-setup/',
+			postId: 100856,
 			title: 'Build Your Website in Five Steps',
 			description:
 				"Great, you've registered a website on wordpress.com. Now what? Whether you're building " +
@@ -319,6 +358,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/pages/landing-pages/',
+			postId: 124077,
 			title: 'Landing Pages',
 			description:
 				'Landing pages are pages with a single purpose: encouraging your visitors to sign up for ' +
@@ -326,12 +366,14 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/posts/',
+			postId: 84,
 			title: 'Posts',
 			description:
 				'Posts are what make your blog a blog — they’re servings of content that are listed in reverse chronological order on...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/posts/post-formats/',
+			postId: 10382,
 			title: 'Post Formats',
 			description:
 				'Learn how to make gallery, video, audio, and other post types pop with post formats. ' +
@@ -341,12 +383,14 @@ const contextLinksForSection = {
 	'settings-writing': [
 		{
 			link: 'http://en.support.wordpress.com/settings/writing-settings/',
+			postId: 1502,
 			title: '"Writing Settings',
 			description:
 				'To change these settings, go to My Sites → Settings → Writing. Manage Categories and Tags Open the Categories or Tags...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/posts/categories-vs-tags/',
+			postId: 2135,
 			title: 'Categories vs. Tags',
 			description:
 				'Once upon a time, WordPress.com only provided a Category option. Categories allowed ' +
@@ -354,12 +398,14 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/feeds/',
+			postId: 3589,
 			title: 'Feeds',
 			description:
 				'A feed (often called RSS) is a stream of posts or comments that is updated when new content is published. This...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/portfolios/',
+			postId: 84808,
 			title: 'Portfolios',
 			description:
 				"If you're hoping to use your WordPress.com site to show off your portfolio separate " +
@@ -369,6 +415,7 @@ const contextLinksForSection = {
 	'settings-discussion': [
 		{
 			link: 'http://en.support.wordpress.com/settings/discussion-settings/',
+			postId: 1504,
 			title: 'Discussion Settings',
 			description:
 				'The Discussion Settings are used to control how visitors and other blogs interact ' +
@@ -376,6 +423,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/enable-disable-comments-for-future-posts/',
+			postId: 5997,
 			title: 'Enable and Disable Comments for Future Posts',
 			description:
 				'You can enable/disable comments on future posts by going into your Discussion settings. ' +
@@ -383,12 +431,14 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/comments/',
+			postId: 113,
 			title: 'Comments',
 			description:
 				'Comments are a way for visitors to add feedback to your posts and pages. If you choose to enable comments...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/subscriptions-and-newsletters/',
+			postId: 67810,
 			title: 'Subscriptions and Newsletters',
 			description:
 				'This article explains how readers can subscribe to your blog to receive email notifications of all of your posts.  On...',
@@ -403,12 +453,14 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/related-posts/',
+			postId: 1545,
 			title: 'Related Posts',
 			description:
 				'The Related Posts feature pulls relevant content from your blog to display at the bottom of your posts.',
 		},
 		{
 			link: 'http://en.support.wordpress.com/webmaster-tools/',
+			postId: 5022,
 			title: 'Webmaster Tools',
 			description:
 				'WordPress.com provides you with built-in stats that give you lots of information ' +
@@ -416,6 +468,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/amp-accelerated-mobile-pages/',
+			postId: 122516,
 			title: 'AMP (Accelerated Mobile Pages)',
 			description:
 				'AMP (Accelerated Mobile Pages) is an open-source framework that allows browsers ' +
@@ -425,12 +478,14 @@ const contextLinksForSection = {
 	'settings-security': [
 		{
 			link: 'http://en.support.wordpress.com/security/',
+			postId: 10977,
 			title: 'Security',
 			description:
 				'The security of your site and your personal data is always a priority. This page describes what we do to...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/unwanted-comments/',
+			postId: 5882,
 			title: 'Unwanted Comments and Comment Spam',
 			description:
 				'There are many ways to protect your WordPress.com blogs from unwanted comments: ' +
@@ -438,6 +493,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/selecting-a-strong-password/',
+			postId: 35364,
 			title: 'Selecting a Strong Password',
 			description:
 				'The weakest point in any security for your online accounts is usually your password. At WordPress.com, we go to great...',
@@ -446,12 +502,14 @@ const contextLinksForSection = {
 	settings: [
 		{
 			link: 'http://en.support.wordpress.com/settings/',
+			postId: 497,
 			title: 'Settings',
 			description:
 				'The Settings menu of your site is where you will configure everything about how the blog works and functions. You...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/settings/general-settings/',
+			postId: 1501,
 			title: 'General Settings',
 			description:
 				'The General Settings let you control how your site is displayed, such as the ' +
@@ -459,11 +517,13 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/site-icons/',
+			postId: 1327,
 			title: 'Site Icons',
 			description: '',
 		},
 		{
 			link: 'http://en.support.wordpress.com/five-step-blog-setup/',
+			postId: 100846,
 			title: 'Set Up Your Blog in Five Steps',
 			description:
 				"Congrats, you've registered your blog -- maybe you've even published your first " +
@@ -473,6 +533,7 @@ const contextLinksForSection = {
 	themes: [
 		{
 			link: 'http://en.support.wordpress.com/themes/',
+			postId: 2278,
 			title: 'Themes',
 			description:
 				'A theme controls the general look and feel of your site including things like ' +
@@ -480,6 +541,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/themes/mobile-themes/',
+			postId: 4925,
 			title: 'Mobile Themes',
 			description:
 				'When a visitor browses to a WordPress.com blog on a mobile device, we show ' +
@@ -487,6 +549,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/premium-themes/',
+			postId: 12112,
 			title: 'Premium Themes',
 			description:
 				'Purchasing a Premium Theme On a site with the Premium or Business plan, you can switch to any premium theme...',
@@ -539,6 +602,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/plan-features/',
+			postId: 134698,
 			title: 'WordPress.com Plans',
 			description:
 				'All WordPress.com sites are packed with awesome features, and if you would like to take yours to the next level, ...',
@@ -552,6 +616,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/jetpack-add-ons/',
+			postId: 115025,
 			title: 'Jetpack Plans',
 			description:
 				'What is Jetpack and do I need it? Jetpack is a feature-rich plugin for self-hosted WordPress sites. If your site...',
@@ -560,18 +625,21 @@ const contextLinksForSection = {
 	'post-editor': [
 		{
 			link: 'http://en.support.wordpress.com/editors/',
+			postId: 3347,
 			title: 'Editors',
 			description:
 				'When creating a post or page on your WordPress.com blog, you have two editing modes available to you. Visual Editor...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/visual-editor/',
+			postId: 3644,
 			title: 'Visual Editor',
 			description:
 				'The visual editor provides a semi-WYSIWYG (What You See is What You Get) content editor that allows you to easily...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/xml-rpc/',
+			postId: 3595,
 			title: 'Offline Editing',
 			description:
 				'There are several desktop applications which you can use to write and publish ' +
@@ -587,6 +655,7 @@ const contextLinksForSection = {
 	reader: [
 		{
 			link: 'http://en.support.wordpress.com/reader/',
+			postId: 32011,
 			title: 'Reader',
 			description:
 				'Read posts from all the sites you follow (even the ones that aren’t on WordPress.com), find great new reads, and keep...',
@@ -599,6 +668,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/topics/',
+			postId: 2166,
 			title: 'Tags in the Reader',
 			description:
 				'Looking for posts on a specific topic? Besides following entire blogs, you can also follow posts on a specific subject...',
@@ -613,6 +683,7 @@ const contextLinksForSection = {
 	help: [
 		{
 			link: 'http://en.support.wordpress.com/blogging-u/',
+			postId: 117437,
 			title: 'Blogging U.',
 			description:
 				'Blogging U. courses deliver expert advice, pro tips, and inspiration right to your ' +
@@ -620,18 +691,19 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/help-support-options/',
+			postId: 149,
 			title: 'Help! Getting WordPress.com Support',
 			description:
 				'WordPress.com offers a number of avenues for reaching helpful, individualized support, ' +
 				'but sometimes it can be difficult to determine the...',
 		},
 		{
-			link: 'https://en.support.wordpress.com/',
+			link: 'http://en.support.wordpress.com/',
 			title: 'All support articles',
 			description: 'Looking to learn more about a feature? Our docs have all the details.',
 		},
 		{
-			link: 'https://learn.wordpress.com/',
+			link: 'http://learn.wordpress.com/',
 			title: 'Self-guided online tutorial',
 			description: 'A step-by-step guide to getting familiar with the platform.',
 		},
@@ -645,6 +717,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/comment-display-options/',
+			postId: 5840,
 			title: 'Comment Display Options',
 			description:
 				'You can control comment threading, paging, and comment order settings from the ' +
@@ -659,6 +732,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/comment-likes/',
+			postId: 88757,
 			title: 'Comment Likes',
 			description:
 				"Comment Likes: how to like others' comments and control how Comment Likes " +
@@ -668,7 +742,7 @@ const contextLinksForSection = {
 };
 
 /*
-source: https://www.youtube.com/playlist?list=PLQFhxUeNFfdKx9gO0a2mp9h8pKjb2y9la
+source: http://www.youtube.com/playlist?list=PLQFhxUeNFfdKx9gO0a2mp9h8pKjb2y9la
 run this in the console to get the videos into a more helpful format (also removes duplicates):
 ```JavaScript
 data = {};
@@ -682,7 +756,7 @@ const videosForSection = {
 	sharing: [
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/YVelWG3hf3o',
+			link: 'http://www.youtube.com/embed/YVelWG3hf3o',
 			title: 'Add Social Sharing Buttons to Your Website',
 			description:
 				'Find out how to add social sharing buttons to your WordPress.com site, which you can also ' +
@@ -690,7 +764,7 @@ const videosForSection = {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/NcCe0ozmqFM',
+			link: 'http://www.youtube.com/embed/NcCe0ozmqFM',
 			title: 'Connect Your Blog to Facebook Using Publicize',
 			description:
 				'Find out how to share blog posts directly on Facebook from your WordPress.com site, ' +
@@ -698,35 +772,35 @@ const videosForSection = {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/f44-4TgnWTs',
+			link: 'http://www.youtube.com/embed/f44-4TgnWTs',
 			title: 'Display Your Instagram Feed on Your Website',
 			description:
 				'Find out how to display your latest Instagram photos right on your WordPress.com site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/3rTooGV_mlg',
+			link: 'http://www.youtube.com/embed/3rTooGV_mlg',
 			title: 'Set Up the Social Links Menu',
 			description:
 				'Find out how to set up a social links menu on your WordPress.com or Jetpack-enabled WordPress site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/gmrOkkqMNlc',
+			link: 'http://www.youtube.com/embed/gmrOkkqMNlc',
 			title: 'Embed a Twitter Timeline in your Sidebar',
 			description:
 				'Find out how to display your Twitter timeline on your WordPress.com or Jetpack-enabled WordPress site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/vy-U5saqG9A',
+			link: 'http://www.youtube.com/embed/vy-U5saqG9A',
 			title: 'Set Up a Social Media Icons Widget',
 			description:
 				'Find out how to set up the social media icons widget on your WordPress.com or Jetpack-enabled WordPress site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/N0GRBFRkzzs',
+			link: 'http://www.youtube.com/embed/N0GRBFRkzzs',
 			title: 'Embed a Tweet from Twitter in Your Website',
 			description:
 				'Find out how to embed a Tweet in your content (including posts and pages) on your WordPress.com ' +
@@ -734,7 +808,7 @@ const videosForSection = {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/uVRji6bKJUE',
+			link: 'http://www.youtube.com/embed/uVRji6bKJUE',
 			title: 'Embed an Instagram Photo in Your Website',
 			description:
 				'Find out how to embed an Instagram photo in your content (including posts and pages) on your WordPress.com ' +
@@ -742,7 +816,7 @@ const videosForSection = {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/sKm3Q83JxM0',
+			link: 'http://www.youtube.com/embed/sKm3Q83JxM0',
 			title: 'Embed a Facebook Update in Your Website',
 			description:
 				'Find out how to embed a Facebook update in your content (including posts, pages, and even comments) on your ' +
@@ -750,7 +824,7 @@ const videosForSection = {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/SBgNkre_b14',
+			link: 'http://www.youtube.com/embed/SBgNkre_b14',
 			title: 'Share Blog Posts Directly on Twitter',
 			description:
 				'Find out how to share blog posts directly on Twitter from your WordPress.com or Jetpack-enabled WordPress site.',
@@ -759,13 +833,13 @@ const videosForSection = {
 	settings: [
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/0YCZ22k4SfQ',
+			link: 'http://www.youtube.com/embed/0YCZ22k4SfQ',
 			title: 'Add a Site Logo',
 			description: 'Find out how to add a custom logo to your WordPress.com site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/vucZ1uZ2NPo',
+			link: 'http://www.youtube.com/embed/vucZ1uZ2NPo',
 			title: 'Update Your Website Title and Tagline',
 			description:
 				'Find out how to update the Title and Tagline of your WordPress.com site, which you can also ' +
@@ -773,38 +847,38 @@ const videosForSection = {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/Y6iPsPwYD7g',
+			link: 'http://www.youtube.com/embed/Y6iPsPwYD7g',
 			title: 'Change Your Privacy Settings',
 			description: 'Find out how to change your website privacy settings on WordPress.com.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/bjxKGxW0MRA',
+			link: 'http://www.youtube.com/embed/bjxKGxW0MRA',
 			title: 'Add a Site Icon',
 			description: 'Find out how to add a site icon on WordPress.com.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/z6fCtvLB0wM',
+			link: 'http://www.youtube.com/embed/z6fCtvLB0wM',
 			title: 'Create a Multilingual Site',
 			description: 'Find out how to create a multilingual site on WordPress.com.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/D142Edhcpaw',
+			link: 'http://www.youtube.com/embed/D142Edhcpaw',
 			title: 'Customize Your Content Options',
 			description: 'Find out how to customize your content options on select WordPress.com themes.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/Vyr-g5SEuIA',
+			link: 'http://www.youtube.com/embed/Vyr-g5SEuIA',
 			title: 'Change Your Language Settings',
 			description:
 				'Find out how to change your blog or website language and your interface language settings on WordPress.com.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/EUuEuW_LCrc',
+			link: 'http://www.youtube.com/embed/EUuEuW_LCrc',
 			title: 'Activate Free Email Forwarding',
 			description:
 				'Find out how to activate free email forwarding from an address using a custom domain registered through WordPress.com.',
@@ -813,20 +887,20 @@ const videosForSection = {
 	'post-editor': [
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/hNg1rrkiAjg',
+			link: 'http://www.youtube.com/embed/hNg1rrkiAjg',
 			title: 'Set a Featured Image for a Post or Page',
 			description:
 				'Find out how to add a featured image where available on your WordPress.com or Jetpack-enabled WordPress site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/dAcEBKXPlyA',
+			link: 'http://www.youtube.com/embed/dAcEBKXPlyA',
 			title: 'Add a Contact Form to Your Website',
 			description: 'Find out how to add a contact form to your WordPress.com site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/ssfHW5lwFZg',
+			link: 'http://www.youtube.com/embed/ssfHW5lwFZg',
 			title: 'Embed a YouTube Video in Your Website',
 			description:
 				'Find out how to embed a YouTube video in your content (including posts, pages, and even comments) ' +
@@ -834,13 +908,13 @@ const videosForSection = {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/_tpcHN6ZtKM',
+			link: 'http://www.youtube.com/embed/_tpcHN6ZtKM',
 			title: 'Schedule a Post',
 			description: 'Find out how to schedule a post on your WordPress.com website or blog.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/V8UToJoSf4Q',
+			link: 'http://www.youtube.com/embed/V8UToJoSf4Q',
 			title: 'Add a Simple Payment Button',
 			description: 'Find out how to add a payment button to your WordPress.com website.',
 		},
@@ -848,25 +922,25 @@ const videosForSection = {
 	account: [
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/aO-6yu3_xWQ',
+			link: 'http://www.youtube.com/embed/aO-6yu3_xWQ',
 			title: 'Change Your Password',
 			description: 'Find out how to change your account password on WordPress.com.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/qhsjkqFdDZo',
+			link: 'http://www.youtube.com/embed/qhsjkqFdDZo',
 			title: 'Change Your WordPress.com Username',
 			description: 'Find out how to change your username on WordPress.com.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/Tyxu_xT6q1k',
+			link: 'http://www.youtube.com/embed/Tyxu_xT6q1k',
 			title: 'Change Your WordPress.com Display Name',
 			description: 'Find out how to change your display name on WordPress.com.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/07Nf8FkjO4o',
+			link: 'http://www.youtube.com/embed/07Nf8FkjO4o',
 			title: 'Change Your Account Email Address',
 			description: 'Find out how to change your account email address WordPress.com.',
 		},
@@ -874,53 +948,53 @@ const videosForSection = {
 	customizer: [
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/pf_ST7gvY8c',
+			link: 'http://www.youtube.com/embed/pf_ST7gvY8c',
 			title: 'Add a Custom Header Image',
 			description:
 				'Find out how to add a custom header image to your WordPress.com website or blog.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/CY20IAtl2Ac',
+			link: 'http://www.youtube.com/embed/CY20IAtl2Ac',
 			title: 'Create a Custom Website Menu',
 			description:
 				'Find out how to create a custom menu on your WordPress.com or Jetpack-enabled WordPress site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/2H_Jsgh2Z3Y',
+			link: 'http://www.youtube.com/embed/2H_Jsgh2Z3Y',
 			title: 'Add a Widget',
 			description: 'Find out how to add a widget to your WordPress.com website.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/ypFF4ONBfSQ',
+			link: 'http://www.youtube.com/embed/ypFF4ONBfSQ',
 			title: 'Add a Custom Background',
 			description: 'Find out how to add a custom background to your WordPress.com site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/b8EuJDrNeOA',
+			link: 'http://www.youtube.com/embed/b8EuJDrNeOA',
 			title: 'Change Your Site Fonts',
 			description: 'Find out how to change the fonts on your WordPress.com website or blog.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/7VPgvxV78Kc',
+			link: 'http://www.youtube.com/embed/7VPgvxV78Kc',
 			title: 'Add a Gallery Widget',
 			description:
 				'Find out how to add an image gallery widget to your WordPress.com website or blog.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/oDBuaBLrwF8',
+			link: 'http://www.youtube.com/embed/oDBuaBLrwF8',
 			title: 'Use Featured Content',
 			description:
 				'Find out how to use the Featured Content option on your WordPress.com website or blog.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/3TqRr21zyiA',
+			link: 'http://www.youtube.com/embed/3TqRr21zyiA',
 			title: 'Add an Image Widget',
 			description: 'Find out how to add an image widget to your WordPress.com website or blog.',
 		},
@@ -928,65 +1002,65 @@ const videosForSection = {
 	'posts-pages': [
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/3RPidSCQ0LI',
+			link: 'http://www.youtube.com/embed/3RPidSCQ0LI',
 			title: 'Create a Landing Page',
 			description:
 				'Find out how to create a one-page website or landing page on your WordPress.com site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/4IkFQzl5nXc',
+			link: 'http://www.youtube.com/embed/4IkFQzl5nXc',
 			title: 'Set Up a Website in 5 Steps',
 			description: 'Find out how to create a website on WordPress.com in five steps.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/mta6Y0o7yJk',
+			link: 'http://www.youtube.com/embed/mta6Y0o7yJk',
 			title: 'Set Up a Blog in 5 Steps',
 			description: 'Find out how to create a blog on WordPress.com in five steps.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/Gx7YNX1Wk5U',
+			link: 'http://www.youtube.com/embed/Gx7YNX1Wk5U',
 			title: 'Create a Page',
 			description: 'Find out how to create a page on your WordPress.com site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/mCfuh5bCOwM',
+			link: 'http://www.youtube.com/embed/mCfuh5bCOwM',
 			title: 'Create a Post',
 			description: 'Find out how to create a post on WordPress.com.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/bEVHg6nopcs',
+			link: 'http://www.youtube.com/embed/bEVHg6nopcs',
 			title: 'Use a Custom Menu in a Widget',
 			description:
 				'Find out how to use a custom menu in a widget on your WordPress.com or Jetpack-enabled WordPress site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/nAzdUOlFoBI',
+			link: 'http://www.youtube.com/embed/nAzdUOlFoBI',
 			title: 'Configure a Static Homepage',
 			description:
 				'By default, your new WordPress.com website displays your latest posts. Find out how to create a static homepage instead.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/MPpVeMmDOhk',
+			link: 'http://www.youtube.com/embed/MPpVeMmDOhk',
 			title: 'Show Related Posts on Your WordPress Blog',
 			description:
 				'Find out how to show related posts on your WordPress.com site, which you can also do on a Jetpack-enabled WordPress blog.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/JVnltCZUKC4',
+			link: 'http://www.youtube.com/embed/JVnltCZUKC4',
 			title: 'Add Testimonials',
 			description: 'Find out how to add testimonials to your WordPress.com website or blog.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/yH_gapAUGAA',
+			link: 'http://www.youtube.com/embed/yH_gapAUGAA',
 			title: 'Change Your Post or Page Visibility Settings',
 			description: 'Find out how to change your page or post visibility settings WordPress.com.',
 		},
@@ -994,7 +1068,7 @@ const videosForSection = {
 	media: [
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/VjGnEHyqVqQ',
+			link: 'http://www.youtube.com/embed/VjGnEHyqVqQ',
 			title: 'Add a Photo Gallery',
 			description:
 				'Find out how to add a photo gallery on your WordPress.com and Jetpack-enabled website.',
@@ -1003,7 +1077,7 @@ const videosForSection = {
 	themes: [
 		{
 			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/embed/yOfAuOb68Hc',
+			link: 'http://www.youtube.com/embed/yOfAuOb68Hc',
 			title: 'Change Your Website Theme on WordPress.com',
 			description: 'Find out how to change your WordPress.com theme.',
 		},

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -14,26 +14,26 @@ import { RESULT_TOUR, RESULT_VIDEO } from './constants';
  */
 const fallbackLinks = [
 	{
-		link: 'http://en.support.wordpress.com/business-plan/',
+		link: 'https://en.support.wordpress.com/business-plan/',
 		post_id: 134940,
 		title: 'Uploading custom plugins and themes',
 		description: 'Learn more about installing a custom theme or plugin using the Business plan.',
 	},
 	{
-		link: 'http://en.support.wordpress.com/all-about-domains/',
+		link: 'https://en.support.wordpress.com/all-about-domains/',
 		post_id: 41171,
 		title: 'All About Domains',
 		description: 'Set up your domain whether it’s registered with WordPress.com or elsewhere.',
 	},
 	{
-		link: 'http://en.support.wordpress.com/start/',
+		link: 'https://en.support.wordpress.com/start/',
 		post_id: 81083,
 		title: 'Get Started',
 		description:
 			'No matter what kind of site you want to build, our five-step checklists will get you set up and ready to publish.',
 	},
 	{
-		link: 'http://en.support.wordpress.com/settings/privacy-settings/',
+		link: 'https://en.support.wordpress.com/settings/privacy-settings/',
 		post_id: 1507,
 		title: 'Privacy Settings',
 		description: 'Limit your site’s visibility or make it completely private.',
@@ -50,21 +50,21 @@ const contextLinksForSection = {
 				'Your stats page includes a bunch of nifty graphs, charts, and lists that show you how many visits your site…',
 		},
 		{
-			link: 'http://en.support.wordpress.com/getting-more-views-and-traffic/',
+			link: 'https://en.support.wordpress.com/getting-more-views-and-traffic/',
 			post_id: 3307,
 			title: 'Getting More Views and Traffic',
 			description:
 				'Want more traffic? Here are some tips for attracting more visitors to your site: Tell people in your social networks…',
 		},
 		{
-			link: 'http://en.support.wordpress.com/increase-your-site-traffic/',
+			link: 'https://en.support.wordpress.com/increase-your-site-traffic/',
 			post_id: 132186,
 			title: 'Increase Your Site Traffic',
 			description:
 				'One of the most frequent questions our community members ask us — and themselves — is how to get more…',
 		},
 		{
-			link: 'http://en.support.wordpress.com/grow-your-community/',
+			link: 'https://en.support.wordpress.com/grow-your-community/',
 			post_id: 132190,
 			title: 'Grow Your Community',
 			description:
@@ -80,14 +80,14 @@ const contextLinksForSection = {
 				'Start sharing your site and attract more traffic and visitors to your content. Learn to activate and control the social…',
 		},
 		{
-			link: 'http://en.support.wordpress.com/sharing/',
+			link: 'https://en.support.wordpress.com/sharing/',
 			post_id: 7499,
 			title: 'Sharing',
 			description:
 				'At the bottom of each post and page you can include sharing buttons for your readers to share your content…',
 		},
 		{
-			link: 'http://en.support.wordpress.com/instagram/',
+			link: 'https://en.support.wordpress.com/instagram/',
 			post_id: 77589,
 			title: 'Instagram',
 			description:
@@ -95,7 +95,7 @@ const contextLinksForSection = {
 				'and share photos and short videos using your smartphone or other mobile device…',
 		},
 		{
-			link: 'http://en.support.wordpress.com/twitter/',
+			link: 'https://en.support.wordpress.com/twitter/',
 			post_id: 124,
 			title: 'Twitter',
 			description:
@@ -698,12 +698,12 @@ const contextLinksForSection = {
 				'but sometimes it can be difficult to determine the...',
 		},
 		{
-			link: 'http://en.support.wordpress.com/',
+			link: 'https://en.support.wordpress.com/',
 			title: 'All support articles',
 			description: 'Looking to learn more about a feature? Our docs have all the details.',
 		},
 		{
-			link: 'http://learn.wordpress.com/',
+			link: 'https://learn.wordpress.com/',
 			title: 'Self-guided online tutorial',
 			description: 'A step-by-step guide to getting familiar with the platform.',
 		},
@@ -742,7 +742,7 @@ const contextLinksForSection = {
 };
 
 /*
-source: http://www.youtube.com/playlist?list=PLQFhxUeNFfdKx9gO0a2mp9h8pKjb2y9la
+source: https://www.youtube.com/playlist?list=PLQFhxUeNFfdKx9gO0a2mp9h8pKjb2y9la
 run this in the console to get the videos into a more helpful format (also removes duplicates):
 ```JavaScript
 data = {};
@@ -756,7 +756,7 @@ const videosForSection = {
 	sharing: [
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/YVelWG3hf3o',
+			link: 'https://www.youtube.com/embed/YVelWG3hf3o',
 			title: 'Add Social Sharing Buttons to Your Website',
 			description:
 				'Find out how to add social sharing buttons to your WordPress.com site, which you can also ' +
@@ -764,7 +764,7 @@ const videosForSection = {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/NcCe0ozmqFM',
+			link: 'https://www.youtube.com/embed/NcCe0ozmqFM',
 			title: 'Connect Your Blog to Facebook Using Publicize',
 			description:
 				'Find out how to share blog posts directly on Facebook from your WordPress.com site, ' +
@@ -772,35 +772,35 @@ const videosForSection = {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/f44-4TgnWTs',
+			link: 'https://www.youtube.com/embed/f44-4TgnWTs',
 			title: 'Display Your Instagram Feed on Your Website',
 			description:
 				'Find out how to display your latest Instagram photos right on your WordPress.com site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/3rTooGV_mlg',
+			link: 'https://www.youtube.com/embed/3rTooGV_mlg',
 			title: 'Set Up the Social Links Menu',
 			description:
 				'Find out how to set up a social links menu on your WordPress.com or Jetpack-enabled WordPress site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/gmrOkkqMNlc',
+			link: 'https://www.youtube.com/embed/gmrOkkqMNlc',
 			title: 'Embed a Twitter Timeline in your Sidebar',
 			description:
 				'Find out how to display your Twitter timeline on your WordPress.com or Jetpack-enabled WordPress site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/vy-U5saqG9A',
+			link: 'https://www.youtube.com/embed/vy-U5saqG9A',
 			title: 'Set Up a Social Media Icons Widget',
 			description:
 				'Find out how to set up the social media icons widget on your WordPress.com or Jetpack-enabled WordPress site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/N0GRBFRkzzs',
+			link: 'https://www.youtube.com/embed/N0GRBFRkzzs',
 			title: 'Embed a Tweet from Twitter in Your Website',
 			description:
 				'Find out how to embed a Tweet in your content (including posts and pages) on your WordPress.com ' +
@@ -808,7 +808,7 @@ const videosForSection = {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/uVRji6bKJUE',
+			link: 'https://www.youtube.com/embed/uVRji6bKJUE',
 			title: 'Embed an Instagram Photo in Your Website',
 			description:
 				'Find out how to embed an Instagram photo in your content (including posts and pages) on your WordPress.com ' +
@@ -816,7 +816,7 @@ const videosForSection = {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/sKm3Q83JxM0',
+			link: 'https://www.youtube.com/embed/sKm3Q83JxM0',
 			title: 'Embed a Facebook Update in Your Website',
 			description:
 				'Find out how to embed a Facebook update in your content (including posts, pages, and even comments) on your ' +
@@ -824,7 +824,7 @@ const videosForSection = {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/SBgNkre_b14',
+			link: 'https://www.youtube.com/embed/SBgNkre_b14',
 			title: 'Share Blog Posts Directly on Twitter',
 			description:
 				'Find out how to share blog posts directly on Twitter from your WordPress.com or Jetpack-enabled WordPress site.',
@@ -833,13 +833,13 @@ const videosForSection = {
 	settings: [
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/0YCZ22k4SfQ',
+			link: 'https://www.youtube.com/embed/0YCZ22k4SfQ',
 			title: 'Add a Site Logo',
 			description: 'Find out how to add a custom logo to your WordPress.com site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/vucZ1uZ2NPo',
+			link: 'https://www.youtube.com/embed/vucZ1uZ2NPo',
 			title: 'Update Your Website Title and Tagline',
 			description:
 				'Find out how to update the Title and Tagline of your WordPress.com site, which you can also ' +
@@ -847,38 +847,38 @@ const videosForSection = {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/Y6iPsPwYD7g',
+			link: 'https://www.youtube.com/embed/Y6iPsPwYD7g',
 			title: 'Change Your Privacy Settings',
 			description: 'Find out how to change your website privacy settings on WordPress.com.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/bjxKGxW0MRA',
+			link: 'https://www.youtube.com/embed/bjxKGxW0MRA',
 			title: 'Add a Site Icon',
 			description: 'Find out how to add a site icon on WordPress.com.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/z6fCtvLB0wM',
+			link: 'https://www.youtube.com/embed/z6fCtvLB0wM',
 			title: 'Create a Multilingual Site',
 			description: 'Find out how to create a multilingual site on WordPress.com.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/D142Edhcpaw',
+			link: 'https://www.youtube.com/embed/D142Edhcpaw',
 			title: 'Customize Your Content Options',
 			description: 'Find out how to customize your content options on select WordPress.com themes.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/Vyr-g5SEuIA',
+			link: 'https://www.youtube.com/embed/Vyr-g5SEuIA',
 			title: 'Change Your Language Settings',
 			description:
 				'Find out how to change your blog or website language and your interface language settings on WordPress.com.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/EUuEuW_LCrc',
+			link: 'https://www.youtube.com/embed/EUuEuW_LCrc',
 			title: 'Activate Free Email Forwarding',
 			description:
 				'Find out how to activate free email forwarding from an address using a custom domain registered through WordPress.com.',
@@ -887,20 +887,20 @@ const videosForSection = {
 	'post-editor': [
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/hNg1rrkiAjg',
+			link: 'https://www.youtube.com/embed/hNg1rrkiAjg',
 			title: 'Set a Featured Image for a Post or Page',
 			description:
 				'Find out how to add a featured image where available on your WordPress.com or Jetpack-enabled WordPress site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/dAcEBKXPlyA',
+			link: 'https://www.youtube.com/embed/dAcEBKXPlyA',
 			title: 'Add a Contact Form to Your Website',
 			description: 'Find out how to add a contact form to your WordPress.com site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/ssfHW5lwFZg',
+			link: 'https://www.youtube.com/embed/ssfHW5lwFZg',
 			title: 'Embed a YouTube Video in Your Website',
 			description:
 				'Find out how to embed a YouTube video in your content (including posts, pages, and even comments) ' +
@@ -908,13 +908,13 @@ const videosForSection = {
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/_tpcHN6ZtKM',
+			link: 'https://www.youtube.com/embed/_tpcHN6ZtKM',
 			title: 'Schedule a Post',
 			description: 'Find out how to schedule a post on your WordPress.com website or blog.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/V8UToJoSf4Q',
+			link: 'https://www.youtube.com/embed/V8UToJoSf4Q',
 			title: 'Add a Simple Payment Button',
 			description: 'Find out how to add a payment button to your WordPress.com website.',
 		},
@@ -922,25 +922,25 @@ const videosForSection = {
 	account: [
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/aO-6yu3_xWQ',
+			link: 'https://www.youtube.com/embed/aO-6yu3_xWQ',
 			title: 'Change Your Password',
 			description: 'Find out how to change your account password on WordPress.com.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/qhsjkqFdDZo',
+			link: 'https://www.youtube.com/embed/qhsjkqFdDZo',
 			title: 'Change Your WordPress.com Username',
 			description: 'Find out how to change your username on WordPress.com.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/Tyxu_xT6q1k',
+			link: 'https://www.youtube.com/embed/Tyxu_xT6q1k',
 			title: 'Change Your WordPress.com Display Name',
 			description: 'Find out how to change your display name on WordPress.com.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/07Nf8FkjO4o',
+			link: 'https://www.youtube.com/embed/07Nf8FkjO4o',
 			title: 'Change Your Account Email Address',
 			description: 'Find out how to change your account email address WordPress.com.',
 		},
@@ -948,53 +948,53 @@ const videosForSection = {
 	customizer: [
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/pf_ST7gvY8c',
+			link: 'https://www.youtube.com/embed/pf_ST7gvY8c',
 			title: 'Add a Custom Header Image',
 			description:
 				'Find out how to add a custom header image to your WordPress.com website or blog.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/CY20IAtl2Ac',
+			link: 'https://www.youtube.com/embed/CY20IAtl2Ac',
 			title: 'Create a Custom Website Menu',
 			description:
 				'Find out how to create a custom menu on your WordPress.com or Jetpack-enabled WordPress site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/2H_Jsgh2Z3Y',
+			link: 'https://www.youtube.com/embed/2H_Jsgh2Z3Y',
 			title: 'Add a Widget',
 			description: 'Find out how to add a widget to your WordPress.com website.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/ypFF4ONBfSQ',
+			link: 'https://www.youtube.com/embed/ypFF4ONBfSQ',
 			title: 'Add a Custom Background',
 			description: 'Find out how to add a custom background to your WordPress.com site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/b8EuJDrNeOA',
+			link: 'https://www.youtube.com/embed/b8EuJDrNeOA',
 			title: 'Change Your Site Fonts',
 			description: 'Find out how to change the fonts on your WordPress.com website or blog.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/7VPgvxV78Kc',
+			link: 'https://www.youtube.com/embed/7VPgvxV78Kc',
 			title: 'Add a Gallery Widget',
 			description:
 				'Find out how to add an image gallery widget to your WordPress.com website or blog.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/oDBuaBLrwF8',
+			link: 'https://www.youtube.com/embed/oDBuaBLrwF8',
 			title: 'Use Featured Content',
 			description:
 				'Find out how to use the Featured Content option on your WordPress.com website or blog.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/3TqRr21zyiA',
+			link: 'https://www.youtube.com/embed/3TqRr21zyiA',
 			title: 'Add an Image Widget',
 			description: 'Find out how to add an image widget to your WordPress.com website or blog.',
 		},
@@ -1002,65 +1002,65 @@ const videosForSection = {
 	'posts-pages': [
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/3RPidSCQ0LI',
+			link: 'https://www.youtube.com/embed/3RPidSCQ0LI',
 			title: 'Create a Landing Page',
 			description:
 				'Find out how to create a one-page website or landing page on your WordPress.com site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/4IkFQzl5nXc',
+			link: 'https://www.youtube.com/embed/4IkFQzl5nXc',
 			title: 'Set Up a Website in 5 Steps',
 			description: 'Find out how to create a website on WordPress.com in five steps.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/mta6Y0o7yJk',
+			link: 'https://www.youtube.com/embed/mta6Y0o7yJk',
 			title: 'Set Up a Blog in 5 Steps',
 			description: 'Find out how to create a blog on WordPress.com in five steps.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/Gx7YNX1Wk5U',
+			link: 'https://www.youtube.com/embed/Gx7YNX1Wk5U',
 			title: 'Create a Page',
 			description: 'Find out how to create a page on your WordPress.com site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/mCfuh5bCOwM',
+			link: 'https://www.youtube.com/embed/mCfuh5bCOwM',
 			title: 'Create a Post',
 			description: 'Find out how to create a post on WordPress.com.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/bEVHg6nopcs',
+			link: 'https://www.youtube.com/embed/bEVHg6nopcs',
 			title: 'Use a Custom Menu in a Widget',
 			description:
 				'Find out how to use a custom menu in a widget on your WordPress.com or Jetpack-enabled WordPress site.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/nAzdUOlFoBI',
+			link: 'https://www.youtube.com/embed/nAzdUOlFoBI',
 			title: 'Configure a Static Homepage',
 			description:
 				'By default, your new WordPress.com website displays your latest posts. Find out how to create a static homepage instead.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/MPpVeMmDOhk',
+			link: 'https://www.youtube.com/embed/MPpVeMmDOhk',
 			title: 'Show Related Posts on Your WordPress Blog',
 			description:
 				'Find out how to show related posts on your WordPress.com site, which you can also do on a Jetpack-enabled WordPress blog.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/JVnltCZUKC4',
+			link: 'https://www.youtube.com/embed/JVnltCZUKC4',
 			title: 'Add Testimonials',
 			description: 'Find out how to add testimonials to your WordPress.com website or blog.',
 		},
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/yH_gapAUGAA',
+			link: 'https://www.youtube.com/embed/yH_gapAUGAA',
 			title: 'Change Your Post or Page Visibility Settings',
 			description: 'Find out how to change your page or post visibility settings WordPress.com.',
 		},
@@ -1068,7 +1068,7 @@ const videosForSection = {
 	media: [
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/VjGnEHyqVqQ',
+			link: 'https://www.youtube.com/embed/VjGnEHyqVqQ',
 			title: 'Add a Photo Gallery',
 			description:
 				'Find out how to add a photo gallery on your WordPress.com and Jetpack-enabled website.',
@@ -1077,7 +1077,7 @@ const videosForSection = {
 	themes: [
 		{
 			type: RESULT_VIDEO,
-			link: 'http://www.youtube.com/embed/yOfAuOb68Hc',
+			link: 'https://www.youtube.com/embed/yOfAuOb68Hc',
 			title: 'Change Your Website Theme on WordPress.com',
 			description: 'Find out how to change your WordPress.com theme.',
 		},

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -15,26 +15,26 @@ import { RESULT_TOUR, RESULT_VIDEO } from './constants';
 const fallbackLinks = [
 	{
 		link: 'http://en.support.wordpress.com/business-plan/',
-		postId: 134940,
+		post_id: 134940,
 		title: 'Uploading custom plugins and themes',
 		description: 'Learn more about installing a custom theme or plugin using the Business plan.',
 	},
 	{
 		link: 'http://en.support.wordpress.com/all-about-domains/',
-		postId: 41171,
+		post_id: 41171,
 		title: 'All About Domains',
 		description: 'Set up your domain whether it’s registered with WordPress.com or elsewhere.',
 	},
 	{
 		link: 'http://en.support.wordpress.com/start/',
-		postId: 81083,
+		post_id: 81083,
 		title: 'Get Started',
 		description:
 			'No matter what kind of site you want to build, our five-step checklists will get you set up and ready to publish.',
 	},
 	{
 		link: 'http://en.support.wordpress.com/settings/privacy-settings/',
-		postId: 1507,
+		post_id: 1507,
 		title: 'Privacy Settings',
 		description: 'Limit your site’s visibility or make it completely private.',
 	},
@@ -44,28 +44,28 @@ const contextLinksForSection = {
 	stats: [
 		{
 			link: 'http://en.support.wordpress.com/stats/',
-			postId: 4454,
+			post_id: 4454,
 			title: 'Stats',
 			description:
 				'Your stats page includes a bunch of nifty graphs, charts, and lists that show you how many visits your site…',
 		},
 		{
 			link: 'http://en.support.wordpress.com/getting-more-views-and-traffic/',
-			postId: 3307,
+			post_id: 3307,
 			title: 'Getting More Views and Traffic',
 			description:
 				'Want more traffic? Here are some tips for attracting more visitors to your site: Tell people in your social networks…',
 		},
 		{
 			link: 'http://en.support.wordpress.com/increase-your-site-traffic/',
-			postId: 132186,
+			post_id: 132186,
 			title: 'Increase Your Site Traffic',
 			description:
 				'One of the most frequent questions our community members ask us — and themselves — is how to get more…',
 		},
 		{
 			link: 'http://en.support.wordpress.com/grow-your-community/',
-			postId: 132190,
+			post_id: 132190,
 			title: 'Grow Your Community',
 			description:
 				"You've worked hard on building your site, now it's time to explore the community and get noticed. On WordPress.com, we…",
@@ -74,21 +74,21 @@ const contextLinksForSection = {
 	sharing: [
 		{
 			link: 'http://en.support.wordpress.com/video-tutorials/connect-to-social-media/',
-			postId: 130825,
+			post_id: 130825,
 			title: 'Integrate and Connect to Social Media',
 			description:
 				'Start sharing your site and attract more traffic and visitors to your content. Learn to activate and control the social…',
 		},
 		{
 			link: 'http://en.support.wordpress.com/sharing/',
-			postId: 7499,
+			post_id: 7499,
 			title: 'Sharing',
 			description:
 				'At the bottom of each post and page you can include sharing buttons for your readers to share your content…',
 		},
 		{
 			link: 'http://en.support.wordpress.com/instagram/',
-			postId: 77589,
+			post_id: 77589,
 			title: 'Instagram',
 			description:
 				'Instagram is a simple way to capture, customize, ' +
@@ -96,7 +96,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/twitter/',
-			postId: 124,
+			post_id: 124,
 			title: 'Twitter',
 			description:
 				'Twitter is a service for the exchange of brief messages, commonly ' +
@@ -106,7 +106,7 @@ const contextLinksForSection = {
 	me: [
 		{
 			link: 'http://en.support.wordpress.com/manage-my-profile/',
-			postId: 19775,
+			post_id: 19775,
 			title: 'Manage My Profile',
 			description:
 				"Your profile is the information you'd like to be shown along with your " +
@@ -114,7 +114,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/gravatars/',
-			postId: 1338,
+			post_id: 1338,
 			title: 'The Gravatar – Your Profile Picture',
 			description:
 				'WordPress.com associates an Avatar with your email address. Gravatar ' +
@@ -123,14 +123,14 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/account-deactivation/',
-			postId: 138080,
+			post_id: 138080,
 			title: 'Account Deactivation',
 			description:
 				'If you are finished with your WordPress.com account and would like to shut it down, please follow the steps outlined...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/change-your-username/',
-			postId: 2116,
+			post_id: 2116,
 			title: 'Change Your Username',
 			description:
 				'You can change both your WordPress.com account username (the name you use to login) and your display name (the name...',
@@ -145,14 +145,14 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/video-tutorials/manage-your-account/',
-			postId: 130826,
+			post_id: 130826,
 			title: 'Manage Your Account',
 			description:
 				'Learn the ins and outs of managing your WordPress.com account and site. Learn how to change your account password and...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/account-settings/',
-			postId: 80368,
+			post_id: 80368,
 			title: 'Account Settings',
 			description:
 				'You can review and edit basic account information in Account Settings. ' +
@@ -168,28 +168,28 @@ const contextLinksForSection = {
 	security: [
 		{
 			link: 'http://en.support.wordpress.com/security/two-step-authentication/',
-			postId: 58847,
+			post_id: 58847,
 			title: 'Two Step Authentication',
 			description:
 				"Your WordPress.com site is your home on the internet, and you want to keep that home safe. Hopefully, you've already...",
 		},
 		{
 			link: 'http://en.support.wordpress.com/account-recovery/',
-			postId: 46365,
+			post_id: 46365,
 			title: 'Account Recovery',
 			description:
 				'At some point, you may run into a situation in which you’ve lost access to your account. We want to...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/passwords/',
-			postId: 89,
+			post_id: 89,
 			title: 'Passwords',
 			description:
 				'Passwords are very important to user accounts, and there may come a time when you need to change your password.',
 		},
 		{
 			link: 'http://en.support.wordpress.com/third-party-applications/',
-			postId: 17288,
+			post_id: 17288,
 			title: 'Third Party Applications',
 			description:
 				'WordPress.com allows you to connect with third-party applications that ' +
@@ -199,7 +199,7 @@ const contextLinksForSection = {
 	purchases: [
 		{
 			link: 'http://en.support.wordpress.com/manage-purchases/',
-			postId: 111349,
+			post_id: 111349,
 			title: 'Manage Purchases',
 			description:
 				'You can manage all of your WordPress.com purchases by navigating to the ' +
@@ -207,7 +207,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/auto-renewal/',
-			postId: 110924,
+			post_id: 110924,
 			title: 'Subscriptions for Plans and Domains',
 			description:
 				'Your WordPress.com plans and any domains you add to your sites are based ' +
@@ -215,7 +215,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/discover-the-wordpress-com-plans/',
-			postId: 140323,
+			post_id: 140323,
 			title: 'Discover the WordPress.com Plans',
 			description:
 				'Thank you for building your site on WordPress.com! Upgrading to a plan unlocks a ton of features.',
@@ -231,7 +231,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/email-notifications/',
-			postId: 9443,
+			post_id: 9443,
 			title: 'Email Notifications',
 			description:
 				'Notifications from WordPress.com will be sent to the email address registered ' +
@@ -239,7 +239,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/following-comments/',
-			postId: 4576,
+			post_id: 4576,
 			title: 'Following Comments',
 			description:
 				'When you leave a comment on a WordPress.com blog, you can choose to automatically ' +
@@ -247,7 +247,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/following/',
-			postId: 4899,
+			post_id: 4899,
 			title: 'Following Blogs',
 			description:
 				'When you follow a blog on WordPress.com, the new posts from that site will appear in your Reader, where you...',
@@ -256,7 +256,7 @@ const contextLinksForSection = {
 	media: [
 		{
 			link: 'http://en.support.wordpress.com/media/',
-			postId: 853,
+			post_id: 853,
 			title: 'Media Library',
 			description:
 				'The Media Library is where you can manage your images, audio, videos, and documents ' +
@@ -264,14 +264,14 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/add-media/finding-free-images-and-other-media/',
-			postId: 78425,
+			post_id: 78425,
 			title: 'Finding Free Images and other Media',
 			description:
 				"What do we mean by 'free media'? While much content on the internet is subject to copyright laws, there are...",
 		},
 		{
 			link: 'http://en.support.wordpress.com/add-media/',
-			postId: 38830,
+			post_id: 38830,
 			title: 'Add Media',
 			description:
 				'Dress up your text-based posts and pages with individual images, image galleries, ' +
@@ -279,7 +279,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/videos/',
-			postId: 4744,
+			post_id: 4744,
 			title: 'Videos',
 			description:
 				'Videos are a great way to enhance your blog posts. We use videos all the time on the WordPress.com News...',
@@ -295,7 +295,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/user-mentions/',
-			postId: 91788,
+			post_id: 91788,
 			title: 'User Mentions',
 			description:
 				'User mentions are a great way to include other WordPress.com users within your ' +
@@ -303,14 +303,14 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/adding-users/',
-			postId: 2160,
+			post_id: 2160,
 			title: 'Inviting Contributors, Followers, and Viewers',
 			description:
 				"On WordPress.com, you are able to add users to your website by sending invitations. To send an invitation, you'll want...",
 		},
 		{
 			link: 'http://en.support.wordpress.com/followers/',
-			postId: 5444,
+			post_id: 5444,
 			title: 'My Followers',
 			description:
 				'When someone follows your site, each time you publish new content on your blog they receive an update in their...',
@@ -319,7 +319,7 @@ const contextLinksForSection = {
 	plugins: [
 		{
 			link: 'http://en.support.wordpress.com/plugins/',
-			postId: 2108,
+			post_id: 2108,
 			title: 'Plugins',
 			description:
 				'On WordPress.com, we include the most popular plugin functionality within our ' +
@@ -327,14 +327,14 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/plugins/managing-plugins/',
-			postId: 134818,
+			post_id: 134818,
 			title: 'Managing plugins',
 			description:
 				'After you install a plugin, it will appear in a list at My Sites → Plugins. This list will display any...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/plugins/adding-plugins/',
-			postId: 134719,
+			post_id: 134719,
 			title: 'Adding plugins',
 			description:
 				'Installing and using plugins In addition to built-in plugin functionality, WordPress.com ' +
@@ -350,7 +350,7 @@ const contextLinksForSection = {
 	'posts-pages': [
 		{
 			link: 'http://en.support.wordpress.com/five-step-website-setup/',
-			postId: 100856,
+			post_id: 100856,
 			title: 'Build Your Website in Five Steps',
 			description:
 				"Great, you've registered a website on wordpress.com. Now what? Whether you're building " +
@@ -358,7 +358,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/pages/landing-pages/',
-			postId: 124077,
+			post_id: 124077,
 			title: 'Landing Pages',
 			description:
 				'Landing pages are pages with a single purpose: encouraging your visitors to sign up for ' +
@@ -366,14 +366,14 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/posts/',
-			postId: 84,
+			post_id: 84,
 			title: 'Posts',
 			description:
 				'Posts are what make your blog a blog — they’re servings of content that are listed in reverse chronological order on...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/posts/post-formats/',
-			postId: 10382,
+			post_id: 10382,
 			title: 'Post Formats',
 			description:
 				'Learn how to make gallery, video, audio, and other post types pop with post formats. ' +
@@ -383,14 +383,14 @@ const contextLinksForSection = {
 	'settings-writing': [
 		{
 			link: 'http://en.support.wordpress.com/settings/writing-settings/',
-			postId: 1502,
+			post_id: 1502,
 			title: '"Writing Settings',
 			description:
 				'To change these settings, go to My Sites → Settings → Writing. Manage Categories and Tags Open the Categories or Tags...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/posts/categories-vs-tags/',
-			postId: 2135,
+			post_id: 2135,
 			title: 'Categories vs. Tags',
 			description:
 				'Once upon a time, WordPress.com only provided a Category option. Categories allowed ' +
@@ -398,14 +398,14 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/feeds/',
-			postId: 3589,
+			post_id: 3589,
 			title: 'Feeds',
 			description:
 				'A feed (often called RSS) is a stream of posts or comments that is updated when new content is published. This...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/portfolios/',
-			postId: 84808,
+			post_id: 84808,
 			title: 'Portfolios',
 			description:
 				"If you're hoping to use your WordPress.com site to show off your portfolio separate " +
@@ -415,7 +415,7 @@ const contextLinksForSection = {
 	'settings-discussion': [
 		{
 			link: 'http://en.support.wordpress.com/settings/discussion-settings/',
-			postId: 1504,
+			post_id: 1504,
 			title: 'Discussion Settings',
 			description:
 				'The Discussion Settings are used to control how visitors and other blogs interact ' +
@@ -423,7 +423,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/enable-disable-comments-for-future-posts/',
-			postId: 5997,
+			post_id: 5997,
 			title: 'Enable and Disable Comments for Future Posts',
 			description:
 				'You can enable/disable comments on future posts by going into your Discussion settings. ' +
@@ -431,14 +431,14 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/comments/',
-			postId: 113,
+			post_id: 113,
 			title: 'Comments',
 			description:
 				'Comments are a way for visitors to add feedback to your posts and pages. If you choose to enable comments...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/subscriptions-and-newsletters/',
-			postId: 67810,
+			post_id: 67810,
 			title: 'Subscriptions and Newsletters',
 			description:
 				'This article explains how readers can subscribe to your blog to receive email notifications of all of your posts.  On...',
@@ -453,14 +453,14 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/related-posts/',
-			postId: 1545,
+			post_id: 1545,
 			title: 'Related Posts',
 			description:
 				'The Related Posts feature pulls relevant content from your blog to display at the bottom of your posts.',
 		},
 		{
 			link: 'http://en.support.wordpress.com/webmaster-tools/',
-			postId: 5022,
+			post_id: 5022,
 			title: 'Webmaster Tools',
 			description:
 				'WordPress.com provides you with built-in stats that give you lots of information ' +
@@ -468,7 +468,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/amp-accelerated-mobile-pages/',
-			postId: 122516,
+			post_id: 122516,
 			title: 'AMP (Accelerated Mobile Pages)',
 			description:
 				'AMP (Accelerated Mobile Pages) is an open-source framework that allows browsers ' +
@@ -478,14 +478,14 @@ const contextLinksForSection = {
 	'settings-security': [
 		{
 			link: 'http://en.support.wordpress.com/security/',
-			postId: 10977,
+			post_id: 10977,
 			title: 'Security',
 			description:
 				'The security of your site and your personal data is always a priority. This page describes what we do to...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/unwanted-comments/',
-			postId: 5882,
+			post_id: 5882,
 			title: 'Unwanted Comments and Comment Spam',
 			description:
 				'There are many ways to protect your WordPress.com blogs from unwanted comments: ' +
@@ -493,7 +493,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/selecting-a-strong-password/',
-			postId: 35364,
+			post_id: 35364,
 			title: 'Selecting a Strong Password',
 			description:
 				'The weakest point in any security for your online accounts is usually your password. At WordPress.com, we go to great...',
@@ -502,14 +502,14 @@ const contextLinksForSection = {
 	settings: [
 		{
 			link: 'http://en.support.wordpress.com/settings/',
-			postId: 497,
+			post_id: 497,
 			title: 'Settings',
 			description:
 				'The Settings menu of your site is where you will configure everything about how the blog works and functions. You...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/settings/general-settings/',
-			postId: 1501,
+			post_id: 1501,
 			title: 'General Settings',
 			description:
 				'The General Settings let you control how your site is displayed, such as the ' +
@@ -517,13 +517,13 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/site-icons/',
-			postId: 1327,
+			post_id: 1327,
 			title: 'Site Icons',
 			description: '',
 		},
 		{
 			link: 'http://en.support.wordpress.com/five-step-blog-setup/',
-			postId: 100846,
+			post_id: 100846,
 			title: 'Set Up Your Blog in Five Steps',
 			description:
 				"Congrats, you've registered your blog -- maybe you've even published your first " +
@@ -533,7 +533,7 @@ const contextLinksForSection = {
 	themes: [
 		{
 			link: 'http://en.support.wordpress.com/themes/',
-			postId: 2278,
+			post_id: 2278,
 			title: 'Themes',
 			description:
 				'A theme controls the general look and feel of your site including things like ' +
@@ -541,7 +541,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/themes/mobile-themes/',
-			postId: 4925,
+			post_id: 4925,
 			title: 'Mobile Themes',
 			description:
 				'When a visitor browses to a WordPress.com blog on a mobile device, we show ' +
@@ -549,7 +549,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/premium-themes/',
-			postId: 12112,
+			post_id: 12112,
 			title: 'Premium Themes',
 			description:
 				'Purchasing a Premium Theme On a site with the Premium or Business plan, you can switch to any premium theme...',
@@ -602,7 +602,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/plan-features/',
-			postId: 134698,
+			post_id: 134698,
 			title: 'WordPress.com Plans',
 			description:
 				'All WordPress.com sites are packed with awesome features, and if you would like to take yours to the next level, ...',
@@ -616,7 +616,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/jetpack-add-ons/',
-			postId: 115025,
+			post_id: 115025,
 			title: 'Jetpack Plans',
 			description:
 				'What is Jetpack and do I need it? Jetpack is a feature-rich plugin for self-hosted WordPress sites. If your site...',
@@ -625,21 +625,21 @@ const contextLinksForSection = {
 	'post-editor': [
 		{
 			link: 'http://en.support.wordpress.com/editors/',
-			postId: 3347,
+			post_id: 3347,
 			title: 'Editors',
 			description:
 				'When creating a post or page on your WordPress.com blog, you have two editing modes available to you. Visual Editor...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/visual-editor/',
-			postId: 3644,
+			post_id: 3644,
 			title: 'Visual Editor',
 			description:
 				'The visual editor provides a semi-WYSIWYG (What You See is What You Get) content editor that allows you to easily...',
 		},
 		{
 			link: 'http://en.support.wordpress.com/xml-rpc/',
-			postId: 3595,
+			post_id: 3595,
 			title: 'Offline Editing',
 			description:
 				'There are several desktop applications which you can use to write and publish ' +
@@ -655,7 +655,7 @@ const contextLinksForSection = {
 	reader: [
 		{
 			link: 'http://en.support.wordpress.com/reader/',
-			postId: 32011,
+			post_id: 32011,
 			title: 'Reader',
 			description:
 				'Read posts from all the sites you follow (even the ones that aren’t on WordPress.com), find great new reads, and keep...',
@@ -668,7 +668,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/topics/',
-			postId: 2166,
+			post_id: 2166,
 			title: 'Tags in the Reader',
 			description:
 				'Looking for posts on a specific topic? Besides following entire blogs, you can also follow posts on a specific subject...',
@@ -683,7 +683,7 @@ const contextLinksForSection = {
 	help: [
 		{
 			link: 'http://en.support.wordpress.com/blogging-u/',
-			postId: 117437,
+			post_id: 117437,
 			title: 'Blogging U.',
 			description:
 				'Blogging U. courses deliver expert advice, pro tips, and inspiration right to your ' +
@@ -691,7 +691,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/help-support-options/',
-			postId: 149,
+			post_id: 149,
 			title: 'Help! Getting WordPress.com Support',
 			description:
 				'WordPress.com offers a number of avenues for reaching helpful, individualized support, ' +
@@ -717,7 +717,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/comment-display-options/',
-			postId: 5840,
+			post_id: 5840,
 			title: 'Comment Display Options',
 			description:
 				'You can control comment threading, paging, and comment order settings from the ' +
@@ -732,7 +732,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: 'http://en.support.wordpress.com/comment-likes/',
-			postId: 88757,
+			post_id: 88757,
 			title: 'Comment Likes',
 			description:
 				"Comment Likes: how to like others' comments and control how Comment Likes " +

--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -24,6 +24,8 @@ import ResizableIframe from 'components/resizable-iframe';
 import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
 import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
 import AsyncLoad from 'components/async-load';
+import SupportArticle from 'blocks/inline-help/inline-help-support-article';
+import { SUPPORT_BLOG_ID } from 'blocks/inline-help/constants';
 
 /**
  * Module variables
@@ -109,23 +111,46 @@ class InlineHelp extends Component {
 	};
 
 	// @TODO: Instead of prop drilling this should be done via redux
-	setDialogState = ( { showDialog, videoLink } ) =>
+	setDialogState = ( {
+		showDialog,
+		videoLink = null,
+		dialogType,
+		dialogPostId = null,
+		dialogPostHref = null,
+	} ) =>
 		this.setState( {
 			showDialog,
 			videoLink,
+			dialogType,
+			dialogPostId,
+			dialogPostHref,
 		} );
 
 	closeDialog = () => this.setState( { showDialog: false } );
 
 	render() {
 		const { translate } = this.props;
-		const { showInlineHelp, showDialog, videoLink } = this.state;
+		const {
+			showInlineHelp,
+			showDialog,
+			videoLink,
+			dialogType,
+			dialogPostId,
+			dialogPostHref,
+		} = this.state;
 		const inlineHelpButtonClasses = { 'inline-help__button': true, 'is-active': showInlineHelp };
 
 		/* @TODO: This class is not valid and this tricks the linter
 		 		  fix this class and fix the linter to catch similar instances.
 		 */
 		const iframeClasses = classNames( 'inline-help__richresult__dialog__video' );
+
+		const dialogButtons = dialogType === 'article' && [
+			<Button href={ dialogPostHref } target="_blank" primary>
+				{ translate( 'Visit Article' ) }
+			</Button>,
+			<Button onClick={ this.closeDialog }>{ translate( 'Close', { textOnly: true } ) }</Button>,
+		];
 
 		return (
 			<div className="inline-help">
@@ -151,20 +176,26 @@ class InlineHelp extends Component {
 					<Dialog
 						additionalClassNames="inline-help__richresult__dialog"
 						isVisible
+						buttons={ dialogButtons }
 						onCancel={ this.closeDialog }
 						onClose={ this.closeDialog }
 					>
-						<div className={ iframeClasses }>
-							<ResizableIframe
-								src={ videoLink + '?rel=0&amp;showinfo=0&amp;autoplay=1' }
-								frameBorder="0"
-								seamless
-								allowFullScreen
-								autoPlay
-								width="640"
-								height="360"
-							/>
-						</div>
+						{ dialogType === 'article' && (
+							<SupportArticle blogId={ SUPPORT_BLOG_ID } postId={ dialogPostId } />
+						) }
+						{ dialogType === 'video' && (
+							<div className={ iframeClasses }>
+								<ResizableIframe
+									src={ videoLink + '?rel=0&amp;showinfo=0&amp;autoplay=1' }
+									frameBorder="0"
+									seamless
+									allowFullScreen
+									autoPlay
+									width="640"
+									height="360"
+								/>
+							</div>
+						) }
 					</Dialog>
 				) }
 				{ this.props.isHappychatButtonVisible &&

--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -144,6 +144,7 @@ class InlineHelp extends Component {
 		 		  fix this class and fix the linter to catch similar instances.
 		 */
 		const iframeClasses = classNames( 'inline-help__richresult__dialog__video' );
+		const dialogClasses = classNames( 'inline-help__richresult__dialog', dialogType );
 
 		const dialogButtons = dialogType === 'article' && [
 			<Button href={ dialogPostHref } target="_blank" primary>
@@ -174,7 +175,7 @@ class InlineHelp extends Component {
 				) }
 				{ showDialog && (
 					<Dialog
-						additionalClassNames="inline-help__richresult__dialog"
+						additionalClassNames={ dialogClasses }
 						isVisible
 						buttons={ dialogButtons }
 						onCancel={ this.closeDialog }

--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -148,7 +148,7 @@ class InlineHelp extends Component {
 
 		const dialogButtons = dialogType === 'article' && [
 			<Button href={ dialogPostHref } target="_blank" primary>
-				{ translate( 'Visit Article' ) }
+				{ translate( 'Visit Article' ) } <Gridicon icon="external" size={ 12 } />
 			</Button>,
 			<Button onClick={ this.closeDialog }>{ translate( 'Close', { textOnly: true } ) }</Button>,
 		];

--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -40,8 +40,9 @@ class InlineHelpRichResult extends Component {
 	handleClick = event => {
 		event.preventDefault();
 		const { href } = event.target;
-		const { type } = this.props;
-		const tour = get( this.props.result, RESULT_TOUR );
+		const { type, result } = this.props;
+		const tour = get( result, RESULT_TOUR );
+		const postId = get( result, 'post_id' );
 		const tracksData = omitBy(
 			{
 				search_query: this.props.searchQuery,
@@ -61,9 +62,18 @@ class InlineHelpRichResult extends Component {
 			} else {
 				this.props.setDialogState( {
 					showDialog: true,
-					videoLink: get( this.props.result, RESULT_LINK ),
+					dialogType: 'video',
+					videoLink: get( result, RESULT_LINK ),
 				} );
 			}
+		} else if ( type === RESULT_ARTICLE && postId ) {
+			event.preventDefault();
+			this.props.setDialogState( {
+				showDialog: true,
+				dialogType: 'article',
+				dialogPostHref: href,
+				dialogPostId: postId,
+			} );
 		} else {
 			if ( ! href ) {
 				return;

--- a/client/blocks/inline-help/inline-help-support-article/_content.scss
+++ b/client/blocks/inline-help/inline-help-support-article/_content.scss
@@ -1,0 +1,214 @@
+.inline-help-support-article__story-content {
+	@extend %content-font;
+	margin: 0;
+	padding-top: 16px;
+	position: relative;
+	font-size: 17px;
+	line-height: 1.7;
+	overflow-wrap: break-word;
+	word-wrap: break-word;
+
+	h1 {
+		font-size: 28px;
+		font-weight: 700;
+		margin: 0 0 16px;
+	}
+
+	h2 {
+		font-size: 24px;
+		font-weight: 700;
+		margin: 0 0 8px;
+	}
+
+	h3 {
+		font-size: 20px;
+		font-weight: 700;
+		margin: 0 0 8px;
+	}
+
+	h4 {
+		font-size: 18px;
+		font-weight: 700;
+		margin: 0 0 8px;
+	}
+
+	h5 {
+		font-weight: 700;
+	}
+
+	p, > div {
+		margin: 0 0 24px;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	blockquote {
+		padding: 0 24px 0 32px;
+		margin: 16px 0 32px;
+		border-left: 3px solid $gray-lighten-30;
+		color: $gray-darken-20;
+		font-weight: normal;
+		background: transparent;
+	}
+
+	hr {
+		background: $gray-lighten-30;
+		margin: 24px 0;
+	}
+
+	img {
+		max-width: 100%;
+		height: auto;
+		display: inline;
+		margin: auto;
+
+		&.emojify__emoji {
+			height: 1em;
+			margin-bottom: 0;
+		}
+	}
+
+	audio {
+		display: block;
+		width: 100%;
+		margin: 24px auto;
+	}
+
+	iframe[class^="twitter-"],
+	iframe[class^="instagram-"],
+	.fb_iframe_widget {
+		display: block;
+		margin: 24px auto !important;
+	}
+
+	@include breakpoint( ">660px" ) {
+		.alignleft {
+			max-width: 100%;
+			float: left;
+			margin-top: 12px;
+			margin-bottom: 12px;
+			margin-right: 32px;
+		}
+
+		.alignright {
+			max-width: 100%;
+			float: right;
+			margin-top: 12px;
+			margin-bottom: 12px;
+			margin-left: 32px;
+		}
+	}
+
+	@include breakpoint( "<660px" ) {
+		.alignleft,
+		.alignright {
+			clear: both;
+			margin-top: 24px;
+			margin-bottom: 24px;
+		}
+	}
+
+	.aligncenter {
+		clear: both;
+		display: block;
+		margin-top: 24px;
+		margin-bottom: 24px;
+	}
+
+	.wp-caption.alignnone {
+		clear: both;
+		display: block;
+		margin-top: 24px;
+		margin-bottom: 24px;
+	}
+
+	.wp-caption {
+		position: relative;
+		max-width: 100%;
+
+		&.alignright {
+			float: right;
+		}
+
+		&.alignleft {
+			float: left;
+		}
+
+		&.alignright,
+		&.alignleft {
+			max-width: 100%;
+
+			@include breakpoint( ">660px" ) {
+				max-width: 50%;
+			}
+
+			img.alignright,
+			img.alignleft {
+				float: none;
+			}
+		}
+
+		img {
+			display: block;
+			margin: 0 auto;
+
+			&.emojify__emoji {
+				display: inline;
+			}
+		}
+	}
+
+	.wp-caption-text,
+	figure figcaption,
+	figure .caption,
+	.wp-caption .wp-media-credit {
+		padding: 12px;
+		margin: 0;
+		font-size: 13px;
+		text-align: center;
+		color: $gray-darken-10;
+	}
+
+	// placeholder for videopress videos
+	.video-plh-notice {
+		position: relative;
+		margin-bottom: 24px;
+		padding: 11px 24px;
+		border-radius: 1px;
+		background: $gray-light;
+		box-sizing: border-box;
+		font-size: 14px;
+		line-height: 1.4285;
+		animation: appear .3s ease-in-out;
+
+		@include breakpoint( ">660px" ) {
+			padding: 13px 48px;
+			font-size: inherit;
+		}
+	}
+
+	sup, sub {
+		vertical-align: baseline;
+		position: relative;
+		font-size: 0.83em;
+	}
+
+	sup {
+		top: -0.4em;
+	}
+
+	sub {
+		bottom: -0.2em;
+	}
+
+	table th,
+	table td {
+		padding: 10px;
+	}
+
+	img:first-child {
+		margin-top: 0;
+	}
+}

--- a/client/blocks/inline-help/inline-help-support-article/_support-article.scss
+++ b/client/blocks/inline-help/inline-help-support-article/_support-article.scss
@@ -1,29 +1,7 @@
 @import 'content';
 
-.inline-help-support-article {
-	margin: 0 auto;
-	padding: 0 20px;
-
-	@include breakpoint( ">1280px" ) {
-		width: 720px;
-	}
-
-	@include breakpoint( "1040px-1280px" ) {
-		width: 720px;
-	}
-
-	@include breakpoint( "660px-1040px" ) {
-		width: auto;
-		margin: 0;
-	}
-
-	@include breakpoint( "<660px" ) {
-		width: auto;
-	}
-}
-
 .inline-help-support-article__story {
-	max-width: 720px;
+	padding: 0 20px;
 
 	.inline-help-support-article__header-title {
 		margin: 12px 0 0;
@@ -35,7 +13,7 @@
 	}
 
 	@include breakpoint( "<660px" ) {
-		// margin-top: -35px;
+		width: auto;
 	}
 }
 

--- a/client/blocks/inline-help/inline-help-support-article/_support-article.scss
+++ b/client/blocks/inline-help/inline-help-support-article/_support-article.scss
@@ -1,6 +1,6 @@
 @import 'content';
 
-.inline-help-support-article__content {
+.inline-help-support-article {
 	margin: 0 auto;
 	padding: 0 20px;
 

--- a/client/blocks/inline-help/inline-help-support-article/_support-article.scss
+++ b/client/blocks/inline-help/inline-help-support-article/_support-article.scss
@@ -1,7 +1,7 @@
 @import 'content';
 
 .inline-help-support-article__story {
-	padding: 0 20px;
+	padding: 0 20px 20px;
 
 	.inline-help-support-article__header-title {
 		margin: 12px 0 0;

--- a/client/blocks/inline-help/inline-help-support-article/_support-article.scss
+++ b/client/blocks/inline-help/inline-help-support-article/_support-article.scss
@@ -1,0 +1,135 @@
+@import 'content';
+
+.inline-help-support-article__content {
+	margin: 0 auto;
+	padding: 0 20px;
+
+	@include breakpoint( ">1280px" ) {
+		width: 720px;
+	}
+
+	@include breakpoint( "1040px-1280px" ) {
+		width: 720px;
+	}
+
+	@include breakpoint( "660px-1040px" ) {
+		width: auto;
+		margin: 0;
+	}
+
+	@include breakpoint( "<660px" ) {
+		width: auto;
+	}
+}
+
+.inline-help-support-article__story {
+	max-width: 720px;
+
+	.inline-help-support-article__header-title {
+		margin: 12px 0 0;
+	}
+
+	@include breakpoint( "<480px" ) {
+		font-size: 15px;
+		line-height: 24px;
+	}
+
+	@include breakpoint( "<660px" ) {
+		// margin-top: -35px;
+	}
+}
+
+.inline-help-support-article__story-content {
+	.toc-jump {
+		display: none;
+	}
+
+	color: $gray-dark;
+	font-size: 17px;
+	line-height: 28px;
+}
+
+.inline-help-support-article__story-content img {
+	margin-bottom: 12px;
+}
+
+.inline-help-support-article__story-content figure img {
+	margin-bottom: 0;
+}
+
+.inline-help-support-article__header-title a {
+	text-decoration: none;
+	clear: none;
+	color: $gray-dark;
+	font-family: $serif;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-size: 26px;
+	font-weight: 700;
+	line-height: 34px;
+	margin: 56px 0 0;
+	max-width: 750px;
+
+	@include breakpoint( ">960px" ) {
+		font-size: 36px;
+		line-height: 46px;
+	}
+
+	@include breakpoint( "480px-960px" ) {
+		font-size: 32px;
+		line-height: 40px;
+	}
+
+	@include breakpoint( "<660px" ) {
+		margin-top: 8px;
+	}
+
+	.inline-help-support-article__header-title-link {
+		display: block;
+	}
+
+	.inline-help-support-article__header-title-link,
+	.inline-help-support-article__header-title-link:hover {
+		text-decoration: underline;
+		color: $gray-dark;
+	}
+}
+
+.inline-help-support-article__header {
+	margin-bottom: 23px;
+}
+
+.inline-help-support-article .embed-youtube,
+.inline-help-support-article .embed-vimeo {
+	display: block;
+	margin-bottom: 25px;
+	position: relative;
+	padding: 25px 0 56.25%;
+	// We currently have to use !important here to override the inline style on the Youtube embed
+	// - see https://github.com/Automattic/wp-calypso/issues/9615
+	text-align: initial !important;
+
+	iframe {
+		height: 100%;
+		position: absolute;
+			top: 0;
+		width: 100%;
+	}
+}
+
+.inline-help-support-article .embed-vimeo {
+	margin-bottom: 0;
+}
+
+// Placeholders
+.inline-help-support-article__header-title {
+	&.is-placeholder {
+		@include placeholder();
+	}
+}
+
+.inline-help-support-article__placeholder-text {
+	@include placeholder();
+	margin-bottom: 16px;
+	min-height: 200px;
+}

--- a/client/blocks/inline-help/inline-help-support-article/header.jsx
+++ b/client/blocks/inline-help/inline-help-support-article/header.jsx
@@ -1,0 +1,38 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ExternalLink from 'components/external-link';
+
+const ReaderFullPostHeader = ( { post, isLoading } ) =>
+	isLoading || ! post ? (
+		<div className="inline-help-support-article__header is-placeholder">
+			<h1 className="inline-help-support-article__header-title is-placeholder">Post loading…</h1>
+		</div>
+	) : (
+		<div className="inline-help-support-article__header">
+			<h1 className="inline-help-support-article__header-title">
+				<ExternalLink
+					className="inline-help-support-article__header-title-link"
+					href={ post.URL }
+					target="_blank"
+					icon={ false }
+				>
+					{ post.title }
+				</ExternalLink>
+			</h1>
+		</div>
+	);
+
+ReaderFullPostHeader.propTypes = {
+	post: PropTypes.object,
+	isLoading: PropTypes.bool,
+};
+
+export default ReaderFullPostHeader;

--- a/client/blocks/inline-help/inline-help-support-article/index.jsx
+++ b/client/blocks/inline-help/inline-help-support-article/index.jsx
@@ -32,28 +32,24 @@ export class FullPostView extends React.Component {
 
 		/*eslint-disable react/no-danger */
 		return (
-			<div className="inline-help-support-article">
+			<Emojify className="inline-help-support-article">
 				{ site && <QueryPostLikes siteId={ post.site_ID } postId={ post.ID } /> }
 				{ post && post.site_ID && <QueryReaderSite siteId={ +post.site_ID } /> }
 				{ isLoading && <QueryReaderPost postKey={ postKey } /> }
-				<div className="inline-help-support-article__content">
-					<Emojify>
-						<article className="inline-help-support-article__story">
-							<SupportArticleHeader post={ post } isLoading={ isLoading } />
-							{ isLoading ? (
-								<Placeholders />
-							) : (
-								<EmbedContainer>
-									<div
-										className="inline-help-support-article__story-content"
-										dangerouslySetInnerHTML={ { __html: post.content } }
-									/>
-								</EmbedContainer>
-							) }
-						</article>
-					</Emojify>
-				</div>
-			</div>
+				<article className="inline-help-support-article__story">
+					<SupportArticleHeader post={ post } isLoading={ isLoading } />
+					{ isLoading ? (
+						<Placeholders />
+					) : (
+						<EmbedContainer>
+							<div
+								className="inline-help-support-article__story-content"
+								dangerouslySetInnerHTML={ { __html: post.content } }
+							/>
+						</EmbedContainer>
+					) }
+				</article>
+			</Emojify>
 		);
 		/*eslint-enable react/no-danger */
 	}

--- a/client/blocks/inline-help/inline-help-support-article/index.jsx
+++ b/client/blocks/inline-help/inline-help-support-article/index.jsx
@@ -1,0 +1,71 @@
+/** @format */
+/**
+ * External Dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import EmbedContainer from 'components/embed-container';
+import SupportArticleHeader from 'blocks/inline-help/inline-help-support-article/header';
+import Placeholders from 'blocks/inline-help/inline-help-support-article/placeholders';
+import { getSite } from 'state/reader/sites/selectors';
+import QueryReaderSite from 'components/data/query-reader-site';
+import QueryReaderPost from 'components/data/query-reader-post';
+import Emojify from 'components/emojify';
+import { getPostByKey } from 'state/reader/posts/selectors';
+import QueryPostLikes from 'components/data/query-post-likes';
+
+export class FullPostView extends React.Component {
+	static propTypes = {
+		post: PropTypes.object,
+	};
+
+	render() {
+		const { post, site, blogId, postId } = this.props;
+		const isLoading = ! post;
+		const postKey = { blogId, postId };
+
+		/*eslint-disable react/no-danger */
+		return (
+			<div className="inline-help-support-article">
+				{ site && <QueryPostLikes siteId={ post.site_ID } postId={ post.ID } /> }
+				{ post && post.site_ID && <QueryReaderSite siteId={ +post.site_ID } /> }
+				{ isLoading && <QueryReaderPost postKey={ postKey } /> }
+				<div className="inline-help-support-article__content">
+					<Emojify>
+						<article className="inline-help-support-article__story">
+							<SupportArticleHeader post={ post } isLoading={ isLoading } />
+							{ isLoading ? (
+								<Placeholders />
+							) : (
+								<EmbedContainer>
+									<div
+										className="inline-help-support-article__story-content"
+										dangerouslySetInnerHTML={ { __html: post.content } }
+									/>
+								</EmbedContainer>
+							) }
+						</article>
+					</Emojify>
+				</div>
+			</div>
+		);
+		/*eslint-enable react/no-danger */
+	}
+}
+
+export default connect( ( state, { blogId, postId } ) => {
+	const post = getPostByKey( state, { blogId, postId } );
+	const siteId = get( post, 'site_ID' );
+	const site = siteId && getSite( state, siteId );
+
+	return {
+		post,
+		site,
+	};
+} )( FullPostView );

--- a/client/blocks/inline-help/inline-help-support-article/index.jsx
+++ b/client/blocks/inline-help/inline-help-support-article/index.jsx
@@ -10,15 +10,15 @@ import { get } from 'lodash';
 /**
  * Internal Dependencies
  */
-import EmbedContainer from 'components/embed-container';
 import SupportArticleHeader from 'blocks/inline-help/inline-help-support-article/header';
 import Placeholders from 'blocks/inline-help/inline-help-support-article/placeholders';
-import { getSite } from 'state/reader/sites/selectors';
-import QueryReaderSite from 'components/data/query-reader-site';
-import QueryReaderPost from 'components/data/query-reader-post';
+import EmbedContainer from 'components/embed-container';
 import Emojify from 'components/emojify';
-import { getPostByKey } from 'state/reader/posts/selectors';
 import QueryPostLikes from 'components/data/query-post-likes';
+import QueryReaderPost from 'components/data/query-reader-post';
+import QueryReaderSite from 'components/data/query-reader-site';
+import { getPostByKey } from 'state/reader/posts/selectors';
+import { getSite } from 'state/reader/sites/selectors';
 
 export class FullPostView extends React.Component {
 	static propTypes = {

--- a/client/blocks/inline-help/inline-help-support-article/placeholders.jsx
+++ b/client/blocks/inline-help/inline-help-support-article/placeholders.jsx
@@ -1,0 +1,28 @@
+/** @format */
+/**
+ * External Dependencies
+ */
+import React from 'react';
+
+const PlaceHolders = () => (
+	<React.Fragment>
+		<div>
+			<p className="inline-help-support-article__placeholder-text" />
+			<p className="inline-help-support-article__placeholder-text" />
+		</div>
+		<div>
+			<p className="inline-help-support-article__placeholder-text" />
+			<p className="inline-help-support-article__placeholder-text" />
+		</div>
+		<div>
+			<p className="inline-help-support-article__placeholder-text" />
+			<p className="inline-help-support-article__placeholder-text" />
+		</div>
+		<div>
+			<p className="inline-help-support-article__placeholder-text" />
+			<p className="inline-help-support-article__placeholder-text" />
+		</div>
+	</React.Fragment>
+);
+
+export default PlaceHolders;

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -230,6 +230,10 @@
 	max-width: 850px;
 }
 
+.inline-help__richresult__dialog.dialog.card.article {
+	max-width: none;
+}
+
 .inline-help__richresult__dialog__video {
 	position: relative;
 	padding-bottom: 56.25%;

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -1,3 +1,5 @@
+@import './inline-help-support-article/support-article';
+
 .inline-help {
 	position: fixed;
 		right: 24px;

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2013,7 +2013,7 @@ Undocumented.prototype.uploadExportFile = function( siteId, params ) {
  */
 Undocumented.prototype.getHelpLinks = function( searchQuery, fn ) {
 	debug( 'help-search/ searchQuery' );
-	return this.wpcom.req.get( '/help/search', { query: searchQuery }, fn );
+	return this.wpcom.req.get( '/help/search', { query: searchQuery, include_post_id: 1 }, fn );
 };
 
 Undocumented.prototype.getQandA = function( query, site, fn ) {


### PR DESCRIPTION
### Summary

This PR aims to add Support Articles as a rich-result type for inline-help, as opposed to an external link as it is right now.

The strategy for adding this view was to ~steal~ borrow as much as possible from an existing view found in reader -- `blocks/reader-full-post` -- with the idea that this would get this feature working faster with minimal deviations between the style of the inline support articles and the articles found in the readers regular view. A downside of this hasty approach is that there was a lot to copy over and prune out - I've attempted to shave off as much as I could from the copied code but please keep 👀 open for anything that's extraneous.

We decided to move the copied views to the `inline-help` directory so as to not advertise this component(s) as being reusable elsewhere in the app as right now it caters only for our support articles. That said, if it becomes apparent that this component would be useful elsewhere we could then look at pulling it out in to `/components/` and making it a little more robust. 

Another note: we had hoped originally to be able to just borrow styles directly from reader. The trouble there is that readers styles are loaded only when necessary - when the customer is looking at the reader side of WP.com. We opted for avoiding pulling these styles in and breaking down some of the work that's been done to split our payload.

### Test Plan

- Test that articles appear in the dialog as expected
  - Go to http://calypso.localhost:3000/
  - Open InlineHelp by clicking the ? button in the bottom right
    - You should see a result for 'Reader', which leads to a Support  Article
  - Click 'Reader' then the button that shows labeled 'Read More'
    - You should now see the dialog open with a loading state (not finished)
    - The loading state should then be replaced with the article content (styling not finished)

- Test Video Results for regressions
  - Go to http://calypso.localhost:3000/media
    - You should see a result for 'Add a Photo Gallery', which leads to a Support  Article
  - Click 'Add a Photo Gallery' then the button that shows labeled 'Watch Video'
  - The Dialog should show with a video and without regressions

- Test anomalies (learn.wordpress.com / support.wordpress.com)
  - Go to http://calypso.localhost:3000/help
  - Open InlineHelp by clicking the ? button in the bottom right
  - Click "Self-guided online tutorial"
    -  You should be taken directly to `learn.wordpress.com` (Do not pass go...)
  - Click "All support articles"
    -  You should be taken directly to `support.wordpress.com/` (...Do not collect $200)