### PR TITLE
i18n: Add getLanguageSlugs() helper

### DIFF
--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -5,7 +5,7 @@
  */
 
 import debugFactory from 'debug';
-import { every, get, includes, isArray, keys, map, reduce, some } from 'lodash';
+import { every, get, includes, isArray, keys, reduce, some } from 'lodash';
 import store from 'store';
 import i18n from 'i18n-calypso';
 
@@ -14,10 +14,10 @@ import i18n from 'i18n-calypso';
  */
 import activeTests from 'lib/abtest/active-tests';
 import analytics from 'lib/analytics';
-import config from 'config';
 import userFactory from 'lib/user';
 import wpcom from 'lib/wp';
 import { ABTEST_LOCALSTORAGE_KEY } from 'lib/abtest/utility';
+import { getLanguageSlugs } from 'lib/i18n-utils/utils';
 
 const debug = debugFactory( 'calypso:abtests' );
 const user = userFactory();
@@ -69,7 +69,7 @@ const parseDateStamp = datestamp => {
 	return date;
 };
 
-const languageSlugs = map( config( 'languages' ), 'langSlug' );
+const languageSlugs = getLanguageSlugs();
 const langSlugIsValid = slug => languageSlugs.indexOf( slug ) !== -1;
 
 ABTest.prototype.init = function( name, geoLocation ) {

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -17,7 +17,7 @@ import analytics from 'lib/analytics';
 import userFactory from 'lib/user';
 import wpcom from 'lib/wp';
 import { ABTEST_LOCALSTORAGE_KEY } from 'lib/abtest/utility';
-import { getLanguageSlugs } from 'lib/i18n-utils/utils';
+import { getLanguageSlugs } from 'lib/i18n-utils';
 
 const debug = debugFactory( 'calypso:abtests' );
 const user = userFactory();

--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -9,6 +9,7 @@ export {
 	addLocaleToWpcomUrl,
 	getForumUrl,
 	getLanguage,
+	getLanguageSlugs,
 	getLocaleFromPath,
 	getSupportSiteLocale,
 	isDefaultLocale,

--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -15,6 +15,7 @@ export {
 	addLocaleToWpcomUrl,
 	getForumUrl,
 	getLanguage,
+	getLanguageSlugs,
 	getLocaleFromPath,
 	getSupportSiteLocale,
 	isDefaultLocale,

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { find, isString } from 'lodash';
+import { find, isString, map } from 'lodash';
 import { parse } from 'url';
 import { getLocaleSlug } from 'i18n-calypso';
 
@@ -59,6 +59,15 @@ export function isLocaleVariant( locale ) {
  */
 export function canBeTranslated( locale ) {
 	return [ 'en', 'sr_latin' ].indexOf( locale ) === -1;
+}
+
+/**
+ * Return a list of all supported language slugs
+ *
+ * @return {Array} A list of all supported language slugs
+ */
+export function getLanguageSlugs() {
+	return map( config( 'languages' ), 'langSlug' );
 }
 
 /**

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -6,7 +6,7 @@
 import page from 'page';
 import { parse } from 'qs';
 import React from 'react';
-import { includes, map } from 'lodash';
+import { includes } from 'lodash';
 import { parse as parseUrl } from 'url';
 
 /**
@@ -17,6 +17,7 @@ import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
 import MagicLogin from './magic-login';
 import WPLogin from './wp-login';
 import { fetchOAuth2ClientData } from 'state/oauth2-clients/actions';
+import { getLanguageSlugs } from 'lib/i18n-utils/utils';
 import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
 
 const enhanceContextWithLogin = context => {
@@ -40,7 +41,7 @@ const enhanceContextWithLogin = context => {
 // Defining this here so it can be used by both ./index.node.js and ./index.web.js
 // We cannot export it from either of those (to import it from the other) because of
 // the way that `server/bundler/loader` expects only a default export and nothing else.
-export const lang = `:lang(${ map( config( 'languages' ), 'langSlug' ).join( '|' ) })?`;
+export const lang = `:lang(${ getLanguageSlugs().join( '|' ) })?`;
 
 export function login( context, next ) {
 	const { query: { client_id, redirect_to } } = context;

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -17,7 +17,7 @@ import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
 import MagicLogin from './magic-login';
 import WPLogin from './wp-login';
 import { fetchOAuth2ClientData } from 'state/oauth2-clients/actions';
-import { getLanguageSlugs } from 'lib/i18n-utils/utils';
+import { getLanguageSlugs } from 'lib/i18n-utils';
 import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
 
 const enhanceContextWithLogin = context => {


### PR DESCRIPTION
Centralize logic for easier maintainability.

To test:
* In an incognito window, verify that `/log-in/fr` fonctionne toujours, whereas `log-in/invalidlocale` 404s.