### PR TITLE
Purchases: Use explicit placeholders for routes

### DIFF
--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -89,7 +89,7 @@ export default function( router ) {
 	);
 
 	router(
-		paths.confirmCancelDomain(),
+		paths.confirmCancelDomain( ':site', ':purchaseId' ),
 		redirectLoggedOut,
 		sidebar,
 		siteSelection,

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -99,7 +99,7 @@ export default function( router ) {
 	);
 
 	router(
-		paths.addCardDetails(),
+		paths.addCardDetails( ':site', ':purchaseId' ),
 		redirectLoggedOut,
 		sidebar,
 		siteSelection,

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -41,7 +41,7 @@ export default function( router ) {
 	);
 
 	router(
-		paths.billingHistoryReceipt(),
+		paths.billingHistoryReceipt( ':receiptId' ),
 		redirectLoggedOut,
 		sidebar,
 		billingController.transaction,

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -79,7 +79,7 @@ export default function( router ) {
 	);
 
 	router(
-		paths.cancelPrivacyProtection(),
+		paths.cancelPrivacyProtection( ':site', ':purchaseId' ),
 		redirectLoggedOut,
 		sidebar,
 		siteSelection,

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -109,7 +109,7 @@ export default function( router ) {
 	);
 
 	router(
-		paths.editCardDetails(),
+		paths.editCardDetails( ':site', ':purchaseId', ':cardId' ),
 		redirectLoggedOut,
 		sidebar,
 		siteSelection,

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -69,7 +69,7 @@ export default function( router ) {
 	);
 
 	router(
-		paths.cancelPurchase(),
+		paths.cancelPurchase( ':site', ':purchaseId' ),
 		redirectLoggedOut,
 		sidebar,
 		siteSelection,

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -59,7 +59,7 @@ export default function( router ) {
 	);
 
 	router(
-		paths.managePurchase(),
+		paths.managePurchase( ':site', ':purchaseId' ),
 		redirectLoggedOut,
 		sidebar,
 		siteSelection,

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -33,6 +33,11 @@ export function confirmCancelDomain( siteName, purchaseId ) {
 }
 
 export function cancelPrivacyProtection( siteName, purchaseId ) {
+	if ( process.env.NODE_ENV !== 'production' ) {
+		if ( 'undefined' === typeof siteName || 'undefined' === typeof purchaseId ) {
+			throw new Error( 'siteName and purchaseId must be provided' );
+		}
+	}
 	return managePurchase( siteName, purchaseId ) + '/cancel-privacy-protection';
 }
 

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -15,7 +15,12 @@ export function billingHistoryReceipt( receiptId ) {
 	return billingHistory + `/${ receiptId }`;
 }
 
-export function managePurchase( siteName = ':site', purchaseId = ':purchaseId' ) {
+export function managePurchase( siteName, purchaseId ) {
+	if ( process.env.NODE_ENV !== 'production' ) {
+		if ( 'undefined' === typeof siteName || 'undefined' === typeof purchaseId ) {
+			throw new Error( 'siteName and purchaseId must be provided' );
+		}
+	}
 	return purchasesRoot + `/${ siteName }/${ purchaseId }`;
 }
 

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -55,6 +55,15 @@ export function addCardDetails( siteName, purchaseId ) {
 	return managePurchase( siteName, purchaseId ) + '/payment/add';
 }
 
-export function editCardDetails( siteName, purchaseId, cardId = ':cardId' ) {
+export function editCardDetails( siteName, purchaseId, cardId ) {
+	if ( process.env.NODE_ENV !== 'production' ) {
+		if (
+			'undefined' === typeof siteName ||
+			'undefined' === typeof purchaseId ||
+			'undefined' === typeof cardId
+		) {
+			throw new Error( 'siteName, purchaseId, and cardId must be provided' );
+		}
+	}
 	return managePurchase( siteName, purchaseId ) + `/payment/edit/${ cardId }`;
 }

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -29,6 +29,11 @@ export function cancelPurchase( siteName, purchaseId ) {
 }
 
 export function confirmCancelDomain( siteName, purchaseId ) {
+	if ( process.env.NODE_ENV !== 'production' ) {
+		if ( 'undefined' === typeof siteName || 'undefined' === typeof purchaseId ) {
+			throw new Error( 'siteName and purchaseId must be provided' );
+		}
+	}
 	return managePurchase( siteName, purchaseId ) + '/confirm-cancel-domain';
 }
 

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -6,7 +6,12 @@ export const addCreditCard = purchasesRoot + '/add-credit-card';
 
 export const billingHistory = purchasesRoot + '/billing';
 
-export function billingHistoryReceipt( receiptId = ':receiptId' ) {
+export function billingHistoryReceipt( receiptId ) {
+	if ( process.env.NODE_ENV !== 'production' ) {
+		if ( 'undefined' === typeof receiptId ) {
+			throw new Error( 'purchaseId must be provided' );
+		}
+	}
 	return billingHistory + `/${ receiptId }`;
 }
 

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -20,6 +20,11 @@ export function managePurchase( siteName = ':site', purchaseId = ':purchaseId' )
 }
 
 export function cancelPurchase( siteName, purchaseId ) {
+	if ( process.env.NODE_ENV !== 'production' ) {
+		if ( 'undefined' === typeof siteName || 'undefined' === typeof purchaseId ) {
+			throw new Error( 'siteName and purchaseId must be provided' );
+		}
+	}
 	return managePurchase( siteName, purchaseId ) + '/cancel';
 }
 

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -47,6 +47,11 @@ export function cancelPrivacyProtection( siteName, purchaseId ) {
 }
 
 export function addCardDetails( siteName, purchaseId ) {
+	if ( process.env.NODE_ENV !== 'production' ) {
+		if ( 'undefined' === typeof siteName || 'undefined' === typeof purchaseId ) {
+			throw new Error( 'siteName and purchaseId must be provided' );
+		}
+	}
 	return managePurchase( siteName, purchaseId ) + '/payment/add';
 }
 

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -9,7 +9,7 @@ export const billingHistory = purchasesRoot + '/billing';
 export function billingHistoryReceipt( receiptId ) {
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if ( 'undefined' === typeof receiptId ) {
-			throw new Error( 'purchaseId must be provided' );
+			throw new Error( 'receiptId must be provided' );
 		}
 	}
 	return billingHistory + `/${ receiptId }`;


### PR DESCRIPTION
Purchases use path builder helper functions for routing. I considered removing the helpers entirely but they are used in many places across Calypso and likely do provide some benefit.

However, they rely on default params to generate the page.js path definitions. This is fragile and leads to building paths like `/me/purchases/:site/12345` in cases where one of the params may be `undefined`.

Additionally, the placeholders which page.js provides as `context.params` are separated from the route definition where the would ideally be colocated.

This PR removes the default placeholder params, colocates them as explicit params in the route definitions, and adds error messages in non-production environments to expose any issues.

Part of #25219 which will proceed to remove the site slugs from routes. See also #25183 for some background and #24692 for motivation.

## Testing
1. No errors in development.
1. No changes in development/production.

Possibly affected routes:
- `/me/purchases/billing/:RECEIPT_ID`
- `/me/purchases/:SITE_SLUG/:PURCHASE_ID/cancel`
- `/me/purchases/:SITE_SLUG/:PURCHASE_ID/confirm-cancel-domain`
- `/me/purchases/:SITE_SLUG/:PURCHASE_ID/cancel-privacy-protection`
- `/me/purchases/:SITE_SLUG/:PURCHASE_ID/payment/add`
- `/me/purchases/:SITE_SLUG/:PURCHASE_ID/payment/edit/:CARD_ID`
- `/me/purchases/:SITE_SLUG/:PURCHASE_ID/cancel-privacy-protection`