### PR TITLE
Prototype: Activity log upgrade nudges

### DIFF
--- a/client/my-sites/stats/activity-log/activity-log-demo.jsx
+++ b/client/my-sites/stats/activity-log/activity-log-demo.jsx
@@ -1,0 +1,112 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ActivityIcon from '../activity-log-item/activity-icon';
+import Gravatar from 'components/gravatar';
+
+class ActivityLogDemo extends Component {
+	render() {
+		return (
+			<section className="activity-log__wrapper">
+				<div className="activity-log-item">
+					<div className="activity-log-item__type">
+						<div className="activity-log-item__time">6:38PM</div>
+						<ActivityIcon activityIcon="posts" activityStatus="success" />
+					</div>
+
+					<div className="card foldable-card activity-log-item__card">
+						<div className="foldable-card__header">
+							<span className="foldable-card__main">
+								<div className="activity-log-item__card-header">
+									<div className="activity-log-item__actor">
+										<Gravatar />
+										<div className="activity-log-item__actor-info">
+											<div className="activity-log-item__actor-name">Filipe Varela</div>
+											<div className="activity-log-item__actor-role">administrator</div>
+										</div>
+									</div>
+									<div className="activity-log-item__description">
+										<div className="activity-log-item__description-content">
+											My journey through Asia
+										</div>
+										<div className="activity-log-item__description-summary">Post published</div>
+									</div>
+								</div>
+							</span>
+						</div>
+					</div>
+				</div>
+
+				<div className="activity-log-item">
+					<div className="activity-log-item__type">
+						<div className="activity-log-item__time">4:20PM</div>
+						<ActivityIcon activityIcon="comment" activityStatus="warning" />
+					</div>
+
+					<div className="card foldable-card activity-log-item__card">
+						<div className="foldable-card__header">
+							<span className="foldable-card__main">
+								<div className="activity-log-item__card-header">
+									<div className="activity-log-item__actor">
+										<Gravatar />
+										<div className="activity-log-item__actor-info">
+											<div className="activity-log-item__actor-name">John Doe</div>
+										</div>
+									</div>
+									<div className="activity-log-item__description">
+										<div className="activity-log-item__description-content">
+											Lovely summer photos
+										</div>
+										<div className="activity-log-item__description-summary">
+											Comment awaiting approval
+										</div>
+									</div>
+								</div>
+							</span>
+						</div>
+					</div>
+				</div>
+
+				<div className="activity-log-item">
+					<div className="activity-log-item__type">
+						<div className="activity-log-item__time">3:10PM</div>
+						<ActivityIcon activityIcon="posts" />
+					</div>
+
+					<div className="card foldable-card activity-log-item__card">
+						<div className="foldable-card__header">
+							<span className="foldable-card__main">
+								<div className="activity-log-item__card-header">
+									<div className="activity-log-item__actor">
+										<Gravatar />
+										<div className="activity-log-item__actor-info">
+											<div className="activity-log-item__actor-name">Filipe Varela</div>
+											<div className="activity-log-item__actor-role">administrator</div>
+										</div>
+									</div>
+									<div className="activity-log-item__description">
+										<div className="activity-log-item__description-content">
+											My journey through Asia
+										</div>
+										<div className="activity-log-item__description-summary">
+											Post draft modified
+										</div>
+									</div>
+								</div>
+							</span>
+						</div>
+					</div>
+				</div>
+			</section>
+		);
+	}
+}
+
+export default localize( ActivityLogDemo );

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -63,6 +63,7 @@ import getRestoreProgress from 'state/selectors/get-restore-progress';
 import getRewindState from 'state/selectors/get-rewind-state';
 import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
+import ActivityLogDemo from './activity-log-demo';
 import FeatureExample from 'components/feature-example';
 import {
 	FEATURE_JETPACK_ESSENTIAL,
@@ -310,34 +311,38 @@ class ActivityLog extends Component {
 	renderUpgradeBanner() {
 		return (
 			<div className="activity-log__upgrade-banner">
-				{ isJetpackSite ? (
+				{ this.props.isJetpackSite ? (
 					<Banner
-						callToAction="Upgrade"
-						description="Secure your site with daily off-site backups for just €3.50/month."
+						callToAction="Get daily backups"
 						dismissPreferenceName="activity-upgrade-banner-jetpack"
 						event="track_event"
 						feature={ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY }
 						list={ [
-							"See a 30-day history of your site's activity",
-							'Rewind your site to any point in the last month',
-							'We automatically scan your files for threats',
+							'See all site activity over the past month',
+							'Rewind your site back to any point',
+							'Automatic threat scanning',
 						] }
 						plan={ PLAN_JETPACK_PERSONAL }
-						title="Get daily backups now!"
+						title="Secure your site with daily backups"
 					/>
 				) : (
 					<div>
+						<FeatureExample>
+							<ActivityLogDemo />
+						</FeatureExample>
 						<Banner
-							callToAction="Upgrade"
-							description="Obtain more features."
-							dismissPreferenceName="activity-upgrade-banner"
+							callToAction="See all activity"
+							dismissPreferenceName="activity-upgrade-banner-simple"
 							event="track_event"
 							feature={ FEATURE_JETPACK_ESSENTIAL }
-							list={ [ 'A feature', 'Another feature' ] }
+							list={ [
+								'Changes made to your posts and pages',
+								'Historical record of site costumizations',
+								'Comments, pingbacks, and more',
+							] }
 							plan={ PLAN_PERSONAL }
-							title="See all the activity on your site!"
+							title="See all your site activity"
 						/>
-						<FeatureExample>Content goes here</FeatureExample>
 					</div>
 				) }
 			</div>

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -39,7 +39,7 @@ import SuccessBanner from '../activity-log-banner/success-banner';
 import UnavailabilityNotice from './unavailability-notice';
 import { adjustMoment, getActivityLogQuery, getStartMoment } from './utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug, getSiteTitle } from 'state/sites/selectors';
+import { getSiteSlug, getSiteTitle, isJetpackSite } from 'state/sites/selectors';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import {
 	activityLogRequest,
@@ -63,6 +63,13 @@ import getRestoreProgress from 'state/selectors/get-restore-progress';
 import getRewindState from 'state/selectors/get-rewind-state';
 import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
+import FeatureExample from 'components/feature-example';
+import {
+	FEATURE_JETPACK_ESSENTIAL,
+	PLAN_PERSONAL,
+	PLAN_JETPACK_PERSONAL,
+	FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
+} from 'lib/plans/constants';
 
 const PAGE_SIZE = 20;
 
@@ -300,6 +307,43 @@ class ActivityLog extends Component {
 		);
 	}
 
+	renderUpgradeBanner() {
+		return (
+			<div className="activity-log__upgrade-banner">
+				{ isJetpackSite ? (
+					<Banner
+						callToAction="Upgrade"
+						description="Secure your site with daily off-site backups for just €3.50/month."
+						dismissPreferenceName="activity-upgrade-banner-jetpack"
+						event="track_event"
+						feature={ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY }
+						list={ [
+							"See a 30-day history of your site's activity",
+							'Rewind your site to any point in the last month',
+							'We automatically scan your files for threats',
+						] }
+						plan={ PLAN_JETPACK_PERSONAL }
+						title="Get daily backups now!"
+					/>
+				) : (
+					<div>
+						<Banner
+							callToAction="Upgrade"
+							description="Obtain more features."
+							dismissPreferenceName="activity-upgrade-banner"
+							event="track_event"
+							feature={ FEATURE_JETPACK_ESSENTIAL }
+							list={ [ 'A feature', 'Another feature' ] }
+							plan={ PLAN_PERSONAL }
+							title="See all the activity on your site!"
+						/>
+						<FeatureExample>Content goes here</FeatureExample>
+					</div>
+				) }
+			</div>
+		);
+	}
+
 	getActivityLog() {
 		const {
 			enableRewind,
@@ -412,6 +456,7 @@ class ActivityLog extends Component {
 					noLogsContent
 				) : (
 					<div>
+						{ this.renderUpgradeBanner() }
 						<section className="activity-log__wrapper">
 							{ theseLogs.map( log => (
 								<Fragment key={ log.activityId }>
@@ -517,6 +562,7 @@ export default connect(
 			slug: getSiteSlug( state, siteId ),
 			timezone,
 			oldestItemTs: getOldestItemTs( state, siteId ),
+			isJetpackSite: isJetpackSite( state, siteId ),
 		};
 	},
 	{


### PR DESCRIPTION
### This is a prototype, do not merge!

This PR contains some examples of how we can show upgrade nudges for the Activity log.

More info here: p9rlnk-iP-p2

### Jetpack

<img width="1339" alt="screen shot 2018-05-28 at 19 32 42" src="https://user-images.githubusercontent.com/390760/40626022-e8441258-62ad-11e8-9954-ed0e7839b638.png">

### WordPress.com Simple

<img width="1339" alt="screen shot 2018-05-28 at 19 31 44" src="https://user-images.githubusercontent.com/390760/40626010-cbb057dc-62ad-11e8-97ff-c7ed30a1d935.png">
