### PR TITLE
Podcasting: add feed url change notice

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -46,8 +46,6 @@ import {
 import { isSavingSiteSettings } from 'state/site-settings/selectors';
 
 class PodcastingDetails extends Component {
-	state = { showChangeNotice: false };
-
 	renderExplicitContent() {
 		const {
 			fields,
@@ -241,7 +239,7 @@ class PodcastingDetails extends Component {
 	}
 
 	renderCategorySetting() {
-		const { siteId, podcastingCategoryId, translate } = this.props;
+		const { siteId, podcastingCategoryId, isCategoryChanging, translate } = this.props;
 
 		return (
 			<Fragment>
@@ -262,7 +260,7 @@ class PodcastingDetails extends Component {
 						onAddTermSuccess={ this.onCategorySelected }
 						height={ 200 }
 					/>
-					{ this.state.showChangeNotice && (
+					{ isCategoryChanging && (
 						<Notice
 							isCompact
 							status="is-info"
@@ -354,17 +352,6 @@ class PodcastingDetails extends Component {
 
 		const fieldsToUpdate = { podcasting_category_id: String( category.ID ) };
 
-		if ( category.ID === settings.podcasting_category_id ) {
-			this.setState( { showChangeNotice: false } );
-		}
-
-		if (
-			category.ID !== settings.podcasting_category_id &&
-			fieldsToUpdate.podcasting_category_id !== fields.podcasting_category_id
-		) {
-			this.setState( { showChangeNotice: true } );
-		}
-
 		if ( ! isPodcastingEnabled ) {
 			// If we are newly enabling podcasting, and no podcast title is set,
 			// use the site title.
@@ -439,6 +426,8 @@ const connectComponent = connect( ( state, ownProps ) => {
 	const selectedCategory = categories && head( filter( categories, { ID: podcastingCategoryId } ) );
 	const podcastingFeedUrl = selectedCategory && selectedCategory.feed_url;
 
+	const isCategoryChanging = podcastingCategoryId !== ownProps.settings.podcasting_category_id;
+
 	const isJetpack = isJetpackSite( state, siteId );
 	const isAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
 
@@ -448,6 +437,7 @@ const connectComponent = connect( ( state, ownProps ) => {
 		isPrivate: isPrivateSite( state, siteId ),
 		podcastingCategoryId,
 		isPodcastingEnabled,
+		isCategoryChanging,
 		isRequestingCategories: isRequestingTermsForQueryIgnoringPage( state, siteId, 'category', {} ),
 		podcastingFeedUrl,
 		userCanManagePodcasting: canCurrentUser( state, siteId, 'manage_options' ),

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -354,7 +354,14 @@ class PodcastingDetails extends Component {
 
 		const fieldsToUpdate = { podcasting_category_id: String( category.ID ) };
 
-		if ( fieldsToUpdate.podcasting_category_id !== fields.podcasting_category_id ) {
+		if ( category.ID === settings.podcasting_category_id ) {
+			this.setState( { showChangeNotice: false } );
+		}
+
+		if (
+			category.ID !== settings.podcasting_category_id &&
+			fieldsToUpdate.podcasting_category_id !== fields.podcasting_category_id
+		) {
 			this.setState( { showChangeNotice: true } );
 		}
 

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -25,6 +25,7 @@ import FormSelect from 'components/forms/form-select';
 import FormTextarea from 'components/forms/form-textarea';
 import HeaderCake from 'components/header-cake';
 import scrollTo from 'lib/scroll-to';
+import Notice from 'components/notice';
 import QueryTerms from 'components/data/query-terms';
 import TermTreeSelector from 'blocks/term-tree-selector';
 import PodcastCoverImageSetting from 'my-sites/site-settings/podcast-cover-image-setting';
@@ -45,6 +46,8 @@ import {
 import { isSavingSiteSettings } from 'state/site-settings/selectors';
 
 class PodcastingDetails extends Component {
+	state = { showChangeNotice: false };
+
 	renderExplicitContent() {
 		const {
 			fields,
@@ -259,6 +262,15 @@ class PodcastingDetails extends Component {
 						onAddTermSuccess={ this.onCategorySelected }
 						height={ 200 }
 					/>
+					{ this.state.showChangeNotice && (
+						<Notice
+							isCompact
+							status="is-info"
+							text={ translate(
+								"If you change categories, you'll need to resubmit your feed to any podcast service."
+							) }
+						/>
+					) }
 				</FormFieldset>
 				{ this.renderFeedUrl() }
 			</Fragment>
@@ -341,6 +353,10 @@ class PodcastingDetails extends Component {
 		const { settings, fields, isPodcastingEnabled } = this.props;
 
 		const fieldsToUpdate = { podcasting_category_id: String( category.ID ) };
+
+		if ( fieldsToUpdate.podcasting_category_id !== fields.podcasting_category_id ) {
+			this.setState( { showChangeNotice: true } );
+		}
 
 		if ( ! isPodcastingEnabled ) {
 			// If we are newly enabling podcasting, and no podcast title is set,

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -100,6 +100,10 @@
 	margin-bottom: 6px;
 }
 
+.podcasting-details__category-wrapper .notice.is-compact {
+	width: 100%;
+}
+
 .podcasting-details__category-wrapper.card {
 	width: 100%;
 	margin-bottom: 0;


### PR DESCRIPTION
When a user changes their selected podcast category, the feed url will change and need to be resubmitted to podcasting services. This PR adds a notice when the category is changed.

This PR is part of a larger epic and is behind the manage/site-settings/podcasting feature flag. See p3Ex-32D-p2.

![change-notice](https://user-images.githubusercontent.com/942359/42286936-76e53df2-7f82-11e8-89d3-8c3755aa18db.gif)

**To test:**
- With the `manage/site-settings/podcasting` enabled (default in development)
- On a site with Podcasting enabled
- Visit the Settings > Writing > Manage Podcast
- Change the selected podcasting category
- The notice should be shown
- If the new category is not saved and the category is changed back, the notice should go away
