### PR TITLE
InlineHelp: Add close button for video results

### DIFF
--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -128,16 +128,31 @@ class InlineHelp extends Component {
 
 	closeDialog = () => this.setState( { showDialog: false } );
 
+	getDialogButtons() {
+		const { translate } = this.props;
+		const { dialogType, dialogPostHref } = this.state;
+
+		if ( dialogType === 'article' ) {
+			return [
+				<Button href={ dialogPostHref } target="_blank" primary>
+					{ translate( 'Visit Article' ) } <Gridicon icon="external" size={ 12 } />
+				</Button>,
+				<Button onClick={ this.closeDialog }>{ translate( 'Close', { textOnly: true } ) }</Button>,
+			];
+		}
+
+		if ( dialogType === 'video' ) {
+			return [
+				<Button onClick={ this.closeDialog }>{ translate( 'Close', { textOnly: true } ) }</Button>,
+			];
+		}
+
+		return [];
+	}
+
 	render() {
 		const { translate } = this.props;
-		const {
-			showInlineHelp,
-			showDialog,
-			videoLink,
-			dialogType,
-			dialogPostId,
-			dialogPostHref,
-		} = this.state;
+		const { showInlineHelp, showDialog, videoLink, dialogType, dialogPostId } = this.state;
 		const inlineHelpButtonClasses = { 'inline-help__button': true, 'is-active': showInlineHelp };
 
 		/* @TODO: This class is not valid and this tricks the linter
@@ -145,13 +160,7 @@ class InlineHelp extends Component {
 		 */
 		const iframeClasses = classNames( 'inline-help__richresult__dialog__video' );
 		const dialogClasses = classNames( 'inline-help__richresult__dialog', dialogType );
-
-		const dialogButtons = dialogType === 'article' && [
-			<Button href={ dialogPostHref } target="_blank" primary>
-				{ translate( 'Visit Article' ) } <Gridicon icon="external" size={ 12 } />
-			</Button>,
-			<Button onClick={ this.closeDialog }>{ translate( 'Close', { textOnly: true } ) }</Button>,
-		];
+		const dialogButtons = this.getDialogButtons();
 
 		return (
 			<div className="inline-help">


### PR DESCRIPTION
This PR adds a 'close' button for inline helps video results.
Though not inline with some of the designs -- where the close button is above the video, leaving room below for related videos and such -- this at least gives the viewer a clearer way to close, even if the layout is just temporary I feel this is of benefit. It's also inline with our existing dialog patterns.

### Testing

- Go to http://calypso.localhost:3000/media (It has all 3 rich result examples)
- Open inline-help
- Open 'Add a Photo Gallery' and click 'Watch a video'
  - You'll notice the popover hide and the dialog open with a video inside
- Click the close button
  - You should see the dialog close
- Re-open 'Add a Photo Gallery' and click 'Watch a video'
- Close the dialog by using the <kbd>esc</kbd> key
  - You should see the dialog close again
- Open 'Finding Free Images and other Media' and click 'Read More'
  - You should see no regressions to the buttons here. 'Close' should still work, as should 'view article'