### PR TITLE
Me: Simplify ConnectedApplications by removing request tracking

### DIFF
--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -6,7 +6,7 @@
 import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { get, times } from 'lodash';
+import { times } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -16,7 +16,6 @@ import ConnectedAppItem from 'me/connected-application-item';
 import DocumentHead from 'components/data/document-head';
 import EmptyContent from 'components/empty-content';
 import getConnectedApplications from 'state/selectors/get-connected-applications';
-import getRequest from 'state/selectors/get-request';
 import Main from 'components/main';
 import MeSidebarNavigation from 'me/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -24,7 +23,6 @@ import QueryConnectedApplications from 'components/data/query-connected-applicat
 import ReauthRequired from 'me/reauth-required';
 import SecuritySectionNav from 'me/security-section-nav';
 import twoStepAuthorization from 'lib/two-step-authorization';
-import { requestConnectedApplications } from 'state/connected-applications/actions';
 
 class ConnectedApplications extends PureComponent {
 	static propTypes = {
@@ -71,8 +69,12 @@ class ConnectedApplications extends PureComponent {
 	renderConnectedApps() {
 		const { apps } = this.props;
 
-		if ( ! apps.length ) {
+		if ( apps === null ) {
 			return this.renderPlaceholders();
+		}
+
+		if ( ! apps.length ) {
+			return this.renderEmptyContent();
 		}
 
 		return apps.map( connection => (
@@ -81,15 +83,13 @@ class ConnectedApplications extends PureComponent {
 	}
 
 	renderConnectedAppsList() {
-		const { apps, isRequestingApps, path } = this.props;
+		const { path } = this.props;
 
 		return (
 			<Fragment>
 				<SecuritySectionNav path={ path } />
 
-				{ ! isRequestingApps && ! apps.length
-					? this.renderEmptyContent()
-					: this.renderConnectedApps() }
+				{ this.renderConnectedApps() }
 			</Fragment>
 		);
 	}
@@ -118,5 +118,4 @@ class ConnectedApplications extends PureComponent {
 
 export default connect( state => ( {
 	apps: getConnectedApplications( state ),
-	isRequestingApps: get( getRequest( state, requestConnectedApplications() ), 'isLoading', false ),
 } ) )( localize( ConnectedApplications ) );

--- a/client/state/connected-applications/actions.js
+++ b/client/state/connected-applications/actions.js
@@ -17,11 +17,6 @@ import {
  */
 export const requestConnectedApplications = () => ( {
 	type: CONNECTED_APPLICATIONS_REQUEST,
-	meta: {
-		dataLayer: {
-			trackRequest: true,
-		},
-	},
 } );
 
 /**

--- a/client/state/connected-applications/reducer.js
+++ b/client/state/connected-applications/reducer.js
@@ -14,7 +14,7 @@ import {
 } from 'state/action-types';
 import schema from './schema';
 
-const reducer = ( state = [], action ) => {
+const reducer = ( state = null, action ) => {
 	switch ( action.type ) {
 		case CONNECTED_APPLICATION_DELETE_SUCCESS:
 			return reject( state, { ID: action.appId } );

--- a/client/state/connected-applications/test/actions.js
+++ b/client/state/connected-applications/test/actions.js
@@ -23,11 +23,6 @@ describe( 'actions', () => {
 
 			expect( action ).toEqual( {
 				type: CONNECTED_APPLICATIONS_REQUEST,
-				meta: {
-					dataLayer: {
-						trackRequest: true,
-					},
-				},
 			} );
 		} );
 	} );

--- a/client/state/connected-applications/test/reducer.js
+++ b/client/state/connected-applications/test/reducer.js
@@ -52,9 +52,9 @@ describe( 'reducer', () => {
 		},
 	];
 
-	test( 'should default to an empty array', () => {
+	test( 'should default to null', () => {
 		const state = reducer( undefined, {} );
-		expect( state ).toEqual( [] );
+		expect( state ).toBeNull();
 	} );
 
 	test( 'should set connected applications to empty array when user has no connected applications', () => {

--- a/client/state/selectors/get-connected-applications.js
+++ b/client/state/selectors/get-connected-applications.js
@@ -9,6 +9,6 @@ import { get } from 'lodash';
  * Returns the connected applications of the current user.
  *
  * @param  {Object} state Global state tree
- * @return {Array}        Connected applications
+ * @return {?Array}       Connected applications
  */
-export default state => get( state, 'connectedApplications', [] );
+export default state => get( state, 'connectedApplications', null );

--- a/client/state/selectors/test/get-connected-applications.js
+++ b/client/state/selectors/test/get-connected-applications.js
@@ -40,8 +40,8 @@ describe( 'getConnectedApplications()', () => {
 		expect( result ).toBe( apps );
 	} );
 
-	test( 'should return an empty array with an empty state', () => {
+	test( 'should return null with an empty state', () => {
 		const result = getConnectedApplications( undefined );
-		expect( result ).toEqual( [] );
+		expect( result ).toBeNull();
 	} );
 } );


### PR DESCRIPTION
This PR is a follow-up to https://github.com/Automattic/wp-calypso/pull/24894#discussion_r192671202 where @sirreal suggested that we simplify `ConnectedApplications` by not having to track the requests and using the `null` default state instead.

The PR updates touches several locations:
* Main connected applications request action creator - to no longer instruct data layer to track the request; tests updated
* Connected applications reducer - to default to `null`; tests updated
* Connected applications selector - to default to `null`; tests updated
* `<ConnectedApplications />` - to remove request tracking usage and simplify the rendering logic

To test:
* Checkout this branch.
* Use a slow connection speed.
* Clear your Redux store.
* Head to http://calypso.localhost:3000/me/security/connected-applications
* Verify you can see the loading state.
* Verify your connected applications load properly in that page.
* Refresh the page, verify data persists.
* Clear the state and try with a user that has no connected apps (or run `dispatch( { type: 'CONNECTED_APPLICATIONS_RECEIVE', apps: [] } )` in the console), verify you see the correct message.
* Smoke test the page to verify there are no functional/behavioral changes.