### PR TITLE
Add Store button to sidebar for non-business users and link it to an upsell landing page

### DIFF
--- a/assets/stylesheets/sections/feature-upsell.scss
+++ b/assets/stylesheets/sections/feature-upsell.scss
@@ -1,0 +1,5 @@
+/** @format */
+
+@import '../shared/mixins/breakpoints';
+@import '../shared/colors';
+@import 'my-sites/feature-upsell/style';

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,5 +1,14 @@
 /** @format */
 export default {
+	nudgeAPalooza: {
+		datestamp: '20180711',
+		variations: {
+			sidebarUpsells: 20,
+			control: 80,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 	springSale30PercentOff: {
 		datestamp: '20180413',
 		variations: {

--- a/client/my-sites/feature-upsell/controller.js
+++ b/client/my-sites/feature-upsell/controller.js
@@ -1,0 +1,31 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import page from 'page';
+
+/**
+ * Internal Dependencies
+ */
+import StoreUpsellComponent from './main';
+import { getSiteFragment } from 'lib/route';
+import { canCurrentUserUseStore } from 'state/sites/selectors';
+
+export default {
+	storeUpsell: function( context, next ) {
+		const siteFragment = getSiteFragment( context.path );
+		if ( ! siteFragment ) {
+			return page.redirect( '/feature/store' );
+		}
+
+		if ( canCurrentUserUseStore( context.store.getState() ) ) {
+			return page.redirect( '/store/' + siteFragment );
+		}
+
+		// Render
+		context.primary = React.createElement( StoreUpsellComponent );
+		next();
+	},
+};

--- a/client/my-sites/feature-upsell/index.js
+++ b/client/my-sites/feature-upsell/index.js
@@ -1,0 +1,41 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { navigation, siteSelection, sites } from 'my-sites/controller';
+import controller from './controller';
+import config from 'config';
+import { makeLayout, render as clientRender } from 'controller';
+import { getSiteFragment } from 'lib/route';
+
+export default function() {
+	if ( config.isEnabled( 'upsell/nudge-a-palooza' ) ) {
+		page( '/feature/store', siteSelection, sites, makeLayout, clientRender );
+
+		page(
+			'/feature/store/:domain',
+			siteSelection,
+			navigation,
+			controller.storeUpsell,
+			makeLayout,
+			clientRender
+		);
+
+		page( '/feature/store/*', ( { path } ) => {
+			const siteFragment = getSiteFragment( path );
+
+			if ( siteFragment ) {
+				return page.redirect( `/feature/store/${ siteFragment }` );
+			}
+
+			return page.redirect( '/feature/store' );
+		} );
+	}
+}

--- a/client/my-sites/feature-upsell/main.jsx
+++ b/client/my-sites/feature-upsell/main.jsx
@@ -1,0 +1,12 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import StoreUpsellComponent from './store-upsell';
+
+export default StoreUpsellComponent;

--- a/client/my-sites/feature-upsell/store-upsell.jsx
+++ b/client/my-sites/feature-upsell/store-upsell.jsx
@@ -50,11 +50,11 @@ class StoreUpsellComponent extends Component {
 		return (
 			<div role="main" className="main is-wide-layout feature-upsell feature-upsell-store">
 				{ ! price && (
-					<>
+					<React.Fragment>
 						<QueryPlans />
 						<QuerySitePlans siteId={ this.props.selectedSiteId } />
 						<QueryActivePromotions />
-					</>
+					</React.Fragment>
 				) }
 
 				<PageViewTracker path={ '/feature/store/:site' } title="StoreUpsell" />
@@ -72,7 +72,7 @@ class StoreUpsellComponent extends Component {
 					{ loadingPrice ? (
 						<div className="feature-upsell-placeholder feature-upsell-placeholder--cta" />
 					) : (
-						<>
+						<React.Fragment>
 							<button
 								onClick={ this.handleUpgradeButtonClick }
 								className="button is-primary feature-upsell-cta__button"
@@ -80,7 +80,7 @@ class StoreUpsellComponent extends Component {
 								Upgrade for { this.renderPrice() } and get started
 							</button>
 							<span className="feature-upsell-cta__guarantee">30-day money back guarantee</span>
-						</>
+						</React.Fragment>
 					) }
 				</div>
 

--- a/client/my-sites/feature-upsell/store-upsell.jsx
+++ b/client/my-sites/feature-upsell/store-upsell.jsx
@@ -1,0 +1,199 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import PurchaseDetail from 'components/purchase-detail';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { getPlan, getPlanPath } from 'lib/plans';
+import { PLAN_BUSINESS } from 'lib/plans/constants';
+import page from 'page';
+import { getSiteSlug } from 'state/sites/selectors';
+import {
+	getCurrentPlan,
+	getPlanDiscountedRawPrice,
+	isRequestingSitePlans,
+} from 'state/sites/plans/selectors';
+import DocumentHead from 'components/data/document-head';
+import QueryPlans from 'components/data/query-plans';
+import QuerySitePlans from 'components/data/query-site-plans';
+import QueryActivePromotions from 'components/data/query-active-promotions';
+import { getPlanRawPrice, isRequestingPlans } from 'state/plans/selectors';
+import { getCurrencyObject } from 'lib/format-currency';
+import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import { isRequestingActivePromotions } from 'state/active-promotions/selectors';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+class StoreUpsellComponent extends Component {
+	static propTypes = {
+		trackTracksEvent: PropTypes.func.isRequired,
+		price: PropTypes.number,
+		loadingPrice: PropTypes.bool.isRequired,
+		selectedSite: PropTypes.object.isRequired,
+		selectedSiteSlug: PropTypes.string.isRequired,
+	};
+
+	render() {
+		const { price, loadingPrice } = this.props;
+		return (
+			<div role="main" className="main is-wide-layout feature-upsell feature-upsell-store">
+				{ ! price && (
+					<>
+						<QueryPlans />
+						<QuerySitePlans siteId={ this.props.selectedSiteId } />
+						<QueryActivePromotions />
+					</>
+				) }
+
+				<PageViewTracker path={ '/feature/store/:site' } title="StoreUpsell" />
+				<DocumentHead title={ 'Store' } />
+
+				<header className="feature-upsell-header">
+					<h1 className="feature-upsell-header__title">Add an eCommerce store to this site</h1>
+					<p className="feature-upsell-header__subtitle">
+						Start selling now in United States - or go global - with the world’s most customizable
+						platform. We will even help you get rolling.
+					</p>
+				</header>
+
+				<div className="feature-upsell-cta">
+					{ loadingPrice ? (
+						<div className="feature-upsell-placeholder feature-upsell-placeholder--cta" />
+					) : (
+						<>
+							<button
+								onClick={ this.handleUpgradeButtonClick }
+								className="button is-primary feature-upsell-cta__button"
+							>
+								Upgrade for { this.renderPrice() } and get started
+							</button>
+							<span className="feature-upsell-cta__guarantee">30-day money back guarantee</span>
+						</>
+					) }
+				</div>
+
+				<h2 className="feature-upsell-section-header">Price includes:</h2>
+
+				<div className="product-purchase-features-list">
+					<div className="product-purchase-features-list__item">
+						<PurchaseDetail
+							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-concierge.svg" /> }
+							title={ '1 on 1 session with us' }
+							description={
+								'Getting where you want is easier when you have a guide. An expert will show you around and help you with setup.'
+							}
+						/>
+					</div>
+					<div className="product-purchase-features-list__item">
+						<PurchaseDetail
+							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-support.svg" /> }
+							title={ 'Priority support' }
+							description={
+								'Need help? A Happiness Engineer can answer any question you may have about your store and your account.'
+							}
+						/>
+					</div>
+					<div className="product-purchase-features-list__item">
+						<PurchaseDetail
+							icon={ <img alt="" src="/calypso/images/illustrations/google-adwords.svg" /> }
+							title={ '$100 for Google AdWords' }
+							description={ 'Start bringing traffic immediately with Google AdWords.' }
+						/>
+					</div>
+					<div className="product-purchase-features-list__item">
+						<PurchaseDetail
+							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-apps.svg" /> }
+							title={ 'Custom site address' }
+							description={
+								".com, .shop, or any other dot - it's on us. You choose an address and we pay for it."
+							}
+						/>
+					</div>
+					<div className="product-purchase-features-list__item">
+						<PurchaseDetail
+							icon={ <img alt="" src="/calypso/images/illustrations/ads-removed.svg" /> }
+							title={ 'Access to premium themes' }
+							description={
+								'Make your site perfect in just a few clicks with beautiful premium themes we prepared.'
+							}
+						/>
+					</div>
+					<div className="product-purchase-features-list__item">
+						<PurchaseDetail
+							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-updates.svg" /> }
+							title={ 'Even more!' }
+							description={
+								'Install plugins, start using advanced SEO features, and even more. We give you all the tools to make your store successful.'
+							}
+						/>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	handleUpgradeButtonClick = () => {
+		const { trackTracksEvent, selectedSiteSlug } = this.props;
+
+		trackTracksEvent( 'calypso_upsell_landing_page_cta_click', {
+			cta_name: 'store-upsell',
+		} );
+
+		page( `/checkout/${ selectedSiteSlug }/${ getPlanPath( PLAN_BUSINESS ) || '' }` );
+	};
+
+	renderPrice() {
+		if ( this.props.price === null ) {
+			return null;
+		}
+		const priceObject = getCurrencyObject( this.props.price, this.props.currencyCode );
+		let price = `${ priceObject.symbol }${ priceObject.integer }`;
+		if ( this.props.price.toFixed( 5 ).split( '.' )[ 1 ] !== '00000' ) {
+			price += priceObject.fraction;
+		}
+		return price;
+	}
+}
+
+const mapStateToProps = state => {
+	const selectedSite = getSelectedSite( state );
+	const selectedSiteId = getSelectedSiteId( state );
+	const currentSitePlan = getCurrentPlan( state, selectedSiteId );
+
+	const currentPlan = getPlan( PLAN_BUSINESS );
+	const currentPlanId = currentPlan.getProductId();
+	const rawPrice = getPlanRawPrice( state, currentPlanId, false );
+	const discountedRawPrice = getPlanDiscountedRawPrice( state, selectedSiteId, PLAN_BUSINESS, {
+		isMonthly: false,
+	} );
+	const price = discountedRawPrice || rawPrice;
+
+	return {
+		price,
+		selectedSite,
+		currentSitePlan,
+		loadingPrice:
+			! price &&
+			( isRequestingPlans( state ) ||
+				isRequestingSitePlans( state ) ||
+				isRequestingActivePromotions( state ) ),
+		currencyCode: getCurrentUserCurrencyCode( state ),
+		selectedSiteSlug: getSiteSlug( state, selectedSiteId ),
+		trackTracksEvent: recordTracksEvent,
+	};
+};
+
+export default connect( mapStateToProps )( localize( StoreUpsellComponent ) );
+/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/my-sites/feature-upsell/store-upsell.jsx
+++ b/client/my-sites/feature-upsell/store-upsell.jsx
@@ -16,7 +16,7 @@ import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import PurchaseDetail from 'components/purchase-detail';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getPlan, getPlanPath } from 'lib/plans';
+import { getPlan, getPlanPath, isFreePlan } from 'lib/plans';
 import { PLAN_BUSINESS } from 'lib/plans/constants';
 import page from 'page';
 import { getSiteSlug } from 'state/sites/selectors';
@@ -46,7 +46,7 @@ class StoreUpsellComponent extends Component {
 	};
 
 	render() {
-		const { price, loadingPrice } = this.props;
+		const { price, loadingPrice, currentSitePlanSlug } = this.props;
 		return (
 			<div role="main" className="main is-wide-layout feature-upsell feature-upsell-store">
 				{ ! price && (
@@ -112,15 +112,28 @@ class StoreUpsellComponent extends Component {
 							description={ 'Start bringing traffic immediately with Google AdWords.' }
 						/>
 					</div>
-					<div className="product-purchase-features-list__item">
-						<PurchaseDetail
-							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-apps.svg" /> }
-							title={ 'Custom site address' }
-							description={
-								".com, .shop, or any other dot - it's on us. You choose an address and we pay for it."
-							}
-						/>
-					</div>
+					{ isFreePlan( currentSitePlanSlug ) ? (
+						<div className="product-purchase-features-list__item">
+							<PurchaseDetail
+								icon={ <img alt="" src="/calypso/images/illustrations/jetpack-apps.svg" /> }
+								title={ 'Custom site address' }
+								description={
+									".com, .shop, or any other dot - it's on us. You choose an address and we pay for it."
+								}
+							/>
+						</div>
+					) : (
+						<div className="product-purchase-features-list__item">
+							<PurchaseDetail
+								icon={ <img alt="" src="/calypso/images/illustrations/jetpack-apps.svg" /> }
+								title={ 'Install Plugins' }
+								description={
+									'Plugins are like smartphone apps for WordPress. They provide features like: ' +
+									'SEO and marketing, lead generation, appointment booking, and much, much more.'
+								}
+							/>
+						</div>
+					) }
 					<div className="product-purchase-features-list__item">
 						<PurchaseDetail
 							icon={ <img alt="" src="/calypso/images/illustrations/ads-removed.svg" /> }
@@ -131,13 +144,23 @@ class StoreUpsellComponent extends Component {
 						/>
 					</div>
 					<div className="product-purchase-features-list__item">
-						<PurchaseDetail
-							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-updates.svg" /> }
-							title={ 'Even more!' }
-							description={
-								'Install plugins, start using advanced SEO features, and even more. We give you all the tools to make your store successful.'
-							}
-						/>
+						{ isFreePlan( currentSitePlanSlug ) ? (
+							<PurchaseDetail
+								icon={ <img alt="" src="/calypso/images/illustrations/jetpack-updates.svg" /> }
+								title={ 'Even more!' }
+								description={
+									'Install plugins, start using advanced SEO features, and even more. We give you all the tools to make your store successful.'
+								}
+							/>
+						) : (
+							<PurchaseDetail
+								icon={ <img alt="" src="/calypso/images/illustrations/jetpack-updates.svg" /> }
+								title={ 'Even more!' }
+								description={
+									'Upload your own themes, start using advanced SEO features, and even more. We give you all the tools to make your store successful.'
+								}
+							/>
+						) }
 					</div>
 				</div>
 			</div>
@@ -184,6 +207,7 @@ const mapStateToProps = state => {
 		price,
 		selectedSite,
 		currentSitePlan,
+		currentSitePlanSlug: currentSitePlan ? currentSitePlan.productSlug : '',
 		loadingPrice:
 			! price &&
 			( isRequestingPlans( state ) ||

--- a/client/my-sites/feature-upsell/style.scss
+++ b/client/my-sites/feature-upsell/style.scss
@@ -1,0 +1,82 @@
+.main.feature-upsell-store {
+	margin-top: 48px;
+}
+
+.feature-upsell-placeholder--cta {
+	animation: pulse-light 800ms ease-in-out infinite;
+	background: $gray-lighten-20;
+	display: inline-block;
+	width: 350px;
+	max-width: 80%;
+	height: 50px;
+}
+
+.feature-upsell-header {
+	text-align: center;
+
+	&__title {
+		font-size: 68px;
+		font-weight: 300;
+		line-height: 1;
+
+		@include breakpoint( '<1280px' ) {
+			font-size: 40px;
+		}
+
+		@include breakpoint( '<660px' ) {
+			font-size: 30px;
+		}
+	}
+
+	&__subtitle {
+		margin-top: 15px;
+		font-size: 30px;
+		font-weight: 300;
+
+		@include breakpoint( '<1280px' ) {
+			font-size: 24px;
+		}
+
+		@include breakpoint( '<660px' ) {
+			font-size: 18px;
+		}
+	}
+}
+
+.feature-upsell-cta {
+	margin-top: 30px;
+	text-align: center;
+
+	&__button {
+		font-size: 25px;
+		margin: 0 auto;
+		padding: 13px 20px;
+
+		@include breakpoint( '<1280px' ) {
+			font-size: 20px;
+		}
+
+		@include breakpoint( '<660px' ) {
+			font-size: 18px;
+		}
+	}
+
+	&__guarantee {
+		display: block;
+		margin-top: 8px;
+		opacity: 0.8;
+	}
+}
+
+.feature-upsell-section-header {
+	margin: 40px 0 20px 0;
+	text-align: center;
+	font-size: 36px;
+	@include breakpoint( '<1280px' ) {
+		font-size: 26px;
+	}
+
+	@include breakpoint( '<660px' ) {
+		font-size: 20px;
+	}
+}

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -1,0 +1,138 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { MySitesSidebar } from '../sidebar';
+import config from 'config';
+import { abtest } from 'lib/abtest';
+
+jest.mock( 'lib/user', () => null );
+jest.mock( 'lib/user/index', () => null );
+jest.mock( 'lib/analytics/index', () => null );
+jest.mock( 'lib/abtest', () => ( {
+	abtest: jest.fn( () => {
+		return 'sidebarUpsells';
+	} ),
+} ) );
+jest.mock( 'lib/cart/store/index', () => null );
+jest.mock( 'my-sites/sidebar/manage-menu', () => null );
+jest.mock( 'lib/analytics/track-component-view', () => 'TrackComponentView' );
+jest.mock( 'my-sites/sidebar/utils', () => ( {
+	itemLinkMatches: jest.fn( () => true ),
+} ) );
+jest.mock( 'config', () => ( {
+	isEnabled: jest.fn( () => true ),
+} ) );
+
+jest.mock( 'config/index', () => ( {
+	isEnabled: jest.fn( () => true ),
+} ) );
+
+describe( 'MySitesSidebar', () => {
+	describe( 'MySitesSidebar.store()', () => {
+		const defaultProps = {
+			site: {},
+			siteSuffix: '/mysite.com',
+			translate: x => x,
+		};
+
+		beforeEach( () => {
+			config.isEnabled.mockImplementation( () => true );
+			abtest.mockImplementation( () => 'sidebarUpsells' );
+		} );
+
+		test( 'Should return null item if woocommerce/extension-dashboard is disabled', () => {
+			config.isEnabled.mockImplementation(
+				feature => feature !== 'woocommerce/extension-dashboard'
+			);
+			const Sidebar = new MySitesSidebar( {
+				isSiteAutomatedTransfer: false,
+				canUserManageOptions: true,
+				...defaultProps,
+			} );
+			const Store = () => Sidebar.store();
+
+			const wrapper = shallow( <Store /> );
+			expect( wrapper.html() ).toEqual( null );
+		} );
+
+		test( 'Should return store menu item if user can use store on this site', () => {
+			const Sidebar = new MySitesSidebar( {
+				canUserUseStore: true,
+				...defaultProps,
+			} );
+			const Store = () => Sidebar.store();
+
+			const wrapper = shallow( <Store /> );
+			expect( wrapper.props().link ).toEqual( '/store/mysite.com' );
+		} );
+
+		test( 'Should return null item if user can not use store on this site (nudge-a-palooza disabled)', () => {
+			config.isEnabled.mockImplementation( feature => feature !== 'upsell/nudge-a-palooza' );
+			const Sidebar = new MySitesSidebar( {
+				canUserUseStore: false,
+				...defaultProps,
+			} );
+			const Store = () => Sidebar.store();
+
+			const wrapper = shallow( <Store /> );
+			expect( wrapper.html() ).toEqual( null );
+		} );
+
+		test( 'Should return null item if managing user can not use store on this site (control a/b group)', () => {
+			abtest.mockImplementation( () => 'control' );
+			const Sidebar = new MySitesSidebar( {
+				canUserUseStore: false,
+				canUserManageOptions: true,
+				...defaultProps,
+			} );
+			const Store = () => Sidebar.store();
+
+			const wrapper = shallow( <Store /> );
+			expect( wrapper.html() ).toEqual( null );
+		} );
+
+		test( 'Should return null if non-managing user can not use store on this site (control a/b group)', () => {
+			abtest.mockImplementation( () => 'control' );
+			const Sidebar = new MySitesSidebar( {
+				canUserUseStore: false,
+				canUserManageOptions: true,
+				...defaultProps,
+			} );
+			const Store = () => Sidebar.store();
+
+			const wrapper = shallow( <Store /> );
+			expect( wrapper.html() ).toEqual( null );
+		} );
+
+		test( 'Should return upsell item if managing user can not use store on this site (nudge-a-palooza enabled)', () => {
+			const Sidebar = new MySitesSidebar( {
+				canUserUseStore: false,
+				canUserManageOptions: true,
+				...defaultProps,
+			} );
+			const Store = () => Sidebar.store();
+
+			const wrapper = shallow( <Store /> );
+			expect( wrapper.props().link ).toEqual( '/feature/store/mysite.com' );
+		} );
+
+		test( 'Should return upsell if non-managing user can not use store on this site (nudge-a-palooza enabled)', () => {
+			const Sidebar = new MySitesSidebar( {
+				canUserUseStore: false,
+				canUserManageOptions: true,
+				...defaultProps,
+			} );
+			const Store = () => Sidebar.store();
+
+			const wrapper = shallow( <Store /> );
+			expect( wrapper.props().link ).toEqual( '/feature/store/mysite.com' );
+		} );
+	} );
+} );

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -269,6 +269,14 @@ const sections = [
 		module: 'mailing-lists',
 		enableLoggedOut: true,
 	},
+	{
+		name: 'feature-upsell',
+		paths: [ '/feature' ],
+		module: 'my-sites/feature-upsell',
+		group: 'sites',
+		secondary: true,
+		css: 'feature-upsell',
+	},
 ];
 
 sections.push( {

--- a/config/development.json
+++ b/config/development.json
@@ -188,6 +188,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
+		"upsell/nudge-a-palooza": true,
 		"webpack/hot-loader": false,
 		"webpack/persistent-caching": false,
 		"woocommerce/extension-dashboard": true,

--- a/config/production.json
+++ b/config/production.json
@@ -135,6 +135,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
+		"upsell/nudge-a-palooza": false,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -142,6 +142,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
+		"upsell/nudge-a-palooza": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -159,6 +159,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
+		"upsell/nudge-a-palooza": false,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,


### PR DESCRIPTION
This PR adds an upsell of business plan by exposing Store menu item and linking it to a Landing Page. Related post: p9jf6J-Hl-p2

**Test plan:**
1. Open a free site in calypso
1. Enter A/B test group nudgeAPalooza -> sidebarUpsells
2. Confirm there is a "Store" Menu item visible and click on it
3. Confirm you were taken to a landing page such as one below:

<img width="1796" alt="zrzut ekranu 2018-07-11 o 20 08 51" src="https://user-images.githubusercontent.com/205419/42591359-c1c16250-8546-11e8-8a0c-30e7ea172c70.png">

4. Confirm that the purchase button takes you straight to checkout
5. Open a premium site in calypso and go the Store section
6. Confirm that "Custom site address" is not listed as one of the benefits and instead you can see "Install plugins"
7. Confirm the price on the purchase button is discounted and reflects what user can see on `/plans` page
8. While on Store landing page, switch to a business site using a site picker
9. Confirm you were redirected form the landing page to `/store`
10. Enter A/B test group nudgeAPalooza -> control 
11. Confirm there is no Store menu item for free sites