### PR TITLE
Framework: `dispatchRequest` update (rewind restore status)

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
@@ -26,7 +26,8 @@ const recentRequests = new Map();
  * replaced by the `freshness` system in the data layer
  * when it arrives. For now, it's statefully ugly.
  *
- * @param {Object} action Redux action
+ * @param  {Object} action Redux action
+ * @return {Object}        Redux action
  */
 const fetchProgress = action => {
 	const { restoreId, siteId } = action;

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
@@ -19,6 +19,9 @@ const POLL_INTERVAL = 1500;
 /** @type {Map<String, Number>} stores most-recent polling times */
 const recentRequests = new Map();
 
+/** @type {string} Request error notice id. Prevents polling from creating endless notices */
+const ERROR_NOTICE_ID = 'AL_REW_RESTORESTATUS_ERR';
+
 /**
  * Fetch status updates for restore operations
  *
@@ -75,7 +78,8 @@ export const updateProgress = ( { siteId, restoreId, timestamp }, data ) =>
 
 export const announceFailure = () =>
 	errorNotice(
-		translate( "Hmm, we can't update the status of your restore. Please refresh this page." )
+		translate( "Hmm, we can't update the status of your restore. Please refresh this page." ),
+		{ id: ERROR_NOTICE_ID }
 	);
 
 export default {

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
@@ -8,7 +8,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { errorNotice } from 'state/notices/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { REWIND_RESTORE_PROGRESS_REQUEST } from 'state/action-types';
 import { updateRewindRestoreProgress } from 'state/activity-log/actions';
@@ -26,10 +26,9 @@ const recentRequests = new Map();
  * replaced by the `freshness` system in the data layer
  * when it arrives. For now, it's statefully ugly.
  *
- * @param {Function} dispatch Redux dispatcher
  * @param {Object} action Redux action
  */
-const fetchProgress = ( { dispatch }, action ) => {
+const fetchProgress = action => {
 	const { restoreId, siteId } = action;
 	const key = `${ siteId }-${ restoreId }`;
 
@@ -42,15 +41,13 @@ const fetchProgress = ( { dispatch }, action ) => {
 
 	recentRequests.set( key, now );
 
-	dispatch(
-		http(
-			{
-				apiVersion: '1',
-				method: 'GET',
-				path: `/activity-log/${ siteId }/rewind/${ restoreId }/restore-status`,
-			},
-			action
-		)
+	return http(
+		{
+			apiVersion: '1',
+			method: 'GET',
+			path: `/activity-log/${ siteId }/rewind/${ restoreId }/restore-status`,
+		},
+		action
 	);
 };
 
@@ -72,18 +69,21 @@ export const fromApi = ( {
 	rewindId: rewind_id,
 } );
 
-export const updateProgress = ( { dispatch }, { siteId, restoreId, timestamp }, data ) =>
-	dispatch( updateRewindRestoreProgress( siteId, timestamp, restoreId, data ) );
+export const updateProgress = ( { siteId, restoreId, timestamp }, data ) =>
+	updateRewindRestoreProgress( siteId, timestamp, restoreId, data );
 
-export const announceFailure = ( { dispatch } ) =>
-	dispatch(
-		errorNotice(
-			translate( "Hmm, we can't update the status of your restore. Please refresh this page." )
-		)
+export const announceFailure = () =>
+	errorNotice(
+		translate( "Hmm, we can't update the status of your restore. Please refresh this page." )
 	);
 
 export default {
 	[ REWIND_RESTORE_PROGRESS_REQUEST ]: [
-		dispatchRequest( fetchProgress, updateProgress, announceFailure, { fromApi } ),
+		dispatchRequestEx( {
+			fetch: fetchProgress,
+			onSuccess: updateProgress,
+			onError: announceFailure,
+			fromApi,
+		} ),
 	],
 };

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/test/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/test/index.js
@@ -2,9 +2,7 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -31,8 +29,7 @@ const FINISHED_RESPONSE = deepFreeze( {
 
 describe( 'receiveRestoreProgress', () => {
 	test( 'should dispatch updateRewindRestoreProgress', () => {
-		const dispatch = sinon.spy();
-		updateProgress( { dispatch }, { siteId, timestamp, restoreId }, fromApi( FINISHED_RESPONSE ) );
+		const action = updateProgress( { siteId, timestamp, restoreId }, fromApi( FINISHED_RESPONSE ) );
 		const expectedAction = updateRewindRestoreProgress( siteId, timestamp, restoreId, {
 			errorCode: '',
 			failureReason: '',
@@ -41,6 +38,6 @@ describe( 'receiveRestoreProgress', () => {
 			status: 'finished',
 			rewindId: '',
 		} );
-		expect( dispatch ).to.have.been.calledWith( expectedAction );
+		expect( action ).toEqual( expectedAction );
 	} );
 } );


### PR DESCRIPTION
See #25121

In this patch we're replacing the use of dispatchRequest()
in the data layer handler to use the newer API exposed
as dispatchRequestEx() This should have no change in
actual effect or interaction.