### PR TITLE
Google My Business: Add location search block

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -46,6 +46,7 @@
 @import 'blocks/image-editor/style';
 @import 'blocks/inline-help/style';
 @import 'blocks/like-button/style';
+@import 'blocks/location-search/style';
 @import 'blocks/nps-survey/style';
 @import 'blocks/plan-storage/style';
 @import 'blocks/login/style';

--- a/client/blocks/location-search/README.md
+++ b/client/blocks/location-search/README.md
@@ -1,7 +1,7 @@
 LocationSearch
 ===
 
-A search component for searching locations via the Google Places API.
+A search component for searching locations via the [Google Places API](https://cloud.google.com/maps-platform/places/).
 
 ## Usage
 
@@ -17,15 +17,10 @@ export default function AwesomeLocationSearch() {
 
 ### Props
 
-Props are displayed as a table with Name, Type, Default, and Description as headings.
-
-**Required props are marked with `*`.**
-
 Name | Type | Default | Description
 --- | --- | --- | ---
 `onPredictionClick` | `func` | `undefined` | Click handler for a search suggestion
 `predictionHref` | `string` | `undefined` | If provided, renders `a` instead of `button` for a suggestion
-
 
 ## Related components
 

--- a/client/blocks/location-search/README.md
+++ b/client/blocks/location-search/README.md
@@ -8,7 +8,7 @@ A search component for searching locations via the Google Places API.
 ```jsx
 import LocationSearch from 'blocks/location-search';
 
-export default function RockOnButton() {
+export default function AwesomeLocationSearch() {
 	return (
 		<LocationSearch />
 	);

--- a/client/blocks/location-search/README.md
+++ b/client/blocks/location-search/README.md
@@ -1,0 +1,32 @@
+LocationSearch
+===
+
+A search component for searching locations via the Google Places API.
+
+## Usage
+
+```jsx
+import LocationSearch from 'blocks/location-search';
+
+export default function RockOnButton() {
+	return (
+		<LocationSearch />
+	);
+}
+```
+
+### Props
+
+Props are displayed as a table with Name, Type, Default, and Description as headings.
+
+**Required props are marked with `*`.**
+
+Name | Type | Default | Description
+--- | --- | --- | ---
+`onPredictionClick` | `func` | `undefined` | Click handler for a search suggestion
+`predictionHref` | `string` | `undefined` | If provided, renders `a` instead of `button` for a suggestion
+
+
+## Related components
+
+* This component is based on SearchCard that is based on [Search](../design/search) component.

--- a/client/blocks/location-search/README.md
+++ b/client/blocks/location-search/README.md
@@ -20,7 +20,6 @@ export default function AwesomeLocationSearch() {
 Name | Type | Default | Description
 --- | --- | --- | ---
 `onPredictionClick` | `func` | `undefined` | Click handler for a search suggestion
-`predictionHref` | `string` | `undefined` | If provided, renders `a` instead of `button` for a suggestion
 
 ## Related components
 

--- a/client/blocks/location-search/README.md
+++ b/client/blocks/location-search/README.md
@@ -7,11 +7,41 @@ A search component for searching locations via the [Google Places API](https://c
 
 ```jsx
 import LocationSearch from 'blocks/location-search';
+import { createNotice } from 'state/notices/actions'
 
-export default function AwesomeLocationSearch() {
-	return (
-		<LocationSearch />
-	);
+class LocationSearchExample extends Component {
+	static propTypes = {
+		createNotice: PropTypes.func.isRequired,
+	};
+
+	handlePredictionClick = prediction => {
+		this.props.createNotice(
+			'is-info',
+			`You clicked the '${ prediction.structured_formatting.main_text }' location`
+		);
+	};
+
+	predictionTransformer( predictions, query ) {
+		return [
+			{
+				place_id: 'my_special_place',
+				structured_formatting: {
+					main_text: query,
+					secondary_text: 'Create a business with this name',
+				},
+			},
+			...( predictions || [] ),
+		];
+	}
+
+	render() {
+		return (
+			<LocationSearch
+				onPredictionClick={ this.handlePredictionClick }
+				predictionsTransformation={ this.predictionTransformer }
+			/>
+		);
+	}
 }
 ```
 

--- a/client/blocks/location-search/README.md
+++ b/client/blocks/location-search/README.md
@@ -20,6 +20,7 @@ export default function AwesomeLocationSearch() {
 Name | Type | Default | Description
 --- | --- | --- | ---
 `onPredictionClick` | `func` | `undefined` | Click handler for a search suggestion
+`predictionsTransformation` | `func` | `predictions => predictions` | A transformation function that takes `predictions` and `query` and returns predictions, for example if you'd like to add additional virtual predictions. ( see example code )
 
 ## Related components
 

--- a/client/blocks/location-search/README.md
+++ b/client/blocks/location-search/README.md
@@ -7,7 +7,7 @@ A search component for searching locations via the [Google Places API](https://c
 
 ```jsx
 import LocationSearch from 'blocks/location-search';
-import { createNotice } from 'state/notices/actions'
+import { createNotice } from 'state/notices/actions';
 
 class LocationSearchExample extends Component {
 	static propTypes = {
@@ -22,6 +22,10 @@ class LocationSearchExample extends Component {
 	};
 
 	predictionTransformer( predictions, query ) {
+		if ( ! query ) {
+			return predictions;
+		}
+
 		return [
 			{
 				place_id: 'my_special_place',

--- a/client/blocks/location-search/docs/example.jsx
+++ b/client/blocks/location-search/docs/example.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 
 /**

--- a/client/blocks/location-search/docs/example.jsx
+++ b/client/blocks/location-search/docs/example.jsx
@@ -1,0 +1,18 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import LocationSearch from 'blocks/location-search';
+
+const LocationSearchExample = () => <LocationSearch />;
+
+LocationSearchExample.displayName = 'LocationSearch';
+
+export default LocationSearchExample;

--- a/client/blocks/location-search/docs/example.jsx
+++ b/client/blocks/location-search/docs/example.jsx
@@ -14,20 +14,36 @@ import LocationSearch from 'blocks/location-search';
 import { createNotice } from 'state/notices/actions';
 
 class LocationSearchExample extends Component {
-	propTypes = {
+	static propTypes = {
 		createNotice: PropTypes.func.isRequired,
 	};
 
-	handlePredictionClick = ( prediction ) => {
+	handlePredictionClick = prediction => {
 		this.props.createNotice(
 			'is-info',
 			`You clicked the '${ prediction.structured_formatting.main_text }' location`
 		);
 	};
 
+	predictionTransformer( predictions, query ) {
+		return [
+			{
+				place_id: 'my_special_place',
+				structured_formatting: {
+					main_text: query,
+					secondary_text: 'Create a business with this name',
+				},
+			},
+			...( predictions || [] ),
+		];
+	}
+
 	render() {
 		return (
-			<LocationSearch onPredictionClick={ this.handlePredictionClick } />
+			<LocationSearch
+				onPredictionClick={ this.handlePredictionClick }
+				predictionsTransformation={ this.predictionTransformer }
+			/>
 		);
 	}
 }

--- a/client/blocks/location-search/docs/example.jsx
+++ b/client/blocks/location-search/docs/example.jsx
@@ -3,15 +3,35 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import LocationSearch from 'blocks/location-search';
+import { createNotice } from 'state/notices/actions';
 
-const LocationSearchExample = () => <LocationSearch />;
+class LocationSearchExample extends Component {
+	propTypes = {
+		createNotice: PropTypes.func.isRequired,
+	};
 
-LocationSearchExample.displayName = 'LocationSearch';
+	handlePredictionClick = ( prediction ) => {
+		this.props.createNotice(
+			'is-info',
+			`You clicked the '${ prediction.structured_formatting.main_text }' location`
+		);
+	};
 
-export default LocationSearchExample;
+	render() {
+		return (
+			<LocationSearch onPredictionClick={ this.handlePredictionClick } />
+		);
+	}
+}
+
+const ConnectedLocationSearchExample = connect( null, { createNotice } )( LocationSearchExample );
+ConnectedLocationSearchExample.displayName = 'LocationSearch';
+export default ConnectedLocationSearchExample;

--- a/client/blocks/location-search/docs/example.jsx
+++ b/client/blocks/location-search/docs/example.jsx
@@ -26,6 +26,10 @@ class LocationSearchExample extends Component {
 	};
 
 	predictionTransformer( predictions, query ) {
+		if ( ! query ) {
+			return predictions;
+		}
+
 		return [
 			{
 				place_id: 'my_special_place',

--- a/client/blocks/location-search/index.jsx
+++ b/client/blocks/location-search/index.jsx
@@ -85,6 +85,8 @@ class LocationSearch extends Component {
 			<Fragment>
 				<SearchCard
 					onSearch={ this.handleSearch }
+					delaySearch={ true }
+					delayTimeout={ 500 }
 					className="location-search__search-card is-compact"
 				/>
 				{ predictions && predictions.map( this.renderPrediction ) }

--- a/client/blocks/location-search/index.jsx
+++ b/client/blocks/location-search/index.jsx
@@ -6,6 +6,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { loadScript } from 'lib/load-script';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -14,7 +15,6 @@ import CompactCard from 'components/card/compact';
 import SearchCard from 'components/search-card';
 
 let autocompleteService = null;
-const googleMapsKey = 'AIzaSyBO5-y0uPC5DhwrcKy-NHUkLUmFQpNj-1g';
 
 class LocationSearch extends Component {
 	static propTypes = {
@@ -28,7 +28,9 @@ class LocationSearch extends Component {
 		if ( ! autocompleteService ) {
 			autocompleteService = {};
 			loadScript(
-				`//maps.googleapis.com/maps/api/js?key=${ googleMapsKey }&libraries=places`,
+				`//maps.googleapis.com/maps/api/js?key=${ config(
+					'google_maps_api_key'
+				) }&libraries=places`,
 				function() {
 					// eslint-disable-next-line no-undef
 					autocompleteService = new google.maps.places.AutocompleteService();
@@ -47,7 +49,13 @@ class LocationSearch extends Component {
 		} );
 
 		if ( query ) {
-			autocompleteService.getQueryPredictions( { input: query }, this.updatePredictions );
+			autocompleteService.getPlacePredictions(
+				{
+					input: query,
+					types: [ 'establishment' ],
+				},
+				this.updatePredictions
+			);
 		} else {
 			this.updatePredictions( [] );
 		}

--- a/client/blocks/location-search/index.jsx
+++ b/client/blocks/location-search/index.jsx
@@ -1,0 +1,88 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { loadScript } from 'lib/load-script';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import SearchCard from 'components/search-card';
+
+let autocompleteService = null;
+const googleMapsKey = 'AIzaSyBO5-y0uPC5DhwrcKy-NHUkLUmFQpNj-1g';
+
+class LocationSearch extends Component {
+	static propTypes = {
+		onPredictionClick: PropTypes.func,
+		predictionHref: PropTypes.string,
+	};
+
+	state = { predictions: [] };
+
+	componentDidMount() {
+		if ( ! autocompleteService ) {
+			autocompleteService = {};
+			loadScript(
+				`//maps.googleapis.com/maps/api/js?key=${ googleMapsKey }&libraries=places`,
+				function() {
+					// eslint-disable-next-line no-undef
+					autocompleteService = new google.maps.places.AutocompleteService();
+				}
+			);
+		}
+	}
+
+	updatePredictions = predictions => {
+		this.setState( { predictions } );
+	};
+
+	handleSearch = query => {
+		this.setState( {
+			query: query,
+		} );
+
+		if ( query ) {
+			autocompleteService.getQueryPredictions( { input: query }, this.updatePredictions );
+		} else {
+			this.updatePredictions( [] );
+		}
+	};
+
+	renderPrediction = prediction => {
+		const { predictionHref, onPredictionClick } = this.props;
+
+		return (
+			<CompactCard
+				key={ prediction.place_id }
+				href={ predictionHref }
+				onClick={ onPredictionClick }
+				className="location-search__result"
+			>
+				<strong>{ prediction.structured_formatting.main_text }</strong>
+				<br />
+				{ prediction.structured_formatting.secondary_text }
+			</CompactCard>
+		);
+	};
+
+	render() {
+		const { predictions } = this.state;
+
+		return (
+			<Fragment>
+				<SearchCard
+					onSearch={ this.handleSearch }
+					className="location-search__search-card is-compact"
+				/>
+				{ predictions && predictions.map( this.renderPrediction ) }
+			</Fragment>
+		);
+	}
+}
+
+export default LocationSearch;

--- a/client/blocks/location-search/index.jsx
+++ b/client/blocks/location-search/index.jsx
@@ -59,6 +59,8 @@ class LocationSearch extends Component {
 	};
 
 	handleSearch = query => {
+		query = query.trim();
+
 		this.setState( { loading: true, query }, () => {
 			if ( query ) {
 				autocompleteService.getPlacePredictions(

--- a/client/blocks/location-search/index.jsx
+++ b/client/blocks/location-search/index.jsx
@@ -27,7 +27,11 @@ class LocationSearch extends Component {
 		predictionsTransformation: predictions => predictions,
 	};
 
-	state = { predictions: [], loading: false };
+	state = {
+		loading: false,
+		predictions: [],
+		query: '',
+	};
 
 	componentDidMount() {
 		if ( ! autocompleteService ) {
@@ -55,19 +59,20 @@ class LocationSearch extends Component {
 	};
 
 	handleSearch = query => {
-		if ( query ) {
-			this.setState( { loading: true, query } );
-			autocompleteService.getPlacePredictions(
-				{
-					input: query,
-					types: [ 'establishment' ],
-					language: getLocaleSlug(),
-				},
-				this.updatePredictions
-			);
-		} else {
-			this.updatePredictions( [] );
-		}
+		this.setState( { loading: true, query }, () => {
+			if ( query ) {
+				autocompleteService.getPlacePredictions(
+					{
+						input: query,
+						types: [ 'establishment' ],
+						language: getLocaleSlug(),
+					},
+					this.updatePredictions
+				);
+			} else {
+				this.updatePredictions( [] );
+			}
+		} );
 	};
 
 	renderPrediction = prediction => {
@@ -95,6 +100,7 @@ class LocationSearch extends Component {
 					searching={ loading }
 					className="location-search__search-card is-compact"
 				/>
+
 				{ predictions && predictions.map( this.renderPrediction ) }
 			</Fragment>
 		);

--- a/client/blocks/location-search/index.jsx
+++ b/client/blocks/location-search/index.jsx
@@ -7,6 +7,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { loadScript } from 'lib/load-script';
 import config from 'config';
+import { getLocaleSlug } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -60,6 +61,7 @@ class LocationSearch extends Component {
 				{
 					input: query,
 					types: [ 'establishment' ],
+					language: getLocaleSlug(),
 				},
 				this.updatePredictions
 			);

--- a/client/blocks/location-search/index.jsx
+++ b/client/blocks/location-search/index.jsx
@@ -28,7 +28,7 @@ class LocationSearch extends Component {
 			autocompleteService = {}; // if multiple components are initialized on the page, we'd want the script to load only once
 			loadScript(
 				`//maps.googleapis.com/maps/api/js?key=${ config(
-					'google_maps_api_key'
+					'google_places_api_key'
 				) }&libraries=places`,
 				function() {
 					// eslint-disable-next-line no-undef

--- a/client/blocks/location-search/index.jsx
+++ b/client/blocks/location-search/index.jsx
@@ -19,6 +19,11 @@ let autocompleteService = null;
 class LocationSearch extends Component {
 	static propTypes = {
 		onPredictionClick: PropTypes.func,
+		predictionsTransformation: PropTypes.func,
+	};
+
+	static defaultProps = {
+		predictionsTransformation: predictions => predictions,
 	};
 
 	state = { predictions: [], loading: false };
@@ -39,12 +44,18 @@ class LocationSearch extends Component {
 	}
 
 	updatePredictions = predictions => {
-		this.setState( { predictions, loading: false } );
+		const { predictionsTransformation } = this.props;
+		const { query } = this.state;
+
+		this.setState( {
+			predictions: predictionsTransformation( predictions, query ),
+			loading: false,
+		} );
 	};
 
 	handleSearch = query => {
 		if ( query ) {
-			this.setState( { loading: true } );
+			this.setState( { loading: true, query } );
 			autocompleteService.getPlacePredictions(
 				{
 					input: query,

--- a/client/blocks/location-search/prediction.jsx
+++ b/client/blocks/location-search/prediction.jsx
@@ -1,0 +1,38 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+
+export default class Prediction extends Component {
+	static propTypes = {
+		onPredictionClick: PropTypes.func,
+		prediction: PropTypes.object.isRequired,
+	};
+
+	handlePredictionClick = () => {
+		const { onPredictionClick } = this.props;
+		if ( typeof onPredictionClick === 'function' ) {
+			onPredictionClick( this.props.prediction );
+		}
+	};
+
+	render() {
+		const { prediction } = this.props;
+
+		return (
+			<CompactCard onClick={ this.handlePredictionClick }>
+				<strong>{ prediction.structured_formatting.main_text }</strong>
+				<br />
+				{ prediction.structured_formatting.secondary_text }
+			</CompactCard>
+		);
+	}
+}

--- a/client/blocks/location-search/prediction.jsx
+++ b/client/blocks/location-search/prediction.jsx
@@ -5,6 +5,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -14,7 +15,12 @@ import CompactCard from 'components/card/compact';
 export default class Prediction extends Component {
 	static propTypes = {
 		onPredictionClick: PropTypes.func,
-		prediction: PropTypes.object.isRequired,
+		prediction: PropTypes.shape( {
+			structured_formatting: PropTypes.shape( {
+				main_text: PropTypes.string,
+				secondary_text: PropTypes.string,
+			} ).isRequired,
+		} ).isRequired,
 	};
 
 	handlePredictionClick = () => {
@@ -28,10 +34,11 @@ export default class Prediction extends Component {
 		const { prediction } = this.props;
 
 		return (
-			<CompactCard onClick={ this.handlePredictionClick }>
+			<CompactCard className="location-search__prediction" onClick={ this.handlePredictionClick }>
 				<strong>{ prediction.structured_formatting.main_text }</strong>
 				<br />
 				{ prediction.structured_formatting.secondary_text }
+				<Gridicon className="location-search__prediction-icon" icon="chevron-right" />
 			</CompactCard>
 		);
 	}

--- a/client/blocks/location-search/prediction.jsx
+++ b/client/blocks/location-search/prediction.jsx
@@ -17,14 +17,15 @@ export default class Prediction extends Component {
 		onPredictionClick: PropTypes.func,
 		prediction: PropTypes.shape( {
 			structured_formatting: PropTypes.shape( {
-				main_text: PropTypes.string,
-				secondary_text: PropTypes.string,
+				main_text: PropTypes.string.isRequired,
+				secondary_text: PropTypes.string.isRequired,
 			} ).isRequired,
 		} ).isRequired,
 	};
 
 	handlePredictionClick = () => {
 		const { onPredictionClick } = this.props;
+
 		if ( typeof onPredictionClick === 'function' ) {
 			onPredictionClick( this.props.prediction );
 		}

--- a/client/blocks/location-search/style.scss
+++ b/client/blocks/location-search/style.scss
@@ -1,0 +1,14 @@
+.location-search__prediction {
+	cursor: pointer;
+	&:hover {
+		color: lighten( $blue-wordpress, 5% );
+	}
+}
+
+.location-search__prediction-icon {
+	display: block;
+	height: 100%;
+	position: absolute;
+	top: 0;
+	right: 16px;
+}

--- a/client/components/search/README.md
+++ b/client/components/search/README.md
@@ -44,6 +44,9 @@ This value is passed to the autoFocus attribute of the `<input>` element, and de
 ### disabled (optional) bool ( default false )
 This value is passed to the disabled attribute of the `<input>` element, and determines whether or not the input is disabled.
 
+### disableAutocorrect (optional) bool ( default false )
+Sets on input the following attributes: autoComplete: 'off', autoCorrect: 'off', spellCheck: 'false'
+
 ### searching (optional) bool ( default false )
 Whether to display a [`<Spinner />`](../spinner/) in place of the search icon.
 

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -78,6 +78,7 @@ import ReaderImportButton from 'blocks/reader-import-button/docs/example';
 import SharingPreviewPane from 'blocks/sharing-preview-pane/docs/example';
 import ReaderShare from 'blocks/reader-share/docs/example';
 import Login from 'blocks/login/docs/example';
+import LocationSearch from 'blocks/location-search/docs/example';
 import UploadImage from 'blocks/upload-image/docs/example';
 import ConversationCommentList from 'blocks/conversations/docs/example';
 import SimplePaymentsDialog from 'components/tinymce/plugins/simple-payments/dialog/docs/example';
@@ -142,6 +143,7 @@ export default class AppComponents extends React.Component {
 					<VideoEditor readmeFilePath="video-editor" />
 					<LikeButtons readmeFilePath="like-button" />
 					<Login />
+					<LocationSearch readmeFilePath="location-search" />
 					<PostEditButton />
 					<PlanStorage readmeFilePath="plan-storage" />
 					<PostSchedule />

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -191,6 +191,6 @@
 	"wpcom_concierge_schedule_id": 1,
 	"wpcom_signup_id": false,
 	"wpcom_signup_key": false,
-    "statsd_analytics_response_time_max_logs_per_second": 50,
-    "google_maps_api_key": "AIzaSyBO5-y0uPC5DhwrcKy-NHUkLUmFQpNj-1g"
+	"statsd_analytics_response_time_max_logs_per_second": 50,
+	"google_maps_api_key": "AIzaSyBO5-y0uPC5DhwrcKy-NHUkLUmFQpNj-1g"
 }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -191,5 +191,6 @@
 	"wpcom_concierge_schedule_id": 1,
 	"wpcom_signup_id": false,
 	"wpcom_signup_key": false,
-	"statsd_analytics_response_time_max_logs_per_second": 50
+    "statsd_analytics_response_time_max_logs_per_second": 50,
+    "google_maps_api_key": "AIzaSyBO5-y0uPC5DhwrcKy-NHUkLUmFQpNj-1g"
 }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -192,5 +192,5 @@
 	"wpcom_signup_id": false,
 	"wpcom_signup_key": false,
 	"statsd_analytics_response_time_max_logs_per_second": 50,
-	"google_maps_api_key": "AIzaSyBO5-y0uPC5DhwrcKy-NHUkLUmFQpNj-1g"
+	"google_places_api_key": "AIzaSyAznW1ev6zto9Dc6lsrWkrMs5R8xDTFWXs"
 }


### PR DESCRIPTION
This PR is the first step in implementing the search location feature in the Google My Business add location wizard.

![image](https://user-images.githubusercontent.com/326402/40578919-896a2cbc-60e2-11e8-99c1-23f82d160b80.png)

<img width="852" alt="screen shot 2018-05-26 at 12 46 15" src="https://user-images.githubusercontent.com/326402/40578939-e229a062-60e2-11e8-8215-1d977f0e906c.png">

  
#### Testing instructions
  
1. Run `git checkout add/location-search` and start your server, or open a [live branch](https://calypso.live/?branch=add/location-search)
2. Open the [`LocationSearch` docs page](http://calypso.localhost:3000/devdocs/blocks/location-search)
3. Assert it's good
  
#### Reviews
  
- [ ] Code
- [ ] Product