### PR TITLE
Settings: Enable Jetpack ownership transfer on staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -51,6 +51,7 @@
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,
 		"jetpack/google-analytics-for-stores-enhanced": true,
+		"jetpack/ownership-change": true,
 		"jitms": true,
 		"login/magic-login": true,
 		"login/native-login-links": true,


### PR DESCRIPTION
This PR enables the connection and plan ownership transfer functionality on Calypso staging.