### PR TITLE
Podcasting: Save onDisable

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -42,7 +42,7 @@ import {
 	isRequestingTermsForQueryIgnoringPage,
 	getTermsForQueryIgnoringPage,
 } from 'state/terms/selectors';
-import { isSavingSiteSettings, isSiteSettingsSaveSuccessful } from 'state/site-settings/selectors';
+import { isSavingSiteSettings } from 'state/site-settings/selectors';
 
 class PodcastingDetails extends Component {
 	renderExplicitContent() {
@@ -87,6 +87,7 @@ class PodcastingDetails extends Component {
 				primary={ true }
 				type="submit"
 				disabled={ isRequestingSettings || isSavingSettings || isRequestingCategories }
+				busy={ isSavingSettings }
 			>
 				{ isSavingSettings ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
 			</Button>
@@ -429,7 +430,6 @@ const connectComponent = connect( ( state, ownProps ) => {
 		userCanManagePodcasting: canCurrentUser( state, siteId, 'manage_options' ),
 		isUnsupportedSite: isJetpack && ! isAutomatedTransfer,
 		isSavingSettings: isSavingSiteSettings( state, siteId ),
-		isSaveRequestSuccessful: isSiteSettingsSaveSuccessful( state, siteId ),
 	};
 } );
 

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -24,6 +24,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormSelect from 'components/forms/form-select';
 import FormTextarea from 'components/forms/form-textarea';
 import HeaderCake from 'components/header-cake';
+import scrollTo from 'lib/scroll-to';
 import QueryTerms from 'components/data/query-terms';
 import TermTreeSelector from 'blocks/term-tree-selector';
 import PodcastCoverImageSetting from 'my-sites/site-settings/podcast-cover-image-setting';
@@ -361,6 +362,7 @@ class PodcastingDetails extends Component {
 
 		updateFields( { podcasting_category_id: '0' }, () => {
 			submitForm();
+			scrollTo( { y: 0 } );
 		} );
 	};
 

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -42,6 +42,7 @@ import {
 	isRequestingTermsForQueryIgnoringPage,
 	getTermsForQueryIgnoringPage,
 } from 'state/terms/selectors';
+import { isSavingSiteSettings, isSiteSettingsSaveSuccessful } from 'state/site-settings/selectors';
 
 class PodcastingDetails extends Component {
 	renderExplicitContent() {
@@ -179,7 +180,14 @@ class PodcastingDetails extends Component {
 	}
 
 	render() {
-		const { handleSubmitForm, siteSlug, siteId, translate, isPodcastingEnabled } = this.props;
+		const {
+			handleSubmitForm,
+			siteSlug,
+			siteId,
+			translate,
+			isPodcastingEnabled,
+			isSavingSettings,
+		} = this.props;
 		if ( ! siteId ) {
 			return null;
 		}
@@ -213,7 +221,7 @@ class PodcastingDetails extends Component {
 					<Card className={ classes }>{ error || this.renderSettings() }</Card>
 					{ isPodcastingEnabled && (
 						<div className="podcasting-details__disable-podcasting">
-							<Button onClick={ this.onCategoryCleared } scary>
+							<Button onClick={ this.onCategoryCleared } scary busy={ isSavingSettings }>
 								{ translate( 'Disable Podcast' ) }
 							</Button>
 							<p>
@@ -350,16 +358,23 @@ class PodcastingDetails extends Component {
 	};
 
 	onCategoryCleared = () => {
-		const { updateFields, clearDirtyFields, submitForm, siteSlug } = this.props;
+		const {
+			updateFields,
+			clearDirtyFields,
+			submitForm,
+			siteSlug,
+			isSaveRequestSuccessful,
+		} = this.props;
 
 		updateFields( { podcasting_category_id: '0' }, () => {
 			submitForm();
 		} );
 
-		// Save changed fields and allow redirect
-		clearDirtyFields();
-
-		page.redirect( '/settings/writing/' + siteSlug );
+		if ( isSaveRequestSuccessful ) {
+			// Save changed fields and allow redirect
+			clearDirtyFields();
+			page.redirect( '/settings/writing/' + siteSlug );
+		}
 	};
 
 	onCoverImageRemoved = () => {
@@ -424,6 +439,8 @@ const connectComponent = connect( ( state, ownProps ) => {
 		podcastingFeedUrl,
 		userCanManagePodcasting: canCurrentUser( state, siteId, 'manage_options' ),
 		isUnsupportedSite: isJetpack && ! isAutomatedTransfer,
+		isSavingSettings: isSavingSiteSettings( state, siteId ),
+		isSaveRequestSuccessful: isSiteSettingsSaveSuccessful( state, siteId ),
 	};
 } );
 

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -359,7 +359,7 @@ class PodcastingDetails extends Component {
 		// Save changed fields and allow redirect
 		clearDirtyFields();
 
-		page.redirect( '/settings/writing/' + siteSlug + '#site-podcasting-settings' );
+		page.redirect( '/settings/writing/' + siteSlug );
 	};
 
 	onCoverImageRemoved = () => {

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -6,6 +6,7 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 import { map, toPairs, pick, flowRight, filter, head } from 'lodash';
 import classNames from 'classnames';
 
@@ -349,7 +350,16 @@ class PodcastingDetails extends Component {
 	};
 
 	onCategoryCleared = () => {
-		this.props.updateFields( { podcasting_category_id: '0' } );
+		const { updateFields, clearDirtyFields, submitForm, siteSlug } = this.props;
+
+		updateFields( { podcasting_category_id: '0' }, () => {
+			submitForm();
+		} );
+
+		// Save changed fields and allow redirect
+		clearDirtyFields();
+
+		page.redirect( '/settings/writing/' + siteSlug + '#site-podcasting-settings' );
 	};
 
 	onCoverImageRemoved = () => {

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -358,23 +358,15 @@ class PodcastingDetails extends Component {
 	};
 
 	onCategoryCleared = () => {
-		const {
-			updateFields,
-			clearDirtyFields,
-			submitForm,
-			siteSlug,
-			isSaveRequestSuccessful,
-		} = this.props;
+		const { updateFields, clearDirtyFields, submitForm, siteSlug } = this.props;
 
 		updateFields( { podcasting_category_id: '0' }, () => {
-			submitForm();
+			submitForm().then( () => {
+				// Save changed fields and allow redirect
+				clearDirtyFields();
+				page.redirect( '/settings/writing/' + siteSlug );
+			} );
 		} );
-
-		if ( isSaveRequestSuccessful ) {
-			// Save changed fields and allow redirect
-			clearDirtyFields();
-			page.redirect( '/settings/writing/' + siteSlug );
-		}
 	};
 
 	onCoverImageRemoved = () => {

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -6,7 +6,6 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import page from 'page';
 import { map, toPairs, pick, flowRight, filter, head } from 'lodash';
 import classNames from 'classnames';
 
@@ -358,14 +357,10 @@ class PodcastingDetails extends Component {
 	};
 
 	onCategoryCleared = () => {
-		const { updateFields, clearDirtyFields, submitForm, siteSlug } = this.props;
+		const { updateFields, submitForm } = this.props;
 
 		updateFields( { podcasting_category_id: '0' }, () => {
-			submitForm().then( () => {
-				// Save changed fields and allow redirect
-				clearDirtyFields();
-				page.redirect( '/settings/writing/' + siteSlug );
-			} );
+			submitForm();
 		} );
 	};
 

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -167,7 +167,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				this.props.saveJetpackSettings( siteId, jetpackFieldsToUpdate );
 			}
 
-			return this.props.saveSiteSettings( siteId, { ...siteFields, apiVersion } );
+			this.props.saveSiteSettings( siteId, { ...siteFields, apiVersion } );
 		};
 
 		handleRadio = event => {

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -162,10 +162,12 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			// Support site settings for older Jetpacks as needed
 			const siteFields = pick( fields, settingsFields.site );
 			const apiVersion = siteIsJetpack ? jetpackSiteSettingsAPIVersion : '1.4';
-			this.props.saveSiteSettings( siteId, { ...siteFields, apiVersion } );
+
 			if ( jetpackSettingsUISupported ) {
 				this.props.saveJetpackSettings( siteId, jetpackFieldsToUpdate );
 			}
+
+			return this.props.saveSiteSettings( siteId, { ...siteFields, apiVersion } );
 		};
 
 		handleRadio = event => {

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -68,7 +68,16 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 					this.props.isSaveRequestSuccessful &&
 					( this.props.isJetpackSaveRequestSuccessful || ! this.props.jetpackSettingsUISupported )
 				) {
-					this.props.successNotice( this.props.translate( 'Settings saved!' ), {
+					let successNoticeText = this.props.translate( 'Settings saved!' );
+
+					if (
+						this.props.dirtyFields.includes( 'podcasting_category_id' ) &&
+						this.props.fields.podcasting_category_id === '0'
+					) {
+						successNoticeText = this.props.translate( 'Podcasting disabled.' );
+					}
+
+					this.props.successNotice( successNoticeText, {
 						id: 'site-settings-save',
 					} );
 					// Upon failure to save Jetpack Settings, don't show an error message,

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -68,16 +68,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 					this.props.isSaveRequestSuccessful &&
 					( this.props.isJetpackSaveRequestSuccessful || ! this.props.jetpackSettingsUISupported )
 				) {
-					let successNoticeText = this.props.translate( 'Settings saved!' );
-
-					if (
-						this.props.dirtyFields.includes( 'podcasting_category_id' ) &&
-						this.props.fields.podcasting_category_id === '0'
-					) {
-						successNoticeText = this.props.translate( 'Podcasting disabled.' );
-					}
-
-					this.props.successNotice( successNoticeText, {
+					this.props.successNotice( this.props.translate( 'Settings saved!' ), {
 						id: 'site-settings-save',
 					} );
 					// Upon failure to save Jetpack Settings, don't show an error message,

--- a/client/state/site-settings/actions.js
+++ b/client/state/site-settings/actions.js
@@ -113,7 +113,7 @@ export function saveSiteSettings( siteId, settings ) {
 					error,
 				} );
 
-				return Promise.reject( error );
+				return error;
 			} );
 	};
 }

--- a/client/state/site-settings/actions.js
+++ b/client/state/site-settings/actions.js
@@ -113,7 +113,7 @@ export function saveSiteSettings( siteId, settings ) {
 					error,
 				} );
 
-				return error;
+				return Promise.reject( error );
 			} );
 	};
 }


### PR DESCRIPTION
This PR changes the action for disabling podcasting to automatically save and scroll to the top of the podcasting details page.

Props @michaeldcain for the original code.
Split out from https://github.com/Automattic/wp-calypso/pull/25514.

This PR is part of a larger epic and is behind the `manage/site-settings/podcasting` feature flag. See p3Ex-32D-p2.

![disable-podcasting](https://user-images.githubusercontent.com/942359/42229646-eb6e38a0-7eb4-11e8-9870-50a4190fa446.gif)

**To test:**
- With the `manage/site-settings/podcasting` enabled (default in development):
- Visit the Settings > Writing > Enable/Manage Podcast
- If disabled, enable podcasting by selecting a category from the term tree selector and save.
- Scroll to the bottom of the page and click the "Disable Podcast" button.
- Verify that podcasting is disabled, the setting it saved and the window is scrolled to the top.