### PR TITLE
Avoid using path.skip() in the Babel transform for action type inlining

### DIFF
--- a/inline-imports.js
+++ b/inline-imports.js
@@ -56,12 +56,12 @@ function transformIt( babel ) {
 			// we haven't deleted the `import` statement yet
 			// so if we don't skip it then we'll enter a cycle
 			if ( t.isImportSpecifier( path.parentPath ) ) {
-				return path.skip();
+				return;
 			}
 
 			const name = path.node.name;
 			if ( ! this.myTypes.hasOwnProperty( name ) ) {
-				return path.skip();
+				return;
 			}
 
 			path.replaceWith( t.stringLiteral( this.myTypes[ name ] ) );
@@ -83,7 +83,7 @@ function transformIt( babel ) {
 				// this is a very-specific transform because
 				// we don't want to mess up other imports
 				if ( name !== 'state/action-types' ) {
-					return path.skip();
+					return;
 				}
 
 				const myTypes = path.node.specifiers


### PR DESCRIPTION
Using the `path.skip()` method in an `ImportDeclaration` visitor that is used by the "main" Babel transform is an insidious bug: it skips also all other visitors from other plugins!

I found the bug when updating the Gutenberg integration PR (#25590) and integrating @aduth's [babel-plugin-import-jsx-pragma](https://github.com/WordPress/gutenberg/tree/master/packages/babel-plugin-import-jsx-pragma) into Calypso's Babel config.

It has visitors for `JSXElement` and `ImportDeclaration` nodes and then a `Program.exit` visitor to insert an import when it's missing and needed. But to my bewilderment, the `ImportDeclaration` visitor was never called! The result was that the `@wordpress/element` import was inserted even if it was already in the file, causing an error.

It took me 2 hours of debugging to figure out that the `inline-imports` transform has an `ImportDeclaration` visitor, too, and that it skips traversing the node. For all plugins.

The fix is to rewrite the `path.skip()` call to a simple return.

Calling `path.skip()` in the `replacer` visitor over which we have full control is OK, according to the [Babel Plugin Handbook](https://github.com/jamiebuilds/babel-handbook/blob/master/translations/en/plugin-handbook.md#stopping-traversal). But in our case it's not necessary -- therefore I replaced it with a simple `return`, too.

**How to test:**
Check that the action type inlining Babel transform still works as expected. I didn't find any unit tests for the transform.
