### PR TITLE
Podcasting: Add notice when default category is selected

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -284,4 +284,8 @@ a.notice__action {
 			opacity: 1;
 		}
 	}
+
+	& + & {
+		margin-top: 8px;
+	}
 }

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -239,7 +239,13 @@ class PodcastingDetails extends Component {
 	}
 
 	renderCategorySetting() {
-		const { siteId, podcastingCategoryId, isCategoryChanging, translate } = this.props;
+		const {
+			siteId,
+			podcastingCategoryId,
+			isCategoryChanging,
+			isDefaultCategorySelected,
+			translate,
+		} = this.props;
 
 		return (
 			<Fragment>
@@ -260,6 +266,30 @@ class PodcastingDetails extends Component {
 						onAddTermSuccess={ this.onCategorySelected }
 						height={ 200 }
 					/>
+					{ isDefaultCategorySelected && (
+						<Notice isCompact status="is-info">
+							<p>
+								{ translate(
+									'Using this category (the {{strong}}default category{{/strong}} for the site) is not recommended.',
+									{
+										components: {
+											strong: <strong />,
+										},
+									}
+								) }
+							</p>
+							<p>
+								{ translate(
+									'Try creating a category named {{strong}}Podcast{{/strong}} instead.',
+									{
+										components: {
+											strong: <strong />,
+										},
+									}
+								) }
+							</p>
+						</Notice>
+					) }
 					{ isCategoryChanging && (
 						<Notice
 							isCompact
@@ -427,6 +457,9 @@ const connectComponent = connect( ( state, ownProps ) => {
 	const podcastingFeedUrl = selectedCategory && selectedCategory.feed_url;
 
 	const isCategoryChanging = podcastingCategoryId !== ownProps.settings.podcasting_category_id;
+	const isDefaultCategorySelected =
+		typeof ownProps.settings.default_category === 'number' &&
+		podcastingCategoryId === ownProps.settings.default_category;
 
 	const isJetpack = isJetpackSite( state, siteId );
 	const isAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
@@ -438,6 +471,7 @@ const connectComponent = connect( ( state, ownProps ) => {
 		podcastingCategoryId,
 		isPodcastingEnabled,
 		isCategoryChanging,
+		isDefaultCategorySelected,
 		isRequestingCategories: isRequestingTermsForQueryIgnoringPage( state, siteId, 'category', {} ),
 		podcastingFeedUrl,
 		userCanManagePodcasting: canCurrentUser( state, siteId, 'manage_options' ),

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -267,28 +267,18 @@ class PodcastingDetails extends Component {
 						height={ 200 }
 					/>
 					{ isDefaultCategorySelected && (
-						<Notice isCompact status="is-info">
-							<p>
-								{ translate(
-									'Using this category (the {{strong}}default category{{/strong}} for the site) is not recommended.',
-									{
-										components: {
-											strong: <strong />,
-										},
-									}
-								) }
-							</p>
-							<p>
-								{ translate(
-									'Try creating a category named {{strong}}Podcast{{/strong}} instead.',
-									{
-										components: {
-											strong: <strong />,
-										},
-									}
-								) }
-							</p>
-						</Notice>
+						<Notice
+							isCompact
+							status="is-info"
+							text={ translate(
+								'We recommend creating a category named {{strong}}Podcast{{/strong}} instead of using the default category for the site.',
+								{
+									components: {
+										strong: <strong />,
+									},
+								}
+							) }
+						/>
 					) }
 					{ isCategoryChanging && (
 						<Notice


### PR DESCRIPTION
Choosing "Uncategorized" as the podcasting category is probably not a very good idea.  However, this is the obvious way forward with a brand new site especially:

![2018-07-04t20 14 34-0500](https://user-images.githubusercontent.com/227022/42298204-54759152-7fca-11e8-80cd-e8f392184c6f.png)

Similarly to #25868, let's show a notice when the site's **default category** (usually Uncategorized) is selected:

![2018-07-04t20 34 29-0500](https://user-images.githubusercontent.com/227022/42298230-7a25c570-7fca-11e8-942c-e4094e4ced5c.png)
