### PR TITLE
Build: Anchor eslintignore dirs to project root 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,9 +1,9 @@
 .vscode
-assets/
-bin/
-!bin/generate-proptypes-index.js
-build/
-docs/
-public/
+/assets/
+/bin/
+!/bin/generate-proptypes-index.js
+/build/
+/docs/
+/public/
 !.eslintrc.js
-server/devdocs/search-index.js
+/server/devdocs/search-index.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,6 @@
 .vscode
 /assets/
 /bin/
-!/bin/generate-proptypes-index.js
 /build/
 /docs/
 /public/


### PR DESCRIPTION
Directories like `client/components/button/docs/` were being ignored.
Add leading `/` to anchor ignores to project root.
Remove non-existent no-ignore rule on bin/generate-proptypes-index.js.

## Testing
Try putting eslint-invalid code into `component/**/docs/*.js` and verify that eslint detects on complains.

Verify that eslint continues to ignore directories like `/docs/` and `/bin/`.