### PR TITLE
Reader: don't fire an error notice when stream page fetch fails

### DIFF
--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -3,8 +3,7 @@
 /**
  * External dependencies
  */
-import { random, map, includes, get } from 'lodash';
-import { translate } from 'i18n-calypso';
+import { random, map, includes, get, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,7 +13,6 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import warn from 'lib/warn';
 import { READER_STREAMS_PAGE_REQUEST } from 'state/action-types';
 import { receivePage, receiveUpdates } from 'state/reader/streams/actions';
-import { errorNotice } from 'state/notices/actions';
 import { receivePosts } from 'state/reader/posts/actions';
 import { keyForPost } from 'reader/post-key';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -242,17 +240,12 @@ export function handlePage( action, data ) {
 	return actions;
 }
 
-export function handleError( action, err ) {
-	warn( 'Could not fetch next page of posts:', action, err );
-	return errorNotice( translate( 'Could not fetch the next page of posts' ) );
-}
-
 export default {
 	[ READER_STREAMS_PAGE_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: requestPage,
 			onSuccess: handlePage,
-			onError: handleError,
+			onError: noop,
 		} ),
 	],
 };

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -8,13 +8,12 @@ import deepfreeze from 'deep-freeze';
  * Internal Dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { requestPage, handlePage, handleError, INITIAL_FETCH, PER_FETCH, QUERY_META } from '../';
+import { requestPage, handlePage, INITIAL_FETCH, PER_FETCH, QUERY_META } from '../';
 import {
 	requestPage as requestPageAction,
 	receivePage,
 	receiveUpdates,
 } from 'state/reader/streams/actions';
-import { errorNotice } from 'state/notices/actions';
 
 jest.mock( 'lib/analytics', () => ( {
 	tracks: { recordEvent: jest.fn() },
@@ -240,16 +239,6 @@ describe( 'streams', () => {
 					pageHandle: { before: '2018' },
 				} ),
 			] );
-		} );
-	} );
-
-	describe( 'handleError', () => {
-		const error = { error: true };
-
-		it( 'should dispatch a notice about the error', () => {
-			const notice = errorNotice( 'Could not fetch the next page of posts' );
-			delete notice.notice.noticeId;
-			expect( handleError( action, error ) ).toMatchObject( notice );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #25420.

If we've been unable to fetch the next stream of posts, we don't need to repeatedly alert the user about it.

### To test

Load a Reader stream (like http://calypso.localhost:3000/) and turn off your network connection. Ensure that no error notices appear. You should still see loading placeholders at the bottom of the stream to indicate that loading is being attempted.

<img width="858" alt="screen shot 2018-06-26 at 13 07 14" src="https://user-images.githubusercontent.com/17325/41883284-eb6bf946-7941-11e8-8722-b4afd106cd77.png">
