### PR TITLE
Fix LabelItem duplicate keys

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -88,6 +88,14 @@ class LabelItem extends Component {
 
 	render() {
 		const { siteId, orderId, label, translate } = this.props;
+		const {
+			labelIndex,
+			serviceName,
+			packageName,
+			productNames,
+			receiptId,
+			labelId,
+		} = label;
 
 		return (
 			<div className="shipping-label__item">
@@ -105,7 +113,16 @@ class LabelItem extends Component {
 								{ this.renderRefund( label ) }
 								{ this.renderReprint( label ) }
 							</EllipsisMenu>
-							<DetailsDialog siteId={ siteId } orderId={ orderId } { ...label } />
+							<DetailsDialog
+								siteId={ siteId }
+								orderId={ orderId }
+								labelIndex= { labelIndex }
+								serviceName={ serviceName }
+								packageName={ packageName }
+								productNames={ productNames }
+								receiptId={ receiptId }
+								labelId= { labelId }
+							/>
 							<RefundDialog siteId={ siteId } orderId={ orderId } { ...label } />
 							<ReprintDialog siteId={ siteId } orderId={ orderId } { ...label } />
 						</span>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -90,7 +90,7 @@ class LabelItem extends Component {
 		const { siteId, orderId, label, translate } = this.props;
 
 		return (
-			<div key={ label.labelId } className="shipping-label__item">
+			<div className="shipping-label__item">
 				<p className="shipping-label__item-detail">
 					{ translate( '%(service)s label (#%(labelIndex)d) printed', {
 						args: {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -134,7 +134,7 @@ class LabelItem extends Component {
 								currency={ currency }
 								labelId={ labelId }
 							/>
-							<ReprintDialog siteId={ siteId } orderId={ orderId } { ...label } />
+							<ReprintDialog siteId={ siteId } orderId={ orderId } labelId={ labelId } />
 						</span>
 					) }
 				</p>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -95,6 +95,9 @@ class LabelItem extends Component {
 			productNames,
 			receiptId,
 			labelId,
+			createdDate,
+			refundableAmount,
+			currency,
 		} = label;
 
 		return (
@@ -116,14 +119,21 @@ class LabelItem extends Component {
 							<DetailsDialog
 								siteId={ siteId }
 								orderId={ orderId }
-								labelIndex= { labelIndex }
+								labelIndex={ labelIndex }
 								serviceName={ serviceName }
 								packageName={ packageName }
 								productNames={ productNames }
 								receiptId={ receiptId }
-								labelId= { labelId }
+								labelId={ labelId }
 							/>
-							<RefundDialog siteId={ siteId } orderId={ orderId } { ...label } />
+							<RefundDialog
+								siteId={ siteId }
+								orderId={ orderId }
+								createdDate={ createdDate }
+								refundableAmount={ refundableAmount }
+								currency={ currency }
+								labelId={ labelId }
+							/>
 							<ReprintDialog siteId={ siteId } orderId={ orderId } { ...label } />
 						</span>
 					) }


### PR DESCRIPTION
When viewing an order page (`http://calypso.localhost:3000/store/order/{store_url}/{order_id}`), these warnings show up:

`
index.jsx:98 Warning: Encountered two children with the same key, `580`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
`

They are caused by passing in all the `label` object properties as props. This PR passes in only the requires props to fix the issue.

I also removed the key in `LabelItem` since it's unneccessary.