### PR TITLE
Concierge: Populate data from the new Initial endpoint

### DIFF
--- a/client/components/data/query-concierge-initial/index.js
+++ b/client/components/data/query-concierge-initial/index.js
@@ -1,0 +1,27 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestConciergeInitial } from 'state/concierge/actions';
+
+class QueryConciergeInitial extends Component {
+	componentDidMount() {
+		this.props.requestConciergeInitial( this.props.scheduleId );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	state => state,
+	{ requestConciergeInitial }
+)( QueryConciergeInitial );

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -21,7 +21,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import Main from 'components/main';
-import QueryConciergeAvailableTimes from 'components/data/query-concierge-available-times';
+import QueryConciergeInitial from 'components/data/query-concierge-initial';
 import QueryUserSettings from 'components/data/query-user-settings';
 import QuerySites from 'components/data/query-sites';
 import QuerySitePlans from 'components/data/query-site-plans';
@@ -84,7 +84,7 @@ export class ConciergeMain extends Component {
 			<Main>
 				<PageViewTracker path={ analyticsPath } title={ analyticsTitle } />
 				<QueryUserSettings />
-				<QueryConciergeAvailableTimes scheduleId={ WPCOM_CONCIERGE_SCHEDULE_ID } />
+				<QueryConciergeInitial scheduleId={ WPCOM_CONCIERGE_SCHEDULE_ID } />
 				<QuerySites />
 				{ site && <QuerySitePlans siteId={ site.ID } /> }
 				{ this.getDisplayComponent() }

--- a/client/state/concierge/available-times/reducer.js
+++ b/client/state/concierge/available-times/reducer.js
@@ -7,11 +7,15 @@ import { createReducer } from 'state/utils';
 import {
 	CONCIERGE_AVAILABLE_TIMES_REQUEST,
 	CONCIERGE_AVAILABLE_TIMES_UPDATE,
+	CONCIERGE_INITIAL_REQUEST,
+	CONCIERGE_INITIAL_UPDATE,
 } from 'state/action-types';
 
 export const availableTimes = createReducer( null, {
 	[ CONCIERGE_AVAILABLE_TIMES_REQUEST ]: () => null,
 	[ CONCIERGE_AVAILABLE_TIMES_UPDATE ]: ( state, action ) => action.availableTimes,
+	[ CONCIERGE_INITIAL_REQUEST ]: () => null,
+	[ CONCIERGE_INITIAL_UPDATE ]: ( state, action ) => action.initial.availableTimes,
 } );
 
 export default availableTimes;

--- a/client/state/concierge/next-appointment/reducer.js
+++ b/client/state/concierge/next-appointment/reducer.js
@@ -1,0 +1,14 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { createReducer } from 'state/utils';
+import { CONCIERGE_INITIAL_REQUEST, CONCIERGE_INITIAL_UPDATE } from 'state/action-types';
+
+export const nextAppointment = createReducer( null, {
+	[ CONCIERGE_INITIAL_REQUEST ]: () => null,
+	[ CONCIERGE_INITIAL_UPDATE ]: ( state, action ) => action.initial.nextAppointment,
+} );
+
+export default nextAppointment;

--- a/client/state/concierge/next-appointment/test/reducer.js
+++ b/client/state/concierge/next-appointment/test/reducer.js
@@ -1,0 +1,44 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { nextAppointment } from '../reducer';
+import { CONCIERGE_INITIAL_REQUEST, CONCIERGE_INITIAL_UPDATE } from 'state/action-types';
+
+describe( 'concierge/nextAppointment/reducer', () => {
+	const mockAppointmentDetails = {
+		nextAppointment: {
+			id: 1,
+			begin_timestamp: 2,
+			end_timestamp: 3,
+		},
+	};
+
+	const requestAction = {
+		type: CONCIERGE_INITIAL_REQUEST,
+	};
+
+	const updateAction = {
+		type: CONCIERGE_INITIAL_UPDATE,
+		initial: mockAppointmentDetails,
+	};
+
+	describe( 'nextAppointment', () => {
+		test( 'should default to null.', () => {
+			expect( nextAppointment( undefined, {} ) ).toBeNull();
+		} );
+
+		test( 'should be null on receiving the request action.', () => {
+			const state = mockAppointmentDetails;
+			expect( nextAppointment( state, requestAction ) ).toBeNull();
+		} );
+
+		test( 'should be the next appointment data on receiving the update action.', () => {
+			const state = [];
+			expect( nextAppointment( state, updateAction ) ).toEqual(
+				mockAppointmentDetails.nextAppointment
+			);
+		} );
+	} );
+} );

--- a/client/state/concierge/reducer.js
+++ b/client/state/concierge/reducer.js
@@ -6,10 +6,12 @@
 import { combineReducers } from 'state/utils';
 import appointmentDetails from './appointment-details/reducer';
 import availableTimes from './available-times/reducer';
+import nextAppointment from './next-appointment/reducer';
 import signupForm from './signup-form/reducer';
 
 export default combineReducers( {
 	appointmentDetails,
 	availableTimes,
+	nextAppointment,
 	signupForm,
 } );


### PR DESCRIPTION
Finishes off the changes required to use the `initial` endpoint introduced in `D15118-code`.

This adds:

- The new component, `QueryConciergeInitial`, that will cause the endpoint to be requested.
- The `nextAppointment` reducer, which will specify how the state changes when the corresponding actions are called.

It also modifies the `availableTimes` reducer to describe the state changes required when available times are received from `initial`.

Replaces #25909.

## Testing
To test the correct endpoint is being used, and the correct data is being used:

1. Navigate to `/me/concierge` - `/concierge/schedules/{schedule id}/initial` should be requested and `/concierge/schedules/{schedule id}/available_times` should not.
2. Click through to the second booking step, available sessions should be displayed as normal.

To test the next appointment is retrieved correctly:

1. Book an appointment.
2. Go to `me/concierge` and inspect the state using a tool such as [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en). The value for `concierge.nextAppointment` should be populated.
