### PR TITLE
Jetpack Checklist: Floating Page Settings Experiment

### DIFF
--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -19,6 +19,7 @@ import { ChecklistSiteTaglineTour } from 'layout/guided-tours/tours/checklist-si
 import { ChecklistSiteTitleTour } from 'layout/guided-tours/tours/checklist-site-title-tour';
 import { ChecklistUserAvatarTour } from 'layout/guided-tours/tours/checklist-user-avatar-tour';
 import { JetpackBasicTour } from 'layout/guided-tours/tours/jetpack-basic-tour';
+import { JetpackMonitoringTour } from 'layout/guided-tours/tours/jetpack-monitoring-tour';
 import { SimplePaymentsEmailTour } from 'layout/guided-tours/tours/simple-payments-email-tour';
 
 export default combineTours( {
@@ -30,6 +31,7 @@ export default combineTours( {
 	checklistSiteTitle: ChecklistSiteTitleTour,
 	checklistUserAvatar: ChecklistUserAvatarTour,
 	jetpack: JetpackBasicTour,
+	jetpackMonitoring: JetpackMonitoringTour,
 	main: MainTour,
 	editorBasicsTour: EditorBasicsTour,
 	mediaBasicsTour: MediaBasicsTour,

--- a/client/layout/guided-tours/tours/jetpack-monitoring-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-monitoring-tour.js
@@ -1,0 +1,79 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Fragment } from 'react';
+import Gridicon from 'gridicons';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	ButtonRow,
+	Continue,
+	makeTour,
+	SiteLink,
+	Step,
+	Tour,
+} from 'layout/guided-tours/config-elements';
+
+export const JetpackMonitoringTour = makeTour(
+	<Tour name="jetpackMonitoring" version="20180611" path="/non-existent-route" when={ noop }>
+		<Step
+			name="init"
+			target=".jetpack-monitor-settings .form-toggle__switch"
+			arrow="top-left"
+			placement="below"
+			style={ {
+				animationDelay: '0.7s',
+				zIndex: 1,
+			} }
+		>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"Let's enable monitoring of your site's uptime " +
+								'by activating the toggle switch for Jetpack Monitor.'
+						) }
+					</p>
+					<ButtonRow>
+						<Continue
+							target=".jetpack-monitor-settings .form-toggle__switch"
+							step="finish"
+							click
+							hidden
+						/>
+						<SiteLink isButton={ false } href="/checklist/:site">
+							{ translate( 'Return to the checklist' ) }
+						</SiteLink>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+
+		<Step name="finish" placement="right">
+			{ ( { translate } ) => (
+				<Fragment>
+					<h1 className="tours__title">
+						<span className="tours__completed-icon-wrapper">
+							<Gridicon icon="checkmark" className="tours__completed-icon" />
+						</span>
+						{ translate( 'Excellent, you’re done!' ) }
+					</h1>
+					<p>
+						{ translate(
+							'Uptime Monitoring has been enabled. Let’s move on and see what’s next on our checklist.'
+						) }
+					</p>
+					<SiteLink isButton href={ '/checklist/:site' }>
+						{ translate( 'Return to the checklist' ) }
+					</SiteLink>
+				</Fragment>
+			) }
+		</Step>
+	</Tour>
+);

--- a/client/my-sites/checklist/jetpack-checklist.js
+++ b/client/my-sites/checklist/jetpack-checklist.js
@@ -34,6 +34,7 @@ const tasks = {
 		completedButtonText: 'Change',
 		duration: translate( '3 min' ),
 		url: '/settings/security/$siteSlug#jetpack-monitor',
+		tour: 'jetpackMonitoring',
 	},
 	jetpack_plugin_updates: {
 		title: translate( 'Automatic Plugin Updates' ),

--- a/client/my-sites/checklist/jetpack-checklist.js
+++ b/client/my-sites/checklist/jetpack-checklist.js
@@ -33,7 +33,7 @@ const tasks = {
 		completedTitle: translate( 'You turned on Jetpack Monitor.' ),
 		completedButtonText: 'Change',
 		duration: translate( '3 min' ),
-		url: '/settings/security/$siteSlug',
+		url: '/settings/security/$siteSlug#jetpack-monitor',
 	},
 	jetpack_plugin_updates: {
 		title: translate( 'Automatic Plugin Updates' ),

--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -5,6 +5,7 @@
  */
 
 import React, { Component } from 'react';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { isEmpty, partial } from 'lodash';
@@ -122,14 +123,18 @@ class SiteSettingsFormJetpackMonitor extends Component {
 	};
 
 	render() {
-		const { siteId, translate } = this.props;
+		const { inactive, siteId, translate } = this.props;
 
 		if ( ! config.isEnabled( 'settings/security/monitor' ) ) {
 			return null;
 		}
 
+		const className = classNames( 'site-settings__security-settings', {
+			'site-settings__inactive-setting': inactive,
+		} );
+
 		return (
-			<div className="site-settings__security-settings" id="jetpack-monitor">
+			<div className={ className } id="jetpack-monitor">
 				<QueryJetpackModules siteId={ siteId } />
 				<QuerySiteMonitorSettings siteId={ siteId } />
 

--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -129,7 +129,7 @@ class SiteSettingsFormJetpackMonitor extends Component {
 		}
 
 		return (
-			<div className="site-settings__security-settings">
+			<div className="site-settings__security-settings" id="jetpack-monitor">
 				<QueryJetpackModules siteId={ siteId } />
 				<QuerySiteMonitorSettings siteId={ siteId } />
 

--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -5,6 +5,7 @@
  */
 
 import React, { Component } from 'react';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { flowRight, partialRight, pick } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -53,6 +54,7 @@ class SiteSettingsFormSecurity extends Component {
 			fields,
 			handleAutosavingToggle,
 			handleSubmitForm,
+			inactive,
 			isAtomic,
 			isRequestingSettings,
 			isSavingSettings,
@@ -73,12 +75,12 @@ class SiteSettingsFormSecurity extends Component {
 		const disableProtect = ! protectModuleActive || protectModuleUnavailable;
 		const disableSpamFiltering = ! fields.akismet || akismetUnavailable;
 
+		const className = classNames( 'site-settings__security-settings', {
+			'site-settings__inactive-setting': inactive,
+		} );
+
 		return (
-			<form
-				id="site-settings"
-				onSubmit={ handleSubmitForm }
-				className="site-settings__security-settings"
-			>
+			<form id="site-settings" onSubmit={ handleSubmitForm } className={ className }>
 				<QueryJetpackModules siteId={ siteId } />
 
 				{ this.renderSectionHeader(

--- a/client/my-sites/site-settings/settings-security/controller.js
+++ b/client/my-sites/site-settings/settings-security/controller.js
@@ -13,7 +13,7 @@ import SecurityMain from 'my-sites/site-settings/settings-security/main';
 
 export default {
 	security( context, next ) {
-		context.primary = React.createElement( SecurityMain );
+		context.primary = <SecurityMain setting={ Object.keys( context.hash )[ 0 ] } />;
 		next();
 	},
 };

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { find } from 'lodash';
+import { find, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,6 +29,7 @@ import JetpackCredentials from 'my-sites/site-settings/jetpack-credentials';
 import QueryRewindState from 'components/data/query-rewind-state';
 
 const SiteSettingsSecurity = ( {
+	setting,
 	showRewindCredentials,
 	site,
 	siteId,
@@ -68,6 +69,9 @@ const SiteSettingsSecurity = ( {
 		return <JetpackManageErrorPage template="updateJetpack" siteId={ siteId } version="3.4" />;
 	}
 
+	const settings = [ 'jetpack-monitor', 'security-settings' ];
+	const isValidSection = includes( settings, setting );
+
 	return (
 		<Main className="settings-security__main site-settings">
 			<QueryRewindState siteId={ siteId } />
@@ -76,8 +80,8 @@ const SiteSettingsSecurity = ( {
 			<SidebarNavigation />
 			<SiteSettingsNavigation site={ site } section="security" />
 			{ showRewindCredentials && <JetpackCredentials /> }
-			<JetpackMonitor />
-			<FormSecurity />
+			<JetpackMonitor inactive={ isValidSection && setting !== 'jetpack-monitor' } />
+			<FormSecurity inactive={ isValidSection && setting !== 'security-settings' } />
 		</Main>
 	);
 };

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -249,6 +249,11 @@
 		margin: 0 -24px 1.5em;
 	}
 }
+
+:target {
+	border: 2px solid black;
+}
+
 .site-settings__general-settings .site-settings__language-picker-notice {
 	margin-bottom: 10px;
 }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -250,8 +250,8 @@
 	}
 }
 
-:target {
-	border: 2px solid black;
+.site-settings__inactive-setting {
+	filter: blur(2px);
 }
 
 .site-settings__general-settings .site-settings__language-picker-notice {


### PR DESCRIPTION
Exploratory PR to riff on option no. 3 (the 'floating page') found at p6TEKc-1TR-p2 (which I find really quite appealing). ~Uses `#fragment-anchors` to highlight sections (thru the `:target` pseudo-selector).~

Couldn't get it to work using `:target` selectors. Using `context.hash` now, which seems to be working alright.

![image](https://user-images.githubusercontent.com/96308/41247076-2de6370a-6dad-11e8-9cdb-8643e92526bf.png)

![image](https://user-images.githubusercontent.com/96308/41247093-38543cfa-6dad-11e8-8aa9-012d0b2a3a16.png)

Pro:
* No new routes need to be introduced
* Less code duplication
* Can be carried over back to WP.com settings to work with their checklist
* Implementation-wise: No futzing with `wrapSettingsForm` which could be annoying

To test:
* Land at `calypso.localhost:3000/checklist/<jpSite>`
* Click the 'Do it!' button next to the 'Jetpack Monitor' item.
* Lo and behold! (Blurred out lower section, Guided Tour)
* Enable JP Monitor, as suggested by the Guided Tour thingy
* Find a gratifying success notice  :heavy_check_mark: 
* Click 'Return to checklist'
* Neat, huh?

TODO (if we think this makes sense; can be tackled in follow-up PRs)
* Disable blurred controls
* Allow clicking outside to enable all the settings?
* Better `target`s for GT (`data-tip-target`, or more precise `className`)