### PR TITLE
Framework: Notice account closures and redirect

### DIFF
--- a/client/lib/wp/browser.js
+++ b/client/lib/wp/browser.js
@@ -16,6 +16,7 @@ import config from 'config';
 import wpcomSupport from 'lib/wp/support';
 import { injectLocalization } from './localization';
 import { injectGuestSandboxTicketHandler } from './handlers/guest-sandbox-ticket';
+import { injectAccountClosedHandler } from './handlers/account-closed-handler';
 import * as oauthToken from 'lib/oauth-token';
 import wpcomXhrWrapper from 'lib/wpcom-xhr-wrapper';
 import wpcomProxyRequest from 'wpcom-proxy-request';
@@ -71,6 +72,8 @@ if ( 'development' === process.env.NODE_ENV ) {
 injectLocalization( wpcom );
 
 injectGuestSandboxTicketHandler( wpcom );
+
+injectAccountClosedHandler( wpcom );
 
 /**
  * Expose `wpcom`

--- a/client/lib/wp/handlers/account-closed-handler.js
+++ b/client/lib/wp/handlers/account-closed-handler.js
@@ -1,11 +1,16 @@
 /** @format */
 
+/**
+ * External Dependencies
+ */
+import { startsWith } from 'lodash';
+
 export function handleAccountClosed( handler ) {
 	return ( params, fn ) =>
 		handler( params, ( err, response ) => {
 			if ( err ) {
 				const { statusCode, message } = err;
-				if ( +statusCode === 400 && message === 'The user account has been closed...' ) {
+				if ( +statusCode === 400 && startsWith( message, 'The user account has been closed' ) ) {
 					require( 'lib/user/utils' ).logout();
 					return;
 				}

--- a/client/lib/wp/handlers/account-closed-handler.js
+++ b/client/lib/wp/handlers/account-closed-handler.js
@@ -10,7 +10,14 @@ export function handleAccountClosed( handler ) {
 		handler( params, ( err, response ) => {
 			if ( err ) {
 				const { statusCode, message } = err;
-				if ( +statusCode === 400 && startsWith( message, 'The user account has been closed' ) ) {
+				if (
+					( +statusCode === 400 && startsWith( message, 'The user account has been closed' ) ) ||
+					( +statusCode === 403 &&
+						startsWith(
+							message,
+							'An active access token must be used to query information about the current user'
+						) )
+				) {
 					require( 'lib/user/utils' ).default.logout();
 					return;
 				}

--- a/client/lib/wp/handlers/account-closed-handler.js
+++ b/client/lib/wp/handlers/account-closed-handler.js
@@ -2,10 +2,13 @@
 
 export function handleAccountClosed( handler ) {
 	return ( params, fn ) =>
-		handler( params, ( err, response = {} ) => {
-			const { code, message } = response;
-			if ( +code === 400 && message === 'The user account has been closed...' ) {
-				require( 'lib/user/utils' ).logout();
+		handler( params, ( err, response ) => {
+			if ( err ) {
+				const { statusCode, message } = err;
+				if ( +statusCode === 400 && message === 'The user account has been closed...' ) {
+					require( 'lib/user/utils' ).logout();
+					return;
+				}
 			}
 			return fn( err, response );
 		} );
@@ -13,8 +16,6 @@ export function handleAccountClosed( handler ) {
 
 export function injectAccountClosedHandler( wpcom ) {
 	const request = wpcom.request.bind( wpcom );
-	return {
-		...wpcom,
-		request: handleAccountClosed( request ),
-	};
+	wpcom.request = handleAccountClosed( request );
+	return wpcom;
 }

--- a/client/lib/wp/handlers/account-closed-handler.js
+++ b/client/lib/wp/handlers/account-closed-handler.js
@@ -1,0 +1,25 @@
+/** @format */
+
+/**
+ * Internal Dependencies
+ */
+import userUtils from 'lib/user/utils';
+
+export function handleAccountClosed( handler ) {
+	return ( params, fn ) =>
+		handler( params, ( err, response = {} ) => {
+			const { code, message } = response;
+			if ( +code === 400 && message === 'The user account has been closed...' ) {
+				userUtils.logout();
+			}
+			return fn( err, response );
+		} );
+}
+
+export function injectAccountClosedHandler( wpcom ) {
+	const request = wpcom.request.bind( wpcom );
+	return {
+		...wpcom,
+		request: handleAccountClosed( request ),
+	};
+}

--- a/client/lib/wp/handlers/account-closed-handler.js
+++ b/client/lib/wp/handlers/account-closed-handler.js
@@ -1,16 +1,11 @@
 /** @format */
 
-/**
- * Internal Dependencies
- */
-import userUtils from 'lib/user/utils';
-
 export function handleAccountClosed( handler ) {
 	return ( params, fn ) =>
 		handler( params, ( err, response = {} ) => {
 			const { code, message } = response;
 			if ( +code === 400 && message === 'The user account has been closed...' ) {
-				userUtils.logout();
+				require( 'lib/user/utils' ).logout();
 			}
 			return fn( err, response );
 		} );

--- a/client/lib/wp/handlers/account-closed-handler.js
+++ b/client/lib/wp/handlers/account-closed-handler.js
@@ -11,7 +11,7 @@ export function handleAccountClosed( handler ) {
 			if ( err ) {
 				const { statusCode, message } = err;
 				if ( +statusCode === 400 && startsWith( message, 'The user account has been closed' ) ) {
-					require( 'lib/user/utils' ).logout();
+					require( 'lib/user/utils' ).default.logout();
 					return;
 				}
 			}

--- a/client/lib/wp/handlers/http-envelope-normalizer.js
+++ b/client/lib/wp/handlers/http-envelope-normalizer.js
@@ -1,5 +1,5 @@
 /**
- * Detect error looking in the reponse data object.
+ * Detect error looking in the response data object.
  *
  *
  * @format

--- a/client/lib/wp/handlers/http-envelope-normalizer.js
+++ b/client/lib/wp/handlers/http-envelope-normalizer.js
@@ -39,8 +39,6 @@ export function requestHandler( handler ) {
 
 export function injectHandler( wpcom ) {
 	const request = wpcom.request.bind( wpcom );
-
-	return Object.assign( wpcom, {
-		request: requestHandler( request ),
-	} );
+	wpcom.request = requestHandler( request );
+	return wpcom;
 }

--- a/client/lib/wpcom-xhr-wrapper/index.js
+++ b/client/lib/wpcom-xhr-wrapper/index.js
@@ -16,7 +16,7 @@ export default function( params, callback ) {
 	return xhr( params, function( error, response, headers ) {
 		if ( error && error.name === 'InvalidTokenError' ) {
 			debug( 'Invalid token error detected, authorisation probably revoked - logging out' );
-			require( 'lib/user/utils' ).logout();
+			require( 'lib/user/utils' ).default.logout();
 		}
 
 		callback( error, response, headers );


### PR DESCRIPTION
This adds a handler to all requests through `lib/wp` to notice when an account has been closed and log the user out.

To test:
< @westi provide test instructions >