### PR TITLE
Post Editor: remove unused 'postDate' prop from editor components

### DIFF
--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -36,7 +36,6 @@ export class EditPostStatus extends Component {
 		site: PropTypes.object,
 		translate: PropTypes.func,
 		type: PropTypes.string,
-		postDate: PropTypes.string,
 		onPrivatePublish: PropTypes.func,
 		status: PropTypes.string,
 		isPostPrivate: PropTypes.bool,

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -283,8 +283,6 @@ class EditorDrawer extends Component {
 	}
 
 	renderStatus() {
-		// TODO: REDUX - remove this logic and prop for EditPostStatus when date is moved to redux
-		const postDate = get( this.props.post, 'date', null );
 		const postStatus = get( this.props.post, 'status', null );
 		const { translate, type } = this.props;
 
@@ -292,7 +290,6 @@ class EditorDrawer extends Component {
 			<Accordion title={ translate( 'Status' ) } e2eTitle="status">
 				<EditPostStatus
 					savedPost={ this.props.savedPost }
-					postDate={ postDate }
 					onSave={ this.props.onSave }
 					onTrashingPost={ this.props.onTrashingPost }
 					onPrivatePublish={ this.props.onPrivatePublish }

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -24,17 +24,12 @@ import { getSelectedSite } from 'state/ui/selectors';
 export class EditorPublishDate extends React.Component {
 	static propTypes = {
 		post: PropTypes.object,
-		postDate: PropTypes.string,
 		setPostDate: PropTypes.func,
 	};
 
-	constructor( props ) {
-		super( props );
-
-		this.state = {
-			isOpen: false,
-		};
-	}
+	state = {
+		isOpen: false,
+	};
 
 	componentWillUnmount() {
 		window.removeEventListener( 'click', this.handleOutsideClick );


### PR DESCRIPTION
The prop is not used since post scheduling work done in #16363 and #16541.