### PR TITLE
Site settings: hide masterbar toggle for Atomic sites

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -70,10 +70,9 @@ class SiteSettingsFormWriting extends Component {
 			handleAutosavingToggle,
 			handleAutosavingRadio,
 			handleSubmitForm,
-			isAtomicSite,
+			isMasterbarSectionVisible,
 			isRequestingSettings,
 			isSavingSettings,
-			jetpackMasterbarSupported,
 			jetpackSettingsUISupported,
 			onChangeField,
 			setFieldValue,
@@ -92,17 +91,15 @@ class SiteSettingsFormWriting extends Component {
 				onSubmit={ handleSubmitForm }
 				className="site-settings__general-settings"
 			>
-				{ siteIsJetpack &&
-					jetpackMasterbarSupported &&
-					! isAtomicSite && (
-						<div>
-							{ this.renderSectionHeader( translate( 'WordPress.com toolbar' ), false ) }
-							<Masterbar
-								isSavingSettings={ isSavingSettings }
-								isRequestingSettings={ isRequestingSettings }
-							/>
-						</div>
-					) }
+				{ isMasterbarSectionVisible && (
+					<div>
+						{ this.renderSectionHeader( translate( 'WordPress.com toolbar' ), false ) }
+						<Masterbar
+							isSavingSettings={ isSavingSettings }
+							isRequestingSettings={ isRequestingSettings }
+						/>
+					</div>
+				) }
 
 				{ config.isEnabled( 'manage/site-settings/categories' ) && (
 					<div className="site-settings__taxonomies">
@@ -221,14 +218,18 @@ class SiteSettingsFormWriting extends Component {
 const connectComponent = connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
+		const siteIsJetpack = isJetpackSite( state, siteId );
 
 		return {
 			jetpackSettingsUISupported: siteSupportsJetpackSettingsUi( state, siteId ),
-			jetpackMasterbarSupported: isJetpackMinimumVersion( state, siteId, '4.8' ),
-			siteIsJetpack: isJetpackSite( state, siteId ),
+			siteIsJetpack,
 			siteId,
 			jetpackVersionSupportsLazyImages: isJetpackMinimumVersion( state, siteId, '5.8-alpha' ),
-			isAtomicSite: isSiteAutomatedTransfer( state, siteId ),
+			isMasterbarSectionVisible:
+				siteIsJetpack &&
+				isJetpackMinimumVersion( state, siteId, '4.8' ) &&
+				// Masterbar can't be turned off on Atomic sites - don't show the toggle in that case
+				! isSiteAutomatedTransfer( state, siteId ),
 		};
 	},
 	{ requestPostTypes },

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -27,6 +27,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestPostTypes } from 'state/post-types/actions';
 import Composing from './composing';
 import CustomContentTypes from './custom-content-types';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import FeedSettings from 'my-sites/site-settings/feed-settings';
 import PodcastingLink from 'my-sites/site-settings/podcasting-details/link';
 import Masterbar from './masterbar';
@@ -69,6 +70,7 @@ class SiteSettingsFormWriting extends Component {
 			handleAutosavingToggle,
 			handleAutosavingRadio,
 			handleSubmitForm,
+			isAtomicSite,
 			isRequestingSettings,
 			isSavingSettings,
 			jetpackMasterbarSupported,
@@ -91,7 +93,8 @@ class SiteSettingsFormWriting extends Component {
 				className="site-settings__general-settings"
 			>
 				{ siteIsJetpack &&
-					jetpackMasterbarSupported && (
+					jetpackMasterbarSupported &&
+					! isAtomicSite && (
 						<div>
 							{ this.renderSectionHeader( translate( 'WordPress.com toolbar' ), false ) }
 							<Masterbar
@@ -225,6 +228,7 @@ const connectComponent = connect(
 			siteIsJetpack: isJetpackSite( state, siteId ),
 			siteId,
 			jetpackVersionSupportsLazyImages: isJetpackMinimumVersion( state, siteId, '5.8-alpha' ),
+			isAtomicSite: isSiteAutomatedTransfer( state, siteId ),
 		};
 	},
 	{ requestPostTypes },


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/25116

This setting is forced for Atomic sites by design via `wpcomsh`. Let's remove the toggle in that case to make it less confusing.

### Testing instructions

1. Navigate to `settings/writing/{site}` for Atomic site.
2. Verify that `WordPress.com toolbar` section is no longer shown.
3. Verify that the section is visible for regular Jetpack sites.