### PR TITLE
Jetpack Connect: Use short boolean prop shorthand in example components

### DIFF
--- a/client/jetpack-connect/example-components/jetpack-activate.jsx
+++ b/client/jetpack-connect/example-components/jetpack-activate.jsx
@@ -25,7 +25,7 @@ const JetpackConnectExampleActivate = ( { isInstall, url, translate, onClick } )
 					<Gridicon size={ 24 } icon="globe" />
 					<FormTextInput
 						className="example-components__browser-chrome-url"
-						disabled="true"
+						disabled
 						placeholder={ url }
 					/>
 				</div>
@@ -36,10 +36,7 @@ const JetpackConnectExampleActivate = ( { isInstall, url, translate, onClick } )
 				<div className="example-components__content-wp-admin-main">
 					{ isInstall ? (
 						<div className="example-components__content-wp-admin-activate-view">
-							<div
-								className="example-components__content-wp-admin-activate-link"
-								aria-hidden="true"
-							>
+							<div className="example-components__content-wp-admin-activate-link" aria-hidden>
 								{ translate( 'Activate Plugin', {
 									context: 'Jetpack Connect activate plugin instructions, activate link',
 								} ) }
@@ -47,14 +44,14 @@ const JetpackConnectExampleActivate = ( { isInstall, url, translate, onClick } )
 						</div>
 					) : (
 						<div className="example-components__content-wp-admin-plugin-card">
-							<div className="example-components__content-wp-admin-plugin-name" aria-hidden="true">
+							<div className="example-components__content-wp-admin-plugin-name" aria-hidden>
 								{ translate( 'Jetpack by WordPress.com', {
 									context: 'Jetpack Connect activate plugin instructions, plugin title',
 								} ) }
 							</div>
 							<div
 								className="example-components__content-wp-admin-plugin-activate-link"
-								aria-hidden="true"
+								aria-hidden
 							>
 								{ translate( 'Activate', {
 									context: 'Jetpack Connect activate plugin instructions, activate link',

--- a/client/jetpack-connect/example-components/jetpack-activate.jsx
+++ b/client/jetpack-connect/example-components/jetpack-activate.jsx
@@ -5,12 +5,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import FormTextInput from 'components/forms/form-text-input';
-import { localize } from 'i18n-calypso';
 
 const JetpackConnectExampleActivate = ( { isInstall, url, translate, onClick } ) => {
 	return (

--- a/client/jetpack-connect/example-components/jetpack-connect.jsx
+++ b/client/jetpack-connect/example-components/jetpack-connect.jsx
@@ -6,12 +6,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import FormTextInput from 'components/forms/form-text-input';
-import { localize } from 'i18n-calypso';
 
 const JetpackConnectExampleConnect = ( { isLegacy, url, translate, onClick } ) => {
 	const contentClassName = classNames(

--- a/client/jetpack-connect/example-components/jetpack-connect.jsx
+++ b/client/jetpack-connect/example-components/jetpack-connect.jsx
@@ -33,7 +33,7 @@ const JetpackConnectExampleConnect = ( { isLegacy, url, translate, onClick } ) =
 					<Gridicon size={ 24 } icon="globe" />
 					<FormTextInput
 						className="example-components__browser-chrome-url"
-						disabled="true"
+						disabled
 						placeholder={ url }
 					/>
 				</div>
@@ -44,11 +44,11 @@ const JetpackConnectExampleConnect = ( { isLegacy, url, translate, onClick } ) =
 				<div className="example-components__content-wp-admin-main">
 					<div className="example-components__content-wp-admin-connect-banner">
 						{ ! isLegacy ? (
-							<div className="example-components__content-wp-admin-plugin-name" aria-hidden="true">
+							<div className="example-components__content-wp-admin-plugin-name" aria-hidden>
 								{ translate( 'Connect Jetpack to WordPress.com' ) }
 							</div>
 						) : null }
-						<div className="example-components__content-wp-admin-connect-button" aria-hidden="true">
+						<div className="example-components__content-wp-admin-connect-button" aria-hidden>
 							{ translate( 'Set up Jetpack' ) }
 						</div>
 					</div>

--- a/client/jetpack-connect/example-components/jetpack-install.jsx
+++ b/client/jetpack-connect/example-components/jetpack-install.jsx
@@ -25,7 +25,7 @@ const JetpackConnectExampleInstall = ( { url, translate, onClick } ) => {
 					<Gridicon size={ 24 } icon="globe" />
 					<FormTextInput
 						className="example-components__browser-chrome-url"
-						disabled="true"
+						disabled
 						placeholder={ url }
 					/>
 				</div>
@@ -34,7 +34,7 @@ const JetpackConnectExampleInstall = ( { url, translate, onClick } ) => {
 				<div className="example-components__install-plugin-header" />
 				<div className="example-components__install-plugin-body" />
 				<div className="example-components__install-plugin-footer">
-					<div className="example-components__install-plugin-footer-button" aria-hidden="true">
+					<div className="example-components__install-plugin-footer-button" aria-hidden>
 						{ translate( 'Install Now', {
 							context: 'Jetpack Connect install plugin instructions, install button',
 						} ) }

--- a/client/jetpack-connect/example-components/jetpack-install.jsx
+++ b/client/jetpack-connect/example-components/jetpack-install.jsx
@@ -5,12 +5,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import FormTextInput from 'components/forms/form-text-input';
-import { localize } from 'i18n-calypso';
 
 const JetpackConnectExampleInstall = ( { url, translate, onClick } ) => {
 	return (


### PR DESCRIPTION
This PR performs a couple of small cleanups on the JPC instructions step example components:

* Using shorthand for truthy boolean props vs passing a string (`disabled` instead of `disabled="true"`)
* Moving external imports to the actual external imports section (`i18n-calypso`)

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/jetpack/connect/instructions?url=yourgroovydomain.com where `yourgroovydomain.com` is a WP.org site with Jetpack not installed or not activated.
* Verify there are no visual or behavioral changes.
* Verify the inputs in all example components are still disabled.
* Verify all `aria-hidden` attributes there are still `true` when looking at the dev tools inspector.