### PR TITLE
Force refetch of external users when visiting the stats page

### DIFF
--- a/client/components/data/query-keyring-connections/index.jsx
+++ b/client/components/data/query-keyring-connections/index.jsx
@@ -16,13 +16,18 @@ import { requestKeyringConnections } from 'state/sharing/keyring/actions';
 
 class QueryKeyringConnections extends Component {
 	static propTypes = {
+		forceRefresh: PropTypes.bool,
 		isRequesting: PropTypes.bool,
 		requestKeyringConnections: PropTypes.func,
 	};
 
+	static defaultProps = {
+		forceRefresh: false,
+	};
+
 	componentWillMount() {
 		if ( ! this.props.isRequesting ) {
-			this.props.requestKeyringConnections();
+			this.props.requestKeyringConnections( this.props.forceRefresh );
 		}
 	}
 

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -193,7 +193,7 @@ class GoogleMyBusinessStats extends Component {
 				<StatsNavigation selectedItem={ 'googleMyBusiness' } siteId={ siteId } slug={ siteSlug } />
 
 				{ siteId && <QuerySiteKeyrings siteId={ siteId } /> }
-				<QueryKeyringConnections />
+				<QueryKeyringConnections forceRefresh />
 
 				{ ! isLocationVerified && (
 					<Notice


### PR DESCRIPTION
The only places where the verified property of location is used/displayed are:
- Select Location page
- GMB Stats Page

The former already refetches the location but is inaccessible once a GMB location is connected.
This PR forces a refetch on the latter.

### Testing Instructions
- Boot this branch locally
- Go to GMB Stats and check that the `/me/keyring` request is made and that it has a `force_external_users_refetch` property set to `true` 
- If you can, test with a connected unverified location by verifying it
- You can also try updating the address or the image that is displayed for the location

### Reviews
- [x] Code
- [x] Product