### PR TITLE
Jetpack: redirect to the correct url when the site is a subdirectory

### DIFF
--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -164,7 +164,7 @@ export class JetpackConnectMain extends Component {
 			url: url,
 			type: 'remote_auth',
 		} );
-		externalRedirect( addCalypsoEnvQueryArg( url + REMOTE_PATH_AUTH ) );
+		externalRedirect( addCalypsoEnvQueryArg( this.props.siteHomeUrl + REMOTE_PATH_AUTH ) );
 	} );
 
 	goToRemoteInstall = this.makeSafeRedirectionFunction( url => {
@@ -391,6 +391,7 @@ const connectComponent = connect(
 			jetpackConnectSite,
 			mobileAppRedirect,
 			skipRemoteInstall,
+			siteHomeUrl: siteData.url,
 		};
 	},
 	{

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -111,7 +111,7 @@ export class JetpackConnectMain extends Component {
 			this.isCurrentUrlFetched() &&
 			! this.state.redirecting
 		) {
-			return this.goToRemoteAuth( this.state.currentUrl );
+			return this.goToRemoteAuth( this.props.siteHomeUrl );
 		}
 		if ( this.getStatus() === ALREADY_OWNED && ! this.state.redirecting ) {
 			if ( isMobileAppFlow ) {
@@ -391,7 +391,7 @@ const connectComponent = connect(
 			jetpackConnectSite,
 			mobileAppRedirect,
 			skipRemoteInstall,
-			siteHomeUrl: siteData.url,
+			siteHomeUrl: siteData.urlAfterRedirects || jetpackConnectSite.url,
 		};
 	},
 	{

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -164,7 +164,7 @@ export class JetpackConnectMain extends Component {
 			url: url,
 			type: 'remote_auth',
 		} );
-		externalRedirect( addCalypsoEnvQueryArg( this.props.siteHomeUrl + REMOTE_PATH_AUTH ) );
+		externalRedirect( addCalypsoEnvQueryArg( url + REMOTE_PATH_AUTH ) );
 	} );
 
 	goToRemoteInstall = this.makeSafeRedirectionFunction( url => {


### PR DESCRIPTION
closes https://github.com/Automattic/wp-calypso/issues/25253
closes https://github.com/Automattic/wp-calypso/issues/6088
closes https://github.com/Automattic/wp-calypso/issues/10980
(I think it should) closes https://github.com/Automattic/wp-calypso/issues/5142

This PR changes the url we use during the connection flow to one that may be returned by the remote site REST API. This will help us to avoid redirecting the user to the wrong wp-admin url.

How to test
===========
0. You need a jetpack site installed in a path that is not the root of its url (ping me for some examples, you  don't really need any access to the site, since the test finishes before needing to log in)
~ 1. Use your WordPress.com sandbox, applying `D14507-co4de`~  it's in production now, you don't need to patch anything
2. Go to http://calypso.localhost:3000/jetpack/connect
3. Enter the test site url
4. You should be redirected to the site wp-admin and get asked to log in 