### PR TITLE
SSR: Fix cacheKey generating function argument

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -191,7 +191,7 @@ function getDefaultContext( request ) {
 	// i.e. they can be created by route-specific middleware. `getDefaultContext` is always
 	// called before route-specific middleware, so it's up to the cache *writes* in server
 	// render to make sure that Redux state and markup are only cached for whitelisted query args.
-	const cacheKey = getNormalizedPath( request.pathname, request.query );
+	const cacheKey = getNormalizedPath( request.path, request.query );
 	const geoLocation = ( request.headers[ 'x-geoip-country-code' ] || '' ).toLowerCase();
 	const isDebug = calypsoEnv === 'development' || request.query.debug !== undefined;
 


### PR DESCRIPTION
Found by @a8dar per #25493. There's no such thing as `request.pathname` in Express -- `pathname` is a `page.js` concept! I missed this in #24152 (tho the erroneous `pathname` had been there before).

This, together with #25003, seems to finally fix SSR!