### PR TITLE
Replace `cart()` with `getCart()`, `setCart()`

### DIFF
--- a/client/lib/cart/store/cart-synchronizer.js
+++ b/client/lib/cart/store/cart-synchronizer.js
@@ -160,7 +160,7 @@ CartSynchronizer.prototype._processQueuedChanges = function() {
 };
 
 CartSynchronizer.prototype._postToServer = function( callback ) {
-	this._wpcom.cart( this._cartKey, 'POST', preprocessCartForServer( this._latestValue ), function(
+	this._wpcom.setCart( this._cartKey, preprocessCartForServer( this._latestValue ), function(
 		error,
 		newValue
 	) {
@@ -182,7 +182,7 @@ CartSynchronizer.prototype.fetch = function() {
 };
 
 CartSynchronizer.prototype._getFromServer = function( callback ) {
-	this._wpcom.cart( this._cartKey, 'GET', function( error, newValue ) {
+	this._wpcom.getCart( this._cartKey, function( error, newValue ) {
 		if ( error ) {
 			callback( error );
 			return;

--- a/client/lib/cart/store/test/fake-wpcom/index.js
+++ b/client/lib/cart/store/test/fake-wpcom/index.js
@@ -14,24 +14,25 @@ function FakeWPCOM() {
 	this._requests = [];
 }
 
-FakeWPCOM.prototype.cart = function() {
-	let arrayArguments = toArray( arguments ),
-		method = arrayArguments[ 1 ];
+FakeWPCOM.prototype.getCart = function() {
+	const arrayArguments = toArray( arguments );
 
-	if ( method === 'POST' ) {
-		this._requests.push( {
-			isResolved: false,
-			method: method,
-			cart: arrayArguments[ 2 ],
-			callback: arrayArguments[ 3 ],
-		} );
-	} else {
-		this._requests.push( {
-			isResolved: false,
-			method: method,
-			callback: arrayArguments[ 2 ],
-		} );
-	}
+	this._requests.push( {
+		isResolved: false,
+		method: 'GET',
+		callback: arrayArguments[ 1 ],
+	} );
+};
+
+FakeWPCOM.prototype.setCart = function() {
+	const arrayArguments = toArray( arguments );
+
+	this._requests.push( {
+		isResolved: false,
+		method: 'POST',
+		cart: arrayArguments[ 1 ],
+		callback: arrayArguments[ 2 ],
+	} );
 };
 
 FakeWPCOM.prototype.resolveRequest = function( index, responseData ) {

--- a/client/lib/signup/cart.js
+++ b/client/lib/signup/cart.js
@@ -37,12 +37,12 @@ export default {
 
 		newCart = addProductsToCart( newCart, newCartItems );
 
-		wpcom.undocumented().cart( cartKey, 'POST', newCart, function( postError ) {
+		wpcom.undocumented().setCart( cartKey, newCart, function( postError ) {
 			callback( postError );
 		} );
 	},
 	addToCart: function( cartKey, newCartItems, callback ) {
-		wpcom.undocumented().cart( cartKey, function( error, data ) {
+		wpcom.undocumented().getCart( cartKey, function( error, data ) {
 			if ( error ) {
 				return callback( error );
 			}
@@ -53,7 +53,7 @@ export default {
 
 			const newCart = addProductsToCart( data, newCartItems );
 
-			wpcom.undocumented().cart( cartKey, 'POST', newCart, callback );
+			wpcom.undocumented().setCart( cartKey, newCart, callback );
 		} );
 	},
 };

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -768,29 +768,39 @@ Undocumented.prototype.getSitePlans = function( siteDomain, fn ) {
 };
 
 /**
- * GET/POST cart
+ * Get cart.
  *
- * @param {string} [cartKey] The cart's key
- * @param {string} [method] The request method
- * @param {object} [data] The REQUEST data
- * @param {Function} fn The callback function
+ * @param {string} cartKey The cart's key.
+ * @param {Function} fn The callback function.
  * @api public
  */
-Undocumented.prototype.cart = function( cartKey, method, data, fn ) {
-	debug( '/me/shopping-cart/:cart-key query' );
-	if ( arguments.length === 2 ) {
-		fn = method;
-		method = 'GET';
-		data = {};
-	} else if ( arguments.length === 3 ) {
-		fn = data;
-		method = 'GET';
-		data = {};
-	}
-	return this._sendRequest(
+Undocumented.prototype.getCart = function( cartKey, fn ) {
+	debug( 'GET: /me/shopping-cart/:cart-key' );
+
+	this._sendRequest(
 		{
 			path: '/me/shopping-cart/' + cartKey,
-			method: method,
+			method: 'GET',
+		},
+		fn
+	);
+};
+
+/**
+ * Set cart.
+ *
+ * @param {string} cartKey The cart's key.
+ * @param {object} data The POST data.
+ * @param {Function} fn The callback function.
+ * @api public
+ */
+Undocumented.prototype.setCart = function( cartKey, data, fn ) {
+	debug( 'POST: /me/shopping-cart/:cart-key', data );
+
+	this._sendRequest(
+		{
+			path: '/me/shopping-cart/' + cartKey,
+			method: 'POST',
 			body: data,
 		},
 		fn


### PR DESCRIPTION
This replaces `Undocumented.prototype.cart()` with
`getCart()` and `setCart()` following a suggestion in https://github.com/Automattic/wp-calypso/pull/25433#discussion_r194655034