### PR TITLE
Defer the initial request on QuerySiteStats.

### DIFF
--- a/client/components/data/query-site-stats/index.jsx
+++ b/client/components/data/query-site-stats/index.jsx
@@ -19,20 +19,20 @@ import { isRequestingSiteStatsForQuery } from 'state/stats/lists/selectors';
 import { isAutoRefreshAllowedForQuery } from 'state/stats/lists/utils';
 
 class QuerySiteStats extends Component {
-	UNSAFE_componentWillMount() {
-		this.deferredTimer = defer( () => this.request( this.props ) );
+	componentDidMount() {
+		this.deferredTimer = defer( () => this.request() );
 	}
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
+	componentDidUpdate( prevProps ) {
 		if (
-			this.props.siteId === nextProps.siteId &&
-			this.props.statType === nextProps.statType &&
-			shallowEqual( this.props.query, nextProps.query )
+			this.props.siteId === prevProps.siteId &&
+			this.props.statType === prevProps.statType &&
+			shallowEqual( this.props.query, prevProps.query )
 		) {
 			return;
 		}
 
-		this.request( nextProps );
+		this.request();
 	}
 
 	componentWillUnmount() {
@@ -40,13 +40,13 @@ class QuerySiteStats extends Component {
 		clearTimeout( this.deferredTimer );
 	}
 
-	request( props ) {
-		const { requesting, siteId, statType, query, heartbeat } = props;
+	request() {
+		const { requesting, siteId, statType, query, heartbeat } = this.props;
 		if ( requesting ) {
 			return;
 		}
 
-		props.requestSiteStats( siteId, statType, query );
+		this.props.requestSiteStats( siteId, statType, query );
 		this.clearInterval();
 		if ( heartbeat && isAutoRefreshAllowedForQuery( query ) ) {
 			this.interval = setInterval( this.heartbeatRequest, heartbeat );

--- a/client/components/data/query-site-stats/index.jsx
+++ b/client/components/data/query-site-stats/index.jsx
@@ -20,7 +20,7 @@ import { isAutoRefreshAllowedForQuery } from 'state/stats/lists/utils';
 
 class QuerySiteStats extends Component {
 	UNSAFE_componentWillMount() {
-		defer( () => this.request( this.props ) );
+		this.deferredTimer = defer( () => this.request( this.props ) );
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
@@ -37,6 +37,7 @@ class QuerySiteStats extends Component {
 
 	componentWillUnmount() {
 		this.clearInterval();
+		clearTimeout( this.deferredTimer );
 	}
 
 	request( props ) {

--- a/client/components/data/query-site-stats/index.jsx
+++ b/client/components/data/query-site-stats/index.jsx
@@ -9,6 +9,8 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import shallowEqual from 'react-pure-render/shallowEqual';
 
+import { defer } from 'lodash';
+
 /**
  * Internal dependencies
  */
@@ -17,11 +19,11 @@ import { isRequestingSiteStatsForQuery } from 'state/stats/lists/selectors';
 import { isAutoRefreshAllowedForQuery } from 'state/stats/lists/utils';
 
 class QuerySiteStats extends Component {
-	componentWillMount() {
-		this.request( this.props );
+	UNSAFE_componentWillMount() {
+		defer( () => this.request( this.props ) );
 	}
 
-	componentWillReceiveProps( nextProps ) {
+	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if (
 			this.props.siteId === nextProps.siteId &&
 			this.props.statType === nextProps.statType &&


### PR DESCRIPTION
Requests are performed asynchronously, but have a non-trivial synchronous setup time. Deferring the initial request allows us to schedule that setup time for later.

In pages with a large number of `QuerySiteStats`, like the Stats page, this allows the page to render earlier, improving responsiveness.

I measured a 200ms decrease (out of 750ms) in the `mouseup` event handler duration when navigating to the Stats page. Total loading time as measured by `perfmon` doesn't seem to be affected.