### PR TITLE
Make sure user keyring connections are loaded on stats

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -34,6 +34,7 @@ import { recordGoogleEvent } from 'state/analytics/actions';
 import PrivacyPolicyBanner from 'blocks/privacy-policy-banner';
 import ChecklistBanner from './checklist-banner';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
+import QueryKeyringConnections from 'components/data/query-keyring-connections';
 import GoogleMyBusinessStatsNudge from 'blocks/google-my-business-stats-nudge';
 import isGoogleMyBusinessStatsNudgeVisibleSelector from 'state/selectors/is-google-my-business-stats-nudge-visible';
 
@@ -135,6 +136,7 @@ class StatsSite extends Component {
 
 		return (
 			<Main wideLayout={ true }>
+				<QueryKeyringConnections />
 				{ siteId && <QuerySiteKeyrings siteId={ siteId } /> }
 				<DocumentHead title={ translate( 'Stats' ) } />
 				<PageViewTracker


### PR DESCRIPTION
This is a follow up of https://github.com/Automattic/wp-calypso/pull/25415

In some cases, (I believe it happens when `my-sites/stats/site.jsx` loads with an empty `siteId`), the keyrings are cleared and the Google My Business tab won't show up.

This fixes it.

### Testing Instructions
- Go to /stats/:site for a site that is already connected with GMB
- Refresh the page multiple times
- The Google My Business tab should show up for all refresh (may take a second or 2 to show up)

### Reviews
- [ ] Code
- [ ] Product