### PR TITLE
EditPostStatus: Get the post data from Redux and remove unneeded props (try 2)

### DIFF
--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -33,12 +33,8 @@ export class EditPostStatus extends Component {
 		onSave: PropTypes.func,
 		post: PropTypes.object,
 		savedPost: PropTypes.object,
-		site: PropTypes.object,
 		translate: PropTypes.func,
-		type: PropTypes.string,
 		onPrivatePublish: PropTypes.func,
-		status: PropTypes.string,
-		isPostPrivate: PropTypes.bool,
 		confirmationSidebarStatus: PropTypes.string,
 	};
 
@@ -77,11 +73,14 @@ export class EditPostStatus extends Component {
 	};
 
 	render() {
-		let isSticky, isPublished, isPending, isScheduled, isPasswordProtected;
-		const { translate, isPostPrivate, canUserPublishPosts } = this.props;
+		let showSticky, isSticky, isPublished, isPending, isScheduled;
+		const { translate, canUserPublishPosts } = this.props;
 
 		if ( this.props.post ) {
-			isPasswordProtected = postUtils.getVisibility( this.props.post ) === 'password';
+			const isPrivate = postUtils.isPrivate( this.props.post );
+			const isPasswordProtected = postUtils.getVisibility( this.props.post ) === 'password';
+
+			showSticky = this.props.post.type === 'post' && ! isPrivate && ! isPasswordProtected;
 			isSticky = this.props.post.sticky;
 			isPending = postUtils.isPending( this.props.post );
 			isPublished = postUtils.isPublished( this.props.savedPost );
@@ -92,27 +91,21 @@ export class EditPostStatus extends Component {
 			<div className="edit-post-status">
 				{ this.renderPostScheduling() }
 				{ this.renderPostVisibility() }
-				{ this.props.type === 'post' &&
-					! isPostPrivate &&
-					! isPasswordProtected && (
-						<label className="edit-post-status__sticky">
-							<span className="edit-post-status__label-text">
-								{ translate( 'Stick to the front page' ) }
-								<InfoPopover
-									position="top right"
-									gaEventCategory="Editor"
-									popoverName="Sticky Post"
-								>
-									{ translate( 'Sticky posts will appear at the top of the posts listing.' ) }
-								</InfoPopover>
-							</span>
-							<FormToggle
-								checked={ isSticky }
-								onChange={ this.toggleStickyStatus }
-								aria-label={ translate( 'Stick post to the front page' ) }
-							/>
-						</label>
-					) }
+				{ showSticky && (
+					<label className="edit-post-status__sticky">
+						<span className="edit-post-status__label-text">
+							{ translate( 'Stick to the front page' ) }
+							<InfoPopover position="top right" gaEventCategory="Editor" popoverName="Sticky Post">
+								{ translate( 'Sticky posts will appear at the top of the posts listing.' ) }
+							</InfoPopover>
+						</span>
+						<FormToggle
+							checked={ isSticky }
+							onChange={ this.toggleStickyStatus }
+							aria-label={ translate( 'Stick post to the front page' ) }
+						/>
+					</label>
+				) }
 				{ ! isPublished &&
 					! isScheduled &&
 					canUserPublishPosts && (
@@ -158,13 +151,13 @@ export class EditPostStatus extends Component {
 			return;
 		}
 
-		const { password, type } = this.props.post || {};
+		const { password, status, type } = this.props.post;
 		const savedStatus = this.props.savedPost ? this.props.savedPost.status : null;
 		const savedPassword = this.props.savedPost ? this.props.savedPost.password : null;
 		const props = {
-			status: this.props.status,
 			onPrivatePublish: this.props.onPrivatePublish,
 			type,
+			status,
 			password,
 			savedStatus,
 			savedPassword,

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -151,7 +151,7 @@ export class EditPostStatus extends Component {
 			return;
 		}
 
-		const { password, status, type } = this.props.post;
+		const { password, status = 'draft', type } = this.props.post;
 		const savedStatus = this.props.savedPost ? this.props.savedPost.status : null;
 		const savedPassword = this.props.savedPost ? this.props.savedPost.password : null;
 		const props = {

--- a/client/post-editor/edit-post-status/test/index.jsx
+++ b/client/post-editor/edit-post-status/test/index.jsx
@@ -21,7 +21,7 @@ jest.mock( 'lib/user', () => () => {} );
 describe( 'EditPostStatus', () => {
 	test( 'should hide sticky option for password protected posts', () => {
 		const wrapper = shallow(
-			<EditPostStatus post={ { password: 'password' } } isPostPrivate={ false } type={ 'post' } />
+			<EditPostStatus post={ { type: 'post', status: 'draft', password: 'password' } } />
 		);
 
 		expect( wrapper.find( '.edit-post-status__sticky' ) ).to.have.lengthOf( 0 );
@@ -29,7 +29,7 @@ describe( 'EditPostStatus', () => {
 
 	test( 'should hide sticky option for private posts', () => {
 		const wrapper = shallow(
-			<EditPostStatus post={ { password: '' } } isPostPrivate={ true } type={ 'post' } />
+			<EditPostStatus post={ { type: 'post', status: 'private', password: '' } } />
 		);
 
 		expect( wrapper.find( '.edit-post-status__sticky' ) ).to.have.lengthOf( 0 );
@@ -38,9 +38,7 @@ describe( 'EditPostStatus', () => {
 	test( 'should show sticky option for published posts', () => {
 		const wrapper = shallow(
 			<EditPostStatus
-				post={ { password: '' } }
-				type={ 'post' }
-				isPostPrivate={ false }
+				post={ { type: 'post', status: 'published', password: '' } }
 				translate={ noop }
 			/>
 		);

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { flow, get, overSome } from 'lodash';
+import { flow, overSome } from 'lodash';
 
 /**
  * Internal dependencies
@@ -82,7 +82,6 @@ class EditorDrawer extends Component {
 		type: PropTypes.string,
 		setPostDate: PropTypes.func,
 		onSave: PropTypes.func,
-		isPostPrivate: PropTypes.bool,
 		confirmationSidebarStatus: PropTypes.string,
 	};
 
@@ -282,20 +281,15 @@ class EditorDrawer extends Component {
 	}
 
 	renderStatus() {
-		const postStatus = get( this.props.post, 'status', null );
-		const { translate, type } = this.props;
+		const { translate } = this.props;
 
 		return (
 			<Accordion title={ translate( 'Status' ) } e2eTitle="status">
 				<EditPostStatus
 					savedPost={ this.props.savedPost }
 					onSave={ this.props.onSave }
-					onTrashingPost={ this.props.onTrashingPost }
 					onPrivatePublish={ this.props.onPrivatePublish }
 					setPostDate={ this.props.setPostDate }
-					status={ postStatus }
-					type={ type }
-					isPostPrivate={ this.props.isPostPrivate }
 					confirmationSidebarStatus={ this.props.confirmationSidebarStatus }
 				/>
 			</Accordion>

--- a/client/post-editor/editor-sidebar/index.jsx
+++ b/client/post-editor/editor-sidebar/index.jsx
@@ -24,7 +24,6 @@ export class EditorSidebar extends Component {
 		site: PropTypes.object,
 		type: PropTypes.string,
 		setPostDate: PropTypes.func,
-		isPostPrivate: PropTypes.bool,
 		confirmationSidebarStatus: PropTypes.string,
 	};
 
@@ -37,7 +36,6 @@ export class EditorSidebar extends Component {
 			savedPost,
 			site,
 			setPostDate,
-			isPostPrivate,
 			confirmationSidebarStatus,
 		} = this.props;
 
@@ -51,7 +49,6 @@ export class EditorSidebar extends Component {
 					setPostDate={ setPostDate }
 					onPrivatePublish={ onPublish }
 					onSave={ onSave }
-					isPostPrivate={ isPostPrivate }
 					confirmationSidebarStatus={ confirmationSidebarStatus }
 				/>
 				<SidebarFooter>

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -389,7 +389,6 @@ export class PostEditor extends React.Component {
 						site={ site }
 						setPostDate={ this.setPostDate }
 						onSave={ this.onSave }
-						isPostPrivate={ utils.isPrivate( this.state.post ) }
 						confirmationSidebarStatus={ this.state.confirmationSidebar }
 					/>
 					{ this.props.isSitePreviewable ? (


### PR DESCRIPTION
This is a second attempt at #24879, including a bug fix where a brand new password-protected post couldn't be autosaved.

**What was wrong:**
When editing a brand new post that hasn't yet been saved and doesn't yet have an ID, the Redux and Flux versions of `status` attribute are out of sync: the Flux post has `status === 'draft'`, while the Redux post doesn't have the attribute set.

When the post visibility is updated to "password-protected" in `EditorVisibility`, its status will be erroneously updated to `publish` instead of leaving it as it is. [The code that does that](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/editor-visibility/index.jsx#L96) is intended to reset the status from `private` to `publish` when switching from "Private" to another visibility.

So the post has no ID yet (it's brand new, never saved) and yet its status is `publish`. That's a situation that `autosave` [refuses to deal with](https://github.com/Automattic/wp-calypso/blob/master/client/lib/posts/actions.js#L134-L141) and the post is not saved.

**What's the fix:**
Default the `status` prop to `draft` when it's passed to `EditorVisibility`. The fix is not ideal: it would be better to keep the Redux and Flux states 100% in sync. But that's a quite large refactoring of the "start editing a post" logic that I'll do in another PR.

**How to test:**
1. Start editing a new post
2. Change its status to "Password Protected" as the very first thing you do
3. Edit the title or content: that's the event that triggers autosave
4. Check that the post is saved and is assigned an ID (visible in URL)

If you enter some title or content first and only then set the post as password protected, the bug won't happen.