### PR TITLE
[nudge-a-palooza] Add feature flag check to updating sidebar nudge URL

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -31,6 +31,7 @@ import {
 import TrackComponentView from 'lib/analytics/track-component-view';
 import DomainToPaidPlanNotice from './domain-to-paid-plan-notice';
 import { abtest } from 'lib/abtest';
+import config from 'config';
 
 class SiteNotice extends React.Component {
 	static propTypes = {
@@ -100,7 +101,10 @@ class SiteNotice extends React.Component {
 
 		const { site, translate } = this.props;
 		let href = '/plans/' + site.slug;
-		if ( abtest( 'nudgeAPalooza' ) === 'plansBannerUpsells' ) {
+		if (
+			config.isEnabled( 'upsell/nudge-a-palooza' ) &&
+			abtest( 'nudgeAPalooza' ) === 'plansBannerUpsells'
+		) {
 			href = href + '/?discount=free_domain';
 		}
 


### PR DESCRIPTION
Related P2 post: p9jf6J-Hl-p2

We want to start all A/B tests at the same time when they are all ready. For this reason we need to check a feature flag for each such test. This PR adds this check to sidebar's nudge that went live.

Test plan:
1. Get this PR locally, it's not possible to test it on calypso.live
1. Assign yourself to `plansBannerUpsell` variation of `nudgeAPalooza` test
1. Confirm that "Free domain with plan" upsell nudge in the sidebar links to the plans page with "?discount=free_domain" addition
1. Disable `upsell/nudge-a-palooza` feature flag in `config/development.json`
1. Restart calypso server so it reloads the configuration
1. Confirm that sidebar upsell nudge no longer has the `discount=` parameter