### PR TITLE
Reader: improve rendering of Gutenberg demo post

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -36,7 +36,8 @@
 		font-weight: 700;
 	}
 
-	p, > div {
+	p,
+	> div {
 		margin: 0 0 24px;
 
 		&:last-child {
@@ -65,7 +66,8 @@
 		margin: auto;
 
 		&.emoji,
-		&.emojify__emoji {
+		&.emojify__emoji,
+		&.wp-smiley {
 			height: 1em;
 			margin-bottom: 0;
 		}
@@ -77,14 +79,14 @@
 		margin: 24px auto;
 	}
 
-	iframe[class^="twitter-"],
-	iframe[class^="instagram-"],
+	iframe[class^='twitter-'],
+	iframe[class^='instagram-'],
 	.fb_iframe_widget {
 		display: block;
 		margin: 24px auto !important;
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		.alignleft {
 			max-width: 100%;
 			float: left;
@@ -102,7 +104,7 @@
 		}
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		.alignleft,
 		.alignright {
 			clear: both;
@@ -141,7 +143,7 @@
 		&.alignleft {
 			max-width: 100%;
 
-			@include breakpoint( ">660px" ) {
+			@include breakpoint( '>660px' ) {
 				max-width: 50%;
 			}
 
@@ -183,15 +185,16 @@
 		box-sizing: border-box;
 		font-size: 14px;
 		line-height: 1.4285;
-		animation: appear .3s ease-in-out;
+		animation: appear 0.3s ease-in-out;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			padding: 13px 48px;
 			font-size: inherit;
 		}
 	}
 
-	sup, sub {
+	sup,
+	sub {
 		vertical-align: baseline;
 		position: relative;
 		font-size: 0.83em;
@@ -213,21 +216,42 @@
 	img:first-child {
 		margin-top: 0;
 	}
+
+	// Gutenberg blocks
+	.wp-block-image,
+	.wp-block-embed {
+		margin-bottom: 1em;
+	}
+
+	ul.wp-block-gallery {
+		list-style-type: none;
+		margin-left: 0;
+		margin-bottom: 1em;
+	}
+
+	.wp-block-embed .embed-vimeo {
+		padding-top: 0;
+		margin-bottom: 1.4em;
+	}
+
+	.wp-block-cover-image {
+		display: none;
+	}
 }
 
 // Discover-Specific Full Post View Styles
 .blog-53424024 .reader-full-post__story-content {
 	.intro {
 		font-size: 20px;
-	    font-weight: 700;
-	    margin: 0 0 24px 0;
+		font-weight: 700;
+		margin: 0 0 24px 0;
 
 		&:first-child:first-letter {
 			float: left;
 			margin: 18px 12px 0 0;
 			font-size: 66px;
-		    font-weight: 400;
-		    line-height: 0.5;
+			font-weight: 400;
+			line-height: 0.5;
 		}
 
 		// Firefox-only position fix
@@ -295,21 +319,21 @@
 		width: 175px;
 		position: relative;
 
-		@media ( min-width: 1400px ) {
+		@media (min-width: 1400px) {
 			position: absolute;
 			left: inherit;
 			right: -( 175px + 32px );
 			margin-left: 0;
 		}
 
-		@media ( max-width: 1400px ) {
+		@media (max-width: 1400px) {
 			background: lighten( $gray, 30 );
 			margin: 0 0 24px 0;
 			padding: 16px;
 			width: calc( 100% - 32px );
 		}
 
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( '<480px' ) {
 			margin: 0 0 24px 0;
 			background: lighten( $gray, 30 );
 			padding: 16px;
@@ -324,14 +348,13 @@
 
 // Longreads-Specific Full Post View Styles
 .blog-70135762 .reader-full-post__story-content {
-
 	.publisher-intro img {
 		float: left;
 		margin: 0 20px 0 0;
 	}
 
 	.publisher-intro p:first-child {
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			margin-bottom: 0;
 		}
 	}
@@ -354,7 +377,6 @@
 	margin: 0 auto;
 	margin-bottom: 24px !important; // override element style from twitter
 }
-
 
 // Hides Jetpack RP in Reader
 .reader-full-post .jp-relatedposts-headline,


### PR DESCRIPTION
This PR introduces some basic styles for improving rendering of Gutenberg posts in Reader, based on the Gutenberg demo post (http://bluefuton.wpsandbox.me/2018/07/17/welcome-to-the-gutenberg-editor/).

<img width="833" alt="screen shot 2018-07-17 at 15 04 30" src="https://user-images.githubusercontent.com/17325/42794415-bbfb6a60-89d2-11e8-9ac8-460dd446c641.png">

### Known issues

* Broken image in footer (we're trying to parse a .svg through Photon, which produces an error - PR to follow) https://i2.wp.com/s.w.org/images/core/emoji/2.3/svg/1f44b.svg?ssl=1
* Cover image not shown ("Of Mountains & Printing Presses") - the image src is in the `style` attribute, which we currently strip. I've hidden cover images for the moment.

### To test

Load the post in Reader at http://calypso.localhost:3000/read/feeds/58215415/posts/1926776088.