### PR TITLE
Podcasting: Redesign link to podcasting settings page

### DIFF
--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -48,6 +48,7 @@ $transparent:            rgba(255,255,255,0);
 $border-ultra-light-gray: #e8f0f5;
 // $green-text-min: minimum contrast needed for WCAG 2.0 AA on white background
 $green-text-min:          darken( $alert-green, 14% ); // #358649
+$podcasting-purple:       #9b4dd5;
 
 // Layout
 $masterbar-color:          $blue-wordpress;

--- a/client/components/podcast-indicator/style.scss
+++ b/client/components/podcast-indicator/style.scss
@@ -2,6 +2,6 @@
 	position: relative;
 
 	.gridicon {
-		fill: #9b4dd5;
+		fill: $podcasting-purple;
 	}
 }

--- a/client/my-sites/site-settings/podcasting-details/link.jsx
+++ b/client/my-sites/site-settings/podcasting-details/link.jsx
@@ -3,7 +3,9 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
+import classnames from 'classnames';
+import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -11,55 +13,121 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
+import Button from 'components/button';
+import ExternalLink from 'components/external-link';
+import ClipboardButtonInput from 'components/clipboard-button-input';
 import SectionHeader from 'components/section-header';
 import PodcastingPrivateSiteMessage from './private-site';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import isPrivateSite from 'state/selectors/is-private-site';
+import { getSupportSiteLocale } from 'lib/i18n-utils';
 
 class PodcastingLink extends Component {
 	render() {
-		const { fields, siteSlug, isPrivate, translate } = this.props;
+		const { isPodcastingEnabled, translate } = this.props;
 
-		if ( isPrivate ) {
-			return (
-				<div className="podcasting-details__link">
-					<SectionHeader label={ translate( 'Podcasting' ) } />
-					<Card className="podcasting-details__link-card">
-						<PodcastingPrivateSiteMessage />
-					</Card>
-				</div>
-			);
-		}
-
-		const podcastingEnabled =
-			fields && fields.podcasting_category_id && Number( fields.podcasting_category_id ) > 0;
-		const detailsLink = `/settings/podcasting/${ siteSlug }`;
+		const classes = classnames( 'podcasting-details__link', {
+			'is-enabled': isPodcastingEnabled,
+		} );
 
 		return (
-			<div className="podcasting-details__link">
+			<div className={ classes }>
 				<SectionHeader label={ translate( 'Podcasting' ) } />
-				<Card className="podcasting-details__link-card" href={ detailsLink }>
-					<div className="podcasting-details__link-title">
-						{ podcastingEnabled
-							? translate( 'Manage Podcasting' )
-							: translate( 'Enable Podcasting' ) }
-					</div>
+				<Card className="podcasting-details__link-card">{ this.renderCardBody() }</Card>
+			</div>
+		);
+	}
+
+	renderCardBody() {
+		const { isPrivate, isPodcastingEnabled, detailsLink, translate } = this.props;
+
+		if ( isPrivate ) {
+			return <PodcastingPrivateSiteMessage />;
+		}
+
+		if ( ! isPodcastingEnabled ) {
+			return (
+				<div className="podcasting-details__link-action-container">
 					<div className="podcasting-details__link-info">
 						{ translate(
 							'Publish a podcast feed to Apple Podcasts and other podcasting services.'
 						) }
+						<br />
+						{ this.renderSupportLink() }
 					</div>
-				</Card>
-			</div>
+					<Button className="podcasting-details__link-button" href={ detailsLink }>
+						{ translate( 'Set Up' ) }
+					</Button>
+				</div>
+			);
+		}
+
+		return (
+			<Fragment>
+				<div className="podcasting-details__link-action-container">
+					<div className="podcasting-details__link-info">
+						<Gridicon icon="microphone" size={ 24 } />
+						<span className="podcasting-details__link-info-text">
+							{ translate(
+								'Publish blog posts in the {{strong}}%s{{/strong}} category to add new episodes.',
+								{
+									args: 'CATEGORY NAME',
+									components: { strong: <strong /> },
+								}
+							) }
+						</span>
+					</div>
+					<Button className="podcasting-details__link-button" href={ detailsLink }>
+						{ translate( 'Manage Details' ) }
+					</Button>
+				</div>
+				<div className="podcasting-details__link-feed">
+					<div className="podcasting-details__link-feed-label">{ translate( 'RSS Feed' ) }</div>
+					<ClipboardButtonInput
+						className="podcasting-details__link-feed-url"
+						value="FEED URL HERE"
+					/>
+					<div className="podcasting-details__link-feed-info">
+						{ translate(
+							'Copy your feed URL and submit it to Apple Podcasts and other podcasting services.'
+						) }
+						{ ' ' }
+						{ this.renderSupportLink() }
+					</div>
+				</div>
+			</Fragment>
 		);
+	}
+
+	renderSupportLink() {
+		const { supportLink, translate } = this.props;
+
+		return translate( '{{a}}Learn more{{/a}}', {
+			components: {
+				a: <ExternalLink href={ supportLink } target="_blank" icon iconSize={ 14 } />,
+			},
+		} );
 	}
 }
 
-export default connect( state => {
+export default connect( ( state, ownProps ) => {
+	const { fields } = ownProps;
+
+	const podcastingCategoryId = Number( fields && fields.podcasting_category_id );
+	const isPodcastingEnabled = podcastingCategoryId > 0;
+
 	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSelectedSiteSlug( state );
+
+	const detailsLink = `/settings/podcasting/${ siteSlug }`;
+	const supportLink =
+		'https://' + getSupportSiteLocale() + '.support.wordpress.com/audio/podcasting/';
 
 	return {
-		siteSlug: getSelectedSiteSlug( state ),
+		siteSlug,
 		isPrivate: isPrivateSite( state, siteId ),
+		isPodcastingEnabled,
+		detailsLink,
+		supportLink,
 	};
 } )( localize( PodcastingLink ) );

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -1,3 +1,87 @@
+// Podcasting section/link on Writing settings page
+
+.podcasting-details__link {
+	&:not( .is-enabled ) {
+		.podcasting-details__link-button {
+			padding-left: 24px;
+			padding-right: 24px;
+		}
+	}
+
+	.podcasting-details__link-action-container {
+		display: flex;
+		align-items: flex-start;
+
+		.podcasting-details__link-info {
+			flex-grow: 1;
+			color: $gray-text;
+			margin-right: 12px;
+		}
+		.podcasting-details__link-button {
+			color: $gray-darken-20;
+			font-weight: bold;
+			flex-shrink: 0;
+		}
+	}
+
+	a.external-link {
+		text-decoration: underline;
+		white-space: nowrap;
+
+		&:hover, &:focus, &:active {
+			color: $link-highlight;
+		}
+
+		.gridicons-external {
+			margin-left: 5px;
+			color: $gray-text-min;
+		}
+	}
+
+	.podcasting-details__link-feed-label {
+		font-weight: 600;
+		margin-bottom: 5px;
+	}
+}
+
+.podcasting-details__link.is-enabled {
+	.podcasting-details__link-info {
+		position: relative;
+		background: $gray-lighten-30;
+		align-self: stretch;
+		padding: 4px 6px 4px 0;
+		// Center contents vertically
+		// Note this element contains a <span> container to ensure normal
+		// display (whitespace) between text items
+		display: flex;
+		align-items: center;
+	}
+
+	.podcasting-details__link-button {
+		// For small viewports when the text is taller than the button
+		align-self: center;
+	}
+
+	.gridicons-microphone {
+		flex-shrink: 0;
+		margin: 0 4px 0 6px;
+		color: $podcasting-purple;
+	}
+
+	.podcasting-details__link-feed {
+		margin-top: 20px;
+	}
+
+	.podcasting-details__link-feed-url input {
+		color: $gray-text-min;
+		font-size: 14px;
+		padding: 6px 10px;
+		margin-bottom: 5px;
+	}
+}
+
+// Podcasting details page
+
 .podcasting-details__wrapper .form-setting-explanation {
 	margin-bottom: 6px;
 }
@@ -21,18 +105,6 @@
 		float: left;
 		width: 63%;
 	}
-}
-
-.podcasting-details__link-title {
-	color: 	$gray-dark;
-	font-weight: 600;
-}
-
-.podcasting-details__link-info {
-	color: $gray-text-min;
-	font-size: 13px;
-	font-style: italic;
-	font-weight: 400;
 }
 
 .podcasting-details__wrapper {


### PR DESCRIPTION
This PR redesigns and expands the functionality of the section that links from the Settings → Writing page to the podcasting settings page.  The new design includes:

- a brief explanation of the podcasting functionality and the next steps, which differ depending on whether podcasting is disabled or enabled
- a button instead of a chevron link to set up or manage podcasting settings
- if podcasting is enabled, a read-only text input displaying the podcast feed URL with a copy-to-clipboard button
- a link to the Podcasting support page, localized using the [`getSupportSiteLocale` helper](https://github.com/Automattic/wp-calypso/blob/0268e9e5/client/lib/i18n-utils/utils.js#L146-L161)

For now, the selected category name and feed URL are displaying placeholders.  We will address this in a future PR, because this one is already pretty large and I wanted to keep it mostly focused on markup and CSS changes.

## To test

Verify that when podcasting is enabled for a site, an informative message shows with a brief explanation of the enabled functionality, a way to copy the podcast's feed URL, and links to manage podcasting settings and to the podcasting support page:

> ![2018-06-13t13 03 24-0500](https://user-images.githubusercontent.com/227022/41369579-e872dd0e-6f0a-11e8-9cb5-06fe75f9f83b.png)

Verify that when podcasting is disabled for a site, an informative message shows with a brief explanation of the podcasting functionality and links to set up a podcast and to the podcasting support page:

> ![2018-06-13t12 19 34-0500](https://user-images.githubusercontent.com/227022/41369638-14978a7e-6f0b-11e8-9a7d-440db7708893.png)

Verify that the appropriate message still displays in this section for private sites:

> ![2018-06-13t11 43 11-0500](https://user-images.githubusercontent.com/227022/41369663-2146dba8-6f0b-11e8-9e32-09e9d0a7619f.png)

Verify that these sections display reasonably at all breakpoints, especially the more complicated section for when podcasting is enabled:

> <img src="https://user-images.githubusercontent.com/227022/41369713-41a35fde-6f0b-11e8-946a-351b2a2019b5.png" width="400">