### PR TITLE
 Podcasting: show link on writing form for atomic sites

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -70,6 +70,7 @@ class SiteSettingsFormWriting extends Component {
 			handleAutosavingToggle,
 			handleAutosavingRadio,
 			handleSubmitForm,
+			isPodcastingSupported,
 			isMasterbarSectionVisible,
 			isRequestingSettings,
 			isSavingSettings,
@@ -169,7 +170,7 @@ class SiteSettingsFormWriting extends Component {
 					onChangeField={ onChangeField }
 				/>
 
-				{ ! siteIsJetpack &&
+				{ isPodcastingSupported &&
 					config.isEnabled( 'manage/site-settings/podcasting' ) && (
 						<PodcastingLink fields={ fields } />
 					) }
@@ -219,6 +220,8 @@ const connectComponent = connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
 		const siteIsJetpack = isJetpackSite( state, siteId );
+		const siteIsAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
+		const isPodcastingSupported = ! siteIsJetpack || siteIsAutomatedTransfer;
 
 		return {
 			jetpackSettingsUISupported: siteSupportsJetpackSettingsUi( state, siteId ),
@@ -229,7 +232,8 @@ const connectComponent = connect(
 				siteIsJetpack &&
 				isJetpackMinimumVersion( state, siteId, '4.8' ) &&
 				// Masterbar can't be turned off on Atomic sites - don't show the toggle in that case
-				! isSiteAutomatedTransfer( state, siteId ),
+				! siteIsAutomatedTransfer,
+			isPodcastingSupported,
 		};
 	},
 	{ requestPostTypes },

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -16,6 +16,7 @@ import Button from 'components/button';
 import Card from 'components/card';
 import ClipboardButtonInput from 'components/clipboard-button-input';
 import DocumentHead from 'components/data/document-head';
+import EmptyContent from 'components/empty-content';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormInput from 'components/forms/form-text-input';
 import { decodeEntities } from 'lib/formatting';
@@ -34,6 +35,8 @@ import podcastingTopics from './topics';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import isPrivateSite from 'state/selectors/is-private-site';
 import canCurrentUser from 'state/selectors/can-current-user';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'state/sites/selectors';
 import {
 	isRequestingTermsForQueryIgnoringPage,
 	getTermsForQueryIgnoringPage,
@@ -175,9 +178,25 @@ class PodcastingDetails extends Component {
 	}
 
 	render() {
-		const { handleSubmitForm, siteSlug, siteId, translate, isPodcastingEnabled } = this.props;
+		const {
+			handleSubmitForm,
+			siteSlug,
+			siteId,
+			translate,
+			isPodcastingEnabled,
+			isUnsupportedSite,
+		} = this.props;
 		if ( ! siteId ) {
 			return null;
+		}
+
+		if ( isUnsupportedSite ) {
+			return (
+				<EmptyContent
+					illustration={ '/calypso/images/illustrations/illustration-nosites.svg' }
+					title={ translate( 'Podcasting settings are not supported on this site.' ) }
+				/>
+			);
 		}
 
 		const error = this.renderSettingsError();
@@ -372,6 +391,9 @@ const connectComponent = connect( ( state, ownProps ) => {
 	const selectedCategory = categories && head( filter( categories, { ID: podcastingCategoryId } ) );
 	const podcastingFeedUrl = selectedCategory && selectedCategory.feed_url;
 
+	const isJetpack = isJetpackSite( state, siteId );
+	const isAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
+
 	return {
 		siteId,
 		siteSlug: getSelectedSiteSlug( state ),
@@ -381,6 +403,7 @@ const connectComponent = connect( ( state, ownProps ) => {
 		isRequestingCategories: isRequestingTermsForQueryIgnoringPage( state, siteId, 'category', {} ),
 		podcastingFeedUrl,
 		userCanManagePodcasting: canCurrentUser( state, siteId, 'manage_options' ),
+		isUnsupportedSite: isJetpack && ! isAutomatedTransfer,
 	};
 } );
 

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -16,7 +16,6 @@ import Button from 'components/button';
 import Card from 'components/card';
 import ClipboardButtonInput from 'components/clipboard-button-input';
 import DocumentHead from 'components/data/document-head';
-import EmptyContent from 'components/empty-content';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormInput from 'components/forms/form-text-input';
 import { decodeEntities } from 'lib/formatting';
@@ -30,6 +29,7 @@ import TermTreeSelector from 'blocks/term-tree-selector';
 import PodcastCoverImageSetting from 'my-sites/site-settings/podcast-cover-image-setting';
 import PodcastingPrivateSiteMessage from './private-site';
 import PodcastingNoPermissionsMessage from './no-permissions';
+import PodcastingNotSupportedMessage from './not-supported';
 import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
 import podcastingTopics from './topics';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -178,25 +178,9 @@ class PodcastingDetails extends Component {
 	}
 
 	render() {
-		const {
-			handleSubmitForm,
-			siteSlug,
-			siteId,
-			translate,
-			isPodcastingEnabled,
-			isUnsupportedSite,
-		} = this.props;
+		const { handleSubmitForm, siteSlug, siteId, translate, isPodcastingEnabled } = this.props;
 		if ( ! siteId ) {
 			return null;
-		}
-
-		if ( isUnsupportedSite ) {
-			return (
-				<EmptyContent
-					illustration={ '/calypso/images/illustrations/illustration-nosites.svg' }
-					title={ translate( 'Podcasting settings are not supported on this site.' ) }
-				/>
-			);
 		}
 
 		const error = this.renderSettingsError();
@@ -304,7 +288,7 @@ class PodcastingDetails extends Component {
 	renderSettingsError() {
 		// If there is a reason that we can't display the podcasting settings
 		// screen, it will be rendered here.
-		const { isPrivate, userCanManagePodcasting } = this.props;
+		const { isPrivate, isUnsupportedSite, userCanManagePodcasting } = this.props;
 
 		if ( isPrivate ) {
 			return <PodcastingPrivateSiteMessage />;
@@ -312,6 +296,10 @@ class PodcastingDetails extends Component {
 
 		if ( ! userCanManagePodcasting ) {
 			return <PodcastingNoPermissionsMessage />;
+		}
+
+		if ( isUnsupportedSite ) {
+			return <PodcastingNotSupportedMessage />;
 		}
 
 		return null;

--- a/client/my-sites/site-settings/podcasting-details/not-supported.jsx
+++ b/client/my-sites/site-settings/podcasting-details/not-supported.jsx
@@ -1,0 +1,25 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import EmptyContent from 'components/empty-content';
+
+function PodcastingNotSupportedMessage( { translate } ) {
+	return (
+		<div className="podcasting-details__not-supported">
+			<EmptyContent
+				illustration={ '/calypso/images/illustrations/illustration-nosites.svg' }
+				title={ translate( 'Management of podcast settings are not supported on this site.' ) }
+			/>
+		</div>
+	);
+}
+
+export default localize( PodcastingNotSupportedMessage );


### PR DESCRIPTION
This PR updates the link to the podcasting settings page such that it's displayed only when settings are supported (for simple and atomic sites), and shows a message in the event of direct navigation to the settings page for unsupported sites (non-atomic Jetpack).

![image](https://user-images.githubusercontent.com/363749/41433450-a5056b34-6fde-11e8-8aba-96bbdb406689.png)


To test:
* Run the branch with `manage/site-settings/podcasting` feature flag enabled (enabled by default in development)
* Visit site-settings > writing using a simple site. Verify that the link to podcasting settings appears beneath feed settings.
* Visit site-settings > writing using an atomic site. Verify that the link to podcasting settings appears beneath feed settings.
* Visit site-settings > writing using a non-atomic Jetpack site. Verify that the link to podcasting settings does NOT appear beneath feed settings.
* Visit site-settings > writing > podcasting for one of the sites for which the link appears (simple or atomic).
* Using the site-switcher, switch to a non-atomic Jetpack site. Verify that the message appears informing you podcasting settings aren't supported for the site.