### PR TITLE
Don't show problematic links when in the domain connect authorize flow.

### DIFF
--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -40,10 +40,6 @@ class MasterbarLoggedOut extends PureComponent {
 		title: '',
 	};
 
-	getRedirectToFromCurrentQuery() {
-		return get( this.props.currentQuery, 'redirect_to', '' );
-	}
-
 	renderLoginItem() {
 		const { currentQuery, currentRoute, sectionName, translate, redirectUri } = this.props;
 

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -22,6 +22,7 @@ import { addQueryArgs } from 'lib/route';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'state/selectors/get-current-route';
 import { login } from 'lib/paths';
+import { isDomainConnectAuthorizePath } from 'lib/domains/utils';
 
 class MasterbarLoggedOut extends PureComponent {
 	static propTypes = {
@@ -38,6 +39,10 @@ class MasterbarLoggedOut extends PureComponent {
 		sectionName: '',
 		title: '',
 	};
+
+	getRedirectToFromCurrentQuery() {
+		return get( this.props.currentQuery, 'redirect_to', '' );
+	}
 
 	renderLoginItem() {
 		const { currentQuery, currentRoute, sectionName, translate, redirectUri } = this.props;
@@ -107,7 +112,7 @@ class MasterbarLoggedOut extends PureComponent {
 		 * by a service provider to authorize a Domain Connect template application.
 		 */
 		const redirectTo = get( currentQuery, 'redirect_to', '' );
-		if ( startsWith( redirectTo, '/domain-connect/authorize/' ) ) {
+		if ( isDomainConnectAuthorizePath( redirectTo ) ) {
 			return null;
 		}
 

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -102,6 +102,15 @@ class MasterbarLoggedOut extends PureComponent {
 			return null;
 		}
 
+		/**
+		 * Hide signup from the screen when we have been sent to the login page from a redirect
+		 * by a service provider to authorize a Domain Connect template application.
+		 */
+		const redirectTo = get( currentQuery, 'redirect_to', '' );
+		if ( startsWith( redirectTo, '/domain-connect/authorize/' ) ) {
+			return null;
+		}
+
 		let signupUrl = config( 'signup_url' );
 		const signupFlow = get( currentQuery, 'signup_flow' );
 		if (

--- a/client/lib/domains/utils.js
+++ b/client/lib/domains/utils.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { drop, isEmpty, join, find, split, values } from 'lodash';
+import { drop, isEmpty, join, find, split, startsWith, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -104,6 +104,10 @@ function getDomainNameFromReceiptOrCart( receipt, cart ) {
 	return null;
 }
 
+function isDomainConnectAuthorizePath( path ) {
+	return startsWith( path, '/domain-connect/authorize/' );
+}
+
 function parseDomainAgainstTldList( domainFragment, tldList ) {
 	if ( ! domainFragment ) {
 		return '';
@@ -124,5 +128,6 @@ export {
 	getDomainType,
 	getGdprConsentStatus,
 	getTransferStatus,
+	isDomainConnectAuthorizePath,
 	parseDomainAgainstTldList,
 };

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -8,7 +8,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
+import { get, startsWith } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { parse as parseUrl } from 'url';
 
@@ -69,11 +69,18 @@ export class LoginLinks extends React.Component {
 	};
 
 	renderBackLink() {
-		// If we seem to be in a Jetpack connection flow, provide some special handling
-		// so users can go back to their site rather than WordPress.com
 		const redirectTo = get( this.props, [ 'query', 'redirect_to' ] );
 		if ( redirectTo ) {
 			const { pathname, query: redirectToQuery } = parseUrl( redirectTo, true );
+
+			// If we are in a Domain Connect authorization flow, don't show the back link
+			// since this page was loaded by a redirect from a third party service provider.
+			if ( startsWith( pathname, '/domain-connect/authorize/' ) ) {
+				return null;
+			}
+
+			// If we seem to be in a Jetpack connection flow, provide some special handling
+			// so users can go back to their site rather than WordPress.com
 			if ( pathname === '/jetpack/connect/authorize' && redirectToQuery.client_id ) {
 				const returnToSiteUrl = addQueryArgs(
 					{ client_id: redirectToQuery.client_id },

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -8,7 +8,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { get, startsWith } from 'lodash';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { parse as parseUrl } from 'url';
 
@@ -25,6 +25,7 @@ import { isEnabled } from 'config';
 import { login } from 'lib/paths';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { resetMagicLoginRequestForm } from 'state/login/magic-login/actions';
+import { isDomainConnectAuthorizePath } from 'lib/domains/utils';
 
 export class LoginLinks extends React.Component {
 	static propTypes = {
@@ -75,7 +76,7 @@ export class LoginLinks extends React.Component {
 
 			// If we are in a Domain Connect authorization flow, don't show the back link
 			// since this page was loaded by a redirect from a third party service provider.
-			if ( startsWith( pathname, '/domain-connect/authorize/' ) ) {
+			if ( isDomainConnectAuthorizePath( redirectTo ) ) {
 				return null;
 			}
 


### PR DESCRIPTION
When a user is redirected to the login page because a service provider is directing a user to the domain connect template authorization flow, we shouldn't show the "sign up" or "back to WordPress.com" links on the login page. The service provider would only have directed a user to this flow if they were already a WordPress.com user, so there is no need for the "sign up" link and clicking on the "back to WordPress.com" link would interrupt the flow and prevent the template from being applied without returning an error or success to the service provider.

To test this, use the link provided in p99Zz8-ih-p2 from an incognito browser window. You should not see the "sign up" link in the top right of the master bar or the "back to WordPress" link below the "Lost your password?" link.