### PR TITLE
Editor Media Google Photos: album / folder dropdown selector

### DIFF
--- a/client/components/data/media-list-data/index.jsx
+++ b/client/components/data/media-list-data/index.jsx
@@ -33,6 +33,7 @@ export default class extends React.Component {
 		postId: PropTypes.number,
 		filter: PropTypes.string,
 		search: PropTypes.string,
+		folder: PropTypes.string,
 	};
 
 	state = getStateData( this.props.siteId );
@@ -78,6 +79,10 @@ export default class extends React.Component {
 		if ( props.source ) {
 			query.source = props.source;
 			query.path = 'recent';
+		}
+
+		if ( props.folder ) {
+			query.folder = props.folder;
 		}
 
 		return query;

--- a/client/components/select-dropdown/README.md
+++ b/client/components/select-dropdown/README.md
@@ -62,6 +62,10 @@ Optional extra class(es) to be applied to the `.select-dropdown`.
 
 Optional tabIndex setting to override tab order via keyboard navigation. By default this is set to `0` which simply puts the element in the tabbing flow according to the component's placement in the document.
 
+`disabled`
+
+Used to determine whether the select dropdown is in a disabled state. When disabled it will not respond to interaction and will render to appear disabled.
+
 #### Dropdown Item
 
 `selected`

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -35,6 +35,7 @@ class SelectDropdown extends Component {
 		onToggle: PropTypes.func,
 		focusSibling: PropTypes.func,
 		tabIndex: PropTypes.number,
+		disabled: PropTypes.bool,
 		options: PropTypes.arrayOf(
 			PropTypes.shape( {
 				value: PropTypes.string.isRequired,
@@ -226,6 +227,7 @@ class SelectDropdown extends Component {
 			'select-dropdown': true,
 			'is-compact': this.props.compact,
 			'is-open': this.state.isOpen,
+			'is-disabled': this.props.disabled,
 			'has-count': 'number' === typeof this.props.selectedCount,
 		} );
 
@@ -243,6 +245,7 @@ class SelectDropdown extends Component {
 					aria-owns={ 'select-submenu-' + this.state.instanceId }
 					aria-controls={ 'select-submenu-' + this.state.instanceId }
 					aria-expanded={ this.state.isOpen }
+					aria-disabled={ this.props.disabled }
 					data-tip-target={ this.props.tipTarget }
 					onClick={ this.toggleDropdown }
 				>
@@ -275,6 +278,7 @@ class SelectDropdown extends Component {
 	}
 
 	toggleDropdown() {
+		if ( this.props && this.props.disabled ) return;
 		this.setState( {
 			isOpen: ! this.state.isOpen,
 		} );

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -8,14 +8,14 @@ $side-margin: 16;
 $compact-header-height: 35;
 
 .select-dropdown {
-	height: #{ $header-height }px;
+	height: #{$header-height}px;
 
 	&.is-open {
 		overflow: visible;
 	}
 
 	&.is-compact {
-		height: #{ $compact-header-height }px;
+		height: #{$compact-header-height}px;
 	}
 }
 
@@ -30,7 +30,10 @@ $compact-header-height: 35;
 
 	.accessible-focus &:focus,
 	.accessible-focus .select-dropdown.is-open & {
-		z-index: z-index( 'root', '.accessible-focus .select-dropdown.is-open .select-dropdown__container' );
+		z-index: z-index(
+			'root',
+			'.accessible-focus .select-dropdown.is-open .select-dropdown__container'
+		);
 		.select-dropdown__header {
 			border-color: $blue-wordpress;
 		}
@@ -51,9 +54,9 @@ $compact-header-height: 35;
 }
 
 .select-dropdown__header {
-	height: #{ $header-height }px;
-	line-height: #{ $header-height - 3 }px;
-	padding: 0 #{ $side-margin }px 0 #{ $side-margin }px;
+	height: #{$header-height}px;
+	line-height: #{$header-height - 3}px;
+	padding: 0 #{$side-margin}px 0 #{$side-margin}px;
 	box-sizing: border-box;
 	display: flex;
 	justify-content: space-between;
@@ -76,18 +79,34 @@ $compact-header-height: 35;
 		margin: 0;
 		flex-shrink: 0;
 		transition: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
+
+		.is-disabled & {
+			fill: $gray-lighten-30;
+		}
 	}
 
 	.is-compact & {
-		height: #{$compact-header-height }px;
-		line-height: #{$compact-header-height - 3 }px;
-		padding-right: #{ $side-margin / 2 }px;
+		height: #{$compact-header-height}px;
+		line-height: #{$compact-header-height - 3}px;
+		padding-right: #{$side-margin / 2}px;
 		font-size: 12px;
 
 		.count {
 			border-width: 0;
 			right: 25px;
-			top: #{ ( $compact-header-height - 18 ) / 2 }px;
+			top: #{( $compact-header-height - 18 ) / 2}px;
+		}
+	}
+
+	.is-disabled & {
+		color: $gray-lighten-30;
+		background: $white;
+		border-color: $gray-lighten-30;
+		cursor: default;
+
+		&:active,
+		&.is-active {
+			border-width: 1px 1px 2px;
 		}
 	}
 
@@ -101,14 +120,14 @@ $compact-header-height: 35;
 		}
 	}
 
-	.accessible-focus .select-dropdown:not(.is-open) .select-dropdown__container:focus & {
+	.accessible-focus .select-dropdown:not( .is-open ) .select-dropdown__container:focus & {
 		box-shadow: 0 0 0 2px $blue-light;
 	}
 
 	.count {
 		position: absolute;
 		right: 40px;
-		top: #{ ( $header-height - 18 - 2 ) / 2 }px;
+		top: #{( $header-height - 18 - 2 ) / 2}px;
 	}
 }
 
@@ -123,7 +142,7 @@ $compact-header-height: 35;
 	}
 
 	.gridicon {
-		margin-right: #{ ( $side-margin / 2 ) }px;
+		margin-right: #{( $side-margin / 2 )}px;
 		vertical-align: text-bottom;
 
 		.is-compact & {
@@ -160,7 +179,7 @@ $compact-header-height: 35;
 }
 
 .select-dropdown__option {
-	height: #{ $option-height }px;
+	height: #{$option-height}px;
 
 	&:last-child .select-dropdown__item {
 		border-radius: 0 0 4px 4px;
@@ -170,9 +189,9 @@ $compact-header-height: 35;
 .select-dropdown__item {
 	display: block;
 	position: relative;
-	height: #{ $option-height }px;
-	line-height: #{ $option-height }px;
-	padding: 0 #{ $side-margin + 46 }px 0 #{ $side-margin }px;
+	height: #{$option-height}px;
+	line-height: #{$option-height}px;
+	padding: 0 #{$side-margin + 46}px 0 #{$side-margin}px;
 
 	color: $gray-dark;
 	font-size: 14px;
@@ -207,7 +226,7 @@ $compact-header-height: 35;
 		background-color: $white;
 		color: $gray;
 		cursor: default;
-		opacity: .5;
+		opacity: 0.5;
 	}
 
 	.notouch & {
@@ -222,7 +241,7 @@ $compact-header-height: 35;
 	}
 
 	.gridicon {
-		margin-right: #{ ( $side-margin / 2 ) }px;
+		margin-right: #{( $side-margin / 2 )}px;
 		vertical-align: text-bottom;
 	}
 }
@@ -235,8 +254,8 @@ $compact-header-height: 35;
 
 	.count {
 		position: absolute;
-			top: #{ ( $option-height - 18 ) / 2 }px;
-			right: #{ $side-margin }px;
+		top: #{( $option-height - 18 ) / 2}px;
+		right: #{$side-margin}px;
 	}
 }
 
@@ -248,8 +267,8 @@ $compact-header-height: 35;
 	display: inline-block;
 	max-width: 100%;
 	position: absolute;
-		left: #{ $side-margin }px;
-		right: #{ $side-margin }px;
+	left: #{$side-margin}px;
+	right: #{$side-margin}px;
 }
 
 .select-dropdown__separator {
@@ -265,6 +284,6 @@ $compact-header-height: 35;
 
 	label {
 		font-size: 12px;
-		padding: 0px #{ $side-margin }px;
+		padding: 0px #{$side-margin}px;
 	}
 }

--- a/client/components/select-dropdown/test/index.js
+++ b/client/components/select-dropdown/test/index.js
@@ -51,6 +51,31 @@ describe( 'index', () => {
 			toggleDropdownStub.restore();
 		} );
 
+		test( 'should not respond when clicked when disabled', () => {
+			const toggleDropdownSpy = sinon.spy( SelectDropdown.prototype, 'toggleDropdown' );
+
+			const dropdown = shallowRenderDropdown( {
+				disabled: true,
+			} );
+
+			expect( dropdown.find( '.select-dropdown.is-disabled' ) ).to.have.lengthOf( 1 );
+
+			dropdown.find( '.select-dropdown__container' ).simulate( 'click' );
+
+			sinon.assert.called( toggleDropdownSpy );
+
+			expect( dropdown.find( '.select-dropdown.is-open' ) ).to.be.empty;
+
+			// Repeat to be sure
+			dropdown.find( '.select-dropdown__container' ).simulate( 'click' );
+
+			sinon.assert.called( toggleDropdownSpy );
+
+			expect( dropdown.find( '.select-dropdown.is-open' ) ).to.be.empty;
+
+			toggleDropdownSpy.restore();
+		} );
+
 		test( 'should be possible to control the dropdown via keyboard', () => {
 			const navigateItemStub = sinon.stub( SelectDropdown.prototype, 'navigateItem' );
 
@@ -134,6 +159,30 @@ describe( 'index', () => {
 			sinon.assert.calledWith( setStateStub, { selected: newSelectedOption.value } );
 
 			setStateStub.restore();
+		} );
+	} );
+
+	describe( 'disabled', () => {
+		test( 'should ignore all toggling when disabled', () => {
+			function runToggleDropdownTest( isCurrentlyOpen ) {
+				const setStateSpy = sinon.spy();
+				const fakeContext = {
+					setState: setStateSpy,
+					props: {
+						disabled: true,
+					},
+					state: {
+						isOpen: isCurrentlyOpen,
+					},
+				};
+
+				SelectDropdown.prototype.toggleDropdown.call( fakeContext );
+
+				sinon.assert.notCalled( setStateSpy );
+			}
+
+			runToggleDropdownTest( true );
+			runToggleDropdownTest( false );
 		} );
 	} );
 

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -43,6 +43,7 @@ class MediaLibraryContent extends React.Component {
 		filterRequiresUpgrade: PropTypes.bool,
 		search: PropTypes.string,
 		source: PropTypes.string,
+		folder: PropTypes.string,
 		containerWidth: PropTypes.number,
 		single: PropTypes.bool,
 		scrollable: PropTypes.bool,
@@ -266,6 +267,7 @@ class MediaLibraryContent extends React.Component {
 				filter={ this.props.filter }
 				search={ this.props.search }
 				source={ this.props.source }
+				folder={ this.props.folder }
 			>
 				<MediaLibrarySelectedData siteId={ this.props.site.ID }>
 					<MediaLibraryList
@@ -299,10 +301,13 @@ class MediaLibraryContent extends React.Component {
 					canCopy={ this.props.postId === undefined }
 					source={ this.props.source }
 					onSourceChange={ this.props.onSourceChange }
+					onFolderChange={ this.props.onFolderChange }
 					selectedItems={ this.props.selectedItems }
 					sticky={ ! this.props.scrollable }
 					hasAttribution={ 'pexels' === this.props.source }
 					hasRefreshButton={ 'pexels' !== this.props.source }
+					hasDateFilters={ 'google_photos' === this.props.source }
+					hasFolders={ 'google_photos' === this.props.source }
 				/>
 			);
 		}

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -112,7 +112,13 @@ class MediaLibraryExternalHeader extends React.Component {
 		const { selectedItems, translate } = this.props;
 
 		return (
-			<Button compact disabled={ selectedItems.length === 0 } onClick={ this.onCopy } primary>
+			<Button
+				className="media-library__header-item"
+				compact
+				disabled={ selectedItems.length === 0 }
+				onClick={ this.onCopy }
+				primary
+			>
 				{ translate( 'Copy to media library' ) }
 			</Button>
 		);
@@ -144,7 +150,12 @@ class MediaLibraryExternalHeader extends React.Component {
 				{ hasAttribution && this.renderPexelsAttribution() }
 
 				{ hasRefreshButton && (
-					<Button compact disabled={ this.state.fetching } onClick={ this.handleClick }>
+					<Button
+						className="media-library__header-item"
+						compact
+						disabled={ this.state.fetching }
+						onClick={ this.handleClick }
+					>
 						<Gridicon icon="refresh" size={ 24 } />
 
 						{ translate( 'Refresh' ) }
@@ -155,6 +166,7 @@ class MediaLibraryExternalHeader extends React.Component {
 
 				{ hasFolders && (
 					<MediaFolderDropdown
+						className="media-library__header-item"
 						disabled={ this.state.fetching }
 						onFolderChange={ this.props.onFolderChange }
 					/>

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import MediaLibraryScale from './scale';
 import Card from 'components/card';
 import Button from 'components/button';
@@ -161,13 +162,14 @@ class MediaLibraryExternalHeader extends React.Component {
 
 				{ canCopy && this.renderCopyButton() }
 
-				{ hasFolders && (
-					<MediaFolderDropdown
-						className="media-library__header-item"
-						disabled={ this.state.fetching }
-						onFolderChange={ this.props.onFolderChange }
-					/>
-				) }
+				{ config.isEnabled( 'external-media/google-photos/folder-dropdown' ) &&
+					hasFolders && (
+						<MediaFolderDropdown
+							className="media-library__header-item"
+							disabled={ this.state.fetching }
+							onFolderChange={ this.props.onFolderChange }
+						/>
+					) }
 
 				<MediaLibraryScale onChange={ onMediaScaleChange } />
 			</Card>

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -153,7 +153,12 @@ class MediaLibraryExternalHeader extends React.Component {
 
 				{ canCopy && this.renderCopyButton() }
 
-				{ hasFolders && <MediaFolderDropdown onFolderChange={ this.props.onFolderChange } /> }
+				{ hasFolders && (
+					<MediaFolderDropdown
+						disabled={ this.state.fetching }
+						onFolderChange={ this.props.onFolderChange }
+					/>
+				) }
 
 				{ hasDateFilters && <MediaDateRange /> }
 

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -19,7 +19,6 @@ import Button from 'components/button';
 import MediaActions from 'lib/media/actions';
 import MediaListStore from 'lib/media/list-store';
 import StickyPanel from 'components/sticky-panel';
-import MediaDateRange from './media-date-range';
 import MediaFolderDropdown from './media-folder-dropdown';
 
 const DEBOUNCE_TIME = 250;
@@ -36,7 +35,6 @@ class MediaLibraryExternalHeader extends React.Component {
 		sticky: PropTypes.bool,
 		hasAttribution: PropTypes.bool,
 		hasRefreshButton: PropTypes.bool,
-		hasDateFilters: PropTypes.bool,
 		hasFolders: PropTypes.bool,
 	};
 
@@ -141,7 +139,6 @@ class MediaLibraryExternalHeader extends React.Component {
 			canCopy,
 			hasRefreshButton,
 			hasAttribution,
-			hasDateFilters,
 			hasFolders,
 		} = this.props;
 
@@ -171,8 +168,6 @@ class MediaLibraryExternalHeader extends React.Component {
 						onFolderChange={ this.props.onFolderChange }
 					/>
 				) }
-
-				{ hasDateFilters && <MediaDateRange /> }
 
 				<MediaLibraryScale onChange={ onMediaScaleChange } />
 			</Card>

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -19,6 +19,8 @@ import Button from 'components/button';
 import MediaActions from 'lib/media/actions';
 import MediaListStore from 'lib/media/list-store';
 import StickyPanel from 'components/sticky-panel';
+import MediaDateRange from './media-date-range';
+import MediaFolderDropdown from './media-folder-dropdown';
 
 const DEBOUNCE_TIME = 250;
 
@@ -30,9 +32,12 @@ class MediaLibraryExternalHeader extends React.Component {
 		canCopy: PropTypes.bool,
 		selectedItems: PropTypes.array,
 		onSourceChange: PropTypes.func,
+		onFolderChange: PropTypes.func,
 		sticky: PropTypes.bool,
 		hasAttribution: PropTypes.bool,
 		hasRefreshButton: PropTypes.bool,
+		hasDateFilters: PropTypes.bool,
+		hasFolders: PropTypes.bool,
 	};
 
 	constructor( props ) {
@@ -124,7 +129,15 @@ class MediaLibraryExternalHeader extends React.Component {
 	}
 
 	renderCard() {
-		const { onMediaScaleChange, translate, canCopy, hasRefreshButton, hasAttribution } = this.props;
+		const {
+			onMediaScaleChange,
+			translate,
+			canCopy,
+			hasRefreshButton,
+			hasAttribution,
+			hasDateFilters,
+			hasFolders,
+		} = this.props;
 
 		return (
 			<Card className="media-library__header">
@@ -139,6 +152,10 @@ class MediaLibraryExternalHeader extends React.Component {
 				) }
 
 				{ canCopy && this.renderCopyButton() }
+
+				{ hasFolders && <MediaFolderDropdown onFolderChange={ this.props.onFolderChange } /> }
+
+				{ hasDateFilters && <MediaDateRange /> }
 
 				<MediaLibraryScale onChange={ onMediaScaleChange } />
 			</Card>

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -54,6 +54,7 @@ class MediaLibrary extends Component {
 		onAddMedia: PropTypes.func,
 		onFilterChange: PropTypes.func,
 		onSourceChange: PropTypes.func,
+		onFolderChange: PropTypes.func,
 		onSearch: PropTypes.func,
 		onScaleChange: PropTypes.func,
 		onEditItem: PropTypes.func,
@@ -166,6 +167,7 @@ class MediaLibrary extends Component {
 				filterRequiresUpgrade={ this.filterRequiresUpgrade() }
 				search={ this.props.search }
 				source={ this.props.source }
+				folder={ this.props.folder }
 				isConnected={ isConnected( this.props ) }
 				containerWidth={ this.props.containerWidth }
 				single={ this.props.single }
@@ -174,6 +176,7 @@ class MediaLibrary extends Component {
 				onAddAndEditImage={ this.props.onAddAndEditImage }
 				onMediaScaleChange={ this.props.onScaleChange }
 				onSourceChange={ this.props.onSourceChange }
+				onFolderChange={ this.props.onFolderChange }
 				selectedItems={ this.props.mediaLibrarySelectedItems }
 				onDeleteItem={ this.props.onDeleteItem }
 				onEditItem={ this.props.onEditItem }

--- a/client/my-sites/media-library/media-folder-dropdown.jsx
+++ b/client/my-sites/media-library/media-folder-dropdown.jsx
@@ -5,6 +5,7 @@
  */
 import React, { Component } from 'react';
 import { bindAll } from 'lodash';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -33,7 +34,18 @@ class MediaFolderDropdown extends Component {
 	}
 
 	render() {
-		const options = [
+		const rootClassNames = classNames( this.props.className, {
+			'media-library__folder-dropdown': true,
+		} );
+
+		const separator = null;
+
+		const folderOptions = [
+			{
+				value: '',
+				label: 'All Photos',
+			},
+			separator,
 			{
 				value: 'album-1',
 				label: 'Album 1',
@@ -57,12 +69,12 @@ class MediaFolderDropdown extends Component {
 		];
 
 		return (
-			<div className="media-library__folder-dropdown">
+			<div className={ rootClassNames }>
 				<SelectDropdown
 					disabled={ this.props.disabled }
 					compact={ true }
 					onSelect={ this.handleOnSelect }
-					options={ options }
+					options={ folderOptions }
 				/>
 			</div>
 		);

--- a/client/my-sites/media-library/media-folder-dropdown.jsx
+++ b/client/my-sites/media-library/media-folder-dropdown.jsx
@@ -23,6 +23,8 @@ class MediaFolderDropdown extends Component {
 	}
 
 	handleOnSelect( option ) {
+		if ( this.props.disabled ) return;
+
 		const folder = option.value;
 		this.setState( {
 			selectedFolder: folder,
@@ -56,7 +58,12 @@ class MediaFolderDropdown extends Component {
 
 		return (
 			<div className="media-library__folder-dropdown">
-				<SelectDropdown compact={ true } onSelect={ this.handleOnSelect } options={ options } />
+				<SelectDropdown
+					disabled={ this.props.disabled }
+					compact={ true }
+					onSelect={ this.handleOnSelect }
+					options={ options }
+				/>
 			</div>
 		);
 	}

--- a/client/my-sites/media-library/media-folder-dropdown.jsx
+++ b/client/my-sites/media-library/media-folder-dropdown.jsx
@@ -1,0 +1,65 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { bindAll } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import SelectDropdown from 'components/select-dropdown';
+
+class MediaFolderDropdown extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			selectedFolder: '',
+		};
+
+		bindAll( this, [ 'handleOnSelect' ] );
+	}
+
+	handleOnSelect( option ) {
+		const folder = option.value;
+		this.setState( {
+			selectedFolder: folder,
+		} );
+		this.props.onFolderChange( folder );
+	}
+
+	render() {
+		const options = [
+			{
+				value: 'album-1',
+				label: 'Album 1',
+				count: 9,
+			},
+			{
+				value: 'album-2',
+				label: 'Album 2',
+				count: 29,
+			},
+			{
+				value: 'album-3',
+				label: 'Album 3',
+				count: 52,
+			},
+			{
+				value: 'album-4',
+				label: 'Album 4',
+				count: 18,
+			},
+		];
+
+		return (
+			<div className="media-library__folder-dropdown">
+				<SelectDropdown compact={ true } onSelect={ this.handleOnSelect } options={ options } />
+			</div>
+		);
+	}
+}
+
+export default MediaFolderDropdown;

--- a/client/my-sites/media-library/media-folder-dropdown.scss
+++ b/client/my-sites/media-library/media-folder-dropdown.scss
@@ -1,0 +1,2 @@
+.media-library__folder-dropdown {
+}

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -2,6 +2,8 @@
 @import 'list-item';
 @import 'list-item-file-details';
 @import 'list-item-video';
+@import 'media-date-range';
+@import 'media-folder-dropdown';
 @import 'upload-button';
 @import 'upload-url';
 

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -28,6 +28,7 @@
 	}
 }
 
+.media-library__header-item,
 .media-library__header .button {
 	margin-right: 8px;
 }

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -2,7 +2,6 @@
 @import 'list-item';
 @import 'list-item-file-details';
 @import 'list-item-video';
-@import 'media-date-range';
 @import 'media-folder-dropdown';
 @import 'upload-button';
 @import 'upload-url';
@@ -23,7 +22,7 @@
 .media-library__header .is-desktop {
 	display: none;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		display: inline-block;
 	}
 }
@@ -35,7 +34,7 @@
 
 .media-library__header .button.media-library__upload-button {
 	margin-right: 0;
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		border-top-right-radius: 0;
 		border-bottom-right-radius: 0;
 	}
@@ -47,7 +46,7 @@
 .media-library__header.media-library__upload-url {
 	margin-bottom: 10px;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		margin-bottom: 16px;
 	}
 }
@@ -63,7 +62,7 @@
 	align-items: stretch;
 	position: relative;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		flex-wrap: wrap;
 	}
 
@@ -71,7 +70,7 @@
 		flex: 1 auto;
 		z-index: z-index( 'root', '.media-library .search.is-expanded-to-container' );
 
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( '<480px' ) {
 			width: auto;
 		}
 	}
@@ -79,33 +78,29 @@
 	.plan-storage {
 		display: none;
 		margin-bottom: 9px;
-		box-shadow:
-		  0 0 0 1px transparentize( $gray-lighten-20, .5 ),
-		  0 1px 2px $gray-lighten-30;
+		box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, 0.5 ), 0 1px 2px $gray-lighten-30;
 		background-color: $white;
 		padding-left: 24px;
 		padding-right: 24px;
 		box-sizing: border-box;
 		flex: 1 0 auto;
 
-		@include breakpoint( ">480px" ) {
+		@include breakpoint( '>480px' ) {
 			display: flex;
 		}
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			display: none;
 		}
 
-		@include breakpoint( ">960px" ) {
+		@include breakpoint( '>960px' ) {
 			display: flex;
 			margin-bottom: 17px;
 		}
 	}
 
 	.media-library__datasource {
-		box-shadow:
-		  0 0 0 1px transparentize( $gray-lighten-20, .5 ),
-		  0 1px 2px $gray-lighten-30;
+		box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, 0.5 ), 0 1px 2px $gray-lighten-30;
 		background-color: $white;
 		box-sizing: border-box;
 		display: flex;
@@ -115,12 +110,12 @@
 		min-width: 65px;
 		margin-bottom: 17px;
 
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( '<480px' ) {
 			align-items: normal;
 			padding-top: 6px;
 		}
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			margin-bottom: 9px;
 		}
 	}
@@ -129,7 +124,7 @@
 .editor-media-modal .media-library__datasource {
 	margin-bottom: 16px;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		margin-bottom: 9px;
 	}
 }
@@ -158,7 +153,7 @@
 
 .editor-media-modal .media-library__filter-bar {
 	.plan-storage {
-		@include breakpoint( ">480px" ) {
+		@include breakpoint( '>480px' ) {
 			margin-bottom: 16px;
 		}
 	}
@@ -171,7 +166,7 @@
 	line-height: 40px;
 	margin-right: 12px;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		display: none;
 	}
 }
@@ -185,7 +180,8 @@
 		padding-left: 12px;
 	}
 
-	.popover__menu img, .popover__menu svg {
+	.popover__menu img,
+	.popover__menu svg {
 		margin-right: 8px;
 		vertical-align: middle;
 	}
@@ -198,7 +194,7 @@
 		padding: 2px 4px;
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		display: none;
 	}
 }
@@ -206,7 +202,7 @@
 .media-library__scale-range {
 	display: none;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		display: block;
 	}
 }
@@ -228,7 +224,9 @@
 	padding: 0 16px;
 }
 
-.media-library__list-item.is-small .media-library__list-item-file-details .media-library__list-item-icon {
+.media-library__list-item.is-small
+	.media-library__list-item-file-details
+	.media-library__list-item-icon {
 	top: 0;
 }
 
@@ -258,9 +256,9 @@
 	box-shadow: none;
 	margin: 0;
 
-	@include breakpoint( ">960px") {
+	@include breakpoint( '>960px' ) {
 		top: 50%;
-		transform: translateY(-50%);
+		transform: translateY( -50% );
 	}
 }
 

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -153,6 +153,7 @@ export class EditorMediaModal extends Component {
 			filter: '',
 			detailSelectedIndex: 0,
 			source: props.source ? props.source : '',
+			folder: '',
 			gallerySettings: props.initialGallerySettings,
 		};
 	}
@@ -431,6 +432,11 @@ export class EditorMediaModal extends Component {
 		this.setState( { source, search: undefined } );
 	};
 
+	onFolderChange = folder => {
+		// MediaActions.sourceChanged( this.props.site.ID );
+		this.setState( { folder, search: undefined } );
+	};
+
 	onClose = () => {
 		this.props.onClose();
 	};
@@ -606,11 +612,13 @@ export class EditorMediaModal extends Component {
 						enabledFilters={ this.props.enabledFilters }
 						search={ this.state.search }
 						source={ this.state.source }
+						folder={ this.state.folder }
 						onAddMedia={ this.onAddMedia }
 						onAddAndEditImage={ this.onAddAndEditImage }
 						onFilterChange={ this.onFilterChange }
 						onScaleChange={ this.onScaleChange }
 						onSourceChange={ this.onSourceChange }
+						onFolderChange={ this.onFolderChange }
 						onSearch={ this.onSearch }
 						onEditItem={ this.editItem }
 						fullScreenDropZone={ false }

--- a/config/development.json
+++ b/config/development.json
@@ -57,6 +57,7 @@
 		"domains/kracken-ui/pagination": true,
 		"external-media": true,
 		"external-media/google-photos": true,
+		"external-media/google-photos/folder-dropdown": true,
 		"external-media/free-photo-library": true,
 		"gdpr-banner": false,
 		"google-my-business": true,


### PR DESCRIPTION
Adds a dropdown to the Google Photos Modal within the editor in response to 

https://github.com/Automattic/wp-calypso/issues/22771

Allows user to select an existing folder from their Google Photos Library (currently the Picasa API) and filter the list of photos to show only photos from that Album. Also allows user to select to show All Photos.