### PR TITLE
Framework: `dispatchRequest` update (blog stickers remove)

### DIFF
--- a/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
@@ -18,14 +18,17 @@ import { errorNotice, plainNotice } from 'state/notices/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
 export const requestBlogStickerRemove = action =>
-	http( {
-		method: 'POST',
-		path: `/sites/${ action.payload.blogId }/blog-stickers/remove/${ action.payload.stickerName }`,
-		body: {}, // have to have an empty body to make wpcom-http happy
-		apiVersion: '1.1',
-		onSuccess: action,
-		onFailure: action,
-	} );
+	http(
+		{
+			method: 'POST',
+			path: `/sites/${ action.payload.blogId }/blog-stickers/remove/${
+				action.payload.stickerName
+			}`,
+			body: {}, // have to have an empty body to make wpcom-http happy
+			apiVersion: '1.1',
+		},
+		action
+	);
 
 export const receiveBlogStickerRemoveError = action => [
 	errorNotice( translate( 'Sorry, we had a problem removing that sticker. Please try again.' ) ),
@@ -45,10 +48,12 @@ export const receiveBlogStickerRemove = action =>
 		}
 	);
 
-const fromApi = ( { success } ) => {
-	if ( ! success ) {
-		throw new Error( 'Remove was unsuccessful on the server' );
+export const fromApi = response => {
+	if ( ! response.success ) {
+		throw new Error( 'Blog sticker removal was unsuccessful on the server' );
 	}
+
+	return response;
 };
 
 export default {

--- a/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
@@ -12,65 +12,52 @@ import { translate } from 'i18n-calypso';
  */
 import { SITES_BLOG_STICKER_REMOVE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { addBlogSticker } from 'state/sites/blog-stickers/actions';
 import { errorNotice, plainNotice } from 'state/notices/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
-export function requestBlogStickerRemove( { dispatch }, action ) {
-	dispatch(
-		http( {
-			method: 'POST',
-			path: `/sites/${ action.payload.blogId }/blog-stickers/remove/${
-				action.payload.stickerName
-			}`,
-			body: {}, // have to have an empty body to make wpcom-http happy
-			apiVersion: '1.1',
-			onSuccess: action,
-			onFailure: action,
-		} )
-	);
-}
+export const requestBlogStickerRemove = action =>
+	http( {
+		method: 'POST',
+		path: `/sites/${ action.payload.blogId }/blog-stickers/remove/${ action.payload.stickerName }`,
+		body: {}, // have to have an empty body to make wpcom-http happy
+		apiVersion: '1.1',
+		onSuccess: action,
+		onFailure: action,
+	} );
 
-export function receiveBlogStickerRemove( store, action, response ) {
-	// validate that it worked
-	const isRemoved = !! ( response && response.success );
-	if ( ! isRemoved ) {
-		receiveBlogStickerRemoveError( store, action );
-		return;
+export const receiveBlogStickerRemoveError = action => [
+	errorNotice( translate( 'Sorry, we had a problem removing that sticker. Please try again.' ) ),
+	bypassDataLayer( addBlogSticker( action.payload.blogId, action.payload.stickerName ) ),
+];
+
+export const receiveBlogStickerRemove = action =>
+	plainNotice(
+		translate( 'The sticker {{i}}%s{{/i}} has been removed.', {
+			args: action.payload.stickerName,
+			components: {
+				i: <i />,
+			},
+		} ),
+		{
+			duration: 5000,
+		}
+	);
+
+const fromApi = ( { success } ) => {
+	if ( ! success ) {
+		throw new Error( 'Remove was unsuccessful on the server' );
 	}
-
-	store.dispatch(
-		plainNotice(
-			translate( 'The sticker {{i}}%s{{/i}} has been removed.', {
-				args: action.payload.stickerName,
-				components: {
-					i: <i />,
-				},
-			} ),
-			{
-				duration: 5000,
-			}
-		)
-	);
-}
-
-export function receiveBlogStickerRemoveError( { dispatch }, action ) {
-	dispatch(
-		errorNotice( translate( 'Sorry, we had a problem removing that sticker. Please try again.' ) )
-	);
-	// Revert the removal
-	dispatch(
-		bypassDataLayer( addBlogSticker( action.payload.blogId, action.payload.stickerName ) )
-	);
-}
+};
 
 export default {
 	[ SITES_BLOG_STICKER_REMOVE ]: [
-		dispatchRequest(
-			requestBlogStickerRemove,
-			receiveBlogStickerRemove,
-			receiveBlogStickerRemoveError
-		),
+		dispatchRequestEx( {
+			fetch: requestBlogStickerRemove,
+			onSuccess: receiveBlogStickerRemove,
+			onError: receiveBlogStickerRemoveError,
+			fromApi,
+		} ),
 	],
 };


### PR DESCRIPTION
See #25121

In this patch we're replacing the use of dispatchRequest()
in the data layer handler to use the newer API exposed
as dispatchRequestEx() This should have no change in
actual effect or interaction.