### PR TITLE
Plugins: show unsupported plugin banner on all plans

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -334,13 +334,9 @@ export class PluginMeta extends Component {
 	}
 
 	maybeDisplayUnsupportedNotice() {
-		const { selectedSite, automatedTransferSite } = this.props;
+		const { selectedSite } = this.props;
 
-		if (
-			selectedSite &&
-			this.isUnsupportedPluginForAT() &&
-			( ! selectedSite.jetpack || automatedTransferSite )
-		) {
+		if ( selectedSite && this.isUnsupportedPluginForAT() ) {
 			return (
 				<Notice
 					text={ this.props.translate(
@@ -616,7 +612,8 @@ export class PluginMeta extends Component {
 					this.props.selectedSite.plan &&
 					! get( this.props.selectedSite, 'jetpack' ) &&
 					! this.hasBusinessPlan() &&
-					! this.isWpcomPreinstalled() && (
+					! this.isWpcomPreinstalled() &&
+					( this.maybeDisplayUnsupportedNotice() || (
 						<div className="plugin-meta__upgrade_nudge">
 							<Banner
 								feature={ FEATURE_UPLOAD_PLUGINS }
@@ -627,7 +624,7 @@ export class PluginMeta extends Component {
 								title={ this.props.translate( 'Upgrade to the Business plan to install plugins.' ) }
 							/>
 						</div>
-					) }
+					) ) }
 
 				{ this.getVersionWarning() }
 				{ this.getUpdateWarning() }


### PR DESCRIPTION
This replaces the Upgrade to Business nudge banner with the Incompatible notice for incompatible plugins for all plans. Currently we only show the Incompatible warning on Business sites.

## Screens

*current* 
<img width="743" alt="wp_fastest_cache_plugin_ _site_title_ _wordpress_com current" src="https://user-images.githubusercontent.com/744755/40566222-8f05d0f4-6024-11e8-9e6c-8f3b321fbc94.png">

*updated*
<img width="730" alt="wp_fastest_cache_plugin_ _site_title_ _wordpress_com" src="https://user-images.githubusercontent.com/744755/40566269-ccd2bcc6-6024-11e8-8cc6-9cc45aed146e.png">

## Testing
- Search for a compatible plugin on a non Business plan site.
- The plugin should display the Upgrade notice
- Search for an Incompatible plugin on a non Business plan site.
- The plugin should only display the Incompatible plugin banner.

 