### PR TITLE
Build: Detect cycles in our module tree

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3337,6 +3337,10 @@
         "safe-buffer": "5.1.2"
       }
     },
+    "circular-dependency-plugin": {
+      "version": "5.0.2",
+      "integrity": "sha512-oC7/DVAyfcY3UWKm0sN/oVoDedQDQiw/vIiAnuTWTpE5s0zWf7l3WY417Xw/Fbi/QbAjctAkxgMiS9P0s3zkmA=="
+    },
     "circular-json": {
       "version": "0.3.3",
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "check-node-version": "2.1.0",
     "chokidar": "2.0.3",
     "chrono-node": "1.3.1",
+    "circular-dependency-plugin": "5.0.2",
     "classnames": "1.1.1",
     "click-outside": "2.0.1",
     "clipboard": "1.5.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ const AssetsWriter = require( './server/bundler/assets-writer' );
 const StatsWriter = require( './server/bundler/stats-writer' );
 const prism = require( 'prismjs' );
 const UglifyJsPlugin = require( 'uglifyjs-webpack-plugin' );
+const CircularDependencyPlugin = require( 'circular-dependency-plugin' );
 
 /**
  * Internal dependencies
@@ -201,6 +202,17 @@ const webpackConfig = {
 		new AssetsWriter( {
 			filename: 'assets.json',
 			path: path.join( __dirname, 'server', 'bundler' ),
+		} ),
+		new CircularDependencyPlugin( {
+			// exclude detection of files based on a RegExp
+			exclude: /node_modules/,
+			// add errors to webpack instead of warnings
+			failOnError: false,
+			// allow import cycles that include an asyncronous import,
+			// e.g. via import(/* webpackMode: "weak" */ './file.js')
+			allowAsyncCycles: false,
+			// set the current working directory for displaying module paths
+			cwd: process.cwd(),
 		} ),
 		shouldEmitStats &&
 			new StatsWriter( {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,7 @@ const bundleEnv = config( 'env' );
 const isDevelopment = bundleEnv !== 'production';
 const shouldMinify = process.env.MINIFY_JS === 'true' || bundleEnv === 'production';
 const shouldEmitStats = process.env.EMIT_STATS === 'true';
+const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
 const codeSplit = config.isEnabled( 'code-splitting' );
 
 /**
@@ -203,17 +204,13 @@ const webpackConfig = {
 			filename: 'assets.json',
 			path: path.join( __dirname, 'server', 'bundler' ),
 		} ),
-		new CircularDependencyPlugin( {
-			// exclude detection of files based on a RegExp
-			exclude: /node_modules/,
-			// add errors to webpack instead of warnings
-			failOnError: false,
-			// allow import cycles that include an asyncronous import,
-			// e.g. via import(/* webpackMode: "weak" */ './file.js')
-			allowAsyncCycles: false,
-			// set the current working directory for displaying module paths
-			cwd: process.cwd(),
-		} ),
+		shouldCheckForCycles &&
+			new CircularDependencyPlugin( {
+				exclude: /node_modules/,
+				failOnError: false,
+				allowAsyncCycles: false,
+				cwd: process.cwd(),
+			} ),
 		shouldEmitStats &&
 			new StatsWriter( {
 				filename: 'stats.json',


### PR DESCRIPTION
Pull in the webpack [circular-dependency-plugin](https://github.com/aackerman/circular-dependency-plugin) and use it to detect module dependency cycles.

We have... so many.

To test, just run a normal webpack build with `npm start` and notice all the warnings about dependency cycles. 

I only have this turned on for the client build, not the server build. Likely we'll want it both places?

![bike-2669639_1280](https://user-images.githubusercontent.com/14350/40512610-65c8001c-5f71-11e8-9895-45b25ffa9f4c.jpg)
