### PR TITLE
Allow domain connect DNS discovery record to be enabled/disabled.

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -86,3 +86,8 @@ export const gdprConsentStatus = {
 	DENIED: 'DENIED',
 	FORCED_ALL_CONTRACTUAL: 'FORCED_ALL_CONTRACTUAL',
 };
+
+export const domainConnect = {
+	DISCOVERY_TXT_RECORD_NAME: '_domainconnect',
+	API_URL: 'public-api.wordpress.com/rest/v1.3/domain-connect',
+};

--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -24,6 +24,7 @@ export const DESIGNATED_AGENT = `${ root }/designated-agent/`;
 export const DOMAIN_HELPER_PREFIX = `${ root }/domain-helper/?host=`;
 export const DOMAIN_REGISTRATION_AGREEMENTS = `${ root }/domain-registration-agreements/`;
 export const DOMAINS = `${ root }/domains`;
+export const DOMAIN_CONNECT = `${ root }/domain-connect`;
 export const INCOMING_DOMAIN_TRANSFER_STATUSES_PENDING_CONFIRMATION = `${ root }/incoming-domain-transfer/status-and-failed-transfers/#confirmation`;
 export const INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS = `${ root }/incoming-domain-transfer/status-and-failed-transfers/#pending`;
 export const INCOMING_DOMAIN_TRANSFER_STATUSES_FAILED = `${ root }/incoming-domain-transfer/status-and-failed-transfers/#failed`;

--- a/client/my-sites/domains/domain-management/dns/dns-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-list.jsx
@@ -17,6 +17,7 @@ import DnsRecord from './dns-record';
 import { errorNotice, removeNotice, successNotice } from 'state/notices/actions';
 import { deleteDns as deleteDnsAction, addDns as addDnsAction } from 'lib/upgrades/actions';
 import { isDeletingLastMXRecord } from 'lib/domains/dns';
+import { domainConnect } from 'lib/domains/constants';
 
 class DnsList extends React.Component {
 	static propTypes = {
@@ -101,10 +102,22 @@ class DnsList extends React.Component {
 		} );
 	}
 
+	isDomainConnectRecord( dnsRecord ) {
+		return (
+			domainConnect.DISCOVERY_TXT_RECORD_NAME === dnsRecord.name &&
+			domainConnect.API_URL === dnsRecord.data &&
+			'TXT' === dnsRecord.type
+		);
+	}
+
 	render() {
 		const { dialog } = this.state;
 		const { dns, selectedDomainName, selectedSite } = this.props;
 		const dnsRecordsList = dns.records.map( ( dnsRecord, index ) => {
+			if ( this.isDomainConnectRecord( dnsRecord ) ) {
+				return;
+			}
+
 			return (
 				<DnsRecord
 					key={ index }

--- a/client/my-sites/domains/domain-management/dns/domain-connect-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/domain-connect-record.jsx
@@ -1,0 +1,141 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { errorNotice, removeNotice, successNotice } from 'state/notices/actions';
+import { deleteDns, addDns } from 'lib/upgrades/actions';
+import Toggle from 'components/forms/form-toggle';
+import { DOMAIN_CONNECT } from 'lib/url/support';
+import { domainConnect } from 'lib/domains/constants';
+import { getNormalizedData } from 'lib/domains/dns';
+
+class DomainConnectRecord extends React.Component {
+	static propTypes = {
+		enabled: PropTypes.bool.isRequired,
+		selectedDomainName: PropTypes.string.isRequired,
+		hasWpcomNameservers: PropTypes.bool.isRequired,
+	};
+
+	state = {
+		enabled: this.props.enabled,
+	};
+
+	disableDomainConnect = () => {
+		const { selectedDomainName, translate } = this.props;
+		const record = {
+			name: domainConnect.DISCOVERY_TXT_RECORD_NAME,
+			data: domainConnect.API_URL,
+			type: 'TXT',
+		};
+
+		deleteDns( selectedDomainName, record, error => {
+			if ( error ) {
+				this.props.errorNotice(
+					error.message || translate( 'The Domain Connect record could not be disabled.' )
+				);
+			} else {
+				const successNoticeId = 'domain-connect-disable-success-notice';
+				this.props.successNotice( translate( 'The Domain Connect record has been disabled.' ), {
+					id: successNoticeId,
+					showDismiss: false,
+					duration: 5000,
+				} );
+			}
+		} );
+	};
+
+	enableDomainConnect() {
+		const { translate } = this.props;
+		const record = {
+			name: domainConnect.DISCOVERY_TXT_RECORD_NAME,
+			data: domainConnect.API_URL,
+			type: 'TXT',
+		};
+
+		const normalizedData = getNormalizedData( record, this.props.selectedDomainName );
+
+		addDns( this.props.selectedDomainName, normalizedData, error => {
+			if ( error ) {
+				this.props.errorNotice(
+					error.message || translate( 'The Domain Connect record could not be enabled.' )
+				);
+			} else {
+				this.props.successNotice( translate( 'The Domain Connect record has been enabled.' ), {
+					showDismiss: false,
+					duration: 5000,
+				} );
+			}
+		} );
+	}
+
+	handleToggle = () => {
+		// this.setState( { enabled: ! this.state.enabled } );
+		if ( this.props.enabled ) {
+			this.disableDomainConnect();
+		} else {
+			this.enableDomainConnect();
+		}
+	};
+
+	render() {
+		const { enabled, selectedDomainName, hasWpcomNameservers, translate } = this.props;
+
+		if ( ! hasWpcomNameservers ) {
+			return null;
+		}
+
+		const name = `${ domainConnect.DISCOVERY_TXT_RECORD_NAME }.${ selectedDomainName }`;
+		const classes = classNames( 'dns__domain-connect-record-wrap', { 'is-disabled': ! enabled } );
+
+		return (
+			<div>
+				<div className="dns__domain-connect-record">
+					<div className={ classes }>
+						<div className="dns__list-type">
+							<span>TXT</span>
+						</div>
+						<div className="dns__list-info">
+							<strong>{ name }</strong>
+							<em>{ translate( 'Handled by WordPress.com' ) }</em>
+						</div>
+					</div>
+					<form className="dns__domain-connect-toggle">
+						<Toggle
+							id="domain-connect-record"
+							name="domain-connect-record"
+							onChange={ this.handleToggle }
+							type="checkbox"
+							checked={ enabled }
+							value="active"
+						/>
+					</form>
+				</div>
+				<div className="dns__domain-connect-explanation">
+					<em>
+						{ translate(
+							'Enabling this special DNS record allows you to automatically configure ' +
+								'some third party services. '
+						) }
+						<a href={ DOMAIN_CONNECT }>{ translate( 'Learn more.' ) }</a>
+					</em>
+				</div>
+			</div>
+		);
+	}
+}
+
+export default connect( null, {
+	errorNotice,
+	removeNotice,
+	successNotice,
+} )( localize( DomainConnectRecord ) );

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import page from 'page';
 import { localize } from 'i18n-calypso';
+import { get, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,6 +25,8 @@ import Card from 'components/card/compact';
 import SectionHeader from 'components/section-header';
 import DnsTemplates from '../name-servers/dns-templates';
 import VerticalNav from 'components/vertical-nav';
+import DomainConnectRecord from './domain-connect-record';
+import { domainConnect } from 'lib/domains/constants';
 
 class Dns extends React.Component {
 	static propTypes = {
@@ -52,11 +55,19 @@ class Dns extends React.Component {
 	}
 
 	render() {
-		const { dns, selectedDomainName, selectedSite, translate } = this.props;
+		const { dns, domains, selectedDomainName, selectedSite, translate } = this.props;
 
-		if ( ! dns.hasLoadedFromServer ) {
+		if ( ! dns.hasLoadedFromServer || ! domains.hasLoadedFromServer ) {
 			return <DomainMainPlaceholder goBack={ this.goBack } />;
 		}
+
+		const domain = getSelectedDomain( this.props );
+		const hasWpcomNameservers = get( domain, 'hasWpcomNameservers', false );
+		const domainConnectEnabled = some( dns.records, {
+			name: domainConnect.DISCOVERY_TXT_RECORD_NAME,
+			data: domainConnect.API_URL,
+			type: 'TXT',
+		} );
 
 		return (
 			<Main className="dns">
@@ -72,6 +83,12 @@ class Dns extends React.Component {
 						dns={ dns }
 						selectedSite={ selectedSite }
 						selectedDomainName={ selectedDomainName }
+					/>
+
+					<DomainConnectRecord
+						enabled={ domainConnectEnabled }
+						selectedDomainName={ selectedDomainName }
+						hasWpcomNameservers={ hasWpcomNameservers }
 					/>
 
 					<DnsAddNew

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -351,12 +351,17 @@ input[type=radio].domain-management-list-item__radio {
 .dns__details,
 .custom-nameservers-form__explanation,
 .email-forwarding__explanation,
-.site-redirect__explanation {
+.site-redirect__explanation,
+.dns__domain-connect-explanation {
 	display: block;
 	margin-top: 5px;
 	font-size: 13px;
 	font-style: italic;
 	color: $gray-text-min;
+}
+
+.dns__domain-connect-explanation {
+	margin-bottom: 5px;
 }
 
 .email-forwarding-card,
@@ -772,13 +777,14 @@ ul.email-forwarding__list {
 }
 
 .dns__list > ul,
-ul.domain-connect__dns-list
-{
+ul.domain-connect__dns-list,
+.dns__domain-connect-record {
 	list-style: none;
 	margin: 15px 0 0 0;
 	padding: 0;
 
-	li {
+	li,
+	.dns__domain-connect-record-wrap {
 		border-top: 1px solid $gray-light;
 		display: flex;
 		justify-content: space-between;
@@ -829,6 +835,22 @@ ul.domain-connect__dns-list
 	.dns__list-remove {
 		text-align: right;
 		width: 100px;
+	}
+}
+
+.dns__domain-connect-record {
+	margin: 0;
+	border-top: 1px solid $gray-light;
+	display: flex;
+	justify-content: space-between;
+
+	.dns__domain-connect-record-wrap {
+		border-top: none;
+
+	}
+
+	.dns__domain-connect-toggle {
+		margin: 15px 0;
 	}
 }
 


### PR DESCRIPTION
This allows the domain connect txt record used for domain connect discovery to be created (enabled) and deleted (disabled) in a controlled way since the value of this record is important and a malformed or incorrect value will cause domain connect to fail for the domain.

Testing
Select a domain that has WordPress.com nameservers and navigate to the DNS management page. You should see the special domain connect record listed below the list of other DNS records. You should be able to enable and disable the record. Verify that the record is actually created and deleted in the database.

Also, make sure that the special record doesn't show up for domains that are not using WordPress.com name servers.