### PR TITLE
CloneCredentials - fixed spacing issue

### DIFF
--- a/client/signup/steps/clone-credentials/style.scss
+++ b/client/signup/steps/clone-credentials/style.scss
@@ -2,7 +2,3 @@
 	max-width: 720px;
 	margin: 0 auto;
 }
-
-.clone-credentials__form .form-fieldset:last-child {
-	margin-bottom: 0;
-}

--- a/client/signup/steps/clone-credentials/style.scss
+++ b/client/signup/steps/clone-credentials/style.scss
@@ -2,3 +2,9 @@
 	max-width: 720px;
 	margin: 0 auto;
 }
+
+.clone-credentials__form {
+	.form-fieldset {
+		margin-bottom: 24px;
+	}
+}


### PR DESCRIPTION
There shouldn't be any change on wider views, but on the smaller screens you'll see the spacing fix.

#### Before
![image](https://user-images.githubusercontent.com/1123119/41315744-a7e9c29c-6e4d-11e8-99e4-92307303754f.png)

#### After
![image](https://user-images.githubusercontent.com/1123119/41315439-bc9358ee-6e4c-11e8-8a5c-54ffb9360798.png)
 