### PR TITLE
Jetpack authorize - send "from" parameter

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -218,11 +218,12 @@ Undocumented.prototype.jetpackAuthorize = function(
 	state,
 	redirect_uri,
 	secret,
-	jp_version
+	jp_version,
+	from
 ) {
 	debug( '/jetpack-blogs/:site_id:/authorize query' );
 	const endpointUrl = '/jetpack-blogs/' + siteId + '/authorize';
-	const params = { code, state, redirect_uri, secret, jp_version };
+	const params = { code, state, redirect_uri, secret, jp_version, from };
 	return this.wpcom.req.post( { path: endpointUrl }, params );
 };
 

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -352,7 +352,7 @@ export function authorize( queryObject ) {
 				} );
 				return wpcom
 					.undocumented()
-					.jetpackAuthorize( client_id, data.code, state, redirect_uri, secret, jp_version );
+					.jetpackAuthorize( client_id, data.code, state, redirect_uri, secret, jp_version, from );
 			} )
 			.then( data => {
 				debug( 'Jetpack authorize complete. Updating sites list.', data );


### PR DESCRIPTION
Jetpack server needs to know what flow a user was in while signing up.

To that end, this PR includes the "from" parameter when sending its "authorize" POST. This is being done on the "authorize" request so that the information is not trusted by the server until after user authentication.

This is part of a larger project, and should not be merged until some other pieces are deployed.