### PR TITLE
DocumentHead: Remove refreshHeadTags() method

### DIFF
--- a/client/components/data/document-head/index.jsx
+++ b/client/components/data/document-head/index.jsx
@@ -7,16 +7,12 @@
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { debounce, forEach, isEqual, map } from 'lodash';
+import { debounce, isEqual } from 'lodash';
 
 /**
  * Internal dependencies.
  */
-import {
-	getDocumentHeadFormattedTitle,
-	getDocumentHeadLink,
-	getDocumentHeadMeta,
-} from 'state/document-head/selectors';
+import { getDocumentHeadFormattedTitle } from 'state/document-head/selectors';
 import {
 	setDocumentHeadTitle as setTitle,
 	setDocumentHeadLink as setLink,
@@ -48,8 +44,6 @@ class DocumentHead extends Component {
 
 	componentDidMount() {
 		this.setFormattedTitle( this.props.formattedTitle );
-
-		this.refreshHeadTags();
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -71,36 +65,6 @@ class DocumentHead extends Component {
 
 		if ( nextProps.formattedTitle !== this.props.formattedTitle ) {
 			this.setFormattedTitle( nextProps.formattedTitle );
-		}
-
-		this.refreshHeadTags( nextProps );
-	}
-
-	refreshHeadTags( props = this.props ) {
-		const { allLinks, allMeta } = props;
-
-		allLinks.forEach( tagProperties => this.ensureTag( 'link', tagProperties ) );
-		allMeta.forEach( tagProperties => this.ensureTag( 'meta', tagProperties ) );
-	}
-
-	ensureTag( tagName, properties ) {
-		const propertiesSelector = map( properties, ( value, key ) => {
-			if ( value !== undefined && typeof value === 'string' ) {
-				const escapedValueInSelector = value
-					.toString()
-					.replace( /([ #;?%&,.+*~\':"!^$[\]()=>|\/@])/g, '\\$1' );
-				return `[${ key }="${ escapedValueInSelector }"]`;
-			}
-			return `[${ key }]`;
-		} ).join( '' );
-		const element = document.querySelector( `${ tagName }${ propertiesSelector }` );
-		if ( ! element ) {
-			const newTag = document.createElement( tagName );
-			forEach( properties, ( value, key ) => {
-				newTag.setAttribute( key, value );
-			} );
-			const head = document.getElementsByTagName( 'head' )[ 0 ];
-			head.appendChild( newTag );
 		}
 	}
 
@@ -131,8 +95,6 @@ DocumentHead.propTypes = {
 export default connect(
 	state => ( {
 		formattedTitle: getDocumentHeadFormattedTitle( state ),
-		allLinks: getDocumentHeadLink( state ),
-		allMeta: getDocumentHeadMeta( state ),
 	} ),
 	{
 		setTitle,


### PR DESCRIPTION
Found while working on #24980. I read through #15297 which introduced this but couldn't make sense of why this method was introduced. (Most of all, adding `meta` and `link` tags on the client side doesn't seem to make a lot of sense when they're already added on the server side.) I'd be thankful if someone could explain the motivation for adding these methods. 

My current strategy for fixing SSR is found in #24977. Since SSR is broken anyway right now, I don't assume this PR to have any impact.

Testing instructions: Make sure that Calypso works as before.