### PR TITLE
Extract the link to the Packaging Manager to its own file

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/lib/utils/get-packaging-manager-link.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/utils/get-packaging-manager-link.js
@@ -1,0 +1,15 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getLink } from 'woocommerce/lib/nav-utils';
+
+/**
+ * Given the site, returns url of the Packaging Manager
+ * @param {Object} site - site
+ * @returns {String} - url of the packaging manager page
+ */
+export default site => {
+	return getLink( '/store/settings/shipping/:site/', site );
+};

--- a/client/extensions/woocommerce/woocommerce-services/views/service-settings/settings-form/settings-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/service-settings/settings-form/settings-item.js
@@ -14,9 +14,9 @@ import NumberField from 'woocommerce/woocommerce-services/components/number-fiel
 import Text from 'woocommerce/woocommerce-services/components/text';
 import TextField from 'woocommerce/woocommerce-services/components/text-field';
 import RadioButtons from 'woocommerce/woocommerce-services/components/radio-buttons';
+import getPackagingManagerLink from 'woocommerce/woocommerce-services/lib/utils/get-packaging-manager-link';
 import ShippingServiceGroups from '../shipping-services';
 import FormLegend from 'components/forms/form-legend';
-import { getLink } from 'woocommerce/lib/nav-utils';
 
 const SettingsItem = ( {
 	formData,
@@ -70,7 +70,7 @@ const SettingsItem = ( {
 					<FormLegend>{ translate( 'Saved Packages' ) }</FormLegend>
 					{ translate( 'Add and edit saved packages using the {{a}}Packaging Manager{{/a}}.', {
 						components: {
-							a: <a href={ getLink( '/store/settings/shipping/:site/', site ) } />,
+							a: <a href={ getPackagingManagerLink( site ) } />,
 						},
 					} ) }
 				</div>


### PR DESCRIPTION
This is a quick one. Extract the link to the packaging manager to its own file so it can be stubbed in `woocommerce-services` for reusing it in WP-Admin.