### PR TITLE
Show "theme to plan" upsell nudge only for premium themes and not for free ones

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -620,6 +620,7 @@ class ThemeSheet extends React.Component {
 
 		let pageUpsellBanner, previewUpsellBanner;
 		const hasUpsellBanner =
+			this.props.price > 0 &&
 			! hasUnlimitedPremiumThemes &&
 			config.isEnabled( 'upsell/nudge-a-palooza' ) &&
 			abtest( 'nudgeAPalooza' ) === 'themesUpsells';


### PR DESCRIPTION
This PR updates the upsell nudge added in https://github.com/Automattic/wp-calypso/pull/26106 so it only shows for premium themes. Related post: p9jf6J-Hl-p2

Test plan:
1. Put yourself in "control" group of nudgeAPalooza A/B test and open a free site
2. Go to customize > themes > any premium theme
3. Confirm there is no upsell nudge
4. Put yourself in "themesUpsell" group of nudgeAPalooza A/B test
5. Confirm there is an upsell nudge now on any premium theme page and also in the live preview
6. Confirm there is no upsell nudge now on any free theme page and also in the live preview