### PR TITLE
Post Editor: reduxify the EditorVisibility component

### DIFF
--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -141,30 +141,15 @@ export class EditPostStatus extends Component {
 	}
 
 	renderPostVisibility() {
-		if ( ! this.props.post ) {
-			return;
-		}
-
 		// Do not render the editor visibility component on both the editor sidebar and the confirmation sidebar
 		// at the same time so that it is predictable which one gets the focus / shows the validation error message.
 		if ( 'open' === this.props.confirmationSidebarStatus ) {
 			return;
 		}
 
-		const { password, status = 'draft', type } = this.props.post;
-		const savedStatus = this.props.savedPost ? this.props.savedPost.status : null;
-		const savedPassword = this.props.savedPost ? this.props.savedPost.password : null;
-		const props = {
-			onPrivatePublish: this.props.onPrivatePublish,
-			type,
-			status,
-			password,
-			savedStatus,
-			savedPassword,
-			context: 'post-settings',
-		};
-
-		return <EditorVisibility { ...props } />;
+		return (
+			<EditorVisibility onPrivatePublish={ this.props.onPrivatePublish } context="post-settings" />
+		);
 	}
 }
 

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -9,7 +9,6 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -101,27 +100,12 @@ class EditorConfirmationSidebar extends Component {
 	}
 
 	renderPrivacyControl() {
-		const { post, onPrivatePublish } = this.props;
-
-		if ( ! post ) {
-			return;
-		}
-
-		const { password, type } = post || {};
-		const status = get( post, 'status', 'draft' );
-		const savedStatus = get( this.props, 'savedPost.status' );
-		const savedPassword = get( this.props, 'savedPost.password' );
-		const props = {
-			onPrivatePublish,
-			type,
-			password,
-			status,
-			savedStatus,
-			savedPassword,
-			context: 'confirmation-sidebar',
-		};
-
-		return <EditorVisibility { ...props } />;
+		return (
+			<EditorVisibility
+				onPrivatePublish={ this.props.onPrivatePublish }
+				context="confirmation-sidebar"
+			/>
+		);
 	}
 
 	renderPublishingBusyButton() {

--- a/client/post-editor/editor-visibility/README.md
+++ b/client/post-editor/editor-visibility/README.md
@@ -9,18 +9,8 @@ Editor Visibility is a React component that allows the user to set a post's visi
 import EditorVisibility from 'post-editor/editor-visibility';
 
 export default function MyComponent() {
-	const props = {
-		siteId: 10,
-		postId: 10,
-		status: 'publish',
-		onPrivatePublish: onPublish,
-		isPrivateSite: false,
-		type: 'post',
-		password: 'password',
-	};
-
 	return (
-		<EditorVisibility { ...props } />
+		<EditorVisibility onPrivatePublish={ onPublish } context="post-settings" />
 	);
 }
 ```
@@ -29,13 +19,17 @@ export default function MyComponent() {
 
 The following props are used with the Editor Visibility component:
 
+- `onPrivatePublish`: (func) Executed after a post is set to 'private'.
+- `context`: (string) A string describing the context in which the component is being rendered. E.g., 'post-settings' or 'confirmation-sidebar'. The context is used when reporting analytics events.
+
+The component is connected to Redux and there are additional props retrieved from the Redux store:
+
 - `siteId`: (int) ID of the current site
 - `postId`: (int) ID of post being edited
+- `hasPost`: (bool) Whether the edited post has been loaded
 - `status`: (string) the current post status
-- `onPrivatePublish`: (func) Executed after a post is set to 'private'.
-- `isPrivateSite`: (bool) Whether or not the current site is private.
 - `type`: (string) The current post type.
 - `password`: (string) A password for 'password' protected post. An empty string if not password protected.
 - `savedStatus`: (string) Auto-save post status.
 - `savedPassword`: (string) Auto-save post password for 'password' protected post.
-- `context`: (string) A string describing the context in which the component is being rendered. (Ex: 'post-settings', 'confirmation-sidebar')
+- `isPrivateSite`: (bool) Whether or not the current site is private.


### PR DESCRIPTION
Refactors the `EditorVisibility` component to get info about the current saved and edited post from Redux instead of relying on the Flux-based `post` and `savedPost` props.

**How to test:**
Verify that post visibility (public, private, password protected) can be changed and that all the combinations (public to private, private to protected, ...) work as expected.

<img width="273" alt="screen shot 2018-05-23 at 09 41 15" src="https://user-images.githubusercontent.com/664258/40411234-23c2af7a-5e70-11e8-9f38-c1ec12c00c5e.png">

Pay attention to the "password is valid" flow. When setting the visibility from public/private to protected, the empty password field should get focused and not display the "Password is empty" error until the field is blurred:

<img width="254" alt="screen shot 2018-05-23 at 10 01 32" src="https://user-images.githubusercontent.com/664258/40411303-4fef88de-5e70-11e8-9e0b-b046e1fdded1.png">
