### PR TITLE
Account closure: add gravatar to the list of things deleted

### DIFF
--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -98,6 +98,7 @@ class AccountSettingsClose extends Component {
 									<ActionPanelFigureListItem>{ translate( 'Pages' ) }</ActionPanelFigureListItem>
 									<ActionPanelFigureListItem>{ translate( 'Media' ) }</ActionPanelFigureListItem>
 									<ActionPanelFigureListItem>{ translate( 'Domains' ) }</ActionPanelFigureListItem>
+									<ActionPanelFigureListItem>{ translate( 'Gravatar' ) }</ActionPanelFigureListItem>
 								</ActionPanelFigureList>
 							</ActionPanelFigure>
 						) }


### PR DESCRIPTION
<img width="776" alt="screen shot 2018-05-30 at 11 00 47" src="https://user-images.githubusercontent.com/17325/40689966-c37ea9be-63f8-11e8-9d12-d9e1d9ed3561.png">

### To test

Go to http://calypso.localhost:3000/me/account/close with an account that has no Atomic sites or active purchases.

Ensure that 'Gravatar' is included in the list.