### PR TITLE
GDPR Privacy Information links (batch 2)

### DIFF
--- a/client/my-sites/site-settings/jetpack-ads.jsx
+++ b/client/my-sites/site-settings/jetpack-ads.jsx
@@ -19,7 +19,7 @@ import CompactFormToggle from 'components/forms/form-toggle/compact';
 import ExternalLink from 'components/external-link';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import InfoPopover from 'components/info-popover';
+import SupportInfo from 'components/support-info';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import SectionHeader from 'components/section-header';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -81,15 +81,12 @@ class JetpackAds extends Component {
 
 		return (
 			<div>
-				<div className="site-settings__info-link-container">
-					<InfoPopover position="left">
-						{ translate( 'Displays high-quality ads on your site that allow you to earn income.' ) }{' '}
-						<ExternalLink href="https://jetpack.com/support/ads" icon={ false } target="_blank">
-							{ translate( 'Learn more' ) }
-						</ExternalLink>
-					</InfoPopover>
-				</div>
-
+				<SupportInfo
+					text={ translate(
+						'Displays high-quality ads on your site that allow you to earn income.'
+					) }
+					link="https://jetpack.com/support/ads/"
+				/>
 				<div>
 					{ translate(
 						'Show ads on the first article on your home page or at the end of every page and post. ' +

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -13,12 +13,11 @@ import { localize } from 'i18n-calypso';
  */
 import CompactCard from 'components/card/compact';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
-import ExternalLink from 'components/external-link';
 import FoldableCard from 'components/foldable-card';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import InfoPopover from 'components/info-popover';
+import SupportInfo from 'components/support-info';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import QuerySiteRoles from 'components/data/query-site-roles';
@@ -128,22 +127,13 @@ class JetpackSiteStats extends Component {
 					clickableHeader
 				>
 					<FormFieldset>
-						<div className="site-settings__info-link-container">
-							<InfoPopover position="left">
-								{ translate(
-									'Displays information on your site activity, ' +
-										'including visitors and popular posts or pages.'
-								) }{' '}
-								<ExternalLink
-									href="https://jetpack.com/support/wordpress-com-stats/"
-									icon={ false }
-									target="_blank"
-								>
-									{ translate( 'Learn more' ) }
-								</ExternalLink>
-							</InfoPopover>
-						</div>
-
+						<SupportInfo
+							text={ translate(
+								'Displays information on your site activity, ' +
+									'including visitors and popular posts or pages.'
+							) }
+							link="https://jetpack.com/support/wordpress-com-stats/"
+						/>
 						{ this.renderToggle(
 							'admin_bar',
 							translate( 'Put a chart showing 48 hours of views in the admin bar' )

--- a/client/my-sites/site-settings/masterbar.jsx
+++ b/client/my-sites/site-settings/masterbar.jsx
@@ -18,8 +18,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 
 const Masterbar = ( {
@@ -35,22 +34,13 @@ const Masterbar = ( {
 
 			<Card className="masterbar__card site-settings__security-settings">
 				<FormFieldset>
-					<div className="masterbar__info-link-container site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate(
-								'Adds a toolbar with links to all your sites, notifications, ' +
-									'your WordPress.com profile, and the Reader.'
-							) }{' '}
-							<ExternalLink
-								href="https://jetpack.com/support/masterbar/"
-								icon={ false }
-								target="_blank"
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
-
+					<SupportInfo
+						text={ translate(
+							'Adds a toolbar with links to all your sites, notifications, ' +
+								'your WordPress.com profile, and the Reader.'
+						) }
+						link="https://jetpack.com/support/masterbar/"
+					/>
 					<JetpackModuleToggle
 						siteId={ selectedSiteId }
 						moduleSlug="masterbar"

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -20,8 +20,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormSelect from 'components/forms/form-select';
 import FormLabel from 'components/forms/form-label';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import {
 	PLAN_JETPACK_PREMIUM,
 	FEATURE_VIDEO_CDN_LIMITED,
@@ -78,18 +77,10 @@ class MediaSettings extends Component {
 		return (
 			isVideoPressAvailable && (
 				<FormFieldset className="site-settings__formfieldset has-divider is-top-only">
-					<div className="site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate( 'Hosts your video files on the global WordPress.com servers.' ) }{' '}
-							<ExternalLink
-								target="_blank"
-								icon={ false }
-								href="https://jetpack.com/support/videopress/"
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+					<SupportInfo
+						text={ translate( 'Hosts your video files on the global WordPress.com servers.' ) }
+						link="https://jetpack.com/support/videopress/"
+					/>
 					<JetpackModuleToggle
 						siteId={ siteId }
 						moduleSlug="videopress"
@@ -198,18 +189,10 @@ class MediaSettings extends Component {
 					 */ }
 					{ ! jetpackVersionSupportsLazyImages && (
 						<FormFieldset>
-							<div className="site-settings__info-link-container">
-								<InfoPopover position="left">
-									{ translate( 'Hosts your image files on the global WordPress.com servers.' ) }{' '}
-									<ExternalLink
-										target="_blank"
-										icon={ false }
-										href="https://jetpack.com/support/photon"
-									>
-										{ translate( 'Learn more' ) }
-									</ExternalLink>
-								</InfoPopover>
-							</div>
+							<SupportInfo
+								text={ translate( 'Hosts your image files on the global WordPress.com servers.' ) }
+								link="https://jetpack.com/support/photon/"
+							/>
 							<JetpackModuleToggle
 								siteId={ siteId }
 								moduleSlug="photon"
@@ -220,21 +203,10 @@ class MediaSettings extends Component {
 						</FormFieldset>
 					) }
 					<FormFieldset className={ carouselFieldsetClasses }>
-						<div className="site-settings__info-link-container">
-							<InfoPopover position="left">
-								{ translate(
-									'Replaces the standard WordPress galleries with a ' +
-										'full-screen photo browsing experience, including comments and EXIF metadata.'
-								) }{' '}
-								<ExternalLink
-									target="_blank"
-									icon={ false }
-									href="https://jetpack.com/support/carousel"
-								>
-									{ translate( 'Learn more' ) }
-								</ExternalLink>
-							</InfoPopover>
-						</div>
+						<SupportInfo
+							text={ translate( 'Gorgeous full-screen photo browsing experience.' ) }
+							link="https://jetpack.com/support/carousel/"
+						/>
 						<JetpackModuleToggle
 							siteId={ siteId }
 							moduleSlug="carousel"

--- a/client/my-sites/site-settings/protect.jsx
+++ b/client/my-sites/site-settings/protect.jsx
@@ -24,8 +24,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 
 class Protect extends Component {
@@ -121,21 +120,12 @@ class Protect extends Component {
 
 				<FormFieldset>
 					<div className="protect__module-settings site-settings__child-settings">
-						<div className="protect__info-link-container site-settings__info-link-container">
-							<InfoPopover position="left">
-								{ translate(
-									'Protects your site from traditional and distributed brute force login attacks.'
-								) }{' '}
-								<ExternalLink
-									href="https://jetpack.com/support/protect"
-									icon={ false }
-									target="_blank"
-								>
-									{ translate( 'Learn more' ) }
-								</ExternalLink>
-							</InfoPopover>
-						</div>
-
+						<SupportInfo
+							text={ translate(
+								'Protects your site from traditional and distributed brute force login attacks.'
+							) }
+							link="https://jetpack.com/support/protect/"
+						/>
 						<p>
 							{ translate( 'Your current IP address: {{strong}}%(IP)s{{/strong}}{{br/}}', {
 								args: {

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -26,8 +26,7 @@ import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
 import isRegeneratingJetpackPostByEmail from 'state/selectors/is-regenerating-jetpack-post-by-email';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import ClipboardButtonInput from 'components/clipboard-button-input';
 import PressThis from '../press-this';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
@@ -116,21 +115,12 @@ class PublishingTools extends Component {
 
 		return (
 			<FormFieldset>
-				<div className="publishing-tools__info-link-container site-settings__info-link-container">
-					<InfoPopover position="left">
-						{ translate(
-							'Allows you to publish new posts by sending an email to a special address.'
-						) }{' '}
-						<ExternalLink
-							href="https://jetpack.com/support/post-by-email/"
-							icon={ false }
-							target="_blank"
-						>
-							{ translate( 'Learn more' ) }
-						</ExternalLink>
-					</InfoPopover>
-				</div>
-
+				<SupportInfo
+					text={ translate(
+						'Allows you to publish new posts by sending an email to a special address.'
+					) }
+					link="https://jetpack.com/support/post-by-email/"
+				/>
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }
 					moduleSlug="post-by-email"

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -15,8 +15,7 @@ import Card from 'components/card';
 import FormFieldset from 'components/forms/form-fieldset';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import SectionHeader from 'components/section-header';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import RelatedContentPreview from './related-content-preview';
 
 const RelatedPosts = ( {
@@ -32,18 +31,12 @@ const RelatedPosts = ( {
 
 			<Card className="related-posts__card site-settings__traffic-settings">
 				<FormFieldset>
-					<div className="related-posts__info site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate( 'Automatically displays similar content at the end of each post.' ) }{' '}
-							<ExternalLink
-								href="https://jetpack.com/support/related-posts/"
-								icon={ false }
-								target="_blank"
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+					<SupportInfo
+						text={ translate(
+							'Automatically displays similar content (related posts) at the end of each post.'
+						) }
+						link="https://jetpack.com/support/related-posts/"
+					/>
 
 					<CompactFormToggle
 						checked={ !! fields.jetpack_relatedposts_enabled }

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -18,8 +18,7 @@ import SectionHeader from 'components/section-header';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import untrailingslashit from 'lib/route/untrailingslashit';
@@ -44,20 +43,17 @@ class Search extends Component {
 		fields: PropTypes.object,
 	};
 
-	renderInfoLink( url ) {
+	renderInfoLink( link, privacyLink ) {
 		const { translate } = this.props;
 
 		return (
-			<div className="search__info-link-container site-settings__info-link-container">
-				<InfoPopover position="left">
-					{ translate(
-						'Replaces the default WordPress search with a faster, filterable search experience.'
-					) }{' '}
-					<ExternalLink href={ url } icon={ false } target="_blank">
-						{ translate( 'Learn more' ) }
-					</ExternalLink>
-				</InfoPopover>
-			</div>
+			<SupportInfo
+				text={ translate(
+					'Replaces the default WordPress search with a faster, filterable search experience.'
+				) }
+				link={ link }
+				privacyLink={ privacyLink }
+			/>
 		);
 	}
 
@@ -92,7 +88,7 @@ class Search extends Component {
 
 		return (
 			<FormFieldset>
-				{ this.renderInfoLink( 'https://jetpack.com/support/search' ) }
+				{ this.renderInfoLink( 'https://jetpack.com/support/search/' ) }
 
 				<JetpackModuleToggle
 					siteId={ siteId }

--- a/client/my-sites/site-settings/seo-settings/help.jsx
+++ b/client/my-sites/site-settings/seo-settings/help.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import SectionHeader from 'components/section-header';
+import SupportInfo from 'components/support-info';
 import { hasFeature } from 'state/sites/plans/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -50,6 +51,16 @@ const SeoSettingsHelpCard = ( {
 						) }
 					</p>
 
+					{ siteIsJetpack && (
+						<SupportInfo
+							text={ translate(
+								'To help improve your search page ranking, you can customize how the content titles' +
+									' appear for your site. You can reorder items such as ‘Site Name’ and ‘Tagline’,' +
+									' and also add custom separators between the items.'
+							) }
+							link="https://jetpack.com/support/seo-tools/"
+						/>
+					) }
 					{ siteIsJetpack && (
 						<JetpackModuleToggle
 							siteId={ siteId }


### PR DESCRIPTION
~~This PR depends on https://github.com/Automattic/wp-calypso/pull/24985.~~ (merged).

The original full PR was broken apart by request: https://github.com/Automattic/wp-calypso/pull/23949#issuecomment-382109504.

---

This is batch two of the new Privacy Information links, implemented using the new `SupportInfo` component in https://github.com/Automattic/wp-calypso/pull/24985

## Overview of Changes

- Removes `.site-settings__info-link-container` in favor of SupportInfo.

- Adds support info icons to `JetpackModuleToggle` instances, covering every Jetpack module/feature. In batch two I covered the following Jetpack features:

  - Ads
  - Site Stats
  - Masterbar
  - Media (VideoPress, Photon, Carousel)
  - Protect
  - Posts by Email
  - Related Posts
  - Search
  - SEO Tools