### PR TITLE
Store Services - wpcom user info: hide in Calypso, use angular brackets

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -162,7 +162,7 @@ class ShippingLabels extends Component {
 		return (
 			<p>
 				{ translate(
-					'Credit cards are retrieved from the following WordPress.com account: %(wpcomLogin)s (%(wpcomEmail)s)',
+					'Credit cards are retrieved from the following WordPress.com account: %(wpcomLogin)s <%(wpcomEmail)s>',
 					{
 						args: {
 							wpcomLogin: masterUserWpcomLogin,
@@ -294,7 +294,7 @@ class ShippingLabels extends Component {
 				<Button className="label-settings__internal" onClick={ openDialog } compact>
 					{ buttonLabel }
 				</Button>
-				<div className="label-settings__credit-card-description">
+				<div className="label-settings__credit-card-description label-settings__external">
 					{ this.renderAddCardExternalInfo() }
 					<Button onClick={ onAddCardExternal } compact>
 						{ buttonLabel } <Gridicon icon="external" />


### PR DESCRIPTION
Fixes an issue brought up by @dmsnell in #25307: the standard for displaying name/address pair is to use angular brackets: `%(wpcomLogin)s <%(wpcomEmail)s>`

Also re-adds the missing `label-settings__external` class to the user info and external payment button. Without it, two buttons appear in Calypso 😱 

To test:
* in calypso, verify there's only one "add another payment method" button
* in wp-admin, verify that the name/email pair appears correctly