### PR TITLE
Fix Google My Business Connect Event Name

### DIFF
--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -75,7 +75,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 
 	trackConnectToGoogleMyBusinessClick = () => {
 		this.props.recordTracksEvent(
-			'calypso_google_my_business_select_business_type_create_my_listing_button_click'
+			'calypso_google_my_business_select_business_type_connect_to_google_my_business_button_click'
 		);
 	};
 


### PR DESCRIPTION
## Specs

On the Select Business Type Page, the "Connect to Google My Business" button was using the same "Create Your listing" event that the Create Your Listing button was.

## Testing 
1. Clear your test account of any Google My Business connections and accounts
2. Activate tracks event logging ( l`ocalStorage.setItem('debug', 'calypso:analytics:tracks');` )
3. Navigate to the Select Business Page `google-my-business/select-business-type/:site`
4. Click the ` Connected to Google My Business` button
5. Verify that `calypso_google_my_business_select_business_type_connect_to_google_my_business_button_click` event was recorded