### PR TITLE
Add A/B test to test possible updates for "theme to plan" upsell nudge on /themes page

### DIFF
--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -8,6 +8,16 @@
 	}
 }
 
+@mixin banner-dark() {
+	background-color: #34444d;
+
+	.banner__list,
+	.banner__title,
+	.banner__description {
+		color: #fff;
+	}
+}
+
 .banner.card {
 	border-left: 3px solid;
 	display: flex;
@@ -46,7 +56,7 @@
 		}
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		padding: 12px 16px;
 		&.is-dismissible {
 			padding-right: 16px;
@@ -80,7 +90,7 @@
 		padding: 3px 4px 4px 3px;
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		align-items: center;
 
 		.banner__icon {
@@ -101,7 +111,7 @@
 		width: 32px;
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		align-items: center;
 	}
 }
@@ -112,7 +122,7 @@
 	flex-grow: 1;
 	flex-wrap: wrap;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		flex-wrap: nowrap;
 	}
 }
@@ -151,7 +161,7 @@
 		}
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		width: auto;
 
 		.banner__list li .gridicon {
@@ -187,7 +197,7 @@
 		}
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		margin: 0 -6px 0 8px;
 		text-align: center;
 		width: auto;

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -4,7 +4,8 @@ export default {
 		datestamp: '20180711',
 		variations: {
 			sidebarUpsells: 20,
-			control: 80,
+			themesUpsells: 20,
+			control: 60,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -41,7 +41,7 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 					className="is-theme-showcase-banner" // eslint-disable-line wpcalypso/jsx-classname-namespace
 					title={ 'Unlock ALL premium themes with our Premium and Business plans!' }
 					event="themes_plans_free_personal"
-					callToAction={ translate( 'View plans' ) }
+					callToAction={ 'View Plans' }
 				/>
 			);
 		} else {

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -39,7 +39,7 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 				<Banner
 					plan={ PLAN_PREMIUM }
 					className="is-theme-showcase-banner" // eslint-disable-line wpcalypso/jsx-classname-namespace
-					title={ translate( 'Unlock ALL premium themes with our Premium and Business plans!' ) }
+					title={ 'Unlock ALL premium themes with our Premium and Business plans!' }
 					event="themes_plans_free_personal"
 					callToAction={ translate( 'View plans' ) }
 				/>

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -21,30 +21,56 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
 import { getSiteSlug } from 'state/sites/selectors';
+import config from 'config';
+import { abtest } from 'lib/abtest';
 
 const ConnectedSingleSiteWpcom = connectOptions( props => {
 	const { hasUnlimitedPremiumThemes, requestingSitePlans, siteId, siteSlug, translate } = props;
 
+	const displayUpsellBanner = ! requestingSitePlans && ! hasUnlimitedPremiumThemes;
+	const bannerLocationBelowSearch =
+		config.isEnabled( 'upsell/nudge-a-palooza' ) && abtest( 'nudgeAPalooza' ) === 'themesUpsells';
+
 	const upsellUrl = `/plans/${ siteSlug }`;
+	let upsellBanner = null;
+	if ( displayUpsellBanner ) {
+		if ( bannerLocationBelowSearch ) {
+			upsellBanner = (
+				<Banner
+					plan={ PLAN_PREMIUM }
+					className="is-theme-showcase-banner" // eslint-disable-line wpcalypso/jsx-classname-namespace
+					title={ translate( 'Unlock ALL premium themes with our Premium and Business plans!' ) }
+					event="themes_plans_free_personal"
+					callToAction={ translate( 'View plans' ) }
+				/>
+			);
+		} else {
+			upsellBanner = (
+				<Banner
+					plan={ PLAN_PREMIUM }
+					title={ translate(
+						'Access all our premium themes with our Premium and Business plans!'
+					) }
+					description={ translate(
+						'Get advanced customization, more storage space, and video support along with all your new themes.'
+					) }
+					event="themes_plans_free_personal"
+				/>
+			);
+		}
+	}
 	return (
 		<div>
 			<SidebarNavigation />
 			<CurrentTheme siteId={ siteId } />
-			{ ! requestingSitePlans &&
-				! hasUnlimitedPremiumThemes && (
-					<Banner
-						plan={ PLAN_PREMIUM }
-						title={ translate(
-							'Access all our premium themes with our Premium and Business plans!'
-						) }
-						description={ translate(
-							'Get advanced customization, more storage space, and video support along with all your new themes.'
-						) }
-						event="themes_plans_free_personal"
-					/>
-				) }
+			{ bannerLocationBelowSearch ? null : upsellBanner }
 
-			<ThemeShowcase { ...props } upsellUrl={ upsellUrl } siteId={ siteId }>
+			<ThemeShowcase
+				{ ...props }
+				upsellUrl={ upsellUrl }
+				upsellBanner={ bannerLocationBelowSearch ? upsellBanner : null }
+				siteId={ siteId }
+			>
 				{ siteId && <QuerySitePlans siteId={ siteId } /> }
 				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 				<ThanksModal source={ 'list' } />

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -1,7 +1,7 @@
-.themes__thanks-modal  {
+.themes__thanks-modal {
 	min-height: 90px;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		box-sizing: border-box;
 		max-width: 100%;
 	}
@@ -13,8 +13,9 @@
 			margin-left: 0;
 		}
 
-		@include breakpoint( "<480px" ) {
-			.button, .button:first-child {
+		@include breakpoint( '<480px' ) {
+			.button,
+			.button:first-child {
 				display: block;
 				margin: 0 auto 10px;
 				width: 100%;
@@ -44,7 +45,6 @@
 			color: $gray-lighten-10;
 			margin-top: 0.3em;
 		}
-
 	}
 
 	ul {
@@ -77,7 +77,7 @@
 
 	.site-selector-modal__content {
 		.theme {
-			@include breakpoint( ">480px" ) {
+			@include breakpoint( '>480px' ) {
 				width: 300px;
 			}
 			margin-left: auto;
@@ -90,7 +90,7 @@
 			margin-bottom: 0;
 		}
 
-		>h2 {
+		> h2 {
 			text-align: center;
 			font-size: 0.75em;
 			line-height: 0.75em;
@@ -103,8 +103,7 @@
 }
 
 .sticky-panel.is-sticky .themes__search-card {
-	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
-	0 2px 4px $gray-lighten-20;
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, 0.5 ), 0 2px 4px $gray-lighten-20;
 }
 
 .themes__upload-button {
@@ -117,11 +116,11 @@
 			padding-right: 4px;
 		}
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			margin-top: 18px;
 		}
 
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( '<480px' ) {
 			margin-top: 24px;
 			margin-right: 15px;
 			font-size: 0;
@@ -136,7 +135,14 @@
 .is-section-themes.has-no-sidebar .themes__content {
 	padding: 0 0 32px;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		padding: 32px;
 	}
+}
+
+.banner.is-theme-showcase-banner {
+	@include banner-dark();
+
+	margin-top: 15px;
+	margin-bottom: 15px;
 }

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -34,6 +34,7 @@ class ThemePreview extends React.Component {
 
 	static propTypes = {
 		// connected props
+		belowToolbar: PropTypes.element,
 		demoUrl: PropTypes.string,
 		isActivating: PropTypes.bool,
 		isActive: PropTypes.bool,
@@ -112,6 +113,7 @@ class ThemePreview extends React.Component {
 		return (
 			<div>
 				{ this.props.isJetpack && <QueryTheme themeId={ themeId } siteId="wporg" /> }
+				{ this.props.children }
 				{ this.props.demoUrl && (
 					<WebPreview
 						showPreview={ true }
@@ -120,6 +122,7 @@ class ThemePreview extends React.Component {
 						onClose={ this.props.hideThemePreview }
 						previewUrl={ this.props.demoUrl + '?demo=true&iframe=true&theme_preview=true' }
 						externalUrl={ this.props.demoUrl }
+						belowToolbar={ this.props.belowToolbar }
 					>
 						{ showActionIndicator && <PulsingDot active={ true } /> }
 						{ ! showActionIndicator && this.renderSecondaryButton() }

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -34,7 +34,6 @@ class ThemePreview extends React.Component {
 
 	static propTypes = {
 		// connected props
-		belowToolbar: PropTypes.element,
 		demoUrl: PropTypes.string,
 		isActivating: PropTypes.bool,
 		isActive: PropTypes.bool,
@@ -113,7 +112,6 @@ class ThemePreview extends React.Component {
 		return (
 			<div>
 				{ this.props.isJetpack && <QueryTheme themeId={ themeId } siteId="wporg" /> }
-				{ this.props.children }
 				{ this.props.demoUrl && (
 					<WebPreview
 						showPreview={ true }
@@ -122,7 +120,6 @@ class ThemePreview extends React.Component {
 						onClose={ this.props.hideThemePreview }
 						previewUrl={ this.props.demoUrl + '?demo=true&iframe=true&theme_preview=true' }
 						externalUrl={ this.props.demoUrl }
-						belowToolbar={ this.props.belowToolbar }
 					>
 						{ showActionIndicator && <PulsingDot active={ true } /> }
 						{ ! showActionIndicator && this.renderSecondaryButton() }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -73,6 +73,7 @@ class ThemeShowcase extends React.Component {
 		secondaryOption: optionShape,
 		getScreenshotOption: PropTypes.func,
 		siteSlug: PropTypes.string,
+		upsellBanner: PropTypes.element,
 		trackATUploadClick: PropTypes.func,
 	};
 
@@ -80,6 +81,7 @@ class ThemeShowcase extends React.Component {
 		tier: '',
 		search: '',
 		emptyContent: null,
+		upsellBanner: false,
 		showUploadButton: true,
 	};
 
@@ -238,6 +240,7 @@ class ThemeShowcase extends React.Component {
 						showTierThemesControl={ ! isMultisite }
 						select={ this.onTierSelect }
 					/>
+					{ this.props.upsellBanner }
 					{ this.showUploadButton() && (
 						<Button
 							className="themes__upload-button"


### PR DESCRIPTION
Quotes in CSS files were automatically updated by eslint, it's not easy to get rid of that update.

Test plan:
1. Assign yourself to "control" group of nudgeAPalooza A/B test
2. Go to /themes and confirm it looks just like in production
3. Assign yourself to "sidebarUpsells" group of nudgeAPalooza A/B test
4. Confirm that /themes page looks now more like this:

<img width="1140" alt="zrzut ekranu 2018-07-16 o 15 54 52" src="https://user-images.githubusercontent.com/205419/42762407-9865f236-8910-11e8-843a-d15aa70d4b1e.png">

5. Confirm that "View plans" button redirects to /plans page