### PR TITLE
Activity: tweak threats styling

### DIFF
--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -79,8 +79,17 @@
 }
 
 .activity-log__threat-alert {
+	padding: 8px 0;
+	font-size: 14px;
+	border-left: 3px solid $alert-red;
+
 	.foldable-card__main {
 		flex: unset;
+	}
+
+	.activity-log-item__activity-icon {
+		margin-right: 16px;
+		padding: 8px;
 	}
 
 	.diff-viewer,
@@ -90,26 +99,36 @@
 	}
 }
 
+.foldable-card.is-compact.activity-log__threat-alert .foldable-card__header {
+	padding: 16px;
+}
+
 .activity-log__threat-alert-header {
-	margin-left: 8px;
 	color: $gray;
+}
 
-	.activity-log__threat-alert-title {
-		color: black;
-	}
+.activity-log__threat-alert-title {
+	font-weight: 500;
+	color: $gray-dark;
 
-	.activity-log__threat-alert-slug {
-		font-weight: bold;
+	code {
+		padding: 0 2px;
+		font-size: 13px;
+		font-weight: 600;
 	}
 }
 
+.activity-log__threat-alert-slug {
+	font-weight: 500;
+}
+
 .activity-log__threat-alert-signature {
-	font-weight: bold;
+	font-weight: 500;
 }
 
 .activity-log__threat-alert-filename {
 	padding: 4px;
-	color: #000;
+	font-size: 14px;
 	font-weight: 500;
 }
 

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -111,7 +111,7 @@
 	font-weight: 500;
 	color: $gray-dark;
 
-	code {
+	.activity-log__threat-alert-filename {
 		padding: 0 2px;
 		font-size: 13px;
 		font-weight: 600;

--- a/client/my-sites/stats/activity-log/threat-alert.jsx
+++ b/client/my-sites/stats/activity-log/threat-alert.jsx
@@ -61,7 +61,7 @@ const headerTitle = ( translate, threat ) => {
 					components: {
 						pluginSlug: <span className="activity-log__threat-alert-slug">{ extension.slug }</span>,
 						version: (
-							<code className="activity-log__threat-alert-version">{ extension.version }</code>
+							<span className="activity-log__threat-alert-version">{ extension.version }</span>
 						),
 					},
 				}
@@ -74,7 +74,7 @@ const headerTitle = ( translate, threat ) => {
 					components: {
 						themeSlug: <span className="activity-log__threat-alert-slug">{ extension.slug }</span>,
 						version: (
-							<code className="activity-log__threat-alert-version">{ extension.version }</code>
+							<span className="activity-log__threat-alert-version">{ extension.version }</span>
 						),
 					},
 				}
@@ -89,10 +89,10 @@ const headerTitle = ( translate, threat ) => {
 const headerSubtitle = ( translate, threat ) => {
 	switch ( detailType( threat ) ) {
 		case 'core':
-			return translate( 'Vulnerability found in WordPress' );
+			return translate( 'Vulnerability Found in WordPress' );
 
 		case 'file':
-			return translate( 'Threat found ({{signature/}})', {
+			return translate( 'Threat Found ({{signature/}})', {
 				components: {
 					signature: (
 						<span className="activity-log__threat-alert-signature">{ threat.signature }</span>
@@ -101,10 +101,10 @@ const headerSubtitle = ( translate, threat ) => {
 			} );
 
 		case 'plugin':
-			return translate( 'Vulnerability found in Plugin' );
+			return translate( 'Vulnerability Found in Plugin' );
 
 		case 'theme':
-			return translate( 'Vulnerability found in Theme' );
+			return translate( 'Vulnerability Found in Theme' );
 
 		case 'none':
 		default:
@@ -135,15 +135,18 @@ export class ThreatAlert extends Component {
 									dateFormat="ll"
 								/>
 							</div>
-							<span>{ headerSubtitle( translate, threat ) }</span>
+							<span className="activity-log__threat-alert-type">
+								{ headerSubtitle( translate, threat ) }
+							</span>
 						</div>
 					</Fragment>
 				}
 			>
+				<p className="activity-log__threat-alert-description">{ threat.description }</p>
 				{ threat.filename ? (
 					<Fragment>
 						<p>
-							{ translate( '{{threatSignature/}} in:', {
+							{ translate( 'Threat {{threatSignature/}} found in file:', {
 								comment: 'filename follows in separate line; e.g. "PHP.Injection.5 in: `post.php`"',
 								components: {
 									threatSignature: (
@@ -159,7 +162,6 @@ export class ThreatAlert extends Component {
 				) : (
 					<p className="activity-log__threat-alert-signature">{ threat.signature }</p>
 				) }
-				<p className="activity-log__threat-alert-description">{ threat.description }</p>
 				{ threat.context && <MarkedLines context={ threat.context } /> }
 				{ threat.diff && <DiffViewer diff={ threat.diff } /> }
 			</FoldableCard>

--- a/client/my-sites/stats/activity-log/threat-alert.jsx
+++ b/client/my-sites/stats/activity-log/threat-alert.jsx
@@ -89,10 +89,10 @@ const headerTitle = ( translate, threat ) => {
 const headerSubtitle = ( translate, threat ) => {
 	switch ( detailType( threat ) ) {
 		case 'core':
-			return translate( 'Vulnerability Found in WordPress' );
+			return translate( 'Vulnerability found in WordPress' );
 
 		case 'file':
-			return translate( 'Threat Found ({{signature/}})', {
+			return translate( 'Threat found ({{signature/}})', {
 				components: {
 					signature: (
 						<span className="activity-log__threat-alert-signature">{ threat.signature }</span>
@@ -101,10 +101,10 @@ const headerSubtitle = ( translate, threat ) => {
 			} );
 
 		case 'plugin':
-			return translate( 'Vulnerability Found in Plugin' );
+			return translate( 'Vulnerability found in plugin' );
 
 		case 'theme':
-			return translate( 'Vulnerability Found in Theme' );
+			return translate( 'Vulnerability found in theme' );
 
 		case 'none':
 		default:


### PR DESCRIPTION
This set of changes tweak the threats styling and change some language to match the current patterns.

Notably:

- Reducing the icon size.
- Tweak overall padding of card.
- Add red alert border.
- Make font weights consistent across the board.
- Reorder description to the top of the expanded section.

### Before

<img width="862" alt="screen shot 2018-05-17 at 11 54 53" src="https://user-images.githubusercontent.com/390760/40176333-f45b3370-59d2-11e8-84aa-527cded73d4c.png">

### After

<img width="863" alt="screen shot 2018-05-17 at 13 07 17" src="https://user-images.githubusercontent.com/390760/40176433-45625708-59d3-11e8-82f3-daf42652d471.png">