### PR TITLE
Activity Log: Adds 'group' to activity log filters

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -493,7 +493,8 @@ export default connect(
 		const requestedBackupId = getRequestedBackup( state, siteId );
 		const rewindState = getRewindState( state, siteId );
 		const restoreStatus = rewindState.rewind && rewindState.rewind.status;
-		const logs = siteId && requestActivityLogs( siteId, {} );
+		const filter = siteId && getActivityLogFilter( state, siteId );
+		const logs = siteId && requestActivityLogs( siteId, filter );
 		const siteIsOnFreePlan = isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) );
 
 		return {
@@ -502,7 +503,7 @@ export default connect(
 			enableRewind:
 				'active' === rewindState.state &&
 				! ( 'queued' === restoreStatus || 'running' === restoreStatus ),
-			filter: getActivityLogFilter( state, siteId ),
+			filter,
 			logs: ( siteId && logs.data ) || emptyList,
 			logLoadingState: logs.state,
 			requestedRestore: find( logs, { activityId: requestedRestoreId } ),

--- a/client/state/activity-log/utils.js
+++ b/client/state/activity-log/utils.js
@@ -19,6 +19,6 @@ export const queryToFilterState = query =>
 		{},
 		query.page && query.page > 0 && { page: query.page },
 		query.group && {
-			group: Object.assign( {}, { includes: query.group.split( ',' ) } ),
+			group: Object.assign( {}, { includes: decodeURI( query.group ).split( ',' ) } ),
 		}
 	);

--- a/client/state/activity-log/utils.js
+++ b/client/state/activity-log/utils.js
@@ -1,9 +1,24 @@
 /** @format */
 
-export const filterStateToApiQuery = () => ( {
-	number: 1000,
-} );
+export const filterStateToApiQuery = filter =>
+	Object.assign(
+		{},
+		{ number: 1000 },
+		filter.group && filter.group.includes && { group: filter.group.includes }
+	);
 
-export const filterStateToQuery = ( { page } ) => ( page > 1 ? { page } : {} );
+export const filterStateToQuery = filter =>
+	Object.assign(
+		{},
+		filter.page > 1 && { page: filter.page },
+		filter.group && filter.group.includes && { group: filter.group.includes.join( ',' ) }
+	);
 
-export const queryToFilterState = ( { page } ) => ( page && page > 0 ? { page } : {} );
+export const queryToFilterState = query =>
+	Object.assign(
+		{},
+		query.page && query.page > 0 && { page: query.page },
+		query.group && {
+			group: Object.assign( {}, { includes: query.group.split( ',' ) } ),
+		}
+	);


### PR DESCRIPTION
If applied, this PR will allow folks to filter their activity log by group via a URL filter or through direct state manipulation:

[ [video](https://cloudup.com/czNvMl1bd4t) ]

Example URLs: ?group=post,  ?group=post,comment,plugin
Try these groups: post, setting, comment, plugin, theme, user