### PR TITLE
Help: add site/blog/both article to most helpful articles in `/help`

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -41,6 +41,14 @@ class Help extends React.PureComponent {
 	getHelpfulArticles = () => {
 		const helpfulResults = [
 			{
+				link:
+					'https://en.support.wordpress.com/do-i-need-a-website-a-blog-or-a-website-with-a-blog/',
+				title: this.props.translate( 'Do I Need a Website, a Blog, or a Website with a Blog?' ),
+				description: this.props.translate(
+					'If you’re building a brand new site, you might be wondering if you need a website, a blog, or a website with a blog. At WordPress.com, you can create all of these options easily, right in your dashboard.'
+				),
+			},
+			{
 				link: 'https://en.support.wordpress.com/business-plan/',
 				title: this.props.translate( 'Uploading custom plugins and themes' ),
 				description: this.props.translate(


### PR DESCRIPTION
This PR adds a new help article to the "most helpful links section" under `/help`: ("Do I Need a Website, a Blog, or a Website with a Blog?")[https://en.support.wordpress.com/do-i-need-a-website-a-blog-or-a-website-with-a-blog/]. 

Screenshot:

<img width="742" alt="screen shot 2018-07-05 at 10 47 57 am" src="https://user-images.githubusercontent.com/23619/42312564-e6b7d4aa-8040-11e8-8fb8-01a97c5c9d9e.png">

To test:
- Navigate to [`/help`](https://calypso.live/help?branch=add/site-blog-both-content-to-help-page) and make sure the article shows up and works as expected. 