### PR TITLE
CommunityTranslator jumpstart & launcher: reduxify userSettings

### DIFF
--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 .community-translator {
 	position: fixed;
 	bottom: 66px;
@@ -7,7 +9,7 @@
 	cursor: pointer;
 	padding: 4px;
 	font-size: 13px;
-	z-index: z-index( 'root', '.community-translator' );
+	z-index: z-index('root', '.community-translator');
 
 	&.is-active {
 		background: $orange-jazzy;
@@ -20,6 +22,7 @@
 	text-decoration: none;
 	outline: 0;
 	display: flex;
+	cursor: pointer;
 
 	&:hover {
 		color: $white;
@@ -46,7 +49,7 @@ body {
 		padding: 0;
 		text-align: inherit;
 		border-color: $gray-lighten-20;
-		z-index: z-index( 'root', 'body .webui-popover' ); // Appear above dialog
+		z-index: z-index('root', 'body .webui-popover'); // Appear above dialog
 
 		.webui-popover-title {
 			background-color: $gray-lighten-20;


### PR DESCRIPTION
This PR is part of #24162 as it removes `lib/user-settings` from `client/layout/community-translator/launcher.jsx` and `client/lib/translator-jumpstart/index.js`.

**Details:**

1. Refactors `translator.init` to accept argument: `isUserSettingsReady` in replacement of `userSettings.getSettings()`
2. Refactors `trackTranslatorStatus` to accept argument: `isTranslatorEnabled` in replacement of `userSettings.getOriginalSetting( 'enable_translator' )`
3. Connects `launcher` to the global state tree, and passes `userSettings` state values to `translator` as stated above on each render
4. Removes `lib/user-settings` event registrations from `layout/community-translator/launcher.jsx` and `lib/translator-jumpstart/index.js`
5. Modifies some JSX tags in launcher to meet a11y requirements and to pass eslint check

**How to test:**

1. Make sure "Enable the in-page translator where available" is checked in account settings: http://calypso.localhost:3000/me/account. (The "Interface Language" must not be "English" for this check box to appear)
2. Open any Calypso page with the browser and confirm that the Community Translator button appears at the bottom right corner.
3. Click on the button and confirm that the translator is enabled.
4. Click on the button again and confirm that the translator is disabled.
5. Open http://calypso.localhost:3000/me/account and uncheck "Enable the in-page translator where available."
6. Open any Calypso page and confirm that the Community Translator button does not appear.

