### PR TITLE
InlineHelp: Hide popover when rich result is actioned

### DIFF
--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -31,6 +31,7 @@ class InlineHelpRichResult extends Component {
 	static propTypes = {
 		result: PropTypes.object,
 		setDialogState: PropTypes.func.isRequired,
+		closePopover: PropTypes.func.isRequired,
 	};
 
 	handleClick = event => {
@@ -49,6 +50,7 @@ class InlineHelpRichResult extends Component {
 		);
 
 		this.props.recordTracksEvent( `calypso_inlinehelp_${ type }_open`, tracksData );
+		this.props.closePopover();
 
 		if ( type === RESULT_TOUR ) {
 			this.props.requestGuidedTour( tour );

--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -33,10 +33,6 @@ class InlineHelpRichResult extends Component {
 		setDialogState: PropTypes.func.isRequired,
 	};
 
-	state = {
-		showDialog: false,
-	};
-
 	handleClick = event => {
 		event.preventDefault();
 		const { href } = event.target;
@@ -84,10 +80,6 @@ class InlineHelpRichResult extends Component {
 				window.location = href;
 			}
 		}
-	};
-
-	onCancel = () => {
-		this.setState( { showDialog: ! this.state.showDialog } );
 	};
 
 	render() {

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -91,6 +91,7 @@ class InlineHelpPopover extends Component {
 							<InlineHelpRichResult
 								result={ this.props.selectedResult }
 								setDialogState={ this.props.setDialogState }
+								closePopover={ this.props.onClose }
 							/>
 						),
 					}[ this.state.activeSecondaryView ]


### PR DESCRIPTION
The changes in this PR aim cause the inline help popover to close when a rich result is actioned.
Until now, whether launching a tour or opening a dialog with a video or article inside, the popover would remain open in the background until an outside click closed it naturally.

### Testing

- Go to http://calypso.localhost:3000/media (It has all 3 rich result examples)
- Open inline-help
- Open 'Learn Media Library Basics' and launch the tour
  - You'll notice the popover and hide the tour start
- Open 'Add a Photo Gallery' and click 'Watch a video'
  - You'll notice the popover hide and the dialog open wit ha video inside
- Open 'Finding Free Images and other Media' and click 'Read More'
  - You'll notice the popover hide and the dialog open with a article embeded