### PR TITLE
Better handling of Domain Connect authorize dialog when redirecting back to service provider.

### DIFF
--- a/client/my-sites/domains/domain-management/domain-connect/constants.js
+++ b/client/my-sites/domains/domain-management/domain-connect/constants.js
@@ -10,6 +10,7 @@ export const actionType = keyMirror( {
 	CLOSE: null,
 	READY_TO_SUBMIT: null,
 	SUBMITTING: null,
+	REDIRECTING: null,
 } );
 
 export const noticeType = {

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize-footer.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize-footer.jsx
@@ -38,7 +38,8 @@ class DomainConnectAuthorizeFooter extends Component {
 
 	renderActionConfirmCancel = () => {
 		const { translate, showAction, onConfirm, onClose } = this.props;
-		const notReadyToSubmit = actionType.READY_TO_SUBMIT !== showAction;
+		const notReadyToSubmit =
+			actionType.READY_TO_SUBMIT !== showAction || actionType.REDIRECTING === showAction;
 
 		const confirm = translate( 'Confirm' );
 		const cancel = translate( 'Cancel' );
@@ -92,6 +93,7 @@ class DomainConnectAuthorizeFooter extends Component {
 		switch ( this.props.showAction ) {
 			case actionType.READY_TO_SUBMIT:
 			case actionType.SUBMITTING:
+			case actionType.REDIRECTING:
 				return this.renderActionConfirmCancel();
 			case actionType.CLOSE:
 				return this.renderActionClose();

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
@@ -83,12 +83,18 @@ class DomainConnectAuthorize extends Component {
 
 		wpcom.applyDnsTemplateSyncFlow( domain, providerId, serviceId, params ).then(
 			result => {
+				let action = actionType.CLOSE;
+				let noticeMessage = translate( 'Hurray! Your new service is now all set up.' );
 				if ( result.redirect_uri ) {
+					action = actionType.REDIRECTING;
+					noticeMessage = translate(
+						"Please wait while we redirect you back to the service provider's site to finalize this update."
+					);
 					window.location.assign( result.redirect_uri );
 				}
 				this.setState( {
-					action: actionType.CLOSE,
-					noticeMessage: translate( 'Hurray! Your new service is now all set up.' ),
+					action,
+					noticeMessage,
 					noticeType: noticeType.SUCCESS,
 				} );
 			},


### PR DESCRIPTION
After a template that includes a `redirect_uri` parameter is successfully applied, we need to make sure that we don't show the "close" button since a user could click close before the redirect happens.

This PR just continues to show the disabled "confirm" and "cancel" buttons and shows a notice indicating that the redirect is happening.

In most cases, this all happens too fast for the user to take any action, but in a couple of cases the pause during the redirect was long enough so that we were able to click "close".

To test this, use the link in p99Zz8-ih-p2. Make sure that the close button isn't shown. And that the "confirm" and "cancel" buttons remain in the disabled state until the redirect happens.