### PR TITLE
Show notice ontop of gmb charts when no data or no activity

### DIFF
--- a/client/my-sites/google-my-business/stats/style.scss
+++ b/client/my-sites/google-my-business/stats/style.scss
@@ -61,3 +61,7 @@
 		width: 100%;
 	}
 }
+
+.gmb-stats__metric-chart {
+	position: relative;
+}


### PR DESCRIPTION
This PR updates the Google My Business Stats page to show a "No activity this period" notice when the chart is empty.

![image](https://user-images.githubusercontent.com/230230/40060400-c64cae82-5856-11e8-9aa6-0a78e41d0fd3.png)

### Testing Instructions
- Go to the GMB Stats page for a location that has no activity for some period, notice the notice when no activity, change the period to see it disappear

### Reviews
- [ ] Code
- [ ] Product