### PR TITLE
Post Editor: clean up the QuickSaveButtons component

### DIFF
--- a/client/post-editor/editor-ground-control/history-button.jsx
+++ b/client/post-editor/editor-ground-control/history-button.jsx
@@ -29,14 +29,11 @@ HistoryButton.propTypes = {
 	translate: PropTypes.func,
 };
 
-const mapDispatchToProps = dispatch => ( {
-	selectHistory: () =>
-		dispatch(
-			withAnalytics(
-				recordTracksEvent( 'calypso_editor_history_button_click' ),
-				openPostRevisionsDialog()
-			)
-		),
-} );
+// Action creator to call openPostRevisionsDialog wrapped with analytics call
+const selectHistory = () =>
+	withAnalytics(
+		recordTracksEvent( 'calypso_editor_history_button_click' ),
+		openPostRevisionsDialog()
+	);
 
-export default connect( null, mapDispatchToProps )( localize( HistoryButton ) );
+export default connect( null, { selectHistory } )( localize( HistoryButton ) );

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -173,7 +173,6 @@ export class EditorGroundControl extends React.Component {
 			isSaveBlocked,
 			isDirty,
 			hasContent,
-			post,
 			onSave,
 			translate,
 			userNeedsVerification,
@@ -218,7 +217,6 @@ export class EditorGroundControl extends React.Component {
 					isSaveBlocked={ isSaveBlocked }
 					isDirty={ isDirty }
 					hasContent={ hasContent }
-					post={ post }
 					onSave={ onSave }
 				/>
 				{ this.renderGroundControlActionButtons() }

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -37,7 +37,6 @@ export class EditorGroundControl extends React.Component {
 		isPublishing: PropTypes.bool,
 		isSaving: PropTypes.bool,
 		isSidebarOpened: PropTypes.bool,
-		loadRevision: PropTypes.func.isRequired,
 		moment: PropTypes.func,
 		onPreview: PropTypes.func,
 		onPublish: PropTypes.func,
@@ -174,7 +173,6 @@ export class EditorGroundControl extends React.Component {
 			isSaveBlocked,
 			isDirty,
 			hasContent,
-			loadRevision,
 			post,
 			onSave,
 			translate,
@@ -220,7 +218,6 @@ export class EditorGroundControl extends React.Component {
 					isSaveBlocked={ isSaveBlocked }
 					isDirty={ isDirty }
 					hasContent={ hasContent }
-					loadRevision={ loadRevision }
 					post={ post }
 					onSave={ onSave }
 				/>

--- a/client/post-editor/editor-ground-control/quick-save-buttons.jsx
+++ b/client/post-editor/editor-ground-control/quick-save-buttons.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
+import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
@@ -34,7 +34,6 @@ const QuickSaveButtons = ( {
 	post,
 	translate,
 	onSave,
-	showRevisions = true,
 } ) => {
 	const onSaveButtonClick = () => {
 		onSave();
@@ -53,7 +52,7 @@ const QuickSaveButtons = ( {
 
 	const showingStatusLabel = isSaving || ( post && post.ID && ! isPublished( post ) );
 	const showingSaveStatus = isSaveAvailable || showingStatusLabel;
-	const hasRevisions = showRevisions && get( post, 'revisions.length' );
+	const hasRevisions = post && ! isEmpty( post.revisions );
 
 	if ( ! ( showingSaveStatus || hasRevisions ) ) {
 		return null;

--- a/client/post-editor/editor-ground-control/quick-save-buttons.jsx
+++ b/client/post-editor/editor-ground-control/quick-save-buttons.jsx
@@ -33,7 +33,6 @@ const QuickSaveButtons = ( {
 	isSaveBlocked,
 	isDirty,
 	hasContent,
-	loadRevision,
 	post,
 	translate,
 	onSave,
@@ -66,7 +65,7 @@ const QuickSaveButtons = ( {
 
 	return (
 		<div className="editor-ground-control__quick-save">
-			{ hasRevisions && <HistoryButton loadRevision={ loadRevision } /> }
+			{ hasRevisions && <HistoryButton /> }
 			{ showingSaveStatus && (
 				<div className="editor-ground-control__status">
 					{ isSaveAvailable && (
@@ -98,7 +97,6 @@ QuickSaveButtons.propTypes = {
 	isSaveBlocked: PropTypes.bool,
 	isDirty: PropTypes.bool,
 	hasContent: PropTypes.bool,
-	loadRevision: PropTypes.func.isRequired,
 	post: PropTypes.object,
 	onSave: PropTypes.func,
 

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -303,7 +303,6 @@ export class PostEditor extends React.Component {
 						isSaveBlocked={ this.isSaveBlocked() }
 						isPublishing={ this.state.isPublishing }
 						isSaving={ this.state.isSaving }
-						loadRevision={ this.loadRevision }
 						onPreview={ this.onPreview }
 						onPublish={ this.onPublish }
 						onSave={ this.onSave }
@@ -333,7 +332,6 @@ export class PostEditor extends React.Component {
 										isSaveBlocked={ this.isSaveBlocked() }
 										isDirty={ this.state.isDirty || this.props.dirty }
 										hasContent={ this.state.hasContent }
-										loadRevision={ this.loadRevision }
 										post={ this.state.post }
 										onSave={ this.onSave }
 									/>

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -332,7 +332,6 @@ export class PostEditor extends React.Component {
 										isSaveBlocked={ this.isSaveBlocked() }
 										isDirty={ this.state.isDirty || this.props.dirty }
 										hasContent={ this.state.hasContent }
-										post={ this.state.post }
 										onSave={ this.onSave }
 									/>
 								) : (


### PR DESCRIPTION
This PR is a series of small commits that removes unneeded props from the `QuickSaveButtons` component and some related ones. See individual commit message for more details.

**How to test:**
`QuickSaveButtons` show the "History", "Save", "Saving..." and "Saved" buttons in the editor masterbar:
<img width="442" alt="screen shot 2018-05-21 at 14 34 54" src="https://user-images.githubusercontent.com/664258/40307817-44d22b90-5d04-11e8-9e65-49b8860efb51.png">

Verify that:
- "Save" is offered only on unpublished posts that are dirty and have some content
- during save (or draft autosave), the "Saving..." label is displayed
- a draft that has been recently saved shows the "Saved" label
- a post that has multiple revisions shows the "History" button and that clicking the button opens the Revisions modal and that it's possible to load a revision from that modal.