### PR TITLE
Podcasting: Fix non-HTTPS feed url

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/feed-url.jsx
+++ b/client/my-sites/site-settings/podcasting-details/feed-url.jsx
@@ -17,6 +17,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import PodcastingSupportLink from './support-link';
 import { getTerm } from 'state/terms/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 
 function PodcastFeedUrl( { feedUrl, translate } ) {
 	if ( ! feedUrl ) {
@@ -45,7 +46,12 @@ export default connect( ( state, ownProps ) => {
 	const podcastingCategory =
 		categoryId && getTerm( state, siteId, 'category', categoryId );
 
-	const feedUrl = podcastingCategory && podcastingCategory.feed_url;
+	let feedUrl = podcastingCategory && podcastingCategory.feed_url;
+
+	if ( feedUrl && ! isJetpackSite( state, siteId ) ) {
+		// Feed URLs for WP.com Simple sites may incorrectly show up as http:
+		feedUrl = feedUrl.replace( /^http:/, 'https:' );
+	}
 
 	return { feedUrl };
 } )( localize( PodcastFeedUrl ) );

--- a/client/my-sites/site-settings/podcasting-details/feed-url.jsx
+++ b/client/my-sites/site-settings/podcasting-details/feed-url.jsx
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -14,8 +15,14 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import PodcastingSupportLink from './support-link';
+import { getTerm } from 'state/terms/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 function PodcastFeedUrl( { feedUrl, translate } ) {
+	if ( ! feedUrl ) {
+		return null;
+	}
+
 	return (
 		<FormFieldset>
 			<FormLabel>{ translate( 'RSS Feed' ) }</FormLabel>
@@ -30,4 +37,15 @@ function PodcastFeedUrl( { feedUrl, translate } ) {
 	);
 }
 
-export default localize( PodcastFeedUrl );
+export default connect( ( state, ownProps ) => {
+	const { categoryId } = ownProps;
+
+	const siteId = getSelectedSiteId( state );
+
+	const podcastingCategory =
+		categoryId && getTerm( state, siteId, 'category', categoryId );
+
+	const feedUrl = podcastingCategory && podcastingCategory.feed_url;
+
+	return { feedUrl };
+} )( localize( PodcastFeedUrl ) );

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -39,7 +39,7 @@ import isPrivateSite from 'state/selectors/is-private-site';
 import canCurrentUser from 'state/selectors/can-current-user';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'state/sites/selectors';
-import { isRequestingTermsForQueryIgnoringPage, getTerm } from 'state/terms/selectors';
+import { isRequestingTermsForQueryIgnoringPage } from 'state/terms/selectors';
 import { isSavingSiteSettings } from 'state/site-settings/selectors';
 
 class PodcastingDetails extends Component {
@@ -219,13 +219,7 @@ class PodcastingDetails extends Component {
 	}
 
 	renderCategorySetting() {
-		const {
-			siteId,
-			podcastingCategoryId,
-			podcastingFeedUrl,
-			isCategoryChanging,
-			translate,
-		} = this.props;
+		const { siteId, podcastingCategoryId, isCategoryChanging, translate } = this.props;
 
 		return (
 			<Fragment>
@@ -256,7 +250,7 @@ class PodcastingDetails extends Component {
 						/>
 					) }
 				</FormFieldset>
-				{ podcastingFeedUrl && <PodcastFeedUrl feedUrl={ podcastingFeedUrl } /> }
+				<PodcastFeedUrl categoryId={ podcastingCategoryId } />
 			</Fragment>
 		);
 	}
@@ -408,10 +402,6 @@ const connectComponent = connect( ( state, ownProps ) => {
 		Number( ownProps.fields.podcasting_category_id );
 	const isPodcastingEnabled = podcastingCategoryId > 0;
 
-	const selectedCategory =
-		isPodcastingEnabled && getTerm( state, siteId, 'category', podcastingCategoryId );
-	const podcastingFeedUrl = selectedCategory && selectedCategory.feed_url;
-
 	const isSavingSettings = isSavingSiteSettings( state, siteId );
 	const isCategoryChanging =
 		! isSavingSettings &&
@@ -427,11 +417,10 @@ const connectComponent = connect( ( state, ownProps ) => {
 		siteId,
 		siteSlug: getSelectedSiteSlug( state ),
 		isPrivate: isPrivateSite( state, siteId ),
-		podcastingCategoryId,
 		isPodcastingEnabled,
+		podcastingCategoryId,
 		isCategoryChanging,
 		isRequestingCategories: isRequestingTermsForQueryIgnoringPage( state, siteId, 'category', {} ),
-		podcastingFeedUrl,
 		userCanManagePodcasting: canCurrentUser( state, siteId, 'manage_options' ),
 		isUnsupportedSite: isJetpack && ! isAutomatedTransfer,
 		isSavingSettings,

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -161,16 +161,6 @@ class PodcastingDetails extends Component {
 		);
 	}
 
-	renderFeedUrl() {
-		const { podcastingFeedUrl } = this.props;
-
-		if ( ! podcastingFeedUrl ) {
-			return;
-		}
-
-		return <PodcastFeedUrl feedUrl={ podcastingFeedUrl } />;
-	}
-
 	render() {
 		const {
 			handleSubmitForm,

--- a/client/my-sites/site-settings/podcasting-details/link.jsx
+++ b/client/my-sites/site-settings/podcasting-details/link.jsx
@@ -42,8 +42,8 @@ class PodcastingLink extends Component {
 		const {
 			isPrivate,
 			isPodcastingEnabled,
-			categoryName,
-			feedUrl,
+			podcastingCategoryId,
+			podcastingCategoryName,
 			detailsLink,
 			translate,
 		} = this.props;
@@ -78,7 +78,7 @@ class PodcastingLink extends Component {
 							{ translate(
 								'Publish blog posts in the {{strong}}%s{{/strong}} category to add new episodes.',
 								{
-									args: categoryName,
+									args: podcastingCategoryName,
 									components: { strong: <strong /> },
 								}
 							) }
@@ -89,7 +89,7 @@ class PodcastingLink extends Component {
 					</Button>
 				</div>
 				<div className="podcasting-details__link-feed">
-					<PodcastFeedUrl feedUrl={ feedUrl } />
+					<PodcastFeedUrl categoryId={ podcastingCategoryId } />
 				</div>
 			</Fragment>
 		);
@@ -112,8 +112,8 @@ export default connect( ( state, ownProps ) => {
 		siteSlug,
 		isPrivate: isPrivateSite( state, siteId ),
 		isPodcastingEnabled: !! podcastingCategory,
-		categoryName: podcastingCategory && podcastingCategory.name,
-		feedUrl: podcastingCategory && podcastingCategory.feed_url,
+		podcastingCategoryId,
+		podcastingCategoryName: podcastingCategory && podcastingCategory.name,
 		detailsLink,
 	};
 } )( localize( PodcastingLink ) );


### PR DESCRIPTION
This PR is a follow-up to https://github.com/Automattic/wp-calypso/pull/25887 and a bugfix.

First, the PR removes some dead code and reworks `<PodcastFeedUrl>` to accept a category ID instead of a feed URL.  This cuts down on the number of times we need to retrieve the feed URL from the podcasting category ID, which is the more commonly-used piece of information in the app.

Second, the PR fixes a bug with some WP.com sites where the feed URL displays `http:` instead of `https:`.

This appears *not* to be an issue with WP.com Business sites with plugins uploaded:

![2018-07-06t16 46 04-0500](https://user-images.githubusercontent.com/227022/42404355-d97ea77e-814d-11e8-8e5e-a4b44a23946d.png)

Because it's not an issue in the default configuration, and since in theory a Business site could be (mis)configured to not support HTTPS, but other WP.com sites cannot, I went with `! isJetpackSite` for this check.