### PR TITLE
Activity Log: don't dismiss all updates after completing one

### DIFF
--- a/client/my-sites/stats/activity-log-tasklist/index.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/index.jsx
@@ -281,7 +281,7 @@ class ActivityLogTasklist extends Component {
 							duration: 3000,
 						}
 					);
-					this.dismiss( slug );
+					this.dismiss( item );
 					this.dequeue();
 					break;
 			}


### PR DESCRIPTION
Fixes an issue that started happening after a refactoring in #25503

This PR fixes an issue where when there are many updates, successfully completing one dismisses all other updates.

I'll merge this as soon as tests pass since it's a bad issue and the fix is very clear and straightforward.

Props @dereksmart for reporting this.