### PR TITLE
Fix path to component documentation

### DIFF
--- a/client/devdocs/design/README.md
+++ b/client/devdocs/design/README.md
@@ -3,4 +3,4 @@ UI Components
 
 These UI Components are simple React components used for composing the UI of Calypso.
 
-Read the [component documentation](../../docs/components.md) for more in-depth information.
+Read the [component documentation](../../../docs/components.md) for more in-depth information.


### PR DESCRIPTION
Fix a broken link in the README.

View the [README](https://github.com/Automattic/wp-calypso/blob/2960aca2eec43803233f04f8191bf274a5bf86fa/client/devdocs/design/README.md) and test the link.