### PR TITLE
People: Use analytics action methods

### DIFF
--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -23,10 +23,10 @@ import FormButtonsBar from 'components/forms/form-buttons-bar';
 import AuthorSelector from 'blocks/author-selector';
 import { deleteUser } from 'lib/users/actions';
 import accept from 'lib/accept';
-import analytics from 'lib/analytics';
 import Gravatar from 'components/gravatar';
 import { localize } from 'i18n-calypso';
 import { getCurrentUser } from 'state/current-user/selectors';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 class DeleteUser extends React.Component {
 	static displayName = 'DeleteUser';
@@ -79,7 +79,7 @@ class DeleteUser extends React.Component {
 		updateObj[ name ] = value;
 
 		this.setState( updateObj );
-		analytics.ga.recordEvent( 'People', 'Selected Delete User Assignment', 'Assign', value );
+		this.props.recordGoogleEvent( 'People', 'Selected Delete User Assignment', 'Assign', value );
 	};
 
 	setReassignLabel = label => {
@@ -116,13 +116,13 @@ class DeleteUser extends React.Component {
 			</div>,
 			accepted => {
 				if ( accepted ) {
-					analytics.ga.recordEvent(
+					this.props.recordGoogleEvent(
 						'People',
 						'Clicked Confirm Remove User on Edit User Network Site'
 					);
 					deleteUser( this.props.siteId, this.props.user.ID );
 				} else {
-					analytics.ga.recordEvent(
+					this.props.recordGoogleEvent(
 						'People',
 						'Clicked Cancel Remove User on Edit User Network Site'
 					);
@@ -130,7 +130,7 @@ class DeleteUser extends React.Component {
 			},
 			translate( 'Remove' )
 		);
-		analytics.ga.recordEvent( 'People', 'Clicked Remove User on Edit User Network Site' );
+		this.props.recordGoogleEvent( 'People', 'Clicked Remove User on Edit User Network Site' );
 	};
 
 	deleteUser = event => {
@@ -145,7 +145,7 @@ class DeleteUser extends React.Component {
 		}
 
 		deleteUser( this.props.siteId, this.props.user.ID, reassignUserId );
-		analytics.ga.recordEvent( 'People', 'Clicked Remove User on Edit User Single Site' );
+		this.props.recordGoogleEvent( 'People', 'Clicked Remove User on Edit User Single Site' );
 	};
 
 	getAuthorSelectPlaceholder = () => {
@@ -282,5 +282,10 @@ class DeleteUser extends React.Component {
 }
 
 export default localize(
-	connect( state => ( { currentUser: getCurrentUser( state ) } ) )( DeleteUser )
+	connect(
+		state => ( {
+			currentUser: getCurrentUser( state ),
+		} ),
+		{ recordGoogleEvent }
+	)( DeleteUser )
 );

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -82,15 +82,9 @@ class DeleteUser extends React.Component {
 		this.props.recordGoogleEvent( 'People', 'Selected Delete User Assignment', 'Assign', value );
 	};
 
-	setReassignLabel = label => {
-		this.reassignLabel = label;
-	};
+	setReassignLabel = label => ( this.reassignLabel = label );
 
-	onSelectAuthor = author => {
-		this.setState( {
-			reassignUser: author,
-		} );
-	};
+	onSelectAuthor = author => this.setState( { reassignUser: author } );
 
 	removeUser = () => {
 		const { translate } = this.props;

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -109,11 +109,7 @@ class EditUserForm extends React.Component {
 	recordFieldFocus = fieldId => () =>
 		this.props.recordGoogleEvent( 'People', 'Focused on field on User Edit', 'Field', fieldId );
 
-	handleChange = event => {
-		this.setState( {
-			[ event.target.name ]: event.target.value,
-		} );
-	};
+	handleChange = event => this.setState( { [ event.target.name ]: event.target.value } );
 
 	renderField( fieldId ) {
 		let returnField = null;

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -16,10 +16,10 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormTextInput from 'components/forms/form-text-input';
 import FormButton from 'components/forms/form-button';
 import FormButtonsBar from 'components/forms/form-buttons-bar';
-import analytics from 'lib/analytics';
 import { updateUser } from 'lib/users/actions';
 import RoleSelect from 'my-sites/people/role-select';
 import { getCurrentUser } from 'state/current-user/selectors';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 /**
  * Module Variables
@@ -103,14 +103,11 @@ class EditUserForm extends React.Component {
 				? Object.assign( changedSettings, { roles: [ changedSettings.roles ] } )
 				: changedSettings
 		);
-		analytics.ga.recordEvent( 'People', 'Clicked Save Changes Button on User Edit' );
+		this.props.recordGoogleEvent( 'People', 'Clicked Save Changes Button on User Edit' );
 	};
 
-	recordFieldFocus( fieldId ) {
-		return () => {
-			analytics.ga.recordEvent( 'People', 'Focused on field on User Edit', 'Field', fieldId );
-		};
-	}
+	recordFieldFocus = fieldId => () =>
+		this.props.recordGoogleEvent( 'People', 'Focused on field on User Edit', 'Field', fieldId );
 
 	handleChange = event => {
 		this.setState( {
@@ -230,5 +227,10 @@ class EditUserForm extends React.Component {
 }
 
 export default localize(
-	connect( state => ( { currentUser: getCurrentUser( state ) } ) )( EditUserForm )
+	connect(
+		state => ( {
+			currentUser: getCurrentUser( state ),
+		} ),
+		{ recordGoogleEvent }
+	)( EditUserForm )
 );

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -21,12 +21,12 @@ import { fetchUser } from 'lib/users/actions';
 import { protectForm } from 'lib/protect-form';
 import DeleteUser from 'my-sites/people/delete-user';
 import PeopleNotices from 'my-sites/people/people-notices';
-import analytics from 'lib/analytics';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import PeopleLogStore from 'lib/people/log-store';
 import { isJetpackSiteMultiSite, isJetpackSite } from 'state/sites/selectors';
 import EditUserForm from './edit-user-form';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 export class EditTeamMemberForm extends Component {
 	constructor( props ) {
@@ -127,7 +127,7 @@ export class EditTeamMemberForm extends Component {
 	};
 
 	goBack = () => {
-		analytics.ga.recordEvent( 'People', 'Clicked Back Button on User Edit' );
+		this.props.recordGoogleEvent( 'People', 'Clicked Back Button on User Edit' );
 		if ( this.props.siteSlug ) {
 			const teamBack = '/people/team/' + this.props.siteSlug,
 				readersBack = '/people/readers/' + this.props.siteSlug;
@@ -178,13 +178,16 @@ export class EditTeamMemberForm extends Component {
 	}
 }
 
-export default connect( state => {
-	const siteId = getSelectedSiteId( state );
+export default connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
 
-	return {
-		siteId,
-		siteSlug: getSelectedSiteSlug( state ),
-		isJetpack: isJetpackSite( state, siteId ),
-		isMultisite: isJetpackSiteMultiSite( state, siteId ),
-	};
-} )( protectForm( EditTeamMemberForm ) );
+		return {
+			siteId,
+			siteSlug: getSelectedSiteSlug( state ),
+			isJetpack: isJetpackSite( state, siteId ),
+			isMultisite: isJetpackSiteMultiSite( state, siteId ),
+		};
+	},
+	{ recordGoogleEvent }
+)( protectForm( EditTeamMemberForm ) );

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -29,7 +29,6 @@ import CountedTextarea from 'components/forms/counted-textarea';
 import { createInviteValidation } from 'lib/invites/actions';
 import InvitesCreateValidationStore from 'lib/invites/stores/invites-create-validation';
 import InvitesSentStore from 'lib/invites/stores/invites-sent';
-import analytics from 'lib/analytics';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import EmptyContent from 'components/empty-content';
 import { userCan } from 'lib/site/utils';
@@ -46,6 +45,7 @@ import isActivatingJetpackModule from 'state/selectors/is-activating-jetpack-mod
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
  * Module variables
@@ -87,7 +87,7 @@ class InvitePeople extends React.Component {
 
 		if ( sendInvitesSuccess ) {
 			this.setState( this.resetState() );
-			analytics.tracks.recordEvent( 'calypso_invite_people_form_refresh_initial' );
+			this.props.recordTracksEvent( 'calypso_invite_people_form_refresh_initial' );
 			debug( 'Submit successful. Resetting form.' );
 		} else {
 			const sendInvitesErrored = InvitesSentStore.getErrors( this.state.formId ),
@@ -105,7 +105,7 @@ class InvitePeople extends React.Component {
 			debug( 'Submit errored. Updating state to:  ' + JSON.stringify( updatedState ) );
 
 			this.setState( updatedState );
-			analytics.tracks.recordEvent( 'calypso_invite_people_form_refresh_retry' );
+			this.props.recordTracksEvent( 'calypso_invite_people_form_refresh_retry' );
 		}
 	};
 
@@ -135,9 +135,9 @@ class InvitePeople extends React.Component {
 		createInviteValidation( this.props.siteId, filteredTokens, role );
 
 		if ( filteredTokens.length > usernamesOrEmails.length ) {
-			analytics.tracks.recordEvent( 'calypso_invite_people_token_added' );
+			this.props.recordTracksEvent( 'calypso_invite_people_token_added' );
 		} else {
-			analytics.tracks.recordEvent( 'calypso_invite_people_token_removed' );
+			this.props.recordTracksEvent( 'calypso_invite_people_token_removed' );
 		}
 	};
 
@@ -152,23 +152,23 @@ class InvitePeople extends React.Component {
 	};
 
 	onFocusTokenField = () => {
-		analytics.tracks.recordEvent( 'calypso_invite_people_token_field_focus' );
+		this.props.recordTracksEvent( 'calypso_invite_people_token_field_focus' );
 	};
 
 	onFocusRoleSelect = () => {
-		analytics.tracks.recordEvent( 'calypso_invite_people_role_select_focus' );
+		this.props.recordTracksEvent( 'calypso_invite_people_role_select_focus' );
 	};
 
 	onFocusCustomMessage = () => {
-		analytics.tracks.recordEvent( 'calypso_invite_people_custom_message_focus' );
+		this.props.recordTracksEvent( 'calypso_invite_people_custom_message_focus' );
 	};
 
 	onClickSendInvites = () => {
-		analytics.tracks.recordEvent( 'calypso_invite_people_send_invite_button_click' );
+		this.props.recordTracksEvent( 'calypso_invite_people_send_invite_button_click' );
 	};
 
 	onClickRoleExplanation = () => {
-		analytics.tracks.recordEvent( 'calypso_invite_people_role_explanation_link_click' );
+		this.props.recordTracksEvent( 'calypso_invite_people_role_explanation_link_click' );
 	};
 
 	refreshValidation = () => {
@@ -185,7 +185,7 @@ class InvitePeople extends React.Component {
 		} );
 
 		if ( errorsKeys.length ) {
-			analytics.tracks.recordEvent( 'calypso_invite_people_validation_refreshed_with_error' );
+			this.props.recordTracksEvent( 'calypso_invite_people_validation_refreshed_with_error' );
 		}
 	};
 
@@ -240,7 +240,7 @@ class InvitePeople extends React.Component {
 			return includes( invitee, '@' ) ? 'email' : 'username';
 		} );
 
-		analytics.tracks.recordEvent( 'calypso_invite_people_form_submit', {
+		this.props.recordTracksEvent( 'calypso_invite_people_form_submit', {
 			role,
 			number_invitees: usernamesOrEmails.length,
 			number_username_invitees: groupedInvitees.username ? groupedInvitees.username.length : 0,
@@ -463,5 +463,5 @@ export default connect(
 			isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
 		};
 	},
-	dispatch => bindActionCreators( { sendInvites, activateModule }, dispatch )
+	dispatch => bindActionCreators( { sendInvites, activateModule, recordTracksEvent }, dispatch )
 )( localize( InvitePeople ) );

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -45,7 +45,7 @@ import isActivatingJetpackModule from 'state/selectors/is-activating-jetpack-mod
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 
 /**
  * Module variables
@@ -87,7 +87,7 @@ class InvitePeople extends React.Component {
 
 		if ( sendInvitesSuccess ) {
 			this.setState( this.resetState() );
-			this.props.recordTracksEvent( 'calypso_invite_people_form_refresh_initial' );
+			this.props.recordTracksEventAction( 'calypso_invite_people_form_refresh_initial' );
 			debug( 'Submit successful. Resetting form.' );
 		} else {
 			const sendInvitesErrored = InvitesSentStore.getErrors( this.state.formId ),
@@ -105,7 +105,7 @@ class InvitePeople extends React.Component {
 			debug( 'Submit errored. Updating state to:  ' + JSON.stringify( updatedState ) );
 
 			this.setState( updatedState );
-			this.props.recordTracksEvent( 'calypso_invite_people_form_refresh_retry' );
+			this.props.recordTracksEventAction( 'calypso_invite_people_form_refresh_retry' );
 		}
 	};
 
@@ -135,9 +135,9 @@ class InvitePeople extends React.Component {
 		createInviteValidation( this.props.siteId, filteredTokens, role );
 
 		if ( filteredTokens.length > usernamesOrEmails.length ) {
-			this.props.recordTracksEvent( 'calypso_invite_people_token_added' );
+			this.props.recordTracksEventAction( 'calypso_invite_people_token_added' );
 		} else {
-			this.props.recordTracksEvent( 'calypso_invite_people_token_removed' );
+			this.props.recordTracksEventAction( 'calypso_invite_people_token_removed' );
 		}
 	};
 
@@ -148,21 +148,6 @@ class InvitePeople extends React.Component {
 		this.setState( { role } );
 		createInviteValidation( this.props.siteId, this.state.usernamesOrEmails, role );
 	};
-
-	onFocusTokenField = () =>
-		this.props.recordTracksEvent( 'calypso_invite_people_token_field_focus' );
-
-	onFocusRoleSelect = () =>
-		this.props.recordTracksEvent( 'calypso_invite_people_role_select_focus' );
-
-	onFocusCustomMessage = () =>
-		this.props.recordTracksEvent( 'calypso_invite_people_custom_message_focus' );
-
-	onClickSendInvites = () =>
-		this.props.recordTracksEvent( 'calypso_invite_people_send_invite_button_click' );
-
-	onClickRoleExplanation = () =>
-		this.props.recordTracksEvent( 'calypso_invite_people_role_explanation_link_click' );
 
 	refreshValidation = () => {
 		const errors =
@@ -178,7 +163,7 @@ class InvitePeople extends React.Component {
 		} );
 
 		if ( errorsKeys.length ) {
-			this.props.recordTracksEvent( 'calypso_invite_people_validation_refreshed_with_error' );
+			this.props.recordTracksEventAction( 'calypso_invite_people_validation_refreshed_with_error' );
 		}
 	};
 
@@ -233,7 +218,7 @@ class InvitePeople extends React.Component {
 			return includes( invitee, '@' ) ? 'email' : 'username';
 		} );
 
-		this.props.recordTracksEvent( 'calypso_invite_people_form_submit', {
+		this.props.recordTracksEventAction( 'calypso_invite_people_form_submit', {
 			role,
 			number_invitees: usernamesOrEmails.length,
 			number_username_invitees: groupedInvitees.username ? groupedInvitees.username.length : 0,
@@ -278,13 +263,13 @@ class InvitePeople extends React.Component {
 	};
 
 	renderRoleExplanation = () => {
-		const { translate } = this.props;
+		const { translate, onClickRoleExplanation } = this.props;
 		return (
 			<a
 				target="_blank"
 				rel="noopener noreferrer"
 				href="http://en.support.wordpress.com/user-roles/"
-				onClick={ this.onClickRoleExplanation }
+				onClick={ onClickRoleExplanation }
 			>
 				{ translate( 'Learn more about roles' ) }
 			</a>
@@ -294,7 +279,17 @@ class InvitePeople extends React.Component {
 	enableSSO = () => this.props.activateModule( this.props.siteId, 'sso' );
 
 	renderInviteForm = () => {
-		const { site, translate, needsVerification, isJetpack, showSSONotice } = this.props;
+		const {
+			site,
+			translate,
+			needsVerification,
+			isJetpack,
+			showSSONotice,
+			onFocusTokenField,
+			onFocusRoleSelect,
+			onFocusCustomMessage,
+			onClickSendInvites,
+		} = this.props;
 
 		const inviteForm = (
 			<Card>
@@ -315,7 +310,7 @@ class InvitePeople extends React.Component {
 								maxLength={ 10 }
 								value={ this.getTokensWithStatus() }
 								onChange={ this.onTokensChange }
-								onFocus={ this.onFocusTokenField }
+								onFocus={ onFocusTokenField }
 								disabled={ this.state.sendingInvites }
 							/>
 							<FormSettingExplanation>
@@ -333,7 +328,7 @@ class InvitePeople extends React.Component {
 							includeFollower
 							siteId={ this.props.siteId }
 							onChange={ this.onRoleChange }
-							onFocus={ this.onFocusRoleSelect }
+							onFocus={ onFocusRoleSelect }
 							value={ this.state.role }
 							disabled={ this.state.sendingInvites }
 							explanation={ this.renderRoleExplanation() }
@@ -348,7 +343,7 @@ class InvitePeople extends React.Component {
 								maxLength={ 500 }
 								acceptableLength={ 500 }
 								onChange={ this.onMessageChange }
-								onFocus={ this.onFocusCustomMessage }
+								onFocus={ onFocusCustomMessage }
 								value={ this.state.message }
 								disabled={ this.state.sendingInvites }
 							/>
@@ -360,7 +355,7 @@ class InvitePeople extends React.Component {
 							</FormSettingExplanation>
 						</FormFieldset>
 
-						<FormButton disabled={ this.isSubmitDisabled() } onClick={ this.onClickSendInvites }>
+						<FormButton disabled={ this.isSubmitDisabled() } onClick={ onClickSendInvites }>
 							{ translate( 'Send Invitation', 'Send Invitations', {
 								count: this.state.usernamesOrEmails.length || 1,
 								context: 'Button label',
@@ -454,5 +449,24 @@ export default connect(
 			isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
 		};
 	},
-	dispatch => bindActionCreators( { sendInvites, activateModule, recordTracksEvent }, dispatch )
+	dispatch => ( {
+		...bindActionCreators(
+			{
+				sendInvites,
+				activateModule,
+			},
+			dispatch
+		),
+		recordTracksEventAction,
+		onFocusTokenField: () =>
+			dispatch( recordTracksEventAction( 'calypso_invite_people_token_field_focus' ) ),
+		onFocusRoleSelect: () =>
+			dispatch( recordTracksEventAction( 'calypso_invite_people_role_select_focus' ) ),
+		onFocusCustomMessage: () =>
+			dispatch( recordTracksEventAction( 'calypso_invite_people_custom_message_focus' ) ),
+		onClickSendInvites: () =>
+			dispatch( recordTracksEventAction( 'calypso_invite_people_send_invite_button_click' ) ),
+		onClickRoleExplanation: () =>
+			dispatch( recordTracksEventAction( 'calypso_invite_people_role_explanation_link_click' ) ),
+	} )
 )( localize( InvitePeople ) );

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -141,9 +141,7 @@ class InvitePeople extends React.Component {
 		}
 	};
 
-	onMessageChange = event => {
-		this.setState( { message: event.target.value } );
-	};
+	onMessageChange = event => this.setState( { message: event.target.value } );
 
 	onRoleChange = event => {
 		const role = event.target.value;
@@ -151,25 +149,20 @@ class InvitePeople extends React.Component {
 		createInviteValidation( this.props.siteId, this.state.usernamesOrEmails, role );
 	};
 
-	onFocusTokenField = () => {
+	onFocusTokenField = () =>
 		this.props.recordTracksEvent( 'calypso_invite_people_token_field_focus' );
-	};
 
-	onFocusRoleSelect = () => {
+	onFocusRoleSelect = () =>
 		this.props.recordTracksEvent( 'calypso_invite_people_role_select_focus' );
-	};
 
-	onFocusCustomMessage = () => {
+	onFocusCustomMessage = () =>
 		this.props.recordTracksEvent( 'calypso_invite_people_custom_message_focus' );
-	};
 
-	onClickSendInvites = () => {
+	onClickSendInvites = () =>
 		this.props.recordTracksEvent( 'calypso_invite_people_send_invite_button_click' );
-	};
 
-	onClickRoleExplanation = () => {
+	onClickRoleExplanation = () =>
 		this.props.recordTracksEvent( 'calypso_invite_people_role_explanation_link_click' );
-	};
 
 	refreshValidation = () => {
 		const errors =
@@ -298,9 +291,7 @@ class InvitePeople extends React.Component {
 		);
 	};
 
-	enableSSO = () => {
-		this.props.activateModule( this.props.siteId, 'sso' );
-	};
+	enableSSO = () => this.props.activateModule( this.props.siteId, 'sso' );
 
 	renderInviteForm = () => {
 		const { site, translate, needsVerification, isJetpack, showSSONotice } = this.props;

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -16,7 +16,6 @@ import Gridicon from 'gridicons';
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import PeopleProfile from 'my-sites/people/people-profile';
-import analytics from 'lib/analytics';
 import config from 'config';
 import {
 	isRequestingInviteResend,
@@ -24,6 +23,7 @@ import {
 	didInviteDeletionSucceed,
 } from 'state/invites/selectors';
 import { resendInvite } from 'state/invites/actions';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 class PeopleListItem extends React.PureComponent {
 	static displayName = 'PeopleListItem';
@@ -35,7 +35,7 @@ class PeopleListItem extends React.PureComponent {
 
 	navigateToUser = () => {
 		window.scrollTo( 0, 0 );
-		analytics.ga.recordEvent( 'People', 'Clicked User Profile From Team List' );
+		this.props.recordGoogleEvent( 'People', 'Clicked User Profile From Team List' );
 	};
 
 	userHasPromoteCapability = () => {
@@ -194,5 +194,5 @@ export default connect(
 			inviteWasDeleted,
 		};
 	},
-	{ resendInvite }
+	{ resendInvite, recordGoogleEvent }
 )( localize( PeopleListItem ) );

--- a/client/my-sites/people/team-list/team.jsx
+++ b/client/my-sites/people/team-list/team.jsx
@@ -140,9 +140,7 @@ class Team extends React.Component {
 	_renderLoadingPeople = () => <PeopleListItem key="people-list-item-placeholder" />;
 }
 
-export default localize(
-	connect(
-		null,
-		{ recordGoogleEvent }
-	)( localize( Team ) )
-);
+export default connect(
+	null,
+	{ recordGoogleEvent }
+)( localize( Team ) );

--- a/client/my-sites/people/team-list/team.jsx
+++ b/client/my-sites/people/team-list/team.jsx
@@ -82,15 +82,15 @@ class Team extends React.Component {
 					ref="infiniteList"
 					fetchingNextPage={ this.props.fetchingUsers }
 					lastPage={ this.isLastPage() }
-					fetchNextPage={ this._fetchNextPage }
-					getItemRef={ this._getPersonRef }
-					renderLoadingPlaceholders={ this._renderLoadingPeople }
-					renderItem={ this._renderPerson }
+					fetchNextPage={ this.fetchNextPage }
+					getItemRef={ this.getPersonRef }
+					renderLoadingPlaceholders={ this.renderLoadingPeople }
+					renderItem={ this.renderPerson }
 					guessedItemHeight={ 126 }
 				/>
 			);
 		} else {
-			people = this._renderLoadingPeople();
+			people = this.renderLoadingPeople();
 		}
 
 		return (
@@ -110,7 +110,7 @@ class Team extends React.Component {
 		);
 	}
 
-	_renderPerson = user => {
+	renderPerson = user => {
 		return (
 			<PeopleListItem
 				key={ user.ID }
@@ -122,7 +122,7 @@ class Team extends React.Component {
 		);
 	};
 
-	_fetchNextPage = () => {
+	fetchNextPage = () => {
 		const offset = this.props.users.length;
 		const fetchOptions = Object.assign( {}, this.props.fetchOptions, { offset: offset } );
 		this.props.recordGoogleEvent(
@@ -135,9 +135,9 @@ class Team extends React.Component {
 		fetchUsers( fetchOptions );
 	};
 
-	_getPersonRef = user => 'user-' + user.ID;
+	getPersonRef = user => 'user-' + user.ID;
 
-	_renderLoadingPeople = () => <PeopleListItem key="people-list-item-placeholder" />;
+	renderLoadingPeople = () => <PeopleListItem key="people-list-item-placeholder" />;
 }
 
 export default connect(

--- a/client/my-sites/people/team-list/team.jsx
+++ b/client/my-sites/people/team-list/team.jsx
@@ -30,15 +30,14 @@ class Team extends React.Component {
 		bulkEditing: false,
 	};
 
-	isLastPage = () => {
-		return this.props.totalUsers <= this.props.users.length + this.props.excludedUsers.length;
-	};
+	isLastPage = () =>
+		this.props.totalUsers <= this.props.users.length + this.props.excludedUsers.length;
 
 	render() {
-		let key = deterministicStringify( omit( this.props.fetchOptions, [ 'number', 'offset' ] ) ),
-			headerText = this.props.translate( 'Team', { context: 'A navigation label.' } ),
-			listClass = this.state.bulkEditing ? 'bulk-editing' : null,
-			people;
+		const key = deterministicStringify( omit( this.props.fetchOptions, [ 'number', 'offset' ] ) );
+		const listClass = this.state.bulkEditing ? 'bulk-editing' : null;
+		let headerText = this.props.translate( 'Team', { context: 'A navigation label.' } );
+		let people;
 
 		if (
 			this.props.fetchInitialized &&
@@ -136,13 +135,9 @@ class Team extends React.Component {
 		fetchUsers( fetchOptions );
 	};
 
-	_getPersonRef = user => {
-		return 'user-' + user.ID;
-	};
+	_getPersonRef = user => 'user-' + user.ID;
 
-	_renderLoadingPeople = () => {
-		return <PeopleListItem key="people-list-item-placeholder" />;
-	};
+	_renderLoadingPeople = () => <PeopleListItem key="people-list-item-placeholder" />;
 }
 
 export default localize(

--- a/client/my-sites/people/team-list/team.jsx
+++ b/client/my-sites/people/team-list/team.jsx
@@ -7,6 +7,7 @@ import { localize } from 'i18n-calypso';
 import { omit } from 'lodash';
 import React from 'react';
 import debugFactory from 'debug';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -16,9 +17,9 @@ import PeopleListItem from 'my-sites/people/people-list-item';
 import { fetchUsers } from 'lib/users/actions';
 import InfiniteList from 'components/infinite-list';
 import NoResults from 'my-sites/no-results';
-import analytics from 'lib/analytics';
 import PeopleListSectionHeader from 'my-sites/people/people-list-section-header';
 import ListEnd from 'components/list-end';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 const debug = debugFactory( 'calypso:my-sites:people:team-list' );
 
@@ -125,7 +126,12 @@ class Team extends React.Component {
 	_fetchNextPage = () => {
 		const offset = this.props.users.length;
 		const fetchOptions = Object.assign( {}, this.props.fetchOptions, { offset: offset } );
-		analytics.ga.recordEvent( 'People', 'Fetched more users with infinite list', 'offset', offset );
+		this.props.recordGoogleEvent(
+			'People',
+			'Fetched more users with infinite list',
+			'offset',
+			offset
+		);
 		debug( 'fetching next batch of users' );
 		fetchUsers( fetchOptions );
 	};
@@ -139,4 +145,9 @@ class Team extends React.Component {
 	};
 }
 
-export default localize( Team );
+export default localize(
+	connect(
+		null,
+		{ recordGoogleEvent }
+	)( localize( Team ) )
+);

--- a/client/my-sites/people/viewers-list/viewers.jsx
+++ b/client/my-sites/people/viewers-list/viewers.jsx
@@ -152,9 +152,7 @@ class Viewers extends React.PureComponent {
 	}
 }
 
-export default localize(
-	connect(
-		null,
-		{ recordGoogleEvent }
-	)( localize( Viewers ) )
-);
+export default connect(
+	null,
+	{ recordGoogleEvent }
+)( localize( Viewers ) );

--- a/client/my-sites/people/viewers-list/viewers.jsx
+++ b/client/my-sites/people/viewers-list/viewers.jsx
@@ -4,6 +4,7 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -15,9 +16,9 @@ import ViewersActions from 'lib/viewers/actions';
 import ViewersStore from 'lib/viewers/store';
 import InfiniteList from 'components/infinite-list';
 import EmptyContent from 'components/empty-content';
-import analytics from 'lib/analytics';
 import accept from 'lib/accept';
 import ListEnd from 'components/list-end';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 class Viewers extends React.PureComponent {
 	static displayName = 'Viewers';
@@ -35,12 +36,17 @@ class Viewers extends React.PureComponent {
 			currentPage = paginationData.currentViewersPage ? paginationData.currentViewersPage : 0,
 			page = currentPage + 1;
 
-		analytics.ga.recordEvent( 'People', 'Fetched more viewers with infinite list', 'page', page );
+		this.props.recordGoogleEvent(
+			'People',
+			'Fetched more viewers with infinite list',
+			'page',
+			page
+		);
 		ViewersActions.fetch( this.props.siteId, page );
 	};
 
 	removeViewer = viewer => {
-		analytics.ga.recordEvent( 'People', 'Clicked Remove Viewer Button On Viewers List' );
+		this.props.recordGoogleEvent( 'People', 'Clicked Remove Viewer Button On Viewers List' );
 		accept(
 			<div>
 				<p>
@@ -52,13 +58,13 @@ class Viewers extends React.PureComponent {
 			</div>,
 			accepted => {
 				if ( accepted ) {
-					analytics.ga.recordEvent(
+					this.props.recordGoogleEvent(
 						'People',
 						'Clicked Remove Button In Remove Viewer Confirmation'
 					);
 					ViewersActions.remove( this.props.site.ID, viewer );
 				} else {
-					analytics.ga.recordEvent(
+					this.props.recordGoogleEvent(
 						'People',
 						'Clicked Cancel Button In Remove Viewer Confirmation'
 					);
@@ -90,7 +96,7 @@ class Viewers extends React.PureComponent {
 	};
 
 	onClickSiteSettings = () => {
-		analytics.ga.recordEvent( 'People', 'Clicked Site Settings Link On Empty Viewers' );
+		this.props.recordGoogleEvent( 'People', 'Clicked Site Settings Link On Empty Viewers' );
 	};
 
 	isLastPage = () => {
@@ -156,4 +162,9 @@ class Viewers extends React.PureComponent {
 	}
 }
 
-export default localize( Viewers );
+export default localize(
+	connect(
+		null,
+		{ recordGoogleEvent }
+	)( localize( Viewers ) )
+);

--- a/client/my-sites/people/viewers-list/viewers.jsx
+++ b/client/my-sites/people/viewers-list/viewers.jsx
@@ -27,14 +27,12 @@ class Viewers extends React.PureComponent {
 		bulkEditing: false,
 	};
 
-	renderPlaceholders = () => {
-		return <PeopleListItem key="people-list-item-placeholder" />;
-	};
+	renderPlaceholders = () => <PeopleListItem key="people-list-item-placeholder" />;
 
 	fetchNextPage = () => {
-		let paginationData = ViewersStore.getPaginationData( this.props.siteId ),
-			currentPage = paginationData.currentViewersPage ? paginationData.currentViewersPage : 0,
-			page = currentPage + 1;
+		const paginationData = ViewersStore.getPaginationData( this.props.siteId );
+		const currentPage = paginationData.currentViewersPage ? paginationData.currentViewersPage : 0;
+		const page = currentPage + 1;
 
 		this.props.recordGoogleEvent(
 			'People',
@@ -91,27 +89,19 @@ class Viewers extends React.PureComponent {
 		);
 	};
 
-	getViewerRef = viewer => {
-		return 'viewer-' + viewer.ID;
-	};
+	getViewerRef = viewer => 'viewer-' + viewer.ID;
 
-	onClickSiteSettings = () => {
-		this.props.recordGoogleEvent( 'People', 'Clicked Site Settings Link On Empty Viewers' );
-	};
-
-	isLastPage = () => {
-		return this.props.totalViewers <= this.props.viewers.length;
-	};
+	isLastPage = () => this.props.totalViewers <= this.props.viewers.length;
 
 	render() {
-		let viewers,
-			emptyContentArgs = {
-				title:
-					this.props.site && this.props.site.jetpack
-						? this.props.translate( "Oops, Jetpack sites don't support viewers." )
-						: this.props.translate( "You don't have any viewers yet." ),
-			},
-			listClass = this.state.bulkEditing ? 'bulk-editing' : null;
+		const listClass = this.state.bulkEditing ? 'bulk-editing' : null;
+		let viewers;
+		let emptyContentArgs = {
+			title:
+				this.props.site && this.props.site.jetpack
+					? this.props.translate( "Oops, Jetpack sites don't support viewers." )
+					: this.props.translate( "You don't have any viewers yet." ),
+		};
 
 		if ( ! this.props.viewers.length && ! this.props.fetching ) {
 			if ( this.props.site && ! this.props.site.jetpack && ! this.props.site.is_private ) {


### PR DESCRIPTION
Hi!

This PR replaces the direct imports of `lib/analytics` with the equivalent action methods.

Background `p4TIVU-38R-p2`

I've also taken the opportunity to do some very light syntactical touch ups.

**Note**: I deliberately omitted the [Followers component](https://github.com/Automattic/wp-calypso/blob/6dc1f10/client/my-sites/people/followers-list/index.jsx
) under the People section (for now), as I thought connecting the dependent components would clutter this already largish PR

To assist review, I've separated the commits:

Analytics method replacement: 017e7c4

Minor syntax updates: d50ee23

## Testing

You can create a breakpoint to ensure that we're still calling the corresponding methods in `lib/analytics`:

<img width="1198" alt="screen shot 2018-06-20 at 11 46 23 am" src="https://user-images.githubusercontent.com/6458278/41633478-7f99c4d2-7482-11e8-8908-e2cac519fb6c.png">

1. Edit a user `/people/edit/{site}/{user}`
2. Visit a site with a large team member list `/people/team/{site}`, scroll, view a user, then click 'Go back'
3. Do the same for viewers `/people/viewers/{site}`
4. Invite a user, assign a role, add a message
5. Delete a follower/contributor

