### PR TITLE
Framework: `dispatchRequest` update (account recovery validate)

### DIFF
--- a/client/state/data-layer/wpcom/account-recovery/validate/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/validate/index.js
@@ -1,52 +1,37 @@
 /** @format */
-
 /**
  * Internal dependencies
  */
-
 import { ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST } from 'state/action-types';
 import {
 	validateRequestSuccess,
 	validateRequestError,
 	setValidationKey,
 } from 'state/account-recovery/reset/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
-export const handleValidateRequest = ( { dispatch }, action ) => {
-	const { userData, method, key } = action;
-	dispatch(
-		http(
-			{
-				method: 'POST',
-				apiNamespace: 'wpcom/v2',
-				path: '/account-recovery/validate',
-				body: {
-					...userData,
-					method,
-					key,
-				},
+export const fetch = action =>
+	http(
+		{
+			method: 'POST',
+			apiNamespace: 'wpcom/v2',
+			path: '/account-recovery/validate',
+			body: {
+				...action.userData,
+				method: action.method,
+				key: action.key,
 			},
-			action
-		)
+		},
+		action
 	);
-};
 
-export const handleValidateRequestSuccess = ( { dispatch }, { key } ) => {
-	dispatch( validateRequestSuccess() );
-	dispatch( setValidationKey( key ) );
-};
+export const onSuccess = ( { key } ) => [ validateRequestSuccess(), setValidationKey( key ) ];
 
-export const handleValidateRequestFailure = ( { dispatch }, action, response ) => {
-	dispatch( validateRequestError( response ) );
-};
+export const onError = ( action, response ) => validateRequestError( response );
 
 export default {
 	[ ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST ]: [
-		dispatchRequest(
-			handleValidateRequest,
-			handleValidateRequestSuccess,
-			handleValidateRequestFailure
-		),
+		dispatchRequestEx( { fetch, onSuccess, onError } ),
 	],
 };

--- a/client/state/data-layer/wpcom/account-recovery/validate/test/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/validate/test/index.js
@@ -1,19 +1,8 @@
 /** @format */
-
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-import { spy } from 'sinon';
-
 /**
  * Internal dependencies
  */
-import {
-	handleValidateRequest,
-	handleValidateRequestSuccess,
-	handleValidateRequestFailure,
-} from '../';
+import { fetch, onSuccess, onError } from '../';
 import {
 	validateRequestSuccess,
 	validateRequestError,
@@ -24,7 +13,6 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 describe( 'handleValidateRequest()', () => {
 	describe( 'success', () => {
 		test( 'should dispatch SUCCESS action on success', () => {
-			const dispatch = spy();
 			const action = {
 				type: 'DUMMY_ACTION',
 				userData: { user: 'foo' },
@@ -33,10 +21,7 @@ describe( 'handleValidateRequest()', () => {
 			};
 			const { userData, method, key } = action;
 
-			handleValidateRequest( { dispatch }, action );
-
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith(
+			expect( fetch( action ) ).toEqual(
 				http(
 					{
 						method: 'POST',
@@ -54,7 +39,6 @@ describe( 'handleValidateRequest()', () => {
 		} );
 
 		test( 'should dispatch SET_VALIDATION_KEY action on success', () => {
-			const dispatch = spy();
 			const action = {
 				type: 'DUMMY_ACTION',
 				userData: { user: 'foo' },
@@ -62,19 +46,14 @@ describe( 'handleValidateRequest()', () => {
 				key: 'a-super-secret-key',
 			};
 
-			handleValidateRequestSuccess( { dispatch }, action );
-
-			expect( dispatch ).to.have.been.calledWith( validateRequestSuccess() );
-			expect( dispatch ).to.have.been.calledWith( setValidationKey( action.key ) );
+			expect( onSuccess( action ) ).toEqual(
+				expect.arrayContaining( [ validateRequestSuccess(), setValidationKey( action.key ) ] )
+			);
 		} );
 
 		test( 'should dispatch ERROR action on failure', () => {
-			const dispatch = spy();
 			const error = 'something bad happened';
-			handleValidateRequestFailure( { dispatch }, {}, error );
-
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith( validateRequestError( error ) );
+			expect( onError( {}, error ) ).toEqual( validateRequestError( error ) );
 		} );
 	} );
 } );


### PR DESCRIPTION
See #25121

In this patch we're replacing the use of dispatchRequest()
in the data layer handler to use the newer API exposed
as dispatchRequestEx() This should have no change in
actual effect or interaction.