### PR TITLE
Concierge: Implement data layer for the new Initial endpoint

### DIFF
--- a/client/state/data-layer/wpcom/concierge/schedules/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/index.js
@@ -6,5 +6,6 @@
 import { mergeHandlers } from 'state/action-watchers/utils';
 import availableTimes from './available-times';
 import appointments from './appointments';
+import initial from './initial';
 
-export default mergeHandlers( availableTimes, appointments );
+export default mergeHandlers( availableTimes, appointments, initial );

--- a/client/state/data-layer/wpcom/concierge/schedules/initial/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/initial/from-api.js
@@ -1,0 +1,17 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import makeJsonSchemaParser from 'lib/make-json-schema-parser';
+import responseSchema from './schema';
+
+export const convertToDate = timestampInSeconds => timestampInSeconds * 1000;
+
+export const transform = response => {
+	return {
+		availableTimes: response.available_times.map( convertToDate ),
+	};
+};
+
+export default makeJsonSchemaParser( responseSchema, transform );

--- a/client/state/data-layer/wpcom/concierge/schedules/initial/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/initial/index.js
@@ -1,0 +1,45 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { updateConciergeInitial } from 'state/concierge/actions';
+import { errorNotice } from 'state/notices/actions';
+import { CONCIERGE_INITIAL_REQUEST } from 'state/action-types';
+import fromApi from './from-api';
+
+export const fetchConciergeInitial = action =>
+	http(
+		{
+			method: 'GET',
+			path: `/concierge/schedules/${ action.scheduleId }/initial`,
+			apiNamespace: 'wpcom/v2',
+		},
+		action
+	);
+
+export const storeFetchedConciergeInitial = ( action, initial ) =>
+	updateConciergeInitial( initial );
+
+export const conciergeInitialFetchError = () =>
+	errorNotice( translate( "We couldn't load our Concierge schedule. Please try again later." ) );
+
+export const showConciergeInitialFetchError = () => conciergeInitialFetchError();
+
+export default {
+	[ CONCIERGE_INITIAL_REQUEST ]: [
+		dispatchRequestEx( {
+			fetch: fetchConciergeInitial,
+			onSuccess: storeFetchedConciergeInitial,
+			onError: showConciergeInitialFetchError,
+			fromApi,
+		} ),
+	],
+};

--- a/client/state/data-layer/wpcom/concierge/schedules/initial/schema.json
+++ b/client/state/data-layer/wpcom/concierge/schedules/initial/schema.json
@@ -1,0 +1,11 @@
+{
+	"type": "object",
+	"properties": {
+		"available_times": {
+			"type": "array",
+			"items": {
+				"type": "integer"
+			}
+		}
+	}
+}

--- a/client/state/data-layer/wpcom/concierge/schedules/initial/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/initial/test/from-api.js
@@ -1,0 +1,63 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import fromApi from '../from-api';
+import { SchemaError } from 'lib/make-json-schema-parser';
+
+describe( 'fromApi()', () => {
+	test( 'should validate and transform the data successfully.', () => {
+		const validResponse = {
+			available_times: [
+				1483264800, // unix timestamp of 2017-01-01 10:00:00 UTC
+				1483266600, // unix timestamp of 2017-01-01 10:30:00 UTC
+				1483268400, // unix timestamp of 2017-01-01 11:00:00 UTC
+			],
+		};
+
+		const expectedResult = { availableTimes: [ 1483264800000, 1483266600000, 1483268400000 ] };
+
+		expect( fromApi( validResponse ) ).toEqual( expectedResult );
+	} );
+
+	test( 'should invalidate unexpected field types.', () => {
+		const invalidateCall = () => {
+			const invalidFieldTypes = [ 'this', 'is', false, 'just wrong.' ];
+
+			fromApi( invalidFieldTypes );
+		};
+
+		expect( invalidateCall ).toThrowError( SchemaError );
+	} );
+
+	test( 'should invalidate missing begin_timestamp.', () => {
+		const invalidateMissingBeginTimestamp = () => {
+			const invalidResponse = [
+				{
+					end_timestamp: 400,
+				},
+			];
+
+			fromApi( invalidResponse );
+		};
+
+		expect( invalidateMissingBeginTimestamp ).toThrowError( SchemaError );
+	} );
+
+	test( 'should invalidate missing end_timestamp.', () => {
+		const invalidateMissingEndTimestamp = () => {
+			const invalidResponse = {
+				available_times: [
+					{
+						begin_timestamp: 333,
+					},
+				],
+			};
+
+			fromApi( invalidResponse );
+		};
+
+		expect( invalidateMissingEndTimestamp ).toThrowError( SchemaError );
+	} );
+} );

--- a/client/state/data-layer/wpcom/concierge/schedules/initial/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/initial/test/index.js
@@ -1,0 +1,59 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import {
+	conciergeInitialFetchError,
+	fetchConciergeInitial,
+	storeFetchedConciergeInitial,
+	showConciergeInitialFetchError,
+} from '../';
+import { updateConciergeInitial } from 'state/concierge/actions';
+import { CONCIERGE_INITIAL_REQUEST } from 'state/action-types';
+
+// we are mocking impure-lodash here, so that conciergeInitialFetchError() will contain the expected id in the tests
+jest.mock( 'lib/impure-lodash', () => ( {
+	uniqueId: () => 'mock-unique-id',
+} ) );
+
+describe( 'wpcom-api', () => {
+	describe( 'concierge', () => {
+		test( 'fetchConciergeInitial()', () => {
+			const action = {
+				type: CONCIERGE_INITIAL_REQUEST,
+				scheduleId: 123,
+			};
+
+			expect( fetchConciergeInitial( action ) ).toEqual(
+				http(
+					{
+						method: 'GET',
+						path: `/concierge/schedules/${ action.scheduleId }/initial`,
+						apiNamespace: 'wpcom/v2',
+					},
+					action
+				)
+			);
+		} );
+
+		test( 'storeFetchedConciergeInitial()', () => {
+			const mockInitial = {
+				available_times: [
+					new Date( '2017-01-01 01:00:00' ),
+					new Date( '2017-01-01 02:00:00' ),
+					new Date( '2017-01-01 03:00:00' ),
+				],
+			};
+
+			expect( storeFetchedConciergeInitial( {}, mockInitial ) ).toEqual(
+				updateConciergeInitial( mockInitial )
+			);
+		} );
+
+		test( 'showConciergeInitialFetchError()', () => {
+			expect( showConciergeInitialFetchError() ).toEqual( conciergeInitialFetchError() );
+		} );
+	} );
+} );


### PR DESCRIPTION
Adds the data layer for the new endpoint added in `D15118-code`.

The new endpoint returns available appointment times, as per `available_times`, as well as the customer's next scheduled appointment if they have one. This will allow a user to be limited to one pending appointment at a time in a future commit.

Subsequent PRs will use this data layer to retrieve available times, instead of the available_times data layer; to check if a customer has a pending appointment and to give the customer appropriate options when the do.

**Testing**
Unit tests have been added, and can be executed with `npm run test-client concierge`.

cc @mattwondra 
cc @nb 