### PR TITLE
Framework: Fix TermTreeSelector resizing

### DIFF
--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -1,4 +1,5 @@
 /** @format */
+
 /**
  * External dependencies
  */
@@ -7,6 +8,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
+import AutoSizer from 'react-virtualized/AutoSizer';
 import List from 'react-virtualized/List';
 import {
 	debounce,
@@ -62,7 +64,6 @@ class TermTreeSelectorList extends Component {
 		onChange: PropTypes.func,
 		isError: PropTypes.bool,
 		height: PropTypes.number,
-		width: PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -135,14 +136,6 @@ class TermTreeSelectorList extends Component {
 		if ( this.isSmall() ) {
 			this.forceUpdate();
 		}
-	};
-
-	setSelectorRef = selectorRef => {
-		if ( ! selectorRef ) {
-			return;
-		}
-
-		this.setState( { selectorRef } );
 	};
 
 	getPageForIndex = index => {
@@ -262,15 +255,6 @@ class TermTreeSelectorList extends Component {
 		return range( 0, this.getRowCount() ).reduce( ( memo, index ) => {
 			return memo + this.getRowHeight( { index } );
 		}, 0 );
-	};
-
-	getResultsWidth = () => {
-		const { selectorRef } = this.state;
-		if ( selectorRef ) {
-			return selectorRef.clientWidth;
-		}
-
-		return 0;
 	};
 
 	getRowCount = () => {
@@ -417,7 +401,7 @@ class TermTreeSelectorList extends Component {
 		const showSearch =
 			( searchLength > 0 || ! isSmall ) &&
 			( this.props.terms || ( ! this.props.terms && searchLength > 0 ) );
-		const { className, isError, loading, siteId, taxonomy, query, height, width } = this.props;
+		const { className, isError, loading, siteId, taxonomy, query, height } = this.props;
 		const classes = classNames( 'term-tree-selector', className, {
 			'is-loading': loading,
 			'is-small': isSmall,
@@ -426,7 +410,7 @@ class TermTreeSelectorList extends Component {
 		} );
 
 		return (
-			<div ref={ this.setSelectorRef } className={ classes }>
+			<div className={ classes }>
 				{ this.state.requestedPages.map( page => (
 					<QueryTerms
 						key={ `query-${ page }` }
@@ -438,18 +422,22 @@ class TermTreeSelectorList extends Component {
 				{ taxonomy === 'category' && siteId && <QuerySiteSettings siteId={ siteId } /> }
 
 				{ showSearch && <Search searchTerm={ this.state.searchTerm } onSearch={ this.onSearch } /> }
-				<List
-					ref={ this.setListRef }
-					width={ width || this.getResultsWidth() }
-					height={ isSmall ? this.getCompactContainerHeight() : height }
-					onRowsRendered={ this.setRequestedPages }
-					rowCount={ rowCount }
-					estimatedRowSize={ ITEM_HEIGHT }
-					rowHeight={ this.getRowHeight }
-					rowRenderer={ this.cellRendererWrapper }
-					noRowsRenderer={ this.renderNoResults }
-					className="term-tree-selector__results"
-				/>
+				<AutoSizer disableHeight>
+					{ ( { width } ) => (
+						<List
+							ref={ this.setListRef }
+							width={ width }
+							height={ isSmall ? this.getCompactContainerHeight() : height }
+							onRowsRendered={ this.setRequestedPages }
+							rowCount={ rowCount }
+							estimatedRowSize={ ITEM_HEIGHT }
+							rowHeight={ this.getRowHeight }
+							rowRenderer={ this.cellRendererWrapper }
+							noRowsRenderer={ this.renderNoResults }
+							className="term-tree-selector__results"
+						/>
+					) }
+				</AutoSizer>
 			</div>
 		);
 	}


### PR DESCRIPTION
`TermTreeSelector` is used in the editor, podcasting settings, and perhaps a couple of other places.  It uses a [`react-virtualized`](https://github.com/bvaughn/react-virtualized) `List`, without wrapping it in an `AutoSizer` component.

Currently you can see some of the issues this causes by opening the podcasting settings at `/settings/podcasting/:site` and resizing the window:

> <img src="https://trello-attachments.s3.amazonaws.com/571615f2db905e4eef101add/5b3f8fea058b0cf5a0895713/97d18d56f0b7c452db61424310f2d2e7/Podcast_Category_Resizing.gif" width="400">

The `AutoSizer` is necessary because by default, `react-virtualized` components do not support automatic resizing:  https://github.com/bvaughn/react-virtualized/issues/229

This pattern is in use in [various places](https://gist.github.com/nylen/f5c307fb0e69440d427b5ae5eab46f9f) in Calypso already.

## To test

Open `/settings/podcasting/site` and verify that the category selector resizes correctly, on a site with fewer than 8 categories and on a site with more than 8 categories (the display of the `TermTreeSelector` component is significantly different in these 2 cases):

> <img src="https://user-images.githubusercontent.com/227022/42720032-b6b5e994-86e5-11e8-8242-1481d7293173.gif" width="300"> <img src="https://user-images.githubusercontent.com/227022/42720038-c93b9d7a-86e5-11e8-944d-ac5b2a6db6d4.gif" width="300">

Open the editor and verify that the category selector in the sidebar looks OK.  Add a new category and verify that the "parent category" selector in the add category dialog resizes correctly (this is also broken before the changes in this PR):

> <img src="https://user-images.githubusercontent.com/227022/42720037-c9253cf6-86e5-11e8-8cbf-e229e3ce75df.gif" width="500">

## Still left to do

cc @justinshreve @timmyc - I think currently this PR may break the changes introduced in https://github.com/Automattic/wp-calypso/pull/21477, but I'm not sure how to test them.

After the changes here, I think we should be able to fix the original issue you were seeing more cleanly, by just setting a width in CSS.

Would you mind taking a look or telling me what we need to do to test this part of the store?