### PR TITLE
Post Editor: move recording a preview button click away from ground control

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -16,12 +16,12 @@ import { connect } from 'react-redux';
  */
 import Card from 'components/card';
 import Site from 'blocks/site';
-import { isPage, isPublished } from 'lib/posts/utils';
+import { isPublished } from 'lib/posts/utils';
 import EditorPublishButton, { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 import Button from 'components/button';
 import QuickSaveButtons from 'post-editor/editor-ground-control/quick-save-buttons';
 import Drafts from 'layout/masterbar/drafts';
-import { composeAnalytics, recordTracksEvent, recordGoogleEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 import canCurrentUser from 'state/selectors/can-current-user';
 import isVipSite from 'state/selectors/is-vip-site';
 import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
@@ -104,7 +104,6 @@ export class EditorGroundControl extends React.Component {
 	onPreviewButtonClick = event => {
 		if ( this.isPreviewEnabled() ) {
 			this.props.onPreview( event );
-			this.props.recordPreviewButtonClick( this.props.post );
 		}
 	};
 
@@ -237,18 +236,6 @@ const mapStateToProps = ( state, ownProps ) => {
 };
 
 const mapDispatchToProps = {
-	recordPreviewButtonClick: post => {
-		const postIsPage = isPage( post );
-		return composeAnalytics(
-			recordTracksEvent( `calypso_editor_${ postIsPage ? 'page' : 'post' }_preview_button_click` ),
-			recordGoogleEvent(
-				'Editor',
-				`Clicked Preview ${ postIsPage ? 'Page' : 'Post' } Button`,
-				`Editor Preview ${ postIsPage ? 'Page' : 'Post' } Button Clicked`,
-				`editor${ postIsPage ? 'Page' : 'Post' }ButtonClicked`
-			)
-		);
-	},
 	recordSiteButtonClick: () => recordTracksEvent( 'calypso_editor_site_button_click' ),
 	recordCloseButtonClick: () => recordTracksEvent( 'calypso_editor_close_button_click' ),
 };

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -43,7 +43,7 @@ import {
 	isEditorSaveBlocked,
 	getEditorPostPreviewUrl,
 } from 'state/ui/editor/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent, recordGoogleEvent } from 'state/analytics/actions';
 import { editPost } from 'state/posts/actions';
 import { getEditedPostValue, getPostEdits, isEditedPostDirty } from 'state/posts/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
@@ -684,7 +684,24 @@ export class PostEditor extends React.Component {
 		return this.props.previewUrl;
 	}
 
+	recordPreviewButtonClick() {
+		const isPage = this.props.type === 'page';
+		this.props.recordTracksEvent(
+			isPage
+				? 'calypso_editor_page_preview_button_click'
+				: 'calypso_editor_post_preview_button_click'
+		);
+		this.props.recordGoogleEvent(
+			'Editor',
+			isPage ? 'Clicked Preview Page Button' : 'Clicked Preview Post Button',
+			isPage ? 'Editor Preview Page Button Clicked' : 'Editor Preview Post Button Clicked',
+			isPage ? 'editorPageButtonClicked' : 'editorPostButtonClicked'
+		);
+	}
+
 	onPreview = event => {
+		this.recordPreviewButtonClick();
+
 		if ( this.props.isSitePreviewable && ! event.metaKey && ! event.ctrlKey ) {
 			return this.iframePreview();
 		}
@@ -1229,6 +1246,7 @@ const enhance = flow(
 			setNextLayoutFocus,
 			saveConfirmationSidebarPreference,
 			recordTracksEvent,
+			recordGoogleEvent,
 			closeEditorSidebar,
 			openEditorSidebar,
 		}


### PR DESCRIPTION
This patch moves the `recordPreviewButtonClick` method/action from `EditorGroundControl` component to the top-level `PostEditor`.

This removes one usage of the Flux-based `post` prop from `EditorGroundControl` and moves the functionality closer to the code that handles everything else preview-related.

The event strings are refactored to be findable with grep.

**How to test:**
Enable analytics debugging in browser console:
```js
localStorage.debug = 'calypso:analytics:*'
```

Click on the "Preview" button when editing a page or a post. Verify that the tracks and GA events are reported as expected.