### PR TITLE
Fix: activity log banners for free jetpack sites

### DIFF
--- a/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
@@ -11,47 +11,29 @@ import { localize } from 'i18n-calypso';
  */
 import { isJetpackSite } from 'state/sites/selectors';
 import Banner from 'components/banner';
-import {
-	PLAN_PERSONAL,
-	PLAN_JETPACK_PERSONAL,
-	FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
-	FEATURE_NO_ADS,
-} from 'lib/plans/constants';
+import { PLAN_PERSONAL, FEATURE_NO_ADS } from 'lib/plans/constants';
 
 class UpgradeBanner extends Component {
 	render() {
-		const { isJetpack, translate } = this.props;
+		const { translate, isJetpack } = this.props;
+		if ( isJetpack ) {
+			return null;
+		}
 		return (
 			<div className="activity-log-banner__upgrade">
-				{ isJetpack ? (
-					<Banner
-						callToAction={ translate( 'Get daily backups' ) }
-						dismissPreferenceName="activity-upgrade-banner-jetpack"
-						event="activity_log_upgrade_click_jetpack"
-						feature={ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY }
-						list={ [
-							translate( 'See all site activity over the past month' ),
-							translate( 'Rewind your site back to any point' ),
-							translate( 'Automatic threat scanning' ),
-						] }
-						plan={ PLAN_JETPACK_PERSONAL }
-						title={ translate( 'Secure your site with daily backups' ) }
-					/>
-				) : (
-					<Banner
-						callToAction={ translate( 'Upgrade' ) }
-						dismissPreferenceName="activity-upgrade-banner-simple"
-						event="activity_log_upgrade_click_wpcom"
-						feature={ FEATURE_NO_ADS }
-						list={ [
-							translate( 'Get a custom domain name' ),
-							translate( 'Remove WordPress.com ads' ),
-							translate( 'See 30 days of past activity' ),
-						] }
-						plan={ PLAN_PERSONAL }
-						title={ translate( 'Upgrade your WordPress.com experience' ) }
-					/>
-				) }
+				<Banner
+					callToAction={ translate( 'Upgrade' ) }
+					dismissPreferenceName="activity-upgrade-banner-simple"
+					event="activity_log_upgrade_click_wpcom"
+					feature={ FEATURE_NO_ADS }
+					list={ [
+						translate( 'Get a custom domain name' ),
+						translate( 'Remove WordPress.com ads' ),
+						translate( 'See 30 days of past activity' ),
+					] }
+					plan={ PLAN_PERSONAL }
+					title={ translate( 'Upgrade your WordPress.com experience' ) }
+				/>
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log/unavailability-notice.jsx
+++ b/client/my-sites/stats/activity-log/unavailability-notice.jsx
@@ -27,6 +27,17 @@ export const UnavailabilityNotice = ( {
 	}
 
 	switch ( reason ) {
+		case 'missing_plan':
+			return (
+				<Banner
+					plan="personal-bundle"
+					href={ `/plans/${ slug }` }
+					callToAction={ translate( 'Upgrade' ) }
+					title={ translate(
+						'Upgrade your Jetpack plan to restore your site to events in the past.'
+					) }
+				/>
+			);
 		case 'no_connected_jetpack':
 			return (
 				<Banner


### PR DESCRIPTION
Fixes #25709 

This will remove the upgrade banner for free jetpack sites, and replace it with the unavailability banner we were using previously.

To test:
1. Ensure you don't see this banner on the activity log for free jetpack sites

![41794387-1f45e2d8-7657-11e8-9943-9f0f92788259 1](https://user-images.githubusercontent.com/2694219/41796031-e19db100-7632-11e8-867c-f6480e4e312a.png)

2. Ensure you see a similar banner on free wpcom sites