### PR TITLE
Add the Google Maps API Key to calypso

### DIFF
--- a/client/lib/geocoding/index.js
+++ b/client/lib/geocoding/index.js
@@ -7,15 +7,21 @@
 import request from 'superagent';
 
 /**
+ * Internal dependencies
+ */
+import config from 'config';
+
+/**
  * Module variables
  */
 const GOOGLE_MAPS_API_BASE_URL = 'https://maps.googleapis.com/maps/api/geocode/json';
+const GOOGLE_MAPS_API_KEY = config( 'google_maps_api_key' );
 
 export function geocode( address ) {
 	return new Promise( ( resolve, reject ) => {
 		request
 			.get( GOOGLE_MAPS_API_BASE_URL )
-			.query( { address } )
+			.query( { address, key: GOOGLE_MAPS_API_KEY } )
 			.end( ( error, response ) => {
 				if ( error || ! response.ok || 'OK' !== response.body.status ) {
 					return reject( error );

--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -15,12 +15,15 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import config from 'config';
 import { loadScript } from 'lib/load-script';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import QuerySiteStats from 'components/data/query-site-stats';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteStatsNormalizedData } from 'state/stats/lists/selectors';
 import { getCurrentUserCountryCode } from 'state/current-user/selectors';
+
+const GOOGLE_MAPS_API_KEY = config( 'google_maps_api_key' );
 
 class StatsGeochart extends Component {
 	static propTypes = {
@@ -139,6 +142,7 @@ class StatsGeochart extends Component {
 		if ( window.google ) {
 			window.google.load( 'visualization', '1', {
 				packages: [ 'geochart' ],
+				mapsApiKey: GOOGLE_MAPS_API_KEY,
 				callback: this.drawRegionsMap,
 			} );
 			clearTimeout( this.timer );

--- a/client/post-editor/editor-location/index.jsx
+++ b/client/post-editor/editor-location/index.jsx
@@ -12,6 +12,7 @@ import { stringify } from 'qs';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import PostActions from 'lib/posts/actions';
 import EditorDrawerWell from 'post-editor/editor-drawer-well';
 import { recordEvent, recordStat } from 'lib/posts/stats';
@@ -23,6 +24,7 @@ import RemoveButton from 'components/remove-button';
  * Module variables
  */
 const GOOGLE_MAPS_BASE_URL = 'https://maps.google.com/maps/api/staticmap?';
+const GOOGLE_MAPS_API_KEY = config( 'google_maps_api_key' );
 
 class EditorLocation extends React.Component {
 	static displayName = 'EditorLocation';
@@ -110,6 +112,7 @@ class EditorLocation extends React.Component {
 				markers: this.props.coordinates.join( ',' ),
 				zoom: 8,
 				size: '400x300',
+				key: GOOGLE_MAPS_API_KEY,
 			} );
 
 		return <img src={ src } className="editor-location__map" />;

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -20,6 +20,7 @@
 	"google_analytics_key": false,
 	"google_adwords_conversion_id": false,
 	"google_adwords_conversion_id_jetpack": false,
+	"google_maps_api_key": "ABC",
 	"hotjar_enabled": false,
 	"hostname": false,
 	"i18n_default_locale_slug": "en",

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -135,5 +135,6 @@
 	"google_analytics_key": "UA-10673494-10",
 	"google_adwords_conversion_id": 1067250390,
 	"google_adwords_conversion_id_jetpack": 937115306,
+	"google_maps_api_key": "ABC",
 	"hotjar_enabled": true
 }

--- a/config/development.json
+++ b/config/development.json
@@ -20,6 +20,7 @@
 	"google_analytics_key": "UA-10673494-15",
 	"google_adwords_conversion_id": 1067250390,
 	"google_adwords_conversion_id_jetpack": 937115306,
+	"google_maps_api_key": "ABC",
 	"hotjar_enabled": true,
 	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -130,5 +130,6 @@
 	"google_analytics_key": "UA-10673494-20",
 	"google_adwords_conversion_id": 1067250390,
 	"google_adwords_conversion_id_jetpack": 937115306,
+	"google_maps_api_key": "ABC",
 	"hotjar_enabled": true
 }

--- a/config/production.json
+++ b/config/production.json
@@ -160,5 +160,6 @@
 	"google_analytics_key": "UA-10673494-10",
 	"google_adwords_conversion_id": 1067250390,
 	"google_adwords_conversion_id_jetpack": 937115306,
+	"google_maps_api_key": "ABC",
 	"hotjar_enabled": true
 }

--- a/config/stage.json
+++ b/config/stage.json
@@ -163,5 +163,6 @@
 	"boom_analytics_key": "stage",
 	"google_adwords_conversion_id": 1067250390,
 	"google_adwords_conversion_id_jetpack": 937115306,
+	"google_maps_api_key": "ABC",
 	"hotjar_enabled": true
 }

--- a/config/test.json
+++ b/config/test.json
@@ -18,6 +18,7 @@
 	"google_analytics_key": "UA-10673494-15",
 	"google_adwords_conversion_id": 1067250390,
 	"google_adwords_conversion_id_jetpack": 937115306,
+	"google_maps_api_key": "ABC",
 	"hotjar_enabled": true,
 	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -182,5 +182,6 @@
 	"google_analytics_key": "UA-10673494-15",
 	"google_adwords_conversion_id": 1067250390,
 	"google_adwords_conversion_id_jetpack": 937115306,
+	"google_maps_api_key": "ABC",
 	"hotjar_enabled": true
 }


### PR DESCRIPTION
We need to start setting the api key to because google maps might stop working for us. 

See p58i-73f-p2

## Testing
Go to the editor screen or a simple wordpress.com site and check that the geocoding works as expected.
<img width="272" alt="screen shot 2018-06-07 at 3 32 52 pm" src="https://user-images.githubusercontent.com/115071/41129701-23883364-6a68-11e8-8494-8b55926e988f.png">

Note that the static image of the location gets generated as expected there once the location is selected.
<img width="266" alt="screen shot 2018-06-07 at 3 32 59 pm" src="https://user-images.githubusercontent.com/115071/41129700-1ef40620-6a68-11e8-8e70-15553c38c746.png">

Go to countries in stats and notice that the map appears as expected. 
<img width="888" alt="screen shot 2018-06-07 at 3 34 47 pm" src="https://user-images.githubusercontent.com/115071/41129746-6926140e-6a68-11e8-8fe0-169bd8cabf5c.png">

If you need a key to test this out with please ping me in slack.
## Todo
- [ ] Add the real keys. 