### PR TITLE
Fix event fired when we click on the `Start Now` button in the GMB nudge v2

### DIFF
--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -29,9 +29,14 @@ class GoogleMyBusinessStatsNudge extends Component {
 		siteId: PropTypes.number.isRequired,
 		siteSlug: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
+		visible: PropTypes.bool,
 	};
 
-	componentWillMount() {
+	static defaultProps = {
+		visible: true,
+	};
+
+	componentDidMount() {
 		if ( ! this.props.isDismissed ) {
 			this.props.recordTracksEvent( 'calypso_google_my_business_stats_nudge_view' );
 		}
@@ -108,6 +113,9 @@ export default connect(
 	} ),
 	{
 		dismissNudge,
-		recordTracksEvent: withEnhancers( recordTracksEvent, [ enhanceWithDismissCount, enhanceWithSiteType ] ),
+		recordTracksEvent: withEnhancers( recordTracksEvent, [
+			enhanceWithDismissCount,
+			enhanceWithSiteType,
+		] ),
 	}
 )( localize( GoogleMyBusinessStatsNudge ) );

--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -52,7 +52,7 @@ class GoogleMyBusinessStatsNudge extends Component {
 	};
 
 	render() {
-		if ( this.props.isDismissed ) {
+		if ( this.props.isDismissed || ! this.props.visible ) {
 			return null;
 		}
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -152,9 +152,11 @@ class StatsSite extends Component {
 				/>
 				<div id="my-stats-content">
 					{ config.isEnabled( 'onboarding-checklist' ) && <ChecklistBanner siteId={ siteId } /> }
-					{ isGoogleMyBusinessStatsNudgeVisible && (
-						<GoogleMyBusinessStatsNudge siteSlug={ slug } siteId={ siteId } />
-					) }
+					<GoogleMyBusinessStatsNudge
+						siteSlug={ slug }
+						siteId={ siteId }
+						visible={ isGoogleMyBusinessStatsNudgeVisible }
+					/>
 					<ChartTabs
 						barClick={ this.barClick }
 						switchTab={ this.switchChart }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -152,11 +152,13 @@ class StatsSite extends Component {
 				/>
 				<div id="my-stats-content">
 					{ config.isEnabled( 'onboarding-checklist' ) && <ChecklistBanner siteId={ siteId } /> }
-					<GoogleMyBusinessStatsNudge
-						siteSlug={ slug }
-						siteId={ siteId }
-						visible={ isGoogleMyBusinessStatsNudgeVisible }
-					/>
+					{ siteId && (
+						<GoogleMyBusinessStatsNudge
+							siteSlug={ slug }
+							siteId={ siteId }
+							visible={ isGoogleMyBusinessStatsNudgeVisible }
+						/>
+					) }
 					<ChartTabs
 						barClick={ this.barClick }
 						switchTab={ this.switchChart }


### PR DESCRIPTION
Retrial for https://github.com/Automattic/wp-calypso/pull/25407

This prevents `calypso_google_my_business_stats_nudge_view` from being fired when user clicks on the `Start Now` button on the GMB nudge.
This was happening because clicking on the nudge would trigger a site keyring request which makes the nudge invisible during that period according to the logic inside the selector https://github.com/Automattic/wp-calypso/blob/master/client/state/selectors/is-google-my-business-stats-nudge-visible.js#L28
I don't think the logic is wrong so we should just prevent the component from being unmounted and remounted in this case.

### Testing Instructions
- Boot this branch locally
- log analytics events in the console: `localStorage.debug = 'calypso:analytics:*';`
- Go to the stats page for a site that is eligible for Google My Business
- Ensure you see the `calypso_google_my_business_stats_nudge_view` event fired on page load
- Click on the `Start Now` button and make sure the event is not fired a second time

### Reviews
- [ ] Code
- [ ] Product
