### PR TITLE
Analytics: anonymize IPs in Google Analytics

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -437,6 +437,7 @@ const analytics = {
 				}
 
 				window.ga( 'create', config( 'google_analytics_key' ), 'auto', parameters );
+				window.ga( 'set', 'anonymizeIp', true );
 				analytics.ga.initialized = true;
 			}
 		},


### PR DESCRIPTION
This PR anonymizes the IP address in Google Analytics for every visitor. 

To test:
- I'm not sure whether this can be tested properly. At least check back with Google's docs [here](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#anonymizeIp) and [here](https://developers.google.com/analytics/devguides/collection/analyticsjs/ip-anonymization) and see whether I did the right thing. 