### PR TITLE
Guided tour: Jetpack guided checklist links to "My Plan"

### DIFF
--- a/client/layout/guided-tours/tours/checklist-about-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-about-page-tour.js
@@ -141,7 +141,7 @@ export const ChecklistAboutPageTour = makeTour(
 								'return to our checklist and see what’s next.'
 						) }
 					</p>
-					<SiteLink isButton href={ '/checklist/:site' }>
+					<SiteLink isButton href="/checklist/:site">
 						{ translate( 'Return to the checklist' ) }
 					</SiteLink>
 				</Fragment>

--- a/client/layout/guided-tours/tours/checklist-contact-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-contact-page-tour.js
@@ -151,7 +151,7 @@ export const ChecklistContactPageTour = makeTour(
 								'to our checklist and see what’s next.'
 						) }
 					</p>
-					<SiteLink isButton href={ '/checklist/:site' }>
+					<SiteLink isButton href="/checklist/:site">
 						{ translate( 'Return to the checklist' ) }
 					</SiteLink>
 				</Fragment>

--- a/client/layout/guided-tours/tours/checklist-publish-post-tour.js
+++ b/client/layout/guided-tours/tours/checklist-publish-post-tour.js
@@ -220,7 +220,7 @@ export const ChecklistPublishPostTour = makeTour(
 								'Let’s move on and see what’s next on our checklist.'
 						) }
 					</p>
-					<SiteLink isButton href={ '/checklist/:site' }>
+					<SiteLink isButton href="/checklist/:site">
 						{ translate( 'Return to the checklist' ) }
 					</SiteLink>
 				</Fragment>

--- a/client/layout/guided-tours/tours/checklist-site-icon-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-icon-tour.js
@@ -139,7 +139,7 @@ export const ChecklistSiteIconTour = makeTour(
 							'Your Site Icon has been saved. Let’s move on and see what’s next on our checklist.'
 						) }
 					</p>
-					<SiteLink isButton href={ '/checklist/:site' }>
+					<SiteLink isButton href="/checklist/:site">
 						{ translate( 'Return to the checklist' ) }
 					</SiteLink>
 				</Fragment>

--- a/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
@@ -79,7 +79,7 @@ export const ChecklistSiteTaglineTour = makeTour(
 							'Your tagline has been saved! Let’s move on and see what’s next on our checklist.'
 						) }
 					</p>
-					<SiteLink isButton href={ '/checklist/:site' }>
+					<SiteLink isButton href="/checklist/:site">
 						{ translate( 'Return to the checklist' ) }
 					</SiteLink>
 				</Fragment>

--- a/client/layout/guided-tours/tours/checklist-site-title-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour.js
@@ -80,7 +80,7 @@ export const ChecklistSiteTitleTour = makeTour(
 							'Your changes have been saved. Let’s move on and see what’s next on our checklist.'
 						) }
 					</p>
-					<SiteLink isButton href={ '/checklist/:site' }>
+					<SiteLink isButton href="/checklist/:site">
 						{ translate( 'Return to the checklist' ) }
 					</SiteLink>
 				</Fragment>

--- a/client/layout/guided-tours/tours/jetpack-monitoring-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-monitoring-tour.js
@@ -69,7 +69,7 @@ export const JetpackMonitoringTour = makeTour(
 						) }
 					</p>
 					<ButtonRow>
-						<SiteLink isButton href={ '/plans/my-plan/:site' }>
+						<SiteLink isButton href="/plans/my-plan/:site">
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
 						<Quit>{ translate( 'No thanks.' ) }</Quit>

--- a/client/layout/guided-tours/tours/jetpack-monitoring-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-monitoring-tour.js
@@ -46,7 +46,9 @@ export const JetpackMonitoringTour = makeTour(
 							click
 							hidden
 						/>
-						<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
+						<SiteLink href="/plans/my-plan/:site">
+							{ translate( 'Return to the checklist' ) }
+						</SiteLink>
 					</ButtonRow>
 				</Fragment>
 			) }
@@ -67,7 +69,7 @@ export const JetpackMonitoringTour = makeTour(
 						) }
 					</p>
 					<ButtonRow>
-						<SiteLink isButton href={ '/checklist/:site' }>
+						<SiteLink isButton href={ '/plans/my-plan/:site' }>
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
 						<Quit>{ translate( 'No thanks.' ) }</Quit>

--- a/client/layout/guided-tours/tours/jetpack-sign-in-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-sign-in-tour.js
@@ -65,7 +65,7 @@ export const JetpackSignInTour = makeTour(
 						) }
 					</p>
 					<ButtonRow>
-						<SiteLink isButton href={ '/plans/my-plan/:site' }>
+						<SiteLink isButton href="/plans/my-plan/:site">
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
 						<Quit>{ translate( 'No thanks.' ) }</Quit>

--- a/client/layout/guided-tours/tours/jetpack-sign-in-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-sign-in-tour.js
@@ -41,7 +41,9 @@ export const JetpackSignInTour = makeTour(
 					</p>
 					<ButtonRow>
 						<Continue target=".sso__card .form-toggle__switch" step="finish" click hidden />
-						<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
+						<SiteLink href="/plans/my-plan/:site">
+							{ translate( 'Return to the checklist' ) }
+						</SiteLink>
 					</ButtonRow>
 				</Fragment>
 			) }
@@ -63,7 +65,7 @@ export const JetpackSignInTour = makeTour(
 						) }
 					</p>
 					<ButtonRow>
-						<SiteLink isButton href={ '/checklist/:site' }>
+						<SiteLink isButton href={ '/plans/my-plan/:site' }>
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
 						<Quit>{ translate( 'No thanks.' ) }</Quit>


### PR DESCRIPTION
Jetpack checklists will be shown at `/plans/my-plan/SITE_SLUG`. Jetpack guided tours that "return" or otherwise link to the related checklist should send users to that route.

Update relevant guided tours.

#26042 Adds redirection from `/checklist/SITE_SLUG` to `/plans/my-plan/SITE_SLUG` for Jetpack sites, so "generic" tours should continue to work well. This change avoids that unnecessary redirection for Jetpack tours.

Closes #26041

## Testing
1. Test with a new Jetpack site to ensure the checklist steps are available
1. Visit https://calypso.live/plans/my-plan/JETPACK_SITE_SLUG?branch=update/jetpack-guided-tours-returnstep
1. Test the monitoring and sign-in tours.
1. Ensure the relevant links link to `/plans/my-plan/JETPACK_SITE_SLUG`.