### PR TITLE
Make it possible to remove coupons from the cart

### DIFF
--- a/client/my-sites/checkout/cart/cart-coupon.jsx
+++ b/client/my-sites/checkout/cart/cart-coupon.jsx
@@ -56,9 +56,9 @@ export class CartCoupon extends React.Component {
 						args: { coupon: this.appliedCouponCode },
 					} ) }
 				</span>{' '}
-				<a href="" onClick={ this.clearCoupon } className="cart__remove-link">
+				<button onClick={ this.clearCoupon } className="button is-link cart__remove-link">
 					{ this.props.translate( 'Remove' ) }
-				</a>
+				</button>
 			</div>
 		);
 	}
@@ -70,9 +70,9 @@ export class CartCoupon extends React.Component {
 
 		return (
 			<div className="cart__coupon">
-				<a href="" onClick={ this.toggleCouponDetails } className="cart__toggle-link">
+				<button onClick={ this.toggleCouponDetails } className="button is-link cart__toggle-link">
 					{ this.props.translate( 'Have a coupon code?' ) }
-				</a>
+				</button>
 
 				{ this.renderCouponForm() }
 			</div>

--- a/client/my-sites/checkout/cart/cart-coupon.jsx
+++ b/client/my-sites/checkout/cart/cart-coupon.jsx
@@ -15,18 +15,15 @@ import Button from 'components/button';
 import analytics from 'lib/analytics';
 import { applyCoupon } from 'lib/upgrades/actions';
 
-class CartCoupon extends React.Component {
+export class CartCoupon extends React.Component {
 	static displayName = 'CartCoupon';
 
 	constructor( props ) {
 		super( props );
-		let coupon = props.cart.coupon,
-			cartHadCouponBeforeMount = Boolean( props.cart.coupon );
 
 		this.state = {
-			isCouponFormShowing: cartHadCouponBeforeMount,
-			hasSubmittedCoupon: cartHadCouponBeforeMount,
-			couponInputValue: coupon,
+			isCouponFormShowing: false,
+			couponInputValue: this.appliedCouponCode,
 			userChangedCoupon: false,
 		};
 	}
@@ -35,6 +32,79 @@ class CartCoupon extends React.Component {
 		if ( ! this.state.userChangedCoupon ) {
 			this.setState( { couponInputValue: nextProps.cart.coupon } );
 		}
+	}
+
+	render() {
+		if ( this.appliedCouponCode ) {
+			return this.renderAppliedCoupon();
+		}
+
+		return this.renderApplyCouponUI();
+	}
+
+	get appliedCouponCode() {
+		return this.props.cart.is_coupon_applied && this.props.cart.coupon;
+	}
+
+	renderAppliedCoupon() {
+		return (
+			<div className="cart-coupon">
+				<span className="cart__details">
+					{ this.props.translate( 'Coupon applied: %(coupon)s', {
+						args: { coupon: this.appliedCouponCode },
+					} ) }
+				</span>{' '}
+				<a href="" onClick={ this.clearCoupon } className="cart__remove-link">
+					{ this.props.translate( 'Remove' ) }
+				</a>
+			</div>
+		);
+	}
+
+	renderApplyCouponUI() {
+		if ( this.props.cart.total_cost === 0 ) {
+			return;
+		}
+
+		return (
+			<div className="cart-coupon">
+				<a href="" onClick={ this.toggleCouponDetails } className="cart__toggle-link">
+					{ this.props.translate( 'Have a coupon code?' ) }
+				</a>
+
+				{ this.renderCouponForm() }
+			</div>
+		);
+	}
+
+	renderCouponForm = () => {
+		if ( ! this.state.isCouponFormShowing ) {
+			return;
+		}
+
+		return (
+			<form onSubmit={ this.applyCoupon } className={ 'cart__form' }>
+				<input
+					type="text"
+					disabled={ this.isSubmitting }
+					placeholder={ this.props.translate( 'Enter Coupon Code', { textOnly: true } ) }
+					onChange={ this.handleCouponInputChange }
+					value={ this.state.couponInputValue }
+					autoFocus // eslint-disable-line jsx-a11y/no-autofocus
+				/>
+				<Button
+					type="submit"
+					disabled={ isEmpty( trim( this.state.couponInputValue ) ) }
+					busy={ this.isSubmitting }
+				>
+					{ this.props.translate( 'Apply' ) }
+				</Button>
+			</form>
+		);
+	};
+
+	get isSubmitting() {
+		return ! this.props.cart.is_coupon_applied && this.props.cart.coupon;
 	}
 
 	toggleCouponDetails = event => {
@@ -49,75 +119,38 @@ class CartCoupon extends React.Component {
 		}
 	};
 
+	clearCoupon = event => {
+		event.preventDefault();
+		this.setState(
+			{
+				couponInputValue: '',
+				isCouponFormShowing: false,
+			},
+			() => {
+				this.applyCoupon( event );
+			}
+		);
+	};
+
 	applyCoupon = event => {
 		event.preventDefault();
+		if ( this.isSubmitting ) {
+			return;
+		}
 
 		analytics.tracks.recordEvent( 'calypso_checkout_coupon_submit', {
 			coupon_code: this.state.couponInputValue,
 		} );
 
-		this.setState( {
-			userChangedCoupon: false,
-			hasSubmittedCoupon: true,
-		} );
 		applyCoupon( this.state.couponInputValue );
 	};
 
-	handleCouponInput = event => {
+	handleCouponInputChange = event => {
 		this.setState( {
 			userChangedCoupon: true,
 			couponInputValue: event.target.value,
 		} );
 	};
-
-	getToggleLink = () => {
-		if ( this.props.cart.total_cost === 0 ) {
-			return;
-		}
-
-		if ( this.state.hasSubmittedCoupon ) {
-			return;
-		}
-
-		return (
-			<a href="" onClick={ this.toggleCouponDetails }>
-				{ this.props.translate( 'Have a coupon code?' ) }
-			</a>
-		);
-	};
-
-	getCouponForm = () => {
-		if ( ! this.state.isCouponFormShowing ) {
-			return;
-		}
-
-		if ( this.state.hasSubmittedCoupon ) {
-			return;
-		}
-
-		return (
-			<form onSubmit={ this.applyCoupon }>
-				<input
-					type="text"
-					placeholder={ this.props.translate( 'Enter Coupon Code', { textOnly: true } ) }
-					onChange={ this.handleCouponInput }
-					value={ this.state.couponInputValue }
-				/>
-				<Button type="submit" disabled={ isEmpty( trim( this.state.couponInputValue ) ) }>
-					{ this.props.translate( 'Apply' ) }
-				</Button>
-			</form>
-		);
-	};
-
-	render() {
-		return (
-			<div className="cart-coupon">
-				{ this.getToggleLink() }
-				{ this.getCouponForm() }
-			</div>
-		);
-	}
 }
 
 export default localize( CartCoupon );

--- a/client/my-sites/checkout/cart/cart-coupon.jsx
+++ b/client/my-sites/checkout/cart/cart-coupon.jsx
@@ -43,7 +43,9 @@ export class CartCoupon extends React.Component {
 	}
 
 	get appliedCouponCode() {
-		return this.props.cart.is_coupon_applied && this.props.cart.coupon;
+		return this.props.cart.is_coupon_applied && this.props.cart.coupon
+			? this.props.cart.coupon
+			: null;
 	}
 
 	renderAppliedCoupon() {
@@ -53,7 +55,7 @@ export class CartCoupon extends React.Component {
 					{ this.props.translate( 'Coupon applied: %(coupon)s', {
 						args: { coupon: this.appliedCouponCode },
 					} ) }
-				</span>{' '}
+				</span>{ ' ' }
 				<a href="" onClick={ this.clearCoupon } className="cart__remove-link">
 					{ this.props.translate( 'Remove' ) }
 				</a>
@@ -104,7 +106,7 @@ export class CartCoupon extends React.Component {
 	};
 
 	get isSubmitting() {
-		return ! this.props.cart.is_coupon_applied && this.props.cart.coupon;
+		return ! this.props.cart.is_coupon_applied && this.props.cart.coupon ? true : false;
 	}
 
 	toggleCouponDetails = event => {
@@ -128,7 +130,7 @@ export class CartCoupon extends React.Component {
 			},
 			() => {
 				this.applyCoupon( event );
-			}
+			},
 		);
 	};
 

--- a/client/my-sites/checkout/cart/cart-coupon.jsx
+++ b/client/my-sites/checkout/cart/cart-coupon.jsx
@@ -50,12 +50,12 @@ export class CartCoupon extends React.Component {
 
 	renderAppliedCoupon() {
 		return (
-			<div className="cart-coupon">
+			<div className="cart__coupon">
 				<span className="cart__details">
 					{ this.props.translate( 'Coupon applied: %(coupon)s', {
 						args: { coupon: this.appliedCouponCode },
 					} ) }
-				</span>{ ' ' }
+				</span>{' '}
 				<a href="" onClick={ this.clearCoupon } className="cart__remove-link">
 					{ this.props.translate( 'Remove' ) }
 				</a>
@@ -69,7 +69,7 @@ export class CartCoupon extends React.Component {
 		}
 
 		return (
-			<div className="cart-coupon">
+			<div className="cart__coupon">
 				<a href="" onClick={ this.toggleCouponDetails } className="cart__toggle-link">
 					{ this.props.translate( 'Have a coupon code?' ) }
 				</a>
@@ -130,7 +130,7 @@ export class CartCoupon extends React.Component {
 			},
 			() => {
 				this.applyCoupon( event );
-			},
+			}
 		);
 	};
 

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -119,7 +119,7 @@
 		}
 	}
 
-	.cart-coupon {
+	.cart__coupon {
 		font-size: 11px;
 
 		@include breakpoint( "<660px" ) {

--- a/client/my-sites/checkout/cart/test/cart-coupon.js
+++ b/client/my-sites/checkout/cart/test/cart-coupon.js
@@ -44,8 +44,8 @@ describe( 'cart-coupon', () => {
 
 	describe( 'General behavior', () => {
 		test( 'Should not blow up', () => {
-			const component = shallow( <CartCoupon { ...props } cart={ cart }/> );
-			expect( component.find( '.cart-coupon' ).length ).toBe( 1 );
+			const component = shallow( <CartCoupon { ...props } cart={ cart } /> );
+			expect( component.find( '.cart__coupon' ).length ).toBe( 1 );
 		} );
 
 		test( 'Should render only coupon code link when there is no coupon', () => {
@@ -57,7 +57,7 @@ describe( 'cart-coupon', () => {
 						is_coupon_applied: false,
 						coupon: '',
 					} }
-				/>,
+				/>
 			);
 			expect( component.find( '.cart__toggle-link' ).length ).toBe( 1 );
 			expect( component.find( '.cart__form' ).length ).toBe( 0 );
@@ -72,7 +72,7 @@ describe( 'cart-coupon', () => {
 						is_coupon_applied: false,
 						coupon: '',
 					} }
-				/>,
+				/>
 			);
 			component.find( '.cart__toggle-link' ).simulate( 'click', event );
 			expect( component.find( '.cart__toggle-link' ).length ).toBe( 1 );
@@ -88,7 +88,7 @@ describe( 'cart-coupon', () => {
 						is_coupon_applied: false,
 						coupon: '',
 					} }
-				/>,
+				/>
 			);
 			component.find( '.cart__toggle-link' ).simulate( 'click', event );
 			component.find( '.cart__toggle-link' ).simulate( 'click', event );
@@ -105,7 +105,7 @@ describe( 'cart-coupon', () => {
 						is_coupon_applied: false,
 						coupon: '',
 					} }
-				/>,
+				/>
 			);
 			applyCoupon.mockReset();
 			component.find( '.cart__toggle-link' ).simulate( 'click', event );
@@ -126,7 +126,7 @@ describe( 'cart-coupon', () => {
 						is_coupon_applied: false,
 						coupon: '',
 					} }
-				/>,
+				/>
 			);
 			applyCoupon.mockReset();
 			component.find( '.cart__toggle-link' ).simulate( 'click', event );
@@ -154,7 +154,7 @@ describe( 'cart-coupon', () => {
 						is_coupon_applied: true,
 						coupon: 'TEST10',
 					} }
-				/>,
+				/>
 			);
 			expect( component.find( '.cart__toggle-link' ).length ).toBe( 0 );
 			expect( component.find( '.cart__form' ).length ).toBe( 0 );
@@ -171,7 +171,7 @@ describe( 'cart-coupon', () => {
 						is_coupon_applied: true,
 						coupon: 'TEST10',
 					} }
-				/>,
+				/>
 			);
 			applyCoupon.mockReset();
 			component.find( '.cart__remove-link' ).simulate( 'click', event );

--- a/client/my-sites/checkout/cart/test/cart-coupon.js
+++ b/client/my-sites/checkout/cart/test/cart-coupon.js
@@ -42,139 +42,217 @@ describe( 'cart-coupon', () => {
 		coupon: '',
 	};
 
-	test( 'Should not blow up', () => {
-		const component = shallow( <CartCoupon { ...props } cart={ cart } /> );
-		expect( component.find( '.cart-coupon' ).length ).toBe( 1 );
-	} );
-
-	test( 'Should render only coupon code link when there is no coupon', () => {
-		const component = shallow(
-			<CartCoupon
-				{ ...props }
-				cart={ {
-					...cart,
-					is_coupon_applied: false,
-					coupon: '',
-				} }
-			/>
-		);
-		expect( component.find( '.cart__toggle-link' ).length ).toBe( 1 );
-		expect( component.find( '.cart__form' ).length ).toBe( 0 );
-	} );
-
-	test( 'Should show coupon form when toggle link is clicked', () => {
-		const component = shallow(
-			<CartCoupon
-				{ ...props }
-				cart={ {
-					...cart,
-					is_coupon_applied: false,
-					coupon: '',
-				} }
-			/>
-		);
-		component.find( '.cart__toggle-link' ).simulate( 'click', event );
-		expect( component.find( '.cart__toggle-link' ).length ).toBe( 1 );
-		expect( component.find( '.cart__form' ).length ).toBe( 1 );
-	} );
-
-	test( 'Should hide coupon form when toggle link is clicked twice', () => {
-		const component = shallow(
-			<CartCoupon
-				{ ...props }
-				cart={ {
-					...cart,
-					is_coupon_applied: false,
-					coupon: '',
-				} }
-			/>
-		);
-		component.find( '.cart__toggle-link' ).simulate( 'click', event );
-		component.find( '.cart__toggle-link' ).simulate( 'click', event );
-		expect( component.find( '.cart__toggle-link' ).length ).toBe( 1 );
-		expect( component.find( '.cart__form' ).length ).toBe( 0 );
-	} );
-
-	test( 'Should apply a coupon when form is submitted', () => {
-		const component = shallow(
-			<CartCoupon
-				{ ...props }
-				cart={ {
-					...cart,
-					is_coupon_applied: false,
-					coupon: '',
-				} }
-			/>
-		);
-		applyCoupon.mockReset();
-		component.find( '.cart__toggle-link' ).simulate( 'click', event );
-		component.setState( {
-			couponInputValue: 'CODE15',
+	describe( 'General behavior', () => {
+		test( 'Should not blow up', () => {
+			const component = shallow( <CartCoupon { ...props } cart={ cart }/> );
+			expect( component.find( '.cart-coupon' ).length ).toBe( 1 );
 		} );
-		component.find( '.cart__form' ).simulate( 'submit', event );
-		expect( applyCoupon.mock.calls.length ).toBe( 1 );
-		expect( applyCoupon.mock.calls[ 0 ][ 0 ] ).toBe( 'CODE15' );
+
+		test( 'Should render only coupon code link when there is no coupon', () => {
+			const component = shallow(
+				<CartCoupon
+					{ ...props }
+					cart={ {
+						...cart,
+						is_coupon_applied: false,
+						coupon: '',
+					} }
+				/>,
+			);
+			expect( component.find( '.cart__toggle-link' ).length ).toBe( 1 );
+			expect( component.find( '.cart__form' ).length ).toBe( 0 );
+		} );
+
+		test( 'Should show coupon form when toggle link is clicked', () => {
+			const component = shallow(
+				<CartCoupon
+					{ ...props }
+					cart={ {
+						...cart,
+						is_coupon_applied: false,
+						coupon: '',
+					} }
+				/>,
+			);
+			component.find( '.cart__toggle-link' ).simulate( 'click', event );
+			expect( component.find( '.cart__toggle-link' ).length ).toBe( 1 );
+			expect( component.find( '.cart__form' ).length ).toBe( 1 );
+		} );
+
+		test( 'Should hide coupon form when toggle link is clicked twice', () => {
+			const component = shallow(
+				<CartCoupon
+					{ ...props }
+					cart={ {
+						...cart,
+						is_coupon_applied: false,
+						coupon: '',
+					} }
+				/>,
+			);
+			component.find( '.cart__toggle-link' ).simulate( 'click', event );
+			component.find( '.cart__toggle-link' ).simulate( 'click', event );
+			expect( component.find( '.cart__toggle-link' ).length ).toBe( 1 );
+			expect( component.find( '.cart__form' ).length ).toBe( 0 );
+		} );
+
+		test( 'Should apply a coupon when form is submitted', () => {
+			const component = shallow(
+				<CartCoupon
+					{ ...props }
+					cart={ {
+						...cart,
+						is_coupon_applied: false,
+						coupon: '',
+					} }
+				/>,
+			);
+			applyCoupon.mockReset();
+			component.find( '.cart__toggle-link' ).simulate( 'click', event );
+			component.setState( {
+				couponInputValue: 'CODE15',
+			} );
+			component.find( '.cart__form' ).simulate( 'submit', event );
+			expect( applyCoupon.mock.calls.length ).toBe( 1 );
+			expect( applyCoupon.mock.calls[ 0 ][ 0 ] ).toBe( 'CODE15' );
+		} );
+
+		test( 'Should disallow submission when form is currently being submitted', () => {
+			const component = shallow(
+				<CartCoupon
+					{ ...props }
+					cart={ {
+						...cart,
+						is_coupon_applied: false,
+						coupon: '',
+					} }
+				/>,
+			);
+			applyCoupon.mockReset();
+			component.find( '.cart__toggle-link' ).simulate( 'click', event );
+			component.setState( {
+				couponInputValue: 'CODE15',
+			} );
+			component.find( '.cart__form' ).simulate( 'submit', event );
+			component.setProps( {
+				cart: {
+					...cart,
+					is_coupon_applied: false,
+					coupon: 'CODE15',
+				},
+			} );
+			component.find( '.cart__form' ).simulate( 'submit', event );
+			expect( applyCoupon.mock.calls.length ).toBe( 1 );
+		} );
+
+		test( 'Should show coupon details when there is a coupon', () => {
+			const component = shallow(
+				<CartCoupon
+					{ ...props }
+					cart={ {
+						...cart,
+						is_coupon_applied: true,
+						coupon: 'TEST10',
+					} }
+				/>,
+			);
+			expect( component.find( '.cart__toggle-link' ).length ).toBe( 0 );
+			expect( component.find( '.cart__form' ).length ).toBe( 0 );
+			expect( component.find( '.cart__details' ).length ).toBe( 1 );
+			expect( component.find( '.cart__remove-link' ).length ).toBe( 1 );
+		} );
+
+		test( 'Should remove a coupon when "remove" link is clicked', () => {
+			const component = shallow(
+				<CartCoupon
+					{ ...props }
+					cart={ {
+						...cart,
+						is_coupon_applied: true,
+						coupon: 'TEST10',
+					} }
+				/>,
+			);
+			applyCoupon.mockReset();
+			component.find( '.cart__remove-link' ).simulate( 'click', event );
+			expect( applyCoupon.mock.calls.length ).toBe( 1 );
+			expect( applyCoupon.mock.calls[ 0 ][ 0 ] ).toBe( '' );
+		} );
 	} );
 
-	test( 'Should disallow submission when form is currently being submitted', () => {
-		const component = shallow(
-			<CartCoupon
-				{ ...props }
-				cart={ {
+	describe( 'isSubmitting', () => {
+		test( 'Should return true if cart suggests the form is being submitted', () => {
+			const component = new CartCoupon( {
+				...props,
+				cart: {
+					...cart,
+					is_coupon_applied: false,
+					coupon: 'TEST10',
+				},
+			} );
+			expect( component.isSubmitting ).toBe( true );
+		} );
+
+		test( 'Should return false if there is no coupon in cart', () => {
+			const component = new CartCoupon( {
+				...props,
+				cart: {
 					...cart,
 					is_coupon_applied: false,
 					coupon: '',
-				} }
-			/>
-		);
-		applyCoupon.mockReset();
-		component.find( '.cart__toggle-link' ).simulate( 'click', event );
-		component.setState( {
-			couponInputValue: 'CODE15',
+				},
+			} );
+			expect( component.isSubmitting ).toBe( false );
 		} );
-		component.find( '.cart__form' ).simulate( 'submit', event );
-		component.setProps( {
-			cart: {
-				...cart,
-				is_coupon_applied: false,
-				coupon: 'CODE15',
-			},
+
+		test( 'Should return false if coupon is applied', () => {
+			const component = new CartCoupon( {
+				...props,
+				cart: {
+					...cart,
+					is_coupon_applied: true,
+					coupon: '',
+				},
+			} );
+			expect( component.isSubmitting ).toBe( false );
 		} );
-		component.find( '.cart__form' ).simulate( 'submit', event );
-		expect( applyCoupon.mock.calls.length ).toBe( 1 );
 	} );
 
-	test( 'Should show coupon details when there is a coupon', () => {
-		const component = shallow(
-			<CartCoupon
-				{ ...props }
-				cart={ {
+	describe( 'appliedCouponCode', () => {
+		test( 'Should return coupon code from cart when that code is applied', () => {
+			const component = new CartCoupon( {
+				...props,
+				cart: {
 					...cart,
 					is_coupon_applied: true,
 					coupon: 'TEST10',
-				} }
-			/>
-		);
-		expect( component.find( '.cart__toggle-link' ).length ).toBe( 0 );
-		expect( component.find( '.cart__form' ).length ).toBe( 0 );
-		expect( component.find( '.cart__details' ).length ).toBe( 1 );
-		expect( component.find( '.cart__remove-link' ).length ).toBe( 1 );
-	} );
+				},
+			} );
+			expect( component.appliedCouponCode ).toBe( 'TEST10' );
+		} );
 
-	test( 'Should remove a coupon when "remove" link is clicked', () => {
-		const component = shallow(
-			<CartCoupon
-				{ ...props }
-				cart={ {
+		test( 'Should return null when that no code is applied', () => {
+			const component = new CartCoupon( {
+				...props,
+				cart: {
+					...cart,
+					is_coupon_applied: false,
+					coupon: 'TEST10',
+				},
+			} );
+			expect( component.appliedCouponCode ).toBe( null );
+		} );
+
+		test( 'Should return null when coupon code is empty', () => {
+			const component = new CartCoupon( {
+				...props,
+				cart: {
 					...cart,
 					is_coupon_applied: true,
-					coupon: 'TEST10',
-				} }
-			/>
-		);
-		applyCoupon.mockReset();
-		component.find( '.cart__remove-link' ).simulate( 'click', event );
-		expect( applyCoupon.mock.calls.length ).toBe( 1 );
-		expect( applyCoupon.mock.calls[ 0 ][ 0 ] ).toBe( '' );
+					coupon: '',
+				},
+			} );
+			expect( component.appliedCouponCode ).toBe( null );
+		} );
 	} );
 } );

--- a/client/my-sites/checkout/cart/test/cart-coupon.js
+++ b/client/my-sites/checkout/cart/test/cart-coupon.js
@@ -1,0 +1,180 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import { identity } from 'lodash';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { CartCoupon } from '../cart-coupon';
+import { applyCoupon } from 'lib/upgrades/actions';
+
+jest.mock( 'lib/upgrades/actions', () => ( {
+	applyCoupon: jest.fn( () => {} ),
+} ) );
+
+jest.mock( 'lib/analytics', () => ( {
+	ga: {
+		recordEvent: () => {},
+	},
+	tracks: {
+		recordEvent: () => {},
+	},
+} ) );
+
+const props = {
+	translate: identity,
+};
+
+const event = {
+	preventDefault: identity,
+};
+
+describe( 'cart-coupon', () => {
+	const cart = {
+		is_coupon_applied: false,
+		coupon: '',
+	};
+
+	test( 'Should not blow up', () => {
+		const component = shallow( <CartCoupon { ...props } cart={ cart } /> );
+		expect( component.find( '.cart-coupon' ).length ).toBe( 1 );
+	} );
+
+	test( 'Should render only coupon code link when there is no coupon', () => {
+		const component = shallow(
+			<CartCoupon
+				{ ...props }
+				cart={ {
+					...cart,
+					is_coupon_applied: false,
+					coupon: '',
+				} }
+			/>
+		);
+		expect( component.find( '.cart__toggle-link' ).length ).toBe( 1 );
+		expect( component.find( '.cart__form' ).length ).toBe( 0 );
+	} );
+
+	test( 'Should show coupon form when toggle link is clicked', () => {
+		const component = shallow(
+			<CartCoupon
+				{ ...props }
+				cart={ {
+					...cart,
+					is_coupon_applied: false,
+					coupon: '',
+				} }
+			/>
+		);
+		component.find( '.cart__toggle-link' ).simulate( 'click', event );
+		expect( component.find( '.cart__toggle-link' ).length ).toBe( 1 );
+		expect( component.find( '.cart__form' ).length ).toBe( 1 );
+	} );
+
+	test( 'Should hide coupon form when toggle link is clicked twice', () => {
+		const component = shallow(
+			<CartCoupon
+				{ ...props }
+				cart={ {
+					...cart,
+					is_coupon_applied: false,
+					coupon: '',
+				} }
+			/>
+		);
+		component.find( '.cart__toggle-link' ).simulate( 'click', event );
+		component.find( '.cart__toggle-link' ).simulate( 'click', event );
+		expect( component.find( '.cart__toggle-link' ).length ).toBe( 1 );
+		expect( component.find( '.cart__form' ).length ).toBe( 0 );
+	} );
+
+	test( 'Should apply a coupon when form is submitted', () => {
+		const component = shallow(
+			<CartCoupon
+				{ ...props }
+				cart={ {
+					...cart,
+					is_coupon_applied: false,
+					coupon: '',
+				} }
+			/>
+		);
+		applyCoupon.mockReset();
+		component.find( '.cart__toggle-link' ).simulate( 'click', event );
+		component.setState( {
+			couponInputValue: 'CODE15',
+		} );
+		component.find( '.cart__form' ).simulate( 'submit', event );
+		expect( applyCoupon.mock.calls.length ).toBe( 1 );
+		expect( applyCoupon.mock.calls[ 0 ][ 0 ] ).toBe( 'CODE15' );
+	} );
+
+	test( 'Should disallow submission when form is currently being submitted', () => {
+		const component = shallow(
+			<CartCoupon
+				{ ...props }
+				cart={ {
+					...cart,
+					is_coupon_applied: false,
+					coupon: '',
+				} }
+			/>
+		);
+		applyCoupon.mockReset();
+		component.find( '.cart__toggle-link' ).simulate( 'click', event );
+		component.setState( {
+			couponInputValue: 'CODE15',
+		} );
+		component.find( '.cart__form' ).simulate( 'submit', event );
+		component.setProps( {
+			cart: {
+				...cart,
+				is_coupon_applied: false,
+				coupon: 'CODE15',
+			},
+		} );
+		component.find( '.cart__form' ).simulate( 'submit', event );
+		expect( applyCoupon.mock.calls.length ).toBe( 1 );
+	} );
+
+	test( 'Should show coupon details when there is a coupon', () => {
+		const component = shallow(
+			<CartCoupon
+				{ ...props }
+				cart={ {
+					...cart,
+					is_coupon_applied: true,
+					coupon: 'TEST10',
+				} }
+			/>
+		);
+		expect( component.find( '.cart__toggle-link' ).length ).toBe( 0 );
+		expect( component.find( '.cart__form' ).length ).toBe( 0 );
+		expect( component.find( '.cart__details' ).length ).toBe( 1 );
+		expect( component.find( '.cart__remove-link' ).length ).toBe( 1 );
+	} );
+
+	test( 'Should remove a coupon when "remove" link is clicked', () => {
+		const component = shallow(
+			<CartCoupon
+				{ ...props }
+				cart={ {
+					...cart,
+					is_coupon_applied: true,
+					coupon: 'TEST10',
+				} }
+			/>
+		);
+		applyCoupon.mockReset();
+		component.find( '.cart__remove-link' ).simulate( 'click', event );
+		expect( applyCoupon.mock.calls.length ).toBe( 1 );
+		expect( applyCoupon.mock.calls[ 0 ][ 0 ] ).toBe( '' );
+	} );
+} );

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -254,7 +254,7 @@
 		}
 	}
 
-	.cart-coupon {
+	.cart__coupon {
 		cursor: pointer;
 		display: none;
 		font-size: 14px;


### PR DESCRIPTION
This PR is part of effort to improve everything coupons-related. We make it possible to remove a coupon from the cart after it was applied - which previously was impossible.

**Test plan:**

1. Go to checkout page
1. Click on "Have a coupon code?":

![](https://cdn-pro.dprcdn.net/files/acc_631815/CQMWXI)

1. A coupon form should appear like this:

![](https://cdn-pro.dprcdn.net/files/acc_631815/FN2LAw)

1. Enter an invalid coupon like "CODE20", coupon form should enter the "loading" state like this and then the error should appear:

<img width="273" alt="zrzut ekranu 2018-06-04 o 14 20 46" src="https://user-images.githubusercontent.com/205419/40917159-8522bbca-6802-11e8-855f-77936045088b.png">

1. Find a valid coupon code in network admin and use it.
1. A coupon should be applied and the form should look like this now:

<img width="292" alt="zrzut ekranu 2018-06-04 o 14 24 14" src="https://user-images.githubusercontent.com/205419/40917290-fb374bc8-6802-11e8-8884-63c88072c9bd.png">

1. Click a "remove" link, coupon should be removed and the summary should look like this again:

<img width="289" alt="zrzut ekranu 2018-06-04 o 14 22 21" src="https://user-images.githubusercontent.com/205419/40917207-b4b93b7a-6802-11e8-9435-cf69b0b1b0e7.png">
