### PR TITLE
My Plan: Fix Ads removed button for business plan sites

### DIFF
--- a/client/blocks/product-purchase-features-list/advertising-removed.jsx
+++ b/client/blocks/product-purchase-features-list/advertising-removed.jsx
@@ -26,8 +26,8 @@ export default localize( ( { isBusinessPlan, selectedSite, translate } ) => {
 									'to remove the WordPress.com footer credit.'
 							)
 				}
-				buttonText={ ! isBusinessPlan && translate( 'Upgrade to Business' ) }
-				href={ ! isBusinessPlan && '/checkout/' + selectedSite.slug + '/business' }
+				buttonText={ ! isBusinessPlan ? translate( 'Upgrade to Business' ) : null }
+				href={ ! isBusinessPlan ? '/checkout/' + selectedSite.slug + '/business' : null }
 			/>
 		</div>
 	);


### PR DESCRIPTION
This PR fixes a couple of React warnings that are thrown in the My Plan page for .com sites that are on the Business plan:

![](https://cldup.com/cbv6CSbZyx.png)

This happens because we try to render a `false` for the button href and copy in the "Advertising Removed" feature when on a Business plan.

To test:
* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/my-plan/:site where :site is one of your .com sites with a Business plan.
* Verify the button is not displayed and you don't see any React warnings.
* Switch to a site with a Premium plan and verify the button is there and you still don't see any React warnings.