### PR TITLE
Upgrade webpack dev and hot middleware

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -19726,7 +19726,7 @@
         "mkdirp": "0.5.1",
         "p-each-series": "1.0.0",
         "p-lazy": "1.0.0",
-        "prettier": "1.13.3",
+        "prettier": "1.13.4",
         "recast": "0.13.2",
         "resolve-cwd": "2.0.0",
         "supports-color": "4.5.0",
@@ -19879,8 +19879,8 @@
           }
         },
         "prettier": {
-          "version": "1.13.3",
-          "integrity": "sha512-CIWJNU+cFFdeA0GJSzzFkxiq2WuMvWZMlz6cV/EXhPlRnI3esSFMh+lNmyZ8z/X8O8C1U60Sc8puXALj4/WmZw=="
+          "version": "1.13.4",
+          "integrity": "sha512-emsEZ2bAigL1lq6ssgkpPm1MIBqgeTvcp90NxOP5XDqprub/V/WS2Hfgih3mS7/1dqTUvhG+sxx1Dv8crnVexA=="
         },
         "read-pkg": {
           "version": "2.0.0",
@@ -19998,8 +19998,8 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "3.1.2",
-      "integrity": "sha512-Z11Zp3GTvCe6mGbbtma+lMB9xRfJcNtupXfmvFBujyXqLNms6onDnSi9f/Cb2rw6KkD5kgibOfxhN7npZwTiGA==",
+      "version": "3.1.3",
+      "integrity": "sha512-I6Mmy/QjWU/kXwCSFGaiOoL5YEQIVmbb0o45xMoCyQAg/mClqZVTcsX327sPfekDyJWpCxb+04whNyLOIxpJdQ==",
       "requires": {
         "loud-rejection": "1.6.0",
         "memory-fs": "0.4.1",
@@ -20234,8 +20234,8 @@
       }
     },
     "webpack-hot-middleware": {
-      "version": "2.22.0",
-      "integrity": "sha512-kmjTZ6WXZowuBfTk1/H/scmyp09eHwPpqF2mHRZ9WMCBlQ61NSkqZ25azPlPOeCIhva57PGrUyeTIW5X8Q7HEw==",
+      "version": "2.22.2",
+      "integrity": "sha512-uccPS6b/UlXJoNCS+3fuc40z2KZgO0qQhnu+Ne1iZiHTy9s5fMCJAV+Vc8VTVkN203UphsxQmkumxYeHLiQ5jg==",
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "walk": "2.3.4",
     "webpack": "4.10.2",
     "webpack-cli": "2.0.9",
-    "webpack-dev-middleware": "3.1.2",
+    "webpack-dev-middleware": "3.1.3",
     "wpcom": "5.4.1",
     "wpcom-oauth": "0.3.3",
     "wpcom-proxy-request": "5.0.0",
@@ -290,7 +290,7 @@
     "supertest": "2.0.0",
     "terminal-kit": "1.13.13",
     "webpack-bundle-analyzer": "2.11.1",
-    "webpack-hot-middleware": "2.22.0"
+    "webpack-hot-middleware": "2.22.2"
   },
   "optionalDependencies": {
     "fsevents": "1.1.3"


### PR DESCRIPTION
Just bugfix releases for both packages. To test, spin up calypso and make sure the dev environment behaves as usual. Changes made should cause an incremental recompile and the badge in the dev environment should reflect the current status (rebuilding -> needs reload)