### PR TITLE
GDPR Privacy Information links (batch 3/3)

### DIFF
--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -15,7 +15,7 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Card from 'components/card';
-import InfoPopover from 'components/info-popover';
+import SupportInfo from 'components/support-info';
 import ExternalLink from 'components/external-link';
 import FormInput from 'components/forms/form-text-input-with-affixes';
 import FormInputValidation from 'components/forms/form-input-validation';
@@ -308,22 +308,13 @@ class SiteVerification extends Component {
 				<Card>
 					{ siteIsJetpack && (
 						<FormFieldset>
-							<div className="seo-settings__info site-settings__info-link-container">
-								<InfoPopover position="left">
-									{ translate(
-										'Provides the necessary hidden tags needed to ' +
-											'verify your WordPress site with various services.'
-									) }{' '}
-									<ExternalLink
-										href="https://jetpack.com/support/site-verification-tools"
-										icon={ false }
-										target="_blank"
-									>
-										{ translate( 'Learn more' ) }
-									</ExternalLink>
-								</InfoPopover>
-							</div>
-
+							<SupportInfo
+								text={ translate(
+									'Provides hidden tags needed to verify your' +
+										' WordPress site with various services.'
+								) }
+								link="https://jetpack.com/support/site-verification-tools/"
+							/>
 							<JetpackModuleToggle
 								siteId={ siteId }
 								moduleSlug="verification-tools"

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -310,8 +310,7 @@ class SiteVerification extends Component {
 						<FormFieldset>
 							<SupportInfo
 								text={ translate(
-									'Provides hidden tags needed to verify your' +
-										' WordPress site with various services.'
+									'Provides hidden tags needed to verify your WordPress site with various services.'
 								) }
 								link="https://jetpack.com/support/site-verification-tools/"
 							/>

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -310,7 +310,7 @@ class SiteVerification extends Component {
 						<FormFieldset>
 							<SupportInfo
 								text={ translate(
-									'Provides hidden tags needed to verify your WordPress site with various services.'
+									'Provides the necessary hidden tags needed to verify your WordPress site with various services.'
 								) }
 								link="https://jetpack.com/support/site-verification-tools/"
 							/>

--- a/client/my-sites/site-settings/sitemaps.jsx
+++ b/client/my-sites/site-settings/sitemaps.jsx
@@ -17,7 +17,7 @@ import SectionHeader from 'components/section-header';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import InfoPopover from 'components/info-popover';
+import SupportInfo from 'components/support-info';
 import ExternalLink from 'components/external-link';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -54,20 +54,17 @@ class Sitemaps extends Component {
 		);
 	}
 
-	renderInfoLink( url ) {
+	renderInfoLink( link, privacyLink ) {
 		const { translate } = this.props;
 
 		return (
-			<div className="sitemaps__info-link-container site-settings__info-link-container">
-				<InfoPopover position="left">
-					{ translate(
-						'Automatically generates the files required for search engines to index your site.'
-					) }{' '}
-					<ExternalLink href={ url } icon={ false } target="_blank">
-						{ translate( 'Learn more' ) }
-					</ExternalLink>
-				</InfoPopover>
-			</div>
+			<SupportInfo
+				text={ translate(
+					'Automatically generates the files required for search engines to index your site.'
+				) }
+				link={ link }
+				privacyLink={ privacyLink }
+			/>
 		);
 	}
 
@@ -107,7 +104,7 @@ class Sitemaps extends Component {
 
 		return (
 			<div>
-				{ this.renderInfoLink( 'https://support.wordpress.com/sitemaps/' ) }
+				{ this.renderInfoLink( 'https://support.wordpress.com/sitemaps/', false ) }
 
 				{ this.isSitePublic() ? (
 					<div>
@@ -173,7 +170,7 @@ class Sitemaps extends Component {
 
 		return (
 			<FormFieldset>
-				{ this.renderInfoLink( 'https://jetpack.com/support/sitemaps' ) }
+				{ this.renderInfoLink( 'https://jetpack.com/support/sitemaps/' ) }
 
 				<JetpackModuleToggle
 					siteId={ siteId }

--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -20,7 +20,7 @@ import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import FormInputValidation from 'components/forms/form-input-validation';
 import Gridicon from 'gridicons';
-import InfoPopover from 'components/info-popover';
+import SupportInfo from 'components/support-info';
 import ExternalLink from 'components/external-link';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import isJetpackSettingsSaveFailure from 'state/selectors/is-jetpack-settings-save-failure';
@@ -95,18 +95,10 @@ const SpamFilteringSettings = ( {
 		>
 			<FormFieldset>
 				<div className="spam-filtering__settings site-settings__child-settings">
-					<div className="spam-filtering__info-link-container site-settings__info-link-container">
-						<InfoPopover>
-							{ translate( 'Removes spam from comments and contact forms.' ) }{' '}
-							<ExternalLink
-								target="_blank"
-								icon={ false }
-								href={ 'https://jetpack.com/features/security/spam-filtering/' }
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+					<SupportInfo
+						text={ translate( 'Removes spam from comments and contact forms.' ) }
+						link="https://jetpack.com/features/security/spam-filtering/"
+					/>
 					<FormLabel htmlFor="wordpress_api_key">{ translate( 'Your API Key' ) }</FormLabel>
 					<FormTextInput
 						name="wordpress_api_key"

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -14,12 +14,11 @@ import { connect } from 'react-redux';
 import Card from 'components/card';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
-import ExternalLink from 'components/external-link';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
-import InfoPopover from 'components/info-popover';
+import SupportInfo from 'components/support-info';
 
 class SpeedUpSiteSettings extends Component {
 	static propTypes = {
@@ -49,18 +48,10 @@ class SpeedUpSiteSettings extends Component {
 			<div className="site-settings__module-settings site-settings__speed-up-site-settings">
 				<Card>
 					<FormFieldset className="site-settings__formfieldset">
-						<div className="site-settings__info-link-container">
-							<InfoPopover position="left">
-								{ translate( 'Hosts your image files on the global WordPress.com servers.' ) }{' '}
-								<ExternalLink
-									target="_blank"
-									icon={ false }
-									href="https://jetpack.com/support/photon"
-								>
-									{ translate( 'Learn more' ) }
-								</ExternalLink>
-							</InfoPopover>
-						</div>
+						<SupportInfo
+							text={ translate( 'Hosts your image files on the global WordPress.com servers.' ) }
+							link="https://jetpack.com/support/photon/"
+						/>
 						<JetpackModuleToggle
 							siteId={ selectedSiteId }
 							moduleSlug="photon"
@@ -76,20 +67,12 @@ class SpeedUpSiteSettings extends Component {
 
 					{ jetpackVersionSupportsLazyImages && (
 						<FormFieldset className="site-settings__formfieldset has-divider is-top-only">
-							<div className="site-settings__info-link-container">
-								<InfoPopover position="left">
-									{ translate(
-										"Delays the loading of images until they are visible in the visitor's browser."
-									) }{' '}
-									<ExternalLink
-										target="_blank"
-										icon={ false }
-										href="https://jetpack.com/support/lazy-images"
-									>
-										{ translate( 'Learn more' ) }
-									</ExternalLink>
-								</InfoPopover>
-							</div>
+							<SupportInfo
+								text={ translate(
+									"Delays the loading of images until they are visible in the visitor's browser."
+								) }
+								link="https://jetpack.com/support/lazy-images/"
+							/>
 							<JetpackModuleToggle
 								siteId={ selectedSiteId }
 								moduleSlug="lazy-images"

--- a/client/my-sites/site-settings/sso.jsx
+++ b/client/my-sites/site-settings/sso.jsx
@@ -20,8 +20,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 
 const Sso = ( {
@@ -40,16 +39,12 @@ const Sso = ( {
 
 			<Card className="sso__card site-settings__security-settings">
 				<FormFieldset>
-					<div className="sso__info-link-container site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate(
-								'Allows registered users to log in to your site with their WordPress.com accounts.'
-							) }
-							<ExternalLink href="https://jetpack.com/support/sso" icon={ false } target="_blank">
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+					<SupportInfo
+						text={ translate(
+							'Allows registered users to log in to your site with their WordPress.com accounts.'
+						) }
+						link="https://jetpack.com/support/sso/"
+					/>
 
 					<JetpackModuleToggle
 						siteId={ selectedSiteId }

--- a/client/my-sites/site-settings/subscriptions.jsx
+++ b/client/my-sites/site-settings/subscriptions.jsx
@@ -21,8 +21,7 @@ import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 
 const Subscriptions = ( {
 	fields,
@@ -41,21 +40,13 @@ const Subscriptions = ( {
 
 			<CompactCard className="subscriptions__card site-settings__discussion-settings">
 				<FormFieldset>
-					<div className="subscriptions__info-link-container site-settings__info-link-container">
-						<InfoPopover position="left">
-							{ translate(
-								'Allows readers to subscribe to your posts or comments, ' +
-									'and receive notifications of new content by email.'
-							) }{' '}
-							<ExternalLink
-								href="https://jetpack.com/support/subscriptions"
-								icon={ false }
-								target="_blank"
-							>
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+					<SupportInfo
+						text={ translate(
+							'Allows readers to subscribe to your posts or comments, ' +
+								'and receive notifications of new content by email.'
+						) }
+						link="https://jetpack.com/support/subscriptions/"
+					/>
 
 					<JetpackModuleToggle
 						siteId={ selectedSiteId }

--- a/client/my-sites/site-settings/test/form-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-analytics.jsx
@@ -1,4 +1,7 @@
-/** @format */
+/**
+ * @format
+ * @jest-environment jsdom
+ */
 
 jest.mock( 'lib/abtest', () => ( {
 	abtest: () => '',

--- a/client/my-sites/site-settings/test/form-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-analytics.jsx
@@ -1,7 +1,4 @@
-/**
- * @format
- * @jest-environment jsdom
- */
+/** @format */
 
 jest.mock( 'lib/abtest', () => ( {
 	abtest: () => '',

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -25,8 +25,7 @@ import CompactFormToggle from 'components/forms/form-toggle/compact';
 import { getCustomizerUrl } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import SupportInfo from 'components/support-info';
 
 class ThemeEnhancements extends Component {
 	static defaultProps = {
@@ -87,21 +86,11 @@ class ThemeEnhancements extends Component {
 		return (
 			<FormFieldset>
 				<FormLegend>{ translate( 'Infinite Scroll' ) }</FormLegend>
-
-				<div className="theme-enhancements__info-link-container site-settings__info-link-container">
-					<InfoPopover position="left">
-						{ translate( 'Control how additional posts are loaded.' ) }
-						<br />
-						<ExternalLink
-							href="https://support.wordpress.com/infinite-scroll/"
-							icon
-							target="_blank"
-						>
-							{ translate( 'Learn more' ) }
-						</ExternalLink>
-					</InfoPopover>
-				</div>
-
+				<SupportInfo
+					text={ translate( 'Control how additional posts are loaded.' ) }
+					link="https://support.wordpress.com/infinite-scroll/"
+					privacyLink={ false }
+				/>
 				{ this.renderToggle(
 					'infinite_scroll',
 					blockedByFooter,
@@ -129,22 +118,12 @@ class ThemeEnhancements extends Component {
 		return (
 			<FormFieldset>
 				<FormLegend>{ translate( 'Infinite Scroll' ) }</FormLegend>
-
-				<div className="theme-enhancements__info-link-container site-settings__info-link-container">
-					<InfoPopover position="left">
-						{ translate(
-							'Loads the next posts automatically when the reader approaches the bottom of the page.'
-						) }{' '}
-						<ExternalLink
-							href="https://jetpack.com/support/infinite-scroll"
-							icon={ false }
-							target="_blank"
-						>
-							{ translate( 'Learn more' ) }
-						</ExternalLink>
-					</InfoPopover>
-				</div>
-
+				<SupportInfo
+					text={ translate(
+						'Loads the next posts automatically when the reader approaches the bottom of the page.'
+					) }
+					link="https://jetpack.com/support/infinite-scroll/"
+				/>
 				{ this.renderRadio(
 					'infinite_scroll',
 					'default',
@@ -170,21 +149,13 @@ class ThemeEnhancements extends Component {
 
 		return (
 			<FormFieldset>
-				<div className="theme-enhancements__info-link-container site-settings__info-link-container">
-					<InfoPopover position="left">
-						{ translate(
-							'Enables a lightweight, mobile-friendly theme ' +
-								'that will be displayed to visitors on mobile devices.'
-						) }{' '}
-						<ExternalLink
-							href="https://jetpack.com/support/mobile-theme"
-							icon={ false }
-							target="_blank"
-						>
-							{ translate( 'Learn more' ) }
-						</ExternalLink>
-					</InfoPopover>
-				</div>
+				<SupportInfo
+					text={ translate(
+						'Enables a lightweight, mobile-friendly theme ' +
+							'that will be displayed to visitors on mobile devices.'
+					) }
+					link="https://jetpack.com/support/mobile-theme/"
+				/>
 
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }


### PR DESCRIPTION
~~This PR depends on https://github.com/Automattic/wp-calypso/pull/24985.~~ (merged).

The original full PR was broken apart by request: https://github.com/Automattic/wp-calypso/pull/23949#issuecomment-382109504.

---

This is batch three of the new Privacy Information links, implemented using the new `SupportInfo` component in https://github.com/Automattic/wp-calypso/pull/24985

## Overview of Changes

- Removes `.site-settings__info-link-container` in favor of SupportInfo.

- Adds support info icons to `JetpackModuleToggle` instances, covering every Jetpack module/feature. In batch three I covered the following Jetpack features:

  - Site Verification
  - Sitemaps
  - Spam Filtering
  - Lazy Images / Photon
  - SSO
  - Subscriptions
  - Infinite Scroll
  - Mobile Theme