### PR TITLE
Build: Add work-around for safari 10 let bug

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -269,6 +269,9 @@ if ( shouldMinify ) {
 					 */
 					collapse_vars: false,
 				},
+				mangle: {
+					safari10: true,
+				},
 				ecma: 5,
 			},
 		} )

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -83,8 +83,8 @@ const webpackConfig = {
 	output: {
 		path: path.join( __dirname, 'public' ),
 		publicPath: '/calypso/',
-		filename: '[name].[chunkhash].opt.js', // prefer the chunkhash, which depends on the chunk, not the entire build
-		chunkFilename: '[name].[chunkhash].opt.js', // ditto
+		filename: '[name].[chunkhash].min.js', // prefer the chunkhash, which depends on the chunk, not the entire build
+		chunkFilename: '[name].[chunkhash].min.js', // ditto
 		devtoolModuleFilenameTemplate: 'app:///[resource-path]',
 	},
 	optimization: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -112,6 +112,9 @@ const webpackConfig = {
 						 */
 						collapse_vars: false,
 					},
+					mangle: {
+						safari10: true,
+					},
 					ecma: 5,
 				},
 			} ),
@@ -251,30 +254,6 @@ if ( isDevelopment ) {
 if ( ! config.isEnabled( 'desktop' ) ) {
 	webpackConfig.plugins.push(
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]desktop$/, 'lodash/noop' )
-	);
-}
-
-if ( shouldMinify ) {
-	webpackConfig.plugins.push(
-		new UglifyJsPlugin( {
-			cache: 'docker' !== process.env.CONTAINER,
-			parallel: true,
-			sourceMap: Boolean( process.env.SOURCEMAP ),
-			uglifyOptions: {
-				compress: {
-					/**
-					 * Produces inconsistent results
-					 * Enable when the following is resolved:
-					 * https://github.com/mishoo/UglifyJS2/issues/3010
-					 */
-					collapse_vars: false,
-				},
-				mangle: {
-					safari10: true,
-				},
-				ecma: 5,
-			},
-		} )
 	);
 }
 


### PR DESCRIPTION
See https://github.com/mishoo/UglifyJS2/pull/1851

Weird bits here:
* We had two separate minifier configs. Only the first one is actually respected. Ditch the old one.
* Our hashes are build off of the contents of the file _pre-minification_. This is just how webpack works. Since we're not modifying the contents, we need a different way to break the CDN cache we use. Change the extension to `.min.js` from `.opt.js` to do so.

Testing: 
* make sure log-in loads in latest browsers, and especially Safari 10.1 on Sierra. Use browserstack and calypso.live for testing.