### PR TITLE
Docs: Updates extensions docs for single-tree rendering example

### DIFF
--- a/client/extensions/README.md
+++ b/client/extensions/README.md
@@ -48,12 +48,9 @@ At the moment we use a simple routing interface with `page.js`. There are a few 
 `renderHelloWorld` in this case is the one you need to create and is responsible for rendering your section:
 
 ```js
-const renderHelloWorld = ( context ) => {
-	renderWithReduxStore( (
-		<Main>
-			<HelloWorld />
-		</Main>
-	), document.getElementById( 'primary' ), context.store );
+const renderHelloWorld = ( context, next ) => {
+	context.primary = <HelloWorld />;
+	next();
 };
 ```
 


### PR DESCRIPTION
See: #19494

Six months ago we updated our main app rendering to use a "single tree"
of React components whereas we where rendering to different DOM nodes in
the past. This README file must have been missed in the update so I'm
updating it in this patch.

**Testing**
The changes should be obvious to see. Please navigate to [/devdocs/client/extensions/README.md](https://calypso.live/devdocs/client/extensions/README.md?branch=docs/update-extensions-use-single-tree) and verify that the example code matches the actual code in the project.