### PR TITLE
Add gravatar-caterpillar component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -160,6 +160,7 @@
 @import 'components/gauge/style';
 @import 'components/global-notices/style';
 @import 'components/gravatar/style';
+@import 'components/gravatar-caterpillar/style';
 @import 'components/happiness-support/style';
 @import 'components/header-button/style';
 @import 'components/header-cake/style';

--- a/client/components/gravatar-caterpillar/README.md
+++ b/client/components/gravatar-caterpillar/README.md
@@ -1,0 +1,24 @@
+Gravatar Caterpillar
+====================
+
+This component is used to display a row of [gravatars](https://gravatar.com/) for a number of users.
+
+On smaller screens (<660px wide), the component will display half the maximum number of gravatars.
+
+#### How to use:
+
+```js
+import GravatarCaterpillar from 'components/gravatar-caterpillar';
+
+render() {
+    return (
+        <GravatarCaterpillar users={ users } />
+    );
+}
+```
+
+#### Props
+
+* `users`: an array of users. Required keys: avatar_url, email
+* `maxGravatarsToDisplay`: maximum number of gravatars to display. Defaults to 10.
+* `onClick`: click handler

--- a/client/components/gravatar-caterpillar/docs/example.jsx
+++ b/client/components/gravatar-caterpillar/docs/example.jsx
@@ -1,0 +1,18 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import GravatarCaterpillar from 'components/gravatar-caterpillar';
+import { authors } from './fixtures';
+
+function GravatarCaterpillarExample() {
+	return <GravatarCaterpillar authors={ authors } />;
+}
+
+export default GravatarCaterpillarExample;

--- a/client/components/gravatar-caterpillar/docs/example.jsx
+++ b/client/components/gravatar-caterpillar/docs/example.jsx
@@ -9,10 +9,10 @@ import React from 'react';
  * Internal dependencies
  */
 import GravatarCaterpillar from 'components/gravatar-caterpillar';
-import { authors } from './fixtures';
+import { users } from './fixtures';
 
 function GravatarCaterpillarExample() {
-	return <GravatarCaterpillar authors={ authors } />;
+	return <GravatarCaterpillar users={ users } />;
 }
 
 export default GravatarCaterpillarExample;

--- a/client/components/gravatar-caterpillar/docs/fixtures.js
+++ b/client/components/gravatar-caterpillar/docs/fixtures.js
@@ -1,0 +1,83 @@
+/** @format */
+
+export const authors = [
+	{
+		ID: 1,
+		name: 'Christophe',
+		email: 'christophe@example.com',
+		avatar_URL:
+			'https://2.gravatar.com/avatar/5512fbf07ae3dd340fb6ed4924861c8e?s=96&d=identicon&r=G',
+		has_avatar: true,
+	},
+	{
+		ID: 2,
+		name: 'Boris',
+		email: 'boris@example.com',
+		avatar_URL: 'https://2.gravatar.com/avatar/22d41e5b6ff197cd7900c0514d1bd305?d=mm&r=G',
+		has_avatar: false, // Test that authors with has_avatar: false are omitted
+	},
+	{
+		ID: 3,
+		name: 'Matt',
+		email: 'matt@example.com',
+		avatar_URL: 'https://1.gravatar.com/avatar/767fc9c115a1b989744c755db47feb60?d=mm&r=G',
+		has_avatar: true,
+	},
+	{
+		ID: 6,
+		name: 'Ben',
+		email: 'ben@example.com',
+		avatar_URL: 'https://0.gravatar.com/avatar/3b7b2c457b9201d166b9a2b47cadc86d?d=mm&r=G',
+		has_avatar: true,
+	},
+	{
+		ID: 7,
+		name: 'Derek',
+		email: 'derek@example.com',
+		avatar_URL: 'https://2.gravatar.com/avatar/2723d05b4e1176e977e1e6641a2ca98b?d=mm&r=G',
+		has_avatar: true,
+	},
+	{
+		ID: 8,
+		name: 'Jake',
+		email: 'jake@example.com',
+		avatar_URL: 'https://1.gravatar.com/avatar/7a6c0fad3d7e9d4038222cbadd095db8?d=mm&r=G',
+		has_avatar: true,
+	},
+	{
+		ID: 9,
+		name: 'Jan',
+		email: 'jan@example.com',
+		avatar_URL:
+			'https://secure.gravatar.com/avatar/3e44726f128c263db20117a659bfa003?d=mm&s=275&r=G',
+		has_avatar: true,
+	},
+	{
+		ID: 10,
+		name: 'Aaron',
+		email: 'aaron@example.com',
+		avatar_URL: 'https://2.gravatar.com/avatar/20600ea4d39b6facdd79875d24d2dbab?d=mm&r=G',
+		has_avatar: true,
+	},
+	{
+		ID: 11,
+		name: 'Greg',
+		email: 'greg@example.com',
+		avatar_URL: 'https://0.gravatar.com/avatar/915ee4efbd21f12b55b6362cf4f7c42f?d=mm&r=G',
+		has_avatar: true,
+	},
+	{
+		ID: 12,
+		name: 'Martin',
+		email: 'martin@example.com',
+		avatar_URL: 'https://0.gravatar.com/avatar/33b3e384f5a150015a5a981402983ca3?d=mm&r=G',
+		has_avatar: true,
+	},
+	{
+		ID: 13,
+		name: 'Yanir',
+		email: 'yanir@example.com',
+		avatar_URL: 'https://1.gravatar.com/avatar/dda019c47a6183120608a6aeac2db6c5?d=mm&r=G',
+		has_avatar: true,
+	},
+];

--- a/client/components/gravatar-caterpillar/docs/fixtures.js
+++ b/client/components/gravatar-caterpillar/docs/fixtures.js
@@ -1,6 +1,6 @@
 /** @format */
 
-export const authors = [
+export const users = [
 	{
 		ID: 1,
 		name: 'Christophe',

--- a/client/components/gravatar-caterpillar/index.jsx
+++ b/client/components/gravatar-caterpillar/index.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop, map, size } from 'lodash';
+import { noop, map, size, takeRight, filter, uniqBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,31 +17,36 @@ class GravatarCaterpillar extends React.Component {
 	};
 
 	render() {
-		const { authors, onClick, maxGravatarsToDisplay } = this.props;
+		const { users, onClick, maxGravatarsToDisplay } = this.props;
 
-		const displayedAuthorsCount = size( authors );
-
-		if ( displayedAuthorsCount < 1 ) {
+		if ( size( users ) < 1 ) {
 			return null;
 		}
 
 		const gravatarSmallScreenThreshold = maxGravatarsToDisplay / 2;
 
+		// Only display authors with a gravatar, and only display each author once
+		const displayedUsers = takeRight(
+			filter( uniqBy( users, 'email' ), 'avatar_URL' ),
+			maxGravatarsToDisplay
+		);
+		const displayedUsersCount = size( displayedUsers );
+
 		return (
 			<div className="gravatar-caterpillar" onClick={ onClick } aria-hidden="true">
-				{ map( authors, ( author, index ) => {
+				{ map( displayedUsers, ( user, index ) => {
 					let gravClasses = 'gravatar-caterpillar__gravatar';
 					// If we have more than x gravs,
 					// add a additional class so we can hide some on small screens
 					if (
-						displayedAuthorsCount > gravatarSmallScreenThreshold &&
-						index < displayedAuthorsCount - gravatarSmallScreenThreshold
+						displayedUsersCount > gravatarSmallScreenThreshold &&
+						index < displayedUsersCount - gravatarSmallScreenThreshold
 					) {
 						gravClasses += ' is-hidden-on-small-screens';
 					}
 
 					return (
-						<Gravatar className={ gravClasses } key={ author.email } user={ author } size={ 32 } />
+						<Gravatar className={ gravClasses } key={ user.email } user={ user } size={ 32 } />
 					);
 				} ) }
 			</div>

--- a/client/components/gravatar-caterpillar/index.jsx
+++ b/client/components/gravatar-caterpillar/index.jsx
@@ -1,0 +1,57 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { noop, map, size } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Gravatar from 'components/gravatar';
+
+class GravatarCaterpillar extends React.Component {
+	static propTypes = {
+		onClick: PropTypes.func,
+	};
+
+	render() {
+		const { authors, onClick, maxGravatarsToDisplay } = this.props;
+
+		const displayedAuthorsCount = size( authors );
+
+		if ( displayedAuthorsCount < 1 ) {
+			return null;
+		}
+
+		const gravatarSmallScreenThreshold = maxGravatarsToDisplay / 2;
+
+		return (
+			<div className="gravatar-caterpillar" onClick={ onClick } aria-hidden="true">
+				{ map( authors, ( author, index ) => {
+					let gravClasses = 'gravatar-caterpillar__gravatar';
+					// If we have more than x gravs,
+					// add a additional class so we can hide some on small screens
+					if (
+						displayedAuthorsCount > gravatarSmallScreenThreshold &&
+						index < displayedAuthorsCount - gravatarSmallScreenThreshold
+					) {
+						gravClasses += ' is-hidden-on-small-screens';
+					}
+
+					return (
+						<Gravatar className={ gravClasses } key={ author.email } user={ author } size={ 32 } />
+					);
+				} ) }
+			</div>
+		);
+	}
+}
+
+GravatarCaterpillar.defaultProps = {
+	onClick: noop,
+	maxGravatarsToDisplay: 10,
+};
+
+export default GravatarCaterpillar;

--- a/client/components/gravatar-caterpillar/style.scss
+++ b/client/components/gravatar-caterpillar/style.scss
@@ -1,0 +1,25 @@
+.gravatar-caterpillar {
+	display: flex;
+	flex-shrink: 0;
+}
+
+.gravatar-caterpillar__gravatar {
+	cursor: pointer;
+	border: 2px solid $white;
+	height: 24px;
+	margin-left: -8px;
+	vertical-align: middle;
+	width: 24px;
+
+	&:first-child {
+		margin-left: -2px;
+	}
+
+	&.is-hidden-on-small-screens {
+		display: none;
+
+		@include breakpoint( ">660px" ) {
+   			display: inline;
+   		}
+	}
+}

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -62,6 +62,7 @@ import FormFields from 'components/forms/docs/example';
 import Gauge from 'components/gauge/docs/example';
 import GlobalNotices from 'components/global-notices/docs/example';
 import Gravatar from 'components/gravatar/docs/example';
+import GravatarCaterpillar from 'components/gravatar-caterpillar/docs/example';
 import HeaderButton from 'components/header-button/docs/example';
 import Headers from 'components/header-cake/docs/example';
 import ImagePreloader from 'components/image-preloader/docs/example';
@@ -202,6 +203,7 @@ class DesignAssets extends React.Component {
 					<Gauge readmeFilePath="gauge" />
 					<GlobalNotices readmeFilePath="global-notices" />
 					<Gravatar readmeFilePath="gravatar" />
+					<GravatarCaterpillar readmeFilePath="gravatar-caterpillar" />
 					<Gridicons />
 					<HeaderButton readmeFilePath="header-button" />
 					<Headers readmeFilePath="header-cake" />


### PR DESCRIPTION
Splits the gravatar caterpillar display out of the existing ConversationCaterpillar block so we can use it elsewhere.

<img width="320" alt="screen shot 2018-07-05 at 15 42 12" src="https://user-images.githubusercontent.com/17325/42301550-0096f062-806a-11e8-9b9f-3cec26fc7f47.png">

### To test

Check out http://calypso.localhost:3000/devdocs/design/gravatar-caterpillar.

Try resizing your viewport to <660px, and verify that you only see 5 avatars.