### PR TITLE
Checklists: Enable for Atomic sites

### DIFF
--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -181,10 +181,10 @@ const mapStateToProps = state => {
 	const siteSlug = getSiteSlug( state, siteId );
 	const siteChecklist = getSiteChecklist( state, siteId );
 	const isAtomic = isSiteAutomatedTransfer( state, siteId );
-	const isJetpack = isJetpackSite( state, siteId );
+	const isJetpack = isJetpackSite( state, siteId ) && ! isAtomic;
 	const tasks = isJetpack ? jetpackTasks( siteChecklist ) : onboardingTasks( siteChecklist );
 	return {
-		checklistAvailable: ! isAtomic && ( config.isEnabled( 'jetpack/checklist' ) || ! isJetpack ),
+		checklistAvailable: config.isEnabled( 'jetpack/checklist' ) || ! isJetpack,
 		siteId,
 		siteSlug,
 		tasks,


### PR DESCRIPTION
* Enable Atomic sites at wordpress.com/checklist/{site}
* Make Atomic sites use the wpcom checklist instead of the jetpack one

Needs patch D13828-code

## Testing

* Checkout this branch and sandbox public-api.wordpress.com with patch D13828-code
* Go to http://calypso.localhost:3000/checklist and choose an atomic site
* Verify that the checklist works as usual
* Verify that if you to a separate tab and do something that is mentioned on the checklist, such as uploading an icon, then refresh the checklist, the item is automatically checked-off

