### PR TITLE
Rewind: Change some labels in clone-credentials step of site cloning flow

### DIFF
--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -36,6 +36,11 @@ export class RewindCredentialsForm extends Component {
 		onCancel: PropTypes.func,
 		onComplete: PropTypes.func,
 		siteUrl: PropTypes.string,
+		labels: PropTypes.object,
+	};
+
+	static defaultProps = {
+		labels: {},
 	};
 
 	state = {
@@ -133,7 +138,7 @@ export class RewindCredentialsForm extends Component {
 	}
 
 	render() {
-		const { formIsSubmitting, onCancel, siteId, translate } = this.props;
+		const { formIsSubmitting, labels, onCancel, siteId, translate } = this.props;
 
 		const { showAdvancedSettings, formErrors } = this.state;
 
@@ -156,7 +161,9 @@ export class RewindCredentialsForm extends Component {
 
 				<div className="rewind-credentials-form__row">
 					<FormFieldset className="rewind-credentials-form__server-address">
-						<FormLabel htmlFor="host-address">{ translate( 'Server Address' ) }</FormLabel>
+						<FormLabel htmlFor="host-address">
+							{ labels.host || translate( 'Server Address' ) }
+						</FormLabel>
 						<FormTextInput
 							name="host"
 							id="host-address"
@@ -170,7 +177,9 @@ export class RewindCredentialsForm extends Component {
 					</FormFieldset>
 
 					<FormFieldset className="rewind-credentials-form__port-number">
-						<FormLabel htmlFor="server-port">{ translate( 'Port Number' ) }</FormLabel>
+						<FormLabel htmlFor="server-port">
+							{ labels.port || translate( 'Port Number' ) }
+						</FormLabel>
 						<FormTextInput
 							name="port"
 							id="server-port"
@@ -186,7 +195,9 @@ export class RewindCredentialsForm extends Component {
 
 				<div className="rewind-credentials-form__row rewind-credentials-form__user-pass">
 					<FormFieldset className="rewind-credentials-form__username">
-						<FormLabel htmlFor="server-username">{ translate( 'Server username' ) }</FormLabel>
+						<FormLabel htmlFor="server-username">
+							{ labels.user || translate( 'Server username' ) }
+						</FormLabel>
 						<FormTextInput
 							name="user"
 							id="server-username"
@@ -200,7 +211,9 @@ export class RewindCredentialsForm extends Component {
 					</FormFieldset>
 
 					<FormFieldset className="rewind-credentials-form__password">
-						<FormLabel htmlFor="server-password">{ translate( 'Server password' ) }</FormLabel>
+						<FormLabel htmlFor="server-password">
+							{ labels.pass || translate( 'Server password' ) }
+						</FormLabel>
 						<FormPasswordInput
 							name="pass"
 							id="server-password"
@@ -228,7 +241,7 @@ export class RewindCredentialsForm extends Component {
 						<div className="rewind-credentials-form__advanced-settings">
 							<FormFieldset className="rewind-credentials-form__path">
 								<FormLabel htmlFor="wordpress-path">
-									{ translate( 'WordPress installation path' ) }
+									{ labels.path || translate( 'WordPress installation path' ) }
 								</FormLabel>
 								<FormTextInput
 									name="path"
@@ -242,7 +255,9 @@ export class RewindCredentialsForm extends Component {
 							</FormFieldset>
 
 							<FormFieldset className="rewind-credentials-form__kpri">
-								<FormLabel htmlFor="private-key">{ translate( 'Private Key' ) }</FormLabel>
+								<FormLabel htmlFor="private-key">
+									{ labels.kpri || translate( 'Private Key' ) }
+								</FormLabel>
 								<FormTextArea
 									name="kpri"
 									id="private-key"
@@ -261,7 +276,7 @@ export class RewindCredentialsForm extends Component {
 
 				<FormFieldset>
 					<Button primary disabled={ formIsSubmitting } onClick={ this.handleSubmit }>
-						{ translate( 'Save' ) }
+						{ labels.save || translate( 'Save' ) }
 					</Button>
 					{ this.props.allowCancel && (
 						<Button
@@ -269,7 +284,7 @@ export class RewindCredentialsForm extends Component {
 							onClick={ onCancel }
 							className="rewind-credentials-form__cancel-button"
 						>
-							{ translate( 'Cancel' ) }
+							{ labels.cancel || translate( 'Cancel' ) }
 						</Button>
 					) }
 					{ this.props.allowDelete && (
@@ -280,7 +295,7 @@ export class RewindCredentialsForm extends Component {
 							className="rewind-credentials-form__delete-button"
 						>
 							<Gridicon icon="trash" size={ 18 } />
-							{ translate( 'Delete' ) }
+							{ labels.delete || translate( 'Delete' ) }
 						</Button>
 					) }
 				</FormFieldset>

--- a/client/signup/steps/clone-credentials/index.jsx
+++ b/client/signup/steps/clone-credentials/index.jsx
@@ -56,6 +56,10 @@ class CloneCredentialsStep extends Component {
 						role={ 'alternate' /* eslint-disable-line */ }
 						siteId={ originBlogId }
 						siteUrl={ destinationSiteUrl }
+						labels={ {
+							host: translate( 'Destination Server Address' ),
+							path: translate( 'Destination WordPress Path' ),
+						} }
 					/>
 				</Card>
 			</div>

--- a/client/signup/steps/clone-credentials/index.jsx
+++ b/client/signup/steps/clone-credentials/index.jsx
@@ -47,9 +47,12 @@ class CloneCredentialsStep extends Component {
 		return (
 			<div>
 				<SectionHeader
-					label={ translate( 'Enter credentials for the destination site, %(site)s.', {
-						args: { site: destinationSiteName },
-					} ) }
+					label={ translate(
+						'Make sure the credentials you enter are for the destination site, %(site)s.',
+						{
+							args: { site: destinationSiteName },
+						}
+					) }
 				/>
 				<Card className="clone-credentials__form">
 					<RewindCredentialsForm
@@ -80,14 +83,13 @@ class CloneCredentialsStep extends Component {
 			positionInFlow,
 			signupProgress,
 			translate,
-			originSiteName,
 			destinationSiteName,
 		} = this.props;
 
 		const headerText = translate( 'Enter your server credentials' );
 		const subHeaderText = translate(
-			'In order to clone %(origin)s, we need the server credentials for %(destination)s.',
-			{ args: { origin: originSiteName, destination: destinationSiteName } }
+			'Before we can start cloning your site, we need the server credentials for %(destination)s.',
+			{ args: { destination: destinationSiteName } }
 		);
 
 		return (


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/25329

To ensure that it's clear what the user is supposed to enter in the clone-credentials step, we need the ability to change the labels in the credentials form based on context.

This PR updates the host and path fields like so:

<img width="740" alt="screen shot 2018-06-07 at 1 23 38 pm" src="https://user-images.githubusercontent.com/5528445/41115621-0bd348ce-6a56-11e8-8e71-68d7739681aa.png">

**Testing**

Step through the site cloning flow until you reach the credentials form. Ensure the labels are reflected as seen in the screenshot above, and no other components are altered.