### PR TITLE
Domain contact details: ensure phone country flag updates

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -120,10 +120,13 @@ export class ContactDetailsFormFields extends Component {
 		this.shouldAutoFocusAddressField = false;
 	}
 
+	// `formState` forces multiple updates to `this.state`
+	// This is an attempt limit the redraws to only what we need.
 	shouldComponentUpdate( nextProps, nextState ) {
 		return (
 			! isEqual( nextState.form, this.state.form ) ||
 			! isEqual( nextProps.labelTexts, this.props.labelTexts ) ||
+			! isEqual( nextState.phoneCountryCode, this.state.phoneCountryCode ) ||
 			! isEqual( nextProps.hasCountryStates, this.props.hasCountryStates ) ||
 			( nextProps.needsFax !== this.props.needsFax ||
 				nextProps.disableSubmitButton !== this.props.disableSubmitButton ||

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -124,9 +124,9 @@ export class ContactDetailsFormFields extends Component {
 	// This is an attempt limit the redraws to only what we need.
 	shouldComponentUpdate( nextProps, nextState ) {
 		return (
+			nextState.phoneCountryCode !== this.state.phoneCountryCode ||
 			! isEqual( nextState.form, this.state.form ) ||
 			! isEqual( nextProps.labelTexts, this.props.labelTexts ) ||
-			! isEqual( nextState.phoneCountryCode, this.state.phoneCountryCode ) ||
 			! isEqual( nextProps.hasCountryStates, this.props.hasCountryStates ) ||
 			( nextProps.needsFax !== this.props.needsFax ||
 				nextProps.disableSubmitButton !== this.props.disableSubmitButton ||


### PR DESCRIPTION
This is a small PR that ensure that the we display the correct flag when a user changes his/her phone country code.

The problem occurs only when the field is empty:

![may-29-2018 16-19-15](https://user-images.githubusercontent.com/6458278/40641231-3c9503f4-635c-11e8-939b-92339de38a19.gif)

The fix was to check for changes to `this.state.phoneCountryCode`.

## Testing
1. Add a domain to the cart
2. At the domain contact details page, clear the phone field
3. Select a new the country code by clicking on the flag in the phone field

### Expectations
We see the flag that corresponds to the selected country, e.g., 🇨🇦 `===` Canada

