### PR TITLE
Post Editor: refactor loading history revision

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -110,7 +110,6 @@ export class PostEditor extends React.Component {
 			selectedText: null,
 			showVerifyEmailDialog: false,
 			showAutosaveDialog: true,
-			isLoadingRevision: false,
 			isTitleFocused: false,
 			showPreview: false,
 			isPostPublishPreview: false,
@@ -424,7 +423,6 @@ export class PostEditor extends React.Component {
 	};
 
 	restoreRevision = revision => {
-		this.setState( { isLoadingRevision: true } );
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		actions.edit( {
 			content: revision.content,
@@ -433,6 +431,9 @@ export class PostEditor extends React.Component {
 			excerpt: revision.excerpt,
 			title: revision.title,
 		} );
+		if ( this.editor ) {
+			this.editor.setEditorContent( revision.content, { initial: true } );
+		}
 	};
 
 	closeAutosaveDialog = () => {
@@ -467,12 +468,8 @@ export class PostEditor extends React.Component {
 			);
 		} else {
 			this.setState( this.getPostEditState(), function() {
-				if ( this.editor && ( didLoad || this.state.isLoadingRevision ) ) {
+				if ( this.editor && didLoad ) {
 					this.editor.setEditorContent( this.state.post.content, { initial: true } );
-				}
-
-				if ( this.state.isLoadingRevision ) {
-					this.setState( { isLoadingRevision: false } );
 				}
 			} );
 		}


### PR DESCRIPTION
Simplifies how the editor content is set after loading a revision from post history. Makes the `onEditedPostChange` lifetime method smaller and removes the `isLoadingRevision` component state.

**How to test:**
Open the post "History" dialog and load one of earlier revisions. Check that the post content in TinyMCE is updated to the expected value.