### PR TITLE
Build: Update docker to use npm@6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,7 @@ RUN npm install --global npm@6.1
 # change. This layer should allow for final build times
 # to be limited only by the Calypso build speed.
 COPY       ./package.json ./npm-shrinkwrap.json /calypso/
-RUN        true \
-           && npm install --production \
-           && rm -rf /root/.npm \
-           && true
+RUN        npm install --production
 
 # Build a "source" layer
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ LABEL maintainer="Automattic"
 
 WORKDIR    /calypso
 
-
 ENV        CONTAINER 'docker'
 ENV        NODE_PATH=/calypso/server:/calypso/client
 
@@ -19,6 +18,9 @@ ENV        NODE_PATH=/calypso/server:/calypso/client
 #   such as the apt and npm mirrors
 COPY       ./env-config.sh /tmp/env-config.sh
 RUN        bash /tmp/env-config.sh
+
+# Update npm
+RUN npm install --global npm@6.1
 
 # Build a "dependencies" layer
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN npm install --global npm@6.1
 # change. This layer should allow for final build times
 # to be limited only by the Calypso build speed.
 COPY       ./package.json ./npm-shrinkwrap.json /calypso/
-RUN        npm install --production
+RUN        npm ci
 
 # Build a "source" layer
 #


### PR DESCRIPTION
- Use `npm@6.1` in Docker.
- Use [`npm ci`](https://docs.npmjs.com/cli/ci) for Docker installs:
  > This command is similar to npm-install, except it's meant to be used in automated environments such as test platforms, continuous integration, and deployment. It can be significantly faster than a regular npm install by skipping certain user-oriented features. It is also more strict than a regular install, which can help catch errors or inconsistencies caused by the incrementally-installed local environments of most npm users.

Should be merged with #25002 so production images use npm@6 as well.

### Testing
- Calypso.live: https://calypso.live/?branch=update/docker-build-npm6
- Local Docker builds `npm run build-docker && npm run docker`