### PR TITLE
Memberships: enable the subscription list

### DIFF
--- a/client/me/memberships/main.jsx
+++ b/client/me/memberships/main.jsx
@@ -32,9 +32,7 @@ const MembershipItem = ( { translate, subscription, moment } ) => (
 			<div className="memberships__service-description">
 				<div className="memberships__service-name">{ subscription.title }</div>
 				<div className="memberships__list-sub">
-					<a href={ subscription.site_url }>
-						{ translate( 'On %s »', { args: subscription.site_title } ) }
-					</a>
+					{ translate( 'On %s', { args: subscription.site_title } ) }
 				</div>
 			</div>
 			<div className="memberships__list-renewal-price">
@@ -60,7 +58,12 @@ const MembershipsHistory = ( { translate, subscriptions, moment } ) => (
 		{ subscriptions &&
 			subscriptions.map(
 				subscription => (
-					<MembershipItem translate={ translate } subscription={ subscription } moment={ moment } />
+					<MembershipItem
+						key={ subscription.ID }
+						translate={ translate }
+						subscription={ subscription }
+						moment={ moment }
+					/>
 				),
 				this
 			) }

--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -64,7 +64,7 @@ class Subscription extends React.Component {
 				{ subscription && (
 					<div>
 						<Card className="memberships__subscription-meta">
-							<Site siteId={ subscription.site_id } href={ subscription.site_url } />
+							<Site siteId={ parseInt( subscription.site_id ) } href={ subscription.site_url } />
 							<div className="memberships__subscription-title">{ subscription.title }</div>
 							<Fragment>
 								<ul className="memberships__subscription-inner-meta">

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -44,22 +44,20 @@ export default function( router ) {
 		);
 	}
 
-	if ( config.isEnabled( 'memberships' ) ) {
-		router(
-			paths.purchasesRoot + '/memberships',
-			sidebar,
-			membershipsController.myMemberships,
-			makeLayout,
-			clientRender
-		);
-		router(
-			paths.purchasesRoot + '/memberships/:subscriptionId',
-			sidebar,
-			membershipsController.subscription,
-			makeLayout,
-			clientRender
-		);
-	}
+	router(
+		paths.purchasesRoot + '/memberships',
+		sidebar,
+		membershipsController.myMemberships,
+		makeLayout,
+		clientRender
+	);
+	router(
+		paths.purchasesRoot + '/memberships/:subscriptionId',
+		sidebar,
+		membershipsController.subscription,
+		makeLayout,
+		clientRender
+	);
 
 	router(
 		paths.billingHistoryReceipt( ':receiptId' ),

--- a/client/me/purchases/purchases-list/header/index.jsx
+++ b/client/me/purchases/purchases-list/header/index.jsx
@@ -13,7 +13,7 @@ import i18n from 'i18n-calypso';
  */
 import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
-import { billingHistory, purchasesRoot, pendingPayments } from '../../paths.js';
+import { billingHistory, purchasesRoot } from '../../paths.js';
 import SectionNav from 'components/section-nav';
 import config from 'config';
 
@@ -41,11 +41,9 @@ const PurchasesHeader = ( { section } ) => {
 					</NavItem>
 				) }
 
-				{ config.isEnabled( 'memberships' ) && (
-					<NavItem path={ purchasesRoot + '/memberships' } selected={ section === 'memberships' }>
-						{ i18n.translate( 'My Memberships' ) }
-					</NavItem>
-				) }
+				<NavItem path={ purchasesRoot + '/memberships' } selected={ section === 'memberships' }>
+					{ i18n.translate( 'My Memberships' ) }
+				</NavItem>
 			</NavTabs>
 		</SectionNav>
 	);

--- a/client/state/memberships/reducer.js
+++ b/client/state/memberships/reducer.js
@@ -3,13 +3,19 @@
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { combineReducers } from 'state/utils';
 import connectedAccounts from './connected-accounts/reducer';
 import productList from './product-list/reducer';
 import subscriptions from './subscriptions/reducer';
 
-export default combineReducers( {
-	connectedAccounts,
-	productList,
+const reducers = {
 	subscriptions,
-} );
+};
+
+if ( config.isEnabled( 'memberships' ) ) {
+	reducers.connectedAccounts = connectedAccounts;
+	reducers.productList = productList;
+}
+
+export default combineReducers( reducers );

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -140,6 +140,7 @@ const reducers = {
 	jitm,
 	login,
 	media,
+	memberships,
 	mobileDownloadSMS,
 	notices,
 	notificationSettings,
@@ -183,10 +184,6 @@ const reducers = {
 	users,
 	wordads,
 };
-
-if ( config.isEnabled( 'memberships' ) ) {
-	reducers.memberships = memberships;
-}
 
 if ( config.isEnabled( 'mailchimp' ) ) {
 	reducers.mailchimp = mailchimp;

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -142,7 +142,6 @@
 		"signup/atomic-store-flow": true,
 		"signup/ecommerce-flow": false,
 		"signup/wpcc": true,
-		"memberships": true,
 		"support-user": true,
 		"try/preconnect": true,
 		"try/preload": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -142,7 +142,7 @@
 		"signup/atomic-store-flow": true,
 		"signup/ecommerce-flow": false,
 		"signup/wpcc": true,
-		"memberships": false,
+		"memberships": true,
 		"support-user": true,
 		"try/preconnect": true,
 		"try/preload": true,


### PR DESCRIPTION
This PR enables the subscription list in /me/purchases.
Early next week we are launching Memberships-powered Longreads and we need to allow subscribers to cancel their membership. This is the place.
More about memberships here: p89M8K-4I-p2

## Screenshots

![zrzut ekranu 2019-02-14 o 11 20 41](https://user-images.githubusercontent.com/3775068/52783182-69619d80-3051-11e9-804a-1707575625b6.png)

![zrzut ekranu 2019-02-14 o 11 20 29](https://user-images.githubusercontent.com/3775068/52783192-6f577e80-3051-11e9-8715-208e726bfdd7.png)

## Details

I did not use `memberships` flag, because that has been developed some time ago. That flag is hiding the UI for starting your own membership in tinymce.
Since that was merged, we transitioned to gutenberg on wpcom and I have to rework whole approach to be gutenberg compliant.
So `memberships` flag stays and I will rework the piece that it's hiding.

But in the meantime, we need to allow users to see their purchases.

## Testing instructions

1. Purchase membership. You have testing instructions here: p2JRYi-3UG-p2
2. Goto http://calypso.localhost:3000/me/purchases/memberships and see purchased membership
