### PR TITLE
Guided Tour: Redirect to Login page if logged out

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -108,8 +108,8 @@ const loggedOutMiddleware = currentUser => {
 
 	page( '*', ( context, next ) => {
 		if ( isValidSection( context.path ) ) {
-			// redirect to login page if we're not on it already
-			if ( ! startsWith( context.path, '/log-in' ) ) {
+			// redirect to login page if we're not on it already, only for stats for now
+			if ( startsWith( context.path, '/stats' ) ) {
 				return page.redirect( '/log-in/?redirect_to=' + encodeURIComponent( context.path ) );
 			}
 			next();

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -108,6 +108,10 @@ const loggedOutMiddleware = currentUser => {
 
 	page( '*', ( context, next ) => {
 		if ( isValidSection( context.path ) ) {
+			// redirect to login page if we're not on it already
+			if ( ! startsWith( context.path, '/log-in' ) ) {
+				return page.redirect( '/log-in/?redirect_to=' + encodeURIComponent( context.path ) );
+			}
 			next();
 		}
 	} );

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -188,6 +188,7 @@ const sections = [
 		module: 'my-sites/stats',
 		secondary: true,
 		group: 'sites',
+		enableLoggedOut: true,
 	},
 	{
 		name: 'checklist',


### PR DESCRIPTION
**EDIT:** This PR has been amended to more surgically focused. A framework-wide redirect for all logged-in pages to the login screen should be pursued, but this is tied to a time-sensitive project and I don't have the resources to pursue something on the framework level. 

All that will happen now is that if you hit a URL beginning with `/stats`, you will be redirected to the login page and then back to your original URL on success. This will enable the users who click in their email to the Guided Tour and are logged out to actually enter it.

Original discussion left below for posterity. I will try to open a Framework issue later.

---

When you hit a valid route as a logged-out user, we should send you to the login page with a redirect back to the page you were trying to access. This is how all `wp-admin` links in core WP works.

There have been fixes for individual pages (eg #24687) but this should be handled at the framework level. We have an email campaign using the Simple Payments Guided Tour (#24627) and it freezes at a blank screen for a logged-out user, using the path `/stats/day/{siteName}/?tour=simplePaymentsEmailTour`.

What this change does is to do a redirect for a valid section with the `enableLoggedOut` property set to true to the login screen with a redirect. A future PR could probably remove all bespoke uses of `import { redirectLoggedOut } from 'controller'` as well since this should supersede it.