### PR TITLE
Checkout: Add back crossed out prices

### DIFF
--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -121,11 +121,9 @@ export class CartItem extends React.Component {
 		if ( cartItem && cartItem.product_cost ) {
 			return (
 				<span>
-					{ ! this.isDomainProductDiscountedTo0() ? (
-						<span className="cart__free-with-plan">
-							{ cartItem.product_cost } { cartItem.currency }
-						</span>
-					) : null }
+					<span className="cart__free-with-plan">
+						{ cartItem.product_cost } { cartItem.currency }
+					</span>
 					<span className="cart__free-text">{ translate( 'Free with your plan' ) }</span>
 				</span>
 			);


### PR DESCRIPTION
This resolves #26119 

# How to test

1. Try to add a custom domain to your free site via My Sites > Domains > Add Domain
2. In the order summary, the cart items of domain and plan should include crossed out prices as belows:
<img src="https://user-images.githubusercontent.com/4924246/42833908-59cbf88c-89aa-11e8-9246-291de233e275.png">

cc @jancavan 