### PR TITLE
Checklist: Switch to redux current user from lib/user

### DIFF
--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -20,6 +20,7 @@ import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isSiteAutomatedTransfer, getSiteChecklist } from 'state/selectors';
 import { isJetpackSite, getSiteSlug } from 'state/sites/selectors';
+import { getCurrentUser } from 'state/current-user/selectors';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 import { launchTask, onboardingTasks } from '../onboardingChecklist';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -27,10 +28,7 @@ import { createNotice } from 'state/notices/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import ChecklistShowShare from './share';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
-import userFactory from 'lib/user';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-
-const user = userFactory();
 
 class ChecklistShow extends PureComponent {
 	onAction = id => {
@@ -72,7 +70,7 @@ class ChecklistShow extends PureComponent {
 					'We’ve prepared a list of things that will help you get there quickly.',
 				{
 					args: {
-						email: user.get().email,
+						email: this.props.user.email,
 					},
 				}
 			);
@@ -187,6 +185,7 @@ const mapStateToProps = state => {
 		siteId,
 		siteSlug,
 		tasks,
+		user: getCurrentUser( state ),
 	};
 };
 


### PR DESCRIPTION
Part of #24004

Switches off of lib/user to the redux current user to grab the user's email for the notice.

