### PR TITLE
Reader/SubscriptionListItem: switch from lib/user-settings to redux

### DIFF
--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -3,7 +3,7 @@
  * External Dependencies
  */
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
 import { connect } from 'react-redux';
@@ -74,7 +74,7 @@ class ConnectedSubscriptionListItem extends React.Component {
 		} = this.props;
 
 		return (
-			<div>
+			<Fragment>
 				<QueryUserSettings />
 				<SubscriptionListItem
 					translate={ translate }
@@ -89,7 +89,7 @@ class ConnectedSubscriptionListItem extends React.Component {
 					followSource={ followSource }
 					railcar={ railcar }
 				/>
-			</div>
+			</Fragment>
 		);
 	}
 }


### PR DESCRIPTION
**Related issue**
#24162 Reduxify: userSettings

**How to test**

1.  Open http://calypso.localhost:3000/me/notifications/subscriptions and make sure the **Block Emails** checkbox is unchecked
1.  Open http://calypso.localhost:3000/following/manage and onfirm that you see a "Settings" option on at the end of the row of each followed sites 
    <img width="123" alt="manage_following_ _wordpress_com" src="https://user-images.githubusercontent.com/681110/40315831-17791ee2-5d4f-11e8-97af-2d917795162d.png">
1.  Open http://calypso.localhost:3000/me/notifications/subscriptions and check the **Block Emails** checkbox
1.  Repeat step 2 and confirm that you no longer see the "Settings" option