### PR TITLE
Checklist: Navigate via show to maintain back functionality

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/setup/tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup/tasks.js
@@ -157,7 +157,7 @@ class SetupTasks extends Component {
 			this.props.setTriedCustomizerDuringInitialSetup( this.props.site.ID, true );
 			window.open( task.url );
 		} else {
-			page.redirect( task.url );
+			page.show( task.url );
 		}
 	};
 


### PR DESCRIPTION
Replace `page.redirect` with `page.show`. This acts like a navigation event –maintaining browser back/forward button functionality– rather than a redirection which "looses" where the user is coming from.

![checklist](https://user-images.githubusercontent.com/841763/42895691-eb11ae16-8aba-11e8-83e5-e346638fa5c3.png)


Spotted while working on #26030 

## Testing
1. Start up a new site with a Store
1. Visit the store dashboard [(`/store/SITE_SLUG`)]()
1. Verify the checklist navigation works by clicking on the different actions.
1. Verify the browser back button works after starting a checklist action.
1. In current production, the back button would not return to the dashboard but to the location _before_ that.