### PR TITLE
Framework: Use dispatchRequestEx in data layer README

### DIFF
--- a/client/state/data-layer/README.md
+++ b/client/state/data-layer/README.md
@@ -152,7 +152,13 @@ const announceFailure( { dispatch, getState }, action, error ) => {
 };
 
 export default {
-	[ SPLINES_REQUEST ]: [ dispatchRequest( fetchSplines, addSplines, announceFailure ) ],
+	[ SPLINES_REQUEST ]: [
+		dispatchRequestEx( {
+			fetch: fetchSplines,
+			onSuccess: addSplines,
+			onError: announceFailure,
+		} ),
+	],
 }
 
 // middlware.js

--- a/client/state/data-layer/README.md
+++ b/client/state/data-layer/README.md
@@ -120,6 +120,8 @@ Let's look at a full example:
  */
 import { addSplines } from 'state/splines/actions';
 import { errorNotice } from 'state/notices/actions';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 
 /**
  * Transform the API response into consumble data

--- a/client/state/data-layer/README.md
+++ b/client/state/data-layer/README.md
@@ -116,6 +116,12 @@ Let's look at a full example:
  */
 
 /**
+ * Internal dependencies
+ */
+import { addSplines } from 'state/splines/actions';
+import { errorNotice } from 'state/notices/actions';
+
+/**
  * Transform the API response into consumble data
  */
 const apiTransformer = data => data.splines;
@@ -148,7 +154,7 @@ const handleSuccess = ( action, splines ) =>
  * @TODO: Explain why and provide better alternatives
  */
 const announceFailure = () =>
-	createError( `Could not retrieve the splines. Please try again.` );
+	errorNotice( `Could not retrieve the splines. Please try again.` );
 
 export default {
 	[ SPLINES_REQUEST ]: [

--- a/client/state/data-layer/README.md
+++ b/client/state/data-layer/README.md
@@ -114,49 +114,49 @@ Let's look at a full example:
  * retry if it fails (up to a certain point where
  * it will give up and launch the failure handler)
  */
-const fetchSplines = ( { dispatch }, action ) => {
-	dispatch( http( {
-		method: 'GET',
-		apiVersion: 'v1.1',
-		path: '/splines',
-		query: {
-			site_id: action.siteId,
-		}
-	}, action ) );
+
+/**
+ * Transform the API response into consumble data
+ */
+const apiTransformer = data => data.splines;
+
+/**
+ * Issue the HTTP request to fetch the splines
+ */
+const fetchSplines = action =>
+	http(
+		{
+			method: 'GET',
+			apiVersion: 'v1.1',
+			path: '/splines',
+			query: {
+				site_id: action.siteId,
+			},
+		}, action
+	);
 };
 
 /**
  * Take spline data from API request and inject into state
- *
- * If the data is invalid we can abort and announce the failure
  */
-const addSplines = ( store, action, responseData ) => {
-	const splines = fromApi( responseData );
-	
-	if ( ! splines ) {
-		return announceFailure( store, action );
-	}
-	
-	splines.forEach( spline => dispatch( addSpline( action.siteId, spline ) ) );
-};
+const handleSuccess = ( action, splines ) =>
+	addSplines( action.siteId, splines );
 
 /**
  * Notify customer that we failed to get splines for site
  *
  * @TODO: Explain why and provide better alternatives
  */
-const announceFailure( { dispatch, getState }, action, error ) => {
-	const siteName = getSiteName( getState(), action.siteId );
-
-	dispatch( createError( `Could not retrieve the splines for ${ siteName }. Please try again.` ) );
-};
+const announceFailure = () =>
+	createError( `Could not retrieve the splines. Please try again.` );
 
 export default {
 	[ SPLINES_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: fetchSplines,
-			onSuccess: addSplines,
+			onSuccess: handleSuccess,
 			onError: announceFailure,
+			fromApi: apiTransformer,
 		} ),
 	],
 }


### PR DESCRIPTION
This PR updates the data layer readme example to use `dispatchRequestEx` instead of `dispatchRequest`. This should hopefully help us to reduce usage of `dispatchRequest` in new code.

See #25121.