### PR TITLE
[WIP] Ebanx payments: payment method not fetched when adding a card

### DIFF
--- a/client/lib/cart/store/index.js
+++ b/client/lib/cart/store/index.js
@@ -54,6 +54,9 @@ const CartStore = {
 
 		_poller = PollerPool.add( CartStore, _synchronizer._poll.bind( _synchronizer ) );
 	},
+	fetch: function() {
+		return _synchronizer && _synchronizer.fetch();
+	},
 };
 
 emitter( CartStore );

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -27,6 +27,7 @@ import titles from './titles';
 import userFactory from 'lib/user';
 import { makeLayout, render as clientRender } from 'controller';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import CartStore from 'lib/cart/store';
 
 const user = userFactory();
 
@@ -67,6 +68,13 @@ export function addCardDetails( context, next ) {
 }
 
 export function addCreditCard( context, next ) {
+	// Check if there's been a first call to get the shopping cart.
+	// If not, it means we don't have the payment methods.
+	if ( ! CartStore.get().hasLoadedFromServer ) {
+		CartStore.setSelectedSiteId( null );
+		CartStore.fetch();
+	}
+
 	context.primary = <AddCreditCard />;
 	next();
 }

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -68,8 +68,9 @@ export function addCardDetails( context, next ) {
 }
 
 export function addCreditCard( context, next ) {
-	// Check if there's been a first call to get the shopping cart.
-	// If not, it means we don't have the payment methods.
+	// Here we check if there's been a first call to get the shopping cart.
+	// If none has been made, it means we don't have any stored payment methods
+	// against which to check before adding a credit card.
 	if ( ! CartStore.get().hasLoadedFromServer ) {
 		CartStore.setSelectedSiteId( null );
 		CartStore.fetch();


### PR DESCRIPTION
This PR addresses #24944

On the 'add a new card' page, when Ebanx is available as a payment method we ask the customer to provide extra details that are required when using this payment method.

Available payment methods arrive at the front end via calls to `/me/shopping-cart`

However when refreshing the add credit card page, no such call is triggered and therefore we do not present the the Ebanx fields. This PR kicks offs a cart store call in order to grab the payment methods.

## Testing
TBD