### PR TITLE
Domains: Revert prevention of prefilling WHOIS info for Tucows.

### DIFF
--- a/client/my-sites/domains/domain-management/edit-contact-info/index.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/index.jsx
@@ -68,19 +68,15 @@ class EditContactInfo extends React.Component {
 			return <PendingWhoisUpdateCard />;
 		}
 
-		const isTucowsDomain = includes( [ OPENHRS, OPENSRS ], domain.registrar );
-		if ( ! isTucowsDomain && domain.privateDomain ) {
+		if ( ! includes( [ OPENHRS, OPENSRS ], domain.registrar ) && domain.privateDomain ) {
 			return <EditContactInfoPrivacyEnabledCard />;
 		}
-
-		// Empty state while Tucows figures out their stuff...
-		const contactInformation = isTucowsDomain ? {} : findRegistrantWhois( this.props.whois.data );
 
 		return (
 			<div>
 				<SectionHeader label={ this.props.translate( 'Edit Contact Info' ) } />
 				<EditContactInfoFormCard
-					contactInformation={ contactInformation }
+					contactInformation={ findRegistrantWhois( this.props.whois.data ) }
 					selectedDomain={ getSelectedDomain( this.props ) }
 					selectedSite={ this.props.selectedSite }
 				/>


### PR DESCRIPTION
This PR reverts #25089.

Due to GDPR-related changes, the information we were receiving from Tucows APIs was masked. So we needed to kill the pre-fill for Tucows domains.

Testing
Go to a custom domain in Domain Management, verify that for Tucows domains the WHOIS form is correctly pre-filled.
