### PR TITLE
Framework: Remove nodemon

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -717,7 +717,7 @@
       "version": "7.0.0-beta.44",
       "integrity": "sha512-G2M4SqLMVJK5y3fs0qgGaBscUmEhAXEY25qNtPBgYsGmdl8k0sdBAf2/4s97iLmhU234DqJYSGa4VS38sau0ig==",
       "requires": {
-        "regenerator-transform": "0.12.3"
+        "regenerator-transform": "0.12.4"
       }
     },
     "@babel/plugin-transform-runtime": {
@@ -3748,41 +3748,6 @@
         }
       }
     },
-    "configstore": {
-      "version": "0.3.2",
-      "integrity": "sha1-JeTBbDdoq/dcWmW8YXYfSVBVtFk=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "3.0.11",
-        "js-yaml": "3.11.0",
-        "mkdirp": "0.5.1",
-        "object-assign": "2.1.1",
-        "osenv": "0.1.5",
-        "user-home": "1.1.1",
-        "uuid": "2.0.3",
-        "xdg-basedir": "1.0.1"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "3.0.11",
-          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-          "dev": true,
-          "requires": {
-            "natives": "1.1.4"
-          }
-        },
-        "object-assign": {
-          "version": "2.1.1",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-          "dev": true
-        },
-        "uuid": {
-          "version": "2.0.3",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-          "dev": true
-        }
-      }
-    },
     "console-browserify": {
       "version": "1.1.0",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
@@ -4197,7 +4162,7 @@
       "version": "1.0.0",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.43"
       }
     },
     "d3-array": {
@@ -5160,8 +5125,8 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.42",
-      "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
+      "version": "0.10.43",
+      "integrity": "sha512-cZd1vezWuTM5qMlasKWqQFioFKwO352nVBzhOTMUf/pKQl5Gcq5EdJzqtSNXKnFQSCJDiQZjCYlYbnzFB657OA==",
       "requires": {
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
@@ -5177,7 +5142,7 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.43",
         "es6-symbol": "3.1.1"
       }
     },
@@ -5187,7 +5152,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.43",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -5205,7 +5170,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.43",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -5216,7 +5181,7 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.43"
       }
     },
     "es6-templates": {
@@ -5233,7 +5198,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.43",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -5752,7 +5717,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.43"
       }
     },
     "event-stream": {
@@ -8600,11 +8565,6 @@
       "version": "0.0.1",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
-    "infinity-agent": {
-      "version": "2.0.3",
-      "integrity": "sha1-ReDi/3qesDCyfWK3SzdEt6esQhY=",
-      "dev": true
-    },
     "inflight": {
       "version": "1.0.6",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
@@ -8923,11 +8883,6 @@
         "xtend": "4.0.1"
       }
     },
-    "is-npm": {
-      "version": "1.0.0",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
-      "dev": true
-    },
     "is-number": {
       "version": "2.1.0",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
@@ -9005,11 +8960,6 @@
     "is-property": {
       "version": "1.0.2",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
-    },
-    "is-redirect": {
-      "version": "1.0.0",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -10853,14 +10803,6 @@
         "is-buffer": "1.1.6"
       }
     },
-    "latest-version": {
-      "version": "1.0.1",
-      "integrity": "sha1-cs/Ebj6NG+ZR4eu1Tqn26pbzdLs=",
-      "dev": true,
-      "requires": {
-        "package-json": "1.2.0"
-      }
-    },
     "lazy-cache": {
       "version": "1.0.4",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
@@ -12033,11 +11975,6 @@
         }
       }
     },
-    "natives": {
-      "version": "1.1.4",
-      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg==",
-      "dev": true
-    },
     "natural-compare": {
       "version": "1.4.0",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
@@ -12112,14 +12049,6 @@
     "neo-async": {
       "version": "1.8.2",
       "integrity": "sha1-MXlYiLed0ENXp8UhE6ZRg+k7ZzU="
-    },
-    "nested-error-stacks": {
-      "version": "1.0.2",
-      "integrity": "sha1-GfYZWRUZ8JZ2mlupqG5u7sgjw88=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.1"
-      }
     },
     "next-tick": {
       "version": "1.0.0",
@@ -12338,73 +12267,6 @@
         "supports-color": {
           "version": "2.0.0",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
-      }
-    },
-    "nodemon": {
-      "version": "1.4.1",
-      "integrity": "sha1-7EDqKOgyYZtr+byTcO3MBilm3ss=",
-      "dev": true,
-      "requires": {
-        "minimatch": "0.3.0",
-        "ps-tree": "0.0.3",
-        "touch": "1.0.0",
-        "update-notifier": "0.3.2"
-      },
-      "dependencies": {
-        "event-stream": {
-          "version": "0.5.3",
-          "integrity": "sha1-t3uTCfcQet3+q2PwwOr9jbC9jBw=",
-          "dev": true,
-          "requires": {
-            "optimist": "0.2.8"
-          }
-        },
-        "lru-cache": {
-          "version": "2.7.3",
-          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "0.3.0",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
-          }
-        },
-        "nopt": {
-          "version": "1.0.10",
-          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-          "dev": true,
-          "requires": {
-            "abbrev": "1.1.1"
-          }
-        },
-        "optimist": {
-          "version": "0.2.8",
-          "integrity": "sha1-6YGrfiaLRXlIWTtVZ0wJmoFcrDE=",
-          "dev": true,
-          "requires": {
-            "wordwrap": "0.0.2"
-          }
-        },
-        "ps-tree": {
-          "version": "0.0.3",
-          "integrity": "sha1-2/jXUqf+Ivp9WGNWiUmWEOknbdw=",
-          "dev": true,
-          "requires": {
-            "event-stream": "0.5.3"
-          }
-        },
-        "touch": {
-          "version": "1.0.0",
-          "integrity": "sha1-RJy+LbrlqMgDjjDXH6D/RklHxN4=",
-          "dev": true,
-          "requires": {
-            "nopt": "1.0.10"
-          }
         }
       }
     },
@@ -12915,44 +12777,6 @@
     "p-try": {
       "version": "1.0.0",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-    },
-    "package-json": {
-      "version": "1.2.0",
-      "integrity": "sha1-yOysCUInzfdqMWh07QXifMk5oOA=",
-      "dev": true,
-      "requires": {
-        "got": "3.3.1",
-        "registry-url": "3.1.0"
-      },
-      "dependencies": {
-        "got": {
-          "version": "3.3.1",
-          "integrity": "sha1-5dDtSvVfw+701WAHdp2YGSvLLso=",
-          "dev": true,
-          "requires": {
-            "duplexify": "3.6.0",
-            "infinity-agent": "2.0.3",
-            "is-redirect": "1.0.0",
-            "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.1",
-            "nested-error-stacks": "1.0.2",
-            "object-assign": "3.0.0",
-            "prepend-http": "1.0.4",
-            "read-all-stream": "3.1.0",
-            "timed-out": "2.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "3.0.0",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-          "dev": true
-        },
-        "timed-out": {
-          "version": "2.0.0",
-          "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo=",
-          "dev": true
-        }
-      }
     },
     "page": {
       "version": "1.6.4",
@@ -13995,29 +13819,6 @@
         "unpipe": "1.0.0"
       }
     },
-    "rc": {
-      "version": "1.2.8",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
-      "requires": {
-        "deep-extend": "0.6.0",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
-      },
-      "dependencies": {
-        "deep-extend": {
-          "version": "0.6.0",
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-          "dev": true
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
     "react": {
       "version": "16.4.0",
       "integrity": "sha512-K0UrkLXSAekf5nJu89obKUM7o2vc6MMN9LYoKnCa+c+8MJRAT120xzPLENcWSRc7GYKIg0LlgJRDorrufdglQQ==",
@@ -15014,15 +14815,6 @@
         }
       }
     },
-    "read-all-stream": {
-      "version": "3.1.0",
-      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "2.0.1",
-        "readable-stream": "2.3.6"
-      }
-    },
     "read-chunk": {
       "version": "2.1.0",
       "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
@@ -15276,8 +15068,8 @@
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regenerator-transform": {
-      "version": "0.12.3",
-      "integrity": "sha512-y2uxO/6u+tVmtEDIKo+tLCtI0GcbQr0OreosKgCd7HP4VypGjtTrw79DezuwT+W5QX0YWuvpeBOgumrepwM1kA==",
+      "version": "0.12.4",
+      "integrity": "sha512-p2I0fY+TbSLD2/VFTFb/ypEHxs3e3AjU0DzttdPqk2bSmDhfSh5E54b86Yc6XhUa5KykK1tgbvZ4Nr82oCJWkQ==",
       "requires": {
         "private": "0.1.8"
       }
@@ -15377,14 +15169,6 @@
         "regjsparser": "0.3.0",
         "unicode-match-property-ecmascript": "1.0.3",
         "unicode-match-property-value-ecmascript": "1.0.1"
-      }
-    },
-    "registry-url": {
-      "version": "3.1.0",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "dev": true,
-      "requires": {
-        "rc": "1.2.8"
       }
     },
     "regjsgen": {
@@ -16692,14 +16476,6 @@
     "semver": {
       "version": "5.1.0",
       "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU="
-    },
-    "semver-diff": {
-      "version": "2.1.0",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "dev": true,
-      "requires": {
-        "semver": "5.1.0"
-      }
     },
     "send": {
       "version": "0.16.2",
@@ -18829,29 +18605,6 @@
       "version": "1.1.0",
       "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw=="
     },
-    "update-notifier": {
-      "version": "0.3.2",
-      "integrity": "sha1-IqhzW6re8zIOLbko9pPaiY3Id3c=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.0.0",
-        "configstore": "0.3.2",
-        "is-npm": "1.0.0",
-        "latest-version": "1.0.1",
-        "semver-diff": "2.1.0",
-        "string-length": "1.0.1"
-      },
-      "dependencies": {
-        "string-length": {
-          "version": "1.0.1",
-          "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
-          "dev": true,
-          "requires": {
-            "strip-ansi": "3.0.1"
-          }
-        }
-      }
-    },
     "upper-case": {
       "version": "1.1.3",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
@@ -19734,7 +19487,7 @@
         "mkdirp": "0.5.1",
         "p-each-series": "1.0.0",
         "p-lazy": "1.0.0",
-        "prettier": "1.13.0",
+        "prettier": "1.13.2",
         "recast": "0.13.2",
         "resolve-cwd": "2.0.0",
         "supports-color": "4.5.0",
@@ -19887,8 +19640,8 @@
           }
         },
         "prettier": {
-          "version": "1.13.0",
-          "integrity": "sha512-ubNahzMwHtdrSVGMMNabOHSeBKvZu+N5Z7Tu2CvbTexffL6aHwwOc7/fvEaWYTtvu4CtXnniHGA2vxV/NIH6KQ=="
+          "version": "1.13.2",
+          "integrity": "sha512-D9oFKkJ7g76fRxkRh9MWBh4j2vbNGO4rtEUJbj46zId5wnm0dwHruoyg4Od9Zqh3WNl0jwxnWSlEGAnl+/thWA=="
         },
         "read-pkg": {
           "version": "2.0.0",
@@ -20527,14 +20280,6 @@
       "version": "0.1.0",
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
       "dev": true
-    },
-    "xdg-basedir": {
-      "version": "1.0.1",
-      "integrity": "sha1-FP+PY6T9vLBdW27qIrNvMDO58E4=",
-      "dev": true,
-      "requires": {
-        "user-home": "1.1.1"
-      }
     },
     "xgettext-js": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -276,7 +276,6 @@
     "md5-file": "3.1.0",
     "mixedindentlint": "1.2.0",
     "nock": "8.0.0",
-    "nodemon": "1.4.1",
     "prettier": "github:Automattic/calypso-prettier#503d7779",
     "pretty-bytes": "4.0.2",
     "react-codemod": "reactjs/react-codemod",


### PR DESCRIPTION
Nodemon was installed because we used to use it to run test-client:watch. Since we moved to jest, we no longer need it.

It also pulls in minimatch@0.3.0 which has some vulnerabilities. Removing it removes those as well and kills a warning on npm install.

To test, validate that we're not using nodemon anywhere in the app. `git grep nodemon` should do the trick.