### PR TITLE
Checklist (Jetpack): Remove 'Backups and Scanning' task

### DIFF
--- a/client/my-sites/checklist/jetpack-checklist.js
+++ b/client/my-sites/checklist/jetpack-checklist.js
@@ -15,16 +15,6 @@ const tasks = {
 		completedTitle: translate( "We've automatically turned on spam filtering." ),
 		completed: true,
 	},
-	jetpack_backups: {
-		title: translate( 'Backups & Scanning' ),
-		description: translate(
-			"Connect your site's server to Jetpack to perform backups, rewinds, and security scans."
-		),
-		completedTitle: translate( 'You turned on backups and scanning.' ),
-		completedButtonText: 'Change',
-		duration: translate( '2 min' ),
-		url: '/stats/activity/$siteSlug',
-	},
 	jetpack_monitor: {
 		title: translate( 'Jetpack Monitor' ),
 		description: translate(
@@ -61,7 +51,6 @@ const tasks = {
 const sequence = [
 	'jetpack_brute_force',
 	'jetpack_spam_filtering',
-	'jetpack_backups',
 	'jetpack_monitor',
 	'jetpack_plugin_updates',
 	'jetpack_sign_in',


### PR DESCRIPTION
The relevant setting in the UI is hidden, since Activity Log/Rewind (which is required for this step) isn't in production yet, see p1530722893000212-slack-activity-log

To test:
* Verify that there are no other occurrences of the string `jetpack_backups` in the codebase
* Navigate to `http://calypso.localhost:3000/checklist/<JPsite>`. Verify that the 'Backups and Scanning' step is gone, and that there are no errors.