### PR TITLE
We no longer depend on jetpack for GMB

### DIFF
--- a/client/state/selectors/is-google-my-business-stats-nudge-visible.js
+++ b/client/state/selectors/is-google-my-business-stats-nudge-visible.js
@@ -3,13 +3,9 @@
 /**
  * Internal dependencies
  */
-import getSiteOptions from 'state/selectors/get-site-options';
-
 import isGoogleMyBusinessLocationConnected from 'state/selectors/is-google-my-business-location-connected';
 import isSiteGoogleMyBusinessEligible from 'state/selectors/is-site-google-my-business-eligible';
 import { isRequestingSiteSettings, getSiteSettings } from 'state/site-settings/selectors';
-import versionCompare from 'lib/version-compare';
-import { isJetpackSite } from 'state/sites/selectors';
 
 /**
  * Returns true if the Google My Business (GMB) nudge should be visible in stats
@@ -30,16 +26,6 @@ export default function isGoogleMyBusinessStatsNudgeVisible( state, siteId ) {
 	}
 
 	if ( isGoogleMyBusinessLocationConnected( state, siteId ) ) {
-		return false;
-	}
-
-	// Jetpack site needs to be at least version 6.1 for us to be able to modify site settings
-	const siteOptions = getSiteOptions( state, siteId );
-
-	if (
-		isJetpackSite( state, siteId ) &&
-		! versionCompare( siteOptions.jetpack_version, '6.1.1', '>=' )
-	) {
 		return false;
 	}
 


### PR DESCRIPTION
After https://github.com/Automattic/wp-calypso/pull/24815 we no longer need to sniff jetpack version.

### Testing:
1. Run `git checkout update/gmb-jetpack` and start your server, or open a [live branch](https://calypso.live/?branch=update/gmb-jetpack)
2. Open the [`Stats` page](http://calypso.localhost:3000/) of an eligible jetpack site ( one with a premium plan )
3. Assert you see the GMB nudge 
