### PR TITLE
Fix Linter Errors From Google My Business Chart

### DIFF
--- a/client/my-sites/google-my-business/stats/chart.js
+++ b/client/my-sites/google-my-business/stats/chart.js
@@ -74,6 +74,9 @@ function getAggregation( props ) {
 	return props.chartType === 'pie' ? 'total' : 'daily';
 }
 
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+/* eslint-disable jsx-a11y/no-onchange */
+
 class GoogleMyBusinessStatsChart extends Component {
 	static propTypes = {
 		changeGoogleMyBusinessStatsInterval: PropTypes.func.isRequired,
@@ -280,14 +283,15 @@ class GoogleMyBusinessStatsChart extends Component {
 						<option value="quarter">{ translate( 'Quarter' ) }</option>
 					</select>
 
-					<div className="gmb-stats__chart">
-						{ this.renderChart() }
-					</div>
+					<div className="gmb-stats__chart">{ this.renderChart() }</div>
 				</Card>
 			</div>
 		);
 	}
 }
+
+/* eslint-enable wpcalypso/jsx-classname-namespace */
+/* eslint-enable jsx-a11y/no-onchange */
 
 export default connect(
 	( state, ownProps ) => {


### PR DESCRIPTION
GMB Chart has a couple listing rules we do not want to use, so let's officially disable them for the chart code.

## Testing

1. run `node_modules/.bin/eslint  ./client/my-sites/google-my-business/stats/chart.js`
2. verify there was no error output
