### PR TITLE
Post Editor: stop passing Flux post to EditorConfirmationSidebar

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -283,7 +283,6 @@ export class PostEditor extends React.Component {
 					handlePreferenceChange={ this.handleConfirmationSidebarPreferenceChange }
 					onPrivatePublish={ this.onPublish }
 					onPublish={ this.onPublish }
-					post={ this.state.post }
 					savedPost={ this.state.savedPost }
 					setPostDate={ this.setPostDate }
 					setStatus={ this.setConfirmationSidebar }


### PR DESCRIPTION
`EditorConfirmationSidebar` gets the `post` prop in its `mapStateToProps` function, so there's no point in passing the Flux `post` from parent component: it's always overwritten.