### PR TITLE
Framework: `dispatchRequest` update (concierge available times)

### DIFF
--- a/client/state/data-layer/wpcom/concierge/schedules/available-times/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/available-times/index.js
@@ -9,43 +9,37 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { updateConciergeAvailableTimes } from 'state/concierge/actions';
 import { errorNotice } from 'state/notices/actions';
 import { CONCIERGE_AVAILABLE_TIMES_REQUEST } from 'state/action-types';
 import fromApi from './from-api';
 
-export const fetchConciergeAvailableTimes = ( { dispatch }, action ) => {
-	const { scheduleId } = action;
-
-	dispatch(
-		http(
-			{
-				method: 'GET',
-				path: `/concierge/schedules/${ scheduleId }/available_times`,
-				apiNamespace: 'wpcom/v2',
-			},
-			action
-		)
+export const fetchConciergeAvailableTimes = action =>
+	http(
+		{
+			method: 'GET',
+			path: `/concierge/schedules/${ action.scheduleId }/available_times`,
+			apiNamespace: 'wpcom/v2',
+		},
+		action
 	);
-};
 
-export const storeFetchedConciergeAvailableTimes = ( { dispatch }, action, availableTimes ) =>
-	dispatch( updateConciergeAvailableTimes( availableTimes ) );
+export const storeFetchedConciergeAvailableTimes = ( action, availableTimes ) =>
+	updateConciergeAvailableTimes( availableTimes );
 
 export const conciergeAvailableTimesFetchError = () =>
 	errorNotice( translate( "We couldn't load our Concierge schedule. Please try again later." ) );
 
-export const showConciergeAvailableTimesFetchError = ( { dispatch } ) =>
-	dispatch( conciergeAvailableTimesFetchError() );
+export const showConciergeAvailableTimesFetchError = () => conciergeAvailableTimesFetchError();
 
 export default {
 	[ CONCIERGE_AVAILABLE_TIMES_REQUEST ]: [
-		dispatchRequest(
-			fetchConciergeAvailableTimes,
-			storeFetchedConciergeAvailableTimes,
-			showConciergeAvailableTimesFetchError,
-			{ fromApi }
-		),
+		dispatchRequestEx( {
+			fetch: fetchConciergeAvailableTimes,
+			onSuccess: storeFetchedConciergeAvailableTimes,
+			onError: showConciergeAvailableTimesFetchError,
+			fromApi,
+		} ),
 	],
 };

--- a/client/state/data-layer/wpcom/concierge/schedules/available-times/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/available-times/test/index.js
@@ -21,15 +21,12 @@ jest.mock( 'lib/impure-lodash', () => ( {
 describe( 'wpcom-api', () => {
 	describe( 'concierge', () => {
 		test( 'fetchConciergeAvailableTimes()', () => {
-			const dispatch = jest.fn();
 			const action = {
 				type: CONCIERGE_AVAILABLE_TIMES_REQUEST,
 				scheduleId: 123,
 			};
 
-			fetchConciergeAvailableTimes( { dispatch }, action );
-
-			expect( dispatch ).toHaveBeenCalledWith(
+			expect( fetchConciergeAvailableTimes( action ) ).toEqual(
 				http(
 					{
 						method: 'GET',
@@ -42,26 +39,21 @@ describe( 'wpcom-api', () => {
 		} );
 
 		test( 'storeFetchedConciergeAvailableTimes()', () => {
-			const dispatch = jest.fn();
 			const mockAvailableTimes = [
 				new Date( '2017-01-01 01:00:00' ),
 				new Date( '2017-01-01 02:00:00' ),
 				new Date( '2017-01-01 03:00:00' ),
 			];
 
-			storeFetchedConciergeAvailableTimes( { dispatch }, {}, mockAvailableTimes );
-
-			expect( dispatch ).toHaveBeenCalledWith(
+			expect( storeFetchedConciergeAvailableTimes( {}, mockAvailableTimes ) ).toEqual(
 				updateConciergeAvailableTimes( mockAvailableTimes )
 			);
 		} );
 
 		test( 'showConciergeAvailableTimesFetchError()', () => {
-			const dispatch = jest.fn();
-
-			showConciergeAvailableTimesFetchError( { dispatch } );
-
-			expect( dispatch ).toHaveBeenCalledWith( conciergeAvailableTimesFetchError() );
+			expect( showConciergeAvailableTimesFetchError() ).toEqual(
+				conciergeAvailableTimesFetchError()
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
See #25121

In this patch we're replacing the use of dispatchRequest()
in the data layer handler to use the newer API exposed
as dispatchRequestEx() This should have no change in
actual effect or interaction.