### PR TITLE
i18n: Use canonical getLanguage() implementation

### DIFF
--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -9,27 +9,9 @@ import { assign, includes } from 'lodash';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import { decodeEntities } from 'lib/formatting';
+import { getLanguage } from 'lib/i18n-utils/utils';
 import { withoutHttp } from 'lib/url';
-
-/**
- * Module variables
- */
-const languages = config( 'languages' );
-
-export function getLanguage( slug ) {
-	const { length: len } = languages;
-	let language;
-	for ( let index = 0; index < len; index++ ) {
-		if ( slug === languages[ index ].langSlug ) {
-			language = languages[ index ];
-			break;
-		}
-	}
-
-	return language;
-}
 
 function getSiteSlug( url ) {
 	const slug = withoutHttp( url );

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -19,6 +19,7 @@ import wpcom from 'lib/wp';
 import Emitter from 'lib/mixins/emitter';
 import { isE2ETest } from 'lib/e2e';
 import { getComputedAttributes, filterUserObject } from './shared-utils';
+import { getLanguage } from 'lib/i18n-utils/utils';
 import localforage from 'lib/localforage';
 import { getActiveTestNames, ABTEST_LOCALSTORAGE_KEY } from 'lib/abtest/utility';
 
@@ -203,21 +204,7 @@ User.prototype.handleFetchSuccess = function( userData ) {
 };
 
 User.prototype.getLanguage = function() {
-	const languages = config( 'languages' );
-	const len = languages.length;
-	let language, index;
-
-	if ( ! this.data.localeSlug ) {
-		return;
-	}
-	for ( index = 0; index < len; index++ ) {
-		if ( this.data.localeSlug === languages[ index ].langSlug ) {
-			language = languages[ index ];
-			break;
-		}
-	}
-
-	return language;
+	return getLanguage( this.data.localeSlug );
 };
 
 /**


### PR DESCRIPTION
Instead of duplicated, homegrown implementations.

To test:
Verify that the app is still properly translated to the currently set locale.