### PR TITLE
Allow Jetpack 6.3-beta1 and later to use geo-location features.

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -329,7 +329,7 @@ const enhance = flow(
 			isJetpack: isJetpackSite( state, siteId ),
 			isSeoToolsModuleActive: isJetpackModuleActive( state, siteId, 'seo-tools' ),
 			jetpackVersionSupportsSeo: isJetpackMinimumVersion( state, siteId, '4.4-beta1' ),
-			jetpackVersionSupportsLocation: isJetpackMinimumVersion( state, siteId, '6.3-beta1' ),
+			jetpackVersionSupportsLocation: isJetpackMinimumVersion( state, siteId, '6.3-beta' ),
 			isRequestingPlugins: isRequesting( state, siteId ),
 			type,
 			typeObject: getPostType( state, siteId, type ),

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -168,7 +168,10 @@ class EditorDrawer extends Component {
 	renderLocation() {
 		const { translate } = this.props;
 
-		if ( ! this.props.site || this.props.isJetpack ) {
+		if (
+			! this.props.site ||
+			( this.props.isJetpack && ! this.props.jetpackVersionSupportsLocation )
+		) {
 			return;
 		}
 
@@ -326,6 +329,7 @@ const enhance = flow(
 			isJetpack: isJetpackSite( state, siteId ),
 			isSeoToolsModuleActive: isJetpackModuleActive( state, siteId, 'seo-tools' ),
 			jetpackVersionSupportsSeo: isJetpackMinimumVersion( state, siteId, '4.4-beta1' ),
+			jetpackVersionSupportsLocation: isJetpackMinimumVersion( state, siteId, '6.3-beta1' ),
 			isRequestingPlugins: isRequesting( state, siteId ),
 			type,
 			typeObject: getPostType( state, siteId, type ),


### PR DESCRIPTION
geo-location support is being added to Jetpack in the upcoming 6.3 release (see https://github.com/Automattic/jetpack/pull/9573), which is scheduled for next week.  This PR modifies our compatibility check so that rather than blocking all Jetpack sites, we instead check for at least version 6.3-beta1.  

To test, you can fire up a Jetpack site.  Jetpack sites running any version prior to 6.3-beta1 will not render the geo-location UI.  If you're running that beta or a non-Jetpack site, you'll get the normal geo-location UI.