### PR TITLE
Editor Action Bar: use React.createRef to set view link tooltip context

### DIFF
--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -51,9 +51,7 @@ class EditorActionBar extends Component {
 		this.setState( { viewLinkTooltip: false } );
 	};
 
-	setViewLinkTooltipContext = viewLinkTooltipContext => {
-		this.setState( { viewLinkTooltipContext } );
-	};
+	viewLinkTooltipContext = React.createRef();
 
 	render() {
 		// We store privacy changes via Flux while we store password changes via Redux.
@@ -92,7 +90,7 @@ class EditorActionBar extends Component {
 							href={ this.props.savedPost.URL }
 							target="_blank"
 							rel="noopener noreferrer"
-							ref={ this.setViewLinkTooltipContext }
+							ref={ this.viewLinkTooltipContext }
 							onMouseEnter={ this.showViewLinkTooltip }
 							onMouseLeave={ this.hideViewLinkTooltip }
 							borderless
@@ -100,7 +98,7 @@ class EditorActionBar extends Component {
 							<Gridicon icon="external" />
 							<Tooltip
 								className="editor-action-bar__view-post-tooltip"
-								context={ this.state.viewLinkTooltipContext }
+								context={ this.viewLinkTooltipContext.current }
 								isVisible={ this.state.viewLinkTooltip }
 								position="bottom left"
 							>


### PR DESCRIPTION
Don't use `setState` to set refs: that's not the right way and can lead to cascading updates, infinite loops and other horrible things. See also #24824.

**How to test:**
Edit an already published/scheduled post and verify that the "View post" button has a tooltip in correct position:
<img width="756" alt="screen shot 2018-05-11 at 19 55 54" src="https://user-images.githubusercontent.com/664258/39939248-e75f0614-5555-11e8-861d-d3c3a45cd13f.png">
