### PR TITLE
Signup: restore original flow when site goals change

### DIFF
--- a/client/lib/signup/actions.js
+++ b/client/lib/signup/actions.js
@@ -73,6 +73,13 @@ const SignupActions = {
 			providedDependencies,
 		} );
 	},
+
+	changeSignupFlow( flow ) {
+		Dispatcher.handleViewAction( {
+			type: 'CHANGE_SIGNUP_FLOW',
+			flow,
+		} );
+	},
 };
 
 export default SignupActions;

--- a/client/lib/signup/test/progress-store.js
+++ b/client/lib/signup/test/progress-store.js
@@ -14,9 +14,13 @@ import sinon from 'sinon';
  * Internal dependencies
  */
 import Dispatcher from 'dispatcher';
+import flows from 'signup/config/flows';
 
 jest.mock( 'lib/user', () => () => {} );
 jest.mock( 'signup/config/steps', () => require( './mocks/signup/config/steps' ) );
+jest.mock( 'signup/config/flows', () => ( {
+	getFlow: jest.fn(),
+} ) );
 
 describe( 'progress-store', () => {
 	let SignupProgressStore, SignupActions;
@@ -126,5 +130,19 @@ describe( 'progress-store', () => {
 
 		SignupActions.processedSignupStep( { stepName: 'site-selection' } );
 		assert.equal( SignupProgressStore.get()[ 0 ].status, 'completed' );
+	} );
+
+	test( 'should remove unneeded steps when flow changes', () => {
+		assert.ok( SignupProgressStore.get().length > 1 );
+
+		flows.getFlow.mockReturnValueOnce( { steps: [ 'site-selection' ] } );
+		SignupActions.changeSignupFlow( 'new-flow' );
+
+		assert.equal( SignupProgressStore.get().length, 1 );
+
+		flows.getFlow.mockReturnValueOnce( { steps: [ 'no-step-matches' ] } );
+		SignupActions.changeSignupFlow( 'another-new-flow' );
+
+		assert.equal( SignupProgressStore.get().length, 0 );
 	} );
 } );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -99,6 +99,7 @@ class Signup extends React.Component {
 			loginHandler: null,
 			hasCartItems: false,
 			plans: false,
+			previousFlowName: null,
 		};
 	}
 
@@ -421,6 +422,11 @@ class Signup extends React.Component {
 			nextProgressItem = this.state.progress[ currentStepIndex + 1 ],
 			nextStepSection = ( nextProgressItem && nextProgressItem.stepSectionName ) || '';
 
+		if ( nextFlowName !== this.props.flowName ) {
+			SignupActions.changeSignupFlow( nextFlowName );
+			this.setState( { previousFlowName: this.props.flowName } );
+		}
+
 		this.goToStep( nextStepName, nextStepSection, nextFlowName );
 	};
 
@@ -498,6 +504,7 @@ class Signup extends React.Component {
 						meta={ flow.meta || {} }
 						goToNextStep={ this.goToNextStep }
 						goToStep={ this.goToStep }
+						previousFlowName={ this.state.previousFlowName }
 						flowName={ this.props.flowName }
 						signupProgress={ this.state.progress }
 						signupDependencies={ this.props.signupDependencies }

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -240,12 +240,13 @@ class AboutStep extends Component {
 
 	handleSubmit = event => {
 		event.preventDefault();
-		const { goToNextStep, stepName, translate } = this.props;
+		const { goToNextStep, stepName, flowName, previousFlowName, translate } = this.props;
 
 		//Defaults
 		let themeRepo = 'pub/radcliffe-2',
 			designType = 'blog',
-			siteTitleValue = 'Site Title';
+			siteTitleValue = 'Site Title',
+			nextFlowName = flowName;
 
 		//Inputs
 		const siteTitleInput = formState.getFieldValue( this.state.form, 'siteTitle' );
@@ -303,7 +304,12 @@ class AboutStep extends Component {
 		this.props.recordTracksEvent( 'calypso_signup_actions_user_input', eventAttributes );
 
 		//Store
-		const nextFlowName = designType === DESIGN_TYPE_STORE ? 'store-nux' : this.props.flowName;
+		if ( designType === DESIGN_TYPE_STORE ) {
+			nextFlowName =
+				siteGoalsArray.indexOf( 'sell' ) === -1 && previousFlowName
+					? previousFlowName
+					: 'store-nux';
+		}
 
 		//Pressable
 		if (


### PR DESCRIPTION
When you choose `Sell products or collect payments` on the `About` page in the site creation process, you will be redirected to `store-nux` flow regardless of the original flow so you're allowed to pick a theme for your store. However, the original flow will not be restored even if you're back to the first step and choose no site goals, which can be annoying.

When you select no site goals, this PR will restore the original flow if available.

## How to reproduce/test

See the reproduction steps @ianstewart reported:

> Thing I noticed in signup in Chrome right now:
>
> - Select sell products or payments on first screen, click continue
> - See choose a store theme and skip
> - Get to domain selection, click back in signup
> - Click back on theme selection
> - unselect sell products or collect payments, select nothing
> - Click Continue
> - See choose a store theme screen
>
> I expected: not to see the choose a store theme page again
> In chrome, proxied, incognito, seeing staging.