### PR TITLE
Remove `secondary` field from `client/wordpress-com.js`

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -34,7 +34,7 @@ import QueryPreferences from 'components/data/query-preferences';
 import PropTypes from 'prop-types';
 import QuerySites from 'components/data/query-sites';
 import { isOffline } from 'state/application/selectors';
-import { hasSidebar, masterbarIsVisible } from 'state/ui/selectors';
+import { masterbarIsVisible } from 'state/ui/selectors';
 import InlineHelp from 'blocks/inline-help';
 import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
 import SitePreview from 'blocks/site-preview';
@@ -169,7 +169,6 @@ export default connect( state => {
 		isLoading,
 		isSupportUser: state.support.isSupportUser,
 		section,
-		hasSidebar: hasSidebar( state ),
 		isOffline: isOffline( state ),
 		currentLayoutFocus: getCurrentLayoutFocus( state ),
 		chatIsOpen: isHappychatOpen( state ),

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -10,7 +10,6 @@ const sections = [
 		paths: [ '/sites' ],
 		module: 'my-sites',
 		group: 'sites',
-		secondary: true,
 	},
 	{
 		name: 'customize',


### PR DESCRIPTION
Removes secondary field in `client/wordpress-com.js`

Removes hasSidebar field in `client/layout/index.jsx`

Resolves #25585 