### PR TITLE
Popover: adds documentation for Popover component when used inside a dialog

### DIFF
--- a/client/components/popover/README.md
+++ b/client/components/popover/README.md
@@ -99,6 +99,15 @@ is called.
 
 This function will be executed when the popover is shown.
 
+### Usage notes
+
+#### Within modals / dialogs
+
+When using a popover within a modal applying the class `is-dialog-visible` to the `Popover` component will cause it to gain the correct `z-index` to allow it to display correctly within the modal.
+
+```jsx
+<Popover className="is-dialog-visible" />
+```
 
 PopoverMenu
 ===========


### PR DESCRIPTION
Previous documentation didn’t cover usage of `Popover` within a dialog (eg: a Modal). Without the necessary class the Popover doesn’t display. Documenting this with example.