### PR TITLE
DevDocs: Add display name for CompactCard

### DIFF
--- a/client/components/card/docs/example.jsx
+++ b/client/components/card/docs/example.jsx
@@ -13,6 +13,7 @@ import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 
 Card.displayName = 'Card';
+CompactCard.displayName = 'CompactCard';
 
 class Cards extends React.Component {
 	static displayName = 'Card';


### PR DESCRIPTION
In production, the DevDocs playground is minified, so examples need a `displayName` to render properly. `Card` was taken care of in #25006, but I missed the `CompactCard` example.