### PR TITLE
Simple Payments: adjust image editor done button text

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -114,6 +114,7 @@ class ProductImagePicker extends Component {
 							confirm: translate( 'Add' ),
 						} }
 						single
+						imageEditorProps={ { doneButtonText: translate( 'Update Payment Button' ) } }
 					/>
 				</MediaLibrarySelectedData>
 


### PR DESCRIPTION
Update the image editor done button text when editing Simple Payment button image according to [feedback from this PR](https://github.com/Automattic/wp-calypso/pull/24858#discussion_r188431628).

### Testing instructions

1. Click on an existing simple payment button with an image set.
2. Edit it.
3. Click to edit the image.
4. In the media modal click edit.
5. Verify that `Update Payment Button` text is shown instead of `Done`.