### PR TITLE
Initial work improving rendering performance; looking for feedback.

### DIFF
--- a/client/components/data/media-library-selected-data/index.jsx
+++ b/client/components/data/media-library-selected-data/index.jsx
@@ -19,7 +19,7 @@ function getStateData( siteId ) {
 	};
 }
 
-export default class extends React.Component {
+export default class extends React.PureComponent {
 	static displayName = 'MediaLibrarySelectedData';
 
 	static propTypes = {
@@ -36,7 +36,7 @@ export default class extends React.Component {
 		MediaLibrarySelectedStore.off( 'change', this.updateState );
 	}
 
-	componentWillReceiveProps( nextProps ) {
+	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if ( this.props.siteId !== nextProps.siteId ) {
 			this.setState( getStateData( nextProps.siteId ) );
 		}

--- a/client/components/section-nav/item.jsx
+++ b/client/components/section-nav/item.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
@@ -13,12 +13,13 @@ import Gridicon from 'gridicons';
  * Internal Dependencies
  */
 import Count from 'components/count';
+import compareProps from 'lib/compare-props';
 import { preload } from 'sections-helper';
 
 /**
  * Main
  */
-class NavItem extends PureComponent {
+class NavItem extends Component {
 	static propTypes = {
 		itemType: PropTypes.string,
 		path: PropTypes.string,
@@ -42,6 +43,18 @@ class NavItem extends PureComponent {
 		}
 	};
 
+	shouldSkipRender = compareProps( { ignore: [ 'onClick' ] } );
+
+	shouldComponentUpdate( nextProps ) {
+		return ! this.shouldSkipRender( this.props, nextProps );
+	}
+
+	onClick = e => {
+		if ( ! this.props.disabled ) {
+			return this.props.onClick( e );
+		}
+	};
+
 	render() {
 		const itemClassPrefix = this.props.itemType ? this.props.itemType : 'tab';
 		const itemClasses = {
@@ -51,14 +64,10 @@ class NavItem extends PureComponent {
 		itemClasses[ 'section-nav-' + itemClassPrefix ] = true;
 		const itemClassName = classNames( this.props.className, itemClasses );
 
-		let target, onClick;
+		let target;
 
 		if ( this.props.isExternalLink ) {
 			target = '_blank';
-		}
-
-		if ( ! this.props.disabled ) {
-			onClick = this.props.onClick;
 		}
 
 		return (
@@ -67,7 +76,7 @@ class NavItem extends PureComponent {
 					href={ this.props.path }
 					target={ target }
 					className={ 'section-nav-' + itemClassPrefix + '__link' }
-					onClick={ onClick }
+					onClick={ this.onClick }
 					onMouseEnter={ this.preload }
 					tabIndex={ this.props.tabIndex || 0 }
 					aria-selected={ this.props.selected }

--- a/client/layout/masterbar/item.jsx
+++ b/client/layout/masterbar/item.jsx
@@ -9,7 +9,12 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { isFunction, noop } from 'lodash';
 import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
 import TranslatableString from 'components/translatable/proptype';
+import compareProps from 'lib/compare-props';
 
 class MasterbarItem extends Component {
 	static propTypes = {
@@ -36,6 +41,15 @@ class MasterbarItem extends Component {
 		}
 	};
 
+	shouldSkipRender = compareProps( { ignore: [ 'onClick' ] } );
+	shouldComponentUpdate( nextProps ) {
+		return ! this.shouldSkipRender( this.props, nextProps );
+	}
+
+	onClick = e => {
+		return this.props.onClick( e );
+	};
+
 	render() {
 		const itemClasses = classNames( 'masterbar__item', this.props.className, {
 			'is-active': this.props.isActive,
@@ -45,7 +59,7 @@ class MasterbarItem extends Component {
 			<a
 				data-tip-target={ this.props.tipTarget }
 				href={ this.props.url }
-				onClick={ this.props.onClick }
+				onClick={ this.onClick }
 				title={ this.props.tooltip }
 				className={ itemClasses }
 				onTouchStart={ this.preload }

--- a/client/layout/sidebar/button.jsx
+++ b/client/layout/sidebar/button.jsx
@@ -12,6 +12,7 @@ import React from 'react';
  * Internal dependencies
  */
 import { isExternal } from 'lib/url';
+import compareProps from 'lib/compare-props';
 import { preload } from 'sections-helper';
 
 class SidebarButton extends React.Component {
@@ -43,6 +44,15 @@ class SidebarButton extends React.Component {
 		return isExternal( this.props.href ) ? '_blank' : null;
 	};
 
+	shouldSkipRender = compareProps( { ignore: [ 'onClick' ] } );
+	shouldComponentUpdate( nextProps ) {
+		return ! this.shouldSkipRender( this.props, nextProps );
+	}
+
+	onClick = ( ...args ) => {
+		return this.props.onClick( ...args );
+	};
+
 	render() {
 		if ( ! this.props.href ) {
 			return null;
@@ -51,7 +61,7 @@ class SidebarButton extends React.Component {
 		return (
 			<a
 				rel={ isExternal( this.props.href ) ? 'external' : null }
-				onClick={ this.props.onClick }
+				onClick={ this.onClick }
 				href={ this.props.href }
 				target={ this.getTarget() }
 				className="sidebar__button"

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -15,6 +15,7 @@ import Gridicon from 'gridicons';
 import { isExternal } from 'lib/url';
 import { preload } from 'sections-helper';
 import TranslatableString from 'components/translatable/proptype';
+import compareProps from 'lib/compare-props';
 
 export default class SidebarItem extends React.Component {
 	static propTypes = {
@@ -39,6 +40,15 @@ export default class SidebarItem extends React.Component {
 		}
 	};
 
+	shouldSkipRender = compareProps( { ignore: [ 'onNavigate' ] } );
+	shouldComponentUpdate( nextProps ) {
+		return ! this.shouldSkipRender( this.props, nextProps );
+	}
+
+	onNavigate = e => {
+		return this.props.onNavigate( e );
+	};
+
 	render() {
 		const isExternalLink = isExternal( this.props.link );
 		const showAsExternal = isExternalLink && ! this.props.forceInternalLink;
@@ -51,7 +61,7 @@ export default class SidebarItem extends React.Component {
 				data-post-type={ this.props.postType }
 			>
 				<a
-					onClick={ this.props.onNavigate }
+					onClick={ this.onNavigate }
 					href={ this.props.link }
 					target={ showAsExternal ? '_blank' : null }
 					rel={ isExternalLink ? 'noopener noreferrer' : null }

--- a/client/lib/keyboard-shortcuts/menu.jsx
+++ b/client/lib/keyboard-shortcuts/menu.jsx
@@ -16,7 +16,7 @@ import config from 'config';
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 import KEY_BINDINGS from 'lib/keyboard-shortcuts/key-bindings';
 
-class KeyboardShortcutsMenu extends React.Component {
+class KeyboardShortcutsMenu extends React.PureComponent {
 	state = {
 		showDialog: false,
 	};

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -30,6 +30,7 @@ import {
 } from 'state/plugins/premium/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import DomainToPaidPlanNotice from './domain-to-paid-plan-notice';
+import compareProps from 'lib/compare-props';
 
 class SiteNotice extends React.Component {
 	static propTypes = {
@@ -37,6 +38,11 @@ class SiteNotice extends React.Component {
 	};
 
 	static defaultProps = {};
+
+	shouldSkipRender = compareProps( { deep: [ 'activeDiscount' ] } );
+	shouldComponentUpdate( nextProps ) {
+		return ! this.shouldSkipRender( this.props, nextProps );
+	}
 
 	getSiteRedirectNotice( site ) {
 		if ( ! site || this.props.isDomainOnly ) {

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -35,7 +35,7 @@ import MediaLibraryList from './list';
 import InlineConnection from 'my-sites/sharing/connections/inline-connection';
 import { isKeyringConnectionsFetching } from 'state/sharing/keyring/selectors';
 
-class MediaLibraryContent extends React.Component {
+class MediaLibraryContent extends React.PureComponent {
 	static propTypes = {
 		site: PropTypes.object,
 		mediaValidationErrors: PropTypes.object,
@@ -344,5 +344,5 @@ export default connect(
 	} ),
 	null,
 	null,
-	{ pure: false }
+	{ pure: true }
 )( localize( MediaLibraryContent ) );

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -24,7 +24,7 @@ import ButtonGroup from 'components/button-group';
 import Button from 'components/button';
 import StickyPanel from 'components/sticky-panel';
 
-class MediaLibraryHeader extends React.Component {
+class MediaLibraryHeader extends React.PureComponent {
 	static displayName = 'MediaLibraryHeader';
 
 	static propTypes = {

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -23,6 +23,7 @@ import FilterBar from './filter-bar';
 import MediaValidationData from 'components/data/media-validation-data';
 import QueryPreferences from 'components/data/query-preferences';
 import searchUrl from 'lib/search-url';
+import compareProps from 'lib/compare-props';
 import {
 	isKeyringConnectionsFetching,
 	getKeyringConnections,
@@ -88,6 +89,12 @@ class MediaLibrary extends Component {
 			// If we have changed to an external data source then check for a keyring connection
 			this.props.requestKeyringConnections();
 		}
+	}
+
+	shouldSkipRender = compareProps( { deep: [ 'connectedServices' ] } );
+	shouldComponentUpdate( nextProps, nextState ) {
+		const stateMatches = this.state === nextState;
+		return ! this.shouldSkipRender( this.props, nextProps ) || ! stateMatches;
 	}
 
 	doSearch = keywords => {

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -27,7 +27,7 @@ import isRtlSelector from 'state/selectors/is-rtl';
 
 const GOOGLE_MAX_RESULTS = 1000;
 
-export class MediaLibraryList extends React.Component {
+export class MediaLibraryList extends React.PureComponent {
 	static displayName = 'MediaLibraryList';
 
 	static propTypes = {
@@ -294,5 +294,5 @@ export default connect(
 	} ),
 	null,
 	null,
-	{ pure: false }
+	{ pure: true }
 )( MediaLibraryList );


### PR DESCRIPTION
This PR contains an initial set of changes targeting the
'My Sites > Media' page, as a small trial before committing to a
larger analysis across the site.

I used `why-did-you-update` to identify components that were going
through an excessive number of renders and targeted those.

The improvements are modest; around 15%, through some unscientific
measurements. Please let me know if there are any procedures or
tools you're currently using to measure in-app routing performance.

It illustrates several useful techniques for avoiding re-renders:
- Using PureComponents for shallow comparisons of state and props.
  Please validate that the components are indeed pure.
  See e.g. `my-sites/media-library/list.jsx`.
- Delegating event listener props through the component, and
  combining it with a `shouldComponentUpdate` handler to avoid
  causing a re-render whenever the listener prop changes.
  See e.g. `layout/masterbar/item.jsx`.
  It involves some boilerplate, so please let me know if you can
  think of a better alternative.
- Performing deep comparisons for select props which are generated
  in a way where references aren't preserved.
  See e.g. `my-sites/current-site/notice.jsx`.
  Please validate whether this approach is correct, or whether it
  would be preferable to use memoization on the state selector.