### PR TITLE
Checklists: Redirect Jetpack checklists to my plan

### DIFF
--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -46,15 +46,15 @@ class ChecklistMain extends PureComponent {
 	 * @param {?boolean} prevProps.isJetpack Previous isJetpack
 	 * @param {?string}  prevProps.siteSlug  Previous siteSlug
 	 */
-	maybeRedirectJetpack( { isAtomic, isJetpack, siteSlug } = {} ) {
+	maybeRedirectJetpack( prevProps = {} ) {
 		if (
 			this.props.siteSlug &&
 			false === this.props.isAtomic &&
 			this.props.isJetpack &&
 			some( [
-				this.props.siteSlug !== siteSlug,
-				this.props.isAtomic !== isAtomic,
-				this.props.isJetpack !== isJetpack,
+				this.props.siteSlug !== prevProps.siteSlug,
+				this.props.isAtomic !== prevProps.isAtomic,
+				this.props.isJetpack !== prevProps.isJetpack,
 			] )
 		) {
 			page.redirect( `/plans/my-plan/${ this.props.siteSlug }` );

--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -2,11 +2,11 @@
 /**
  * External dependencies
  */
+import page from 'page';
 import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
 import { find, some } from 'lodash';
-import page from 'page';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
Jetpack checklists are shown on the "My Plan" page.

When users arrive at the `/checklist/:SITE_SLUG` route for a Jetpack site, redirect to My Plan page.

Closes #26040 

## Testing
1. Visit https://calypso.live/checklist/SITE_SLUG?branch=update/redir-jp-checklists for a Simple site. No redirection.
1. Use Calypso site selection (navigate by clicking menus) to select an Atomic site. No redirection.
1. Use Calypso site selection (navigate by clicking menus) to select a Jetpack site. You should be redirected to `/plans/my-plan/SITE_SLUG` for the Jetpack site.
1. Other behavior remains unchanged.