### PR TITLE
SiteSettingsSecurity: Add Blurred Styling to Individual Settings

### DIFF
--- a/client/my-sites/checklist/jetpack-checklist.js
+++ b/client/my-sites/checklist/jetpack-checklist.js
@@ -33,7 +33,7 @@ const tasks = {
 		completedTitle: translate( 'You turned on Jetpack Monitor.' ),
 		completedButtonText: 'Change',
 		duration: translate( '3 min' ),
-		url: '/settings/security/$siteSlug',
+		url: '/settings/security/$siteSlug#jetpack-monitor',
 	},
 	jetpack_plugin_updates: {
 		title: translate( 'Automatic Plugin Updates' ),

--- a/client/my-sites/checklist/jetpack-checklist.js
+++ b/client/my-sites/checklist/jetpack-checklist.js
@@ -23,7 +23,7 @@ const tasks = {
 		completedTitle: translate( 'You turned on backups and scanning.' ),
 		completedButtonText: 'Change',
 		duration: translate( '2 min' ),
-		url: '/stats/activity/$siteSlug',
+		url: '/settings/security/$siteSlug#jetpack-credentials',
 	},
 	jetpack_monitor: {
 		title: translate( 'Jetpack Monitor' ),

--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -134,7 +134,7 @@ class SiteSettingsFormJetpackMonitor extends Component {
 		} );
 
 		return (
-			<div className={ className }>
+			<div className={ className } id="jetpack-monitor">
 				<QueryJetpackModules siteId={ siteId } />
 				<QuerySiteMonitorSettings siteId={ siteId } />
 

--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -5,6 +5,7 @@
  */
 
 import React, { Component } from 'react';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { isEmpty, partial } from 'lodash';
@@ -122,14 +123,18 @@ class SiteSettingsFormJetpackMonitor extends Component {
 	};
 
 	render() {
-		const { siteId, translate } = this.props;
+		const { blurred, siteId, translate } = this.props;
 
 		if ( ! config.isEnabled( 'settings/security/monitor' ) ) {
 			return null;
 		}
 
+		const className = classNames( 'site-settings__security-settings', {
+			'site-settings__blurred': blurred,
+		} );
+
 		return (
-			<div className="site-settings__security-settings">
+			<div className={ className }>
 				<QueryJetpackModules siteId={ siteId } />
 				<QuerySiteMonitorSettings siteId={ siteId } />
 

--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -5,7 +5,6 @@
  */
 
 import React, { Component } from 'react';
-import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { flowRight, partialRight, pick } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -50,7 +49,6 @@ class SiteSettingsFormSecurity extends Component {
 	render() {
 		const {
 			akismetUnavailable,
-			blurred,
 			dirtyFields,
 			fields,
 			handleAutosavingToggle,
@@ -72,14 +70,15 @@ class SiteSettingsFormSecurity extends Component {
 			return null;
 		}
 
-		const className = classNames( 'site-settings__security-settings', {
-			'site-settings__blurred': blurred,
-		} );
 		const disableProtect = ! protectModuleActive || protectModuleUnavailable;
 		const disableSpamFiltering = ! fields.akismet || akismetUnavailable;
 
 		return (
-			<form className={ className } id="site-settings" onSubmit={ handleSubmitForm }>
+			<form
+				id="site-settings"
+				onSubmit={ handleSubmitForm }
+				className="site-settings__security-settings"
+			>
 				<QueryJetpackModules siteId={ siteId } />
 
 				{ this.renderSectionHeader(

--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -5,6 +5,7 @@
  */
 
 import React, { Component } from 'react';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { flowRight, partialRight, pick } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -49,6 +50,7 @@ class SiteSettingsFormSecurity extends Component {
 	render() {
 		const {
 			akismetUnavailable,
+			blurred,
 			dirtyFields,
 			fields,
 			handleAutosavingToggle,
@@ -70,15 +72,14 @@ class SiteSettingsFormSecurity extends Component {
 			return null;
 		}
 
+		const className = classNames( 'site-settings__security-settings', {
+			'site-settings__blurred': blurred,
+		} );
 		const disableProtect = ! protectModuleActive || protectModuleUnavailable;
 		const disableSpamFiltering = ! fields.akismet || akismetUnavailable;
 
 		return (
-			<form
-				id="site-settings"
-				onSubmit={ handleSubmitForm }
-				className="site-settings__security-settings"
-			>
+			<form className={ className } id="site-settings" onSubmit={ handleSubmitForm }>
 				<QueryJetpackModules siteId={ siteId } />
 
 				{ this.renderSectionHeader(

--- a/client/my-sites/site-settings/jetpack-credentials/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/index.jsx
@@ -32,7 +32,7 @@ class JetpackCredentials extends Component {
 		} );
 
 		return (
-			<div className={ className }>
+			<div className={ className } id="jetpack-credentials">
 				<QueryRewindState siteId={ siteId } />
 				<SectionHeader label={ translate( 'Backups and security scans' ) }>
 					{ hasAuthorized && (

--- a/client/my-sites/site-settings/jetpack-credentials/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/index.jsx
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { some } from 'lodash';
@@ -22,12 +23,16 @@ import { getSiteSlug } from 'state/sites/selectors';
 
 class JetpackCredentials extends Component {
 	render() {
-		const { credentials, rewindState, siteId, translate, siteSlug } = this.props;
+		const { blurred, credentials, rewindState, siteId, translate, siteSlug } = this.props;
 		const hasAuthorized = rewindState === 'provisioning' || rewindState === 'active';
 		const hasCredentials = some( credentials, { role: 'main' } );
 
+		const className = classNames( 'jetpack-credentials', {
+			'site-settings__blurred': blurred,
+		} );
+
 		return (
-			<div className="jetpack-credentials">
+			<div className={ className }>
 				<QueryRewindState siteId={ siteId } />
 				<SectionHeader label={ translate( 'Backups and security scans' ) }>
 					{ hasAuthorized && (

--- a/client/my-sites/site-settings/settings-security/controller.js
+++ b/client/my-sites/site-settings/settings-security/controller.js
@@ -13,7 +13,7 @@ import SecurityMain from 'my-sites/site-settings/settings-security/main';
 
 export default {
 	security( context, next ) {
-		context.primary = React.createElement( SecurityMain );
+		context.primary = <SecurityMain setting={ Object.keys( context.hash )[ 0 ] } />;
 		next();
 	},
 };

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { find } from 'lodash';
@@ -28,66 +28,64 @@ import Placeholder from 'my-sites/site-settings/placeholder';
 import JetpackCredentials from 'my-sites/site-settings/jetpack-credentials';
 import QueryRewindState from 'components/data/query-rewind-state';
 
-const SiteSettingsSecurity = ( {
-	showRewindCredentials,
-	site,
-	siteId,
-	siteIsJetpack,
-	translate,
-} ) => {
-	if ( ! site ) {
-		return <Placeholder />;
-	}
+class SiteSettingsSecurity extends PureComponent {
+	static propTypes = {
+		showRewindCredentials: PropTypes.bool,
+		site: PropTypes.object,
+		siteId: PropTypes.number,
+		siteIsJetpack: PropTypes.bool,
+	};
 
-	if ( ! siteIsJetpack ) {
+	render() {
+		const { showRewindCredentials, site, siteId, siteIsJetpack, translate } = this.props;
+
+		if ( ! site ) {
+			return <Placeholder />;
+		}
+
+		if ( ! siteIsJetpack ) {
+			return (
+				<JetpackManageErrorPage
+					action={ translate( 'Manage general settings for %(site)s', {
+						args: { site: site.name },
+					} ) }
+					actionURL={ '/settings/general/' + site.slug }
+					title={ translate( 'No security configuration is required.' ) }
+					line={ translate( 'Security management is automatic for WordPress.com sites.' ) }
+					illustration="/calypso/images/illustrations/illustration-jetpack.svg"
+				/>
+			);
+		}
+
+		if ( ! site.canManage ) {
+			return (
+				<JetpackManageErrorPage
+					template="optInManage"
+					title={ translate( "Looking to manage this site's security settings?" ) }
+					section="security-settings"
+					siteId={ siteId }
+				/>
+			);
+		}
+
+		if ( ! site.hasMinimumJetpackVersion ) {
+			return <JetpackManageErrorPage template="updateJetpack" siteId={ siteId } version="3.4" />;
+		}
+
 		return (
-			<JetpackManageErrorPage
-				action={ translate( 'Manage general settings for %(site)s', {
-					args: { site: site.name },
-				} ) }
-				actionURL={ '/settings/general/' + site.slug }
-				title={ translate( 'No security configuration is required.' ) }
-				line={ translate( 'Security management is automatic for WordPress.com sites.' ) }
-				illustration="/calypso/images/illustrations/illustration-jetpack.svg"
-			/>
+			<Main className="settings-security__main site-settings">
+				<QueryRewindState siteId={ siteId } />
+				<DocumentHead title={ translate( 'Site Settings' ) } />
+				<JetpackDevModeNotice />
+				<SidebarNavigation />
+				<SiteSettingsNavigation site={ site } section="security" />
+				{ showRewindCredentials && <JetpackCredentials /> }
+				<JetpackMonitor />
+				<FormSecurity />
+			</Main>
 		);
 	}
-
-	if ( ! site.canManage ) {
-		return (
-			<JetpackManageErrorPage
-				template="optInManage"
-				title={ translate( "Looking to manage this site's security settings?" ) }
-				section="security-settings"
-				siteId={ siteId }
-			/>
-		);
-	}
-
-	if ( ! site.hasMinimumJetpackVersion ) {
-		return <JetpackManageErrorPage template="updateJetpack" siteId={ siteId } version="3.4" />;
-	}
-
-	return (
-		<Main className="settings-security__main site-settings">
-			<QueryRewindState siteId={ siteId } />
-			<DocumentHead title={ translate( 'Site Settings' ) } />
-			<JetpackDevModeNotice />
-			<SidebarNavigation />
-			<SiteSettingsNavigation site={ site } section="security" />
-			{ showRewindCredentials && <JetpackCredentials /> }
-			<JetpackMonitor />
-			<FormSecurity />
-		</Main>
-	);
-};
-
-SiteSettingsSecurity.propTypes = {
-	showRewindCredentials: PropTypes.bool,
-	site: PropTypes.object,
-	siteId: PropTypes.number,
-	siteIsJetpack: PropTypes.bool,
-};
+}
 
 export default connect( state => {
 	const site = getSelectedSite( state );

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { find } from 'lodash';
+import { find, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,10 +30,17 @@ import QueryRewindState from 'components/data/query-rewind-state';
 
 class SiteSettingsSecurity extends PureComponent {
 	static propTypes = {
+		setting: PropTypes.string,
 		showRewindCredentials: PropTypes.bool,
 		site: PropTypes.object,
 		siteId: PropTypes.number,
 		siteIsJetpack: PropTypes.bool,
+	};
+
+	isActiveSetting = setting => {
+		const settings = [ 'jetpack-credentials', 'jetpack-monitor', 'security-settings' ];
+		// Fall back to active if the setting isn't known (so we don't blur it)
+		return setting === this.props.setting || ! includes( settings, this.props.setting );
 	};
 
 	render() {
@@ -79,9 +86,11 @@ class SiteSettingsSecurity extends PureComponent {
 				<JetpackDevModeNotice />
 				<SidebarNavigation />
 				<SiteSettingsNavigation site={ site } section="security" />
-				{ showRewindCredentials && <JetpackCredentials /> }
-				<JetpackMonitor />
-				<FormSecurity />
+				{ showRewindCredentials && (
+					<JetpackCredentials blurred={ ! this.isActiveSetting( 'jetpack-credentials' ) } />
+				) }
+				<JetpackMonitor blurred={ ! this.isActiveSetting( 'jetpack-monitor' ) } />
+				<FormSecurity blurred={ ! this.isActiveSetting( 'security-settings' ) } />
 			</Main>
 		);
 	}

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -38,7 +38,7 @@ class SiteSettingsSecurity extends PureComponent {
 	};
 
 	isActiveSetting = setting => {
-		const settings = [ 'jetpack-credentials', 'jetpack-monitor', 'security-settings' ];
+		const settings = [ 'jetpack-credentials', 'jetpack-monitor' ];
 		// Fall back to active if the setting isn't known (so we don't blur it)
 		return setting === this.props.setting || ! includes( settings, this.props.setting );
 	};
@@ -90,7 +90,7 @@ class SiteSettingsSecurity extends PureComponent {
 					<JetpackCredentials blurred={ ! this.isActiveSetting( 'jetpack-credentials' ) } />
 				) }
 				<JetpackMonitor blurred={ ! this.isActiveSetting( 'jetpack-monitor' ) } />
-				<FormSecurity blurred={ ! this.isActiveSetting( 'security-settings' ) } />
+				<FormSecurity />
 			</Main>
 		);
 	}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 .site-settings {
 	font-size: 14px;
 
@@ -27,13 +29,13 @@
 		margin-top: 24px; // Give labels some margin when they immediately follow a select
 	}
 
-	input[type="number"] {
+	input[type='number'] {
 		padding: 0;
 		width: 50px;
 		text-align: center;
 	}
 
-	input[type="text"] {
+	input[type='text'] {
 		-webkit-appearance: none;
 	}
 
@@ -47,10 +49,10 @@
 	legend + label,
 	label + label,
 	li label,
-	input[type="checkbox"] + label,
-	input[type="radio"] + label,
-	label input[type="checkbox"],
-	label input[type="radio"] {
+	input[type='checkbox'] + label,
+	input[type='radio'] + label,
+	label input[type='checkbox'],
+	label input[type='radio'] {
 		font-weight: normal;
 	}
 
@@ -126,7 +128,7 @@
 	}
 
 	.site-settings__blogaddress-settings {
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			display: flex;
 		}
 
@@ -135,7 +137,7 @@
 			margin-left: 0;
 			margin-top: 5px;
 
-			@include breakpoint( ">660px" ) {
+			@include breakpoint( '>660px' ) {
 				width: 45%;
 				margin-left: 16px;
 				margin-top: 0;
@@ -183,7 +185,7 @@
 	fieldset.site-icon-setting {
 		padding-bottom: 16px;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			flex: 0 0 122px;
 			order: 1;
 			margin-bottom: 0;
@@ -193,21 +195,21 @@
 	}
 
 	.site-icon-setting__heading {
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			justify-content: space-between;
 			white-space: nowrap;
 		}
 	}
 
 	.site-icon-setting__icon {
-		@include breakpoint( "<660px") {
+		@include breakpoint( '<660px') {
 			float: left;
 			margin-right: 8px;
 		}
 	}
 
 	.site-icon-setting__button {
-		@include breakpoint( "<660px") {
+		@include breakpoint( '<660px') {
 			display: block;
 			margin-bottom: 8px;
 		}
@@ -249,6 +251,11 @@
 		margin: 0 -24px 1.5em;
 	}
 }
+
+.site-settings__blurred {
+	filter: blur(2px);
+}
+
 .site-settings__general-settings .site-settings__language-picker-notice {
 	margin-bottom: 10px;
 }
@@ -298,7 +305,7 @@
 }
 
 .site-settings__site-options {
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		display: flex;
 	}
 
@@ -310,7 +317,7 @@
 }
 
 .site-settings__site-title-tagline {
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		flex: 0 1 100%;
 		order: 2;
 	}
@@ -326,24 +333,23 @@
 
 .site-settings__footer-credit-change {
 	width: 175px;
-	text-align:center;
+	text-align: center;
 	margin-left: 24px;
 }
 
 .site-settings__footer-credit-explanation {
-	display:flex;
+	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
 }
 .site-settings__footer-credit-explanation p {
-	margin: 0
+	margin: 0;
 }
-
 
 .writing-settings,
 .general-settings {
-	@include breakpoint( "<660px" ) {
-		select{
+	@include breakpoint( '<660px' ) {
+		select {
 			width: 100%;
 		}
 	}
@@ -358,7 +364,8 @@
 }
 
 // @TODO: Remove has-divider once all instances have been replaced with .site-settings__has-divider
-.has-divider, .site-settings__has-divider {
+.has-divider,
+.site-settings__has-divider {
 	margin: 0 -24px;
 	padding: 24px 24px 16px 24px;
 	border: 1px $gray-lighten-30 solid;
@@ -388,7 +395,8 @@
 	.foldable-card__header {
 		padding: 24px;
 
-		.gridicons-checkmark, .gridicons-notice-outline {
+		.gridicons-checkmark,
+		.gridicons-notice-outline {
 			margin-right: 4px;
 			vertical-align: bottom;
 		}


### PR DESCRIPTION
Broken out of #25416.

Also, point the Jetpack Checklist items for Jetpack Monitoring and Jetpack Credentials directly to the corresponding settings.

### Testing Instructions

(Preferably use a JP site for which you haven't set up backup credentials yet so that option will actually be visible.)

* Land at `calypso.localhost:3000/settings/security/<jpSite>` and verify that no setting is blurred, and that everything works as before.
* Land at `calypso.localhost:3000/settings/security/<jpSite>#jetpack-credentials` and verify that the 'Jetpack Monitor' setting is blurred.
* Land at `calypso.localhost:3000/settings/security/<jpSite>#jetpack-monitor` 
and verify that the 'Jetpack Credentials' setting is blurred.
* Land at `calypso.localhost:3000/settings/security/<jpSite>#foo` and verify that no setting is blurred for an invalid `#fragment`.
* Finally:
  * Land at `calypso.localhost:3000/checklist/<jpSite>`
  * Click the 'Do it!' button next to the 'Jetpack Monitor' item.
  * Verify that you land at `calypso.localhost:3000/settings/security/<jpSite>#jetpack-monitor`, i.e. with the JP Credentials setting blurred.
  * Do the same for the checklist's 'Jetpack credentials' item.

_Note that the settings below 'Downtime Monitoring' aren't blurred yet -- that's blocked by #25444, #25445, and #25448._

### Design(ish) Question

Do we want `jetpack` in the `#fragment` names? Or rather just `#uptime-monitor` and `#credentials`?

### Screenshots

`#jetpack-credentials`:

![image](https://user-images.githubusercontent.com/96308/41302518-f26e7674-6e6a-11e8-86e5-69afc76a4974.png)

`#jetpack-monitor`:

![image](https://user-images.githubusercontent.com/96308/41302534-ff8fabfc-6e6a-11e8-8879-04c5d1b0125a.png)

