### PR TITLE
Components: Code update for `<Card />`

### DIFF
--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -3,13 +3,25 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
-import { assign, omit } from 'lodash';
-import classnames from 'classnames';
+import React, { PureComponent } from 'react';
+import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 
-class Card extends Component {
+const getClassName = ( { className, compact, highlightClass, href, onClick } ) =>
+	classNames(
+		'card',
+		className,
+		{
+			'is-card-link': !! href,
+			'is-clickable': !! onClick,
+			'is-compact': compact,
+			'is-highlight': highlightClass,
+		},
+		highlightClass
+	);
+
+class Card extends PureComponent {
 	static propTypes = {
 		className: PropTypes.string,
 		href: PropTypes.string,
@@ -25,38 +37,26 @@ class Card extends Component {
 	};
 
 	render() {
-		const { children, compact, highlight, href, onClick, tagName, target } = this.props;
+		const {
+			children,
+			compact, // eslint-disable-line no-unused-vars
+			highlight, // eslint-disable-line no-unused-vars
+			highlightClass, // eslint-disable-line no-unused-vars
+			tagName: TagName,
+			href,
+			target,
+			...props
+		} = this.props;
 
-		const highlightClass = highlight ? 'is-' + highlight : false;
-
-		const className = classnames(
-			'card',
-			this.props.className,
-			{
-				'is-card-link': !! href,
-				'is-clickable': !! onClick,
-				'is-compact': compact,
-				'is-highlight': highlightClass,
-			},
-			highlightClass
-		);
-
-		const omitProps = [ 'compact', 'highlight', 'tagName' ];
-
-		let linkIndicator;
-		if ( href ) {
-			linkIndicator = (
+		return href ? (
+			<a { ...props } href={ href } target={ target } className={ getClassName( this.props ) }>
 				<Gridicon className="card__link-indicator" icon={ target ? 'external' : 'chevron-right' } />
-			);
-		} else {
-			omitProps.push( 'href', 'target' );
-		}
-
-		return React.createElement(
-			href ? 'a' : tagName,
-			assign( omit( this.props, omitProps ), { className } ),
-			linkIndicator,
-			children
+				{ children }
+			</a>
+		) : (
+			<TagName { ...props } className={ getClassName( this.props ) }>
+				{ children }
+			</TagName>
 		);
 	}
 }

--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -39,9 +39,9 @@ class Card extends PureComponent {
 	render() {
 		const {
 			children,
-			compact, // eslint-disable-line no-unused-vars
-			highlight, // eslint-disable-line no-unused-vars
-			highlightClass, // eslint-disable-line no-unused-vars
+			compact,
+			highlight,
+			highlightClass,
 			tagName: TagName,
 			href,
 			target,


### PR DESCRIPTION
See #24818

While hunting for a performance issue I stumbled upon
a few components that could use some updating. This is
one of them.

 - move CSS class-name generator into a separate function
 - manually omit props and try to minimize rerenders from recreating
   props on every render
 - remove mutation and split primary logic in two to simplify

**Testing**

Confirm that `<Card />`s still work. You can play around in the
DevDocs with different configurations. Pay special attention to
how the behavior changes when there's a supplied `href` prop.

Manual code auditing is much appreciated too.