### PR TITLE
Simple Payments: Bump MC stats on create, insert, and delete

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -14,8 +14,7 @@ import { find, isNumber, pick, noop, get, isEmpty } from 'lodash';
  * Internal dependencies
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug } from 'state/sites/selectors';
-import { isJetpackSite, isJetpackMinimumVersion } from 'state/sites/selectors';
+import { getSiteSlug, isJetpackSite, isJetpackMinimumVersion } from 'state/sites/selectors';
 import getSimplePayments from 'state/selectors/get-simple-payments';
 import QuerySimplePayments from 'components/data/query-simple-payments';
 import QuerySitePlans from 'components/data/query-site-plans';
@@ -136,13 +135,13 @@ class SimplePaymentsDialog extends Component {
 		};
 	}
 
-	componentWillReceiveProps( nextProps ) {
+	componentDidUpdate( prevProps ) {
 		// When transitioning from hidden to visible, show and initialize the form
-		if ( nextProps.showDialog && ! this.props.showDialog ) {
-			if ( nextProps.editPaymentId ) {
+		if ( this.props.showDialog && ! prevProps.showDialog ) {
+			if ( this.props.editPaymentId ) {
 				// Explicitly ordered to edit a particular button
-				this.showButtonForm( nextProps.editPaymentId );
-			} else if ( isEmptyArray( nextProps.paymentButtons ) ) {
+				this.showButtonForm( this.props.editPaymentId );
+			} else if ( isEmptyArray( this.props.paymentButtons ) ) {
 				// If the button list is loaded and empty, show the "Add New" form
 				this.showButtonForm( null );
 			} else {
@@ -152,7 +151,7 @@ class SimplePaymentsDialog extends Component {
 		}
 
 		// If the list has finished loading and is empty, switch from list to the "Add New" form
-		if ( this.props.paymentButtons === null && isEmptyArray( nextProps.paymentButtons ) ) {
+		if ( prevProps.paymentButtons === null && isEmptyArray( this.props.paymentButtons ) ) {
 			this.showButtonForm( null );
 		}
 	}

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -7,6 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { getFormValues } from 'redux-form';
 import { localize } from 'i18n-calypso';
 import { find, isNumber, pick, noop, get, isEmpty } from 'lodash';
 
@@ -52,7 +53,6 @@ import {
 } from 'state/analytics/actions';
 import EmptyContent from 'components/empty-content';
 import Banner from 'components/banner';
-import { getFormValues } from 'redux-form';
 
 // Utility function for checking the state of the Payment Buttons list
 const isEmptyArray = a => Array.isArray( a ) && a.length === 0;


### PR DESCRIPTION
Context: #25484

Add `bumpStat` to all the actions that already record  included in the Simple Payments TinyMCE plugin.

cc @artpi for the Memberships (I don't know how to test them!)

### Note

In #25484 the event `calypso_simple_payments_dialog_view` was mentioned.
Though, it's recorded with `TrackComponentView` which already uses `bumpStat`.

I've also replaced the deprecated React `componentWillReceiveProps` method with `componentDidUpdate` to avoid ESLint underlining the entire file.

## Testing instructions

- Enable analytics debugging with `localStorage.setItem('debug', 'calypso:analytics:*')` and filter the log to `simple_payments` to reduce the noise.
- Open a post on a Premium/Business site, and open the Add Payment Button dialog.
- Try creating, updating, deleting, and inserting into the post a button.
- All those actions should be logged twice: one for the Tracks event and one for the MC stat bump.