### PR TITLE
Account closure: fetch purchases and sites, and display appropriate message to user

### DIFF
--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -92,23 +92,28 @@ class AccountSettingsClose extends Component {
 								</ActionPanelFigureList>
 							</ActionPanelFigure>
 						) }
-						{ hasAtomicSites && (
-							<Fragment>
-								<p className="account-close__body-copy">
-									{ translate(
-										"To close your account, you'll need to contact our support team. Account closure cannot be undone " +
-											'and will remove all sites and content.'
-									) }
-								</p>
-								<p className="account-close__body-copy">
-									{ translate(
-										"If you're unsure about what account closure means or have any other questions, " +
-											"you'll have a chance to chat with someone from our support team before anything happens."
-									) }
-								</p>
-							</Fragment>
-						) }
-						{ hasPurchases &&
+						{ ! isLoading &&
+							hasAtomicSites && (
+								<Fragment>
+									<p className="account-close__body-copy">
+										{ translate(
+											'Account closure cannot be undone and will remove all sites and content.'
+										) }
+									</p>
+									<p className="account-close__body-copy">
+										{ translate(
+											"To close your account, you'll need to {{a}}contact our support team{{/a}}.",
+											{
+												components: {
+													a: <ActionPanelLink href="/help/contact" />,
+												},
+											}
+										) }
+									</p>
+								</Fragment>
+							) }
+						{ ! isLoading &&
+							hasPurchases &&
 							! hasAtomicSites && (
 								<Fragment>
 									<p className="account-close__body-copy">
@@ -149,13 +154,13 @@ class AccountSettingsClose extends Component {
 						) }
 					</ActionPanelBody>
 					<ActionPanelFooter>
-						{ isDeletePossible && (
+						{ ( isLoading || isDeletePossible ) && (
 							<Button scary onClick={ this.handleDeleteClick }>
 								<Gridicon icon="trash" />
 								{ translate( 'Close Account' ) }
 							</Button>
 						) }
-						{ ( isLoading || hasAtomicSites ) && (
+						{ hasAtomicSites && (
 							<Button primary href="/help/contact">
 								{ translate( 'Contact Support' ) }
 							</Button>

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -92,23 +92,52 @@ class AccountSettingsClose extends Component {
 								</ActionPanelFigureList>
 							</ActionPanelFigure>
 						) }
-						{ ! hasAtomicSites && (
+						{ hasAtomicSites && (
 							<Fragment>
-								<p class="account-close__body-copy">
+								<p className="account-close__body-copy">
 									{ translate(
-										'Account closure {{strong}}cannot{{/strong}} be undone, ' +
-											'and will remove all sites and content.',
-										{
-											components: {
-												strong: <strong />,
-											},
-										}
+										"To close your account, you'll need to contact our support team. Account closure cannot be undone " +
+											'and will remove all sites and content.'
 									) }
 								</p>
-								<p class="account-close__body-copy">
+								<p className="account-close__body-copy">
 									{ translate(
 										"If you're unsure about what account closure means or have any other questions, " +
-											'please {{a}}chat with someone from our support team{{/a}} before proceeding.',
+											"you'll have a chance to chat with someone from our support team before anything happens."
+									) }
+								</p>
+							</Fragment>
+						) }
+						{ hasPurchases &&
+							! hasAtomicSites && (
+								<Fragment>
+									<p className="account-close__body-copy">
+										{ translate( 'You still have active purchases on your account.' ) }
+									</p>
+									<p className="account-close__body-copy">
+										{ translate(
+											"To delete your account, you'll need to cancel any active purchases " +
+												'in {{a}}Manage Purchases{{/a}} before proceeding.',
+											{
+												components: {
+													a: <ActionPanelLink href="/me/purchases" />,
+												},
+											}
+										) }
+									</p>
+								</Fragment>
+							) }
+						{ ( isLoading || isDeletePossible ) && (
+							<Fragment>
+								<p className="account-close__body-copy">
+									{ translate(
+										'Account closure cannot be undone and will remove all sites and content.'
+									) }
+								</p>
+								<p className="account-close__body-copy">
+									{ translate(
+										"If you're unsure about what account closure means or have any other questions, " +
+											'{a}chat with someone from our support team{/a} before going ahead.',
 										{
 											components: {
 												a: <ActionPanelLink href="/help/contact" />,
@@ -118,35 +147,25 @@ class AccountSettingsClose extends Component {
 								</p>
 							</Fragment>
 						) }
-						{ hasAtomicSites && (
-							<Fragment>
-								<p>
-									{ translate(
-										"To close your account, you'll need to contact our support team. Account closure cannot be undone " +
-											'and will remove all sites and content.'
-									) }
-								</p>
-								<p>
-									{ translate(
-										"If you're unsure about what account closure means or have any other questions, " +
-											"you'll have a chance to chat with someone from our support team before anything happens."
-									) }
-								</p>
-							</Fragment>
-						) }
 					</ActionPanelBody>
 					<ActionPanelFooter>
 						{ isDeletePossible && (
 							<Button scary onClick={ this.handleDeleteClick }>
 								<Gridicon icon="trash" />
-								{ translate( 'Close account' ) }
+								{ translate( 'Close Account' ) }
 							</Button>
 						) }
-						{ ! isDeletePossible && (
+						{ ( isLoading || hasAtomicSites ) && (
 							<Button primary href="/help/contact">
-								{ translate( 'Contact support' ) }
+								{ translate( 'Contact Support' ) }
 							</Button>
 						) }
+						{ hasPurchases &&
+							! hasAtomicSites && (
+								<Button primary href="/me/purchases">
+									{ translate( 'Manage Purchases' ) }
+								</Button>
+							) }
 					</ActionPanelFooter>
 					<AccountCloseConfirmDialog
 						isVisible={ this.state.showConfirmDialog }

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -3,11 +3,12 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import page from 'page';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -56,11 +57,14 @@ class AccountSettingsClose extends Component {
 	};
 
 	render() {
-		const { translate, currentUserId, hasAtomicSites, hasPurchases } = this.props;
-		const isDeletePossible = ! hasAtomicSites && ! hasPurchases;
+		const { translate, currentUserId, hasAtomicSites, hasPurchases, isLoading } = this.props;
+		const isDeletePossible = ! isLoading && ! hasAtomicSites && ! hasPurchases;
+		const containerClasses = classnames( 'account-close', 'main', {
+			'is-loading': isLoading,
+		} );
 
 		return (
-			<div className="account-close main" role="main">
+			<div className={ containerClasses } role="main">
 				{ currentUserId && <QueryUserPurchases userId={ currentUserId } /> }
 				<QuerySites allSites />
 				<HeaderCake onClick={ this.goBack }>
@@ -89,8 +93,8 @@ class AccountSettingsClose extends Component {
 							</ActionPanelFigure>
 						) }
 						{ ! hasAtomicSites && (
-							<div>
-								<p>
+							<Fragment>
+								<p class="account-close__body-copy">
 									{ translate(
 										'Account closure {{strong}}cannot{{/strong}} be undone, ' +
 											'and will remove all sites and content.',
@@ -101,7 +105,7 @@ class AccountSettingsClose extends Component {
 										}
 									) }
 								</p>
-								<p>
+								<p class="account-close__body-copy">
 									{ translate(
 										"If you're unsure about what account closure means or have any other questions, " +
 											'please {{a}}chat with someone from our support team{{/a}} before proceeding.',
@@ -112,10 +116,10 @@ class AccountSettingsClose extends Component {
 										}
 									) }
 								</p>
-							</div>
+							</Fragment>
 						) }
 						{ hasAtomicSites && (
-							<div>
+							<Fragment>
 								<p>
 									{ translate(
 										"To close your account, you'll need to contact our support team. Account closure cannot be undone " +
@@ -128,7 +132,7 @@ class AccountSettingsClose extends Component {
 											"you'll have a chance to chat with someone from our support team before anything happens."
 									) }
 								</p>
-							</div>
+							</Fragment>
 						) }
 					</ActionPanelBody>
 					<ActionPanelFooter>
@@ -157,8 +161,9 @@ class AccountSettingsClose extends Component {
 export default connect( state => {
 	const user = getCurrentUser( state );
 	const currentUserId = user && user.ID;
-	const isLoading = ! hasLoadedSites( state ) || ! hasLoadedUserPurchasesFromServer( state );
 	const purchases = getUserPurchases( state, currentUserId );
+	const isLoading =
+		! purchases || ! hasLoadedSites( state ) || ! hasLoadedUserPurchasesFromServer( state );
 
 	return {
 		currentUserId: user && user.ID,

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -137,7 +137,7 @@ class AccountSettingsClose extends Component {
 								<p className="account-close__body-copy">
 									{ translate(
 										"If you're unsure about what account closure means or have any other questions, " +
-											'{a}chat with someone from our support team{/a} before going ahead.',
+											'{{a}}chat with someone from our support team{{/a}} before going ahead.',
 										{
 											components: {
 												a: <ActionPanelLink href="/help/contact" />,
@@ -187,7 +187,7 @@ export default connect( state => {
 	return {
 		currentUserId: user && user.ID,
 		isLoading,
-		hasPurchases: !! purchases,
+		hasPurchases: purchases && purchases.length > 0,
 		hasAtomicSites: userHasAnyAtomicSites( state ),
 	};
 } )( localize( AccountSettingsClose ) );

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -28,7 +28,8 @@ import QueryUserPurchases from 'components/data/query-user-purchases';
 import QuerySites from 'components/data/query-sites';
 import { getCurrentUser } from 'state/current-user/selectors';
 import hasLoadedSites from 'state/selectors/has-loaded-sites';
-import { hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
+import userHasAnyAtomicSites from 'state/selectors/user-has-any-atomic-sites';
+import { hasLoadedUserPurchasesFromServer, getUserPurchases } from 'state/purchases/selectors';
 
 class AccountSettingsClose extends Component {
 	state = {
@@ -55,9 +56,7 @@ class AccountSettingsClose extends Component {
 	};
 
 	render() {
-		const { translate, currentUserId } = this.props;
-		const hasAtomicSites = false;
-		const hasPurchases = false;
+		const { translate, currentUserId, hasAtomicSites, hasPurchases } = this.props;
 		const isDeletePossible = ! hasAtomicSites && ! hasPurchases;
 
 		return (
@@ -133,13 +132,13 @@ class AccountSettingsClose extends Component {
 						) }
 					</ActionPanelBody>
 					<ActionPanelFooter>
-						{ ! hasAtomicSites && (
+						{ isDeletePossible && (
 							<Button scary onClick={ this.handleDeleteClick }>
 								<Gridicon icon="trash" />
 								{ translate( 'Close account' ) }
 							</Button>
 						) }
-						{ hasAtomicSites && (
+						{ ! isDeletePossible && (
 							<Button primary href="/help/contact">
 								{ translate( 'Contact support' ) }
 							</Button>
@@ -157,10 +156,14 @@ class AccountSettingsClose extends Component {
 
 export default connect( state => {
 	const user = getCurrentUser( state );
+	const currentUserId = user && user.ID;
 	const isLoading = ! hasLoadedSites( state ) || ! hasLoadedUserPurchasesFromServer( state );
+	const purchases = getUserPurchases( state, currentUserId );
 
 	return {
 		currentUserId: user && user.ID,
 		isLoading,
+		hasPurchases: !! purchases,
+		hasAtomicSites: userHasAnyAtomicSites( state ),
 	};
 } )( localize( AccountSettingsClose ) );

--- a/client/me/account-close/style.scss
+++ b/client/me/account-close/style.scss
@@ -31,3 +31,15 @@ h1.account-close__confirm-dialog-header {
 .account-close__confirm-dialog-target-username {
 	color: $alert-red;
 }
+
+// Placeholders
+.account-close.is-loading .account-close__body-copy,
+.account-close.is-loading .account-close__body-copy a,
+.account-close.is-loading .action-panel__footer .button {
+	@include placeholder();
+}
+
+.account-close.is-loading .action-panel__footer .button {
+	border: 0;
+}
+


### PR DESCRIPTION
A user with any Atomic sites will see:

<img width="771" alt="screen shot 2018-05-21 at 18 08 25" src="https://user-images.githubusercontent.com/17325/40293105-61d3e174-5d23-11e8-9918-12a3598e4ed1.png">

A user without Atomic sites, but with active purchases, will see:

<img width="776" alt="screen shot 2018-05-21 at 17 43 50" src="https://user-images.githubusercontent.com/17325/40293120-74262aee-5d23-11e8-86e7-23fdc5a7d601.png">

Finally, a user without any active purchases or Atomic sites will be able to delete the account themselves:

<img width="764" alt="screen shot 2018-05-21 at 18 03 13" src="https://user-images.githubusercontent.com/17325/40293130-8682a866-5d23-11e8-8cc4-3054c595055a.png">

### To test

Visit http://calypso.localhost:3000/me/account/close.