### PR TITLE
Build/Test: Add step names to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,11 @@ jobs:
 
       - run: npm ci
 
-      - run: NODE_ENV=test npm run build-server
+      - run:
+          name: Build Server
+          environment:
+              NODE_ENV: test
+          command: npm run build-server
 
       - run:
           name: Build calypso-strings.pot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,13 @@ jobs:
 
     steps:
       - restore_cache:
+          name: Restore git cache
           key: v1-20180524-git
 
       - checkout
 
       - save_cache:
+          name: Save git cache
           key: v1-20180524-git
           paths:
             - ".git"
@@ -31,11 +33,13 @@ jobs:
       - run: NODE_ENV=test npm run build-server
 
       - run:
+          name: Build calypso-strings.pot
           command: |
             npm run translate; mkdir -p $CIRCLE_ARTIFACTS/translate
             mv calypso-strings.pot $CIRCLE_ARTIFACTS/translate
 
       - run:
+          name: Build New Strings .pot
           command: |
             git clone https://github.com/Automattic/gp-localci-client.git
             bash gp-localci-client/generate-new-strings-pot.sh $CIRCLE_BRANCH $CIRCLE_SHA1 $CIRCLE_ARTIFACTS/translate
@@ -47,7 +51,7 @@ jobs:
             bin/run-integration $(circleci tests glob "bin/**/integration/*.js" "client/**/integration/*.js" "server/**/integration/*.js" | circleci tests split --split-by=timings)
 
       - run:
-          name: Lint
+          name: Lint Config Keys
           command: npm run lint:config-defaults
 
       - run:


### PR DESCRIPTION
Is it helpful to have descriptive concise names for CircleCI steps? Are these names concise, descriptive, helpful and accurate?

Also uses `environment` map for command scoped environment on `build-server`.

## Screens

### Before (`master`)

![before](https://user-images.githubusercontent.com/841763/41406572-101b22f4-6fcd-11e8-90ff-c538e225890c.png)

### After

![after](https://user-images.githubusercontent.com/841763/41407535-037d6900-6fd0-11e8-9cd8-72bced525826.png)

## Testing

Look at the step names in CI. Good? An improvement?

https://circleci.com/gh/Automattic/wp-calypso/97201