### PR TITLE
Purchases: Remove redundant PurchaseNotice props

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -445,15 +445,12 @@ class ManagePurchase extends Component {
 				) }
 				<Main className={ classes }>
 					<HeaderCake backHref={ purchasesRoot }>{ titles.managePurchase }</HeaderCake>
-					{
-						<PurchaseNotice
-							isDataLoading={ isDataLoading( this.props ) }
-							handleRenew={ this.handleRenew }
-							selectedSite={ selectedSite }
-							purchase={ purchase }
-							editCardDetailsPath={ editCardDetailsPath }
-						/>
-					}
+					<PurchaseNotice
+						handleRenew={ this.handleRenew }
+						selectedSite={ selectedSite }
+						purchase={ purchase }
+						editCardDetailsPath={ editCardDetailsPath }
+					/>
 					{ this.renderPurchaseDetail() }
 				</Main>
 			</Fragment>

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -446,6 +446,7 @@ class ManagePurchase extends Component {
 				<Main className={ classes }>
 					<HeaderCake backHref={ purchasesRoot }>{ titles.managePurchase }</HeaderCake>
 					<PurchaseNotice
+						isDataLoading={ isDataLoading( this.props ) }
 						handleRenew={ this.handleRenew }
 						selectedSite={ selectedSite }
 						purchase={ purchase }

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -37,6 +37,7 @@ const eventProperties = warning => ( { warning, position: 'individual-purchase' 
 
 class PurchaseNotice extends Component {
 	static propTypes = {
+		isDataLoading: PropTypes.bool,
 		handleRenew: PropTypes.func,
 		purchase: PropTypes.object,
 		selectedSite: PropTypes.object,
@@ -242,7 +243,7 @@ class PurchaseNotice extends Component {
 	}
 
 	render() {
-		if ( ! this.props.purchase ) {
+		if ( this.props.isDataLoading ) {
 			return null;
 		}
 

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -37,10 +37,9 @@ const eventProperties = warning => ( { warning, position: 'individual-purchase' 
 
 class PurchaseNotice extends Component {
 	static propTypes = {
-		isDataLoading: PropTypes.bool,
 		handleRenew: PropTypes.func,
 		purchase: PropTypes.object,
-		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
+		selectedSite: PropTypes.object,
 		editCardDetailsPath: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 	};
 
@@ -243,7 +242,7 @@ class PurchaseNotice extends Component {
 	}
 
 	render() {
-		if ( this.props.isDataLoading ) {
+		if ( ! this.props.purchase ) {
 			return null;
 		}
 
@@ -270,7 +269,4 @@ class PurchaseNotice extends Component {
 	}
 }
 
-const mapStateToProps = null;
-const mapDispatchToProps = { recordTracksEvent };
-
-export default connect( mapStateToProps, mapDispatchToProps )( localize( PurchaseNotice ) );
+export default connect( null, { recordTracksEvent } )( localize( PurchaseNotice ) );


### PR DESCRIPTION
Simplify props passed to `PurchaseNotice`.

- `isDataLoading` ensures the sites and purchases requests have completed. It should be sufficient to wait for a purchase to be present.
- Require `selectedSite` to be an object.
- Inline simple `connect` arguments.

## ~Known differences:~

### Changes noted in this section have been rolled back. No functional changes.

The component can be loaded when the purchase is loaded but the site is not. This may result in displaying a purchase expiration notice before the site is loaded, which changes to a purchase renewal notice when the site data is loaded. Here's the code:

This condition fails:

https://github.com/Automattic/wp-calypso/blob/fcb4b2e124b8fc1de1f456fb9490a00fe3b5d88e/client/me/purchases/manage-purchase/notices.jsx#L49

Resulting in this message being displayed initially:

![first](https://user-images.githubusercontent.com/841763/40973087-353b98fe-68c3-11e8-8044-ba480f7c4707.png)

Then updating to this:

![second](https://user-images.githubusercontent.com/841763/40973094-3747d7d4-68c3-11e8-8244-7c13bd43700f.png)

In practice its hard to encounter this situation as users should be navigating to this page with sites data loaded. Reproduce by loading the page, clearing cached state and refreshing.

## Testing
Visit https://calypso.live/me/purchases?branch=update/remove-purchase-notice-props and pick a purchase. There are a variety of notices that you may see:
- Expired purchases
- Purchases with no associated credit cards for renew
- etc.