### PR TITLE
i18n: Invite users to contribute to WordPress.com translations

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -249,6 +249,7 @@
 @import 'components/tile-grid/style';
 @import 'components/title-format-editor/style';
 @import 'components/token-field/style';
+@import 'components/translator-invite/style';
 @import 'components/pagination/style';
 @import 'components/post-schedule/style';
 @import 'components/phone-input/style';

--- a/client/components/translator-invite/README.md
+++ b/client/components/translator-invite/README.md
@@ -1,0 +1,21 @@
+Translator invite
+==========
+
+This component invites users to translate WordPress.com into a non-default locale based on a locale:
+
+1. passed down as a prop
+2. in the url
+3. in their browser preferences.
+
+If a locale is found, the component fetches the localized name of the language.
+
+#### Usage:
+
+```javascript
+	<TranslatorInvite locale={ locale } path={ path } />
+```
+
+#### Props
+
+* `locale`: {String} (optional) A WordPress.com locale that takes priority over other locales
+* `path`: {String} (optional) Current path

--- a/client/components/translator-invite/README.md
+++ b/client/components/translator-invite/README.md
@@ -3,7 +3,7 @@ Translator invite
 
 This component invites users to translate WordPress.com into a non-default locale based on a locale:
 
-1. passed down as a prop
+1. currently set as the UI locale
 2. in the url
 3. in their browser preferences.
 
@@ -12,10 +12,9 @@ If a locale is found, the component fetches the localized name of the language.
 #### Usage:
 
 ```javascript
-	<TranslatorInvite locale={ locale } path={ path } />
+	<TranslatorInvite path={ path } />
 ```
 
 #### Props
 
-* `locale`: {String} (optional) A WordPress.com locale that takes priority over other locales
 * `path`: {String} (optional) Current path

--- a/client/components/translator-invite/index.jsx
+++ b/client/components/translator-invite/index.jsx
@@ -6,7 +6,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
 import { startsWith } from 'lodash';
 
 /**
@@ -80,23 +79,15 @@ export class TranslatorInvite extends Component {
 			return (
 				<Notice icon="globe" showDismiss={ true } onDismissClick={ this.dismiss }>
 					<div className="translator-invite__content">
-						{ this.props.translate(
-							'Would you like to help us translate WordPress into {{translateLink}}%(defaultLanguage)s{{/translateLink}}?',
-							{
-								args: {
-									defaultLanguage: localizedLanguageNames[ locale ].localized,
-								},
-								components: {
-									translateLink: (
-										<a
-											href={ `https://translate.wordpress.com/projects/wpcom/${ locale }/default/` }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-								},
-							}
-						) }
+						Would you like to help us translate WordPress into{' '}
+						<a
+							href={ `https://translate.wordpress.com/projects/wpcom/${ locale }/default/` }
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							{ localizedLanguageNames[ locale ].en }
+						</a>{' '}
+						?
 					</div>
 				</Notice>
 			);
@@ -124,4 +115,4 @@ export default connect(
 		localizedLanguageNames: getLocalizedLanguageNames( state ),
 	} ),
 	null
-)( localize( TranslatorInvite ) );
+)( TranslatorInvite );

--- a/client/components/translator-invite/index.jsx
+++ b/client/components/translator-invite/index.jsx
@@ -86,8 +86,7 @@ export class TranslatorInvite extends Component {
 							rel="noopener noreferrer"
 						>
 							{ localizedLanguageNames[ locale ].en }
-						</a>{' '}
-						?
+						</a>?
 					</div>
 				</Notice>
 			);

--- a/client/components/translator-invite/index.jsx
+++ b/client/components/translator-invite/index.jsx
@@ -1,0 +1,127 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { startsWith } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import Notice from 'components/notice';
+import QueryLanguageNames from 'components/data/query-language-names';
+import getLocalizedLanguageNames from 'state/selectors/get-localized-language-names';
+import { getLanguage, getLocaleFromPath } from 'lib/i18n-utils';
+
+/**
+ * Module variables
+ */
+const defaultLanguageSlug = config( 'i18n_default_locale_slug' );
+
+export class TranslatorInvite extends Component {
+	static propTypes = {
+		locale: PropTypes.string,
+		path: PropTypes.string.isRequired,
+	};
+
+	static defaultProps = {
+		locale: '',
+		path: '',
+	};
+
+	state = {
+		dismissed: false,
+	};
+
+	isDefaultLocale( browserLanguage ) {
+		return startsWith( browserLanguage, defaultLanguageSlug );
+	}
+
+	getLocale() {
+		// First try the locale.
+		let browserLanguage = ! this.isDefaultLocale( this.props.locale ) ? this.props.locale : null;
+
+		// Then the path.
+		if ( ! browserLanguage && this.props.path ) {
+			browserLanguage = getLocaleFromPath( this.props.path );
+			browserLanguage = ! this.isDefaultLocale( browserLanguage ) ? browserLanguage : null;
+		}
+
+		// Then navigator.languages.
+		if ( ! browserLanguage && typeof navigator === 'object' && 'languages' in navigator ) {
+			for ( const langSlug of navigator.languages ) {
+				const language = getLanguage( langSlug.toLowerCase() );
+				if ( language && ! this.isDefaultLocale( language.langSlug ) ) {
+					browserLanguage = language.langSlug;
+					break;
+				}
+			}
+		}
+
+		if ( browserLanguage ) {
+			return browserLanguage;
+		}
+
+		return null;
+	}
+
+	dismiss = () => this.setState( { dismissed: true } );
+
+	renderNoticeLabelText() {
+		const { localizedLanguageNames } = this.props;
+		const locale = this.getLocale();
+
+		if ( localizedLanguageNames && localizedLanguageNames[ locale ] ) {
+			return (
+				<Notice icon="globe" showDismiss={ true } onDismissClick={ this.dismiss }>
+					<div className="translator-invite__content">
+						{ this.props.translate(
+							'Would you like to help us translate WordPress into {{translateLink}}%(defaultLanguage)s{{/translateLink}}?',
+							{
+								args: {
+									defaultLanguage: localizedLanguageNames[ locale ].localized,
+								},
+								components: {
+									translateLink: (
+										<a
+											href={ `https://translate.wordpress.com/projects/wpcom/${ locale }/default/` }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								},
+							}
+						) }
+					</div>
+				</Notice>
+			);
+		}
+
+		return null;
+	}
+
+	render() {
+		if ( this.state.dismissed ) {
+			return null;
+		}
+
+		return (
+			<div className="translator-invite">
+				{ this.renderNoticeLabelText() }
+				<QueryLanguageNames />
+			</div>
+		);
+	}
+}
+
+export default connect(
+	state => ( {
+		localizedLanguageNames: getLocalizedLanguageNames( state ),
+	} ),
+	null
+)( localize( TranslatorInvite ) );

--- a/client/components/translator-invite/index.jsx
+++ b/client/components/translator-invite/index.jsx
@@ -17,9 +17,6 @@ import getLocalizedLanguageNames from 'state/selectors/get-localized-language-na
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getCurrentNonDefaultLocale } from 'components/translator-invite/utils';
-/**
- * Module variables
- */
 
 export class TranslatorInvite extends Component {
 	static propTypes = {

--- a/client/components/translator-invite/style.scss
+++ b/client/components/translator-invite/style.scss
@@ -1,0 +1,10 @@
+.translator-invite__content {
+	margin: 15px;
+	font-size: 12px;
+	font-style: italic;
+}
+
+.translator-invite__gridicon {
+	margin: 0 2px 0 0;
+	float: left;
+}

--- a/client/components/translator-invite/test/index.js
+++ b/client/components/translator-invite/test/index.js
@@ -16,7 +16,6 @@ import { TranslatorInvite } from '../';
 
 describe( 'TranslatorInvite', () => {
 	const defaultProps = {
-		translate: jest.fn(),
 		localizedLanguageNames: {
 			'en-gb': {
 				localized: 'British English',
@@ -64,15 +63,13 @@ describe( 'TranslatorInvite', () => {
 		test( 'should render using browser locales', () => {
 			const wrapper = shallow( <TranslatorInvite { ...defaultProps } /> );
 			expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 1 );
-			expect( defaultProps.translate.mock.calls[ 0 ][ 1 ].args.defaultLanguage ).toBe( 'Maltese' );
+			expect( wrapper.find( '.translator-invite__content a' ).text() ).toBe( 'Maltese' );
 		} );
 
 		test( 'should render using path prop over browser locale', () => {
 			const wrapper = shallow( <TranslatorInvite path="/log-in/uk" { ...defaultProps } /> );
 			expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 1 );
-			expect( defaultProps.translate.mock.calls[ 1 ][ 1 ].args.defaultLanguage ).toBe(
-				'Ukrainian'
-			);
+			expect( wrapper.find( '.translator-invite__content a' ).text() ).toBe( 'Ukrainian' );
 		} );
 
 		test( 'should render using locale prop over path and browser locale', () => {
@@ -80,7 +77,7 @@ describe( 'TranslatorInvite', () => {
 				<TranslatorInvite path="/log-in/uk" locale="tl" { ...defaultProps } />
 			);
 			expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 1 );
-			expect( defaultProps.translate.mock.calls[ 2 ][ 1 ].args.defaultLanguage ).toBe( 'Filipino' );
+			expect( wrapper.find( '.translator-invite__content a' ).text() ).toBe( 'Filipino' );
 		} );
 
 		test( 'should render using path when locale is defaultish', () => {
@@ -88,15 +85,13 @@ describe( 'TranslatorInvite', () => {
 				<TranslatorInvite path="/log-in/uk" locale="en-gb" { ...defaultProps } />
 			);
 			expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 1 );
-			expect( defaultProps.translate.mock.calls[ 3 ][ 1 ].args.defaultLanguage ).toBe(
-				'Ukrainian'
-			);
+			expect( wrapper.find( '.translator-invite__content a' ).text() ).toBe( 'Ukrainian' );
 		} );
 
 		test( 'should render using path when pth is default', () => {
 			const wrapper = shallow( <TranslatorInvite path="/log-in/en" { ...defaultProps } /> );
 			expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 1 );
-			expect( defaultProps.translate.mock.calls[ 4 ][ 1 ].args.defaultLanguage ).toBe( 'Maltese' );
+			expect( wrapper.find( '.translator-invite__content a' ).text() ).toBe( 'Maltese' );
 		} );
 	} );
 } );

--- a/client/components/translator-invite/test/index.js
+++ b/client/components/translator-invite/test/index.js
@@ -1,0 +1,102 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { TranslatorInvite } from '../';
+
+describe( 'TranslatorInvite', () => {
+	const defaultProps = {
+		translate: jest.fn(),
+		localizedLanguageNames: {
+			'en-gb': {
+				localized: 'British English',
+				name: 'English (UK)',
+				en: 'British English',
+			},
+			mt: {
+				localized: 'Maltese',
+				name: 'Malti',
+				en: 'Maltese',
+			},
+			uk: {
+				localized: 'Ukrainian',
+				name: 'Українська',
+				en: 'Ukrainian',
+			},
+			tl: {
+				localized: 'Filipino',
+				name: 'Tagalog',
+				en: 'Filipino',
+			},
+		},
+	};
+
+	test( 'should not render when no locale information present', () => {
+		const wrapper = shallow( <TranslatorInvite { ...defaultProps } /> );
+		expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 0 );
+	} );
+
+	describe( 'TranslatorInvite with browser locales', () => {
+		let _navigator;
+		const browserLanguages = [ 'en-GB', 'en', 'en-US', 'en-AU', 'mt' ];
+		beforeEach( () => {
+			_navigator = global.navigator;
+			Object.defineProperty( global.navigator, 'languages', {
+				get: () => browserLanguages,
+				configurable: true,
+			} );
+		} );
+
+		afterEach( () => {
+			global.navigator = _navigator;
+		} );
+
+		test( 'should render using browser locales', () => {
+			const wrapper = shallow( <TranslatorInvite { ...defaultProps } /> );
+			expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 1 );
+			expect( defaultProps.translate.mock.calls[ 0 ][ 1 ].args.defaultLanguage ).toBe( 'Maltese' );
+		} );
+
+		test( 'should render using path prop over browser locale', () => {
+			const wrapper = shallow( <TranslatorInvite path="/log-in/uk" { ...defaultProps } /> );
+			expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 1 );
+			expect( defaultProps.translate.mock.calls[ 1 ][ 1 ].args.defaultLanguage ).toBe(
+				'Ukrainian'
+			);
+		} );
+
+		test( 'should render using locale prop over path and browser locale', () => {
+			const wrapper = shallow(
+				<TranslatorInvite path="/log-in/uk" locale="tl" { ...defaultProps } />
+			);
+			expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 1 );
+			expect( defaultProps.translate.mock.calls[ 2 ][ 1 ].args.defaultLanguage ).toBe( 'Filipino' );
+		} );
+
+		test( 'should render using path when locale is defaultish', () => {
+			const wrapper = shallow(
+				<TranslatorInvite path="/log-in/uk" locale="en-gb" { ...defaultProps } />
+			);
+			expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 1 );
+			expect( defaultProps.translate.mock.calls[ 3 ][ 1 ].args.defaultLanguage ).toBe(
+				'Ukrainian'
+			);
+		} );
+
+		test( 'should render using path when pth is default', () => {
+			const wrapper = shallow( <TranslatorInvite path="/log-in/en" { ...defaultProps } /> );
+			expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 1 );
+			expect( defaultProps.translate.mock.calls[ 4 ][ 1 ].args.defaultLanguage ).toBe( 'Maltese' );
+		} );
+	} );
+} );

--- a/client/components/translator-invite/test/index.js
+++ b/client/components/translator-invite/test/index.js
@@ -46,18 +46,12 @@ describe( 'TranslatorInvite', () => {
 	} );
 
 	describe( 'TranslatorInvite with browser locales', () => {
-		let _navigator;
 		const browserLanguages = [ 'en-GB', 'en', 'en-US', 'en-AU', 'mt' ];
 		beforeEach( () => {
-			_navigator = global.navigator;
 			Object.defineProperty( global.navigator, 'languages', {
 				get: () => browserLanguages,
 				configurable: true,
 			} );
-		} );
-
-		afterEach( () => {
-			global.navigator = _navigator;
 		} );
 
 		test( 'should render using browser locales', () => {
@@ -88,7 +82,7 @@ describe( 'TranslatorInvite', () => {
 			expect( wrapper.find( '.translator-invite__content a' ).text() ).toBe( 'Ukrainian' );
 		} );
 
-		test( 'should render using path when pth is default', () => {
+		test( 'should render using path when path is default', () => {
 			const wrapper = shallow( <TranslatorInvite path="/log-in/en" { ...defaultProps } /> );
 			expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 1 );
 			expect( wrapper.find( '.translator-invite__content a' ).text() ).toBe( 'Maltese' );

--- a/client/components/translator-invite/test/index.js
+++ b/client/components/translator-invite/test/index.js
@@ -46,47 +46,8 @@ describe( 'TranslatorInvite', () => {
 		expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 0 );
 	} );
 
-	describe( 'TranslatorInvite with browser locales', () => {
-		const browserLanguages = [ 'en-GB', 'en', 'en-US', 'en-AU', 'mt' ];
-		beforeEach( () => {
-			Object.defineProperty( global.navigator, 'languages', {
-				get: () => browserLanguages,
-				configurable: true,
-			} );
-		} );
-
-		test( 'should render', () => {
-			const wrapper = shallow( <TranslatorInvite { ...defaultProps } /> );
-			expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 1 );
-		} );
-
-		test( 'should get non-English locale using browser locales', () => {
-			const wrapper = shallow( <TranslatorInvite { ...defaultProps } /> );
-			expect( wrapper.instance().getLocale() ).toBe( 'mt' );
-		} );
-
-		test( 'should get non-English locale using path prop over browser locale', () => {
-			const wrapper = shallow( <TranslatorInvite path="/log-in/uk" { ...defaultProps } /> );
-			expect( wrapper.instance().getLocale() ).toBe( 'uk' );
-		} );
-
-		test( 'should get non-English locale using locale prop over path and browser locale', () => {
-			const wrapper = shallow(
-				<TranslatorInvite path="/log-in/uk" locale="tl" { ...defaultProps } />
-			);
-			expect( wrapper.instance().getLocale() ).toBe( 'tl' );
-		} );
-
-		test( 'should get non-English locale using path when locale is defaultish', () => {
-			const wrapper = shallow(
-				<TranslatorInvite path="/log-in/uk" locale="en-gb" { ...defaultProps } />
-			);
-			expect( wrapper.instance().getLocale() ).toBe( 'uk' );
-		} );
-
-		test( 'should get non-English locale using browser locale when path is a default lang', () => {
-			const wrapper = shallow( <TranslatorInvite path="/log-in/en" { ...defaultProps } /> );
-			expect( wrapper.instance().getLocale() ).toBe( 'mt' );
-		} );
+	test( 'should render when no locale information present', () => {
+		const wrapper = shallow( <TranslatorInvite { ...defaultProps } locale="tl" /> );
+		expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 1 );
 	} );
 } );

--- a/client/components/translator-invite/test/index.js
+++ b/client/components/translator-invite/test/index.js
@@ -16,6 +16,7 @@ import { TranslatorInvite } from '../';
 
 describe( 'TranslatorInvite', () => {
 	const defaultProps = {
+		translate: x => x,
 		localizedLanguageNames: {
 			'en-gb': {
 				localized: 'British English',
@@ -54,38 +55,38 @@ describe( 'TranslatorInvite', () => {
 			} );
 		} );
 
-		test( 'should render using browser locales', () => {
+		test( 'should render', () => {
 			const wrapper = shallow( <TranslatorInvite { ...defaultProps } /> );
 			expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 1 );
-			expect( wrapper.find( '.translator-invite__content a' ).text() ).toBe( 'Maltese' );
 		} );
 
-		test( 'should render using path prop over browser locale', () => {
+		test( 'should get non-English locale using browser locales', () => {
+			const wrapper = shallow( <TranslatorInvite { ...defaultProps } /> );
+			expect( wrapper.instance().getLocale() ).toBe( 'mt' );
+		} );
+
+		test( 'should get non-English locale using path prop over browser locale', () => {
 			const wrapper = shallow( <TranslatorInvite path="/log-in/uk" { ...defaultProps } /> );
-			expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 1 );
-			expect( wrapper.find( '.translator-invite__content a' ).text() ).toBe( 'Ukrainian' );
+			expect( wrapper.instance().getLocale() ).toBe( 'uk' );
 		} );
 
-		test( 'should render using locale prop over path and browser locale', () => {
+		test( 'should get non-English locale using locale prop over path and browser locale', () => {
 			const wrapper = shallow(
 				<TranslatorInvite path="/log-in/uk" locale="tl" { ...defaultProps } />
 			);
-			expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 1 );
-			expect( wrapper.find( '.translator-invite__content a' ).text() ).toBe( 'Filipino' );
+			expect( wrapper.instance().getLocale() ).toBe( 'tl' );
 		} );
 
-		test( 'should render using path when locale is defaultish', () => {
+		test( 'should get non-English locale using path when locale is defaultish', () => {
 			const wrapper = shallow(
 				<TranslatorInvite path="/log-in/uk" locale="en-gb" { ...defaultProps } />
 			);
-			expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 1 );
-			expect( wrapper.find( '.translator-invite__content a' ).text() ).toBe( 'Ukrainian' );
+			expect( wrapper.instance().getLocale() ).toBe( 'uk' );
 		} );
 
-		test( 'should render using path when path is default', () => {
+		test( 'should get non-English locale using browser locale when path is a default lang', () => {
 			const wrapper = shallow( <TranslatorInvite path="/log-in/en" { ...defaultProps } /> );
-			expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 1 );
-			expect( wrapper.find( '.translator-invite__content a' ).text() ).toBe( 'Maltese' );
+			expect( wrapper.instance().getLocale() ).toBe( 'mt' );
 		} );
 	} );
 } );

--- a/client/components/translator-invite/test/utils.js
+++ b/client/components/translator-invite/test/utils.js
@@ -1,0 +1,88 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import { isDefaultLocale, getCurrentNonDefaultLocale } from '../utils';
+
+jest.mock( 'config', () => key => {
+	if ( 'i18n_default_locale_slug' === key ) {
+		return 'it';
+	}
+	if ( 'languages' === key ) {
+		return [
+			{
+				value: 1,
+				langSlug: 'it',
+				name: 'Italian English',
+				wpLocale: 'it_US',
+				popular: 1,
+				territories: [ '019' ],
+			},
+			{
+				value: 465,
+				langSlug: 'mt',
+				name: 'Malti',
+				territories: [ '039' ],
+			},
+			{
+				value: 455,
+				langSlug: 'tl',
+				name: 'Tagalog',
+				territories: [ '035' ],
+			},
+			{
+				value: 73,
+				langSlug: 'uk',
+				name: 'Українська',
+				territories: [ '151' ],
+			},
+		];
+	}
+} );
+
+describe( 'TranslatorInvite utils', () => {
+	describe( 'getCurrentNonDefaultLocale()', () => {
+		const browserLanguages = [ 'it-GB', 'it', 'it-US', 'it-AU', 'mt' ];
+		beforeEach( () => {
+			Object.defineProperty( global.navigator, 'languages', {
+				get: () => browserLanguages,
+				configurable: true,
+			} );
+		} );
+		test( 'should get non-English locale using browser locales', () => {
+			expect( getCurrentNonDefaultLocale() ).toBe( 'mt' );
+		} );
+
+		test( 'should get non-English locale using path prop over browser locale', () => {
+			expect( getCurrentNonDefaultLocale( null, '/log-in/uk' ) ).toBe( 'uk' );
+		} );
+
+		test( 'should get non-English locale using locale prop over path and browser locale', () => {
+			expect( getCurrentNonDefaultLocale( 'tl', '/log-in/uk' ) ).toBe( 'tl' );
+		} );
+
+		test( 'should get non-English locale using path when locale is defaultish', () => {
+			expect( getCurrentNonDefaultLocale( 'it-gb', '/log-in/uk' ) ).toBe( 'uk' );
+		} );
+
+		test( 'should get non-English locale using browser locale when path is a default lang', () => {
+			expect( getCurrentNonDefaultLocale( null, '/log-in/it' ) ).toBe( 'mt' );
+		} );
+	} );
+
+	describe( 'isDefaultLocale()', () => {
+		test( 'should return true for direct matches', () => {
+			expect( isDefaultLocale( 'it' ) ).toBe( true );
+		} );
+		test( 'should return false for partial matches', () => {
+			expect( isDefaultLocale( 'it-AU' ) ).toBe( true );
+		} );
+		test( 'should return false for non matches', () => {
+			expect( isDefaultLocale( 'ja' ) ).toBe( false );
+		} );
+	} );
+} );

--- a/client/components/translator-invite/utils.js
+++ b/client/components/translator-invite/utils.js
@@ -11,6 +11,9 @@ import { startsWith } from 'lodash';
 import config from 'config';
 import { getLanguage, getLocaleFromPath } from 'lib/i18n-utils';
 
+/**
+ * Module variables
+ */
 const defaultLanguageSlug = config( 'i18n_default_locale_slug' );
 
 /**

--- a/client/components/translator-invite/utils.js
+++ b/client/components/translator-invite/utils.js
@@ -1,0 +1,62 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { startsWith } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { getLanguage, getLocaleFromPath } from 'lib/i18n-utils';
+
+const defaultLanguageSlug = config( 'i18n_default_locale_slug' );
+
+/**
+ * Checks a locale against the default. Returns true if the
+ * locale's prefix matches the default locale. E.g., a locale of en-AU
+ * starts with 'en', the defaultLanguageSlug.
+ *
+ * @param {String} locale An language slug
+ * @returns {Boolean} The locale slug of the language, if any found.
+ */
+export function isDefaultLocale( locale ) {
+	return startsWith( locale, defaultLanguageSlug );
+}
+
+/**
+ * Checks incoming locale then urlPath for a valid non-default locale.
+ * If no matching locale exists, we look in the user's browser preferences.
+ *
+ * @param {String} locale The language slug of an existing locale
+ * @param {String} urlPath Current path
+ * @returns {String|Null} The locale slug of the language, if any found.
+ */
+export function getCurrentNonDefaultLocale( locale, urlPath ) {
+	// First try the locale passed as props.
+	let languageLocale = ! isDefaultLocale( locale ) ? locale : null;
+
+	// Then the locale in the path, if any.
+	if ( ! languageLocale && urlPath ) {
+		languageLocale = getLocaleFromPath( urlPath );
+		languageLocale = ! isDefaultLocale( languageLocale ) ? languageLocale : null;
+	}
+
+	// Then navigator.languages.
+	if ( ! languageLocale && typeof navigator === 'object' && 'languages' in navigator ) {
+		for ( const langSlug of navigator.languages ) {
+			const language = getLanguage( langSlug.toLowerCase() );
+			if ( language && ! isDefaultLocale( language.langSlug ) ) {
+				languageLocale = language.langSlug;
+				break;
+			}
+		}
+	}
+
+	if ( languageLocale ) {
+		return languageLocale;
+	}
+
+	return null;
+}

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -5,7 +5,7 @@
  */
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { startCase } from 'lodash';
@@ -16,6 +16,7 @@ import { startCase } from 'lodash';
 import DocumentHead from 'components/data/document-head';
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 import LocaleSuggestions from 'components/locale-suggestions';
+import TranslatorInvite from 'components/translator-invite';
 import LoginBlock from 'blocks/login';
 import LoginLinks from './login-links';
 import Main from 'components/main';
@@ -81,14 +82,19 @@ export class Login extends React.Component {
 		this.props.recordPageView( url, title );
 	}
 
-	renderLocaleSuggestions() {
+	renderI18nSuggestions() {
 		const { locale, path, twoFactorAuthType, socialConnect } = this.props;
 
 		if ( twoFactorAuthType || socialConnect ) {
 			return null;
 		}
 
-		return <LocaleSuggestions locale={ locale } path={ path } />;
+		return (
+			<Fragment>
+				<TranslatorInvite locale={ locale } path={ path } />
+				<LocaleSuggestions locale={ locale } path={ path } />
+			</Fragment>
+		);
 	}
 
 	renderFooter() {
@@ -176,7 +182,7 @@ export class Login extends React.Component {
 		return (
 			<div>
 				<Main className="wp-login__main">
-					{ this.renderLocaleSuggestions() }
+					{ this.renderI18nSuggestions() }
 
 					<DocumentHead
 						title={ translate( 'Log In' ) }

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -5,7 +5,7 @@
  */
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React, { Fragment } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { startCase } from 'lodash';
@@ -89,12 +89,7 @@ export class Login extends React.Component {
 			return null;
 		}
 
-		return (
-			<Fragment>
-				<TranslatorInvite locale={ locale } path={ path } />
-				<LocaleSuggestions locale={ locale } path={ path } />
-			</Fragment>
-		);
+		return <LocaleSuggestions locale={ locale } path={ path } />;
 	}
 
 	renderFooter() {
@@ -176,9 +171,8 @@ export class Login extends React.Component {
 	}
 
 	render() {
-		const { locale, privateSite, socialConnect, translate, twoFactorAuthType } = this.props;
+		const { locale, path, privateSite, socialConnect, translate, twoFactorAuthType } = this.props;
 		const canonicalUrl = addLocaleToWpcomUrl( 'https://wordpress.com/log-in', locale );
-
 		return (
 			<div>
 				<Main className="wp-login__main">
@@ -200,6 +194,7 @@ export class Login extends React.Component {
 								twoFactorAuthType={ twoFactorAuthType }
 							/>
 						) }
+						<TranslatorInvite locale={ locale } path={ path } />
 					</div>
 				</Main>
 

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -34,6 +34,7 @@ export class Login extends React.Component {
 	static propTypes = {
 		clientId: PropTypes.string,
 		isLoggedIn: PropTypes.bool.isRequired,
+		isLoginView: PropTypes.bool,
 		isJetpack: PropTypes.bool.isRequired,
 		locale: PropTypes.string.isRequired,
 		oauth2Client: PropTypes.object,
@@ -47,7 +48,7 @@ export class Login extends React.Component {
 		twoFactorAuthType: PropTypes.string,
 	};
 
-	static defaultProps = { isJetpack: false };
+	static defaultProps = { isJetpack: false, isLoginView: true };
 
 	componentDidMount() {
 		this.recordPageView( this.props );
@@ -83,9 +84,9 @@ export class Login extends React.Component {
 	}
 
 	renderI18nSuggestions() {
-		const { locale, path, twoFactorAuthType, socialConnect } = this.props;
+		const { locale, path, isLoginView } = this.props;
 
-		if ( twoFactorAuthType || socialConnect ) {
+		if ( ! isLoginView ) {
 			return null;
 		}
 
@@ -171,7 +172,15 @@ export class Login extends React.Component {
 	}
 
 	render() {
-		const { locale, path, privateSite, socialConnect, translate, twoFactorAuthType } = this.props;
+		const {
+			isLoginView,
+			locale,
+			path,
+			privateSite,
+			socialConnect,
+			translate,
+			twoFactorAuthType,
+		} = this.props;
 		const canonicalUrl = addLocaleToWpcomUrl( 'https://wordpress.com/log-in', locale );
 		return (
 			<div>
@@ -194,7 +203,7 @@ export class Login extends React.Component {
 								twoFactorAuthType={ twoFactorAuthType }
 							/>
 						) }
-						<TranslatorInvite locale={ locale } path={ path } />
+						{ isLoginView && <TranslatorInvite locale={ locale } path={ path } /> }
 					</div>
 				</Main>
 
@@ -205,10 +214,11 @@ export class Login extends React.Component {
 }
 
 export default connect(
-	state => ( {
+	( state, props ) => ( {
 		isLoggedIn: Boolean( getCurrentUserId( state ) ),
 		locale: getCurrentLocaleSlug( state ),
 		oauth2Client: getCurrentOAuth2Client( state ),
+		isLoginView: ! props.twoFactorAuthType || ! props.socialConnect,
 	} ),
 	{
 		recordPageView: withEnhancers( recordPageView, [ enhanceWithSiteType ] ),

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -203,7 +203,7 @@ export class Login extends React.Component {
 								twoFactorAuthType={ twoFactorAuthType }
 							/>
 						) }
-						{ isLoginView && <TranslatorInvite locale={ locale } path={ path } /> }
+						{ isLoginView && <TranslatorInvite path={ path } /> }
 					</div>
 				</Main>
 
@@ -218,7 +218,7 @@ export default connect(
 		isLoggedIn: Boolean( getCurrentUserId( state ) ),
 		locale: getCurrentLocaleSlug( state ),
 		oauth2Client: getCurrentOAuth2Client( state ),
-		isLoginView: ! props.twoFactorAuthType || ! props.socialConnect,
+		isLoginView: ! props.twoFactorAuthType && ! props.socialConnect,
 	} ),
 	{
 		recordPageView: withEnhancers( recordPageView, [ enhanceWithSiteType ] ),


### PR DESCRIPTION
This PR adds a nudge to the login page (underneath the form), inviting users to contribute to translating WordPress.com in a language other than English (or the default app locale). Click tracking is included.

<img width="542" alt="screen shot 2018-07-26 at 7 16 42 pm" src="https://user-images.githubusercontent.com/6458278/43253524-8816f68c-9108-11e8-9b4b-8eb9057be1fb.png">

The text is translated into the current i18n locale (via `translate`). The priority of locales considered before displaying the notice are:

1. passed down as a prop
2. in the url
3. in their browser preferences.

## Testing

Open **https://calypso.live/?branch=add/login-page-translator-nudge** in an incognito tab (or signed out) and wait for it to load.

1. Visit `/log-in` with only English in your browser language preferences.
2. Visit `/log-in/fr`
3. Add a language other than English to your browser. Visit `/log-in`
4. Try some other combos.

### Expectation

At 1: The text will not appear
At 2: The text will appear inviting you to translate to French.
At 3: The text will appear inviting you to translate to French.
