### PR TITLE
Activity log: show correct plan for unavailability nudge

### DIFF
--- a/client/my-sites/stats/activity-log/unavailability-notice.jsx
+++ b/client/my-sites/stats/activity-log/unavailability-notice.jsx
@@ -13,6 +13,7 @@ import Banner from 'components/banner';
 import { getSiteAdminUrl } from 'state/sites/selectors';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import getRewindState from 'state/selectors/get-rewind-state';
+import { PLAN_JETPACK_BUSINESS } from 'lib/plans/constants';
 
 export const UnavailabilityNotice = ( {
 	adminUrl,
@@ -30,7 +31,7 @@ export const UnavailabilityNotice = ( {
 		case 'missing_plan':
 			return (
 				<Banner
-					plan="personal-bundle"
+					plan={ PLAN_JETPACK_BUSINESS }
 					href={ `/plans/${ slug }` }
 					callToAction={ translate( 'Upgrade' ) }
 					title={ translate(


### PR DESCRIPTION
Use correct plan in the unavailability nudge when Rewind is unavailable

The banner was using "personal" plan colours previously, which doesn't have Rewind available.

Before
![image](https://user-images.githubusercontent.com/87168/42025695-e0828b48-7acd-11e8-8ff5-ea8042e43415.png)

After
![screen shot 2018-06-28 at 14 52 12](https://user-images.githubusercontent.com/87168/42033448-94dfdcb4-7ae5-11e8-973d-7dec8aa8efbc.png)
