### PR TITLE
Devdocs: Use whitelist instead of blacklist to build search index

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "build-devdocs:components-usage-stats": "npm run -s env -- npm run -s build-devdocs:components-usage-stats:_env",
     "build-devdocs:components-usage-stats:_env": "node server/devdocs/bin/generate-components-usage-stats.js \"client/**/*.js\" \"client/**/*.jsx\" \"!**/docs/**\" \"!**/test/**\" \"!**/docs-example/**\"",
     "build-devdocs:index": "npm run -s env -- npm run -s build-devdocs:index:_env",
-    "build-devdocs:index:_env": "node server/devdocs/bin/generate-devdocs-index \"**/*.md\" \".github/**.md\" \"!build/**\" \"!node_modules/**\" \"!public/**\"",
+    "build-devdocs:index:_env": "node server/devdocs/bin/generate-devdocs-index",
     "build-docker": "node bin/build-docker.js",
     "prebuild-server": "mkdirp build",
     "build-server": "CALYPSO_SERVER=true npm run -s env -- webpack --display-error-details --config webpack.config.node.js",

--- a/server/devdocs/bin/generate-devdocs-index
+++ b/server/devdocs/bin/generate-devdocs-index
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 /**
- * This script generates a Lunr.js index and document array suitable
- * for server-side documentation search. It accepts a newline-delimited list of .md files
- * as its input, and writes the index to server/devdocs/search-index.js
+ * This script generates a Lunr.js index and document array suitable for server-side
+ * documentation search. It finds all .md files that are part of the Calypso repository
+ * and writes the index to server/devdocs/search-index.js .
  *
  * The design is currently limited by available RAM, both during indexing and serving the
  * content. A more scalable solution would need to use a separate indexing service like Sphinx.

--- a/server/devdocs/bin/generate-devdocs-index
+++ b/server/devdocs/bin/generate-devdocs-index
@@ -16,14 +16,23 @@ const globby = require( 'globby' );
 const root = fspath.dirname( fspath.join( __dirname, '..', '..' ) );
 
 function main() {
-	const fileList = globby.sync( process.argv.slice( 2 ) );
+	// Build a list of all .md files in allowed subdirectories...
+	const dirList = [
+		'assets',
+		'bin',
+		'client',
+		'CODE-OF-CONDUCT.md',
+		'config',
+		'CREDITS.md',
+		'docs',
+		'LICENSE.md',
+		'README.md',
+		'server',
+		'test',
+		'.github',
+	].map( dir => /\.md/.test( dir ) ? dir : dir + '/**/*.md' );
 
-	if ( fileList.length === 0 ) {
-		process.stderr.write( 'You must pass a list of files to process (try "npm run build-devdocs:index"' );
-		process.exit( 1 );
-	}
-
-	const documents = fileList.map( fileWithPath => {
+	const documents = globby.sync( dirList ).map( fileWithPath => {
 		return documentFromFile( root, fileWithPath );
 	} ).filter( doc => {
 		// skip empty/invalid files

--- a/server/devdocs/bin/generate-devdocs-index
+++ b/server/devdocs/bin/generate-devdocs-index
@@ -9,45 +9,44 @@
  * content. A more scalable solution would need to use a separate indexing service like Sphinx.
  */
 
-var fs = require( 'fs' ),
-	fspath = require( 'path' ),
-	lunr = require( 'lunr' ),
-	globby = require( 'globby' ),
-	root = fspath.dirname( fspath.join( __dirname, '..', '..' ) );
+const fs = require( 'fs' );
+const fspath = require( 'path' );
+const lunr = require( 'lunr' );
+const globby = require( 'globby' );
+const root = fspath.dirname( fspath.join( __dirname, '..', '..' ) );
 
 function main() {
 	const fileList = globby.sync( process.argv.slice( 2 ) );
 
-	if( fileList.length === 0 ) {
+	if ( fileList.length === 0 ) {
 		process.stderr.write( 'You must pass a list of files to process (try "npm run build-devdocs:index"' );
 		process.exit( 1 );
 	}
 
-	var documents = fileList.map( function( fileWithPath ) {
+	const documents = fileList.map( fileWithPath => {
 		return documentFromFile( root, fileWithPath );
-	} ).
-	// skip empty/invalid files
-	filter( function( document ) {
-		return document.title && document.body;
+	} ).filter( doc => {
+		// skip empty/invalid files
+		return doc.title && doc.body;
 	} );
 
 	writeSearchIndex( documents, 'server/devdocs/search-index.js' );
 }
 
 function writeSearchIndex( documents, searchIndexPath ) {
-	var idx = lunr( function () {
-		this.field('title', { boost: 10 });
-		this.field('body');
+	const idx = lunr( function() {
+		this.field( 'title', { boost: 10 } );
+		this.field( 'body' );
 	} );
 
-	documents.forEach( function ( doc, index ) {
+	documents.forEach( ( doc, index ) => {
 		/*
 		 * we use the array index as the document id
 		 * so that we can look the preprocessed contents
 		 * up out of the "documents" array also exported below
 		 */
 
-		var indexDoc = {};
+		const indexDoc = {};
 		indexDoc.id = index;
 		indexDoc.title = doc.title;
 
@@ -57,7 +56,7 @@ function writeSearchIndex( documents, searchIndexPath ) {
 		idx.add( indexDoc );
 	} );
 
-	var searchIndexJS = 'module.exports.index = ' + jsFromJSON( JSON.stringify( idx ) ) + ';' +
+	const searchIndexJS = 'module.exports.index = ' + jsFromJSON( JSON.stringify( idx ) ) + ';' +
 		'module.exports.documents = ' + jsFromJSON( JSON.stringify( documents ) ) + ';';
 
 	fs.writeFileSync( fspath.join( root, searchIndexPath ), searchIndexJS );
@@ -82,7 +81,7 @@ function jsFromJSON( json ) {
  */
 
 function documentFromFile( root, fileWithPath ) {
-	var data = fs.readFileSync( fspath.join( root, fileWithPath ), { encoding: 'utf8' });
+	let data = fs.readFileSync( fspath.join( root, fileWithPath ), { encoding: 'utf8' } );
 
 	// render as markdown so that embedded HTML is properly escaped
 	// data = striptags( marked ( data) );
@@ -93,15 +92,15 @@ function documentFromFile( root, fileWithPath ) {
 	//strip common, noisy markdown stuff
 	data = data.replace( /^#+|^={2,}|^-{2,}/gm, '' );
 
-	var firstLineEnd = data.indexOf( '\n' );
+	const firstLineEnd = data.indexOf( '\n' );
 
-	if( firstLineEnd === -1 ) {
+	if ( firstLineEnd === -1 ) {
 		//this must be an empty file
 		return {};
 	}
 
-	var title = data.slice( 0, firstLineEnd );
-	var body = data.slice( firstLineEnd + 1 );
+	const title = data.slice( 0, firstLineEnd );
+	const body = data.slice( firstLineEnd + 1 );
 
 	return {
 		path: fileWithPath,

--- a/server/devdocs/bin/generate-devdocs-index
+++ b/server/devdocs/bin/generate-devdocs-index
@@ -21,16 +21,14 @@ function main() {
 		'assets',
 		'bin',
 		'client',
-		'CODE-OF-CONDUCT.md',
 		'config',
-		'CREDITS.md',
 		'docs',
-		'LICENSE.md',
-		'README.md',
 		'server',
 		'test',
 		'.github',
-	].map( dir => /\.md/.test( dir ) ? dir : dir + '/**/*.md' );
+	].map( dir => dir + '/**/*.md' );
+	// ... and the current directory
+	dirList.push( '*.md' );
 
 	const documents = globby.sync( dirList ).map( fileWithPath => {
 		return documentFromFile( root, fileWithPath );


### PR DESCRIPTION
This PR makes the list of files used to generate the devdocs search index more predictable.

I ran something like `cp -var node_modules/ node_modules_backup/` to try to diagnose an issue.  This caused a build failure with the following symptoms:

```
> wp-calypso@0.17.0 poststart /home/james/a8c/code/wp-calypso
> CALYPSO_CLIENT=true npm run -s env -- cross-env-shell node $NODE_ARGS build/bundle.js

 10% building modules 1/1 modules 0 activevm.js:80                                 
  return new Script(code, options);
         ^

RangeError: Maximum call stack size exceeded
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:616:28)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at Object.devdocs/search-index (.../wp-calypso/build/webpack:/external "devdocs/search-index":1:1)
...
```

```
$ ls -lah server/devdocs/search-index.js
-rw-r--r-- 1 james james 82M May 29 14:25 server/devdocs/search-index.js
```

The reason was that every `*.md` file in the new `node_modules_backup/` folder was getting included in the search index.

Having extra files/folders in the root dir shouldn't break the build, so let's use a whitelist rather than a blacklist to generate this list of `*.md` files.

### To test

Copy `node_modules/` to `node_modules_backup/` and try running `npm run build-devdocs:index` before and after this PR.  Before this PR, you'll see an ~82 MB `server/devdocs/search-index.js` file generated (and probably some build failures).  After this PR, it should be around 5.1 MB regardless of the presence of this extra folder.

If you want, you can back out the last commit of this PR and verify that the generated `server/devdocs/search-index.js` file is exactly equal to what's generated in `master`.  For code simplicity, though, this PR will change the order of the files included in the index slightly.

Make sure searching from `/devdocs` still works, especially for phrases like `license` which should return several results from `*.md` files in the root directory and `.github/CONTRIBUTING.md`.