### PR TITLE
Add `site_type` property to pageview Tracks events

### DIFF
--- a/client/lib/analytics/page-view-tracker/index.jsx
+++ b/client/lib/analytics/page-view-tracker/index.jsx
@@ -7,14 +7,18 @@
 import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { flowRight, get, isNumber, noop } from 'lodash';
+import { get, isNumber, noop } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { getSiteFragment } from 'lib/route';
-import { recordPageView } from 'state/analytics/actions';
+import {
+	recordPageViewWithClientId as recordPageView,
+	enhanceWithSiteType,
+} from 'state/analytics/actions';
+import { withEnhancers } from 'state/utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 
@@ -106,8 +110,8 @@ const mapStateToProps = state => {
 	};
 };
 
-const mapDispatchToProps = dispatch => ( {
-	recorder: flowRight( dispatch, recordPageView ),
-} );
+const mapDispatchToProps = {
+	recorder: withEnhancers( recordPageView, [ enhanceWithSiteType ] ),
+};
 
 export default connect( mapStateToProps, mapDispatchToProps )( PageViewTracker );

--- a/client/login/magic-login/emailed-login-link-expired.jsx
+++ b/client/login/magic-login/emailed-login-link-expired.jsx
@@ -16,7 +16,11 @@ import { addQueryArgs } from 'lib/route';
 import EmptyContent from 'components/empty-content';
 import RedirectWhenLoggedIn from 'components/redirect-when-logged-in';
 import { hideMagicLoginRequestForm } from 'state/login/magic-login/actions';
-import { recordPageViewWithClientId as recordPageView } from 'state/analytics/actions';
+import {
+	recordPageViewWithClientId as recordPageView,
+	enhanceWithSiteType,
+} from 'state/analytics/actions';
+import { withEnhancers } from 'state/utils';
 
 const nativeLoginUrl = login( { isNative: true, twoFactorAuthType: 'link' } );
 
@@ -76,7 +80,7 @@ class EmailedLoginLinkExpired extends React.Component {
 
 const mapDispatchToProps = {
 	hideMagicLoginRequestForm,
-	recordPageView,
+	recordPageView: withEnhancers( recordPageView, [ enhanceWithSiteType ] ),
 };
 
 export default connect( null, mapDispatchToProps )( localize( EmailedLoginLinkExpired ) );

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -18,7 +18,11 @@ import Card from 'components/card';
 import RedirectWhenLoggedIn from 'components/redirect-when-logged-in';
 import { hideMagicLoginRequestForm } from 'state/login/magic-login/actions';
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
-import { recordPageViewWithClientId as recordPageView } from 'state/analytics/actions';
+import {
+	recordPageViewWithClientId as recordPageView,
+	enhanceWithSiteType,
+} from 'state/analytics/actions';
+import { withEnhancers } from 'state/utils';
 import Gridicon from 'gridicons';
 
 class EmailedLoginLinkSuccessfully extends React.Component {
@@ -92,7 +96,7 @@ const mapState = state => ( {
 
 const mapDispatch = {
 	hideMagicLoginRequestForm,
-	recordPageView,
+	recordPageView: withEnhancers( recordPageView, [ enhanceWithSiteType ] ),
 };
 
 export default connect( mapState, mapDispatch )( localize( EmailedLoginLinkSuccessfully ) );

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -23,7 +23,9 @@ import LocaleSuggestions from 'components/locale-suggestions';
 import {
 	recordTracksEventWithClientId as recordTracksEvent,
 	recordPageViewWithClientId as recordPageView,
+	enhanceWithSiteType,
 } from 'state/analytics/actions';
+import { withEnhancers } from 'state/utils';
 import Main from 'components/main';
 import RequestLoginEmailForm from './request-login-email-form';
 import GlobalNotices from 'components/global-notices';
@@ -110,8 +112,8 @@ const mapState = state => ( {
 
 const mapDispatch = {
 	hideMagicLoginRequestForm,
-	recordPageView,
-	recordTracksEvent,
+	recordPageView: withEnhancers( recordPageView, [ enhanceWithSiteType ] ),
+	recordTracksEvent: withEnhancers( recordTracksEvent, [ enhanceWithSiteType ] ),
 };
 
 export default connect( mapState, mapDispatch )( localize( MagicLogin ) );

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -23,7 +23,11 @@ import PrivateSite from './private-site';
 import { addLocaleToWpcomUrl } from 'lib/i18n-utils';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
-import { recordPageViewWithClientId as recordPageView } from 'state/analytics/actions';
+import {
+	recordPageViewWithClientId as recordPageView,
+	enhanceWithSiteType,
+} from 'state/analytics/actions';
+import { withEnhancers } from 'state/utils';
 
 export class Login extends React.Component {
 	static propTypes = {
@@ -203,6 +207,6 @@ export default connect(
 		oauth2Client: getCurrentOAuth2Client( state ),
 	} ),
 	{
-		recordPageView,
+		recordPageView: withEnhancers( recordPageView, [ enhanceWithSiteType ] ),
 	}
 )( localize( Login ) );

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -959,10 +959,5 @@ describe( 'utils', () => {
 
 			expect( providedGetState ).toEqual( getState );
 		} );
-
-		it( 'should warn about supporting only plain object actions', () => {
-			const actionCreator = () => () => ( {} ); // returns thunk
-			expect( withEnhancers( actionCreator, [] )() ).toThrow();
-		} );
 	} );
 } );

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -959,5 +959,25 @@ describe( 'utils', () => {
 
 			expect( providedGetState ).toEqual( getState );
 		} );
+
+		it( 'should accept an action creator as first parameter', () => {
+			const actionCreator = () => ( { type: 'HELLO' } );
+			const enhancedActionCreator = withEnhancers(
+				withEnhancers( actionCreator, action => Object.assign( { name: 'test' }, action ) ),
+				action => Object.assign( { hello: 'world' }, action )
+			);
+
+			const thunk = enhancedActionCreator();
+			const getState = () => ( {} );
+			let dispatchedAction = null;
+			const dispatch = action => ( dispatchedAction = action );
+			thunk( dispatch, getState );
+
+			expect( dispatchedAction ).toEqual( {
+				name: 'test',
+				hello: 'world',
+				type: 'HELLO',
+			} );
+		} );
 	} );
 } );

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -227,20 +227,20 @@ export const withEnhancers = ( actionCreator, enhancers ) => ( ...args ) => (
 ) => {
 	const action = actionCreator( ...args );
 
-	if ( typeof action !== 'object' ) {
-		throw new Error(
-			'withEnhancers only works with an action creator that returns a plain action object'
-		);
-	}
-
 	if ( ! Array.isArray( enhancers ) ) {
 		enhancers = [ enhancers ];
 	}
 
+	if ( typeof action === 'function' ) {
+		const newDispatch = actionValue =>
+			dispatch(
+				enhancers.reduce( ( result, enhancer ) => enhancer( result, getState ), actionValue )
+			);
+		return action( newDispatch, getState );
+	}
+
 	return dispatch(
-		enhancers.reduce( ( result, enhancer ) => {
-			return enhancer( result, getState );
-		}, action )
+		enhancers.reduce( ( result, enhancer ) => enhancer( result, getState ), action )
 	);
 };
 


### PR DESCRIPTION
This PR updates the analytics middleware to be able to add custom properties from the state to page view track events.
It also updates all existing calls to page view to add the `site_type` property which value can either be `wpcom` or `jetpack`.

### Testing Instructions
- Boot this branch locally
- Log analytics events in the console: localStorage.debug = 'calypso:analytics:*';
- Navigate from page to page on calypso and notice that this property is added to every page view event.
- Go to the Google My Business Stats page and notice that the `calypso_google_my_business_stats_update_listing_button_click` still has a `site_type` property.
- Check that the track events emitted from an oauth2 flow have the `client_id` props: go to woocommerce.com and click on get started

### Reviews
- [ ] Code
- [ ] Product
