### PR TITLE
Update Google My Business Connection Flow

### DIFF
--- a/client/blocks/keyring-connect-button/index.js
+++ b/client/blocks/keyring-connect-button/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { isEqual, noop, some } from 'lodash';
@@ -38,11 +38,15 @@ class KeyringConnectButton extends Component {
 		keyringConnections: PropTypes.array,
 		onClick: PropTypes.func,
 		onConnect: PropTypes.func,
+		forceReconnect: PropTypes.bool,
+		primary: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		onClick: noop,
 		onConnect: noop,
+		forceReconnect: false,
+		primary: false,
 	};
 
 	state = {
@@ -84,11 +88,12 @@ class KeyringConnectButton extends Component {
 	}
 
 	performAction = () => {
+		const { forceReconnect } = this.props;
 		const connectionStatus = this.getConnectionStatus();
 
 		// Depending on current status, perform an action when user clicks the
 		// service action button
-		if ( 'connected' === connectionStatus ) {
+		if ( 'connected' === connectionStatus && ! forceReconnect ) {
 			this.props.onConnect();
 		} else {
 			this.addConnection();
@@ -163,10 +168,10 @@ class KeyringConnectButton extends Component {
 	}
 
 	render() {
-		const { service, translate } = this.props;
+		const { primary, service, translate } = this.props;
 		const { isConnecting, isRefreshing } = this.state;
 		const status = service ? this.getConnectionStatus() : 'unknown';
-		let primary = false,
+		let localPrimary = false,
 			warning = false,
 			label;
 
@@ -181,21 +186,21 @@ class KeyringConnectButton extends Component {
 			label = translate( 'Connecting…' );
 		} else {
 			label = this.props.children;
-			primary = true;
+			localPrimary = primary;
 		}
 
 		return (
-			<div>
+			<Fragment>
 				<QueryKeyringServices />
 				<Button
-					primary={ primary }
+					primary={ localPrimary }
 					scary={ warning }
 					onClick={ this.onClick }
 					disabled={ isPending }
 				>
 					{ label }
 				</Button>
-			</div>
+			</Fragment>
 		);
 	}
 }

--- a/client/my-sites/google-my-business/index.js
+++ b/client/my-sites/google-my-business/index.js
@@ -103,26 +103,32 @@ export default function( router ) {
 		makeLayout
 	);
 
-	router( '/google-my-business/:site', siteSelection, loadKeyringsMiddleware, context => {
-		const state = context.store.getState();
-		const siteId = getSelectedSiteId( state );
-		const hasConnectedLocation = isGoogleMyBusinessLocationConnected( state, siteId );
-		const hasLocationsAvailable = getGoogleMyBusinessLocations( state, siteId ).length > 0;
-		const hasAuthenticated = getKeyringConnectionsByName( state, 'google-my-business' ).length > 0;
+	router(
+		'/google-my-business/:site',
+		siteSelection,
+		loadKeyringsMiddleware,
+		context => {
+			const state = context.store.getState();
+			const siteId = getSelectedSiteId( state );
+			const hasConnectedLocation = isGoogleMyBusinessLocationConnected( state, siteId );
+			const hasLocationsAvailable = getGoogleMyBusinessLocations( state, siteId ).length > 0;
+			const hasAuthenticated =
+				getKeyringConnectionsByName( state, 'google_my_business' ).length > 0;
 
-		if ( ! config.isEnabled( 'google-my-business' ) ) {
-			page.redirect( `/google-my-business/select-business-type/${ context.params.site }` );
-			return;
-		}
+			if ( ! config.isEnabled( 'google-my-business' ) ) {
+				page.redirect( `/google-my-business/select-business-type/${ context.params.site }` );
+				return;
+			}
 
-		if ( hasConnectedLocation ) {
-			page.redirect( `/google-my-business/stats/${ context.params.site }` );
-		} else if ( hasLocationsAvailable ) {
-			page.redirect( `/google-my-business/select-location/${ context.params.site }` );
-		} else if ( hasAuthenticated ) {
-			page.redirect( `/google-my-business/new/${ context.params.site }` );
-		} else {
-			page.redirect( `/google-my-business/select-business-type/${ context.params.site }` );
+			if ( hasConnectedLocation ) {
+				page.redirect( `/google-my-business/stats/${ context.params.site }` );
+			} else if ( hasLocationsAvailable ) {
+				page.redirect( `/google-my-business/select-location/${ context.params.site }` );
+			} else if ( hasAuthenticated && ! hasLocationsAvailable ) {
+				page.redirect( `/google-my-business/new/${ context.params.site }` );
+			} else {
+				page.redirect( `/google-my-business/select-business-type/${ context.params.site }` );
+			}
 		}
-	} );
+	);
 }

--- a/client/my-sites/google-my-business/new-account/index.js
+++ b/client/my-sites/google-my-business/new-account/index.js
@@ -23,7 +23,7 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import KeyringConnectButton from 'blocks/keyring-connect-button';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getGoogleMyBusinessLocations } from 'state/selectors';
+import getGoogleMyBusinessLocations from 'state/selectors/get-google-my-business-locations';
 import { dismissNudge } from 'blocks/google-my-business-stats-nudge/actions';
 
 class GoogleMyBusinessNewAccount extends Component {

--- a/client/my-sites/google-my-business/new-account/index.js
+++ b/client/my-sites/google-my-business/new-account/index.js
@@ -3,11 +3,13 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import page from 'page';
+import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import page from 'page';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,21 +17,31 @@ import React, { Component } from 'react';
 import Button from 'components/button';
 import Card from 'components/card';
 import DocumentHead from 'components/data/document-head';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import KeyringConnectButton from 'blocks/keyring-connect-button';
+import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getGoogleMyBusinessLocations } from 'state/selectors';
+import { dismissNudge } from 'blocks/google-my-business-stats-nudge/actions';
 
 class GoogleMyBusinessNewAccount extends Component {
 	static propTypes = {
 		recordTracksEvent: PropTypes.func.isRequired,
 		siteSlug: PropTypes.string,
 		translate: PropTypes.func.isRequired,
+		locations: PropTypes.arrayOf( PropTypes.object ).isRequired,
 	};
 
 	goBack = () => {
 		page.back( `/google-my-business/select-business-type/${ this.props.siteSlug }` );
+	};
+
+	trackUseAnotherAccountButtonClick = () => {
+		this.props.recordTracksEvent(
+			'calypso_google_my_business_new_account_use_another_account_button_click'
+		);
 	};
 
 	trackCreateMyListingClick = () => {
@@ -38,8 +50,25 @@ class GoogleMyBusinessNewAccount extends Component {
 		);
 	};
 
-	trackNoThanksClick = () => {
+	handleConnect = () => {
+		const { locations } = this.props;
+
+		const locationCount = locations.length;
+		const verifiedLocationCount = locations.filter( location =>
+			get( location, 'meta.state.isVerified', false )
+		).length;
+
+		this.props.recordTracksEvent( 'calypso_google_my_business_new_connect', {
+			location_count: locationCount,
+			verified_location_count: verifiedLocationCount,
+		} );
+
+		page.redirect( `/google-my-business/${ this.props.siteSlug }` );
+	};
+
+	handleNoThanksClick = () => {
 		this.props.recordTracksEvent( 'calypso_google_my_business_new_account_no_thanks_button_click' );
+		this.props.dismissNudge();
 	};
 
 	render() {
@@ -70,20 +99,30 @@ class GoogleMyBusinessNewAccount extends Component {
 						<p>
 							{ translate(
 								'Google My Business lists your local business on Google Search and Google Maps. ' +
-									'It works for businesses that have a physical location or serve a local area'
+									'It works for businesses that have a physical location, or serve a local area.'
 							) }
 						</p>
 
 						<div className="gmb-new-account__actions">
 							<Button
-								href={ `/google-my-business/select-location/${ siteSlug }` }
+								href={ 'https://business.google.com/create' }
+								target="_blank"
 								onClick={ this.trackCreateMyListingClick }
 								primary
 							>
-								{ translate( 'Create Your Listing' ) }
+								{ translate( 'Create Listing' ) } <Gridicon icon="external" />
 							</Button>
 
-							<Button href={ `/stats/${ siteSlug }` } onClick={ this.trackNoThanksClick }>
+							<KeyringConnectButton
+								serviceId="google_my_business"
+								forceReconnect={ true }
+								onClick={ this.trackUseAnotherAccountButtonClick }
+								onConnect={ this.handleConnect }
+							>
+								{ translate( 'Use another Google Account' ) }
+							</KeyringConnectButton>
+
+							<Button href={ `/stats/${ siteSlug }` } onClick={ this.handleNoThanksClick }>
 								{ translate( 'No thanks' ) }
 							</Button>
 						</div>
@@ -97,8 +136,10 @@ class GoogleMyBusinessNewAccount extends Component {
 export default connect(
 	state => ( {
 		siteSlug: getSelectedSiteSlug( state ),
+		locations: getGoogleMyBusinessLocations( state, getSelectedSiteId( state ) ),
 	} ),
 	{
+		dismissNudge,
 		recordTracksEvent,
 	}
 )( localize( GoogleMyBusinessNewAccount ) );

--- a/client/my-sites/google-my-business/new-account/style.scss
+++ b/client/my-sites/google-my-business/new-account/style.scss
@@ -12,27 +12,3 @@
 		max-width: 300px;
 	}
 }
-
-.gmb-new-account__actions {
-	display: flex;
-
-	@include breakpoint( '<480px' ) {
-		flex-direction: column;
-	}
-}
-
-.gmb-new-account__actions .button {
-	@include breakpoint( '<480px' ) {
-		text-align: center;
-	}
-
-	&.is-primary {
-		@include breakpoint( '<480px' ) {
-			margin-bottom: 10px;
-		}
-
-		@include breakpoint( '>480px' ) {
-			margin-right: 10px;
-		}
-	}
-}

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -34,8 +34,10 @@ import QueryKeyringConnections from 'components/data/query-keyring-connections';
 
 class GoogleMyBusinessSelectBusinessType extends Component {
 	static propTypes = {
+		googleMyBusinessLocations: PropTypes.array.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
+		siteIsJetpack: PropTypes.bool.isRequired,
 		siteSlug: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 	};
@@ -70,6 +72,12 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 		);
 	};
 
+	trackConnectToGoogleMyBusinessClick = () => {
+		this.props.recordTracksEvent(
+			'calypso_google_my_business_select_business_type_create_my_listing_button_click'
+		);
+	};
+
 	trackOptimizeYourSEOClick = () => {
 		this.props.recordTracksEvent(
 			'calypso_google_my_business_select_business_type_optimize_your_seo_button_click'
@@ -91,11 +99,13 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 			connectButton = (
 				<KeyringConnectButton
 					serviceId="google_my_business"
-					onClick={ this.trackCreateYourListingClick }
+					onClick={ this.trackConnectToGoogleMyBusinessClick }
 					onConnect={ this.handleConnect }
+					primary
 				>
-					{ translate( 'Create Your Listing', {
-						comment: 'Call to Action to add a business listing to Google My Business',
+					{ translate( 'Connect to Google My Business', {
+						comment:
+							'Call to Action to connect the site to a business listing in Google My Business',
 					} ) }
 				</KeyringConnectButton>
 			);
@@ -107,14 +117,13 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 					target="_blank"
 					onClick={ this.trackCreateYourListingClick }
 				>
-					{ translate( 'Create Your Listing', {
+					{ translate( 'Create Listing', {
 						comment: 'Call to Action to add a business listing to Google My Business',
 					} ) }{' '}
 					<Gridicon icon="external" />
 				</Button>
 			);
 		}
-
 		return (
 			<ActionCard
 				headerText={ translate( 'Physical Location or Service Area', {
@@ -131,7 +140,11 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 	}
 
 	renderOnlineBusinessCard() {
-		const { siteSlug, translate } = this.props;
+		const { siteIsJetpack, translate } = this.props;
+
+		const seoHelpLink = siteIsJetpack
+			? 'https://jetpack.com/support/seo-tools/'
+			: 'https://en.blog.wordpress.com/2013/03/22/seo-on-wordpress-com/';
 
 		return (
 			<ActionCard
@@ -141,8 +154,10 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 				mainText={ translate(
 					"Don't provide in-person services? Learn more about reaching your customers online."
 				) }
-				buttonText={ translate( 'Optimize Your SEO', { comment: 'Call to Action button' } ) }
-				buttonHref={ `/settings/traffic/${ siteSlug }` }
+				buttonTarget="_blank"
+				buttonText={ translate( 'Learn More about SEO', { comment: 'Call to Action button' } ) }
+				buttonHref={ seoHelpLink }
+				buttonIcon="external"
 				buttonOnClick={ this.trackOptimizeYourSEOClick }
 			/>
 		);
@@ -176,7 +191,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 						<p>
 							{ translate(
 								'{{link}}Google My Business{{/link}} lists your local business on Google Search and Google Maps. ' +
-									'It works for businesses that have a physical location or serve a local area.',
+									'It works for businesses that have a physical location, or serve a local area.',
 								{
 									components: {
 										link: (
@@ -212,10 +227,12 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
+
 		return {
 			googleMyBusinessLocations: getGoogleMyBusinessLocations( state, siteId ),
 			canUserManageOptions: canCurrentUser( state, siteId, 'manage_options' ),
 			siteId,
+			siteIsJetpack: isJetpackSite( state, siteId ),
 			siteSlug: getSelectedSiteSlug( state ),
 		};
 	},

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -31,6 +31,7 @@ import getGoogleMyBusinessLocations from 'state/selectors/get-google-my-business
 import { recordTracksEvent } from 'state/analytics/actions';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
 import QueryKeyringConnections from 'components/data/query-keyring-connections';
+import { isJetpackSite } from 'state/sites/selectors';
 
 class GoogleMyBusinessSelectBusinessType extends Component {
 	static propTypes = {

--- a/client/my-sites/google-my-business/select-location/button.js
+++ b/client/my-sites/google-my-business/select-location/button.js
@@ -56,13 +56,17 @@ class GoogleMyBusinessSelectLocationButton extends Component {
 						className="gmb-select-location__connected-icon"
 						icon="checkmark-circle"
 						size={ 18 }
-					/>{' '}
+					/>{ ' ' }
 					{ translate( 'Connected' ) }
 				</div>
 			);
 		}
 
-		return <Button onClick={ this.connectLocation }>{ translate( 'Connect Location' ) }</Button>;
+		return (
+			<Button onClick={ this.connectLocation } primary>
+				{ translate( 'Connect Location' ) }
+			</Button>
+		);
 	}
 }
 

--- a/client/my-sites/google-my-business/select-location/style.scss
+++ b/client/my-sites/google-my-business/select-location/style.scss
@@ -1,5 +1,5 @@
 
-.gmb-select-location__add {
+.gmb-select-location__help {
 	margin-top: 16px;
 }
 

--- a/client/my-sites/google-my-business/style.scss
+++ b/client/my-sites/google-my-business/style.scss
@@ -10,3 +10,29 @@
 		margin-top: 10px;
 	}
 }
+
+.gmb-new-account__actions,
+.gmb-select-location__help-actions {
+	display: flex;
+
+	@include breakpoint( '<480px' ) {
+		flex-direction: column;
+	}
+}
+
+.gmb-new-account__actions .button,
+.gmb-select-location__help-actions .button {
+	@include breakpoint( '<480px' ) {
+		text-align: center;
+	}
+
+	&:not( :last-child ) {
+		@include breakpoint( '<480px' ) {
+			margin-bottom: 10px;
+		}
+
+		@include breakpoint( '>480px' ) {
+			margin-right: 10px;
+		}
+	}
+}

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -33,7 +33,7 @@ import { getSiteOption, isJetpackSite } from 'state/sites/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import PrivacyPolicyBanner from 'blocks/privacy-policy-banner';
 import ChecklistBanner from './checklist-banner';
-import QuerySiteSettings from 'components/data/query-site-settings';
+import QuerySiteKeyrings from 'components/data/query-site-keyrings';
 import GoogleMyBusinessStatsNudge from 'blocks/google-my-business-stats-nudge';
 import isGoogleMyBusinessStatsNudgeVisibleSelector from 'state/selectors/is-google-my-business-stats-nudge-visible';
 
@@ -135,7 +135,7 @@ class StatsSite extends Component {
 
 		return (
 			<Main wideLayout={ true }>
-				<QuerySiteSettings siteId={ siteId } />
+				{ siteId && <QuerySiteKeyrings siteId={ siteId } /> }
 				<DocumentHead title={ translate( 'Stats' ) } />
 				<PageViewTracker
 					path={ `/stats/${ period }/:site` }

--- a/client/state/selectors/is-site-google-my-business-eligible.js
+++ b/client/state/selectors/is-site-google-my-business-eligible.js
@@ -46,7 +46,7 @@ export const siteHasBusinessPlan = createSelector(
 );
 
 /**
- * Returns true if site has jetpack premium/business plan
+ * Returns true if site has Jetpack premium/business plan
  *
  * @param  {Object}  state  Global state tree
  * @param  {String}  siteId The Site ID
@@ -65,10 +65,10 @@ export const siteHasEligibleJetpackPlan = createSelector(
 );
 
 /**
- * Returns true if the site is eliglbe to  use Google My Business (GMB)
+ * Returns true if the site is eligible to use Google My Business (GMB)
  *
  * It should be visible if:
- * - site has a business plan on wpcom or jetpack premium/business
+ * - site has a business plan on wpcom or Jetpack premium/business
  * @param  {Object}  state  Global state tree
  * @param  {String}  siteId The Site ID
  * @return {Boolean} True if we should show the nudge


### PR DESCRIPTION
## Specs

### Terms

- **associating account**: adding a Google account to the external accounts of a Wordpress.com account
- **connecting location**: adding a Google My Business to a Wordpress.com site to use additional Google My Business features

This PR changes:

### The Flow

[Flow.pdf](https://github.com/Automattic/wp-calypso/files/2018899/Flow.pdf)

### Select Business Page
<img width="1019" alt="screen shot 2018-05-17 at 8 29 01 pm" src="https://user-images.githubusercontent.com/2810519/40214717-384b7e76-5a11-11e8-862a-f9c9e1ff23a1.png">

The text of the primary button this page is now dependent on if there are GMB locations available. If there are, or there is no account connected, the button will display "Connect to Google My Business", otherwise it will read "Create your Listing". Separate events are issued for each button.

### Select Location Page
<img width="1008" alt="screen_shot_2018-05-17_at_8_29_50_pm" src="https://user-images.githubusercontent.com/2810519/40214733-48e97986-5a11-11e8-9b10-e482067b7d2c.png">

The footer card now has two buttons, one which sends the user to the Google My Business creation page, and another which allows them to associate a different Google My Business account.

### New Account Page
<img width="1003" alt="screen shot 2018-05-17 at 8 30 15 pm" src="https://user-images.githubusercontent.com/2810519/40214745-59986fd0-5a11-11e8-903b-0ac1f449305d.png">

The "Use another Google My Business Account" button has been added here. Additionally, clicking "No Thanks" will dismiss the Google My Business Stats Nudge.

## Testing

### Clearing out your Google My Business Connections

1. Disconnect Google My Business at `/sharing/:site`
2. See p9j7e4-eC on clearing out the keyring connection

### Select Business Page

1. Disconnect GMB and clear out Keyring connections
2. Navigate to `/google-my-business/select-business-type/:site`
3. Verify that the primary button is labeled "Connect to Google My Business"
4. Verify that clicking on"Connect to Google My Business" opens the GMB connection dialog
5. Associate a Google account with a GMB Location
6. Verify that you are sent to the "Select Location" page after the connection is complete
7. Repeat Steps 1-4
8. Associate a Google account **without** a GMB Location
9. Verify that you are sent to the "new Account" page after the connection is complete

### Select Location Page

1. Disconnect GMB and clear out Keyring connections
2. Associate a Google account with a Google My Business location to a site
3. Navigate to `/google-my-business/select-location/:site`
4. Click the "Use another Google Account" button
5. Associate another Google with different locations
6. Verify locations from both verified accounts are now being shown

### New Account Page

1. Disconnect GMB and clear out Keyring connections
2. Navigate to `/google-my-business/new/:site`
3. Click the "No Thanks" Button
4. Verify that you have been returned the stats page of the site
 and that the GMB Stats Nudge has been hidden
5. Clear the `google-my-business-dismissible-nudge` preference and return to `/google-my-business/new/:site`
6. Click the "Use another Google Account" button
7. Associate an account with a Google My Business location
8. Verify that you are taken to the "Select Location"

### Stats Nudge
1. Disconnect GMB and clear out Keyring connections
2. Navigate to `/stats/:site`
3. Click "Start Now" on the Nudge
4. Verify you are taken to the "Select Business Type" page
5. Associate an account with a Google My Business location
6. Return to `/stats/:site`
7. Click "Start Now" on the Nudge
8. Verify you are taken to the "Select Location " page

## Review
- [ ] Code
- [ ] Product
- [ ] Copy 