### PR TITLE
Settings: Push Jetpack plan and connection transfer to production

### DIFF
--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -16,7 +16,6 @@ import accept from 'lib/accept';
 import AuthorSelector from 'blocks/author-selector';
 import canCurrentUser from 'state/selectors/can-current-user';
 import Card from 'components/card';
-import config from 'config';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
@@ -143,7 +142,7 @@ class SiteOwnership extends Component {
 			return;
 		}
 
-		if ( ! config.isEnabled( 'jetpack/ownership-change' ) || ! isConnectionTransferSupported ) {
+		if ( ! isConnectionTransferSupported ) {
 			return this.renderCurrentUser();
 		}
 
@@ -227,7 +226,6 @@ class SiteOwnership extends Component {
 
 	renderCardContent() {
 		const { isPaidPlan, translate } = this.props;
-		const showPlanSection = config.isEnabled( 'jetpack/ownership-change' ) && isPaidPlan;
 
 		return (
 			<Card>
@@ -236,7 +234,7 @@ class SiteOwnership extends Component {
 					{ this.renderConnectionDetails() }
 				</FormFieldset>
 
-				{ showPlanSection && (
+				{ isPaidPlan && (
 					<Fragment>
 						<FormFieldset className="manage-connection__formfieldset has-divider is-top-only">
 							<FormLabel>{ translate( 'Plan purchaser' ) }</FormLabel>

--- a/config/development.json
+++ b/config/development.json
@@ -78,7 +78,6 @@
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,
 		"jetpack/google-analytics-for-stores-enhanced": true,
-		"jetpack/ownership-change": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,
 		"login/magic-login": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -45,7 +45,6 @@
 		"jetpack/api-cache": true,
 		"jetpack/connect/remote-install": true,
 		"jetpack/happychat": true,
-		"jetpack/ownership-change": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,
 		"login/native-login-links": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -51,7 +51,6 @@
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,
 		"jetpack/google-analytics-for-stores-enhanced": true,
-		"jetpack/ownership-change": true,
 		"jitms": true,
 		"login/magic-login": true,
 		"login/native-login-links": true,

--- a/config/test.json
+++ b/config/test.json
@@ -44,7 +44,6 @@
 		"jetpack/checklist": true,
 		"jetpack/connect/remote-install": true,
 		"jetpack/happychat": true,
-		"jetpack/ownership-change": true,
 		"jitms": true,
 		"login/native-login-links": true,
 		"login/wp-login": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -58,7 +58,6 @@
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,
 		"jetpack/google-analytics-for-stores-enhanced": true,
-		"jetpack/ownership-change": true,
 		"jitms": true,
 		"login/magic-login": true,
 		"login/native-login-links": true,


### PR DESCRIPTION
This PR pushes the Jetpack plan and connection transfer to production. It removes the `jetpack/ownership-change` feature flag usage from the site ownership logic and completely deletes it from the various environment configs.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/settings/manage-connection/:site and verify you see no errors and everything looks similar to what you see on staging or wpcalypso.
* Verify the `jetpack/ownership-change` feature flag isn't used anywhere anymore.