### PR TITLE
State: Prevent logged-in user state from persisting for logged-out users

### DIFF
--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -14,6 +14,7 @@ import { createStore } from 'redux';
  */
 import { isEnabled } from 'config';
 import localforage from 'lib/localforage';
+import userFactory from 'lib/user';
 import { isSupportUserSession } from 'lib/user/support-user-interop';
 import { useSandbox, useFakeTimers } from 'test/helpers/use-sinon';
 
@@ -90,6 +91,7 @@ describe( 'initial-state', () => {
 					let state, sandbox;
 					useSandbox( _sandbox => ( sandbox = _sandbox ) );
 					const savedState = {
+						currentUser: { id: 123456789 },
 						postTypes: {
 							items: {
 								2916284: {
@@ -103,7 +105,7 @@ describe( 'initial-state', () => {
 					beforeAll( done => {
 						isEnabled.mockReturnValue( true );
 						isSupportUserSession.mockReturnValue( true );
-						window.initialReduxState = { currentUser: { id: 123456789 } };
+						window.initialReduxState = { currentUser: { currencyCode: 'USD' } };
 						sandbox.spy( console, 'error' );
 						sandbox.stub( localforage, 'getItem' ).returns(
 							new Promise( function( resolve ) {
@@ -131,7 +133,7 @@ describe( 'initial-state', () => {
 						chaiExpect( state._timestamp ).to.equal( undefined );
 					} );
 					test( 'does not build state using server state', () => {
-						chaiExpect( state.currentUser.id ).to.equal( null );
+						chaiExpect( state.currentUser.currencyCode ).to.equal( null );
 					} );
 				} );
 			} );
@@ -295,21 +297,81 @@ describe( 'initial-state', () => {
 					chaiExpect( state._timestamp ).to.equal( undefined );
 				} );
 			} );
+			describe( 'with invalid persisted data and no initial server data', () => {
+				let state, sandbox;
+				useSandbox( _sandbox => ( sandbox = _sandbox ) );
+
+				const savedState = {
+						// Create an invalid state by forcing the user ID
+						// stored in the state to differ from the current
+						// mocked user ID.
+						currentUser: { id: userFactory().get().ID + 1 },
+						postTypes: {
+							items: {
+								2916284: {
+									post: { name: 'post', label: 'Posts' },
+									page: { name: 'page', label: 'Pages' },
+								},
+							},
+						},
+						_timestamp: Date.now(),
+					},
+					serverState = {};
+				beforeAll( done => {
+					window.initialReduxState = serverState;
+					isEnabled.mockReturnValue( true );
+					sandbox.spy( console, 'error' );
+					sandbox.stub( localforage, 'getItem' ).returns(
+						new Promise( function( resolve ) {
+							resolve( savedState );
+						} )
+					);
+					const reduxReady = function( reduxStore ) {
+						state = reduxStore.getState();
+						done();
+					};
+					createReduxStoreFromPersistedInitialState( reduxReady );
+				} );
+				afterAll( () => {
+					window.initialReduxState = null;
+					isEnabled.mockReturnValue( false );
+				} );
+				test( 'builds store without errors', () => {
+					chaiExpect( console.error.called ).to.equal( false ); // eslint-disable-line no-console
+				} );
+				test( 'does not build using local forage state', () => {
+					chaiExpect( state.postTypes.items[ 2916284 ] ).to.equal( undefined );
+				} );
+				test( 'does not add timestamp to store', () => {
+					chaiExpect( state._timestamp ).to.equal( undefined );
+				} );
+			} );
 		} );
 	} );
 
 	describe( '#persistOnChange()', () => {
 		let store, setItemSpy;
 
+		const reducer = ( state, { data: newData, userId: userId } ) => {
+			if ( newData && newData !== state.data ) {
+				state = Object.assign( {}, state, { data: newData } );
+			}
+			if ( userId && userId !== state.currentUser.id ) {
+				state = Object.assign( {}, state, { currentUser: { id: userId } } );
+			}
+			return state;
+		};
+
+		// Create a valid initial state (with a stored user ID that matches the
+		// current mocked user ID).
+		const initialState = { currentUser: { id: 123456789 } };
+
 		beforeEach( () => {
 			setItemSpy = jest
 				.spyOn( localforage, 'setItem' )
 				.mockImplementation( () => Promise.resolve() );
 
-			store = persistOnChange(
-				createStore( ( state, { data: nextState } ) => nextState ),
-				state => state
-			);
+			store = persistOnChange( createStore( reducer, initialState ), state => state );
 		} );
 
 		afterEach( () => {
@@ -326,6 +388,20 @@ describe( 'initial-state', () => {
 			clock.tick( SERIALIZE_THROTTLE );
 
 			expect( setItemSpy ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'should not persist invalid state', () => {
+			// Create an invalid state by forcing the user ID stored in the
+			// state to differ from the current mocked user ID.
+			store.dispatch( {
+				type: 'foo',
+				data: 1,
+				userId: userFactory().get().ID + 1,
+			} );
+
+			clock.tick( SERIALIZE_THROTTLE );
+
+			expect( setItemSpy ).toHaveBeenCalledTimes( 0 );
 		} );
 
 		test( 'should persist state for changed state', () => {
@@ -395,8 +471,14 @@ describe( 'initial-state', () => {
 			clock.tick( SERIALIZE_THROTTLE );
 
 			expect( setItemSpy ).toHaveBeenCalledTimes( 2 );
-			expect( setItemSpy ).toHaveBeenCalledWith( 'redux-state-123456789', 3 );
-			expect( setItemSpy ).toHaveBeenCalledWith( 'redux-state-123456789', 5 );
+			expect( setItemSpy ).toHaveBeenCalledWith(
+				'redux-state-123456789',
+				Object.assign( {}, initialState, { data: 3 } )
+			);
+			expect( setItemSpy ).toHaveBeenCalledWith(
+				'redux-state-123456789',
+				Object.assign( {}, initialState, { data: 5 } )
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
This grew out of an issue discovered in https://github.com/Automattic/wp-calypso/pull/25626, but turned out to be a more fundamental bug.

Whenever you log out of Calypso, the entire state tree from the previous logged-in user gets written to the logged-out user's local storage.  This may have a variety of consequences.  One definite consequence is the bug report above ("Email me a login link" option missing on the login form).

### Steps to reproduce

1. Run Calypso locally using `ENABLE_FEATURES=no-force-sympathy npm start` (to mimic the production environment, in which the bug always occurs).
2. Log in to Calypso.
3. Log out.
4. Visit the login page again.

**Before the patch**: The "Email me a login link" (a.k.a. magic links) option will be missing from underneath the login form.  Furthermore, if you use your browser's development tools to look at `calypso_store` in the Indexed DB local storage, you'll see that the `redux-state-logged-out` entry has lots of data from the previous logged-in user (the `currentUser` and `sites` keys within that entry are particularly good places to look).

**After the patch**: The "Email me a login link" option should appear, and the  `redux-state-logged-out` entry in `calypso_store` should not contain any data from the previous logged-in user.

### Solution

As eventually determined in the discussion at https://github.com/Automattic/wp-calypso/pull/25626 (hat tip to several people, but especially @jsnajdr), this bug happens because although `user.clear()` (which is called on logout) clears the local storage, it doesn't do anything to change the Redux state in memory, or to prevent the `persistOnChange` method (particularly when called during the `beforeunload` event) from writing that now-stale Redux state to local storage later on.

There were a few possible ways to fix this discussed in the previous pull request.  Here, I settled on the solution of making the persistence code in `initial-state.js` detect cases where the user ID in the state doesn't match the user ID associated with the local storage key, and skip reading/writing the state when it does.  I chose this for a few reasons:

1. It seemed to be a more self-contained (and easy-to-write-tests-for) solution than having `user.clear()` trigger the persistence to be disabled.
2. It is more comprehensive, in the sense that if the current user ever changes via some other method besides `user.clear()`, the bug will still be prevented.
3. It doesn't just fix the bug when the state is being written, but also when it is being read. Although the latter isn't strictly necessary, it's extra protection, plus it also ensures that people experiencing the bug currently get it fixed right away, as opposed to waiting until the stored state expires - which can take 7 days, or potentially longer if they are interacting with the site during that time.

Some alternative fixes I didn't do:
- Stop persisting state for logged-out users altogether.  There were several people in the previous discussion who wanted to keep this feature in place.
- Actually make `user.clear()` remove the outdated Redux state from memory, so that it's automatically rebuilt for the new user without refreshing the page.  This would probably be the theoretically cleanest solution, but it led to way too many errors when I made a rudimentary attempt at it.  I did leave a code comment in place mentioning it though.