### PR TITLE
Signup: update plans tables after AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -83,15 +83,6 @@ export default {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
-	mobilePlansTablesOnSignup: {
-		datestamp: '20180330',
-		variations: {
-			original: 50,
-			vertical: 50,
-		},
-		defaultVariation: 'original',
-		allowExistingUsers: true,
-	},
 	jetpackSignupGoogleTop: {
 		datestamp: '20180427',
 		variations: {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -71,7 +71,6 @@ class PlanFeatures extends Component {
 			`has-${ planProperties.length }-cols`
 		);
 		const planClasses = classNames( 'plan-features', {
-			'has-mobile-table': abtest( 'mobilePlansTablesOnSignup' ) === 'vertical',
 			'plan-features--signup': isInSignup,
 		} );
 		const planWrapperClasses = classNames( { 'plans-wrapper': isInSignup } );

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -64,17 +64,6 @@ import {
 } from 'lib/plans/constants';
 
 class PlanFeatures extends Component {
-	componentDidMount() {
-		const { basePlansPath, isInSignup } = this.props;
-		// Check if user is in signup flow & small screens
-		// Used in AB test: mobilePlansTablesOnSignup_20180330
-		if ( isInSignup && window.matchMedia( '(max-width: 660px)' ).matches ) {
-			this.props.recordTracksEvent( 'calypso_wp_plans_verticalabtest_view', {
-				base_plans_path: basePlansPath,
-			} );
-		}
-	}
-
 	render() {
 		const { isInSignup, planProperties } = this.props;
 		const tableClasses = classNames(

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -85,10 +85,6 @@ class PlanFeatures extends Component {
 
 		mobileView = <div className="plan-features__mobile">{ this.renderMobileView() }</div>;
 
-		if ( isInSignup && abtest( 'mobilePlansTablesOnSignup' ) === 'original' ) {
-			mobileView = '';
-		}
-
 		return (
 			<div className={ planWrapperClasses } ref={ this.setScrollLeft }>
 				<QueryActivePromotions />

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -86,7 +86,7 @@ class PlanFeatures extends Component {
 		mobileView = <div className="plan-features__mobile">{ this.renderMobileView() }</div>;
 
 		return (
-			<div className={ planWrapperClasses } ref={ this.setScrollLeft }>
+			<div className={ planWrapperClasses }>
 				<QueryActivePromotions />
 				<div className={ planClasses }>
 					{ this.renderUpgradeDisabledNotice() }
@@ -107,15 +107,6 @@ class PlanFeatures extends Component {
 			</div>
 		);
 	}
-
-	setScrollLeft = plansWrapper => {
-		const { isInSignup, displayJetpackPlans } = this.props;
-
-		// center plans
-		if ( isInSignup && plansWrapper ) {
-			displayJetpackPlans ? ( plansWrapper.scrollLeft = 312 ) : ( plansWrapper.scrollLeft = 495 );
-		}
-	};
 
 	renderDiscountNotice() {
 		const { canPurchase, hasPlaceholders, withDiscount, activeDiscount } = this.props;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -449,28 +449,29 @@ $plan-features-sidebar-width: 272px;
 	margin: 0 auto;
 
 	.jetpack-connect__plans & {
-		max-width: 1000px;
+		width: auto;
 
-		@include breakpoint( "<660px" ) {
-			width: auto;
+		@include breakpoint( ">660px" ) {
+			max-width: 1000px;
 		}
 	}
 
 	.signup__steps & {
-		max-width: 1100px;
+		width: auto;
 
-		@include breakpoint( "<660px" ) {
-			width: auto;
+		@include breakpoint( ">660px" ) {
+			max-width: 1100px;
 		}
 	}
 
 	.plan-features__table {
-		width: 100%;
-		margin: 0;
-		padding: 0 16px;
+		display: none;
 
-		@include breakpoint( "<660px" ) {
-			display: none !important;
+		@include breakpoint( ">660px" ) {
+			display: table;
+			width: 100%;
+			margin: 0;
+			padding: 0 16px;
 		}
 
 		@include breakpoint( ">1040px" ) {
@@ -501,15 +502,16 @@ $plan-features-sidebar-width: 272px;
 	}
 
 	.plan-features__graphic {
-		width: 100px;
-		height: 100px;
-		margin: 20px auto;
+		float: right;
+		width: 50px;
+		height: 50px;
+		margin: 16px 20px;
 
-		@include breakpoint( "<660px" ) {
-			float: right;
-			width: 50px;
-			height: 50px;
-			margin: 16px 20px;
+		@include breakpoint( ">660px" ) {
+			float: none;
+			width: 100px;
+			height: 100px;
+			margin: 20px auto;
 		}
 	}
 
@@ -519,11 +521,12 @@ $plan-features-sidebar-width: 272px;
 	}
 
 	.plan-features__pricing {
-		padding: 0 12px;
+		margin: 20px 20px -12px;
+		padding: 0;
 
-		@include breakpoint( "<660px" ) {
-			margin: 20px 20px -12px;
-			padding: 0;
+		@include breakpoint( ">660px" ) {
+			margin-bottom: 0;
+			padding: 0 12px;
 		}
 	}
 

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -445,29 +445,38 @@ $plan-features-sidebar-width: 272px;
 	overflow-x: auto;
 }
 
-.touch {
-	.plans-wrapper {
-		overflow-x: scroll;
-		-webkit-overflow-scrolling: touch;
-	}
-}
-
 .plan-features--signup {
 	margin: 0 auto;
 
 	.jetpack-connect__plans & {
-		width: 1000px;
+		max-width: 1000px;
+
+		@include breakpoint( "<660px" ) {
+			width: auto;
+		}
 	}
 
 	.signup__steps & {
-		width: 1100px;
+		max-width: 1100px;
+
+		@include breakpoint( "<660px" ) {
+			width: auto;
+		}
 	}
 
 	.plan-features__table {
-		display: table !important;
-		border-spacing: 15px 0 !important;
 		width: 100%;
 		margin: 0;
+		padding: 0 16px;
+
+		@include breakpoint( "<660px" ) {
+			display: none !important;
+		}
+
+		@include breakpoint( ">1040px" ) {
+			border-spacing: 15px 0 !important;
+			padding: 0;
+		}
 	}
 
 	.plan-features__content {
@@ -495,11 +504,27 @@ $plan-features-sidebar-width: 272px;
 		width: 100px;
 		height: 100px;
 		margin: 20px auto;
+
+		@include breakpoint( "<660px" ) {
+			float: right;
+			width: 50px;
+			height: 50px;
+			margin: 16px 20px;
+		}
 	}
 
 	.plan-features__pricing,
 	.plan-price.is-discounted {
 		color: $gray-dark;
+	}
+
+	.plan-features__pricing {
+		padding: 0 12px;
+
+		@include breakpoint( "<660px" ) {
+			margin: 20px 20px -12px;
+			padding: 0;
+		}
 	}
 
 	.is-placeholder {
@@ -544,36 +569,9 @@ $plan-features-sidebar-width: 272px;
 	.plan-features__row:last-of-type .plan-features__table-item {
 		border-bottom: solid 1px lighten( $gray, 27% );
 	}
-}
 
-/**
- * A/B test for horizontal vs vertical scroll
- */
-.has-mobile-table.plan-features--signup {
-
-	@include breakpoint( "<660px" ) {
-
-		.signup__steps &,
-		.jetpack-connect__plans & {
-			width: auto;
-		}
-
-		.plan-features__graphic {
-			float: right;
-			width: 50px;
-			height: 50px;
-			margin: 16px 20px;
-		}
-
-		.plan-features__pricing {
-			margin: 20px 20px -12px;
-		}
-
-		.plan-features__table {
-			display: none !important;
-		}
-
-		.jetpack-connect__hide-plan-icons .jetpack-connect__plans & .plan-features__pricing {
+	.jetpack-connect__hide-plan-icons .jetpack-connect__plans & .plan-features__pricing {
+		@include breakpoint( "<660px" ) {
 			padding-top: 0;
 		}
 	}


### PR DESCRIPTION
This PR removes the AB test code added in #23454 and updated later in #23802.
It also updates the existing code to always render the `mobileView` on smaller devices, and updates all associated styles.

More details in: p6TEKc-29X-p2

Fixes #18660

Related wp-e2e-tests PR: https://github.com/Automattic/wp-e2e-tests/pull/1271

### Testing

- Checkout this branch.
- Go to `/start/plans` or `/jetpack/connect/plans/[SITE_URL]` and verify that tables are presented correctly:
  - Desktop, responsive version for screens 661px wide or more.
  - Mobile, responsive version for screens 660px wide of less.