### PR TITLE
Activity Log: simplify update notices 

### DIFF
--- a/client/my-sites/stats/activity-log-tasklist/style.scss
+++ b/client/my-sites/stats/activity-log-tasklist/style.scss
@@ -46,12 +46,16 @@
 	.button.is-borderless {
 		vertical-align: middle;
 		line-height: 1;
+		color: $gray-dark;
 	}
 }
 
-.activity-log-tasklist__update-version,
-.activity-log-tasklist__update-type,
-.activity-log-tasklist__update-bullet {
+.activity-log-tasklist__update-version {
+	color: $gray-text-min;
+}
+
+.activity-log-tasklist__update-bullet,
+.activity-log-tasklist__update-type {
 	color: $gray;
 }
 

--- a/client/my-sites/stats/activity-log-tasklist/update.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/update.jsx
@@ -50,15 +50,9 @@ class ActivityLogTaskUpdate extends Component {
 				<span className="activity-log-tasklist__update-item">
 					<div>
 						<span className="activity-log-tasklist__update-text">
-							{ translate( 'Update available for {{linked/}}', {
-								components: {
-									linked: (
-										<Button onClick={ this.handleNameClick } borderless>
-											{ name }
-										</Button>
-									),
-								},
-							} ) }
+							<Button borderless onClick={ this.handleNameClick }>
+								{ name }
+							</Button>
 						</span>
 						<span className="activity-log-tasklist__update-bullet">&bull;</span>
 						<span className="activity-log-tasklist__update-version">{ version }</span>


### PR DESCRIPTION
This PR aims to simplify the notices for plugin and theme updates in persistent notices in Activity Log:
- removes the repeated text *Update available for*
- updates colors to move up in visual hierarchy

### Before

<img width="547" alt="captura-de-pantalla-2018-06-25-a-las-14-38-52" src="https://user-images.githubusercontent.com/1041600/41928286-120d4b00-794b-11e8-8bdc-a4857918de95.png">


### After

<img width="572" alt="captura de pantalla 2018-06-26 a la s 14 14 48" src="https://user-images.githubusercontent.com/1041600/41928591-15ef06f4-794c-11e8-9f78-ba2b4365e329.png">

