### PR TITLE
Post Editor: reduxify the recordSaveEvent action

### DIFF
--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -122,7 +122,7 @@ PostActions = {
 		} );
 	},
 
-	autosave: async function( site ) {
+	autosave: async function() {
 		const post = PostEditStore.get();
 		const savedPost = PostEditStore.getSavedPost();
 
@@ -136,7 +136,7 @@ PostActions = {
 		if ( utils.isPublished( savedPost ) || utils.isPublished( post ) ) {
 			await reduxDispatch( editorAutosave( post ) );
 		} else {
-			await PostActions.saveEdited( site, null, null, {
+			await PostActions.saveEdited( null, {
 				recordSaveEvent: false,
 				autosave: true,
 			} );
@@ -179,12 +179,10 @@ PostActions = {
 	/**
 	 * Calls out to API to save a Post object
 	 *
-	 * @param {Object} site Site object
 	 * @param {object} attributes post attributes to change before saving
-	 * @param {object} context additional properties for recording the save event
 	 * @param {object} options object with optional recordSaveEvent property. True if you want to record the save event.
 	 */
-	saveEdited: async function( site, attributes, context, options ) {
+	saveEdited: async function( attributes, options ) {
 		// TODO: skip this edit if `attributes` are `null`. That means
 		// we don't want to do any additional edit before saving.
 		Dispatcher.handleViewAction( {
@@ -234,7 +232,7 @@ PostActions = {
 		}
 
 		if ( ! options || options.recordSaveEvent !== false ) {
-			recordSaveEvent( site, context ); // do this before changing status from 'future'
+			reduxDispatch( recordSaveEvent() ); // do this before changing status from 'future'
 		}
 
 		if (

--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -267,7 +267,6 @@ PostActions = {
 				// it
 				rawContent: mode === currentMode ? rawContent : null,
 				post: data,
-				site,
 			} );
 
 			// Retrieve the normalized post and use it to update Redux store

--- a/client/lib/posts/post-edit-store.js
+++ b/client/lib/posts/post-edit-store.js
@@ -77,7 +77,7 @@ function startEditing( site, post ) {
 	_isLoading = false;
 }
 
-function updatePost( site, post ) {
+function updatePost( post ) {
 	post = normalize( post );
 	if ( post.title ) {
 		post.title = decodeEntities( post.title );
@@ -245,7 +245,7 @@ function dispatcherCallback( payload ) {
 
 		case 'RECEIVE_POST_BEING_EDITED':
 			if ( ! action.error ) {
-				updatePost( action.site, action.post );
+				updatePost( action.post );
 				if ( typeof action.rawContent === 'string' ) {
 					_initialRawContent = action.rawContent;
 				}

--- a/client/lib/posts/stats.js
+++ b/client/lib/posts/stats.js
@@ -3,32 +3,31 @@
  * External dependencies
  */
 import debugModule from 'debug';
-import { noop } from 'lodash';
+import { get, noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import PostEditStore from 'lib/posts/post-edit-store';
 import * as utils from 'lib/posts/utils';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+import { getEditorPostId, isConfirmationSidebarEnabled } from 'state/ui/editor/selectors';
+import { getEditedPost, getSitePost } from 'state/posts/selectors';
 
 /**
  * Module variables
  */
 const debug = debugModule( 'calypso:posts:stats' );
 
-function recordUsageStats( site, action, postType ) {
-	let source;
-
+function recordUsageStats( siteIsJetpack, action, postType ) {
 	analytics.mc.bumpStat( 'editor_usage', action );
 
-	if ( site ) {
-		source = site.jetpack ? 'jetpack' : 'wpcom';
-		analytics.mc.bumpStat( 'editor_usage_' + source, action );
+	const source = siteIsJetpack ? 'jetpack' : 'wpcom';
+	analytics.mc.bumpStat( 'editor_usage_' + source, action );
 
-		if ( postType ) {
-			analytics.mc.bumpStat( 'editor_cpt_usage_' + source, postType + '_' + action );
-		}
+	if ( postType ) {
+		analytics.mc.bumpStat( 'editor_cpt_usage_' + source, postType + '_' + action );
 	}
 }
 
@@ -40,15 +39,13 @@ export function recordEvent( action, label, value ) {
 	analytics.ga.recordEvent( 'Editor', action, label, value );
 }
 
-export function recordSaveEvent( site, context ) {
-	const post = PostEditStore.get();
-	const savedPost = PostEditStore.getSavedPost();
-
-	if ( ! post || ! savedPost ) {
-		return;
-	}
-
-	const currentStatus = savedPost.status;
+export const recordSaveEvent = () => ( dispatch, getState ) => {
+	const state = getState();
+	const siteId = getSelectedSiteId( state );
+	const postId = getEditorPostId( state );
+	const post = getEditedPost( state, siteId, postId );
+	const currentStatus = get( getSitePost( state, siteId, postId ), 'status', 'draft' );
+	const confirmationSidebarEnabled = isConfirmationSidebarEnabled( state, siteId );
 	const nextStatus = post.status;
 	let tracksEventName = 'calypso_editor_';
 	let statName = false;
@@ -66,7 +63,7 @@ export function recordSaveEvent( site, context ) {
 	} else if ( 'publish' === nextStatus || 'private' === nextStatus ) {
 		tracksEventName += 'publish';
 		usageAction = 'new';
-		if ( context && context.isConfirmationSidebarEnabled ) {
+		if ( confirmationSidebarEnabled ) {
 			eventContext = 'confirmation_sidebar';
 		}
 	} else if ( 'pending' === nextStatus ) {
@@ -75,13 +72,13 @@ export function recordSaveEvent( site, context ) {
 		tracksEventName += 'schedule';
 		statName = 'status-schedule';
 		statEvent = 'Scheduled Post';
-		if ( context && context.isConfirmationSidebarEnabled ) {
+		if ( confirmationSidebarEnabled ) {
 			eventContext = 'confirmation_sidebar';
 		}
 	}
 
 	if ( usageAction ) {
-		recordUsageStats( site, usageAction, post.type );
+		recordUsageStats( isJetpackSite( state, siteId ), usageAction, post.type );
 	}
 
 	// if this action has an mc stat name, record it
@@ -109,7 +106,7 @@ export function recordSaveEvent( site, context ) {
 		next_status: nextStatus,
 		context: eventContext,
 	} );
-}
+};
 
 const shouldBumpStat = Math.random() <= 0.01 || process.env.NODE_ENV === 'development';
 const maybeBumpStat = shouldBumpStat ? analytics.mc.bumpStat : noop;

--- a/client/lib/posts/test/actions.js
+++ b/client/lib/posts/test/actions.js
@@ -23,12 +23,6 @@ jest.mock( 'lib/redux-bridge', () => ( {
 	reduxGetState: () => ( { ui: { editor: { saveBlockers: [] } } } ),
 } ) );
 
-const sampleSite = {
-	ID: 123,
-	jetpack: false,
-	slug: 'example.wordpress.com',
-	URL: 'https://example.wordpress.com',
-};
 describe( 'actions', () => {
 	let sandbox;
 
@@ -52,7 +46,7 @@ describe( 'actions', () => {
 		test( 'should not send a request if the post has no content', () => {
 			sandbox.stub( PostEditStore, 'hasContent' ).returns( false );
 
-			const saveResult = PostActions.saveEdited( sampleSite, null, {} );
+			const saveResult = PostActions.saveEdited( null );
 			return expect( saveResult ).rejects.toThrow( 'NO_CONTENT' );
 		} );
 
@@ -60,7 +54,7 @@ describe( 'actions', () => {
 			sandbox.stub( PostEditStore, 'hasContent' ).returns( true );
 			sandbox.stub( PostEditStore, 'getChangedAttributes' ).returns( {} );
 
-			const saveResult = PostActions.saveEdited( sampleSite, null, {} );
+			const saveResult = PostActions.saveEdited( null );
 			return expect( saveResult ).resolves.toBeUndefined();
 		} );
 
@@ -94,7 +88,7 @@ describe( 'actions', () => {
 
 			sandbox.stub( PostEditStore, 'getChangedAttributes' ).returns( changedAttributes );
 
-			const saveResult = PostActions.saveEdited( sampleSite, null, {} );
+			const saveResult = PostActions.saveEdited( null );
 			await expect( saveResult ).resolves.toBeUndefined();
 
 			sinon.assert.calledTwice( Dispatcher.handleViewAction );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -564,7 +564,7 @@ export class PostEditor extends React.Component {
 
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		try {
-			await actions.autosave( this.props.selectedSite );
+			await actions.autosave();
 			if ( ! savingPublishedPost ) {
 				this.onSaveDraftSuccess();
 			}
@@ -647,11 +647,7 @@ export class PostEditor extends React.Component {
 		edits.content = this.editor.getContent();
 
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		actions
-			.saveEdited( this.props.selectedSite, edits, {
-				isConfirmationSidebarEnabled: this.props.isConfirmationSidebarEnabled,
-			} )
-			.then( this.onSaveDraftSuccess, this.onSaveDraftFailure );
+		actions.saveEdited( edits ).then( this.onSaveDraftSuccess, this.onSaveDraftFailure );
 	};
 
 	getExternalUrl() {
@@ -790,11 +786,7 @@ export class PostEditor extends React.Component {
 		this.saveRawContent();
 		edits.content = this.editor.getContent();
 
-		actions
-			.saveEdited( this.props.selectedSite, edits, {
-				isConfirmationSidebarEnabled: this.props.isConfirmationSidebarEnabled,
-			} )
-			.then( this.onPublishSuccess, this.onPublishFailure );
+		actions.saveEdited( edits ).then( this.onPublishSuccess, this.onPublishFailure );
 	};
 
 	onPublishFailure = error => {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -631,6 +631,8 @@ export class PostEditor extends React.Component {
 		const edits = { ...this.props.edits };
 		if ( status ) {
 			edits.status = status;
+			// Sync the status edit to Redux to ensure that Flux and Redux stores have the same info
+			this.props.editPost( this.props.siteId, this.props.postId, { status } );
 		}
 
 		if (
@@ -779,6 +781,9 @@ export class PostEditor extends React.Component {
 		} else {
 			edits.status = 'publish';
 		}
+
+		// Sync the status edit to Redux to ensure that Flux and Redux stores have the same info
+		this.props.editPost( this.props.siteId, this.props.postId, { status: edits.status } );
 
 		// Flush any pending raw content saves
 		// Update content on demand to avoid unnecessary lag and because it is expensive


### PR DESCRIPTION
When saving post modification, we call the `recordSaveEvent` function to record a lot of information about this event: previous and next status, post type, sidebar status... This patch refactors this function to a Redux thunk that is self-sufficient: it retrieves all the reported data with Redux selectors and doesn't need any parameters.

These parameters were passed through several function on the call stack. Now we can remove a lot of params from methods like `saveEdited` or `autosave`.

There's one commit that ensures that the Flux and Redux `status` attributes are in sync.

**How to test:**
- enable analytics debugging in console with `localStorage.debug = 'calypso:analytics:*'`
- save a draft, publish a draft as public/private/protected, revert a draft
- verify that the right `calypso_editor_*` tracks events and `editor_usage_*` stats bumps are recorded. Check the event params, too.
