### PR TITLE
Domains: Handle disabled .blog domains for UK users

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -68,7 +68,14 @@ class DomainSearchResults extends React.Component {
 			'domain-search-results__domain-not-available': ! availableDomain,
 		} );
 		const suggestions = this.props.suggestions || [];
-		const { MAPPABLE, MAPPED, TLD_NOT_SUPPORTED, TRANSFERRABLE, UNKNOWN } = domainAvailability;
+		const {
+			MAPPABLE,
+			MAPPED,
+			TLD_NOT_SUPPORTED,
+			TLD_NOT_SUPPORTED_TEMPORARILY,
+			TRANSFERRABLE,
+			UNKNOWN,
+		} = domainAvailability;
 
 		const domain = get( availableDomain, 'domain_name', lastDomainSearched );
 
@@ -78,7 +85,14 @@ class DomainSearchResults extends React.Component {
 			domain &&
 			suggestions.length !== 0 &&
 			includes(
-				[ TRANSFERRABLE, MAPPABLE, MAPPED, TLD_NOT_SUPPORTED, UNKNOWN ],
+				[
+					TRANSFERRABLE,
+					MAPPABLE,
+					MAPPED,
+					TLD_NOT_SUPPORTED,
+					TLD_NOT_SUPPORTED_TEMPORARILY,
+					UNKNOWN,
+				],
 				lastDomainStatus
 			) &&
 			this.props.products.domain_map
@@ -107,7 +121,7 @@ class DomainSearchResults extends React.Component {
 				offer = null;
 			}
 
-			const domainUnavailableMessage = includes( [ TLD_NOT_SUPPORTED, UNKNOWN ], lastDomainStatus )
+			let domainUnavailableMessage = includes( [ TLD_NOT_SUPPORTED, UNKNOWN ], lastDomainStatus )
 				? translate( '{{strong}}.%(tld)s{{/strong}} domains are not offered on WordPress.com.', {
 						args: { tld: getTld( domain ) },
 						components: { strong: <strong /> },
@@ -116,6 +130,17 @@ class DomainSearchResults extends React.Component {
 						args: { domain },
 						components: { strong: <strong /> },
 					} );
+
+			if ( TLD_NOT_SUPPORTED_TEMPORARILY === lastDomainStatus ) {
+				domainUnavailableMessage = translate(
+					'{{strong}}.%(tld)s{{/strong}} domains are temporarily not offered on WordPress.com. ' +
+						'Please try again later or choose a different extension.',
+					{
+						args: { tld: getTld( domain ) },
+						components: { strong: <strong /> },
+					}
+				);
+			}
 
 			if ( this.props.offerUnavailableOption ) {
 				if ( this.props.siteDesignType !== DESIGN_TYPE_STORE && lastDomainIsTransferrable ) {

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -436,6 +436,7 @@ class TransferDomainStep extends React.Component {
 							break;
 						case domainAvailability.MAPPABLE:
 						case domainAvailability.TLD_NOT_SUPPORTED:
+						case domainAvailability.TLD_NOT_SUPPORTED_TEMPORARILY:
 							const tld = getTld( domain );
 
 							this.setState( {

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -49,6 +49,7 @@ export const domainAvailability = {
 	REGISTERED_SAME_SITE: 'registered_on_same_site',
 	RESTRICTED: 'restricted_domain',
 	TLD_NOT_SUPPORTED: 'tld_not_supported',
+	TLD_NOT_SUPPORTED_TEMPORARILY: 'tld_not_supported_temporarily',
 	TRANSFER_PENDING: 'transfer_pending',
 	TRANSFER_PENDING_SAME_USER: 'transfer_pending_same_user',
 	TRANSFERRABLE: 'transferrable',

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -197,6 +197,7 @@ function getAvailabilityNotice( domain, error, errorData ) {
 		case domainAvailability.MAPPABLE:
 		case domainAvailability.AVAILABLE:
 		case domainAvailability.TLD_NOT_SUPPORTED:
+		case domainAvailability.TLD_NOT_SUPPORTED_TEMPORARILY:
 		case domainAvailability.UNKNOWN:
 		case domainAvailability.EMPTY_RESULTS:
 			// unavailable domains are displayed in the search results, not as a notice OR


### PR DESCRIPTION
Because our partners are having trouble validating GB postal codes, we
need to temporarily disable .blog purchases for UK users.

This patch adds handling for new availability status - see
`D14002-code`.

### Testing
Apply backend patch.
Check that if not in UK, you can register .blog no problems.

Check that if in UK, .blog is not in suggestions, TLD list and if you directly search for a .blog, you'll get a semi-helpful at least notice:
<img width="951" alt="screen shot 2018-05-27 at 21 58 55" src="https://user-images.githubusercontent.com/3392497/40590117-c3299cae-61f9-11e8-90cf-3b2db6c6e375.png">
