### PR TITLE
Domains: Run a new domain suggestion engines test for Kracken

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -867,7 +867,7 @@ class RegisterDomainStep extends React.Component {
 		}
 
 		if ( this.props.isSignupStep ) {
-			searchVendor = abtest( 'domainSuggestionKrakenV321' );
+			searchVendor = abtest( 'domainSuggestionKrakenV322' );
 		}
 
 		enqueueSearchStatReport( { query: searchQuery, section: this.props.analyticsSection } );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -91,13 +91,14 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
-	domainSuggestionKrakenV321: {
-		datestamp: '20180524',
+	domainSuggestionKrakenV322: {
+		datestamp: '20180621',
 		variations: {
 			domainsbot: 0,
-			group_1: 10000,
-			group_3: 10000,
-			group_4: 10000,
+			group_1: 36600,
+			group_3: 36600,
+			group_4: 36600,
+			group_6: 1000,
 		},
 		defaultVariation: 'domainsbot',
 	},


### PR DESCRIPTION
As discussed in p8kIbR-jN-p2 we've added a new provider `group_6` that will be allocated a very small percentage of the traffic. We're ending the old test `domainSuggestionKrakenV321`.

This PR depends on D15129-code
