### PR TITLE
Podcasting: enable on wpcalypso for testing.

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -83,6 +83,7 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
+		"manage/site-settings/podcasting": true,
 		"manage/stats": true,
 		"manage/stats/podcasts": true,
 		"manage/themes": true,


### PR DESCRIPTION
This enables the `manage/site-settings/podcasting` feature flag in wpcalypso for pre-launch testing.

This PR is part of a larger epic. See p3Ex-32D-p2.

**Update:** removed testing instructions - wpcalypso requires docker