### PR TITLE
State: Don't persist current user state after logout, since that hides "email me a login link" functionality

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -118,6 +118,13 @@ export function persistOnChange( reduxStore, serializeState = serialize ) {
 	const throttledSaveState = throttle(
 		function() {
 			const nextState = reduxStore.getState();
+
+			// Remove properties that shouldn't be persisted for logged-out
+			// users.
+			if ( ! isLoggedIn() ) {
+				delete nextState.currentUser;
+			}
+
 			if ( state && nextState === state ) {
 				return;
 			}


### PR DESCRIPTION
If you log in to Calypso, log out, and then go to the login page (https://wordpress.com/log-in) again, you'll notice the "Email me a login link" (a.k.a. magic links) option is missing from underneath the login form.

What's happening is that after you log out, `state.currentUser` still has the data from your previous session in it, and the code that normally displays the "email me a login link" option consequently thinks you're already logged in.

Based on the way state is persisted, it looks like this bug will continue for around 7 days after logout.

The fact that `state.currentUser` has stale data after logout seems like a pretty fundamental problem, so I wonder what else might be broken by it.  (I encountered this particular bug, though, since we're looking to improve the way magic link logins work for who log in via a billing-related email reminder.)