### PR TITLE
Checklists: enable in all envs

### DIFF
--- a/client/my-sites/checklist/index.js
+++ b/client/my-sites/checklist/index.js
@@ -11,12 +11,9 @@ import page from 'page';
  */
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { show } from './controller';
-import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	if ( config.isEnabled( 'onboarding-checklist' ) ) {
-		page( '/checklist', siteSelection, sites, makeLayout, clientRender );
-		page( '/checklist/:site_id', siteSelection, navigation, show, makeLayout, clientRender );
-	}
+	page( '/checklist', siteSelection, sites, makeLayout, clientRender );
+	page( '/checklist/:site_id', siteSelection, navigation, show, makeLayout, clientRender );
 }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -151,7 +151,7 @@ class StatsSite extends Component {
 					slug={ slug }
 				/>
 				<div id="my-stats-content">
-					{ config.isEnabled( 'onboarding-checklist' ) && <ChecklistBanner siteId={ siteId } /> }
+					<ChecklistBanner siteId={ siteId } />
 					{ config.isEnabled( 'google-my-business' ) &&
 						siteId && (
 							<GoogleMyBusinessStatsNudge

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -19,7 +19,6 @@ import Button from 'components/button';
 import Notice from 'components/notice';
 import analytics from 'lib/analytics';
 import { showOAuth2Layout } from 'state/ui/oauth2-clients/selectors';
-import config from 'config';
 import { getCurrentUser } from 'state/current-user/selectors';
 
 export class SignupProcessingScreen extends Component {
@@ -293,7 +292,6 @@ export class SignupProcessingScreen extends Component {
 		}, null );
 
 		return (
-			config.isEnabled( 'onboarding-checklist' ) &&
 			'blog' === designType &&
 			[ 'personal', 'premium', 'business' ].indexOf( this.props.flowName ) === -1
 		);

--- a/client/state/selectors/is-eligible-for-checkout-to-checklist.js
+++ b/client/state/selectors/is-eligible-for-checkout-to-checklist.js
@@ -11,7 +11,6 @@ import { some } from 'lodash';
 import { getSiteOption, isNewSite } from 'state/sites/selectors';
 import { cartItems } from 'lib/cart-values';
 import { isBusiness, isJetpackPlan } from 'lib/products-values';
-import config from 'config';
 
 /**
  * @param {Object} state Global state tree
@@ -21,10 +20,6 @@ import config from 'config';
  */
 export default function isEligibleForCheckoutToChecklist( state, siteId, cart ) {
 	const designType = getSiteOption( state, siteId, 'design_type' );
-
-	if ( ! config.isEnabled( 'onboarding-checklist' ) ) {
-		return false;
-	}
 
 	if (
 		cartItems.hasDomainMapping( cart ) ||

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -110,7 +110,6 @@
 		"notifications2beta": true,
 		"notifications/link-to-reader": true,
 		"oauth": true,
-		"onboarding-checklist": true,
 		"perfmon": false,
 		"persist-redux": true,
 		"plans/personal-plan": true,

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -110,7 +110,7 @@
 		"notifications2beta": true,
 		"notifications/link-to-reader": true,
 		"oauth": true,
-		"onboarding-checklist": false,
+		"onboarding-checklist": true,
 		"perfmon": false,
 		"persist-redux": true,
 		"plans/personal-plan": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -79,7 +79,7 @@
 		"me/notifications": true,
 		"me/trophies": false,
 		"oauth": true,
-		"onboarding-checklist": false,
+		"onboarding-checklist": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -79,7 +79,6 @@
 		"me/notifications": true,
 		"me/trophies": false,
 		"oauth": true,
-		"onboarding-checklist": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,

--- a/config/development.json
+++ b/config/development.json
@@ -128,7 +128,6 @@
 		"notifications2beta": true,
 		"notifications/link-to-reader": true,
 		"oauth": false,
-		"onboarding-checklist": true,
 		"perfmon": false,
 		"persist-redux": true,
 		"plans/personal-plan": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -83,7 +83,6 @@
 		"network-connection": true,
 		"notifications2beta": true,
 		"notifications/link-to-reader": true,
-		"onboarding-checklist": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -83,7 +83,7 @@
 		"network-connection": true,
 		"notifications2beta": true,
 		"notifications/link-to-reader": true,
-		"onboarding-checklist": false,
+		"onboarding-checklist": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,

--- a/config/production.json
+++ b/config/production.json
@@ -90,7 +90,6 @@
 		"nps-survey/devdocs": false,
 		"nps-survey/dev-trigger": false,
 		"nps-survey/notice": true,
-		"onboarding-checklist": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -92,7 +92,6 @@
 		"nps-survey/devdocs": false,
 		"nps-survey/dev-trigger": false,
 		"nps-survey/notice": true,
-		"onboarding-checklist": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,

--- a/config/test.json
+++ b/config/test.json
@@ -78,7 +78,7 @@
 		"me/trophies": false,
 		"network-connection": true,
 		"notifications2beta": true,
-		"onboarding-checklist": false,
+		"onboarding-checklist": true,
 		"perfmon": false,
 		"persist-redux": true,
 		"plans/personal-plan": true,

--- a/config/test.json
+++ b/config/test.json
@@ -78,7 +78,6 @@
 		"me/trophies": false,
 		"network-connection": true,
 		"notifications2beta": true,
-		"onboarding-checklist": true,
 		"perfmon": false,
 		"persist-redux": true,
 		"plans/personal-plan": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -103,7 +103,6 @@
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,
 		"nps-survey/notice": true,
-		"onboarding-checklist": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,


### PR DESCRIPTION
This PR enables the checklist in all environments.

In atomic commits:
- Enable in all env configs
- Remove the feature flag entirely (always enabled)

Is there a need to keep the feature flag?

- I can't think of a reason to disable _only_ on https://horizon.wordpress.com
- Desktop could be more sensitive, lets make sure to test there…

## Testing
1. Start up the desktop app (instructions p4TIVU-906-p2)
1. I've been unable to test 😕 