### PR TITLE
Signup: Cleanup main component

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -2,12 +2,13 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-import url from 'url';
+import cookie from 'cookie';
 import debugModule from 'debug';
 import page from 'page';
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
+import url from 'url';
 import {
 	assign,
 	defer,
@@ -23,38 +24,45 @@ import {
 	some,
 	startsWith,
 } from 'lodash';
+import { translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { setSurvey } from 'state/signup/steps/survey/actions';
-import cookie from 'cookie';
 
 /**
  * Internal dependencies
  */
 import config from 'config';
-import SignupDependencyStore from 'lib/signup/dependency-store';
-import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
-import SignupProgressStore from 'lib/signup/progress-store';
-import SignupFlowController from 'lib/signup/flow-controller';
-import LocaleSuggestions from 'components/locale-suggestions';
-import FlowProgressIndicator from './flow-progress-indicator';
-import steps from './config/steps';
-import stepComponents from './config/step-components';
-import flows from './config/flows';
-import WpcomLoginForm from './wpcom-login-form';
-import analytics from 'lib/analytics';
-import SignupProcessingScreen from 'signup/processing-screen';
-import { getDestination, canResumeFlow, getStepUrl } from './utils';
-import { currentUserHasFlag, getCurrentUser, isUserLoggedIn } from 'state/current-user/selectors';
-import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
-import * as oauthToken from 'lib/oauth-token';
+
+// Components
 import DocumentHead from 'components/data/document-head';
-import { translate } from 'i18n-calypso';
-import SignupActions from 'lib/signup/actions';
+import LocaleSuggestions from 'components/locale-suggestions';
+import SignupProcessingScreen from 'signup/processing-screen';
+
+// Libraries
+import analytics from 'lib/analytics';
 import { recordSignupStart, recordSignupCompletion } from 'lib/analytics/ad-tracking';
-import { disableCart } from 'lib/upgrades/actions';
-import { loadTrackingTool } from 'state/analytics/actions';
-import { affiliateReferral } from 'state/refer/actions';
+import * as oauthToken from 'lib/oauth-token';
 import { isDomainRegistration, isDomainTransfer, isDomainMapping } from 'lib/products-values';
+import SignupActions from 'lib/signup/actions';
+import SignupDependencyStore from 'lib/signup/dependency-store';
+import SignupFlowController from 'lib/signup/flow-controller';
+import SignupProgressStore from 'lib/signup/progress-store';
+import { disableCart } from 'lib/upgrades/actions';
+
+// State actions and selectors
+import { loadTrackingTool } from 'state/analytics/actions';
+import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
+import { currentUserHasFlag, getCurrentUser, isUserLoggedIn } from 'state/current-user/selectors';
+import { affiliateReferral } from 'state/refer/actions';
+import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
+import { setSurvey } from 'state/signup/steps/survey/actions';
+
+// Current directory dependencies
+import steps from './config/steps';
+import flows from './config/flows';
+import stepComponents from './config/step-components';
+import FlowProgressIndicator from './flow-progress-indicator';
+import { getDestination, canResumeFlow, getStepUrl } from './utils';
+import WpcomLoginForm from './wpcom-login-form';
 
 /**
  * Constants

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -139,7 +139,7 @@ class Signup extends React.Component {
 			return this.resumeProgress();
 		}
 
-		if ( this.positionInFlow() !== 0 ) {
+		if ( this.getPositionInFlow() !== 0 ) {
 			// no progress was resumed and we're on a non-zero step
 			// redirect to the beginning of the flow
 			return page.redirect(
@@ -432,10 +432,8 @@ class Signup extends React.Component {
 		return flowSteps.length === signupProgress.length;
 	};
 
-	positionInFlow = () => {
+	getPositionInFlow() {
 		return indexOf( flows.getFlow( this.props.flowName ).steps, this.props.stepName );
-	};
-
 	}
 
 	renderCurrentStep() {
@@ -484,7 +482,7 @@ class Signup extends React.Component {
 						signupProgress={ this.state.progress }
 						signupDependencies={ this.props.signupDependencies }
 						stepSectionName={ this.props.stepSectionName }
-						positionInFlow={ this.positionInFlow() }
+						positionInFlow={ this.getPositionInFlow() }
 						hideFreePlan={ hideFreePlan }
 						{ ...propsFromConfig }
 					/>
@@ -496,7 +494,7 @@ class Signup extends React.Component {
 	render() {
 		if (
 			! this.props.stepName ||
-			( this.positionInFlow() > 0 && this.state.progress.length === 0 ) ||
+			( this.getPositionInFlow() > 0 && this.state.progress.length === 0 ) ||
 			this.state.resumingStep
 		) {
 			return null;
@@ -516,7 +514,7 @@ class Signup extends React.Component {
 				{ ! this.state.loadingScreenStartTime &&
 					showProgressIndicator && (
 						<FlowProgressIndicator
-							positionInFlow={ this.positionInFlow() }
+							positionInFlow={ this.getPositionInFlow() }
 							flowLength={ flow.steps.length }
 							flowName={ this.props.flowName }
 						/>

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -77,6 +77,15 @@ class Signup extends React.Component {
 		store: PropTypes.object,
 	};
 
+	static propTypes = {
+		domainsWithPlansOnly: PropTypes.bool,
+		isLoggedIn: PropTypes.bool,
+		loadTrackingTool: PropTypes.func.isRequired,
+		setSurvey: PropTypes.func.isRequired,
+		signupDependencies: PropTypes.object,
+		trackAffiliateReferral: PropTypes.func.isRequired,
+	};
+
 	constructor( props, context ) {
 		super( props, context );
 		SignupDependencyStore.setReduxStore( context.store );
@@ -204,7 +213,7 @@ class Signup extends React.Component {
 		const campaignId = parsedUrl.query.cid;
 
 		if ( affiliateId && ! isNaN( affiliateId ) ) {
-			this.props.affiliateReferral( { affiliateId, campaignId, urlPath } );
+			this.props.trackAffiliateReferral( { affiliateId, campaignId, urlPath } );
 			// Record the referral in Tracks
 			analytics.tracks.recordEvent( 'calypso_refer_visit', {
 				flow: this.props.flowName,
@@ -559,7 +568,7 @@ export default connect(
 		signupDependencies: getSignupDependencyStore( state ),
 		isLoggedIn: isUserLoggedIn( state ),
 	} ),
-	{ setSurvey, loadTrackingTool, affiliateReferral },
+	{ setSurvey, loadTrackingTool, trackAffiliateReferral: affiliateReferral },
 	undefined,
 	{ pure: false }
 )( Signup );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -61,6 +61,7 @@ import { isDomainRegistration, isDomainTransfer, isDomainMapping } from 'lib/pro
  */
 const debug = debugModule( 'calypso:signup' );
 const MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED = 3000;
+
 class Signup extends React.Component {
 	static displayName = 'Signup';
 
@@ -83,50 +84,6 @@ class Signup extends React.Component {
 			plans: false,
 		};
 	}
-
-	loadProgressFromStore = () => {
-		const newProgress = SignupProgressStore.get(),
-			invalidSteps = some( newProgress, matchesProperty( 'status', 'invalid' ) ),
-			waitingForServer = ! invalidSteps && this.isEveryStepSubmitted(),
-			startLoadingScreen = waitingForServer && ! this.state.loadingScreenStartTime;
-
-		this.setState( { progress: newProgress } );
-
-		if ( this.isEveryStepSubmitted() ) {
-			this.goToFirstInvalidStep();
-		}
-
-		if ( startLoadingScreen ) {
-			this.setState( { loadingScreenStartTime: Date.now() } );
-		}
-
-		if ( invalidSteps ) {
-			this.setState( { loadingScreenStartTime: undefined } );
-		}
-	};
-
-	submitQueryDependencies = () => {
-		if ( isEmpty( this.props.initialContext && this.props.initialContext.query ) ) {
-			return;
-		}
-
-		const queryObject = this.props.initialContext.query;
-		const flowSteps = flows.getFlow( this.props.flowName ).steps;
-
-		// `vertical` query parameter
-		const vertical = queryObject.vertical;
-		if ( 'undefined' !== typeof vertical && -1 === flowSteps.indexOf( 'survey' ) ) {
-			debug( 'From query string: vertical = %s', vertical );
-			this.props.setSurvey( {
-				vertical,
-				otherText: '',
-			} );
-			SignupActions.submitSignupStep( { stepName: 'survey' }, [], {
-				surveySiteType: 'blog',
-				surveyQuestion: vertical,
-			} );
-		}
-	};
 
 	componentWillMount() {
 		analytics.tracks.recordEvent( 'calypso_signup_start', {
@@ -219,6 +176,77 @@ class Signup extends React.Component {
 		this.checkForCartItems( signupDependencies );
 	}
 
+	componentDidMount() {
+		debug( 'Signup component mounted' );
+
+		SignupProgressStore.on( 'change', this.loadProgressFromStore );
+		this.props.loadTrackingTool( 'HotJar' );
+
+		const urlPath = location.href;
+		const parsedUrl = url.parse( urlPath, true );
+		const affiliateId = parsedUrl.query.aff;
+		const campaignId = parsedUrl.query.cid;
+
+		if ( affiliateId && ! isNaN( affiliateId ) ) {
+			this.props.affiliateReferral( { affiliateId, campaignId, urlPath } );
+			// Record the referral in Tracks
+			analytics.tracks.recordEvent( 'calypso_refer_visit', {
+				flow: this.props.flowName,
+				// The current page without any query params
+				page: parsedUrl.host + parsedUrl.pathname,
+			} );
+		}
+	}
+
+	componentWillUnmount() {
+		debug( 'Signup component unmounted' );
+		SignupProgressStore.off( 'change', this.loadProgressFromStore );
+	}
+
+	loadProgressFromStore = () => {
+		const newProgress = SignupProgressStore.get(),
+			invalidSteps = some( newProgress, matchesProperty( 'status', 'invalid' ) ),
+			waitingForServer = ! invalidSteps && this.isEveryStepSubmitted(),
+			startLoadingScreen = waitingForServer && ! this.state.loadingScreenStartTime;
+
+		this.setState( { progress: newProgress } );
+
+		if ( this.isEveryStepSubmitted() ) {
+			this.goToFirstInvalidStep();
+		}
+
+		if ( startLoadingScreen ) {
+			this.setState( { loadingScreenStartTime: Date.now() } );
+		}
+
+		if ( invalidSteps ) {
+			this.setState( { loadingScreenStartTime: undefined } );
+		}
+	};
+
+	submitQueryDependencies = () => {
+		if ( isEmpty( this.props.initialContext && this.props.initialContext.query ) ) {
+			return;
+		}
+
+		const queryObject = this.props.initialContext.query;
+		const flowSteps = flows.getFlow( this.props.flowName ).steps;
+
+		// `vertical` query parameter
+		const vertical = queryObject.vertical;
+		if ( 'undefined' !== typeof vertical && -1 === flowSteps.indexOf( 'survey' ) ) {
+			debug( 'From query string: vertical = %s', vertical );
+			this.props.setSurvey( {
+				vertical,
+				otherText: '',
+			} );
+			SignupActions.submitSignupStep( { stepName: 'survey' }, [], {
+				surveySiteType: 'blog',
+				surveyQuestion: vertical,
+			} );
+		}
+	};
+
 	checkForCartItems = signupDependencies => {
 		const dependenciesContainCartItem = dependencies => {
 			return (
@@ -289,33 +317,6 @@ class Signup extends React.Component {
 			} );
 		}
 	};
-
-	componentDidMount() {
-		debug( 'Signup component mounted' );
-
-		SignupProgressStore.on( 'change', this.loadProgressFromStore );
-		this.props.loadTrackingTool( 'HotJar' );
-
-		const urlPath = location.href;
-		const parsedUrl = url.parse( urlPath, true );
-		const affiliateId = parsedUrl.query.aff;
-		const campaignId = parsedUrl.query.cid;
-
-		if ( affiliateId && ! isNaN( affiliateId ) ) {
-			this.props.affiliateReferral( { affiliateId, campaignId, urlPath } );
-			// Record the referral in Tracks
-			analytics.tracks.recordEvent( 'calypso_refer_visit', {
-				flow: this.props.flowName,
-				// The current page without any query params
-				page: parsedUrl.host + parsedUrl.pathname,
-			} );
-		}
-	}
-
-	componentWillUnmount() {
-		debug( 'Signup component unmounted' );
-		SignupProgressStore.off( 'change', this.loadProgressFromStore );
-	}
 
 	loginRedirectTo = path => {
 		let redirectTo;

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -94,12 +94,6 @@ class Signup extends React.Component {
 	}
 
 	componentWillMount() {
-		analytics.tracks.recordEvent( 'calypso_signup_start', {
-			flow: this.props.flowName,
-			ref: this.props.refParameter,
-		} );
-		recordSignupStart();
-
 		// Signup updates the cart through `SignupCart`. To prevent
 		// synchronization issues and unnecessary polling, the cart is disabled
 		// here.
@@ -186,10 +180,26 @@ class Signup extends React.Component {
 
 	componentDidMount() {
 		debug( 'Signup component mounted' );
-
+		this.recordSignupStart();
 		SignupProgressStore.on( 'change', this.loadProgressFromStore );
-		this.props.loadTrackingTool( 'HotJar' );
+	}
 
+	componentWillUnmount() {
+		debug( 'Signup component unmounted' );
+		SignupProgressStore.off( 'change', this.loadProgressFromStore );
+	}
+
+	recordSignupStart() {
+		analytics.tracks.recordEvent( 'calypso_signup_start', {
+			flow: this.props.flowName,
+			ref: this.props.refParameter,
+		} );
+		this.recordReferralVisit();
+		this.props.loadTrackingTool( 'HotJar' );
+		recordSignupStart();
+	}
+
+	recordReferralVisit() {
 		const urlPath = location.href;
 		const parsedUrl = url.parse( urlPath, true );
 		const affiliateId = parsedUrl.query.aff;
@@ -201,14 +211,9 @@ class Signup extends React.Component {
 			analytics.tracks.recordEvent( 'calypso_refer_visit', {
 				flow: this.props.flowName,
 				// The current page without any query params
-				page: parsedUrl.host + parsedUrl.pathname,
+				page: `${ parsedUrl.host }${ parsedUrl.pathname }`,
 			} );
 		}
-	}
-
-	componentWillUnmount() {
-		debug( 'Signup component unmounted' );
-		SignupProgressStore.off( 'change', this.loadProgressFromStore );
 	}
 
 	loadProgressFromStore = () => {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -436,30 +436,9 @@ class Signup extends React.Component {
 		return indexOf( flows.getFlow( this.props.flowName ).steps, this.props.stepName );
 	};
 
-	localeSuggestions = () => {
-		return 0 === this.positionInFlow() && ! this.props.isLoggedIn ? (
-			<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
-		) : null;
-	};
+	}
 
-	loginForm = () => {
-		return this.state.bearerToken ? (
-			<WpcomLoginForm
-				authorization={ 'Bearer ' + this.state.bearerToken }
-				log={ this.state.username }
-				redirectTo={ this.state.redirectTo }
-			/>
-		) : null;
-	};
-
-	pageTitle = () => {
-		const accountFlowName = 'account';
-		return this.props.flowName === accountFlowName
-			? translate( 'Create an account' )
-			: translate( 'Create a site' );
-	};
-
-	currentStep = () => {
+	renderCurrentStep() {
 		const userIsLoggedIn = this.props.isLoggedIn;
 		const domainItem = get( this.props, 'signupDependencies.domainItem', false );
 		const currentStepProgress = find( this.state.progress, { stepName: this.props.stepName } ),
@@ -475,10 +454,13 @@ class Signup extends React.Component {
 					isDomainMapping( domainItem ) ) &&
 					this.props.domainsWithPlansOnly )
 			);
+		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;
 
 		return (
 			<div className="signup__step" key={ stepKey }>
-				{ this.localeSuggestions() }
+				{ shouldRenderLocaleSuggestions && (
+					<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
+				) }
 				{ this.state.loadingScreenStartTime ? (
 					<SignupProcessingScreen
 						hasCartItems={ this.state.hasCartItems }
@@ -509,7 +491,7 @@ class Signup extends React.Component {
 				) }
 			</div>
 		);
-	};
+	}
 
 	render() {
 		if (
@@ -523,9 +505,14 @@ class Signup extends React.Component {
 		const flow = flows.getFlow( this.props.flowName );
 		const showProgressIndicator = 'pressable-nux' === this.props.flowName ? false : true;
 
+		const pageTitle =
+			this.props.flowName === 'account'
+				? translate( 'Create an account' )
+				: translate( 'Create a site' );
+
 		return (
 			<span>
-				<DocumentHead title={ this.pageTitle() } />
+				<DocumentHead title={ pageTitle } />
 				{ ! this.state.loadingScreenStartTime &&
 					showProgressIndicator && (
 						<FlowProgressIndicator
@@ -541,9 +528,15 @@ class Signup extends React.Component {
 					transitionEnterTimeout={ 400 }
 					transitionLeaveTimeout={ 400 }
 				>
-					{ this.currentStep() }
+					{ this.renderCurrentStep() }
 				</ReactCSSTransitionGroup>
-				{ this.loginForm() }
+				{ this.state.bearerToken && (
+					<WpcomLoginForm
+						authorization={ 'Bearer ' + this.state.bearerToken }
+						log={ this.state.username }
+						redirectTo={ this.state.redirectTo }
+					/>
+				) }
 			</span>
 		);
 	}

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -114,24 +114,7 @@ class Signup extends React.Component {
 			flowName: this.props.flowName,
 			providedDependencies,
 			reduxStore: this.context.store,
-			onComplete: function( dependencies, destination ) {
-				const timeSinceLoading = this.state.loadingScreenStartTime
-					? Date.now() - this.state.loadingScreenStartTime
-					: undefined;
-				const filteredDestination = getDestination(
-					destination,
-					dependencies,
-					this.props.flowName
-				);
-
-				if ( timeSinceLoading && timeSinceLoading < MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED ) {
-					return delay(
-						this.handleFlowComplete.bind( this, dependencies, filteredDestination ),
-						MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED - timeSinceLoading
-					);
-				}
-				return this.handleFlowComplete( dependencies, filteredDestination );
-			}.bind( this ),
+			onComplete: this.handleSignupFlowControllerCompletion,
 		} );
 
 		this.loadProgressFromStore();
@@ -188,6 +171,21 @@ class Signup extends React.Component {
 		debug( 'Signup component unmounted' );
 		SignupProgressStore.off( 'change', this.loadProgressFromStore );
 	}
+
+	handleSignupFlowControllerCompletion = ( dependencies, destination ) => {
+		const timeSinceLoading = this.state.loadingScreenStartTime
+			? Date.now() - this.state.loadingScreenStartTime
+			: undefined;
+		const filteredDestination = getDestination( destination, dependencies, this.props.flowName );
+
+		if ( timeSinceLoading && timeSinceLoading < MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED ) {
+			return delay(
+				this.handleFlowComplete.bind( this, dependencies, filteredDestination ),
+				MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED - timeSinceLoading
+			);
+		}
+		return this.handleFlowComplete( dependencies, filteredDestination );
+	};
 
 	recordSignupStart() {
 		analytics.tracks.recordEvent( 'calypso_signup_start', {


### PR DESCRIPTION
For the most part, this only moves around existing functions for readability and clarity. This is in preparation for my task for [reduxifying the signup flow](https://github.com/Automattic/wp-calypso/issues/6709).

A few instances where behavior has been tweaked:
1. Analytic events were moved from `componentWillMount` to `componentDidMount`. Note that componentWillMount is being [deprecated](https://reactjs.org/docs/react-component.html#unsafe_componentwillmount).
2. Redundant render helper functions were moved inside the main `render()` block.

To summarize, no new behavior has been intended. Any behavioral changes introduced with this PR should be considered a bug.

# Test Instructions
1. Audit the code.
2. Spin up this branch locally.
3. While logged out, go through user registration flow from `/`.
4. (For e2e testers) Try going through the registration flow for Jetpack and WooCommerce.