### PR TITLE
Post Editor: retrieve EditorPageSlug's path from from Redux

### DIFF
--- a/client/post-editor/editor-page-slug/index.jsx
+++ b/client/post-editor/editor-page-slug/index.jsx
@@ -6,19 +6,30 @@
 
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 
 /**
  * Internal Dependencies
  */
 import EditorSlug from 'post-editor/editor-slug';
+import * as utils from 'lib/posts/utils';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPost } from 'state/posts/selectors';
+import { getSite } from 'state/sites/selectors';
 
-export default class PostEditorPageSlug extends PureComponent {
+class EditorPageSlug extends PureComponent {
 	static propTypes = {
+		isDisplayed: PropTypes.bool,
 		path: PropTypes.string,
 	};
 
 	render() {
+		if ( ! this.props.isDisplayed ) {
+			return null;
+		}
+
 		return (
 			<EditorSlug path={ this.props.path } instanceName="page-permalink">
 				<Gridicon icon="link" />
@@ -26,3 +37,28 @@ export default class PostEditorPageSlug extends PureComponent {
 		);
 	}
 }
+
+// Determine the page base path, i.e., without the last component.
+// Don't remove components beyond the site URL.
+// TODO: merge with utils.getPagePath and add unit tests for the site URL behavior.
+function getPagePath( site, post ) {
+	const siteURL = site ? site.URL + '/' : null;
+	if ( post && post.URL && post.URL !== siteURL ) {
+		return utils.getPagePath( post );
+	}
+
+	return siteURL;
+}
+
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+	const postId = getEditorPostId( state );
+	const site = getSite( state, siteId );
+	const post = getEditedPost( state, siteId, postId );
+
+	// display only when both site and post are available (i.e., not null) and the post is a page
+	const isDisplayed = siteId && utils.isPage( post );
+	const path = getPagePath( site, post );
+
+	return { isDisplayed, path };
+} )( EditorPageSlug );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -271,14 +271,11 @@ export class PostEditor extends React.Component {
 		const site = this.props.selectedSite || undefined;
 		const mode = this.getEditorMode();
 		const isInvalidURL = this.state.loadingError;
-		const siteURL = site ? site.URL + '/' : null;
 
-		let isPage;
 		let isTrashed;
 		let hasAutosave;
 
 		if ( this.state.post ) {
-			isPage = utils.isPage( this.state.post );
 			isTrashed = this.state.post.status === 'trash';
 			hasAutosave = get( this.state.post.meta, [ 'data', 'autosave' ] );
 		}
@@ -361,15 +358,7 @@ export class PostEditor extends React.Component {
 								<FeaturedImage maxWidth={ 1462 } hasDropZone />
 								<div className="post-editor__header">
 									<EditorTitle onChange={ this.onEditorTitleChange } tabIndex={ 1 } />
-									{ this.state.post && isPage && site ? (
-										<EditorPageSlug
-											path={
-												this.state.post.URL && this.state.post.URL !== siteURL
-													? utils.getPagePath( this.state.post )
-													: siteURL
-											}
-										/>
-									) : null }
+									<EditorPageSlug />
 									<SegmentedControl className="post-editor__switch-mode" compact={ true }>
 										<SegmentedControlItem
 											selected={ mode === 'tinymce' }


### PR DESCRIPTION
Move the code that determines whether the `EditorPageSlug` component is displayed and what path prefix it shows from `post-editor` to the component itself. I.e., its `connect` call. This makes the already huge `post-editor.jsx` file a bit smaller.

**How to test:**
Edit a page and verify that editing the page slug works as expected:

<img width="401" alt="screen shot 2018-05-14 at 13 36 58" src="https://user-images.githubusercontent.com/664258/39995274-f4e98f84-577b-11e8-8cce-766fc0bf9652.png">

There are two special cases:
1. Page that has a parent page set. In that case, the path has multiple components, like `https://example.wordpress.com/parent/child`. Verify that the path prefix is displayed as `https://example.wordpress.com/parent/` (including the `parent` bit). See also #1583.
2. Page that is set as front page and its URL is `https://example.wordpress.com/`. Verify that the path prefix is `https://example.wordpress.com` and not just `https://`. See also #4974.