### PR TITLE
Jetpack Connect: Use Fragment in PlansLanding

### DIFF
--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import page from 'page';
 import { connect } from 'react-redux';
@@ -100,7 +100,7 @@ class PlansLanding extends Component {
 		}
 
 		return (
-			<div>
+			<Fragment>
 				<DocumentHead title={ translate( 'Plans' ) } />
 				<QueryPlans />
 
@@ -120,7 +120,7 @@ class PlansLanding extends Component {
 						</JetpackConnectHappychatButton>
 					</LoggedOutFormLinks>
 				</PlansGrid>
-			</div>
+			</Fragment>
 		);
 	}
 }


### PR DESCRIPTION
This is a follow-up PR to #25041, where @sirreal suggested that we get rid of the `<div>` wrapper inside `<PlansLanding />` - https://github.com/Automattic/wp-calypso/pull/25041#discussion_r192156690

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/jetpack/connect/store
* Verify there are no visual/functional changes on that page.