### PR TITLE
Support running Webpack build with MINIFY_JS=false

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,9 @@ const config = require( './server/config' );
 const calypsoEnv = config( 'env_id' );
 const bundleEnv = config( 'env' );
 const isDevelopment = bundleEnv !== 'production';
-const shouldMinify = process.env.MINIFY_JS === 'true' || bundleEnv === 'production';
+const shouldMinify =
+	process.env.MINIFY_JS === 'true' ||
+	( process.env.MINIFY_JS !== 'false' && bundleEnv === 'production' );
 const shouldEmitStats = process.env.EMIT_STATS === 'true';
 const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
 const codeSplit = config.isEnabled( 'code-splitting' );


### PR DESCRIPTION
This patch adds support for running a non-minified production build:
```
MINIFY_JS=false CALYPSO_ENV=production npm run build-client
```

I use that sometimes when debugging bundle size changes, like in #25961.