### PR TITLE
Activity Log: Apply design of clone site button

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -264,13 +264,16 @@ class ActivityLogItem extends Component {
 		const { translate } = this.props;
 
 		return (
-			<Button
-				className="activity-log-item__clone-action"
-				primary
-				onClick={ this.performCloneAction }
-			>
-				{ translate( 'Clone from here' ) }
-			</Button>
+			<div className="activity-log-item__action">
+				<Button
+					className="activity-log-item__clone-action"
+					primary
+					compact
+					onClick={ this.performCloneAction }
+				>
+					{ translate( 'Clone from here' ) }
+				</Button>
+			</div>
 		);
 	};
 


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/24741/commits/8999533d815f26e740fcb82852c41222f362e81d got lost in a merge conflict. This PR reintroduces it.

**Testing**

1. Select a rewind-enabled site, navigate to Site Settings > General > Clone.
2. Make your way through the clone flow and make sure to select "Clone previous state" on step 4.
3. Observe that the "Clone from here" button matches the design below, is clickable, and navigates to the next step.

<img width="1004" alt="screen shot 2018-05-29 at 5 50 29 pm" src="https://user-images.githubusercontent.com/5528445/40673146-d026bb42-6368-11e8-8a96-00e443b8ad9f.png">
