### PR TITLE
Domains: Prepend TLD tokens with period

### DIFF
--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -175,4 +175,8 @@
 		padding-top: 0;
 		overflow-y: scroll;
 	}
+
+	.token-field__suggestion-match {
+		color: inherit;
+	}
 }

--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -161,6 +161,8 @@ export class TldFilterBar extends Component {
 				<FormFieldset className="search-filters__token-field-fieldset">
 					<TokenField
 						isExpanded
+						displayTransform={ item => `.${ item }` }
+						saveTransform={ query => ( query[ 0 ] === '.' ? query.substr( 1 ) : query ) }
 						maxSuggestions={ 500 }
 						onChange={ this.handleTokenChange }
 						placeholder={ translate( 'Select an extension' ) }


### PR DESCRIPTION
This change prepends all TLD suggestions in the drop-down token field to be prefixed with a period.

<img width="396" alt="wordpress_com" src="https://user-images.githubusercontent.com/4044428/40333029-a9282360-5d13-11e8-8e4c-b6e5c63005d9.png">

# Testing Instructions
1. Spin up this change locally or via a live branch.
2. Navigate to `/start/domains` and enter a query.
3. Open the TLD drop-down menu. Verify that all TLDs are prefixed with a period.
4. Try a variety of searches, like `.com`, `com.br`, `business`, etc. Ensure that the component works as expected.