### PR TITLE
Fixing issues with empty help cards from #24998

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -45,7 +45,7 @@ class InlineHelpPopover extends Component {
 		const { selectedResult } = this.props;
 		event.preventDefault();
 
-		if ( 'undefined' != typeof selectedResult ) {
+		if ( 'undefined' !== typeof selectedResult ) {
 			this.openSecondaryView( VIEW_RICH_RESULT );
 		}
 	};

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -4,7 +4,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { noop } from 'lodash';
+import { noop, isUndefined } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -45,7 +45,7 @@ class InlineHelpPopover extends Component {
 		const { selectedResult } = this.props;
 		event.preventDefault();
 
-		if ( 'undefined' !== typeof selectedResult ) {
+		if ( ! isUndefined( selectedResult ) ) {
 			this.openSecondaryView( VIEW_RICH_RESULT );
 		}
 	};

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -42,8 +42,12 @@ class InlineHelpPopover extends Component {
 	};
 
 	openResultView = event => {
+		const { selectedResult } = this.props;
 		event.preventDefault();
-		this.openSecondaryView( VIEW_RICH_RESULT );
+
+		if ( 'undefined' != typeof selectedResult ) {
+			this.openSecondaryView( VIEW_RICH_RESULT );
+		}
 	};
 
 	moreHelpClicked = () => {

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -4,7 +4,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { noop, isUndefined } from 'lodash';
+import { noop, isEmpty } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -45,7 +45,7 @@ class InlineHelpPopover extends Component {
 		const { selectedResult } = this.props;
 		event.preventDefault();
 
-		if ( ! isUndefined( selectedResult ) ) {
+		if ( ! isEmpty( selectedResult ) ) {
 			this.openSecondaryView( VIEW_RICH_RESULT );
 		}
 	};

--- a/client/state/inline-help/reducer.js
+++ b/client/state/inline-help/reducer.js
@@ -41,13 +41,11 @@ export const search = createReducer(
 			} );
 		},
 		[ INLINE_HELP_SEARCH_REQUEST_SUCCESS ]: ( state, action ) => {
-			const results = action.searchResults;
-
 			return Object.assign( {}, state, {
-				selectedResult: results.length ? 0 : -1,
+				selectedResult: -1,
 				items: {
 					...state.items,
-					[ action.searchQuery ]: results,
+					[ action.searchQuery ]: action.searchResults,
 				},
 			} );
 		},

--- a/client/state/inline-help/reducer.js
+++ b/client/state/inline-help/reducer.js
@@ -41,11 +41,13 @@ export const search = createReducer(
 			} );
 		},
 		[ INLINE_HELP_SEARCH_REQUEST_SUCCESS ]: ( state, action ) => {
+			const results = action.searchResults;
+
 			return Object.assign( {}, state, {
-				selectedResult: -1,
+				selectedResult: results.length ? 0 : -1,
 				items: {
 					...state.items,
-					[ action.searchQuery ]: action.searchResults,
+					[ action.searchQuery ]: results,
 				},
 			} );
 		},


### PR DESCRIPTION
In this PR I am attempting to fix the issue reported by @jblz in #24998

The changes are small, but here is what I have changed in order to achieve the result, described in the "What I expected" section of the issue:

1. To actually fix the issue, I added a check in `client/blocks/inline-help/popover.jsx` in order to ensure that the secondary view (the one with the "Read More" button) is not being opened unless there is a selected result.
2. To slighly improve usability, every time new results are being displayed, the first one gets preselected. By doing so in `client/state/inline-help/reducer.js`, users can directly hit the Enter key after a successful search query, without having to use any arrows.

Since this is my first PR for the project and I do not find any tests for the block, I have not created any on my own. Still, I tested various scenarios and could not break anything.

As per the "Contributing to Calypso" guideline, I am pinging @lsinger to review the PR.

Fixes  #24998. 