### PR TITLE
Framework: Update to express@4.16.3

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -940,8 +940,8 @@
       "integrity": "sha512-vCpf75JDcdomXvUd7Rn6DfYAVqPAFI66FVjxiWGwh85OLdvfo3paBoPJaam5keIYRyUolnS7SleS/ZPCidCvzw=="
     },
     "@types/node": {
-      "version": "10.1.0",
-      "integrity": "sha512-sELcX/cJHwRp8kn4hYSvBxKGJ+ubl3MvS8VJQe5gz/sp7CifYxsiCxIJ35wMIYyGVMgfO2AzRa8UcVReAcJRlw==",
+      "version": "10.1.2",
+      "integrity": "sha512-bjk1RIeZBCe/WukrFToIVegOf91Pebr8cXYBwLBIsfiGWVQ+ifwWsT59H3RxrWzWrzd1l/Amk1/ioY5Fq3/bpA==",
       "dev": true
     },
     "JSONStream": {
@@ -963,11 +963,11 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "accepts": {
-      "version": "1.2.13",
-      "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
+      "version": "1.3.5",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
         "mime-types": "2.1.18",
-        "negotiator": "0.5.3"
+        "negotiator": "0.6.1"
       }
     },
     "acorn": {
@@ -1294,13 +1294,13 @@
       "integrity": "sha512-LuWbpSYdTwrGv5MWhsUY69UaQAc3AYMwf/LwTupotu/ubb/1TjDd03WK1eoMXRK/s3bmi4aUkKY0TmxYQgRrmw==",
       "dev": true,
       "requires": {
-        "nextgen-events": "0.14.5",
+        "nextgen-events": "0.14.6",
         "tree-kit": "0.5.27"
       },
       "dependencies": {
         "nextgen-events": {
-          "version": "0.14.5",
-          "integrity": "sha512-NV7BBka95RVt0A43LTx8vCbBzJbrzZkCKPgQH42nhKk41NmMbt1VXUR9K9BzXjuVWDG2Qigt0X9tM7OWACRFDQ==",
+          "version": "0.14.6",
+          "integrity": "sha512-Ln9d5Midoah7RCxFk8z9tAAcRW/VkB4wZ61Nnw8aqM1/lb/WfPAnlzpLGYRghEjwZdXQNQedTfD/gclYMeI0eQ==",
           "dev": true
         }
       }
@@ -1323,7 +1323,7 @@
       "integrity": "sha1-a8vQOKM3xwYn5/zkQ4+lgYjwk3s=",
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000841",
+        "caniuse-db": "1.0.30000844",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -1334,7 +1334,7 @@
           "version": "1.3.6",
           "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
           "requires": {
-            "caniuse-db": "1.0.30000841"
+            "caniuse-db": "1.0.30000844"
           }
         }
       }
@@ -1567,7 +1567,7 @@
       "integrity": "sha512-rEdN/jevSuX0IQKcUqwqOGa0gDNis4jGY52Rq53aizfDGPwQYNJq+f9NCMT1HUhtUZhYSjvfGUfHQWBRT1/icA==",
       "requires": {
         "babel-plugin-istanbul": "4.1.6",
-        "babel-preset-jest": "22.4.3"
+        "babel-preset-jest": "22.4.4"
       }
     },
     "babel-loader": {
@@ -1628,8 +1628,8 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "22.4.3",
-      "integrity": "sha512-zhvv4f6OTWy2bYevcJftwGCWXMFe7pqoz41IhMi4xna7xNsX5NygdagsrE0y6kkfuXq8UalwvPwKTyAxME2E/g=="
+      "version": "22.4.4",
+      "integrity": "sha512-DUvGfYaAIlkdnygVIEl0O4Av69NtuQWcrjMOv6DODPuhuGLDnbsARz3AwiiI/EkIMMlxQDUcrZ9yoyJvTNjcVQ=="
     },
     "babel-plugin-jscript": {
       "version": "1.0.4",
@@ -2035,16 +2035,6 @@
         "babel-runtime": "6.26.0"
       }
     },
-    "babel-plugin-transform-imports": {
-      "version": "1.4.1",
-      "integrity": "sha512-o7EqCZFj0pKUUDwYDZLTRSg1wNMN69p31l3Sf1+ujTFjWUq+/plAUJ04kO1kn5oLVaHbwLi2F4jQbIHFTN2t+A==",
-      "requires": {
-        "babel-types": "6.26.0",
-        "lodash.camelcase": "4.3.0",
-        "lodash.kebabcase": "4.1.1",
-        "lodash.snakecase": "4.1.1"
-      }
-    },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.26.0",
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
@@ -2171,10 +2161,10 @@
       }
     },
     "babel-preset-jest": {
-      "version": "22.4.3",
-      "integrity": "sha512-a+M3LTEXTq3gxv0uBN9Qm6ahUl7a8pj923nFbCUdqFUSsf3YrX8Uc+C3MEwji5Af3LiQjSC7w4ooYewlz8HRTA==",
+      "version": "22.4.4",
+      "integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
       "requires": {
-        "babel-plugin-jest-hoist": "22.4.3",
+        "babel-plugin-jest-hoist": "22.4.4",
         "babel-plugin-syntax-object-rest-spread": "6.13.0"
       }
     },
@@ -2545,13 +2535,6 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
-    "boom": {
-      "version": "4.3.1",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "requires": {
-        "hoek": "4.2.1"
-      }
-    },
     "bounding-client-rect": {
       "version": "1.0.5",
       "integrity": "sha1-meLNJgLQfyLqO+7kIFNFBP1EJM8=",
@@ -2671,8 +2654,8 @@
       "version": "3.2.7",
       "integrity": "sha512-oYVLxFVqpX9uMhOIQBLtZL+CX4uY8ZpWcjNTaxyWl5rO8yA9SSNikFnAfvk8J3P/7z3BZwNmEqFKaJoYltj3MQ==",
       "requires": {
-        "caniuse-lite": "1.0.30000841",
-        "electron-to-chromium": "1.3.46"
+        "caniuse-lite": "1.0.30000844",
+        "electron-to-chromium": "1.3.47"
       }
     },
     "bser": {
@@ -2847,12 +2830,12 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000841",
-      "integrity": "sha1-26QAiVmQNI4t47cXlaUOg38Ts/Y="
+      "version": "1.0.30000844",
+      "integrity": "sha1-vKV5jNoraTHWgQDC1p5V+zOMu0E="
     },
     "caniuse-lite": {
-      "version": "1.0.30000841",
-      "integrity": "sha512-LeOGLEY4hl6xZc/xMYOrVmSrHOybyHWNShFN51qCmDXo69nEGKHTJTfe6jdWe4hLxSJcwEIYtKHFFh93fF/kNA=="
+      "version": "1.0.30000844",
+      "integrity": "sha512-UpKQE7y6dLHhlv75UyBCRiun34Q+bmxyX3zS+ve9M07YG52tRafOvop9N9d5jC+sikKuG7UMweJKJNts4FVehA=="
     },
     "capture-exit": {
       "version": "1.2.0",
@@ -3537,7 +3520,7 @@
       "integrity": "sha512-9ljtIROIjPIUmMRqO+XuDITDoV8xRrZmA0jcEq6p2hg2+wY9wGmLfreAZGIL72IzUfdEDZaU8+Vjidg1fBQ8GQ==",
       "requires": {
         "argv": "0.0.2",
-        "request": "2.86.0",
+        "request": "2.87.0",
         "urlgrey": "0.4.4"
       }
     },
@@ -3829,8 +3812,8 @@
       "dev": true
     },
     "content-disposition": {
-      "version": "0.5.0",
-      "integrity": "sha1-QoT+auBjCHRjnkToCkGMKTQTXp4="
+      "version": "0.5.2",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
       "version": "1.0.4",
@@ -4052,22 +4035,6 @@
         "lru-cache": "4.1.3",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
-      }
-    },
-    "cryptiles": {
-      "version": "3.1.2",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        }
       }
     },
     "crypto-browserify": {
@@ -4563,8 +4530,8 @@
       }
     },
     "destroy": {
-      "version": "1.0.3",
-      "integrity": "sha1-tDO0ck5x/YVR2YhRdIUcX8N34sk="
+      "version": "1.0.4",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-conflict": {
       "version": "1.0.1",
@@ -4643,7 +4610,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000841",
+        "caniuse-db": "1.0.30000844",
         "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
         "jsonfilter": "1.1.2",
@@ -4661,8 +4628,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000841",
-            "electron-to-chromium": "1.3.46"
+            "caniuse-db": "1.0.30000844",
+            "electron-to-chromium": "1.3.47"
           }
         },
         "isarray": {
@@ -4892,8 +4859,8 @@
       "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
     },
     "electron-to-chromium": {
-      "version": "1.3.46",
-      "integrity": "sha1-AOheIidUFaiHUF5KtJc3GU8YubA="
+      "version": "1.3.47",
+      "integrity": "sha1-dk6IfKkQTQGgrI6r7n38DizhQQQ="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -4938,8 +4905,7 @@
     },
     "encodeurl": {
       "version": "1.0.2",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-      "dev": true
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "encoding": {
       "version": "0.1.12",
@@ -5297,8 +5263,8 @@
       }
     },
     "escape-html": {
-      "version": "1.0.2",
-      "integrity": "sha1-130y+pjjjC9BroXpJ44ODmuhAiw="
+      "version": "1.0.3",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-regexp": {
       "version": "0.0.1",
@@ -5811,8 +5777,8 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
-      "version": "1.7.0",
-      "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg="
+      "version": "1.8.1",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "event-emitter": {
       "version": "0.3.5",
@@ -5953,51 +5919,125 @@
       }
     },
     "express": {
-      "version": "4.13.3",
-      "integrity": "sha1-3bLx+0UCvzNZjSsDKwN5YMpsgKM=",
+      "version": "4.16.3",
+      "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
-        "accepts": "1.2.13",
+        "accepts": "1.3.5",
         "array-flatten": "1.1.1",
-        "content-disposition": "0.5.0",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
         "content-type": "1.0.4",
-        "cookie": "0.1.3",
+        "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
-        "debug": "2.2.0",
-        "depd": "1.0.1",
-        "escape-html": "1.0.2",
-        "etag": "1.7.0",
-        "finalhandler": "0.4.0",
-        "fresh": "0.3.0",
-        "merge-descriptors": "1.0.0",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.0.10",
-        "qs": "4.0.0",
-        "range-parser": "1.0.3",
-        "send": "0.13.0",
-        "serve-static": "1.10.3",
+        "proxy-addr": "2.0.3",
+        "qs": "6.5.1",
+        "range-parser": "1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.4.0",
         "type-is": "1.6.16",
-        "utils-merge": "1.0.0",
-        "vary": "1.0.1"
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2"
       },
       "dependencies": {
+        "body-parser": {
+          "version": "1.18.2",
+          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "1.0.4",
+            "debug": "2.6.9",
+            "depd": "1.1.2",
+            "http-errors": "1.6.3",
+            "iconv-lite": "0.4.19",
+            "on-finished": "2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "1.6.16"
+          }
+        },
+        "bytes": {
+          "version": "3.0.0",
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+        },
         "cookie": {
-          "version": "0.1.3",
-          "integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU="
+          "version": "0.3.1",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
         },
         "cookie-signature": {
           "version": "1.0.6",
           "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
         },
-        "depd": {
-          "version": "1.0.1",
-          "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo="
+        "debug": {
+          "version": "2.6.9",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
-        "qs": {
-          "version": "4.0.0",
-          "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc="
+        "iconv-lite": {
+          "version": "0.4.19",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "raw-body": {
+          "version": "2.3.2",
+          "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.2",
+            "iconv-lite": "0.4.19",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+            },
+            "http-errors": {
+              "version": "1.6.2",
+              "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+              "requires": {
+                "depd": "1.1.1",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.3",
+                "statuses": "1.4.0"
+              }
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+        },
+        "statuses": {
+          "version": "1.4.0",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
       }
     },
@@ -6554,13 +6594,33 @@
       }
     },
     "finalhandler": {
-      "version": "0.4.0",
-      "integrity": "sha1-llpS2ejQXSuFdUhUH7ibU6JJfZs=",
+      "version": "1.1.1",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
-        "debug": "2.2.0",
-        "escape-html": "1.0.2",
+        "debug": "2.6.9",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
         "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.4.0",
         "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "statuses": {
+          "version": "1.4.0",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+        }
       }
     },
     "find-cache-dir": {
@@ -6739,8 +6799,8 @@
       }
     },
     "fresh": {
-      "version": "0.3.0",
-      "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
+      "version": "0.5.2",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "from": {
       "version": "0.1.7",
@@ -7662,7 +7722,7 @@
         "omggif": "1.0.9",
         "parse-data-uri": "0.2.0",
         "pngjs": "2.3.1",
-        "request": "2.86.0",
+        "request": "2.87.0",
         "through": "2.3.8"
       }
     },
@@ -8194,16 +8254,6 @@
         }
       }
     },
-    "hawk": {
-      "version": "6.0.2",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
-      }
-    },
     "he": {
       "version": "0.5.0",
       "integrity": "sha1-LAX/rvkLaOhg8/0rVO9YCYknfuI="
@@ -8216,10 +8266,6 @@
         "minimalistic-assert": "1.0.1",
         "minimalistic-crypto-utils": "1.0.1"
       }
-    },
-    "hoek": {
-      "version": "4.2.1",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "hoist-non-react-statics": {
       "version": "1.2.0",
@@ -8716,8 +8762,8 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.0.5",
-      "integrity": "sha1-X6eM8wG4JceKvDBC2BJyMEnqI8c="
+      "version": "1.6.0",
+      "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
     },
     "irregular-plurals": {
       "version": "1.4.0",
@@ -9195,7 +9241,7 @@
       "integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
+        "async": "2.6.1",
         "compare-versions": "3.2.1",
         "fileset": "2.0.3",
         "istanbul-lib-coverage": "1.2.0",
@@ -9210,11 +9256,11 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.0",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "version": "2.6.1",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.5"
+            "lodash": "4.17.10"
           }
         },
         "debug": {
@@ -9236,6 +9282,11 @@
             "rimraf": "2.6.2",
             "source-map": "0.5.7"
           }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
         },
         "ms": {
           "version": "2.0.0",
@@ -9382,7 +9433,7 @@
       "dev": true,
       "requires": {
         "import-local": "1.0.0",
-        "jest-cli": "22.4.3"
+        "jest-cli": "22.4.4"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9439,8 +9490,8 @@
           "dev": true
         },
         "jest-cli": {
-          "version": "22.4.3",
-          "integrity": "sha512-IiHybF0DJNqZPsbjn4Cy4vcqcmImpoFwNFnkehzVw8lTUSl4axZh5DHewu5bdpZF2Y5gUqFKYzH0FH4Qx2k+UA==",
+          "version": "22.4.4",
+          "integrity": "sha512-I9dsgkeyjVEEZj9wrGrqlH+8OlNob9Iptyl+6L5+ToOLJmHm4JwOPatin1b2Bzp5R5YRQJ+oiedx7o1H7wJzhA==",
           "dev": true,
           "requires": {
             "ansi-escapes": "3.1.0",
@@ -9455,18 +9506,18 @@
             "istanbul-lib-instrument": "1.10.1",
             "istanbul-lib-source-maps": "1.2.3",
             "jest-changed-files": "22.4.3",
-            "jest-config": "22.4.3",
+            "jest-config": "22.4.4",
             "jest-environment-jsdom": "22.4.3",
             "jest-get-type": "22.4.3",
             "jest-haste-map": "22.4.3",
             "jest-message-util": "22.4.3",
             "jest-regex-util": "22.4.3",
             "jest-resolve-dependencies": "22.4.3",
-            "jest-runner": "22.4.3",
-            "jest-runtime": "22.4.3",
+            "jest-runner": "22.4.4",
+            "jest-runtime": "22.4.4",
             "jest-snapshot": "22.4.3",
             "jest-util": "22.4.3",
-            "jest-validate": "22.4.3",
+            "jest-validate": "22.4.4",
             "jest-worker": "22.4.3",
             "micromatch": "2.3.11",
             "node-notifier": "5.2.1",
@@ -9554,8 +9605,8 @@
       }
     },
     "jest-config": {
-      "version": "22.4.3",
-      "integrity": "sha512-KSg3EOToCgkX+lIvenKY7J8s426h6ahXxaUFJxvGoEk0562Z6inWj1TnKoGycTASwiLD+6kSYFALcjdosq9KIQ==",
+      "version": "22.4.4",
+      "integrity": "sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
       "dev": true,
       "requires": {
         "chalk": "2.4.1",
@@ -9563,11 +9614,11 @@
         "jest-environment-jsdom": "22.4.3",
         "jest-environment-node": "22.4.3",
         "jest-get-type": "22.4.3",
-        "jest-jasmine2": "22.4.3",
+        "jest-jasmine2": "22.4.4",
         "jest-regex-util": "22.4.3",
         "jest-resolve": "22.4.3",
         "jest-util": "22.4.3",
-        "jest-validate": "22.4.3",
+        "jest-validate": "22.4.4",
         "pretty-format": "22.4.3"
       },
       "dependencies": {
@@ -9691,8 +9742,8 @@
       }
     },
     "jest-jasmine2": {
-      "version": "22.4.3",
-      "integrity": "sha512-yZCPCJUcEY6R5KJB/VReo1AYI2b+5Ky+C+JA1v34jndJsRcLpU4IZX4rFJn7yDTtdNbO/nNqg+3SDIPNH2ecnw==",
+      "version": "22.4.4",
+      "integrity": "sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==",
       "dev": true,
       "requires": {
         "chalk": "2.4.1",
@@ -9933,18 +9984,18 @@
       }
     },
     "jest-runner": {
-      "version": "22.4.3",
-      "integrity": "sha512-U7PLlQPRlWNbvOHWOrrVay9sqhBJmiKeAdKIkvX4n1G2tsvzLlf77nBD28GL1N6tGv4RmuTfI8R8JrkvCa+IBg==",
+      "version": "22.4.4",
+      "integrity": "sha512-5S/OpB51igQW9xnkM5Tgd/7ZjiAuIoiJAVtvVTBcEBiXBIFzWM3BAMPBM19FX68gRV0KWyFuGKj0EY3M3aceeQ==",
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "jest-config": "22.4.3",
+        "jest-config": "22.4.4",
         "jest-docblock": "22.4.3",
         "jest-haste-map": "22.4.3",
-        "jest-jasmine2": "22.4.3",
+        "jest-jasmine2": "22.4.4",
         "jest-leak-detector": "22.4.3",
         "jest-message-util": "22.4.3",
-        "jest-runtime": "22.4.3",
+        "jest-runtime": "22.4.4",
         "jest-util": "22.4.3",
         "jest-worker": "22.4.3",
         "throat": "4.1.0"
@@ -9961,23 +10012,23 @@
       }
     },
     "jest-runtime": {
-      "version": "22.4.3",
-      "integrity": "sha512-Eat/esQjevhx9BgJEC8udye+FfoJ2qvxAZfOAWshYGS22HydHn5BgsvPdTtt9cp0fSl5LxYOFA1Pja9Iz2Zt8g==",
+      "version": "22.4.4",
+      "integrity": "sha512-WRTj9m///npte1YjuphCYX7GRY/c2YvJImU9t7qOwFcqHr4YMzmX6evP/3Sehz5DKW2Vi8ONYPCFWe36JVXxfw==",
       "dev": true,
       "requires": {
         "babel-core": "6.26.3",
-        "babel-jest": "22.4.3",
+        "babel-jest": "22.4.4",
         "babel-plugin-istanbul": "4.1.6",
         "chalk": "2.4.1",
         "convert-source-map": "1.5.1",
         "exit": "0.1.2",
         "graceful-fs": "4.1.11",
-        "jest-config": "22.4.3",
+        "jest-config": "22.4.4",
         "jest-haste-map": "22.4.3",
         "jest-regex-util": "22.4.3",
         "jest-resolve": "22.4.3",
         "jest-util": "22.4.3",
-        "jest-validate": "22.4.3",
+        "jest-validate": "22.4.4",
         "json-stable-stringify": "1.0.1",
         "micromatch": "2.3.11",
         "realpath-native": "1.0.0",
@@ -10019,12 +10070,12 @@
           }
         },
         "babel-jest": {
-          "version": "22.4.3",
-          "integrity": "sha512-BgSjmtl3mW3i+VeVHEr9d2zFSAT66G++pJcHQiUjd00pkW+voYXFctIm/indcqOWWXw5a1nUpR1XWszD9fJ1qg==",
+          "version": "22.4.4",
+          "integrity": "sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==",
           "dev": true,
           "requires": {
             "babel-plugin-istanbul": "4.1.6",
-            "babel-preset-jest": "22.4.3"
+            "babel-preset-jest": "22.4.4"
           }
         },
         "babylon": {
@@ -10243,12 +10294,12 @@
       }
     },
     "jest-validate": {
-      "version": "22.4.3",
-      "integrity": "sha512-CfFM18W3GSP/xgmA4UouIx0ljdtfD2mjeBC6c89Gg17E44D4tQhAcTrZmf9djvipwU30kSTnk6CzcxdCCeSXfA==",
+      "version": "22.4.4",
+      "integrity": "sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==",
       "dev": true,
       "requires": {
         "chalk": "2.4.1",
-        "jest-config": "22.4.3",
+        "jest-config": "22.4.4",
         "jest-get-type": "22.4.3",
         "leven": "2.1.0",
         "pretty-format": "22.4.3"
@@ -10294,8 +10345,8 @@
       "integrity": "sha1-Epi4i5COfH91AeuMGmHxrIM3tTE="
     },
     "js-base64": {
-      "version": "2.4.3",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
+      "version": "2.4.5",
+      "integrity": "sha512-aUnNwqMOXw3yvErjMPSQu6qIIzUmT1e5KcU1OZxRDU1g/am6mzBvcrmLAYwzmB59BHPrh5/tKaiF4OPhqRWESQ=="
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -10334,7 +10385,7 @@
         "babel-preset-stage-1": "6.24.1",
         "babel-register": "6.26.0",
         "babylon": "6.18.0",
-        "colors": "1.2.5",
+        "colors": "1.3.0",
         "es6-promise": "3.3.1",
         "flow-parser": "0.72.0",
         "lodash": "4.17.5",
@@ -10427,8 +10478,8 @@
           "dev": true
         },
         "colors": {
-          "version": "1.2.5",
-          "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+          "version": "1.3.0",
+          "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw==",
           "dev": true
         },
         "core-js": {
@@ -10560,7 +10611,7 @@
         "nwmatcher": "1.4.4",
         "parse5": "4.0.0",
         "pn": "1.1.0",
-        "request": "2.86.0",
+        "request": "2.87.0",
         "request-promise-native": "1.0.5",
         "sax": "1.2.4",
         "symbol-tree": "3.2.2",
@@ -11244,10 +11295,6 @@
         "lodash.keys": "3.1.2"
       }
     },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
@@ -11289,10 +11336,6 @@
     "lodash.istypedarray": {
       "version": "3.0.6",
       "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I="
-    },
-    "lodash.kebabcase": {
-      "version": "4.1.1",
-      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY="
     },
     "lodash.keys": {
       "version": "3.1.2",
@@ -11340,10 +11383,6 @@
     "lodash.restparam": {
       "version": "3.6.1",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-    },
-    "lodash.snakecase": {
-      "version": "4.1.1",
-      "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -11755,8 +11794,8 @@
       "dev": true
     },
     "merge-descriptors": {
-      "version": "1.0.0",
-      "integrity": "sha1-IWnPdTjhsMyH+4jhUC2EdLv3mGQ="
+      "version": "1.0.1",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "merge-stream": {
       "version": "1.0.1",
@@ -11802,8 +11841,8 @@
       }
     },
     "mime": {
-      "version": "1.3.4",
-      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+      "version": "1.4.1",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
       "version": "1.33.0",
@@ -12084,8 +12123,8 @@
       }
     },
     "negotiator": {
-      "version": "0.5.3",
-      "integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g="
+      "version": "0.6.1",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "neo-async": {
       "version": "1.8.2",
@@ -12168,7 +12207,7 @@
         "nopt": "3.0.6",
         "npmlog": "4.1.2",
         "osenv": "0.1.5",
-        "request": "2.86.0",
+        "request": "2.87.0",
         "rimraf": "2.6.2",
         "semver": "5.3.0",
         "tar": "2.2.1",
@@ -12269,7 +12308,7 @@
         "nan": "2.10.0",
         "node-gyp": "3.6.2",
         "npmlog": "4.1.2",
-        "request": "2.86.0",
+        "request": "2.87.0",
         "sass-graph": "2.2.4",
         "stdout-stream": "1.4.0"
       },
@@ -13046,7 +13085,7 @@
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
-        "@types/node": "10.1.0"
+        "@types/node": "10.1.2"
       }
     },
     "parsejson": {
@@ -13271,7 +13310,7 @@
       "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
       "requires": {
         "chalk": "1.1.3",
-        "js-base64": "2.4.3",
+        "js-base64": "2.4.5",
         "source-map": "0.5.7",
         "supports-color": "3.2.3"
       },
@@ -13806,11 +13845,11 @@
       "dev": true
     },
     "proxy-addr": {
-      "version": "1.0.10",
-      "integrity": "sha1-DUCoL4Afw1VWfS7LZe/j8HfxIcU=",
+      "version": "2.0.3",
+      "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
       "requires": {
         "forwarded": "0.1.2",
-        "ipaddr.js": "1.0.5"
+        "ipaddr.js": "1.6.0"
       }
     },
     "prr": {
@@ -13955,8 +13994,8 @@
       }
     },
     "range-parser": {
-      "version": "1.0.3",
-      "integrity": "sha1-aHKCNTXGkuLCoBA4Jq/YLC4P8XU="
+      "version": "1.2.0",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "raw-body": {
       "version": "2.2.0",
@@ -14575,7 +14614,7 @@
             "html-encoding-sniffer": "1.0.2",
             "nwmatcher": "1.4.4",
             "parse5": "1.5.1",
-            "request": "2.86.0",
+            "request": "2.87.0",
             "sax": "1.2.4",
             "symbol-tree": "3.2.2",
             "tough-cookie": "2.3.4",
@@ -15489,8 +15528,8 @@
       "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "request": {
-      "version": "2.86.0",
-      "integrity": "sha512-BQZih67o9r+Ys94tcIW4S7Uu8pthjrQVxhsZ/weOwHbDfACxvIyvnAbzFQxjy1jMtvFSzv5zf4my6cZsJBbVzw==",
+      "version": "2.87.0",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.7.0",
@@ -15500,7 +15539,6 @@
         "forever-agent": "0.6.1",
         "form-data": "2.3.2",
         "har-validator": "5.0.3",
-        "hawk": "6.0.2",
         "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
@@ -16684,7 +16722,7 @@
       "version": "0.2.3",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "requires": {
-        "js-base64": "2.4.3",
+        "js-base64": "2.4.5",
         "source-map": "0.4.4"
       },
       "dependencies": {
@@ -16718,38 +16756,38 @@
       }
     },
     "send": {
-      "version": "0.13.0",
-      "integrity": "sha1-UY+SGusFYK7H3KspkLFM9vPM5d4=",
+      "version": "0.16.2",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
-        "debug": "2.2.0",
-        "depd": "1.0.1",
-        "destroy": "1.0.3",
-        "escape-html": "1.0.2",
-        "etag": "1.7.0",
-        "fresh": "0.3.0",
-        "http-errors": "1.3.1",
-        "mime": "1.3.4",
-        "ms": "0.7.1",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.3",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
         "on-finished": "2.3.0",
-        "range-parser": "1.0.3",
-        "statuses": "1.2.1"
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
       },
       "dependencies": {
-        "depd": {
-          "version": "1.0.1",
-          "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo="
-        },
-        "http-errors": {
-          "version": "1.3.1",
-          "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
+        "debug": {
+          "version": "2.6.9",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
-            "inherits": "2.0.1",
-            "statuses": "1.2.1"
+            "ms": "2.0.0"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
         "statuses": {
-          "version": "1.2.1",
-          "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg="
+          "version": "1.4.0",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
       }
     },
@@ -16765,52 +16803,13 @@
       "integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ=="
     },
     "serve-static": {
-      "version": "1.10.3",
-      "integrity": "sha1-zlpuzTEB/tXsCYJ9rCKpwpv7BTU=",
+      "version": "1.13.2",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
-        "send": "0.13.2"
-      },
-      "dependencies": {
-        "destroy": {
-          "version": "1.0.4",
-          "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-        },
-        "escape-html": {
-          "version": "1.0.3",
-          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-        },
-        "http-errors": {
-          "version": "1.3.1",
-          "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-          "requires": {
-            "inherits": "2.0.1",
-            "statuses": "1.2.1"
-          }
-        },
-        "send": {
-          "version": "0.13.2",
-          "integrity": "sha1-dl52B8gFVFK7pvCwUllTUJhgNt4=",
-          "requires": {
-            "debug": "2.2.0",
-            "depd": "1.1.2",
-            "destroy": "1.0.4",
-            "escape-html": "1.0.3",
-            "etag": "1.7.0",
-            "fresh": "0.3.0",
-            "http-errors": "1.3.1",
-            "mime": "1.3.4",
-            "ms": "0.7.1",
-            "on-finished": "2.3.0",
-            "range-parser": "1.0.3",
-            "statuses": "1.2.1"
-          }
-        },
-        "statuses": {
-          "version": "1.2.1",
-          "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg="
-        }
+        "send": "0.16.2"
       }
     },
     "set-blocking": {
@@ -17047,13 +17046,6 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
         "kind-of": "3.2.2"
-      }
-    },
-    "sntp": {
-      "version": "2.1.0",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "requires": {
-        "hoek": "4.2.1"
       }
     },
     "social-logos": {
@@ -17442,8 +17434,8 @@
       "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4="
     },
     "string-kit": {
-      "version": "0.6.17",
-      "integrity": "sha512-c1r25H8wmVY0sQbQp/40E2B/Gz05z15MfUlR9NsAyerhBHVGhnj50R1KKn19fkYSpJbfllgpRmeunhsMFjlKPg==",
+      "version": "0.6.18",
+      "integrity": "sha512-G/nR5FBUcVkFagf0ckMPCnV8UIlldTa60LaYPR4bZ6MtAj6o03cQcJK9TqoU13dOy52Sjt/XqY+bO7iJcJ+chw==",
       "dev": true,
       "requires": {
         "xregexp": "4.1.1"
@@ -17581,8 +17573,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000841",
-            "electron-to-chromium": "1.3.46"
+            "caniuse-db": "1.0.30000844",
+            "electron-to-chromium": "1.3.47"
           }
         },
         "chalk": {
@@ -17831,7 +17823,7 @@
         "form-data": "1.0.0-rc4",
         "formidable": "1.2.1",
         "methods": "1.1.2",
-        "mime": "1.3.4",
+        "mime": "1.4.1",
         "qs": "6.5.1",
         "readable-stream": "2.3.6"
       },
@@ -18003,7 +17995,7 @@
         "get-pixels": "3.3.0",
         "ndarray": "1.0.18",
         "nextgen-events": "0.10.2",
-        "string-kit": "0.6.17",
+        "string-kit": "0.6.18",
         "tree-kit": "0.5.27"
       }
     },
@@ -18269,17 +18261,21 @@
       "version": "1.1.5",
       "integrity": "sha512-BklxWyBW9EsRC6neZPuwwV6L1iRkGwe8sFWUcI1g+3DS3JajW/zJKo2t6j2a72bXngv9a4xyDHpn1EpXM9VWDw==",
       "requires": {
-        "async": "2.6.0",
+        "async": "2.6.1",
         "loader-runner": "2.3.0",
         "loader-utils": "1.1.0"
       },
       "dependencies": {
         "async": {
-          "version": "2.6.0",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "version": "2.6.1",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
-            "lodash": "4.17.5"
+            "lodash": "4.17.10"
           }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
@@ -19021,8 +19017,8 @@
       }
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+      "version": "1.0.1",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "3.2.1",
@@ -19045,8 +19041,8 @@
       }
     },
     "vary": {
-      "version": "1.0.1",
-      "integrity": "sha1-meSYFWaihhGN+yuBc1ffeZM3bRA="
+      "version": "1.1.2",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",
@@ -19669,8 +19665,8 @@
           "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
         },
         "colors": {
-          "version": "1.2.5",
-          "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg=="
+          "version": "1.3.0",
+          "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
         },
         "esprima": {
           "version": "4.0.0",
@@ -19686,7 +19682,7 @@
             "babel-preset-stage-1": "6.24.1",
             "babel-register": "6.26.0",
             "babylon": "6.18.0",
-            "colors": "1.2.5",
+            "colors": "1.3.0",
             "flow-parser": "0.72.0",
             "lodash": "4.17.5",
             "micromatch": "2.3.11",
@@ -19733,37 +19729,6 @@
         "ws": "4.1.0"
       },
       "dependencies": {
-        "accepts": {
-          "version": "1.3.5",
-          "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-          "dev": true,
-          "requires": {
-            "mime-types": "2.1.18",
-            "negotiator": "0.6.1"
-          }
-        },
-        "body-parser": {
-          "version": "1.18.2",
-          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
-          "dev": true,
-          "requires": {
-            "bytes": "3.0.0",
-            "content-type": "1.0.4",
-            "debug": "2.6.9",
-            "depd": "1.1.2",
-            "http-errors": "1.6.3",
-            "iconv-lite": "0.4.19",
-            "on-finished": "2.3.0",
-            "qs": "6.5.1",
-            "raw-body": "2.3.2",
-            "type-is": "1.6.16"
-          }
-        },
-        "bytes": {
-          "version": "3.0.0",
-          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-          "dev": true
-        },
         "chalk": {
           "version": "2.4.1",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
@@ -19779,242 +19744,14 @@
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
-        "content-disposition": {
-          "version": "0.5.2",
-          "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-          "dev": true
-        },
-        "cookie": {
-          "version": "0.3.1",
-          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-          "dev": true
-        },
-        "cookie-signature": {
-          "version": "1.0.6",
-          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "destroy": {
-          "version": "1.0.4",
-          "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-          "dev": true
-        },
-        "escape-html": {
-          "version": "1.0.3",
-          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-          "dev": true
-        },
         "escape-string-regexp": {
           "version": "1.0.5",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
-        "etag": {
-          "version": "1.8.1",
-          "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-          "dev": true
-        },
-        "express": {
-          "version": "4.16.3",
-          "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
-          "dev": true,
-          "requires": {
-            "accepts": "1.3.5",
-            "array-flatten": "1.1.1",
-            "body-parser": "1.18.2",
-            "content-disposition": "0.5.2",
-            "content-type": "1.0.4",
-            "cookie": "0.3.1",
-            "cookie-signature": "1.0.6",
-            "debug": "2.6.9",
-            "depd": "1.1.2",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
-            "finalhandler": "1.1.1",
-            "fresh": "0.5.2",
-            "merge-descriptors": "1.0.1",
-            "methods": "1.1.2",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "path-to-regexp": "0.1.7",
-            "proxy-addr": "2.0.3",
-            "qs": "6.5.1",
-            "range-parser": "1.2.0",
-            "safe-buffer": "5.1.1",
-            "send": "0.16.2",
-            "serve-static": "1.13.2",
-            "setprototypeof": "1.1.0",
-            "statuses": "1.4.0",
-            "type-is": "1.6.16",
-            "utils-merge": "1.0.1",
-            "vary": "1.1.2"
-          }
-        },
         "filesize": {
           "version": "3.6.1",
           "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
-          "dev": true
-        },
-        "finalhandler": {
-          "version": "1.1.1",
-          "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "statuses": "1.4.0",
-            "unpipe": "1.0.0"
-          }
-        },
-        "fresh": {
-          "version": "0.5.2",
-          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-          "dev": true
-        },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-          "dev": true
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "ipaddr.js": {
-          "version": "1.6.0",
-          "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs=",
-          "dev": true
-        },
-        "merge-descriptors": {
-          "version": "1.0.1",
-          "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-          "dev": true
-        },
-        "mime": {
-          "version": "1.4.1",
-          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "negotiator": {
-          "version": "0.6.1",
-          "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-          "dev": true
-        },
-        "proxy-addr": {
-          "version": "2.0.3",
-          "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
-          "dev": true,
-          "requires": {
-            "forwarded": "0.1.2",
-            "ipaddr.js": "1.6.0"
-          }
-        },
-        "range-parser": {
-          "version": "1.2.0",
-          "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
-          "dev": true
-        },
-        "raw-body": {
-          "version": "2.3.2",
-          "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-          "dev": true,
-          "requires": {
-            "bytes": "3.0.0",
-            "http-errors": "1.6.2",
-            "iconv-lite": "0.4.19",
-            "unpipe": "1.0.0"
-          },
-          "dependencies": {
-            "depd": {
-              "version": "1.1.1",
-              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-              "dev": true
-            },
-            "http-errors": {
-              "version": "1.6.2",
-              "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-              "dev": true,
-              "requires": {
-                "depd": "1.1.1",
-                "inherits": "2.0.3",
-                "setprototypeof": "1.0.3",
-                "statuses": "1.4.0"
-              }
-            },
-            "setprototypeof": {
-              "version": "1.0.3",
-              "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-              "dev": true
-            }
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
-        },
-        "send": {
-          "version": "0.16.2",
-          "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "depd": "1.1.2",
-            "destroy": "1.0.4",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
-            "fresh": "0.5.2",
-            "http-errors": "1.6.3",
-            "mime": "1.4.1",
-            "ms": "2.0.0",
-            "on-finished": "2.3.0",
-            "range-parser": "1.2.0",
-            "statuses": "1.4.0"
-          }
-        },
-        "serve-static": {
-          "version": "1.13.2",
-          "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-          "dev": true,
-          "requires": {
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "parseurl": "1.3.2",
-            "send": "0.16.2"
-          }
-        },
-        "statuses": {
-          "version": "1.4.0",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-          "dev": true
-        },
-        "utils-merge": {
-          "version": "1.0.1",
-          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-          "dev": true
-        },
-        "vary": {
-          "version": "1.1.2",
-          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
           "dev": true
         },
         "ws": {
@@ -20023,7 +19760,7 @@
           "dev": true,
           "requires": {
             "async-limiter": "1.0.0",
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -20122,8 +19859,8 @@
           }
         },
         "colors": {
-          "version": "1.2.5",
-          "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg=="
+          "version": "1.3.0",
+          "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
         },
         "enhanced-resolve": {
           "version": "3.4.1",
@@ -20153,7 +19890,7 @@
             "babel-preset-stage-1": "6.24.1",
             "babel-register": "6.26.0",
             "babylon": "6.18.0",
-            "colors": "1.2.5",
+            "colors": "1.3.0",
             "flow-parser": "0.72.0",
             "lodash": "4.17.5",
             "micromatch": "2.3.11",
@@ -20330,7 +20067,7 @@
         "memory-fs": "0.4.1",
         "mime": "2.3.1",
         "path-is-absolute": "1.0.1",
-        "range-parser": "1.0.3",
+        "range-parser": "1.2.0",
         "url-join": "4.0.0",
         "webpack-log": "1.2.0"
       },
@@ -20345,7 +20082,7 @@
       "version": "1.1.1",
       "integrity": "sha512-TrLT6Bw6gl9rJA7iZw+YJ+4xHhEUzfOQB3tHpyINBFdZDmO0tlDW9MtMSMZ5rsUNjHxcEba5yuGaAW86J84j/w==",
       "requires": {
-        "async": "2.6.0",
+        "async": "2.6.1",
         "chalk": "1.0.0",
         "cli-table": "0.3.1",
         "cross-spawn": "5.1.0",
@@ -20377,10 +20114,16 @@
           "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
         },
         "async": {
-          "version": "2.6.0",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "version": "2.6.1",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
-            "lodash": "4.17.5"
+            "lodash": "4.17.10"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "4.17.10",
+              "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+            }
           }
         },
         "cli-cursor": {
@@ -20945,7 +20688,7 @@
         "mem-fs": "1.1.3",
         "strip-ansi": "4.0.0",
         "text-table": "0.2.0",
-        "untildify": "3.0.2"
+        "untildify": "3.0.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -21069,8 +20812,8 @@
           }
         },
         "untildify": {
-          "version": "3.0.2",
-          "integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E="
+          "version": "3.0.3",
+          "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "escape-string-regexp": "1.0.3",
     "events": "1.0.2",
     "exports-loader": "0.6.2",
-    "express": "4.13.3",
+    "express": "4.16.3",
     "express-useragent": "1.0.7",
     "filesize": "3.2.1",
     "flag-icon-css": "2.3.0",


### PR DESCRIPTION
From 4.13.3:

Release notes since then:

4.16.3 / 2018-03-12
===================

  * deps: accepts@~1.3.5
    - deps: mime-types@~2.1.18
  * deps: depd@~1.1.2
    - perf: remove argument reassignment
  * deps: encodeurl@~1.0.2
    - Fix encoding `%` as last character
  * deps: finalhandler@1.1.1
    - Fix 404 output for bad / missing pathnames
    - deps: encodeurl@~1.0.2
    - deps: statuses@~1.4.0
  * deps: proxy-addr@~2.0.3
    - deps: ipaddr.js@1.6.0
  * deps: send@0.16.2
    - Fix incorrect end tag in default error & redirects
    - deps: depd@~1.1.2
    - deps: encodeurl@~1.0.2
    - deps: statuses@~1.4.0
  * deps: serve-static@1.13.2
    - Fix incorrect end tag in redirects
    - deps: encodeurl@~1.0.2
    - deps: send@0.16.2
  * deps: statuses@~1.4.0
  * deps: type-is@~1.6.16
    - deps: mime-types@~2.1.18

4.16.2 / 2017-10-09
===================

  * Fix `TypeError` in `res.send` when given `Buffer` and `ETag` header set
  * perf: skip parsing of entire `X-Forwarded-Proto` header

4.16.1 / 2017-09-29
===================

  * deps: send@0.16.1
  * deps: serve-static@1.13.1
    - Fix regression when `root` is incorrectly set to a file
    - deps: send@0.16.1

4.16.0 / 2017-09-28
===================

  * Add `"json escape"` setting for `res.json` and `res.jsonp`
  * Add `express.json` and `express.urlencoded` to parse bodies
  * Add `options` argument to `res.download`
  * Improve error message when autoloading invalid view engine
  * Improve error messages when non-function provided as middleware
  * Skip `Buffer` encoding when not generating ETag for small response
  * Use `safe-buffer` for improved Buffer API
  * deps: accepts@~1.3.4
    - deps: mime-types@~2.1.16
  * deps: content-type@~1.0.4
    - perf: remove argument reassignment
    - perf: skip parameter parsing when no parameters
  * deps: etag@~1.8.1
    - perf: replace regular expression with substring
  * deps: finalhandler@1.1.0
    - Use `res.headersSent` when available
  * deps: parseurl@~1.3.2
    - perf: reduce overhead for full URLs
    - perf: unroll the "fast-path" `RegExp`
  * deps: proxy-addr@~2.0.2
    - Fix trimming leading / trailing OWS in `X-Forwarded-For`
    - deps: forwarded@~0.1.2
    - deps: ipaddr.js@1.5.2
    - perf: reduce overhead when no `X-Forwarded-For` header
  * deps: qs@6.5.1
    - Fix parsing & compacting very deep objects
  * deps: send@0.16.0
    - Add 70 new types for file extensions
    - Add `immutable` option
    - Fix missing `</html>` in default error & redirects
    - Set charset as "UTF-8" for .js and .json
    - Use instance methods on steam to check for listeners
    - deps: mime@1.4.1
    - perf: improve path validation speed
  * deps: serve-static@1.13.0
    - Add 70 new types for file extensions
    - Add `immutable` option
    - Set charset as "UTF-8" for .js and .json
    - deps: send@0.16.0
  * deps: setprototypeof@1.1.0
  * deps: utils-merge@1.0.1
  * deps: vary@~1.1.2
    - perf: improve header token parsing speed
  * perf: re-use options object when generating ETags
  * perf: remove dead `.charset` set in `res.jsonp`

4.15.5 / 2017-09-24
===================

  * deps: debug@2.6.9
  * deps: finalhandler@~1.0.6
    - deps: debug@2.6.9
    - deps: parseurl@~1.3.2
  * deps: fresh@0.5.2
    - Fix handling of modified headers with invalid dates
    - perf: improve ETag match loop
    - perf: improve `If-None-Match` token parsing
  * deps: send@0.15.6
    - Fix handling of modified headers with invalid dates
    - deps: debug@2.6.9
    - deps: etag@~1.8.1
    - deps: fresh@0.5.2
    - perf: improve `If-Match` token parsing
  * deps: serve-static@1.12.6
    - deps: parseurl@~1.3.2
    - deps: send@0.15.6
    - perf: improve slash collapsing

4.15.4 / 2017-08-06
===================

  * deps: debug@2.6.8
  * deps: depd@~1.1.1
    - Remove unnecessary `Buffer` loading
  * deps: finalhandler@~1.0.4
    - deps: debug@2.6.8
  * deps: proxy-addr@~1.1.5
    - Fix array argument being altered
    - deps: ipaddr.js@1.4.0
  * deps: qs@6.5.0
  * deps: send@0.15.4
    - deps: debug@2.6.8
    - deps: depd@~1.1.1
    - deps: http-errors@~1.6.2
  * deps: serve-static@1.12.4
    - deps: send@0.15.4

4.15.3 / 2017-05-16
===================

  * Fix error when `res.set` cannot add charset to `Content-Type`
  * deps: debug@2.6.7
    - Fix `DEBUG_MAX_ARRAY_LENGTH`
    - deps: ms@2.0.0
  * deps: finalhandler@~1.0.3
    - Fix missing `</html>` in HTML document
    - deps: debug@2.6.7
  * deps: proxy-addr@~1.1.4
    - deps: ipaddr.js@1.3.0
  * deps: send@0.15.3
    - deps: debug@2.6.7
    - deps: ms@2.0.0
  * deps: serve-static@1.12.3
    - deps: send@0.15.3
  * deps: type-is@~1.6.15
    - deps: mime-types@~2.1.15
  * deps: vary@~1.1.1
    - perf: hoist regular expression

4.15.2 / 2017-03-06
===================

  * deps: qs@6.4.0
    - Fix regression parsing keys starting with `[`

4.15.1 / 2017-03-05
===================

  * deps: send@0.15.1
    - Fix issue when `Date.parse` does not return `NaN` on invalid date
    - Fix strict violation in broken environments
  * deps: serve-static@1.12.1
    - Fix issue when `Date.parse` does not return `NaN` on invalid date
    - deps: send@0.15.1

4.15.0 / 2017-03-01
===================

  * Add debug message when loading view engine
  * Add `next("router")` to exit from router
  * Fix case where `router.use` skipped requests routes did not
  * Remove usage of `res._headers` private field
    - Improves compatibility with Node.js 8 nightly
  * Skip routing when `req.url` is not set
  * Use `%o` in path debug to tell types apart
  * Use `Object.create` to setup request & response prototypes
  * Use `setprototypeof` module to replace `__proto__` setting
  * Use `statuses` instead of `http` module for status messages
  * deps: debug@2.6.1
    - Allow colors in workers
    - Deprecated `DEBUG_FD` environment variable set to `3` or higher
    - Fix error when running under React Native
    - Use same color for same namespace
    - deps: ms@0.7.2
  * deps: etag@~1.8.0
    - Use SHA1 instead of MD5 for ETag hashing
    - Works with FIPS 140-2 OpenSSL configuration
  * deps: finalhandler@~1.0.0
    - Fix exception when `err` cannot be converted to a string
    - Fully URL-encode the pathname in the 404
    - Only include the pathname in the 404 message
    - Send complete HTML document
    - Set `Content-Security-Policy: default-src 'self'` header
    - deps: debug@2.6.1
  * deps: fresh@0.5.0
    - Fix false detection of `no-cache` request directive
    - Fix incorrect result when `If-None-Match` has both `*` and ETags
    - Fix weak `ETag` matching to match spec
    - perf: delay reading header values until needed
    - perf: enable strict mode
    - perf: hoist regular expressions
    - perf: remove duplicate conditional
    - perf: remove unnecessary boolean coercions
    - perf: skip checking modified time if ETag check failed
    - perf: skip parsing `If-None-Match` when no `ETag` header
    - perf: use `Date.parse` instead of `new Date`
  * deps: qs@6.3.1
    - Fix array parsing from skipping empty values
    - Fix compacting nested arrays
  * deps: send@0.15.0
    - Fix false detection of `no-cache` request directive
    - Fix incorrect result when `If-None-Match` has both `*` and ETags
    - Fix weak `ETag` matching to match spec
    - Remove usage of `res._headers` private field
    - Support `If-Match` and `If-Unmodified-Since` headers
    - Use `res.getHeaderNames()` when available
    - Use `res.headersSent` when available
    - deps: debug@2.6.1
    - deps: etag@~1.8.0
    - deps: fresh@0.5.0
    - deps: http-errors@~1.6.1
  * deps: serve-static@1.12.0
    - Fix false detection of `no-cache` request directive
    - Fix incorrect result when `If-None-Match` has both `*` and ETags
    - Fix weak `ETag` matching to match spec
    - Remove usage of `res._headers` private field
    - Send complete HTML document in redirect response
    - Set default CSP header in redirect response
    - Support `If-Match` and `If-Unmodified-Since` headers
    - Use `res.getHeaderNames()` when available
    - Use `res.headersSent` when available
    - deps: send@0.15.0
  * perf: add fast match path for `*` route
  * perf: improve `req.ips` performance

4.14.1 / 2017-01-28
===================

  * deps: content-disposition@0.5.2
  * deps: finalhandler@0.5.1
    - Fix exception when `err.headers` is not an object
    - deps: statuses@~1.3.1
    - perf: hoist regular expressions
    - perf: remove duplicate validation path
  * deps: proxy-addr@~1.1.3
    - deps: ipaddr.js@1.2.0
  * deps: send@0.14.2
    - deps: http-errors@~1.5.1
    - deps: ms@0.7.2
    - deps: statuses@~1.3.1
  * deps: serve-static@~1.11.2
    - deps: send@0.14.2
  * deps: type-is@~1.6.14
    - deps: mime-types@~2.1.13

4.14.0 / 2016-06-16
===================

  * Add `acceptRanges` option to `res.sendFile`/`res.sendfile`
  * Add `cacheControl` option to `res.sendFile`/`res.sendfile`
  * Add `options` argument to `req.range`
    - Includes the `combine` option
  * Encode URL in `res.location`/`res.redirect` if not already encoded
  * Fix some redirect handling in `res.sendFile`/`res.sendfile`
  * Fix Windows absolute path check using forward slashes
  * Improve error with invalid arguments to `req.get()`
  * Improve performance for `res.json`/`res.jsonp` in most cases
  * Improve `Range` header handling in `res.sendFile`/`res.sendfile`
  * deps: accepts@~1.3.3
    - Fix including type extensions in parameters in `Accept` parsing
    - Fix parsing `Accept` parameters with quoted equals
    - Fix parsing `Accept` parameters with quoted semicolons
    - Many performance improvments
    - deps: mime-types@~2.1.11
    - deps: negotiator@0.6.1
  * deps: content-type@~1.0.2
    - perf: enable strict mode
  * deps: cookie@0.3.1
    - Add `sameSite` option
    - Fix cookie `Max-Age` to never be a floating point number
    - Improve error message when `encode` is not a function
    - Improve error message when `expires` is not a `Date`
    - Throw better error for invalid argument to parse
    - Throw on invalid values provided to `serialize`
    - perf: enable strict mode
    - perf: hoist regular expression
    - perf: use for loop in parse
    - perf: use string concatination for serialization
  * deps: finalhandler@0.5.0
    - Change invalid or non-numeric status code to 500
    - Overwrite status message to match set status code
    - Prefer `err.statusCode` if `err.status` is invalid
    - Set response headers from `err.headers` object
    - Use `statuses` instead of `http` module for status messages
  * deps: proxy-addr@~1.1.2
    - Fix accepting various invalid netmasks
    - Fix IPv6-mapped IPv4 validation edge cases
    - IPv4 netmasks must be contingous
    - IPv6 addresses cannot be used as a netmask
    - deps: ipaddr.js@1.1.1
  * deps: qs@6.2.0
    - Add `decoder` option in `parse` function
  * deps: range-parser@~1.2.0
    - Add `combine` option to combine overlapping ranges
    - Fix incorrectly returning -1 when there is at least one valid range
    - perf: remove internal function
  * deps: send@0.14.1
    - Add `acceptRanges` option
    - Add `cacheControl` option
    - Attempt to combine multiple ranges into single range
    - Correctly inherit from `Stream` class
    - Fix `Content-Range` header in 416 responses when using `start`/`end` options
    - Fix `Content-Range` header missing from default 416 responses
    - Fix redirect error when `path` contains raw non-URL characters
    - Fix redirect when `path` starts with multiple forward slashes
    - Ignore non-byte `Range` headers
    - deps: http-errors@~1.5.0
    - deps: range-parser@~1.2.0
    - deps: statuses@~1.3.0
    - perf: remove argument reassignment
  * deps: serve-static@~1.11.1
    - Add `acceptRanges` option
    - Add `cacheControl` option
    - Attempt to combine multiple ranges into single range
    - Fix redirect error when `req.url` contains raw non-URL characters
    - Ignore non-byte `Range` headers
    - Use status code 301 for redirects
    - deps: send@0.14.1
  * deps: type-is@~1.6.13
    - Fix type error when given invalid type to match against
    - deps: mime-types@~2.1.11
  * deps: vary@~1.1.0
    - Only accept valid field names in the `field` argument
  * perf: use strict equality when possible

4.13.4 / 2016-01-21
===================

  * deps: content-disposition@0.5.1
    - perf: enable strict mode
  * deps: cookie@0.1.5
    - Throw on invalid values provided to `serialize`
  * deps: depd@~1.1.0
    - Support web browser loading
    - perf: enable strict mode
  * deps: escape-html@~1.0.3
    - perf: enable strict mode
    - perf: optimize string replacement
    - perf: use faster string coercion
  * deps: finalhandler@0.4.1
    - deps: escape-html@~1.0.3
  * deps: merge-descriptors@1.0.1
    - perf: enable strict mode
  * deps: methods@~1.1.2
    - perf: enable strict mode
  * deps: parseurl@~1.3.1
    - perf: enable strict mode
  * deps: proxy-addr@~1.0.10
    - deps: ipaddr.js@1.0.5
    - perf: enable strict mode
  * deps: range-parser@~1.0.3
    - perf: enable strict mode
  * deps: send@0.13.1
    - deps: depd@~1.1.0
    - deps: destroy@~1.0.4
    - deps: escape-html@~1.0.3
    - deps: range-parser@~1.0.3
  * deps: serve-static@~1.10.2
    - deps: escape-html@~1.0.3
    - deps: parseurl@~1.3.0
    - deps: send@0.13.1