### PR TITLE
Store Services - display anonymized labels

### DIFF
--- a/client/extensions/woocommerce/state/sites/orders/activity-log/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/activity-log/selectors.js
@@ -134,7 +134,10 @@ export const getActivityLogEvents = ( state, orderId, siteId = getSelectedSiteId
 
 	if ( plugins.isWcsEnabled( state, siteId ) ) {
 		const labels = getLabels( state, orderId, siteId );
-		const renderableLabels = filter( labels, { status: 'PURCHASED' } );
+		const renderableLabels = filter(
+			labels,
+			label => 'PURCHASED' === label.status || 'ANONYMIZED' === label.status
+		);
 		renderableLabels.forEach( ( label, index, allLabels ) => {
 			const labelIndex = allLabels.length - 1 - index;
 			if ( label.refund ) {
@@ -188,6 +191,7 @@ export const getActivityLogEvents = ( state, orderId, siteId = getSelectedSiteId
 				amount: label.rate,
 				refundableAmount: label.refundable_amount,
 				currency: label.currency,
+				anonymized: 'ANONYMIZED' === label.status,
 				// If there's a refund in progress or completed, the Reprint/Refund buttons or the tracking number must *not* be shown
 				showDetails:
 					! label.refund || 'rejected' === label.refund.status || 'unknown' === label.refund.status,

--- a/client/extensions/woocommerce/state/sites/orders/activity-log/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/activity-log/test/selectors.js
@@ -216,6 +216,29 @@ const labelsErrorSubtree = {
 	error: true,
 };
 
+const anonymizedLabelsSubtree = {
+	isFetching: false,
+	loaded: true,
+	labels: [
+		{
+			label_id: 4,
+			refundable_amount: 10,
+			rate: 10,
+			status: 'ANONYMIZED',
+			currency: 'CAD',
+			created_date: 4000000,
+			used_date: null,
+			expiry_date: 4500000,
+			product_names: [ 'poutine' ],
+			package_name: 'box',
+			tracking: '12345',
+			carrier_id: 'canada_post',
+			service_name: 'Xpress',
+			main_receipt_id: 12345,
+		},
+	],
+};
+
 const notesAndLabelsLoadingState = getState( notesLoadingSubtree, labelsLoadingSubtree );
 const notesLoadingState = getState( notesLoadingSubtree, labelsLoadedSubtree );
 const labelsLoadingState = getState( notesLoadedSubtree, labelsLoadingSubtree );
@@ -395,6 +418,7 @@ describe( 'selectors', () => {
 					carrierId: 'canada_post',
 					serviceName: 'Xpress',
 					receiptId: 12345,
+					anonymized: false,
 				},
 				{
 					key: 3,
@@ -423,6 +447,7 @@ describe( 'selectors', () => {
 					carrierId: 'usps',
 					serviceName: 'First Class',
 					receiptId: 12345,
+					anonymized: false,
 				},
 				{
 					key: 2,
@@ -451,6 +476,7 @@ describe( 'selectors', () => {
 					carrierId: 'canada_post',
 					serviceName: 'Xpress',
 					receiptId: 67890,
+					anonymized: false,
 				},
 				{
 					key: 1,
@@ -471,6 +497,7 @@ describe( 'selectors', () => {
 					carrierId: 'usps',
 					serviceName: 'First Class',
 					receiptId: 654321,
+					anonymized: false,
 				},
 			] );
 		} );
@@ -485,6 +512,15 @@ describe( 'selectors', () => {
 
 		it( 'should get the siteId from the UI tree if not provided.', () => {
 			expect( getActivityLogEvents( loadedStateWithUi, 45 ) ).to.not.be.empty;
+		} );
+
+		it( 'should mark anonymized labels as not available for reprint', () => {
+			const result = getActivityLogEvents(
+				getState( emptyNotesSubtree, anonymizedLabelsSubtree ),
+				45,
+				123
+			);
+			expect( result[ 0 ].anonymized ).to.be.true;
 		} );
 	} );
 } );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -29,7 +29,11 @@ class LabelItem extends Component {
 
 		const today = new Date();
 		const thirtyDaysAgo = new Date().setDate( today.getDate() - 30 );
-		if ( label.usedDate || ( label.createdDate && label.createdDate < thirtyDaysAgo ) ) {
+		if (
+			label.anonymized ||
+			label.usedDate ||
+			( label.createdDate && label.createdDate < thirtyDaysAgo )
+		) {
 			return null;
 		}
 
@@ -50,7 +54,11 @@ class LabelItem extends Component {
 
 	renderReprint = label => {
 		const todayTime = new Date().getTime();
-		if ( label.usedDate || ( label.expiryDate && label.expiryDate < todayTime ) ) {
+		if (
+			label.anonymized ||
+			label.usedDate ||
+			( label.expiryDate && label.expiryDate < todayTime )
+		) {
 			return null;
 		}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/woocommerce-services/pull/1408

To test:
* either `npm link` this branch to the local WCS (might need to remove `node_modules` in calypso first, then link, then reinstall modules in the calypso directory) or upload the latest release of the plugin to your AT site
* make sure the site under test uses the latest `master` of the WCS server or points at staging
* anonymize the labels and/or view an order with already anonymized labels (see https://github.com/Automattic/woocommerce-services/pull/1408 for details)
* the anonymized labels should appear, but no Reprint and Refund buttons should be shown
![screen shot 2018-05-23 at 11 53 35](https://user-images.githubusercontent.com/800604/40421897-58db5f30-5e85-11e8-9486-8d2b8211a2ca.png)
