### PR TITLE
Components: Code update for `<PopoverMenu />`

### DIFF
--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -2,17 +2,20 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import ReactDom from 'react-dom';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { over, pick } from 'lodash';
+import { over } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Popover from 'components/popover';
 
-class PopoverMenu extends React.Component {
+const isInvalidTarget = target => {
+	return target.tagName === 'HR';
+};
+
+class PopoverMenu extends Component {
 	static propTypes = {
 		autoPosition: PropTypes.bool,
 		isVisible: PropTypes.bool.isRequired,
@@ -31,34 +34,47 @@ class PopoverMenu extends React.Component {
 		popoverComponent: Popover,
 	};
 
+	menu = React.createRef();
+
 	componentWillUnmount() {
 		// Make sure we don't hold on to reference to the DOM reference
 		this._previouslyFocusedElement = null;
 	}
 
 	render() {
-		const children = React.Children.map( this.props.children, this._setPropsOnChild, this );
-		const PopoverComponent = this.props.popoverComponent;
-		const popoverProps = pick( this.props, [
-			'isVisible',
-			'context',
-			'autoPosition',
-			'position',
-			'className',
-			'rootClassName',
-			'popoverTitle',
-			'customPosition',
-		] );
+		const {
+			popoverComponent: PopoverComponent,
+			autoPosition,
+			className,
+			context,
+			customPosition,
+			isVisible,
+			popoverTitle,
+			position,
+			rootClassName,
+		} = this.props;
+
 		return (
-			<PopoverComponent onClose={ this._onClose } onShow={ this._onShow } { ...popoverProps }>
+			<PopoverComponent
+				onClose={ this._onClose }
+				onShow={ this._onShow }
+				autoPosition={ autoPosition }
+				className={ className }
+				context={ context }
+				customPosition={ customPosition }
+				isVisible={ isVisible }
+				popoverTitle={ popoverTitle }
+				position={ position }
+				rootClassName={ rootClassName }
+			>
 				<div
-					ref="menu"
+					ref={ this.menu }
 					role="menu"
 					className="popover__menu"
 					onKeyDown={ this._onKeyDown }
 					tabIndex="-1"
 				>
-					{ children }
+					{ React.Children.map( this.props.children, this._setPropsOnChild, this ) }
 				</div>
 			</PopoverComponent>
 		);
@@ -82,17 +98,13 @@ class PopoverMenu extends React.Component {
 	};
 
 	_onShow = () => {
-		const elementToFocus = ReactDom.findDOMNode( this.refs.menu );
+		const elementToFocus = this.menu.current;
 
 		this._previouslyFocusedElement = document.activeElement;
 
 		if ( elementToFocus ) {
 			elementToFocus.focus();
 		}
-	};
-
-	_isInvalidTarget = target => {
-		return target.tagName === 'HR';
 	};
 
 	/*
@@ -102,7 +114,7 @@ class PopoverMenu extends React.Component {
 	 * bottom.
 	 */
 	_getClosestSibling = ( target, isDownwardMotion = true ) => {
-		const menu = ReactDom.findDOMNode( this.refs.menu );
+		const menu = this.menu.current;
 
 		let first = menu.firstChild,
 			last = menu.lastChild;
@@ -120,7 +132,7 @@ class PopoverMenu extends React.Component {
 
 		const sibling = closest || last;
 
-		return this._isInvalidTarget( sibling )
+		return isInvalidTarget( sibling )
 			? this._getClosestSibling( sibling, isDownwardMotion )
 			: sibling;
 	};


### PR DESCRIPTION
See #24818

While hunting for a performance issue I stumbled upon
a few components that could use some updating. This is
one of them.

 - Replaced relatively costly use of `pick`
 - Updated `ref` to use `createRef()`
 - Tried to minimize re-renders from recreating props each render

**Testing**

This occurs in many different places - pretty much anywhere
that there's an ellipsis menu too this will be there. Smoke-test.
I could use some help testing because I'm not sure how best
to do it.

Other than that a considerate review of the code should catch
more mistakes than visual testing.