### PR TITLE
Store Services: Move shipping label activity log buttons into a menu

### DIFF
--- a/client/extensions/woocommerce/app/order/order-activity-log/event.js
+++ b/client/extensions/woocommerce/app/order/order-activity-log/event.js
@@ -66,8 +66,9 @@ class OrderEvent extends Component {
 				icon: 'time',
 				content: (
 					<div>
-						{ translate( 'Label #%(labelNum)d refund requested (%(amount)s)', {
+						{ translate( '%(service)s label (#%(labelNum)d) refund requested (%(amount)s)', {
 							args: {
+								service: event.serviceName,
 								labelNum: event.labelIndex + 1,
 								amount: formatCurrency( event.amount, event.currency ),
 							},
@@ -83,8 +84,9 @@ class OrderEvent extends Component {
 				icon: 'refund',
 				content: (
 					<div>
-						{ translate( 'Label #%(labelNum)d refunded (%(amount)s)', {
+						{ translate( '%(service)s label (#%(labelNum)d) refunded (%(amount)s)', {
 							args: {
+								service: event.serviceName,
 								labelNum: event.labelIndex + 1,
 								amount: formatCurrency( event.amount, event.currency ),
 							},
@@ -100,7 +102,8 @@ class OrderEvent extends Component {
 				icon: 'cross-small',
 				content: (
 					<div>
-						{ translate( 'Label #%(labelNum)d refund rejected', {
+						{ translate( '%(service)s label (#%(labelNum)d) refund rejected', {
+							service: event.serviceName,
 							args: { labelNum: event.labelIndex + 1 },
 						} ) }
 					</div>

--- a/client/extensions/woocommerce/state/sites/orders/activity-log/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/activity-log/selectors.js
@@ -147,6 +147,7 @@ export const getActivityLogEvents = ( state, orderId, siteId = getSelectedSiteId
 							key: label.label_id,
 							type: EVENT_TYPES.LABEL_REFUND_COMPLETED,
 							timestamp: label.refund.refund_date,
+							serviceName: label.service_name,
 							labelIndex,
 							amount: parseFloat( label.refund.amount ) || label.refundable_amount,
 							currency: label.currency,
@@ -157,6 +158,7 @@ export const getActivityLogEvents = ( state, orderId, siteId = getSelectedSiteId
 							key: label.label_id,
 							type: EVENT_TYPES.LABEL_REFUND_REJECTED,
 							timestamp: label.refund.refund_date,
+							serviceName: label.service_name,
 							labelIndex,
 						} );
 						break;
@@ -166,6 +168,7 @@ export const getActivityLogEvents = ( state, orderId, siteId = getSelectedSiteId
 							key: label.label_id,
 							type: EVENT_TYPES.LABEL_REFUND_REQUESTED,
 							timestamp: label.refund.request_date,
+							serviceName: label.service_name,
 							labelIndex,
 							amount: parseFloat( label.refund.amount ) || label.refundable_amount,
 							currency: label.currency,

--- a/client/extensions/woocommerce/state/sites/orders/activity-log/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/activity-log/test/selectors.js
@@ -397,6 +397,7 @@ describe( 'selectors', () => {
 					key: 4,
 					type: 'LABEL_REFUND_REJECTED',
 					timestamp: 4200000,
+					serviceName: 'Xpress',
 					labelIndex: 3,
 				},
 				{
@@ -424,6 +425,7 @@ describe( 'selectors', () => {
 					key: 3,
 					type: 'LABEL_REFUND_COMPLETED',
 					timestamp: 3200000,
+					serviceName: 'First Class',
 					labelIndex: 2,
 					amount: 6.95,
 					currency: 'USD',
@@ -453,6 +455,7 @@ describe( 'selectors', () => {
 					key: 2,
 					type: 'LABEL_REFUND_REQUESTED',
 					timestamp: 2100000,
+					serviceName: 'Xpress',
 					labelIndex: 1,
 					amount: 7,
 					currency: 'CAD',

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -98,17 +98,17 @@ class LabelItem extends Component {
 							labelIndex: label.labelIndex + 1,
 						},
 					} ) }
-
-					<DetailsDialog siteId={ siteId } orderId={ orderId } { ...label } />
-					<RefundDialog siteId={ siteId } orderId={ orderId } { ...label } />
-					<ReprintDialog siteId={ siteId } orderId={ orderId } { ...label } />
-
 					{ label.showDetails && (
-						<EllipsisMenu position="bottom left">
-							{ this.renderLabelDetails( label ) }
-							{ this.renderRefund( label ) }
-							{ this.renderReprint( label ) }
-						</EllipsisMenu>
+						<span>
+							<EllipsisMenu position="bottom left">
+								{ this.renderLabelDetails( label ) }
+								{ this.renderRefund( label ) }
+								{ this.renderReprint( label ) }
+							</EllipsisMenu>
+							<DetailsDialog siteId={ siteId } orderId={ orderId } { ...label } />
+							<RefundDialog siteId={ siteId } orderId={ orderId } { ...label } />
+							<ReprintDialog siteId={ siteId } orderId={ orderId } { ...label } />
+						</span>
 					) }
 				</p>
 				{ label.showDetails && (

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -95,8 +95,9 @@ class LabelItem extends Component {
 		return (
 			<div key={ label.labelId } className="shipping-label__item">
 				<p className="shipping-label__item-detail">
-					{ translate( 'Label #%(labelIndex)s printed', {
+					{ translate( '%(service)s label (#%(labelIndex)d) printed', {
 						args: {
+							service: label.serviceName,
 							labelIndex: label.labelIndex + 1,
 						},
 					} ) }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -12,7 +12,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
+import EllipsisMenu from 'components/ellipsis-menu';
+import PopoverMenuItem from 'components/popover/menu-item';
 import RefundDialog from './label-refund-modal';
 import ReprintDialog from './label-reprint-modal';
 import DetailsDialog from './label-details-modal';
@@ -43,12 +44,9 @@ class LabelItem extends Component {
 		};
 
 		return (
-			<span>
-				<RefundDialog siteId={ siteId } orderId={ orderId } { ...label } />
-				<Button onClick={ openDialog } borderless className="shipping-label__button">
-					{ translate( 'Request refund' ) }
-				</Button>
-			</span>
+			<PopoverMenuItem onClick={ openDialog } icon="refund">
+				{ translate( 'Request refund' ) }
+			</PopoverMenuItem>
 		);
 	};
 
@@ -70,12 +68,9 @@ class LabelItem extends Component {
 		};
 
 		return (
-			<span>
-				<ReprintDialog siteId={ siteId } orderId={ orderId } { ...label } />
-				<Button onClick={ openDialog } borderless className="shipping-label__button">
-					{ translate( 'Reprint' ) }
-				</Button>
-			</span>
+			<PopoverMenuItem onClick={ openDialog } icon="print">
+				{ translate( 'Reprint' ) }
+			</PopoverMenuItem>
 		);
 	};
 
@@ -88,41 +83,41 @@ class LabelItem extends Component {
 		};
 
 		return (
-			<span>
-				<DetailsDialog siteId={ siteId } orderId={ orderId } { ...label } />
-				<Button onClick={ openDialog } borderless className="shipping-label__button">
-					{ translate( 'View details' ) }
-				</Button>
-			</span>
+			<PopoverMenuItem onClick={ openDialog } icon="info-outline">
+				{ translate( 'View details' ) }
+			</PopoverMenuItem>
 		);
 	};
 
 	render() {
-		const { label, translate } = this.props;
+		const { siteId, orderId, label, translate } = this.props;
 
 		return (
 			<div key={ label.labelId } className="shipping-label__item">
 				<p className="shipping-label__item-detail">
-					<span>
-						{ translate( 'Label #%(labelIndex)s printed', {
-							args: {
-								labelIndex: label.labelIndex + 1,
-							},
-						} ) }
-					</span>
-					{ label.showDetails && this.renderLabelDetails( label ) }
+					{ translate( 'Label #%(labelIndex)s printed', {
+						args: {
+							labelIndex: label.labelIndex + 1,
+						},
+					} ) }
+
+					<DetailsDialog siteId={ siteId } orderId={ orderId } { ...label } />
+					<RefundDialog siteId={ siteId } orderId={ orderId } { ...label } />
+					<ReprintDialog siteId={ siteId } orderId={ orderId } { ...label } />
+
+					{ label.showDetails && (
+						<EllipsisMenu position="bottom left">
+							{ this.renderLabelDetails( label ) }
+							{ this.renderRefund( label ) }
+							{ this.renderReprint( label ) }
+						</EllipsisMenu>
+					) }
 				</p>
 				{ label.showDetails && (
 					<p className="shipping-label__item-tracking">
 						{ translate( 'Tracking #: {{trackingLink/}}', {
 							components: { trackingLink: <TrackingLink { ...label } /> },
 						} ) }
-					</p>
-				) }
-				{ label.showDetails && (
-					<p className="shipping-label__item-actions">
-						{ this.renderRefund( label ) }
-						{ this.renderReprint( label ) }
 					</p>
 				) }
 			</div>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -38,8 +38,7 @@ class LabelItem extends Component {
 			return null;
 		}
 
-		const openDialog = e => {
-			e.preventDefault();
+		const openDialog = () => {
 			this.props.openRefundDialog( orderId, siteId, label.labelId );
 		};
 
@@ -62,8 +61,7 @@ class LabelItem extends Component {
 
 		const { orderId, siteId, translate } = this.props;
 
-		const openDialog = e => {
-			e.preventDefault();
+		const openDialog = () => {
 			this.props.openReprintDialog( orderId, siteId, label.labelId );
 		};
 
@@ -77,8 +75,7 @@ class LabelItem extends Component {
 	renderLabelDetails = label => {
 		const { orderId, siteId, translate } = this.props;
 
-		const openDialog = e => {
-			e.preventDefault();
+		const openDialog = () => {
 			this.props.openDetailsDialog( orderId, siteId, label.labelId );
 		};
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
@@ -24,8 +24,8 @@
 		margin-top: 16px;
 	}
 
-	.shipping-label__button {
-		color: $blue-wordpress;
+	.ellipsis-menu__toggle {
+		padding: 0;
 	}
 
 	.shipping-label__item-detail, .shipping-label__item-actions {


### PR DESCRIPTION
a) Moves shipping label item buttons into an ellipsis menu, and b) pulls the service name into the event text.

Test by purchasing a shipping label for a Store order with a test card in sandbox mode.

Before:

<img width="570" src="https://user-images.githubusercontent.com/1867547/41138957-b5d6c8e4-6ab2-11e8-8120-071a32f1889a.png">

After:

<img width="570" src="https://user-images.githubusercontent.com/1867547/41138722-3c58c98c-6ab1-11e8-8f67-b288cd4116d1.gif">

Concerns:
- Moved rendering of `Dialog`s outside of their respective methods since the having them inside the `<EllipsisMenu>` was interfering with the event handling. Is there another way to prevent the dialog going away when clicking it? Otherwise, is it worth using a portal to keep it where it was in the method?
- Discussion of the need for this sort of design change in https://github.com/Automattic/wp-calypso/pull/25388 may affect this PR