### PR TITLE
Show a banner on the plans page when the free-to-paid-sidebar nudge is clicked

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -127,5 +127,6 @@ export default {
 			show: 50,
 		},
 		defaultVariation: 'noShow',
+		allowExistingUsers: true,
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -120,4 +120,12 @@ export default {
 		},
 		defaultVariation: 'control',
 	},
+	plansBannerFromDomainNudge: {
+		datestamp: '20180712',
+		variations: {
+			noShow: 50,
+			show: 50,
+		},
+		defaultVariation: 'noShow',
+	},
 };

--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -48,4 +48,12 @@ export default [
 			{ type: TYPE_PREMIUM, group: GROUP_WPCOM },
 		],
 	},
+	{
+		name: 'free_domain',
+		startsAt: new Date( 2018, 6, 9, 0, 0, 0 ),
+		endsAt: new Date( 2018, 8, 9, 23, 59, 59 ),
+		plansPageNoticeTextTitle: 'Get a free domain name by upgrading to any plan listed below!',
+		plansPageNoticeText:
+			'Improve your SEO, branding, credibility, and even word-of-mouth marketing with a custom domain. All plan upgrades include a free domain name of your choice.',
+	},
 ];

--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -50,8 +50,6 @@ export default [
 	},
 	{
 		name: 'free_domain',
-		startsAt: new Date( 2018, 6, 9, 0, 0, 0 ),
-		endsAt: new Date( 2018, 8, 9, 23, 59, 59 ),
 		plansPageNoticeTextTitle: 'Get a free domain name by upgrading to any plan listed below!',
 		plansPageNoticeText:
 			'Improve your SEO, branding, credibility, and even word-of-mouth marketing with a custom domain. All plan upgrades include a free domain name of your choice.',

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -30,6 +30,7 @@ import {
 } from 'state/plugins/premium/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import DomainToPaidPlanNotice from './domain-to-paid-plan-notice';
+import { abtest } from 'lib/abtest';
 
 class SiteNotice extends React.Component {
 	static propTypes = {
@@ -98,12 +99,16 @@ class SiteNotice extends React.Component {
 		}
 
 		const { site, translate } = this.props;
+		let href = '/plans/' + site.slug;
+		if ( abtest( 'plansBannerFromDomainNudge' ) === 'show' ) {
+			href = href + '/?discount=free_domain';
+		}
 
 		return (
 			<SidebarBanner
 				ctaName="free-to-paid-sidebar"
 				ctaText={ translate( 'Upgrade' ) }
-				href={ `/plans/${ site.slug }` }
+				href={ href }
 				icon="info-outline"
 				text={ translate( 'Free domain with a plan' ) }
 			/>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -127,6 +127,12 @@ class PlanFeatures extends Component {
 				icon="info-outline"
 				status="is-success"
 			>
+				{ activeDiscount.plansPageNoticeTextTitle && (
+					<strong>
+						{ activeDiscount.plansPageNoticeTextTitle }
+						{ <br /> }
+					</strong>
+				) }
 				{ activeDiscount.plansPageNoticeText }
 			</Notice>,
 			bannerContainer

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1348,7 +1348,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -6017,8 +6016,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6036,13 +6034,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6055,18 +6051,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6169,8 +6162,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6180,7 +6172,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6193,20 +6184,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6223,7 +6211,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6296,8 +6283,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6307,7 +6293,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6383,8 +6368,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6414,7 +6398,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6432,7 +6415,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6471,13 +6453,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -9153,8 +9133,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "longest-streak": {
       "version": "2.0.2",
@@ -14082,9 +14061,9 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "striptags": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
-      "integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-2.2.1.tgz",
+      "integrity": "sha1-TEULcI1BuL85zyTEn/I0/Gqr/TI="
     },
     "style-search": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "source-map": "0.1.39",
     "source-map-support": "0.5.6",
     "store": "1.3.20",
-    "striptags": "3.1.1",
+    "striptags": "2.2.1",
     "superagent": "2.3.0",
     "textarea-caret": "3.1.0",
     "thread-loader": "1.1.5",


### PR DESCRIPTION
A test to show a banner on the plans page when the free-to-paid-sidebar nudge is clicked

The PR depends on https://github.com/Automattic/wp-calypso/pull/26025 to first be merged.

------------

**Test Plan**

* Make sure https://github.com/Automattic/wp-calypso/pull/26025 has been merged.

* Visit http://calypso.localhost:3000/stats/day and choose one of your **free** sites.

* In the side bar you should see the "_Free domain with plan_" nudge.
<img width="277" alt="screen shot 2018-07-13 at 9 58 15 am" src="https://user-images.githubusercontent.com/690843/42704054-507097cc-8683-11e8-8f01-952fbe4e3018.png">

* Click the nudge.

* When you're taken to the plans page you should either see a banner or not, depending on your ab test assignment.

<img width="1098" alt="screen shot 2018-07-13 at 9 53 31 am" src="https://user-images.githubusercontent.com/690843/42703980-0a0b20ae-8683-11e8-9bde-c366ca95695d.png">

Change your assignment, refresh, and try again to make sure both variations work.

<img width="667" alt="screen shot 2018-07-13 at 9 53 15 am" src="https://user-images.githubusercontent.com/690843/42703989-160ed6ca-8683-11e8-879a-7162b5d2cf61.png">
