### PR TITLE
Framework: `dispatchRequest` update (sites media)

### DIFF
--- a/client/state/data-layer/wpcom/sites/media/test/index.js
+++ b/client/state/data-layer/wpcom/sites/media/test/index.js
@@ -45,7 +45,7 @@ describe( 'media request', () => {
 
 	test( 'should dispatch FAILURE action when request fails', () => {
 		expect( requestMediaError( { siteId: 2916284, query: 'a=b' } ) ).toEqual(
-			expect.objectContaining( failMediaRequest( 2916284, 'a=b' ) )
+			failMediaRequest( 2916284, 'a=b' )
 		);
 	} );
 
@@ -118,8 +118,6 @@ describe( 'receiveMediaItemError', () => {
 			mediaId,
 			siteId,
 		};
-		expect( receiveMediaItemError( action ) ).toEqual(
-			expect.objectContaining( failMediaItemRequest( siteId, mediaId ) )
-		);
+		expect( receiveMediaItemError( action ) ).toEqual( failMediaItemRequest( siteId, mediaId ) );
 	} );
 } );

--- a/client/state/data-layer/wpcom/sites/media/test/index.js
+++ b/client/state/data-layer/wpcom/sites/media/test/index.js
@@ -1,15 +1,15 @@
 /** @format */
-
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-
 /**
  * Internal dependencies
  */
-import { handleMediaItemRequest, receiveMediaItem, receiveMediaItemError } from '../';
-import { requestMediaSuccess, requestMediaError, requestMedia } from '../';
+import {
+	handleMediaItemRequest,
+	receiveMediaItem,
+	receiveMediaItemError,
+	requestMedia,
+	requestMediaError,
+	requestMediaSuccess,
+} from '../';
 import { MEDIA_ITEM_REQUEST } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
@@ -21,65 +21,51 @@ import {
 	successMediaItemRequest,
 	successMediaRequest,
 } from 'state/media/actions';
-import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'media request', () => {
-	let dispatch;
-
-	useSandbox( sandbox => ( dispatch = sandbox.spy() ) );
-
-	const getState = () => ( {
-		media: {
-			queryRequests: {
-				2916284: {
-					'[]': true,
-				},
-			},
-		},
-	} );
-
 	test( 'should dispatch REQUESTING action when request triggers', () => {
-		requestMedia( { dispatch, getState }, { siteId: 2916284, query: 'a=b' } );
-		expect( dispatch ).to.have.been.calledWith( requestingMedia( 2916284, 'a=b' ) );
+		expect( requestMedia( { siteId: 2916284, query: 'a=b' } ) ).toEqual(
+			expect.arrayContaining( [ requestingMedia( 2916284, 'a=b' ) ] )
+		);
 	} );
 
 	test( 'should dispatch SUCCESS action when request completes', () => {
-		requestMediaSuccess(
-			{ dispatch },
-			{ siteId: 2916284, query: 'a=b' },
-			{ media: { ID: 10, title: 'media title' }, found: true }
-		);
-		expect( dispatch ).to.have.been.calledWith( successMediaRequest( 2916284, 'a=b' ) );
-		expect( dispatch ).to.have.been.calledWith(
-			receiveMedia( 2916284, { ID: 10, title: 'media title' }, true, 'a=b' )
+		expect(
+			requestMediaSuccess(
+				{ siteId: 2916284, query: 'a=b' },
+				{ media: { ID: 10, title: 'media title' }, found: true }
+			)
+		).toEqual(
+			expect.arrayContaining( [
+				successMediaRequest( 2916284, 'a=b' ),
+				receiveMedia( 2916284, { ID: 10, title: 'media title' }, true, 'a=b' ),
+			] )
 		);
 	} );
 
 	test( 'should dispatch FAILURE action when request fails', () => {
-		requestMediaError( { dispatch }, { siteId: 2916284, query: 'a=b' } );
-		expect( dispatch ).to.have.been.calledWith( failMediaRequest( 2916284, 'a=b' ) );
+		expect( requestMediaError( { siteId: 2916284, query: 'a=b' } ) ).toEqual(
+			expect.objectContaining( failMediaRequest( 2916284, 'a=b' ) )
+		);
 	} );
 
 	test( 'should dispatch http request', () => {
-		requestMedia( { dispatch, getState }, { siteId: 2916284, query: 'a=b' } );
-		expect( dispatch ).to.have.been.calledWith(
-			http(
-				{
-					method: 'GET',
-					path: '/sites/2916284/media',
-					apiVersion: '1.1',
-				},
-				{ siteId: 2916284, query: 'a=b' }
-			)
+		expect( requestMedia( { siteId: 2916284, query: 'a=b' } ) ).toEqual(
+			expect.arrayContaining( [
+				http(
+					{
+						method: 'GET',
+						path: '/sites/2916284/media',
+						apiVersion: '1.1',
+					},
+					{ siteId: 2916284, query: 'a=b' }
+				),
+			] )
 		);
 	} );
 } );
 
 describe( 'handleMediaItemRequest', () => {
-	let dispatch;
-
-	useSandbox( sandbox => ( dispatch = sandbox.spy() ) );
-
 	test( 'should dispatch an http action', () => {
 		const siteId = 12345;
 		const mediaId = 67890;
@@ -88,27 +74,23 @@ describe( 'handleMediaItemRequest', () => {
 			mediaId,
 			siteId,
 		};
-		handleMediaItemRequest( { dispatch }, action );
-		expect( dispatch ).to.have.been.calledTwice;
-		expect( dispatch ).to.have.been.calledWith( requestingMediaItem( siteId ) );
-		expect( dispatch ).to.have.been.calledWith(
-			http(
-				{
-					apiVersion: '1.2',
-					method: 'GET',
-					path: `/sites/${ siteId }/media/${ mediaId }`,
-				},
-				action
-			)
+		expect( handleMediaItemRequest( action ) ).toEqual(
+			expect.arrayContaining( [
+				requestingMediaItem( siteId ),
+				http(
+					{
+						apiVersion: '1.2',
+						method: 'GET',
+						path: `/sites/${ siteId }/media/${ mediaId }`,
+					},
+					action
+				),
+			] )
 		);
 	} );
 } );
 
 describe( 'receiveMediaItem', () => {
-	let dispatch;
-
-	useSandbox( sandbox => ( dispatch = sandbox.spy() ) );
-
 	test( 'should dispatch media recieve actions', () => {
 		const siteId = 12345;
 		const mediaId = 67890;
@@ -118,18 +100,16 @@ describe( 'receiveMediaItem', () => {
 			siteId,
 		};
 		const media = { ID: 91827364 };
-		receiveMediaItem( { dispatch }, action, media );
-		expect( dispatch ).to.have.been.calledTwice,
-			expect( dispatch ).to.have.been.calledWith( receiveMedia( siteId, media ) );
-		expect( dispatch ).to.have.been.calledWith( successMediaItemRequest( siteId, mediaId ) );
+		expect( receiveMediaItem( action, media ) ).toEqual(
+			expect.arrayContaining( [
+				receiveMedia( siteId, media ),
+				successMediaItemRequest( siteId, mediaId ),
+			] )
+		);
 	} );
 } );
 
 describe( 'receiveMediaItemError', () => {
-	let dispatch;
-
-	useSandbox( sandbox => ( dispatch = sandbox.spy() ) );
-
 	test( 'should dispatch failure', () => {
 		const siteId = 12345;
 		const mediaId = 67890;
@@ -138,7 +118,8 @@ describe( 'receiveMediaItemError', () => {
 			mediaId,
 			siteId,
 		};
-		receiveMediaItemError( { dispatch }, action );
-		expect( dispatch ).to.have.been.calledWith( failMediaItemRequest( siteId, mediaId ) );
+		expect( receiveMediaItemError( action ) ).toEqual(
+			expect.objectContaining( failMediaItemRequest( siteId, mediaId ) )
+		);
 	} );
 } );


### PR DESCRIPTION
See #25121

In this patch we're replacing the use of dispatchRequest()
in the data layer handler to use the newer API exposed
as dispatchRequestEx() This should have no change in
actual effect or interaction.