### PR TITLE
Purchases: Prevent Ebanx fields rendering on add/update card

### DIFF
--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { isEmpty, noop } from 'lodash';
+import { isEmpty, noop, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,6 +28,7 @@ export class CreditCardFormFields extends React.Component {
 		onFieldChange: PropTypes.func,
 		getErrorMessage: PropTypes.func,
 		autoFocus: PropTypes.bool,
+		transaction: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -35,6 +36,7 @@ export class CreditCardFormFields extends React.Component {
 		onFieldChange: noop,
 		getErrorMessage: noop,
 		autoFocus: true,
+		transaction: null,
 	};
 
 	createField = ( fieldName, componentClass, props ) => {
@@ -90,7 +92,13 @@ export class CreditCardFormFields extends React.Component {
 	};
 
 	shouldRenderEbanxFields() {
-		return shouldRenderAdditionalEbanxFields( this.getFieldValue( 'country' ) );
+		// The add/update card endpoints do not yet process Ebanx payment details
+		// so we only show Ebanx fields at checkout,
+		// i.e., when there is a current transaction.
+		return (
+			get( this.props.transaction, 'step', null ) &&
+			shouldRenderAdditionalEbanxFields( this.getFieldValue( 'country' ) )
+		);
 	}
 
 	render() {

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { isEmpty, noop, get } from 'lodash';
+import { isEmpty, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,7 +28,7 @@ export class CreditCardFormFields extends React.Component {
 		onFieldChange: PropTypes.func,
 		getErrorMessage: PropTypes.func,
 		autoFocus: PropTypes.bool,
-		transaction: PropTypes.object,
+		isNewTransaction: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -36,7 +36,7 @@ export class CreditCardFormFields extends React.Component {
 		onFieldChange: noop,
 		getErrorMessage: noop,
 		autoFocus: true,
-		transaction: null,
+		isNewTransaction: false,
 	};
 
 	createField = ( fieldName, componentClass, props ) => {
@@ -92,11 +92,11 @@ export class CreditCardFormFields extends React.Component {
 	};
 
 	shouldRenderEbanxFields() {
-		// The add/update card endpoints do not yet process Ebanx payment details
+		// The add/update card endpoints do not process Ebanx payment details
 		// so we only show Ebanx fields at checkout,
 		// i.e., when there is a current transaction.
 		return (
-			get( this.props.transaction, 'step', null ) &&
+			this.props.isNewTransaction &&
 			shouldRenderAdditionalEbanxFields( this.getFieldValue( 'country' ) )
 		);
 	}

--- a/client/components/credit-card-form-fields/test/index.js
+++ b/client/components/credit-card-form-fields/test/index.js
@@ -35,9 +35,7 @@ const defaultProps = {
 	translate: identity,
 	isFieldInvalid: identity,
 	onFieldChange: noop,
-	transaction: {
-		step: 'cupcake',
-	},
+	isNewTransaction: true,
 };
 
 describe( 'CreditCardFormFields', () => {
@@ -67,7 +65,7 @@ describe( 'CreditCardFormFields', () => {
 
 		test( 'should not display Ebanx fields when there is a transaction in process', () => {
 			const wrapper = shallow( <CreditCardFormFields { ...defaultProps } /> );
-			wrapper.setProps( { card: { country: 'BR' }, transaction: null } );
+			wrapper.setProps( { card: { country: 'BR' }, isNewTransaction: false } );
 			expect( wrapper.find( 'EbanxPaymentFields' ) ).toHaveLength( 0 );
 		} );
 	} );

--- a/client/components/credit-card-form-fields/test/index.js
+++ b/client/components/credit-card-form-fields/test/index.js
@@ -35,12 +35,20 @@ const defaultProps = {
 	translate: identity,
 	isFieldInvalid: identity,
 	onFieldChange: noop,
+	transaction: {
+		step: 'cupcake',
+	},
 };
 
 describe( 'CreditCardFormFields', () => {
 	test( 'should have `CreditCardFormFields` class', () => {
 		const wrapper = shallow( <CreditCardFormFields { ...defaultProps } /> );
 		expect( wrapper.find( '.credit-card-form-fields' ) ).toHaveLength( 1 );
+	} );
+
+	test( 'should not render ebanx fields', () => {
+		const wrapper = shallow( <CreditCardFormFields { ...defaultProps } /> );
+		expect( wrapper.find( 'EbanxPaymentFields' ) ).toHaveLength( 0 );
 	} );
 
 	describe( 'with ebanx activated', () => {
@@ -51,10 +59,16 @@ describe( 'CreditCardFormFields', () => {
 			shouldRenderAdditionalEbanxFields.mockReturnValue( false );
 		} );
 
-		test( 'should display Ebanx fields when an Ebanx payment country is selected', () => {
+		test( 'should display Ebanx fields when an Ebanx payment country is selected and there is a transaction in process', () => {
 			const wrapper = shallow( <CreditCardFormFields { ...defaultProps } /> );
 			wrapper.setProps( { card: { country: 'BR' } } );
 			expect( wrapper.find( 'EbanxPaymentFields' ) ).toHaveLength( 1 );
+		} );
+
+		test( 'should not display Ebanx fields when there is a transaction in process', () => {
+			const wrapper = shallow( <CreditCardFormFields { ...defaultProps } /> );
+			wrapper.setProps( { card: { country: 'BR' }, transaction: null } );
+			expect( wrapper.find( 'EbanxPaymentFields' ) ).toHaveLength( 0 );
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/checkout/new-card-form.jsx
+++ b/client/my-sites/checkout/checkout/new-card-form.jsx
@@ -48,7 +48,7 @@ class NewCardForm extends Component {
 					<CreditCardFormFields
 						card={ transaction.newCardFormFields }
 						countriesList={ countriesList }
-						transaction={ transaction }
+						isNewTransaction={ !! transaction }
 						eventFormName="Checkout Form"
 						onFieldChange={ this.handleFieldChange }
 						getErrorMessage={ this.getErrorMessage }

--- a/client/my-sites/checkout/checkout/new-card-form.jsx
+++ b/client/my-sites/checkout/checkout/new-card-form.jsx
@@ -48,6 +48,7 @@ class NewCardForm extends Component {
 					<CreditCardFormFields
 						card={ transaction.newCardFormFields }
 						countriesList={ countriesList }
+						transaction={ transaction }
 						eventFormName="Checkout Form"
 						onFieldChange={ this.handleFieldChange }
 						getErrorMessage={ this.getErrorMessage }


### PR DESCRIPTION
Since the backend does not handle the extra fields require for purchases made via Ebanx, we'll hide them. Users will be able to save/update cards.

## Testing
`beforeAll() =>` Set your currency to `BRL`

Toggle between `Brazil` and another country in the country dropdown at the following pages:

1. `/me/purchases/add-credit-card`
2. The update credit card screen for an existing purchase
3. For a new purchase at the payment screen.

### Expectations
**At 1-2**: No extra fields are shown

<img width="746" alt="screen shot 2018-05-23 at 11 39 54 am" src="https://user-images.githubusercontent.com/6458278/40399258-b2874b6c-5e7f-11e8-93b3-d88dd629af95.png">

**At 3**: You'll see the Ebanx fields!

<img width="728" alt="screen shot 2018-05-23 at 11 50 38 am" src="https://user-images.githubusercontent.com/6458278/40399239-950b36f2-5e7f-11e8-9b3c-0fd8af35b523.png">

