### PR TITLE
Themes: Fix Current Theme and Banner z-index Site Picker

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -71,6 +71,7 @@ $z-layers: (
 		'.people-list-item__label': 1,
 		'.is-actionable .theme__active-focus': 1,
 		'.is-section-themes.focus-sidebar #secondary': 1,
+		'.is-section-themes.focus-sites #secondary': 1,
 		'.accessible-focus .current-theme__button:focus': 1,
 		'.signup-processing-screen__processing-step.is-processing:before': 1,
 		'.accessible-focus .theme__more-button button:focus': 1,

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -147,6 +147,7 @@
 }
 
 // prevent themes panel from appearing on top of the sidebar when you click back
-.is-section-themes.focus-sidebar #secondary {
+.is-section-themes.focus-sidebar #secondary,
+.is-section-themes.focus-sites #secondary {
 	z-index: z-index( 'root', '.is-section-themes.focus-sidebar #secondary' );
 }


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/26179, we fixed the Current theme card and Banner which were overlapping with the sidebar. However, this was still an issue if you switch to the Site Picker.

**Before:**
![screenshot 2018-07-20 14 05 21](https://user-images.githubusercontent.com/4924246/43025282-f4dc6852-8c25-11e8-9be0-c46e89456deb.png)

**After:**
![screenshot 2018-07-20 13 59 40](https://user-images.githubusercontent.com/4924246/43025077-2e4d6a6a-8c25-11e8-8b3b-9938aa8cd382.png)
