### PR TITLE
Concierge: Add data layer for the new Initial endpoint

### DIFF
--- a/client/state/data-layer/wpcom/concierge/schedules/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/index.js
@@ -6,5 +6,6 @@
 import { mergeHandlers } from 'state/action-watchers/utils';
 import availableTimes from './available-times';
 import appointments from './appointments';
+import initial from './initial';
 
-export default mergeHandlers( availableTimes, appointments );
+export default mergeHandlers( availableTimes, appointments, initial );

--- a/client/state/data-layer/wpcom/concierge/schedules/initial/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/initial/from-api.js
@@ -5,12 +5,17 @@
  */
 import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import responseSchema from './schema';
+import { transform as appointmentTransformer } from 'state/data-layer/wpcom/concierge/schedules/appointments/detail/from-api';
 
 export const convertToDate = timestampInSeconds => timestampInSeconds * 1000;
 
 export const transform = response => {
+	const nextAppointment =
+		response.next_appointment === null ? null : appointmentTransformer( response.next_appointment );
+
 	return {
 		availableTimes: response.available_times.map( convertToDate ),
+		nextAppointment: nextAppointment,
 	};
 };
 

--- a/client/state/data-layer/wpcom/concierge/schedules/initial/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/initial/from-api.js
@@ -1,0 +1,17 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import makeJsonSchemaParser from 'lib/make-json-schema-parser';
+import responseSchema from './schema';
+
+export const convertToDate = timestampInSeconds => timestampInSeconds * 1000;
+
+export const transform = response => {
+	return {
+		availableTimes: response.available_times.map( convertToDate ),
+	};
+};
+
+export default makeJsonSchemaParser( responseSchema, transform );

--- a/client/state/data-layer/wpcom/concierge/schedules/initial/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/initial/from-api.js
@@ -7,14 +7,14 @@ import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import responseSchema from './schema';
 import { transform as appointmentTransformer } from 'state/data-layer/wpcom/concierge/schedules/appointments/detail/from-api';
 
-export const convertToDate = timestampInSeconds => timestampInSeconds * 1000;
+export const convertToMilliseconds = timestampInSeconds => timestampInSeconds * 1000;
 
 export const transform = response => {
 	const nextAppointment =
 		response.next_appointment === null ? null : appointmentTransformer( response.next_appointment );
 
 	return {
-		availableTimes: response.available_times.map( convertToDate ),
+		availableTimes: response.available_times.map( convertToMilliseconds ),
 		nextAppointment: nextAppointment,
 	};
 };

--- a/client/state/data-layer/wpcom/concierge/schedules/initial/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/initial/index.js
@@ -1,0 +1,45 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { updateConciergeInitial } from 'state/concierge/actions';
+import { errorNotice } from 'state/notices/actions';
+import { CONCIERGE_INITIAL_REQUEST } from 'state/action-types';
+import fromApi from './from-api';
+
+export const fetchConciergeInitial = action =>
+	http(
+		{
+			method: 'GET',
+			path: `/concierge/schedules/${ action.scheduleId }/initial`,
+			apiNamespace: 'wpcom/v2',
+		},
+		action
+	);
+
+export const storeFetchedConciergeInitial = ( action, initial ) =>
+	updateConciergeInitial( initial );
+
+export const conciergeInitialFetchError = () =>
+	errorNotice( translate( "We couldn't load our Concierge schedule. Please try again later." ) );
+
+export const showConciergeInitialFetchError = () => conciergeInitialFetchError();
+
+export default {
+	[ CONCIERGE_INITIAL_REQUEST ]: [
+		dispatchRequestEx( {
+			fetch: fetchConciergeInitial,
+			onSuccess: storeFetchedConciergeInitial,
+			onError: showConciergeInitialFetchError,
+			fromApi,
+		} ),
+	],
+};

--- a/client/state/data-layer/wpcom/concierge/schedules/initial/schema.json
+++ b/client/state/data-layer/wpcom/concierge/schedules/initial/schema.json
@@ -6,6 +6,23 @@
 			"items": {
 				"type": "integer"
 			}
+		},
+		"next_appointment": {
+			"type": [ "object", "null" ],
+			"properties": {
+				"begin_timestamp": { "type": "number" },
+				"end_timestamp": { "type": "number" },
+				"id": { "type": "number" },
+				"meta": {
+					"type": "object",
+					"properties": {
+						"google_calendar_event_id": { "type": "string" },
+						"message": { "type": "string" },
+						"timezone": { "type": "string" }
+					}
+				},
+				"schedule_id": { "type": "number" }
+			}
 		}
 	}
 }

--- a/client/state/data-layer/wpcom/concierge/schedules/initial/schema.json
+++ b/client/state/data-layer/wpcom/concierge/schedules/initial/schema.json
@@ -1,0 +1,11 @@
+{
+	"type": "object",
+	"properties": {
+		"available_times": {
+			"type": "array",
+			"items": {
+				"type": "integer"
+			}
+		}
+	}
+}

--- a/client/state/data-layer/wpcom/concierge/schedules/initial/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/initial/test/from-api.js
@@ -1,0 +1,63 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import fromApi from '../from-api';
+import { SchemaError } from 'lib/make-json-schema-parser';
+
+describe( 'fromApi()', () => {
+	test( 'should validate and transform the data successfully.', () => {
+		const validResponse = {
+			available_times: [
+				1483264800, // unix timestamp of 2017-01-01 10:00:00 UTC
+				1483266600, // unix timestamp of 2017-01-01 10:30:00 UTC
+				1483268400, // unix timestamp of 2017-01-01 11:00:00 UTC
+			],
+		};
+
+		const expectedResult = { availableTimes: [ 1483264800000, 1483266600000, 1483268400000 ] };
+
+		expect( fromApi( validResponse ) ).toEqual( expectedResult );
+	} );
+
+	test( 'should invalidate unexpected field types.', () => {
+		const invalidateCall = () => {
+			const invalidFieldTypes = [ 'this', 'is', false, 'just wrong.' ];
+
+			fromApi( invalidFieldTypes );
+		};
+
+		expect( invalidateCall ).toThrowError( SchemaError );
+	} );
+
+	test( 'should invalidate missing begin_timestamp.', () => {
+		const invalidateMissingBeginTimestamp = () => {
+			const invalidResponse = [
+				{
+					end_timestamp: 400,
+				},
+			];
+
+			fromApi( invalidResponse );
+		};
+
+		expect( invalidateMissingBeginTimestamp ).toThrowError( SchemaError );
+	} );
+
+	test( 'should invalidate missing end_timestamp.', () => {
+		const invalidateMissingEndTimestamp = () => {
+			const invalidResponse = {
+				available_times: [
+					{
+						begin_timestamp: 333,
+					},
+				],
+			};
+
+			fromApi( invalidResponse );
+		};
+
+		expect( invalidateMissingEndTimestamp ).toThrowError( SchemaError );
+	} );
+} );

--- a/client/state/data-layer/wpcom/concierge/schedules/initial/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/initial/test/from-api.js
@@ -9,14 +9,28 @@ import { SchemaError } from 'lib/make-json-schema-parser';
 describe( 'fromApi()', () => {
 	test( 'should validate and transform the data successfully.', () => {
 		const validResponse = {
-			available_times: [
-				1483264800, // unix timestamp of 2017-01-01 10:00:00 UTC
-				1483266600, // unix timestamp of 2017-01-01 10:30:00 UTC
-				1483268400, // unix timestamp of 2017-01-01 11:00:00 UTC
-			],
+			available_times: [ 1483264800, 1483266600, 1483268400 ],
+			next_appointment: { begin_timestamp: 1, end_timestamp: 2, schedule_id: 3 },
 		};
 
-		const expectedResult = { availableTimes: [ 1483264800000, 1483266600000, 1483268400000 ] };
+		const expectedResult = {
+			availableTimes: [ 1483264800000, 1483266600000, 1483268400000 ],
+			nextAppointment: { beginTimestamp: 1000, endTimestamp: 2000, scheduleId: 3 },
+		};
+
+		expect( fromApi( validResponse ) ).toEqual( expectedResult );
+	} );
+
+	test( 'should leave a null next_appointment as null.', () => {
+		const validResponse = {
+			available_times: [ 1483264800, 1483266600, 1483268400 ],
+			next_appointment: null,
+		};
+
+		const expectedResult = {
+			availableTimes: [ 1483264800000, 1483266600000, 1483268400000 ],
+			nextAppointment: null,
+		};
 
 		expect( fromApi( validResponse ) ).toEqual( expectedResult );
 	} );

--- a/client/state/data-layer/wpcom/concierge/schedules/initial/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/initial/test/index.js
@@ -1,0 +1,59 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import {
+	conciergeInitialFetchError,
+	fetchConciergeInitial,
+	storeFetchedConciergeInitial,
+	showConciergeInitialFetchError,
+} from '../';
+import { updateConciergeInitial } from 'state/concierge/actions';
+import { CONCIERGE_INITIAL_REQUEST } from 'state/action-types';
+
+// we are mocking impure-lodash here, so that conciergeInitialFetchError() will contain the expected id in the tests
+jest.mock( 'lib/impure-lodash', () => ( {
+	uniqueId: () => 'mock-unique-id',
+} ) );
+
+describe( 'wpcom-api', () => {
+	describe( 'concierge', () => {
+		test( 'fetchConciergeInitial()', () => {
+			const action = {
+				type: CONCIERGE_INITIAL_REQUEST,
+				scheduleId: 123,
+			};
+
+			expect( fetchConciergeInitial( action ) ).toEqual(
+				http(
+					{
+						method: 'GET',
+						path: `/concierge/schedules/${ action.scheduleId }/initial`,
+						apiNamespace: 'wpcom/v2',
+					},
+					action
+				)
+			);
+		} );
+
+		test( 'storeFetchedConciergeInitial()', () => {
+			const mockInitial = {
+				available_times: [
+					new Date( '2017-01-01 01:00:00' ),
+					new Date( '2017-01-01 02:00:00' ),
+					new Date( '2017-01-01 03:00:00' ),
+				],
+			};
+
+			expect( storeFetchedConciergeInitial( {}, mockInitial ) ).toEqual(
+				updateConciergeInitial( mockInitial )
+			);
+		} );
+
+		test( 'showConciergeInitialFetchError()', () => {
+			expect( showConciergeInitialFetchError() ).toEqual( conciergeInitialFetchError() );
+		} );
+	} );
+} );


### PR DESCRIPTION
Adds the data layer for the new endpoint added in `D15118-code`. This will allow `/concierge/schedules/{schedule id}/initial` to be used.

The data returned by the endpoint will contain an array of available times, `available_times`, and a `next_appointment` property which will either be `null` if the customer does not have a pending appointment, or an `object` containing the customer's next appointment details:

``` json
{
    "available_times": [ 1531569600, 1531571400 ],
    "next_appointment": { 
        "begin_timestamp": 1531569600,
        "end_timestamp": 1531571400,
        "id": 1234,
        "meta": { }
    }
}
```

This PR replaces #25900.

## General Structure
I've conformed to the structure of other Concierge data layer code. The consistency will mean the code is easier to work with for future developers. It will also make the code review easier for people already familiar with the code.

## Where the data will be stored
Although this PR doesn't deal with storing the data in the global state it's worth outlining where it will be kept as that informs some design decisions regarding how the data layer works.

The components that use the data we retrieve here shouldn't have to care where the data has come from as that would tightly couple the frontend components to the data source. The whole point of the data layer is to abstract away from this as it simplifies the code as a whole and gives it a single responsibility.

With that in mind we'll be storing the available times retrieved in this data layer in the same place as they are in the `available_times` data layer code. The frontend components can then just request available times and it won't matter where it's come from and data isn't duplicated.

We'll store the next appointment as a new item in the global state and won't use the same location as in the `appointments/detail` code. This is because the next appointment may be different from an appointment that has been specifically requested.

## Transformations
The data returned must be transformed - all timestamps from the API are in seconds however JavaScript works with timestamps in milliseconds so they'll need to be converted.

Additionally, the properties need to be renamed so that they follow the [naming conventions](https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/javascript.md#naming-conventions) in the global state.

There are already two transformations in the data layer that can handle the `next_appointment` and `available_times`:

- `schedules/appointments/detail/from-api.js` contains the transformation required for `next_appointment`.
- `schedules/available-times/from-api.js` contains the transformation for `available_times`.

In a subsequent PR to this (see #25936), this data layer will supercede `available_times` and the code from that will be removed so I don't want to re-use that transformer as it won't exist later on.

We can, however, reuse the transformation for the appointment. A downside to this is that if the appointment formats of the two endpoints were to become different (which seems unlikely, but it's worth touching on) this could cause problems. That said, the tests should catch any major errors this will cause and, as both the `appointment/details` and `initial` endpoints sanitise the appointment with the same class this does seem very unlikely to be an issue.

### Alternatives
#### Transforming in the selector
We could perform the transformations in the selector, adding the API response as it's received to the global state and transforming the data into the correct format when it's requested. This has a couple of downsides:

- It blurs what the selectors do - they're intended to retrieve and return data, not modify it.
- Transforming the data here would mean it has to be transformed each time the function is called, so work may be repeated.
- If the data is inserted in the global state before it's transformed it will not follow naming conventions.

#### Transform the data in the Reducer
Transforming the data in the reducer could work. No matter where the data comes from it must go through the reducer to be put into the global state, so transforming here means the work is only done once and no code has to be duplicated.

The reducers are being used for this elsewhere, as well, so the behaviour would be expected.

That said, in this instance I decided against doing so because:

- The transformation will not be duplicated once the `available_times` data layer code is removed.
- Keeping the transformation within the data layer is consistent with the other Concierge code.
- It makes more sense to me that API data is in the data layer. It keeps all of the API interaction code together in one logical place. There's a trade off here when code needs to be repeated across endpoints, but as it won't be in the long run I'm not worried about that here. 

If `available_times` were to remain I'd transform the data in the reducer to avoid repeating the transformation logic but as it'll only be used in one place, and as the transformation for `appointment/details` is also being executed in `from-api.js` I've chosen to remain consistent with this.

## Schema
The API response is validated using JSON Schema. The schema for both the data used in `initial` and that in `appointments/detail` is very similar in that `initial` includes an appointment which has the same structure as `appointments/detail`.

### Duplicate Schema
We could duplicate the schema for both `initial` and `appointments/detail`. This has the benefit of making the structure very apparent for both endpoints, but equally means we have to double up on some code and introduce the potential for changing one schema file but forgetting to change the other.

### Combine Schema before validation in `initial`
Another option would be to combine the schema for the available times and for appointment details before we validate against it in `initial`. This removes the duplication but adds complexity - we'd need to modify the schema on-the-fly depending on whether or not `next_appointment` is `null`.

### Complete Schema for `initial`, use that in `appointments/detail`
A third possibility is to add the complete schema to `initial` and then use the `appointment_times` property of that to validate against in `appointments/detail` (thanks @nb!). Doing so means no code has to be duplicated, nothing has to be concatenated and modified on-the-fly and the risk of changing one but not the other is removed.

This PR has implemented this option as it addresses all of the issues in the other two. It also provides a single source of truth, defining how available times and appointments will be structured.

## Testing
Unit tests have been added, and can be executed with `npm run test-client concierge`.