### PR TITLE
Framework: `dispatchRequest` update (feed follow me delete)

### DIFF
--- a/client/state/data-layer/wpcom/read/following/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/index.js
@@ -9,7 +9,7 @@ import { translate } from 'i18n-calypso';
  */
 import config from 'config';
 import { READER_UNFOLLOW } from 'state/action-types';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 import { follow } from 'state/reader/follows/actions';
@@ -18,38 +18,39 @@ import { getSiteByFeedUrl } from 'state/reader/sites/selectors';
 import { getSiteName } from 'reader/get-helpers';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
-export function requestUnfollow( { dispatch }, action ) {
-	const {
-		payload: { feedUrl },
-	} = action;
-	dispatch(
-		http( {
-			method: 'POST',
-			path: '/read/following/mine/delete',
-			apiVersion: '1.1',
-			body: {
-				url: feedUrl,
-				source: config( 'readerFollowingSource' ),
-			},
-			onSuccess: action,
-			onFailure: action,
-		} )
-	);
-}
+export const requestUnfollow = action =>
+	http( {
+		method: 'POST',
+		path: '/read/following/mine/delete',
+		apiVersion: '1.1',
+		body: {
+			url: action.payload.feedUrl,
+			source: config( 'readerFollowingSource' ),
+		},
+		onSuccess: action,
+		onFailure: action,
+	} );
 
-export function receiveUnfollow( store, action, response ) {
-	if ( response && ! response.subscribed ) {
-		store.dispatch( bypassDataLayer( action ) );
-	} else {
-		unfollowError( store, action );
+export const fromApi = data => {
+	if ( ! data ) {
+		throw new Error( 'Invalid API response: missing data' );
 	}
-}
 
-export function unfollowError( { dispatch, getState }, action ) {
+	if ( data.subscribed ) {
+		throw new Error( 'Did not unfollow' );
+	}
+
+	return data.subscribed;
+};
+
+export const receiveUnfollow = action => bypassDataLayer( action );
+
+export const unfollowError = action => ( dispatch, getState ) => {
 	const feedUrl = action.payload.feedUrl;
 	const site = getSiteByFeedUrl( getState(), feedUrl );
 	const feed = getFeedByFeedUrl( getState(), feedUrl );
 	const siteTitle = getSiteName( { feed, site } ) || feedUrl;
+
 	dispatch(
 		errorNotice(
 			translate( 'Sorry, there was a problem unfollowing %(siteTitle)s. Please try again.', {
@@ -60,9 +61,17 @@ export function unfollowError( { dispatch, getState }, action ) {
 			{ duration: 5000 }
 		)
 	);
+
 	dispatch( bypassDataLayer( follow( action.payload.feedUrl ) ) );
-}
+};
 
 export default {
-	[ READER_UNFOLLOW ]: [ dispatchRequest( requestUnfollow, receiveUnfollow, unfollowError ) ],
+	[ READER_UNFOLLOW ]: [
+		dispatchRequestEx( {
+			fetch: requestUnfollow,
+			onSuccess: receiveUnfollow,
+			onError: unfollowError,
+			fromApi,
+		} ),
+	],
 };


### PR DESCRIPTION
See #25121

In this patch we're replacing the use of dispatchRequest()
in the data layer handler to use the newer API exposed
as dispatchRequestEx() This should have no change in
actual effect or interaction.