### PR TITLE
Google My Business: Add Enter Address page

### DIFF
--- a/assets/stylesheets/sections/google-my-business.scss
+++ b/assets/stylesheets/sections/google-my-business.scss
@@ -3,6 +3,7 @@
 @import '../shared/mixins/breakpoints';
 @import '../shared/mixins/placeholder';
 
+@import 'my-sites/google-my-business/enter-address/style';
 @import 'my-sites/google-my-business/location/style';
 @import 'my-sites/google-my-business/new-account/style';
 @import 'my-sites/google-my-business/select-business-type/style';

--- a/client/components/forms/form-country-select/index.jsx
+++ b/client/components/forms/form-country-select/index.jsx
@@ -7,7 +7,6 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import classnames from 'classnames';
-import observe from 'lib/mixins/data-observe';
 import { isEmpty, omit } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -16,8 +15,6 @@ import { localize } from 'i18n-calypso';
 /* eslint-disable jsx-a11y/no-onchange */
 export const FormCountrySelect = createReactClass( {
 	displayName: 'FormCountrySelect',
-
-	mixins: [ observe( 'countriesList' ) ],
 
 	getOptions( countriesList ) {
 		if ( isEmpty( countriesList ) ) {
@@ -37,7 +34,7 @@ export const FormCountrySelect = createReactClass( {
 	},
 
 	render() {
-		const countriesList = this.props.countriesList.get(),
+		const countriesList = this.props.countriesList,
 			options = this.getOptions( countriesList );
 
 		return (

--- a/client/my-sites/google-my-business/controller.js
+++ b/client/my-sites/google-my-business/controller.js
@@ -8,10 +8,17 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
+import GoogleMyBusinessEnterAddress from './enter-address';
 import GoogleMyBusinessNewAccount from './new-account';
 import GoogleMyBusinessSelectBusinessType from './select-business-type';
 import GoogleMyBusinessSelectLocation from './select-location';
 import GoogleMyBusinessStats from './stats';
+
+export function enterAddress( context, next ) {
+	context.primary = <GoogleMyBusinessEnterAddress />;
+
+	next();
+}
 
 export function newAccount( context, next ) {
 	context.primary = <GoogleMyBusinessNewAccount />;

--- a/client/my-sites/google-my-business/enter-address/index.js
+++ b/client/my-sites/google-my-business/enter-address/index.js
@@ -17,6 +17,7 @@ import DocumentHead from 'components/data/document-head';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import WizardProgressBar from 'components/wizard-progress-bar';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 class GoogleMyBusinessEnterAddress extends Component {
@@ -45,11 +46,16 @@ class GoogleMyBusinessEnterAddress extends Component {
 					{ translate( 'Google My Business' ) }
 				</HeaderCake>
 
-				<Card>
+				<Card className="gmb-enter-address__form">
 					<h1>
 						{ translate( 'Where are you located?' ) }
 					</h1>
 				</Card>
+
+				<WizardProgressBar
+					currentStep={ 2 }
+					numberOfSteps={ 5 }
+				/>
 			</Main>
 		);
 	}

--- a/client/my-sites/google-my-business/enter-address/index.js
+++ b/client/my-sites/google-my-business/enter-address/index.js
@@ -15,6 +15,7 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import DocumentHead from 'components/data/document-head';
 import HeaderCake from 'components/header-cake';
+import FormToggle from 'components/forms/form-toggle';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import WizardProgressBar from 'components/wizard-progress-bar';
@@ -26,8 +27,18 @@ class GoogleMyBusinessEnterAddress extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
+	state = {
+		isServiceAreaBusiness: false
+	};
+
 	goBack = () => {
 		page.back( `/google-my-business/new/${ this.props.siteSlug }` );
+	};
+
+	toggleServiceAreaBusiness = () => {
+		this.setState( {
+			isServiceAreaBusiness: ! this.state.isServiceAreaBusiness
+		} );
 	};
 
 	render() {
@@ -50,6 +61,17 @@ class GoogleMyBusinessEnterAddress extends Component {
 					<h1>
 						{ translate( 'Where are you located?' ) }
 					</h1>
+
+					<FormToggle
+						checked={ this.state.isServiceAreaBusiness }
+						onChange={ this.toggleServiceAreaBusiness }
+					>
+						{ translate( 'I deliver goods and services to my customers. {{link}}Learn more{{/link}}.', {
+							components: {
+								link: <a href="https://support.google.com/business/answer/3038163" rel="noopener noreferrer" target="_blank" />,
+							}
+						} ) }
+					</FormToggle>
 				</Card>
 
 				<WizardProgressBar

--- a/client/my-sites/google-my-business/enter-address/index.js
+++ b/client/my-sites/google-my-business/enter-address/index.js
@@ -1,0 +1,62 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import page from 'page';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import DocumentHead from 'components/data/document-head';
+import HeaderCake from 'components/header-cake';
+import Main from 'components/main';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+
+class GoogleMyBusinessEnterAddress extends Component {
+	static propTypes = {
+		siteSlug: PropTypes.string,
+		translate: PropTypes.func.isRequired,
+	};
+
+	goBack = () => {
+		page.back( `/google-my-business/new/${ this.props.siteSlug }` );
+	};
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<Main wideLayout>
+				<PageViewTracker
+					path="/google-my-business/create/enter-address/:site"
+					title="Google My Business > Create > Enter Address"
+				/>
+
+				<DocumentHead title={ translate( 'Google My Business' ) } />
+
+				<HeaderCake isCompact={ false } alwaysShowActionText={ false } onClick={ this.goBack }>
+					{ translate( 'Google My Business' ) }
+				</HeaderCake>
+
+				<Card>
+					<h1>
+						{ translate( 'Where are you located?' ) }
+					</h1>
+				</Card>
+			</Main>
+		);
+	}
+}
+
+export default connect(
+	state => ( {
+		siteSlug: getSelectedSiteSlug( state ),
+	} )
+)( localize( GoogleMyBusinessEnterAddress ) );

--- a/client/my-sites/google-my-business/enter-address/index.js
+++ b/client/my-sites/google-my-business/enter-address/index.js
@@ -15,14 +15,18 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import DocumentHead from 'components/data/document-head';
 import HeaderCake from 'components/header-cake';
+import FormCountrySelect from 'components/forms/form-country-select';
 import FormToggle from 'components/forms/form-toggle';
+import getCountries from 'state/selectors/get-countries';
 import Main from 'components/main';
+import QueryDomainCountries from 'components/data/query-countries/domains';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import WizardProgressBar from 'components/wizard-progress-bar';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 class GoogleMyBusinessEnterAddress extends Component {
 	static propTypes = {
+		countriesList: PropTypes.array.isRequired,
 		siteSlug: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 	};
@@ -62,6 +66,9 @@ class GoogleMyBusinessEnterAddress extends Component {
 						{ translate( 'Where are you located?' ) }
 					</h1>
 
+					<QueryDomainCountries />
+					<FormCountrySelect countriesList={ this.props.countriesList } />
+
 					<FormToggle
 						checked={ this.state.isServiceAreaBusiness }
 						onChange={ this.toggleServiceAreaBusiness }
@@ -85,6 +92,7 @@ class GoogleMyBusinessEnterAddress extends Component {
 
 export default connect(
 	state => ( {
+		countriesList: getCountries( state, 'domains' ),
 		siteSlug: getSelectedSiteSlug( state ),
 	} )
 )( localize( GoogleMyBusinessEnterAddress ) );

--- a/client/my-sites/google-my-business/enter-address/style.scss
+++ b/client/my-sites/google-my-business/enter-address/style.scss
@@ -1,0 +1,3 @@
+.gmb-enter-address__form {
+	margin-bottom: 0;
+}

--- a/client/my-sites/google-my-business/enter-address/style.scss
+++ b/client/my-sites/google-my-business/enter-address/style.scss
@@ -1,8 +1,12 @@
 .gmb-enter-address__form {
 	margin-bottom: 0;
 
+	.form-country-select,
+	.form-toggle__wrapper {
+		margin-top: 20px;
+	}
+
 	.form-toggle__wrapper {
 		display: block;
-		margin-top: 15px;
 	}
 }

--- a/client/my-sites/google-my-business/enter-address/style.scss
+++ b/client/my-sites/google-my-business/enter-address/style.scss
@@ -1,3 +1,8 @@
 .gmb-enter-address__form {
 	margin-bottom: 0;
+
+	.form-toggle__wrapper {
+		display: block;
+		margin-top: 15px;
+	}
 }

--- a/client/my-sites/google-my-business/index.js
+++ b/client/my-sites/google-my-business/index.js
@@ -11,7 +11,7 @@ import page from 'page';
 import config from 'config';
 import { makeLayout, redirectLoggedOut } from 'controller';
 import { navigation, sites, siteSelection } from 'my-sites/controller';
-import { newAccount, selectBusinessType, selectLocation, stats } from './controller';
+import { enterAddress, newAccount, selectBusinessType, selectLocation, stats } from './controller';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getKeyringConnectionsByName } from 'state/sharing/keyring/selectors';
 import getGoogleMyBusinessLocations from 'state/selectors/get-google-my-business-locations';
@@ -48,6 +48,25 @@ export default function( router ) {
 	}
 
 	router( '/google-my-business', siteSelection, sites, navigation, makeLayout );
+
+	if ( config.isEnabled( 'google-my-business-m3' ) ) {
+		router( '/google-my-business/create/enter-address',
+			redirectLoggedOut,
+			siteSelection,
+			sites,
+			makeLayout
+		);
+
+		router(
+			'/google-my-business/create/enter-address/:site',
+			redirectLoggedOut,
+			siteSelection,
+			redirectUnauthorized,
+			enterAddress,
+			navigation,
+			makeLayout
+		);
+	}
 
 	router( '/google-my-business/new', redirectLoggedOut, siteSelection, sites, makeLayout );
 

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -38,6 +38,7 @@
 		"gdpr-banner": true,
 		"google-analytics": true,
 		"google-my-business": false,
+		"google-my-business-m3": false,
 		"help": true,
 		"help/courses": true,
 		"jetpack/connect/remote-install": true,

--- a/config/development.json
+++ b/config/development.json
@@ -61,6 +61,7 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": false,
 		"google-my-business": true,
+		"google-my-business-m3": true,
 		"google-analytics": false,
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -36,7 +36,7 @@
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,
 		"gdpr-banner": true,
-		"google-my-business": false,
+		"google-my-business": true,
 		"google-analytics": true,
 		"happychat": false,
 		"help": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -37,6 +37,7 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": true,
 		"google-my-business": true,
+		"google-my-business-m3": false,
 		"google-analytics": true,
 		"happychat": false,
 		"help": true,

--- a/config/production.json
+++ b/config/production.json
@@ -37,6 +37,7 @@
 		"gdpr-banner": true,
 		"google-analytics": true,
 		"google-my-business": true,
+		"google-my-business-m3": false,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -40,6 +40,7 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": false,
 		"google-my-business": true,
+		"google-my-business-m3": false,
 		"google-analytics": false,
 		"happychat": true,
 		"help": true,

--- a/config/test.json
+++ b/config/test.json
@@ -37,6 +37,7 @@
 		"gdpr-banner": false,
 		"google-analytics": false,
 		"google-my-business": true,
+		"google-my-business-m3": false,
 		"help": true,
 		"jetpack/checklist": true,
 		"jetpack/connect/remote-install": true,

--- a/config/test.json
+++ b/config/test.json
@@ -36,7 +36,7 @@
 		"devdocs/components-usage-stats": false,
 		"gdpr-banner": false,
 		"google-analytics": false,
-		"google-my-business": false,
+		"google-my-business": true,
 		"help": true,
 		"jetpack/checklist": true,
 		"jetpack/connect/remote-install": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -43,6 +43,7 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": true,
 		"google-my-business": true,
+		"google-my-business-m3": false,
 		"google-analytics": false,
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,


### PR DESCRIPTION
This pull request introduces the `Enter Address` page that will be part of the flow that will allow users to create a new Google My Business location from WordPress.com itself.

#### Testing instructions

1. Run `git checkout add/enter-address-page` and start your server, or open a [live branch](https://calypso.live/?branch=add/enter-address-page)
2. Open the [`Enter Address` page](http://calypso.localhost:3000/google-my-business/create/enter-address)

#### Reviews

- [ ] Code
- [ ] Product
- [ ] Tests