### PR TITLE
Promote ActionPanel to component and update existing usage

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -88,6 +88,7 @@
 @import 'blocks/user-mentions/style';
 @import 'components/accordion/style';
 @import 'components/action-card/style';
+@import 'components/action-panel/style';
 @import 'components/animate/style';
 @import 'components/async-load/style';
 @import 'components/back-button/style';

--- a/assets/stylesheets/sections/site-settings.scss
+++ b/assets/stylesheets/sections/site-settings.scss
@@ -9,7 +9,6 @@
 
 @import 'my-sites/site-settings/style';
 
-@import 'my-sites/site-settings/action-panel/style';
 @import 'my-sites/site-settings/amp/style';
 @import 'my-sites/site-settings/comment-display-settings/style';
 @import 'my-sites/site-settings/custom-content-types/style';

--- a/client/components/action-panel/README.md
+++ b/client/components/action-panel/README.md
@@ -1,0 +1,42 @@
+Action Panel
+============
+
+This is a larger [`Card` component](../../components/card) that has a title, description, right-aligned figure and call-to-action button.
+
+## Usage
+
+```es6
+import ActionPanel from 'components/action-panel';
+import ActionPanelTitle from 'components/action-panel/title';
+import ActionPanelBody from 'components/action-panel/body';
+import ActionPanelFigure from 'components/action-panel/figure';
+import ActionPanelFooter from 'components/action-panel/footer';
+import Button from 'components/button';
+
+const ActionPanelExample = ( { translate }) => {
+  return (
+      <ActionPanel>
+        <ActionPanelBody>
+          <ActionPanelFigure inlineBodyText={ true }>
+            <img
+              src="/calypso/images/wordpress/logo-stars.svg"
+              width="170"
+              height="143"
+              alt="WordPress logo"
+            />
+          </ActionPanelFigure>
+          <ActionPanelTitle>Action panel title</ActionPanelTitle>
+          <p>
+            This is a description of the action. It gives a bit more detail and explains what we are
+            inviting the user to do.
+          </p>
+        </ActionPanelBody>
+        <ActionPanelFooter>
+          <Button className="action-panel__support-button" href="/help/contact">
+            Call to action!
+          </Button>
+        </ActionPanelFooter>
+      </ActionPanel>
+  );
+}
+```

--- a/client/components/action-panel/body.jsx
+++ b/client/components/action-panel/body.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 const ActionPanelBody = ( { children } ) => {
-	return <div className="settings-action-panel__body">{ children }</div>;
+	return <div className="action-panel__body">{ children }</div>;
 };
 
 export default ActionPanelBody;

--- a/client/components/action-panel/docs/example.jsx
+++ b/client/components/action-panel/docs/example.jsx
@@ -1,0 +1,49 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ActionPanel from 'components/action-panel';
+import ActionPanelTitle from 'components/action-panel/title';
+import ActionPanelBody from 'components/action-panel/body';
+import ActionPanelFigure from 'components/action-panel/figure';
+import ActionPanelFooter from 'components/action-panel/footer';
+import Button from 'components/button';
+
+const ActionPanelExample = () => (
+	<div className="design-assets__group">
+		<div>
+			<ActionPanel>
+				<ActionPanelBody>
+					<ActionPanelFigure inlineBodyText={ true }>
+						<img
+							src="/calypso/images/wordpress/logo-stars.svg"
+							width="170"
+							height="143"
+							alt="WordPress logo"
+						/>
+					</ActionPanelFigure>
+					<ActionPanelTitle>Action panel title</ActionPanelTitle>
+					<p>
+						This is a description of the action. It gives a bit more detail and explains what we are
+						inviting the user to do.
+					</p>
+				</ActionPanelBody>
+				<ActionPanelFooter>
+					<Button className="action-panel__support-button" href="/help/contact">
+						Call to action!
+					</Button>
+				</ActionPanelFooter>
+			</ActionPanel>
+		</div>
+	</div>
+);
+
+ActionPanelExample.displayName = 'ActionPanel';
+
+export default ActionPanelExample;

--- a/client/components/action-panel/figure.jsx
+++ b/client/components/action-panel/figure.jsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 
 const ActionPanelFigure = ( { inlineBodyText, children } ) => {
 	const figureClasses = classNames( {
-		'settings-action-panel__figure': true,
+		'action-panel__figure': true,
 		'is-inline-body-text': inlineBodyText,
 	} );
 

--- a/client/components/action-panel/footer.jsx
+++ b/client/components/action-panel/footer.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 const ActionPanelFooter = ( { children } ) => {
-	return <div className="settings-action-panel__footer">{ children }</div>;
+	return <div className="action-panel__footer">{ children }</div>;
 };
 
 export default ActionPanelFooter;

--- a/client/components/action-panel/index.jsx
+++ b/client/components/action-panel/index.jsx
@@ -12,7 +12,7 @@ import React from 'react';
 import Card from 'components/card';
 
 const ActionPanel = ( { children } ) => {
-	return <Card className="settings-action-panel">{ children }</Card>;
+	return <Card className="action-panel">{ children }</Card>;
 };
 
 export default ActionPanel;

--- a/client/components/action-panel/style.scss
+++ b/client/components/action-panel/style.scss
@@ -1,10 +1,10 @@
 // Main
-.settings-action-panel {
+.action-panel {
 	padding-bottom: 16px;
 }
 
 // Title
-.settings-action-panel__title {
+.action-panel__title {
 	margin-bottom: 16px;
 	font-size: 21px;
 	font-weight: 300;
@@ -14,7 +14,7 @@
 }
 
 // Body
-.settings-action-panel__body {
+.action-panel__body {
 	font-size: 14px;
 	line-height: 20px;
 	color: $gray-darken-10;
@@ -25,7 +25,7 @@
 	}
 }
 
-a.settings-action-panel__body-text-link {
+a.action-panel__body-text-link {
 	color: $blue-medium;
 	text-decoration: underline;
 
@@ -35,7 +35,7 @@ a.settings-action-panel__body-text-link {
 }
 
 // Figure
-.settings-action-panel__figure {
+.action-panel__figure {
 	width: 100%;
 	margin: 24px 0;
 	text-align: center;
@@ -52,7 +52,7 @@ a.settings-action-panel__body-text-link {
 }
 
 // Footer
-.settings-action-panel__footer {
+.action-panel__footer {
 	position: relative;
 	padding-top: 17px;
 
@@ -72,12 +72,12 @@ a.settings-action-panel__body-text-link {
 	}
 }
 
-.settings-action-panel__export-button .gridicon,
-.settings-action-panel__support-button .gridicon {
+.action-panel__export-button .gridicon,
+.action-panel__support-button .gridicon {
 	margin-left: 8px;
 }
 
-.settings-action-panel__support-button {
+.action-panel__support-button {
 	&.is-external {
 		margin-right: 8px;
 	}

--- a/client/components/action-panel/title.jsx
+++ b/client/components/action-panel/title.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 const ActionPanelTitle = ( { children } ) => {
-	return <h2 className="settings-action-panel__title">{ children }</h2>;
+	return <h2 className="action-panel__title">{ children }</h2>;
 };
 
 export default ActionPanelTitle;

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -28,6 +28,7 @@ import SearchCard from 'components/search-card';
  */
 import Accordions from 'components/accordion/docs/example';
 import ActionCard from 'components/action-card/docs/example';
+import ActionPanel from 'components/action-panel/docs/example';
 import Animate from 'components/animate/docs/example';
 import BackButton from 'components/back-button/docs/example';
 import Badge from 'components/badge/docs/example';
@@ -160,6 +161,7 @@ class DesignAssets extends React.Component {
 
 				<Collection component={ component } filter={ filter }>
 					<ActionCard readmeFilePath="action-card" />
+					<ActionPanel readmeFilePath="action-panel" />
 					<Accordions
 						componentUsageStats={ componentsUsageStats.accordion }
 						readmeFilePath="accordion"

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -16,11 +16,11 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import HeaderCake from 'components/header-cake';
-import ActionPanel from 'my-sites/site-settings/action-panel';
-import ActionPanelTitle from 'my-sites/site-settings/action-panel/title';
-import ActionPanelBody from 'my-sites/site-settings/action-panel/body';
-import ActionPanelFigure from 'my-sites/site-settings/action-panel/figure';
-import ActionPanelFooter from 'my-sites/site-settings/action-panel/footer';
+import ActionPanel from 'components/action-panel';
+import ActionPanelTitle from 'components/action-panel/title';
+import ActionPanelBody from 'components/action-panel/body';
+import ActionPanelFigure from 'components/action-panel/figure';
+import ActionPanelFooter from 'components/action-panel/footer';
 import Button from 'components/button';
 import DeleteSiteWarningDialog from 'my-sites/site-settings/delete-site-warning-dialog';
 import Dialog from 'components/dialog';
@@ -235,7 +235,7 @@ class DeleteSite extends Component {
 					</ActionPanelBody>
 					<ActionPanelFooter>
 						<Button
-							className="delete-site__export-button settings-action-panel__export-button"
+							className="delete-site__export-button action-panel__export-button"
 							disabled={ ! siteId }
 							onClick={ this._checkSiteLoaded }
 							href={ exportLink }
@@ -287,7 +287,7 @@ class DeleteSite extends Component {
 								</p>
 								<p>
 									<a
-										className="delete-site__body-text-link settings-action-panel__body-text-link"
+										className="delete-site__body-text-link action-panel__body-text-link"
 										href="/help/contact"
 									>
 										{ strings.contactSupport }

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -13,11 +13,11 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import HeaderCake from 'components/header-cake';
-import ActionPanel from 'my-sites/site-settings/action-panel';
-import ActionPanelTitle from 'my-sites/site-settings/action-panel/title';
-import ActionPanelBody from 'my-sites/site-settings/action-panel/body';
-import ActionPanelFigure from 'my-sites/site-settings/action-panel/figure';
-import ActionPanelFooter from 'my-sites/site-settings/action-panel/footer';
+import ActionPanel from 'components/action-panel';
+import ActionPanelTitle from 'components/action-panel/title';
+import ActionPanelBody from 'components/action-panel/body';
+import ActionPanelFigure from 'components/action-panel/figure';
+import ActionPanelFooter from 'components/action-panel/footer';
 import Button from 'components/button';
 import { EMPTY_SITE } from 'lib/url/support';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
@@ -57,14 +57,14 @@ const StartOver = ( { translate, selectedSiteSlug } ) => {
 				</ActionPanelBody>
 				<ActionPanelFooter>
 					<Button
-						className="settings-action-panel__support-button is-external" // eslint-disable-line wpcalypso/jsx-classname-namespace
+						className="action-panel__support-button is-external" // eslint-disable-line wpcalypso/jsx-classname-namespace
 						href={ EMPTY_SITE }
 					>
 						{ translate( 'Follow the Steps' ) }
 						<Gridicon icon="external" size={ 48 } />
 					</Button>
 					<Button
-						className="settings-action-panel__support-button" // eslint-disable-line wpcalypso/jsx-classname-namespace
+						className="action-panel__support-button" // eslint-disable-line wpcalypso/jsx-classname-namespace
 						href="/help/contact"
 					>
 						{ translate( 'Contact Support' ) }

--- a/client/my-sites/site-settings/theme-setup/theme-setup-card.jsx
+++ b/client/my-sites/site-settings/theme-setup/theme-setup-card.jsx
@@ -10,11 +10,11 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import ActionPanel from 'my-sites/site-settings/action-panel';
-import ActionPanelTitle from 'my-sites/site-settings/action-panel/title';
-import ActionPanelBody from 'my-sites/site-settings/action-panel/body';
-import ActionPanelFooter from 'my-sites/site-settings/action-panel/footer';
-import ActionPanelFigure from 'my-sites/site-settings/action-panel/figure';
+import ActionPanel from 'components/action-panel';
+import ActionPanelTitle from 'components/action-panel/title';
+import ActionPanelBody from 'components/action-panel/body';
+import ActionPanelFooter from 'components/action-panel/footer';
+import ActionPanelFigure from 'components/action-panel/figure';
 import Notice from 'components/notice';
 import Button from 'components/button';
 import ActiveThemeScreenshot from './active-theme-screenshot';

--- a/client/my-sites/site-settings/theme-setup/theme-setup-placeholder.jsx
+++ b/client/my-sites/site-settings/theme-setup/theme-setup-placeholder.jsx
@@ -11,10 +11,11 @@ import React from 'react';
  */
 
 const ThemeSetupPlaceholder = () => {
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<div className="card settings-action-panel">
-			<div className="settings-action-panel__body">
-				<h2 className="settings-action-panel__title">
+		<div className="card action-panel">
+			<div className="action-panel__body">
+				<h2 className="action-panel__title">
 					<span className="is-placeholder">Theme Setup</span>
 				</h2>
 				<div className="notice is-placeholder">
@@ -30,13 +31,14 @@ const ThemeSetupPlaceholder = () => {
 					to look like the demo, so Theme Setup adds those for you. Please customize it!
 				</p>
 			</div>
-			<div className="settings-action-panel__footer">
+			<div className="action-panel__footer">
 				<button className="button theme-setup__button is-placeholder">
 					Set Up And Keep Content
 				</button>
 			</div>
 		</div>
 	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };
 
 export default ThemeSetupPlaceholder;


### PR DESCRIPTION
My Sites currently uses a component called `ActionPanel`, which produces a card containing a title, body, right-aligned figure, and call to action:

<img width="752" alt="screen shot 2018-05-15 at 5 57 20 pm" src="https://user-images.githubusercontent.com/17325/40039217-91ef6c70-5869-11e8-9c39-ef7eb9e43fa4.png">

<img width="748" alt="screen shot 2018-05-15 at 6 00 56 pm" src="https://user-images.githubusercontent.com/17325/40039296-f70345b4-5869-11e8-8e85-e24506d68d4a.png">

I'd quite like to use this component in Me > Account > Close (in #24859) to keep that consistent with the site deletion process, but the component is currently in `my-sites/site-settings` and the styles are in the My Sites section  (so aren't loaded for Me > Account).

This PR moves `ActionPanel` out to components, so it can be used across Calypso.

To do:
- [x] add README
- [x] add example
- [x] test existing usage

### To test

Visit http://calypso.localhost:3000/devdocs/design/action-panel.