### PR TITLE
Reader: only show likes popover when post has likes

### DIFF
--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -15,6 +15,8 @@ import { markPostSeen } from 'state/reader/posts/actions';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 import { getPostByKey } from 'state/reader/posts/selectors';
 import { isEnabled } from 'config';
+import QueryPostLikes from 'components/data/query-post-likes';
+import getPostLikeCount from 'state/selectors/get-post-like-count';
 
 class ReaderLikeButton extends React.Component {
 	constructor( props ) {
@@ -73,11 +75,12 @@ class ReaderLikeButton extends React.Component {
 	};
 
 	render() {
-		const { siteId, postId } = this.props;
+		const { siteId, postId, likeCount } = this.props;
 		const { showLikesPopover, likesPopoverContext } = this.state;
 
 		return (
 			<Fragment>
+				<QueryPostLikes siteId={ siteId } postId={ postId } />
 				<LikeButtonContainer
 					{ ...this.props }
 					ref={ this.setLikesPopoverContext }
@@ -88,7 +91,8 @@ class ReaderLikeButton extends React.Component {
 				/>
 				{ showLikesPopover &&
 					siteId &&
-					postId && (
+					postId &&
+					likeCount > 0 && (
 						<PostLikesPopover
 							className="reader-likes-popover" // eslint-disable-line
 							onMouseEnter={ this.maybeShowLikesPopover }
@@ -104,4 +108,11 @@ class ReaderLikeButton extends React.Component {
 	}
 }
 
-export default connect( null, { markPostSeen } )( ReaderLikeButton );
+export default connect(
+	( state, { siteId, postId } ) => {
+		return {
+			likeCount: getPostLikeCount( state, siteId, postId ),
+		};
+	},
+	{ markPostSeen }
+)( ReaderLikeButton );

--- a/config/development.json
+++ b/config/development.json
@@ -146,6 +146,7 @@
 		"reader/conversations": true,
 		"reader/following-intro": true,
 		"reader/full-errors": true,
+		"reader/likes-hover": true,
 		"reader/list-management": false,
 		"reader/nesting-arrow": true,
 		"reader/paste-to-link": true,


### PR DESCRIPTION
Following on from https://github.com/Automattic/wp-calypso/pull/24612, this PR hides the experimental post likes popover when a post has no likes.

Previously, it popped up with a redundant message saying "there are no likes on this post yet".

No likes:

<img width="170" alt="screen shot 2018-06-06 at 11 44 34" src="https://user-images.githubusercontent.com/17325/41008412-0383eade-697f-11e8-94c3-750c4bc52414.png">

Has likes:

<img width="168" alt="screen shot 2018-06-06 at 11 44 22" src="https://user-images.githubusercontent.com/17325/41008417-06f6b9b2-697f-11e8-9ccb-c3a73e3feee2.png">

### To test

Load a Reader stream at http://calypso.localhost:3000/ and hover over like buttons.

Note: this feature is not enabled in all environments, so best to test locally.