### PR TITLE
Checkout: simplify pricing format

### DIFF
--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -31,7 +31,7 @@ export default class PlanPrice extends Component {
 				<span className={ classes }>
 					{ price.symbol }
 					{ price.integer }
-					{ rawPrice > 0 && price.fraction }
+					{ rawPrice - price.integer > 0 && price.fraction }
 				</span>
 			);
 		}
@@ -40,7 +40,9 @@ export default class PlanPrice extends Component {
 			<h4 className={ classes }>
 				<sup className="plan-price__currency-symbol">{ price.symbol }</sup>
 				<span className="plan-price__integer">{ price.integer }</span>
-				<sup className="plan-price__fraction">{ rawPrice > 0 && price.fraction }</sup>
+				<sup className="plan-price__fraction">
+					{ rawPrice - price.integer > 0 && price.fraction }
+				</sup>
 			</h4>
 		);
 	}


### PR DESCRIPTION
This resolves #26134 

# How to test

1. Get to the plans page in the signup flow.
2. The plan price should not display a zero fraction value as below.
<img width="1084" alt="create_a_site_ _wordpress_com" src="https://user-images.githubusercontent.com/212034/42925518-718f1330-8b69-11e8-9c17-b793e4601307.png">

cc @jancavan 