### PR TITLE
State: Improve the "Skipping initial state rehydration" message

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -150,7 +150,7 @@ export default function createReduxStoreFromPersistedInitialState( reduxStoreRea
 		if ( shouldAddSympathy() ) {
 			// eslint-disable-next-line no-console
 			console.log(
-				'%cSkipping initial state rehydration to recreate first-load experience.',
+				'%cSkipping initial state rehydration. (This runs during random page requests in the Calypso development environment, to simulate a user loading the application for the first time.)',
 				'font-size: 14px; color: red;'
 			);
 

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -150,7 +150,7 @@ export default function createReduxStoreFromPersistedInitialState( reduxStoreRea
 		if ( shouldAddSympathy() ) {
 			// eslint-disable-next-line no-console
 			console.log(
-				'%cSkipping initial state rehydration. (This runs during random page requests in the Calypso development environment, to simulate a user loading the application for the first time.)',
+				'%cSkipping initial state rehydration. (This runs during random page requests in the Calypso development environment, to simulate loading the application with an empty cache.)',
 				'font-size: 14px; color: red;'
 			);
 


### PR DESCRIPTION
I have been working on and off with Calypso for a few months now (mostly off).

Something I noticed early on but didn't understand for a long time was the "sympathy" feature (a.k.a. the "Skipping initial state rehydration" message that appears in the console sometimes).  More recently, I've seen and worked with the code that generates it, so now I understand what it does and why.  But before then:
1. I had very little idea what it meant.  (I did realize pretty early on that it meant the local storage wouldn't be used, but I didn't really understand the details.)
2. I had no idea that it was intentional behavior, as opposed to a bug :)
3. I had no idea that it was a Calypso-specific behavior (or beyond that, a behavior that only runs during Calypso development).  To be honest, I think I just assumed the message probably came from deep within React, which is one reason I didn't even bother researching it further.

Here's an attempt to improve the console message along the lines of the above.

Before:
> Skipping initial state rehydration to recreate first-load experience.

After:
> ~~Skipping initial state rehydration. (This runs during random page requests in the Calypso development environment, to simulate a user loading the application for the first time.)~~

> Skipping initial state rehydration. (This runs during random page requests in the Calypso development environment, to simulate loading the application with an empty cache.)