### PR TITLE
Framework: Use dispatchRequestEx for reader teams

### DIFF
--- a/client/state/data-layer/wpcom/read/teams/index.js
+++ b/client/state/data-layer/wpcom/read/teams/index.js
@@ -1,41 +1,39 @@
 /** @format */
+
 /**
  * Internal dependencies
  */
 import { READER_TEAMS_REQUEST, READER_TEAMS_RECEIVE } from 'state/action-types';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
-export const handleTeamsRequest = ( { dispatch }, action ) => {
-	dispatch(
-		http(
-			{
-				method: 'GET',
-				path: '/read/teams',
-				apiVersion: '1.2',
-			},
-			action
-		)
+export const handleTeamsRequest = action =>
+	http(
+		{
+			method: 'GET',
+			path: '/read/teams',
+			apiVersion: '1.2',
+		},
+		action
 	);
-};
 
-export const teamRequestReceived = ( { dispatch }, action, apiResponse ) => {
-	dispatch( {
-		type: READER_TEAMS_RECEIVE,
-		payload: apiResponse,
-	} );
-};
+export const teamRequestReceived = ( action, apiResponse ) => ( {
+	type: READER_TEAMS_RECEIVE,
+	payload: apiResponse,
+} );
 
-export const teamRequestFailure = ( { dispatch }, error ) => {
-	dispatch( {
-		type: READER_TEAMS_RECEIVE,
-		payload: error,
-		error: true,
-	} );
-};
+export const teamRequestFailure = error => ( {
+	type: READER_TEAMS_RECEIVE,
+	payload: error,
+	error: true,
+} );
 
 export default {
 	[ READER_TEAMS_REQUEST ]: [
-		dispatchRequest( handleTeamsRequest, teamRequestReceived, teamRequestFailure ),
+		dispatchRequestEx( {
+			fetch: handleTeamsRequest,
+			onSuccess: teamRequestReceived,
+			onError: teamRequestFailure,
+		} ),
 	],
 };

--- a/client/state/data-layer/wpcom/read/teams/test/index.js
+++ b/client/state/data-layer/wpcom/read/teams/test/index.js
@@ -1,9 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-import { spy } from 'sinon';
 
 /**
  * Internal dependencies
@@ -12,49 +7,46 @@ import { handleTeamsRequest, teamRequestFailure, teamRequestReceived } from '../
 import { READER_TEAMS_RECEIVE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
-const apiResponse = { teams: [ { slug: 'a8c', title: 'Automattic' } ] };
+const action = { type: 'DUMMY_ACTION' };
 
-describe( 'wpcom-api', () => {
-	describe( 'teams request', () => {
-		const action = { type: 'DUMMY_ACTION' };
+test( 'should return an action for an HTTP request to teams endpoint', () => {
+	const result = handleTeamsRequest( action );
 
-		test( 'should dispatch HTTP request to teams endpoint', () => {
-			const dispatch = spy();
-			handleTeamsRequest( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith(
-				http(
-					{
-						method: 'GET',
-						path: '/read/teams',
-						apiVersion: '1.2',
-					},
-					action
-				)
-			);
-		} );
+	expect( result ).toEqual(
+		http(
+			{
+				method: 'GET',
+				path: '/read/teams',
+				apiVersion: '1.2',
+			},
+			action
+		)
+	);
+} );
 
-		test( 'should dispatch READER_TEAMS_RECEIVE action with error when request errors', () => {
-			const dispatch = spy();
-			teamRequestFailure( { dispatch }, action );
+test( 'should return a READER_TEAMS_RECEIVE action with error when request errors', () => {
+	const result = teamRequestFailure( action );
 
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith( {
-				type: READER_TEAMS_RECEIVE,
-				payload: action,
-				error: true,
-			} );
-		} );
+	expect( result ).toEqual( {
+		type: READER_TEAMS_RECEIVE,
+		payload: action,
+		error: true,
+	} );
+} );
 
-		test( 'should dispatch READER_TEAMS_RECEIVE action without error when request succeeds', () => {
-			const dispatch = spy();
-			teamRequestReceived( { dispatch }, action, apiResponse );
+test( 'should return a READER_TEAMS_RECEIVE action without error when request succeeds', () => {
+	const apiResponse = {
+		teams: [
+			{
+				slug: 'a8c',
+				title: 'Automattic',
+			},
+		],
+	};
+	const result = teamRequestReceived( action, apiResponse );
 
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith( {
-				type: READER_TEAMS_RECEIVE,
-				payload: apiResponse,
-			} );
-		} );
+	expect( result ).toEqual( {
+		type: READER_TEAMS_RECEIVE,
+		payload: apiResponse,
 	} );
 } );


### PR DESCRIPTION
This PR updates reader teams to use `dispatchRequestEx` instead of `dispatchRequest`, as part of #25121. It also uses the chance to update the tests to use Jest.

There should be no visual, functional or behavioral changes introduced by this PR.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/
* Make sure teams (a8c) load properly.
* Click on a team and make sure it loads its corresponding posts properly.
* Make sure to test with a clean Redux state.
* Verify all tests pass: `npm run test-client read/teams`