### PR TITLE
Set site attribute in errorData for transferrable domain mapped to same site

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -604,7 +604,12 @@ class RegisterDomainStep extends React.Component {
 					const status = get( result, 'status', error );
 					const domainChecked = get( result, 'domain_name', domain );
 
-					const { AVAILABLE, TRANSFERRABLE, UNKNOWN } = domainAvailability;
+					const {
+						AVAILABLE,
+						MAPPED_SAME_SITE_TRANSFERRABLE,
+						TRANSFERRABLE,
+						UNKNOWN,
+					} = domainAvailability;
 					const isDomainAvailable = includes( [ AVAILABLE, UNKNOWN ], status );
 					const isDomainTransferrable = TRANSFERRABLE === status;
 
@@ -620,8 +625,12 @@ class RegisterDomainStep extends React.Component {
 							errorData: null,
 						} );
 					} else {
+						let site = get( result, 'other_site_domain', null );
+						if ( MAPPED_SAME_SITE_TRANSFERRABLE === status ) {
+							site = get( this.props, 'selectedSite.slug', null );
+						}
 						this.showValidationErrorMessage( domain, status, {
-							site: get( result, 'other_site_domain', null ),
+							site,
 							maintenanceEndTime: get( result, 'maintenance_end_time', null ),
 						} );
 					}


### PR DESCRIPTION
From domain search, if a transferrable domain the is mapped to the same site is entered, the `site` property of the `errorData` that is passed to the method to get the availability message is not set. This means that the `:site_id` portion of the transfer link URL is `null`.

This PR sets the `site` property to the `selectedSite.slug` stored in the props of `RegisterDomainSteop`.

To test, select a site that has a mapped domain. Search for the mapped domain. You should see a notification with the message, "yourdomain.com is already connected to this site, but registered somewhere else. Do you want to move it from your current domain provider to WordPress.com so you can manage the domain and the site together? Yes, transfer it to WordPress.com."

Make sure that the link is valid.