### PR TITLE
Reader: make recommendation dismiss button clickable in Firefox

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -43,6 +43,7 @@ $z-layers: (
 		'.reader-post-card__title': 0,
 		'.reader-feed-header': 0,
 		'.reader-feed-header__back-and-follow': 0,
+		'.reader-recommended-sites__recommended-site-dismiss': 1,
 		'.reader-related-card.card': 0,
 		'.reader-full-post__sidebar-comment-like': 1,
 		'.list-stream__header-follow': 0,

--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -70,6 +70,8 @@
 				top: 0;
 			}
 		}
+
+		z-index: z-index( 'root', '.reader-recommended-sites__recommended-site-dismiss' );
 	}
 
 	.reader-subscription-list-item {


### PR DESCRIPTION
@rantoncuadrado reported in https://github.com/Automattic/wp-calypso/issues/24811 that it's not possible to click the "dismiss recommendation" button in Firefox, as it's obscured underneath the title:

![39908960-d6e02b70-54f0-11e8-9295-d313ff14a01c](https://user-images.githubusercontent.com/17325/39980168-9f159936-579e-11e8-88a3-f291c57cc9b5.png)

This PR fixes the z-index of the button so it's clickable once more.

Fixes https://github.com/Automattic/wp-calypso/issues/24811.

### To test

In Firefox, go to http://calypso.localhost:3000/following/manage and try to dismiss a recommendation.