### PR TITLE
Site Settings: Use CompactCard for SiteOwnership

### DIFF
--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -11,7 +11,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
+import CompactCard from 'components/card/compact';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
@@ -29,9 +29,9 @@ import isJetpackUserMaster from 'state/selectors/is-jetpack-user-master';
 class SiteOwnership extends Component {
 	renderPlaceholder() {
 		return (
-			<Card className="manage-connection__card site-settings__card is-placeholder">
+			<CompactCard className="manage-connection__card site-settings__card is-placeholder">
 				<div />
-			</Card>
+			</CompactCard>
 		);
 	}
 
@@ -82,12 +82,12 @@ class SiteOwnership extends Component {
 		const { translate } = this.props;
 
 		return (
-			<Card>
+			<CompactCard>
 				<FormFieldset>
 					<FormLegend>{ translate( 'Connection owner' ) }</FormLegend>
 					{ this.renderConnectionDetails() }
 				</FormFieldset>
-			</Card>
+			</CompactCard>
 		);
 	}
 


### PR DESCRIPTION
This PR updates the `SiteOwnership` to use `CompactCard` instead of regular `Card` components. This is a preparatory task to make it easier to implement the new connection and plan ownership change fields. This follows the suggested design in p6TEKc-29d-p2, which lacks space between the cards (with the exception of the disconnect one).

Before:
![](https://cldup.com/WZL0qV788j.png)

After:
![](https://cldup.com/pcHYqmJAm2.png)

To test:
* Checkout this branch
* Go to `http://calypso.localhost:3000/settings/manage-connection/:site` where `:site` is a Jetpack site.
* Verify the space between cards in the Site Ownership page has been removed, as shown on the screenshot.