### PR TITLE
Guided Tours: Add Jetpack Sign-In Tour

### DIFF
--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -20,6 +20,7 @@ import { ChecklistSiteTitleTour } from 'layout/guided-tours/tours/checklist-site
 import { ChecklistUserAvatarTour } from 'layout/guided-tours/tours/checklist-user-avatar-tour';
 import { JetpackBasicTour } from 'layout/guided-tours/tours/jetpack-basic-tour';
 import { JetpackMonitoringTour } from 'layout/guided-tours/tours/jetpack-monitoring-tour';
+import { JetpackSignInTour } from 'layout/guided-tours/tours/jetpack-sign-in-tour';
 import { SimplePaymentsEmailTour } from 'layout/guided-tours/tours/simple-payments-email-tour';
 
 export default combineTours( {
@@ -32,6 +33,7 @@ export default combineTours( {
 	checklistUserAvatar: ChecklistUserAvatarTour,
 	jetpack: JetpackBasicTour,
 	jetpackMonitoring: JetpackMonitoringTour,
+	jetpackSignIn: JetpackSignInTour,
 	main: MainTour,
 	editorBasicsTour: EditorBasicsTour,
 	mediaBasicsTour: MediaBasicsTour,

--- a/client/layout/guided-tours/tours/jetpack-sign-in-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-sign-in-tour.js
@@ -1,0 +1,74 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Fragment } from 'react';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import {
+	ButtonRow,
+	Continue,
+	makeTour,
+	Quit,
+	SiteLink,
+	Step,
+	Tour,
+} from 'layout/guided-tours/config-elements';
+
+export const JetpackSignInTour = makeTour(
+	<Tour name="jetpackSignIn" version="20180704">
+		<Step
+			name="init"
+			target=".sso__card .form-toggle__switch"
+			arrow="top-left"
+			placement="below"
+			style={ {
+				animationDelay: '0.7s',
+				zIndex: 1,
+			} }
+		>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"Let's enable sign in using WordPress.com's secure authentication " +
+								'for easy login by activating the toggle switch above.'
+						) }
+					</p>
+					<ButtonRow>
+						<Continue target=".sso__card .form-toggle__switch" step="finish" click hidden />
+						<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+
+		<Step name="finish" placement="right">
+			{ ( { translate } ) => (
+				<Fragment>
+					<h1 className="tours__title">
+						<span className="tours__completed-icon-wrapper">
+							<Gridicon icon="checkmark" className="tours__completed-icon" />
+						</span>
+						{ translate( 'Excellent, you’re done!' ) }
+					</h1>
+					<p>
+						{ translate(
+							'You can now sign into your Jetpack site with your WordPress.com account. Would you like to continue setting up the security essential features for your site?'
+						) }
+					</p>
+					<ButtonRow>
+						<SiteLink isButton href={ '/checklist/:site' }>
+							{ translate( "Yes, let's do it." ) }
+						</SiteLink>
+						<Quit>{ translate( 'No thanks.' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+	</Tour>
+);

--- a/client/layout/guided-tours/tours/jetpack-sign-in-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-sign-in-tour.js
@@ -58,7 +58,8 @@ export const JetpackSignInTour = makeTour(
 					</h1>
 					<p>
 						{ translate(
-							'You can now sign into your Jetpack site with your WordPress.com account. Would you like to continue setting up the security essential features for your site?'
+							'You can now sign into your Jetpack site with your WordPress.com account. ' +
+								'Would you like to continue setting up the security essential features for your site?'
 						) }
 					</p>
 					<ButtonRow>

--- a/client/my-sites/checklist/jetpack-checklist.js
+++ b/client/my-sites/checklist/jetpack-checklist.js
@@ -54,6 +54,7 @@ const tasks = {
 		completedTitle: translate( 'You completed your sign in preferences.' ),
 		completedButtonText: 'Change',
 		duration: translate( '3 min' ),
+		tour: 'jetpackSignIn',
 		url: '/settings/security/$siteSlug',
 	},
 };


### PR DESCRIPTION
Screenshots:

![image](https://user-images.githubusercontent.com/96308/42277359-61b8817c-7f97-11e8-8eaf-4616e19375c0.png)

Success Message:

![image](https://user-images.githubusercontent.com/96308/42277381-721a9d66-7f97-11e8-956c-8121b3376704.png)

To test:
* Land at `calypso.localhost:3000/checklist/<jpSite>`
* Click the 'Do it!' button next to the 'WordPress.com sign in' item.
* Lo and behold the Guided Tour
* Enable WordPress.com sign in, as suggested by the Guided Tour thingy
* Find a gratifying success notice  :heavy_check_mark: 
* Verify that 'Yes' button takes you back to the checklist, 'No' drops you off where you are.

Original Mockup (from p6TEKc-1UX-p2):

<img width="1399" alt="04-wpcom-signin" src="https://user-images.githubusercontent.com/96308/41308366-f88bcafa-6e7b-11e8-91d1-895aa7a18fe9.png">

Fixes #25459.