### PR TITLE
Domains: Prevent prefilling WHOIS information for Tucows

### DIFF
--- a/client/my-sites/domains/domain-management/edit-contact-info/index.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/index.jsx
@@ -68,15 +68,19 @@ class EditContactInfo extends React.Component {
 			return <PendingWhoisUpdateCard />;
 		}
 
-		if ( ! includes( [ OPENHRS, OPENSRS ], domain.registrar ) && domain.privateDomain ) {
+		const isTucowsDomain = includes( [ OPENHRS, OPENSRS ], domain.registrar );
+		if ( ! isTucowsDomain && domain.privateDomain ) {
 			return <EditContactInfoPrivacyEnabledCard />;
 		}
+
+		// Empty state while Tucows figures out their stuff...
+		const contactInformation = isTucowsDomain ? {} : findRegistrantWhois( this.props.whois.data );
 
 		return (
 			<div>
 				<SectionHeader label={ this.props.translate( 'Edit Contact Info' ) } />
 				<EditContactInfoFormCard
-					contactInformation={ findRegistrantWhois( this.props.whois.data ) }
+					contactInformation={ contactInformation }
 					selectedDomain={ getSelectedDomain( this.props ) }
 					selectedSite={ this.props.selectedSite }
 				/>


### PR DESCRIPTION
Due to GDPR-related changes, the information we're getting from their APIs is masked. So we need to kill the pre-fill for Tucows domains. WWD domains should not be impacted.

### Testing
Go to a custom domain in Domain Management, verify that for Tucows domains the WHOIS form is not pre-filled.
For WWD it should be pre-filled.

Checkout should not be impacted.