### PR TITLE
GDPR: tweak banner design and sizing

### DIFF
--- a/client/blocks/gdpr-banner/style.scss
+++ b/client/blocks/gdpr-banner/style.scss
@@ -3,7 +3,7 @@
 	bottom: 0;
 	width: 100%;
 	padding: 16px;
-	background-color: darken( $gray, 18% );
+	background-color: $gray-dark;
 	color: $white;
 	z-index: z-index( 'root', '.gdpr-banner' );
 
@@ -20,9 +20,12 @@
 		font-size: 16px;
 		padding: 16px 24px;
 	}
+
 	@include breakpoint( ">960px" ) {
 		font-size: 16px;
 		padding: 16px 32px;
+		max-width: 960px;
+		left: calc( 50% - 480px );
 	}
 
 	a {
@@ -69,9 +72,8 @@
 }
 
 .gdpr-banner__text-content {
-	font-size: 12px;
 	line-height: 1.4;
-	max-width: 800px;
+	max-width: 700px;
 	margin-right: auto;
 }
 

--- a/client/blocks/gdpr-banner/style.scss
+++ b/client/blocks/gdpr-banner/style.scss
@@ -2,14 +2,36 @@
 	position: fixed;
 	bottom: 0;
 	width: 100%;
-	margin-bottom: 0;
-	background-color: $blue-light;
-	color: $blue-dark;
+	padding: 16px;
+	background-color: darken( $gray, 18% );
+	color: $white;
 	z-index: z-index( 'root', '.gdpr-banner' );
 
 	animation-duration: 0.5s;
 	animation-name: gdpr-banner__slideup;
 	animation-timing-function: ease-in-out;
+
+	&.is-compact {
+		margin-bottom: 0;
+	}
+
+	@include breakpoint( ">660px" ) {
+		display: flex;
+		font-size: 16px;
+		padding: 16px 24px;
+	}
+	@include breakpoint( ">960px" ) {
+		font-size: 16px;
+		padding: 16px 32px;
+	}
+
+	a {
+		color: $white;
+		text-decoration: underline;
+		&:hover {
+			text-decoration: none;
+		}
+	}
 }
 
 @keyframes gdpr-banner__slideup {
@@ -49,16 +71,18 @@
 .gdpr-banner__text-content {
 	font-size: 12px;
 	line-height: 1.4;
-	max-width: 50em;
-	margin: 0 auto;
-	@include breakpoint( ">660px" ) {
-		font-size: 16px;
-	}
+	max-width: 800px;
+	margin-right: auto;
 }
 
 .gdpr-banner__buttons {
 	margin-top: 14px;
 	text-align: center;
+	@include breakpoint( ">660px" ) {
+		flex: 0 0 auto;
+		margin: 0 0 0 16px;
+		text-align: inherit;
+	}
 }
 
 .gdpr-banner__acknowledge-button {


### PR DESCRIPTION
This PR iterates on the GDPR banner design as proposed by @shaunandrews in p2-p9mQOq-Hz. 

This is what it looks like:

![gdpr-banner-tweaks](https://user-images.githubusercontent.com/23619/41160469-23002122-6b30-11e8-80b5-d74c2cb6fe01.gif)

To test:
- Verify that the banner design looks OK in different screen and window sizes on different devices and browsers. You can use the calypso.live link. 

**Note:** for testing, this PR contains a commit that modifies a few things so that the banner will always show. 