### PR TITLE
CancelPurchase: update "will be removed" text to highlight CTA

### DIFF
--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -127,14 +127,20 @@ class CancelPurchase extends React.Component {
 		const renewalDate = this.props.moment( renewDate ).format( 'LL' );
 
 		if ( isDomainRegistration( purchase ) ) {
-			return this.props.translate( 'Domain will be removed on %(renewalDate)s', {
-				args: { renewalDate },
-			} );
+			return this.props.translate(
+				'When you click to confirm, the domain will be removed on %(renewalDate)s',
+				{
+					args: { renewalDate },
+				}
+			);
 		}
 
-		return this.props.translate( 'Subscription will be removed on %(renewalDate)s', {
-			args: { renewalDate },
-		} );
+		return this.props.translate(
+			'When you click to confirm, the subscription will be removed on %(renewalDate)s',
+			{
+				args: { renewalDate },
+			}
+		);
 	};
 
 	render() {

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -128,7 +128,7 @@ class CancelPurchase extends React.Component {
 
 		if ( isDomainRegistration( purchase ) ) {
 			return this.props.translate(
-				'When you click to confirm, the domain will be removed on %(renewalDate)s',
+				'After you confirm this change, the domain will be removed on %(renewalDate)s',
 				{
 					args: { renewalDate },
 				}
@@ -136,7 +136,7 @@ class CancelPurchase extends React.Component {
 		}
 
 		return this.props.translate(
-			'When you click to confirm, the subscription will be removed on %(renewalDate)s',
+			'After you confirm this change, the subscription will be removed on %(renewalDate)s',
 			{
 				args: { renewalDate },
 			}


### PR DESCRIPTION
It might not be obvious from the text on the cancellation page that the
cancellation will not take place until the button is clicked. This
modifies the text to hopefully make it more clear.

Fixes #24884

(Ignore the "Invalid date" in the below screenshots; I forced the component to display for an invalid product which apparently has no date.)

Before:
![before](https://user-images.githubusercontent.com/2036909/41131699-d907eeec-6a8a-11e8-85f8-1eb34b447c57.png)

After:
![after](https://user-images.githubusercontent.com/2036909/41131705-de6ea34e-6a8a-11e8-9cd7-3a23f18cf7ef.png)

Testing Instructions:

I'm trying to figure out how to view this component. It appears to be shown on
the route '/me/purchases/:site/:purchaseId/cancel', but that just redirects me
to '/me/purchases/:site/:purchaseId'. That redirect happens because the `isDataValid()` function returns false for the purchases I've tried. I need to find a purchase which `isCancelable()` and `isRefundable()`. Suggestions welcome.