### PR TITLE
Memberships: remove 1 week interval

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/membershipProductForm.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/membershipProductForm.jsx
@@ -235,7 +235,6 @@ class ProductForm extends Component {
 					label={ translate( 'Renewal Schedule' ) }
 					component={ FormSelect }
 				>
-					<option value="1 week">{ translate( '1 Week' ) }</option>
 					<option value="1 month">{ translate( '1 Month' ) }</option>
 					<option value="1 year">{ translate( '1 Year' ) }</option>
 				</ReduxFormFieldset>


### PR DESCRIPTION
In memberships, there are only 1 month and 1 year renewal schedules.
1 week does not work. We need to remove it from the UI

## Testing

Go through "add a plan" flow from here:

More details how to test in p89M8K-4I-p2