### PR TITLE
Domains: Move TLD filters above featured results

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -361,6 +361,7 @@ class RegisterDomainStep extends React.Component {
 			? getAvailabilityNotice( lastDomainSearched, error, errorData )
 			: {};
 		const showTldFilterBar =
+			( Array.isArray( this.state.searchResults ) || this.state.loadingResults ) &&
 			config.isEnabled( 'domains/kracken-ui/tld-filter' ) &&
 			abtest( 'domainSearchTLDFilterPlacement' ) === 'aboveFeatured';
 		return (

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -111,7 +111,7 @@ export default {
 		defaultVariation: 'domainsbot',
 	},
 	domainSearchTLDFilterPlacement: {
-		datestamp: '20180528',
+		datestamp: '20180531',
 		variations: {
 			belowFeatured: 50,
 			aboveFeatured: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -110,4 +110,12 @@ export default {
 		},
 		defaultVariation: 'domainsbot',
 	},
+	domainSearchTLDFilterPlacement: {
+		datestamp: '20180528',
+		variations: {
+			belowFeatured: 50,
+			aboveFeatured: 50,
+		},
+		defaultVariation: 'belowFeatured',
+	},
 };


### PR DESCRIPTION
This creates an A/B test variation in which the TLD filter bar is moved from below the featured suggestions to between the search bar and the featured suggestions.

<img width="992" alt="wordpress_com" src="https://user-images.githubusercontent.com/4044428/40515481-34dce438-5f6a-11e8-9a70-15ae3c5b027f.png">

# Test Instructions
1. Spin up this branch locally and set your A/B group for `domainSearchTLDFilterPlacement` to `aboveFeatured`.
2. Navigate to `/start/domains` and enter a query.
3. Ensure that you can see the TLD filter between the search bar and the featured suggestions.