### PR TITLE
Rewind: Add tracks event on credentials form submission

### DIFF
--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -27,6 +27,7 @@ import { deleteCredentials, updateCredentials } from 'state/jetpack/credentials/
 import { getSiteSlug } from 'state/sites/selectors';
 import getJetpackCredentialsUpdateStatus from 'state/selectors/get-jetpack-credentials-update-status';
 import getRewindState from 'state/selectors/get-rewind-state';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 export class RewindCredentialsForm extends Component {
 	static propTypes = {
@@ -114,6 +115,15 @@ export class RewindCredentialsForm extends Component {
 				! payload.kpri && { pass: translate( 'Please enter your server password.' ) },
 			! payload.path && requirePath && { path: translate( 'Please enter a server path.' ) }
 		);
+
+		const eventName =
+			'main' === payload.role
+				? 'calypso_rewind_credentials_save_main'
+				: 'calypso_rewind_credentials_save_alternate';
+
+		const eventData = isEmpty( errors ) ? {} : { errors: Object.keys( errors ).join( ',' ) };
+
+		this.props.recordTracksEvent( eventName, eventData );
 
 		return isEmpty( errors )
 			? updateCredentials( siteId, payload )
@@ -328,5 +338,5 @@ const mapStateToProps = ( state, { siteId } ) => ( {
 
 export default connect(
 	mapStateToProps,
-	{ deleteCredentials, updateCredentials }
+	{ deleteCredentials, updateCredentials, recordTracksEvent }
 )( localize( RewindCredentialsForm ) );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/25758

This PR fires a tracks event whenever the credentials form is submitted. Field validation error keys will be concatenated into a string and sent as a property with the event. When the errors property is omitted, we have a successful form validation.

**Testing**

1. Run this `localStorage.debug = 'calypso:analytics:tracks'` in your browser console.
2. Submit the credentials form for a non-pressable rewind site, and also in the clone flow. You should see `calypso_rewind_credentials_save_main` and `calypso_rewind_credentials_save_alternate` firing respectively, and they should carry an error payload when there were form validation errors.
3. Obviously, make sure all other parts of the credentials form operate normally and are not affected by this PR.