### PR TITLE
Simple Payments: allow saving the form after product image is edited

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -176,11 +176,15 @@ const renderPriceField = ( { price, currency, ...props } ) => {
 
 class ProductForm extends Component {
 	render() {
-		const { translate } = this.props;
+		const { translate, makeDirtyAfterImageEdit } = this.props;
 
 		return (
 			<form className="editor-simple-payments-modal__form">
-				<Field name="featuredImageId" component={ ProductImagePicker } />
+				<Field
+					name="featuredImageId"
+					component={ ProductImagePicker }
+					makeDirtyAfterImageEdit={ makeDirtyAfterImageEdit }
+				/>
 				<div className="editor-simple-payments-modal__form-fields">
 					<ReduxFormFieldset
 						name="title"

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -194,6 +194,7 @@ class SimplePaymentsDialog extends Component {
 			selectedPaymentId: null,
 			isSubmitting: false,
 			errorMessage: null,
+			isDirtyAfterImageEdit: false,
 		};
 	}
 
@@ -419,11 +420,18 @@ class SimplePaymentsDialog extends Component {
 		);
 	};
 
+	// The only thing we track about image in Simple Payments product form is its media id.
+	// However this doesn't change when the image is edited, and as a result redux form
+	// isDirty selector is not detecting any update, so it's not possible to submit changes
+	// after editing the image (even though they are saved behind the scenes in Media library).
+	// This allows us to force re-enabling of the save button in that case.
+	makeDirtyAfterImageEdit = () => this.setState( { isDirtyAfterImageEdit: true } );
+
 	getActionButtons() {
 		const { formIsValid, formIsDirty, translate, featuredImageId } = this.props;
-		const { activeTab, editedPaymentId, isSubmitting } = this.state;
+		const { activeTab, editedPaymentId, isSubmitting, isDirtyAfterImageEdit } = this.state;
 
-		const formCanBeSubmitted = formIsValid && formIsDirty;
+		const formCanBeSubmitted = formIsValid && ( formIsDirty || isDirtyAfterImageEdit );
 
 		let cancelHandler, finishHandler, finishDisabled, finishLabel;
 		if ( activeTab === 'form' && isNumber( editedPaymentId ) ) {
@@ -585,7 +593,11 @@ class SimplePaymentsDialog extends Component {
 					<Notice status="is-error" text={ errorMessage } onDismissClick={ this.dismissError } />
 				) }
 				{ activeTab === 'form' ? (
-					<ProductForm initialValues={ initialFormValues } showError={ this.showError } />
+					<ProductForm
+						initialValues={ initialFormValues }
+						showError={ this.showError }
+						makeDirtyAfterImageEdit={ this.makeDirtyAfterImageEdit }
+					/>
 				) : (
 					<ProductList
 						siteId={ siteId }

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -122,6 +122,7 @@ class ProductImagePicker extends Component {
 						single
 						imageEditorProps={ { doneButtonText: translate( 'Update Payment Button' ) } }
 						onImageEditorDoneHook={ makeDirtyAfterImageEdit }
+						onRestoreMediaHook={ makeDirtyAfterImageEdit }
 					/>
 				</MediaLibrarySelectedData>
 

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -99,7 +99,7 @@ class ProductImagePicker extends Component {
 	}
 
 	render() {
-		const { siteId, translate } = this.props;
+		const { siteId, translate, makeDirtyAfterImageEdit } = this.props;
 		const { isSelecting } = this.state;
 
 		if ( ! siteId ) {
@@ -121,6 +121,7 @@ class ProductImagePicker extends Component {
 						} }
 						single
 						imageEditorProps={ { doneButtonText: translate( 'Update Payment Button' ) } }
+						onImageEditorDoneHook={ makeDirtyAfterImageEdit }
 					/>
 				</MediaLibrarySelectedData>
 

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -84,6 +84,7 @@ export class EditorMediaModal extends Component {
 		disableLargeImageSources: PropTypes.bool,
 		disabledDataSources: PropTypes.arrayOf( PropTypes.string ),
 		onImageEditorDoneHook: PropTypes.func,
+		onRestoreMediaHook: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -102,6 +103,7 @@ export class EditorMediaModal extends Component {
 		disableLargeImageSources: false,
 		disabledDataSources: [],
 		onImageEditorDoneHook: noop,
+		onRestoreMediaHook: noop,
 	};
 
 	constructor( props ) {
@@ -313,6 +315,8 @@ export class EditorMediaModal extends Component {
 		}
 
 		MediaActions.update( siteId, { ID: item.ID, media_url: item.guid }, true );
+
+		this.props.onRestoreMediaHook();
 	};
 
 	onImageEditorDone = ( error, blob, imageEditorProps ) => {

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -83,6 +83,7 @@ export class EditorMediaModal extends Component {
 		postId: PropTypes.number,
 		disableLargeImageSources: PropTypes.bool,
 		disabledDataSources: PropTypes.arrayOf( PropTypes.string ),
+		onImageEditorDoneHook: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -100,6 +101,7 @@ export class EditorMediaModal extends Component {
 		deleteMedia: () => {},
 		disableLargeImageSources: false,
 		disabledDataSources: [],
+		onImageEditorDoneHook: noop,
 	};
 
 	constructor( props ) {
@@ -342,6 +344,10 @@ export class EditorMediaModal extends Component {
 		resetAllImageEditorState();
 
 		this.props.setView( ModalViews.DETAIL );
+
+		if ( this.props.onImageEditorDoneHook ) {
+			this.props.onImageEditorDoneHook();
+		}
 	};
 
 	handleUpdatePoster = ( { ID, posterUrl } ) => {

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -345,9 +345,7 @@ export class EditorMediaModal extends Component {
 
 		this.props.setView( ModalViews.DETAIL );
 
-		if ( this.props.onImageEditorDoneHook ) {
-			this.props.onImageEditorDoneHook();
-		}
+		this.props.onImageEditorDoneHook();
 	};
 
 	handleUpdatePoster = ( { ID, posterUrl } ) => {


### PR DESCRIPTION
Reopening https://github.com/Automattic/wp-calypso/pull/24858 (I couldn't do it there since I forced pushed the rebase with master).

### Testing instructions

1. Click on an existing simple payment button with an image set.
2. Edit it.
3. Click to edit the image.
4. In the media modal click edit.
5. Make some changes to the image (crop etc), or restore the original image if it was already edited before.
6. Save changes.
7. The Done button should be enabled.