### PR TITLE
Add styles for hiding toc-jump in support articles

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -335,6 +335,11 @@
 	}
 }
 
+// WP.com support Full Post View Styles
+.blog-9619154 .reader-full-post__story-content .toc-jump {
+	display: none;
+}
+
 // gizmodo fixes
 .reader-full-post.feed-10080096 {
 	.align--bleed {


### PR DESCRIPTION
While working on adding support articles inline in inline-help I found that I had to hide `.toc-jump` from the article content.

This PR does the same to those articles when found in reader. 
I'm not sure, though, if they are actually naturally accessible from anywhere without directly linking/typing out the address so this could be a non-issue.

### Testing

- Go to https://wordpress.com/read/blogs/9619154/posts/134940 to see the issue
- Patch this PR and go http://calypso.localhost:3000/read/blogs/9619154/posts/134940
  - Note that the `↑ Table of Contents ↑` links are all hidden