### PR TITLE
Purchases: Use redux store for user

### DIFF
--- a/client/me/purchases/cancel-privacy-protection/index.jsx
+++ b/client/me/purchases/cancel-privacy-protection/index.jsx
@@ -31,12 +31,10 @@ import Notice from 'components/notice';
 import { managePurchase, purchasesRoot } from 'me/purchases/paths';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import titles from 'me/purchases/titles';
-import userFactory from 'lib/user';
 import { CALYPSO_CONTACT } from 'lib/url/support';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import TrackPurchasePageView from 'me/purchases/track-purchase-page-view';
-
-const user = userFactory();
+import { getCurrentUserId } from 'state/current-user/selectors';
 
 class CancelPrivacyProtection extends Component {
 	static propTypes = {
@@ -211,7 +209,7 @@ class CancelPrivacyProtection extends Component {
 					path="/me/purchases/:site/:purchaseId/cancel-privacy-protection"
 					title="Purchases > Cancel Privacy Protection"
 				/>
-				<QueryUserPurchases userId={ user.get().ID } />
+				<QueryUserPurchases userId={ this.props.userId } />
 				<HeaderCake backHref={ managePurchase( this.props.siteSlug, this.props.purchaseId ) }>
 					{ titles.cancelPrivacyProtection }
 				</HeaderCake>
@@ -238,6 +236,7 @@ export default connect(
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		purchase: getByPurchaseId( state, props.purchaseId ),
 		selectedSite: getSelectedSite( state ),
+		userId: getCurrentUserId( state ),
 	} ),
 	{ cancelPrivacyProtection }
 )( localize( CancelPrivacyProtection ) );

--- a/client/me/purchases/cancel-privacy-protection/index.jsx
+++ b/client/me/purchases/cancel-privacy-protection/index.jsx
@@ -44,6 +44,7 @@ class CancelPrivacyProtection extends Component {
 		purchaseId: PropTypes.number.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 		siteSlug: PropTypes.string.isRequired,
+		userId: PropTypes.number,
 	};
 
 	static initialState = {

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -50,6 +50,7 @@ class CancelPurchase extends React.Component {
 		purchaseId: PropTypes.number.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 		siteSlug: PropTypes.string.isRequired,
+		userId: PropTypes.number,
 	};
 
 	state = {

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -38,10 +38,8 @@ import { managePurchase, purchasesRoot } from 'me/purchases/paths';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import ProductLink from 'me/purchases/product-link';
 import titles from 'me/purchases/titles';
-import userFactory from 'lib/user';
 import TrackPurchasePageView from 'me/purchases/track-purchase-page-view';
-
-const user = userFactory();
+import { getCurrentUserId } from 'state/current-user/selectors';
 
 class CancelPurchase extends React.Component {
 	static propTypes = {
@@ -146,7 +144,7 @@ class CancelPurchase extends React.Component {
 		if ( isDataLoading( this.props ) ) {
 			return (
 				<div>
-					<QueryUserPurchases userId={ user.get().ID } />
+					<QueryUserPurchases userId={ this.props.userId } />
 					<CancelPurchaseLoadingPlaceholder
 						purchaseId={ this.props.purchaseId }
 						selectedSite={ this.props.selectedSite }
@@ -225,5 +223,6 @@ export default connect( ( state, props ) => {
 		purchase,
 		includedDomainPurchase: getIncludedDomainPurchase( state, purchase ),
 		selectedSite: getSelectedSite( state ),
+		userId: getCurrentUserId( state ),
 	};
 } )( localize( CancelPurchase ) );

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -53,6 +53,7 @@ class ConfirmCancelDomain extends React.Component {
 		selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 		setAllSitesSelected: PropTypes.func.isRequired,
 		siteSlug: PropTypes.string.isRequired,
+		userId: PropTypes.number,
 	};
 
 	state = {

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -39,11 +39,9 @@ import { refreshSitePlans } from 'state/sites/plans/actions';
 import SelectDropdown from 'components/select-dropdown';
 import { setAllSitesSelected } from 'state/ui/actions';
 import titles from 'me/purchases/titles';
-import userFactory from 'lib/user';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import TrackPurchasePageView from 'me/purchases/track-purchase-page-view';
-
-const user = userFactory();
+import { getCurrentUserId } from 'state/current-user/selectors';
 
 class ConfirmCancelDomain extends React.Component {
 	static propTypes = {
@@ -244,7 +242,7 @@ class ConfirmCancelDomain extends React.Component {
 		if ( isDataLoading( this.props ) ) {
 			return (
 				<div>
-					<QueryUserPurchases userId={ user.get().ID } />
+					<QueryUserPurchases userId={ this.props.userId } />
 					<ConfirmCancelDomainLoadingPlaceholder
 						purchaseId={ this.props.purchaseId }
 						selectedSite={ this.props.selectedSite }
@@ -311,6 +309,7 @@ export default connect(
 			isDomainOnlySite: isDomainOnly( state, selectedSite && selectedSite.ID ),
 			purchase: getByPurchaseId( state, props.purchaseId ),
 			selectedSite,
+			userId: getCurrentUserId( state ),
 		};
 	},
 	{

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -83,6 +83,7 @@ class ManagePurchase extends Component {
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
 		purchase: PropTypes.object,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
+		userId: PropTypes.number,
 	};
 
 	componentWillMount() {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -71,12 +71,10 @@ import VerticalNavItem from 'components/vertical-nav/item';
 import { cancelPurchase, cancelPrivacyProtection, purchasesRoot } from '../paths';
 import { CALYPSO_CONTACT } from 'lib/url/support';
 import titles from 'me/purchases/titles';
-import userFactory from 'lib/user';
 import { addItems } from 'lib/upgrades/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import TrackPurchasePageView from 'me/purchases/track-purchase-page-view';
-
-const user = userFactory();
+import { getCurrentUserId } from 'state/current-user/selectors';
 
 class ManagePurchase extends Component {
 	static propTypes = {
@@ -440,7 +438,7 @@ class ManagePurchase extends Component {
 					path="/me/purchases/:site/:purchaseId"
 					title="Purchases > Manage Purchase"
 				/>
-				<QueryUserPurchases userId={ user.get().ID } />
+				<QueryUserPurchases userId={ this.props.userId } />
 				{ isPurchaseTheme && (
 					<QueryCanonicalTheme siteId={ selectedSiteId } themeId={ purchase.meta } />
 				) }
@@ -478,5 +476,6 @@ export default connect( ( state, props ) => {
 		isPurchaseTheme,
 		theme: isPurchaseTheme && getCanonicalTheme( state, selectedSiteId, purchase.meta ),
 		isAtomicSite: selectedSite && isSiteAtomic( state, selectedSiteId ),
+		userId: getCurrentUserId( state ),
 	};
 } )( localize( ManagePurchase ) );

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -22,12 +22,10 @@ import Main from 'components/main';
 import PurchaseCardDetails from 'me/purchases/components/purchase-card-details';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import titles from 'me/purchases/titles';
-import userFactory from 'lib/user';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { managePurchase } from 'me/purchases/paths';
 import TrackPurchasePageView from 'me/purchases/track-purchase-page-view';
-
-const user = userFactory();
+import { getCurrentUserId } from 'state/current-user/selectors';
 
 class AddCardDetails extends PurchaseCardDetails {
 	static propTypes = {
@@ -52,7 +50,7 @@ class AddCardDetails extends PurchaseCardDetails {
 		if ( isDataLoading( this.props ) ) {
 			return (
 				<div>
-					<QueryUserPurchases userId={ user.get().ID } />
+					<QueryUserPurchases userId={ this.props.userId } />
 
 					<CreditCardFormLoadingPlaceholder title={ titles.addCardDetails } />
 				</div>
@@ -90,6 +88,7 @@ const mapStateToProps = ( state, { purchaseId } ) => {
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		purchase: getByPurchaseId( state, purchaseId ),
 		selectedSite: getSelectedSite( state ),
+		userId: getCurrentUserId( state ),
 	};
 };
 

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -36,6 +36,7 @@ class AddCardDetails extends PurchaseCardDetails {
 		purchase: PropTypes.object,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 		siteSlug: PropTypes.string.isRequired,
+		userId: PropTypes.number,
 	};
 
 	componentWillMount() {

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -40,6 +40,7 @@ class EditCardDetails extends PurchaseCardDetails {
 		purchase: PropTypes.object,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 		siteSlug: PropTypes.string.isRequired,
+		userId: PropTypes.number,
 	};
 
 	componentWillMount() {

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -24,12 +24,10 @@ import PurchaseCardDetails from 'me/purchases/components/purchase-card-details';
 import QueryStoredCards from 'components/data/query-stored-cards';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import titles from 'me/purchases/titles';
-import userFactory from 'lib/user';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { managePurchase } from 'me/purchases/paths';
 import TrackPurchasePageView from 'me/purchases/track-purchase-page-view';
-
-const user = userFactory();
+import { getCurrentUserId } from 'state/current-user/selectors';
 
 class EditCardDetails extends PurchaseCardDetails {
 	static propTypes = {
@@ -58,7 +56,7 @@ class EditCardDetails extends PurchaseCardDetails {
 				<div>
 					<QueryStoredCards />
 
-					<QueryUserPurchases userId={ user.get().ID } />
+					<QueryUserPurchases userId={ this.props.userId } />
 
 					<CreditCardFormLoadingPlaceholder title={ titles.editCardDetails } />
 				</div>
@@ -91,16 +89,15 @@ class EditCardDetails extends PurchaseCardDetails {
 	}
 }
 
-const mapStateToProps = ( state, { cardId, purchaseId } ) => {
-	return {
-		card: getStoredCardById( state, cardId ),
-		hasLoadedSites: ! isRequestingSites( state ),
-		hasLoadedStoredCardsFromServer: hasLoadedStoredCardsFromServer( state ),
-		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
-		purchase: getByPurchaseId( state, purchaseId ),
-		selectedSite: getSelectedSite( state ),
-	};
-};
+const mapStateToProps = ( state, { cardId, purchaseId } ) => ( {
+	card: getStoredCardById( state, cardId ),
+	hasLoadedSites: ! isRequestingSites( state ),
+	hasLoadedStoredCardsFromServer: hasLoadedStoredCardsFromServer( state ),
+	hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
+	purchase: getByPurchaseId( state, purchaseId ),
+	selectedSite: getSelectedSite( state ),
+	userId: getCurrentUserId( state ),
+} );
 
 const mapDispatchToProps = {
 	clearPurchases,

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -59,6 +59,7 @@ class RemovePurchase extends Component {
 		purchase: PropTypes.object,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 		setAllSitesSelected: PropTypes.func.isRequired,
+		userId: PropTypes.number.isRequired,
 	};
 
 	state = {

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -36,15 +36,13 @@ import { removePurchase } from 'state/purchases/actions';
 import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 import FormSectionHeading from 'components/forms/form-section-heading';
-import userFactory from 'lib/user';
 import { isDomainOnlySite as isDomainOnly, isSiteAutomatedTransfer } from 'state/selectors';
 import { receiveDeletedSite } from 'state/sites/actions';
 import { setAllSitesSelected } from 'state/ui/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import HappychatButton from 'components/happychat/button';
 import isPrecancellationChatAvailable from 'state/happychat/selectors/is-precancellation-chat-available';
-
-const user = userFactory();
+import { getCurrentUserId } from 'state/current-user/selectors';
 
 /**
  * Module dependencies
@@ -191,7 +189,7 @@ class RemovePurchase extends Component {
 
 		this.recordEvent( 'calypso_purchases_cancel_form_submit' );
 
-		this.props.removePurchase( purchase.id, user.get().ID ).then( () => {
+		this.props.removePurchase( purchase.id, this.props.userId ).then( () => {
 			const productName = getName( purchase );
 			const { purchasesError } = this.props;
 
@@ -499,6 +497,7 @@ export default connect(
 		isChatActive: hasActiveHappychatSession( state ),
 		purchasesError: getPurchasesError( state ),
 		precancellationChatAvailable: isPrecancellationChatAvailable( state ),
+		userId: getCurrentUserId( state ),
 	} ),
 	{
 		receiveDeletedSite,


### PR DESCRIPTION
`lib/user` was being used throughout purchases. Update to pull user data from the redux store.

All of the usage was getting the current user ID. This has been done by connecting with a the `getCurrentUserId` selector.

`lib/user` is used in the purchases controller to check for sites. That data is available via selectors but the changes are left for another PR.

## Testing
Make sure you're able to view the various purchase pages and they continue to work as expected:

https://calypso.live/me/purchases/?branch=update/purchases-redux-user

- `/me/purchases/:SITE_SLUG/:PURCHASE_ID`
- `/me/purchases/:SITE_SLUG/:PURCHASE_ID/confirm-cancel-domain`
- `/me/purchases/:SITE_SLUG/:PURCHASE_ID/cancel`
- `/me/purchases/:SITE_SLUG/:PURCHASE_ID/payment/add`
- `/me/purchases/:SITE_SLUG/:PURCHASE_ID/payment/edit/:CARD_ID`
- `/me/purchases/:SITE_SLUG/:PURCHASE_ID/cancel-privacy-protection`