### PR TITLE
Post Editor: fix publish button label for new or loading post

### DIFF
--- a/client/post-editor/editor-publish-button/index.jsx
+++ b/client/post-editor/editor-publish-button/index.jsx
@@ -89,6 +89,8 @@ export class EditorPublishButton extends Component {
 				} );
 			case 'requestReview':
 				return translate( 'Submit for Review' );
+			default:
+				return translate( 'Loading…' );
 		}
 	}
 

--- a/client/state/ui/editor/selectors.js
+++ b/client/state/ui/editor/selectors.js
@@ -152,7 +152,7 @@ export function getEditorPublishButtonStatus( state ) {
 
 	// Return `null` (means "unknown") if the site or the post to edit is not available.
 	// Typically happens when async-loading them is in progress.
-	if ( ! siteId || ! currentPost || ! editedPost ) {
+	if ( ! siteId || ! editedPost ) {
 		return null;
 	}
 


### PR DESCRIPTION
When editing a new, yet unsaved post, show a "Publish" label instead of empty one. Done by fixing the return value of the `getEditorPublishButtonStatus` selector in case when the `currentPost` is `null` (i.e., nothing saved yet) and `post` is not null (i.e., something is edited).

Also, when the site or post is still loading, never display an empty label: show a "Loading..." label as a last resort.

Fixes #25032.

**How to test:**

Two cases to test:
- edit a brand new post that hasn't been saved yet. Verify that the Publish button is disabled and as a "Publish..." label instead of an empty one.
- with empty local storage (no state persisted), open Calypso URL to edit an existing post (`/post/example.blog/123`). Watch the disabled Publish button closely: it should never show an empty label, but should starts as "Loading..." and change to "Publish..." when loading the post is finished.