### PR TITLE
Rewind: Change credentials timeout error message to more accurately reflect what happened

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -145,9 +145,9 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 		case 'service_unavailable':
 			announce(
 				translate(
-					"Our service isn't working right now. We're working to restore it as soon as possible."
+					'A error occurred when we were trying to validate your site information. Please make sure your credentials and host URL are correct and try again. If you need help, please click on the support chat link.'
 				),
-				{ button: translate( 'Try again' ), onClick: () => dispatch( action ) }
+				{ button: translate( 'Support chat' ), onClick: getHelp }
 			);
 			spreadHappiness(
 				'Rewind Credentials: update request failed on timeout (could be us or remote site)'


### PR DESCRIPTION
When a timeout occurs during the update-credentials request, we send a `service_unavailable` message, which leads to "Our service isn't working right now..." in the UI. This isn't accurate.

![screen shot 2018-06-13 at 2 42 56 pm](https://user-images.githubusercontent.com/5528445/41375795-1ef6a1ca-6f25-11e8-8f2c-22820d058b4a.png)

Instead, the credentials or host address are incorrect, and there are actions the user can take to rectify this. In this PR, we're updating the text to the following, and adding a help link instead of "Try again":

![screen shot 2018-06-13 at 3 14 04 pm](https://user-images.githubusercontent.com/5528445/41375842-3aae10ba-6f25-11e8-9978-c46e1b59579b.png)

Testing:

Attempt to save credentials in the clone site flow that you know are bad, OR, enter the SOURCE URL into the DESTINATION SERVER ADDRESS field. One of these should cause this error to occur. Obviously, the error should reflect the second screenshot above.