### PR TITLE
Login: Jetpack Connect: Use JetpackHeader and getPartnerSlugFromQuery for cobranding

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -36,7 +36,8 @@ import Notice from 'components/notice';
 import PushNotificationApprovalPoller from './two-factor-authentication/push-notification-approval-poller';
 import userFactory from 'lib/user';
 import SocialConnectPrompt from './social-connect-prompt';
-import JetpackLogo from 'components/jetpack-logo';
+import JetpackHeader from 'components/jetpack-header';
+import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
 
 const user = userFactory();
 
@@ -193,7 +194,7 @@ class Login extends Component {
 			headerText = translate( 'Log in to your WordPress.com account to set up Jetpack.' );
 			preHeader = (
 				<div className="login__jetpack-logo">
-					<JetpackLogo full size={ 45 } />
+					<JetpackHeader partnerSlug={ this.props.partnerSlug } />
 				</div>
 			);
 		}
@@ -299,6 +300,7 @@ export default connect(
 		oauth2Client: getCurrentOAuth2Client( state ),
 		isLinking: getSocialAccountIsLinking( state ),
 		linkingSocialService: getSocialAccountLinkService( state ),
+		partnerSlug: getPartnerSlugFromQuery( state ),
 	} ),
 	{
 		recordTracksEvent,

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -27,7 +27,9 @@ import {
 	getSocialAccountLinkService,
 } from 'state/login/selectors';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
+import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
 import { isWooOAuth2Client } from 'lib/oauth2-clients';
+import JetpackHeader from 'components/jetpack-header';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import VerificationCodeForm from './two-factor-authentication/verification-code-form';
 import WaitingTwoFactorNotificationApproval from './two-factor-authentication/waiting-notification-approval';
@@ -36,8 +38,6 @@ import Notice from 'components/notice';
 import PushNotificationApprovalPoller from './two-factor-authentication/push-notification-approval-poller';
 import userFactory from 'lib/user';
 import SocialConnectPrompt from './social-connect-prompt';
-import JetpackHeader from 'components/jetpack-header';
-import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
 
 const user = userFactory();
 

--- a/client/components/jetpack-header/style.scss
+++ b/client/components/jetpack-header/style.scss
@@ -1,3 +1,7 @@
 .jetpack-header {
 	text-align: center;
 }
+
+.jetpack-header > svg {
+	max-width: 100%;
+}

--- a/client/components/jetpack-header/style.scss
+++ b/client/components/jetpack-header/style.scss
@@ -1,4 +1,5 @@
 .jetpack-header {
+	padding: 0 16px;
 	text-align: center;
 }
 

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -20,6 +20,7 @@ import { authQueryPropTypes } from './utils';
 import { decodeEntities } from 'lib/formatting';
 import { getAuthorizationData } from 'state/jetpack-connect/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
+import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
 
 export class AuthFormHeader extends Component {
 	static propTypes = {
@@ -31,8 +32,7 @@ export class AuthFormHeader extends Component {
 	};
 
 	getState() {
-		const { user, authorize } = this.props;
-		const { partnerSlug } = this.props.authQuery;
+		const { user, authorize, partnerSlug } = this.props;
 
 		if ( partnerSlug ) {
 			return 'partner';
@@ -50,8 +50,7 @@ export class AuthFormHeader extends Component {
 	}
 
 	getHeaderText() {
-		const { translate } = this.props;
-		const { partnerSlug } = this.props.authQuery;
+		const { translate, partnerSlug } = this.props;
 
 		let host = '';
 		switch ( partnerSlug ) {
@@ -149,5 +148,6 @@ export default connect( state => {
 	return {
 		authorize: getAuthorizationData( state ),
 		user: getCurrentUser( state ),
+		partnerSlug: getPartnerSlugFromQuery( state ),
 	};
 } )( localize( AuthFormHeader ) );

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -68,6 +68,7 @@ import {
 	hasXmlrpcError as hasXmlrpcErrorSelector,
 	isRemoteSiteOnSitesList,
 } from 'state/jetpack-connect/selectors';
+import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
 
 /**
  * Constants
@@ -254,7 +255,7 @@ export class JetpackAuthorize extends Component {
 	}
 
 	shouldRedirectJetpackStart( props = this.props ) {
-		const { partnerSlug } = props.authQuery;
+		const { partnerSlug } = props;
 		const partnerRedirectFlag = config.isEnabled(
 			'jetpack/connect-redirect-pressable-credential-approval'
 		);
@@ -531,7 +532,8 @@ export class JetpackAuthorize extends Component {
 	}
 
 	getRedirectionTarget() {
-		const { clientId, homeUrl, partnerSlug, redirectAfterAuth } = this.props.authQuery;
+		const { clientId, homeUrl, redirectAfterAuth } = this.props.authQuery;
+		const { partnerSlug } = this.props;
 
 		// Redirect sites hosted on Pressable with a partner plan to some URL.
 		if (
@@ -618,9 +620,8 @@ export class JetpackAuthorize extends Component {
 	}
 
 	render() {
-		const { partnerSlug } = this.props.authQuery;
 		return (
-			<MainWrapper partnerSlug={ partnerSlug }>
+			<MainWrapper>
 				<div className="jetpack-connect__authorize-form">
 					<div className="jetpack-connect__logged-in-form">
 						<QueryUserConnection
@@ -662,6 +663,7 @@ export default connect(
 			mobileAppRedirect,
 			user: getCurrentUser( state ),
 			userAlreadyConnected: getUserAlreadyConnected( state ),
+			partnerSlug: getPartnerSlugFromQuery( state ),
 		};
 	},
 	{

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -7,13 +7,15 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import JetpackLogo from 'components/jetpack-logo';
 import Main from 'components/main';
 import { retrieveMobileRedirect } from './persistence-utils';
+import JetpackHeader from 'components/jetpack-header';
+import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
 
 export class JetpackConnectMainWrapper extends PureComponent {
 	static propTypes = {
@@ -26,55 +28,6 @@ export class JetpackConnectMainWrapper extends PureComponent {
 		isWide: false,
 	};
 
-	getHeaderImage() {
-		const { partnerSlug, translate } = this.props;
-		const baseCobrandedAttributes = {
-			width: '662.5',
-			height: '85',
-			className: 'jetpack-connect__main-partner-logo',
-		};
-
-		switch ( partnerSlug ) {
-			case 'dreamhost':
-				return (
-					<img
-						{ ...baseCobrandedAttributes }
-						src="/calypso/images/jetpack/jetpack-dreamhost-connection.png"
-						alt={ translate( 'Co-branded Jetpack and DreamHost logo' ) }
-					/>
-				);
-
-			case 'pressable':
-				return (
-					<img
-						{ ...baseCobrandedAttributes }
-						src="/calypso/images/jetpack/jetpack-pressable-connection.png"
-						alt={ translate( 'Co-branded Jetpack and Pressable logo' ) }
-					/>
-				);
-
-			case 'milesweb':
-				return (
-					<img
-						{ ...baseCobrandedAttributes }
-						src="/calypso/images/jetpack/jetpack-milesweb-connection.png"
-						alt={ translate( 'Co-branded Jetpack and MilesWeb logo' ) }
-					/>
-				);
-
-			case 'bluehost':
-				return (
-					<img
-						{ ...baseCobrandedAttributes }
-						src="/calypso/images/jetpack/jetpack-bluehost-connection.png"
-						alt={ translate( 'Co-branded Jetpack and Bluehost logo' ) }
-					/>
-				);
-		}
-
-		return <JetpackLogo full size={ 45 } />;
-	}
-
 	render() {
 		const { isWide, className, children } = this.props;
 		const wrapperClassName = classNames( 'jetpack-connect__main', {
@@ -84,11 +37,15 @@ export class JetpackConnectMainWrapper extends PureComponent {
 
 		return (
 			<Main className={ classNames( className, wrapperClassName ) }>
-				<div className="jetpack-connect__main-logo">{ this.getHeaderImage() }</div>
+				<div className="jetpack-connect__main-logo">
+					<JetpackHeader partnerSlug={ this.props.partnerSlug } />
+				</div>
 				{ children }
 			</Main>
 		);
 	}
 }
 
-export default localize( JetpackConnectMainWrapper );
+export default connect( state => ( {
+	partnerSlug: getPartnerSlugFromQuery( state ),
+} ) )( localize( JetpackConnectMainWrapper ) );

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -4,18 +4,18 @@
  * External dependencies
  */
 import classNames from 'classnames';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
+import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
+import JetpackHeader from 'components/jetpack-header';
 import Main from 'components/main';
 import { retrieveMobileRedirect } from './persistence-utils';
-import JetpackHeader from 'components/jetpack-header';
-import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
 
 export class JetpackConnectMainWrapper extends PureComponent {
 	static propTypes = {

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -201,10 +201,9 @@ export class JetpackSignup extends Component {
 		);
 	}
 	render() {
-		const { partnerSlug } = this.props.authQuery;
 		const { isCreatingAccount } = this.state;
 		return (
-			<MainWrapper partnerSlug={ partnerSlug }>
+			<MainWrapper>
 				<div className="jetpack-connect__authorize-form">
 					{ this.renderLocaleSuggestions() }
 					<AuthFormHeader authQuery={ this.props.authQuery } />

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`JetpackAuthorize renders as expected 1`] = `
-<Localized(JetpackConnectMainWrapper)>
+<Connect(Localized(JetpackConnectMainWrapper))>
   <div
     className="jetpack-connect__authorize-form"
   >
@@ -96,5 +96,5 @@ exports[`JetpackAuthorize renders as expected 1`] = `
       </LoggedOutFormLinks>
     </div>
   </div>
-</Localized(JetpackConnectMainWrapper)>
+</Connect(Localized(JetpackConnectMainWrapper))>
 `;

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`JetpackSignup should render 1`] = `
-<Localized(JetpackConnectMainWrapper)>
+<Connect(Localized(JetpackConnectMainWrapper))>
   <div
     className="jetpack-connect__authorize-form"
   >
@@ -49,11 +49,11 @@ exports[`JetpackSignup should render 1`] = `
       suggestedUsername=""
     />
   </div>
-</Localized(JetpackConnectMainWrapper)>
+</Connect(Localized(JetpackConnectMainWrapper))>
 `;
 
 exports[`JetpackSignup should render with locale suggestions 1`] = `
-<Localized(JetpackConnectMainWrapper)>
+<Connect(Localized(JetpackConnectMainWrapper))>
   <div
     className="jetpack-connect__authorize-form"
   >
@@ -106,5 +106,5 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
       suggestedUsername=""
     />
   </div>
-</Localized(JetpackConnectMainWrapper)>
+</Connect(Localized(JetpackConnectMainWrapper))>
 `;

--- a/client/jetpack-connect/test/__snapshots__/utils.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/utils.js.snap
@@ -10,7 +10,6 @@ Object {
   "homeUrl": "http://yourjetpack.blog",
   "jpVersion": null,
   "nonce": "foobar",
-  "partnerSlug": null,
   "redirectAfterAuth": null,
   "redirectUri": "http://yourjetpack.blog/wp-admin/admin.php",
   "scope": "administrator:34579bf2a3185a47d1b31aab30125d",

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -37,7 +37,6 @@ export function authQueryTransformer( queryObject ) {
 		blogname: queryObject.blogname || null,
 		from: queryObject.from || '[unknown]',
 		jpVersion: queryObject.jp_version || null,
-		partnerSlug: getPartnerSlugFromId( queryObject.partner_id ),
 		redirectAfterAuth: queryObject.redirect_after_auth || null,
 		siteIcon: queryObject.site_icon || null,
 		siteUrl: queryObject.site_url || null,
@@ -125,25 +124,4 @@ export function parseAuthorizationQuery( query ) {
 		// The parser is expected to throw SchemaError or TransformerError on bad input.
 	}
 	return null;
-}
-
-export function getPartnerSlugFromId( partnerId ) {
-	switch ( parseInt( partnerId, 10 ) ) {
-		case 51945:
-		case 51946:
-			return 'dreamhost';
-		case 49615:
-		case 49640:
-			return 'pressable';
-		case 57152:
-		case 57733:
-			return 'milesweb';
-		case 41986:
-		case 42000:
-			return 'bluehost';
-		case 51652: // Clients used for testing.
-			return 'dreamhost';
-		default:
-			return null;
-	}
 }

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -53,7 +53,6 @@ export const authQueryPropTypes = PropTypes.shape( {
 	homeUrl: PropTypes.string.isRequired,
 	jpVersion: PropTypes.string,
 	nonce: PropTypes.string.isRequired,
-	partnerSlug: PropTypes.string,
 	redirectAfterAuth: PropTypes.string,
 	redirectUri: PropTypes.string.isRequired,
 	scope: PropTypes.string.isRequired,

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -55,7 +55,7 @@ class MasterbarLoggedOut extends PureComponent {
 
 		const isJetpack = 'jetpack-connect' === sectionName;
 
-		const loginUrl = login( {
+		let loginUrl = login( {
 			// We may know the email from Jetpack connection details
 			emailAddress: isJetpack && get( currentQuery, 'user_email', false ),
 			isJetpack,
@@ -63,6 +63,10 @@ class MasterbarLoggedOut extends PureComponent {
 			locale: getLocaleSlug(),
 			redirectTo,
 		} );
+
+		if ( currentQuery && currentQuery.partner_id ) {
+			loginUrl = addQueryArgs( { partner_id: currentQuery.partner_id }, loginUrl );
+		}
 
 		return (
 			<Item url={ loginUrl }>

--- a/client/state/selectors/get-partner-id-from-query.js
+++ b/client/state/selectors/get-partner-id-from-query.js
@@ -8,7 +8,7 @@ import { get, toNumber, isInteger } from 'lodash';
 /**
  * Internal dependencies
  */
-import getInitialQueryArguments from 'state/selectors/get-initial-query-arguments';
+import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 
 /**
  * Returns the partner_id query param if present or null.
@@ -17,7 +17,7 @@ import getInitialQueryArguments from 'state/selectors/get-initial-query-argument
  * @return {?number}       The partner ID as an integer or null
  */
 export const getPartnerIdFromQuery = function( state ) {
-	const partnerId = toNumber( get( getInitialQueryArguments( state ), 'partner_id' ) );
+	const partnerId = toNumber( get( getCurrentQueryArguments( state ), 'partner_id' ) );
 	return isInteger( partnerId ) ? partnerId : null;
 };
 

--- a/client/state/selectors/test/get-partner-id-from-query.js
+++ b/client/state/selectors/test/get-partner-id-from-query.js
@@ -15,7 +15,7 @@ describe( '#getPartnerIdFromQuery', () => {
 			ui: {
 				route: {
 					query: {
-						initial: {
+						current: {
 							email_address: 'user@wordpress.com',
 						},
 					},
@@ -30,7 +30,7 @@ describe( '#getPartnerIdFromQuery', () => {
 			ui: {
 				route: {
 					query: {
-						initial: {
+						current: {
 							email_address: 'user@wordpress.com',
 							partner_id: 'meh',
 						},
@@ -47,7 +47,7 @@ describe( '#getPartnerIdFromQuery', () => {
 			ui: {
 				route: {
 					query: {
-						initial: {
+						current: {
 							email_address: 'user@wordpress.com',
 							partner_id: '49640',
 						},

--- a/client/state/selectors/test/get-partner-slug-from-query.js
+++ b/client/state/selectors/test/get-partner-slug-from-query.js
@@ -15,7 +15,7 @@ describe( '#getPartnerSlugFromQuery', () => {
 			ui: {
 				route: {
 					query: {
-						initial: {
+						current: {
 							email_address: 'user@wordpress.com',
 						},
 					},
@@ -30,7 +30,7 @@ describe( '#getPartnerSlugFromQuery', () => {
 			ui: {
 				route: {
 					query: {
-						initial: {
+						current: {
 							email_address: 'user@wordpress.com',
 							partner_id: 'meh',
 						},
@@ -47,7 +47,7 @@ describe( '#getPartnerSlugFromQuery', () => {
 			ui: {
 				route: {
 					query: {
-						initial: {
+						current: {
 							email_address: 'user@wordpress.com',
 							partner_id: '49640',
 						},


### PR DESCRIPTION
This PR makes use of the JetpackHeader component merged in #24830 and the `getPartnerSlugFromQuery` selector merged in #24738 to cobrand the JetpackConnect and login flows for users that are receiving a plan from a partner.

To test:

- Checkout this branch
- For all of the tests below, ensure that the partner's logo shows up when expected and that the standard Jetpack logo is shown when:
    1. `partner_id` is not present in the query
    2. The partner ID value is not a known partner with a logo
- Test the following both logged in and logged out
    - Go to a Jetpack site and click the green "Set up Jetpack" button to connect to WordPress.com
    - Once on WordPress.com, copy the connection URL
    - Replace WordPress.com with `calypso.localhost:3000`
    - To test the various co-branded screens you'll add `&partner_id={$ID}` where `$ID` represents one of the hosts below:
        - `51945` or `51946` for DreamHost
        - `49615` or `49640` for Pressable
        - `57152` or `57733` for MilesWeb
        - `41986` or `42000` for Bluehost
    - While going through the various flows, ensure there are no errors
- Test the following while logged out
    - Go to `http://calypso.localhost:3000/log-in/jetpack
    - To test the various co-branded screens you'll add `&partner_id={$ID}` where `$ID` represents one of the hosts below:
        - `51945` or `51946` for DreamHost
        - `49615` or `49640` for Pressable
        - `57152` or `57733` for MilesWeb
        - `41986` or `42000` for Bluehost
- Provision a new site on Pressable
    - Wait a couple of minutes then connect the site to WordPress.com
    - Change the URL from wordpress.com to calypso.localhost:3000 and then authorize
    - Ensure that you land on a screen to approve credential sharing

I'm pinging some Jetpack folks for review as well as @stephanethomas who Github recommended. 😄

The biggest change here is in on the login page, so here are a couple of screenshots of that:

Cobranded:

<img width="448" alt="screen shot 2018-05-21 at 3 58 44 pm" src="https://user-images.githubusercontent.com/1126811/40329688-f69714b6-5d0f-11e8-94b3-37a7232a8991.png">

Standard:

<img width="472" alt="screen shot 2018-05-21 at 3 58 15 pm" src="https://user-images.githubusercontent.com/1126811/40329679-ee145fc4-5d0f-11e8-9e68-1cd5cde7fb21.png">
