### PR TITLE
Simple Payments: refresh image in products list and post editor after editing

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -48,10 +48,9 @@ class ProductImagePicker extends Component {
 
 			this.props.input.onChange( value.items[ 0 ].ID );
 
-			// In case of image editing request this media item again in order to
-			// update the image in product list and existing buttons in editor.
-			// This is required to fetch the new URL of edited image, since its
-			// media id remains the same as for the original.
+			// In case of image editing, request this media item again in order to
+			// update the image in product list and existing payment buttons in editor.
+			// This is required to fetch the new URL of edited image.
 			this.props.requestMediaItem( this.props.siteId, value.items[ 0 ].ID );
 		} );
 	};

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -19,6 +19,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
 import EditorFeaturedImagePreviewContainer from 'post-editor/editor-featured-image/preview-container';
 import RemoveButton from 'components/remove-button';
+import { requestMediaItem } from 'state/media/actions';
 
 class ProductImagePicker extends Component {
 	static propTypes = {
@@ -46,6 +47,12 @@ class ProductImagePicker extends Component {
 			}
 
 			this.props.input.onChange( value.items[ 0 ].ID );
+
+			// In case of image editing request this media item again in order to
+			// update the image in product list and existing buttons in editor.
+			// This is required to fetch the new URL of edited image, since its
+			// media id remains the same as for the original.
+			this.props.requestMediaItem( this.props.siteId, value.items[ 0 ].ID );
 		} );
 	};
 
@@ -127,6 +134,6 @@ class ProductImagePicker extends Component {
 	}
 }
 
-export default connect( state => ( { siteId: getSelectedSiteId( state ) } ) )(
+export default connect( state => ( { siteId: getSelectedSiteId( state ) } ), { requestMediaItem } )(
 	localize( ProductImagePicker )
 );


### PR DESCRIPTION
This is an attempt to work around the issue reported [in this PR](https://github.com/Automattic/wp-calypso/pull/24858#issuecomment-389235057).

> The button preview in the post doesn't update to reflect the change just made; edit an image by rotating it to replicate (a full page refresh will show the updated image).

One of the options for resolving this was to create a copy for each version of edited image, but there were [other considerations](https://github.com/Automattic/wp-calypso/pull/24858#discussion_r188771578) behind this decision (like storage limits, testing feedback and similarity with core editor).

Instead of that, here I'm dispatching the `requestMediaItem` every time the media modal is closed. In cases when image was edited this will also fetch the new URL of edited image and it will cause the existing image in product list and post editor to update.

### Testing instructions

1. Assuming that you already have at least one Simple Payments button with image, navigate to `post/{site}` and insert that button to new post (`Add` > `Payment Button`).
2. Click on `Add` > `Payment Button` again.
3. Locate the button inserted in previous step in the list and select `Edit` from ellipsis menu.
3. Click on existing image to edit it.
4. In the media modal click on `Edit`.
5. Make some changes to the image (crop, rotate etc).
6. Click on `Update Payment Button` and after that `Add`.
7. Click on `Cancel` (this step is kind of weird, but we can always reconsider bringing back the https://github.com/Automattic/wp-calypso/pull/24858 :smile:)
8. Verify that image in the product list has been refreshed and is now showing the edited image thumbnail.
9.  Click `Cancel` again to close the Simple payments dialog.
10. Verify that the image of existing Simple payments button in the post has also been updated to the edited version of the image.