### PR TITLE
Form: Further reduxify countries

### DIFF
--- a/client/components/data/query-countries/README.md
+++ b/client/components/data/query-countries/README.md
@@ -1,0 +1,22 @@
+Query Countries
+===============
+
+`QueryDomainCountries`, `QueryPaymentCountries`, and `QuerySmsCountries` are React components used in managing network requests for lists of countries.
+
+## Usage
+
+Render the component without props. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+
+```jsx
+import React from 'react';
+import QueryDomainCountries from 'components/data/query-countries/domains';
+
+export default function CountriesList( { countries } ) {
+	return (
+		<ul>
+			<QueryDomainCountries />
+			{ countries.map( ( country ) => <li>{ country.label }</li> ) }
+		</ul>
+	);
+}
+```

--- a/client/components/data/query-countries/domains.jsx
+++ b/client/components/data/query-countries/domains.jsx
@@ -1,0 +1,22 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import areCountriesFetching from 'state/selectors/are-countries-fetching';
+import QueryCountries from 'components/data/query-countries';
+import { fetchDomainCountries } from 'state/countries/actions';
+
+export default connect(
+	state => ( {
+		isRequesting: areCountriesFetching( state, 'domains' ),
+	} ),
+	{
+		requestCountries: fetchDomainCountries,
+	}
+)( QueryCountries );

--- a/client/components/data/query-countries/index.jsx
+++ b/client/components/data/query-countries/index.jsx
@@ -1,0 +1,24 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+
+export default class QueryCountries extends Component {
+	static propTypes = {
+		isRequesting: PropTypes.bool.isRequired,
+		requestCountries: PropTypes.func.isRequired,
+	};
+
+	componentDidMount() {
+		if ( ! this.props.isRequesting ) {
+			this.props.requestCountries();
+		}
+	}
+
+	render() {
+		return null;
+	}
+}

--- a/client/components/data/query-countries/payments.jsx
+++ b/client/components/data/query-countries/payments.jsx
@@ -1,0 +1,22 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import areCountriesFetching from 'state/selectors/are-countries-fetching';
+import QueryCountries from 'components/data/query-countries';
+import { fetchPaymentCountries } from 'state/countries/actions';
+
+export default connect(
+	state => ( {
+		isRequesting: areCountriesFetching( state, 'payments' ),
+	} ),
+	{
+		requestCountries: fetchPaymentCountries,
+	}
+)( QueryCountries );

--- a/client/components/data/query-countries/sms.jsx
+++ b/client/components/data/query-countries/sms.jsx
@@ -1,0 +1,22 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import areCountriesFetching from 'state/selectors/are-countries-fetching';
+import QueryCountries from 'components/data/query-countries';
+import { fetchSmsCountries } from 'state/countries/actions';
+
+export default connect(
+	state => ( {
+		isRequesting: areCountriesFetching( state, 'sms' ),
+	} ),
+	{
+		requestCountries: fetchSmsCountries,
+	}
+)( QueryCountries );

--- a/client/components/forms/form-country-select/index.jsx
+++ b/client/components/forms/form-country-select/index.jsx
@@ -23,7 +23,6 @@ export default localize(
 					{
 						key: '',
 						label: this.props.translate( 'Loading…' ),
-						disabled: true,
 					},
 				];
 			}

--- a/client/components/forms/form-country-select/index.jsx
+++ b/client/components/forms/form-country-select/index.jsx
@@ -11,6 +11,9 @@ import observe from 'lib/mixins/data-observe';
 import { isEmpty, omit } from 'lodash';
 import { localize } from 'i18n-calypso';
 
+/* mixins need to be refactored out eventually */
+/* eslint-disable react/prefer-es6-class */
+/* eslint-disable jsx-a11y/no-onchange */
 export const FormCountrySelect = createReactClass( {
 	displayName: 'FormCountrySelect',
 
@@ -29,7 +32,7 @@ export const FormCountrySelect = createReactClass( {
 			key: idx,
 			label: name,
 			code,
-			disabled: !code,
+			disabled: ! code,
 		} ) );
 	},
 
@@ -61,5 +64,7 @@ export const FormCountrySelect = createReactClass( {
 		);
 	},
 } );
+/* eslint-enable jsx-a11y/no-onchange */
+/* eslint-enable react/prefer-es6-class */
 
 export default localize( FormCountrySelect );

--- a/client/components/forms/form-country-select/index.jsx
+++ b/client/components/forms/form-country-select/index.jsx
@@ -11,55 +11,55 @@ import observe from 'lib/mixins/data-observe';
 import { isEmpty, omit } from 'lodash';
 import { localize } from 'i18n-calypso';
 
-export default localize(
-	createReactClass( {
-		displayName: 'FormCountrySelect',
+export const FormCountrySelect = createReactClass( {
+	displayName: 'FormCountrySelect',
 
-		mixins: [ observe( 'countriesList' ) ],
+	mixins: [ observe( 'countriesList' ) ],
 
-		getOptions( countriesList ) {
-			if ( isEmpty( countriesList ) ) {
-				return [
-					{
-						key: '',
-						label: this.props.translate( 'Loading…' ),
-					},
-				];
-			}
-			return countriesList.map( ( { code, name }, idx ) => ( {
-				key: idx,
-				label: name,
-				code,
-				disabled: ! code,
-			} ) );
-		},
+	getOptions( countriesList ) {
+		if ( isEmpty( countriesList ) ) {
+			return [
+				{
+					key: '',
+					label: this.props.translate( 'Loading…' ),
+				},
+			];
+		}
+		return countriesList.map( ( { code, name }, idx ) => ( {
+			key: idx,
+			label: name,
+			code,
+			disabled: !code,
+		} ) );
+	},
 
-		render() {
-			const countriesList = this.props.countriesList.get(),
-				options = this.getOptions( countriesList );
+	render() {
+		const countriesList = this.props.countriesList.get(),
+			options = this.getOptions( countriesList );
 
-			return (
-				<select
-					{ ...omit( this.props, [
-						'className',
-						'countriesList',
-						'translate',
-						'moment',
-						'numberFormat',
-					] ) }
-					className={ classnames( this.props.className, 'form-country-select' ) }
-					onChange={ this.props.onChange }
-					disabled={ this.props.disabled }
-				>
-					{ options.map( function( option ) {
-						return (
-							<option key={ option.key } value={ option.code } disabled={ option.disabled }>
-								{ option.label }
-							</option>
-						);
-					} ) }
-				</select>
-			);
-		},
-	} )
-);
+		return (
+			<select
+				{ ...omit( this.props, [
+					'className',
+					'countriesList',
+					'translate',
+					'moment',
+					'numberFormat',
+				] ) }
+				className={ classnames( this.props.className, 'form-country-select' ) }
+				onChange={ this.props.onChange }
+				disabled={ this.props.disabled }
+			>
+				{ options.map( function( option ) {
+					return (
+						<option key={ option.key } value={ option.code } disabled={ option.disabled }>
+							{ option.label }
+						</option>
+					);
+				} ) }
+			</select>
+		);
+	},
+} );
+
+export default localize( FormCountrySelect );

--- a/client/components/forms/form-country-select/test/index.jsx
+++ b/client/components/forms/form-country-select/test/index.jsx
@@ -1,0 +1,62 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { identity } from 'lodash';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import CountriesList from 'components/forms/form-country-select/test/mocks/mock-countries-list';
+import { FormCountrySelect } from 'components/forms/form-country-select';
+
+describe( 'FormCountrySelect', () => {
+	let countriesList;
+
+	beforeEach( () => {
+		countriesList = new CountriesList();
+	} );
+
+	test( 'should render a select box with a placeholder when the country list provided is empty', () => {
+		const select = shallow( <FormCountrySelect countriesList={ countriesList } translate={ identity } /> );
+
+		const options = select.find( 'option' );
+		expect( options ).to.have.length( 1 );
+
+		const option = options.first();
+		expect( option.text() ).to.equal( 'Loading…' );
+	} );
+
+	test( 'should render a select box with options matching the country list provided', () => {
+		countriesList.fetch();
+
+		const select = shallow( <FormCountrySelect countriesList={ countriesList } translate={ identity } /> );
+
+		const options = select.find( 'option' );
+		expect( options ).to.have.length( 2 );
+
+		const option = options.first();
+		expect( option.text() ).to.equal( 'United States (+1)' );
+	} );
+
+	test( 'should react to country list changes and rerender', () => {
+		countriesList.fetch();
+
+		const component = <FormCountrySelect countriesList={ countriesList } translate={ identity } />;
+
+		// Let's clear the list after the component was rendered
+		countriesList.clear();
+
+		const select = shallow( component );
+
+		const options = select.find( 'option' );
+		expect( options ).to.have.length( 1 );
+
+		const option = options.first();
+		expect( option.text() ).to.equal( 'Loading…' );
+	} );
+} );

--- a/client/components/forms/form-country-select/test/mocks/mock-countries-list.js
+++ b/client/components/forms/form-country-select/test/mocks/mock-countries-list.js
@@ -1,0 +1,46 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import makeEmitter from 'lib/mixins/emitter';
+
+/**
+ * @see client/lib/countries-list
+ */
+function CountriesList() {
+	this.list = [];
+
+	this.clear = () => {
+		this.list = [];
+
+		this.emit( 'change' );
+	};
+
+	this.fetch = () => {
+		this.list = [
+			{
+				code: 'US',
+				name: 'United States (+1)',
+				numeric_code: '+1',
+				country_name: 'United States',
+			},
+			{
+				code: 'AR',
+				name: 'Argentina (+54)',
+				numeric_code: '+54',
+				country_name: 'Argentina',
+			},
+		];
+
+		this.emit( 'change' );
+	};
+
+	this.get = () => {
+		return this.list;
+	};
+}
+
+makeEmitter( CountriesList.prototype );
+
+export default CountriesList;

--- a/client/my-sites/domains/components/form/country-select.jsx
+++ b/client/my-sites/domains/components/form/country-select.jsx
@@ -52,7 +52,6 @@ const CountrySelect = createReactClass( {
 			options.push( {
 				key: 'loading',
 				label: this.props.translate( 'Loading…' ),
-				disabled: 'disabled',
 			} );
 		} else {
 			options = options.concat( [

--- a/client/state/countries/actions.js
+++ b/client/state/countries/actions.js
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import {
+	COUNTRIES_DOMAINS_FETCH,
+	COUNTRIES_PAYMENTS_FETCH,
+	COUNTRIES_SMS_FETCH
+} from 'state/action-types';
+
+export const fetchDomainCountries = () => ( { type: COUNTRIES_DOMAINS_FETCH } );
+
+export const fetchPaymentCountries = () => ( { type: COUNTRIES_PAYMENTS_FETCH } );
+
+export const fetchSmsCountries = () => ( { type: COUNTRIES_SMS_FETCH } );

--- a/client/state/countries/reducer.js
+++ b/client/state/countries/reducer.js
@@ -1,25 +1,40 @@
 /** @format */
+
 /**
  * External dependencies
  */
-import { createReducer, combineReducers } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import {
+	COUNTRIES_DOMAINS_FETCH,
 	COUNTRIES_DOMAINS_UPDATED,
+	COUNTRIES_PAYMENTS_FETCH,
 	COUNTRIES_PAYMENTS_UPDATED,
+	COUNTRIES_SMS_FETCH,
 	COUNTRIES_SMS_UPDATED,
 } from 'state/action-types';
 
-const domains = createReducer( [], {
-	[ COUNTRIES_DOMAINS_UPDATED ]: ( countries, action ) => action.countries,
-} );
+const createListReducer = ( fetchActionType, updatedActionType ) => createReducer(
+	{
+		isFetching: false,
+		items: [],
+	},
+	{
+		[ fetchActionType ]: ( state ) => ( {
+			...state,
+			isFetching: true
+		} ),
+		[ updatedActionType ]: ( state, action ) => ( {
+			isFetching: false,
+			items: action.countries,
+		} )
+	}
+);
 
-const payments = createReducer( [], {
-	[ COUNTRIES_PAYMENTS_UPDATED ]: ( countries, action ) => action.countries,
-} );
+const domains = createListReducer( COUNTRIES_DOMAINS_FETCH, COUNTRIES_DOMAINS_UPDATED );
 
-const sms = createReducer( [], {
-	[ COUNTRIES_SMS_UPDATED ]: ( countries, action ) => action.countries,
-} );
+const payments = createListReducer( COUNTRIES_PAYMENTS_FETCH, COUNTRIES_PAYMENTS_UPDATED );
+
+const sms = createListReducer( COUNTRIES_SMS_FETCH, COUNTRIES_SMS_UPDATED );
 
 export default combineReducers( {
 	domains,

--- a/client/state/selectors/are-countries-fetching.js
+++ b/client/state/selectors/are-countries-fetching.js
@@ -1,0 +1,17 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Determines whether the list of countries from the specified type is being fetched.
+ *
+ * @param {Object} state - global state tree
+ * @param {String} type - type of list ('domains, 'payments', or 'sms)
+ * @return {Boolean} true if the list is being fetched, false otherwise
+ */
+export default function areCountriesFetching( state, type ) {
+	return get( state, [ 'countries', type, 'isFetching' ], false );
+}

--- a/client/state/selectors/get-countries.js
+++ b/client/state/selectors/get-countries.js
@@ -1,0 +1,17 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Retrieves the list of countries from the specified type.
+ *
+ * @param {Object} state - global state tree
+ * @param {String} type - type of list ('domains, 'payments', or 'sms)
+ * @return {Array?} the list of countries
+ */
+export default function getCountries( state, type ) {
+	return get( state, [ 'countries', type, 'items' ], null );
+}


### PR DESCRIPTION
This pull request was extracted from https://github.com/Automattic/wp-calypso/pull/25223 (which was getting too long), and relates to #18095. It introduces a new set of query components, actions, and selectors for countries. It also adds unit tests for the `FormCountrySelect` component, and fixes two placeholders that wouldn't be displayed.

#### Testing instructions

1. Run `git checkout update/countries` and start your server, or open a [live branch](https://calypso.live/?branch=update/countries)
2. Apply 1dfd8-pb server-side patch to your sandbox
3. Point `public-api.wordpress.com` to your sandbox
4. Open the [`Two-Step Authentication` page](http://calypso.localhost:3000/me/security/two-step)
5. Execute `localStorage.clear()` in your browser console, then reload the page
6. Click the `Get Started` button
7. Assert that `Loading…` is displayed in the `Country Code` select box a short moment
8. Assert that `United States (+1)` is displayed once the list of countries has loaded
9. Navigate to the [`Add Domain` page](http://calypso.localhost:3000/domains/add)
10. Select a domain name, and proceed to checkout
12. Scroll down to the the `Domain Contact Information` section
13. Assert that `Loading…` is displayed in the `Country Code` select box a short moment
14. Assert that the name of a country is displayed once the list of countries has loaded

#### Additional notes

The `mock-countries-list` is a temporary addition that will go away with https://github.com/Automattic/wp-calypso/pull/25223.

#### Reviews

- [ ] Code
- [ ] Product
