### PR TITLE
Comments: Edit comment date

### DIFF
--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -19,6 +19,7 @@ import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import InfoPopover from 'components/info-popover';
 import PostSchedule from 'components/post-schedule';
+import QuerySiteSettings from 'components/data/query-site-settings';
 import { decodeEntities } from 'lib/formatting';
 import {
 	bumpStat,
@@ -29,6 +30,7 @@ import {
 import { editComment } from 'state/comments/actions';
 import { removeNotice, successNotice } from 'state/notices/actions';
 import getSiteComment from 'state/selectors/get-site-comment';
+import getSiteSetting from 'state/selectors/get-site-setting';
 import { getSiteSlug, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
@@ -49,6 +51,11 @@ export class CommentEdit extends Component {
 		const { authorDisplayName, authorUrl, commentContent, commentDate } = this.props;
 		this.setState( { authorDisplayName, authorUrl, commentContent, commentDate } );
 	}
+
+	getTimezoneForPostSchedule = () => ( {
+		timezone: this.props.siteTimezone || undefined,
+		gmtOffset: parseInt( this.props.siteGmtOffset, 10 ),
+	} );
 
 	setAuthorDisplayNameValue = event => this.setState( { authorDisplayName: event.target.value } );
 
@@ -101,7 +108,10 @@ export class CommentEdit extends Component {
 		const {
 			isAuthorRegistered,
 			isEditCommentSupported,
+			siteGmtOffset,
+			siteId,
 			siteSlug,
+			siteTimezone,
 			toggleEditMode,
 			translate,
 		} = this.props;
@@ -109,6 +119,7 @@ export class CommentEdit extends Component {
 
 		return (
 			<div className="comment__edit">
+				{ ! siteTimezone && ! siteGmtOffset && <QuerySiteSettings siteId={ siteId } /> }
 				<div className="comment__edit-header">{ translate( 'Edit Comment' ) }</div>
 
 				<div className="comment__edit-wrapper">
@@ -144,7 +155,11 @@ export class CommentEdit extends Component {
 
 					<FormFieldset>
 						<FormLabel htmlFor="date">{ translate( 'Submitted on' ) }</FormLabel>
-						<PostSchedule selectedDay={ commentDate } onDateChange={ this.setCommentDateValue } />
+						<PostSchedule
+							selectedDay={ commentDate }
+							onDateChange={ this.setCommentDateValue }
+							{ ...this.getTimezoneForPostSchedule() }
+						/>
 					</FormFieldset>
 
 					<CommentHtmlEditor
@@ -195,8 +210,10 @@ const mapStateToProps = ( state, { commentId } ) => {
 		isAuthorRegistered: 0 !== get( comment, 'author.ID' ),
 		isEditCommentSupported,
 		postId: get( comment, 'post.ID' ),
+		siteGmtOffset: getSiteSetting( state, siteId, 'gmt_offset' ),
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
+		siteTimezone: getSiteSetting( state, siteId, 'timezone_string' ),
 	};
 };
 

--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -18,6 +18,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import InfoPopover from 'components/info-popover';
+import PostSchedule from 'components/post-schedule';
 import { decodeEntities } from 'lib/formatting';
 import {
 	bumpStat,
@@ -41,11 +42,12 @@ export class CommentEdit extends Component {
 		authorDisplayName: '',
 		authorUrl: '',
 		commentContent: '',
+		commentDate: '',
 	};
 
 	componentWillMount() {
-		const { authorDisplayName, authorUrl, commentContent } = this.props;
-		this.setState( { authorDisplayName, authorUrl, commentContent } );
+		const { authorDisplayName, authorUrl, commentContent, commentDate } = this.props;
+		this.setState( { authorDisplayName, authorUrl, commentContent, commentDate } );
 	}
 
 	setAuthorDisplayNameValue = event => this.setState( { authorDisplayName: event.target.value } );
@@ -54,6 +56,9 @@ export class CommentEdit extends Component {
 
 	setCommentContentValue = ( event, callback = noop ) =>
 		this.setState( { commentContent: event.target.value }, callback );
+
+	setCommentDateValue = commentDate =>
+		this.setState( { commentDate: this.props.moment( commentDate ).format() } );
 
 	showNotice = () => {
 		const { translate } = this.props;
@@ -100,7 +105,7 @@ export class CommentEdit extends Component {
 			toggleEditMode,
 			translate,
 		} = this.props;
-		const { authorDisplayName, authorUrl, commentContent } = this.state;
+		const { authorDisplayName, authorUrl, commentContent, commentDate } = this.state;
 
 		return (
 			<div className="comment__edit">
@@ -135,6 +140,11 @@ export class CommentEdit extends Component {
 							onChange={ this.setAuthorUrlValue }
 							value={ authorUrl }
 						/>
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel htmlFor="date">{ translate( 'Submitted on' ) }</FormLabel>
+						<PostSchedule selectedDay={ commentDate } onDateChange={ this.setCommentDateValue } />
 					</FormFieldset>
 
 					<CommentHtmlEditor
@@ -181,6 +191,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 		authorDisplayName,
 		authorUrl: get( comment, 'author.URL', '' ),
 		commentContent: get( comment, 'raw_content' ),
+		commentDate: get( comment, 'date' ),
 		isAuthorRegistered: 0 !== get( comment, 'author.ID' ),
 		isEditCommentSupported,
 		postId: get( comment, 'post.ID' ),

--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -58,13 +58,18 @@ export class CommentEdit extends Component {
 
 	storeDatePopoverButtonRef = button => ( this.datePopoverButtonRef = button );
 
-	openDatePopover = () =>
-		this.setState( ( { commentDate } ) => ( {
-			isDatePopoverVisible: true,
-			tmpCommentDate: commentDate,
+	toggleDatePopover = () =>
+		this.setState( ( { commentDate, isDatePopoverVisible } ) => ( {
+			isDatePopoverVisible: ! isDatePopoverVisible,
+			tmpCommentDate: isDatePopoverVisible ? '' : commentDate,
 		} ) );
 
-	closeDatePopover = () => this.setState( { isDatePopoverVisible: false, tmpCommentDate: '' } );
+	cancelCommentDataValueChange = () =>
+		this.setState( ( { tmpCommentDate } ) => ( {
+			commentDate: tmpCommentDate,
+			isDatePopoverVisible: false,
+			tmpCommentDate: '',
+		} ) );
 
 	getTimezoneForPostSchedule = () => ( {
 		timezone: this.props.siteTimezone || undefined,
@@ -80,13 +85,6 @@ export class CommentEdit extends Component {
 
 	setCommentDateValue = commentDate =>
 		this.setState( { commentDate: this.props.moment( commentDate ).format() } );
-
-	cancelCommentDataValueChange = () =>
-		this.setState( ( { tmpCommentDate } ) => ( {
-			commentDate: tmpCommentDate,
-			isDatePopoverVisible: false,
-			tmpCommentDate: '',
-		} ) );
 
 	showNotice = () => {
 		const { translate } = this.props;
@@ -191,7 +189,7 @@ export class CommentEdit extends Component {
 						<Button
 							className="comment__edit-date-button"
 							ref={ this.storeDatePopoverButtonRef }
-							onClick={ this.openDatePopover }
+							onClick={ this.toggleDatePopover }
 						>
 							{ moment( commentDate ).format( 'll LT' ) }
 						</Button>
@@ -199,7 +197,7 @@ export class CommentEdit extends Component {
 							className="comment__edit-date-popover"
 							context={ this.datePopoverButtonRef }
 							isVisible={ isDatePopoverVisible }
-							onClose={ this.closeDatePopover }
+							onClose={ this.cancelCommentDataValueChange }
 							position="bottom"
 						>
 							<PostSchedule
@@ -209,7 +207,7 @@ export class CommentEdit extends Component {
 								{ ...this.getTimezoneForPostSchedule() }
 							/>
 							<div className="comment__edit-date-popover-buttons">
-								<Button primary compact onClick={ this.closeDatePopover }>
+								<Button primary compact onClick={ this.toggleDatePopover }>
 									{ translate( 'Change' ) }
 								</Button>
 								<Button compact onClick={ this.cancelCommentDataValueChange }>

--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, createRef } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -43,20 +43,15 @@ export class CommentEdit extends Component {
 	};
 
 	state = {
-		authorDisplayName: '',
-		authorUrl: '',
-		commentContent: '',
-		commentDate: '',
+		authorDisplayName: this.props.authorDisplayName || '',
+		authorUrl: this.props.authorUrl || '',
+		commentContent: this.props.commentContent || '',
+		commentDate: this.props.commentDate || '',
 		isDatePopoverVisible: false,
 		tmpCommentDate: '',
 	};
 
-	componentWillMount() {
-		const { authorDisplayName, authorUrl, commentContent, commentDate } = this.props;
-		this.setState( { authorDisplayName, authorUrl, commentContent, commentDate } );
-	}
-
-	storeDatePopoverButtonRef = button => ( this.datePopoverButtonRef = button );
+	datePopoverButtonRef = createRef();
 
 	toggleDatePopover = () =>
 		this.setState( ( { commentDate, isDatePopoverVisible } ) => ( {
@@ -188,14 +183,14 @@ export class CommentEdit extends Component {
 						<FormLabel htmlFor="date">{ translate( 'Submitted on' ) }</FormLabel>
 						<Button
 							className="comment__edit-date-button"
-							ref={ this.storeDatePopoverButtonRef }
+							ref={ this.datePopoverButtonRef }
 							onClick={ this.toggleDatePopover }
 						>
 							{ moment( commentDate ).format( 'll LT' ) }
 						</Button>
 						<Popover
 							className="comment__edit-date-popover"
-							context={ this.datePopoverButtonRef }
+							context={ this.datePopoverButtonRef.current }
 							isVisible={ isDatePopoverVisible }
 							onClose={ this.cancelCommentDataValueChange }
 							position="bottom"

--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -186,7 +186,8 @@ export class CommentEdit extends Component {
 							ref={ this.datePopoverButtonRef }
 							onClick={ this.toggleDatePopover }
 						>
-							{ moment( commentDate ).format( 'll LT' ) }
+							<Gridicon icon="calendar" />
+							<span>{ moment( commentDate ).format( 'lll' ) }</span>
 						</Button>
 						<Popover
 							className="comment__edit-date-popover"

--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -48,6 +48,7 @@ export class CommentEdit extends Component {
 		commentContent: '',
 		commentDate: '',
 		isDatePopoverVisible: false,
+		tmpCommentDate: '',
 	};
 
 	componentWillMount() {
@@ -56,6 +57,14 @@ export class CommentEdit extends Component {
 	}
 
 	storeDatePopoverButtonRef = button => ( this.datePopoverButtonRef = button );
+
+	openDatePopover = () =>
+		this.setState( ( { commentDate } ) => ( {
+			isDatePopoverVisible: true,
+			tmpCommentDate: commentDate,
+		} ) );
+
+	closeDatePopover = () => this.setState( { isDatePopoverVisible: false, tmpCommentDate: '' } );
 
 	getTimezoneForPostSchedule = () => ( {
 		timezone: this.props.siteTimezone || undefined,
@@ -71,6 +80,13 @@ export class CommentEdit extends Component {
 
 	setCommentDateValue = commentDate =>
 		this.setState( { commentDate: this.props.moment( commentDate ).format() } );
+
+	cancelCommentDataValueChange = () =>
+		this.setState( ( { tmpCommentDate } ) => ( {
+			commentDate: tmpCommentDate,
+			isDatePopoverVisible: false,
+			tmpCommentDate: '',
+		} ) );
 
 	showNotice = () => {
 		const { translate } = this.props;
@@ -107,11 +123,6 @@ export class CommentEdit extends Component {
 
 		toggleEditMode();
 	};
-
-	toggleDatePopover = () =>
-		this.setState( ( { isDatePopoverVisible } ) => ( {
-			isDatePopoverVisible: ! isDatePopoverVisible,
-		} ) );
 
 	undo = previousCommentData => () => {
 		const { postId, siteId } = this.props;
@@ -180,7 +191,7 @@ export class CommentEdit extends Component {
 						<Button
 							className="comment__edit-date-button"
 							ref={ this.storeDatePopoverButtonRef }
-							onClick={ this.toggleDatePopover }
+							onClick={ this.openDatePopover }
 						>
 							{ moment( commentDate ).format( 'll LT' ) }
 						</Button>
@@ -188,14 +199,23 @@ export class CommentEdit extends Component {
 							className="comment__edit-date-popover"
 							context={ this.datePopoverButtonRef }
 							isVisible={ isDatePopoverVisible }
-							onClose={ this.toggleDatePopover }
+							onClose={ this.closeDatePopover }
 							position="bottom"
 						>
 							<PostSchedule
 								selectedDay={ commentDate }
+								displayInputChrono={ false }
 								onDateChange={ this.setCommentDateValue }
 								{ ...this.getTimezoneForPostSchedule() }
 							/>
+							<div className="comment__edit-date-popover-buttons">
+								<Button primary compact onClick={ this.closeDatePopover }>
+									{ translate( 'Change' ) }
+								</Button>
+								<Button compact onClick={ this.cancelCommentDataValueChange }>
+									{ translate( 'Cancel' ) }
+								</Button>
+							</div>
 						</Popover>
 					</FormFieldset>
 

--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -48,7 +48,7 @@ export class CommentEdit extends Component {
 		commentContent: this.props.commentContent || '',
 		commentDate: this.props.commentDate || '',
 		isDatePopoverVisible: false,
-		tmpCommentDate: '',
+		storedCommentDate: '',
 	};
 
 	datePopoverButtonRef = createRef();
@@ -56,14 +56,14 @@ export class CommentEdit extends Component {
 	toggleDatePopover = () =>
 		this.setState( ( { commentDate, isDatePopoverVisible } ) => ( {
 			isDatePopoverVisible: ! isDatePopoverVisible,
-			tmpCommentDate: isDatePopoverVisible ? '' : commentDate,
+			storedCommentDate: isDatePopoverVisible ? '' : commentDate,
 		} ) );
 
 	cancelCommentDataValueChange = () =>
-		this.setState( ( { tmpCommentDate } ) => ( {
-			commentDate: tmpCommentDate,
+		this.setState( ( { storedCommentDate } ) => ( {
+			commentDate: storedCommentDate,
 			isDatePopoverVisible: false,
-			tmpCommentDate: '',
+			storedCommentDate: '',
 		} ) );
 
 	getTimezoneForPostSchedule = () => ( {

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -499,6 +499,13 @@
 	width: 100%;
 }
 
+.comment__edit-date-button {
+	display: block;
+}
+.comment__edit-date-popover .popover__inner {
+	padding: 0 8px;
+}
+
 // HTML Editor
 
 .comment-html-editor {

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -505,6 +505,16 @@
 .comment__edit-date-popover .popover__inner {
 	padding: 0 8px;
 }
+.comment__edit-date-popover-buttons {
+	display: flex;
+	flex-direction: row-reverse;
+	justify-content: flex-start;
+	padding-bottom: 8px;
+
+	.button {
+		margin-left: 10px;
+	}
+}
 
 // HTML Editor
 

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -440,6 +440,10 @@
 	.form-fieldset {
 		padding: 0 8px;
 		width: 50%;
+
+		@include breakpoint( '>1280px' ) {
+			width: 33%;
+		}
 	}
 
 	.form-textarea {
@@ -501,6 +505,7 @@
 
 .comment__edit-date-button {
 	display: block;
+	width: 100%;
 }
 .comment__edit-date-popover .popover__inner {
 	padding: 0 8px;

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -505,7 +505,6 @@
 
 .comment__edit-date-button {
 	display: block;
-	width: 100%;
 }
 .comment__edit-date-popover .popover__inner {
 	padding: 0 8px;

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -506,8 +506,11 @@
 .comment__edit-date-button {
 	display: block;
 }
-.comment__edit-date-popover .popover__inner {
-	padding: 0 8px;
+.comment__edit-date-popover {
+	min-width: 300px;
+	.popover__inner {
+		padding: 0 8px;
+	}
 }
 .comment__edit-date-popover-buttons {
 	display: flex;

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -215,11 +215,12 @@ export const editComment = ( { dispatch, getState }, action ) => {
 	// Though, there is no direct match between the GET response (which feeds the state) and the POST request.
 	// This ternary matches the updated fields sent by Comment Management's Edit form to the fields expected by the API.
 	const body =
-		comment.authorDisplayName || comment.authorUrl || comment.commentContent
+		comment.authorDisplayName || comment.authorUrl || comment.commentContent || comment.commentDate
 			? {
 					author: comment.authorDisplayName,
 					author_url: comment.authorUrl,
 					content: comment.commentContent,
+					date: comment.commentDate,
 			  }
 			: comment;
 


### PR DESCRIPTION
Fix #19252

Add a datetime picker popover to the Comment Edit form to allow for updating the comment's date and time.

| (Small Screens) Closed | (Wide Screens) Closed | Open |
| --- | --- | --- |
| <img width="864" alt="screen shot 2018-06-11 at 16 30 10" src="https://user-images.githubusercontent.com/2070010/41241629-56e014f4-6d95-11e8-8e31-854c19c2840e.png"> | <img width="1052" alt="screen shot 2018-06-11 at 16 29 49" src="https://user-images.githubusercontent.com/2070010/41241636-5af9e132-6d95-11e8-9eaa-0b186e7875d4.png"> | <img width="1053" alt="screen shot 2018-06-11 at 16 29 57" src="https://user-images.githubusercontent.com/2070010/41241645-603afc94-6d95-11e8-922a-ff6c6518cf76.png"> |

## Notes

Since the datetime picker uses text fields for the time, I couldn't simply close the popover on date change. Instead, I've added two Change/Cancel buttons to explicitly confirm the change date intent.

Design-wise, I've decided to add a third column to `>1280px` screens. Imho it looks good and it does make sense.
On the other hand, I don't really like the "2 + 1" layout on smaller screens, but I can't come up with a better alternative. 🤔  

## Testing instructions

- Open `/comments` and click "Edit" on a comment.
- Make sure the datetime picker button displays the correct date.
- Try changing the date and save the comment. Make sure the change is still there after reloading the page.
- Try changing the site timezone (in `/settings/general`), and make sure the comments dates change accordingly.