### PR TITLE
Track clicks on Preview/Screenshot button in the single theme showcase page

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -178,6 +178,10 @@ class ThemeSheet extends React.Component {
 		this.trackButtonClick( 'css_forum' );
 	};
 
+	trackPreviewClick = () => {
+		this.trackButtonClick( 'preview' );
+	};
+
 	renderBar = () => {
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = this.props.name || placeholder;
@@ -207,6 +211,7 @@ class ThemeSheet extends React.Component {
 			return;
 		}
 		event.preventDefault();
+		this.trackPreviewClick();
 
 		const { preview } = this.props.options;
 		this.props.setThemePreviewOptions( this.props.defaultOption, this.props.secondaryOption );


### PR DESCRIPTION
We are going to run some tests with different types of screenshots (mobile vs desktop) so we need to add a tracker for the preview button