### PR TITLE
Media Library: Fix console warning when opening Media modal

### DIFF
--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -92,7 +92,6 @@ class MediaModalSecondaryActions extends Component {
 					<Button
 						className={ classNames( 'editor-media-modal__secondary-action', button.className ) }
 						data-e2e-button={ button.key }
-						icon={ !! button.icon }
 						compact
 						{ ...pick( button, [ 'key', 'disabled', 'onClick', 'primary' ] ) }
 					>


### PR DESCRIPTION
This fixes the console warning that is displayed icon attribute when opening Media Modal in Simple Payments.

### Testing instructions

1. In order to reproduce this navigate to `post/{site}`.
2. Click on `Add` > `Media`.
3. Select some image from your Media library. You should see the following warning in the console:

```
Warning: Received `false` for a non-boolean attribute `icon`.
...
```

4. Apply this patch and verify that the warning is no longer present.
5. Verify that this is not causing some visual or functional regression. As far as I can see the `Button` component is not using the `icon` prop, and I don't see the point of passing it directly to `a` or `button` HTML tags.