### PR TITLE
Alias debug to one version

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -191,7 +191,7 @@ const webpackConfig = {
 				'gridicons/example': 'gridicons/dist/example',
 				'react-virtualized': 'react-virtualized/dist/commonjs',
 				'social-logos/example': 'social-logos/build/example',
-				debug: 'debug',
+				debug: path.resolve( __dirname, 'node_modules/debug' ),
 			},
 			getAliasesForExtensions()
 		),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -191,6 +191,7 @@ const webpackConfig = {
 				'gridicons/example': 'gridicons/dist/example',
 				'react-virtualized': 'react-virtualized/dist/commonjs',
 				'social-logos/example': 'social-logos/build/example',
+				debug: 'debug',
 			},
 			getAliasesForExtensions()
 		),


### PR DESCRIPTION
We currently have a few different versions of debug in our transitive dependencies across two major versions. Happily, 2 and 3 are compatible, so we should be able to force everyone onto 3.

I expect this drop a few bytes off of the build and/or vendor chunk.