### PR TITLE
Activity Log - Persistent notices: add split button to fix threats

### DIFF
--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -164,6 +164,7 @@
 }
 
 .activity-log__threat-alert-title {
+	padding-right: 16px;
 	font-weight: 500;
 	color: $gray-dark;
 

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -108,6 +108,8 @@
 
 	.foldable-card__main {
 		flex: unset;
+		max-width: 100%;
+		width: 100%;
 	}
 
 	.activity-log-item__activity-icon {
@@ -148,6 +150,17 @@
 
 .activity-log__threat-alert-header {
 	color: $gray;
+	width: 100%;
+}
+
+.activity-log__threat-header-top {
+	align-items: center;
+	display: flex;
+	justify-content: space-between;
+
+	.split-button {
+		white-space: pre;
+	}
 }
 
 .activity-log__threat-alert-title {
@@ -183,6 +196,7 @@
 	margin-left: 2px;
 	padding-left: 4px;
 	color: $gray;
+	font-weight: 400;
 
 	&:before {
 		// cdot three-per-em-space

--- a/client/my-sites/stats/activity-log/threat-alert.jsx
+++ b/client/my-sites/stats/activity-log/threat-alert.jsx
@@ -13,6 +13,8 @@ import DiffViewer from 'components/diff-viewer';
 import FoldableCard from 'components/foldable-card';
 import MarkedLines from 'components/marked-lines';
 import TimeSince from 'components/time-since';
+import PopoverMenuItem from 'components/popover/menu-item';
+import SplitButton from 'components/split-button';
 
 const detailType = threat => {
 	if ( threat.hasOwnProperty( 'diff' ) ) {
@@ -122,19 +124,50 @@ export class ThreatAlert extends Component {
 					className="activity-log__threat-alert"
 					highlight="error"
 					compact
+					clickableHeader={ true }
+					actionButton={ <span /> }
 					header={
 						<Fragment>
 							<ActivityIcon activityIcon="notice-outline" activityStatus="error" />
 							<div className="activity-log__threat-alert-header">
-								<div>
+								<div className="activity-log__threat-header-top">
 									<span className="activity-log__threat-alert-title">
 										{ headerTitle( translate, threat ) }
+										<TimeSince
+											className="activity-log__threat-alert-time-since"
+											date={ threat.firstDetected }
+											dateFormat="ll"
+										/>
 									</span>
-									<TimeSince
-										className="activity-log__threat-alert-time-since"
-										date={ threat.firstDetected }
-										dateFormat="ll"
-									/>
+									<SplitButton
+										compact
+										primary
+										label={ translate( 'Fix threat' ) }
+										onClick={ () => console.log( 'main button clicked' ) }
+										disabled={ false }
+									>
+										<PopoverMenuItem
+											onClick={ () => console.log( 'documentation clicked' ) }
+											className="activity-log__threat-menu-item"
+											icon="help"
+										>
+											<span>{ translate( 'Documentation' ) }</span>
+										</PopoverMenuItem>
+										<PopoverMenuItem
+											onClick={ () => console.log( 'get help clicked' ) }
+											className="activity-log__threat-menu-item"
+											icon="chat"
+										>
+											<span>{ translate( 'Get help' ) }</span>
+										</PopoverMenuItem>
+										<PopoverMenuItem
+											onClick={ () => console.log( 'ignore threat clicked' ) }
+											className="activity-log__threat-menu-item"
+											icon="trash"
+										>
+											<span>{ translate( 'Ignore threat' ) }</span>
+										</PopoverMenuItem>
+									</SplitButton>
 								</div>
 								<span className="activity-log__threat-alert-type">
 									{ headerSubtitle( translate, threat ) }


### PR DESCRIPTION
The popover menu includes the following actions:
- documentation
- get help
- ignore threat

<img width="896" alt="captura de pantalla 2018-05-28 a la s 19 48 50" src="https://user-images.githubusercontent.com/1041600/40626423-658625c4-62b0-11e8-9a24-8c4a48bae731.png">
