### PR TITLE
Add default icon for GMB external accounts

### DIFF
--- a/client/my-sites/google-my-business/location/index.js
+++ b/client/my-sites/google-my-business/location/index.js
@@ -14,7 +14,6 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import Card from 'components/card';
-import GoogleMyBusinessLogo from 'my-sites/google-my-business/logo';
 
 function GoogleMyBusinessLocationPlaceholder( { isCompact } ) {
 	const classes = classNames( 'gmb-location', 'is-loading', { 'is-compact': isCompact } );
@@ -22,9 +21,7 @@ function GoogleMyBusinessLocationPlaceholder( { isCompact } ) {
 	return (
 		<Card className={ classes }>
 			<div className="gmb-location__content">
-				<div className="gmb-location__logo">
-					<GoogleMyBusinessLogo height="30" width="30" />
-				</div>
+				<Gridicon icon="institution" height="60px" width="60px" />
 				<div className="gmb-location__description">
 					<div className="gmb-location__name" />
 					<div className="gmb-location__address" />
@@ -53,9 +50,7 @@ function GoogleMyBusinessLocation( { children, isCompact, location, translate } 
 						src={ location.picture }
 					/>
 				) : (
-					<div className="gmb-location__logo">
-						<GoogleMyBusinessLogo height="30" width="30" />
-					</div>
+					<Gridicon icon="institution" height="60px" width="60px" />
 				) }
 
 				<div className="gmb-location__description">

--- a/client/my-sites/google-my-business/location/style.scss
+++ b/client/my-sites/google-my-business/location/style.scss
@@ -30,19 +30,10 @@
 	display: flex;
 }
 
-.gmb-location__logo,
 .gmb-location__picture {
 	border-radius: 50%;
 	height: 60px;
 	width: 60px;
-}
-
-.gmb-location__logo {
-	align-items: center;
-	background-color: $gray-light;
-	display: flex;
-	justify-content: center;
-	min-width: 60px; // Makes sure aspect ratio is maintained when viewport is super narrow
 }
 
 .gmb-location__description {

--- a/client/my-sites/sharing/connections/account-dialog-account.jsx
+++ b/client/my-sites/sharing/connections/account-dialog-account.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
-const AccountDialogAccount = ( { account, conflicting, onChange, selected } ) => {
+const AccountDialogAccount = ( { account, conflicting, onChange, selected, defaultIcon } ) => {
 	const classes = classNames( 'account-dialog-account', {
 		'is-connected': account.isConnected,
 		'is-conflict': conflicting,
@@ -33,6 +33,9 @@ const AccountDialogAccount = ( { account, conflicting, onChange, selected } ) =>
 						alt={ account.name }
 						className="account-dialog-account__picture"
 					/>
+				) }
+				{ ! account.picture && (
+					<Gridicon icon={ defaultIcon } className="account-dialog-account__picture" />
 				) }
 				<span className="account-dialog-account__content">
 					<div className="account-dialog-account__name">{ account.name }</div>

--- a/client/my-sites/sharing/connections/account-dialog-account.jsx
+++ b/client/my-sites/sharing/connections/account-dialog-account.jsx
@@ -9,6 +9,7 @@ import React from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 const AccountDialogAccount = ( { account, conflicting, onChange, selected, defaultIcon } ) => {
 	const classes = classNames( 'account-dialog-account', {
 		'is-connected': account.isConnected,
@@ -46,6 +47,7 @@ const AccountDialogAccount = ( { account, conflicting, onChange, selected, defau
 		</li>
 	);
 };
+/* eslint-enable wpcalypso/jsx-classname-namespace */
 
 AccountDialogAccount.propTypes = {
 	account: PropTypes.shape( {

--- a/client/my-sites/sharing/connections/account-dialog-account.jsx
+++ b/client/my-sites/sharing/connections/account-dialog-account.jsx
@@ -27,14 +27,13 @@ const AccountDialogAccount = ( { account, conflicting, onChange, selected, defau
 						className="account-dialog-account__input"
 					/>
 				) }
-				{ account.picture && (
+				{ account.picture ? (
 					<img
 						src={ account.picture }
 						alt={ account.name }
 						className="account-dialog-account__picture"
 					/>
-				) }
-				{ ! account.picture && (
+				) : (
 					<Gridicon icon={ defaultIcon } className="account-dialog-account__picture" />
 				) }
 				<span className="account-dialog-account__content">

--- a/client/my-sites/sharing/connections/account-dialog.jsx
+++ b/client/my-sites/sharing/connections/account-dialog.jsx
@@ -115,6 +115,8 @@ class AccountDialog extends Component {
 
 	getAccountElements( accounts ) {
 		const selectedAccount = this.getSelectedAccount();
+		const defaultAccountIcon =
+			this.props.service.ID === 'google_my_business' ? 'institution' : null;
 
 		return accounts.map( account => (
 			<AccountDialogAccount
@@ -127,6 +129,7 @@ class AccountDialog extends Component {
 					this.areAccountsConflicting( account, selectedAccount )
 				}
 				onChange={ this.onSelectedAccountChanged.bind( null, account ) }
+				defaultIcon={ defaultAccountIcon }
 			/>
 		) );
 	}

--- a/client/my-sites/sharing/connections/connection.jsx
+++ b/client/my-sites/sharing/connections/connection.jsx
@@ -50,6 +50,9 @@ class SharingConnection extends Component {
 		translate: identity,
 		userHasCaps: false,
 		userId: 0,
+		defaultServiceIcon: {
+			google_my_business: 'institution',
+		},
 	};
 
 	disconnect = () => {
@@ -113,6 +116,12 @@ class SharingConnection extends Component {
 					'sharing-connection__account-avatar is-fallback ' + this.props.connection.service
 				}
 			>
+				{ this.props.defaultServiceIcon[ this.props.connection.service ] && (
+					<Gridicon
+						icon={ this.props.defaultServiceIcon[ this.props.connection.service ] }
+						size={ 36 }
+					/>
+				) }
 				<span className="screen-reader-text">{ this.props.connection.label }</span>
 			</span>
 		);

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -397,7 +397,7 @@
 	height: 36px;
 	width: 36px;
 	border: 1px solid $gray-light;
-	color: white;
+	text-align: center;
 }
 
 .sharing-connection__account-status {


### PR DESCRIPTION
This PR adds a default icon for GMB external accounts who don't have a picture of their own.
![screen shot 2018-07-05 at 16 20 03](https://user-images.githubusercontent.com/326402/42325682-9b65f160-806f-11e8-9eaa-29846f82eacc.png)

![screen shot 2018-07-05 at 17 16 44](https://user-images.githubusercontent.com/326402/42328706-aa84e3ba-8077-11e8-988e-9a9031a308cc.png)

![screen shot 2018-07-05 at 17 16 06](https://user-images.githubusercontent.com/326402/42328709-aca046bc-8077-11e8-8c71-2b3b76d724fe.png)



#### Testing instructions
  
1. Run `git checkout add/default-icon-for-external-accounts` and start your server, or open a [live branch](https://calypso.live/?branch=add/default-icon-for-external-accounts)
2. Open the [`Sharing` page](http://calypso.localhost:3000/sharing)
3. Connect a GMB account that have some locations without a picutre
4. Assert you can see the default "instituion" [icon](https://automattic.github.io/gridicons/)

  #### Reviews
  
- [ ] Code
- [ ] Product

