### PR TITLE
Podcasting: fix cover image stretching on IE11

### DIFF
--- a/client/my-sites/site-settings/podcast-cover-image-setting/style.scss
+++ b/client/my-sites/site-settings/podcast-cover-image-setting/style.scss
@@ -1,6 +1,5 @@
 .podcast-cover-image-setting__preview {
 	position: relative;
-	overflow: hidden;
 	display: flex;
 	float: left;
 	margin: 0;
@@ -24,6 +23,9 @@
 	align-self: center;
 	background: $transparent;
 	position: relative;
+	max-height: 100%;
+	max-width: 100%;
+	margin: 0 auto;
 
 	.is-disabled & {
 		opacity: 0.3;


### PR DESCRIPTION
**Update by @mattsherman: PR retitled to reflect that it fixes an IE11 issue, instead of a mobile Safari issue as originally intended. The iPhone X loading issue still intermittently occurs and will be addressed by a followup PR.**

~~For preset cover images (whether by the legacy url method, or through previous podcast testing), the cover image is blank on first load in Safari. The bug is intermittent, and goes away after resetting the cover image, but using `overflow: hidden` on the container seems to be the cause of the problem.~~

This PR is part of a larger epic and is behind the manage/site-settings/podcasting feature flag. See p3Ex-32D-p2.

**To test:**
- On a site with podcasting already enabled and a cover image already set
- Visit Settings > Writing > Manage Podcast
- Verify that the cover image is properly shown in all supported browsers, including IE11
- Verify that in desktop browsers, the image is properly constrained by its container (no overflow for non-square images)