### PR TITLE
Concierge: Use the new Initial endpoint to populate the available times.

### DIFF
--- a/client/components/data/query-concierge-initial/index.js
+++ b/client/components/data/query-concierge-initial/index.js
@@ -1,0 +1,27 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestConciergeInitial } from 'state/concierge/actions';
+
+class QueryConciergeInitial extends Component {
+	componentDidMount() {
+		this.props.requestConciergeInitial( this.props.scheduleId );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	state => state,
+	{ requestConciergeInitial }
+)( QueryConciergeInitial );

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -21,7 +21,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import Main from 'components/main';
-import QueryConciergeAvailableTimes from 'components/data/query-concierge-available-times';
+import QueryConciergeInitial from 'components/data/query-concierge-initial';
 import QueryUserSettings from 'components/data/query-user-settings';
 import QuerySites from 'components/data/query-sites';
 import QuerySitePlans from 'components/data/query-site-plans';
@@ -84,7 +84,7 @@ export class ConciergeMain extends Component {
 			<Main>
 				<PageViewTracker path={ analyticsPath } title={ analyticsTitle } />
 				<QueryUserSettings />
-				<QueryConciergeAvailableTimes scheduleId={ WPCOM_CONCIERGE_SCHEDULE_ID } />
+				<QueryConciergeInitial scheduleId={ WPCOM_CONCIERGE_SCHEDULE_ID } />
 				<QuerySites />
 				{ site && <QuerySitePlans siteId={ site.ID } /> }
 				{ this.getDisplayComponent() }

--- a/client/state/concierge/available-times/reducer.js
+++ b/client/state/concierge/available-times/reducer.js
@@ -7,11 +7,13 @@ import { createReducer } from 'state/utils';
 import {
 	CONCIERGE_AVAILABLE_TIMES_REQUEST,
 	CONCIERGE_AVAILABLE_TIMES_UPDATE,
+	CONCIERGE_INITIAL_UPDATE,
 } from 'state/action-types';
 
 export const availableTimes = createReducer( null, {
 	[ CONCIERGE_AVAILABLE_TIMES_REQUEST ]: () => null,
 	[ CONCIERGE_AVAILABLE_TIMES_UPDATE ]: ( state, action ) => action.availableTimes,
+	[ CONCIERGE_INITIAL_UPDATE ]: ( state, action ) => action.initial.availableTimes,
 } );
 
 export default availableTimes;


### PR DESCRIPTION
Finishes off the changes required to use the Initial endpoint introduced in `D15118-code`.

This PR depends on #25906 and #25900.

Adds the new component and uses that to retrieve available 1:1 session times.

**Testing**
 - Navigate to `/me/concierge` - `/concierge/schedules/{schedule id}/initial` should be requested and `/concierge/schedules/{schedule id}/available_times` should not.
- Click through to the second booking step, available sessions should be displayed as normal.

cc @mattwondra 
cc @nb 