### PR TITLE
Reader: redirect common paths when logged out

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -110,11 +110,15 @@ const loggedOutMiddleware = currentUser => {
 	const validSections = getSections().reduce( ( acc, section ) => {
 		return section.enableLoggedOut ? acc.concat( section.paths ) : acc;
 	}, [] );
+
 	const isValidSection = sectionPath =>
-		some( validSections, validPath => startsWith( sectionPath, validPath ) );
+		some(
+			validSections,
+			validPath => startsWith( sectionPath, validPath ) || sectionPath.match( validPath )
+		);
 
 	page( '*', ( context, next ) => {
-		if ( isValidSection( context.path ) ) {
+		if ( context.path && isValidSection( context.path ) ) {
 			// redirect to login page if we're not on it already, only for stats for now
 			if ( startsWith( context.path, '/stats' ) ) {
 				return page.redirect( '/log-in/?redirect_to=' + encodeURIComponent( context.path ) );

--- a/client/reader/conversations/index.js
+++ b/client/reader/conversations/index.js
@@ -10,12 +10,13 @@ import page from 'page';
 import config from 'config';
 import { conversations, conversationsA8c } from './controller';
 import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
-import { makeLayout, render as clientRender } from 'controller';
+import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 
 export default function() {
 	if ( config.isEnabled( 'reader/conversations' ) ) {
 		page(
 			'/read/conversations',
+			redirectLoggedOut,
 			preloadReaderBundle,
 			updateLastRoute,
 			initAbTests,
@@ -27,6 +28,7 @@ export default function() {
 
 		page(
 			'/read/conversations/a8c',
+			redirectLoggedOut,
 			preloadReaderBundle,
 			updateLastRoute,
 			initAbTests,

--- a/client/reader/discover/index.js
+++ b/client/reader/discover/index.js
@@ -9,11 +9,12 @@ import page from 'page';
  */
 import { discover } from './controller';
 import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
-import { makeLayout, render as clientRender } from 'controller';
+import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 
 export default function() {
 	page(
 		'/discover',
+		redirectLoggedOut,
 		preloadReaderBundle,
 		updateLastRoute,
 		initAbTests,

--- a/client/reader/following/index.js
+++ b/client/reader/following/index.js
@@ -12,15 +12,7 @@ import { initAbTests, updateLastRoute, sidebar } from 'reader/controller';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/following/*', initAbTests );
-	page(
-		'/following/manage',
-		redirectLoggedOut,
-		updateLastRoute,
-		sidebar,
-		followingManage,
-		makeLayout,
-		clientRender
-	);
+	page( '/following/*', redirectLoggedOut, initAbTests );
+	page( '/following/manage', updateLastRoute, sidebar, followingManage, makeLayout, clientRender );
 	page.redirect( '/following/edit*', '/following/manage' );
 }

--- a/client/reader/following/index.js
+++ b/client/reader/following/index.js
@@ -9,10 +9,18 @@ import page from 'page';
  */
 import { followingManage } from './controller';
 import { initAbTests, updateLastRoute, sidebar } from 'reader/controller';
-import { makeLayout, render as clientRender } from 'controller';
+import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 
 export default function() {
 	page( '/following/*', initAbTests );
-	page( '/following/manage', updateLastRoute, sidebar, followingManage, makeLayout, clientRender );
+	page(
+		'/following/manage',
+		redirectLoggedOut,
+		updateLastRoute,
+		sidebar,
+		followingManage,
+		makeLayout,
+		clientRender
+	);
 	page.redirect( '/following/edit*', '/following/manage' );
 }

--- a/client/reader/full-post/index.js
+++ b/client/reader/full-post/index.js
@@ -9,12 +9,13 @@ import page from 'page';
  */
 import { blogPost, feedPost } from './controller';
 import { updateLastRoute, unmountSidebar } from 'reader/controller';
-import { makeLayout, render as clientRender } from 'controller';
+import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 
 export default function() {
 	// Feed full post
 	page(
 		'/read/feeds/:feed/posts/:post',
+		redirectLoggedOut,
 		updateLastRoute,
 		unmountSidebar,
 		feedPost,
@@ -25,6 +26,7 @@ export default function() {
 	// Blog full post
 	page(
 		'/read/blogs/:blog/posts/:post',
+		redirectLoggedOut,
 		updateLastRoute,
 		unmountSidebar,
 		blogPost,

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -22,7 +22,7 @@ import {
 	updateLastRoute,
 } from './controller';
 import config from 'config';
-import { makeLayout, render as clientRender } from 'controller';
+import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 
 function forceTeamA8C( context, next ) {
 	context.params.team = 'a8c';
@@ -57,6 +57,7 @@ export default function() {
 		page( '/read/feeds/:feed_id/posts', incompleteUrlRedirects );
 		page(
 			'/read/feeds/:feed_id',
+			redirectLoggedOut,
 			updateLastRoute,
 			prettyRedirects,
 			sidebar,
@@ -71,6 +72,7 @@ export default function() {
 		page( '/read/blogs/:blog_id/posts', incompleteUrlRedirects );
 		page(
 			'/read/blogs/:blog_id',
+			redirectLoggedOut,
 			updateLastRoute,
 			prettyRedirects,
 			sidebar,
@@ -88,5 +90,14 @@ export default function() {
 	}
 
 	// Automattic Employee Posts
-	page( '/read/a8c', updateLastRoute, sidebar, forceTeamA8C, readA8C, makeLayout, clientRender );
+	page(
+		'/read/a8c',
+		redirectLoggedOut,
+		updateLastRoute,
+		sidebar,
+		forceTeamA8C,
+		readA8C,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/reader/liked-stream/index.js
+++ b/client/reader/liked-stream/index.js
@@ -9,11 +9,12 @@ import page from 'page';
  */
 import { likes } from './controller';
 import { preloadReaderBundle, initAbTests, updateLastRoute, sidebar } from 'reader/controller';
-import { makeLayout, render as clientRender } from 'controller';
+import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 
 export default function() {
 	page(
 		'/activities/likes',
+		redirectLoggedOut,
 		preloadReaderBundle,
 		initAbTests,
 		updateLastRoute,

--- a/client/reader/list/index.js
+++ b/client/reader/list/index.js
@@ -9,8 +9,16 @@ import page from 'page';
  */
 import { listListing } from './controller';
 import { sidebar, updateLastRoute } from 'reader/controller';
-import { makeLayout, render as clientRender } from 'controller';
+import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/read/list/:user/:list', updateLastRoute, sidebar, listListing, makeLayout, clientRender );
+	page(
+		'/read/list/:user/:list',
+		redirectLoggedOut,
+		updateLastRoute,
+		sidebar,
+		listListing,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/reader/search/index.js
+++ b/client/reader/search/index.js
@@ -10,12 +10,13 @@ import page from 'page';
 import config from 'config';
 import { search } from './controller';
 import { preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
-import { makeLayout, render as clientRender } from 'controller';
+import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 
 export default function() {
 	if ( config.isEnabled( 'reader/search' ) ) {
 		page(
 			'/read/search',
+			redirectLoggedOut,
 			preloadReaderBundle,
 			updateLastRoute,
 			sidebar,

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -10,7 +10,7 @@ import { startsWith } from 'lodash';
  */
 import { tagListing } from './controller';
 import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
-import { makeLayout, render as clientRender } from 'controller';
+import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 
 const redirectHashtaggedTags = ( context, next ) => {
 	if ( context.hashstring && startsWith( context.pathname, '/tag/#' ) ) {
@@ -21,5 +21,13 @@ const redirectHashtaggedTags = ( context, next ) => {
 
 export default function() {
 	page( '/tag/*', preloadReaderBundle, redirectHashtaggedTags, initAbTests );
-	page( '/tag/:tag', updateLastRoute, sidebar, tagListing, makeLayout, clientRender );
+	page(
+		'/tag/:tag',
+		redirectLoggedOut,
+		updateLastRoute,
+		sidebar,
+		tagListing,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -20,14 +20,6 @@ const redirectHashtaggedTags = ( context, next ) => {
 };
 
 export default function() {
-	page( '/tag/*', preloadReaderBundle, redirectHashtaggedTags, initAbTests );
-	page(
-		'/tag/:tag',
-		redirectLoggedOut,
-		updateLastRoute,
-		sidebar,
-		tagListing,
-		makeLayout,
-		clientRender
-	);
+	page( '/tag/*', redirectLoggedOut, preloadReaderBundle, redirectHashtaggedTags, initAbTests );
+	page( '/tag/:tag', updateLastRoute, sidebar, tagListing, makeLayout, clientRender );
 }

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -313,6 +313,7 @@ sections.push( {
 	secondary: false,
 	group: 'reader',
 	css: 'reader-full-post',
+	enableLoggedOut: true,
 } );
 
 sections.push( {

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -299,6 +299,15 @@ sections.push( {
 
 sections.push( {
 	name: 'reader',
+	paths: [ '/read/feeds/[^\\/]+', '/read/blogs/[^\\/]+', '/read/a8c' ],
+	module: 'reader',
+	secondary: true,
+	group: 'reader',
+	enableLoggedOut: true,
+} );
+
+sections.push( {
+	name: 'reader',
 	paths: [ '/read/feeds/[^\\/]+/posts/[^\\/]+', '/read/blogs/[^\\/]+/posts/[^\\/]+' ],
 	module: 'reader/full-post',
 	secondary: false,

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -322,6 +322,7 @@ sections.push( {
 	module: 'reader/discover',
 	secondary: true,
 	group: 'reader',
+	enableLoggedOut: true,
 } );
 
 sections.push( {

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -349,6 +349,7 @@ sections.push( {
 	module: 'reader/liked-stream',
 	secondary: true,
 	group: 'reader',
+	enableLoggedOut: true,
 } );
 
 sections.push( {
@@ -357,6 +358,7 @@ sections.push( {
 	module: 'reader/search',
 	secondary: true,
 	group: 'reader',
+	enableLoggedOut: true,
 } );
 
 sections.push( {
@@ -365,6 +367,7 @@ sections.push( {
 	module: 'reader/list',
 	secondary: true,
 	group: 'reader',
+	enableLoggedOut: true,
 } );
 
 sections.push( {
@@ -373,6 +376,7 @@ sections.push( {
 	module: 'reader/conversations',
 	secondary: true,
 	group: 'reader',
+	enableLoggedOut: true,
 } );
 
 sections.push( {

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -329,6 +329,7 @@ sections.push( {
 	module: 'reader/tag-stream',
 	secondary: true,
 	group: 'reader',
+	enableLoggedOut: true,
 } );
 
 sections.push( {

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -320,6 +320,7 @@ sections.push( {
 	module: 'reader/following',
 	secondary: true,
 	group: 'reader',
+	enableLoggedOut: true,
 } );
 
 sections.push( {


### PR DESCRIPTION
This PR attempts to redirect common Reader paths to the login page when the user doesn't have an active session.

Fixes https://github.com/Automattic/wp-calypso/issues/23623.

These paths are:
- [x] following/manage
- [x] read/feeds/x
- [x] read/blogs/x
- [x] read/feeds/x/posts/x
- [x] read/blogs/x/posts/x
- [x] activities/likes
- [x] read/list/x/x
- [x] tag/x
- [x] read/search
- [x] read/conversations
- [x] read/a8c
- [x] read/conversations/a8c
- [x] discover

### To test 

Try all of the above paths when logged out (incognito mode works well), and verify that you're redirected to the login page.

Try all of the above paths when logged in, and verify that they work as normal.