### PR TITLE
DocumentHead: Only reset `unreadCount` on ROUTE_SET

### DIFF
--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -23,7 +23,6 @@ export const title = createReducer(
 	'',
 	{
 		[ DOCUMENT_HEAD_TITLE_SET ]: ( state, action ) => action.title,
-		[ ROUTE_SET ]: () => '',
 	},
 	titleSchema
 );
@@ -38,10 +37,9 @@ export const unreadCount = createReducer(
 );
 
 export const meta = createReducer(
-	[ { property: 'og:site_name', content: 'WordPress.com' } ],
+	DEFAULT_META_STATE,
 	{
 		[ DOCUMENT_HEAD_META_SET ]: ( state, action ) => action.meta,
-		[ ROUTE_SET ]: () => DEFAULT_META_STATE,
 	},
 	metaSchema
 );
@@ -50,7 +48,6 @@ export const link = createReducer(
 	[],
 	{
 		[ DOCUMENT_HEAD_LINK_SET ]: ( state, action ) => action.link,
-		[ ROUTE_SET ]: () => [],
 	},
 	linkSchema
 );

--- a/client/state/document-head/test/reducer.js
+++ b/client/state/document-head/test/reducer.js
@@ -32,13 +32,6 @@ describe( 'reducer', () => {
 
 			expect( newState ).to.equal( 'new title' );
 		} );
-
-		it( 'should return initial state on route set action', () => {
-			const original = 'new title';
-			const state = title( original, { type: ROUTE_SET } );
-
-			expect( state ).to.equal( '' );
-		} );
 	} );
 
 	describe( '#unreadCount()', () => {
@@ -88,13 +81,6 @@ describe( 'reducer', () => {
 
 			expect( newState ).to.eql( expectedState );
 		} );
-
-		it( 'should return initial state on route set action', () => {
-			const original = deepFreeze( [ { content: 'some content', type: 'some type' } ] );
-			const state = meta( original, { type: ROUTE_SET } );
-
-			expect( state ).to.eql( DEFAULT_META_STATE );
-		} );
 	} );
 
 	describe( '#link()', () => {
@@ -119,13 +105,6 @@ describe( 'reducer', () => {
 			const expectedState = [ { rel: 'another-rel', href: 'https://automattic.com' } ];
 
 			expect( newState ).to.eql( expectedState );
-		} );
-
-		it( 'should return initial state on route set action', () => {
-			const original = deepFreeze( [ { rel: 'some-rel', href: 'https://wordpress.org' } ] );
-			const state = link( original, { type: ROUTE_SET } );
-
-			expect( state ).to.eql( [] );
 		} );
 	} );
 } );


### PR DESCRIPTION
Variation of #25005 (without requiring #24980).

This is the conclusion of a call with @a8dar and @sirreal, based on previous work and investigation found in #25493 and #23961, etc.

Reverts most of #8224, except for its main objective: to reset `unreadCount` upon route change. However, resetting all the other parts of `document-head` (title, meta, and links) turned out to be undesirable found documented in the issues and PRs linked from this PR :)

Fixes #24977. Also fixes #23924.

Stealing @a8dar's testing instructions from #25493:

> 1) Checkout the branch and start the server `npm start`. You can also do it on calypso.live, but locally you have more control on the cache.
> 2) Access https://calypso.localhost:3000/log-in
> 3) See the page title. Should contain 'Log In'. In production probably it doesn't.
> 4) Look at the page source (not Inspector, but rather real page source that was initially generated). You should see a rel=canonical pointing to the /log-in source.
> 5) _[Skipping step 5 from #25493 which doesn't apply]_
> 6) Access themes section and make sure everything is ok, as in production. Themes section is also SSR-ed and uses the cache. Watch for the page title, hoping that everything works as expected (or better than expected).

Now reload any of these pages, and verify that the site title is still intact, and that the page source continues to include `canonical` `link`s.

---

This finally fixes server-side caching of `document-head` stuff.
Potential (but less crucial) follow-ups include #24980 and #25003.