### PR TITLE
Signup: Unique copy for button text

### DIFF
--- a/client/blocks/checklist/checklist-task.jsx
+++ b/client/blocks/checklist/checklist-task.jsx
@@ -56,8 +56,9 @@ export class ChecklistTask extends PureComponent {
 			duration,
 			title,
 			translate,
+			buttonText,
 		} = this.props;
-		const { buttonText = translate( 'Do it!' ) } = this.props;
+		//{ buttonText = translate( 'Do it!' ) } = this.props;
 		const hasActionlink = completed && completedButtonText;
 
 		return (

--- a/client/blocks/checklist/checklist-task.jsx
+++ b/client/blocks/checklist/checklist-task.jsx
@@ -58,7 +58,6 @@ export class ChecklistTask extends PureComponent {
 			translate,
 			buttonText,
 		} = this.props;
-		//{ buttonText = translate( 'Do it!' ) } = this.props;
 		const hasActionlink = completed && completedButtonText;
 
 		return (
@@ -87,8 +86,11 @@ export class ChecklistTask extends PureComponent {
 						className="checklist__task-action"
 						onClick={ this.handleClick }
 						primary={ buttonPrimary }
+						title={ buttonText }
 					>
-						{ hasActionlink ? completedButtonText : buttonText }
+						{ hasActionlink
+							? completedButtonText
+							: translate( '%(buttonText)s!', { args: { buttonText: buttonText } } ) }
 					</Button>
 					{ duration && (
 						<small className="checklist__task-duration">

--- a/client/blocks/checklist/style.scss
+++ b/client/blocks/checklist/style.scss
@@ -257,6 +257,7 @@
 		@include breakpoint( '<480px' ) {
 			.checklist__task-action {
 				padding-right: 0;
+				max-width: 50px;
 			}
 		}
 	}

--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -31,6 +31,7 @@ const tasks = {
 		url: '/me',
 		image: '/calypso/images/stats/tasks/upload-profile-picture.svg',
 		tour: 'checklistUserAvatar',
+		buttonText: 'Add Profile!',
 	},
 	blogname_set: {
 		title: 'Give your site a name',
@@ -41,6 +42,7 @@ const tasks = {
 		url: '/settings/general/$siteSlug',
 		image: '/calypso/images/stats/tasks/personalize-your-site.svg',
 		tour: 'checklistSiteTitle',
+		buttonText: 'Name Site!',
 	},
 	blogdescription_set: {
 		title: 'Create a tagline',
@@ -51,6 +53,7 @@ const tasks = {
 		url: '/settings/general/$siteSlug',
 		image: '/calypso/images/stats/tasks/create-tagline.svg',
 		tour: 'checklistSiteTagline',
+		buttonText: 'Add Tagline!',
 	},
 	contact_page_updated: {
 		title: 'Personalize your Contact page',
@@ -61,6 +64,7 @@ const tasks = {
 		image: '/calypso/images/stats/tasks/contact.svg',
 		url: '/post/$siteSlug/2',
 		tour: 'checklistContactPage',
+		buttonText: 'Personalize!',
 	},
 	custom_domain_registered: {
 		title: 'Register a custom domain',
@@ -88,6 +92,7 @@ const tasks = {
 		url: '/post/$siteSlug',
 		image: '/calypso/images/stats/tasks/first-post.svg',
 		tour: 'checklistPublishPost',
+		buttonText: 'Publish!',
 	},
 	site_created: {
 		title: 'Create your site',
@@ -104,6 +109,7 @@ const tasks = {
 		url: '/settings/general/$siteSlug',
 		image: '/calypso/images/stats/tasks/upload-icon.svg',
 		tour: 'checklistSiteIcon',
+		buttonText: 'Add icon!',
 	},
 	social_links_set: {
 		title: 'Display links to your social accounts',

--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -31,7 +31,7 @@ const tasks = {
 		url: '/me',
 		image: '/calypso/images/stats/tasks/upload-profile-picture.svg',
 		tour: 'checklistUserAvatar',
-		buttonText: 'Add Profile!',
+		buttonText: 'Add Profile',
 	},
 	blogname_set: {
 		title: 'Give your site a name',
@@ -42,7 +42,7 @@ const tasks = {
 		url: '/settings/general/$siteSlug',
 		image: '/calypso/images/stats/tasks/personalize-your-site.svg',
 		tour: 'checklistSiteTitle',
-		buttonText: 'Name Site!',
+		buttonText: 'Name Site',
 	},
 	blogdescription_set: {
 		title: 'Create a tagline',
@@ -53,7 +53,7 @@ const tasks = {
 		url: '/settings/general/$siteSlug',
 		image: '/calypso/images/stats/tasks/create-tagline.svg',
 		tour: 'checklistSiteTagline',
-		buttonText: 'Add Tagline!',
+		buttonText: 'Add Tagline',
 	},
 	contact_page_updated: {
 		title: 'Personalize your Contact page',
@@ -64,7 +64,7 @@ const tasks = {
 		image: '/calypso/images/stats/tasks/contact.svg',
 		url: '/post/$siteSlug/2',
 		tour: 'checklistContactPage',
-		buttonText: 'Personalize!',
+		buttonText: 'Personalize',
 	},
 	custom_domain_registered: {
 		title: 'Register a custom domain',
@@ -92,7 +92,7 @@ const tasks = {
 		url: '/post/$siteSlug',
 		image: '/calypso/images/stats/tasks/first-post.svg',
 		tour: 'checklistPublishPost',
-		buttonText: 'Publish!',
+		buttonText: 'Publish',
 	},
 	site_created: {
 		title: 'Create your site',
@@ -109,7 +109,7 @@ const tasks = {
 		url: '/settings/general/$siteSlug',
 		image: '/calypso/images/stats/tasks/upload-icon.svg',
 		tour: 'checklistSiteIcon',
-		buttonText: 'Add icon!',
+		buttonText: 'Add icon',
 	},
 	social_links_set: {
 		title: 'Display links to your social accounts',


### PR DESCRIPTION
This branch is associated with #25216.

Currently, the button copy for the Onboarding checklist items are the same. @alisterscott suggested changing the copy for each button to break up the repetition. 
The image below is just a sample of what the buttons look like with different text. 

Before 
![image](https://user-images.githubusercontent.com/14166723/40945149-09afdb6a-681d-11e8-9847-b4fed3221633.png)

**After**
![wp-calypso_onboard_checklist_edits](https://user-images.githubusercontent.com/14166723/40944886-07bbfb64-681c-11e8-96c3-dc5a29fb8a51.PNG)
 
I had to use the React add on in dev tools to change the state because I'm currently receiving 304 or 404 messages and the changes I've made are not displaying in the browser even on rebuild.
My plan is to add `buttonText` to the props for the onboardingChecklist.js and remove `{ buttonText = translate( 'Do it!' ) } = this.props` from checklist-task.jsx. 
