### PR TITLE
Checkout: Remove unnecessary period in Domain Search and Transfer

### DIFF
--- a/client/components/domains/domain-registration-suggestion/utility.js
+++ b/client/components/domains/domain-registration-suggestion/utility.js
@@ -37,8 +37,8 @@ function getMatchReasonPhrasesMap( tld ) {
 		[
 			'tld-common',
 			tld === 'com'
-				? translate( 'Most common extension: ".com"' )
-				: translate( 'Common extension: ".%(tld)s"', { args: { tld } } ),
+				? translate( '".com" is the most common extension' )
+				: translate( '".%(tld)s" is a common extension', { args: { tld } } ),
 		],
 	] );
 }

--- a/client/components/domains/domain-registration-suggestion/utility.js
+++ b/client/components/domains/domain-registration-suggestion/utility.js
@@ -37,8 +37,8 @@ function getMatchReasonPhrasesMap( tld ) {
 		[
 			'tld-common',
 			tld === 'com'
-				? translate( 'Most common extension, ".com"' )
-				: translate( 'Common extension, ".%(tld)s"', { args: { tld } } ),
+				? translate( 'Most common extension: ".com"' )
+				: translate( 'Common extension: ".%(tld)s"', { args: { tld } } ),
 		],
 	] );
 }

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -183,7 +183,7 @@ class TransferDomainStep extends React.Component {
 							{ translate(
 								'Transfer your domain away from your current provider to WordPress.com so you can update settings, ' +
 									"renew your domain, and more \u2013 right in your dashboard. We'll renew it for another year " +
-									'when the transfer is successful. {{a}}Learn more{{/a}}.',
+									'when the transfer is successful. {{a}}Learn more{{/a}}',
 								{
 									components: {
 										a: (


### PR DESCRIPTION
### Domain Search:
Change comma to a colon:

**Before:**
![screenshot 2018-07-17 12 42 31](https://user-images.githubusercontent.com/4924246/42841460-fb56c9ac-89be-11e8-9cdb-744da462246a.png)

**After:**
![screenshot 2018-07-17 12 42 46](https://user-images.githubusercontent.com/4924246/42841464-fedfcad8-89be-11e8-8111-2fc4853998f3.png)

Another option is to just remove the colon: cc @danhauk 
![screenshot 2018-07-17 12 44 35](https://user-images.githubusercontent.com/4924246/42841516-2ebbbea6-89bf-11e8-9764-dac68198cc16.png)

### Domain Transfer
Remove unnecessary period after "Learn more":

**Before:**
![screenshot 2018-07-17 12 34 12](https://user-images.githubusercontent.com/4924246/42841388-bc497cf0-89be-11e8-8818-2f01efb3f3a2.png)

**After:**
![screenshot 2018-07-17 12 34 16](https://user-images.githubusercontent.com/4924246/42841384-b7f85554-89be-11e8-9525-0d5a6a06adb3.png)

cc @lucasartoni 