### PR TITLE
Editor (HTML): autoFocus on add link/img dialogs

### DIFF
--- a/client/post-editor/editor-html-toolbar/add-image-dialog.jsx
+++ b/client/post-editor/editor-html-toolbar/add-image-dialog.jsx
@@ -85,6 +85,7 @@ export class AddImageDialog extends Component {
 					<FormLabel htmlFor="image_url">{ translate( 'URL' ) }</FormLabel>
 					<FormTextInput
 						autoFocus // eslint-disable-line jsx-a11y/no-autofocus
+						id="image_url"
 						name="image_url"
 						onChange={ this.setImageUrl }
 						value={ imageUrl }
@@ -92,11 +93,21 @@ export class AddImageDialog extends Component {
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="image_title">{ translate( 'Title' ) }</FormLabel>
-					<FormTextInput name="image_title" onChange={ this.setImageTitle } value={ imageTitle } />
+					<FormTextInput
+						id="image_title"
+						name="image_title"
+						onChange={ this.setImageTitle }
+						value={ imageTitle }
+					/>
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="image_alt">{ translate( 'Alt Text' ) }</FormLabel>
-					<FormTextInput name="image_alt" onChange={ this.setImageAlt } value={ imageAlt } />
+					<FormTextInput
+						id="image_alt"
+						name="image_alt"
+						onChange={ this.setImageAlt }
+						alue={ imageAlt }
+					/>
 				</FormFieldset>
 			</Dialog>
 		);

--- a/client/post-editor/editor-html-toolbar/add-image-dialog.jsx
+++ b/client/post-editor/editor-html-toolbar/add-image-dialog.jsx
@@ -76,7 +76,6 @@ export class AddImageDialog extends Component {
 
 		return (
 			<Dialog
-				autoFocus={ false }
 				isVisible={ shouldDisplay }
 				buttons={ buttons }
 				onClose={ this.onCloseDialog }
@@ -84,7 +83,12 @@ export class AddImageDialog extends Component {
 			>
 				<FormFieldset>
 					<FormLabel htmlFor="image_url">{ translate( 'URL' ) }</FormLabel>
-					<FormTextInput name="image_url" onChange={ this.setImageUrl } value={ imageUrl } />
+					<FormTextInput
+						autoFocus // eslint-disable-line jsx-a11y/no-autofocus
+						name="image_url"
+						onChange={ this.setImageUrl }
+						value={ imageUrl }
+					/>
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="image_title">{ translate( 'Title' ) }</FormLabel>

--- a/client/post-editor/editor-html-toolbar/add-link-dialog.jsx
+++ b/client/post-editor/editor-html-toolbar/add-link-dialog.jsx
@@ -146,6 +146,7 @@ export class AddLinkDialog extends Component {
 					<FormLabel htmlFor="link_url">{ translate( 'URL' ) }</FormLabel>
 					<FormTextInput
 						autoFocus // eslint-disable-line jsx-a11y/no-autofocus
+						id="link_url"
 						name="link_url"
 						onChange={ this.setLinkUrl }
 						ref={ this.bindLinkUrlRef }
@@ -154,7 +155,12 @@ export class AddLinkDialog extends Component {
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="link_text">{ translate( 'Link Text' ) }</FormLabel>
-					<FormTextInput name="link_text" onChange={ this.setLinkText } value={ linkText } />
+					<FormTextInput
+						id="link_text"
+						name="link_text"
+						onChange={ this.setLinkText }
+						value={ linkText }
+					/>
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel>

--- a/client/post-editor/editor-html-toolbar/add-link-dialog.jsx
+++ b/client/post-editor/editor-html-toolbar/add-link-dialog.jsx
@@ -137,7 +137,6 @@ export class AddLinkDialog extends Component {
 
 		return (
 			<Dialog
-				autoFocus={ false }
 				isVisible={ shouldDisplay }
 				buttons={ buttons }
 				onClose={ this.onCloseDialog }
@@ -146,6 +145,7 @@ export class AddLinkDialog extends Component {
 				<FormFieldset>
 					<FormLabel htmlFor="link_url">{ translate( 'URL' ) }</FormLabel>
 					<FormTextInput
+						autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 						name="link_url"
 						onChange={ this.setLinkUrl }
 						ref={ this.bindLinkUrlRef }


### PR DESCRIPTION
This PR addresses #25860 by giving focus to the first input on the add link/image dialog modals.

![jul-10-2018 17-02-49](https://user-images.githubusercontent.com/6458278/42494321-4b430c70-8463-11e8-808f-af01bc20c2b8.gif)

To the inputs I've also added `id` attributes, which correspond to their labels' `for`.

## Testing

1. Starting at URL: https://wordpress.com/post
2. Switch to HTML mode
3. Highlight text and choose the `link` editor item
4. Close and tab across to the `img` editor item. Press enter.

### Expectations

At 3: The first field should be focussed.

At 4: You should be able to tab from `link` to `img` (meaning that original focus is restored), and the first field should also be focussed.

