### PR TITLE
Account closure: add email address reuse warning

### DIFF
--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -112,6 +112,11 @@ class AccountSettingsClose extends Component {
 									</p>
 									<p className="account-close__body-copy">
 										{ translate(
+											'You will also be unable to open a new WordPress.com account with the same email address for 30 days.'
+										) }
+									</p>
+									<p className="account-close__body-copy">
+										{ translate(
 											"To close your account, you'll need to {{a}}contact our support team{{/a}}.",
 											{
 												components: {
@@ -147,6 +152,11 @@ class AccountSettingsClose extends Component {
 								<p className="account-close__body-copy">
 									{ translate(
 										'Account closure cannot be undone and will remove all sites and content.'
+									) }
+								</p>
+								<p className="account-close__body-copy">
+									{ translate(
+										'You will also be unable to open a new WordPress.com account with the same email address for 30 days.'
 									) }
 								</p>
 								<p className="account-close__body-copy">

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -107,17 +107,17 @@ class AccountSettingsClose extends Component {
 								<Fragment>
 									<p className="account-close__body-copy">
 										{ translate(
-											'Account closure cannot be undone and will remove all sites and content.'
+											'Account closure cannot be undone. It will remove your account along with all your sites and all their content.'
 										) }
 									</p>
 									<p className="account-close__body-copy">
 										{ translate(
-											'You will also be unable to open a new WordPress.com account with the same email address for 30 days.'
+											'You will not be able to open a new WordPress.com account using the same email address for 30 days.'
 										) }
 									</p>
 									<p className="account-close__body-copy">
 										{ translate(
-											"To close your account, you'll need to {{a}}contact our support team{{/a}}.",
+											'To close this account now, {{a}}contact our support team{{/a}}.',
 											{
 												components: {
 													a: <ActionPanelLink href="/help/contact" />,
@@ -151,24 +151,28 @@ class AccountSettingsClose extends Component {
 							<Fragment>
 								<p className="account-close__body-copy">
 									{ translate(
-										'Account closure cannot be undone and will remove all sites and content.'
+										'Account closure cannot be undone. It will remove your account along with all your sites and all their content.'
 									) }
 								</p>
 								<p className="account-close__body-copy">
 									{ translate(
-										'You will also be unable to open a new WordPress.com account with the same email address for 30 days.'
+										'You will not be able to open a new WordPress.com account using the same email address for 30 days.'
 									) }
 								</p>
 								<p className="account-close__body-copy">
 									{ translate(
-										"If you're unsure about what account closure means or have any other questions, " +
-											'{{a}}chat with someone from our support team{{/a}} before going ahead.',
+										'If you have any questions at all about what happens when you close an account, ' +
+											'please {{a}}chat with someone from our support team{{/a}} first. ' +
+											"They'll explain the ramifications and help you explore alternatives. ",
 										{
 											components: {
 												a: <ActionPanelLink href="/help/contact" />,
 											},
 										}
 									) }
+								</p>
+								<p className="account-close__body-copy">
+									{ translate( 'When you\'re ready to proceed, use the "Close account" button.' ) }
 								</p>
 							</Fragment>
 						) }
@@ -177,18 +181,18 @@ class AccountSettingsClose extends Component {
 						{ ( isLoading || isDeletePossible ) && (
 							<Button scary onClick={ this.handleDeleteClick }>
 								<Gridicon icon="trash" />
-								{ translate( 'Close Account' ) }
+								{ translate( 'Close account' ) }
 							</Button>
 						) }
 						{ hasAtomicSites && (
 							<Button primary href="/help/contact">
-								{ translate( 'Contact Support' ) }
+								{ translate( 'Contact support' ) }
 							</Button>
 						) }
 						{ hasPurchases &&
 							! hasAtomicSites && (
 								<Button primary href="/me/purchases">
-									{ translate( 'Manage Purchases' ) }
+									{ translate( 'Manage purchases' ) }
 								</Button>
 							) }
 					</ActionPanelFooter>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/25202.

Adds a sentence about email reuse after account closure. Discussed in p2-p9SXHV-2w.

For users with Atomic sites:

<img width="752" alt="screen shot 2018-06-01 at 13 25 42" src="https://user-images.githubusercontent.com/17325/40816225-cb6def1a-659f-11e8-8bd2-87ac6b1d990d.png">

For users without Atomic sites or active purchases:

<img width="749" alt="screen shot 2018-06-01 at 13 26 12" src="https://user-images.githubusercontent.com/17325/40816226-d4427d4a-659f-11e8-926b-817b20656b78.png">

### To test

Visit http://calypso.localhost:3000/me/account/close.