### PR TITLE
Build: Use npm ci for install-if-* scripts

### DIFF
--- a/bin/install-if-deps-outdated.js
+++ b/bin/install-if-deps-outdated.js
@@ -24,7 +24,7 @@ const needsInstall = () => {
 };
 
 if ( needsInstall() ) {
-	const installResult = spawnSync( 'npm', [ 'install' ], {
+	const installResult = spawnSync( 'npm', [ 'ci' ], {
 		shell: true,
 		stdio: 'inherit',
 	} ).status;

--- a/bin/install-if-no-packages.js
+++ b/bin/install-if-no-packages.js
@@ -3,7 +3,7 @@ const fs = require( 'fs' );
 
 if ( ! fs.existsSync( 'node_modules' ) ) {
 	console.log( 'No "node_modules" present, installing dependencies...' );
-	const installResult = spawnSync( 'npm', [ 'install' ], {
+	const installResult = spawnSync( 'npm', [ 'ci' ], {
 		shell: true,
 		stdio: 'inherit',
 	} ).status;


### PR DESCRIPTION
`npm install` results in frequent updates to npm-shrinkwrap.json. Use
`npm ci` to avoid that and produce regular installs.

Package and shrinkwrap updates can continue to be produced with `npm run
update-deps`

I'm not sure if this is the best approach, but I have noticed that shrinkwrap is changed whenever I boot Calypso since the node/npm upgrade (#25374).

## Testing
1. Run `npm install`. Note that the shrinkwrap file is changed.
1. Undo the changes from above.
1. Run `npm run distclean && npm run install-if-no-packages`
1. Packages should be installed, note that shrinkwrap is unchanged.
1. Run `npm install-if-deps-outdated`. Nothing should be installed.