### PR TITLE
Post Editor: stop passing Flux data to EditorDeletePost

### DIFF
--- a/client/post-editor/editor-delete-post/index.jsx
+++ b/client/post-editor/editor-delete-post/index.jsx
@@ -28,8 +28,11 @@ class EditorDeletePost extends React.Component {
 	static displayName = 'EditorDeletePost';
 
 	static propTypes = {
-		site: PropTypes.object,
-		post: PropTypes.object,
+		siteId: PropTypes.number,
+		postId: PropTypes.number,
+		postType: PropTypes.string,
+		postStatus: PropTypes.string,
+		canDelete: PropTypes.bool,
 		onTrashingPost: PropTypes.func,
 	};
 
@@ -54,14 +57,14 @@ class EditorDeletePost extends React.Component {
 	};
 
 	onSendToTrash = () => {
-		const { translate, post } = this.props;
+		const { translate, postType } = this.props;
 
 		if ( this.state.isTrashing ) {
 			return;
 		}
 
 		let message;
-		if ( post.type === 'page' ) {
+		if ( postType === 'page' ) {
 			message = translate( 'Are you sure you want to trash this page?' );
 		} else {
 			message = translate( 'Are you sure you want to trash this post?' );
@@ -117,8 +120,8 @@ export default connect(
 
 		return {
 			siteId,
-			post,
 			postId,
+			postType: get( post, 'type', null ),
 			postStatus: get( post, 'status', null ),
 			canDelete: canCurrentUser( state, siteId, isAuthor ? 'delete_posts' : 'delete_others_posts' ),
 		};

--- a/client/post-editor/editor-sidebar/index.jsx
+++ b/client/post-editor/editor-sidebar/index.jsx
@@ -52,7 +52,7 @@ export class EditorSidebar extends Component {
 					confirmationSidebarStatus={ confirmationSidebarStatus }
 				/>
 				<SidebarFooter>
-					<EditorDeletePost post={ post } onTrashingPost={ onTrashingPost } />
+					<EditorDeletePost onTrashingPost={ onTrashingPost } />
 				</SidebarFooter>
 			</div>
 		);


### PR DESCRIPTION
The `EditorDeletePost` component is getting the `post` prop from Redux, no need to pass the Flux version from the parent component.

There's also a `PropTypes` cleanup and instead of the full `post`, we pass only the required `postType` and `postStatus`. That avoids a lot of unneeded rerenders when irrelevant post attributes change.

**How to test:**
Check that the "Move to trash" link at the very bottom of the editor sidebar works as expected.
