### PR TITLE
Fix: added redirect in page /sites/site.com

### DIFF
--- a/client/my-sites/index.js
+++ b/client/my-sites/index.js
@@ -13,5 +13,6 @@ import { siteSelection, sites } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/sites/:sitesFilter?', siteSelection, sites, makeLayout, clientRender );
+	page( '/sites/:site', context => page.redirect( '/stats/insights/' + context.params.site ) );
+	page( '/sites', siteSelection, sites, makeLayout, clientRender );
 }


### PR DESCRIPTION
From #25783

Removed `sitesFilter` param from route `/sites/:sitesFilter?` 
Fix the bug from #11543 redirecting `/sites/:site` to `/stats/insights/:site`.

---

@jsnajdr Is there already a way to check `:site` is valid and if not redirect to 404?