### PR TITLE
[nudge-a-palooza] Restrict access to all upsell pages only to users who can upgrade currentSite

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -183,7 +183,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	ads() {
-		const { path, canUserManageOptions, canUserUpgradeSite, canUserUseAds } = this.props;
+		const { path, canUserUpgradeSite, canUserUseAds } = this.props;
 
 		if ( canUserUseAds ) {
 			return (
@@ -201,7 +201,6 @@ export class MySitesSidebar extends Component {
 		if (
 			! this.props.isJetpack &&
 			config.isEnabled( 'upsell/nudge-a-palooza' ) &&
-			canUserManageOptions &&
 			canUserUpgradeSite &&
 			abtest( 'nudgeAPalooza' ) === 'sidebarUpsells'
 		) {
@@ -421,7 +420,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	store() {
-		const { canUserManageOptions, site, canUserUseStore } = this.props;
+		const { canUserUpgradeSite, site, canUserUseStore } = this.props;
 
 		if ( ! config.isEnabled( 'woocommerce/extension-dashboard' ) || ! site ) {
 			return null;
@@ -430,7 +429,7 @@ export class MySitesSidebar extends Component {
 		if ( ! canUserUseStore ) {
 			if (
 				config.isEnabled( 'upsell/nudge-a-palooza' ) &&
-				canUserManageOptions &&
+				canUserUpgradeSite &&
 				abtest( 'nudgeAPalooza' ) === 'sidebarUpsells'
 			) {
 				return this.storeUpsellSidebarItem();

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -53,7 +53,7 @@ describe( 'MySitesSidebar', () => {
 			);
 			const Sidebar = new MySitesSidebar( {
 				isSiteAutomatedTransfer: false,
-				canUserManageOptions: true,
+				canUserUpgradeSite: true,
 				...defaultProps,
 			} );
 			const Store = () => Sidebar.store();
@@ -85,11 +85,11 @@ describe( 'MySitesSidebar', () => {
 			expect( wrapper.html() ).toEqual( null );
 		} );
 
-		test( 'Should return null item if managing user can not use store on this site (control a/b group)', () => {
+		test( 'Should return null item if user who can upgrade can not use store on this site (control a/b group)', () => {
 			abtest.mockImplementation( () => 'control' );
 			const Sidebar = new MySitesSidebar( {
 				canUserUseStore: false,
-				canUserManageOptions: true,
+				canUserUpgradeSite: true,
 				...defaultProps,
 			} );
 			const Store = () => Sidebar.store();
@@ -98,11 +98,11 @@ describe( 'MySitesSidebar', () => {
 			expect( wrapper.html() ).toEqual( null );
 		} );
 
-		test( 'Should return null if non-managing user can not use store on this site (control a/b group)', () => {
+		test( "Should return null if user who can't upgrade  user can not use store on this site (control a/b group)", () => {
 			abtest.mockImplementation( () => 'control' );
 			const Sidebar = new MySitesSidebar( {
 				canUserUseStore: false,
-				canUserManageOptions: true,
+				canUserUpgradeSite: true,
 				...defaultProps,
 			} );
 			const Store = () => Sidebar.store();
@@ -111,10 +111,10 @@ describe( 'MySitesSidebar', () => {
 			expect( wrapper.html() ).toEqual( null );
 		} );
 
-		test( 'Should return upsell item if managing user can not use store on this site (nudge-a-palooza enabled)', () => {
+		test( 'Should return upsell item if user who can upgrade can not use store on this site (nudge-a-palooza enabled)', () => {
 			const Sidebar = new MySitesSidebar( {
 				canUserUseStore: false,
-				canUserManageOptions: true,
+				canUserUpgradeSite: true,
 				...defaultProps,
 			} );
 			const Store = () => Sidebar.store();
@@ -126,7 +126,7 @@ describe( 'MySitesSidebar', () => {
 		test( 'Should return upsell if non-managing user can not use store on this site (nudge-a-palooza enabled)', () => {
 			const Sidebar = new MySitesSidebar( {
 				canUserUseStore: false,
-				canUserManageOptions: true,
+				canUserUpgradeSite: true,
 				...defaultProps,
 			} );
 			const Store = () => Sidebar.store();
@@ -183,10 +183,9 @@ describe( 'MySitesSidebar', () => {
 			expect( wrapper.html() ).toEqual( null );
 		} );
 
-		test( "Should return upsell menu item if user can't use ads on this site but can manage options and upgrade site", () => {
+		test( "Should return upsell menu item if user can't use ads on this site but can upgrade site", () => {
 			const Sidebar = new MySitesSidebar( {
 				canUserUseAds: false,
-				canUserManageOptions: true,
 				canUserUpgradeSite: true,
 				...defaultProps,
 			} );
@@ -196,37 +195,10 @@ describe( 'MySitesSidebar', () => {
 			expect( wrapper.props().link ).toEqual( '/feature/ads/mysite.com' );
 		} );
 
-		test( "Should return null if user can't use ads on this site and can't manage options or upgrade site", () => {
+		test( "Should return null if user can't use ads on this site upgrade site", () => {
 			const Sidebar = new MySitesSidebar( {
 				canUserUseAds: false,
-				canUserManageOptions: false,
 				canUserUpgradeSite: false,
-				...defaultProps,
-			} );
-			const Ads = () => Sidebar.ads();
-
-			const wrapper = shallow( <Ads /> );
-			expect( wrapper.html() ).toEqual( null );
-		} );
-
-		test( "Should return null if user can't use ads on this site and can manage options but can't upgrade site", () => {
-			const Sidebar = new MySitesSidebar( {
-				canUserUseAds: false,
-				canUserManageOptions: true,
-				canUserUpgradeSite: false,
-				...defaultProps,
-			} );
-			const Ads = () => Sidebar.ads();
-
-			const wrapper = shallow( <Ads /> );
-			expect( wrapper.html() ).toEqual( null );
-		} );
-
-		test( "Should return null if user can't use ads on this site and can't manage options but can upgrade site", () => {
-			const Sidebar = new MySitesSidebar( {
-				canUserUseAds: false,
-				canUserManageOptions: false,
-				canUserUpgradeSite: true,
 				...defaultProps,
 			} );
 			const Ads = () => Sidebar.ads();


### PR DESCRIPTION
This PR makes sure only correct users with the ability to actually upgrade the site will be able to access new upsell pages.

Test plan:
* Create a non-superadmin user and invite it as an editor to a free site, then open that free site as this non-superadmin user
* Confirm you each of these URLs redirects to /stats
* - /feature/plugins/<site address>
* - /feature/themes/<site address>
* - /feature/ads/<site address>
* - /feature/store/<site address>
* Confirm that you cannot see Store sidebar item while you are in `sidebarUpsells` group of `nudgeAPalooza` A/B 
* Switch to a free site that you own
* Confirm that you can see a Store sidebar item and visit each of the URLs listed above - they should display landing pages and there should be no redirection