### PR TITLE
Cleanup: Remove unused destinationType

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -260,7 +260,6 @@ export function plansLanding( context, next ) {
 	context.primary = (
 		<PlansLanding
 			context={ context }
-			destinationType={ context.params.destinationType }
 			interval={ context.params.interval }
 			url={ context.query.site }
 		/>
@@ -287,7 +286,6 @@ export function plansSelection( context, next ) {
 						: JPC_PATH_PLANS
 				}
 				context={ context }
-				destinationType={ context.params.destinationType }
 				interval={ context.params.interval }
 				queryRedirect={ context.query.redirect }
 			/>

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -154,11 +154,6 @@ export function managePurchase( context, next ) {
 
 	setTitle( context, titles.managePurchase );
 
-	context.primary = (
-		<ManagePurchase
-			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-			destinationType={ context.params.destinationType }
-		/>
-	);
+	context.primary = <ManagePurchase purchaseId={ parseInt( context.params.purchaseId, 10 ) } />;
 	next();
 }

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -78,7 +78,6 @@ import { getCurrentUserId } from 'state/current-user/selectors';
 
 class ManagePurchase extends Component {
 	static propTypes = {
-		destinationType: PropTypes.string,
 		hasLoadedSites: PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
 		purchase: PropTypes.object,

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -23,7 +23,6 @@ export default {
 				<Plans
 					context={ context }
 					intervalType={ context.params.intervalType }
-					destinationType={ context.params.destinationType }
 					selectedFeature={ context.query.feature }
 					selectedPlan={ context.query.plan }
 					withDiscount={ context.query.discount }


### PR DESCRIPTION
Remove `destinationType`. This prop appears to have been removed in #7129 and is no longer used.

## Testing
1. Jetpack plans still work:
   - https://calypso.live/jetpack/connect/store/?branch=update/purchases-remove-destinationType
   - https://calypso.live/jetpack/connect/plans/:JETPACK_SITE_ON_FREE_PLAN_SLUG?branch=update/purchases-remove-destinationType
2. Manage purchase works correctly (click purchase to manage): https://calypso.live/me/purchases/?branch=update/purchases-remove-destinationType