### PR TITLE
Jetpack: Add tracks to the return to your site link

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -272,6 +272,13 @@ export class JetpackAuthorize extends Component {
 		userUtilities.logout( window.location.href );
 	};
 
+	handleBackToSite = () => {
+		const { recordTracksEvent } = this.props;
+		const { redirectAfterAuth } = this.props.authQuery;
+		recordTracksEvent( 'calypso_jpc_cancel_authorize_click' );
+		this.externalRedirect( redirectAfterAuth );
+	};
+
 	handleResolve = () => {
 		const { site, recordTracksEvent } = this.props;
 		this.retryingAuth = false;
@@ -552,9 +559,9 @@ export class JetpackAuthorize extends Component {
 	renderFooterLinks() {
 		const { translate } = this.props;
 		const { authorizeSuccess, isAuthorizing } = this.props.authorizationData;
-		const { blogname, redirectAfterAuth } = this.props.authQuery;
+		const { blogname } = this.props.authQuery;
 		const backToWpAdminLink = (
-			<LoggedOutFormLinkItem href={ redirectAfterAuth }>
+			<LoggedOutFormLinkItem onClick={ this.handleBackToSite }>
 				<Gridicon size={ 18 } icon="arrow-left" />{' '}
 				{ translate( 'Return to %(sitename)s', {
 					args: { sitename: decodeEntities( blogname ) },

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -274,9 +274,7 @@ export class JetpackAuthorize extends Component {
 
 	handleBackToSite = () => {
 		const { recordTracksEvent } = this.props;
-		const { redirectAfterAuth } = this.props.authQuery;
 		recordTracksEvent( 'calypso_jpc_cancel_authorize_click' );
-		this.externalRedirect( redirectAfterAuth );
 	};
 
 	handleResolve = () => {
@@ -559,9 +557,9 @@ export class JetpackAuthorize extends Component {
 	renderFooterLinks() {
 		const { translate } = this.props;
 		const { authorizeSuccess, isAuthorizing } = this.props.authorizationData;
-		const { blogname } = this.props.authQuery;
+		const { blogname, redirectAfterAuth } = this.props.authQuery;
 		const backToWpAdminLink = (
-			<LoggedOutFormLinkItem onClick={ this.handleBackToSite }>
+			<LoggedOutFormLinkItem onClick={ this.handleBackToSite } href={ redirectAfterAuth }>
 				<Gridicon size={ 18 } icon="arrow-left" />{' '}
 				{ translate( 'Return to %(sitename)s', {
 					args: { sitename: decodeEntities( blogname ) },

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -70,6 +70,7 @@ exports[`JetpackAuthorize renders as expected 1`] = `
       <LoggedOutFormLinks>
         <LoggedOutFormLinkItem
           href="http://an.example.site/wp-admin/admin.php?page=jetpack"
+          onClick={[Function]}
         >
           <t
             icon="arrow-left"


### PR DESCRIPTION
This PR just adds some tracking to the "Return to your site" link that cancels the authorization flow of Jetpack

Testing Instructions
* Create a new Jetpack site (e.g. Jurassic Ninja)
* Make sure you are logged to WordPress.com
* In wp-admin, locate the green 'Set up Jetpack' button and click it. You will end in the WordPress.com version of this page: 
![image](https://user-images.githubusercontent.com/1554855/42092815-956662f0-7baa-11e8-9fe0-583f68130e4e.png)
* Go to the dev console and clear your storage (Everything but cookies)
* Without doing anything, chage the "wordpress.com" part of the url to either calypso.live or calypso.localhost (if you use calypso.live you probably need to add the branch name parameter too)
* Open the browser console, enter `localStorage.setItem( 'debug', 'calypso:analytics*' );` and reload
* Click the 'Back to ...' link on the bottom of the page and check a tracks event is fired before being redirected back to your site
