### PR TITLE
InlineHelp: Right click YT link opens non-embed link

### DIFF
--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -27,6 +27,9 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { getSearchQuery } from 'state/inline-help/selectors';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 
+const fixYouTubeEmbedLink = ( link = '' ) =>
+	link.replace( 'youtube.com/embed/', 'youtube.com/watch?v=' );
+
 class InlineHelpRichResult extends Component {
 	static propTypes = {
 		result: PropTypes.object,
@@ -95,7 +98,7 @@ class InlineHelpRichResult extends Component {
 		const { translate, result } = this.props;
 		const title = get( result, RESULT_TITLE );
 		const description = get( result, RESULT_DESCRIPTION );
-		const link = get( result, RESULT_LINK );
+		const link = fixYouTubeEmbedLink( get( result, RESULT_LINK ) );
 		const classes = classNames( 'inline-help__richresult__title' );
 		return (
 			<div>


### PR DESCRIPTION
Previously, we've simply used the link given to us from the API for a CTA link for all inline help rich results. The trouble with doing so is that our youtube links are all `youtube.com/embed/xx` formatted. This makes displaying the embed straight forward but breaks the expected behaviour for right clicking on the CTAs - it takes the viewer directly to an embedded version of the video rather than to the video itself (on YouTube, with YouTubes UI).

This PR fixes this by passing these links through a simple `string.replace`.

### Testing
- Go to http://calypso.localhost:3000/media
- Open inline-help
- Open 'Add a Photo Gallery' and right click 'Watch a video'
  - Notice that a new tab opens with the video in a regular YouTube context, with the usual chrome of YouTube instead of being an embed
- Go back to Calypso  and this time left click 'Watch a video'
  - Note that the embed still works as expected and plays in the dialog once loaded.