### PR TITLE
[nudge-a-palooza] Add explainatory comments why some strings are not being translated

### DIFF
--- a/client/my-sites/feature-upsell/plugins-upsell.jsx
+++ b/client/my-sites/feature-upsell/plugins-upsell.jsx
@@ -25,6 +25,10 @@ import { PLAN_BUSINESS } from 'lib/plans/constants';
 import PurchaseDetail from 'components/purchase-detail';
 import { getCurrencyObject } from 'lib/format-currency';
 
+/*
+ * This is just for english audience and is not translated on purpose, remember to add
+ * translate() calls before removing a/b test check and enabling it for everyone
+ */
 class PluginsUpsellComponent extends Component {
 	static propTypes = {
 		selectedSiteSlug: PropTypes.string.isRequired,

--- a/client/my-sites/feature-upsell/store-upsell.jsx
+++ b/client/my-sites/feature-upsell/store-upsell.jsx
@@ -37,6 +37,10 @@ import { isRequestingActivePromotions } from 'state/active-promotions/selectors'
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
+/*
+ * This is just for english audience and is not translated on purpose, remember to add
+ * translate() calls before removing a/b test check and enabling it for everyone
+ */
 class StoreUpsellComponent extends Component {
 	static propTypes = {
 		trackTracksEvent: PropTypes.func.isRequired,

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -35,6 +35,8 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 	let upsellBanner = null;
 	if ( displayUpsellBanner ) {
 		if ( bannerLocationBelowSearch ) {
+			// This is just for english audience and is not translated on purpose, remember to add
+			// translate() calls before removing a/b test check and enabling it for everyone
 			upsellBanner = (
 				<Banner
 					plan={ PLAN_PREMIUM }


### PR DESCRIPTION
We are starting a series of tests related to updates in upsell nudges. Those tests are being conducted on english audience only so we are not calling `translate()` for most strings there. Since there were some confusion about it in a few related PRs, this one adds some comments to explain it.

Related P2 post: p9jf6J-Hl-p2

Test plan:
1. Read the diff :-)