### PR TITLE
Enable nudge-a-palooza updates in wpcalypso  (store upsell)

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -161,7 +161,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"upsell/nudge-a-palooza": false,
+		"upsell/nudge-a-palooza": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,


### PR DESCRIPTION
We want to be able to test PRs behind a feature flag nudge-a-palooza in wpcalypso and on calypso.live URLs, this PR makes it possible. Changes in upsells are currently work in progress so for now this will enable just a new store upsell.

Related P2 post: p9jf6J-Hl-p2 (project 5 test 1)

Test plan:
1. Click on calypso.live link below
2. Put yourself in group "sidebarUpsells" of "nudgeAPalooza" A/B test and confirm you can now see a Store sidebar item for a free site. It should be clickable and lead to a landing page:

<img width="279" alt="screen shot on 2018-07-16 at 20_27_30" src="https://user-images.githubusercontent.com/205419/42776271-bf6b0b7a-8936-11e8-9885-dc8afef92a07.png">

3. Put yourself in group "control" of the same test and confirm there's no Store sidebar item for free sites