### PR TITLE
Store: Fix JS error that can occur when creating promotions

### DIFF
--- a/client/extensions/woocommerce/state/sites/promotions/helpers.js
+++ b/client/extensions/woocommerce/state/sites/promotions/helpers.js
@@ -119,7 +119,7 @@ export function createCouponUpdateFromPromotion( promotion ) {
 	let productCategoryIds = ( appliesTo && appliesTo.productCategoryIds ) || undefined;
 
 	// If 'all' was selected, pass in empty arrays to reset product ids and category ids
-	if ( appliesTo.all ) {
+	if ( appliesTo && appliesTo.all ) {
 		productIds = [];
 		productCategoryIds = [];
 	}


### PR DESCRIPTION
Reported at p75Izm-17a-p2. This PR fixes the `Cannot read property 'all' of undefined` error that can show up when creating a coupon promotion.

To Test:
* Create (not update) a promotion and select 'All Products' and save.
* Make sure the product saves.