### PR TITLE
Signup Actions: Remove `error` argument to `submitSignupStep` 

### DIFF
--- a/client/lib/signup/actions.js
+++ b/client/lib/signup/actions.js
@@ -28,13 +28,12 @@ const SignupActions = {
 		} );
 	},
 
-	submitSignupStep( step, errors, providedDependencies ) {
+	submitSignupStep( step, providedDependencies ) {
 		analytics.tracks.recordEvent( 'calypso_signup_actions_submit_step', { step: step.stepName } );
 
 		Dispatcher.handleViewAction( {
 			type: 'SUBMIT_SIGNUP_STEP',
 			data: step,
-			errors: undefined === errors ? [] : errors,
 			providedDependencies: providedDependencies,
 		} );
 	},

--- a/client/lib/signup/progress-store.js
+++ b/client/lib/signup/progress-store.js
@@ -79,15 +79,6 @@ function updateOrAddStep( step ) {
 	}
 }
 
-function setStepInvalid( step, errors ) {
-	updateOrAddStep(
-		assign( {}, step, {
-			status: 'invalid',
-			errors: errors,
-		} )
-	);
-}
-
 function saveStep( step ) {
 	if ( find( signupProgress, { stepName: step.stepName } ) ) {
 		updateStep( step );
@@ -151,14 +142,10 @@ function addStorableDependencies( step, action ) {
 }
 
 SignupProgressStore.dispatchToken = Dispatcher.register( function( payload ) {
-	let action = payload.action,
-		step = addTimestamp( action.data );
+	const action = payload.action;
+	const step = addTimestamp( action.data );
 
 	Dispatcher.waitFor( [ SignupDependencyStore.dispatchToken ] );
-
-	if ( ! isEmpty( action.errors ) ) {
-		return setStepInvalid( step, action.errors );
-	}
 
 	switch ( action.type ) {
 		case 'FETCH_CACHED_SIGNUP':

--- a/client/lib/signup/test/dependency-store.js
+++ b/client/lib/signup/test/dependency-store.js
@@ -43,7 +43,7 @@ describe( 'dependency-store', () => {
 	} );
 
 	test( 'should store dependencies if they are provided in either signup action', () => {
-		SignupActions.submitSignupStep( { stepName: 'userCreation' }, [], { bearer_token: 'TOKEN' } );
+		SignupActions.submitSignupStep( { stepName: 'userCreation' }, { bearer_token: 'TOKEN' } );
 
 		assert.deepEqual( SignupDependencyStore.get(), { bearer_token: 'TOKEN' } );
 

--- a/client/lib/signup/test/flow-controller.js
+++ b/client/lib/signup/test/flow-controller.js
@@ -64,7 +64,7 @@ describe( 'flow-controller', () => {
 		} );
 
 		test( 'should call apiRequestFunction on steps with that property', done => {
-			SignupActions.submitSignupStep( { stepName: 'userCreation' }, [], { bearer_token: 'TOKEN' } );
+			SignupActions.submitSignupStep( { stepName: 'userCreation' }, { bearer_token: 'TOKEN' } );
 
 			SignupActions.submitSignupStep( {
 				stepName: 'asyncStep',
@@ -73,7 +73,7 @@ describe( 'flow-controller', () => {
 		} );
 
 		test( 'should not call apiRequestFunction multiple times', done => {
-			SignupActions.submitSignupStep( { stepName: 'userCreation' }, [], { bearer_token: 'TOKEN' } );
+			SignupActions.submitSignupStep( { stepName: 'userCreation' }, { bearer_token: 'TOKEN' } );
 			SignupActions.submitSignupStep( {
 				stepName: 'asyncStep',
 				done: done,
@@ -81,7 +81,7 @@ describe( 'flow-controller', () => {
 
 			// resubmit the first step to initiate another call to SignupFlowController#_process
 			// implicitly asserting that apiRequestFunction/done is only called once
-			SignupActions.submitSignupStep( { stepName: 'userCreation' }, [], { bearer_token: 'TOKEN' } );
+			SignupActions.submitSignupStep( { stepName: 'userCreation' }, { bearer_token: 'TOKEN' } );
 		} );
 	} );
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -121,10 +121,13 @@ class Signup extends React.Component {
 				vertical,
 				otherText: '',
 			} );
-			SignupActions.submitSignupStep( { stepName: 'survey' }, [], {
-				surveySiteType: 'blog',
-				surveyQuestion: vertical,
-			} );
+			SignupActions.submitSignupStep(
+				{ stepName: 'survey' },
+				{
+					surveySiteType: 'blog',
+					surveyQuestion: vertical,
+				}
+			);
 		}
 	};
 

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -327,7 +327,6 @@ class AboutStep extends Component {
 				processingMessage: translate( 'Collecting your information' ),
 				stepName: stepName,
 			},
-			[],
 			{
 				themeSlugWithRepo: themeRepo,
 				siteTitle: siteTitleValue,

--- a/client/signup/steps/clone-credentials/index.jsx
+++ b/client/signup/steps/clone-credentials/index.jsx
@@ -34,9 +34,12 @@ class CloneCredentialsStep extends Component {
 	};
 
 	goToNextStep = () => {
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
-			roleName: 'alternate',
-		} );
+		SignupActions.submitSignupStep(
+			{ stepName: this.props.stepName },
+			{
+				roleName: 'alternate',
+			}
+		);
 
 		this.props.goToNextStep();
 	};

--- a/client/signup/steps/clone-destination/index.jsx
+++ b/client/signup/steps/clone-destination/index.jsx
@@ -60,7 +60,7 @@ class CloneDestinationStep extends Component {
 		);
 
 		if ( isEmpty( errors ) ) {
-			SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
+			SignupActions.submitSignupStep( { stepName: this.props.stepName }, {
 				destinationSiteName,
 				destinationSiteUrl,
 			} );

--- a/client/signup/steps/clone-jetpack/index.jsx
+++ b/client/signup/steps/clone-jetpack/index.jsx
@@ -27,17 +27,23 @@ class CloneJetpackStep extends Component {
 	};
 
 	selectNew = () => {
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
-			cloneJetpack: 'new',
-		} );
+		SignupActions.submitSignupStep(
+			{ stepName: this.props.stepName },
+			{
+				cloneJetpack: 'new',
+			}
+		);
 
 		this.props.goToNextStep();
 	};
 
 	selectMigrate = () => {
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
-			cloneJetpack: 'migrate',
-		} );
+		SignupActions.submitSignupStep(
+			{ stepName: this.props.stepName },
+			{
+				cloneJetpack: 'migrate',
+			}
+		);
 
 		this.props.goToNextStep();
 	};

--- a/client/signup/steps/clone-point/index.jsx
+++ b/client/signup/steps/clone-point/index.jsx
@@ -36,17 +36,23 @@ class ClonePointStep extends Component {
 	};
 
 	selectCurrent = () => {
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
-			clonePoint: 0,
-		} );
+		SignupActions.submitSignupStep(
+			{ stepName: this.props.stepName },
+			{
+				clonePoint: 0,
+			}
+		);
 
 		this.props.goToNextStep();
 	};
 
 	selectedPoint = activityTs => {
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
-			clonePoint: activityTs,
-		} );
+		SignupActions.submitSignupStep(
+			{ stepName: this.props.stepName },
+			{
+				clonePoint: activityTs,
+			}
+		);
 
 		this.props.goToNextStep();
 	};

--- a/client/signup/steps/clone-ready/index.jsx
+++ b/client/signup/steps/clone-ready/index.jsx
@@ -31,7 +31,7 @@ class CloneReadyStep extends Component {
 	goToNextStep = () => {
 		const { originBlogId, clonePoint } = this.props.payload;
 
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {} );
+		SignupActions.submitSignupStep( { stepName: this.props.stepName }, {} );
 
 		this.props.initRewind( originBlogId, clonePoint, this.props.payload );
 		this.props.goToNextStep();

--- a/client/signup/steps/clone-start/index.jsx
+++ b/client/signup/steps/clone-start/index.jsx
@@ -30,11 +30,14 @@ class CloneStartStep extends Component {
 	goToNextStep = () => {
 		const { originBlogId, originSiteSlug, originSiteName } = this.props;
 
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
-			originBlogId,
-			originSiteSlug,
-			originSiteName,
-		} );
+		SignupActions.submitSignupStep(
+			{ stepName: this.props.stepName },
+			{
+				originBlogId,
+				originSiteSlug,
+				originSiteName,
+			}
+		);
 
 		this.props.goToNextStep();
 	};

--- a/client/signup/steps/creds-confirm/index.jsx
+++ b/client/signup/steps/creds-confirm/index.jsx
@@ -58,7 +58,6 @@ class CredsConfirmStep extends Component {
 				processingMessage: this.props.translate( 'Setting up your site' ),
 				stepName: this.props.stepName,
 			},
-			undefined,
 			{ rewindconfig: true }
 		);
 

--- a/client/signup/steps/creds-permission/index.jsx
+++ b/client/signup/steps/creds-permission/index.jsx
@@ -42,7 +42,6 @@ class CredsPermissionStep extends Component {
 				processingMessage: this.props.translate( 'Setting up your site' ),
 				stepName: this.props.stepName,
 			},
-			undefined,
 			{ rewindconfig: true }
 		);
 

--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -106,10 +106,13 @@ class DesignTypeWithAtomicStoreStep extends Component {
 			return;
 		}
 
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
-			designType,
-			themeSlugWithRepo,
-		} );
+		SignupActions.submitSignupStep(
+			{ stepName: this.props.stepName },
+			{
+				designType,
+				themeSlugWithRepo,
+			}
+		);
 
 		// If the user chooses `store` as design type, redirect to the `store-nux` flow.
 		// For other choices, continue with the current flow.

--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -107,10 +107,13 @@ class DesignTypeWithStoreStep extends Component {
 
 		const themeSlugWithRepo = getThemeForDesignType( designType );
 
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
-			designType,
-			themeSlugWithRepo,
-		} );
+		SignupActions.submitSignupStep(
+			{ stepName: this.props.stepName },
+			{
+				designType,
+				themeSlugWithRepo,
+			}
+		);
 
 		this.props.goToNextStep();
 	};

--- a/client/signup/steps/design-type/index.jsx
+++ b/client/signup/steps/design-type/index.jsx
@@ -135,10 +135,13 @@ export class DesignTypeStep extends Component {
 
 		this.props.recordTracksEvent( 'calypso_triforce_select_design', { category: designType } );
 
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
-			designType,
-			themeSlugWithRepo,
-		} );
+		SignupActions.submitSignupStep(
+			{ stepName: this.props.stepName },
+			{
+				designType,
+				themeSlugWithRepo,
+			}
+		);
 		this.props.goToNextStep();
 	}
 }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -153,7 +153,6 @@ class DomainsStep extends React.Component {
 				},
 				this.getThemeArgs()
 			),
-			[],
 			{ domainItem }
 		);
 
@@ -183,7 +182,6 @@ class DomainsStep extends React.Component {
 				},
 				this.getThemeArgs()
 			),
-			[],
 			{ domainItem }
 		);
 
@@ -215,7 +213,6 @@ class DomainsStep extends React.Component {
 				},
 				this.getThemeArgs()
 			),
-			[],
 			{ domainItem }
 		);
 

--- a/client/signup/steps/plans-atomic-store/index.jsx
+++ b/client/signup/steps/plans-atomic-store/index.jsx
@@ -102,7 +102,7 @@ export class PlansAtomicStoreStep extends Component {
 
 		const providedDependencies = { cartItem, privacyItem };
 
-		SignupActions.submitSignupStep( step, [], providedDependencies );
+		SignupActions.submitSignupStep( step, providedDependencies );
 
 		goToNextStep();
 	}

--- a/client/signup/steps/plans-atomic-store/test/index.jsx
+++ b/client/signup/steps/plans-atomic-store/test/index.jsx
@@ -147,8 +147,8 @@ describe( 'PlansAtomicStoreStep.onSelectPlan', () => {
 
 		const calls = SignupActions.submitSignupStep.mock.calls;
 		const args = calls[ calls.length - 1 ];
-		expect( args[ 2 ].cartItem ).toBe( cartItem );
-		expect( args[ 2 ].privacyItem ).toEqual( null );
+		expect( args[ 1 ].cartItem ).toBe( cartItem );
+		expect( args[ 1 ].privacyItem ).toEqual( null );
 		expect( args[ 0 ].privacyItem ).toEqual( null );
 	} );
 
@@ -173,7 +173,7 @@ describe( 'PlansAtomicStoreStep.onSelectPlan', () => {
 		const calls = SignupActions.submitSignupStep.mock.calls;
 		const args = calls[ calls.length - 1 ];
 		expect( args[ 0 ].privacyItem ).toEqual( 43 );
-		expect( args[ 2 ].privacyItem ).toEqual( 43 );
+		expect( args[ 1 ].privacyItem ).toEqual( 43 );
 	} );
 
 	test( 'Should call recordEvent when cartItem is specified', () => {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -67,7 +67,7 @@ class PlansStep extends Component {
 
 		const providedDependencies = { cartItem, privacyItem };
 
-		SignupActions.submitSignupStep( step, [], providedDependencies );
+		SignupActions.submitSignupStep( step, providedDependencies );
 
 		goToNextStep();
 	};

--- a/client/signup/steps/rewind-form-creds/index.jsx
+++ b/client/signup/steps/rewind-form-creds/index.jsx
@@ -43,7 +43,6 @@ class RewindFormCreds extends Component {
 					processingMessage: this.props.translate( 'Migrating your credentials' ),
 					stepName: this.props.stepName,
 				},
-				undefined,
 				{ rewindconfig: true }
 			);
 			this.props.goToNextStep();

--- a/client/signup/steps/rewind-migrate/index.jsx
+++ b/client/signup/steps/rewind-migrate/index.jsx
@@ -43,7 +43,6 @@ class RewindMigrate extends Component {
 					processingMessage: this.props.translate( 'Migrating your credentials' ),
 					stepName: this.props.stepName,
 				},
-				undefined,
 				{ rewindconfig: true }
 			);
 			this.props.goToNextStep();

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -143,26 +143,31 @@ class SiteOrDomain extends Component {
 				siteUrl,
 				isPurchasingItem: true,
 			},
-			[],
 			{ designType, domainItem, siteUrl }
 		);
 
 		if ( designType === 'domain' ) {
 			// we can skip the next two steps in the `domain-first` flow if the
 			// user is only purchasing a domain
-			SignupActions.submitSignupStep( { stepName: 'site-picker', wasSkipped: true }, [], {} );
-			SignupActions.submitSignupStep( { stepName: 'themes', wasSkipped: true }, [], {
-				themeSlugWithRepo: 'pub/twentysixteen',
-			} );
-			SignupActions.submitSignupStep( { stepName: 'plans-site-selected', wasSkipped: true }, [], {
-				cartItem: null,
-				privacyItem: null,
-			} );
+			SignupActions.submitSignupStep( { stepName: 'site-picker', wasSkipped: true }, {} );
+			SignupActions.submitSignupStep(
+				{ stepName: 'themes', wasSkipped: true },
+				{
+					themeSlugWithRepo: 'pub/twentysixteen',
+				}
+			);
+			SignupActions.submitSignupStep(
+				{ stepName: 'plans-site-selected', wasSkipped: true },
+				{
+					cartItem: null,
+					privacyItem: null,
+				}
+			);
 			goToStep( 'user' );
 		} else if ( designType === 'existing-site' ) {
 			goToNextStep();
 		} else {
-			SignupActions.submitSignupStep( { stepName: 'site-picker', wasSkipped: true }, [], {} );
+			SignupActions.submitSignupStep( { stepName: 'site-picker', wasSkipped: true }, {} );
 			goToStep( 'themes' );
 		}
 	};

--- a/client/signup/steps/site-picker/site-picker-submit.jsx
+++ b/client/signup/steps/site-picker/site-picker-submit.jsx
@@ -30,19 +30,24 @@ export class SitePickerSubmit extends React.Component {
 				siteId,
 				siteSlug,
 			},
-			[],
 			{}
 		);
 
-		SignupActions.submitSignupStep( { stepName: 'themes', wasSkipped: true }, [], {
-			themeSlugWithRepo: 'pub/twentysixteen',
-		} );
+		SignupActions.submitSignupStep(
+			{ stepName: 'themes', wasSkipped: true },
+			{
+				themeSlugWithRepo: 'pub/twentysixteen',
+			}
+		);
 
 		if ( hasPaidPlan ) {
-			SignupActions.submitSignupStep( { stepName: 'plans-site-selected', wasSkipped: true }, [], {
-				cartItem: null,
-				privacyItem: null,
-			} );
+			SignupActions.submitSignupStep(
+				{ stepName: 'plans-site-selected', wasSkipped: true },
+				{
+					cartItem: null,
+					privacyItem: null,
+				}
+			);
 
 			goToStep( 'user' );
 		} else {

--- a/client/signup/steps/site-title/index.jsx
+++ b/client/signup/steps/site-title/index.jsx
@@ -38,7 +38,6 @@ class SiteTitleStep extends React.Component {
 				stepName: this.props.stepName,
 				siteTitle,
 			},
-			[],
 			{ siteTitle }
 		);
 

--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -175,7 +175,6 @@ class SurveyStep extends React.Component {
 				stepSectionName: this.props.stepSectionName,
 				otherWriteIn: otherWriteIn,
 			},
-			[],
 			{ surveySiteType: this.props.surveySiteType, surveyQuestion: value }
 		);
 

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -53,7 +53,6 @@ class ThemeSelectionStep extends Component {
 				processingMessage: this.props.translate( 'Adding your theme' ),
 				repoSlug,
 			},
-			null,
 			{
 				themeSlugWithRepo: repoSlug,
 			}

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -154,7 +154,6 @@ export class UserStep extends Component {
 				oauth2Signup,
 				...data,
 			},
-			null,
 			dependencies
 		);
 


### PR DESCRIPTION
While doing some unrelated work I realized with the help of @gwwar
that nothing is passing errors into the `submitSignupStep` function
and at the same time the places passing "no errors" were doing it
in three separate ways:
 - `undefined`
 - `null`
 - `[]`

In this patch I'm removing the error entirely and the corresponding
logic for handling it. If we need to pass an error someday we can
add it back in. It's probably not worth the prime second-position
in which it currently lives.

**Testing**

Audit the code, run the tests.