### PR TITLE
Account closure: username confirm step in confirmation dialog

### DIFF
--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -21,15 +21,20 @@ class AccountCloseConfirmDialog extends React.Component {
 		inputValue: '',
 	};
 
+	handleCancel = () => {
+		this.setState( { inputValue: '' } );
+		this.props.closeConfirmDialog();
+	};
+
 	handleInputChange = event => {
 		this.setState( { inputValue: event.target.value.toLowerCase() } );
 	};
 
 	render() {
-		const { isVisible, currentUsername, onConfirm, translate, closeConfirmDialog } = this.props;
-		const isButtonDisabled = this.state.inputValue !== currentUsername;
+		const { isVisible, currentUsername, onConfirm, translate } = this.props;
+		const isButtonDisabled = currentUsername && this.state.inputValue !== currentUsername;
 		const deleteButtons = [
-			<Button onClick={ closeConfirmDialog }>{ translate( 'Cancel' ) }</Button>,
+			<Button onClick={ this.handleCancel }>{ translate( 'Cancel' ) }</Button>,
 			<Button primary scary disabled={ isButtonDisabled } onClick={ onConfirm }>
 				{ translate( 'Close your account' ) }
 			</Button>,

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -21,13 +21,27 @@ class AccountCloseConfirmDialog extends React.Component {
 		inputValue: '',
 	};
 
+	componentDidMount() {
+		document.addEventListener( 'keydown', this.handleDialogKeydown );
+	}
+
+	componentWillUnmount() {
+		document.removeEventListener( 'keydown', this.handleDialogKeydown );
+	}
+
 	handleCancel = () => {
-		this.setState( { inputValue: '' } );
 		this.props.closeConfirmDialog();
+		this.setState( { inputValue: '' } );
 	};
 
 	handleInputChange = event => {
 		this.setState( { inputValue: event.target.value.toLowerCase() } );
+	};
+
+	handleDialogKeydown = event => {
+		if ( event.key === 'Escape' ) {
+			this.handleCancel();
+		}
 	};
 
 	render() {

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -13,61 +14,76 @@ import { noop } from 'lodash';
 import Dialog from 'components/dialog';
 import FormLabel from 'components/forms/form-label';
 import Button from 'components/button';
+import { getCurrentUser } from 'state/current-user/selectors';
 
-const AccountCloseConfirmDialog = ( {
-	isVisible,
-	username,
-	onConfirm,
-	translate,
-	closeConfirmDialog,
-	deleteAccount,
-} ) => {
-	const deleteButtons = [
-		<Button onClick={ closeConfirmDialog }>{ translate( 'Cancel' ) }</Button>,
-		<Button primary scary disabled onClick={ deleteAccount }>
-			{ translate( 'Close your account' ) }
-		</Button>,
-	];
+class AccountCloseConfirmDialog extends React.Component {
+	state = {
+		inputValue: '',
+	};
 
-	return (
-		<Dialog
-			isVisible={ isVisible }
-			buttons={ deleteButtons }
-			className="account-close__confirm-dialog"
-		>
-			<h1 className="account-close__confirm-dialog-header">
-				{ translate( 'Confirm account closure' ) }
-			</h1>
-			<FormLabel htmlFor="confirmAccountCloseInput" className="account-close__confirm-dialog-label">
-				{ translate(
-					'Please type {{warn}}%(username)s{{/warn}} in the field below to confirm. ' +
-						'Your account will then be gone forever.',
-					{
-						components: {
-							warn: <span className="account-close__confirm-dialog-target-username" />,
-						},
-						args: {
-							username: username,
-						},
-					}
-				) }
-			</FormLabel>
+	handleInputChange = event => {
+		this.setState( { inputValue: event.target.value.toLowerCase() } );
+	};
 
-			<input
-				autoCapitalize="off"
-				className="account-close__confirm-dialog-confirm-input"
-				type="text"
-				onChange={ onConfirm }
-				aria-required="true"
-				id="confirmAccountCloseInput"
-			/>
-		</Dialog>
-	);
-};
+	render() {
+		const { isVisible, currentUsername, onConfirm, translate, closeConfirmDialog } = this.props;
+		const isButtonDisabled = this.state.inputValue !== currentUsername;
+		const deleteButtons = [
+			<Button onClick={ closeConfirmDialog }>{ translate( 'Cancel' ) }</Button>,
+			<Button primary scary disabled={ isButtonDisabled } onClick={ onConfirm }>
+				{ translate( 'Close your account' ) }
+			</Button>,
+		];
+
+		return (
+			<Dialog
+				isVisible={ isVisible }
+				buttons={ deleteButtons }
+				className="account-close__confirm-dialog"
+			>
+				<h1 className="account-close__confirm-dialog-header">
+					{ translate( 'Confirm account closure' ) }
+				</h1>
+				<FormLabel
+					htmlFor="confirmAccountCloseInput"
+					className="account-close__confirm-dialog-label"
+				>
+					{ translate(
+						'Please type {{warn}}%(currentUsername)s{{/warn}} in the field below to confirm. ' +
+							'Your account will then be gone forever.',
+						{
+							components: {
+								warn: <span className="account-close__confirm-dialog-target-username" />,
+							},
+							args: {
+								currentUsername,
+							},
+						}
+					) }
+				</FormLabel>
+
+				<input
+					autoCapitalize="off"
+					className="account-close__confirm-dialog-confirm-input"
+					type="text"
+					onChange={ this.handleInputChange }
+					value={ this.state.inputValue }
+					aria-required="true"
+					id="confirmAccountCloseInput"
+				/>
+			</Dialog>
+		);
+	}
+}
 
 AccountCloseConfirmDialog.defaultProps = {
-	deleteAccount: noop,
-	username: 'yourusername', // @todo connect this to get real username
+	onConfirm: noop,
 };
 
-export default localize( AccountCloseConfirmDialog );
+export default connect( state => {
+	const user = getCurrentUser( state );
+
+	return {
+		currentUsername: user && user.username,
+	};
+} )( localize( AccountCloseConfirmDialog ) );


### PR DESCRIPTION
This PR switches to use the real username for the confirm step:

<img width="508" alt="screen shot 2018-05-21 at 12 08 24" src="https://user-images.githubusercontent.com/17325/40285416-ca7bad9e-5cef-11e8-896d-944f2ae0639c.png">

### To test

Head to http://calypso.localhost:3000/me/account/close. 

Check that your username is displayed, and make sure that the delete button doesn't become active until your input matches your username.

Make sure pressing Cancel (or pressing Escape) clears the input and closes the dialog.