### PR TITLE
Podcasting: Simplify `selectedCategory` logic

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -6,7 +6,7 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { map, toPairs, pick, flowRight, filter, head } from 'lodash';
+import { map, toPairs, pick, flowRight } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -39,10 +39,7 @@ import isPrivateSite from 'state/selectors/is-private-site';
 import canCurrentUser from 'state/selectors/can-current-user';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'state/sites/selectors';
-import {
-	isRequestingTermsForQueryIgnoringPage,
-	getTermsForQueryIgnoringPage,
-} from 'state/terms/selectors';
+import { isRequestingTermsForQueryIgnoringPage, getTerm } from 'state/terms/selectors';
 import { isSavingSiteSettings } from 'state/site-settings/selectors';
 
 class PodcastingDetails extends Component {
@@ -422,8 +419,8 @@ const connectComponent = connect( ( state, ownProps ) => {
 		Number( ownProps.fields.podcasting_category_id );
 	const isPodcastingEnabled = podcastingCategoryId > 0;
 
-	const categories = getTermsForQueryIgnoringPage( state, siteId, 'category', {} );
-	const selectedCategory = categories && head( filter( categories, { ID: podcastingCategoryId } ) );
+	const selectedCategory =
+		isPodcastingEnabled && getTerm( state, siteId, 'category', podcastingCategoryId );
 	const podcastingFeedUrl = selectedCategory && selectedCategory.feed_url;
 
 	const isCategoryChanging = podcastingCategoryId !== ownProps.settings.podcasting_category_id;


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/blob/eef2b884/client/my-sites/site-settings/podcasting-details/index.jsx#L425-L427

This code, introduced in https://github.com/Automattic/wp-calypso/pull/25238, will cause a performance issue on sites with large numbers of categories, because it retrieves the entire list of categories each time the podcasting settings screen's `connect` method is called.

We don't actually need this list for anything, so let's use `getTerm` to request only the specific category we're interested in.