### PR TITLE
Signup: don't use page.js for external URLs on signup completion redirects

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -316,6 +316,11 @@ class Signup extends React.Component {
 		}
 
 		if ( userIsLoggedIn ) {
+			// don't use page.js for external URLs (eg redirect to new site after signup)
+			if ( /^https?:\/\//.test( destination ) ) {
+				return ( window.location.href = destination );
+			}
+
 			// deferred in case the user is logged in and the redirect triggers a dispatch
 			defer(
 				function() {


### PR DESCRIPTION
page.js is for internal navigation via `window.location.pushState` and although it will fall back to `window.location.href` in [some unhandled situations](https://github.com/visionmedia/page.js/blob/043e68cfdea0c8adec24c4e719c4af2c956b96e0/index.js#L393), there appear to be edge cases where it tries to push an external URL into the `pushState` stack, producing errors as seen in #25886 and way back in #908

This will simply test for an `^https?://` prefix on a redirect destination URL and call `window.location.href` to navigate to it, bypassing page.js.

Fixes #25886

## To Test

This one is difficult to test, since the issue would only appear sporadically. I have not yet been able to duplicate the reported issue, but I am confident that this will fix it (it is the code path taken in my testing with a new site signup) and will also have the benefit that even a false positive taking the new code path here would still navigate to the desired location, albeit with a full reload.