### PR TITLE
Stats: Fix StatsPostPerformance warning

### DIFF
--- a/client/components/emojify/README.md
+++ b/client/components/emojify/README.md
@@ -24,3 +24,4 @@ const textToEmojify = 'This will be converted 🙈🙉🙊';
 | -------------- | ---------------- | -------- | ------------------ | ------- |
 | `children`     | Text\|Components | yes      | none               | Typically a string that you want to search for UTF emoji |
 | `imgClassName` | String           | no       | `"emojify__emoji"` | classname applied to the image |
+| `tagName`      | String           | no       | `div`              | Tag name used for the wrapper element |

--- a/client/components/emojify/index.jsx
+++ b/client/components/emojify/index.jsx
@@ -11,11 +11,13 @@ import twemoji from 'twemoji';
 export default class Emojify extends PureComponent {
 	static propTypes = {
 		imgClassName: PropTypes.string,
+		tagName: PropTypes.string,
 		twemojiUrl: PropTypes.string,
 	};
 
 	static defaultProps = {
 		imgClassName: 'emojify__emoji',
+		tagName: 'div',
 	};
 
 	constructor( props ) {
@@ -57,14 +59,20 @@ export default class Emojify extends PureComponent {
 	render() {
 		// We want other props to content everything but children, className, imgClassName, and twemojiUrl.
 		// We can't delete imgClassName and twemojiUrl despite they not being used here.
-		const { children, className, imgClassName, twemojiUrl, ...other } = this.props; // eslint-disable-line no-unused-vars
-
+		const {
+			children,
+			className,
+			imgClassName,
+			tagName: WrapperTagName,
+			twemojiUrl,
+			...other
+		} = this.props; // eslint-disable-line no-unused-vars
 		const classes = classNames( className, 'emojify' );
 
 		return (
-			<div className={ classes } ref={ this.setRef } { ...other }>
+			<WrapperTagName className={ classes } ref={ this.setRef } { ...other }>
 				{ children }
-			</div>
+			</WrapperTagName>
 		);
 	}
 }

--- a/client/components/emojify/test/emojify.jsx
+++ b/client/components/emojify/test/emojify.jsx
@@ -36,6 +36,13 @@ describe( 'Emojify', () => {
 			expect( wrapper.html() ).to.equal( '<div class="emojify"><p>Bar</p></div>' );
 		} );
 
+		test( 'wraps a block in a certain tag, if tagName is specified', () => {
+			const wrapper = shallow( <Emojify tagName="span">Bar</Emojify>, {
+				disableLifecycleMethods: true,
+			} );
+			expect( wrapper.html() ).to.equal( '<span class="emojify">Bar</span>' );
+		} );
+
 		test( 'replaces emoji in a string', () => {
 			const wrapper = mount( <Emojify twemojiUrl={ twemojiUrl }>🙂</Emojify> );
 

--- a/client/my-sites/stats/post-performance/index.jsx
+++ b/client/my-sites/stats/post-performance/index.jsx
@@ -115,7 +115,7 @@ class StatsPostPerformance extends Component {
 										},
 										components: {
 											href: <a href={ post.URL } target="_blank" rel="noopener noreferrer" />,
-											postTitle: <Emojify>{ postTitle }</Emojify>,
+											postTitle: <Emojify tagName="span">{ postTitle }</Emojify>,
 										},
 										context:
 											'Stats: Sentence showing how much time has passed since the last post, and how the stats are',


### PR DESCRIPTION
When looking at the Insights stats page, we see the following error coming from emojifying inside a `<p>` in `<StatsPostPerformance />`:

![](https://cldup.com/bgh_lsDGHZ.png)

This is caused by embedding `<Emojify />` in a `<p>`, which results in a `<div>` inside a `<p>`.

This PR adds support for `tagName` to the `Emojify` component, adds a test and docs for it and uses  it in `<StatsPostPerformance />` to change the `<div>` to a `<span>` for the post title.

To test:
* Checkout this branch
* Select one of your .com sites.
* Make sure the last post in that site contains an emoji in the post title.
* Verify tests pass: `npm run test-client client/components/emojify`
* Go to `http://calypso.localhost:3000/stats/insights/:site`
* Verify the warning is gone.
* Verify the component looks behaves and looks the same as before:

![](https://cldup.com/rhKymgMs-K.png)

Note: there might be a `isCompact` propType warning on that page too, #25154 takes care of that separately.