### PR TITLE
Media Library - adds ability to show/hide icon for Video items

### DIFF
--- a/client/my-sites/media-library/list-item-video.jsx
+++ b/client/my-sites/media-library/list-item-video.jsx
@@ -23,11 +23,13 @@ export default class extends React.Component {
 		media: PropTypes.object,
 		maxImageWidth: PropTypes.number,
 		thumbnailType: PropTypes.string,
+		showIcon: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		maxImageWidth: 450,
 		thumbnailType: MEDIA_IMAGE_PHOTON,
+		showIcon: true,
 	};
 
 	getHighestQualityThumbnail = () => {
@@ -50,13 +52,15 @@ export default class extends React.Component {
 					? thumbnail
 					: photon( thumbnail, { width: this.props.maxImageWidth } );
 
+			const maybeIcon = this.props.showIcon ? <Gridicon icon="video-camera" /> : null;
+
 			return (
 				<div
 					className="media-library__list-item-video"
 					style={ { backgroundImage: 'url(' + url + ')' } }
 				>
 					<span className="media-library__list-item-icon media-library__list-item-centered">
-						<Gridicon icon="video-camera" />
+						{ maybeIcon }
 					</span>
 				</div>
 			);

--- a/client/my-sites/media-library/list-item.jsx
+++ b/client/my-sites/media-library/list-item.jsx
@@ -35,6 +35,7 @@ export default class extends React.Component {
 		onToggle: PropTypes.func,
 		onEditItem: PropTypes.func,
 		style: PropTypes.object,
+		source: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -107,7 +108,9 @@ export default class extends React.Component {
 			'is-small': this.props.scale <= 0.125,
 		} );
 
-		const props = omit( this.props, Object.keys( this.constructor.propTypes ) );
+		const propsToOmit = Object.keys( this.constructor.propTypes ).concat( [ 'showIcon' ] );
+
+		const props = omit( this.props, propsToOmit );
 
 		const style = assign(
 			{

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -190,6 +190,7 @@ export class MediaLibraryList extends React.Component {
 				selectedIndex={ selectedIndex }
 				onToggle={ this.toggleItem }
 				onEditItem={ this.props.onEditItem }
+				showIcon={ this.props.source !== 'google_photos' }
 			/>
 		);
 	};
@@ -282,6 +283,7 @@ export class MediaLibraryList extends React.Component {
 				renderLoadingPlaceholders={ this.renderLoadingPlaceholders }
 				renderTrailingItems={ this.renderTrailingItems }
 				className="media-library__list"
+				source={ this.props.source }
 			/>
 		);
 	}


### PR DESCRIPTION
Previously icon could not be disabled. In certain situations you might need to do this. For example, Google Photos automatically embeds a video icon on to the thumbnails of all videos coming through from it’s API. As a result we need to disable our icon so as not to double up.

See
https://github.com/Automattic/wp-calypso/pull/25776#issuecomment-402199408

Originally part of PR above but moved on advice from @ehg
https://github.com/Automattic/wp-calypso/pull/25776#pullrequestreview-135410485