### PR TITLE
Activity Log: remove inline button to update plugin

### DIFF
--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { get, map } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -40,28 +40,6 @@ export function processItem( item ) {
 		case 'rewind__backup_error':
 			if ( '2' === get( item.object, 'error_code', '' ) ) {
 				activityMeta.errorCode = 'bad_credentials';
-			}
-			break;
-
-		case 'plugin__update_available':
-			const pluginSlug = get( item, 'items.0.object_slug', '' );
-			if ( pluginSlug ) {
-				// Directory and main file: hello-dolly/hello
-				activityMeta.pluginId = pluginSlug.replace( /\.php$/, '' );
-				// Directory: hello-dolly
-				activityMeta.pluginSlug = activityMeta.pluginId.split( '/' )[ 0 ];
-			}
-			const pluginsToUpdate = get( item, 'items', [] );
-			if ( pluginsToUpdate ) {
-				activityMeta.pluginsToUpdate = map( pluginsToUpdate, plugin => {
-					const pluginId = plugin.object_slug.replace( /\.php$/, '' );
-					return {
-						// Directory and main file: hello-dolly/hello
-						pluginId,
-						// Directory: hello-dolly
-						pluginSlug: pluginId.split( '/' )[ 0 ],
-					};
-				} );
 			}
 			break;
 	}


### PR DESCRIPTION
This PR removes the buttons that were previously added in events corresponding a plugin update available since we now have a better system in the persistent notices.

### Testing

Load https://calypso.live/?branch=update/activity-log/remove-inline-plugin-update and ensure the buttons are gone with no side effects.