### PR TITLE
Settings: Removing `toLowerCase()` on translation output

### DIFF
--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -114,7 +114,7 @@ class CustomContentTypes extends Component {
 
 	renderBlogPostSettings() {
 		const { translate } = this.props;
-		const fieldLabel = translate( 'blog posts' );
+		const fieldLabel = translate( 'Blog posts' );
 		const fieldDescription = translate( 'On blog pages, the number of posts to show per page.' );
 
 		return (
@@ -126,7 +126,7 @@ class CustomContentTypes extends Component {
 
 	renderTestimonialSettings() {
 		const { translate } = this.props;
-		const fieldLabel = translate( 'testimonials' );
+		const fieldLabel = translate( 'Testimonials' );
 		const fieldDescription = translate(
 			'Add, organize, and display {{link}}testimonials{{/link}}. If your theme doesn’t support testimonials yet, ' +
 				'you can display them using the shortcode [testimonials].',
@@ -142,7 +142,7 @@ class CustomContentTypes extends Component {
 
 	renderPortfolioSettings() {
 		const { translate } = this.props;
-		const fieldLabel = translate( 'portfolio projects' );
+		const fieldLabel = translate( 'Portfolio Projects' );
 		const fieldDescription = translate(
 			'Add, organize, and display {{link}}portfolio projects{{/link}}. If your theme doesn’t support portfolio projects yet, ' +
 				'you can display them using the shortcode [portfolio].',

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -67,7 +67,7 @@ class CustomContentTypes extends Component {
 		return (
 			<div className="custom-content-types__indented-form-field indented-form-field">
 				{ translate( 'Display {{field /}} %s per page', {
-					args: postTypeLabel.toLowerCase(),
+					args: postTypeLabel,
 					components: {
 						field: (
 							<FormTextInput

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -114,7 +114,7 @@ class CustomContentTypes extends Component {
 
 	renderBlogPostSettings() {
 		const { translate } = this.props;
-		const fieldLabel = translate( 'Blog posts' );
+		const fieldLabel = translate( 'blog posts' );
 		const fieldDescription = translate( 'On blog pages, the number of posts to show per page.' );
 
 		return (
@@ -126,7 +126,7 @@ class CustomContentTypes extends Component {
 
 	renderTestimonialSettings() {
 		const { translate } = this.props;
-		const fieldLabel = translate( 'Testimonials' );
+		const fieldLabel = translate( 'testimonials' );
 		const fieldDescription = translate(
 			'Add, organize, and display {{link}}testimonials{{/link}}. If your theme doesn’t support testimonials yet, ' +
 				'you can display them using the shortcode [testimonials].',
@@ -142,7 +142,7 @@ class CustomContentTypes extends Component {
 
 	renderPortfolioSettings() {
 		const { translate } = this.props;
-		const fieldLabel = translate( 'Portfolio Projects' );
+		const fieldLabel = translate( 'portfolio projects' );
 		const fieldDescription = translate(
 			'Add, organize, and display {{link}}portfolio projects{{/link}}. If your theme doesn’t support portfolio projects yet, ' +
 				'you can display them using the shortcode [portfolio].',

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -59,54 +59,52 @@ class CustomContentTypes extends Component {
 		return isRequestingSettings || isSavingSettings;
 	}
 
-	renderPostsPerPageField( fieldName, postTypeLabel ) {
-		const { fields, onChangeField, translate } = this.props;
-		const numberFieldName = fieldName === 'post' ? 'posts_per_page' : fieldName + '_posts_per_page';
-		const isDisabled = this.isFormPending() || ( ! fields[ fieldName ] && fieldName !== 'post' );
-
-		return (
-			<div className="custom-content-types__indented-form-field indented-form-field">
-				{ translate( 'Display {{field /}} %s per page', {
-					args: postTypeLabel,
-					components: {
-						field: (
-							<FormTextInput
-								name={ numberFieldName }
-								type="number"
-								step="1"
-								min="0"
-								id={ numberFieldName }
-								value={
-									'undefined' === typeof fields[ numberFieldName ] ? 10 : fields[ numberFieldName ]
-								}
-								onChange={ onChangeField( numberFieldName ) }
-								disabled={ isDisabled }
-							/>
-						),
-					},
-				} ) }
-			</div>
-		);
-	}
-
 	renderContentTypeSettings( name, label, description ) {
-		const { activatingCustomContentTypesModule, fields, handleAutosavingToggle } = this.props;
+		const {
+			activatingCustomContentTypesModule,
+			fields,
+			handleAutosavingToggle,
+			onChangeField,
+			translate,
+		} = this.props;
+		const numberFieldIdentifier = name === 'post' ? 'posts_per_page' : name + '_posts_per_page';
+		const isDisabled = this.isFormPending() || ( ! fields[ name ] && name !== 'post' );
 		return (
 			<div className="custom-content-types__module-settings">
-				{ name !== 'post' ? (
+				{ name !== 'post' && (
 					<CompactFormToggle
 						checked={ !! fields[ name ] }
 						disabled={ this.isFormPending() || activatingCustomContentTypesModule }
 						onChange={ handleAutosavingToggle( name ) }
-					>
-						{ label }
-					</CompactFormToggle>
-				) : (
-					<div className="custom-content-types__label">{ label }</div>
+					/>
 				) }
-
-				{ this.renderPostsPerPageField( name, label ) }
-
+				<div id={ numberFieldIdentifier } className="custom-content-types__label">
+					{ label }
+				</div>
+				<div className="custom-content-types__indented-form-field indented-form-field">
+					{ translate( 'Display {{field /}} per page', {
+						comment:
+							'The field value is a number that refers to site content type, e.g., blog post, testimonial or portfolio project',
+						components: {
+							field: (
+								<FormTextInput
+									name={ numberFieldIdentifier }
+									type="number"
+									step="1"
+									min="0"
+									aria-labelledby={ numberFieldIdentifier }
+									value={
+										'undefined' === typeof fields[ numberFieldIdentifier ]
+											? 10
+											: fields[ numberFieldIdentifier ]
+									}
+									onChange={ onChangeField( numberFieldIdentifier ) }
+									disabled={ isDisabled }
+								/>
+							),
+						},
+					} ) }
+				</div>
 				<FormSettingExplanation isIndented>{ description }</FormSettingExplanation>
 			</div>
 		);

--- a/client/my-sites/site-settings/custom-content-types/style.scss
+++ b/client/my-sites/site-settings/custom-content-types/style.scss
@@ -6,12 +6,9 @@
 	}
 
 	.custom-content-types__label {
-		margin-bottom: 5px;
-	}
-
-	.custom-content-types__label {
-		font-weight: 600;
 		display: inline-block;
+		font-weight: 600;
+		margin-bottom: 5px;
 	}
 
 	.form-toggle__wrapper {

--- a/client/my-sites/site-settings/custom-content-types/style.scss
+++ b/client/my-sites/site-settings/custom-content-types/style.scss
@@ -8,16 +8,13 @@
 	.custom-content-types__label {
 		margin-bottom: 5px;
 	}
-}
 
-.custom-content-types__label,
-.custom-content-types__module-settings .form-toggle__label-content {
-	font-weight: 600;
-}
+	.custom-content-types__label {
+		font-weight: 600;
+		display: inline-block;
+	}
 
-html:not( [lang='de'] ) .custom-content-types__indented-form-field {
-	text-transform: lowercase;
-	&::first-letter {
-		text-transform: capitalize;
+	.form-toggle__wrapper {
+		display: inline-block;
 	}
 }

--- a/client/my-sites/site-settings/custom-content-types/style.scss
+++ b/client/my-sites/site-settings/custom-content-types/style.scss
@@ -14,3 +14,10 @@
 .custom-content-types__module-settings .form-toggle__label-content {
 	font-weight: 600;
 }
+
+html:not( [lang='de'] ) .custom-content-types__indented-form-field {
+	text-transform: lowercase;
+	&::first-letter {
+		text-transform: capitalize;
+	}
+}

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -78,11 +78,11 @@ export class EditorNotice extends Component {
 		switch ( key ) {
 			case 'publishFailure':
 				if ( 'post' === type ) {
-					return translate( 'Publishing of post failed' );
+					return translate( 'Publishing of post failed.' );
 				}
 
 				if ( 'page' === type ) {
-					return translate( 'Publishing of page failed' );
+					return translate( 'Publishing of page failed.' );
 				}
 
 				return translate( 'Publishing of %(typeLabel)s failed.', {

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -77,20 +77,44 @@ export class EditorNotice extends Component {
 
 		switch ( key ) {
 			case 'publishFailure':
+				if ( 'post' === type ) {
+					return translate( 'Publishing of post failed' );
+				}
+
+				if ( 'page' === type ) {
+					return translate( 'Publishing of page failed' );
+				}
+
 				return translate( 'Publishing of %(typeLabel)s failed.', {
-					args: { typeLabel: typeLabel.toLowerCase() },
+					args: { typeLabel: typeLabel },
 				} );
 
 			case 'saveFailure':
 				return translate( 'Saving of draft failed.' );
 
 			case 'trashFailure':
+				if ( 'page' === type ) {
+					return translate( 'Trashing of page failed!' );
+				}
+
+				if ( 'post' === type ) {
+					return translate( 'Trashing of post failed!' );
+				}
+
 				return translate( 'Trashing of %(typeLabel)s failed.', {
-					args: { typeLabel: typeLabel.toLowerCase() },
+					args: { typeLabel: typeLabel },
 				} );
 
 			case 'published':
 				if ( ! site ) {
+					if ( 'page' === type ) {
+						return translate( 'Page published!' );
+					}
+
+					if ( 'post' === type ) {
+						return translate( 'Post published!' );
+					}
+
 					return translate( '%(typeLabel)s published!', { args: { typeLabel: typeLabel } } );
 				}
 
@@ -108,6 +132,20 @@ export class EditorNotice extends Component {
 					} );
 				}
 
+				if ( 'post' === type ) {
+					return translate( 'Post published on {{postLink/}}! {{a}}Add another post{{/a}}', {
+						components: {
+							postLink: (
+								<a href={ postUrl } onClick={ this.handleViewPostClick }>
+									{ site.title }
+								</a>
+							),
+							a: <a href={ `/post/${ site.slug }` } onClick={ this.handleAddPagePromptClick } />,
+						},
+						comment: 'Editor: Message displayed when a post is published, with a link to the post.',
+					} );
+				}
+
 				return translate( '%(typeLabel)s published on {{postLink/}}!', {
 					args: { typeLabel: typeLabel },
 					components: {
@@ -122,10 +160,26 @@ export class EditorNotice extends Component {
 				} );
 
 			case 'scheduled':
+				if ( 'post' === type ) {
+					return translate( 'Post scheduled for %(formattedPostDate)s!', {
+						args: { formattedPostDate },
+						comment:
+							'Editor: Message displayed when a post is scheduled, with the scheduled date and time.',
+					} );
+				}
+
+				if ( 'page' === type ) {
+					return translate( 'Page scheduled for %(formattedPostDate)s!', {
+						args: { formattedPostDate },
+						comment:
+							'Editor: Message displayed when a page is scheduled, with the scheduled date and time.',
+					} );
+				}
+
 				return translate( '%(typeLabel)s scheduled for %(formattedPostDate)s!', {
 					args: { typeLabel, formattedPostDate },
 					comment:
-						'Editor: Message displayed when a post, page, or post of a custom type is scheduled, with the scheduled date and time.',
+						'Editor: Message displayed when a post of a custom type is scheduled, with the scheduled date and time.',
 				} );
 
 			case 'publishedPrivately':
@@ -146,13 +200,33 @@ export class EditorNotice extends Component {
 				return translate( 'View Preview' );
 
 			case 'updated':
+				if ( 'page' === type ) {
+					return translate( 'Page updated! {{pageLink}}Visit page{{/pageLink}}.', {
+						components: {
+							pageLink: <a href={ postUrl } onClick={ this.handleViewPostClick } />,
+						},
+						comment:
+							'Editor: Message displayed when a page is updated, with a link to the updated page.',
+					} );
+				}
+
+				if ( 'post' === type ) {
+					return translate( 'Post updated! {{postLink}}Visit post{{/postLink}}.', {
+						components: {
+							postLink: <a href={ postUrl } onClick={ this.handleViewPostClick } />,
+						},
+						comment:
+							'Editor: Message displayed when a post is updated, with a link to the updated post.',
+					} );
+				}
+
 				return translate( '%(typeLabel)s updated! {{postLink}}Visit %(typeLabel)s{{/postLink}}.', {
 					args: { typeLabel },
 					components: {
 						postLink: <a href={ postUrl } onClick={ this.handleViewPostClick } />,
 					},
 					comment:
-						'Editor: Message displayed when a page, post, or post of a custom type is updated, with a link to the updated post.',
+						'Editor: Message displayed when a post of a custom type is updated, with a link to the updated post.',
 				} );
 		}
 	}

--- a/client/post-editor/editor-notice/test/__snapshots__/index.jsx.snap
+++ b/client/post-editor/editor-notice/test/__snapshots__/index.jsx.snap
@@ -73,14 +73,20 @@ exports[`EditorNotice should display publish success for post 1`] = `
     status="is-success"
     text={
       Array [
-        "post published on ",
+        "Post published on ",
         <a
           href={undefined}
           onClick={[Function]}
         >
           Example Site
         </a>,
-        "!",
+        "! ",
+        <a
+          href="/post/example.wordpress.com"
+          onClick={[Function]}
+        >
+          Add another post
+        </a>,
       ]
     }
   />


### PR DESCRIPTION
**Note**: the branch name is a misnomer :)

See: #14718 which introduced the `.toLowerCase()` a year ago ([e.g.](https://github.com/Automattic/wp-calypso/pull/14718/files#diff-5832a88e66f1c149f5666b93306f55e3R98))

Calling `toLowerCase()` on the output of a `translate()` call causes two problems:

1. When the community translator is enabled, the output of of `translate()` might not be a string, but an object

![jun-18-2018 14-34-27](https://user-images.githubusercontent.com/6458278/41520142-934b1f86-730f-11e8-853b-0612f8bc7615.gif)

2. Forcing lowercase on translated strings creates ungrammatical output for languages that capitalize nouns, such as German.

<img width="462" alt="screen shot 2018-06-18 at 3 52 55 pm" src="https://user-images.githubusercontent.com/6458278/41520207-f4eae190-730f-11e8-98ad-9c0f5fcaa185.png">

## Solution

We've removed the noun completely to avoid concatenation. We already have a descriptive title.

<img width="395" alt="screen shot 2018-06-21 at 11 38 46 am" src="https://user-images.githubusercontent.com/6458278/41693412-7cbef72a-7548-11e8-891c-7f3821a13be8.png">

Tested in IE, Chrome, FF

## Testing
1. Go to http://calypso.localhost:3000/settings/writing/{your-site}
2. Switch to a non-English language and enable the community translation on this site

### Expectations
With the community translator enabled, the page should not break.


