### PR TITLE
Podcast: add PodcastCoverImage block

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -50,6 +50,7 @@
 @import 'blocks/login/style';
 @import 'blocks/payment-methods/style';
 @import 'blocks/plan-thank-you-card/style';
+@import 'blocks/podcast-cover-image/style';
 @import 'blocks/post-edit-button/style';
 @import 'blocks/post-item/style';
 @import 'blocks/post-likes/style';

--- a/client/blocks/podcast-cover-image/README.md
+++ b/client/blocks/podcast-cover-image/README.md
@@ -1,0 +1,18 @@
+Podcast Cover Image
+=========
+
+This component is used to display the podcast cover image for a site.
+
+#### How to use:
+
+```js
+import PodcastCoverImage from 'blocks/podcast-cover-image';
+
+render: function() {
+	return <PodcastCoverImage size={ 96 } />
+}
+```
+
+#### Props
+
+* `size`: (default: 32) change the requested image size.

--- a/client/blocks/podcast-cover-image/index.jsx
+++ b/client/blocks/podcast-cover-image/index.jsx
@@ -1,0 +1,75 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import classNames from 'classnames';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Image from 'components/image';
+import Spinner from 'components/spinner';
+import QuerySites from 'components/data/query-sites';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isTransientMedia } from 'state/selectors';
+import {
+	getPodcastingCoverImageUrl,
+	getPodcastingCoverImageId,
+} from 'state/selectors/get-podcasting-cover-image';
+import resizeImageUrl from 'lib/resize-image-url';
+
+function PodcastCoverImage( { siteId, coverImageUrl, size, isTransientIcon } ) {
+	const imageSrc = resizeImageUrl( coverImageUrl, size );
+
+	const classes = classNames( 'podcast-cover-image', {
+		'is-blank': ! imageSrc,
+		'is-transient': isTransientIcon,
+	} );
+
+	const style = {
+		height: size,
+		width: size,
+		lineHeight: size + 'px',
+		fontSize: size + 'px',
+	};
+
+	return (
+		<div className={ classes } style={ style }>
+			{ siteId > 0 && <QuerySites siteId={ siteId } /> }
+			{ imageSrc ? (
+				<Image className="podcast-cover-image__img" src={ imageSrc } alt="" />
+			) : (
+				<Gridicon icon="globe" size={ Math.round( size / 1.3 ) } />
+			) }
+			{ isTransientIcon && <Spinner /> }
+		</div>
+	);
+}
+
+PodcastCoverImage.propTypes = {
+	siteId: PropTypes.number,
+	coverImageUrl: PropTypes.string,
+	size: PropTypes.number,
+	isTransientImage: PropTypes.bool,
+};
+
+PodcastCoverImage.defaultProps = {
+	size: 32,
+};
+
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+	const imageId = getPodcastingCoverImageId( state, siteId );
+
+	return {
+		siteId,
+		coverImageUrl: getPodcastingCoverImageUrl( state, siteId ),
+		isTransientImage: isTransientMedia( state, siteId, imageId ),
+	};
+} )( PodcastCoverImage );

--- a/client/blocks/podcast-cover-image/index.jsx
+++ b/client/blocks/podcast-cover-image/index.jsx
@@ -48,8 +48,6 @@ class PodcastCoverImage extends PureComponent {
 		const style = {
 			height: size,
 			width: size,
-			lineHeight: size + 'px',
-			fontSize: size + 'px',
 		};
 
 		return (

--- a/client/blocks/podcast-cover-image/index.jsx
+++ b/client/blocks/podcast-cover-image/index.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
@@ -24,44 +24,47 @@ import {
 } from 'state/selectors/get-podcasting-cover-image';
 import resizeImageUrl from 'lib/resize-image-url';
 
-function PodcastCoverImage( { siteId, coverImageUrl, size, isTransientIcon } ) {
-	const imageSrc = resizeImageUrl( coverImageUrl, size );
-
-	const classes = classNames( 'podcast-cover-image', {
-		'is-blank': ! imageSrc,
-		'is-transient': isTransientIcon,
-	} );
-
-	const style = {
-		height: size,
-		width: size,
-		lineHeight: size + 'px',
-		fontSize: size + 'px',
+class PodcastCoverImage extends PureComponent {
+	static propTypes = {
+		siteId: PropTypes.number,
+		coverImageUrl: PropTypes.string,
+		size: PropTypes.number,
+		isTransientImage: PropTypes.bool,
 	};
 
-	return (
-		<div className={ classes } style={ style }>
-			{ siteId > 0 && <QuerySites siteId={ siteId } /> }
-			{ imageSrc ? (
-				<Image className="podcast-cover-image__img" src={ imageSrc } alt="" />
-			) : (
-				<Gridicon icon="globe" size={ Math.round( size / 1.3 ) } />
-			) }
-			{ isTransientIcon && <Spinner /> }
-		</div>
-	);
+	static defaultProps = {
+		size: 32,
+	};
+
+	render() {
+		const { siteId, coverImageUrl, size, isTransientIcon } = this.props;
+		const imageSrc = resizeImageUrl( coverImageUrl, size );
+
+		const classes = classNames( 'podcast-cover-image', {
+			'is-blank': ! imageSrc,
+			'is-transient': isTransientIcon,
+		} );
+
+		const style = {
+			height: size,
+			width: size,
+			lineHeight: size + 'px',
+			fontSize: size + 'px',
+		};
+
+		return (
+			<div className={ classes } style={ style }>
+				{ siteId > 0 && <QuerySites siteId={ siteId } /> }
+				{ imageSrc ? (
+					<Image className="podcast-cover-image__img" src={ imageSrc } alt="" />
+				) : (
+					<Gridicon icon="globe" size={ Math.round( size / 1.3 ) } />
+				) }
+				{ isTransientIcon && <Spinner /> }
+			</div>
+		);
+	}
 }
-
-PodcastCoverImage.propTypes = {
-	siteId: PropTypes.number,
-	coverImageUrl: PropTypes.string,
-	size: PropTypes.number,
-	isTransientImage: PropTypes.bool,
-};
-
-PodcastCoverImage.defaultProps = {
-	size: 32,
-};
 
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );

--- a/client/blocks/podcast-cover-image/index.jsx
+++ b/client/blocks/podcast-cover-image/index.jsx
@@ -56,7 +56,7 @@ class PodcastCoverImage extends PureComponent {
 				{ imageSrc ? (
 					<Image className="podcast-cover-image__img" src={ imageSrc } alt="" />
 				) : (
-					<span className="podcast-cover-image__placeholder">{ translate( 'No image set.' ) }</span>
+					<span className="podcast-cover-image__placeholder">{ translate( 'No image set' ) }</span>
 				) }
 				{ isTransientIcon && <Spinner /> }
 			</div>

--- a/client/blocks/podcast-cover-image/index.jsx
+++ b/client/blocks/podcast-cover-image/index.jsx
@@ -7,8 +7,8 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -37,7 +37,7 @@ class PodcastCoverImage extends PureComponent {
 	};
 
 	render() {
-		const { siteId, coverImageUrl, size, isTransientIcon } = this.props;
+		const { siteId, coverImageUrl, size, isTransientIcon, translate } = this.props;
 		const imageSrc = resizeImageUrl( coverImageUrl, size );
 
 		const classes = classNames( 'podcast-cover-image', {
@@ -56,7 +56,7 @@ class PodcastCoverImage extends PureComponent {
 				{ imageSrc ? (
 					<Image className="podcast-cover-image__img" src={ imageSrc } alt="" />
 				) : (
-					<Gridicon icon="globe" size={ Math.round( size / 1.3 ) } />
+					<span className="podcast-cover-image__placeholder">{ translate( 'No image set.' ) }</span>
 				) }
 				{ isTransientIcon && <Spinner /> }
 			</div>
@@ -73,4 +73,4 @@ export default connect( state => {
 		coverImageUrl: getPodcastingCoverImageUrl( state, siteId ),
 		isTransientImage: isTransientMedia( state, siteId, imageId ),
 	};
-} )( PodcastCoverImage );
+} )( localize( PodcastCoverImage ) );

--- a/client/blocks/podcast-cover-image/style.scss
+++ b/client/blocks/podcast-cover-image/style.scss
@@ -1,0 +1,31 @@
+.podcast-cover-image {
+	position: relative;
+	overflow: hidden;
+	display: flex;
+	margin: 0;
+	text-align: center;
+
+	// Globe icon for sites without an icon
+	&.is-blank {
+		background: $gray-lighten-20;
+		.gridicon {
+			color: $white;
+			margin: auto;
+		}
+	}
+}
+
+.podcast-cover-image.is-transient .spinner {
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	background-color: rgba( $white, 0.75 );
+}
+
+.podcast-cover-image__img {
+	align-self: center;
+	background: $transparent;
+	position: relative;
+}

--- a/client/blocks/podcast-cover-image/style.scss
+++ b/client/blocks/podcast-cover-image/style.scss
@@ -4,15 +4,7 @@
 	display: flex;
 	margin: 0;
 	text-align: center;
-
-	// Globe icon for sites without an icon
-	&.is-blank {
-		background: $gray-lighten-20;
-		.gridicon {
-			color: $white;
-			margin: auto;
-		}
-	}
+	border: 1px solid $gray-lighten-20;
 }
 
 .podcast-cover-image.is-transient .spinner {
@@ -28,4 +20,15 @@
 	align-self: center;
 	background: $transparent;
 	position: relative;
+}
+
+.podcast-cover-image__placeholder {
+	color: $gray-text-min;
+	display: block;
+	font-size: 13px;
+	font-style: italic;
+	font-weight: 400;
+	margin: 0 7px;
+	text-align: center;
+	align-self: center;
 }

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -26,6 +26,7 @@ import FormTextarea from 'components/forms/form-textarea';
 import HeaderCake from 'components/header-cake';
 import QueryTerms from 'components/data/query-terms';
 import TermTreeSelector from 'blocks/term-tree-selector';
+import PodcastCoverImage from 'blocks/podcast-cover-image';
 import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
 import podcastingTopics from './topics';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -206,6 +207,10 @@ class PodcastingDetails extends Component {
 							) }
 						</FormFieldset>
 						<div className="podcasting-details__basic-settings">
+							<FormFieldset className="podcasting-details__cover-image">
+								<FormLabel>{ translate( 'Podcast Cover Image' ) }</FormLabel>
+								<PodcastCoverImage size={ 96 } />
+							</FormFieldset>
 							{ this.renderTextField( {
 								key: 'podcasting_title',
 								label: translate( 'Title' ),

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -208,7 +208,7 @@ class PodcastingDetails extends Component {
 						</FormFieldset>
 						<div className="podcasting-details__basic-settings">
 							<FormFieldset className="podcasting-details__cover-image">
-								<FormLabel>{ translate( 'Podcast Cover Image' ) }</FormLabel>
+								<FormLabel>{ translate( 'Cover Image' ) }</FormLabel>
 								<PodcastCoverImage size={ 96 } />
 							</FormFieldset>
 							{ this.renderTextField( {

--- a/client/state/selectors/get-podcasting-cover-image.js
+++ b/client/state/selectors/get-podcasting-cover-image.js
@@ -1,0 +1,28 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns the Podcasting Cover Image URL for a given site ID.
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {Number}  siteId  Site ID
+ * @return {string}          Cover Image URL or null if not found
+ */
+export function getPodcastingCoverImageUrl( state, siteId ) {
+	return get( state.siteSettings.items, [ siteId, 'podcasting_image' ], null );
+}
+
+/**
+ * Returns the Podcasting Cover Image ID for a given site ID.
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {Number}  siteId  Site ID
+ * @return {Number}          Cover Image ID or null if not found
+ */
+export function getPodcastingCoverImageId( state, siteId ) {
+	return get( state.siteSettings.items, [ siteId, 'podcasting_image_id' ], null );
+}


### PR DESCRIPTION
This adds a `PodcastCoverImage` block that renders the site's `podcasting_image` option as a thumbnail on the Podcasting Details settings page.

<img width="115" alt="podcast-cover-image" src="https://user-images.githubusercontent.com/942359/40206072-8c1a9aa6-59fc-11e8-8ad3-59386d658336.png">

**To test:**
- On a site with podcasting enabled, navigate to Settings > Writing > Manage Podcast
- If no podcast image is set, the fallback text (en: "No image set.") should be shown
- If an image is set via url (legacy) in wp-admin > Settings > Media > Podcasting, the image should be rendered with aspect ratio in tact
- If an image is set via `podcasting_image_id` (future) using wp-cli, the image should be rendered with aspect ration in tact
