### PR TITLE
Post Editor: Disable the feature that "remembers" editor position between modes

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -1086,7 +1086,7 @@ export class PostEditor extends React.Component {
 
 			// `this.findBookmarkedPosition` inserted some markup into the TinyMCE content.
 			// Reset it back to the original.
-			this.editor.setEditorContent( content );
+			//this.editor.setEditorContent( content );
 
 			if ( this.state.selectedText ) {
 				// Word count is not available in the HTML mode
@@ -1096,7 +1096,7 @@ export class PostEditor extends React.Component {
 
 			this.editor.setSelection( selectionRange );
 		} else if ( mode === 'tinymce' ) {
-			this.addHTMLBookmarkInTextAreaContent();
+			//this.addHTMLBookmarkInTextAreaContent();
 			this.editor._editor.on( 'SetContent', this.focusHTMLBookmarkInVisualEditor );
 		}
 


### PR DESCRIPTION
I'm creating this PR to (hopefully) demonstrate that this mutation of the post content during the mode switch is contributing to some subset of the issues being reported in #9833.

## To Test

### Confirm existing behavior:

On `master`:
* Create a new post (or page, etc. -- it happens there as well)
* Switch to `HTML` mode
* Paste: `<p style="padding-left:30px;">hi</p>` (note there is **NO** space between the `:` & the `30px`)
* Switch to `Visual` mode
* Switch back to `HTML` mode

Notice a space has been added between the `:` & the `30px`.

### Confirm the "fix"

On this branch:
* Repeat the above

Notice **NO** space has been added between the `:` & the `30px`.

### Question

Can we achieve this same behavior without mutating the post content in some way? Perhaps we can keep some external reference to where the cursor is supposed to be post-switch somehow?

If we can't do that quickly, we should probably go ahead & disable this feature (a bit more cleanly than is done here thus far) while we more-fully understand the way it changes the content so we can compensate.