### PR TITLE
Purchases: Manage for disconnected sites :: Take 3

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -11,7 +11,13 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { isDomainRegistration, isDomainTransfer, isPlan, isTheme } from 'lib/products-values';
+import {
+	isDomainRegistration,
+	isDomainTransfer,
+	isJetpackPlan,
+	isPlan,
+	isTheme,
+} from 'lib/products-values';
 
 function getIncludedDomain( purchase ) {
 	return purchase.includedDomain;
@@ -173,6 +179,7 @@ function isRemovable( purchase ) {
 	}
 
 	return (
+		isJetpackPlan( purchase ) ||
 		isExpiring( purchase ) ||
 		isExpired( purchase ) ||
 		( isDomainTransfer( purchase ) &&

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -154,6 +154,11 @@ export function managePurchase( context, next ) {
 
 	setTitle( context, titles.managePurchase );
 
-	context.primary = <ManagePurchase purchaseId={ parseInt( context.params.purchaseId, 10 ) } />;
+	context.primary = (
+		<ManagePurchase
+			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+			siteSlug={ context.params.site }
+		/>
+	);
 	next();
 }

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -78,11 +78,14 @@ export default function( router ) {
 		clientRender
 	);
 
+	/**
+	 * The siteSelection middleware has been removed from this root.
+	 * No selected site!
+	 */
 	router(
 		paths.managePurchase( ':site', ':purchaseId' ),
 		redirectLoggedOut,
 		sidebar,
-		siteSelection,
 		controller.managePurchase,
 		makeLayout,
 		clientRender

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -79,7 +79,7 @@ export default function( router ) {
 	);
 
 	/**
-	 * The siteSelection middleware has been removed from this root.
+	 * The siteSelection middleware has been removed from this route.
 	 * No selected site!
 	 */
 	router(

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -40,7 +40,6 @@ import {
 import { canEditPaymentDetails, getEditCardDetailsPath, isDataLoading } from '../utils';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getCanonicalTheme } from 'state/themes/selectors';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import isSiteAtomic from 'state/selectors/is-site-automated-transfer';
 import Gridicon from 'gridicons';
 import HeaderCake from 'components/header-cake';
@@ -55,7 +54,7 @@ import {
 	isDomainTransfer,
 	isTheme,
 } from 'lib/products-values';
-import { isRequestingSites } from 'state/sites/selectors';
+import { getSite, isRequestingSites } from 'state/sites/selectors';
 import Main from 'components/main';
 import PlanIcon from 'components/plans/plan-icon';
 import PlanPrice from 'my-sites/plan-price';
@@ -80,8 +79,11 @@ class ManagePurchase extends Component {
 	static propTypes = {
 		hasLoadedSites: PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
+		isAtomicSite: PropTypes.bool,
 		purchase: PropTypes.object,
-		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
+		site: PropTypes.object,
+		siteId: PropTypes.number,
+		siteSlug: PropTypes.string.isRequired,
 		userId: PropTypes.number,
 	};
 
@@ -135,7 +137,7 @@ class ManagePurchase extends Component {
 
 		addItems( renewItems );
 
-		page( '/checkout/' + this.props.selectedSite.slug );
+		page( '/checkout/' + this.props.siteSlug );
 	};
 
 	renderRenewButton() {
@@ -149,7 +151,7 @@ class ManagePurchase extends Component {
 			! isRenewable( purchase ) ||
 			isExpired( purchase ) ||
 			isExpiring( purchase ) ||
-			! this.props.selectedSite
+			! this.props.site
 		) {
 			return null;
 		}
@@ -161,24 +163,15 @@ class ManagePurchase extends Component {
 		);
 	}
 
-	renderPlanDetails() {
-		return (
-			<PurchasePlanDetails
-				selectedSite={ this.props.selectedSite }
-				purchaseId={ this.props.purchaseId }
-			/>
-		);
-	}
-
 	renderEditPaymentMethodNavItem() {
 		const { purchase, translate } = this.props;
 
-		if ( ! this.props.selectedSite ) {
+		if ( ! this.props.site ) {
 			return null;
 		}
 
 		if ( canEditPaymentDetails( purchase ) ) {
-			const path = getEditCardDetailsPath( this.props.selectedSite.slug, purchase );
+			const path = getEditCardDetailsPath( this.props.siteSlug, purchase );
 			const renewing = isRenewing( purchase );
 
 			if (
@@ -201,7 +194,7 @@ class ManagePurchase extends Component {
 		const { isAtomicSite, purchase, translate } = this.props;
 		const { id } = purchase;
 
-		if ( ! isCancelable( purchase ) || ! this.props.selectedSite ) {
+		if ( ! isCancelable( purchase ) || ! this.props.site ) {
 			return null;
 		}
 
@@ -214,7 +207,7 @@ class ManagePurchase extends Component {
 		};
 
 		let text,
-			link = cancelPurchase( this.props.selectedSite.slug, id );
+			link = cancelPurchase( this.props.siteSlug, id );
 
 		if ( isAtomicSite && isSubscription( purchase ) ) {
 			text = translate( 'Contact Support to Cancel your Subscription' );
@@ -261,16 +254,12 @@ class ManagePurchase extends Component {
 		const { purchase, translate } = this.props;
 		const { id } = purchase;
 
-		if (
-			isExpired( purchase ) ||
-			! hasPrivacyProtection( purchase ) ||
-			! this.props.selectedSite
-		) {
+		if ( isExpired( purchase ) || ! hasPrivacyProtection( purchase ) || ! this.props.site ) {
 			return null;
 		}
 
 		return (
-			<CompactCard href={ cancelPrivacyProtection( this.props.selectedSite.slug, id ) }>
+			<CompactCard href={ cancelPrivacyProtection( this.props.siteSlug, id ) }>
 				{ translate( 'Cancel Privacy Protection' ) }
 			</CompactCard>
 		);
@@ -306,7 +295,7 @@ class ManagePurchase extends Component {
 	}
 
 	renderPlanDescription() {
-		const { plan, purchase, selectedSite, theme, translate } = this.props;
+		const { plan, purchase, site, theme, translate } = this.props;
 
 		let description = purchaseType( purchase );
 		if ( isPlan( purchase ) ) {
@@ -319,7 +308,7 @@ class ManagePurchase extends Component {
 					'making it easier to remember and easier to share.',
 				{
 					args: {
-						domain: selectedSite.domain,
+						domain: purchase.domain,
 					},
 				}
 			);
@@ -334,7 +323,7 @@ class ManagePurchase extends Component {
 			<div className="manage-purchase__content">
 				<span className="manage-purchase__description">{ description }</span>
 				<span className="manage-purchase__settings-link">
-					<ProductLink purchase={ purchase } selectedSite={ selectedSite } />
+					<ProductLink purchase={ purchase } selectedSite={ site } />
 				</span>
 			</div>
 		);
@@ -355,11 +344,9 @@ class ManagePurchase extends Component {
 						<span className="manage-purchase__settings-link" />
 					</div>
 
-					<PurchaseMeta purchaseId={ false } />
+					<PurchaseMeta purchaseId={ false } siteSlug={ this.props.siteSlug } />
 				</Card>
-
-				{ this.renderPlanDetails() }
-
+				<PurchasePlanDetails />
 				<VerticalNavItem isPlaceholder />
 				<VerticalNavItem isPlaceholder />
 			</Fragment>
@@ -371,7 +358,7 @@ class ManagePurchase extends Component {
 			return this.renderPlaceholder();
 		}
 
-		const { purchase, selectedSiteId, selectedSite } = this.props;
+		const { purchase, siteId, site } = this.props;
 		const classes = classNames( 'manage-purchase__info', {
 			'is-expired': purchase && isExpired( purchase ),
 			'is-personal': isPersonal( purchase ),
@@ -383,7 +370,7 @@ class ManagePurchase extends Component {
 
 		return (
 			<Fragment>
-				<PurchaseSiteHeader siteId={ selectedSiteId } name={ siteName } domain={ siteDomain } />
+				<PurchaseSiteHeader siteId={ siteId } name={ siteName } domain={ siteDomain } />
 				<Card className={ classes }>
 					<header className="manage-purchase__header">
 						{ this.renderPlanIcon() }
@@ -395,21 +382,18 @@ class ManagePurchase extends Component {
 					</header>
 					{ this.renderPlanDescription() }
 
-					<PurchaseMeta purchaseId={ purchase.id } />
+					<PurchaseMeta purchaseId={ purchase.id } siteSlug={ this.props.siteSlug } />
 
 					{ this.renderRenewButton() }
 				</Card>
-
-				{ this.renderPlanDetails() }
-
+				<PurchasePlanDetails purchaseId={ this.props.purchaseId } />
 				{ this.renderEditPaymentMethodNavItem() }
 				{ this.renderCancelPurchaseNavItem() }
 				{ this.renderCancelPrivacyProtection() }
-
 				<RemovePurchase
 					hasLoadedSites={ this.props.hasLoadedSites }
 					hasLoadedUserPurchasesFromServer={ this.props.hasLoadedUserPurchasesFromServer }
-					selectedSite={ selectedSite }
+					site={ site }
 					purchase={ purchase }
 				/>
 			</Fragment>
@@ -420,12 +404,12 @@ class ManagePurchase extends Component {
 		if ( ! this.isDataValid() ) {
 			return null;
 		}
-		const { selectedSite, selectedSiteId, purchase, isPurchaseTheme } = this.props;
+		const { site, siteId, siteSlug, purchase, isPurchaseTheme } = this.props;
 		const classes = 'manage-purchase';
 
 		let editCardDetailsPath = false;
-		if ( ! isDataLoading( this.props ) && selectedSite && canEditPaymentDetails( purchase ) ) {
-			editCardDetailsPath = getEditCardDetailsPath( selectedSite.slug, purchase );
+		if ( ! isDataLoading( this.props ) && site && canEditPaymentDetails( purchase ) ) {
+			editCardDetailsPath = getEditCardDetailsPath( siteSlug, purchase );
 		}
 
 		return (
@@ -439,15 +423,13 @@ class ManagePurchase extends Component {
 					title="Purchases > Manage Purchase"
 				/>
 				<QueryUserPurchases userId={ this.props.userId } />
-				{ isPurchaseTheme && (
-					<QueryCanonicalTheme siteId={ selectedSiteId } themeId={ purchase.meta } />
-				) }
+				{ isPurchaseTheme && <QueryCanonicalTheme siteId={ siteId } themeId={ purchase.meta } /> }
 				<Main className={ classes }>
 					<HeaderCake backHref={ purchasesRoot }>{ titles.managePurchase }</HeaderCake>
 					<PurchaseNotice
 						isDataLoading={ isDataLoading( this.props ) }
 						handleRenew={ this.handleRenew }
-						selectedSite={ selectedSite }
+						selectedSite={ site }
 						purchase={ purchase }
 						editCardDetailsPath={ editCardDetailsPath }
 					/>
@@ -460,20 +442,21 @@ class ManagePurchase extends Component {
 
 export default connect( ( state, props ) => {
 	const purchase = getByPurchaseId( state, props.purchaseId );
-	const selectedSiteId = getSelectedSiteId( state );
+	const siteId = purchase ? purchase.siteId : null;
 	const isPurchasePlan = purchase && isPlan( purchase );
 	const isPurchaseTheme = purchase && isTheme( purchase );
-	const selectedSite = getSelectedSite( state );
+	const site = getSite( state, siteId );
+	const hasLoadedSites = ! isRequestingSites( state );
 	return {
-		hasLoadedSites: ! isRequestingSites( state ),
+		hasLoadedSites,
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		purchase,
-		selectedSiteId,
-		selectedSite,
+		siteId,
+		site,
 		plan: isPurchasePlan && applyTestFiltersToPlansList( purchase.productSlug, abtest ),
 		isPurchaseTheme,
-		theme: isPurchaseTheme && getCanonicalTheme( state, selectedSiteId, purchase.meta ),
-		isAtomicSite: selectedSite && isSiteAtomic( state, selectedSiteId ),
+		theme: isPurchaseTheme && getCanonicalTheme( state, siteId, purchase.meta ),
+		isAtomicSite: isSiteAtomic( state, siteId ),
 		userId: getCurrentUserId( state ),
 	};
 } )( localize( ManagePurchase ) );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -74,6 +74,7 @@ import { addItems } from 'lib/upgrades/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import TrackPurchasePageView from 'me/purchases/track-purchase-page-view';
 import { getCurrentUserId } from 'state/current-user/selectors';
+import CartStore from 'lib/cart/store';
 
 class ManagePurchase extends Component {
 	static propTypes = {
@@ -94,10 +95,22 @@ class ManagePurchase extends Component {
 		}
 	}
 
+	componentDidMount() {
+		if ( this.props.siteId ) {
+			CartStore.setSelectedSiteId( this.props.siteId );
+		}
+	}
+
 	componentWillReceiveProps( nextProps ) {
 		if ( this.isDataValid() && ! this.isDataValid( nextProps ) ) {
 			page.redirect( purchasesRoot );
 			return;
+		}
+	}
+
+	componentDidUpdate( { siteId } ) {
+		if ( this.props.siteId && siteId !== this.props.siteId ) {
+			CartStore.setSelectedSiteId( this.props.siteId );
 		}
 	}
 

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -171,7 +171,7 @@ class PurchaseItem extends Component {
 	}
 
 	render() {
-		const { isPlaceholder, isDisconnectedSite, purchase } = this.props;
+		const { isPlaceholder, isDisconnectedSite, purchase, isJetpack } = this.props;
 		const classes = classNames(
 			'purchase-item',
 			{ 'is-expired': purchase && 'expired' === purchase.expiryStatus },
@@ -195,19 +195,19 @@ class PurchaseItem extends Component {
 			);
 		}
 
-		let props;
+		let onClick;
+		let href;
 		if ( ! isPlaceholder ) {
-			props = {
-				onClick: this.scrollToTop,
-			};
-
-			if ( ! isDisconnectedSite ) {
-				props.href = managePurchase( this.props.slug, this.props.purchase.id );
+			// A "disconnected" Jetpack site's purchases may be managed.
+			// A "disconnected" WordPress.com site may not (the user has been removed).
+			if ( ! isDisconnectedSite || isJetpack ) {
+				onClick = this.scrollToTop;
+				href = managePurchase( this.props.slug, this.props.purchase.id );
 			}
 		}
 
 		return (
-			<CompactCard className={ classes } { ...props }>
+			<CompactCard className={ classes } onClick={ onClick } href={ href }>
 				{ content }
 			</CompactCard>
 		);
@@ -219,6 +219,7 @@ PurchaseItem.propTypes = {
 	isDisconnectedSite: PropTypes.bool,
 	purchase: PropTypes.object,
 	slug: PropTypes.string,
+	isJetpack: PropTypes.bool,
 };
 
 export default localize( PurchaseItem );

--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -32,6 +32,8 @@ const PurchasesSite = ( {
 } ) => {
 	let items;
 
+	const isJetpack = ! isPlaceholder && some( purchases, purchase => isJetpackPlan( purchase ) );
+
 	if ( isPlaceholder ) {
 		items = times( 2, index => <PurchaseItem isPlaceholder key={ index } /> );
 	} else {
@@ -41,11 +43,10 @@ const PurchasesSite = ( {
 				slug={ slug }
 				isDisconnectedSite={ ! site }
 				purchase={ purchase }
+				isJetpack={ isJetpack }
 			/>
 		) );
 	}
-
-	const isJetpack = some( purchases, purchase => isJetpackPlan( purchase ) );
 
 	return (
 		<div className={ classNames( 'purchases-site', { 'is-placeholder': isPlaceholder } ) }>
@@ -59,9 +60,9 @@ const PurchasesSite = ( {
 
 			{ items }
 
-			{ ! isPlaceholder && hasLoadedSite && ! site ? (
-				<PurchaseReconnectNotice isJetpack={ isJetpack } name={ name } domain={ domain } />
-			) : null }
+			{ ! isPlaceholder &&
+				hasLoadedSite &&
+				! site && <PurchaseReconnectNotice isJetpack={ isJetpack } name={ name } /> }
 		</div>
 	);
 };

--- a/client/me/purchases/purchases-site/reconnect-notice.jsx
+++ b/client/me/purchases/purchases-site/reconnect-notice.jsx
@@ -13,34 +13,35 @@ import React, { Component } from 'react';
  */
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
-import { CALYPSO_CONTACT, JETPACK_CONTACT_SUPPORT } from 'lib/url/support';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 
 class PurchaseReconnectNotice extends Component {
 	static propTypes = {
 		name: PropTypes.string,
-		domain: PropTypes.string,
+		translate: PropTypes.func.isRequired,
 	};
 
 	render() {
 		const { translate, name, isJetpack } = this.props;
-		let text = translate( 'You are no longer a user on %(site)s and cannot manage this purchase.', {
-			args: {
-				site: name,
-			},
-		} );
-		if ( isJetpack ) {
-			text = translate( '%(site)s has been disconnected from WordPress.com.', {
-				args: {
-					site: name,
-				},
-			} );
-		}
+
+		const text = isJetpack
+			? translate( '%(site)s has been disconnected from WordPress.com.', {
+					args: {
+						site: name,
+					},
+			  } )
+			: translate( 'You are no longer a user on %(site)s and cannot manage this purchase.', {
+					args: {
+						site: name,
+					},
+			  } );
 
 		return (
 			<Notice showDismiss={ false } status="is-error" text={ text }>
-				<NoticeAction href={ isJetpack ? JETPACK_CONTACT_SUPPORT : CALYPSO_CONTACT }>
-					{ translate( 'Contact Support' ) }
-				</NoticeAction>
+				{ /* Disconnected Jetpack sites can remove purchases. No need to contact support */
+				! isJetpack && (
+					<NoticeAction href={ CALYPSO_CONTACT }>{ translate( 'Contact Support' ) }</NoticeAction>
+				) }
 			</Notice>
 		);
 	}

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -28,7 +28,13 @@ import previousStep from 'components/marketing-survey/cancel-purchase-form/previ
 import { INITIAL_STEP, FINAL_STEP } from 'components/marketing-survey/cancel-purchase-form/steps';
 import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'lib/purchases';
 import { isDataLoading } from '../utils';
-import { isDomainRegistration, isPlan, isBusiness, isGoogleApps } from 'lib/products-values';
+import {
+	isBusiness,
+	isDomainRegistration,
+	isGoogleApps,
+	isJetpackPlan,
+	isPlan,
+} from 'lib/products-values';
 import notices from 'notices';
 import { purchasesRoot } from '../paths';
 import { getPurchasesError } from 'state/purchases/selectors';
@@ -58,7 +64,7 @@ class RemovePurchase extends Component {
 		receiveDeletedSite: PropTypes.func.isRequired,
 		removePurchase: PropTypes.func.isRequired,
 		purchase: PropTypes.object,
-		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
+		site: PropTypes.object,
 		setAllSitesSelected: PropTypes.func.isRequired,
 		userId: PropTypes.number.isRequired,
 	};
@@ -156,12 +162,12 @@ class RemovePurchase extends Component {
 	removePurchase = closeDialog => {
 		this.setState( { isRemoving: true } );
 
-		const { isDomainOnlySite, purchase, selectedSite, translate } = this.props;
+		const { isDomainOnlySite, purchase, site, translate } = this.props;
 
 		if ( ! isDomainRegistration( purchase ) && config.isEnabled( 'upgrades/removal-survey' ) ) {
 			const survey = wpcom
 				.marketing()
-				.survey( 'calypso-remove-purchase', this.props.selectedSite.ID );
+				.survey( 'calypso-remove-purchase', this.props.purchase.siteId );
 			const surveyData = {
 				'why-cancel': {
 					response: this.state.survey.questionOneRadio,
@@ -175,7 +181,7 @@ class RemovePurchase extends Component {
 				type: 'remove',
 			};
 
-			survey.addResponses( enrichedSurveyData( surveyData, moment(), selectedSite, purchase ) );
+			survey.addResponses( enrichedSurveyData( surveyData, moment(), site, purchase ) );
 
 			debug( 'Survey responses', survey );
 			survey
@@ -204,7 +210,7 @@ class RemovePurchase extends Component {
 			} else {
 				if ( isDomainRegistration( purchase ) ) {
 					if ( isDomainOnlySite ) {
-						this.props.receiveDeletedSite( selectedSite.ID );
+						this.props.receiveDeletedSite( purchase.siteId );
 						this.props.setAllSitesSelected();
 					}
 
@@ -218,7 +224,7 @@ class RemovePurchase extends Component {
 					notices.success(
 						translate( '%(productName)s was removed from {{siteName/}}.', {
 							args: { productName },
-							components: { siteName: <em>{ selectedSite.domain }</em> },
+							components: { siteName: <em>{ purchase.domain }</em> },
 						} ),
 						{ persistent: true }
 					);
@@ -293,7 +299,7 @@ class RemovePurchase extends Component {
 	}
 
 	renderPlanDialog() {
-		const { purchase, selectedSite, translate } = this.props;
+		const { purchase, site, translate } = this.props;
 		const buttons = {
 			cancel: {
 				action: 'cancel',
@@ -352,7 +358,7 @@ class RemovePurchase extends Component {
 					defaultContent={ this.renderPlanDialogText() }
 					onInputChange={ this.onSurveyChange }
 					purchase={ purchase }
-					selectedSite={ selectedSite }
+					selectedSite={ site }
 					showSurvey={ config.isEnabled( 'upgrades/removal-survey' ) }
 					surveyStep={ this.state.surveyStep }
 				/>
@@ -378,7 +384,7 @@ class RemovePurchase extends Component {
 				<p>
 					{ translate( 'Are you sure you want to remove %(productName)s from {{siteName/}}?', {
 						args: { productName },
-						components: { siteName: <em>{ this.props.selectedSite.domain }</em> },
+						components: { siteName: <em>{ purchase.domain }</em> },
 					} ) }{' '}
 					{ isGoogleApps( purchase )
 						? translate(
@@ -450,7 +456,12 @@ class RemovePurchase extends Component {
 	}
 
 	render() {
-		if ( isDataLoading( this.props ) || ! this.props.selectedSite ) {
+		if ( isDataLoading( this.props ) ) {
+			return null;
+		}
+
+		// If we have a disconnected site that is _not_ a Jetpack purchase, no removal allowed.
+		if ( ! this.props.site && ! this.props.isJetpack ) {
 			return null;
 		}
 
@@ -475,15 +486,19 @@ class RemovePurchase extends Component {
 }
 
 export default connect(
-	( state, { selectedSite } ) => ( {
-		isDomainOnlySite: selectedSite && isDomainOnly( state, selectedSite.ID ),
-		isAutomatedTransferSite: selectedSite && isSiteAutomatedTransfer( state, selectedSite.ID ),
-		isChatAvailable: isHappychatAvailable( state ),
-		isChatActive: hasActiveHappychatSession( state ),
-		purchasesError: getPurchasesError( state ),
-		precancellationChatAvailable: isPrecancellationChatAvailable( state ),
-		userId: getCurrentUserId( state ),
-	} ),
+	( state, { purchase } ) => {
+		const isJetpack = purchase && isJetpackPlan( purchase );
+		return {
+			isDomainOnlySite: purchase && isDomainOnly( state, purchase.siteId ),
+			isAutomatedTransferSite: isSiteAutomatedTransfer( state, purchase.siteId ),
+			isChatAvailable: isHappychatAvailable( state ),
+			isChatActive: hasActiveHappychatSession( state ),
+			isJetpack,
+			purchasesError: getPurchasesError( state ),
+			precancellationChatAvailable: isPrecancellationChatAvailable( state ),
+			userId: getCurrentUserId( state ),
+		};
+	},
 	{
 		receiveDeletedSite,
 		recordTracksEvent,


### PR DESCRIPTION
Third attempt at #25473
Second attempt at #25743

The only difference from #25473 is a fix which allows Jetpack purchases to be removed regardless of their expiration.

The only difference from #25743 is a fix which correctly loads the cart in the absence of the siteSelection middleware (3abdb48fb3b791a4b2a9c7d0b79c52af6b49661f). This was the cause of the error in #25873 which prompted the revert in #25874.

## Testing
Compare results with these branches:

- https://calypso.live/me/purchases/?debug&branch=update/manage-disconnected-site-purchases
- https://calypso.live/me/purchases/?debug&branch=revert-25742-revert-25473-update/no-required-site-manage-purchase

Confirm that you can correctly renew an expired or expiring purchase on [this branch](https://calypso.live/me/purchases/?debug&branch=update/manage-disconnected-site-purchases) where the [previous branch](https://calypso.live/me/purchases/?debug&branch=revert-25742-revert-25473-update/no-required-site-manage-purchase) would error:

![renew](https://user-images.githubusercontent.com/841763/42468056-025823d8-83b4-11e8-8477-9f64c4c40ec5.png)

It's a good idea to clear any redux state and land fresh on the `/me/purchases` page for testing.

---

# Previous PR description reproduced here

Fixes 1642-gh-jpop-issues

A purchase may have been made on a site that is disconnected. Users may wish to remove these purchases and there's no technical limitation for doing so.

Allow the user to mange and remove Jetpack purchases for disconnected sites.

The most notable change is that `siteSelection` route middleware has been removed from the manage purchases (`/me/purchases/:SITE_SLUG/:PURCHASE_ID`) route. No globally selectedSite is available. Instead, we remove the requirement for a selected site, use the `purchase.siteId` to select the site, and treat it as an enhancement when available.

Other changes are included to ensure that components which may be rendered continue to function well in the absence of a site.

## Screens (`/me/purchases`)

Disconnected sites previously had no navigation but scrolled to the top and showed a pointer on hover. After changes:
- Disconnected Jetpack sites navigate to the manage purchase page
- Disconnected WordPress.com sites do not scroll and show the default cursor.

### Disconnected Jetpack

#### Before

![before-jp](https://user-images.githubusercontent.com/841763/41409448-8abf42d4-6fd6-11e8-9f77-4f6b0438894c.png)

#### After
![after-jp](https://user-images.githubusercontent.com/841763/41409368-386328d4-6fd6-11e8-98ae-976d3c8337c7.png)

### Disconnected WordPress.com

#### Before

![before-wp](https://user-images.githubusercontent.com/841763/41409450-8d98daba-6fd6-11e8-9a29-c3ddfcd54307.png)

#### After
![after-wp](https://user-images.githubusercontent.com/841763/41409364-34def9d6-6fd6-11e8-923b-ec78d374bcff.png)

## Screens (`/me/purchases/:SITE_SLUG/:PURCHASE_ID`)

From the manage purchase page, you should be able to remove a Jetpack purchase, but not a WordPress.com purchase for disconnected sites.

### Jetpack 

![removal](https://user-images.githubusercontent.com/841763/41410755-bca78eec-6fda-11e8-90e2-b3f9e5d571cf.png)

### WordPress.com (removal not rendered)

_Note: There is no existing navigation to this view I'm aware of._

![missing](https://user-images.githubusercontent.com/841763/41410748-bb50895e-6fda-11e8-90ad-b76b7fae107c.png)


## Testing
1. Verify that management and removal existing purchases continue to work as before.
1. Try to remove a purchase for a disconnected site:
   1. Connect a new Jetpack site.
   1. Purchase a plan.
   1. Disconnect the Jetpack site.
   1. Go to purchases, select the purchase and remove it.
1. Repeat with a WordPress.com site:
   1. Create a new site.
   1. Add a second user as an admin.
   1. Purchase a plan as the second user.
   1. Remove the second user from the site.
   1. Try to manage the plan as the second user (`/me/purchases`).
1. Try manually navigating to the management page for these example sites. You'll need to manually modify the URL:
   1. Jetpack site should allow you to remove the purchase.
   1. WordPress.com site should not render a removal link.

---

Supersedes #25586 