### PR TITLE
EditPostStatus: Get the post data from Redux and remove unneeded props

### DIFF
--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -33,12 +33,8 @@ export class EditPostStatus extends Component {
 		onSave: PropTypes.func,
 		post: PropTypes.object,
 		savedPost: PropTypes.object,
-		site: PropTypes.object,
 		translate: PropTypes.func,
-		type: PropTypes.string,
 		onPrivatePublish: PropTypes.func,
-		status: PropTypes.string,
-		isPostPrivate: PropTypes.bool,
 		confirmationSidebarStatus: PropTypes.string,
 	};
 
@@ -77,11 +73,14 @@ export class EditPostStatus extends Component {
 	};
 
 	render() {
-		let isSticky, isPublished, isPending, isScheduled, isPasswordProtected;
-		const { translate, isPostPrivate, canUserPublishPosts } = this.props;
+		let showSticky, isSticky, isPublished, isPending, isScheduled;
+		const { translate, canUserPublishPosts } = this.props;
 
 		if ( this.props.post ) {
-			isPasswordProtected = postUtils.getVisibility( this.props.post ) === 'password';
+			const isPrivate = postUtils.isPrivate( this.props.post );
+			const isPasswordProtected = postUtils.getVisibility( this.props.post ) === 'password';
+
+			showSticky = this.props.post.type === 'post' && ! isPrivate && ! isPasswordProtected;
 			isSticky = this.props.post.sticky;
 			isPending = postUtils.isPending( this.props.post );
 			isPublished = postUtils.isPublished( this.props.savedPost );
@@ -92,27 +91,21 @@ export class EditPostStatus extends Component {
 			<div className="edit-post-status">
 				{ this.renderPostScheduling() }
 				{ this.renderPostVisibility() }
-				{ this.props.type === 'post' &&
-					! isPostPrivate &&
-					! isPasswordProtected && (
-						<label className="edit-post-status__sticky">
-							<span className="edit-post-status__label-text">
-								{ translate( 'Stick to the front page' ) }
-								<InfoPopover
-									position="top right"
-									gaEventCategory="Editor"
-									popoverName="Sticky Post"
-								>
-									{ translate( 'Sticky posts will appear at the top of the posts listing.' ) }
-								</InfoPopover>
-							</span>
-							<FormToggle
-								checked={ isSticky }
-								onChange={ this.toggleStickyStatus }
-								aria-label={ translate( 'Stick post to the front page' ) }
-							/>
-						</label>
-					) }
+				{ showSticky && (
+					<label className="edit-post-status__sticky">
+						<span className="edit-post-status__label-text">
+							{ translate( 'Stick to the front page' ) }
+							<InfoPopover position="top right" gaEventCategory="Editor" popoverName="Sticky Post">
+								{ translate( 'Sticky posts will appear at the top of the posts listing.' ) }
+							</InfoPopover>
+						</span>
+						<FormToggle
+							checked={ isSticky }
+							onChange={ this.toggleStickyStatus }
+							aria-label={ translate( 'Stick post to the front page' ) }
+						/>
+					</label>
+				) }
 				{ ! isPublished &&
 					! isScheduled &&
 					canUserPublishPosts && (
@@ -158,13 +151,13 @@ export class EditPostStatus extends Component {
 			return;
 		}
 
-		const { password, type } = this.props.post || {};
+		const { password, status, type } = this.props.post;
 		const savedStatus = this.props.savedPost ? this.props.savedPost.status : null;
 		const savedPassword = this.props.savedPost ? this.props.savedPost.password : null;
 		const props = {
-			status: this.props.status,
 			onPrivatePublish: this.props.onPrivatePublish,
 			type,
+			status,
 			password,
 			savedStatus,
 			savedPassword,

--- a/client/post-editor/edit-post-status/test/index.jsx
+++ b/client/post-editor/edit-post-status/test/index.jsx
@@ -21,7 +21,7 @@ jest.mock( 'lib/user', () => () => {} );
 describe( 'EditPostStatus', () => {
 	test( 'should hide sticky option for password protected posts', () => {
 		const wrapper = shallow(
-			<EditPostStatus post={ { password: 'password' } } isPostPrivate={ false } type={ 'post' } />
+			<EditPostStatus post={ { type: 'post', status: 'draft', password: 'password' } } />
 		);
 
 		expect( wrapper.find( '.edit-post-status__sticky' ) ).to.have.lengthOf( 0 );
@@ -29,7 +29,7 @@ describe( 'EditPostStatus', () => {
 
 	test( 'should hide sticky option for private posts', () => {
 		const wrapper = shallow(
-			<EditPostStatus post={ { password: '' } } isPostPrivate={ true } type={ 'post' } />
+			<EditPostStatus post={ { type: 'post', status: 'private', password: '' } } />
 		);
 
 		expect( wrapper.find( '.edit-post-status__sticky' ) ).to.have.lengthOf( 0 );
@@ -38,9 +38,7 @@ describe( 'EditPostStatus', () => {
 	test( 'should show sticky option for published posts', () => {
 		const wrapper = shallow(
 			<EditPostStatus
-				post={ { password: '' } }
-				type={ 'post' }
-				isPostPrivate={ false }
+				post={ { type: 'post', status: 'published', password: '' } }
 				translate={ noop }
 			/>
 		);

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { flow, get, overSome } from 'lodash';
+import { flow, overSome } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -82,7 +82,6 @@ class EditorDrawer extends Component {
 		type: PropTypes.string,
 		setPostDate: PropTypes.func,
 		onSave: PropTypes.func,
-		isPostPrivate: PropTypes.bool,
 		confirmationSidebarStatus: PropTypes.string,
 	};
 
@@ -282,20 +281,15 @@ class EditorDrawer extends Component {
 	}
 
 	renderStatus() {
-		const postStatus = get( this.props.post, 'status', null );
-		const { translate, type } = this.props;
+		const { translate } = this.props;
 
 		return (
 			<Accordion title={ translate( 'Status' ) } e2eTitle="status">
 				<EditPostStatus
 					savedPost={ this.props.savedPost }
 					onSave={ this.props.onSave }
-					onTrashingPost={ this.props.onTrashingPost }
 					onPrivatePublish={ this.props.onPrivatePublish }
 					setPostDate={ this.props.setPostDate }
-					status={ postStatus }
-					type={ type }
-					isPostPrivate={ this.props.isPostPrivate }
 					confirmationSidebarStatus={ this.props.confirmationSidebarStatus }
 				/>
 			</Accordion>

--- a/client/post-editor/editor-sidebar/index.jsx
+++ b/client/post-editor/editor-sidebar/index.jsx
@@ -24,7 +24,6 @@ export class EditorSidebar extends Component {
 		site: PropTypes.object,
 		type: PropTypes.string,
 		setPostDate: PropTypes.func,
-		isPostPrivate: PropTypes.bool,
 		confirmationSidebarStatus: PropTypes.string,
 	};
 
@@ -37,7 +36,6 @@ export class EditorSidebar extends Component {
 			savedPost,
 			site,
 			setPostDate,
-			isPostPrivate,
 			confirmationSidebarStatus,
 		} = this.props;
 
@@ -51,7 +49,6 @@ export class EditorSidebar extends Component {
 					setPostDate={ setPostDate }
 					onPrivatePublish={ onPublish }
 					onSave={ onSave }
-					isPostPrivate={ isPostPrivate }
 					confirmationSidebarStatus={ confirmationSidebarStatus }
 				/>
 				<SidebarFooter>

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -390,7 +390,6 @@ export class PostEditor extends React.Component {
 						site={ site }
 						setPostDate={ this.setPostDate }
 						onSave={ this.onSave }
-						isPostPrivate={ utils.isPrivate( this.state.post ) }
 						confirmationSidebarStatus={ this.state.confirmationSidebar }
 					/>
 					{ this.props.isSitePreviewable ? (


### PR DESCRIPTION
The `EditPostStatus` can get all the post attributes it needs from the Redux-supplied `post` prop and doesn't need extra props like `type`, `status` or `isPostPrivate`.

Since #24698 was merged, the post status is stored in Redux and always has the correct value. There's no need to retrieve the `status` from the Flux store.

The same applies to the `isPostPrivate` prop, whose value depends on the status. Instead of an extra prop, determine the `isPrivateOrPasswordProtected` value from the `post` object. Exactly the same value is used also by `EditorActionBar` for exactly the same purpose: to determine if the post supports the `sticky` attribute and if the toggling UI should be displayed. For `EditorActionBar`, similar Redux refactor was done in #24760.

There are also two props being removed that `EditPostStatus` doesn't use: `site` and `onTrashingPost`.

This PR touches some JSX that has a preexisting a11y eslint warning about labels not being associated with their controls. That's for another PR to fix. Don't be surprised if `eslines` reports this PR as a failure.

**How to test:**
Verify that editing the post status still works as expected:
<img width="274" alt="screen shot 2018-05-15 at 21 19 37" src="https://user-images.githubusercontent.com/664258/40078736-ca8335f0-5885-11e8-8e78-9d6a2b77478d.png">

Set the post to Public, Private or Password Protected, back and forth. Is the "Stick to front page" toggle displayed only for public posts? Not displayed for any page or anything non-public?