### PR TITLE
Purchases: Allow no selectedSite for cancel purchase form

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -37,7 +37,7 @@ class CancelPurchaseForm extends React.Component {
 		defaultContent: PropTypes.node.isRequired,
 		onInputChange: PropTypes.func.isRequired,
 		purchase: PropTypes.object.isRequired,
-		selectedSite: PropTypes.object.isRequired,
+		selectedSite: PropTypes.shape( { slug: PropTypes.string.isRequired } ),
 		showSurvey: PropTypes.bool.isRequired,
 		surveyStep: PropTypes.string.isRequired,
 		translate: PropTypes.func,
@@ -267,24 +267,29 @@ class CancelPurchaseForm extends React.Component {
 	};
 
 	openConcierge = () => {
+		if ( ! this.props.selectedSite ) {
+			return;
+		}
 		this.props.clickConcierge();
 		return window.open( `/me/concierge/${ this.props.selectedSite.slug }/book` );
 	};
 
 	renderConciergeOffer = () => {
-		const { translate } = this.props;
+		const { selectedSite, translate } = this.props;
 		return (
-			<FormFieldset>
-				<p>
-					{ translate(
-						'Schedule a 30 minute orientation with one of our Happiness Engineers. ' +
-							"We'll help you to setup your site and answer any questions you have!"
-					) }
-				</p>
-				<Button onClick={ this.openConcierge } primary>
-					{ translate( 'Schedule a session' ) }
-				</Button>
-			</FormFieldset>
+			selectedSite && (
+				<FormFieldset>
+					<p>
+						{ translate(
+							'Schedule a 30 minute orientation with one of our Happiness Engineers. ' +
+								"We'll help you to setup your site and answer any questions you have!"
+						) }
+					</p>
+					<Button onClick={ this.openConcierge } primary>
+						{ translate( 'Schedule a session' ) }
+					</Button>
+				</FormFieldset>
+			)
 		);
 	};
 


### PR DESCRIPTION
Make the cancel-purchase-form safe with no selected site.

Removing the requirement for a selected site is part of the effort to allow management of purchases for disconnected sites.

## Testing

I don't believe there's a good way to test this. Review the code and ensure that the component can safely be used with a `null` `selectedSite`.