### PR TITLE
Framework: `dispatchRequest` update (activity log activate)

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/activate/index.js
+++ b/client/state/data-layer/wpcom/activity-log/activate/index.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { translate } from 'i18n-calypso';
 import { get } from 'lodash';
 
@@ -12,28 +10,24 @@ import { get } from 'lodash';
  */
 import { REWIND_ACTIVATE_REQUEST, REWIND_STATE_UPDATE } from 'state/action-types';
 import { rewindActivateFailure, rewindActivateSuccess } from 'state/activity-log/actions';
-import { dispatchRequestEx, getData } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 import { transformApi } from 'state/data-layer/wpcom/sites/rewind/api-transformer';
 
-const activateRewind = action => {
-	const params = {
-		method: 'POST',
-		path: `/activity-log/${ action.siteId }/rewind/activate`,
-		apiVersion: '1',
-	};
+const activateRewind = action =>
+	http(
+		{
+			method: 'POST',
+			path: `/activity-log/${ action.siteId }/rewind/activate`,
+			apiVersion: '1',
+			...( action.isVpMigrate ? { body: { rewindOptIn: true } } : {} ),
+		},
+		action
+	);
 
-	if ( action.isVpMigrate ) {
-		params.body = { rewindOptIn: true };
-	}
-
-	return http( params, action );
-};
-
-export const activateSucceeded = action => {
+export const activateSucceeded = ( action, rawData ) => {
 	const successNotifier = rewindActivateSuccess( action.siteId );
-	const rawData = getData( action );
 
 	if ( undefined === get( rawData, 'rewind_state', undefined ) ) {
 		return successNotifier;

--- a/client/state/data-layer/wpcom/activity-log/activate/index.js
+++ b/client/state/data-layer/wpcom/activity-log/activate/index.js
@@ -12,44 +12,54 @@ import { get } from 'lodash';
  */
 import { REWIND_ACTIVATE_REQUEST, REWIND_STATE_UPDATE } from 'state/action-types';
 import { rewindActivateFailure, rewindActivateSuccess } from 'state/activity-log/actions';
-import { dispatchRequest, getData } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx, getData } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 import { transformApi } from 'state/data-layer/wpcom/sites/rewind/api-transformer';
 
-const activateRewind = ( { dispatch }, action ) => {
+const activateRewind = action => {
 	const params = {
 		method: 'POST',
 		path: `/activity-log/${ action.siteId }/rewind/activate`,
 		apiVersion: '1',
 	};
+
 	if ( action.isVpMigrate ) {
 		params.body = { rewindOptIn: true };
 	}
-	dispatch( http( params, action ) );
+
+	return http( params, action );
 };
 
-export const activateSucceeded = ( { dispatch }, action ) => {
-	dispatch( rewindActivateSuccess( action.siteId ) );
+export const activateSucceeded = action => {
+	const successNotifier = rewindActivateSuccess( action.siteId );
 	const rawData = getData( action );
-	if ( undefined !== get( rawData, 'rewind_state', undefined ) ) {
-		dispatch( {
+
+	if ( undefined === get( rawData, 'rewind_state', undefined ) ) {
+		return successNotifier;
+	}
+
+	return [
+		successNotifier,
+		{
 			type: REWIND_STATE_UPDATE,
 			siteId: action.siteId,
 			data: transformApi( rawData.rewind_state ),
-		} );
-	}
+		},
+	];
 };
 
-export const activateFailed = ( { dispatch }, { siteId }, { message } ) => {
-	dispatch(
-		errorNotice( translate( 'Problem activating rewind: %(message)s', { args: { message } } ) )
-	);
-	dispatch( rewindActivateFailure( siteId ) );
-};
+export const activateFailed = ( { siteId }, { message } ) => [
+	errorNotice( translate( 'Problem activating rewind: %(message)s', { args: { message } } ) ),
+	rewindActivateFailure( siteId ),
+];
 
 export default {
 	[ REWIND_ACTIVATE_REQUEST ]: [
-		dispatchRequest( activateRewind, activateSucceeded, activateFailed ),
+		dispatchRequestEx( {
+			fetch: activateRewind,
+			onSuccess: activateSucceeded,
+			onError: activateFailed,
+		} ),
 	],
 };

--- a/client/state/data-layer/wpcom/activity-log/activate/test/index.js
+++ b/client/state/data-layer/wpcom/activity-log/activate/test/index.js
@@ -23,7 +23,10 @@ describe( 'activateFailed', () => {
 	test( 'should dispatch an error notice', () => {
 		expect( activateFailed( { siteId }, { message: 'some problem' } ) ).toContainEqual(
 			expect.objectContaining( {
-				notice: expect.anything(),
+				notice: expect.objectContaining( {
+					status: 'is-error',
+					text: 'Problem activating rewind: some problem',
+				} ),
 			} )
 		);
 	} );

--- a/client/state/data-layer/wpcom/activity-log/activate/test/index.js
+++ b/client/state/data-layer/wpcom/activity-log/activate/test/index.js
@@ -1,11 +1,4 @@
 /** @format */
-
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-import sinon from 'sinon';
-
 /**
  * Internal dependencies
  */
@@ -16,28 +9,21 @@ const siteId = 77203074;
 
 describe( 'activateSucceeded', () => {
 	test( 'should dispatch rewind activate success action', () => {
-		const dispatch = sinon.spy();
-		activateSucceeded( { dispatch }, { siteId } );
-		expect( dispatch ).to.have.been.calledWith( rewindActivateSuccess( siteId ) );
+		expect( activateSucceeded( { siteId } ) ).toEqual( rewindActivateSuccess( siteId ) );
 	} );
 } );
 
 describe( 'activateFailed', () => {
 	test( 'should dispatch rewind activate failed action', () => {
-		const dispatch = sinon.spy();
-		activateFailed( { dispatch }, { siteId }, { message: 'some problem' } );
-		expect( dispatch ).to.have.been.calledWith( rewindActivateFailure( siteId ) );
+		expect( activateFailed( { siteId }, { message: 'some problem' } ) ).toContainEqual(
+			rewindActivateFailure( siteId )
+		);
 	} );
 
 	test( 'should dispatch an error notice', () => {
-		const dispatch = sinon.spy();
-		activateFailed( { dispatch }, { siteId }, { message: 'some problem' } );
-		expect( dispatch ).to.have.been.calledWith(
-			sinon.match( {
-				notice: {
-					status: 'is-error',
-					text: 'Problem activating rewind: some problem',
-				},
+		expect( activateFailed( { siteId }, { message: 'some problem' } ) ).toContainEqual(
+			expect.objectContaining( {
+				notice: expect.anything(),
 			} )
 		);
 	} );


### PR DESCRIPTION
See #25121

In this patch we're replacing the use of dispatchRequest()
in the data layer handler to use the newer API exposed
as dispatchRequestEx() This should have no change in
actual effect or interaction.