### PR TITLE
Activity Log: Show only basename of file in threat alert

### DIFF
--- a/client/my-sites/stats/activity-log/threat-alert.jsx
+++ b/client/my-sites/stats/activity-log/threat-alert.jsx
@@ -32,14 +32,15 @@ const detailType = threat => {
 };
 
 const headerTitle = ( translate, threat ) => {
-	const { extension } = threat;
+	const { extension, filename } = threat;
+	const basename = s => s.replace( /.*\//, '' );
 
 	switch ( detailType( threat ) ) {
 		case 'core':
 			return translate( 'The file {{filename/}} has been modified from its original.', {
 				components: {
 					filename: (
-						<code className="activity-log__threat-alert-filename">{ threat.filename }</code>
+						<code className="activity-log__threat-alert-filename">{ basename( filename ) }</code>
 					),
 				},
 			} );
@@ -48,7 +49,7 @@ const headerTitle = ( translate, threat ) => {
 			return translate( 'The file {{filename/}} contains a malicious code pattern.', {
 				components: {
 					filename: (
-						<code className="activity-log__threat-alert-filename">{ threat.filename }</code>
+						<code className="activity-log__threat-alert-filename">{ basename( filename ) }</code>
 					),
 				},
 			} );


### PR DESCRIPTION
The threat alert card header shows a terse description
of the kind of threat that VaultPress has detected.
In this patch we're refining the display so that when
we show a filename we only show the `basename()` of
that file until you open the card and see the entire thing.

**In Master**
<img width="592" alt="screen shot 2018-05-16 at 5 28 59 pm" src="https://user-images.githubusercontent.com/5431237/40127083-ec92a97e-592e-11e8-83b8-6ff6bcf16bdc.png">

**In this branch**
<img width="599" alt="screen shot 2018-05-16 at 5 26 04 pm" src="https://user-images.githubusercontent.com/5431237/40127080-eb576cc0-592e-11e8-9a6a-4f54f15f556a.png">

**Testing**

Fake data in the console dispatcher to fill the threats and
look at the header to see if it looks right. Test with various
anticipated fake files. I know this will fail if we have a file
using `\` for the path separator but the Rewind process
itself might also have the same issue so I'm unaware if it's
actually a problem here.