### PR TITLE
My Sites Stats: Make week label translatable

### DIFF
--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -189,8 +189,14 @@ export function getChartLabels( unit, date, localizedDate ) {
 		const isWeekend = 'day' === unit && ( 6 === dayOfWeek || 0 === dayOfWeek );
 		const labelName = `label${ unit.charAt( 0 ).toUpperCase() + unit.slice( 1 ) }`;
 		const formats = {
-			day: 'MMM D',
-			week: 'MMM D',
+			day: translate( 'MMM D', {
+				context: 'momentjs format string (day)',
+				comment: 'This specifies a day for the stats x-axis label.',
+			} ),
+			week: translate( 'MMM D', {
+				context: 'momentjs format string (week)',
+				comment: 'This specifies a week for the stats x-axis label.',
+			} ),
 			month: 'MMM',
 			year: 'YYYY',
 		};


### PR DESCRIPTION
In Site Stats, while the month name appears translated, it's currently not possible to change the sequence of month and day.

Old (example in German):
<img width="189" alt="screen shot 2018-06-12 at 22 56 21" src="https://user-images.githubusercontent.com/203408/41302159-ff15066c-6e93-11e8-9abc-a2b5f325de2f.png">

New:
<img width="261" alt="screen shot 2018-06-12 at 22 47 31" src="https://user-images.githubusercontent.com/203408/41302085-cb2b1a62-6e93-11e8-95e1-cdd82085895f.png">

See https://wpcomtranslation.wordpress.com/2018/06/12/i-we-have-some-problems/