### PR TITLE
AL/Rewind: Transparently pass a site URL through the RewindCredentialsForm component

### DIFF
--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -34,6 +34,7 @@ export class RewindCredentialsForm extends Component {
 		allowDelete: PropTypes.bool,
 		onCancel: PropTypes.func,
 		onComplete: PropTypes.func,
+		siteUrl: PropTypes.string,
 	};
 
 	state = {
@@ -72,10 +73,11 @@ export class RewindCredentialsForm extends Component {
 	};
 
 	handleSubmit = () => {
-		const { role, siteId, translate, updateCredentials } = this.props;
+		const { role, siteId, siteUrl, translate, updateCredentials } = this.props;
 
 		const payload = {
 			role,
+			site_url: siteUrl,
 			...this.state.form,
 		};
 


### PR DESCRIPTION
This PR begins preparation for the clone site feature in https://github.com/Automattic/wp-calypso/pull/24741

We need the ability to submit a site's base URL to the `update-credentials` endpoint in order to support testing alternate credentials. This allows passing a `siteUrl` property to the `RewindCredentialsForm` component, and it will submit that property as part of the resulting payload.

**Testing Instructions**

For now, simply test the form in it's typical use case and ensure you can save and revoke credentials on a non-Pressable site. No parts of the form's function should be affected in any noticeable way.