### PR TITLE
Domain: Fix input clear filter reset bug

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -506,18 +506,13 @@ class RegisterDomainStep extends React.Component {
 			tlds.delete( newTld );
 		}
 
-		this.setState(
-			{
-				filters: {
-					...this.state.filters,
-					tlds: [ ...tlds ],
-				},
+		this.repeatSearch( {
+			filters: {
+				...this.state.filters,
+				tlds: [ ...tlds ],
 			},
-			() => {
-				this.save();
-				this.repeatSearch( { pageNumber: 1 } );
-			}
-		);
+			pageNumber: 1,
+		} );
 	};
 
 	onFiltersChange = ( newFilters, { shouldSubmit = false } = {} ) => {
@@ -533,19 +528,17 @@ class RegisterDomainStep extends React.Component {
 
 	onFiltersReset = ( ...keysToReset ) => {
 		this.props.recordFiltersReset( this.state.filters, keysToReset, this.props.analyticsSection );
-		this.setState(
-			{
-				filters: {
-					...this.state.filters,
-					...( Array.isArray( keysToReset ) && keysToReset.length > 0
-						? pick( this.getInitialFiltersState(), keysToReset )
-						: this.getInitialFiltersState() ),
-				},
-			},
-			() => {
-				this.repeatSearch( { pageNumber: 1 } );
-			}
-		);
+		const filters = {
+			...this.state.filters,
+			...( Array.isArray( keysToReset ) && keysToReset.length > 0
+				? pick( this.getInitialFiltersState(), keysToReset )
+				: this.getInitialFiltersState() ),
+		};
+		this.repeatSearch( {
+			filters,
+			lastFilters: filters,
+			pageNumber: 1,
+		} );
 	};
 
 	onFiltersSubmit = () => {
@@ -651,7 +644,6 @@ class RegisterDomainStep extends React.Component {
 			vertical: this.props.surveyVertical,
 			...this.getActiveFiltersForAPI(),
 		};
-		this.setState( { lastFilters: this.state.filters } );
 
 		debug( 'Fetching domains suggestions with the following query', query );
 
@@ -821,7 +813,11 @@ class RegisterDomainStep extends React.Component {
 		const domain = getFixedDomainSearch( searchQuery );
 
 		this.setState(
-			{ lastQuery: searchQuery, lastSurveyVertical: this.props.surveyVertical },
+			{
+				lastQuery: searchQuery,
+				lastSurveyVertical: this.props.surveyVertical,
+				lastFilters: this.state.filters,
+			},
 			this.save
 		);
 


### PR DESCRIPTION
Due to how we persist `filters` and `lastFilters` component states, it was possible for the interface to persist filters despite pressing a filter `Reset` button.

This change fixes this behavior by modifying how we persist those two state values.

# Testing Instructions
1. Spin up this branch locally.
2. Enter any query at `/start/domains`
3. Apply an exact match filter.
4. Click x in the query input.
5. Verify that the exact match filter is still enabled.
6. Open the drop-down filter and click Reset.
7. Verify that the exact match filter has been disabled and the filter icon is no longer blue.