### PR TITLE
Analytics: adds conversion value to Yahoo Gemini pixel

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -691,6 +691,8 @@ export function recordOrder( cart, orderId ) {
 		return;
 	}
 
+	const usdTotalCost = costToUSD( cart.total_cost, cart.currency );
+
 	// load the ecommerce plugin
 	debug( 'recordOrder: ga ecommerce plugin load' );
 	window.ga( 'require', 'ecommerce' );
@@ -727,7 +729,11 @@ export function recordOrder( cart, orderId ) {
 
 	// Yahoo Gemini
 	if ( isGeminiEnabled ) {
-		new Image().src = YAHOO_GEMINI_CONVERSION_PIXEL_URL;
+		let valueParam = '';
+		if ( usdTotalCost !== null ) {
+			valueParam = '&gv=' + usdTotalCost;
+		}
+		new Image().src = YAHOO_GEMINI_CONVERSION_PIXEL_URL + valueParam;
 	}
 
 	if ( isAolEnabled ) {

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -729,11 +729,8 @@ export function recordOrder( cart, orderId ) {
 
 	// Yahoo Gemini
 	if ( isGeminiEnabled ) {
-		let valueParam = '';
-		if ( usdTotalCost !== null ) {
-			valueParam = '&gv=' + usdTotalCost;
-		}
-		new Image().src = YAHOO_GEMINI_CONVERSION_PIXEL_URL + ( usdTotalCost !== null ? '&gv=' + usdTotalCost : '' );
+		new Image().src =
+			YAHOO_GEMINI_CONVERSION_PIXEL_URL + ( usdTotalCost !== null ? '&gv=' + usdTotalCost : '' );
 	}
 
 	if ( isAolEnabled ) {

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -733,7 +733,7 @@ export function recordOrder( cart, orderId ) {
 		if ( usdTotalCost !== null ) {
 			valueParam = '&gv=' + usdTotalCost;
 		}
-		new Image().src = YAHOO_GEMINI_CONVERSION_PIXEL_URL + valueParam;
+		new Image().src = YAHOO_GEMINI_CONVERSION_PIXEL_URL + ( usdTotalCost !== null ? '&gv=' + usdTotalCost : '' );
 	}
 
 	if ( isAolEnabled ) {


### PR DESCRIPTION
This PR adds conversion value to Yahoo Gemini pixel.

- Test link: 
  - https://calypso.live/?branch=add/add-conversion-value-to-oath-pixel&flags=ad-tracking,google-analytics
    or 
  - http://calypso.localhost:3000/?flags=ad-tracking,google-analytics (local Calypso since calypso.live seems to be stuck for me)
- Set the `sensitive_pixel_option` cookie to `yes` on the domain you're using for testing - this is needed otherwise the ad-trackers won't be fired
- In the JS console you should see `isAdTrackingAllowed = true`

![image](https://user-images.githubusercontent.com/10284338/41111380-b68672f6-6a73-11e8-8bd8-316fb497592d.png)
- In the JS console type `localStorage.setItem( 'debug', 'calypso:analytics:*' );` to see the logs
- Purchase something like an update to a test site using free credits
- In the Network tab you should see the Yahoo/Gemini pixel containing the order value in USD like this:

https://sp.analytics.yahoo.com/spp.pl?a=10000&.yp=10014088&ec=wordpresspurchase&gv=48.000

Thanks!