### PR TITLE
GDPR Privacy Information links (batch 1)

### DIFF
--- a/client/components/support-info/style.scss
+++ b/client/components/support-info/style.scss
@@ -1,6 +1,6 @@
 .support-info {
 	float: right;
-	margin: 0 0 20px 20px;
+	margin: 0 0 0 20px;
 }
 
 .popover {

--- a/client/my-sites/site-settings/comment-display-settings/index.jsx
+++ b/client/my-sites/site-settings/comment-display-settings/index.jsx
@@ -17,8 +17,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormSelect from 'components/forms/form-select';
 import FormTextInput from 'components/forms/form-text-input';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
@@ -33,21 +32,13 @@ class CommentDisplaySettings extends Component {
 
 		return (
 			<FormFieldset className="comment-display-settings">
-				<div className="comment-display-settings__info site-settings__info-link-container">
-					<InfoPopover position="left">
-						{ translate(
-							'Replaces the standard WordPress comment form with a new comment system ' +
-								'that includes social media login options.'
-						) }{' '}
-						<ExternalLink
-							target="_blank"
-							icon={ false }
-							href="https://jetpack.com/support/comments"
-						>
-							{ translate( 'Learn more' ) }
-						</ExternalLink>
-					</InfoPopover>
-				</div>
+				<SupportInfo
+					text={ translate(
+						'Replaces the standard WordPress comment form with a new comment system ' +
+							'that includes social media login options.'
+					) }
+					link="https://jetpack.com/support/comments/"
+				/>
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }
 					moduleSlug="comments"

--- a/client/my-sites/site-settings/composing/after-the-deadline.jsx
+++ b/client/my-sites/site-settings/composing/after-the-deadline.jsx
@@ -217,7 +217,7 @@ class AfterTheDeadline extends Component {
 				<div className="composing__module-settings site-settings__child-settings">
 					<SupportInfo
 						text={ translate(
-							'Checks your content for correct grammar and spelling, misused words, and style.'
+							'Checks your content for correct grammar and spelling, misused words, and style while you write.'
 						) }
 						link="https://jetpack.com/support/spelling-and-grammar/"
 					/>

--- a/client/my-sites/site-settings/composing/after-the-deadline.jsx
+++ b/client/my-sites/site-settings/composing/after-the-deadline.jsx
@@ -19,8 +19,7 @@ import FormLegend from 'components/forms/form-legend';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import TokenField from 'components/token-field';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
@@ -216,22 +215,12 @@ class AfterTheDeadline extends Component {
 				<QueryJetpackConnection siteId={ selectedSiteId } />
 
 				<div className="composing__module-settings site-settings__child-settings">
-					<div className="composing__info-link-container site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate(
-								'Checks your content for correct grammar and spelling, ' +
-									'misused words, and style while you write.'
-							) }{' '}
-							<ExternalLink
-								href="https://jetpack.com/support/spelling-and-grammar/"
-								icon={ false }
-								target="_blank"
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
-
+					<SupportInfo
+						text={ translate(
+							'Checks your content for correct grammar and spelling, misused words, and style.'
+						) }
+						link="https://jetpack.com/support/spelling-and-grammar/"
+					/>
 					{ this.renderProofreadingSection() }
 					{ this.renderAutoLanguageDetectionSection() }
 					{ this.renderEnglishOptionsSection() }

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -22,8 +22,7 @@ import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import { activateModule } from 'state/jetpack/modules/actions';
 import { isJetpackSite } from 'state/sites/selectors';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 
 class CustomContentTypes extends Component {
 	componentDidUpdate() {
@@ -162,57 +161,33 @@ class CustomContentTypes extends Component {
 		return (
 			<Card className="custom-content-types site-settings">
 				<FormFieldset>
-					<div className="custom-content-types__info-link-container site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate( 'Showcases your portfolio or displays testimonials on your site.' ) +
-								' ' }
-							<ExternalLink
-								href="https://support.wordpress.com/custom-post-types/"
-								icon={ false }
-								target="_blank"
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+					<SupportInfo
+						text={ translate( 'Showcases your portfolio or displays testimonials on your site.' ) }
+						link="https://support.wordpress.com/custom-post-types/"
+						privacyLink={ false }
+					/>
 					{ this.renderBlogPostSettings() }
 				</FormFieldset>
 
 				<FormFieldset>
-					<div className="custom-content-types__info-link-container site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate(
-								'Adds the Testimonial custom post type, allowing you to collect, organize, ' +
-									'and display testimonials on your site.'
-							) }{' '}
-							<ExternalLink
-								target="_blank"
-								icon={ false }
-								href="https://jetpack.com/support/custom-content-types/"
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+					<SupportInfo
+						text={ translate(
+							'Adds the Testimonial custom post type, allowing you to collect, organize, ' +
+								'and display testimonials on your site.'
+						) }
+						link="https://jetpack.com/support/custom-content-types/"
+					/>
 					{ this.renderTestimonialSettings() }
 				</FormFieldset>
 
 				<FormFieldset>
-					<div className="custom-content-types__info-link-container site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate(
-								'Adds the Portfolio custom post type, allowing you to ' +
-									'manage and showcase projects on your site.'
-							) }{' '}
-							<ExternalLink
-								target="_blank"
-								icon={ false }
-								href="https://jetpack.com/support/custom-content-types/"
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+					<SupportInfo
+						text={ translate(
+							'Adds the Portfolio custom post type, allowing you to ' +
+								'manage and showcase projects on your site.'
+						) }
+						link="https://jetpack.com/support/custom-content-types/"
+					/>
 					{ this.renderPortfolioSettings() }
 				</FormFieldset>
 			</Card>

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -16,6 +16,7 @@ import Card from 'components/card';
 import Button from 'components/button';
 import SectionHeader from 'components/section-header';
 import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import Banner from 'components/banner';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import { getPlugins } from 'state/plugins/installed/selectors';
@@ -179,6 +180,14 @@ export class GoogleAnalyticsForm extends Component {
 					<Card className="analytics-settings site-settings__analytics-settings">
 						{ siteIsJetpack && (
 							<fieldset>
+								<SupportInfo
+									text={ translate(
+										'Reports help you track the path visitors take' +
+											' through your site, and goal conversion lets you' +
+											' measure how visitors complete specific tasks.'
+									) }
+									link="https://jetpack.com/support/google-analytics/"
+								/>
 								<JetpackModuleToggle
 									siteId={ siteId }
 									moduleSlug="google-analytics"

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -13,6 +13,7 @@ import { flowRight, pick } from 'lodash';
  */
 import Button from 'components/button';
 import Card from 'components/card';
+import SupportInfo from 'components/support-info';
 import CommentDisplaySettings from './comment-display-settings';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -185,12 +186,28 @@ class SiteSettingsFormDiscussion extends Component {
 						'Comments should be displayed with the older comments at the top of each page'
 					) }
 				</CompactFormToggle>
+
+				{ this.props.isJetpack && (
+					<SupportInfo
+						text={ translate( 'Hovercards appear when you place your mouse over any Gravatar.' ) }
+						link="https://jetpack.com/support/gravatar-hovercards/"
+					/>
+				) }
 				<JetpackModuleToggle
 					disabled={ isRequestingSettings || isSavingSettings }
 					label={ translate( 'Enable pop-up business cards over commenters’ Gravatars' ) }
 					moduleSlug="gravatar-hovercards"
 					siteId={ siteId }
 				/>
+
+				{ this.props.isJetpack && (
+					<SupportInfo
+						text={ translate(
+							'Comment Likes are a fun, easy way to demonstrate your appreciation or agreement.'
+						) }
+						link="https://jetpack.com/support/comment-likes/"
+					/>
+				) }
 				<JetpackModuleToggle
 					disabled={ isRequestingSettings || isSavingSettings }
 					label={ translate( 'Enable comment likes' ) }

--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -17,8 +17,7 @@ import Card from 'components/card';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import SectionHeader from 'components/section-header';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import QuerySiteMonitorSettings from 'components/data/query-site-monitor-settings';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -137,18 +136,10 @@ class SiteSettingsFormJetpackMonitor extends Component {
 				<SectionHeader label={ translate( 'Downtime Monitoring' ) } />
 
 				<Card className="jetpack-monitor-settings">
-					<div className="site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate( "Notifies you when there's an issue with your site." ) }{' '}
-							<ExternalLink
-								href="https://jetpack.com/support/monitor/"
-								icon={ false }
-								target="_blank"
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+					<SupportInfo
+						text={ translate( "Notifies you when there's an issue with your site." ) }
+						link="https://jetpack.com/support/monitor/"
+					/>
 
 					<JetpackModuleToggle
 						siteId={ siteId }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -415,9 +415,9 @@
 		padding: 24px;
 	}
 
-	.composing__module-settings .site-settings__info-link-container,
-	.protect__module-settings .site-settings__info-link-container,
-	.spam-filtering__settings .site-settings__info-link-container {
+	.composing__module-settings .support-info,
+	.protect__module-settings .support-info,
+	.spam-filtering__settings .support-info {
 		margin-right: -36px;
 		height: 0;
 	}
@@ -436,11 +436,7 @@
 	margin: 16px 36px 0;
 }
 
-.site-settings__info-link-container {
-	float: right;
-}
-
-.form-legend + .site-settings__info-link-container {
+.form-legend + .support-info {
 	margin-top: -21px;
 }
 

--- a/client/my-sites/site-settings/test/form-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-analytics.jsx
@@ -1,4 +1,7 @@
-/** @format */
+/**
+ * @format
+ * @jest-environment jsdom
+ */
 
 jest.mock( 'lib/abtest', () => ( {
 	abtest: () => '',


### PR DESCRIPTION
~~This PR depends on https://github.com/Automattic/wp-calypso/pull/24985.~~ (merged).

The original full PR was broken apart by request: https://github.com/Automattic/wp-calypso/pull/23949#issuecomment-382109504.

---

This is batch one of the new Privacy Information links, implemented using the new `SupportInfo` component in https://github.com/Automattic/wp-calypso/pull/24985

## Overview of Changes

- Updates CSS, changing `.site-settings__info-link-container` to `.support-info`.

- Removes `.site-settings__info-link-container` in favor of SupportInfo.

- Adds support info icons to `JetpackModuleToggle` instances, covering every Jetpack module/feature. In batch one I covered the following Jetpack features:

  - Comment Display Settings
  - After the Deadline
  - Custom Content Types
  - Google Analytics
  - Comment Links + Hovercards
  - Jetpack Monitoring