### PR TITLE
Checklist: Update Steps

### DIFF
--- a/client/my-sites/checklist/jetpack-checklist.js
+++ b/client/my-sites/checklist/jetpack-checklist.js
@@ -20,6 +20,7 @@ const tasks = {
 		description: translate(
 			"Connect your site's server to Jetpack to perform backups, rewinds, and security scans."
 		),
+		completed: true,
 		completedTitle: translate( 'You turned on backups and scanning.' ),
 		completedButtonText: 'Change',
 		duration: translate( '2 min' ),

--- a/client/my-sites/checklist/jetpack-checklist.js
+++ b/client/my-sites/checklist/jetpack-checklist.js
@@ -15,6 +15,16 @@ const tasks = {
 		completedTitle: translate( "We've automatically turned on spam filtering." ),
 		completed: true,
 	},
+	jetpack_backups: {
+		title: translate( 'Backups & Scanning' ),
+		description: translate(
+			"Connect your site's server to Jetpack to perform backups, rewinds, and security scans."
+		),
+		completedTitle: translate( 'You turned on backups and scanning.' ),
+		completedButtonText: 'Change',
+		duration: translate( '2 min' ),
+		url: '/stats/activity/$siteSlug',
+	},
 	jetpack_monitor: {
 		title: translate( 'Jetpack Monitor' ),
 		description: translate(
@@ -52,6 +62,7 @@ const tasks = {
 const sequence = [
 	'jetpack_brute_force',
 	'jetpack_spam_filtering',
+	'jetpack_backups',
 	'jetpack_monitor',
 	'jetpack_plugin_updates',
 	'jetpack_sign_in',

--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -10,17 +10,6 @@ import { isDesktop } from 'lib/viewport';
  * Internal dependencies
  */
 const tasks = {
-	about_page_updated: {
-		title: 'Create your About page',
-		description:
-			'It’s the first place we all go! Don’t miss the opportunity to tell people more about you and your site.',
-		duration: '10 mins',
-		completedTitle: 'You updated your About page',
-		completedButtonText: 'Change',
-		image: '/calypso/images/stats/tasks/about.svg',
-		url: '/pages/$siteSlug',
-		tour: 'checklistAboutPage',
-	},
 	avatar_uploaded: {
 		title: 'Upload your profile picture',
 		description:
@@ -62,16 +51,6 @@ const tasks = {
 		url: '/post/$siteSlug/2',
 		tour: 'checklistContactPage',
 	},
-	custom_domain_registered: {
-		title: 'Register a custom domain',
-		description:
-			'Memorable domain names make it easy for people to remember your address — and search engines love ’em.',
-		duration: '2 mins',
-		completedTitle: 'You registered a custom domain',
-		completedButtonText: 'Add email',
-		url: '/domains/add/$siteSlug',
-		image: '/calypso/images/stats/tasks/domains.svg',
-	},
 	domain_selected: {
 		title: 'Pick a website address',
 		description: 'Choose an address so people can find you on the internet.',
@@ -104,15 +83,6 @@ const tasks = {
 		url: '/settings/general/$siteSlug',
 		image: '/calypso/images/stats/tasks/upload-icon.svg',
 		tour: 'checklistSiteIcon',
-	},
-	social_links_set: {
-		title: 'Display links to your social accounts',
-		description: 'Let your audience know where else they can find you online.',
-		duration: '2 mins',
-		completedTitle: 'You added your social accounts.',
-		completedButtonText: 'Change',
-		url: '/customize/$siteSlug?guide=social-media',
-		image: '/calypso/images/stats/tasks/social-links.svg',
 	},
 };
 


### PR DESCRIPTION
* WP.com: Remove unused tasks. Note that only tasks whitelisted in https://github.com/Automattic/wp-calypso/blob/52cfffdb51c915be3ca0e40413b82bbbee452573/client/my-sites/checklist/onboardingChecklist.js#L119-L128 are ever [made available](https://github.com/Automattic/wp-calypso/blob/52cfffdb51c915be3ca0e40413b82bbbee452573/client/my-sites/checklist/onboardingChecklist.js#L166).
* Jetpack: Bring back the 'Backups and Scanning' step that was removed per #25872. The reason is that it is still sent by the REST API. We are going to use this step to reflect VP installation status later.

## Testing Instructions

(mostly copied from #25953)

### Verify that the checklist still works, both for WP.com, and JP sites

* Navigate to `http://calypso.localhost:3000/checklist/:site`
* Verify that the loading state (pulsating placeholders) works fine: no errors, and it's only transient :slightly_smiling_face: 
* Try completing a couple of steps. Verify that they are correctly marked as complete afterwards, and that their completions status persists across a reload.
* For WP.com sites (!), verify that you can also tick off tasks even without actually completing them by clicking the circle on the left hand side (which will turn into a green checkmark). Verify that this also persists across a reload.
