### PR TITLE
Store: Fix error when saving product with categories containing escaped characters 

### DIFF
--- a/client/extensions/woocommerce/app/products/products-list-row.js
+++ b/client/extensions/woocommerce/app/products/products-list-row.js
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { unescape } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,7 +23,7 @@ const ProductsListRow = ( { site, product } ) => {
 	const categoryNames =
 		product.categories &&
 		product.categories.map( function( category ) {
-			return category.name;
+			return unescape( category.name );
 		} );
 
 	const renderCategories = () => (

--- a/client/extensions/woocommerce/state/data-layer/product-categories/index.js
+++ b/client/extensions/woocommerce/state/data-layer/product-categories/index.js
@@ -26,11 +26,10 @@ import {
 	WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_SUCCESS,
 	WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_FAILURE,
 } from 'woocommerce/state/action-types';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { DEFAULT_QUERY } from 'woocommerce/state/sites/product-categories/utils';
 import request from 'woocommerce/state/sites/http-request';
-
-// @TODO Move these handlers to product-categories/handlers.js
+import { verifyResponseHasValidCategories } from 'woocommerce/state/data-layer/utils';
 
 export function handleProductCategoryCreate( store, action ) {
 	const { siteId, category, successAction, failureAction } = action;
@@ -124,32 +123,17 @@ export function handleProductCategoryDeleteSuccess( { dispatch }, action, catego
 	} );
 }
 
-export function handleProductCategoriesRequest( { dispatch }, action ) {
+export const fetch = action => {
 	const { siteId, query } = action;
 	const requestQuery = { ...DEFAULT_QUERY, ...query };
 	const queryString = stringify( omitBy( requestQuery, val => '' === val ) );
 
-	dispatch( request( siteId, action ).getWithHeaders( `products/categories?${ queryString }` ) );
+	return request( siteId, action ).getWithHeaders( `products/categories?${ queryString }` );
 }
 
-export function handleProductCategoriesSuccess( { dispatch }, action, { data } ) {
+export const onFetchSuccess = ( action, { data } ) => dispatch => {
 	const { siteId, query } = action;
-	const { headers, body, status } = data;
-
-	// handleProductCategoriesRequest uses &_envelope
-	// ( https://developer.wordpress.org/rest-api/using-the-rest-api/global-parameters/#_envelope )
-	// so that we can get the X-WP-Total header back from the end-site. This means we will always get a 200
-	// status back, and the real status of the request will be stored in the response. This checks the real status.
-	if ( status !== 200 || ! isValidCategoriesArray( body ) ) {
-		dispatch( {
-			type: WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_FAILURE,
-			siteId,
-			error: 'Invalid Categories Array',
-			query,
-		} );
-		dispatch( setError( siteId, action, { message: 'Invalid Categories Array', body } ) );
-		return;
-	}
+	const { headers, body } = data;
 
 	const total = headers[ 'X-WP-Total' ];
 	const totalPages = headers[ 'X-WP-TotalPages' ];
@@ -172,7 +156,7 @@ export function handleProductCategoriesSuccess( { dispatch }, action, { data } )
 	}
 }
 
-export function handleProductCategoriesError( { dispatch }, action, error ) {
+export const onFetchError = ( action, error ) => dispatch => {
 	const { siteId, query } = action;
 
 	dispatch( {
@@ -185,28 +169,6 @@ export function handleProductCategoriesError( { dispatch }, action, error ) {
 	dispatch( setError( siteId, action, error ) );
 }
 
-function isValidCategoriesArray( categories ) {
-	for ( let i = 0; i < categories.length; i++ ) {
-		if ( ! isValidProductCategory( categories[ i ] ) ) {
-			// Short-circuit the loop and return now.
-			return false;
-		}
-	}
-	return true;
-}
-
-function isValidProductCategory( category ) {
-	return (
-		category &&
-		category.id &&
-		'number' === typeof category.id &&
-		category.name &&
-		'string' === typeof category.name &&
-		category.slug &&
-		'string' === typeof category.slug
-	);
-}
-
 export default {
 	[ WOOCOMMERCE_PRODUCT_CATEGORY_CREATE ]: [ handleProductCategoryCreate ],
 	[ WOOCOMMERCE_PRODUCT_CATEGORY_DELETE ]: [
@@ -215,10 +177,11 @@ export default {
 	],
 	[ WOOCOMMERCE_PRODUCT_CATEGORY_UPDATE ]: [ handleProductCategoryUpdate ],
 	[ WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST ]: [
-		dispatchRequest(
-			handleProductCategoriesRequest,
-			handleProductCategoriesSuccess,
-			handleProductCategoriesError
-		),
+		dispatchRequestEx( {
+			fetch,
+			onSuccess: onFetchSuccess,
+			onError: onFetchError,
+			fromApi: verifyResponseHasValidCategories,
+		} ),
 	],
 };

--- a/client/extensions/woocommerce/state/data-layer/product-categories/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/product-categories/test/index.js
@@ -15,9 +15,9 @@ import {
 	handleProductCategoryDelete,
 	handleProductCategoryDeleteSuccess,
 	handleProductCategoryUpdate,
-	handleProductCategoriesRequest,
-	handleProductCategoriesSuccess,
-	handleProductCategoriesError,
+	fetch,
+	onFetchSuccess,
+	onFetchError,
 } from '../';
 import {
 	WOOCOMMERCE_API_REQUEST,
@@ -32,40 +32,37 @@ import {
 	updateProductCategory,
 	deleteProductCategory,
 } from 'woocommerce/state/sites/product-categories/actions';
-import { WPCOM_HTTP_REQUEST } from 'state/action-types';
+import { http } from 'state/data-layer/wpcom-http/actions';
 
 describe( 'handlers', () => {
-	describe( '#handleProductCategoriesRequest()', () => {
+	describe( '#fetch()', () => {
 		test( 'should dispatch a get action', () => {
 			const siteId = '123';
-			const dispatch = spy();
 			const action = {
 				type: WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST,
 				siteId,
 				query: {},
 			};
-			handleProductCategoriesRequest( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledWith(
-				match( {
-					type: WPCOM_HTTP_REQUEST,
+			const result = fetch( action );
+			expect( result ).to.eql(
+				http( {
 					method: 'GET',
-					path: `/jetpack-blogs/${ siteId }/rest-api/`,
+					path: '/jetpack-blogs/123/rest-api/',
+					apiVersion: '1.1',
+					body: null,
 					query: {
-						path: '/wc/v3/products/categories&page=1&per_page=100&_envelope&_method=GET',
 						json: true,
-						apiVersion: '1.1',
+						path: '/wc/v3/products/categories&page=1&per_page=100&_envelope&_method=GET',
 					},
-				} )
+				}, action )
 			);
 		} );
 	} );
 
-	describe( '#handleProductCategoriesSuccess()', () => {
+	describe( '#onFetchSuccess()', () => {
 		test( 'should dispatch a success action with product category information when request completes', () => {
 			const siteId = '123';
-			const store = {
-				dispatch: spy(),
-			};
+			const dispatch = spy();
 
 			const cats = [
 				{
@@ -93,9 +90,9 @@ describe( 'handlers', () => {
 				siteId,
 				query: {},
 			};
-			handleProductCategoriesSuccess( store, action, response );
+			onFetchSuccess( action, response )( dispatch );
 
-			expect( store.dispatch ).calledWith( {
+			expect( dispatch ).calledWith( {
 				type: WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_SUCCESS,
 				siteId,
 				data: cats,
@@ -104,78 +101,20 @@ describe( 'handlers', () => {
 				query: {},
 			} );
 		} );
-		test( 'should dispatch with an error if the envelope response is not 200', () => {
-			const siteId = '123';
-			const store = {
-				dispatch: spy(),
-			};
-
-			const response = {
-				data: {
-					body: {
-						message: 'No route was found matching the URL and request method',
-						code: 'rest_no_route',
-					},
-					status: 404,
-				},
-			};
-
-			const action = {
-				type: WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST,
-				siteId,
-				query: {},
-			};
-			handleProductCategoriesSuccess( store, action, response );
-
-			expect( store.dispatch ).to.have.been.calledWith(
-				match( {
-					type: WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_FAILURE,
-					siteId,
-				} )
-			);
-		} );
-		test( 'should dispatch with an error if the response is not valid', () => {
-			const siteId = '123';
-			const store = {
-				dispatch: spy(),
-			};
-
-			const response = {
-				data: {
-					body: [ { bogus: 'test' } ],
-					status: 200,
-				},
-			};
-
-			const action = {
-				type: WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST,
-				siteId,
-			};
-			handleProductCategoriesSuccess( store, action, response );
-
-			expect( store.dispatch ).to.have.been.calledWith(
-				match( {
-					type: WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_FAILURE,
-					siteId,
-				} )
-			);
-		} );
 	} );
 
-	describe( '#handleProductCategoriesError()', () => {
+	describe( '#onFetchError()', () => {
 		test( 'should dispatch error', () => {
 			const siteId = '123';
-			const store = {
-				dispatch: spy(),
-			};
+			const dispatch = spy();
 
 			const action = {
 				type: WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST,
 				siteId,
 			};
-			handleProductCategoriesError( store, action, 'error' );
+			onFetchError( action, 'error' )( dispatch );
 
-			expect( store.dispatch ).to.have.been.calledWith(
+			expect( dispatch ).to.have.been.calledWith(
 				match( {
 					type: WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_FAILURE,
 					siteId,

--- a/client/extensions/woocommerce/state/data-layer/utils.js
+++ b/client/extensions/woocommerce/state/data-layer/utils.js
@@ -1,4 +1,8 @@
 /** @format */
+/**
+ * External dependencies
+ */
+import { unescape } from 'lodash';
 
 /**
  * Verify that this response has data (is not an error).
@@ -14,4 +18,72 @@ export function verifyResponseHasData( response ) {
 		throw new Error( 'Failure at remote site.', response );
 	}
 	return response;
+}
+
+/**
+ * Check that all categories in a given list are valid category objects.
+ *
+ * @param  {Array} categories List of categories from the remote site API
+ * @return {Boolean}          True if the categories are valid.
+ */
+function isValidCategoriesArray( categories ) {
+	for ( let i = 0; i < categories.length; i++ ) {
+		if ( ! isValidProductCategory( categories[ i ] ) ) {
+			// Short-circuit the loop and return now.
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
+ * Check if the given category has the expected properties
+ *
+ * @param  {Object} category A single category from the remote site API
+ * @return {Boolean}         True if the category is valid.
+ */
+function isValidProductCategory( category ) {
+	return (
+		category &&
+		category.id &&
+		'number' === typeof category.id &&
+		category.name &&
+		'string' === typeof category.name &&
+		category.slug &&
+		'string' === typeof category.slug
+	);
+}
+
+/**
+ * Verify that this response has valid categories.
+ *
+ * If the response object has a data property, it has data from
+ * the site. Otherwise it has an error message from the remote site.
+ *
+ * @param  {Object} response Response from an API call
+ * @return {Object}          Verified response
+ */
+export function verifyResponseHasValidCategories( response ) {
+	if ( ! response.data ) {
+		throw new Error( 'Failure at remote site.', response );
+	}
+	const { body = [], status = 400 } = response.data;
+	if ( status !== 200 || ! isValidCategoriesArray( body ) ) {
+		throw new Error( 'Invalid categories.', response );
+	}
+
+	const unescapedBody = body.map( cat => {
+		return {
+			...cat,
+			name: unescape( cat.name ),
+			description: cat.description ? unescape( cat.description ) : '',
+		};
+	} )
+
+	return {
+		data: {
+			...response.data,
+			body: unescapedBody,
+		},
+	};
 }


### PR DESCRIPTION
Fixes #24578  — When adding an existing category to a product, if that category contains an escaped character (`&` for example), the code can't match it to the existing category. This is because the category name comes to us from the API already escaped, so when [we escape to compare it with the escaped token name](https://github.com/Automattic/wp-calypso/blob/master/client/extensions/woocommerce/app/products/product-form-categories-card.js#L37), it tries to match a doubly-escaped string to a normally-escaped string: `"Hats &amp;amp; Visors" === "Hats &amp; Visors"`

I initially just unescaped the string before comparing the two, but then I noticed that we displayed this escaped string everywhere:
![screen shot 2018-06-04 at 6 05 40 pm](https://user-images.githubusercontent.com/541093/40944219-f65461bc-6821-11e8-83fb-1570718cd95b.png)
![screen shot 2018-06-04 at 6 05 48 pm](https://user-images.githubusercontent.com/541093/40944220-f666f688-6821-11e8-9fcd-72007370caa7.png)

**Rather than `unescape` wherever we want to display this data, I decided to tweak the response at the data-layer.** The product categories fetch request now uses `dispatchRequestEx`, which lets me add in a `fromApi` function to manipulate the response before it hits the onSuccess/onError actions. So here I can unescape `name` and `description`, and they'll display correctly:

![screen shot 2018-06-04 at 6 14 27 pm](https://user-images.githubusercontent.com/541093/40944527-25b9dd3c-6823-11e8-923d-82e0cdb11d83.png)

I've also moved the `isValidCategoriesArray` & `isValidProductCategory` into this `fromApi` callback, which means if the response is an error, or has invalid categories from the remote site, `dispatchRequestEx` will call the `onError` callback – we don't need to worry about handling cases where "the request to the remote site succeeded but the enveloped request failed" in the success callback anymore.

**To test**

- Make sure the tests pass
- Check that categories display correctly on:
  - The product list
  - In tokens on the single product edit page
  - The product categories list
  - The single product category edit page
  - The promotions list edit screen
- Check that you can save a product with a category that has an `&`, and it saves to the correct category.
