### PR TITLE
Jetpack New Site: Do not force protocol in JPC URL form

### DIFF
--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -28,13 +28,23 @@ class JetpackNewSite extends Component {
 		this.handleBack = this.handleBack.bind( this );
 	}
 
-	state = { jetpackUrl: '' };
+	state = {
+		jetpackUrl: '',
+		shownUrl: '',
+	};
 
 	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_jetpack_new_site_view' );
 	}
 
-	handleJetpackUrlChange = event => this.setState( { jetpackUrl: cleanUrl( event.target.value ) } );
+	handleJetpackUrlChange = event => {
+		const url = event.target.value;
+
+		this.setState( {
+			jetpackUrl: cleanUrl( url ),
+			shownUrl: url,
+		} );
+	};
 
 	getNewWpcomSiteUrl() {
 		return config( 'signup_url' ) + '?ref=calypso-selector';
@@ -109,7 +119,7 @@ class JetpackNewSite extends Component {
 								onChange={ this.handleJetpackUrlChange }
 								onSubmit={ this.handleJetpackSubmit }
 								handleOnClickTos={ this.handleOnClickTos }
-								url={ this.state.jetpackUrl }
+								url={ this.state.shownUrl }
 								autoFocus={ false } // eslint-disable-line jsx-a11y/no-autofocus
 							/>
 						</Card>
@@ -129,7 +139,7 @@ class JetpackNewSite extends Component {
 									onChange={ this.handleJetpackUrlChange }
 									onSubmit={ this.handleJetpackSubmit }
 									handleOnClickTos={ this.handleOnClickTos }
-									url={ this.state.jetpackUrl }
+									url={ this.state.shownUrl }
 									autoFocus={ false } // eslint-disable-line jsx-a11y/no-autofocus
 								/>
 							</div>


### PR DESCRIPTION
This PR fixes a bug reported by @keoshi, where there is misbehavior with the protocol being prepended and wrongly handled as the URL is changed in the Jetpack Connect site URL form in `/jetpack/new`.

![jp-connect-url](https://user-images.githubusercontent.com/8436925/41539160-b903e04a-7315-11e8-98b5-6e3d44a41f33.gif)

This PR aligns how we approach the JPC site URL input change event with the way we're doing it in `/jetpack/connect` (see [here](https://github.com/Automattic/wp-calypso/blob/master/client/jetpack-connect/main.jsx) for details).

To test:
* Checkout this branch, or use calypso.live
* Go to `/jetpack/new` or https://calypso.live/jetpack/new?branch=fix/jetpack-new-jpc-http-behavior
* Try inputting, changing and deleting parts of the URL as shown on the gif.
* Verify `http` no longer is prepended automatically, but it can be manually inputted and slashes can be used freely.
* Compare the behavior with the one at `/jetpack/connect` and verify they work the same way.