### PR TITLE
Settings: Introduce a ownership information section to SiteOwnership

### DIFF
--- a/client/components/forms/form-setting-explanation/style.scss
+++ b/client/components/forms/form-setting-explanation/style.scss
@@ -9,4 +9,17 @@
 	&.is-indented {
 		margin-left: 24px;
 	}
+
+	button.is-borderless {
+		color: $blue-wordpress;
+		font-size: inherit;
+		font-style: inherit;
+		font-weight: inherit;
+		line-height: inherit;
+		padding: 0;
+	}
+
+	button.is-borderless:hover {
+		color: $link-highlight;
+	}
 }

--- a/client/my-sites/site-settings/manage-connection/ownership-information.jsx
+++ b/client/my-sites/site-settings/manage-connection/ownership-information.jsx
@@ -1,0 +1,60 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FormFieldset from 'components/forms/form-fieldset';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import HappychatButton from 'components/happychat/button';
+
+const OwnershipInformation = ( { translate } ) => (
+	<FormFieldset className="manage-connection__formfieldset has-divider is-top-only">
+		<div className="manage-connection__ownership-info">
+			<Gridicon
+				icon="info-outline"
+				size={ 24 }
+				className="manage-connection__ownership-info-icon"
+			/>
+
+			<div className="manage-connection__ownership-info-text">
+				<FormSettingExplanation>
+					{ translate(
+						'{{strong}}Site owners{{/strong}} are users who have connected Jetpack to WordPress.com.',
+						{
+							components: {
+								strong: <strong />,
+							},
+						}
+					) }
+					<br />
+					{ translate(
+						'{{strong}}Plan purchasers{{/strong}} are users who purchased a paid plan for the site.',
+						{
+							components: {
+								strong: <strong />,
+							},
+						}
+					) }
+				</FormSettingExplanation>
+				<FormSettingExplanation>
+					{ translate(
+						'Usually these are the same person, but sometimes they can differ. E.g., developers may be ' +
+							'a Site owner, because they set up the website and connected Jetpack to WordPress.com and ' +
+							'their clients may be Plan purchasers who use their billing information to purchase the plan ' +
+							'for the site.'
+					) }
+					<HappychatButton>{ translate( 'Need help? Chat with us' ) }</HappychatButton>
+				</FormSettingExplanation>
+			</div>
+		</div>
+	</FormFieldset>
+);
+
+export default localize( OwnershipInformation );

--- a/client/my-sites/site-settings/manage-connection/ownership-information.jsx
+++ b/client/my-sites/site-settings/manage-connection/ownership-information.jsx
@@ -5,6 +5,7 @@
  */
 import React from 'react';
 import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -13,8 +14,11 @@ import { localize } from 'i18n-calypso';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import HappychatButton from 'components/happychat/button';
+import HappychatConnection from 'components/happychat/connection-connected';
+import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
+import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 
-const OwnershipInformation = ( { translate } ) => (
+const OwnershipInformation = ( { isChatActive, isChatAvailable, translate } ) => (
 	<FormFieldset className="manage-connection__formfieldset has-divider is-top-only">
 		<div className="manage-connection__ownership-info">
 			<Gridicon
@@ -50,11 +54,20 @@ const OwnershipInformation = ( { translate } ) => (
 							'their clients may be Plan purchasers who use their billing information to purchase the plan ' +
 							'for the site.'
 					) }
-					<HappychatButton>{ translate( 'Need help? Chat with us' ) }</HappychatButton>
 				</FormSettingExplanation>
+
+				<HappychatConnection />
+				{ ( isChatActive || isChatAvailable ) && (
+					<FormSettingExplanation>
+						<HappychatButton>{ translate( 'Need help? Chat with us' ) }</HappychatButton>
+					</FormSettingExplanation>
+				) }
 			</div>
 		</div>
 	</FormFieldset>
 );
 
-export default localize( OwnershipInformation );
+export default connect( state => ( {
+	isChatAvailable: isHappychatAvailable( state ),
+	isChatActive: hasActiveHappychatSession( state ),
+} ) )( localize( OwnershipInformation ) );

--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -23,6 +23,7 @@ import Gravatar from 'components/gravatar';
 import isJetpackSiteConnected from 'state/selectors/is-jetpack-site-connected';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
 import isJetpackUserMaster from 'state/selectors/is-jetpack-user-master';
+import OwnershipInformation from './ownership-information';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import QueryJetpackUserConnection from 'components/data/query-jetpack-user-connection';
 import SectionHeader from 'components/section-header';
@@ -212,10 +213,14 @@ class SiteOwnership extends Component {
 				</FormFieldset>
 
 				{ showPlanSection && (
-					<FormFieldset className="manage-connection__formfieldset has-divider is-top-only">
-						<FormLabel>{ translate( 'Plan purchaser' ) }</FormLabel>
-						{ this.renderPlanDetails() }
-					</FormFieldset>
+					<Fragment>
+						<FormFieldset className="manage-connection__formfieldset has-divider is-top-only">
+							<FormLabel>{ translate( 'Plan purchaser' ) }</FormLabel>
+							{ this.renderPlanDetails() }
+						</FormFieldset>
+
+						<OwnershipInformation />
+					</Fragment>
 				) }
 			</Card>
 		);

--- a/client/my-sites/site-settings/manage-connection/style.scss
+++ b/client/my-sites/site-settings/manage-connection/style.scss
@@ -28,3 +28,25 @@
 		padding-right: 5px;
 	}
 }
+
+.manage-connection__ownership-info {
+	display: flex;
+}
+
+.manage-connection__ownership-info-icon {
+	color: $gray-text-min;
+	flex: 0 0 24px;
+	margin-right: 20px;
+}
+
+.manage-connection__ownership-info-text {
+	flex: 1;
+
+	p.form-setting-explanation {
+		margin-top: 0;
+
+		& + p.form-setting-explanation {
+			margin-top: 20px;
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces a section to explain what **Site owner** and **Plan purchaser** are. It follows the designs, suggested in p6TEKc-29d-p2, and is intended to land after #25725, which introduces the UI to allow Jetpack plan ownership to be transferred to another user.

Preview:

![](https://cldup.com/EoGA3SsHeq.png)

To test:
* Checkout this branch.
* Go to `http://calypso.localhost:3000/settings/manage-connection/:site`, where `:site` is a Jetpack site.
* Verify the new section is at the bottom of the **Site ownership** card, and it looks as shown on the screenshot.
* Try enabling the Happychat staging HUD to simulate that chats are available, and refresh the page; verify the chat link appears properly.
* Verify it works well on mobile devices.