### PR TITLE
LoaderStats: fail with more useful error output

### DIFF
--- a/bin/loader-stats.js
+++ b/bin/loader-stats.js
@@ -53,7 +53,6 @@ filesToLoadPerSection = sectionsToLoad.map(section => {
 
 async function calculateSizes( section ) {
 	const fileSizePromises = section.filesToLoad.map( f => gzipSize.file( f ) );
-
 	const fileSizes = await Promise.all( fileSizePromises );
 
 	const filesWithSizes = _.zipObject( section.filesToLoad, fileSizes );
@@ -79,7 +78,7 @@ async function go() {
 	console.log("Total Load: " + (totalSize / 1000) + "kb");
 }
 
-go();
+go().catch( console.error );
 
 
 


### PR DESCRIPTION
The script `bin/loader-stats.js` failed with a `UnhandledPromiseRejectionWarning` before in case `public/build.js` isn't there. Makes the output more readable. Discovered while working on #25978.

before

```
(node:16350) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, open '/wp-calypso/public/build.js'
(node:16350) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:16350) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code
```

after

```
{ [Error: ENOENT: no such file or directory, open '/wp-calypso/public/build.js']
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/Users/flootr/dev/wp-calypso/public/build.js' }
```