### PR TITLE
Checklist: Cleanup actions

### DIFF
--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -167,11 +167,7 @@ const mapStateToProps = state => {
 	};
 };
 
-const mapDispatchToProps = {
-	recordTracksEvent,
-};
-
 export default connect(
 	mapStateToProps,
-	mapDispatchToProps
+	{ recordTracksEvent }
 )( localize( ChecklistMain ) );

--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -27,7 +27,6 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, getSiteSlug } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
 
 class ChecklistMain extends PureComponent {
@@ -173,7 +172,6 @@ const mapStateToProps = state => {
 const mapDispatchToProps = {
 	track: recordTracksEvent,
 	notify: createNotice,
-	requestTour: requestGuidedTour,
 	update: requestSiteChecklistTaskUpdate,
 };
 

--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -81,7 +81,7 @@ class ChecklistMain extends PureComponent {
 					<ChecklistShowShare
 						className="checklist__share"
 						siteSlug={ this.props.siteSlug }
-						recordTracksEvent={ this.props.track }
+						recordTracksEvent={ this.props.recordTracksEvent }
 					/>
 				</Fragment>
 			);
@@ -168,7 +168,7 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = {
-	track: recordTracksEvent,
+	recordTracksEvent,
 };
 
 export default connect(

--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -27,7 +27,6 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, getSiteSlug } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
 
 class ChecklistMain extends PureComponent {
 	getHeaderTitle( displayMode ) {
@@ -172,7 +171,6 @@ const mapStateToProps = state => {
 const mapDispatchToProps = {
 	track: recordTracksEvent,
 	notify: createNotice,
-	update: requestSiteChecklistTaskUpdate,
 };
 
 export default connect(

--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -22,7 +22,6 @@ import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
-import { createNotice } from 'state/notices/actions';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, getSiteSlug } from 'state/sites/selectors';
@@ -170,7 +169,6 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = {
 	track: recordTracksEvent,
-	notify: createNotice,
 };
 
 export default connect(


### PR DESCRIPTION
Remove unused dispatch actions from `ChecklistMain`:

These all appear to be unused (check the [source](https://github.com/Automattic/wp-calypso/blob/d1ae0f19de591e0dc4e2809dc217c1bc00445eaa/client/my-sites/checklist/main.jsx))
- notify: createNotice,	
- requestTour: requestGuidedTour,	
- update: requestSiteChecklistTaskUpdate,

Remove this trivial rename to keep the action creator name:
`this.props.track` -> `this.props.recordTracksEvent`.

## Testing
1. Inspect and verify the assumption that these props are unused is correct.
1. Test checklists and ensure they behave as expected for Simple and Jetpack sites:
   https://calypso.live/checklist/SITE_SLUG?branch=update/cleanup-checklist-unused
