### PR TITLE
Build: Cache the git checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,15 @@ jobs:
           CIRCLE_TEST_REPORTS: /tmp/test_results
 
     steps:
+      - restore_cache:
+          key: v1-20180524-git
+
       - checkout
+
+      - save_cache:
+          key: v1-20180524-git
+          paths:
+            - ".git"
 
       - run:
           name: Create Directories for Results and Artifacts


### PR DESCRIPTION
Reduce the time spent pulling it down. Drops checkout time from ~25s to ~5s on Circle CI.

Currently we checkout the entire Calypso repo on every build. This patch teaches Circle how to use a cached copy of the repo as a starting point. This reduces the time to checkout by about 5x.

The timestamp in the key is due to how circle does caching. Each key has an immutable value, so once we set it, that's the value forever. Adding a date stamp is a hacky way to scope the cache. We'll need to update the cache key periodically to continue to see the benefit of the cache.

Compare checkout time on https://circleci.com/gh/Automattic/wp-calypso/95402 to https://circleci.com/gh/Automattic/wp-calypso/95401