### PR TITLE
Imports/Site Importer: Add tracks to imports

### DIFF
--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import { flowRight, includes } from 'lodash';
 import SocialLogo from 'social-logos';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -18,6 +19,8 @@ import { appStates } from 'state/imports/constants';
 import { cancelImport, resetImport, startImport } from 'lib/importer/actions';
 import { connectDispatcher } from './dispatcher-converter';
 import SiteImporterPlaceholderLogo from './site-importer/placeholder-logo';
+
+import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
  * Module variables
@@ -56,10 +59,22 @@ class ImporterHeader extends React.PureComponent {
 
 		if ( includes( [ ...cancelStates, ...stopStates ], importerState ) ) {
 			cancelImport( siteId, importerId );
+
+			this.props.recordTracksEvent( 'calypso_importer_main_cancel_import', {
+				importer_id: type,
+			} );
 		} else if ( includes( startStates, importerState ) ) {
 			startImport( siteId, type );
+
+			this.props.recordTracksEvent( 'calypso_importer_main_start_import', {
+				importer_id: type,
+			} );
 		} else if ( includes( doneStates, importerState ) ) {
 			resetImport( siteId, importerId );
+
+			this.props.recordTracksEvent( 'calypso_importer_main_done_import', {
+				importer_id: type,
+			} );
 		}
 	};
 
@@ -140,4 +155,6 @@ const mapDispatchToProps = dispatch => ( {
 	),
 } );
 
-export default connectDispatcher( null, mapDispatchToProps )( localize( ImporterHeader ) );
+export default connect( null, { recordTracksEvent } )(
+	connectDispatcher( null, mapDispatchToProps )( localize( ImporterHeader ) )
+);

--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -19,7 +19,6 @@ import { appStates } from 'state/imports/constants';
 import { cancelImport, resetImport, startImport } from 'lib/importer/actions';
 import { connectDispatcher } from './dispatcher-converter';
 import SiteImporterPlaceholderLogo from './site-importer/placeholder-logo';
-
 import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
@@ -155,6 +154,7 @@ const mapDispatchToProps = dispatch => ( {
 	),
 } );
 
-export default connect( null, { recordTracksEvent } )(
-	connectDispatcher( null, mapDispatchToProps )( localize( ImporterHeader ) )
-);
+export default connect(
+	null,
+	{ recordTracksEvent }
+)( connectDispatcher( null, mapDispatchToProps )( localize( ImporterHeader ) ) );

--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -60,18 +60,21 @@ class ImporterHeader extends React.PureComponent {
 			cancelImport( siteId, importerId );
 
 			this.props.recordTracksEvent( 'calypso_importer_main_cancel_import', {
+				blog_id: siteId,
 				importer_id: type,
 			} );
 		} else if ( includes( startStates, importerState ) ) {
 			startImport( siteId, type );
 
 			this.props.recordTracksEvent( 'calypso_importer_main_start_import', {
+				blog_id: siteId,
 				importer_id: type,
 			} );
 		} else if ( includes( doneStates, importerState ) ) {
 			resetImport( siteId, importerId );
 
 			this.props.recordTracksEvent( 'calypso_importer_main_done_import', {
+				blog_id: siteId,
 				importer_id: type,
 			} );
 		}

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -45,6 +45,7 @@ class SiteImporterInputPane extends React.Component {
 		} ),
 		onStartImport: PropTypes.func,
 		disabled: PropTypes.bool,
+		site: PropTypes.object,
 	};
 
 	static defaultProps = { description: null, onStartImport: noop };
@@ -85,6 +86,7 @@ class SiteImporterInputPane extends React.Component {
 				defer( props => startMappingAuthors( props.importerStatus.importerId ), nextProps );
 
 				this.props.recordTracksEvent( 'calypso_site_importer_map_authors_multi', {
+					blog_id: this.props.site.ID,
 					site_url: this.state.importSiteURL,
 				} );
 			}
@@ -104,6 +106,7 @@ class SiteImporterInputPane extends React.Component {
 				}, nextProps );
 
 				this.props.recordTracksEvent( 'calypso_site_importer_map_authors_single', {
+					blog_id: this.props.site.ID,
 					site_url: this.state.importSiteURL,
 				} );
 			}
@@ -131,6 +134,7 @@ class SiteImporterInputPane extends React.Component {
 		this.setState( { loading: true }, this.resetErrors );
 
 		this.props.recordTracksEvent( 'calypso_site_importer_validate_site', {
+			blog_id: this.props.site.ID,
 			site_url: siteURL,
 		} );
 
@@ -161,9 +165,16 @@ class SiteImporterInputPane extends React.Component {
 				} );
 
 				this.props.recordTracksEvent( 'calypso_site_importer_validate_site_done', {
+					blog_id: this.props.site.ID,
 					site_url: this.state.importSiteURL,
-					supported_content: resp.supported_content,
-					unsupported_content: resp.unsupported_content,
+					supported_content: resp.supported_content
+						.slice( 0 )
+						.sort()
+						.join( ', ' ),
+					unsupported_content: resp.unsupported_content
+						.slice( 0 )
+						.sort()
+						.join( ', ' ),
 					site_engine: resp.engine,
 				} );
 			} )
@@ -175,6 +186,7 @@ class SiteImporterInputPane extends React.Component {
 				} );
 
 				this.props.recordTracksEvent( 'calypso_site_importer_validate_site_fail', {
+					blog_id: this.props.site.ID,
 					site_url: this.state.importSiteURL,
 				} );
 			} );
@@ -184,9 +196,16 @@ class SiteImporterInputPane extends React.Component {
 		this.setState( { loading: true }, this.resetErrors );
 
 		this.props.recordTracksEvent( 'calypso_site_importer_start_import', {
+			blog_id: this.props.site.ID,
 			site_url: this.state.importSiteURL,
-			supported_content: this.state.importData.supported,
-			unsupported_content: this.state.importData.unsupported,
+			supported_content: this.state.importData.supported
+				.slice( 0 )
+				.sort()
+				.join( ', ' ),
+			unsupported_content: this.state.importData.unsupported
+				.slice( 0 )
+				.sort()
+				.join( ', ' ),
 			site_engine: this.state.importData.engine,
 		} );
 
@@ -203,9 +222,16 @@ class SiteImporterInputPane extends React.Component {
 				this.setState( { loading: false } );
 
 				this.props.recordTracksEvent( 'calypso_site_importer_start_import_done', {
+					blog_id: this.props.site.ID,
 					site_url: this.state.importSiteURL,
-					supported_content: this.state.importData.supported,
-					unsupported_content: this.state.importData.unsupported,
+					supported_content: this.state.importData.supported
+						.slice( 0 )
+						.sort()
+						.join( ', ' ),
+					unsupported_content: this.state.importData.unsupported
+						.slice( 0 )
+						.sort()
+						.join( ', ' ),
 					site_engine: this.state.importData.engine,
 				} );
 
@@ -217,9 +243,16 @@ class SiteImporterInputPane extends React.Component {
 			} )
 			.catch( err => {
 				this.props.recordTracksEvent( 'calypso_site_importer_start_import_fail', {
+					blog_id: this.props.site.ID,
 					site_url: this.state.importSiteURL,
-					supported_content: this.state.importData.supported,
-					unsupported_content: this.state.importData.unsupported,
+					supported_content: this.state.importData.supported
+						.slice( 0 )
+						.sort()
+						.join( ', ' ),
+					unsupported_content: this.state.importData.unsupported
+						.slice( 0 )
+						.sort()
+						.join( ', ' ),
 					site_engine: this.state.importData.engine,
 				} );
 
@@ -233,6 +266,7 @@ class SiteImporterInputPane extends React.Component {
 
 	resetImport = () => {
 		this.props.recordTracksEvent( 'calypso_site_importer_reset_import', {
+			blog_id: this.props.site.ID,
 			site_url: this.state.importSiteURL || this.state.siteURLInput,
 			previous_stage: this.state.importStage,
 		} );
@@ -277,6 +311,7 @@ class SiteImporterInputPane extends React.Component {
 							isLoading={ this.state.loading }
 							resetImport={ this.resetImport }
 							startImport={ this.importSite }
+							site={ this.props.site }
 						/>
 					</div>
 				) }
@@ -295,6 +330,7 @@ const mapDispatchToProps = dispatch => ( {
 		} ),
 } );
 
-export default connect( null, { recordTracksEvent } )(
-	connectDispatcher( null, mapDispatchToProps )( localize( SiteImporterInputPane ) )
-);
+export default connect(
+	null,
+	{ recordTracksEvent }
+)( connectDispatcher( null, mapDispatchToProps )( localize( SiteImporterInputPane ) ) );

--- a/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
@@ -26,6 +26,7 @@ class SiteImporterSitePreview extends React.Component {
 		isLoading: PropTypes.bool,
 		startImport: PropTypes.func,
 		resetImport: PropTypes.func,
+		site: PropTypes.object,
 	};
 
 	state = {
@@ -57,6 +58,7 @@ class SiteImporterSitePreview extends React.Component {
 				} );
 
 				this.props.recordTracksEvent( 'calypso_site_importer_site_preview_done', {
+					blog_id: this.props.site.ID,
 					site_url: this.state.siteURL,
 					time_taken_ms: Date.now() - this.state.previewStartTime,
 				} );
@@ -69,6 +71,7 @@ class SiteImporterSitePreview extends React.Component {
 				} );
 
 				this.props.recordTracksEvent( 'calypso_site_importer_site_preview_failed', {
+					blog_id: this.props.site.ID,
 					site_url: this.state.siteURL,
 					time_taken_ms: Date.now() - this.state.previewStartTime,
 				} );
@@ -155,4 +158,7 @@ class SiteImporterSitePreview extends React.Component {
 	};
 }
 
-export default connect( null, { recordTracksEvent } )( localize( SiteImporterSitePreview ) );
+export default connect(
+	null,
+	{ recordTracksEvent }
+)( localize( SiteImporterSitePreview ) );


### PR DESCRIPTION
This PR adds tracking to the Site Importer and several places in the main import process, so we can monitor and get alerts for any issues of the importing process.

To test:

1. Check out branch or use Calypso.live link
2. Go through the Site Importer flow
3. Monitor network requests to make sure each step sends requests to the tracks API
4. Make sure the logged events make sense
5. Run a standard WordPress import
6. Make sure the import runs correctly and doesn't break somewhere
7. Monitor for JS errors and general flow failures