### PR TITLE
Settings: Update connection/plan transfer copy to add a note

### DIFF
--- a/client/components/dialog/style.scss
+++ b/client/components/dialog/style.scss
@@ -74,6 +74,10 @@
 		line-height: 2em;
 		margin-bottom: .5em;
 	}
+
+	p:last-child {
+		margin-bottom: 0;
+	}
 }
 
 .dialog__action-buttons {

--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -61,17 +61,19 @@ class SiteOwnership extends Component {
 		const { translate } = this.props;
 		const message = (
 			<Fragment>
-				{ translate( 'Are you sure you want to transfer site ownership to {{user /}}?', {
-					components: {
-						user: <strong>{ user.display_name || user.name }</strong>,
-					},
-				} ) }
-				<br />
-				<br />
-				{ translate(
-					'Note: you cannot undo this action. ' +
-						'Going forward, only the new Site Owner can initiate a transfer.'
-				) }
+				<p>
+					{ translate( 'Are you sure you want to transfer site ownership to {{user /}}?', {
+						components: {
+							user: <strong>{ user.display_name || user.name }</strong>,
+						},
+					} ) }
+				</p>
+				<p>
+					{ translate(
+						'Note: you cannot undo this action. ' +
+							'Going forward, only the new Site Owner can initiate a transfer.'
+					) }
+				</p>
 			</Fragment>
 		);
 
@@ -93,17 +95,19 @@ class SiteOwnership extends Component {
 		const { translate } = this.props;
 		const message = (
 			<Fragment>
-				{ translate( 'Are you sure you want to change the Plan Purchaser to {{user /}}?', {
-					components: {
-						user: <strong>{ user.display_name || user.name }</strong>,
-					},
-				} ) }
-				<br />
-				<br />
-				{ translate(
-					'Note: you cannot undo this action. ' +
-						'Going forward, only the new Plan Purchaser can initiate a change.'
-				) }
+				<p>
+					{ translate( 'Are you sure you want to change the Plan Purchaser to {{user /}}?', {
+						components: {
+							user: <strong>{ user.display_name || user.name }</strong>,
+						},
+					} ) }
+				</p>
+				<p>
+					{ translate(
+						'Note: you cannot undo this action. ' +
+							'Going forward, only the new Plan Purchaser can initiate a change.'
+					) }
+				</p>
 			</Fragment>
 		);
 

--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -59,13 +59,24 @@ class SiteOwnership extends Component {
 
 	onSelectConnectionOwner = user => {
 		const { translate } = this.props;
+		const message = (
+			<Fragment>
+				{ translate( 'Are you sure you want to transfer site ownership to {{user /}}?', {
+					components: {
+						user: <strong>{ user.display_name || user.name }</strong>,
+					},
+				} ) }
+				<br />
+				<br />
+				{ translate(
+					'Note: you cannot undo this action. ' +
+						'Going forward, only the new Site Owner can initiate a transfer.'
+				) }
+			</Fragment>
+		);
 
 		accept(
-			translate( 'Are you sure you want to transfer site ownership to {{user /}}?', {
-				components: {
-					user: <strong>{ user.display_name || user.name }</strong>,
-				},
-			} ),
+			message,
 			accepted => {
 				if ( accepted ) {
 					this.props.changeOwner( this.props.siteId, user.ID, user.name );
@@ -80,16 +91,24 @@ class SiteOwnership extends Component {
 
 	onSelectPlanOwner = user => {
 		const { translate } = this.props;
-
-		accept(
-			translate(
-				'Are you absolutely sure you want to change the plan purchaser for this site to {{user /}}?',
-				{
+		const message = (
+			<Fragment>
+				{ translate( 'Are you sure you want to change the Plan Purchaser to {{user /}}?', {
 					components: {
 						user: <strong>{ user.display_name || user.name }</strong>,
 					},
-				}
-			),
+				} ) }
+				<br />
+				<br />
+				{ translate(
+					'Note: you cannot undo this action. ' +
+						'Going forward, only the new Plan Purchaser can initiate a change.'
+				) }
+			</Fragment>
+		);
+
+		accept(
+			message,
 			accepted => {
 				if ( accepted ) {
 					this.props.transferPlanOwnership( this.props.siteId, user.linked_user_ID );


### PR DESCRIPTION
This PR updates the copy of the confirmation dialogs when transferring a connection or plan ownership. As suggested in https://github.com/Automattic/wp-calypso/pull/25725#issuecomment-401118457

### Connection (site) ownership

**Before**
![](https://cldup.com/vL9RKPlgkR.png)

**After**
![](https://cldup.com/QHwL9dKmV7.png)

### Plan ownership

**Before**
![](https://cldup.com/aY_c2k8RsY.png)

**After**
![](https://cldup.com/90qMtSNEBv.png)

To test:
* Checkout this branch.
* Login to WP.com and make sure you have a connected Jetpack site with paid plan where you're the connection owner and the plan purchaser.
* Go to http://calypso.localhost:3000/settings/manage-connection/:site, where `:site` is your Jetpack site.
* Select another connected admin user from the Site Owner dropdown.
* Verify the confirmation screen looks well, as shown on the screenshots.
* Select another connected admin user from the Plan Purchaser dropdown.
* Verify the confirmation screen looks well, as shown on the screenshots.