### PR TITLE
Components: Restore highlighting to cards.

### DIFF
--- a/client/components/card/docs/example.jsx
+++ b/client/components/card/docs/example.jsx
@@ -12,6 +12,8 @@ import React from 'react';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 
+Card.displayName = 'Card';
+
 class Cards extends React.Component {
 	static displayName = 'Cards';
 

--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 
-const getClassName = ( { className, compact, highlightClass, href, onClick } ) =>
+const getClassName = ( { className, compact, highlight, href, onClick } ) =>
 	classNames(
 		'card',
 		className,
@@ -16,9 +16,9 @@ const getClassName = ( { className, compact, highlightClass, href, onClick } ) =
 			'is-card-link': !! href,
 			'is-clickable': !! onClick,
 			'is-compact': compact,
-			'is-highlight': highlightClass,
+			'is-highlight': highlight,
 		},
-		highlightClass
+		highlight ? 'is-' + highlight : false
 	);
 
 class Card extends PureComponent {
@@ -37,16 +37,7 @@ class Card extends PureComponent {
 	};
 
 	render() {
-		const {
-			children,
-			compact,
-			highlight,
-			highlightClass,
-			tagName: TagName,
-			href,
-			target,
-			...props
-		} = this.props;
+		const { children, compact, highlight, tagName: TagName, href, target, ...props } = this.props;
 
 		return href ? (
 			<a { ...props } href={ href } target={ target } className={ getClassName( this.props ) }>


### PR DESCRIPTION
This restores the `is-highlight` and `highlight-` classes to cards. Broken in #24899.

Before | After
------------ | -------------
<img width="757" alt="screen shot 2018-05-22 at 2 14 25 pm" src="https://user-images.githubusercontent.com/942359/40381765-9bd9ee5c-5dca-11e8-95d2-2e5cfa24ca8e.png">  | <img width="758" alt="screen shot 2018-05-22 at 2 14 15 pm" src="https://user-images.githubusercontent.com/942359/40381784-a32512cc-5dca-11e8-8227-5e268dcc87eb.png">


**To test:**
- Check http://calypso.localhost:3000/devdocs/design/cards for card highlighting