### PR TITLE
Post Editor: Remove usages of lib/user 

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -17,15 +17,13 @@ import { startsWith } from 'lodash';
  */
 import { startEditingPostCopy, startEditingExistingPost } from 'lib/posts/actions';
 import { addSiteFragment } from 'lib/route';
-import User from 'lib/user';
 import PostEditor from './post-editor';
+import { getCurrentUser } from 'state/current-user/selectors';
 import { startEditingNewPost, stopEditingPost } from 'state/ui/editor/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite } from 'state/sites/selectors';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { getEditURL } from 'lib/posts/utils';
-
-const user = User();
 
 function getPostID( context ) {
 	if ( ! context.params.post || 'new' === context.params.post ) {
@@ -239,13 +237,13 @@ export default {
 			return next();
 		}
 
-		const currentUser = user.get();
+		const  { primarySiteSlug } = getCurrentUser( context.store.getState() );
 
-		if ( ! currentUser.primarySiteSlug ) {
+		if ( ! primarySiteSlug ) {
 			return next();
 		}
 
-		const redirectPath = addSiteFragment( context.pathname, currentUser.primarySiteSlug );
+		const redirectPath = addSiteFragment( context.pathname, primarySiteSlug );
 		const queryString = stringify( context.query );
 		const redirectWithParams = [ redirectPath, queryString ].join( '?' );
 

--- a/client/post-editor/edit-post-status/test/index.jsx
+++ b/client/post-editor/edit-post-status/test/index.jsx
@@ -16,8 +16,6 @@ import React from 'react';
  */
 import { EditPostStatus } from '../';
 
-jest.mock( 'lib/user', () => () => {} );
-
 describe( 'EditPostStatus', () => {
 	test( 'should hide sticky option for password protected posts', () => {
 		const wrapper = shallow(

--- a/client/post-editor/editor-categories-tags/test/accordion.jsx
+++ b/client/post-editor/editor-categories-tags/test/accordion.jsx
@@ -17,7 +17,6 @@ import React from 'react';
 import { EditorCategoriesTagsAccordion } from 'post-editor/editor-categories-tags/accordion';
 
 jest.mock( 'components/info-popover', () => require( 'components/empty-component' ) );
-jest.mock( 'lib/user', () => () => {} );
 jest.mock( 'post-editor/editor-term-selector', () => require( 'components/empty-component' ) );
 
 describe( 'EditorCategoriesTagsAccordion', () => {

--- a/client/post-editor/editor-publish-button/test/index.jsx
+++ b/client/post-editor/editor-publish-button/test/index.jsx
@@ -21,7 +21,6 @@ import { EditorPublishButton } from '../';
 jest.mock( 'lib/posts/stats', () => ( {
 	recordEvent: () => {},
 } ) );
-jest.mock( 'lib/user', () => () => {} );
 
 /**
  * Module variables

--- a/client/post-editor/media-modal/test/markup.js
+++ b/client/post-editor/media-modal/test/markup.js
@@ -14,8 +14,6 @@ import ReactDomServer from 'react-dom/server';
  */
 import { useSandbox } from 'test/helpers/use-sinon';
 
-jest.mock( 'lib/user', () => () => {} );
-
 describe( 'markup', () => {
 	let sandbox, markup, site;
 


### PR DESCRIPTION
The only usage of `lib/user` is in the "Press This" code that figures out the primary site slug from the User object. This can be replaced safely by the `getCurrentUser` Redux selector.

We don't need to check for `null` user and wait until it's populated, like we do for sites. The User object is always populated when logged in, as the `window.AppBoot` function will wait until it's fetched from the network and delays the whole app boot process.

The second commit removes `lib/user` mocks from Post Editor tests. They are no longer needed.

**How to test:**
1. Go to a Press This URL in form `/post?title=Hello&text=world&url=site.blog`
2. Check that new draft post starts being edited on your primary site
