### PR TITLE
Google My Business Chart: Display a custom tooltip for stats aggregated by week

### DIFF
--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -474,7 +474,7 @@ class LineChart extends Component {
 	};
 
 	renderTooltips = () => {
-		const { selectedPoints, data } = this.state;
+		const { selectedPoints } = this.state;
 		const selectPointsValues = selectedPoints.map( point => d3Select( point ).datum().value );
 		const tooltipPositionsMap = this.getTooltipPositionMap( selectPointsValues );
 
@@ -495,7 +495,7 @@ class LineChart extends Component {
 					key={ uniqueKey }
 					isVisible
 				>
-					{ this.props.renderTooltipForDatanum( pointData, data[ pointData.dataSeriesIndex ] ) }
+					{ this.props.renderTooltipForDatanum( pointData ) }
 				</Tooltip>
 			);
 		} );

--- a/client/my-sites/google-my-business/stats/chart.js
+++ b/client/my-sites/google-my-business/stats/chart.js
@@ -31,6 +31,22 @@ import { getStatsInterval } from 'state/ui/google-my-business/selectors';
 import { requestGoogleMyBusinessStats } from 'state/google-my-business/actions';
 import { withEnhancers } from 'state/utils';
 
+const withToolTip = WrappedComponent => props => {
+	// inject interval props to renderTooltipForDatanum
+	const renderTooltipForDatanum = props.renderTooltipForDatanum
+		? partialRight( props.renderTooltipForDatanum, props.tooltipInterval )
+		: null;
+
+	const newProps = {
+		...props,
+		renderTooltipForDatanum,
+	};
+
+	return <WrappedComponent { ...newProps } />;
+};
+
+const LineChartWithTooltip = withToolTip( LineChart );
+
 function transformData( props ) {
 	const { data } = props;
 
@@ -186,7 +202,7 @@ class GoogleMyBusinessStatsChart extends Component {
 	}
 
 	renderLineChart() {
-		const { renderTooltip } = this.props;
+		const { renderTooltipForDatanum, interval } = this.props;
 		const { transformedData, legendInfo } = this.state;
 
 		if ( ! transformedData ) {
@@ -196,11 +212,12 @@ class GoogleMyBusinessStatsChart extends Component {
 		return (
 			<Fragment>
 				<div className="gmb-stats__line-chart">
-					<LineChart
+					<LineChartWithTooltip
 						fillArea
 						data={ transformedData }
-						renderTooltipForDatanum={ renderTooltip }
 						legendInfo={ legendInfo }
+						renderTooltipForDatanum={ renderTooltipForDatanum }
+						tooltipInterval={ interval }
 					/>
 
 					{ this.renderChartNotice() }
@@ -302,10 +319,6 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const interval = getStatsInterval( state, siteId, ownProps.statType );
 		const aggregation = getAggregation( ownProps );
-		// inject interval props to renderTooltipForDatanum
-		const renderTooltip = ownProps.renderTooltipForDatanum
-			? partialRight( ownProps.renderTooltipForDatanum, interval )
-			: null;
 
 		return {
 			siteId,
@@ -318,7 +331,6 @@ export default connect(
 				interval,
 				aggregation
 			),
-			renderTooltip,
 		};
 	},
 	{

--- a/client/my-sites/google-my-business/stats/chart.js
+++ b/client/my-sites/google-my-business/stats/chart.js
@@ -6,7 +6,7 @@
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { flatten, get, sumBy } from 'lodash';
+import { flatten, get, partialRight, sumBy } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -186,7 +186,7 @@ class GoogleMyBusinessStatsChart extends Component {
 	}
 
 	renderLineChart() {
-		const { renderTooltipForDatanum } = this.props;
+		const { renderTooltip } = this.props;
 		const { transformedData, legendInfo } = this.state;
 
 		if ( ! transformedData ) {
@@ -199,7 +199,7 @@ class GoogleMyBusinessStatsChart extends Component {
 					<LineChart
 						fillArea
 						data={ transformedData }
-						renderTooltipForDatanum={ renderTooltipForDatanum }
+						renderTooltipForDatanum={ renderTooltip }
 						legendInfo={ legendInfo }
 					/>
 
@@ -302,6 +302,11 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const interval = getStatsInterval( state, siteId, ownProps.statType );
 		const aggregation = getAggregation( ownProps );
+		// inject interval props to renderTooltipForDatanum
+		const renderTooltip = ownProps.renderTooltipForDatanum
+			? partialRight( ownProps.renderTooltipForDatanum, interval )
+			: null;
+
 		return {
 			siteId,
 			interval,
@@ -313,6 +318,7 @@ export default connect(
 				interval,
 				aggregation
 			),
+			renderTooltip,
 		};
 	},
 	{

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -66,9 +66,22 @@ class GoogleMyBusinessStats extends Component {
 		} );
 	};
 
-	renderViewsTooltipForDatanum = ( datanum, dataSeries ) => {
+	renderViewsTooltipForDatanum = ( datanum, interval ) => {
 		const { value: valueCount, date } = datanum;
-		if ( dataSeries.length > 20 ) {
+		if ( interval === 'quarter' ) {
+			return this.props.translate(
+				'%(value)d view on week %(week)s',
+				'%(value)d views on week %(week)s',
+				{
+					count: valueCount,
+					args: {
+						value: valueCount,
+						week: moment( date ).format( 'D MMMM YYYY' ),
+					},
+					comment: 'How many views per week for a Google My Business location with date.',
+				}
+			);
+		} else if ( interval === 'week' ) {
 			return this.props.translate( '%(value)d view on %(day)s', '%(value)d views on %(day)s', {
 				count: valueCount,
 				args: {
@@ -82,9 +95,22 @@ class GoogleMyBusinessStats extends Component {
 		return valueCount;
 	};
 
-	renderActionsTooltipForDatanum = ( datanum, dataSeries ) => {
+	renderActionsTooltipForDatanum = ( datanum, interval ) => {
 		const { value: valueCount, date } = datanum;
-		if ( dataSeries.length > 20 ) {
+		if ( interval === 'quarter' ) {
+			return this.props.translate(
+				'%(value)d action on week %(week)s',
+				'%(value)d action on week %(week)s',
+				{
+					count: valueCount,
+					args: {
+						value: valueCount,
+						week: moment( date ).format( 'D MMMM YYYY' ),
+					},
+					comment: 'How many views per week for a Google My Business location with date.',
+				}
+			);
+		} else if ( interval === 'week' ) {
 			return this.props.translate( '%(value)d action on %(day)s', '%(value)d actions on %(day)s', {
 				count: valueCount,
 				args: {

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -67,61 +67,65 @@ class GoogleMyBusinessStats extends Component {
 	};
 
 	renderViewsTooltipForDatanum = ( datanum, interval ) => {
-		const { value: valueCount, date } = datanum;
+		const { value: viewCount, date } = datanum;
 		if ( interval === 'quarter' ) {
 			return this.props.translate(
-				'%(value)d view on week %(week)s',
-				'%(value)d views on week %(week)s',
+				'%(viewCount)d view on the week of %(monday)s',
+				'%(viewCount)d views on the week of %(monday)s',
 				{
-					count: valueCount,
+					count: viewCount,
 					args: {
-						value: valueCount,
-						week: moment( date ).format( 'D MMMM YYYY' ),
+						viewCount,
+						monday: moment( date ).format( 'LL' ),
 					},
-					comment: 'How many views per week for a Google My Business location with date.',
 				}
 			);
 		} else if ( interval === 'week' ) {
-			return this.props.translate( '%(value)d view on %(day)s', '%(value)d views on %(day)s', {
-				count: valueCount,
-				args: {
-					value: valueCount,
-					day: moment( date ).format( 'D MMMM YYYY' ),
-				},
-				comment: 'How many views per day for a Google My Business location with date.',
-			} );
+			return this.props.translate(
+				'%(viewCount)d view on %(day)s',
+				'%(viewCount)d views on %(day)s',
+				{
+					count: viewCount,
+					args: {
+						viewCount,
+						day: moment( date ).format( 'LL' ),
+					},
+				}
+			);
 		}
 
-		return valueCount;
+		return viewCount;
 	};
 
 	renderActionsTooltipForDatanum = ( datanum, interval ) => {
-		const { value: valueCount, date } = datanum;
+		const { value: actionCount, date } = datanum;
 		if ( interval === 'quarter' ) {
 			return this.props.translate(
-				'%(value)d action on week %(week)s',
-				'%(value)d action on week %(week)s',
+				'%(actionCount)d action on the week of %(monday)s',
+				'%(actionCount)d action on the week of %(monday)s',
 				{
-					count: valueCount,
+					count: actionCount,
 					args: {
-						value: valueCount,
-						week: moment( date ).format( 'D MMMM YYYY' ),
+						actionCount,
+						monday: moment( date ).format( 'LL' ),
 					},
-					comment: 'How many views per week for a Google My Business location with date.',
 				}
 			);
 		} else if ( interval === 'week' ) {
-			return this.props.translate( '%(value)d action on %(day)s', '%(value)d actions on %(day)s', {
-				count: valueCount,
-				args: {
-					value: valueCount,
-					day: moment( date ).format( 'D MMMM YYYY' ),
-				},
-				comment: 'How many actions per day for a Google My Business location with date.',
-			} );
+			return this.props.translate(
+				'%(actionCount)d action on %(day)s',
+				'%(actionCount)d actions on %(day)s',
+				{
+					count: actionCount,
+					args: {
+						actionCount,
+						day: moment( date ).format( 'LL' ),
+					},
+				}
+			);
 		}
 
-		return valueCount;
+		return actionCount;
 	};
 
 	renderStats() {

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -80,17 +80,15 @@ class GoogleMyBusinessStats extends Component {
 					},
 				}
 			);
-		} else if ( interval === 'week' ) {
-			return this.props.translate( '%(value)d view on %(day)s', '%(value)d views on %(day)s', {
-				count: viewCount,
-				args: {
-					value: viewCount,
-					day: moment( date ).format( 'LL' ),
-				},
-			} );
 		}
 
-		return viewCount;
+		return this.props.translate( '%(value)d view on %(day)s', '%(value)d views on %(day)s', {
+			count: viewCount,
+			args: {
+				value: viewCount,
+				day: moment( date ).format( 'LL' ),
+			},
+		} );
 	};
 
 	renderActionsTooltipForDatanum = ( datanum, interval ) => {
@@ -107,17 +105,15 @@ class GoogleMyBusinessStats extends Component {
 					},
 				}
 			);
-		} else if ( interval === 'week' ) {
-			return this.props.translate( '%(value)d action on %(day)s', '%(value)d actions on %(day)s', {
-				count: actionCount,
-				args: {
-					value: actionCount,
-					day: moment( date ).format( 'LL' ),
-				},
-			} );
 		}
 
-		return actionCount;
+		return this.props.translate( '%(value)d action on %(day)s', '%(value)d actions on %(day)s', {
+			count: actionCount,
+			args: {
+				value: actionCount,
+				day: moment( date ).format( 'LL' ),
+			},
+		} );
 	};
 
 	renderStats() {

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -70,28 +70,24 @@ class GoogleMyBusinessStats extends Component {
 		const { value: viewCount, date } = datanum;
 		if ( interval === 'quarter' ) {
 			return this.props.translate(
-				'%(viewCount)d view on the week of %(monday)s',
-				'%(viewCount)d views on the week of %(monday)s',
+				'%(value)d view on the week of %(monday)s',
+				'%(value)d views on the week of %(monday)s',
 				{
 					count: viewCount,
 					args: {
-						viewCount,
+						value: viewCount,
 						monday: moment( date ).format( 'LL' ),
 					},
 				}
 			);
 		} else if ( interval === 'week' ) {
-			return this.props.translate(
-				'%(viewCount)d view on %(day)s',
-				'%(viewCount)d views on %(day)s',
-				{
-					count: viewCount,
-					args: {
-						viewCount,
-						day: moment( date ).format( 'LL' ),
-					},
-				}
-			);
+			return this.props.translate( '%(value)d view on %(day)s', '%(value)d views on %(day)s', {
+				count: viewCount,
+				args: {
+					value: viewCount,
+					day: moment( date ).format( 'LL' ),
+				},
+			} );
 		}
 
 		return viewCount;
@@ -101,28 +97,24 @@ class GoogleMyBusinessStats extends Component {
 		const { value: actionCount, date } = datanum;
 		if ( interval === 'quarter' ) {
 			return this.props.translate(
-				'%(actionCount)d action on the week of %(monday)s',
-				'%(actionCount)d action on the week of %(monday)s',
+				'%(value)d action on the week of %(monday)s',
+				'%(value)d action on the week of %(monday)s',
 				{
 					count: actionCount,
 					args: {
-						actionCount,
+						value: actionCount,
 						monday: moment( date ).format( 'LL' ),
 					},
 				}
 			);
 		} else if ( interval === 'week' ) {
-			return this.props.translate(
-				'%(actionCount)d action on %(day)s',
-				'%(actionCount)d actions on %(day)s',
-				{
-					count: actionCount,
-					args: {
-						actionCount,
-						day: moment( date ).format( 'LL' ),
-					},
-				}
-			);
+			return this.props.translate( '%(value)d action on %(day)s', '%(value)d actions on %(day)s', {
+				count: actionCount,
+				args: {
+					value: actionCount,
+					day: moment( date ).format( 'LL' ),
+				},
+			} );
 		}
 
 		return actionCount;


### PR DESCRIPTION
Requires server patch D15004

The Google My Business line charts are a bit messy for quater intervals at the moment (too many data points). Let's aggregate the data returned by the GMB API by week in this case, that's what server patch D15004 is for.

This PR updates the client side to make sure it is clear that the data points represent weeks instead of days.

### Testing Instructions
- Boot this branch locally
- Apply server side patch
- Go to the GMB Stats page
- Select "Quarter" for one of the 2 line charts
- You should see data aggregated by weeks instead of days ( so about 12 data points instead of 90 )
- Hovering on the graph you should see the tooltips with a mention of the week

### Reviews
- [x] Code
- [x] Product
