### PR TITLE
Add GDPR consent management for domains

### DIFF
--- a/client/lib/domains/assembler.js
+++ b/client/lib/domains/assembler.js
@@ -10,7 +10,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { getDomainType, getTransferStatus } from './utils';
+import { getDomainType, getTransferStatus, getGdprConsentStatus } from './utils';
 
 export function createDomainObjects( dataTransferObject ) {
 	let domains = [];
@@ -29,6 +29,7 @@ export function createDomainObjects( dataTransferObject ) {
 			expirationMoment: domain.expiry && i18n.moment( domain.expiry ),
 			expired: domain.expired,
 			expirySoon: domain.expiry_soon,
+			gdprConsentStatus: getGdprConsentStatus( domain ),
 			googleAppsSubscription: assembleGoogleAppsSubscription( domain.google_apps_subscription ),
 			hasPrivacyProtection: domain.has_private_registration,
 			hasWpcomNameservers: domain.has_wpcom_nameservers,

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -75,3 +75,13 @@ export const domainProductSlugs = {
 	TRANSFER_IN: 'domain_transfer',
 	TRANSFER_IN_PRIVACY: 'domain_transfer_privacy',
 };
+
+export const gdprConsentStatus = {
+	NONE: 'NONE',
+	PENDING: 'PENDING',
+	PENDING_ASYNC: 'PENDING_ASYNC',
+	ACCEPTED_CONTRACTUAL_MINIMUM: 'ACCEPTED_CONTRACTUAL_MINIMUM',
+	ACCEPTED_FULL: 'ACCEPTED_FULL',
+	DENIED: 'DENIED',
+	FORCED_ALL_CONTRACTUAL: 'FORCED_ALL_CONTRACTUAL',
+};

--- a/client/lib/domains/test/assembler.js
+++ b/client/lib/domains/test/assembler.js
@@ -41,6 +41,7 @@ describe( 'assembler', () => {
 			expirationMoment: undefined,
 			expired: undefined,
 			expirySoon: undefined,
+			gdprConsentStatus: null,
 			googleAppsSubscription: undefined,
 			hasPrivacyProtection: undefined,
 			isAutoRenewing: undefined,

--- a/client/lib/domains/utils.js
+++ b/client/lib/domains/utils.js
@@ -8,7 +8,7 @@ import { drop, isEmpty, join, find, split, values } from 'lodash';
 /**
  * Internal dependencies
  */
-import { type as domainTypes, transferStatus } from './constants';
+import { type as domainTypes, transferStatus, gdprConsentStatus } from './constants';
 import { cartItems } from 'lib/cart-values';
 import { isDomainRegistration } from 'lib/products-values';
 
@@ -56,6 +56,27 @@ function getTransferStatus( domainFromApi ) {
 	return null;
 }
 
+function getGdprConsentStatus( domainFromApi ) {
+	switch ( domainFromApi.gdpr_consent_status ) {
+		case 'NONE':
+			return gdprConsentStatus.NONE;
+		case 'PENDING':
+			return gdprConsentStatus.PENDING;
+		case 'PENDING_ASYNC':
+			return gdprConsentStatus.PENDING_ASYNC;
+		case 'ACCEPTED_CONTRACTUAL_MINIMUM':
+			return gdprConsentStatus.ACCEPTED_CONTRACTUAL_MINIMUM;
+		case 'ACCEPTED_FULL':
+			return gdprConsentStatus.ACCEPTED_FULL;
+		case 'DENIED':
+			return gdprConsentStatus.DENIED;
+		case 'FORCED_ALL_CONTRACTUAL':
+			return gdprConsentStatus.FORCED_ALL_CONTRACTUAL;
+		default:
+			return null;
+	}
+}
+
 /**
  * Depending on the current step in checkout, the user's domain can be found in
  * either the cart or the receipt.
@@ -101,6 +122,7 @@ function parseDomainAgainstTldList( domainFragment, tldList ) {
 export {
 	getDomainNameFromReceiptOrCart,
 	getDomainType,
+	getGdprConsentStatus,
 	getTransferStatus,
 	parseDomainAgainstTldList,
 };

--- a/client/lib/upgrades/actions/domain-management.js
+++ b/client/lib/upgrades/actions/domain-management.js
@@ -581,6 +581,6 @@ export function declineTransfer( domainName, onComplete ) {
 	} );
 }
 
-export function requestGdprConsentManagement( domainName, onComplete ) {
-	wpcom.gdprConsentManagement( domainName, onComplete );
+export function requestGdprConsentManagementLink( domainName, onComplete ) {
+	wpcom.requestGdprConsentManagementLink( domainName, onComplete );
 }

--- a/client/lib/upgrades/actions/domain-management.js
+++ b/client/lib/upgrades/actions/domain-management.js
@@ -580,3 +580,7 @@ export function declineTransfer( domainName, onComplete ) {
 		onComplete( null );
 	} );
 }
+
+export function requestGdprConsentManagement( domainName, onComplete ) {
+	wpcom.gdprConsentManagement( domainName, onComplete );
+}

--- a/client/lib/upgrades/actions/index.js
+++ b/client/lib/upgrades/actions/index.js
@@ -56,7 +56,7 @@ export {
 	updateNameservers,
 	updateSiteRedirect,
 	updateWhois,
-	requestGdprConsentManagement,
+	requestGdprConsentManagementLink,
 } from './domain-management';
 
 export { goToDomainCheckout } from './domain-search';

--- a/client/lib/upgrades/actions/index.js
+++ b/client/lib/upgrades/actions/index.js
@@ -56,6 +56,7 @@ export {
 	updateNameservers,
 	updateSiteRedirect,
 	updateWhois,
+	requestGdprConsentManagement,
 } from './domain-management';
 
 export { goToDomainCheckout } from './domain-search';

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2495,4 +2495,18 @@ Undocumented.prototype.updateSiteAddress = function( siteId, blogname, discard, 
 	);
 };
 
+Undocumented.prototype.gdprConsentManagement = function( domain, callback ) {
+	return this.wpcom.req.get( `/domains/${ domain }/gdpr-consent-management`, function(
+		error,
+		response
+	) {
+		if ( error ) {
+			callback( error );
+			return;
+		}
+
+		callback( null, response );
+	} );
+};
+
 export default Undocumented;

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2495,8 +2495,8 @@ Undocumented.prototype.updateSiteAddress = function( siteId, blogname, discard, 
 	);
 };
 
-Undocumented.prototype.gdprConsentManagement = function( domain, callback ) {
-	return this.wpcom.req.get( `/domains/${ domain }/gdpr-consent-management`, function(
+Undocumented.prototype.requestGdprConsentManagementLink = function( domain, callback ) {
+	return this.wpcom.req.get( `/domains/${ domain }/request-gdpr-consent-management-link`, function(
 		error,
 		response
 	) {

--- a/client/my-sites/current-site/domain-warnings.jsx
+++ b/client/my-sites/current-site/domain-warnings.jsx
@@ -29,6 +29,7 @@ const ruleWhiteList = [
 	'pendingGappsTosAcceptanceDomains',
 	'transferStatus',
 	'newTransfersWrongNS',
+	'pendingConsent',
 ];
 
 const CurrentSiteDomainWarnings = ( { domains, isAtomic, isJetpack, selectedSite } ) => {

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -18,7 +18,7 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import PendingGappsTosNotice from './pending-gapps-tos-notice';
 import { purchasesRoot } from 'me/purchases/paths';
-import { type as domainTypes, transferStatus } from 'lib/domains/constants';
+import { type as domainTypes, transferStatus, gdprConsentStatus } from 'lib/domains/constants';
 import { isSubdomain, hasPendingGoogleAppsUsers } from 'lib/domains';
 import {
 	ALL_ABOUT_DOMAINS,
@@ -34,6 +34,7 @@ import {
 	domainManagementList,
 	domainManagementNameServers,
 	domainManagementTransferIn,
+	domainManagementManageConsent,
 } from 'my-sites/domains/paths';
 import TrackComponentView from 'lib/analytics/track-component-view';
 
@@ -74,6 +75,7 @@ export class DomainWarnings extends React.PureComponent {
 			'newDomains',
 			'transferStatus',
 			'newTransfersWrongNS',
+			'pendingConsent',
 		],
 	};
 
@@ -115,6 +117,7 @@ export class DomainWarnings extends React.PureComponent {
 			this.pendingTransfer,
 			this.transferStatus,
 			this.newTransfersWrongNS,
+			this.pendingConsent,
 		];
 		const validRules = this.props.ruleWhiteList.map( ruleName => this[ ruleName ] );
 
@@ -983,6 +986,58 @@ export class DomainWarnings extends React.PureComponent {
 				text={ isCompact && compactMessage }
 			>
 				{ isCompact ? compactMessage && action : message }
+			</Notice>
+		);
+	};
+
+	pendingConsent = () => {
+		const pendingConsentDomains = this.getDomains().filter(
+			domain =>
+				domain.type === domainTypes.REGISTERED &&
+				gdprConsentStatus.PENDING_ASYNC === domain.gdprConsentStatus
+		);
+
+		if ( 0 === pendingConsentDomains.length ) {
+			return null;
+		}
+
+		const { isCompact, translate, selectedSite } = this.props;
+		let noticeText;
+
+		if ( pendingConsentDomains.length === 1 ) {
+			const currentDomain = pendingConsentDomains[ 0 ].name;
+
+			noticeText = translate(
+				'The domain {{strong}}%(domain)s{{/strong}} is still pending registration. Please check the domain owner email since explicit consent is required for the registration to complete. {{a}}More info{{/a}}',
+				{
+					components: {
+						strong: <strong />,
+						a: (
+							<a
+								href={ domainManagementManageConsent( selectedSite.slug, currentDomain ) }
+								rel="noopener noreferrer"
+							/>
+						),
+					},
+					args: {
+						domain: currentDomain,
+					},
+				}
+			);
+		} else {
+			noticeText = translate(
+				'Some domains are still pending registration. User consent is required before the registration can be completed.'
+			);
+		}
+		return (
+			<Notice
+				isCompact={ isCompact }
+				status="is-error"
+				showDismiss={ false }
+				className="domain-warnings__notice"
+				key="pending-consent"
+			>
+				{ noticeText }
 			</Notice>
 		);
 	};

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -1023,22 +1023,22 @@ export class DomainWarnings extends React.PureComponent {
 
 			if ( isCompact ) {
 				noticeText = translate(
-					'The domain {{strong}}%(domain)s{{/strong}} requires user consent confirmation to complete the registration.',
+					'The domain {{strong}}%(domain)s{{/strong}} requires explicit user consent to complete the registration.',
 					translateOptions
 				);
 			} else {
 				noticeText = translate(
-					'The domain {{strong}}%(domain)s{{/strong}} is still pending registration. Please check the domain owner email since explicit consent is required for the registration to complete. {{a}}More info{{/a}}',
+					'The domain {{strong}}%(domain)s{{/strong}} is still pending registration. Please check the domain owner email since explicit consent is required for the registration to complete or go to the {{a}}Consent Management{{/a}} page for more details.',
 					translateOptions
 				);
 			}
 		} else if ( isCompact ) {
 			noticeText = translate(
-				'Some domains require user consent confirmation to complete the registration.'
+				'Some domains require explicit user consent to complete the registration.'
 			);
 		} else {
 			noticeText = translate(
-				'Some domains are still pending registration. User consent is required before the registration can be completed.'
+				'Some domains are still pending registration. Please check the domain owner email to give explicit consent before the registration can be completed.'
 			);
 		}
 

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -1006,29 +1006,42 @@ export class DomainWarnings extends React.PureComponent {
 
 		if ( pendingConsentDomains.length === 1 ) {
 			const currentDomain = pendingConsentDomains[ 0 ].name;
+			const translateOptions = {
+				components: {
+					strong: <strong />,
+					a: (
+						<a
+							href={ domainManagementManageConsent( selectedSite.slug, currentDomain ) }
+							rel="noopener noreferrer"
+						/>
+					),
+				},
+				args: {
+					domain: currentDomain,
+				},
+			};
 
+			if ( isCompact ) {
+				noticeText = translate(
+					'The domain {{strong}}%(domain)s{{/strong}} requires user consent confirmation to complete the registration.',
+					translateOptions
+				);
+			} else {
+				noticeText = translate(
+					'The domain {{strong}}%(domain)s{{/strong}} is still pending registration. Please check the domain owner email since explicit consent is required for the registration to complete. {{a}}More info{{/a}}',
+					translateOptions
+				);
+			}
+		} else if ( isCompact ) {
 			noticeText = translate(
-				'The domain {{strong}}%(domain)s{{/strong}} is still pending registration. Please check the domain owner email since explicit consent is required for the registration to complete. {{a}}More info{{/a}}',
-				{
-					components: {
-						strong: <strong />,
-						a: (
-							<a
-								href={ domainManagementManageConsent( selectedSite.slug, currentDomain ) }
-								rel="noopener noreferrer"
-							/>
-						),
-					},
-					args: {
-						domain: currentDomain,
-					},
-				}
+				'Some domains require user consent confirmation to complete the registration.'
 			);
 		} else {
 			noticeText = translate(
 				'Some domains are still pending registration. User consent is required before the registration can be completed.'
 			);
 		}
+
 		return (
 			<Notice
 				isCompact={ isCompact }

--- a/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import ContactsPrivacyCard from './card';
 import DomainMainPlaceholder from 'my-sites/domains/domain-management/components/domain/main-placeholder';
 import Header from 'my-sites/domains/domain-management/components/header';
@@ -42,7 +43,8 @@ class ContactsPrivacy extends React.PureComponent {
 		const { translate, whois } = this.props;
 		const domain = getSelectedDomain( this.props );
 		const { hasPrivacyProtection, privateDomain, privacyAvailable, currentUserCanManage } = domain;
-		const canManageConsent = domain.registrar !== registrarNames.WWD;
+		const canManageConsent =
+			config.isEnabled( 'domains/gdpr-consent-page' ) && domain.registrar !== registrarNames.WWD;
 		const contactInformation = privateDomain
 			? findPrivacyServiceWhois( whois.data )
 			: findRegistrantWhois( whois.data );

--- a/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
@@ -82,7 +82,7 @@ class ContactsPrivacy extends React.PureComponent {
 								this.props.selectedDomainName
 							) }
 						>
-							{ translate( 'Manage Personal Data Consent' ) }
+							{ translate( 'Manage Consent for Personal Data Use' ) }
 						</VerticalNavItem>
 					) }
 

--- a/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
@@ -20,7 +20,9 @@ import {
 	domainManagementEdit,
 	domainManagementEditContactInfo,
 	domainManagementPrivacyProtection,
+	domainManagementManageConsent,
 } from 'my-sites/domains/paths';
+import { registrar as registrarNames } from 'lib/domains/constants';
 import { getSelectedDomain } from 'lib/domains';
 import { findRegistrantWhois, findPrivacyServiceWhois } from 'lib/domains/whois/utils';
 
@@ -40,6 +42,7 @@ class ContactsPrivacy extends React.PureComponent {
 		const { translate, whois } = this.props;
 		const domain = getSelectedDomain( this.props );
 		const { hasPrivacyProtection, privateDomain, privacyAvailable, currentUserCanManage } = domain;
+		const canManageConsent = domain.registrar !== registrarNames.WWD;
 		const contactInformation = privateDomain
 			? findPrivacyServiceWhois( whois.data )
 			: findRegistrantWhois( whois.data );
@@ -69,6 +72,17 @@ class ContactsPrivacy extends React.PureComponent {
 					>
 						{ translate( 'Edit Contact Info' ) }
 					</VerticalNavItem>
+
+					{ canManageConsent && (
+						<VerticalNavItem
+							path={ domainManagementManageConsent(
+								this.props.selectedSite.slug,
+								this.props.selectedDomainName
+							) }
+						>
+							{ translate( 'Manage Personal Data Use' ) }
+						</VerticalNavItem>
+					) }
 
 					{ ! hasPrivacyProtection &&
 						privacyAvailable && (

--- a/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
@@ -80,7 +80,7 @@ class ContactsPrivacy extends React.PureComponent {
 								this.props.selectedDomainName
 							) }
 						>
-							{ translate( 'Manage Personal Data Use' ) }
+							{ translate( 'Manage Personal Data Consent' ) }
 						</VerticalNavItem>
 					) }
 

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -32,6 +32,7 @@ import {
 	domainManagementTransferOut,
 	domainManagementTransferToAnotherUser,
 	domainManagementTransferToOtherSite,
+	domainManagementManageConsent,
 } from 'my-sites/domains/paths';
 import ProductsList from 'lib/products-list';
 import SiteRedirectData from 'components/data/domain-management/site-redirect';
@@ -93,6 +94,20 @@ export default {
 				component={ DomainManagement.ContactsPrivacy }
 				context={ pageContext }
 				selectedDomainName={ pageContext.params.domain }
+			/>
+		);
+		next();
+	},
+
+	domainManagementManageConsent( pageContext, next ) {
+		pageContext.primary = (
+			<DomainManagementData
+				analyticsPath={ domainManagementManageConsent( ':site', ':domain' ) }
+				analyticsTitle="Domain Management > Contacts and Privacy > Manage Personal Data Use"
+				component={ DomainManagement.ManageConsent }
+				context={ pageContext }
+				productsList={ productsList }
+				selectedDomainName={ decodeURIComponentIfValid( pageContext.params.domain ) }
 			/>
 		);
 		next();

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -103,7 +103,7 @@ export default {
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementManageConsent( ':site', ':domain' ) }
-				analyticsTitle="Domain Management > Contacts and Privacy > Manage Personal Data Use"
+				analyticsTitle="Domain Management > Contacts and Privacy > Manage Personal Data Consent"
 				component={ DomainManagement.ManageConsent }
 				context={ pageContext }
 				productsList={ productsList }

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -103,7 +103,7 @@ export default {
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementManageConsent( ':site', ':domain' ) }
-				analyticsTitle="Domain Management > Contacts and Privacy > Manage Personal Data Consent"
+				analyticsTitle="Domain Management > Contacts and Privacy > Manage Consent for Personal Data Use"
 				component={ DomainManagement.ManageConsent }
 				context={ pageContext }
 				productsList={ productsList }

--- a/client/my-sites/domains/domain-management/domain-management.jsx
+++ b/client/my-sites/domains/domain-management/domain-management.jsx
@@ -9,6 +9,7 @@ import Dns from './dns';
 import Edit from './edit';
 import TransferIn from './edit/transfer-in';
 import EditContactInfo from './edit-contact-info';
+import ManageConsent from './manage-consent';
 import Email from './email';
 import EmailForwarding from './email-forwarding';
 import List from './list';
@@ -27,6 +28,7 @@ export default {
 	Dns,
 	Edit,
 	EditContactInfo,
+	ManageConsent,
 	Email,
 	EmailForwarding,
 	List,

--- a/client/my-sites/domains/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/registered-domain.jsx
@@ -151,6 +151,7 @@ const RegisteredDomain = createReactClass( {
 					'expiringDomainsCannotManage',
 					'pendingTransfer',
 					'newTransfersWrongNS',
+					'pendingConsent',
 				] }
 			/>
 		);

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -78,6 +78,7 @@ export class List extends React.Component {
 						'wrongNSMappedDomains',
 						'transferStatus',
 						'newTransfersWrongNS',
+						'pendingConsent',
 					] }
 				/>
 			);

--- a/client/my-sites/domains/domain-management/list/item.jsx
+++ b/client/my-sites/domains/domain-management/list/item.jsx
@@ -159,7 +159,7 @@ class ListItem extends React.PureComponent {
 		) {
 			return (
 				<Notice isCompact status="is-error" icon="spam">
-					{ translate( 'Registration pending' ) }
+					{ translate( 'Action Required' ) }
 				</Notice>
 			);
 		}

--- a/client/my-sites/domains/domain-management/list/item.jsx
+++ b/client/my-sites/domains/domain-management/list/item.jsx
@@ -17,7 +17,7 @@ import CompactCard from 'components/card/compact';
 import DomainPrimaryFlag from 'my-sites/domains/domain-management/components/domain/primary-flag';
 import DomainTransferFlag from 'my-sites/domains/domain-management/components/domain/transfer-flag';
 import Notice from 'components/notice';
-import { type as domainTypes } from 'lib/domains/constants';
+import { type as domainTypes, gdprConsentStatus } from 'lib/domains/constants';
 import Spinner from 'components/spinner';
 
 class ListItem extends React.PureComponent {
@@ -57,6 +57,7 @@ class ListItem extends React.PureComponent {
 					<span className="domain-management-list-item__type">{ this.getDomainTypeText() }</span>
 					{ this.props.domain.type !== 'WPCOM' &&
 						this.showDomainExpirationWarning( this.props.domain ) }
+					{ this.showGdprConsentPending( this.props.domain ) }
 					<DomainPrimaryFlag domain={ this.props.domain } />
 					<DomainTransferFlag domain={ this.props.domain } />
 				</span>
@@ -145,6 +146,20 @@ class ListItem extends React.PureComponent {
 						context:
 							'timeUntilExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"',
 					} ) }
+				</Notice>
+			);
+		}
+	}
+
+	showGdprConsentPending( domain ) {
+		const { translate } = this.props;
+		if (
+			domain.gdprConsentStatus &&
+			gdprConsentStatus.PENDING_ASYNC === domain.gdprConsentStatus
+		) {
+			return (
+				<Notice isCompact status="is-error" icon="spam">
+					{ translate( 'Registration pending' ) }
 				</Notice>
 			);
 		}

--- a/client/my-sites/domains/domain-management/manage-consent/index.jsx
+++ b/client/my-sites/domains/domain-management/manage-consent/index.jsx
@@ -21,7 +21,7 @@ import Button from 'components/button';
 import { domainManagementContactsPrivacy } from 'my-sites/domains/paths';
 import { getSelectedDomain } from 'lib/domains';
 import SectionHeader from 'components/section-header';
-import { requestGdprConsentManagement } from 'lib/upgrades/actions';
+import { requestGdprConsentManagementLink } from 'lib/upgrades/actions';
 
 class ManageConsent extends React.Component {
 	static propTypes = {
@@ -104,7 +104,7 @@ class ManageConsent extends React.Component {
 
 	requestConsentManagementLink = () => {
 		this.setState( { submitting: true } );
-		requestGdprConsentManagement( this.props.selectedDomainName, error => {
+		requestGdprConsentManagementLink( this.props.selectedDomainName, error => {
 			if ( error ) {
 				this.setState( { error: error.message, success: false, submitting: false } );
 			} else {

--- a/client/my-sites/domains/domain-management/manage-consent/index.jsx
+++ b/client/my-sites/domains/domain-management/manage-consent/index.jsx
@@ -53,13 +53,16 @@ class ManageConsent extends React.Component {
 				</Header>
 				{ this.state.error && (
 					<Notice status="is-error" icon="notice" onDismissClick={ this.dismissError }>
-						{ this.state.error }
+						{ translate(
+							'An error occurred while trying to send you the consent management link. ' +
+								'If this is persistent please contact our support staff.'
+						) }
 					</Notice>
 				) }
 				{ this.state.success && (
 					<Notice status="is-success" icon="checkmark" showDismiss={ false }>
 						{ translate(
-							'Consent management link was successfully sent to the domain owners email'
+							'Consent management link was successfully sent to the domain owners email.'
 						) }
 					</Notice>
 				) }
@@ -74,9 +77,7 @@ class ManageConsent extends React.Component {
 								) }
 							</p>
 							<p>
-								{ translate(
-									'You can request the link again by clicking on ' + 'the button below.'
-								) }
+								{ translate( 'You can request the link again by clicking on the button below.' ) }
 							</p>
 							<Button
 								className="manage-consent__action-button"

--- a/client/my-sites/domains/domain-management/manage-consent/index.jsx
+++ b/client/my-sites/domains/domain-management/manage-consent/index.jsx
@@ -49,31 +49,31 @@ class ManageConsent extends React.Component {
 					onClick={ this.goToContactsPrivacy }
 					selectedDomainName={ this.props.selectedDomainName }
 				>
-					{ translate( 'Manage Personal Data Use' ) }
+					{ translate( 'Manage Personal Data Consent' ) }
 				</Header>
 				{ this.state.error && (
 					<Notice status="is-error" icon="notice" onDismissClick={ this.dismissError }>
 						{ translate(
-							'An error occurred while trying to send you the consent management link. ' +
-								'If this is persistent please contact our support staff.'
+							'An error occured while sending you the Personal Data Consent Link. ' +
+								'If the issue persists please contact our support staff.'
 						) }
 					</Notice>
 				) }
 				{ this.state.success && (
 					<Notice status="is-success" icon="checkmark" showDismiss={ false }>
 						{ translate(
-							'Consent management link was successfully sent to the domain owners email.'
+							'Personal Data Consent Link was successfully sent to the domain owner email.'
 						) }
 					</Notice>
 				) }
 				<div>
-					<SectionHeader label={ translate( 'Manage Personal Data Use' ) } />
+					<SectionHeader label={ translate( 'Manage Personal Data Consent' ) } />
 					<Card>
 						<div>
 							<p>
 								{ translate(
 									'You can manage how your personal data is used ' +
-										'using the consent management link you have received via email.'
+										'using the consent management link you have received via email during domain registration.'
 								) }
 							</p>
 							<p>
@@ -85,7 +85,7 @@ class ManageConsent extends React.Component {
 								primary
 								disabled={ this.state.submitting }
 							>
-								{ translate( 'Request Consent Management Link' ) }
+								{ translate( 'Re-send the Personal Data Consent Link' ) }
 							</Button>
 						</div>
 					</Card>

--- a/client/my-sites/domains/domain-management/manage-consent/index.jsx
+++ b/client/my-sites/domains/domain-management/manage-consent/index.jsx
@@ -1,0 +1,122 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import React from 'react';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Notice from 'components/notice';
+import DomainMainPlaceholder from 'my-sites/domains/domain-management/components/domain/main-placeholder';
+import Header from 'my-sites/domains/domain-management/components/header';
+import Main from 'components/main';
+import Button from 'components/button';
+import { domainManagementContactsPrivacy } from 'my-sites/domains/paths';
+import { getSelectedDomain } from 'lib/domains';
+import SectionHeader from 'components/section-header';
+import { requestGdprConsentManagement } from 'lib/upgrades/actions';
+
+class ManageConsent extends React.Component {
+	static propTypes = {
+		domains: PropTypes.object.isRequired,
+		selectedDomainName: PropTypes.string.isRequired,
+		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
+	};
+
+	state = {
+		submitting: false,
+		error: null,
+		success: false,
+	};
+
+	render() {
+		const { translate } = this.props;
+
+		if ( this.isDataLoading() ) {
+			return <DomainMainPlaceholder goBack={ this.goToContactsPrivacy } />;
+		}
+
+		return (
+			<Main className="manage-consent">
+				<Header
+					onClick={ this.goToContactsPrivacy }
+					selectedDomainName={ this.props.selectedDomainName }
+				>
+					{ translate( 'Manage Personal Data Use' ) }
+				</Header>
+				{ this.state.error && (
+					<Notice status="is-error" icon="notice" onDismissClick={ this.dismissError }>
+						{ this.state.error }
+					</Notice>
+				) }
+				{ this.state.success && (
+					<Notice status="is-success" icon="checkmark" showDismiss={ false }>
+						{ translate(
+							'Consent management link was successfully sent to the domain owners email'
+						) }
+					</Notice>
+				) }
+				<div>
+					<SectionHeader label={ translate( 'Manage Personal Data Use' ) } />
+					<Card>
+						<div>
+							<p>
+								{ translate(
+									'You can manage how your personal data is used ' +
+										'using the consent management link you have received via email.'
+								) }
+							</p>
+							<p>
+								{ translate(
+									'You can request the link again by clicking on ' + 'the button below.'
+								) }
+							</p>
+							<Button
+								className="manage-consent__action-button"
+								onClick={ this.requestConsentManagementLink }
+								primary
+								disabled={ this.state.submitting }
+							>
+								{ translate( 'Request Consent Management Link' ) }
+							</Button>
+						</div>
+					</Card>
+				</div>
+			</Main>
+		);
+	}
+
+	isDataLoading = () => {
+		return ! getSelectedDomain( this.props );
+	};
+
+	dismissError = () => {
+		this.setState( { error: null } );
+	};
+
+	requestConsentManagementLink = () => {
+		this.setState( { submitting: true } );
+		requestGdprConsentManagement( this.props.selectedDomainName, error => {
+			if ( error ) {
+				this.setState( { error: error.message, success: false, submitting: false } );
+			} else {
+				this.setState( { error: null, success: true, submitting: false } );
+			}
+		} );
+	};
+
+	goToContactsPrivacy = () => {
+		page(
+			domainManagementContactsPrivacy( this.props.selectedSite.slug, this.props.selectedDomainName )
+		);
+	};
+}
+
+export default localize( ManageConsent );

--- a/client/my-sites/domains/domain-management/manage-consent/index.jsx
+++ b/client/my-sites/domains/domain-management/manage-consent/index.jsx
@@ -49,7 +49,7 @@ class ManageConsent extends React.Component {
 					onClick={ this.goToContactsPrivacy }
 					selectedDomainName={ this.props.selectedDomainName }
 				>
-					{ translate( 'Manage Personal Data Consent' ) }
+					{ translate( 'Manage Consent for Personal Data Use' ) }
 				</Header>
 				{ this.state.error && (
 					<Notice status="is-error" icon="notice" onDismissClick={ this.dismissError }>
@@ -67,17 +67,18 @@ class ManageConsent extends React.Component {
 					</Notice>
 				) }
 				<div>
-					<SectionHeader label={ translate( 'Manage Personal Data Consent' ) } />
+					<SectionHeader label={ translate( 'Manage Consent for Personal Data Use' ) } />
 					<Card>
 						<div>
 							<p>
 								{ translate(
-									'You can manage how your personal data is used ' +
-										'using the consent management link you have received via email during domain registration.'
+									'You can view or change your consent for how we use or share personally identifiable data related to your domain registration at any time.'
 								) }
 							</p>
 							<p>
-								{ translate( 'You can request the link again by clicking on the button below.' ) }
+								{ translate(
+									'Click the button below to receive an email with a unique link to manage your consent options. Please note that this email will be sent to the registrant contact email address, which may be different than your WordPress.com account email address.'
+								) }
 							</p>
 							<Button
 								className="manage-consent__action-button"
@@ -85,7 +86,7 @@ class ManageConsent extends React.Component {
 								primary
 								disabled={ this.state.submitting }
 							>
-								{ translate( 'Re-send the Personal Data Consent Link' ) }
+								{ translate( 'Request Consent Management Email' ) }
 							</Button>
 						</div>
 					</Card>

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -105,6 +105,14 @@ export default function() {
 	);
 
 	page(
+		paths.domainManagementManageConsent( ':site', ':domain' ),
+		...getCommonHandlers(),
+		domainManagementController.domainManagementManageConsent,
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		paths.domainManagementDns( ':site', ':domain' ),
 		...getCommonHandlers(),
 		domainManagementController.domainManagementDns,

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -46,6 +46,10 @@ export function domainManagementEditContactInfo( siteName, domainName ) {
 	return domainManagementEdit( siteName, domainName, 'edit-contact-info' );
 }
 
+export function domainManagementManageConsent( siteName, domainName ) {
+	return domainManagementEdit( siteName, domainName, 'manage-consent' );
+}
+
 export function domainManagementEmail( siteName, domainName ) {
 	let path;
 

--- a/client/state/sites/domains/assembler.js
+++ b/client/state/sites/domains/assembler.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { getDomainType, getTransferStatus } from 'lib/domains/utils';
+import { getDomainType, getGdprConsentStatus, getTransferStatus } from 'lib/domains/utils';
 import { assembleGoogleAppsSubscription } from 'lib/domains/assembler';
 
 export const createSiteDomainObject = domain => {
@@ -20,6 +20,7 @@ export const createSiteDomainObject = domain => {
 		expired: Boolean( domain.expired ),
 		expiry: ! domain.expiry ? null : String( domain.expiry ),
 		expirySoon: Boolean( domain.expiry_soon ),
+		gdprConsentStatus: getGdprConsentStatus( domain ),
 		googleAppsSubscription: assembleGoogleAppsSubscription( domain.google_apps_subscription ),
 		hasPrivacyProtection: Boolean( domain.has_private_registration ),
 		privacyAvailable: Boolean( domain.privacy_available ),

--- a/client/state/sites/domains/test/fixture/index.js
+++ b/client/state/sites/domains/test/fixture/index.js
@@ -34,6 +34,7 @@ export const DOMAIN_PRIMARY = {
 	expired: false,
 	expiry: '2017-03-09T00:00:00+00:00',
 	expirySoon: false,
+	gdprConsentStatus: null,
 	googleAppsSubscription: {
 		status: 'no_subscription',
 	},
@@ -78,6 +79,7 @@ export const DOMAIN_NOT_PRIMARY = {
 	expired: false,
 	expiry: null,
 	expirySoon: false,
+	gdprConsentStatus: null,
 	googleAppsSubscription: {
 		status: 'no_subscription',
 	},
@@ -124,6 +126,7 @@ export const REST_API_SITE_DOMAIN_FIRST = {
 	expired: false,
 	expiry: '2017-03-09T00:00:00+00:00',
 	expiry_soon: false,
+	gdprConsentStatus: null,
 	google_apps_subscription: {
 		status: 'no_subscription',
 	},
@@ -165,6 +168,7 @@ export const REST_API_SITE_DOMAIN_SECOND = {
 	expired: false,
 	expiry: false,
 	expiry_soon: false,
+	gdprConsentStatus: null,
 	google_apps_subscription: {
 		status: 'no_subscription',
 	},

--- a/config/development.json
+++ b/config/development.json
@@ -48,6 +48,7 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"domains/cctlds/uk": true,
+		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/dashes-filter": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/max-characters-filter": true,


### PR DESCRIPTION
Since GDPR is closing on us we need to add a way for the user to manage their consent regarding personal data for domains. The way to do this is by sending a consent management link to the domain owner.

So - we've added a new section under Contacts and Privacy called "Manage Personal Data Use" (to be renamed) where you can click on a button to request the consent management link to be sent via email to the domain owner.

<img width="760" alt="screen shot 2018-05-22 at 14 29 40" src="https://user-images.githubusercontent.com/1355045/40360004-451391ec-5dcd-11e8-9e3b-1239d23215d6.png">

I also added a notice in case the domain is in `PENDING_ASYNC` (which means that user action is required before the registration is completed) that is shown in the domains list and in the domain settings page.

<img width="1070" alt="screen shot 2018-05-22 at 14 29 21" src="https://user-images.githubusercontent.com/1355045/40360014-4e32a93e-5dcd-11e8-8610-13f039c3d995.png">

Also shamelessly merged the changes from https://github.com/Automattic/wp-calypso/pull/24911 in here (kudos @delputnam ).

Testing instructions:
* This PR depends on D13434-code and D13312-code - so make sure you're sandboxed and applied those diffs
* Set one or more of your domains to return `gdpr_consent_status` set to `PENDING_ASYNC`
* Check that you see the notices for those domains
* Go to Contacts and Privacy > Manage Personal Data Use and click on the button. You should see an error. Short circuit the API to return `true` and click on the button again - should see a success notice.

Things left to fix:
- [ ] fix the copy (page content, button, notices)
- [x] add notice in the navigation bar too
- [ ] maybe show more information in the consent management section in case the domain is still in `PENDING_ASYNC`?
