### PR TITLE
Reader: make getOffsetItem selector aware of x-posts

### DIFF
--- a/client/reader/xpost-helper.js
+++ b/client/reader/xpost-helper.js
@@ -50,8 +50,8 @@ const exported = {
 					}
 				} else if ( meta.key === 'xpost_origin' ) {
 					const ids = meta.value.split( ':' );
-					xPostMetadata.blogId = ids[ 0 ];
-					xPostMetadata.postId = ids[ 1 ];
+					xPostMetadata.blogId = +ids[ 0 ];
+					xPostMetadata.postId = +ids[ 1 ];
 				}
 			}
 		}

--- a/client/state/selectors/get-reader-stream-offset-item.js
+++ b/client/state/selectors/get-reader-stream-offset-item.js
@@ -6,15 +6,20 @@
 import { findIndex } from 'lodash';
 
 /**
- * Internal dependencie
+ * Internal dependencies
  */
 import { keysAreEqual } from 'reader/post-key';
 import getCurrentStream from 'state/selectors/get-reader-current-stream';
 
 /*
- * given state, an item, and an offset: return the item that is offset away from the currentItem in the list.
- * For example: in order to get the next item directly after the current one you can do: getOffsetItem( state, currentItem, 1 )
- * If the offset would be out of bounds, this function returns null;
+ * Given state, an item, and an offset: return the item that is offset away from the currentItem in the list.
+ *
+ * For example: in order to get the next item directly after the current one you can do: getOffsetItem( state, currentItem, 1 ).
+ *
+ * @param  {object} Redux state
+ * @param  {object} Current stream item
+ * @param  {integer} Offset from current stream item (e.g. -1 for previous item)
+ * @return {object|null} The stream item, or null if the offset would be out of bounds
  */
 function getOffsetItem( state, currentItem, offset ) {
 	const streamKey = getCurrentStream( state );
@@ -23,7 +28,13 @@ function getOffsetItem( state, currentItem, offset ) {
 	}
 
 	const stream = state.reader.streams[ streamKey ];
-	const index = findIndex( stream.items, item => keysAreEqual( item, currentItem ) );
+	let index = findIndex( stream.items, item => keysAreEqual( item, currentItem ) );
+
+	// If we didn't find a match, check x-posts too
+	if ( index < 0 ) {
+		index = findIndex( stream.items, item => keysAreEqual( item.xPostMetadata, currentItem ) );
+	}
+
 	const newIndex = index + offset;
 
 	if ( newIndex >= 0 && newIndex < stream.items.length ) {

--- a/client/state/selectors/get-reader-stream-offset-item.js
+++ b/client/state/selectors/get-reader-stream-offset-item.js
@@ -35,13 +35,24 @@ function getOffsetItem( state, currentItem, offset ) {
 		index = findIndex( stream.items, item => keysAreEqual( item.xPostMetadata, currentItem ) );
 	}
 
-	const newIndex = index + offset;
-
-	if ( newIndex >= 0 && newIndex < stream.items.length ) {
-		return stream.items[ newIndex ];
+	if ( index < 0 ) {
+		return null;
 	}
 
-	return null;
+	const newIndex = index + offset;
+
+	if ( newIndex < 0 || newIndex >= stream.items.length ) {
+		return null;
+	}
+
+	const offsetItem = stream.items[ newIndex ];
+
+	// If the item is an x-post, return the original post details
+	if ( offsetItem && offsetItem.xPostMetadata ) {
+		return offsetItem.xPostMetadata;
+	}
+
+	return offsetItem;
 }
 
 export default getOffsetItem;

--- a/client/state/selectors/get-reader-stream-prev-item.js
+++ b/client/state/selectors/get-reader-stream-prev-item.js
@@ -1,11 +1,7 @@
 /** @format */
 
 /**
- * External dependencies
- */
-
-/**
- * Internal dependencie
+ * Internal dependencies
  */
 import getReaderStreamOffsetItem from 'state/selectors/get-reader-stream-offset-item';
 

--- a/client/state/selectors/test/get-reader-stream-offset-item.js
+++ b/client/state/selectors/test/get-reader-stream-offset-item.js
@@ -1,11 +1,11 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import freeze from 'deep-freeze';
+import deepFreeze from 'deep-freeze';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import getOffsetItem from 'state/selectors/get-reader-stream-offset-item';
 
@@ -16,17 +16,19 @@ jest.mock( 'state/selectors/get-reader-follows' );
 const postKey1 = { postId: 1, feedId: 1 };
 const postKey2 = { postId: 1, blogId: 1 };
 const postKey3 = { postId: 2, feedId: 1 };
+const postKey4 = { postId: 1, feedId: 4, xPostMetadata: { blogId: 123, postId: 456 } };
+const postKey5 = { postId: 2, feedId: 4 };
 
 const currentStream = { ui: { reader: { currentStream: 'following' } } };
 
 describe( 'getOffsetItem', () => {
 	test( 'should return null when not given a currentItem', () => {
-		const state = freeze( { reader: { streams: {} }, ...currentStream } );
+		const state = deepFreeze( { reader: { streams: {} }, ...currentStream } );
 		expect( getOffsetItem( state ) ).toBe( null );
 	} );
 
 	test( 'should return null for out of bounds', () => {
-		const state = freeze( {
+		const state = deepFreeze( {
 			reader: { streams: { following: { items: [ postKey1 ] } } },
 			...currentStream,
 		} );
@@ -35,11 +37,25 @@ describe( 'getOffsetItem', () => {
 	} );
 
 	test( 'should return items offset by one in either direction', () => {
-		const state = freeze( {
+		const state = deepFreeze( {
 			reader: { streams: { following: { items: [ postKey1, postKey2, postKey3 ] } } },
 			...currentStream,
 		} );
 		expect( getOffsetItem( state, postKey2, 1 ) ).toBe( postKey3 );
 		expect( getOffsetItem( state, postKey2, -1 ) ).toBe( postKey1 );
+	} );
+
+	test( 'should return items offset by one in either direction for a x-post', () => {
+		const state = deepFreeze( {
+			reader: {
+				streams: {
+					following: { items: [ postKey1, postKey2, postKey3, postKey4, postKey5 ] },
+				},
+			},
+			...currentStream,
+		} );
+		const xPostKey = { blogId: 123, postId: 456 };
+		expect( getOffsetItem( state, xPostKey, 1 ) ).toBe( postKey5 );
+		expect( getOffsetItem( state, xPostKey, -1 ) ).toBe( postKey3 );
 	} );
 } );

--- a/client/state/selectors/test/get-reader-stream-offset-item.js
+++ b/client/state/selectors/test/get-reader-stream-offset-item.js
@@ -58,4 +58,16 @@ describe( 'getOffsetItem', () => {
 		expect( getOffsetItem( state, xPostKey, 1 ) ).toBe( postKey5 );
 		expect( getOffsetItem( state, xPostKey, -1 ) ).toBe( postKey3 );
 	} );
+
+	test( 'should return the x-post details if the offset item is a x-post', () => {
+		const state = deepFreeze( {
+			reader: {
+				streams: {
+					following: { items: [ postKey1, postKey2, postKey3, postKey4, postKey5 ] },
+				},
+			},
+			...currentStream,
+		} );
+		expect( getOffsetItem( state, postKey3, 1 ) ).toEqual( postKey4.xPostMetadata );
+	} );
 } );


### PR DESCRIPTION
The `getOffsetItem` selector is used in Reader full post to decide what the previous and next items in the stream are. We use this information to make the <kdb>j</kdb> and <kdb>k</kdb> keyboard shortcuts work in full post.

X-posts currently break these keyboard shortcuts, because we open the original post in full post view rather than the x-post itself. `getOffsetItem` then cannot find the previous and next posts because it's using the blog ID and post ID of the _original_ post rather than the x-post.

Dependent upon the merge of https://github.com/Automattic/wp-calypso/pull/25823, which adds xPostMetadata to post keys.

Discussed in p5PDj3-4z8-p2.