### PR TITLE
Fix calypso login failing when adding new properties to the login endpoint response

### DIFF
--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { get, isEmpty, omit, startsWith } from 'lodash';
+import { get, isEmpty, pick, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -162,15 +162,29 @@ const updateTwoStepNonce = ( state, { twoStepNonce, nonceType } ) =>
 		[ `two_step_nonce_${ nonceType }` ]: twoStepNonce,
 	} );
 
+const twoFactorProperties = [
+	'push_web_token',
+	'phone_number',
+	'two_step_id',
+	'two_step_nonce',
+	'two_step_supported_auth_types',
+	'two_step_notification_sent',
+	'two_step_nonce_backup',
+	'two_step_nonce_sms',
+	'two_step_nonce_authenticator',
+	'two_step_nonce_push',
+	'user_id',
+];
+
 export const twoFactorAuth = createReducer( null, {
 	[ LOGIN_REQUEST ]: () => null,
 	[ LOGIN_REQUEST_FAILURE ]: () => null,
 	[ LOGIN_REQUEST_SUCCESS ]: ( state, { data } ) => {
 		if ( data ) {
-			const rest = omit( data, 'redirect_to' );
+			const twoFactorData = pick( data, twoFactorProperties );
 
-			if ( ! isEmpty( rest ) ) {
-				return rest;
+			if ( ! isEmpty( twoFactorData ) ) {
+				return twoFactorData;
 			}
 		}
 
@@ -180,10 +194,10 @@ export const twoFactorAuth = createReducer( null, {
 	[ SOCIAL_LOGIN_REQUEST_FAILURE ]: () => null,
 	[ SOCIAL_LOGIN_REQUEST_SUCCESS ]: ( state, { data } ) => {
 		if ( data ) {
-			const rest = omit( data, 'redirect_to' );
+			const twoFactorData = pick( data, twoFactorProperties );
 
-			if ( ! isEmpty( rest ) ) {
-				return rest;
+			if ( ! isEmpty( twoFactorData ) ) {
+				return twoFactorData;
 			}
 		}
 

--- a/client/state/login/test/reducer.js
+++ b/client/state/login/test/reducer.js
@@ -494,7 +494,10 @@ describe( 'reducer', () => {
 				data,
 			} );
 
-			expect( state ).to.eql( { ...data } );
+			expect( state ).to.eql( {
+				two_step_id: 12345678,
+				two_step_nonce: 'abcdefgh1234',
+			} );
 		} );
 
 		test( 'should set twoFactorAuth to null value if a request is unsuccessful', () => {
@@ -516,7 +519,10 @@ describe( 'reducer', () => {
 				data,
 			} );
 
-			expect( state ).to.eql( { ...data } );
+			expect( state ).to.eql( {
+				two_step_id: 12345678,
+				two_step_nonce: 'abcdefgh1234',
+			} );
 		} );
 
 		test( 'should set twoFactorAuth to null value if a social request is unsuccessful', () => {


### PR DESCRIPTION
There's a problem in how we detect if an account is 2fa or not on login: https://github.com/Automattic/wp-calypso/blob/master/client/state/login/reducer.js#L169
We basically exclude `redirect_to` and check if there are any properties left. Instead we should extract all 2fa properties from a whitelist.

### Testing Instructions
- Boot the branch locally
- Apply server side patch D15243
- Open a new incognito window and login with a non-2fa account http://calypso.localhost:3000/log-in, it should work
- Try logging in with a 2fa account, it should work as well

### Reviews
- [ ] Code
- [ ] Product