### PR TITLE
Settings: Hide plan purchaser section for non-admins

### DIFF
--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -226,9 +226,8 @@ class SiteOwnership extends Component {
 	}
 
 	renderCardContent() {
-		const { canManageOptions, isPaidPlan, translate } = this.props;
-		const showPlanSection =
-			config.isEnabled( 'jetpack/ownership-change' ) && isPaidPlan && canManageOptions;
+		const { isPaidPlan, translate } = this.props;
+		const showPlanSection = config.isEnabled( 'jetpack/ownership-change' ) && isPaidPlan;
 
 		return (
 			<Card>
@@ -252,7 +251,15 @@ class SiteOwnership extends Component {
 	}
 
 	render() {
-		const { siteId, siteIsConnected, siteIsJetpack, translate } = this.props;
+		const { canManageOptions, siteId, siteIsConnected, siteIsJetpack, translate } = this.props;
+
+		if ( canManageOptions === false ) {
+			return null;
+		}
+
+		if ( ! canManageOptions ) {
+			return this.renderPlaceholder();
+		}
 
 		return (
 			<Fragment>

--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -14,6 +14,7 @@ import { includes } from 'lodash';
  */
 import accept from 'lib/accept';
 import AuthorSelector from 'blocks/author-selector';
+import canCurrentUser from 'state/selectors/can-current-user';
 import Card from 'components/card';
 import config from 'config';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -225,8 +226,9 @@ class SiteOwnership extends Component {
 	}
 
 	renderCardContent() {
-		const { isPaidPlan, translate } = this.props;
-		const showPlanSection = config.isEnabled( 'jetpack/ownership-change' ) && isPaidPlan;
+		const { canManageOptions, isPaidPlan, translate } = this.props;
+		const showPlanSection =
+			config.isEnabled( 'jetpack/ownership-change' ) && isPaidPlan && canManageOptions;
 
 		return (
 			<Card>
@@ -272,6 +274,7 @@ export default connect(
 		const isCurrentPlanOwner = isPaidPlan && isCurrentUserCurrentPlanOwner( state, siteId );
 
 		return {
+			canManageOptions: canCurrentUser( state, siteId, 'manage_options' ),
 			currentUser: getCurrentUser( state ),
 			isConnectionTransferSupported: isJetpackMinimumVersion( state, siteId, '6.2' ),
 			isCurrentPlanOwner,

--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -253,12 +253,12 @@ class SiteOwnership extends Component {
 	render() {
 		const { canManageOptions, siteId, siteIsConnected, siteIsJetpack, translate } = this.props;
 
-		if ( canManageOptions === false ) {
-			return null;
+		if ( ! siteId ) {
+			return this.renderPlaceholder();
 		}
 
 		if ( ! canManageOptions ) {
-			return this.renderPlaceholder();
+			return null;
 		}
 
 		return (


### PR DESCRIPTION
This PR hides the Site Ownership card non-admin users, as discussed in https://github.com/Automattic/wp-calypso/pull/25725#issuecomment-401390855

To test:
* Checkout this branch.
* Login as the admin of the Jetpack site, owner of the connection and owner of the plan on a site that has at least 1 more connected admin.
* Go to `http://calypso.localhost:3000/settings/manage-connection/:site` where `:site` is your Jetpack site slug.
* Make sure you can see the Site Ownership card.
* Login as a non-admin of the Jetpack site. 
* Verify you can't see the Site Ownership section and the info section below it.