### PR TITLE
User mentions: fix multi-line text selection with keyboard

### DIFF
--- a/client/blocks/user-mentions/add.jsx
+++ b/client/blocks/user-mentions/add.jsx
@@ -81,10 +81,14 @@ export default WrappedComponent =>
 		}
 
 		handleKeyDown = event => {
+			if ( ! this.state.showPopover ) {
+				return;
+			}
+
 			const selectedIndex = this.getSelectedSuggestionIndex();
 
 			// Cancel Enter and Tab default actions so we can define our own in keyUp
-			if ( includes( [ keys.enter, keys.tab ], event.keyCode ) && this.state.showPopover ) {
+			if ( includes( [ keys.enter, keys.tab ], event.keyCode ) ) {
 				event.preventDefault();
 				return false;
 			}
@@ -98,6 +102,7 @@ export default WrappedComponent =>
 			// Cancel the cursor move.
 			event.preventDefault();
 
+			// Change the selected suggestion
 			if ( event.keyCode === keys.downArrow ) {
 				nextIndex = ( selectedIndex + 1 ) % this.matchingSuggestions.length;
 			} else {


### PR DESCRIPTION
With the user mentions feature enabled (currently all environments apart from production), the keyDown handler is a bit keen and intercepts up and down arrow presses even when the popover is closed. This means it's not possible to select lines of text with the keyboard.

This PR fixes the selection behaviour:

![2018-05-29 18_36_39](https://user-images.githubusercontent.com/17325/40641861-512f091e-636f-11e8-9093-1ab7aba28557.gif)

### To test

Using http://calypso.localhost:3000/devdocs/blocks/user-mentions, ensure that you are able to:
- select a user mention suggestion from the popover using up and down arrows
- use the up and down arrows to make a multi-line selection in the textarea