### PR TITLE
Build: Construct node_modules cache from shrinkwrap

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,12 +19,12 @@ jobs:
             mkdir -p $CIRCLE_TEST_REPORTS
 
       - restore_cache:
-          key: v1-{{ .Branch }}-{{ checksum "npm-shrinkwrap.json" }}
+          key: v1-npmdeps-{{ checksum "npm-shrinkwrap.json" }}
 
       - run: npm install
 
       - save_cache:
-          key: v1-{{ .Branch }}-{{ checksum "npm-shrinkwrap.json" }}
+          key: v1-npmdeps-{{ checksum "npm-shrinkwrap.json" }}
           paths:
             - "node_modules"
 


### PR DESCRIPTION
See https://discuss.circleci.com/t/circle-2-0-caching-is-too-limited-to-be-very-useful/11694/2

Our node_module cache today is effectively useless, except for rebuilds. 

This patch alters the cache key to be the checksum of the shrinkwrap, plus a prefix. Builds that share the same shrinkwrap (which is most) will get a cached node_modules. This cuts the npm install time from ~1:40 to ~0:36, saving us just over a minute on most builds on CircleCI.