### PR TITLE
2FA code can now contain spaces, update reauth popup to handle this

### DIFF
--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -21,7 +21,7 @@ import FormCheckbox from 'components/forms/form-checkbox';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormLabel from 'components/forms/form-label';
-import FormTelInput from 'components/forms/form-tel-input';
+import FormTextInput from 'components/forms/form-text-input';
 import Notice from 'components/notice';
 /* eslint-disable no-restricted-imports */
 import observe from 'lib/mixins/data-observe';
@@ -207,7 +207,8 @@ const ReauthRequired = createReactClass( {
 				<form onSubmit={ this.submitForm }>
 					<FormFieldset>
 						<FormLabel htmlFor="code">{ this.props.translate( 'Verification Code' ) }</FormLabel>
-						<FormTelInput
+						<FormTextInput
+							type="tel"
 							autoComplete="off"
 							autoFocus={ true }
 							id="code"

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -208,7 +208,7 @@ const ReauthRequired = createReactClass( {
 					<FormFieldset>
 						<FormLabel htmlFor="code">{ this.props.translate( 'Verification Code' ) }</FormLabel>
 						<FormVerificationCodeInput
-							autoFocus={ true }
+							autoFocus
 							id="code"
 							isError={ this.props.twoStepAuthorization.codeValidationFailed() }
 							name="code"

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -21,7 +21,7 @@ import FormCheckbox from 'components/forms/form-checkbox';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormLabel from 'components/forms/form-label';
-import FormTextInput from 'components/forms/form-text-input';
+import FormVerificationCodeInput from 'components/forms/form-verification-code-input';
 import Notice from 'components/notice';
 /* eslint-disable no-restricted-imports */
 import observe from 'lib/mixins/data-observe';
@@ -207,9 +207,7 @@ const ReauthRequired = createReactClass( {
 				<form onSubmit={ this.submitForm }>
 					<FormFieldset>
 						<FormLabel htmlFor="code">{ this.props.translate( 'Verification Code' ) }</FormLabel>
-						<FormTextInput
-							type="tel"
-							autoComplete="off"
+						<FormVerificationCodeInput
 							autoFocus={ true }
 							id="code"
 							isError={ this.props.twoStepAuthorization.codeValidationFailed() }


### PR DESCRIPTION
It seems we missed the reauth popup in https://github.com/Automattic/wp-calypso/pull/23176.
This PR should fix that.

Specifically, it updates the reauth popup, sometimes appearing when accessing the `/me` section with a 2FA account, to allow spaces in codes.

### Testing Instructions
- Boot this branch locally (or using calypso.live)
- Make your 2fa cookie 2 days older
- Navigate to `/me`
- Make sure you receive a 2FA code with a space
- Copy paste the code and make sure you are authenticated

### Reviews
- [ ] Code
- [ ] Product
