### PR TITLE
Add affiliate campaign ID tracking to Calypso.

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -297,8 +297,9 @@ class Signup extends React.Component {
 		const urlPath = location.href;
 		const parsedUrl = url.parse( urlPath, true );
 		const affiliateId = parsedUrl.query.aff;
+		const campaignId = parsedUrl.query.cid;
 		if ( affiliateId && ! isNaN( affiliateId ) ) {
-			this.props.affiliateReferral( { urlPath, affiliateId } );
+			this.props.affiliateReferral( { urlPath, affiliateId, campaignId } );
 			// Record the referral in Tracks
 			analytics.tracks.recordEvent( 'calypso_refer_visit', {
 				flow: this.props.flowName,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -292,14 +292,17 @@ class Signup extends React.Component {
 
 	componentDidMount() {
 		debug( 'Signup component mounted' );
+
 		SignupProgressStore.on( 'change', this.loadProgressFromStore );
 		this.props.loadTrackingTool( 'HotJar' );
+
 		const urlPath = location.href;
 		const parsedUrl = url.parse( urlPath, true );
 		const affiliateId = parsedUrl.query.aff;
 		const campaignId = parsedUrl.query.cid;
+
 		if ( affiliateId && ! isNaN( affiliateId ) ) {
-			this.props.affiliateReferral( { urlPath, affiliateId, campaignId } );
+			this.props.affiliateReferral( { affiliateId, campaignId, urlPath } );
 			// Record the referral in Tracks
 			analytics.tracks.recordEvent( 'calypso_refer_visit', {
 				flow: this.props.flowName,

--- a/client/state/data-layer/third-party/refer/index.js
+++ b/client/state/data-layer/third-party/refer/index.js
@@ -18,7 +18,7 @@ const aDebug = debug( 'calypso:analytics:affiliate' );
 import { AFFILIATE_REFERRAL } from 'state/action-types';
 
 const trackAffiliatePageLoad = ( { dispatch }, action ) => {
-	const { affiliateId, urlPath } = action;
+	const { affiliateId, campaignId, urlPath } = action;
 
 	if ( ! affiliateId || isNaN( affiliateId ) ) {
 		return;
@@ -34,6 +34,7 @@ const trackAffiliatePageLoad = ( { dispatch }, action ) => {
 				headers: [ [ 'content-type', 'application/x-www-form-urlencoded; charset=UTF-8' ] ],
 				body: {
 					affiliate_id: affiliateId,
+					campaign_id: campaignId || '',
 					referrer: urlPath,
 				},
 				// Needed to check and set the 'wp-affiliate-tracker' cookie

--- a/client/state/refer/actions.js
+++ b/client/state/refer/actions.js
@@ -6,6 +6,6 @@
 
 import { AFFILIATE_REFERRAL } from 'state/action-types';
 
-export function affiliateReferral( { affiliateId, urlPath } ) {
-	return { type: AFFILIATE_REFERRAL, affiliateId, urlPath };
+export function affiliateReferral( { affiliateId, campaignId, urlPath } ) {
+	return { type: AFFILIATE_REFERRAL, affiliateId, campaignId, urlPath };
 }


### PR DESCRIPTION
Adds support for `&cid=[campaign ID]` to track affiliate campaigns.

## Testing Instructions

- Visit: https://calypso.live/start/?aff=123&cid=456&branch=add/affiliate-campaign-id-tracking
- Filter the Network tab in console by `refer.wordpress.com` and confirm the following network request includes `campaign_id: 456` (screenshots attached).
  <img width="580" alt="2018-06-07_21-31-54" src="https://user-images.githubusercontent.com/1563559/41140495-50e0d334-6a9a-11e8-93d0-eadb4474b93b.png">
  <img width="610" alt="2018-06-07_21-32-08" src="https://user-images.githubusercontent.com/1563559/41140496-510fad4e-6a9a-11e8-94a1-d50916ed4c28.png">

---

- Repeat the same test, but this time without `&cid=[campaign ID]`...
- Visit: https://calypso.live/start/?aff=123&branch=add/affiliate-campaign-id-tracking
- Confirm that `campaign_id` is empty.
  <img width="564" alt="2018-06-07_21-34-02" src="https://user-images.githubusercontent.com/1563559/41140544-8bc51eb0-6a9a-11e8-977e-0e8d236286c9.png">


---

Confirm there are no errors in the console.

