### PR TITLE
Revert "Fix event fired when we click on the `Start Now` button in the GMB nudge"

### DIFF
--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -29,14 +29,9 @@ class GoogleMyBusinessStatsNudge extends Component {
 		siteId: PropTypes.number.isRequired,
 		siteSlug: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
-		visible: PropTypes.bool,
 	};
 
-	static defaultProps = {
-		visible: true,
-	};
-
-	componentDidMount() {
+	componentWillMount() {
 		if ( ! this.props.isDismissed ) {
 			this.props.recordTracksEvent( 'calypso_google_my_business_stats_nudge_view' );
 		}
@@ -113,9 +108,6 @@ export default connect(
 	} ),
 	{
 		dismissNudge,
-		recordTracksEvent: withEnhancers( recordTracksEvent, [
-			enhanceWithDismissCount,
-			enhanceWithSiteType,
-		] ),
+		recordTracksEvent: withEnhancers( recordTracksEvent, [ enhanceWithDismissCount, enhanceWithSiteType ] ),
 	}
 )( localize( GoogleMyBusinessStatsNudge ) );

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -152,11 +152,9 @@ class StatsSite extends Component {
 				/>
 				<div id="my-stats-content">
 					{ config.isEnabled( 'onboarding-checklist' ) && <ChecklistBanner siteId={ siteId } /> }
-					<GoogleMyBusinessStatsNudge
-						siteSlug={ slug }
-						siteId={ siteId }
-						visible={ isGoogleMyBusinessStatsNudgeVisible }
-					/>
+					{ isGoogleMyBusinessStatsNudgeVisible && (
+						<GoogleMyBusinessStatsNudge siteSlug={ slug } siteId={ siteId } />
+					) }
 					<ChartTabs
 						barClick={ this.barClick }
 						switchTab={ this.switchChart }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#25407

This caused the nudge to be visible, even when user is already connected to Google My Business.
Need to look at the reason behind this.