### PR TITLE
Podcasting: Add error message for insufficient permissions.

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -28,10 +28,12 @@ import QueryTerms from 'components/data/query-terms';
 import TermTreeSelector from 'blocks/term-tree-selector';
 import PodcastCoverImageSetting from 'my-sites/site-settings/podcast-cover-image-setting';
 import PodcastingPrivateSiteMessage from './private-site';
+import PodcastingNoPermissionsMessage from './no-permissions';
 import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
 import podcastingTopics from './topics';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import isPrivateSite from 'state/selectors/is-private-site';
+import canCurrentUser from 'state/selectors/can-current-user';
 import {
 	isRequestingTermsForQueryIgnoringPage,
 	getTermsForQueryIgnoringPage,
@@ -283,10 +285,14 @@ class PodcastingDetails extends Component {
 	renderSettingsError() {
 		// If there is a reason that we can't display the podcasting settings
 		// screen, it will be rendered here.
-		const { isPrivate } = this.props;
+		const { isPrivate, userCanManagePodcasting } = this.props;
 
 		if ( isPrivate ) {
 			return <PodcastingPrivateSiteMessage />;
+		}
+
+		if ( ! userCanManagePodcasting ) {
+			return <PodcastingNoPermissionsMessage />;
 		}
 
 		return null;
@@ -374,6 +380,7 @@ const connectComponent = connect( ( state, ownProps ) => {
 		isPodcastingEnabled,
 		isRequestingCategories: isRequestingTermsForQueryIgnoringPage( state, siteId, 'category', {} ),
 		podcastingFeedUrl,
+		userCanManagePodcasting: canCurrentUser( state, siteId, 'manage_options' ),
 	};
 } );
 

--- a/client/my-sites/site-settings/podcasting-details/no-permissions.jsx
+++ b/client/my-sites/site-settings/podcasting-details/no-permissions.jsx
@@ -1,0 +1,22 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+function PodcastingNoPermissionsMessage( { translate } ) {
+	return (
+		<div className="podcasting-details__no-permissions">
+			<p>
+				{ translate(
+					"Oops! You don't have permission to manage Podcasting. " +
+						"If you think you should, contact this site's administrator."
+				) }
+			</p>
+		</div>
+	);
+}
+
+export default localize( PodcastingNoPermissionsMessage );

--- a/client/my-sites/site-settings/podcasting-details/no-permissions.jsx
+++ b/client/my-sites/site-settings/podcasting-details/no-permissions.jsx
@@ -11,9 +11,11 @@ function PodcastingNoPermissionsMessage( { translate } ) {
 		<div className="podcasting-details__no-permissions">
 			<p>
 				{ translate(
-					"Oops! You don't have permission to manage Podcasting. " +
-						"If you think you should, contact this site's administrator."
+					"Oops! You don't have permission to manage Podcasting settings on this site."
 				) }
+			</p>
+			<p>
+				{ translate( "Try changing to a different site or contacting this site's administrator." ) }
 			</p>
 		</div>
 	);

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -42,7 +42,8 @@
 	}
 }
 
-.podcasting-details__private-site {
+.podcasting-details__private-site,
+.podcasting-details__no-permissions {
 	.site-settings .podcasting-details__link & {
 		p {
 			margin-bottom: 0.75em;


### PR DESCRIPTION
This adds an error message for users attempting to navigate directly to the Podcasting Details page when they don't have sufficient privileges. 

This PR is part of a larger epic and is behind the `manage/site-settings/podcasting` feature flag. See p3Ex-32D-p2.

<img width="1166" alt="no-permissions" src="https://user-images.githubusercontent.com/942359/41248523-4d098462-6d7f-11e8-8454-c4ff90ee0733.png">


**To test:**
- With the `manage/site-settings/podcasting` enabled (default in development):
- Given a user without `manage_settings` permission (an author)
- When they attempt to visit the podcasting settings page (i.e. http://calypso.localhost:3000/settings/podcasting/mygroovydomain.com)
- Then a message is shown stating that they don't have permission