### PR TITLE
Importers: Fix importer rendering refactor #25556

### DIFF
--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -138,7 +138,7 @@ class SiteSettingsImport extends Component {
 	 * @param {Array} importsForSite The list of active import jobs
 	 * @returns {Array} Importer react elements for the active import jobs
 	 */
-	renderActiveImporters( site, siteTitle, importsForSite ) {
+	renderActiveImporters( importsForSite ) {
 		return importers.map( importer => {
 			const { type, isImporterEnabled, component: ImporterComponent } = importer;
 
@@ -146,16 +146,15 @@ class SiteSettingsImport extends Component {
 				return;
 			}
 
-			return importsForSite.filter( importItem => importItem.type === type ).map( importItem => (
-				<ImporterComponent
-					key={ importItem.importerId }
-					site={ site }
-					importerStatus={ {
-						siteTitle,
-						...importItem,
-					} }
-				/>
-			) );
+			return importsForSite
+				.filter( importItem => importItem.type === type )
+				.map( importItem => (
+					<ImporterComponent
+						key={ importItem.importerId }
+						site={ importItem.site }
+						importerStatus={ importItem }
+					/>
+				) );
 		} );
 	}
 
@@ -177,13 +176,15 @@ class SiteSettingsImport extends Component {
 			return this.renderIdleImporters( site, siteTitle, appStates.DISABLED );
 		}
 
-		const importsForSite = filterImportsForSite( site.ID, imports );
+		const importsForSite = filterImportsForSite( site.ID, imports )
+			// Add in the 'site' and 'siteTitle' properties to the import objects.
+			.map( item => Object.assign( {}, item, { site, siteTitle } ) );
 
 		if ( 0 === importsForSite.length ) {
 			return this.renderIdleImporters( site, siteTitle, appStates.INACTIVE );
 		}
 
-		return this.renderActiveImporters( site, siteTitle, importsForSite );
+		return this.renderActiveImporters( importsForSite );
 	}
 
 	updateFromAPI = () => {

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -48,6 +48,11 @@ const importers = [
 		component: MediumImporter,
 	},
 	{
+		type: BLOGGER,
+		isImporterEnabled: isEnabled( 'manage/import/blogger' ),
+		component: BloggerImporter,
+	},
+	{
 		type: SITE_IMPORTER,
 		isImporterEnabled: isEnabled( 'manage/import/site-importer' ),
 		component: SiteImporter,
@@ -106,7 +111,9 @@ class SiteSettingsImport extends Component {
 		} );
 
 		// add the 'other importers' card to the end of the list of importers
-		const { options: { admin_url: adminUrl } } = site;
+		const {
+			options: { admin_url: adminUrl },
+		} = site;
 
 		const otherImportersCard = (
 			<CompactCard
@@ -158,7 +165,10 @@ class SiteSettingsImport extends Component {
 	 * @returns {Array} Importer react elements
 	 */
 	renderImporters() {
-		const { api: { isHydrated }, importers: imports } = this.state;
+		const {
+			api: { isHydrated },
+			importers: imports,
+		} = this.state;
 		const { site } = this.props;
 		const { slug, title } = site;
 		const siteTitle = title.length ? title : slug;

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -132,8 +132,6 @@ class SiteSettingsImport extends Component {
 	 * Receives import jobs data (`importsForSite`) and maps this to return a
 	 * list of importer elements for active import jobs
 	 *
-	 * @param {object} site Data for the currently active site
-	 * @param {string} siteTitle The site's title
 	 * @param {Array} importsForSite The list of active import jobs
 	 * @returns {Array} Importer react elements for the active import jobs
 	 */

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { isEnabled } from 'config';
+import { filter } from 'lodash';
 
 /**
  * Internal dependencies
@@ -60,9 +61,7 @@ const importers = [
 ];
 
 const filterImportsForSite = ( siteID, imports ) => {
-	return Object.keys( imports )
-		.filter( importerId => imports[ importerId ].site.ID === siteID )
-		.map( importerId => imports[ importerId ] );
+	return filter( imports, importItem => importItem.site.ID === siteID );
 };
 
 class SiteSettingsImport extends Component {
@@ -117,7 +116,7 @@ class SiteSettingsImport extends Component {
 
 		const otherImportersCard = (
 			<CompactCard
-				key={ 'other-importers-card' }
+				key="other-importers-card"
 				href={ adminUrl + 'import.php' }
 				target="_blank"
 				rel="noopener noreferrer"

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -145,9 +145,9 @@ class SiteSettingsImport extends Component {
 
 			return importsForSite
 				.filter( importItem => importItem.type === type )
-				.map( importItem => (
+				.map( ( importItem, idx ) => (
 					<ImporterComponent
-						key={ importItem.importerId }
+						key={ type + idx }
 						site={ importItem.site }
 						importerStatus={ importItem }
 					/>

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -9,7 +9,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { isEnabled } from 'config';
-import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,10 +29,36 @@ import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
 import Placeholder from 'my-sites/site-settings/placeholder';
 
-const hasActiveImports = imports =>
-	!! find( imports, ( { importerState } ) => {
-		return importerState !== appStates.INACTIVE && importerState !== appStates.READY_FOR_UPLOAD;
-	} );
+/**
+ * Configuration for each of the importers to be rendered in this section. If
+ * you're adding a new importer, add it here. Importers will be rendered in the
+ * order they are listed in this array.
+ *
+ * @type {Array}
+ */
+const importers = [
+	{
+		type: WORDPRESS,
+		isImporterEnabled: true,
+		component: WordPressImporter,
+	},
+	{
+		type: MEDIUM,
+		isImporterEnabled: isEnabled( 'manage/import/medium' ),
+		component: MediumImporter,
+	},
+	{
+		type: SITE_IMPORTER,
+		isImporterEnabled: isEnabled( 'manage/import/site-importer' ),
+		component: SiteImporter,
+	},
+];
+
+const filterImportsForSite = ( siteID, imports ) => {
+	return Object.keys( imports )
+		.filter( importerId => imports[ importerId ].site.ID === siteID )
+		.map( importerId => imports[ importerId ] );
+};
 
 class SiteSettingsImport extends Component {
 	static propTypes = {
@@ -52,35 +77,103 @@ class SiteSettingsImport extends Component {
 	}
 
 	/**
-	 * Finds the import status objects for a
-	 * particular type of importer
+	 * Renders each enabled importer at the provided `state`
 	 *
-	 * @param {enum} type ImportConstants.IMPORT_TYPE_*
-	 * @returns {Array<Object>} ImportStatus objects
+	 * @param {object} site Data for the currently active site
+	 * @param {string} siteTitle The site's title
+	 * @param {string} state The state constant for the importer components
+	 * @returns {Array} A list of react elements for each enabled importer
 	 */
-	getImports( type ) {
-		const {
-			api: { isHydrated },
-			importers,
-		} = this.state;
+	renderIdleImporters( site, siteTitle, state ) {
+		const importerElements = importers.map( importer => {
+			const { type, isImporterEnabled, component: ImporterComponent } = importer;
+
+			if ( ! isImporterEnabled ) {
+				return;
+			}
+
+			return (
+				<ImporterComponent
+					key={ type }
+					site={ site }
+					importerStatus={ {
+						importerState: state,
+						siteTitle,
+						type,
+					} }
+				/>
+			);
+		} );
+
+		// add the 'other importers' card to the end of the list of importers
+		const { options: { admin_url: adminUrl } } = site;
+
+		const otherImportersCard = (
+			<CompactCard
+				key={ 'other-importers-card' }
+				href={ adminUrl + 'import.php' }
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				{ this.props.translate( 'Other importers' ) }
+			</CompactCard>
+		);
+
+		return [ ...importerElements, otherImportersCard ];
+	}
+
+	/**
+	 * Receives import jobs data (`importsForSite`) and maps this to return a
+	 * list of importer elements for active import jobs
+	 *
+	 * @param {object} site Data for the currently active site
+	 * @param {string} siteTitle The site's title
+	 * @param {Array} importsForSite The list of active import jobs
+	 * @returns {Array} Importer react elements for the active import jobs
+	 */
+	renderActiveImporters( site, siteTitle, importsForSite ) {
+		return importers.map( importer => {
+			const { type, isImporterEnabled, component: ImporterComponent } = importer;
+
+			if ( ! isImporterEnabled ) {
+				return;
+			}
+
+			return importsForSite.filter( importItem => importItem.type === type ).map( importItem => (
+				<ImporterComponent
+					key={ importItem.importerId }
+					site={ site }
+					importerStatus={ {
+						siteTitle,
+						...importItem,
+					} }
+				/>
+			) );
+		} );
+	}
+
+	/**
+	 * Return rendered importer elements
+	 *
+	 * @returns {Array} Importer react elements
+	 */
+	renderImporters() {
+		const { api: { isHydrated }, importers: imports } = this.state;
 		const { site } = this.props;
 		const { slug, title } = site;
 		const siteTitle = title.length ? title : slug;
 
 		if ( ! isHydrated ) {
-			return [ { importerState: appStates.DISABLED, type, siteTitle } ];
+			return this.renderIdleImporters( site, siteTitle, appStates.DISABLED );
 		}
 
-		const status = Object.keys( importers )
-			.map( id => importers[ id ] )
-			.filter( importer => site.ID === importer.site.ID )
-			.filter( importer => type === importer.type );
+		const importsForSite = filterImportsForSite( site.ID, imports );
 
-		if ( 0 === status.length ) {
-			return [ { importerState: appStates.INACTIVE, type, siteTitle } ];
+		if ( 0 === importsForSite.length ) {
+			return this.renderIdleImporters( site, siteTitle, appStates.INACTIVE );
 		}
 
-		return status.map( item => Object.assign( {}, item, { site, siteTitle } ) );
+		return this.renderActiveImporters( site, siteTitle, importsForSite );
 	}
 
 	updateFromAPI = () => {
@@ -119,17 +212,6 @@ class SiteSettingsImport extends Component {
 			}
 		);
 
-		const wpImports = this.getImports( WORDPRESS );
-		const mediumImports = isEnabled( 'manage/import/medium' ) ? this.getImports( MEDIUM ) : [];
-		const bloggerImports = isEnabled( 'manage/import/blogger' ) ? this.getImports( BLOGGER ) : [];
-
-		const siteImporterImports = this.getImports( SITE_IMPORTER );
-
-		const hasWpActiveImports = hasActiveImports( wpImports );
-		const hasMediumActiveImports = hasActiveImports( mediumImports );
-		const hasBloggerActiveImports = hasActiveImports( bloggerImports );
-		const hasSiteImporterActiveImports = hasActiveImports( siteImporterImports );
-
 		return (
 			<Main>
 				<HeaderCake backHref={ '/settings/general/' + siteSlug }>
@@ -156,39 +238,7 @@ class SiteSettingsImport extends Component {
 								<p className="importer__section-description">{ description }</p>
 							</header>
 						</CompactCard>
-
-						{ ( ( ! hasMediumActiveImports && ! hasBloggerActiveImports ) || hasWpActiveImports ) &&
-							wpImports.map( ( importerStatus, key ) => (
-								<WordPressImporter { ...{ key, site, importerStatus } } />
-							) ) }
-
-						{ ( ( ! hasWpActiveImports && ! hasBloggerActiveImports ) || hasMediumActiveImports ) &&
-							mediumImports.map( ( importerStatus, key ) => (
-								<MediumImporter { ...{ key, site, importerStatus } } />
-							) ) }
-
-						{ ( ( ! hasWpActiveImports && ! hasMediumActiveImports ) || hasBloggerActiveImports ) &&
-							bloggerImports.map( ( importerStatus, key ) => (
-								<BloggerImporter { ...{ key, site, importerStatus } } />
-							) ) }
-
-						{ isEnabled( 'manage/import/site-importer' ) &&
-							siteImporterImports.map( ( importerStatus, key ) => (
-								<SiteImporter { ...{ key, site, importerStatus } } />
-							) ) }
-
-						{ ! hasWpActiveImports &&
-							! hasBloggerActiveImports &&
-							! hasMediumActiveImports &&
-							! hasSiteImporterActiveImports && (
-								<CompactCard
-									href={ adminUrl + 'import.php' }
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									{ translate( 'Other importers' ) }
-								</CompactCard>
-							) }
+						{ this.renderImporters() }
 					</EmailVerificationGate>
 				) }
 			</Main>


### PR DESCRIPTION
The refactor of the rendering of importers (#25556) was reverted by @bisko after he discovered that it was causing the `SiteImporterInputPane` to be remounted which meant it didn't detect the state change and start the import process.

This change is based on #25556 along with a fix to make the key of the `ImporterSiteImporter` component stable - this prevents the remount from happening.