### PR TITLE
Store: Better handling of shipment tracking in order email

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/lib/initialize-labels-state/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/initialize-labels-state/index.js
@@ -50,8 +50,6 @@ export default data => {
 		labels: labelsData || [],
 		paperSize,
 		storeOptions,
-		fulfillOrder: true,
-		emailDetails: true,
 		form: {
 			orderId: formData.order_id,
 			origin: {

--- a/client/extensions/woocommerce/woocommerce-services/state/label-settings/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/label-settings/selectors.js
@@ -114,3 +114,13 @@ export const getMasterUserInfo = ( state, siteId = getSelectedSiteId( state ) ) 
 		masterUserEmail: meta && meta.master_user_email,
 	};
 };
+
+export const getMarkOrdersComplete = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const data = getLabelSettingsFormData( state, siteId );
+	return data && data.mark_orders_complete;
+};
+
+export const getEmailTrackingInfo = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const data = getLabelSettingsFormData( state, siteId );
+	return data && data.email_tracking_info;
+};

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -14,6 +14,8 @@ import { hasNonEmptyLeaves } from 'woocommerce/woocommerce-services/lib/utils/tr
 import {
 	areSettingsLoaded,
 	areSettingsErrored,
+	getMarkOrdersComplete,
+	getEmailTrackingInfo,
 } from 'woocommerce/woocommerce-services/state/label-settings/selectors';
 import {
 	isLoaded as arePackagesLoaded,
@@ -55,12 +57,12 @@ export const getLabels = ( state, orderId, siteId = getSelectedSiteId( state ) )
 
 export const shouldFulfillOrder = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
 	const shippingLabel = getShippingLabel( state, orderId, siteId );
-	return shippingLabel && shippingLabel.fulfillOrder;
+	return get( shippingLabel, 'fulfillOrder', getMarkOrdersComplete( state, siteId ) );
 };
 
 export const shouldEmailDetails = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
 	const shippingLabel = getShippingLabel( state, orderId, siteId );
-	return shippingLabel && shippingLabel.emailDetails;
+	return get( shippingLabel, 'emailDetails', getEmailTrackingInfo( state, siteId ) );
 };
 
 export const getSelectedPaymentMethod = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -33,6 +33,8 @@ import {
 	areSettingsFetching,
 	areSettingsLoaded,
 	getEmailReceipts,
+	getMarkOrdersComplete,
+	getEmailTrackingInfo,
 	getLabelSettingsStoreOptions,
 	getMasterUserInfo,
 	getPaperSize,
@@ -324,6 +326,45 @@ class ShippingLabels extends Component {
 		);
 	};
 
+	renderFulfillmentSection = () => {
+		const { translate, canEditSettings, markOrdersComplete, emailTrackingInfo } = this.props;
+
+		const onMarkOrdersCompleteChange = () =>
+			this.props.setValue( 'mark_orders_complete', ! markOrdersComplete );
+		const onEmailTrackingInfoChange = () =>
+			this.props.setValue( 'email_tracking_info', ! emailTrackingInfo );
+
+		return (
+			<FormFieldSet>
+				<FormLabel className="label-settings__cards-label">
+					{ translate( 'Order Fulfillment' ) }
+				</FormLabel>
+				<FormLabel>
+					<FormCheckbox
+						checked={ markOrdersComplete }
+						onChange={ onMarkOrdersCompleteChange }
+						disabled={ ! canEditSettings }
+					/>
+					<span className="label-settings__credit-card-description">
+						{ translate( 'Mark orders completed when purchasing shipping labels' ) }
+					</span>
+				</FormLabel>
+				<FormLabel>
+					<FormCheckbox
+						checked={ emailTrackingInfo }
+						onChange={ onEmailTrackingInfoChange }
+						disabled={ ! canEditSettings }
+					/>
+					<span className="label-settings__credit-card-description">
+						{ translate(
+							'Include tracking information in Completed Order email sent to customer'
+						) }
+					</span>
+				</FormLabel>
+			</FormFieldSet>
+		);
+	};
+
 	renderContent = () => {
 		const { canEditSettings, isLoading, paperSize, storeOptions, translate } = this.props;
 
@@ -358,6 +399,7 @@ class ShippingLabels extends Component {
 					{ this.renderPaymentsSection() }
 				</FormFieldSet>
 				{ this.renderEmailReceiptsSection() }
+				{ this.renderFulfillmentSection() }
 			</div>
 		);
 	};
@@ -387,6 +429,8 @@ export default connect(
 			canEditSettings:
 				userCanManagePayments( state, siteId ) || userCanEditSettings( state, siteId ),
 			emailReceipts: getEmailReceipts( state, siteId ),
+			markOrdersComplete: getMarkOrdersComplete( state, siteId ),
+			emailTrackingInfo: getEmailTrackingInfo( state, siteId ),
 			...getMasterUserInfo( state, siteId ),
 		};
 	},

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/sidebar.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/sidebar.js
@@ -48,14 +48,20 @@ const Sidebar = props => {
 				updateValue={ onPaperSizeChange }
 				error={ errors.paperSize }
 			/>
-			<FormLabel className="label-purchase-modal__option-email-customer">
-				<FormCheckbox checked={ emailDetails } onChange={ onEmailDetailsChange } />
-				<span>{ translate( 'Email shipment details to the customer' ) }</span>
-			</FormLabel>
 			<FormLabel className="label-purchase-modal__option-mark-order-fulfilled">
 				<FormCheckbox checked={ fulfillOrder } onChange={ onFulfillOrderChange } />
 				<span>{ translate( 'Mark the order as fulfilled' ) }</span>
 			</FormLabel>
+			{ fulfillOrder && (
+				<FormLabel className="label-purchase-modal__option-email-customer">
+					<FormCheckbox
+						checked={ emailDetails }
+						onChange={ onEmailDetailsChange }
+						disabled={ ! fulfillOrder }
+					/>
+					<span>{ translate( 'Email shipment details to the customer' ) }</span>
+				</FormLabel>
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
Addresses https://github.com/Automattic/woocommerce-services/issues/1274.

This PR adds two store-wide settings for order fulfillment:

![screen shot 2018-06-08 at 3 55 50 pm](https://user-images.githubusercontent.com/63922/41184147-948c7cfe-6b3b-11e8-9eb7-3080d8fb4b14.png)

These settings are used to default the label print options:

![screen shot 2018-06-08 at 4 35 09 pm](https://user-images.githubusercontent.com/63922/41184153-a2f3a98e-6b3b-11e8-81a1-222e17f5cb5d.png)

**This PR also removes the customer note mechanism for sending tracking numbers.** Tracking numbers will be included in "Complete order" emails if the checkbox is ticked.

Testing should be done on https://github.com/Automattic/woocommerce-services/pull/1437.