### PR TITLE
State: Introduce getConnectedApplications selector

### DIFF
--- a/client/state/selectors/get-connected-applications.js
+++ b/client/state/selectors/get-connected-applications.js
@@ -1,0 +1,14 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns the connected applications of the current user.
+ *
+ * @param  {Object} state Global state tree
+ * @return {Array}        Connected applications
+ */
+export default state => get( state, 'connectedApplications', [] );

--- a/client/state/selectors/test/get-connected-applications.js
+++ b/client/state/selectors/test/get-connected-applications.js
@@ -1,0 +1,47 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getConnectedApplications } from 'state/selectors';
+
+describe( 'getConnectedApplications()', () => {
+	test( 'should return connected applications of the current user', () => {
+		const apps = [
+			{
+				ID: '12345678',
+				URL: 'http://wordpress.com',
+				authorized: '2018-01-01T00:00:00+00:00',
+				description: 'Example description of the application here',
+				icon: 'https://wordpress.com/calypso/images/wordpress/logo-stars.svg',
+				permissions: [
+					{
+						name: 'follow',
+						description: 'Follow and unfollow blogs.',
+					},
+					{
+						name: 'posts',
+						description: 'View and manage posts including reblogs and likes.',
+					},
+				],
+				scope: 'global',
+				site: {
+					site_ID: '87654321',
+					site_URL: 'http://wordpress.com',
+					site_name: 'WordPress',
+				},
+				title: 'WordPress',
+			},
+		];
+		const state = {
+			connectedApplications: apps,
+		};
+		const result = getConnectedApplications( state );
+		expect( result ).toBe( apps );
+	} );
+
+	test( 'should return an empty array with an empty state', () => {
+		const result = getConnectedApplications( undefined );
+		expect( result ).toEqual( [] );
+	} );
+} );


### PR DESCRIPTION
This PR introduces a selector for retrieving connected applications out of the current Redux state.

For context of how the selector would be used, you can see the full connected applications reduxification PR: #24175.

To test:
* Checkout this branch.
* Verify all tests pass by running:

```
npm run test-client client/state/selectors/test/get-connected-applications.js
```