### PR TITLE
Checklist: roll out the onboarding checklist to 100% blog users.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -67,24 +67,6 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
-	checklistThankYouForFreeUser: {
-		datestamp: '20171204',
-		variations: {
-			show: 50,
-			hide: 50,
-		},
-		defaultVariation: 'hide',
-		allowExistingUsers: true,
-	},
-	checklistThankYouForPaidUser: {
-		datestamp: '20171204',
-		variations: {
-			show: 50,
-			hide: 50,
-		},
-		defaultVariation: 'hide',
-		allowExistingUsers: true,
-	},
 	jetpackSignupGoogleTop: {
 		datestamp: '20180427',
 		variations: {

--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -24,8 +24,9 @@ import QuerySiteChecklist from 'components/data/query-site-checklist';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite, getSiteSlug } from 'state/sites/selectors';
+import { isJetpackSite, isNewSite, getSiteSlug } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
+import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
 
 class ChecklistMain extends PureComponent {
 	componentDidMount() {
@@ -61,10 +62,10 @@ class ChecklistMain extends PureComponent {
 		}
 	}
 
-	getHeaderTitle( displayMode ) {
-		const { translate } = this.props;
+	getHeaderTitle() {
+		const { translate, siteHasFreePlan } = this.props;
 
-		if ( displayMode === 'free' ) {
+		if ( siteHasFreePlan ) {
 			return translate( 'Your site has been created!' );
 		}
 
@@ -94,7 +95,7 @@ class ChecklistMain extends PureComponent {
 	}
 
 	renderHeader( completed, displayMode ) {
-		const { translate } = this.props;
+		const { translate, isNewlyCreatedSite } = this.props;
 
 		if ( completed ) {
 			return (
@@ -120,7 +121,7 @@ class ChecklistMain extends PureComponent {
 			);
 		}
 
-		if ( displayMode ) {
+		if ( isNewlyCreatedSite ) {
 			return (
 				<Fragment>
 					<img
@@ -130,7 +131,7 @@ class ChecklistMain extends PureComponent {
 						alt=""
 					/>
 					<FormattedHeader
-						headerText={ this.getHeaderTitle( displayMode ) }
+						headerText={ this.getHeaderTitle() }
 						subHeaderText={ this.getSubHeaderText( displayMode ) }
 					/>
 				</Fragment>
@@ -190,14 +191,18 @@ class ChecklistMain extends PureComponent {
 const mapStateToProps = state => {
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSiteSlug( state, siteId );
+	const siteHasFreePlan = isSiteOnFreePlan( state, siteId );
 	const isAtomic = isSiteAutomatedTransfer( state, siteId );
 	const isJetpack = isJetpackSite( state, siteId );
+	const isNewlyCreatedSite = isNewSite( state, siteId );
 	return {
 		checklistAvailable: ! isAtomic && ( config.isEnabled( 'jetpack/checklist' ) || ! isJetpack ),
 		isAtomic,
 		isJetpack,
+		isNewlyCreatedSite,
 		siteId,
 		siteSlug,
+		siteHasFreePlan,
 		user: getCurrentUser( state ),
 	};
 };

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { get, some } from 'lodash';
 import page from 'page';
 
 /**
@@ -16,11 +17,11 @@ import DocumentHead from 'components/data/document-head';
 import GoogleAppsDialog from 'components/upgrades/google-apps/google-apps-dialog';
 import Main from 'components/main';
 import QuerySites from 'components/data/query-sites';
-import { getSiteSlug, getSiteTitle } from 'state/sites/selectors';
+import { getSiteSlug, getSiteTitle, getSitePlan } from 'state/sites/selectors';
+import { getReceiptById } from 'state/receipts/selectors';
 import { addItem, removeItem } from 'lib/upgrades/actions';
 import { cartItems } from 'lib/cart-values';
-import { isDotComPlan } from 'lib/products-values';
-import { getABTestVariation } from 'lib/abtest';
+import { isDotComPlan, isBusiness } from 'lib/products-values';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 export class GsuiteNudge extends React.Component {
@@ -31,14 +32,13 @@ export class GsuiteNudge extends React.Component {
 	};
 
 	handleClickSkip = () => {
-		const { siteSlug, receiptId } = this.props;
+		const { siteSlug, receiptId, hasDotComBusiness } = this.props;
 
-		// DO NOT assign the test here.
-		if ( 'show' === getABTestVariation( 'checklistThankYouForPaidUser' ) ) {
-			page( `/checklist/${ siteSlug }?d=paid` );
-		} else {
-			page( `/checkout/thank-you/${ siteSlug }/${ receiptId }` );
-		}
+		page(
+			hasDotComBusiness
+				? `/checkout/thank-you/${ siteSlug }/${ receiptId }`
+				: `/checklist/${ siteSlug }`
+		);
 	};
 
 	handleAddGoogleApps = googleAppsCartItem => {
@@ -93,8 +93,18 @@ export class GsuiteNudge extends React.Component {
 }
 
 export default connect( ( state, props ) => {
+	const purchases = get( getReceiptById( state, props.receiptId ), 'data.purchases', [] );
+	const sitePlan = getSitePlan( state, props.selectedSiteId );
+	const hasDotComBusiness =
+		isDotComBusinessPlan( sitePlan ) || some( purchases, isDotComBusinessPlan );
+
 	return {
 		siteSlug: getSiteSlug( state, props.selectedSiteId ),
 		siteTitle: getSiteTitle( state, props.selectedSiteId ),
+		hasDotComBusiness,
 	};
 } )( localize( GsuiteNudge ) );
+
+function isDotComBusinessPlan( product ) {
+	return product && isBusiness( product ) && isDotComPlan( product );
+}

--- a/client/my-sites/stats/checklist-banner/index.jsx
+++ b/client/my-sites/stats/checklist-banner/index.jsx
@@ -27,7 +27,6 @@ import { mergeObjectIntoArrayById } from 'my-sites/checklist/util';
 import ChecklistShowShare from 'my-sites/checklist/share';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
-import { getABTestVariation } from 'lib/abtest';
 
 const storeKeyForNeverShow = 'sitesNeverShowChecklistBanner';
 
@@ -109,13 +108,6 @@ export class ChecklistBanner extends Component {
 		}
 
 		if ( this.props.siteDesignType !== 'blog' ) {
-			return false;
-		}
-
-		if (
-			getABTestVariation( 'checklistThankYouForPaidUser' ) !== 'show' &&
-			getABTestVariation( 'checklistThankYouForFreeUser' ) !== 'show'
-		) {
 			return false;
 		}
 

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -20,7 +20,6 @@ import Notice from 'components/notice';
 import analytics from 'lib/analytics';
 import { showOAuth2Layout } from 'state/ui/oauth2-clients/selectors';
 import config from 'config';
-import { abtest } from 'lib/abtest';
 import { getCurrentUser } from 'state/current-user/selectors';
 
 export class SignupProcessingScreen extends Component {
@@ -286,7 +285,7 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	showChecklistAfterLogin = () => {
-		this.props.loginHandler( { redirectTo: `/checklist/${ this.state.siteSlug }?d=free` } );
+		this.props.loginHandler( { redirectTo: `/checklist/${ this.state.siteSlug }` } );
 	};
 
 	shouldShowChecklist() {
@@ -312,12 +311,7 @@ export class SignupProcessingScreen extends Component {
 			);
 		}
 
-		let clickHandler;
-		if ( this.shouldShowChecklist() && 'show' === abtest( 'checklistThankYouForFreeUser' ) ) {
-			clickHandler = this.showChecklistAfterLogin;
-		} else {
-			clickHandler = loginHandler;
-		}
+		const clickHandler = this.shouldShowChecklist() ? this.showChecklistAfterLogin : loginHandler;
 
 		return (
 			<Button primary className="email-confirmation__button" onClick={ clickHandler }>
@@ -332,8 +326,7 @@ export class SignupProcessingScreen extends Component {
 			! this.props.useOAuth2Layout &&
 			this.props.flowSteps.indexOf( 'domains' ) !== -1 &&
 			this.props.flowSteps.indexOf( 'plans' ) !== -1 &&
-			! this.shouldShowChecklist() &&
-			'show' !== abtest( 'checklistThankYouForFreeUser' )
+			! this.shouldShowChecklist()
 		) {
 			return this.renderUpgradeScreen();
 		}

--- a/client/state/selectors/is-eligible-for-checkout-to-checklist.js
+++ b/client/state/selectors/is-eligible-for-checkout-to-checklist.js
@@ -3,12 +3,12 @@
 /**
  * External dependencies
  */
-import { get, some } from 'lodash';
+import { some } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { getSite } from 'state/sites/selectors';
+import { getSiteOption, isNewSite } from 'state/sites/selectors';
 import { cartItems } from 'lib/cart-values';
 import { isBusiness, isJetpackPlan } from 'lib/products-values';
 import config from 'config';
@@ -20,10 +20,7 @@ import config from 'config';
  * @return {Boolean} True if current user is able to see the checklist after checkout
  */
 export default function isEligibleForCheckoutToChecklist( state, siteId, cart ) {
-	const site = getSite( state, siteId );
-	const designType = get( site, 'options.design_type' );
-	const createdAt = get( site, 'options.created_at' );
-	const isNewSite = createdAt && Date.now() - Date.parse( createdAt ) < 30 * 60000; // within 30 mins
+	const designType = getSiteOption( state, siteId, 'design_type' );
 
 	if ( ! config.isEnabled( 'onboarding-checklist' ) ) {
 		return false;
@@ -38,8 +35,8 @@ export default function isEligibleForCheckoutToChecklist( state, siteId, cart ) 
 	}
 
 	return (
-		isNewSite &&
 		'blog' === designType &&
+		isNewSite( state, siteId ) &&
 		cartItems.hasPlan( cart ) &&
 		! some( cartItems.getAll( cart ), isDotcomBusinessPlan )
 	);


### PR DESCRIPTION
From the @fditrapani's p2 post about this release:
> Despite the lack of significant differences in behavior, we believe that the checklist holds greater potential for engaging and retaining users so we’re going to roll it out to 100% of our customers and begin iterating on it.

See p5XAZ9-1Jk-p2 for more detail.

# How to test

You should be able to see the onboarding checklist in the following cases:
- Create a `blog` type site on the free plan.
  <img width="768" alt="checklist_free" src="https://user-images.githubusercontent.com/212034/42461823-71636d00-83dc-11e8-80e0-dad458d164b5.png">
- Create a `blog` type site on the Personal or Premium plan.
  <img width="768" alt="checklist_paid" src="https://user-images.githubusercontent.com/212034/42461830-78b99e30-83dc-11e8-8b81-9c39748279f8.png">
- Create a `blog` type site on the Personal or Premium plan with G Suite.
  <img width="768" alt="checklist_gsuite-2" src="https://user-images.githubusercontent.com/212034/42461927-c35e8e32-83dc-11e8-851a-b7b63a4014f9.png">

Here, a `blog` type site means a website you create with the `Share ideas, experiences, updates, reviews, stories, videos, or photos` site goal.

The onboarding checklist should not show up when you create a site with another site goal such as `Sell products or collect payments` or when your account is not an English speaker.

*Note*: In my testing, the G suite doesn't work with the `.live` TLD so you may need to pick another TLD.