### PR TITLE
Lib: Remove sectionifyWithRoutes

### DIFF
--- a/client/lib/route/index.js
+++ b/client/lib/route/index.js
@@ -16,7 +16,6 @@ export {
 	getStatsPathForTab,
 	mapPostStatus,
 	sectionify,
-	sectionifyWithRoutes,
 } from './path';
 
 const appendQueryString = ( basepath, querystring ) =>

--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -85,29 +85,6 @@ export function addSiteFragment( path, site ) {
 	return pieces.join( '/' );
 }
 
-export function sectionifyWithRoutes( path, routes ) {
-	const routeParams = {};
-	if ( ! routes || ! Array.isArray( routes ) ) {
-		return {
-			routePath: sectionify( path, routes ),
-			routeParams,
-		};
-	}
-
-	let routePath = path.split( '?' )[ 0 ];
-	for ( const route of routes ) {
-		if ( route.match( routePath, routeParams ) ) {
-			routePath = route.path;
-			break;
-		}
-	}
-
-	return {
-		routePath: untrailingslashit( routePath ),
-		routeParams,
-	};
-}
-
 export function sectionify( path, siteFragment ) {
 	let basePath = path.split( '?' )[ 0 ];
 

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -7,24 +7,11 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { Route } from 'page';
 
 /**
  * Internal dependencies
  */
 import * as route from '../';
-
-const checkoutRoutes = [
-	new Route( '/checkout/thank-you' ),
-	new Route( '/checkout/thank-you/:receipt' ),
-	new Route( '/checkout/:product' ),
-	new Route( '/checkout/:product/renew/:receipt' ),
-];
-
-const commentsRoutes = [
-	new Route( '/comments/approved/:domain' ),
-	new Route( '/comments/pending/:domain' ),
-];
 
 describe( 'route', function() {
 	describe( '#addQueryArgs()', () => {
@@ -481,128 +468,6 @@ describe( 'route', function() {
 				expect( route.sectionify( '/domains/manage/not-a-site', 'not-a-site' ) ).to.equal(
 					'/domains/manage'
 				);
-			} );
-		} );
-	} );
-	describe( 'sectionifyWithRoutes', function() {
-		describe( 'for checkout paths', function() {
-			test( 'should parameterize checkout thank you paths', function() {
-				expect( route.sectionifyWithRoutes( '/checkout/thank-you', checkoutRoutes ) ).to.deep.equal(
-					{
-						routePath: '/checkout/thank-you',
-						routeParams: {},
-					}
-				);
-				expect(
-					route.sectionifyWithRoutes( '/checkout/thank-you/25222194', checkoutRoutes )
-				).to.deep.equal( {
-					routePath: '/checkout/thank-you/:receipt',
-					routeParams: {
-						receipt: '25222194',
-					},
-				} );
-			} );
-			test( 'should parameterize checkout paths', function() {
-				expect( route.sectionifyWithRoutes( '/checkout/gapps', checkoutRoutes ) ).to.deep.equal( {
-					routePath: '/checkout/:product',
-					routeParams: {
-						product: 'gapps',
-					},
-				} );
-				expect(
-					route.sectionifyWithRoutes( '/checkout/theme:elemin', checkoutRoutes )
-				).to.deep.equal( {
-					routePath: '/checkout/:product',
-					routeParams: {
-						product: 'theme:elemin',
-					},
-				} );
-				expect(
-					route.sectionifyWithRoutes( '/checkout/domain_map:69thclergycouncil.com', checkoutRoutes )
-				).to.deep.equal( {
-					routePath: '/checkout/:product',
-					routeParams: {
-						product: 'domain_map:69thclergycouncil.com',
-					},
-				} );
-			} );
-			test( 'should parameterize checkout renew paths', function() {
-				expect(
-					route.sectionifyWithRoutes( '/checkout/gapps/renew/6527469', checkoutRoutes )
-				).to.deep.equal( {
-					routePath: '/checkout/:product/renew/:receipt',
-					routeParams: {
-						product: 'gapps',
-						receipt: '6527469',
-					},
-				} );
-				expect(
-					route.sectionifyWithRoutes(
-						'/checkout/jetpack_premium_monthly/renew/7980613',
-						checkoutRoutes
-					)
-				).to.deep.equal( {
-					routePath: '/checkout/:product/renew/:receipt',
-					routeParams: {
-						product: 'jetpack_premium_monthly',
-						receipt: '7980613',
-					},
-				} );
-				expect(
-					route.sectionifyWithRoutes( '/checkout/personal-bundle/renew/6611954', checkoutRoutes )
-				).to.deep.equal( {
-					routePath: '/checkout/:product/renew/:receipt',
-					routeParams: {
-						product: 'personal-bundle',
-						receipt: '6611954',
-					},
-				} );
-				expect(
-					route.sectionifyWithRoutes(
-						'/checkout/domain_map:69thclergycouncil.com/renew/5164008',
-						checkoutRoutes
-					)
-				).to.deep.equal( {
-					routePath: '/checkout/:product/renew/:receipt',
-					routeParams: {
-						product: 'domain_map:69thclergycouncil.com',
-						receipt: '5164008',
-					},
-				} );
-			} );
-			test( 'should parameterize comment paths', function() {
-				expect( route.sectionifyWithRoutes( '/comments/approved', commentsRoutes ) ).to.deep.equal(
-					{
-						routePath: '/comments/approved',
-						routeParams: {},
-					}
-				);
-				expect( route.sectionifyWithRoutes( '/comments/pending', commentsRoutes ) ).to.deep.equal( {
-					routePath: '/comments/pending',
-					routeParams: {},
-				} );
-				expect(
-					route.sectionifyWithRoutes(
-						'/comments/approved/elmundodelaliteraturasite.wordpress.com',
-						commentsRoutes
-					)
-				).to.deep.equal( {
-					routePath: '/comments/approved/:domain',
-					routeParams: {
-						domain: 'elmundodelaliteraturasite.wordpress.com',
-					},
-				} );
-				expect(
-					route.sectionifyWithRoutes(
-						'/comments/pending/17evasetyowatimm2.wordpress.com',
-						commentsRoutes
-					)
-				).to.deep.equal( {
-					routePath: '/comments/pending/:domain',
-					routeParams: {
-						domain: '17evasetyowatimm2.wordpress.com',
-					},
-				} );
 			} );
 		} );
 	} );


### PR DESCRIPTION
Thanks to the page view tracking audit (p7jreA-1xN-p2) that spurred the refactor of almost all the paths tracked by the `calypso_page_view` event, we realized that building these paths _automagically_ by using `sectionifyWithRoutes` (introduced in #17938) sometimes resulted in unexpected outcomes.

To decrease this kind of outcomes and improve path searchability, in our refactor we opted to write manually as many paths as possible.

After the refactor, `sectionifyWithRoutes` is not used anymore anywhere in Calypso.
This PR simply removes it.