### PR TITLE
Support User: make path work in environments other than development

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -759,6 +759,7 @@ module.exports = function() {
 					authorized: true,
 					supportUser: req.query.support_user,
 					supportToken: req.query._support_token,
+					supportPath: req.query.support_path,
 				} )
 			);
 		} );


### PR DESCRIPTION
In #25675 we introduced support for a path for support-path. There was a different code-path for non-development, so that path wasn't properly propagated. This diff fixes that.

To test: confidence check.