### PR TITLE
Reader: remove reader/nesting-arrow feature flag

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -56,7 +56,6 @@ import { isFeaturedImageInContent } from 'lib/post-normalizer/utils';
 import ReaderFullPostContentPlaceholder from './placeholders/content';
 import { showSelectedPost } from 'reader/utils';
 import Emojify from 'components/emojify';
-import config from 'config';
 import { COMMENTS_FILTER_ALL } from 'blocks/comments/comments-filters';
 import { READER_FULL_POST } from 'reader/follow-sources';
 import { getPostByKey } from 'state/reader/posts/selectors';
@@ -444,7 +443,7 @@ export class FullPostView extends React.Component {
 							<div className="reader-full-post__comments-wrapper" ref={ this.commentsWrapper }>
 								{ shouldShowComments( post ) && (
 									<Comments
-										showNestingReplyArrow={ config.isEnabled( 'reader/nesting-arrow' ) }
+										showNestingReplyArrow={ true }
 										post={ post }
 										initialSize={ startingCommentId ? commentCount : 10 }
 										pageSize={ 25 }

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -129,7 +129,6 @@
 		"reader/following-intro": true,
 		"reader/full-errors": true,
 		"reader/list-management": false,
-		"reader/nesting-arrow": true,
 		"reader/new-post-notifications": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,

--- a/config/development.json
+++ b/config/development.json
@@ -148,7 +148,6 @@
 		"reader/full-errors": true,
 		"reader/likes-hover": true,
 		"reader/list-management": false,
-		"reader/nesting-arrow": true,
 		"reader/paste-to-link": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -96,7 +96,6 @@
 		"reader": true,
 		"reader/conversations": false,
 		"reader/following-intro": true,
-		"reader/nesting-arrow": true,
 		"reader/related-posts": true,
 		"reader/search": true,
 		"reader/user-mention-suggestions": true,

--- a/config/production.json
+++ b/config/production.json
@@ -105,7 +105,6 @@
 		"reader/conversations": true,
 		"reader/following-intro": true,
 		"reader/full-errors": false,
-		"reader/nesting-arrow": true,
 		"reader/related-posts": true,
 		"reader/search": true,
 		"reader/user-mention-suggestions": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -109,7 +109,6 @@
 		"reader/following-intro": true,
 		"reader/full-errors": false,
 		"reader/likes-hover": true,
-		"reader/nesting-arrow": true,
 		"reader/paste-to-link": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -120,7 +120,6 @@
 		"reader/conversations": true,
 		"reader/following-intro": true,
 		"reader/full-errors": true,
-		"reader/nesting-arrow": true,
 		"reader/paste-to-link": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,


### PR DESCRIPTION
Removes the now-redundant `reader/nesting-arrow` feature flag. 

We now show the nesting arrow on comments in Reader full post in all environments.

<img width="175" alt="screen shot 2018-07-11 at 16 04 26" src="https://user-images.githubusercontent.com/17325/42550156-1c1e035c-8524-11e8-8bdc-427231d0bcdb.png">
