### PR TITLE
Post Editor: show correct status label for new draft

### DIFF
--- a/client/post-editor/editor-status-label/index.jsx
+++ b/client/post-editor/editor-status-label/index.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,7 +17,7 @@ import classNames from 'classnames';
 import * as postUtils from 'lib/posts/utils';
 import EditorStatusLabelPlaceholder from './placeholder';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditorPostId, isEditorNewPost } from 'state/ui/editor/selectors';
 import { getSitePost } from 'state/posts/selectors';
 
 class EditorStatusLabel extends React.Component {
@@ -46,23 +47,23 @@ class EditorStatusLabel extends React.Component {
 	}
 
 	render() {
-		if ( ! this.props.post ) {
+		if ( ! this.props.post && ! this.props.isNew ) {
 			return <EditorStatusLabelPlaceholder className="editor-status-label" />;
 		}
 
 		const className = classNames(
 			'editor-status-label',
 			'is-plain',
-			'is-' + this.props.post.status
+			'is-' + get( this.props.post, 'status', 'draft' )
 		);
 
 		return <span className={ className }>{ this.renderLabel() }</span>;
 	}
 
 	renderLabel() {
-		const { post, translate, moment } = this.props;
+		const { isNew, post, translate, moment } = this.props;
 
-		if ( ! post.modified ) {
+		if ( isNew ) {
 			return translate( 'New Draft' );
 		}
 
@@ -133,5 +134,7 @@ export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const postId = getEditorPostId( state );
 	const post = getSitePost( state, siteId, postId );
-	return { post };
+	const isNew = isEditorNewPost( state );
+
+	return { isNew, post };
 } )( localize( EditorStatusLabel ) );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -293,7 +293,7 @@ export class PostEditor extends React.Component {
 				<div className="post-editor__inner">
 					<EditorGroundControl
 						setPostDate={ this.setPostDate }
-						hasContent={ this.state.hasContent }
+						hasContent={ this.state.hasContent || this.props.hasContent }
 						isConfirmationSidebarEnabled={ this.props.isConfirmationSidebarEnabled }
 						confirmationSidebarStatus={ this.state.confirmationSidebar }
 						isDirty={ this.state.isDirty || this.props.dirty }
@@ -326,7 +326,7 @@ export class PostEditor extends React.Component {
 										isSaving={ this.state.isSaving }
 										isSaveBlocked={ this.isSaveBlocked() }
 										isDirty={ this.state.isDirty || this.props.dirty }
-										hasContent={ this.state.hasContent }
+										hasContent={ this.state.hasContent || this.props.hasContent }
 										onSave={ this.onSave }
 									/>
 								) : (


### PR DESCRIPTION
Fixes the `EditorStatusLabel` component to display a "New Draft" label instead of "Loading Post..." for new drafts.

If the `post` is `null`, it can mean either that the post is not loaded yet, or that it's a new draft that hasn't been saved yet.

Use the `isEditorNewPost` selector to distinguish between these cases. That's more reliable than `post.modified`, too.

The bug is a regression introduced during the post editor reduxification.

**How to test:**
Start editing a brand new post and check the status label (at different locations on desktop and mobile)

Before fix:
<img width="472" alt="screen shot 2018-05-24 at 14 14 10" src="https://user-images.githubusercontent.com/664258/40485128-f85ddcd0-5f5d-11e8-8b9d-c5394bf1b8e3.png">

After fix:
<img width="473" alt="screen shot 2018-05-24 at 14 15 01" src="https://user-images.githubusercontent.com/664258/40485150-04141454-5f5e-11e8-8700-e3ccc5fbac0c.png">
