### PR TITLE
Plans: do not show Sell Online feature card for Personal .com plans

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -118,7 +118,6 @@ export class ProductPurchaseFeaturesList extends Component {
 				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
 				<AdvertisingRemoved isBusinessPlan selectedSite={ selectedSite } />
 				<MobileApps />
-				<SellOnlinePaypal isJetpack={ false } />
 			</Fragment>
 		);
 	}


### PR DESCRIPTION
It should not be rendered as part of the Personal .com plan.

Fixes:
https://github.com/Automattic/wp-calypso/pull/24535#issuecomment-388700737

## To test:

- go to `plans/my-plan/:site` on local Calypso build or calypso.live
- verify that the card is NOT present when a site is on a Personal .com plan