### PR TITLE
Store: Change sidebar back from chevron to cross

### DIFF
--- a/client/extensions/woocommerce/store-sidebar/store-ground-control.js
+++ b/client/extensions/woocommerce/store-sidebar/store-ground-control.js
@@ -26,9 +26,9 @@ const StoreGroundControl = ( { site, translate } ) => {
 				className="store-sidebar__ground-control-back"
 				disabled={ isPlaceholder }
 				href={ backLink }
-				aria-label={ translate( 'Go back' ) }
+				aria-label={ translate( 'Close Store' ) }
 			>
-				<Gridicon icon="chevron-left" />
+				<Gridicon icon="cross" />
 			</Button>
 			<div className="store-sidebar__ground-control-site">
 				<Site site={ site } indicator={ false } homeLink externalLink />


### PR DESCRIPTION
This branch is an attempt to fix #24488 

Currently the Store sidebar has a left chevron at the top, which when clicked, returns the user to their Site Stats page ( aka "Top Level" of Calypso ). In various contexts in Store, this button has been confused for a back button.

The solution proposed by @kellychoffman that is implemented here is to change the chevron to a cross to show that the action will close out of the store:

__Before__
![before](https://user-images.githubusercontent.com/22080/40944638-584ac22a-680a-11e8-8326-0fa7b0c6e2be.png)

__After__
![after](https://user-images.githubusercontent.com/22080/40944646-5e51bd2c-680a-11e8-8382-c1d9d7e66fec.png)

__To Test__
Open up a Store, and note the gridicon at the top of the sidebar has changed.

The only oddness that I can see being introduced here is how things look on small viewports now. I guess it is really no more confusing than the nested chevron that happens right now in small viewports, but figured I'd mention it:

![small-viewport](https://user-images.githubusercontent.com/22080/40944675-80d1af74-680a-11e8-9774-9bbfcddc7a2f.gif)
