### PR TITLE
Checkout: Add a track event for cart abandonment notice view

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -66,6 +66,8 @@ class CurrentSite extends Component {
 			cartItems.hasStaleItem( CartStore.get() ) &&
 			this.props.staleCartItemNoticeLastTimeShown < Date.now() - 10 * 60 * 1000
 		) {
+			this.props.recordTracksEvent( 'calypso_cart_abandonment_notice_view' );
+
 			this.props.infoNotice( this.props.translate( 'Your site deserves a boost!' ), {
 				id: staleCartItemNoticeId,
 				isPersistent: false,


### PR DESCRIPTION
Required by #22995

Add a new Tracks event, `calypso_cart_abandonment_notice_view`, fired whenever the stale cart notice is displayed.

This is required to appropriately set up the funnel to A/B test #22995.

## Testing instructions

- Open the Plans page for a less-than-Business site: `/plans/${ siteSlug }`.
- Pick a higher plan and click on Upgrade: you should be redirected to the Cart.
- Navigate away from the Cart and wait for 10 minutes. Do not change site (or remember to switch back to it for the next step)!
- Meanwhile, enable the Tracks debug by entering `localStorage.setItem('debug', 'calypso:analytics:tracks')` in the console.
- A stale cart notice ("Your site deserves a boost!") should appear, or just refresh to make it appear.
- Check in the console that the event `calypso_cart_abandonment_notice_view` has been fired.