### PR TITLE
Podcasting: Fix image upload race conditions

### DIFF
--- a/client/my-sites/site-settings/podcast-cover-image-setting/index.jsx
+++ b/client/my-sites/site-settings/podcast-cover-image-setting/index.jsx
@@ -49,6 +49,7 @@ class PodcastCoverImageSetting extends PureComponent {
 		coverImageUrl: PropTypes.string,
 		onRemove: PropTypes.func,
 		onSelect: PropTypes.func,
+		onUploadStateChange: PropTypes.func,
 		isDisabled: PropTypes.bool,
 	};
 
@@ -90,6 +91,7 @@ class PodcastCoverImageSetting extends PureComponent {
 		const transientMediaId = uniqueId( 'podcast-cover-image' );
 
 		this.setState( { transientMediaId } );
+		this.onUploadStateChange( true );
 
 		const checkUploadComplete = () => {
 			// MediaStore tracks pointers from transient media to the persisted
@@ -118,6 +120,7 @@ class PodcastCoverImageSetting extends PureComponent {
 
 			// Remove transient image so that new image shows or if failed upload, the prior image
 			this.setState( { transientMediaId: null } );
+			this.onUploadStateChange( false );
 		};
 
 		MediaStore.on( 'change', checkUploadComplete );
@@ -128,6 +131,11 @@ class PodcastCoverImageSetting extends PureComponent {
 			fileName,
 		} );
 	}
+
+	onUploadStateChange = isUploading => {
+		this.props.onUploadStateChange( isUploading );
+		this.setState( { isUploading } );
+	};
 
 	setCoverImage = ( error, blob ) => {
 		if ( error || ! blob ) {
@@ -186,6 +194,7 @@ class PodcastCoverImageSetting extends PureComponent {
 
 	renderChangeButton() {
 		const { coverImageId, coverImageUrl, translate, isDisabled } = this.props;
+		const { isUploading } = this.state;
 		const isCoverSet = coverImageId || coverImageUrl;
 
 		return (
@@ -194,7 +203,7 @@ class PodcastCoverImageSetting extends PureComponent {
 				compact
 				onClick={ this.showModal }
 				onMouseEnter={ this.preloadModal }
-				disabled={ isDisabled }
+				disabled={ isDisabled || isUploading }
 			>
 				{ isCoverSet ? translate( 'Change' ) : translate( 'Add' ) }
 			</Button>
@@ -203,7 +212,7 @@ class PodcastCoverImageSetting extends PureComponent {
 
 	renderCoverPreview() {
 		const { coverImageUrl, siteId, translate, isDisabled } = this.props;
-		const { transientMediaId } = this.state;
+		const { transientMediaId, isUploading } = this.state;
 		const media = transientMediaId && MediaStore.get( siteId, transientMediaId );
 		const imageUrl = ( media && media.URL ) || coverImageUrl;
 		const imageSrc = imageUrl && resizeImageUrl( imageUrl, 96 );
@@ -221,7 +230,7 @@ class PodcastCoverImageSetting extends PureComponent {
 				onClick={ this.showModal }
 				onMouseEnter={ this.preloadModal }
 				type="button" // default is "submit" which saves settings on click
-				disabled={ isDisabled }
+				disabled={ isDisabled || isUploading }
 			>
 				{ imageSrc ? (
 					<Image className="podcast-cover-image-setting__img" src={ imageSrc } alt="" />
@@ -274,6 +283,7 @@ class PodcastCoverImageSetting extends PureComponent {
 
 	renderRemoveButton() {
 		const { coverImageId, coverImageUrl, onRemove, translate, isDisabled } = this.props;
+		const { isUploading } = this.state;
 		const isCoverSet = coverImageId || coverImageUrl;
 
 		return (
@@ -283,7 +293,7 @@ class PodcastCoverImageSetting extends PureComponent {
 					compact
 					onClick={ onRemove }
 					scary
-					disabled={ isDisabled }
+					disabled={ isDisabled || isUploading }
 				>
 					{ translate( 'Remove' ) }
 				</Button>

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -43,6 +43,13 @@ import { isRequestingTermsForQueryIgnoringPage, getTerm } from 'state/terms/sele
 import { isSavingSiteSettings } from 'state/site-settings/selectors';
 
 class PodcastingDetails extends Component {
+	constructor() {
+		super();
+		this.state = {
+			isCoverImageUploading: false,
+		};
+	}
+
 	renderExplicitContent() {
 		const {
 			fields,
@@ -78,16 +85,29 @@ class PodcastingDetails extends Component {
 			isRequestingCategories,
 			translate,
 		} = this.props;
+		const { isCoverImageUploading } = this.state;
+
+		const saveButtonDisabled =
+			isRequestingSettings || isSavingSettings || isRequestingCategories || isCoverImageUploading;
+		let saveButtonText;
+		if ( isCoverImageUploading ) {
+			saveButtonText = translate( 'Uploading image…' );
+		} else if ( isSavingSettings ) {
+			saveButtonText = translate( 'Saving…' );
+		} else {
+			saveButtonText = translate( 'Save Settings' );
+		}
+
 		return (
 			<Button
 				compact={ true }
 				onClick={ handleSubmitForm }
 				primary={ true }
 				type="submit"
-				disabled={ isRequestingSettings || isSavingSettings || isRequestingCategories }
+				disabled={ saveButtonDisabled }
 				busy={ isSavingSettings }
 			>
-				{ isSavingSettings ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
+				{ saveButtonText }
 			</Button>
 		);
 	}
@@ -281,6 +301,7 @@ class PodcastingDetails extends Component {
 					coverImageUrl={ fields.podcasting_image }
 					onRemove={ this.onCoverImageRemoved }
 					onSelect={ this.onCoverImageSelected }
+					onUploadStateChange={ this.onCoverImageUploadStateChanged }
 					isDisabled={ ! isPodcastingEnabled }
 				/>
 				<div className="podcasting-details__title-subtitle-wrapper">
@@ -384,6 +405,12 @@ class PodcastingDetails extends Component {
 		this.props.updateFields( {
 			podcasting_image_id: String( coverId ),
 			podcasting_image: coverUrl,
+		} );
+	};
+
+	onCoverImageUploadStateChanged = isUploading => {
+		this.setState( {
+			isCoverImageUploading: isUploading,
 		} );
 	};
 }

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -200,6 +200,8 @@ class PodcastingDetails extends Component {
 			isPodcastingEnabled,
 			isSavingSettings,
 		} = this.props;
+		const { isCoverImageUploading } = this.state;
+
 		if ( ! siteId ) {
 			return null;
 		}
@@ -233,7 +235,12 @@ class PodcastingDetails extends Component {
 					<Card className={ classes }>{ error || this.renderSettings() }</Card>
 					{ isPodcastingEnabled && (
 						<div className="podcasting-details__disable-podcasting">
-							<Button onClick={ this.onCategoryCleared } scary busy={ isSavingSettings }>
+							<Button
+								onClick={ this.onCategoryCleared }
+								scary
+								busy={ isSavingSettings }
+								disabled={ isCoverImageUploading }
+							>
 								{ translate( 'Disable Podcast' ) }
 							</Button>
 							<p>

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -91,7 +91,7 @@ class PodcastingDetails extends Component {
 			isRequestingSettings || isSavingSettings || isRequestingCategories || isCoverImageUploading;
 		let saveButtonText;
 		if ( isCoverImageUploading ) {
-			saveButtonText = translate( 'Uploading image…' );
+			saveButtonText = translate( 'Image uploading…' );
 		} else if ( isSavingSettings ) {
 			saveButtonText = translate( 'Saving…' );
 		} else {


### PR DESCRIPTION
This PR fixes a few race conditions involving the `PodcastCoverImageSetting` component.

1. While an image is uploading, you can click "Save settings" at the top of the screen.  What is actually saved is the previous cover image ID, and when the upload completes, the settings are marked as dirty again.
2. You can click the cover image buttons such as "Remove" while an image is uploading.  I am not sure exactly what this does internally, but it is not anything good.
3. You can click the "Disable podcast" button while an image is uploading.  This behaves similarly to (1) with the note that the settings will immediately be saved when the button is clicked.

The fix for the first issue is pretty obvious:  just disable the "Save settings" button while an image is being uploaded.

I took the same approach for the cover image buttons, but it might be better to (in a future PR) add logic for cancelling an in-progress upload.

The "Disable podcast" button is a bit more tricky to handle fully correctly.  I've just disabled it for now, which is an improvement over the current state, but this is a bit strange without at least some visual feedback like the "Save settings" button has.