### PR TITLE
Update the tooltip to support pro-rated discounts

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -103,7 +103,7 @@ export class PlanFeaturesHeader extends Component {
 		const price = formatCurrency( rawPrice, currencyCode );
 
 		return translate(
-			"We'll deduct the cost of your current plan from the full price (%(price)s) for the next 12 months.",
+			"You'll receive a discount from the full price of %(price)s because you already have a plan.",
 			{ args: { price } }
 		);
 	}

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -91,7 +91,7 @@ describe( 'PlanFeaturesHeader.getDiscountTooltipMessage()', () => {
 		test( `Should render different message for paid plans (${ productSlug })`, () => {
 			const comp = new PlanFeaturesHeader( { ...props, currentSitePlan: { productSlug } } );
 			expect( comp.getDiscountTooltipMessage() ).toBe(
-				"We'll deduct the cost of your current plan from the full price (%(price)s) for the next 12 months."
+				"You'll receive a discount from the full price of %(price)s because you already have a plan."
 			);
 		} );
 	} );


### PR DESCRIPTION
We are going to test pro-rated discounts for plan upgrades. D15952-code got thumbs but it needs this tooltip to be slightly less specific.

To test:
1. Get a Personal plan
2. Go to plans page after getting the plan
3. Check the tooltip

<img width="325" alt="screen shot 2018-07-18 at 12 29 09" src="https://user-images.githubusercontent.com/82778/42875040-4d3d5430-8a8b-11e8-8a30-e4b8eaaa3229.png">

It needs to show the new text