### PR TITLE
Build: Only lint files that have changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       - run:
           name: Lint Client and Server
           command: |
-            ./node_modules/.bin/eslint-eslines $(git diff --name-only origin/master... | grep -E "^(client|server).+\.jsx?" | circleci tests split)
+            ./node_modules/.bin/eslint-eslines $(git diff --name-only origin/master... | grep -E '^(client|server)' | grep -E '\.jsx?$' | circleci tests split)
 
       - run:
           name: Run Client Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,11 @@ jobs:
 
       - checkout
 
+    # Update origin/master so we can diff against it later
+      - run:
+          name: Update master branch
+          command: git fetch --force origin master
+
       - save_cache:
           name: Save git cache
           key: v1-20180524-git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
       - run:
           name: Lint Client and Server
           command: |
-            ./node_modules/.bin/eslint-eslines $(circleci tests glob "client/**/*.js" "client/**/*.jsx" "server/**/*.js" "server/**/*.jsx" | circleci tests split)
+            ./node_modules/.bin/eslint-eslines $(git diff --name-only origin/master... | grep -E "^(client|server).+\.jsx?" | circleci tests split)
 
       - run:
           name: Run Client Tests


### PR DESCRIPTION
Only lint files that have changed. This assumes we're merging into master, but I think that's a pretty safe assumption for most things.

I also looked at using CIRCLE_COMPARE_URL, but that only tells us what changes are in the current build vs. the previous build, not what changes are in the PR. 

To test, make a new branch from this PR and modify some js or jsx files in client and server. Make a PR targeting master and watch the Circle tests. Only the modified files should be linted.