### PR TITLE
Reader: Avoid potential undefined property access error

### DIFF
--- a/client/state/reader/streams/reducer.js
+++ b/client/state/reader/streams/reducer.js
@@ -113,7 +113,6 @@ export const pendingItems = ( state = PENDING_ITEMS_DEFAULT, action ) => {
 			return { ...state, lastUpdated: maxDate };
 		case READER_STREAMS_UPDATES_RECEIVE:
 			streamItems = action.payload.streamItems;
-			maxDate = moment( streamItems[ 0 ].date );
 			const minDate = moment( last( streamItems ).date );
 
 			// only retain posts that are newer than ones we already have
@@ -126,6 +125,8 @@ export const pendingItems = ( state = PENDING_ITEMS_DEFAULT, action ) => {
 			if ( streamItems.length === 0 ) {
 				return state;
 			}
+
+			maxDate = moment( streamItems[ 0 ].date );
 
 			const newItems = [ ...streamItems ];
 

--- a/client/state/reader/streams/reducer.js
+++ b/client/state/reader/streams/reducer.js
@@ -113,6 +113,11 @@ export const pendingItems = ( state = PENDING_ITEMS_DEFAULT, action ) => {
 			return { ...state, lastUpdated: maxDate };
 		case READER_STREAMS_UPDATES_RECEIVE:
 			streamItems = action.payload.streamItems;
+			if ( streamItems.length === 0 ) {
+				return state;
+			}
+
+			maxDate = moment( streamItems[ 0 ].date );
 			const minDate = moment( last( streamItems ).date );
 
 			// only retain posts that are newer than ones we already have
@@ -125,8 +130,6 @@ export const pendingItems = ( state = PENDING_ITEMS_DEFAULT, action ) => {
 			if ( streamItems.length === 0 ) {
 				return state;
 			}
-
-			maxDate = moment( streamItems[ 0 ].date );
 
 			const newItems = [ ...streamItems ];
 

--- a/client/state/reader/streams/test/reducer.js
+++ b/client/state/reader/streams/test/reducer.js
@@ -173,6 +173,14 @@ describe( 'streams.pendingItems reducer', () => {
 
 		expect( nextState ).toBe( prevState );
 	} );
+
+	it( 'should return the original state with empty changes', () => {
+		const prevState = deepfreeze( { items: [], lastUpdated: moment( TIME2 ) } );
+		const action = receiveUpdates( { streamItems: [] } );
+		const nextState = pendingItems( prevState, action );
+
+		expect( nextState ).toBe( prevState );
+	} );
 } );
 
 describe( 'streams.selected reducer', () => {


### PR DESCRIPTION
This PR fixes a potential error in the reader stream reducer.

We're seeing a lot of `Cannot read property 'date' of undefined` errors in the Calypso error dashboard, at least some of which show a backtrace that includes `pendingItems`.

I'm not sure that this change will fix those errors, but it's a simple improvement without an apparent downside.

@samouri: Your feedback would be welcome if you cared to review.