### PR TITLE
Fix/purchases a11y anchor

### DIFF
--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -25,7 +25,7 @@ class Card extends PureComponent {
 	static propTypes = {
 		className: PropTypes.string,
 		href: PropTypes.string,
-		tagName: PropTypes.string,
+		tagName: PropTypes.oneOfType( [ PropTypes.func, PropTypes.string ] ).isRequired,
 		target: PropTypes.string,
 		compact: PropTypes.bool,
 		highlight: PropTypes.oneOf( [ false, 'error', 'info', 'success', 'warning' ] ),

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -260,7 +260,8 @@ class RemovePurchase extends Component {
 	};
 
 	renderDomainDialog() {
-		const { translate } = this.props;
+		const { purchase, translate } = this.props;
+		const productName = getName( purchase );
 		const buttons = [
 			{
 				action: 'cancel',
@@ -275,7 +276,6 @@ class RemovePurchase extends Component {
 				onClick: this.removePurchase,
 			},
 		];
-		const productName = getName( this.props.purchase );
 
 		if (
 			config.isEnabled( 'upgrades/precancellation-chat' ) &&
@@ -294,24 +294,15 @@ class RemovePurchase extends Component {
 				<FormSectionHeading>
 					{ translate( 'Remove %(productName)s', { args: { productName } } ) }
 				</FormSectionHeading>
-				{ this.renderDomainDialogText() }
+				<p>
+					{ translate(
+						'This will remove %(domain)s from your account. By removing, ' +
+							'you are canceling the domain registration. This may stop ' +
+							'you from using it again, even with another service.',
+						{ args: { domain: productName } }
+					) }
+				</p>
 			</Dialog>
-		);
-	}
-
-	renderDomainDialogText() {
-		const { purchase, translate } = this.props;
-		const productName = getName( purchase );
-
-		return (
-			<p>
-				{ translate(
-					'This will remove %(domain)s from your account. By removing, ' +
-						'you are canceling the domain registration. This may stop ' +
-						'you from using it again, even with another service.',
-					{ args: { domain: productName } }
-				) }
-			</p>
 		);
 	}
 

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -44,7 +44,6 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import HappychatButton from 'components/happychat/button';
 import isPrecancellationChatAvailable from 'state/happychat/selectors/is-precancellation-chat-available';
 import { getCurrentUserId } from 'state/current-user/selectors';
-import Focusable from 'components/focusable';
 
 /**
  * Module dependencies
@@ -464,11 +463,7 @@ class RemovePurchase extends Component {
 
 		return (
 			<Fragment>
-				<CompactCard
-					tagName={ Focusable }
-					className="remove-purchase__card"
-					onClick={ this.openDialog }
-				>
+				<CompactCard tagName="button" className="remove-purchase__card" onClick={ this.openDialog }>
 					<Gridicon icon="trash" />
 					{ translate( 'Remove %(productName)s', { args: { productName } } ) }
 				</CompactCard>

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -44,6 +44,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import HappychatButton from 'components/happychat/button';
 import isPrecancellationChatAvailable from 'state/happychat/selectors/is-precancellation-chat-available';
 import { getCurrentUserId } from 'state/current-user/selectors';
+import Focusable from 'components/focusable';
 
 /**
  * Module dependencies
@@ -234,11 +235,13 @@ class RemovePurchase extends Component {
 		const productName = getName( this.props.purchase );
 
 		return (
-			<CompactCard className="remove-purchase__card" onClick={ this.openDialog }>
-				<a href="#">
-					<Gridicon icon="trash" />
-					{ translate( 'Remove %(productName)s', { args: { productName } } ) }
-				</a>
+			<CompactCard
+				tagName={ Focusable }
+				className="remove-purchase__card"
+				onClick={ this.openDialog }
+			>
+				<Gridicon icon="trash" />
+				{ translate( 'Remove %(productName)s', { args: { productName } } ) }
 			</CompactCard>
 		);
 	};

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -5,7 +5,7 @@
 import { connect } from 'react-redux';
 import page from 'page';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import Gridicon from 'gridicons';
 import { localize, moment } from 'i18n-calypso';
 import { get } from 'lodash';
@@ -483,10 +483,10 @@ class RemovePurchase extends Component {
 		}
 
 		return (
-			<span>
+			<Fragment>
 				{ this.renderCard() }
 				{ this.renderDialog( purchase ) }
-			</span>
+			</Fragment>
 		);
 	}
 }

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -230,22 +230,6 @@ class RemovePurchase extends Component {
 		} );
 	};
 
-	renderCard = () => {
-		const { translate } = this.props;
-		const productName = getName( this.props.purchase );
-
-		return (
-			<CompactCard
-				tagName={ Focusable }
-				className="remove-purchase__card"
-				onClick={ this.openDialog }
-			>
-				<Gridicon icon="trash" />
-				{ translate( 'Remove %(productName)s', { args: { productName } } ) }
-			</CompactCard>
-		);
-	};
-
 	getChatButton = () => {
 		return (
 			<HappychatButton className="remove-purchase__chat-button" onClick={ this.chatButtonClicked }>
@@ -471,14 +455,24 @@ class RemovePurchase extends Component {
 			return null;
 		}
 
-		const purchase = this.props.purchase;
+		const { purchase, translate } = this.props;
+		const productName = getName( purchase );
+
 		if ( ! isRemovable( purchase ) ) {
 			return null;
 		}
 
 		return (
 			<Fragment>
-				{ this.renderCard() }
+				<CompactCard
+					tagName={ Focusable }
+					className="remove-purchase__card"
+					onClick={ this.openDialog }
+				>
+					<Gridicon icon="trash" />
+					{ translate( 'Remove %(productName)s', { args: { productName } } ) }
+				</CompactCard>
+
 				{ this.renderDialog( purchase ) }
 			</Fragment>
 		);

--- a/client/me/purchases/remove-purchase/style.scss
+++ b/client/me/purchases/remove-purchase/style.scss
@@ -6,6 +6,13 @@
 
 .remove-purchase__card {
 	cursor: pointer;
+	color: $blue-wordpress;
+
+	&:active,
+	&:focus,
+	&:hover {
+		color: $link-highlight;
+	}
 
 	.gridicon {
 		margin-top: -2px;

--- a/client/me/purchases/remove-purchase/style.scss
+++ b/client/me/purchases/remove-purchase/style.scss
@@ -5,8 +5,9 @@
 }
 
 .remove-purchase__card {
-	cursor: pointer;
 	color: $blue-wordpress;
+	text-align: left;
+	width: 100%;
 
 	&:active,
 	&:focus,

--- a/client/me/purchases/remove-purchase/style.scss
+++ b/client/me/purchases/remove-purchase/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 .remove-purchase__dialog {
 	max-width: 500px;
 }
@@ -15,7 +17,7 @@
 .remove-purchase__chat-button {
 	display: block;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		float: left;
 	}
 }


### PR DESCRIPTION
Fix a11y lint error
Refactor component for clarity

This component is responsible for the purchase removal button and following dialogs from the manage purchase view:

![remove](https://user-images.githubusercontent.com/841763/41037580-ff99bdc6-6993-11e8-9e0f-6386542cf18e.png)


## Testing
1. https://calypso.live/me/purchases?branch=fix/purchases-a11y-anchor
1. Click a variety of purchase types
1. Verify the RemovePurhcase component works as before:
   - Atomic purchase
   - Domain purchase
   - "Normal" plan purchase
1. Ensure you try both keyboard focus
   - tab to element and use <kbd>Return</kbd> and <kbd>space</kbd>
   - Use mouse interaction
1. Are hover/focus styles ok?