### PR TITLE
Enable account closure in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -77,6 +77,7 @@
 		"manage/themes/logged-out": true,
 		"manage/themes/upload": true,
 		"me/account": true,
+		"me/account-close": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/notifications": true,


### PR DESCRIPTION
Flips the `me/account-close` feature flag in production, enabling the user to close their account via:

https://wordpress.com/me/account