### PR TITLE
Signup: Use Redux for handling/persisting signup progress

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -12,7 +12,6 @@ import { includes, capitalize } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import classNames from 'classnames';
-import store from 'store';
 
 /**
  * Internal dependencies
@@ -129,27 +128,10 @@ class Login extends Component {
 		// Redirects to / if no redirect url is available
 		const url = redirectTo ? redirectTo : window.location.origin;
 
-		// For a seamless signup experience, the site creation data
-		// should be restored when users log in to WordPress.com
-		const signupFlowName = store.get( 'signupFlowName' );
-		const signupProgress = ( store.get( 'signupProgress' ) || [] ).filter(
-			step => step.stepName !== 'user'
-		);
-
 		// user data is persisted in localstorage at `lib/user/user` line 157
 		// therefor we need to reset it before we redirect, otherwise we'll get
 		// mixed data from old and new user
-		user.clear( () => {
-			if ( signupFlowName && signupProgress.length ) {
-				const lastStep = signupProgress.pop();
-				store.set( 'signupFlowName', signupFlowName );
-				store.set( 'signupProgress', [
-					...signupProgress,
-					{ ...lastStep, resumeAfterLogin: true },
-				] );
-			}
-			window.location.href = url;
-		} );
+		user.clear( () => ( window.location.href = url ) );
 	};
 
 	renderHeader() {

--- a/client/lib/signup/actions.js
+++ b/client/lib/signup/actions.js
@@ -13,10 +13,6 @@ import Dispatcher from 'dispatcher';
 import analytics from 'lib/analytics';
 
 const SignupActions = {
-	fetchCachedSignup() {
-		Dispatcher.handleViewAction( { type: 'FETCH_CACHED_SIGNUP' } );
-	},
-
 	saveSignupStep( step ) {
 		// there are some conditions in which a step could be saved/processed in the same event loop
 		// so we should defer the action

--- a/client/lib/signup/actions.js
+++ b/client/lib/signup/actions.js
@@ -74,10 +74,10 @@ const SignupActions = {
 		} );
 	},
 
-	changeSignupFlow( flow ) {
+	changeSignupFlow( flowName ) {
 		Dispatcher.handleViewAction( {
 			type: 'CHANGE_SIGNUP_FLOW',
-			flow,
+			flowName,
 		} );
 	},
 };

--- a/client/lib/signup/progress-store.js
+++ b/client/lib/signup/progress-store.js
@@ -187,7 +187,7 @@ SignupProgressStore.dispatchToken = Dispatcher.register( function( payload ) {
 			break;
 		case 'CHANGE_SIGNUP_FLOW':
 			debug( 'change flow' );
-			removeUnneededStep( action.flow );
+			removeUnneededStep( action.flowName );
 			break;
 	}
 } );

--- a/client/lib/signup/progress-store.js
+++ b/client/lib/signup/progress-store.js
@@ -158,8 +158,8 @@ function removeUnneededStep( flowName ) {
 }
 
 SignupProgressStore.dispatchToken = Dispatcher.register( function( payload ) {
-	let action = payload.action,
-		step = addTimestamp( action.data );
+	const action = payload.action;
+	const step = addTimestamp( action.data );
 
 	Dispatcher.waitFor( [ SignupDependencyStore.dispatchToken ] );
 

--- a/client/lib/signup/progress-store.js
+++ b/client/lib/signup/progress-store.js
@@ -4,139 +4,86 @@
  * External dependencies
  */
 
-import { assign, clone, filter, find, get, isEmpty, map, omit } from 'lodash';
+import { isEqual, get, isEmpty, omit } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:signup-progress-store' );
-import store from 'store';
 
 /**
  * Internal dependencies
  */
 import Dispatcher from 'dispatcher';
-import emitter from 'lib/mixins/emitter';
-import SignupDependencyStore from './dependency-store';
-import flows from 'signup/config/flows';
 import steps from 'signup/config/steps-pure';
-
-/**
- * Constants
- */
-const STORAGE_KEY = 'signupProgress';
-
-/**
- * Module variables
- */
-let signupProgress = [];
+import { SIGNUP_COMPLETE_RESET, SIGNUP_PROGRESS_SET } from 'state/action-types';
+import {
+	completeStep,
+	processStep,
+	removeUnneededSteps,
+	saveStep,
+	invalidateStep,
+	submitStep,
+} from 'state/signup/progress/actions';
+import { getSignupProgress } from 'state/signup/progress/selectors';
+import SignupDependencyStore from './dependency-store';
 
 const SignupProgressStore = {
-	get: function() {
-		return clone( signupProgress );
+	currentValue: null,
+	reduxStore: null,
+	subscribers: new Map(),
+
+	get() {
+		if ( ! this.reduxStore ) {
+			debug( 'Tried to read redux state before store was ready' );
+			return [];
+		}
+		return getSignupProgress( this.reduxStore.getState() );
 	},
-	reset: function() {
-		signupProgress = [];
-		store.remove( STORAGE_KEY );
+	reset() {
+		this.unsubscribeAll();
+		this.reduxStore.dispatch( {
+			type: SIGNUP_COMPLETE_RESET,
+		} );
 	},
-	getFromCache: function() {
-		loadProgressFromCache();
-		return this.get();
+	set( input ) {
+		this.reduxStore.dispatch( {
+			type: SIGNUP_PROGRESS_SET,
+			steps: input,
+		} );
+	},
+	setReduxStore( reduxStore ) {
+		this.reduxStore = reduxStore;
+	},
+
+	// Subscriptions and change handling
+	off( eventName, callback ) {
+		eventName === 'change' && this.unsubscribe( callback );
+	},
+	on( eventName, callback ) {
+		eventName === 'change' && this.subscribe( callback );
+	},
+	subscribe( callback ) {
+		this.currentValue = this.get();
+		const unsubscribeFn = this.reduxStore.subscribe( () => {
+			if ( ! isEqual( this.currentValue, this.get() ) ) {
+				this.currentValue = this.get();
+				callback( this.currentValue );
+			}
+		} );
+		this.subscribers.set( callback, unsubscribeFn );
+	},
+	unsubscribe( callback ) {
+		if ( this.subscribers.has( callback ) ) {
+			// NOTE: Executing the function stored at this key unsubscribes the listener
+			this.subscribers.get( callback )();
+			this.subscribers.delete( callback );
+		}
+	},
+	unsubscribeAll() {
+		[ ...this.subscribers.keys() ].forEach( key => this.unsubscribe( key ) );
 	},
 };
 
-emitter( SignupProgressStore );
-
-function updateStep( newStep ) {
-	signupProgress = map( signupProgress, function( step ) {
-		if ( step.stepName === newStep.stepName ) {
-			const { status } = newStep;
-			if ( status === 'pending' || status === 'completed' ) {
-				// Steps that are resubmitted may decide to omit the
-				// `processingMessage` or `wasSkipped` status of a step if e.g.
-				// the user goes back and chooses to not skip a step. If a step
-				// is submitted without these, we explicitly remove them from
-				// the step data.
-				return assign( {}, omit( step, [ 'processingMessage', 'wasSkipped' ] ), newStep );
-			}
-
-			return assign( {}, step, newStep );
-		}
-
-		return step;
-	} );
-
-	handleChange();
-}
-
-function addStep( step ) {
-	signupProgress = signupProgress.concat( step );
-
-	handleChange();
-}
-
-function updateOrAddStep( step ) {
-	if ( find( signupProgress, { stepName: step.stepName } ) ) {
-		updateStep( step );
-	} else {
-		addStep( step );
-	}
-}
-
-function setStepInvalid( step, errors ) {
-	updateOrAddStep(
-		assign( {}, step, {
-			status: 'invalid',
-			errors: errors,
-		} )
-	);
-}
-
-function saveStep( step ) {
-	if ( find( signupProgress, { stepName: step.stepName } ) ) {
-		updateStep( step );
-	} else {
-		addStep( assign( {}, step, { status: 'in-progress' } ) );
-	}
-}
-
-function submitStep( step ) {
-	const stepHasApiRequestFunction =
-			steps[ step.stepName ] && steps[ step.stepName ].apiRequestFunction,
-		status = stepHasApiRequestFunction ? 'pending' : 'completed';
-
-	updateOrAddStep( assign( {}, step, { status } ) );
-}
-
-function processStep( step ) {
-	updateStep( assign( {}, step, { status: 'processing' } ) );
-}
-
-function completeStep( step ) {
-	updateStep( assign( {}, step, { status: 'completed' } ) );
-}
-
 function addTimestamp( step ) {
-	return assign( {}, step, { lastUpdated: Date.now() } );
-}
-
-function loadProgressFromCache() {
-	const cachedSignupProgress = store.get( STORAGE_KEY );
-
-	if ( ! isEmpty( cachedSignupProgress ) ) {
-		signupProgress = cachedSignupProgress;
-	}
-
-	handleChange();
-}
-
-function omitUserData( progress ) {
-	return map( progress, step => {
-		return omit( step, 'userData' );
-	} );
-}
-
-function handleChange() {
-	SignupProgressStore.emit( 'change' );
-
-	store.set( STORAGE_KEY, omitUserData( signupProgress ) );
+	return { ...step, lastUpdated: Date.now() };
 }
 
 function addStorableDependencies( step, action ) {
@@ -151,43 +98,44 @@ function addStorableDependencies( step, action ) {
 	return { ...step, providedDependencies };
 }
 
-function removeUnneededStep( flowName ) {
-	const flowSteps = flows.getFlow( flowName ).steps;
-	signupProgress = filter( signupProgress, ( { stepName } ) => flowSteps.indexOf( stepName ) > -1 );
-	handleChange();
-}
-
+/**
+ * Compatibility layer
+ */
 SignupProgressStore.dispatchToken = Dispatcher.register( function( payload ) {
-	const action = payload.action;
+	const { action } = payload;
 	const step = addTimestamp( action.data );
 
 	Dispatcher.waitFor( [ SignupDependencyStore.dispatchToken ] );
 
 	if ( ! isEmpty( action.errors ) ) {
-		return setStepInvalid( step, action.errors );
+		SignupProgressStore.reduxStore.dispatch( invalidateStep( step, action.errors ) );
+		return;
 	}
 
+	debug( `Handling ${ action.type }` );
 	switch ( action.type ) {
-		case 'FETCH_CACHED_SIGNUP':
-			loadProgressFromCache();
-			break;
 		case 'SAVE_SIGNUP_STEP':
-			saveStep( addStorableDependencies( step, action ) );
+			SignupProgressStore.reduxStore.dispatch(
+				saveStep( addStorableDependencies( step, action ) )
+			);
 			break;
 		case 'SUBMIT_SIGNUP_STEP':
-			debug( 'submit step' );
-			submitStep( addStorableDependencies( step, action ) );
+			SignupProgressStore.reduxStore.dispatch(
+				submitStep( addStorableDependencies( step, action ) )
+			);
 			break;
 		case 'PROCESS_SIGNUP_STEP':
-			processStep( addStorableDependencies( step, action ) );
+			SignupProgressStore.reduxStore.dispatch(
+				processStep( addStorableDependencies( step, action ) )
+			);
 			break;
 		case 'PROCESSED_SIGNUP_STEP':
-			debug( 'complete step' );
-			completeStep( addStorableDependencies( step, action ) );
+			SignupProgressStore.reduxStore.dispatch(
+				completeStep( addStorableDependencies( step, action ) )
+			);
 			break;
 		case 'CHANGE_SIGNUP_FLOW':
-			debug( 'change flow' );
-			removeUnneededStep( action.flowName );
+			SignupProgressStore.reduxStore.dispatch( removeUnneededSteps( action.flowName ) );
 			break;
 	}
 } );

--- a/client/lib/signup/test/dependency-store.js
+++ b/client/lib/signup/test/dependency-store.js
@@ -27,6 +27,7 @@ describe( 'dependency-store', () => {
 
 		const store = createStore( reducer );
 		SignupDependencyStore.setReduxStore( store );
+		SignupProgressStore.setReduxStore( store );
 	} );
 
 	afterEach( () => {

--- a/client/lib/signup/test/mocks/signup/config/flows-pure.js
+++ b/client/lib/signup/test/mocks/signup/config/flows-pure.js
@@ -1,0 +1,33 @@
+/** @format */
+
+const flows = {
+	simple_flow: {
+		steps: [ 'stepA', 'stepB' ],
+		destination: '/',
+	},
+
+	flow_with_async: {
+		steps: [ 'userCreation', 'asyncStep' ],
+	},
+
+	flow_with_dependencies: {
+		steps: [ 'siteCreation', 'userCreation' ],
+		destination: function( dependencies ) {
+			return '/checkout/' + dependencies.siteSlug;
+		},
+	},
+
+	invalid_flow_with_dependencies: {
+		steps: [ 'siteCreation', 'userCreationWithoutToken' ],
+	},
+
+	flowWithDelay: {
+		steps: [ 'delayedStep', 'stepA' ],
+	},
+
+	flowWithProvidedDependencies: {
+		steps: [ 'stepRequiringSiteSlug' ],
+		providesDependenciesInQuery: [ 'siteSlug' ],
+	},
+};
+export default flows;

--- a/client/lib/signup/test/mocks/signup/config/flows.js
+++ b/client/lib/signup/test/mocks/signup/config/flows.js
@@ -1,34 +1,9 @@
 /** @format */
-const flows = {
-	simple_flow: {
-		steps: [ 'stepA', 'stepB' ],
-		destination: '/',
-	},
 
-	flow_with_async: {
-		steps: [ 'userCreation', 'asyncStep' ],
-	},
-
-	flow_with_dependencies: {
-		steps: [ 'siteCreation', 'userCreation' ],
-		destination: function( dependencies ) {
-			return '/checkout/' + dependencies.siteSlug;
-		},
-	},
-
-	invalid_flow_with_dependencies: {
-		steps: [ 'siteCreation', 'userCreationWithoutToken' ],
-	},
-
-	flowWithDelay: {
-		steps: [ 'delayedStep', 'stepA' ],
-	},
-
-	flowWithProvidedDependencies: {
-		steps: [ 'stepRequiringSiteSlug' ],
-		providesDependenciesInQuery: [ 'siteSlug' ],
-	},
-};
+/**
+ * Internal dependencies
+ */
+import flows from './flows-pure';
 
 export default {
 	defaultFlowName: 'simple_flow',

--- a/client/lib/signup/test/progress-store.js
+++ b/client/lib/signup/test/progress-store.js
@@ -6,32 +6,34 @@
 /**
  * External dependencies
  */
-import assert from 'assert'; // eslint-disable-line import/no-nodejs-modules
-import { defer, find, last, omit } from 'lodash';
+import { first, defer, find, last, omit } from 'lodash';
 import sinon from 'sinon';
+import { createStore } from 'redux';
 
 /**
  * Internal dependencies
  */
 import Dispatcher from 'dispatcher';
-import flows from 'signup/config/flows';
+import { reducer } from 'state';
+import SignupActions from '../actions';
+import SignupProgressStore from '../progress-store';
 
 jest.mock( 'lib/user', () => () => {} );
 jest.mock( 'signup/config/steps-pure', () => require( './mocks/signup/config/steps' ) );
-jest.mock( 'signup/config/flows', () => ( {
-	getFlow: jest.fn(),
-} ) );
+jest.mock( 'signup/config/flows-pure', () => require( './mocks/signup/config/flows-pure' ) );
 
 describe( 'progress-store', () => {
-	let SignupProgressStore, SignupActions;
-
 	beforeAll( () => {
-		SignupProgressStore = require( '../progress-store' );
-		SignupActions = require( '../actions' );
+		const store = createStore( reducer );
+		SignupProgressStore.setReduxStore( store );
+	} );
+
+	afterEach( () => {
+		SignupProgressStore.reset();
 	} );
 
 	test( 'should return an empty at first', () => {
-		assert.equal( SignupProgressStore.get().length, 0 );
+		expect( SignupProgressStore.get() ).toHaveLength( 0 );
 	} );
 
 	test( 'should store a new step', () => {
@@ -40,8 +42,8 @@ describe( 'progress-store', () => {
 			formData: { url: 'my-site.wordpress.com' },
 		} );
 
-		assert.equal( SignupProgressStore.get().length, 1 );
-		assert.equal( SignupProgressStore.get()[ 0 ].stepName, 'site-selection' );
+		expect( SignupProgressStore.get() ).toHaveLength( 1 );
+		expect( first( SignupProgressStore.get() ).stepName ).toEqual( 'site-selection' );
 	} );
 
 	describe( 'timestamps', () => {
@@ -63,43 +65,39 @@ describe( 'progress-store', () => {
 				},
 			} );
 
-			assert.equal( SignupProgressStore.get()[ 0 ].lastUpdated, 12345 );
+			expect( first( SignupProgressStore.get() ).lastUpdated ).toEqual( 12345 );
 		} );
 	} );
 
 	test( 'should not store the same step twice', () => {
+		SignupActions.submitSignupStep( {
+			stepName: 'site-selection',
+			formData: { url: 'my-site.wordpress.com' },
+		} );
+
 		SignupActions.submitSignupStep( { stepName: 'site-selection' } );
 
-		assert.equal( SignupProgressStore.get().length, 1 );
-		assert.deepEqual( omit( SignupProgressStore.get()[ 0 ], 'lastUpdated' ), {
+		expect( SignupProgressStore.get() ).toHaveLength( 1 );
+		expect( omit( first( SignupProgressStore.get() ), 'lastUpdated' ) ).toEqual( {
 			stepName: 'site-selection',
 			formData: { url: 'my-site.wordpress.com' },
 			status: 'completed',
 		} );
 	} );
 
-	test( 'should not be possible to mutate', () => {
-		assert.equal( SignupProgressStore.get().length, 1 );
-
-		// attempt to mutate
-		SignupProgressStore.get().pop();
-
-		assert.equal( SignupProgressStore.get().length, 1 );
-	} );
-
 	test( 'should store multiple steps in order', () => {
+		SignupActions.submitSignupStep( { stepName: 'site-selection' } );
 		SignupActions.submitSignupStep( { stepName: 'theme-selection' } );
 
-		assert.equal( SignupProgressStore.get().length, 2 );
-		assert.equal( SignupProgressStore.get()[ 0 ].stepName, 'site-selection' );
-		assert.equal( SignupProgressStore.get()[ 1 ].stepName, 'theme-selection' );
+		expect( SignupProgressStore.get() ).toHaveLength( 2 );
+		expect( first( SignupProgressStore.get() ).stepName ).toEqual( 'site-selection' );
+		expect( SignupProgressStore.get()[ 1 ].stepName ).toEqual( 'theme-selection' );
 	} );
 
 	test( 'should mark submitted steps without an API request method as completed', () => {
 		SignupActions.submitSignupStep( { stepName: 'step-without-api' } );
 
-		assert.equal(
-			find( SignupProgressStore.get(), { stepName: 'step-without-api' } ).status,
+		expect( find( SignupProgressStore.get(), { stepName: 'step-without-api' } ).status ).toEqual(
 			'completed'
 		);
 	} );
@@ -109,40 +107,109 @@ describe( 'progress-store', () => {
 			stepName: 'asyncStep',
 		} );
 
-		assert.equal( find( SignupProgressStore.get(), { stepName: 'asyncStep' } ).status, 'pending' );
+		expect( find( SignupProgressStore.get(), { stepName: 'asyncStep' } ).status ).toEqual(
+			'pending'
+		);
 	} );
 
-	test( 'should mark only new saved steps as in-progress', () => {
+	test( 'should mark only new saved steps as in-progress', done => {
+		SignupActions.submitSignupStep( { stepName: 'site-selection' } );
 		SignupActions.saveSignupStep( { stepName: 'site-selection' } );
-		defer( () => {
-			assert.notEqual( SignupProgressStore.get()[ 0 ].status, 'in-progress' );
-		} );
-
 		SignupActions.saveSignupStep( { stepName: 'last-step' } );
+
 		defer( () => {
-			assert.equal( last( SignupProgressStore.get() ).status, 'in-progress' );
+			expect( first( SignupProgressStore.get() ).status ).not.toEqual( 'in-progress' );
+			expect( last( SignupProgressStore.get() ).status ).toEqual( 'in-progress' );
+			done();
 		} );
 	} );
 
 	test( 'should set the status of a signup step', () => {
 		SignupActions.submitSignupStep( { stepName: 'site-selection' } );
-		assert.equal( SignupProgressStore.get()[ 0 ].status, 'completed' );
+		expect( first( SignupProgressStore.get() ).status ).toEqual( 'completed' );
 
 		SignupActions.processedSignupStep( { stepName: 'site-selection' } );
-		assert.equal( SignupProgressStore.get()[ 0 ].status, 'completed' );
+		expect( first( SignupProgressStore.get() ).status ).toEqual( 'completed' );
+	} );
+
+	describe( 'set', () => {
+		beforeEach( () => {
+			SignupProgressStore.reset();
+		} );
+		test( 'should overwrite existing progress data', () => {
+			SignupProgressStore.set( [ { stepName: 'fake name' } ] );
+			expect( SignupProgressStore.get() ).toEqual( [ { stepName: 'fake name' } ] );
+
+			SignupProgressStore.set( [ { stepName: 'fake name' }, { stepName: 'fake name 2' } ] );
+			expect( SignupProgressStore.get() ).toEqual( [
+				{ stepName: 'fake name' },
+				{ stepName: 'fake name 2' },
+			] );
+		} );
+	} );
+
+	describe( 'subscriptions', () => {
+		beforeEach( () => {
+			SignupProgressStore.reset();
+		} );
+
+		test( 'should handle adding and removing subscriptions', () => {
+			const callback = () => {};
+			SignupProgressStore.subscribe( callback );
+			expect( SignupProgressStore.subscribers.size ).toEqual( 1 );
+			expect( SignupProgressStore.subscribers.get( callback ) ).toBeInstanceOf( Function );
+
+			SignupProgressStore.unsubscribe( callback );
+			expect( SignupProgressStore.subscribers.size ).toEqual( 0 );
+			expect( SignupProgressStore.subscribers.get( callback ) ).not.toBeDefined();
+		} );
+
+		test( 'should not have any subscribers by default', () => {
+			expect( SignupProgressStore.get() ).toHaveLength( 0 );
+			expect( SignupProgressStore.subscribers.size ).toEqual( 0 );
+		} );
+
+		test( 'should not trigger any subscribers without a value change', () => {
+			const callback = jest.fn();
+			SignupProgressStore.subscribe( callback );
+			expect( callback ).not.toHaveBeenCalled();
+			expect( SignupProgressStore.subscribers.size ).toEqual( 1 );
+		} );
+
+		test( 'should notify subscribers only if the values change', () => {
+			const stepName = 'site-selection';
+
+			// Make a subscription
+			const callback = jest.fn();
+			SignupProgressStore.subscribe( callback );
+
+			// Trigger a change, which should call the first callback
+			SignupProgressStore.set( [ { stepName } ] );
+			expect( callback ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'should not notify subscribers if the value has remained the same', () => {
+			const stepName = 'some-fake-step-name';
+
+			SignupProgressStore.set( [ { stepName } ] );
+
+			const uncalledCallback = jest.fn();
+			SignupProgressStore.subscribe( uncalledCallback );
+			expect( uncalledCallback ).not.toHaveBeenCalled();
+
+			SignupProgressStore.set( [ { stepName } ] );
+			expect( uncalledCallback ).not.toHaveBeenCalled();
+		} );
 	} );
 
 	test( 'should remove unneeded steps when flow changes', () => {
-		assert.ok( SignupProgressStore.get().length > 1 );
+		SignupProgressStore.set( [ { stepName: 'stepA' }, { stepName: 'stepC' } ] );
+		expect( SignupProgressStore.get() ).toHaveLength( 2 );
 
-		flows.getFlow.mockReturnValueOnce( { steps: [ 'site-selection' ] } );
-		SignupActions.changeSignupFlow( 'new-flow' );
+		SignupActions.changeSignupFlow( 'simple_flow' );
+		expect( SignupProgressStore.get() ).toHaveLength( 1 );
 
-		assert.equal( SignupProgressStore.get().length, 1 );
-
-		flows.getFlow.mockReturnValueOnce( { steps: [ 'no-step-matches' ] } );
-		SignupActions.changeSignupFlow( 'another-new-flow' );
-
-		assert.equal( SignupProgressStore.get().length, 0 );
+		SignupActions.changeSignupFlow( 'invalid_flow_with_dependencies' );
+		expect( SignupProgressStore.get() ).toHaveLength( 0 );
 	} );
 } );

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -78,13 +78,14 @@ export default {
 		const flowName = getFlowName( context.params );
 		const localeFromParams = getLocale( context.params );
 		const localeFromStore = store.get( 'signup-locale' );
+		SignupProgressStore.setReduxStore( context.store );
 
 		// if flow can be resumed, use saved locale
 		if (
 			! user.get() &&
 			! localeFromParams &&
 			localeFromStore &&
-			canResumeFlow( flowName, SignupProgressStore.getFromCache() )
+			canResumeFlow( flowName, SignupProgressStore.get() )
 		) {
 			window.location =
 				getStepUrl(

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -20,7 +20,6 @@ import {
 	isEqual,
 	last,
 	pick,
-	some,
 	startsWith,
 } from 'lodash';
 import { translate } from 'i18n-calypso';
@@ -104,7 +103,6 @@ class Signup extends React.Component {
 			hasCartItems: false,
 			plans: false,
 			previousFlowName: null,
-			resumedAfterLogin: false,
 		};
 	}
 
@@ -379,17 +377,10 @@ class Signup extends React.Component {
 		flows.resumingFlow = true;
 
 		const firstUnsubmittedStep = this.firstUnsubmittedStepName(),
-			hasResumedAfterLogin = some( this.props.progress, { resumeAfterLogin: true } ),
 			stepSectionName = firstUnsubmittedStep.stepSectionName;
 
 		// set `resumingStep` so we don't render/animate anything until we have mounted this step
 		this.setState( { firstUnsubmittedStep } );
-
-		// Reset loadingScreenStartTime only once when the flow resumed after login
-		// in order to prevent the flow from getting stuck in the processing screen.
-		if ( hasResumedAfterLogin && ! this.state.resumedAfterLogin ) {
-			this.setState( { resumedAfterLogin: true, loadingScreenStartTime: undefined } );
-		}
 
 		return page.redirect(
 			getStepUrl( this.props.flowName, firstUnsubmittedStep, stepSectionName, this.props.locale )

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -13,13 +13,12 @@ import {
 	assign,
 	defer,
 	delay,
-	filter,
 	find,
 	get,
 	indexOf,
 	isEmpty,
+	isEqual,
 	last,
-	matchesProperty,
 	pick,
 	some,
 	startsWith,
@@ -43,9 +42,7 @@ import { recordSignupStart, recordSignupCompletion } from 'lib/analytics/ad-trac
 import * as oauthToken from 'lib/oauth-token';
 import { isDomainRegistration, isDomainTransfer, isDomainMapping } from 'lib/products-values';
 import SignupActions from 'lib/signup/actions';
-import SignupDependencyStore from 'lib/signup/dependency-store';
 import SignupFlowController from 'lib/signup/flow-controller';
-import SignupProgressStore from 'lib/signup/progress-store';
 import { disableCart } from 'lib/upgrades/actions';
 
 // State actions and selectors
@@ -54,6 +51,7 @@ import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import { currentUserHasFlag, getCurrentUser, isUserLoggedIn } from 'state/current-user/selectors';
 import { affiliateReferral } from 'state/refer/actions';
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
+import { getSignupProgress } from 'state/signup/progress/selectors';
 import { setSurvey } from 'state/signup/steps/survey/actions';
 
 // Current directory dependencies
@@ -61,7 +59,14 @@ import steps from './config/steps';
 import flows from './config/flows';
 import stepComponents from './config/step-components';
 import FlowProgressIndicator from './flow-progress-indicator';
-import { getDestination, canResumeFlow, getStepUrl } from './utils';
+import {
+	canResumeFlow,
+	getCompletedSteps,
+	getDestination,
+	getFilteredSteps,
+	getFirstInvalidStep,
+	getStepUrl,
+} from './utils';
 import WpcomLoginForm from './wpcom-login-form';
 
 /**
@@ -88,11 +93,10 @@ class Signup extends React.Component {
 
 	constructor( props, context ) {
 		super( props, context );
-		SignupDependencyStore.setReduxStore( context.store );
 
 		this.state = {
+			controllerHasReset: false,
 			login: false,
-			progress: SignupProgressStore.get(),
 			dependencies: props.signupDependencies,
 			loadingScreenStartTime: undefined,
 			resumingStep: undefined,
@@ -104,7 +108,7 @@ class Signup extends React.Component {
 		};
 	}
 
-	componentWillMount() {
+	UNSAFE_componentWillMount() {
 		// Signup updates the cart through `SignupCart`. To prevent
 		// synchronization issues and unnecessary polling, the cart is disabled
 		// here.
@@ -128,16 +132,15 @@ class Signup extends React.Component {
 			onComplete: this.handleSignupFlowControllerCompletion,
 		} );
 
-		this.loadProgressFromStore();
+		this.updateLoadingScreenStartTime();
 
-		if ( canResumeFlow( this.props.flowName, SignupProgressStore.get() ) ) {
-			// we loaded progress from local storage, attempt to resume progress
+		if ( canResumeFlow( this.props.flowName, this.props.progress ) ) {
+			// Resume progress if possible
 			return this.resumeProgress();
 		}
 
 		if ( this.getPositionInFlow() !== 0 ) {
-			// no progress was resumed and we're on a non-zero step
-			// redirect to the beginning of the flow
+			// Flow is not resumable; redirect to the beginning of the flow
 			return page.redirect(
 				getStepUrl(
 					this.props.flowName,
@@ -152,7 +155,7 @@ class Signup extends React.Component {
 		this.recordStep();
 	}
 
-	componentWillReceiveProps( { signupDependencies, stepName, flowName } ) {
+	UNSAFE_componentWillReceiveProps( { signupDependencies, stepName, flowName, progress } ) {
 		if ( this.props.stepName !== stepName ) {
 			this.recordStep( stepName );
 		}
@@ -169,18 +172,16 @@ class Signup extends React.Component {
 			this.signupFlowController.changeFlowName( flowName );
 		}
 
+		if ( ! this.state.controllerHasReset && ! isEqual( this.props.progress, progress ) ) {
+			this.updateLoadingScreenStartTime( progress );
+		}
+
 		this.checkForCartItems( signupDependencies );
 	}
 
 	componentDidMount() {
 		debug( 'Signup component mounted' );
 		this.recordSignupStart();
-		SignupProgressStore.on( 'change', this.loadProgressFromStore );
-	}
-
-	componentWillUnmount() {
-		debug( 'Signup component unmounted' );
-		SignupProgressStore.off( 'change', this.loadProgressFromStore );
 	}
 
 	handleSignupFlowControllerCompletion = ( dependencies, destination ) => {
@@ -225,24 +226,20 @@ class Signup extends React.Component {
 		}
 	}
 
-	loadProgressFromStore = () => {
-		const newProgress = SignupProgressStore.get(),
-			invalidSteps = some( newProgress, matchesProperty( 'status', 'invalid' ) ),
-			// skipLoadingScreen = some( newProgress, matchesProperty( '', '' ) ),
-			waitingForServer = ! invalidSteps && this.isEveryStepSubmitted(),
+	updateLoadingScreenStartTime = ( progress = this.props.progress ) => {
+		const hasInvalidSteps = !! getFirstInvalidStep( this.props.flowName, progress ),
+			waitingForServer = ! hasInvalidSteps && this.isEveryStepSubmitted( progress ),
 			startLoadingScreen = waitingForServer && ! this.state.loadingScreenStartTime;
 
-		this.setState( { progress: newProgress } );
-
-		if ( this.isEveryStepSubmitted() ) {
-			this.goToFirstInvalidStep();
+		if ( this.isEveryStepSubmitted( progress ) ) {
+			this.goToFirstInvalidStep( progress );
 		}
 
 		if ( startLoadingScreen ) {
 			this.setState( { loadingScreenStartTime: Date.now() } );
 		}
 
-		if ( invalidSteps ) {
+		if ( hasInvalidSteps ) {
 			this.setState( { loadingScreenStartTime: undefined } );
 		}
 	};
@@ -291,12 +288,11 @@ class Signup extends React.Component {
 	};
 
 	handleFlowComplete = ( dependencies, destination ) => {
-		debug( 'The flow is completed. Logging you in...' );
+		debug( 'The flow is completed. Destination: %s', destination );
 
 		analytics.tracks.recordEvent( 'calypso_signup_complete', { flow: this.props.flowName } );
 		recordSignupCompletion();
 
-		this.signupFlowController.reset();
 		if (
 			dependencies.cartItem ||
 			dependencies.domainItem ||
@@ -317,6 +313,10 @@ class Signup extends React.Component {
 			destination = event.redirectTo;
 		}
 
+		debug( `Logging you in to "${ destination }"` );
+
+		this.setState( { controllerHasReset: true } );
+
 		if ( userIsLoggedIn ) {
 			// don't use page.js for external URLs (eg redirect to new site after signup)
 			if ( /^https?:\/\//.test( destination ) ) {
@@ -324,20 +324,23 @@ class Signup extends React.Component {
 			}
 
 			// deferred in case the user is logged in and the redirect triggers a dispatch
-			defer(
-				function() {
-					page( destination );
-				}.bind( this )
-			);
+			defer( () => {
+				debug( `Redirecting you to "${ destination }"` );
+				this.signupFlowController.reset();
+				window.location.href = destination;
+			} );
 		}
 
 		if ( ! userIsLoggedIn && ( config.isEnabled( 'oauth' ) || dependencies.oauth2_client_id ) ) {
+			debug( `Handling oauth login` );
 			oauthToken.setToken( dependencies.bearer_token );
+			this.signupFlowController.reset();
 			window.location.href = destination;
 			return;
 		}
 
 		if ( ! userIsLoggedIn && ! config.isEnabled( 'oauth' ) ) {
+			debug( `Handling regular login` );
 			this.setState( {
 				bearerToken: dependencies.bearer_token,
 				username: dependencies.username,
@@ -363,10 +366,7 @@ class Signup extends React.Component {
 
 	firstUnsubmittedStepName = () => {
 		const currentSteps = flows.getFlow( this.props.flowName ).steps,
-			signupProgress = filter(
-				SignupProgressStore.get(),
-				step => -1 !== currentSteps.indexOf( step.stepName )
-			),
+			signupProgress = getFilteredSteps( this.props.flowName, this.props.progress ),
 			nextStepName = currentSteps[ signupProgress.length ],
 			firstInProgressStep = find( signupProgress, { status: 'in-progress' } ) || {},
 			firstInProgressStepName = firstInProgressStep.stepName;
@@ -379,7 +379,7 @@ class Signup extends React.Component {
 		flows.resumingFlow = true;
 
 		const firstUnsubmittedStep = this.firstUnsubmittedStepName(),
-			hasResumedAfterLogin = some( SignupProgressStore.get(), { resumeAfterLogin: true } ),
+			hasResumedAfterLogin = some( this.props.progress, { resumeAfterLogin: true } ),
 			stepSectionName = firstUnsubmittedStep.stepSectionName;
 
 		// set `resumingStep` so we don't render/animate anything until we have mounted this step
@@ -433,7 +433,7 @@ class Signup extends React.Component {
 		const flowSteps = flows.getFlow( nextFlowName, this.props.stepName ).steps,
 			currentStepIndex = indexOf( flowSteps, this.props.stepName ),
 			nextStepName = flowSteps[ currentStepIndex + 1 ],
-			nextProgressItem = this.state.progress[ currentStepIndex + 1 ],
+			nextProgressItem = this.props.progress[ currentStepIndex + 1 ],
 			nextStepSection = ( nextProgressItem && nextProgressItem.stepSectionName ) || '';
 
 		if ( nextFlowName !== this.props.flowName ) {
@@ -444,8 +444,8 @@ class Signup extends React.Component {
 		this.goToStep( nextStepName, nextStepSection, nextFlowName );
 	};
 
-	goToFirstInvalidStep = () => {
-		const firstInvalidStep = find( SignupProgressStore.get(), { status: 'invalid' } );
+	goToFirstInvalidStep = ( progress = this.props.progress ) => {
+		const firstInvalidStep = getFirstInvalidStep( this.props.flowName, progress );
 
 		if ( firstInvalidStep ) {
 			analytics.tracks.recordEvent( 'calypso_signup_goto_invalid_step', {
@@ -455,21 +455,19 @@ class Signup extends React.Component {
 
 			if ( firstInvalidStep.stepName === this.props.stepName ) {
 				// No need to redirect
+				debug( `Already navigated to the first invalid step: ${ firstInvalidStep.stepName }` );
 				return;
 			}
 
+			debug( `Navigating to the first invalid step: ${ firstInvalidStep.stepName }` );
 			page( getStepUrl( this.props.flowName, firstInvalidStep.stepName, this.props.locale ) );
 		}
 	};
 
-	isEveryStepSubmitted = () => {
+	isEveryStepSubmitted = ( progress = this.props.progress ) => {
 		const flowSteps = flows.getFlow( this.props.flowName ).steps;
-		const signupProgress = filter(
-			SignupProgressStore.get(),
-			step => -1 !== flowSteps.indexOf( step.stepName ) && 'in-progress' !== step.status
-		);
-
-		return flowSteps.length === signupProgress.length;
+		const completedSteps = getCompletedSteps( this.props.flowName, progress );
+		return flowSteps.length === completedSteps.length;
 	};
 
 	getPositionInFlow() {
@@ -478,7 +476,7 @@ class Signup extends React.Component {
 
 	renderCurrentStep() {
 		const domainItem = get( this.props, 'signupDependencies.domainItem', false );
-		const currentStepProgress = find( this.state.progress, { stepName: this.props.stepName } ),
+		const currentStepProgress = find( this.props.progress, { stepName: this.props.stepName } ),
 			CurrentComponent = stepComponents[ this.props.stepName ],
 			propsFromConfig = assign( {}, this.props, steps[ this.props.stepName ].props ),
 			stepKey = this.state.loadingScreenStartTime ? 'processing' : this.props.stepName,
@@ -500,7 +498,7 @@ class Signup extends React.Component {
 				{ this.state.loadingScreenStartTime ? (
 					<SignupProcessingScreen
 						hasCartItems={ this.state.hasCartItems }
-						steps={ this.state.progress }
+						steps={ this.props.progress }
 						loginHandler={ this.state.loginHandler }
 						signupDependencies={ this.props.signupDependencies }
 						flowName={ this.props.flowName }
@@ -518,7 +516,7 @@ class Signup extends React.Component {
 						goToStep={ this.goToStep }
 						previousFlowName={ this.state.previousFlowName }
 						flowName={ this.props.flowName }
-						signupProgress={ this.state.progress }
+						signupProgress={ this.props.progress }
 						signupDependencies={ this.props.signupDependencies }
 						stepSectionName={ this.props.stepSectionName }
 						positionInFlow={ this.getPositionInFlow() }
@@ -533,7 +531,7 @@ class Signup extends React.Component {
 	render() {
 		if (
 			! this.props.stepName ||
-			( this.getPositionInFlow() > 0 && this.state.progress.length === 0 ) ||
+			( this.getPositionInFlow() > 0 && this.props.progress.length === 0 ) ||
 			this.state.resumingStep
 		) {
 			return null;
@@ -584,6 +582,7 @@ export default connect(
 		domainsWithPlansOnly: getCurrentUser( state )
 			? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )
 			: true,
+		progress: getSignupProgress( state ),
 		signupDependencies: getSignupDependencyStore( state ),
 		isLoggedIn: isUserLoggedIn( state ),
 	} ),

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -2,7 +2,7 @@
 /**
  * Exernal dependencies
  */
-import { filter, find, indexOf, isEmpty, merge, pick } from 'lodash';
+import { filter, find, includes, indexOf, isEmpty, merge, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -189,12 +189,21 @@ export function getSiteTypeForSiteGoals( siteGoals, flow ) {
 	return 'blog';
 }
 
+export function getFilteredSteps( flowName, progress ) {
+	const flow = flows.getFlow( flowName );
+	return filter( progress, step => includes( flow.steps, step.stepName ) );
+}
+
+export function getFirstInvalidStep( flowName, progress ) {
+	return find( getFilteredSteps( flowName, progress ), { status: 'invalid' } );
+}
+
+export function getCompletedSteps( flowName, progress ) {
+	return filter( getFilteredSteps( flowName, progress ), step => 'in-progress' !== step.status );
+}
+
 export function canResumeFlow( flowName, progress ) {
 	const flow = flows.getFlow( flowName );
-	const flowStepsInProgressStore = filter(
-		progress,
-		step => -1 !== flow.steps.indexOf( step.stepName )
-	);
-
+	const flowStepsInProgressStore = getCompletedSteps( flowName, progress );
 	return flowStepsInProgressStore.length > 0 && ! flow.disallowResume;
 }


### PR DESCRIPTION
Part of step 2 for #6709; builds on #25645. See p9xfpQ-8z-p2 for further discussion.

This change reworks the SignupProgressStore to use Redux instead of Flux. The SignupProgressStore is responsible for tracking and persisting the user's progression through our various signup flows.

Previously, this store persisted the current user's signup progress into localStorage via the [store.js](https://www.npmjs.com/package/store). It now relies on Calypso's [Redux state persistence mechanism](https://github.com/Automattic/wp-calypso/blob/master/client/state/initial-state.js#L166) which relies on [localforage](https://www.npmjs.com/package/localforage).

Existing signup flow behavior should remain identical as before.

Some notes: 

1. The signup flow is designed to cross the logged-out/logged-in boundary. Since the store persisted in logged-out state isn't loaded in the logged-in state, I'm assuming that the progress store is only useful during the signup process to the logged-out user. Once a user completes signup by completing the `user` step, we discard the logged-out state.

2. Upon construction of the signup flow controller, we invoke a function to discard steps not associated with the current flow. This ensures that we clear out stale/invalid steps persisted by the progress state in the Redux store.

# Testing instructions
1. Spin up this branch either on the [live branch](https://calypso.live/?branch=reduxify/signup-progress-store-part-2) or locally.
2. Go through the entirety of a signup flow such as [`/start`](http://calypso.localhost:3000/start/domains). 
3. Verify that you are correctly redirected following the signup flow. Depending on your A/B test configuration, this is either your new site or the new user checklist page.