### PR TITLE
Post Editor: cleanup restoring trashed post

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -401,7 +401,7 @@ export class PostEditor extends React.Component {
 					<EditorNotice { ...this.state.notice } onDismissClick={ this.hideNotice } />
 				</div>
 				{ isTrashed ? (
-					<RestorePostDialog onClose={ this.onClose } onRestore={ this.onSaveTrashed } />
+					<RestorePostDialog onClose={ this.onClose } onRestore={ this.restoreTrashed } />
 				) : null }
 				{ this.state.showVerifyEmailDialog ? (
 					<VerifyEmailDialog onClose={ this.closeVerifyEmailDialog } />
@@ -417,6 +417,10 @@ export class PostEditor extends React.Component {
 			</div>
 		);
 	}
+
+	restoreTrashed = () => {
+		this.onSave( 'draft' );
+	};
 
 	restoreAutosave = () => {
 		this.setState( { showAutosaveDialog: false } );
@@ -622,10 +626,6 @@ export class PostEditor extends React.Component {
 		this.props.markSaved();
 
 		page( this.getAllPostsUrl( 'trashed' ) );
-	};
-
-	onSaveTrashed = ( status, callback ) => {
-		this.onSave( status, callback );
 	};
 
 	onSave = ( status, callback ) => {

--- a/client/post-editor/restore-post-dialog.jsx
+++ b/client/post-editor/restore-post-dialog.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop, get } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,22 +26,12 @@ class EditorRestorePostDialog extends Component {
 		onRestore: PropTypes.func,
 		isAutosave: PropTypes.bool,
 		postType: PropTypes.string,
-		canUserDeletePost: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		onClose: noop,
 		onRestore: noop,
 		isAutosave: false,
-	};
-
-	restorePost = () => {
-		const { isAutosave, canUserDeletePost, onRestore } = this.props;
-		if ( isAutosave ) {
-			onRestore();
-		} else if ( canUserDeletePost ) {
-			onRestore( 'draft' );
-		}
 	};
 
 	getStrings = () => {
@@ -76,11 +66,11 @@ class EditorRestorePostDialog extends Component {
 	};
 
 	render() {
-		const { onClose, translate } = this.props;
+		const { onClose, onRestore, translate } = this.props;
 		const strings = this.getStrings();
 
 		const dialogButtons = [
-			<FormButton key="restore" isPrimary={ true } onClick={ this.restorePost }>
+			<FormButton key="restore" isPrimary={ true } onClick={ onRestore }>
 				{ translate( 'Restore' ) }
 			</FormButton>,
 			<FormButton key="back" isPrimary={ false } onClick={ onClose }>
@@ -100,10 +90,6 @@ class EditorRestorePostDialog extends Component {
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const postId = getEditorPostId( state );
-	const capabilities = getEditedPostValue( state, siteId, postId, 'capabilities' );
-
-	return {
-		postType: getEditedPostValue( state, siteId, postId, 'type' ),
-		canUserDeletePost: get( capabilities, 'delete_post' ),
-	};
+	const postType = getEditedPostValue( state, siteId, postId, 'type' );
+	return { postType };
 } )( localize( EditorRestorePostDialog ) );


### PR DESCRIPTION
Refactors the `onRestore` prop to be a simple handler that's always called the same way, whether the action is restoring an autosave or restoring a trashed post.

Checking the `delete_posts` capability is not neccessary: to restore a trashed post, the user needs `edit_posts` and if it was left in the current state, the dialog would be still displayed, but click on "Restore" would do nothing. Clearly bug or broken code.

**How to test:**
Enter edit URL of a trashed post. Verify that a restore is offered in a modal dialog and that it works.
