### PR TITLE
lib/safe-image-url: return null for external images with query string before hitting Photon

### DIFF
--- a/client/lib/safe-image-url/index.js
+++ b/client/lib/safe-image-url/index.js
@@ -48,10 +48,16 @@ export default function safeImageUrl( url ) {
 		return url;
 	}
 
-	const { hostname } = parseUrl( url, false, true );
+	const { hostname, query } = parseUrl( url, false, true );
+
 	if ( REGEXP_A8C_HOST.test( hostname ) ) {
 		// Safely promote Automattic domains to HTTPS
 		return url.replace( /^http:/, 'https:' );
+	}
+
+	// If there's a query string, bail out because Photon doesn't support them on external URLs
+	if ( query && query.length > 0 ) {
+		return null;
 	}
 
 	return photon( url );

--- a/client/lib/safe-image-url/index.js
+++ b/client/lib/safe-image-url/index.js
@@ -48,7 +48,11 @@ export default function safeImageUrl( url ) {
 		return url;
 	}
 
-	const { hostname, query } = parseUrl( url, false, true );
+	const { hostname, query } = parseUrl(
+		url,
+		/* parseQueryString */ false,
+		/* slashesDenoteHost */ true
+	);
 
 	if ( REGEXP_A8C_HOST.test( hostname ) ) {
 		// Safely promote Automattic domains to HTTPS

--- a/client/lib/safe-image-url/test/index.js
+++ b/client/lib/safe-image-url/test/index.js
@@ -1,46 +1,41 @@
 /** @format */
 
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-
 describe( 'safeImageUrl()', () => {
 	let safeImageUrl;
 
 	function commonTests() {
 		test( 'should ignore a relative url', () => {
-			expect( safeImageUrl( '/foo' ) ).to.equal( '/foo' );
+			expect( safeImageUrl( '/foo' ) ).toEqual( '/foo' );
 		} );
 
 		test( 'should ignore a data url', () => {
 			const dataImageUrl =
 				'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-			expect( safeImageUrl( dataImageUrl ) ).to.equal( dataImageUrl );
+			expect( safeImageUrl( dataImageUrl ) ).toEqual( dataImageUrl );
 		} );
 
 		test( 'should make a non-whitelisted protocol safe', () => {
 			[ 'javascript:alert("foo")', 'data:application/json;base64,', 'about:config' ].forEach(
 				url => {
-					expect( safeImageUrl( url ) ).to.match( /^https:\/\/i[0-2]\.wp.com\// );
+					expect( safeImageUrl( url ) ).toMatch( /^https:\/\/i[0-2]\.wp.com\// );
 				}
 			);
 		} );
 
 		test( 'should make a non-wpcom http url safe', () => {
-			expect( safeImageUrl( 'http://example.com/foo' ) ).to.equal(
+			expect( safeImageUrl( 'http://example.com/foo' ) ).toEqual(
 				'https://i1.wp.com/example.com/foo'
 			);
 		} );
 
 		test( 'should make a non-wpcom https url safe', () => {
-			expect( safeImageUrl( 'https://example.com/foo' ) ).to.equal(
+			expect( safeImageUrl( 'https://example.com/foo' ) ).toEqual(
 				'https://i1.wp.com/example.com/foo?ssl=1'
 			);
 		} );
 
 		test( 'should make wp-com like subdomain url safe', () => {
-			expect( safeImageUrl( 'https://wordpress.com.example.com/foo' ) ).to.equal(
+			expect( safeImageUrl( 'https://wordpress.com.example.com/foo' ) ).toEqual(
 				'https://i0.wp.com/wordpress.com.example.com/foo?ssl=1'
 			);
 		} );
@@ -52,7 +47,7 @@ describe( 'safeImageUrl()', () => {
 					'https://wordpresscom/foo',
 					'https://wordpress.com.example.com/foo',
 				].map( safeImageUrl )
-			).to.eql( [
+			).toEqual( [
 				'https://i0.wp.com/examplewordpress.com/foo?ssl=1',
 				'https://i0.wp.com/wordpresscom/foo?ssl=1',
 				'https://i0.wp.com/wordpress.com.example.com/foo?ssl=1',
@@ -60,46 +55,46 @@ describe( 'safeImageUrl()', () => {
 		} );
 
 		test( 'should make a non-wpcom protocol relative url safe', () => {
-			expect( safeImageUrl( '//example.com/foo' ) ).to.equal( 'https://i1.wp.com/example.com/foo' );
+			expect( safeImageUrl( '//example.com/foo' ) ).toEqual( 'https://i1.wp.com/example.com/foo' );
 		} );
 
 		test( 'should promote an http wpcom url to https', () => {
-			expect( safeImageUrl( 'http://files.wordpress.com/' ) ).to.equal(
+			expect( safeImageUrl( 'http://files.wordpress.com/' ) ).toEqual(
 				'https://files.wordpress.com/'
 			);
-			expect( safeImageUrl( 'http://wordpress.com/' ) ).to.equal( 'https://wordpress.com/' );
+			expect( safeImageUrl( 'http://wordpress.com/' ) ).toEqual( 'https://wordpress.com/' );
 		} );
 
 		test( 'should leave https wpcom url alone', () => {
-			expect( safeImageUrl( 'https://files.wordpress.com/' ) ).to.equal(
+			expect( safeImageUrl( 'https://files.wordpress.com/' ) ).toEqual(
 				'https://files.wordpress.com/'
 			);
-			expect( safeImageUrl( 'https://wordpress.com/' ) ).to.equal( 'https://wordpress.com/' );
-			expect( safeImageUrl( 'https://blog-en.files.wordpress.com/' ) ).to.equal(
+			expect( safeImageUrl( 'https://wordpress.com/' ) ).toEqual( 'https://wordpress.com/' );
+			expect( safeImageUrl( 'https://blog-en.files.wordpress.com/' ) ).toEqual(
 				'https://blog-en.files.wordpress.com/'
 			);
 		} );
 
 		test( 'should promote an http gravatar url to https', () => {
-			expect( safeImageUrl( 'http://files.gravatar.com/' ) ).to.equal(
+			expect( safeImageUrl( 'http://files.gravatar.com/' ) ).toEqual(
 				'https://files.gravatar.com/'
 			);
-			expect( safeImageUrl( 'http://gravatar.com/' ) ).to.equal( 'https://gravatar.com/' );
+			expect( safeImageUrl( 'http://gravatar.com/' ) ).toEqual( 'https://gravatar.com/' );
 		} );
 
 		test( 'should leave https gravatar url alone', () => {
-			expect( safeImageUrl( 'https://files.gravatar.com/' ) ).to.equal(
+			expect( safeImageUrl( 'https://files.gravatar.com/' ) ).toEqual(
 				'https://files.gravatar.com/'
 			);
-			expect( safeImageUrl( 'https://gravatar.com/' ) ).to.equal( 'https://gravatar.com/' );
+			expect( safeImageUrl( 'https://gravatar.com/' ) ).toEqual( 'https://gravatar.com/' );
 		} );
 
 		test( 'should return null for urls with querystrings', () => {
-			expect( safeImageUrl( 'https://example.com/foo?bar' ) ).to.be.null;
-			expect( safeImageUrl( 'https://example.com/foo.jpg?bar' ) ).to.be.null;
-			expect( safeImageUrl( 'https://example.com/foo.jpeg?bar' ) ).to.be.null;
-			expect( safeImageUrl( 'https://example.com/foo.gif?bar' ) ).to.be.null;
-			expect( safeImageUrl( 'https://example.com/foo.png?bar' ) ).to.be.null;
+			expect( safeImageUrl( 'https://example.com/foo?bar' ) ).toBeNull();
+			expect( safeImageUrl( 'https://example.com/foo.jpg?bar' ) ).toBeNull();
+			expect( safeImageUrl( 'https://example.com/foo.jpeg?bar' ) ).toBeNull();
+			expect( safeImageUrl( 'https://example.com/foo.gif?bar' ) ).toBeNull();
+			expect( safeImageUrl( 'https://example.com/foo.png?bar' ) ).toBeNull();
 		} );
 	}
 
@@ -117,14 +112,14 @@ describe( 'safeImageUrl()', () => {
 
 		test( 'should ignore a blob url for current origin', () => {
 			const originalUrl = 'blob:https://wordpress.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71';
-			expect( safeImageUrl( originalUrl ) ).to.equal( originalUrl );
+			expect( safeImageUrl( originalUrl ) ).toEqual( originalUrl );
 		} );
 
 		test( 'should make a blob url for other origin safe', () => {
 			const originalUrl = 'blob:http://example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71';
 			const expectedUrl =
 				'https://i1.wp.com/http//example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71';
-			expect( safeImageUrl( originalUrl ) ).to.equal( expectedUrl );
+			expect( safeImageUrl( originalUrl ) ).toEqual( expectedUrl );
 		} );
 
 		commonTests();
@@ -139,7 +134,7 @@ describe( 'safeImageUrl()', () => {
 			const originalUrl = 'blob:http://example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71';
 			const expectedUrl =
 				'https://i1.wp.com/http//example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71';
-			expect( safeImageUrl( originalUrl ) ).to.equal( expectedUrl );
+			expect( safeImageUrl( originalUrl ) ).toEqual( expectedUrl );
 		} );
 
 		commonTests();

--- a/client/lib/safe-image-url/test/index.js
+++ b/client/lib/safe-image-url/test/index.js
@@ -95,6 +95,7 @@ describe( 'safeImageUrl()', () => {
 			expect( safeImageUrl( 'https://example.com/foo.jpeg?bar' ) ).toBeNull();
 			expect( safeImageUrl( 'https://example.com/foo.gif?bar' ) ).toBeNull();
 			expect( safeImageUrl( 'https://example.com/foo.png?bar' ) ).toBeNull();
+			expect( safeImageUrl( 'https://example.com/foo.png?width=90' ) ).toBeNull();
 		} );
 	}
 


### PR DESCRIPTION
`lib/safe-image-url` is a small module that takes a URL to a supposed image and returns a safe
version of it, guaranteed to be hosted by Automattic. It passes external images to Photon.

Photon does not process external images with a query string, and currently we just wait for Photon to handle that situation. Unfortunately, when Photon receives a URL that's malformed, it throws an error and that in turn breaks Reader streams.

<img width="1434" alt="screen shot 2018-07-13 at 11 58 15" src="https://user-images.githubusercontent.com/17325/42665516-101edce0-8694-11e8-94cd-32741b0670a8.png">

This PR amends `lib/safe-image-url` to bail out if we encounter an external image with a query string, before it is passed to Photon.

### To test 

Switch to the user mentioned in p5PDj3-4Bk-p2, and load their following stream at this point:

http://calypso.localhost:3000/?at=2018-07-12T15:06:00Z

Ensure that the stream is rendered correctly and that no placeholders get stuck.