### PR TITLE
EditorPublishDate: Fix issue that prevented cancelation of scheduling

### DIFF
--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -64,7 +64,7 @@ export class EditorPublishDate extends React.Component {
 	};
 
 	setImmediate = () => {
-		this.props.setPostDate( null );
+		this.props.setPostDate( false );
 		this.setState( { isOpen: false } );
 	};
 

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -787,7 +787,7 @@ export class PostEditor extends React.Component {
 
 	setPostDate = date => {
 		const { siteId, postId } = this.props;
-		const dateValue = date ? date.format() : null;
+		const dateValue = date ? date.format() : false;
 
 		this.props.editPost( siteId, postId, { date: dateValue } );
 

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -1444,6 +1444,34 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		test( 'should consider date not edited after resetting draft date', () => {
+			const original = deepFreeze( {
+				2916284: {
+					842: {
+						title: 'I like turtles',
+						date: false,
+					},
+				},
+			} );
+			const state = edits( original, {
+				type: POST_SAVE_SUCCESS,
+				siteId: 2916284,
+				postId: 842,
+				savedPost: {
+					ID: 842,
+					title: 'I like turtles',
+					date: '2018-06-14T16:47:21+00:00',
+				},
+			} );
+			expect( state ).to.eql( {
+				2916284: {
+					842: {
+						title: 'I like turtles',
+					},
+				},
+			} );
+		} );
+
 		test( "should ignore stop editor action when site doesn't exist", () => {
 			const original = deepFreeze( {} );
 			const state = edits( original, {

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -383,7 +383,7 @@ export function isAuthorEqual( localAuthorEdit, savedAuthor ) {
 }
 
 export function isDateEqual( localDateEdit, savedDate ) {
-	return moment( localDateEdit ).isSame( savedDate );
+	return localDateEdit && moment( localDateEdit ).isSame( savedDate );
 }
 
 export function isStatusEqual( localStatusEdit, savedStatus ) {


### PR DESCRIPTION
This PR fixes #24829. The API doesn't accept `null` for resetting the publish date, `false` must be passed instead.

To test

1. Create a new post
2. In the Post Settings > Status, pick a date in the future 
3. Save a draft of the post by clicking "save" in the header (or wait for autosave)
4. Click the "Cancel scheduling" button
5. Click "Save" link in header
6. Reload the page, and verify that "Publish Immediately" is persisted.
