### PR TITLE
Checklist: Redirect if the current user has insufficient capabilities

### DIFF
--- a/client/my-sites/checklist/controller/index.jsx
+++ b/client/my-sites/checklist/controller/index.jsx
@@ -5,15 +5,25 @@
  */
 
 import React from 'react';
+import page from 'page';
 import { get } from 'lodash';
 
 /**
  * Internal Dependencies
  */
-
+import { getSelectedSiteId } from 'state/ui/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
 import ChecklistShow from '../checklist-show';
 
 export function show( context, next ) {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+
+	//@TODO This doesn't work until the state gets hydrated....hrmmm
+	if ( ! canCurrentUser( state, siteId, 'manage_options' ) ) {
+		return page.redirect( '/view/' + get( context, 'params.site_id' ) );
+	}
+
 	const displayMode = get( context, 'query.d' );
 	context.primary = <ChecklistShow displayMode={ displayMode } />;
 	next();


### PR DESCRIPTION
Browsing to the checklist for a site where you're not an admin results in placeholders that never resolve:

<img width="778" alt="screen shot 2018-06-05 at 1 09 32 am" src="https://user-images.githubusercontent.com/1587282/40956239-2632ad54-685d-11e8-938a-fe881041cbe4.png">

API calls fail with:
```
error: "Forbidden"
message: "You do not have the capability to manage settings for this site."
```

Until such time we have a checklist experience for users without appropriate capabilities, redirect somewhere more meaningful if such users land here.