### PR TITLE
CircleCI: Use single-branch shallow gp-localci-client checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
           name: Build New Strings .pot
           when: always
           command: |
-            git clone https://github.com/Automattic/gp-localci-client.git
+            git clone --single-branch --depth=1 https://github.com/Automattic/gp-localci-client.git
             bash gp-localci-client/generate-new-strings-pot.sh "$CIRCLE_BRANCH" "$CIRCLE_SHA1" "$CIRCLE_ARTIFACTS/translate"
             rm -rf gp-localci-client
       - store-artifacts-and-test-results


### PR DESCRIPTION
Do the shallowest possible checkout, we're not interested in the whole repo. Should keep things as quick as possible.

Alternatively, could https://github.com/Automattic/gp-localci-client/blob/master/generate-new-strings-pot.sh  just become a script in this repo? I can only find it being used in two places.