### PR TITLE
Store: Stats: Referrers: Stats page layout

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/constants.js
+++ b/client/extensions/woocommerce/app/store-stats/constants.js
@@ -6,7 +6,7 @@
 
 import { translate } from 'i18n-calypso';
 
-const sparkWidgetList1 = [
+export const sparkWidgets = [
 	{
 		key: 'products',
 		title: translate( 'Products Purchased' ),
@@ -22,27 +22,12 @@ const sparkWidgetList1 = [
 		title: translate( 'Coupons Used' ),
 		format: 'number',
 	},
-];
-
-const sparkWidgetList2 = [
 	{
 		key: 'total_refund',
 		title: translate( 'Refunds' ),
 		format: 'currency',
 	},
-	{
-		key: 'total_shipping',
-		title: translate( 'Shipping' ),
-		format: 'currency',
-	},
-	{
-		key: 'total_tax',
-		title: translate( 'Tax' ),
-		format: 'currency',
-	},
 ];
-
-export const sparkWidgets = [ sparkWidgetList1, sparkWidgetList2 ];
 
 export const topProducts = {
 	basePath: '/store/stats/products',

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -31,7 +31,6 @@ import {
 } from 'woocommerce/app/store-stats/constants';
 import { getEndPeriod, getQueries, getWidgetPath } from './utils';
 import QuerySiteStats from 'components/data/query-site-stats';
-import config from 'config';
 import StoreStatsReferrerWidget from './store-stats-referrer-widget';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import titlecase from 'to-title-case';
@@ -99,8 +98,24 @@ class StoreStats extends Component {
 						showQueryDate
 					/>
 				</StatsPeriodNavigation>
-				{ config.isEnabled( 'woocommerce/extension-referrers' ) && (
-					<div>
+				<div className="store-stats__widgets">
+					<div className="store-stats__widgets-column widgets">
+						<Module
+							siteId={ siteId }
+							emptyMessage={ noDataMsg }
+							query={ orderQuery }
+							statType="statsOrders"
+						>
+							<WidgetList
+								siteId={ siteId }
+								query={ orderQuery }
+								selectedDate={ endSelectedDate }
+								statType="statsOrders"
+								widgets={ sparkWidgets }
+							/>
+						</Module>
+					</div>
+					<div className="store-stats__widgets-column widgets">
 						{ siteId && (
 							<QuerySiteStats
 								statType="statsStoreReferrers"
@@ -133,26 +148,6 @@ class StoreStats extends Component {
 							/>
 						</Module>
 					</div>
-				) }
-				<div className="store-stats__widgets">
-					{ sparkWidgets.map( ( widget, index ) => (
-						<div className="store-stats__widgets-column widgets" key={ index }>
-							<Module
-								siteId={ siteId }
-								emptyMessage={ noDataMsg }
-								query={ orderQuery }
-								statType="statsOrders"
-							>
-								<WidgetList
-									siteId={ siteId }
-									query={ orderQuery }
-									selectedDate={ endSelectedDate }
-									statType="statsOrders"
-									widgets={ widget }
-								/>
-							</Module>
-						</div>
-					) ) }
 					{ topWidgets.map( widget => {
 						const header = (
 							<SectionHeader href={ widget.basePath + widgetPath } label={ widget.title } />


### PR DESCRIPTION
This PR fixes the layout of the Referrers widget on Store stats page and removes the feature flag.

## Screenshots
I'm not entirely sure how to proceed here for wide screens. Any ideas @greenafrican @timmyc ? Here were our initial designs, https://automattic.invisionapp.com/d/main#/console/12315429/259978445/preview

wide widths
![screen shot 2018-07-12 at 10 25 01 am](https://user-images.githubusercontent.com/1922453/42602925-c8f9c49e-85bf-11e8-9fe2-24574b27361e.png)

narrow widths
![screen shot 2018-07-12 at 10 25 25 am](https://user-images.githubusercontent.com/1922453/42602941-d3aa7456-85bf-11e8-905b-e3bccf0d3cfe.png)

