### PR TITLE
Gutenberg: add a section for development

### DIFF
--- a/assets/stylesheets/sections/gutenberg-editor.scss
+++ b/assets/stylesheets/sections/gutenberg-editor.scss
@@ -1,0 +1,10 @@
+@import '../shared/colors';
+@import '../shared/functions/z-index';
+@import '../shared/mixins/breakpoints';
+@import '../shared/mixins/clear-fix';
+@import '../shared/mixins/clear-text';
+@import '../shared/mixins/long-content-fade';
+@import '../shared/mixins/placeholder';
+@import '../shared/typography';
+
+@import 'gutenberg/editor/style';

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -1,0 +1,16 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import GutenbergEditor from 'gutenberg/editor/main';
+
+export const post = ( context, next ) => {
+	//reserved space for adding the post to context see post-editor/controller.js
+	context.primary = <GutenbergEditor />;
+	next();
+};

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -1,0 +1,27 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { siteSelection, sites } from 'my-sites/controller';
+import { post } from './controller';
+import config from 'config';
+import { makeLayout, render as clientRender } from 'controller';
+
+export default function() {
+	if ( config.isEnabled( 'gutenberg' ) ) {
+		page( '/gutenberg', '/gutenberg/post' );
+		page( '/gutenberg/post', siteSelection, sites, makeLayout, clientRender );
+		page( '/gutenberg/post/:site?/:post?', siteSelection, post, makeLayout, clientRender );
+		page( '/gutenberg/page', siteSelection, sites, makeLayout, clientRender );
+		page( '/gutenberg/page/:site?/:post?', siteSelection, post, makeLayout, clientRender );
+	} else {
+		page( '/gutenberg', '/post' );
+		page( '/gutenberg/*', '/post' );
+	}
+	//don't forget CPTs later
+}

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -1,0 +1,13 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+class GutenbergEditor extends Component {
+	render() {
+		return <div className="editor">Hello, Gutenberg!</div>;
+	}
+}
+
+export default GutenbergEditor;

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -1,0 +1,3 @@
+.editor {
+	background: none;
+}

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -448,4 +448,13 @@ sections.push( {
 	isomorphic: false,
 } );
 
+sections.push( {
+	name: 'gutenberg-editor',
+	paths: [ '/gutenberg' ],
+	module: 'gutenberg/editor',
+	group: 'editor',
+	css: 'gutenberg-editor',
+	secondary: true,
+} );
+
 module.exports = sections;

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -43,6 +43,7 @@
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,
+		"gutenberg": false,
 		"help": true,
 		"help/courses": true,
 		"jetpack/api-cache": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -37,6 +37,7 @@
 		"gdpr-banner": true,
 		"google-analytics": true,
 		"google-my-business": false,
+		"gutenberg": false,
 		"help": true,
 		"help/courses": true,
 		"jetpack/connect/remote-install": true,

--- a/config/development.json
+++ b/config/development.json
@@ -63,6 +63,7 @@
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,
+		"gutenberg": true,
 		"help": true,
 		"help/courses": true,
 		"i18n/community-translator": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -37,6 +37,7 @@
 		"gdpr-banner": true,
 		"google-my-business": false,
 		"google-analytics": true,
+		"gutenberg": false,
 		"happychat": false,
 		"help": true,
 		"help/courses": true,

--- a/config/production.json
+++ b/config/production.json
@@ -36,6 +36,7 @@
 		"gdpr-banner": true,
 		"google-analytics": true,
 		"google-my-business": true,
+		"gutenberg": false,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -39,6 +39,7 @@
 		"gdpr-banner": false,
 		"google-my-business": true,
 		"google-analytics": false,
+		"gutenberg": false,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/test.json
+++ b/config/test.json
@@ -37,6 +37,7 @@
 		"gdpr-banner": false,
 		"google-analytics": false,
 		"google-my-business": false,
+		"gutenberg": true,
 		"help": true,
 		"jetpack/checklist": true,
 		"jetpack/connect/remote-install": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -45,6 +45,7 @@
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,
+		"gutenberg": false,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
This closes #25971, and adds a feature flag and basic routes: `/gutenberg` and `/gutenberg/post` and `/gutenberg/page` to allow us to work on adding Gutenberg into Calypso without a long lived feature branch. Eventually when Gutenberg will take over as the primary editor, it will use `/post` and `/page`, but that is a ways off.

@jsnajdr has made an excellent start in https://github.com/Automattic/wp-calypso/pull/25590 and @Automattic/lannister will be building on top of that work, and pulling in smaller changes to master, in the next few weeks.

Care was taken to add a new css and js bundle so we don't bloat other sections during development.

Folks may verify that no js bundles were affected here:
http://iscalypsofastyet.com/branch?branch=add/gutenberg-section

### Testing Instructions

#### With the gutenberg feature flag enabled:
- Start calypso in a development environment with `npm start`
- Navigate to /gutenberg
- You are redirected to /gutenberg/post and prompted to select a site
- Site Selection works and we see a hello world page:
<img width="1094" alt="screen shot 2018-07-11 at 6 12 07 pm" src="https://user-images.githubusercontent.com/1270189/42607341-30b18c90-8537-11e8-9508-02623353398e.png">

#### With the gutenberg feature flag disabled
- Stop the Calypso instance and run with the `gutenberg` feature flag disabled `DISABLE_FEATURES=gutenberg npm start`
-  Navigate to /gutenberg
- You are redirected to /post
(Note that new routes need to be whitelisted for WordPress.com anyway)

#### Verify
- Verify that the gutenberg styles are in their own css file.
- Verify that we do not bloat other js sections
- No Calypso Regressions

### Next Steps After this PR lands
- Some tasks I see after this is figuring out a good working space for the editor. For example, can we avoid rendering the masterbar, and adding additional css resets?
- In parallel, we can experiment with pulling in needed Gutenberg files without copying them physically. For example, either by helping publish additional packages, or using github dep links.
