### PR TITLE
Me: add account closure option to Me > Account Settings

### DIFF
--- a/client/me/account/close.jsx
+++ b/client/me/account/close.jsx
@@ -1,0 +1,32 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
+
+import CompactCard from 'components/card/compact';
+
+class AccountSettingsClose extends React.Component {
+	render() {
+		const { translate } = this.props;
+		const href = '/me/account/close';
+		const onClick = noop;
+		return (
+			<CompactCard href={ href } onClick={ onClick } className="account__settings-close">
+				<div>
+					<p className="account__close-section-title is-warning">
+						{ translate( 'Close your account permanently' ) }
+					</p>
+					<p className="account__close-section-desc">
+						{ translate( 'Delete all of your sites, and close your account completely.' ) }
+					</p>
+				</div>
+			</CompactCard>
+		);
+	}
+}
+
+export default localize( AccountSettingsClose );

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -49,6 +49,7 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import _user from 'lib/user';
 import { canDisplayCommunityTranslator } from 'components/community-translator/utils';
 import { ENABLE_TRANSLATOR_KEY } from 'components/community-translator/constants';
+import AccountSettingsClose from './close';
 
 const user = _user();
 const colorSchemeKey = 'calypso_preferences.colorScheme';
@@ -787,6 +788,8 @@ const Account = createReactClass( {
 						</ReactCSSTransitionGroup>
 					</form>
 				</Card>
+
+				{ config.isEnabled( 'me/account-close' ) && <AccountSettingsClose /> }
 			</Main>
 		);
 	},

--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -23,3 +23,22 @@
 .account__settings-form select {
 	width: 100%;
 }
+
+/* Account close */
+.account__close-section-title {
+	margin-bottom: 4px;
+	font-size: 14px;
+	line-height: 18px;
+	color: $gray-dark;
+
+	&.is-warning {
+		color: $alert-red;
+	}
+}
+
+.account__close-section-desc {
+	margin-bottom: 0;
+	font-size: 13px;
+	color: $gray-text-min;
+	font-style: italic;
+}

--- a/config/development.json
+++ b/config/development.json
@@ -109,6 +109,7 @@
 		"manage/themes/logged-out": true,
 		"manage/themes/upload": true,
 		"me/account": true,
+		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/find-friends": false,
 		"me/my-profile": true,


### PR DESCRIPTION
Adds a 'close your account permanently' option to the end of Me > Account Settings.

Just adding UI at the moment. The link doesn't take you anywhere useful or check whether you have any purchases/Atomic sites yet.

### To test

Head to http://calypso.localhost:3000/me/account in development. The new option is hidden behind a feature flag, `me/account-close`.

<img width="774" alt="screen shot 2018-05-14 at 10 59 23 am" src="https://user-images.githubusercontent.com/17325/39972518-e2699ac2-5765-11e8-8112-e75278489b5c.png">
