### PR TITLE
Related Posts: update wording

### DIFF
--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -66,7 +66,7 @@ const RelatedPosts = ( {
 							}
 							onChange={ handleAutosavingToggle( 'jetpack_relatedposts_show_thumbnails' ) }
 						>
-							{ translate( 'Use a large and visually striking layout' ) }
+							{ translate( 'Show a thumbnail image where available' ) }
 						</CompactFormToggle>
 					</div>
 


### PR DESCRIPTION
This PR updates the label that refers to the layout alternative to be more clear about how the layout will change.

Addresses the Calypso portion of https://github.com/Automattic/jetpack/issues/9568

### Before

<img width="734" alt="captura de pantalla 2018-06-06 a la s 11 52 47" src="https://user-images.githubusercontent.com/1041600/41046288-8c139196-6980-11e8-8c69-ded636cd2473.png">

### After

<img width="738" alt="captura de pantalla 2018-06-06 a la s 11 56 07" src="https://user-images.githubusercontent.com/1041600/41046345-a69052fc-6980-11e8-930e-6252d7b05e70.png">