### PR TITLE
Try using npm install instead of npm ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - restore_cache:
           key: v10-4-0-npmdeps-{{ checksum "npm-shrinkwrap.json" }}
 
-      - run: npm ci
+      - run: npm install --no-save
 
       - save_cache:
           key: v10-4-0-npmdeps-{{ checksum "npm-shrinkwrap.json" }}


### PR DESCRIPTION
Might benefit from the circle cache? Check out timings in circle ci.

Use --no-save to prevent the package.lock from getting updated.