### PR TITLE
Account closure: fix account closed error message on login

### DIFF
--- a/client/blocks/login/error-notice.jsx
+++ b/client/blocks/login/error-notice.jsx
@@ -7,6 +7,8 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -78,9 +80,30 @@ class ErrorNotice extends Component {
 			return null;
 		}
 
+		let message = error.message;
+
+		// Account closed error from the API contains HTML, so set a custom message for that case
+		if ( error.code === 'deleted_user' ) {
+			message = this.props.translate(
+				'This account has been closed. ' +
+					'If you believe your account was closed in error, please {{a}}contact us{{/a}}.',
+				{
+					components: {
+						a: (
+							<a
+								href={ config( 'login_url' ) + '?action=recovery' }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+					},
+				}
+			);
+		}
+
 		return (
 			<Notice status={ 'is-error' } showDismiss={ false }>
-				{ error.message }
+				{ message }
 			</Notice>
 		);
 	}
@@ -91,4 +114,4 @@ export default connect( state => ( {
 	requestAccountError: getRequestSocialAccountError( state ),
 	requestError: getRequestError( state ),
 	twoFactorAuthRequestError: getTwoFactorAuthRequestError( state ),
-} ) )( ErrorNotice );
+} ) )( localize( ErrorNotice ) );


### PR DESCRIPTION
Fixes #24990.

Before:

<img width="517" alt="screen shot 2018-05-24 at 11 26 39" src="https://user-images.githubusercontent.com/17325/40456485-c0595de0-5f45-11e8-931e-35faebaa2628.png">

After: 

<img width="513" alt="screen shot 2018-05-24 at 11 26 29" src="https://user-images.githubusercontent.com/17325/40456486-c23ce1b8-5f45-11e8-861c-3164c1b9c91c.png">

### To test

Close your account via http://wordpress.com/me/account/close (currently enabled in staging).

Try to login to the same account afterwards.