### PR TITLE
Domains: Remove A/B test for TLD filter bar placement

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -275,9 +275,9 @@ class DomainSearchResults extends React.Component {
 
 		return (
 			<div className="domain-search-results__domain-suggestions">
+				{ this.props.children }
 				{ suggestionCount }
 				{ featuredSuggestionElement }
-				{ this.props.children }
 				{ suggestionElements }
 				{ unavailableOffer }
 			</div>

--- a/client/components/domains/domain-search-results/style.scss
+++ b/client/components/domains/domain-search-results/style.scss
@@ -1,4 +1,5 @@
-.domain-search-results__domain-availability, .transfer-domain-step__domain-availability {
+.domain-search-results__domain-availability,
+.transfer-domain-step__domain-availability {
 	.notice.is-success {
 		margin: 0;
 	}
@@ -27,6 +28,7 @@
 .domain-search-results__transfer-card {
 	display: flex;
 	flex-direction: column;
+	margin-bottom: 12px;
 
 	@include breakpoint( '>480px' ) {
 		align-items: center;

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -383,6 +383,14 @@ class RegisterDomainStep extends React.Component {
 						{ this.renderSearchFilters() }
 					</CompactCard>
 				</StickyPanel>
+				{ message && (
+					<Notice
+						className="register-domain-step__notice"
+						text={ message }
+						status={ `is-${ severity }` }
+						showDismiss={ false }
+					/>
+				) }
 				{ showTldFilterBar && (
 					<TldFilterBar
 						availableTlds={ this.state.availableTlds }
@@ -394,9 +402,6 @@ class RegisterDomainStep extends React.Component {
 						onSubmit={ this.onFiltersSubmit }
 						showPlaceholder={ this.state.loadingResults || ! this.getSuggestionsFromProps() }
 					/>
-				) }
-				{ message && (
-					<Notice text={ message } status={ `is-${ severity }` } showDismiss={ false } />
 				) }
 				{ this.renderContent() }
 				{ this.renderFilterResetNotice() }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -360,7 +360,12 @@ class RegisterDomainStep extends React.Component {
 		const { message, severity } = showNotice
 			? getAvailabilityNotice( lastDomainSearched, error, errorData )
 			: {};
-		const showTldFilterBar = Array.isArray( this.state.searchResults ) || this.state.loadingResults;
+		const showTldFilterBar =
+			( Array.isArray( this.state.searchResults ) &&
+				this.state.searchResults.length > 0 &&
+				Array.isArray( this.state.availableTlds ) &&
+				this.state.availableTlds.length > 0 ) ||
+			this.state.loadingResults;
 		return (
 			<div className="register-domain-step">
 				<StickyPanel className="register-domain-step__search">

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -362,7 +362,6 @@ class RegisterDomainStep extends React.Component {
 			: {};
 		const showTldFilterBar =
 			( Array.isArray( this.state.searchResults ) || this.state.loadingResults ) &&
-			config.isEnabled( 'domains/kracken-ui/tld-filter' ) &&
 			abtest( 'domainSearchTLDFilterPlacement' ) === 'aboveFeatured';
 		return (
 			<div className="register-domain-step">
@@ -998,9 +997,7 @@ class RegisterDomainStep extends React.Component {
 			return this.renderExampleSuggestions();
 		}
 
-		const showTldFilterBar =
-			config.isEnabled( 'domains/kracken-ui/tld-filter' ) &&
-			abtest( 'domainSearchTLDFilterPlacement' ) === 'belowFeatured';
+		const showTldFilterBar = abtest( 'domainSearchTLDFilterPlacement' ) === 'belowFeatured';
 
 		return (
 			<DomainSearchResults

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -231,7 +231,7 @@ class RegisterDomainStep extends React.Component {
 			.substring( 1 );
 	}
 
-	componentWillReceiveProps( nextProps ) {
+	UNSAFE_componentWillReceiveProps( nextProps ) {
 		// Reset state on site change
 		if (
 			nextProps.selectedSite &&
@@ -268,7 +268,7 @@ class RegisterDomainStep extends React.Component {
 		}
 	}
 
-	componentWillMount() {
+	UNSAFE_componentWillMount() {
 		searchCount = 0; // reset the counter
 
 		if ( this.props.initialState ) {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -360,9 +360,7 @@ class RegisterDomainStep extends React.Component {
 		const { message, severity } = showNotice
 			? getAvailabilityNotice( lastDomainSearched, error, errorData )
 			: {};
-		const showTldFilterBar =
-			( Array.isArray( this.state.searchResults ) || this.state.loadingResults ) &&
-			abtest( 'domainSearchTLDFilterPlacement' ) === 'aboveFeatured';
+		const showTldFilterBar = Array.isArray( this.state.searchResults ) || this.state.loadingResults;
 		return (
 			<div className="register-domain-step">
 				<StickyPanel className="register-domain-step__search">
@@ -997,8 +995,6 @@ class RegisterDomainStep extends React.Component {
 			return this.renderExampleSuggestions();
 		}
 
-		const showTldFilterBar = abtest( 'domainSearchTLDFilterPlacement' ) === 'belowFeatured';
-
 		return (
 			<DomainSearchResults
 				key="domain-search-results" // key is required for CSS transition of content/
@@ -1023,20 +1019,7 @@ class RegisterDomainStep extends React.Component {
 				railcarSeed={ this.state.railcarSeed }
 				fetchAlgo={ searchVendor + '/v1' }
 				cart={ this.props.cart }
-			>
-				{ showTldFilterBar && (
-					<TldFilterBar
-						availableTlds={ this.state.availableTlds }
-						filters={ this.state.filters }
-						isSignupStep={ this.props.isSignupStep }
-						lastFilters={ this.state.lastFilters }
-						onChange={ this.onFiltersChange }
-						onReset={ this.onFiltersReset }
-						onSubmit={ this.onFiltersSubmit }
-						showPlaceholder={ this.state.loadingResults || ! suggestions }
-					/>
-				) }
-			</DomainSearchResults>
+			/>
 		);
 	}
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -360,12 +360,6 @@ class RegisterDomainStep extends React.Component {
 		const { message, severity } = showNotice
 			? getAvailabilityNotice( lastDomainSearched, error, errorData )
 			: {};
-		const showTldFilterBar =
-			( Array.isArray( this.state.searchResults ) &&
-				this.state.searchResults.length > 0 &&
-				Array.isArray( this.state.availableTlds ) &&
-				this.state.availableTlds.length > 0 ) ||
-			this.state.loadingResults;
 		return (
 			<div className="register-domain-step">
 				<StickyPanel className="register-domain-step__search">
@@ -394,18 +388,6 @@ class RegisterDomainStep extends React.Component {
 						text={ message }
 						status={ `is-${ severity }` }
 						showDismiss={ false }
-					/>
-				) }
-				{ showTldFilterBar && (
-					<TldFilterBar
-						availableTlds={ this.state.availableTlds }
-						filters={ this.state.filters }
-						isSignupStep={ this.props.isSignupStep }
-						lastFilters={ this.state.lastFilters }
-						onChange={ this.onFiltersChange }
-						onReset={ this.onFiltersReset }
-						onSubmit={ this.onFiltersSubmit }
-						showPlaceholder={ this.state.loadingResults || ! this.getSuggestionsFromProps() }
 					/>
 				) }
 				{ this.renderContent() }
@@ -1005,6 +987,13 @@ class RegisterDomainStep extends React.Component {
 			return this.renderExampleSuggestions();
 		}
 
+		const showTldFilterBar =
+			( Array.isArray( this.state.searchResults ) &&
+				this.state.searchResults.length > 0 &&
+				Array.isArray( this.state.availableTlds ) &&
+				this.state.availableTlds.length > 0 ) ||
+			this.state.loadingResults;
+
 		return (
 			<DomainSearchResults
 				key="domain-search-results" // key is required for CSS transition of content/
@@ -1029,7 +1018,20 @@ class RegisterDomainStep extends React.Component {
 				railcarSeed={ this.state.railcarSeed }
 				fetchAlgo={ searchVendor + '/v1' }
 				cart={ this.props.cart }
-			/>
+			>
+				{ showTldFilterBar && (
+					<TldFilterBar
+						availableTlds={ this.state.availableTlds }
+						filters={ this.state.filters }
+						isSignupStep={ this.props.isSignupStep }
+						lastFilters={ this.state.lastFilters }
+						onChange={ this.onFiltersChange }
+						onReset={ this.onFiltersReset }
+						onSubmit={ this.onFiltersSubmit }
+						showPlaceholder={ this.state.loadingResults || ! this.getSuggestionsFromProps() }
+					/>
+				) }
+			</DomainSearchResults>
 		);
 	}
 

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -29,6 +29,10 @@
 	}
 }
 
+.register-domain-step > .notice.register-domain-step__notice {
+	margin-bottom: 12px;
+}
+
 @keyframes shake {
 	0%,
 	100% {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -91,14 +91,6 @@ export default {
 		},
 		defaultVariation: 'domainsbot',
 	},
-	domainSearchTLDFilterPlacement: {
-		datestamp: '20180531',
-		variations: {
-			belowFeatured: 50,
-			aboveFeatured: 50,
-		},
-		defaultVariation: 'belowFeatured',
-	},
 	staleCartNotice: {
 		datestamp: '20180618',
 		variations: {

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -30,7 +30,6 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"domains/kracken-ui/tld-filter": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/development.json
+++ b/config/development.json
@@ -53,7 +53,6 @@
 		"domains/kracken-ui/dashes-filter": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/max-characters-filter": true,
-		"domains/kracken-ui/tld-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"external-media": true,
 		"external-media/google-photos": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -31,7 +31,6 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"domains/kracken-ui/tld-filter": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/production.json
+++ b/config/production.json
@@ -30,7 +30,6 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"domains/kracken-ui/tld-filter": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -33,7 +33,6 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"domains/kracken-ui/tld-filter": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -36,7 +36,6 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"domains/kracken-ui/tld-filter": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
Follow-up of #25057, summary at p8kIbR-jG.

This PR prominently places the TLD filter bar above the featured suggestions like so:

<img width="1003" alt="create_a_site_ _wordpress_com" src="https://user-images.githubusercontent.com/4044428/41937186-e8128976-794c-11e8-83b9-ff6a46b2ed18.png">

It also removes the feature flag for TLD filters.

# Testing instructions
1. Spin up this branch locally.
2. Navigate to [the signup flow](http://calypso.localhost:3000/start/) with the browser console open. 
3. Fill out the About step and press continue. Ensure that no errors appear in the console.
4. Upon domain step load, ensure that the TLD filter is shown above the featured suggestions.