### PR TITLE
Rewind: Hide site cloning link in site tools for atomic sites

### DIFF
--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -6,7 +6,7 @@
 
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { some } from 'lodash';
+import { find, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -212,7 +212,8 @@ export default connect( state => {
 		exportUrl,
 		cloneUrl,
 		showChangeAddress: ! isJetpack && ! isVip,
-		showClone: 'active' === rewindState.state,
+		showClone:
+			'active' === rewindState.state && ! find( rewindState.credentials, { type: 'managed' } ),
 		showThemeSetup: config.isEnabled( 'settings/theme-setup' ) && ! isJetpack && ! isVip,
 		showDeleteContent: ! isJetpack && ! isVip,
 		showDeleteSite: ( ! isJetpack || isAtomic ) && ! isVip && sitePurchasesLoaded,


### PR DESCRIPTION
We don't want to encourage Atomic sites to perform clones, so we are hiding the link in the site-tools page.

**Testing**

1. Ensure the Clone link is still active for rewindable sites that are non-Atomic.
2. Ensure the Clone link is hidden for rewindable sites that are Atomic.