### PR TITLE
Activity log: search filters UI

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -438,6 +438,7 @@
 @import 'my-sites/stats/activity-log-confirm-dialog/style';
 @import 'my-sites/stats/activity-log-example/style';
 @import 'my-sites/stats/activity-log-item/style';
+@import 'my-sites/stats/activity-log-search/style';
 @import 'my-sites/stats/activity-log-switch/style';
 @import 'my-sites/stats/activity-log-tasklist/style';
 @import 'my-sites/stats/all-time/style';

--- a/client/my-sites/stats/activity-log-search/activity-log-search-groups.jsx
+++ b/client/my-sites/stats/activity-log-search/activity-log-search-groups.jsx
@@ -1,0 +1,49 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { updateFilter } from 'state/activity-log/actions';
+import Gridicon from 'gridicons';
+
+// Note: this data-set will eventually come from the API
+const groups = [
+	{ slug: 'post', title: 'Posts and Pages', icon: 'posts' },
+	{ slug: 'user', title: 'Users', icon: 'user' },
+	{ slug: 'comment', title: 'Comments', icon: 'comment' },
+	{ slug: 'attachment', title: 'Media and Attachments', icon: 'attachment' },
+	{ slug: 'setting', title: 'Settings', icon: 'cog' },
+	{ slug: 'term', title: 'Categories and Tags', icon: 'tag' },
+];
+
+class ActivityLogSearchGroups extends Component {
+	render() {
+		return (
+			<div className="activity-log-search__filters-groups">
+				{ groups.map( group => (
+					<button key={ group.slug }>
+						<Gridicon
+							icon={ group.icon }
+							className="activity-log-search__filter-group-icon"
+							size={ 18 }
+							data-group={ group.slug }
+						/>
+						<span>{ group.title }</span>
+					</button>
+				) ) }
+			</div>
+		);
+	}
+}
+
+export default connect(
+	null,
+	{ updateFilter }
+)( localize( ActivityLogSearchGroups ) );

--- a/client/my-sites/stats/activity-log-search/activity-log-search-groups.jsx
+++ b/client/my-sites/stats/activity-log-search/activity-log-search-groups.jsx
@@ -3,15 +3,18 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { pull, union } from 'lodash';
 import React, { Component } from 'react';
 
 /**
  * Internal dependencies
  */
-import { updateFilter } from 'state/activity-log/actions';
+import getActivityLogFilter from 'state/selectors/get-activity-log-filter';
 import Gridicon from 'gridicons';
+import { updateFilter } from 'state/activity-log/actions';
 
 // Note: this data-set will eventually come from the API
 const groups = [
@@ -24,16 +27,69 @@ const groups = [
 ];
 
 class ActivityLogSearchGroups extends Component {
+	onGroupClick = event => {
+		const { filter, siteId } = this.props;
+		const currentState = event.target.getAttribute( 'class' );
+		const group = event.target.getAttribute( 'data-group' );
+		event.preventDefault;
+
+		if ( 'included' === currentState ) {
+			this.props.updateFilter(
+				siteId,
+				Object.assign(
+					{},
+					filter,
+					filter.group.length > 1 ? { group: pull( filter.group, group ) } : { group: null },
+					filter.notGroup
+						? { notGroup: union( filter.notGroup, [ group ] ) }
+						: { notGroup: [ group ] }
+				)
+			);
+			return;
+		}
+
+		if ( 'excluded' === currentState ) {
+			this.props.updateFilter(
+				siteId,
+				Object.assign(
+					{},
+					filter,
+					filter.notGroup.length > 1
+						? { notGroup: pull( filter.notGroup, group ) }
+						: { notGroup: null }
+				)
+			);
+			return;
+		}
+
+		this.props.updateFilter(
+			siteId,
+			Object.assign(
+				{},
+				filter,
+				filter.group ? { group: union( filter.group, [ group ] ) } : { group: [ group ] }
+			)
+		);
+	};
+
 	render() {
+		const { filter } = this.props;
 		return (
 			<div className="activity-log-search__filters-groups">
 				{ groups.map( group => (
-					<button key={ group.slug }>
+					<button
+						data-group={ group.slug }
+						onClick={ this.onGroupClick }
+						className={ classNames( {
+							included: filter.group && filter.group.includes( group.slug ),
+							excluded: filter.notGroup && filter.notGroup.includes( group.slug ),
+						} ) }
+						key={ group.slug }
+					>
 						<Gridicon
 							icon={ group.icon }
 							className="activity-log-search__filter-group-icon"
 							size={ 18 }
-							data-group={ group.slug }
 						/>
 						<span>{ group.title }</span>
 					</button>
@@ -44,6 +100,10 @@ class ActivityLogSearchGroups extends Component {
 }
 
 export default connect(
-	null,
+	( state, ownProps ) => {
+		return {
+			filter: getActivityLogFilter( state, ownProps.siteId ),
+		};
+	},
 	{ updateFilter }
 )( localize( ActivityLogSearchGroups ) );

--- a/client/my-sites/stats/activity-log-search/activity-log-search-tokens.jsx
+++ b/client/my-sites/stats/activity-log-search/activity-log-search-tokens.jsx
@@ -1,0 +1,36 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { filterStateToTokens, tokensToFilterState } from 'state/activity-log/utils';
+import TokenField from 'components/token-field';
+import { setFilter } from 'state/activity-log/actions';
+
+class ActivityLogSearchTokens extends Component {
+	static propTypes = {
+		filter: PropTypes.object.isRequired,
+	};
+
+	onTokensChange = tokens => {
+		this.props.setFilter( this.props.siteId, tokensToFilterState( tokens ) );
+	};
+
+	render() {
+		const tokens = filterStateToTokens( this.props.filter );
+		return <TokenField value={ tokens } onChange={ this.onTokensChange } />;
+	}
+}
+
+export default connect(
+	null,
+	{ setFilter }
+)( localize( ActivityLogSearchTokens ) );

--- a/client/my-sites/stats/activity-log-search/index.jsx
+++ b/client/my-sites/stats/activity-log-search/index.jsx
@@ -1,0 +1,112 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { omit, isEmpty } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import ActivityLogSearchTokens from './activity-log-search-tokens';
+import ActivityLogSearchGroups from './activity-log-search-groups';
+import Button from 'components/button';
+import Gridicon from 'gridicons';
+
+class ActivityLogSearch extends Component {
+	static propTypes = {
+		translate: PropTypes.func.isRequired,
+		filter: PropTypes.object.isRequired,
+	};
+
+	state = {
+		activeFilter: null,
+	};
+
+	hasTokens() {
+		return ! isEmpty( omit( this.props.filter, 'page' ) );
+	}
+
+	handleFilterClick = event => {
+		event.preventDefault();
+		this.setState( { activeFilter: event.target.getAttribute( 'data-filter' ) } );
+	};
+
+	handleBackClick = event => {
+		event.preventDefault();
+		this.setState( { activeFilter: null } );
+	};
+
+	activeFilterHeaderText() {
+		const { translate } = this.props;
+		switch ( this.state.activeFilter ) {
+			case 'group':
+				return translate( 'Search by Activity Group' );
+			case 'time':
+				return translate( 'Search by time' );
+		}
+	}
+
+	render() {
+		const { translate, filter, siteId } = this.props;
+
+		return (
+			<section className="activity-log-search">
+				{ this.hasTokens() && <ActivityLogSearchTokens filter={ filter } siteId={ siteId } /> }
+				<div className="activity-log-search__filters">
+					{ this.state.activeFilter ? (
+						<div className="activity-log-search__filters-header">
+							<Button
+								className="activity-log-search__filters-back"
+								onClick={ this.handleBackClick }
+								borderless={ true }
+								compact={ true }
+							>
+								<Gridicon icon="arrow-left" />
+								<span>{ translate( 'Go Back' ) }</span>
+							</Button>
+							<div className="activity-log-search__filters-header-text">
+								{ this.activeFilterHeaderText() }
+							</div>
+						</div>
+					) : (
+						<div className="activity-log-search__filters-header">
+							<div className="activity-log-search__filters-header-text">
+								{ translate( 'Search by' ) }
+							</div>
+						</div>
+					) }
+
+					{ 'group' === this.state.activeFilter && <ActivityLogSearchGroups siteId={ siteId } /> }
+
+					{ ! this.state.activeFilter && (
+						<div className="activity-log-search__filters-categories">
+							<button
+								className="activity-log-search__filter"
+								onClick={ this.handleFilterClick }
+								data-filter="group"
+							>
+								<Gridicon icon="types" className="activity-log-search__filter-icon" size={ 18 } />
+								<span>{ translate( 'Activity Group' ) }</span>
+							</button>
+							<button
+								className="activity-log-search__filter"
+								onClick={ this.handleFilterClick }
+								data-filter="time"
+							>
+								<Gridicon icon="time" className="activity-log-search__filter-icon" size={ 18 } />
+								<span>{ translate( 'Time' ) }</span>
+							</button>
+						</div>
+					) }
+				</div>
+			</section>
+		);
+	}
+}
+
+export default localize( ActivityLogSearch );

--- a/client/my-sites/stats/activity-log-search/style.scss
+++ b/client/my-sites/stats/activity-log-search/style.scss
@@ -1,0 +1,101 @@
+.activity-log-search {
+	.search {
+		margin-bottom: 0;
+	}
+}
+
+.activity-log-search__filters {
+	color: $gray;
+	background-color: $white;
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, 0.5 ), 0 1px 2px $gray-lighten-30;
+	display: flex;
+	flex-direction: column;
+}
+
+.activity-log-search__filters-categories {
+	display: flex;
+	flex-wrap: wrap;
+
+	@include breakpoint( '>660px' ) {
+		flex-wrap: nowrap;
+	}
+}
+
+.activity-log-search__filters-header {
+	background-color: $gray-light;
+	border-bottom: 1px solid darken( $gray-light, 10% );
+	border-top: 0px;
+	padding: 4px 8px;
+	font-size: 13px;
+	color: $gray-dark;
+	display: flex;
+	align-items: center;
+
+	.activity-log-search__filters-header-text {
+		text-transform: uppercase;
+	}
+
+	.activity-log-search__filters-back {
+		width: 30%;
+		text-align: left;
+	}
+}
+
+.activity-log-search__filter {
+	text-align: center;
+	overflow: hidden;
+	width: 50%;
+	padding: 10px 6px;
+	margin: 0;
+	font-size: 13px;
+	line-height: 16px;
+	text-transform: capitalize;
+	cursor: pointer;
+	color: $gray-dark;
+	transition: all 200ms ease-in;
+
+	span {
+		display: block;
+	}
+
+	.gridicon {
+		fill: $gray-dark;
+		margin: 0 auto;
+		transition: fill 200ms ease-in;
+	}
+
+	&:hover {
+		color: $blue-medium;
+
+		.gridicon {
+			fill: $blue-medium;
+		}
+
+		@include breakpoint( '>660px' ) {
+			background: lighten( $gray, 35% );
+			box-shadow: inset 0 -3px 0 0 $blue-medium;
+		}
+	}
+
+	.activity-log-search__filter-icon,
+	span {
+		pointer-events: none;
+	}
+}
+
+.activity-log-search__filters-groups {
+	display: flex;
+	flex-wrap: wrap;
+
+	button {
+		width: 50%;
+		text-align: left;
+		padding: 10px;
+		cursor: pointer;
+	}
+
+	.activity-log-search__filter-group-icon,
+	span {
+		pointer-events: none;
+	}
+}

--- a/client/my-sites/stats/activity-log-search/style.scss
+++ b/client/my-sites/stats/activity-log-search/style.scss
@@ -92,6 +92,14 @@
 		text-align: left;
 		padding: 10px;
 		cursor: pointer;
+
+		&.included {
+			background-color: lightgreen;
+		}
+
+		&.excluded {
+			background-color: lightcoral;
+		}
 	}
 
 	.activity-log-search__filter-group-icon,

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -13,8 +13,8 @@ import { find, get, includes, isEmpty, isEqual } from 'lodash';
 /**
  * Internal dependencies
  */
-import ActivityLogBanner from 'my-sites/stats/activity-log-banner';
 import ActivityLogExample from '../activity-log-example';
+import ActivityLogSearch from 'my-sites/stats/activity-log-search';
 import ActivityLogItem from '../activity-log-item';
 import ActivityLogSwitch from '../activity-log-switch';
 import ActivityLogTasklist from '../activity-log-tasklist';
@@ -337,6 +337,7 @@ class ActivityLog extends Component {
 	getActivityLog() {
 		const {
 			enableRewind,
+			filter,
 			filter: { page: requestedPage },
 			logs,
 			moment,
@@ -427,6 +428,7 @@ class ActivityLog extends Component {
 					this.renderNoLogsContent()
 				) : (
 					<div>
+						<ActivityLogSearch filter={ filter } siteId={ siteId } />
 						<Pagination
 							className="activity-log__pagination"
 							key="activity-list-pagination-top"

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import page from 'page';
 import i18n from 'i18n-calypso';
-import { find, pick, get, isEqual } from 'lodash';
+import { find, pick, get } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -29,7 +29,7 @@ import StatsCommentFollows from './comment-follows';
 import ActivityLog from './activity-log';
 import { isDesktop } from 'lib/viewport';
 import { setFilter } from 'state/activity-log/actions';
-import { queryToFilterState } from 'state/activity-log/utils';
+import { queryToFilterState, logsNeedRefresh } from 'state/activity-log/utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 function rangeOfPeriod( period, date ) {
@@ -395,7 +395,7 @@ export default {
 		const filter = getActivityLogFilter( state, siteId );
 		const queryFilter = queryToFilterState( context.query );
 
-		if ( ! isEqual( filter, queryFilter ) ) {
+		if ( logsNeedRefresh( queryFilter, filter ) ) {
 			context.store.dispatch( {
 				...setFilter( siteId, queryFilter ),
 				meta: { skipUrlUpdate: true },

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -1,5 +1,10 @@
 /** @format */
 /**
+ * External dependencies
+ */
+import { omit } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { http as rawHttp } from 'state/http/actions';
@@ -9,7 +14,7 @@ import { filterStateToApiQuery } from 'state/activity-log/utils';
 import fromActivityLogApi from 'state/data-layer/wpcom/sites/activity/from-api';
 
 export const requestActivityLogs = ( siteId, filter, { freshness = 5 * 60 * 1000 } = {} ) => {
-	const id = `activity-log-${ siteId }`;
+	const id = `activity-log-${ siteId }-${ JSON.stringify( omit( filter, 'page' ) ) }`;
 
 	return requestHttpData(
 		id,


### PR DESCRIPTION
WIP. Search filter UI for the activity log

The goal so far was mostly to explore what components we can re-use here. Lots of this is from `/themes` and can be shared together with that section as smaller components to avoid code duplication. Some component ideas:
- “Search by” -header/card -combo
- Button/tab thingy with an icon


Currently, this gives just a static view:

![image](https://user-images.githubusercontent.com/87168/42170965-b3a6a32e-7e20-11e8-8a66-32158706a56b.png)
