### PR TITLE
Signup: Improve transitions and fix incorrect props

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -530,10 +530,11 @@ class Signup extends React.Component {
 						/>
 					) }
 				<ReactCSSTransitionGroup
+					component="div"
 					className="signup__steps"
 					transitionName="signup__step"
-					transitionEnterTimeout={ 500 }
-					transitionLeaveTimeout={ 300 }
+					transitionEnterTimeout={ 400 }
+					transitionLeaveTimeout={ 400 }
 				>
 					{ this.currentStep() }
 				</ReactCSSTransitionGroup>

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -576,7 +576,7 @@ class AboutStep extends Component {
 				flowName={ flowName }
 				stepName={ stepName }
 				positionInFlow={ positionInFlow }
-				headerText={ translate( 'Let’s create a site' ) }
+				headerText={ translate( 'Let’s create a site.' ) }
 				subHeaderText={ translate(
 					'Please answer these questions so we can help you make the site you need.'
 				) }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { defer, endsWith, get } from 'lodash';
 import { localize, getLocaleSlug } from 'i18n-calypso';
+import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 
 /**
  * Internal dependencies
@@ -251,6 +252,7 @@ class DomainsStep extends React.Component {
 
 		return (
 			<RegisterDomainStep
+				key="domainForm"
 				path={ this.props.path }
 				initialState={ initialState }
 				onAddDomain={ this.handleAddDomain }
@@ -280,7 +282,7 @@ class DomainsStep extends React.Component {
 				this.props.step && this.props.step.domainForm && this.props.step.domainForm.lastQuery;
 
 		return (
-			<div className="domains__step-section-wrapper">
+			<div className="domains__step-section-wrapper" key="mappingForm">
 				<MapDomainStep
 					initialState={ initialState }
 					path={ this.props.path }
@@ -305,7 +307,7 @@ class DomainsStep extends React.Component {
 			this.props.step && this.props.step.domainForm && this.props.step.domainForm.lastQuery;
 
 		return (
-			<div className="domains__step-section-wrapper">
+			<div className="domains__step-section-wrapper" key="transferForm">
 				<TransferDomainStep
 					analyticsSection="signup"
 					basePath={ this.props.path }
@@ -322,16 +324,19 @@ class DomainsStep extends React.Component {
 		);
 	};
 
-	render() {
-		let content;
+	getSubHeaderText() {
 		const { translate } = this.props;
-		const backUrl = this.props.stepSectionName
-			? getStepUrl( this.props.flowName, this.props.stepName, undefined, getLocaleSlug() )
-			: undefined;
-		let fallbackSubHeaderText = translate(
-			"Enter your site's name, or some key words that describe it - " +
-				"we'll use this to create your new site's address."
-		);
+
+		return 'transfer' === this.props.stepSectionName
+			? translate( 'Use a domain you already own with your new WordPress.com site.' )
+			: translate(
+					"Enter your site's name, or some key words that describe it - " +
+						"we'll use this to create your new site's address."
+				);
+	}
+
+	renderContent() {
+		let content;
 
 		if ( 'mapping' === this.props.stepSectionName ) {
 			content = this.mappingForm();
@@ -339,9 +344,6 @@ class DomainsStep extends React.Component {
 
 		if ( 'transfer' === this.props.stepSectionName ) {
 			content = this.transferForm();
-			fallbackSubHeaderText = translate(
-				'Use a domain you already own with your new WordPress.com site.'
-			);
 		}
 
 		if ( ! this.props.stepSectionName ) {
@@ -359,6 +361,17 @@ class DomainsStep extends React.Component {
 			);
 		}
 
+		return content;
+	}
+
+	render() {
+		const { translate } = this.props;
+		const backUrl = this.props.stepSectionName
+			? getStepUrl( this.props.flowName, this.props.stepName, undefined, getLocaleSlug() )
+			: undefined;
+
+		const fallbackSubHeaderText = this.getSubHeaderText();
+
 		return (
 			<StepWrapper
 				flowName={ this.props.flowName }
@@ -366,10 +379,18 @@ class DomainsStep extends React.Component {
 				backUrl={ backUrl }
 				positionInFlow={ this.props.positionInFlow }
 				signupProgress={ this.props.signupProgress }
-				subHeaderText={ translate( "First up, let's find a domain." ) }
 				fallbackHeaderText={ translate( "Let's give your site an address." ) }
 				fallbackSubHeaderText={ fallbackSubHeaderText }
-				stepContent={ content }
+				stepContent={
+					<ReactCSSTransitionGroup
+						component="div"
+						transitionEnterTimeout={ 200 }
+						transitionLeave={ false }
+						transitionName="domains__step-content"
+					>
+						{ this.renderContent() }
+					</ReactCSSTransitionGroup>
+				}
 			/>
 		);
 	}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -2,3 +2,13 @@
 	margin: 0 auto;
 	max-width: 650px;
 }
+
+.domains__step-content-enter {
+	opacity: 0.01;
+
+	&.domains__step-content-enter-active {
+		opacity: 1;
+		pointer-events: none;
+		transition: opacity 0.2s ease-in-out;
+	}
+}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -5,10 +5,12 @@
 
 .domains__step-content-enter {
 	opacity: 0.01;
+	transform: translate3d( 0, 32px, 0 );
 
 	&.domains__step-content-enter-active {
 		opacity: 1;
 		pointer-events: none;
-		transition: opacity 0.2s ease-in-out;
+		transition: all 0.2s ease-in-out;
+		transform: translate3d( 0, 0, 0 );
 	}
 }


### PR DESCRIPTION
This change mainly consists of adding animated transitions using opacity between domain step modes: the registration form, the mapping form, and the transfer form.

It also includes the following minor tweaks:
1. The About step header now ends with a period, making it consistent with headers for all other steps.
2. It removes an unused subHeaderText property from the StepWrapper in the Domain step.
3. It fixes the incorrect transition timing from the main Signup component. 

# Testing Instructions
1. Spin this up locally or in a live branch.
2. Navigate to `/start`. 
3. Fill out the form and press `Continue`. Ensure that the transitions between steps work as expected.
4. In `/start/domain`, click `Already own a domain?`. Ensure that the page transitions with an opacity animation to the transfer form.
5. In the transfer form, click `manually connect it`. Ensure that the page transitions like step 4 to the mapping form.
6. Press `Back` at the bottom of the page. Ensure that the page transitions like step 4 & 5 to the domain registration form.
7. Enter a query and select any domain name. Ensure that the page transitions as expected like step 3.