### PR TITLE
Split button: stop event propagation when the main/chevron down buttons are clicked

### DIFF
--- a/client/components/split-button/index.jsx
+++ b/client/components/split-button/index.jsx
@@ -53,9 +53,15 @@ class SplitButton extends PureComponent {
 
 	popoverContext = React.createRef();
 
-	handleMainClick = event => this.props.onClick( event );
+	handleMainClick = event => {
+		event.stopPropagation();
+		return this.props.onClick( event );
+	};
 
-	handleMenuClick = () => this.toggleMenu( ! this.state.isMenuVisible );
+	handleMenuClick = event => {
+		event.stopPropagation();
+		return this.toggleMenu( ! this.state.isMenuVisible );
+	};
 
 	hideMenu = () => this.toggleMenu( false );
 


### PR DESCRIPTION
This allows the SplitButton to be used in FoldableCard components when the header is made clickable.

This will be required in the threats PR that introduces a split button in the header, since it's clickable so users can expand it and see more information about the threat.