### PR TITLE
GDPR: restrict banner to {desktop, horizon, production, wpcalypso} environments

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -34,6 +34,7 @@
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,
 		"fluid-width": true,
+		"gdpr-banner": true,
 		"google-analytics": true,
 		"help": true,
 		"help/courses": true,

--- a/config/development.json
+++ b/config/development.json
@@ -57,6 +57,7 @@
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,
+		"gdpr-banner": false,
 		"google-my-business": true,
 		"google-analytics": false,
 		"guided-tours/design-showcase-welcome": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -34,6 +34,7 @@
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,
+		"gdpr-banner": true,
 		"google-my-business": false,
 		"google-analytics": true,
 		"happychat": false,

--- a/config/production.json
+++ b/config/production.json
@@ -33,6 +33,7 @@
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,
+		"gdpr-banner": true,
 		"google-analytics": true,
 		"google-my-business": false,
 		"happychat": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -36,6 +36,7 @@
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,
+		"gdpr-banner": false,
 		"google-my-business": false,
 		"google-analytics": false,
 		"happychat": true,

--- a/config/test.json
+++ b/config/test.json
@@ -34,6 +34,7 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"devdocs/components-usage-stats": false,
+		"gdpr-banner": false,
 		"google-analytics": false,
 		"google-my-business": false,
 		"help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -39,6 +39,7 @@
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,
+		"gdpr-banner": true,
 		"google-my-business": true,
 		"google-analytics": false,
 		"guided-tours/design-showcase-welcome": true,


### PR DESCRIPTION
This PR focuses where we show the GDPR banner to the {desktop, horizon, production, wpcalypso} environments and should thus lead to cleaner data and should make things easier for people working on staging such as HEs. 
