### PR TITLE
Purchases: Prevent widow on plan purchase

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -86,7 +86,7 @@ class CheckoutThankYouHeader extends PureComponent {
 		if ( isPlan( primaryPurchase ) ) {
 			return translate(
 				'Your site is now on the {{strong}}%(productName)s{{/strong}} plan. ' +
-					"It's doing somersaults in excitement!",
+					preventWidows( "It's doing somersaults in excitement!" ),
 				{
 					args: { productName: primaryPurchase.productName },
 					components: { strong: <strong /> },


### PR DESCRIPTION
This is a quick fix for #26051. It uses [an internal function `preventWidow`](https://github.com/Automattic/wp-calypso/blob/master/client/lib/formatting/index.js#L56) on the success message we show after a plan purchase to prevent a single word from getting bumped to the next line.

It's a bit of a hack in some ways because we're only using it on the latter half of the string. `preventWidow` is currently  set up to [only accept strings](https://github.com/Automattic/wp-calypso/blob/master/client/lib/formatting/index.js#L59). With `translate()` used with args and components (like this case), it outputs an object, not a string. Long-term, it would be great if we could modify the function to be used on translation strings with args and components.

### To test

1. Load this branch.
2. Buy a plan on a site and view the purchase page.

### Screenshot

**Before**

![42698202-ce3209a8-8682-11e8-8970-d92780c3ad9a](https://user-images.githubusercontent.com/7240478/43011212-cc8294ea-8c10-11e8-82fb-64381c85661a.png)

**After**

<img width="780" alt="screen shot 2018-07-20 at 11 09 44 am" src="https://user-images.githubusercontent.com/7240478/43011207-c6421038-8c10-11e8-944b-fb5fbd465c97.png">

I also tested this on small screens as well, and it looks good.

<img width="412" alt="screen shot 2018-07-23 at 6 29 16 am" src="https://user-images.githubusercontent.com/7240478/43076567-d7467396-8e41-11e8-8123-4f56e433bc4c.png">


Fixes: #26030 