### PR TITLE
Check for malformed success query string.

### DIFF
--- a/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
@@ -48,6 +48,10 @@ class DomainConnectMapping extends React.Component {
 		const queryObject = parse( window.location.search.replace( '?', '' ) );
 		const status = get( queryObject, 'status', null );
 		const redirectUriStatusString = this.getRedirectUriStatusString();
+
+		// Some domain providers return the status string as a key rather than the value of
+		// the `status` variable in the query string, so we need to check for both.
+		// ex. (...?status=example-redirect-status-string or ...?example-redirect-status-string)
 		return status === redirectUriStatusString || redirectUriStatusString in queryObject;
 	};
 

--- a/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
@@ -47,7 +47,8 @@ class DomainConnectMapping extends React.Component {
 	isDomainConnectComplete = () => {
 		const queryObject = parse( window.location.search.replace( '?', '' ) );
 		const status = get( queryObject, 'status', null );
-		return status === this.getRedirectUriStatusString();
+		const redirectUriStatusString = this.getRedirectUriStatusString();
+		return status === redirectUriStatusString || redirectUriStatusString in queryObject;
 	};
 
 	renderErrorNotice = () => {


### PR DESCRIPTION
Some domain providers just send back the value passed as the status string instead of assigning it to the `status` variable in the query string. This PR fixes that and will show the success message for either the correct or the malformed query string.

To test follow the instructions in D14291-code and make sure that the success message is shown for URLs similar to both of the following:

http://calypso.localhost:3000/domains/manage/mydomain.com/domain-connect-mapping/mysite.com?status=domain-connect-complete-mydomain-com

http://calypso.localhost:3000/domains/manage/mydomain.com/domain-connect-mapping/mysite.com?domain-connect-complete-mydomain-com