### PR TITLE
Help: update forum search url with /search/ path

### DIFF
--- a/client/me/help/help-search/index.jsx
+++ b/client/me/help/help-search/index.jsx
@@ -103,7 +103,7 @@ class HelpSearch extends React.PureComponent {
 					helpLinks={ this.state.helpLinks.wordpress_forum_links }
 					footer={ this.props.translate( 'See more from Community Forum…' ) }
 					iconTypeDescription="comment"
-					searchLink={ getForumUrl() + '/search.php?search=' + this.state.searchQuery }
+					searchLink={ getForumUrl() + '/search/' + this.state.searchQuery }
 				/>
 				<HelpResults
 					header={ this.props.translate( 'Jetpack Documentation' ) }


### PR DESCRIPTION
After a topic search on the help page, we construct a forum search url for that topic, for which the label is `See more from Community Forum…`.

However, the url, which looks something like this:

https://de.forums.wordpress.com/search.php?search=domains

Redirects to unrelated pages, like this one:

https://de.forums.wordpress.com/topic/searchformphp-ich-mochte-eine-grafik-statt-eines-buttons/

Background: https://github.com/Automattic/wp-calypso/pull/25031#issuecomment-391647094

![may-25-2018 16-03-36](https://user-images.githubusercontent.com/6458278/40528878-c28d5134-6035-11e8-881e-1c6e37d14047.gif)

This PR changes the url format so that the user sees relevant results.

## Testing
1. Visit http://calypso.localhost:3000/help and search for 'domains' or another thrilling term.
2. Check the `See more from Community Forum…` link
3. Change your language to one of the bb-supported locales (`"ar", "de", "el", "en", "es", "fa", "fi", "fr", "he", "id", "it", "ja", "nl", "pt", "pt-br", "ru", "sv", "th", "tl", "tr"`)
4. Repeat 1-2

### Expectations
The `See more from Community Forum…` link should be in the following format:

`https://{lang-slug}.forums.wordpress.com/search/{search-term}`

For example:
https://de.forums.wordpress.com/search/domains

This format should work for all locales, e.g.,
https://ru.forums.wordpress.com/search/host
https://it.forums.wordpress.com/search/host
https://fr.forums.wordpress.com/search/host
https://ar.forums.wordpress.com/search/host
...

## Bonus points
Apply `D13911-code` and test the `topic-closed` issue mentioned by @spen [here](https://github.com/Automattic/wp-calypso/pull/25031#issuecomment-391718747).

🥇 