### PR TITLE
Framework: `dispatchRequest` update (activity log deactivate)

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/deactivate/index.js
+++ b/client/state/data-layer/wpcom/activity-log/deactivate/index.js
@@ -11,36 +11,33 @@ import { translate } from 'i18n-calypso';
  */
 import { REWIND_DEACTIVATE_REQUEST } from 'state/action-types';
 import { rewindDeactivateFailure, rewindDeactivateSuccess } from 'state/activity-log/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 
-const deactivateRewind = ( { dispatch }, action ) => {
-	dispatch(
-		http(
-			{
-				method: 'POST',
-				path: `/activity-log/${ action.siteId }/rewind/deactivate`,
-				apiVersion: '1',
-			},
-			action
-		)
+const deactivateRewind = action =>
+	http(
+		{
+			method: 'POST',
+			path: `/activity-log/${ action.siteId }/rewind/deactivate`,
+			apiVersion: '1',
+		},
+		action
 	);
-};
 
-export const deactivateSucceeded = ( { dispatch }, { siteId } ) => {
-	dispatch( rewindDeactivateSuccess( siteId ) );
-};
+export const deactivateSucceeded = ( { siteId } ) => rewindDeactivateSuccess( siteId );
 
-export const deactivateFailed = ( { dispatch }, { siteId }, { message } ) => {
-	dispatch(
-		errorNotice( translate( 'Problem deactivating rewind: %(message)s', { args: { message } } ) )
-	);
-	dispatch( rewindDeactivateFailure( siteId ) );
-};
+export const deactivateFailed = ( { siteId }, { message } ) => [
+	errorNotice( translate( 'Problem deactivating rewind: %(message)s', { args: { message } } ) ),
+	rewindDeactivateFailure( siteId ),
+];
 
 export default {
 	[ REWIND_DEACTIVATE_REQUEST ]: [
-		dispatchRequest( deactivateRewind, deactivateSucceeded, deactivateFailed ),
+		dispatchRequestEx( {
+			fetch: deactivateRewind,
+			onSuccess: deactivateSucceeded,
+			onError: deactivateFailed,
+		} ),
 	],
 };

--- a/client/state/data-layer/wpcom/activity-log/deactivate/test/index.js
+++ b/client/state/data-layer/wpcom/activity-log/deactivate/test/index.js
@@ -1,11 +1,4 @@
 /** @format */
-
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-import sinon from 'sinon';
-
 /**
  * Internal dependencies
  */
@@ -16,28 +9,24 @@ const siteId = 77203074;
 
 describe( 'dectivateSucceeded', () => {
 	test( 'should dispatch rewind deactivate success action', () => {
-		const dispatch = sinon.spy();
-		deactivateSucceeded( { dispatch }, { siteId } );
-		expect( dispatch ).to.have.been.calledWith( rewindDeactivateSuccess( siteId ) );
+		expect( deactivateSucceeded( { siteId } ) ).toEqual( rewindDeactivateSuccess( siteId ) );
 	} );
 } );
 
 describe( 'deactivateFailed', () => {
 	test( 'should dispatch rewind deactivate failed action', () => {
-		const dispatch = sinon.spy();
-		deactivateFailed( { dispatch }, { siteId }, { message: 'some problem' } );
-		expect( dispatch ).to.have.been.calledWith( rewindDeactivateFailure( siteId ) );
+		expect( deactivateFailed( { siteId }, { message: 'some problem' } ) ).toContainEqual(
+			rewindDeactivateFailure( siteId )
+		);
 	} );
 
 	test( 'should dispatch an error notice', () => {
-		const dispatch = sinon.spy();
-		deactivateFailed( { dispatch }, { siteId }, { message: 'some problem' } );
-		expect( dispatch ).to.have.been.calledWith(
-			sinon.match( {
-				notice: {
+		expect( deactivateFailed( { siteId }, { message: 'some problem' } ) ).toContainEqual(
+			expect.objectContaining( {
+				notice: expect.objectContaining( {
 					status: 'is-error',
 					text: 'Problem deactivating rewind: some problem',
-				},
+				} ),
 			} )
 		);
 	} );


### PR DESCRIPTION
See #25121

In this patch we're replacing the use of dispatchRequest()
in the data layer handler to use the newer API exposed
as dispatchRequestEx() This should have no change in
actual effect or interaction.