### PR TITLE
Podcasting: highlight selected term when changing Podcast category

### DIFF
--- a/client/blocks/term-tree-selector/index.jsx
+++ b/client/blocks/term-tree-selector/index.jsx
@@ -30,6 +30,7 @@ export default class extends React.Component {
 		addTerm: PropTypes.bool,
 		postType: PropTypes.string,
 		onAddTermSuccess: PropTypes.func,
+		podcastingCategoryId: PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -74,6 +75,7 @@ export default class extends React.Component {
 			addTerm,
 			postType,
 			onAddTermSuccess,
+			podcastingCategoryId,
 		} = this.props;
 
 		const classes = classNames( className );
@@ -95,6 +97,7 @@ export default class extends React.Component {
 					multiple={ multiple }
 					height={ height }
 					compact={ compact }
+					podcastingCategoryId={ podcastingCategoryId }
 				/>
 				{ addTerm && (
 					<TermSelectorAddTerm

--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -465,6 +465,8 @@ export default connect( ( state, ownProps ) => {
 		lastPage: getTermsLastPageForQuery( state, siteId, taxonomy, query ),
 		siteId,
 		query,
-		podcastingCategoryId: taxonomy === 'category' && getPodcastingCategoryId( state, siteId ),
+		podcastingCategoryId:
+			ownProps.podcastingCategoryId ||
+			( taxonomy === 'category' && getPodcastingCategoryId( state, siteId ) ),
 	};
 } )( localize( TermTreeSelectorList ) );

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -195,6 +195,7 @@ class PodcastingDetails extends Component {
 							<TermTreeSelector
 								taxonomy="category"
 								selected={ podcastingCategoryId ? [ podcastingCategoryId ] : [] }
+								podcastingCategoryId={ podcastingCategoryId }
 								onChange={ this.onCategorySelected }
 								addTerm={ true }
 								onAddTermSuccess={ this.onCategorySelected }


### PR DESCRIPTION
On the Podcast Details page (Settings > Writing > Manage Podcast), the term selector does not accurately reflect the current podcast category selection when a user is changing categories and hasn't saved. The `getPodcastingCategoryId` selector returns the current saved setting value, but not the dirty state value.

This PR passes an optional `podcastingCategoryId` prop with the current form state for selected category to the `TermTreeSelector` component, to be used as an overriding value, with the fallback being the saved selector value.

This PR is part of a larger epic and is behind the `manage/site-settings/podcasting` feature flag. See p3Ex-32D-p2.

![podcast-term-highlighting](https://user-images.githubusercontent.com/942359/40628624-05013a8e-6294-11e8-8581-243cb1767bdd.gif)

**To test:**
- With the `manage/site-settings/podcasting` enabled (default in development):
- Navigate to Settings > Writing > Manage Podcast
- Change the current selected podcast category.
 - Verify that the podcast icon reflects your current selection.
- Leave the settings page without saving and add a new post.
 - Verify that, in the category list, the proper saved podcast category is highlighted with the icon.
- Return to the Podcast Details settings page.
 - Verify that the correct, saved value is highlighted in the term selector.
- Change the current selected podcast category and save the settings page.
 - Verify that the correct category setting is saved.
- Add a new post.
 - Verify that, in the category list, the proper saved podcast category is highlighted with the icon.
