### PR TITLE
Signup: Tweak featured domain suggestions styling

### DIFF
--- a/client/components/domains/featured-domain-suggestions/styles/base.scss
+++ b/client/components/domains/featured-domain-suggestions/styles/base.scss
@@ -22,6 +22,7 @@
 	margin-top: 0;
 
 	.domain-suggestion__content {
+		display: flex;
 		flex-direction: column;
 		flex-grow: 2;
 		margin-top: 0;


### PR DESCRIPTION
Inspired by #25789.

This change fixes an unintended styling quirk where the domain price would be rendered in the wrong order for featured suggestions in a small viewport.

---

<img width="651" alt="banners_and_alerts_and_create_a_site_ _wordpress_com" src="https://user-images.githubusercontent.com/4044428/42188438-20f4878a-7e11-11e8-8dd3-48c090954413.png">

---

<img width="650" alt="banners_and_alerts_and_create_a_site_ _wordpress_com" src="https://user-images.githubusercontent.com/4044428/42188422-0c203534-7e11-11e8-88f6-539a9e2d8d5e.png">

# Testing Instructions
1. Spin up this branch locally or via a live branch.
2. Navigate to the [signup flow](http://calypso.localhost:3000/start/) and proceed to the domain registration step.
3. Resize your viewport to have a width narrower than 661px. Confirm that the domain name price is rendered below the domain name (as shown in the `After` screenshot above).