### PR TITLE
Build: Limit the numbers of cores used by the build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ const StatsWriter = require( './server/bundler/stats-writer' );
 const prism = require( 'prismjs' );
 const UglifyJsPlugin = require( 'uglifyjs-webpack-plugin' );
 const CircularDependencyPlugin = require( 'circular-dependency-plugin' );
-const threadLoader = require( 'thread-loader' );
+const os = require( 'os' );
 
 /**
  * Internal dependencies
@@ -72,8 +72,6 @@ const babelLoader = {
 	},
 };
 
-threadLoader.warmup( {}, [ 'babel-loader' ] );
-
 const webpackConfig = {
 	bail: ! isDevelopment,
 	entry: { build: [ path.join( __dirname, 'client', 'boot', 'app' ) ] },
@@ -125,7 +123,15 @@ const webpackConfig = {
 			{
 				test: /\.jsx?$/,
 				exclude: /node_modules[\/\\](?!notifications-panel)/,
-				use: [ 'thread-loader', babelLoader ],
+				use: [
+					{
+						loader: 'thread-loader',
+						options: {
+							workers: Math.max( Math.floor( os.cpus().length / 2 ), 1 ),
+						},
+					},
+					babelLoader,
+				],
 			},
 			{
 				test: /node_modules[\/\\](redux-form|react-redux)[\/\\]es/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -127,7 +127,7 @@ const webpackConfig = {
 					{
 						loader: 'thread-loader',
 						options: {
-							workers: Math.max( Math.floor( os.cpus().length / 2 ), 1 ),
+							workers: Math.max( 2, Math.floor( os.cpus().length / 2 ) ),
 						},
 					},
 					babelLoader,

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -107,7 +107,7 @@ const webpackConfig = {
 				use: [
 					{
 						loader: 'thread-loader',
-						options: { workers: Math.max( Math.floor( os.cpus().length / 2 ), 1 ) },
+						options: { workers: Math.max( 2, Math.floor( os.cpus().length / 2 ) ) },
 					},
 					babelLoader,
 				],

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -4,6 +4,8 @@
  * @format
  */
 
+/* eslint-disable import/no-nodejs-modules */
+
 /**
  * External dependencies
  */
@@ -11,7 +13,7 @@ const fs = require( 'fs' );
 const path = require( 'path' );
 const webpack = require( 'webpack' );
 const _ = require( 'lodash' );
-const threadLoader = require( 'thread-loader' );
+const os = require( 'os' );
 
 /**
  * Internal dependencies
@@ -38,8 +40,7 @@ function getExternals() {
 
 	// Don't bundle any node_modules, both to avoid a massive bundle, and problems
 	// with modules that are incompatible with webpack bundling.
-	fs
-		.readdirSync( 'node_modules' )
+	fs.readdirSync( 'node_modules' )
 		.filter( function( module ) {
 			return [ '.bin' ].indexOf( module ) === -1;
 		} )
@@ -76,8 +77,6 @@ const babelLoader = {
 	},
 };
 
-threadLoader.warmup( {}, [ 'babel-loader' ] );
-
 const webpackConfig = {
 	devtool: 'source-map',
 	entry: './index.js',
@@ -105,7 +104,13 @@ const webpackConfig = {
 			{
 				test: /\.jsx?$/,
 				exclude: /(node_modules|devdocs[\/\\]search-index)/,
-				use: [ 'thread-loader', babelLoader ],
+				use: [
+					{
+						loader: 'thread-loader',
+						options: { workers: Math.max( Math.floor( os.cpus().length / 2 ), 1 ) },
+					},
+					babelLoader,
+				],
 			},
 			{
 				test: /node_modules[\/\\](redux-form|react-redux)[\/\\]es/,


### PR DESCRIPTION
Limit to half of the available cores. This seems to give the best performance across machines.