### PR TITLE
Update to i18n-calypso 1.9.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3578,6 +3578,11 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
     "check-node-version": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-2.1.0.tgz",
@@ -4865,6 +4870,11 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "cryptiles": {
       "version": "2.0.5",
@@ -6871,9 +6881,9 @@
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
     "estree-walker": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
-      "integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
+      "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao="
     },
     "esutils": {
       "version": "2.0.2",
@@ -8029,13 +8039,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8048,18 +8056,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8162,8 +8167,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8173,7 +8177,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8186,20 +8189,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -8216,7 +8216,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8289,8 +8288,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8300,7 +8298,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8406,7 +8403,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9458,9 +9454,9 @@
       }
     },
     "i18n-calypso": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/i18n-calypso/-/i18n-calypso-1.8.4.tgz",
-      "integrity": "sha512-vAEAmvbuytZEs/2d0M4WJYCKtzuCt4L2R7jMg57yO50kCmm5uPIj/9EJadum+MBPU7JgyWzDHH5J8PDr7deW4A==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/i18n-calypso/-/i18n-calypso-1.9.1.tgz",
+      "integrity": "sha512-5lnGA5+ew4m+jlWjH54rTt+KrsCoYbFPxg/20dGyuZZHIQ4+BizMqzIVkS6L091mmrCNnUHtv8Slf0/u+74cRQ==",
       "requires": {
         "async": "^1.5.2",
         "commander": "^2.9.0",
@@ -9475,7 +9471,8 @@
         "lru": "^3.1.0",
         "moment-timezone": "0.5.11",
         "react": "0.14.8 || ^15.5.0 || ^16.0.0",
-        "xgettext-js": "1.0.0"
+        "sha1": "^1.1.1",
+        "xgettext-js": "^1.0.0"
       },
       "dependencies": {
         "async": {
@@ -18115,6 +18112,15 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "sha1": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz",
+      "integrity": "sha1-rdqnqTFo85PxnrKxUJFhjicA+Eg=",
+      "requires": {
+        "charenc": ">= 0.0.1",
+        "crypt": ">= 0.0.1"
+      }
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -22388,22 +22394,19 @@
       "dev": true
     },
     "xgettext-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/xgettext-js/-/xgettext-js-1.0.0.tgz",
-      "integrity": "sha1-zZwElVeUaLH0ODReVEhcOJTqMFc=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xgettext-js/-/xgettext-js-1.1.0.tgz",
+      "integrity": "sha1-BSqSm2dVMjmyaqXrHjI1gSvqtm0=",
       "requires": {
-        "babylon": "6.8.4",
-        "estree-walker": "0.2.1",
+        "babylon": "^6.8.4",
+        "estree-walker": "^0.3.0",
         "lodash": "^4.13.1"
       },
       "dependencies": {
         "babylon": {
-          "version": "6.8.4",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.4.tgz",
-          "integrity": "sha1-CXMGuNq66VFZIlzymz6lWRIFMYA=",
-          "requires": {
-            "babel-runtime": "^6.0.0"
-          }
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "he": "0.5.0",
     "html-loader": "0.4.0",
     "html-to-react": "1.3.1",
-    "i18n-calypso": "1.8.4",
+    "i18n-calypso": "1.9.1",
     "immutability-helper": "2.4.0",
     "immutable": "3.7.6",
     "imports-loader": "0.6.5",


### PR DESCRIPTION
Pick up security fixes and new deps

Changelog: https://github.com/Automattic/i18n-calypso/blob/master/CHANGELOG.md

1.9.1
Fix a reference to an undefined value.

1.9.0
Add support for key hashing and add a method hasTranslation().

1.8.5
Allow newer versions of xgettext-js #46.

Unsure how to test this fully. Might want to wait on https://github.com/Automattic/i18n-calypso/pull/60 ?