### PR TITLE
Editor: Defer mounting of children in Accordion.

### DIFF
--- a/client/components/accordion/index.jsx
+++ b/client/components/accordion/index.jsx
@@ -50,14 +50,20 @@ export default class Accordion extends Component {
 		this.props.onToggle( isExpanded );
 	};
 
+	_mountChildren = false;
+
 	render() {
 		const { className, icon, title, subtitle, status, children, e2eTitle } = this.props;
+		const isExpanded = this.state.isExpanded || this.props.forceExpand;
 		const classes = classNames( 'accordion', className, {
-			'is-expanded': this.state.isExpanded || this.props.forceExpand,
+			'is-expanded': isExpanded,
 			'has-icon': !! icon,
 			'has-subtitle': !! subtitle,
 			'has-status': !! status,
 		} );
+
+		// Keep children off the render tree until it's first expanded.
+		this._mountChildren = this._mountChildren || isExpanded;
 
 		return (
 			<div
@@ -76,9 +82,11 @@ export default class Accordion extends Component {
 					</button>
 					{ status && <AccordionStatus { ...status } /> }
 				</header>
-				<div className="accordion__content">
-					<div className="accordion__content-wrap">{ children }</div>
-				</div>
+				{ this._mountChildren && (
+					<div className="accordion__content">
+						<div className="accordion__content-wrap">{ children }</div>
+					</div>
+				) }
 			</div>
 		);
 	}

--- a/client/components/accordion/test/index.jsx
+++ b/client/components/accordion/test/index.jsx
@@ -115,21 +115,12 @@ describe( 'Accordion', () => {
 			expect( wrapper.state( 'isExpanded' ) ).toBe( false );
 		} );
 
-		test( 'should render as expected with a title and content when initially open', () => {
+		test( 'should render content when initially open', () => {
 			const wrapper = shallow(
 				<Accordion initialExpanded={ true } title="Section">
 					Content
 				</Accordion>
 			);
-
-			expect( wrapper.hasClass( 'accordion' ) ).toBe( true );
-			expect( wrapper.state( 'isExpanded' ) ).toBe( true );
-			expect( wrapper.hasClass( 'has-icon' ) ).toBe( false );
-			expect( wrapper.hasClass( 'has-subtitle' ) ).toBe( false );
-			expect( wrapper.find( '.accordion__icon' ) ).toHaveLength( 0 );
-			expect( wrapper.find( '.accordion__title' ).text() ).toBe( 'Section' );
-			expect( wrapper.find( '.accordion__subtitle' ) ).toHaveLength( 0 );
-			expect( wrapper.find( '.accordion__icon' ) ).toHaveLength( 0 );
 			expect( wrapper.find( '.accordion__content' ).text() ).toBe( 'Content' );
 		} );
 	} );

--- a/client/components/accordion/test/index.jsx
+++ b/client/components/accordion/test/index.jsx
@@ -18,7 +18,7 @@ describe( 'Accordion', () => {
 		AccordionStatus = require( '../status' );
 	} );
 
-	test( 'should render as expected with a title and content', () => {
+	test( 'should render as expected with a title but no content when initially closed', () => {
 		const wrapper = shallow( <Accordion title="Section">Content</Accordion> );
 
 		expect( wrapper.hasClass( 'accordion' ) ).toBe( true );
@@ -29,7 +29,7 @@ describe( 'Accordion', () => {
 		expect( wrapper.find( '.accordion__title' ).text() ).toBe( 'Section' );
 		expect( wrapper.find( '.accordion__subtitle' ) ).toHaveLength( 0 );
 		expect( wrapper.find( '.accordion__icon' ) ).toHaveLength( 0 );
-		expect( wrapper.find( '.accordion__content' ).text() ).toBe( 'Content' );
+		expect( wrapper.find( '.accordion__content' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should accept an icon prop to be rendered', () => {
@@ -113,6 +113,24 @@ describe( 'Accordion', () => {
 			expect( toggleSpy ).toHaveBeenCalledTimes( 1 );
 			expect( toggleSpy ).toHaveBeenCalledWith( false );
 			expect( wrapper.state( 'isExpanded' ) ).toBe( false );
+		} );
+
+		test( 'should render as expected with a title and content when initially open', () => {
+			const wrapper = shallow(
+				<Accordion initialExpanded={ true } title="Section">
+					Content
+				</Accordion>
+			);
+
+			expect( wrapper.hasClass( 'accordion' ) ).toBe( true );
+			expect( wrapper.state( 'isExpanded' ) ).toBe( true );
+			expect( wrapper.hasClass( 'has-icon' ) ).toBe( false );
+			expect( wrapper.hasClass( 'has-subtitle' ) ).toBe( false );
+			expect( wrapper.find( '.accordion__icon' ) ).toHaveLength( 0 );
+			expect( wrapper.find( '.accordion__title' ).text() ).toBe( 'Section' );
+			expect( wrapper.find( '.accordion__subtitle' ) ).toHaveLength( 0 );
+			expect( wrapper.find( '.accordion__icon' ) ).toHaveLength( 0 );
+			expect( wrapper.find( '.accordion__content' ).text() ).toBe( 'Content' );
 		} );
 	} );
 } );


### PR DESCRIPTION
The accordion was designed to create its entire render tree when mounting, and revealing/hiding it through CSS. This is a solid approach, but it can be improved by deferring the mounting of its children until it's actually opened for the first time.

The post editor has a sidebar which makes use of a number of accordions, each of which with a number of components. By making use of the approach in this PR, the amount of work in initializing the post editor can be drastically reduced, by culling a large portion of the render tree. The work of mounting each accordion's children can then be performed later, if needed, when it's actually opened, and when the main thread is likely under much less strain.

Initial opening of the post editor takes extra time, due to other factors, but subsequent reopens take only 38% of the total time they used to in my machine, after this PR is applied (303ms vs 788ms, average over 5 measurements with perfmon).