### PR TITLE
Help: display localized forum search results

### DIFF
--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -286,5 +286,20 @@ describe( 'utils', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'xxxx' );
 			expect( getForumUrl() ).toEqual( '//en.forums.wordpress.com' );
 		} );
+
+		test( 'should prioritize passed argument over current local', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( getForumUrl( 'ja' ) ).toEqual( '//ja.forums.wordpress.com' );
+		} );
+
+		test( 'should return `en` if passed argument is not available in config', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( getForumUrl( 'boom!' ) ).toEqual( '//en.forums.wordpress.com' );
+		} );
+
+		test( 'should return `en` for if neither current i18n locale slug nor passed argument is available in config', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'bonnie' );
+			expect( getForumUrl( 'clyde' ) ).toEqual( '//en.forums.wordpress.com' );
+		} );
 	} );
 } );

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -165,10 +165,10 @@ export function getSupportSiteLocale() {
  *
  * Checks for a valid bb forum against a list `forum_locales` defined in config/_shared.json.
  *
+ * @param {string} localeSlug Forum subdomain locale. Default is getLocaleSlug().
  * @returns {string} //{locale}.forums.wordpress.com
  */
-export function getForumUrl() {
-	const localeSlug = getLocaleSlug();
+export function getForumUrl( localeSlug = getLocaleSlug() ) {
 	if ( config( 'forum_locales' ).indexOf( localeSlug ) > -1 ) {
 		return `//${ localeSlug }.forums.wordpress.com`;
 	}

--- a/client/me/help/help-search/index.jsx
+++ b/client/me/help/help-search/index.jsx
@@ -24,7 +24,7 @@ class HelpSearch extends React.PureComponent {
 	static displayName = 'HelpSearch';
 
 	state = {
-		helpLinks: [],
+		helpLinks: {},
 		searchQuery: '',
 	};
 
@@ -41,7 +41,7 @@ class HelpSearch extends React.PureComponent {
 	};
 
 	onSearch = searchQuery => {
-		this.setState( { helpLinks: [], searchQuery: searchQuery } );
+		this.setState( { helpLinks: {}, searchQuery: searchQuery } );
 		analytics.tracks.recordEvent( 'calypso_help_search', { query: searchQuery } );
 		HelpSearchActions.fetch( searchQuery );
 	};
@@ -75,6 +75,7 @@ class HelpSearch extends React.PureComponent {
 		if (
 			isEmpty( this.state.helpLinks.wordpress_support_links ) &&
 			isEmpty( this.state.helpLinks.wordpress_forum_links ) &&
+			isEmpty( this.state.helpLinks.wordpress_forum_links_localized ) &&
 			isEmpty( this.state.helpLinks.jetpack_support_links )
 		) {
 			return (
@@ -98,13 +99,23 @@ class HelpSearch extends React.PureComponent {
 					iconTypeDescription="book"
 					searchLink={ 'https://en.support.wordpress.com?s=' + this.state.searchQuery }
 				/>
-				<HelpResults
-					header={ this.props.translate( 'Community Answers' ) }
-					helpLinks={ this.state.helpLinks.wordpress_forum_links }
-					footer={ this.props.translate( 'See more from Community Forum…' ) }
-					iconTypeDescription="comment"
-					searchLink={ getForumUrl() + '/search/' + this.state.searchQuery }
-				/>
+				{ this.state.helpLinks.wordpress_forum_links_localized ? (
+					<HelpResults
+						header={ this.props.translate( 'Community Answers' ) }
+						helpLinks={ this.state.helpLinks.wordpress_forum_links_localized }
+						footer={ this.props.translate( 'See more from Community Forum…' ) }
+						iconTypeDescription="comment"
+						searchLink={ getForumUrl() + '/search/' + this.state.searchQuery }
+					/>
+				) : (
+					<HelpResults
+						header={ this.props.translate( 'Community Answers' ) }
+						helpLinks={ this.state.helpLinks.wordpress_forum_links }
+						footer={ this.props.translate( 'See more from Community Forum…' ) }
+						iconTypeDescription="comment"
+						searchLink={ getForumUrl( 'en' ) + '/search/' + this.state.searchQuery }
+					/>
+				) }
 				<HelpResults
 					header={ this.props.translate( 'Jetpack Documentation' ) }
 					helpLinks={ this.state.helpLinks.jetpack_support_links }

--- a/client/me/help/help-search/index.jsx
+++ b/client/me/help/help-search/index.jsx
@@ -21,7 +21,7 @@ import CompactCard from 'components/card/compact';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getForumUrl } from 'lib/i18n-utils';
 
-class HelpSearch extends React.PureComponent {
+export class HelpSearch extends React.PureComponent {
 	static displayName = 'HelpSearch';
 
 	state = {

--- a/client/me/help/help-search/index.jsx
+++ b/client/me/help/help-search/index.jsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import { connect } from 'react-redux';
 import { isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -17,7 +18,7 @@ import HelpResults from 'me/help/help-results';
 import NoResults from 'my-sites/no-results';
 import SearchCard from 'components/search-card';
 import CompactCard from 'components/card/compact';
-import analytics from 'lib/analytics';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { getForumUrl } from 'lib/i18n-utils';
 
 class HelpSearch extends React.PureComponent {
@@ -36,14 +37,11 @@ class HelpSearch extends React.PureComponent {
 		HelpSearchStore.removeListener( 'change', this.refreshHelpLinks );
 	}
 
-	refreshHelpLinks = () => {
-		this.setState( { helpLinks: HelpSearchStore.getHelpLinks() } );
-	};
+	refreshHelpLinks = () => this.setState( { helpLinks: HelpSearchStore.getHelpLinks() } );
 
 	onSearch = searchQuery => {
 		this.setState( { helpLinks: {}, searchQuery: searchQuery } );
-		analytics.tracks.recordEvent( 'calypso_help_search', { query: searchQuery } );
-		HelpSearchActions.fetch( searchQuery );
+		this.props.fetchSearchResults( searchQuery );
 	};
 
 	displaySearchResults = () => {
@@ -139,4 +137,12 @@ class HelpSearch extends React.PureComponent {
 	}
 }
 
-export default localize( HelpSearch );
+export default connect(
+	null,
+	dispatch => ( {
+		fetchSearchResults: searchQuery => {
+			dispatch( recordTracksEvent( 'calypso_help_search', { query: searchQuery } ) );
+			HelpSearchActions.fetch( searchQuery );
+		},
+	} )
+)( localize( HelpSearch ) );

--- a/client/me/help/help-search/index.jsx
+++ b/client/me/help/help-search/index.jsx
@@ -47,11 +47,13 @@ class HelpSearch extends React.PureComponent {
 	};
 
 	displaySearchResults = () => {
-		if ( isEmpty( this.state.searchQuery ) ) {
+		const { searchQuery, helpLinks } = this.state;
+
+		if ( isEmpty( searchQuery ) ) {
 			return null;
 		}
 
-		if ( isEmpty( this.state.helpLinks ) ) {
+		if ( isEmpty( helpLinks ) ) {
 			return (
 				<div className="help-results__placeholder">
 					<HelpResults
@@ -73,16 +75,16 @@ class HelpSearch extends React.PureComponent {
 		}
 
 		if (
-			isEmpty( this.state.helpLinks.wordpress_support_links ) &&
-			isEmpty( this.state.helpLinks.wordpress_forum_links ) &&
-			isEmpty( this.state.helpLinks.wordpress_forum_links_localized ) &&
-			isEmpty( this.state.helpLinks.jetpack_support_links )
+			isEmpty( helpLinks.wordpress_support_links ) &&
+			isEmpty( helpLinks.wordpress_forum_links ) &&
+			isEmpty( helpLinks.wordpress_forum_links_localized ) &&
+			isEmpty( helpLinks.jetpack_support_links )
 		) {
 			return (
 				<CompactCard className="help-search__no-results">
 					<NoResults
 						text={ this.props.translate( 'No results found for {{em}}%(searchQuery)s{{/em}}', {
-							args: { searchQuery: this.state.searchQuery },
+							args: { searchQuery },
 							components: { em: <em /> },
 						} ) }
 					/>
@@ -90,35 +92,29 @@ class HelpSearch extends React.PureComponent {
 			);
 		}
 
+		const forumBaseUrl = helpLinks.wordpress_forum_links_localized
+			? getForumUrl()
+			: getForumUrl( 'en' );
+
 		return (
 			<div>
 				<HelpResults
 					header={ this.props.translate( 'WordPress.com Documentation' ) }
-					helpLinks={ this.state.helpLinks.wordpress_support_links }
+					helpLinks={ helpLinks.wordpress_support_links }
 					footer={ this.props.translate( 'See more from WordPress.com Documentation…' ) }
 					iconTypeDescription="book"
-					searchLink={ 'https://en.support.wordpress.com?s=' + this.state.searchQuery }
+					searchLink={ 'https://en.support.wordpress.com?s=' + searchQuery }
 				/>
-				{ this.state.helpLinks.wordpress_forum_links_localized ? (
-					<HelpResults
-						header={ this.props.translate( 'Community Answers' ) }
-						helpLinks={ this.state.helpLinks.wordpress_forum_links_localized }
-						footer={ this.props.translate( 'See more from Community Forum…' ) }
-						iconTypeDescription="comment"
-						searchLink={ getForumUrl() + '/search/' + this.state.searchQuery }
-					/>
-				) : (
-					<HelpResults
-						header={ this.props.translate( 'Community Answers' ) }
-						helpLinks={ this.state.helpLinks.wordpress_forum_links }
-						footer={ this.props.translate( 'See more from Community Forum…' ) }
-						iconTypeDescription="comment"
-						searchLink={ getForumUrl( 'en' ) + '/search/' + this.state.searchQuery }
-					/>
-				) }
+				<HelpResults
+					header={ this.props.translate( 'Community Answers' ) }
+					helpLinks={ helpLinks.wordpress_forum_links_localized || helpLinks.wordpress_forum_links }
+					footer={ this.props.translate( 'See more from Community Forum…' ) }
+					iconTypeDescription="comment"
+					searchLink={ `${ forumBaseUrl }/search/${ searchQuery }` }
+				/>
 				<HelpResults
 					header={ this.props.translate( 'Jetpack Documentation' ) }
-					helpLinks={ this.state.helpLinks.jetpack_support_links }
+					helpLinks={ helpLinks.jetpack_support_links }
 					footer={ this.props.translate( 'See more from Jetpack Documentation…' ) }
 					iconTypeDescription="jetpack"
 					searchLink="https://jetpack.me/support/"

--- a/client/me/help/help-search/test/__snapshots__/index.js.snap
+++ b/client/me/help/help-search/test/__snapshots__/index.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HelpSearch should render  1`] = `
+<div
+  className="help-search"
+>
+  <SearchCard
+    analyticsGroup="Help"
+    delaySearch={true}
+    onSearch={[Function]}
+    placeholder="How can we help?"
+  />
+</div>
+`;

--- a/client/me/help/help-search/test/index.js
+++ b/client/me/help/help-search/test/index.js
@@ -1,0 +1,76 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+
+import { HelpSearch } from '../';
+
+jest.mock( '', () => ( {} ) );
+
+const defaultProps = {
+	translate: x => x,
+	fetchSearchResults: jest.fn(),
+};
+
+const helpLinks = {
+	wordpress_forum_links_localized: [
+		{
+			description: 'bacon',
+			link: 'apple',
+			title: 'pancake',
+		},
+	],
+	wordpress_forum_links: [
+		{
+			description: 'walnut',
+			link: 'apricot',
+			title: 'cream',
+		},
+	],
+};
+
+const searchQuery = 'maplesyrup';
+
+describe( 'HelpSearch', () => {
+	test( 'should render ', () => {
+		const wrapper = shallow( <HelpSearch { ...defaultProps } /> );
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	test( 'should prioritize and pass localized forum search results if available ', () => {
+		const wrapper = shallow( <HelpSearch { ...defaultProps } /> );
+		wrapper.setState( { searchQuery, helpLinks } );
+		wrapper.update();
+		const HelpResultsElements = wrapper.find( 'HelpResults' );
+		expect( HelpResultsElements ).toHaveLength( 3 );
+		expect( HelpResultsElements.at( 1 ).props().helpLinks ).toEqual(
+			helpLinks.wordpress_forum_links_localized
+		);
+	} );
+
+	test( 'should display `en` forum search results localized not available', () => {
+		const wrapper = shallow( <HelpSearch { ...defaultProps } /> );
+		wrapper.setState( {
+			searchQuery,
+			helpLinks: {
+				wordpress_forum_links: helpLinks.wordpress_forum_links,
+			},
+		} );
+		wrapper.update();
+		const HelpResultsElements = wrapper.find( 'HelpResults' );
+		expect( HelpResultsElements ).toHaveLength( 3 );
+		expect( HelpResultsElements.at( 1 ).props().helpLinks ).toEqual(
+			helpLinks.wordpress_forum_links
+		);
+	} );
+} );


### PR DESCRIPTION
We have forums in other languages. Let's use them! 

This PR adds localized search results from our forums to the help search.

If the API returns results in the user's language, we display them. If no results come back we default to the English results (if any).

<img width="758" alt="screen shot 2018-07-17 at 4 20 05 pm" src="https://user-images.githubusercontent.com/6458278/42799997-4c5dc760-89dd-11e8-8998-074d24f0b6c5.png">

## Testing
1. Apply `code-D13821`
2. Fire up this branch and switch to a language for which a forum exists^. 
3. Visit http://calypso.localhost:3000/help and search for a common term in that language, followed by an English term. For example, with your language switched to Italian, search for 'Dominio', hen search for 'Domain'. This won't always work for popular forums such as Spanish, which will return Spanish language results for most terms.
4. Check that the links to the forum posts work.

### Expectations
Where there are results for the set locale, the page should display them. If not, or if we're using a language that does not have a forum^, then English results should display (if any).

^ `"ar", "de", "el", "en", "es", "fa", "fi", "fr", "he", "id", "it", "ja", "nl", "pt", "pt-br", "ru", "sv", "th", "tl", "tr"`

## Postscript
It might be an overkill, but there is an option to present both results, or an option to display results in English, since we return both anyway. Would this be helpful?

<img width="757" alt="screen shot 2018-07-17 at 4 14 57 pm" src="https://user-images.githubusercontent.com/6458278/42799847-baebf7a2-89dc-11e8-9267-f7ca7e715724.png">

