### PR TITLE
The new community translator component: enable at the first page load

### DIFF
--- a/client/components/community-translator/index.jsx
+++ b/client/components/community-translator/index.jsx
@@ -31,9 +31,7 @@ class CommunityTranslator extends Component {
 		this.setLanguage();
 
 		// wrap translations from i18n
-		i18n.registerTranslateHook( ( translation, options ) =>
-			this.wrapTranslation( options.original, translation, options )
-		);
+		i18n.registerTranslateHook( this.wrapTranslation );
 
 		// callback when translated component changes.
 		// the callback is overwritten by the translator on load/unload, so we're returning it within an anonymous function.
@@ -49,21 +47,20 @@ class CommunityTranslator extends Component {
 		userSettings.off( 'change', this.setLanguage );
 	}
 
-	setLanguage() {
+	setLanguage = () => {
 		this.languageJson = i18n.getLocale() || { '': {} };
 		const { localeSlug, localeVariant } = this.languageJson[ '' ];
 		this.localeCode = localeVariant || localeSlug;
 		this.currentLocale = find( languages, lang => lang.langSlug === this.localeCode );
-	}
+	};
 
 	/**
 	 * Wraps translation in a DOM object and attaches `toString()` method in case in can't be rendered
-	 * @param { String } originalFromPage - original string
 	 * @param { String } displayedTranslationFromPage - translated string
 	 * @param  { Object } optionsFromPage - i18n.translate options
 	 * @returns {Object} DOM object
 	 */
-	wrapTranslation( originalFromPage, displayedTranslationFromPage, optionsFromPage ) {
+	wrapTranslation = ( displayedTranslationFromPage, optionsFromPage ) => {
 		if ( ! isCommunityTranslatorEnabled() ) {
 			return displayedTranslationFromPage;
 		}
@@ -71,6 +68,8 @@ class CommunityTranslator extends Component {
 		if ( 'object' !== typeof optionsFromPage ) {
 			optionsFromPage = {};
 		}
+
+		const originalFromPage = optionsFromPage.original;
 
 		if ( 'string' !== typeof originalFromPage ) {
 			debug( 'unknown original format' );
@@ -124,7 +123,7 @@ class CommunityTranslator extends Component {
 		Object.freeze( translatableElement );
 
 		return translatableElement;
-	}
+	};
 
 	render() {
 		return null;

--- a/client/components/community-translator/index.jsx
+++ b/client/components/community-translator/index.jsx
@@ -38,15 +38,15 @@ class CommunityTranslator extends Component {
 		// callback when translated component changes.
 		// the callback is overwritten by the translator on load/unload, so we're returning it within an anonymous function.
 		i18n.registerComponentUpdateHook( () => {} );
-		i18n.on( 'change', this.refresh );
-		user.on( 'change', this.refresh );
-		userSettings.on( 'change', this.refresh );
+		i18n.on( 'change', this.setLanguage );
+		user.on( 'change', this.setLanguage );
+		userSettings.on( 'change', this.setLanguage );
 	}
 
 	componentWillUnmount() {
-		i18n.off( 'change', this.refresh );
-		user.removeListener( 'change', this.refresh );
-		userSettings.removeListener( 'change', this.refresh );
+		i18n.off( 'change', this.setLanguage );
+		user.off( 'change', this.setLanguage );
+		userSettings.off( 'change', this.setLanguage );
 	}
 
 	setLanguage() {
@@ -55,32 +55,6 @@ class CommunityTranslator extends Component {
 		this.localeCode = localeVariant || localeSlug;
 		this.currentLocale = find( languages, lang => lang.langSlug === this.localeCode );
 	}
-
-	refresh = () => {
-		if ( this.initialized ) {
-			return;
-		}
-
-		if ( ! userSettings.getSettings() ) {
-			debug( 'initialization failed because userSettings are not ready' );
-			return;
-		}
-
-		if ( ! isCommunityTranslatorEnabled() ) {
-			debug( 'not initializing, not enabled' );
-			return;
-		}
-
-		this.setLanguage();
-
-		if ( ! this.localeCode || ! this.languageJson ) {
-			debug( 'trying to initialize translator without loaded language' );
-			return;
-		}
-
-		debug( 'Successfully initialized' );
-		this.initialized = true;
-	};
 
 	/**
 	 * Wraps translation in a DOM object and attaches `toString()` method in case in can't be rendered

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -47,7 +47,6 @@ import { getPreference } from 'state/preferences/selectors';
 import JITM from 'blocks/jitm';
 import KeyboardShortcutsMenu from 'lib/keyboard-shortcuts/menu';
 import SupportUser from 'support/support-user';
-import { isCommunityTranslatorEnabled } from 'components/community-translator/utils';
 import { isE2ETest } from 'lib/e2e';
 
 /* eslint-disable react/no-deprecated */
@@ -144,7 +143,7 @@ const Layout = createReactClass( {
 					</div>
 				</div>
 				{ config.isEnabled( 'i18n/community-translator' ) ? (
-					isCommunityTranslatorEnabled() && <AsyncLoad require="components/community-translator" />
+					<AsyncLoad require="components/community-translator" />
 				) : (
 					<TranslatorLauncher />
 				) }


### PR DESCRIPTION
## Summary
As stated in https://github.com/Automattic/wp-calypso/pull/21591#issuecomment-383770950, the new CT component won't wrap strings as `Translatable` at the first page load. Inspired by the very recent OSS PR https://github.com/Automattic/wp-calypso/pull/24834, this PR aims to solve the same problem on the new CT component side.

## Test Plan
WIP
