### PR TITLE
Domains: Remove filter closure A/B test

### DIFF
--- a/client/components/domains/search-filters/dropdown-filters.jsx
+++ b/client/components/domains/search-filters/dropdown-filters.jsx
@@ -13,7 +13,6 @@ import { isEqual, pick } from 'lodash';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import config from 'config';
 import ValidationFieldset from 'signup/validation-fieldset';
 import FormTextInput from 'components/forms/form-text-input';
@@ -160,7 +159,6 @@ export class DropdownFilters extends Component {
 			translate,
 		} = this.props;
 
-		const filterOnClose = abtest( 'domainSearchFilterOnClose' ) === 'enabled';
 		const isDashesFilterEnabled = config.isEnabled( 'domains/kracken-ui/dashes-filter' );
 		const isExactMatchFilterEnabled = config.isEnabled( 'domains/kracken-ui/exact-match-filter' );
 		const isLengthFilterEnabled = config.isEnabled( 'domains/kracken-ui/max-characters-filter' );
@@ -171,7 +169,7 @@ export class DropdownFilters extends Component {
 				className="search-filters__popover"
 				context={ this.button.current }
 				isVisible={ this.state.showPopover }
-				onClose={ filterOnClose ? this.handleFiltersSubmit : this.togglePopover }
+				onClose={ this.handleFiltersSubmit }
 				position="bottom left"
 			>
 				{ isLengthFilterEnabled && (

--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -14,7 +14,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -158,7 +157,6 @@ export class TldFilterBar extends Component {
 
 	renderPopover() {
 		const { translate } = this.props;
-		const filterOnClose = abtest( 'domainSearchFilterOnClose' ) === 'enabled';
 
 		return (
 			<Popover
@@ -166,7 +164,7 @@ export class TldFilterBar extends Component {
 				className="search-filters__popover"
 				context={ this.button }
 				isVisible={ this.state.showPopover }
-				onClose={ filterOnClose ? this.handleFiltersSubmit : this.togglePopover }
+				onClose={ this.handleFiltersSubmit }
 				position="bottom left"
 			>
 				<FormFieldset className="search-filters__token-field-fieldset">

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -100,14 +100,6 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
-	domainSearchFilterOnClose: {
-		datestamp: '20180524',
-		variations: {
-			disabled: 50,
-			enabled: 50,
-		},
-		defaultVariation: 'disabled',
-	},
 	domainSuggestionKrakenV321: {
 		datestamp: '20180524',
 		variations: {


### PR DESCRIPTION
This removes the A/B test introduced in #24983. This change makes it so that closing a filter popover will always apply the selected filters inside that popover.

cc @sixhours.

# Testing instructions
1. Spin up this branch locally.
2. Navigate to `/start/domains/` and enter a query.
3. Open the drop-down filter next to the search bar.
4. Select some filters and close the drop-down by clicking outside of the popover.
5. Ensure that a new search is kicked off with the filters applied.
6. Repeat 3~5 with the TLD drop-down filter.