### PR TITLE
CircleCI: Fail on multiline command failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
       - run:
           name: Create Directories for Results and Artifacts
           command: |
+            set -o errexit
             mkdir -p $CIRCLE_ARTIFACTS
             mkdir -p $CIRCLE_TEST_REPORTS
 
@@ -56,6 +57,7 @@ jobs:
       - run:
           name: Build calypso-strings.pot
           command: |
+            set -o errexit
             npm run translate; mkdir -p $CIRCLE_ARTIFACTS/translate
             exit 1
             mv calypso-strings.pot $CIRCLE_ARTIFACTS/translate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,7 @@ jobs:
           name: Build calypso-strings.pot
           command: |
             npm run translate; mkdir -p $CIRCLE_ARTIFACTS/translate
+            exit 1
             mv calypso-strings.pot $CIRCLE_ARTIFACTS/translate
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,14 +63,14 @@ jobs:
       - run:
           name: Build New Strings .pot
           command: |
+            set -o errexit
             git clone https://github.com/Automattic/gp-localci-client.git
             bash gp-localci-client/generate-new-strings-pot.sh $CIRCLE_BRANCH $CIRCLE_SHA1 $CIRCLE_ARTIFACTS/translate
             rm -rf gp-localci-client
 
       - run:
           name: Run Integration Tests
-          command: |
-            bin/run-integration $(circleci tests glob "bin/**/integration/*.js" "client/**/integration/*.js" "server/**/integration/*.js" | circleci tests split --split-by=timings)
+          command: bin/run-integration $(circleci tests glob "bin/**/integration/*.js" "client/**/integration/*.js" "server/**/integration/*.js" | circleci tests split --split-by=timings)
 
       - run:
           name: Lint Config Keys
@@ -78,23 +78,19 @@ jobs:
 
       - run:
           name: Lint Client and Server
-          command: |
-            ./node_modules/.bin/eslint-eslines $(git diff --name-only origin/master... | grep -E '^(client|server)' | grep -E '\.jsx?$' | circleci tests split)
+          command: ./node_modules/.bin/eslint-eslines $(git diff --name-only origin/master... | grep -E '^(client|server)' | grep -E '\.jsx?$' | circleci tests split)
 
       - run:
           name: Run Client Tests
-          command: |
-              npm run test-client:ci $(circleci tests glob "client/**/test/*.js" "client/**/test/*.jsx" | circleci tests split --split-by=timings)
+          command: npm run test-client:ci $(circleci tests glob "client/**/test/*.js" "client/**/test/*.jsx" | circleci tests split --split-by=timings)
 
       - run:
           name: Run Server Tests
-          command: |
-              npm run test-server:ci $(circleci tests glob "server/**/test/*.js" "server/**/test/*.jsx" | circleci tests split --split-by=timings)
+          command: npm run test-server:ci $(circleci tests glob "server/**/test/*.js" "server/**/test/*.jsx" | circleci tests split --split-by=timings)
 
       - run:
           name: Gather Test Results
-          command: |
-            find . -type f -regex  ".*/test-results.*\.xml" -exec cp {} $CIRCLE_TEST_REPORTS/ \;
+          command: find . -type f -regex  ".*/test-results.*\.xml" -exec cp {} $CIRCLE_TEST_REPORTS/ \;
           when: always
 
       - store_test_results:


### PR DESCRIPTION
If one step of a multiline command fails in CircleCI, the job won't fail.

Add `set -o errexit` to ensure that a single failing command that's part of a multiline command makes the entire job fail.