### PR TITLE
Podcasts: set initial values for title and subtitle when enabling podcast

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -160,6 +160,7 @@ class PodcastingDetails extends Component {
 			isPodcastingEnabled,
 			fields,
 		} = this.props;
+
 		if ( ! siteId ) {
 			return null;
 		}
@@ -257,7 +258,24 @@ class PodcastingDetails extends Component {
 	}
 
 	onCategorySelected = category => {
-		this.setFieldForcingString( 'podcasting_category_id' )( category.ID );
+		const { settings, fields, isPodcastingEnabled } = this.props;
+
+		const fieldsToUpdate = { podcasting_category_id: String( category.ID ) };
+
+		if ( ! isPodcastingEnabled ) {
+			// If we are newly enabling podcasting, and no podcast title is set,
+			// use the site title.
+			if ( ! fields.podcasting_title ) {
+				fieldsToUpdate.podcasting_title = settings.blogname;
+			}
+			// If we are newly enabling podcasting, and no podcast subtitle is set,
+			// use the site description.
+			if ( ! fields.podcasting_subtitle ) {
+				fieldsToUpdate.podcasting_subtitle = settings.blogdescription;
+			}
+		}
+
+		this.props.updateFields( fieldsToUpdate );
 	};
 
 	onCategoryCleared = () => {

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -279,13 +279,10 @@ class PodcastingDetails extends Component {
 	};
 
 	onCategoryCleared = () => {
-		this.setFieldForcingString( 'podcasting_category_id' )( 0 );
+		this.props.updateFields( { podcasting_category_id: '0' } );
 	};
 
 	onCoverImageRemoved = () => {
-		// Do not call setFieldForcingString / onChangeField multiple times in
-		// the same render cycle - this breaks dirty detection in
-		// wrapSettingsForm.
 		this.props.updateFields( {
 			podcasting_image_id: '0',
 			podcasting_image: '',
@@ -297,17 +294,6 @@ class PodcastingDetails extends Component {
 			podcasting_image_id: String( coverId ),
 			podcasting_image: coverUrl,
 		} );
-	};
-
-	setFieldForcingString = field => value => {
-		const { onChangeField } = this.props;
-
-		// Always send and save IDs as strings because this is what
-		// the settings form wrapper expects (otherwise the settings form will
-		// be marked dirty again immediately after saving).
-		const event = { target: { value: String( value ) } };
-
-		onChangeField( field )( event );
 	};
 }
 


### PR DESCRIPTION
This PR sets the podcast title to the site title and podcast subtitle to the site description when enabling a new podcast.

This PR is part of a larger epic and is behind the `manage/site-settings/podcasting` feature flag. See p3Ex-32D-p2.

![initial-values](https://user-images.githubusercontent.com/942359/40853197-33a29086-659b-11e8-8eff-2abcfef12bab.gif)

**To test:**
- Run this branch with the `manage/site-settings/podcasting` feature flag enabled (enabled by default in development)
- On a site with podcasting disabled, navigate to Settings > Writing > Enable Podcast
- Enable the podcast by selecting a category in the term selector.
- If the title or subtitle fields are blank, they should be populated with the site title or site description
- If the title or subtitle fields were already populated (from previous podcast settings), their existing settings should persist.
- After enabling, edit the podcast title and subtitle, and click the "Save Settings" button.
- The title and subtitle values should be properly saved.
- Click the "disable" button, click the "Save Settings" button
- Re-enable podcasts by choosing a category. The title and subtitle values should persist. 
