### PR TITLE
Signup: Reversing the minimized free plan test

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -463,7 +463,6 @@ class Signup extends React.Component {
 	}
 
 	renderCurrentStep() {
-		const userIsLoggedIn = this.props.isLoggedIn;
 		const domainItem = get( this.props, 'signupDependencies.domainItem', false );
 		const currentStepProgress = find( this.state.progress, { stepName: this.props.stepName } ),
 			CurrentComponent = stepComponents[ this.props.stepName ],
@@ -471,7 +470,6 @@ class Signup extends React.Component {
 			stepKey = this.state.loadingScreenStartTime ? 'processing' : this.props.stepName,
 			flow = flows.getFlow( this.props.flowName ),
 			hideFreePlan = !! (
-				! userIsLoggedIn ||
 				this.state.plans ||
 				( ( isDomainRegistration( domainItem ) ||
 					isDomainTransfer( domainItem ) ||


### PR DESCRIPTION
This PR will remove the minimized free plan in signup. Because the related code has been changed a lot since the test landed, I try to keep the changes small to avoid side effects.

See p9jf6J-Dq-p2 for more detail.

Related PRs: #23489 #23406 #23113

## How to test

Follow the signup flow. No matter you're logged in or not, the free plan column should show up.

<img width="1110" alt="_2018-06-25_ _10_45_44" src="https://user-images.githubusercontent.com/212034/41854093-4ebfbf46-78ca-11e8-9666-3ef25fda6a9a.png">


