### PR TITLE
Lint: Fix all the lint errors in account recovery

### DIFF
--- a/client/account-recovery/forgot-username-form/index.jsx
+++ b/client/account-recovery/forgot-username-form/index.jsx
@@ -90,7 +90,6 @@ export class ForgotUsernameFormComponent extends Component {
 							onChange={ this.firstNameUpdated }
 							value={ firstName }
 							disabled={ isRequesting }
-							autoFocus
 						/>
 					</FormLabel>
 					<FormLabel>

--- a/client/account-recovery/lost-password-form/index.jsx
+++ b/client/account-recovery/lost-password-form/index.jsx
@@ -86,7 +86,6 @@ export class LostPasswordFormComponent extends Component {
 								onChange={ this.onUserLoginChanged }
 								value={ userLoginFormValue }
 								disabled={ isRequesting }
-								autoFocus
 							/>
 						</FormLabel>
 						{ requestError && (

--- a/client/account-recovery/reset-password-confirm-form/index.jsx
+++ b/client/account-recovery/reset-password-confirm-form/index.jsx
@@ -69,7 +69,6 @@ class ResetPasswordConfirmForm extends Component {
 						id="password"
 						onChange={ this.updateNewPassword }
 						value={ newPassword }
-						autoFocus
 					/>
 					<FormButton
 						className="reset-password-confirm-form__button generate-password-button"

--- a/client/account-recovery/reset-password-sms-form/index.jsx
+++ b/client/account-recovery/reset-password-sms-form/index.jsx
@@ -69,7 +69,6 @@ class ResetPasswordSmsForm extends Component {
 						disabled={ isValidating }
 						value={ this.state.candidateKey }
 						onChange={ this.updateValidationKey }
-						autoFocus
 					/>
 					{ error && <ErrorMessage error={ error } /> }
 					<FormButton


### PR DESCRIPTION
This removes the autoFocus attributes from various account recovery forms. We no longer want to use autofocus, as it presents challenges to folks using screen readers.

Should be no functional changes, but validating the various account recovery flows would be good. Note, autofocus of a text input will no longer happen.