### PR TITLE
Chcekout: minor fix to emergent paywall css

### DIFF
--- a/assets/stylesheets/emergent-paywall.scss
+++ b/assets/stylesheets/emergent-paywall.scss
@@ -563,6 +563,7 @@ div[ng-show='busyIndicator'] {
 	max-height: 200px;
 	overflow-x: hidden;
 	margin-top: -1px;
+	position: inherit !important;
 }
 
 body > .ui-select-bootstrap.open {


### PR DESCRIPTION
This is a workaround for an issue where the list of banks isn't visible when choosing "consumer" as the customer type.