### PR TITLE
Activity Log: better handling of notices produced by inline plugin update

### DIFF
--- a/client/my-sites/stats/activity-log-tasklist/index.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/index.jsx
@@ -204,7 +204,7 @@ class ActivityLogTasklist extends Component {
 				args: { item: item.name, siteName },
 			} ),
 			{
-				id: item.slug,
+				id: `alitemupdate-${ item.slug }`,
 				showDismiss: false,
 			}
 		);
@@ -260,7 +260,7 @@ class ActivityLogTasklist extends Component {
 					showErrorNotice(
 						translate( 'An error occurred while updating %(item)s on %(siteName)s.', noticeArgs ),
 						{
-							id: slug,
+							id: `alitemupdate-${ slug }`,
 							button: translate( 'Try again' ),
 							onClick: () => this.enqueue( item, 'notice' ),
 						}
@@ -271,7 +271,7 @@ class ActivityLogTasklist extends Component {
 					showSuccessNotice(
 						translate( 'Successfully updated %(item)s in %(siteName)s.', noticeArgs ),
 						{
-							id: slug,
+							id: `alitemupdate-${ slug }`,
 							duration: 3000,
 						}
 					);


### PR DESCRIPTION
Fixes #24823

This removes the notice management through the indexes returned when they were created, and instead manages them through an id, written using a prefix, and the plugin slug. For example:
```
alpluginupdate-hello-world
```

#### Testing

Edit a plugin and downgrade its version.
Go to Activity Log and update it using the inline button found in the plugin update available event.
Only one notice should be displayed after a successful update.