### PR TITLE
Settings: Fix clearing the podcasting cover image

### DIFF
--- a/client/lib/track-form/index.jsx
+++ b/client/lib/track-form/index.jsx
@@ -3,9 +3,11 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import { union } from 'lodash';
+import debugFactory from 'debug';
+
+const debug = debugFactory( 'calypso:track-form' );
 
 export const trackForm = WrappedComponent =>
 	class TrackFormComponent extends Component {
@@ -22,11 +24,13 @@ export const trackForm = WrappedComponent =>
 					...fields,
 				},
 			};
+			debug( 'updateFields', { fields, newState } );
 
 			this.setState( newState, callback );
 		};
 
 		replaceFields = ( fields, callback, keepPrevFields = true ) => {
+			debug( 'replaceFields', { fields, keepPrevFields } );
 			const prevFields = keepPrevFields ? this.state.fields : {};
 			const newFields = {
 				...prevFields,
@@ -37,6 +41,7 @@ export const trackForm = WrappedComponent =>
 		};
 
 		clearDirtyFields = () => {
+			debug( 'clearDirtyFields' );
 			this.setState( {
 				dirtyFields: [],
 			} );

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -265,14 +265,20 @@ class PodcastingDetails extends Component {
 	};
 
 	onCoverImageRemoved = () => {
-		this.setFieldForcingString( 'podcasting_image_id' )( 0 );
-		// When we remove the image, we want to clear the legacy value as well.
-		this.setFieldForcingString( 'podcasting_image' )( '' );
+		// Do not call setFieldForcingString / onChangeField multiple times in
+		// the same render cycle - this breaks dirty detection in
+		// wrapSettingsForm.
+		this.props.updateFields( {
+			podcasting_image_id: '0',
+			podcasting_image: '',
+		} );
 	};
 
 	onCoverImageSelected = ( coverId, coverUrl ) => {
-		this.setFieldForcingString( 'podcasting_image_id' )( coverId );
-		this.setFieldForcingString( 'podcasting_image' )( coverUrl );
+		this.props.updateFields( {
+			podcasting_image_id: String( coverId ),
+			podcasting_image: coverUrl,
+		} );
 	};
 
 	setFieldForcingString = field => value => {

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -251,6 +251,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				setFieldValue: this.setFieldValue,
 				submitForm: this.submitForm,
 				uniqueEventTracker: this.uniqueEventTracker,
+				updateFields: this.props.updateFields,
 			};
 
 			return (

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -3,12 +3,12 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { flowRight, isEqual, keys, omit, pick, isNaN } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -38,6 +38,8 @@ import {
 } from 'state/sites/selectors';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import QueryJetpackSettings from 'components/data/query-jetpack-settings';
+
+const debug = debugFactory( 'calypso:site-settings' );
 
 const wrapSettingsForm = getFormSettings => SettingsForm => {
 	class WrappedSettingsForm extends Component {
@@ -155,6 +157,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				jetpackSettingsUISupported,
 			} = this.props;
 			this.props.removeNotice( 'site-settings-save' );
+			debug( 'submitForm', { fields, settingsFields } );
 
 			// Support site settings for older Jetpacks as needed
 			const siteFields = pick( fields, settingsFields.site );
@@ -205,12 +208,15 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 		};
 
 		onChangeField = field => event => {
+			const value = event.target.value;
+			debug( 'onChangeField', { field, value } );
 			this.props.updateFields( {
-				[ field ]: event.target.value,
+				[ field ]: value,
 			} );
 		};
 
 		setFieldValue = ( field, value, autosave = false ) => {
+			debug( 'setFieldValue', { field, value } );
 			this.props.updateFields(
 				{
 					[ field ]: value,


### PR DESCRIPTION
This PR addresses an issue where clearing the podcasting cover image appeared to work from within Calypso, but the change was not correctly persisted to the REST API.

This is because we were calling `onChangeField` multiple times in the same render cycle, which breaks the settings form dirty detection [here](https://github.com/Automattic/wp-calypso/blob/2d3ad83a/client/my-sites/site-settings/wrap-settings-form.jsx#L90) and causes the first settings update not to be persisted correctly.

I added some `debug` statements to track down this issue.  I think we should leave them in place to help with similar issues in the future, because the settings form code is far from straightforward.

### To test

Test setting and clearing the podcasting category image and verify that the intended changes are sent to the `settings` API endpoint and carry through to the podcasting category feed.