### PR TITLE
Data layer: know when to trust total count from read/following/mine

### DIFF
--- a/client/state/data-layer/wpcom/read/following/mine/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/index.js
@@ -73,10 +73,18 @@ export function receivePage( store, action, apiResponse ) {
 
 	const { page, number } = apiResponse;
 	const follows = subscriptionsFromApi( apiResponse );
+	let totalCount = null;
+
+	// Only trust the total count if we're on the first page of results,
+	// or on subsequent pages where we have more than one follow returned
+	if ( page === 1 || number > 0 ) {
+		totalCount = apiResponse.total_subscriptions;
+	}
+
 	store.dispatch(
 		receiveFollowsAction( {
 			follows,
-			totalCount: apiResponse.total_subscriptions,
+			totalCount,
 		} )
 	);
 
@@ -89,6 +97,7 @@ export function receivePage( store, action, apiResponse ) {
 		store.dispatch( requestPageAction( page + 1 ) );
 		return;
 	}
+
 	// all done syncing
 	store.dispatch( syncComplete( Array.from( seenSubscriptions ) ) );
 

--- a/client/state/data-layer/wpcom/read/following/mine/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/test/index.js
@@ -141,7 +141,7 @@ describe( 'get follow subscriptions', () => {
 			expect( dispatch ).to.have.been.calledWith(
 				receiveFollowsAction( {
 					follows: [],
-					totalCount: 10,
+					totalCount: null,
 				} )
 			);
 			expect( dispatch ).to.have.been.calledWith(
@@ -185,7 +185,7 @@ describe( 'get follow subscriptions', () => {
 			expect( dispatch ).to.have.been.calledWith(
 				receiveFollowsAction( {
 					follows: [],
-					totalCount: 10,
+					totalCount: null,
 				} )
 			);
 


### PR DESCRIPTION
When requesting user subscriptions from `/read/following/mine`, the response includes a `total_subscriptions` count.

On page 1 of results when we have less subs than the page size (e.g. 50 subs and we've tried to fetch 200), `total_subscriptions` will be completely accurate and will exclude any deleted or private blogs that we can't display.

On page 2 of results and above, `total_subscriptions` is a quick count of the user's subscription matrix, which potentially includes deleted, spammy or private blogs, so may not be entirely accurate.

This PR stops us from using the `total_subscriptions` count from page 2+ of results when the result set for that page is empty. It addresses the scenario where:

- the user has less than 200 subs
- we have an accurate count from page 1
- we don't want an empty page 2 result set to override the accurate count we already have

We encountered this when investigating p5PDj3-4zs-p2.

### To test

Switch to the user in the above p2 post.

Verify that their subscriptions count on http://calypso.localhost:3000/following/manage is 1, not 35.

(They have 34 followed sites that are private and they don't have access to.)