### PR TITLE
Turn titles from objects to strings

### DIFF
--- a/client/my-sites/feature-upsell/plugins-upsell.jsx
+++ b/client/my-sites/feature-upsell/plugins-upsell.jsx
@@ -133,11 +133,7 @@ class PluginsUpsellComponent extends Component {
 					<div className="product-purchase-features-list__item">
 						<PurchaseDetail
 							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-payments.svg" /> }
-							title={
-								<span>
-									Easily Accept Credit Card Payments with <i>Simple Payments</i>
-								</span>
-							}
+							title="Easily Accept Credit Card Payments with Simple Payments"
 							description={
 								<span>
 									The <i>Simple Payments</i> feature lets you accept credit card payments right on

--- a/client/my-sites/feature-upsell/themes-upsell.jsx
+++ b/client/my-sites/feature-upsell/themes-upsell.jsx
@@ -131,11 +131,7 @@ class ThemesUpsellComponent extends Component {
 					<div className="product-purchase-features-list__item">
 						<PurchaseDetail
 							icon={ <img alt="" src="/calypso/images/illustrations/jetpack-payments.svg" /> }
-							title={
-								<span>
-									Easily Accept Credit Card Payments with <i>Simple Payments</i>
-								</span>
-							}
+							title="Easily Accept Credit Card Payments with Simple Payments"
 							description={
 								<span>
 									The <i>Simple Payments</i> feature lets you accept credit card payments right on


### PR DESCRIPTION
PurchaseDetail component expects a string but it was receiving an object, this PR updates that so we pass a string there

Test plan:
1. Go to /feature/plugins and /feature/themes and confirm there is no red warning in the console and also that Simple Payments are listed as one of the features