### PR TITLE
Upsell/feature wordads

### DIFF
--- a/client/my-sites/feature-upsell/ads-upsell.jsx
+++ b/client/my-sites/feature-upsell/ads-upsell.jsx
@@ -1,0 +1,210 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import PurchaseDetail from 'components/purchase-detail';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { getPlan, getPlanPath, isFreePlan } from 'lib/plans';
+import { PLAN_PREMIUM } from 'lib/plans/constants';
+import page from 'page';
+import { getSiteSlug } from 'state/sites/selectors';
+import {
+	getCurrentPlan,
+	getPlanDiscountedRawPrice,
+	isRequestingSitePlans,
+} from 'state/sites/plans/selectors';
+import DocumentHead from 'components/data/document-head';
+import QueryPlans from 'components/data/query-plans';
+import QuerySitePlans from 'components/data/query-site-plans';
+import QueryActivePromotions from 'components/data/query-active-promotions';
+import { getPlanRawPrice, isRequestingPlans } from 'state/plans/selectors';
+import { getCurrencyObject } from 'lib/format-currency';
+import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import { isRequestingActivePromotions } from 'state/active-promotions/selectors';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+class WordAdsUpsellComponent extends Component {
+	static propTypes = {
+		trackTracksEvent: PropTypes.func.isRequired,
+		price: PropTypes.number,
+		loadingPrice: PropTypes.bool.isRequired,
+		selectedSite: PropTypes.object.isRequired,
+		selectedSiteSlug: PropTypes.string.isRequired,
+	};
+
+	render() {
+		const { price, loadingPrice, currentSitePlanSlug } = this.props;
+		return (
+			<div role="main" className="main is-wide-layout feature-upsell feature-upsell-ads">
+				{ ! price && (
+					<React.Fragment>
+						<QueryPlans />
+						<QuerySitePlans siteId={ this.props.selectedSiteId } />
+						<QueryActivePromotions />
+					</React.Fragment>
+				) }
+
+				<PageViewTracker path={ '/feature/ads/:site' } title="AdsUpsell" />
+				<DocumentHead title={ 'Ads' } />
+
+				<header className="feature-upsell-header">
+					<h1 className="feature-upsell-header__title">Start making money with this site!</h1>
+					<p className="feature-upsell-header__subtitle">
+						Welcome to WordAds: the advertising platform where internet’s top ad suppliers bid
+						against each other to deliver their ads to your site, maximizing your revenue.
+					</p>
+				</header>
+
+				<div className="feature-upsell-cta">
+					{ loadingPrice ? (
+						<div className="feature-upsell-placeholder feature-upsell-placeholder--cta" />
+					) : (
+						<React.Fragment>
+							<button
+								onClick={ this.handleUpgradeButtonClick }
+								className="button is-primary feature-upsell-cta__button"
+							>
+								Upgrade for { this.renderPrice() } and get started
+							</button>
+							<span className="feature-upsell-cta__guarantee">30-day money back guarantee</span>
+						</React.Fragment>
+					) }
+				</div>
+
+				<h2 className="feature-upsell-section-header">Price includes:</h2>
+
+				<div className="product-purchase-features-list">
+					<div className="product-purchase-features-list__item">
+						<PurchaseDetail
+							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-concierge.svg" /> }
+							title={ 'Access to WordAds' }
+							description={ '...' }
+						/>
+					</div>
+					<div className="product-purchase-features-list__item">
+						<PurchaseDetail
+							icon={ <img alt="" src="/calypso/images/illustrations/ads-removed.svg" /> }
+							title={ 'Unlimited access to premium themes' }
+							description={
+								'Make your site perfect in just a few clicks with beautiful premium themes we prepared.'
+							}
+						/>
+					</div>
+					{ isFreePlan( currentSitePlanSlug ) ? (
+						<div className="product-purchase-features-list__item">
+							<PurchaseDetail
+								icon={ <img alt="" src="/calypso/images/illustrations/jetpack-apps.svg" /> }
+								title={ 'Custom site address' }
+								description={
+									".com, .shop, or any other dot - it's on us. You choose an address and we pay for it."
+								}
+							/>
+						</div>
+					) : (
+						false
+					) }
+					<div className="product-purchase-features-list__item">
+						<PurchaseDetail
+							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-support.svg" /> }
+							title={ 'Advanced design customizations' }
+							description={ '...' }
+						/>
+					</div>
+					<div className="product-purchase-features-list__item">
+						<PurchaseDetail
+							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-support.svg" /> }
+							title={ 'Simple payments' }
+							description={ '...' }
+						/>
+					</div>
+					<div className="product-purchase-features-list__item">
+						<PurchaseDetail
+							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-support.svg" /> }
+							title={ 'Priority support' }
+							description={
+								'Need help? A Happiness Engineer can answer any question you may have about your ads and your account.'
+							}
+						/>
+					</div>
+					<div className="product-purchase-features-list__item">
+						<PurchaseDetail
+							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-support.svg" /> }
+							title={ 'Even more!' }
+							description={
+								'Need help? A Happiness Engineer can answer any question you may have about your ads and your account.'
+							}
+						/>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	handleUpgradeButtonClick = () => {
+		const { trackTracksEvent, selectedSiteSlug } = this.props;
+
+		trackTracksEvent( 'calypso_upsell_landing_page_cta_click', {
+			cta_name: 'ads-upsell',
+		} );
+
+		page( `/checkout/${ selectedSiteSlug }/${ getPlanPath( PLAN_PREMIUM ) || '' }` );
+	};
+
+	renderPrice() {
+		if ( this.props.price === null ) {
+			return null;
+		}
+		const priceObject = getCurrencyObject( this.props.price, this.props.currencyCode );
+		let price = `${ priceObject.symbol }${ priceObject.integer }`;
+		if ( this.props.price.toFixed( 5 ).split( '.' )[ 1 ] !== '00000' ) {
+			price += priceObject.fraction;
+		}
+		return price;
+	}
+}
+
+const mapStateToProps = state => {
+	const selectedSite = getSelectedSite( state );
+	const selectedSiteId = getSelectedSiteId( state );
+	const currentSitePlan = getCurrentPlan( state, selectedSiteId );
+
+	const upsellPlanSlug = PLAN_PREMIUM;
+	const upsellPlan = getPlan( upsellPlanSlug );
+	const upsellPlanId = upsellPlan.getProductId();
+	const rawPrice = getPlanRawPrice( state, upsellPlanId, false );
+	const discountedRawPrice = getPlanDiscountedRawPrice( state, selectedSiteId, upsellPlanSlug, {
+		isMonthly: false,
+	} );
+	const price = discountedRawPrice || rawPrice;
+
+	return {
+		price,
+		selectedSite,
+		currentSitePlan,
+		currentSitePlanSlug: currentSitePlan ? currentSitePlan.productSlug : '',
+		loadingPrice:
+			! price &&
+			( isRequestingPlans( state ) ||
+				isRequestingSitePlans( state ) ||
+				isRequestingActivePromotions( state ) ),
+		currencyCode: getCurrentUserCurrencyCode( state ),
+		selectedSiteSlug: getSiteSlug( state, selectedSiteId ),
+		trackTracksEvent: recordTracksEvent,
+	};
+};
+
+export default connect( mapStateToProps )( localize( WordAdsUpsellComponent ) );
+/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/my-sites/feature-upsell/ads-upsell.jsx
+++ b/client/my-sites/feature-upsell/ads-upsell.jsx
@@ -80,8 +80,8 @@ class WordAdsUpsellComponent extends Component {
 						height="100%"
 						className="feature-upsell__video"
 						src="https://videopress.com/embed/kRaHRuHQ"
-						frameborder="0"
-						allowfullscreen
+						frameBorder="0"
+						allowFullScreen={ true }
 					/>
 				</div>
 

--- a/client/my-sites/feature-upsell/ads-upsell.jsx
+++ b/client/my-sites/feature-upsell/ads-upsell.jsx
@@ -46,9 +46,9 @@ class WordAdsUpsellComponent extends Component {
 	};
 
 	render() {
-		const { price, loadingPrice, currentSitePlanSlug } = this.props;
+		const { price, currentSitePlanSlug } = this.props;
 		return (
-			<div role="main" className="main is-wide-layout feature-upsell feature-upsell-ads">
+			<div role="main" className="main is-wide-layout feature-upsell__main">
 				{ ! price && (
 					<React.Fragment>
 						<QueryPlans />
@@ -60,40 +60,103 @@ class WordAdsUpsellComponent extends Component {
 				<PageViewTracker path={ '/feature/ads/:site' } title="AdsUpsell" />
 				<DocumentHead title={ 'Ads' } />
 
-				<header className="feature-upsell-header">
-					<h1 className="feature-upsell-header__title">Start making money with this site!</h1>
-					<p className="feature-upsell-header__subtitle">
+				<header className="feature-upsell__header">
+					<h1 className="feature-upsell__header-title">Start making money with this site!</h1>
+					<p className="feature-upsell__header-subtitle">
 						Welcome to WordAds: the advertising platform where internet’s top ad suppliers bid
 						against each other to deliver their ads to your site, maximizing your revenue.
 					</p>
 				</header>
 
-				<div className="feature-upsell-cta">
-					{ loadingPrice ? (
-						<div className="feature-upsell-placeholder feature-upsell-placeholder--cta" />
-					) : (
-						<React.Fragment>
-							<button
-								onClick={ this.handleUpgradeButtonClick }
-								className="button is-primary feature-upsell-cta__button"
-							>
-								Upgrade for { this.renderPrice() } and get started
-							</button>
-							<span className="feature-upsell-cta__guarantee">30-day money back guarantee</span>
-						</React.Fragment>
-					) }
+				<h2 className="feature-upsell__section-header">How it works?</h2>
+
+				<div className="feature-upsell__video-container">
+					<div className="feature-upsell__placeholder feature-upsell__placeholder--cover" />
+					<iframe
+						title="How WordAds work?"
+						width="100%"
+						height="100%"
+						className="feature-upsell__video"
+						src="https://videopress.com/embed/kRaHRuHQ"
+						frameborder="0"
+						allowfullscreen
+					/>
 				</div>
 
-				<h2 className="feature-upsell-section-header">Price includes:</h2>
+				{ this.renderCTA() }
+
+				<h2 className="feature-upsell__section-header">As simple as 1, 2, 3</h2>
+
+				<ul className="feature-upsell__benefits-list">
+					<li className="feature-upsell__benefits-list-item">
+						<div className="feature-upsell__benefits-list-marker">1.</div>
+						<div className="feature-upsell__benefits-list-item-content">
+							<div className="feature-upsell__benefits-list-name">Enable WordAds</div>
+							<div className="feature-upsell__benefits-list-description">
+								After you upgrade, you can install WordAds on your site in just a few clicks.
+								WordAds places the ads automatically, optimizes their placement in your page layout
+								to give you the best return. No need to approve individual ads. Just turn it on and
+								WordAds does the rest.
+							</div>
+						</div>
+						<div className="feature-upsell__benefits-list-image-wrapper">
+							<img
+								alt=""
+								className="feature-upsell__benefits-list-image"
+								src="https://s2.wp.com/wp-content/themes/a8c/wordads/i/wordads_turn-on-ads@2x.png"
+							/>
+						</div>
+					</li>
+					<li className="feature-upsell__benefits-list-item">
+						<div className="feature-upsell__benefits-list-marker">2.</div>
+						<div className="feature-upsell__benefits-list-item-content">
+							<div className="feature-upsell__benefits-list-name">
+								High quality Ads start to show on your site
+							</div>
+							<div className="feature-upsell__benefits-list-description">
+								We only partner with advertisers that display family-friendly ads, and our fraud
+								prevention team proactively identifies malicious ads. That means WordAds won't place
+								an advertisement that contains nudity, promotes gambling, or makes fraudulent claims
+								on your site, and you don't have to worry what visitors will see. If you have any
+								questions, Automattic’s global team of happiness engineers are always available to
+								address any questions and concerns.
+							</div>
+						</div>
+						<div className="feature-upsell__benefits-list-image-wrapper">
+							<img
+								alt=""
+								className="feature-upsell__benefits-list-image"
+								src="https://s2.wp.com/wp-content/themes/a8c/wordads/i/wordads_high-quality-ads@2x.png"
+							/>
+						</div>
+					</li>
+					<li className="feature-upsell__benefits-list-item">
+						<div className="feature-upsell__benefits-list-marker">3.</div>
+						<div className="feature-upsell__benefits-list-item-content">
+							<div className="feature-upsell__benefits-list-name">Collect the payout</div>
+							<div className="feature-upsell__benefits-list-description">
+								You’re paid when the ad is seen by a visitor, not by click. That means the more
+								visits you get, and the more each visitor uses your site, the more you’ll earn.
+								WordAds pays monthly via PayPal. Payments are sent around the last day of the
+								following month. If you earned less than $100 in a given month, your earnings will
+								carry over to the next month instead.
+							</div>
+						</div>
+						<div className="feature-upsell__benefits-list-image-wrapper">
+							<img
+								alt=""
+								className="feature-upsell__benefits-list-image"
+								src="https://s2.wp.com/wp-content/themes/a8c/wordads/i/wordads_impressions-2017-Q3.@2x.png"
+							/>
+						</div>
+					</li>
+				</ul>
+
+				{ this.renderCTA() }
+
+				<h2 className="feature-upsell__section-header">Price includes also:</h2>
 
 				<div className="product-purchase-features-list">
-					<div className="product-purchase-features-list__item">
-						<PurchaseDetail
-							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-concierge.svg" /> }
-							title={ 'Access to WordAds' }
-							description={ '...' }
-						/>
-					</div>
 					<div className="product-purchase-features-list__item">
 						<PurchaseDetail
 							icon={ <img alt="" src="/calypso/images/illustrations/ads-removed.svg" /> }
@@ -113,21 +176,24 @@ class WordAdsUpsellComponent extends Component {
 								}
 							/>
 						</div>
-					) : (
-						false
-					) }
+					) : null }
 					<div className="product-purchase-features-list__item">
 						<PurchaseDetail
-							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-support.svg" /> }
+							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-dashboard.svg" /> }
 							title={ 'Advanced design customizations' }
-							description={ '...' }
+							description={
+								'Make your site look perfect with additional customization features - extended color schemes, background designs, and complete control over website CSS.'
+							}
 						/>
 					</div>
 					<div className="product-purchase-features-list__item">
 						<PurchaseDetail
-							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-support.svg" /> }
+							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-wordads.svg" /> }
 							title={ 'Simple payments' }
-							description={ '...' }
+							description={
+								'Accept credit card payments right on your site with the click of a button! Whether you sell products, memberships, ' +
+								'or subscriptions - we got you covered.'
+							}
 						/>
 					</div>
 					<div className="product-purchase-features-list__item">
@@ -135,13 +201,14 @@ class WordAdsUpsellComponent extends Component {
 							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-support.svg" /> }
 							title={ 'Priority support' }
 							description={
-								'Need help? A Happiness Engineer can answer any question you may have about your ads and your account.'
+								'Unlimited access to our world-class live chat and email support - no matter how complicated your question, our team ' +
+								'will find you an answer, guaranteed.'
 							}
 						/>
 					</div>
 					<div className="product-purchase-features-list__item">
 						<PurchaseDetail
-							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-support.svg" /> }
+							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-updates.svg" /> }
 							title={ 'Even more!' }
 							description={
 								'Need help? A Happiness Engineer can answer any question you may have about your ads and your account.'
@@ -149,6 +216,28 @@ class WordAdsUpsellComponent extends Component {
 						/>
 					</div>
 				</div>
+			</div>
+		);
+	}
+
+	renderCTA() {
+		const { loadingPrice } = this.props;
+
+		return (
+			<div className="feature-upsell__cta">
+				{ loadingPrice ? (
+					<div className="feature-upsell__placeholder feature-upsell__placeholder--cta" />
+				) : (
+					<React.Fragment>
+						<button
+							onClick={ this.handleUpgradeButtonClick }
+							className="button is-primary feature-upsell__cta-button"
+						>
+							Upgrade for { this.renderPrice() } and get started
+						</button>
+						<span className="feature-upsell__cta-guarantee">30-day money back guarantee</span>
+					</React.Fragment>
+				) }
 			</div>
 		);
 	}

--- a/client/my-sites/feature-upsell/ads-upsell.jsx
+++ b/client/my-sites/feature-upsell/ads-upsell.jsx
@@ -68,7 +68,7 @@ class WordAdsUpsellComponent extends Component {
 					</p>
 				</header>
 
-				<h2 className="feature-upsell-section-header">
+				<h2 className="feature-upsell__section-header">
 					Here's how WordAds can help you make money:
 				</h2>
 

--- a/client/my-sites/feature-upsell/ads-upsell.jsx
+++ b/client/my-sites/feature-upsell/ads-upsell.jsx
@@ -68,7 +68,9 @@ class WordAdsUpsellComponent extends Component {
 					</p>
 				</header>
 
-				<h2 className="feature-upsell__section-header">How it works?</h2>
+				<h2 className="feature-upsell-section-header">
+					Here's how WordAds can help you make money:
+				</h2>
 
 				<div className="feature-upsell__video-container">
 					<div className="feature-upsell__placeholder feature-upsell__placeholder--cover" />

--- a/client/my-sites/feature-upsell/controller.js
+++ b/client/my-sites/feature-upsell/controller.js
@@ -9,7 +9,12 @@ import page from 'page';
 /**
  * Internal Dependencies
  */
-import { PluginsUpsellComponent, StoreUpsellComponent, ThemesUpsellComponent, WordAdsUpsellComponent } from './main';
+import {
+	PluginsUpsellComponent,
+	StoreUpsellComponent,
+	ThemesUpsellComponent,
+	WordAdsUpsellComponent,
+} from './main';
 import { getSiteFragment } from 'lib/route';
 import {
 	canCurrentUserUseStore,
@@ -17,8 +22,6 @@ import {
 	canAdsBeEnabledOnCurrentSite,
 	canCurrentUserUpgradeSite,
 } from 'state/sites/selectors';
-import canCurrentUser from 'state/selectors/can-current-user';
-import { getSelectedSiteId } from 'state/ui/selectors';
 
 export default {
 	storeUpsell: function( context, next ) {
@@ -64,12 +67,6 @@ export default {
 
 		const state = context.store.getState();
 		if ( ! canCurrentUserUpgradeSite( state ) ) {
-			return page.redirect( '/stats/' + siteFragment );
-		}
-
-		const siteId = getSelectedSiteId( state );
-		const canUserManageOptions = canCurrentUser( state, siteId, 'manage_options' );
-		if ( ! canUserManageOptions ) {
 			return page.redirect( '/stats/' + siteFragment );
 		}
 

--- a/client/my-sites/feature-upsell/index.js
+++ b/client/my-sites/feature-upsell/index.js
@@ -17,8 +17,7 @@ import { getSiteFragment } from 'lib/route';
 
 export default function() {
 	if ( config.isEnabled( 'upsell/nudge-a-palooza' ) ) {
-		page( '/feature/store', siteSelection, sites, makeLayout, clientRender );
-
+		page( '/feature/:feature', siteSelection, sites, makeLayout, clientRender );
 		page(
 			'/feature/store/:domain',
 			siteSelection,
@@ -28,14 +27,23 @@ export default function() {
 			clientRender
 		);
 
-		page( '/feature/store/*', ( { path } ) => {
+		page(
+			'/feature/ads/:domain',
+			siteSelection,
+			navigation,
+			controller.wordAdsUpsell,
+			makeLayout,
+			clientRender
+		);
+
+		page( '/feature/:feature/*', ( { path, params } ) => {
 			const siteFragment = getSiteFragment( path );
 
 			if ( siteFragment ) {
-				return page.redirect( `/feature/store/${ siteFragment }` );
+				return page.redirect( `/feature/${ params.feature }/${ siteFragment }` );
 			}
 
-			return page.redirect( '/feature/store' );
+			return page.redirect( `/feature/${ params.feature }` );
 		} );
 
 		page( '/feature/plugins', siteSelection, sites, makeLayout, clientRender );

--- a/client/my-sites/feature-upsell/main.jsx
+++ b/client/my-sites/feature-upsell/main.jsx
@@ -10,5 +10,6 @@
 import PluginsUpsellComponent from './plugins-upsell';
 import StoreUpsellComponent from './store-upsell';
 import ThemesUpsellComponent from './themes-upsell';
+import WordAdsUpsellComponent from './ads-upsell';
 
-export { PluginsUpsellComponent, StoreUpsellComponent, ThemesUpsellComponent };
+export { PluginsUpsellComponent, StoreUpsellComponent, ThemesUpsellComponent, WordAdsUpsellComponent };

--- a/client/my-sites/feature-upsell/style.scss
+++ b/client/my-sites/feature-upsell/style.scss
@@ -13,6 +13,7 @@ $feature-upsell-break-at: '1040px';
 	width: 350px;
 	max-width: 80%;
 	height: 50px;
+	margin: 0 auto;
 }
 
 .feature-upsell__placeholder--cover {

--- a/client/my-sites/feature-upsell/style.scss
+++ b/client/my-sites/feature-upsell/style.scss
@@ -1,14 +1,26 @@
+$feature-upsell-break-at: '1040px';
+
 .feature-upsell__main {
 	margin-top: 48px;
 }
 
-.feature-upsell__placeholder-cta {
+.feature-upsell__placeholder {
 	animation: pulse-light 800ms ease-in-out infinite;
 	background: $gray-lighten-20;
-	display: inline-block;
+}
+
+.feature-upsell__placeholder--cta {
 	width: 350px;
 	max-width: 80%;
 	height: 50px;
+}
+
+.feature-upsell__placeholder--cover {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
 }
 
 .feature-upsell__header {
@@ -77,7 +89,114 @@
 	}
 
 	@include breakpoint( '<660px' ) {
-		font-size: 20px;
+		margin: 30px 0 10px 0;
+	}
+}
+
+.feature-upsell__video-container {
+	max-width: 800px;
+	width: 100%;
+	position: relative;
+	overflow: hidden;
+	padding-top: 56.25%;
+	margin: 0 auto;
+}
+
+.feature-upsell__video {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	border: 0;
+	iframe {
+		position: relative;
+		z-index: 10;
+	}
+}
+
+.feature-upsell__benefits-list {
+	padding: 0;
+	margin: 0;
+	list-style-type: decimal;
+
+	&-item {
+		width: 100%;
+		display: flex;
+		flex-flow: row;
+		padding: 0;
+		margin: 35px 0;
+
+		@include breakpoint( '<#{$feature-upsell-break-at}' ) {
+			flex-flow: row wrap;
+		}
+		@include breakpoint( '<660px' ) {
+			margin: 15px 0;
+		}
+	}
+
+	&-item-content {
+		order: 2;
+		width: 100%;
+		display: flex;
+		flex-flow: column;
+		@include breakpoint( '<#{$feature-upsell-break-at}' ) {
+			flex-basis: 90%;
+		}
+	}
+
+	&-marker {
+		order: 1;
+		margin-right: 5px;
+		@include breakpoint( '<#{$feature-upsell-break-at}' ) {
+			margin-left: 3%;
+		}
+	}
+
+	&-name,
+	&-marker {
+		font-size: 26px;
+		@include breakpoint( '<1280px' ) {
+			font-size: 22px;
+		}
+	}
+
+	&-description {
+		font-size: 16px;
+		margin-top: 5px;
+		@include breakpoint( '<660px' ) {
+			margin-top: 15px;
+		}
+	}
+
+	&-item:nth-child( 2n ) {
+		.feature-upsell__benefits-list-image-wrapper {
+			@include breakpoint( '>#{$feature-upsell-break-at}' ) {
+				order: 0;
+				margin-left: 0;
+				margin-right: 50px;
+			}
+		}
+	}
+
+	&-image-wrapper {
+		order: 3;
+		margin-left: 30px;
+		max-width: 40%;
+
+		@include breakpoint( '<#{$feature-upsell-break-at}' ) {
+			flex-basis: 100%;
+			max-width: 70%;
+			margin: 15px auto;
+		}
+
+		@include breakpoint( '<660px' ) {
+			max-width: 90%;
+		}
+	}
+
+	&-image {
+		width: 100%;
 	}
 }
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -55,6 +55,7 @@ import { getAutomatedTransferStatus } from 'state/automated-transfer/selectors';
 import { transferStates } from 'state/automated-transfer/constants';
 import { itemLinkMatches } from './utils';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
+import { canCurrentUserUpgradeSite } from '../../state/sites/selectors';
 
 /**
  * Module variables
@@ -182,7 +183,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	ads() {
-		const { path, canUserManageOptions, canUserUseAds } = this.props;
+		const { path, canUserManageOptions, canUserUpgradeSite, canUserUseAds } = this.props;
 
 		if ( canUserUseAds ) {
 			return (
@@ -201,6 +202,7 @@ export class MySitesSidebar extends Component {
 			! this.props.isJetpack &&
 			config.isEnabled( 'upsell/nudge-a-palooza' ) &&
 			canUserManageOptions &&
+			canUserUpgradeSite &&
 			abtest( 'nudgeAPalooza' ) === 'sidebarUpsells'
 		) {
 			return (
@@ -778,6 +780,7 @@ function mapStateToProps( state ) {
 		canUserViewStats: canCurrentUser( state, siteId, 'view_stats' ),
 		canUserUseStore: canCurrentUserUseStore( state, siteId ),
 		canUserUseAds: canCurrentUserUseAds( state, siteId ),
+		canUserUpgradeSite: canCurrentUserUpgradeSite( state, siteId ),
 		currentUser,
 		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
 		hasJetpackSites: hasJetpackSites( state ),

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -135,4 +135,76 @@ describe( 'MySitesSidebar', () => {
 			expect( wrapper.props().link ).toEqual( '/feature/store/mysite.com' );
 		} );
 	} );
+
+	describe( 'MySitesSidebar.ads()', () => {
+		const defaultProps = {
+			site: {},
+			siteSuffix: '/mysite.com',
+			translate: x => x,
+		};
+
+		beforeEach( () => {
+			config.isEnabled.mockImplementation( () => true );
+			abtest.mockImplementation( () => 'sidebarUpsells' );
+		} );
+
+		test( 'Should return ads menu item if user can use ads on this site', () => {
+			const Sidebar = new MySitesSidebar( {
+				canUserUseAds: true,
+				...defaultProps,
+			} );
+			const Ads = () => Sidebar.ads();
+
+			const wrapper = shallow( <Ads /> );
+			expect( wrapper.props().link ).toEqual( '/ads/earnings/mysite.com' );
+		} );
+
+		test( "Should return null if user can't use ads on this site and nudge-a-palooza is disabled", () => {
+			config.isEnabled.mockImplementation( feature => feature !== 'upsell/nudge-a-palooza' );
+			const Sidebar = new MySitesSidebar( {
+				canUserUseAds: false,
+				...defaultProps,
+			} );
+			const Ads = () => Sidebar.ads();
+
+			const wrapper = shallow( <Ads /> );
+			expect( wrapper.html() ).toEqual( null );
+		} );
+
+		test( "Should return null if user can't use ads on this site and user is in control A/B test group", () => {
+			abtest.mockImplementation( () => 'control' );
+			const Sidebar = new MySitesSidebar( {
+				canUserUseAds: false,
+				...defaultProps,
+			} );
+			const Ads = () => Sidebar.ads();
+
+			const wrapper = shallow( <Ads /> );
+			expect( wrapper.html() ).toEqual( null );
+		} );
+
+		test( "Should return upsell menu item if user can't use ads on this site but can manage options", () => {
+			const Sidebar = new MySitesSidebar( {
+				canUserUseAds: false,
+				canUserManageOptions: true,
+				...defaultProps,
+			} );
+			const Ads = () => Sidebar.ads();
+
+			const wrapper = shallow( <Ads /> );
+			expect( wrapper.props().link ).toEqual( '/feature/ads/mysite.com' );
+		} );
+
+		test( "Should return null if user can't use ads on this site and can't manage options", () => {
+			const Sidebar = new MySitesSidebar( {
+				canUserUseAds: false,
+				canUserManageOptions: false,
+				...defaultProps,
+			} );
+			const Ads = () => Sidebar.ads();
+
+			const wrapper = shallow( <Ads /> );
+			expect( wrapper.html() ).toEqual( null );
+		} );
+	} );
 } );

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -183,10 +183,11 @@ describe( 'MySitesSidebar', () => {
 			expect( wrapper.html() ).toEqual( null );
 		} );
 
-		test( "Should return upsell menu item if user can't use ads on this site but can manage options", () => {
+		test( "Should return upsell menu item if user can't use ads on this site but can manage options and upgrade site", () => {
 			const Sidebar = new MySitesSidebar( {
 				canUserUseAds: false,
 				canUserManageOptions: true,
+				canUserUpgradeSite: true,
 				...defaultProps,
 			} );
 			const Ads = () => Sidebar.ads();
@@ -195,10 +196,37 @@ describe( 'MySitesSidebar', () => {
 			expect( wrapper.props().link ).toEqual( '/feature/ads/mysite.com' );
 		} );
 
-		test( "Should return null if user can't use ads on this site and can't manage options", () => {
+		test( "Should return null if user can't use ads on this site and can't manage options or upgrade site", () => {
 			const Sidebar = new MySitesSidebar( {
 				canUserUseAds: false,
 				canUserManageOptions: false,
+				canUserUpgradeSite: false,
+				...defaultProps,
+			} );
+			const Ads = () => Sidebar.ads();
+
+			const wrapper = shallow( <Ads /> );
+			expect( wrapper.html() ).toEqual( null );
+		} );
+
+		test( "Should return null if user can't use ads on this site and can manage options but can't upgrade site", () => {
+			const Sidebar = new MySitesSidebar( {
+				canUserUseAds: false,
+				canUserManageOptions: true,
+				canUserUpgradeSite: false,
+				...defaultProps,
+			} );
+			const Ads = () => Sidebar.ads();
+
+			const wrapper = shallow( <Ads /> );
+			expect( wrapper.html() ).toEqual( null );
+		} );
+
+		test( "Should return null if user can't use ads on this site and can't manage options but can upgrade site", () => {
+			const Sidebar = new MySitesSidebar( {
+				canUserUseAds: false,
+				canUserManageOptions: false,
+				canUserUpgradeSite: true,
 				...defaultProps,
 			} );
 			const Ads = () => Sidebar.ads();

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -362,6 +362,22 @@ export function canCurrentUserUseStore( state, siteId = null ) {
 }
 
 /**
+ * Returns true if current user can see and use WordAds option in menu
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {Number}   siteId Site ID
+ * @return {?Boolean}        Whether site is previewable
+ */
+export function canCurrentUserUseAds( state, siteId = null ) {
+	if ( ! siteId ) {
+		siteId = getSelectedSiteId( state );
+	}
+	const site = getSite( state, siteId );
+	const canUserManageOptions = canCurrentUser( state, siteId, 'manage_options' );
+	return site && site.options.wordads && canUserManageOptions;
+}
+
+/**
  * Returns a site option for a site
  *
  * @param  {Object}  state  Global state tree

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -351,6 +351,11 @@ export function canCurrentUserUpgradeSite( state, siteId = null ) {
 	if ( ! siteId ) {
 		siteId = getSelectedSiteId( state );
 	}
+	const canUserManageOptions = canCurrentUser( state, siteId, 'manage_options' );
+	if ( ! canUserManageOptions ) {
+		return false;
+	}
+
 	const isPaid = isCurrentPlanPaid( state, siteId );
 	return ! isPaid || isCurrentUserCurrentPlanOwner( state, siteId );
 }

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -45,6 +45,9 @@ import isSiteAutomatedTransfer from '../selectors/is-site-automated-transfer';
 import hasSitePendingAutomatedTransfer from '../selectors/has-site-pending-automated-transfer';
 import { getAutomatedTransferStatus } from '../automated-transfer/selectors';
 import { getSelectedSiteId } from '../ui/selectors';
+import { FEATURE_WORDADS_INSTANT } from 'lib/plans/constants';
+import { hasFeature } from 'state/sites/plans/selectors';
+import { isCurrentUserCurrentPlanOwner } from './plans/selectors';
 
 /**
  * Returns the slug for a site, or null if the site is unknown.
@@ -338,6 +341,21 @@ export function isSitePreviewable( state, siteId ) {
 }
 
 /**
+ * Returns true if current user can purchase upgrades for this site
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {Number}   siteId Site ID
+ * @return {?Boolean}        Whether site is previewable
+ */
+export function canCurrentUserUpgradeSite( state, siteId = null ) {
+	if ( ! siteId ) {
+		siteId = getSelectedSiteId( state );
+	}
+	const isPaid = isCurrentPlanPaid( state, siteId );
+	return ! isPaid || isCurrentUserCurrentPlanOwner( state, siteId );
+}
+
+/**
  * Returns true if current user can see and use Store option in menu
  *
  * @param  {Object}   state  Global state tree
@@ -375,6 +393,21 @@ export function canCurrentUserUseAds( state, siteId = null ) {
 	const site = getSite( state, siteId );
 	const canUserManageOptions = canCurrentUser( state, siteId, 'manage_options' );
 	return site && site.options.wordads && canUserManageOptions;
+}
+
+/**
+ * Returns true if current user can see and use WordAds option in menu
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {Number}   siteId Site ID
+ * @return {?Boolean}        Whether site is previewable
+ */
+export function canAdsBeEnabledOnCurrentSite( state, siteId = null ) {
+	if ( ! siteId ) {
+		siteId = getSelectedSiteId( state );
+	}
+	const site = getSite( state, siteId );
+	return site && hasFeature( state, siteId, FEATURE_WORDADS_INSTANT );
 }
 
 /**

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -36,6 +36,7 @@ import {
 	getSitePostsPage,
 	getSiteFrontPageType,
 	hasStaticFrontPage,
+	canCurrentUserUseAds,
 	canCurrentUserUseStore,
 	canJetpackSiteManage,
 	canJetpackSiteUpdateFiles,
@@ -4006,6 +4007,46 @@ describe( 'selectors', () => {
 
 		test( "should return false if user can't manage a site, but it has background transfer and atomic store flow is disabled", () => {
 			expect( canCurrentUserUseStore( createState( false, false, true ) ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'canCurrentUserUseAds()', () => {
+		const createState = ( manage_options, wordads ) => ( {
+			ui: {
+				selectedSiteId: 1,
+			},
+			currentUser: {
+				capabilities: {
+					1: {
+						manage_options,
+					},
+				},
+			},
+			sites: {
+				items: {
+					1: {
+						options: {
+							wordads,
+						},
+					},
+				},
+			},
+		} );
+
+		test( 'should return true if site has WordAds user can manage it', () => {
+			expect( canCurrentUserUseAds( createState( true, true ) ) ).toBe( true );
+		} );
+
+		test( "should return false if site doesn't have WordAds and user can manage it", () => {
+			expect( canCurrentUserUseAds( createState( true, false ) ) ).toBe( false );
+		} );
+
+		test( 'should return false if site has WordAds user can not manage it', () => {
+			expect( canCurrentUserUseAds( createState( false, true ) ) ).toBe( false );
+		} );
+
+		test( 'should return false if site doesn\t have WordAds and user can not manage it', () => {
+			expect( canCurrentUserUseAds( createState( false, false ) ) ).toBe( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds an upsell of business plan by exposing WordAds menu item and linking it to a Landing Page. Related post: p9jf6J-Hl-p2

**Test plan:**
1. Open a free site in calypso
1. Enter A/B test group nudgeAPalooza -> sidebarUpsells
2. Confirm there is a "WordAds" Menu item visible and click on it
3. Confirm you were taken to a landing page such as one below:

<img width="1075" alt="zrzut ekranu 2018-07-13 o 15 31 34" src="https://user-images.githubusercontent.com/205419/42694205-dd6f87fe-86b1-11e8-91b8-e9354f8217a2.png">

4. Confirm that the purchase button takes you straight to checkout
5. Open a premium site that you can manage and has WordAds disabled and go the WordAds section
5. Confirm you were redirected to `/ads/settings`
5. Go back to the upsell page and switch to a premium site that you can't manage (such as a8ckudos)
5. Confirm you were redirected to `/stats` and that there is no WordAds item in the sidebar
5. Open a personal site that you can manage and open the upsell page again
6. Confirm that "Custom site address" is not listed as one of the benefits
7. Confirm the price on the purchase button is discounted and reflects what user can see on `/plans` page
8. While on WordAds landing page, switch to a premium site that you can manage and has WordAds enabled using a site picker
9. Confirm you were redirected form the landing page to `/ads/earnings`
10. Enter A/B test group nudgeAPalooza -> control 
11. Confirm there is no WordAds menu item for free sites