### PR TITLE
NUX: Show .blog subdomain based on the about step 

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -107,4 +107,12 @@ export default {
 		},
 		defaultVariation: 'siteDeservesBoost',
 	},
+	includeDotBlogSubdomain: {
+		datestamp: '20180702',
+		variations: {
+			yes: 50,
+			no: 50,
+		},
+		defaultVariation: 'no',
+	},
 };

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -34,6 +34,7 @@ import { getCurrentUser, currentUserHasFlag } from 'state/current-user/selectors
 import Notice from 'components/notice';
 import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { setDesignType } from 'state/signup/steps/design-type/actions';
+import { getSiteGoals } from 'state/signup/steps/site-goals/selectors';
 
 const productsList = productsListFactory();
 
@@ -246,9 +247,27 @@ class DomainsStep extends React.Component {
 		return this.props.designType;
 	};
 
+	shouldIncludeDotBlogSubdomain() {
+		const { flowName, siteGoals } = this.props;
+		const siteGoalsArray = siteGoals ? siteGoals.split( ',' ) : [];
+
+		return (
+			// 'subdomain' flow coming from .blog landing pages
+			flowName === 'subdomain' ||
+			// User picked only 'share' on the `about` step
+			( siteGoalsArray.length === 1 && siteGoalsArray.indexOf( 'share' ) !== -1 )
+		);
+	}
+
 	domainForm = () => {
 		const initialState = this.props.step ? this.props.step.domainForm : this.state.domainForm;
-		const includeDotBlogSubdomain = this.props.flowName === 'subdomain';
+		const includeDotBlogSubdomain = this.shouldIncludeDotBlogSubdomain();
+
+		// Default to `home` vertical if we should include .blog subdomain but no vertical set
+		let vertical = this.props.surveyVertical;
+		if ( includeDotBlogSubdomain && ! vertical ) {
+			vertical = 'a8c.10';
+		}
 
 		return (
 			<RegisterDomainStep
@@ -266,10 +285,10 @@ class DomainsStep extends React.Component {
 				analyticsSection="signup"
 				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 				includeWordPressDotCom={ ! this.props.isDomainOnly && ! this.isDomainForAtomicSite() }
-				includeDotBlogSubdomain={ includeDotBlogSubdomain }
+				includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
 				isSignupStep
 				showExampleSuggestions
-				surveyVertical={ this.props.surveyVertical }
+				surveyVertical={ vertical }
 				suggestion={ get( this.props, 'queryObject.new', '' ) }
 				designType={ this.getDesignType() }
 			/>
@@ -429,12 +448,13 @@ const submitDomainStepSelection = ( suggestion, section ) => {
 
 export default connect(
 	state => ( {
+		designType: getDesignType( state ),
 		// no user = DOMAINS_WITH_PLANS_ONLY
 		domainsWithPlansOnly: getCurrentUser( state )
 			? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )
 			: true,
+		siteGoals: getSiteGoals( state ),
 		surveyVertical: getSurveyVertical( state ),
-		designType: getDesignType( state ),
 	} ),
 	{
 		recordAddDomainButtonClick,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -13,6 +13,7 @@ import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import MapDomainStep from 'components/domains/map-domain-step';
 import TransferDomainStep from 'components/domains/transfer-domain-step';
 import productsListFactory from 'lib/products-list';
@@ -255,7 +256,9 @@ class DomainsStep extends React.Component {
 			// 'subdomain' flow coming from .blog landing pages
 			flowName === 'subdomain' ||
 			// User picked only 'share' on the `about` step
-			( siteGoalsArray.length === 1 && siteGoalsArray.indexOf( 'share' ) !== -1 )
+			( abtest( 'includeDotBlogSubdomain' ) === 'yes' &&
+				siteGoalsArray.length === 1 &&
+				siteGoalsArray.indexOf( 'share' ) !== -1 )
 		);
 	}
 


### PR DESCRIPTION
If users only selected `share` on the about screen show them a .blog subdomain instead of the wp.com one.