### PR TITLE
Google My Business: Update SEO url on Select Business Type page

### DIFF
--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -139,7 +139,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 
 		const seoHelpLink = siteIsJetpack
 			? 'https://jetpack.com/support/seo-tools/'
-			: 'https://en.blog.wordpress.com/2013/03/22/seo-on-wordpress-com/';
+			: 'https://blog.wordpress.com/seo/';
 
 		return (
 			<ActionCard


### PR DESCRIPTION
This very simple pull request updates the url of the `Learn More about SEO` button on `Select Business Type` page in order to redirect users to a more appropriate page:

<img width="470" alt="screenshot" src="https://user-images.githubusercontent.com/594356/40931051-dd155f96-6829-11e8-9005-42f4120ed63b.png">

#### Testing instructions

You should test with a site eligible to Google My Business but which has never been connected:

1. Run `git checkout update/google-my-business-seo-url` and start your server, or open a [live branch](https://calypso.live/?branch=update/google-my-business-seo-url)
2. Open the [`Stats` page](http://calypso.localhost:3000/stats)
3. Clicks the `Start Now` button in the nudge
4. Clicks the `Learn More about SEO` button
5. Asserts that https://en.blog.wordpress.com/seo/ was opened in a new tab

#### Additional notes

The original requirement was to use https://en.blog.wordpress.com/seo/ but it obviously displays content in English. Using https://blog.wordpress.com/seo/ is not really fixing this, as it always redirects to the aforementioned url even if the `accept-Language` HTTP header defines another primary language. It's still a step in the right direction though, but we may want to better handle non-English languages in the future server-side (e.g. there accessing https://fr.blog.wordpress.com/seo/ currently redirects you to https://fr.blog.wordpress.com/2016/07/15/seo-settings-panel/).

#### Reviews

- [ ] Code
- [ ] Product