### PR TITLE
Inline Help: Fix empty results / two click selection bugs

### DIFF
--- a/client/blocks/inline-help/inline-help-search-card.jsx
+++ b/client/blocks/inline-help/inline-help-search-card.jsx
@@ -16,6 +16,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import SearchCard from 'components/search-card';
 import {
 	getInlineHelpCurrentlySelectedLink,
+	getSelectedResultIndex,
 	isRequestingInlineHelpSearchResultsForQuery,
 } from 'state/inline-help/selectors';
 import {
@@ -60,9 +61,11 @@ class InlineHelpSearchCard extends Component {
 			case 'ArrowDown':
 				this.props.selectNextResult();
 				break;
-			case 'Enter':
-				this.props.openResult( event );
+			case 'Enter': {
+				const hasSelection = this.props.selectedResultIndex >= 0;
+				hasSelection && this.props.openResult( event );
 				break;
+			}
 		}
 	};
 
@@ -90,6 +93,7 @@ class InlineHelpSearchCard extends Component {
 const mapStateToProps = ( state, ownProps ) => ( {
 	isSearching: isRequestingInlineHelpSearchResultsForQuery( state, ownProps.query ),
 	selectedLink: getInlineHelpCurrentlySelectedLink( state ),
+	selectedResultIndex: getSelectedResultIndex( state ),
 } );
 const mapDispatchToProps = {
 	recordTracksEvent,

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -4,7 +4,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { noop, isEmpty } from 'lodash';
+import { noop } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -42,12 +42,8 @@ class InlineHelpPopover extends Component {
 	};
 
 	openResultView = event => {
-		const { selectedResult } = this.props;
 		event.preventDefault();
-
-		if ( ! isEmpty( selectedResult ) ) {
-			this.openSecondaryView( VIEW_RICH_RESULT );
-		}
+		this.openSecondaryView( VIEW_RICH_RESULT );
 	};
 
 	moreHelpClicked = () => {

--- a/client/state/inline-help/reducer.js
+++ b/client/state/inline-help/reducer.js
@@ -17,11 +17,16 @@ import {
 export function requesting( state = {}, action ) {
 	switch ( action.type ) {
 		case INLINE_HELP_SEARCH_REQUEST:
+			return {
+				...state,
+				[ action.searchQuery ]: true,
+			};
 		case INLINE_HELP_SEARCH_REQUEST_SUCCESS:
 		case INLINE_HELP_SEARCH_REQUEST_FAILURE:
-			return Object.assign( {}, state, {
-				[ action.searchQuery ]: INLINE_HELP_SEARCH_REQUEST === action.type,
-			} );
+			return {
+				...state,
+				[ action.searchQuery ]: false,
+			};
 	}
 
 	return state;
@@ -35,44 +40,48 @@ export const search = createReducer(
 		shouldOpenSelectedResult: false,
 	},
 	{
-		[ INLINE_HELP_SEARCH_REQUEST ]: ( state, action ) => {
-			return Object.assign( {}, state, {
-				searchQuery: action.searchQuery,
-			} );
-		},
-		[ INLINE_HELP_SEARCH_REQUEST_SUCCESS ]: ( state, action ) => {
-			return Object.assign( {}, state, {
-				selectedResult: -1,
-				items: {
-					...state.items,
-					[ action.searchQuery ]: action.searchResults,
-				},
-			} );
-		},
+		[ INLINE_HELP_SEARCH_REQUEST ]: ( state, action ) => ( {
+			...state,
+			searchQuery: action.searchQuery,
+		} ),
+		[ INLINE_HELP_SEARCH_REQUEST_SUCCESS ]: ( state, action ) => ( {
+			...state,
+			selectedResult: -1,
+			items: {
+				...state.items,
+				[ action.searchQuery ]: action.searchResults,
+			},
+		} ),
 		[ INLINE_HELP_SELECT_RESULT ]: ( state, action ) => ( {
 			...state,
 			selectedResult: action.resultIndex,
 		} ),
 		[ INLINE_HELP_SELECT_NEXT_RESULT ]: state => {
 			if ( state.items[ state.searchQuery ] && state.items[ state.searchQuery ].length ) {
-				return Object.assign( {}, state, {
+				return {
+					...state,
 					selectedResult: ( state.selectedResult + 1 ) % state.items[ state.searchQuery ].length,
-				} );
+				};
 			}
-			return Object.assign( {}, state, {
+
+			return {
+				...state,
 				selectedResult: -1,
-			} );
+			};
 		},
 		[ INLINE_HELP_SELECT_PREVIOUS_RESULT ]: state => {
 			if ( state.items[ state.searchQuery ] && state.items[ state.searchQuery ].length ) {
 				const newResult = ( state.selectedResult - 1 ) % state.items[ state.searchQuery ].length;
-				return Object.assign( {}, state, {
+				return {
+					...state,
 					selectedResult: newResult < 0 ? state.items[ state.searchQuery ].length - 1 : newResult,
-				} );
+				};
 			}
-			return Object.assign( {}, state, {
+
+			return {
+				...state,
 				selectedResult: -1,
-			} );
+			};
 		},
 	}
 );


### PR DESCRIPTION
As reported in #24998, a blank result view was being shown when hitting enter. The PR #25079 addressed this issue but as a side effect left another issue whereby clicking on a listed result would first make a selection and require a second click to go through to the results view.

This PR adds logic that first checks that there is a selection made before attempting to show a result, mitigating the initial issue and rolls back the changes that caused the secondary issue 

### Testing

Keyboard:
- Open inline-help and type a search term (video for example)
  - Search should automatically happen
- use ⬇️and ⬆️buttons to highlight ('select') a result
- hit <kbd>⏎</kbd> button
  - Result should be successfully shown in place of the results list
- Make sure this works for first and last results (given result selections are based on their indexes)

Mouse:
- Make sure clicking any of these results works with a single a click