### PR TITLE
Revert "Reader full post: treat images with class 'emoji' correctly"

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -64,7 +64,6 @@
 		display: inline;
 		margin: auto;
 
-		&.emoji,
 		&.emojify__emoji {
 			height: 1em;
 			margin-bottom: 0;
@@ -155,7 +154,6 @@
 			display: block;
 			margin: 0 auto;
 
-			&.emoji,
 			&.emojify__emoji {
 				display: inline;
 			}


### PR DESCRIPTION
Reverts Automattic/wp-calypso#25652 due to a build problem.