### PR TITLE
Activity Log: update URL filters

### DIFF
--- a/client/state/activity-log/utils.js
+++ b/client/state/activity-log/utils.js
@@ -3,22 +3,60 @@
 export const filterStateToApiQuery = filter =>
 	Object.assign(
 		{},
-		{ number: 1000 },
-		filter.group && filter.group.includes && { group: filter.group.includes }
+		filter.action && { action: filter.action },
+		filter.after && { after: filter.after },
+		filter.before && { before: filter.before },
+		filter.by && { by: filter.by },
+		filter.dateRange && { date_range: filter.dateRange },
+		filter.group && filter.group.includes && { group: filter.group.includes },
+		filter.group && filter.group.excludes && { not_group: filter.group.excludes },
+		filter.name && { name: filter.name },
+		{ number: 1000 }
 	);
 
 export const filterStateToQuery = filter =>
 	Object.assign(
 		{},
-		filter.page > 1 && { page: filter.page },
-		filter.group && filter.group.includes && { group: filter.group.includes.join( ',' ) }
+		filter.action && { action: filter.action.join( ',' ) },
+		filter.after && { after: filter.after },
+		filter.before && { before: filter.before },
+		filter.by && { by: filter.by },
+		filter.dateRange && { date_range: filter.dateRange },
+		filter.group && filter.group.includes && { group: filter.group.includes.join( ',' ) },
+		filter.group && filter.group.excludes && { not_group: filter.group.excludes( ',' ) },
+		filter.name && { name: filter.name.join( ',' ) },
+		filter.page > 1 && { page: filter.page }
 	);
 
-export const queryToFilterState = query =>
-	Object.assign(
-		{},
-		query.page && query.page > 0 && { page: query.page },
-		query.group && {
-			group: Object.assign( {}, { includes: decodeURI( query.group ).split( ',' ) } ),
-		}
+export const queryToFilterState = query => {
+	const hasGroup = query.group || query.not_group;
+	const {
+		action,
+		after,
+		before,
+		by,
+		date_range: dateRange,
+		group,
+		name,
+		not_group: notGroup,
+		page,
+	} = query;
+	// helper to fold in new properties conditionally
+	const p = ( ...o ) => Object.assign( {}, ...o );
+
+	return p(
+		action && { action: decodeURI( action ).split( ',' ) },
+		after && { after },
+		before && { before },
+		by && { by }, // and a sweet one at that
+		dateRange && { dateRange },
+		name && { name: decodeURI( name ).split( ',' ) },
+		hasGroup && {
+			group: p(
+				group && { includes: decodeURI( group ).split( ',' ) },
+				notGroup && { excludes: decodeURI( notGroup ).split( ',' ) }
+			),
+		},
+		page && page > 0 && { page }
 	);
+};


### PR DESCRIPTION
Poseidon has done some recent work in adding new filters to the activity log api, and this PR will expose them in Calypso URLs.

New params:
- `after` a date string, example: `?after=2018-06-01+12:53:00`
- `action` a string or an array specifying which actions to include, example `?action=published,deleted`
- `before` a date string, example `?before=2018-07-01`
- `by` a string specifying a user's display name, example `?by=Rocco+Tripaldi`
- `date_range` a string specifying a [PHP relative formated](http://php.net/manual/en/datetime.formats.relative.php) date , example `?date_range=10+days+ago`
- `name`  a string or array specifying exact name or names to include, example `?name=post__published,comment__trashed`
- `not_group` a string or array specifying which groups to exclude, exampe `?not_group=post,comment`

Try it out by appending some URL params to you activity log page.