### PR TITLE
Domains: Remove the country code stickiness from the phone input for domains

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -376,6 +376,7 @@ export class ContactDetailsFormFields extends Component {
 					onChange: this.handlePhoneChange,
 					countriesList,
 					countryCode: this.state.phoneCountryCode,
+					enableStickyCountry: false,
 				} ) }
 
 				{ needsFax &&

--- a/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
+++ b/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
@@ -96,6 +96,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
         }
         countryCode="US"
         disabled={false}
+        enableStickyCountry={false}
         errorMessage=""
         eventFormName="Domain contact details form"
         isError={false}

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -32,6 +32,7 @@ class PhoneInput extends React.PureComponent {
 
 	static defaultProps = {
 		setComponentReference: noop,
+		enableStickyCountry: true,
 	};
 
 	constructor( props ) {
@@ -228,7 +229,7 @@ class PhoneInput extends React.PureComponent {
 			countryCode: newCountryCode,
 			value: this.format( inputValue, newCountryCode ),
 		} );
-		this.setState( { freezeSelection: true } );
+		this.setState( { freezeSelection: this.props.enableStickyCountry } );
 	}
 
 	setNumberInputRef = c => ( this.numberInput = c );


### PR DESCRIPTION
We sometimes get a phone number with mixed up country codes in the domain registration requests. So for example instead of `+44xxx` we get `+144xxx`. We're not 100% sure what the issue is, but one thing that stands out is the "stickiness" of the country if it's choosen from the countries dropdown. So once you choose a country from the dropdown it won't change even if you enter the `+` sign in the phone input. So, I think if we disable the stickiness for the phone input that would probably improve how we handle the phone numbers.

Test instructions:

Go in the domain contact details form and try entering different country codes in the phone input. Choose different country from the dropdown and then enter different phone with country code in the input field. The country should always match the country code of whatever was entered in the phone input.
