### PR TITLE
Purchases: Allow removal for non expired/expiring purchases

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -3,15 +3,21 @@
 /**
  * External dependencies
  */
-
-import { find, includes } from 'lodash';
-import moment from 'moment';
 import i18n from 'i18n-calypso';
+import moment from 'moment';
+import { includes, find, overSome } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { isDomainRegistration, isDomainTransfer, isPlan, isTheme } from 'lib/products-values';
+import {
+	isDomainMapping,
+	isDomainRegistration,
+	isDomainTransfer,
+	isPlan,
+	isSiteRedirect,
+	isTheme,
+} from 'lib/products-values';
 
 function getIncludedDomain( purchase ) {
 	return purchase.includedDomain;
@@ -172,13 +178,20 @@ function isRemovable( purchase ) {
 		return false;
 	}
 
-	return (
-		isExpiring( purchase ) ||
-		isExpired( purchase ) ||
-		( isDomainTransfer( purchase ) &&
-			! isRefundable( purchase ) &&
-			isPurchaseCancelable( purchase ) )
-	);
+	// Disallow removal of non-expired or non-expiring purchases of these types
+	if ( overSome( isDomainMapping, isDomainRegistration, isSiteRedirect )( purchase ) ) {
+		return isExpired( purchase ) || isExpiring( purchase );
+	}
+
+	if ( isDomainTransfer( purchase ) ) {
+		return (
+			isExpired( purchase ) ||
+			isExpiring( purchase ) ||
+			( ! isRefundable( purchase ) && isPurchaseCancelable( purchase ) )
+		);
+	}
+
+	return true;
 }
 
 /**

--- a/client/lib/purchases/test/data/index.js
+++ b/client/lib/purchases/test/data/index.js
@@ -1,5 +1,5 @@
 /** @format */
-const DOMAIN_PURCHASE = {
+export const DOMAIN_PURCHASE = {
 	expiryStatus: 'active',
 	id: 10001,
 	isDomainRegistration: true,
@@ -10,7 +10,7 @@ const DOMAIN_PURCHASE = {
 	isCancelable: true,
 };
 
-const DOMAIN_PURCHASE_PENDING_TRANSFER = {
+export const DOMAIN_PURCHASE_PENDING_TRANSFER = {
 	expiryStatus: 'active',
 	id: 10001,
 	isDomainRegistration: true,
@@ -20,18 +20,18 @@ const DOMAIN_PURCHASE_PENDING_TRANSFER = {
 	pendingTransfer: true,
 };
 
-const DOMAIN_PURCHASE_EXPIRED = Object.assign( {}, DOMAIN_PURCHASE, {
+export const DOMAIN_PURCHASE_EXPIRED = Object.assign( {}, DOMAIN_PURCHASE, {
 	expiryStatus: 'expired',
 	id: 10002,
 	isCancelable: false,
 } );
 
-const DOMAIN_PURCHASE_INCLUDED_IN_PLAN = Object.assign( {}, DOMAIN_PURCHASE, {
+export const DOMAIN_PURCHASE_INCLUDED_IN_PLAN = Object.assign( {}, DOMAIN_PURCHASE, {
 	id: 10004,
 	expiryStatus: 'included',
 } );
 
-const DOMAIN_MAPPING_PURCHASE = {
+export const DOMAIN_MAPPING_PURCHASE = {
 	expiryStatus: 'active',
 	id: 20001,
 	isDomainRegistration: false,
@@ -41,13 +41,13 @@ const DOMAIN_MAPPING_PURCHASE = {
 	isCancelable: true,
 };
 
-const DOMAIN_MAPPING_PURCHASE_EXPIRED = Object.assign( {}, DOMAIN_MAPPING_PURCHASE, {
+export const DOMAIN_MAPPING_PURCHASE_EXPIRED = Object.assign( {}, DOMAIN_MAPPING_PURCHASE, {
 	expiryStatus: 'expired',
 	id: 20002,
 	isCancelable: false,
 } );
 
-const SITE_REDIRECT_PURCHASE = {
+export const SITE_REDIRECT_PURCHASE = {
 	expiryStatus: 'active',
 	id: 30001,
 	isDomainRegistration: false,
@@ -57,12 +57,12 @@ const SITE_REDIRECT_PURCHASE = {
 	isCancelable: false,
 };
 
-const SITE_REDIRECT_PURCHASE_EXPIRED = Object.assign( {}, SITE_REDIRECT_PURCHASE, {
+export const SITE_REDIRECT_PURCHASE_EXPIRED = Object.assign( {}, SITE_REDIRECT_PURCHASE, {
 	expiryStatus: 'expired',
 	id: 30002,
 } );
 
-const PLAN_PURCHASE = {
+export const PLAN_PURCHASE = {
 	expiryStatus: 'active',
 	id: 40001,
 	meta: '',
@@ -74,7 +74,7 @@ const PLAN_PURCHASE = {
 	isDomainRegistration: false,
 };
 
-const PLAN_PURCHASE_WITH_CREDITS = {
+export const PLAN_PURCHASE_WITH_CREDITS = {
 	id: 4002,
 	payment: {
 		type: 'credits',
@@ -86,7 +86,7 @@ const PLAN_PURCHASE_WITH_CREDITS = {
 	productSlug: 'jetpack_personal_monthly',
 };
 
-const PLAN_PURCHASE_WITH_PAYPAL = {
+export const PLAN_PURCHASE_WITH_PAYPAL = {
 	id: 4003,
 	payment: {
 		type: 'paypal',
@@ -94,18 +94,4 @@ const PLAN_PURCHASE_WITH_PAYPAL = {
 	productId: 2006,
 	productName: 'Personal',
 	productSlug: 'jetpack_personal_monthly',
-};
-
-export default {
-	DOMAIN_PURCHASE,
-	DOMAIN_PURCHASE_PENDING_TRANSFER,
-	DOMAIN_PURCHASE_EXPIRED,
-	DOMAIN_PURCHASE_INCLUDED_IN_PLAN,
-	DOMAIN_MAPPING_PURCHASE,
-	DOMAIN_MAPPING_PURCHASE_EXPIRED,
-	PLAN_PURCHASE,
-	SITE_REDIRECT_PURCHASE,
-	SITE_REDIRECT_PURCHASE_EXPIRED,
-	PLAN_PURCHASE_WITH_CREDITS,
-	PLAN_PURCHASE_WITH_PAYPAL,
 };

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import moment from 'moment';
 
 /**
@@ -28,64 +26,64 @@ import {
 describe( 'index', () => {
 	describe( '#isRemovable', () => {
 		test( 'should not be removable when domain registration purchase is not expired', () => {
-			expect( isRemovable( DOMAIN_PURCHASE ) ).to.be.false;
+			expect( isRemovable( DOMAIN_PURCHASE ) ).toBe( false );
 		} );
 
 		test( 'should not be removable when domain mapping purchase is not expired', () => {
-			expect( isRemovable( DOMAIN_MAPPING_PURCHASE ) ).to.be.false;
+			expect( isRemovable( DOMAIN_MAPPING_PURCHASE ) ).toBe( false );
 		} );
 
 		test( 'should not be removable when site redirect purchase is not expired', () => {
-			expect( isRemovable( SITE_REDIRECT_PURCHASE ) ).to.be.false;
+			expect( isRemovable( SITE_REDIRECT_PURCHASE ) ).toBe( false );
 		} );
 
 		test( 'should be removable when domain registration purchase is expired', () => {
-			expect( isRemovable( DOMAIN_PURCHASE_EXPIRED ) ).to.be.true;
+			expect( isRemovable( DOMAIN_PURCHASE_EXPIRED ) ).toBe( true );
 		} );
 
 		test( 'should be removable when domain mapping purchase is expired', () => {
-			expect( isRemovable( DOMAIN_MAPPING_PURCHASE_EXPIRED ) ).to.be.true;
+			expect( isRemovable( DOMAIN_MAPPING_PURCHASE_EXPIRED ) ).toBe( true );
 		} );
 
 		test( 'should be removable when site redirect purchase is expired', () => {
-			expect( isRemovable( SITE_REDIRECT_PURCHASE_EXPIRED ) ).to.be.true;
+			expect( isRemovable( SITE_REDIRECT_PURCHASE_EXPIRED ) ).toBe( true );
 		} );
 	} );
 	describe( '#isCancelable', () => {
 		test( 'should not be cancelable when the purchase is included in a plan', () => {
-			expect( isCancelable( DOMAIN_PURCHASE_INCLUDED_IN_PLAN ) ).to.be.false;
+			expect( isCancelable( DOMAIN_PURCHASE_INCLUDED_IN_PLAN ) ).toBe( false );
 		} );
 
 		test( 'should not be cancelable when the purchase is expired', () => {
-			expect( isCancelable( DOMAIN_PURCHASE_EXPIRED ) ).to.be.false;
+			expect( isCancelable( DOMAIN_PURCHASE_EXPIRED ) ).toBe( false );
 		} );
 
 		test( 'should be cancelable when the purchase is refundable', () => {
-			expect( isCancelable( DOMAIN_PURCHASE ) ).to.be.true;
+			expect( isCancelable( DOMAIN_PURCHASE ) ).toBe( true );
 		} );
 
 		test( 'should be cancelable when the purchase can have auto-renew disabled', () => {
-			expect( isCancelable( PLAN_PURCHASE ) ).to.be.true;
+			expect( isCancelable( PLAN_PURCHASE ) ).toBe( true );
 		} );
 
 		test( 'should not be cancelable if domain is pending transfer', () => {
-			expect( isCancelable( DOMAIN_PURCHASE_PENDING_TRANSFER ) ).to.be.false;
+			expect( isCancelable( DOMAIN_PURCHASE_PENDING_TRANSFER ) ).toBe( false );
 		} );
 	} );
 	describe( '#isPaidWithCredits', () => {
 		test( 'should be true when paid with credits', () => {
-			expect( isPaidWithCredits( PLAN_PURCHASE_WITH_CREDITS ) ).to.be.true;
+			expect( isPaidWithCredits( PLAN_PURCHASE_WITH_CREDITS ) ).toBe( true );
 		} );
 		test( 'should false when not paid with credits', () => {
-			expect( isPaidWithCredits( PLAN_PURCHASE_WITH_PAYPAL ) ).to.be.false;
+			expect( isPaidWithCredits( PLAN_PURCHASE_WITH_PAYPAL ) ).toBe( false );
 		} );
 		test( 'should be false when payment not set on purchase', () => {
-			expect( isPaidWithCredits( {} ) ).to.be.false;
+			expect( isPaidWithCredits( {} ) ).toBe( false );
 		} );
 	} );
 	describe( '#subscribedWithinPastWeek', () => {
 		test( 'should return false when no subscribed date', () => {
-			expect( subscribedWithinPastWeek( {} ) ).to.be.false;
+			expect( subscribedWithinPastWeek( {} ) ).toBe( false );
 		} );
 		test( 'should return false when subscribed more than 1 week ago', () => {
 			expect(
@@ -94,7 +92,7 @@ describe( 'index', () => {
 						.subtract( 8, 'days' )
 						.format(),
 				} )
-			).to.be.false;
+			).toBe( false );
 		} );
 		test( 'should return true when subscribed less than 1 week ago', () => {
 			expect(
@@ -103,7 +101,7 @@ describe( 'index', () => {
 						.subtract( 3, 'days' )
 						.format(),
 				} )
-			).to.be.true;
+			).toBe( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
Purchases that are "not expired" or "not expiring," are not considered removable. Why? This is problematic for #25473 and has been reported (p1HpG7-5ez-p2 #comment-26434).

This PR modifies the `isRemovable` condition to allow some non-expiring purchases to be removable.

## Testing
The relevant bits have been pulled into #25473 and can be tested there with a credit card purchase.