### PR TITLE
Domains Signup: checking for valid args in getAvailabilityNotice

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -333,7 +333,7 @@ class RegisterDomainStep extends React.Component {
 
 	render() {
 		const queryObject = getQueryObject( this.props );
-		const { errorData = {}, error, lastDomainSearched, showNotice } = this.state;
+		const { errorData, error, lastDomainSearched, showNotice } = this.state;
 		const { message, severity } = showNotice
 			? getAvailabilityNotice( lastDomainSearched, error, errorData )
 			: {};

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -24,12 +24,16 @@ import {
 } from 'my-sites/domains/paths';
 
 function getAvailabilityNotice( domain, error, errorData ) {
+	const tld = domain ? getTld( domain ) : null;
+	const { site, maintenanceEndTime } = errorData || {};
+
+	// The message is set only when there is a valid error
+	// and the conditions of the corresponding switch block are met.
+	// Consumers should check for the message prop in order
+	// to determine whether to display the notice
+	// See for e.g., client/components/domains/register-domain-step/index.jsx
 	let message,
 		severity = 'error';
-
-	const tld = getTld( domain );
-
-	const { site, maintenanceEndTime } = errorData;
 
 	switch ( error ) {
 		case domainAvailability.REGISTERED:
@@ -197,11 +201,10 @@ function getAvailabilityNotice( domain, error, errorData ) {
 		case domainAvailability.EMPTY_RESULTS:
 			// unavailable domains are displayed in the search results, not as a notice OR
 			// domain registrations are closed, in which case it is handled in parent
-			message = null;
 			break;
 
 		case domainAvailability.BLACKLISTED:
-			if ( domain.toLowerCase().indexOf( 'wordpress' ) > -1 ) {
+			if ( domain && domain.toLowerCase().indexOf( 'wordpress' ) > -1 ) {
 				message = translate(
 					'Due to {{a1}}trademark policy{{/a1}}, ' +
 						'we are not able to allow domains containing {{strong}}WordPress{{/strong}} to be registered or mapped here. ' +

--- a/client/lib/domains/registration/test/availability-messages.js
+++ b/client/lib/domains/registration/test/availability-messages.js
@@ -1,0 +1,69 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getAvailabilityNotice } from '../availability-messages';
+import { domainAvailability } from 'lib/domains/constants';
+
+jest.mock( 'i18n-calypso', () => ( {
+	translate: jest.fn( () => 'default' ),
+} ) );
+
+describe( 'getAvailabilityNotice()', () => {
+	test( 'Should return default message and severity', () => {
+		expect( getAvailabilityNotice() ).toEqual( { message: 'default', severity: 'error' } );
+	} );
+
+	test( 'Should return default message and severity when error type not defined', () => {
+		expect(
+			getAvailabilityNotice( 'hello.com', null, { site: 1, maintenanceEndTime: 2 } )
+		).toEqual( { message: 'default', severity: 'error' } );
+	} );
+
+	test( 'Should return default message when domain is not a string', () => {
+		expect(
+			getAvailabilityNotice( null, domainAvailability.BLACKLISTED, {
+				site: 1,
+				maintenanceEndTime: 2,
+			} )
+		).toEqual( { message: 'default', severity: 'error' } );
+	} );
+
+	test( 'Should return default message when domain or site not present', () => {
+		expect(
+			getAvailabilityNotice( null, domainAvailability.MAPPED_SAME_SITE_TRANSFERRABLE, null )
+		).toEqual( { message: 'default', severity: 'error' } );
+	} );
+
+	test( 'Should return no message when tld is not present', () => {
+		expect( getAvailabilityNotice( null, domainAvailability.MAINTENANCE, null ) ).toEqual( {
+			message: undefined,
+			severity: 'error',
+		} );
+		expect( getAvailabilityNotice( null, domainAvailability.NOT_REGISTRABLE, null ) ).toEqual( {
+			message: undefined,
+			severity: 'error',
+		} );
+	} );
+
+	test( 'Should return no message when domain unavailable, unmappable, unknown, tld not supported, or search results are empty', () => {
+		// These are special cases where the error notice should not be handled by client/components/domains/register-domain-step/index.jsx
+		// but in client/components/domains/domain-search-results/index.jsx
+		[
+			domainAvailability.MAPPABLE,
+			domainAvailability.AVAILABLE,
+			domainAvailability.TLD_NOT_SUPPORTED,
+			domainAvailability.UNKNOWN,
+			domainAvailability.EMPTY_RESULTS,
+		].forEach( error => {
+			expect( getAvailabilityNotice( null, error, null ) ).toEqual( {
+				message: undefined,
+				severity: 'error',
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR follows up on `p5XAZ9-1IL-p2` and the quick fix by @alisterscott in #24891

After the bug fix PR #24720, `getAvailabilityNotice()` was receiving a null value for `errorData` from which it was attempting to extract object properties:

```
const { site, maintenanceEndTime } = errorData;
```

Here, we're shoring up the internal defences of `getAvailabilityNotice()` so that it may decide internally what to do in the event of unexpected arguments.

Tests added.

## Testing
1. Fire up the branch and head to `/start` in an incognito tab (or logged-out state)
2. Continue to the next step and enter a some special characters or emojis 🐝🐝🐝🐝🐝
3. Try out an invalid domain name (`test.xxx`)
4. Enter a domain name that is already registered and mapped with wordpress.com (e.g., illustratedshorts.com)
5. Try to break in general :)

### Expectations

**At 2-5:** The relevant notices should display to the page.

<img width="973" alt="screen shot 2018-05-16 at 6 27 14 pm" src="https://user-images.githubusercontent.com/6458278/40105837-766fd768-5937-11e8-8ed3-06fc170f792e.png">

<img width="987" alt="screen shot 2018-05-16 at 6 20 14 pm" src="https://user-images.githubusercontent.com/6458278/40105851-7f533e38-5937-11e8-8eb9-f1adcf71cdc2.png">

<img width="1015" alt="screen shot 2018-05-16 at 6 20 03 pm" src="https://user-images.githubusercontent.com/6458278/40105840-79b0714e-5937-11e8-852a-f446eabb59fc.png">


