### PR TITLE
Activity: update loading state

### DIFF
--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -116,7 +116,7 @@
 	.is-loading & {
 		width: 48px;
 		height: 48px;
-		margin-top: -12px;
+		margin-top: 0px;
 		padding: 0;
 		background-color: $gray-lighten-20;
 

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -59,6 +59,10 @@
 	@include breakpoint( '<480px' ) {
 		margin: -2px 8px 0 0px;
 	}
+
+	.is-loading & {
+		align-self: center;
+	}
 }
 
 .activity-log-item__time {
@@ -108,6 +112,20 @@
 	&.is-error {
 		background: $alert-red;
 	}
+
+	.is-loading & {
+		width: 48px;
+		height: 48px;
+		margin-top: -12px;
+		padding: 0;
+		background-color: $gray-lighten-20;
+
+		@include breakpoint( '<480px' ) {
+			width: 32px;
+			height: 32px;
+			margin: 2px 0 0 2px;
+		}
+	}
 }
 
 .activity-log-item__card {
@@ -126,6 +144,11 @@
 		padding: 16px;
 		font-size: 14px;
 		color: $gray-darken-20;
+	}
+
+	.is-loading & {
+		height: 80px;
+		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 }
 

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -24,7 +24,6 @@ import EmptyContent from 'components/empty-content';
 import ErrorBanner from '../activity-log-banner/error-banner';
 import UpgradeBanner from '../activity-log-banner/upgrade-banner';
 import { isFreePlan } from 'lib/plans';
-import FoldableCard from 'components/foldable-card';
 import JetpackColophon from 'components/jetpack-colophon';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -320,17 +319,16 @@ class ActivityLog extends Component {
 		// The network request is still ongoing
 		return (
 			<section className="activity-log__wrapper">
+				<div className="activity-log__time-period is-loading">
+					<span />
+				</div>
 				{ [ 1, 2, 3 ].map( i => (
-					<FoldableCard
-						key={ i }
-						className="activity-log-day__placeholder"
-						header={
-							<div>
-								<div className="activity-log-day__day" />
-								<div className="activity-log-day__events" />
-							</div>
-						}
-					/>
+					<div key={ i } className="activity-log-item is-loading">
+						<div className="activity-log-item__type">
+							<div className="activity-log-item__activity-icon" />
+						</div>
+						<div className="card foldable-card activity-log-item__card" />
+					</div>
 				) ) }
 			</section>
 		);

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -42,6 +42,15 @@
 	@include breakpoint( '<660px' ) {
 		margin-left: 10px;
 	}
+
+	&.is-loading span {
+		display: block;
+		height: 23px;
+		width: 100px;
+		margin: 3px 0;
+		background-color: $gray-lighten-20;
+		animation: loading-fade 1.6s ease-in-out infinite;
+	}
 }
 
 .activity-log__rewind-toggle {


### PR DESCRIPTION
This set of changes updates the loading state of the Activity log, since we were still using the old month/day foldable cards.

#### Before

<img width="782" alt="screen shot 2018-07-19 at 15 31 04" src="https://user-images.githubusercontent.com/390760/42949063-d9b7ac7a-8b68-11e8-8fbf-5cfc94797e8e.png">

#### After

<img width="784" alt="screen shot 2018-07-19 at 15 33 18" src="https://user-images.githubusercontent.com/390760/42949174-1a49874a-8b69-11e8-86da-9e0b649ee4cf.png">
