### PR TITLE
Framework: Prevent cascading updates in PopoverContext

### DIFF
--- a/client/blocks/post-likes/docs/example.jsx
+++ b/client/blocks/post-likes/docs/example.jsx
@@ -16,6 +16,8 @@ import PostLikesPopover from '../popover';
 import Button from 'components/button';
 
 class PostLikesExample extends React.PureComponent {
+	popoverContext = React.createRef();
+
 	state = {
 		showDisplayNames: false,
 		showPopover: false,
@@ -39,8 +41,6 @@ class PostLikesExample extends React.PureComponent {
 		} );
 	};
 
-	setPopoverContext = ref => ( this.popoverContext = ref );
-
 	render() {
 		return (
 			<div>
@@ -56,7 +56,7 @@ class PostLikesExample extends React.PureComponent {
 					postId={ 37769 }
 					showDisplayNames={ this.state.showDisplayNames }
 				/>
-				<Button ref={ this.setPopoverContext } onClick={ this.togglePopover }>
+				<Button ref={ this.popoverContext } onClick={ this.togglePopover }>
 					Toggle likes popover
 				</Button>
 				{ this.state.showPopover && (
@@ -64,7 +64,7 @@ class PostLikesExample extends React.PureComponent {
 						siteId={ 3584907 }
 						postId={ 39717 }
 						showDisplayNames={ this.state.showDisplayNames }
-						context={ this.popoverContext }
+						context={ this.popoverContext.current }
 						position="bottom"
 						onClose={ this.closePopover }
 					/>

--- a/client/blocks/post-likes/docs/example.jsx
+++ b/client/blocks/post-likes/docs/example.jsx
@@ -16,14 +16,10 @@ import PostLikesPopover from '../popover';
 import Button from 'components/button';
 
 class PostLikesExample extends React.PureComponent {
-	constructor() {
-		super();
-		this.state = {
-			showDisplayNames: false,
-			showPopover: false,
-			popoverContext: null,
-		};
-	}
+	state = {
+		showDisplayNames: false,
+		showPopover: false,
+	};
 
 	toggleDisplayNames = () => {
 		this.setState( {
@@ -43,11 +39,7 @@ class PostLikesExample extends React.PureComponent {
 		} );
 	};
 
-	setPopoverContext = element => {
-		this.setState( {
-			popoverContext: element,
-		} );
-	};
+	setPopoverContext = ref => ( this.popoverContext = ref );
 
 	render() {
 		return (
@@ -72,7 +64,7 @@ class PostLikesExample extends React.PureComponent {
 						siteId={ 3584907 }
 						postId={ 39717 }
 						showDisplayNames={ this.state.showDisplayNames }
-						context={ this.state.popoverContext }
+						context={ this.popoverContext }
 						position="bottom"
 						onClose={ this.closePopover }
 					/>

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -37,6 +37,8 @@ class EllipsisMenu extends Component {
 		isMenuVisible: false,
 	};
 
+	popoverContext = React.createRef();
+
 	handleClick = event => {
 		const { onClick } = this.props;
 		const { isMenuVisible } = this.state;
@@ -51,8 +53,6 @@ class EllipsisMenu extends Component {
 	};
 
 	hideMenu = () => this.toggleMenu( false );
-
-	setPopoverContext = ref => ( this.popoverContext = ref );
 
 	showMenu = () => this.toggleMenu( true );
 
@@ -83,7 +83,7 @@ class EllipsisMenu extends Component {
 		return (
 			<span className={ classes }>
 				<Button
-					ref={ this.setPopoverContext }
+					ref={ this.popoverContext }
 					onClick={ this.handleClick }
 					title={ toggleTitle || translate( 'Toggle menu' ) }
 					borderless
@@ -96,7 +96,7 @@ class EllipsisMenu extends Component {
 					isVisible={ isMenuVisible }
 					onClose={ this.hideMenu }
 					position={ position }
-					context={ this.popoverContext }
+					context={ this.popoverContext.current }
 					className={ popoverClasses }
 				>
 					{ children }

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -33,19 +33,9 @@ class EllipsisMenu extends Component {
 		onToggle: noop,
 	};
 
-	constructor() {
-		super( ...arguments );
-
-		this.state = {
-			isMenuVisible: false,
-			popoverContext: null,
-		};
-
-		this.showMenu = this.toggleMenu.bind( this, true );
-		this.hideMenu = this.toggleMenu.bind( this, false );
-
-		this.setPopoverContext = this.setPopoverContext.bind( this );
-	}
+	state = {
+		isMenuVisible: false,
+	};
 
 	handleClick = event => {
 		const { onClick } = this.props;
@@ -60,18 +50,18 @@ class EllipsisMenu extends Component {
 		}
 	};
 
-	setPopoverContext( popoverContext ) {
-		if ( popoverContext ) {
-			this.setState( { popoverContext } );
-		}
-	}
+	hideMenu = () => this.toggleMenu( false );
 
-	toggleMenu( isMenuVisible ) {
+	setPopoverContext = ref => ( this.popoverContext = ref );
+
+	showMenu = () => this.toggleMenu( true );
+
+	toggleMenu = isMenuVisible => {
 		if ( ! this.props.disabled ) {
 			this.setState( { isMenuVisible } );
 			this.props.onToggle( isMenuVisible );
 		}
-	}
+	};
 
 	render() {
 		const {
@@ -83,7 +73,7 @@ class EllipsisMenu extends Component {
 			className,
 			popoverClassName,
 		} = this.props;
-		const { isMenuVisible, popoverContext } = this.state;
+		const { isMenuVisible } = this.state;
 		const classes = classnames( 'ellipsis-menu', className, {
 			'is-menu-visible': isMenuVisible,
 			'is-disabled': disabled,
@@ -106,7 +96,7 @@ class EllipsisMenu extends Component {
 					isVisible={ isMenuVisible }
 					onClose={ this.hideMenu }
 					position={ position }
-					context={ popoverContext }
+					context={ this.popoverContext }
 					className={ popoverClasses }
 				>
 					{ children }

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -56,12 +56,12 @@ class EllipsisMenu extends Component {
 
 	showMenu = () => this.toggleMenu( true );
 
-	toggleMenu = isMenuVisible => {
+	toggleMenu( isMenuVisible ) {
 		if ( ! this.props.disabled ) {
 			this.setState( { isMenuVisible } );
 			this.props.onToggle( isMenuVisible );
 		}
-	};
+	}
 
 	render() {
 		const {

--- a/client/components/split-button/index.jsx
+++ b/client/components/split-button/index.jsx
@@ -61,12 +61,12 @@ class SplitButton extends Component {
 
 	hideMenu = () => this.toggleMenu( false );
 
-	toggleMenu = isMenuVisible => {
+	toggleMenu( isMenuVisible ) {
 		if ( ! this.props.disabled ) {
 			this.setState( { isMenuVisible } );
 			this.props.onToggle( isMenuVisible );
 		}
-	};
+	}
 
 	render() {
 		const {

--- a/client/components/split-button/index.jsx
+++ b/client/components/split-button/index.jsx
@@ -53,13 +53,13 @@ class SplitButton extends Component {
 		isMenuVisible: false,
 	};
 
+	popoverContext = React.createRef();
+
 	handleMainClick = event => this.props.onClick( event );
 
 	handleMenuClick = () => this.toggleMenu( ! this.state.isMenuVisible );
 
 	hideMenu = () => this.toggleMenu( false );
-
-	setPopoverContext = ref => ( this.popoverContext = ref );
 
 	toggleMenu = isMenuVisible => {
 		if ( ! this.props.disabled ) {
@@ -110,7 +110,7 @@ class SplitButton extends Component {
 					compact={ compact }
 					primary={ primary }
 					scary={ scary }
-					ref={ this.setPopoverContext }
+					ref={ this.popoverContext }
 					onClick={ this.handleMenuClick }
 					title={ toggleTitle || translate( 'Toggle menu' ) }
 					disabled={ disabled || disableMenu }
@@ -122,7 +122,7 @@ class SplitButton extends Component {
 					isVisible={ isMenuVisible }
 					onClose={ this.hideMenu }
 					position={ position }
-					context={ this.popoverContext }
+					context={ this.popoverContext.current }
 					className={ popoverClasses }
 				>
 					{ children }

--- a/client/components/split-button/index.jsx
+++ b/client/components/split-button/index.jsx
@@ -49,42 +49,24 @@ class SplitButton extends Component {
 		scary: false,
 	};
 
-	constructor() {
-		super( ...arguments );
-
-		this.state = {
-			isMenuVisible: false,
-			popoverContext: null,
-		};
-
-		this.showMenu = this.toggleMenu.bind( this, true );
-		this.hideMenu = this.toggleMenu.bind( this, false );
-
-		this.setPopoverContext = this.setPopoverContext.bind( this );
-	}
+	state = {
+		isMenuVisible: false,
+	};
 
 	handleMainClick = event => this.props.onClick( event );
 
-	handleMenuClick = () => {
-		if ( this.state.isMenuVisible ) {
-			this.hideMenu();
-		} else {
-			this.showMenu();
-		}
-	};
+	handleMenuClick = () => this.toggleMenu( ! this.state.isMenuVisible );
 
-	setPopoverContext( popoverContext ) {
-		if ( popoverContext ) {
-			this.setState( { popoverContext } );
-		}
-	}
+	hideMenu = () => this.toggleMenu( false );
 
-	toggleMenu( isMenuVisible ) {
+	setPopoverContext = ref => ( this.popoverContext = ref );
+
+	toggleMenu = isMenuVisible => {
 		if ( ! this.props.disabled ) {
 			this.setState( { isMenuVisible } );
 			this.props.onToggle( isMenuVisible );
 		}
-	}
+	};
 
 	render() {
 		const {
@@ -103,7 +85,7 @@ class SplitButton extends Component {
 			className,
 			popoverClassName,
 		} = this.props;
-		const { isMenuVisible, popoverContext } = this.state;
+		const { isMenuVisible } = this.state;
 		const popoverClasses = classnames( 'split-button__menu', 'popover', popoverClassName );
 		const classes = classnames( 'split-button', className, {
 			'is-menu-visible': isMenuVisible,
@@ -140,7 +122,7 @@ class SplitButton extends Component {
 					isVisible={ isMenuVisible }
 					onClose={ this.hideMenu }
 					position={ position }
-					context={ popoverContext }
+					context={ this.popoverContext }
 					className={ popoverClasses }
 				>
 					{ children }

--- a/client/components/tinymce/plugins/mentions/mentions.jsx
+++ b/client/components/tinymce/plugins/mentions/mentions.jsx
@@ -30,7 +30,6 @@ export class Mentions extends Component {
 	matchingSuggestions = [];
 
 	state = {
-		popoverContext: null,
 		query: '',
 		showPopover: false,
 	};
@@ -247,13 +246,13 @@ export class Mentions extends Component {
 		} );
 	};
 
-	setPopoverContext = popoverContext => popoverContext && this.setState( { popoverContext } );
+	setPopoverContext = ref => ( this.popoverContext = ref );
 
 	hidePopover = () => this.setState( { showPopover: false } );
 
 	render() {
 		const { siteId, suggestions } = this.props;
-		const { query, showPopover, popoverContext } = this.state;
+		const { query, showPopover } = this.state;
 
 		this.matchingSuggestions = this.getMatchingSuggestions( suggestions, query );
 		const selectedSuggestionId =
@@ -268,7 +267,7 @@ export class Mentions extends Component {
 							query={ query }
 							suggestions={ this.matchingSuggestions }
 							selectedSuggestionId={ selectedSuggestionId }
-							popoverContext={ popoverContext }
+							popoverContext={ this.popoverContext }
 							onClick={ this.insertSuggestion }
 							onClose={ this.hidePopover }
 						/>

--- a/client/components/tinymce/plugins/mentions/mentions.jsx
+++ b/client/components/tinymce/plugins/mentions/mentions.jsx
@@ -34,6 +34,8 @@ export class Mentions extends Component {
 		showPopover: false,
 	};
 
+	popoverContext = React.createRef();
+
 	componentDidMount() {
 		const { editor } = this.props;
 		const { left, top } = this.getPosition();
@@ -246,8 +248,6 @@ export class Mentions extends Component {
 		} );
 	};
 
-	setPopoverContext = ref => ( this.popoverContext = ref );
-
 	hidePopover = () => this.setState( { showPopover: false } );
 
 	render() {
@@ -259,7 +259,7 @@ export class Mentions extends Component {
 			this.state.selectedSuggestionId || get( head( this.matchingSuggestions ), 'ID' );
 
 		return (
-			<div ref={ this.setPopoverContext }>
+			<div ref={ this.popoverContext }>
 				<QueryUsersSuggestions siteId={ siteId } />
 				{ this.matchingSuggestions.length > 0 &&
 					showPopover && (
@@ -267,7 +267,7 @@ export class Mentions extends Component {
 							query={ query }
 							suggestions={ this.matchingSuggestions }
 							selectedSuggestionId={ selectedSuggestionId }
-							popoverContext={ this.popoverContext }
+							popoverContext={ this.popoverContext.current }
 							onClick={ this.insertSuggestion }
 							onClose={ this.hidePopover }
 						/>

--- a/client/me/profile-links/add-buttons.jsx
+++ b/client/me/profile-links/add-buttons.jsx
@@ -31,6 +31,8 @@ class AddProfileLinksButtons extends React.Component {
 		popoverPosition: 'top',
 	};
 
+	popoverContext = React.createRef();
+
 	recordClickEvent = action => {
 		this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
 	};
@@ -45,8 +47,6 @@ class AddProfileLinksButtons extends React.Component {
 		this.props.onShowAddOther();
 	};
 
-	setPopoverContext = ref => ( this.popoverMenuButton = ref );
-
 	render() {
 		return (
 			<div>
@@ -54,7 +54,7 @@ class AddProfileLinksButtons extends React.Component {
 					isVisible={ this.props.showPopoverMenu }
 					onClose={ this.props.onClosePopoverMenu }
 					position={ this.state.popoverPosition }
-					context={ this.popoverMenuButton }
+					context={ this.popoverContext.current }
 				>
 					<PopoverMenuItem onClick={ this.handleAddWordPressSiteButtonClick }>
 						{ this.props.translate( 'Add WordPress Site' ) }
@@ -66,7 +66,7 @@ class AddProfileLinksButtons extends React.Component {
 
 				<Button
 					compact
-					ref={ this.setPopoverContext }
+					ref={ this.popoverContext }
 					className="popover-icon"
 					onClick={ this.props.onShowPopoverMenu }
 				>

--- a/client/me/profile-links/add-buttons.jsx
+++ b/client/me/profile-links/add-buttons.jsx
@@ -45,7 +45,7 @@ class AddProfileLinksButtons extends React.Component {
 		this.props.onShowAddOther();
 	};
 
-	setPopoverContext = button => ( this.popoverMenuButton = button );
+	setPopoverContext = ref => ( this.popoverMenuButton = ref );
 
 	render() {
 		return (


### PR DESCRIPTION
While hunting a performance issue I discovered that we were
triggering cascading updates in React. This happens in cases
when, for example, we call `setState()` from within `render()`

In several of our components that use a popover menu we do
just that. We call `setState()` inside the `ref` function in
order to save the DOM reference in local state.

Refs are not supposed to work this way though and that triggers
the cascade.

In this patch I have elected to set a value imperatively on
the component backing store directly inside of `ref`. No more
cascading will trigger because we're not breaking the prop and
state cycle.

**Random update in master**
<img width="1202" alt="screen shot 2018-05-11 at 5 40 59 pm" src="https://user-images.githubusercontent.com/5431237/39933250-b81bbb6c-5542-11e8-9d5a-94eac2facf46.png">

**Same update in this branch**
<img width="909" alt="screen shot 2018-05-11 at 5 37 53 pm" src="https://user-images.githubusercontent.com/5431237/39933276-d05709d4-5542-11e8-91aa-87cd72238118.png">
