### PR TITLE
Podcasting: Improve "category changing" notice

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -426,7 +426,12 @@ const connectComponent = connect( ( state, ownProps ) => {
 	const selectedCategory = categories && head( filter( categories, { ID: podcastingCategoryId } ) );
 	const podcastingFeedUrl = selectedCategory && selectedCategory.feed_url;
 
-	const isCategoryChanging = podcastingCategoryId !== ownProps.settings.podcasting_category_id;
+	const isSavingSettings = isSavingSiteSettings( state, siteId );
+	const isCategoryChanging =
+		! isSavingSettings &&
+		! ownProps.isRequestingSettings &&
+		Number( ownProps.settings.podcasting_category_id ) > 0 &&
+		podcastingCategoryId !== Number( ownProps.settings.podcasting_category_id );
 
 	const isJetpack = isJetpackSite( state, siteId );
 	const isAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
@@ -442,7 +447,7 @@ const connectComponent = connect( ( state, ownProps ) => {
 		podcastingFeedUrl,
 		userCanManagePodcasting: canCurrentUser( state, siteId, 'manage_options' ),
 		isUnsupportedSite: isJetpack && ! isAutomatedTransfer,
-		isSavingSettings: isSavingSiteSettings( state, siteId ),
+		isSavingSettings,
 	};
 } );
 


### PR DESCRIPTION
This PR fixes a few issues with the "podcast category changing" notice added in https://github.com/Automattic/wp-calypso/pull/25868.

### Setting up podcasting

The notice should not appear in this case because there is no "previous category" indicating a change.  The most likely case is setting up a new site, but even if podcasting was enabled and then disabled again, we should assume that this was an intentional action.

Additionally, the notice does not disappear after settings are successfully saved.

![podcasting-notice-1](https://user-images.githubusercontent.com/227022/42298824-84e54dca-7fcd-11e8-83f6-110a7e3e77df.gif)

### Disabling podcasting

The notice should not appear in this case either, when settings are being saved or when the save has completed.

![podcasting-notice-2](https://user-images.githubusercontent.com/227022/42298873-d084091a-7fcd-11e8-98b0-8023feacede6.gif)

### Switching the podcasting category

When the podcasting category is switched and settings are saved, the notice does not disappear.  This is because the podcast category ID that comes back from the REST API is a string:

![podcasting-notice-3](https://user-images.githubusercontent.com/227022/42298904-f9d43718-7fcd-11e8-89af-2c427181f03a.gif)

### This PR

This PR should fix the 3 issues described above.

It also disables this notice while settings are being saved.  This prevents the notice from flashing when podcasting is disabled and settings are being saved.