### PR TITLE
Support locales: splitting support locales for chat 

### DIFF
--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -9,7 +9,7 @@ export {
 	addLocaleToWpcomUrl,
 	getLanguage,
 	getLocaleFromPath,
-	getSupportLocale,
+	getSupportSiteLocale,
 	isDefaultLocale,
 	isLocaleVariant,
 	canBeTranslated,

--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -15,7 +15,7 @@ export {
 	addLocaleToWpcomUrl,
 	getLanguage,
 	getLocaleFromPath,
-	getSupportLocale,
+	getSupportSiteLocale,
 	isDefaultLocale,
 	isLocaleVariant,
 	canBeTranslated,

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -16,7 +16,7 @@ import {
 	removeLocaleFromPath,
 	isLocaleVariant,
 	canBeTranslated,
-	getSupportLocale,
+	getSupportSiteLocale,
 } from 'lib/i18n-utils';
 
 jest.mock( 'config', () => key => {
@@ -258,19 +258,19 @@ describe( 'utils', () => {
 		} );
 	} );
 
-	describe( '#getSupportLocale', () => {
+	describe( '#getSupportSiteLocale', () => {
 		test( 'should return `en` by default', () => {
-			expect( getSupportLocale() ).to.equal( 'en' );
+			expect( getSupportSiteLocale() ).to.equal( 'en' );
 		} );
 
 		test( 'should return support slug for current i18n locale slug if available in config', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'ja' );
-			expect( getSupportLocale() ).to.equal( 'ja' );
+			expect( getSupportSiteLocale() ).to.equal( 'ja' );
 		} );
 
 		test( 'should return `en` for current i18n locale slug if not available in config', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'ar' );
-			expect( getSupportLocale() ).to.equal( 'en' );
+			expect( getSupportSiteLocale() ).to.equal( 'en' );
 		} );
 	} );
 } );

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -4,7 +4,7 @@
  */
 import assert from 'assert'; // eslint-disable-line import/no-nodejs-modules
 import { expect } from 'chai';
-
+import { getLocaleSlug } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
@@ -16,11 +16,16 @@ import {
 	removeLocaleFromPath,
 	isLocaleVariant,
 	canBeTranslated,
+	getSupportLocale,
 } from 'lib/i18n-utils';
 
 jest.mock( 'config', () => key => {
 	if ( 'i18n_default_locale_slug' === key ) {
 		return 'en';
+	}
+
+	if ( 'support_site_locales' === key ) {
+		return [ 'en', 'es', 'de', 'ja', 'pt-br' ];
 	}
 
 	if ( 'languages' === key ) {
@@ -87,6 +92,10 @@ jest.mock( 'config', () => key => {
 		];
 	}
 } );
+
+jest.mock( 'i18n-calypso', () => ( {
+	getLocaleSlug: jest.fn( () => 'en' ),
+} ) );
 
 describe( 'utils', () => {
 	describe( '#isDefaultLocale', () => {
@@ -246,6 +255,22 @@ describe( 'utils', () => {
 
 		test( 'should return true for languages not in the exception list', () => {
 			expect( canBeTranslated( 'de' ) ).to.be.true;
+		} );
+	} );
+
+	describe( '#getSupportLocale', () => {
+		test( 'should return `en` by default', () => {
+			expect( getSupportLocale() ).to.equal( 'en' );
+		} );
+
+		test( 'should return support slug for current i18n locale slug if available in config', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'ja' );
+			expect( getSupportLocale() ).to.equal( 'ja' );
+		} );
+
+		test( 'should return `en` for current i18n locale slug if not available in config', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'ar' );
+			expect( getSupportLocale() ).to.equal( 'en' );
 		} );
 	} );
 } );

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -149,7 +149,7 @@ export function removeLocaleFromPath( path ) {
  */
 export function getSupportLocale() {
 	const localeSlug = getLocaleSlug();
-	if ( config( 'support_locales' ).indexOf( localeSlug ) > -1 ) {
+	if ( config( 'support_site_locales' ).indexOf( localeSlug ) > -1 ) {
 		return localeSlug;
 	}
 	return 'en';

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -147,7 +147,7 @@ export function removeLocaleFromPath( path ) {
  *
  * @returns {string} A slug which is a valid subdomain of *.support.wordpress.com.
  */
-export function getSupportLocale() {
+export function getSupportSiteLocale() {
 	const localeSlug = getLocaleSlug();
 	if ( config( 'support_site_locales' ).indexOf( localeSlug ) > -1 ) {
 		return localeSlug;

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -410,14 +410,14 @@ class HelpContact extends React.Component {
 		//    requests are sent to the language specific forums (for popular languages)
 		//    we don't tell the user that support is only offered in English.
 		const showHelpLanguagePrompt =
-			config( 'support_locales' ).indexOf( currentUserLocale ) === -1 &&
+			config( 'happychat_support_locales' ).indexOf( currentUserLocale ) === -1 &&
 			SUPPORT_FORUM !== variationSlug;
 
 		return {
 			compact: this.props.compact,
 			selectedSite: this.props.selectedSite,
 			disabled: isSubmitting,
-			showHelpLanguagePrompt: showHelpLanguagePrompt,
+			showHelpLanguagePrompt,
 			valueLink: {
 				value: savedContactForm,
 				requestChange: contactForm => ( savedContactForm = contactForm ),

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -410,7 +410,7 @@ class HelpContact extends React.Component {
 		//    requests are sent to the language specific forums (for popular languages)
 		//    we don't tell the user that support is only offered in English.
 		const showHelpLanguagePrompt =
-			config( 'happychat_support_locales' ).indexOf( currentUserLocale ) === -1 &&
+			config( 'livechat_support_locales' ).indexOf( currentUserLocale ) === -1 &&
 			SUPPORT_FORUM !== variationSlug;
 
 		return {

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -30,7 +30,7 @@ import { planMatches } from 'lib/plans';
 import { GROUP_WPCOM, TYPE_BUSINESS } from 'lib/plans/constants';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { getSupportLocale } from 'lib/i18n-utils';
+import { getSupportSiteLocale } from 'lib/i18n-utils';
 
 /**
  * Module variables
@@ -57,7 +57,7 @@ class Help extends React.PureComponent {
 				),
 			},
 			{
-				link: `https://${ getSupportLocale() }.support.wordpress.com/start/`,
+				link: `https://${ getSupportSiteLocale() }.support.wordpress.com/start/`,
 				title: this.props.translate( 'Get Started' ),
 				description: this.props.translate(
 					'No matter what kind of site you want to build, our five-step checklists will get you set up and ready to publish.'
@@ -102,7 +102,7 @@ class Help extends React.PureComponent {
 			<div className="help__support-links">
 				<CompactCard
 					className="help__support-link"
-					href={ `https://${ getSupportLocale() }.support.wordpress.com` }
+					href={ `https://${ getSupportSiteLocale() }.support.wordpress.com` }
 					target="__blank"
 				>
 					<div className="help__support-link-section">

--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -16,7 +16,7 @@ import isHappychatAvailable from 'state/happychat/selectors/is-happychat-availab
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { isEnabled } from 'config';
 import { purchasesRoot } from 'me/purchases/paths';
-import { getSupportLocale } from 'lib/i18n-utils';
+import { getSupportSiteLocale } from 'lib/i18n-utils';
 
 const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 	const helpLink =
@@ -58,7 +58,7 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 						components: {
 							a: (
 								<a
-									href={ 'https://' + getSupportLocale() + '.support.wordpress.com/plugins/' }
+									href={ 'https://' + getSupportSiteLocale() + '.support.wordpress.com/plugins/' }
 									target="_blank"
 									rel="noopener noreferrer"
 								/>

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -34,7 +34,8 @@
 	"google_oauth_client_id": "108380595987-j91sm1alavcdgd81i2655kp8q1lbtvrc.apps.googleusercontent.com",
 	"facebook_app_id": "611241942420191",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-    "support_locales": [ "en", "es", "pt-br" ],
+    "happychat_support_locales": [ "en", "es", "pt-br" ],
+    "support_site_locales": [ "en", "es", "de", "ja", "pt-br" ],
     "english_locales": [ "en", "en-gb"],
     "languages": [
         { "value": 2, "langSlug": "af", "name": "Afrikaans", "wpLocale": "af", "territories": [ "002" ] },

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -34,7 +34,7 @@
 	"google_oauth_client_id": "108380595987-j91sm1alavcdgd81i2655kp8q1lbtvrc.apps.googleusercontent.com",
 	"facebook_app_id": "611241942420191",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-    "happychat_support_locales": [ "en", "es", "pt-br" ],
+    "livechat_support_locales": [ "en", "es", "pt-br" ],
     "support_site_locales": [ "en", "es", "de", "ja", "pt-br" ],
     "english_locales": [ "en", "en-gb"],
     "languages": [

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -10,7 +10,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "/",
 	"rebrand_cities_prefix": "rebrandcitiessite",
-	"support_locales": [
+	"happychat_support_locales": [
 		"en",
 		"es",
 		"pt-br"

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -10,7 +10,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "/",
 	"rebrand_cities_prefix": "rebrandcitiessite",
-	"happychat_support_locales": [
+	"livechat_support_locales": [
 		"en",
 		"es",
 		"pt-br"

--- a/config/development.json
+++ b/config/development.json
@@ -26,7 +26,8 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
 	"rebrand_cities_prefix": "rebrandcitiesdevelopmentsite",
-	"support_locales": [ "en", "es", "pt-br" ],
+	"happychat_support_locales": [ "en", "es", "pt-br" ],
+	"support_site_locales": [ "en", "es", "de", "ja", "pt-br" ],
 	"features": {
 		"activity-log-wpcom-free": true,
 		"account-recovery": true,

--- a/config/development.json
+++ b/config/development.json
@@ -26,7 +26,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
 	"rebrand_cities_prefix": "rebrandcitiesdevelopmentsite",
-	"happychat_support_locales": [ "en", "es", "pt-br" ],
+	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"support_site_locales": [ "en", "es", "de", "ja", "pt-br" ],
 	"features": {
 		"activity-log-wpcom-free": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -12,7 +12,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"support_locales": [
+	"happychat_support_locales": [
 		"en",
 		"es",
 		"pt-br"

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -12,7 +12,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"happychat_support_locales": [
+	"livechat_support_locales": [
 		"en",
 		"es",
 		"pt-br"

--- a/config/production.json
+++ b/config/production.json
@@ -11,7 +11,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"facebook_app_id": "2373049596",
 	"rebrand_cities_prefix": "rebrandcitiessite",
-	"support_locales": [
+	"happychat_support_locales": [
 		"en",
 		"es",
 		"pt-br"

--- a/config/production.json
+++ b/config/production.json
@@ -11,7 +11,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"facebook_app_id": "2373049596",
 	"rebrand_cities_prefix": "rebrandcitiessite",
-	"happychat_support_locales": [
+	"livechat_support_locales": [
 		"en",
 		"es",
 		"pt-br"

--- a/config/stage.json
+++ b/config/stage.json
@@ -13,7 +13,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"happychat_support_locales": [
+	"livechat_support_locales": [
 		"en",
 		"es",
 		"pt-br"

--- a/config/stage.json
+++ b/config/stage.json
@@ -13,7 +13,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"support_locales": [
+	"happychat_support_locales": [
 		"en",
 		"es",
 		"pt-br"

--- a/config/test.json
+++ b/config/test.json
@@ -24,7 +24,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"happychat_support_locales": [ "en", "es", "pt-br" ],
+	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
 		"apple-pay": true,

--- a/config/test.json
+++ b/config/test.json
@@ -24,7 +24,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"support_locales": [ "en", "es", "pt-br" ],
+	"happychat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
 		"apple-pay": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -14,7 +14,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"happychat_support_locales": [ "en", "es", "pt-br" ],
+	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"activity-log-wpcom-free": true,
 		"ad-tracking": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -14,7 +14,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"support_locales": [ "en", "es", "pt-br" ],
+	"happychat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"activity-log-wpcom-free": true,
 		"ad-tracking": false,


### PR DESCRIPTION
This PR extends the array of supported locales in Calypso's config to include `de` and `ja`. The intention is to offer, where we can, localized help pages to users of languages other than English.

At the same time, we have split the concept of _support locales_ into those available:

1. in chat (`happychat_support_locales`)
2. on our support site (`*.support.wordpress.com`) chat (`support_site_locales`)

This is because the level of support for each differs depending on the user's locale.

I also tried to add `ru` since the support site for which is getting better, however I dropped it as it yet to offer a landing page for `ru.support.wordpress.com/start/`

## Testing
Visit the following pages with your UI set to first `de`, then `ja` (or use  https://calypso.live/?branch=add/localized-support-links):

1. http://calypso.localhost:3000/help
2. http://calypso.localhost:3000/plans/{yoursite.wordpress.com} (With no plan, at the bottom in the FAQs)
3. http://calypso.localhost:3000/help/contact

### Expectations
**At 1:** `{ja|de}.support.wordpress.com` and `{ja|de}.support.wordpress.com/start/` should be available

<img width="859" alt="screen shot 2018-05-16 at 1 32 18 pm" src="https://user-images.githubusercontent.com/6458278/40095260-5799c458-590e-11e8-866c-d5d8778649cd.png">

**At 2:**  `{ja|de}.support.wordpress.com/plugins/` should be available

<img width="377" alt="screen shot 2018-05-16 at 1 31 51 pm" src="https://user-images.githubusercontent.com/6458278/40095237-30d05508-590e-11e8-8a1d-65cb2018b067.png">

**At 3:**  A notice should appear indicating that chat is only available in English

<img width="740" alt="screen shot 2018-05-16 at 1 35 48 pm" src="https://user-images.githubusercontent.com/6458278/40095262-5beb9554-590e-11e8-9179-5ddb80ad73fa.png">


