### PR TITLE
Store Services: display the username of the connected wpcom user

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/label-settings/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/label-settings/selectors.js
@@ -112,5 +112,6 @@ export const getMasterUserInfo = ( state, siteId = getSelectedSiteId( state ) ) 
 		masterUserName: meta && meta.master_user_name,
 		masterUserLogin: meta && meta.master_user_login,
 		masterUserEmail: meta && meta.master_user_email,
+		masterUserWpcomLogin: meta && meta.master_user_wpcom_login,
 	};
 };

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -152,6 +152,28 @@ class ShippingLabels extends Component {
 		);
 	};
 
+	renderAddCardExternalInfo = () => {
+		const { masterUserWpcomLogin, masterUserEmail, translate } = this.props;
+
+		if ( ! masterUserWpcomLogin ) {
+			return null;
+		}
+
+		return (
+			<p>
+				{ translate(
+					'Credit cards are retrieved from the following WordPress.com account: %(wpcomLogin)s (%(wpcomEmail)s)',
+					{
+						args: {
+							wpcomLogin: masterUserWpcomLogin,
+							wpcomEmail: masterUserEmail,
+						},
+					}
+				) }
+			</p>
+		);
+	};
+
 	onVisibilityChange = () => {
 		if ( ! document.hidden ) {
 			this.refetchSettings();
@@ -272,9 +294,12 @@ class ShippingLabels extends Component {
 				<Button className="label-settings__internal" onClick={ openDialog } compact>
 					{ buttonLabel }
 				</Button>
-				<Button className="label-settings__external" onClick={ onAddCardExternal } compact>
-					{ buttonLabel } <Gridicon icon="external" />
-				</Button>
+				<div className="label-settings__credit-card-description">
+					{ this.renderAddCardExternalInfo() }
+					<Button onClick={ onAddCardExternal } compact>
+						{ buttonLabel } <Gridicon icon="external" />
+					</Button>
+				</div>
 			</div>
 		);
 	};


### PR DESCRIPTION
Part of the work on https://github.com/Automattic/woocommerce-services/issues/1208

Adds the username and email address of the connected WP.com user who can manage the payment methods in Calypso. Only appears in wp-admin.
<img width="711" alt="screen shot 2018-06-06 at 14 15 52" src="https://user-images.githubusercontent.com/800604/41042507-bc2ed32c-6999-11e8-9a0b-c7bd549c86c1.png">

CC @kellychoffman - is the copy for this ok?

To test:
* Checkout https://github.com/Automattic/woocommerce-services/pull/1431
* Link this Calypso branch to the WCS code (I found that `ln -s`in `node_modules` works better than `npm link`)
* Go to `WooCommerce > Settings > Shipping > WooCommerce Services` - the label should appear above the add card button