### PR TITLE
Language Picker: fixed an issue where jetpack sites did not show an indication that the locale is not supported

### DIFF
--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -79,7 +79,7 @@ export class LanguagePicker extends PureComponent {
 		}
 
 		// onChange takes an object in shape of a DOM event as argument
-		const value = language[ this.props.valueKey ];
+		const value = language[ this.props.valueKey ] || language.langSlug;
 		const event = { target: { value } };
 		this.props.onChange( event );
 		this.setState( {


### PR DESCRIPTION
Fixed an issue where jetpack sites did not show an indication that the locale is not supported.

Fixes #25546 

**Description**
Some locales are not supported under jetpack sites, so their "wpLocale" field is empty in the _shared.json file under the languages section. 

This causes an issue on master because when the user selects a language for a jetpack site, the selected language value that is being sent to the server is derived from the valueKey which is set to be "wpLocale" for jetpack sites, and once "wpLocale" is empty, it selects the first matching language with an empty "wpLocale" (ALM).

The fix for the issue is properly showing the user that the locale is not supported, by allowing a fallback to "langSlug" when the value from the valueKey turns out empty.

**Expected behavior**
When choosing an unsupported locale under a jetpack site - I expect to see that it is not supported. 

**In master**
Once you select one of the unsupported locales it picks the 'ALM' locale which is the first matched unsupported locale instead of the selected one and showing a proper message.

![wrong-language mov](https://user-images.githubusercontent.com/5431237/41530025-24ee132e-72ef-11e8-81fc-e9d109c04a0b.gif)

**In this branch**
Once you pick an unsupported locale, it selects it and shows a proper message.

![right-language mov](https://user-images.githubusercontent.com/5431237/41530033-29146674-72ef-11e8-8b9e-c4fa51db537c.gif)

**Testing**
1. Choose a Jetpack (/AT) site from your site list, and select Settings from the sidebar
2.  Under "Language", open the language picker.
3. Choose `कश्मीरी` from the Asia-Pacific tab ('ks') and click on Select Language

