### PR TITLE
Reader: show a special error message for 403 errors on Reader full post

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -566,8 +566,8 @@
 	margin-bottom: 0;
 }
 
-.reader-full-post__unavailable-message {
-	margin-top: 1em;
+.reader-full-post__unavailable-body {
+	margin-top: 2em;
 }
 
 // Placeholders

--- a/client/blocks/reader-full-post/unavailable.jsx
+++ b/client/blocks/reader-full-post/unavailable.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import config from 'config';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
+import { noop, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,19 +16,38 @@ import DocumentHead from 'components/data/document-head';
 import BackButton from 'components/back-button';
 
 const ReaderFullPostUnavailable = ( { post, onBackClick, translate } ) => {
+	const statusCode = get( post, [ 'error', 'statusCode' ] );
+
+	let errorTitle = translate( 'Post unavailable' );
+	let errorDescription = translate( "Sorry, we can't display that post right now." );
+	let errorHelp = null;
+
+	if ( statusCode === 403 ) {
+		errorTitle = translate( 'Private post' );
+		errorDescription = translate( "This post exists, but you don't have permission to read it." );
+		errorHelp = translate(
+			"If it's a post on a private site, you need be a member of the site to view the post."
+		);
+	}
+
+	if ( statusCode === 404 ) {
+		errorTitle = translate( 'Post not found' );
+	}
+
 	return (
 		<ReaderMain className="reader-full-post reader-full-post__unavailable">
 			<BackButton onClick={ onBackClick } />
 			<DocumentHead title={ translate( 'Post unavailable' ) } />
 			<div className="reader-full-post__content">
 				<div className="reader-full-post__story">
-					<h1 className="reader-full-post__header-title">{ translate( 'Post unavailable' ) }</h1>
-					<p className="reader-full-post__unavailable-message">
-						{ translate( "Sorry, we can't display that post right now." ) }
-					</p>
-					{ config.isEnabled( 'reader/full-errors' ) ? (
-						<pre>{ JSON.stringify( post, null, '  ' ) }</pre>
-					) : null }
+					<h1 className="reader-full-post__header-title">{ errorTitle }</h1>
+					<div className="reader-full-post__unavailable-body">
+						<p className="reader-full-post__unavailable-message">{ errorDescription }</p>
+						{ errorHelp && <p className="reader-full-post__unavailable-message">{ errorHelp }</p> }
+						{ config.isEnabled( 'reader/full-errors' ) ? (
+							<pre>{ JSON.stringify( post, null, '  ' ) }</pre>
+						) : null }
+					</div>
 				</div>
 			</div>
 		</ReaderMain>

--- a/config/stage.json
+++ b/config/stage.json
@@ -106,7 +106,7 @@
 		"reader": true,
 		"reader/conversations": true,
 		"reader/following-intro": true,
-		"reader/full-errors": true,
+		"reader/full-errors": false,
 		"reader/likes-hover": true,
 		"reader/nesting-arrow": true,
 		"reader/paste-to-link": true,


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/24644.

If we're not able to display a post, Reader users currently see a generic 'post unavailable' error.

This PR checks for a 403 or 404 error, and changes the content accordingly.

403:

<img width="618" alt="screen shot 2018-05-28 at 14 02 29" src="https://user-images.githubusercontent.com/17325/40593995-6a7b311c-6280-11e8-977d-fd7b1ec8a6f5.png">

404:

<img width="389" alt="screen shot 2018-05-28 at 14 07 19" src="https://user-images.githubusercontent.com/17325/40594002-7312c1b4-6280-11e8-8d1a-db15b18a7d09.png">

This PR also turns off error debugging information on staging, where internal users might see it.


### To test

403:

http://calypso.localhost:3000/read/blogs/83270087/posts/4

404:

http://calypso.localhost:3000/read/blogs/99999999999999/posts/1