### PR TITLE
Framework: `dispatchRequest` update (blog stickers add)

### DIFF
--- a/client/state/data-layer/wpcom/sites/blog-stickers/add/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/add/index.js
@@ -33,13 +33,7 @@ export const receiveBlogStickerAddError = action => [
 	bypassDataLayer( removeBlogSticker( action.payload.blogId, action.payload.stickerName ) ),
 ];
 
-export const receiveBlogStickerAdd = ( action, response ) => {
-	// validate that it worked
-	const isAdded = !! ( response && response.success );
-	if ( ! isAdded ) {
-		return receiveBlogStickerAddError( action );
-	}
-
+export const receiveBlogStickerAdd = action => {
 	return successNotice(
 		translate( 'The sticker {{i}}%s{{/i}} has been successfully added.', {
 			args: action.payload.stickerName,
@@ -53,12 +47,20 @@ export const receiveBlogStickerAdd = ( action, response ) => {
 	);
 };
 
+export function fromApi( response ) {
+	if ( ! response.success ) {
+		throw new Error( 'Adding blog sticker was unsuccessful', response );
+	}
+	return response;
+}
+
 export default {
 	[ SITES_BLOG_STICKER_ADD ]: [
 		dispatchRequestEx( {
 			fetch: requestBlogStickerAdd,
 			onSuccess: receiveBlogStickerAdd,
 			onError: receiveBlogStickerAddError,
+			fromApi,
 		} ),
 	],
 };

--- a/client/state/data-layer/wpcom/sites/blog-stickers/add/test/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/add/test/index.js
@@ -1,88 +1,80 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-import { spy } from 'sinon';
-
-/**
  * Internal dependencies
  */
-import { requestBlogStickerAdd, receiveBlogStickerAdd, receiveBlogStickerAddError } from '../';
+import {
+	requestBlogStickerAdd,
+	receiveBlogStickerAdd,
+	receiveBlogStickerAddError,
+	fromApi,
+} from '../';
 import { bypassDataLayer } from 'state/data-layer/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { addBlogSticker, removeBlogSticker } from 'state/sites/blog-stickers/actions';
 
 describe( 'blog-sticker-add', () => {
 	describe( 'requestBlogStickerAdd', () => {
-		test( 'should dispatch an http request and call through next', () => {
-			const dispatch = spy();
+		test( 'should dispatch a http request', () => {
 			const action = addBlogSticker( 123, 'broken-in-reader' );
-			requestBlogStickerAdd( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledWith(
-				http( {
-					method: 'POST',
-					path: '/sites/123/blog-stickers/add/broken-in-reader',
-					body: {},
-					apiVersion: '1.1',
-					onSuccess: action,
-					onFailure: action,
-				} )
+
+			expect( requestBlogStickerAdd( action ) ).toEqual(
+				http(
+					{
+						method: 'POST',
+						path: '/sites/123/blog-stickers/add/broken-in-reader',
+						body: {},
+						apiVersion: '1.1',
+					},
+					action
+				)
 			);
 		} );
 	} );
 
 	describe( 'receiveBlogStickerAdd', () => {
 		test( 'should dispatch a success notice', () => {
-			const dispatch = spy();
-			receiveBlogStickerAdd(
-				{ dispatch },
-				{ payload: { blogId: 123, stickerName: 'broken-in-reader' } },
-				{ success: true }
-			);
-			expect( dispatch ).to.have.been.calledWithMatch( {
-				notice: {
-					status: 'is-success',
-				},
+			const output = receiveBlogStickerAdd( {
+				payload: { blogId: 123, stickerName: 'broken-in-reader' },
 			} );
+			expect( output ).toEqual(
+				expect.objectContaining( {
+					notice: expect.objectContaining( {
+						status: 'is-success',
+					} ),
+				} )
+			);
 		} );
+	} );
 
-		test( 'should dispatch a sticker removal if it fails using next', () => {
-			const dispatch = spy();
-			receiveBlogStickerAdd(
-				{ dispatch },
+	describe( 'receiveBlogStickerAddError', () => {
+		test( 'should revert to the previous state', () => {
+			const output = receiveBlogStickerAddError(
 				{ payload: { blogId: 123, stickerName: 'broken-in-reader' } },
 				{
 					success: false,
 				}
 			);
-			expect( dispatch ).to.have.been.calledWith(
+
+			expect( output[ 0 ] ).toEqual(
+				expect.objectContaining( {
+					notice: expect.objectContaining( {
+						status: 'is-error',
+					} ),
+				} )
+			);
+			expect( output[ 1 ] ).toEqual(
 				bypassDataLayer( removeBlogSticker( 123, 'broken-in-reader' ) )
 			);
-			expect( dispatch ).to.have.been.calledWithMatch( {
-				notice: {
-					status: 'is-error',
-				},
-			} );
 		} );
 	} );
 
-	describe( 'receiveBlogStickerAddError', () => {
-		test( 'should dispatch an error notice and remove sticker action using next', () => {
-			const dispatch = spy();
-			receiveBlogStickerAddError(
-				{ dispatch },
-				{ payload: { blogId: 123, stickerName: 'broken-in-reader' } }
-			);
-			expect( dispatch ).to.have.been.calledWithMatch( {
-				notice: {
-					status: 'is-error',
-				},
-			} );
-			expect( dispatch ).to.have.been.calledWith(
-				bypassDataLayer( removeBlogSticker( 123, 'broken-in-reader' ) )
-			);
+	describe( 'fromApi', () => {
+		it( 'should throw an error for an unsuccessful add', () => {
+			expect( () => fromApi( { success: false } ) ).toThrow();
+		} );
+		it( 'should return original response for a successful add', () => {
+			expect( fromApi( { success: true } ) ).toEqual( { success: true } );
 		} );
 	} );
 } );


### PR DESCRIPTION
See #25121

In this patch we're replacing the use of dispatchRequest()
in the data layer handler to use the newer API exposed
as dispatchRequestEx() This should have no change in
actual effect or interaction.