### PR TITLE
NUX: Add helper text to give context for the questions in step 1

### DIFF
--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -541,7 +541,7 @@ class AboutStep extends Component {
 							<FormFieldset>
 								<FormLabel htmlFor="siteTitle">
 									{ translate( 'What would you like to name your site?' ) }
-									<InfoPopover className="about__info-popover" position="right">
+									<InfoPopover className="about__info-popover" position="top">
 										{ translate(
 											"We'll use this as your site title. " +
 												"Don't worry, you can change this later."
@@ -560,7 +560,7 @@ class AboutStep extends Component {
 							<FormFieldset>
 								<FormLabel htmlFor="siteTopic">
 									{ translate( 'What will your site be about?' ) }
-									<InfoPopover className="about__info-popover" position="right">
+									<InfoPopover className="about__info-popover" position="top">
 										{ translate( "We'll use this to personalize your site and experience." ) }
 									</InfoPopover>
 								</FormLabel>

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -35,7 +35,7 @@ import { isUserLoggedIn } from 'state/current-user/selectors';
 import Card from 'components/card';
 import Button from 'components/button';
 import FormTextInput from 'components/forms/form-text-input';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import InfoPopover from 'components/info-popover';
 import FormLabel from 'components/forms/form-label';
 import FormLegend from 'components/forms/form-legend';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -541,6 +541,12 @@ class AboutStep extends Component {
 							<FormFieldset>
 								<FormLabel htmlFor="siteTitle">
 									{ translate( 'What would you like to name your site?' ) }
+									<InfoPopover className="about__info-popover" position="right">
+										{ translate(
+											"We'll use this as your site title. " +
+												"Don't worry, you can change this later."
+										) }
+									</InfoPopover>
 								</FormLabel>
 								<FormTextInput
 									id="siteTitle"
@@ -549,14 +555,14 @@ class AboutStep extends Component {
 									defaultValue={ siteTitle }
 									onChange={ this.handleChangeEvent }
 								/>
-								<FormSettingExplanation>
-									{ translate( "Don't worry, you can change this anytime." ) }
-								</FormSettingExplanation>
 							</FormFieldset>
 
 							<FormFieldset>
 								<FormLabel htmlFor="siteTopic">
 									{ translate( 'What will your site be about?' ) }
+									<InfoPopover className="about__info-popover" position="right">
+										{ translate( "We'll use this to personalize your site and experience." ) }
+									</InfoPopover>
 								</FormLabel>
 								<FormTextInput
 									id="siteTopic"
@@ -574,9 +580,6 @@ class AboutStep extends Component {
 									suggestions={ this.getSuggestions() }
 									suggest={ this.handleSuggestionMouseDown }
 								/>
-								<FormSettingExplanation>
-									{ translate( "We'll start you off with a theme designed for you." ) }
-								</FormSettingExplanation>
 							</FormFieldset>
 
 							<FormFieldset>

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -35,6 +35,7 @@ import { isUserLoggedIn } from 'state/current-user/selectors';
 import Card from 'components/card';
 import Button from 'components/button';
 import FormTextInput from 'components/forms/form-text-input';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormLabel from 'components/forms/form-label';
 import FormLegend from 'components/forms/form-legend';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -548,6 +549,9 @@ class AboutStep extends Component {
 									defaultValue={ siteTitle }
 									onChange={ this.handleChangeEvent }
 								/>
+								<FormSettingExplanation>
+									{ translate( "Don't worry, you can change this anytime." ) }
+								</FormSettingExplanation>
 							</FormFieldset>
 
 							<FormFieldset>
@@ -570,6 +574,9 @@ class AboutStep extends Component {
 									suggestions={ this.getSuggestions() }
 									suggest={ this.handleSuggestionMouseDown }
 								/>
+								<FormSettingExplanation>
+									{ translate( "We'll start you off with a theme designed for you." ) }
+								</FormSettingExplanation>
 							</FormFieldset>
 
 							<FormFieldset>

--- a/client/signup/steps/about/style.scss
+++ b/client/signup/steps/about/style.scss
@@ -27,10 +27,10 @@
 
 .info-popover.about__info-popover {
 	margin-left: 5px;
-	margin-bottom: -2px;
 
 	.gridicon {
 		color: $gray;
+		margin-bottom: -3px;
 	}
 }
 

--- a/client/signup/steps/about/style.scss
+++ b/client/signup/steps/about/style.scss
@@ -25,7 +25,7 @@
 	opacity: 0;
 }
 
-.about__info-popover {
+.info-popover.about__info-popover {
 	margin-left: 5px;
 	margin-bottom: -2px;
 

--- a/client/signup/steps/about/style.scss
+++ b/client/signup/steps/about/style.scss
@@ -25,6 +25,15 @@
 	opacity: 0;
 }
 
+.about__info-popover {
+	margin-left: 5px;
+	margin-bottom: -2px;
+
+	.gridicon {
+		color: $gray;
+	}
+}
+
 .about__checkboxes {
 	border: 1px solid $gray-lighten-20;
 	border-radius: 3px;


### PR DESCRIPTION
User testing revealed some questions around why we're asking the questions we ask on the first step of signup. This PR adds some context to them, and also makes it clear the site title can be changed later.

Before | After
------------ | -------------
<img width="518" alt="image" src="https://user-images.githubusercontent.com/448298/42888953-50bf4d7a-8a77-11e8-9d40-6506d1e2b200.png"> | <img width="524" alt="screen shot 2018-07-17 at 16 42 48" src="https://user-images.githubusercontent.com/448298/42888932-460e987c-8a77-11e8-9e8c-e869cc5a3bf7.png">

#### Testing

* Checkout this branch or open the calypso.live branch
* Go to `/start` to start the new site flow
* Confirm the helper text appears as in the screenshot above

cc @ranh for a copy review