### PR TITLE
Components: Fix spacing for large dialog buttons on mobile

### DIFF
--- a/client/components/dialog/style.scss
+++ b/client/components/dialog/style.scss
@@ -91,6 +91,11 @@
 		padding-left: 24px;
 		padding-right: 24px;
 	}
+	
+	@include breakpoint( "<480px" ) {
+		display: flex;
+		flex-direction: column-reverse;
+	}
 
 	&:before {
 		content: "";
@@ -108,8 +113,6 @@
 .dialog__action-buttons .button {
 	margin-left: 10px;
 	min-width: 80px;
-	display: flex;
-	flex-direction: column-reverse;
 
 	.is-left-aligned {
 		margin-left: 0;

--- a/client/components/dialog/style.scss
+++ b/client/components/dialog/style.scss
@@ -108,6 +108,8 @@
 .dialog__action-buttons .button {
 	margin-left: 10px;
 	min-width: 80px;
+	display: flex;
+	flex-direction: column-reverse;
 
 	.is-left-aligned {
 		margin-left: 0;
@@ -115,8 +117,7 @@
 	}
 
 	@include breakpoint( "<480px" ) {
-		margin-top: 2px;
-		margin-bottom: 2px;
+		margin: 2px 0;
 	}
 }
 

--- a/client/components/dialog/style.scss
+++ b/client/components/dialog/style.scss
@@ -113,6 +113,11 @@
 		margin-left: 0;
 		margin-right: 10px;
 	}
+
+	@include breakpoint( "<480px" ) {
+		margin-top: 2px;
+		margin-bottom: 2px;
+	}
 }
 
 .dialog__action-buttons .is-left-aligned {


### PR DESCRIPTION
This PR fixes the spacing issues with large buttons on confirmation dialogs on mobile devices, as reported on: p1HpG7-5iF-p2 #comment-26659 by @brbrr

The fix is simple - we introduce some spacing above and below each of the buttons, make them full-width and swap them, as suggested by @joanrho in p1HpG7-5iF-p2 #comment-26731

Before:
![](https://cldup.com/C2jiuTngvb.jpg)

After:
![](https://cldup.com/J9ut7Y7GLq.jpg)

To test:
* Checkout this branch.
* Login to WP.com and make sure you have a connected Jetpack site where you're the plan purchaser.
* Go to http://calypso.localhost:3000/settings/manage-connection/:site, where `:site` is your Jetpack site.
* Select another connected admin user from the dropdown.
* Observe the buttons and verify they look well both on desktop and mobile.
* Since this affects all confirmation dialogs throughout Calypso, test some of them (you can find all instances by looking for `lib/accept` usage in the Calypso codebase).