### PR TITLE
Simple Payments: Add unsupported message to the shortcode

### DIFF
--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -20,7 +20,6 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import formatCurrency from 'lib/format-currency';
 import QuerySimplePayments from 'components/data/query-simple-payments';
 import QueryMedia from 'components/data/query-media';
-import { isJetpackSite } from 'state/sites/selectors';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { hasFeature, getSitePlanSlug } from 'state/sites/plans/selectors';
 import { FEATURE_SIMPLE_PAYMENTS } from 'lib/plans/constants';
@@ -32,7 +31,6 @@ class SimplePaymentsView extends Component {
 			productId,
 			product,
 			siteId,
-			isJetpack,
 			shouldQuerySitePlans,
 			planHasSimplePaymentsFeature,
 		} = this.props;
@@ -46,9 +44,6 @@ class SimplePaymentsView extends Component {
 		}
 
 		if ( ! shouldQuerySitePlans && ! planHasSimplePaymentsFeature ) {
-			const unsupportedMessage = isJetpack
-				? translate( 'Simple Payments is not supported by your current Jetpack Plan.' )
-				: translate( 'Simple Payments is not supported by your Plan.' );
 			return (
 				<div className="wpview-content wpview-type-simple-payments">
 					<div className="wpview-type-simple-payments__unsupported">
@@ -58,7 +53,7 @@ class SimplePaymentsView extends Component {
 						<p
 							className="wpview-type-simple-payments__unsupported-message"
 							//eslint-disable-next-line react/no-danger
-							dangerouslySetInnerHTML={ { __html: unsupportedMessage } }
+							dangerouslySetInnerHTML={ { __html: "Your plan doesn't include Simple Payments." } }
 						/>
 					</div>
 				</div>
@@ -134,7 +129,6 @@ SimplePaymentsView = connect( ( state, props ) => {
 		siteId,
 		product,
 		productImage: getMediaItem( state, siteId, get( product, 'featuredImageId' ) ),
-		isJetpack: isJetpackSite( state, siteId ),
 		shouldQuerySitePlans: getSitePlanSlug( state, siteId ) === null,
 		planHasSimplePaymentsFeature: hasFeature( state, siteId, FEATURE_SIMPLE_PAYMENTS ),
 	};

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -50,11 +50,9 @@ class SimplePaymentsView extends Component {
 						<div className="wpview-type-simple-payments__unsupported-icon">
 							<Gridicon icon="cross" />
 						</div>
-						<p
-							className="wpview-type-simple-payments__unsupported-message"
-							//eslint-disable-next-line react/no-danger
-							dangerouslySetInnerHTML={ { __html: "Your plan doesn't include Simple Payments." } }
-						/>
+						<p className="wpview-type-simple-payments__unsupported-message">
+							{ translate( "Your plan doesn't include Simple Payments." ) }
+						</p>
 					</div>
 				</div>
 			);

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -20,30 +20,18 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import formatCurrency from 'lib/format-currency';
 import QuerySimplePayments from 'components/data/query-simple-payments';
 import QueryMedia from 'components/data/query-media';
-import QuerySitePlans from 'components/data/query-site-plans';
-import { hasFeature, getSitePlanSlug } from 'state/sites/plans/selectors';
+import { hasFeature } from 'state/sites/plans/selectors';
 import { FEATURE_SIMPLE_PAYMENTS } from 'lib/plans/constants';
 
 class SimplePaymentsView extends Component {
 	render() {
-		const {
-			translate,
-			productId,
-			product,
-			siteId,
-			shouldQuerySitePlans,
-			planHasSimplePaymentsFeature,
-		} = this.props;
+		const { translate, productId, product, siteId, planHasSimplePaymentsFeature } = this.props;
 
 		if ( ! product ) {
 			return <QuerySimplePayments siteId={ siteId } productId={ productId } />;
 		}
 
-		if ( shouldQuerySitePlans ) {
-			return <QuerySitePlans siteId={ siteId } />;
-		}
-
-		if ( ! shouldQuerySitePlans && ! planHasSimplePaymentsFeature ) {
+		if ( ! planHasSimplePaymentsFeature ) {
 			return (
 				<div className="wpview-content wpview-type-simple-payments">
 					<div className="wpview-type-simple-payments__unsupported">
@@ -127,7 +115,6 @@ SimplePaymentsView = connect( ( state, props ) => {
 		siteId,
 		product,
 		productImage: getMediaItem( state, siteId, get( product, 'featuredImageId' ) ),
-		shouldQuerySitePlans: getSitePlanSlug( state, siteId ) === null,
 		planHasSimplePaymentsFeature: hasFeature( state, siteId, FEATURE_SIMPLE_PAYMENTS ),
 	};
 } )( localize( SimplePaymentsView ) );

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
@@ -3,7 +3,7 @@
 	flex-direction: column;
 	padding: 10px;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		flex-direction: row;
 	}
 }
@@ -12,8 +12,8 @@
 	flex: 0 0 30%;
 	margin-bottom: 24px;
 
-	@include breakpoint( ">480px" ) {
-		margin-bottom: 0
+	@include breakpoint( '>480px' ) {
+		margin-bottom: 0;
 	}
 }
 
@@ -22,7 +22,7 @@
 	background-color: $gray-lighten-30;
 	margin: 0;
 	min-width: 70px;
-	padding-top: calc(100% - 2px);
+	padding-top: calc( 100% - 2px );
 	position: relative;
 }
 
@@ -34,7 +34,7 @@
 	max-width: 100%;
 	position: absolute;
 	top: 50%;
-	transform: translate(-50%, -50%);
+	transform: translate( -50%, -50% );
 	width: auto;
 }
 
@@ -42,12 +42,14 @@
 	flex-basis: 100%;
 }
 
-.mce-content-body .wpview-type-simple-payments__text-part > div:not(.wpview-type-simple-payments__pay-part) {
+.mce-content-body
+	.wpview-type-simple-payments__text-part
+	> div:not( .wpview-type-simple-payments__pay-part ) {
 	line-height: 1.7;
 }
 
 .wpview-type-simple-payments__image-part + .wpview-type-simple-payments__text-part {
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		flex-basis: 70%;
 		padding-left: 24px;
 	}
@@ -105,7 +107,8 @@
 	position: absolute;
 	right: -1px;
 	width: 144px;
-	background: rgba(0, 0, 0, 0) linear-gradient(rgb(245, 245, 245), rgb(204, 204, 204)) repeat scroll 0px 100% /  auto padding-box border-box;
+	background: rgba( 0, 0, 0, 0 ) linear-gradient( rgb( 245, 245, 245 ), rgb( 204, 204, 204 ) )
+		repeat scroll 0px 100% / auto padding-box border-box;
 	border-radius: 4px 4px 4px 4px;
 	padding: 1px;
 }
@@ -115,15 +118,15 @@
 	height: 12px;
 	position: relative;
 	text-align: left;
-	text-shadow: rgb(204, 204, 204) 0px -1px;
+	text-shadow: rgb( 204, 204, 204 ) 0px -1px;
 	top: 50%;
 	width: 43px;
-	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 	font-size: 10px;
 	font-style: normal;
 	font-weight: 500;
 	line-height: normal;
-	transform: translateY(-50%);
+	transform: translateY( -50% );
 	vertical-align: top;
 }
 
@@ -133,6 +136,28 @@
 	position: relative;
 	vertical-align: top;
 	width: 53px;
-	background-image: url('/calypso/images/simple-payments/paypal-logo.svg');
+	background-image: url( '/calypso/images/simple-payments/paypal-logo.svg' );
 	background-size: 53px 17px;
+}
+
+.wpview-type-simple-payments__unsupported {
+	align-items: center;
+	background-color: $white;
+	border: 2px solid $white;
+	border-radius: 2px;
+	box-shadow: 0 0 0 1px $gray-lighten-20, 0 1px 2px $gray-lighten-30;
+	display: flex;
+	flex-flow: row;
+	flex-wrap: nowrap;
+	padding: 1em;
+}
+.wpview-type-simple-payments__unsupported-icon {
+	flex-shrink: 1;
+	flex-grow: 0;
+	fill: $alert-red;
+	margin-right: 1em;
+}
+.wpview-type-simple-payments__unsupported-message {
+	flex-grow: 1;
+	line-height: 1.7;
 }

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
@@ -150,14 +150,15 @@
 	flex-flow: row;
 	flex-wrap: nowrap;
 	padding: 1em;
-}
-.wpview-type-simple-payments__unsupported-icon {
-	flex-shrink: 1;
-	flex-grow: 0;
-	fill: $alert-red;
-	margin-right: 1em;
-}
-.wpview-type-simple-payments__unsupported-message {
-	flex-grow: 1;
-	line-height: 1.7;
+	.wpview-type-simple-payments__unsupported-icon {
+		flex-shrink: 1;
+		flex-grow: 0;
+		fill: $alert-red;
+		line-height: 0;
+		margin-right: 1em;
+	}
+	.wpview-type-simple-payments__unsupported-message {
+		flex-grow: 1;
+		line-height: 1.7;
+	}
 }


### PR DESCRIPTION
Follow up to https://github.com/Automattic/jetpack/pull/9842

Add an unsupported message to the Simple Payments shortcode display in the editor.

<img width="729" alt="screen shot 2018-07-17 at 12 39 08" src="https://user-images.githubusercontent.com/2070010/42815162-8393a00c-89be-11e8-95b5-e0e40dc5f27b.png">

## Notes

The big difference with the widget/theme version is that Calypso editor prevent clicking on a shortcode, so the [link to the support pages](https://user-images.githubusercontent.com/233601/42135832-28e73cfc-7d27-11e8-8dad-8c5b188097c7.png) is useless.

## Testing instructions

On a business/premium plan, add one or more Simple Payments buttons to a post.
Then downgrade the site to a free or personal plan, and make sure the Simple Payments buttons are replaced with the unsupported message.