### PR TITLE
Bump notifications to 2.1.10.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12503,8 +12503,8 @@
       "dev": true
     },
     "notifications-panel": {
-      "version": "2.1.9",
-      "integrity": "sha512-8bkVfKcMy9b2YNQ52oETkvDDe2tHf8L8xCi4LXVDxUhrjamzfWsHe2UkSFk9Hvau9K4mbtRz5D0KVZhwwUXGow=="
+      "version": "2.1.10",
+      "integrity": "sha512-lGQocN7VDL5aue1SMwLifFe88UT1zqcLJ6v0x+QtL3Ws5yYfLC3sM+qaHVGrRdqFh3GZsc4PG4gzt+oGZgX+7Q=="
     },
     "npm-run-all": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "morgan": "1.2.0",
     "ms": "0.7.1",
     "node-sass": "4.5.3",
-    "notifications-panel": "2.1.9",
+    "notifications-panel": "2.1.10",
     "npm-run-all": "4.0.2",
     "object-path-immutable": "0.5.2",
     "objectpath": "1.2.1",


### PR DESCRIPTION
Bump the `notifications-panel` package to v2.1.10 (a21f8fa).

The only changes since the last version are to [included documentation](https://github.com/Automattic/notifications-panel/commits/master). This release was done mostly as a test drive for new a new server-side deploy process.

**Testing**

1. Switch to this branch.
2. Restart Calypso.
3. Make sure notifications load as expected.