### PR TITLE
Signup: fix site/domain text to be consistent

### DIFF
--- a/client/components/domains/example-domain-suggestions/index.jsx
+++ b/client/components/domains/example-domain-suggestions/index.jsx
@@ -30,7 +30,7 @@ class DomainSuggestionsExample extends React.Component {
 			<div className="example-domain-suggestions">
 				<p className="example-domain-suggestions__explanation">
 					{ translate(
-						'A domain name is what people type into their browser to visit your site.'
+						'A domain name is the site address people type into their browser to visit your site.'
 					) }
 				</p>
 				{ showDomainOption && (

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -328,7 +328,7 @@ class DomainsStep extends React.Component {
 			? getStepUrl( this.props.flowName, this.props.stepName, undefined, getLocaleSlug() )
 			: undefined;
 		let fallbackSubHeaderText = translate(
-			"Enter your site's name, or some key words that describe it - " +
+			"Enter your site's name, or some keywords that describe it - " +
 				"we'll use this to create your new site's address."
 		);
 


### PR DESCRIPTION
Fixes #22469

**Before:**

<img width="748" alt="screen shot 2018-06-01 at 10 03 56 am" src="https://user-images.githubusercontent.com/128826/40814362-23a92f40-6583-11e8-9a68-d62b29a6a3c0.png">

**After:**

<img width="748" alt="screen shot 2018-06-01 at 10 03 36 am" src="https://user-images.githubusercontent.com/128826/40814369-2c8ce912-6583-11e8-9a7c-77a95590397c.png">

**Testing Instructions**

1. Visit the domains page on signup and ensure text looks okay