### PR TITLE
Add labels to renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,8 @@
     "jquery"
   ],
   "labels": [
-    "Framework"
+	"Framework",
+	"[Type] Task",
+	"[Status] Needs Review"
   ]
 }


### PR DESCRIPTION
Automatically add Status: Needs Review and Type: Task to Renovate PRs. Saves us having to do it ourselves.

Leaving off the e2e label for now since those are fairly expensive to run and not always needed.