### PR TITLE
Post Editor: fix error notice when saving post that has no changes

### DIFF
--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -5,7 +5,7 @@
  */
 
 import store from 'store';
-import { assign, clone, includes, isEmpty, pick, reduce } from 'lodash';
+import { assign, clone, get, includes, isEmpty, pick, reduce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -215,7 +215,7 @@ export const saveEdited = options => async ( dispatch, getState ) => {
 	// when toggling editor modes, it is possible for the post to be dirty
 	// even though the content hasn't changed. To avoid a confusing UX
 	// let's just pass the content through and save it anyway
-	if ( ! changedAttributes.content && rawContent !== initialRawContent ) {
+	if ( ! get( changedAttributes, 'content' ) && rawContent !== initialRawContent ) {
 		changedAttributes = {
 			...changedAttributes,
 			content: post.content,


### PR DESCRIPTION
Fixes #25801. The `getPostEdits` selector returns `null` when the post has no local edits. And then we check for `changedAttributes.content`... This patch wraps the check with `_.get`.

Nice catch by @flootr. It's a regression introduced in #25160.

I'm not changing any UI behavior in this patch: the "Update" button continues to be enabled and does nothing when there are no changes to save.