### PR TITLE
Remove 'ignore' dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6079,9 +6079,9 @@
       }
     },
     "eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.2.tgz",
+      "integrity": "sha512-tava3nCx6wgTGpAECrAWSdS638CQBNgfQbJ4Mo1SmFL3TkFjM3G43WIn2zweFIkOfcRKzQwjPE5o2yFdQqwUWw==",
       "requires": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -258,7 +258,6 @@
     "fs-extra": "6.0.1",
     "glob": "7.1.2",
     "husky": "0.14.3",
-    "ignore": "3.3.10",
     "jest": "22.4.2",
     "jest-docblock": "22.0.3",
     "jest-junit-reporter": "1.1.0",


### PR DESCRIPTION
related to #25816 

The only occurrence of 'ignore' was removed with #24906. We should be able to safely remove it from our dependency list.

### testing

I did a search for _'ignore'_ in Calypso but couldn't find any usage. 