### PR TITLE
Jetpack logo: add cache buster param

### DIFF
--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -129,7 +129,10 @@ export class Login extends React.Component {
 						</a>
 					</div>
 				) : (
-					<img src="/calypso/images/jetpack/powered-by-jetpack.svg" alt="Powered by Jetpack" />
+					<img
+						src="/calypso/images/jetpack/powered-by-jetpack.svg?v=20180619"
+						alt="Powered by Jetpack"
+					/>
 				) }
 			</div>
 		);


### PR DESCRIPTION
When opening a page that loaded the Jetpack logo —  `https://wordpress.com/calypso/images/jetpack/powered-by-jetpack.svg —, different versions would be served:

- on mobile devices (not emulated) it shows the old Jetpack logo.
- on desktop devices (even emulating mobile) it shows the new Jetpack logo.

Turns out it's a caching issue that should be sorted out in code.

This PR adds a cache buster param where the image URL is being called.

Reported by @squirk in p1529410174000500-slack-jetpack-design

#### Before

![image uploaded from ios](https://user-images.githubusercontent.com/390760/41599585-91c3e4d8-73cb-11e8-8f34-e278480da70b.png)

#### After

![image 2](https://user-images.githubusercontent.com/390760/41599591-95cd9efc-73cb-11e8-8523-b3695b52728c.png)
