### PR TITLE
[WIP] Checkout: Update/hosted paywall to data layer

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1165,26 +1165,6 @@ Undocumented.prototype.ebanxConfiguration = function( query, fn ) {
 };
 
 /**
- * GET emergent paywall iframe client configuration
- *
- * @param {string} countryCode - user's country code
- * @param {object} cart - current cart object. See: client/lib/cart/store/index.js
- * @param {Function} fn The callback function
- * @api public
- *
- * @returns {Promise} promise
- */
-Undocumented.prototype.emergentPaywallConfiguration = function( countryCode, cart, fn ) {
-	debug( '/me/emergent-paywall-configuration query' );
-
-	return this.wpcom.req.post(
-		'/me/emergent-paywall-configuration',
-		{ country: countryCode, cart },
-		fn
-	);
-};
-
-/**
  * GET paypal_express_url
  *
  * @param {object} [data] The GET data

--- a/client/my-sites/checkout/checkout/emergent-paywall-box.jsx
+++ b/client/my-sites/checkout/checkout/emergent-paywall-box.jsx
@@ -75,7 +75,11 @@ export class EmergentPaywallBox extends Component {
 	}
 
 	componentDidMount() {
-		this.props.requestEmergentPaywallConfiguration( this.props.userCountryCode, this.props.cart );
+		this.props.requestEmergentPaywallConfiguration(
+			this.props.userCountryCode,
+			this.props.cart,
+			this.props.transaction.domainDetails
+		);
 		window.addEventListener( 'message', this.onMessageReceiveHandler, false );
 	}
 
@@ -88,7 +92,11 @@ export class EmergentPaywallBox extends Component {
 			prevProps.cart.total_cost !== this.props.cart.total_cost ||
 			prevProps.cart.products.length !== this.props.cart.products.length
 		) {
-			this.props.requestEmergentPaywallConfiguration( this.props.userCountryCode, this.props.cart );
+			this.props.requestEmergentPaywallConfiguration(
+				this.props.userCountryCode,
+				this.props.cart,
+				this.props.transaction.domainDetails
+			);
 			return;
 		}
 
@@ -253,17 +261,18 @@ export class EmergentPaywallBox extends Component {
  *
  * @param {string} countryCode - user's country code
  * @param {object} cart - current cart object. See: client/lib/cart/store/index.js
+ * @param {object} domainDetails - transaction store domain details
  *
  * @return {*} Stored data container for request.
  */
-export const requestEmergentPaywallConfiguration = ( countryCode, cart ) => {
+export const requestEmergentPaywallConfiguration = ( countryCode, cart, domainDetails ) => {
 	return requestHttpData(
 		httpDataId,
 		http( {
 			apiVersion: '1.1',
 			method: 'POST',
 			path: '/me/emergent-paywall-configuration',
-			body: { country: countryCode, cart },
+			body: { country: countryCode, cart, domainDetails },
 		} ),
 		{
 			fromApi: () => config => [ [ 'config', config ] ],

--- a/client/my-sites/checkout/checkout/emergent-paywall-box.jsx
+++ b/client/my-sites/checkout/checkout/emergent-paywall-box.jsx
@@ -18,11 +18,13 @@ import { translate } from 'i18n-calypso';
 import analytics from 'lib/analytics';
 import notices from 'notices';
 import TermsOfService from './terms-of-service';
+import wp from 'lib/wp';
 import { paymentMethodName, paymentMethodClassName } from 'lib/cart-values';
 import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { getHttpData, requestHttpData } from 'state/data-layer/http-data';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
+const wpcom = wp.undocumented();
 const log = debug( 'calypso:checkout:payment:emergent-payall' );
 const httpDataId = 'emergent-paywall-config';
 

--- a/client/my-sites/checkout/checkout/emergent-paywall-box.jsx
+++ b/client/my-sites/checkout/checkout/emergent-paywall-box.jsx
@@ -262,7 +262,17 @@ export const requestEmergentPaywallConfiguration = ( cart, domainDetails, countr
 			body: { cart, domainDetails, country },
 		} ),
 		{
-			fromApi: () => config => [ [ 'config', config ] ],
+			fromApi: () => ( { paywall_url, payload, charge_id, signature } ) => [
+				[
+					emergentPaywallLookupKey,
+					{
+						paywall_url,
+						payload,
+						charge_id,
+						signature,
+					},
+				],
+			],
 			freshness: -Infinity,
 		}
 	);

--- a/client/my-sites/checkout/checkout/emergent-paywall-box.jsx
+++ b/client/my-sites/checkout/checkout/emergent-paywall-box.jsx
@@ -33,6 +33,7 @@ export class EmergentPaywallBox extends Component {
 		cart: PropTypes.object.isRequired,
 		selectedSite: PropTypes.object,
 		transaction: PropTypes.object.isRequired,
+		fetchIframeConfig: PropTypes.func.isRequired,
 		iframeConfig: PropTypes.object,
 		iframeConfigRequestState: PropTypes.string,
 		showErrorNotice: PropTypes.func.isRequired,

--- a/client/my-sites/checkout/checkout/test/__snapshots__/emergent-paywall-box.js.snap
+++ b/client/my-sites/checkout/checkout/test/__snapshots__/emergent-paywall-box.js.snap
@@ -20,7 +20,6 @@ exports[`<EmergentPaywallBox /> should render 1`] = `
       className="checkout__emergent-paywall-frame-container"
     >
       <form
-        action=""
         className="checkout__emergent-paywall-form"
         method="POST"
         name="emergent-paywall-get-iframe-contents"
@@ -30,12 +29,10 @@ exports[`<EmergentPaywallBox /> should render 1`] = `
         <input
           name="payload"
           type="hidden"
-          value=""
         />
         <input
           name="signature"
           type="hidden"
-          value=""
         />
       </form>
       <iframe

--- a/client/my-sites/checkout/checkout/test/emergent-paywall-box.js
+++ b/client/my-sites/checkout/checkout/test/emergent-paywall-box.js
@@ -23,6 +23,11 @@ const defaultProps = {
 		products: [],
 	},
 	transaction: {},
+	iframeConfig: {},
+	iframeConfigRequestState: '',
+	fetchIframeConfig: jest.fn(),
+	showErrorNotice: jest.fn(),
+	removeNotice: jest.fn(),
 	translate: identity,
 	userCountryCode: 'IN',
 };
@@ -37,12 +42,12 @@ describe( '<EmergentPaywallBox />', () => {
 		const wrapper = mount( <EmergentPaywallBox { ...defaultProps } /> );
 		expect( wrapper.find( '.iframe-loaded' ) ).toHaveLength( 0 );
 		wrapper.setProps( {
-			emergentPaywallConfig: {
+			iframeConfig: {
 				paywall_url: 'http://bork.it',
 				signature: 'signature',
 				payload: 'payload',
 			},
-			emergentPaywallConfigState: 'success',
+			iframeConfigRequestState: 'success',
 		} );
 		expect( wrapper.find( '.iframe-loaded' ) ).toHaveLength( 1 );
 		expect( wrapper.find( 'input[name="payload"]' ).props().value ).toEqual( 'payload' );

--- a/client/my-sites/checkout/checkout/test/emergent-paywall-box.js
+++ b/client/my-sites/checkout/checkout/test/emergent-paywall-box.js
@@ -6,7 +6,7 @@
  * External dependencies
  */
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { identity } from 'lodash';
 
 /**
@@ -19,7 +19,9 @@ import { EmergentPaywallBox } from '../emergent-paywall-box';
 jest.mock( 'lib/user', () => () => {} );
 
 const defaultProps = {
-	cart: {},
+	cart: {
+		products: [],
+	},
 	transaction: {},
 	translate: identity,
 	userCountryCode: 'IN',
@@ -32,13 +34,15 @@ describe( '<EmergentPaywallBox />', () => {
 	} );
 
 	test( 'should display iframe and form when we assign iframe properties', () => {
-		const wrapper = shallow( <EmergentPaywallBox { ...defaultProps } /> );
+		const wrapper = mount( <EmergentPaywallBox { ...defaultProps } /> );
 		expect( wrapper.find( '.iframe-loaded' ) ).toHaveLength( 0 );
-		wrapper.setState( {
-			hasConfigLoaded: true,
-			paywall_url: 'http://bork.it',
-			signature: 'signature',
-			payload: 'payload',
+		wrapper.setProps( {
+			emergentPaywallConfig: {
+				paywall_url: 'http://bork.it',
+				signature: 'signature',
+				payload: 'payload',
+			},
+			emergentPaywallConfigState: 'success',
 		} );
 		expect( wrapper.find( '.iframe-loaded' ) ).toHaveLength( 1 );
 		expect( wrapper.find( 'input[name="payload"]' ).props().value ).toEqual( 'payload' );


### PR DESCRIPTION
Based on feedback for #24675

WIP - haven't done much testing. 

@dmsnell Any tips on `httpData` usage here? I've created a data-getter ([requestEmergentPaywallConfiguration](https://github.com/Automattic/wp-calypso/pull/25553/files#diff-550ffb59f9f9143d8e599986c91d8dd4R39)) _in situ_, until a sensible place to dump it comes up. :)

## Testing

`beforeAll():`

1. Tweak `getCurrentUserPaymentMethods` in `client/state/selectors/get-current-user-payment-methods.js` by hardcoding `IN` as the countryCode for `paymentMethods.byCountry[ countryCode ] ||`.

2. In `client/my-sites/checkout/checkout/emergent-paywall-box.jsx` pass replace `this.props.userCountryCode` with `IN` `wpcom.emergentPaywallConfiguration`.

### Test payment info:
- *paytm*: 
  - Phone Number: 7777777777
  - OTP: 489871
- *Bank Transfer*
  - Bank: "AXIS Bank"
- Debit Card
  - Card no : 4012 0010 3714 1112
  - Card expiry : 05/20
  - CVV : 123