### PR TITLE
Site Importer: Prevent fatal on importer section w/ empty state

### DIFF
--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { isEnabled } from 'config';
-import { filter } from 'lodash';
+import { filter, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -185,7 +185,8 @@ class SiteSettingsImport extends Component {
 	}
 
 	updateFromAPI = () => {
-		fetchState( this.props.site.ID );
+		const siteID = get( this, 'props.site.ID' );
+		siteID && fetchState( siteID );
 	};
 
 	updateState = () => {


### PR DESCRIPTION
When the `import` section is loaded & the local state tree is not populated, the current site ID is not yet set.

As a result, when we try to reference it, it throws an error:
`Uncaught TypeError: Cannot read property 'ID' of null`

...and Calypso white screens

This change makes sure the siteID is set and truthy before calling `fetchState`.

## To Test

* Confirm current behavior
  * Run the `master` branch
  * Visit http://calypso.localhost:3000/settings/import/yourtestsite.wordpress.com?flags=force-sympathy
  * See the error and a white screen
* Confirm fix
  * Switch to this branch
  * Visit http://calypso.localhost:3000/settings/import/yourtestsite.wordpress.com?flags=force-sympathy
  * Ensure the section loads
