### PR TITLE
Remove dependency 'ms'

### DIFF
--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -35,6 +35,7 @@ import setupGlobalKeyboardShortcuts from 'lib/keyboard-shortcuts/global';
 import * as controller from 'controller';
 
 const debug = debugFactory( 'calypso' );
+const TWO_DAYS_IN_MILLISECONDS = 1000 * 60 * 60 * 24 * 2;
 
 function renderLayout( reduxStore ) {
 	const Layout = controller.ReduxWrappedLayout;
@@ -51,8 +52,8 @@ function renderLayout( reduxStore ) {
 export function utils() {
 	debug( 'Executing WordPress.com utils.' );
 
-	// prune sync-handler records more than two days old
-	pruneStaleRecords( '2 days' );
+	// prune sync-handler records more than two days old ()
+	pruneStaleRecords( TWO_DAYS_IN_MILLISECONDS );
 }
 
 export const configureReduxStore = ( currentUser, reduxStore ) => {

--- a/client/lib/wp/sync-handler/README.md
+++ b/client/lib/wp/sync-handler/README.md
@@ -27,8 +27,7 @@ const wpcom = wpcomUndocumented( handler );
 two methods to invalidate records:
 
 #### syncHandler#pruneStaleRecords( [lifetime] );
-Prune records older than the given `lifetime` (milliseconds or [natural
-language](https://github.com/rauchg/ms.js)). By default the value of the lifetime is `2 days`.
+Prune records older than the given `lifetime` (milliseconds). By default the value of the lifetime is `172800000` (2 days).
 
 ```es6
 // prune the records that are older than one hour of life
@@ -36,7 +35,7 @@ syncHandler.pruneStaleRecords( 1000 * 60 * 60 );
 
 // prune older than 10 hours old
 syncHandler
-	.pruneStaleRecords( '10 hours' )
+	.pruneStaleRecords( 1000 * 60 * 60 * 10 )
 	.then( records => {
 		console.log( 'current records count: %s', records.length );
 	} );
@@ -89,5 +88,5 @@ It allows access to `cache-index` API from the dev console. For instance:
 
 ```es6
 // prune records older than 25 minutes of lifetime.
-cacheIndex.pruneStaleRecords( '25 minutes' );
+cacheIndex.pruneStaleRecords( 1000 * 60 * 25 );
 ```

--- a/client/lib/wp/sync-handler/cache-index.js
+++ b/client/lib/wp/sync-handler/cache-index.js
@@ -5,7 +5,6 @@
  */
 
 import debugFactory from 'debug';
-import ms from 'ms';
 import { difference, filter, matchesProperty, negate } from 'lodash';
 
 /**
@@ -152,9 +151,7 @@ export const cacheIndex = {
 	 * @return {Promise} promise
 	 */
 	pruneStaleRecords( lifetime = LIFETIME ) {
-		lifetime = typeof lifetime === 'number' ? lifetime : ms( lifetime );
-
-		debug( 'start to prune records older than %s', ms( lifetime, { long: true } ) );
+		debug( `start to prune records older than ${ lifetime }ms` );
 
 		return this.findStaleRecords( lifetime ).then( this.removeRecordsByList );
 	},

--- a/client/lib/wp/sync-handler/constants.js
+++ b/client/lib/wp/sync-handler/constants.js
@@ -2,4 +2,4 @@
 
 export const RECORDS_LIST_KEY = 'records-list';
 export const SYNC_RECORD_NAMESPACE = 'sync-record-';
-export const LIFETIME = '2 days';
+export const LIFETIME = 1000 * 60 * 60 * 24 * 2; // 2 days

--- a/client/lib/wp/sync-handler/test/cache-index.js
+++ b/client/lib/wp/sync-handler/test/cache-index.js
@@ -4,7 +4,6 @@
  */
 import { expect } from 'chai';
 import localforageMock from 'localforage';
-import ms from 'ms';
 
 /**
  * Internal dependencies
@@ -19,6 +18,8 @@ jest.mock( 'localforage', () => require( './mocks/localforage' ) );
 const localData = () => localforageMock.getLocalData();
 const setLocalData = data => localforageMock.setLocalData( data );
 const clearLocal = () => setLocalData( {} );
+
+const ONE_DAY_IN_MILLISECONDS = 1000 * 60 * 60 * 24;
 
 describe( 'cache-index', () => {
 	beforeEach( clearLocal ); // also do inside nested blocks with >1 test
@@ -91,7 +92,7 @@ describe( 'cache-index', () => {
 				postListWithSearchLocalRecord,
 			} = testData;
 			const now = Date.now();
-			const yesterday = now - ms( '1 day' );
+			const yesterday = now - ONE_DAY_IN_MILLISECONDS;
 			setLocalData( {
 				[ postListKey ]: postListLocalRecord,
 				[ postListWithSearchKey ]: postListWithSearchLocalRecord,
@@ -100,7 +101,7 @@ describe( 'cache-index', () => {
 					{ key: postListWithSearchKey, timestamp: yesterday },
 				],
 			} );
-			return cacheIndex.pruneStaleRecords( '1 hour' ).then( () => {
+			return cacheIndex.pruneStaleRecords( 1000 * 60 * 60 ).then( () => {
 				const freshData = localData();
 				const currentIndex = freshData[ RECORDS_LIST_KEY ];
 				expect( currentIndex ).to.eql( [ { key: postListKey, timestamp: now } ] );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -82,11 +82,6 @@
             "ms": "2.0.0"
           }
         },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -932,11 +927,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -1076,11 +1066,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -1109,11 +1094,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -1146,11 +1126,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -1178,11 +1153,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -1237,11 +1207,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -1276,11 +1241,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -4774,13 +4734,6 @@
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
       }
     },
     "decamelize": {
@@ -5503,12 +5456,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -5537,11 +5484,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -5922,12 +5864,6 @@
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
           "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "optionator": {
@@ -9300,12 +9236,6 @@
             "source-map": "^0.5.3"
           }
         },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -9399,12 +9329,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         },
         "source-map": {
           "version": "0.5.7",
@@ -11136,11 +11060,11 @@
       "optional": true
     },
     "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "loud-rejection": {
@@ -11651,9 +11575,9 @@
       }
     },
     "ms": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
-      "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multimatch": {
       "version": "2.1.0",
@@ -13325,11 +13249,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -15513,11 +15432,6 @@
         "statuses": "~1.4.0"
       },
       "dependencies": {
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
         "statuses": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -15830,12 +15744,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -15873,11 +15781,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -15903,11 +15806,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -18949,11 +18847,6 @@
             "mime-types": "^2.1.12"
           }
         },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
         "superagent": {
           "version": "3.8.3",
           "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
@@ -19238,11 +19131,6 @@
             "ms": "2.0.0"
           }
         },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -19316,11 +19204,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "parse-json": {
           "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "mkdirp": "0.5.1",
     "moment": "2.22.2",
     "morgan": "1.9.0",
-    "ms": "0.7.3",
     "node-sass": "4.9.2",
     "notifications-panel": "2.1.10",
     "npm-run-all": "4.1.3",


### PR DESCRIPTION
related to #25834

Remove any occurence of the `ms` dependency. There's a Renovate PR to update it to the current version. As of now we only use it in one place so it's be justifiable to remove it altogether.

Alternatively we could use it in more places where we construct milliseconds manually.