### PR TITLE
Simplify formatting the user-selected rate since it's forced to "USD" anyway

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
@@ -28,7 +28,6 @@ import {
 	getTotalPriceBreakdown,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 import { getAllPackageDefinitions } from 'woocommerce/woocommerce-services/state/packages/selectors';
-import { getPaymentCurrencySettings } from 'woocommerce/state/sites/settings/general/selectors';
 import { getOrderShippingTotal } from 'woocommerce/lib/order-values/totals';
 import { getOrderShippingMethod } from 'woocommerce/lib/order-values';
 import { getOrder } from 'woocommerce/state/sites/orders/selectors';
@@ -93,7 +92,7 @@ const getRatesStatus = ( { retrievalInProgress, errors, available, form } ) => {
 };
 
 const showCheckoutShippingInfo = props => {
-	const { shippingMethod, shippingCost, currency, translate } = props;
+	const { shippingMethod, shippingCost, translate } = props;
 
 	if ( shippingMethod ) {
 		let shippingInfo;
@@ -108,7 +107,7 @@ const showCheckoutShippingInfo = props => {
 						),
 						shippingCost: (
 							<span className="rates-step__shipping-info-cost">
-								{ formatCurrency( shippingCost, currency ) }
+								{ formatCurrency( shippingCost, 'USD' ) }
 							</span>
 						),
 					},
@@ -198,7 +197,6 @@ const mapStateToProps = ( state, { orderId, siteId } ) => {
 		errors: loaded && getFormErrors( state, orderId, siteId ).rates,
 		ratesTotal: priceBreakdown ? priceBreakdown.total : 0,
 		allPackages: getAllPackageDefinitions( state, siteId ),
-		currency: getPaymentCurrencySettings( state, siteId ),
 		shippingCost: getOrderShippingTotal( order ),
 		shippingMethod: getOrderShippingMethod( order ),
 	};


### PR DESCRIPTION
In the `Rates` step of the `Purchase shipping label` flow, this string is displayed to the merchant:
> Your customer selected Priority Mail and paid $5.00

Since the shipping labels feature only works when the store currency is set to `USD`, getting the selected currency to format that price is redundant. Plus, in `WP-Admin`, the currency settings aren't fetched into the Redux state tree, so this logic doesn't work anyway (it *appears* to work because, if `currency` is not defined, `formatCurrency` defaults to `$`).

If in the future we want to support more currencies, we need to make sure that the `wc/v2/settings/general` data is fetched before starting the `Purchase Label` flow, both in `WP-Admin` and in `Calypso`.