### PR TITLE
Build: Let thread-loader use as many cores as it wants

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,7 @@ const StatsWriter = require( './server/bundler/stats-writer' );
 const prism = require( 'prismjs' );
 const UglifyJsPlugin = require( 'uglifyjs-webpack-plugin' );
 const CircularDependencyPlugin = require( 'circular-dependency-plugin' );
+const threadLoader = require( 'thread-loader' );
 
 /**
  * Internal dependencies
@@ -69,6 +70,8 @@ const babelLoader = {
 	},
 };
 
+threadLoader.warmup( {}, [ 'babel-loader' ] );
+
 const webpackConfig = {
 	bail: ! isDevelopment,
 	entry: { build: [ path.join( __dirname, 'client', 'boot', 'app' ) ] },
@@ -120,13 +123,7 @@ const webpackConfig = {
 			{
 				test: /\.jsx?$/,
 				exclude: /node_modules[\/\\](?!notifications-panel)/,
-				use: _.compact( [
-					{
-						loader: 'thread-loader',
-						options: { workers: 3 },
-					},
-					babelLoader,
-				] ),
+				use: _.compact( [ 'thread-loader', babelLoader ] ),
 			},
 			{
 				test: /node_modules[\/\\](redux-form|react-redux)[\/\\]es/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -123,7 +123,7 @@ const webpackConfig = {
 			{
 				test: /\.jsx?$/,
 				exclude: /node_modules[\/\\](?!notifications-panel)/,
-				use: _.compact( [ 'thread-loader', babelLoader ] ),
+				use: [ 'thread-loader', babelLoader ],
 			},
 			{
 				test: /node_modules[\/\\](redux-form|react-redux)[\/\\]es/,

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -11,6 +11,7 @@ const fs = require( 'fs' );
 const path = require( 'path' );
 const webpack = require( 'webpack' );
 const _ = require( 'lodash' );
+const threadLoader = require( 'thread-loader' );
 
 /**
  * Internal dependencies
@@ -37,7 +38,8 @@ function getExternals() {
 
 	// Don't bundle any node_modules, both to avoid a massive bundle, and problems
 	// with modules that are incompatible with webpack bundling.
-	fs.readdirSync( 'node_modules' )
+	fs
+		.readdirSync( 'node_modules' )
 		.filter( function( module ) {
 			return [ '.bin' ].indexOf( module ) === -1;
 		} )
@@ -74,6 +76,8 @@ const babelLoader = {
 	},
 };
 
+threadLoader.warmup( {}, [ 'babel-loader' ] );
+
 const webpackConfig = {
 	devtool: 'source-map',
 	entry: './index.js',
@@ -101,13 +105,7 @@ const webpackConfig = {
 			{
 				test: /\.jsx?$/,
 				exclude: /(node_modules|devdocs[\/\\]search-index)/,
-				use: [
-					{
-						loader: 'thread-loader',
-						options: { workers: 3 },
-					},
-					babelLoader,
-				],
+				use: [ 'thread-loader', babelLoader ],
 			},
 			{
 				test: /node_modules[\/\\](redux-form|react-redux)[\/\\]es/,


### PR DESCRIPTION
Should make builds on high multicore hardware faster.

By default, thread-loader [spins up a worker for each cpu](https://github.com/webpack-contrib/thread-loader#examples) on the host machine. We were forcing it to 3 workers, no matter the number of CPUs. 

This should let us experiment with using more cores when building production images to make that faster, if we need to make it faster. It should also take better advantage on dev laptops, which are usually 8 or 16 core.