### PR TITLE
[nudge-a-palooza] Simplify routes definition

### DIFF
--- a/client/my-sites/feature-upsell/index.js
+++ b/client/my-sites/feature-upsell/index.js
@@ -36,18 +36,6 @@ export default function() {
 			clientRender
 		);
 
-		page( '/feature/:feature/*', ( { path, params } ) => {
-			const siteFragment = getSiteFragment( path );
-
-			if ( siteFragment ) {
-				return page.redirect( `/feature/${ params.feature }/${ siteFragment }` );
-			}
-
-			return page.redirect( `/feature/${ params.feature }` );
-		} );
-
-		page( '/feature/plugins', siteSelection, sites, makeLayout, clientRender );
-
 		page(
 			'/feature/plugins/:domain',
 			siteSelection,
@@ -56,18 +44,6 @@ export default function() {
 			makeLayout,
 			clientRender
 		);
-
-		page( '/feature/plugins/*', ( { path } ) => {
-			const siteFragment = getSiteFragment( path );
-
-			if ( siteFragment ) {
-				return page.redirect( `/feature/plugins/${ siteFragment }` );
-			}
-
-			return page.redirect( '/feature/plugins' );
-		} );
-
-		page( '/feature/themes', siteSelection, sites, makeLayout, clientRender );
 
 		page(
 			'/feature/themes/:domain',
@@ -78,14 +54,14 @@ export default function() {
 			clientRender
 		);
 
-		page( '/feature/themes/*', ( { path } ) => {
+		page( '/feature/:feature/*', ( { path, params } ) => {
 			const siteFragment = getSiteFragment( path );
 
 			if ( siteFragment ) {
-				return page.redirect( `/feature/themes/${ siteFragment }` );
+				return page.redirect( `/feature/${ params.feature }/${ siteFragment }` );
 			}
 
-			return page.redirect( '/feature/themes' );
+			return page.redirect( `/feature/${ params.feature }` );
 		} );
 	}
 }


### PR DESCRIPTION
This PR simplifies routes definition in `feature-upsell/index.js`. Specifically it replaces explicit routes like `/feature/plugins` with a catch-all `/feature/:feature`

Test plan:
* Confirm you can visit each of these URLs (on a free site):
- /feature/plugins
- /feature/themes
- /feature/ads
- /feature/store
* Confirm that visiting /feature/themes brings up a site picker
* Confirm that visiting /feature/themes/<SITE ADDRESS>/something redirects to /feature/themes/<SITE ADDRESS>