### PR TITLE
Activity Log: make theme updates available to all users

### DIFF
--- a/client/my-sites/stats/activity-log-tasklist/to-update.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/to-update.jsx
@@ -13,7 +13,6 @@ import { get, unionBy } from 'lodash';
  */
 import { getPluginsWithUpdates } from 'state/plugins/installed/selectors';
 import { requestSiteAlerts } from 'state/data-getters';
-import config from 'config';
 
 const emptyList = [];
 
@@ -57,9 +56,7 @@ export default WrappedComponent => {
 	return connect( ( state, { siteId } ) => {
 		return {
 			plugins: getPluginsWithUpdates( state, [ siteId ] ),
-			themes: config.isEnabled( 'activity-log-theme-update' )
-				? get( requestSiteAlerts( siteId ), 'data.updates.themes', emptyList )
-				: emptyList,
+			themes: get( requestSiteAlerts( siteId ), 'data.updates.themes', emptyList ),
 		};
 	} )( ToUpdate );
 };

--- a/config/development.json
+++ b/config/development.json
@@ -29,7 +29,6 @@
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"support_site_locales": [ "en", "es", "de", "ja", "pt-br" ],
 	"features": {
-		"activity-log-theme-update": true,
 		"activity-log-wpcom-free": true,
 		"account-recovery": true,
 		"ad-tracking": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -19,7 +19,6 @@
 		"pt-br"
 	],
 	"features": {
-		"activity-log-theme-update": true,
 		"activity-log-wpcom-free": true,
 		"ad-tracking": false,
 		"apple-pay": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -16,7 +16,6 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
-		"activity-log-theme-update": true,
 		"activity-log-wpcom-free": true,
 		"ad-tracking": false,
 		"automated-transfer": true,


### PR DESCRIPTION
This removes the flags and rolls the feature for all users.

### Testing

Test with different plans:

- non a8c user with
    - free plan
    - paid plan