### PR TITLE
Activity Log: fix issue where rewinds through unexpected errors.

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -118,7 +118,7 @@ class ActivityLog extends Component {
 	}
 
 	findExistingRewind = ( { siteId, rewindState } ) => {
-		if ( rewindState.rewind ) {
+		if ( rewindState.rewind && rewindState.rewind.restoreId ) {
 			this.props.getRewindRestoreProgress( siteId, rewindState.rewind.restoreId );
 		}
 	};

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
@@ -43,6 +43,10 @@ const fetchProgress = action => {
 		return;
 	}
 
+	if ( ! restoreId ) {
+		return;
+	}
+
 	recentRequests.set( key, now );
 
 	return http(

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
@@ -39,11 +39,11 @@ const fetchProgress = action => {
 	const lastUpdate = recentRequests.get( key ) || -Infinity;
 	const now = Date.now();
 
-	if ( now - lastUpdate < POLL_INTERVAL ) {
+	if ( ! restoreId ) {
 		return;
 	}
 
-	if ( ! restoreId ) {
+	if ( now - lastUpdate < POLL_INTERVAL ) {
 		return;
 	}
 

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
@@ -39,10 +39,6 @@ const fetchProgress = action => {
 	const lastUpdate = recentRequests.get( key ) || -Infinity;
 	const now = Date.now();
 
-	if ( ! restoreId ) {
-		return;
-	}
-
 	if ( now - lastUpdate < POLL_INTERVAL ) {
 		return;
 	}


### PR DESCRIPTION
Currently, when you try to initiate a rewind on a site, you end up with an unexpected error:

<img width="1381" alt="68747470733a2f2f636c6475702e636f6d2f386e62657a71695539622e706e67" src="https://user-images.githubusercontent.com/2694219/42970025-278dfa1e-8b76-11e8-8bfd-e274cb244cbc.png">


To test:
- apply this patch, and ensure you can still rewind as usual
- ensure the 'Hmm...' error goes away

Cc: @dmsnell - does this seem like a reasonable fix, or is it just a band-aid. I haven't been able to trace why the restore id is `undefined` - See linked issue below for more details