### PR TITLE
 Store: Fixed the selectors/plugins.js logic

### DIFF
--- a/client/extensions/woocommerce/state/selectors/plugins.js
+++ b/client/extensions/woocommerce/state/selectors/plugins.js
@@ -9,14 +9,14 @@ import { every, find } from 'lodash';
 import config from 'config';
 import { getPlugins, isRequestingForSites } from 'state/plugins/installed/selectors';
 import { getRequiredPluginsForCalypso } from 'woocommerce/lib/get-required-plugins';
-import { getSelectedSiteWithFallback } from '../sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * @param {Object} state Whole Redux state tree
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {boolean|null} Whether the given site has woocommerce services installed & active
  */
-export const isWcsEnabled = ( state, siteId = getSelectedSiteWithFallback( state ) ) => {
+export const isWcsEnabled = ( state, siteId = getSelectedSiteId( state ) ) => {
 	if ( ! config.isEnabled( 'woocommerce/extension-wcservices' ) ) {
 		return false;
 	}
@@ -36,10 +36,7 @@ export const isWcsEnabled = ( state, siteId = getSelectedSiteWithFallback( state
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {boolean|null} Whether the given site has all required plugins installed & active
  */
-export const areAllRequiredPluginsActive = (
-	state,
-	siteId = getSelectedSiteWithFallback( state )
-) => {
+export const areAllRequiredPluginsActive = ( state, siteId = getSelectedSiteId( state ) ) => {
 	const siteIds = [ siteId ];
 
 	if ( isRequestingForSites( state, siteIds ) ) {

--- a/client/extensions/woocommerce/state/selectors/test/fixtures/plugins.js
+++ b/client/extensions/woocommerce/state/selectors/test/fixtures/plugins.js
@@ -28,15 +28,15 @@ const woocommerceStripe = {
 export default {
 	installed: {
 		isRequesting: {
-			'site.one': false,
-			'site.two': false,
-			'site.three': false,
-			'site.four': true,
+			1: false,
+			2: false,
+			3: false,
+			4: true,
 		},
 		plugins: {
-			'site.one': [ woocommerce, woocommerceServices, woocommerceStripe ],
-			'site.two': [ woocommerce, woocommerceStripe, { ...woocommerceServices, active: false } ],
-			'site.three': [ woocommerce, woocommerceStripe ],
+			1: [ woocommerce, woocommerceServices, woocommerceStripe ],
+			2: [ woocommerce, woocommerceStripe, { ...woocommerceServices, active: false } ],
+			3: [ woocommerce, woocommerceStripe ],
 		},
 	},
 };

--- a/client/extensions/woocommerce/state/selectors/test/plugins.js
+++ b/client/extensions/woocommerce/state/selectors/test/plugins.js
@@ -18,28 +18,28 @@ const state = deepFreeze( { plugins } );
 
 /*
  * state.plugins has four sites:
- *  - site.one: all plugins installed and active
- *  - site.two: all plugins installed, WCS inactive
- *  - site.three: 2/3 plugins installed, WCS not installed
- *  - site.four: plugin state is still loading
+ *  - 1: all plugins installed and active
+ *  - 2: all plugins installed, WCS inactive
+ *  - 3: 2/3 plugins installed, WCS not installed
+ *  - 4: plugin state is still loading
  */
 
 describe( 'plugins', () => {
 	describe( '#areAllRequiredPluginsActive', () => {
 		it( 'should be null if the plugin list is being requested', () => {
-			expect( areAllRequiredPluginsActive( state, 'site.four' ) ).to.be.null;
+			expect( areAllRequiredPluginsActive( state, 4 ) ).to.be.null;
 		} );
 
 		it( 'should be false if a required plugin is not installed', () => {
-			expect( areAllRequiredPluginsActive( state, 'site.three' ) ).to.be.false;
+			expect( areAllRequiredPluginsActive( state, 3 ) ).to.be.false;
 		} );
 
 		it( 'should be false if a required plugin is not active', () => {
-			expect( areAllRequiredPluginsActive( state, 'site.two' ) ).to.be.false;
+			expect( areAllRequiredPluginsActive( state, 2 ) ).to.be.false;
 		} );
 
 		it( 'should be true if the plugin is installed and active', () => {
-			expect( areAllRequiredPluginsActive( state, 'site.one' ) ).to.be.true;
+			expect( areAllRequiredPluginsActive( state, 1 ) ).to.be.true;
 		} );
 	} );
 
@@ -48,24 +48,24 @@ describe( 'plugins', () => {
 			const configStub = sinon.stub( config, 'isEnabled' );
 			configStub.withArgs( 'woocommerce/extension-wcservices' ).returns( false );
 
-			expect( isWcsEnabled( state, 'site.one' ) ).to.be.false;
+			expect( isWcsEnabled( state, 1 ) ).to.be.false;
 			configStub.restore();
 		} );
 
 		it( 'should be null if the plugin list is being requested', () => {
-			expect( isWcsEnabled( state, 'site.four' ) ).to.be.null;
+			expect( isWcsEnabled( state, 4 ) ).to.be.null;
 		} );
 
 		it( 'should be false if the plugin is not installed', () => {
-			expect( isWcsEnabled( state, 'site.three' ) ).to.be.false;
+			expect( isWcsEnabled( state, 3 ) ).to.be.false;
 		} );
 
 		it( 'should be false if the plugin is not active', () => {
-			expect( isWcsEnabled( state, 'site.two' ) ).to.be.false;
+			expect( isWcsEnabled( state, 2 ) ).to.be.false;
 		} );
 
 		it( 'should be true if the plugin is installed and active', () => {
-			expect( isWcsEnabled( state, 'site.one' ) ).to.be.true;
+			expect( isWcsEnabled( state, 1 ) ).to.be.true;
 		} );
 	} );
 } );


### PR DESCRIPTION
If "siteId" is not provided, the default should be "getSelectedSiteId()", not "getSelectedSite()".

This doesn't affect any production code since those functions were always called with an explicit "siteId".

To test: Just check that the test passes.