### PR TITLE
Activity Log: Replace Rewind buttons with Clone buttons when enableClone is set

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -214,6 +214,7 @@ class ActivityLogItem extends Component {
 
 	renderItemAction() {
 		const {
+			enableClone,
 			hideRestore,
 			activity: { activityIsRewindable, activityName, activityMeta },
 			plugin,
@@ -256,7 +257,27 @@ class ActivityLogItem extends Component {
 		if ( ! hideRestore && activityIsRewindable ) {
 			return this.renderRewindAction();
 		}
+
+		if ( enableClone && activityIsRewindable ) {
+			return this.renderCloneAction();
+		}
 	}
+
+	renderCloneAction = () => {
+		const { translate } = this.props;
+
+		return (
+			<Button
+				className="activity-log-item__clone-action"
+				primary
+				onClick={ this.performCloneAction }
+			>
+				{ translate( 'Clone from here' ) }
+			</Button>
+		);
+	};
+
+	performCloneAction = () => this.props.cloneOnClick( this.props.activity.activityTs );
 
 	renderRewindAction() {
 		const { createBackup, createRewind, disableRestore, disableBackup, translate } = this.props;


### PR DESCRIPTION
During the clone site flow, we need to alter the rewind buttons in the activity log so that they more clearly explain what they do. When the `enableClone` property of `ActivityLogItem` is set to `true`, we will replace the button and dropdown menu with a single "Clone from here" button. On click, these buttons will perform an action provided by the parent element and executed via `cloneOnClick` property.

