### PR TITLE
Reader Stream: Refactor pendingItems reducer to improve clarity

### DIFF
--- a/client/state/reader/streams/reducer.js
+++ b/client/state/reader/streams/reducer.js
@@ -121,17 +121,13 @@ export const pendingItems = ( state = PENDING_ITEMS_DEFAULT, action ) => {
 			const minDate = moment( last( streamItems ).date );
 
 			// only retain posts that are newer than ones we already have
-			if ( state.lastUpdated ) {
-				streamItems = streamItems.filter( item =>
-					moment( item.date ).isAfter( state.lastUpdated )
-				);
-			}
+			const newItems = state.lastUpdated
+				? streamItems.filter( item => moment( item.date ).isAfter( state.lastUpdated ) )
+				: [ ...streamItems ];
 
-			if ( streamItems.length === 0 ) {
+			if ( newItems.length === 0 ) {
 				return state;
 			}
-
-			const newItems = [ ...streamItems ];
 
 			// there is a gap if the oldest item in the poll is newer than last update time
 			if ( state.lastUpdated && minDate.isAfter( state.lastUpdated ) ) {


### PR DESCRIPTION
This PR attempts to refactor the Reader streams reducer to improve readability without altering the semantics of the code, following up on discussion in #25777

The code currently checks `streamItems.length === 0` twice because it mutates the variable in between. The mutation is pretty unusual in our code base, and the second test was really checking whether we've got any new items, so I've just rearranged things a bit so that it says that.

I don't know why the previous code copies the `streamItems` into a fresh array, so I've preserved that behavior, but only if we don't use `Array.filter()`, which creates a new array anyway.

### Testing:
The existing tests provide some reassurance that there's no change in behavior, so it should be sufficient to agree that the logic is unchanged and to run the existing tests.

The trickier part is confirming that it's actually clearer. Avoiding mutation is clearly an improvement, but I really need a second opinion for the subjective "easier to read".

@jsnajdr - Do you find this more obvious?