### PR TITLE
Add feature flag to enable international shipping labels

### DIFF
--- a/client/extensions/woocommerce/app/order/order-fulfillment/index.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/index.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { first } from 'lodash';
+import { first, includes } from 'lodash';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 
@@ -24,6 +24,7 @@ import {
 	getLabels,
 	isLabelDataFetchError,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
+import { ACCEPTED_USPS_ORIGIN_COUNTRY_CODES } from 'woocommerce/woocommerce-services/state/shipping-label/constants';
 import {
 	areSettingsGeneralLoaded,
 	getStoreLocation,
@@ -44,6 +45,7 @@ import { openPrintingFlow } from 'woocommerce/woocommerce-services/state/shippin
 import QueryLabels from 'woocommerce/woocommerce-services/components/query-labels';
 import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
 import { saveOrder } from 'woocommerce/state/sites/orders/actions';
+import { isEnabled } from 'config';
 
 class OrderFulfillment extends Component {
 	static propTypes = {
@@ -141,7 +143,13 @@ class OrderFulfillment extends Component {
 		}
 	};
 
-	isAddressValidForLabels( address ) {
+	isAddressValidForLabels( address, type ) {
+		if ( isEnabled( 'woocommerce/extension-wcservices/international-labels' ) ) {
+			return (
+				'destination' === type || includes( ACCEPTED_USPS_ORIGIN_COUNTRY_CODES, address.country )
+			);
+		}
+
 		const { labelCountriesData } = this.props;
 		if ( ! labelCountriesData ) {
 			return false;
@@ -175,8 +183,8 @@ class OrderFulfillment extends Component {
 		return (
 			labelsEnabled &&
 			hasLabelsPaymentMethod &&
-			this.isAddressValidForLabels( storeAddress ) &&
-			this.isAddressValidForLabels( shipping )
+			this.isAddressValidForLabels( storeAddress, 'origin' ) &&
+			this.isAddressValidForLabels( shipping, 'destination' )
 		);
 	}
 

--- a/client/extensions/woocommerce/woocommerce-services/components/country-dropdown/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/country-dropdown/index.js
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 import Dropdown from '../dropdown';
 
 const CountryDropdown = props => {
-	const valuesMap = {};
+	const valuesMap = { [ props.value ]: props.value };
 	Object.keys( props.countriesData ).forEach( countryCode => {
 		valuesMap[ countryCode ] = props.countriesData[ countryCode ].name;
 	} );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/constants.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/constants.js
@@ -1,0 +1,12 @@
+// "Countries" from when USPS can ship a package. That is, the countries or territories with at least 1 USPS post office
+export const ACCEPTED_USPS_ORIGIN_COUNTRY_CODES = [
+	'US', // United States
+	'PR', // Puerto Rico
+	'VI', // Virgin Islands
+	'GU', // Guam
+	'AS', // American Samoa
+	'UM', // United States Minor Outlying Islands
+	'MH', // Marshall Islands
+	'FM', // Micronesia
+	'MP', // Northern Mariana Islands
+];

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -3,7 +3,19 @@
 /**
  * External dependencies
  */
-import { find, get, isEmpty, isEqual, isFinite, mapValues, round, some } from 'lodash';
+import {
+	find,
+	get,
+	includes,
+	isEmpty,
+	isEqual,
+	isFinite,
+	mapValues,
+	omit,
+	pick,
+	round,
+	some,
+} from 'lodash';
 import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
@@ -19,6 +31,8 @@ import {
 	isLoaded as arePackagesLoaded,
 	isFetchError as arePackagesErrored,
 } from 'woocommerce/woocommerce-services/state/packages/selectors';
+import { isEnabled } from 'config';
+import { ACCEPTED_USPS_ORIGIN_COUNTRY_CODES } from './constants';
 
 export const getShippingLabel = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
 	return get(
@@ -31,11 +45,6 @@ export const getShippingLabel = ( state, orderId, siteId = getSelectedSiteId( st
 export const isLoaded = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
 	const shippingLabel = getShippingLabel( state, orderId, siteId );
 	return shippingLabel && shippingLabel.loaded;
-};
-
-export const isEnabled = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
-	const shippingLabel = getShippingLabel( state, orderId, siteId );
-	return shippingLabel && shippingLabel.enabled;
 };
 
 export const isFetching = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
@@ -123,6 +132,26 @@ export const getTotalPriceBreakdown = ( state, orderId, siteId = getSelectedSite
 		: null;
 };
 
+export const getCountriesData = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
+	if ( ! isLoaded( state, orderId, siteId ) ) {
+		return null;
+	}
+
+	const shippingLabel = getShippingLabel( state, orderId, siteId );
+	const { countriesData } = shippingLabel.storeOptions;
+	if ( isEnabled( 'woocommerce/extension-wcservices/international-labels' ) || ! countriesData ) {
+		return countriesData;
+	}
+
+	return {
+		...pick( countriesData, [ 'PR', 'VI' ] ),
+		US: {
+			...countriesData.US,
+			states: omit( countriesData.US.states, [ 'AA', 'AE', 'AP' ] ), // Exclude military addresses
+		},
+	};
+};
+
 const getAddressErrors = (
 	{
 		values,
@@ -155,12 +184,11 @@ const getAddressErrors = (
 	} );
 
 	if ( countriesData[ country ] ) {
-		switch ( country ) {
-			case 'US':
-				if ( ! /^\d{5}(?:-\d{4})?$/.test( postcode ) ) {
-					errors.postcode = translate( 'Invalid ZIP code format' );
-				}
-				break;
+		if (
+			includes( ACCEPTED_USPS_ORIGIN_COUNTRY_CODES, country ) &&
+			! /^\d{5}(?:-\d{4})?$/.test( postcode )
+		) {
+			errors.postcode = translate( 'Invalid ZIP code format' );
 		}
 
 		if ( ! isEmpty( countriesData[ country ].states ) && ! state ) {
@@ -331,13 +359,4 @@ export const isLabelDataFetchError = ( state, orderId, siteId = getSelectedSiteI
 		areSettingsErrored( state, siteId ) ||
 		arePackagesErrored( state, siteId )
 	);
-};
-
-export const getCountriesData = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
-	if ( ! isLoaded( state, orderId, siteId ) ) {
-		return null;
-	}
-
-	const shippingLabel = getShippingLabel( state, orderId, siteId );
-	return shippingLabel.storeOptions.countriesData;
 };

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/selectors.js
@@ -316,7 +316,10 @@ describe( 'Shipping label selectors', () => {
 			storeOptions: {
 				countriesData: {
 					US: {
-						CA: 'California',
+						name: 'US of A',
+						states: {
+							CA: 'California',
+						},
 					},
 				},
 			},
@@ -324,7 +327,10 @@ describe( 'Shipping label selectors', () => {
 		const result = getCountriesData( state, orderId, siteId );
 		expect( result ).to.eql( {
 			US: {
-				CA: 'California',
+				name: 'US of A',
+				states: {
+					CA: 'California',
+				},
 			},
 		} );
 	} );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/fields.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/fields.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
-import { isEqual, isObject, size } from 'lodash';
+import { isEqual, isObject, pick, size } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,7 +34,9 @@ import {
 	getShippingLabel,
 	isLoaded,
 	getFormErrors,
+	getCountriesData,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
+import { ACCEPTED_USPS_ORIGIN_COUNTRY_CODES } from 'woocommerce/woocommerce-services/state/shipping-label/constants';
 
 const AddressFields = props => {
 	const {
@@ -47,7 +49,7 @@ const AddressFields = props => {
 		normalizationInProgress,
 		allowChangeCountry,
 		group,
-		storeOptions,
+		countriesData,
 		errors,
 		translate,
 	} = props;
@@ -71,7 +73,7 @@ const AddressFields = props => {
 					selectNormalizedAddress={ selectNormalizedAddressHandler }
 					confirmAddressSuggestion={ confirmAddressSuggestionHandler }
 					editAddress={ editAddressHandler }
-					countriesData={ storeOptions.countriesData }
+					countriesData={ countriesData }
 				/>
 			);
 		}
@@ -85,7 +87,7 @@ const AddressFields = props => {
 					values={ values }
 					confirmAddressSuggestion={ confirmAddressSuggestionHandler }
 					editUnverifiableAddress={ editUnverifiableAddressHandler }
-					countriesData={ storeOptions.countriesData }
+					countriesData={ countriesData }
 					fieldErrors={ fieldErrors }
 				/>
 			);
@@ -162,7 +164,7 @@ const AddressFields = props => {
 					title={ translate( 'State' ) }
 					value={ getValue( 'state' ) }
 					countryCode={ getValue( 'country' ) }
-					countriesData={ storeOptions.countriesData }
+					countriesData={ countriesData }
 					updateValue={ updateValue( 'state' ) }
 					className="address-step__state"
 					error={ fieldErrors.state || generalErrorOnly }
@@ -181,7 +183,7 @@ const AddressFields = props => {
 				title={ translate( 'Country' ) }
 				value={ getValue( 'country' ) }
 				disabled={ ! allowChangeCountry }
-				countriesData={ storeOptions.countriesData }
+				countriesData={ countriesData }
 				updateValue={ updateValue( 'country' ) }
 				error={ fieldErrors.country || generalErrorOnly }
 			/>
@@ -203,19 +205,22 @@ AddressFields.propTypes = {
 	normalized: PropTypes.object,
 	selectNormalized: PropTypes.bool.isRequired,
 	allowChangeCountry: PropTypes.bool.isRequired,
-	storeOptions: PropTypes.object.isRequired,
 	errors: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 	group: PropTypes.string.isRequired,
+	countriesData: PropTypes.object.isRequired,
 };
 
 const mapStateToProps = ( state, { group, orderId, siteId } ) => {
 	const loaded = isLoaded( state, orderId, siteId );
 	const shippingLabel = getShippingLabel( state, orderId, siteId );
-	const storeOptions = loaded ? shippingLabel.storeOptions : {};
+	let countriesData = getCountriesData( state, orderId, siteId );
+	if ( 'origin' === group ) {
+		countriesData = pick( countriesData, ACCEPTED_USPS_ORIGIN_COUNTRY_CODES );
+	}
 	return {
 		...shippingLabel.form[ group ],
 		errors: loaded && getFormErrors( state, orderId, siteId )[ group ],
-		storeOptions,
+		countriesData,
 	};
 };
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
@@ -56,7 +56,7 @@ const renderSummary = (
 	}
 	str += 'US' === country ? postcode.split( '-' )[ 0 ] : postcode;
 	if ( showCountry ) {
-		str += ', ' + countriesData[ country ].name;
+		str += ', ' + ( countriesData[ country ] ? countriesData[ country ].name : country );
 	}
 	return str;
 };

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/summary.js
@@ -14,7 +14,7 @@ const AddressSummary = ( { values, originalValues, countriesData, expandStateNam
 		const statesMap = ( expandStateName && ( countriesData[ country ] || {} ).states ) || {};
 		stateStr = statesMap[ state ] || state;
 	}
-	const countryStr = countriesData[ country ].name;
+	const countryStr = countriesData[ country ] ? countriesData[ country ].name : country;
 
 	const getValue = fieldName => {
 		const rawValue = values[ fieldName ];
@@ -41,7 +41,7 @@ const AddressSummary = ( { values, originalValues, countriesData, expandStateNam
 				{ getValue( 'address' ) } { getValue( 'address_2' ) }
 			</p>
 			<p>
-				{ getValue( 'city' ) }, { getValue( 'state' ) }&nbsp;{ getValue( 'postcode' ) }
+				{ getValue( 'city' ) }, { getValue( 'state' ) }&nbsp; { getValue( 'postcode' ) }
 			</p>
 			<p>{ getValue( 'country' ) }</p>
 		</div>

--- a/config/development.json
+++ b/config/development.json
@@ -210,6 +210,7 @@
 		"woocommerce/extension-settings-stripe-connect-flows": true,
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
+		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": false
 	}

--- a/config/stage.json
+++ b/config/stage.json
@@ -159,6 +159,7 @@
 		"woocommerce/extension-settings-stripe-connect-flows": true,
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
+		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true
 	},


### PR DESCRIPTION
This is part of the international USPS shipping labels work.

In this PR:
- Added the feature flag `woocommerce/extension-wcservices/international-labels`, set it to `true` just in `development` and `staging` (maybe it makes sense just in `development` for now?)
- Logic to show or hide the `Print label & fulfill` button. If the config flag is enabled, it will always be displayed. If not, then it will only be displayed if the origin and destination are in the US, Puerto Rico, or Virgin Islands, since in those cases there's no need for a customs form.
- If the feature flag is disabled, the merchant won't be able to choose any other country than US, PR or VI in the label purchase flow.

The `add/intl-labels` branch in the `woocommerce-services` repo ensures that the REST API replies with all the countries in the world, not only the "supported" ones. Without it, you'll only see US and Puerto Rico, even if you have the feature flag enabled. Not ideal, but a good enough experience for backwards-compatibility.

Note that nothing else is changes in this PR. The purchase label flow will probable explode at the time of purchasing the label if it's an international request.