### PR TITLE
Revert "EditPostStatus: Get the post data from Redux and remove unneeded props"

### DIFF
--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -33,8 +33,12 @@ export class EditPostStatus extends Component {
 		onSave: PropTypes.func,
 		post: PropTypes.object,
 		savedPost: PropTypes.object,
+		site: PropTypes.object,
 		translate: PropTypes.func,
+		type: PropTypes.string,
 		onPrivatePublish: PropTypes.func,
+		status: PropTypes.string,
+		isPostPrivate: PropTypes.bool,
 		confirmationSidebarStatus: PropTypes.string,
 	};
 
@@ -73,14 +77,11 @@ export class EditPostStatus extends Component {
 	};
 
 	render() {
-		let showSticky, isSticky, isPublished, isPending, isScheduled;
-		const { translate, canUserPublishPosts } = this.props;
+		let isSticky, isPublished, isPending, isScheduled, isPasswordProtected;
+		const { translate, isPostPrivate, canUserPublishPosts } = this.props;
 
 		if ( this.props.post ) {
-			const isPrivate = postUtils.isPrivate( this.props.post );
-			const isPasswordProtected = postUtils.getVisibility( this.props.post ) === 'password';
-
-			showSticky = this.props.post.type === 'post' && ! isPrivate && ! isPasswordProtected;
+			isPasswordProtected = postUtils.getVisibility( this.props.post ) === 'password';
 			isSticky = this.props.post.sticky;
 			isPending = postUtils.isPending( this.props.post );
 			isPublished = postUtils.isPublished( this.props.savedPost );
@@ -91,21 +92,27 @@ export class EditPostStatus extends Component {
 			<div className="edit-post-status">
 				{ this.renderPostScheduling() }
 				{ this.renderPostVisibility() }
-				{ showSticky && (
-					<label className="edit-post-status__sticky">
-						<span className="edit-post-status__label-text">
-							{ translate( 'Stick to the front page' ) }
-							<InfoPopover position="top right" gaEventCategory="Editor" popoverName="Sticky Post">
-								{ translate( 'Sticky posts will appear at the top of the posts listing.' ) }
-							</InfoPopover>
-						</span>
-						<FormToggle
-							checked={ isSticky }
-							onChange={ this.toggleStickyStatus }
-							aria-label={ translate( 'Stick post to the front page' ) }
-						/>
-					</label>
-				) }
+				{ this.props.type === 'post' &&
+					! isPostPrivate &&
+					! isPasswordProtected && (
+						<label className="edit-post-status__sticky">
+							<span className="edit-post-status__label-text">
+								{ translate( 'Stick to the front page' ) }
+								<InfoPopover
+									position="top right"
+									gaEventCategory="Editor"
+									popoverName="Sticky Post"
+								>
+									{ translate( 'Sticky posts will appear at the top of the posts listing.' ) }
+								</InfoPopover>
+							</span>
+							<FormToggle
+								checked={ isSticky }
+								onChange={ this.toggleStickyStatus }
+								aria-label={ translate( 'Stick post to the front page' ) }
+							/>
+						</label>
+					) }
 				{ ! isPublished &&
 					! isScheduled &&
 					canUserPublishPosts && (
@@ -151,13 +158,13 @@ export class EditPostStatus extends Component {
 			return;
 		}
 
-		const { password, status, type } = this.props.post;
+		const { password, type } = this.props.post || {};
 		const savedStatus = this.props.savedPost ? this.props.savedPost.status : null;
 		const savedPassword = this.props.savedPost ? this.props.savedPost.password : null;
 		const props = {
+			status: this.props.status,
 			onPrivatePublish: this.props.onPrivatePublish,
 			type,
-			status,
 			password,
 			savedStatus,
 			savedPassword,

--- a/client/post-editor/edit-post-status/test/index.jsx
+++ b/client/post-editor/edit-post-status/test/index.jsx
@@ -21,7 +21,7 @@ jest.mock( 'lib/user', () => () => {} );
 describe( 'EditPostStatus', () => {
 	test( 'should hide sticky option for password protected posts', () => {
 		const wrapper = shallow(
-			<EditPostStatus post={ { type: 'post', status: 'draft', password: 'password' } } />
+			<EditPostStatus post={ { password: 'password' } } isPostPrivate={ false } type={ 'post' } />
 		);
 
 		expect( wrapper.find( '.edit-post-status__sticky' ) ).to.have.lengthOf( 0 );
@@ -29,7 +29,7 @@ describe( 'EditPostStatus', () => {
 
 	test( 'should hide sticky option for private posts', () => {
 		const wrapper = shallow(
-			<EditPostStatus post={ { type: 'post', status: 'private', password: '' } } />
+			<EditPostStatus post={ { password: '' } } isPostPrivate={ true } type={ 'post' } />
 		);
 
 		expect( wrapper.find( '.edit-post-status__sticky' ) ).to.have.lengthOf( 0 );
@@ -38,7 +38,9 @@ describe( 'EditPostStatus', () => {
 	test( 'should show sticky option for published posts', () => {
 		const wrapper = shallow(
 			<EditPostStatus
-				post={ { type: 'post', status: 'published', password: '' } }
+				post={ { password: '' } }
+				type={ 'post' }
+				isPostPrivate={ false }
 				translate={ noop }
 			/>
 		);

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { flow, overSome } from 'lodash';
+import { flow, get, overSome } from 'lodash';
 
 /**
  * Internal dependencies
@@ -82,6 +82,7 @@ class EditorDrawer extends Component {
 		type: PropTypes.string,
 		setPostDate: PropTypes.func,
 		onSave: PropTypes.func,
+		isPostPrivate: PropTypes.bool,
 		confirmationSidebarStatus: PropTypes.string,
 	};
 
@@ -281,15 +282,20 @@ class EditorDrawer extends Component {
 	}
 
 	renderStatus() {
-		const { translate } = this.props;
+		const postStatus = get( this.props.post, 'status', null );
+		const { translate, type } = this.props;
 
 		return (
 			<Accordion title={ translate( 'Status' ) } e2eTitle="status">
 				<EditPostStatus
 					savedPost={ this.props.savedPost }
 					onSave={ this.props.onSave }
+					onTrashingPost={ this.props.onTrashingPost }
 					onPrivatePublish={ this.props.onPrivatePublish }
 					setPostDate={ this.props.setPostDate }
+					status={ postStatus }
+					type={ type }
+					isPostPrivate={ this.props.isPostPrivate }
 					confirmationSidebarStatus={ this.props.confirmationSidebarStatus }
 				/>
 			</Accordion>

--- a/client/post-editor/editor-sidebar/index.jsx
+++ b/client/post-editor/editor-sidebar/index.jsx
@@ -24,6 +24,7 @@ export class EditorSidebar extends Component {
 		site: PropTypes.object,
 		type: PropTypes.string,
 		setPostDate: PropTypes.func,
+		isPostPrivate: PropTypes.bool,
 		confirmationSidebarStatus: PropTypes.string,
 	};
 
@@ -36,6 +37,7 @@ export class EditorSidebar extends Component {
 			savedPost,
 			site,
 			setPostDate,
+			isPostPrivate,
 			confirmationSidebarStatus,
 		} = this.props;
 
@@ -49,6 +51,7 @@ export class EditorSidebar extends Component {
 					setPostDate={ setPostDate }
 					onPrivatePublish={ onPublish }
 					onSave={ onSave }
+					isPostPrivate={ isPostPrivate }
 					confirmationSidebarStatus={ confirmationSidebarStatus }
 				/>
 				<SidebarFooter>

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -389,6 +389,7 @@ export class PostEditor extends React.Component {
 						site={ site }
 						setPostDate={ this.setPostDate }
 						onSave={ this.onSave }
+						isPostPrivate={ utils.isPrivate( this.state.post ) }
 						confirmationSidebarStatus={ this.state.confirmationSidebar }
 					/>
 					{ this.props.isSitePreviewable ? (


### PR DESCRIPTION
Reverts Automattic/wp-calypso#24879

Reverting because autosave of password-protected posts is broken.