### PR TITLE
Memberships: remove UNSAFE_componentWillReceiveProps 

### DIFF
--- a/client/components/data/query-memberships/index.js
+++ b/client/components/data/query-memberships/index.js
@@ -15,9 +15,7 @@ import { requestProducts } from 'state/memberships/product-list/actions';
 
 class QueryMemberships extends Component {
 	static propTypes = {
-		productId: PropTypes.number,
 		siteId: PropTypes.number.isRequired,
-		requestProduct: PropTypes.func,
 		requestProducts: PropTypes.func,
 	};
 
@@ -25,29 +23,16 @@ class QueryMemberships extends Component {
 		productId: null,
 	};
 
-	UNSAFE_componentWillMount() {
-		this.request( this.props );
-	}
-
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.siteId !== this.props.siteId || nextProps.productId !== this.props.productId ) {
-			this.request( nextProps );
-		}
-	}
-
-	request( props ) {
-		const { siteId, productId } = props;
-
-		if ( ! siteId ) {
+	componentDidMount() {
+		if ( this.props.requesting ) {
 			return;
 		}
 
-		// Products are indexed from 1.
-		if ( productId === 0 ) {
+		if ( ! this.props.siteId ) {
 			return;
 		}
 
-		props.requestProducts( siteId );
+		this.props.requestProducts( this.props.siteId );
 	}
 
 	render() {

--- a/client/components/data/query-memberships/index.js
+++ b/client/components/data/query-memberships/index.js
@@ -19,11 +19,7 @@ class QueryMemberships extends Component {
 		requestProducts: PropTypes.func,
 	};
 
-	static defaultProps = {
-		productId: null,
-	};
-
-	componentDidMount() {
+	request() {
 		if ( this.props.requesting ) {
 			return;
 		}
@@ -33,6 +29,16 @@ class QueryMemberships extends Component {
 		}
 
 		this.props.requestProducts( this.props.siteId );
+	}
+
+	componentDidMount() {
+		this.request();
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( this.props.siteId !== prevProps.siteId ) {
+			this.request();
+		}
 	}
 
 	render() {

--- a/client/components/tinymce/plugins/simple-payments/dialog/memberships.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/memberships.jsx
@@ -148,13 +148,13 @@ class MembershipsDialog extends Component {
 		};
 	}
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
+	componentDidUpdate( prevProps ) {
 		// When transitioning from hidden to visible, show and initialize the form
-		if ( nextProps.showDialog && ! this.props.showDialog ) {
-			if ( nextProps.editPaymentId ) {
+		if ( this.props.showDialog && ! prevProps.showDialog ) {
+			if ( this.props.editPaymentId ) {
 				// Explicitly ordered to edit a particular button
-				this.showButtonForm( nextProps.editPaymentId );
-			} else if ( isEmptyArray( nextProps.paymentButtons ) ) {
+				this.showButtonForm( this.props.editPaymentId );
+			} else if ( isEmptyArray( this.props.paymentButtons ) ) {
 				// If the button list is loaded and empty, show the "Add New" form
 				this.showButtonForm( null );
 			} else {
@@ -164,7 +164,7 @@ class MembershipsDialog extends Component {
 		}
 
 		// If the list has finished loading and is empty, switch from list to the "Add New" form
-		if ( this.props.paymentButtons === null && isEmptyArray( nextProps.paymentButtons ) ) {
+		if ( prevProps.paymentButtons === null && isEmptyArray( this.props.paymentButtons ) ) {
 			this.showButtonForm( null );
 		}
 	}

--- a/client/components/tinymce/plugins/simple-payments/dialog/memberships.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/memberships.jsx
@@ -148,26 +148,62 @@ class MembershipsDialog extends Component {
 		};
 	}
 
-	componentDidUpdate( prevProps ) {
-		// When transitioning from hidden to visible, show and initialize the form
-		if ( this.props.showDialog && ! prevProps.showDialog ) {
-			if ( this.props.editPaymentId ) {
-				// Explicitly ordered to edit a particular button
-				this.showButtonForm( this.props.editPaymentId );
-			} else if ( isEmptyArray( this.props.paymentButtons ) ) {
-				// If the button list is loaded and empty, show the "Add New" form
-				this.showButtonForm( null );
-			} else {
-				// If the list is loading or is non-empty, show it
-				this.showButtonList();
-			}
+	getDerivedStateFromProps( props, state ) {
+		const openedDialog = props.showDialog && ! state.showDialog;
+		const loadedAndEmpty = state.paymentButtons === null && isEmptyArray( props.paymentButtons );
+
+		if ( ! openedDialog && ! loadedAndEmpty ) {
+			return null;
 		}
 
-		// If the list has finished loading and is empty, switch from list to the "Add New" form
-		if ( prevProps.paymentButtons === null && isEmptyArray( this.props.paymentButtons ) ) {
-			this.showButtonForm( null );
-		}
+		const buttonFormState = editedPaymentId => ( {
+			activeTab: 'form',
+			editedPaymentId,
+			initialFormValues: this.getInitialFormFields( editedPaymentId ),
+		} );
+
+		const dialogState = () => {
+			if ( props.editPaymentId ) {
+				return buttonFormState( props.editPaymentId );
+			}
+
+			if ( isEmptyArray( props.paymentButtons ) ) {
+				return buttonFormState( null );
+			}
+
+			return { activeTab: 'list' };
+		};
+
+		const formState = () => buttonFormState( null );
+
+		return {
+			...( openedDialog ? dialogState() : {} ),
+			...( loadedAndEmpty ? formState() : {} ),
+			showDialog: props.showDialog,
+			paymentButtons: props.paymentButtons,
+		};
 	}
+
+	// componentDidUpdate( prevProps ) {
+	// 	// When transitioning from hidden to visible, show and initialize the form
+	// 	if ( this.props.showDialog && ! prevProps.showDialog ) {
+	// 		if ( this.props.editPaymentId ) {
+	// 			// Explicitly ordered to edit a particular button
+	// 			this.showButtonForm( this.props.editPaymentId );
+	// 		} else if ( isEmptyArray( this.props.paymentButtons ) ) {
+	// 			// If the button list is loaded and empty, show the "Add New" form
+	// 			this.showButtonForm( null );
+	// 		} else {
+	// 			// If the list is loading or is non-empty, show it
+	// 			this.showButtonList();
+	// 		}
+	// 	}
+	//
+	// 	// If the list has finished loading and is empty, switch from list to the "Add New" form
+	// 	if ( prevProps.paymentButtons === null && isEmptyArray( this.props.paymentButtons ) ) {
+	// 		this.showButtonForm( null );
+	// 	}
+	// }
 
 	componentDidMount() {
 		this._isMounted = true;

--- a/client/components/tinymce/plugins/simple-payments/dialog/memberships.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/memberships.jsx
@@ -148,7 +148,7 @@ class MembershipsDialog extends Component {
 		};
 	}
 
-	getDerivedStateFromProps( props, state ) {
+	static getDerivedStateFromProps( props, state ) {
 		const openedDialog = props.showDialog && ! state.showDialog;
 		const loadedAndEmpty = state.paymentButtons === null && isEmptyArray( props.paymentButtons );
 

--- a/client/components/tinymce/plugins/simple-payments/dialog/memberships.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/memberships.jsx
@@ -184,27 +184,6 @@ class MembershipsDialog extends Component {
 		};
 	}
 
-	// componentDidUpdate( prevProps ) {
-	// 	// When transitioning from hidden to visible, show and initialize the form
-	// 	if ( this.props.showDialog && ! prevProps.showDialog ) {
-	// 		if ( this.props.editPaymentId ) {
-	// 			// Explicitly ordered to edit a particular button
-	// 			this.showButtonForm( this.props.editPaymentId );
-	// 		} else if ( isEmptyArray( this.props.paymentButtons ) ) {
-	// 			// If the button list is loaded and empty, show the "Add New" form
-	// 			this.showButtonForm( null );
-	// 		} else {
-	// 			// If the list is loading or is non-empty, show it
-	// 			this.showButtonList();
-	// 		}
-	// 	}
-	//
-	// 	// If the list has finished loading and is empty, switch from list to the "Add New" form
-	// 	if ( prevProps.paymentButtons === null && isEmptyArray( this.props.paymentButtons ) ) {
-	// 		this.showButtonForm( null );
-	// 	}
-	// }
-
 	componentDidMount() {
 		this._isMounted = true;
 	}


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/25808 I introduced UNSAFE_componentWillReceiveProps  . In this PR I am rectifying that.

This should introduce no functional changes.

# Testing
Detailed testing instructions for memberships are here p89M8K-4I-p2
This touches 'Testing setting up a plan – publisher flow'.
 
Remember to build calypso with `ENABLE_FEATURES=memberships npm start`
