### PR TITLE
Framework: `dispatchRequest` update (account recovery reset)

### DIFF
--- a/client/state/data-layer/wpcom/account-recovery/reset/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/reset/index.js
@@ -1,59 +1,43 @@
 /** @format */
-
 /**
  * Internal dependencies
  */
-
 import {
 	ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST,
 	ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_SUCCESS,
 	ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_ERROR,
 } from 'state/action-types';
 
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
-export const resetPassword = ( { dispatch }, action ) => {
-	const {
-		userData, // userData can be either { user } or { firstname, lastname, url }
-		method,
-		key,
-		password,
-	} = action;
-
-	dispatch(
-		http(
-			{
-				method: 'POST',
-				apiNamespace: 'wpcom/v2',
-				path: '/account-recovery/reset',
-				body: {
-					...userData,
-					method,
-					key,
-					password,
-				},
+export const fetch = action =>
+	http(
+		{
+			method: 'POST',
+			apiNamespace: 'wpcom/v2',
+			path: '/account-recovery/reset',
+			body: {
+				...action.userData,
+				method: action.method,
+				key: action.key,
+				password: action.password,
 			},
-			action
-		)
+		},
+		action
 	);
-};
 
-export const handleError = ( { dispatch }, action, rawError ) => {
-	dispatch( {
-		type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_ERROR,
-		error: rawError.message,
-	} );
-};
+export const onError = ( action, rawError ) => ( {
+	type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_ERROR,
+	error: rawError.message,
+} );
 
-export const handleSuccess = ( { dispatch } ) => {
-	dispatch( {
-		type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_SUCCESS,
-	} );
-};
+export const onSuccess = () => ( {
+	type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_SUCCESS,
+} );
 
 export default {
 	[ ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST ]: [
-		dispatchRequest( resetPassword, handleSuccess, handleError ),
+		dispatchRequestEx( { fetch, onSuccess, onError } ),
 	],
 };

--- a/client/state/data-layer/wpcom/account-recovery/reset/test/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/reset/test/index.js
@@ -1,15 +1,8 @@
 /** @format */
-
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-import { spy } from 'sinon';
-
 /**
  * Internal dependencies
  */
-import { resetPassword, handleError, handleSuccess } from '../';
+import { fetch, onError, onSuccess } from '../';
 import {
 	ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_SUCCESS,
 	ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_ERROR,
@@ -20,7 +13,6 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 describe( 'account-recovery/reset', () => {
 	describe( '#handleResetPasswordRequest', () => {
 		test( 'should dispatch HTTP request to account recovery reset endpoint', () => {
-			const dispatchSpy = spy();
 			const dummyAction = {
 				userData: {
 					user: 'foo',
@@ -30,11 +22,8 @@ describe( 'account-recovery/reset', () => {
 				password: 'my-new-password-which-I-cannot-remember',
 			};
 
-			resetPassword( { dispatch: dispatchSpy }, dummyAction );
-
 			const { userData, method, key, password } = dummyAction;
-			expect( dispatchSpy ).to.have.been.calledOnce;
-			expect( dispatchSpy ).to.have.been.calledWith(
+			expect( fetch( dummyAction ) ).toEqual(
 				http(
 					{
 						method: 'POST',
@@ -55,13 +44,10 @@ describe( 'account-recovery/reset', () => {
 
 	describe( '#requestResetPasswordError', () => {
 		test( 'should dispatch failure action with error message', () => {
-			const dispatchSpy = spy();
 			const message = 'This is an error message.';
 			const rawError = Error( message );
 
-			handleError( { dispatch: dispatchSpy }, null, rawError );
-
-			expect( dispatchSpy ).to.have.been.calledWith( {
+			expect( onError( null, rawError ) ).toEqual( {
 				type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_ERROR,
 				error: message,
 			} );
@@ -70,11 +56,7 @@ describe( 'account-recovery/reset', () => {
 
 	describe( '#requestResetPasswordSuccess', () => {
 		test( 'should dispatch success action', () => {
-			const dispatchSpy = spy();
-
-			handleSuccess( { dispatch: dispatchSpy } );
-
-			expect( dispatchSpy ).to.have.been.calledWith( {
+			expect( onSuccess() ).toEqual( {
 				type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_SUCCESS,
 			} );
 		} );


### PR DESCRIPTION
See #25121

In this patch we're replacing the use of dispatchRequest()
in the data layer handler to use the newer API exposed
as dispatchRequestEx() This should have no change in
actual effect or interaction.