### PR TITLE
GDPR: restrict `max-width` of cookie banner text so it looks nicer on wide screens

### DIFF
--- a/client/blocks/gdpr-banner/style.scss
+++ b/client/blocks/gdpr-banner/style.scss
@@ -49,6 +49,8 @@
 .gdpr-banner__text-content {
 	font-size: 12px;
 	line-height: 1.4;
+	max-width: 50em;
+	margin: 0 auto;
 	@include breakpoint( ">660px" ) {
 		font-size: 16px;
 	}


### PR DESCRIPTION
Before: 

<img width="2032" alt="screen shot 2018-05-23 at 3 02 23 pm" src="https://user-images.githubusercontent.com/23619/40426079-6cd8639c-5e9a-11e8-9d9e-f3082263a1d3.png">

After:

<img width="2032" alt="screen shot 2018-05-23 at 3 02 26 pm" src="https://user-images.githubusercontent.com/23619/40426090-6ff5e4a0-5e9a-11e8-9302-e2753966ac84.png">
