### PR TITLE
Fix `calypso_google_my_business_stats_nudge_view` triggered all the time in Stats

### DIFF
--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -37,7 +37,7 @@ class GoogleMyBusinessStatsNudge extends Component {
 	};
 
 	componentDidMount() {
-		if ( ! this.props.isDismissed ) {
+		if ( this.isVisible() ) {
 			this.props.recordTracksEvent( 'calypso_google_my_business_stats_nudge_view' );
 		}
 	}
@@ -51,8 +51,12 @@ class GoogleMyBusinessStatsNudge extends Component {
 		this.props.recordTracksEvent( 'calypso_google_my_business_stats_nudge_start_now_button_click' );
 	};
 
+	isVisible() {
+		return ! this.props.isDismissed && this.props.visible;
+	}
+
 	render() {
-		if ( this.props.isDismissed || ! this.props.visible ) {
+		if ( ! this.isVisible() ) {
 			return null;
 		}
 


### PR DESCRIPTION
This PR makes sure the `calypso_google_my_business_stats_nudge_view` event is only triggered when the nudge is visible.
The nudge display condition was updated in https://github.com/Automattic/wp-calypso/pull/25436 but we didn't consider the case where the nudge was not visible for tracking.

### Testing Instructions
- Boot this branch locally
- Log analytics events in the console: localStorage.debug = 'calypso:analytics:*';
- Go to the stats page for a site that is eligible for Google My Business
- Ensure you see the calypso_google_my_business_stats_nudge_view event fired on page load
- Click on the Start Now button and make sure the event is not fired a second time
- Switch to a site that is not eligible for GMB
- Make sure this event is not triggered

### Reviews
- [ ] Code
- [ ] Product