### PR TITLE
Framework: `dispatchRequest` update (countries list)

### DIFF
--- a/client/state/data-layer/wpcom/domains/countries-list/index.js
+++ b/client/state/data-layer/wpcom/domains/countries-list/index.js
@@ -8,27 +8,24 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { COUNTRIES_DOMAINS_FETCH, COUNTRIES_DOMAINS_UPDATED } from 'state/action-types';
 import { errorNotice } from 'state/notices/actions';
 
 /**
  * Dispatches a request to fetch all available WordPress.com countries
  *
- * @param   {Function} dispatch Redux dispatcher
  * @param 	{String} action The action to dispatch next
  * @returns {Object} dispatched http action
  */
-export const fetchCountriesDomains = ( { dispatch }, action ) =>
-	dispatch(
-		http(
-			{
-				apiVersion: '1.1',
-				method: 'GET',
-				path: '/domains/supported-countries/',
-			},
-			action
-		)
+export const fetchCountriesDomains = action =>
+	http(
+		{
+			apiVersion: '1.1',
+			method: 'GET',
+			path: '/domains/supported-countries/',
+		},
+		action
 	);
 
 /**
@@ -39,11 +36,10 @@ export const fetchCountriesDomains = ( { dispatch }, action ) =>
  * @param   {Array}    countries  array of raw device data returned from the endpoint
  * @returns {Object}            disparched user devices add action
  */
-export const updateCountriesDomains = ( { dispatch }, action, countries ) =>
-	dispatch( {
-		type: COUNTRIES_DOMAINS_UPDATED,
-		countries,
-	} );
+export const updateCountriesDomains = ( action, countries ) => ( {
+	type: COUNTRIES_DOMAINS_UPDATED,
+	countries,
+} );
 
 /**
  * Dispatches a error notice action when the request for the supported countries list fails.
@@ -51,15 +47,15 @@ export const updateCountriesDomains = ( { dispatch }, action, countries ) =>
  * @param   {Function} dispatch Redux dispatcher
  * @returns {Object}            dispatched error notice action
  */
-export const showCountriesDomainsLoadingError = ( { dispatch } ) =>
-	dispatch( errorNotice( translate( "We couldn't load the countries list." ) ) );
+export const showCountriesDomainsLoadingError = () =>
+	errorNotice( translate( "We couldn't load the countries list." ) );
 
 export default {
 	[ COUNTRIES_DOMAINS_FETCH ]: [
-		dispatchRequest(
-			fetchCountriesDomains,
-			updateCountriesDomains,
-			showCountriesDomainsLoadingError
-		),
+		dispatchRequestEx( {
+			fetch: fetchCountriesDomains,
+			onSuccess: updateCountriesDomains,
+			onError: showCountriesDomainsLoadingError,
+		} ),
 	],
 };

--- a/client/state/data-layer/wpcom/domains/countries-list/test/index.js
+++ b/client/state/data-layer/wpcom/domains/countries-list/test/index.js
@@ -1,11 +1,5 @@
 /** @format */
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-import { spy } from 'sinon';
-
-/**
  * Internal dependencies
  */
 import {
@@ -21,12 +15,8 @@ describe( 'wpcom-api', () => {
 		describe( '#fetchCountriesDomains', () => {
 			test( 'should dispatch HTTP request to plans endpoint', () => {
 				const action = { type: 'DUMMY' };
-				const dispatch = spy();
 
-				fetchCountriesDomains( { dispatch }, action );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith(
+				expect( fetchCountriesDomains( action ) ).toEqual(
 					http(
 						{
 							apiVersion: '1.1',
@@ -42,13 +32,9 @@ describe( 'wpcom-api', () => {
 		describe( '#updateCountriesDomains', () => {
 			test( 'should dispatch updated action', () => {
 				const action = { type: 'DUMMY' };
-				const dispatch = spy();
 				const data = [ 'BG', 'US', 'UK' ];
 
-				updateCountriesDomains( { dispatch }, action, data );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith( {
+				expect( updateCountriesDomains( action, data ) ).toEqual( {
 					type: COUNTRIES_DOMAINS_UPDATED,
 					countries: data,
 				} );
@@ -57,18 +43,15 @@ describe( 'wpcom-api', () => {
 
 		describe( '#showCountriesDomainsLoadingError', () => {
 			test( 'should dispatch error notice', () => {
-				const dispatch = spy();
-
-				showCountriesDomainsLoadingError( { dispatch } );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWithMatch( {
-					type: NOTICE_CREATE,
-					notice: {
-						status: 'is-error',
-						text: "We couldn't load the countries list.",
-					},
-				} );
+				expect( showCountriesDomainsLoadingError() ).toEqual(
+					expect.objectContaining( {
+						type: NOTICE_CREATE,
+						notice: expect.objectContaining( {
+							status: 'is-error',
+							text: "We couldn't load the countries list.",
+						} ),
+					} )
+				);
 			} );
 		} );
 	} );


### PR DESCRIPTION
See #25121

In this patch we're replacing the use of dispatchRequest()
in the data layer handler to use the newer API exposed
as dispatchRequestEx() This should have no change in
actual effect or interaction.

@delputnam is any of this used? I can't find any reference
to actually calling it. If it's unused, can we just rip it all out?