### PR TITLE
Make the isFollowing selector aware of alias feed URLs

### DIFF
--- a/client/blocks/follow-button/index.jsx
+++ b/client/blocks/follow-button/index.jsx
@@ -3,14 +3,13 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { noop, omitBy, isUndefined } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import FollowButton from './button';
 import isFollowing from 'state/selectors/is-following';

--- a/client/state/selectors/is-following.js
+++ b/client/state/selectors/is-following.js
@@ -7,15 +7,16 @@
 import { find } from 'lodash';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { prepareComparableUrl } from 'state/reader/follows/utils';
+import getReaderAliasedFollowFeedUrl from 'state/selectors/get-reader-aliased-follow-feed-url';
 
 export default function isFollowing( state, { feedUrl, feedId, blogId } ) {
 	let follow;
 	if ( feedUrl ) {
-		const url = prepareComparableUrl( feedUrl );
-		follow = state.reader.follows.items[ url ];
+		const url = getReaderAliasedFollowFeedUrl( state, feedUrl );
+		follow = state.reader.follows.items[ prepareComparableUrl( url ) ];
 	} else if ( feedId ) {
 		follow = find( state.reader.follows.items, { feed_ID: feedId } );
 	} else if ( blogId ) {

--- a/client/state/selectors/test/is-following.js
+++ b/client/state/selectors/test/is-following.js
@@ -3,8 +3,7 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-import deepfreeze from 'deep-freeze';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -12,7 +11,7 @@ import deepfreeze from 'deep-freeze';
 import isFollowing from '../is-following';
 
 describe( 'is-following', () => {
-	const state = deepfreeze( {
+	const state = deepFreeze( {
 		reader: {
 			follows: {
 				items: {
@@ -20,6 +19,7 @@ describe( 'is-following', () => {
 						feed_ID: 1,
 						blog_ID: 2,
 						feed_URL: 'https://example.com/feed',
+						alias_feed_URLs: [ 'alias.example.com' ],
 						is_following: true,
 					},
 					'badexample.com/feed': {
@@ -32,19 +32,28 @@ describe( 'is-following', () => {
 			},
 		},
 	} );
+
 	test( 'should find an item by feed ID', () => {
-		expect( isFollowing( state, { feedId: 1 } ) ).to.be.true;
+		expect( isFollowing( state, { feedId: 1 } ) ).toBe( true );
 	} );
+
 	test( 'should find an item by blog ID', () => {
-		expect( isFollowing( state, { blogId: 2 } ) ).to.be.true;
+		expect( isFollowing( state, { blogId: 2 } ) ).toBe( true );
 	} );
+
 	test( 'should find an item by url', () => {
-		expect( isFollowing( state, { feedUrl: 'https://example.com/feed' } ) ).to.be.true;
+		expect( isFollowing( state, { feedUrl: 'https://example.com/feed' } ) ).toBe( true );
 	} );
+
+	test( 'should find an item by alias url', () => {
+		expect( isFollowing( state, { feedUrl: 'http://alias.example.com' } ) ).toBe( true );
+	} );
+
 	test( 'should respect is_following', () => {
-		expect( isFollowing( state, { feedId: 10 } ) ).to.be.false;
+		expect( isFollowing( state, { feedId: 10 } ) ).toBe( false );
 	} );
+
 	test( 'should return false for an unknown follow', () => {
-		expect( isFollowing( state, { feedId: -1 } ) ).to.be.false;
+		expect( isFollowing( state, { feedId: -1 } ) ).toBe( false );
 	} );
 } );


### PR DESCRIPTION
Fixes #24601.

This PR makes the isFollowing selector use `getReaderAliasedFollowFeedUrl`, so that we look at possible aliases for a feed URL when deciding whether the user is following it.

In particular, this helps in Discover, where the supplied site URL is often slightly different to the actual feed URL (e.g. http://www.londnr.com" where the following feed URL is "http://www.londnr.com/feed"). Where we encounter these slightly different feed URLs we record them in state under the key 'alias_feed_URLs', but we were not previously using this information for determining follow status.

### To test

Visit http://calypso.localhost:3000/discover and follow a site using the special follow button on Discover cards. Make sure that the following status persists after pressing the button.

<img width="873" alt="screen shot 2018-06-25 at 12 58 13" src="https://user-images.githubusercontent.com/17325/41825740-920f7eb0-7877-11e8-991f-78fd38b7fddc.png">
