### PR TITLE
Add store tracking number copy to clipboard button

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -141,7 +141,9 @@ class LabelItem extends Component {
 				{ label.showDetails && (
 					<p className="shipping-label__item-tracking">
 						{ translate( 'Tracking #: {{trackingLink/}}', {
-							components: { trackingLink: <TrackingLink { ...label } /> },
+							components: {
+								trackingLink: <TrackingLink tracking={ label.tracking } carrierId={ label.carrierId } />
+							},
 						} ) }
 					</p>
 				) }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -159,6 +159,7 @@ LabelItem.propTypes = {
 	openRefundDialog: PropTypes.func.isRequired,
 	openReprintDialog: PropTypes.func.isRequired,
 	openDetailsDialog: PropTypes.func.isRequired,
+	translate: PropTypes.func.isRequired,
 };
 
 const mapDispatchToProps = dispatch => {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/1400

This PR adds a 'Copy to clipboard' button for tracking numbers in orders. Here's what it looks like:

<img width="979" alt="after-copy-to-clipboard-button" src="https://user-images.githubusercontent.com/11487924/41132960-1951df10-6a92-11e8-8bf9-da98b228141d.png">

The 'Label #1 printed' section looks a bit messy now. Does it need design clean up?

Here's what it looked like before the button:

<img width="970" alt="before-copy-to-clipboard-button" src="https://user-images.githubusercontent.com/11487924/41132962-1fa620f6-6a92-11e8-809e-ea219ad6c9f3.png">

Here's the button working:

![copy-to-clipboard-tracking-code](https://user-images.githubusercontent.com/11487924/41132966-25d5ee7a-6a92-11e8-838c-4f0a407e85f6.gif)

There's no real success indicator :(. **Suggestion:I** want to the button to say 'Copied!' after it was clicked, like in the edit post page:

![copy-to-clipboard-success](https://user-images.githubusercontent.com/11487924/41132979-40803e24-6a92-11e8-8900-6f2bb0b89bff.gif)

If this is cool with design, I'll add the success indicator to this PR, probably by adding it directly to the component `<ClipboardButton />` since a success indication should be a feature of that component, and folks using it shouldn't have to worry about that.

Questions / To dos
- [x] rebase (needed for the changes in #25393)
- [x] move 'Copied!' success indicator to `<ClipboardButton />`