### PR TITLE
Ad Tracking: Nanigans - ignore all products that have are free

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -944,18 +944,19 @@ function recordOrderInNanigans( cart, orderId ) {
 		return;
 	}
 
-	// As for the FB pixel, we have decided to skip negative or 0-value carts.
-	if ( cart.total_cost < 0.01 ) {
-		debug( 'recordOrderInNanigans: Skipping due to a 0-value cart.' );
+	const paidProducts = cart.products.filter( product => product.cost >= 0.01 );
+
+	if ( paidProducts.length === 0 ) {
+		debug( 'recordOrderInNanigans: Skip cart because it has ONLY <0.01 products' );
 		return;
 	}
 
 	debug( 'recordOrderInNanigans: Record purchase' );
 
-	const productPrices = cart.products.map( product => product.cost * 100 ); // VALUE is in cents, [ 0, 9600 ]
+	const productPrices = paidProducts.map( product => product.cost * 100 ); // VALUE is in cents, [ 0, 9600 ]
 	const eventDetails = {
-		sku: cart.products.map( product => product.product_slug ), // [ 'blog_domain', 'plan_premium' ]
-		qty: cart.products.map( () => 1 ), // [ 1, 1 ]
+		sku: paidProducts.map( product => product.product_slug ), // [ 'blog_domain', 'plan_premium' ]
+		qty: paidProducts.map( () => 1 ), // [ 1, 1 ]
 		currency: cart.currency,
 		unique: orderId, // unique transaction id
 	};


### PR DESCRIPTION
We decided previously to ignore all carts that have 0 value (i.e. sales of free domains, sales of free private whois) such that they will not be seen as a conversion in Nanigans reporting. To do that, we applied a check such that that the cart's total value would be greater or equal than 0.01.

Previously:
```
	if ( cart.total_cost < 0.01 ) {
		debug( 'recordOrderInNanigans: Skipping due to a 0-value cart.' );
		return;
	}
```

After that implementation, we analyzed reported rows and noticed they still contained the free products (and they looked like individual purchases). I thought that this was a typecasting bug, in case `undefined < 0.01 == false`, but it turns out the issue is different: we are creating an object with a list of prices and a list of SKUs which we submit to Nanigans as one object (cart), but then Nanigans splits each item of the cart into its own reported row. As a result, when the cart's value was $48 for a personal plan and it contained a free domain in the same step, the domain ended up as a row in the report because $48 > $0.01.

This new implementation takes a different approach and simply ignores the products of the cart that cost 0 or less. If there are no products left in the cart (i.e. when the domain is added separately), then no data is sent to Nanigans.

TESTING PLAN:
==============
1) Start Calyspo with ad tracking enabled. If you do it locally, then `ENABLE_FEATURES=ad-tracking npm start`. If you do it on calypso.live, you will need to append ?flags=ad-tracking to the URL when reaching the payment page (http://calypso.live/checkout/radu004.wordpress.com/personal?flags=ad-tracking)
2) Filter the console by 'Nanigans' such that you observe the relevant events.

Case 1: Upgrade one of your sites to a Personal Plan and purchase a domain at the same time (to do that, you must return after adding the plan to the purchases of domains and add the domain to the cart). When looking at the reported data, you should only see `qty: [1], sku: ['personal-bundle'], and value: [4800]` (value may depend on currency). Practically, you should not see any 0-value product like `free-domain`. Example: https://cloudup.com/cwLQ1tO99XN

Case 2: Upgrade one of your sites to a Personal Plan, but don't purchase a domain at the same time (but only the plan). You will see a regular report sent to Nanigans, similar to the one in case 1. Then buy the domain, and you should see the message `recordOrderInNanigans: Skipping this cart because it has ONLY 0-value or negative products.` because the domain is free in this case and Naningans will not know anything about this purchase. https://cloudup.com/cwObUYYGoMp