### PR TITLE
Activity Log: fix issues with button that dismisses all updates

### DIFF
--- a/client/my-sites/stats/activity-log-tasklist/update.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/update.jsx
@@ -38,7 +38,7 @@ class ActivityLogTaskUpdate extends Component {
 	};
 
 	handleEnqueue = () => this.props.enqueue( this.props.toUpdate );
-	handleDismiss = () => this.props.dismiss( this.props.slug );
+	handleDismiss = () => this.props.dismiss( this.props.toUpdate );
 	handleNameClick = () => this.props.goToPage( this.props.slug, this.props.type );
 
 	render() {


### PR DESCRIPTION
This PR fixes issues with dismiss all button and introduces missed tracking for them
e update/dismissal:
- Dismiss all button now correctly dismisses themes as well as plugins. Events were renamed:
    - calypso_activitylog_tasklist_update_all
    - calypso_activitylog_tasklist_dismiss_all
- Dismiss all and Update all tracking events are now named generically:
    - calypso_activitylog_tasklist_update_all
    - calypso_activitylog_tasklist_dismiss_all
- Updating or dismissing a theme is now tracked:
    - calypso_activitylog_tasklist_update_theme
    - calypso_activitylog_tasklist_update_theme_from_error (when it's updated from the error notice)
    - calypso_activitylog_tasklist_dismiss_theme
    all these events receive the theme slug as meta property

### Testing

Verify that:
- the Dismiss all button dismisses all plugin _and_ theme updates
- the buttons to Dismiss or Update a theme fire tracking events
- updates should continue to work normally for plugins and themes