### PR TITLE
Reader Share: clean up props of SiteSelector component

### DIFF
--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -223,11 +223,8 @@ class ReaderShare extends React.Component {
 						{ this.props.hasSites && (
 							<SiteSelector
 								className="reader-share__site-selector"
-								siteBasePath="/post"
 								onSiteSelect={ this.pickSiteToShareTo }
-								showAddNewSite={ false }
-								indicator={ false }
-								groups={ true }
+								groups
 							/>
 						) }
 					</ReaderPopoverMenu>


### PR DESCRIPTION
The `SiteSelector` component doesn't need the `siteBasePath` prop, because handling the site selection is handled completely by the custom handler whose `handledByHost` return value [is always `true`](https://github.com/Automattic/wp-calypso/blob/82f7c5fbd6905bc99a9638ea9075d7db48a14092/client/blocks/reader-share/index.jsx#L156). The [code path](https://github.com/Automattic/wp-calypso/blob/82f7c5fbd6905bc99a9638ea9075d7db48a14092/client/components/site-selector/index.jsx#L207-L209) that uses `siteBasePath` is never used.

Properties `showAddNewSite` and `indicator` don't need to be specified as their default values are what we want.