### PR TITLE
Hide GMB pages for other users

### DIFF
--- a/client/state/selectors/is-google-my-business-location-connected.js
+++ b/client/state/selectors/is-google-my-business-location-connected.js
@@ -5,16 +5,28 @@
  */
 import { get, find } from 'lodash';
 
-const getGoogleMyBusinessLocationId = ( state, siteId ) => {
+import { getKeyringConnectionsByName } from 'state/sharing/keyring/selectors';
+
+export default function isGoogleMyBusinessLocationConnected( state, siteId ) {
 	const siteKeyrings = get( state, `siteKeyrings.items.${ siteId }`, [] );
 	const googleMyBusinessSiteKeyring = find(
 		siteKeyrings,
 		keyring => keyring.service === 'google_my_business'
 	);
 
-	return googleMyBusinessSiteKeyring ? googleMyBusinessSiteKeyring.external_user_id : undefined;
-};
+	if ( ! googleMyBusinessSiteKeyring ) {
+		return false;
+	}
 
-export default function isGoogleMyBusinessLocationConnected( state, siteId ) {
-	return !! getGoogleMyBusinessLocationId( state, siteId );
+	const keyringConnections = getKeyringConnectionsByName( state, 'google_my_business' ).filter(
+		keyringConnection => {
+			return keyringConnection.ID === googleMyBusinessSiteKeyring.keyring_id;
+		}
+	);
+
+	if ( keyringConnections.length === 0 ) {
+		return false;
+	}
+
+	return !! googleMyBusinessSiteKeyring.external_user_id;
 }

--- a/client/state/selectors/is-google-my-business-stats-nudge-visible.js
+++ b/client/state/selectors/is-google-my-business-stats-nudge-visible.js
@@ -1,11 +1,15 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import { find, get } from 'lodash';
+
+/**
  * Internal dependencies
  */
-import isGoogleMyBusinessLocationConnected from 'state/selectors/is-google-my-business-location-connected';
 import isSiteGoogleMyBusinessEligible from 'state/selectors/is-site-google-my-business-eligible';
-import { isRequestingSiteSettings, getSiteSettings } from 'state/site-settings/selectors';
+import { isRequestingSiteKeyrings, getSiteKeyrings } from 'state/site-keyrings/selectors';
 
 /**
  * Returns true if the Google My Business (GMB) nudge should be visible in stats
@@ -21,11 +25,18 @@ export default function isGoogleMyBusinessStatsNudgeVisible( state, siteId ) {
 	// We don't want to show the nudge, and then hide it when it's obvious
 	// the site is actually already connected, therefore we must wait for the site
 	// settings to be fetched so we could verify site does not have connection connected
-	if ( getSiteSettings( state, siteId ) === null || isRequestingSiteSettings( state, siteId ) ) {
+	if ( getSiteKeyrings( state, siteId ) === null || isRequestingSiteKeyrings( state, siteId ) ) {
 		return false;
 	}
 
-	if ( isGoogleMyBusinessLocationConnected( state, siteId ) ) {
+	// Don't show the nudge if the site is already connected (can be from another admin)
+	const siteKeyrings = get( state, `siteKeyrings.items.${ siteId }`, [] );
+	const googleMyBusinessSiteKeyring = find(
+		siteKeyrings,
+		keyring => keyring.service === 'google_my_business'
+	);
+
+	if ( googleMyBusinessSiteKeyring ) {
 		return false;
 	}
 

--- a/client/state/selectors/test/is-google-my-business-location-connected.js
+++ b/client/state/selectors/test/is-google-my-business-location-connected.js
@@ -31,6 +31,17 @@ describe( 'isGoogleMyBusinessLocationConnected()', () => {
 					],
 				},
 			},
+			sharing: {
+				keyring: {
+					items: {
+						'1234': {
+							ID: '1234',
+							external_ID: '65789',
+							service: 'google_my_business',
+						},
+					},
+				},
+			},
 		};
 
 		expect( isGoogleMyBusinessLocationConnected( state, 1234 ) ).toBe( true );

--- a/client/state/site-keyrings/reducer.js
+++ b/client/state/site-keyrings/reducer.js
@@ -8,7 +8,7 @@ import { remove } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { siteKeyrings as siteKeyringsSchema } from './schema';
 import {
 	SITE_KEYRINGS_REQUEST,
@@ -63,20 +63,6 @@ export const saveRequests = createReducer(
 	}
 );
 
-const siteKeyrings = createReducer(
-	[],
-	{
-		[ SITE_KEYRINGS_REQUEST_SUCCESS ]: ( _, { keyrings } ) => keyrings,
-		[ SITE_KEYRINGS_SAVE_SUCCESS ]: ( state, { keyring } ) => state.concat( [ keyring ] ),
-		[ SITE_KEYRINGS_DELETE_SUCCESS ]: ( state, { keyringId, externalUserId } ) =>
-			remove(
-				state,
-				keyring => keyring.keyring_id === keyringId && keyring.external_user_id === externalUserId
-			),
-	},
-	siteKeyringsSchema
-);
-
 /**
  * Returns the updated items state after an action has been dispatched. The
  * state maps site ID to the site keyrings object.
@@ -85,7 +71,27 @@ const siteKeyrings = createReducer(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = keyedReducer( 'siteId', siteKeyrings );
+const items = createReducer(
+	{},
+	{
+		[ SITE_KEYRINGS_REQUEST_SUCCESS ]: ( state, { siteId, keyrings } ) => ( {
+			...state,
+			[ siteId ]: keyrings,
+		} ),
+		[ SITE_KEYRINGS_SAVE_SUCCESS ]: ( state, { siteId, keyring } ) => ( {
+			...state,
+			[ siteId ]: state[ siteId ].concat( [ keyring ] ),
+		} ),
+		[ SITE_KEYRINGS_DELETE_SUCCESS ]: ( state, { siteId, keyringId, externalUserId } ) => ( {
+			...state,
+			[ siteId ]: remove(
+				state,
+				keyring => keyring.keyring_id === keyringId && keyring.external_user_id === externalUserId
+			),
+		} ),
+	},
+	siteKeyringsSchema
+);
 
 export default combineReducers( {
 	items,


### PR DESCRIPTION
This PR improves the Google My Business experience by hiding the pages for users that do not have access to all the features.

### Testing Instructions
- Go to `/stats/day/:site` for a site which is eligible to GMB
- Connect to GMB
- Use another admin account which has access to the same site
- Go to `/stats/day/:site` and check that the nudge is not visible and the tab "Google My Business" is not visible either
- Try to navigate directly to any GMB page via the url, you should be redirected to `/stats/:site`

### Reviews
- [ ] Product
- [ ] Code