### PR TITLE
Podcasting: Enable in staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -74,6 +74,7 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
+		"manage/site-settings/podcasting": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,


### PR DESCRIPTION
This enables the `manage/site-settings/podcasting` feature flag in staging for pre-launch testing.

This PR is part of a larger epic. See p3Ex-32D-p2.