### PR TITLE
Refine line chart

### DIFF
--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -10,7 +10,7 @@ import { line as d3Line, area as d3Area, curveMonotoneX as d3MonotoneXCurve } fr
 import { scaleLinear as d3ScaleLinear, scaleTime as d3TimeScale } from 'd3-scale';
 import { axisBottom as d3AxisBottom, axisRight as d3AxisRight } from 'd3-axis';
 import { select as d3Select, mouse as d3Mouse } from 'd3-selection';
-import { concat, first, last, mean, throttle } from 'lodash';
+import { concat, first, last, mean, throttle, uniq } from 'lodash';
 import { moment } from 'i18n-calypso';
 
 /**
@@ -441,8 +441,40 @@ class LineChart extends Component {
 		};
 	};
 
+	getTooltipPositionMap = values => {
+		const sortedUniqValues = uniq( values ).sort();
+
+		switch ( sortedUniqValues.length ) {
+			case 1:
+				return {
+					[ sortedUniqValues[ 0 ] ]: 'top',
+				};
+			case 2:
+				return {
+					[ sortedUniqValues[ 0 ] ]: 'bottom',
+					[ sortedUniqValues[ 1 ] ]: 'top',
+				};
+			case 3:
+				return {
+					[ sortedUniqValues[ 0 ] ]: 'bottom',
+					[ sortedUniqValues[ 1 ] ]: 'left',
+					[ sortedUniqValues[ 2 ] ]: 'top',
+				};
+			default:
+				return {
+					[ sortedUniqValues[ 0 ] ]: 'bottom',
+					[ sortedUniqValues[ 1 ] ]: 'left',
+					[ sortedUniqValues[ 2 ] ]: 'right',
+					[ sortedUniqValues[ 3 ] ]: 'bottom',
+				};
+		}
+	};
+
 	renderTooltips = () => {
 		const { selectedPoints } = this.state;
+		const selectPointsValues = selectedPoints.map( point => d3Select( point ).datum().value );
+		const tooltipPositionsMap = this.getTooltipPositionMap( selectPointsValues );
+
 		return selectedPoints.map( point => {
 			const pointData = d3Select( point ).datum();
 
@@ -456,7 +488,7 @@ class LineChart extends Component {
 				<Tooltip
 					className="line-chart__tooltip is-streak"
 					context={ point }
-					position="top"
+					position={ tooltipPositionsMap[ pointData.value ] }
 					key={ uniqueKey }
 					isVisible
 				>

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -23,6 +23,7 @@ import LineChartLegend from './legend';
 const CHART_MARGIN = 0.01;
 const POINTS_MAX = 10;
 const POINTS_SIZE = 3;
+const POINT_HIGHLIGHT_SIZE_FACTOR = 1.5;
 const POINTS_END_SIZE = 1;
 const X_AXIS_TICKS_MAX = 8;
 const X_AXIS_TICKS_SPACE = 70;
@@ -300,7 +301,7 @@ class LineChart extends Component {
 				const selectedPoints = svg.selectAll(
 					`circle.line-chart__line-point[cx="${ xScale( closestDate ) }"]`
 				);
-				selectedPoints.attr( 'r', Math.floor( POINTS_SIZE * 1.5 ) );
+				selectedPoints.attr( 'r', Math.floor( POINTS_SIZE * POINT_HIGHLIGHT_SIZE_FACTOR ) );
 				this.setState( { selectedPoints: selectedPoints.nodes() } );
 			} else {
 				svg.selectAll( 'circle.line-chart__line-point-hover' ).remove();
@@ -318,7 +319,7 @@ class LineChart extends Component {
 								)
 								.attr( 'cx', xScale( datum.date ) )
 								.attr( 'cy', yScale( datum.value ) )
-								.attr( 'r', Math.floor( POINTS_SIZE * 1.5 ) )
+								.attr( 'r', Math.floor( POINTS_SIZE * POINT_HIGHLIGHT_SIZE_FACTOR ) )
 								.datum( { ...datum, dataSeriesIndex } );
 							circles = circles.concat( circleSelection.nodes() );
 						}
@@ -418,7 +419,7 @@ class LineChart extends Component {
 				const selectedPoints = svg.selectAll(
 					`circle.line-chart__line-point-color-${ dataSeriesIndex }`
 				);
-				selectedPoints.attr( 'r', Math.floor( POINTS_SIZE * 1.5 ) );
+				selectedPoints.attr( 'r', Math.floor( POINTS_SIZE * POINT_HIGHLIGHT_SIZE_FACTOR ) );
 				this.setState( { selectedPoints: selectedPoints.nodes() } );
 			}
 		} );

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -473,7 +473,7 @@ class LineChart extends Component {
 	};
 
 	renderTooltips = () => {
-		const { selectedPoints } = this.state;
+		const { selectedPoints, data } = this.state;
 		const selectPointsValues = selectedPoints.map( point => d3Select( point ).datum().value );
 		const tooltipPositionsMap = this.getTooltipPositionMap( selectPointsValues );
 
@@ -494,7 +494,7 @@ class LineChart extends Component {
 					key={ uniqueKey }
 					isVisible
 				>
-					{ this.props.renderTooltipForDatanum( pointData ) }
+					{ this.props.renderTooltipForDatanum( pointData, data[ pointData.dataSeriesIndex ] ) }
 				</Tooltip>
 			);
 		} );

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -442,7 +442,9 @@ class LineChart extends Component {
 	};
 
 	getTooltipPositionMap = values => {
-		const sortedUniqValues = uniq( values ).sort();
+		const sortedUniqValues = uniq( values ).sort(
+			( leftValue, rightValue ) => leftValue - rightValue
+		);
 
 		switch ( sortedUniqValues.length ) {
 			case 1:
@@ -465,7 +467,7 @@ class LineChart extends Component {
 					[ sortedUniqValues[ 0 ] ]: 'bottom',
 					[ sortedUniqValues[ 1 ] ]: 'left',
 					[ sortedUniqValues[ 2 ] ]: 'right',
-					[ sortedUniqValues[ 3 ] ]: 'bottom',
+					[ sortedUniqValues[ 3 ] ]: 'top',
 				};
 		}
 	};

--- a/client/components/line-chart/style.scss
+++ b/client/components/line-chart/style.scss
@@ -158,3 +158,9 @@
 .line-chart__legend-sample-2-fill {
 	fill: $blue-light;
 }
+
+
+.line-chart__date-range-selected {
+	fill: $blue-medium;
+	opacity: 0.1;
+}

--- a/client/components/line-chart/style.scss
+++ b/client/components/line-chart/style.scss
@@ -153,8 +153,11 @@
 	fill: $blue-light;
 }
 
-
 .line-chart__date-range-selected {
 	fill: $blue-medium;
 	opacity: 0.1;
+}
+
+.line-chart__tooltip {
+	pointer-events: none;
 }

--- a/client/components/line-chart/style.scss
+++ b/client/components/line-chart/style.scss
@@ -1,3 +1,7 @@
+.line-chart__base {
+	cursor: pointer;
+}
+
 .line-chart__line-color-0 {
 	fill: none;
 	stroke: $blue-dark;
@@ -20,6 +24,10 @@
 	stroke-width: 5px;
 }
 
+.line-chart__line-not-selected, .line-chart__area-not-selected {
+	opacity: 0.5;
+}
+
 .line-chart__area-color-0 {
 	fill: $blue-dark;
 	opacity: 0.6;
@@ -39,20 +47,6 @@
 	cursor: pointer;
 	fill: $white;
 	stroke-width: 3px;
-}
-
-.line-chart__area-selected {
-	&.line-chart__area-color-0 {
-		opacity: 0.8;
-	}
-
-	&.line-chart__area-color-1 {
-		opacity: 0.5;
-	}
-
-	&.line-chart__area-color-2 {
-		opacity: 0.3;
-	}
 }
 
 .line-chart__line-point-color-0 {

--- a/client/my-sites/google-my-business/stats/chart.js
+++ b/client/my-sites/google-my-business/stats/chart.js
@@ -186,7 +186,7 @@ class GoogleMyBusinessStatsChart extends Component {
 	}
 
 	renderLineChart() {
-		const { renderTooltipForDatanum } = this.props;
+		const { interval, renderTooltipForDatanum } = this.props;
 		const { transformedData, legendInfo } = this.state;
 
 		if ( ! transformedData ) {
@@ -199,7 +199,9 @@ class GoogleMyBusinessStatsChart extends Component {
 					<LineChart
 						fillArea
 						data={ transformedData }
-						renderTooltipForDatanum={ renderTooltipForDatanum }
+						renderTooltipForDatanum={
+							renderTooltipForDatanum ? renderTooltipForDatanum( interval ) : undefined
+						}
 						legendInfo={ legendInfo }
 					/>
 

--- a/client/my-sites/google-my-business/stats/chart.js
+++ b/client/my-sites/google-my-business/stats/chart.js
@@ -186,7 +186,7 @@ class GoogleMyBusinessStatsChart extends Component {
 	}
 
 	renderLineChart() {
-		const { interval, renderTooltipForDatanum } = this.props;
+		const { renderTooltipForDatanum } = this.props;
 		const { transformedData, legendInfo } = this.state;
 
 		if ( ! transformedData ) {
@@ -199,9 +199,7 @@ class GoogleMyBusinessStatsChart extends Component {
 					<LineChart
 						fillArea
 						data={ transformedData }
-						renderTooltipForDatanum={
-							renderTooltipForDatanum ? renderTooltipForDatanum( interval ) : undefined
-						}
+						renderTooltipForDatanum={ renderTooltipForDatanum }
 						legendInfo={ legendInfo }
 					/>
 

--- a/client/my-sites/google-my-business/stats/chart.js
+++ b/client/my-sites/google-my-business/stats/chart.js
@@ -50,8 +50,14 @@ function transformData( props ) {
 
 	return data.metricValues.map( metric => {
 		return metric.dimensionalValues.map( datum => {
+			const datumDate = new Date( datum.time );
+			/* lock date to midnight for all values to better align with ticks */
+			datumDate.setHours( 0 );
+			datumDate.setMinutes( 0 );
+			datumDate.setSeconds( 0 );
+			datumDate.setMilliseconds( 0 );
 			return {
-				date: Date.parse( datum.time ),
+				date: datumDate.getTime(),
 				value: datum.value || 0,
 			};
 		} );

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -66,32 +66,32 @@ class GoogleMyBusinessStats extends Component {
 		} );
 	};
 
-	renderSearchTooltipForDatanum = datanum => {
-		const { value: searchCount, date } = datanum;
-		return this.props.translate(
-			'%(searches)d search on %(day)s',
-			'%(searches)d searches on %(day)s',
-			{
-				count: searchCount,
-				args: {
-					searches: searchCount,
-					day: moment( date ).format( 'D MMMM YYYY' ),
-				},
-				comment: 'How many searches per day for a Google My Business location.',
-			}
-		);
-	};
-
-	renderViewsOrActionsTooltipForDatanum = interval => datanum => {
+	renderViewsTooltipForDatanum = ( datanum, dataSeries ) => {
 		const { value: valueCount, date } = datanum;
-		if ( 'week' !== interval ) {
-			return this.props.translate( '%(value)d on %(day)s', '%(value)d on %(day)s', {
+		if ( dataSeries.length > 20 ) {
+			return this.props.translate( '%(value)d view on %(day)s', '%(value)d views on %(day)s', {
 				count: valueCount,
 				args: {
 					value: valueCount,
 					day: moment( date ).format( 'D MMMM YYYY' ),
 				},
-				comment: 'How many views or actions per day for a Google My Business location with date.',
+				comment: 'How many views per day for a Google My Business location with date.',
+			} );
+		}
+
+		return valueCount;
+	};
+
+	renderActionsTooltipForDatanum = ( datanum, dataSeries ) => {
+		const { value: valueCount, date } = datanum;
+		if ( dataSeries.length > 20 ) {
+			return this.props.translate( '%(value)d action on %(day)s', '%(value)d actions on %(day)s', {
+				count: valueCount,
+				args: {
+					value: valueCount,
+					day: moment( date ).format( 'D MMMM YYYY' ),
+				},
+				comment: 'How many actions per day for a Google My Business location with date.',
 			} );
 		}
 
@@ -127,7 +127,6 @@ class GoogleMyBusinessStats extends Component {
 								),
 							},
 						} }
-						renderTooltipForDatanum={ this.renderSearchTooltipForDatanum }
 					/>
 				</div>
 
@@ -147,7 +146,7 @@ class GoogleMyBusinessStats extends Component {
 								name: translate( 'Listings On Search' ),
 							},
 						} }
-						renderTooltipForDatanum={ this.renderViewsOrActionsTooltipForDatanum }
+						renderTooltipForDatanum={ this.renderViewsTooltipForDatanum }
 					/>
 				</div>
 
@@ -170,7 +169,7 @@ class GoogleMyBusinessStats extends Component {
 								name: translate( 'Call You' ),
 							},
 						} }
-						renderTooltipForDatanum={ this.renderViewsOrActionsTooltipForDatanum }
+						renderTooltipForDatanum={ this.renderActionsTooltipForDatanum }
 					/>
 				</div>
 			</div>

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -82,6 +82,22 @@ class GoogleMyBusinessStats extends Component {
 		);
 	};
 
+	renderViewsOrActionsTooltipForDatanum = interval => datanum => {
+		const { value: valueCount, date } = datanum;
+		if ( 'week' !== interval ) {
+			return this.props.translate( '%(value)d on %(day)s', '%(value)d on %(day)s', {
+				count: valueCount,
+				args: {
+					value: valueCount,
+					day: moment( date ).format( 'D MMMM YYYY' ),
+				},
+				comment: 'How many views or actions per day for a Google My Business location with date.',
+			} );
+		}
+
+		return valueCount;
+	};
+
 	renderStats() {
 		const { siteId, translate } = this.props;
 
@@ -131,6 +147,7 @@ class GoogleMyBusinessStats extends Component {
 								name: translate( 'Listings On Search' ),
 							},
 						} }
+						renderTooltipForDatanum={ this.renderViewsOrActionsTooltipForDatanum }
 					/>
 				</div>
 
@@ -153,6 +170,7 @@ class GoogleMyBusinessStats extends Component {
 								name: translate( 'Call You' ),
 							},
 						} }
+						renderTooltipForDatanum={ this.renderViewsOrActionsTooltipForDatanum }
 					/>
 				</div>
 			</div>


### PR DESCRIPTION
## Specs

This is a set of improvements for the line chart component. This should both make getting tooltips on a line chart easier.
<img width="1065" alt="screen shot 2018-06-15 at 4 17 11 pm" src="https://user-images.githubusercontent.com/2810519/41492963-982b7dfc-70b7-11e8-9b20-a7089bcc4e95.png">

<img width="1065" alt="screen shot 2018-06-15 at 4 16 34 pm" src="https://user-images.githubusercontent.com/2810519/41492953-84683d50-70b7-11e8-903f-78b74de967b4.png">

## Testing
1. Navigate to the LineChart DevDocs on a [local](http://calypso.localhost:3000/devdocs/design/line-chart) or live branch.
2. Verify the extra highlighting on line chart mouseover.
3. Verify that the top line tooltip is drawn on top, the middle is drawn to the left, and the bottom is on the bottom.
4. Navigate to a Google My Business stats page.
5. Verify that only values are shown on highlight for the views and actions charts when the interval is set to `week`.
6. Verify that when the chart interval is set to `month` or `quarter` the date is also displayed in the tooltip.
