### PR TITLE
Don't show transfer pricing when domain hasn't yet been selected.

### DIFF
--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -148,7 +148,9 @@ class UseYourDomainStep extends React.Component {
 			domainsWithPlansOnly && ( ( selectedSite && ! isPlan( selectedSite.plan ) ) || isSignupStep );
 
 		let domainProductPrice = getDomainPrice( productSlug, productsList, currencyCode );
-		domainProductPrice += ' per year';
+		if ( domainProductPrice ) {
+			domainProductPrice += ' per year';
+		}
 
 		if ( isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, searchQuery ) ) {
 			domainProductPrice = translate( 'Free with your plan' );


### PR DESCRIPTION
This fixes issue #25891 

To test:

Starting at My Site > Domains
Click Add Domain
Click to use a domain you already own without putting it in the search box

Make sure that there is no price shown for the transfers option.