### PR TITLE
Build: Move to 6 executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   build:
-    parallelism: 4
+    parallelism: 6
     working_directory: ~/wp-calypso
     docker:
       - image: circleci/node:8.11-browsers


### PR DESCRIPTION
We have some more containers available now and we have more files to lint and test than in the past. Add two more executors and see how much times drop.

Carry on from https://github.com/Automattic/wp-calypso/pull/25047 and https://github.com/Automattic/wp-calypso/pull/25046