### PR TITLE
Add e2e data attributes to invites

### DIFF
--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -165,6 +166,7 @@ class PeopleListItem extends React.PureComponent {
 							borderless
 							className="people-list-item__remove-button"
 							onClick={ onRemove }
+							data-e2e-remove-login={ get( user, 'login', '' ) }
 						>
 							<Gridicon icon="trash" />
 							{ translate( 'Remove', {

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -166,7 +166,7 @@ class PeopleProfile extends React.PureComponent {
 
 		if ( login ) {
 			login = (
-				<div className="people-profile__login">
+				<div className="people-profile__login" data-e2e-login={ login }>
 					<span>@{ login }</span>
 				</div>
 			);


### PR DESCRIPTION
No functional changes

Add data attributes for e2e testing - PR: https://github.com/Automattic/wp-e2e-tests/pull/1324

**Testing**

1. Load People Page Lists of People
2. Make sure `.people-profile__login` have a `data-e2e-login` attribute with login username
3. Make sure `.people-list-item__remove-button` have a `data-e2e-remove-login` attribute with login username