### PR TITLE
Enable perfmon statsd logging for Post Editor

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -42,6 +42,7 @@ const mcDebug = debug( 'calypso:analytics:mc' );
 const gaDebug = debug( 'calypso:analytics:ga' );
 const hotjarDebug = debug( 'calypso:analytics:hotjar' );
 const tracksDebug = debug( 'calypso:analytics:tracks' );
+const statsdDebug = debug( 'calypso:analytics:statsd' );
 
 let _superProps, _user, _selectedSite, _siteCount, _dispatch, _loadTracksError;
 
@@ -442,7 +443,17 @@ const analytics = {
 					featureSlug = 'read_post_id__id';
 				} else if ( ( matched = featureSlug.match( /^start_(.*)_(..)$/ ) ) != null ) {
 					featureSlug = `start_${ matched[ 1 ] }`;
+				} else if ( startsWith( featureSlug, 'page__' ) ) {
+					// Fold post editor routes for page, post and CPT into one generic 'post__*' one
+					featureSlug = featureSlug.replace( /^page__/, 'post__' );
+				} else if ( startsWith( featureSlug, 'edit_' ) ) {
+					// use non-greedy +? operator to match the custom post type slug
+					featureSlug = featureSlug.replace( /^edit_.+?__/, 'post__' );
 				}
+
+				statsdDebug(
+					`Recording timing: path=${ featureSlug } event=${ eventType } duration=${ duration }ms`
+				);
 
 				const imgUrl = statsdTimingUrl( featureSlug, eventType, duration );
 				new Image().src = imgUrl;

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -15,6 +15,7 @@ import { startsWith } from 'lodash';
 /**
  * Internal dependencies
  */
+import { recordPlaceholdersTiming } from 'lib/perfmon';
 import { startEditingPostCopy, startEditingExistingPost } from 'lib/posts/actions';
 import { addSiteFragment } from 'lib/route';
 import User from 'lib/user';
@@ -141,6 +142,8 @@ export default {
 		const postType = determinePostType( context );
 		const postId = getPostID( context );
 		const postToCopyId = context.query.copy;
+
+		recordPlaceholdersTiming();
 
 		function startEditing( siteId ) {
 			if ( maybeRedirect( context ) ) {


### PR DESCRIPTION
For Post Editor routes, enable the "perfmon" feature that tracks the time it takes from navigation start until all page placeholder DOM elements disappear and reports the timing to statsd.

So far, the feature has been enabled only for the `/stats` page (since Jan 2018). Now I'd like to track these stats also for the Post Editor, one of the most popular Calypso destinations.

**How to test:**
1. In the `config/development.json` file, enable `perfmon` and `boom_analytics_enabled` temporarily.
2. Enable debug logging with `localStorage.debug = "calypso:perfmon,calypso:analytics:statsd"`
3. Open editor for new/existing posts of various types (post, page, CPT)
4. Check in console that statsd bump is send, with route slug in form `post__site` or `post__site__post_id`, no matter what the post type is.

<img width="964" alt="screen shot 2018-06-26 at 12 50 50" src="https://user-images.githubusercontent.com/664258/41908419-2af96a56-7944-11e8-85be-fd1ea68186f2.png">
