### PR TITLE
Build: Ignore babel and jquery for greenkeeper updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -294,5 +294,20 @@
   },
   "optionalDependencies": {
     "fsevents": "1.1.3"
+  },
+  "greenkeeper": {
+    "ignore": [
+    "@babel/cli",
+    "@babel/core",
+    "@babel/plugin-proposal-export-default-from",
+    "@babel/plugin-syntax-jsx",
+    "@babel/plugin-transform-runtime",
+    "@babel/polyfill",
+    "@babel/preset-env",
+    "@babel/preset-react",
+    "@babel/preset-stage-2",
+    "@babel/runtime",
+    "jquery"
+    ]
   }
 }


### PR DESCRIPTION
Babel we need to upgrade as a set, so Greenkeeper isn't that useful.
jQuery we're staying with the old version.

Docs: https://greenkeeper.io/docs.html#ignoring-dependencies