### PR TITLE
Remove Columns From Google My Business Stats Pages

### DIFF
--- a/client/my-sites/google-my-business/stats/style.scss
+++ b/client/my-sites/google-my-business/stats/style.scss
@@ -1,8 +1,4 @@
 .gmb-stats__metrics {
-	@include breakpoint( '>1040px' ) {
-		column-count: 2;
-		column-gap: 16px;
-	}
 
 	.pie-chart__chart-drawing,
 	.pie-chart__placeholder-drawing {


### PR DESCRIPTION
## Specs

We now have too few cards for the multiple columns on the stat page  to look ok, let's remove it for now.

### Before
<img width="643" alt="screen_shot_2018-05-26_at_12_02_06_pm" src="https://user-images.githubusercontent.com/2810519/40578668-5f5c9b94-60dd-11e8-9fff-ba9ee574e8b2.png">

### After
<img width="635" alt="screen_shot_2018-05-26_at_12_02_52_pm" src="https://user-images.githubusercontent.com/2810519/40578672-6fe6462c-60dd-11e8-9d2c-18cfb42d1675.png">

## Testing
1. Connect GMB Account
2. Navigate to Stats Page
3. Verify columns no longer appear at any reasonable screen width
