### PR TITLE
[wip] plugins: improve uploading-plugin notices

### DIFF
--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -54,6 +54,14 @@ const showErrorNotice = error => {
 		return errorNotice( knownError );
 	}
 
+	const uploadingErrors = {
+		invalid_plugin_package: translate( 'The uploaded file is not a valid plugin package.' ),
+	};
+
+	if ( error && error.error && uploadingErrors[ error.error ] ) {
+		return errorNotice( uploadingErrors[ error.error ] );
+	}
+
 	if ( error.error ) {
 		return errorNotice(
 			translate( 'Upload problem: %(error)s.', {


### PR DESCRIPTION
`[WIP]`
This PR handles more response errors when the customer tries to upload a new plugin.

![image](https://user-images.githubusercontent.com/77539/42783323-0df7630c-8922-11e8-9723-052c87a12763.png)
