### PR TITLE
Fix/plans tooltip

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -1278,7 +1278,7 @@ export const FEATURES_LIST = {
 		getSlug: () => FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
 		getTitle: () => i18n.translate( 'Email & Live Chat Support' ),
 		getDescription: () =>
-			i18n.translate( 'Live chat support to help you get started with Jetpack.' ),
+			i18n.translate( 'Live chat support to help you get started with your site.' ),
 	},
 
 	[ FEATURE_PREMIUM_SUPPORT ]: {

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -1278,16 +1278,14 @@ export const FEATURES_LIST = {
 		getSlug: () => FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
 		getTitle: () => i18n.translate( 'Email & Live Chat Support' ),
 		getDescription: () =>
-			i18n.translate(
-				'Hands-on support to help you set up your site ' + 'exactly how you want it.'
-			),
+			i18n.translate( 'Live chat support to help you get started with Jetpack.' ),
 	},
 
 	[ FEATURE_PREMIUM_SUPPORT ]: {
 		getSlug: () => FEATURE_PREMIUM_SUPPORT,
 		getTitle: () => i18n.translate( 'Priority Support' ),
 		getDescription: () =>
-			i18n.translate( 'Hands-on support to help you set up your site exactly how you want it.' ),
+			i18n.translate( 'Live chat support to help you get started with Jetpack.' ),
 	},
 
 	[ FEATURE_STANDARD_SECURITY_TOOLS ]: {


### PR DESCRIPTION
Fixes #25967

Changes the copy on both WordPress.com and Jetpack plans.

To test:
* Go to a WordPress.com site in Calypso
* Go to Plans
* Click the tooltip for Email & Live Chat Support

* Go to a Jetpack site in Calypso
* Go to Plans
* Click the tooltip for Priority Support

#### Before
**WordPress.com plans:**
![image](https://user-images.githubusercontent.com/1123119/42590635-9bdb3c0e-8501-11e8-8486-7a24847a13f9.png)

**Jetpack plans:**
![image](https://user-images.githubusercontent.com/1123119/42590654-abaa5e9e-8501-11e8-9a8e-1e94539a64da.png)


#### After

**WordPress.com plans:**
![image](https://user-images.githubusercontent.com/1123119/42590489-2bd6fcd6-8501-11e8-8672-a380efa3a617.png)

**Jetpack plans:**
![image](https://user-images.githubusercontent.com/1123119/42590337-cc93f300-8500-11e8-868e-8d0e1a6d3708.png)
