### PR TITLE
Shopping Cart: Fix not passing the correct extra for the product

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -47,13 +47,15 @@ function preprocessCartForServer( {
 			currency,
 			temporary,
 			extra,
-			products: products.map( ( { product_id, meta, free_trial, volume, _extra } ) => ( {
-				product_id,
-				meta,
-				free_trial,
-				volume,
-				extra: _extra,
-			} ) ),
+			products: products.map(
+				( { product_id, meta, free_trial, volume, extra: productExtra } ) => ( {
+					product_id,
+					meta,
+					free_trial,
+					volume,
+					extra: productExtra,
+				} )
+			),
 		},
 		needsUrlCoupon &&
 			urlCoupon && {


### PR DESCRIPTION
Regression introduced in #25433

Destructuring was not done properly and a non-exisiting `_extra` property was used.
It has caused G Suite purchases to be completely broken, see: p2MSmN-6ER-p2.

### Testing
Have a custom domain name (registration or mapping).
Add Email (G Suite) to it (Domains -> example.com -> Email).
Fill out the contact details.
Verify that the `shopping-cart` endpoint returned a product with valid `extra` field:
```
"products": [{
	"product_id": 69,
	"product_name": "G Suite",
	"product_slug": "gapps",
	/* ... */
	"extra": {
		"google_apps_users": [{
			"email": "foo@example.com",
			"firstname": "John",
			"lastname": "Smith"
		}],
		"context": "calypstore"
	},
	/* ... */
}],
/* ... */
```