### PR TITLE
Reader: fix visit link label spacing in combined card

### DIFF
--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -191,10 +191,6 @@
 .reader-combined-card .reader-visit-link {
 	margin-left: 0;
 	margin-right: 26px;
-
-	.reader-visit-link__label {
-		margin-left: -4px;
-	}
 }
 
 .reader-combined-card .reader-visit-link,


### PR DESCRIPTION
We've had a style regression which caused the Visit link label in combined cards to appear right next to the icon:

<img width="179" alt="screen shot 2018-06-21 at 17 19 19" src="https://user-images.githubusercontent.com/17325/41699501-40c1afbc-7578-11e8-9334-b8bf845b6272.png">

This PR fixes the spacing:

<img width="244" alt="screen shot 2018-06-21 at 17 20 08" src="https://user-images.githubusercontent.com/17325/41699509-47141710-7578-11e8-9c52-4c63c35b8782.png">

### To test

Open your Reader stream at http://calypso.localhost:3000 and locate a combined card (several consective posts from the same site).
