### PR TITLE
Activity Log: Reflect appropriate restore context in dialogs

### DIFF
--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -52,39 +52,45 @@ function ProgressBanner( {
 
 	const dateTime = applySiteOffset( moment.utc( ms( timestamp ) ) ).format( 'LLLL' );
 
-	if ( 'restore' === action && 'alternate' === context ) {
-		title = translate( 'Currently cloning your site' );
-		description = translate(
-			"We're in the process of cloning your site to %(dateTime)s. " +
-				"You'll be notified once it's complete.",
-			{ args: { dateTime } }
-		);
-		statusMessage =
-			'queued' === status
-				? translate( 'The cloning process will start in a moment.' )
-				: translate( "We're on it! Your site is being cloned." );
-	} else if ( 'restore' === action ) {
-		title = translate( 'Currently restoring your site' );
-		description = translate(
-			"We're in the process of restoring your site back to %(dateTime)s. " +
-				"You'll be notified once it's complete.",
-			{ args: { dateTime } }
-		);
-		statusMessage =
-			'queued' === status
-				? translate( 'Your restore will start in a moment.' )
-				: translate( "We're on it! Your site is being restored." );
-	} else {
-		title = translate( 'Currently creating a downloadable backup of your site' );
-		description = translate(
-			"We're in the process of creating a downloadable backup of your site at %(dateTime)s. " +
-				"You'll be notified once it's complete.",
-			{ args: { dateTime } }
-		);
-		statusMessage =
-			0 < percent
-				? translate( "We're on it! Your download is being created." )
-				: translate( 'The creation of your backup will start in a moment.' );
+	switch ( action ) {
+		case 'restore':
+			if ( 'alternate' === context ) {
+				title = translate( 'Currently cloning your site' );
+				description = translate(
+					"We're in the process of cloning your site to %(dateTime)s. " +
+						"You'll be notified once it's complete.",
+					{ args: { dateTime } }
+				);
+				statusMessage =
+					'queued' === status
+						? translate( 'The cloning process will start in a moment.' )
+						: translate( "We're on it! Your site is being cloned." );
+			} else {
+				title = translate( 'Currently restoring your site' );
+				description = translate(
+					"We're in the process of restoring your site back to %(dateTime)s. " +
+						"You'll be notified once it's complete.",
+					{ args: { dateTime } }
+				);
+				statusMessage =
+					'queued' === status
+						? translate( 'Your restore will start in a moment.' )
+						: translate( "We're on it! Your site is being restored." );
+			}
+			break;
+
+		case 'backup':
+			title = translate( 'Currently creating a downloadable backup of your site' );
+			description = translate(
+				"We're in the process of creating a downloadable backup of your site at %(dateTime)s. " +
+					"You'll be notified once it's complete.",
+				{ args: { dateTime } }
+			);
+			statusMessage =
+				0 < percent
+					? translate( "We're on it! Your download is being created." )
+					: translate( 'The creation of your backup will start in a moment.' );
+			break;
 	}
 
 	return (

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -44,48 +44,61 @@ function ProgressBanner( {
 	restoreId,
 	downloadId,
 	action,
+	context,
 } ) {
+	let title = '';
+	let description = '';
+	let statusMessage = '';
+
+	if ( 'restore' === action && 'alternate' === context ) {
+		title = translate( 'Currently cloning your site' );
+		description = translate(
+			"We're in the process of cloning your site to %s. " +
+				"You'll be notified once it's complete.",
+			{ args: applySiteOffset( moment.utc( ms( timestamp ) ) ).format( 'LLLL' ) }
+		);
+		statusMessage =
+			'queued' === status
+				? translate( 'The cloning process will start in a moment.' )
+				: translate( "We're on it! Your site is being cloned." );
+	} else if ( 'restore' === action ) {
+		title = translate( 'Currently restoring your site' );
+		description = translate(
+			"We're in the process of restoring your site back to %s. " +
+				"You'll be notified once it's complete.",
+			{ args: applySiteOffset( moment.utc( ms( timestamp ) ) ).format( 'LLLL' ) }
+		);
+		statusMessage =
+			'queued' === status
+				? translate( 'Your restore will start in a moment.' )
+				: translate( "We're on it! Your site is being restored." );
+	} else {
+		title = translate( 'Currently creating a downloadable backup of your site' );
+		description = translate(
+			"We're in the process of creating a downloadable backup of your site at %s. " +
+				"You'll be notified once it's complete.",
+			{ args: applySiteOffset( moment.utc( ms( timestamp ) ) ).format( 'LLLL' ) }
+		);
+		statusMessage =
+			0 < percent
+				? translate( "We're on it! Your download is being created." )
+				: translate( 'The creation of your backup will start in a moment.' );
+	}
+
 	return (
-		<ActivityLogBanner
-			status="info"
-			title={
-				'restore' === action
-					? translate( 'Currently restoring your site' )
-					: translate( 'Currently creating a downloadable backup of your site' )
-			}
-		>
+		<ActivityLogBanner status="info" title={ title }>
 			{ 'restore' === action && (
 				<div>
 					<QueryRewindRestoreStatus restoreId={ restoreId } siteId={ siteId } />
-					<p>
-						{ translate(
-							"We're in the process of restoring your site back to %s. " +
-								"You'll be notified once it's complete.",
-							{ args: applySiteOffset( moment.utc( ms( timestamp ) ) ).format( 'LLLL' ) }
-						) }
-					</p>
-					<em>
-						{ 'queued' === status
-							? translate( 'Your restore will start in a moment.' )
-							: translate( "We're on it! Your site is being restored." ) }
-					</em>
+					<p>{ description }</p>
+					<em>{ statusMessage }</em>
 				</div>
 			) }
 			{ 'backup' === action && (
 				<div>
 					<QueryRewindBackupStatus downloadId={ downloadId } siteId={ siteId } />
-					<p>
-						{ translate(
-							"We're in the process of creating a downloadable backup of your site at %s. " +
-								"You'll be notified once it's complete.",
-							{ args: applySiteOffset( moment.utc( ms( timestamp ) ) ).format( 'LLLL' ) }
-						) }
-					</p>
-					<em>
-						{ 0 < percent
-							? translate( "We're on it! Your download is being created." )
-							: translate( 'The creation of your backup will start in a moment.' ) }
-					</em>
+					<p>{ description }</p>
+					<em>{ statusMessage }</em>
 				</div>
 			) }
 			{ ( 'running' === status || ( 0 <= percent && percent <= 100 ) ) && (

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -50,12 +50,14 @@ function ProgressBanner( {
 	let description = '';
 	let statusMessage = '';
 
+	const dateTime = applySiteOffset( moment.utc( ms( timestamp ) ) ).format( 'LLLL' );
+
 	if ( 'restore' === action && 'alternate' === context ) {
 		title = translate( 'Currently cloning your site' );
 		description = translate(
-			"We're in the process of cloning your site to %s. " +
+			"We're in the process of cloning your site to %(dateTime)s. " +
 				"You'll be notified once it's complete.",
-			{ args: applySiteOffset( moment.utc( ms( timestamp ) ) ).format( 'LLLL' ) }
+			{ args: { dateTime } }
 		);
 		statusMessage =
 			'queued' === status
@@ -64,9 +66,9 @@ function ProgressBanner( {
 	} else if ( 'restore' === action ) {
 		title = translate( 'Currently restoring your site' );
 		description = translate(
-			"We're in the process of restoring your site back to %s. " +
+			"We're in the process of restoring your site back to %(dateTime)s. " +
 				"You'll be notified once it's complete.",
-			{ args: applySiteOffset( moment.utc( ms( timestamp ) ) ).format( 'LLLL' ) }
+			{ args: { dateTime } }
 		);
 		statusMessage =
 			'queued' === status
@@ -75,9 +77,9 @@ function ProgressBanner( {
 	} else {
 		title = translate( 'Currently creating a downloadable backup of your site' );
 		description = translate(
-			"We're in the process of creating a downloadable backup of your site at %s. " +
+			"We're in the process of creating a downloadable backup of your site at %(dateTime)s. " +
 				"You'll be notified once it's complete.",
-			{ args: applySiteOffset( moment.utc( ms( timestamp ) ) ).format( 'LLLL' ) }
+			{ args: { dateTime } }
 		);
 		statusMessage =
 			0 < percent
@@ -87,20 +89,16 @@ function ProgressBanner( {
 
 	return (
 		<ActivityLogBanner status="info" title={ title }>
-			{ 'restore' === action && (
-				<div>
+			<div>
+				{ 'restore' === action && (
 					<QueryRewindRestoreStatus restoreId={ restoreId } siteId={ siteId } />
-					<p>{ description }</p>
-					<em>{ statusMessage }</em>
-				</div>
-			) }
-			{ 'backup' === action && (
-				<div>
+				) }
+				{ 'backup' === action && (
 					<QueryRewindBackupStatus downloadId={ downloadId } siteId={ siteId } />
-					<p>{ description }</p>
-					<em>{ statusMessage }</em>
-				</div>
-			) }
+				) }
+				<p>{ description }</p>
+				<em>{ statusMessage }</em>
+			</div>
 			{ ( 'running' === status || ( 0 <= percent && percent <= 100 ) ) && (
 				<ProgressBar isPulsing value={ percent || 0 } />
 			) }

--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -92,7 +92,7 @@ class SuccessBanner extends PureComponent {
 					track: (
 						<TrackComponentView eventName="calypso_activitylog_backup_successbanner_impression" />
 					),
-					taskFinished: translate( 'We successfully created a backup of your site to %s!', {
+					taskFinished: translate( 'We successfully created a backup of your site at %s!', {
 						args: date,
 					} ),
 					actionButton: (

--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -50,6 +50,7 @@ class SuccessBanner extends PureComponent {
 		backupUrl: PropTypes.string,
 		downloadCount: PropTypes.number,
 		downloadId: PropTypes.number,
+		context: PropTypes.string,
 
 		// connect
 		dismissRestoreProgress: PropTypes.func.isRequired,
@@ -79,6 +80,7 @@ class SuccessBanner extends PureComponent {
 			timestamp,
 			translate,
 			backupUrl,
+			context,
 			trackHappyChatBackup,
 			trackHappyChatRestore,
 		} = this.props;
@@ -101,7 +103,10 @@ class SuccessBanner extends PureComponent {
 					trackHappyChat: trackHappyChatBackup,
 				}
 			: {
-					title: translate( 'Your site has been successfully restored' ),
+					title:
+						'alternate' === context
+							? translate( 'Your site has been successfully cloned' )
+							: translate( 'Your site has been successfully restored' ),
 					icon: 'history',
 					track: (
 						<TrackComponentView
@@ -109,9 +114,10 @@ class SuccessBanner extends PureComponent {
 							eventProperties={ { restore_to: timestamp } }
 						/>
 					),
-					taskFinished: translate( 'We successfully restored your site back to %s!', {
-						args: date,
-					} ),
+					taskFinished:
+						'alternate' === context
+							? translate( 'We successfully cloned your site to %s!', { args: date } )
+							: translate( 'We successfully restored your site back to %s!', { args: date } ),
 					actionButton: (
 						<Button href={ siteUrl } primary>
 							{ translate( 'View site' ) }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -211,6 +211,7 @@ class ActivityLog extends Component {
 			status,
 			timestamp,
 			rewindId,
+			context,
 		} = actionProgress;
 		return (
 			<ProgressBanner
@@ -223,6 +224,7 @@ class ActivityLog extends Component {
 				status={ status }
 				timestamp={ timestamp || rewindId }
 				action={ action }
+				context={ context }
 			/>
 		);
 	}
@@ -245,6 +247,7 @@ class ActivityLog extends Component {
 			restoreId,
 			downloadId,
 			rewindId,
+			context,
 		} = progress;
 		const requestedRestoreId = this.props.requestedRestoreId || rewindId;
 		return (
@@ -262,6 +265,7 @@ class ActivityLog extends Component {
 						siteId={ siteId }
 						siteTitle={ siteTitle }
 						timestamp={ timestamp }
+						context={ context }
 					/>
 				) : (
 					<SuccessBanner
@@ -272,6 +276,7 @@ class ActivityLog extends Component {
 						downloadId={ downloadId }
 						backupUrl={ url }
 						downloadCount={ downloadCount }
+						context={ context }
 					/>
 				) }
 			</div>

--- a/client/state/activity-log/restore/reducer.js
+++ b/client/state/activity-log/restore/reducer.js
@@ -26,7 +26,7 @@ const startProgress = ( state, { timestamp } ) => ( {
 
 const updateProgress = (
 	state,
-	{ errorCode, failureReason, message, percent, restoreId, status, timestamp, rewindId }
+	{ errorCode, failureReason, message, percent, restoreId, status, timestamp, rewindId, context }
 ) => ( {
 	errorCode,
 	failureReason,
@@ -36,6 +36,7 @@ const updateProgress = (
 	status,
 	timestamp,
 	rewindId,
+	context,
 } );
 
 export const restoreProgress = keyedReducer(

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
@@ -63,6 +63,7 @@ export const fromApi = ( {
 		percent = 0,
 		status = '',
 		rewind_id = '',
+		context = '',
 	} = {},
 } ) => ( {
 	errorCode: error_code,
@@ -71,6 +72,7 @@ export const fromApi = ( {
 	percent: +percent,
 	status,
 	rewindId: rewind_id,
+	context,
 } );
 
 export const updateProgress = ( { siteId, restoreId, timestamp }, data ) =>

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/test/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/test/index.js
@@ -24,6 +24,7 @@ const FINISHED_RESPONSE = deepFreeze( {
 		percent: 100,
 		status: 'finished',
 		rewindId: '',
+		context: 'main',
 	},
 } );
 
@@ -37,6 +38,7 @@ describe( 'receiveRestoreProgress', () => {
 			percent: 100,
 			status: 'finished',
 			rewindId: '',
+			context: 'main',
 		} );
 		expect( action ).toEqual( expectedAction );
 	} );


### PR DESCRIPTION
With the introduction of cloning, the progress dialogs need to be updated to reflect context. Currently, there are only two contexts and adding additional contexts is tricky. This PR makes adding contexts more straightforward, as well as adds the cloning context.

**Testing Instructions**

1. Perform a Rewind. Check the progress dialog, success dialog, and error dialog. They should all reflect that a rewind/restore is/has happened.
2. Perform a Clone. Check the progress dialog, success dialog, and error dialog. They should all reflect that a rewind/clone is/has happened.
3. Create a downloadable backup. Check that the progress dialog, success dialog, and error dialog all reflect that a backup is being created.
