### PR TITLE
Activity Log: display WordPress core updates

### DIFF
--- a/client/my-sites/stats/activity-log-tasklist/index.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/index.jsx
@@ -109,9 +109,11 @@ class ActivityLogTasklist extends Component {
 			trackDismiss( item );
 		} else {
 			items = union(
-				coreWithUpdate.map( p => p.slug ),
 				pluginWithUpdate.map( p => p.slug ),
-				themeWithUpdate.map( p => p.slug )
+				themeWithUpdate.map( t => t.slug ),
+				// Although core doesn't have a slug, we call it 'wordpress'
+				// to work with it like plugins or themes.
+				coreWithUpdate.map( c => c.slug )
 			);
 			trackDismissAll();
 		}
@@ -256,7 +258,7 @@ class ActivityLogTasklist extends Component {
 
 		each( itemsWithUpdate, item => {
 			const { slug, updateStatus, type, name } = item;
-			// Finds in either prevProps.pluginWithUpdate or prevProps.themeWithUpdate
+			// Finds in prevProps.pluginWithUpdate, prevProps.themeWithUpdate or prevpros.coreWithUpdate
 			const prevItemWithUpdate = find( prevProps[ `${ type }WithUpdate` ], { slug } );
 
 			if ( false === get( prevItemWithUpdate, [ 'updateStatus' ], false ) ) {

--- a/client/my-sites/stats/activity-log-tasklist/index.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/index.jsx
@@ -28,23 +28,24 @@ import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import { navigate } from 'state/ui/actions';
 
 /**
- * Checks if the supplied plugins or themes are currently updating.
+ * Checks if the supplied core update, plugins, or themes are being updated.
  *
- * @param {Array} s List of plugin or theme objects to check their update status.
+ * @param {Array} updatables List of plugin, theme or core update objects to check their update status.
  *
- * @returns {bool}  True if one or more plugins or themes are updating.
+ * @returns {boolean}  True if one or more plugins or themes are updating.
  */
-const isItemUpdating = s => s.some( p => 'inProgress' === get( p, 'updateStatus.status' ) );
+const isItemUpdating = updatables =>
+	updatables.some( item => 'inProgress' === get( item, 'updateStatus.status' ) );
 
 /**
- * Checks if the plugin or theme is enqueued to be updated, searching it in the list by its slug.
+ * Checks if the plugin, theme or core update is enqueued to be updated, searching it in the list by its slug.
  *
- * @param {string} g Plugin or theme slug.
- * @param {array}  q Collection of plugins or themes currently in the update queue.
+ * @param {string} updateSlug  Plugin or theme slug, or 'wordpress' for core updates.
+ * @param {array}  updateQueue Collection of plugins or themes currently queued to be updated.
  *
- * @returns {bool}   True if the plugin or theme is enqueued to be updated.
+ * @returns {boolean}   True if the plugin or theme is enqueued to be updated.
  */
-const isItemEnqueued = ( g, q ) => !! find( q, { slug: g } );
+const isItemEnqueued = ( updateSlug, updateQueue ) => !! find( updateQueue, { slug: updateSlug } );
 
 class ActivityLogTasklist extends Component {
 	static propTypes = {
@@ -109,11 +110,11 @@ class ActivityLogTasklist extends Component {
 			trackDismiss( item );
 		} else {
 			items = union(
-				pluginWithUpdate.map( p => p.slug ),
-				themeWithUpdate.map( t => t.slug ),
+				pluginWithUpdate.map( plugin => plugin.slug ),
+				themeWithUpdate.map( theme => theme.slug ),
 				// Although core doesn't have a slug, we call it 'wordpress'
 				// to work with it like plugins or themes.
-				coreWithUpdate.map( c => c.slug )
+				coreWithUpdate.map( core => core.slug )
 			);
 			trackDismissAll();
 		}
@@ -398,7 +399,7 @@ class ActivityLogTasklist extends Component {
  * @param {bool}   isUpdateComplete If update actually produced what is expected to be after a successful update.
  *                                  In themes, the 'update' prop of the theme object is nullified when an update is succesful.
  *
- * @returns {bool|object} False is update hasn't started. One of 'inProgress', 'error', 'completed', when
+ * @returns {boolean|object} False is update hasn't started. One of 'inProgress', 'error', 'completed', when
  * the update is running, failed, or was successfully completed, respectively.
  */
 const getNormalizedStatus = ( state, isUpdateComplete ) => {
@@ -423,7 +424,7 @@ const getNormalizedStatus = ( state, isUpdateComplete ) => {
  * @param {number} siteId  Site Id.
  * @param {string} themeId Theme slug.
  *
- * @returns {bool|object} False is update hasn't started. One of 'inProgress', 'error', 'completed', when
+ * @returns {boolean|object} False is update hasn't started. One of 'inProgress', 'error', 'completed', when
  * the update is running, failed, or was successfully completed, respectively.
  */
 const getStatusForTheme = ( siteId, themeId ) => {
@@ -437,7 +438,7 @@ const getStatusForTheme = ( siteId, themeId ) => {
  * Get data about the status of a core update.
  * @param {number} siteId      Site Id.
  * @param {string} coreVersion Version of core that the WP installation will be updated to.
- * @returns {bool|Object}      False is update hasn't started. One of 'inProgress', 'error', 'completed', when
+ * @returns {boolean|Object}      False is update hasn't started. One of 'inProgress', 'error', 'completed', when
  * the update is running, failed, or was successfully completed, respectively.
  */
 const getStatusForCore = ( siteId, coreVersion ) => {

--- a/client/my-sites/stats/activity-log-tasklist/style.scss
+++ b/client/my-sites/stats/activity-log-tasklist/style.scss
@@ -73,3 +73,7 @@
 	display: flex;
 	align-items: center;
 }
+
+.activity-log-tasklist__unlinked {
+	cursor: default;
+}

--- a/client/my-sites/stats/activity-log-tasklist/to-update.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/to-update.jsx
@@ -7,6 +7,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { get, unionBy } from 'lodash';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -60,7 +61,9 @@ export default WrappedComponent => {
 		return {
 			plugins: getPluginsWithUpdates( state, [ siteId ] ),
 			themes: get( alertsData, 'data.updates.themes', emptyList ),
-			core: get( alertsData, 'data.updates.core', emptyList ),
+			core: config.isEnabled( 'activity-log-core-update' )
+				? get( alertsData, 'data.updates.core', emptyList )
+				: emptyList,
 		};
 	} )( ToUpdate );
 };

--- a/client/my-sites/stats/activity-log-tasklist/update.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/update.jsx
@@ -25,6 +25,7 @@ class ActivityLogTaskUpdate extends Component {
 		type: PropTypes.string,
 		updateType: PropTypes.string,
 
+		linked: PropTypes.bool,
 		goToPage: PropTypes.func,
 		enqueueTheme: PropTypes.func,
 		dismissTheme: PropTypes.func,
@@ -42,17 +43,27 @@ class ActivityLogTaskUpdate extends Component {
 	handleNameClick = () => this.props.goToPage( this.props.slug, this.props.type );
 
 	render() {
-		const { translate, name, version, type, updateType, disable } = this.props;
+		const { translate, name, version, type, updateType, disable, linked } = this.props;
 
 		return (
 			<Card className="activity-log-tasklist__task" compact>
-				<ActivityIcon activityIcon={ `${ type }s` } activityStatus="warning" />
+				<ActivityIcon
+					activityIcon={ 'plugin' === type || 'theme' === type ? `${ type }s` : 'my-sites' }
+					activityStatus="warning"
+				/>
 				<span className="activity-log-tasklist__update-item">
 					<div>
 						<span className="activity-log-tasklist__update-text">
-							<Button borderless onClick={ this.handleNameClick }>
-								{ name }
-							</Button>
+							{ linked ? (
+								<Button borderless onClick={ this.handleNameClick }>
+									{ name }
+								</Button>
+							) : (
+								// Add button classes so unlinked names look the same.
+								<span className="activity-log-tasklist__unlinked button is-borderless">
+									{ name }
+								</span>
+							) }
 						</span>
 						<span className="activity-log-tasklist__update-bullet">&bull;</span>
 						<span className="activity-log-tasklist__update-version">{ version }</span>

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -87,7 +87,12 @@ export const requestSiteAlerts = siteId => {
 								type: theme.type,
 								version: theme.version,
 							} ) ),
-							core: updates.core,
+							core: updates.core.map( theme => ( {
+								name: theme.name,
+								slug: theme.slug,
+								type: theme.type,
+								version: theme.version,
+							} ) ),
 						},
 					},
 				],

--- a/config/development.json
+++ b/config/development.json
@@ -29,6 +29,7 @@
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"support_site_locales": [ "en", "es", "de", "ja", "pt-br" ],
 	"features": {
+		"activity-log-core-update": true,
 		"activity-log-wpcom-free": true,
 		"account-recovery": true,
 		"ad-tracking": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -19,6 +19,7 @@
 		"pt-br"
 	],
 	"features": {
+		"activity-log-core-update": true,
 		"activity-log-wpcom-free": true,
 		"ad-tracking": false,
 		"apple-pay": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -16,6 +16,7 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
+		"activity-log-core-update": true,
 		"activity-log-wpcom-free": true,
 		"ad-tracking": false,
 		"automated-transfer": true,


### PR DESCRIPTION
This PR introduces the ability to display a notice in Activity Log when a WordPress core update is available.
I'm adding core updates at the beginning of notices since it's the most important item to update.

<img width="743" alt="captura de pantalla 2018-07-06 a la s 18 38 38" src="https://user-images.githubusercontent.com/1041600/42401402-d92c6da8-814b-11e8-910c-6b66cfd72dd5.png">

### Ready for internal test

Once merged, this PR will provide the core update functionality for a12s only, in staging, development and wpcalypso thanks to a config flag. Its name is `activity-log-core-update`.

### Data source

Data for core updates is provided by the `/alerts` endpoint. Its shape, an array with a single object, is similar to the update data for themes or plugins for consistency and be parsed similarly for the existing functions that process data for those.

### The WordPress name is unlinked

The word "WordPress" in the notice won't be linked since while we link plugins and themes to pages in Calypso, we have nothing similar for core. To this end, the `ActivityLogTaskUpdate` component has a new prop `linked` that indicates if the name in an update is linked or not.

### Testing

Edit `wp-includes/version.php` and downgrade the version. Visit `wp-admin/update-core.php` to trigger an update check.
Build this branch and go to Activity Log, you should see a notice:
- clicking Dismiss in the notice should dismiss it
- clicking Dismiss all at the top of notices should dismiss it
- clicking Update in the notice should update the core in the site
