### PR TITLE
Guided Tours: Add Jetpack Plugin Autoupdate Tour

### DIFF
--- a/client/layout/guided-tours/config-elements/step.js
+++ b/client/layout/guided-tours/config-elements/step.js
@@ -63,7 +63,7 @@ export default class Step extends Component {
 		wait: PropTypes.func,
 		onTargetDisappear: PropTypes.func,
 		keepRepositioning: PropTypes.bool,
-		children: PropTypes.func,
+		children: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
@@ -90,11 +90,7 @@ export default class Step extends Component {
 		this.wait( this.props, this.context ).then( () => {
 			this.start();
 			this.setStepSection( this.context, { init: true } );
-			debug(
-				'Step#componentWillMount: stepSection: %s, name: %s',
-				this.stepSection,
-				this.props.name
-			);
+			debug( 'Step#componentWillMount: stepSection:', this.stepSection );
 			this.skipIfInvalidContext( this.props, this.context );
 			this.scrollContainer = query( this.props.scrollContainer )[ 0 ] || window;
 			this.setStepPosition( this.props );
@@ -111,10 +107,6 @@ export default class Step extends Component {
 		if ( this.props.keepRepositioning ) {
 			this.repositionInterval = setInterval( this.onScrollOrResize, 3000 );
 		}
-	}
-
-	componentDidUpdate() {
-		debug( '<Step/> updated. Name: %s', this.props.name );
 	}
 
 	componentWillReceiveProps( nextProps, nextContext ) {
@@ -385,10 +377,10 @@ export default class Step extends Component {
 
 		const style = { ...this.props.style, ...stepCoords };
 
-		return ContentComponent ? (
+		return (
 			<Card className={ classNames( ...classes ) } style={ style }>
 				<ContentComponent translate={ translate } />
 			</Card>
-		) : null;
+		);
 	}
 }

--- a/client/layout/guided-tours/config-elements/step.js
+++ b/client/layout/guided-tours/config-elements/step.js
@@ -63,7 +63,7 @@ export default class Step extends Component {
 		wait: PropTypes.func,
 		onTargetDisappear: PropTypes.func,
 		keepRepositioning: PropTypes.bool,
-		children: PropTypes.func.isRequired,
+		children: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -90,7 +90,11 @@ export default class Step extends Component {
 		this.wait( this.props, this.context ).then( () => {
 			this.start();
 			this.setStepSection( this.context, { init: true } );
-			debug( 'Step#componentWillMount: stepSection:', this.stepSection );
+			debug(
+				'Step#componentWillMount: stepSection: %s, name: %s',
+				this.stepSection,
+				this.props.name
+			);
 			this.skipIfInvalidContext( this.props, this.context );
 			this.scrollContainer = query( this.props.scrollContainer )[ 0 ] || window;
 			this.setStepPosition( this.props );
@@ -377,10 +381,10 @@ export default class Step extends Component {
 
 		const style = { ...this.props.style, ...stepCoords };
 
-		return (
+		return ContentComponent ? (
 			<Card className={ classNames( ...classes ) } style={ style }>
 				<ContentComponent translate={ translate } />
 			</Card>
-		);
+		) : null;
 	}
 }

--- a/client/layout/guided-tours/config-elements/step.js
+++ b/client/layout/guided-tours/config-elements/step.js
@@ -113,6 +113,10 @@ export default class Step extends Component {
 		}
 	}
 
+	componentDidUpdate() {
+		debug( '<Step/> updated. Name: %s', this.props.name );
+	}
+
 	componentWillReceiveProps( nextProps, nextContext ) {
 		const shouldScrollTo = nextProps.shouldScrollTo && this.props.name !== nextProps.name;
 		this.wait( nextProps, nextContext ).then( () => {

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -20,6 +20,7 @@ import { ChecklistSiteTitleTour } from 'layout/guided-tours/tours/checklist-site
 import { ChecklistUserAvatarTour } from 'layout/guided-tours/tours/checklist-user-avatar-tour';
 import { JetpackBasicTour } from 'layout/guided-tours/tours/jetpack-basic-tour';
 import { JetpackMonitoringTour } from 'layout/guided-tours/tours/jetpack-monitoring-tour';
+import { JetpackPluginUpdatesTour } from 'layout/guided-tours/tours/jetpack-plugin-updates-tour';
 import { JetpackSignInTour } from 'layout/guided-tours/tours/jetpack-sign-in-tour';
 import { SimplePaymentsEmailTour } from 'layout/guided-tours/tours/simple-payments-email-tour';
 import { PluginsBasicTour } from 'layout/guided-tours/tours/plugins-basic-tour';
@@ -34,6 +35,7 @@ export default combineTours( {
 	checklistUserAvatar: ChecklistUserAvatarTour,
 	jetpack: JetpackBasicTour,
 	jetpackMonitoring: JetpackMonitoringTour,
+	jetpackPluginUpdates: JetpackPluginUpdatesTour,
 	jetpackSignIn: JetpackSignInTour,
 	main: MainTour,
 	editorBasicsTour: EditorBasicsTour,

--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
@@ -36,8 +36,8 @@ export const JetpackPluginUpdatesTour = makeTour(
 				<Fragment>
 					<p>
 						{ translate(
-							"Let's enable monitoring of your site's uptime " +
-								'by activating the toggle switch for Jetpack Monitor.'
+							"Let's activate autoupdates for Jetpack to ensure you're always " +
+								'up-to-date with the latest features and security fixes.'
 						) }
 					</p>
 					<ButtonRow>
@@ -61,7 +61,7 @@ export const JetpackPluginUpdatesTour = makeTour(
 					</h1>
 					<p>
 						{ translate(
-							'Uptime Monitoring has been enabled. Would you like to continue setting up the security essential features for your site?'
+							'Jetpack will now autoupdate for you. Would you like to continue setting up the security essential features for your site?'
 						) }
 					</p>
 					<SiteLink isButton href={ '/checklist/:site' }>

--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
@@ -1,0 +1,74 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Fragment } from 'react';
+import Gridicon from 'gridicons';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	ButtonRow,
+	Continue,
+	makeTour,
+	SiteLink,
+	Step,
+	Tour,
+} from 'layout/guided-tours/config-elements';
+
+export const JetpackPluginUpdatesTour = makeTour(
+	<Tour name="jetpackPluginUpdates" version="20180611" path="/non-existent-route" when={ noop }>
+		<Step
+			name="init"
+			target="#plugin-jetpack .form-toggle__switch"
+			arrow="top-left"
+			placement="below"
+			style={ {
+				animationDelay: '0.7s',
+				zIndex: 1,
+			} }
+		>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"Let's enable monitoring of your site's uptime " +
+								'by activating the toggle switch for Jetpack Monitor.'
+						) }
+					</p>
+					<ButtonRow>
+						<Continue target="#plugin-jetpack .form-toggle__switch" step="finish" click hidden />
+						<SiteLink isButton={ false } href="/checklist/:site">
+							{ translate( 'Return to the checklist' ) }
+						</SiteLink>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+
+		<Step name="finish" placement="right">
+			{ ( { translate } ) => (
+				<Fragment>
+					<h1 className="tours__title">
+						<span className="tours__completed-icon-wrapper">
+							<Gridicon icon="checkmark" className="tours__completed-icon" />
+						</span>
+						{ translate( 'Excellent, you’re done!' ) }
+					</h1>
+					<p>
+						{ translate(
+							'Uptime Monitoring has been enabled. Would you like to continue setting up the security essential features for your site?'
+						) }
+					</p>
+					<SiteLink isButton href={ '/checklist/:site' }>
+						{ translate( 'Return to the checklist' ) }
+					</SiteLink>
+				</Fragment>
+			) }
+		</Step>
+	</Tour>
+);

--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
@@ -18,12 +18,22 @@ import {
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
+import { query } from 'layout/guided-tours/positioning';
 
 export const JetpackPluginUpdatesTour = makeTour(
 	<Tour name="jetpackPluginUpdates" version="20180611">
+		{ /* Phantom step, wait for placeholder to disappear, then advance */ }
 		<Step
 			name="init"
+			target=".plugin-item.is-placeholder"
+			onTargetDisappear={ ( { next } ) => next() }
+			next="onLoaded"
+		/>
+		<Step
+			name="onLoaded"
+			wait={ () => !! query( '.plugin-item-jetpack .form-toggle:enabled' ).length }
 			target=".plugin-item-jetpack .form-toggle__switch"
+			onTargetDisappear={ /** Errors if missing */ () => {} }
 			arrow="top-left"
 			placement="below"
 			style={ {

--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
@@ -3,10 +3,8 @@
 /**
  * External dependencies
  */
-
 import React, { Fragment } from 'react';
 import Gridicon from 'gridicons';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,7 +20,7 @@ import {
 } from 'layout/guided-tours/config-elements';
 
 export const JetpackPluginUpdatesTour = makeTour(
-	<Tour name="jetpackPluginUpdates" version="20180611" path="/non-existent-route" when={ noop }>
+	<Tour name="jetpackPluginUpdates" version="20180611">
 		<Step
 			name="init"
 			target="#plugin-jetpack .form-toggle__switch"
@@ -43,9 +41,7 @@ export const JetpackPluginUpdatesTour = makeTour(
 					</p>
 					<ButtonRow>
 						<Continue target="#plugin-jetpack .form-toggle__switch" step="finish" click hidden />
-						<SiteLink isButton={ false } href="/checklist/:site">
-							{ translate( 'Return to the checklist' ) }
-						</SiteLink>
+						<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
 					</ButtonRow>
 				</Fragment>
 			) }

--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
@@ -15,6 +15,7 @@ import {
 	ButtonRow,
 	Continue,
 	makeTour,
+	Quit,
 	SiteLink,
 	Step,
 	Tour,
@@ -64,9 +65,12 @@ export const JetpackPluginUpdatesTour = makeTour(
 							'Jetpack will now autoupdate for you. Would you like to continue setting up the security essential features for your site?'
 						) }
 					</p>
-					<SiteLink isButton href={ '/checklist/:site' }>
-						{ translate( 'Return to the checklist' ) }
-					</SiteLink>
+					<ButtonRow>
+						<SiteLink isButton href={ '/checklist/:site' }>
+							{ translate( "Yes, let's do it." ) }
+						</SiteLink>
+						<Quit>{ translate( 'No thanks.' ) }</Quit>
+					</ButtonRow>
 				</Fragment>
 			) }
 		</Step>

--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
@@ -23,7 +23,7 @@ export const JetpackPluginUpdatesTour = makeTour(
 	<Tour name="jetpackPluginUpdates" version="20180611">
 		<Step
 			name="init"
-			target="#plugin-jetpack .form-toggle__switch"
+			target=".plugin-item-jetpack .form-toggle__switch"
 			arrow="top-left"
 			placement="below"
 			style={ {
@@ -40,7 +40,12 @@ export const JetpackPluginUpdatesTour = makeTour(
 						) }
 					</p>
 					<ButtonRow>
-						<Continue target="#plugin-jetpack .form-toggle__switch" step="finish" click hidden />
+						<Continue
+							target=".plugin-item-jetpack .form-toggle__switch"
+							step="finish"
+							click
+							hidden
+						/>
 						<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
 					</ButtonRow>
 				</Fragment>

--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
@@ -46,7 +46,9 @@ export const JetpackPluginUpdatesTour = makeTour(
 							click
 							hidden
 						/>
-						<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
+						<SiteLink href="/plans/my-plan/:site">
+							{ translate( 'Return to the checklist' ) }
+						</SiteLink>
 					</ButtonRow>
 				</Fragment>
 			) }
@@ -67,7 +69,7 @@ export const JetpackPluginUpdatesTour = makeTour(
 						) }
 					</p>
 					<ButtonRow>
-						<SiteLink isButton href={ '/checklist/:site' }>
+						<SiteLink isButton href={ '/plans/my-plan/:site' }>
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
 						<Quit>{ translate( 'No thanks.' ) }</Quit>

--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
@@ -18,22 +18,32 @@ import {
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
+import PluginsStore from 'lib/plugins/store';
+import { getSelectedSite } from 'state/ui/selectors';
 import { query } from 'layout/guided-tours/positioning';
 
+window.pstore = PluginsStore;
+
 export const JetpackPluginUpdatesTour = makeTour(
-	<Tour name="jetpackPluginUpdates" version="20180611">
-		{ /* Phantom step, wait for placeholder to disappear, then advance */ }
+	<Tour
+		name="jetpackPluginUpdates"
+		version="20180611"
+		when={ state => PluginsStore.getSitePlugin( getSelectedSite( state ), 'jetpack' ) }
+	>
 		<Step
 			name="init"
-			target=".plugin-item.is-placeholder"
-			onTargetDisappear={ ( { next } ) => next() }
-			next="onLoaded"
-		/>
-		<Step
-			name="onLoaded"
-			wait={ () => ! query( '.plugin-item-jetpack .form-toggle:enabled' ).length }
+			wait={ () => !! query( '.plugin-item-jetpack .form-toggle:enabled' ).length }
 			target=".plugin-item-jetpack .form-toggle__switch"
-			onTargetDisappear={ /** Errors if missing */ () => {} }
+			onTargetDisappear={
+				/**
+				 * noop
+				 *
+				 * Wait doesn't _wait_ for it's condition before calling this.
+				 * This will therefore be called _before_ we've shown the tour.
+				 * We don't want to quit in those cases :/
+				 */
+				() => {}
+			}
 			arrow="top-left"
 			placement="below"
 			style={ {

--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
@@ -31,7 +31,7 @@ export const JetpackPluginUpdatesTour = makeTour(
 		/>
 		<Step
 			name="onLoaded"
-			wait={ () => !! query( '.plugin-item-jetpack .form-toggle:enabled' ).length }
+			wait={ () => ! query( '.plugin-item-jetpack .form-toggle:enabled' ).length }
 			target=".plugin-item-jetpack .form-toggle__switch"
 			onTargetDisappear={ /** Errors if missing */ () => {} }
 			arrow="top-left"

--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
@@ -1,14 +1,15 @@
 /** @format */
-
 /**
  * External dependencies
  */
-import React, { Fragment } from 'react';
 import Gridicon from 'gridicons';
+import React, { Fragment } from 'react';
 
 /**
  * Internal dependencies
  */
+import PluginsStore from 'lib/plugins/store';
+import { getSelectedSite } from 'state/ui/selectors';
 import {
 	ButtonRow,
 	Continue,
@@ -18,32 +19,18 @@ import {
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
-import PluginsStore from 'lib/plugins/store';
-import { getSelectedSite } from 'state/ui/selectors';
-import { query } from 'layout/guided-tours/positioning';
-
-window.pstore = PluginsStore;
 
 export const JetpackPluginUpdatesTour = makeTour(
-	<Tour
-		name="jetpackPluginUpdates"
-		version="20180611"
-		when={ state => PluginsStore.getSitePlugin( getSelectedSite( state ), 'jetpack' ) }
-	>
+	<Tour name="jetpackPluginUpdates" version="20180611">
 		<Step
 			name="init"
-			wait={ () => !! query( '.plugin-item-jetpack .form-toggle:enabled' ).length }
+			when={ state => {
+				const site = getSelectedSite( state );
+				const res =
+					! PluginsStore.isFetchingSite( site ) && !! PluginsStore.getSitePlugin( site, 'jetpack' );
+				return res;
+			} }
 			target=".plugin-item-jetpack .form-toggle__switch"
-			onTargetDisappear={
-				/**
-				 * noop
-				 *
-				 * Wait doesn't _wait_ for it's condition before calling this.
-				 * This will therefore be called _before_ we've shown the tour.
-				 * We don't want to quit in those cases :/
-				 */
-				() => {}
-			}
 			arrow="top-left"
 			placement="below"
 			style={ {

--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour.js
@@ -76,7 +76,7 @@ export const JetpackPluginUpdatesTour = makeTour(
 						) }
 					</p>
 					<ButtonRow>
-						<SiteLink isButton href={ '/plans/my-plan/:site' }>
+						<SiteLink isButton href="/plans/my-plan/:site">
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
 						<Quit>{ translate( 'No thanks.' ) }</Quit>

--- a/client/my-sites/checklist/jetpack-checklist.js
+++ b/client/my-sites/checklist/jetpack-checklist.js
@@ -11,11 +11,15 @@ export const tasks = [
 			"We've automatically protected you from brute force login attacks."
 		),
 		completed: true,
+		title: '', // Required prop, item is always complete
+		description: '', // Required prop, item is always complete
 	},
 	{
 		id: 'jetpack_spam_filtering',
 		completedTitle: translate( "We've automatically turned on spam filtering." ),
 		completed: true,
+		description: '', // Required prop, item is always complete
+		title: '', // Required prop, item is always complete
 	},
 	{
 		id: 'jetpack_backups',

--- a/client/my-sites/checklist/jetpack-checklist.js
+++ b/client/my-sites/checklist/jetpack-checklist.js
@@ -50,6 +50,7 @@ export const tasks = [
 		completedTitle: translate( 'You turned on automatic plugin updates.' ),
 		completedButtonText: translate( 'Change' ),
 		duration: translate( '%d minute', '%d minutes', { count: 3, args: [ 3 ] } ),
+		tour: 'jetpackPluginUpdates',
 		url: '/plugins/manage/$siteSlug',
 	},
 	{

--- a/client/my-sites/checklist/jetpack-checklist.js
+++ b/client/my-sites/checklist/jetpack-checklist.js
@@ -7,19 +7,15 @@ import { translate } from 'i18n-calypso';
 export const tasks = [
 	{
 		id: 'jetpack_brute_force',
-		completedTitle: translate(
-			"We've automatically protected you from brute force login attacks."
-		),
+		title: translate( "We've automatically protected you from brute force login attacks." ),
 		completed: true,
-		title: '', // Required prop, item is always complete
 		description: '', // Required prop, item is always complete
 	},
 	{
 		id: 'jetpack_spam_filtering',
-		completedTitle: translate( "We've automatically turned on spam filtering." ),
+		title: translate( "We've automatically turned on spam filtering." ),
 		completed: true,
 		description: '', // Required prop, item is always complete
-		title: '', // Required prop, item is always complete
 	},
 	{
 		id: 'jetpack_backups',

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -36,6 +36,7 @@ import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer'
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ChecklistShow from 'my-sites/checklist/checklist-show';
 import { isEnabled } from 'config';
+import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 
 class CurrentPlan extends Component {
 	static propTypes = {
@@ -146,7 +147,12 @@ class CurrentPlan extends Component {
 					/>
 					{ isEnabled( 'jetpack/checklist' ) &&
 						isJetpack &&
-						! isAutomatedTransfer && <ChecklistShow /> }
+						! isAutomatedTransfer && (
+							<Fragment>
+								<QueryJetpackPlugins siteIds={ [ selectedSiteId ] } />
+								<ChecklistShow />
+							</Fragment>
+						) }
 					<div
 						className={ classNames( 'current-plan__header-text current-plan__text', {
 							'is-placeholder': { isLoading },

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -346,7 +346,7 @@ class PluginItem extends Component {
 		const pluginItemClasses = classNames( 'plugin-item', { disabled } );
 
 		return (
-			<CompactCard className={ pluginItemClasses }>
+			<CompactCard id={ 'plugin-' + plugin.slug } className={ pluginItemClasses }>
 				{ disabled || ! this.props.isSelectable ? null : (
 					<input
 						className="plugin-item__checkbox"

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -343,10 +343,12 @@ class PluginItem extends Component {
 			pluginActions = this.renderActions();
 		}
 
-		const pluginItemClasses = classNames( 'plugin-item', { disabled } );
+		const pluginItemClasses = classNames( 'plugin-item', 'plugin-item-' + plugin.slug, {
+			disabled,
+		} );
 
 		return (
-			<CompactCard id={ 'plugin-' + plugin.slug } className={ pluginItemClasses }>
+			<CompactCard className={ pluginItemClasses }>
 				{ disabled || ! this.props.isSelectable ? null : (
 					<input
 						className="plugin-item__checkbox"


### PR DESCRIPTION
Adds the tour.

Waits for plugins to be loaded with some magic. See notes. Existing tools don't seem to be applicable because plugin store is not redux and the wait may be too long.

Try rolling back f7170ea01ee3b09c0f8392ad6aab6074e3bb4102 while testing.
Ensure you test with clean application state and with already loaded plugin data in state. Should display the tour under all conditions.

## Testing
Visit the checklist for a new Jetpack site and click the plugin auto-update step.

Closes #25458 