### PR TITLE
Fix Disconnect Google My Business from Sharing

### DIFF
--- a/client/state/site-keyrings/reducer.js
+++ b/client/state/site-keyrings/reducer.js
@@ -90,7 +90,11 @@ const items = createReducer(
 		[ SITE_KEYRINGS_DELETE_SUCCESS ]: ( state, { siteId, keyringId, externalUserId } ) => ( {
 			...state,
 			[ siteId ]: ( state[ siteId ] || [] ).filter(
-				keyring => keyring.keyring_id !== keyringId || keyring.external_user_id !== externalUserId
+				keyring =>
+					! (
+						keyring.keyring_id === keyringId &&
+						( ! externalUserId || keyring.external_user_id === externalUserId )
+					)
 			),
 		} ),
 	},


### PR DESCRIPTION
Calling deleteSiteKeyring without an external user id actually removes all site keyrings matching the keyring id, but only site keyrings matching both the keyring id and the external user id are removed ath the moment.

This causes the Disconnect button for GMB to now update when clicking on it.

### Testing Instructions
- Boot the branch locally
- Connect a GMB location to your site (full connect)
- Go to Sharing, click on Disconnect
- The button should update to Connect

### Reviews
- [ ] Code
- [ ] Product
