### PR TITLE
Domains: Remove strikethrough price feature

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 
@@ -62,24 +61,10 @@ class DomainProductPrice extends React.Component {
 
 	renderIncludedInPremium() {
 		const { translate } = this.props;
-		const shouldShowStrikethrough = abtest( 'signupDomainStrikethruPrice' ) === 'enabled';
 
 		return (
 			<div className="domain-product-price domain-product-price__is-with-plans-only">
-				{ shouldShowStrikethrough && (
-					<span className="domain-product-price__strikethrough-price">
-						{ this.props.translate( '%(cost)s /year', {
-							args: { cost: this.props.price },
-						} ) }
-					</span>
-				) }
-				<span
-					className={ classnames( {
-						'domain-product-price__included-in-plan': shouldShowStrikethrough,
-					} ) }
-				>
-					{ translate( 'Included in paid plans' ) }
-				</span>
+				{ translate( 'Included in paid plans' ) }
 			</div>
 		);
 	}

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -34,16 +34,6 @@
 		font-size: 0.9em;
 	}
 
-	.domain-product-price__included-in-plan {
-		color: $blue-dark;
-	}
-
-	.domain-product-price__strikethrough-price {
-		text-decoration: line-through;
-		margin-right: 0.75em;
-		opacity: 0.7;
-	}
-
 	.domain-product-price__premium-text {
 		cursor: pointer;
 	}

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -100,12 +100,4 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
-	signupDomainStrikethruPrice: {
-		datestamp: '20180507',
-		variations: {
-			enabled: 50,
-			disabled: 50,
-		},
-		defaultVariation: 'disabled',
-	},
 };


### PR DESCRIPTION
This change removes showing the struckthrough domain name prices from the registration experience. It also cleans up the corresponding A/B test.

This removal is motivated by the feature’s negative impact on clicks and registrations. See `p8kIbR-iq`.

# Testing Instructions
1. Spin up this branch locally.
2. Navigate to `/start/domains`.
3. Ensure that strikethrough domain prices are not visible.
4. Ensure that the A/B test selector no longer shows the `signupDomainStrikethruPrice` test.