### PR TITLE
Framework: `dispatchRequest` update (timezones)

### DIFF
--- a/client/state/data-layer/wpcom/timezones/index.js
+++ b/client/state/data-layer/wpcom/timezones/index.js
@@ -3,8 +3,7 @@
 /**
  * External dependencies
  */
-
-import { fromPairs, map, mapValues } from 'lodash';
+import { fromPairs, map, mapValues, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -60,6 +59,7 @@ export default {
 		dispatchRequestEx( {
 			fetch: fetchTimezones,
 			onSuccess: addTimezones,
+			onError: noop,
 			fromApi,
 		} ),
 	],

--- a/client/state/data-layer/wpcom/timezones/index.js
+++ b/client/state/data-layer/wpcom/timezones/index.js
@@ -10,7 +10,7 @@ import { fromPairs, map, mapValues } from 'lodash';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { TIMEZONES_REQUEST } from 'state/action-types';
 import { timezonesReceive } from 'state/timezones/actions';
 
@@ -43,21 +43,24 @@ export const fromApi = ( { manual_utc_offsets, timezones, timezones_by_continent
 /*
  * Start a request to WordPress.com server to get the timezones data
  */
-export const fetchTimezones = ( { dispatch }, action ) =>
-	dispatch(
-		http(
-			{
-				method: 'GET',
-				path: '/timezones',
-				apiNamespace: 'wpcom/v2',
-			},
-			action
-		)
+export const fetchTimezones = action =>
+	http(
+		{
+			method: 'GET',
+			path: '/timezones',
+			apiNamespace: 'wpcom/v2',
+		},
+		action
 	);
 
-export const addTimezones = ( { dispatch }, action, data ) =>
-	dispatch( timezonesReceive( fromApi( data ) ) );
+export const addTimezones = ( action, data ) => timezonesReceive( data );
 
 export default {
-	[ TIMEZONES_REQUEST ]: [ dispatchRequest( fetchTimezones, addTimezones ) ],
+	[ TIMEZONES_REQUEST ]: [
+		dispatchRequestEx( {
+			fetch: fetchTimezones,
+			onSuccess: addTimezones,
+			fromApi,
+		} ),
+	],
 };

--- a/client/state/data-layer/wpcom/timezones/test/index.js
+++ b/client/state/data-layer/wpcom/timezones/test/index.js
@@ -1,11 +1,5 @@
 /** @format */
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-import { spy } from 'sinon';
-
-/**
  * Internal dependencies
  */
 import { addTimezones, fetchTimezones, fromApi } from '../';
@@ -16,19 +10,17 @@ describe( 'timezones request', () => {
 	describe( 'successful requests', () => {
 		test( 'should dispatch HTTP GET request to /timezones endpoint', () => {
 			const action = { type: 'DUMMY' };
-			const dispatch = spy();
 
-			fetchTimezones( { dispatch }, action );
-
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith(
-				http(
-					{
-						apiNamespace: 'wpcom/v2',
-						method: 'GET',
-						path: '/timezones',
-					},
-					action
+			expect( fetchTimezones( action ) ).toEqual(
+				expect.objectContaining(
+					http(
+						{
+							apiNamespace: 'wpcom/v2',
+							method: 'GET',
+							path: '/timezones',
+						},
+						action
+					)
 				)
 			);
 		} );
@@ -57,12 +49,10 @@ describe( 'timezones request', () => {
 				},
 			};
 			const action = timezonesReceive( fromApi( responseData ) );
-			const dispatch = spy();
 
-			addTimezones( { dispatch }, action, responseData );
-
-			expect( dispatch ).to.have.been.calledOncee;
-			expect( dispatch ).to.have.been.calledWith( timezonesReceive( fromApi( responseData ) ) );
+			expect( addTimezones( action, fromApi( responseData ) ) ).toEqual(
+				expect.objectContaining( timezonesReceive( fromApi( responseData ) ) )
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
See #25121

In this patch we're replacing the use of dispatchRequest()
in the data layer handler to use the newer API exposed
as dispatchRequestEx() This should have no change in
actual effect or interaction.

**Testing**

View the Timezone component in the DevDocs and make
sure that it loads properly and does nothing when failing.
This should involve no functional or visual changes from
the existing code in **master**