### PR TITLE
Typo Fix: "jetpack" not capitalized in error message

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -192,7 +192,7 @@ class PlansSetup extends React.Component {
 			<JetpackManageErrorPage
 				siteId={ this.props.siteId }
 				title={ this.props.translate(
-					'Oh no! You need to select a jetpack site to be able to setup your plan'
+					'Oh no! You need to select a Jetpack site to be able to setup your plan'
 				) }
 				illustration={ '/calypso/images/jetpack/jetpack-manage.svg' }
 			/>


### PR DESCRIPTION
Resolves #25320

Use of `Jetpack` instead of `jetpack` in line 195 of `index.jsx`

cc @tyxla 