### PR TITLE
Framework: `dispatchRequest` update (theme filters)

### DIFF
--- a/client/state/data-layer/wpcom/theme-filters/index.js
+++ b/client/state/data-layer/wpcom/theme-filters/index.js
@@ -10,29 +10,30 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import { THEME_FILTERS_REQUEST, THEME_FILTERS_ADD } from 'state/action-types';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 
-const fetchFilters = ( { dispatch }, action ) => {
-	dispatch(
-		http(
-			{
-				method: 'GET',
-				apiVersion: '1.2',
-				path: '/theme-filters',
-			},
-			action
-		)
+const fetchFilters = action =>
+	http(
+		{
+			method: 'GET',
+			apiVersion: '1.2',
+			path: '/theme-filters',
+		},
+		action
 	);
-};
 
-const storeFilters = ( { dispatch }, action, data ) =>
-	dispatch( { type: THEME_FILTERS_ADD, filters: data } );
+const storeFilters = ( action, data ) => ( { type: THEME_FILTERS_ADD, filters: data } );
 
-const reportError = ( { dispatch } ) =>
-	dispatch( errorNotice( i18n.translate( 'Problem fetching theme filters.' ) ) );
+const reportError = () => errorNotice( i18n.translate( 'Problem fetching theme filters.' ) );
 
 export default {
-	[ THEME_FILTERS_REQUEST ]: [ dispatchRequest( fetchFilters, storeFilters, reportError ) ],
+	[ THEME_FILTERS_REQUEST ]: [
+		dispatchRequestEx( {
+			fetch: fetchFilters,
+			onSuccess: storeFilters,
+			onError: reportError,
+		} ),
+	],
 };


### PR DESCRIPTION
See #25121

In this patch we're replacing the use of dispatchRequest()
in the data layer handler to use the newer API exposed
as dispatchRequestEx() This should have no change in
actual effect or interaction.

## Testing

The theme filters endpoint supplies the taxonomies, terms, and descriptions for the theme filter UI at /themes:

<img width="1241" alt="screen shot 2018-05-30 at 13 58 39" src="https://user-images.githubusercontent.com/7767559/40721627-f4c038f8-6411-11e8-8675-7733e63fdb7a.png">

* Check out this branch
* Restart the build because this data is also used for server-side-renders. Use `ENABLE_FEATURES=force-sympathy npm start` to make sure the filter data is cleared.
* In a logged-in window, go to http://calypso.localhost:3000/themes
* Check that the theme filter UI works properly as above
* In a logged-out window, hit a URL with filters, such as http://calypso.localhost:3000/themes/filter/orange
* The page should render sensibly, like so:
<img width="1248" alt="screen shot 2018-05-30 at 14 08 57" src="https://user-images.githubusercontent.com/7767559/40722070-36ca1f10-6413-11e8-9ac6-87c6bf595f12.png">
