### PR TITLE
Reader post card: show post likers in gravatar caterpillar

### DIFF
--- a/client/blocks/post-likes-caterpillar/index.jsx
+++ b/client/blocks/post-likes-caterpillar/index.jsx
@@ -31,9 +31,9 @@ const PostLikesCaterpillar = props => {
 			{ likes && (
 				<GravatarCaterpillar
 					users={ likes }
-					showCount={ true }
 					gravatarSize={ gravatarSize }
-					maxGravatarsToDisplay={ 5 }
+					maxGravatarsToDisplay={ 3 }
+					showCount={ false }
 				/>
 			) }
 		</div>

--- a/client/blocks/post-likes-caterpillar/index.jsx
+++ b/client/blocks/post-likes-caterpillar/index.jsx
@@ -45,7 +45,7 @@ export default connect( ( state, { blogId, postId } ) => {
 	//const likeCount = countPostLikes( state, blogId, postId );
 	const likes = getPostLikes( state, blogId, postId );
 	return {
-		likeCount,
+		//likeCount,
 		likes,
 	};
 } )( localize( PostLikesCaterpillar ) );

--- a/client/blocks/post-likes-caterpillar/index.jsx
+++ b/client/blocks/post-likes-caterpillar/index.jsx
@@ -12,11 +12,12 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import QueryPostLikes from 'components/data/query-post-likes';
-import countPostLikes from 'state/selectors/count-post-likes';
+//import countPostLikes from 'state/selectors/count-post-likes';
 import getPostLikes from 'state/selectors/get-post-likes';
+import GravatarCaterpillar from 'components/gravatar-caterpillar';
 
 const PostLikesCaterpillar = props => {
-	const { blogId, postId, className } = props;
+	const { blogId, postId, className, likes /*, likeCount*/ } = props;
 
 	if ( ! blogId || ! postId ) {
 		return null;
@@ -26,9 +27,8 @@ const PostLikesCaterpillar = props => {
 
 	return (
 		<div className={ containerClassnames }>
-			{ blogId &&
-				postId && <QueryPostLikes siteId={ blogId } postId={ postId } needsLikers={ true } /> }
-			<p>caterpillar!</p>
+			{ ! likes && <QueryPostLikes siteId={ blogId } postId={ postId } needsLikers={ true } /> }
+			{ likes && <GravatarCaterpillar users={ likes } showCount={ true } /> }
 		</div>
 	);
 };
@@ -42,7 +42,7 @@ export default connect( ( state, { blogId, postId } ) => {
 	if ( ! blogId || ! postId ) {
 		return {};
 	}
-	const likeCount = countPostLikes( state, blogId, postId );
+	//const likeCount = countPostLikes( state, blogId, postId );
 	const likes = getPostLikes( state, blogId, postId );
 	return {
 		likeCount,

--- a/client/blocks/post-likes-caterpillar/index.jsx
+++ b/client/blocks/post-likes-caterpillar/index.jsx
@@ -17,7 +17,7 @@ import getPostLikes from 'state/selectors/get-post-likes';
 import GravatarCaterpillar from 'components/gravatar-caterpillar';
 
 const PostLikesCaterpillar = props => {
-	const { blogId, postId, className, likes /*, likeCount*/ } = props;
+	const { blogId, postId, className, likes /*, likeCount*/, gravatarSize } = props;
 
 	if ( ! blogId || ! postId ) {
 		return null;
@@ -28,7 +28,14 @@ const PostLikesCaterpillar = props => {
 	return (
 		<div className={ containerClassnames }>
 			{ ! likes && <QueryPostLikes siteId={ blogId } postId={ postId } needsLikers={ true } /> }
-			{ likes && <GravatarCaterpillar users={ likes } showCount={ true } /> }
+			{ likes && (
+				<GravatarCaterpillar
+					users={ likes }
+					showCount={ true }
+					gravatarSize={ gravatarSize }
+					maxGravatarsToDisplay={ 5 }
+				/>
+			) }
 		</div>
 	);
 };

--- a/client/blocks/post-likes-caterpillar/index.jsx
+++ b/client/blocks/post-likes-caterpillar/index.jsx
@@ -1,0 +1,51 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import QueryPostLikes from 'components/data/query-post-likes';
+import countPostLikes from 'state/selectors/count-post-likes';
+import getPostLikes from 'state/selectors/get-post-likes';
+
+const PostLikesCaterpillar = props => {
+	const { blogId, postId, className } = props;
+
+	if ( ! blogId || ! postId ) {
+		return null;
+	}
+
+	const containerClassnames = classnames( 'post-likes-caterpillar', className );
+
+	return (
+		<div className={ containerClassnames }>
+			{ blogId &&
+				postId && <QueryPostLikes siteId={ blogId } postId={ postId } needsLikers={ true } /> }
+			<p>caterpillar!</p>
+		</div>
+	);
+};
+
+PostLikesCaterpillar.propTypes = {
+	blogId: PropTypes.number.isRequired,
+	postId: PropTypes.number.isRequired,
+};
+
+export default connect( ( state, { blogId, postId } ) => {
+	if ( ! blogId || ! postId ) {
+		return {};
+	}
+	const likeCount = countPostLikes( state, blogId, postId );
+	const likes = getPostLikes( state, blogId, postId );
+	return {
+		likeCount,
+		likes,
+	};
+} )( localize( PostLikesCaterpillar ) );

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -96,9 +96,6 @@ const ReaderPostActions = props => {
 			{ shouldShowLikes( post ) && (
 				<Fragment>
 					<li className="reader-post-actions__item">
-						<PostLikesCaterpillar blogId={ +post.site_ID } postId={ +post.ID } />
-					</li>
-					<li className="reader-post-actions__item">
 						<LikeButton
 							key="like-button"
 							siteId={ +post.site_ID }
@@ -112,6 +109,9 @@ const ReaderPostActions = props => {
 							showZeroCount={ false }
 							likeSource={ 'reader' }
 						/>
+					</li>
+					<li className="reader-post-actions__item">
+						<PostLikesCaterpillar blogId={ +post.site_ID } postId={ +post.ID } />
 					</li>
 				</Fragment>
 			) }

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { Fragment } from 'react';
+import React from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 
@@ -20,7 +20,6 @@ import { shouldShowLikes } from 'reader/like-helper';
 import { shouldShowShare } from 'blocks/reader-share/helper';
 import { userCan } from 'lib/posts/utils';
 import * as stats from 'reader/stats';
-import ReaderVisitLink from 'blocks/reader-visit-link';
 import PostLikesCaterpillar from 'blocks/post-likes-caterpillar';
 
 const ReaderPostActions = props => {
@@ -29,14 +28,11 @@ const ReaderPostActions = props => {
 		site,
 		onCommentClick,
 		showEdit,
-		showVisit,
 		showMenu,
 		showMenuFollow,
 		iconSize,
 		className,
-		visitUrl,
 		fullPost,
-		translate,
 	} = props;
 
 	const onEditClick = () => {
@@ -45,24 +41,20 @@ const ReaderPostActions = props => {
 		stats.recordTrackForPost( 'calypso_reader_edit_post_clicked', post );
 	};
 
-	function onPermalinkVisit() {
-		stats.recordPermalinkClick( 'card', post );
-	}
-
 	const listClassnames = classnames( 'reader-post-actions', className );
+	const showLikes = shouldShowLikes( post );
 
 	/* eslint-disable react/jsx-no-target-blank, wpcalypso/jsx-classname-namespace */
 	return (
 		<ul className={ listClassnames }>
-			{ showVisit && (
+			{ showLikes && (
 				<li className="reader-post-actions__item reader-post-actions__visit">
-					<ReaderVisitLink
-						href={ visitUrl || post.URL }
-						iconSize={ iconSize }
-						onClick={ onPermalinkVisit }
-					>
-						{ translate( 'Visit' ) }
-					</ReaderVisitLink>
+					<PostLikesCaterpillar
+						blogId={ +post.site_ID }
+						postId={ +post.ID }
+						gravatarSize={ 18 }
+						className="reader-post-actions__post-likes-caterpillar"
+					/>
 				</li>
 			) }
 			{ showEdit &&
@@ -93,27 +85,22 @@ const ReaderPostActions = props => {
 					/>
 				</li>
 			) }
-			{ shouldShowLikes( post ) && (
-				<Fragment>
-					<li className="reader-post-actions__item">
-						<LikeButton
-							key="like-button"
-							siteId={ +post.site_ID }
-							postId={ +post.ID }
-							post={ post }
-							site={ site }
-							fullPost={ fullPost }
-							tagName="div"
-							forceCounter={ true }
-							iconSize={ iconSize }
-							showZeroCount={ false }
-							likeSource={ 'reader' }
-						/>
-					</li>
-					<li className="reader-post-actions__item">
-						<PostLikesCaterpillar blogId={ +post.site_ID } postId={ +post.ID } />
-					</li>
-				</Fragment>
+			{ showLikes && (
+				<li className="reader-post-actions__item">
+					<LikeButton
+						key="like-button"
+						siteId={ +post.site_ID }
+						postId={ +post.ID }
+						post={ post }
+						site={ site }
+						fullPost={ fullPost }
+						tagName="div"
+						forceCounter={ true }
+						iconSize={ iconSize }
+						showZeroCount={ false }
+						likeSource={ 'reader' }
+					/>
+				</li>
 			) }
 			{ showMenu && (
 				<li className="reader-post-actions__item">

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 
@@ -94,22 +94,26 @@ const ReaderPostActions = props => {
 				</li>
 			) }
 			{ shouldShowLikes( post ) && (
-				<li className="reader-post-actions__item">
-					<PostLikesCaterpillar blogId={ +post.site_ID } postId={ +post.ID } />
-					<LikeButton
-						key="like-button"
-						siteId={ +post.site_ID }
-						postId={ +post.ID }
-						post={ post }
-						site={ site }
-						fullPost={ fullPost }
-						tagName="div"
-						forceCounter={ true }
-						iconSize={ iconSize }
-						showZeroCount={ false }
-						likeSource={ 'reader' }
-					/>
-				</li>
+				<Fragment>
+					<li className="reader-post-actions__item">
+						<PostLikesCaterpillar blogId={ +post.site_ID } postId={ +post.ID } />
+					</li>
+					<li className="reader-post-actions__item">
+						<LikeButton
+							key="like-button"
+							siteId={ +post.site_ID }
+							postId={ +post.ID }
+							post={ post }
+							site={ site }
+							fullPost={ fullPost }
+							tagName="div"
+							forceCounter={ true }
+							iconSize={ iconSize }
+							showZeroCount={ false }
+							likeSource={ 'reader' }
+						/>
+					</li>
+				</Fragment>
 			) }
 			{ showMenu && (
 				<li className="reader-post-actions__item">

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -3,9 +3,9 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { Fragment } from 'react';
-import { connect } from 'react-redux';
+import React from 'react';
 import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -20,11 +20,8 @@ import { shouldShowLikes } from 'reader/like-helper';
 import { shouldShowShare } from 'blocks/reader-share/helper';
 import { userCan } from 'lib/posts/utils';
 import * as stats from 'reader/stats';
-import { localize } from 'i18n-calypso';
 import ReaderVisitLink from 'blocks/reader-visit-link';
-import QueryPostLikes from 'components/data/query-post-likes';
-import countPostLikes from 'state/selectors/count-post-likes';
-import getPostLikes from 'state/selectors/get-post-likes';
+import PostLikesCaterpillar from 'blocks/post-likes-caterpillar';
 
 const ReaderPostActions = props => {
 	const {
@@ -56,76 +53,74 @@ const ReaderPostActions = props => {
 
 	/* eslint-disable react/jsx-no-target-blank, wpcalypso/jsx-classname-namespace */
 	return (
-		<Fragment>
-			{ site && <QueryPostLikes siteId={ site.ID } postId={ post.ID } needsLikers={ true } /> }
-			<ul className={ listClassnames }>
-				{ showVisit && (
-					<li className="reader-post-actions__item reader-post-actions__visit">
-						<ReaderVisitLink
-							href={ visitUrl || post.URL }
-							iconSize={ iconSize }
-							onClick={ onPermalinkVisit }
-						>
-							{ translate( 'Visit' ) }
-						</ReaderVisitLink>
-					</li>
-				) }
-				{ showEdit &&
-					site &&
-					userCan( 'edit_post', post ) && (
-						<li className="reader-post-actions__item">
-							<PostEditButton
-								post={ post }
-								site={ site }
-								onClick={ onEditClick }
-								iconSize={ iconSize }
-							/>
-						</li>
-					) }
-				{ shouldShowShare( post ) && (
+		<ul className={ listClassnames }>
+			{ showVisit && (
+				<li className="reader-post-actions__item reader-post-actions__visit">
+					<ReaderVisitLink
+						href={ visitUrl || post.URL }
+						iconSize={ iconSize }
+						onClick={ onPermalinkVisit }
+					>
+						{ translate( 'Visit' ) }
+					</ReaderVisitLink>
+				</li>
+			) }
+			{ showEdit &&
+				site &&
+				userCan( 'edit_post', post ) && (
 					<li className="reader-post-actions__item">
-						<ShareButton post={ post } position="bottom" tagName="div" iconSize={ iconSize } />
-					</li>
-				) }
-				{ shouldShowComments( post ) && (
-					<li className="reader-post-actions__item">
-						<CommentButton
-							key="comment-button"
-							commentCount={ post.discussion.comment_count }
-							onClick={ onCommentClick }
-							tagName="div"
-							size={ iconSize }
-						/>
-					</li>
-				) }
-				{ shouldShowLikes( post ) && (
-					<li className="reader-post-actions__item">
-						<LikeButton
-							key="like-button"
-							siteId={ +post.site_ID }
-							postId={ +post.ID }
+						<PostEditButton
 							post={ post }
 							site={ site }
-							fullPost={ fullPost }
-							tagName="div"
-							forceCounter={ true }
+							onClick={ onEditClick }
 							iconSize={ iconSize }
-							showZeroCount={ false }
-							likeSource={ 'reader' }
 						/>
 					</li>
 				) }
-				{ showMenu && (
-					<li className="reader-post-actions__item">
-						<ReaderPostOptionsMenu
-							className="ignore-click"
-							showFollow={ showMenuFollow }
-							post={ post }
-						/>
-					</li>
-				) }
-			</ul>
-		</Fragment>
+			{ shouldShowShare( post ) && (
+				<li className="reader-post-actions__item">
+					<ShareButton post={ post } position="bottom" tagName="div" iconSize={ iconSize } />
+				</li>
+			) }
+			{ shouldShowComments( post ) && (
+				<li className="reader-post-actions__item">
+					<CommentButton
+						key="comment-button"
+						commentCount={ post.discussion.comment_count }
+						onClick={ onCommentClick }
+						tagName="div"
+						size={ iconSize }
+					/>
+				</li>
+			) }
+			{ shouldShowLikes( post ) && (
+				<li className="reader-post-actions__item">
+					<PostLikesCaterpillar blogId={ +post.site_ID } postId={ +post.ID } />
+					<LikeButton
+						key="like-button"
+						siteId={ +post.site_ID }
+						postId={ +post.ID }
+						post={ post }
+						site={ site }
+						fullPost={ fullPost }
+						tagName="div"
+						forceCounter={ true }
+						iconSize={ iconSize }
+						showZeroCount={ false }
+						likeSource={ 'reader' }
+					/>
+				</li>
+			) }
+			{ showMenu && (
+				<li className="reader-post-actions__item">
+					<ReaderPostOptionsMenu
+						className="ignore-click"
+						showFollow={ showMenuFollow }
+						post={ post }
+					/>
+				</li>
+			) }
+		</ul>
 	);
 	/* eslint-enable react/jsx-no-target-blank, wpcalypso/jsx-classname-namespace */
 };
@@ -150,15 +145,4 @@ ReaderPostActions.defaultProps = {
 	showMenuFollow: true,
 };
 
-export default connect( ( state, { site, post } ) => {
-	// @todo destructure IDs in here
-	if ( ! site || ! post.ID ) {
-		return {};
-	}
-	const likeCount = countPostLikes( state, site.ID, post.ID );
-	const likes = getPostLikes( state, site.ID, post.ID );
-	return {
-		likeCount,
-		likes,
-	};
-} )( localize( ReaderPostActions ) );
+export default localize( ReaderPostActions );

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -3,7 +3,8 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
 import classnames from 'classnames';
 
 /**
@@ -21,6 +22,9 @@ import { userCan } from 'lib/posts/utils';
 import * as stats from 'reader/stats';
 import { localize } from 'i18n-calypso';
 import ReaderVisitLink from 'blocks/reader-visit-link';
+import QueryPostLikes from 'components/data/query-post-likes';
+import countPostLikes from 'state/selectors/count-post-likes';
+import getPostLikes from 'state/selectors/get-post-likes';
 
 const ReaderPostActions = props => {
 	const {
@@ -52,73 +56,76 @@ const ReaderPostActions = props => {
 
 	/* eslint-disable react/jsx-no-target-blank, wpcalypso/jsx-classname-namespace */
 	return (
-		<ul className={ listClassnames }>
-			{ showVisit && (
-				<li className="reader-post-actions__item reader-post-actions__visit">
-					<ReaderVisitLink
-						href={ visitUrl || post.URL }
-						iconSize={ iconSize }
-						onClick={ onPermalinkVisit }
-					>
-						{ translate( 'Visit' ) }
-					</ReaderVisitLink>
-				</li>
-			) }
-			{ showEdit &&
-				site &&
-				userCan( 'edit_post', post ) && (
-					<li className="reader-post-actions__item">
-						<PostEditButton
-							post={ post }
-							site={ site }
-							onClick={ onEditClick }
+		<Fragment>
+			{ site && <QueryPostLikes siteId={ site.ID } postId={ post.ID } needsLikers={ true } /> }
+			<ul className={ listClassnames }>
+				{ showVisit && (
+					<li className="reader-post-actions__item reader-post-actions__visit">
+						<ReaderVisitLink
+							href={ visitUrl || post.URL }
 							iconSize={ iconSize }
+							onClick={ onPermalinkVisit }
+						>
+							{ translate( 'Visit' ) }
+						</ReaderVisitLink>
+					</li>
+				) }
+				{ showEdit &&
+					site &&
+					userCan( 'edit_post', post ) && (
+						<li className="reader-post-actions__item">
+							<PostEditButton
+								post={ post }
+								site={ site }
+								onClick={ onEditClick }
+								iconSize={ iconSize }
+							/>
+						</li>
+					) }
+				{ shouldShowShare( post ) && (
+					<li className="reader-post-actions__item">
+						<ShareButton post={ post } position="bottom" tagName="div" iconSize={ iconSize } />
+					</li>
+				) }
+				{ shouldShowComments( post ) && (
+					<li className="reader-post-actions__item">
+						<CommentButton
+							key="comment-button"
+							commentCount={ post.discussion.comment_count }
+							onClick={ onCommentClick }
+							tagName="div"
+							size={ iconSize }
 						/>
 					</li>
 				) }
-			{ shouldShowShare( post ) && (
-				<li className="reader-post-actions__item">
-					<ShareButton post={ post } position="bottom" tagName="div" iconSize={ iconSize } />
-				</li>
-			) }
-			{ shouldShowComments( post ) && (
-				<li className="reader-post-actions__item">
-					<CommentButton
-						key="comment-button"
-						commentCount={ post.discussion.comment_count }
-						onClick={ onCommentClick }
-						tagName="div"
-						size={ iconSize }
-					/>
-				</li>
-			) }
-			{ shouldShowLikes( post ) && (
-				<li className="reader-post-actions__item">
-					<LikeButton
-						key="like-button"
-						siteId={ +post.site_ID }
-						postId={ +post.ID }
-						post={ post }
-						site={ site }
-						fullPost={ fullPost }
-						tagName="div"
-						forceCounter={ true }
-						iconSize={ iconSize }
-						showZeroCount={ false }
-						likeSource={ 'reader' }
-					/>
-				</li>
-			) }
-			{ showMenu && (
-				<li className="reader-post-actions__item">
-					<ReaderPostOptionsMenu
-						className="ignore-click"
-						showFollow={ showMenuFollow }
-						post={ post }
-					/>
-				</li>
-			) }
-		</ul>
+				{ shouldShowLikes( post ) && (
+					<li className="reader-post-actions__item">
+						<LikeButton
+							key="like-button"
+							siteId={ +post.site_ID }
+							postId={ +post.ID }
+							post={ post }
+							site={ site }
+							fullPost={ fullPost }
+							tagName="div"
+							forceCounter={ true }
+							iconSize={ iconSize }
+							showZeroCount={ false }
+							likeSource={ 'reader' }
+						/>
+					</li>
+				) }
+				{ showMenu && (
+					<li className="reader-post-actions__item">
+						<ReaderPostOptionsMenu
+							className="ignore-click"
+							showFollow={ showMenuFollow }
+							post={ post }
+						/>
+					</li>
+				) }
+			</ul>
+		</Fragment>
 	);
 	/* eslint-enable react/jsx-no-target-blank, wpcalypso/jsx-classname-namespace */
 };
@@ -143,4 +150,15 @@ ReaderPostActions.defaultProps = {
 	showMenuFollow: true,
 };
 
-export default localize( ReaderPostActions );
+export default connect( ( state, { site, post } ) => {
+	// @todo destructure IDs in here
+	if ( ! site || ! post.ID ) {
+		return {};
+	}
+	const likeCount = countPostLikes( state, site.ID, post.ID );
+	const likes = getPostLikes( state, site.ID, post.ID );
+	return {
+		likeCount,
+		likes,
+	};
+} )( localize( ReaderPostActions ) );

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -28,3 +28,7 @@
 		margin-right: 0;
 	}
 }
+
+.reader-post-actions__post-likes-caterpillar {
+	margin-top: 4px;
+}

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -14,14 +14,9 @@
 
 	&.reader-post-actions__visit {
 		flex: 1;
-
-		.reader-visit-link {
-			align-items: center;
-			box-sizing: border-box;
-			display: inline-flex;
-			padding: 4px 4px 4px 0;
-			position: relative;
-		}
+		display: flex;
+		flex-direction: row;
+		align-items: center;
 	}
 
 	&:last-child {
@@ -31,4 +26,12 @@
 
 .reader-post-actions__post-likes-caterpillar {
 	margin-top: 4px;
+}
+
+.reader-post-actions__item-text {
+	color: $gray;
+	padding-left: 8px;
+	padding-right: 4px;
+	font-size: 12px;
+	margin-top: 8px;
 }

--- a/client/components/count/index.jsx
+++ b/client/components/count/index.jsx
@@ -14,20 +14,28 @@ import { omit } from 'lodash';
  */
 import formatNumberCompact from 'lib/format-number-compact';
 
-export const Count = ( { count, compact, numberFormat, primary, ...inheritProps } ) => {
+export const Count = ( { count, compact, numberFormat, primary, className, ...inheritProps } ) => {
+	let formattedCount = count;
+	// Only attempt to format the count if we've been handed a number
+	if ( ! isNaN( count ) ) {
+		formattedCount = compact
+			? formatNumberCompact( count ) || numberFormat( count )
+			: numberFormat( count );
+	}
+
 	return (
 		// Omit props passed from the `localize` higher-order component that we don't need.
 		<span
-			className={ classnames( 'count', { 'is-primary': primary } ) }
+			className={ classnames( 'count', { 'is-primary': primary }, className ) }
 			{ ...omit( inheritProps, [ 'translate', 'moment' ] ) }
 		>
-			{ compact ? formatNumberCompact( count ) || numberFormat( count ) : numberFormat( count ) }
+			{ formattedCount }
 		</span>
 	);
 };
 
 Count.propTypes = {
-	count: PropTypes.number.isRequired,
+	count: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ).isRequired,
 	numberFormat: PropTypes.func,
 	primary: PropTypes.bool,
 	compact: PropTypes.bool,

--- a/client/components/gravatar-caterpillar/index.jsx
+++ b/client/components/gravatar-caterpillar/index.jsx
@@ -46,7 +46,7 @@ class GravatarCaterpillar extends React.Component {
 					}
 
 					return (
-						<Gravatar className={ gravClasses } key={ user.email } user={ user } size={ 32 } />
+						<Gravatar className={ gravClasses } key={ user.avatar_URL } user={ user } size={ 32 } />
 					);
 				} ) }
 			</div>

--- a/client/components/gravatar-caterpillar/index.jsx
+++ b/client/components/gravatar-caterpillar/index.jsx
@@ -10,14 +10,16 @@ import { noop, map, size, takeRight, filter, uniqBy } from 'lodash';
  * Internal dependencies
  */
 import Gravatar from 'components/gravatar';
+import Count from 'components/count';
 
 class GravatarCaterpillar extends React.Component {
 	static propTypes = {
 		onClick: PropTypes.func,
+		showCount: PropTypes.bool,
 	};
 
 	render() {
-		const { users, onClick, maxGravatarsToDisplay } = this.props;
+		const { users, onClick, maxGravatarsToDisplay, showCount } = this.props;
 
 		if ( size( users ) < 1 ) {
 			return null;
@@ -31,6 +33,8 @@ class GravatarCaterpillar extends React.Component {
 			maxGravatarsToDisplay
 		);
 		const displayedUsersCount = size( displayedUsers );
+		const allUsersCount = size( users );
+		const usersNotDisplayedCount = allUsersCount - displayedUsersCount;
 
 		return (
 			<div className="gravatar-caterpillar" onClick={ onClick } aria-hidden="true">
@@ -49,6 +53,14 @@ class GravatarCaterpillar extends React.Component {
 						<Gravatar className={ gravClasses } key={ user.avatar_URL } user={ user } size={ 32 } />
 					);
 				} ) }
+				{ // @todo handle the increased count for small screens, because fewer avatars are displayed
+				showCount &&
+					usersNotDisplayedCount > 0 && (
+						<Count
+							count={ `${ usersNotDisplayedCount }+` }
+							className="gravatar-caterpillar__count"
+						/>
+					) }
 			</div>
 		);
 	}
@@ -57,6 +69,7 @@ class GravatarCaterpillar extends React.Component {
 GravatarCaterpillar.defaultProps = {
 	onClick: noop,
 	maxGravatarsToDisplay: 10,
+	showCount: false,
 };
 
 export default GravatarCaterpillar;

--- a/client/components/gravatar-caterpillar/index.jsx
+++ b/client/components/gravatar-caterpillar/index.jsx
@@ -19,7 +19,7 @@ class GravatarCaterpillar extends React.Component {
 	};
 
 	render() {
-		const { users, onClick, maxGravatarsToDisplay, showCount } = this.props;
+		const { users, onClick, maxGravatarsToDisplay, showCount, gravatarSize } = this.props;
 
 		if ( size( users ) < 1 ) {
 			return null;
@@ -50,7 +50,12 @@ class GravatarCaterpillar extends React.Component {
 					}
 
 					return (
-						<Gravatar className={ gravClasses } key={ user.avatar_URL } user={ user } size={ 32 } />
+						<Gravatar
+							className={ gravClasses }
+							key={ user.avatar_URL }
+							user={ user }
+							size={ gravatarSize }
+						/>
 					);
 				} ) }
 				{ // @todo handle the increased count for small screens, because fewer avatars are displayed
@@ -70,6 +75,7 @@ GravatarCaterpillar.defaultProps = {
 	onClick: noop,
 	maxGravatarsToDisplay: 10,
 	showCount: false,
+	gravatarSize: 32,
 };
 
 export default GravatarCaterpillar;

--- a/client/components/gravatar-caterpillar/style.scss
+++ b/client/components/gravatar-caterpillar/style.scss
@@ -18,8 +18,15 @@
 	&.is-hidden-on-small-screens {
 		display: none;
 
-		@include breakpoint( ">660px" ) {
-   			display: inline;
-   		}
+		@include breakpoint( '>660px' ) {
+			display: inline;
+		}
 	}
+}
+
+.gravatar-caterpillar__count {
+	height: 50%;
+	margin-top: 6px;
+	color: $gray;
+	border-color: $gray;
 }


### PR DESCRIPTION
Based on @jancavan's designs in p5PDj3-4fQ, show post likers on the Reader post card and at the end of full posts:

![likes0061](https://user-images.githubusercontent.com/17325/42858562-584f9fb4-8aa3-11e8-94ff-2e5771db8a32.png)

### Todo
- [ ] Pass total count to caterpillar (from `countPostLikes`)
- [ ] Move likes popover to caterpillar from like button
- [ ] Fix like count for smaller screens (where fewer avatars are shown)