### PR TITLE
Checkout: Remove staleCartNotice A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -103,14 +103,6 @@ export default {
 		},
 		defaultVariation: 'domainsbot',
 	},
-	staleCartNotice: {
-		datestamp: '20180618',
-		variations: {
-			siteDeservesBoost: 50,
-			cartAwaitingPayment: 50,
-		},
-		defaultVariation: 'siteDeservesBoost',
-	},
 	aboutSuggestionMatches: {
 		datestamp: '20180704',
 		variations: {

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -29,7 +29,6 @@ import { getNoticeLastTimeShown } from 'state/notices/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import isRtl from 'state/selectors/is-rtl';
 import { hasAllSitesList } from 'state/sites/selectors';
-import { abtest } from 'lib/abtest';
 
 class CurrentSite extends Component {
 	static propTypes = {
@@ -69,19 +68,14 @@ class CurrentSite extends Component {
 		) {
 			this.props.recordTracksEvent( 'calypso_cart_abandonment_notice_view' );
 
-      this.props.infoNotice(
-				'siteDeservesBoost' === abtest( 'staleCartNotice' )
-					? this.props.translate( 'Your site deserves a boost!' )
-					: this.props.translate( 'Your cart is awaiting payment.' ),
-				{
-					id: staleCartItemNoticeId,
-					isPersistent: false,
-					duration: 10000,
-					button: this.props.translate( 'Complete your purchase' ),
-					href: '/checkout/' + selectedSite.slug,
-					onClick: this.clickStaleCartItemsNotice,
-				}
-			);
+			this.props.infoNotice( this.props.translate( 'Your cart is awaiting payment.' ), {
+				id: staleCartItemNoticeId,
+				isPersistent: false,
+				duration: 10000,
+				button: this.props.translate( 'Complete your purchase' ),
+				href: '/checkout/' + selectedSite.slug,
+				onClick: this.clickStaleCartItemsNotice,
+			} );
 		}
 	};
 


### PR DESCRIPTION
Remove `staleCartNotice` test introduced in #22995, and replace the stale cart message "Your site deserves a boost!" with "Your cart is awaiting payment." 

The test results are strongly in favour of the proposed variation, with a completion rate of the hypothesis funnel 51.85% better than the control group.

See: p7jreA-1Ff-p2

cc @millerf for the groundwork 🎉