### PR TITLE
Add Google My Business to Business plan feature list.

### DIFF
--- a/client/blocks/product-purchase-features-list/google-my-business.js
+++ b/client/blocks/product-purchase-features-list/google-my-business.js
@@ -1,0 +1,29 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import PurchaseDetail from 'components/purchase-detail';
+
+export default localize( ( { selectedSite, translate } ) => {
+	return (
+		<div className="product-purchase-features-list__item">
+			<PurchaseDetail
+				icon={ <img alt="" src="/calypso/images/illustrations/google-my-business-feature.svg" /> }
+				title={ translate( 'Google My Business' ) }
+				description={ translate(
+					'View how customers find your business and what action they take by connecting to a Google My Business location.'
+				) }
+				buttonText={ translate( 'Connect Google My Business' ) }
+				href={ '/google-my-business/' + selectedSite.slug }
+			/>
+		</div>
+	);
+} );

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -31,6 +31,7 @@ import MonetizeSite from './monetize-site';
 import BusinessOnboarding from './business-onboarding';
 import CustomDomain from './custom-domain';
 import GoogleAnalyticsStats from './google-analytics-stats';
+import GoogleMyBusiness from './google-my-business';
 import HappinessSupportCard from './happiness-support-card';
 import JetpackAntiSpam from './jetpack-anti-spam';
 import JetpackPublicize from './jetpack-publicize';
@@ -78,6 +79,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<JetpackSearch selectedSite={ selectedSite } />
 				<GoogleVouchers selectedSite={ selectedSite } />
 				<GoogleAnalyticsStats selectedSite={ selectedSite } />
+				<GoogleMyBusiness selectedSite={ selectedSite } />
 				<AdvertisingRemoved isBusinessPlan selectedSite={ selectedSite } />
 				<CustomizeTheme selectedSite={ selectedSite } />
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
@@ -223,6 +225,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<JetpackSearch selectedSite={ selectedSite } />
 				<MonetizeSite selectedSite={ selectedSite } />
 				<GoogleAnalyticsStats selectedSite={ selectedSite } />
+				<GoogleMyBusiness selectedSite={ selectedSite } />
 				<JetpackWordPressCom selectedSite={ selectedSite } />
 				<FindNewTheme selectedSite={ selectedSite } />
 				<JetpackVideo selectedSite={ selectedSite } />

--- a/public/images/illustrations/google-my-business-feature.svg
+++ b/public/images/illustrations/google-my-business-feature.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="175px" height="123px" viewBox="0 0 175 123" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
+    <title>google-my-business-feature</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <polygon id="path-1" points="0 0 46 0 46 30 0 30"></polygon>
+    </defs>
+    <g id="google-my-business-feature" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Laptop" transform="translate(1.000000, 4.000000)">
+            <path d="M156.1572,109.478 L15.2992,109.478 L15.2992,7.91 C15.2992,3.905 18.5462,0.659 22.5512,0.659 L156.1572,0.659 L156.1572,109.478 Z" id="Fill-53" fill="#7ED2F1"></path>
+            <polyline id="Fill-54" fill="#C6E8F4" points="27.7036 97.6499 27.7036 28.9069 144.8966 28.9069 144.8966 97.6499 34.0396 97.6499"></polyline>
+            <polyline id="Fill-55" fill="#00A4D9" points="27.7036 28.561 27.7036 12.463 144.8966 12.463 144.8966 28.561 34.0396 28.561"></polyline>
+            <polyline id="Fill-56" fill="#FFFFFF" points="135.9653 45.5522 135.9653 97.6502 100.7913 97.6502 100.7913 39.7732 135.9653 39.7732"></polyline>
+            <polyline id="Fill-63" fill="#FFFFFF" points="86.453 97.877 37 97.877 37 40 94.461 40 94.461 97.877"></polyline>
+            <path d="M129.0908,76.5971 C123.2208,76.5971 122.4418,79.1331 121.1838,81.9551 C120.1828,84.2021 116.6688,85.7871 112.8508,86.5491 C108.9568,87.3261 107.6598,90.3531 107.6598,92.6711 L129.2768,92.6711 L129.0908,76.5971 Z" id="Fill-64" fill="#7ED2F1"></path>
+            <path d="M164.8261,118.1264 L5.2461,118.1264 C2.4741,118.1264 0.2281,115.8794 0.2281,113.1074 L0.2281,108.8284 L171.0531,108.8284 L171.0531,111.8994 C171.0531,115.3384 168.2651,118.1264 164.8261,118.1264" id="Fill-66" fill="#0383BF"></path>
+            <path d="M96.9213,113.477 L74.3593,113.477 C72.2193,113.477 70.4853,111.743 70.4853,109.603 L70.4853,108.829 L100.7953,108.829 L100.7953,109.603 C100.7953,111.743 99.0613,113.477 96.9213,113.477" id="Fill-67" fill="#004F82"></path>
+            <path d="M148.871,28.811 C138.478,29.677 128.081,29.675 117.685,29.78 L86.495,30.088 L55.304,30.126 C44.907,30.136 34.511,30.255 24.109,29.503 L24.106,29.003 C34.499,28.136 44.896,28.139 55.292,28.033 L86.482,27.726 L117.673,27.687 C128.07,27.677 138.467,27.561 148.868,28.311 L148.871,28.811 Z" id="Fill-75" fill="#004F82"></path>
+            <g id="Group" transform="translate(107.000000, 49.000000)">
+                <polygon id="Fill-7" fill="#7ED2F1" points="0.826 14.185 6.015 14.185 6.015 9.994 0.826 9.994"></polygon>
+                <polygon id="Fill-8" fill="#7ED2F1" points="8.644 12.469 13.833 12.469 13.833 5.994 8.644 5.994"></polygon>
+                <polygon id="Fill-9" fill="#7ED2F1" points="16.463 9.994 21.652 9.994 21.652 0.226 16.463 0.226"></polygon>
+                <polygon id="Fill-10" fill="#00BE28" points="0.826 18.335 6.015 18.335 6.015 15.185 0.826 15.185"></polygon>
+                <polygon id="Fill-11" fill="#00BE28" points="8.644 18.335 13.833 18.335 13.833 13.469 8.644 13.469"></polygon>
+                <polygon id="Fill-12" fill="#00BE28" points="16.463 18.335 21.652 18.335 21.652 10.993 16.463 10.993"></polygon>
+            </g>
+        </g>
+        <polygon id="Fill-1" fill="#7ED2F1" points="44 61.9250011 90 61.9250011 90 49.8388672 44 49.8388672"></polygon>
+        <g id="Group-4" opacity="0.499888393" transform="translate(44.000000, 67.000000)">
+            <mask id="mask-2" fill="white">
+                <use xlink:href="#path-1"></use>
+            </mask>
+            <g id="Clip-3"></g>
+            <path d="M37.7805459,30 L0,30 L0,0 L46,0 L46,21.0092005 C46,25.9731831 42.3195307,30 37.7805459,30" id="Fill-2" fill="#84A5BC" mask="url(#mask-2)"></path>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
## Specs

Before                                 |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/2810519/41886503-7c02c8fe-78b1-11e8-9189-4a987b4a2d25.png)  |  ![](https://user-images.githubusercontent.com/2810519/41886585-de4f7d0e-78b1-11e8-8bc1-ad7f160cc584.png)

Adds a card to the Business Plan Features list that explains and links to our Google My Business page.

## Testing

1. Boot locally or navigate to the live branch
2. Navigate to `/plans/my-plans/:site` on a site connected to Google My Business
3. Verify that it looks like the "After" image above
4. Verify that clicking the "Connect Google My Business" button takes you to the Google My Business Stats page
5. Repeat steps 2 & 3 for a business site not connected to Google My Business
6. Verify that clicking the "Connect Google My Business" button takes you to the Google My Business Select Business Type page.

## Review
- [ ] Code
- [ ] Product
- [ ] Copy

