### PR TITLE
Domains: Fix sticky panel top margin when scrolling on mobile

### DIFF
--- a/client/components/sticky-panel/style.scss
+++ b/client/components/sticky-panel/style.scss
@@ -22,10 +22,3 @@
 		margin-top: 8px;
 	}
 }
-
-// To remove margin top sticky panel on domain registration
-.sticky-panel.register-domain-step__search {
-	>.sticky-panel__content {
-		margin-top: 0;
-	}
-}

--- a/client/components/sticky-panel/style.scss
+++ b/client/components/sticky-panel/style.scss
@@ -22,3 +22,10 @@
 		margin-top: 8px;
 	}
 }
+
+// To remove margin top sticky panel on domain registration
+.sticky-panel.register-domain-step__search {
+	>.sticky-panel__content {
+		margin-top: 0;
+	}
+}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -13,6 +13,14 @@
 	left: 0;
 	right: 0;
 	overflow: hidden;
+
+
+	// To remove margin top sticky panel on domain registration
+	.sticky-panel.register-domain-step__search {
+		>.sticky-panel__content {
+			margin-top: 0;
+		}
+	}
 }
 
 .signup__step-enter {


### PR DESCRIPTION
## What i change : 
I change file `client/components/sticky-panel/style.scss`.

## Why i change : 
I found this issue : #25143 

## What will affect : 
It make all page have sticky panel be no any space on the top of it (margin top).
This is the list component will affect : 
- `domains/registration`
- `comment-list-header`
- `external-media-header`
- `media-library`
- `stats/site`
- `themes-magic-search-card`
- `editor-ground-control/test`
