### PR TITLE
Reset keyring connect button state when user closes the popup without selecting an account

### DIFF
--- a/client/blocks/keyring-connect-button/index.js
+++ b/client/blocks/keyring-connect-button/index.js
@@ -109,6 +109,11 @@ class KeyringConnectButton extends Component {
 			// Attempt to create a new connection. If a Keyring connection ID
 			// is not provided, the user will need to authorize the app
 			requestExternalAccess( this.props.service.connect_URL, keyringId => {
+				if ( ! keyringId ) {
+					this.setState( { isConnecting: false } );
+					return;
+				}
+
 				// When the user has finished authorizing the connection
 				// (or otherwise closed the window), force a refresh
 				this.props.requestKeyringConnections( true );

--- a/client/blocks/keyring-connect-button/index.js
+++ b/client/blocks/keyring-connect-button/index.js
@@ -67,7 +67,7 @@ class KeyringConnectButton extends Component {
 	 * @return {string} Connection status.
 	 */
 	getConnectionStatus() {
-		if ( this.props.isFetching ) {
+		if ( this.props.isFetching || this.props.isAwaitingConnections ) {
 			// When connections are still loading, we don't know the status
 			return 'unknown';
 		}

--- a/client/blocks/keyring-connect-button/index.js
+++ b/client/blocks/keyring-connect-button/index.js
@@ -6,7 +6,7 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { find, isEqual, last, noop, some } from 'lodash';
+import { find, last, noop, some } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -123,28 +123,21 @@ class KeyringConnectButton extends Component {
 	};
 
 	componentWillReceiveProps( nextProps ) {
-		if ( ! isEqual( this.props.keyringConnections, nextProps.keyringConnections ) ) {
+		if ( this.state.isAwaitingConnections ) {
 			this.setState( {
-				isConnecting: false,
+				isAwaitingConnections: false,
+				isRefreshing: false,
 			} );
-		}
 
-		if ( ! this.state.isAwaitingConnections ) {
-			return;
-		}
-
-		this.setState( {
-			isAwaitingConnections: false,
-			isRefreshing: false,
-		} );
-
-		if ( this.didKeyringConnectionSucceed( nextProps.keyringConnections ) ) {
-			const keyringId = this.state.keyringId;
-			const newKeyringConnection = find( nextProps.keyringConnections, { ID: keyringId } );
-			if ( newKeyringConnection ) {
-				this.props.onConnect( newKeyringConnection );
+			if ( this.didKeyringConnectionSucceed( nextProps.keyringConnections ) ) {
+				const newKeyringConnection = find( nextProps.keyringConnections, {
+					ID: this.state.keyringId,
+				} );
+				if ( newKeyringConnection ) {
+					this.props.onConnect( newKeyringConnection );
+				}
+				this.setState( { keyringId: null, isConnecting: false } );
 			}
-			this.setState( { keyringId: null } );
 		}
 	}
 
@@ -164,9 +157,10 @@ class KeyringConnectButton extends Component {
 
 		if ( ! this.state.keyringId || keyringConnections.length === 0 || ! hasAnyConnectionOptions ) {
 			this.setState( { isConnecting: false } );
+			return false;
 		}
 
-		return this.state.keyringId && keyringConnections.length && hasAnyConnectionOptions;
+		return true;
 	}
 
 	render() {

--- a/client/blocks/keyring-connect-button/index.js
+++ b/client/blocks/keyring-connect-button/index.js
@@ -6,7 +6,7 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { differenceBy, find, isEqual, last, noop, some } from 'lodash';
+import { find, isEqual, last, noop, some } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -139,20 +139,12 @@ class KeyringConnectButton extends Component {
 		} );
 
 		if ( this.didKeyringConnectionSucceed( nextProps.keyringConnections ) ) {
-			const keyringId = this.state.keyringId || null;
-			this.setState( { isConnecting: false, keyringId: null } );
-			let newKeyringConnection = null;
-			if ( keyringId ) {
-				newKeyringConnection = find( nextProps.keyringConnections, { ID: keyringId } );
-			} else {
-				// if no keyring id is given from the popup,
-				// fallback to less reliable ways of determining the new connection
-				newKeyringConnection =
-					differenceBy( this.props.keyringConnections, nextProps.keyringConnections, 'ID' )[ 0 ] ||
-					last( nextProps.keyringConnections );
+			const keyringId = this.state.keyringId;
+			const newKeyringConnection = find( nextProps.keyringConnections, { ID: keyringId } );
+			if ( newKeyringConnection ) {
+				this.props.onConnect( newKeyringConnection );
 			}
-
-			this.props.onConnect( newKeyringConnection );
+			this.setState( { keyringId: null } );
 		}
 	}
 
@@ -170,13 +162,11 @@ class KeyringConnectButton extends Component {
 				keyringConnection.isConnected === false || keyringConnection.isConnected === undefined
 		);
 
-		if ( keyringConnections.length === 0 ) {
-			this.setState( { isConnecting: false } );
-		} else if ( ! hasAnyConnectionOptions ) {
+		if ( ! this.state.keyringId || keyringConnections.length === 0 || ! hasAnyConnectionOptions ) {
 			this.setState( { isConnecting: false } );
 		}
 
-		return keyringConnections.length && hasAnyConnectionOptions;
+		return this.state.keyringId && keyringConnections.length && hasAnyConnectionOptions;
 	}
 
 	render() {

--- a/client/state/google-my-business/actions.js
+++ b/client/state/google-my-business/actions.js
@@ -29,17 +29,19 @@ export const connectGoogleMyBusinessAccount = ( siteId, keyringId, locationId = 
 	dispatch,
 	getState
 ) => {
-	if ( ! getSiteKeyringConnection( getState(), siteId, keyringId ) ) {
-		return dispatch( disconnectAllGoogleMyBusinessAccounts( siteId ) ).then( () =>
-			dispatch(
-				createSiteKeyring( siteId, {
-					keyring_id: keyringId,
-					service: 'google_my_business',
-					external_user_id: locationId,
-				} )
-			)
-		);
+	if ( getSiteKeyringConnection( getState(), siteId, keyringId ) ) {
+		return Promise.resolve();
 	}
+
+	return dispatch( disconnectAllGoogleMyBusinessAccounts( siteId ) ).then( () =>
+		dispatch(
+			createSiteKeyring( siteId, {
+				keyring_id: keyringId,
+				service: 'google_my_business',
+				external_user_id: locationId,
+			} )
+		)
+	);
 };
 
 export const connectGoogleMyBusinessLocation = ( siteId, keyringId, locationId ) => dispatch =>


### PR DESCRIPTION
This makes sure we don't trigger a `calypso_google_my_business_select_business_type_connect` when the OAuth flow is canceled (popup is closed).
Also prevents the user from reusing an old connected account when no account was selected.

### Testing Instructions
- Boot this branch locally
- Go to Stats for a site eligible for Google My Business (business site, not already connected)
- Click on Start Now
- Click on Connect to Google My Business
- Close the popup without completing the flow
- The button should fall back to its default state and nothing should happen
- In the console enable analytics logs (`localStorage.debug = 'calypso:analytics:*';`) and try again opening and closing the popup, the `calypso_google_my_business_new_account_connect` event should not be triggered
- Finally, open the popup one last time and select an account
- The `calypso_google_my_business_new_account_connect` event should be visible in the logs
- On the `Select Location` page, click on "Use another Google Account"
- Close the popup without selecting an account
- The button should revert back to its original state
- Check the analytics logs, only `*_button_click` events should have been triggered
- Click on "Use another Google Account" again and select an account again
- Check the analytics log, `calypso_google_my_business_select_location_connect` should be triggered
- Navigate manually to `http://calypso.localhost:3000/google-my-business/new/:site`
- Click on `Use another Google Account`
- Close the popup without selecting an account
- Check the analytics logs, only `*_button_click` events should have been triggered
- Click on `Use another Google Account` again and this time select an account
- Make sure `calypso_google_my_business_new_account_connect` is visible in the logs

### Reviews
- [ ] Code
- [ ] Product
