### PR TITLE
Domains: Fix duplicated featured domains in the suggestions search results

### DIFF
--- a/client/components/domains/register-domain-step/utility.js
+++ b/client/components/domains/register-domain-step/utility.js
@@ -34,12 +34,10 @@ export function markFeaturedSuggestions(
 	}
 
 	const output = [ ...suggestions ];
+
 	const recommendedSuggestion = featuredSuggestionsAtTop
 		? null
 		: find( output, isExactMatchBeforeTld );
-	const bestAlternativeSuggestion = featuredSuggestionsAtTop
-		? null
-		: find( output, isBestAlternative );
 
 	if ( recommendedSuggestion ) {
 		recommendedSuggestion.isRecommended = true;
@@ -47,6 +45,10 @@ export function markFeaturedSuggestions(
 	} else if ( output.length > 0 ) {
 		output[ 0 ].isRecommended = true;
 	}
+
+	const bestAlternativeSuggestion = featuredSuggestionsAtTop
+		? null
+		: find( output, isBestAlternative );
 
 	if ( bestAlternativeSuggestion ) {
 		bestAlternativeSuggestion.isBestAlternative = true;


### PR DESCRIPTION
If you enter some very specific wordpress.com subdomain in the search field it is very likely to get only exact SLD matches results in the suggestion response. In that case the first featured suggestion will be set to null (because we have no exact match) so the first suggestion will be marked as `isRecommended` and then the second featured suggestion will also be the first suggestion because we call the `find` one after another before we have marked the `isRecommended` on any of the suggestions. So we end up with duplicated featued domain in that case.

So I moved the `bestAlternativeSuggestion` `find` call after we've set the `isRecommended` flag.

To test:
Make sure you use `group_1` as suggestion engine and enter `somethingveryrandom1238723jk.wordpress.com` - you should see two different featured domain suggestions (as opposed to when not using this PR)

Before:
<img width="1010" alt="screen shot 2018-07-09 at 23 09 14" src="https://user-images.githubusercontent.com/1355045/42473420-3ed414ca-83cd-11e8-9524-d3aaf721ee78.png">

After:
<img width="1006" alt="screen shot 2018-07-09 at 23 09 27" src="https://user-images.githubusercontent.com/1355045/42473428-439a3908-83cd-11e8-9e3a-fc075aebdd27.png">

