### PR TITLE
Podcasting: enabled podcast management in Calypso

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -170,10 +170,7 @@ class SiteSettingsFormWriting extends Component {
 					onChangeField={ onChangeField }
 				/>
 
-				{ isPodcastingSupported &&
-					config.isEnabled( 'manage/site-settings/podcasting' ) && (
-						<PodcastingLink fields={ fields } />
-					) }
+				{ isPodcastingSupported && <PodcastingLink fields={ fields } /> }
 
 				{ jetpackSettingsUI && <QueryJetpackModules siteId={ siteId } /> }
 

--- a/client/my-sites/site-settings/settings-writing/index.js
+++ b/client/my-sites/site-settings/settings-writing/index.js
@@ -38,17 +38,15 @@ export default function() {
 		);
 	}
 
-	if ( config.isEnabled( 'manage/site-settings/podcasting' ) ) {
-		page( '/settings/podcasting', siteSelection, sites, makeLayout, clientRender );
+	page( '/settings/podcasting', siteSelection, sites, makeLayout, clientRender );
 
-		page(
-			'/settings/podcasting/:site_id',
-			siteSelection,
-			navigation,
-			settingsController.setScroll,
-			controller.podcasting,
-			makeLayout,
-			clientRender
-		);
-	}
+	page(
+		'/settings/podcasting/:site_id',
+		siteSelection,
+		navigation,
+		settingsController.setScroll,
+		controller.podcasting,
+		makeLayout,
+		clientRender
+	);
 }

--- a/config/development.json
+++ b/config/development.json
@@ -106,7 +106,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/site-settings/podcasting": true,
 		"manage/stats": true,
 		"manage/stats/podcasts": true,
 		"manage/themes": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -76,7 +76,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/site-settings/podcasting": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -84,7 +84,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/site-settings/podcasting": true,
 		"manage/stats": true,
 		"manage/stats/podcasts": true,
 		"manage/themes": true,


### PR DESCRIPTION
This removes the `manage/site-settings/podcasting` feature flag to enable podcast management in Calypso. This PR is part of a larger epic. See p3Ex-32D-p2.