### PR TITLE
Purchases: Improve manage purchase styling

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -342,7 +342,7 @@ class ManagePurchase extends Component {
 
 	renderPlaceholder() {
 		return (
-			<div>
+			<Fragment>
 				<PurchaseSiteHeader isPlaceholder />
 				<Card className="manage-purchase__info is-placeholder">
 					<header className="manage-purchase__header">
@@ -362,7 +362,7 @@ class ManagePurchase extends Component {
 
 				<VerticalNavItem isPlaceholder />
 				<VerticalNavItem isPlaceholder />
-			</div>
+			</Fragment>
 		);
 	}
 
@@ -382,7 +382,7 @@ class ManagePurchase extends Component {
 		const siteDomain = purchase.domain;
 
 		return (
-			<div>
+			<Fragment>
 				<PurchaseSiteHeader siteId={ selectedSiteId } name={ siteName } domain={ siteDomain } />
 				<Card className={ classes }>
 					<header className="manage-purchase__header">
@@ -412,7 +412,7 @@ class ManagePurchase extends Component {
 					selectedSite={ selectedSite }
 					purchase={ purchase }
 				/>
-			</div>
+			</Fragment>
 		);
 	}
 

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -38,6 +38,7 @@ import PaymentLogo from 'components/payment-logo';
 import { CALYPSO_CONTACT } from 'lib/url/support';
 import UserItem from 'components/user';
 import { canEditPaymentDetails, getEditCardDetailsPath, isDataLoading } from '../utils';
+import CompactCard from 'components/card/compact';
 
 class PurchaseMeta extends Component {
 	static propTypes = {
@@ -246,7 +247,7 @@ class PurchaseMeta extends Component {
 		}
 
 		return (
-			<div className="manage-purchase__contact-support">
+			<CompactCard className="manage-purchase__contact-support">
 				{ translate(
 					'You are the owner of %(purchaseName)s but because you are no longer a user on %(siteSlug)s, ' +
 						'renewing it will require staff assistance. Please {{contactSupportLink}}contact support{{/contactSupportLink}}, ' +
@@ -261,7 +262,7 @@ class PurchaseMeta extends Component {
 						},
 					}
 				) }
-			</div>
+			</CompactCard>
 		);
 	}
 

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -38,7 +38,6 @@ import PaymentLogo from 'components/payment-logo';
 import { CALYPSO_CONTACT } from 'lib/url/support';
 import UserItem from 'components/user';
 import { canEditPaymentDetails, getEditCardDetailsPath, isDataLoading } from '../utils';
-import CompactCard from 'components/card/compact';
 
 class PurchaseMeta extends Component {
 	static propTypes = {
@@ -247,7 +246,7 @@ class PurchaseMeta extends Component {
 		}
 
 		return (
-			<CompactCard className="manage-purchase__contact-support">
+			<div className="manage-purchase__contact-support">
 				{ translate(
 					'You are the owner of %(purchaseName)s but because you are no longer a user on %(siteSlug)s, ' +
 						'renewing it will require staff assistance. Please {{contactSupportLink}}contact support{{/contactSupportLink}}, ' +
@@ -262,7 +261,7 @@ class PurchaseMeta extends Component {
 						},
 					}
 				) }
-			</CompactCard>
+			</div>
 		);
 	}
 

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -317,7 +317,7 @@ class PurchaseMeta extends Component {
 		}
 
 		return (
-			<div>
+			<Fragment>
 				<ul className="manage-purchase__meta">
 					{ this.renderOwner() }
 					<li>
@@ -328,7 +328,7 @@ class PurchaseMeta extends Component {
 					{ this.renderPaymentDetails() }
 				</ul>
 				{ this.renderContactSupportToRenewMessage() }
-			</div>
+			</Fragment>
 		);
 	}
 }

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -231,7 +231,7 @@
 		font-family: $sans;
 		font-size: 12px;
 		font-weight: 400;
-		margin: 0 0 12px 0;
+		margin: 0 0 12px;
 	}
 }
 

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -1,8 +1,9 @@
+/** @format */
 .manage-purchase__info {
 	font-size: 13px;
 	padding: 0;
 
-	@include breakpoint ( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		font-size: 14px;
 		padding: 0;
 	}
@@ -15,14 +16,14 @@
 		.manage-purchase__detail-label,
 		.manage-purchase__detail,
 		.manage-purchase__detail .user {
-			opacity: .7;
+			opacity: 0.7;
 		}
 	}
 
 	&.is-expired + .notice {
 		margin-top: -10px;
 
-		@include breakpoint ( ">480px" ) {
+		@include breakpoint( '>480px' ) {
 			margin-top: -16px;
 		}
 	}
@@ -71,7 +72,7 @@
 			width: 60%;
 		}
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			.manage-purchase__description,
 			.manage-purchase__detail,
 			.manage-purchase__detail-label {
@@ -79,7 +80,7 @@
 			}
 		}
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			.manage-purchase__detail {
 				width: 25%;
 			}
@@ -95,7 +96,7 @@
 .manage-purchase__content {
 	padding: 16px 24px;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		padding: 16px;
 	}
 }
@@ -143,7 +144,7 @@
 	font-weight: 400;
 	clear: none;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		font-size: 22px;
 		padding-right: 100px;
 	}
@@ -168,7 +169,7 @@
 	padding: 0 24px;
 	border-top: 1px solid $gray-lighten-30;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		padding: 0 16px;
 	}
 }
@@ -179,7 +180,7 @@
 	list-style: none;
 	overflow: auto;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		flex-direction: column;
 		padding-bottom: 16px;
 	}
@@ -188,13 +189,13 @@
 		color: $gray-darken-30;
 		font-size: 13px;
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			clear: both;
 			overflow: auto;
 			margin-top: 15px;
 		}
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			box-sizing: border-box;
 			flex: 1 1 auto;
 			font-size: 14px;
@@ -210,7 +211,7 @@
 		}
 
 		+ li {
-			@include breakpoint( ">660px" ) {
+			@include breakpoint( '>660px' ) {
 				border-left: 1px solid $gray-lighten-30;
 			}
 		}
@@ -227,12 +228,12 @@
 	font-style: normal;
 	font-weight: 600;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		flex-direction: row;
 		float: left;
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		color: $gray-text-min;
 		display: block;
 		font-family: $sans;
@@ -243,7 +244,7 @@
 }
 
 .manage-purchase__detail {
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		display: block;
 		float: right;
 		text-align: right;
@@ -267,21 +268,21 @@
 .manage-purchase__purchase-expiring-notice.notice {
 	margin-bottom: 10px;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		margin-bottom: 16px;
 	}
 }
 
 .manage-purchase__renew-button {
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		margin-top: 16px;
 		width: 100%;
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		position: absolute;
-			right: 24px;
-			top: 16px;
+		right: 24px;
+		top: 16px;
 	}
 }
 

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -280,4 +280,12 @@
 
 .manage-purchase__contact-support {
 	color: $gray-text-min;
+	border-top: solid 1px $gray-lighten-30;
+	margin: 0 auto;
+	padding: 16px;
+	background: $white;
+
+	@include breakpoint( '>480px' ) {
+		padding: 16px 24px;
+	}
 }

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -279,5 +279,5 @@
 }
 
 .manage-purchase__contact-support {
-	color: $gray;
+	color: $gray-text-min;
 }

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -164,25 +164,17 @@
 	margin-top: 16px;
 }
 
-.manage-purchase__meta,
-.manage-purchase__contact-support {
-	padding: 0 24px;
-	border-top: 1px solid $gray-lighten-30;
-
-	@include breakpoint( '<660px' ) {
-		padding: 0 16px;
-	}
-}
-
 .manage-purchase__meta {
 	display: flex;
 	margin: 0;
 	list-style: none;
 	overflow: auto;
+	padding: 0 24px;
+	border-top: 1px solid $gray-lighten-30;
 
 	@include breakpoint( '<660px' ) {
 		flex-direction: column;
-		padding-bottom: 16px;
+		padding: 0 16px 16px;
 	}
 
 	li {
@@ -287,8 +279,5 @@
 }
 
 .manage-purchase__contact-support {
-	border-top: solid 1px $gray-lighten-30;
 	color: $gray;
-	margin-top: 15px;
-	padding-top: 10px;
 }


### PR DESCRIPTION
Update some purchase styles so they work well on disconnected sites (#25473)

- Layout
- Acceptable text contrast (https://dotcombrand.wordpress.com/colors/)
  > For text that is non-essential but should still be readable, use `$gray-text-min` or darker
- Refactor some styles for cleanliness and reduced redundancy 

via p1HpG7-5ez-p2 #comment-26409 (@keoshi)

## Screens

### Before

![before](https://user-images.githubusercontent.com/841763/41458511-18cb6de0-7087-11e8-9c0b-25522543c8d9.png)

### After
![after](https://user-images.githubusercontent.com/841763/41459859-18ed4b8c-708b-11e8-957e-54b6e44da098.png)

## Testing
1. Manually navigate to a purchase for a disconnected site (you'll need to build the URL until #25473 lands). `/me/purchases/SITE_SLUG/PURCHASE_ID`
1. Everything look good?
1. Check views at `<480`, `<660`, `=660`??, and `>660`
1. Verify a variety of other purchases and connected sites continue to work well.