### PR TITLE
Purchases: Add tracking component and tests

### DIFF
--- a/client/me/purchases/track-purchase-page-view/README.md
+++ b/client/me/purchases/track-purchase-page-view/README.md
@@ -1,0 +1,15 @@
+# TrackPurchasePageView
+
+This component fire a single tracks event with the provided `eventName` prop.
+
+The provided `purchaseId` will be used to retrieve a purchase from state. Its product slug will be used for the event property `product_slug`.
+
+## Props
+
+### `eventName` (string)
+
+The event name used to track the purchase page view.
+
+### `purchaseId` (number)
+
+A purchase ID that will be used to look up a purchase in state and retrieve its product slug for tracking.

--- a/client/me/purchases/track-purchase-page-view/index.js
+++ b/client/me/purchases/track-purchase-page-view/index.js
@@ -1,0 +1,63 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal Dependencies
+ */
+import { getByPurchaseId } from 'state/purchases/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
+
+export class TrackPurchasePageView extends Component {
+	static propTypes = {
+		purchaseId: PropTypes.number.isRequired,
+		productSlug: PropTypes.string,
+		recordTracksEvent: PropTypes.func.isRequired,
+		eventName: PropTypes.string.isRequired,
+	};
+
+	hasTracked = false;
+
+	trackOnce() {
+		if ( ! this.hasTracked && ( this.props.productSlug && this.props.eventName ) ) {
+			this.hasTracked = true;
+			this.props.recordTracksEvent( this.props.eventName, {
+				product_slug: this.props.productSlug,
+			} );
+		}
+	}
+
+	componentDidMount() {
+		this.trackOnce();
+	}
+
+	componentDidUpdate( prevProps ) {
+		if (
+			this.props.eventName !== prevProps.eventName ||
+			this.props.productSlug !== prevProps.productSlug
+		) {
+			this.hasTracked = false;
+		}
+
+		this.trackOnce();
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	( state, { purchaseId } ) => {
+		const purchase = getByPurchaseId( state, purchaseId );
+		return {
+			productSlug: purchase ? purchase.productSlug : null,
+		};
+	},
+	{ recordTracksEvent }
+)( TrackPurchasePageView );

--- a/client/me/purchases/track-purchase-page-view/index.js
+++ b/client/me/purchases/track-purchase-page-view/index.js
@@ -21,11 +21,8 @@ export class TrackPurchasePageView extends Component {
 		eventName: PropTypes.string.isRequired,
 	};
 
-	hasTracked = false;
-
-	trackOnce() {
-		if ( ! this.hasTracked && ( this.props.productSlug && this.props.eventName ) ) {
-			this.hasTracked = true;
+	track() {
+		if ( this.props.productSlug && this.props.eventName ) {
 			this.props.recordTracksEvent( this.props.eventName, {
 				product_slug: this.props.productSlug,
 			} );
@@ -33,7 +30,7 @@ export class TrackPurchasePageView extends Component {
 	}
 
 	componentDidMount() {
-		this.trackOnce();
+		this.track();
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -41,10 +38,8 @@ export class TrackPurchasePageView extends Component {
 			this.props.eventName !== prevProps.eventName ||
 			this.props.productSlug !== prevProps.productSlug
 		) {
-			this.hasTracked = false;
+			this.track();
 		}
-
-		this.trackOnce();
 	}
 
 	render() {

--- a/client/me/purchases/track-purchase-page-view/test/index.js
+++ b/client/me/purchases/track-purchase-page-view/test/index.js
@@ -1,0 +1,88 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { TrackPurchasePageView } from '..';
+
+const baseProps = deepFreeze( {
+	eventName: 'calypso_testtracking_purchase_view',
+	productSlug: 'my-fancy-product',
+	recordTracksEvent: jest.fn(),
+
+	// Not consumed by component, but required for connect to find slug
+	purchaseId: 12345,
+} );
+
+beforeEach( jest.clearAllMocks );
+
+describe( 'TrackPurchasePageView', () => {
+	test( 'should render nothing', () => {
+		const wrapper = shallow( <TrackPurchasePageView { ...baseProps } /> );
+		expect( wrapper.type() ).toBeNull();
+	} );
+
+	test( 'should track on mount if data is loaded', () => {
+		shallow( <TrackPurchasePageView { ...baseProps } /> );
+		expect( baseProps.recordTracksEvent ).toHaveBeenCalledTimes( 1 );
+		expect( baseProps.recordTracksEvent ).toHaveBeenCalledWith( baseProps.eventName, {
+			product_slug: baseProps.productSlug,
+		} );
+	} );
+
+	test( 'should not track if productSlug is absent (data not loaded)', () => {
+		shallow( <TrackPurchasePageView { ...baseProps } productSlug={ null } /> );
+		expect( baseProps.recordTracksEvent ).toHaveBeenCalledTimes( 0 );
+	} );
+
+	test( 'should track when productSlug is provided (data loads)', () => {
+		const wrapper = shallow( <TrackPurchasePageView { ...baseProps } productSlug={ null } /> );
+		expect( baseProps.recordTracksEvent ).toHaveBeenCalledTimes( 0 );
+
+		wrapper.setProps( { productSlug: baseProps.productSlug } );
+		expect( baseProps.recordTracksEvent ).toHaveBeenCalledTimes( 1 );
+		expect( baseProps.recordTracksEvent ).toHaveBeenCalledWith( baseProps.eventName, {
+			product_slug: baseProps.productSlug,
+		} );
+	} );
+
+	test( 'should only track once if relevant props are unchanged', () => {
+		const wrapper = shallow( <TrackPurchasePageView { ...baseProps } /> );
+		wrapper.update();
+		wrapper.update();
+		wrapper.update();
+		expect( baseProps.recordTracksEvent ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'should track when relevant props update', () => {
+		const wrapper = shallow( <TrackPurchasePageView { ...baseProps } /> );
+
+		expect( baseProps.recordTracksEvent ).toHaveBeenCalledTimes( 1 );
+		expect( baseProps.recordTracksEvent ).toHaveBeenCalledWith( baseProps.eventName, {
+			product_slug: baseProps.productSlug,
+		} );
+
+		const productSlug = 'new-product-slug';
+
+		wrapper.setProps( { productSlug } );
+		expect( baseProps.recordTracksEvent ).toHaveBeenCalledTimes( 2 );
+		expect( baseProps.recordTracksEvent ).toHaveBeenLastCalledWith( baseProps.eventName, {
+			product_slug: productSlug,
+		} );
+
+		const eventName = 'new-tracking-slug';
+
+		wrapper.setProps( { eventName } );
+		expect( baseProps.recordTracksEvent ).toHaveBeenCalledTimes( 3 );
+		expect( baseProps.recordTracksEvent ).toHaveBeenLastCalledWith( eventName, {
+			product_slug: productSlug,
+		} );
+	} );
+} );


### PR DESCRIPTION
Add a component responsible for tracks analytics. It should serve as a replacement for the `recordPageView` util:
https://github.com/Automattic/wp-calypso/blob/dab66765c342f27002cf8be02d53221643170e07/client/me/purchases/utils.js#L26-L50

`recordPageView` is fragile and obscure. It receives `props` and optionally `nextProps`, and will attempt to fire a tracks event depending on the contents of these. This means that it must be used in a component with specifically names connected props.

Replacing this fragile function with a simple component that can be used as follows should simplify behavior and be less error-prone.

## Testing
1. Tests pass?
1. This component is unused in this PR but has been put into use in #24862 and its behavior can be verified there.