### PR TITLE
Framework: `dispatchRequest` update (blog stickers)

### DIFF
--- a/client/state/data-layer/wpcom/sites/blog-stickers/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/index.js
@@ -20,14 +20,15 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import { receiveBlogStickers } from 'state/sites/blog-stickers/actions';
 
 export const requestBlogStickerList = action =>
-	http( {
-		method: 'GET',
-		path: `/sites/${ action.payload.blogId }/blog-stickers`,
-		body: {}, // have to have an empty body to make wpcom-http happy
-		apiVersion: '1.1',
-		onSuccess: action,
-		onFailure: action,
-	} );
+	http(
+		{
+			method: 'GET',
+			path: `/sites/${ action.payload.blogId }/blog-stickers`,
+			body: {}, // have to have an empty body to make wpcom-http happy
+			apiVersion: '1.1',
+		},
+		action
+	);
 
 export const receiveBlogStickerListError = () =>
 	errorNotice( translate( 'Sorry, we had a problem retrieving blog stickers. Please try again.' ) );

--- a/client/state/data-layer/wpcom/sites/blog-stickers/test/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/test/index.js
@@ -1,12 +1,6 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-import { spy } from 'sinon';
-
-/**
  * Internal dependencies
  */
 import { requestBlogStickerList, receiveBlogStickerListError } from '../';
@@ -15,32 +9,33 @@ import { listBlogStickers } from 'state/sites/blog-stickers/actions';
 
 describe( 'blog-sticker-list', () => {
 	describe( 'requestBlogStickerList', () => {
-		test( 'should dispatch an http request and call through next', () => {
-			const dispatch = spy();
+		test( 'should dispatch a http request', () => {
 			const action = listBlogStickers( 123 );
-			requestBlogStickerList( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledWith(
-				http( {
-					method: 'GET',
-					path: '/sites/123/blog-stickers',
-					body: {},
-					apiVersion: '1.1',
-					onSuccess: action,
-					onFailure: action,
-				} )
+			const output = requestBlogStickerList( action );
+			expect( output ).toEqual(
+				http(
+					{
+						method: 'GET',
+						path: '/sites/123/blog-stickers',
+						body: {},
+						apiVersion: '1.1',
+					},
+					action
+				)
 			);
 		} );
 	} );
 
 	describe( 'receiveBlogStickerListError', () => {
 		test( 'should dispatch an error notice', () => {
-			const dispatch = spy();
-			receiveBlogStickerListError( { dispatch }, { payload: { blogId: 123 } } );
-			expect( dispatch ).to.have.been.calledWithMatch( {
-				notice: {
-					text: 'Sorry, we had a problem retrieving blog stickers. Please try again.',
-				},
-			} );
+			const output = receiveBlogStickerListError( { payload: { blogId: 123 } } );
+			expect( output ).toEqual(
+				expect.objectContaining( {
+					notice: expect.objectContaining( {
+						status: 'is-error',
+					} ),
+				} )
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
See #25121

In this patch we're replacing the use of dispatchRequest()
in the data layer handler to use the newer API exposed
as dispatchRequestEx() This should have no change in
actual effect or interaction.