### PR TITLE
Show a banner on the plans page when free-to-paid-sidebar nudge is clicked

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -5,7 +5,8 @@ export default {
 		variations: {
 			sidebarUpsells: 20,
 			themesUpsells: 20,
-			control: 60,
+			plansBannerUpsells: 20,
+			control: 40,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
@@ -119,14 +120,5 @@ export default {
 			enhancedSort: 50,
 		},
 		defaultVariation: 'control',
-	},
-	plansBannerFromDomainNudge: {
-		datestamp: '20180712',
-		variations: {
-			noShow: 50,
-			show: 50,
-		},
-		defaultVariation: 'noShow',
-		allowExistingUsers: true,
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -120,4 +120,13 @@ export default {
 		},
 		defaultVariation: 'control',
 	},
+	plansBannerFromDomainNudge: {
+		datestamp: '20180712',
+		variations: {
+			noShow: 50,
+			show: 50,
+		},
+		defaultVariation: 'noShow',
+		allowExistingUsers: true,
+	},
 };

--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -48,4 +48,10 @@ export default [
 			{ type: TYPE_PREMIUM, group: GROUP_WPCOM },
 		],
 	},
+	{
+		name: 'free_domain',
+		plansPageNoticeTextTitle: 'Get a free domain name by upgrading to any plan listed below!',
+		plansPageNoticeText:
+			'Improve your SEO, branding, credibility, and even word-of-mouth marketing with a custom domain. All plan upgrades include a free domain name of your choice.',
+	},
 ];

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -100,7 +100,7 @@ class SiteNotice extends React.Component {
 
 		const { site, translate } = this.props;
 		let href = '/plans/' + site.slug;
-		if ( abtest( 'plansBannerFromDomainNudge' ) === 'show' ) {
+		if ( abtest( 'nudgeAPalooza' ) === 'plansBannerUpsells' ) {
 			href = href + '/?discount=free_domain';
 		}
 

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -30,6 +30,7 @@ import {
 } from 'state/plugins/premium/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import DomainToPaidPlanNotice from './domain-to-paid-plan-notice';
+import { abtest } from 'lib/abtest';
 
 class SiteNotice extends React.Component {
 	static propTypes = {
@@ -98,12 +99,16 @@ class SiteNotice extends React.Component {
 		}
 
 		const { site, translate } = this.props;
+		let href = '/plans/' + site.slug;
+		if ( abtest( 'plansBannerFromDomainNudge' ) === 'show' ) {
+			href = href + '/?discount=free_domain';
+		}
 
 		return (
 			<SidebarBanner
 				ctaName="free-to-paid-sidebar"
 				ctaText={ translate( 'Upgrade' ) }
-				href={ `/plans/${ site.slug }` }
+				href={ href }
 				icon="info-outline"
 				text={ translate( 'Free domain with a plan' ) }
 			/>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -127,6 +127,12 @@ class PlanFeatures extends Component {
 				icon="info-outline"
 				status="is-success"
 			>
+				{ activeDiscount.plansPageNoticeTextTitle && (
+					<strong>
+						{ activeDiscount.plansPageNoticeTextTitle }
+						{ <br /> }
+					</strong>
+				) }
 				{ activeDiscount.plansPageNoticeText }
 			</Notice>,
 			bannerContainer


### PR DESCRIPTION
A test to show a banner on the plans page when the free-to-paid-sidebar nudge is clicked

------------

**Test Plan**

* Visit http://calypso.localhost:3000/stats/day and choose one of your **free** sites.

* In the side bar you should see the "_Free domain with plan_" nudge.
<img width="277" alt="screen shot 2018-07-13 at 9 58 15 am" src="https://user-images.githubusercontent.com/690843/42704054-507097cc-8683-11e8-8f01-952fbe4e3018.png">

* Click the nudge.

* When you're taken to the plans page you should either see a banner or not, depending on your ab test assignment.

<img width="1098" alt="screen shot 2018-07-13 at 9 53 31 am" src="https://user-images.githubusercontent.com/690843/42703980-0a0b20ae-8683-11e8-9bde-c366ca95695d.png">

Change your assignment, refresh, and try again to make sure both variations work.

<img width="667" alt="screen shot 2018-07-13 at 9 53 15 am" src="https://user-images.githubusercontent.com/690843/42703989-160ed6ca-8683-11e8-879a-7162b5d2cf61.png">
