### PR TITLE
Post Editor: maybeRedirect should do a real redirect, not a replace

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -65,7 +65,7 @@ function maybeRedirect( context ) {
 			if ( context.querystring ) {
 				path += `?${ context.querystring }`;
 			}
-			page.replace( path, null, false, false );
+			page.redirect( path );
 			return true;
 		}
 	}

--- a/client/state/ui/editor/actions.js
+++ b/client/state/ui/editor/actions.js
@@ -68,6 +68,7 @@ export function startEditingNewPost( siteId, post ) {
 			title: '',
 		} );
 
+		dispatch( editorReset( { isLoading: true } ) );
 		dispatch( { type: EDITOR_START, siteId, postId: null } );
 		dispatch( editPost( siteId, null, postAttributes ) );
 		dispatch( editorReset() );


### PR DESCRIPTION
`page.replace` call will cancel the currently executed handler chain (`controller.post`, `makeLayout`, `clientRender`) after the `controller.post` call, causing the UI to never get rerendered.

This is the sequence of events:
1. After clicking "Share" in Reader, Calypso navigates to `/post/123?queryStringWithContent`, where `123` is numeric ID of the site.
2. the `maybeRedirect` function replaces the URL with the canonical `/post/site.slug?queryStringWithContent` one. It uses `page.replace()` with `dispatch` parameter set to `false`. When working on #25160, I tried to be smart here, just replacing the URL without running the associated handler chain the controller.
3. However, this `page.replace` changes the internal `page.current` variable in the `page` lib, and the handler chain for the original route (with numeric site ID), [gets interrupted](https://github.com/visionmedia/page.js/blob/master/index.js#L357-L360).
4. Therefore, the `makeLayout` and `clientRender` [handlers](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/index.js#L18) are never called. As they are the ones that actually update the React UI, the UI gets stuck in the original state, i.e., Reader.

This patch reverts this code back to the state before #25160, where `page.redirect( path )` was used.