### PR TITLE
Rewind: Do not show help and update actions on activity log in clone flow

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -195,6 +195,10 @@ class ActivityLogItem extends Component {
 			pluginsToUpdate,
 		} = this.props;
 
+		if ( enableClone && activityIsRewindable ) {
+			return this.renderCloneAction();
+		}
+
 		switch ( activityName ) {
 			case 'plugin__update_available':
 				// If every plugin is either still updating or finished successfully, hide the button.
@@ -229,10 +233,6 @@ class ActivityLogItem extends Component {
 
 		if ( ! hideRestore && activityIsRewindable ) {
 			return this.renderRewindAction();
-		}
-
-		if ( enableClone && activityIsRewindable ) {
-			return this.renderCloneAction();
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/25398

Currently, help actions are displayed on the activity log in step 4 of the clone flow. This PR addresses that by doing the clone action method before any of the other actions, and returning even when the item is not rewindable.

**Testing**

- Check the regular activity log, make sure that help, update, and rewind buttons all still appear where they should.
- Check the clone site flow. Ensure that help and update buttons do not display, and only clone buttons are visible.