### PR TITLE
Signup: Use the provided Site Title to pre-fill suggested domains

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -31,6 +31,7 @@ import {
 } from 'state/domains/actions';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { getCurrentUser, currentUserHasFlag } from 'state/current-user/selectors';
+import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import Notice from 'components/notice';
 import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { setDesignType } from 'state/signup/steps/design-type/actions';
@@ -247,14 +248,11 @@ class DomainsStep extends React.Component {
 	};
 
 	domainForm = () => {
+		const { siteTitle } = this.props;
 		const initialState = this.props.step ? this.props.step.domainForm : this.state.domainForm;
 		const includeDotBlogSubdomain = this.props.flowName === 'subdomain';
 
-		const suggestion = get(
-			this.props,
-			'queryObject.new',
-			get( this.props, 'signupDependencies.siteTitle', '' )
-		);
+		const suggestion = get( this.props, 'queryObject.new', siteTitle );
 
 		return (
 			<RegisterDomainStep
@@ -440,6 +438,7 @@ export default connect(
 		domainsWithPlansOnly: getCurrentUser( state )
 			? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )
 			: true,
+		siteTitle: getSiteTitle( state ),
 		surveyVertical: getSurveyVertical( state ),
 		designType: getDesignType( state ),
 	} ),

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -250,6 +250,12 @@ class DomainsStep extends React.Component {
 		const initialState = this.props.step ? this.props.step.domainForm : this.state.domainForm;
 		const includeDotBlogSubdomain = this.props.flowName === 'subdomain';
 
+		const suggestion = get(
+			this.props,
+			'queryObject.new',
+			get( this.props, 'signupDependencies.siteTitle', '' )
+		);
+
 		return (
 			<RegisterDomainStep
 				key="domainForm"
@@ -270,7 +276,7 @@ class DomainsStep extends React.Component {
 				isSignupStep
 				showExampleSuggestions
 				surveyVertical={ this.props.surveyVertical }
-				suggestion={ get( this.props, 'queryObject.new', '' ) }
+				suggestion={ suggestion }
 				designType={ this.getDesignType() }
 			/>
 		);


### PR DESCRIPTION
When you go through a signup flow that asks you to name your site before choosing a domain:

<img width="515" alt="screen shot 2018-06-05 at 3 33 01 pm" src="https://user-images.githubusercontent.com/1587282/40998445-d480d994-68d5-11e8-9831-214f0cc0abc7.png">

...we do not use that value at all when it comes to domain suggestions & customers have to type their site title again before results are shown:

<img width="1010" alt="screen shot 2018-06-05 at 3 35 02 pm" src="https://user-images.githubusercontent.com/1587282/40998512-0ad0a678-68d6-11e8-9f95-707ec465d98e.png">

## This change

When there are no domain `suggestion`s from other sources, attempt to get the siteTitle out of the state tree, so we can instantly provide suggestions based on the data already provided.

![signup-prefill-domain-suggesstions](https://user-images.githubusercontent.com/1587282/40998831-ee3d8fe8-68d6-11e8-9abc-854925075431.gif)

Fixes #25214