### PR TITLE
Vaultpress: Fix vaultpress legacy plans billing items

### DIFF
--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -74,6 +74,10 @@ class TransactionsTable extends React.Component {
 			return <strong>{ this.props.translate( 'Multiple items' ) }</strong>;
 		}
 
+		if ( transactionItem.product === transactionItem.variation ) {
+			return transactionItem.product;
+		}
+
 		return this.serviceNameDescription( {
 			...transactionItem,
 			plan: capitalPDangit( titleCase( transactionItem.variation ) ),


### PR DESCRIPTION
fixes https://github.com/Automattic/wp-calypso/issues/24091  (partially)

![image](https://user-images.githubusercontent.com/1554855/40110355-0c82a038-5900-11e8-95a4-c2c57a0b400b.png)

When you have a legacy Vaultpress plan, its name appears as "Vaultpress Vault Press" due to some fancy text transformations we are applying to the data coming from the API (which are ok for WordPress.com plans, but not for the info returned for Vaultpress plans). 

This PR fixes it so it's simplified to  just "Vaultpress":

![image](https://user-images.githubusercontent.com/1554855/40110749-1aca99ec-5901-11e8-917f-b7fef4588807.png)


How to test
=========
0. You need a Vaultpress plan. It's not easy to get, since we don't sell them anymore. Your best bet is pinging @briancolinger 
1. Go to https://calypso.live/me/purchases/billing/?branch=fix/vaultpress-billing
2. The Vaultpress plan item title should be just "Vaultpress"

