### PR TITLE
DevDocs: update the banner readme file

### DIFF
--- a/client/components/banner/README.md
+++ b/client/components/banner/README.md
@@ -1,5 +1,5 @@
 
-Button
+Banner
 ===
 
 This component renders a customizable banner.

--- a/client/components/banner/README.md
+++ b/client/components/banner/README.md
@@ -2,30 +2,6 @@
 
 This component renders a customizable banner.
 
-## Props:
-
-- *callToAction* - shows a CTA text.
-- *className* - any additional CSS classes.
-- *description* - the banner description.
-- *disableHref* - when true, prevent the Banner to be linked either via the `href` props or as a side effect of the `siteSlug` connected prop.
-- *dismissPreferenceName*: the user preference name that we store a boolean against, prefixed with 'dismissible-card-' to avoid namespace collisions.
-- *dismissTemporary*: when true, clicking on the cross will dismiss the card for the current page load.
-- *event* - event to distinguish the nudge in tracks. Used as `cta_name` event property.
-- *feature* - slug of the feature to highlight in the plans compare card.
-- *href* - the component target URL.
-- *icon* - the component icon.
-- *list* - a list of the upgrade features.
-- *onClick* - a function associated to the click on the whole banner or just the CTA or dismiss button.
-- *plan* - PlanSlug of the plan that upgrade leads to.
-- *price* - one or two (original/discounted) upgrade prices.
-- *title* - (required) the banner title.
-
-If `href` is not provided, `feature` can auto-generate it.
-
-If `callToAction` is provided, `href` and `onClick` are not applied to the whole banner, but to the `callToAction` button only.
-
-If `dismissPreferenceName` is provided, `href` is only applied if `callToAction` is provided.
-
 ## Usage:
 
 ```jsx
@@ -53,3 +29,116 @@ render() {
 	);
 }
 ```
+
+## Props:
+
+<table>
+	<thead>
+		<tr>
+			<th>Name</th>
+			<th>Type</th>
+			<th>Default</th>
+			<th>Description</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td><code>callToAction</code></td>
+			<td><code>string</code></td>
+			<td></td>
+			<td>Shows a CTA text.</td>
+		</tr>
+		<tr>
+			<td><code>className</code></td>
+			<td><code>string</code></td>
+			<td></td>
+			<td>And additional CSS classes.</td>
+		</tr>
+		<tr>
+			<td><code>description</code></td>
+			<td><code>string</code></td>
+			<td></td>
+			<td>The banner description.</td>
+		</tr>
+		<tr>
+			<td><code>disableHref</code></td>
+			<td><code>bool</code></td>
+			<td></td>
+			<td>When true, prevent the Banner to be linked either via the <code>href</code> props or as a side effect of the <code>siteSlug</code> connected prop.</td>
+		</tr>
+		<tr>
+			<td><code>dismissPreferenceName</code></td>
+			<td><code>bool</code></td>
+			<td></td>
+			<td>The user preference name that we store a boolean against, prefixed with <code>dismissible-card-</code> to avoid namespace collisions.</td>
+		</tr>
+		<tr>
+			<td><code>dismissTemporary</code></td>
+			<td><code>bool</code></td>
+			<td></td>
+			<td>When true, clicking on the cross will dismiss the card for the current page load.</td>
+		</tr>
+		<tr>
+			<td><code>event</code></td>
+			<td><code>string</code></td>
+			<td></td>
+			<td>Event to distinguish the nudge in tracks. Used as <code>cta_name</code> event property.</td>
+		</tr>
+		<tr>
+			<td><code>feature</code></td>
+			<td><code>string</code></td>
+			<td></td>
+			<td>Slug of the feature to highlight in the plans compare card.</td>
+		</tr>
+		<tr>
+			<td><code>href</code></td>
+			<td><code>string</code></td>
+			<td></td>
+			<td>The component target URL.</td>
+		</tr>
+		<tr>
+			<td><code>icon</code></td>
+			<td><code>string</code></td>
+			<td></td>
+			<td>The component icon.</td>
+		</tr>
+		<tr>
+			<td><code>list</code></td>
+			<td><code>string</code></td>
+			<td></td>
+			<td>A list of the upgrade features.</td>
+		</tr>
+		<tr>
+			<td><code>onClick</code></td>
+			<td><code>string</code></td>
+			<td></td>
+			<td>A function associated to the click on the whole banner or just the CTA or dismiss button.</td>
+		</tr>
+		<tr>
+			<td><code>plan</code></td>
+			<td><code>string</code></td>
+			<td></td>
+			<td>PlanSlug of the plan that upgrade leads to.</td>
+		</tr>
+		<tr>
+			<td><code>price</code></td>
+			<td><code>string</code></td>
+			<td></td>
+			<td>One or two (original/discounted) upgrade prices.</td>
+		</tr>
+		<tr>
+			<td><code>title</code></td>
+			<td><code>string</code></td>
+			<td></td>
+			<td>(required) The banner title.</td>
+		</tr>
+	</tbody>
+</table>
+
+If `href` is not provided, `feature` can auto-generate it.
+
+If `callToAction` is provided, `href` and `onClick` are not applied to the whole banner, but to the `callToAction` button only.
+
+If `dismissPreferenceName` is provided, `href` is only applied if `callToAction` is provided.
+
+

--- a/client/components/banner/README.md
+++ b/client/components/banner/README.md
@@ -1,8 +1,10 @@
-# Banner
+
+Button
+===
 
 This component renders a customizable banner.
 
-## Usage:
+## Usage
 
 ```jsx
 import { PLAN_BUSINESS, FEATURE_ADVANCED_SEO } from 'lib/plans/constants';
@@ -30,115 +32,31 @@ render() {
 }
 ```
 
-## Props:
+### Props
 
-<table>
-	<thead>
-		<tr>
-			<th>Name</th>
-			<th>Type</th>
-			<th>Default</th>
-			<th>Description</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td><code>callToAction</code></td>
-			<td><code>string</code></td>
-			<td></td>
-			<td>Shows a CTA text.</td>
-		</tr>
-		<tr>
-			<td><code>className</code></td>
-			<td><code>string</code></td>
-			<td></td>
-			<td>And additional CSS classes.</td>
-		</tr>
-		<tr>
-			<td><code>description</code></td>
-			<td><code>string</code></td>
-			<td></td>
-			<td>The banner description.</td>
-		</tr>
-		<tr>
-			<td><code>disableHref</code></td>
-			<td><code>bool</code></td>
-			<td></td>
-			<td>When true, prevent the Banner to be linked either via the <code>href</code> props or as a side effect of the <code>siteSlug</code> connected prop.</td>
-		</tr>
-		<tr>
-			<td><code>dismissPreferenceName</code></td>
-			<td><code>bool</code></td>
-			<td></td>
-			<td>The user preference name that we store a boolean against, prefixed with <code>dismissible-card-</code> to avoid namespace collisions.</td>
-		</tr>
-		<tr>
-			<td><code>dismissTemporary</code></td>
-			<td><code>bool</code></td>
-			<td></td>
-			<td>When true, clicking on the cross will dismiss the card for the current page load.</td>
-		</tr>
-		<tr>
-			<td><code>event</code></td>
-			<td><code>string</code></td>
-			<td></td>
-			<td>Event to distinguish the nudge in tracks. Used as <code>cta_name</code> event property.</td>
-		</tr>
-		<tr>
-			<td><code>feature</code></td>
-			<td><code>string</code></td>
-			<td></td>
-			<td>Slug of the feature to highlight in the plans compare card.</td>
-		</tr>
-		<tr>
-			<td><code>href</code></td>
-			<td><code>string</code></td>
-			<td></td>
-			<td>The component target URL.</td>
-		</tr>
-		<tr>
-			<td><code>icon</code></td>
-			<td><code>string</code></td>
-			<td></td>
-			<td>The component icon.</td>
-		</tr>
-		<tr>
-			<td><code>list</code></td>
-			<td><code>string</code></td>
-			<td></td>
-			<td>A list of the upgrade features.</td>
-		</tr>
-		<tr>
-			<td><code>onClick</code></td>
-			<td><code>string</code></td>
-			<td></td>
-			<td>A function associated to the click on the whole banner or just the CTA or dismiss button.</td>
-		</tr>
-		<tr>
-			<td><code>plan</code></td>
-			<td><code>string</code></td>
-			<td></td>
-			<td>PlanSlug of the plan that upgrade leads to.</td>
-		</tr>
-		<tr>
-			<td><code>price</code></td>
-			<td><code>string</code></td>
-			<td></td>
-			<td>One or two (original/discounted) upgrade prices.</td>
-		</tr>
-		<tr>
-			<td><code>title</code></td>
-			<td><code>string</code></td>
-			<td></td>
-			<td>(required) The banner title.</td>
-		</tr>
-	</tbody>
-</table>
 
-If `href` is not provided, `feature` can auto-generate it.
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `callToAction` | `string` | null | Shows a CTA text. |
+| `className` | `string` | null | Any additional CSS classes. |
+| `description` | `string` | null | The banner description. |
+| `disableHref` | `bool` | false | When true, prevent the Banner to be linked either via the `href` props or as a side effect of the `siteSlug` connected prop. |
+| `dismissPreferenceName` | `bool` | false | The user preference name that we store a boolean against, prefixed with `dismissible-card-` to avoid namespace collisions. |
+| `dismissTemporary` | `bool` | false | When true, clicking on the cross will dismiss the card for the current page load. |
+| `event` | `string` | null | Event to distinguish the nudge in tracks. Used as <code>cta_name</code> event property. |
+| `feature` | `string` | null | Slug of the feature to highlight in the plans compare card. |
+| `href` | `string` | null | The component target URL. |
+| `icon` | `string` | null | The component icon. |
+| `list` | `string` | null | A list of the upgrade features. |
+| `onClick` | `string` | null | A function associated to the click on the whole banner or just the CTA or dismiss button. |
+| `plan` | `string` | null | PlanSlug of the plan that upgrade leads to. |
+| `price` | `string` | null | One or two (original/discounted) upgrade prices. |
+| `title` | `string` | null | (required) The banner title. |
 
-If `callToAction` is provided, `href` and `onClick` are not applied to the whole banner, but to the `callToAction` button only.
+### General guidelines
 
-If `dismissPreferenceName` is provided, `href` is only applied if `callToAction` is provided.
+* If `href` is not provided, `feature` can auto-generate it.
+* If `callToAction` is provided, `href` and `onClick` are not applied to the whole banner, but to the `callToAction` button only.
+* If `dismissPreferenceName` is provided, `href` is only applied if `callToAction` is provided.
 
 


### PR DESCRIPTION
I wanted to update the Banner readme file based on the guidelines here: https://github.com/Automattic/wp-calypso/pull/24343 but I'm unsure if I'm doing this right. Also not sure if everything I said was a `string` is actually a `string`.

This task is based on this issue: #24282

@scruffian please take a look and let me know if this is correct.