### PR TITLE
Switch lib/accept tests to use Jest assertions

### DIFF
--- a/client/lib/accept/dialog.jsx
+++ b/client/lib/accept/dialog.jsx
@@ -41,6 +41,7 @@ class AcceptDialog extends Component {
 				label: this.props.cancelButtonText
 					? this.props.cancelButtonText
 					: this.props.translate( 'Cancel' ),
+				additionalClassNames: 'is-cancel',
 			},
 			{
 				action: 'accept',

--- a/client/lib/accept/test/index.js
+++ b/client/lib/accept/test/index.js
@@ -4,11 +4,6 @@
  */
 
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import accept from '../';
@@ -24,13 +19,13 @@ describe( '#accept()', () => {
 		accept( message, function() {} );
 
 		const dialog = document.querySelector( '.accept-dialog' );
-		expect( dialog ).to.be.an.instanceof( window.Element );
-		expect( dialog.textContent ).to.equal( message );
+		expect( dialog ).toBeInstanceOf( window.Element );
+		expect( dialog.textContent ).toEqual( message );
 	} );
 
 	test( 'should trigger the callback with an accepted prompt', done => {
 		accept( 'Are you sure?', function( accepted ) {
-			expect( accepted ).to.be.be.true;
+			expect( accepted ).toBe( true );
 			done();
 		} );
 
@@ -39,7 +34,7 @@ describe( '#accept()', () => {
 
 	test( 'should trigger the callback with a denied prompt', done => {
 		accept( 'Are you sure?', function( accepted ) {
-			expect( accepted ).to.be.be.false;
+			expect( accepted ).toBe( false );
 			done();
 		} );
 
@@ -49,6 +44,6 @@ describe( '#accept()', () => {
 	test( 'should clean up after itself once the prompt is closed', () => {
 		accept( 'Are you sure?', () => {} );
 		document.querySelector( '.button.is-primary' ).click();
-		expect( document.querySelector( '.accept-dialog' ) ).to.be.null;
+		expect( document.querySelector( '.accept-dialog' ) ).toBe( null );
 	} );
 } );

--- a/client/lib/accept/test/index.js
+++ b/client/lib/accept/test/index.js
@@ -38,7 +38,7 @@ describe( '#accept()', () => {
 			done();
 		} );
 
-		document.querySelector( '.button:not( .is-primary )' ).click();
+		document.querySelector( '.button.is-cancel' ).click();
 	} );
 
 	test( 'should clean up after itself once the prompt is closed', () => {


### PR DESCRIPTION
This PR switches out `chai` for Jest assertions, and removes use of the `:not` selector, which was causing intermittent build failures. For example:

https://circleci.com/gh/Automattic/wp-calypso/95317

<img width="1322" alt="screen shot 2018-05-24 at 12 14 59" src="https://user-images.githubusercontent.com/17325/40457726-1a966b4e-5f4c-11e8-84ac-ada3c89fd449.png">


