### PR TITLE
Login: Fix Canonical URL

### DIFF
--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -168,7 +168,7 @@ export class Login extends React.Component {
 
 	render() {
 		const { locale, privateSite, socialConnect, translate, twoFactorAuthType } = this.props;
-		const canonicalUrl = addLocaleToWpcomUrl( 'https://wordpress.com/login', locale );
+		const canonicalUrl = addLocaleToWpcomUrl( 'https://wordpress.com/log-in', locale );
 
 		return (
 			<div>


### PR DESCRIPTION
Our login URL is actually https://wordpress.com/log-in (with a dash) -- the non-dash version actually redirects there. Consequently, this is what our `canonical` link should point to.

Taken from @a8dar's #25493.

Can anyone tell me why we even have the dash in `log-in`? Seems pretty nonstandard.