### PR TITLE
Activity Log: Fixes #26184 and improves upgrade banners

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -1044,9 +1044,9 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Jetpack Essential Features' ),
 		getDescription: () =>
 			i18n.translate(
-				'Improve your SEO results, protect your site from spammers, ' +
-					"keep an eye on your site's activity and stats, " +
-					'and instantly share on social media with the help of Jetpack.'
+				'Improve your SEO, protect your site from spammers, ' +
+					'keep a closer eye on your site with expanded activity logs, ' +
+					'and automate social media sharing.'
 			),
 	},
 

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -1044,8 +1044,9 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Jetpack Essential Features' ),
 		getDescription: () =>
 			i18n.translate(
-				'Jetpack is a powerful plugin that includes SEO, spam protection, ' +
-					'social sharing, site stats, and more.'
+				'Improve your SEO results, protect your site from spammers, ' +
+					"keep an eye on your site's activity and stats, " +
+					'and instantly share on social media with the help of Jetpack.'
 			),
 	},
 

--- a/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
@@ -11,7 +11,7 @@ import { localize } from 'i18n-calypso';
  */
 import { isJetpackSite } from 'state/sites/selectors';
 import Banner from 'components/banner';
-import { PLAN_PERSONAL, FEATURE_NO_ADS } from 'lib/plans/constants';
+import { PLAN_PERSONAL, FEATURE_JETPACK_ESSENTIAL } from 'lib/plans/constants';
 
 class UpgradeBanner extends Component {
 	render() {
@@ -25,11 +25,11 @@ class UpgradeBanner extends Component {
 					callToAction={ translate( 'Upgrade' ) }
 					dismissPreferenceName="activity-upgrade-banner-simple"
 					event="activity_log_upgrade_click_wpcom"
-					feature={ FEATURE_NO_ADS }
+					feature={ FEATURE_JETPACK_ESSENTIAL }
 					list={ [
 						translate( 'Get a custom domain name' ),
 						translate( 'Remove WordPress.com ads' ),
-						translate( 'See 30 days of past activity' ),
+						translate( 'Keep an eye on your site with more activities types and details' ),
 					] }
 					plan={ PLAN_PERSONAL }
 					title={ translate( 'Upgrade your WordPress.com experience' ) }

--- a/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
@@ -26,13 +26,12 @@ class UpgradeBanner extends Component {
 					dismissPreferenceName="activity-upgrade-banner-simple"
 					event="activity_log_upgrade_click_wpcom"
 					feature={ FEATURE_JETPACK_ESSENTIAL }
-					list={ [
-						translate( 'Get a custom domain name' ),
-						translate( 'Remove WordPress.com ads' ),
-						translate( 'Keep an eye on your site with more activities types and details' ),
-					] }
 					plan={ PLAN_PERSONAL }
-					title={ translate( 'Upgrade your WordPress.com experience' ) }
+					title={ translate( 'Enhance your WP.com experience' ) }
+					description={ translate(
+						'Improve your SEO, protect your site from spammers, ' +
+							'and keep a closer eye on your site with expanded activity logs.'
+					) }
 				/>
 			</div>
 		);

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -393,7 +393,9 @@ class ActivityLog extends Component {
 				{ siteIsOnFreePlan && <UpgradeBanner siteId={ siteId } /> }
 				{ config.isEnabled( 'rewind-alerts' ) && siteId && <RewindAlerts siteId={ siteId } /> }
 				{ siteId &&
-					'unavailable' === rewindState.state && <UnavailabilityNotice siteId={ siteId } /> }
+					'unavailable' === rewindState.state && (
+						<UnavailabilityNotice siteId={ siteId } siteIsOnFreePlan={ siteIsOnFreePlan } />
+					) }
 				{ 'awaitingCredentials' === rewindState.state && (
 					<Banner
 						icon="history"

--- a/client/my-sites/stats/activity-log/unavailability-notice.jsx
+++ b/client/my-sites/stats/activity-log/unavailability-notice.jsx
@@ -13,6 +13,11 @@ import Banner from 'components/banner';
 import { getSiteAdminUrl } from 'state/sites/selectors';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import getRewindState from 'state/selectors/get-rewind-state';
+import {
+	FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
+	PLAN_PERSONAL,
+	PLAN_JETPACK_PERSONAL,
+} from 'lib/plans/constants';
 
 export const UnavailabilityNotice = ( {
 	adminUrl,
@@ -21,16 +26,35 @@ export const UnavailabilityNotice = ( {
 	slug,
 	translate,
 	siteId,
+	siteIsOnFreePlan,
 } ) => {
 	if ( rewindState !== 'unavailable' ) {
 		return null;
 	}
 
 	switch ( reason ) {
+		case 'host_not_supported':
+			if ( siteIsOnFreePlan ) {
+				return (
+					<Banner
+						callToAction={ translate( 'Upgrade' ) }
+						dismissPreferenceName="activity-upgrade-banner-jetpack"
+						event="activity_log_upgrade_click_jetpack"
+						feature={ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY }
+						plan={ PLAN_JETPACK_PERSONAL }
+						title={ translate( 'Upgrade' ) }
+						description={ translate(
+							'Get daily off-site backups and keep an eye on your site ' +
+								'with more activity types and details'
+						) }
+					/>
+				);
+			}
+			return 'null';
 		case 'missing_plan':
 			return (
 				<Banner
-					plan="personal-bundle"
+					plan={ PLAN_PERSONAL }
 					href={ `/plans/${ slug }` }
 					callToAction={ translate( 'Upgrade' ) }
 					title={ translate(
@@ -67,7 +91,7 @@ export const UnavailabilityNotice = ( {
 	}
 };
 
-const mapStateToProps = ( state, { siteId } ) => {
+const mapStateToProps = ( state, { siteId, siteIsOnFreePlan } ) => {
 	const { reason, state: rewindState } = getRewindState( state, siteId );
 
 	return {
@@ -76,6 +100,7 @@ const mapStateToProps = ( state, { siteId } ) => {
 		rewindState,
 		slug: getSelectedSiteSlug( state ),
 		siteId,
+		siteIsOnFreePlan,
 	};
 };
 

--- a/client/my-sites/stats/activity-log/unavailability-notice.jsx
+++ b/client/my-sites/stats/activity-log/unavailability-notice.jsx
@@ -42,10 +42,10 @@ export const UnavailabilityNotice = ( {
 						event="activity_log_upgrade_click_jetpack"
 						feature={ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY }
 						plan={ PLAN_JETPACK_PERSONAL }
-						title={ translate( 'Upgrade' ) }
+						title={ translate( 'Stay Safe' ) }
 						description={ translate(
-							'Get daily off-site backups and keep an eye on your site ' +
-								'with more activity types and details'
+							'Protect your data with daily off-site backups, ' +
+								'and keep a closer eye on your site with expanded activity logs.'
 						) }
 					/>
 				);


### PR DESCRIPTION
This PR adds an upgrade banner for free Jetpack sites where Rewind™ is not available. The banner advertises daily-offsite backups, which will be highlighted when clicked.

<img width="1552" alt="screen shot 2018-07-19 at 4 19 19 pm" src="https://user-images.githubusercontent.com/2694219/42968202-9bf95cdc-8b70-11e8-9580-d539a496276c.png">

<img width="290" alt="screen shot 2018-07-19 at 4 19 40 pm" src="https://user-images.githubusercontent.com/2694219/42968208-a165158a-8b70-11e8-99c5-a4b376edec55.png">


This PR also updates the text on the banner we are using for free wordpress.com sites. This banner now advertises Jetpack's essential features which will be highlighted when clicked.



<img width="1552" alt="screen shot 2018-07-19 at 4 20 06 pm" src="https://user-images.githubusercontent.com/2694219/42968164-7fa17af6-8b70-11e8-96b2-02a8b77dbe05.png">

<img width="291" alt="screen shot 2018-07-19 at 4 20 28 pm" src="https://user-images.githubusercontent.com/2694219/42968171-83945804-8b70-11e8-88a1-31e3f324fbf7.png">


This PR also updates the feature-text for Jetpack essential features:

<img width="374" alt="screen shot 2018-07-19 at 4 21 05 pm" src="https://user-images.githubusercontent.com/2694219/42968219-a7ba3316-8b70-11e8-9625-9175f9ff9ee4.png">


Fixes #26184