### PR TITLE
Settings: Fix connection ownership message while loading

### DIFF
--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -68,11 +68,13 @@ class SiteOwnership extends Component {
 
 		return (
 			<div>
-				<FormSettingExplanation>
-					{ userIsMaster
-						? translate( "You are the owner of this site's connection to WordPress.com." )
-						: translate( "Somebody else owns this site's connection to WordPress.com." ) }
-				</FormSettingExplanation>
+				{ userIsMaster !== null && (
+					<FormSettingExplanation>
+						{ userIsMaster
+							? translate( "You are the owner of this site's connection to WordPress.com." )
+							: translate( "Somebody else owns this site's connection to WordPress.com." ) }
+					</FormSettingExplanation>
+				) }
 				{ userIsMaster && this.renderCurrentUser() }
 			</div>
 		);


### PR DESCRIPTION
It seems that in the "Site Ownership" card we briefly might show the wrong message while the connection data is loading. This has been reported by @joanrho.

To reproduce:
* Go to `http://wordpress.com/settings/manage-connection/:site?debug`, where `:site` is a Jetpack site.
* Open your browser development console.
* Type `dispatch( { type: 'JETPACK_USER_CONNECTION_DATA_RECEIVE', siteId: 1234, data: null } )` there (where `1234` is your site ID) and press enter/return.
* You'll see the "Somebody else owns this site's connection to WordPress.com." briefly; but this is wrong - we still don't know that, so we shouldn't show it.

To test this PR:
* Checkout this branch
* Go to `http://calypso.localhost:3000/settings/manage-connection/:site?debug`, where `:site` is a Jetpack site.
* Open your browser development console.
* Type `dispatch( { type: 'JETPACK_USER_CONNECTION_DATA_RECEIVE', siteId: 1234, data: null } )` there (where `1234` is your site ID) and press enter/return.
* Verify you don't see any of the following messages in the "Site Ownership" card:
  *  `You are the owner of this site's connection to WordPress.com.`
  * `Somebody else owns this site's connection to WordPress.com.`
* Try with `dispatch( { type: 'JETPACK_USER_CONNECTION_DATA_RECEIVE', siteId: 1234, data: { isMaster: true } } )` (where `1234` is your site ID). You should see `You are the owner of this site's connection to WordPress.com.` in the "Site Ownership" card.
* Try with `dispatch( { type: 'JETPACK_USER_CONNECTION_DATA_RECEIVE', siteId: 1234, data: { isMaster: false } } )` (where `1234` is your site ID). You should see `Somebody else owns this site's connection to WordPress.com.` in the "Site Ownership" card.