### PR TITLE
Stats: Fix StatsMostPopular notice isCompact prop

### DIFF
--- a/client/my-sites/stats/most-popular/index.jsx
+++ b/client/my-sites/stats/most-popular/index.jsx
@@ -74,7 +74,7 @@ class StatsMostPopular extends Component {
 									<Notice
 										className="most-popular__notice"
 										status="is-warning"
-										isCompact="true"
+										isCompact
 										text={ translate( 'No popular day and time recorded', {
 											context: 'Message on stats insights page when no most popular data exists.',
 											comment: 'Should be limited to 32 characters to prevent wrapping',


### PR DESCRIPTION
Currently, in the `StatsMostPopular` component we pass a `"true"` to a boolean `isCompact` prop of the `<Notice />` component, which works, but leads to the following propType warning:

![](https://cldup.com/y5IGh_-tzW.png)

This PR fixes this case to properly use a boolean.

To test:
* Checkout this branch
* Go to `http://calypso.localhost:3000/stats/insights/:site`, where `:site` is one of your .com sites without any traffic (ideally, a private/hidden site).
* Verify the warning is gone.
* Verify the notice still looks properly and is still compact:

![](https://cldup.com/ogqEFTPdOX.png)

Note: there is a `validateDOMNesting` warning on that page too, #25156 takes care of that separately.