### PR TITLE
Podcasting settings: Change "iTunes" to "Apple Podcasts"

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -117,7 +117,7 @@ class PodcastingDetails extends Component {
 			>
 				<option value="0">None</option>
 				{ map( toPairs( podcastingTopics ), ( [ topic, subtopics ] ) => {
-					// The keys for podcasting in iTunes use &amp;
+					// The keys for podcasting in Apple Podcasts use &amp;
 					const topicKey = topic.replace( '&', '&amp;' );
 					return [
 						<option key={ topicKey } value={ topicKey }>
@@ -145,7 +145,7 @@ class PodcastingDetails extends Component {
 				<FormLabel htmlFor="podcasting_category_1">{ translate( 'Podcast Topics' ) }</FormLabel>
 				<FormSettingExplanation>
 					{ translate(
-						'Choose how your podcast should be categorized within iTunes and other podcasting services.'
+						'Choose how your podcast should be categorized within Apple Podcasts and other podcasting services.'
 					) }
 				</FormSettingExplanation>
 				{ this.renderTopicSelector( 'podcasting_category_1' ) }


### PR DESCRIPTION
> ![2018-06-11t22 27 33-0500](https://user-images.githubusercontent.com/227022/41268652-c1c58cdc-6dc6-11e8-861a-30841c6452f3.png)

### To test

Verify that all references to `iTunes` in podcasting settings (UI and code) have been changed to `Apple Podcasts`.