### PR TITLE
Pass the path for the 'use your domain' page in the props.

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -272,6 +272,7 @@ class DomainsStep extends React.Component {
 				basePath={ this.props.path }
 				mapDomainUrl={ this.getMapDomainUrl() }
 				transferDomainUrl={ this.getTransferDomainUrl() }
+				useYourDomainUrl={ this.getUseYourDomainUrl() }
 				onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }
 				onSave={ this.handleSave.bind( this, 'domainForm' ) }
 				offerUnavailableOption={ ! this.props.isDomainOnly }


### PR DESCRIPTION
As noted in p5XAZ9-1JH-p2, the path to a theme is sometimes incorrect. This was due to the URL for the "Use Your Domain" not being passed as a prop into the `RegisterDomainStep ` component. So, the URL was being built "on-the-fly" and the last path part was simply appended to the existing URL creating something such as: `https://wordpress.com/start/with-theme/domains-theme-preselected?ref=calypshowcase&theme=altofocus/use-your-domain/use-your-domain`

A new `/use-your-domain` was added each time that one of the links to the "Use Your Domain" page was clicked.

To test:

1. In an incognito browser window, visit `calypso.localhost:3000/themes`.
2. Select a theme by clicking on "Pick this design".
3. On the domain search page, click on "Already own a domain?"
4. Make sure that the Use Your Domain page is shown. (the page to select either transfer or mapping).

Repeat, but in step 3, enter a taken domain and select the "Yes, I own this domain" link just under the search box.

Repeat again, but in step 3, select the "Use a domain I own" link at the bottom of the page.
