### PR TITLE
Defer expensive layout calcs for InfiniteScroll and StickyPanel.

### DIFF
--- a/client/components/infinite-scroll/README.md
+++ b/client/components/infinite-scroll/README.md
@@ -12,7 +12,7 @@ First, require the component with
 import InfiniteScroll from 'components/infinite-scroll';
 ```
 
-and in your component's `render` method, render it, passing a name of method that fetches next page.
+and in your component's `render` method, render it, passing a name of method that fetches next page. Be sure to place it at the bottom of your content list, so that it can serve as an anchor point for a new load.
 
 If there are conditions when next page should not be loaded (e.g. next page is already loading, or last page was reached, it must be checked in that method.
 
@@ -38,8 +38,8 @@ class List extends Component {
 	render() {
 		return (
 			<div>
-				<InfiniteScroll fetchNextPage={ this.fetchNextPage } />
 				{ this.props.items.map( this.renderItem ) }
+				<InfiniteScroll fetchNextPage={ this.fetchNextPage } />
 			</div>
 		);
 	}

--- a/client/components/infinite-scroll/index.js
+++ b/client/components/infinite-scroll/index.js
@@ -3,59 +3,92 @@
 /**
  * External dependencies
  */
-import { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { throttle, defer } from 'lodash';
+import afterLayoutFlush from 'lib/after-layout-flush';
 
 const SCROLL_CHECK_RATE_IN_MS = 400;
 
-export default class InfiniteScroll extends Component {
+export default class InfiniteScroll extends React.Component {
 	static propTypes = {
 		nextPageMethod: PropTypes.func.isRequired,
 	};
 
-	checkScrollPositionHandler = throttle(
-		() => this.checkScrollPosition( true ),
-		SCROLL_CHECK_RATE_IN_MS
-	);
+	observedElement = React.createRef();
 
 	componentDidMount() {
-		this.initialMount = true;
-		window.addEventListener( 'scroll', this.checkScrollPositionHandler );
-		this.deferredTimer = defer( () => this.checkScrollPosition( false ) );
+		this.hasIntersectionObserver = 'IntersectionObserver' in window;
+
+		if ( this.hasIntersectionObserver && this.observedElement.current ) {
+			this.observer = new IntersectionObserver( this.handleIntersection, {
+				rootMargin: '100%',
+				threshold: 1.0,
+			} );
+			this.observer.observe( this.observedElement.current );
+		} else {
+			window.addEventListener( 'scroll', this.checkScrollPositionHandler );
+			this.deferredTimer = defer( () => this.checkScrollPositionHandler( false ) );
+		}
 	}
 
 	componentDidUpdate() {
-		if ( this.initialMount ) {
-			this.initialMount = false;
-		} else {
-			this.checkScrollPosition( false );
+		if ( ! this.hasIntersectionObserver && ! this.deferredTimer ) {
+			this.deferredTimer = defer( () => this.checkScrollPositionHandler( false ) );
 		}
 	}
 
 	componentWillUnmount() {
+		// Clean up scroll codepath.
 		window.removeEventListener( 'scroll', this.checkScrollPositionHandler );
-		window.clearTimeout( this.deferredTimer );
+		this.clearTimers();
+
+		// Clean up IntersectionObserver codepath.
+		if ( this.observer ) {
+			this.observer.disconnect();
+		}
 	}
 
-	checkScrollPosition( triggeredByScroll ) {
-		const scrollPosition = window.pageYOffset;
-		const documentHeight = document.body.scrollHeight;
-		const viewportHeight = window.innerHeight;
-		const scrollOffset = 2 * viewportHeight;
-
-		if ( scrollPosition >= documentHeight - viewportHeight - scrollOffset ) {
-			// Consider all page fetches once user starts scrolling as triggered by scroll
-			// Same condition check is in components/infinite-list/scroll-helper loadNextPage
-			if ( scrollPosition > viewportHeight ) {
-				triggeredByScroll = true;
-			}
-
+	handleIntersection = entries => {
+		if ( entries && entries[ 0 ] && entries[ 0 ].isIntersecting ) {
+			const { boundingClientRect, rootBounds } = entries[ 0 ];
+			const triggeredByScroll = boundingClientRect.bottom >= rootBounds.bottom;
 			this.props.nextPageMethod( { triggeredByScroll } );
+		}
+	};
+
+	clearTimers() {
+		window.clearTimeout( this.deferredTimer );
+		this.deferredTimer = null;
+	}
+
+	checkScrollPositionHandler = throttle(
+		afterLayoutFlush( triggeredByScroll => this.checkScrollPosition( triggeredByScroll ) ),
+		SCROLL_CHECK_RATE_IN_MS
+	);
+
+	checkScrollPosition( triggeredByScroll ) {
+		if ( ! this.hasIntersectionObserver ) {
+			this.clearTimers();
+
+			const scrollPosition = window.pageYOffset;
+			const documentHeight = document.body.scrollHeight;
+			const viewportHeight = window.innerHeight;
+			const scrollOffset = 2 * viewportHeight;
+
+			if ( scrollPosition >= documentHeight - viewportHeight - scrollOffset ) {
+				// Consider all page fetches once user starts scrolling as triggered by scroll
+				// Same condition check is in components/infinite-list/scroll-helper loadNextPage
+				if ( scrollPosition > viewportHeight ) {
+					triggeredByScroll = true;
+				}
+
+				this.props.nextPageMethod( { triggeredByScroll } );
+			}
 		}
 	}
 
 	render() {
-		return null;
+		return <div ref={ this.observedElement } />;
 	}
 }

--- a/client/components/infinite-scroll/index.js
+++ b/client/components/infinite-scroll/index.js
@@ -22,7 +22,7 @@ export default class InfiniteScroll extends Component {
 	componentDidMount() {
 		this.initialMount = true;
 		window.addEventListener( 'scroll', this.checkScrollPositionHandler );
-		defer( () => this.checkScrollPosition( false ) );
+		this.deferredTimer = defer( () => this.checkScrollPosition( false ) );
 	}
 
 	componentDidUpdate() {
@@ -35,6 +35,7 @@ export default class InfiniteScroll extends Component {
 
 	componentWillUnmount() {
 		window.removeEventListener( 'scroll', this.checkScrollPositionHandler );
+		window.clearTimeout( this.deferredTimer );
 	}
 
 	checkScrollPosition( triggeredByScroll ) {

--- a/client/components/infinite-scroll/index.js
+++ b/client/components/infinite-scroll/index.js
@@ -5,7 +5,7 @@
  */
 import { Component } from 'react';
 import PropTypes from 'prop-types';
-import { throttle } from 'lodash';
+import { throttle, defer } from 'lodash';
 
 const SCROLL_CHECK_RATE_IN_MS = 400;
 
@@ -20,12 +20,17 @@ export default class InfiniteScroll extends Component {
 	);
 
 	componentDidMount() {
+		this.initialMount = true;
 		window.addEventListener( 'scroll', this.checkScrollPositionHandler );
-		this.checkScrollPosition( false );
+		defer( () => this.checkScrollPosition( false ) );
 	}
 
 	componentDidUpdate() {
-		this.checkScrollPosition( false );
+		if ( this.initialMount ) {
+			this.initialMount = false;
+		} else {
+			this.checkScrollPosition( false );
+		}
 	}
 
 	componentWillUnmount() {

--- a/client/components/infinite-scroll/index.js
+++ b/client/components/infinite-scroll/index.js
@@ -18,6 +18,7 @@ const propTypeDefinition = {
 
 class InfiniteScrollWithIntersectionObserver extends React.Component {
 	static propTypes = propTypeDefinition;
+	static displayName = 'InfiniteScroll';
 
 	observedElement = React.createRef();
 
@@ -77,6 +78,7 @@ class InfiniteScrollWithIntersectionObserver extends React.Component {
 
 class InfiniteScrollWithScrollEvent extends React.Component {
 	static propTypes = propTypeDefinition;
+	static displayName = 'InfiniteScroll';
 
 	componentDidMount() {
 		window.addEventListener( 'scroll', this.checkScrollPositionHandler );

--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { throttle } from 'lodash';
+import { throttle, defer } from 'lodash';
 import PropTypes from 'prop-types';
 import ReactDom from 'react-dom';
 import React from 'react';
@@ -33,14 +33,16 @@ export default class extends React.Component {
 	};
 
 	componentDidMount() {
-		// Determine and cache vertical threshold from rendered element's
-		// offset relative the document
-		this.threshold = ReactDom.findDOMNode( this ).offsetTop;
+		defer( () => {
+			// Determine and cache vertical threshold from rendered element's
+			// offset relative the document
+			this.threshold = ReactDom.findDOMNode( this ).offsetTop;
+			this.updateIsSticky();
+		} );
 		this.throttleOnResize = throttle( this.onWindowResize, 200 );
 
 		window.addEventListener( 'scroll', this.onWindowScroll );
 		window.addEventListener( 'resize', this.throttleOnResize );
-		this.updateIsSticky();
 	}
 
 	componentWillUnmount() {

--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import ReactDom from 'react-dom';
 import React from 'react';
 import classNames from 'classnames';
+import afterLayoutFlush from 'lib/after-layout-flush';
 
 /**
  * Internal dependencies
@@ -63,7 +64,7 @@ export default class extends React.Component {
 		} );
 	};
 
-	updateIsSticky = () => {
+	updateIsSticky = afterLayoutFlush( () => {
 		const isSticky = window.pageYOffset > this.threshold;
 
 		if (
@@ -80,7 +81,7 @@ export default class extends React.Component {
 				blockWidth: isSticky ? ReactDom.findDOMNode( this ).clientWidth : 0,
 			} );
 		}
-	};
+	} );
 
 	getBlockStyle = () => {
 		let offset;

--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -51,6 +51,7 @@ export default class extends React.Component {
 		window.removeEventListener( 'resize', this.throttleOnResize );
 		window.cancelAnimationFrame( this.rafHandle );
 		window.clearTimeout( this.deferredTimer );
+		this.updateIsSticky.cancel();
 	}
 
 	onWindowScroll = () => {

--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -33,7 +33,7 @@ export default class extends React.Component {
 	};
 
 	componentDidMount() {
-		defer( () => {
+		this.deferredTimer = defer( () => {
 			// Determine and cache vertical threshold from rendered element's
 			// offset relative the document
 			this.threshold = ReactDom.findDOMNode( this ).offsetTop;
@@ -49,6 +49,7 @@ export default class extends React.Component {
 		window.removeEventListener( 'scroll', this.onWindowScroll );
 		window.removeEventListener( 'resize', this.throttleOnResize );
 		window.cancelAnimationFrame( this.rafHandle );
+		window.clearTimeout( this.deferredTimer );
 	}
 
 	onWindowScroll = () => {

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -122,10 +122,10 @@ export class ThemesList extends React.Component {
 
 		return (
 			<div className="themes-list">
-				<InfiniteScroll nextPageMethod={ this.fetchNextPage } />
 				{ this.props.themes.map( this.renderTheme, this ) }
 				{ this.props.loading && this.renderLoadingPlaceholders() }
 				{ this.renderTrailingItems() }
+				<InfiniteScroll nextPageMethod={ this.fetchNextPage } />
 			</div>
 		);
 	}

--- a/client/components/themes-list/test/__snapshots__/index.jsx.snap
+++ b/client/components/themes-list/test/__snapshots__/index.jsx.snap
@@ -4,9 +4,6 @@ exports[`ThemesList should render a div with a className of "themes-list" 1`] = 
 <div
   className="themes-list"
 >
-  <InfiniteScroll
-    nextPageMethod={[Function]}
-  />
   <Connect(Localized(Theme))
     actionLabel=""
     active={false}
@@ -82,6 +79,9 @@ exports[`ThemesList should render a div with a className of "themes-list" 1`] = 
   <div
     className="themes-list__spacer"
     key="themes-list__spacer-10"
+  />
+  <InfiniteScroll
+    nextPageMethod={[Function]}
   />
 </div>
 `;

--- a/client/lib/after-layout-flush/index.js
+++ b/client/lib/after-layout-flush/index.js
@@ -18,7 +18,7 @@ export default function afterLayoutFlush( func ) {
 	let rafHandle = undefined;
 	let timeoutHandle = undefined;
 
-	const scheduleRAF = rafFunc => () => {
+	const scheduleRAF = rafFunc => ( ...args ) => {
 		// if a RAF is already scheduled and not yet executed, don't schedule another one
 		if ( rafHandle !== undefined ) {
 			return;
@@ -27,11 +27,11 @@ export default function afterLayoutFlush( func ) {
 		rafHandle = requestAnimationFrame( () => {
 			// clear the handle to signal that the scheduled RAF has been executed
 			rafHandle = undefined;
-			rafFunc();
+			rafFunc( ...args );
 		} );
 	};
 
-	const scheduleTimeout = timeoutFunc => () => {
+	const scheduleTimeout = timeoutFunc => ( ...args ) => {
 		// If a timeout is already scheduled and not yet executed, don't schedule another one.
 		// Multiple `requestAnimationFrame` handlers can be scheduled and executed before the
 		// browser decides to finally execute the timeout handler.
@@ -42,7 +42,7 @@ export default function afterLayoutFlush( func ) {
 		timeoutHandle = setTimeout( () => {
 			// clear the handle to signal that the timeout handler has been executed
 			timeoutHandle = undefined;
-			timeoutFunc();
+			timeoutFunc( ...args );
 		}, 0 );
 	};
 

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -363,11 +363,11 @@ class Pages extends Component {
 
 		return (
 			<div id="pages" className="pages__page-list">
-				<InfiniteScroll nextPageMethod={ this.fetchPages } />
 				{ showBlogPostsPage && (
 					<BlogPostsPage key="blog-posts-page" site={ site } pages={ pages } />
 				) }
 				{ rows }
+				<InfiniteScroll nextPageMethod={ this.fetchPages } />
 				{ this.props.lastPage && pages.length ? <ListEnd /> : null }
 			</div>
 		);

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -563,13 +563,13 @@ export class PluginsBrowser extends Component {
 		return (
 			<MainComponent wideLayout>
 				{ this.renderPageViewTracker() }
-				<InfiniteScroll nextPageMethod={ this.fetchNextPagePlugins } />
 				<NonSupportedJetpackVersionNotice />
 				{ this.renderDocumentHead() }
 				<SidebarNavigation />
 				{ this.renderUpgradeNudge() }
 				{ this.getPageHeaderView() }
 				{ this.getPluginBrowserContent() }
+				<InfiniteScroll nextPageMethod={ this.fetchNextPagePlugins } />
 			</MainComponent>
 		);
 	}


### PR DESCRIPTION
InfiniteScroll and StickyPanel perform expensive layout calculations on start, but they aren't actually needed until a scroll occurs.

Deferring the calculations allows them to happen after the initial event loop and thus the initial render, improving responsiveness.

These changes massively improve the event response time for navigating to the Themes page. The first time is affected by other factors, but the event response time on subsequent navigations is now ~500ms instead of ~1200ms on my machine.