### PR TITLE
Domains: Apply filters on popover closure

### DIFF
--- a/client/components/domains/search-filters/dropdown-filters.jsx
+++ b/client/components/domains/search-filters/dropdown-filters.jsx
@@ -13,6 +13,7 @@ import { isEqual, pick } from 'lodash';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import config from 'config';
 import ValidationFieldset from 'signup/validation-fieldset';
 import FormTextInput from 'components/forms/form-text-input';
@@ -159,6 +160,7 @@ export class DropdownFilters extends Component {
 			translate,
 		} = this.props;
 
+		const filterOnClose = abtest( 'domainSearchFilterOnClose' ) === 'enabled';
 		const isDashesFilterEnabled = config.isEnabled( 'domains/kracken-ui/dashes-filter' );
 		const isExactMatchFilterEnabled = config.isEnabled( 'domains/kracken-ui/exact-match-filter' );
 		const isLengthFilterEnabled = config.isEnabled( 'domains/kracken-ui/max-characters-filter' );
@@ -169,7 +171,7 @@ export class DropdownFilters extends Component {
 				className="search-filters__popover"
 				context={ this.button.current }
 				isVisible={ this.state.showPopover }
-				onClose={ this.togglePopover }
+				onClose={ filterOnClose ? this.handleFiltersSubmit : this.togglePopover }
 				position="bottom left"
 			>
 				{ isLengthFilterEnabled && (

--- a/client/components/domains/search-filters/dropdown-filters.jsx
+++ b/client/components/domains/search-filters/dropdown-filters.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
+import { isEqual, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,6 +21,8 @@ import FormInputCheckbox from 'components/forms/form-checkbox';
 import FormFieldset from 'components/forms/form-fieldset';
 import Popover from 'components/popover';
 import Button from 'components/button';
+
+const HANDLED_FILTER_KEYS = [ 'includeDashes', 'maxCharacters', 'exactSldMatchesOnly' ];
 
 export class DropdownFilters extends Component {
 	static propTypes = {
@@ -117,9 +120,16 @@ export class DropdownFilters extends Component {
 
 		this.setState( { showOverallValidationError: false }, () => {
 			this.togglePopover( { discardChanges: false } );
-			this.props.onSubmit();
+			this.hasFiltersChanged() && this.props.onSubmit();
 		} );
 	};
+
+	hasFiltersChanged() {
+		return ! isEqual(
+			pick( this.props.filters, HANDLED_FILTER_KEYS ),
+			pick( this.props.lastFilters, HANDLED_FILTER_KEYS )
+		);
+	}
 
 	render() {
 		const hasFilterValues = this.getFiltercounts() > 0;

--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -14,6 +14,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -157,6 +158,7 @@ export class TldFilterBar extends Component {
 
 	renderPopover() {
 		const { translate } = this.props;
+		const filterOnClose = abtest( 'domainSearchFilterOnClose' ) === 'enabled';
 
 		return (
 			<Popover
@@ -164,7 +166,7 @@ export class TldFilterBar extends Component {
 				className="search-filters__popover"
 				context={ this.button }
 				isVisible={ this.state.showPopover }
-				onClose={ this.togglePopover }
+				onClose={ filterOnClose ? this.handleFiltersSubmit : this.togglePopover }
 				position="bottom left"
 			>
 				<FormFieldset className="search-filters__token-field-fieldset">

--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import React, { Component } from 'react';
-import { includes } from 'lodash';
+import { includes, isEqual, pick } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -20,6 +20,8 @@ import FormFieldset from 'components/forms/form-fieldset';
 import Popover from 'components/popover';
 import TokenField from 'components/token-field';
 import { recordTldFilterSelected } from './analytics';
+
+const HANDLED_FILTER_KEYS = [ 'tlds' ];
 
 export class TldFilterBar extends Component {
 	static propTypes = {
@@ -75,7 +77,7 @@ export class TldFilterBar extends Component {
 	};
 	handleFiltersSubmit = () => {
 		this.togglePopover();
-		this.props.onSubmit();
+		this.hasFiltersChanged() && this.props.onSubmit();
 	};
 	handleTokenChange = newTlds => {
 		const tlds = newTlds.filter( tld => includes( this.props.availableTlds, tld ) );
@@ -87,6 +89,13 @@ export class TldFilterBar extends Component {
 			showPopover: ! this.state.showPopover,
 		} );
 	};
+
+	hasFiltersChanged() {
+		return ! isEqual(
+			pick( this.props.filters, HANDLED_FILTER_KEYS ),
+			pick( this.props.lastFilters, HANDLED_FILTER_KEYS )
+		);
+	}
 
 	render() {
 		if ( this.props.showPlaceholder ) {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -100,4 +100,12 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
+	domainSearchFilterOnClose: {
+		datestamp: '20180524',
+		variations: {
+			disabled: 50,
+			enabled: 50,
+		},
+		defaultVariation: 'disabled',
+	},
 };


### PR DESCRIPTION
This change changes the behavior of popover closure to trigger a filter submission if a filter in that interface has been changed.

# Testing instructions
1. Spin up this branch locally.
2. Set your group for the `domainSearchFilterOnClose` test to `enabled` using the A/B helper component on the bottom right.
3. Navigate to `/start/domains/` and enter a query.
4. Open the drop-down filter next to the search bar.
5. Select some filters and close the drop-down by clicking outside of the popover.
6. Ensure that a new search is kicked off with the filters applied.
7. Repeat 4~6 with the TLD drop-down filter.