### PR TITLE
Revert "Purchases: Manage for disconnected sites :: Take 2 (#25743)"

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -11,13 +11,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import {
-	isDomainRegistration,
-	isDomainTransfer,
-	isJetpackPlan,
-	isPlan,
-	isTheme,
-} from 'lib/products-values';
+import { isDomainRegistration, isDomainTransfer, isPlan, isTheme } from 'lib/products-values';
 
 function getIncludedDomain( purchase ) {
 	return purchase.includedDomain;
@@ -179,7 +173,6 @@ function isRemovable( purchase ) {
 	}
 
 	return (
-		isJetpackPlan( purchase ) ||
 		isExpiring( purchase ) ||
 		isExpired( purchase ) ||
 		( isDomainTransfer( purchase ) &&

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -154,11 +154,6 @@ export function managePurchase( context, next ) {
 
 	setTitle( context, titles.managePurchase );
 
-	context.primary = (
-		<ManagePurchase
-			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-			siteSlug={ context.params.site }
-		/>
-	);
+	context.primary = <ManagePurchase purchaseId={ parseInt( context.params.purchaseId, 10 ) } />;
 	next();
 }

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -70,14 +70,11 @@ export default function( router ) {
 		clientRender
 	);
 
-	/**
-	 * The siteSelection middleware has been removed from this route.
-	 * No selected site!
-	 */
 	router(
 		paths.managePurchase( ':site', ':purchaseId' ),
 		redirectLoggedOut,
 		sidebar,
+		siteSelection,
 		controller.managePurchase,
 		makeLayout,
 		clientRender

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -27,19 +27,7 @@ import { getPluginsForSite } from 'state/plugins/premium/selectors';
 
 class PurchasePlanDetails extends Component {
 	static propTypes = {
-		purchaseId: PropTypes.number,
-
-		// Connected props
 		purchase: PropTypes.object,
-		hasLoadedSites: PropTypes.bool,
-		hasLoadedUserPurchasesFromServer: PropTypes.bool,
-		pluginList: PropTypes.arrayOf(
-			PropTypes.shape( {
-				slug: PropTypes.string.isRequired,
-				key: PropTypes.string.isRequired,
-			} ).isRequired
-		).isRequired,
-		siteId: PropTypes.number,
 	};
 
 	renderPlaceholder() {
@@ -64,14 +52,15 @@ class PurchasePlanDetails extends Component {
 	}
 
 	render() {
-		const { pluginList, purchase, siteId, translate } = this.props;
+		const { selectedSite, pluginList, translate } = this.props;
+		const { purchase } = this.props;
 
 		// Short out as soon as we know it's not a Jetpack plan
 		if ( purchase && ( ! isJetpackPlan( purchase ) || isFreeJetpackPlan( purchase ) ) ) {
 			return null;
 		}
 
-		if ( isDataLoading( this.props ) ) {
+		if ( isDataLoading( this.props ) || ! this.props.selectedSite ) {
 			return this.renderPlaceholder();
 		}
 
@@ -87,7 +76,7 @@ class PurchasePlanDetails extends Component {
 
 		return (
 			<div className="plan-details">
-				{ siteId && <QueryPluginKeys siteId={ siteId } /> }
+				<QueryPluginKeys siteId={ selectedSite.ID } />
 				<SectionHeader label={ headerText } />
 				<Card>
 					<PlanBillingPeriod purchase={ purchase } />
@@ -109,14 +98,9 @@ class PurchasePlanDetails extends Component {
 }
 
 // hasLoadedSites & hasLoadedUserPurchasesFromServer are used in isDataLoading
-export default connect( ( state, props ) => {
-	const purchase = getByPurchaseId( state, props.purchaseId );
-	const siteId = purchase ? purchase.siteId : null;
-	return {
-		hasLoadedSites: ! isRequestingSites( state ),
-		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
-		purchase,
-		pluginList: getPluginsForSite( state, siteId ),
-		siteId,
-	};
-} )( localize( PurchasePlanDetails ) );
+export default connect( ( state, props ) => ( {
+	hasLoadedSites: ! isRequestingSites( state ),
+	hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
+	purchase: getByPurchaseId( state, props.purchaseId ),
+	pluginList: props.selectedSite ? getPluginsForSite( state, props.selectedSite.ID ) : [],
+} ) )( localize( PurchasePlanDetails ) );

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -171,7 +171,7 @@ class PurchaseItem extends Component {
 	}
 
 	render() {
-		const { isPlaceholder, isDisconnectedSite, purchase, isJetpack } = this.props;
+		const { isPlaceholder, isDisconnectedSite, purchase } = this.props;
 		const classes = classNames(
 			'purchase-item',
 			{ 'is-expired': purchase && 'expired' === purchase.expiryStatus },
@@ -195,19 +195,19 @@ class PurchaseItem extends Component {
 			);
 		}
 
-		let onClick;
-		let href;
+		let props;
 		if ( ! isPlaceholder ) {
-			// A "disconnected" Jetpack site's purchases may be managed.
-			// A "disconnected" WordPress.com site may not (the user has been removed).
-			if ( ! isDisconnectedSite || isJetpack ) {
-				onClick = this.scrollToTop;
-				href = managePurchase( this.props.slug, this.props.purchase.id );
+			props = {
+				onClick: this.scrollToTop,
+			};
+
+			if ( ! isDisconnectedSite ) {
+				props.href = managePurchase( this.props.slug, this.props.purchase.id );
 			}
 		}
 
 		return (
-			<CompactCard className={ classes } onClick={ onClick } href={ href }>
+			<CompactCard className={ classes } { ...props }>
 				{ content }
 			</CompactCard>
 		);
@@ -219,7 +219,6 @@ PurchaseItem.propTypes = {
 	isDisconnectedSite: PropTypes.bool,
 	purchase: PropTypes.object,
 	slug: PropTypes.string,
-	isJetpack: PropTypes.bool,
 };
 
 export default localize( PurchaseItem );

--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -32,8 +32,6 @@ const PurchasesSite = ( {
 } ) => {
 	let items;
 
-	const isJetpack = ! isPlaceholder && some( purchases, purchase => isJetpackPlan( purchase ) );
-
 	if ( isPlaceholder ) {
 		items = times( 2, index => <PurchaseItem isPlaceholder key={ index } /> );
 	} else {
@@ -43,10 +41,11 @@ const PurchasesSite = ( {
 				slug={ slug }
 				isDisconnectedSite={ ! site }
 				purchase={ purchase }
-				isJetpack={ isJetpack }
 			/>
 		) );
 	}
+
+	const isJetpack = some( purchases, purchase => isJetpackPlan( purchase ) );
 
 	return (
 		<div className={ classNames( 'purchases-site', { 'is-placeholder': isPlaceholder } ) }>
@@ -60,9 +59,9 @@ const PurchasesSite = ( {
 
 			{ items }
 
-			{ ! isPlaceholder &&
-				hasLoadedSite &&
-				! site && <PurchaseReconnectNotice isJetpack={ isJetpack } name={ name } /> }
+			{ ! isPlaceholder && hasLoadedSite && ! site ? (
+				<PurchaseReconnectNotice isJetpack={ isJetpack } name={ name } domain={ domain } />
+			) : null }
 		</div>
 	);
 };

--- a/client/me/purchases/purchases-site/reconnect-notice.jsx
+++ b/client/me/purchases/purchases-site/reconnect-notice.jsx
@@ -13,35 +13,34 @@ import React, { Component } from 'react';
  */
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
-import { CALYPSO_CONTACT } from 'lib/url/support';
+import { CALYPSO_CONTACT, JETPACK_CONTACT_SUPPORT } from 'lib/url/support';
 
 class PurchaseReconnectNotice extends Component {
 	static propTypes = {
 		name: PropTypes.string,
-		translate: PropTypes.func.isRequired,
+		domain: PropTypes.string,
 	};
 
 	render() {
 		const { translate, name, isJetpack } = this.props;
-
-		const text = isJetpack
-			? translate( '%(site)s has been disconnected from WordPress.com.', {
-					args: {
-						site: name,
-					},
-			  } )
-			: translate( 'You are no longer a user on %(site)s and cannot manage this purchase.', {
-					args: {
-						site: name,
-					},
-			  } );
+		let text = translate( 'You are no longer a user on %(site)s and cannot manage this purchase.', {
+			args: {
+				site: name,
+			},
+		} );
+		if ( isJetpack ) {
+			text = translate( '%(site)s has been disconnected from WordPress.com.', {
+				args: {
+					site: name,
+				},
+			} );
+		}
 
 		return (
 			<Notice showDismiss={ false } status="is-error" text={ text }>
-				{ /* Disconnected Jetpack sites can remove purchases. No need to contact support */
-				! isJetpack && (
-					<NoticeAction href={ CALYPSO_CONTACT }>{ translate( 'Contact Support' ) }</NoticeAction>
-				) }
+				<NoticeAction href={ isJetpack ? JETPACK_CONTACT_SUPPORT : CALYPSO_CONTACT }>
+					{ translate( 'Contact Support' ) }
+				</NoticeAction>
 			</Notice>
 		);
 	}


### PR DESCRIPTION
This reverts commit b7484d11a64432e47a978e5f82ccdfa1fd4b6893.

`Renew Now` notices on all domain purchases were broken: https://github.com/Automattic/wp-calypso/issues/25873

Steps to reproduce:
- Go to Me -> Manage Purchases
- Select any domain
- Click renew now
- See error, nothing happens

Stack:
![renew now](https://user-images.githubusercontent.com/1103398/42292265-815d39a2-7fd1-11e8-9a6d-b02df462ce94.png)

Why it happens:
- The siteSelection middleware fires `SELECTED_SITE_SET`
- It is picked here https://github.com/Automattic/wp-calypso/blob/7b91038e6b42d9fc63722cdc051d76e95e5ba698/client/state/lib/middleware.js#L209
- And it initializes the cart for the site https://github.com/Automattic/wp-calypso/blob/ac187dd32d38f573bec8683dcc184bf0cc611452/client/lib/cart/store/index.js#L36

Fixes https://github.com/Automattic/wp-calypso/issues/25873
