### PR TITLE
Focusable: Allow no click handler

### DIFF
--- a/client/components/focusable/index.jsx
+++ b/client/components/focusable/index.jsx
@@ -5,7 +5,6 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { noop } from 'lodash';
 
 class Focusable extends Component {
 	static propTypes = {
@@ -13,11 +12,9 @@ class Focusable extends Component {
 		onKeyDown: PropTypes.func,
 	};
 
-	static defaultProps = { onClick: noop };
-
 	onKeyDown = event => {
 		const { onClick, onKeyDown } = this.props;
-		if ( event.key === 'Enter' || event.key === ' ' ) {
+		if ( onClick && ( event.key === 'Enter' || event.key === ' ' ) ) {
 			event.preventDefault();
 			onClick( event );
 		}
@@ -34,7 +31,6 @@ class Focusable extends Component {
 				className={ classNames( 'focusable', className ) }
 				role="button"
 				tabIndex="0"
-				onClick={ this.props.onClick }
 				onKeyDown={ this.onKeyDown }
 			>
 				{ children }

--- a/client/components/focusable/index.jsx
+++ b/client/components/focusable/index.jsx
@@ -2,10 +2,10 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
 import classNames from 'classnames';
-import { omit } from 'lodash';
 import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { noop } from 'lodash';
 
 class Focusable extends Component {
 	static propTypes = {
@@ -13,13 +13,10 @@ class Focusable extends Component {
 		onKeyDown: PropTypes.func,
 	};
 
-	onClick = event => {
-		const { onClick } = this.props;
-		onClick( event );
-	};
+	static defaultProps = { onClick: noop };
 
 	onKeyDown = event => {
-		const { onClick, onKeyDown = false } = this.props;
+		const { onClick, onKeyDown } = this.props;
 		if ( event.key === 'Enter' || event.key === ' ' ) {
 			event.preventDefault();
 			onClick( event );
@@ -30,17 +27,15 @@ class Focusable extends Component {
 	};
 
 	render = () => {
-		const { children, className } = this.props;
-		const omitProps = [ 'children', 'className', 'onClick', 'onKeyDown', 'role', 'tabIndex' ];
-		const props = omit( this.props, omitProps );
+		const { children, className, ...passProps } = this.props;
 		return (
 			<div
+				{ ...passProps }
 				className={ classNames( 'focusable', className ) }
 				role="button"
 				tabIndex="0"
-				onClick={ this.onClick }
+				onClick={ this.props.onClick }
 				onKeyDown={ this.onKeyDown }
-				{ ...props }
 			>
 				{ children }
 			</div>


### PR DESCRIPTION
Require `onClick` via `propTypes`, but ensure that no provided `onClick` prop does not result in an error.

Simplify some implementation bits of the `Focusable` component.

Inspired by work on #25302

## Testing
Focusable is used by checklist-tasks. Make sure they still work! You can find them here:
- https://calypso.live/checklist/:SITE_SLUG/?branch=update/focusable
- https://calypso.live/devdocs/blocks/checklist/?branch=update/focusable

![focusable](https://user-images.githubusercontent.com/841763/41095452-bfd6a064-6a51-11e8-85b3-5fbbd3ac1e7e.png)
