### PR TITLE
Post Editor: remove unneeded props from InvalidUrlDialog

### DIFF
--- a/client/post-editor/invalid-url-dialog.jsx
+++ b/client/post-editor/invalid-url-dialog.jsx
@@ -30,11 +30,11 @@ class EditorTrashedDialog extends React.Component {
 		isPage: this.isPage(),
 	};
 
-	isPage = () => {
+	isPage() {
 		return startsWith( page.current, '/page/' );
-	};
+	}
 
-	getDialogButtons = () => {
+	getDialogButtons() {
 		const newText = this.state.isPage
 			? this.props.translate( 'New Page' )
 			: this.props.translate( 'New Post' );
@@ -46,7 +46,7 @@ class EditorTrashedDialog extends React.Component {
 				{ this.props.translate( 'Close' ) }
 			</FormButton>,
 		];
-	};
+	}
 
 	startNewPage = () => {
 		const siteFragment = getSiteFragment( page.current );
@@ -54,7 +54,7 @@ class EditorTrashedDialog extends React.Component {
 		page( postSegment + siteFragment );
 	};
 
-	getStrings = isPage => {
+	getStrings( isPage ) {
 		if ( isPage ) {
 			return {
 				dialogTitle: this.props.translate( 'Invalid Page Address' ),
@@ -69,7 +69,7 @@ class EditorTrashedDialog extends React.Component {
 				'This post cannot be found. Check the web address or start a new post.'
 			),
 		};
-	};
+	}
 
 	render() {
 		const strings = this.getStrings( this.state.isPage );

--- a/client/post-editor/invalid-url-dialog.jsx
+++ b/client/post-editor/invalid-url-dialog.jsx
@@ -20,12 +20,14 @@ class EditorTrashedDialog extends React.Component {
 
 	static defaultProps = {
 		onClose: noop,
-		onSave: noop,
 	};
 
 	static propTypes = {
 		onClose: PropTypes.func,
-		onSave: PropTypes.func,
+	};
+
+	state = {
+		isPage: this.isPage(),
 	};
 
 	isPage = () => {
@@ -67,10 +69,6 @@ class EditorTrashedDialog extends React.Component {
 				'This post cannot be found. Check the web address or start a new post.'
 			),
 		};
-	};
-
-	state = {
-		isPage: this.isPage(),
 	};
 
 	render() {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -416,9 +416,7 @@ export class PostEditor extends React.Component {
 				{ this.state.showVerifyEmailDialog ? (
 					<VerifyEmailDialog onClose={ this.closeVerifyEmailDialog } />
 				) : null }
-				{ isInvalidURL ? (
-					<InvalidURLDialog post={ this.state.post } onClose={ this.onClose } />
-				) : null }
+				{ isInvalidURL && <InvalidURLDialog onClose={ this.onClose } /> }
 				{ hasAutosave && this.state.showAutosaveDialog ? (
 					<RestorePostDialog
 						onRestore={ this.restoreAutosave }


### PR DESCRIPTION
The `InvalidUrlDialog` doesn't need the `post` prop and the `onSave` prop is unused, too. This patch removes the unneeded code.

**How to test:**
Enter an editor URL of post with invalid ID:
```
https://wordpress.com/post/example.blog/1234
https://wordpress.com/page/example.blog/5678
```
Verify that the "Invalid URL" dialog is displayed, that the copy reflects the Post vs Page difference and that both buttons (Close and Start New) do their job.