### PR TITLE
Remove any whitespace around the domain transfer authorization code.

### DIFF
--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -293,7 +293,7 @@ class TransferDomainPrecheck extends React.Component {
 	}
 
 	setAuthCode = event => {
-		this.setState( { authCode: event.target.value } );
+		this.setState( { authCode: event.target.value.trim() } );
 	};
 
 	getHeader() {


### PR DESCRIPTION
Testing: 
Start a domain transfer.
In the authorization code section the string will be trimmed.

This will prevent errant spaces from being added to the code causing it to fail validation.