### PR TITLE
Make Domain Connect authorize page work for logged out users.

### DIFF
--- a/client/my-sites/domains/domain-management/domain-connect/index.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/index.jsx
@@ -5,13 +5,15 @@
  */
 
 import { domainConnectAuthorize, notFoundError } from './controller';
-import { makeLayout } from 'controller';
+import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 
 export default router => {
 	router(
 		'/domain-connect/authorize/v2/domainTemplates/providers/:providerId/services/:serviceId/apply',
+		redirectLoggedOut,
 		domainConnectAuthorize,
-		makeLayout
+		makeLayout,
+		clientRender
 	);
-	router( '/*', notFoundError, makeLayout );
+	router( '/domain-connect/*', notFoundError, makeLayout, clientRender );
 };

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -425,7 +425,7 @@ sections.push( {
 	name: 'domain-connect-authorize',
 	paths: [ '/domain-connect' ],
 	module: 'my-sites/domains/domain-management/domain-connect',
-	enableLoggedOut: false,
+	enableLoggedOut: true,
 	secondary: false,
 	isomorphic: false,
 } );


### PR DESCRIPTION
When a user is directed to the Domain Connect Authorize page, they should be prompted to log in if they are currently logged out.

To test: Attempt to apply a domain connect template when logged out of WordPress.com or from an incognito browser. See p99Zz8-ih-p2 for a test link to use and additional instructions.

Also make sure that this still works when logged in. :-D