### PR TITLE
Google My Business: Segment Track events by type of site

### DIFF
--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -14,16 +14,15 @@ import Gridicon from 'gridicons';
  */
 import Button from 'components/button';
 import Card from 'components/card';
-import { recordTracksEvent } from 'state/analytics/actions';
-import SectionHeader from 'components/section-header';
-import QueryPreferences from 'components/data/query-preferences';
 import getGoogleMyBusinessStatsNudgeDismissCount from 'state/selectors/get-google-my-business-stats-nudge-dismiss-count';
 import isGoogleMyBusinessStatsNudgeDismissed from 'state/selectors/is-google-my-business-stats-nudge-dismissed';
+import QueryPreferences from 'components/data/query-preferences';
+import SectionHeader from 'components/section-header';
 import { dismissNudge } from './actions';
+import { enhanceWithSiteType, recordTracksEvent, withEnhancers } from 'state/analytics/actions';
 
 class GoogleMyBusinessStatsNudge extends Component {
 	static propTypes = {
-		dismissCount: PropTypes.number.isRequired,
 		isDismissed: PropTypes.bool.isRequired,
 		siteId: PropTypes.number.isRequired,
 		siteSlug: PropTypes.string.isRequired,
@@ -111,7 +110,7 @@ export default connect(
 	} ),
 	{
 		dismissNudge,
-		recordTracksEvent,
+		recordTracksEvent: withEnhancers( recordTracksEvent, enhanceWithSiteType ),
 	},
 	( stateProps, dispatchProps, ownProps ) => {
 		return {
@@ -121,17 +120,14 @@ export default connect(
 			trackNudgeView: () =>
 				dispatchProps.recordTracksEvent( 'calypso_google_my_business_stats_nudge_view', {
 					dismiss_count: stateProps.dismissCount,
-					path: ownProps.path,
 				} ),
 			trackNudgeDismissClick: () =>
 				dispatchProps.recordTracksEvent( 'calypso_google_my_business_stats_nudge_dismiss_icon_click', {
 					dismiss_count: stateProps.dismissCount,
-					path: ownProps.path,
 				} ),
 			trackNudgeStartNowClick: () =>
 				dispatchProps.recordTracksEvent( 'calypso_google_my_business_stats_nudge_start_now_button_click', {
 					dismiss_count: stateProps.dismissCount,
-					path: ownProps.path,
 				} ),
 			dismissNudge,
 		};

--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -23,10 +23,10 @@ import { dismissNudge } from './actions';
 
 class GoogleMyBusinessStatsNudge extends Component {
 	static propTypes = {
-		siteSlug: PropTypes.string.isRequired,
-		siteId: PropTypes.number.isRequired,
-		isDismissed: PropTypes.bool.isRequired,
 		dismissCount: PropTypes.number.isRequired,
+		isDismissed: PropTypes.bool.isRequired,
+		siteId: PropTypes.number.isRequired,
+		siteSlug: PropTypes.string.isRequired,
 		trackNudgeDismissClick: PropTypes.func.isRequired,
 		trackNudgeStartNowClick: PropTypes.func.isRequired,
 		trackNudgeView: PropTypes.func.isRequired,
@@ -35,17 +35,17 @@ class GoogleMyBusinessStatsNudge extends Component {
 
 	componentWillMount() {
 		if ( ! this.props.isDismissed ) {
-			this.props.trackNudgeView( this.props.dismissCount );
+			this.props.trackNudgeView();
 		}
 	}
 
 	onDismissClick = () => {
-		this.props.trackNudgeDismissClick( this.props.dismissCount );
+		this.props.trackNudgeDismissClick();
 		this.props.dismissNudge();
 	};
 
 	onStartNowClick = () => {
-		this.props.trackNudgeStartNowClick( this.props.dismissCount );
+		this.props.trackNudgeStartNowClick();
 	};
 
 	render() {
@@ -56,11 +56,13 @@ class GoogleMyBusinessStatsNudge extends Component {
 		return (
 			<Card className="google-my-business-stats-nudge">
 				<QueryPreferences />
+
 				<Gridicon
 					icon="cross"
 					className="google-my-business-stats-nudge__close-icon"
 					onClick={ this.onDismissClick }
 				/>
+
 				<SectionHeader
 					className="google-my-business-stats-nudge__header"
 					label={ this.props.translate( 'Recommendations from WordPress.com' ) }
@@ -108,18 +110,30 @@ export default connect(
 		dismissCount: getGoogleMyBusinessStatsNudgeDismissCount( state, ownProps.siteId ),
 	} ),
 	{
-		trackNudgeView: dismissCount =>
-			recordTracksEvent( 'calypso_google_my_business_stats_nudge_view', {
-				dismiss_count: dismissCount,
-			} ),
-		trackNudgeDismissClick: dismissCount =>
-			recordTracksEvent( 'calypso_google_my_business_stats_nudge_dismiss_icon_click', {
-				dismiss_count: dismissCount,
-			} ),
-		trackNudgeStartNowClick: dismissCount =>
-			recordTracksEvent( 'calypso_google_my_business_stats_nudge_start_now_button_click', {
-				dismiss_count: dismissCount,
-			} ),
 		dismissNudge,
+		recordTracksEvent,
+	},
+	( stateProps, dispatchProps, ownProps ) => {
+		return {
+			...ownProps,
+			...stateProps,
+			...dispatchProps,
+			trackNudgeView: () =>
+				dispatchProps.recordTracksEvent( 'calypso_google_my_business_stats_nudge_view', {
+					dismiss_count: stateProps.dismissCount,
+					path: ownProps.path,
+				} ),
+			trackNudgeDismissClick: () =>
+				dispatchProps.recordTracksEvent( 'calypso_google_my_business_stats_nudge_dismiss_icon_click', {
+					dismiss_count: stateProps.dismissCount,
+					path: ownProps.path,
+				} ),
+			trackNudgeStartNowClick: () =>
+				dispatchProps.recordTracksEvent( 'calypso_google_my_business_stats_nudge_start_now_button_click', {
+					dismiss_count: stateProps.dismissCount,
+					path: ownProps.path,
+				} ),
+			dismissNudge,
+		};
 	}
 )( localize( GoogleMyBusinessStatsNudge ) );

--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -14,37 +14,35 @@ import Gridicon from 'gridicons';
  */
 import Button from 'components/button';
 import Card from 'components/card';
-import getGoogleMyBusinessStatsNudgeDismissCount from 'state/selectors/get-google-my-business-stats-nudge-dismiss-count';
 import isGoogleMyBusinessStatsNudgeDismissed from 'state/selectors/is-google-my-business-stats-nudge-dismissed';
 import QueryPreferences from 'components/data/query-preferences';
 import SectionHeader from 'components/section-header';
 import { dismissNudge } from './actions';
+import { enhanceWithDismissCount } from 'my-sites/google-my-business/utils';
 import { enhanceWithSiteType, recordTracksEvent, withEnhancers } from 'state/analytics/actions';
 
 class GoogleMyBusinessStatsNudge extends Component {
 	static propTypes = {
 		isDismissed: PropTypes.bool.isRequired,
+		recordTracksEvent: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
 		siteSlug: PropTypes.string.isRequired,
-		trackNudgeDismissClick: PropTypes.func.isRequired,
-		trackNudgeStartNowClick: PropTypes.func.isRequired,
-		trackNudgeView: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 
 	componentWillMount() {
 		if ( ! this.props.isDismissed ) {
-			this.props.trackNudgeView();
+			this.props.recordTracksEvent( 'calypso_google_my_business_stats_nudge_view' );
 		}
 	}
 
 	onDismissClick = () => {
-		this.props.trackNudgeDismissClick();
+		this.props.recordTracksEvent( 'calypso_google_my_business_stats_nudge_dismiss_icon_click' );
 		this.props.dismissNudge();
 	};
 
 	onStartNowClick = () => {
-		this.props.trackNudgeStartNowClick();
+		this.props.recordTracksEvent( 'calypso_google_my_business_stats_nudge_start_now_button_click' );
 	};
 
 	render() {
@@ -106,30 +104,9 @@ class GoogleMyBusinessStatsNudge extends Component {
 export default connect(
 	( state, ownProps ) => ( {
 		isDismissed: isGoogleMyBusinessStatsNudgeDismissed( state, ownProps.siteId ),
-		dismissCount: getGoogleMyBusinessStatsNudgeDismissCount( state, ownProps.siteId ),
 	} ),
 	{
 		dismissNudge,
-		recordTracksEvent: withEnhancers( recordTracksEvent, enhanceWithSiteType ),
-	},
-	( stateProps, dispatchProps, ownProps ) => {
-		return {
-			...ownProps,
-			...stateProps,
-			...dispatchProps,
-			trackNudgeView: () =>
-				dispatchProps.recordTracksEvent( 'calypso_google_my_business_stats_nudge_view', {
-					dismiss_count: stateProps.dismissCount,
-				} ),
-			trackNudgeDismissClick: () =>
-				dispatchProps.recordTracksEvent( 'calypso_google_my_business_stats_nudge_dismiss_icon_click', {
-					dismiss_count: stateProps.dismissCount,
-				} ),
-			trackNudgeStartNowClick: () =>
-				dispatchProps.recordTracksEvent( 'calypso_google_my_business_stats_nudge_start_now_button_click', {
-					dismiss_count: stateProps.dismissCount,
-				} ),
-			dismissNudge,
-		};
+		recordTracksEvent: withEnhancers( recordTracksEvent, [ enhanceWithDismissCount, enhanceWithSiteType ] ),
 	}
 )( localize( GoogleMyBusinessStatsNudge ) );

--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -19,7 +19,8 @@ import QueryPreferences from 'components/data/query-preferences';
 import SectionHeader from 'components/section-header';
 import { dismissNudge } from './actions';
 import { enhanceWithDismissCount } from 'my-sites/google-my-business/utils';
-import { enhanceWithSiteType, recordTracksEvent, withEnhancers } from 'state/analytics/actions';
+import { enhanceWithSiteType, recordTracksEvent } from 'state/analytics/actions';
+import { withEnhancers } from 'state/utils';
 
 class GoogleMyBusinessStatsNudge extends Component {
 	static propTypes = {

--- a/client/my-sites/google-my-business/new-account/index.js
+++ b/client/my-sites/google-my-business/new-account/index.js
@@ -23,7 +23,8 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { dismissNudge } from 'blocks/google-my-business-stats-nudge/actions';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { enhanceWithLocationCounts } from 'my-sites/google-my-business/utils';
-import { enhanceWithSiteType, recordTracksEvent, withEnhancers } from 'state/analytics/actions';
+import { enhanceWithSiteType, recordTracksEvent } from 'state/analytics/actions';
+import { withEnhancers } from 'state/utils';
 
 class GoogleMyBusinessNewAccount extends Component {
 	static propTypes = {

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -28,22 +28,19 @@ import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryKeyringConnections from 'components/data/query-keyring-connections';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
+import { enhanceWithLocationCounts } from 'my-sites/google-my-business/utils';
+import { enhanceWithSiteType, recordTracksEvent, withEnhancers } from 'state/analytics/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
-import { recordTracksEventWithLocationCounts } from 'my-sites/google-my-business/utils';
 
 class GoogleMyBusinessSelectBusinessType extends Component {
 	static propTypes = {
 		locations: PropTypes.array.isRequired,
+		recordTracksEvent: PropTypes.func.isRequired,
+		recordTracksEventWithLocationCounts: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
 		siteIsJetpack: PropTypes.bool.isRequired,
 		siteSlug: PropTypes.string,
-		trackConnect: PropTypes.func.isRequired,
-		trackConnectToGoogleMyBusinessClick: PropTypes.func.isRequired,
-		trackCreateListingClick: PropTypes.func.isRequired,
-		trackGoogleMyBusinessClick: PropTypes.func.isRequired,
-		trackLearnMoreAboutSEOClick: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 
@@ -54,7 +51,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 	handleConnect = () => {
 		const { locations, siteSlug } = this.props;
 
-		this.props.trackConnect();
+		this.props.recordTracksEventWithLocationCounts( 'calypso_google_my_business_select_business_type_connect' );
 
 		if ( locations.length === 0 ) {
 			page.redirect( `/google-my-business/new/${ siteSlug }` );
@@ -64,19 +61,27 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 	};
 
 	trackCreateListingClick = () => {
-		this.props.trackCreateListingClick();
+		this.props.recordTracksEvent(
+			'calypso_google_my_business_select_business_type_create_listing_button_click'
+		);
 	};
 
 	trackConnectToGoogleMyBusinessClick = () => {
-		this.props.trackConnectToGoogleMyBusinessClick();
+		this.props.recordTracksEvent(
+			'calypso_google_my_business_select_business_type_connect_to_google_my_business_button_click'
+		);
 	};
 
 	trackLearnMoreAboutSEOClick = () => {
-		this.props.trackLearnMoreAboutSEOClick();
+		this.props.recordTracksEvent(
+			'calypso_google_my_business_select_business_type_learn_more_about_seo_button_click'
+		);
 	};
 
 	trackGoogleMyBusinessClick = () => {
-		this.props.trackGoogleMyBusinessClick();
+		this.props.recordTracksEvent(
+			'calypso_google_my_business_select_business_type_google_my_business_link_click'
+		);
 	};
 
 	renderLocalBusinessCard() {
@@ -226,38 +231,7 @@ export default connect(
 		};
 	},
 	{
-		recordTracksEvent,
-	},
-	( stateProps, dispatchProps, ownProps ) => {
-		const path = '/google-my-business/select-business-type/:site';
-
-		return {
-			...ownProps,
-			...stateProps,
-			...dispatchProps,
-			trackConnect: () =>
-				recordTracksEventWithLocationCounts(
-					stateProps,
-					dispatchProps,
-					'calypso_google_my_business_select_business_type_connect',
-					path
-				),
-			trackConnectToGoogleMyBusinessClick: () =>
-				dispatchProps.recordTracksEvent( 'calypso_google_my_business_select_business_type_connect_to_google_my_business_button_click', {
-					path,
-				} ),
-			trackCreateListingClick: () =>
-				dispatchProps.recordTracksEvent( 'calypso_google_my_business_select_business_type_create_listing_button_click', {
-					path,
-				} ),
-			trackGoogleMyBusinessClick: () =>
-				dispatchProps.recordTracksEvent( 'calypso_google_my_business_select_business_type_google_my_business_link_click', {
-					path,
-				} ),
-			trackLearnMoreAboutSEOClick: () =>
-				dispatchProps.recordTracksEvent( 'calypso_google_my_business_select_business_type_learn_more_about_seo_button_click', {
-					path,
-				} ),
-		};
+		recordTracksEvent: withEnhancers( recordTracksEvent, enhanceWithSiteType ),
+		recordTracksEventWithLocationCounts: withEnhancers( recordTracksEvent, [ enhanceWithLocationCounts, enhanceWithSiteType ] ),
 	}
 )( localize( GoogleMyBusinessSelectBusinessType ) );

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -29,9 +29,10 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryKeyringConnections from 'components/data/query-keyring-connections';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
 import { enhanceWithLocationCounts } from 'my-sites/google-my-business/utils';
-import { enhanceWithSiteType, recordTracksEvent, withEnhancers } from 'state/analytics/actions';
+import { enhanceWithSiteType, recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
+import { withEnhancers } from 'state/utils';
 
 class GoogleMyBusinessSelectBusinessType extends Component {
 	static propTypes = {

--- a/client/my-sites/google-my-business/select-location/button.js
+++ b/client/my-sites/google-my-business/select-location/button.js
@@ -22,7 +22,7 @@ class GoogleMyBusinessSelectLocationButton extends Component {
 	static propTypes = {
 		connectGoogleMyBusinessLocation: PropTypes.func.isRequired,
 		location: PropTypes.object.isRequired,
-		recordTracksEvent: PropTypes.func.isRequired,
+		trackConnectLocation: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
 		translate: PropTypes.func.isRequired,
 		onSelected: PropTypes.func,
@@ -35,9 +35,7 @@ class GoogleMyBusinessSelectLocationButton extends Component {
 	connectLocation = () => {
 		const { location, onSelected, siteId } = this.props;
 
-		this.props.recordTracksEvent(
-			'calypso_google_my_business_select_location_connect_location_button_click'
-		);
+		this.props.trackConnectLocation();
 
 		this.props
 			.connectGoogleMyBusinessLocation( siteId, location.keyringConnectionId, location.ID )
@@ -77,5 +75,14 @@ export default connect(
 	{
 		connectGoogleMyBusinessLocation,
 		recordTracksEvent,
-	}
+	},
+	( stateProps, dispatchProps, ownProps ) => ( {
+		...ownProps,
+		...stateProps,
+		...dispatchProps,
+		trackConnectLocation: () =>
+			dispatchProps.recordTracksEvent( 'calypso_google_my_business_select_location_connect_location_button_click', {
+				path: '/google-my-business/select-location/:site'
+			} ),
+	} )
 )( localize( GoogleMyBusinessSelectLocationButton ) );

--- a/client/my-sites/google-my-business/select-location/button.js
+++ b/client/my-sites/google-my-business/select-location/button.js
@@ -16,13 +16,14 @@ import Gridicon from 'gridicons';
 import Button from 'components/button';
 import { connectGoogleMyBusinessLocation } from 'state/google-my-business/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { enhanceWithSiteType, recordTracksEvent, withEnhancers } from 'state/analytics/actions';
+import { enhanceWithLocationCounts } from 'my-sites/google-my-business/utils';
 
 class GoogleMyBusinessSelectLocationButton extends Component {
 	static propTypes = {
 		connectGoogleMyBusinessLocation: PropTypes.func.isRequired,
 		location: PropTypes.object.isRequired,
-		trackConnectLocation: PropTypes.func.isRequired,
+		recordTracksEventWithLocationCounts: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
 		translate: PropTypes.func.isRequired,
 		onSelected: PropTypes.func,
@@ -35,7 +36,9 @@ class GoogleMyBusinessSelectLocationButton extends Component {
 	connectLocation = () => {
 		const { location, onSelected, siteId } = this.props;
 
-		this.props.trackConnectLocation();
+		this.props.recordTracksEventWithLocationCounts(
+			'calypso_google_my_business_select_location_connect_location_button_click'
+		);
 
 		this.props
 			.connectGoogleMyBusinessLocation( siteId, location.keyringConnectionId, location.ID )
@@ -74,15 +77,6 @@ export default connect(
 	} ),
 	{
 		connectGoogleMyBusinessLocation,
-		recordTracksEvent,
-	},
-	( stateProps, dispatchProps, ownProps ) => ( {
-		...ownProps,
-		...stateProps,
-		...dispatchProps,
-		trackConnectLocation: () =>
-			dispatchProps.recordTracksEvent( 'calypso_google_my_business_select_location_connect_location_button_click', {
-				path: '/google-my-business/select-location/:site'
-			} ),
-	} )
+		recordTracksEventWithLocationCounts: withEnhancers( recordTracksEvent, [ enhanceWithLocationCounts, enhanceWithSiteType ] ),
+	}
 )( localize( GoogleMyBusinessSelectLocationButton ) );

--- a/client/my-sites/google-my-business/select-location/button.js
+++ b/client/my-sites/google-my-business/select-location/button.js
@@ -16,8 +16,9 @@ import Gridicon from 'gridicons';
 import Button from 'components/button';
 import { connectGoogleMyBusinessLocation } from 'state/google-my-business/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { enhanceWithSiteType, recordTracksEvent, withEnhancers } from 'state/analytics/actions';
+import { enhanceWithSiteType, recordTracksEvent } from 'state/analytics/actions';
 import { enhanceWithLocationCounts } from 'my-sites/google-my-business/utils';
+import { withEnhancers } from 'state/utils';
 
 class GoogleMyBusinessSelectLocationButton extends Component {
 	static propTypes = {

--- a/client/my-sites/google-my-business/select-location/index.js
+++ b/client/my-sites/google-my-business/select-location/index.js
@@ -28,9 +28,10 @@ import QueryKeyringConnections from 'components/data/query-keyring-connections';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
 import { connectGoogleMyBusinessLocation } from 'state/google-my-business/actions';
 import { enhanceWithLocationCounts } from 'my-sites/google-my-business/utils';
-import { enhanceWithSiteType, recordTracksEvent, withEnhancers } from 'state/analytics/actions';
+import { enhanceWithSiteType, recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
 import { requestKeyringConnections } from 'state/sharing/keyring/actions';
+import { withEnhancers } from 'state/utils';
 
 class GoogleMyBusinessSelectLocation extends Component {
 	static propTypes = {

--- a/client/my-sites/google-my-business/stats/chart.js
+++ b/client/my-sites/google-my-business/stats/chart.js
@@ -86,12 +86,12 @@ class GoogleMyBusinessStatsChart extends Component {
 		dataSeriesInfo: PropTypes.object,
 		description: PropTypes.string,
 		interval: PropTypes.oneOf( [ 'week', 'month', 'quarter' ] ),
-		recordTracksEvent: PropTypes.func.isRequired,
 		renderTooltipForDatanum: PropTypes.func,
 		requestGoogleMyBusinessStats: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
 		statType: PropTypes.string.isRequired,
 		title: PropTypes.string.isRequired,
+		trackIntervalChange: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
@@ -142,13 +142,9 @@ class GoogleMyBusinessStatsChart extends Component {
 	}
 
 	handleIntervalChange = event => {
-		const { interval, statType, siteId } = this.props;
+		const { statType, siteId } = this.props;
 
-		this.props.recordTracksEvent( 'calypso_google_my_business_stats_chart_interval_change', {
-			previous_interval: interval,
-			new_interval: event.target.value,
-			stat_type: statType,
-		} );
+		this.props.trackIntervalChange( event.target.value );
 
 		this.props.changeGoogleMyBusinessStatsInterval( siteId, statType, event.target.value );
 	};
@@ -315,5 +311,17 @@ export default connect(
 		changeGoogleMyBusinessStatsInterval,
 		recordTracksEvent,
 		requestGoogleMyBusinessStats,
-	}
+	},
+	( stateProps, dispatchProps, ownProps ) => ( {
+		...ownProps,
+		...stateProps,
+		...dispatchProps,
+		trackIntervalChange: ( newInterval ) =>
+			dispatchProps.recordTracksEvent( 'calypso_google_my_business_stats_chart_interval_change', {
+				path: '/google-my-business/stats/:site',
+				previous_interval: stateProps.interval,
+				new_interval: newInterval,
+				stat_type: ownProps.statType,
+			} ),
+	} )
 )( localize( GoogleMyBusinessStatsChart ) );

--- a/client/my-sites/google-my-business/stats/chart.js
+++ b/client/my-sites/google-my-business/stats/chart.js
@@ -25,10 +25,11 @@ import PieChartLegendPlaceholder from 'components/pie-chart/legend-placeholder';
 import PieChartPlaceholder from 'components/pie-chart/placeholder';
 import SectionHeader from 'components/section-header';
 import { changeGoogleMyBusinessStatsInterval } from 'state/ui/google-my-business/actions';
-import { enhanceWithSiteType, recordTracksEvent, withEnhancers } from 'state/analytics/actions';
+import { enhanceWithSiteType, recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getStatsInterval } from 'state/ui/google-my-business/selectors';
 import { requestGoogleMyBusinessStats } from 'state/google-my-business/actions';
+import { withEnhancers } from 'state/utils';
 
 function transformData( props ) {
 	const { data } = props;

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -15,30 +15,30 @@ import { get } from 'lodash';
  */
 import Button from 'components/button';
 import DocumentHead from 'components/data/document-head';
+import getGoogleMyBusinessConnectedLocation from 'state/selectors/get-google-my-business-connected-location';
 import GoogleMyBusinessLocation from 'my-sites/google-my-business/location';
 import GoogleMyBusinessStatsChart from 'my-sites/google-my-business/stats/chart';
 import Main from 'components/main';
 import Notice from 'components/notice';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import QueryKeyringConnections from 'components/data/query-keyring-connections';
+import QuerySiteKeyrings from 'components/data/query-site-keyrings';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import StatsNavigation from 'blocks/stats-navigation';
+import { enhanceWithSiteType, recordTracksEvent, withEnhancers } from 'state/analytics/actions';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
-import getGoogleMyBusinessConnectedLocation from 'state/selectors/get-google-my-business-connected-location';
-import QuerySiteKeyrings from 'components/data/query-site-keyrings';
-import QueryKeyringConnections from 'components/data/query-keyring-connections';
 
 class GoogleMyBusinessStats extends Component {
 	static propTypes = {
 		locationData: PropTypes.object,
+		recordTracksEvent: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
 		siteSlug: PropTypes.string,
-		trackUpdateListingClick: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 
 	trackUpdateListingClick = () => {
-		this.props.trackUpdateListingClick();
+		this.props.recordTracksEvent( 'calypso_google_my_business_stats_update_listing_button_click' );
 	};
 
 	searchChartTitleFunc = ( translate, dataTotal ) => {
@@ -219,6 +219,7 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const locationData = getGoogleMyBusinessConnectedLocation( state, siteId );
 		const isLocationVerified = get( locationData, 'meta.state.isVerified', false );
+
 		return {
 			isLocationVerified,
 			locationData,
@@ -227,15 +228,6 @@ export default connect(
 		};
 	},
 	{
-		recordTracksEvent,
-	},
-	( stateProps, dispatchProps, ownProps ) => ( {
-		...ownProps,
-		...stateProps,
-		...dispatchProps,
-		trackUpdateListingClick: () =>
-			dispatchProps.recordTracksEvent( 'calypso_google_my_business_stats_update_listing_button_click', {
-				path: '/google-my-business/stats/:site'
-			} ),
-	} )
+		recordTracksEvent: withEnhancers( recordTracksEvent, enhanceWithSiteType ),
+	}
 )( localize( GoogleMyBusinessStats ) );

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -31,14 +31,14 @@ import QueryKeyringConnections from 'components/data/query-keyring-connections';
 class GoogleMyBusinessStats extends Component {
 	static propTypes = {
 		locationData: PropTypes.object,
-		recordTracksEvent: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
 		siteSlug: PropTypes.string,
+		trackUpdateListingClick: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 
 	trackUpdateListingClick = () => {
-		this.props.recordTracksEvent( 'calypso_google_my_business_stats_update_listing_button_click' );
+		this.props.trackUpdateListingClick();
 	};
 
 	searchChartTitleFunc = ( translate, dataTotal ) => {
@@ -228,5 +228,14 @@ export default connect(
 	},
 	{
 		recordTracksEvent,
-	}
+	},
+	( stateProps, dispatchProps, ownProps ) => ( {
+		...ownProps,
+		...stateProps,
+		...dispatchProps,
+		trackUpdateListingClick: () =>
+			dispatchProps.recordTracksEvent( 'calypso_google_my_business_stats_update_listing_button_click', {
+				path: '/google-my-business/stats/:site'
+			} ),
+	} )
 )( localize( GoogleMyBusinessStats ) );

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -25,8 +25,9 @@ import QueryKeyringConnections from 'components/data/query-keyring-connections';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import StatsNavigation from 'blocks/stats-navigation';
-import { enhanceWithSiteType, recordTracksEvent, withEnhancers } from 'state/analytics/actions';
+import { enhanceWithSiteType, recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
+import { withEnhancers } from 'state/utils';
 
 class GoogleMyBusinessStats extends Component {
 	static propTypes = {

--- a/client/my-sites/google-my-business/utils.js
+++ b/client/my-sites/google-my-business/utils.js
@@ -5,18 +5,47 @@
  */
 import { get } from 'lodash';
 
-export function recordTracksEventWithLocationCounts( stateProps, dispatchProps, eventName, path ) {
-	const { locations } = stateProps;
+/**
+ * Internal dependencies
+ */
+import getGoogleMyBusinessLocations from 'state/selectors/get-google-my-business-locations';
+import { ANALYTICS_EVENT_RECORD } from 'state/action-types';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
-	const locationCount = locations.length;
+/**
+ * Enhances any Redux action that aims at recording an analytics event with two additional properties which specify the
+ * number of verified and unverified locations of the Google My Business account currently connected.
+ *
+ * @param {Object} action - Redux action as a plain object
+ * @param {Function} getState - Redux function that can be used to retrieve the current state tree
+ * @returns {Object|null} a set of properties that should be merged into the original Redux action, or null otherwise
+ * @see client/state/analytics/actions/withEnhancers
+ */
+export const enhanceWithLocationCounts = ( action, getState ) => {
+	if ( action.type === ANALYTICS_EVENT_RECORD ) {
+		const siteId = getSelectedSiteId( getState() );
 
-	const verifiedLocationCount = locations.filter( location =>
-		get( location, 'meta.state.isVerified', false )
-	).length;
+		if ( siteId !== null ) {
+			const locations = getGoogleMyBusinessLocations( getState(), siteId );
 
-	dispatchProps.recordTracksEvent( eventName, {
-		location_count: locationCount,
-		path,
-		verified_location_count: verifiedLocationCount,
-	} );
-}
+			const verifiedLocationCount = locations.filter( location =>
+				get( location, 'meta.state.isVerified', false )
+			).length;
+
+			return {
+				meta: {
+					analytics: [ {
+						payload: {
+							properties: {
+								location_count: locations.length,
+								verified_location_count: verifiedLocationCount,
+							}
+						}
+					} ]
+				}
+			};
+		}
+	}
+
+	return null;
+};

--- a/client/my-sites/google-my-business/utils.js
+++ b/client/my-sites/google-my-business/utils.js
@@ -1,0 +1,22 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+export function recordTracksEventWithLocationCounts( stateProps, dispatchProps, eventName, path ) {
+	const { locations } = stateProps;
+
+	const locationCount = locations.length;
+
+	const verifiedLocationCount = locations.filter( location =>
+		get( location, 'meta.state.isVerified', false )
+	).length;
+
+	dispatchProps.recordTracksEvent( eventName, {
+		location_count: locationCount,
+		path,
+		verified_location_count: verifiedLocationCount,
+	} );
+}

--- a/client/my-sites/google-my-business/utils.js
+++ b/client/my-sites/google-my-business/utils.js
@@ -9,8 +9,42 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import getGoogleMyBusinessLocations from 'state/selectors/get-google-my-business-locations';
+import getGoogleMyBusinessStatsNudgeDismissCount from 'state/selectors/get-google-my-business-stats-nudge-dismiss-count';
 import { ANALYTICS_EVENT_RECORD } from 'state/action-types';
 import { getSelectedSiteId } from 'state/ui/selectors';
+
+/**
+ * Enhances any Redux action that aims at recording an analytics event with an additional property which specifies the
+ * number of times the Google My Business nudge has been dismissed by the user on the Stats page.
+ *
+ * @param {Object} action - Redux action as a plain object
+ * @param {Function} getState - Redux function that can be used to retrieve the current state tree
+ * @returns {Object|null} a set of properties that should be merged into the original Redux action, or null otherwise
+ * @see client/state/analytics/actions/withEnhancers
+ */
+export const enhanceWithDismissCount = ( action, getState ) => {
+	if ( action.type === ANALYTICS_EVENT_RECORD ) {
+		const siteId = getSelectedSiteId( getState() );
+
+		if ( siteId !== null ) {
+			const dismissCount = getGoogleMyBusinessStatsNudgeDismissCount( getState(), siteId );
+
+			return {
+				meta: {
+					analytics: [ {
+						payload: {
+							properties: {
+								dismiss_count: dismissCount,
+							}
+						}
+					} ]
+				}
+			};
+		}
+	}
+
+	return null;
+};
 
 /**
  * Enhances any Redux action that aims at recording an analytics event with two additional properties which specify the

--- a/client/my-sites/google-my-business/utils.js
+++ b/client/my-sites/google-my-business/utils.js
@@ -19,7 +19,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
  * @param {Object} action - Redux action as a plain object
  * @param {Function} getState - Redux function that can be used to retrieve the current state tree
  * @returns {Object} the new Redux action
- * @see client/state/analytics/actions/withEnhancers
+ * @see client/state/utils/withEnhancers
  */
 export const enhanceWithDismissCount = ( action, getState ) => {
 	const siteId = getSelectedSiteId( getState() );
@@ -50,7 +50,7 @@ export const enhanceWithDismissCount = ( action, getState ) => {
  * @param {Object} action - Redux action as a plain object
  * @param {Function} getState - Redux function that can be used to retrieve the current state tree
  * @returns {Object} the new Redux action
- * @see client/state/analytics/actions/withEnhancers
+ * @see client/state/utils/withEnhancers
  */
 export const enhanceWithLocationCounts = ( action, getState ) => {
 	const siteId = getSelectedSiteId( getState() );

--- a/client/my-sites/google-my-business/utils.js
+++ b/client/my-sites/google-my-business/utils.js
@@ -3,83 +3,78 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { get, merge } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import getGoogleMyBusinessLocations from 'state/selectors/get-google-my-business-locations';
 import getGoogleMyBusinessStatsNudgeDismissCount from 'state/selectors/get-google-my-business-stats-nudge-dismiss-count';
-import { ANALYTICS_EVENT_RECORD } from 'state/action-types';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
- * Enhances any Redux action that aims at recording an analytics event with an additional property which specifies the
- * number of times the Google My Business nudge has been dismissed by the user on the Stats page.
+ * Enhances any Redux action that denotes the recording of an analytics event with an additional property which
+ * specifies the number of times the Google My Business nudge has been dismissed by the user on the Stats page.
  *
  * @param {Object} action - Redux action as a plain object
  * @param {Function} getState - Redux function that can be used to retrieve the current state tree
- * @returns {Object|null} a set of properties that should be merged into the original Redux action, or null otherwise
+ * @returns {Object} the new Redux action
  * @see client/state/analytics/actions/withEnhancers
  */
 export const enhanceWithDismissCount = ( action, getState ) => {
-	if ( action.type === ANALYTICS_EVENT_RECORD ) {
-		const siteId = getSelectedSiteId( getState() );
+	const siteId = getSelectedSiteId( getState() );
 
-		if ( siteId !== null ) {
-			const dismissCount = getGoogleMyBusinessStatsNudgeDismissCount( getState(), siteId );
+	if ( siteId !== null ) {
+		const dismissCount = getGoogleMyBusinessStatsNudgeDismissCount( getState(), siteId );
 
-			return {
-				meta: {
-					analytics: [ {
-						payload: {
-							properties: {
-								dismiss_count: dismissCount,
-							}
+		return merge( action, {
+			meta: {
+				analytics: [ {
+					payload: {
+						properties: {
+							dismiss_count: dismissCount,
 						}
-					} ]
-				}
-			};
-		}
+					}
+				} ]
+			}
+		} );
 	}
 
-	return null;
+	return action;
 };
 
 /**
- * Enhances any Redux action that aims at recording an analytics event with two additional properties which specify the
- * number of verified and unverified locations of the Google My Business account currently connected.
+ * Enhances any Redux action that denotes the recording of an analytics event with two additional properties which
+ * specify the number of verified and unverified locations of the Google My Business account currently connected.
  *
  * @param {Object} action - Redux action as a plain object
  * @param {Function} getState - Redux function that can be used to retrieve the current state tree
- * @returns {Object|null} a set of properties that should be merged into the original Redux action, or null otherwise
+ * @returns {Object} the new Redux action
  * @see client/state/analytics/actions/withEnhancers
  */
 export const enhanceWithLocationCounts = ( action, getState ) => {
-	if ( action.type === ANALYTICS_EVENT_RECORD ) {
-		const siteId = getSelectedSiteId( getState() );
+	const siteId = getSelectedSiteId( getState() );
 
-		if ( siteId !== null ) {
-			const locations = getGoogleMyBusinessLocations( getState(), siteId );
+	if ( siteId !== null ) {
+		const locations = getGoogleMyBusinessLocations( getState(), siteId );
 
-			const verifiedLocationCount = locations.filter( location =>
-				get( location, 'meta.state.isVerified', false )
-			).length;
+		const verifiedLocationCount = locations.filter( location =>
+			get( location, 'meta.state.isVerified', false )
+		).length;
 
-			return {
-				meta: {
-					analytics: [ {
-						payload: {
-							properties: {
-								location_count: locations.length,
-								verified_location_count: verifiedLocationCount,
-							}
+		return merge( action, {
+			meta: {
+				analytics: [ {
+					payload: {
+						properties: {
+							location_count: locations.length,
+							verified_location_count: verifiedLocationCount,
 						}
-					} ]
-				}
-			};
-		}
+					}
+				} ]
+			}
+		} );
 	}
 
-	return null;
+	return action;
 };

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -133,12 +133,14 @@ class StatsSite extends Component {
 			);
 		}
 
+		const path = `/stats/${ period }/:site`;
+
 		return (
 			<Main wideLayout={ true }>
 				{ siteId && <QuerySiteKeyrings siteId={ siteId } /> }
 				<DocumentHead title={ translate( 'Stats' ) } />
 				<PageViewTracker
-					path={ `/stats/${ period }/:site` }
+					path={ path }
 					title={ `Stats > ${ titlecase( period ) }` }
 				/>
 				<PrivacyPolicyBanner />
@@ -153,7 +155,7 @@ class StatsSite extends Component {
 				<div id="my-stats-content">
 					{ config.isEnabled( 'onboarding-checklist' ) && <ChecklistBanner siteId={ siteId } /> }
 					{ isGoogleMyBusinessStatsNudgeVisible && (
-						<GoogleMyBusinessStatsNudge siteSlug={ slug } siteId={ siteId } />
+						<GoogleMyBusinessStatsNudge siteSlug={ slug } siteId={ siteId } path={ path } />
 					) }
 					<ChartTabs
 						barClick={ this.barClick }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -133,14 +133,12 @@ class StatsSite extends Component {
 			);
 		}
 
-		const path = `/stats/${ period }/:site`;
-
 		return (
 			<Main wideLayout={ true }>
 				{ siteId && <QuerySiteKeyrings siteId={ siteId } /> }
 				<DocumentHead title={ translate( 'Stats' ) } />
 				<PageViewTracker
-					path={ path }
+					path={ `/stats/${ period }/:site` }
 					title={ `Stats > ${ titlecase( period ) }` }
 				/>
 				<PrivacyPolicyBanner />
@@ -155,7 +153,7 @@ class StatsSite extends Component {
 				<div id="my-stats-content">
 					{ config.isEnabled( 'onboarding-checklist' ) && <ChecklistBanner siteId={ siteId } /> }
 					{ isGoogleMyBusinessStatsNudgeVisible && (
-						<GoogleMyBusinessStatsNudge siteSlug={ slug } siteId={ siteId } path={ path } />
+						<GoogleMyBusinessStatsNudge siteSlug={ slug } siteId={ siteId } />
 					) }
 					<ChartTabs
 						barClick={ this.barClick }

--- a/client/state/analytics/actions.js
+++ b/client/state/analytics/actions.js
@@ -165,39 +165,37 @@ export const withEnhancers = ( actionCreator, enhancers ) => ( ...args ) => ( di
 
 	return dispatch( enhancers.reduce(
 		( result, enhancer ) => {
-			return merge( result, enhancer( result, getState ) );
+			return enhancer( result, getState );
 		},
 		action
 	) );
 };
 
 /**
- * Enhances any Redux action that aims at recording an analytics event with an additional property that specifies the
- * type of the current selected site.
+ * Enhances any Redux action that denotes the recording of an analytics event with an additional property which
+ * specifies the type of the current selected site.
  *
  * @param {Object} action - Redux action as a plain object
  * @param {Function} getState - Redux function that can be used to retrieve the current state tree
- * @returns {Object|null} a set of properties that should be merged into the original Redux action, or null otherwise
+ * @returns {Object} the new Redux action
  * @see client/state/analytics/actions/withEnhancers
  */
 export const enhanceWithSiteType = ( action, getState ) => {
-	if ( action.type === ANALYTICS_EVENT_RECORD ) {
-		const site = getSelectedSite( getState() );
+	const site = getSelectedSite( getState() );
 
-		if ( site !== null ) {
-			return {
-				meta: {
-					analytics: [ {
-						payload: {
-							properties: {
-								site_type: site.jetpack ? 'jetpack' : 'wpcom',
-							}
+	if ( site !== null ) {
+		return merge( action, {
+			meta: {
+				analytics: [ {
+					payload: {
+						properties: {
+							site_type: site.jetpack ? 'jetpack' : 'wpcom',
 						}
-					} ]
-				}
-			};
-		}
+					}
+				} ]
+			}
+		} );
 	}
 
-	return null;
+	return action;
 };

--- a/client/state/analytics/actions.js
+++ b/client/state/analytics/actions.js
@@ -149,36 +149,13 @@ export const recordTracksEventWithClientId = withClientId( recordTracksEvent );
 export const recordPageViewWithClientId = withClientId( recordPageView );
 
 /**
- * Dispatches the specified Redux action creator once enhancers have been applied to the result of its call. This
- * function can be seen as an alternative to Redux middlewares with a more focused/local scope.
- */
-export const withEnhancers = ( actionCreator, enhancers ) => ( ...args ) => ( dispatch, getState ) => {
-	const action = actionCreator( ...args );
-
-	if ( typeof action !== 'object' ) {
-		throw new Error( 'withEnhancers only works with an action creator that returns a plain action object' );
-	}
-
-	if ( ! Array.isArray( enhancers ) ) {
-		enhancers = [ enhancers ];
-	}
-
-	return dispatch( enhancers.reduce(
-		( result, enhancer ) => {
-			return enhancer( result, getState );
-		},
-		action
-	) );
-};
-
-/**
  * Enhances any Redux action that denotes the recording of an analytics event with an additional property which
  * specifies the type of the current selected site.
  *
  * @param {Object} action - Redux action as a plain object
  * @param {Function} getState - Redux function that can be used to retrieve the current state tree
  * @returns {Object} the new Redux action
- * @see client/state/analytics/actions/withEnhancers
+ * @see client/state/utils/withEnhancers
  */
 export const enhanceWithSiteType = ( action, getState ) => {
 	const site = getSelectedSite( getState() );

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -197,6 +197,7 @@ export const keyedReducer = ( keyPath, reducer, globalActions = [ SERIALIZE, DES
  * @param  {(Function|Object)} action Action object or thunk
  * @param  {Object}            data   Additional data to include in action
  * @return {(Function|Object)}        Augmented action object or thunk
+ * @see client/state/utils/withEnhancers for a more advanced alternative
  */
 export function extendAction( action, data ) {
 	if ( 'function' !== typeof action ) {
@@ -208,6 +209,35 @@ export function extendAction( action, data ) {
 		return action( newDispatch, getState );
 	};
 }
+
+/**
+ * Dispatches the specified Redux action creator once enhancers have been applied to the result of its call. Enhancers
+ * have access to the state tree and can be used to modify an action, e.g. to add an additional property to an analytics
+ * event.
+ *
+ * @param {Function} actionCreator - Redux action creator function
+ * @param {Function|Array} enhancers - either a single function or a list of functions that can be used to modify a Redux action
+ * @see client/state/analytics/actions/enhanceWithSiteType for an example
+ * @see client/state/extendAction for a simpler alternative
+ */
+export const withEnhancers = ( actionCreator, enhancers ) => ( ...args ) => ( dispatch, getState ) => {
+	const action = actionCreator( ...args );
+
+	if ( typeof action !== 'object' ) {
+		throw new Error( 'withEnhancers only works with an action creator that returns a plain action object' );
+	}
+
+	if ( ! Array.isArray( enhancers ) ) {
+		enhancers = [ enhancers ];
+	}
+
+	return dispatch( enhancers.reduce(
+		( result, enhancer ) => {
+			return enhancer( result, getState );
+		},
+		action
+	) );
+};
 
 function getInitialState( reducer ) {
 	return reducer( undefined, { type: '@@calypso/INIT' } );

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -217,26 +217,31 @@ export function extendAction( action, data ) {
  *
  * @param {Function} actionCreator - Redux action creator function
  * @param {Function|Array} enhancers - either a single function or a list of functions that can be used to modify a Redux action
+ * @returns {Function} enhanced action creator
  * @see client/state/analytics/actions/enhanceWithSiteType for an example
  * @see client/state/extendAction for a simpler alternative
  */
-export const withEnhancers = ( actionCreator, enhancers ) => ( ...args ) => ( dispatch, getState ) => {
+export const withEnhancers = ( actionCreator, enhancers ) => ( ...args ) => (
+	dispatch,
+	getState
+) => {
 	const action = actionCreator( ...args );
 
 	if ( typeof action !== 'object' ) {
-		throw new Error( 'withEnhancers only works with an action creator that returns a plain action object' );
+		throw new Error(
+			'withEnhancers only works with an action creator that returns a plain action object'
+		);
 	}
 
 	if ( ! Array.isArray( enhancers ) ) {
 		enhancers = [ enhancers ];
 	}
 
-	return dispatch( enhancers.reduce(
-		( result, enhancer ) => {
+	return dispatch(
+		enhancers.reduce( ( result, enhancer ) => {
 			return enhancer( result, getState );
-		},
-		action
-	) );
+		}, action )
+	);
 };
 
 function getInitialState( reducer ) {


### PR DESCRIPTION
This pull request introduces a way in our stats to segment users who access Google My Business pages according to the type of their site (i.e. WordPress.com or Jetpack). More specifically, it updates all Track events triggered from those pages with a `site_type` prop using a new `withEnhancers()` helper function that can be employed to modify a Redux action before dispatching it.

This pull request takes advantage of this new helper to remove duplicate code that was used in `handleConnect()` event handlers. It also makes other event handler names more consistent with event sources.
  
#### Testing instructions
 
1. Run `git checkout fix/google-my-business-jetpack-stats` and start your server, or open a [live branch](https://calypso.live/?branch=fix/google-my-business-jetpack-stats)
2. Open the [`Stats` page](http://calypso.localhost:3000/stats) of a WordPress.com site that is eligible to Google My Business
3. Enter `localStorage.setItem( 'debug', 'calypso:analytics:tracks' )` in your browser's console
4. Reload the page, and click the `Start Now` button in the nudge
5. Proceed to the `Stats` page while checking that all actions fire a Tracks event
6. Check that a `dismiss_count` prop is added to events fired by the nudge
7. Check that the `location_count` and `verified_location_count` props are added to events fired by the connection process
8. Check that all Tracks events have a `site_type` prop set to `wpcom`
9. Repeat step #2 to #7 with a Jetpack site this time
10. Check that all Tracks events have a `site_type` prop set to `jetpack`

#### Reviews
 
- [ ] Code
- [ ] Product
