### PR TITLE
Settings: Allow Jetpack plan owner to be changed to another user

### DIFF
--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -15,10 +15,9 @@ import { includes } from 'lodash';
 import accept from 'lib/accept';
 import AuthorSelector from 'blocks/author-selector';
 import Card from 'components/card';
-import CompactCard from 'components/card/compact';
 import config from 'config';
 import FormFieldset from 'components/forms/form-fieldset';
-import FormLegend from 'components/forms/form-legend';
+import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Gravatar from 'components/gravatar';
 import isJetpackSiteConnected from 'state/selectors/is-jetpack-site-connected';
@@ -209,26 +208,21 @@ class SiteOwnership extends Component {
 	renderCardContent() {
 		const { isPaidPlan, translate } = this.props;
 		const showPlanSection = config.isEnabled( 'jetpack/ownership-change' ) && isPaidPlan;
-		const ConnectionCardComponent = showPlanSection ? CompactCard : Card;
 
 		return (
-			<Fragment>
-				<ConnectionCardComponent>
-					<FormFieldset>
-						<FormLegend>{ translate( 'Site owner' ) }</FormLegend>
-						{ this.renderConnectionDetails() }
-					</FormFieldset>
-				</ConnectionCardComponent>
+			<Card>
+				<FormFieldset className="manage-connection__formfieldset">
+					<FormLabel>{ translate( 'Site owner' ) }</FormLabel>
+					{ this.renderConnectionDetails() }
+				</FormFieldset>
 
 				{ showPlanSection && (
-					<Card>
-						<FormFieldset>
-							<FormLegend>{ translate( 'Plan purchaser' ) }</FormLegend>
-							{ this.renderPlanDetails() }
-						</FormFieldset>
-					</Card>
+					<FormFieldset className="manage-connection__formfieldset has-divider is-top-only">
+						<FormLabel>{ translate( 'Plan purchaser' ) }</FormLabel>
+						{ this.renderPlanDetails() }
+					</FormFieldset>
 				) }
-			</Fragment>
+			</Card>
 		);
 	}
 

--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -191,16 +191,12 @@ class SiteOwnership extends Component {
 			return;
 		}
 
-		return (
-			<Fragment>
-				{ isCurrentPlanOwner ? (
-					this.renderPlanOwnerDropdown()
-				) : (
-					<FormSettingExplanation>
-						{ translate( 'Somebody else is the plan purchaser for this site.' ) }
-					</FormSettingExplanation>
-				) }
-			</Fragment>
+		return isCurrentPlanOwner ? (
+			this.renderPlanOwnerDropdown()
+		) : (
+			<FormSettingExplanation>
+				{ translate( 'Somebody else is the plan purchaser for this site.' ) }
+			</FormSettingExplanation>
 		);
 	}
 

--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -91,7 +91,7 @@ class SiteOwnership extends Component {
 			),
 			accepted => {
 				if ( accepted ) {
-					this.props.transferPlanOwnership( this.props.siteId, user.ID );
+					this.props.transferPlanOwnership( this.props.siteId, user.linked_user_ID );
 					this.props.recordTracksEvent( 'calypso_jetpack_plan_ownership_changed' );
 				}
 			},
@@ -176,7 +176,6 @@ class SiteOwnership extends Component {
 				<AuthorSelector
 					siteId={ siteId }
 					exclude={ this.isUserExcludedFromSelector }
-					transformAuthor={ this.transformUser }
 					allowSingleUser
 					onSelect={ this.onSelectPlanOwner }
 				>

--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -56,7 +56,7 @@ class SiteOwnership extends Component {
 		return { ...user.linked_user_info, ...{ ID: user.ID } };
 	}
 
-	onSelect = user => {
+	onSelectConnectionOwner = user => {
 		const { translate } = this.props;
 
 		accept(
@@ -105,7 +105,7 @@ class SiteOwnership extends Component {
 					exclude={ this.isUserExcludedFromSelector }
 					transformAuthor={ this.transformUser }
 					allowSingleUser
-					onSelect={ this.onSelect }
+					onSelect={ this.onSelectConnectionOwner }
 				>
 					{ this.renderCurrentUser() }
 				</AuthorSelector>

--- a/client/state/data-layer/wpcom/sites/plan-transfer/index.js
+++ b/client/state/data-layer/wpcom/sites/plan-transfer/index.js
@@ -11,6 +11,7 @@ import { translate } from 'i18n-calypso';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import { refreshSitePlans } from 'state/sites/plans/actions';
 import { SITE_PLAN_OWNERSHIP_TRANSFER } from 'state/action-types';
 
 const noticeOptions = siteId => ( {
@@ -43,11 +44,13 @@ export const requestPlanOwnershipTransfer = action =>
  * @param   {Object} action Redux action
  * @returns {Object} Success notice action
  */
-export const handleTransferSuccess = ( { siteId } ) =>
+export const handleTransferSuccess = ( { siteId } ) => [
 	successNotice(
 		translate( 'Plan purchaser has been changed successfully.' ),
 		noticeOptions( siteId )
-	);
+	),
+	refreshSitePlans( siteId ),
+];
 
 /**
  * Dispatches an error notice when the request failed.

--- a/client/state/data-layer/wpcom/sites/plan-transfer/test/index.js
+++ b/client/state/data-layer/wpcom/sites/plan-transfer/test/index.js
@@ -33,15 +33,17 @@ describe( 'requestPlanOwnershipTransfer()', () => {
 } );
 
 describe( 'handleTransferSuccess()', () => {
-	test( 'should return a success notice action', () => {
-		const action = handleTransferSuccess( { siteId } );
+	test( 'should return a success notice action and a function', () => {
+		const actions = handleTransferSuccess( { siteId } );
 
-		expect( action ).toMatchObject(
+		expect( actions ).toHaveLength( 2 );
+		expect( actions[ 0 ] ).toMatchObject(
 			successNotice( 'Plan purchaser has been changed successfully.', {
 				duration: 8000,
 				id: `sites-plan-transfer-notice-${ siteId }`,
 			} )
 		);
+		expect( actions[ 1 ] ).toBeInstanceOf( Function );
 	} );
 } );
 


### PR DESCRIPTION
This PR introduces the interface for transferring a Jetpack plan to another user. Only a connected admin, who is the owner of the Jetpack plan can transfer a plan to another user; also plans can be transferred only to other Jetpack-connected administrator users of that site.

The new interface is part of the Manage Connection page, and appears right under the field to transfer the connection to another user:

![](https://cldup.com/ti7KqfQx6n.png)

Clicking the field will show all other admin users in that site, who are connected to Jetpack:

![](https://cldup.com/i3OPSM9NzB.png)

Selecting a user from the dropdown will display a confirmation window:

![](https://cldup.com/813QtGwool.png)

Clicking "Cancel" brings the user back to the same state they were before selecting a different user. Clicking the "Yes" button will transfer the plan, and upon success the user will see a success message:

![](https://cldup.com/l5MUEIlb2I.png)

A user who isn't the current plan owner will see the following message in this section:

![](https://cldup.com/LDWZxmaEJM.png)

If you're the only connected admin in the site, you'll not see a dropdown to change the plan purchaser:

![](https://cldup.com/X_rE973ZkL.png)

FWIW, this is under a feature flag, so anyone who tries to access the connection management page with this feature disabled, will not see any of the new UI:

![](https://cldup.com/8otfb6kWk2.png)

Fixes #24090.

To test:
* Checkout this branch.
* Login to WP.com and make sure you have a connected Jetpack site where you're the plan purchaser.
* Go to http://calypso.localhost:3000/settings/manage-connection/:site, where `:site` is your Jetpack site.
* Select another connected admin user from the dropdown.
* Click the cancel button from the confirmation window, verify you're taken back to where you were.
* Select the user again.
* Confirm the transfer by pressing the "Yes.." button.
* Verify the transfer actually happens, you can see a success message and you can see the updated plan owner area, saying that someone else is now the plan purchaser.
* Test as a connected admin that's not the owner, verify you can see the message saying that someone else is the plan purchaser.
* Try testing with the feature flag disabled (by adding `?flags=-jetpack/ownership-change` to the URL), verify you don't see this new UI
* Test with a site where you're the only connected admin; verify you can see yourself as the owner, but there is no dropdown to change the owner.
