### PR TITLE
Break dependency cycle in get-site-options

### DIFF
--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -13,7 +13,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { getRawSite } from 'state/sites/selectors';
+import getRawSite from 'state/selectors/get-raw-site';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import QuerySites from 'components/data/query-sites';
 import QuerySitePlans from 'components/data/query-site-plans';

--- a/client/state/data-layer/wpcom/sites/comments-tree/index.js
+++ b/client/state/data-layer/wpcom/sites/comments-tree/index.js
@@ -15,7 +15,7 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
-import { getRawSite } from 'state/sites/selectors';
+import getRawSite from 'state/selectors/get-raw-site';
 
 export const fetchCommentsTreeForSite = ( { dispatch }, action ) => {
 	const { siteId, status = 'unapproved' } = action.query;

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -22,7 +22,7 @@ import { dispatchRequest, dispatchRequestEx } from 'state/data-layer/wpcom-http/
 import replies from './replies';
 import likes from './likes';
 import { errorNotice, removeNotice } from 'state/notices/actions';
-import { getRawSite } from 'state/sites/selectors';
+import getRawSite from 'state/selectors/get-raw-site';
 import getSiteComment from 'state/selectors/get-site-comment';
 import {
 	receiveComments,

--- a/client/state/selectors/get-menu-item-types.js
+++ b/client/state/selectors/get-menu-item-types.js
@@ -9,7 +9,8 @@ import { endsWith, filter, find, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getRawSite, getSiteAdminUrl } from 'state/sites/selectors';
+import { getSiteAdminUrl } from 'state/sites/selectors';
+import getRawSite from 'state/selectors/get-raw-site';
 import { getPostTypes } from 'state/post-types/selectors';
 
 function getDefaultItemTypes( state, siteId ) {

--- a/client/state/selectors/get-raw-site.js
+++ b/client/state/selectors/get-raw-site.js
@@ -1,0 +1,17 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import getSitesItems from 'state/selectors/get-sites-items';
+
+/**
+ * Returns a raw site object by its ID.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?Object}        Site object
+ */
+export default ( state, siteId ) => {
+	return getSitesItems( state )[ siteId ] || null;
+};

--- a/client/state/selectors/get-site-default-post-format.js
+++ b/client/state/selectors/get-site-default-post-format.js
@@ -9,7 +9,8 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getRawSite, getSiteOption } from 'state/sites/selectors';
+import { getSiteOption } from 'state/sites/selectors';
+import getRawSite from 'state/selectors/get-raw-site';
 import { getSiteSettings } from 'state/site-settings/selectors';
 
 /**

--- a/client/state/selectors/get-site-icon-id.js
+++ b/client/state/selectors/get-site-icon-id.js
@@ -9,7 +9,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getRawSite } from 'state/sites/selectors';
+import getRawSite from 'state/selectors/get-raw-site';
 import { getSiteSettings } from 'state/site-settings/selectors';
 
 /**

--- a/client/state/selectors/get-site-icon-url.js
+++ b/client/state/selectors/get-site-icon-url.js
@@ -9,7 +9,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getRawSite } from 'state/sites/selectors';
+import getRawSite from 'state/selectors/get-raw-site';
 import getMediaUrl from 'state/selectors/get-media-url';
 import getSiteIconId from 'state/selectors/get-site-icon-id';
 

--- a/client/state/selectors/get-site-options.js
+++ b/client/state/selectors/get-site-options.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { getRawSite } from 'state/sites/selectors';
+import getRawSite from 'state/selectors/get-raw-site';
 
 const EMTPY_OPTIONS = Object.freeze( {} );
 

--- a/client/state/selectors/get-site-url.js
+++ b/client/state/selectors/get-site-url.js
@@ -9,7 +9,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getRawSite } from 'state/sites/selectors';
+import getRawSite from 'state/selectors/get-raw-site';
 
 /**
  * Returns a site's URL or null if the site doesn't exist or the URL is unknown

--- a/client/state/selectors/is-domain-only-site.js
+++ b/client/state/selectors/is-domain-only-site.js
@@ -9,7 +9,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getRawSite } from 'state/sites/selectors';
+import getRawSite from 'state/selectors/get-raw-site';
 
 /**
  * Returns true if site is a Domain-only site, false if the site is a regular site,

--- a/client/state/selectors/is-mapped-domain-site.js
+++ b/client/state/selectors/is-mapped-domain-site.js
@@ -9,7 +9,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getRawSite } from 'state/sites/selectors';
+import getRawSite from 'state/selectors/get-raw-site';
 
 /**
  * Returns true if site is a mapped domain site, false if the site is not,

--- a/client/state/selectors/is-private-site.js
+++ b/client/state/selectors/is-private-site.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { getRawSite } from 'state/sites/selectors';
+import getRawSite from 'state/selectors/get-raw-site';
 import { getSiteSettings } from 'state/site-settings/selectors';
 
 /**

--- a/client/state/selectors/is-site-upgradeable.js
+++ b/client/state/selectors/is-site-upgradeable.js
@@ -6,7 +6,7 @@
 
 import canCurrentUser from 'state/selectors/can-current-user';
 import { getCurrentUserId } from 'state/current-user/selectors';
-import { getRawSite } from 'state/sites/selectors';
+import getRawSite from 'state/selectors/get-raw-site';
 
 /**
  * Returns true if the site can be upgraded by the user, false if the

--- a/client/state/selectors/is-vip-site.js
+++ b/client/state/selectors/is-vip-site.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { getRawSite } from 'state/sites/selectors';
+import getRawSite from 'state/selectors/get-raw-site';
 
 /**
  * Returns true if the site is VIP

--- a/client/state/selectors/test/get-raw-site.js
+++ b/client/state/selectors/test/get-raw-site.js
@@ -1,0 +1,38 @@
+/**
+ * Internal dependencies
+ */
+import getRawSite from '../get-raw-site';
+
+describe( '#getRawSite()', () => {
+	test( 'it should return null if there is no such site', () => {
+		const rawSite = getRawSite(
+			{
+				sites: {
+					items: {},
+				},
+			},
+			77203199
+		);
+
+		expect( rawSite ).toBeNull();
+	} );
+
+	test( 'it should return the raw site object for site with that ID', () => {
+		const site = {
+			ID: 77203199,
+			URL: 'https://example.com',
+		};
+		const rawSite = getRawSite(
+			{
+				sites: {
+					items: {
+						77203199: site,
+					},
+				},
+			},
+			77203199
+		);
+
+		expect( rawSite ).toEqual( site );
+	} );
+} );

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -39,17 +39,7 @@ import { getSiteComputedAttributes } from './utils';
 import getSiteOptions from 'state/selectors/get-site-options';
 import getSitesItems from 'state/selectors/get-sites-items';
 import isSiteUpgradeable from 'state/selectors/is-site-upgradeable';
-
-/**
- * Returns a raw site object by its ID.
- *
- * @param  {Object}  state  Global state tree
- * @param  {Number}  siteId Site ID
- * @return {?Object}        Site object
- */
-export const getRawSite = ( state, siteId ) => {
-	return getSitesItems( state )[ siteId ] || null;
-};
+import getRawSite from 'state/selectors/get-raw-site';
 
 /**
  * Returns a site object by its slug.

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -9,7 +9,6 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import {
-	getRawSite,
 	getSite,
 	getSiteCollisions,
 	isSiteConflicting,
@@ -75,40 +74,6 @@ describe( 'selectors', () => {
 		getSite.clearCache();
 		getSiteCollisions.memoizedSelector.cache.clear();
 		getSiteBySlug.memoizedSelector.cache.clear();
-	} );
-
-	describe( '#getRawSite()', () => {
-		test( 'it should return null if there is no such site', () => {
-			const rawSite = getRawSite(
-				{
-					sites: {
-						items: {},
-					},
-				},
-				77203199
-			);
-
-			expect( rawSite ).to.be.null;
-		} );
-
-		test( 'it should return the raw site object for site with that ID', () => {
-			const site = {
-				ID: 77203199,
-				URL: 'https://example.com',
-			};
-			const rawSite = getRawSite(
-				{
-					sites: {
-						items: {
-							77203199: site,
-						},
-					},
-				},
-				77203199
-			);
-
-			expect( rawSite ).to.eql( site );
-		} );
 	} );
 
 	describe( '#getSite()', () => {

--- a/client/state/sites/utils.js
+++ b/client/state/sites/utils.js
@@ -5,7 +5,6 @@
  */
 
 import {
-	getRawSite,
 	getSiteDomain,
 	getSiteOption,
 	getSiteSlug,
@@ -14,6 +13,7 @@ import {
 	isSiteConflicting,
 	isSitePreviewable,
 } from 'state/sites/selectors';
+import getRawSite from 'state/selectors/get-raw-site';
 import canCurrentUser from 'state/selectors/can-current-user';
 import getSiteOptions from 'state/selectors/get-site-options';
 import { withoutHttp } from 'lib/url';


### PR DESCRIPTION
Move `getRawSite` out to a dependency free selector, which breaks a few dependency cycles, notably one with `get-site-options`.

Also update all users of `getRawSite` and move the tests.

To test, click around My Sites in calypso with the console open. Calypso should behave as expected and no odd warnings should be logged. 

This is a pretty low-level move, so e2e tests should also pass.

To see dependency cycles, run `CHECK_CYCLES=true npm start`