### PR TITLE
Prettier: Add pragma where missing

### DIFF
--- a/client/devdocs/design/component-examples.js
+++ b/client/devdocs/design/component-examples.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal dependencies
  */

--- a/client/my-sites/importer/site-importer/site-preview-actions.js
+++ b/client/my-sites/importer/site-importer/site-preview-actions.js
@@ -1,10 +1,11 @@
+/** @format */
 /**
  * External dependencies
  */
 import request from 'superagent';
 import { noop } from 'lodash';
 
-const querymShotsEndpoint = ( options ) => {
+const querymShotsEndpoint = options => {
 	const maxRetries = options.maxRetries || 1;
 	const retryTimeout = options.retryTimeout || 1000;
 	const currentRetries = options.currentRetries || 0;
@@ -13,7 +14,7 @@ const querymShotsEndpoint = ( options ) => {
 	const resolve = options.resolve || noop;
 	const reject = options.reject || noop;
 
-	const mShotsEndpointUrl = `https://s0.wp.com/mshots/v1/${url}`;
+	const mShotsEndpointUrl = `https://s0.wp.com/mshots/v1/${ url }`;
 
 	if ( ! url ) {
 		// TODO translate
@@ -31,21 +32,21 @@ const querymShotsEndpoint = ( options ) => {
 				currentRetries < maxRetries
 			) {
 				// Still generating the preview or something failed in mShots
-				setTimeout( querymShotsEndpoint.bind( this, {
-					...options,
-					currentRetries: currentRetries + 1
-				} ), retryTimeout );
-			}
-			else if ( res.type === 'image/jpeg' ) {
+				setTimeout(
+					querymShotsEndpoint.bind( this, {
+						...options,
+						currentRetries: currentRetries + 1,
+					} ),
+					retryTimeout
+				);
+			} else if ( res.type === 'image/jpeg' ) {
 				// Successfully generated the preview
 				try {
 					resolve( window.URL.createObjectURL( res.xhr.response ) );
-				}
-				catch ( e ) {
+				} catch ( e ) {
 					resolve( mShotsEndpointUrl );
 				}
-			}
-			else {
+			} else {
 				reject();
 			}
 		} )

--- a/client/state/connected-applications/schema.js
+++ b/client/state/connected-applications/schema.js
@@ -1,3 +1,4 @@
+/** @format */
 export default {
 	type: 'array',
 	items: {
@@ -35,7 +36,8 @@ export default {
 						},
 						required: [ 'site_ID', 'site_URL', 'site_name' ],
 						additionalProperties: false,
-					} ],
+					},
+				],
 			},
 			title: { type: 'string' },
 		},

--- a/client/state/countries/actions.js
+++ b/client/state/countries/actions.js
@@ -1,10 +1,11 @@
+/** @format */
 /**
  * Internal dependencies
  */
 import {
 	COUNTRIES_DOMAINS_FETCH,
 	COUNTRIES_PAYMENTS_FETCH,
-	COUNTRIES_SMS_FETCH
+	COUNTRIES_SMS_FETCH,
 } from 'state/action-types';
 
 export const fetchDomainCountries = () => ( { type: COUNTRIES_DOMAINS_FETCH } );

--- a/client/state/reader/posts/sizes.js
+++ b/client/state/reader/posts/sizes.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Module vars
  */

--- a/client/state/selectors/test/get-raw-site.js
+++ b/client/state/selectors/test/get-raw-site.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal dependencies
  */


### PR DESCRIPTION
Add `/** @format */` pragma where missing so prettier operates on more files.

Also [removes `client/layout/community-translator/invitation-utils.js`](https://github.com/Automattic/wp-calypso/pull/25471/files#diff-15deff49674d203c72e2edf5f14efdec) , an empty file spotted when searching for no-pragma files.