### PR TITLE
Post Editor: promisify the save and autosave actions

### DIFF
--- a/client/lib/posts/test/mocks/lib/wp.js
+++ b/client/lib/posts/test/mocks/lib/wp.js
@@ -5,9 +5,7 @@ export default {
 	} ),
 	site: () => ( {
 		post: () => ( {
-			add: ( query, attributes, callback ) => {
-				callback( null, attributes );
-			},
+			add: async ( query, attributes ) => attributes,
 		} ),
 	} ),
 };


### PR DESCRIPTION
Promisify the `saveEdited` and `autosave` post editor Flux actions and also the `onSave`, `onPublish` and `autosave` methods of the `PostEditor` components. I.e., instead of accepting a `callback` arg, they return a promise. That will make converting these actions to Redux thunks much easier.

There's a little cleanup of code that opens a post preview. For preview that opens the post in a new tab, we first autosave the post (to ensure the preview will show the latest changes) and only then open a new tab.

For preview that shows a modal with iframe inside Calypso, we trigger autosave and open the preview modal immediately. If we waited for autosave, there would be a confusing and uncomfortable delay between clicking the "Preview" button and opening the modal.

The `EditorPreview` component already watches the `isSaving` flag and shows an empty `about:blank` content while the (auto)save is in progress. And it will update the iframe's `src` after the (auto)save is finished.

I also updated the `lib/posts/actions` tests for the new API. I migrated them to use Jest `expect` APIs -- they have some convenient helpers for testing promise resolved values.

**How to test:**
Verify post save, publish and autosave -- do they work as expected? Try to simulate failed REST API requests, e.g., by going offline in the Network devtool.