### PR TITLE
Refactor ellipsis-menu component style so it can be imported in WooCommerce Services

### DIFF
--- a/client/components/ellipsis-menu/style.scss
+++ b/client/components/ellipsis-menu/style.scss
@@ -1,7 +1,7 @@
 .gridicon.ellipsis-menu__toggle-icon {
 	transition: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
+}
 
-	.ellipsis-menu.is-menu-visible & {
-		transform: rotate( 90deg );
-	}
+.ellipsis-menu.is-menu-visible .gridicon.ellipsis-menu__toggle-icon {
+	transform: rotate( 90deg );
 }


### PR DESCRIPTION
In SASS, this code:
```css
.a {
    .b & {
        color: red;
    }
}
```

Is compiled into:
```css
.b .a {
    color: red;
}
```

But when a file containing that rule is imported into a parent context, like this:
```css
.root {
    @import("a-and-b.scss");
}
```

Then the result is:
```css
.b .root .a {
    color: red;
}
```

Which is normally not what's expected. Components in `WooCommerce Services` are styled in that way, so putting an `&` in any part other than the start of a rule breaks our styles.

This PR fixes that problem. The changes should make no difference in Calypso, but by avoiding the `&` at the end of the rule it will work in `Woocommerce Services`.