### PR TITLE
lib/safe-image-url: don't pass .svg images to Photon

### DIFF
--- a/client/lib/safe-image-url/index.js
+++ b/client/lib/safe-image-url/index.js
@@ -6,6 +6,7 @@
 
 import photon from 'photon';
 import { parse as parseUrl } from 'url';
+import { endsWith } from 'lodash';
 
 /**
  * Pattern matching URLs to be left unmodified.
@@ -48,7 +49,7 @@ export default function safeImageUrl( url ) {
 		return url;
 	}
 
-	const { hostname, query } = parseUrl(
+	const { hostname, path, query } = parseUrl(
 		url,
 		/* parseQueryString */ false,
 		/* slashesDenoteHost */ true
@@ -61,6 +62,11 @@ export default function safeImageUrl( url ) {
 
 	// If there's a query string, bail out because Photon doesn't support them on external URLs
 	if ( query && query.length > 0 ) {
+		return null;
+	}
+
+	// Photon doesn't support SVGs
+	if ( endsWith( path, '.svg' ) ) {
 		return null;
 	}
 

--- a/client/lib/safe-image-url/test/index.js
+++ b/client/lib/safe-image-url/test/index.js
@@ -97,6 +97,11 @@ describe( 'safeImageUrl()', () => {
 			expect( safeImageUrl( 'https://example.com/foo.png?bar' ) ).toBeNull();
 			expect( safeImageUrl( 'https://example.com/foo.png?width=90' ) ).toBeNull();
 		} );
+
+		test( 'should return null for SVG images', () => {
+			expect( safeImageUrl( 'https://example.com/foo.svg' ) ).toBeNull();
+			expect( safeImageUrl( 'https://example.com/foo.svg?ssl=1' ) ).toBeNull();
+		} );
 	}
 
 	describe( 'browser', () => {


### PR DESCRIPTION
Photon does not support .svg images, and produces the following error when one is handed to it:

> Error 0002. The type of image you are trying to process is not allowed.

Try https://i2.wp.com/s.w.org/images/core/emoji/2.3/svg/1f44b.svg?ssl=1, for example.

This PR stops passing .svg images to Photon from `lib/safe-image-url`.

### To test

Load the post in Reader at http://calypso.localhost:3000/read/feeds/58215415/posts/1926776088.

Make sure there is no broken .svg image at the end of the post.

Before:

<img width="291" alt="screen shot 2018-07-18 at 14 21 30" src="https://user-images.githubusercontent.com/17325/42855927-eaa9ace0-8a96-11e8-9ae2-ed4600e2d5bd.png">

After:

<img width="285" alt="screen shot 2018-07-18 at 14 28 47" src="https://user-images.githubusercontent.com/17325/42855941-fd667926-8a96-11e8-9f66-3f8f85d57b8e.png">
