### PR TITLE
Reader: don't fire an error notice when a comments page load fails

### DIFF
--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { compact, get, isDate, startsWith, pickBy, map } from 'lodash';
+import { compact, get, isDate, startsWith, pickBy, map, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,7 +17,6 @@ import {
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
-import { getSitePost } from 'state/posts/selectors';
 import { requestCommentsList } from 'state/comments/actions';
 import { getPostOldestCommentDate, getPostNewestCommentDate } from 'state/comments/selectors';
 import getSiteComment from 'state/selectors/get-site-comment';
@@ -102,23 +101,6 @@ export const addComments = ( action, { comments, found } ) => {
 	return receiveAction;
 };
 
-export const announceFailure = ( { siteId, postId } ) => ( dispatch, getState ) => {
-	const post = getSitePost( getState(), siteId, postId );
-	const postTitle =
-		post &&
-		post.title &&
-		post.title
-			.trim()
-			.slice( 0, 20 )
-			.trim()
-			.concat( '…' );
-	const error = postTitle
-		? translate( 'Could not retrieve comments for “%(postTitle)s”', { args: { postTitle } } )
-		: translate( 'Could not retrieve comments for requested post' );
-
-	dispatch( errorNotice( error ) );
-};
-
 // @see https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/comments/%24comment_ID/delete/
 export const deleteComment = action => ( dispatch, getState ) => {
 	const { siteId, commentId } = action;
@@ -192,7 +174,7 @@ export default {
 		dispatchRequestEx( {
 			fetch: fetchPostComments,
 			onSuccess: addComments,
-			onError: announceFailure,
+			onError: noop,
 		} ),
 	],
 	[ COMMENTS_DELETE ]: [

--- a/client/state/data-layer/wpcom/comments/test/index.js
+++ b/client/state/data-layer/wpcom/comments/test/index.js
@@ -2,13 +2,7 @@
 /**
  * Internal dependencies
  */
-import {
-	fetchPostComments,
-	addComments,
-	announceFailure,
-	commentsFromApi,
-	handleDeleteSuccess,
-} from '../';
+import { fetchPostComments, addComments, commentsFromApi, handleDeleteSuccess } from '../';
 import { COMMENTS_RECEIVE, COMMENTS_COUNT_RECEIVE, NOTICE_CREATE } from 'state/action-types';
 import { NUMBER_OF_COMMENTS_PER_FETCH } from 'state/comments/constants';
 import { http } from 'state/data-layer/wpcom-http/actions';
@@ -156,30 +150,6 @@ describe( 'wpcom-api', () => {
 					{ author: { name: 'joe' } },
 					{ author: { name: '♥' } },
 				] );
-			} );
-		} );
-
-		describe( '#announceFailure', () => {
-			test( 'should dispatch an error notice', () => {
-				const dispatch = jest.fn();
-				const getState = () => ( {
-					posts: {
-						queries: {},
-					},
-				} );
-
-				announceFailure( { siteId: 2916284, postId: 1010 } )( dispatch, getState );
-
-				expect( dispatch ).toHaveBeenCalledTimes( 1 );
-				expect( dispatch ).toHaveBeenCalledWith(
-					expect.objectContaining( {
-						type: NOTICE_CREATE,
-						notice: expect.objectContaining( {
-							status: 'is-error',
-							text: 'Could not retrieve comments for requested post',
-						} ),
-					} )
-				);
 			} );
 		} );
 


### PR DESCRIPTION
Similar to #25721. Fixes https://github.com/Automattic/wp-calypso/issues/25262.

If we've been unable to fetch the next page of comments, we don't need to repeatedly alert the user about it.

### To test

Load a full post with lots of comments, like http://calypso.localhost:3000/read/blogs/82798297/posts/82. Turn off your network connection, and try to load earlier comments. No error notices should be shown.