### PR TITLE
Activity Log: update list of plugins to update when site changes

### DIFF
--- a/client/my-sites/stats/activity-log-tasklist/plugins-to-update.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/plugins-to-update.jsx
@@ -25,10 +25,17 @@ export default WrappedComponent => {
 		state = {
 			// Plugins already updated + those with pending updates
 			plugins: [],
+			siteId: this.props.siteId,
 		};
 
 		static getDerivedStateFromProps( nextProps, prevState ) {
-			return { plugins: unionBy( nextProps.plugins, prevState.plugins, 'slug' ) };
+			return {
+				plugins:
+					nextProps.siteId === prevState.siteId
+						? unionBy( nextProps.plugins, prevState.plugins, 'slug' )
+						: [],
+				siteId: nextProps.siteId,
+			};
 		}
 
 		render() {


### PR DESCRIPTION
Fixes p1526067189000146-slack-activity-log

The plugin list wasn't previously refreshed since it's taken from the component state and not the props passed by the parent. This fixes it by cleaning the list when the site changes.

#### Testing
Launch https://calypso.live/?branch=fix/activity-log/plugin-updates-not-updating-switch-site
Verify that the plugin updates aren't stuck from site to site when you change the site using Switch Site in the left sidebar.