### PR TITLE
Clean up domain name selection on small screens

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -2,13 +2,16 @@
 
 .domain-suggestion {
 	box-sizing: border-box;
-	display: flex;
-	align-items: center;
 
 	@include clear-fix;
 
 	@include breakpoint( '>660px' ) {
 		padding: 15px 20px;
+	}
+
+	@include breakpoint( '>480px' ) {
+		display: flex;
+		align-items: center;
 	}
 
 	&.is-clickable {
@@ -103,27 +106,47 @@
 	}
 }
 
+.domain-product-price__price {
+	font-size: 1.2em;
+
+	@include breakpoint( '>480px' ) {
+		font-size: 1em;
+	}
+}
+
 .domain-registration-suggestion__title {
-	align-self: center;
-	line-height: 1.25;
-	padding-right: 2em;
+	font-size: 1.3em;
+
+	@include breakpoint( '>480px' ) {
+		align-self: center;
+		padding-right: 2em;
+		font-size: 1em;
+		line-height: 1.25;
+	}
 }
 
 .button.domain-suggestion__action {
-	flex: 1 0 auto;
 	min-width: 66px;
 	text-align: center;
 	color: $blue-medium;
+	margin-top: 0.5em;
+	padding-left: 3em;
+	padding-right: 3em;
 
 	&.is-primary {
 		color: $white;
-		margin-left: 1em;
-		padding: 0.25em 3em;
 		transition: all 0.1s linear;
 
 		&:hover {
 			background-color: lighten( $blue-medium, 4% );
 			border-color: darken( $blue-medium, 4% );
+		}
+
+		@include breakpoint( '>480px' ) {
+			margin-left: 1em;
+			margin-top: 0;
+			padding-top: 0.25em;
+			padding-bottom: 0.25em;
 		}
 	}
 
@@ -135,6 +158,10 @@
 		color: transparent;
 		margin-left: 40px;
 		min-height: 26px;
+	}
+
+	@include breakpoint( '>480px' ) {
+		flex: 1 0 auto;
 	}
 }
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -130,8 +130,8 @@
 	text-align: center;
 	color: $blue-medium;
 	margin-top: 0.5em;
-	padding-left: 3em;
-	padding-right: 3em;
+	padding: 0.25em 3em;
+	float: right;
 
 	&.is-primary {
 		color: $white;
@@ -145,8 +145,6 @@
 		@include breakpoint( '>480px' ) {
 			margin-left: 1em;
 			margin-top: 0;
-			padding-top: 0.25em;
-			padding-bottom: 0.25em;
 		}
 	}
 
@@ -162,6 +160,19 @@
 
 	@include breakpoint( '>480px' ) {
 		flex: 1 0 auto;
+		float: none;
+	}
+}
+
+.domain-transfer-suggestion {
+	display: flex;
+	align-items: center;
+
+	.button.domain-suggestion__action {
+		flex: 1 0 auto;
+		margin: 0;
+		padding-left: 0;
+		padding-right: 0;
 	}
 }
 


### PR DESCRIPTION
This is one way we could fix the display of long domain names on smaller screens; everything gets its own line and the font sizes get bumped up.

Steps to test

* Switch to this branch
* Navigate to http://calypso.localhost:3000/start
* Resize screen to less than 480px wide, or test on your phone in portrait mode
* Search for a domain name; try both long and short varieties
* Note the changes in placement of the button when the screen is wide vs. narrow

Before:

![image uploaded from ios](https://user-images.githubusercontent.com/2124984/41987351-df515b18-7a06-11e8-8d2f-44e7f9dc6641.jpg)

After:

<img width="350" alt="screen shot 2018-06-27 at 12 42 09 pm" src="https://user-images.githubusercontent.com/2124984/41987624-b66f9f60-7a07-11e8-822e-33de77c188a7.png">

I'm not entirely sold on this, because if the domain name suggestions are short, you get a screen like this:

<img width="354" alt="screen shot 2018-06-27 at 12 41 04 pm" src="https://user-images.githubusercontent.com/2124984/41987612-ae79e43c-7a07-11e8-882d-c88c94480171.png">

I have another idea I want to try, too, but this is one option.