### PR TITLE
Build: Increase "max old space size" to 16GB

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
     "build-docker": "node bin/build-docker.js",
     "prebuild-server": "mkdirp build",
     "build-server": "cross-env-shell CALYPSO_SERVER=true NODE_PATH=$NODE_PATH:server:client:. webpack --display-error-details --config webpack.config.node.js",
-    "build-client": "cross-env-shell CALYPSO_CLIENT=true NODE_PATH=$NODE_PATH:server:client:. node --max_old_space_size=8192 ./node_modules/webpack/bin/webpack.js --display-error-details --config webpack.config.js",
+    "build-client": "cross-env-shell CALYPSO_CLIENT=true NODE_PATH=$NODE_PATH:server:client:. node --max_old_space_size=16384 ./node_modules/webpack/bin/webpack.js --display-error-details --config webpack.config.js",
     "build-client-if-prod": "node -e \"process.env.CALYPSO_ENV === 'production' && process.exit(1)\" || npm run build-client",
     "build-client-if-desktop": "node -e \"process.env.CALYPSO_ENV === 'desktop' && process.exit(1)\" || npm run build-client",
     "clean": "npm run -s clean:build && npm run -s clean:devdocs && npm run -s clean:public",


### PR DESCRIPTION
Over the past few days I have been getting out of memory errors during incremental rebuilds.  It seems like doubling the `max_old_space_size` from 8 GB to 16 GB (!!) will address this.

Example error:

```
0ms after seal 
 95% emitting CopyPlugin
<--- Last few GCs --->

[4250:0x228c670]  2637499 ms: Mark-sweep 1337.2 (1411.1) -> 1337.2 (1412.6) MB, 806.0 / 0.1 ms  allo
cation failure GC in old space requested
[4250:0x228c670]  2638306 ms: Mark-sweep 1337.2 (1412.6) -> 1337.2 (1401.6) MB, 807.3 / 0.1 ms  last
 resort GC in old space requested
[4250:0x228c670]  2639113 ms: Mark-sweep 1337.2 (1401.6) -> 1337.2 (1401.6) MB, 806.5 / 0.1 ms  last
 resort GC in old space requested


<--- JS stacktrace --->

==== JS stack trace =========================================

Security context: 0x10876dea5879 <JSObject>
    1: fromString(aka fromString) [buffer.js:314] [bytecode=0xf48cace1b61 offset=164](this=0x34dbbc2
822d1 <undefined>,string=0x2b7debce0f59 <Very long string[44517373]>,encoding=0x10876deb4ba1 <String
[4]: utf8>)
```

See: https://github.com/webpack/webpack/issues/1914

Follow-up to: https://github.com/Automattic/wp-calypso/pull/22066