### PR TITLE
Add a "theme to plan" upsell nudge to cart when a premium theme is the only product

### DIFF
--- a/client/my-sites/checkout/cart/cart-plan-ad-theme.jsx
+++ b/client/my-sites/checkout/cart/cart-plan-ad-theme.jsx
@@ -1,0 +1,104 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import CartAd from './cart-ad';
+import { abtest } from 'lib/abtest';
+import { cartItems } from 'lib/cart-values';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { addItem } from 'lib/upgrades/actions';
+import { PLAN_PREMIUM, FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
+import { hasFeature } from 'state/sites/plans/selectors';
+import TrackComponentView from 'lib/analytics/track-component-view';
+import { recordTracksEvent } from 'state/analytics/actions';
+
+const eventName = 'cart_theme_to_plan_upsell';
+
+class CartPlanAdTheme extends Component {
+	addToCartAndRedirect = event => {
+		event.preventDefault();
+		addItem( cartItems.premiumPlan( PLAN_PREMIUM, {} ) );
+		this.props.recordTracksEvent( 'calypso_banner_cta_click', {
+			cta_name: eventName,
+		} );
+		page( '/checkout/' + this.props.selectedSite.slug );
+	};
+
+	shouldDisplayAd = () => {
+		const { cart, hasUnlimitedPremiumThemes, selectedSite } = this.props;
+		const items = cartItems.getAll( cart );
+		const hasOnlyAPremiumTheme = items.length === 1 && items[ 0 ].product_slug === 'premium_theme';
+
+		return (
+			config.isEnabled( 'upsell/nudge-a-palooza' ) &&
+			! hasUnlimitedPremiumThemes &&
+			cart.hasLoadedFromServer &&
+			! cart.hasPendingServerUpdates &&
+			hasOnlyAPremiumTheme &&
+			selectedSite &&
+			selectedSite.plan &&
+			abtest( 'nudgeAPalooza' ) === 'themesUpsells'
+		);
+	};
+
+	render() {
+		// Nothing here is translated on purpose - this is a part of an A/B test that we are launching
+		// only for US english audience. Remember to add translate() calls before concluding a test and
+		// enabling this for everyone!
+		if ( ! this.shouldDisplayAd() ) {
+			return null;
+		}
+
+		const className = 'button is-link';
+
+		return (
+			<CartAd>
+				<TrackComponentView
+					eventName={ 'calypso_banner_cta_impression' }
+					eventProperties={ {
+						cta_name: eventName,
+					} }
+				/>
+				Get this theme for FREE when you upgrade to a Premium plan!{' '}
+				<button className={ className } onClick={ this.addToCartAndRedirect }>
+					{ 'Upgrade Now' }
+				</button>
+			</CartAd>
+		);
+	}
+}
+
+CartPlanAdTheme.propTypes = {
+	cart: PropTypes.object.isRequired,
+	hasUnlimitedPremiumThemes: PropTypes.bool,
+	selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
+};
+
+const mapStateToProps = state => {
+	const selectedSiteId = getSelectedSiteId( state );
+
+	return {
+		hasUnlimitedPremiumThemes: hasFeature(
+			state,
+			selectedSiteId,
+			FEATURE_UNLIMITED_PREMIUM_THEMES
+		),
+	};
+};
+
+export default connect(
+	mapStateToProps,
+	{ recordTracksEvent }
+)( localize( CartPlanAdTheme ) );

--- a/client/my-sites/checkout/cart/cart-plan-ad-theme.jsx
+++ b/client/my-sites/checkout/cart/cart-plan-ad-theme.jsx
@@ -55,7 +55,7 @@ class CartPlanAdTheme extends Component {
 
 	render() {
 		// Nothing here is translated on purpose - this is a part of an A/B test that we are launching
-		// only for US english audience. Remember to add translate() calls before concluding a test and
+		// only for english audience. Remember to add translate() calls before concluding a test and
 		// enabling this for everyone!
 		if ( ! this.shouldDisplayAd() ) {
 			return null;

--- a/client/my-sites/checkout/cart/secondary-cart.jsx
+++ b/client/my-sites/checkout/cart/secondary-cart.jsx
@@ -18,6 +18,7 @@ import CartBody from 'my-sites/checkout/cart/cart-body';
 import CartMessages from './cart-messages';
 import CartSummaryBar from 'my-sites/checkout/cart/cart-summary-bar';
 import CartPlanAd from './cart-plan-ad';
+import CartPlanAdTheme from './cart-plan-ad-theme';
 import CartPlanDiscountAd from './cart-plan-discount-ad';
 import Sidebar from 'layout/sidebar';
 import CartBodyLoadingPlaceholder from 'my-sites/checkout/cart/cart-body/loading-placeholder';
@@ -81,6 +82,7 @@ class SecondaryCart extends Component {
 				<CartMessages cart={ cart } selectedSite={ selectedSite } />
 				<CartSummaryBar additionalClasses="cart-header" />
 				<CartPlanAd selectedSite={ selectedSite } cart={ cart } />
+				<CartPlanAdTheme selectedSite={ selectedSite } cart={ cart } />
 				<CartBody
 					ref={ this.setCartBodyRef }
 					cart={ cart }


### PR DESCRIPTION
This PR adds an upsell nudge to cart when a premium theme is the only product. Related post: p9jf6J-Hl-p2


Test plan:
1. Put yourself in "control" group of nudgeAPalooza A/B test
1. Go to customize > themes as a free user and purchase any premium theme
1. When you are in the cart, the sidebar should have no upsell at all:

<img width="278" alt="zrzut ekranu 2018-07-17 o 11 44 18" src="https://user-images.githubusercontent.com/205419/42810799-137a28ea-89b9-11e8-86a3-6547eae972e2.png">

4. Now put yourself in "themesUpsell" group of the same test and confirm you can see the following upsell:

<img width="274" alt="zrzut ekranu 2018-07-17 o 11 44 29" src="https://user-images.githubusercontent.com/205419/42810812-1f098dfe-89b9-11e8-9bdd-adc48de558db.png">

5. Click on "Upgrade now" and confirm it replaced a theme with a premium plan