### PR TITLE
Framework: Move @babel/polyfill import to webpack config

### DIFF
--- a/client/boot/polyfills.js
+++ b/client/boot/polyfills.js
@@ -1,13 +1,8 @@
 /** @format */
-/**
- * External dependencies
- */
-import '@babel/polyfill';
 
 /**
  * Internal dependencies
  */
-
 import localStoragePolyfill from 'lib/local-storage';
 
 localStoragePolyfill();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,7 +74,7 @@ const babelLoader = {
 
 const webpackConfig = {
 	bail: ! isDevelopment,
-	entry: { build: [ path.join( __dirname, 'client', 'boot', 'app' ) ] },
+	entry: { build: [ '@babel/polyfill', path.join( __dirname, 'client', 'boot', 'app' ) ] },
 	profile: shouldEmitStats,
 	mode: isDevelopment ? 'development' : 'production',
 	devtool: isDevelopment ? '#eval' : process.env.SOURCEMAP || false, // in production builds you can specify a source-map via env var


### PR DESCRIPTION
For #24788 (which otherwise [breaks](https://github.com/Automattic/wp-calypso/pull/24788/files#r202687634)). Usage in `webpack.config.js` is documented in [official Babel docs](https://babeljs.io/docs/en/babel-polyfill/#usage-in-node-browserify-webpack).

### Testing Instructions

Verify that functionality that isn't present in a browser but provided by the polyfill still works.

In particular, follow testing instructions found in #25419 to make sure we're not introducing a regression here. @jblz I don't have Android Studio installed on my computer, can I ask you to give this a test?