### PR TITLE
InlineHelp: Create selector to respond with default results

### DIFF
--- a/client/state/inline-help/reducer.js
+++ b/client/state/inline-help/reducer.js
@@ -1,9 +1,5 @@
 /** @format */
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-/**
  * Internal dependencies
  */
 import { combineReducers, createReducer } from 'state/utils';
@@ -55,7 +51,7 @@ export const search = createReducer(
 		},
 		[ INLINE_HELP_SELECT_RESULT ]: ( state, action ) => ( {
 			...state,
-			selectedResult: isEmpty( state.items[ state.searchQuery ] ) ? -1 : action.resultIndex,
+			selectedResult: action.resultIndex,
 		} ),
 		[ INLINE_HELP_SELECT_NEXT_RESULT ]: state => {
 			if ( state.items[ state.searchQuery ] && state.items[ state.searchQuery ].length ) {


### PR DESCRIPTION
Fixes a bug where inline helps contextual results were lost after search...

To replicate issue (before patching): 
- Open inline-help
- Click a result ('reader' for example)
  - See reader content in inline-help
- Go back to list view
- Search 'video'
- Click a result
  - See content for that result
- Go back to list view
-Click 'reader' again
  - See empty content for this option

### Testing
Follow the above but you should see content at every step expected.