### PR TITLE
Signup: Remove last unnecessary Tile href

### DIFF
--- a/client/signup/steps/design-type/index.jsx
+++ b/client/signup/steps/design-type/index.jsx
@@ -77,7 +77,6 @@ export class DesignTypeStep extends Component {
 			<Tile
 				buttonLabel={ choice.label }
 				description={ choice.description }
-				href={ `#${ choice.type }` }
 				image={ choice.image }
 				key={ choice.type }
 				onClick={ choiceHandlers[ choice.type ] }


### PR DESCRIPTION
This is a follow-up to https://github.com/Automattic/wp-calypso/pull/24979#discussion_r192074387 and removes the last `href` from the signup step `Tile`s.

To test:
* Follow the test instructions from #24979
* Verify there are no visual/behavioral changes