### PR TITLE
Update to page 1.8.6, Take 2

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -76,6 +76,13 @@ const setupContextMiddleware = reduxStore => {
 
 		next();
 	} );
+
+	page.exit( '*', ( context, next ) => {
+		if ( ! context.store ) {
+			context.store = reduxStore;
+		}
+		next();
+	} );
 };
 
 // We need to require sections to load React with i18n mixin

--- a/client/my-sites/checkout/cart/test/cart-buttons.js
+++ b/client/my-sites/checkout/cart/test/cart-buttons.js
@@ -16,18 +16,21 @@ import React from 'react';
  */
 import CartButtons from '../cart-buttons';
 import { recordStub } from 'lib/mixins/analytics';
+import page from 'page';
 import { useSandbox } from 'test/helpers/use-sinon';
 
 jest.mock( 'lib/mixins/analytics', () => {
-	const recordStub = require( 'sinon' ).stub();
+	const recordEventStub = require( 'sinon' ).stub();
 
 	const analytics = () => ( {
-		recordEvent: recordStub,
+		recordEvent: recordEventStub,
 	} );
-	analytics.recordStub = recordStub;
+	analytics.recordStub = recordEventStub;
 
 	return analytics;
 } );
+
+jest.mock( 'page', () => require( 'sinon' ).stub() );
 
 describe( 'cart-buttons', () => {
 	let cartButtonsComponent, onKeepSearchingClickStub;
@@ -68,6 +71,7 @@ describe( 'cart-buttons', () => {
 		test( 'should track "checkoutButtonClick" event', () => {
 			cartButtonsComponent.find( '.cart-checkout-button' ).simulate( 'click' );
 			expect( recordStub ).to.have.been.calledWith( 'checkoutButtonClick' );
+			expect( page ).to.have.been.calledWith( '/checkout/example.com' );
 		} );
 	} );
 } );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7936,8 +7936,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8289,8 +8288,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8337,7 +8335,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8376,13 +8373,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -14200,9 +14195,9 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "page": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/page/-/page-1.6.4.tgz",
-      "integrity": "sha1-+3QTJXJH2eBPArFvE4H2two3v1o=",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/page/-/page-1.8.6.tgz",
+      "integrity": "sha512-AMF34NihxNZkWtJBUr06EwlydSfeJxVnA057jpxqcie8LVCV+m1XToEzNw2R9e3bBJkZqWvwWgdIJ9QjUUWwFw==",
       "requires": {
         "path-to-regexp": "~1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "npm-run-all": "4.1.3",
     "object-path-immutable": "0.5.3",
     "objectpath": "1.2.1",
-    "page": "1.6.4",
+    "page": "1.8.6",
     "path-browserify": "1.0.0",
     "percentage-regex": "3.0.0",
     "phone": "git+https://github.com/Automattic/node-phone.git#1.0.8",


### PR DESCRIPTION
Brings us up to page 1.8.6. 

Originally attempted in #25597 and reverted in #25703

The original was reverted because trashing a post was broken. We think this may be due to a change in how exit handlers work. @dmsnell noticed us throwing in here, trying to access the `store`:

https://github.com/Automattic/wp-calypso/blob/5b0492ba10cbb7957c85f16fa048f761c2bf0aa6/client/post-editor/controller.js#L223-L230