### PR TITLE
Fixes GMB nudge view track events not fired on site switch

### DIFF
--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -32,11 +32,31 @@ class GoogleMyBusinessStatsNudge extends Component {
 		visible: PropTypes.bool,
 	};
 
+	state = {
+		siteSwitch: false,
+	};
+
 	static defaultProps = {
 		visible: true,
 	};
 
 	componentDidMount() {
+		this.recordView();
+	}
+
+	componentWillReceiveProps( newProps ) {
+		if ( this.props.siteId && newProps.siteId && this.props.siteId !== newProps.siteId ) {
+			this.setState( { siteSwitch: true } );
+			return;
+		}
+
+		if ( this.state.siteSwitch ) {
+			this.recordView();
+			this.setState( { siteSwitch: false } );
+		}
+	}
+
+	recordView() {
 		if ( this.isVisible() ) {
 			this.props.recordTracksEvent( 'calypso_google_my_business_stats_nudge_view' );
 		}

--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -34,6 +34,7 @@ class GoogleMyBusinessStatsNudge extends Component {
 
 	state = {
 		siteSwitch: false,
+		siteId: null,
 	};
 
 	static defaultProps = {
@@ -44,15 +45,24 @@ class GoogleMyBusinessStatsNudge extends Component {
 		this.recordView();
 	}
 
-	componentWillReceiveProps( newProps ) {
-		if ( this.props.siteId && newProps.siteId && this.props.siteId !== newProps.siteId ) {
-			this.setState( { siteSwitch: true } );
-			return;
+	static getDerivedStateFromProps( props, state ) {
+		if ( props.siteId !== state.siteId ) {
+			return {
+				siteId: props.siteId,
+				siteSwitch: !! ( state.siteId && props.siteId ),
+			};
 		}
 
+		if ( state.siteSwitch ) {
+			return {
+				siteSwitch: false,
+			};
+		}
+	}
+
+	componentDidUpdate() {
 		if ( this.state.siteSwitch ) {
 			this.recordView();
-			this.setState( { siteSwitch: false } );
 		}
 	}
 

--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -32,11 +32,6 @@ class GoogleMyBusinessStatsNudge extends Component {
 		visible: PropTypes.bool,
 	};
 
-	state = {
-		siteSwitch: false,
-		siteId: null,
-	};
-
 	static defaultProps = {
 		visible: true,
 	};
@@ -45,23 +40,8 @@ class GoogleMyBusinessStatsNudge extends Component {
 		this.recordView();
 	}
 
-	static getDerivedStateFromProps( props, state ) {
-		if ( props.siteId !== state.siteId ) {
-			return {
-				siteId: props.siteId,
-				siteSwitch: !! ( state.siteId && props.siteId ),
-			};
-		}
-
-		if ( state.siteSwitch ) {
-			return {
-				siteSwitch: false,
-			};
-		}
-	}
-
-	componentDidUpdate() {
-		if ( this.state.siteSwitch ) {
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.siteId && this.props.siteId && this.props.siteId !== prevProps.siteId ) {
 			this.recordView();
 		}
 	}


### PR DESCRIPTION
This fires the `calypso_google_my_business_stats_nudge_view` event on site switch.

### Testing Instructions
- Boot this branch locally
- Log analytics events in the console: localStorage.debug = 'calypso:analytics:*';
- Go to the stats page for a site that is eligible for Google My Business
- Ensure you see the `calypso_google_my_business_stats_nudge_view` event fired on page load
- Switch to a site that is not eligible for GMB
- Ensure you do not see the `calypso_google_my_business_stats_nudge_view` event
- Switch to another site that is eligible for GMB
- Ensure you see the `calypso_google_my_business_stats_nudge_view` event


### Reviews
- [ ] Code
- [ ] Product