### PR TITLE
Gutenblock Builder: Try adding external dependencies

### DIFF
--- a/bin/create-scripts/block.js
+++ b/bin/create-scripts/block.js
@@ -18,6 +18,7 @@ const config = {
 		externals: {
 			...baseConfig.externals,
 			wp: 'wp',
+			'@automattic/simple-components': 'automattic-components',
 		},
 		optimization: {
 			splitChunks: false,

--- a/client/gutenberg/extensions/hello-dolly/hello-block.js
+++ b/client/gutenberg/extensions/hello-dolly/hello-block.js
@@ -3,11 +3,17 @@
  * External dependencies
  */
 import wp from 'wp';
+import { Button } from '@automattic/simple-components';
 
 wp.blocks.registerBlockType( 'calypsoberg/hello-dolly', {
 	title: 'Hello Dolly',
 	icon: 'format-audio',
 	category: 'layout',
-	edit: ( { isSelected } ) => <p>{ isSelected ? 'Editing Hello Dolly' : 'Viewing Hello Dolly' }</p>,
+	edit: ( { isSelected } ) => (
+		<p>
+			{ isSelected ? 'Editing Hello Dolly' : 'Viewing Hello Dolly' }
+			<Button>Test</Button>
+		</p>
+	),
 	save: () => <p>Saving Hello Dolly</p>,
 } );


### PR DESCRIPTION
WIP

Build by running

```
node bin/create-scripts/block.js client/gutenberg/extensions/hello-dolly/hello-block.js
```

TODO:
* Generate PHP to `enqueue` `@automattic/simple-components` repo, expose as `automattic-components` global (maybe we don't need to alias, wasn't sure about the `@`)

/cc @dmsnell @simison 