### PR TITLE
Notices: Stop neglecting updates to `duration` property

### DIFF
--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -53,6 +53,14 @@ export class Notice extends Component {
 		}
 	}
 
+	componentDidUpdate() {
+		clearTimeout( this.dismissTimeout );
+
+		if ( this.props.duration > 0 ) {
+			this.dismissTimeout = setTimeout( this.props.onDismissClick, this.props.duration );
+		}
+	}
+
 	getIcon() {
 		let icon;
 


### PR DESCRIPTION
Notices in Calypso are linked to each other optionally through
a `noticeId` attribute on the notice data structure. That is,
if we create two or more separate notices with different values
for things like the text string or the status or what not, then
instead of creating two notices the system will collapse them
into one and the newer notice will effectively replace the old one.

When updating the text then the notice will redraw and the text
will update, however, when updating the `duration` which specified
an auto-close behavior for the notice, that duration update won't
be respected.

If we start with a notice of a given id with no duration but then
add one later, if we start with a duration but remove it later, or
if we change a duration, then only the duration property of the first
creation of the notice will have any associated behavior.

See #2711 where the dismissal behavior was brought into the `<Notice />`
component itself.

In this patch I'm going to perform a quick update to the component
simply to fix the bug at hand, but while investigating I determined
that we should probably follow-up here at some point by moving this
behavior out of otherwise-stateless React components and into the
React middleware which is more suited for time-based and other
side-effecting actions.

On component update we automatically clear the timeout and reset it
if need be. We had a choice to make when the component updates but
the `duration` value didn't change: on one hand we may want to keep
the existing timer and might be updating to do something unexpected
like counting down... "3" "2" "1" (disappear). However, that case
seems to be _more_ unexpected than the case when we want to _extend_
the timer and keep the notice showing for longer.

That is, if we send a notification with a twenty second timeout and
then update it to hold another twenty second timeout then I would
expect the notice to remain visible for another twenty seconds, not
to disappear within a few.

**Testing**

Start anywhere in local development or with the `?debug` flag so that
the console dispatcher is active.

Create a notice without a `duration`:
```js
dispatch( { 
	type: 'NOTICE_CREATE',
	notice: {
            noticeId: 'test',
	    status: 'is-info', 
	    text: 'Hello Calypso!'
        }
} )
```

Then, create another of the same id _with_ a `duration`:
```js
dispatch( { 
	type: 'NOTICE_CREATE',
	notice: {
        noticeId: 'test',
		status: 'is-info', 
		text: 'Not wanting to leave?',
 		duration: 1000
	}
} )
```

In **master** the second notice should never disappear even
though we specify the one-second timeout. In **this branch**
however it should disappear as expected.

Verify by testing the separate possible cases:
 - notice without duration, then one with
 - notice with duration, then one without
 - notice with one duration, then one with another

![nondisappearingact mov](https://user-images.githubusercontent.com/5431237/40575051-9dbef506-60d5-11e8-82f3-c9084b84ce2f.gif)
