### PR TITLE
Ad Tracking: Nanigans - ignore 0 or negative value carts

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -874,6 +874,12 @@ function recordOrderInNanigans( cart, orderId ) {
 		return;
 	}
 
+	// As for the FB pixel, we have decided to skip negative or 0-value carts.
+	if ( cart.total_cost < 0.01 ) {
+		debug( 'recordOrderInNanigans: Skipping due to a 0-value cart.' );
+		return;
+	}
+
 	debug( 'recordOrderInNanigans: Record purchase' );
 
 	const productPrices = cart.products.map( product => product.cost * 100 ); // VALUE is in cents, [ 0, 9600 ]


### PR DESCRIPTION
Before this change, 0-value carts (i.e. when user already had a plan, but claimed a domain) were also considered a conversion in the Nanigans system. We have already decided to remove such carts for the FB tracking, so we are replicating the same behavior to Nanigans.

After this change, negative carts (i.e. carts that may have received back credit) and the ones with 0 value (i.e. domain purchases when the user already has a plan) will not be recorded.

How to test:
1) Enable ad-tarcking to the calypso.live branch. https://calypso.live?branch=add/nanigans-0-carts&flags=ad-tracking
2) Enable debugging in Console: `localStorage.setItem( 'debug', 'calypso:analytics:*' );`
3) For one of your existing plans without a domain, claim a domain. This will generate a 0-value cart, which will NOT be reported to Nanigans.  You should see, though, a message in the console saying * recordOrderInFacebook: Skipping due to a 0-value cart. What I recommend: on the last page, just before you finalize the purchase, add once again ?flags=ad-tracking to the URL. 
4) In general, the rest of the tracking should work without being broken.