### PR TITLE
[Media Library] set caption on transient media

### DIFF
--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -46,6 +46,7 @@ const EXPECTED_FILE_OBJECT = {
 	ID: UNIQUEID,
 	file: DUMMY_FILENAME,
 	title: 'test.jpg',
+	caption: '',
 	extension: 'jpg',
 	mime_type: 'image/jpeg',
 	guid: DUMMY_FILENAME,

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -547,6 +547,7 @@ export function createTransientMedia( file ) {
 		Object.assign( transientMedia, {
 			file: file.URL,
 			title: file.name,
+			caption: file.caption || '',
 			extension: file.extension,
 			mime_type: file.mime_type,
 			guid: file.URL,


### PR DESCRIPTION
if coming from an external media API where captions are supplied, they get set and saved, but not on the transient media. This PR sets them so if the user edits the transient media, the caption is there. Without this, they have to refresh the media library to pick up the caption from the uploaded media.