### PR TITLE
Signup: fixed a bug takes users to the start of the flow again when login

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -12,6 +12,7 @@ import { includes, capitalize } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import classNames from 'classnames';
+import store from 'store';
 
 /**
  * Internal dependencies
@@ -128,10 +129,27 @@ class Login extends Component {
 		// Redirects to / if no redirect url is available
 		const url = redirectTo ? redirectTo : window.location.origin;
 
+		// For a seamless signup experience, the site creation data
+		// should be restored when users log in to WordPress.com
+		const signupFlowName = store.get( 'signupFlowName' );
+		const signupProgress = ( store.get( 'signupProgress' ) || [] ).filter(
+			step => step.stepName !== 'user'
+		);
+
 		// user data is persisted in localstorage at `lib/user/user` line 157
 		// therefor we need to reset it before we redirect, otherwise we'll get
 		// mixed data from old and new user
-		user.clear( () => ( window.location.href = url ) );
+		user.clear( () => {
+			if ( signupFlowName && signupProgress.length ) {
+				const lastStep = signupProgress.pop();
+				store.set( 'signupFlowName', signupFlowName );
+				store.set( 'signupProgress', [
+					...signupProgress,
+					{ ...lastStep, resumeAfterLogin: true },
+				] );
+			}
+			window.location.href = url;
+		} );
 	};
 
 	renderHeader() {


### PR DESCRIPTION
This resolves #10738.

When users log in during the signup flow they are redirected to the start of the flow again, which is not good for UX. This PR will fix the bug by restoring the signup flow data when users sign in to WordPress.com.

# Test Plan
@alisterscott explained how to produce it in the issue.
> Steps
> 1. As a non-logged-in customer visit wordpress.com/start
> 2. Proceed to the account screen
> 3. Enter email of existing account
> 4. Use the log in now link
> 5. Customer is redirected back to the start of the sign up flow