### PR TITLE
Update SEO help link to the new master link

### DIFF
--- a/client/my-sites/site-settings/seo-settings/help.jsx
+++ b/client/my-sites/site-settings/seo-settings/help.jsx
@@ -29,7 +29,7 @@ const SeoSettingsHelpCard = ( {
 } ) => {
 	const seoHelpLink = siteIsJetpack
 		? 'https://jetpack.com/support/seo-tools/'
-		: 'https://en.blog.wordpress.com/2013/03/22/seo-on-wordpress-com/';
+		: 'https://wpbizseo.wordpress.com/';
 
 	return (
 		<div id="seo">


### PR DESCRIPTION
Change the SEO link (for WP.com and not Jetpack) to a newer resource for our Business Plan customers on WP.com. Note that Business Plan customers are the only ones who have access to SEO tools.

<img width="1019" alt="screen shot 2018-07-09 at 9 59 14 pm" src="https://user-images.githubusercontent.com/2140796/42484943-5eb137be-83c3-11e8-86cf-353a84f0022f.png">

The way to test it is to be on a site with a WP.com Business Plan.

1. Go to Settings > Traffic
2. Click on the hyperlink that says "Read more about what you can do to **optimize your site's SEO**."