### PR TITLE
Remove the 5to6 codemods

### DIFF
--- a/bin/codemods/README.md
+++ b/bin/codemods/README.md
@@ -90,20 +90,6 @@ selecting your local Node process from the list. Refer to the
 
 ## List of available transformations
 
-### 5to6-codemod scripts ([docs](https://github.com/5to6/5to6-codemod#transforms))
-
-- commonjs-exports
-	- This codemod converts `module.exports` to `export` and `export default`.
-
-- commonjs-imports
-	- This transformation converts occurrences of `require( '...' )` to `import ... from '...'` occurring at the top level scope. It will ignore CommonJS imports inside block statements, like conditionals or function definitions.
-
-- commonjs-imports-hoist
-	- This transformation hoists all occurrences of `require( '...' )` inside if, loop, and function blocks. This can cause breakage! Use with caution.
-
-- named-exports-from-default
-	- This transformation generates named exports given a `default export { ... }`. This can be useful in transitioning away from namespace imports (`import * as blah from 'blah'`) to named imports (`import named from 'blah'`).
-
 ### React scripts ([docs](https://github.com/reactjs/react-codemod))
 
 - react-create-class

--- a/bin/codemods/src/config.js
+++ b/bin/codemods/src/config.js
@@ -20,10 +20,6 @@ const recastOptions = {
 	}
 };
 const commonArgs = {
-	'5to6': [
-		// Recast options via 5to6
-		...recastArgs,
-	],
 	'react': [
 		// Recast options via react-codemod
 		`--printOptions=${ JSON.stringify( recastOptions ) }`,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,291 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "5to6-codemod": {
-      "version": "github:5to6/5to6-codemod#60306b71d8dde341e4d4bb968e6fbaf6875e19ae",
-      "from": "github:5to6/5to6-codemod#v1.7.0",
-      "dev": true,
-      "requires": {
-        "jscodeshift": "^0.3.28",
-        "lodash": "^4.17.4",
-        "recast": "^0.12.1"
-      },
-      "dependencies": {
-        "ast-types": {
-          "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
-          "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ==",
-          "dev": true
-        },
-        "babel-core": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
-          "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "^1.0.1",
-            "babel-plugin-dead-code-elimination": "^1.0.2",
-            "babel-plugin-eval": "^1.0.1",
-            "babel-plugin-inline-environment-variables": "^1.0.1",
-            "babel-plugin-jscript": "^1.0.4",
-            "babel-plugin-member-expression-literals": "^1.0.1",
-            "babel-plugin-property-literals": "^1.0.1",
-            "babel-plugin-proto-to-assign": "^1.0.3",
-            "babel-plugin-react-constant-elements": "^1.0.3",
-            "babel-plugin-react-display-name": "^1.0.3",
-            "babel-plugin-remove-console": "^1.0.1",
-            "babel-plugin-remove-debugger": "^1.0.1",
-            "babel-plugin-runtime": "^1.0.7",
-            "babel-plugin-undeclared-variables-check": "^1.0.2",
-            "babel-plugin-undefined-to-void": "^1.1.6",
-            "babylon": "^5.8.38",
-            "bluebird": "^2.9.33",
-            "chalk": "^1.0.0",
-            "convert-source-map": "^1.1.0",
-            "core-js": "^1.0.0",
-            "debug": "^2.1.1",
-            "detect-indent": "^3.0.0",
-            "esutils": "^2.0.0",
-            "fs-readdir-recursive": "^0.1.0",
-            "globals": "^6.4.0",
-            "home-or-tmp": "^1.0.0",
-            "is-integer": "^1.0.4",
-            "js-tokens": "1.0.1",
-            "json5": "^0.4.0",
-            "lodash": "^3.10.0",
-            "minimatch": "^2.0.3",
-            "output-file-sync": "^1.1.0",
-            "path-exists": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "private": "^0.1.6",
-            "regenerator": "0.8.40",
-            "regexpu": "^1.3.0",
-            "repeating": "^1.1.2",
-            "resolve": "^1.1.6",
-            "shebang-regex": "^1.0.0",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.0",
-            "source-map-support": "^0.2.10",
-            "to-fast-properties": "^1.0.0",
-            "trim-right": "^1.0.0",
-            "try-resolve": "^1.0.0"
-          },
-          "dependencies": {
-            "babylon": {
-              "version": "5.8.38",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
-              "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
-              "dev": true
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-              "dev": true
-            }
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-          "dev": true
-        },
-        "bluebird": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
-          "dev": true
-        },
-        "colors": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
-          "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw==",
-          "dev": true
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
-        },
-        "detect-indent": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-          "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "^4.0.1",
-            "minimist": "^1.1.0",
-            "repeating": "^1.1.0"
-          }
-        },
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-          "dev": true
-        },
-        "fs-readdir-recursive": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
-          "integrity": "sha1-MVtPuMHKW4xH3v7zGdBz2tNWgFk=",
-          "dev": true
-        },
-        "globals": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
-          "dev": true
-        },
-        "home-or-tmp": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-          "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "^1.0.1",
-            "user-home": "^1.1.1"
-          }
-        },
-        "js-tokens": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-          "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
-          "dev": true
-        },
-        "jscodeshift": {
-          "version": "0.3.32",
-          "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.3.32.tgz",
-          "integrity": "sha1-3s5etgLxY0DY2VTH+WrJB8UC6rs=",
-          "dev": true,
-          "requires": {
-            "async": "^1.5.0",
-            "babel-core": "^5",
-            "babel-plugin-transform-flow-strip-types": "^6.8.0",
-            "babel-preset-es2015": "^6.9.0",
-            "babel-preset-stage-1": "^6.5.0",
-            "babel-register": "^6.9.0",
-            "babylon": "^6.17.3",
-            "colors": "^1.1.2",
-            "flow-parser": "^0.*",
-            "lodash": "^4.13.1",
-            "micromatch": "^2.3.7",
-            "node-dir": "0.1.8",
-            "nomnom": "^1.8.1",
-            "recast": "^0.12.5",
-            "temp": "^0.8.1",
-            "write-file-atomic": "^1.2.0"
-          }
-        },
-        "json5": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "output-file-sync": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-          "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.4",
-            "mkdirp": "^0.5.1",
-            "object-assign": "^4.1.0"
-          }
-        },
-        "path-exists": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
-          "dev": true
-        },
-        "recast": {
-          "version": "0.12.9",
-          "resolved": "https://registry.npmjs.org/recast/-/recast-0.12.9.tgz",
-          "integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
-          "dev": true,
-          "requires": {
-            "ast-types": "0.10.1",
-            "core-js": "^2.4.1",
-            "esprima": "~4.0.0",
-            "private": "~0.1.5",
-            "source-map": "~0.6.1"
-          },
-          "dependencies": {
-            "core-js": {
-              "version": "2.5.7",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-              "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-              "dev": true
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-              "dev": true
-            }
-          }
-        },
-        "repeating": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "^1.0.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        },
-        "source-map-support": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-          "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.32",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
-            }
-          }
-        },
-        "to-fast-properties": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-          "dev": true
-        }
-      }
-    },
     "@babel/cli": {
       "version": "7.0.0-beta.44",
       "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.0.0-beta.44.tgz",
@@ -7936,8 +7651,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8289,8 +8003,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8337,7 +8050,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8376,13 +8088,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -20303,12 +20013,6 @@
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
-    },
-    "user-home": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-      "dev": true
     },
     "util": {
       "version": "0.10.4",

--- a/package.json
+++ b/package.json
@@ -243,7 +243,6 @@
     "postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\""
   },
   "devDependencies": {
-    "5to6-codemod": "5to6/5to6-codemod#v1.7.0",
     "babel-eslint": "8.2.3",
     "chai": "4.1.2",
     "chai-enzyme": "1.0.0-beta.1",


### PR DESCRIPTION
We're all on es6 now, no more need for these.

Plus they're 50MB on disk.