### PR TITLE
Fix redirect to `login_url` in desktop-development env

### DIFF
--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -48,7 +48,7 @@ export default {
 
 		// Check we have an OAuth token, otherwise redirect to auth/login page
 		if ( OAuthToken.getToken() === false && ! isValidSection ) {
-			if ( config( 'env_id' ) === 'desktop' ) {
+			if ( config( 'env_id' ) === 'desktop' || config( 'env_id' ) === 'desktop-development' ) {
 				return page( config( 'login_url' ) );
 			}
 


### PR DESCRIPTION
When launching the desktop app in dev mode in a vanilla state (no `settings.json` in `~/Library/Application Support/Wordpress.com`) Calypso redirects to `/authorize` instead of `login_url` config from the desktop-development env. 

Going to `/authorize` however displays 

> You need to set 'oauth_client_id' in your config file.

as the desktop app is using `desktop_oauth_client_id` instead of `oauth_client_id` as a key.

### How to test
- Get the latest commit of wp-desktop
- Delete `~/Library/Application Support/Wordpress.com/settings.json`
- Start the dev server with `make dev-server`
- Start the app  with`make dev`
- You should see the oauth login screen

### Context
https://github.com/Automattic/wp-desktop/pull/447#issuecomment-404605975
