### PR TITLE
Post Editor: reduxify Post Status optional toggles and buttons

### DIFF
--- a/client/lib/posts/test/utils.js
+++ b/client/lib/posts/test/utils.js
@@ -43,8 +43,8 @@ describe( 'utils', () => {
 	} );
 
 	describe( '#getVisibility', () => {
-		test( 'should return undefined when no post is supplied', () => {
-			expect( postUtils.getVisibility() ).toBeUndefined();
+		test( 'should return null when no post is supplied', () => {
+			expect( postUtils.getVisibility() ).toBeNull();
 		} );
 
 		test( 'should return public when password and private are not set', () => {

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -86,6 +86,10 @@ export const isPublished = function( post ) {
 	);
 };
 
+export const isScheduled = function( post ) {
+	return post && 'future' === post.status;
+};
+
 export const isPrivate = function( post ) {
 	return post && 'private' === post.status;
 };
@@ -153,7 +157,7 @@ export const normalizeSync = function( post, callback ) {
 
 export const getVisibility = function( post ) {
 	if ( ! post ) {
-		return;
+		return null;
 	}
 
 	if ( post.password ) {

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -21,7 +21,7 @@ import { recordStat, recordEvent } from 'lib/posts/stats';
 import { editPost } from 'state/posts/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
-import { getEditedPost } from 'state/posts/selectors';
+import { getEditedPost, getSitePost } from 'state/posts/selectors';
 import EditorPublishDate from 'post-editor/editor-publish-date';
 import EditorVisibility from 'post-editor/editor-visibility';
 import canCurrentUser from 'state/selectors/can-current-user';
@@ -33,6 +33,7 @@ export class EditPostStatus extends Component {
 		onSave: PropTypes.func,
 		post: PropTypes.object,
 		savedPost: PropTypes.object,
+		currentPost: PropTypes.object,
 		translate: PropTypes.func,
 		onPrivatePublish: PropTypes.func,
 		confirmationSidebarStatus: PropTypes.string,
@@ -73,20 +74,20 @@ export class EditPostStatus extends Component {
 	};
 
 	render() {
-		let showSticky, isSticky, isPublished, isPending, isScheduled;
-		const { translate, canUserPublishPosts } = this.props;
+		const { translate, canUserPublishPosts, post, currentPost } = this.props;
 
-		if ( this.props.post ) {
-			const isPrivate = postUtils.isPrivate( this.props.post );
-			const isPasswordProtected = postUtils.getVisibility( this.props.post ) === 'password';
+		const isPending = postUtils.isPending( post );
+		const isPrivate = postUtils.isPrivate( post );
+		const isPasswordProtected = postUtils.getVisibility( post ) === 'password';
+		const isPublished = postUtils.isPublished( currentPost );
+		const isScheduled = postUtils.isScheduled( currentPost );
 
-			showSticky = this.props.post.type === 'post' && ! isPrivate && ! isPasswordProtected;
-			isSticky = this.props.post.sticky;
-			isPending = postUtils.isPending( this.props.post );
-			isPublished = postUtils.isPublished( this.props.savedPost );
-			isScheduled = this.props.savedPost && this.props.savedPost.status === 'future';
-		}
+		const showSticky = post && post.type === 'post' && ! isPrivate && ! isPasswordProtected;
+		const showPending = post && ! isPublished && ! isScheduled && canUserPublishPosts;
+		const showRevertToDraft = isPublished || isScheduled || ( isPending && ! canUserPublishPosts );
 
+		/* TODO: fix the label a11y and enable the ESLint rule again */
+		/* eslint-disable jsx-a11y/label-has-for */
 		return (
 			<div className="edit-post-status">
 				{ this.renderPostScheduling() }
@@ -100,30 +101,28 @@ export class EditPostStatus extends Component {
 							</InfoPopover>
 						</span>
 						<FormToggle
-							checked={ isSticky }
+							checked={ post.sticky }
 							onChange={ this.toggleStickyStatus }
 							aria-label={ translate( 'Stick post to the front page' ) }
 						/>
 					</label>
 				) }
-				{ ! isPublished &&
-					! isScheduled &&
-					canUserPublishPosts && (
-						<label className="edit-post-status__pending-review">
-							<span className="edit-post-status__label-text">
-								{ translate( 'Pending review' ) }
-								<InfoPopover position="top right">
-									{ translate( 'Flag this post to be reviewed for approval.' ) }
-								</InfoPopover>
-							</span>
-							<FormToggle
-								checked={ isPending }
-								onChange={ this.togglePendingStatus }
-								aria-label={ translate( 'Request review for post' ) }
-							/>
-						</label>
-					) }
-				{ ( isPublished || isScheduled || ( isPending && ! canUserPublishPosts ) ) && (
+				{ showPending && (
+					<label className="edit-post-status__pending-review">
+						<span className="edit-post-status__label-text">
+							{ translate( 'Pending review' ) }
+							<InfoPopover position="top right">
+								{ translate( 'Flag this post to be reviewed for approval.' ) }
+							</InfoPopover>
+						</span>
+						<FormToggle
+							checked={ isPending }
+							onChange={ this.togglePendingStatus }
+							aria-label={ translate( 'Request review for post' ) }
+						/>
+					</label>
+				) }
+				{ showRevertToDraft && (
 					<Button
 						className="edit-post-status__revert-to-draft"
 						onClick={ this.revertToDraft }
@@ -134,6 +133,7 @@ export class EditPostStatus extends Component {
 				) }
 			</div>
 		);
+		/* eslint-enable jsx-a11y/label-has-for */
 	}
 
 	renderPostScheduling() {
@@ -173,12 +173,14 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const postId = getEditorPostId( state );
 		const post = getEditedPost( state, siteId, postId );
+		const currentPost = getSitePost( state, siteId, postId );
 		const canUserPublishPosts = canCurrentUser( state, siteId, 'publish_posts' );
 
 		return {
 			siteId,
 			postId,
 			post,
+			currentPost,
 			canUserPublishPosts,
 		};
 	},


### PR DESCRIPTION
The `EditPostStatus` component displays a few toggles and buttons (Stick to the front page, Pending review, Revert to draft) that are displayed conditionally based on the saved and edited post status (is published? is it page or post? is it private or protected?).

This patch retrieves the saved and edited post info from Redux and stops using the Flux-based `post` and `savedPost` props.

**How to test:**
Few example scenarios:

Published post can be reverted to draft or made sticky. No option to request review:
<img width="276" alt="screen shot 2018-05-23 at 10 48 42" src="https://user-images.githubusercontent.com/664258/40414584-ecd1c844-5e78-11e8-9266-24734e413261.png">

Draft post can be made sticky or flagged for review, but can't be reverted to draft:
<img width="274" alt="screen shot 2018-05-23 at 10 49 15" src="https://user-images.githubusercontent.com/664258/40414590-ee981ba6-5e78-11e8-9adb-a53d90bb43a0.png">

Published page cannot be made sticky -- only posts can be sticky:
<img width="274" alt="screen shot 2018-05-23 at 10 52 13" src="https://user-images.githubusercontent.com/664258/40414594-f09267f4-5e78-11e8-8430-58d8ebe276c6.png">
