### PR TITLE
Add Sites Activity Site Picker

### DIFF
--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -78,6 +78,9 @@ export const Sites = createReactClass( {
 		switch ( path ) {
 			case 'stats':
 				path = i18n.translate( 'Insights' );
+				if ( '/stats/activity' === this.props.path ) {
+					path = i18n.translate( 'Activity' );
+				}
 				break;
 			case 'plans':
 				path = i18n.translate( 'Plans' );

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -14,6 +14,8 @@ import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
+	page( '/stats/activity', siteSelection, sites, makeLayout, clientRender );
+
 	page(
 		'/stats/activity/:site_id',
 		siteSelection,


### PR DESCRIPTION
Fixes #25518

Before: 
When an admin navigated to a site that didn't have a Activity log they would end up on the insights page.
 
Now they see 
![screen_shot_2018-06-26_at_12_53_17_pm](https://user-images.githubusercontent.com/115071/41936030-ab52b77e-7940-11e8-9119-ed42d0713c09.png)

This PR fixes this by adding a explicit route that lets the user choose an site. 

Also it fixes the wording in the header from Insights to Activity. 