### PR TITLE
Activity: updates “restore” terms to “rewind”

### DIFF
--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -72,8 +72,8 @@ class ErrorBanner extends PureComponent {
 		} = this.props;
 		const strings = isUndefined( downloadId )
 			? {
-					title: translate( 'Problem restoring your site' ),
-					details: translate( 'We came across a problem while trying to restore your site.' ),
+					title: translate( 'Problem rewinding your site' ),
+					details: translate( 'We came across a problem while trying to rewind your site.' ),
 			  }
 			: {
 					title: translate( 'Problem preparing your file' ),

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -66,16 +66,16 @@ function ProgressBanner( {
 						? translate( 'The cloning process will start in a moment.' )
 						: translate( "We're on it! Your site is being cloned." );
 			} else {
-				title = translate( 'Currently restoring your site' );
+				title = translate( 'Currently rewinding your site' );
 				description = translate(
-					"We're in the process of restoring your site back to %(dateTime)s. " +
+					"We're in the process of rewinding your site back to %(dateTime)s. " +
 						"You'll be notified once it's complete.",
 					{ args: { dateTime } }
 				);
 				statusMessage =
 					'queued' === status
-						? translate( 'Your restore will start in a moment.' )
-						: translate( "We're on it! Your site is being restored." );
+						? translate( 'Your rewind will start in a moment.' )
+						: translate( "We're on it! Your site is being rewound." );
 			}
 			break;
 

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -57,38 +57,37 @@ function ProgressBanner( {
 			if ( 'alternate' === context ) {
 				title = translate( 'Currently cloning your site' );
 				description = translate(
-					"We're in the process of cloning your site to %(dateTime)s. " +
-						"You'll be notified once it's complete.",
+					"We're cloning your site to %(dateTime)s. " + "You'll be notified once it's complete.",
 					{ args: { dateTime } }
 				);
 				statusMessage =
 					'queued' === status
 						? translate( 'The cloning process will start in a moment.' )
-						: translate( "We're on it! Your site is being cloned." );
+						: translate( 'Away we go! Your site is being cloned.' );
 			} else {
 				title = translate( 'Currently rewinding your site' );
 				description = translate(
-					"We're in the process of rewinding your site back to %(dateTime)s. " +
+					"We're rewinding your site back to %(dateTime)s. " +
 						"You'll be notified once it's complete.",
 					{ args: { dateTime } }
 				);
 				statusMessage =
 					'queued' === status
 						? translate( 'Your rewind will start in a moment.' )
-						: translate( "We're on it! Your site is being rewound." );
+						: translate( 'Away we go! Your site is being rewound.' );
 			}
 			break;
 
 		case 'backup':
 			title = translate( 'Currently creating a downloadable backup of your site' );
 			description = translate(
-				"We're in the process of creating a downloadable backup of your site at %(dateTime)s. " +
+				"We're creating a downloadable backup of your site at %(dateTime)s. " +
 					"You'll be notified once it's complete.",
 				{ args: { dateTime } }
 			);
 			statusMessage =
 				0 < percent
-					? translate( "We're on it! Your download is being created." )
+					? translate( 'Away we go! Your download is being created.' )
 					: translate( 'The creation of your backup will start in a moment.' );
 			break;
 	}

--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -109,7 +109,7 @@ class SuccessBanner extends PureComponent {
 					title:
 						'alternate' === context
 							? translate( 'Your site has been successfully cloned' )
-							: translate( 'Your site has been successfully restored' ),
+							: translate( 'Your site has been successfully rewound' ),
 					icon: 'history',
 					track: (
 						<TrackComponentView
@@ -122,7 +122,7 @@ class SuccessBanner extends PureComponent {
 							? translate( 'We successfully cloned your site to the state as of %(date)s!', {
 									args: { date },
 							  } )
-							: translate( 'We successfully restored your site back to %(date)s!', {
+							: translate( 'We successfully rewound your site back to %(date)s!', {
 									args: { date },
 							  } ),
 					actionButton: (


### PR DESCRIPTION
This PR updates the wording from “restore” to “rewind” on all these banners, making the language consistent across the entire flow:

- Progress banner
- Success banner
- Error banner

#### Before

<img width="734" alt="screen shot 2018-06-27 at 10 05 53" src="https://user-images.githubusercontent.com/390760/41964418-cc7992a4-79f1-11e8-9f85-4f976d81e997.png">


#### After

<img width="726" alt="screen shot 2018-06-27 at 10 06 21" src="https://user-images.githubusercontent.com/390760/41964422-cec0cde8-79f1-11e8-914f-53e03d8e36e1.png">
