### PR TITLE
Add core-js as dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "cookie": "0.3.1",
     "cookie-parser": "1.4.3",
     "copy-webpack-plugin": "4.5.2",
+    "core-js": "2.5.7",
     "cpf_cnpj": "0.2.0",
     "create-react-class": "15.6.3",
     "creditcards": "3.0.1",


### PR DESCRIPTION
Pins the version in top-level `node_modules` to 2.5.7, not a random version that happens to be promoted by NPM Install to the top-level directory.

Fixes a potential bug where `import from 'core-js'` statements generated by `babel-preset-env` can suddenly start using an old 1.x version.

Cherrypicked from the Lerna PR (#24788), where this issue happened. See https://github.com/Automattic/wp-calypso/pull/24788#issuecomment-406290939