### PR TITLE
Notifications: Bump `notifications-panel` to v2.1.10.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -822,7 +822,7 @@
         "@babel/plugin-transform-template-literals": "7.0.0-beta.44",
         "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.44",
         "@babel/plugin-transform-unicode-regex": "7.0.0-beta.44",
-        "browserslist": "3.2.7",
+        "browserslist": "3.2.8",
         "invariant": "2.2.4",
         "semver": "5.5.0"
       },
@@ -936,8 +936,8 @@
       }
     },
     "@nodelib/fs.stat": {
-      "version": "1.0.2",
-      "integrity": "sha512-vCpf75JDcdomXvUd7Rn6DfYAVqPAFI66FVjxiWGwh85OLdvfo3paBoPJaam5keIYRyUolnS7SleS/ZPCidCvzw=="
+      "version": "1.1.0",
+      "integrity": "sha512-LAQ1d4OPfSJ/BMbI2DuizmYrrkD9JMaTdi2hQTlI53lQ4kRQPyZQRS4CYQ7O66bnBBnP/oYdRxbk++X0xuFU6A=="
     },
     "@types/node": {
       "version": "10.1.2",
@@ -2651,11 +2651,11 @@
       }
     },
     "browserslist": {
-      "version": "3.2.7",
-      "integrity": "sha512-oYVLxFVqpX9uMhOIQBLtZL+CX4uY8ZpWcjNTaxyWl5rO8yA9SSNikFnAfvk8J3P/7z3BZwNmEqFKaJoYltj3MQ==",
+      "version": "3.2.8",
+      "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "requires": {
         "caniuse-lite": "1.0.30000844",
-        "electron-to-chromium": "1.3.47"
+        "electron-to-chromium": "1.3.48"
       }
     },
     "bser": {
@@ -3768,7 +3768,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "1.1.3"
+            "natives": "1.1.4"
           }
         },
         "object-assign": {
@@ -4167,8 +4167,8 @@
       "dev": true
     },
     "cssstyle": {
-      "version": "0.2.37",
-      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+      "version": "0.3.1",
+      "integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
       "dev": true,
       "requires": {
         "cssom": "0.3.2"
@@ -4629,7 +4629,7 @@
           "dev": true,
           "requires": {
             "caniuse-db": "1.0.30000844",
-            "electron-to-chromium": "1.3.47"
+            "electron-to-chromium": "1.3.48"
           }
         },
         "isarray": {
@@ -4859,8 +4859,8 @@
       "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
     },
     "electron-to-chromium": {
-      "version": "1.3.47",
-      "integrity": "sha1-dk6IfKkQTQGgrI6r7n38DizhQQQ="
+      "version": "1.3.48",
+      "integrity": "sha1-07DYWTgUBE4JLs4hCPw6ya6kuQA="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -6134,7 +6134,7 @@
       "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
       "requires": {
         "@mrmlnc/readdir-enhanced": "2.2.1",
-        "@nodelib/fs.stat": "1.0.2",
+        "@nodelib/fs.stat": "1.1.0",
         "glob-parent": "3.1.0",
         "is-glob": "4.0.0",
         "merge2": "1.2.2",
@@ -7683,8 +7683,8 @@
       }
     },
     "gaze": {
-      "version": "1.1.2",
-      "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+      "version": "1.1.3",
+      "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
       "requires": {
         "globule": "1.2.0"
       }
@@ -9695,7 +9695,7 @@
       "requires": {
         "jest-mock": "22.4.3",
         "jest-util": "22.4.3",
-        "jsdom": "11.10.0"
+        "jsdom": "11.11.0"
       }
     },
     "jest-environment-node": {
@@ -10593,8 +10593,8 @@
       }
     },
     "jsdom": {
-      "version": "11.10.0",
-      "integrity": "sha512-x5No5FpJgBg3j5aBwA8ka6eGuS5IxbC8FOkmyccKvObtFT0bDMict/LOxINZsZGZSfGdNomLZ/qRV9Bpq/GIBA==",
+      "version": "11.11.0",
+      "integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
       "dev": true,
       "requires": {
         "abab": "1.0.4",
@@ -10602,13 +10602,13 @@
         "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
         "cssom": "0.3.2",
-        "cssstyle": "0.2.37",
+        "cssstyle": "0.3.1",
         "data-urls": "1.0.0",
         "domexception": "1.0.1",
         "escodegen": "1.9.1",
         "html-encoding-sniffer": "1.0.2",
         "left-pad": "1.3.0",
-        "nwmatcher": "1.4.4",
+        "nwsapi": "2.0.0",
         "parse5": "4.0.0",
         "pn": "1.1.0",
         "request": "2.87.0",
@@ -10976,7 +10976,7 @@
         "log-update": "1.0.2",
         "ora": "0.2.3",
         "p-map": "1.2.0",
-        "rxjs": "5.5.10",
+        "rxjs": "5.5.11",
         "stream-to-observable": "0.1.0",
         "strip-ansi": "3.0.1"
       },
@@ -12051,8 +12051,8 @@
       }
     },
     "natives": {
-      "version": "1.1.3",
-      "integrity": "sha512-BZGSYV4YOLxzoTK73l0/s/0sH9l8SHs2ocReMH1f8JYSh5FUWu4ZrKCpJdRkWXV6HFR/pZDz7bwWOVAY07q77g==",
+      "version": "1.1.4",
+      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg==",
       "dev": true
     },
     "natural-compare": {
@@ -12296,7 +12296,7 @@
         "async-foreach": "0.1.3",
         "chalk": "1.1.3",
         "cross-spawn": "3.0.1",
-        "gaze": "1.1.2",
+        "gaze": "1.1.3",
         "get-stdin": "4.0.1",
         "glob": "7.1.2",
         "in-publish": "2.0.0",
@@ -12486,8 +12486,8 @@
       "dev": true
     },
     "notifications-panel": {
-      "version": "2.1.9",
-      "integrity": "sha512-8bkVfKcMy9b2YNQ52oETkvDDe2tHf8L8xCi4LXVDxUhrjamzfWsHe2UkSFk9Hvau9K4mbtRz5D0KVZhwwUXGow=="
+      "version": "2.1.10",
+      "integrity": "sha512-lGQocN7VDL5aue1SMwLifFe88UT1zqcLJ6v0x+QtL3Ws5yYfLC3sM+qaHVGrRdqFh3GZsc4PG4gzt+oGZgX+7Q=="
     },
     "npm-run-all": {
       "version": "4.0.2",
@@ -12589,6 +12589,11 @@
     "nwmatcher": {
       "version": "1.4.4",
       "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
+      "dev": true
+    },
+    "nwsapi": {
+      "version": "2.0.0",
+      "integrity": "sha512-9kj1oCEDNq+LHDAVPGDPg9+qRcBcpXb1IYC8q89jR8xJvOC2byQwEVsM3W1qQcSPVyzGGaXN7wZHnXORCiZl4w==",
       "dev": true
     },
     "oauth-sign": {
@@ -14243,6 +14248,14 @@
             "wrap-ansi": "2.1.0"
           }
         },
+        "cssstyle": {
+          "version": "0.2.37",
+          "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+          "dev": true,
+          "requires": {
+            "cssom": "0.3.2"
+          }
+        },
         "debug": {
           "version": "2.6.9",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
@@ -15774,8 +15787,8 @@
       }
     },
     "rxjs": {
-      "version": "5.5.10",
-      "integrity": "sha512-SRjimIDUHJkon+2hFo7xnvNC4ZEHGzCRwh9P7nzX3zPkCGFEg/tuElrNR7L/rZMagnK2JeH2jQwPRpmyXyLB6A==",
+      "version": "5.5.11",
+      "integrity": "sha512-3bjO7UwWfA2CV7lmwYMBzj4fQ6Cq+ftHc2MvUe+WMS7wcdJ1LosDWmdjPQanYp2dBRj572p7PeU81JUxHKOcBA==",
       "requires": {
         "symbol-observable": "1.0.1"
       }
@@ -17574,7 +17587,7 @@
           "dev": true,
           "requires": {
             "caniuse-db": "1.0.30000844",
-            "electron-to-chromium": "1.3.47"
+            "electron-to-chromium": "1.3.48"
           }
         },
         "chalk": {
@@ -18442,12 +18455,12 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
-        "punycode": "2.1.0"
+        "punycode": "2.1.1"
       },
       "dependencies": {
         "punycode": {
-          "version": "2.1.0",
-          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+          "version": "2.1.1",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
           "dev": true
         }
       }
@@ -18928,12 +18941,12 @@
       "version": "4.2.1",
       "integrity": "sha512-jpKCA3HjsBfSDOEgxRDAxQCNyHfCPSbq57PqCkd3gAyBuPb3IWxw54EHncqESznIdqSetHfw3D7ylThu2Kcc9A==",
       "requires": {
-        "punycode": "2.1.0"
+        "punycode": "2.1.1"
       },
       "dependencies": {
         "punycode": {
-          "version": "2.1.0",
-          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+          "version": "2.1.1",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         }
       }
     },
@@ -20770,7 +20783,7 @@
             "lodash": "4.17.10",
             "mute-stream": "0.0.7",
             "run-async": "2.3.0",
-            "rxjs": "5.5.10",
+            "rxjs": "5.5.11",
             "string-width": "2.1.1",
             "strip-ansi": "4.0.0",
             "through": "2.3.8"

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "morgan": "1.2.0",
     "ms": "0.7.1",
     "node-sass": "4.5.3",
-    "notifications-panel": "2.1.9",
+    "notifications-panel": "2.1.10",
     "npm-run-all": "4.0.2",
     "object-path-immutable": "0.5.2",
     "objectpath": "1.2.1",


### PR DESCRIPTION
Bump the `notifications-panel` package to v2.1.10 (a21f8fa).

The only changes since the last version are to [included documentation](https://github.com/Automattic/notifications-panel/commits/master). This release was done mostly as a test drive for new a new server-side deploy process.

**Testing**

1. Switch to this branch.
2. Restart Calypso.
3. Make sure notifications load as expected.