### PR TITLE
Domains: Fix map domain signup link

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -56,6 +56,7 @@ class TransferDomainStep extends React.Component {
 		goBack: PropTypes.func,
 		initialQuery: PropTypes.string,
 		isSignupStep: PropTypes.bool,
+		mapDomainUrl: PropTypes.string,
 		onRegisterDomain: PropTypes.func,
 		onTransferDomain: PropTypes.func,
 		onSave: PropTypes.func,
@@ -112,20 +113,23 @@ class TransferDomainStep extends React.Component {
 	}
 
 	getMapDomainUrl() {
-		const { basePath, selectedSite } = this.props;
-		let mapDomainUrl;
+		const { basePath, mapDomainUrl, selectedSite } = this.props;
+		if ( mapDomainUrl ) {
+			return mapDomainUrl;
+		}
 
+		let buildMapDomainUrl;
 		const basePathForMapping = endsWith( basePath, '/transfer' )
 			? basePath.substring( 0, basePath.length - 9 )
 			: basePath;
 
-		const query = stringify( { initialQuery: this.state.searchQuery.trim() } );
-		mapDomainUrl = `${ basePathForMapping }/mapping`;
+		buildMapDomainUrl = `${ basePathForMapping }/mapping`;
 		if ( selectedSite ) {
-			mapDomainUrl += `/${ selectedSite.slug }?${ query }`;
+			const query = stringify( { initialQuery: this.state.searchQuery.trim() } );
+			buildMapDomainUrl += `/${ selectedSite.slug }?${ query }`;
 		}
 
-		return mapDomainUrl;
+		return buildMapDomainUrl;
 	}
 
 	goToMapDomainStep = event => {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -312,6 +312,7 @@ class DomainsStep extends React.Component {
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 					initialQuery={ initialQuery }
 					isSignupStep
+					mapDomainUrl={ this.getMapDomainUrl() }
 					onRegisterDomain={ this.handleAddDomain }
 					onTransferDomain={ this.handleAddTransfer }
 					onSave={ this.onTransferSave }


### PR DESCRIPTION
When a localized /start page is used, the mapping link from the transfer screen is broken.

To test follow steps in issue, and make sure it's not reproducible and you can properly map a domain. Also check non-NUX flow for different locales.

Fixes: https://github.com/Automattic/wp-calypso/issues/25114