### PR TITLE
Changed import guide link to international (English) subdomain

### DIFF
--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -151,20 +151,10 @@ class ImportingPane extends React.PureComponent {
 
 		if ( pageCount || postCount ) {
 			return this.props.translate(
-				'All done! Check out {{a}}Posts{{/a}}, ' +
-					'{{b}}Pages{{/b}}, and ' +
-					'{{c}}Media{{/c}} ' +
-					'to see your imported content.',
-				/*{
+				'All done! Check out {{a}}%(articles)s{{/a}} ' + 'to see your imported content.',
+				{
 					components: { a: pageCount ? pageLink : postLink },
 					args: { articles: pageCount ? pageText : postText },
-				}*/
-				{
-					components: {
-						a: postLink,
-						b: pageLink,
-						c: mediaLink,
-					},
 				}
 			);
 		}

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -127,19 +127,23 @@ class ImportingPane extends React.PureComponent {
 			pageLink = <a href={ '/pages/' + slug } />,
 			pageText = translate( 'Pages', { context: 'noun' } ),
 			postLink = <a href={ '/posts/' + slug } />,
-			postText = translate( 'Posts', { context: 'noun' } );
+			postText = translate( 'Posts', { context: 'noun' } ),
+			mediaLink = <a href={ '/media/' + slug } />,
+			mediaText = translate( 'Media', { context: 'noun' } );
 
 		const pageCount = page.total;
 		const postCount = post.total;
 
 		if ( pageCount && postCount ) {
 			return this.props.translate(
-				'All done! Check out {{a}}Posts{{/a}} and ' +
-					'{{b}}Pages{{/b}} to see your imported content.',
+				'All done! Check out {{a}}Posts{{/a}}, ' +
+					'{{b}}Pages{{/b}} ' +
+					'and {{c}}Media{[/c}} to see your imported content.',
 				{
 					components: {
 						a: postLink,
 						b: pageLink,
+						c: mediaLink,
 					},
 				}
 			);

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -137,7 +137,7 @@ class ImportingPane extends React.PureComponent {
 		if ( pageCount && postCount ) {
 			return this.props.translate(
 				'All done! Check out {{a}}Posts{{/a}}, ' +
-					'{{b}}Pages{{/b}} ' +
+					'{{b}}Pages{{/b}}, ' +
 					'and {{c}}Media{{/c}} to see your imported content.',
 				{
 					components: {
@@ -151,10 +151,20 @@ class ImportingPane extends React.PureComponent {
 
 		if ( pageCount || postCount ) {
 			return this.props.translate(
-				'All done! Check out {{a}}%(articles)s{{/a}} ' + 'to see your imported content.',
-				{
+				'All done! Check out {{a}}Posts{{/a}}, ' +
+					'{{b}}Pages{{/b}}, and ' +
+					'{{c}}Media{{/c}} ' +
+					'to see your imported content.',
+				/*{
 					components: { a: pageCount ? pageLink : postLink },
 					args: { articles: pageCount ? pageText : postText },
+				}*/
+				{
+					components: {
+						a: postLink,
+						b: pageLink,
+						c: mediaLink,
+					},
 				}
 			);
 		}

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -138,7 +138,7 @@ class ImportingPane extends React.PureComponent {
 			return this.props.translate(
 				'All done! Check out {{a}}Posts{{/a}}, ' +
 					'{{b}}Pages{{/b}} ' +
-					'and {{c}}Media{[/c}} to see your imported content.',
+					'and {{c}}Media{{/c}} to see your imported content.',
 				{
 					components: {
 						a: postLink,

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -105,7 +105,7 @@ class SiteSettingsImport extends Component {
 			{
 				args: { title },
 				components: {
-					a: <a href="https://en.support.wordpress.com/import/" />,
+					a: <a href="https://support.wordpress.com/import/" />,
 					strong: <strong />,
 				},
 			}

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -105,7 +105,7 @@ class SiteSettingsImport extends Component {
 			{
 				args: { title },
 				components: {
-					a: <a href="https://support.wordpress.com/import/" />,
+					a: <a href="https://en.support.wordpress.com/import/" />,
 					strong: <strong />,
 				},
 			}


### PR DESCRIPTION
Changed the import guide link on https://wordpress.com/settings/import, to make it consistent with the export guide link shown (shown when one clicks on the WordPress importer module)