### PR TITLE
SDK: Add "editor notes" block

### DIFF
--- a/client/gutenberg/extensions/editor-notes/index.js
+++ b/client/gutenberg/extensions/editor-notes/index.js
@@ -1,0 +1,50 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import wp from 'wp';
+const { RichText } = wp.editor;
+
+const attributes = {
+	notes: {
+		type: 'array',
+	},
+};
+
+const edit = ( { attributes: { notes }, className, isSelected, setAttributes } ) => (
+	<div
+		style={ {
+			border: '2px solid gray',
+			position: 'relative',
+			padding: '6px',
+			paddingTop: isSelected ? '6px' : '32px',
+			backgroundColor: '#c0e7ff',
+		} }
+	>
+		{ ! isSelected && (
+			<span style={ { position: 'absolute', top: 0, left: '8px', fontStyle: 'italic' } }>
+				<span role="img" aria-label="notebook">
+					📔
+				</span>
+				Editor's Notes: hidden from rendered page
+			</span>
+		) }
+		<RichText
+			tagName="p"
+			className={ className }
+			value={ notes }
+			onChange={ newNotes => setAttributes( { notes: newNotes } ) }
+		/>
+	</div>
+);
+
+const save = () => null;
+
+wp.blocks.registerBlockType( 'a8c/editor-notes', {
+	title: 'Editor Notes',
+	icon: 'welcome-write-blog',
+	category: 'common',
+	attributes,
+	edit,
+	save,
+} );

--- a/client/gutenberg/extensions/editor-notes/index.js
+++ b/client/gutenberg/extensions/editor-notes/index.js
@@ -41,7 +41,7 @@ const edit = ( { attributes: { notes }, className, isSelected, setAttributes } )
 const save = () => null;
 
 wp.blocks.registerBlockType( 'a8c/editor-notes', {
-	title: 'Editor Notes',
+	title: "Editor's Notes",
 	icon: 'welcome-write-blog',
 	category: 'common',
 	attributes,


### PR DESCRIPTION
This patch adds a new Gutenberg block whose purpose is to provide
an area to write notes about a post while writing it while making
sure that those notes are never published in the open.

The motivation for adding a block here is to test building a block
from Calypso and then including it in another project. That is,
the output will be used in an external PHP plugin for WordPress
which loads the block itself.

![editor-notes mov](https://user-images.githubusercontent.com/5431237/42900567-81ee6d84-8ac9-11e8-8e11-7324820f010b.gif)

Once built with…

```bash
node bin/create-scripts/block.js client/gutenberg/extensions/editor-notes/index.js
```

…then copy the bundle into a place with a WordPress plugin that loads it.

```php
add_action( 'enqueue_block_editor_assets', function() {
	wp_enqueue_script(
		'editor-notes',
		plugins_url( '/built-blocks/blocks-editor-notes.js', __FILE__ ),
		array()
	);
} );
```