### PR TITLE
Gutenberg: reset styles in new section

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -1,3 +1,15 @@
+.is-group-editor::before {
+	content: '';
+	position: fixed;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	background-color: $white;
+	pointer-events: none;
+	z-index: z-index( 'root', '.is-group-editor::before' );
+}
+
 .editor {
 	background: none;
 }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -11,8 +11,8 @@ $autobar-height: 20px;
 	height: $masterbar-height;
 	margin: 0;
 	position: fixed;
-		left: 0;
-		top: 0;
+	left: 0;
+	top: 0;
 	width: 100%;
 	z-index: z-index( 'root', '.masterbar' );
 	-webkit-font-smoothing: subpixel-antialiased;
@@ -43,11 +43,12 @@ $autobar-height: 20px;
 		#38a6d7 66.66666666666667%,
 		#38a6d7 83.33333333333333%,
 		#8c7ab8 83.33333333333333%,
-		#8c7ab8 100%);
+		#8c7ab8 100%
+	);
 
-	>.masterbar__item:not( .masterbar__item-title ),
-	>.masterbar__notifications,
-	>.masterbar__login-links a {
+	> .masterbar__item:not( .masterbar__item-title ),
+	> .masterbar__notifications,
+	> .masterbar__login-links a {
 		&:not( .is-active ) {
 			background: rgba( $blue-wordpress, 0.85 );
 		}
@@ -69,7 +70,7 @@ $autobar-height: 20px;
 .masterbar__item {
 	flex: 0 1 auto;
 	display: flex;
-		align-items: center;
+	align-items: center;
 	position: relative;
 	color: var( --masterbar-color );
 	font-size: 14px;
@@ -119,7 +120,7 @@ $autobar-height: 20px;
 		background: darken( $orange-jazzy, 10% );
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		flex: 1 1 auto;
 
 		.gridicon {
@@ -147,7 +148,7 @@ $autobar-height: 20px;
 		margin: 0 5px;
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		& {
 			padding-right: 14px;
 		}
@@ -186,7 +187,7 @@ $autobar-height: 20px;
 	.masterbar__item-content {
 		display: block;
 
-		@include breakpoint( ">480px" ) {
+		@include breakpoint( '>480px' ) {
 			margin-top: 3px; /*Align with logo*/
 		}
 	}
@@ -233,7 +234,7 @@ $autobar-height: 20px;
 		color: var( --masterbar-item-new-color );
 		display: none;
 
-		@include breakpoint( ">960px" ) {
+		@include breakpoint( '>960px' ) {
 			display: block;
 			margin-right: 4px;
 		}
@@ -264,7 +265,6 @@ $autobar-height: 20px;
 	.is-group-editor &:hover {
 		background: var( --masterbar-item-new-editor-hover-background );
 	}
-
 }
 
 .masterbar__item-me {
@@ -290,7 +290,7 @@ $autobar-height: 20px;
 .masterbar__item-notifications {
 	margin-right: 12px;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		margin-right: 0;
 	}
 
@@ -301,7 +301,7 @@ $autobar-height: 20px;
 	.gridicon + .masterbar__item-content {
 		padding: 0;
 
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( '<480px' ) {
 			display: block;
 		}
 	}
@@ -321,14 +321,14 @@ $autobar-height: 20px;
 		margin: 0 0 0 -12px;
 		padding: 0;
 		position: absolute;
-			top: 9px;
-			left: 50%;
+		top: 9px;
+		left: 50%;
 		width: 8px;
 		z-index: z-index( '.masterbar', '.masterbar__notifications-bubble' );
 
 		// Animation
-		transform: translateZ(0);
-		animation: bubble-unread-indication .5s linear both;
+		transform: translateZ( 0 );
+		animation: bubble-unread-indication 0.5s linear both;
 		transition: all 150ms ease-in;
 	}
 
@@ -352,13 +352,13 @@ $autobar-height: 20px;
 
 @keyframes bubble-unread-indication {
 	30% {
-		transform: scale(1.5);
+		transform: scale( 1.5 );
 	}
 	60% {
-		transform: scale(.85);
+		transform: scale( 0.85 );
 	}
 	80% {
-		transform: scale(1.1);
+		transform: scale( 1.1 );
 	}
 }
 
@@ -372,12 +372,12 @@ $autobar-height: 20px;
 	}
 
 	.masterbar__item:last-child {
-			padding-right: 20px;
+		padding-right: 20px;
 	}
 }
 
 .masterbar__reader {
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		margin-right: auto;
 	}
 }
@@ -413,7 +413,7 @@ $autobar-height: 20px;
 
 .masterbar__recent-drafts.popover {
 	width: 310px;
-	max-width: calc(100vw - 20px );
+	max-width: calc( 100vw - 20px );
 
 	.popover__inner {
 		text-align: left;
@@ -433,9 +433,9 @@ $autobar-height: 20px;
 	padding: 0 16px;
 	margin: 0;
 	position: absolute;
-		top: 0;
-		right: 0;
-		left: 0;
+	top: 0;
+	right: 0;
+	left: 0;
 	height: 46px;
 	line-height: 45px;
 	border-bottom: 1px solid lighten( $gray, 20 );
@@ -444,8 +444,8 @@ $autobar-height: 20px;
 
 .masterbar__recent-drafts-add-new {
 	position: absolute;
-		top: 8px;
-		right: 8px;
+	top: 8px;
+	right: 8px;
 }
 
 .masterbar__recent-drafts-see-all.button.is-compact {
@@ -455,9 +455,9 @@ $autobar-height: 20px;
 	background: $gray-light;
 	text-align: center;
 	position: absolute;
-		right: 0;
-		bottom: 0;
-		left: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
 	border-radius: 0 0 3px 3px;
 
 	.count {
@@ -496,7 +496,8 @@ $autobar-height: 20px;
 	transition: all 0.3s ease-in-out;
 }
 
-.is-section-post-editor .masterbar {
+.is-section-post-editor .masterbar,
+.is-section-gutenberg-editor .masterbar {
 	opacity: 0;
 	pointer-events: none;
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -13,8 +13,7 @@
 .layout__secondary,
 .layout__secondary .sidebar,
 .layout__secondary .site-selector {
-	transition: transform 0.15s ease-in-out,
-				opacity 0.15s ease-out;
+	transition: transform 0.15s ease-in-out, opacity 0.15s ease-out;
 }
 
 // If things take a bit to load...
@@ -24,8 +23,8 @@
 	height: 46px;
 	margin-left: -10%;
 	position: absolute;
-		left: 50%;
-		top: 0;
+	left: 50%;
+	top: 0;
 	width: 20%;
 	z-index: z-index( 'root', '.layout__loader' );
 
@@ -77,7 +76,7 @@
 	}
 
 	// Tablets
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		padding: 71px 24px 24px ( $sidebar-width-min + 24px + 1px );
 
 		.has-no-sidebar & {
@@ -96,7 +95,7 @@
 	}
 
 	// Mobile (Full Width)
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		margin-left: 0;
 		padding: 0;
 		padding-top: 47px;
@@ -115,26 +114,27 @@
 // the site-selector elements.
 .layout__secondary {
 	position: fixed;
-		top: 47px;
-		left: 0;
-		bottom: 0;
+	top: 47px;
+	left: 0;
+	bottom: 0;
 	color: var( --sidebar-color );
 	background: var( --sidebar-background );
 	border-right: 1px solid darken( $sidebar-bg-color, 5% );
 	width: $sidebar-width-max;
 	overflow: hidden;
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		width: $sidebar-width-min;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		width: 100%;
 	}
 
 	// The editor has its own sidebar which doesnt
 	// use the secondary element.
 	.is-section-post-editor &,
+	.is-section-gutenberg-editor &,
 	// Some screens (like /theme/) simply dont have
 	// a sidebar.
 	.has-no-sidebar & {
@@ -146,10 +146,10 @@
 // position is off screen.
 .layout__secondary .site-selector {
 	position: absolute;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
 	pointer-events: none;
 	transform: translateX( -$sidebar-width-max );
 
@@ -163,12 +163,11 @@
 		}
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		-webkit-overflow-scrolling: touch;
 		transform: translateX( -100% );
 	}
 }
-
 
 /*
 	Focus States
@@ -179,10 +178,10 @@
 
 // Adjust the content as needed when focused on the site selector
 // or sidebar, but never in the editor.
-.layout.focus-sites:not(.is-section-post-editor),
-.layout.focus-sidebar:not(.is-section-post-editor) {
+.layout.focus-sites:not( .is-section-post-editor ),
+.layout.focus-sidebar:not( .is-section-post-editor ) {
 	.layout__primary .main {
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			pointer-events: none;
 			overflow: hidden;
 			max-height: calc( 100vh - 47px );
@@ -205,13 +204,13 @@
 		pointer-events: none;
 		transform: translateX( $sidebar-width-max );
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			transform: translateX( 100% );
 		}
 	}
 
 	.layout__primary .main {
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			pointer-events: none;
 			opacity: 0.25;
 		}
@@ -221,7 +220,7 @@
 // Move the secondary element off screen when focused
 // on the content. This only applies to small screens.
 .layout.focus-content {
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		.layout__secondary {
 			transform: translateX( -100% );
 		}


### PR DESCRIPTION
Fix #26037

Reset the new Gutenberg section base styles to make it as ready as possible for a full page Gutenberg editor.

### Changes

Note: VSCode format on save accidentally prettified the SCSS files included in this PR.
The actual changes are only 1 line for each file, but I'd like to keep everything else because it could be handy for other people doing more complicated changes on those files.

- Hide the masterbar https://github.com/Automattic/wp-calypso/pull/26084/files#diff-5cca3554e92bb3dbda445deb63773859R500

- Hide the sidebar https://github.com/Automattic/wp-calypso/pull/26084/files#diff-2c1d63e1a000efc0261f2c7ee8032077R137

- Applies the [same rules](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/style.scss#L1-L16) (and white background) of the post editor section https://github.com/Automattic/wp-calypso/pull/26084/files#diff-36b35bf39d17a53869c0ef9e8bfc1ac4R1

| Before | After |
| --- | --- |
| <img width="1094" alt="42607341-30b18c90-8537-11e8-9508-02623353398e" src="https://user-images.githubusercontent.com/1270189/42669010-51f68e2e-8608-11e8-9630-a10bb4fba766.png"> | <img width="1656" alt="screen shot 2018-07-16 at 13 11 42" src="https://user-images.githubusercontent.com/2070010/42758012-e7ebd062-88f9-11e8-99f5-2818f2018e69.png"> |