### PR TITLE
Activity Log: Adds 'group' to activity log filters

### DIFF
--- a/client/components/data/query-activity-log/index.jsx
+++ b/client/components/data/query-activity-log/index.jsx
@@ -5,6 +5,7 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,6 +22,9 @@ class QueryActivityLog extends Component {
 
 		// Number of results
 		number: PropTypes.number,
+
+		// Group
+		group: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -35,13 +39,18 @@ class QueryActivityLog extends Component {
 		this.request( nextProps );
 	}
 
-	request( { dateEnd, dateStart, number, siteId } ) {
+	request( { dateEnd, dateStart, number, siteId, group } ) {
 		if ( siteId ) {
-			this.props.activityLogRequest( siteId, {
-				dateEnd,
-				dateStart,
-				number,
-			} );
+			this.props.activityLogRequest(
+				siteId,
+				Object.assign(
+					{},
+					dateEnd,
+					dateStart,
+					number,
+					group && ! isEmpty( group.includes ) && { group: group.includes }
+				)
+			);
 		}
 	}
 

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -306,6 +306,7 @@ class ActivityLog extends Component {
 		const {
 			enableRewind,
 			filter: { page: requestedPage },
+			filter: { group },
 			logRequestQuery,
 			logs,
 			moment,
@@ -373,7 +374,7 @@ class ActivityLog extends Component {
 
 		return (
 			<div>
-				<QueryActivityLog siteId={ siteId } { ...logRequestQuery } />
+				<QueryActivityLog siteId={ siteId } { ...logRequestQuery } group={ group } />
 				{ siteId &&
 					'active' === rewindState.state && <QueryRewindBackupStatus siteId={ siteId } /> }
 				<QuerySiteSettings siteId={ siteId } />

--- a/client/state/activity-log/reducer.js
+++ b/client/state/activity-log/reducer.js
@@ -11,6 +11,7 @@ import { backupRequest, backupProgress } from './backup/reducer';
 
 export const emptyFilter = {
 	page: 1,
+	group: { includes: [] },
 };
 
 export const filterState = ( state = emptyFilter, { type, filter } ) => {

--- a/client/state/activity-log/utils.js
+++ b/client/state/activity-log/utils.js
@@ -1,5 +1,25 @@
 /** @format */
+/**
+ * External dependencies
+ */
+import { isEmpty } from 'lodash';
 
-export const filterStateToQuery = ( { page } ) => ( page > 1 ? { page } : {} );
+export const filterStateToQuery = ( { page, group } ) =>
+	Object.assign(
+		{},
+		page && page > 1 && { page },
+		group && ! isEmpty( group.includes ) && { group: group.includes.join( ',' ) }
+	);
 
-export const queryToFilterState = ( { page } ) => ( page && page > 0 ? { page } : {} );
+export const queryToFilterState = query =>
+	Object.assign(
+		{},
+		query.page && query.page > 0 && { page: query.page },
+		query.group && {
+			group: Object.assign( {}, query.group && { includes: query.group.split( ',' ) } ),
+		}
+	);
+
+export const optimizeActivityLogUrl = url => {
+	return url.split( '%2C' ).join( ',' );
+};

--- a/client/state/navigation/middleware.js
+++ b/client/state/navigation/middleware.js
@@ -10,7 +10,7 @@ import { get } from 'lodash';
  */
 import { addQueryArgs } from 'lib/url';
 import { ACTIVITY_LOG_FILTER_SET, ACTIVITY_LOG_FILTER_UPDATE, NAVIGATE } from 'state/action-types';
-import { filterStateToQuery } from 'state/activity-log/utils';
+import { filterStateToQuery, optimizeActivityLogUrl } from 'state/activity-log/utils';
 import { getActivityLogFilter } from 'state/selectors';
 
 export const navigationMiddleware = store => {
@@ -30,7 +30,11 @@ export const navigationMiddleware = store => {
 				const filter = getActivityLogFilter( store.getState(), action.siteId );
 				const query = filterStateToQuery( filter );
 
-				page( addQueryArgs( query, window.location.pathname + window.location.hash ) );
+				page(
+					optimizeActivityLogUrl(
+						addQueryArgs( query, window.location.pathname + window.location.hash )
+					)
+				);
 
 				return afterFilter;
 


### PR DESCRIPTION
If applied, this PR will allow folks to filter their activity log by group via a URL filter or through direct state manipulation:

[ [video](https://cloudup.com/czNvMl1bd4t) ]

Example URLs: ?group=post,  ?group=post,comment,plugin
Try these groups: post, setting, comment, plugin, theme, user

Note, the URL middleware uses `addQueryArgs` which changes commas to '%2C'
I've added an optimizer which allows us to keep commas in the URL, as I forsee we will use them for other array-like filters.

