### PR TITLE
Update notifications to 2.2.0-alpha.1 to test a build

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8212,13 +8212,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8231,18 +8229,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8345,8 +8340,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8356,7 +8350,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8369,20 +8362,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -8399,7 +8389,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8472,8 +8461,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8483,7 +8471,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8589,7 +8576,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -14272,9 +14258,9 @@
       "dev": true
     },
     "notifications-panel": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/notifications-panel/-/notifications-panel-2.1.10.tgz",
-      "integrity": "sha512-lGQocN7VDL5aue1SMwLifFe88UT1zqcLJ6v0x+QtL3Ws5yYfLC3sM+qaHVGrRdqFh3GZsc4PG4gzt+oGZgX+7Q=="
+      "version": "2.2.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/notifications-panel/-/notifications-panel-2.2.0-alpha.1.tgz",
+      "integrity": "sha512-pPwfLHJb1ov1NVvsDDHg0d8olnflMNVHtDG8WdCVBtVL/gU/VImNSySM7Z1HECY0y6Kfqps1/QVoOVvpheH1kg=="
     },
     "npm-run-all": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "morgan": "1.2.0",
     "ms": "0.7.1",
     "node-sass": "4.9.0",
-    "notifications-panel": "2.1.10",
+    "notifications-panel": "2.2.0-alpha.1",
     "npm-run-all": "4.0.2",
     "object-path-immutable": "0.5.2",
     "objectpath": "1.2.1",


### PR DESCRIPTION
DO NOT MERGE. Used to test a Node version bump and developer dependency changes in https://github.com/Automattic/notifications-panel/pull/280