### PR TITLE
Move the babel-core bridge package to devDependencies

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1735,7 +1735,8 @@
     "babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
-      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg=="
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+      "dev": true
     },
     "babel-eslint": {
       "version": "8.2.6",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@babel/runtime": "7.0.0-beta.44",
     "autoprefixer": "8.6.5",
     "autosize": "4.0.2",
-    "babel-core": "7.0.0-bridge.0",
     "babel-loader": "8.0.0-beta.3",
     "babel-plugin-add-module-exports": "0.2.1",
     "babel-plugin-transform-class-properties": "6.24.1",
@@ -236,6 +235,7 @@
     "postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\""
   },
   "devDependencies": {
+    "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "8.2.6",
     "babel-jest": "23.4.0",
     "chai": "4.1.2",

--- a/server/bundler/babel/babel-loader-cache-identifier/index.js
+++ b/server/bundler/babel/babel-loader-cache-identifier/index.js
@@ -27,7 +27,7 @@ function getModuleVersion( id ) {
  */
 module.exports = JSON.stringify( {
 	'babel-loader': getModuleVersion( 'babel-loader' ),
-	'babel-core': getModuleVersion( 'babel-core' ),
+	'babel-core': getModuleVersion( '@babel/core' ),
 	'babel-plugin-transform-wpcalypso-async': getModuleVersion(
 		'../babel-plugin-transform-wpcalypso-async'
 	),


### PR DESCRIPTION
After updating the Babel cache key creator to use `@babel/core`, the compatibility bridge is not used by anything else and can be removed.

**Edit:** repurposed to moving the bridge to `devDependencies` as it's used only by Jest now.