### PR TITLE
Gutenberg: include @wordpress/data package

### DIFF
--- a/client/gutenberg/editor/test/index.js
+++ b/client/gutenberg/editor/test/index.js
@@ -1,0 +1,103 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import {
+	registerStore,
+	registerReducer,
+	registerSelectors,
+	dispatch,
+	select,
+} from '@wordpress/data';
+
+describe( 'Gutenberg @wordress/data package', () => {
+	describe( 'registerStore', () => {
+		it( 'should be shorthand for reducer, actions, selectors registration', () => {
+			const DEFAULT_STATE = {
+				prices: { shirt: 5 },
+				discountPercent: 0,
+			};
+
+			const store = registerStore( 'my-shop', {
+				reducer( state = DEFAULT_STATE, action ) {
+					switch ( action.type ) {
+						case 'SET_PRICE':
+							return {
+								...state,
+								prices: {
+									...state.prices,
+									[ action.item ]: action.price,
+								},
+							};
+
+						case 'START_SALE':
+							return {
+								...state,
+								discountPercent: action.discountPercent,
+							};
+					}
+
+					return state;
+				},
+
+				actions: {
+					setPrice( item, price ) {
+						return {
+							type: 'SET_PRICE',
+							item,
+							price,
+						};
+					},
+					startSale( discountPercent ) {
+						return {
+							type: 'START_SALE',
+							discountPercent,
+						};
+					},
+				},
+
+				selectors: {
+					getPrice( state, item ) {
+						const { prices, discountPercent } = state;
+						const price = prices[ item ];
+
+						return price * ( 1 - 0.01 * discountPercent );
+					},
+				},
+			} );
+
+			expect( store.getState() ).toEqual( DEFAULT_STATE );
+			expect( select( 'my-shop' ) ).toHaveProperty( 'getPrice' );
+			expect( select( 'my-shop' ).getPrice( 'shirt' ) ).toEqual( 5 );
+			dispatch( 'my-shop' ).setPrice( 'shirt', 10 );
+			expect( select( 'my-shop' ).getPrice( 'shirt' ) ).toEqual( 10 );
+			dispatch( 'my-shop' ).startSale( 20 );
+			expect( select( 'my-shop' ).getPrice( 'shirt' ) ).toEqual( 8 );
+		} );
+	} );
+
+	describe( 'registerReducer', () => {
+		it( 'Should append reducers to the state', () => {
+			const reducer = () => 'tea';
+
+			const store = registerReducer( 'reducer', reducer );
+			expect( store.getState() ).toEqual( 'tea' );
+		} );
+	} );
+
+	describe( 'select', () => {
+		it( 'registers multiple selectors to the public API', () => {
+			const store = registerReducer( 'reducer', () => {} );
+			const selector = jest.fn( () => 'test-result' );
+
+			registerSelectors( 'reducer', { selector } );
+
+			expect( select( 'reducer' ).selector() ).toEqual( 'test-result' );
+			expect( selector ).toBeCalledWith( store.getState() );
+		} );
+	} );
+} );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1163,6 +1163,74 @@
         "long": "^3.2.0"
       }
     },
+    "@wordpress/compose": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-1.0.1.tgz",
+      "integrity": "sha512-BvopgvFpWWZxCGPmX2jI7ESjhHU8A62pDnI0v+beDO70STmnTrfLfLWA+dfxxTxHLKk666HC6NUUr4AanDEIZA==",
+      "requires": {
+        "@babel/runtime": "^7.0.0-beta.52",
+        "@wordpress/element": "^1.0.1",
+        "@wordpress/is-shallow-equal": "^1.1.1",
+        "lodash": "^4.17.10"
+      }
+    },
+    "@wordpress/data": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-1.0.1.tgz",
+      "integrity": "sha512-LBevjZQnyWHmB4nhLqeIFns1TonmbumKxCHjxM5xfzjtQs6AV41K6yST/2/0pN7q8hBWY/jzUdmVCXWwsrH8yA==",
+      "requires": {
+        "@babel/runtime": "^7.0.0-beta.52",
+        "@wordpress/compose": "^1.0.1",
+        "@wordpress/deprecated": "^1.0.1",
+        "@wordpress/element": "^1.0.1",
+        "@wordpress/is-shallow-equal": "^1.1.1",
+        "equivalent-key-map": "^0.2.0",
+        "lodash": "^4.17.10",
+        "redux": "^3.7.2"
+      },
+      "dependencies": {
+        "redux": {
+          "version": "3.7.2",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+          "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+          "requires": {
+            "lodash": "^4.2.1",
+            "lodash-es": "^4.2.1",
+            "loose-envify": "^1.1.0",
+            "symbol-observable": "^1.0.3"
+          }
+        }
+      }
+    },
+    "@wordpress/deprecated": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-1.0.1.tgz",
+      "integrity": "sha512-o99RsKIteL2lJAXoM7su7SLstTjhnNBszuaRMnii4pdAORN6Li4zYNNvbJABIctCVGgW2jPJE9IYNToxIsG/EQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0-beta.52"
+      }
+    },
+    "@wordpress/element": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-1.0.1.tgz",
+      "integrity": "sha512-KbIS/IB1+iSE4+pTzCxcRLOqo6I6VfolBmb0HdgT+dNYqcQL0HGNnbKR5sSU1VhGP8SmXFUab0D+xY5Zr5aZug==",
+      "requires": {
+        "@babel/runtime": "^7.0.0-beta.52",
+        "@wordpress/deprecated": "^1.0.1",
+        "@wordpress/is-shallow-equal": "^1.1.1",
+        "lodash": "^4.17.10",
+        "react": "^16.4.1",
+        "react-dom": "^16.4.1"
+      }
+    },
+    "@wordpress/is-shallow-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.1.1.tgz",
+      "integrity": "sha512-t5zQ4/uDvk+6YbiqhRZtjuZnpdu/mKUryTChn/nM292lEvSSpqPGrfnDIL11htK0U3Oug9OgwXAOER5zd+xRGQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0-beta.52"
+      }
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -1237,7 +1305,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -4540,6 +4607,11 @@
         "lodash": "^4.17.4"
       }
     },
+    "equivalent-key-map": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.2.1.tgz",
+      "integrity": "sha512-dmHJQuM7gMbZexuf9DfZdFUyeCUs2Srpa8Proo1TGC4YAF5UsLO+SNSFDvsf43kFJRLEKxpmGCAFNLOf6OjNPw=="
+    },
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
@@ -6107,13 +6179,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6126,18 +6196,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6240,8 +6307,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6251,7 +6317,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6264,20 +6329,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6294,7 +6356,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6367,8 +6428,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6378,7 +6438,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6484,7 +6543,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9204,8 +9262,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "longest-streak": {
       "version": "2.0.2",
@@ -15719,12 +15776,21 @@
       "dev": true
     },
     "unist-util-visit": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.1.tgz",
-      "integrity": "sha512-0fdB9EQJU0tho5tK0VzOJzAQpPv2LyLZ030b10GxuzAWEfvd54mpY7BMjQ1L69k2YNvL+SvxRzH0yUIehOO8aA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
+      "integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
       "dev": true,
       "requires": {
-        "unist-util-is": "^2.1.1"
+        "unist-util-visit-parents": "^2.0.0"
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
+      "integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
+      "dev": true,
+      "requires": {
+        "unist-util-is": "^2.1.2"
       }
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@babel/preset-env": "7.0.0-beta.53",
     "@babel/preset-react": "7.0.0-beta.53",
     "@babel/runtime": "7.0.0-beta.53",
+    "@wordpress/data": "1.0.1",
     "autoprefixer": "9.0.1",
     "autosize": "4.0.2",
     "babel-loader": "8.0.0-beta.4",


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/26180

Set up a Calypso test branch for `@wordpress/data` package and add some basic tests for it.

### Testing instructions

- `npm run test-client client/gutenberg/editor/test/index.js`
- Calypso smoke test