### PR TITLE
Post Editor: refactor redirect to a route with the correct post type

### DIFF
--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -68,15 +68,16 @@ PostActions = {
 	 *
 	 * @param {Object} site   Site object
 	 * @param {Number} postId Post ID to load
+	 * @return {Promise<?Object>} The edited post object
 	 */
 	startEditingExisting: function( site, postId ) {
 		if ( ! site || ! site.ID ) {
-			return;
+			return Promise.resolve( null );
 		}
 
 		const currentPost = PostEditStore.get();
 		if ( currentPost && currentPost.site_ID === site.ID && currentPost.ID === postId ) {
-			return; // already editing same post
+			return Promise.resolve( currentPost ); // already editing same post
 		}
 
 		Dispatcher.handleViewAction( {
@@ -85,7 +86,7 @@ PostActions = {
 			postId: postId,
 		} );
 
-		wpcom
+		return wpcom
 			.site( site.ID )
 			.post( postId )
 			.get( { context: 'edit', meta: 'autosave' } )
@@ -99,12 +100,16 @@ PostActions = {
 				// Retrieve the normalized post and use it to update Redux store
 				const receivedPost = PostEditStore.get();
 				reduxDispatch( receivePost( receivedPost ) );
+
+				return receivedPost;
 			} )
 			.catch( error => {
 				Dispatcher.handleServerAction( {
 					type: 'SET_POST_LOADING_ERROR',
 					error,
 				} );
+
+				return null;
 			} );
 	},
 

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -247,8 +247,9 @@ export default {
 				startEditingPostCopy( site, postToCopyId, context );
 			} else if ( postID ) {
 				// TODO: REDUX - remove flux actions when whole post-editor is reduxified
+				const contextPath = context.path;
 				actions.startEditingExisting( site, postID ).then( editedPost => {
-					if ( context.path !== page.current ) {
+					if ( contextPath !== page.current ) {
 						// browser navigated elsewhere while the load was in progress
 						return;
 					}

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -27,7 +27,7 @@ import { getEditorPostId, getEditorPath } from 'state/ui/editor/selectors';
 import { editPost } from 'state/posts/actions';
 import wpcom from 'lib/wp';
 import Dispatcher from 'dispatcher';
-import { getFeaturedImageId } from 'lib/posts/utils';
+import { getEditURL, getFeaturedImageId } from 'lib/posts/utils';
 
 const user = User();
 
@@ -247,7 +247,12 @@ export default {
 				startEditingPostCopy( site, postToCopyId, context );
 			} else if ( postID ) {
 				// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-				actions.startEditingExisting( site, postID );
+				actions.startEditingExisting( site, postID ).then( editedPost => {
+					if ( editedPost && editedPost.type && editedPost.type !== postType ) {
+						// incorrect post type in URL
+						page.redirect( getEditURL( editedPost, site ) );
+					}
+				} );
 			} else {
 				const postOptions = { type: postType };
 

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -248,6 +248,11 @@ export default {
 			} else if ( postID ) {
 				// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 				actions.startEditingExisting( site, postID ).then( editedPost => {
+					if ( context.path !== page.current ) {
+						// browser navigated elsewhere while the load was in progress
+						return;
+					}
+
 					if ( editedPost && editedPost.type && editedPost.type !== postType ) {
 						// incorrect post type in URL
 						page.redirect( getEditURL( editedPost, site ) );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -478,14 +478,7 @@ export class PostEditor extends React.Component {
 				() => this.editor && this.editor.setEditorContent( this.state.post.content )
 			);
 		} else {
-			const postEditState = this.getPostEditState();
-			const post = postEditState.post;
-			const site = this.props.selectedSite;
-			if ( didLoad && site && ( this.props.type === 'page' ) !== utils.isPage( post ) ) {
-				// incorrect post type in URL
-				page.redirect( utils.getEditURL( post, site ) );
-			}
-			this.setState( postEditState, function() {
+			this.setState( this.getPostEditState(), function() {
 				if ( this.editor && ( didLoad || this.state.isLoadingRevision ) ) {
 					this.editor.setEditorContent( this.state.post.content, { initial: true } );
 				}


### PR DESCRIPTION
After the post editor loads the post to edit, specified by ID in the route params:
```
/page/example.blog/123
```
it checks if the post with ID=123 is actually a Page. If it's not, it redirects to:
```
/post/example.blog/123
```
or, in case of a custom post type, to:
```
/edit/jetpack-testimonial/example.blog/123
```

This PR refactors the code that does this redirect. It's moved from `PostEditor` lifecycle method to the `startEditingExisting` flow in the controller. This makes the sequence of events much clearer:
1. Start editing existing post with a gived ID
2. Wait until the post to edit loads from server
3. Check the URL type and actual post type and redirect if needed

**How to test:**
Choose a post of a particular type and enter an editor URL to your browser's location field. Does Calypso redirect if the types don't match?

To test custom post types like `jetpack-testimonial`, you need a theme that supports CPTs. I used "Dara" for testing.

This code has a chance to cause infinite redirect loops if there was a bug in the type check. During review, please verify that I haven't overlooked anything.
