### PR TITLE
Build: Allow greenkeeper-lockfile to push shrinkwrap updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
 
       - run:
           name: Update the lockfile
-          command: npx greenkeeper-lockfile-update
+          command: CI_PULL_REQUEST='' npx greenkeeper-lockfile-update
 
       - run: NODE_ENV=test npm run build-server
 


### PR DESCRIPTION
By unsetting the CI_PULL_REQUEST env var, we allow greenkeeper-lockfile to push an update to the lockfile. This is the result of us not wanting to turn on builds for all commits and instead limit to PRs.

No great way to test this. Notice in the Circle CI build that the "update lockfile" step bails because this is not a greenkeeper PR, not because this might be a PR.

Follow on from #25001 