### PR TITLE
Revert "Domains: Run a new domain suggestion engines test for Kracken"

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -867,7 +867,7 @@ class RegisterDomainStep extends React.Component {
 		}
 
 		if ( this.props.isSignupStep ) {
-			searchVendor = abtest( 'domainSuggestionKrakenV322' );
+			searchVendor = abtest( 'domainSuggestionKrakenV321' );
 		}
 
 		enqueueSearchStatReport( { query: searchQuery, section: this.props.analyticsSection } );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -81,14 +81,13 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
-	domainSuggestionKrakenV322: {
-		datestamp: '20180621',
+	domainSuggestionKrakenV321: {
+		datestamp: '20180524',
 		variations: {
 			domainsbot: 0,
-			group_1: 36600,
-			group_3: 36600,
-			group_4: 36600,
-			group_6: 1000,
+			group_1: 10000,
+			group_3: 10000,
+			group_4: 10000,
 		},
 		defaultVariation: 'domainsbot',
 	},


### PR DESCRIPTION
Reverts Automattic/wp-calypso#25665 since Dot is randomly timing out