### PR TITLE
Inline Help: add "site/blog/both" content to fallback and posts-pages links

### DIFF
--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -14,6 +14,13 @@ import { RESULT_TOUR, RESULT_VIDEO } from './constants';
  */
 const fallbackLinks = [
 	{
+		link: 'https://en.support.wordpress.com/do-i-need-a-website-a-blog-or-a-website-with-a-blog/',
+		post_id: 143180,
+		title: 'Do I Need a Website, a Blog, or a Website with a Blog?',
+		description:
+			'If you’re building a brand new site, you might be wondering if you need a website, a blog, or a website with a blog. At WordPress.com, you can create all of these options easily, right in your dashboard.',
+	},
+	{
 		link: 'https://en.support.wordpress.com/business-plan/',
 		post_id: 134940,
 		title: 'Uploading custom plugins and themes',
@@ -348,6 +355,13 @@ const contextLinksForSection = {
 		},
 	],
 	'posts-pages': [
+		{
+			link: 'https://en.support.wordpress.com/do-i-need-a-website-a-blog-or-a-website-with-a-blog/',
+			post_id: 143180,
+			title: 'Do I Need a Website, a Blog, or a Website with a Blog?',
+			description:
+				'If you’re building a brand new site, you might be wondering if you need a website, a blog, or a website with a blog. At WordPress.com, you can create all of these options easily, right in your dashboard.',
+		},
 		{
 			link: 'http://en.support.wordpress.com/five-step-website-setup/',
 			post_id: 100856,


### PR DESCRIPTION
This PR adds [this link](https://en.support.wordpress.com/do-i-need-a-website-a-blog-or-a-website-with-a-blog/) to the Inline Help fallback links (visible at https://wordpress.com/me/privacy for example) and the contextual links displayed when visiting the pages and posts lists. 

To test:
- Verify that the post is listed at the URLs mentioned above. 

Screenshots: 

<img width="453" alt="screen shot 2018-06-28 at 3 30 28 pm" src="https://user-images.githubusercontent.com/23619/42037577-0bef1b78-7ae9-11e8-8023-d17e2751cf7a.png">

(/posts and /pages)

<img width="559" alt="screen shot 2018-06-28 at 3 32 24 pm" src="https://user-images.githubusercontent.com/23619/42037584-0fc5be5a-7ae9-11e8-8f30-e688a2f126f4.png">

(fallback links)