### PR TITLE
InlineHelp: Track contact view

### DIFF
--- a/client/blocks/inline-help/inline-help-contact-view.jsx
+++ b/client/blocks/inline-help/inline-help-contact-view.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 
 /**
@@ -16,6 +16,7 @@ import getInlineHelpSupportVariation, {
 } from 'state/selectors/get-inline-help-support-variation';
 import { getHelpSelectedSite } from 'state/help/selectors';
 import isSupportVariationDetermined from 'state/selectors/is-support-variation-determined';
+import TrackComponentView from 'lib/analytics/track-component-view';
 
 const InlineHelpContactView = ( {
 	/* eslint-disable no-unused-vars, no-shadow */
@@ -28,11 +29,21 @@ const InlineHelpContactView = ( {
 		return <PlaceholderLines />;
 	}
 
-	if ( supportVariation === SUPPORT_FORUM ) {
-		return <InlineHelpForumView />;
-	}
-
-	return <HelpContact compact selectedSite={ selectedSite } />;
+	return (
+		<Fragment>
+			<TrackComponentView
+				eventName="calypso_inlinehelp_contact_view"
+				eventProperties={ {
+					support_variation: supportVariation,
+				} }
+			/>
+			{ supportVariation === SUPPORT_FORUM ? (
+				<InlineHelpForumView />
+			) : (
+				<HelpContact compact selectedSite={ selectedSite } />
+			) }
+		</Fragment>
+	);
 };
 
 export default connect( state => ( {


### PR DESCRIPTION
This PR aims to add a tracking for views of the contact view (covering the forum view and the contact view). I think this event may give insight in to how many times folks with different levels of support open 'Contact Us' from inline-help and should show up any anomalies there.

### Testing
- Open your network panel to be able to see tracking requests
- Set the filtering of the network activity to "calypso_inlinehelp_contact_view" to more easily spot the correct event
- Checkout this branch 
- Click on the blue `?` button in the bottom right
- Click on 'Contact Us'
  - You shouldn't see the event fire while the view is in loading state
  - Once the view is 'loaded' you should see an entry in your network activity for "calypso_inlinehelp_contact_view"
  - Make sure this event contains a value for `support_variation` - this should reflect the level of support that your account has access to.