### PR TITLE
[nudge-a-palooza] Adjust placeholder CSS class name to a new name convention introduced by a recent PR

### DIFF
--- a/client/my-sites/feature-upsell/store-upsell.jsx
+++ b/client/my-sites/feature-upsell/store-upsell.jsx
@@ -75,7 +75,7 @@ class StoreUpsellComponent extends Component {
 
 				<div className="feature-upsell__cta">
 					{ loadingPrice ? (
-						<div className="feature-upsell__placeholder-cta" />
+						<div className="feature-upsell__placeholder feature-upsell__placeholder--cta" />
 					) : (
 						<React.Fragment>
 							<button


### PR DESCRIPTION
A CSS class name for a CTA loading placeholder was updated recently but didn't make it to this file, this PR fixes that.

Test plan:
1. Go to /feature/store 
1. Confirm that before CTA button "Upgrade now" loads, there isn't a just blank space there but a blinking placeholder is visible first, just like on the screencast here:

![screen capture on 2018-07-18 at 13-52-14](https://user-images.githubusercontent.com/205419/42879716-e1bcf68c-8a91-11e8-8b98-e3c7f2854096.gif)
