### PR TITLE
Fixes incorrect animation when adding/removing categories/tags

### DIFF
--- a/client/components/accordion/style.scss
+++ b/client/components/accordion/style.scss
@@ -25,7 +25,6 @@ $accordion-background-expanded: $white;
 	color: $gray-dark;
 	background-color: $accordion-background-collapsed;
 	text-align: left;
-	transition: all 150ms ease-in;
 
 	&:hover {
 		background-color: $accordion-background-hover;


### PR DESCRIPTION
Fixes #24577 
This removes the animation entirely - and I confirmed the animation/jump no longer occurs.