### PR TITLE
GDPR: actually use the `gdpr-banner` feature flag

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -156,7 +156,7 @@ const Layout = createReactClass( {
 				) }
 				<InlineHelp />
 				<AppBanner />
-				<GdprBanner />
+				{ config.isEnabled( 'gdpr-banner' ) && <GdprBanner /> }
 			</div>
 		);
 	},

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -39,6 +39,7 @@
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,
+		"gdpr-banner": false,
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,


### PR DESCRIPTION
**Actually use** the feature flag for the GDPR banner added in #25021. Props to @akirk and @adlk for noticing! 

Also adds the flag to `config/desktop-development.js`. 

To test: 
- Be in Europe. 
- Clean your cookies. 
- Launch Calypso with the `NODE_ENV` variable set to `development`. Should be the default when run locally, `export NODE_ENV="development"; npm start` to make sure. 
- Go to Calypso and make sure **you do not see** the banner. 
- Change `gdpr-banner` to `true` in `config/development.js`. Launch Calypso with the `NODE_ENV` variable set to `development`.
- Go to Calypso and make sure **you do see** the banner.
