### PR TITLE
Domains: Fix and enhance featured suggestions

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -122,7 +122,11 @@ class DomainRegistrationSuggestion extends React.Component {
 	}
 
 	renderProgressBar() {
-		const { suggestion: { isRecommended, isBestAlternative }, translate, isFeatured } = this.props;
+		const {
+			suggestion: { isRecommended, isBestAlternative, relevance: matchScore },
+			translate,
+			isFeatured,
+		} = this.props;
 
 		if ( ! isFeatured ) {
 			return null;
@@ -134,7 +138,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			progressBarProps = {
 				color: NOTICE_GREEN,
 				title,
-				value: 90,
+				value: matchScore * 100 || 90,
 			};
 		}
 
@@ -142,7 +146,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			title = translate( 'Best Alternative' );
 			progressBarProps = {
 				title,
-				value: 80,
+				value: matchScore * 100 || 80,
 			};
 		}
 

--- a/client/components/domains/featured-domain-suggestions/styles/base.scss
+++ b/client/components/domains/featured-domain-suggestions/styles/base.scss
@@ -65,6 +65,7 @@
 		.progress-bar {
 			width: 25%;
 			margin-right: 1em;
+			height: 10px;
 		}
 	}
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -62,6 +62,7 @@ import {
 	getTldWeightOverrides,
 	isNumberString,
 	isUnknownSuggestion,
+	markFeaturedSuggestions,
 } from 'components/domains/register-domain-step/utility';
 import {
 	recordDomainAvailabilityReceive,
@@ -728,35 +729,16 @@ class RegisterDomainStep extends React.Component {
 				? suggestionMap.set( domainName, { ...suggestionMap.get( domainName ), ...result } )
 				: suggestionMap.set( domainName, result );
 		} );
-		const suggestions = [ ...suggestionMap.values() ];
-
-		const strippedDomainBase = getStrippedDomainBase( domain );
-		const exactMatchBeforeTld = suggestion =>
-			suggestion.domain_name === this.state.exactMatchDomain ||
-			startsWith( suggestion.domain_name, `${ strippedDomainBase }.` );
-		const bestAlternative = suggestion =>
-			! exactMatchBeforeTld( suggestion ) && suggestion.isRecommended !== true;
-
-		const availableSuggestions = reject( suggestions, isUnknownSuggestion );
-
-		const recommendedSuggestion = find( availableSuggestions, exactMatchBeforeTld );
-
-		if ( recommendedSuggestion ) {
-			recommendedSuggestion.isRecommended = true;
-		} else if ( availableSuggestions.length > 0 ) {
-			availableSuggestions[ 0 ].isRecommended = true;
-		}
-
-		const bestAlternativeSuggestion = find( availableSuggestions, bestAlternative );
-		if ( bestAlternativeSuggestion ) {
-			bestAlternativeSuggestion.isBestAlternative = true;
-		} else if ( availableSuggestions.length > 1 ) {
-			availableSuggestions[ 1 ].isBestAlternative = true;
-		}
+		const suggestions = reject( [ ...suggestionMap.values() ], isUnknownSuggestion );
+		const markedSuggestions = markFeaturedSuggestions(
+			suggestions,
+			this.state.exactMatchDomain,
+			getStrippedDomainBase( domain )
+		);
 
 		this.setState(
 			{
-				searchResults: suggestions,
+				searchResults: markedSuggestions,
 				loadingResults: false,
 			},
 			this.save


### PR DESCRIPTION
This change does the following: 

1. Fixes a bug where a featured suggestion could fail to render due to being indexed outside of the initial pagination (ex. Best match suggestion’s index > `PAGE_SIZE`). This is fixed by moving both the best match and best alternative suggestions to the first and second index, respectively.

2. Enhances the match score progress bar by using actual search relevance match values instead of hardcoded `90%` and `80%` values for best match and best alternative suggestions, respectively.

# Testing Instructions
1. Spin up this branch locally.
2. Navigate to `/start/domains`.
3. To test the first change, try searching for `juiced`. Compare to search results from [`wpcalypso`](https://wpcalypso.wordpress.com/start/domains), where the bug currently exists. Try other search queries to ensure the search works as expected.
4. To test the second change, try various searches and verify that the match scores vary accordingly to the API response. 

