### PR TITLE
Show 2-year personal and premium plans to everyone, test business plans 50/50

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,7 +1,7 @@
 /** @format */
 export default {
-	multiyearSubscriptions: {
-		datestamp: '20180417',
+	multiyearSubscriptionsBusinessPriceTest: {
+		datestamp: '20180530',
 		variations: {
 			show: 50,
 			hide: 50,

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -159,24 +159,15 @@ export const TYPE_PERSONAL = 'TYPE_PERSONAL';
 export const TYPE_PREMIUM = 'TYPE_PREMIUM';
 export const TYPE_BUSINESS = 'TYPE_BUSINESS';
 
-const WPComGetBillingTimeframe = abtest => {
-	if ( abtest ) {
-		if ( isEnabled( 'upgrades/2-year-plans' ) && abtest( 'multiyearSubscriptions' ) === 'show' ) {
-			return i18n.translate( '/month, billed annually or every two years' );
-		}
+const WPComGetBillingTimeframe = () => {
+	if ( isEnabled( 'upgrades/2-year-plans' ) ) {
+		return i18n.translate( '/month, billed annually or every two years' );
 	}
 	return i18n.translate( 'per month, billed yearly' );
 };
 
-const WPComGetBiennialBillingTimeframe = abtest => {
-	if ( abtest ) {
-		if ( isEnabled( 'upgrades/2-year-plans' ) && abtest( 'multiyearSubscriptions' ) === 'show' ) {
-			return i18n.translate( '/month, billed every two years' );
-		}
-	}
-
-	return WPComGetBillingTimeframe( abtest );
-};
+const WPComGetBiennialOnlyBillingTimeframe = () =>
+	i18n.translate( '/month, billed every two years' );
 
 const getPlanPersonalDetails = () => ( {
 	group: GROUP_WPCOM,
@@ -433,7 +424,7 @@ export const PLANS_LIST = {
 	[ PLAN_PERSONAL_2_YEARS ]: {
 		...getPlanPersonalDetails(),
 		term: TERM_BIENNIALLY,
-		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
+		getBillingTimeFrame: WPComGetBiennialOnlyBillingTimeframe,
 		availableFor: plan => includes( [ PLAN_FREE, PLAN_PERSONAL ], plan ),
 		getProductId: () => 1029,
 		getStoreSlug: () => PLAN_PERSONAL_2_YEARS,
@@ -453,7 +444,7 @@ export const PLANS_LIST = {
 	[ PLAN_PREMIUM_2_YEARS ]: {
 		...getPlanPremiumDetails(),
 		term: TERM_BIENNIALLY,
-		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
+		getBillingTimeFrame: WPComGetBiennialOnlyBillingTimeframe,
 		availableFor: plan =>
 			includes( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM ], plan ),
 		getProductId: () => 1023,
@@ -464,7 +455,16 @@ export const PLANS_LIST = {
 	[ PLAN_BUSINESS ]: {
 		...getPlanBusinessDetails(),
 		term: TERM_ANNUALLY,
-		getBillingTimeFrame: WPComGetBillingTimeframe,
+		getBillingTimeFrame: abtest => {
+			if ( isEnabled( 'upgrades/2-year-plans' ) ) {
+				if ( abtest && abtest( 'multiyearSubscriptionsBusinessPriceTest' ) === 'show' ) {
+					return i18n.translate( '/month, billed annually or every two years' );
+				}
+				return i18n.translate( '/month, billed annually' );
+			}
+
+			return i18n.translate( 'per month, billed yearly' );
+		},
 		availableFor: plan =>
 			includes(
 				[ PLAN_FREE, PLAN_PERSONAL, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM, PLAN_PREMIUM_2_YEARS ],
@@ -478,7 +478,7 @@ export const PLANS_LIST = {
 	[ PLAN_BUSINESS_2_YEARS ]: {
 		...getPlanBusinessDetails(),
 		term: TERM_BIENNIALLY,
-		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
+		getBillingTimeFrame: WPComGetBiennialOnlyBillingTimeframe,
 		availableFor: plan =>
 			includes(
 				[

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -166,8 +166,12 @@ const WPComGetBillingTimeframe = () => {
 	return i18n.translate( 'per month, billed yearly' );
 };
 
-const WPComGetBiennialOnlyBillingTimeframe = () =>
-	i18n.translate( '/month, billed every two years' );
+const WPComGetBiennialOnlyBillingTimeframe = () => {
+	if ( isEnabled( 'upgrades/2-year-plans' ) ) {
+		return i18n.translate( '/month, billed every two years' );
+	}
+	return WPComGetBillingTimeframe();
+};
 
 const getPlanPersonalDetails = () => ( {
 	group: GROUP_WPCOM,

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -70,6 +70,8 @@ import { getProductsList, isProductsListFetching } from 'state/products-list/sel
 import QueryProducts from 'components/data/query-products-list';
 import { isRequestingSitePlans } from 'state/sites/plans/selectors';
 import { isRequestingPlans } from 'state/plans/selectors';
+import { planMatches } from '../../../lib/plans';
+import { TYPE_BUSINESS } from '../../../lib/plans/constants';
 
 export class Checkout extends React.Component {
 	static propTypes = {
@@ -506,11 +508,23 @@ export class Checkout extends React.Component {
 				handleCheckoutCompleteRedirect={ this.handleCheckoutCompleteRedirect }
 				handleCheckoutExternalRedirect={ this.handleCheckoutExternalRedirect }
 			>
-				{ config.isEnabled( 'upgrades/2-year-plans' ) &&
-					abtest( 'multiyearSubscriptions' ) === 'show' &&
-					this.renderSubscriptionLengthPicker() }
+				{ this.shouldDisplayLengthPicker() && this.renderSubscriptionLengthPicker() }
 			</SecurePaymentForm>
 		);
+	}
+
+	shouldDisplayLengthPicker() {
+		const planInCart = this.getPlanProducts()[ 0 ];
+		if ( ! planInCart ) {
+			return false;
+		}
+
+		const enabled2YearPlans = config.isEnabled( 'upgrades/2-year-plans' );
+
+		const buyingNonBusinessPlan = ! planMatches( planInCart.product_slug, { type: TYPE_BUSINESS } );
+		const testingMultiYearBusiness = abtest( 'multiyearSubscriptionsBusinessPriceTest' ) === 'show';
+
+		return enabled2YearPlans && ( buyingNonBusinessPlan || testingMultiYearBusiness );
 	}
 
 	renderSubscriptionLengthPicker() {

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -169,7 +169,8 @@ export class Checkout extends React.Component {
 	}
 
 	getPlanProducts() {
-		return this.props.cart.products.filter( ( { product_slug } ) => getPlan( product_slug ) );
+		const products = this.props.cart.products || [];
+		return products.filter( ( { product_slug } ) => getPlan( product_slug ) );
 	}
 
 	getProductSlugFromSynonym( slug ) {

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -54,8 +54,8 @@ import getUpgradePlanSlugFromPath from 'state/selectors/get-upgrade-plan-slug-fr
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import isEligibleForCheckoutToChecklist from 'state/selectors/is-eligible-for-checkout-to-checklist';
 import { getStoredCards } from 'state/stored-cards/selectors';
-import { isValidFeatureKey, getPlan, findPlansKeys } from 'lib/plans';
-import { GROUP_WPCOM } from 'lib/plans/constants';
+import { isValidFeatureKey, getPlan, findPlansKeys, planMatches } from 'lib/plans';
+import { GROUP_WPCOM, TYPE_BUSINESS } from 'lib/plans/constants';
 import { recordViewCheckout } from 'lib/analytics/ad-tracking';
 import { recordApplePayStatus } from 'lib/apple-pay';
 import { requestSite } from 'state/sites/actions';
@@ -70,8 +70,6 @@ import { getProductsList, isProductsListFetching } from 'state/products-list/sel
 import QueryProducts from 'components/data/query-products-list';
 import { isRequestingSitePlans } from 'state/sites/plans/selectors';
 import { isRequestingPlans } from 'state/plans/selectors';
-import { planMatches } from '../../../lib/plans';
-import { TYPE_BUSINESS } from '../../../lib/plans/constants';
 
 export class Checkout extends React.Component {
 	static propTypes = {

--- a/client/my-sites/checkout/checkout/secure-payment-form-placeholder.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form-placeholder.jsx
@@ -10,7 +10,6 @@ import config from 'config';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import PaymentBox from './payment-box.jsx';
 
 const SecurePaymentFormPlaceholder = () => {
@@ -31,17 +30,16 @@ const SecurePaymentFormPlaceholder = () => {
 				</div>
 				<div className="placeholder-row placeholder" />
 			</div>
-			{ config.isEnabled( 'upgrades/2-year-plans' ) &&
-				abtest( 'multiyearSubscriptions' ) === 'show' && (
-					<div className="payment-box-section">
-						<div className="placeholder-col-narrow placeholder-inline-pad">
-							<div className="placeholder" />
-						</div>
-						<div className="placeholder-col-narrow">
-							<div className="placeholder" />
-						</div>
+			{ config.isEnabled( 'upgrades/2-year-plans' ) && (
+				<div className="payment-box-section">
+					<div className="placeholder-col-narrow placeholder-inline-pad">
+						<div className="placeholder" />
 					</div>
-				) }
+					<div className="placeholder-col-narrow">
+						<div className="placeholder" />
+					</div>
+				</div>
+			) }
 			<div className="payment-box-hr" />
 			<div className="placeholder-button-container">
 				<div className="placeholder-col-narrow">

--- a/client/my-sites/checkout/checkout/test/checkout.js
+++ b/client/my-sites/checkout/checkout/test/checkout.js
@@ -56,9 +56,7 @@ jest.mock( 'lib/cart-values', () => ( {
 describe( 'Checkout', () => {
 	const defaultProps = {
 		cards: [],
-		cart: {
-			products: [],
-		},
+		cart: {},
 		translate: identity,
 		loadTrackingTool: identity,
 		recordApplePayStatus: identity,

--- a/client/my-sites/checkout/checkout/test/checkout.js
+++ b/client/my-sites/checkout/checkout/test/checkout.js
@@ -56,7 +56,9 @@ jest.mock( 'lib/cart-values', () => ( {
 describe( 'Checkout', () => {
 	const defaultProps = {
 		cards: [],
-		cart: {},
+		cart: {
+			products: [],
+		},
 		translate: identity,
 		loadTrackingTool: identity,
 		recordApplePayStatus: identity,

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -230,7 +230,7 @@ class PlanFeatures extends Component {
 						planType={ planName }
 						rawPrice={ rawPrice }
 						discountPrice={ discountPrice }
-						billingTimeFrame={ planConstantObj.getBillingTimeFrame() }
+						billingTimeFrame={ planConstantObj.getBillingTimeFrame( abtest ) }
 						hideMonthly={ hideMonthly }
 						isPlaceholder={ isPlaceholder }
 						basePlansPath={ basePlansPath }
@@ -296,7 +296,7 @@ class PlanFeatures extends Component {
 			const { rawPrice, discountPrice } = properties;
 			const classes = classNames( 'plan-features__table-item', 'has-border-top' );
 			let audience = planConstantObj.getAudience();
-			let billingTimeFrame = planConstantObj.getBillingTimeFrame();
+			let billingTimeFrame = planConstantObj.getBillingTimeFrame( abtest );
 
 			if ( isInSignup && ! displayJetpackPlans ) {
 				switch ( siteType ) {

--- a/client/my-sites/plans/plans.js
+++ b/client/my-sites/plans/plans.js
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 /**
  * Internal Dependencies
  */
-import { abtest } from 'lib/abtest';
 import config from 'config';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import getIntervalTypeForTerm from 'lib/plans/get-interval-type-for-term';
@@ -18,11 +17,7 @@ import Plans from 'my-sites/plans/main';
 export default connect( ( state, { intervalType } ) => {
 	// For WP.com plans page, if intervalType is not explicitly specified in the URL,
 	// we want to show plans of the same term as plan that is currently active
-	if (
-		! intervalType &&
-		config.isEnabled( 'upgrades/2-year-plans' ) &&
-		abtest( 'multiyearSubscriptions' ) === 'show'
-	) {
+	if ( ! intervalType && config.isEnabled( 'upgrades/2-year-plans' ) ) {
 		const selectedSiteId = getSelectedSiteId( state );
 		intervalType = getIntervalTypeForTerm( getCurrentPlanTerm( state, selectedSiteId ) );
 	}


### PR DESCRIPTION
This PR concludes multiyear testing for personal and premium plans, and makes them available to everyone. Since we need to iterate a bit more on 2-year plans, this PR creates another a/b test and only makes 2-year business plan available to 50% of all users.

**Test plan:**

1. Add yourself to `hide` group of `multiyearSubscriptionsBusinessPriceTest`
2. Confirm that if you try to checkout personal or premium plan, the term picker is visible in checkout form:

<img width="716" alt="zrzut ekranu 2018-05-29 o 15 15 47" src="https://user-images.githubusercontent.com/205419/40661131-3924f21e-6353-11e8-8652-8b10de7a756c.png">

3. Confirm that if you try to checkout a business plan, the term picker is not visible in checkout form.

4. Go to `/plans` for a free site, confirm plans headers are looking like this:

<img width="1076" alt="zrzut ekranu 2018-05-29 o 15 19 34" src="https://user-images.githubusercontent.com/205419/40661322-b8f49134-6353-11e8-85a6-26732fc4cdf0.png">

5. Go to `/plans` for a 1-year personal site, confirm plans headers are looking like this:

<img width="1069" alt="zrzut ekranu 2018-05-29 o 15 18 32" src="https://user-images.githubusercontent.com/205419/40661278-95f90368-6353-11e8-84fb-eeb87ffb3e0a.png">

6. Go to `/plans` for a 2-year business site, confirm plans headers are looking like this:

<img width="1066" alt="zrzut ekranu 2018-05-29 o 15 14 49" src="https://user-images.githubusercontent.com/205419/40661045-0aea6c26-6353-11e8-99ee-3211ce48eefd.png">

7. Add yourself to `show` group of `multiyearSubscriptionsBusinessPriceTest`

8. Confirm that if you try to checkout personal, premium, or business plan, the term picker is visible in checkout form:

<img width="716" alt="zrzut ekranu 2018-05-29 o 15 15 47" src="https://user-images.githubusercontent.com/205419/40661131-3924f21e-6353-11e8-8652-8b10de7a756c.png">

9. Go to `/plans` for a free site, confirm plans headers are looking like this:

<img width="1051" alt="zrzut ekranu 2018-05-29 o 15 20 15" src="https://user-images.githubusercontent.com/205419/40661361-d6b46a78-6353-11e8-83f1-94c15765ddd1.png">

10. Go to `/plans` for a 1-year personal site, confirm plans headers are looking like this:

<img width="1058" alt="zrzut ekranu 2018-05-29 o 15 20 49" src="https://user-images.githubusercontent.com/205419/40661380-e428a93a-6353-11e8-9b2c-838d5b683633.png">

11. Go to `/plans` for a 2-year business site, confirm plans headers are looking like this:

<img width="1070" alt="zrzut ekranu 2018-05-29 o 15 12 42" src="https://user-images.githubusercontent.com/205419/40660943-c7e4bb02-6352-11e8-9eca-fd7b60c2117d.png">