### PR TITLE
Fix: Activity log page can throw errors when given an empty state

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -505,7 +505,7 @@ export default connect(
 				! ( 'queued' === restoreStatus || 'running' === restoreStatus ),
 			filter,
 			logs: ( siteId && logs.data ) || emptyList,
-			logLoadingState: logs.state,
+			logLoadingState: logs && logs.state,
 			requestedRestore: find( logs, { activityId: requestedRestoreId } ),
 			requestedRestoreId,
 			requestedBackup: find( logs, { activityId: requestedBackupId } ),


### PR DESCRIPTION
While developing locally, i randomly get this error while viewing the activity log:

<img width="1428" alt="screen shot 2018-06-22 at 2 12 05 pm" src="https://user-images.githubusercontent.com/2694219/41794623-e7bb2518-762d-11e8-9203-0b39199c4f5d.png">

This PR will fix it