### PR TITLE
Add a new banner config to the plans page for an upcoming email

### DIFF
--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -3,7 +3,13 @@
 /**
  * Internal dependencies
  */
-import { GROUP_JETPACK, GROUP_WPCOM, TYPE_FREE, TYPE_PERSONAL } from 'lib/plans/constants';
+import {
+	GROUP_JETPACK,
+	GROUP_WPCOM,
+	TYPE_FREE,
+	TYPE_PERSONAL,
+	TYPE_PREMIUM,
+} from 'lib/plans/constants';
 
 /**
  * No translate() used in this file since we're launching those promotions just for the EN audience
@@ -29,6 +35,17 @@ export default [
 		targetPlans: [
 			{ type: TYPE_FREE, group: GROUP_JETPACK },
 			{ type: TYPE_PERSONAL, group: GROUP_JETPACK },
+		],
+	},
+	{
+		name: 'renewing_plan',
+		startsAt: new Date( 2018, 6, 11, 0, 0, 0 ),
+		endsAt: new Date( 2018, 6, 16, 23, 59, 59 ),
+		plansPageNoticeText:
+			'Enter coupon code YOURGIFT30 during checkout to redeem your 30% off discount!',
+		targetPlans: [
+			{ type: TYPE_PERSONAL, group: GROUP_WPCOM },
+			{ type: TYPE_PREMIUM, group: GROUP_WPCOM },
 		],
 	},
 ];


### PR DESCRIPTION
**Test Plan**

1. Set an attribute for _your user_.

From `wpsh`:
```
update_user_attribute(USER_ID, 'SSE_weekly_marketing_email_holdout_renewing_plan_upsell_autorenew_on_20180101', 'send')
```

2. Visit this page for _your site_ **with a Personal or Premium plan**.
http://calypso.localhost:3000/plans/[YOUR_SITE]/?discount=renewing_plan

3. You should see a banner at the top like this:
<img width="1068" alt="screen shot 2018-07-11 at 1 07 45 pm" src="https://user-images.githubusercontent.com/690843/42596711-7bfbee10-850b-11e8-88ab-ce04a2192b20.png">
