### PR TITLE
Rewind: Show path field by default and require a value

### DIFF
--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { find, get, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -246,7 +247,11 @@ export class RewindCredentialsForm extends Component {
 						</Button>
 					) }
 					{ ( showAdvancedSettings || requirePath ) && (
-						<div className="rewind-credentials-form__advanced-settings">
+						<div
+							className={ classNames( {
+								'rewind-credentials-form__advanced-settings': ! requirePath,
+							} ) }
+						>
 							<FormFieldset className="rewind-credentials-form__path">
 								<FormLabel htmlFor="wordpress-path">
 									{ labels.path || translate( 'WordPress installation path' ) }

--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -44,6 +44,10 @@ export class RewindCredentialsForm extends Component {
 		requirePath: PropTypes.bool,
 	};
 
+	static defaultProps = {
+		requirePath: false,
+	};
+
 	state = {
 		showPrivateKeyField: false,
 		form: {
@@ -230,15 +234,17 @@ export class RewindCredentialsForm extends Component {
 				</div>
 
 				<FormFieldset>
-					<Button
-						disabled={ formIsSubmitting }
-						onClick={ this.toggleAdvancedSettings }
-						borderless={ true }
-						primary={ true }
-						className="rewind-credentials-form__advanced-button"
-					>
-						{ translate( 'Advanced settings' ) }
-					</Button>
+					{ ! requirePath && (
+						<Button
+							disabled={ formIsSubmitting }
+							onClick={ this.toggleAdvancedSettings }
+							borderless={ true }
+							primary={ true }
+							className="rewind-credentials-form__advanced-button"
+						>
+							{ translate( 'Advanced settings' ) }
+						</Button>
+					) }
 					{ ( showAdvancedSettings || requirePath ) && (
 						<div className="rewind-credentials-form__advanced-settings">
 							<FormFieldset className="rewind-credentials-form__path">

--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -41,6 +41,7 @@ export class RewindCredentialsForm extends Component {
 
 	static defaultProps = {
 		labels: {},
+		requirePath: PropTypes.bool,
 	};
 
 	state = {
@@ -59,6 +60,7 @@ export class RewindCredentialsForm extends Component {
 			port: false,
 			user: false,
 			pass: false,
+			path: false,
 		},
 	};
 
@@ -79,7 +81,7 @@ export class RewindCredentialsForm extends Component {
 	};
 
 	handleSubmit = () => {
-		const { role, siteId, siteUrl, translate, updateCredentials } = this.props;
+		const { requirePath, role, siteId, siteUrl, translate, updateCredentials } = this.props;
 
 		const payload = {
 			role,
@@ -104,7 +106,8 @@ export class RewindCredentialsForm extends Component {
 			isNaN( payload.port ) && { port: translate( 'Port number must be numeric.' ) },
 			userError && { user: userError },
 			! payload.pass &&
-				! payload.kpri && { pass: translate( 'Please enter your server password.' ) }
+				! payload.kpri && { pass: translate( 'Please enter your server password.' ) },
+			! payload.path && requirePath && { path: translate( 'Please enter a server path.' ) }
 		);
 
 		return isEmpty( errors )
@@ -138,8 +141,7 @@ export class RewindCredentialsForm extends Component {
 	}
 
 	render() {
-		const { formIsSubmitting, labels, onCancel, siteId, translate } = this.props;
-
+		const { formIsSubmitting, labels, onCancel, requirePath, siteId, translate } = this.props;
 		const { showAdvancedSettings, formErrors } = this.state;
 
 		return (
@@ -237,7 +239,7 @@ export class RewindCredentialsForm extends Component {
 					>
 						{ translate( 'Advanced settings' ) }
 					</Button>
-					{ showAdvancedSettings && (
+					{ ( showAdvancedSettings || requirePath ) && (
 						<div className="rewind-credentials-form__advanced-settings">
 							<FormFieldset className="rewind-credentials-form__path">
 								<FormLabel htmlFor="wordpress-path">
@@ -252,6 +254,9 @@ export class RewindCredentialsForm extends Component {
 									disabled={ formIsSubmitting }
 									isError={ !! formErrors.path }
 								/>
+								{ formErrors.path && (
+									<FormInputValidation isError={ true } text={ formErrors.path } />
+								) }
 							</FormFieldset>
 
 							<FormFieldset className="rewind-credentials-form__kpri">

--- a/client/signup/steps/clone-credentials/index.jsx
+++ b/client/signup/steps/clone-credentials/index.jsx
@@ -63,6 +63,7 @@ class CloneCredentialsStep extends Component {
 							host: translate( 'Destination Server Address' ),
 							path: translate( 'Destination WordPress Path' ),
 						} }
+						requirePath
 					/>
 				</Card>
 			</div>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/25332

It's very easy to miss the path field in the clone site flow, since it's hidden under the advanced settings in the credentials form. Additionally, a value is required here.

This PR adds a new prop to `RewindCredentialsForm` called `requirePath`. When set to true, the advanced settings will be expanded by default, and we will require a value in this field to submit the form.

**Testing**

Walk through the clone site flow, and make sure the credentials form has the advanced settings expanded by default. Attempt to submit the form without a value in the path field, and make sure that the form validation stops submission. Make sure the field resets when you add a value to it, and make sure the form will submit after adding a value.