### PR TITLE
Reader: replace componentWillMount

### DIFF
--- a/client/reader/search-stream/suggestion.jsx
+++ b/client/reader/search-stream/suggestion.jsx
@@ -20,7 +20,7 @@ export class Suggestion extends Component {
 		railcar: PropTypes.object,
 	};
 
-	componentWillMount() {
+	componentDidMount() {
 		const { railcar } = this.props;
 		analytics.tracks.recordEvent( 'calypso_traintracks_render', railcar );
 	}

--- a/client/reader/stream/post-unavailable.jsx
+++ b/client/reader/stream/post-unavailable.jsx
@@ -12,7 +12,7 @@ import config from 'config';
 import Card from 'components/card';
 
 class PostUnavailable extends React.PureComponent {
-	componentWillMount() {
+	componentDidMount() {
 		this.errors = {
 			unauthorized: this.props.translate(
 				'This is a post on a private site that you’re following, but not currently a member of.' +

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -36,7 +36,7 @@ class TagStream extends React.Component {
 
 	_isMounted = false;
 
-	componentWillMount() {
+	componentDidMount() {
 		const self = this;
 		this._isMounted = true;
 		// can't use arrows with asyncRequire


### PR DESCRIPTION
Replaces the now-deprecated lifecycle method `componentWillMount` in `client/reader`.

https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html

No functional changes.