### PR TITLE
Store Product Categories: Remove the fixed width on the terms container

### DIFF
--- a/client/extensions/woocommerce/app/product-categories/form.js
+++ b/client/extensions/woocommerce/app/product-categories/form.js
@@ -285,7 +285,6 @@ class ProductCategoryForm extends Component {
 											onChange={ this.setParent }
 											multiple={ false }
 											height={ 300 }
-											width={ 400 }
 											hideTermAndChildren={ ( isNumber( category.id ) && category.id ) || null }
 											query={ query }
 											onSearch={ this.onSearch }


### PR DESCRIPTION
Fixes #21741 – the product category terms container has a fixed width, causing deeply nested product categories to overflow horizontally and be cut off.

<img width="465" alt="screen shot 2018-06-05 at 5 22 10 pm" src="https://user-images.githubusercontent.com/541093/41003579-17d5c5c4-68e5-11e8-850a-4492bfa87f5e.png">

This also causes improbably long names to wrap early:

<img width="457" alt="screen shot 2018-06-05 at 5 22 17 pm" src="https://user-images.githubusercontent.com/541093/41003578-17c23aa4-68e5-11e8-8980-4d04abe89a79.png">

This PR removes the fixed width, which at least fixes the problem for desktop users - the container is not prematurely cut off:

<img width="698" alt="screen shot 2018-06-05 at 5 24 38 pm" src="https://user-images.githubusercontent.com/541093/41003663-62ba3e4e-68e5-11e8-82ee-52109fee3f73.png">
<img width="707" alt="screen shot 2018-06-05 at 5 24 49 pm" src="https://user-images.githubusercontent.com/541093/41003664-62d6aeee-68e5-11e8-852d-90397882cca9.png">

This doesn't fix this for mobile screens, the ReactVirtualized list itself doesn't seem to support horizontal scrolling, so if the parent (browser) is too narrow, the terms are cut off and they can't be clicked.

**To test**

- Create a ridiculous amount of nested categories
- Create a new category, `/store/products/category/:site`
- Check that you can select deeply nested categories
