### PR TITLE
Guided Tours: Leverage flexbox for styling

### DIFF
--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -105,21 +105,15 @@
 .guided-tours__choice-button-row {
 	display: flex;
 	align-items: center;
+	justify-content: space-between;
 }
 
+.guided-tours__choice-button-row,
 .guided-tours__single-button-row {
 	text-align: center;
-}
 
-.guided-tours__choice-button-row, .guided-tours__single-button-row {
 	.button {
 		min-width: 48%;
-	}
-	.guided-tours__button-link {
-		text-align: center;
-	}
-	.button:nth-child(1) {
-		margin-right: 4%;
 	}
 	.guided-tours__quit-button {
 		color: darken( $white, 20% );


### PR DESCRIPTION
Prompted by https://github.com/Automattic/wp-calypso/pull/25454#pullrequestreview-128837409

To test:
* Starting at `calypso.localhost:3000/checklist/<yourJetpackSite>`, pick the 'Jetpack Monitor' step in the checklist, and follow its instructions. Compare the styling of buttons and links in the Guided Tour bubbles to wpcalypso, and verify that the "Yes, let's do it" button label is now nicely centered.

**Before**
![image](https://user-images.githubusercontent.com/96308/41546561-450a2f9c-731e-11e8-949f-6f63821f1a48.png)

**After**
![image](https://user-images.githubusercontent.com/96308/41546599-5a8c309a-731e-11e8-904d-42df4710e43e.png)

* Starting at `calypso.localhost:3000/checklist/<yourWpComSite>`, pick any step in the checklist, and follow its instructions. Compare the styling of buttons and links in the Guided Tour bubbles to production, and verify that there are no visual changes (or no ugly ones :grin:).

A few examples:

Tagline:

**Before**

![image](https://user-images.githubusercontent.com/96308/41547479-9359ce80-7320-11e8-88a2-962c73b589ac.png)

**After**

![image](https://user-images.githubusercontent.com/96308/41547380-55694c22-7320-11e8-8e4a-e1b30d4320ca.png)

Site Icon:

**Before**

![image](https://user-images.githubusercontent.com/96308/41547784-71fee5c6-7321-11e8-8917-23544690f741.png)

**After**

![image](https://user-images.githubusercontent.com/96308/41547804-7bd8600e-7321-11e8-8f68-6a6e9174ed43.png)

Contact Page:

**Before**
![image](https://user-images.githubusercontent.com/96308/41546685-9a661cf8-731e-11e8-983f-06b3e51813a7.png)

**After**
![image](https://user-images.githubusercontent.com/96308/41546722-b07809c0-731e-11e8-82d7-f828b5b3ca96.png)