### PR TITLE
Build/Test: Cache the npm cache on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,17 @@ jobs:
             mkdir -p $CIRCLE_ARTIFACTS
             mkdir -p $CIRCLE_TEST_REPORTS
 
+      - restore_cache:
+          name: "Restoring npm cache"
+          key: v1-{{ checksum ".nvmrc" }}-npmcache
+
       - run: npm ci
+
+      - save_cache:
+          name: "Saving npm cache"
+          key: v1-{{ checksum ".nvmrc" }}-npmcache
+          paths:
+            - ~/.npm
 
       - run:
           name: Build Server

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,13 +30,14 @@ jobs:
 
       - restore_cache:
           name: "Restoring npm cache"
-          key: v1-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}-npmcache
+          key: v1-npmcache-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
+          key: v1-npmcache-{{ checksum ".nvmrc" }}
 
       - run: npm ci
 
       - save_cache:
           name: "Saving npm cache"
-          key: v1-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}-npmcache
+          key: v1-npmcache-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
           paths:
             - ~/.npm
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,13 +30,13 @@ jobs:
 
       - restore_cache:
           name: "Restoring npm cache"
-          key: v1-{{ checksum ".nvmrc" }}-npmcache
+          key: v1-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}-npmcache
 
       - run: npm ci
 
       - save_cache:
           name: "Saving npm cache"
-          key: v1-{{ checksum ".nvmrc" }}-npmcache
+          key: v1-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}-npmcache
           paths:
             - ~/.npm
 


### PR DESCRIPTION
`npm ci` removes all of a project's node_modules before installing.
Caching `node_modules` on our testing platform is therefore
counterproductive (#25431).

However, `npm ci` can use the npm cache to avoid heavy network usage.
This change adds CircleCI caching for the npm cache.

Some anecdotal evidence: https://github.com/Automattic/wp-calypso/pull/25487#issuecomment-397228180