### PR TITLE
Add Google Maps API key to the editor

### DIFF
--- a/client/lib/geocoding/index.js
+++ b/client/lib/geocoding/index.js
@@ -37,5 +37,5 @@ export function geocode( address ) {
 }
 
 export function reverseGeocode( latitude, longitude ) {
-	return queryGoogleMapsApi( { latlng: latitude + ',' + longitude } );
+	return queryGoogleMapsApi( { latlng: latitude + ',' + longitude, key: GOOGLE_MAPS_API_KEY } );
 }

--- a/client/lib/geocoding/index.js
+++ b/client/lib/geocoding/index.js
@@ -7,9 +7,15 @@
 import request from 'superagent';
 
 /**
++ * Internal dependencies
++ */
+import config from 'config';
+
+/**
  * Module variables
  */
 const GOOGLE_MAPS_API_BASE_URL = 'https://maps.googleapis.com/maps/api/geocode/json';
+const GOOGLE_MAPS_API_KEY = config( 'google_maps_and_places_api_key' );
 
 function queryGoogleMapsApi( queryParams ) {
 	return new Promise( ( resolve, reject ) => {
@@ -27,7 +33,7 @@ function queryGoogleMapsApi( queryParams ) {
 }
 
 export function geocode( address ) {
-	return queryGoogleMapsApi( { address } );
+	return queryGoogleMapsApi( { address, key: GOOGLE_MAPS_API_KEY } );
 }
 
 export function reverseGeocode( latitude, longitude ) {

--- a/client/lib/geocoding/index.js
+++ b/client/lib/geocoding/index.js
@@ -42,5 +42,8 @@ export function geocode( address ) {
 }
 
 export function reverseGeocode( latitude, longitude ) {
-	return queryGoogleMapsApi( { location: { lat: latitude, lng: longitude } } );
+	console.log( { location: { lat: parseFloat( latitude ), lng: parseFloat( longitude ) } } );
+	return queryGoogleMapsApi( {
+		location: { lat: parseFloat( latitude ), lng: parseFloat( longitude ) },
+	} );
 }

--- a/client/lib/geocoding/index.js
+++ b/client/lib/geocoding/index.js
@@ -20,15 +20,12 @@ const GOOGLE_MAPS_API_KEY = config( 'google_maps_and_places_api_key' );
 let geocoder;
 
 function queryGoogleMapsApi( queryParams ) {
-	console.log( 'called queryGoogleMapsApi' );
 	return new Promise( ( resolve, reject ) => {
 		if ( geocoder ) {
-			console.log( 'Howdy!' );
 			return queryGeocoder( queryParams, resolve, reject );
 		}
 
 		loadScript( GOOGLE_MAPS_API_BASE_URL + '?key=' + GOOGLE_MAPS_API_KEY, function() {
-			console.log( 'load script' );
 			// eslint-disable-next-line no-undef
 			geocoder = new google.maps.Geocoder();
 			return queryGeocoder( queryParams, resolve, reject );
@@ -37,13 +34,10 @@ function queryGoogleMapsApi( queryParams ) {
 }
 
 function queryGeocoder( queryParams, resolve, reject ) {
-	console.log( 'queryGeocoder', queryParams );
 	geocoder.geocode( queryParams, function( results, status ) {
 		if ( status === 'OK' ) {
-			console.log( 'WORKED', results, status );
 			return resolve( results );
 		}
-		console.log( 'FAILED', results, status );
 		reject( status );
 	} );
 }

--- a/client/lib/geocoding/index.js
+++ b/client/lib/geocoding/index.js
@@ -1,8 +1,8 @@
 /** @format */
 
 /**
-+ * Internal dependencies
-+ */
+ * Internal dependencies
+ */
 import config from 'config';
 import { loadScript } from 'lib/load-script';
 

--- a/client/lib/geocoding/index.js
+++ b/client/lib/geocoding/index.js
@@ -20,12 +20,15 @@ const GOOGLE_MAPS_API_KEY = config( 'google_maps_and_places_api_key' );
 let geocoder;
 
 function queryGoogleMapsApi( queryParams ) {
+	console.log( 'called queryGoogleMapsApi' );
 	return new Promise( ( resolve, reject ) => {
 		if ( geocoder ) {
+			console.log( 'Howdy!' );
 			return queryGeocoder( queryParams, resolve, reject );
 		}
 
 		loadScript( GOOGLE_MAPS_API_BASE_URL + '?key=' + GOOGLE_MAPS_API_KEY, function() {
+			console.log( 'load script' );
 			// eslint-disable-next-line no-undef
 			geocoder = new google.maps.Geocoder();
 			return queryGeocoder( queryParams, resolve, reject );
@@ -34,10 +37,13 @@ function queryGoogleMapsApi( queryParams ) {
 }
 
 function queryGeocoder( queryParams, resolve, reject ) {
-	geocode.geocode( queryParams, function( results, status ) {
+	console.log( 'queryGeocoder', queryParams );
+	geocoder.geocode( queryParams, function( results, status ) {
 		if ( status === 'OK' ) {
+			console.log( 'WORKED', results, status );
 			return resolve( results );
 		}
+		console.log( 'FAILED', results, status );
 		reject( status );
 	} );
 }

--- a/client/lib/geocoding/index.js
+++ b/client/lib/geocoding/index.js
@@ -1,15 +1,10 @@
 /** @format */
 
 /**
- * External dependencies
- */
-
-import { loadScript } from 'lib/load-script';
-
-/**
 + * Internal dependencies
 + */
 import config from 'config';
+import { loadScript } from 'lib/load-script';
 
 /**
  * Module variables

--- a/client/lib/geocoding/index.js
+++ b/client/lib/geocoding/index.js
@@ -42,7 +42,6 @@ export function geocode( address ) {
 }
 
 export function reverseGeocode( latitude, longitude ) {
-	console.log( { location: { lat: parseFloat( latitude ), lng: parseFloat( longitude ) } } );
 	return queryGoogleMapsApi( {
 		location: { lat: parseFloat( latitude ), lng: parseFloat( longitude ) },
 	} );

--- a/client/lib/geocoding/test/index.js
+++ b/client/lib/geocoding/test/index.js
@@ -8,8 +8,8 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { geocode, reverseGeocode } from '../';
-import { useNock } from 'test/helpers/use-nock';
 
+jest.mock( 'lib/load-script', () => require( './mocks/load-script' ) );
 /**
  * Module variables
  */
@@ -21,14 +21,6 @@ const TEST_LONGITUDE = '-87.629798';
 
 describe( 'geocoding', () => {
 	describe( 'when converting a search string to location results', () => {
-		useNock( nock => {
-			nock( 'https://maps.googleapis.com' )
-				.persist()
-				.get( '/maps/api/geocode/json' )
-				.query( { address: TEST_ADDRESS } )
-				.reply( 200, { results: [ 1, 2, 3 ], status: 'OK' } );
-		} );
-
 		describe( '#geocode()', () => {
 			test( 'should return a promise', () => {
 				expect( geocode( TEST_ADDRESS ) ).to.be.an.instanceof( Promise );
@@ -46,14 +38,6 @@ describe( 'geocoding', () => {
 	} );
 
 	describe( 'when converting from coordinates to address labels', () => {
-		useNock( nock => {
-			nock( 'https://maps.googleapis.com', { encodedQueryParams: true } )
-				.persist()
-				.get( '/maps/api/geocode/json' )
-				.query( { latlng: TEST_LATITUDE + '%2C' + TEST_LONGITUDE } )
-				.reply( 200, { results: [ 1, 2, 3 ], status: 'OK' } );
-		} );
-
 		describe( '#reverseGeocode()', () => {
 			test( 'should return a promise', () => {
 				expect( reverseGeocode( TEST_LATITUDE, TEST_LONGITUDE ) ).to.be.an.instanceof( Promise );

--- a/client/lib/geocoding/test/mocks/load-script/index.js
+++ b/client/lib/geocoding/test/mocks/load-script/index.js
@@ -1,0 +1,30 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { defer } from 'lodash';
+
+function fakeLoader( url, callback ) {
+	// eslint-disable-next-line no-undef
+	google = {
+		maps: {
+			Geocoder: function() {
+				return {
+					geocode: function( queryParams, result_callback ) {
+						defer( result_callback, [ 1, 2, 3 ], 'OK' ); // fake the results
+					},
+				};
+			},
+		},
+	};
+	fakeLoader.urlsLoaded.push( url );
+	if ( callback ) {
+		defer( callback );
+	}
+}
+
+fakeLoader.urlsLoaded = [];
+
+export default { loadScript: fakeLoader };

--- a/client/post-editor/editor-location/index.jsx
+++ b/client/post-editor/editor-location/index.jsx
@@ -25,6 +25,7 @@ import { updatePostMetadata, deletePostMetadata } from 'state/posts/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getSitePost, getEditedPost } from 'state/posts/selectors';
+import config from 'config';
 
 /**
  * Module variables
@@ -106,7 +107,6 @@ class EditorLocation extends React.Component {
 			error: error,
 			locating: false,
 		} );
-
 		recordStat( 'location_geolocate_failed' );
 	};
 
@@ -141,8 +141,8 @@ class EditorLocation extends React.Component {
 
 	onSearchSelect = result => {
 		this.props.updatePostMetadata( this.props.siteId, this.props.postId, {
-			geo_latitude: toGeoString( result.geometry.location.lat ),
-			geo_longitude: toGeoString( result.geometry.location.lng ),
+			geo_latitude: toGeoString( result.geometry.location.lat() ),
+			geo_longitude: toGeoString( result.geometry.location.lng() ),
 			geo_address: result.formatted_address,
 			geo_public: '1',
 		} );
@@ -159,6 +159,7 @@ class EditorLocation extends React.Component {
 				markers: this.props.coordinates.join( ',' ),
 				zoom: 8,
 				size: '400x300',
+				key: config( 'google_maps_and_places_api_key' ),
 			} );
 
 		return <img src={ src } className="editor-location__map" />;

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -193,5 +193,5 @@
 	"wpcom_signup_id": false,
 	"wpcom_signup_key": false,
 	"statsd_analytics_response_time_max_logs_per_second": 50,
-	"google_maps_and_places_api_key": "AIzaSyAznW1ev6zto9Dc6lsrWkrMs5R8xDTFWXs"
+	"google_maps_and_places_api_key": "AIzaSyAJN-ceOpTLP1CSQdyoRLS4VT9Zlsibkeg"
 }

--- a/test/client/jest.config.json
+++ b/test/client/jest.config.json
@@ -16,5 +16,8 @@
 	"testMatch": [ "<rootDir>/client/**/test/*.js?(x)" ],
 	"testURL": "https://example.com",
 	"setupTestFrameworkScriptFile": "<rootDir>/test/client/setup-test-framework.js",
-	"verbose": false
+	"verbose": false,
+	"globals": {
+		"google": {}
+	}
 }


### PR DESCRIPTION
Update the api keys that are already defined.

1. We switched from using the geocode api to using the JS api because the geocode api key was expecting  to be called server side. 
2. Add the api key to the google maps image that is shown to the editor.
3. Update the tests so that they work with the new assumptions. 

### To test 
Go to the post editor notice that you can add the location as expected. You see the image map as expected
Go to the stats page notice that you see the map as expected. 

Go to devdocs notice that location search works as expected 
https://wpcalypso.wordpress.com/devdocs/blocks/location-search 
