### PR TITLE
Close Account: Add context for the button text

### DIFF
--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -181,7 +181,7 @@ class AccountSettingsClose extends Component {
 						{ ( isLoading || isDeletePossible ) && (
 							<Button scary onClick={ this.handleDeleteClick }>
 								<Gridicon icon="trash" />
-								{ translate( 'Close account' ) }
+								{ translate( 'Close account', { context: 'button label' } ) }
 							</Button>
 						) }
 						{ hasAtomicSites && (
@@ -192,7 +192,7 @@ class AccountSettingsClose extends Component {
 						{ hasPurchases &&
 							! hasAtomicSites && (
 								<Button primary href="/me/purchases">
-									{ translate( 'Manage purchases' ) }
+									{ translate( 'Manage purchases', { context: 'button label' } ) }
 								</Button>
 							) }
 					</ActionPanelFooter>


### PR DESCRIPTION
In #24859 we started to use the phrase `Close Account` in two meanings:
1. as a headline
2. as a button label ("action")

This needs differen translations in some languages. Adding a context allows to do this. The `Manage Purchases` has a similar problem which has already been addressed with a `button label` context elsewhere, so we're just re-using this.