### PR TITLE
Activity: style threats block

### DIFF
--- a/client/my-sites/stats/activity-log/rewind-alerts.jsx
+++ b/client/my-sites/stats/activity-log/rewind-alerts.jsx
@@ -26,12 +26,12 @@ export class RewindAlerts extends Component {
 		return (
 			<Fragment>
 				{ threats.length > 0 && (
-					<div className="activity-log__threats">
-						<Card className="activity-log__threat-alert " highlight="error" compact>
+					<Card className="activity-log__threats" highlight="error">
+						<div className="activity-log__threats-heading">
 							{ translate( 'These items require your immediate attention' ) }
-						</Card>
+						</div>
 						{ threats.map( threat => <ThreatAlert key={ threat.id } threat={ threat } /> ) }
-					</div>
+					</Card>
 				) }
 			</Fragment>
 		);

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -87,6 +87,10 @@
 	margin-bottom: 16px;
 	font-weight: 600;
 	color: $alert-red;
+
+	@include breakpoint( '>480px' ) {
+		margin-bottom: 24px;
+	}
 }
 
 .activity-log__threat-alert {

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -78,23 +78,21 @@
 	margin: 14px 0 48px;
 }
 
-.activity-log__threats {
-	margin-bottom: 10px;
+.card.activity-log__threats {
+	padding-bottom: 4px;
+	font-size: 14px;
+}
 
-	@include breakpoint( '>480px' ) {
-		margin-bottom: 16px;
-	}
-
-	.activity-log__threat-alert:first-of-type {
-		font-weight: 600;
-		color: $alert-red;
-	}
+.activity-log__threats-heading {
+	margin-bottom: 16px;
+	font-weight: 600;
+	color: $alert-red;
 }
 
 .activity-log__threat-alert {
 	padding: 8px 0;
 	font-size: 14px;
-	border-left: 3px solid $alert-red;
+	box-shadow: 0 -1px 0 transparentize($gray-lighten-20, 0.5);
 
 	.foldable-card__main {
 		flex: unset;
@@ -113,7 +111,19 @@
 }
 
 .foldable-card.is-compact.activity-log__threat-alert .foldable-card__header {
-	padding: 16px;
+	padding: 16px 0;
+}
+
+.foldable-card.is-expanded.activity-log__threat-alert {
+	margin: 0;
+
+	.foldable-card__content {
+		padding-left: 56px;
+
+		p:last-of-type {
+			margin-bottom: 0;
+		}
+	}
 }
 
 .activity-log__threat-alert-header {

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -80,7 +80,11 @@
 
 .card.activity-log__threats {
 	padding-bottom: 4px;
-	font-size: 14px;
+	font-size: 13px;
+
+	@include breakpoint( '>480px' ) {
+		font-size: 14px;
+	}
 }
 
 .activity-log__threats-heading {
@@ -95,8 +99,12 @@
 
 .activity-log__threat-alert {
 	padding: 8px 0;
-	font-size: 14px;
+	font-size: 13px;
 	box-shadow: 0 -1px 0 transparentize($gray-lighten-20, 0.5);
+
+	@include breakpoint( '>480px' ) {
+		font-size: 14px;
+	}
 
 	.foldable-card__main {
 		flex: unset;
@@ -104,7 +112,11 @@
 
 	.activity-log-item__activity-icon {
 		margin-right: 16px;
-		padding: 8px;
+		padding: 7px;
+
+		@include breakpoint( '>480px' ) {
+			padding-left: 8px;
+		}
 	}
 
 	.diff-viewer,
@@ -122,7 +134,11 @@
 	margin: 0;
 
 	.foldable-card__content {
-		padding-left: 56px;
+		padding-left: 48px;
+
+		@include breakpoint( '>480px' ) {
+			padding-left: 56px;
+		}
 
 		p:last-of-type {
 			margin-bottom: 0;
@@ -155,8 +171,12 @@
 
 .activity-log__threat-alert-filename {
 	padding: 4px;
-	font-size: 14px;
+	font-size: 13px;
 	font-weight: 500;
+
+	@include breakpoint( '>480px' ) {
+		font-size: 14px;
+	}
 }
 
 .activity-log__threat-alert-time-since {


### PR DESCRIPTION
This PR rejigs a bit how the threats markup is structured so that we can style them consistently with the other persistent noticed on the Activity log.

Related: https://github.com/Automattic/wp-calypso/pull/25103

### Before

![image](https://user-images.githubusercontent.com/390760/40615781-1e517a4e-6280-11e8-94b5-6a16a3bb9196.png)


### After

![image](https://user-images.githubusercontent.com/390760/40615411-8d477f04-627e-11e8-994e-8ae454f60dca.png)


### Testing

Open **My Sites > Stats > Activity** with the console dispatcher active. If running in production then ensure that `?debug&flags=rewind-alerts` is added to the URL

Inject fake threats by copying the [setup code](https://gist.githubusercontent.com/dmsnell/13d7caf065333da343c0da975a563906/raw/72d95360e03d698804737eff5e3d56d7e9b02f3b/activity-log-threat-injections.js) into your console making sure to insert your site id at the bottom where it mentions replacing it.