### PR TITLE
PurchaseItem: Add `data-e2e-connected-site` attribute

### DIFF
--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -174,7 +174,6 @@ class PurchaseItem extends Component {
 		const { isPlaceholder, isDisconnectedSite, purchase, isJetpack } = this.props;
 		const classes = classNames(
 			'purchase-item',
-			{ 'is-disconnected-site': isDisconnectedSite }, // Required for e2e tests, see https://github.com/Automattic/wp-e2e-tests/pull/1349
 			{ 'is-expired': purchase && 'expired' === purchase.expiryStatus },
 			{ 'is-placeholder': isPlaceholder },
 			{ 'is-included-with-plan': purchase && isIncludedWithPlan( purchase ) }
@@ -208,7 +207,12 @@ class PurchaseItem extends Component {
 		}
 
 		return (
-			<CompactCard className={ classes } onClick={ onClick } href={ href }>
+			<CompactCard
+				className={ classes }
+				data-e2e-connected-site={ ! isDisconnectedSite }
+				href={ href }
+				onClick={ onClick }
+			>
 				{ content }
 			</CompactCard>
 		);

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -174,6 +174,7 @@ class PurchaseItem extends Component {
 		const { isPlaceholder, isDisconnectedSite, purchase, isJetpack } = this.props;
 		const classes = classNames(
 			'purchase-item',
+			{ 'is-disconnected-site': isDisconnectedSite }, // Required for e2e tests, see https://github.com/Automattic/wp-e2e-tests/pull/1349
 			{ 'is-expired': purchase && 'expired' === purchase.expiryStatus },
 			{ 'is-placeholder': isPlaceholder },
 			{ 'is-included-with-plan': purchase && isIncludedWithPlan( purchase ) }


### PR DESCRIPTION
Needed for https://github.com/Automattic/wp-e2e-tests/pull/1349

To test: On `/me/purchases`, verify that `PurchaseItem`s for disconnected JP sites have the `is-disconnected` class, while others don't.