### PR TITLE
Billing-History: Prevent groupDomainProducts from mutating raw_amount

### DIFF
--- a/client/me/billing-history/test/utils.js
+++ b/client/me/billing-history/test/utils.js
@@ -1,0 +1,234 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { groupDomainProducts } from '../utils';
+
+const ident = x => x;
+
+describe( 'utils', () => {
+	describe( '#groupDomainProducts()', () => {
+		test( 'should return non-domain items unchanged', () => {
+			const items = deepFreeze( [ { foo: 'bar', product_slug: 'foobar' } ] );
+			const result = groupDomainProducts( items, ident );
+			expect( result ).to.eql( items );
+		} );
+
+		test( 'should return a domain item with a groupCount and hasPrivateRegistration added if there is only one', () => {
+			const items = deepFreeze( [
+				{ foo: 'bar', product_slug: 'foobar' },
+				{ product_slug: 'wp-domains', domain: 'foo.com', variation_slug: 'none' },
+			] );
+			const expected = [
+				{ foo: 'bar', product_slug: 'foobar' },
+				{
+					product_slug: 'wp-domains',
+					variation_slug: 'none',
+					domain: 'foo.com',
+					groupCount: 1,
+					hasPrivateRegistration: 0,
+				},
+			];
+			const result = groupDomainProducts( items, ident );
+			expect( result ).to.eql( expected );
+		} );
+
+		test( 'should return a domain item with hasPrivateRegistration true if the variation_slug has a private slug', () => {
+			const items = deepFreeze( [
+				{ foo: 'bar', product_slug: 'foobar' },
+				{
+					product_slug: 'wp-domains',
+					domain: 'foo.com',
+					variation_slug: 'wp-private-registration',
+				},
+			] );
+			const result = groupDomainProducts( items, ident );
+			expect( result[ 1 ].hasPrivateRegistration ).to.eql( 1 );
+		} );
+
+		test( 'should not group domain items with different domains', () => {
+			const items = deepFreeze( [
+				{ foo: 'bar', product_slug: 'foobar' },
+				{
+					id: '2',
+					product_slug: 'wp-domains',
+					domain: 'foo.com',
+					variation_slug: 'wp-private-registration',
+				},
+				{
+					id: '3',
+					product_slug: 'wp-domains',
+					domain: 'bar.com',
+					variation_slug: 'wp-private-registration',
+				},
+			] );
+			const expected = [
+				{ foo: 'bar', product_slug: 'foobar' },
+				{
+					id: '2',
+					product_slug: 'wp-domains',
+					variation_slug: 'wp-private-registration',
+					domain: 'foo.com',
+					groupCount: 1,
+					hasPrivateRegistration: 1,
+				},
+				{
+					id: '3',
+					product_slug: 'wp-domains',
+					variation_slug: 'wp-private-registration',
+					domain: 'bar.com',
+					groupCount: 1,
+					hasPrivateRegistration: 1,
+				},
+			];
+			const result = groupDomainProducts( items, ident );
+			expect( result ).to.eql( expected );
+			expect( result.length ).to.eql( 3 );
+		} );
+
+		test( 'should only return one domain item of multiple with the same domain', () => {
+			const items = deepFreeze( [
+				{ foo: 'bar', product_slug: 'foobar' },
+				{
+					id: '2',
+					product_slug: 'wp-domains',
+					domain: 'foo.com',
+					variation_slug: 'wp-private-registration',
+				},
+				{
+					id: '3',
+					product_slug: 'wp-domains',
+					domain: 'foo.com',
+					variation_slug: 'wp-private-registration',
+				},
+			] );
+			const result = groupDomainProducts( items, ident );
+			expect( result.length ).to.eql( 2 );
+		} );
+
+		test( 'should increment groupCount for multiple items with the same domain', () => {
+			const items = deepFreeze( [
+				{ foo: 'bar', product_slug: 'foobar' },
+				{
+					id: '2',
+					product_slug: 'wp-domains',
+					domain: 'foo.com',
+					variation_slug: 'wp-private-registration',
+				},
+				{
+					id: '3',
+					product_slug: 'wp-domains',
+					domain: 'foo.com',
+					variation_slug: 'wp-private-registration',
+				},
+			] );
+			const result = groupDomainProducts( items, ident );
+			expect( result[ 1 ].groupCount ).to.eql( 2 );
+		} );
+
+		test( 'should set hasPrivateRegistration to a union of multiple items with the same domain', () => {
+			const items = deepFreeze( [
+				{ foo: 'bar', product_slug: 'foobar' },
+				{
+					id: '2',
+					product_slug: 'wp-domains',
+					domain: 'foo.com',
+					variation_slug: 'none',
+				},
+				{
+					id: '3',
+					product_slug: 'wp-domains',
+					domain: 'foo.com',
+					variation_slug: 'wp-private-registration',
+				},
+			] );
+			const result = groupDomainProducts( items, ident );
+			expect( result[ 1 ].hasPrivateRegistration ).to.eql( 1 );
+		} );
+
+		test( 'should sum the raw_amount for multiple items with the same domain', () => {
+			const items = deepFreeze( [
+				{ foo: 'bar', product_slug: 'foobar' },
+				{
+					id: '1',
+					product_slug: 'wp-domains',
+					domain: 'bar.com',
+					variation_slug: 'none',
+					raw_amount: 2,
+				},
+				{
+					id: '2',
+					product_slug: 'wp-domains',
+					domain: 'foo.com',
+					variation_slug: 'none',
+					raw_amount: 3,
+				},
+				{
+					id: '3',
+					product_slug: 'wp-domains',
+					domain: 'foo.com',
+					variation_slug: 'wp-private-registration',
+					raw_amount: 7,
+				},
+				{
+					id: '4',
+					product_slug: 'wp-domains',
+					domain: 'foo.com',
+					variation_slug: 'wp-private-registration',
+					raw_amount: 9,
+				},
+			] );
+			const result = groupDomainProducts( items, ident );
+			expect( result[ 1 ].raw_amount ).to.eql( 2 );
+			expect( result[ 2 ].raw_amount ).to.eql( 19 );
+		} );
+
+		test( 'should include the formatted, summed raw_amount as amount for multiple items with teh same domain', () => {
+			const items = deepFreeze( [
+				{ foo: 'bar', product_slug: 'foobar' },
+				{
+					id: '1',
+					product_slug: 'wp-domains',
+					domain: 'bar.com',
+					variation_slug: 'none',
+					amount: '$2.00',
+					raw_amount: 2,
+				},
+				{
+					id: '2',
+					product_slug: 'wp-domains',
+					domain: 'foo.com',
+					variation_slug: 'none',
+					amount: '$3.00',
+					raw_amount: 3,
+				},
+				{
+					id: '3',
+					product_slug: 'wp-domains',
+					domain: 'foo.com',
+					variation_slug: 'wp-private-registration',
+					amount: '$7.00',
+					raw_amount: 7,
+				},
+				{
+					id: '4',
+					product_slug: 'wp-domains',
+					domain: 'foo.com',
+					variation_slug: 'wp-private-registration',
+					amount: '$9.00',
+					raw_amount: 9,
+				},
+			] );
+			const result = groupDomainProducts( items, ident );
+			expect( result[ 1 ].amount ).to.eql( '$2.00' );
+			expect( result[ 2 ].amount ).to.eql( '$19.00' );
+		} );
+	} );
+} );

--- a/client/me/billing-history/utils.js
+++ b/client/me/billing-history/utils.js
@@ -9,7 +9,10 @@ import { find, map, partition, reduce } from 'lodash';
  */
 import formatCurrency from 'lib/format-currency';
 
-export const groupDomainProducts = ( transactionItems, translate ) => {
+export const groupDomainProducts = ( originalItems, translate ) => {
+	const transactionItems = Object.keys( originalItems ).map( key => {
+		return Object.assign( {}, originalItems[ key ] );
+	} );
 	const [ domainProducts, otherProducts ] = partition( transactionItems, {
 		product_slug: 'wp-domains',
 	} );


### PR DESCRIPTION
When viewing a receipt under Me > Manage Purchases > Billing History (tab) > View Receipt (link below a purchase), the prices of individual items are calculated by grouping domain products together and summing their `raw_amount` properties into one by the function `groupDomainProducts()`. That function, however, does not operate on a copy of the data; it actually changes the `raw_amount` (and other properties) of the purchased items.

When the calculation is performed multiple times in a row, the total for each domain item increases beyond the real total because the first item in the list has the last total, instead of its actual value.

![price-bug-before](https://user-images.githubusercontent.com/2036909/40745283-091ed8f0-6425-11e8-9cdd-6f2ed4c24819.png)


This change makes copies of all the receipt items before modifying them. It also adds tests to verify the operation of the function.

The bug was introduced with the function in #23055

More information: p4jECJ-1aG-p2

### Testing instructions 

Theoretically it should be possible to simulate this by viewing a receipt which has grouped domain items. I just haven't been able to simulate that outside of production.

In any case, I think this is a good idea technically and if it fixes the bug then 👍 