### PR TITLE
Add new selector: userHasAnyAtomicSites

### DIFF
--- a/client/state/selectors/test/user-has-any-atomic-sites.js
+++ b/client/state/selectors/test/user-has-any-atomic-sites.js
@@ -1,0 +1,68 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { userHasAnyAtomicSites } from 'state/selectors';
+
+describe( 'userHasAnyAtomicSites()', () => {
+	test( 'should return false if no sites in state', () => {
+		const state = {
+			sites: {
+				items: {},
+			},
+		};
+
+		expect( userHasAnyAtomicSites( state ) ).toBe( false );
+	} );
+
+	test( 'should return false if no sites are Atomic', () => {
+		const state = {
+			sites: {
+				items: {
+					2916288: {
+						ID: 2916288,
+						name: 'WordPress.com Example Blog',
+						options: {
+							is_automated_transfer: false,
+						},
+					},
+					1234567: {
+						ID: 1234567,
+						name: 'WordPress.com Example Blog',
+						options: {
+							is_automated_transfer: false,
+						},
+					},
+				},
+			},
+		};
+
+		expect( userHasAnyAtomicSites( state ) ).toBe( false );
+	} );
+
+	test( 'should return true if at least one site is Atomic', () => {
+		const state = {
+			sites: {
+				items: {
+					2916288: {
+						ID: 2916288,
+						name: 'WordPress.com Example Blog',
+						options: {
+							is_automated_transfer: true,
+						},
+					},
+					1234567: {
+						ID: 1234567,
+						name: 'WordPress.com Example Blog',
+						options: {
+							is_automated_transfer: false,
+						},
+					},
+				},
+			},
+		};
+
+		expect( userHasAnyAtomicSites( state ) ).toBe( true );
+	} );
+} );

--- a/client/state/selectors/user-has-any-atomic-sites.js
+++ b/client/state/selectors/user-has-any-atomic-sites.js
@@ -1,0 +1,23 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { some } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import { getSitesItems, isSiteAutomatedTransfer as isAtomicSite } from 'state/selectors';
+
+/**
+ * Whether the user currently has any Atomic sites
+ *
+ * @param {Object} state  Global state tree
+ * @return {Boolean}
+ */
+export default createSelector(
+	state => some( getSitesItems( state ), site => isAtomicSite( state, site.ID ) ),
+	state => [ getSitesItems( state ) ]
+);


### PR DESCRIPTION
When closing a user's account, we need to check if they have any Atomic sites, but we don't currently have a selector to do that.

This PR adds a new selector checking whether the current user has any Atomic sites.

### To test

Run the unit tests:

`npm run test-client client/state/selectors/test/user-has-any-atomic-sites.js`