### PR TITLE
Framework: `dispatchRequest` update (user auth options)

### DIFF
--- a/client/state/data-layer/wpcom/users/auth-options/index.js
+++ b/client/state/data-layer/wpcom/users/auth-options/index.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
 	LOGIN_AUTH_ACCOUNT_TYPE_REQUESTING,
@@ -18,60 +18,51 @@ import {
 import { noRetry } from 'state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 
-export const getAuthAccountType = ( { dispatch }, action ) => {
-	const { usernameOrEmail } = action;
-
-	dispatch(
-		http(
-			{
-				path: `/users/${ usernameOrEmail }/auth-options`,
-				method: 'GET',
-				apiVersion: '1.1',
-				retryPolicy: noRetry(),
-			},
-			action
-		)
+export const getAuthAccountType = action =>
+	http(
+		{
+			path: `/users/${ action.usernameOrEmail }/auth-options`,
+			method: 'GET',
+			apiVersion: '1.1',
+			retryPolicy: noRetry(),
+		},
+		action
 	);
-};
 
-export const receiveSuccess = ( { dispatch }, action, data ) => {
+export const receiveSuccess = ( action, data ) => {
 	const isPasswordless = get( data, 'passwordless' );
 
-	dispatch( {
-		type: LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_SUCCESS,
-		data: {
-			type: isPasswordless ? 'passwordless' : 'regular',
+	return [
+		{
+			type: LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_SUCCESS,
+			data: {
+				type: isPasswordless ? 'passwordless' : 'regular',
+			},
 		},
-	} );
-
-	dispatch( recordTracksEvent( 'calypso_login_block_login_form_get_auth_type_success' ) );
+		recordTracksEvent( 'calypso_login_block_login_form_get_auth_type_success' ),
+	];
 };
 
-export const receiveError = ( { dispatch }, action, error ) => {
-	const { error: code, message } = error;
-
-	dispatch( {
+export const receiveError = ( action, { error: code, message } ) => [
+	{
 		type: LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_FAILURE,
 		error: {
 			code,
 			message,
 			field: 'usernameOrEmail',
 		},
-	} );
+	},
+	recordTracksEvent( 'calypso_login_block_login_form_get_auth_type_failure', {
+		error_code: code,
+		error_message: message,
+	} ),
+];
 
-	dispatch(
-		recordTracksEvent( 'calypso_login_block_login_form_get_auth_type_failure', {
-			error_code: code,
-			error_message: message,
-		} )
-	);
-};
-
-const getAuthAccountTypeRequest = dispatchRequest(
-	getAuthAccountType,
-	receiveSuccess,
-	receiveError
-);
+const getAuthAccountTypeRequest = dispatchRequestEx( {
+	fetch: getAuthAccountType,
+	onSuccess: receiveSuccess,
+	onError: receiveError,
+} );
 
 export default {
 	[ LOGIN_AUTH_ACCOUNT_TYPE_REQUESTING ]: [ getAuthAccountTypeRequest ],


### PR DESCRIPTION
In this patch we're replacing the use of dispatchRequest()
in the data layer handler to use the newer API exposed
as dispatchRequestEx() This should have no change in
actual effect or interaction.

**Testing**
I'm not sure - I would love some help figuring out how to test this!