### PR TITLE
Activity Log: make core updates available to everyone

### DIFF
--- a/client/my-sites/stats/activity-log-tasklist/to-update.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/to-update.jsx
@@ -7,7 +7,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { get, unionBy } from 'lodash';
-import config from 'config';
 
 /**
  * Internal dependencies
@@ -61,9 +60,7 @@ export default WrappedComponent => {
 		return {
 			plugins: getPluginsWithUpdates( state, [ siteId ] ),
 			themes: get( alertsData, 'data.updates.themes', emptyList ),
-			core: config.isEnabled( 'activity-log-core-update' )
-				? get( alertsData, 'data.updates.core', emptyList )
-				: emptyList,
+			core: get( alertsData, 'data.updates.core', emptyList ),
 		};
 	} )( ToUpdate );
 };

--- a/config/development.json
+++ b/config/development.json
@@ -29,7 +29,6 @@
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"support_site_locales": [ "en", "es", "de", "ja", "pt-br" ],
 	"features": {
-		"activity-log-core-update": true,
 		"activity-log-wpcom-free": true,
 		"account-recovery": true,
 		"ad-tracking": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -19,7 +19,6 @@
 		"pt-br"
 	],
 	"features": {
-		"activity-log-core-update": true,
 		"activity-log-wpcom-free": true,
 		"ad-tracking": false,
 		"apple-pay": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -16,7 +16,6 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
-		"activity-log-core-update": true,
 		"activity-log-wpcom-free": true,
 		"ad-tracking": false,
 		"automated-transfer": true,


### PR DESCRIPTION
This PR removes the config flag thus making persistent notices for core updates introduced in https://github.com/Automattic/wp-calypso/pull/25911 available to all users.