### PR TITLE
Fix eslint errors in client/post-editor/editor-permalink/index.jsx

### DIFF
--- a/client/post-editor/editor-permalink/index.jsx
+++ b/client/post-editor/editor-permalink/index.jsx
@@ -30,6 +30,8 @@ class EditorPermalink extends Component {
 		slug: PropTypes.string,
 	};
 
+	permalinkToggleReference = React.createRef();
+
 	constructor() {
 		super( ...arguments );
 		this.showPopover = this.showPopover.bind( this );
@@ -120,13 +122,13 @@ class EditorPermalink extends Component {
 					className="editor-permalink__toggle"
 					icon="link"
 					onClick={ this.showPopover }
-					ref="popoverButton"
+					ref={ this.permalinkToggleReference }
 				/>
 				<Popover
 					isVisible={ this.state.showPopover }
 					onClose={ this.closePopover }
 					position={ 'bottom right' }
-					context={ this.refs && this.refs.popoverButton }
+					context={ this.permalinkToggleReference.current }
 					className="editor-permalink__popover"
 				>
 					<Slug
@@ -137,7 +139,7 @@ class EditorPermalink extends Component {
 					{ this.renderCopyButton() }
 				</Popover>
 				<Tooltip
-					context={ this.refs && this.refs.popoverButton }
+					context={ this.permalinkToggleReference.current }
 					isVisible={ this.state.tooltip }
 					position="bottom"
 				>

--- a/client/post-editor/editor-permalink/index.jsx
+++ b/client/post-editor/editor-permalink/index.jsx
@@ -40,21 +40,9 @@ class EditorPermalink extends Component {
 
 		this.state = {
 			showPopover: false,
-			popoverVisible: false,
 			showCopyConfirmation: false,
 			tooltip: false,
 		};
-	}
-
-	componentDidUpdate( prevProps, prevState ) {
-		if ( this.state.showPopover !== prevState.showPopover ) {
-			// The contents of <Popover /> are only truly rendered into the
-			// DOM after its `componentDidUpdate` finishes executing, so we
-			// wait to render the clipboard button until after the update.
-			this.setState( {
-				popoverVisible: this.state.showPopover,
-			} );
-		}
 	}
 
 	componentWillUnmount() {
@@ -96,9 +84,6 @@ class EditorPermalink extends Component {
 	}
 
 	renderCopyButton() {
-		if ( ! this.state.popoverVisible ) {
-			return;
-		}
 		const { path, slug, translate } = this.props;
 
 		let label;


### PR DESCRIPTION
Part of #24504 

No functional changes are expected to be introduced by this PR -- just eslint cleanup.

To test:
- Use the permalink popover on both new and existing posts and verify that no regressions have been introduced

<img width="614" alt="screencapture at thu jun 7 10 36 05 edt 2018" src="https://user-images.githubusercontent.com/2098816/41107637-be216b8e-6a40-11e8-8234-18a7ca65a78d.png">

/cc @aduth You originally wrote the code that used `state.popoverVisible`. That doesn't seem necessary anymore, so I removed that handling. If there is a reason this still should exist, please let me know!