### PR TITLE
Jetpack Connect: Use DocumentHead instead of setTitle() in plans

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -6,7 +6,6 @@ import React from 'react';
 import Debug from 'debug';
 import page from 'page';
 import { get, isEmpty, some } from 'lodash';
-import { translate } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -34,7 +33,6 @@ import { login } from 'lib/paths';
 import { parseAuthorizationQuery } from './utils';
 import { persistMobileRedirect, retrieveMobileRedirect, storePlan } from './persistence-utils';
 import { receiveJetpackOnboardingCredentials } from 'state/jetpack/onboarding/actions';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { startAuthorizeStep } from 'state/jetpack-connect/actions';
 import { urlToSlug } from 'lib/url';
 import {
@@ -256,8 +254,6 @@ export function plansLanding( context, next ) {
 
 	removeSidebar( context );
 
-	context.store.dispatch( setTitle( translate( 'Plans', { textOnly: true } ) ) );
-
 	analytics.tracks.recordEvent( 'calypso_plans_view' );
 	analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
 
@@ -278,9 +274,6 @@ export function plansSelection( context, next ) {
 	const analyticsBasePath = basePath + '/:site';
 
 	removeSidebar( context );
-
-	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( translate( 'Plans', { textOnly: true } ) ) );
 
 	analytics.tracks.recordEvent( 'calypso_plans_view' );
 	analytics.pageView.record( analyticsBasePath, analyticsPageTitle );

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { addQueryArgs } from 'lib/route';
+import DocumentHead from 'components/data/document-head';
 import HelpButton from './help-button';
 import JetpackConnectHappychatButton from './happychat-button';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
@@ -90,7 +91,7 @@ class PlansLanding extends Component {
 	};
 
 	render() {
-		const { interval, requestingSites, site, url } = this.props;
+		const { interval, requestingSites, site, translate, url } = this.props;
 
 		// We're redirecting in componentDidMount if the site is already connected
 		// so don't bother rendering any markup if this is the case
@@ -100,6 +101,7 @@ class PlansLanding extends Component {
 
 		return (
 			<div>
+				<DocumentHead title={ translate( 'Plans' ) } />
 				<QueryPlans />
 
 				<PlansGrid

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import DocumentHead from 'components/data/document-head';
 import HelpButton from './help-button';
 import JetpackConnectHappychatButton from './happychat-button';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
@@ -204,6 +205,7 @@ class Plans extends Component {
 
 		return (
 			<Fragment>
+				<DocumentHead title={ translate( 'Plans' ) } />
 				<QueryPlans />
 				{ selectedSite && <QuerySitePlans siteId={ selectedSite.ID } /> }
 				<PlansGrid

--- a/client/jetpack-connect/test/__snapshots__/plans.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/plans.js.snap
@@ -9,6 +9,9 @@ exports[`Plans should render placeholder when shouldShowPlaceholder is true 1`] 
 
 exports[`Plans should render plans 1`] = `
 <React.Fragment>
+  <Connect(DocumentHead)
+    title="Plans"
+  />
   <Connect(QueryPlans) />
   <Connect(QuerySitePlans)
     siteId={1234567}


### PR DESCRIPTION
This PR updates the last usages of the legacy `setTitle()` in Jetpack Connect to use `<DocumentHead />`. They were in the `<Plans />` and `<PlansLanding />` components. There should be no behavioral or functional changes coming from this PR.

To test:
* Checkout this branch.
* Connect a fresh Jetpack site and reach the plans page.
* Verify the site title is properly set to "Plans" and there are no errors in the console.
* Go to http://calypso.localhost:3000/jetpack/connect/store
* Verify the site title is properly set to "Plans" and there are no errors in the console.