### PR TITLE
Build/Test: Try adding babel cache caching to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,11 +46,21 @@ jobs:
           paths:
             - ~/.npm
 
+      - restore_cache:
+          name: Restoring server build babel cache
+          key: v1-server-babel-
+
       - run:
           name: Build Server
           environment:
               NODE_ENV: test
           command: npm run build-server
+
+      - save_cache:
+          name: Saving server build babel cache
+          key: v1-server-babel-{{ epoch }}
+          paths:
+            - "build/.babel-server-cache"
 
       - run:
           name: Build calypso-strings.pot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,8 @@ jobs:
 
       - restore_cache:
           name: Restore Server Build Babel cache
-          key: v1-server-babel-{{ checksum "npm-shrinkwrap.json"}}
+          key: v1-server-babel-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
+          key: v1-server-babel-{{ checksum ".nvmrc" }}
 
       - run:
           name: Build Server
@@ -58,7 +59,7 @@ jobs:
 
       - save_cache:
           name: Saving Server Build Babel cache
-          key: v1-server-babel-{{ checksum "npm-shrinkwrap.json" }}-{{ epoch }}
+          key: v1-server-babel-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
           paths:
             - "build/.babel-server-cache"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,8 @@ jobs:
             - ~/.npm
 
       - restore_cache:
-          name: Restoring server build babel cache
-          key: v1-server-babel-
+          name: Restore Server Build Babel cache
+          key: v1-server-babel-{{ checksum "npm-shrinkwrap.json"}}
 
       - run:
           name: Build Server
@@ -57,8 +57,8 @@ jobs:
           command: npm run build-server
 
       - save_cache:
-          name: Saving server build babel cache
-          key: v1-server-babel-{{ epoch }}
+          name: Saving Server Build Babel cache
+          key: v1-server-babel-{{ checksum "npm-shrinkwrap.json" }}-{{ epoch }}
           paths:
             - "build/.babel-server-cache"
 


### PR DESCRIPTION
Try storing and sharing `build/.babel-server-cache` among builds.

Cache keys are designed to always pull the latest cache, and save after. [save_cache](https://circleci.com/docs/2.0/configuration-reference/#save_cache) and [restore_cache](https://circleci.com/docs/2.0/configuration-reference/#restore_cache)

Does this speed up subsequent builds?
Is the speed up offset by the save step, or is there a net improvement?

~Will the size of the babel cache increase monotonically? How should we control this? Flush on `npm-shrinkwrap.json` checksum?~ Added key on `npm-shrinkwrap`. All builds should accumulate the babel cache and share the latest with a matching `npm-shrinkwrap.json` checksum.