### PR TITLE
Purchases: Manage for disconnected sites

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -3,15 +3,21 @@
 /**
  * External dependencies
  */
-
-import { find, includes } from 'lodash';
-import moment from 'moment';
 import i18n from 'i18n-calypso';
+import moment from 'moment';
+import { includes, find, overSome } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { isDomainRegistration, isDomainTransfer, isPlan, isTheme } from 'lib/products-values';
+import {
+	isDomainMapping,
+	isDomainRegistration,
+	isDomainTransfer,
+	isPlan,
+	isSiteRedirect,
+	isTheme,
+} from 'lib/products-values';
 
 function getIncludedDomain( purchase ) {
 	return purchase.includedDomain;
@@ -172,13 +178,20 @@ function isRemovable( purchase ) {
 		return false;
 	}
 
-	return (
-		isExpiring( purchase ) ||
-		isExpired( purchase ) ||
-		( isDomainTransfer( purchase ) &&
-			! isRefundable( purchase ) &&
-			isPurchaseCancelable( purchase ) )
-	);
+	// Disallow removal of non-expired or non-expiring purchases of these types
+	if ( overSome( isDomainMapping, isDomainRegistration, isSiteRedirect )( purchase ) ) {
+		return isExpired( purchase ) || isExpiring( purchase );
+	}
+
+	if ( isDomainTransfer( purchase ) ) {
+		return (
+			isExpired( purchase ) ||
+			isExpiring( purchase ) ||
+			( ! isRefundable( purchase ) && isPurchaseCancelable( purchase ) )
+		);
+	}
+
+	return true;
 }
 
 /**

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -3,21 +3,15 @@
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
+
+import { find, includes } from 'lodash';
 import moment from 'moment';
-import { includes, find, overSome } from 'lodash';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import {
-	isDomainMapping,
-	isDomainRegistration,
-	isDomainTransfer,
-	isPlan,
-	isSiteRedirect,
-	isTheme,
-} from 'lib/products-values';
+import { isDomainRegistration, isDomainTransfer, isPlan, isTheme } from 'lib/products-values';
 
 function getIncludedDomain( purchase ) {
 	return purchase.includedDomain;
@@ -178,20 +172,13 @@ function isRemovable( purchase ) {
 		return false;
 	}
 
-	// Disallow removal of non-expired or non-expiring purchases of these types
-	if ( overSome( isDomainMapping, isDomainRegistration, isSiteRedirect )( purchase ) ) {
-		return isExpired( purchase ) || isExpiring( purchase );
-	}
-
-	if ( isDomainTransfer( purchase ) ) {
-		return (
-			isExpired( purchase ) ||
-			isExpiring( purchase ) ||
-			( ! isRefundable( purchase ) && isPurchaseCancelable( purchase ) )
-		);
-	}
-
-	return true;
+	return (
+		isExpiring( purchase ) ||
+		isExpired( purchase ) ||
+		( isDomainTransfer( purchase ) &&
+			! isRefundable( purchase ) &&
+			isPurchaseCancelable( purchase ) )
+	);
 }
 
 /**

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -154,6 +154,11 @@ export function managePurchase( context, next ) {
 
 	setTitle( context, titles.managePurchase );
 
-	context.primary = <ManagePurchase purchaseId={ parseInt( context.params.purchaseId, 10 ) } />;
+	context.primary = (
+		<ManagePurchase
+			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+			siteSlug={ context.params.site }
+		/>
+	);
 	next();
 }

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -58,11 +58,14 @@ export default function( router ) {
 		clientRender
 	);
 
+	/**
+	 * The siteSelection middleware has been removed from this root.
+	 * No selected site!
+	 */
 	router(
 		paths.managePurchase( ':site', ':purchaseId' ),
 		redirectLoggedOut,
 		sidebar,
-		siteSelection,
 		controller.managePurchase,
 		makeLayout,
 		clientRender

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -83,6 +83,7 @@ class ManagePurchase extends Component {
 		purchase: PropTypes.object,
 		selectedSite: PropTypes.object,
 		selectedSiteId: PropTypes.number,
+		siteSlug: PropTypes.string.isRequired,
 		userId: PropTypes.number,
 	};
 

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -344,7 +344,7 @@ class ManagePurchase extends Component {
 						<span className="manage-purchase__settings-link" />
 					</div>
 
-					<PurchaseMeta purchaseId={ false } />
+					<PurchaseMeta purchaseId={ false } siteSlug={ this.props.siteSlug } />
 				</Card>
 				<PurchasePlanDetails />
 				<VerticalNavItem isPlaceholder />
@@ -382,7 +382,7 @@ class ManagePurchase extends Component {
 					</header>
 					{ this.renderPlanDescription() }
 
-					<PurchaseMeta purchaseId={ purchase.id } />
+					<PurchaseMeta purchaseId={ purchase.id } siteSlug={ this.props.siteSlug } />
 
 					{ this.renderRenewButton() }
 				</Card>

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -456,7 +456,7 @@ export default connect( ( state, props ) => {
 		plan: isPurchasePlan && applyTestFiltersToPlansList( purchase.productSlug, abtest ),
 		isPurchaseTheme,
 		theme: isPurchaseTheme && getCanonicalTheme( state, siteId, purchase.meta ),
-		isAtomicSite: site ? isSiteAtomic( state, siteId ) : null,
+		isAtomicSite: isSiteAtomic( state, siteId ),
 		userId: getCurrentUserId( state ),
 	};
 } )( localize( ManagePurchase ) );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -81,8 +81,8 @@ class ManagePurchase extends Component {
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
 		isAtomicSite: PropTypes.bool,
 		purchase: PropTypes.object,
-		selectedSite: PropTypes.object,
-		selectedSiteId: PropTypes.number,
+		site: PropTypes.object,
+		siteId: PropTypes.number,
 		siteSlug: PropTypes.string.isRequired,
 		userId: PropTypes.number,
 	};
@@ -151,7 +151,7 @@ class ManagePurchase extends Component {
 			! isRenewable( purchase ) ||
 			isExpired( purchase ) ||
 			isExpiring( purchase ) ||
-			! this.props.selectedSite
+			! this.props.site
 		) {
 			return null;
 		}
@@ -166,7 +166,7 @@ class ManagePurchase extends Component {
 	renderEditPaymentMethodNavItem() {
 		const { purchase, translate } = this.props;
 
-		if ( ! this.props.selectedSite ) {
+		if ( ! this.props.site ) {
 			return null;
 		}
 
@@ -194,7 +194,7 @@ class ManagePurchase extends Component {
 		const { isAtomicSite, purchase, translate } = this.props;
 		const { id } = purchase;
 
-		if ( ! isCancelable( purchase ) || ! this.props.selectedSite ) {
+		if ( ! isCancelable( purchase ) || ! this.props.site ) {
 			return null;
 		}
 
@@ -254,11 +254,7 @@ class ManagePurchase extends Component {
 		const { purchase, translate } = this.props;
 		const { id } = purchase;
 
-		if (
-			isExpired( purchase ) ||
-			! hasPrivacyProtection( purchase ) ||
-			! this.props.selectedSite
-		) {
+		if ( isExpired( purchase ) || ! hasPrivacyProtection( purchase ) || ! this.props.site ) {
 			return null;
 		}
 
@@ -299,7 +295,7 @@ class ManagePurchase extends Component {
 	}
 
 	renderPlanDescription() {
-		const { plan, purchase, selectedSite, theme, translate } = this.props;
+		const { plan, purchase, site, theme, translate } = this.props;
 
 		let description = purchaseType( purchase );
 		if ( isPlan( purchase ) ) {
@@ -327,7 +323,7 @@ class ManagePurchase extends Component {
 			<div className="manage-purchase__content">
 				<span className="manage-purchase__description">{ description }</span>
 				<span className="manage-purchase__settings-link">
-					<ProductLink purchase={ purchase } selectedSite={ selectedSite } />
+					<ProductLink purchase={ purchase } selectedSite={ site } />
 				</span>
 			</div>
 		);
@@ -362,7 +358,7 @@ class ManagePurchase extends Component {
 			return this.renderPlaceholder();
 		}
 
-		const { purchase, selectedSiteId, selectedSite } = this.props;
+		const { purchase, siteId, site } = this.props;
 		const classes = classNames( 'manage-purchase__info', {
 			'is-expired': purchase && isExpired( purchase ),
 			'is-personal': isPersonal( purchase ),
@@ -374,7 +370,7 @@ class ManagePurchase extends Component {
 
 		return (
 			<Fragment>
-				<PurchaseSiteHeader siteId={ selectedSiteId } name={ siteName } domain={ siteDomain } />
+				<PurchaseSiteHeader siteId={ siteId } name={ siteName } domain={ siteDomain } />
 				<Card className={ classes }>
 					<header className="manage-purchase__header">
 						{ this.renderPlanIcon() }
@@ -397,7 +393,7 @@ class ManagePurchase extends Component {
 				<RemovePurchase
 					hasLoadedSites={ this.props.hasLoadedSites }
 					hasLoadedUserPurchasesFromServer={ this.props.hasLoadedUserPurchasesFromServer }
-					selectedSite={ selectedSite }
+					site={ site }
 					purchase={ purchase }
 				/>
 			</Fragment>
@@ -408,11 +404,11 @@ class ManagePurchase extends Component {
 		if ( ! this.isDataValid() ) {
 			return null;
 		}
-		const { selectedSite, selectedSiteId, siteSlug, purchase, isPurchaseTheme } = this.props;
+		const { site, siteId, siteSlug, purchase, isPurchaseTheme } = this.props;
 		const classes = 'manage-purchase';
 
 		let editCardDetailsPath = false;
-		if ( ! isDataLoading( this.props ) && selectedSite && canEditPaymentDetails( purchase ) ) {
+		if ( ! isDataLoading( this.props ) && site && canEditPaymentDetails( purchase ) ) {
 			editCardDetailsPath = getEditCardDetailsPath( siteSlug, purchase );
 		}
 
@@ -427,15 +423,13 @@ class ManagePurchase extends Component {
 					title="Purchases > Manage Purchase"
 				/>
 				<QueryUserPurchases userId={ this.props.userId } />
-				{ isPurchaseTheme && (
-					<QueryCanonicalTheme siteId={ selectedSiteId } themeId={ purchase.meta } />
-				) }
+				{ isPurchaseTheme && <QueryCanonicalTheme siteId={ siteId } themeId={ purchase.meta } /> }
 				<Main className={ classes }>
 					<HeaderCake backHref={ purchasesRoot }>{ titles.managePurchase }</HeaderCake>
 					<PurchaseNotice
 						isDataLoading={ isDataLoading( this.props ) }
 						handleRenew={ this.handleRenew }
-						selectedSite={ selectedSite }
+						selectedSite={ site }
 						purchase={ purchase }
 						editCardDetailsPath={ editCardDetailsPath }
 					/>
@@ -448,21 +442,21 @@ class ManagePurchase extends Component {
 
 export default connect( ( state, props ) => {
 	const purchase = getByPurchaseId( state, props.purchaseId );
-	const selectedSiteId = purchase ? purchase.siteId : null;
+	const siteId = purchase ? purchase.siteId : null;
 	const isPurchasePlan = purchase && isPlan( purchase );
 	const isPurchaseTheme = purchase && isTheme( purchase );
-	const selectedSite = getSite( state, selectedSiteId );
+	const site = getSite( state, siteId );
 	const hasLoadedSites = ! isRequestingSites( state );
 	return {
 		hasLoadedSites,
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		purchase,
-		selectedSiteId,
-		selectedSite,
+		siteId,
+		site,
 		plan: isPurchasePlan && applyTestFiltersToPlansList( purchase.productSlug, abtest ),
 		isPurchaseTheme,
-		theme: isPurchaseTheme && getCanonicalTheme( state, selectedSiteId, purchase.meta ),
-		isAtomicSite: selectedSite ? isSiteAtomic( state, selectedSiteId ) : null,
+		theme: isPurchaseTheme && getCanonicalTheme( state, siteId, purchase.meta ),
+		isAtomicSite: site ? isSiteAtomic( state, siteId ) : null,
 		userId: getCurrentUserId( state ),
 	};
 } )( localize( ManagePurchase ) );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -161,15 +161,6 @@ class ManagePurchase extends Component {
 		);
 	}
 
-	renderPlanDetails() {
-		return (
-			<PurchasePlanDetails
-				selectedSite={ this.props.selectedSite }
-				purchaseId={ this.props.purchaseId }
-			/>
-		);
-	}
-
 	renderEditPaymentMethodNavItem() {
 		const { purchase, translate } = this.props;
 
@@ -357,9 +348,7 @@ class ManagePurchase extends Component {
 
 					<PurchaseMeta purchaseId={ false } />
 				</Card>
-
-				{ this.renderPlanDetails() }
-
+				<PurchasePlanDetails />
 				<VerticalNavItem isPlaceholder />
 				<VerticalNavItem isPlaceholder />
 			</Fragment>
@@ -399,13 +388,10 @@ class ManagePurchase extends Component {
 
 					{ this.renderRenewButton() }
 				</Card>
-
-				{ this.renderPlanDetails() }
-
+				<PurchasePlanDetails purchaseId={ this.props.purchaseId } />
 				{ this.renderEditPaymentMethodNavItem() }
 				{ this.renderCancelPurchaseNavItem() }
 				{ this.renderCancelPrivacyProtection() }
-
 				<RemovePurchase
 					hasLoadedSites={ this.props.hasLoadedSites }
 					hasLoadedUserPurchasesFromServer={ this.props.hasLoadedUserPurchasesFromServer }

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -27,7 +27,18 @@ import { getPluginsForSite } from 'state/plugins/premium/selectors';
 
 class PurchasePlanDetails extends Component {
 	static propTypes = {
+		purchaseId: PropTypes.number,
+
+		// Connected props
 		purchase: PropTypes.object,
+		hasLoadedSites: PropTypes.bool,
+		hasLoadedUserPurchasesFromServer: PropTypes.bool,
+		pluginList: PropTypes.arrayOf(
+			PropTypes.shape( {
+				slug: PropTypes.string.isRequired,
+				key: PropTypes.string.isRequired,
+			} ).isRequired
+		).isRequired,
 	};
 
 	renderPlaceholder() {
@@ -52,7 +63,7 @@ class PurchasePlanDetails extends Component {
 	}
 
 	render() {
-		const { selectedSite, pluginList, translate } = this.props;
+		const { pluginList, translate } = this.props;
 		const { purchase } = this.props;
 
 		// Short out as soon as we know it's not a Jetpack plan
@@ -60,7 +71,7 @@ class PurchasePlanDetails extends Component {
 			return null;
 		}
 
-		if ( isDataLoading( this.props ) || ! this.props.selectedSite ) {
+		if ( isDataLoading( this.props ) ) {
 			return this.renderPlaceholder();
 		}
 
@@ -76,7 +87,7 @@ class PurchasePlanDetails extends Component {
 
 		return (
 			<div className="plan-details">
-				<QueryPluginKeys siteId={ selectedSite.ID } />
+				{ purchase && <QueryPluginKeys siteId={ purchase.siteId } /> }
 				<SectionHeader label={ headerText } />
 				<Card>
 					<PlanBillingPeriod purchase={ purchase } />
@@ -98,9 +109,12 @@ class PurchasePlanDetails extends Component {
 }
 
 // hasLoadedSites & hasLoadedUserPurchasesFromServer are used in isDataLoading
-export default connect( ( state, props ) => ( {
-	hasLoadedSites: ! isRequestingSites( state ),
-	hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
-	purchase: getByPurchaseId( state, props.purchaseId ),
-	pluginList: props.selectedSite ? getPluginsForSite( state, props.selectedSite.ID ) : [],
-} ) )( localize( PurchasePlanDetails ) );
+export default connect( ( state, props ) => {
+	const purchase = getByPurchaseId( state, props.purchaseId );
+	return {
+		hasLoadedSites: ! isRequestingSites( state ),
+		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
+		purchase,
+		pluginList: purchase ? getPluginsForSite( state, purchase.siteId ) : [],
+	};
+} )( localize( PurchasePlanDetails ) );

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -39,6 +39,7 @@ class PurchasePlanDetails extends Component {
 				key: PropTypes.string.isRequired,
 			} ).isRequired
 		).isRequired,
+		siteId: PropTypes.number,
 	};
 
 	renderPlaceholder() {
@@ -63,8 +64,7 @@ class PurchasePlanDetails extends Component {
 	}
 
 	render() {
-		const { pluginList, translate } = this.props;
-		const { purchase } = this.props;
+		const { pluginList, purchase, siteId, translate } = this.props;
 
 		// Short out as soon as we know it's not a Jetpack plan
 		if ( purchase && ( ! isJetpackPlan( purchase ) || isFreeJetpackPlan( purchase ) ) ) {
@@ -87,7 +87,7 @@ class PurchasePlanDetails extends Component {
 
 		return (
 			<div className="plan-details">
-				{ purchase && <QueryPluginKeys siteId={ purchase.siteId } /> }
+				{ siteId && <QueryPluginKeys siteId={ siteId } /> }
 				<SectionHeader label={ headerText } />
 				<Card>
 					<PlanBillingPeriod purchase={ purchase } />
@@ -111,10 +111,12 @@ class PurchasePlanDetails extends Component {
 // hasLoadedSites & hasLoadedUserPurchasesFromServer are used in isDataLoading
 export default connect( ( state, props ) => {
 	const purchase = getByPurchaseId( state, props.purchaseId );
+	const siteId = purchase ? purchase.siteId : null;
 	return {
 		hasLoadedSites: ! isRequestingSites( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		purchase,
-		pluginList: purchase ? getPluginsForSite( state, purchase.siteId ) : [],
+		pluginList: getPluginsForSite( state, siteId ),
+		siteId,
 	};
 } )( localize( PurchasePlanDetails ) );

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -171,7 +171,7 @@ class PurchaseItem extends Component {
 	}
 
 	render() {
-		const { isPlaceholder, isDisconnectedSite, purchase } = this.props;
+		const { isPlaceholder, isDisconnectedSite, purchase, isJetpack } = this.props;
 		const classes = classNames(
 			'purchase-item',
 			{ 'is-expired': purchase && 'expired' === purchase.expiryStatus },
@@ -195,19 +195,19 @@ class PurchaseItem extends Component {
 			);
 		}
 
-		let props;
+		let onClick;
+		let href;
 		if ( ! isPlaceholder ) {
-			props = {
-				onClick: this.scrollToTop,
-			};
-
-			if ( ! isDisconnectedSite ) {
-				props.href = managePurchase( this.props.slug, this.props.purchase.id );
+			// A "disconnected" Jetpack site purchases may be managed.
+			// "Disconnected" WordPress.com sites (the user has been removed) may not.
+			if ( ! isDisconnectedSite || isJetpack ) {
+				onClick = this.scrollToTop;
+				href = managePurchase( this.props.slug, this.props.purchase.id );
 			}
 		}
 
 		return (
-			<CompactCard className={ classes } { ...props }>
+			<CompactCard className={ classes } onClick={ onClick } href={ href }>
 				{ content }
 			</CompactCard>
 		);
@@ -219,6 +219,7 @@ PurchaseItem.propTypes = {
 	isDisconnectedSite: PropTypes.bool,
 	purchase: PropTypes.object,
 	slug: PropTypes.string,
+	isJetpack: PropTypes.bool,
 };
 
 export default localize( PurchaseItem );

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -198,8 +198,8 @@ class PurchaseItem extends Component {
 		let onClick;
 		let href;
 		if ( ! isPlaceholder ) {
-			// A "disconnected" Jetpack site purchases may be managed.
-			// "Disconnected" WordPress.com sites (the user has been removed) may not.
+			// A "disconnected" Jetpack site's purchases may be managed.
+			// A "disconnected" WordPress.com site may not (the user has been removed).
 			if ( ! isDisconnectedSite || isJetpack ) {
 				onClick = this.scrollToTop;
 				href = managePurchase( this.props.slug, this.props.purchase.id );

--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -61,7 +61,7 @@ const PurchasesSite = ( {
 			{ items }
 
 			{ ! isPlaceholder && hasLoadedSite && ! site ? (
-				<PurchaseReconnectNotice isJetpack={ isJetpack } name={ name } domain={ domain } />
+				<PurchaseReconnectNotice isJetpack={ isJetpack } name={ name } />
 			) : null }
 		</div>
 	);

--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -60,9 +60,9 @@ const PurchasesSite = ( {
 
 			{ items }
 
-			{ ! isPlaceholder && hasLoadedSite && ! site ? (
-				<PurchaseReconnectNotice isJetpack={ isJetpack } name={ name } />
-			) : null }
+			{ ! isPlaceholder &&
+				hasLoadedSite &&
+				! site && <PurchaseReconnectNotice isJetpack={ isJetpack } name={ name } /> }
 		</div>
 	);
 };

--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -32,6 +32,8 @@ const PurchasesSite = ( {
 } ) => {
 	let items;
 
+	const isJetpack = ! isPlaceholder && some( purchases, purchase => isJetpackPlan( purchase ) );
+
 	if ( isPlaceholder ) {
 		items = times( 2, index => <PurchaseItem isPlaceholder key={ index } /> );
 	} else {
@@ -41,11 +43,10 @@ const PurchasesSite = ( {
 				slug={ slug }
 				isDisconnectedSite={ ! site }
 				purchase={ purchase }
+				isJetpack={ isJetpack }
 			/>
 		) );
 	}
-
-	const isJetpack = some( purchases, purchase => isJetpackPlan( purchase ) );
 
 	return (
 		<div className={ classNames( 'purchases-site', { 'is-placeholder': isPlaceholder } ) }>

--- a/client/me/purchases/purchases-site/reconnect-notice.jsx
+++ b/client/me/purchases/purchases-site/reconnect-notice.jsx
@@ -13,7 +13,7 @@ import React, { Component } from 'react';
  */
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
-import { CALYPSO_CONTACT, JETPACK_CONTACT_SUPPORT } from 'lib/url/support';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 
 class PurchaseReconnectNotice extends Component {
 	static propTypes = {
@@ -23,24 +23,25 @@ class PurchaseReconnectNotice extends Component {
 
 	render() {
 		const { translate, name, isJetpack } = this.props;
-		let text = translate( 'You are no longer a user on %(site)s and cannot manage this purchase.', {
-			args: {
-				site: name,
-			},
-		} );
-		if ( isJetpack ) {
-			text = translate( '%(site)s has been disconnected from WordPress.com.', {
-				args: {
-					site: name,
-				},
-			} );
-		}
+
+		const text = isJetpack
+			? translate( '%(site)s has been disconnected from WordPress.com.', {
+					args: {
+						site: name,
+					},
+			  } )
+			: translate( 'You are no longer a user on %(site)s and cannot manage this purchase.', {
+					args: {
+						site: name,
+					},
+			  } );
 
 		return (
 			<Notice showDismiss={ false } status="is-error" text={ text }>
-				<NoticeAction href={ isJetpack ? JETPACK_CONTACT_SUPPORT : CALYPSO_CONTACT }>
-					{ translate( 'Contact Support' ) }
-				</NoticeAction>
+				{ /* Disconnected Jetpack sites can remove purchases. No need to contact support */
+				! isJetpack && (
+					<NoticeAction href={ CALYPSO_CONTACT }>{ translate( 'Contact Support' ) }</NoticeAction>
+				) }
 			</Notice>
 		);
 	}

--- a/client/me/purchases/purchases-site/reconnect-notice.jsx
+++ b/client/me/purchases/purchases-site/reconnect-notice.jsx
@@ -18,7 +18,7 @@ import { CALYPSO_CONTACT, JETPACK_CONTACT_SUPPORT } from 'lib/url/support';
 class PurchaseReconnectNotice extends Component {
 	static propTypes = {
 		name: PropTypes.string,
-		domain: PropTypes.string,
+		translate: PropTypes.func.isRequired,
 	};
 
 	render() {

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -58,7 +58,7 @@ class RemovePurchase extends Component {
 		receiveDeletedSite: PropTypes.func.isRequired,
 		removePurchase: PropTypes.func.isRequired,
 		purchase: PropTypes.object,
-		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
+		selectedSite: PropTypes.object,
 		setAllSitesSelected: PropTypes.func.isRequired,
 		userId: PropTypes.number.isRequired,
 	};
@@ -161,7 +161,7 @@ class RemovePurchase extends Component {
 		if ( ! isDomainRegistration( purchase ) && config.isEnabled( 'upgrades/removal-survey' ) ) {
 			const survey = wpcom
 				.marketing()
-				.survey( 'calypso-remove-purchase', this.props.selectedSite.ID );
+				.survey( 'calypso-remove-purchase', this.props.purchase.siteId );
 			const surveyData = {
 				'why-cancel': {
 					response: this.state.survey.questionOneRadio,
@@ -204,7 +204,7 @@ class RemovePurchase extends Component {
 			} else {
 				if ( isDomainRegistration( purchase ) ) {
 					if ( isDomainOnlySite ) {
-						this.props.receiveDeletedSite( selectedSite.ID );
+						this.props.receiveDeletedSite( purchase.siteId );
 						this.props.setAllSitesSelected();
 					}
 
@@ -218,7 +218,7 @@ class RemovePurchase extends Component {
 					notices.success(
 						translate( '%(productName)s was removed from {{siteName/}}.', {
 							args: { productName },
-							components: { siteName: <em>{ selectedSite.domain }</em> },
+							components: { siteName: <em>{ purchase.domain }</em> },
 						} ),
 						{ persistent: true }
 					);
@@ -378,7 +378,7 @@ class RemovePurchase extends Component {
 				<p>
 					{ translate( 'Are you sure you want to remove %(productName)s from {{siteName/}}?', {
 						args: { productName },
-						components: { siteName: <em>{ this.props.selectedSite.domain }</em> },
+						components: { siteName: <em>{ purchase.domain }</em> },
 					} ) }{' '}
 					{ isGoogleApps( purchase )
 						? translate(
@@ -450,7 +450,7 @@ class RemovePurchase extends Component {
 	}
 
 	render() {
-		if ( isDataLoading( this.props ) || ! this.props.selectedSite ) {
+		if ( isDataLoading( this.props ) ) {
 			return null;
 		}
 
@@ -475,9 +475,11 @@ class RemovePurchase extends Component {
 }
 
 export default connect(
-	( state, { selectedSite } ) => ( {
-		isDomainOnlySite: selectedSite && isDomainOnly( state, selectedSite.ID ),
-		isAutomatedTransferSite: selectedSite && isSiteAutomatedTransfer( state, selectedSite.ID ),
+	( state, { purchase, selectedSite } ) => ( {
+		isDomainOnlySite: purchase && isDomainOnly( state, purchase.siteId ),
+		isAutomatedTransferSite: selectedSite
+			? isSiteAutomatedTransfer( state, selectedSite.ID )
+			: null,
 		isChatAvailable: isHappychatAvailable( state ),
 		isChatActive: hasActiveHappychatSession( state ),
 		purchasesError: getPurchasesError( state ),

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -64,7 +64,7 @@ class RemovePurchase extends Component {
 		receiveDeletedSite: PropTypes.func.isRequired,
 		removePurchase: PropTypes.func.isRequired,
 		purchase: PropTypes.object,
-		selectedSite: PropTypes.object,
+		site: PropTypes.object,
 		setAllSitesSelected: PropTypes.func.isRequired,
 		userId: PropTypes.number.isRequired,
 	};
@@ -162,7 +162,7 @@ class RemovePurchase extends Component {
 	removePurchase = closeDialog => {
 		this.setState( { isRemoving: true } );
 
-		const { isDomainOnlySite, purchase, selectedSite, translate } = this.props;
+		const { isDomainOnlySite, purchase, site, translate } = this.props;
 
 		if ( ! isDomainRegistration( purchase ) && config.isEnabled( 'upgrades/removal-survey' ) ) {
 			const survey = wpcom
@@ -181,7 +181,7 @@ class RemovePurchase extends Component {
 				type: 'remove',
 			};
 
-			survey.addResponses( enrichedSurveyData( surveyData, moment(), selectedSite, purchase ) );
+			survey.addResponses( enrichedSurveyData( surveyData, moment(), site, purchase ) );
 
 			debug( 'Survey responses', survey );
 			survey
@@ -299,7 +299,7 @@ class RemovePurchase extends Component {
 	}
 
 	renderPlanDialog() {
-		const { purchase, selectedSite, translate } = this.props;
+		const { purchase, site, translate } = this.props;
 		const buttons = {
 			cancel: {
 				action: 'cancel',
@@ -358,7 +358,7 @@ class RemovePurchase extends Component {
 					defaultContent={ this.renderPlanDialogText() }
 					onInputChange={ this.onSurveyChange }
 					purchase={ purchase }
-					selectedSite={ selectedSite }
+					selectedSite={ site }
 					showSurvey={ config.isEnabled( 'upgrades/removal-survey' ) }
 					surveyStep={ this.state.surveyStep }
 				/>
@@ -461,7 +461,7 @@ class RemovePurchase extends Component {
 		}
 
 		// If we have a disconnected site that is _not_ a Jetpack purchase, no removal allowed.
-		if ( ! this.props.selectedSite && ! this.props.isJetpack ) {
+		if ( ! this.props.site && ! this.props.isJetpack ) {
 			return null;
 		}
 
@@ -486,13 +486,11 @@ class RemovePurchase extends Component {
 }
 
 export default connect(
-	( state, { purchase, selectedSite } ) => {
+	( state, { purchase } ) => {
 		const isJetpack = purchase && isJetpackPlan( purchase );
 		return {
 			isDomainOnlySite: purchase && isDomainOnly( state, purchase.siteId ),
-			/* We know Jetpack sites are not Atomic */
-			isAutomatedTransferSite:
-				! isJetpack && ( selectedSite ? isSiteAutomatedTransfer( state, selectedSite.ID ) : null ),
+			isAutomatedTransferSite: isSiteAutomatedTransfer( state, purchase.siteId ),
 			isChatAvailable: isHappychatAvailable( state ),
 			isChatActive: hasActiveHappychatSession( state ),
 			isJetpack,


### PR DESCRIPTION
Fixes 1642-gh-jpop-issues

A purchase may have been made on a site that is disconnected. Users may wish to remove these purchases and there's no technical limitation for doing so.

Allow the user to mange and remove Jetpack purchases for disconnected sites.

The most notable change is that `siteSelection` route middleware has been removed from the manage purchases (`/me/purchases/:SITE_SLUG/:PURCHASE_ID`) route. No globally selectedSite is available. Instead, we remove the requirement for a selected site, use the `purchase.siteId` to select the site, and treat it as an enhancement when available.

Other changes are included to ensure that components which may be rendered continue to function well in the absence of a site.

## Screens (`/me/purchases`)

Disconnected sites previously had no navigation but scrolled to the top and showed a pointer on hover. After changes:
- Disconnected Jetpack sites navigate to the manage purchase page
- Disconnected WordPress.com sites do not scroll and show the default cursor.

### Disconnected Jetpack

#### Before

![before-jp](https://user-images.githubusercontent.com/841763/41409448-8abf42d4-6fd6-11e8-9f77-4f6b0438894c.png)

#### After
![after-jp](https://user-images.githubusercontent.com/841763/41409368-386328d4-6fd6-11e8-98ae-976d3c8337c7.png)

### Disconnected WordPress.com

#### Before

![before-wp](https://user-images.githubusercontent.com/841763/41409450-8d98daba-6fd6-11e8-9a29-c3ddfcd54307.png)

#### After
![after-wp](https://user-images.githubusercontent.com/841763/41409364-34def9d6-6fd6-11e8-923b-ec78d374bcff.png)

## Screens (`/me/purchases/:SITE_SLUG/:PURCHASE_ID`)

From the manage purchase page, you should be able to remove a Jetpack purchase, but not a WordPress.com purchase for disconnected sites.

### Jetpack 

![removal](https://user-images.githubusercontent.com/841763/41410755-bca78eec-6fda-11e8-90e2-b3f9e5d571cf.png)

### WordPress.com (removal not rendered)

_Note: There is no existing navigation to this view I'm aware of._

![missing](https://user-images.githubusercontent.com/841763/41410748-bb50895e-6fda-11e8-90ad-b76b7fae107c.png)


## Testing
1. Verify that management and removal existing purchases continue to work as before.
1. Try to remove a purchase for a disconnected site:
   1. Connect a new Jetpack site.
   1. Purchase a plan.
   1. Disconnect the Jetpack site.
   1. Go to purchases, select the purchase and remove it.
1. Repeat with a WordPress.com site:
   1. Create a new site.
   1. Add a second user as an admin.
   1. Purchase a plan as the second user.
   1. Remove the second user from the site.
   1. Try to manage the plan as the second user (`/me/purchases`).
1. Try manually navigating to the management page for these example sites. You'll need to manually modify the URL:
   1. Jetpack site should allow you to remove the purchase.
   1. WordPress.com site should not render a removal link.