### PR TITLE
Update to store 2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -18272,9 +18272,9 @@
       "dev": true
     },
     "store": {
-      "version": "1.3.16",
-      "resolved": "https://registry.npmjs.org/store/-/store-1.3.16.tgz",
-      "integrity": "sha1-Tc/RiVRjfNrExqBF4DX1Y2E103Y="
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/store/-/store-2.0.12.tgz",
+      "integrity": "sha1-jFNOKguDH3K3X8XxEZhXxE711ZM="
     },
     "stream-browserify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "socket.io-client": "2.1.1",
     "source-map": "0.1.39",
     "source-map-support": "0.5.6",
-    "store": "1.3.16",
+    "store": "2.0.12",
     "striptags": "2.2.1",
     "superagent": "2.3.0",
     "textarea-caret": "3.1.0",


### PR DESCRIPTION
An alternative to https://github.com/Automattic/wp-calypso/pull/25640

Might as well move to the newest supported version instead.

Need to look at how to configure it: https://github.com/marcuswestin/store.js#make-your-own-build