### PR TITLE
Domains: Handle undefined TLD filter in FilterResetNotice component

### DIFF
--- a/client/components/domains/search-filters/filter-reset-notice.jsx
+++ b/client/components/domains/search-filters/filter-reset-notice.jsx
@@ -26,12 +26,10 @@ export class FilterResetNotice extends Component {
 	};
 
 	hasActiveFilters() {
-		return (
-			( this.props.lastFilters.includeDashes && 1 ) ||
-			( this.props.lastFilters.exactSldMatchesOnly && 1 ) ||
-			( this.props.lastFilters.maxCharacters !== '' && 1 ) ||
-			this.props.lastFilters.tlds.length > 0
-		);
+		const {
+			lastFilters: { includeDashes, exactSldMatchesOnly, maxCharacters, tlds = [] } = {},
+		} = this.props;
+		return includeDashes || exactSldMatchesOnly || maxCharacters !== '' || tlds.length > 0;
 	}
 
 	hasTooFewSuggestions() {


### PR DESCRIPTION
A follow-up to #24838. 

This change also addresses stale component state handling, but for `FilterResetNotice` w.r.t. `lastFilters.tlds`.