### PR TITLE
NUX: Simplify Route Defs

### DIFF
--- a/client/signup/index.node.js
+++ b/client/signup/index.node.js
@@ -3,38 +3,19 @@
 /**
  * Internal dependencies
  */
+import { getLanguage, getLanguageSlugs } from 'lib/i18n-utils';
 
-import { getLanguage } from 'lib/i18n-utils';
+const lang = `:lang(${ getLanguageSlugs().join( '|' ) })?`;
 
 export default function( router ) {
-	router( '/start/:flowName?/:stepName?/:stepSectionName?/:lang?', setUpLocale );
+	router( `/start/:flowName?/:stepName?/:stepSectionName?/${ lang }`, setUpLocale );
 }
 
 // Set up the locale in case it has ended up in the flow param
 function setUpLocale( context, next ) {
-	let { flowName, stepName, stepSectionName, lang } = context.params;
-
-	if ( ! lang && stepSectionName && getLanguage( stepSectionName ) ) {
-		lang = stepSectionName;
-		stepSectionName = undefined;
-	} else if ( ! lang && stepName && getLanguage( stepName ) ) {
-		lang = stepName;
-		stepName = undefined;
-	} else if ( ! lang && flowName && getLanguage( flowName ) ) {
-		lang = flowName;
-		flowName = undefined;
-	}
-
-	context.params = Object.assign( {}, context.params, {
-		flowName,
-		stepName,
-		stepSectionName,
-		lang,
-	} );
-
-	const language = getLanguage( lang );
+	const language = getLanguage( context.params.lang );
 	if ( language ) {
-		context.lang = lang;
+		context.lang = context.params.lang;
 		if ( language.rtl ) {
 			context.isRTL = true;
 		}

--- a/client/signup/index.node.js
+++ b/client/signup/index.node.js
@@ -8,9 +8,9 @@ import { getLanguage, getLanguageSlugs } from 'lib/i18n-utils';
 const lang = `(${ getLanguageSlugs().join( '|' ) })`;
 
 export default function( router ) {
-	// The idea is that we look out for `lang` route params matching our whitelist,
+	// The idea is to look out for optional `lang` route params matching our whitelist,
 	// and fall through to the next route def (with free form `flowName`, `stepName`,
-	// and `stepSectionName` route params) if we don't.
+	// and `stepSectionName` route params) if we don't match one.
 	router( `/start/:lang${ lang }?`, setUpLocale );
 	router( `/start/:flowName/:lang${ lang }?`, setUpLocale );
 	router( `/start/:flowName/:stepName/:lang${ lang }?`, setUpLocale );

--- a/client/signup/index.node.js
+++ b/client/signup/index.node.js
@@ -8,6 +8,9 @@ import { getLanguage, getLanguageSlugs } from 'lib/i18n-utils';
 const lang = `(${ getLanguageSlugs().join( '|' ) })`;
 
 export default function( router ) {
+	// The idea is that we look out for `lang` route params matching our whitelist,
+	// and fall through to the next route def (with free form `flowName`, `stepName`,
+	// and `stepSectionName` route params) if we don't.
 	router( `/start/:lang${ lang }?`, setUpLocale );
 	router( `/start/:flowName/:lang${ lang }?`, setUpLocale );
 	router( `/start/:flowName/:stepName/:lang${ lang }?`, setUpLocale );

--- a/client/signup/index.node.js
+++ b/client/signup/index.node.js
@@ -5,13 +5,16 @@
  */
 import { getLanguage, getLanguageSlugs } from 'lib/i18n-utils';
 
-const lang = `:lang(${ getLanguageSlugs().join( '|' ) })?`;
+const lang = `:lang(${ getLanguageSlugs().join( '|' ) })`;
 
 export default function( router ) {
-	router( `/start/:flowName?/:stepName?/:stepSectionName?/${ lang }`, setUpLocale );
+	router( `/start/:flowName/:stepName/:stepSectionName/${ lang }`, setUpLocale );
+	router( `/start/:flowName/:stepName/${ lang }`, setUpLocale );
+	router( `/start/:flowName/${ lang }`, setUpLocale );
+	router( `/start/${ lang }`, setUpLocale );
 }
 
-// Set up the locale in case it has ended up in the flow param
+// Set up the locale if there is one
 function setUpLocale( context, next ) {
 	const language = getLanguage( context.params.lang );
 	if ( language ) {

--- a/client/signup/index.node.js
+++ b/client/signup/index.node.js
@@ -5,13 +5,13 @@
  */
 import { getLanguage, getLanguageSlugs } from 'lib/i18n-utils';
 
-const lang = `:lang(${ getLanguageSlugs().join( '|' ) })`;
+const lang = `(${ getLanguageSlugs().join( '|' ) })`;
 
 export default function( router ) {
-	router( `/start/:flowName/:stepName/:stepSectionName/${ lang }`, setUpLocale );
-	router( `/start/:flowName/:stepName/${ lang }`, setUpLocale );
-	router( `/start/:flowName/${ lang }`, setUpLocale );
-	router( `/start/${ lang }`, setUpLocale );
+	router( `/start/:lang${ lang }?`, setUpLocale );
+	router( `/start/:flowName/:lang${ lang }?`, setUpLocale );
+	router( `/start/:flowName/:stepName/:lang${ lang }?`, setUpLocale );
+	router( `/start/:flowName/:stepName/:stepSectionName/:lang${ lang }?`, setUpLocale );
 }
 
 // Set up the locale if there is one


### PR DESCRIPTION
By using a route fragment pattern instead of confusing and [error-prone](https://github.com/Automattic/wp-calypso/pull/23787) heuristics.

To test:
* In an incognito window, start at `calypso.localhost:3000/start/`, and move thru the NUX flow. Verify that every steps works and successfully takes you to the next.
* Try the same with various valid and invalid locale route fragments appended, e.g.
  * http://calypso.localhost:3000/start/de
  * http://calypso.localhost:3000/start/de_formal
  * http://calypso.localhost:3000/start/pt-br
  * http://calypso.localhost:3000/start/ast
  * http://calypso.localhost:3000/start/foo (invalid)
* Verify that the [regression](https://github.com/Automattic/wp-calypso/pull/25378#discussion_r194719126) introduced by an earlier stage of this PR found by @ramonjd is fixed:
  * Land at http://calypso.localhost:3000/start/it
  * Click 'Continua', landing on the second step (http://calypso.localhost:3000/start/domains/it)
  * Reload
  * Verify the second step is still in Italian ("Assegna un indirizzo al tuo sito.")