### PR TITLE
Build: Fix the assets writer when building sourcemaps

### DIFF
--- a/server/bundler/assets-writer.js
+++ b/server/bundler/assets-writer.js
@@ -49,9 +49,15 @@ Object.assign( AssetsWriter.prototype, {
 			for ( const name in stats.assetsByChunkName ) {
 				// make the manifest inlineable
 				if ( String( name ).startsWith( 'manifest' ) ) {
-					statsToOutput.manifests[ name ] = compilation.assets[
-						stats.assetsByChunkName[ name ]
-					].source();
+					// Usually there's only one asset per chunk, but when we build with sourcemaps, we'll have two.
+					// Remove the sourcemap from the list and just take the js asset
+					// This may not hold true for all chunks, but it does for the manifest.
+					const jsAsset = _.head(
+						_.reject( _.castArray( stats.assetsByChunkName[ name ] ), asset =>
+							_.endsWith( asset, '.map' )
+						)
+					);
+					statsToOutput.manifests[ name ] = compilation.assets[ jsAsset ].source();
 				}
 			}
 


### PR DESCRIPTION
The assets writer assumed that every chunk only contained one asset, but when we build with sourcemaps, each chunk contains two assets: the chunk itself and the sourcemap for that chunk.

Teach the asset writer to deal with this and pick out the js file when inlining the manifest.

### Testing
```
npm ci
CALYPSO_ENV=production SOURCEMAP=source-map npm run build-client
```
Should work. On master, it fails as in #26170 

Fixes #26170