### PR TITLE
Fix eslint errors in client/components/clipboard-button

### DIFF
--- a/client/components/forms/clipboard-button/index.jsx
+++ b/client/components/forms/clipboard-button/index.jsx
@@ -32,8 +32,10 @@ class ClipboardButton extends React.Component {
 		onCopy: noop,
 	};
 
+	buttonReference = React.createRef();
+
 	componentDidMount() {
-		const button = ReactDom.findDOMNode( this.refs.button );
+		const button = ReactDom.findDOMNode( this.buttonReference.current );
 		this.clipboard = new Clipboard( button, {
 			text: () => this.props.text,
 		} );
@@ -58,7 +60,7 @@ class ClipboardButton extends React.Component {
 
 		return (
 			<Button
-				ref="button"
+				ref={ this.buttonReference }
 				{ ...omit( this.props, Object.keys( this.constructor.propTypes ) ) }
 				className={ classes }
 			/>


### PR DESCRIPTION
Part of #24504 

No functional changes are expected to be introduced by this PR -- just eslint cleanup.

To test:
- Use the `ClipboardButton` in the permalink popover on both new and existing posts and verify that no regressions have been introduced
- Use the `ClipboardButton` in `/devdocs/design/clipboard-buttons` and verify that no regressions have been introduced

<img width="614" alt="screencapture at thu jun 7 10 36 05 edt 2018" src="https://user-images.githubusercontent.com/2098816/41107637-be216b8e-6a40-11e8-8234-18a7ca65a78d.png">