### PR TITLE
Language switcher: Adding a tracks record event

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -50,6 +50,7 @@ import _user from 'lib/user';
 import { canDisplayCommunityTranslator } from 'components/community-translator/utils';
 import { ENABLE_TRANSLATOR_KEY } from 'components/community-translator/constants';
 import AccountSettingsCloseLink from './close-link';
+import { requestGeoLocation } from 'state/data-getters';
 
 const user = _user();
 const colorSchemeKey = 'calypso_preferences.colorScheme';
@@ -90,6 +91,10 @@ const Account = createReactClass( {
 		return this.props.userSettings.getSetting( settingName );
 	},
 
+	getUserOriginalSetting( settingName ) {
+		return this.props.userSettings.getOriginalSetting( settingName );
+	},
+
 	updateUserSetting( settingName, value ) {
 		this.props.userSettings.updateSetting( settingName, value );
 	},
@@ -111,11 +116,12 @@ const Account = createReactClass( {
 
 	updateLanguage( event ) {
 		const { value } = event.target;
-		const originalLanguage = this.props.userSettings.getOriginalSetting( 'language' );
-		const originalLocaleVariant = this.props.userSettings.getOriginalSetting( 'locale_variant' );
 		this.updateUserSetting( 'language', value );
 		const redirect =
-			value !== originalLanguage || value !== originalLocaleVariant ? '/me/account' : false;
+			value !== this.getUserOriginalSetting( 'language' ) ||
+			value !== this.getUserOriginalSetting( 'locale_variant' )
+				? '/me/account'
+				: false;
 		// store any selected locale variant so we can test it against those with no GP translation sets
 		const localeVariantSelected = isLocaleVariant( value ) ? value : '';
 		this.setState( { redirect, localeVariantSelected } );
@@ -278,6 +284,16 @@ const Account = createReactClass( {
 		if ( has( unsavedSettings, colorSchemeKey ) ) {
 			this.props.recordTracksEvent( 'calypso_color_schemes_save', {
 				color_scheme: get( unsavedSettings, colorSchemeKey ),
+			} );
+		}
+
+		if ( has( unsavedSettings, 'language' ) ) {
+			this.props.recordTracksEvent( 'calypso_user_language_switch', {
+				new_language: this.getUserSetting( 'language' ),
+				previous_language:
+					this.getUserOriginalSetting( 'locale_variant' ) ||
+					this.getUserOriginalSetting( 'language' ),
+				country_code: this.props.countryCode,
 			} );
 		}
 	},
@@ -799,6 +815,7 @@ export default compose(
 	connect(
 		state => ( {
 			requestingMissingSites: isRequestingMissingSites( state ),
+			countryCode: requestGeoLocation().data,
 		} ),
 		{ errorNotice, recordGoogleEvent, recordTracksEvent, successNotice }
 	),


### PR DESCRIPTION
This is a temporary (2-6 months) tracks event record Language Switcher usage.

## Why?

We'd like to know, not only the frequency at which users switch between languages, but also their preferences in terms of locale variants and location.

Hopefully we'll garner some meaningful data on whether our language groupings make sense, and if locale variants are used at all.

## Testing
Using Chrome's dev tools, select the Sources tab, and create a breakpoint in `app:///./client/state/analytics/middleware.js` to track calls to `analytics.tracks.recordEvent` 

<img width="1363" alt="screen shot 2018-06-01 at 1 09 39 pm" src="https://user-images.githubusercontent.com/6458278/40818983-4f9e7974-659d-11e8-8c08-bc11be547929.png">

Check to see if the properties are present, for example:
```
country_code : "AU"
new_language : "es"
previous_language : "de"
```
