### PR TITLE
Activity Log: fix grammar issue in update status notices

### DIFF
--- a/client/my-sites/stats/activity-log-tasklist/index.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/index.jsx
@@ -200,7 +200,7 @@ class ActivityLogTasklist extends Component {
 		updateSingle( item );
 
 		showInfoNotice(
-			translate( 'Updating %(item)s in %(siteName)s.', {
+			translate( 'Updating %(item)s on %(siteName)s.', {
 				args: { item: item.name, siteName },
 			} ),
 			{
@@ -269,7 +269,7 @@ class ActivityLogTasklist extends Component {
 					break;
 				case 'completed':
 					showSuccessNotice(
-						translate( 'Successfully updated %(item)s in %(siteName)s.', noticeArgs ),
+						translate( 'Successfully updated %(item)s on %(siteName)s.', noticeArgs ),
 						{
 							id: `alitemupdate-${ slug }`,
 							duration: 3000,
@@ -417,7 +417,7 @@ const makeUpdatableList = ( itemList, siteId, state = null ) =>
 	} ) );
 
 /**
- * Start updating the theme in the specified site.
+ * Start updating the theme on the specified site.
  *
  * @param {number} siteId  Site Id.
  * @param {string} themeId Theme slug.


### PR DESCRIPTION
This fixes a grammar issue in the notices that are displayed when updating a plugin or a theme or when the update ends successfully.

<img width="618" alt="captura de pantalla 2018-06-07 a la s 17 49 17" src="https://user-images.githubusercontent.com/1041600/41125552-2c95d53e-6a7b-11e8-82c3-a12c4f15f5e0.png">
<img width="452" alt="captura de pantalla 2018-06-07 a la s 17 49 37" src="https://user-images.githubusercontent.com/1041600/41125553-2cbe3484-6a7b-11e8-8f68-a5d43d4c9a24.png">
