### PR TITLE
Simple Payments: allow saving the form after product image is edited

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -176,11 +176,15 @@ const renderPriceField = ( { price, currency, ...props } ) => {
 
 class ProductForm extends Component {
 	render() {
-		const { translate } = this.props;
+		const { translate, makeDirtyAfterImageEdit } = this.props;
 
 		return (
 			<form className="editor-simple-payments-modal__form">
-				<Field name="featuredImageId" component={ ProductImagePicker } />
+				<Field
+					name="featuredImageId"
+					component={ ProductImagePicker }
+					makeDirtyAfterImageEdit={ makeDirtyAfterImageEdit }
+				/>
 				<div className="editor-simple-payments-modal__form-fields">
 					<ReduxFormFieldset
 						name="title"

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -194,6 +194,7 @@ class SimplePaymentsDialog extends Component {
 			selectedPaymentId: null,
 			isSubmitting: false,
 			errorMessage: null,
+			isDirtyAfterImageEdit: false,
 		};
 	}
 
@@ -419,11 +420,18 @@ class SimplePaymentsDialog extends Component {
 		);
 	};
 
+	// The only thing we track about image in Simple Payments product form is its media id.
+	// However this doesn't change when the image is edited, and as a result redux form
+	// isDirty selector is not detecting any update, so it's not possible to submit changes
+	// after editing the image (even though they are saved behind the scenes in Media library).
+	// This allows us to force re-enabling of the save button in that case.
+	makeDirtyAfterImageEdit = () => this.setState( { isDirtyAfterImageEdit: true } );
+
 	getActionButtons() {
 		const { formIsValid, formIsDirty, translate, featuredImageId } = this.props;
-		const { activeTab, editedPaymentId, isSubmitting } = this.state;
+		const { activeTab, editedPaymentId, isSubmitting, isDirtyAfterImageEdit } = this.state;
 
-		const formCanBeSubmitted = formIsValid && formIsDirty;
+		const formCanBeSubmitted = formIsValid && ( formIsDirty || isDirtyAfterImageEdit );
 
 		let cancelHandler, finishHandler, finishDisabled, finishLabel;
 		if ( activeTab === 'form' && isNumber( editedPaymentId ) ) {
@@ -585,7 +593,11 @@ class SimplePaymentsDialog extends Component {
 					<Notice status="is-error" text={ errorMessage } onDismissClick={ this.dismissError } />
 				) }
 				{ activeTab === 'form' ? (
-					<ProductForm initialValues={ initialFormValues } showError={ this.showError } />
+					<ProductForm
+						initialValues={ initialFormValues }
+						showError={ this.showError }
+						makeDirtyAfterImageEdit={ this.makeDirtyAfterImageEdit }
+					/>
 				) : (
 					<ProductList
 						siteId={ siteId }

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -93,7 +93,7 @@ class ProductImagePicker extends Component {
 	}
 
 	render() {
-		const { siteId, translate } = this.props;
+		const { siteId, translate, makeDirtyAfterImageEdit } = this.props;
 		const { isSelecting } = this.state;
 
 		if ( ! siteId ) {
@@ -114,6 +114,7 @@ class ProductImagePicker extends Component {
 							confirm: translate( 'Add' ),
 						} }
 						single
+						onImageEditorDoneHook={ makeDirtyAfterImageEdit }
 					/>
 				</MediaLibrarySelectedData>
 

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -83,6 +83,7 @@ export class EditorMediaModal extends Component {
 		postId: PropTypes.number,
 		disableLargeImageSources: PropTypes.bool,
 		disabledDataSources: PropTypes.arrayOf( PropTypes.string ),
+		onImageEditorDoneHook: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -100,6 +101,7 @@ export class EditorMediaModal extends Component {
 		deleteMedia: () => {},
 		disableLargeImageSources: false,
 		disabledDataSources: [],
+		onImageEditorDoneHook: noop,
 	};
 
 	constructor( props ) {
@@ -342,6 +344,10 @@ export class EditorMediaModal extends Component {
 		resetAllImageEditorState();
 
 		this.props.setView( ModalViews.DETAIL );
+
+		if ( this.props.onImageEditorDoneHook ) {
+			this.props.onImageEditorDoneHook();
+		}
 	};
 
 	handleUpdatePoster = ( { ID, posterUrl } ) => {


### PR DESCRIPTION
This issue was originally reported by @gwwar in this [PR review comment](https://github.com/Automattic/wp-calypso/pull/24659#issuecomment-387914461).

We are relying on `isDirty` redux form selector to determine if some form fields were updated, and consequently enable the `Done` button if they were. However, the only field we pass to the form for image is its media id, and this doesn't get updated when the image is edited. So after editing an image no change would be detected and the form submit field would remain disabled, which could confuse users (even though the actual edited image is saved behind the scenes).

The workaround for this was to introduce a separate piece of component state that would toggle the flag if image editing occurred, and enable the button based on that. It's not the most elegant solution because I had to pass the handler for switching it all the way to post editor's media modal, but I couldn't find anything better in redux form's API that would allow for a more concise solution.

### Testing instructions

1. Click on an existing simple payment button with an image set
2. Edit it
3. Click to edit the image
4. In the media modal click edit
5. Make some changes to the image (crop etc)
6. Save changes. 
7. The Done button should be enabled.