### PR TITLE
Remote login to mapped domains on login

### DIFF
--- a/client/state/data-layer/wpcom/login-2fa/index.js
+++ b/client/state/data-layer/wpcom/login-2fa/index.js
@@ -12,7 +12,6 @@ import { get } from 'lodash';
 import config from 'config';
 import {
 	TWO_FACTOR_AUTHENTICATION_UPDATE_NONCE,
-	TWO_FACTOR_AUTHENTICATION_PUSH_POLL_COMPLETED,
 	TWO_FACTOR_AUTHENTICATION_PUSH_POLL_START,
 	TWO_FACTOR_AUTHENTICATION_PUSH_POLL_STOP,
 } from 'state/action-types';
@@ -26,6 +25,7 @@ import { http } from 'state/http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { bypassDataLayer } from 'state/data-layer/utils';
 import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
+import { receivedTwoFactorPushNotificationApproved } from 'state/login/actions.js';
 
 /**
  * Module constants
@@ -60,8 +60,8 @@ const requestTwoFactorPushNotificationStatus = ( store, action ) => {
 	);
 };
 
-const receivedTwoFactorPushNotificationApproved = ( { dispatch } ) =>
-	dispatch( { type: TWO_FACTOR_AUTHENTICATION_PUSH_POLL_COMPLETED } );
+const receivedTwoFactorPushNotificationApprovedResponse = ( { dispatch }, _, response ) =>
+	dispatch( receivedTwoFactorPushNotificationApproved( get( response, 'body.data.token_links' ) ) );
 
 /**
  * Receive error from the two factor push notification status http request
@@ -97,7 +97,7 @@ const receivedTwoFactorPushNotificationError = ( store, action, error ) => {
 
 const makePushNotificationRequest = dispatchRequest(
 	requestTwoFactorPushNotificationStatus,
-	receivedTwoFactorPushNotificationApproved,
+	receivedTwoFactorPushNotificationApprovedResponse,
 	receivedTwoFactorPushNotificationError
 );
 

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -61,7 +61,7 @@ import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analyt
 export const remoteLoginUser = loginLinks => {
 	return Promise.all(
 		loginLinks
-			.map( loginLink => fetch( loginLink ) )
+			.map( loginLink => fetch( loginLink, { credentials: 'include' } ) )
 			// make sure we continue even when a remote login fails
 			.map( promise => promise.catch( () => Promise.resolve() ) )
 	);

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -110,11 +110,19 @@ export const loginUser = ( usernameOrEmail, password, redirectTo ) => dispatch =
 				} );
 			}
 
-			return remoteLoginUser( get( response, 'body.data.token_links', [] ) ).then( () => {
-				dispatch( {
-					type: LOGIN_REQUEST_SUCCESS,
-					data: response.body && response.body.data,
+			// if the user has 2FA, in this stage he's not yet logged in.
+			if ( ! get( response, 'body.data.two_step_notification_sent' ) ) {
+				return remoteLoginUser( get( response, 'body.data.token_links', [] ) ).then( () => {
+					dispatch( {
+						type: LOGIN_REQUEST_SUCCESS,
+						data: response.body && response.body.data,
+					} );
 				} );
+			}
+
+			return dispatch( {
+				type: LOGIN_REQUEST_SUCCESS,
+				data: response.body && response.body.data,
 			} );
 		} )
 		.catch( httpError => {

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -68,10 +68,10 @@ export const createTimingOutPromise = ms =>
  * Makes a request to a given link in an iframe
  *
  * @param {string} loginLink the login link to load
- * @param {int} requestTimeout amount of time to allow the link to load, default 5000ms
+ * @param {int} requestTimeout amount of time to allow the link to load, default 25s
  * @returns {Promise} a promise that will be resolved if the link was successfully loaded
  */
-export const makeRemoteLoginRequest = ( loginLink, requestTimeout = 5000 ) => {
+export const makeRemoteLoginRequest = ( loginLink, requestTimeout = 25000 ) => {
 	let iframe;
 	const iframeLoadPromise = new Promise( resolve => {
 		iframe = document.createElement( 'iframe' );

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -110,7 +110,7 @@ export const loginUser = ( usernameOrEmail, password, redirectTo ) => dispatch =
 				} );
 			}
 
-			remoteLoginUser( get( response, 'body.data.token_links', [] ) ).then( () => {
+			return remoteLoginUser( get( response, 'body.data.token_links', [] ) ).then( () => {
 				dispatch( {
 					type: LOGIN_REQUEST_SUCCESS,
 					data: response.body && response.body.data,
@@ -162,7 +162,7 @@ export const loginUserWithTwoFactorVerificationCode = ( twoStepCode, twoFactorAu
 			client_secret: config( 'wpcom_signup_key' ),
 		} )
 		.then( response => {
-			remoteLoginUser( get( response, 'body.data.token_links', [] ) ).then( () => {
+			return remoteLoginUser( get( response, 'body.data.token_links', [] ) ).then( () => {
 				dispatch( { type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_SUCCESS } );
 			} );
 		} )
@@ -218,13 +218,6 @@ export const loginSocialUser = ( socialInfo, redirectTo ) => dispatch => {
 			client_secret: config( 'wpcom_signup_key' ),
 		} )
 		.then( response => {
-			remoteLoginUser( get( response, 'body.data.token_links', [] ) ).then( () => {
-				dispatch( {
-					type: SOCIAL_LOGIN_REQUEST_SUCCESS,
-					data: get( response, 'body.data' ),
-				} );
-			} );
-
 			if ( get( response, 'body.data.two_step_notification_sent' ) === 'sms' ) {
 				dispatch( {
 					type: TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS,
@@ -235,6 +228,13 @@ export const loginSocialUser = ( socialInfo, redirectTo ) => dispatch => {
 					twoStepNonce: get( response, 'body.data.two_step_nonce_sms' ),
 				} );
 			}
+
+			return remoteLoginUser( get( response, 'body.data.token_links', [] ) ).then( () => {
+				dispatch( {
+					type: SOCIAL_LOGIN_REQUEST_SUCCESS,
+					data: get( response, 'body.data' ),
+				} );
+			} );
 		} )
 		.catch( httpError => {
 			const error = getErrorFromHTTPError( httpError );

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -110,18 +110,11 @@ export const loginUser = ( usernameOrEmail, password, redirectTo ) => dispatch =
 				} );
 			}
 
-			if ( get( response, 'body.data.token_links', null ) ) {
-				return remoteLoginUser( get( response, 'body.data.token_links', [] ) ).then( () => {
-					dispatch( {
-						type: LOGIN_REQUEST_SUCCESS,
-						data: response.body && response.body.data,
-					} );
+			remoteLoginUser( get( response, 'body.data.token_links', [] ) ).then( () => {
+				dispatch( {
+					type: LOGIN_REQUEST_SUCCESS,
+					data: response.body && response.body.data,
 				} );
-			}
-
-			dispatch( {
-				type: LOGIN_REQUEST_SUCCESS,
-				data: response.body && response.body.data,
 			} );
 		} )
 		.catch( httpError => {
@@ -168,8 +161,10 @@ export const loginUserWithTwoFactorVerificationCode = ( twoStepCode, twoFactorAu
 			client_id: config( 'wpcom_signup_id' ),
 			client_secret: config( 'wpcom_signup_key' ),
 		} )
-		.then( () => {
-			dispatch( { type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_SUCCESS } );
+		.then( response => {
+			remoteLoginUser( get( response, 'body.data.token_links', [] ) ).then( () => {
+				dispatch( { type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_SUCCESS } );
+			} );
 		} )
 		.catch( httpError => {
 			const twoStepNonce = get( httpError, 'response.body.data.two_step_nonce' );
@@ -223,9 +218,11 @@ export const loginSocialUser = ( socialInfo, redirectTo ) => dispatch => {
 			client_secret: config( 'wpcom_signup_key' ),
 		} )
 		.then( response => {
-			dispatch( {
-				type: SOCIAL_LOGIN_REQUEST_SUCCESS,
-				data: get( response, 'body.data' ),
+			remoteLoginUser( get( response, 'body.data.token_links', [] ) ).then( () => {
+				dispatch( {
+					type: SOCIAL_LOGIN_REQUEST_SUCCESS,
+					data: get( response, 'body.data' ),
+				} );
 			} );
 
 			if ( get( response, 'body.data.two_step_notification_sent' ) === 'sms' ) {

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -40,6 +40,7 @@ import {
 	TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_SUCCESS,
 	TWO_FACTOR_AUTHENTICATION_PUSH_POLL_START,
 	TWO_FACTOR_AUTHENTICATION_PUSH_POLL_STOP,
+	TWO_FACTOR_AUTHENTICATION_PUSH_POLL_COMPLETED,
 	TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST,
 	TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_FAILURE,
 	TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS,
@@ -583,3 +584,19 @@ export const getAuthAccountType = usernameOrEmail => dispatch => {
 export const resetAuthAccountType = () => ( {
 	type: LOGIN_AUTH_ACCOUNT_TYPE_RESET,
 } );
+
+/**
+ * Creates an action that indicates that the push poll is completed
+ *
+ * @param {Array<String>} tokenLinks token links array
+ * @returns {Function} a thunk
+ */
+export const receivedTwoFactorPushNotificationApproved = tokenLinks => dispatch => {
+	if ( ! Array.isArray( tokenLinks ) ) {
+		return dispatch( { type: TWO_FACTOR_AUTHENTICATION_PUSH_POLL_COMPLETED } );
+	}
+
+	remoteLoginUser( tokenLinks ).then( () =>
+		dispatch( { type: TWO_FACTOR_AUTHENTICATION_PUSH_POLL_COMPLETED } )
+	);
+};


### PR DESCRIPTION
Requires server side code D15243.

This patch updates the login endpoint to trigger additional remote login requests to mapped domain upon successful login. With `D15243` login endpoints now return an extra property in `response.body.data` which is not related to 2FA (see prior work on https://github.com/Automattic/wp-calypso/pull/25798)

### Testing Instructions
- Boot this branch locally and apply server side patch
- Open an incognito window and try login with:
    - A normal WordPress.com account with username and password
    - An account with code or sms 2FA enabled
    - An account with push 2FA enabled
    - A Google account
- From devtools, click on preserve logs, filter by "remote" and ensure that remote login requests are fired after a successful login (if the account has mapped domain)
- Inspect the requests and note that set cookies header are sent
- Navigate to the domains that successfully set the cookies and ensure you are logged in

### Reviews
- [ ] Code
- [ ] Product

