### PR TITLE
WIP: Add simple block build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ cover.html
 .test.log
 
 cached-requests.json
+
+# Gutenberg extensions
+/client/gutenberg/extensions/*/build

--- a/bin/create-scripts/block.js
+++ b/bin/create-scripts/block.js
@@ -1,0 +1,36 @@
+/** @format */
+const path = require( 'path' );
+const webpack = require( 'webpack' );
+
+const __rootDir = path.resolve( __dirname, '../../' );
+const entryPath = path.resolve( process.argv[ 2 ] );
+const sourceDir = path.dirname( entryPath );
+const outputDir = path.join( sourceDir, 'build' );
+const blockName = path.basename( path.dirname( entryPath ) );
+
+const baseConfig = require( path.join( __rootDir, 'webpack.config.js' ) );
+
+const config = {
+	...baseConfig,
+	...{
+		mode: 'production',
+		entry: entryPath,
+		externals: {
+			...baseConfig.externals,
+			wp: 'wp',
+		},
+		optimization: {
+			splitChunks: false,
+		},
+		output: {
+			path: outputDir,
+			filename: `blocks-${ blockName }.js`,
+			libraryTarget: 'window',
+			library: `blocks-${ blockName }`,
+		},
+	},
+};
+
+const compiler = webpack( config );
+
+compiler.run( ( error, stats ) => console.log( stats.toString() ) );

--- a/client/gutenberg/extensions/.eslintrc.js
+++ b/client/gutenberg/extensions/.eslintrc.js
@@ -1,0 +1,8 @@
+/** @format */
+
+module.exports = {
+	extends: '../../../.eslintrc.js',
+	rules: {
+		'react/react-in-jsx-scope': 0,
+	},
+};

--- a/client/gutenberg/extensions/hello-dolly/hello-block.js
+++ b/client/gutenberg/extensions/hello-dolly/hello-block.js
@@ -1,0 +1,8 @@
+/** @format */
+wp.blocks.registerBlockType( 'calypsoberg/hello-dolly', {
+	title: 'Hello Dolly',
+	icon: 'format-audio',
+	category: 'layout',
+	edit: ( { isSelected } ) => <p>{ isSelected ? 'Editing Hello Dolly' : 'Viewing Hello Dolly' }</p>,
+	save: () => <p>Saving Hello Dolly</p>,
+} );

--- a/client/gutenberg/extensions/hello-dolly/hello-block.js
+++ b/client/gutenberg/extensions/hello-dolly/hello-block.js
@@ -1,4 +1,9 @@
 /** @format */
+/**
+ * External dependencies
+ */
+import wp from 'wp';
+
 wp.blocks.registerBlockType( 'calypsoberg/hello-dolly', {
 	title: 'Hello Dolly',
 	icon: 'format-audio',


### PR DESCRIPTION
Creating a build script to start the Calypso SDK

See https://github.com/Automattic/wp-calypso/projects/72

 - This PR should not affect Calypso on WordPress.com
 - This PR is one component in a big project and thus represents an unfinished midpoint.

This PR is taking the first step towards reusing Calypso's libraries and build systems as a base for building Gutenberg blocks. Our goal will be to write blocks once in one place and have those blocks load natively inside Calypso as well as within `wp-admin`

In this PR we're hijacking the Calypso build process to perform code transpilation and build a bundle that we can import into WordPress via a normal `enqueue_script()` call.

![calytenberg mov](https://user-images.githubusercontent.com/5431237/42717640-bea5fe10-8702-11e8-9591-db30bea8c644.gif)

Currently building like this…
```bash
node bin/create-scripts/block.js client/gutenberg/extensions/hello-dolly/hello-block.js
```

That generates `block-hello-dolly.js`. For now this will depend on manually creating the corresponding PHP plugin for WordPress to load in `wp-admin` environments.

**Todo**
 - [x] move block to `client/gutenberg/extensions/hello-dolly` (play well with #26009)
 - [ ] ~generate PHP script to load block as plugin~ (deferred for later)

**Questions**
 - how should we be writing/wrapping the main export, how do we deal with the globals like `wp`?
 - how do we split our own dependencies so each block doesn't duplicate them?