### PR TITLE
Domains: Enable the GDPR consent management page in production

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -27,6 +27,7 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"domains/cctlds/uk": true,
+		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/kracken-ui/tld-filter": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -28,6 +28,7 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"domains/cctlds/uk": true,
+		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/kracken-ui/tld-filter": true,

--- a/config/production.json
+++ b/config/production.json
@@ -27,6 +27,7 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"domains/cctlds/uk": true,
+		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/kracken-ui/tld-filter": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -30,6 +30,7 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"domains/cctlds/uk": true,
+		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/kracken-ui/tld-filter": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -33,6 +33,7 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"domains/cctlds/uk": true,
+		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/kracken-ui/tld-filter": true,


### PR DESCRIPTION
Enables the `domains/gdpr-consent-page` feature flag on the production env