### PR TITLE
Canonical URLs: fix /log-in DocumentHead: canonical, title, and meta

### DIFF
--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -168,7 +168,7 @@ export class Login extends React.Component {
 
 	render() {
 		const { locale, privateSite, socialConnect, translate, twoFactorAuthType } = this.props;
-		const canonicalUrl = addLocaleToWpcomUrl( 'https://wordpress.com/login', locale );
+		const canonicalUrl = addLocaleToWpcomUrl( 'https://wordpress.com/log-in', locale );
 
 		return (
 			<div>

--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -23,7 +23,9 @@ export const title = createReducer(
 	'',
 	{
 		[ DOCUMENT_HEAD_TITLE_SET ]: ( state, action ) => action.title,
-		[ ROUTE_SET ]: () => '',
+		[ ROUTE_SET ]: ( state, action ) => {
+			return action.isSSR ? state : '';
+		},
 	},
 	titleSchema
 );
@@ -41,7 +43,9 @@ export const meta = createReducer(
 	[ { property: 'og:site_name', content: 'WordPress.com' } ],
 	{
 		[ DOCUMENT_HEAD_META_SET ]: ( state, action ) => action.meta,
-		[ ROUTE_SET ]: () => DEFAULT_META_STATE,
+		[ ROUTE_SET ]: ( state, action ) => {
+			return action.isSSR ? state : DEFAULT_META_STATE;
+		},
 	},
 	metaSchema
 );
@@ -50,7 +54,9 @@ export const link = createReducer(
 	[],
 	{
 		[ DOCUMENT_HEAD_LINK_SET ]: ( state, action ) => action.link,
-		[ ROUTE_SET ]: () => [],
+		[ ROUTE_SET ]: ( state, action ) => {
+			return action.isSSR ? state : [];
+		},
 	},
 	linkSchema
 );

--- a/client/state/ui/actions.js
+++ b/client/state/ui/actions.js
@@ -44,15 +44,20 @@ export function setAllSitesSelected() {
 /**
  * Returns an action object signalling that the current route is to be changed
  *
- * @param  {String} path    Route path
- * @param  {Object} [query] Query arguments
- * @return {Object}         Action object
+ * @param  {String}  path    Route path
+ * @param  {Object}  [query] Query arguments
+ * @param  {boolean} isSSR   If this is a ServerSideRendering call, then the actions make take different decisions.
+ *                           One example: in case of SSR, the title, meta, and links may be preloaded from cache and
+ *                           therefore have a valid value that should not make ROUTE_SET behave as the user would have
+ *                           changed the page by clicking a link.
+ * @return {Object}          Action object
  */
-export function setRoute( path, query = {} ) {
+export function setRoute( path, query = {}, isSSR = false ) {
 	return {
 		type: ROUTE_SET,
 		path,
 		query,
+		isSSR,
 	};
 }
 

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -47,7 +47,7 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 }
 
 function setRouteMiddleware( context, next ) {
-	context.store.dispatch( setRouteAction( context.pathname, context.query ) );
+	context.store.dispatch( setRouteAction( context.pathname, context.query, true ) );
 
 	next();
 }

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -191,7 +191,7 @@ function getDefaultContext( request ) {
 	// i.e. they can be created by route-specific middleware. `getDefaultContext` is always
 	// called before route-specific middleware, so it's up to the cache *writes* in server
 	// render to make sure that Redux state and markup are only cached for whitelisted query args.
-	const cacheKey = getNormalizedPath( request.pathname, request.query );
+	const cacheKey = getNormalizedPath( request.path, request.query );
 	const geoLocation = ( request.headers[ 'x-geoip-country-code' ] || '' ).toLowerCase();
 	const isDebug = calypsoEnv === 'development' || request.query.debug !== undefined;
 


### PR DESCRIPTION
Before this change, accessing https://wordpress.com/log-in would, most of the time, show a "WordPress.com" default title tag and no valid link rel=canonical (although the code has both a title - WordPress.com Log-In, and a rel=canonical defined). The reason is that the title and rel=canonical is only rendered properly when the page is NOT loaded from cache (keyword: SSR). In development, the first load would trigger the correct version of the page (observe the page title), while the 2nd one would make both the title and the rel="canonical" reset to the default values (or disappear).

After this change, the title and the rel=canonical should be rendered with each page refresh. What the commit includes:

1) Fixes the on-read cacheKey, making it use request.path instead of request.pathname (which is always undefined)
2) When dispatching ROUTE_SET (the Redux action that was actually clearing the title), it also informs the system that this is a SSR request. Therefore, the reducers can make decisions based on that.
3) Modifies the reducers that were setting the title and rel=canonical to blank/defaults such that they don't change the value when this is a first-time SSR rendering.

Rewinding to the problem, described in a few easy steps (same order as in the code):

1. The state.documentHead (other filtered & cache loaded nodes: themes, ui) is loaded from cache (server/pages/index.js:200)
2. When doing the server-side rendering, ROUTE_SET is called ( server/isomorphic-routing/index.js, setRouteMiddleware) after the data at #1 was loaded from cache: `context.store.dispatch( setRouteAction( context.pathname, context.query, true ) );`
3. Because ROUTE_SET is called, the reducer cleans documentHead values ( client/state/document-head/reducer.js: 26, 35, 44, 53 ): `[ ROUTE_SET ]: () => '',`
4. ... and therefore the title, meta, and links are rendered with blank or default values on page refresh.

I thought of the following variants for fixing:
1. Remove ROUTE_SET 'reset to default' reducers for links, title, meta - too dangerous, too many uncontrolled side-effects, since we very probably expect the route change to clear this data
2. Let ROUTE_SET reducer know if this is a first-time SSR load and keep the previously loaded value (the one that the state has) - ADOPTED solution
3. Introduce a middleware that sets the links, title, meta after they were cleaned by ROUTE_SET. But since ROUTE_SET modifies the state, I would have needed to access the previous state OR to hold the values somewhere else in the context (context.cacheLoadedState), which would change too much of the flow in pages/index : getDefaultContext.
4. Introduce another action like ROUTE_SET_SSR, which would be called instead of ROUTE_SET. But practically that would mean that all the places where ROUTE_SET has reducers would need a ROUTE_SET_SSR that would replicate the behavior (except where we wouldn't want that to happen).
5. Do not call ROUTE_SET at all when SSR-ying, but that would mean that all the reducers where ROUTE_SET actually is useful would not be triggered.

How to (happy-)test:
1) Checkout the branch and start the server `npm start`. You can also do it on calypso.live, but locally you have more control on the cache.
2) Access https://calypso.localhost:3000/log-in
3) See the page title. Should contain 'Log In'. In production probably it doesn't.
4) Look at the page source (not Inspector, but rather real page source that was initially generated). You should see a rel=canonical pointing to the /log-in source.
5) Access https://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2Fgo%2Ftutorials%2Fthree-tips-for-taking-a-vacation-thats-good-for-you-and-your-business%2F (so now we have a parameter) and repeat step 4. The canonical should be the same as before. Try a few more URLs that have redirect_to.
6) Access themes section and make sure everything is ok, as in production. Themes section is also SSR-ed and uses the cache. Watch for the page title, hoping that everything works as expected (or better than expected).
7) If you know what 'ui' is used for in the state, then also do a regression testing to see what is happening.