### PR TITLE
Reader: remove search feature flag

### DIFF
--- a/client/reader/search/index.js
+++ b/client/reader/search/index.js
@@ -7,25 +7,19 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import { search } from './controller';
 import { preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 
 export default function() {
-	if ( config.isEnabled( 'reader/search' ) ) {
-		page(
-			'/read/search',
-			redirectLoggedOut,
-			preloadReaderBundle,
-			updateLastRoute,
-			sidebar,
-			search,
-			makeLayout,
-			clientRender
-		);
-	} else {
-		// redirect search to the root
-		page.redirect( '/read/search', '/' );
-	}
+	page(
+		'/read/search',
+		redirectLoggedOut,
+		preloadReaderBundle,
+		updateLastRoute,
+		sidebar,
+		search,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -233,18 +233,16 @@ export const ReaderSidebar = createReactClass( {
 								</li>
 							) : null }
 
-							{ config.isEnabled( 'reader/search' ) && (
-								<li
-									className={ ReaderSidebarHelper.itemLinkClass( '/read/search', this.props.path, {
-										'sidebar-streams__search': true,
-									} ) }
-								>
-									<a href="/read/search" onClick={ this.handleReaderSidebarSearchClicked }>
-										<Gridicon icon="search" size={ 24 } />
-										<span className="menu-link-text">{ this.props.translate( 'Search' ) }</span>
-									</a>
-								</li>
-							) }
+							<li
+								className={ ReaderSidebarHelper.itemLinkClass( '/read/search', this.props.path, {
+									'sidebar-streams__search': true,
+								} ) }
+							>
+								<a href="/read/search" onClick={ this.handleReaderSidebarSearchClicked }>
+									<Gridicon icon="search" size={ 24 } />
+									<span className="menu-link-text">{ this.props.translate( 'Search' ) }</span>
+								</a>
+							</li>
 
 							<li
 								className={ ReaderSidebarHelper.itemLinkClass(

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -133,7 +133,6 @@
 		"reader/new-post-notifications": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
-		"reader/search": true,
 		"reader/high-watermark": true,
 		"reader/tags-with-elasticsearch": false,
 		"resume-editing": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -89,7 +89,6 @@
 		"reader": true,
 		"reader/following-intro": true,
 		"reader/full-errors": false,
-		"reader/search": true,
 		"reader/conversations": false,
 		"reader/user-mention-suggestions": false,
 		"resume-editing": true,

--- a/config/development.json
+++ b/config/development.json
@@ -152,7 +152,6 @@
 		"reader/paste-to-link": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
-		"reader/search": true,
 		"reader/high-watermark": true,
 		"reader/user-mention-suggestions": true,
 		"resume-editing": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -98,7 +98,6 @@
 		"reader/following-intro": true,
 		"reader/nesting-arrow": true,
 		"reader/related-posts": true,
-		"reader/search": true,
 		"reader/user-mention-suggestions": true,
 		"resume-editing": true,
 		"republicize": true,

--- a/config/production.json
+++ b/config/production.json
@@ -107,7 +107,6 @@
 		"reader/full-errors": false,
 		"reader/nesting-arrow": true,
 		"reader/related-posts": true,
-		"reader/search": true,
 		"reader/user-mention-suggestions": false,
 		"resume-editing": true,
 		"republicize": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -124,7 +124,6 @@
 		"reader/paste-to-link": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
-		"reader/search": true,
 		"reader/high-watermark": true,
 		"reader/user-mention-suggestions": true,
 		"resume-editing": true,


### PR DESCRIPTION
Removes the now-redundant `reader/search` feature flag.

We now show Reader Search (http://calypso.localhost:3000/read/search?q=shiba) in all environments.

No functional changes.