### PR TITLE
Framework: Use dispatchRequestEx for notification settings

### DIFF
--- a/client/state/data-layer/wpcom/me/notification/settings/index.js
+++ b/client/state/data-layer/wpcom/me/notification/settings/index.js
@@ -3,65 +3,59 @@
 /**
  * External dependencies
  */
-
 import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { NOTIFICATION_SETTINGS_REQUEST } from 'state/action-types';
 import { updateNotificationSettings } from 'state/notification-settings/actions';
 import { errorNotice } from 'state/notices/actions';
 
 /**
- * Dispatches a request to fetch the current user notification settings
+ * Returns an action for HTTP request to fetch the current user notification settings
  *
- * @param   {Function} dispatch Redux dispatcher
  * @param   {Object}   action   Redux action
- * @returns {Object}            dispatched http action
+ * @returns {Object}            http action
  */
-export const requestNotificationSettings = ( { dispatch }, action ) =>
-	dispatch(
-		http(
-			{
-				apiVersion: '1.1',
-				method: 'GET',
-				path: '/me/notifications/settings',
-			},
-			action
-		)
+export const requestNotificationSettings = action =>
+	http(
+		{
+			apiVersion: '1.1',
+			method: 'GET',
+			path: '/me/notifications/settings',
+		},
+		action
 	);
 
 /**
- * Dispatches a notification settings receive action then the request succeeded.
+ * Returns a notification settings receive action then the request succeeded.
  *
- * @param   {Function} dispatch  Redux dispatcher
  * @param   {Object}   action    Redux action
  * @param   {Object}   settings  raw notification settings object returned by the endpoint
- * @returns {Object}             disparched user devices add action
+ * @returns {Object}             user devices add action
  */
-export const updateSettings = ( { dispatch }, action, settings ) =>
-	dispatch(
-		updateNotificationSettings( {
-			settings,
-		} )
-	);
+export const updateSettings = ( action, settings ) =>
+	updateNotificationSettings( {
+		settings,
+	} );
 
 /**
- * Dispatches a error notice action when the request fails
+ * Returns an error notice action when the request fails
  *
- * @param   {Function} dispatch Redux dispatcher
- * @returns {Object}            dispatched error notice action
+ * @returns {Object}   error notice action
  */
-export const handleError = ( { dispatch } ) =>
-	dispatch(
-		errorNotice( translate( "We couldn't load your notification settings, please try again." ) )
-	);
+export const handleError = () =>
+	errorNotice( translate( "We couldn't load your notification settings, please try again." ) );
 
 export default {
 	[ NOTIFICATION_SETTINGS_REQUEST ]: [
-		dispatchRequest( requestNotificationSettings, updateSettings, handleError ),
+		dispatchRequestEx( {
+			fetch: requestNotificationSettings,
+			onSuccess: updateSettings,
+			onError: handleError,
+		} ),
 	],
 };

--- a/client/state/data-layer/wpcom/me/notification/settings/index.js
+++ b/client/state/data-layer/wpcom/me/notification/settings/index.js
@@ -35,12 +35,9 @@ export const requestNotificationSettings = action =>
  *
  * @param   {Object}   action    Redux action
  * @param   {Object}   settings  raw notification settings object returned by the endpoint
- * @returns {Object}             user devices add action
+ * @returns {Object}             notification settings update action
  */
-export const updateSettings = ( action, settings ) =>
-	updateNotificationSettings( {
-		settings,
-	} );
+export const updateSettings = ( action, settings ) => updateNotificationSettings( settings );
 
 /**
  * Returns an error notice action when the request fails

--- a/client/state/data-layer/wpcom/me/notification/settings/test/index.js
+++ b/client/state/data-layer/wpcom/me/notification/settings/test/index.js
@@ -1,26 +1,17 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-import { spy } from 'sinon';
-
-/**
  * Internal dependencies
  */
 import { requestNotificationSettings, updateSettings, handleError } from '../';
 import { NOTIFICATION_SETTINGS_UPDATE, NOTICE_CREATE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
-describe( '#requestNotificationSettings()', () => {
-	test( 'should dispatch HTTP request to the user notification settings endpoint', () => {
-		const dispatch = spy();
+describe( 'requestNotificationSettings()', () => {
+	test( 'should return an HTTP action to fetch the user notification settings', () => {
+		const action = requestNotificationSettings();
 
-		requestNotificationSettings( { dispatch } );
-
-		expect( dispatch ).to.have.been.calledOnce;
-		expect( dispatch ).to.have.been.calledWith(
+		expect( action ).toEqual(
 			http( {
 				apiVersion: '1.1',
 				method: 'GET',
@@ -30,28 +21,22 @@ describe( '#requestNotificationSettings()', () => {
 	} );
 } );
 
-describe( '#updateSettings()', () => {
-	test( 'should dispatch notification settings', () => {
-		const dispatch = spy();
+describe( 'updateSettings()', () => {
+	test( 'should return a notification settings update action', () => {
+		const action = updateSettings( null, {} );
 
-		updateSettings( { dispatch }, null, {} );
-
-		expect( dispatch ).to.have.been.calledOnce;
-		expect( dispatch ).to.have.been.calledWith( {
+		expect( action ).toEqual( {
 			type: NOTIFICATION_SETTINGS_UPDATE,
 			settings: {},
 		} );
 	} );
 } );
 
-describe( '#handleError()', () => {
-	test( 'should dispatch error notice', () => {
-		const dispatch = spy();
+describe( 'handleError()', () => {
+	test( 'should return an action for an error notice', () => {
+		const action = handleError();
 
-		handleError( { dispatch } );
-
-		expect( dispatch ).to.have.been.calledOnce;
-		expect( dispatch ).to.have.been.calledWithMatch( {
+		expect( action ).toMatchObject( {
 			type: NOTICE_CREATE,
 			notice: {
 				status: 'is-error',

--- a/client/state/data-layer/wpcom/me/notification/settings/test/index.js
+++ b/client/state/data-layer/wpcom/me/notification/settings/test/index.js
@@ -26,7 +26,7 @@ describe( 'updateSettings()', () => {
 		const settings = {};
 		const action = updateSettings( null, settings );
 
-		expect( action ).toBe( {
+		expect( action ).toEqual( {
 			type: NOTIFICATION_SETTINGS_UPDATE,
 			settings,
 		} );

--- a/client/state/data-layer/wpcom/me/notification/settings/test/index.js
+++ b/client/state/data-layer/wpcom/me/notification/settings/test/index.js
@@ -23,11 +23,12 @@ describe( 'requestNotificationSettings()', () => {
 
 describe( 'updateSettings()', () => {
 	test( 'should return a notification settings update action', () => {
-		const action = updateSettings( null, {} );
+		const settings = {};
+		const action = updateSettings( null, settings );
 
-		expect( action ).toEqual( {
+		expect( action ).toBe( {
 			type: NOTIFICATION_SETTINGS_UPDATE,
-			settings: {},
+			settings,
 		} );
 	} );
 } );

--- a/client/state/notification-settings/actions.js
+++ b/client/state/notification-settings/actions.js
@@ -18,7 +18,7 @@ export const requestNotificationSettings = () => ( { type: NOTIFICATION_SETTINGS
  * @param  {Object} settings User Notification Settings
  * @return {Object}          action object
  */
-export const updateNotificationSettings = ( { settings } ) => ( {
+export const updateNotificationSettings = settings => ( {
 	type: NOTIFICATION_SETTINGS_UPDATE,
 	settings,
 } );

--- a/client/state/notification-settings/test/actions.js
+++ b/client/state/notification-settings/test/actions.js
@@ -23,7 +23,7 @@ describe( 'actions', () => {
 	describe( '#updateNotificationSettings()', () => {
 		test( 'should return an action object', () => {
 			const settings = {};
-			const action = updateNotificationSettings( { settings } );
+			const action = updateNotificationSettings( settings );
 
 			expect( action ).to.eql( { type: NOTIFICATION_SETTINGS_UPDATE, settings } );
 		} );

--- a/client/state/notification-settings/test/actions.js
+++ b/client/state/notification-settings/test/actions.js
@@ -1,31 +1,24 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import { requestNotificationSettings, updateNotificationSettings } from '../actions';
 import { NOTIFICATION_SETTINGS_REQUEST, NOTIFICATION_SETTINGS_UPDATE } from 'state/action-types';
 
-describe( 'actions', () => {
-	describe( '#requestNotificationSettings()', () => {
-		test( 'should return an action object', () => {
-			const action = requestNotificationSettings();
+describe( 'requestNotificationSettings()', () => {
+	test( 'should return an action object', () => {
+		const action = requestNotificationSettings();
 
-			expect( action ).to.eql( { type: NOTIFICATION_SETTINGS_REQUEST } );
-		} );
+		expect( action ).toEqual( { type: NOTIFICATION_SETTINGS_REQUEST } );
 	} );
+} );
 
-	describe( '#updateNotificationSettings()', () => {
-		test( 'should return an action object', () => {
-			const settings = {};
-			const action = updateNotificationSettings( settings );
+describe( 'updateNotificationSettings()', () => {
+	test( 'should return an action object', () => {
+		const settings = {};
+		const action = updateNotificationSettings( settings );
 
-			expect( action ).to.eql( { type: NOTIFICATION_SETTINGS_UPDATE, settings } );
-		} );
+		expect( action ).toEqual( { type: NOTIFICATION_SETTINGS_UPDATE, settings } );
 	} );
 } );


### PR DESCRIPTION
This PR updates notification settings to use `dispatchRequestEx` instead of `dispatchRequest`, as part of #25121. It also uses the chance to update the tests to use Jest and do some minor simplifications and cleanups.

There should be no visual, functional or behavioral changes introduced by this PR.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/me/notifications
* Pass through all notification settings tabs and verify all notification settings for sites load properly like they did before.
* Make sure to test with a clean Redux state.
* Verify all tests pass:
  * `npm run test-client notification/settings`
  * `npm run test-client notification-settings`