### PR TITLE
Simple Payments: Fix product image picker icons positioning

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -100,9 +100,10 @@
 	}
 
 	.dialog__product-image-container {
-		position: relative;
+		height: 200px;
 		margin-bottom: 20px;
 		margin-right: 25px;
+		position: relative;
 		width: 200px;
 	}
 

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -103,6 +103,7 @@
 		position: relative;
 		margin-bottom: 20px;
 		margin-right: 25px;
+		width: 200px;
 	}
 
 	.dialog__product-image-placeholder,


### PR DESCRIPTION
On small screens, the product image picker icons are positioned incorrectly because their container has no fixed width value set.
By adding a width to the container, the icons, absolutely positioned, get back into the correct position.

| Before | After |
| --- | --- |
| <img width="604" alt="screen shot 2018-05-15 at 10 35 10" src="https://user-images.githubusercontent.com/2070010/40049157-dbd29508-582b-11e8-8bff-f6f09d977e17.png"> | <img width="638" alt="screen shot 2018-05-15 at 10 35 26" src="https://user-images.githubusercontent.com/2070010/40049168-e13b71ea-582b-11e8-9099-414e0d6e5d56.png"> |

## Testing instructions

- Open the Editor, click on "Add", and then on "Payment Button".
- Edit a button with an image set (or create a new one and set an image).
- Narrow the browser window until the payment button form is in a single column.
- Make sure the payment button image icons are in the correct position.