### PR TITLE
Remove `me/privacy` feature flag

### DIFF
--- a/client/me/privacy/controller.js
+++ b/client/me/privacy/controller.js
@@ -4,19 +4,14 @@
  * External dependencies
  */
 import React from 'react';
-import page from 'page';
 
 /**
  * Internal dependencies
  */
-import config from 'config';
 import userSettings from 'lib/user-settings';
 import PrivacyComponent from 'me/privacy/main';
 
 export function privacy( context, next ) {
-	if ( ! config.isEnabled( 'me/privacy' ) ) {
-		return page.redirect( '/me' );
-	}
 	context.primary = React.createElement( PrivacyComponent, {
 		userSettings: userSettings,
 	} );

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -111,7 +111,7 @@ const Privacy = createReactClass( {
 							<p>
 								{ translate(
 									'We use other tracking tools, including some from third parties. ' +
-										'{{cookiePolicyLink}}Read about those{{/cookiePolicyLink}} these and how to ' +
+										'{{cookiePolicyLink}}Read about these{{/cookiePolicyLink}} and how to ' +
 										'control them.',
 									{
 										components: {

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -155,16 +155,14 @@ class MeSidebar extends React.Component {
 								preloadSectionName="security"
 							/>
 
-							{ config.isEnabled( 'me/privacy' ) && (
-								<SidebarItem
-									selected={ selected === 'privacy' }
-									link={ '/me/privacy' }
-									label={ translate( 'Privacy' ) }
-									icon="visible"
-									onNavigate={ this.onNavigate }
-									preloadSectionName="privacy"
-								/>
-							) }
+							<SidebarItem
+								selected={ selected === 'privacy' }
+								link={ '/me/privacy' }
+								label={ translate( 'Privacy' ) }
+								icon="visible"
+								onNavigate={ this.onNavigate }
+								preloadSectionName="privacy"
+							/>
 
 							<SidebarItem
 								selected={ selected === 'notifications' }

--- a/config/development.json
+++ b/config/development.json
@@ -117,7 +117,6 @@
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/notifications": true,
-		"me/privacy": true,
 		"me/trophies": false,
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,


### PR DESCRIPTION
Today's the day: opt-out should go live before the May 25th deadline :)

** Testing **

1- Make sure you don't get redirected anymore visiting [/me/privacy ](http://calypso.localhost:3000/me/privacy)
2- Check that the opt-out status is still saved in the user settings ( call to `https://public-api.wordpress.com/rest/v1.1/me` and/or the settings is properly set when reloading the page )

Brace yourselves for the rest of GDPR hitting in the next few days / weeks :D 

