### PR TITLE
Guided Tours: Fix Simple Payments tour minor visual issues

### DIFF
--- a/client/layout/guided-tours/config-elements/step.js
+++ b/client/layout/guided-tours/config-elements/step.js
@@ -62,6 +62,7 @@ export default class Step extends Component {
 		canSkip: PropTypes.bool,
 		wait: PropTypes.func,
 		onTargetDisappear: PropTypes.func,
+		keepRepositioning: PropTypes.bool,
 		children: PropTypes.func.isRequired,
 	};
 
@@ -102,6 +103,7 @@ export default class Step extends Component {
 		this.wait( this.props, this.context ).then( () => {
 			window.addEventListener( 'resize', this.onScrollOrResize );
 			this.watchTarget();
+			this.repositionInterval = setInterval( this.forceReposition, 3000 );
 		} );
 	}
 
@@ -127,7 +129,7 @@ export default class Step extends Component {
 		if ( this.scrollContainer ) {
 			this.scrollContainer.removeEventListener( 'scroll', this.onScrollOrResize );
 		}
-
+		clearInterval( this.repositionInterval );
 		this.unwatchTarget();
 	}
 
@@ -304,6 +306,15 @@ export default class Step extends Component {
 	shouldSkipAnalytics() {
 		return this.lastTransitionTimestamp && Date.now() - this.lastTransitionTimestamp < 500;
 	}
+
+	forceReposition = () => {
+		if ( ! window || ! this.props.keepRepositioning ) {
+			return;
+		}
+		const scrollY = window.scrollY;
+		window.scrollTo( window.scrollX, scrollY + 1 );
+		window.scrollTo( window.scrollX, scrollY );
+	};
 
 	onScrollOrResize = () => {
 		if ( ! this.isUpdatingPosition ) {

--- a/client/layout/guided-tours/config-elements/step.js
+++ b/client/layout/guided-tours/config-elements/step.js
@@ -103,8 +103,10 @@ export default class Step extends Component {
 		this.wait( this.props, this.context ).then( () => {
 			window.addEventListener( 'resize', this.onScrollOrResize );
 			this.watchTarget();
-			this.repositionInterval = setInterval( this.forceReposition, 3000 );
 		} );
+		if ( this.props.keepRepositioning ) {
+			this.repositionInterval = setInterval( this.onScrollOrResize, 3000 );
+		}
 	}
 
 	componentWillReceiveProps( nextProps, nextContext ) {
@@ -119,6 +121,11 @@ export default class Step extends Component {
 			this.setStepPosition( nextProps, shouldScrollTo );
 			this.watchTarget();
 		} );
+		if ( ! nextProps.keepRepositioning ) {
+			clearInterval( this.repositionInterval );
+		} else if ( ! this.repositionInterval ) {
+			this.repositionInterval = setInterval( this.onScrollOrResize, 3000 );
+		}
 	}
 
 	componentWillUnmount() {
@@ -129,8 +136,8 @@ export default class Step extends Component {
 		if ( this.scrollContainer ) {
 			this.scrollContainer.removeEventListener( 'scroll', this.onScrollOrResize );
 		}
-		clearInterval( this.repositionInterval );
 		this.unwatchTarget();
+		clearInterval( this.repositionInterval );
 	}
 
 	/*
@@ -306,15 +313,6 @@ export default class Step extends Component {
 	shouldSkipAnalytics() {
 		return this.lastTransitionTimestamp && Date.now() - this.lastTransitionTimestamp < 500;
 	}
-
-	forceReposition = () => {
-		if ( ! window || ! this.props.keepRepositioning ) {
-			return;
-		}
-		const scrollY = window.scrollY;
-		window.scrollTo( window.scrollX, scrollY + 1 );
-		window.scrollTo( window.scrollX, scrollY );
-	};
 
 	onScrollOrResize = () => {
 		if ( ! this.isUpdatingPosition ) {

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -33,14 +33,9 @@
 		margin-top: -4px;
 	}
 
-	.gridicon[height="16"] {
-		position: relative;
-		top: 2px;
-	}
-
 	.gridicon[height="18"] {
 		position: relative;
-		top: 3px;
+		top: 0;
 	}
 
 	.tours__title {

--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -34,6 +34,11 @@ const handleTargetDisappear = () => {
 	tourFirstStep.style.left = '-9999px';
 };
 
+// IE9+ polyfill for `Element.matches()` used in `DelegatingQuit`
+if ( ! Element.prototype.matches ) {
+	Element.prototype.matches = Element.prototype.msMatchesSelector;
+}
+
 class DelegatingQuit extends Quit {
 	addTargetListener = () => {
 		const { parentTarget } = this.props;

--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -62,7 +62,7 @@ class DelegatingQuit extends Quit {
 
 	onClick = event => {
 		let eventTarget = event.target;
-		while ( eventTarget !== event.currentTarget ) {
+		while ( !! eventTarget && eventTarget !== event.currentTarget ) {
 			if ( eventTarget.matches( this.props.target ) ) {
 				this.props.onClick && this.props.onClick( event );
 				const { quit, tour, tourVersion, step, isLastStep } = this.context;

--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -84,6 +84,7 @@ export const SimplePaymentsEmailTour = makeTour(
 			style={ { animationDelay: '2s', marginTop: '-5px' } }
 			onTargetDisappear={ handleTargetDisappear }
 			when={ sectionHasSidebar }
+			keepRepositioning
 		>
 			{ ( { translate } ) => (
 				<Fragment>

--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -62,6 +62,7 @@ class DelegatingQuit extends Quit {
 
 	onClick = event => {
 		let eventTarget = event.target;
+		// Event delegation
 		while ( !! eventTarget && eventTarget !== event.currentTarget ) {
 			if ( eventTarget.matches( this.props.target ) ) {
 				this.props.onClick && this.props.onClick( event );


### PR DESCRIPTION
Fix issues raised in p9jf6J-qG-p2 (comment-1938)

### First step positioning

The first step of the tour, which targets the **Add (page)** button in the sidebar, might appear before the sidebar is fully loaded.
In my tests, this usually happened for sites on a paid plan but with the domain unclaimed: these sites have a "Free domain available" notice near the top of the sidebar, that loads with a bit of a delay.
When that notice appears, of course the rest of the sidebar items are pushed down, but the tour step, by design, does not reposition accordingly.

My solution is a generalization of what I already did on [another tour](https://github.com/Automattic/wp-calypso/blob/master/client/layout/guided-tours/tours/editor-insert-menu-tour.js#L21).
Extending the `Step` class though is only viable for single-step tours, because as far as I understand, the logic relies on the fact that all steps are instances of `Step` (by replacing the first `Step` with `RepositioningStep`, the following `Step` does not work anymore).

In this case I've added a new `keepRepositioning` prop to the standard `Step` component that, every 3 seconds, forces the step to reposition to its target.

### External link icon

Tours' `Link` components use `ExternalLink` internally.
In the GT stylesheet there are a couple selectors attempting to fix the `ExternalLink`s' `Gridicon`s positions, but for some reasons this make things worse.

I've removed the `.gridicon[height="16"]` rule because it just doesn't happen anywhere, and forced the `top: 0` in `.gridicon[height="18"]`, which correctly fixes the `Gridicon` position.

### Quit on target click

I've added the "quit on target click" logic in #24739, but as it turns out it's a bit flawed, and for the same reason the "continue on target click" logic is potentially flawed as well.

Basically the whole logic assumes that the `target` is always rendered, and doesn't use any event delegation logic.
This PR extends `Quit` into `DelegatingQuit` that, instead of attaching an event listener directly to `target`, it attaches it to a new `parentTarget` prop instead, and then checks if the event target is indeed `target` (or part of it).

## Testing instructions

- Empty the Calypso cache with `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );`.
- Open `/stats/day/{site}?tour=simplePaymentsEmailTour` possibly on a Premium/Business plan with an unclaimed domain.
- Make sure the first step is always positioned to the "Add (page)" button in the sidebar, even if the sidebar changes.
- Click on "Add (page)" and wait for the second step to appear.
- Make sure that the `Gridicon` in the `ExternalLink` is aligned correctly with the link text.
- Switch editor mode (if it loaded in Visual switch it to HTML mode, or vice versa).
- Click on the "Add (+)" button in the editor toolbar and make sure the second step is dismissed for good.