### PR TITLE
Podcasting: Only print error message once.

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -201,9 +201,11 @@ class PodcastingDetails extends Component {
 					>
 						<h1>{ translate( 'Podcasting Settings' ) }</h1>
 					</HeaderCake>
-					<Card className="podcasting-details__category-wrapper">
-						{ error || this.renderCategorySetting() }
-					</Card>
+					{ ! error && (
+						<Card className="podcasting-details__category-wrapper">
+							{ this.renderCategorySetting() }
+						</Card>
+					) }
 					<Card className={ classes }>{ error || this.renderSettings() }</Card>
 					{ isPodcastingEnabled && (
 						<div className="podcasting-details__disable-podcasting">


### PR DESCRIPTION
This PR removes the second call to `error` introduced with the Podcasting Details changes in #25477.

This PR is part of a larger epic and is behind the `manage/site-settings/podcasting` feature flag. See p3Ex-32D-p2.

**To test:**
- With the `manage/site-settings/podcasting` enabled (default in development):
- Given a user without `manage_settings` permission (i.e. an author), or a site with 'private' visibility.
- When the user attempts to visit the podcasting settings page (i.e. http://calypso.localhost:3000/settings/podcasting/mygroovydomain.com).
- Then only a single error message is displayed.