### PR TITLE
Ad Tracking: add a debug statement for `isAdTrackingAllowed`

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -415,7 +415,10 @@ async function loadTrackingScripts( callback ) {
  * @returns {Boolean} Is ad tracking is allowed?
  */
 function isAdTrackingAllowed() {
-	return config.isEnabled( 'ad-tracking' ) && ! shouldSkipAds() && mayWeTrackCurrentUserGdpr();
+	const result =
+		config.isEnabled( 'ad-tracking' ) && ! shouldSkipAds() && mayWeTrackCurrentUserGdpr();
+	debug( 'isAdTrackingAllowed:', result );
+	return result;
 }
 
 /**


### PR DESCRIPTION
We don't show the GDPR banner in non-production environments, so if we don't have the cookie set and work in a development environment, we never have a chance to approve tracking and therefore test it. This PR adds a debug statement to the ad tracking code so that it's easier to notice that and why we're not triggering any ad tracking code under those circumstances. 

To test:
- Load Calypso and make sure the debug statement is triggered properly. 