### PR TITLE
Reader: fix Polldaddy survey embeds

### DIFF
--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -119,6 +119,7 @@ import makeEmbedsSafe from './rule-content-make-embeds-safe';
 import detectMedia from './rule-content-detect-media';
 import { disableAutoPlayOnMedia, disableAutoPlayOnEmbeds } from './rule-content-disable-autoplay';
 import detectPolls from './rule-content-detect-polls';
+import detectSurveys from './rule-content-detect-surveys';
 import makeContentLinksSafe from './rule-content-make-links-safe';
 
 normalizePost.content = {
@@ -131,6 +132,7 @@ normalizePost.content = {
 	disableAutoPlayOnMedia,
 	disableAutoPlayOnEmbeds,
 	detectPolls,
+	detectSurveys,
 };
 
 export default normalizePost;

--- a/client/lib/post-normalizer/rule-content-detect-polls.js
+++ b/client/lib/post-normalizer/rule-content-detect-polls.js
@@ -26,7 +26,7 @@ export default function detectPolls( post, dom ) {
 			return;
 		}
 
-		// some browers don't require this and let us query the dom inside a noscript. some do not. maybe just jsdom.
+		// some browsers don't require this and let us query the dom inside a noscript. some do not. maybe just jsdom.
 		const noscriptDom = domForHtml( noscript.innerHTML );
 
 		const pollLink = noscriptDom.querySelector( 'a[href^="http://polldaddy.com/poll/"]' );

--- a/client/lib/post-normalizer/rule-content-detect-surveys.js
+++ b/client/lib/post-normalizer/rule-content-detect-surveys.js
@@ -19,9 +19,15 @@ export default function detectSurveys( post, dom ) {
 
 	forEach( surveys, survey => {
 		// Get survey details
-		const { domain: surveyDomain, id: surveySlug } = JSON.parse(
-			survey.getAttribute( 'data-settings' )
-		);
+		let surveyDetails = null;
+
+		try {
+			surveyDetails = JSON.parse( survey.getAttribute( 'data-settings' ) );
+		} catch ( e ) {
+			return;
+		}
+
+		const { domain: surveyDomain, id: surveySlug } = surveyDetails;
 
 		if ( ! surveyDomain || ! surveySlug ) {
 			return;

--- a/client/lib/post-normalizer/rule-content-detect-surveys.js
+++ b/client/lib/post-normalizer/rule-content-detect-surveys.js
@@ -1,0 +1,20 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+// import { forEach } from 'lodash';
+// import i18n from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+//import { domForHtml } from './utils';
+
+export default function detectSurveys( post, dom ) {
+	if ( ! dom ) {
+		throw new Error( 'this transform must be used as part of withContentDOM' );
+	}
+
+	return post;
+}

--- a/client/lib/post-normalizer/rule-content-detect-surveys.js
+++ b/client/lib/post-normalizer/rule-content-detect-surveys.js
@@ -3,18 +3,43 @@
 /**
  * External dependencies
  */
-// import { forEach } from 'lodash';
-// import i18n from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-//import { domForHtml } from './utils';
+import { forEach } from 'lodash';
+import i18n from 'i18n-calypso';
 
 export default function detectSurveys( post, dom ) {
 	if ( ! dom ) {
 		throw new Error( 'this transform must be used as part of withContentDOM' );
 	}
+
+	const surveys = dom.querySelectorAll( '.pd-embed' );
+
+	if ( ! surveys ) {
+		return post;
+	}
+
+	forEach( surveys, survey => {
+		// Get survey details
+		const { domain: surveyDomain, id: surveySlug } = JSON.parse(
+			survey.getAttribute( 'data-settings' )
+		);
+
+		if ( ! surveyDomain || ! surveySlug ) {
+			return;
+		}
+
+		// Construct a survey link
+		const p = document.createElement( 'p' );
+		p.innerHTML =
+			'<a target="_blank" rel="external noopener noreferrer" href="https://' +
+			surveyDomain +
+			surveySlug +
+			'">' +
+			i18n.translate( 'Take our survey' ) +
+			'</a>';
+
+		// Replace the .pd-embed div with the new paragraph
+		survey.parentNode.replaceChild( p, survey );
+	} );
 
 	return post;
 }

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -1092,6 +1092,24 @@ describe( 'index', () => {
 				}
 			);
 		} );
+		test( 'links to embedded Polldaddy surveys', done => {
+			normalizer(
+				{
+					content:
+						'<div class="embed-polldaddy">' +
+						'<div class="pd-embed" data-settings="{&quot;type&quot;:&quot;iframe&quot;,&quot;auto&quot;:true,&quot;domain&quot;:&quot;bluefuton.polldaddy.com/s/&quot;,&quot;id&quot;:&quot;what-s-your-favourite-bird&quot;}">' +
+						'</div>',
+				},
+				[ normalizer.withContentDOM( [ normalizer.content.detectSurveys ] ) ],
+				function( err, normalized ) {
+					assert.include(
+						normalized.content,
+						'<p><a target="_blank" rel="external noopener noreferrer" href="https://bluefuton.polldaddy.com/s/what-s-your-favourite-bird">Take our survey</a></p>'
+					);
+					done( err );
+				}
+			);
+		} );
 
 		test( 'removes elements by selector', done => {
 			normalizer(

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -15,6 +15,7 @@ import DISPLAY_TYPES from './display-types';
 import createBetterExcerpt from 'lib/post-normalizer/rule-create-better-excerpt';
 import detectMedia from 'lib/post-normalizer/rule-content-detect-media';
 import detectPolls from 'lib/post-normalizer/rule-content-detect-polls';
+import detectSurveys from 'lib/post-normalizer/rule-content-detect-surveys';
 import makeEmbedsSafe from 'lib/post-normalizer/rule-content-make-embeds-safe';
 import removeStyles from 'lib/post-normalizer/rule-content-remove-styles';
 import makeImagesSafe from 'lib/post-normalizer/rule-content-make-images-safe';
@@ -114,6 +115,7 @@ const fastPostNormalizationRules = flow( [
 		disableAutoPlayOnMedia,
 		detectMedia,
 		detectPolls,
+		detectSurveys,
 		linkJetpackCarousels,
 	] ),
 	createBetterExcerpt,


### PR DESCRIPTION
When a Polldaddy survey is included in a post, Reader currently strips it out completely.

This PR adds a normalization rule that looks for Polldaddy surveys and renders a link to the survey (similar to the way we handle polls).

Fixes #25972 and fixes #10893.

### To test

Visit the test post at http://calypso.localhost:3000/read/feeds/84820645/posts/1921317670.

Ensure that it displays a 'Take our survey' link which links to my amazing "What is your favourite bird" survey.

<img width="186" alt="screen shot 2018-07-12 at 14 50 17" src="https://user-images.githubusercontent.com/17325/42609879-ea07a110-85e2-11e8-992f-3d5687b3616f.png">

If you're interested to see how other types of poll and survey embed look, there are more examples in this feed:

http://calypso.localhost:3000/read/feeds/84820645

