### PR TITLE
ESLint: add ignoreRestSiblings flag to the no-unused-vars rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,6 +43,9 @@ module.exports = {
 		// Allows Chai `expect` expressions. Now that we're on jest, hopefully we can remove this one.
 		'no-unused-expressions': 0,
 
+		// Ignore rest siblings used to omit properties from objects: const { a, b, ...rest } = props
+		'no-unused-vars': [ 'error', { ignoreRestSiblings: true } ],
+
 		// enforce our classname namespacing rules
 		'wpcalypso/jsx-classname-namespace': [
 			2,


### PR DESCRIPTION
Allow unused variables that are used to omit properties from an object:
```js
const { a, b, ...rest } = props;
```
`a` and `b` are unused variables, but yet ESLint doesn't complain about them, because they are used to omit properties from the `props` object and assign the new object to `rest`. That's a handy alternative to Lodash `omit`.

Inspired by @dmsnell's #24897 where he can avoid disabling the `no-unused-vars` rule after this PR is merged.