### PR TITLE
Me: Update connected applications to use Redux

### DIFF
--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -12,10 +12,10 @@ const debug = debugFactory( 'calypso:two-step-authorization' );
  */
 import emitter from 'lib/mixins/emitter';
 import userSettings from 'lib/user-settings';
-import connectedApplications from 'lib/connected-applications-data';
 import analytics from 'lib/analytics';
 import wp from 'lib/wp';
 import { reduxDispatch } from 'lib/redux-bridge';
+import { requestConnectedApplications } from 'state/connected-applications/actions';
 import { requestUserProfileLinks } from 'state/profile-links/actions';
 
 const wpcom = wp.undocumented();
@@ -78,7 +78,7 @@ TwoStepAuthorization.prototype.validateCode = function( args, callback ) {
 				// data from the following modules.
 				if ( this.isReauthRequired() ) {
 					userSettings.fetchSettings();
-					connectedApplications.fetch();
+					reduxDispatch( requestConnectedApplications() );
 					reduxDispatch( requestUserProfileLinks() );
 				}
 

--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -15,6 +15,7 @@ import Button from 'components/button';
 import ConnectedApplicationIcon from 'me/connected-application-icon';
 import FoldableCard from 'components/foldable-card';
 import safeProtocolUrl from 'lib/safe-protocol-url';
+import { deleteConnectedApplication } from 'state/connected-applications/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 class ConnectedApplicationItem extends React.Component {
@@ -42,7 +43,7 @@ class ConnectedApplicationItem extends React.Component {
 		const { connection: { title, ID } } = this.props;
 		event.stopPropagation();
 		this.recordClickEvent( 'Disconnect Connected Application Link', title );
-		this.props.revoke( ID );
+		this.props.deleteConnectedApplication( ID );
 	};
 
 	renderAccessScopeBadge() {
@@ -212,5 +213,6 @@ class ConnectedApplicationItem extends React.Component {
 }
 
 export default connect( null, {
+	deleteConnectedApplication,
 	recordGoogleEvent,
 } )( localize( ConnectedApplicationItem ) );

--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -3,12 +3,10 @@
 /**
  * External dependencies
  */
-
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
+import { get, times } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -19,10 +17,6 @@ import DocumentHead from 'components/data/document-head';
 import EmptyContent from 'components/empty-content';
 import Main from 'components/main';
 import MeSidebarNavigation from 'me/sidebar-navigation';
-/* eslint-disable no-restricted-imports */
-// FIXME: Remove use of this mixin
-import observe from 'lib/mixins/data-observe';
-/* eslint-enable no-restricted-imports */
 import QueryConnectedApplications from 'components/data/query-connected-applications';
 import ReauthRequired from 'me/reauth-required';
 import SecuritySectionNav from 'me/security-section-nav';
@@ -31,26 +25,14 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { getConnectedApplications, getRequest } from 'state/selectors';
 import { requestConnectedApplications } from 'state/connected-applications/actions';
 
-/* eslint-disable react/prefer-es6-class */
-// FIXME: Remove use of createReactClass
-const ConnectedApplications = createReactClass( {
-	/* eslint-enable react/prefer-es6-class */
-	displayName: 'ConnectedApplications',
-
-	propTypes: {
+class ConnectedApplications extends PureComponent {
+	static propTypes = {
 		translate: PropTypes.func.isRequired,
-	},
+	};
 
-	mixins: [ observe( 'connectedAppsData' ) ],
-
-	getDefaultProps: function() {
-		return {
-			applicationID: 0,
-		};
-	},
-
-	renderEmptyContent: function() {
+	renderEmptyContent() {
 		const { translate } = this.props;
+
 		return (
 			<EmptyContent
 				title={ translate( "You haven't connected any apps yet." ) }
@@ -68,28 +50,24 @@ const ConnectedApplications = createReactClass( {
 				} ) }
 			/>
 		);
-	},
+	}
 
-	renderPlaceholders: function() {
-		const placeholders = [];
+	renderPlaceholders() {
+		const { translate } = this.props;
 
-		for ( let i = 0; i < 5; i++ ) {
-			placeholders.push(
-				<ConnectedAppItem
-					connection={ {
-						ID: i,
-						title: this.props.translate( 'Loading Connected Applications' ),
-					} }
-					key={ i }
-					isPlaceholder
-				/>
-			);
-		}
+		return times( 5, index => (
+			<ConnectedAppItem
+				connection={ {
+					ID: index,
+					title: translate( 'Loading Connected Applications' ),
+				} }
+				key={ index }
+				isPlaceholder
+			/>
+		) );
+	}
 
-		return placeholders;
-	},
-
-	renderConnectedApps: function() {
+	renderConnectedApps() {
 		const { apps } = this.props;
 
 		if ( ! apps.length ) {
@@ -99,23 +77,25 @@ const ConnectedApplications = createReactClass( {
 		return apps.map( connection => (
 			<ConnectedAppItem connection={ connection } key={ connection.ID } />
 		) );
-	},
+	}
 
-	renderConnectedAppsList: function() {
-		const { apps, isRequestingApps } = this.props;
+	renderConnectedAppsList() {
+		const { apps, isRequestingApps, path } = this.props;
 
 		return (
-			<div>
-				<SecuritySectionNav path={ this.props.path } />
+			<Fragment>
+				<SecuritySectionNav path={ path } />
 
 				{ ! isRequestingApps && ! apps.length
 					? this.renderEmptyContent()
 					: this.renderConnectedApps() }
-			</div>
+			</Fragment>
 		);
-	},
+	}
 
-	render: function() {
+	render() {
+		const { translate } = this.props;
+
 		return (
 			<Main className="connected-applications">
 				<QueryConnectedApplications />
@@ -127,13 +107,13 @@ const ConnectedApplications = createReactClass( {
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 				<MeSidebarNavigation />
 
-				<DocumentHead title={ this.props.translate( 'Connected Applications' ) } />
+				<DocumentHead title={ translate( 'Connected Applications' ) } />
 
 				{ this.renderConnectedAppsList() }
 			</Main>
 		);
-	},
-} );
+	}
+}
 
 export default connect( state => ( {
 	apps: getConnectedApplications( state ),

--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -15,6 +15,8 @@ import { localize } from 'i18n-calypso';
 import ConnectedAppItem from 'me/connected-application-item';
 import DocumentHead from 'components/data/document-head';
 import EmptyContent from 'components/empty-content';
+import getConnectedApplications from 'state/selectors/get-connected-applications';
+import getRequest from 'state/selectors/get-request';
 import Main from 'components/main';
 import MeSidebarNavigation from 'me/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -22,8 +24,6 @@ import QueryConnectedApplications from 'components/data/query-connected-applicat
 import ReauthRequired from 'me/reauth-required';
 import SecuritySectionNav from 'me/security-section-nav';
 import twoStepAuthorization from 'lib/two-step-authorization';
-import getConnectedApplications from 'state/selectors/get-connected-applications';
-import getRequest from 'state/selectors/get-request';
 import { requestConnectedApplications } from 'state/connected-applications/actions';
 
 class ConnectedApplications extends PureComponent {

--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -7,8 +7,6 @@
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -19,7 +17,6 @@ import DocumentHead from 'components/data/document-head';
 import EmptyContent from 'components/empty-content';
 import Main from 'components/main';
 import MeSidebarNavigation from 'me/sidebar-navigation';
-import notices from 'notices';
 /* eslint-disable no-restricted-imports */
 // FIXME: Remove use of this mixin
 import observe from 'lib/mixins/data-observe';
@@ -27,7 +24,6 @@ import observe from 'lib/mixins/data-observe';
 import ReauthRequired from 'me/reauth-required';
 import SecuritySectionNav from 'me/security-section-nav';
 import twoStepAuthorization from 'lib/two-step-authorization';
-import { successNotice } from 'state/notices/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 /* eslint-disable react/prefer-es6-class */
@@ -46,32 +42,6 @@ const ConnectedApplications = createReactClass( {
 		return {
 			applicationID: 0,
 		};
-	},
-
-	revokeConnection: function( applicationID, callback ) {
-		const application = this.props.connectedAppsData.getApplication( applicationID );
-		if ( 'undefined' !== typeof application ) {
-			this.props.connectedAppsData.revoke(
-				parseInt( applicationID, 10 ),
-				function( error ) {
-					if ( error ) {
-						notices.clearNotices( 'notices' );
-						callback( error );
-					} else {
-						this.props.successNotice(
-							this.props.translate(
-								'%(applicationTitle)s no longer has access to your WordPress.com account.',
-								{
-									args: {
-										applicationTitle: application.title,
-									},
-								}
-							)
-						);
-					}
-				}.bind( this )
-			);
-		}
 	},
 
 	renderEmptyContent: function() {
@@ -165,6 +135,4 @@ const ConnectedApplications = createReactClass( {
 	},
 } );
 
-export default connect( null, dispatch => bindActionCreators( { successNotice }, dispatch ) )(
-	localize( ConnectedApplications )
-);
+export default localize( ConnectedApplications );

--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -22,7 +22,8 @@ import QueryConnectedApplications from 'components/data/query-connected-applicat
 import ReauthRequired from 'me/reauth-required';
 import SecuritySectionNav from 'me/security-section-nav';
 import twoStepAuthorization from 'lib/two-step-authorization';
-import { getConnectedApplications, getRequest } from 'state/selectors';
+import getConnectedApplications from 'state/selectors/get-connected-applications';
+import getRequest from 'state/selectors/get-request';
 import { requestConnectedApplications } from 'state/connected-applications/actions';
 
 class ConnectedApplications extends PureComponent {

--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -3,8 +3,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import React, { Fragment, PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { get, times } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -17,11 +17,11 @@ import DocumentHead from 'components/data/document-head';
 import EmptyContent from 'components/empty-content';
 import Main from 'components/main';
 import MeSidebarNavigation from 'me/sidebar-navigation';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryConnectedApplications from 'components/data/query-connected-applications';
 import ReauthRequired from 'me/reauth-required';
 import SecuritySectionNav from 'me/security-section-nav';
 import twoStepAuthorization from 'lib/two-step-authorization';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { getConnectedApplications, getRequest } from 'state/selectors';
 import { requestConnectedApplications } from 'state/connected-applications/actions';
 

--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -122,7 +122,6 @@ const ConnectedApplications = createReactClass( {
 							connection={ connection }
 							key={ connection.ID }
 							connectedApplications={ this.props.connectedAppsData }
-							revoke={ this.revokeConnection }
 						/>
 					);
 				}, this )

--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -5,13 +5,11 @@
  */
 
 import createReactClass from 'create-react-class';
-import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-const debug = debugFactory( 'calypso:me:connected-applications' );
 
 /**
  * Internal dependencies
@@ -50,27 +48,16 @@ const ConnectedApplications = createReactClass( {
 		};
 	},
 
-	componentDidMount: function() {
-		debug( this.constructor.displayName + ' React component is mounted.' );
-	},
-
-	componentWillUnmount: function() {
-		debug( this.constructor.displayName + ' React component is unmounting.' );
-	},
-
 	revokeConnection: function( applicationID, callback ) {
 		const application = this.props.connectedAppsData.getApplication( applicationID );
 		if ( 'undefined' !== typeof application ) {
 			this.props.connectedAppsData.revoke(
 				parseInt( applicationID, 10 ),
 				function( error ) {
-					debug( 'API call to revoke application is completed.' );
 					if ( error ) {
-						debug( 'There was an error revoking an application.' );
 						notices.clearNotices( 'notices' );
 						callback( error );
 					} else {
-						debug( 'Application connection was successfully revoked.' );
 						this.props.successNotice(
 							this.props.translate(
 								'%(applicationTitle)s no longer has access to your WordPress.com account.',

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -17,7 +17,6 @@ import PasswordComponent from 'me/security/main';
 import accountPasswordData from 'lib/account-password-data';
 import SocialLoginComponent from 'me/social-login';
 import ConnectedAppsComponent from 'me/connected-applications';
-import connectedAppsData from 'lib/connected-applications-data';
 import AccountRecoveryComponent from 'me/security-account-recovery';
 
 export function password( context, next ) {
@@ -51,7 +50,6 @@ export function connectedApplications( context, next ) {
 	context.primary = React.createElement( ConnectedAppsComponent, {
 		userSettings: userSettings,
 		path: context.path,
-		connectedAppsData: connectedAppsData,
 	} );
 	next();
 }


### PR DESCRIPTION
This PR updates the connected applications controller and components to use Redux instead of the legacy emitter store. It also uses the time to apply some minor cleanups. Commits are atomic and self-explanatory, so they can be used for more expanded details on the minor improvements that the PR suggests.

This PR shouldn't be introducing any visual or behavioral changes, everything should be working like it did before (with the exception of a notice copy that we made a little more generic).

For more context of the full connected applications reduxification effort, you can see this PR: #24175.

Note: removing the legacy libs/functions will be done in a subsequent PR.

To test:
* Checkout this branch.
* Clear your Redux store.
* Head to http://calypso.localhost:3000/me/security/connected-applications
* Verify your connected applications load properly in that page.
* Refresh the page, verify data persists.
* Try removing a connected application, verify it works as expected.
* Smoke test (expand and collapse some connected applications, click on everything you can, refresh to test the persistence, try turning off your connection before deleting a connected app, etc.)