### PR TITLE
Hide GMB connect option in sharing if site is not eligible

### DIFF
--- a/client/state/sharing/services/selectors.js
+++ b/client/state/sharing/services/selectors.js
@@ -12,6 +12,7 @@ import { filter } from 'lodash';
 import config from 'config';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { isJetpackSite, isJetpackModuleActive } from 'state/sites/selectors';
+import isSiteGoogleMyBusinessEligible from 'state/selectors/is-site-google-my-business-eligible';
 
 /**
  * Returns an object of service objects.
@@ -93,10 +94,11 @@ export function getEligibleKeyringServices( state, siteId, type ) {
 			return false;
 		}
 
-		// Omit if service is settings-oriented and user cannot manage
+		// Omit if site is not eligible or user cannot manage
 		if (
 			'google_my_business' === service.ID &&
 			( ! canCurrentUser( state, siteId, 'manage_options' ) ||
+				! isSiteGoogleMyBusinessEligible( state, siteId ) ||
 				! config.isEnabled( 'google-my-business' ) )
 		) {
 			return false;


### PR DESCRIPTION
This PR updates the Sharing page to hide the Google My Business service when the current site is not eligible.

### Testing Instructions
- Apply this patch locally
- Go to the Sharing page for a site which has a free plan, notice the Google My Business option is hidden
- Go to the Sharing page for a site which has a business plan, notice the Google My Business service is visible and you can connect to it

### Reviews
- [ ] Code
- [ ] Product
