### PR TITLE
DevDocs: Adding a 404/error view

### DIFF
--- a/client/devdocs/doc.jsx
+++ b/client/devdocs/doc.jsx
@@ -11,6 +11,7 @@ import React from 'react';
  * Internal dependencies
  */
 import DocService from './service';
+import Error from './error';
 import DocumentHead from 'components/data/document-head';
 import highlight from 'lib/highlight';
 
@@ -25,6 +26,7 @@ export default class extends React.Component {
 
 	state = {
 		body: '',
+		error: null,
 	};
 
 	timeoutID = null;
@@ -49,13 +51,15 @@ export default class extends React.Component {
 	fetch = () => {
 		this.setState( {
 			body: '',
+			error: null,
 		} );
 		this.delayLoadingMessage();
 		DocService.fetch(
 			this.props.path,
-			function( err, body ) {
+			function( error, body ) {
 				this.setState( {
-					body: err || body,
+					body,
+					error,
 				} );
 			}.bind( this )
 		);
@@ -92,16 +96,18 @@ export default class extends React.Component {
 		}
 	};
 
-	render() {
+	renderBody() {
 		const editURL = encodeURI(
 			'https://github.com/Automattic/wp-calypso/edit/master/' + this.props.path
 		);
-		const titleMatches = this.state.body.length && this.state.body.match( /<h1[^>]+>(.+)<\/h1>/ );
-		const title = titleMatches && titleMatches[ 1 ];
+		const { body, error } = this.state;
+
+		if ( ! body || error ) {
+			return null;
+		}
 
 		return (
-			<div className="devdocs devdocs__doc">
-				{ title ? <DocumentHead title={ title } /> : null }
+			<>
 				<a
 					className="devdocs__doc-edit-link"
 					href={ editURL }
@@ -114,8 +120,22 @@ export default class extends React.Component {
 					className="devdocs__doc-content"
 					ref="body"
 					//eslint-disable-next-line react/no-danger
-					dangerouslySetInnerHTML={ { __html: highlight( this.props.term, this.state.body ) } }
+					dangerouslySetInnerHTML={ { __html: highlight( this.props.term, body ) } }
 				/>
+			</>
+		);
+	}
+
+	render() {
+		const { body, error } = this.state;
+		const titleMatches = body && body.length && body.match( /<h1[^>]+>(.+)<\/h1>/ );
+		const title = titleMatches && titleMatches[ 1 ];
+
+		return (
+			<div className="devdocs devdocs__doc">
+				{ title ? <DocumentHead title={ title } /> : null }
+				{ this.renderBody() }
+				{ error && <Error /> }
 			</div>
 		);
 	}

--- a/client/devdocs/doc.jsx
+++ b/client/devdocs/doc.jsx
@@ -107,7 +107,7 @@ export default class extends React.Component {
 		}
 
 		return (
-			<>
+			<div className="devdocs__body">
 				<a
 					className="devdocs__doc-edit-link"
 					href={ editURL }
@@ -118,11 +118,10 @@ export default class extends React.Component {
 				</a>
 				<div
 					className="devdocs__doc-content"
-					ref="body"
 					//eslint-disable-next-line react/no-danger
 					dangerouslySetInnerHTML={ { __html: highlight( this.props.term, body ) } }
 				/>
-			</>
+			</div>
 		);
 	}
 

--- a/client/devdocs/error.jsx
+++ b/client/devdocs/error.jsx
@@ -11,12 +11,12 @@ export default class extends React.PureComponent {
 
 	render() {
 		return (
-			<div className="devdocs_error devdocs__doc-content">
+			<div className="devdocs__error devdocs__doc-content">
 				<h1>Sorry, we can't find that page right now</h1>
 				<img alt="WordPress" src="/calypso/images/illustrations/illustration-404.svg" />
 				<p>
 					Are we missing documentation? Could our docs be improved? Let us know by{' '}
-					<a href="/devdocs/.github/CONTRIBUTING.md">filing a GitHub issue</a>. Thanks!
+					<a href="/devdocs/.github/CONTRIBUTING.md">filing a GitHub issue</a>!
 				</p>
 			</div>
 		);

--- a/client/devdocs/error.jsx
+++ b/client/devdocs/error.jsx
@@ -1,0 +1,24 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+
+export default class extends React.PureComponent {
+	static displayName = 'Error';
+
+	render() {
+		return (
+			<div className="devdocs_error devdocs__doc-content">
+				<h1>Sorry, we can't find that page right now</h1>
+				<img alt="WordPress" src="/calypso/images/illustrations/illustration-404.svg" />
+				<p>
+					Are we missing documentation? Could our docs be improved? Let us know by{' '}
+					<a href="/devdocs/.github/CONTRIBUTING.md">filing a GitHub issue</a>. Thanks!
+				</p>
+			</div>
+		);
+	}
+}

--- a/client/devdocs/test/doc.jsx
+++ b/client/devdocs/test/doc.jsx
@@ -6,10 +6,8 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import React from 'react';
-import TestUtils from 'react-dom/test-utils';
-import ReactDom from 'react-dom';
+import { shallow } from 'enzyme';
 
 /**
  * Internal dependencies
@@ -20,22 +18,30 @@ jest.mock( 'devdocs/service', () => ( {
 	fetch: () => {},
 } ) );
 
+const defaultProps = {
+	term: 'hello',
+	path: '/example',
+	sectionId: '',
+};
+
 describe( 'SingleDoc', () => {
-	describe( 'makeSnip', () => {
-		describe( 'render test', () => {
-			let renderedSingleDoc;
+	describe( 'render test', () => {
+		test( 'should render html with marked text', () => {
+			const wrapper = shallow( <SingleDocClass { ...defaultProps } /> );
+			wrapper.setState( { body: '<div><p>something hello</p></div>' } );
+			expect( wrapper.find( '.devdocs__body .devdocs__doc-content' ).html() ).toEqual(
+				'<div class="devdocs__doc-content"><div><p>something <mark>hello</mark></p></div></div>'
+			);
+			expect( wrapper.find( 'Error' ) ).toHaveLength( 0 );
+		} );
 
-			beforeEach( () => {
-				renderedSingleDoc = TestUtils.renderIntoDocument(
-					<SingleDocClass path={ '/example' } term={ 'hello' } />
-				);
+		test( 'should render Error component', () => {
+			const wrapper = shallow( <SingleDocClass { ...defaultProps } /> );
+			wrapper.setState( {
+				error: 'Error invoking /devdocs/content: File does not exist" is displayed',
 			} );
-
-			test( 'should render html with marked text', () => {
-				renderedSingleDoc.setState( { body: '<div><p>something hello</p></div>' } );
-				const html = ReactDom.findDOMNode( renderedSingleDoc.refs.body ).innerHTML;
-				expect( html ).to.equal( '<div><p>something <mark>hello</mark></p></div>' );
-			} );
+			expect( wrapper.find( 'Error' ) ).toHaveLength( 1 );
+			expect( wrapper.find( '.devdocs__body' ) ).toHaveLength( 0 );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR address #26066 by displaying a generic error component when `fetchDocsEndpoint` returns an error. No frills, little cerebral effort invested.

<img width="821" alt="screen shot 2018-07-17 at 6 45 41 pm" src="https://user-images.githubusercontent.com/6458278/42806559-1419035a-89f2-11e8-9c1c-3a177ffa26f5.png">

Adding former editors of this section as reviewers. (Thanks in advance!)

props to @mmtr

An improvement would be to remove the [error message completely](https://github.com/Automattic/wp-calypso/blob/f2be75b/client/devdocs/service.js#L17). Or return the status code. 

## Testing
Visit `/devdocs/{whatever}` and behold the 404 page!


