### PR TITLE
Signup: Save steps data to persist signup progress

### DIFF
--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -24,6 +24,12 @@ import PlansSkipButton from 'components/plans/plans-skip-button';
 import QueryPlans from 'components/data/query-plans';
 
 class PlansStep extends Component {
+	componentDidMount() {
+		SignupActions.saveSignupStep( {
+			stepName: this.props.stepName,
+		} );
+	}
+
 	onSelectPlan = cartItem => {
 		const {
 				additionalStepData,

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -84,6 +84,12 @@ export class UserStep extends Component {
 		}
 	}
 
+	componentDidMount() {
+		SignupActions.saveSignupStep( {
+			stepName: this.props.stepName,
+		} );
+	}
+
 	setSubHeaderText( props ) {
 		const { flowName, oauth2Client, translate } = props;
 


### PR DESCRIPTION
Fixes #24547. 

Currently, the `Back` buttons in the `Plans` and `User` pages misdirect the user. For the `Plans` page, the back button navigates to the `About` step. For the `User` step, the back button navigates to the `Domains` step.

This change makes it so that the `NavigationLink` in `StepWrapper` gets the right previous step name by persisting the step data after the parent Step components have mounted.

(Context for the branch name: I started out fixing the Plans step's back button, but discovered that the User step also suffers from the same issue.)

# Testing Instructions
1. Spin this up locally or in a live branch.
2. Navigate to `/start`. Complete the form and proceed by pressing `Continue`.
3. On `/start/domains`, enter a query and select a free subdomain.
4. On `/start/plans`, click `Start with free` button.
5. On `/start/user`, click `Back` and ensure that you are directed to the Plans step. (In production, you would be erroneously directed to the Domains step.) 
6. On the Plans step, click `Back` and ensure that you are directed to the Domains step. (In production, you would be erroneously directed to the About step.) 