### PR TITLE
Framework: Remove flags/images/*.svg during cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "clean": "npm run -s clean:build && npm run -s clean:devdocs && npm run -s clean:public",
     "clean:build": "npm run -s rm -- build && npm run -s rm -- server/bundler .json && npm run -s rm -- .babel-cache",
     "clean:devdocs": "npm run -s rm -- server/devdocs/search-index.js && npm run -s rm -- server/devdocs/proptypes-index.json && npm run -s rm -- server/devdocs/components-usage-stats.json",
-    "clean:public": "npm run -s rm -- public .css .css.map .js .js.map && npm run -s rm -- public/sections .css .css.map && npm run -s rm -- public/sections-rtl .css .css.map",
+    "clean:public": "npm run -s rm -- public .css .css.map .js .js.map && npm run -s rm -- public/images/flags .svg && npm run -s rm -- public/sections .css .css.map && npm run -s rm -- public/sections-rtl .css .css.map",
     "distclean": "npm run -s clean && npm run -s rm -- node_modules",
     "docker": "docker run -it --name wp-calypso --rm -p 80:3000 wp-calypso",
     "eslint-branch": "node bin/eslint-branch.js",


### PR DESCRIPTION
These are [copied](https://github.com/Automattic/wp-calypso/blob/df921833f057e827a6a741aa2aa96141c39d6e43/webpack.config.js#L208-L210) from some node module to our assets dir during build, but never removed during cleanup.

(In the long run, we might want to come up with a better solution wrt flags (see https://github.com/Automattic/wp-calypso/pull/26048#issuecomment-405869404)). Webpack loader maybe? Will inflate our bundle size tho, won't it :slightly_frowning_face: 

Testing Instructions:

* On `master`, run Calypso (`npm start`).
* Cancel it.
* Run `npm clean`.
* Verify that there are a lot of SVGs in `public/images/flags`.
* Switch to this branch.
* `npm clean`.
* Flags are gone.
* `npm start` to verify Calypso still runs (and copies flags to `public/images/flags`.

