### PR TITLE
Make a proper redirect on GMB eligable site

### DIFF
--- a/client/my-sites/google-my-business/index.js
+++ b/client/my-sites/google-my-business/index.js
@@ -36,7 +36,8 @@ const redirectUnauthorized = ( context, next ) => {
 	const siteIsGMBEligible = isSiteGoogleMyBusinessEligible( state, siteId );
 	const canUserManageOptions = canCurrentUser( state, siteId, 'manage_options' );
 	if ( ! siteIsGMBEligible || ! canUserManageOptions ) {
-		context.redirect( `/stats/${ context.params.site }` );
+		page.redirect( `/stats/${ siteId }` );
+		return;
 	}
 
 	next();

--- a/client/my-sites/google-my-business/index.js
+++ b/client/my-sites/google-my-business/index.js
@@ -36,8 +36,7 @@ const redirectUnauthorized = ( context, next ) => {
 	const siteIsGMBEligible = isSiteGoogleMyBusinessEligible( state, siteId );
 	const canUserManageOptions = canCurrentUser( state, siteId, 'manage_options' );
 	if ( ! siteIsGMBEligible || ! canUserManageOptions ) {
-		page.redirect( `/stats/${ siteId }` );
-		return;
+		page.redirect( `/stats/${ context.params.site }` );
 	}
 
 	next();


### PR DESCRIPTION
When you are on the GMB stats page, and you switch to a different site, if the site that is being switched to doesn't have GMB connected, the user should be redirected to the "default" stats page.

Before:
![gmb-site-switch-before](https://user-images.githubusercontent.com/326402/41661067-7c8288fa-74a6-11e8-96d8-e35fd260d5d4.gif)

After:
![gmb-site-switch](https://user-images.githubusercontent.com/326402/41661076-7fa3ae9c-74a6-11e8-8e28-5d57ee330349.gif)
  
#### Testing instructions
  
1. Run `git checkout fix/gmb-switch-site` and start your server, or open a [live branch](https://calypso.live/?branch=fix/gmb-switch-site)
2. Open the [`Home` page](http://calypso.localhost:3000/)
3. Open GMB stats page for a connected site
4. Switch to a site ( see gifs above ) that doesn't have GMB connected
5. Asserted you're redirected to the main stats page
  
 
#### Reviews
  
- [ ] Code
- [ ] Product


