### PR TITLE
InlineHelp: Add icons to CTAs

### DIFF
--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -121,6 +121,7 @@ class InlineHelpRichResult extends Component {
 				<p>{ preventWidows( decodeEntities( description ) ) }</p>
 				<Button primary onClick={ this.handleClick } href={ link }>
 					{ buttonIcon && <Gridicon icon={ buttonIcon } size={ 12 } /> }
+					{ buttonIcon && buttonLabel && ' ' }
 					{ buttonLabel }
 				</Button>
 			</div>

--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import { get, isUndefined, omitBy } from 'lodash';
+import Gridicon from 'gridicons';
 
 /**
  * Internal Dependencies
@@ -34,6 +35,18 @@ class InlineHelpRichResult extends Component {
 	static propTypes = {
 		result: PropTypes.object,
 		setDialogState: PropTypes.func.isRequired,
+	};
+
+	buttonLabels = {
+		article: this.props.translate( 'Read more' ),
+		video: this.props.translate( 'Watch a video' ),
+		tour: this.props.translate( 'Start Tour' ),
+	};
+
+	buttonIcons = {
+		tour: 'list-ordered',
+		video: 'video',
+		article: 'reader',
 	};
 
 	state = {
@@ -94,24 +107,21 @@ class InlineHelpRichResult extends Component {
 	};
 
 	render() {
-		const { type } = this.props;
-		const { translate, result } = this.props;
+		const { result, type } = this.props;
 		const title = get( result, RESULT_TITLE );
 		const description = get( result, RESULT_DESCRIPTION );
 		const link = amendYouTubeLink( get( result, RESULT_LINK ) );
+		const buttonLabel = get( this.buttonLabels, type, '' );
+		const buttonIcon = get( this.buttonIcons, type );
 		const classes = classNames( 'inline-help__richresult__title' );
+
 		return (
 			<div>
 				<h2 className={ classes }>{ preventWidows( decodeEntities( title ) ) }</h2>
 				<p>{ preventWidows( decodeEntities( description ) ) }</p>
 				<Button primary onClick={ this.handleClick } href={ link }>
-					{
-						{
-							article: translate( 'Read more' ),
-							video: translate( 'Watch a video' ),
-							tour: translate( 'Start Tour' ),
-						}[ type ]
-					}
+					{ buttonIcon && <Gridicon icon={ buttonIcon } size={ 12 } /> }
+					{ buttonLabel }
 				</Button>
 			</div>
 		);


### PR DESCRIPTION
This PR adds an icon to each of the CTAs found in the rich result views for videos, articles and guided tours
Though this seems like it would be a nice addition, I'm not convinced by how this looks in-situ. 
The button is quite wide and, with the addition of the icon, ends up looking quite clumsy. 
I tried a few variations and none seem to look better (The first shows the current state as found in this change-set):

<img width="303" alt="screen shot 2018-06-07 at 13 26 49" src="https://user-images.githubusercontent.com/4335450/41099802-84fbba14-6a57-11e8-9a9b-442772843a99.png">
<img width="301" alt="screen shot 2018-06-07 at 13 27 54" src="https://user-images.githubusercontent.com/4335450/41099799-8482a4f8-6a57-11e8-9c4f-d5bc6883d1fd.png">
<img width="303" alt="screen shot 2018-06-07 at 13 27 13" src="https://user-images.githubusercontent.com/4335450/41099801-84df67d8-6a57-11e8-8221-0affdf877306.png">

### Testing

- Go to http://calypso.localhost:3000/media (It has all 3 rich result examples)
- Open inline-help
- Open 'Learn Media Library Basics'
  - You should see a numbered list icon in the CTA
- Open 'Add a Photo Gallery'
  - You should see a play video icon in the CTA
- Open 'Finding Free Images and other Media'
  - You should see a reader icon in the CTA