### PR TITLE
Reader full post: treat images with class 'emoji' correctly

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -64,6 +64,7 @@
 		display: inline;
 		margin: auto;
 
+		&.emoji,
 		&.emojify__emoji {
 			height: 1em;
 			margin-bottom: 0;
@@ -154,6 +155,7 @@
 			display: block;
 			margin: 0 auto;
 
+			&.emoji,
 			&.emojify__emoji {
 				display: inline;
 			}


### PR DESCRIPTION
We have special styles for emoji in Reader full post already, with the class `.emojify__emoji`. 

Sometimes, emoji images can be directly embedded in the post with the class `.emoji` too. This PR applies the same styles to `.emoji` images.

### To test

Compare:

https://wpcalypso.wordpress.com/read/blogs/76295396/posts/22

<img width="278" alt="screen shot 2018-06-21 at 11 42 25" src="https://user-images.githubusercontent.com/17325/41690125-31a092c6-7548-11e8-9c73-5cbc5f92c579.png">

to 

http://calypso.localhost:3000/read/blogs/76295396/posts/22

<img width="263" alt="screen shot 2018-06-21 at 11 42 21" src="https://user-images.githubusercontent.com/17325/41690130-36c3fce8-7548-11e8-86c6-8fb5118d3dc0.png">
