### PR TITLE
Activity Log: Improve variables and wording

### DIFF
--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -92,9 +92,12 @@ class SuccessBanner extends PureComponent {
 					track: (
 						<TrackComponentView eventName="calypso_activitylog_backup_successbanner_impression" />
 					),
-					taskFinished: translate( 'We successfully created a backup of your site at %s!', {
-						args: date,
-					} ),
+					taskFinished: translate(
+						'We successfully created a backup of your site as of %(date)s!',
+						{
+							args: { date },
+						}
+					),
 					actionButton: (
 						<Button href={ backupUrl } onClick={ this.trackDownload } primary>
 							{ translate( 'Download' ) }
@@ -116,8 +119,12 @@ class SuccessBanner extends PureComponent {
 					),
 					taskFinished:
 						'alternate' === context
-							? translate( 'We successfully cloned your site to %s!', { args: date } )
-							: translate( 'We successfully restored your site back to %s!', { args: date } ),
+							? translate( 'We successfully cloned your site to the state as of %(date)s!', {
+									args: { date },
+							  } )
+							: translate( 'We successfully restored your site back to %(date)s!', {
+									args: { date },
+							  } ),
 					actionButton: (
 						<Button href={ siteUrl } primary>
 							{ translate( 'View site' ) }


### PR DESCRIPTION
In #25288 we introduced the string `We successfully cloned your site to %s!` which is hard to translate because:
1. it's not clear for translators that %s is a date (they really only see this string).
2. it's hard to understand why a site can be cloned to a date.

This PR changes this (and other strings that reference a date) to `We successfully cloned your site to the state as of %(date)s!`

It should make both the English clearer and easier for translators to translate.