### PR TITLE
Babel Env: Explicitly include `es6.set` in the config

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -18,6 +18,7 @@ const config = {
 				targets: {
 					browsers: [ 'last 2 versions', 'Safari >= 10', 'iOS >= 10', 'ie >= 11' ],
 				},
+				include: [ 'es6.set' ],
 				exclude: [ 'transform-classes', 'transform-template-literals' ], // transform-classes is added manually later.
 			},
 		],


### PR DESCRIPTION
Work in progress -- do not merge

---

Attempt to fix Calypso not booting on specific device / browser combos.