### PR TITLE
ChecklistShow: Decouple `tasks` prop

### DIFF
--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -6,20 +6,16 @@
 import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find, get } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Checklist from 'blocks/checklist';
-import { tasks as jetpackTasks } from '../jetpack-checklist';
 import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import getSiteChecklist from 'state/selectors/get-site-checklist';
-import { isJetpackSite, getSiteSlug } from 'state/sites/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
-import { launchTask, tasks as wpcomTasks } from '../onboardingChecklist';
-import { mergeObjectIntoArrayById } from '../util';
+import { launchTask } from '../onboardingChecklist';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { createNotice } from 'state/notices/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
@@ -65,20 +61,10 @@ class ChecklistShow extends PureComponent {
 	}
 }
 
-const mapStateToProps = state => {
-	const siteId = getSelectedSiteId( state );
-	const siteSlug = getSiteSlug( state, siteId );
-	const siteChecklist = getSiteChecklist( state, siteId );
-	const isJetpack = isJetpackSite( state, siteId );
-	const tasks = isJetpack ? jetpackTasks : wpcomTasks;
-	const tasksFromServer = get( siteChecklist, [ 'tasks' ] );
-
-	return {
-		siteId,
-		siteSlug,
-		tasks: tasksFromServer ? mergeObjectIntoArrayById( tasks, tasksFromServer ) : null,
-	};
-};
+const mapStateToProps = state => ( {
+	siteId: getSelectedSiteId( state ),
+	siteSlug: getSelectedSiteSlug( state ),
+} );
 
 const mapDispatchToProps = {
 	track: recordTracksEvent,

--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import React, { Fragment, PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
@@ -21,6 +22,10 @@ import { createNotice } from 'state/notices/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 
 class ChecklistShow extends PureComponent {
+	static propTypes = {
+		tasks: PropTypes.array,
+	};
+
 	handleAction = id => {
 		const { requestTour, siteSlug, tasks, track } = this.props;
 		const task = find( tasks, { id } );

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -80,15 +80,15 @@ class CurrentPlan extends Component {
 
 	render() {
 		const {
-			selectedSite,
-			selectedSiteId,
-			domains,
 			context,
 			currentPlan,
+			domains,
 			hasDomainsLoaded,
 			isAutomatedTransfer,
 			isExpiring,
 			isJetpack,
+			selectedSite,
+			selectedSiteId,
 			shouldShowDomainWarnings,
 			translate,
 		} = this.props;

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -172,16 +172,16 @@ export default connect( ( state, ownProps ) => {
 	const isAutomatedTransfer = isSiteAutomatedTransfer( state, selectedSiteId );
 
 	return {
-		selectedSite,
-		selectedSiteId,
-		domains,
-		isAutomatedTransfer,
 		context: ownProps.context,
 		currentPlan: getCurrentPlan( state, selectedSiteId ),
-		isExpiring: isCurrentPlanExpiring( state, selectedSiteId ),
-		shouldShowDomainWarnings: ! isJetpack || isAutomatedTransfer,
+		domains,
 		hasDomainsLoaded: !! domains,
-		isRequestingSitePlans: isRequestingSitePlans( state, selectedSiteId ),
+		isAutomatedTransfer,
+		isExpiring: isCurrentPlanExpiring( state, selectedSiteId ),
 		isJetpack,
+		isRequestingSitePlans: isRequestingSitePlans( state, selectedSiteId ),
+		selectedSite,
+		selectedSiteId,
+		shouldShowDomainWarnings: ! isJetpack || isAutomatedTransfer,
 	};
 } )( localize( CurrentPlan ) );

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -163,7 +163,7 @@ class CurrentPlan extends Component {
 	}
 }
 
-export default connect( ( state, ownProps ) => {
+export default connect( ( state, { context } ) => {
 	const selectedSite = getSelectedSite( state );
 	const selectedSiteId = getSelectedSiteId( state );
 	const domains = getDecoratedSiteDomains( state, selectedSiteId );
@@ -172,7 +172,7 @@ export default connect( ( state, ownProps ) => {
 	const isAutomatedTransfer = isSiteAutomatedTransfer( state, selectedSiteId );
 
 	return {
-		context: ownProps.context,
+		context,
 		currentPlan: getCurrentPlan( state, selectedSiteId ),
 		domains,
 		hasDomainsLoaded: !! domains,

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -12,30 +12,30 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
+import ChecklistShow from 'my-sites/checklist/checklist-show';
+import CurrentPlanHeader from './header';
+import DocumentHead from 'components/data/document-head';
+import DomainWarnings from 'my-sites/domains/components/domain-warnings';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import Main from 'components/main';
+import PlansNavigation from 'my-sites/domains/navigation';
+import ProductPurchaseFeaturesList from 'blocks/product-purchase-features-list';
+import QuerySiteDomains from 'components/data/query-site-domains';
+import QuerySitePlans from 'components/data/query-site-plans';
+import QuerySites from 'components/data/query-sites';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import TrackComponentView from 'lib/analytics/track-component-view';
 import {
 	getCurrentPlan,
 	isCurrentPlanExpiring,
 	isRequestingSitePlans,
 } from 'state/sites/plans/selectors';
-import { isFreeJetpackPlan } from 'lib/products-values';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
-import DocumentHead from 'components/data/document-head';
-import TrackComponentView from 'lib/analytics/track-component-view';
-import PlansNavigation from 'my-sites/domains/navigation';
-import ProductPurchaseFeaturesList from 'blocks/product-purchase-features-list';
-import CurrentPlanHeader from './header';
-import QuerySites from 'components/data/query-sites';
-import QuerySitePlans from 'components/data/query-site-plans';
-import { getPlan } from 'lib/plans';
-import QuerySiteDomains from 'components/data/query-site-domains';
 import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
-import DomainWarnings from 'my-sites/domains/components/domain-warnings';
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import SidebarNavigation from 'my-sites/sidebar-navigation';
-import ChecklistShow from 'my-sites/checklist/checklist-show';
+import { getPlan } from 'lib/plans';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isEnabled } from 'config';
+import { isFreeJetpackPlan } from 'lib/products-values';
+import { isJetpackSite } from 'state/sites/selectors';
 
 class CurrentPlan extends Component {
 	static propTypes = {


### PR DESCRIPTION
Move the responsibility to provide a `tasks` array prop to the `Checklist` prop from the `ChecklistShow` wrapper to its consumer. The rationale is that for https://github.com/Automattic/wp-calypso/projects/70, the logic providing that prop will diverge for JP sites from how we're doing it for WP.com ones, since in the Jetpack case, we want to display 'pending' state for some steps (spinners), which we'll infer from selectors (essentially plugin installation state, see #25935). To that end, we want to be able to transparently extend the `tasks` array in the `connect()` that is relevant for the JP case.

Note that this PR changes behavior: the checklist for JP sites is now only available at `/plans/my-plan/:site`, whereas `/checklist/:site` will no longer show a checklist for JP sites (only for WP.com).

## Testing Instructions

### Verify that the checklist still works for WP.com sites

* Navigate to `http://calypso.localhost:3000/checklist/<wpcomSite>`
* Verify that the loading state (pulsating placeholders) works fine: no errors, and it's only transient :slightly_smiling_face: 
* Try completing a couple of steps. Verify that they are correctly marked as complete afterwards, and that their completions status persists across a reload.
* Verify that you can also tick off tasks even without actually completing them by clicking the circle on the left hand side (which will turn into a green checkmark). Verify that this also persists across a reload.
* Try switching to a JP site -- you'll see a message "Checklist not available for this site" (We will add a redirect to `/plans/my-plan/<jpSite>` going forward.)

### Verify that the checklist still works for Jetpack sites

* Navigate to `http://calypso.localhost:3000/checklist/<jpSite>`
* Verify that the loading state (pulsating placeholders) works fine: no errors, and it's only transient :slightly_smiling_face: 
* Try completing a couple of steps. Verify that they are correctly marked as complete afterwards, and that their completions status persists across a reload.
* Verify that `propType` errors in the console are pre-existing on `master`.
* Try switching to a WP.com site, and verify that no checklist is being displayed.