### PR TITLE
Checkout: Update/payment action item layout

### DIFF
--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -258,7 +258,7 @@
 		cursor: pointer;
 		display: none;
 		font-size: 14px;
-		margin: 5px 0 0;
+		margin: 0;
 		padding: 10px 0;
 
 		// On larger screens, users can use the coupon functionality present on the sidebar

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -657,8 +657,7 @@
 	color: $gray-lighten-10;
 
 	@include breakpoint( '>660px' ) {
-		margin-left: 10px;
-		margin-top: 0;
+		margin: 0 10px;
 		display: inline-block;
 	}
 }


### PR DESCRIPTION
This PR addresses #23667

A small layout tweak to adjust whitespace around the credit card payment action items.

### Result

**Desktop**
<img width="717" alt="screen shot 2018-07-02 at 1 26 24 pm" src="https://user-images.githubusercontent.com/6458278/42144027-22de5194-7dfc-11e8-8dc2-0ae9712224db.png">

**Mobile**
<img width="382" alt="screen shot 2018-07-02 at 1 28 27 pm" src="https://user-images.githubusercontent.com/6458278/42144032-2661790e-7dfc-11e8-9574-2512e9e430fe.png">

### Testing

For the chat call to action to display, pre-sales chat has to be available, and there has to be a business plan in the cart. Or you can checkout the branch, and force it by removing the wrapper condition around `<PaymentChatButton ...>` in [/client/my-sites/checkout/checkout/credit-card-payment-box.jsx](https://github.com/Automattic/wp-calypso/blob/d588a48/client/my-sites/checkout/checkout/credit-card-payment-box.jsx#L154) , and commenting out the `showButton` condition block in [/client/components/happychat/button.jsx](https://github.com/Automattic/wp-calypso/blob/d588a48/client/components/happychat/button.jsx#L91).
