### PR TITLE
Post Editor: improve how post edits are merged after publish date reset

### DIFF
--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -500,36 +500,20 @@ export function edits( state = {}, action ) {
 			} );
 
 		case POST_SAVE_SUCCESS:
-			if ( ! state.hasOwnProperty( action.siteId ) || ! action.savedPost ) {
+			if ( ! state.hasOwnProperty( action.siteId ) || ! action.savedPost || action.postId ) {
 				break;
 			}
 			const { siteId, savedPost } = action;
 
-			if ( ! action.postId ) {
-				// a new post (edited with a transient postId of '') has been just saved and assigned
-				// a real numeric ID. Rewrite the state key with the new postId.
-				return {
-					...state,
-					[ siteId ]: mapKeys(
-						state[ siteId ],
-						( value, key ) => ( '' === key ? savedPost.ID : key )
-					),
-				};
-			} else if ( state[ siteId ].hasOwnProperty( action.postId ) ) {
-				// a draft saved with a date of `false` resets the publish date via the api
-				// thus the `date` should no longer be treated as dirty.
-				const dateEdits = get( state, [ action.siteId, action.postId ] );
-				if ( ! dateEdits || false !== dateEdits.date ) {
-					break;
-				}
-				return {
-					...state,
-					[ siteId ]: {
-						...state[ siteId ],
-						[ action.postId ]: omit( dateEdits, 'date' ),
-					},
-				};
-			}
+			// a new post (edited with a transient postId of '') has been just saved and assigned
+			// a real numeric ID. Rewrite the state key with the new postId.
+			return {
+				...state,
+				[ siteId ]: mapKeys(
+					state[ siteId ],
+					( value, key ) => ( '' === key ? savedPost.ID : key )
+				),
+			};
 	}
 
 	return state;

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -1356,6 +1356,38 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		test( 'should consider date not edited after resetting draft date', () => {
+			const state = edits(
+				deepFreeze( {
+					2916284: {
+						842: {
+							title: 'I like turtles',
+							date: false,
+						},
+					},
+				} ),
+				{
+					type: POSTS_RECEIVE,
+					posts: [
+						{
+							ID: 842,
+							site_ID: 2916284,
+							title: 'I like turtles!',
+							date: '2018-06-14T16:47:21+00:00',
+						},
+					],
+				}
+			);
+
+			expect( state ).to.eql( {
+				2916284: {
+					842: {
+						title: 'I like turtles',
+					},
+				},
+			} );
+		} );
+
 		test( 'should remove status edits after they are saved', () => {
 			const emptyEditsState = {
 				2916284: {
@@ -1437,34 +1469,6 @@ describe( 'reducer', () => {
 					841: {
 						title: 'Ribs & Chicken',
 					},
-					842: {
-						title: 'I like turtles',
-					},
-				},
-			} );
-		} );
-
-		test( 'should consider date not edited after resetting draft date', () => {
-			const original = deepFreeze( {
-				2916284: {
-					842: {
-						title: 'I like turtles',
-						date: false,
-					},
-				},
-			} );
-			const state = edits( original, {
-				type: POST_SAVE_SUCCESS,
-				siteId: 2916284,
-				postId: 842,
-				savedPost: {
-					ID: 842,
-					title: 'I like turtles',
-					date: '2018-06-14T16:47:21+00:00',
-				},
-			} );
-			expect( state ).to.eql( {
-				2916284: {
 					842: {
 						title: 'I like turtles',
 					},

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -383,6 +383,13 @@ export function isAuthorEqual( localAuthorEdit, savedAuthor ) {
 }
 
 export function isDateEqual( localDateEdit, savedDate ) {
+	// if the local date edit is false, it means we are asking the server to reset
+	// the scheduled date to "now". In that case, we accept the date value returned
+	// by the server and consider the edit saved.
+	if ( localDateEdit === false ) {
+		return true;
+	}
+
 	return localDateEdit && moment( localDateEdit ).isSame( savedDate );
 }
 


### PR DESCRIPTION
This PR iterates on #25422 by improving the way how local date edits are removed after receiving updated post from server.

Many post attributes already have nontrivial (i.e., it's not a simple `===` value comparison) logic to compare incoming post update with local edits and decide if the edits are applied or not.

#25422 does the check for `edits.date === false` special case in the `edits` reducer for `POST_SAVE_SUCCESS` action. This PR moves it to the reducer for `POSTS_RECEIVE`
action, where all the other comparisons are done.

There should be no change in functionality.