### PR TITLE
Update webpack to version 4.10.x

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -944,6 +944,211 @@
       "integrity": "sha512-GpQxofkdlHYxjHad98UUdNoMO7JrmzQZoAaghtNg14Gwg7YkohcrCoJEcEMSgllx4VIZ+mYw7ZHjfaeIagP/rg==",
       "dev": true
     },
+    "@webassemblyjs/ast": {
+      "version": "1.5.9",
+      "integrity": "sha512-xL3hC0TOc4ic1UNG8ZZNeaiPf1klozt6rqajcy7hfO/qqfkEhLff1AFt5g2LJkTjhw+QSEYVMt7qOaaApu7JzA==",
+      "requires": {
+        "@webassemblyjs/helper-module-context": "1.5.9",
+        "@webassemblyjs/helper-wasm-bytecode": "1.5.9",
+        "@webassemblyjs/wast-parser": "1.5.9",
+        "debug": "3.1.0",
+        "mamacro": "0.0.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.5.9",
+      "integrity": "sha512-naMJjuBqDqx4dPSzwpI9pkjdLds4tDTzvsOEzwxPDp655IfgLLP/QEvK/9PQp4p5DExqrR87rk8DWByoqWWlGA=="
+    },
+    "@webassemblyjs/helper-api-error": {
+      "version": "1.5.9",
+      "integrity": "sha512-tzGdqBo7Xf3McJcXbwbwzwElRzF/nELJN+G4MGGfm0DGRQB6UTmMe44jFIOQYT1Za89Aiz5DMQJotdnnLheixw=="
+    },
+    "@webassemblyjs/helper-buffer": {
+      "version": "1.5.9",
+      "integrity": "sha512-WYkys6y33viEY23tHJ+KkSd9yHZBd54Sy6gcSgwLGPP1or9pLqWBrjWWATHuDuIkpvSJSt/+3qjAV6zHd1nS0g==",
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "@webassemblyjs/helper-code-frame": {
+      "version": "1.5.9",
+      "integrity": "sha512-SYjNAlqcRH+YynslbIhFYOnGvE3WBl82/XlcFXiNkqnWsvHWnNkJbtxAtzrT/dcf69O/2pt8j1Q0+qc/rtacVw==",
+      "requires": {
+        "@webassemblyjs/wast-printer": "1.5.9"
+      }
+    },
+    "@webassemblyjs/helper-fsm": {
+      "version": "1.5.9",
+      "integrity": "sha512-8D+VVIJTRbsn31zt3eyidYyUkhH1jk2/58mrIPiMarflRsisItJa5WZVu/gw0l+ubFOJf9PivTJB6Kw/Kgxx3g=="
+    },
+    "@webassemblyjs/helper-module-context": {
+      "version": "1.5.9",
+      "integrity": "sha512-DbeLbFOhioEeY7yAff12+n5sf7WP7Fmi0lnhCSzfW4xBsgwXKmRjAx7nVmsUf3z+BDnwHHVKIXBUM+ucccNUsw=="
+    },
+    "@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.5.9",
+      "integrity": "sha512-zHQuTMMd2nTyEa3fbmGfzlJW305py1sgf1gHNCO/LVN8nWlKysB/+6J68sP1Cd+9USnT1VS2vyD1z+YJPS6GqQ=="
+    },
+    "@webassemblyjs/helper-wasm-section": {
+      "version": "1.5.9",
+      "integrity": "sha512-+ff+8Ju6sLCMFNygcDdLRNRsmuD0PHwq77d2mbfWj5YzUvFaKN2q2kRppJSEAixOnM2xLADuG5y/blpMo5G90A==",
+      "requires": {
+        "@webassemblyjs/ast": "1.5.9",
+        "@webassemblyjs/helper-buffer": "1.5.9",
+        "@webassemblyjs/helper-wasm-bytecode": "1.5.9",
+        "@webassemblyjs/wasm-gen": "1.5.9",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "@webassemblyjs/ieee754": {
+      "version": "1.5.9",
+      "integrity": "sha512-mhetZBDnpV3VYqZb5Aail9X01VyIqDDZrNYdYj8bfx/PsVPG2znX90wRyVNTeqC5ylqHCgGkJ63bPaPEyINfsw==",
+      "requires": {
+        "ieee754": "1.1.11"
+      }
+    },
+    "@webassemblyjs/leb128": {
+      "version": "1.5.9",
+      "integrity": "sha512-oZ3eUB9EViUtiuMwW/xeYamXgfFS2cmXl6aUIYBfpXJQ5v5aOC8ZuPpz2/LqlgNlT8ThpyFd6kfgkYVwKwkGvQ==",
+      "requires": {
+        "leb": "0.3.0"
+      }
+    },
+    "@webassemblyjs/wasm-edit": {
+      "version": "1.5.9",
+      "integrity": "sha512-pMWe3HomnWAMZytJ5sSNBS6qTbSoULUHkvDrtcarmLBTclmupZe25INy1jxbWGKsuFxw6w0xQ+eLRPlC8HPjhg==",
+      "requires": {
+        "@webassemblyjs/ast": "1.5.9",
+        "@webassemblyjs/helper-buffer": "1.5.9",
+        "@webassemblyjs/helper-wasm-bytecode": "1.5.9",
+        "@webassemblyjs/helper-wasm-section": "1.5.9",
+        "@webassemblyjs/wasm-gen": "1.5.9",
+        "@webassemblyjs/wasm-opt": "1.5.9",
+        "@webassemblyjs/wasm-parser": "1.5.9",
+        "@webassemblyjs/wast-printer": "1.5.9",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "@webassemblyjs/wasm-gen": {
+      "version": "1.5.9",
+      "integrity": "sha512-UEhymlxupBUJuwnD2N860MqkpE7LHt0tNKqAgT4YAVjbx+88P6MBBk+q+9wr2FJCXxMgsPTxMWifqC4wd2FzVg==",
+      "requires": {
+        "@webassemblyjs/ast": "1.5.9",
+        "@webassemblyjs/helper-wasm-bytecode": "1.5.9",
+        "@webassemblyjs/ieee754": "1.5.9",
+        "@webassemblyjs/leb128": "1.5.9"
+      }
+    },
+    "@webassemblyjs/wasm-opt": {
+      "version": "1.5.9",
+      "integrity": "sha512-oQm84US3e36dPq5bOeybVKA2ZyzeWR4fereg9kJa0Y9XLKxHwlsBa2kFyNXwZNrhMP33iyXAW+ym7om1zPZeAg==",
+      "requires": {
+        "@webassemblyjs/ast": "1.5.9",
+        "@webassemblyjs/helper-buffer": "1.5.9",
+        "@webassemblyjs/wasm-gen": "1.5.9",
+        "@webassemblyjs/wasm-parser": "1.5.9",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "@webassemblyjs/wasm-parser": {
+      "version": "1.5.9",
+      "integrity": "sha512-jBKBTKE4M/WYCSqLjRvK+/QD55E/HNcQjswbksof3GEXfkq0iMqYxoPfqR7uLAD9/jVf9HpBNW2FJOyfTTlYfw==",
+      "requires": {
+        "@webassemblyjs/ast": "1.5.9",
+        "@webassemblyjs/helper-api-error": "1.5.9",
+        "@webassemblyjs/helper-wasm-bytecode": "1.5.9",
+        "@webassemblyjs/ieee754": "1.5.9",
+        "@webassemblyjs/leb128": "1.5.9",
+        "@webassemblyjs/wasm-parser": "1.5.9"
+      }
+    },
+    "@webassemblyjs/wast-parser": {
+      "version": "1.5.9",
+      "integrity": "sha512-bDuYH/NR5D+MmwVZdGW2rUvu4UcKGpodiHBSueajon3oNPu+PAKG+7br3BVFKxDUtDoVtuHLUQvkqp1lTrqPCA==",
+      "requires": {
+        "@webassemblyjs/ast": "1.5.9",
+        "@webassemblyjs/floating-point-hex-parser": "1.5.9",
+        "@webassemblyjs/helper-api-error": "1.5.9",
+        "@webassemblyjs/helper-code-frame": "1.5.9",
+        "@webassemblyjs/helper-fsm": "1.5.9",
+        "long": "3.2.0",
+        "mamacro": "0.0.3"
+      }
+    },
+    "@webassemblyjs/wast-printer": {
+      "version": "1.5.9",
+      "integrity": "sha512-04iV32TO69kZChP3DN6W8i6GCa5UtEn1Lnzb4sQGe5YNjIFz2k8+KZLxbovWIZgj9pk06k3Egq/wyD98lSKaLw==",
+      "requires": {
+        "@webassemblyjs/ast": "1.5.9",
+        "@webassemblyjs/wast-parser": "1.5.9",
+        "long": "3.2.0"
+      }
+    },
     "JSONStream": {
       "version": "0.8.4",
       "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
@@ -971,14 +1176,14 @@
       }
     },
     "acorn": {
-      "version": "5.5.3",
-      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
+      "version": "5.6.0",
+      "integrity": "sha512-QatFQ4C0n+PLqemyC6zXEv04tSqRR0hRqe+uGKPEVgKe2G8kl8wJvHzRYWwz6vqqEqt6idPVMFojZ4P1zlyAzQ=="
     },
     "acorn-dynamic-import": {
       "version": "3.0.0",
       "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
       "requires": {
-        "acorn": "5.5.3"
+        "acorn": "5.6.0"
       }
     },
     "acorn-globals": {
@@ -986,14 +1191,14 @@
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3"
+        "acorn": "5.6.0"
       }
     },
     "acorn-jsx": {
       "version": "4.1.1",
       "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
       "requires": {
-        "acorn": "5.5.3"
+        "acorn": "5.6.0"
       }
     },
     "after": {
@@ -1323,7 +1528,7 @@
       "integrity": "sha1-a8vQOKM3xwYn5/zkQ4+lgYjwk3s=",
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000846",
+        "caniuse-db": "1.0.30000847",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -1334,7 +1539,7 @@
           "version": "1.3.6",
           "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
           "requires": {
-            "caniuse-db": "1.0.30000846"
+            "caniuse-db": "1.0.30000847"
           }
         }
       }
@@ -2654,7 +2859,7 @@
       "version": "3.2.8",
       "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "requires": {
-        "caniuse-lite": "1.0.30000846",
+        "caniuse-lite": "1.0.30000847",
         "electron-to-chromium": "1.3.48"
       }
     },
@@ -2670,7 +2875,7 @@
       "version": "0.19.3",
       "integrity": "sha512-3B0Lcy2u6x6km0BqTz/FS3UnrOJlnIlBWsyjvtqzdtmWkqiS0+Sg4hc6L9Mmm63hZKTACpYS9vUeIoKSi1vcrQ==",
       "requires": {
-        "acorn": "5.5.3",
+        "acorn": "5.6.0",
         "acorn-dynamic-import": "3.0.0",
         "acorn-jsx": "4.1.1",
         "chalk": "2.4.1",
@@ -2830,12 +3035,12 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000846",
-      "integrity": "sha1-2chvkUc4202gmO7e2ZdBPERWG9I="
+      "version": "1.0.30000847",
+      "integrity": "sha1-/0BypUaICf7ArprDtANe+JHlsUQ="
     },
     "caniuse-lite": {
-      "version": "1.0.30000846",
-      "integrity": "sha512-qxUOHr5mTaadWH1ap0ueivHd8x42Bnemcn+JutVr7GWmm2bU4zoBhjuv5QdXgALQnnT626lOQros7cCDf8PwCg=="
+      "version": "1.0.30000847",
+      "integrity": "sha512-Weo+tRtVWcN2da782Ebx/27hFNEb+KP+uP6tdqAa+2S5bp1zOJhVH9tEpDygagrfvU4QjeuPwi/5VGsgT4SLaA=="
     },
     "capture-exit": {
       "version": "1.2.0",
@@ -4528,7 +4733,7 @@
       "version": "4.7.1",
       "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
       "requires": {
-        "acorn": "5.5.3",
+        "acorn": "5.6.0",
         "defined": "1.0.0"
       }
     },
@@ -4585,7 +4790,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000846",
+        "caniuse-db": "1.0.30000847",
         "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
         "jsonfilter": "1.1.2",
@@ -4603,7 +4808,7 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000846",
+            "caniuse-db": "1.0.30000847",
             "electron-to-chromium": "1.3.48"
           }
         },
@@ -5665,7 +5870,7 @@
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3",
+        "acorn": "5.6.0",
         "acorn-jsx": "3.0.1"
       },
       "dependencies": {
@@ -9181,7 +9386,7 @@
         "istanbul-lib-hook": "1.2.0",
         "istanbul-lib-instrument": "1.10.1",
         "istanbul-lib-report": "1.1.4",
-        "istanbul-lib-source-maps": "1.2.4",
+        "istanbul-lib-source-maps": "1.2.5",
         "istanbul-reports": "1.3.0",
         "js-yaml": "3.11.0",
         "mkdirp": "0.5.1",
@@ -9205,8 +9410,8 @@
           }
         },
         "istanbul-lib-source-maps": {
-          "version": "1.2.4",
-          "integrity": "sha512-UzuK0g1wyQijiaYQxj/CdNycFhAd2TLtO2obKQMTZrZ1jzEMRY3rvpASEKkaxbRR6brvdovfA03znPa/pXcejg==",
+          "version": "1.2.5",
+          "integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
           "dev": true,
           "requires": {
             "debug": "3.1.0",
@@ -10531,7 +10736,7 @@
       "dev": true,
       "requires": {
         "abab": "1.0.4",
-        "acorn": "5.5.3",
+        "acorn": "5.6.0",
         "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
         "cssom": "0.3.2",
@@ -10581,6 +10786,10 @@
     "json-loader": {
       "version": "0.5.4",
       "integrity": "sha1-i6oTZaYy9Yo8RtIBdfxgAsluN94="
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -10854,6 +11063,10 @@
           }
         }
       }
+    },
+    "leb": {
+      "version": "0.3.0",
+      "integrity": "sha1-Mr7p+tFoMo1q6oUi2DP0GA7tHaM="
     },
     "left-pad": {
       "version": "1.3.0",
@@ -11425,6 +11638,10 @@
       "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
       "dev": true
     },
+    "long": {
+      "version": "3.2.0",
+      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+    },
     "longest": {
       "version": "1.0.1",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
@@ -11511,6 +11728,10 @@
       "requires": {
         "tmpl": "1.0.4"
       }
+    },
+    "mamacro": {
+      "version": "0.0.3",
+      "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA=="
     },
     "map-cache": {
       "version": "0.2.2",
@@ -17302,7 +17523,7 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000846",
+            "caniuse-db": "1.0.30000847",
             "electron-to-chromium": "1.3.48"
           }
         },
@@ -19074,16 +19295,21 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.5.0",
-      "integrity": "sha512-6GrZsvQJnG7o7mjbfjp6s5CyMfdopjt1A/X8LcYwceis9ySjqBX6Lusso2wNZ06utHj2ZvfL6L3f7hfgVeJP6g==",
+      "version": "4.10.2",
+      "integrity": "sha512-S4yIBevM7DFSAOAvWSBgvuH5mtJ3HgjAS6tCGsTxxHtrVdbntdRVaPey2u9sCns6KV859Vwd2DwkvBLTcs6t6g==",
       "requires": {
-        "acorn": "5.5.3",
+        "@webassemblyjs/ast": "1.5.9",
+        "@webassemblyjs/wasm-edit": "1.5.9",
+        "@webassemblyjs/wasm-opt": "1.5.9",
+        "@webassemblyjs/wasm-parser": "1.5.9",
+        "acorn": "5.6.0",
         "acorn-dynamic-import": "3.0.0",
         "ajv": "6.5.0",
         "ajv-keywords": "3.2.0",
         "chrome-trace-event": "0.1.3",
         "enhanced-resolve": "4.0.0",
         "eslint-scope": "3.7.1",
+        "json-parse-better-errors": "1.0.2",
         "loader-runner": "2.3.0",
         "loader-utils": "1.1.0",
         "memory-fs": "0.4.1",
@@ -19421,7 +19647,7 @@
       "integrity": "sha512-VKUVkVMc6TWVXmF1OxsBXoiRjYiDRA4XT0KqtbLMDK+891VX7FCuklYwzldND8J2upUcHHnuXYNTP+4mSFi4Kg==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3",
+        "acorn": "5.6.0",
         "bfj-node4": "5.3.1",
         "chalk": "2.4.1",
         "commander": "2.15.1",

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "uuid": "3.2.1",
     "valid-url": "1.0.9",
     "walk": "2.3.4",
-    "webpack": "4.5.0",
+    "webpack": "4.10.2",
     "webpack-cli": "2.0.9",
     "webpack-dev-middleware": "3.1.2",
     "wpcom": "5.4.1",


### PR DESCRIPTION
Closes #25145

Release Notes: https://github.com/webpack/webpack/releases

Highlights:
* side-effect-free modules referenced by export * from are no longer including in the bundle
* the side-effects optimization is now possible in incremental compilation
* fix behavior of splitChunks when request limit has reached (caused suboptimal splitting)
* fix handling of circular chunks (caused missing __webpack_require__.e)
* add chunkGroups to Stats
* fix a caching issue for concatenated modules
* namedModules now handle name conflicts correctly
* Performance improvements
* add webpackPrefetch/webpackPreload magic comments to import()
