### PR TITLE
Payments: Ensuring a top margin on Ebanx fields

### DIFF
--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -900,6 +900,10 @@
 		flex-grow: 1;
 		flex-shrink: 0;
 		margin-left: 15px;
+		margin-top: 15px;
+		&.state {
+			margin-top: 0;
+		}
 	}
 	.checkout__form-state-field {
 		margin-left: 0;


### PR DESCRIPTION
While testing adding a new credit card (`/me/purchases/add-credit-card`) I noticed that the Ebanx fields have inconsistent spacing:

<img width="721" alt="screen shot 2018-05-18 at 4 18 07 pm" src="https://user-images.githubusercontent.com/6458278/40219239-e2eedd86-5ab7-11e8-8b0f-e3c473c9dc16.png">

## This PR...

Ensure that the fields have the same top margin across forms.

### Payment
<img width="736" alt="screen shot 2018-05-18 at 4 16 54 pm" src="https://user-images.githubusercontent.com/6458278/40219296-185984e4-5ab8-11e8-8fe9-5abc4900b320.png">

### Add a new credit card (payment)
<img width="727" alt="screen shot 2018-05-18 at 4 15 40 pm" src="https://user-images.githubusercontent.com/6458278/40219322-2a68896e-5ab8-11e8-96f1-10be6868870e.png">

### Add a new credit card
<img width="727" alt="screen shot 2018-05-18 at 4 15 21 pm" src="https://user-images.githubusercontent.com/6458278/40219344-433d710c-5ab8-11e8-8cc6-6d4bc0886b34.png">



