### PR TITLE
Add simple payments banner

### DIFF
--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -3,19 +3,32 @@
 /**
  * Internal dependencies
  */
-import { TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM } from 'lib/plans/constants';
+import { GROUP_JETPACK, GROUP_WPCOM, TYPE_FREE, TYPE_PREMIUM } from 'lib/plans/constants';
 
 /**
  * No translate() used in this file since we're launching those promotions just for the EN audience
  */
 export default [
 	{
-		name: 'june_2018',
-		startsAt: new Date( 2018, 4, 26, 0, 0, 0 ),
-		endsAt: new Date( 2018, 5, 30, 23, 59, 59 ),
-		nudgeText: '20% Off All Plans',
-		nudgeEndsTodayText: '20% Off (Ends Today)',
-		plansPageNoticeText: 'Enter coupon code “JUNE20” during checkout to claim your 20% discount',
-		targetPlans: [ { type: TYPE_FREE }, { type: TYPE_PERSONAL }, { type: TYPE_PREMIUM } ],
+		name: 'simple_payments_wpcom',
+		startsAt: new Date( 2018, 6, 9, 0, 0, 0 ),
+		endsAt: new Date( 2018, 8, 9, 23, 59, 59 ),
+		plansPageNoticeText:
+			'Upgrade to a Premium or Business plan today and start collecting payments with the Simple Payments button!',
+		targetPlans: [
+			{ type: TYPE_FREE, group: GROUP_WPCOM },
+			{ type: TYPE_PREMIUM, group: GROUP_WPCOM },
+		],
+	},
+	{
+		name: 'simple_payments_jetpack',
+		startsAt: new Date( 2018, 6, 9, 0, 0, 0 ),
+		endsAt: new Date( 2018, 8, 9, 23, 59, 59 ),
+		plansPageNoticeText:
+			'Upgrade to a Premium or Professional plan today and start collecting payments with the Simple Payments button!',
+		targetPlans: [
+			{ type: TYPE_FREE, group: GROUP_JETPACK },
+			{ type: TYPE_PREMIUM, group: GROUP_JETPACK },
+		],
 	},
 ];

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -117,10 +117,15 @@ class SiteNotice extends React.Component {
 
 		const { site, activeDiscount } = this.props;
 		const { nudgeText, nudgeEndsTodayText, ctaText, name } = activeDiscount;
+
 		const bannerText =
 			nudgeEndsTodayText && this.promotionEndsToday( activeDiscount )
 				? nudgeEndsTodayText
 				: nudgeText;
+
+		if ( ! bannerText ) {
+			return null;
+		}
 
 		return (
 			<SidebarBanner


### PR DESCRIPTION
This adds the banner to the plans page for the simple payments button promotion.

Note that the active discounts api response must already return the 'simple_payments_wpcom' or 'simple_payments_jetpack'.

The `/plans/<site>/?discount=simple_payments_wpcom` and `/plans/<site>/?discount=simple_payments_jetpack` routes will then show the banner.

