### PR TITLE
Send to plugins upsell page from plugins page banner for nudge upsell a/b test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -5,6 +5,7 @@ export default {
 		variations: {
 			sidebarUpsells: 20,
 			themesUpsells: 20,
+			pluginUpsells: 20,
 			plansBannerUpsells: 20,
 			control: 40,
 		},

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -500,7 +500,7 @@ export class PluginsBrowser extends Component {
 		}
 
 		const { siteSlug, translate } = this.props;
-		const plan = findFirstSimilarPlanKey( this.props.selectedSite.plan.product_slug, {
+		const plan = findFirstSimilarPlanKey( this.props.sitePlan.product_slug, {
 			type: TYPE_BUSINESS,
 		} );
 		const title = translate( 'Upgrade to the Business plan to install plugins.' );

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import DocumentHead from 'components/data/document-head';
 import Search from 'components/search';
@@ -46,6 +47,7 @@ import { findFirstSimilarPlanKey } from 'lib/plans';
 import Banner from 'components/banner';
 import { isEnabled } from 'config';
 import wpcomFeaturesAsPlugins from './wpcom-features-as-plugins';
+import { abtest } from 'lib/abtest';
 
 /**
  * Module variables
@@ -497,14 +499,33 @@ export class PluginsBrowser extends Component {
 			return null;
 		}
 
+		const { siteSlug, translate } = this.props;
+		const plan = findFirstSimilarPlanKey( this.props.selectedSite.plan.product_slug, {
+			type: TYPE_BUSINESS,
+		} );
+		const title = translate( 'Upgrade to the Business plan to install plugins.' );
+
+		if (
+			config.isEnabled( 'upsell/nudge-a-palooza' ) &&
+			abtest( 'nudgeAPalooza' ) === 'pluginUpsells'
+		) {
+			const href = '/feature/plugins/' + siteSlug;
+			return (
+				<Banner
+					event="calypso_plugins_browser_upgrade_nudge_upsell"
+					href={ href }
+					plan={ plan }
+					title={ title }
+				/>
+			);
+		}
+
 		return (
 			<Banner
 				feature={ FEATURE_UPLOAD_PLUGINS }
-				event={ 'calypso_plugins_browser_upgrade_nudge' }
-				plan={ findFirstSimilarPlanKey( this.props.sitePlan.product_slug, {
-					type: TYPE_BUSINESS,
-				} ) }
-				title={ this.props.translate( 'Upgrade to the Business plan to install plugins.' ) }
+				event="calypso_plugins_browser_upgrade_nudge"
+				plan={ plan }
+				title={ title }
 			/>
 		);
 	}


### PR DESCRIPTION
This is a test to send a proportion of users to the plugins feature upsell page instead of the plans page from the banners on the plugin gallery and individual plugin pages (for wpcom sites that are not on a business plan)

# Testing instructions

Choose a site that is not on a business plan

* choose the 'control' variant for the nudgeAPalooza a/b test
* browse to the `/plugins/<site>` page
* verify that the banner link takes you to `/plans/<site>?feature=upload-plugins&plan=business-bundle`
* browse to `/plugins/woocommerce/<site>` 
* verify that the banner link takes you to `/plans/<site>?feature=upload-plugins&plan=business-bundle`

* choose the 'pluginsUpsells' variant for the nudgeAPalooza a/b test
* browse to the `/plugins/<site>` page
* verify that the banner link takes you to `/feature/plugins/<site>`
* browse to `/plugins/woocommerce/<site>` 
* verify that the banner link takes you to `/feature/plugins/<site>`