### PR TITLE
Components: Remove div wrapper around query components

### DIFF
--- a/client/components/data/query-canonical-theme/index.jsx
+++ b/client/components/data/query-canonical-theme/index.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 
 /**
@@ -15,11 +15,11 @@ import QueryTheme from 'components/data/query-theme';
 import { isWpcomTheme, isWporgTheme } from 'state/themes/selectors';
 
 const QueryCanonicalTheme = ( { siteId, themeId, isWpcom, isWporg } ) => (
-	<div>
+	<Fragment>
 		<QueryTheme themeId={ themeId } siteId="wpcom" />
 		{ ! isWpcom && <QueryTheme themeId={ themeId } siteId="wporg" /> }
 		{ ! isWpcom && ! isWporg && siteId && <QueryTheme themeId={ themeId } siteId={ siteId } /> }
-	</div>
+	</Fragment>
 );
 
 QueryCanonicalTheme.propTypes = {


### PR DESCRIPTION
Replaces an empty `div` wrapper around some query components with a Fragment.

## Testing
