### PR TITLE
Specify a Google Maps API key for StatsGeochart

### DIFF
--- a/client/blocks/location-search/index.jsx
+++ b/client/blocks/location-search/index.jsx
@@ -38,7 +38,7 @@ class LocationSearch extends Component {
 			autocompleteService = {}; // if multiple components are initialized on the page, we'd want the script to load only once
 			loadScript(
 				`//maps.googleapis.com/maps/api/js?key=${ config(
-					'google_places_api_key'
+					'google_maps_and_places_api_key'
 				) }&libraries=places`,
 				function() {
 					// eslint-disable-next-line no-undef

--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -35,7 +35,7 @@ class StatsGeochart extends Component {
 	visualization = null;
 
 	componentDidMount() {
-		if ( ! window.google ) {
+		if ( ! window.google || ! window.google.charts ) {
 			loadScript( 'https://www.gstatic.com/charts/loader.js' );
 			this.tick();
 		} else {
@@ -138,7 +138,7 @@ class StatsGeochart extends Component {
 	loadVisualizations = () => {
 		// If google is already in the DOM, don't load it again.
 		if ( window.google && window.google.charts ) {
-			window.google.charts.load( 'current', {
+			window.google.charts.load( '45', {
 				packages: [ 'geochart' ],
 				mapsApiKey: config( 'google_maps_and_places_api_key' ),
 			} );

--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -36,7 +36,7 @@ class StatsGeochart extends Component {
 
 	componentDidMount() {
 		if ( ! window.google ) {
-			loadScript( 'https://www.google.com/jsapi' );
+			loadScript( 'https://www.gstatic.com/charts/loader.js' );
 			this.tick();
 		} else {
 			// google jsapi is in the dom, load the visualizations again just in case
@@ -137,12 +137,12 @@ class StatsGeochart extends Component {
 
 	loadVisualizations = () => {
 		// If google is already in the DOM, don't load it again.
-		if ( window.google ) {
-			window.google.load( 'visualization', '1', {
+		if ( window.google && window.google.charts ) {
+			window.google.charts.load( 'current', {
 				packages: [ 'geochart' ],
-				callback: this.drawRegionsMap,
 				mapsApiKey: config( 'google_maps_and_places_api_key' ),
 			} );
+			window.google.charts.setOnLoadCallback( this.drawRegionsMap );
 			clearTimeout( this.timer );
 		} else {
 			this.tick();

--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -15,6 +15,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import config from 'config';
 import { loadScript } from 'lib/load-script';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import QuerySiteStats from 'components/data/query-site-stats';
@@ -140,6 +141,7 @@ class StatsGeochart extends Component {
 			window.google.load( 'visualization', '1', {
 				packages: [ 'geochart' ],
 				callback: this.drawRegionsMap,
+				mapsApiKey: config( 'google_maps_and_places_api_key' ),
 			} );
 			clearTimeout( this.timer );
 		} else {

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -192,5 +192,5 @@
 	"wpcom_signup_id": false,
 	"wpcom_signup_key": false,
 	"statsd_analytics_response_time_max_logs_per_second": 50,
-	"google_places_api_key": "AIzaSyAznW1ev6zto9Dc6lsrWkrMs5R8xDTFWXs"
+	"google_maps_and_places_api_key": "AIzaSyAznW1ev6zto9Dc6lsrWkrMs5R8xDTFWXs"
 }


### PR DESCRIPTION
This PR updates `StatsGeochart`, the component used in Stats to show views per country on a world map, to use the new chart library (see https://developers.google.com/chart/interactive/docs/basic_load_libs).

It also provides the chart lib with our google maps public api key which will be required after the June 11.

### Testing Instructions
- Boot this branch locally
- Navigate to http://calypso.localhost:3000/stats/day/:site for a site that has visitors
- Check that the world map is displayed in the Countries card
- And again in a bigger format when you click on "Countries"
- Looking at the network requests you should not see any use of the google maps api key as it does not seem to be used for this client at this moment.

### Reviews
- [ ] Code
- [ ] Product