### PR TITLE
Checkout: send domainDetails to emergent configuration endpoint

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1185,14 +1185,24 @@ Undocumented.prototype.ebanxConfiguration = function( query, fn ) {
  *
  * @returns {Promise} promise
  */
-Undocumented.prototype.emergentPaywallConfiguration = function( countryCode, cart, fn ) {
+Undocumented.prototype.emergentPaywallConfiguration = function(
+	countryCode,
+	cart,
+	domainDetails,
+	fn
+) {
 	debug( '/me/emergent-paywall-configuration query' );
 
-	return this.wpcom.req.post(
-		'/me/emergent-paywall-configuration',
-		{ country: countryCode, cart },
-		fn
+	const data = mapKeysRecursively(
+		{
+			country: countryCode,
+			cart,
+			domainDetails,
+		},
+		snakeCase
 	);
+
+	return this.wpcom.req.post( '/me/emergent-paywall-configuration', data, fn );
 };
 
 /**

--- a/client/my-sites/checkout/checkout/emergent-paywall-box.jsx
+++ b/client/my-sites/checkout/checkout/emergent-paywall-box.jsx
@@ -166,6 +166,7 @@ export class EmergentPaywallBox extends Component {
 		wpcom.emergentPaywallConfiguration(
 			this.props.userCountryCode,
 			this.props.cart,
+			this.props.transaction.domainDetails,
 			this.loadIframe
 		);
 	};


### PR DESCRIPTION
Currently, if the cart contains a domain registration, the Emergent Iframe will fail to load.

This is part of what's included in #25553, but we can't wait on that PR - Emergent is going to be launched soon.

*Testing:*
- You need an account with the currency set to INR.
- Add a domain registration to the cart
- On the checkout page, reload with the `?debug` query string and paste the following in the console:
`httpData.set( 'geo', {state: "success", data: "IN", error: undefined, lastUpdated: 1527746419292, pendingSince: undefined} )`
- The Emergent payment option should show up.
- Selecting the tab should load the different payment options.

 