### PR TITLE
Domains: Count featured suggestions in TrainTracks

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -227,11 +227,13 @@ class DomainSearchResults extends React.Component {
 				<FeaturedDomainSuggestions
 					cart={ this.props.cart }
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+					fetchAlgo={ this.props.fetchAlgo }
 					isSignupStep={ this.props.isSignupStep }
 					key="featured"
 					onButtonClick={ this.props.onClickResult }
 					primarySuggestion={ first( bestMatchSuggestions ) }
 					query={ this.props.lastDomainSearched }
+					railcarSeed={ this.props.railcarSeed }
 					secondarySuggestion={ first( bestAlternativeSuggestions ) }
 					selectedSite={ this.props.selectedSite }
 				/>
@@ -250,8 +252,8 @@ class DomainSearchResults extends React.Component {
 						isSignupStep={ this.props.isSignupStep }
 						selectedSite={ this.props.selectedSite }
 						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-						railcarId={ `${ this.props.railcarSeed }-registration-suggestion-${ i }` }
-						uiPosition={ i }
+						railcarId={ `${ this.props.railcarSeed }-registration-suggestion-${ i + 2 }` }
+						uiPosition={ i + 2 }
 						fetchAlgo={
 							endsWith( suggestion.domain_name, '.wordpress.com' ) ? 'wpcom' : this.props.fetchAlgo
 						}

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { pick } from 'lodash';
+import { endsWith, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,8 +18,10 @@ import DomainRegistrationSuggestion from 'components/domains/domain-registration
 export class FeaturedDomainSuggestions extends Component {
 	static propTypes = {
 		cart: PropTypes.object,
+		fetchAlgo: PropTypes.string,
 		isSignupStep: PropTypes.bool,
 		primarySuggestion: PropTypes.object,
+		railcarSeed: PropTypes.string,
 		secondarySuggestion: PropTypes.object,
 		showPlaceholders: PropTypes.bool,
 	};
@@ -79,6 +81,10 @@ export class FeaturedDomainSuggestions extends Component {
 		} );
 	}
 
+	getFetchAlgorithm( suggestion ) {
+		return endsWith( suggestion.domain_name, '.wordpress.com' ) ? 'wpcom' : this.props.fetchAlgo;
+	}
+
 	hasMatchReasons() {
 		const { primarySuggestion = {}, secondarySuggestion = {} } = this.props;
 		return (
@@ -101,6 +107,9 @@ export class FeaturedDomainSuggestions extends Component {
 					<DomainRegistrationSuggestion
 						suggestion={ primarySuggestion }
 						isFeatured
+						railcarId={ `${ this.props.railcarSeed }-registration-suggestion-0` }
+						uiPosition={ 0 }
+						fetchAlgo={ this.getFetchAlgorithm( primarySuggestion ) }
 						{ ...childProps }
 					/>
 				) }
@@ -108,6 +117,9 @@ export class FeaturedDomainSuggestions extends Component {
 					<DomainRegistrationSuggestion
 						suggestion={ secondarySuggestion }
 						isFeatured
+						railcarId={ `${ this.props.railcarSeed }-registration-suggestion-1` }
+						uiPosition={ 1 }
+						fetchAlgo={ this.getFetchAlgorithm( secondarySuggestion ) }
 						{ ...childProps }
 					/>
 				) }


### PR DESCRIPTION
When we implemented #23384, I inadvertently forgot to implement proper TrainTracks analytics for the featured domains. This PR remedies this by properly attaching `railcarId` and `fetchAlgo` to the featured domain suggestion components.

# Testing instructions
1. Spin up this branch locally.
2. Navigate to the [domains registration page](http://calypso.localhost:3000/start/domains) with your [redux-devtools](https://github.com/reduxjs/redux-devtools) enabled browser.
3. With redux-devtools open, enter a domain search query.
4. In redux-devtools, ensure that you see 10 `ANALYTICS_EVENT_RECORD` events.
5. Ensure that each `ANALYTICS_EVENT_RECORD` event contains a proper railcar id at `meta.analytics[0].payload.properties.railcar` (e.g. `25e9241-registration-suggestion-2`). The suffixed number will correspond to `meta.analytics[0].payload.properties.ui_position`.
6. Ensure that each `ANALYTICS_EVENT_RECORD` event contains a proper fetch algorithm information at `meta.analytics[0].payload.properties.fetch_algo` (e.g. `wpcom` or `group_1/v1`).