### PR TITLE
Remove the object-path-immutable dependency

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/service-settings/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/service-settings/reducer.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import objectPath from 'object-path-immutable';
+import { setWith, clone } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,7 +13,7 @@ import { WOOCOMMERCE_SERVICES_SERVICE_SETTINGS_UPDATE_FIELD } from '../action-ty
 const reducers = {};
 
 reducers[ WOOCOMMERCE_SERVICES_SERVICE_SETTINGS_UPDATE_FIELD ] = ( state, action ) => {
-	return objectPath.set( state, action.path, action.value );
+	return setWith( clone( state ), action.path, action.value, clone );
 };
 
 const settings = ( state = {}, action ) => {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1400,7 +1400,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -7226,8 +7225,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7245,13 +7243,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7264,18 +7260,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7378,8 +7371,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7389,7 +7381,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7402,20 +7393,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -7432,7 +7420,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7505,8 +7492,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7516,7 +7502,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7592,8 +7577,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7623,7 +7607,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7641,7 +7624,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7680,13 +7662,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -11177,8 +11157,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -12738,11 +12717,6 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
       "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
-    },
-    "object-path-immutable": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/object-path-immutable/-/object-path-immutable-0.5.3.tgz",
-      "integrity": "sha512-MKKU8uPX+Xa2PlQw7ibOh6Qh8GUxQVd2g/19Ym8bVa04XXSoPebzXoiV+a4298tnDtjDtSwDfcHLjoYmKHSz8Q=="
     },
     "object-visit": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "node-sass": "4.9.0",
     "notifications-panel": "2.1.10",
     "npm-run-all": "4.1.3",
-    "object-path-immutable": "0.5.3",
     "objectpath": "1.2.1",
     "page": "1.8.6",
     "path-browserify": "1.0.0",


### PR DESCRIPTION
For a little bit of code cleanup (pointed out in https://github.com/Automattic/wp-calypso/pull/25595#issuecomment-398434235), I've removed the dependency `object-path-immutable` and replaced it with a `lodash` one-liner equivalent instead.

Alternatively, using `lodash/fp`, the code could be like this, since `lodash/fp` doesn't mutate the data by default:
```js
import { set } from 'lodash/fp';

reducers[ WOOCOMMERCE_SERVICES_SERVICE_SETTINGS_UPDATE_FIELD ] = ( state, action ) => {
    return set( action.path, action.value, state );
}
```
It's cleaner but it can also be more confusing because we almost don't use `lodash/fp` all through Calypso. Thoughts?

To test:
* Go to an USPS or Canada Post shipping method settings (in Calypso).
* Check that the UI is responsive. It would be very obvious if this didn't work, the UI would simply not react to user input.