### PR TITLE
Lint fixes: client/state/reader

### DIFF
--- a/client/state/reader/follows/actions.js
+++ b/client/state/reader/follows/actions.js
@@ -73,7 +73,7 @@ export function unfollow( feedUrl ) {
  * when following a URL.
  *
  * @param  {String} feedUrl Feed URL
- * @param  {Object} response Error response (contains keys 'info' and 'subscribed')
+ * @param  {Object} error Error response (contains keys 'info' and 'subscribed')
  * @return {Object} Action
  */
 export function recordFollowError( feedUrl, error ) {

--- a/client/state/reader/posts/test/actions.js
+++ b/client/state/reader/posts/test/actions.js
@@ -58,6 +58,7 @@ describe( 'actions', () => {
 		} );
 
 		// TODO: move to analytics middleware so that this doesn't cascade out the need for mocking
+		// eslint-disable-next-line jest/no-disabled-tests
 		test.skip( 'should fire tracks events for posts with railcars', () => {
 			const posts = [
 				{

--- a/client/state/reader/related-posts/test/reducer.js
+++ b/client/state/reader/related-posts/test/reducer.js
@@ -92,7 +92,7 @@ describe( 'queuedRequests', () => {
 		} );
 	} );
 
-	test( 'request should set the flag', () => {
+	test( 'request failure should unset the flag', () => {
 		expect(
 			queuedRequests(
 				{},

--- a/client/state/reader/sites/schema.js
+++ b/client/state/reader/sites/schema.js
@@ -1,4 +1,8 @@
 /** @format */
+
+/**
+ * Internal dependencies
+ */
 import { sitesSchema } from 'state/sites/schema';
 
 // based on the normal site endpoint schema with a few extra properties


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/24504.

Address linting issues in client/state/reader.

No functional changes.