### PR TITLE
Comments: add a display duration to comment loading error notices

### DIFF
--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -116,7 +116,7 @@ export const announceFailure = ( { siteId, postId } ) => ( dispatch, getState ) 
 		? translate( 'Could not retrieve comments for “%(postTitle)s”', { args: { postTitle } } )
 		: translate( 'Could not retrieve comments for requested post' );
 
-	dispatch( errorNotice( error ) );
+	dispatch( errorNotice( error ), { duration: 5000 } );
 };
 
 // @see https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/comments/%24comment_ID/delete/

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -116,7 +116,7 @@ export const announceFailure = ( { siteId, postId } ) => ( dispatch, getState ) 
 		? translate( 'Could not retrieve comments for “%(postTitle)s”', { args: { postTitle } } )
 		: translate( 'Could not retrieve comments for requested post' );
 
-	dispatch( errorNotice( error ), { duration: 5000 } );
+	dispatch( errorNotice( error, { duration: 5000 } ) );
 };
 
 // @see https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/comments/%24comment_ID/delete/

--- a/client/state/data-layer/wpcom/comments/test/index.js
+++ b/client/state/data-layer/wpcom/comments/test/index.js
@@ -177,6 +177,7 @@ describe( 'wpcom-api', () => {
 						notice: expect.objectContaining( {
 							status: 'is-error',
 							text: 'Could not retrieve comments for requested post',
+							duration: 5000,
 						} ),
 					} )
 				);


### PR DESCRIPTION
Fixes #25262.

<img width="686" alt="screen shot 2018-06-27 at 15 29 53" src="https://user-images.githubusercontent.com/17325/41951412-f8263d12-7a1e-11e8-9dc9-c9ea8ce8e6e1.png">

If we've been unable to fetch the next page of comments, we currently fill the screen with error notices as the request is repeatedly retried. This small PR adds a display duration to ensure that the error notices vanish after 5 seconds.

### To test

Load a full post with lots of comments, like http://calypso.localhost:3000/read/blogs/82798297/posts/82. Turn off your network connection, and try to load earlier comments. Multiple error notices should not be shown.