### PR TITLE
Activity Log: add an upgrade banner

### DIFF
--- a/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
@@ -1,0 +1,62 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { isJetpackSite } from 'state/sites/selectors';
+import Banner from 'components/banner';
+import {
+	PLAN_PERSONAL,
+	PLAN_JETPACK_PERSONAL,
+	FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
+	FEATURE_NO_ADS,
+} from 'lib/plans/constants';
+
+class UpgradeBanner extends PureComponent {
+	render() {
+		const { isJetpack, translate } = this.props;
+		return (
+			<div className="activity-log-banner__upgrade">
+				{ isJetpack ? (
+					<Banner
+						callToAction={ translate( 'Get daily backups' ) }
+						dismissPreferenceName="activity-upgrade-banner-jetpack"
+						event="track_event"
+						feature={ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY }
+						list={ [
+							translate( 'See all site activity over the past month' ),
+							translate( 'Rewind your site back to any point' ),
+							translate( 'Automatic threat scanning' ),
+						] }
+						plan={ PLAN_JETPACK_PERSONAL }
+						title={ translate( 'Secure your site with daily backups' ) }
+					/>
+				) : (
+					<Banner
+						callToAction={ translate( 'Upgrade' ) }
+						dismissPreferenceName="activity-upgrade-banner-simple"
+						event="track_event"
+						feature={ FEATURE_NO_ADS }
+						list={ [
+							translate( 'Get a custom domain name' ),
+							translate( 'Remove WordPress.com ads' ),
+							translate( 'See 30 days of past activity' ),
+						] }
+						plan={ PLAN_PERSONAL }
+						title={ translate( 'Upgrade your WordPress.com experience' ) }
+					/>
+				) }
+			</div>
+		);
+	}
+}
+
+export default connect( ( state, { siteId } ) => ( {
+	isJetpack: isJetpackSite( state, siteId ),
+} ) )( localize( UpgradeBanner ) );

--- a/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -18,7 +18,7 @@ import {
 	FEATURE_NO_ADS,
 } from 'lib/plans/constants';
 
-class UpgradeBanner extends PureComponent {
+class UpgradeBanner extends Component {
 	render() {
 		const { isJetpack, translate } = this.props;
 		return (
@@ -27,7 +27,7 @@ class UpgradeBanner extends PureComponent {
 					<Banner
 						callToAction={ translate( 'Get daily backups' ) }
 						dismissPreferenceName="activity-upgrade-banner-jetpack"
-						event="track_event"
+						event="activity_log_upgrade_click_jetpack"
 						feature={ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY }
 						list={ [
 							translate( 'See all site activity over the past month' ),
@@ -41,7 +41,7 @@ class UpgradeBanner extends PureComponent {
 					<Banner
 						callToAction={ translate( 'Upgrade' ) }
 						dismissPreferenceName="activity-upgrade-banner-simple"
-						event="track_event"
+						event="activity_log_upgrade_click_wpcom"
 						feature={ FEATURE_NO_ADS }
 						list={ [
 							translate( 'Get a custom domain name' ),

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -21,6 +21,8 @@ import Banner from 'components/banner';
 import DocumentHead from 'components/data/document-head';
 import EmptyContent from 'components/empty-content';
 import ErrorBanner from '../activity-log-banner/error-banner';
+import UpgradeBanner from '../activity-log-banner/upgrade-banner';
+import { isFreePlan } from 'lib/plans';
 import FoldableCard from 'components/foldable-card';
 import JetpackColophon from 'components/jetpack-colophon';
 import Main from 'components/main';
@@ -38,6 +40,7 @@ import SuccessBanner from '../activity-log-banner/success-banner';
 import UnavailabilityNotice from './unavailability-notice';
 import { adjustMoment, getStartMoment } from './utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getSiteSlug, getSiteTitle } from 'state/sites/selectors';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import {
@@ -299,6 +302,14 @@ class ActivityLog extends Component {
 		);
 	}
 
+	renderUpgradeBanner() {
+		const { siteIsOnFreePlan } = this.props;
+		if ( ! siteIsOnFreePlan ) {
+			return null;
+		}
+		return <UpgradeBanner />;
+	}
+
 	getActivityLog() {
 		const {
 			enableRewind,
@@ -375,6 +386,7 @@ class ActivityLog extends Component {
 				<QuerySiteSettings siteId={ siteId } />
 				<SidebarNavigation />
 				<StatsNavigation selectedItem={ 'activity' } siteId={ siteId } slug={ slug } />
+				{ this.renderUpgradeBanner() }
 				{ config.isEnabled( 'rewind-alerts' ) && siteId && <RewindAlerts siteId={ siteId } /> }
 				{ siteId &&
 					'unavailable' === rewindState.state && <UnavailabilityNotice siteId={ siteId } /> }
@@ -490,6 +502,7 @@ export default connect(
 		const rewindState = getRewindState( state, siteId );
 		const restoreStatus = rewindState.rewind && rewindState.rewind.status;
 		const logs = siteId && requestActivityLogs( siteId, {} );
+		const siteIsOnFreePlan = isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) );
 
 		return {
 			canViewActivityLog: canCurrentUser( state, siteId, 'manage_options' ),
@@ -511,6 +524,7 @@ export default connect(
 			siteTitle: getSiteTitle( state, siteId ),
 			slug: getSiteSlug( state, siteId ),
 			timezone,
+			siteIsOnFreePlan,
 		};
 	},
 	{

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -302,14 +302,6 @@ class ActivityLog extends Component {
 		);
 	}
 
-	renderUpgradeBanner() {
-		const { siteIsOnFreePlan } = this.props;
-		if ( ! siteIsOnFreePlan ) {
-			return null;
-		}
-		return <UpgradeBanner />;
-	}
-
 	getActivityLog() {
 		const {
 			enableRewind,
@@ -386,7 +378,7 @@ class ActivityLog extends Component {
 				<QuerySiteSettings siteId={ siteId } />
 				<SidebarNavigation />
 				<StatsNavigation selectedItem={ 'activity' } siteId={ siteId } slug={ slug } />
-				{ this.renderUpgradeBanner() }
+				{ this.props.siteIsOnFreePlan && <UpgradeBanner siteId={ siteId } /> }
 				{ config.isEnabled( 'rewind-alerts' ) && siteId && <RewindAlerts siteId={ siteId } /> }
 				{ siteId &&
 					'unavailable' === rewindState.state && <UnavailabilityNotice siteId={ siteId } /> }

--- a/client/my-sites/stats/activity-log/unavailability-notice.jsx
+++ b/client/my-sites/stats/activity-log/unavailability-notice.jsx
@@ -27,18 +27,6 @@ export const UnavailabilityNotice = ( {
 	}
 
 	switch ( reason ) {
-		case 'missing_plan':
-			return (
-				<Banner
-					plan="personal-bundle"
-					href={ `/plans/${ slug }` }
-					callToAction={ translate( 'Upgrade' ) }
-					title={ translate(
-						'Upgrade your Jetpack plan to restore your site to events in the past.'
-					) }
-				/>
-			);
-
 		case 'no_connected_jetpack':
 			return (
 				<Banner


### PR DESCRIPTION
Show an upgrade banner to sites on a free plan.

This is a continuation of a prototype started by @keoshi in #25136

Banner as shown for a free wordpress.com site:
<img width="1371" alt="screen shot 2018-06-15 at 3 56 50 pm" src="https://user-images.githubusercontent.com/2694219/41487290-18281d50-70b6-11e8-95dd-4dce4c117524.png">

Banner as shown for a free Jetpack site:
<img width="1371" alt="screen shot 2018-06-15 at 3 57 23 pm" src="https://user-images.githubusercontent.com/2694219/41487313-27101052-70b6-11e8-8922-3808a6a712d6.png">


Banner as show for a free wordpress.com site with no activity:
<img width="1381" alt="screen shot 2018-06-15 at 4 08 43 pm" src="https://user-images.githubusercontent.com/2694219/41487399-865bfa08-70b6-11e8-82f8-54a34185fdf7.png">



In an other PR, we can show a demo list of activities.