### PR TITLE
Framework: Update Redux DevTools integration

### DIFF
--- a/client/state/index.js
+++ b/client/state/index.js
@@ -242,6 +242,7 @@ export function createReduxStore( initialState = {} ) {
 		applyMiddleware( ...middlewares ),
 		isBrowser && window.app && window.app.isDebug && actionLogger,
 		isBrowser && window.devToolsExtension && window.devToolsExtension(),
+		isBrowser && window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
 	].filter( Boolean );
 
 	return compose( ...enhancers )( createStore )( reducer, initialState );


### PR DESCRIPTION
Starting from Redux DevTools v2.7, `window.devToolsExtension` was renamed to `window.__REDUX_DEVTOOLS_EXTENSION__` and `window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__`. See [here](https://github.com/zalmoxisus/redux-devtools-extension#usage) for the official documentation on this matter.

This change enables support for newer versions of Redux DevTools as well as preserving functionality of older versions.