### PR TITLE
Plans: Add Checklist to My Plan page (JP)

### DIFF
--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -144,7 +144,9 @@ class CurrentPlan extends Component {
 						isAutomatedTransfer={ isAutomatedTransfer }
 						includePlansLink={ currentPlan && isFreeJetpackPlan( currentPlan ) }
 					/>
-					{ isEnabled( 'jetpack/checklist' ) && isJetpack && <ChecklistShow /> }
+					{ isEnabled( 'jetpack/checklist' ) &&
+						isJetpack &&
+						! isAutomatedTransfer && <ChecklistShow /> }
 					<div
 						className={ classNames( 'current-plan__header-text current-plan__text', {
 							'is-placeholder': { isLoading },

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -34,6 +34,7 @@ import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
 import DomainWarnings from 'my-sites/domains/components/domain-warnings';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import ChecklistShow from 'my-sites/checklist/checklist-show';
 
 class CurrentPlan extends Component {
 	static propTypes = {
@@ -83,11 +84,12 @@ class CurrentPlan extends Component {
 			domains,
 			context,
 			currentPlan,
-			isExpiring,
-			shouldShowDomainWarnings,
 			hasDomainsLoaded,
-			translate,
 			isAutomatedTransfer,
+			isExpiring,
+			isJetpack,
+			shouldShowDomainWarnings,
+			translate,
 		} = this.props;
 
 		const currentPlanSlug = selectedSite.plan.product_slug,
@@ -141,6 +143,7 @@ class CurrentPlan extends Component {
 						isAutomatedTransfer={ isAutomatedTransfer }
 						includePlansLink={ currentPlan && isFreeJetpackPlan( currentPlan ) }
 					/>
+					{ isJetpack && <ChecklistShow /> }
 					<div
 						className={ classNames( 'current-plan__header-text current-plan__text', {
 							'is-placeholder': { isLoading },
@@ -176,5 +179,6 @@ export default connect( ( state, ownProps ) => {
 		shouldShowDomainWarnings: isWpcom || isAutomatedTransfer,
 		hasDomainsLoaded: !! domains,
 		isRequestingSitePlans: isRequestingSitePlans( state, selectedSiteId ),
+		isJetpack: isJetpackSite( state, selectedSiteId ),
 	};
 } )( localize( CurrentPlan ) );

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -166,7 +166,7 @@ export default connect( ( state, ownProps ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	const domains = getDecoratedSiteDomains( state, selectedSiteId );
 
-	const isWpcom = ! isJetpackSite( state, selectedSiteId );
+	const isJetpack = isJetpackSite( state, selectedSiteId );
 	const isAutomatedTransfer = isSiteAutomatedTransfer( state, selectedSiteId );
 
 	return {
@@ -177,9 +177,9 @@ export default connect( ( state, ownProps ) => {
 		context: ownProps.context,
 		currentPlan: getCurrentPlan( state, selectedSiteId ),
 		isExpiring: isCurrentPlanExpiring( state, selectedSiteId ),
-		shouldShowDomainWarnings: isWpcom || isAutomatedTransfer,
+		shouldShowDomainWarnings: ! isJetpack || isAutomatedTransfer,
 		hasDomainsLoaded: !! domains,
 		isRequestingSitePlans: isRequestingSitePlans( state, selectedSiteId ),
-		isJetpack: isJetpackSite( state, selectedSiteId ),
+		isJetpack,
 	};
 } )( localize( CurrentPlan ) );

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -34,11 +34,7 @@ import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
 import DomainWarnings from 'my-sites/domains/components/domain-warnings';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
-import Checklist from 'blocks/checklist';
-import { isEnabled } from 'config';
-import { jetpackTasks } from 'my-sites/checklist/jetpack-checklist';
-import { launchTask } from 'my-sites/checklist/onboardingChecklist';
-import getSiteChecklist from 'state/selectors/get-site-checklist';
+import ChecklistShow from 'my-sites/checklist/checklist-show';
 
 class CurrentPlan extends Component {
 	static propTypes = {
@@ -81,42 +77,18 @@ class CurrentPlan extends Component {
 		};
 	}
 
-	handleAction = id => {
-		const { requestTour, siteSlug, tasks, track } = this.props;
-		const task = find( tasks, { id } );
-
-		launchTask( {
-			task,
-			location: 'checklist_show',
-			requestTour,
-			siteSlug,
-			track,
-		} );
-	};
-
-	handleToggle = id => {
-		const { notify, siteId, tasks, update } = this.props;
-		const task = find( tasks, { id } );
-
-		if ( task && ! task.completed ) {
-			notify( 'is-success', 'You completed a task!' );
-			update( siteId, id );
-		}
-	};
-
 	render() {
 		const {
+			selectedSite,
+			selectedSiteId,
+			domains,
 			context,
 			currentPlan,
-			domains,
 			hasDomainsLoaded,
 			isAutomatedTransfer,
 			isExpiring,
 			isJetpack,
-			selectedSite,
-			selectedSiteId,
 			shouldShowDomainWarnings,
-			tasks,
 			translate,
 		} = this.props;
 
@@ -171,14 +143,7 @@ class CurrentPlan extends Component {
 						isAutomatedTransfer={ isAutomatedTransfer }
 						includePlansLink={ currentPlan && isFreeJetpackPlan( currentPlan ) }
 					/>
-					{ isJetpack && (
-						<Checklist
-							isLoading={ ! tasks }
-							tasks={ tasks }
-							onAction={ this.handleAction }
-							onToggle={ this.handleToggle }
-						/>
-					) }
+					{ isJetpack && <ChecklistShow /> }
 					<div
 						className={ classNames( 'current-plan__header-text current-plan__text', {
 							'is-placeholder': { isLoading },
@@ -195,31 +160,25 @@ class CurrentPlan extends Component {
 	}
 }
 
-export default connect( ( state, { context } ) => {
+export default connect( ( state, ownProps ) => {
 	const selectedSite = getSelectedSite( state );
 	const selectedSiteId = getSelectedSiteId( state );
-	const siteChecklist = getSiteChecklist( state, selectedSiteId );
 	const domains = getDecoratedSiteDomains( state, selectedSiteId );
 
-	const isJetpack = isJetpackSite( state, selectedSiteId );
+	const isWpcom = ! isJetpackSite( state, selectedSiteId );
 	const isAutomatedTransfer = isSiteAutomatedTransfer( state, selectedSiteId );
 
-	const tasks = isJetpack ? jetpackTasks( siteChecklist ) : [];
-
 	return {
-		checklistAvailable:
-			! isAutomatedTransfer && ( isEnabled( 'jetpack/checklist' ) || ! isJetpack ),
-		context,
-		currentPlan: getCurrentPlan( state, selectedSiteId ),
-		domains,
-		hasDomainsLoaded: !! domains,
-		isAutomatedTransfer,
-		isExpiring: isCurrentPlanExpiring( state, selectedSiteId ),
-		isJetpack,
-		isRequestingSitePlans: isRequestingSitePlans( state, selectedSiteId ),
 		selectedSite,
 		selectedSiteId,
-		shouldShowDomainWarnings: ! isJetpack || isAutomatedTransfer,
-		tasks,
+		domains,
+		isAutomatedTransfer,
+		context: ownProps.context,
+		currentPlan: getCurrentPlan( state, selectedSiteId ),
+		isExpiring: isCurrentPlanExpiring( state, selectedSiteId ),
+		shouldShowDomainWarnings: isWpcom || isAutomatedTransfer,
+		hasDomainsLoaded: !! domains,
+		isRequestingSitePlans: isRequestingSitePlans( state, selectedSiteId ),
+		isJetpack: isJetpackSite( state, selectedSiteId ),
 	};
 } )( localize( CurrentPlan ) );

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -35,6 +35,7 @@ import DomainWarnings from 'my-sites/domains/components/domain-warnings';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ChecklistShow from 'my-sites/checklist/checklist-show';
+import { isEnabled } from 'config';
 
 class CurrentPlan extends Component {
 	static propTypes = {
@@ -143,7 +144,7 @@ class CurrentPlan extends Component {
 						isAutomatedTransfer={ isAutomatedTransfer }
 						includePlansLink={ currentPlan && isFreeJetpackPlan( currentPlan ) }
 					/>
-					{ isJetpack && <ChecklistShow /> }
+					{ isEnabled( 'jetpack/checklist' ) && isJetpack && <ChecklistShow /> }
 					<div
 						className={ classNames( 'current-plan__header-text current-plan__text', {
 							'is-placeholder': { isLoading },


### PR DESCRIPTION
## Screenshot

![image](https://user-images.githubusercontent.com/96308/42385126-2d61d864-813c-11e8-876d-2a9e20a47e91.png)

## Testing Instructions

* Navigate to `http://calypso.localhost:3000/plans/my-plan/<jpSite>`
* Verify that you see the checklist as in the screenshot above
* Verify that the checklist is fully functional (Note that only the Jetpack Monitor task's 'Do it' button will currently start a Guided Tour)
* Navigate that no checklist is shown for WP.com sites, i.e. `http://calypso.localhost:3000/plans/my-plan/<wpcomSite>`
* Verify that the checklist is hidden behind a feature flag:
 * Apply the patch below and restart Calypso. Verify that the checklist is no longer shown on `http://calypso.localhost:3000/plans/my-plan/<jpSite>`

```
diff --git a/config/development.json b/config/development.json
index bc77f97..773cd30 100644
--- a/config/development.json
+++ b/config/development.json
@@ -68,7 +68,7 @@
                "help/courses": true,
                "i18n/community-translator": false,
                "jetpack/api-cache": true,
-               "jetpack/checklist": true,
+               "jetpack/checklist": false,
                "jetpack/connect-redirect-pressable-credential-approval": true,
                "jetpack/connect/remote-install": true,
                "jetpack/connect/mobile-app-flow": true,
```

Fixes #25871