### PR TITLE
Activity Log: show error when theme update fails, allow to restart

### DIFF
--- a/client/my-sites/stats/activity-log-tasklist/index.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/index.jsx
@@ -371,7 +371,8 @@ class ActivityLogTasklist extends Component {
  * the update is running, failed, or was successfully completed, respectively.
  */
 const getStatusForTheme = ( siteId, themeId ) => {
-	const { state } = getHttpData( `theme-update-${ siteId }-${ themeId }` );
+	const themeHttpData = getHttpData( `theme-update-${ siteId }-${ themeId }` );
+	const { state } = themeHttpData;
 	if ( 'pending' === state ) {
 		return { status: 'inProgress' };
 	}
@@ -379,7 +380,11 @@ const getStatusForTheme = ( siteId, themeId ) => {
 		return { status: 'error' };
 	}
 	if ( 'success' === state ) {
-		return { status: 'completed' };
+		// When a theme successfully updates, the theme 'update' property is nullified.
+		if ( null === get( themeHttpData, 'data.themes.0.update' ) ) {
+			return { status: 'completed' };
+		}
+		return { status: 'error' };
 	}
 	return false;
 };

--- a/client/my-sites/stats/activity-log-tasklist/index.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/index.jsx
@@ -432,7 +432,10 @@ const updateTheme = ( siteId, themeId ) =>
 			path: `/sites/${ siteId }/themes`,
 			body: { action: 'update', themes: themeId },
 		} ),
-		{ fromApi: () => ( { themes } ) => themes.map( ( { id } ) => [ id, true ] ) }
+		{
+			fromApi: () => ( { themes } ) => themes.map( ( { id } ) => [ id, true ] ),
+			freshness: -Infinity,
+		}
 	);
 
 const mapStateToProps = ( state, { siteId, plugins, themes } ) => {


### PR DESCRIPTION
This PR fixes an issue found while updating themes. If the theme update failed, the http request still returns a 200.
Props to @coder-karen and @designsimply for finding this.

To work around that, this PR checks that the update still exists for the theme: when a theme is successfully updated, the `update` property of the theme object is nullified. When it fails, the update is still pending, so the `update` property includes an object with data about this update. This PR also fixes an issue that was preventing the theme update from being restarted.

With this PR, the error notice will be shown and the theme update can be restarted from the Try again link in the notice or using the blue Update button again.

<img width="764" alt="captura de pantalla 2018-06-04 a la s 19 44 01" src="https://user-images.githubusercontent.com/1041600/40945537-a8ddf99e-682f-11e8-8a70-aaf95b0a81f2.png">

### Testing

1. Ensure you have a theme whose update will fail. This can be forced by setting the permissions of the theme folder to 555, so it's not writable.

2. Launch this branch https://calypso.live/?branch=fix/activity-log/theme-update-error

3. go to Activity Log and update. It should fail and display an error notice.
