### PR TITLE
AboutStep: Improve site topic suggestions

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -107,4 +107,12 @@ export default {
 		},
 		defaultVariation: 'siteDeservesBoost',
 	},
+	aboutSuggestionMatches: {
+		datestamp: '20180704',
+		variations: {
+			control: 50,
+			enhancedSort: 50,
+		},
+		defaultVariation: 'control',
+	},
 };

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -46,6 +46,7 @@ import Suggestions from 'components/suggestions';
 class AboutStep extends Component {
 	constructor( props ) {
 		super( props );
+		this._isMounted = false;
 		this.state = {
 			query: '',
 			siteTopicValue: this.props.siteTopic,
@@ -55,7 +56,8 @@ class AboutStep extends Component {
 		};
 	}
 
-	componentWillMount() {
+	componentDidMount() {
+		this._isMounted = true;
 		this.formStateController = new formState.Controller( {
 			fieldNames: [ 'siteTitle', 'siteGoals', 'siteTopic' ],
 			validatorFunction: noop,
@@ -73,12 +75,15 @@ class AboutStep extends Component {
 				},
 			},
 		} );
-
 		this.setFormState( this.formStateController.getInitialState() );
 	}
 
+	componentWillUnmount() {
+		this._isMounted = false;
+	}
+
 	setFormState = state => {
-		this.setState( { form: state } );
+		this._isMounted && this.setState( { form: state } );
 	};
 
 	setPressableStore = ref => {

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -98,14 +98,13 @@ class AboutStep extends Component {
 		this.setState( { query: '' } );
 	};
 
-	handleSuggestionChangeEvent = event => {
-		this.setState( { query: event.target.value } );
-		this.setState( { siteTopicValue: event.target.value } );
+	handleSuggestionChangeEvent = ( { target: { name, value } } ) => {
+		this.setState( { query: value } );
+		this.setState( { siteTopicValue: value } );
 
-		this.formStateController.handleFieldChange( {
-			name: event.target.name,
-			value: event.target.value,
-		} );
+		this.props.recordTracksEvent( 'calypso_signup_actions_select_site_topic', { value } );
+
+		this.formStateController.handleFieldChange( { name, value } );
 	};
 
 	handleSuggestionKeyDown = event => {
@@ -172,11 +171,19 @@ class AboutStep extends Component {
 	};
 
 	getSuggestions() {
+		const query = this.state.query && escapeRegExp( this.state.query ).toLowerCase();
+		const regex = new RegExp( query, 'i' );
+
+		// Prioritize suggestions starting with query input first
+		const sortFunction = ( a, b ) =>
+			abtest( 'aboutSuggestionMatches' ) === 'enhancedSort'
+				? a.localeCompare( b ) -
+				  2 * ( b.toLowerCase().indexOf( query ) - a.toLowerCase().indexOf( query ) )
+				: a.localeCompare( b );
+
 		return Object.values( hints )
-			.filter(
-				hint =>
-					this.state.query && hint.match( new RegExp( escapeRegExp( this.state.query ), 'i' ) )
-			)
+			.filter( hint => query && hint.match( regex ) )
+			.sort( sortFunction )
 			.map( hint => ( { label: hint } ) );
 	}
 
@@ -279,6 +286,9 @@ class AboutStep extends Component {
 			findKey( hints, siteTopic => siteTopic === siteTopicInput ) || siteTopicInput;
 
 		eventAttributes.site_topic = englishSiteTopicInput || 'N/A';
+		this.props.recordTracksEvent( 'calypso_signup_actions_submit_site_topic', {
+			value: eventAttributes.site_topic,
+		} );
 
 		this.props.setSurvey( {
 			vertical: englishSiteTopicInput,


### PR DESCRIPTION
This PR improves the suggestion logic for the site topic input to ~match the beginning and end of words~ prioritize suggestions beginning with the user's query. It also creates an A/B test named `aboutSuggestionMatches` starting on `20180704`. We hypothesize that this will increase the quality of site topic selections.

<img width="521" alt="create_a_site_ _wordpress_com" src="https://user-images.githubusercontent.com/4044428/42002701-6e03099c-7a25-11e8-8a67-43522e56b633.png">

This PR also fixes a bug relating to the [About step of the signup flow](http://calypso.localhost:3000/start/about) where we invoke `setState` on an unmounted component.

# Testing instructions
1. Spin up this branch locally.
2. Navigate to the [signup flow](http://calypso.localhost:3000/start/about).
3. Using the A/B test helper component on the bottom right of the screen, set `aboutSuggestionMatches` test to `beginningAndEndOfWords`. (EDIT: Try `enhancedSort` now instead of `beginningAndEndOfWords`.)

<img width="505" alt="create_a_site_ _wordpress_com" src="https://user-images.githubusercontent.com/4044428/42001675-ef66fcfe-7a21-11e8-98fa-1f9c07c5fb20.png">

4. Try a variety of queries for the site topic input. Ensure that they only match the beginning or ending of words. 