### PR TITLE
Activity: use sentence case for all item summaries

### DIFF
--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -206,6 +206,8 @@
 }
 
 .activity-log-item__actor-role {
+	text-transform: capitalize;
+
 	@include breakpoint( '<480px' ) {
 		display: inline-block;
 		margin-left: 8px;
@@ -214,7 +216,6 @@
 
 .activity-log-item__actor-role,
 .activity-log-item__description-summary {
-	text-transform: capitalize;
 	font-size: 12px;
 	color: $gray-text-min;
 


### PR DESCRIPTION
This PR changes the way we capitalize items summaries — we're now using sentence case for all of them.

### Before

<img width="872" alt="screen shot 2018-05-17 at 16 02 40" src="https://user-images.githubusercontent.com/390760/40186035-01261192-59ec-11e8-9a6d-846d6a9a34e2.png">


### After

<img width="879" alt="screen shot 2018-05-17 at 16 03 28" src="https://user-images.githubusercontent.com/390760/40186033-febf81a4-59eb-11e8-9462-da38a9137a17.png">
