### PR TITLE
Settings: Bump Jetpack connection transfer minimum version

### DIFF
--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -283,7 +283,7 @@ export default connect(
 		return {
 			canManageOptions: canCurrentUser( state, siteId, 'manage_options' ),
 			currentUser: getCurrentUser( state ),
-			isConnectionTransferSupported: isJetpackMinimumVersion( state, siteId, '6.2' ),
+			isConnectionTransferSupported: isJetpackMinimumVersion( state, siteId, '6.3.3' ),
 			isCurrentPlanOwner,
 			isPaidPlan,
 			siteId,


### PR DESCRIPTION
This PR updates the minimum required version for being able to transfer Jetpack connection ownership to another user. This is necessary so we can support transferring site ownership as well, see https://github.com/Automattic/jetpack/pull/9925