### PR TITLE
Update URL for `wpcom.js` to use HTTPS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Calypso is the new WordPress.com front-end – a beautiful redesign of the WordP
 
 ![beautiful screenshot](https://cldup.com/Q74QJCh0Yl.png)
 
-It’s built with JavaScript – a very light [node](https://nodejs.org/) plus [express](https://expressjs.com/) server, [React.js](https://reactjs.org/), [Redux](https://redux.js.org/), [wpcom.js](http://wpcomjs.com/), and many other wonderful libraries on the front-end.
+It’s built with JavaScript – a very light [node](https://nodejs.org/) plus [express](https://expressjs.com/) server, [React.js](https://reactjs.org/), [Redux](https://redux.js.org/), [wpcom.js](https://wpcomjs.com/), and many other wonderful libraries on the front-end.
 
 You can read more about Calypso at [developer.wordpress.com/calypso](https://developer.wordpress.com/calypso/).
 


### PR DESCRIPTION
Context: URL for `wpcom.js` wasn't updated to HTTPS in https://github.com/Automattic/wp-calypso/pull/25301, 
because its certificate had expired at the time.

>Github support said it was a bug on their side. While they work on
fixing it they have "manually" renewed the cert.
>— https://github.com/Automattic/wpcom.js/issues/219#issuecomment-395287290

👆 means it is okay to use HTTPS again.

Fixes: https://github.com/Automattic/wp-calypso/issues/25299
Refs: https://github.com/Automattic/wp-calypso/pull/25301
Refs: https://github.com/Automattic/wpcom.js/issues/219