### PR TITLE
Update README badge from greenkeeper to renovate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Calypso
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/Automattic/wp-calypso.svg)](https://greenkeeper.io/)
+[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovateapp.com/)
 
 Calypso is the new WordPress.com front-end – a beautiful redesign of the WordPress dashboard using a single-page web application, powered by the WordPress.com REST API. Calypso is built for reading, writing, and managing all of your WordPress sites in one place.
 


### PR DESCRIPTION
* We're moving off Greenkeeper and on to Renovate. In light of this,
  - Remove greenkeeper badge
  - Add renovate badge

Fixes: https://github.com/Automattic/wp-calypso/issues/25338