### PR TITLE
Framework: dispatchRequest updates

### DIFF
--- a/client/state/data-layer/wpcom/sites/stats/google-my-business/index.js
+++ b/client/state/data-layer/wpcom/sites/stats/google-my-business/index.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 import { convertToCamelCase } from 'state/data-layer/utils';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { GOOGLE_MY_BUSINESS_STATS_REQUEST } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
@@ -14,54 +14,52 @@ import {
 
 export const fromApi = data => convertToCamelCase( data );
 
-export const fetchStats = ( { dispatch }, action ) => {
+export const fetchStats = action => {
 	const { siteId, statType, interval = 'week', aggregation = 'total' } = action;
 
-	dispatch(
-		http(
-			{
-				path: `/sites/${ siteId }/stats/google-my-business/${ statType }`,
-				method: 'GET',
-				query: {
-					interval,
-					aggregation,
-				},
+	http(
+		{
+			path: `/sites/${ siteId }/stats/google-my-business/${ statType }`,
+			method: 'GET',
+			query: {
+				interval,
+				aggregation,
 			},
-			action
-		)
+		},
+		action
 	);
 };
 
 /**
  * Dispatches returned stats
  *
- * @param {Function} dispatch Redux dispatcher
  * @param {Object} action Redux action
  * @param {Array} data raw data from stats API
  */
-export const receiveStats = ( { dispatch }, action, data ) => {
+export const receiveStats = ( action, data ) => {
 	const { siteId, statType, interval, aggregation } = action;
 
-	dispatch(
-		receiveGoogleMyBusinessStats( siteId, statType, interval, aggregation, fromApi( data ) )
-	);
+	return receiveGoogleMyBusinessStats( siteId, statType, interval, aggregation, fromApi( data ) );
 };
 
 /**
  * Dispatches a failure to retrieve stats
  *
- * @param {Function} dispatch Redux dispatcher
  * @param {Object} action Redux action
  * @param {Object} error raw error from stats API
  */
-export const receiveStatsError = ( { dispatch }, action, error ) => {
+export const receiveStatsError = ( action, error ) => {
 	const { siteId, statType, interval, aggregation } = action;
 
-	dispatch( failedRequestGoogleMyBusinessStats( siteId, statType, interval, aggregation, error ) );
+	return failedRequestGoogleMyBusinessStats( siteId, statType, interval, aggregation, error );
 };
 
 export default {
 	[ GOOGLE_MY_BUSINESS_STATS_REQUEST ]: [
-		dispatchRequest( fetchStats, receiveStats, receiveStatsError ),
+		dispatchRequestEx( {
+			fetch: fetchStats,
+			onSuccess: receiveStats,
+			onError: receiveStatsError,
+		} ),
 	],
 };

--- a/client/state/http/README.md
+++ b/client/state/http/README.md
@@ -14,12 +14,12 @@ import {
 	EXAMPLE_DATA_ADD,
 	NOTICE_CREATE,
 } from 'state/action-types';
-import { dispatchRequest } from 'state/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/wpcom-http/utils';
 import { http } from 'state/http/actions';
 import { get } from 'lodash';
 
-const requestExampleData = ( { dispatch }, action ) => {
-	dispatch( http( {
+const requestExampleData = action => {
+	http( {
 		url: 'https://api.example.com/endpoint',
 		method: 'POST',
 		headers: [
@@ -28,23 +28,26 @@ const requestExampleData = ( { dispatch }, action ) => {
 		body: {
 			user_id: 123,
 		}
-	}, action ) );
+	}, action)
 };
 
-const receivedExampleData = ( { dispatch }, action, data ) =>
-	dispatch( { type: EXAMPLE_DATA_ADD, data } );
+const receivedExampleData = (action, data ) => {
+	return { type: EXAMPLE_DATA_ADD, data }
+}
 
-const receivedExampleDataError = ( { dispatch }, action, error ) => {
-	dispatch( { type: NOTICE_CREATE, notice: { text: get( error, 'response.body.error', null ) } } );
-};
+const receivedExampleDataError = (action, error ) =>
+		return {
+			type: NOTICE_CREATE,
+			notice: { text: get( error, 'response.body.error', null ) } 
+	}
 
 export default {
 	[ GET_EXAMPLE_DATA ]: [
-		dispatchRequest(
-			requestExampleData,
-			receivedExampleData,
-			receivedExampleDataError
-	 	)
+		dispatchRequestEx({
+			fetch: requestExampleData,
+			onSuccess: receivedExampleData,
+			onError: receivedExampleDataError
+	 })
 	],
 };
 ```


### PR DESCRIPTION
See #25121 

cc @dmsnell Before I move forward, how do these look?

I see that instead of directly dispatching actions, we are returning actions from their creator functions to `dispatchRequestEx`. Looking into some of the other files, am I correct to think some of these functions actually do need to dispatch actions themselves? That's just based off the code I'm seeing, initially I thought we were removing dispatch from almost all the action creators in order to cut down on code duplication. Just looking to make sure I understand what's happening before continuing.

I'm trying to understand why [this](https://github.com/Automattic/wp-calypso/pull/25291/files#diff-eb907c621e9baef19ba28723f81ccabfR42) function would still use dispatch. Maybe that one is a bad example, check out [this](https://github.com/Automattic/wp-calypso/blob/master/client/state/data-layer/wpcom/sites/users/index.js#L85) line in /state/data-layer/sites/users/index.js which uses `_.flow` to call dispatch with a list of users. Or is flow just being used here to collect the results from receiveUser?

**Note: I didn't update the tests yet**