### PR TITLE
Add `SupportInfo` component for GDPR Privacy Information links

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -235,6 +235,7 @@
 @import 'components/sticky-panel/style';
 @import 'components/sub-masterbar-nav/style';
 @import 'components/suggestions/style';
+@import 'components/support-info/style';
 @import 'components/textarea-autosize/style';
 @import 'components/text-diff/style';
 @import 'components/thank-you-card/style';

--- a/client/components/support-info/README.md
+++ b/client/components/support-info/README.md
@@ -1,0 +1,27 @@
+Support Info
+=============
+
+This component is used to display a support info icon. When clicked, it displays a popover with a description, a learn more link, and a privacy info link.
+
+## Example Usage:
+
+```js
+import SupportInfo from 'components/support-info';
+
+render() {
+	const support = {
+		text: 'About this.',
+		link: 'https://example.com/',
+		privacyLink: 'https://example.com/#privacy',
+	};
+	return (
+		<SupportInfo { ...support } />
+	);
+}
+```
+
+## Props
+
+- `text` - (string) A brief description of a feature.
+- `link` - *optional* (string|bool) A URL leading to an overview of a feature. If `false`, no link will be displayed.
+- `privacyLink` - *optional* (string|bool) A URL leading to the privacy information for a feature. If empty, defaults to `[link]#privacy`. If false, no privacy link will be displayed.

--- a/client/components/support-info/docs/example.jsx
+++ b/client/components/support-info/docs/example.jsx
@@ -1,0 +1,24 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import SupportInfo from 'components/support-info';
+
+export default class extends React.PureComponent {
+	static displayName = 'SupportInfo';
+
+	render() {
+		const support = {
+			text: 'Example support info. Lorem Ipsum is simply dummy text.',
+			link: 'https://www.lipsum.com/',
+			privacyLink: 'https://www.lipsum.com/#privacy',
+		};
+		return <SupportInfo { ...support } />;
+	}
+}

--- a/client/components/support-info/index.jsx
+++ b/client/components/support-info/index.jsx
@@ -1,0 +1,61 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import InfoPopover from 'components/info-popover';
+import ExternalLink from 'components/external-link';
+
+class SupportInfo extends Component {
+	static propTypes = {
+		text: PropTypes.string,
+		link: PropTypes.string,
+		privacyLink: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
+	};
+
+	static defaultProps = {
+		text: '',
+		link: '',
+		privacyLink: '',
+	};
+
+	render() {
+		const { text, link, translate } = this.props;
+		let { privacyLink } = this.props;
+
+		if ( ! privacyLink && privacyLink !== false && link ) {
+			privacyLink = link + '#privacy';
+		}
+
+		return (
+			<div className="support-info">
+				<InfoPopover position="left" screenReaderText={ translate( 'Learn more' ) }>
+					{ text + ' ' }
+					{ link && (
+						<span className="support-info__learn-more">
+							<ExternalLink href={ link } target="_blank" rel="noopener noreferrer">
+								{ translate( 'Learn more' ) }
+							</ExternalLink>
+						</span>
+					) }
+					{ privacyLink && (
+						<span className="support-info__privacy">
+							<ExternalLink href={ privacyLink } target="_blank" rel="noopener noreferrer">
+								{ translate( 'Privacy Information' ) }
+							</ExternalLink>
+						</span>
+					) }
+				</InfoPopover>
+			</div>
+		);
+	}
+}
+
+export default localize( SupportInfo );

--- a/client/components/support-info/index.jsx
+++ b/client/components/support-info/index.jsx
@@ -27,12 +27,9 @@ class SupportInfo extends Component {
 	};
 
 	render() {
-		const { text, link, translate } = this.props;
-		let { privacyLink } = this.props;
-
-		if ( ! privacyLink && privacyLink !== false && link ) {
-			privacyLink = link + '#privacy';
-		}
+		const { text, link, privacyLink, translate } = this.props;
+		const actualPrivacyLink =
+			! privacyLink && privacyLink !== false && link ? link + '#privacy' : privacyLink;
 
 		return (
 			<div className="support-info">
@@ -45,9 +42,9 @@ class SupportInfo extends Component {
 							</ExternalLink>
 						</span>
 					) }
-					{ privacyLink && (
+					{ actualPrivacyLink && (
 						<span className="support-info__privacy">
-							<ExternalLink href={ privacyLink } target="_blank" rel="noopener noreferrer">
+							<ExternalLink href={ actualPrivacyLink } target="_blank" rel="noopener noreferrer">
 								{ translate( 'Privacy Information' ) }
 							</ExternalLink>
 						</span>

--- a/client/components/support-info/style.scss
+++ b/client/components/support-info/style.scss
@@ -1,0 +1,13 @@
+.support-info {
+	float: right;
+	margin: 0 0 20px 20px;
+}
+
+.popover {
+	.support-info__privacy {
+		display: block;
+		margin-top: 14px;
+		padding-top: 12px;
+		border-top: 1px solid rgba( $gray, 0.5 );
+	}
+}

--- a/client/components/support-info/style.scss
+++ b/client/components/support-info/style.scss
@@ -8,6 +8,6 @@
 		display: block;
 		margin-top: 14px;
 		padding-top: 12px;
-		border-top: 1px solid rgba( $gray, 0.5 );
+		border-top: 1px solid $gray-lighten-30;
 	}
 }

--- a/client/components/support-info/test/index.js
+++ b/client/components/support-info/test/index.js
@@ -1,0 +1,36 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import SupportInfo from '../';
+
+describe( 'SupportInfo', () => {
+	const testProps = {
+		text: 'Hello world!',
+		link: 'https://foo.com/',
+		privacyLink: 'https://foo.com/privacy/',
+	};
+
+	const wrapper = shallow( <SupportInfo { ...testProps } /> ).dive();
+
+	it( 'should have a proper "Learn more" link', () => {
+		expect( wrapper.find( 'ExternalLink' ).get( 0 ).props.href ).to.be.equal( 'https://foo.com/' );
+	} );
+
+	it( 'should have a proper "Privacy Information" link', () => {
+		expect( wrapper.find( 'ExternalLink' ).get( 1 ).props.href ).to.be.equal(
+			'https://foo.com/privacy/'
+		);
+	} );
+} );

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -99,6 +99,7 @@ import SpinnerButton from 'components/spinner-button/docs/example';
 import SpinnerLine from 'components/spinner-line/docs/example';
 import SplitButton from 'components/split-button/docs/example';
 import Suggestions from 'components/suggestions/docs/example';
+import SupportInfoExample from 'components/support-info/docs/example';
 import TextareaAutosize from 'components/textarea-autosize/docs/example';
 import TextDiff from 'components/text-diff/docs/example';
 import TileGrid from 'components/tile-grid/docs/example';
@@ -237,6 +238,7 @@ class DesignAssets extends React.Component {
 					<SpinnerButton searchKeywords="loading input submit" readmeFilePath="spinner-button" />
 					<SpinnerLine searchKeywords="loading" readmeFilePath="spinner-line" />
 					<Suggestions readmeFilePath="suggestions" />
+					<SupportInfoExample />
 					<TextareaAutosize readmeFilePath="textarea-autosize" />
 					<TextDiff readmeFilePath="text-diff" />
 					<TileGrid readmeFilePath="tile-grid" />


### PR DESCRIPTION
This cherry picks only the `client/components/support-info/` directory
from https://github.com/Automattic/wp-calypso/pull/23949 so it can be reviewed and merged separately.

### Overview of Changes

- Adds a new `SupportInfo` component. See [README](https://github.com/Automattic/wp-calypso/blob/cb1346aede4d260129652ffb814ce12b9b0320df/client/components/support-info/README.md) in the [`client/components/support-info`](https://github.com/Automattic/wp-calypso/blob/cb1346aede4d260129652ffb814ce12b9b0320df/client/components/support-info) directory. The new component is used to display a support info icon. When clicked, it displays a popover with a description, a learn more link, and a privacy info link.