### PR TITLE
Update Facebook Publicize to work for facebook pages only.

### DIFF
--- a/client/my-sites/sharing/connections/service-action.jsx
+++ b/client/my-sites/sharing/connections/service-action.jsx
@@ -50,13 +50,16 @@ const SharingServiceAction = ( {
 		label = translate( 'Connecting…', {
 			context: 'Sharing: Publicize connect pending button label',
 		} );
-	} else if ( 'connected' === status ) {
+	} else if ( 'connected' === status || 'must-disconnect' === status ) {
 		if ( removableConnections.length > 1 ) {
 			label = translate( 'Disconnect All', {
 				context: 'Sharing: Publicize disconnect button label',
 			} );
 		} else {
 			label = translate( 'Disconnect', { context: 'Sharing: Publicize disconnect button label' } );
+		}
+		if ( 'must-disconnect' === status ) {
+			warning = true;
 		}
 	} else if ( 'reconnect' === status ) {
 		label = translate( 'Reconnect', {

--- a/client/my-sites/sharing/connections/service-description.jsx
+++ b/client/my-sites/sharing/connections/service-description.jsx
@@ -167,7 +167,7 @@ class SharingServiceDescription extends Component {
 	render() {
 		let description;
 
-		if ( 'reconnect' === this.props.status ) {
+		if ( 'reconnect' === this.props.status || 'must-disconnect' === this.props.status ) {
 			description = this.props.translate( 'There is an issue connecting to %(service)s.', {
 				args: { service: this.props.service.label },
 				context: 'Sharing: Publicize',

--- a/client/my-sites/sharing/connections/service-description.jsx
+++ b/client/my-sites/sharing/connections/service-description.jsx
@@ -167,7 +167,24 @@ class SharingServiceDescription extends Component {
 	render() {
 		let description;
 
-		if ( 'reconnect' === this.props.status || 'must-disconnect' === this.props.status ) {
+		// Temporary message: the `must-disconnect` status for Facebook connection is likely due to Facebook API changes
+		if ( 'facebook' === this.props.service.ID && 'must-disconnect' === this.props.status ) {
+			description = this.props.translate(
+				'As of August 1, 2018, Facebook no longer allows direct sharing of posts to Facebook Profiles. ' +
+					'Connections to Facebook Pages remain unchanged. {{a}}Learn more{{/a}}',
+				{
+					components: {
+						a: (
+							<a
+								href="https://en.support.wordpress.com/publicize/#facebook-pages"
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+					},
+				}
+			);
+		} else if ( 'reconnect' === this.props.status || 'must-disconnect' === this.props.status ) {
 			description = this.props.translate( 'There is an issue connecting to %(service)s.', {
 				args: { service: this.props.service.label },
 				context: 'Sharing: Publicize',

--- a/client/my-sites/sharing/connections/service-examples.jsx
+++ b/client/my-sites/sharing/connections/service-examples.jsx
@@ -143,12 +143,12 @@ class SharingServiceExamples extends Component {
 			{
 				image: {
 					src: '/calypso/images/sharing/facebook-profile.png',
-					alt: this.props.translate( 'Share posts to your Facebook page or profile', {
+					alt: this.props.translate( 'Share posts to your Facebook page', {
 						textOnly: true,
 					} ),
 				},
 				label: this.props.translate(
-					'{{strong}}Connect{{/strong}} to automatically share posts on your Facebook page or profile.',
+					'{{strong}}Connect{{/strong}} to automatically share posts on your Facebook page.',
 					{
 						components: {
 							strong: <strong />,

--- a/client/my-sites/sharing/connections/services/facebook.js
+++ b/client/my-sites/sharing/connections/services/facebook.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 
 /**
  * Internal dependencies
@@ -21,13 +22,31 @@ export class Facebook extends SharingService {
 	didKeyringConnectionSucceed( availableExternalAccounts ) {
 		if ( availableExternalAccounts.length === 0 ) {
 			this.props.failCreateConnection( {
-				message: this.props.translate(
-					'The %(service)s connection could not be made because this account does not have access to any Pages.',
-					{
-						args: { service: this.props.service.label },
-						context: 'Sharing: Publicize connection error',
-					}
-				),
+				message: [
+					this.props.translate(
+						'The Facebook connection could not be made because this account does not have access to any Pages.',
+						{
+							context: 'Sharing: Publicize connection error',
+						}
+					),
+					// Append temporary message to inform of Facebook API change
+					' ',
+					this.props.translate(
+						'Facebook supports Publicize connections to Facebook Pages, but not to Facebook Profiles. ' +
+							'{{a}}Learn More about Publicize for Facebook{{/a}}',
+						{
+							components: {
+								a: (
+									<a
+										href="https://en.support.wordpress.com/publicize/#facebook-pages"
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						}
+					),
+				],
 			} );
 			this.setState( { isConnecting: false } );
 			return false;

--- a/client/my-sites/sharing/connections/services/facebook.js
+++ b/client/my-sites/sharing/connections/services/facebook.js
@@ -1,0 +1,40 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { SharingService, connectFor } from 'my-sites/sharing/connections/service';
+
+export class Facebook extends SharingService {
+	static propTypes = {
+		...SharingService.propTypes,
+	};
+
+	static defaultProps = {
+		...SharingService.defaultProps,
+	};
+
+	didKeyringConnectionSucceed( availableExternalAccounts ) {
+		if ( availableExternalAccounts.length === 0 ) {
+			this.props.failCreateConnection( {
+				message: this.props.translate(
+					'The %(service)s connection could not be made because this account does not have access to any Pages.',
+					{
+						args: { service: this.props.service.label },
+						context: 'Sharing: Publicize connection error',
+					}
+				),
+			} );
+			this.setState( { isConnecting: false } );
+			return false;
+		}
+
+		return super.didKeyringConnectionSucceed( availableExternalAccounts );
+	}
+}
+
+export default connectFor( Facebook, ( state, props ) => props );

--- a/client/my-sites/sharing/connections/services/index.js
+++ b/client/my-sites/sharing/connections/services/index.js
@@ -3,6 +3,13 @@ export eventbrite from './eventbrite';
 export instagram from './instagram';
 export google_photos from './google-photos';
 export google_my_business from './google-my-business';
+export facebook from './facebook';
 
-const services = new Set( [ 'eventbrite', 'instagram', 'google_photos', 'google_my_business' ] );
+const services = new Set( [
+	'eventbrite',
+	'facebook',
+	'instagram',
+	'google_photos',
+	'google_my_business',
+] );
 export const hasOwnProperty = name => services.has( name );

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -1,5 +1,4 @@
 .foldable-card.sharing-service {
-
 	.sharing-service__logo {
 		float: left;
 		margin-right: 8px;
@@ -7,14 +6,14 @@
 
 	&.facebook {
 		h2,
-		.sharing-service__logo{
+		.sharing-service__logo {
 			color: $color-facebook;
 		}
 	}
 
 	&.twitter {
 		h2,
-		.sharing-service__logo{
+		.sharing-service__logo {
 			color: $color-twitter;
 		}
 	}
@@ -31,31 +30,30 @@
 		.sharing-service__logo {
 			color: $color-linkedin;
 		}
-
 	}
 
-	&.tumblr{
+	&.tumblr {
 		h2,
 		.sharing-service__logo {
 			color: $color-tumblr;
 		}
 	}
 
-	&.path{
+	&.path {
 		h2,
 		.sharing-service__logo {
 			color: $color-path;
 		}
 	}
 
-	&.eventbrite{
+	&.eventbrite {
 		h2,
 		.sharing-service__logo {
 			color: $color-eventbrite;
 		}
 	}
 
-	&.instagram{
+	&.instagram {
 		h2,
 		.sharing-service__logo {
 			color: $color-instagram;
@@ -95,13 +93,13 @@
 		margin-bottom: 0.5em;
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		padding: 0 0.25em;
 	}
 }
 
 .sharing-settings.sharing-connections {
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		padding: 16px 0;
 	}
 
@@ -110,7 +108,7 @@
 		vertical-align: top;
 		width: 48%;
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			display: block;
 			width: 100%;
 			margin: 20px 0;
@@ -120,12 +118,12 @@
 		&:first-child {
 			padding-right: 4%;
 
-			@include breakpoint( "<660px" ) {
+			@include breakpoint( '<660px' ) {
 				border-bottom: 1px solid $gray-lighten-30;
 				padding-bottom: 10px;
 			}
 
-			@include breakpoint( "<480px" ) {
+			@include breakpoint( '<480px' ) {
 				margin-bottom: 16px;
 				padding: 0 0 16px 0;
 			}
@@ -151,7 +149,7 @@
 	.sharing-service-tip {
 		margin-top: 16px;
 		font-size: 14px;
-		color: darken( $gray,10 );
+		color: darken( $gray, 10 );
 
 		.gridicons-info {
 			margin-right: 3px;
@@ -183,7 +181,6 @@
 	}
 
 	.sharing-service-accounts-detail {
-
 		h2 {
 			font-size: 1.2em;
 		}
@@ -205,15 +202,15 @@
 
 .sharing-service-action {
 	position: absolute;
-		right: 64px;
-		top: 26px;
+	right: 64px;
+	top: 26px;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		right: 10px;
 		top: 15px;
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		top: 11px;
 	}
 
@@ -248,10 +245,10 @@
 	&.is-placeholder::before {
 		content: '';
 		position: absolute;
-			top: 16px;
-			right: 16px;
-			bottom: 16px;
-			left: 16px;
+		top: 16px;
+		right: 16px;
+		bottom: 16px;
+		left: 16px;
 		background-color: $gray-lighten-20;
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
@@ -280,7 +277,7 @@
 	width: 50px;
 	border-radius: 4px;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		height: 21px;
 		padding-top: 5px;
 		margin: 2px 8px 0 32px;
@@ -302,14 +299,14 @@
 	}
 }
 
-@include sharing-service( "facebook", $color-facebook );
-@include sharing-service( "twitter", $color-twitter );
-@include sharing-service( "google_plus", $color-gplus );
-@include sharing-service( "tumblr", $color-tumblr );
-@include sharing-service( "linkedin", $color-linkedin );
-@include sharing-service( "path", $color-path );
-@include sharing-service( "instagram", $color-instagram );
-@include sharing-service( "eventbrite", $color-eventbrite );
+@include sharing-service( 'facebook', $color-facebook );
+@include sharing-service( 'twitter', $color-twitter );
+@include sharing-service( 'google_plus', $color-gplus );
+@include sharing-service( 'tumblr', $color-tumblr );
+@include sharing-service( 'linkedin', $color-linkedin );
+@include sharing-service( 'path', $color-path );
+@include sharing-service( 'instagram', $color-instagram );
+@include sharing-service( 'eventbrite', $color-eventbrite );
 
 .sharing-service__name {
 	clear: none;
@@ -320,7 +317,7 @@
 	color: $gray-darken-20;
 	font-size: 14px;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		display: none;
 	}
 }
@@ -329,18 +326,19 @@
 	font-style: italic;
 }
 
-.sharing-service.reconnect .sharing-service__description {
+.sharing-service.reconnect .sharing-service__description,
+.sharing-service.must-disconnect .sharing-service__description {
 	font-weight: bold;
 }
 
 .sharing-service__content-toggle {
 	position: absolute;
-		right: 16px;
-		top: 30px;
+	right: 16px;
+	top: 30px;
 	font-size: 22px;
 	color: #aeb8be;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		left: 14px;
 		top: 20px;
 	}
@@ -362,7 +360,7 @@
 	position: absolute;
 	left: 80px;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		width: 30%;
 	}
 }
@@ -408,7 +406,7 @@
 		padding-bottom: 0;
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		padding-right: 0;
 	}
 }
@@ -416,7 +414,7 @@
 .sharing-service.reconnect .sharing-connection__account-status {
 	padding-right: 200px;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		padding-right: 0;
 	}
 }
@@ -438,7 +436,7 @@
 	display: block;
 }
 
-.sharing-connection__account-sitewide-connection input[type="checkbox"] {
+.sharing-connection__account-sitewide-connection input[type='checkbox'] {
 	margin-top: 3px;
 }
 
@@ -449,11 +447,11 @@
 
 .sharing-connection__account-actions {
 	position: absolute;
-		right: -10px;
-		top: 50%;
+	right: -10px;
+	top: 50%;
 	margin-top: -16px;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		position: static;
 		margin-top: 4px;
 		text-align: right;
@@ -467,13 +465,14 @@
 	line-height: 16px;
 }
 
-.sharing-connection__account-action.reconnect {
+.sharing-connection__account-action.reconnect,
+.sharing-connection__account-action.must-disconnect {
 	color: $alert-yellow;
 
 	.gridicon {
 		margin-right: 4px;
 		position: relative;
-			top: 3px;
+		top: 3px;
 	}
 }
 
@@ -517,7 +516,7 @@
 }
 
 .sharing-buttons-tray__buttons {
-	@include breakpoint ( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		margin-right: -16px;
 	}
 }
@@ -545,7 +544,7 @@
 	border: 1px solid #ccc;
 	border-radius: 2px;
 	background-color: $white;
-	box-shadow: 0px 5px 20px rgba( 0, 0, 0, .2 );
+	box-shadow: 0px 5px 20px rgba( 0, 0, 0, 0.2 );
 }
 
 .sharing-buttons-preview-buttons__more-inner .sharing-buttons-preview-button,
@@ -555,17 +554,17 @@
 }
 
 .sharing-buttons-preview-buttons__more::before {
-	content: "";
+	content: '';
 	position: absolute;
-		top: 8px;
-		left: 20px  #{"/*rtl:ignore*/"};
+	top: 8px;
+	left: 20px #{'/*rtl:ignore*/'};
 	display: block;
 	width: 8px;
 	height: 8px;
 	transform: rotate( 45deg );
 	background-color: $white;
 	border-top: 1px solid #ccc;
-	border-left: 1px solid #ccc  #{"/*rtl:ignore*/"};
+	border-left: 1px solid #ccc #{'/*rtl:ignore*/'};
 }
 
 .sharing-buttons__panel {
@@ -581,7 +580,7 @@
 	@include clear-fix;
 	margin: 0 -3%;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		margin: 0;
 	}
 }
@@ -593,14 +592,14 @@
 	padding: 0 3%;
 	margin-bottom: 20px;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		width: 100%;
 		padding: 0;
 	}
 }
 
-.sharing-buttons__fieldset input[type="radio"],
-.sharing-buttons__fieldset input[type="checkbox"] {
+.sharing-buttons__fieldset input[type='radio'],
+.sharing-buttons__fieldset input[type='checkbox'] {
 	margin-right: 8px;
 }
 
@@ -688,7 +687,7 @@
 	background-color: $white;
 	color: $blue-wordpress;
 
-	@include breakpoint( "<480px") {
+	@include breakpoint( '<480px' ) {
 		padding-right: 0;
 	}
 
@@ -729,7 +728,7 @@
 
 	&.is-bottom {
 		margin-top: 14px;
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( '<480px' ) {
 			margin: 14px 1% 0;
 		}
 	}
@@ -760,7 +759,7 @@
 }
 
 .sharing-buttons-preview__button-tray-actions {
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		margin: 0 -6%;
 	}
 }
@@ -768,24 +767,24 @@
 .sharing-buttons-preview-action + .sharing-buttons-preview-action {
 	margin-left: 8px;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		margin-left: 1%;
 	}
 }
 
 .sharing-buttons-preview-action:last-child {
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		width: 46%;
 	}
 }
 
 .sharing-buttons-preview-action {
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		width: 50%;
 	}
 
 	&::before {
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( '<480px' ) {
 			float: left;
 			margin: 6px 6px 0 0;
 		}
@@ -853,7 +852,7 @@
 	color: #777;
 	background: #f8f8f8;
 	border: 1px solid #ccc;
-	box-shadow: 0 1px 0 rgba( 0, 0, 0, .08 );
+	box-shadow: 0 1px 0 rgba( 0, 0, 0, 0.08 );
 	line-height: 23px;
 	padding: 1px 8px 0px 5px;
 
@@ -936,25 +935,24 @@
 	}
 }
 
-@include sharing-button-service( "facebook", $color-facebook );
-@include sharing-button-service( "twitter", $color-twitter );
-@include sharing-button-service( "press-this", $blue-wordpress );
-@include sharing-button-service( "path", $color-path );
-@include sharing-button-service( "google-plus-1", $color-gplus );
-@include sharing-button-service( "instagram", $color-instagram );
-@include sharing-button-service( "eventbrite", $color-eventbrite );
-@include sharing-button-service( "linkedin", $color-linkedin );
-@include sharing-button-service( "stumbleupon", $color-stumbleupon );
-@include sharing-button-service( "tumblr", $color-tumblr );
-@include sharing-button-service( "reddit", $color-reddit );
-@include sharing-button-service( "pinterest", $color-pinterest );
-@include sharing-button-service( "pocket", $color-pocket );
-@include sharing-button-service( "email", $color-email );
-@include sharing-button-service( "print", $color-print );
-@include sharing-button-service( "skype", $color-skype );
-@include sharing-button-service( "telegram", $color-telegram );
-@include sharing-button-service( "jetpack-whatsapp", $color-whatsapp );
-
+@include sharing-button-service( 'facebook', $color-facebook );
+@include sharing-button-service( 'twitter', $color-twitter );
+@include sharing-button-service( 'press-this', $blue-wordpress );
+@include sharing-button-service( 'path', $color-path );
+@include sharing-button-service( 'google-plus-1', $color-gplus );
+@include sharing-button-service( 'instagram', $color-instagram );
+@include sharing-button-service( 'eventbrite', $color-eventbrite );
+@include sharing-button-service( 'linkedin', $color-linkedin );
+@include sharing-button-service( 'stumbleupon', $color-stumbleupon );
+@include sharing-button-service( 'tumblr', $color-tumblr );
+@include sharing-button-service( 'reddit', $color-reddit );
+@include sharing-button-service( 'pinterest', $color-pinterest );
+@include sharing-button-service( 'pocket', $color-pocket );
+@include sharing-button-service( 'email', $color-email );
+@include sharing-button-service( 'print', $color-print );
+@include sharing-button-service( 'skype', $color-skype );
+@include sharing-button-service( 'telegram', $color-telegram );
+@include sharing-button-service( 'jetpack-whatsapp', $color-whatsapp );
 
 .sharing-buttons-preview__panel {
 	position: relative;
@@ -968,7 +966,7 @@
 		content: '';
 		position: absolute;
 		border: 1px solid $gray-lighten-20;
-		border-right-width: 0  #{"/*rtl:ignore*/"};
+		border-right-width: 0 #{'/*rtl:ignore*/'};
 		border-bottom-width: 0;
 		background: $white;
 		display: block;
@@ -984,12 +982,12 @@
 	&.is-top::before {
 		bottom: -7px;
 		left: 30px;
-		border-width: 0 1px 1px 0  #{"/*rtl:ignore*/"};
+		border-width: 0 1px 1px 0 #{'/*rtl:ignore*/'};
 	}
 
 	&.is-bottom {
 		margin: 14px 0 0;
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( '<480px' ) {
 			margin: 15px -8px 0 -8px;
 		}
 	}
@@ -1055,21 +1053,21 @@
 .sharing-buttons-preview__panel-content .sharing-buttons-preview-button {
 	margin-top: 8px;
 	cursor: pointer;
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		margin: 18px 18px 0 0;
 	}
 
 	&.style-icon:hover {
 		border: none;
-		opacity: .6;
+		opacity: 0.6;
 	}
 
 	&.is-enabled {
-		opacity: .3;
+		opacity: 0.3;
 	}
 
 	&.is-enabled.style-icon {
-		opacity: .2;
+		opacity: 0.2;
 	}
 }
 
@@ -1077,7 +1075,9 @@
 	opacity: 1;
 }
 
-.sharing-buttons-preview__panel.is-reordering .sortable-list__item.is-draggable.is-active .sharing-buttons-preview-button {
+.sharing-buttons-preview__panel.is-reordering
+	.sortable-list__item.is-draggable.is-active
+	.sharing-buttons-preview-button {
 	margin: 0;
 }
 
@@ -1101,8 +1101,7 @@
 	max-width: 300px;
 }
 
-@include breakpoint( "<660px" ) {
-
+@include breakpoint( '<660px' ) {
 	.right-column {
 		box-sizing: border-box;
 	}

--- a/client/state/selectors/get-google-my-business-locations.js
+++ b/client/state/selectors/get-google-my-business-locations.js
@@ -21,7 +21,6 @@ export default function getGoogleMyBusinessLocations( state, siteId ) {
 	}
 
 	const externalUsers = filter( getAvailableExternalAccounts( state, 'google_my_business' ), {
-		isExternal: true,
 		keyringConnectionId: googleMyBusinessSiteKeyring.keyring_id,
 	} );
 

--- a/client/state/sharing/selectors.js
+++ b/client/state/sharing/selectors.js
@@ -44,16 +44,15 @@ export function getAvailableExternalAccounts( state, serviceName ) {
 	// Iterate over Keyring connections for this service and generate a
 	// flattened array of all accounts, including external users
 	return getKeyringConnectionsByName( state, serviceName ).reduce( ( memo, keyringConnection ) => {
-		if (
-			! service.external_users_only ||
-			isConnected( keyringConnection.ID, keyringConnection.external_ID )
-		) {
+		if ( ! service.external_users_only ) {
 			memo = memo.concat( [
 				{
+					ID: keyringConnection.external_ID,
 					name: keyringConnection.external_display || keyringConnection.external_name,
 					picture: keyringConnection.external_profile_picture,
 					keyringConnectionId: keyringConnection.ID,
 					isConnected: isConnected( keyringConnection.ID, keyringConnection.external_ID ),
+					isExternal: false,
 				},
 			] );
 		}

--- a/client/state/sharing/selectors.js
+++ b/client/state/sharing/selectors.js
@@ -44,7 +44,10 @@ export function getAvailableExternalAccounts( state, serviceName ) {
 	// Iterate over Keyring connections for this service and generate a
 	// flattened array of all accounts, including external users
 	return getKeyringConnectionsByName( state, serviceName ).reduce( ( memo, keyringConnection ) => {
-		if ( ! service.external_users_only ) {
+		if (
+			! service.external_users_only ||
+			isConnected( keyringConnection.ID, keyringConnection.external_ID )
+		) {
 			memo = memo.concat( [
 				{
 					name: keyringConnection.external_display || keyringConnection.external_name,

--- a/client/state/sharing/selectors.js
+++ b/client/state/sharing/selectors.js
@@ -13,52 +13,59 @@ import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getKeyringConnectionsByName } from './keyring/selectors';
 import { getSiteUserConnectionsForService } from './publicize/selectors';
+import { getKeyringServiceByName } from './services/selectors';
 
 /**
  * Given a service, returns a flattened array of all possible accounts for the
  * service for which a connection can be created.
  *
- * @param  {Object} state   Global state tree
- * @param  {String} service The name of the service to check
- * @return {Array}          Flattened array of all possible accounts for the service
+ * @param  {Object} state       Global state tree
+ * @param  {String} serviceName The name of the service to check
+ * @return {Array}              Flattened array of all possible accounts for the service
  */
-export function getAvailableExternalAccounts( state, service ) {
+export function getAvailableExternalAccounts( state, serviceName ) {
 	const isConnected = ( keyring_connection_ID, external_ID ) => {
 		const siteUserConnectionsForService = getSiteUserConnectionsForService(
 			state,
 			getSelectedSiteId( state ),
 			getCurrentUserId( state ),
-			service
+			serviceName
 		);
 
 		return some( siteUserConnectionsForService, { keyring_connection_ID, external_ID } );
 	};
 
+	const service = getKeyringServiceByName( state, serviceName );
+
+	if ( ! service ) {
+		return [];
+	}
+
 	// Iterate over Keyring connections for this service and generate a
 	// flattened array of all accounts, including external users
-	return getKeyringConnectionsByName( state, service ).reduce(
-		( memo, keyringConnection ) =>
-			memo
-				.concat( [
-					{
-						name: keyringConnection.external_display || keyringConnection.external_name,
-						picture: keyringConnection.external_profile_picture,
-						keyringConnectionId: keyringConnection.ID,
-						isConnected: isConnected( keyringConnection.ID, keyringConnection.external_ID ),
-					},
-				] )
-				.concat(
-					keyringConnection.additional_external_users.map( externalUser => ( {
-						ID: externalUser.external_ID,
-						name: externalUser.external_name,
-						description: externalUser.external_description,
-						picture: externalUser.external_profile_picture,
-						meta: externalUser.external_meta,
-						keyringConnectionId: keyringConnection.ID,
-						isConnected: isConnected( keyringConnection.ID, externalUser.external_ID ),
-						isExternal: true,
-					} ) )
-				),
-		[]
-	);
+	return getKeyringConnectionsByName( state, serviceName ).reduce( ( memo, keyringConnection ) => {
+		if ( ! service.external_users_only ) {
+			memo = memo.concat( [
+				{
+					name: keyringConnection.external_display || keyringConnection.external_name,
+					picture: keyringConnection.external_profile_picture,
+					keyringConnectionId: keyringConnection.ID,
+					isConnected: isConnected( keyringConnection.ID, keyringConnection.external_ID ),
+				},
+			] );
+		}
+
+		return memo.concat(
+			keyringConnection.additional_external_users.map( externalUser => ( {
+				ID: externalUser.external_ID,
+				name: externalUser.external_name,
+				description: externalUser.external_description,
+				picture: externalUser.external_profile_picture,
+				meta: externalUser.external_meta,
+				keyringConnectionId: keyringConnection.ID,
+				isConnected: isConnected( keyringConnection.ID, externalUser.external_ID ),
+				isExternal: true,
+			} ) )
+		);
+	}, [] );
 }

--- a/client/state/sharing/services/schema.js
+++ b/client/state/sharing/services/schema.js
@@ -14,6 +14,7 @@ export const itemSchema = {
 				'jetpack_support',
 				'label',
 				'multiple_external_user_ID_support',
+				'external_users_only',
 				'type',
 			],
 			properties: {
@@ -26,6 +27,7 @@ export const itemSchema = {
 				jetpack_support: { type: 'boolean' },
 				label: { type: 'string' },
 				multiple_external_user_ID_support: { type: 'boolean' },
+				external_users_only: { type: 'boolean' },
 				type: { type: 'string' },
 			},
 		},

--- a/client/state/sharing/services/test/reducer.js
+++ b/client/state/sharing/services/test/reducer.js
@@ -34,6 +34,7 @@ const originalKeyringServices = {
 		jetpack_support: true,
 		label: 'Facebook',
 		multiple_external_user_ID_support: true,
+		external_users_only: true,
 		type: 'publicize',
 	},
 	twitter: {
@@ -50,6 +51,7 @@ const originalKeyringServices = {
 		jetpack_support: true,
 		label: 'Twitter',
 		multiple_external_user_ID_support: false,
+		external_users_only: false,
 		type: 'publicize',
 	},
 };

--- a/client/state/sharing/test/selectors.js
+++ b/client/state/sharing/test/selectors.js
@@ -18,7 +18,12 @@ describe( 'selectors', () => {
 		sharing: {
 			keyring: {
 				items: {
-					1: { ID: 1, service: 'twitter', sites: [ '2916284' ], additional_external_users: [] },
+					1: {
+						ID: 1,
+						service: 'twitter',
+						sites: [ '2916284' ],
+						additional_external_users: [],
+					},
 					2: {
 						ID: 2,
 						service: 'instagram',
@@ -58,7 +63,31 @@ describe( 'selectors', () => {
 					2: { ID: 2, site_ID: 2916284, keyring_connection_user_ID: 26957695 },
 				},
 			},
+			services: {
+				items: {
+					facebook: {
+						ID: 'facebook',
+						label: 'Facebook',
+						type: 'publicize',
+						multiple_external_user_ID_support: true,
+						external_users_only: true,
+						jetpack_support: true,
+						jetpack_module_required: 'publicize',
+					},
+					twitter: {
+						ID: 'twitter',
+						label: 'Twitter',
+						type: 'publicize',
+						multiple_external_user_ID_support: false,
+						external_users_only: false,
+						jetpack_support: true,
+						jetpack_module_required: 'publicize',
+					},
+					isFetching: false,
+				},
+			},
 		},
+
 		ui: {
 			selectedSiteId: 2916284,
 		},
@@ -83,8 +112,6 @@ describe( 'selectors', () => {
 			const connections = getAvailableExternalAccounts( state, 'facebook' );
 
 			expect( connections ).to.eql( [
-				{ isConnected: false, keyringConnectionId: 3, name: undefined, picture: undefined },
-				{ isConnected: false, keyringConnectionId: 4, name: undefined, picture: undefined },
 				{
 					ID: 1,
 					isConnected: false,

--- a/client/state/sharing/test/selectors.js
+++ b/client/state/sharing/test/selectors.js
@@ -20,12 +20,14 @@ describe( 'selectors', () => {
 				items: {
 					1: {
 						ID: 1,
+						external_ID: '23455664',
 						service: 'twitter',
 						sites: [ '2916284' ],
 						additional_external_users: [],
 					},
 					2: {
 						ID: 2,
+						external_ID: '6675433',
 						service: 'instagram',
 						sites: [ '77203074' ],
 						keyring_connection_user_ID: 1,
@@ -33,6 +35,7 @@ describe( 'selectors', () => {
 					},
 					3: {
 						ID: 3,
+						external_ID: '35332233',
 						service: 'facebook',
 						sites: [ '2916284', '77203074' ],
 						shared: true,
@@ -40,12 +43,13 @@ describe( 'selectors', () => {
 					},
 					4: {
 						ID: 4,
+						external_ID: '99009233',
 						service: 'facebook',
 						sites: [ '77203074' ],
 						shared: false,
 						additional_external_users: [
 							{
-								external_ID: 1,
+								external_ID: '1222',
 								external_name: 'John',
 								external_profile_picture: undefined,
 							},
@@ -104,7 +108,14 @@ describe( 'selectors', () => {
 			const connections = getAvailableExternalAccounts( state, 'twitter' );
 
 			expect( connections ).to.eql( [
-				{ isConnected: false, keyringConnectionId: 1, name: undefined, picture: undefined },
+				{
+					ID: '23455664',
+					isConnected: false,
+					isExternal: false,
+					keyringConnectionId: 1,
+					name: undefined,
+					picture: undefined,
+				},
 			] );
 		} );
 
@@ -113,7 +124,7 @@ describe( 'selectors', () => {
 
 			expect( connections ).to.eql( [
 				{
-					ID: 1,
+					ID: '1222',
 					isConnected: false,
 					isExternal: true,
 					keyringConnectionId: 4,


### PR DESCRIPTION
Requires server patch D16126.

As mentioned [here](https://developers.facebook.com/blog/post/2018/04/24/new-facebook-platform-product-changes-policy-updates/), Facebook is deprecating the ability for apps to publish to a personal page/timeline.

Consequently, this PR removes the ability to select your own user account after the OAuth2 flow has completed in the Sharing page.

More generally, this PR adds support for Keyring Connections for which only external users can be used. Google My Business being one of them as well even though it is not a publicize service.
It also adds shows an error message when a publicize connection is not available anymore in the user's keyrings (if the user owns the connection).

### Testing Instructions
- Apply server patch and boot this branch locally
- Go to Sharing
- Click on Connect for the Facebook connection
- Complete the OAuth2 flow
- Ensure that your own Facebook account is not listed as an option to connect to

### Reviews
- [ ] Code
- [ ] Product