### PR TITLE
Activity log: show second-precision time when hovering

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -399,7 +399,9 @@ class ActivityLogItem extends Component {
 				) }
 				<div className={ classes }>
 					<div className="activity-log-item__type">
-						<div className="activity-log-item__time">{ adjustedTime.format( 'LT' ) }</div>
+						<div className="activity-log-item__time" title={ adjustedTime.format( 'LTS' ) }>
+							{ adjustedTime.format( 'LT' ) }
+						</div>
 						<ActivityIcon activityIcon={ activityIcon } activityStatus={ activityStatus } />
 					</div>
 					<FoldableCard


### PR DESCRIPTION
Adds precision to activity log timestamps by showing seconds when hovering the time. 

![seconds](https://user-images.githubusercontent.com/87168/42037016-df530398-7aef-11e8-939d-c0d1cd733677.gif)

Closes #24623