### PR TITLE
Show desktop download only when user is not using the desktop app

### DIFF
--- a/client/me/get-apps/index.jsx
+++ b/client/me/get-apps/index.jsx
@@ -15,6 +15,7 @@ import GetAppsIllustration from './illustration.jsx';
 import DesktopDownloadCard from './desktop-download-card.jsx';
 import MobileDownloadCard from './mobile-download-card.jsx';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import config from 'config';
 
 export const GetApps = () => {
 	return (
@@ -23,7 +24,7 @@ export const GetApps = () => {
 			<MeSidebarNavigation />
 			<GetAppsIllustration />
 			<MobileDownloadCard />
-			<DesktopDownloadCard />
+			{ ! config( 'env_id' ).startsWith( 'desktop' ) && <DesktopDownloadCard /> }
 		</Main>
 	);
 };


### PR DESCRIPTION
A minor detail but we shouldn't show the user the option to download the app when already using the desktop app. Instead just show the mobile app downloads.

### Screenshot
<img width="702" alt="downloads" src="https://user-images.githubusercontent.com/3265004/42996071-c4203ada-8c12-11e8-910f-45dd34872dc4.png">

Thanks to @jeremeylduvall for bringing this to my attention.

### How to test
#### Browser
- Open calypso
- Go to your profile -> Get Apps
- "Desktop App for [OS]" banner should be visible

#### Desktop App
- Point calypso submodule to this PR
- [Start app in dev mode ](https://github.com/Automattic/wp-desktop/blob/develop/docs/development.md#dev-mode)
- Go to your profile -> Get Apps
- "Desktop App for [OS]" banner should be hidden
 