### PR TITLE
Domains: Send user’s query to available TLD API

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -290,8 +290,6 @@ class RegisterDomainStep extends React.Component {
 			this.setState( state );
 		}
 
-		this.getAvailableTlds();
-
 		this._isMounted = false;
 	}
 
@@ -302,7 +300,10 @@ class RegisterDomainStep extends React.Component {
 	componentDidMount() {
 		if ( this.state.lastQuery ) {
 			this.onSearch( this.state.lastQuery );
+		} else {
+			this.getAvailableTlds();
 		}
+
 		this.props.recordSearchFormView( this.props.analyticsSection );
 
 		this._isMounted = true;
@@ -576,10 +577,12 @@ class RegisterDomainStep extends React.Component {
 		);
 	};
 
-	getAvailableTlds = () => {
-		getAvailableTlds().then( availableTlds => {
-			this.setState( { availableTlds } );
-		} );
+	getAvailableTlds = ( domain = undefined ) => {
+		return getAvailableTlds( domain ? { search: domain } : {} )
+			.then( availableTlds => {
+				this.setState( { availableTlds } );
+			} )
+			.catch( noop );
 	};
 
 	checkDomainAvailability = ( domain, timestamp ) => {
@@ -839,6 +842,7 @@ class RegisterDomainStep extends React.Component {
 
 		const timestamp = Date.now();
 
+		this.getAvailableTlds( domain );
 		const domainSuggestions = Promise.all( [
 			this.checkDomainAvailability( domain, timestamp ),
 			this.getDomainsSuggestions( domain, timestamp ),

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -271,8 +271,8 @@ function getDomainPrice( slug, productsList, currencyCode ) {
 	return price;
 }
 
-function getAvailableTlds() {
-	return wpcom.undocumented().getAvailableTlds();
+function getAvailableTlds( query = {} ) {
+	return wpcom.undocumented().getAvailableTlds( query );
 }
 
 export {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -494,12 +494,12 @@ Undocumented.prototype.resendInboundTransferEmail = function( domain, fn ) {
 /**
  * Fetches a list of available top-level domain names ordered by popularity.
  *
- * @param {Function} fn The callback function
+ * @param {object} query Optional query parameters
  * @returns {Promise} A promise that resolves when the request completes
  * @api public
  */
-Undocumented.prototype.getAvailableTlds = function( fn ) {
-	return this.wpcom.req.get( '/domains/suggestions/tlds', fn );
+Undocumented.prototype.getAvailableTlds = function( query = {} ) {
+	return this.wpcom.req.get( '/domains/suggestions/tlds', query );
 };
 
 /**


### PR DESCRIPTION
This change sends an optional `search` query to the available TLD API.

It also adds error handling in case the API returns an error code.

# Test Instructions
1. Spin up this branch locally.
2. With the network panel open, navigate to `/start/domains`.
3. Find an API request for `/domains/suggestions/tlds`. Ensure no query string has been appended to the request.
4. Enter a query and find another request for `/domains/suggestions/tlds`. Ensure that it has the query string `search` with a value corresponding to your search query. 
5. Refresh the page.
6. Ensure that a query for `/domains/suggestions/tlds` is made using the same query string from step 4.