### PR TITLE
Activity Log: fixes a rehydration issue causing a white-out when `filter` is empty

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -493,7 +493,7 @@ export default connect(
 		const requestedBackupId = getRequestedBackup( state, siteId );
 		const rewindState = getRewindState( state, siteId );
 		const restoreStatus = rewindState.rewind && rewindState.rewind.status;
-		const filter = siteId && getActivityLogFilter( state, siteId );
+		const filter = getActivityLogFilter( state, siteId );
 		const logs = siteId && requestActivityLogs( siteId, filter );
 		const siteIsOnFreePlan = isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) );
 


### PR DESCRIPTION
[Reported](https://github.com/Automattic/wp-calypso/pull/25683#discussion_r201063923) by @dmsnell

To test:

1. Run this branch locally
2. Go to the Activity Log page for a site and open your JS console
3. Refresh the screen a few times until you get a 'Rehydration' notice in the console
4. Ensure the screen does not white out
