### PR TITLE
Podcasting: add notice for next steps

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -32,6 +32,7 @@ import PodcastFeedUrl from './feed-url';
 import PodcastingPrivateSiteMessage from './private-site';
 import PodcastingNoPermissionsMessage from './no-permissions';
 import PodcastingNotSupportedMessage from './not-supported';
+import PodcastingPublishNotice from './publish-notice';
 import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
 import podcastingTopics from './topics';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -246,12 +247,21 @@ class PodcastingDetails extends Component {
 	}
 
 	renderCategorySetting() {
-		const { siteId, podcastingCategoryId, isCategoryChanging, translate } = this.props;
+		const {
+			siteId,
+			isPodcastingEnabled,
+			podcastingCategoryId,
+			isCategoryChanging,
+			translate,
+		} = this.props;
 
 		return (
 			<Fragment>
 				<QueryTerms siteId={ siteId } taxonomy="category" />
 				<FormFieldset>
+					{ isPodcastingEnabled && (
+						<PodcastingPublishNotice podcastingCategoryId={ podcastingCategoryId } />
+					) }
 					<FormLabel>{ translate( 'Podcast Category' ) }</FormLabel>
 					<FormSettingExplanation>
 						{ translate(

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -12,20 +12,20 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
+import { decodeEntities } from 'lib/formatting';
+import scrollTo from 'lib/scroll-to';
 import Button from 'components/button';
 import Card from 'components/card';
 import DocumentHead from 'components/data/document-head';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormInput from 'components/forms/form-text-input';
-import { decodeEntities } from 'lib/formatting';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormSelect from 'components/forms/form-select';
 import FormTextarea from 'components/forms/form-textarea';
 import HeaderCake from 'components/header-cake';
-import scrollTo from 'lib/scroll-to';
 import Notice from 'components/notice';
-import QueryTerms from 'components/data/query-terms';
 import TermTreeSelector from 'blocks/term-tree-selector';
 import PodcastCoverImageSetting from 'my-sites/site-settings/podcast-cover-image-setting';
 import PodcastFeedUrl from './feed-url';
@@ -33,8 +33,12 @@ import PodcastingPrivateSiteMessage from './private-site';
 import PodcastingNoPermissionsMessage from './no-permissions';
 import PodcastingNotSupportedMessage from './not-supported';
 import PodcastingPublishNotice from './publish-notice';
-import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
 import podcastingTopics from './topics';
+
+/**
+ * Selectors, actions, and query components
+ */
+import QueryTerms from 'components/data/query-terms';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import isPrivateSite from 'state/selectors/is-private-site';
 import canCurrentUser from 'state/selectors/can-current-user';
@@ -253,6 +257,7 @@ class PodcastingDetails extends Component {
 			podcastingCategoryId,
 			isCategoryChanging,
 			translate,
+			newPostUrl,
 		} = this.props;
 
 		return (
@@ -260,7 +265,12 @@ class PodcastingDetails extends Component {
 				<QueryTerms siteId={ siteId } taxonomy="category" />
 				<FormFieldset>
 					{ isPodcastingEnabled && (
-						<PodcastingPublishNotice podcastingCategoryId={ podcastingCategoryId } />
+						<div className="podcasting-details__publish-wrapper">
+							<PodcastingPublishNotice podcastingCategoryId={ podcastingCategoryId } />
+							<Button className="podcasting-details__publish-button" href={ newPostUrl }>
+								{ translate( 'Create Episode' ) }
+							</Button>
+						</div>
 					) }
 					<FormLabel>{ translate( 'Podcast Category' ) }</FormLabel>
 					<FormSettingExplanation>
@@ -457,9 +467,12 @@ const connectComponent = connect( ( state, ownProps ) => {
 	const isJetpack = isJetpackSite( state, siteId );
 	const isAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
 
+	const siteSlug = getSelectedSiteSlug( state );
+	const newPostUrl = `/post/${ siteSlug }`;
+
 	return {
 		siteId,
-		siteSlug: getSelectedSiteSlug( state ),
+		siteSlug,
 		isPrivate: isPrivateSite( state, siteId ),
 		isPodcastingEnabled,
 		podcastingCategoryId,
@@ -468,6 +481,7 @@ const connectComponent = connect( ( state, ownProps ) => {
 		userCanManagePodcasting: canCurrentUser( state, siteId, 'manage_options' ),
 		isUnsupportedSite: isJetpack && ! isAutomatedTransfer,
 		isSavingSettings,
+		newPostUrl,
 	};
 } );
 

--- a/client/my-sites/site-settings/podcasting-details/link.jsx
+++ b/client/my-sites/site-settings/podcasting-details/link.jsx
@@ -5,7 +5,6 @@
  */
 import React, { Component, Fragment } from 'react';
 import classnames from 'classnames';
-import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -18,6 +17,7 @@ import SectionHeader from 'components/section-header';
 import PodcastFeedUrl from './feed-url';
 import PodcastingPrivateSiteMessage from './private-site';
 import PodcastingSupportLink from './support-link';
+import PodcastingPublishNotice from './publish-notice';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import isPrivateSite from 'state/selectors/is-private-site';
 import { getTerm } from 'state/terms/selectors';
@@ -43,7 +43,6 @@ class PodcastingLink extends Component {
 			isPrivate,
 			isPodcastingEnabled,
 			podcastingCategoryId,
-			podcastingCategoryName,
 			detailsLink,
 			translate,
 		} = this.props;
@@ -72,18 +71,7 @@ class PodcastingLink extends Component {
 		return (
 			<Fragment>
 				<div className="podcasting-details__link-action-container">
-					<div className="podcasting-details__link-info">
-						<Gridicon icon="microphone" size={ 24 } />
-						<span className="podcasting-details__link-info-text">
-							{ translate(
-								'Publish blog posts in the {{strong}}%s{{/strong}} category to add new episodes.',
-								{
-									args: podcastingCategoryName,
-									components: { strong: <strong /> },
-								}
-							) }
-						</span>
-					</div>
+					<PodcastingPublishNotice podcastingCategoryId={ podcastingCategoryId } />
 					<Button className="podcasting-details__link-button" href={ detailsLink }>
 						{ translate( 'Manage Details' ) }
 					</Button>
@@ -113,7 +101,6 @@ export default connect( ( state, ownProps ) => {
 		isPrivate: isPrivateSite( state, siteId ),
 		isPodcastingEnabled: !! podcastingCategory,
 		podcastingCategoryId,
-		podcastingCategoryName: podcastingCategory && podcastingCategory.name,
 		detailsLink,
 	};
 } )( localize( PodcastingLink ) );

--- a/client/my-sites/site-settings/podcasting-details/publish-notice.jsx
+++ b/client/my-sites/site-settings/podcasting-details/publish-notice.jsx
@@ -11,24 +11,23 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import PodcastingSupportLink from './support-link';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { getTerm } from 'state/terms/selectors';
 
-function PodcastingPublishNotice( { translate, podcastingCategoryName, newPostUrl } ) {
+function PodcastingPublishNotice( { translate, podcastingCategoryName } ) {
 	return (
 		<div className="podcasting-details__publish-notice">
 			<Gridicon icon="microphone" size={ 24 } />
 			<span className="podcasting-details__publish-notice-text">
 				{ translate(
-					'{{newPostLink}}Publish a post{{/newPostLink}} in the {{strong}}%s{{/strong}} category to add a new episode.',
+					'Publish blog posts in the {{strong}}%s{{/strong}} category to add new episodes.',
 					{
 						args: podcastingCategoryName,
-						components: {
-							strong: <strong />,
-							newPostLink: <a href={ newPostUrl } />,
-						},
+						components: { strong: <strong /> },
 					}
 				) }
+				<PodcastingSupportLink />
 			</span>
 		</div>
 	);
@@ -40,14 +39,9 @@ export default connect( ( state, ownProps ) => {
 	}
 
 	const siteId = getSelectedSiteId( state );
-	const siteSlug = getSelectedSiteSlug( state );
-
 	const podcastingCategory = getTerm( state, siteId, 'category', ownProps.podcastingCategoryId );
-
-	const newPostUrl = `/post/${ siteSlug }`;
 
 	return {
 		podcastingCategoryName: podcastingCategory && podcastingCategory.name,
-		newPostUrl,
 	};
 } )( localize( PodcastingPublishNotice ) );

--- a/client/my-sites/site-settings/podcasting-details/publish-notice.jsx
+++ b/client/my-sites/site-settings/podcasting-details/publish-notice.jsx
@@ -16,17 +16,25 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getTerm } from 'state/terms/selectors';
 
 function PodcastingPublishNotice( { translate, podcastingCategoryName } ) {
+	let podcastNoticeText;
+
+	if ( podcastingCategoryName ) {
+		podcastNoticeText = translate(
+			'Publish blog posts in the {{strong}}%s{{/strong}} category to add new episodes.',
+			{
+				args: podcastingCategoryName,
+				components: { strong: <strong /> },
+			}
+		);
+	} else {
+		podcastNoticeText = translate( 'Select a category to enable podcasting.' );
+	}
+
 	return (
 		<div className="podcasting-details__publish-notice">
 			<Gridicon icon="microphone" size={ 24 } />
 			<span className="podcasting-details__publish-notice-text">
-				{ translate(
-					'Publish blog posts in the {{strong}}%s{{/strong}} category to add new episodes.',
-					{
-						args: podcastingCategoryName,
-						components: { strong: <strong /> },
-					}
-				) }
+				{ podcastNoticeText }
 				<PodcastingSupportLink />
 			</span>
 		</div>

--- a/client/my-sites/site-settings/podcasting-details/publish-notice.jsx
+++ b/client/my-sites/site-settings/podcasting-details/publish-notice.jsx
@@ -1,0 +1,53 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getTerm } from 'state/terms/selectors';
+
+function PodcastingPublishNotice( { translate, podcastingCategoryName, newPostUrl } ) {
+	return (
+		<div className="podcasting-details__publish-notice">
+			<Gridicon icon="microphone" size={ 24 } />
+			<span className="podcasting-details__publish-notice-text">
+				{ translate(
+					'{{newPostLink}}Publish a post{{/newPostLink}} in the {{strong}}%s{{/strong}} category to add a new episode.',
+					{
+						args: podcastingCategoryName,
+						components: {
+							strong: <strong />,
+							newPostLink: <a href={ newPostUrl } />,
+						},
+					}
+				) }
+			</span>
+		</div>
+	);
+}
+
+export default connect( ( state, ownProps ) => {
+	if ( ownProps.podcastingCategoryId <= 0 ) {
+		return null;
+	}
+
+	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSelectedSiteSlug( state );
+
+	const podcastingCategory = getTerm( state, siteId, 'category', ownProps.podcastingCategoryId );
+
+	const newPostUrl = `/post/${ siteSlug }`;
+
+	return {
+		podcastingCategoryName: podcastingCategory && podcastingCategory.name,
+		newPostUrl,
+	};
+} )( localize( PodcastingPublishNotice ) );

--- a/client/my-sites/site-settings/podcasting-details/publish-notice.jsx
+++ b/client/my-sites/site-settings/podcasting-details/publish-notice.jsx
@@ -11,7 +11,6 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import PodcastingSupportLink from './support-link';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getTerm } from 'state/terms/selectors';
 
@@ -33,10 +32,7 @@ function PodcastingPublishNotice( { translate, podcastingCategoryName } ) {
 	return (
 		<div className="podcasting-details__publish-notice">
 			<Gridicon icon="microphone" size={ 24 } />
-			<span className="podcasting-details__publish-notice-text">
-				{ podcastNoticeText }
-				<PodcastingSupportLink />
-			</span>
+			<span className="podcasting-details__publish-notice-text">{ podcastNoticeText }</span>
 		</div>
 	);
 }

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -15,13 +15,13 @@
 		.podcasting-details__link-info {
 			flex-grow: 1;
 			color: $gray-text;
-			margin-right: 12px;
 		}
 
 		.podcasting-details__link-button {
 			color: $gray-darken-20;
 			font-weight: 600;
 			flex-shrink: 0;
+			margin-left: 12px;
 			// For viewports/translations when the text is taller than the button
 			align-self: center;
 		}
@@ -33,26 +33,38 @@
 	}
 }
 
-.podcasting-details__link.is-enabled {
-	.podcasting-details__link-info {
-		position: relative;
-		background: $gray-lighten-30;
-		border-radius: 4px;
-		align-self: stretch;
-		padding: 4px 6px 4px 0;
-		// Center contents vertically
-		// Note this element contains a <span> container to ensure normal
-		// display (whitespace) between text items
-		display: flex;
-		align-items: center;
+.podcasting-details__publish-notice {
+	position: relative;
+	background: $gray-lighten-30;
+	border-radius: 4px;
+	align-self: stretch;
+	padding: 6px;
+	font-size: 14px;
+	text-align: left;
+	// Center contents vertically
+	// Note this element contains a <span> container to ensure normal
+	// display (whitespace) between text items
+	display: flex;
+	flex-grow: 1;
+	align-items: center;
+
+	.podcasting-details__category-wrapper & {
+		margin-bottom: 16px;
 	}
 
 	.gridicons-microphone {
 		flex-shrink: 0;
-		margin: 0 4px 0 6px;
+		margin-right: 6px;
 		color: $podcasting-purple;
 	}
 
+	a {
+		color: $gray-dark;
+		text-decoration: underline;
+	}
+}
+
+.podcasting-details__link.is-enabled {
 	.podcasting-details__link-feed {
 		margin-top: 20px;
 	}
@@ -64,9 +76,8 @@
 			display: block;
 			text-align: right;
 		}
-		.podcasting-details__link-info {
-			text-align: left;
-			margin-right: 0;
+		.podcasting-details__link-info,
+		.podcasting-details__publish-notice {
 			margin-bottom: 8px;
 		}
 	}

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -33,6 +33,12 @@
 	}
 }
 
+.podcasting-details__publish-wrapper {
+	display: flex;
+	align-items: flex-start;
+	margin-bottom: 16px;
+}
+
 .podcasting-details__publish-notice {
 	position: relative;
 	background: $gray-lighten-30;
@@ -48,10 +54,6 @@
 	flex-grow: 1;
 	align-items: center;
 
-	.podcasting-details__category-wrapper & {
-		margin-bottom: 16px;
-	}
-
 	.gridicons-microphone {
 		flex-shrink: 0;
 		margin-right: 6px;
@@ -62,6 +64,19 @@
 		color: $gray-dark;
 		text-decoration: underline;
 	}
+
+	.podcasting-details__support-link {
+		margin-left: 4px;
+	}
+}
+
+.podcasting-details__publish-button {
+	color: $gray-darken-20;
+	font-weight: 600;
+	flex-shrink: 0;
+	margin-left: 12px;
+	// For viewports/translations when the text is taller than the button
+	align-self: center;
 }
 
 .podcasting-details__link.is-enabled {
@@ -71,15 +86,14 @@
 }
 
 @include breakpoint( '<800px' ) {
-	.podcasting-details__link.is-enabled {
-		.podcasting-details__link-action-container {
-			display: block;
-			text-align: right;
-		}
-		.podcasting-details__link-info,
-		.podcasting-details__publish-notice {
-			margin-bottom: 8px;
-		}
+	.podcasting-details__link.is-enabled .podcasting-details__link-action-container,
+	.podcasting-details__publish-wrapper {
+		display: block;
+		text-align: right;
+	}
+	.podcasting-details__link.is-enabled .podcasting-details__link-info,
+	.podcasting-details__publish-notice {
+		margin-bottom: 8px;
 	}
 }
 


### PR DESCRIPTION
This PR adds a prompt to the top of the Podcast Settings page when a podcast is enabled, to let users know how to create a podcast episodes, and to offer a link to the documentation. The prompt is reused from the Settings > Writing > Podcasting link area when podcasting is enabled.

Fixes #26111.

**Before:** | **After:**
------------ | -------------
<img width="758" alt="before" src="https://user-images.githubusercontent.com/942359/43012744-f14a8892-8c14-11e8-9946-797de89c2707.png"> | ![new-post-notice](https://user-images.githubusercontent.com/942359/43011785-6fc6a294-8c12-11e8-8ea9-c4657aa66720.png)

**To test:**
- On a site with Podcasting disabled, visit Settings > Writing > Podcasting > "Set Up"
- Verify that no prompt is shown while the podcast is disabled.
- Enable podcasting by selecting a category.
- Verify that the prompt is shown at the top of the page with a "learn more" link to the support documentation, and a "create episode" button that starts a new post.
