### PR TITLE
Install only "production" dependencies on Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN        bash /tmp/env-config.sh
 # change. This layer should allow for final build times
 # to be limited only by the Calypso build speed.
 COPY       ./package.json ./npm-shrinkwrap.json /calypso/
-RUN        npm ci
+RUN        npm ci --only=production
 
 # Build a "source" layer
 #


### PR DESCRIPTION
Use `npm ci` with the `--only=production` flag on the Dockerfile so it only installs the "production" dependencies, ignoring the `devDependencies`. Before, we had `npm install --production`, but when we switched to `npm ci` that flag got forgotten :)

This came to me during the `eslint-scope` debacle, we shouldn't be installing those packages on production builds, that's just a waste of resources.

On my machine (with the `npm` cache full), `npm ci` takes about 12 seconds, and `npm ci --only=production` takes 9 seconds. I assume the difference is bigger in Docker because it doesn't have a cache.

To test, run `npm run build-docker && npm run docker` and check it compiles correctly.