### PR TITLE
ConversationCaterpillar: use the new GravatarCaterpillar component

### DIFF
--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -82,7 +82,7 @@ class ConversationCaterpillarComponent extends React.Component {
 			: size( allExpandableComments );
 
 		// Only display each author once
-		const uniqueAuthors = uniqBy( map( expandableComments, 'author' ), 'email' );
+		const uniqueAuthors = uniqBy( map( expandableComments, 'author' ), 'avatar_URL' );
 		const uniqueAuthorsCount = size( uniqueAuthors );
 		const lastAuthorName = get( last( uniqueAuthors ), 'name' );
 

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -11,12 +11,12 @@ import { localize } from 'i18n-calypso';
 /***
  * Internal dependencies
  */
-import Gravatar from 'components/gravatar';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { getPostCommentsTree, getDateSortedPostComments } from 'state/comments/selectors';
 import { expandComments } from 'state/comments/actions';
 import { POST_COMMENT_DISPLAY_TYPES } from 'state/comments/constants';
 import { isAncestor } from 'blocks/comments/utils';
+import GravatarCaterpillar from 'components/gravatar-caterpillar';
 
 const MAX_GRAVATARS_TO_DISPLAY = 10;
 const NUMBER_TO_EXPAND = 10;
@@ -81,45 +81,18 @@ class ConversationCaterpillarComponent extends React.Component {
 			? numberUnfetchedComments + size( allExpandableComments )
 			: size( allExpandableComments );
 
-		// Only display authors with a gravatar, and only display each author once
+		// Only display each author once
 		const uniqueAuthors = uniqBy( map( expandableComments, 'author' ), 'email' );
-		const displayedAuthors = takeRight(
-			filter( uniqueAuthors, 'avatar_URL' ),
-			MAX_GRAVATARS_TO_DISPLAY
-		);
 		const uniqueAuthorsCount = size( uniqueAuthors );
-		const displayedAuthorsCount = size( displayedAuthors );
-		const lastAuthorName = get( last( displayedAuthors ), 'name' );
-		const gravatarSmallScreenThreshold = MAX_GRAVATARS_TO_DISPLAY / 2;
+		const lastAuthorName = get( last( uniqueAuthors ), 'name' );
 
 		return (
 			<div className="conversation-caterpillar">
-				<div
-					className="conversation-caterpillar__gravatars"
+				<GravatarCaterpillar
+					users={ uniqueAuthors }
 					onClick={ this.handleTickle }
-					aria-hidden="true"
-				>
-					{ map( displayedAuthors, ( author, index ) => {
-						let gravClasses = 'conversation-caterpillar__gravatar';
-						// If we have more than 5 gravs,
-						// add a additional class so we can hide some on small screens
-						if (
-							displayedAuthorsCount > gravatarSmallScreenThreshold &&
-							index < displayedAuthorsCount - gravatarSmallScreenThreshold
-						) {
-							gravClasses += ' is-hidden-on-small-screens';
-						}
-
-						return (
-							<Gravatar
-								className={ gravClasses }
-								key={ author.email }
-								user={ author }
-								size={ 32 }
-							/>
-						);
-					} ) }
-				</div>
+					maxGravatarsToDisplay={ MAX_GRAVATARS_TO_DISPLAY }
+				/>
 				<button
 					className="conversation-caterpillar__count"
 					onClick={ this.handleTickle }

--- a/client/blocks/conversation-caterpillar/style.scss
+++ b/client/blocks/conversation-caterpillar/style.scss
@@ -2,7 +2,6 @@
 	display: flex;
 }
 
-.conversation-caterpillar__gravatars,
 .conversation-caterpillar__count {
 	display: flex;
 	flex-shrink: 0;
@@ -34,27 +33,6 @@
 	@include breakpoint( "<660px" ) {
 		padding: 0;
 		text-align: left;
-	}
-}
-
-.conversation-caterpillar__gravatar {
-	cursor: pointer;
-	border: 2px solid $white;
-	height: 24px;
-	margin-left: -8px;
-	vertical-align: middle;
-	width: 24px;
-
-	&:first-child {
-		margin-left: -2px;
-	}
-
-	&.is-hidden-on-small-screens {
-		display: none;
-
-		@include breakpoint( ">660px" ) {
-   			display: inline;
-   		}
 	}
 }
 

--- a/client/components/gravatar-caterpillar/index.jsx
+++ b/client/components/gravatar-caterpillar/index.jsx
@@ -27,7 +27,7 @@ class GravatarCaterpillar extends React.Component {
 
 		// Only display authors with a gravatar, and only display each author once
 		const displayedUsers = takeRight(
-			filter( uniqBy( users, 'email' ), 'avatar_URL' ),
+			filter( uniqBy( users, 'avatar_URL' ), 'avatar_URL' ),
 			maxGravatarsToDisplay
 		);
 		const displayedUsersCount = size( displayedUsers );


### PR DESCRIPTION
We recently added a new GravatarCaterpillar component in https://github.com/Automattic/wp-calypso/pull/25879 which handles the avatar display in a "caterpillar":

<img width="291" alt="screen shot 2018-07-06 at 11 52 09" src="https://user-images.githubusercontent.com/17325/42353178-0ac949fa-8113-11e8-8d10-b1a9d206d49b.png">

This PR converts Reader Conversations to use the new component rather than assembling the avatars itself.

### To test

Visit http://calypso.localhost:3000/read/conversations and ensure that the caterpillar appears and functions as expected.