### PR TITLE
Framework: Revert "Move @babel/polyfill import to webpack config"

### DIFF
--- a/client/boot/polyfills.js
+++ b/client/boot/polyfills.js
@@ -1,8 +1,13 @@
 /** @format */
+/**
+ * External dependencies
+ */
+import '@babel/polyfill';
 
 /**
  * Internal dependencies
  */
+
 import localStoragePolyfill from 'lib/local-storage';
 
 localStoragePolyfill();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,7 +74,7 @@ const babelLoader = {
 
 const webpackConfig = {
 	bail: ! isDevelopment,
-	entry: { build: [ '@babel/polyfill', path.join( __dirname, 'client', 'boot', 'app' ) ] },
+	entry: { build: [ path.join( __dirname, 'client', 'boot', 'app' ) ] },
 	profile: shouldEmitStats,
 	mode: isDevelopment ? 'development' : 'production',
 	devtool: isDevelopment ? '#eval' : process.env.SOURCEMAP || false, // in production builds you can specify a source-map via env var


### PR DESCRIPTION
Revert #26094.

[Rationale](https://github.com/Automattic/wp-calypso/pull/26094#issuecomment-405972594):

> This PR [increased](http://iscalypsofastyet.com/push/ed6beaa5e0b54f6ddbe11360c8ad8a572b83a32f/e3642614723d88c353e5d768969d8f877d7472c4) the bundle size and [reverted](http://iscalypsofastyet.com/push/acef9fa493cc06a9fefece7ff00759997af8ca8a/03502467b044464e191c9746c510c6a10a7930e0) the improvements achieved in #25961.
>
> It's because `babel-preset-env` used to transform the `@babel/polyfill` import into a list that excludes the polyfills that are not needed on the target browser list. In the new location of `@babel/polyfill`, the plugin doesn't get the opportunity to do that transform and all polyfills are bundled again.

I filed #26094 in the first place to get #24788 to work. Fortunately, @jsnajdr found [another way](https://github.com/Automattic/wp-calypso/pull/24788#issuecomment-406290939).

To test: Verify that the app still builds and runs. Check ICFY to verfiy that bundle size drops back down again.