### PR TITLE
Add temporary GDPR notice to tranasfer out screen.

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
@@ -15,9 +15,11 @@ import SectionHeader from 'components/section-header';
 import { getSelectedDomain } from 'lib/domains';
 import Button from 'components/button';
 import { requestTransferCode } from 'lib/upgrades/actions';
-import { displayRequestTransferCodeResponseNotice } from './shared';
+import {
+	displayRequestTransferCodeResponseNotice,
+	renderGdprTransferWarningNotice,
+} from './shared';
 import { TRANSFER_DOMAIN_REGISTRATION } from 'lib/url/support';
-import Notice from 'components/notice';
 
 class Locked extends React.Component {
 	state = {
@@ -63,26 +65,13 @@ class Locked extends React.Component {
 	render() {
 		const { translate } = this.props;
 		const { privateDomain } = getSelectedDomain( this.props );
+
 		return (
 			<div>
-				<Notice status="is-warning" showDismiss={ false }>
-					{ translate(
-						"Due to the EU's {{gdpr}}General Data Protection Regulation{{/gdpr}}, " +
-							'some providers may have trouble transferring your domain to them. ' +
-							'{{learn}}Learn more.{{/learn}}',
-						{
-							components: {
-								gdpr: (
-									<a href="https://automattic.com/automattic-and-the-general-data-protection-regulation-gdpr/" />
-								),
-								learn: (
-									<a href="https://en.support.wordpress.com/move-domain/transfer-domain-registration/#what-if-my-new-registrar-says-they-cant-start-my-transfer-because-my-contact-information-is-not-public" />
-								),
-							},
-						}
-					) }
-				</Notice>
+				{ renderGdprTransferWarningNotice() }
+
 				<SectionHeader label={ translate( 'Transfer Domain' ) } />
+
 				<Card className="transfer-card">
 					<p>
 						{ privateDomain

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
@@ -67,12 +67,9 @@ class Locked extends React.Component {
 			<div>
 				<Notice status="is-warning" showDismiss={ false }>
 					{ translate(
-						'Currently, many domain providers are experiencing difficulty with their ' +
-							'processes for handling transfers due to changes required for The ' +
-							'European Union’s {{gdpr}}General Data Protection Regulation{{/gdpr}}, ' +
-							'which went into full effect on May 25, 2018. Please note this may ' +
-							'impact your ability to transfer your domain from WordPress.com to ' +
-							'other providers. {{learn}}Learn more.{{/learn}}',
+						"Due to the EU's {{gdpr}}General Data Protection Regulation{{/gdpr}}, " +
+							'some providers may have trouble transferring your domain to them. ' +
+							'{{learn}}Learn more.{{/learn}}',
 						{
 							components: {
 								gdpr: (

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
@@ -17,6 +17,7 @@ import Button from 'components/button';
 import { requestTransferCode } from 'lib/upgrades/actions';
 import { displayRequestTransferCodeResponseNotice } from './shared';
 import { TRANSFER_DOMAIN_REGISTRATION } from 'lib/url/support';
+import Notice from 'components/notice';
 
 class Locked extends React.Component {
 	state = {
@@ -64,30 +65,48 @@ class Locked extends React.Component {
 		const { privateDomain } = getSelectedDomain( this.props );
 		return (
 			<div>
+				<Notice status="is-warning" showDismiss={ false }>
+					{ translate(
+						'Currently, many domain providers are experiencing difficulty with their ' +
+							'processes for handling transfers due to changes required for The ' +
+							'European Union’s {{gdpr}}General Data Protection Regulation{{/gdpr}}, ' +
+							'which went into full effect on May 25, 2018. Please note this may ' +
+							'impact your ability to transfer your domain from WordPress.com to ' +
+							'other providers. {{learn}}Learn more.{{/learn}}',
+						{
+							components: {
+								gdpr: (
+									<a href="https://automattic.com/automattic-and-the-general-data-protection-regulation-gdpr/" />
+								),
+								learn: (
+									<a href="https://en.support.wordpress.com/move-domain/transfer-domain-registration/#what-if-my-new-registrar-says-they-cant-start-my-transfer-because-my-contact-information-is-not-public" />
+								),
+							},
+						}
+					) }
+				</Notice>
 				<SectionHeader label={ translate( 'Transfer Domain' ) } />
 				<Card className="transfer-card">
-					<div>
-						<p>
-							{ privateDomain
-								? translate(
-										'To transfer your domain, we must unlock it and remove Privacy Protection. ' +
-											'Your contact information will be publicly available during the transfer period.'
-									)
-								: translate( 'To transfer your domain, we must unlock it.' ) }{' '}
-							<a href={ TRANSFER_DOMAIN_REGISTRATION } target="_blank" rel="noopener noreferrer">
-								{ translate( 'Learn More.' ) }
-							</a>
-						</p>
-						{ this.isManualTransferRequired() && this.renderManualTransferInfo() }
-						<Button
-							className="transfer__action-button"
-							onClick={ this.unlockAndRequestTransferCode }
-							primary
-							disabled={ this.state.submitting }
-						>
-							{ translate( 'Update Settings And Continue' ) }
-						</Button>
-					</div>
+					<p>
+						{ privateDomain
+							? translate(
+									'To transfer your domain, we must unlock it and remove Privacy Protection. ' +
+										'Your contact information will be publicly available during the transfer period.'
+								)
+							: translate( 'To transfer your domain, we must unlock it.' ) }{' '}
+						<a href={ TRANSFER_DOMAIN_REGISTRATION } target="_blank" rel="noopener noreferrer">
+							{ translate( 'Learn More.' ) }
+						</a>
+					</p>
+					{ this.isManualTransferRequired() && this.renderManualTransferInfo() }
+					<Button
+						className="transfer-out__action-button"
+						onClick={ this.unlockAndRequestTransferCode }
+						primary
+						disabled={ this.state.submitting }
+					>
+						{ translate( 'Update Settings And Continue' ) }
+					</Button>
 				</Card>
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/shared.js
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/shared.js
@@ -12,6 +12,29 @@ import { translate } from 'i18n-calypso';
  */
 import notices from 'notices';
 import { CALYPSO_CONTACT } from 'lib/url/support';
+import Notice from 'components/notice';
+
+export const renderGdprTransferWarningNotice = () => {
+	return (
+		<Notice status="is-warning" showDismiss={ false }>
+			{ translate(
+				"Due to the EU's {{gdpr}}General Data Protection Regulation{{/gdpr}}, " +
+					'some providers may have trouble transferring your domain to them. ' +
+					'{{learn}}Learn more.{{/learn}}',
+				{
+					components: {
+						gdpr: (
+							<a href="https://automattic.com/automattic-and-the-general-data-protection-regulation-gdpr/" />
+						),
+						learn: (
+							<a href="https://en.support.wordpress.com/move-domain/transfer-domain-registration/#what-if-my-new-registrar-says-they-cant-start-my-transfer-because-my-contact-information-is-not-public" />
+						),
+					},
+				}
+			) }
+		</Notice>
+	);
+};
 
 export const displayResponseError = responseError => {
 	const errorMessages = {

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/style.scss
@@ -12,7 +12,7 @@
 	}
 }
 
-.transfer__action-button {
+.transfer-out__action-button {
 	float: right;
 	margin-right: 10px;
 	&:first-of-type {

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
@@ -17,7 +17,10 @@ import { getSelectedDomain } from 'lib/domains';
 import Button from 'components/button';
 import { requestTransferCode, cancelTransferRequest } from 'lib/upgrades/actions';
 import notices from 'notices';
-import { displayRequestTransferCodeResponseNotice } from './shared';
+import {
+	displayRequestTransferCodeResponseNotice,
+	renderGdprTransferWarningNotice,
+} from './shared';
 import { CALYPSO_CONTACT, TRANSFER_DOMAIN_REGISTRATION } from 'lib/url/support';
 
 class Unlocked extends React.Component {
@@ -281,6 +284,8 @@ class Unlocked extends React.Component {
 
 		return (
 			<div>
+				{ renderGdprTransferWarningNotice() }
+
 				<SectionHeader
 					label={ translate( 'Transfer Domain' ) }
 					className="transfer-out__section-header"


### PR DESCRIPTION
We need to temporarily display a warning on the transfer out page since some domain providers are having issues becoming compliant with GDPR and are causing transfers out to fail.

Go to the transfer out page, make sure the notice is shown at the top of the card and that the links work. Make sure that the notice is shown for both the locked and unlocked pages. You should see the notice in the image below.

<img width="745" alt="transfer_domain_ _a8c_test_site_ _wordpress_com" src="https://user-images.githubusercontent.com/1379730/41122110-7dad392a-6a68-11e8-8c4e-e06b05f744bb.png">
