### PR TITLE
Fix devdocs example for conversation caterpillar 🐛

### DIFF
--- a/client/blocks/conversation-caterpillar/docs/example.jsx
+++ b/client/blocks/conversation-caterpillar/docs/example.jsx
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React from 'react';
+import { size } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,6 +22,7 @@ const ConversationCaterpillarExample = () => {
 					blogId={ 123 }
 					postId={ 12 }
 					commentsTree={ commentsTree }
+					commentCount={ size( comments ) }
 					commentsToShow={ {} }
 					expandComments={ () => {} }
 				/>

--- a/client/blocks/conversation-caterpillar/docs/fixtures.js
+++ b/client/blocks/conversation-caterpillar/docs/fixtures.js
@@ -12,6 +12,7 @@ export const comments = [
 		author: {
 			ID: 1,
 			name: 'Christophe',
+			email: 'christophe@example.com',
 			avatar_URL:
 				'https://2.gravatar.com/avatar/5512fbf07ae3dd340fb6ed4924861c8e?s=96&d=identicon&r=G',
 			has_avatar: true,
@@ -24,6 +25,7 @@ export const comments = [
 		author: {
 			ID: 2,
 			name: 'Boris',
+			email: 'boris@example.com',
 			avatar_URL: 'https://2.gravatar.com/avatar/22d41e5b6ff197cd7900c0514d1bd305?d=mm&r=G',
 			has_avatar: false, // Test that authors with has_avatar: false are omitted
 		},
@@ -35,6 +37,7 @@ export const comments = [
 		author: {
 			ID: 3,
 			name: 'Matt Mullenweg',
+			email: 'matt@example.com',
 			avatar_URL: 'https://1.gravatar.com/avatar/767fc9c115a1b989744c755db47feb60?d=mm&r=G',
 			has_avatar: true,
 		},
@@ -46,6 +49,7 @@ export const comments = [
 		author: {
 			ID: 1,
 			name: 'Christophe',
+			email: 'christophe@example.com',
 			avatar_URL:
 				'https://2.gravatar.com/avatar/5512fbf07ae3dd340fb6ed4924861c8e?s=96&d=identicon&r=G',
 			has_avatar: true,
@@ -69,6 +73,7 @@ export const comments = [
 		author: {
 			ID: 6,
 			name: 'Ben',
+			email: 'ben@example.com',
 			avatar_URL: 'https://0.gravatar.com/avatar/3b7b2c457b9201d166b9a2b47cadc86d?d=mm&r=G',
 			has_avatar: true,
 		},
@@ -80,6 +85,7 @@ export const comments = [
 		author: {
 			ID: 7,
 			name: 'Derek',
+			email: 'derek@example.com',
 			avatar_URL: 'https://2.gravatar.com/avatar/2723d05b4e1176e977e1e6641a2ca98b?d=mm&r=G',
 			has_avatar: true,
 		},
@@ -91,6 +97,7 @@ export const comments = [
 		author: {
 			ID: 8,
 			name: 'Jake',
+			email: 'jake@example.com',
 			avatar_URL: 'https://1.gravatar.com/avatar/7a6c0fad3d7e9d4038222cbadd095db8?d=mm&r=G',
 			has_avatar: true,
 		},
@@ -102,6 +109,7 @@ export const comments = [
 		author: {
 			ID: 9,
 			name: 'Jan',
+			email: 'jan@example.com',
 			avatar_URL:
 				'https://secure.gravatar.com/avatar/3e44726f128c263db20117a659bfa003?d=mm&s=275&r=G',
 			has_avatar: true,
@@ -114,6 +122,7 @@ export const comments = [
 		author: {
 			ID: 10,
 			name: 'Aaron',
+			email: 'aaron@example.com',
 			avatar_URL: 'https://2.gravatar.com/avatar/20600ea4d39b6facdd79875d24d2dbab?d=mm&r=G',
 			has_avatar: true,
 		},
@@ -125,6 +134,7 @@ export const comments = [
 		author: {
 			ID: 11,
 			name: 'Greg',
+			email: 'greg@example.com',
 			avatar_URL: 'https://0.gravatar.com/avatar/915ee4efbd21f12b55b6362cf4f7c42f?d=mm&r=G',
 			has_avatar: true,
 		},
@@ -136,6 +146,7 @@ export const comments = [
 		author: {
 			ID: 11,
 			name: 'Greg',
+			email: 'greg@example.com',
 			avatar_URL: 'https://1.gravatar.com/avatar/765b5dca3190e27b9c88d6143c5527d5?d=mm&r=G',
 			has_avatar: true,
 		},
@@ -147,6 +158,7 @@ export const comments = [
 		author: {
 			ID: 12,
 			name: 'Martin',
+			email: 'martin@example.com',
 			avatar_URL: 'https://0.gravatar.com/avatar/33b3e384f5a150015a5a981402983ca3?d=mm&r=G',
 			has_avatar: true,
 		},
@@ -158,6 +170,7 @@ export const comments = [
 		author: {
 			ID: 13,
 			name: 'Yanir',
+			email: 'yanir@example.com',
 			avatar_URL: 'https://1.gravatar.com/avatar/dda019c47a6183120608a6aeac2db6c5?d=mm&r=G',
 			has_avatar: true,
 		},

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -123,16 +123,19 @@ class ConversationCaterpillarComponent extends React.Component {
 				<button
 					className="conversation-caterpillar__count"
 					onClick={ this.handleTickle }
-					title={ translate(
-						'View %(count)s comment for this post',
-						'View %(count)s comments for this post',
-						{
-							count: +commentCount,
-							args: {
-								count: commentCount,
-							},
-						}
-					) }
+					title={
+						commentCount > 0 &&
+						translate(
+							'View %(count)s comment for this post',
+							'View %(count)s comments for this post',
+							{
+								count: +commentCount,
+								args: {
+									count: commentCount,
+								},
+							}
+						)
+					}
 				>
 					{ commentCount > 1 &&
 						uniqueAuthorsCount > 1 &&


### PR DESCRIPTION
Before:

<img width="543" alt="screen shot 2018-06-20 at 15 44 33" src="https://user-images.githubusercontent.com/17325/41636568-576696ea-74a3-11e8-96b8-9aac9fcc384c.png">

After:

<img width="657" alt="screen shot 2018-06-20 at 15 44 29" src="https://user-images.githubusercontent.com/17325/41636574-5d20817c-74a3-11e8-92c0-b7db74ff9833.png">

### To test

Check http://calypso.localhost:3000/devdocs/blocks/conversation-caterpillar.