### PR TITLE
Jetpack connect: Use receiveSite action

### DIFF
--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -40,7 +40,6 @@ import {
 	JETPACK_CONNECT_SSO_VALIDATION_REQUEST,
 	JETPACK_CONNECT_SSO_VALIDATION_SUCCESS,
 	JETPACK_CONNECT_USER_ALREADY_CONNECTED,
-	SITE_RECEIVE,
 	SITE_REQUEST,
 	SITE_REQUEST_FAILURE,
 	SITE_REQUEST_SUCCESS,
@@ -380,10 +379,7 @@ export function authorize( queryObject ) {
 					} )
 				);
 				debug( 'Site updated', data );
-				dispatch( {
-					type: SITE_RECEIVE,
-					site: data,
-				} );
+				receiveSite( data );
 				dispatch( {
 					type: JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST,
 				} );

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -379,7 +379,7 @@ export function authorize( queryObject ) {
 					} )
 				);
 				debug( 'Site updated', data );
-				receiveSite( data );
+				dispatch( receiveSite( data ) );
 				dispatch( {
 					type: JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST,
 				} );


### PR DESCRIPTION
Use existing action creator over manually created action object.

Extracted from #24449

## Testing

Verify that the `SITE_RECEIVE` action is identical when dispatched during the connection flow.

In both cases it should look like:

```js
{
  meta: { timestamp: 12345 },
  site: { ID: 12345, /* … */ },
  type: "SITE_RECEIVE"
}
```

- Prod: https://wordpress.com/jetpack/connect?debug
  Make sure you maintain the `?debug` param during the connection flow
- Branch: https://calypso.live/jetpack/connect?branch=update/jpc-use-receive-site-action&debug
  Make sure you stay on calypso.live with the branch and debug params. It's easy to be bounced off during the connection flow.

```js
// After connecting a new Jetpack site
actionLog.filter('SITE_RECEIVE')
```