### PR TITLE
Me: add /me/account/close page

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -280,6 +280,7 @@
 @import 'mailing-lists/style';
 @import 'me/account-password/style';
 @import 'me/account/style';
+@import 'me/account-close/style';
 @import 'me/application-password-item/style';
 @import 'me/application-passwords/style';
 @import 'me/billing-history/style';

--- a/client/components/action-panel/figure-header.jsx
+++ b/client/components/action-panel/figure-header.jsx
@@ -1,0 +1,13 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+
+const ActionPanelFigureHeader = ( { children, className } ) => {
+	return <h3 className={ classnames( 'action-panel__figure-header', className ) }>{ children }</h3>;
+};
+
+export default ActionPanelFigureHeader;

--- a/client/components/action-panel/figure-list-item.jsx
+++ b/client/components/action-panel/figure-list-item.jsx
@@ -1,0 +1,15 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+
+const ActionPanelFigureListItem = ( { children, className } ) => {
+	return (
+		<li className={ classnames( 'action-panel__figure-list-item', className ) }>{ children }</li>
+	);
+};
+
+export default ActionPanelFigureListItem;

--- a/client/components/action-panel/figure-list.jsx
+++ b/client/components/action-panel/figure-list.jsx
@@ -1,0 +1,13 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+
+const ActionPanelFigureList = ( { children, className } ) => {
+	return <ul className={ classnames( 'action-panel__figure-list', className ) }>{ children }</ul>;
+};
+
+export default ActionPanelFigureList;

--- a/client/components/action-panel/link.jsx
+++ b/client/components/action-panel/link.jsx
@@ -1,0 +1,17 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+
+const ActionPanelLink = ( { children, href, className } ) => {
+	return (
+		<a href={ href } className={ classnames( 'action-panel__body-text-link', className ) }>
+			{ children }
+		</a>
+	);
+};
+
+export default ActionPanelLink;

--- a/client/components/action-panel/style.scss
+++ b/client/components/action-panel/style.scss
@@ -51,6 +51,37 @@ a.action-panel__body-text-link {
 	}
 }
 
+.action-panel__figure-header {
+	margin-bottom: 8px;
+	font-size: 11px;
+	line-height: 16px;
+	text-transform: uppercase;
+	text-align: left;
+	color: $gray-text-min;
+}
+
+.action-panel__figure-list {
+	margin: 0 0 20px;
+	border: solid 1px $gray-lighten-20;
+	border-radius: 4px;
+	list-style: none;
+	text-align: left;
+}
+
+.action-panel__figure-list-item {
+	box-sizing: border-box;
+	width: 100%;
+	padding: 12px 16px;
+	border-top: solid 1px $gray-lighten-20;
+	font-size: 14px;
+	line-height: 18px;
+	color: $gray-dark;
+
+	&:first-child {
+		border-top: none;
+	}
+}
+
 // Footer
 .action-panel__footer {
 	position: relative;

--- a/client/components/action-panel/title.jsx
+++ b/client/components/action-panel/title.jsx
@@ -3,11 +3,13 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
+import classnames from 'classnames';
 
-const ActionPanelTitle = ( { children } ) => {
-	return <h2 className="action-panel__title">{ children }</h2>;
+const ActionPanelTitle = ( { children, className } ) => {
+	return (
+		<h2 className={ classnames( 'settings-action-panel__title', className ) }>{ children }</h2>
+	);
 };
 
 export default ActionPanelTitle;

--- a/client/components/action-panel/title.jsx
+++ b/client/components/action-panel/title.jsx
@@ -7,9 +7,7 @@ import React from 'react';
 import classnames from 'classnames';
 
 const ActionPanelTitle = ( { children, className } ) => {
-	return (
-		<h2 className={ classnames( 'settings-action-panel__title', className ) }>{ children }</h2>
-	);
+	return <h2 className={ classnames( 'action-panel__title', className ) }>{ children }</h2>;
 };
 
 export default ActionPanelTitle;

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -1,0 +1,73 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import FormLabel from 'components/forms/form-label';
+import Button from 'components/button';
+
+const AccountCloseConfirmDialog = ( {
+	isVisible,
+	username,
+	onConfirm,
+	translate,
+	closeConfirmDialog,
+	deleteAccount,
+} ) => {
+	const deleteButtons = [
+		<Button onClick={ closeConfirmDialog }>{ translate( 'Cancel' ) }</Button>,
+		<Button primary scary onClick={ deleteAccount }>
+			{ translate( 'Close your account' ) }
+		</Button>,
+	];
+
+	return (
+		<Dialog
+			isVisible={ isVisible }
+			buttons={ deleteButtons }
+			className="account-close__confirm-dialog"
+		>
+			<h1 className="account-close__confirm-dialog-header">
+				{ translate( 'Confirm account closure' ) }
+			</h1>
+			<FormLabel htmlFor="confirmAccountCloseInput" className="account-close__confirm-dialog-label">
+				{ translate(
+					'Please type {{warn}}%(username)s{{/warn}} in the field below to confirm. ' +
+						'Your account will then be gone forever.',
+					{
+						components: {
+							warn: <span className="account-close__confirm-dialog-target-username" />,
+						},
+						args: {
+							username: username,
+						},
+					}
+				) }
+			</FormLabel>
+
+			<input
+				autoCapitalize="off"
+				className="account-close__confirm-dialog-confirm-input"
+				type="text"
+				onChange={ onConfirm }
+				aria-required="true"
+				id="confirmAccountCloseInput"
+			/>
+		</Dialog>
+	);
+};
+
+AccountCloseConfirmDialog.defaultProps = {
+	deleteAccount: noop,
+	username: 'yourusername', // @todo connect this to get real username
+};
+
+export default localize( AccountCloseConfirmDialog );

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -24,7 +24,7 @@ const AccountCloseConfirmDialog = ( {
 } ) => {
 	const deleteButtons = [
 		<Button onClick={ closeConfirmDialog }>{ translate( 'Cancel' ) }</Button>,
-		<Button primary scary onClick={ deleteAccount }>
+		<Button primary scary disabled onClick={ deleteAccount }>
 			{ translate( 'Close your account' ) }
 		</Button>,
 	];

--- a/client/me/account-close/controller.js
+++ b/client/me/account-close/controller.js
@@ -1,0 +1,16 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import AccountSettingsCloseComponent from 'me/account-close/main';
+
+export function accountClose( context, next ) {
+	context.primary = React.createElement( AccountSettingsCloseComponent );
+	next();
+}

--- a/client/me/account-close/index.js
+++ b/client/me/account-close/index.js
@@ -11,7 +11,10 @@ import page from 'page';
 import { accountClose } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { sidebar } from 'me/controller';
+import { isEnabled } from 'config';
 
 export default function() {
-	page( '/me/account/close', sidebar, accountClose, makeLayout, clientRender );
+	if ( isEnabled( 'me/account-close' ) ) {
+		page( '/me/account/close', sidebar, accountClose, makeLayout, clientRender );
+	}
 }

--- a/client/me/account-close/index.js
+++ b/client/me/account-close/index.js
@@ -1,0 +1,17 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { accountClose } from './controller';
+import { makeLayout, render as clientRender } from 'controller';
+import { sidebar } from 'me/controller';
+
+export default function() {
+	page( '/me/account/close', sidebar, accountClose, makeLayout, clientRender );
+}

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -16,6 +16,10 @@ import ActionPanel from 'components/action-panel';
 import ActionPanelTitle from 'components/action-panel/title';
 import ActionPanelBody from 'components/action-panel/body';
 import ActionPanelFigure from 'components/action-panel/figure';
+import ActionPanelFigureHeader from 'components/action-panel/figure-header';
+import ActionPanelFigureList from 'components/action-panel/figure-list';
+import ActionPanelFigureListItem from 'components/action-panel/figure-list-item';
+import ActionPanelLink from 'components/action-panel/link';
 import ActionPanelFooter from 'components/action-panel/footer';
 import Button from 'components/button';
 
@@ -33,7 +37,7 @@ class AccountSettingsClose extends Component {
 		const hasAtomicSites = false;
 
 		return (
-			<div className="account-close" role="main">
+			<div className="account-close main" role="main">
 				<HeaderCake onClick={ this.goBack }>
 					<h1>{ translate( 'Close account' ) }</h1>
 				</HeaderCake>
@@ -43,21 +47,26 @@ class AccountSettingsClose extends Component {
 					</ActionPanelTitle>
 					<ActionPanelBody>
 						<ActionPanelFigure>
-							<h3>{ translate( 'These items will be deleted' ) }</h3>
-							<ul>
-								<li>{ translate( 'Posts' ) }</li>
-								<li>{ translate( 'Pages' ) }</li>
-								<li>{ translate( 'Media' ) }</li>
-								<li>{ translate( 'Users & Authors' ) }</li>
-								<li>{ translate( 'Domains' ) }</li>
-							</ul>
+							<ActionPanelFigureHeader>
+								{ translate( 'These items will be deleted' ) }
+							</ActionPanelFigureHeader>
+							<ActionPanelFigureList>
+								<ActionPanelFigureListItem>{ translate( 'Sites' ) }</ActionPanelFigureListItem>
+								<ActionPanelFigureListItem>{ translate( 'Posts' ) }</ActionPanelFigureListItem>
+								<ActionPanelFigureListItem>{ translate( 'Pages' ) }</ActionPanelFigureListItem>
+								<ActionPanelFigureListItem>{ translate( 'Media' ) }</ActionPanelFigureListItem>
+								<ActionPanelFigureListItem>
+									{ translate( 'Users & Authors' ) }
+								</ActionPanelFigureListItem>
+								<ActionPanelFigureListItem>{ translate( 'Domains' ) }</ActionPanelFigureListItem>
+							</ActionPanelFigureList>
 						</ActionPanelFigure>
 						{ ! hasAtomicSites && (
 							<div>
 								<p>
 									{ translate(
 										'Account closure {{strong}}cannot{{/strong}} be undone, ' +
-											'and will remove all content, contributors and domains from your account.',
+											'and will remove all sites and content.',
 										{
 											components: {
 												strong: <strong />,
@@ -67,12 +76,9 @@ class AccountSettingsClose extends Component {
 								</p>
 								<p>
 									{ translate(
-										"If you're unsure about what deletion means or have any other questions, " +
+										"If you're unsure about what account closure means or have any other questions, " +
 											'please chat with someone from our support team before proceeding.'
 									) }
-								</p>
-								<p>
-									<a href="/help/contact">{ translate( 'Contact support' ) }</a>
 								</p>
 							</div>
 						) }
@@ -80,22 +86,27 @@ class AccountSettingsClose extends Component {
 							<div>
 								<p>
 									{ translate(
-										"To close your account, you'll need to contact our support team. Account closure cannot be undone, " +
-											'and will remove all content, contributors and domains from this site.'
+										"To close your account, you'll need to contact our support team. Account closure cannot be undone " +
+											'and will remove all sites and content.'
 									) }
 								</p>
 								<p>
 									{ translate(
-										"If you're unsure about what deletion means or have any other questions, " +
+										"If you're unsure about what account closure means or have any other questions, " +
 											"you'll have a chance to chat with someone from our support team before anything happens."
 									) }
 								</p>
 							</div>
 						) }
+						<p>
+							<ActionPanelLink href="/help/contact">
+								{ translate( 'Contact support' ) }
+							</ActionPanelLink>
+						</p>
 					</ActionPanelBody>
 					<ActionPanelFooter>
 						{ ! hasAtomicSites && (
-							<Button scary disabled={ true } onClick={ this.handleDeleteClick }>
+							<Button scary onClick={ this.handleDeleteClick }>
 								<Gridicon icon="trash" />
 								{ translate( 'Close account' ) }
 							</Button>

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -12,11 +12,11 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import HeaderCake from 'components/header-cake';
-import ActionPanel from 'my-sites/site-settings/action-panel';
-import ActionPanelTitle from 'my-sites/site-settings/action-panel/title';
-import ActionPanelBody from 'my-sites/site-settings/action-panel/body';
-import ActionPanelFigure from 'my-sites/site-settings/action-panel/figure';
-import ActionPanelFooter from 'my-sites/site-settings/action-panel/footer';
+import ActionPanel from 'components/action-panel';
+import ActionPanelTitle from 'components/action-panel/title';
+import ActionPanelBody from 'components/action-panel/body';
+import ActionPanelFigure from 'components/action-panel/figure';
+import ActionPanelFooter from 'components/action-panel/footer';
 import Button from 'components/button';
 
 class AccountSettingsClose extends Component {

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -22,14 +22,27 @@ import ActionPanelFigureListItem from 'components/action-panel/figure-list-item'
 import ActionPanelLink from 'components/action-panel/link';
 import ActionPanelFooter from 'components/action-panel/footer';
 import Button from 'components/button';
+import AccountCloseConfirmDialog from './confirm-dialog';
 
 class AccountSettingsClose extends Component {
+	state = {
+		showConfirmDialog: false,
+	};
+
 	goBack = () => {
 		page( '/me/account' );
 	};
 
 	handleDeleteClick = event => {
 		event.preventDefault();
+
+		// @todo check if purchases and sites have loaded
+
+		this.setState( { showConfirmDialog: true } );
+	};
+
+	closeConfirmDialog = () => {
+		this.setState( { showConfirmDialog: false } );
 	};
 
 	render() {
@@ -117,6 +130,10 @@ class AccountSettingsClose extends Component {
 							</Button>
 						) }
 					</ActionPanelFooter>
+					<AccountCloseConfirmDialog
+						isVisible={ this.state.showConfirmDialog }
+						closeConfirmDialog={ this.closeConfirmDialog }
+					/>
 				</ActionPanel>
 			</div>
 		);

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -3,15 +3,112 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
+import page from 'page';
+import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 
-import CompactCard from 'components/card/compact';
+/**
+ * Internal dependencies
+ */
+import HeaderCake from 'components/header-cake';
+import ActionPanel from 'my-sites/site-settings/action-panel';
+import ActionPanelTitle from 'my-sites/site-settings/action-panel/title';
+import ActionPanelBody from 'my-sites/site-settings/action-panel/body';
+import ActionPanelFigure from 'my-sites/site-settings/action-panel/figure';
+import ActionPanelFooter from 'my-sites/site-settings/action-panel/footer';
+import Button from 'components/button';
 
-class AccountSettingsClose extends React.Component {
+class AccountSettingsClose extends Component {
+	goBack = () => {
+		page( '/me/account' );
+	};
+
+	handleDeleteClick = event => {
+		event.preventDefault();
+	};
+
 	render() {
-		// const { translate } = this.props;
-		return <CompactCard>banana</CompactCard>;
+		const { translate } = this.props;
+		const hasAtomicSites = false;
+
+		return (
+			<div className="account-close" role="main">
+				<HeaderCake onClick={ this.goBack }>
+					<h1>{ translate( 'Close account' ) }</h1>
+				</HeaderCake>
+				<ActionPanel>
+					<ActionPanelTitle className="account-close__heading">
+						{ translate( 'Close account' ) }
+					</ActionPanelTitle>
+					<ActionPanelBody>
+						<ActionPanelFigure>
+							<h3>{ translate( 'These items will be deleted' ) }</h3>
+							<ul>
+								<li>{ translate( 'Posts' ) }</li>
+								<li>{ translate( 'Pages' ) }</li>
+								<li>{ translate( 'Media' ) }</li>
+								<li>{ translate( 'Users & Authors' ) }</li>
+								<li>{ translate( 'Domains' ) }</li>
+							</ul>
+						</ActionPanelFigure>
+						{ ! hasAtomicSites && (
+							<div>
+								<p>
+									{ translate(
+										'Account closure {{strong}}cannot{{/strong}} be undone, ' +
+											'and will remove all content, contributors and domains from your account.',
+										{
+											components: {
+												strong: <strong />,
+											},
+										}
+									) }
+								</p>
+								<p>
+									{ translate(
+										"If you're unsure about what deletion means or have any other questions, " +
+											'please chat with someone from our support team before proceeding.'
+									) }
+								</p>
+								<p>
+									<a href="/help/contact">{ translate( 'Contact support' ) }</a>
+								</p>
+							</div>
+						) }
+						{ hasAtomicSites && (
+							<div>
+								<p>
+									{ translate(
+										"To close your account, you'll need to contact our support team. Account closure cannot be undone, " +
+											'and will remove all content, contributors and domains from this site.'
+									) }
+								</p>
+								<p>
+									{ translate(
+										"If you're unsure about what deletion means or have any other questions, " +
+											"you'll have a chance to chat with someone from our support team before anything happens."
+									) }
+								</p>
+							</div>
+						) }
+					</ActionPanelBody>
+					<ActionPanelFooter>
+						{ ! hasAtomicSites && (
+							<Button scary disabled={ true } onClick={ this.handleDeleteClick }>
+								<Gridicon icon="trash" />
+								{ translate( 'Close account' ) }
+							</Button>
+						) }
+						{ hasAtomicSites && (
+							<Button primary href="/help/contact">
+								{ translate( 'Contact support' ) }
+							</Button>
+						) }
+					</ActionPanelFooter>
+				</ActionPanel>
+			</div>
+		);
 	}
 }
 

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -1,0 +1,18 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+import CompactCard from 'components/card/compact';
+
+class AccountSettingsClose extends React.Component {
+	render() {
+		// const { translate } = this.props;
+		return <CompactCard>banana</CompactCard>;
+	}
+}
+
+export default localize( AccountSettingsClose );

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -64,13 +64,13 @@ class AccountSettingsClose extends Component {
 								{ translate( 'These items will be deleted' ) }
 							</ActionPanelFigureHeader>
 							<ActionPanelFigureList>
+								<ActionPanelFigureListItem>
+									{ translate( 'Personal details' ) }
+								</ActionPanelFigureListItem>
 								<ActionPanelFigureListItem>{ translate( 'Sites' ) }</ActionPanelFigureListItem>
 								<ActionPanelFigureListItem>{ translate( 'Posts' ) }</ActionPanelFigureListItem>
 								<ActionPanelFigureListItem>{ translate( 'Pages' ) }</ActionPanelFigureListItem>
 								<ActionPanelFigureListItem>{ translate( 'Media' ) }</ActionPanelFigureListItem>
-								<ActionPanelFigureListItem>
-									{ translate( 'Users & Authors' ) }
-								</ActionPanelFigureListItem>
 								<ActionPanelFigureListItem>{ translate( 'Domains' ) }</ActionPanelFigureListItem>
 							</ActionPanelFigureList>
 						</ActionPanelFigure>
@@ -90,7 +90,12 @@ class AccountSettingsClose extends Component {
 								<p>
 									{ translate(
 										"If you're unsure about what account closure means or have any other questions, " +
-											'please chat with someone from our support team before proceeding.'
+											'please {{a}}chat with someone from our support team{{/a}} before proceeding.',
+										{
+											components: {
+												a: <ActionPanelLink href="/help/contact" />,
+											},
+										}
 									) }
 								</p>
 							</div>
@@ -111,11 +116,6 @@ class AccountSettingsClose extends Component {
 								</p>
 							</div>
 						) }
-						<p>
-							<ActionPanelLink href="/help/contact">
-								{ translate( 'Contact support' ) }
-							</ActionPanelLink>
-						</p>
 					</ActionPanelBody>
 					<ActionPanelFooter>
 						{ ! hasAtomicSites && (

--- a/client/me/account-close/style.scss
+++ b/client/me/account-close/style.scss
@@ -5,3 +5,29 @@
 	line-height: 24px;
 	color: $gray-dark;
 }
+
+// Confirm dialog
+.account-close__confirm-dialog {
+	max-width: 424px;
+	padding-bottom: 16px;
+}
+
+h1.account-close__confirm-dialog-header {
+	height: auto;
+	margin-bottom: 16px;
+	font-size: 21px;
+	font-weight: 300;
+	line-height: 24px;
+	color: $gray-dark;
+}
+
+.account-close__confirm-dialog-label {
+	margin-bottom: 8px;
+	line-height: 24px;
+	color: $gray-text-min;
+	font-weight: normal;
+}
+
+.account-close__confirm-dialog-target-username {
+	color: $alert-red;
+}

--- a/client/me/account-close/style.scss
+++ b/client/me/account-close/style.scss
@@ -1,0 +1,7 @@
+.account-close__heading {
+	margin-bottom: 16px;
+	font-size: 21px;
+	font-weight: 300;
+	line-height: 24px;
+	color: $gray-dark;
+}

--- a/client/me/account/close-link.jsx
+++ b/client/me/account/close-link.jsx
@@ -9,7 +9,7 @@ import { noop } from 'lodash';
 
 import CompactCard from 'components/card/compact';
 
-class AccountSettingsClose extends React.Component {
+class AccountSettingsCloseLink extends React.Component {
 	render() {
 		const { translate } = this.props;
 		const href = '/me/account/close';
@@ -29,4 +29,4 @@ class AccountSettingsClose extends React.Component {
 	}
 }
 
-export default localize( AccountSettingsClose );
+export default localize( AccountSettingsCloseLink );

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -49,7 +49,7 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import _user from 'lib/user';
 import { canDisplayCommunityTranslator } from 'components/community-translator/utils';
 import { ENABLE_TRANSLATOR_KEY } from 'components/community-translator/constants';
-import AccountSettingsClose from './close';
+import AccountSettingsCloseLink from './close-link';
 
 const user = _user();
 const colorSchemeKey = 'calypso_preferences.colorScheme';
@@ -789,7 +789,7 @@ const Account = createReactClass( {
 					</form>
 				</Card>
 
-				{ config.isEnabled( 'me/account-close' ) && <AccountSettingsClose /> }
+				{ config.isEnabled( 'me/account-close' ) && <AccountSettingsCloseLink /> }
 			</Main>
 		);
 	},

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -34,6 +34,13 @@ const sections = [
 		secondary: true,
 	},
 	{
+		name: 'account-close',
+		paths: [ '/me/account/close' ],
+		module: 'me/account-close',
+		group: 'me',
+		secondary: true,
+	},
+	{
 		name: 'security',
 		paths: [ '/me/security' ],
 		module: 'me/security',


### PR DESCRIPTION
Adds a page explaining what account closure entails, along with a big scary button and confirmation dialogue to do the actual deletion.

UI only. Does not check for user's Atomic sites/purchases or do any actual deletion, or verify your username yet.

Todo:
- [x] scary warning dialogue to confirm deletion

### To test

Head to http://calypso.localhost:3000/me/account/close.

<img width="739" alt="screen shot 2018-05-17 at 6 18 08 pm" src="https://user-images.githubusercontent.com/17325/40159729-b35ae614-59fe-11e8-9711-f5736807f80d.png">
<img width="558" alt="screen shot 2018-05-17 at 6 18 15 pm" src="https://user-images.githubusercontent.com/17325/40159730-b3877936-59fe-11e8-8604-4ba40911c199.png">

cc @westi 