### PR TITLE
Importers: Make the site importer text input respond to the Enter key

### DIFF
--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -110,6 +110,10 @@ class SiteImporterInputPane extends React.Component {
 		this.setState( { siteURLInput: event.target.value } );
 	};
 
+	validateOnEnter = event => {
+		event.key === 'Enter' && this.validateSite();
+	};
+
 	validateSite = () => {
 		const siteURL = this.state.siteURLInput;
 
@@ -200,6 +204,7 @@ class SiteImporterInputPane extends React.Component {
 							<TextInput
 								disabled={ this.state.loading }
 								onChange={ this.setUrl }
+								onKeyPress={ this.validateOnEnter }
 								value={ this.state.siteURLInput }
 							/>
 							<Button


### PR DESCRIPTION
After typing the URL to import, the user would have to click the button next to the input field. This change allows the user to press the enter key to achive the same result.

__Testing__
Simply enter a URL in the text input, press enter and check that the same behaviour is triggered as when you click the 'Continue' button