### PR TITLE
Editor: fix ability to edit feedbacks

### DIFF
--- a/client/post-editor/editor-author/index.jsx
+++ b/client/post-editor/editor-author/index.jsx
@@ -105,7 +105,9 @@ export default connect(
 
 		const site = getSite( state, siteId );
 		const post = getEditedPost( state, siteId, postId );
-		const author = get( post, 'author', getCurrentUser( state ) );
+		const postAuthor = get( post, 'author' );
+		//default to current user when null or falsey
+		const author = postAuthor ? postAuthor : getCurrentUser( state );
 
 		return { site, post, author, isNew };
 	},


### PR DESCRIPTION
Fixes #25315 When folks leave feedback in a contact form, sometimes we'd like to edit this in the Editor. In production, we're seeing a blank page instead of the feedback loading. 

This is likely a regression from #23844 on an easy to miss case. Basically `const author = get( post, 'author', getCurrentUser( state ) );` will use the value `null` instead of the default fallback because it's a valid value. When this happens, an error is thrown on `const name = author.display_name || author.name;`

![41048006-1849dc38-69ae-11e8-9295-984ffe3fd424](https://user-images.githubusercontent.com/1270189/41264329-f4b8475e-6da0-11e8-9195-2d2323ed9e4f.gif)

### Testing Instructions
- In Calypso, add a post or page with a contact form
- Publish the post or page
- Visit the published page/post
- Submit the contact form
- Navigate to https://wordpress.com/types/feedback/{site}
- Edit your feedback