### PR TITLE
Comments: add paste-to-link functionality to comments textarea

### DIFF
--- a/client/blocks/comments/form-textarea.jsx
+++ b/client/blocks/comments/form-textarea.jsx
@@ -9,6 +9,7 @@ import React from 'react';
  * Internal dependencies
  */
 import withUserMentions from 'blocks/user-mentions/index';
+import withPasteToLink from 'lib/paste-to-link';
 import { isEnabled } from 'config';
 
 /* eslint-disable jsx-a11y/no-autofocus */
@@ -23,14 +24,15 @@ const PostCommentFormTextarea = React.forwardRef( ( props, ref ) => (
 		onFocus={ props.onFocus }
 		onBlur={ props.onBlur }
 		onChange={ props.onChange }
+		onPaste={ props.onPaste }
 		autoFocus={ props.enableAutoFocus }
 	/>
 ) );
 /* eslint-enable jsx-a11y/no-autofocus */
 
-let component = PostCommentFormTextarea;
+let component = withPasteToLink( PostCommentFormTextarea );
 if ( isEnabled( 'reader/user-mention-suggestions' ) ) {
-	component = withUserMentions( PostCommentFormTextarea );
+	component = withUserMentions( component );
 }
 
 export default component;

--- a/client/blocks/comments/form-textarea.jsx
+++ b/client/blocks/comments/form-textarea.jsx
@@ -30,7 +30,10 @@ const PostCommentFormTextarea = React.forwardRef( ( props, ref ) => (
 ) );
 /* eslint-enable jsx-a11y/no-autofocus */
 
-let component = withPasteToLink( PostCommentFormTextarea );
+let component = PostCommentFormTextarea;
+if ( isEnabled( 'reader/paste-to-link' ) ) {
+	component = withPasteToLink( component );
+}
 if ( isEnabled( 'reader/user-mention-suggestions' ) ) {
 	component = withUserMentions( component );
 }

--- a/client/lib/paste-to-link/README.md
+++ b/client/lib/paste-to-link/README.md
@@ -1,0 +1,22 @@
+Paste-to-Link
+=============
+
+Paste-to-Link is a higher-order component (HOC) that adds special paste behaviour to the wrapped component.
+
+If the clipboard contains a URL and some text is selected, pasting will wrap the selected text in an
+<a> element with the href set to the URL in the clipboard.
+
+For example, type and highlight "WordPress" with "http://wordpress.com" in your clipboard and then paste.
+The textarea will then contain:
+
+<a href="http://wordpress.com">WordPress</a>
+
+## Usage
+
+Wrap your component like this:
+
+```
+export default withPasteToLink( WrappedComponent );
+```
+
+This HOC is enabled by default for the main comments form in `blocks/comments`.

--- a/client/lib/paste-to-link/index.jsx
+++ b/client/lib/paste-to-link/index.jsx
@@ -1,0 +1,80 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { resemblesUrl } from 'lib/url';
+
+/**
+ * Paste-to-link adds special paste behaviour to the wrapped component.
+ *
+ * If the clipboard contains a URL and some text is selected, pasting will wrap the selected text
+ * in an <a> element with the href set to the URL in the clipboard.
+ *
+ * @example: withPasteToLink( Component )
+ * @param {object} WrappedComponent - React component to wrap
+ * @returns {object} Enhanced component
+ */
+export default WrappedComponent => {
+	class WithPasteToLink extends React.Component {
+		static displayName = `withPasteToLink( ${ WrappedComponent.displayName ||
+			WrappedComponent.name } )`;
+		static propTypes = {};
+
+		handlePaste = event => {
+			const clipboardText = event.clipboardData && event.clipboardData.getData( 'text/plain' );
+
+			// If we have a URL in the clipboard, pass it to insertLink to wrap in an <a> element
+			if ( clipboardText && clipboardText.length > 0 && resemblesUrl( clipboardText ) ) {
+				event.preventDefault();
+				this.insertLink( clipboardText );
+			}
+		};
+
+		// Insert a link from the clipboard into the textbox
+		insertLink( url ) {
+			const { forwardedRef } = this.props;
+
+			if ( ! forwardedRef ) {
+				return;
+			}
+
+			const node = forwardedRef.current;
+
+			// If selectionStart and selectionEnd are the same, we don't have a selection
+			if ( node.selectionStart === node.selectionEnd ) {
+				return;
+			}
+
+			const textBeforeSelection = node.value.slice( 0, node.selectionStart );
+			const selectionText = node.value.slice( node.selectionStart, node.selectionEnd );
+			const textAfterSelectionEnd = node.value.slice( node.selectionEnd, node.value.length + 1 );
+
+			const newLink = '<a href="' + encodeURI( url ) + '">' + selectionText + '</a>';
+
+			// Set the new text field value, including the link
+			node.value = textBeforeSelection + newLink + textAfterSelectionEnd;
+
+			// Move the caret to the end of the inserted string
+			node.selectionEnd = textBeforeSelection.length + newLink.length;
+		}
+
+		render() {
+			return (
+				<WrappedComponent
+					{ ...this.props }
+					onPaste={ this.handlePaste }
+					ref={ this.props.forwardedRef }
+				/>
+			);
+		}
+	}
+
+	return React.forwardRef( ( props, ref ) => {
+		return <WithPasteToLink { ...props } forwardedRef={ ref } />;
+	} );
+};

--- a/client/lib/paste-to-link/index.jsx
+++ b/client/lib/paste-to-link/index.jsx
@@ -25,6 +25,15 @@ export default WrappedComponent => {
 			WrappedComponent.name } )`;
 		static propTypes = {};
 
+		constructor( props ) {
+			super( props );
+
+			this.textareaRef = this.props.forwardedRef;
+			if ( ! this.textareaRef ) {
+				this.textareaRef = React.createRef();
+			}
+		}
+
 		handlePaste = event => {
 			const clipboardText = event.clipboardData && event.clipboardData.getData( 'text/plain' );
 
@@ -37,13 +46,11 @@ export default WrappedComponent => {
 
 		// Insert a link from the clipboard into the textbox
 		insertLink( url ) {
-			const { forwardedRef } = this.props;
+			const node = this.textareaRef.current;
 
-			if ( ! forwardedRef ) {
+			if ( ! node ) {
 				return;
 			}
-
-			const node = forwardedRef.current;
 
 			// If selectionStart and selectionEnd are the same, we don't have a selection
 			if ( node.selectionStart === node.selectionEnd ) {
@@ -65,11 +72,7 @@ export default WrappedComponent => {
 
 		render() {
 			return (
-				<WrappedComponent
-					{ ...this.props }
-					onPaste={ this.handlePaste }
-					ref={ this.props.forwardedRef }
-				/>
+				<WrappedComponent { ...this.props } onPaste={ this.handlePaste } ref={ this.textareaRef } />
 			);
 		}
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -148,6 +148,7 @@
 		"reader/full-errors": true,
 		"reader/list-management": false,
 		"reader/nesting-arrow": true,
+		"reader/paste-to-link": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
 		"reader/search": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -108,6 +108,7 @@
 		"reader/full-errors": true,
 		"reader/likes-hover": true,
 		"reader/nesting-arrow": true,
+		"reader/paste-to-link": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
 		"reader/search": true,

--- a/config/test.json
+++ b/config/test.json
@@ -87,6 +87,7 @@
 		"reader/following-intro": true,
 		"reader/full-errors": true,
 		"reader/list-management": false,
+		"reader/paste-to-link": true,
 		"reader/user-mention-suggestions": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -119,6 +119,7 @@
 		"reader/following-intro": true,
 		"reader/full-errors": true,
 		"reader/nesting-arrow": true,
+		"reader/paste-to-link": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
 		"reader/search": true,


### PR DESCRIPTION
Paste-to-link is a special paste behaviour we have on P2/O2 blogs, and this PR brings it to Calypso comments too.

In summary: if the clipboard contains a URL and some text is selected, pasting will wrap the selected text in an `<a>` element with the href set to the URL in the clipboard.

![2018-05-28 17_19_27](https://user-images.githubusercontent.com/17325/40598351-51a9da88-629b-11e8-88f1-2407b5fd0123.gif)

### To test

Open a Reader full post like:

http://calypso.localhost:3000/read/feeds/82926118/posts/1864180970

Copy a URL to your clipboard, type and highlight some text in the comments, and then paste.

Ensure that:
- @ user mentions still work
- copying a non-URL to your clipboard does not change the regular paste behaviour
 