### PR TITLE
enable new nudges in wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -159,7 +159,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"upsell/nudge-a-palooza": false,
+		"upsell/nudge-a-palooza": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,


### PR DESCRIPTION
At the moment it is not possible to test the new feature pages and nudges in calypso.live or wpcalypso.

This change just enables the feature.

# Testing

Visit https://calypso.live/feature/plugins?branch=add/enable-new-nudges-in-wpcalypso and verify that you are shown the site selector and then see the current version of the plugins feature page.