### PR TITLE
Framework: `dispatchRequest` update (plugins new)

### DIFF
--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -16,19 +16,18 @@ import {
 	pluginUploadError,
 	updatePluginUploadProgress,
 } from 'state/plugins/upload/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSite } from 'state/sites/selectors';
 import Dispatcher from 'dispatcher';
 
-export const uploadPlugin = ( { dispatch }, action ) => {
+export const uploadPlugin = action => {
 	const { siteId, file } = action;
 
-	dispatch( recordTracksEvent( 'calypso_plugin_upload' ) );
-
-	dispatch(
+	return [
+		recordTracksEvent( 'calypso_plugin_upload' ),
 		http(
 			{
 				method: 'POST',
@@ -37,11 +36,11 @@ export const uploadPlugin = ( { dispatch }, action ) => {
 				formData: [ [ 'zip[]', file ] ],
 			},
 			action
-		)
-	);
+		),
+	];
 };
 
-const showErrorNotice = ( dispatch, error ) => {
+const showErrorNotice = error => {
 	const knownErrors = {
 		exists: translate( 'This plugin is already installed on your site.' ),
 		'too large': translate( 'The plugin zip file must be smaller than 10MB.' ),
@@ -52,23 +51,21 @@ const showErrorNotice = ( dispatch, error ) => {
 	const knownError = find( knownErrors, ( v, key ) => includes( errorString, key ) );
 
 	if ( knownError ) {
-		dispatch( errorNotice( knownError ) );
-		return;
+		return errorNotice( knownError );
 	}
+
 	if ( error.error ) {
-		dispatch(
-			errorNotice(
-				translate( 'Upload problem: %(error)s.', {
-					args: { error: error.error },
-				} )
-			)
+		return errorNotice(
+			translate( 'Upload problem: %(error)s.', {
+				args: { error: error.error },
+			} )
 		);
-		return;
 	}
-	dispatch( errorNotice( translate( 'Problem installing the plugin.' ) ) );
+
+	return errorNotice( translate( 'Problem installing the plugin.' ) );
 };
 
-export const uploadComplete = ( { dispatch, getState }, { siteId }, data ) => {
+export const uploadComplete = ( { siteId }, data ) => ( dispatch, getState ) => {
 	const { slug: pluginId } = data;
 	const state = getState();
 	const site = getSite( state, siteId );
@@ -94,26 +91,27 @@ export const uploadComplete = ( { dispatch, getState }, { siteId }, data ) => {
 	} );
 };
 
-export const receiveError = ( { dispatch }, { siteId }, error ) => {
-	dispatch(
-		recordTracksEvent( 'calypso_plugin_upload_error', {
-			error_code: error.error,
-			error_message: error.message,
-		} )
-	);
+export const receiveError = ( { siteId }, error ) => [
+	recordTracksEvent( 'calypso_plugin_upload_error', {
+		error_code: error.error,
+		error_message: error.message,
+	} ),
+	showErrorNotice( error ),
+	pluginUploadError( siteId, error ),
+];
 
-	showErrorNotice( dispatch, error );
-	dispatch( pluginUploadError( siteId, error ) );
-};
-
-export const updateUploadProgress = ( { dispatch }, { siteId }, { loaded, total } ) => {
+export const updateUploadProgress = ( { siteId }, { loaded, total } ) => {
 	const progress = total ? loaded / total * 100 : total;
-	dispatch( updatePluginUploadProgress( siteId, progress ) );
+
+	return updatePluginUploadProgress( siteId, progress );
 };
 
 export default {
 	[ PLUGIN_UPLOAD ]: [
-		dispatchRequest( uploadPlugin, uploadComplete, receiveError, {
+		dispatchRequestEx( {
+			fetch: uploadPlugin,
+			onSuccess: uploadComplete,
+			onError: receiveError,
 			onProgress: updateUploadProgress,
 		} ),
 	],

--- a/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
@@ -92,7 +92,7 @@ describe( 'receiveError', () => {
 } );
 
 describe( 'updateUploadProgress', () => {
-	test( 'should return a  plugin upload progress update action', () => {
+	test( 'should return a plugin upload progress update action', () => {
 		const action = updateUploadProgress( { siteId }, { loaded: 200, total: 400 } );
 		expect( action ).toEqual( updatePluginUploadProgress( siteId, 50 ) );
 	} );

--- a/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
@@ -1,10 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-import deepFreeze from 'deep-freeze';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -16,11 +10,12 @@ import {
 	pluginUploadError,
 	updatePluginUploadProgress,
 } from 'state/plugins/upload/actions';
+import { getSite } from 'state/sites/selectors';
 
 const siteId = 77203074;
 const pluginId = 'hello-dolly';
 
-const SUCCESS_RESPONSE = deepFreeze( {
+const SUCCESS_RESPONSE = {
 	active: false,
 	author: 'blah',
 	author_url: 'http://example.com',
@@ -32,65 +27,52 @@ const SUCCESS_RESPONSE = deepFreeze( {
 	plugin_url: 'http://wordpress.org/extend/plugins/hello-dolly/',
 	slug: 'hello-dolly',
 	version: '1.6',
-} );
+};
 
-const ERROR_RESPONSE = deepFreeze( {
+const ERROR_RESPONSE = {
 	error: 'folder_exists',
 	message: 'folder_exists',
-} );
+};
+
+jest.mock( 'dispatcher' );
+jest.mock( 'state/sites/selectors' );
 
 describe( 'uploadPlugin', () => {
-	test( 'should distpatch an http request', () => {
-		const dispatch = sinon.spy();
-		uploadPlugin( { dispatch }, { siteId, file: 'xyz' } );
-		expect( dispatch ).to.have.been.calledWithMatch( {
-			formData: [ [ 'zip[]', 'xyz' ] ],
-			method: 'POST',
-			path: `/sites/${ siteId }/plugins/new`,
-		} );
+	test( 'should return an http request action', () => {
+		const action = uploadPlugin( { siteId, file: 'xyz' } );
+		expect( action ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					formData: [ [ 'zip[]', 'xyz' ] ],
+					method: 'POST',
+					path: `/sites/${ siteId }/plugins/new`,
+				} ),
+			] )
+		);
 	} );
 } );
 
 describe( 'uploadComplete', () => {
-	let sandbox;
 	const site = {
 		ID: siteId,
 		URL: 'https://wordpress.com',
 	};
-	const getState = () => ( {
-		sites: {
-			items: {
-				[ siteId ]: site,
-			},
-		},
-		currentUser: {
-			capabilities: {
-				edit_theme_options: true,
-			},
-		},
-	} );
+	const getState = jest.fn();
 
-	beforeEach( () => {
-		sandbox = sinon.sandbox.create();
-		sandbox.stub( Dispatcher, 'handleServerAction' );
-	} );
-
-	afterEach( () => {
-		sandbox.restore();
-	} );
-
-	test( 'should dispatch plugin upload complete action', () => {
-		const dispatch = sinon.spy();
-		uploadComplete( { dispatch, getState }, { siteId }, SUCCESS_RESPONSE );
-		expect( dispatch ).to.have.been.calledWith( completePluginUpload( siteId, pluginId ) );
+	test( 'should return a plugin upload complete action', () => {
+		const dispatch = jest.fn();
+		uploadComplete( { siteId }, SUCCESS_RESPONSE )( dispatch, getState );
+		expect( dispatch ).toHaveBeenCalledWith( completePluginUpload( siteId, pluginId ) );
 	} );
 
 	test( 'should dispatch a receive installed plugin action', () => {
-		const dispatch = sinon.spy();
+		Dispatcher.handleServerAction.mockImplementation( () => {} );
+		getSite.mockImplementation( () => site );
+		const dispatch = jest.fn();
 
-		uploadComplete( { dispatch, getState }, { siteId }, SUCCESS_RESPONSE );
+		uploadComplete( { siteId }, SUCCESS_RESPONSE )( dispatch, getState );
 
-		expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
+		expect( Dispatcher.handleServerAction ).toHaveBeenCalledWith( {
 			type: 'RECEIVE_INSTALLED_PLUGIN',
 			action: 'PLUGIN_UPLOAD',
 			site,
@@ -101,17 +83,17 @@ describe( 'uploadComplete', () => {
 } );
 
 describe( 'receiveError', () => {
-	test( 'should dispatch plugin upload error', () => {
-		const dispatch = sinon.spy();
-		receiveError( { dispatch }, { siteId }, ERROR_RESPONSE );
-		expect( dispatch ).to.have.been.calledWith( pluginUploadError( siteId, ERROR_RESPONSE ) );
+	test( 'should return a plugin upload error action', () => {
+		const action = receiveError( { siteId }, ERROR_RESPONSE );
+		expect( action ).toEqual(
+			expect.arrayContaining( [ pluginUploadError( siteId, ERROR_RESPONSE ) ] )
+		);
 	} );
 } );
 
 describe( 'updateUploadProgress', () => {
-	test( 'should dispatch plugin upload progress update', () => {
-		const dispatch = sinon.spy();
-		updateUploadProgress( { dispatch }, { siteId }, { loaded: 200, total: 400 } );
-		expect( dispatch ).to.have.been.calledWith( updatePluginUploadProgress( siteId, 50 ) );
+	test( 'should return a  plugin upload progress update action', () => {
+		const action = updateUploadProgress( { siteId }, { loaded: 200, total: 400 } );
+		expect( action ).toEqual( updatePluginUploadProgress( siteId, 50 ) );
 	} );
 } );


### PR DESCRIPTION
See #25121

In this patch we're replacing the use of dispatchRequest()
in the data layer handler to use the newer API exposed
as dispatchRequestEx() This should have no change in
actual effect or interaction.

## Testing
* Check out and build this branch
* go to http://calypso.localhost:3000/plugins/upload/{jetpack-site}
* Upload a plugin (on that is not already on the site)
* You should see a success notice and a details screen for the plugin
* Upload the same plugin again
* You should get an error notice
