### PR TITLE
Add concierge banner

### DIFF
--- a/client/components/action-card/README.md
+++ b/client/components/action-card/README.md
@@ -85,3 +85,10 @@ Button onClick handler
   - **Default:** `true`
 
 Determines whether or not this is a compact card
+
+### `illustration`
+  - **Type:** `String`
+  - **Required:** `no`
+  - **Default:** `undefined`
+
+An illustration to show on the card

--- a/client/components/action-card/README.md
+++ b/client/components/action-card/README.md
@@ -78,3 +78,10 @@ Button target, to use in conjunction with `buttonHref`
   - **Default:** `undefined`
 
 Button onClick handler
+
+### `compact`
+  - **Type:** `Boolean`
+  - **Required:** `no`
+  - **Default:** `true`
+
+Determines whether or not this is a compact card

--- a/client/components/action-card/README.md
+++ b/client/components/action-card/README.md
@@ -91,4 +91,4 @@ Determines whether or not this is a compact card
   - **Required:** `no`
   - **Default:** `undefined`
 
-An illustration to show on the card
+The URL of an illustration to show on the card

--- a/client/components/action-card/index.jsx
+++ b/client/components/action-card/index.jsx
@@ -24,8 +24,16 @@ const ActionCard = ( {
 	buttonOnClick,
 	children,
 	compact = true,
+	illustration,
 } ) => (
 	<Card className="action-card" compact={ compact }>
+		{ illustration && (
+			<img
+				className="action-card__illustration"
+				alt="concierge session signup form header"
+				src={ illustration }
+			/>
+		) }
 		<div className="action-card__main">
 			<h2 className="action-card__heading">{ headerText }</h2>
 			<p>{ mainText }</p>
@@ -56,6 +64,7 @@ ActionCard.propTypes = {
 	buttonTarget: PropTypes.string,
 	children: PropTypes.any,
 	compact: PropTypes.bool,
+	illustration: PropTypes.string,
 };
 
 export default ActionCard;

--- a/client/components/action-card/index.jsx
+++ b/client/components/action-card/index.jsx
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import CompactCard from 'components/card/compact';
+import Card from 'components/card';
 import Button from 'components/button';
 
 const ActionCard = ( {
@@ -23,8 +23,9 @@ const ActionCard = ( {
 	buttonHref,
 	buttonOnClick,
 	children,
+	compact = true,
 } ) => (
-	<CompactCard className="action-card">
+	<Card className="action-card" compact={ compact }>
 		<div className="action-card__main">
 			<h2 className="action-card__heading">{ headerText }</h2>
 			<p>{ mainText }</p>
@@ -41,7 +42,7 @@ const ActionCard = ( {
 				</Button>
 			) }
 		</div>
-	</CompactCard>
+	</Card>
 );
 
 ActionCard.propTypes = {
@@ -54,6 +55,7 @@ ActionCard.propTypes = {
 	buttonHref: PropTypes.string,
 	buttonTarget: PropTypes.string,
 	children: PropTypes.any,
+	compact: PropTypes.bool,
 };
 
 export default ActionCard;

--- a/client/components/action-card/style.scss
+++ b/client/components/action-card/style.scss
@@ -10,6 +10,10 @@
 	flex: 2 1;
 }
 
+.action-card__illustration {
+	max-width: 200px;
+}
+
 .action-card__button-container {
 	align-self: center;
 	flex: 1;

--- a/client/components/action-card/style.scss
+++ b/client/components/action-card/style.scss
@@ -12,6 +12,10 @@
 
 .action-card__illustration {
 	max-width: 200px;
+
+	@include breakpoint( '<960px' ) {
+		display: none;
+	}
 }
 
 .action-card__button-container {

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -65,6 +65,7 @@ class PurchasesList extends Component {
 								this.props.recordTracksEvent( 'calypso_purchases_concierge_banner_click' );
 							} }
 							compact={ false }
+							illustration="/calypso/images/illustrations/illustration-start.svg"
 						/>
 					) }
 

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -54,9 +54,9 @@ class PurchasesList extends Component {
 						<ActionCard
 							headerText={ this.props.translate( 'Looking for Expert Help?' ) }
 							mainText={ this.props.translate(
-								'Shedule your free 1-1 concierge session with a Happiness Engineer today and get 30 minutes dedicated to the success of your site!'
+								'Get 30 minutes dedicated to the success of your site. Schedule your free 1-1 concierge session with a Happiness Engineer today!'
 							) }
-							buttonText="Get Started"
+							buttonText="Schedule Now"
 							buttonIcon={ null }
 							buttonPrimary={ true }
 							buttonHref="/me/concierge"

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
+import ActionCard from 'components/action-card';
 import CompactCard from 'components/card';
 import EmptyContent from 'components/empty-content';
 import Main from 'components/main';
@@ -45,16 +46,33 @@ class PurchasesList extends Component {
 		}
 
 		if ( this.props.hasLoadedUserPurchasesFromServer && this.props.purchases.length ) {
-			content = getPurchasesBySite( this.props.purchases, this.props.sites ).map( site => (
-				<PurchasesSite
-					key={ site.id }
-					siteId={ site.id }
-					name={ site.name }
-					domain={ site.domain }
-					slug={ site.slug }
-					purchases={ site.purchases }
-				/>
-			) );
+			content = (
+				<div>
+					<ActionCard
+						headerText={ this.props.translate( 'Looking for Expert Help?' ) }
+						mainText={ this.props.translate(
+							'Shedule your free 1-1 concierge session with a Happiness Engineer today and get 30 minutes dedicated to the success of your site!'
+						) }
+						buttonText="Get Started"
+						buttonIcon={ null }
+						buttonPrimary={ true }
+						buttonHref="/me/concierge"
+						buttonTarget={ null }
+						buttonOnClick={ null }
+					/>
+
+					{ getPurchasesBySite( this.props.purchases, this.props.sites ).map( site => (
+						<PurchasesSite
+							key={ site.id }
+							siteId={ site.id }
+							name={ site.name }
+							domain={ site.domain }
+							slug={ site.slug }
+							purchases={ site.purchases }
+						/>
+					) ) }
+				</div>
+			);
 		}
 
 		if ( this.props.hasLoadedUserPurchasesFromServer && ! this.props.purchases.length ) {

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
 import ActionCard from 'components/action-card';
 import CompactCard from 'components/card';
 import EmptyContent from 'components/empty-content';
+import isBusinessPlanUser from 'state/selectors/is-business-plan-user';
 import Main from 'components/main';
 import MeSidebarNavigation from 'me/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -48,18 +49,20 @@ class PurchasesList extends Component {
 		if ( this.props.hasLoadedUserPurchasesFromServer && this.props.purchases.length ) {
 			content = (
 				<div>
-					<ActionCard
-						headerText={ this.props.translate( 'Looking for Expert Help?' ) }
-						mainText={ this.props.translate(
-							'Shedule your free 1-1 concierge session with a Happiness Engineer today and get 30 minutes dedicated to the success of your site!'
-						) }
-						buttonText="Get Started"
-						buttonIcon={ null }
-						buttonPrimary={ true }
-						buttonHref="/me/concierge"
-						buttonTarget={ null }
-						buttonOnClick={ null }
-					/>
+					{ this.props.isBusinessPlanUser && (
+						<ActionCard
+							headerText={ this.props.translate( 'Looking for Expert Help?' ) }
+							mainText={ this.props.translate(
+								'Shedule your free 1-1 concierge session with a Happiness Engineer today and get 30 minutes dedicated to the success of your site!'
+							) }
+							buttonText="Get Started"
+							buttonIcon={ null }
+							buttonPrimary={ true }
+							buttonHref="/me/concierge"
+							buttonTarget={ null }
+							buttonOnClick={ null }
+						/>
+					) }
 
 					{ getPurchasesBySite( this.props.purchases, this.props.sites ).map( site => (
 						<PurchasesSite
@@ -104,6 +107,7 @@ class PurchasesList extends Component {
 }
 
 PurchasesList.propTypes = {
+	isBusinessPlanUser: PropTypes.bool.isRequired,
 	noticeType: PropTypes.string,
 	purchases: PropTypes.oneOfType( [ PropTypes.array, PropTypes.bool ] ),
 	sites: PropTypes.array.isRequired,
@@ -114,6 +118,7 @@ export default connect( state => {
 	const userId = getCurrentUserId( state );
 	return {
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
+		isBusinessPlanUser: isBusinessPlanUser( state ),
 		isFetchingUserPurchases: isFetchingUserPurchases( state ),
 		purchases: getUserPurchases( state, userId ),
 		sites: getSites( state ),

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -62,7 +62,9 @@ class PurchasesList extends Component {
 							buttonHref="/me/concierge"
 							buttonTarget={ null }
 							buttonOnClick={ () => {
-								this.props.recordTracksEvent( 'calypso_purchases_concierge_banner_click' );
+								this.props.recordTracksEvent( 'calypso_purchases_concierge_banner_click', {
+									referer: '/me/purchases',
+								} );
 							} }
 							compact={ false }
 							illustration="/calypso/images/illustrations/illustration-start.svg"

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -61,6 +61,7 @@ class PurchasesList extends Component {
 							buttonHref="/me/concierge"
 							buttonTarget={ null }
 							buttonOnClick={ null }
+							compact={ false }
 						/>
 					) }
 

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -29,6 +29,7 @@ import {
 	hasLoadedUserPurchasesFromServer,
 	isFetchingUserPurchases,
 } from 'state/purchases/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class PurchasesList extends Component {
 	isDataLoading() {
@@ -60,7 +61,9 @@ class PurchasesList extends Component {
 							buttonPrimary={ true }
 							buttonHref="/me/concierge"
 							buttonTarget={ null }
-							buttonOnClick={ null }
+							buttonOnClick={ () => {
+								this.props.recordTracksEvent( 'calypso_purchases_concierge_banner_click' );
+							} }
 							compact={ false }
 						/>
 					) }
@@ -115,14 +118,17 @@ PurchasesList.propTypes = {
 	userId: PropTypes.number.isRequired,
 };
 
-export default connect( state => {
-	const userId = getCurrentUserId( state );
-	return {
-		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
-		isBusinessPlanUser: isBusinessPlanUser( state ),
-		isFetchingUserPurchases: isFetchingUserPurchases( state ),
-		purchases: getUserPurchases( state, userId ),
-		sites: getSites( state ),
-		userId,
-	};
-} )( localize( PurchasesList ) );
+export default connect(
+	state => {
+		const userId = getCurrentUserId( state );
+		return {
+			hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
+			isBusinessPlanUser: isBusinessPlanUser( state ),
+			isFetchingUserPurchases: isFetchingUserPurchases( state ),
+			purchases: getUserPurchases( state, userId ),
+			sites: getSites( state ),
+			userId,
+		};
+	},
+	{ recordTracksEvent }
+)( localize( PurchasesList ) );

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -54,7 +54,7 @@ class PurchasesList extends Component {
 						<ActionCard
 							headerText={ this.props.translate( 'Looking for Expert Help?' ) }
 							mainText={ this.props.translate(
-								'Get 30 minutes dedicated to the success of your site. Schedule your free 1-1 concierge session with a Happiness Engineer today!'
+								'Get 30 minutes dedicated to the success of your site. Schedule your free 1-1 concierge session with a Happiness Engineer!'
 							) }
 							buttonText="Schedule Now"
 							buttonIcon={ null }

--- a/client/me/purchases/purchases-site/style.scss
+++ b/client/me/purchases/purchases-site/style.scss
@@ -45,3 +45,11 @@
 		padding: 11px 24px;
 	}
 }
+
+@include breakpoint( ">960px" ) {
+	.purchases-list {
+		.action-card__illustration {
+			margin: -40px 20px 0 -20px;
+		}
+	}
+}

--- a/client/me/purchases/purchases-site/style.scss
+++ b/client/me/purchases/purchases-site/style.scss
@@ -46,10 +46,8 @@
 	}
 }
 
-@include breakpoint( ">960px" ) {
-	.purchases-list {
-		.action-card__illustration {
-			margin: -40px 20px 0 -20px;
-		}
+.purchases-list .action-card__illustration {
+	@include breakpoint( ">960px" ) {
+		margin: -40px 20px 0 -20px;
 	}
 }


### PR DESCRIPTION
This adds a banner to `/purchases` when users have a business plan, to encourage them to schedule a 1-1. It looks like this:

<img width="430" alt="screen shot 2018-06-21 at 13 21 46" src="https://user-images.githubusercontent.com/275961/41718832-176ce856-7556-11e8-80d3-2e8d3613bdce.png">
<img width="775" alt="screen shot 2018-06-21 at 13 21 22" src="https://user-images.githubusercontent.com/275961/41718833-178e8a7e-7556-11e8-9507-60c08fa5552e.png">
  
#### Testing instructions
  
1. Run `git checkout add/concierge-banner` and start your server
2. Open the [`Purchases` page](http://calypso.localhost:3000/me/purchases) for a user that has a business plan
3. Check that the banner displays
4. Click the "Get Started" button
5. Check that you go to the "/me/concierge" page 
2. Open the [`Purchases` page](http://calypso.localhost:3000/me/purchases) for a user that doesn't have a business plan
3. Check that the banner isn't there

From p9mQOq-Sm-p2

Todo
- [x] copy review
- [ ] mobile design
- [x] design review