### PR TITLE
Fixed an issue with inidividual plugin page on IE11 not showing because of a JS error

### DIFF
--- a/client/lib/plugins/sanitize-section-content.js
+++ b/client/lib/plugins/sanitize-section-content.js
@@ -133,7 +133,8 @@ export const sanitizeSectionContent = content => {
 	const doc = parser.parseFromString( content, 'text/html' );
 
 	// this will let us visit every single DOM node programmatically
-	const walker = doc.createTreeWalker( doc.body );
+	// the third & fourth arguments are required by IE 11
+	const walker = doc.createTreeWalker( doc.body, NodeFilter.SHOW_ALL, null, false );
 
 	/**
 	 * we don't want to remove nodes while walking the tree


### PR DESCRIPTION
Fixes issue #25280 

**Description**
The individual plugin page has a JS error in IE11 which is caused by a wrong number of arguments passed to the ```createTreeWalker``` method.

**Steps to reproduce**
Use Internet Explorer 11
Log into WordPress.com, and switch to an AT site.
Go to the Plugins Page
Click on any Plugin

**What I expected**
Once I select a Plugin, I expected the page to load with information about that particular Plugin.

**What happened instead**
The Plugin's page loads fine. Once I selected a Plugin, the Place Holder images display, but the page fails to load.

**Browser / OS version**
Internet Explorer 11, accessed using Windows 10