### PR TITLE
Framework: Use dispatchRequestEx for user devices

### DIFF
--- a/client/state/data-layer/wpcom/me/devices/index.js
+++ b/client/state/data-layer/wpcom/me/devices/index.js
@@ -11,7 +11,7 @@ import { keyBy } from 'lodash';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { USER_DEVICES_REQUEST } from 'state/action-types';
 import { userDevicesAdd } from 'state/user-devices/actions';
 import { errorNotice } from 'state/notices/actions';
@@ -25,45 +25,47 @@ const devicesFromApi = devices =>
 /**
  * Dispatches a request to fetch all available WordPress.com plans
  *
- * @param   {Function} dispatch Redux dispatcher
+ * @param   {Object} action Redux action
  * @returns {Object} dispatched http action
  */
-export const requestUserDevices = ( { dispatch }, action ) =>
-	dispatch(
-		http(
-			{
-				apiVersion: '1.1',
-				method: 'GET',
-				path: '/notifications/devices',
-			},
-			action
-		)
+export const requestUserDevices = action =>
+	http(
+		{
+			apiVersion: '1.1',
+			method: 'GET',
+			path: '/notifications/devices',
+		},
+		action
 	);
 
 /**
  * Dispatches a user devices add action then the request for user devices succeeded.
  *
- * @param   {Function} dispatch Redux dispatcher
  * @param   {Object}   action   Redux action
  * @param   {Array}    devices  array of raw device data returned from the endpoint
- * @returns {Object}            disparched user devices add action
+ * @returns {Object}            user devices add action
  */
-export const handleSuccess = ( { dispatch }, action, devices ) =>
-	dispatch(
-		userDevicesAdd( {
-			devices: devicesFromApi( devices ),
-		} )
-	);
+export const handleSuccess = ( action, devices ) =>
+	userDevicesAdd( {
+		devices,
+	} );
 
 /**
- * Dispatches a error notice action when the request for user devices fails
+ * Dispatches an error notice action when the request for user devices fails
  *
  * @param   {Function} dispatch Redux dispatcher
  * @returns {Object}            dispatched error notice action
  */
-export const handleError = ( { dispatch } ) =>
-	dispatch( errorNotice( translate( "We couldn't load your devices, please try again." ) ) );
+export const handleError = () =>
+	errorNotice( translate( "We couldn't load your devices, please try again." ) );
 
 export default {
-	[ USER_DEVICES_REQUEST ]: [ dispatchRequest( requestUserDevices, handleSuccess, handleError ) ],
+	[ USER_DEVICES_REQUEST ]: [
+		dispatchRequestEx( {
+			fetch: requestUserDevices,
+			onSuccess: handleSuccess,
+			onError: handleError,
+			fromApi: devicesFromApi,
+		} ),
+	],
 };

--- a/client/state/data-layer/wpcom/me/devices/index.js
+++ b/client/state/data-layer/wpcom/me/devices/index.js
@@ -26,7 +26,7 @@ const devicesFromApi = devices =>
  * Dispatches a request to fetch all available WordPress.com plans
  *
  * @param   {Object} action Redux action
- * @returns {Object} dispatched http action
+ * @returns {Object} http request action
  */
 export const requestUserDevices = action =>
 	http(
@@ -42,19 +42,15 @@ export const requestUserDevices = action =>
  * Dispatches a user devices add action then the request for user devices succeeded.
  *
  * @param   {Object}   action   Redux action
- * @param   {Array}    devices  array of raw device data returned from the endpoint
- * @returns {Object}            user devices add action
+ * @param   {Object}   devices  Devices, returned from the endpoint
+ * @returns {Object}            User devices add action
  */
-export const handleSuccess = ( action, devices ) =>
-	userDevicesAdd( {
-		devices,
-	} );
+export const handleSuccess = ( action, devices ) => userDevicesAdd( devices );
 
 /**
  * Dispatches an error notice action when the request for user devices fails
  *
- * @param   {Function} dispatch Redux dispatcher
- * @returns {Object}            dispatched error notice action
+ * @returns {Object}            Error notice action
  */
 export const handleError = () =>
 	errorNotice( translate( "We couldn't load your devices, please try again." ) );

--- a/client/state/data-layer/wpcom/me/devices/index.js
+++ b/client/state/data-layer/wpcom/me/devices/index.js
@@ -23,7 +23,7 @@ const devicesFromApi = devices =>
 	);
 
 /**
- * Dispatches a request to fetch all available WordPress.com plans
+ * Returns an action for HTTP request to fetch all available WordPress.com plans
  *
  * @param   {Object} action Redux action
  * @returns {Object} http request action
@@ -39,7 +39,7 @@ export const requestUserDevices = action =>
 	);
 
 /**
- * Dispatches a user devices add action then the request for user devices succeeded.
+ * Returns a user devices add action then the request for user devices succeeded.
  *
  * @param   {Object}   action   Redux action
  * @param   {Object}   devices  Devices, returned from the endpoint
@@ -48,7 +48,7 @@ export const requestUserDevices = action =>
 export const handleSuccess = ( action, devices ) => userDevicesAdd( devices );
 
 /**
- * Dispatches an error notice action when the request for user devices fails
+ * Returns an error notice action when the request for user devices fails
  *
  * @returns {Object}            Error notice action
  */

--- a/client/state/data-layer/wpcom/me/devices/test/index.js
+++ b/client/state/data-layer/wpcom/me/devices/test/index.js
@@ -23,7 +23,10 @@ describe( 'requestUserDevices()', () => {
 
 describe( 'handleSuccess()', () => {
 	test( 'should return an action to add user devices', () => {
-		const devices = [ { id: 1, name: 'Mobile Phone' }, { id: 2, name: 'Tablet' } ];
+		const devices = {
+			1: { id: 1, name: 'Mobile Phone' },
+			2: { id: 2, name: 'Tablet' },
+		};
 
 		const action = handleSuccess( null, devices );
 

--- a/client/state/data-layer/wpcom/me/devices/test/index.js
+++ b/client/state/data-layer/wpcom/me/devices/test/index.js
@@ -1,72 +1,48 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-import { spy } from 'sinon';
-
-/**
  * Internal dependencies
  */
 import { requestUserDevices, handleSuccess, handleError } from '../';
 import { NOTICE_CREATE, USER_DEVICES_ADD } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
-describe( 'wpcom-api', () => {
-	describe( 'user devices', () => {
-		describe( '#requestUserDevices', () => {
-			test( 'should dispatch HTTP request to the users devices endpoint', () => {
-				const dispatch = spy();
+describe( 'requestUserDevices()', () => {
+	test( 'should return an action for an HTTP request to the users devices endpoint', () => {
+		const action = requestUserDevices();
 
-				requestUserDevices( { dispatch } );
+		expect( action ).toEqual(
+			http( {
+				apiVersion: '1.1',
+				method: 'GET',
+				path: '/notifications/devices',
+			} )
+		);
+	} );
+} );
 
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith(
-					http( {
-						apiVersion: '1.1',
-						method: 'GET',
-						path: '/notifications/devices',
-					} )
-				);
-			} );
+describe( 'handleSuccess()', () => {
+	test( 'should return an action to add user devices', () => {
+		const devices = [ { id: 1, name: 'Mobile Phone' }, { id: 2, name: 'Tablet' } ];
+
+		const action = handleSuccess( null, devices );
+
+		expect( action ).toEqual( {
+			type: USER_DEVICES_ADD,
+			devices,
 		} );
+	} );
+} );
 
-		describe( '#handleSuccess', () => {
-			test( 'should dispatch user devices updates', () => {
-				const devices = [
-					{ device_id: 1, device_name: 'Mobile Phone' },
-					{ device_id: 2, device_name: 'Tablet' },
-				];
-				const dispatch = spy();
+describe( 'handleError()', () => {
+	test( 'should return an action for an error notice', () => {
+		const action = handleError();
 
-				handleSuccess( { dispatch }, null, devices );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith( {
-					type: USER_DEVICES_ADD,
-					devices: {
-						1: { id: 1, name: 'Mobile Phone' },
-						2: { id: 2, name: 'Tablet' },
-					},
-				} );
-			} );
-		} );
-
-		describe( '#handleError', () => {
-			test( 'should dispatch error notice', () => {
-				const dispatch = spy();
-
-				handleError( { dispatch } );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWithMatch( {
-					type: NOTICE_CREATE,
-					notice: {
-						status: 'is-error',
-					},
-				} );
-			} );
+		expect( action ).toMatchObject( {
+			type: NOTICE_CREATE,
+			notice: {
+				status: 'is-error',
+			},
 		} );
 	} );
 } );

--- a/client/state/user-devices/actions.js
+++ b/client/state/user-devices/actions.js
@@ -18,4 +18,4 @@ export const requestUserDevices = () => ( { type: USER_DEVICES_REQUEST } );
  * @param  {Object} devices Object containing one or more devices, keyed by id.
  * @return {Object}         Action object
  */
-export const userDevicesAdd = ( { devices } ) => ( { type: USER_DEVICES_ADD, devices } );
+export const userDevicesAdd = devices => ( { type: USER_DEVICES_ADD, devices } );

--- a/client/state/user-devices/test/actions.js
+++ b/client/state/user-devices/test/actions.js
@@ -28,7 +28,7 @@ describe( 'actions', () => {
 				1: { id: 1, name: 'Mobile Phone' },
 				2: { id: 2, name: 'Tablet' },
 			};
-			const action = userDevicesAdd( { devices } );
+			const action = userDevicesAdd( devices );
 
 			expect( action ).to.eql( {
 				type: USER_DEVICES_ADD,

--- a/client/state/user-devices/test/actions.js
+++ b/client/state/user-devices/test/actions.js
@@ -1,39 +1,32 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import { requestUserDevices, userDevicesAdd } from '../actions';
 import { USER_DEVICES_REQUEST, USER_DEVICES_ADD } from 'state/action-types';
 
-describe( 'actions', () => {
-	describe( '#requestUserDevices()', () => {
-		test( 'should return an action object', () => {
-			const action = requestUserDevices();
+describe( 'requestUserDevices()', () => {
+	test( 'should return an action object', () => {
+		const action = requestUserDevices();
 
-			expect( action ).to.eql( {
-				type: USER_DEVICES_REQUEST,
-			} );
+		expect( action ).toEqual( {
+			type: USER_DEVICES_REQUEST,
 		} );
 	} );
+} );
 
-	describe( '#userDevicesRequestSuccess()', () => {
-		test( 'should return an action object', () => {
-			const devices = {
-				1: { id: 1, name: 'Mobile Phone' },
-				2: { id: 2, name: 'Tablet' },
-			};
-			const action = userDevicesAdd( devices );
+describe( 'userDevicesAdd()', () => {
+	test( 'should return an action object', () => {
+		const devices = {
+			1: { id: 1, name: 'Mobile Phone' },
+			2: { id: 2, name: 'Tablet' },
+		};
+		const action = userDevicesAdd( devices );
 
-			expect( action ).to.eql( {
-				type: USER_DEVICES_ADD,
-				devices,
-			} );
+		expect( action ).toEqual( {
+			type: USER_DEVICES_ADD,
+			devices,
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR updates user devices to use `dispatchRequestEx` instead of `dispatchRequest`, as part of #25121. It also uses the chance to update the tests to use Jest and do some minor simplifications and cleanups.

There should be no visual, functional or behavioral changes introduced by this PR.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/me/notifications
* Verify all notification devices for sites load properly like they did before.
* Go to http://calypso.localhost:3000/me/notifications/comments
* Verify comment notification devices load properly like they did before.
* Make sure to test with a clean Redux state.
* Verify all tests pass: `npm run test-client devices`