### PR TITLE
Site Settings: Update SiteOwnership title

### DIFF
--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -84,7 +84,7 @@ class SiteOwnership extends Component {
 		return (
 			<Card>
 				<FormFieldset>
-					<FormLegend>{ translate( 'Connection owner' ) }</FormLegend>
+					<FormLegend>{ translate( 'Site owner' ) }</FormLegend>
 					{ this.renderConnectionDetails() }
 				</FormFieldset>
 			</Card>


### PR DESCRIPTION
This PR updates the `SiteOwnership` title from "Connection Owner" to "Site Owner". This is a preparatory task to make it easier to implement the new connection and plan ownership change fields. This follows the suggested design in p6TEKc-29d-p2.

Before:
![](https://cldup.com/vSm4zmXN1t.png)

After:
![](https://cldup.com/JQCEL8MedY.png)

To test:
* Checkout this branch
* Go to `http://calypso.localhost:3000/settings/manage-connection/:site` where `:site` is a Jetpack site.
* Verify you can see the new title in the "Site Ownership" section.