### PR TITLE
Adding attachment fields in the edit gallery modal

### DIFF
--- a/client/my-sites/media-library/list-item.jsx
+++ b/client/my-sites/media-library/list-item.jsx
@@ -35,6 +35,7 @@ export default class extends React.Component {
 		onToggle: PropTypes.func,
 		onEditItem: PropTypes.func,
 		style: PropTypes.object,
+		photon: PropTypes.bool,
 	};
 
 	static defaultProps = {

--- a/client/post-editor/media-modal/fieldset.scss
+++ b/client/post-editor/media-modal/fieldset.scss
@@ -8,6 +8,10 @@
 	font-size: 13px;
 }
 
+.editor-media-modal__fieldset .form-text-input[readonly] {
+	background: #eee;
+}
+
 .editor-media-modal__fieldset textarea {
 	min-height: 76px;
 }

--- a/client/post-editor/media-modal/gallery/edit-item.jsx
+++ b/client/post-editor/media-modal/gallery/edit-item.jsx
@@ -7,6 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -21,6 +22,7 @@ class EditorMediaModalGalleryEditItem extends Component {
 		site: PropTypes.object,
 		item: PropTypes.object,
 		showRemoveButton: PropTypes.bool,
+		selected: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -37,10 +39,15 @@ class EditorMediaModalGalleryEditItem extends Component {
 	};
 
 	render() {
-		const { site, item, showRemoveButton } = this.props;
+		const { site, item, selected, showRemoveButton } = this.props;
+
+		const className = classNames(
+			'editor-media-modal-gallery__edit-item',
+			selected && 'editor-media-modal-gallery__edit-item--selected'
+		);
 
 		return (
-			<div className="editor-media-modal-gallery__edit-item">
+			<div className={ className }>
 				<MediaLibraryListItem media={ item } scale={ 1 } photon={ false } />
 				{ this.renderCaption() }
 				{ showRemoveButton && (

--- a/client/post-editor/media-modal/gallery/edit-item.jsx
+++ b/client/post-editor/media-modal/gallery/edit-item.jsx
@@ -47,8 +47,19 @@ class EditorMediaModalGalleryEditItem extends Component {
 		);
 
 		return (
-			<div className={ className }>
-				<MediaLibraryListItem media={ item } scale={ 1 } photon={ false } />
+			<div
+				className={ className }
+				onClick={ this.onClick }
+				onKeyUp={ this.onKeyUp }
+				tabIndex="0"
+				role="button"
+			>
+				<MediaLibraryListItem
+					media={ item }
+					scale={ 1 }
+					photon={ false }
+					onClick={ this.onClick }
+				/>
 				{ this.renderCaption() }
 				{ showRemoveButton && (
 					<EditorMediaModalGalleryRemoveButton siteId={ site.ID } itemId={ item.ID } />
@@ -56,6 +67,27 @@ class EditorMediaModalGalleryEditItem extends Component {
 			</div>
 		);
 	}
+
+	onSelect = () => {
+		const { item, onSelect } = this.props;
+		onSelect( item.ID );
+	};
+
+	onClick = e => {
+		const { selected } = this.props;
+
+		if ( selected && 'INPUT' === e.target.tagName ) {
+			return;
+		}
+
+		this.onSelect();
+	};
+
+	onKeyUp = e => {
+		if ( 'Enter' === e.key ) {
+			this.onSelect();
+		}
+	};
 }
 
 export default connect( ( state, { site = {} } ) => {

--- a/client/post-editor/media-modal/gallery/edit.jsx
+++ b/client/post-editor/media-modal/gallery/edit.jsx
@@ -43,7 +43,7 @@ class EditorMediaModalGalleryEdit extends React.Component {
 	};
 
 	render() {
-		const { onUpdateSetting, site, settings, translate } = this.props;
+		const { onUpdateSetting, site, settings, translate, activeItem, onItemSelected } = this.props;
 
 		if ( ! site || ! settings.items ) {
 			return null;
@@ -67,14 +67,15 @@ class EditorMediaModalGalleryEdit extends React.Component {
 						);
 					} ) }
 				</EllipsisMenu>
-				<SortableList onChange={ this.onOrderChanged }>
+				<SortableList onChange={ this.onOrderChanged } minimumDistance={ 10 }>
 					{ settings.items.map( item => {
 						return (
 							<EditorMediaModalGalleryEditItem
 								key={ item.ID }
 								site={ site }
 								item={ item }
-								selected={ true }
+								selected={ activeItem === item.ID }
+								onSelect={ onItemSelected }
 								showRemoveButton={ settings.items.length > 1 }
 							/>
 						);

--- a/client/post-editor/media-modal/gallery/edit.jsx
+++ b/client/post-editor/media-modal/gallery/edit.jsx
@@ -74,6 +74,7 @@ class EditorMediaModalGalleryEdit extends React.Component {
 								key={ item.ID }
 								site={ site }
 								item={ item }
+								selected={ true }
 								showRemoveButton={ settings.items.length > 1 }
 							/>
 						);

--- a/client/post-editor/media-modal/gallery/index.jsx
+++ b/client/post-editor/media-modal/gallery/index.jsx
@@ -38,6 +38,7 @@ class EditorMediaModalGallery extends React.Component {
 
 	state = {
 		invalidItemDropped: false,
+		activeItem: -1,
 	};
 
 	componentWillMount() {
@@ -123,6 +124,7 @@ class EditorMediaModalGallery extends React.Component {
 
 	render() {
 		const { site, items, settings } = this.props;
+		const { activeItem } = this.state;
 
 		return (
 			<div className="editor-media-modal-gallery">
@@ -142,6 +144,8 @@ class EditorMediaModalGallery extends React.Component {
 						onUpdateSetting={ this.updateSetting }
 						invalidItemDropped={ this.state.invalidItemDropped }
 						onDismissInvalidItemDropped={ () => this.setState( { invalidItemDropped: false } ) }
+						activeItem={ activeItem }
+						onItemSelected={ this.selectItem }
 					/>
 					<div className="editor-media-modal-gallery__sidebar">
 						<EditorMediaModalGalleryFields
@@ -150,11 +154,21 @@ class EditorMediaModalGallery extends React.Component {
 							onUpdateSetting={ this.updateSetting }
 							numberOfItems={ items.length }
 						/>
+
+						{ this.state.activeItem }
 					</div>
 				</div>
 			</div>
 		);
 	}
+
+	selectItem = item => {
+		const { activeItem } = this.state;
+
+		this.setState( {
+			activeItem: ! item || activeItem === item ? -1 : item,
+		} );
+	};
 }
 
 export default connect( null, {

--- a/client/post-editor/media-modal/gallery/item-fields.jsx
+++ b/client/post-editor/media-modal/gallery/item-fields.jsx
@@ -1,0 +1,78 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import EditorMediaModalFieldset from '../fieldset';
+import FormTextInput from 'components/forms/form-text-input';
+import FormTextareaInput from 'components/forms/form-textarea';
+
+export class EditorMediaModalGalleryItemFields extends React.Component {
+	static propTypes = {
+		translate: PropTypes.func,
+		item: PropTypes.object,
+		updateSetting: PropTypes.func,
+		onBlur: PropTypes.func,
+	};
+
+	render() {
+		const {
+			translate: t,
+			item: { URL, title, caption, alt, description },
+			updateSetting: update,
+			onBlur: blur,
+		} = this.props;
+
+		return (
+			<div className="editor-media-modal-gallery__item-fields">
+				<h3 className="editor-media-modal-gallery__item-heading">{ t( 'Attachment Details' ) }</h3>
+
+				<EditorMediaModalFieldset legend={ t( 'URL' ) }>
+					<FormTextInput value={ URL } onBlur={ blur } readOnly={ true } />
+				</EditorMediaModalFieldset>
+
+				<EditorMediaModalFieldset legend={ t( 'Title' ) }>
+					<FormTextInput
+						value={ title }
+						onBlur={ blur }
+						onChange={ e => update( 'title', e.target.value ) }
+					/>
+				</EditorMediaModalFieldset>
+
+				<EditorMediaModalFieldset legend={ t( 'Caption' ) }>
+					<FormTextareaInput
+						value={ caption }
+						onBlur={ blur }
+						onChange={ e => update( 'caption', e.target.value ) }
+					/>
+				</EditorMediaModalFieldset>
+
+				<EditorMediaModalFieldset legend={ t( 'Alt Text' ) }>
+					<FormTextInput
+						value={ alt }
+						onBlur={ blur }
+						onChange={ e => update( 'alt', e.target.value ) }
+					/>
+				</EditorMediaModalFieldset>
+
+				<EditorMediaModalFieldset legend={ t( 'Description' ) }>
+					<FormTextareaInput
+						value={ description }
+						onBlur={ blur }
+						onChange={ e => update( 'description', e.target.value ) }
+					/>
+				</EditorMediaModalFieldset>
+			</div>
+		);
+	}
+}
+
+export default localize( EditorMediaModalGalleryItemFields );

--- a/client/post-editor/media-modal/gallery/preview-shortcode.jsx
+++ b/client/post-editor/media-modal/gallery/preview-shortcode.jsx
@@ -43,8 +43,12 @@ export default createReactClass( {
 		} );
 	},
 
+	componentDidMount() {
+		this.isMounted = true;
+	},
+
 	setLoaded() {
-		if ( ! this.isMounted() ) {
+		if ( ! this.isMounted ) {
 			return;
 		}
 

--- a/client/post-editor/media-modal/gallery/preview.jsx
+++ b/client/post-editor/media-modal/gallery/preview.jsx
@@ -61,13 +61,13 @@ class EditorMediaModalGalleryPreview extends Component {
 			<SegmentedControl className="editor-media-modal-gallery__preview-toggle" compact>
 				<SegmentedControlItem
 					selected={ ! this.state.isEditing }
-					onClick={ () => this.setState( { isEditing: false } ) }
+					onClick={ () => this.setEditingState( false ) }
 				>
 					{ translate( 'Preview' ) }
 				</SegmentedControlItem>
 				<SegmentedControlItem
 					selected={ this.state.isEditing }
-					onClick={ () => this.setState( { isEditing: true } ) }
+					onClick={ () => this.setEditingState( true ) }
 				>
 					{ translate( 'Edit' ) }
 				</SegmentedControlItem>

--- a/client/post-editor/media-modal/gallery/preview.jsx
+++ b/client/post-editor/media-modal/gallery/preview.jsx
@@ -41,6 +41,19 @@ class EditorMediaModalGalleryPreview extends Component {
 		isEditing: false,
 	};
 
+	setEditingState( isEditing ) {
+		// Save the normal state
+		this.setState( {
+			isEditing,
+		} );
+
+		// Deselect the selected item if one is not being edited anymore
+		if ( ! isEditing ) {
+			const { onItemSelected } = this.props;
+			onItemSelected( -1 );
+		}
+	}
+
 	renderPreviewModeToggle() {
 		const { translate } = this.props;
 
@@ -63,7 +76,7 @@ class EditorMediaModalGalleryPreview extends Component {
 	}
 
 	renderPreview() {
-		const { site, settings, onUpdateSetting } = this.props;
+		const { site, settings, activeItem, onUpdateSetting, onItemSelected } = this.props;
 
 		if ( ! site || ! settings.items ) {
 			return;
@@ -75,6 +88,8 @@ class EditorMediaModalGalleryPreview extends Component {
 					site={ site }
 					settings={ settings }
 					onUpdateSetting={ onUpdateSetting }
+					activeItem={ activeItem }
+					onItemSelected={ onItemSelected }
 				/>
 			);
 		}

--- a/client/post-editor/media-modal/gallery/style.scss
+++ b/client/post-editor/media-modal/gallery/style.scss
@@ -66,13 +66,28 @@
 	margin: 3%;
 
 	@include breakpoint( ">660px" ) {
-		width: 160px;
+		width: 166px;
 		margin: 16px 0 0 16px;
 	}
 }
 
+.editor-media-modal-gallery .sortable-list__item.is-active {
+	margin: 0;
+}
+
 .editor-media-modal-gallery__edit-item {
+	display: block;
 	position: relative;
+	border: 3px solid transparent;
+}
+
+.editor-media-modal-gallery__edit-item--selected,
+.editor-media-modal-gallery__edit-item:focus {
+	border-color: $blue-medium;
+}
+
+.editor-media-modal-gallery__edit-item .media-library__list-item:hover .media-library__list-item-figure {
+    box-shadow: none;
 }
 
 .editor-media-modal-gallery__remove {

--- a/client/post-editor/media-modal/gallery/style.scss
+++ b/client/post-editor/media-modal/gallery/style.scss
@@ -225,6 +225,11 @@ input.editor-media-modal-gallery__caption[type="text"] {
 	}
 }
 
+.editor-media-modal-gallery__item-heading {
+	font-size: 1.5em;
+    margin-bottom: .5em;
+}
+
 .editor-media-modal-gallery__fields .for-setting-type {
 	position: absolute;
 		top: 0;


### PR DESCRIPTION
This is a pull request, which addresses the issue, reported in #25111

It includes a few commits:
- 362b373 fixes an annoying console warning
- 7c0f7ee also adjusts the behavior of the sortable component, in order to:
   1. Allow items to be clicked by delaying the drag-start until the cursor has moved 5 pixels in some direction.
  2. I noticed that the initial sortable helper (may also be called clone or cursor) was being positioned strangely relative to the position of the original element. I fixed that in order to improve the overall feel of the component

The rest of the commits add the "Attachment Details" section whenever an attachment has been selected in the "Edit" mode of the shortcode. Those fields, as in the media gallery, include:

- URL
- Title
- Caption
- Alt Text
- Description

Like in other places, those changes are only saved when a field has been changed and blurred.

@designsimply normally I should ping someone to review my code, but all of the files in `client/post-editor/media-modal/` seem to have been there from the beginning of the project and I do not know whom to choose. You seem to be tagging all issues, so do you maybe have any suggestions?