### PR TITLE
Invites: Improve screen text for revoking a invitation

### DIFF
--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -65,8 +65,8 @@ export class PeopleInviteDetails extends React.PureComponent {
 		const { deleting, invite, translate } = this.props;
 		const { isPending } = invite;
 		const revokeMessage = translate(
-			'Revoking an invite will no longer allow this person to join your site. ' +
-				'You can always invite them again if your change your mind.'
+			'Revoking an invite will no longer allow this person to become a member of ' +
+				'your site. You can always invite them again if your change your mind.'
 		);
 		const clearMessage = translate(
 			'If you no longer wish to see this record, you can clear it. ' +


### PR DESCRIPTION
<img width="770" alt="english message" src="https://user-images.githubusercontent.com/203408/40481670-681fe074-5f52-11e8-94a3-5dec87a7f446.png">

> Revoking an invite will no longer allow this person to join your site. You can always invite them again if your change your mind.

The [Italian translation of this](https://translate.wordpress.com/projects/wpcom/it/default/?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=238578&filters%5Btranslation_id%5D=7267059) was confusing to a user. @michelleweber suggested to change to English text to make it more clear, thus also enabling better translations.