### PR TITLE
Add upsell banners to specific theme's page and theme preview

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -257,6 +257,7 @@ export class WebPreviewContent extends Component {
 					selectSeoPreview={ this.selectSEO }
 					isLoading={ this.state.isLoadingSubpage }
 				/>
+				{ this.props.belowToolbar }
 				{ ( ! this.state.loaded || this.state.isLoadingSubpage ) && <SpinnerLine /> }
 				<div className="web-preview__placeholder">
 					{ showLoadingMessage && (
@@ -288,6 +289,8 @@ export class WebPreviewContent extends Component {
 }
 
 WebPreviewContent.propTypes = {
+	// Additional elements to display below the toolbar
+	belowToolbar: PropTypes.element,
 	// Display the preview
 	showPreview: PropTypes.bool,
 	// Show external link button
@@ -338,6 +341,7 @@ WebPreviewContent.propTypes = {
 };
 
 WebPreviewContent.defaultProps = {
+	belowToolbar: null,
 	showExternal: true,
 	showClose: true,
 	showSEO: true,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -624,6 +624,8 @@ class ThemeSheet extends React.Component {
 			config.isEnabled( 'upsell/nudge-a-palooza' ) &&
 			abtest( 'nudgeAPalooza' ) === 'themesUpsells';
 		if ( hasUpsellBanner ) {
+			// This is just for US-english audience and is not translated, remember to add translate() calls before
+			// removing a/b test check and enabling it for everyone
 			pageUpsellBanner = (
 				<Banner
 					plan={ PLAN_PREMIUM }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -29,7 +29,7 @@ import HeaderCake from 'components/header-cake';
 import SectionHeader from 'components/section-header';
 import ThemeDownloadCard from './theme-download-card';
 import ThemePreview from 'my-sites/themes/theme-preview';
-import { Banner } from 'components/banner';
+import Banner from 'components/banner';
 import Button from 'components/button';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -22,12 +22,14 @@ import photon from 'photon';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import QueryCanonicalTheme from 'components/data/query-canonical-theme';
 import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
 import SectionHeader from 'components/section-header';
 import ThemeDownloadCard from './theme-download-card';
 import ThemePreview from 'my-sites/themes/theme-preview';
+import { Banner } from 'components/banner';
 import Button from 'components/button';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
@@ -56,6 +58,7 @@ import {
 	getThemeForumUrl,
 } from 'state/themes/selectors';
 import { getBackPath } from 'state/themes/themes-ui/selectors';
+import { abtest } from 'lib/abtest';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
 import { decodeEntities } from 'lib/formatting';
@@ -63,6 +66,8 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { setThemePreviewOptions } from 'state/themes/actions';
 import ThemeNotFoundError from './theme-not-found-error';
 import ThemeFeaturesCard from './theme-features-card';
+import { FEATURE_UNLIMITED_PREMIUM_THEMES, PLAN_PREMIUM } from 'lib/plans/constants';
+import { hasFeature } from 'state/sites/plans/selectors';
 
 class ThemeSheet extends React.Component {
 	static displayName = 'ThemeSheet';
@@ -213,14 +218,28 @@ class ThemeSheet extends React.Component {
 		return preview.action( this.props.id );
 	};
 
-	renderPreviewButton( demo_uri ) {
+	shouldRenderPreviewButton() {
+		return this.isThemeAvailable() && ! this.isThemeCurrentOne();
+	}
+
+	isThemeCurrentOne() {
+		return this.props.isActive;
+	}
+
+	isThemeAvailable() {
+		const { demo_uri, retired } = this.props;
+		return demo_uri && ! retired;
+	}
+
+	renderPreviewButton( demo_uri = this.props.demo_uri, props = {} ) {
 		return (
 			<a
-				className="theme__sheet-preview-link"
+				className={ 'theme__sheet-preview-link' }
 				onClick={ this.previewAction }
 				data-tip-target="theme-sheet-preview"
 				href={ demo_uri }
 				rel="noopener noreferrer"
+				{ ...props }
 			>
 				<span className="theme__sheet-preview-link-text">
 					{ i18n.translate( 'Open Live Demo', {
@@ -232,7 +251,7 @@ class ThemeSheet extends React.Component {
 	}
 
 	renderScreenshot() {
-		const { demo_uri, retired, isActive, isWpcomTheme, name: themeName } = this.props;
+		const { isWpcomTheme, name: themeName } = this.props;
 		const screenshotFull = isWpcomTheme ? this.getFullLengthScreenshot() : this.props.screenshot;
 		const width = 735;
 		// Photon may return null, allow fallbacks
@@ -248,10 +267,10 @@ class ThemeSheet extends React.Component {
 			/>
 		);
 
-		if ( demo_uri && ! retired ) {
+		if ( this.isThemeAvailable() ) {
 			return (
 				<div className="theme__sheet-screenshot is-active" onClick={ this.previewAction }>
-					{ isActive ? null : this.renderPreviewButton( demo_uri ) }
+					{ this.shouldRenderPreviewButton() ? this.renderPreviewButton() : null }
 					{ img }
 				</div>
 			);
@@ -281,6 +300,18 @@ class ThemeSheet extends React.Component {
 						{ filterStrings[ section ] }
 					</NavItem>
 				) ) }
+				{ this.shouldRenderPreviewButton() ? (
+					<NavItem
+						key="theme-preview"
+						path={ this.props.demo_uri }
+						onClick={ this.previewAction }
+						className={ 'is-' + 'theme-preview' }
+					>
+						{ i18n.translate( 'Open Live Demo', {
+							context: 'Individual theme live preview button',
+						} ) }
+					</NavItem>
+				) : null }
 			</NavTabs>
 		);
 
@@ -548,7 +579,7 @@ class ThemeSheet extends React.Component {
 
 	renderSheet = () => {
 		const section = this.validateSection( this.props.section );
-		const { id, siteId, retired } = this.props;
+		const { id, siteId, retired, hasUnlimitedPremiumThemes } = this.props;
 
 		const analyticsPath = `/theme/${ id }${ section ? '/' + section : '' }${
 			siteId ? '/:site' : ''
@@ -587,10 +618,34 @@ class ThemeSheet extends React.Component {
 			} );
 		}
 
+		let pageUpsellBanner, previewUpsellBanner;
+		const hasUpsellBanner =
+			! hasUnlimitedPremiumThemes &&
+			config.isEnabled( 'upsell/nudge-a-palooza' ) &&
+			abtest( 'nudgeAPalooza' ) === 'themesUpsells';
+		if ( hasUpsellBanner ) {
+			pageUpsellBanner = (
+				<Banner
+					plan={ PLAN_PREMIUM }
+					className="is-particular-theme-banner" // eslint-disable-line wpcalypso/jsx-classname-namespace
+					title={ 'Access this theme for FREE with a Premium or Business plan!' }
+					description={
+						'Instantly unlock all premium themes, more storage space, advanced customization, video support, and more when you upgrade.'
+					}
+					event="themes_plan_particular_free_with_plan"
+					callToAction={ 'View plans' }
+				/>
+			);
+			previewUpsellBanner = React.cloneElement( pageUpsellBanner, {
+				className: 'is-theme-preview-banner',
+			} );
+		}
+		const className = classNames( 'theme__sheet', { 'is-with-upsell-banner': hasUpsellBanner } );
+
 		const links = [ { rel: 'canonical', href: canonicalUrl } ];
 
 		return (
-			<Main className="theme__sheet">
+			<Main className={ className }>
 				<QueryCanonicalTheme themeId={ this.props.id } siteId={ siteId } />
 				{ currentUserId && <QueryUserPurchases userId={ currentUserId } /> }
 				{ siteId && (
@@ -602,6 +657,7 @@ class ThemeSheet extends React.Component {
 				{ this.renderBar() }
 				<QueryActiveTheme siteId={ siteId } />
 				<ThanksModal source={ 'details' } />
+				{ pageUpsellBanner }
 				<HeaderCake
 					className="theme__sheet-action-bar"
 					backHref={ this.props.backPath }
@@ -616,7 +672,7 @@ class ThemeSheet extends React.Component {
 					</div>
 					<div className="theme__sheet-column-right">{ this.renderScreenshot() }</div>
 				</div>
-				<ThemePreview />
+				<ThemePreview belowToolbar={ previewUpsellBanner } />
 			</Main>
 		);
 	};
@@ -705,6 +761,7 @@ export default connect(
 			isPremium: isThemePremium( state, id ),
 			isPurchased: isPremiumThemeAvailable( state, id, siteId ),
 			forumUrl: getThemeForumUrl( state, id, siteId ),
+			hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
 			// No siteId specified since we want the *canonical* URL :-)
 			canonicalUrl: 'https://wordpress.com' + getThemeDetailsUrl( state, id ),
 		};

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -2,8 +2,7 @@
 	max-width: none;
 }
 
-.theme__sheet-bar
-{
+.theme__sheet-bar {
 	background-color: $blue-wordpress;
 	color: white;
 	height: 180px;
@@ -36,7 +35,7 @@
 	max-width: 1500px;
 	margin: 0 auto;
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		flex-direction: column-reverse;
 	}
 }
@@ -47,7 +46,7 @@
 	width: 50%;
 	flex-direction: column;
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		width: 100%;
 	}
 }
@@ -55,7 +54,7 @@
 .theme__sheet-action-bar {
 	height: 50px;
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		&.card {
 			margin: 0 0 1px 0;
 		}
@@ -64,15 +63,15 @@
 
 .theme__sheet-primary-button {
 	position: absolute;
-		top: 5px;
-		right: 50%;
+	top: 5px;
+	right: 50%;
 	margin-right: 20px;
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		margin-right: 0;
 		position: absolute;
-			top: 5px;
-			right: 5px;
+		top: 5px;
+		right: 5px;
 	}
 }
 
@@ -80,9 +79,19 @@
 	color: transparent;
 }
 
+.theme__sheet-section-nav {
+	.is-theme-preview {
+		margin-left: auto;
+
+		@include breakpoint( '<960px' ) {
+			display: none;
+		}
+	}
+}
+
 .theme__sheet-action-bar-cost {
 	font-weight: 600;
-	color: #4AB866;
+	color: #4ab866;
 	margin-left: 10px;
 	display: inline-block;
 	max-width: 50%;
@@ -106,7 +115,7 @@
 	// also x-browser issues, so it's smaller than 4:3 proper
 	min-height: 36.15vw; // 36.75vw would be correct, but Safari is slightly off
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		position: relative;
 		margin-top: 0;
 		top: 0;
@@ -116,17 +125,22 @@
 		box-shadow: none;
 
 		&:before {
-			content: "";
+			content: '';
 			display: block;
 			position: absolute;
 			bottom: 0;
 			width: 100%;
 			height: 30%;
-			background: linear-gradient( to bottom, transparentize( $gray-light, 1.0 ) 0%, transparentize( $gray-light, 0.5 ) 40%, $gray-light 93% );
+			background: linear-gradient(
+				to bottom,
+				transparentize( $gray-light, 1 ) 0%,
+				transparentize( $gray-light, 0.5 ) 40%,
+				$gray-light 93%
+			);
 		}
 	}
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		&.is-active:hover {
 			cursor: pointer;
 			box-shadow: 0 0 0 1px $gray, 0px 2px 10px 0px transparentize( $gray-dark, 0.5 );
@@ -140,10 +154,8 @@
 }
 
 .theme__sheet-preview-link {
-	display: flex;
+	display: none;
 	position: absolute;
-		top: 269px;
-		right: calc( 50% + 30px );
 	margin: 0 auto;
 	padding: 10px;
 	color: $blue-wordpress;
@@ -159,7 +171,8 @@
 		margin-top: 2px;
 	}
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
+		display: flex;
 		top: auto;
 		bottom: -10px;
 		left: 0;
@@ -238,7 +251,7 @@
 		padding: 15px 20px 15px;
 		border-bottom: 1px solid #dce5eb;
 
-		&:nth-child(n+2) {
+		&:nth-child( n + 2 ) {
 			// Everything except the first
 			border-top: 1px solid #dce5eb;
 			margin: 20px -20px 20px;
@@ -246,7 +259,7 @@
 
 			&:before {
 				// The "fake" Card separation
-				content: "";
+				content: '';
 				display: block;
 				height: 15px;
 				margin: -15px -21px 15px;
@@ -310,7 +323,7 @@
 		font-size: 13px;
 		line-height: 21px;
 
-		&>p:first-child {
+		& > p:first-child {
 			color: $gray;
 			font-weight: 600;
 			margin: 0 0 14px;
@@ -340,7 +353,7 @@
 
 .theme__sheet-placeholder {
 	color: transparent;
-	background-color: rgba(255, 255, 255, 0.4);
+	background-color: rgba( 255, 255, 255, 0.4 );
 	animation: loading-fade 1.6s ease-in-out infinite;
 }
 
@@ -360,7 +373,7 @@
 		transition: all 100ms ease-in;
 
 		&:after {
-			content: "";
+			content: '';
 			pointer-events: none;
 			position: absolute;
 			width: 100%;
@@ -371,7 +384,7 @@
 			left: 0;
 			padding: 0;
 			z-index: -1;
-			transform: scale(0.9, 0.9);
+			transform: scale( 0.9, 0.9 );
 			transition: transform 300ms, opacity 400ms;
 		}
 
@@ -380,7 +393,7 @@
 			background-color: $blue-dark;
 
 			&:after {
-				transform: scale(1.07, 1.16);
+				transform: scale( 1.07, 1.16 );
 			}
 		}
 	}
@@ -397,11 +410,11 @@
 	display: flex;
 	align-items: center;
 
-	&:not(:last-child) {
+	&:not( :last-child ) {
 		margin-bottom: 0;
 	}
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		flex-wrap: wrap;
 	}
 
@@ -413,7 +426,7 @@
 	.button {
 		flex: 0 0 auto;
 
-		@include breakpoint( "<960px" ) {
+		@include breakpoint( '<960px' ) {
 			flex: 1 1 100%;
 			margin-top: 20px;
 			text-align: center;
@@ -436,7 +449,7 @@
 	align-items: center;
 	margin-bottom: 40px;
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		flex-wrap: wrap;
 	}
 
@@ -448,7 +461,7 @@
 	.button {
 		flex: 0 0 auto;
 
-		@include breakpoint( "<960px" ) {
+		@include breakpoint( '<960px' ) {
 			flex: 1 1 100%;
 			margin-top: 20px;
 			text-align: center;
@@ -481,4 +494,23 @@
 	// This is used in conjunction with the theme content output.
 	// NOT to be used anywhere in Calypso UI.
 	display: none;
+}
+
+.banner.is-particular-theme-banner {
+	@include banner-dark();
+
+	width: 50%;
+
+	margin: 0 0 10px 0;
+	background-color: #34444d;
+
+	@include breakpoint( '<960px' ) {
+		width: 100%;
+	}
+}
+
+.banner.is-theme-preview-banner {
+	@include banner-dark();
+	width: 100%;
+	margin: 0;
 }

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -34,6 +34,7 @@ class ThemePreview extends React.Component {
 
 	static propTypes = {
 		// connected props
+		belowToolbar: PropTypes.element,
 		demoUrl: PropTypes.string,
 		isActivating: PropTypes.bool,
 		isActive: PropTypes.bool,
@@ -112,6 +113,7 @@ class ThemePreview extends React.Component {
 		return (
 			<div>
 				{ this.props.isJetpack && <QueryTheme themeId={ themeId } siteId="wporg" /> }
+				{ this.props.children }
 				{ this.props.demoUrl && (
 					<WebPreview
 						showPreview={ true }
@@ -120,6 +122,7 @@ class ThemePreview extends React.Component {
 						onClose={ this.props.hideThemePreview }
 						previewUrl={ this.props.demoUrl + '?demo=true&iframe=true&theme_preview=true' }
 						externalUrl={ this.props.demoUrl }
+						belowToolbar={ this.props.belowToolbar }
 					>
 						{ showActionIndicator && <PulsingDot active={ true } /> }
 						{ ! showActionIndicator && this.renderSecondaryButton() }


### PR DESCRIPTION
This PR adds an upsell nudge to specific theme's page and also to theme preview. Related post: p9jf6J-Hl-p2

Some formatting updates to css were made by linter and there's no easy way to get rid of them.

Test plan:
1. Put yourself in "control" group of nudgeAPalooza A/B test
2. Go to customize > themes > any premium theme
3. Confirm there is no upsell nudge
4. Confirm you can see "Open live demo" link (there are substantial CSS updates in this PR):

<img width="1521" alt="screen shot on 2018-07-17 at 10_56_29" src="https://user-images.githubusercontent.com/205419/42807062-20131dd6-89b0-11e8-8e9b-00962029edb1.png">

5. Resize your browser to tablet and mobile and confirm that Open live demo behaves the same way it does in production:

<img width="912" alt="screen shot on 2018-07-17 at 10_57_20" src="https://user-images.githubusercontent.com/205419/42807095-36936462-89b0-11e8-85fd-1b02fe606a01.png">

6. Click on "Open live demo" link and confirm there is no upsell nudge there
7. Put yourself in "themesUpsell" group of nudgeAPalooza A/B test
8. Confirm there is an upsell nudge now on the theme page and that clicking on it takes you to plans page

<img width="1740" alt="zrzut ekranu 2018-07-17 o 11 01 48" src="https://user-images.githubusercontent.com/205419/42807344-d6ea4228-89b0-11e8-9639-8f61a9f6ee98.png">

9. Click on "Open live demo" link and confirm there an upsell nudge there and that clicking on it takes you to plans page

<img width="1734" alt="zrzut ekranu 2018-07-17 o 11 01 56" src="https://user-images.githubusercontent.com/205419/42807346-d9254682-89b0-11e8-83d8-9bd1ec4a2c6e.png">

10. Resize your browser to tablet and mobile and confirm that page behaves in a sensible way and nothing feels off
11. Open a free theme
12. Confirm there is no upsell nudge both on theme's page and in the live preview
