### PR TITLE
Domains: Align text on transfer screen

### DIFF
--- a/client/components/domains/use-your-domain-step/style.scss
+++ b/client/components/domains/use-your-domain-step/style.scss
@@ -33,6 +33,7 @@
 		display: flex;
 		justify-content: center;
 		margin: 1em 0;
+		max-height: 150px;
 	}
 
 	.use-your-domain-step__option-title,
@@ -85,7 +86,7 @@
 	color: $gray-text;
 }
 
-@include breakpoint( '<660px' ) {
+@include breakpoint( '<800px' ) {
 	.use-your-domain-step__content {
 		flex-flow: wrap;
 	}


### PR DESCRIPTION
This PR makes some slight adjustments to the domain transfer screen. The text is better aligned when side by side, and the illustration doesn't use up so much vertical space on smaller screens. I also increased the breakpoint for wrapping the columns. The narrow columns were difficult to read on mid-size screens.

Before | After
------------ | -------------
<img width="736" alt="screen shot 2018-07-06 at 10 35 31" src="https://user-images.githubusercontent.com/448298/42386323-31668984-810d-11e8-91db-d96a829a3a6c.png"> | <img width="736" alt="screen shot 2018-07-06 at 10 58 00" src="https://user-images.githubusercontent.com/448298/42386333-365864d0-810d-11e8-8fa8-71dddd5bcd6f.png">
<img width="649" alt="screen shot 2018-07-06 at 10 21 52" src="https://user-images.githubusercontent.com/448298/42386382-5a5b6e04-810d-11e8-92f3-b58ab8689260.png"> | <img width="614" alt="screen shot 2018-07-06 at 11 12 59" src="https://user-images.githubusercontent.com/448298/42386472-98203242-810d-11e8-96d0-0401a241bf2f.png">
<img width="720" alt="screen shot 2018-07-06 at 10 45 48" src="https://user-images.githubusercontent.com/448298/42386341-3f3e102c-810d-11e8-8dc5-4d6acf43f7a8.png"> | <img width="719" alt="screen shot 2018-07-06 at 10 44 57" src="https://user-images.githubusercontent.com/448298/42386349-459ec25e-810d-11e8-855d-cd7cf7b5fbb5.png">


#### Testing

* Checkout this branch or open the calypso.live branch in your browser.
* Visit `My Sites > Domains > Add` and click to use a domain you already own.
* Confirm the text is aligned like the above screenshot.
* Resize your browser and confirm it looks like the screenshots above.