### PR TITLE
Add hack for IE11 to make our new landing pages look good

### DIFF
--- a/client/my-sites/feature-upsell/style.scss
+++ b/client/my-sites/feature-upsell/style.scss
@@ -1,5 +1,12 @@
 .feature-upsell__main {
 	margin-top: 48px;
+	/*
+	 * Hack for IE 11 - max-width is in place to limit constraints but it still
+	 * needs an explicit rule for width
+	 */
+	.product-purchase-feature-list__item {
+		width: 100%;
+	}
 }
 
 .feature-upsell__placeholder-cta {


### PR DESCRIPTION
This PR updates a CSS on an upsell landing page to make it compatible with IE11. Related post: p9jf6J-Hl-p2

Test plan:
1. Go to /feature/store on IE11 and confirm it looks the same as on chrome. Specifically, it should **not** look like this:

<img width="1675" alt="zrzut ekranu 2018-07-17 o 14 56 41" src="https://user-images.githubusercontent.com/205419/42818625-a560d598-89d1-11e8-8ea3-e38817786a2f.png">


