### PR TITLE
New Kracken domain suggestion engines test V3.2.1

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -56,7 +56,6 @@ import {
 	getDomainsSuggestions,
 	getDomainsSuggestionsError,
 } from 'state/domains/suggestions/selectors';
-
 import {
 	getStrippedDomainBase,
 	getTldWeightOverrides,
@@ -76,6 +75,7 @@ import {
 	recordTransferDomainButtonClick,
 } from 'components/domains/register-domain-step/analytics';
 import Spinner from 'components/spinner';
+import { abtest } from 'lib/abtest';
 
 const debug = debugFactory( 'calypso:domains:register-domain-step' );
 
@@ -90,8 +90,7 @@ const PAGE_SIZE = 10;
 const MAX_PAGES = 3;
 const SUGGESTION_QUANTITY = isPaginationEnabled ? PAGE_SIZE * MAX_PAGES : PAGE_SIZE;
 
-const searchVendor = 'group_1';
-const fetchAlgo = searchVendor + '/v1';
+let searchVendor = 'domainsbot';
 
 let searchQueue = [];
 let searchStackTimer = null;
@@ -829,6 +828,10 @@ class RegisterDomainStep extends React.Component {
 			return;
 		}
 
+		if ( this.props.isSignupStep ) {
+			searchVendor = abtest( 'domainSuggestionKrakenV321' );
+		}
+
 		enqueueSearchStatReport( { query: searchQuery, section: this.props.analyticsSection } );
 
 		this.setState( {
@@ -999,7 +1002,7 @@ class RegisterDomainStep extends React.Component {
 				placeholderQuantity={ PAGE_SIZE }
 				isSignupStep={ this.props.isSignupStep }
 				railcarSeed={ this.state.railcarSeed }
-				fetchAlgo={ fetchAlgo }
+				fetchAlgo={ searchVendor + '/v1' }
 				cart={ this.props.cart }
 			>
 				{ showTldFilterBar && (

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -111,7 +111,7 @@ export default {
 	domainSuggestionKrakenV321: {
 		datestamp: '20180524',
 		variations: {
-			domainsbot: 1,
+			domainsbot: 0,
 			group_1: 10000,
 			group_3: 10000,
 			group_4: 10000,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -108,4 +108,14 @@ export default {
 		},
 		defaultVariation: 'disabled',
 	},
+	domainSuggestionKrakenV321: {
+		datestamp: '20180524',
+		variations: {
+			domainsbot: 1,
+			group_1: 10000,
+			group_3: 10000,
+			group_4: 10000,
+		},
+		defaultVariation: 'domainsbot',
+	},
 };


### PR DESCRIPTION
We'll run this test using the default settings but with the new domain search UI elements. We've included only `group_1`, `group_3` and `group_4`.

Depends on D13916-code

Testing instructions:
Run this branch locally and test that TLD filters and/or exact match filters work as expected using the different groups for `domainSuggestionKrakenV321` abtest