### PR TITLE
Config: Add Jetpack plan ownership change feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -77,6 +77,7 @@
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,
 		"jetpack/google-analytics-for-stores-enhanced": true,
+		"jetpack/plan-ownership-change": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,
 		"login/magic-login": true,


### PR DESCRIPTION
This PR adds a feature flag for plan ownership change and enables it only on the development environment. I'm planning to use it for a feature that is currently in development.