### PR TITLE
Components: remove dead userSettings code

### DIFF
--- a/client/reader/following/controller.js
+++ b/client/reader/following/controller.js
@@ -9,7 +9,6 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import { sectionify } from 'lib/route';
-import userSettings from 'lib/user-settings';
 import { trackPageLoad, setPageTitle } from 'reader/controller-helper';
 import AsyncLoad from 'components/async-load';
 
@@ -36,7 +35,6 @@ const exported = {
 				showMoreResults={ Boolean( showMoreResults ) }
 				subsSortOrder={ subsSortOrder }
 				context={ context }
-				userSettings={ userSettings }
 			/>
 		);
 		next();


### PR DESCRIPTION
Remove unused userSettings code.
Part of #24162.

This PR:

- Removes userSettings from `reader/following/controller.js`, because the controller passes userSettings to `reader/following-manage.index.js` which doesn't use userSettings at all
- ~Removes userSettings from `<NotificationSubscriptions />` because this component does not use userSettings anymore~
- ~Removes userSettings from `me/notification-settings/controller.js`, because this controller passes userSettings to `<NotificationsComponent />` and `<NotificationSubscriptions />`, and both components do not use userSettings anymore~

