### PR TITLE
Purchases: Display credits purchase type in meta

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { times } from 'lodash';
@@ -175,14 +175,14 @@ class PurchaseMeta extends Component {
 		const { purchase, translate } = this.props;
 
 		if ( isIncludedWithPlan( purchase ) ) {
-			return <span className="manage-purchase__detail">{ translate( 'Included with plan' ) }</span>;
+			return translate( 'Included with plan' );
 		}
 
 		if ( typeof purchase.payment.type !== 'undefined' ) {
 			let paymentInfo = null;
 
 			if ( purchase.payment.type === 'credits' ) {
-				return <span className="manage-purchase__detail">{ translate( 'Credits' ) }</span>;
+				return translate( 'Credits' );
 			}
 
 			if ( isPaidWithCreditCard( purchase ) ) {
@@ -196,14 +196,14 @@ class PurchaseMeta extends Component {
 			}
 
 			return (
-				<span className="manage-purchase__detail">
+				<Fragment>
 					<PaymentLogo type={ paymentLogoType( purchase ) } />
 					{ paymentInfo }
-				</span>
+				</Fragment>
 			);
 		}
 
-		return <span className="manage-purchase__detail">{ translate( 'None' ) }</span>;
+		return translate( 'None' );
 	}
 
 	renderPaymentDetails() {
@@ -216,7 +216,7 @@ class PurchaseMeta extends Component {
 		const paymentDetails = (
 			<span>
 				<em className="manage-purchase__detail-label">{ translate( 'Payment method' ) }</em>
-				{ this.renderPaymentInfo() }
+				<span className="manage-purchase__detail">{ this.renderPaymentInfo() }</span>
 			</span>
 		);
 

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -181,6 +181,10 @@ class PurchaseMeta extends Component {
 		if ( typeof purchase.payment.type !== 'undefined' ) {
 			let paymentInfo = null;
 
+			if ( purchase.payment.type === 'credits' ) {
+				return <span className="manage-purchase__detail">{ translate( 'Credits' ) }</span>;
+			}
+
 			if ( isPaidWithCreditCard( purchase ) ) {
 				paymentInfo = purchase.payment.creditCard.number;
 			} else if ( isPaidWithPayPalDirect( purchase ) ) {


### PR DESCRIPTION
This PR updates the purchases detail screen to display the purchases type when the payment is made with credits. Currently, if the payment has been done with credits, just an empty white space is displayed:

![](https://cldup.com/yHUnVdj-f1.png)

With the PR, any credits-made payments will appear this way:

![](https://cldup.com/KiPuJcAky6.png)

This is already reusing the styles for displaying "None" when the purchase isn't associated with a particular payment type, so design review shouldn't be necessary:

![](https://cldup.com/1zSK7fVTdE.png)

Finally, the PR uses the occasion to cleanup some unnecessary `<span className="manage-purchase__detail" />` instances in the related sutiations.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/me/purchases
* Select a purchase that has been made with credits
* Verify you can see the "Credits" label in the "Payment method" section.
* Test with some purchases with various other payment methods and verify they still appear properly and unchanged:
  * Credit Card
  * PayPal
  * Others (Alipay, Bancontact, Giropay, EPS, iDEAL, P24, Brazilian TEF)