### PR TITLE
Plugins: Calypsoify plugins

### DIFF
--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -22,6 +22,7 @@ import { JetpackBasicTour } from 'layout/guided-tours/tours/jetpack-basic-tour';
 import { JetpackMonitoringTour } from 'layout/guided-tours/tours/jetpack-monitoring-tour';
 import { JetpackSignInTour } from 'layout/guided-tours/tours/jetpack-sign-in-tour';
 import { SimplePaymentsEmailTour } from 'layout/guided-tours/tours/simple-payments-email-tour';
+import { PluginsBasicTour } from 'layout/guided-tours/tours/plugins-basic-tour';
 
 export default combineTours( {
 	checklistAboutPage: ChecklistAboutPageTour,
@@ -41,4 +42,5 @@ export default combineTours( {
 	gdocsIntegrationTour: GDocsIntegrationTour,
 	simplePaymentsTour: SimplePaymentsTour,
 	simplePaymentsEmailTour: SimplePaymentsEmailTour,
+	pluginsBasicTour: PluginsBasicTour,
 } );

--- a/client/layout/guided-tours/tours/plugins-basic-tour.js
+++ b/client/layout/guided-tours/tours/plugins-basic-tour.js
@@ -1,0 +1,45 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Fragment } from 'react';
+import { overEvery as and } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { makeTour, Tour, Step, ButtonRow, Quit } from 'layout/guided-tours/config-elements';
+import { isEnabled } from 'state/ui/guided-tours/contexts';
+import { isDesktop } from 'lib/viewport';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+
+const isAtomic = state => isSiteAutomatedTransfer( state, getSelectedSiteId( state ) );
+
+export const PluginsBasicTour = makeTour(
+	<Tour
+		name="pluginsBasicTour"
+		version="20180718"
+		path={ [ '/stats', '/plugins' ] }
+		when={ and( isAtomic, isDesktop, isEnabled( 'calypsoify/plugins' ) ) }
+	>
+		<Step
+			name="init"
+			arrow="left-middle"
+			target=".manage_menu__plugins-extra-icon"
+			placement="below"
+			style={ { animationDelay: '2s', marginTop: '-89px', marginLeft: '40px' } }
+			scrollContainer=".sidebar__region"
+		>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>{ translate( 'Manage plugin settings, and install more plugins here' ) }</p>
+					<ButtonRow>
+						<Quit primary>{ translate( 'Got it.' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+	</Tour>
+);

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -191,7 +191,7 @@ form.sidebar__button input {
 
 // Selected Menu
 @include breakpoint( ">660px" ) {
-	.sidebar__menu .selected {
+	.sidebar__menu .selected:not(.sidebar__plugins-item) {
 		background-color: var( --sidebar-menu-selected-background-color );
 
 		a {

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -4,12 +4,12 @@
 	overflow: auto;
 	padding: 0;
 	position: absolute;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		-webkit-overflow-scrolling: touch;
 	}
 }
@@ -20,7 +20,7 @@
 
 	.current-site,
 	.sidebar__footer {
-		flex-shrink: 0;	// prevents items from squishing together under their initial height in Safari
+		flex-shrink: 0; // prevents items from squishing together under their initial height in Safari
 	}
 
 	ul {
@@ -48,14 +48,14 @@
 .sidebar__menu {
 	display: block;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		margin-top: 24px;
 	}
 
 	li {
 		display: flex;
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			background-color: $gray-light;
 			border-bottom: 1px solid lighten( $gray, 25 );
 
@@ -74,19 +74,15 @@
 			content: '';
 			text-align: right;
 			position: absolute;
-				top: 0;
-				right: 0;
-				bottom: 0;
+			top: 0;
+			right: 0;
+			bottom: 0;
 			width: 15%;
 
 			background: overflow-gradient( var( --sidebar-menu-a-first-child-after-background ) );
 
-			@include breakpoint( "<660px" ) {
-
-				background: linear-gradient(
-					to right,
-					rgba( $gray-light, 0 ),
-					rgba( $gray-light, 1 ) 50% );
+			@include breakpoint( '<660px' ) {
+				background: linear-gradient( to right, rgba( $gray-light, 0 ), rgba( $gray-light, 1 ) 50% );
 			}
 		}
 	}
@@ -114,7 +110,7 @@
 			}
 		}
 
-		-webkit-tap-highlight-color: rgba( $gray-dark, .2 );
+		-webkit-tap-highlight-color: rgba( $gray-dark, 0.2 );
 
 		.sidebar__menu-link-secondary-text {
 			padding: 3px 8px 4px 8px;
@@ -140,14 +136,12 @@
 		// External indicator for sections that aren't available in Calypso
 		&.gridicons-external {
 			position: absolute;
-				top: 13px;
-				right: 8px;
-				left: auto;
+			top: 13px;
+			right: 8px;
+			left: auto;
 			z-index: z-index( 'icon-parent', '.sidebar__menu .gridicon.gridicons-external' );
 			height: 18px;
 			margin-right: 0;
-
-
 		}
 	}
 }
@@ -170,7 +164,7 @@ form.sidebar__button {
 	border-radius: 3px;
 	border: 1px solid $gray-lighten-20;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		font-size: 14px;
 		height: 30px;
 		line-height: 23px;
@@ -190,8 +184,8 @@ form.sidebar__button input {
 }
 
 // Selected Menu
-@include breakpoint( ">660px" ) {
-	.sidebar__menu .selected:not(.sidebar__plugins-item) {
+@include breakpoint( '>660px' ) {
+	.sidebar__menu .selected:not( .sidebar__plugins-item ) {
 		background-color: var( --sidebar-menu-selected-background-color );
 
 		a {
@@ -202,7 +196,9 @@ form.sidebar__button input {
 			}
 
 			&:first-child:after {
-				background: overflow-gradient( var( --sidebar-menu-selected-a-first-child-after-background ) );
+				background: overflow-gradient(
+					var( --sidebar-menu-selected-a-first-child-after-background )
+				);
 			}
 		}
 
@@ -222,19 +218,15 @@ form.sidebar__button input {
 
 		&.is-action-button-selected a {
 			&:first-child:after {
-				background: linear-gradient(
-					to right,
-					rgba( $gray-light, 0 ),
-					rgba( $gray-light, 1 ) 50% );
+				background: linear-gradient( to right, rgba( $gray-light, 0 ), rgba( $gray-light, 1 ) 50% );
 			}
 		}
 	}
 }
 
-
 // Menu Hover
 .notouch .sidebar__menu li:hover {
-	&:not(.selected) {
+	&:not( .selected ) {
 		background-color: lighten( $sidebar-bg-color, 3% );
 
 		a,
@@ -243,7 +235,8 @@ form.sidebar__button input {
 				background: linear-gradient(
 					to right,
 					rgba( lighten( $sidebar-bg-color, 3% ), 0 ),
-					rgba( lighten( $sidebar-bg-color, 3% ), 1 ) 50% );
+					rgba( lighten( $sidebar-bg-color, 3% ), 1 ) 50%
+				);
 			}
 
 			&.sidebar__button {
@@ -253,7 +246,7 @@ form.sidebar__button input {
 		}
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		background-color: $gray-light;
 
 		a,
@@ -261,10 +254,7 @@ form.sidebar__button input {
 			color: $blue-medium;
 
 			&:first-child:after {
-				background: linear-gradient(
-					to right,
-					rgba( $gray-light, 0 ),
-					rgba( $gray-light, 1 ) 50% );
+				background: linear-gradient( to right, rgba( $gray-light, 0 ), rgba( $gray-light, 1 ) 50% );
 			}
 
 			&.sidebar__button {
@@ -279,7 +269,7 @@ form.sidebar__button input {
 	}
 }
 
-.notouch .sidebar__menu li:not(.selected) {
+.notouch .sidebar__menu li:not( .selected ) {
 	a,
 	form {
 		&.sidebar__button:hover {
@@ -291,7 +281,8 @@ form.sidebar__button input {
 		border-color: darken( $sidebar-bg-color, 10% );
 	}
 
-	a:hover, form:hover {
+	a:hover,
+	form:hover {
 		color: $blue-medium;
 
 		.sidebar__menu-link-secondary-text {
@@ -343,7 +334,7 @@ form.sidebar__button input {
 		color: $gray-dark;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		padding: 16px;
 	}
 
@@ -354,7 +345,6 @@ form.sidebar__button input {
 		top: auto;
 		margin-top: auto;
 	}
-
 }
 
 .sidebar__region {
@@ -405,7 +395,9 @@ form.sidebar__button input {
 		cursor: default;
 		pointer-events: none;
 
-		.gridicon, span, .sidebar__button {
+		.gridicon,
+		span,
+		.sidebar__button {
 			animation: loading-fade 1.6s ease-in-out infinite;
 			background-color: lighten( $gray, 25% );
 			color: transparent;
@@ -425,8 +417,9 @@ form.sidebar__button input {
 }
 
 .sidebar__chevron-right {
-	position: absolute;
-	right: 0;
+	position: relative;
+	width: 36px;
+	height: 46px;
 	pointer-events: none;
 
 	.gridicon {

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -16,6 +16,7 @@ import { receiveSite, requestSite } from 'state/sites/actions';
 import {
 	getSite,
 	getSiteSlug,
+	getSiteAdminUrl,
 	isJetpackModuleActive,
 	isJetpackSite,
 	isRequestingSites,
@@ -37,6 +38,7 @@ import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import getSiteId from 'state/selectors/get-site-id';
 import getSites from 'state/selectors/get-sites';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import {
 	domainManagementAddGoogleApps,
 	domainManagementContactsPrivacy,
@@ -375,6 +377,20 @@ export function siteSelection( context, next ) {
 
 	const siteId = getSiteId( getState(), siteFragment );
 	if ( siteId ) {
+		const isAtomicSite = isSiteAutomatedTransfer( getState(), siteId );
+		const calypsoify = isAtomicSite && config.isEnabled( 'calypsoify/plugins' );
+
+		if (
+			window &&
+			window.location &&
+			window.location.replace &&
+			calypsoify &&
+			/^\/plugins/.test( basePath )
+		) {
+			const pluginLink = getSiteAdminUrl( getState(), siteId ) + 'plugin-install.php?calypsoify=1';
+			return window.location.replace( pluginLink );
+		}
+
 		dispatch( setSelectedSiteId( siteId ) );
 		const selectionComplete = onSelectedSiteAvailable( context );
 

--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -32,6 +32,7 @@ class PluginInformation extends React.Component {
 		hasUpdate: PropTypes.bool,
 		pluginVersion: PropTypes.string,
 		siteVersion: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
+		calypsoify: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -178,6 +179,10 @@ class PluginInformation extends React.Component {
 	};
 
 	getActionLinks = plugin => {
+		if ( this.props.calypsoify ) {
+			return null;
+		}
+
 		if ( ! get( plugin, 'active' ) ) {
 			return null;
 		}

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -580,7 +580,7 @@ export class PluginMeta extends Component {
 							{ this.renderName() }
 							<div className="plugin-meta__meta">{ this.renderAuthorUrl() }</div>
 						</div>
-						{ this.renderActions() }
+						{ ! this.props.calypsoify && this.renderActions() }
 					</div>
 				</Card>
 
@@ -604,6 +604,7 @@ export class PluginMeta extends Component {
 								this.props.selectedSite && this.props.selectedSite.options.software_version
 							}
 							hasUpdate={ this.getAvailableNewVersions().length > 0 }
+							calypsoify={ this.props.calypsoify }
 						/>
 					) }
 

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -15,6 +15,7 @@ import { includes, uniq } from 'lodash';
  */
 import PluginSiteList from 'my-sites/plugins/plugin-site-list';
 import HeaderCake from 'components/header-cake';
+import Card from 'components/card';
 import PluginMeta from 'my-sites/plugins/plugin-meta';
 import PluginsStore from 'lib/plugins/store';
 import PluginsLog from 'lib/plugins/log-store';
@@ -132,6 +133,10 @@ const SinglePlugin = createReactClass( {
 	},
 
 	displayHeader() {
+		if ( ! this.props.selectedSite ) {
+			return <Card className="plugins__installed-header" />;
+		}
+
 		const recordEvent = this.recordEvent.bind( this, 'Clicked Header Plugin Back Arrow' );
 		return (
 			<HeaderCake

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -35,6 +35,10 @@
 	}
 }
 
+.plugins__installed-header {
+	margin-bottom: 1px;
+}
+
 .plugins__header-buttons {
 	display: flex;
 
@@ -58,7 +62,7 @@
 	margin: 40px 0 20px;
 	padding: 0 15px;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		padding: 0;
 	}
 }

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -136,7 +136,7 @@ class ManageMenu extends PureComponent {
 			paths: [ '/extensions', '/plugins' ],
 			wpAdminLink: 'plugin-install.php?calypsoify=1',
 			showOnAllMySites: true,
-			buttonLink: ! isAtomicSite ? '/plugins/manage' + this.props.siteSlug : '',
+			buttonLink: ! isAtomicSite ? `/plugins/manage/${ this.props.siteSlug }` : '',
 			buttonText: translate( 'Manage' ),
 			extraIcon: isAtomicSite ? 'chevron-right' : null,
 			customClassName: isAtomicSite ? 'sidebar__plugins-item' : '',

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -9,6 +9,7 @@ import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { compact, includes, omit, reduce, get } from 'lodash';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -71,12 +72,12 @@ class ManageMenu extends PureComponent {
 	}
 
 	getDefaultMenuItems() {
-		const { siteSlug } = this.props;
+		const { siteSlug, translate } = this.props;
 
-		const items = [
+		return [
 			{
 				name: 'page',
-				label: this.props.translate( 'Site Pages' ),
+				label: translate( 'Site Pages' ),
 				capability: 'edit_pages',
 				queryable: true,
 				config: 'manage/pages',
@@ -87,7 +88,7 @@ class ManageMenu extends PureComponent {
 			},
 			{
 				name: 'post',
-				label: this.props.translate( 'Blog Posts' ),
+				label: translate( 'Blog Posts' ),
 				capability: 'edit_posts',
 				config: 'manage/posts',
 				queryable: true,
@@ -99,7 +100,7 @@ class ManageMenu extends PureComponent {
 			},
 			{
 				name: 'media',
-				label: this.props.translate( 'Media' ),
+				label: translate( 'Media' ),
 				capability: 'upload_files',
 				queryable: true,
 				config: 'manage/media',
@@ -110,7 +111,7 @@ class ManageMenu extends PureComponent {
 			},
 			{
 				name: 'comments',
-				label: this.props.translate( 'Comments' ),
+				label: translate( 'Comments' ),
 				capability: 'edit_posts',
 				queryable: true,
 				config: 'manage/comments',
@@ -120,8 +121,27 @@ class ManageMenu extends PureComponent {
 				showOnAllMySites: false,
 			},
 		];
+	}
 
-		return items;
+	getPluginItem() {
+		const { isAtomicSite, translate } = this.props;
+
+		return {
+			name: 'plugins',
+			label: translate( 'Plugins' ),
+			capability: 'manage_options',
+			queryable: ! isAtomicSite,
+			config: 'manage/plugins',
+			link: '/plugins',
+			paths: [ '/extensions', '/plugins' ],
+			wpAdminLink: 'plugin-install.php?calypsoify=1',
+			showOnAllMySites: true,
+			buttonLink: ! isAtomicSite ? '/plugins/manage' + this.props.siteSlug : '',
+			buttonText: translate( 'Manage' ),
+			extraIcon: isAtomicSite ? 'chevron-right' : null,
+			customClassName: isAtomicSite ? 'sidebar__plugins-item' : '',
+			forceInternalLink: isAtomicSite,
+		};
 	}
 
 	onNavigate = postType => () => {
@@ -189,12 +209,22 @@ class ManageMenu extends PureComponent {
 			case 'comments':
 				icon = 'chat';
 				break;
+			case 'plugins':
+				icon = 'plugins';
+				break;
 			default:
 				icon = 'custom-post-type';
 		}
 
+		const extraIcon = menuItem.extraIcon && (
+			<div className={ `manage_menu__${ menuItem.name }-extra-icon` }>
+				<Gridicon icon={ menuItem.extraIcon } />
+			</div>
+		);
+
 		return (
 			<SidebarItem
+				className={ menuItem.customClassName }
 				key={ menuItem.name }
 				label={ menuItem.label }
 				selected={ itemLinkMatches( menuItem.paths || menuItem.link, this.props.path ) }
@@ -202,8 +232,9 @@ class ManageMenu extends PureComponent {
 				onNavigate={ this.onNavigate( menuItem.name ) }
 				icon={ icon }
 				preloadSectionName={ preload }
-				postType={ menuItem.name }
+				postType={ menuItem.name === 'plugins' ? null : menuItem.name }
 				tipTarget={ `side-menu-${ menuItem.name }` }
+				forceInternalLink={ menuItem.forceInternalLink }
 			>
 				{ menuItem.name === 'media' && (
 					<MediaLibraryUploadButton
@@ -221,9 +252,10 @@ class ManageMenu extends PureComponent {
 						href={ menuItem.buttonLink }
 						preloadSectionName="post-editor"
 					>
-						{ this.props.translate( 'Add' ) }
+						{ menuItem.buttonText || this.props.translate( 'Add' ) }
 					</SidebarButton>
 				) }
+				{ extraIcon }
 			</SidebarItem>
 		);
 	}
@@ -276,6 +308,10 @@ class ManageMenu extends PureComponent {
 
 	render() {
 		const menuItems = [ ...this.getDefaultMenuItems(), ...this.getCustomMenuItems() ];
+
+		if ( config.isEnabled( 'calypsoify/plugins' ) ) {
+			menuItems.push( this.getPluginItem() );
+		}
 
 		return (
 			<ul>

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -16,7 +16,7 @@ import page from 'page';
  */
 import { abtest } from 'lib/abtest';
 import Button from 'components/button';
-import config from 'config';
+import { isEnabled } from 'config';
 import CurrentSite from 'my-sites/current-site';
 import ManageMenu from './manage-menu';
 import Sidebar from 'layout/sidebar';
@@ -200,7 +200,7 @@ export class MySitesSidebar extends Component {
 
 		if (
 			! this.props.isJetpack &&
-			config.isEnabled( 'upsell/nudge-a-palooza' ) &&
+			isEnabled( 'upsell/nudge-a-palooza' ) &&
 			canUserUpgradeSite &&
 			abtest( 'nudgeAPalooza' ) === 'sidebarUpsells'
 		) {
@@ -226,14 +226,14 @@ export class MySitesSidebar extends Component {
 
 	themes() {
 		const { path, site, translate, canUserEditThemeOptions } = this.props,
-			jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' );
+			jetpackEnabled = isEnabled( 'manage/themes-jetpack' );
 		let themesLink;
 
 		if ( site && ! canUserEditThemeOptions ) {
 			return null;
 		}
 
-		if ( ! config.isEnabled( 'manage/themes' ) ) {
+		if ( ! isEnabled( 'manage/themes' ) ) {
 			return null;
 		}
 
@@ -282,8 +282,9 @@ export class MySitesSidebar extends Component {
 	};
 
 	plugins() {
-		const pluginsLink = '/plugins' + this.props.siteSuffix;
-		const managePluginsLink = '/plugins/manage' + this.props.siteSuffix;
+		if ( isEnabled( 'calypsoify/plugins' ) ) {
+			return null;
+		}
 
 		// checks for manage plugins capability across all sites
 		if ( ! this.props.canManagePlugins ) {
@@ -294,6 +295,9 @@ export class MySitesSidebar extends Component {
 		if ( this.props.siteId && ! this.props.canUserManageOptions ) {
 			return null;
 		}
+
+		const pluginsLink = '/plugins' + this.props.siteSuffix;
+		const managePluginsLink = '/plugins/manage' + this.props.siteSuffix;
 
 		const manageButton =
 			this.props.isJetpack || ( ! this.props.siteId && this.props.hasJetpackSites ) ? (
@@ -422,13 +426,13 @@ export class MySitesSidebar extends Component {
 	store() {
 		const { canUserUpgradeSite, site, canUserUseStore } = this.props;
 
-		if ( ! config.isEnabled( 'woocommerce/extension-dashboard' ) || ! site ) {
+		if ( ! isEnabled( 'woocommerce/extension-dashboard' ) || ! site ) {
 			return null;
 		}
 
 		if ( ! canUserUseStore ) {
 			if (
-				config.isEnabled( 'upsell/nudge-a-palooza' ) &&
+				isEnabled( 'upsell/nudge-a-palooza' ) &&
 				canUserUpgradeSite &&
 				abtest( 'nudgeAPalooza' ) === 'sidebarUpsells'
 			) {

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -108,6 +108,7 @@ export class MySitesSidebar extends Component {
 			<ManageMenu
 				siteId={ this.props.siteId }
 				path={ this.props.path }
+				isAtomicSite={ this.props.isAtomicSite }
 				onNavigate={ this.onNavigate }
 			/>
 		);

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -70,7 +70,7 @@ export class MySitesSidebar extends Component {
 		currentUser: PropTypes.object,
 		isDomainOnly: PropTypes.bool,
 		isJetpack: PropTypes.bool,
-		isSiteAutomatedTransfer: PropTypes.bool,
+		isAtomicSite: PropTypes.bool,
 	};
 
 	componentDidMount() {
@@ -342,7 +342,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		if ( this.props.isJetpack && ! this.props.isSiteAutomatedTransfer ) {
+		if ( this.props.isJetpack && ! this.props.isAtomicSite ) {
 			return null;
 		}
 
@@ -438,6 +438,7 @@ export class MySitesSidebar extends Component {
 			) {
 				return this.storeUpsellSidebarItem();
 			}
+
 			return null;
 		}
 
@@ -600,7 +601,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		if ( ! this.useWPAdminFlows() && ! this.props.isSiteAutomatedTransfer ) {
+		if ( ! this.useWPAdminFlows() && ! this.props.isAtomicSite ) {
 			return null;
 		}
 
@@ -791,7 +792,7 @@ function mapStateToProps( state ) {
 		isJetpack,
 		isPreviewable: isSitePreviewable( state, selectedSiteId ),
 		isSharingEnabledOnJetpackSite,
-		isSiteAutomatedTransfer: !! isSiteAutomatedTransfer( state, selectedSiteId ),
+		isAtomicSite: !! isSiteAutomatedTransfer( state, selectedSiteId ),
 		siteId,
 		site,
 		siteSuffix: site ? '/' + site.slug : '',

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -5,7 +5,7 @@
 	right: 16px;
 	top: 8px;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		top: 13px;
 		right: 20px;
 	}
@@ -14,16 +14,31 @@
 .sidebar__menu li.stats.selected .sidebar__sparkline {
 	display: none;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		display: block;
 	}
 }
 
 .sidebar__menu li.stats a:after,
-.notouch .sidebar__menu li.stats:hover:not(.selected) a:first-child:after  {
+.notouch .sidebar__menu li.stats:hover:not( .selected ) a:first-child:after {
 	background: none;
 }
 
 .sidebar__menu-link-secondary-text {
 	top: 13px;
+}
+
+.manage_menu__plugins-extra-icon {
+	position: relative;
+	width: 36px;
+	height: 46px;
+	pointer-events: none;
+
+	.gridicon {
+		padding-top: 10px;
+	}
+
+	:hover + & .gridicon {
+		fill: $blue-medium;
+	}
 }

--- a/client/state/ui/guided-tours/selectors/index.js
+++ b/client/state/ui/guided-tours/selectors/index.js
@@ -39,7 +39,7 @@ const BLACKLISTED_SECTIONS = [
 	'checkout-thank-you', // thank you page
 ];
 
-const getToursHistory = state => getPreference( state, 'guided-tours-history' );
+export const getToursHistory = state => getPreference( state, 'guided-tours-history' );
 const debug = debugFactory( 'calypso:guided-tours' );
 
 const mappable = x => ( ! Array.isArray( x ) ? [ x ] : x );

--- a/config/development.json
+++ b/config/development.json
@@ -35,6 +35,7 @@
 		"ad-tracking": false,
 		"automated-transfer": true,
 		"apple-pay": true,
+		"calypsoify/plugins": true,
 		"code-splitting": true,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -21,6 +21,7 @@
 		"ad-tracking": false,
 		"apple-pay": false,
 		"automated-transfer": true,
+		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"devdocs": false,

--- a/config/test.json
+++ b/config/test.json
@@ -28,6 +28,7 @@
 	"features": {
 		"ad-tracking": false,
 		"apple-pay": true,
+		"calypsoify/plugins": true,
 		"catch-js-errors": false,
 		"code-splitting": true,
 		"desktop-promo": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -22,6 +22,7 @@
 		"automated-transfer": true,
 		"apple-pay": true,
 		"comments/management/threaded-view": false,
+		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"desktop-promo": true,


### PR DESCRIPTION
This PR implements the calypsoification for plugins.
For more context, please read the following thread: https://wp.me/p58i-76F-p2

In short, it changes the regular behavior of the plugins sections for Atomic sites.

#### now

* `Plugins` link points to `http://calypso.localhost:3000/plugins/<simple-site>`.

* `Plugins` link has the `Manage` button

<img src="https://user-images.githubusercontent.com/77539/42229384-c0af3a3a-7ebc-11e8-96ce-4f9417680bf0.png" width="300px" />

#### after these changes

* `Plugins` link points to `https://<atomic-site>/wp-admin/plugin-install.php?calypsoify=1`.

* `Manage` button is removed
* Add a `chevron-right` icon at the right of the `Plugins` item

<img src="https://user-images.githubusercontent.com/77539/42229648-4ded27ae-7ebd-11e8-89c0-24213a2cc7f3.png" width="300px" />

* The `http://wordpress.com/plugins/` route is not achieved for Atomic sites. It should redirect to the wp-admin one.
* For new Atomic sites it shows a guided tour immediatlly after the site is transferred.


