### PR TITLE
Signup: Finalize reduxification of DependencyStore

### DIFF
--- a/client/lib/signup/dependency-store.js
+++ b/client/lib/signup/dependency-store.js
@@ -9,21 +9,20 @@ import { keys, difference, isEmpty } from 'lodash';
 /**
  * Internal dependencies
  */
-import { SIGNUP_COMPLETE_RESET, SIGNUP_DEPENDENCY_STORE_UPDATE } from 'state/action-types';
-
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
+import { updateDependencies, resetDependencies } from 'state/signup/dependency-store/actions';
 import Dispatcher from 'dispatcher';
 import steps from 'signup/config/steps';
 
 const SignupDependencyStore = {
-	get: function() {
+	get() {
 		return getSignupDependencyStore( SignupDependencyStore.reduxStore.getState() );
 	},
-	reset: function() {
-		SignupDependencyStore.reduxStore.dispatch( {
-			type: SIGNUP_COMPLETE_RESET,
-			data: {},
-		} );
+	update( dependencies ) {
+		SignupDependencyStore.reduxStore.dispatch( updateDependencies( dependencies ) );
+	},
+	reset() {
+		SignupDependencyStore.reduxStore.dispatch( resetDependencies() );
 	},
 	setReduxStore( reduxStore ) {
 		this.reduxStore = reduxStore;
@@ -61,10 +60,7 @@ SignupDependencyStore.dispatchToken = Dispatcher.register( function( payload ) {
 			case 'SUBMIT_SIGNUP_STEP':
 				if ( action.type === 'PROVIDE_SIGNUP_DEPENDENCIES' || assertValidDependencies( action ) ) {
 					// any dependency from `PROVIDE_SIGNUP_DEPENDENCIES` is valid as it is not associated with a step
-					SignupDependencyStore.reduxStore.dispatch( {
-						type: SIGNUP_DEPENDENCY_STORE_UPDATE,
-						data: action.providedDependencies,
-					} );
+					SignupDependencyStore.update( action.providedDependencies );
 				}
 				break;
 		}

--- a/client/lib/signup/test/dependency-store.js
+++ b/client/lib/signup/test/dependency-store.js
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import assert from 'assert'; // eslint-disable-line import/no-nodejs-modules
 import { createStore } from 'redux';
 
 /**
@@ -30,28 +29,29 @@ describe( 'dependency-store', () => {
 	} );
 
 	afterEach( () => {
+		SignupDependencyStore.reset();
 		SignupProgressStore.reset();
 	} );
 
 	test( 'should return an empty object at first', () => {
-		assert.deepEqual( SignupDependencyStore.get(), {} );
+		expect( SignupDependencyStore.get() ).toEqual( {} );
 	} );
 
 	test( 'should not store dependencies if none are included in an action', () => {
 		SignupActions.submitSignupStep( { stepName: 'stepA' } );
-		assert.deepEqual( SignupDependencyStore.get(), {} );
+		expect( SignupDependencyStore.get() ).toEqual( {} );
 	} );
 
 	test( 'should store dependencies if they are provided in either signup action', () => {
 		SignupActions.submitSignupStep( { stepName: 'userCreation' }, [], { bearer_token: 'TOKEN' } );
 
-		assert.deepEqual( SignupDependencyStore.get(), { bearer_token: 'TOKEN' } );
+		expect( SignupDependencyStore.get() ).toEqual( { bearer_token: 'TOKEN' } );
 
 		SignupActions.processedSignupStep( { stepName: 'userCreation' }, [], {
 			bearer_token: 'TOKEN2',
 		} );
 
-		assert.deepEqual( SignupDependencyStore.get(), { bearer_token: 'TOKEN2' } );
+		expect( SignupDependencyStore.get() ).toEqual( { bearer_token: 'TOKEN2' } );
 	} );
 
 	test( 'should store dependencies if they are provided in the `PROVIDE_SIGNUP_DEPENDENCIES` action', () => {
@@ -62,6 +62,6 @@ describe( 'dependency-store', () => {
 
 		SignupActions.provideDependencies( dependencies );
 
-		assert.deepEqual( SignupDependencyStore.get(), { bearer_token: 'TOKEN2', ...dependencies } );
+		expect( SignupDependencyStore.get() ).toEqual( dependencies );
 	} );
 } );

--- a/client/state/signup/dependency-store/actions.js
+++ b/client/state/signup/dependency-store/actions.js
@@ -1,0 +1,14 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { SIGNUP_COMPLETE_RESET, SIGNUP_DEPENDENCY_STORE_UPDATE } from 'state/action-types';
+
+export function updateDependencies( dependencies ) {
+	return { type: SIGNUP_DEPENDENCY_STORE_UPDATE, dependencies };
+}
+
+export function resetDependencies() {
+	return { type: SIGNUP_COMPLETE_RESET };
+}

--- a/client/state/signup/dependency-store/reducer.js
+++ b/client/state/signup/dependency-store/reducer.js
@@ -3,17 +3,15 @@
 /**
  * Internal dependencies
  */
-
 import { SIGNUP_COMPLETE_RESET, SIGNUP_DEPENDENCY_STORE_UPDATE } from 'state/action-types';
-
 import { createReducer } from 'state/utils';
 import { dependencyStoreSchema } from './schema';
 
 export default createReducer(
 	{},
 	{
-		[ SIGNUP_DEPENDENCY_STORE_UPDATE ]: ( state = {}, action ) => {
-			return Object.assign( {}, state, action.data );
+		[ SIGNUP_DEPENDENCY_STORE_UPDATE ]: ( state = {}, { dependencies } ) => {
+			return { ...state, ...dependencies };
 		},
 		[ SIGNUP_COMPLETE_RESET ]: () => {
 			return {};

--- a/client/state/signup/dependency-store/selectors.js
+++ b/client/state/signup/dependency-store/selectors.js
@@ -6,6 +6,7 @@
 
 import { get } from 'lodash';
 
+const initialState = {};
 export function getSignupDependencyStore( state ) {
-	return get( state, 'signup.dependencyStore', {} );
+	return get( state, 'signup.dependencyStore', initialState );
 }

--- a/client/state/signup/dependency-store/test/reducer.js
+++ b/client/state/signup/dependency-store/test/reducer.js
@@ -1,11 +1,6 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import signupDependencyStore from '../reducer';
@@ -18,10 +13,10 @@ describe( 'reducer', () => {
 				{},
 				{
 					type: SIGNUP_DEPENDENCY_STORE_UPDATE,
-					data: { test: 123 },
+					dependencies: { test: 123 },
 				}
 			)
-		).to.be.eql( { test: 123 } );
+		).toEqual( { test: 123 } );
 	} );
 
 	test( 'should reset the signup store', () => {
@@ -32,6 +27,6 @@ describe( 'reducer', () => {
 					type: SIGNUP_COMPLETE_RESET,
 				}
 			)
-		).to.be.eql( {} );
+		).toEqual( {} );
 	} );
 } );


### PR DESCRIPTION
This small refactor achieves two things:
1. DependencyStore redux actions are now in their own `actions` file.
2. DependencyStore tests have been rewritten to use Jest's API instead of `assert`.

No interaction changes have been introduced to the interface.

# Testing Instructions
1. Audit the code.
2. Spin up this branch locally.
3. Run through the full [sign-up](http://calypso.localhost:3000/start/) flow.