### PR TITLE
Settings: enable subsection anchors when redirecting to the /traffic tab.

### DIFF
--- a/client/blocks/product-purchase-features-list/google-analytics-stats.jsx
+++ b/client/blocks/product-purchase-features-list/google-analytics-stats.jsx
@@ -22,7 +22,7 @@ export default localize( ( { selectedSite, translate } ) => {
 					"Complement WordPress.com's stats with Google's in-depth look at your visitors and traffic patterns."
 				) }
 				buttonText={ translate( 'Connect Google Analytics' ) }
-				href={ '/settings/analytics/' + selectedSite.slug }
+				href={ '/settings/analytics/' + selectedSite.slug + '#analytics' }
 			/>
 		</div>
 	);

--- a/client/my-sites/site-settings/settings-traffic/index.js
+++ b/client/my-sites/site-settings/settings-traffic/index.js
@@ -13,7 +13,11 @@ import settingsController from 'my-sites/site-settings/settings-controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 const redirectToTrafficSection = context => {
-	page.redirect( '/settings/traffic/' + ( context.params.site_id || '' ) );
+	const sectionAnchor = context.hashstring;
+	const siteId = context.params.site_id || '';
+
+	page.redirect( '/settings/traffic/' + siteId );
+	sectionAnchor && window.location.replace( '/settings/traffic/' + siteId + '#' + sectionAnchor );
 };
 
 export default function() {


### PR DESCRIPTION
Atm sections with plans feature related content are marked with hashtags (-> HTML5 `id` keys). When redirected from elsewhere within Calypso the hashtag will not be read and thus the view is always set to the top of the tab. 

This commit expands on the definition of the redirect function to point to the relevant section (as passed via hashstring) after the /traffic section has been loaded.

Href link from the Google Analytics feature card is adapted to point to the GA content in the /traffic tab.

## To test:
- `http://calypso.localhost:3000/plans/my-plan/:site`, for a Pro JP site ( or .com site with Google Analytics enabled  )
- click on the CTA button of the Google Analytics feature card 
- verify redirect to `http://calypso.localhost:3000/settings/analytics/:site#analytics` with the relevant view 

Note: 
- currently only 2 sections SEO, GA are tagged and we will expand on those in the follow-up. Only GA has a feature card,
- `/settings/analytics/` route is kept for use in the external documentation. 