### PR TITLE
Framework: `dispatchRequest` update (al rewind downloads)

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/rewind/downloads/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/downloads/index.js
@@ -11,48 +11,42 @@ import { pick } from 'lodash';
  */
 import { REWIND_BACKUP } from 'state/action-types';
 import { rewindBackupUpdateError, getRewindBackupProgress } from 'state/activity-log/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
-const createBackup = ( { dispatch }, action ) => {
-	dispatch(
-		http(
-			{
-				method: 'POST',
-				apiNamespace: 'wpcom/v2',
-				path: `/sites/${ action.siteId }/rewind/downloads`,
-				body: {
-					rewindId: action.rewindId,
-				},
+const createBackup = action =>
+	http(
+		{
+			method: 'POST',
+			apiNamespace: 'wpcom/v2',
+			path: `/sites/${ action.siteId }/rewind/downloads`,
+			body: {
+				rewindId: action.rewindId,
 			},
-			action
-		)
+		},
+		action
 	);
-};
 
-const fromApi = data => ( {
-	downloadId: +data.downloadId,
-} );
-
-export const receiveBackupSuccess = ( { dispatch }, { siteId }, apiData ) => {
-	const { downloadId } = fromApi( apiData );
-	if ( downloadId ) {
-		dispatch( getRewindBackupProgress( siteId ) );
-	} else {
-		dispatch(
-			rewindBackupUpdateError( siteId, {
-				status: 'finished',
-				error: 'missing_download_id',
-				message: 'Bad response. No download ID provided.',
-			} )
-		);
+const fromApi = data => {
+	if ( ! data.hasOwnProperty( 'downloadId' ) ) {
+		throw new Error( 'Missing downloadId field in response' );
 	}
+
+	return true;
 };
 
-export const receiveBackupError = ( { dispatch }, { siteId }, error ) => {
-	dispatch( rewindBackupUpdateError( siteId, pick( error, [ 'error', 'status', 'message' ] ) ) );
-};
+export const receiveBackupSuccess = ( { siteId } ) => getRewindBackupProgress( siteId );
+
+export const receiveBackupError = ( { siteId }, error ) =>
+	rewindBackupUpdateError( siteId, pick( error, [ 'error', 'status', 'message' ] ) );
 
 export default {
-	[ REWIND_BACKUP ]: [ dispatchRequest( createBackup, receiveBackupSuccess, receiveBackupError ) ],
+	[ REWIND_BACKUP ]: [
+		dispatchRequestEx( {
+			fetch: createBackup,
+			onSuccess: receiveBackupSuccess,
+			onError: receiveBackupError,
+			fromApi,
+		} ),
+	],
 };


### PR DESCRIPTION
See #25121

In this patch we're replacing the use of dispatchRequest()
in the data layer handler to use the newer API exposed
as dispatchRequestEx() This should have no change in
actual effect or interaction.