### PR TITLE
Update App Banner deep links for iOS universal links

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -197,39 +197,31 @@ export function getiOSDeepLink( currentRoute, currentSection ) {
 	const baseURI = 'https://apps.wordpress.com/get';
 	const fragment = buildDeepLinkFragment( currentRoute, currentSection );
 
-	if ( fragment.length === 0 ) {
-		return baseURI;
-	}
-
-	return `${ baseURI }#${ fragment }`;
+	return fragment.length > 0 ? `${ baseURI }#${ fragment }` : baseURI;
 }
 
 export function buildDeepLinkFragment( currentRoute, currentSection ) {
 	const hasRoute = currentRoute !== null && currentRoute !== '/';
-	let fragment;
 
-	switch ( currentSection ) {
-		case EDITOR:
-			fragment = '/post';
-			break;
-		case NOTES:
-			fragment = '/notifications';
-			break;
-		case READER:
-			// The Reader is generally accessed at the root of WordPress.com ('/').
-			// In this case, we need to manually add the section name to the
-			// URL so that the iOS app knows which section to open.
-			fragment = hasRoute ? currentRoute : '/read';
-			break;
-		case STATS:
-			fragment = hasRoute ? currentRoute : '/stats';
-			break;
-		default:
-			fragment = '';
-			break;
-	}
+	const getFragment = () => {
+		switch ( currentSection ) {
+			case EDITOR:
+				return '/post';
+			case NOTES:
+				return '/notifications';
+			case READER:
+				// The Reader is generally accessed at the root of WordPress.com ('/').
+				// In this case, we need to manually add the section name to the
+				// URL so that the iOS app knows which section to open.
+				return hasRoute ? currentRoute : '/read';
+			case STATS:
+				return hasRoute ? currentRoute : '/stats';
+			default:
+				return '';
+		}
+	};
 
-	return encodeURIComponent( fragment );
+	return encodeURIComponent( getFragment() );
 }
 
 const mapStateToProps = state => {

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -132,35 +132,10 @@ export class AppBanner extends Component {
 		}
 
 		if ( this.isiOS() ) {
-			return this.getiOSDeepLink( currentRoute, currentSection );
+			return getiOSDeepLink( currentRoute, currentSection );
 		}
 
 		return null;
-	}
-
-	getiOSDeepLink( currentRoute, currentSection ) {
-		const hasRoute = currentRoute !== null && currentRoute !== '/';
-		let fragment;
-
-		switch ( currentSection ) {
-			case EDITOR:
-				fragment = '/post';
-				break;
-			case NOTES:
-				fragment = '/notifications';
-				break;
-			case READER:
-				// The Reader is generally accessed at the root of WordPress.com ('/').
-				// In this case, we need to manually add the section name to the
-				// URL so that the iOS app knows which section to open.
-				fragment = hasRoute ? currentRoute : '/read';
-				break;
-			case STATS:
-				fragment = hasRoute ? currentRoute : '/stats';
-				break;
-		}
-
-		return `https://apps.wordpress.com/get#${ encodeURIComponent( fragment ) }`;
 	}
 
 	render() {
@@ -216,6 +191,33 @@ export class AppBanner extends Component {
 			</Card>
 		);
 	}
+}
+
+export function getiOSDeepLink( currentRoute, currentSection ) {
+	const hasRoute = currentRoute !== null && currentRoute !== '/';
+	let fragment;
+
+	switch ( currentSection ) {
+		case EDITOR:
+			fragment = '/post';
+			break;
+		case NOTES:
+			fragment = '/notifications';
+			break;
+		case READER:
+			// The Reader is generally accessed at the root of WordPress.com ('/').
+			// In this case, we need to manually add the section name to the
+			// URL so that the iOS app knows which section to open.
+			fragment = hasRoute ? currentRoute : '/read';
+			break;
+		case STATS:
+			fragment = hasRoute ? currentRoute : '/stats';
+			break;
+		default:
+			return 'https://apps.wordpress.com/get';
+	}
+
+	return `https://apps.wordpress.com/get#${ encodeURIComponent( fragment ) }`;
 }
 
 const mapStateToProps = state => {

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -37,6 +37,7 @@ import {
 	STATS,
 	getAppBannerData,
 	getNewDismissTimes,
+	getCurrentPathFragment,
 	getCurrentSection,
 	isDismissed,
 	APP_BANNER_DISMISS_TIMES_PREFERENCE,
@@ -115,7 +116,7 @@ class AppBanner extends Component {
 	};
 
 	getDeepLink() {
-		const { currentSection } = this.props;
+		const { currentPathFragment, currentSection } = this.props;
 
 		if ( this.isAndroid() ) {
 			//TODO: update when section deep links are available.
@@ -131,9 +132,21 @@ class AppBanner extends Component {
 			}
 		}
 
-		//TODO: update when deferred deep links are available
 		if ( this.isiOS() ) {
-			return 'itms://itunes.apple.com/us/app/wordpress/id335703880?mt=8';
+			switch ( currentSection ) {
+				case EDITOR:
+					return 'https://apps.wordpress.com/get#post';
+				case NOTES:
+					return 'https://apps.wordpress.com/get#notifications';
+				case READER:
+					if ( currentPathFragment.length === 0 ) {
+						return 'https://apps.wordpress.com/get#read';
+					}
+
+					return 'https://apps.wordpress.com/get#' + currentPathFragment;
+				case STATS:
+					return 'https://apps.wordpress.com/get#' + currentPathFragment;
+			}
 		}
 
 		return null;
@@ -201,6 +214,7 @@ const mapStateToProps = state => {
 	return {
 		dismissedUntil: getPreference( state, APP_BANNER_DISMISS_TIMES_PREFERENCE ),
 		currentSection: getCurrentSection( sectionName, isNotesOpen ),
+		currentPathFragment: getCurrentPathFragment( state ),
 		fetchingPreferences: isFetchingPreferences( state ),
 		siteId: getSelectedSiteId( state ),
 	};

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -194,6 +194,17 @@ export class AppBanner extends Component {
 }
 
 export function getiOSDeepLink( currentRoute, currentSection ) {
+	const baseURI = 'https://apps.wordpress.com/get';
+	const fragment = buildDeepLinkFragment( currentRoute, currentSection );
+
+	if ( fragment.length === 0 ) {
+		return baseURI;
+	}
+
+	return `${ baseURI }#${ fragment }`;
+}
+
+export function buildDeepLinkFragment( currentRoute, currentSection ) {
 	const hasRoute = currentRoute !== null && currentRoute !== '/';
 	let fragment;
 
@@ -214,10 +225,11 @@ export function getiOSDeepLink( currentRoute, currentSection ) {
 			fragment = hasRoute ? currentRoute : '/stats';
 			break;
 		default:
-			return 'https://apps.wordpress.com/get';
+			fragment = '';
+			break;
 	}
 
-	return `https://apps.wordpress.com/get#${ encodeURIComponent( fragment ) }`;
+	return encodeURIComponent( fragment );
 }
 
 const mapStateToProps = state => {

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -16,7 +16,8 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Card from 'components/card';
-import { getSectionName, getSelectedSiteId, getCurrentRoute } from 'state/ui/selectors';
+import { getSectionName, getSelectedSiteId } from 'state/ui/selectors';
+import getCurrentRoute from 'state/selectors/get-current-route';
 import { getPreference, isFetchingPreferences } from 'state/preferences/selectors';
 import isNotificationsOpen from 'state/selectors/is-notifications-open';
 import {

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -139,6 +139,7 @@ export class AppBanner extends Component {
 	}
 
 	getiOSDeepLink( currentRoute, currentSection ) {
+		const hasRoute = currentRoute !== null && currentRoute !== '/';
 		let fragment;
 
 		switch ( currentSection ) {
@@ -152,10 +153,10 @@ export class AppBanner extends Component {
 				// The Reader is generally accessed at the root of WordPress.com ('/').
 				// In this case, we need to manually add the section name to the
 				// URL so that the iOS app knows which section to open.
-				fragment = currentRoute === '/' ? '/read' : currentRoute;
+				fragment = hasRoute ? currentRoute : '/read';
 				break;
 			case STATS:
-				fragment = currentRoute;
+				fragment = hasRoute ? currentRoute : '/stats';
 				break;
 		}
 

--- a/client/blocks/app-banner/test/__snapshots__/app-banner.jsx.snap
+++ b/client/blocks/app-banner/test/__snapshots__/app-banner.jsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`iOS deep links returns a URI even if the path is null 1`] = `"https://apps.wordpress.com/get#%2Fstats"`;
+
+exports[`iOS deep links returns a URI even if the path is null 2`] = `"https://apps.wordpress.com/get#%2Fread"`;
+
+exports[`iOS deep links returns a URI even if the path is null 3`] = `"https://apps.wordpress.com/get#%2Fpost"`;
+
+exports[`iOS deep links returns a URI even if the path is null 4`] = `"https://apps.wordpress.com/get#%2Fnotifications"`;
+
+exports[`iOS deep links returns correct URIs for each route 1`] = `"https://apps.wordpress.com/get#%2Ftest"`;
+
+exports[`iOS deep links returns correct URIs for each route 2`] = `"https://apps.wordpress.com/get#%2Ftest"`;
+
+exports[`iOS deep links returns correct URIs for each route 3`] = `"https://apps.wordpress.com/get#%2Fpost"`;
+
+exports[`iOS deep links returns correct URIs for each route 4`] = `"https://apps.wordpress.com/get#%2Fnotifications"`;

--- a/client/blocks/app-banner/test/__snapshots__/app-banner.jsx.snap
+++ b/client/blocks/app-banner/test/__snapshots__/app-banner.jsx.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`iOS deep links returns a URI even if the path is null 1`] = `"https://apps.wordpress.com/get#%2Fstats"`;
+exports[`iOS deep link fragments returns a fragment for each section 1`] = `"%2Ftest"`;
 
-exports[`iOS deep links returns a URI even if the path is null 2`] = `"https://apps.wordpress.com/get#%2Fread"`;
+exports[`iOS deep link fragments returns a fragment for each section 2`] = `"%2Ftest"`;
 
-exports[`iOS deep links returns a URI even if the path is null 3`] = `"https://apps.wordpress.com/get#%2Fpost"`;
+exports[`iOS deep link fragments returns a fragment for each section 3`] = `"%2Fpost"`;
 
-exports[`iOS deep links returns a URI even if the path is null 4`] = `"https://apps.wordpress.com/get#%2Fnotifications"`;
+exports[`iOS deep link fragments returns a fragment for each section 4`] = `"%2Fnotifications"`;
 
-exports[`iOS deep links returns correct URIs for each route 1`] = `"https://apps.wordpress.com/get#%2Ftest"`;
+exports[`iOS deep links returns URIs for each path 1`] = `"https://apps.wordpress.com/get#%2Ftest"`;
 
-exports[`iOS deep links returns correct URIs for each route 2`] = `"https://apps.wordpress.com/get#%2Ftest"`;
+exports[`iOS deep links returns URIs for each path 2`] = `"https://apps.wordpress.com/get#%2Ftest"`;
 
-exports[`iOS deep links returns correct URIs for each route 3`] = `"https://apps.wordpress.com/get#%2Fpost"`;
+exports[`iOS deep links returns URIs for each path 3`] = `"https://apps.wordpress.com/get#%2Fpost"`;
 
-exports[`iOS deep links returns correct URIs for each route 4`] = `"https://apps.wordpress.com/get#%2Fnotifications"`;
+exports[`iOS deep links returns URIs for each path 4`] = `"https://apps.wordpress.com/get#%2Fnotifications"`;

--- a/client/blocks/app-banner/test/app-banner.jsx
+++ b/client/blocks/app-banner/test/app-banner.jsx
@@ -12,61 +12,47 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { AppBanner } from 'blocks/app-banner';
+import { getiOSDeepLink } from 'blocks/app-banner';
 import { EDITOR, NOTES, READER, STATS } from 'blocks/app-banner/utils';
 
-describe( 'AppBanner', () => {
-	let wrapper;
-
-	beforeEach( () => {
-		wrapper = shallow( <AppBanner /> );
-	} );
-
-	test( 'iOS deep links return correct URIs for EDITOR', () => {
-		expect( wrapper.instance().getiOSDeepLink( '/post', EDITOR ) ).toBe(
-			'https://apps.wordpress.com/get#%2Fpost'
-		);
-		expect( wrapper.instance().getiOSDeepLink( '/post/discover.wordpress.com', EDITOR ) ).toBe(
-			'https://apps.wordpress.com/get#%2Fpost'
-		);
-		expect( wrapper.instance().getiOSDeepLink( null, EDITOR ) ).toBe(
-			'https://apps.wordpress.com/get#%2Fpost'
+describe( 'iOS deep links', () => {
+	test( 'returns correct URIs for each route', () => {
+		[ STATS, READER, EDITOR, NOTES ].forEach( section =>
+			expect( getiOSDeepLink( '/test', section ) ).toMatchSnapshot()
 		);
 	} );
 
-	test( 'iOS deep links return correct URIs for NOTES', () => {
-		expect( wrapper.instance().getiOSDeepLink( '/notifications', NOTES ) ).toBe(
-			'https://apps.wordpress.com/get#%2Fnotifications'
-		);
-		expect( wrapper.instance().getiOSDeepLink( '/notifications/12345', NOTES ) ).toBe(
-			'https://apps.wordpress.com/get#%2Fnotifications'
-		);
-		expect( wrapper.instance().getiOSDeepLink( null, NOTES ) ).toBe(
-			'https://apps.wordpress.com/get#%2Fnotifications'
+	test( 'returns a valid Reader URI for the root path', () => {
+		expect( getiOSDeepLink( '/', READER ).split( '#' )[ 1 ] ).toBe( '%2Fread' );
+	} );
+
+	test( 'passes through a non-root Reader URI as the fragment', () => {
+		expect( getiOSDeepLink( '/read/feeds/12345/posts/6789', READER ).split( '#' )[ 1 ] ).toBe(
+			'%2Fread%2Ffeeds%2F12345%2Fposts%2F6789'
 		);
 	} );
 
-	test( 'iOS deep links return correct URIs for READER', () => {
-		expect( wrapper.instance().getiOSDeepLink( '/', READER ) ).toBe(
-			'https://apps.wordpress.com/get#%2Fread'
-		);
-		expect( wrapper.instance().getiOSDeepLink( '/read/feeds/12345/posts/6789', READER ) ).toBe(
-			'https://apps.wordpress.com/get#%2Fread%2Ffeeds%2F12345%2Fposts%2F6789'
-		);
-		expect( wrapper.instance().getiOSDeepLink( null, READER ) ).toBe(
-			'https://apps.wordpress.com/get#%2Fread'
+	test( 'passes through a Stats URI as the fragment', () => {
+		expect( getiOSDeepLink( '/stats/day/discover.wordpress.com', STATS ).split( '#' )[ 1 ] ).toBe(
+			'%2Fstats%2Fday%2Fdiscover.wordpress.com'
 		);
 	} );
 
-	test( 'iOS deep links return correct URIs for STATS', () => {
-		expect( wrapper.instance().getiOSDeepLink( '/stats', STATS ) ).toBe(
-			'https://apps.wordpress.com/get#%2Fstats'
-		);
-		expect( wrapper.instance().getiOSDeepLink( '/stats/day/discover.wordpress.com', STATS ) ).toBe(
-			'https://apps.wordpress.com/get#%2Fstats%2Fday%2Fdiscover.wordpress.com'
-		);
-		expect( wrapper.instance().getiOSDeepLink( null, STATS ) ).toBe(
-			'https://apps.wordpress.com/get#%2Fstats'
+	test( 'adds link info in fragment', () => {
+		expect( getiOSDeepLink( 'test', STATS ).includes( '#' ) ).toBeTruthy();
+	} );
+
+	test( 'returns correct URIs for other sections', () => {
+		expect( getiOSDeepLink( 'test', 'example' ).includes( '#' ) ).toBeFalsy();
+	} );
+
+	test( 'properly encodes tricky fragments', () => {
+		expect( getiOSDeepLink( '?://&#', STATS ).split( '#' )[ 1 ] ).toEqual( '%3F%3A%2F%2F%26%23' );
+	} );
+
+	test( 'returns a URI even if the path is null', () => {
+		[ STATS, READER, EDITOR, NOTES ].forEach( section =>
+			expect( getiOSDeepLink( null, section ) ).toMatchSnapshot()
 		);
 	} );
 } );

--- a/client/blocks/app-banner/test/app-banner.jsx
+++ b/client/blocks/app-banner/test/app-banner.jsx
@@ -11,7 +11,10 @@ import { EDITOR, NOTES, READER, STATS } from 'blocks/app-banner/utils';
 
 describe( 'iOS deep link fragments', () => {
 	test( 'properly encodes tricky fragments', () => {
-		expect( buildDeepLinkFragment( '?://&#', STATS ) ).toEqual( '%3F%3A%2F%2F%26%23' );
+		const funnyFragment = '?://&#';
+		expect( buildDeepLinkFragment( funnyFragment, STATS ) ).toEqual(
+			encodeURIComponent( funnyFragment )
+		);
 	} );
 
 	test( 'returns a fragment for a null path', () => {
@@ -33,15 +36,13 @@ describe( 'iOS deep link fragments', () => {
 	} );
 
 	test( 'passes through a non-root Reader path', () => {
-		expect( buildDeepLinkFragment( '/read/feeds/12345/posts/6789', READER ) ).toBe(
-			'%2Fread%2Ffeeds%2F12345%2Fposts%2F6789'
-		);
+		const path = '/read/feeds/12345/posts/6789';
+		expect( buildDeepLinkFragment( path, READER ) ).toBe( encodeURIComponent( path ) );
 	} );
 
 	test( 'passes through a Stats path', () => {
-		expect( buildDeepLinkFragment( '/stats/day/discover.wordpress.com', STATS ) ).toBe(
-			'%2Fstats%2Fday%2Fdiscover.wordpress.com'
-		);
+		const path = '/stats/day/discover.wordpress.com';
+		expect( buildDeepLinkFragment( path, STATS ) ).toBe( encodeURIComponent( path ) );
 	} );
 } );
 

--- a/client/blocks/app-banner/test/app-banner.jsx
+++ b/client/blocks/app-banner/test/app-banner.jsx
@@ -30,6 +30,9 @@ describe( 'AppBanner', () => {
 		expect( wrapper.instance().getiOSDeepLink( '/post/discover.wordpress.com', EDITOR ) ).equal(
 			'https://apps.wordpress.com/get#%2Fpost'
 		);
+		expect( wrapper.instance().getiOSDeepLink( null, EDITOR ) ).equal(
+			'https://apps.wordpress.com/get#%2Fpost'
+		);
 	} );
 
 	test( 'iOS deep links return correct URIs for NOTES', () => {
@@ -37,6 +40,9 @@ describe( 'AppBanner', () => {
 			'https://apps.wordpress.com/get#%2Fnotifications'
 		);
 		expect( wrapper.instance().getiOSDeepLink( '/notifications/12345', NOTES ) ).equal(
+			'https://apps.wordpress.com/get#%2Fnotifications'
+		);
+		expect( wrapper.instance().getiOSDeepLink( null, NOTES ) ).equal(
 			'https://apps.wordpress.com/get#%2Fnotifications'
 		);
 	} );
@@ -48,6 +54,9 @@ describe( 'AppBanner', () => {
 		expect( wrapper.instance().getiOSDeepLink( '/read/feeds/12345/posts/6789', READER ) ).equal(
 			'https://apps.wordpress.com/get#%2Fread%2Ffeeds%2F12345%2Fposts%2F6789'
 		);
+		expect( wrapper.instance().getiOSDeepLink( null, READER ) ).equal(
+			'https://apps.wordpress.com/get#%2Fread'
+		);
 	} );
 
 	test( 'iOS deep links return correct URIs for STATS', () => {
@@ -56,6 +65,9 @@ describe( 'AppBanner', () => {
 		);
 		expect( wrapper.instance().getiOSDeepLink( '/stats/day/discover.wordpress.com', STATS ) ).equal(
 			'https://apps.wordpress.com/get#%2Fstats%2Fday%2Fdiscover.wordpress.com'
+		);
+		expect( wrapper.instance().getiOSDeepLink( null, STATS ) ).equal(
+			'https://apps.wordpress.com/get#%2Fstats'
 		);
 	} );
 } );

--- a/client/blocks/app-banner/test/app-banner.jsx
+++ b/client/blocks/app-banner/test/app-banner.jsx
@@ -1,0 +1,61 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { AppBanner } from 'blocks/app-banner';
+import { EDITOR, NOTES, READER, STATS } from 'blocks/app-banner/utils';
+
+describe( 'AppBanner', () => {
+	let wrapper;
+
+	beforeEach( () => {
+		wrapper = shallow( <AppBanner /> );
+	} );
+
+	test( 'iOS deep links return correct URIs for EDITOR', () => {
+		expect( wrapper.instance().getiOSDeepLink( '/post', EDITOR ) ).equal(
+			'https://apps.wordpress.com/get#%2Fpost'
+		);
+		expect( wrapper.instance().getiOSDeepLink( '/post/discover.wordpress.com', EDITOR ) ).equal(
+			'https://apps.wordpress.com/get#%2Fpost'
+		);
+	} );
+
+	test( 'iOS deep links return correct URIs for NOTES', () => {
+		expect( wrapper.instance().getiOSDeepLink( '/notifications', NOTES ) ).equal(
+			'https://apps.wordpress.com/get#%2Fnotifications'
+		);
+		expect( wrapper.instance().getiOSDeepLink( '/notifications/12345', NOTES ) ).equal(
+			'https://apps.wordpress.com/get#%2Fnotifications'
+		);
+	} );
+
+	test( 'iOS deep links return correct URIs for READER', () => {
+		expect( wrapper.instance().getiOSDeepLink( '/', READER ) ).equal(
+			'https://apps.wordpress.com/get#%2Fread'
+		);
+		expect( wrapper.instance().getiOSDeepLink( '/read/feeds/12345/posts/6789', READER ) ).equal(
+			'https://apps.wordpress.com/get#%2Fread%2Ffeeds%2F12345%2Fposts%2F6789'
+		);
+	} );
+
+	test( 'iOS deep links return correct URIs for STATS', () => {
+		expect( wrapper.instance().getiOSDeepLink( '/stats', STATS ) ).equal(
+			'https://apps.wordpress.com/get#%2Fstats'
+		);
+		expect( wrapper.instance().getiOSDeepLink( '/stats/day/discover.wordpress.com', STATS ) ).equal(
+			'https://apps.wordpress.com/get#%2Fstats%2Fday%2Fdiscover.wordpress.com'
+		);
+	} );
+} );

--- a/client/blocks/app-banner/test/app-banner.jsx
+++ b/client/blocks/app-banner/test/app-banner.jsx
@@ -4,55 +4,60 @@
  */
 
 /**
- * External dependencies
- */
-import { shallow } from 'enzyme';
-import React from 'react';
-
-/**
  * Internal dependencies
  */
-import { getiOSDeepLink } from 'blocks/app-banner';
+import { getiOSDeepLink, buildDeepLinkFragment } from 'blocks/app-banner';
 import { EDITOR, NOTES, READER, STATS } from 'blocks/app-banner/utils';
 
+describe( 'iOS deep link fragments', () => {
+	test( 'properly encodes tricky fragments', () => {
+		expect( buildDeepLinkFragment( '?://&#', STATS ) ).toEqual( '%3F%3A%2F%2F%26%23' );
+	} );
+
+	test( 'returns a fragment for a null path', () => {
+		expect( buildDeepLinkFragment( null, STATS ).length ).toBeTruthy();
+	} );
+
+	test( 'returns a fragment for each section', () => {
+		[ STATS, READER, EDITOR, NOTES ].forEach( section =>
+			expect( buildDeepLinkFragment( '/test', section ) ).toMatchSnapshot()
+		);
+	} );
+
+	test( 'returns an empty fragment for other sections', () => {
+		expect( buildDeepLinkFragment( 'test', 'example' ).length ).toBeFalsy();
+	} );
+
+	test( 'returns a valid Reader URI for the root path', () => {
+		expect( buildDeepLinkFragment( '/', READER ) ).toBe( '%2Fread' );
+	} );
+
+	test( 'passes through a non-root Reader path', () => {
+		expect( buildDeepLinkFragment( '/read/feeds/12345/posts/6789', READER ) ).toBe(
+			'%2Fread%2Ffeeds%2F12345%2Fposts%2F6789'
+		);
+	} );
+
+	test( 'passes through a Stats path', () => {
+		expect( buildDeepLinkFragment( '/stats/day/discover.wordpress.com', STATS ) ).toBe(
+			'%2Fstats%2Fday%2Fdiscover.wordpress.com'
+		);
+	} );
+} );
+
 describe( 'iOS deep links', () => {
-	test( 'returns correct URIs for each route', () => {
+	test( 'returns a URI even if the path is null', () => {
+		expect( getiOSDeepLink( null, STATS ) ).toBeTruthy();
+	} );
+
+	test( 'returns URIs for each path', () => {
 		[ STATS, READER, EDITOR, NOTES ].forEach( section =>
 			expect( getiOSDeepLink( '/test', section ) ).toMatchSnapshot()
 		);
 	} );
 
-	test( 'returns a valid Reader URI for the root path', () => {
-		expect( getiOSDeepLink( '/', READER ).split( '#' )[ 1 ] ).toBe( '%2Fread' );
-	} );
-
-	test( 'passes through a non-root Reader URI as the fragment', () => {
-		expect( getiOSDeepLink( '/read/feeds/12345/posts/6789', READER ).split( '#' )[ 1 ] ).toBe(
-			'%2Fread%2Ffeeds%2F12345%2Fposts%2F6789'
-		);
-	} );
-
-	test( 'passes through a Stats URI as the fragment', () => {
-		expect( getiOSDeepLink( '/stats/day/discover.wordpress.com', STATS ).split( '#' )[ 1 ] ).toBe(
-			'%2Fstats%2Fday%2Fdiscover.wordpress.com'
-		);
-	} );
-
-	test( 'adds link info in fragment', () => {
-		expect( getiOSDeepLink( 'test', STATS ).includes( '#' ) ).toBeTruthy();
-	} );
-
-	test( 'returns correct URIs for other sections', () => {
-		expect( getiOSDeepLink( 'test', 'example' ).includes( '#' ) ).toBeFalsy();
-	} );
-
-	test( 'properly encodes tricky fragments', () => {
-		expect( getiOSDeepLink( '?://&#', STATS ).split( '#' )[ 1 ] ).toEqual( '%3F%3A%2F%2F%26%23' );
-	} );
-
-	test( 'returns a URI even if the path is null', () => {
-		[ STATS, READER, EDITOR, NOTES ].forEach( section =>
-			expect( getiOSDeepLink( null, section ) ).toMatchSnapshot()
-		);
+	test( 'includes fragment in URI', () => {
+		expect( getiOSDeepLink( '/test', STATS ).includes( '#' ) ).toBeTruthy();
+		expect( getiOSDeepLink( '/test', STATS ).split( '#' )[ 1 ].length ).toBeTruthy();
 	} );
 } );

--- a/client/blocks/app-banner/test/app-banner.jsx
+++ b/client/blocks/app-banner/test/app-banner.jsx
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
 
@@ -24,49 +23,49 @@ describe( 'AppBanner', () => {
 	} );
 
 	test( 'iOS deep links return correct URIs for EDITOR', () => {
-		expect( wrapper.instance().getiOSDeepLink( '/post', EDITOR ) ).equal(
+		expect( wrapper.instance().getiOSDeepLink( '/post', EDITOR ) ).toBe(
 			'https://apps.wordpress.com/get#%2Fpost'
 		);
-		expect( wrapper.instance().getiOSDeepLink( '/post/discover.wordpress.com', EDITOR ) ).equal(
+		expect( wrapper.instance().getiOSDeepLink( '/post/discover.wordpress.com', EDITOR ) ).toBe(
 			'https://apps.wordpress.com/get#%2Fpost'
 		);
-		expect( wrapper.instance().getiOSDeepLink( null, EDITOR ) ).equal(
+		expect( wrapper.instance().getiOSDeepLink( null, EDITOR ) ).toBe(
 			'https://apps.wordpress.com/get#%2Fpost'
 		);
 	} );
 
 	test( 'iOS deep links return correct URIs for NOTES', () => {
-		expect( wrapper.instance().getiOSDeepLink( '/notifications', NOTES ) ).equal(
+		expect( wrapper.instance().getiOSDeepLink( '/notifications', NOTES ) ).toBe(
 			'https://apps.wordpress.com/get#%2Fnotifications'
 		);
-		expect( wrapper.instance().getiOSDeepLink( '/notifications/12345', NOTES ) ).equal(
+		expect( wrapper.instance().getiOSDeepLink( '/notifications/12345', NOTES ) ).toBe(
 			'https://apps.wordpress.com/get#%2Fnotifications'
 		);
-		expect( wrapper.instance().getiOSDeepLink( null, NOTES ) ).equal(
+		expect( wrapper.instance().getiOSDeepLink( null, NOTES ) ).toBe(
 			'https://apps.wordpress.com/get#%2Fnotifications'
 		);
 	} );
 
 	test( 'iOS deep links return correct URIs for READER', () => {
-		expect( wrapper.instance().getiOSDeepLink( '/', READER ) ).equal(
+		expect( wrapper.instance().getiOSDeepLink( '/', READER ) ).toBe(
 			'https://apps.wordpress.com/get#%2Fread'
 		);
-		expect( wrapper.instance().getiOSDeepLink( '/read/feeds/12345/posts/6789', READER ) ).equal(
+		expect( wrapper.instance().getiOSDeepLink( '/read/feeds/12345/posts/6789', READER ) ).toBe(
 			'https://apps.wordpress.com/get#%2Fread%2Ffeeds%2F12345%2Fposts%2F6789'
 		);
-		expect( wrapper.instance().getiOSDeepLink( null, READER ) ).equal(
+		expect( wrapper.instance().getiOSDeepLink( null, READER ) ).toBe(
 			'https://apps.wordpress.com/get#%2Fread'
 		);
 	} );
 
 	test( 'iOS deep links return correct URIs for STATS', () => {
-		expect( wrapper.instance().getiOSDeepLink( '/stats', STATS ) ).equal(
+		expect( wrapper.instance().getiOSDeepLink( '/stats', STATS ) ).toBe(
 			'https://apps.wordpress.com/get#%2Fstats'
 		);
-		expect( wrapper.instance().getiOSDeepLink( '/stats/day/discover.wordpress.com', STATS ) ).equal(
+		expect( wrapper.instance().getiOSDeepLink( '/stats/day/discover.wordpress.com', STATS ) ).toBe(
 			'https://apps.wordpress.com/get#%2Fstats%2Fday%2Fdiscover.wordpress.com'
 		);
-		expect( wrapper.instance().getiOSDeepLink( null, STATS ) ).equal(
+		expect( wrapper.instance().getiOSDeepLink( null, STATS ) ).toBe(
 			'https://apps.wordpress.com/get#%2Fstats'
 		);
 	} );

--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -6,6 +6,8 @@
 
 import { get, includes, reduce } from 'lodash';
 
+import getCurrentRoute from 'state/selectors/get-current-route';
+
 export const APP_BANNER_DISMISS_TIMES_PREFERENCE = 'appBannerDismissTimes';
 export const EDITOR = 'post-editor';
 export const NOTES = 'notifications';
@@ -59,6 +61,13 @@ export function getCurrentSection( currentSection, isNotesOpen ) {
 	}
 
 	return null;
+}
+
+export function getCurrentPathFragment( state ) {
+	const route = getCurrentRoute( state );
+
+	// Strip off the leading forward slash for use as a fragment
+	return route.substring( 1 );
 }
 
 export function getNewDismissTimes( dismissedSection, currentDismissTimes ) {

--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -6,8 +6,6 @@
 
 import { get, includes, reduce } from 'lodash';
 
-import getCurrentRoute from 'state/selectors/get-current-route';
-
 export const APP_BANNER_DISMISS_TIMES_PREFERENCE = 'appBannerDismissTimes';
 export const EDITOR = 'post-editor';
 export const NOTES = 'notifications';
@@ -61,13 +59,6 @@ export function getCurrentSection( currentSection, isNotesOpen ) {
 	}
 
 	return null;
-}
-
-export function getCurrentPathFragment( state ) {
-	const route = getCurrentRoute( state );
-
-	// Strip off the leading forward slash for use as a fragment
-	return route.substring( 1 );
 }
 
 export function getNewDismissTimes( dismissedSection, currentDismissTimes ) {


### PR DESCRIPTION
**Disclaimer:** I'm not a web developer, and I think there may be better ways to do this! Please let me know if something is wrong or can be improved.

This PR updates the mobile app banner deep link URLs for iOS.

![simulator-screen-shot-iphone-8-2018-07-04-at-17-22-06](https://user-images.githubusercontent.com/4780/42832134-2ededfe8-89e8-11e8-8f38-c2dff3c3ac11.png)

The app banners now point to `https://apps.wordpress.com/get`, which will redirect the user to the App Store if they don't have the WordPress for iOS app installed.

If the user does have the app installed, the app will be launched and we'll attempt to navigate them into the appropriate section of the app. To accomplish this, we also append a URL fragment to the base URL for each route.

* **Editor:** `https://apps.wordpress.com/get#post`
* **Notifications:** `https://apps.wordpress.com/get#notifications`
* **Reader:** `https://apps.wordpress.com/get#read` for the root of the Reader. If the user is in a specific section of the Reader, we'll attempt to pass through the entire feed URL so we can load the same one in the app. For example, `https://apps.wordpress.com/get#read/feeds/123456/posts/123456`
* **Stats:** As with the Reader, we'll attempt to append the current path as the fragment, so we can show the same section in the app. For example, `https://apps.wordpress.com/get#stats/discover.wordpress.com`

### To test

Unfortunately the deep linking can't easily be fully tested unless you have a development build of the iOS app. I may be able to put together a special alpha build if you really want to test this, but I think it's sufficient to verify that the URLs we're constructing are correct (I've already tested the launching of the app myself with a development build).

* If you don't have the WordPress app for iOS installed, or you don't have a development version, tapping the **Open in App** button on each of the 4 app banners should launch the App Store (via apps.wordpress.com). The App Store should show the WordPress app listing.
* Please verify that the URLs for each of the **Open in App** buttons match the schemas described above.