### PR TITLE
Checklist: Some minor Cleanup

### DIFF
--- a/client/blocks/checklist/index.jsx
+++ b/client/blocks/checklist/index.jsx
@@ -69,18 +69,18 @@ export class Checklist extends Component {
 	renderTask = task => {
 		return (
 			<ChecklistTask
-				key={ task.id }
-				id={ task.id }
-				title={ task.title }
 				buttonPrimary={ task.buttonPrimary }
 				buttonText={ task.buttonText }
-				completedTitle={ task.completedTitle }
+				completed={ task.completed }
 				completedButtonText={ task.completedButtonText }
+				completedTitle={ task.completedTitle }
 				description={ task.description }
 				duration={ task.duration }
-				completed={ task.completed }
+				id={ task.id }
+				key={ task.id }
 				onAction={ this.props.onAction }
 				onToggle={ this.props.onToggle }
+				title={ task.title }
 			/>
 		);
 	};

--- a/client/blocks/checklist/index.jsx
+++ b/client/blocks/checklist/index.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { filter, noop, range } from 'lodash';
+import { filter, noop, times } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -59,9 +59,7 @@ export class Checklist extends Component {
 		return (
 			<div className={ classNames( 'checklist', 'is-expanded', 'is-placeholder' ) }>
 				<ChecklistHeader total={ 0 } completed={ 0 } hideCompleted={ false } />
-				{ range( this.props.placeholderCount ).map( index => (
-					<ChecklistPlaceholder key={ index } />
-				) ) }
+				{ times( this.props.placeholderCount, index => <ChecklistPlaceholder key={ index } /> ) }
 			</div>
 		);
 	}

--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -11,13 +11,11 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import Checklist from 'blocks/checklist';
 import { jetpackTasks } from '../jetpack-checklist';
 import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import getSiteChecklist from 'state/selectors/get-site-checklist';
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { isJetpackSite, getSiteSlug } from 'state/sites/selectors';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 import { launchTask, onboardingTasks } from '../onboardingChecklist';
@@ -70,11 +68,9 @@ const mapStateToProps = state => {
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSiteSlug( state, siteId );
 	const siteChecklist = getSiteChecklist( state, siteId );
-	const isAtomic = isSiteAutomatedTransfer( state, siteId );
 	const isJetpack = isJetpackSite( state, siteId );
 	const tasks = isJetpack ? jetpackTasks( siteChecklist ) : onboardingTasks( siteChecklist );
 	return {
-		checklistAvailable: ! isAtomic && ( config.isEnabled( 'jetpack/checklist' ) || ! isJetpack ),
 		siteId,
 		siteSlug,
 		tasks,


### PR DESCRIPTION
Factored out of #25924.

* Checklist: Alphabetize `ChecklistTask` props
* Checklist: Use `times()` instead of `range().map()`
* ChecklistShow: Remove obsolete checklistAvailable prop

## Testing Instructions

(mostly copied from #25924)

### Verify that the checklist still works, both for WP.com, and JP sites

* Navigate to `http://calypso.localhost:3000/checklist/:site`
* Verify that the loading state (pulsating placeholders) works fine: no errors, and it's only transient :slightly_smiling_face: 
* Try completing a couple of steps. Verify that they are correctly marked as complete afterwards, and that their completions status persists across a reload.
* For WP.com sites (!), verify that you can also tick off tasks even without actually completing them by clicking the circle on the left hand side (which will turn into a green checkmark). Verify that this also persists across a reload.
