### PR TITLE
Components: Introduce connected applications query component

### DIFF
--- a/client/components/data/query-connected-applications/README.md
+++ b/client/components/data/query-connected-applications/README.md
@@ -8,11 +8,12 @@ Query Connected Applications
 Render the component without props. It does not accept any children, nor does it render any elements to the page.
 
 ```jsx
+import React, { Fragment } from 'react';
 import QueryConnectedApplications from 'components/data/query-connected-applications';
 
 export default () => (
-	<div>
+	<Fragment>
 		<QueryConnectedApplications />
-	</div>
+	</Fragment>
 );
 ```

--- a/client/components/data/query-connected-applications/README.md
+++ b/client/components/data/query-connected-applications/README.md
@@ -1,0 +1,18 @@
+Query Connected Applications
+===========================
+
+`<QueryConnectedApplications />` is a React component used to request the connected applications of the current user.
+
+## Usage
+
+Render the component without props. It does not accept any children, nor does it render any elements to the page.
+
+```jsx
+import QueryConnectedApplications from 'components/data/query-connected-applications';
+
+export default () => (
+	<div>
+		<QueryConnectedApplications />
+	</div>
+);
+```

--- a/client/components/data/query-connected-applications/index.jsx
+++ b/client/components/data/query-connected-applications/index.jsx
@@ -1,0 +1,29 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestConnectedApplications } from 'state/connected-applications/actions';
+
+class QueryConnectedApplications extends Component {
+	static propTypes = {
+		requestConnectedApplications: PropTypes.func,
+	};
+
+	componentDidMount() {
+		this.props.requestConnectedApplications();
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect( null, { requestConnectedApplications } )( QueryConnectedApplications );


### PR DESCRIPTION
This PR introduces a query component for managing connected applications fetch requests.

For context of how the query component would be used, you can see the full connected applications reduxification PR: #24175.

To test:
* Checkout this branch.
* Clean your Redux store.
* Drop this component somewhere.
* Verify it dispatches the expected network request to fetch the user's connected applications.
* You can also run `state.connectedApplications` in your browser console to verify that connected apps were fetched successfully.