### PR TITLE
Fix Google My Business tab not displayed when switching site

### DIFF
--- a/client/components/data/query-site-keyrings/index.js
+++ b/client/components/data/query-site-keyrings/index.js
@@ -33,8 +33,8 @@ class QuerySiteKeyrings extends Component {
 		return { siteId: nextProps.siteId };
 	}
 
-	shouldComponentUpdate( nextProps, nextState ) {
-		return nextProps.siteId !== nextState.siteId;
+	shouldComponentUpdate( nextProps ) {
+		return this.state.siteId !== nextProps.siteId;
 	}
 
 	componentDidMount() {


### PR DESCRIPTION
This PR fixes a bug in `QuerySiteKeyrings` which did not have the right condition to query the site keyrings on site change.

### Testing Instructions
- Boot this branch locally
- Navigate to the Stats page for a site which is not connected to Google My Business
- Reload the page
- Switch to a site which is connected to Google My Business
- The Google My Business tab should appear

### Reviews
- [ ] Code
- [ ] Product
