### PR TITLE
Guided Tours: Avoid overriding the parent class onClick method

### DIFF
--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -45,8 +45,8 @@ class DelegatingQuit extends Quit {
 		const container = targetForSlug( parentTarget );
 
 		if ( container && container.addEventListener ) {
-			container.addEventListener( 'click', this.onClick );
-			container.addEventListener( 'touchstart', this.onClick );
+			container.addEventListener( 'click', this.onParentClick );
+			container.addEventListener( 'touchstart', this.onParentClick );
 		}
 	};
 
@@ -55,12 +55,12 @@ class DelegatingQuit extends Quit {
 		const container = targetForSlug( parentTarget );
 
 		if ( container && container.addEventListener ) {
-			container.removeEventListener( 'click', this.onClick );
-			container.removeEventListener( 'touchstart', this.onClick );
+			container.removeEventListener( 'click', this.onParentClick );
+			container.removeEventListener( 'touchstart', this.onParentClick );
 		}
 	};
 
-	onClick = event => {
+	onParentClick = event => {
 		let eventTarget = event.target;
 		// Event delegation
 		while ( !! eventTarget && eventTarget !== event.currentTarget ) {


### PR DESCRIPTION
Fix #25506

Guided tour `Quit` components have an `onClick` method that dismiss the tour.
In the `simplePaymentsEmailTour`, I introduced a new `DelegatingQuit` component that extended the vanilla `Quit` one, in order to target dynamically added elements.
To do so, I've overridden the `onClick` method with a new one that expects an event delegation, accidentally breaking its original usage.

## Testing instructions

- Trigger the Simple Payments Email Tour by opening `/stats/day/{ siteSlug }?tour=simplePaymentsEmailTour` (possibly on a Premium/Business site, but it shouldn't matter).
- Follow the first step of the tour by clicking on the "Add (page)" button.
- Once in the editor, make sure that the tour can be quit:
  - either by clicking on the "(+) Add" button in the editor toolbar;
  - or on the "Got it, thanks!" blue button in the tour itself.