### PR TITLE
[nudge-a-palooza] For clearer distinction, rename tests themesUpsells and pluginUpsells to themesNudgesUpdates and customPluginAndThemeLandingPages

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -4,8 +4,8 @@ export default {
 		datestamp: '20180711',
 		variations: {
 			sidebarUpsells: 20,
-			themesUpsells: 20,
-			pluginUpsells: 20,
+			themesNudgesUpdates: 20,
+			customPluginAndThemeLandingPages: 20,
 			plansBannerUpsells: 20,
 			control: 40,
 		},

--- a/client/my-sites/checkout/cart/cart-plan-ad-theme.jsx
+++ b/client/my-sites/checkout/cart/cart-plan-ad-theme.jsx
@@ -49,7 +49,7 @@ class CartPlanAdTheme extends Component {
 			hasOnlyAPremiumTheme &&
 			selectedSite &&
 			selectedSite.plan &&
-			abtest( 'nudgeAPalooza' ) === 'themesUpsells'
+			abtest( 'nudgeAPalooza' ) === 'themesNudgesUpdates'
 		);
 	};
 

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -563,7 +563,7 @@ export class PluginMeta extends Component {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		if (
 			config.isEnabled( 'upsell/nudge-a-palooza' ) &&
-			abtest( 'nudgeAPalooza' ) === 'pluginUpsells'
+			abtest( 'nudgeAPalooza' ) === 'customPluginAndThemeLandingPages'
 		) {
 			return (
 				<div className="plugin-meta__upgrade_nudge">

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -507,7 +507,7 @@ export class PluginsBrowser extends Component {
 
 		if (
 			config.isEnabled( 'upsell/nudge-a-palooza' ) &&
-			abtest( 'nudgeAPalooza' ) === 'pluginUpsells'
+			abtest( 'nudgeAPalooza' ) === 'customPluginAndThemeLandingPages'
 		) {
 			const href = '/feature/plugins/' + siteSlug;
 			return (

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -623,7 +623,7 @@ class ThemeSheet extends React.Component {
 			isPremium &&
 			! hasUnlimitedPremiumThemes &&
 			config.isEnabled( 'upsell/nudge-a-palooza' ) &&
-			abtest( 'nudgeAPalooza' ) === 'themesUpsells';
+			abtest( 'nudgeAPalooza' ) === 'themesNudgesUpdates';
 		if ( hasUpsellBanner ) {
 			// This is just for US-english audience and is not translated, remember to add translate() calls before
 			// removing a/b test check and enabling it for everyone

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -29,7 +29,8 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 
 	const displayUpsellBanner = ! requestingSitePlans && ! hasUnlimitedPremiumThemes;
 	const bannerLocationBelowSearch =
-		config.isEnabled( 'upsell/nudge-a-palooza' ) && abtest( 'nudgeAPalooza' ) === 'themesUpsells';
+		config.isEnabled( 'upsell/nudge-a-palooza' ) &&
+		abtest( 'nudgeAPalooza' ) === 'themesNudgesUpdates';
 
 	const upsellUrl = `/plans/${ siteSlug }`;
 	let upsellBanner = null;


### PR DESCRIPTION
Since test `pluginUpsells` is related also to redirecting users from "theme upload" upsell to a dedicated landing page, we are renaming it to `customPluginAndThemeLandingPages`.

Related P2 post: p9jf6J-Hl-p2

Test plan:
1. Put yourself in `themesNudgesUpdates` group of `nudgeAPalooza` test
1. Login to a free site
1. Go to /themes and confirm the upsell is dark
1. Click on a specific premium theme and confirm the upsell is dark
1. Add a premium theme to the cart and confirm there is an upsell in the sidebar
1. Put yourself in `customPluginAndThemeLandingPages` group of `nudgeAPalooza` test
1. Go to plugins browser
1. Click on the upsell and confirm it redirects to a landing page
1. Go to specific plugin page and click on the upsell, confirm it redirects to a landing page