### PR TITLE
Purchases: Remove site dependency from CancelPrivacyProtection

### DIFF
--- a/client/me/purchases/cancel-privacy-protection/index.jsx
+++ b/client/me/purchases/cancel-privacy-protection/index.jsx
@@ -98,7 +98,7 @@ class CancelPrivacyProtection extends Component {
 					{ persistent: true }
 				);
 
-				page( managePurchase( this.props.selectedSite.slug, id ) );
+				page( managePurchase( this.props.siteSlug, id ) );
 			} )
 			.catch( () => {
 				this.resetState();

--- a/client/me/purchases/cancel-privacy-protection/index.jsx
+++ b/client/me/purchases/cancel-privacy-protection/index.jsx
@@ -38,6 +38,7 @@ class CancelPrivacyProtection extends Component {
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
 		purchase: PropTypes.object,
 		purchaseId: PropTypes.number.isRequired,
+		siteSlug: PropTypes.string.isRequired,
 		userId: PropTypes.number,
 	};
 

--- a/client/me/purchases/cancel-privacy-protection/index.jsx
+++ b/client/me/purchases/cancel-privacy-protection/index.jsx
@@ -21,10 +21,7 @@ import {
 	getPurchasesError,
 	hasLoadedUserPurchasesFromServer,
 } from 'state/purchases/selectors';
-import { isDataLoading } from '../utils';
-import { getSelectedSite } from 'state/ui/selectors';
 import { hasPrivacyProtection, isRefundable } from 'lib/purchases';
-import { isRequestingSites } from 'state/sites/selectors';
 import Main from 'components/main';
 import notices from 'notices';
 import Notice from 'components/notice';
@@ -38,12 +35,9 @@ import { getCurrentUserId } from 'state/current-user/selectors';
 
 class CancelPrivacyProtection extends Component {
 	static propTypes = {
-		hasLoadedSites: PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
 		purchase: PropTypes.object,
 		purchaseId: PropTypes.number.isRequired,
-		selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
-		siteSlug: PropTypes.string.isRequired,
 		userId: PropTypes.number,
 	};
 
@@ -69,13 +63,13 @@ class CancelPrivacyProtection extends Component {
 	};
 
 	isDataValid = ( props = this.props ) => {
-		if ( isDataLoading( props ) ) {
+		if ( ! props.hasLoadedUserPurchasesFromServer ) {
 			return true;
 		}
 
-		const { purchase, selectedSite } = props;
+		const { purchase } = props;
 
-		return selectedSite && purchase && hasPrivacyProtection( purchase );
+		return purchase && hasPrivacyProtection( purchase );
 	};
 
 	cancel = event => {
@@ -176,7 +170,7 @@ class CancelPrivacyProtection extends Component {
 
 	render() {
 		const classes = classNames( 'cancel-privacy-protection__card', {
-			'is-placeholder': isDataLoading( this.props ),
+			'is-placeholder': ! this.props.hasLoadedUserPurchasesFromServer,
 		} );
 
 		let notice,
@@ -193,7 +187,7 @@ class CancelPrivacyProtection extends Component {
 				</p>
 			);
 
-		if ( ! isDataLoading( this.props ) && this.isDataValid() ) {
+		if ( this.props.hasLoadedUserPurchasesFromServer && this.isDataValid() ) {
 			notice = this.renderNotice();
 			button = this.renderButton();
 			descriptionText = this.renderDescriptionText();
@@ -233,10 +227,8 @@ class CancelPrivacyProtection extends Component {
 export default connect(
 	( state, props ) => ( {
 		error: getPurchasesError( state ),
-		hasLoadedSites: ! isRequestingSites( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		purchase: getByPurchaseId( state, props.purchaseId ),
-		selectedSite: getSelectedSite( state ),
 		userId: getCurrentUserId( state ),
 	} ),
 	{ cancelPrivacyProtection }


### PR DESCRIPTION
This component does not have strong data requirements on a site. Remove references to the selected site where possible.

Extracted from #25219

## Testing
1. https://calypso.live/me/purchases?branch=remove/sites-cancel-privacy-protection
1. Pick a purchase including privacy protection.
1. Click the button to cancel privacy protection.
1. Verify everything continues to behave as expected. 