### PR TITLE
Framework: Remove the CircleCI cache around node_modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,15 +26,7 @@ jobs:
             mkdir -p $CIRCLE_ARTIFACTS
             mkdir -p $CIRCLE_TEST_REPORTS
 
-      - restore_cache:
-          key: v10-4-0-npmdeps-{{ checksum "npm-shrinkwrap.json" }}
-
       - run: npm ci
-
-      - save_cache:
-          key: v10-4-0-npmdeps-{{ checksum "npm-shrinkwrap.json" }}
-          paths:
-            - "node_modules"
 
       - run: NODE_ENV=test npm run build-server
 


### PR DESCRIPTION
With the move to npm@6.1.0, we also moving to using [npm ci](https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable) for Circle builds. However, we're still caching `node_modules` between builds.  `npm ci` is very fast, but `npm ci` blows up `node_modules` when it runs, so having the cache just slows it down.

Typical cache + `npm ci` was ~ 10s to restore cache and ~25s to run `npm ci`

Removing the cache doesn't affect `npm ci` time (still ~25s)

https://github.com/Automattic/wp-calypso/pull/25430 tried cache + `npm install --no-save`, but `npm install` times had much greater variance (between 25 and 60s) than `npm ci`.

No functional changes, just more predictable Circle CI build times. 