### PR TITLE
Sites Page: Fix site picker choking when path does not include registered route

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -333,13 +333,28 @@ export function siteSelection( context, next ) {
 	 * If the user has only one site, redirect to the single site
 	 * context instead of rendering the all-site views.
 	 *
+	 * IsSiteSelectionPath check we are in a page with only site picker.
+	 * If we are, should redirect even with siteFragment because it's the same page.
+	 *
 	 * If the /me/sites API endpoint hasn't returned yet, postpone the redirect until
 	 * after the sites data are available by scheduling a `SITES_ONCE_CHANGED` callback.
 	 */
-	if ( hasOneSite && ! siteFragment ) {
+	const isSiteSelectionPath = basePath === '/sites' || basePath === '/settings';
+	if ( hasOneSite && ( ! siteFragment || isSiteSelectionPath ) ) {
 		const redirectToPrimary = () => {
 			const primarySiteSlug = getPrimarySiteSlug( getState() );
-			let redirectPath = `${ context.pathname }/${ primarySiteSlug }`;
+
+			let pathname = context.pathname;
+			switch ( basePath ) {
+				case '/sites':
+					pathname = '/stats/insights';
+					break;
+				case '/settings':
+					pathname = '/settings/general';
+					break;
+			}
+
+			let redirectPath = `${ pathname }/${ primarySiteSlug }`;
 
 			redirectPath = context.querystring
 				? `${ redirectPath }?${ context.querystring }`

--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -18,7 +18,7 @@ import Card from 'components/card';
 import Main from 'components/main';
 import observe from 'lib/mixins/data-observe';
 import SiteSelector from 'components/site-selector';
-import { addSiteFragment } from 'lib/route';
+import { addSiteFragment, sectionify } from 'lib/route';
 import getSites from 'state/selectors/get-sites';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
@@ -128,7 +128,19 @@ export const Sites = createReactClass( {
 } );
 
 const selectSite = ( siteId, rawPath ) => ( dispatch, getState ) => {
-	const path = rawPath === '/sites' ? '/stats/insights' : rawPath;
+	const basePath = sectionify( rawPath );
+
+	let path = rawPath;
+
+	switch ( basePath ) {
+		case '/sites':
+			path = '/stats/insights';
+			break;
+		case '/settings':
+			path = '/settings/general';
+			break;
+	}
+
 	page( addSiteFragment( path, getSiteSlug( getState(), siteId ) ) );
 };
 


### PR DESCRIPTION
**Problem:**

Issue #11543 

1. When we are in `/sites` the site picker works.
2. But in `/sites/mywebsite.com` it change the current site, but that's all because `/sites/mywebsite.com` is equal to `/sites/anothersite.com`.

**Solution:**

We can fix the routing by:

- Redirecting `/sites/mywebsite.com` to `/sites` (like `/sites/invalid.com`) or to `/stats/insights/mywebsite.com` like a shortcut.
- Considering `/sites/mywebsite.com` like `/sites` and onClick will go to `/stats/insights/selectedsite.com` (that's the proposed solution in this initial PR).
- Consider it a 404

**Another Problem:**

Site picker on `/settings/mywebsite.com` fails too.

**Solution:**

- Redirect `/settings/mywebsite.com` to site settings (`/settings/general/mywebsite.com`)
- Considering `/settings/mywebsite.com` like `/settings/general` and onClick will go to `/settings/general/selectedsite.com` (that's the proposed solution in this initial PR).
- Consider to be 404

**EDIT:**

1 - Just for clarifying: each item of list is a option to fix the problem not a step.
2 - Rewrited list of solutions to be more clear