### PR TITLE
Post Editor: remove check for 'post' prop when rendering post formats accordion

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -126,16 +126,11 @@ class EditorDrawer extends Component {
 	}
 
 	renderPostFormats() {
-		if ( ! this.props.post || ! this.currentPostTypeSupports( 'post-formats' ) ) {
+		if ( ! this.currentPostTypeSupports( 'post-formats' ) ) {
 			return;
 		}
 
-		return (
-			<AsyncLoad
-				require="post-editor/editor-post-formats/accordion"
-				className="editor-drawer__accordion"
-			/>
-		);
+		return <AsyncLoad require="post-editor/editor-post-formats/accordion" />;
 	}
 
 	renderSharing() {

--- a/client/post-editor/editor-post-formats/accordion.jsx
+++ b/client/post-editor/editor-post-formats/accordion.jsx
@@ -8,8 +8,7 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { get, has, isEmpty } from 'lodash';
-import classNames from 'classnames';
+import { has, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,7 +20,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPostFormats } from 'state/post-formats/selectors';
 import getSiteDefaultPostFormat from 'state/selectors/get-site-default-post-format';
 import { getEditorPostId } from 'state/ui/editor/selectors';
-import { getEditedPost } from 'state/posts/selectors';
+import { getEditedPostValue } from 'state/posts/selectors';
 
 class EditorPostFormatsAccordion extends Component {
 	static propTypes = {
@@ -32,11 +31,7 @@ class EditorPostFormatsAccordion extends Component {
 	};
 
 	getSubtitle() {
-		const { isLoading, postFormats, formatValue } = this.props;
-
-		if ( isLoading ) {
-			return;
-		}
+		const { postFormats, formatValue } = this.props;
 
 		if ( has( postFormats, formatValue ) ) {
 			return postFormats[ formatValue ];
@@ -48,19 +43,16 @@ class EditorPostFormatsAccordion extends Component {
 	}
 
 	render() {
-		const { className, isLoading, siteId, postFormats } = this.props;
-		const classes = classNames( 'editor-post-formats__accordion', className, {
-			'is-loading': isLoading,
-		} );
+		const { siteId, postFormats } = this.props;
 
 		return (
 			<Fragment>
-				<QueryPostFormats siteId={ siteId } />
+				{ siteId && <QueryPostFormats siteId={ siteId } /> }
 				{ ! isEmpty( postFormats ) && (
 					<Accordion
 						title={ this.props.translate( 'Post Format' ) }
 						subtitle={ this.getSubtitle() }
-						className={ classes }
+						className="editor-drawer__accordion editor-post-formats__accordion"
 						e2eTitle="post-format"
 					>
 						<EditorPostFormats />
@@ -74,10 +66,10 @@ class EditorPostFormatsAccordion extends Component {
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const postId = getEditorPostId( state );
-	const post = getEditedPost( state, siteId, postId );
 	const postFormats = getPostFormats( state, siteId );
-	const isLoading = ! ( post && postFormats );
-	const formatValue = get( post, 'format' ) || getSiteDefaultPostFormat( state, siteId );
+	const formatValue =
+		getEditedPostValue( state, siteId, postId, 'format' ) ||
+		getSiteDefaultPostFormat( state, siteId );
 
-	return { siteId, isLoading, postFormats, formatValue };
+	return { siteId, postFormats, formatValue };
 } )( localize( EditorPostFormatsAccordion ) );


### PR DESCRIPTION
The Post Format Accordion does its own check for null `post` or `siteId` and doesn't render anything in that case: it waits until the `postFormats` for the site and post type are fully known.

There's no need to check the `post` prop in the `EditorDrawer` component. This patch removes that check, which is one of the last remaining usages of the Flux-based post object.

I also do a little cleanup of the Post Formats Accordion, namely removing the `isLoading` prop. As the component doesn't render anything at all until all data are available, it's redundant. The prop is a leftover from earlier refactoring in #8593.

**How to test:**
Verify that the Post Formats still work as expected:
- shown only on posts (not pages or other post types)
- shown only on themes that support them (I used "Pique")
- no console errors on loading, especially on a new post or a post not in local state