### PR TITLE
[nudge-a-palooza] Add feature page

### DIFF
--- a/client/my-sites/feature-upsell/controller.js
+++ b/client/my-sites/feature-upsell/controller.js
@@ -10,6 +10,7 @@ import page from 'page';
  * Internal Dependencies
  */
 import {
+	FeaturesComponent,
 	PluginsUpsellComponent,
 	StoreUpsellComponent,
 	ThemesUpsellComponent,
@@ -42,6 +43,11 @@ const featurePageController = ( url, callback ) => {
 };
 
 export default {
+	features: featurePageController( '/feature', function( context, next ) {
+		context.primary = React.createElement( FeaturesComponent );
+		next();
+	} ),
+
 	storeUpsell: featurePageController( '/feature/store', function( context, next, siteFragment ) {
 		if ( canCurrentUserUseStore( context.store.getState() ) ) {
 			return page.redirect( '/store/' + siteFragment );

--- a/client/my-sites/feature-upsell/features.jsx
+++ b/client/my-sites/feature-upsell/features.jsx
@@ -1,0 +1,235 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import PurchaseDetail from 'components/purchase-detail';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { getSiteSlug } from 'state/sites/selectors';
+import { getCurrentPlan } from 'state/sites/plans/selectors';
+import DocumentHead from 'components/data/document-head';
+import TipInfo from '../../components/purchase-detail/tip-info';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+class FeaturesComponent extends Component {
+	static propTypes = {
+		trackTracksEvent: PropTypes.func.isRequired,
+		price: PropTypes.number,
+		loadingPrice: PropTypes.bool.isRequired,
+		selectedSite: PropTypes.object.isRequired,
+		selectedSiteSlug: PropTypes.string.isRequired,
+	};
+
+	render() {
+		return (
+			<div role="main" className="main is-wide-layout feature-upsell__main">
+				<PageViewTracker path={ '/feature/:site' } title="FeaturesList" />
+				<DocumentHead title={ 'Features' } />
+
+				<div className="feature-upsell__text-content">
+					<h2 className="feature-upsell__section-header">Personal plan features</h2>
+				</div>
+
+				<div className="product-purchase-features-list">{ this.renderPersonalFeatures() }</div>
+
+				<div className="feature-upsell__text-content">
+					<h2 className="feature-upsell__section-header">Premium plan features</h2>
+				</div>
+
+				<div className="product-purchase-features-list">{ this.renderPremiumFeatures() }</div>
+
+				<div className="feature-upsell__text-content">
+					<h2 className="feature-upsell__section-header">Business plan features</h2>
+				</div>
+
+				<div className="product-purchase-features-list">{ this.renderBusinessFeatures() }</div>
+			</div>
+		);
+	}
+
+	renderPersonalFeatures() {
+		const { translate } = this.props;
+		return (
+			<>
+				<div className="product-purchase-features-list__item">
+					<PurchaseDetail
+						icon={ <img alt="" src="/calypso/images/illustrations/jetpack-support.svg" /> }
+						title={ 'Priority support' }
+						description={
+							'Unlimited access to our world-class live chat and email support. No question is too big or too small!'
+						}
+					/>
+				</div>
+				<div className="product-purchase-features-list__item">
+					<PurchaseDetail
+						icon={ <img alt="" src="/calypso/images/illustrations/jetpack-apps.svg" /> }
+						title={ 'Custom site address' }
+						description={
+							'Make your site memorable and professional - choose a .com, .shop, or any other dot.'
+						}
+					/>
+				</div>
+				<div className="product-purchase-features-list__item">
+					<PurchaseDetail
+						icon={ <img alt="" src="/calypso/images/illustrations/ads-removed.svg" /> }
+						title={ translate( 'Advertising removed' ) }
+						description="All WordPress.com advertising is removed from your site."
+					/>
+				</div>
+			</>
+		);
+	}
+
+	renderPremiumFeatures() {
+		const { translate, selectedSite } = this.props;
+		return (
+			<>
+				{ this.renderPersonalFeatures() }
+
+				<div className="product-purchase-features-list__item">
+					<PurchaseDetail
+						icon={ <img alt="" src="/calypso/images/illustrations/google-adwords.svg" /> }
+						title={ '$100 for Google AdWords' }
+						description={ 'Attract new (and more!) traffic immediately with Google AdWords.' }
+						body={
+							<div className="google-voucher__initial-step">
+								<TipInfo
+									info={ 'Offer valid in US after spending the first $25 on Google AdWords.' }
+								/>
+							</div>
+						}
+					/>
+				</div>
+				<div className="product-purchase-features-list__item">
+					<PurchaseDetail
+						icon={ <img alt="" src="/calypso/images/illustrations/jetpack-themes.svg" /> }
+						title={ 'Access to premium themes' }
+						description={
+							'You don’t have to be a designer to make a beautiful site. Choose from a range of business-focused layouts created by pros.'
+						}
+						buttonText={ translate( 'Browse premium themes' ) }
+						href={ '/themes/' + selectedSite.slug }
+					/>
+				</div>
+				<div className="product-purchase-features-list__item">
+					<PurchaseDetail
+						icon={ <img alt="" src="/calypso/images/illustrations/jetpack-dashboard.svg" /> }
+						title={ 'Advanced design customizations' }
+						description={
+							'Take creative control with additional customization features - like color schemes and, background designs, or add completely ' +
+							'personal touches with your CSS code.'
+						}
+					/>
+				</div>
+				<div className="product-purchase-features-list__item">
+					<PurchaseDetail
+						icon={ <img alt="" src="/calypso/images/illustrations/jetpack-wordads.svg" /> }
+						title={ 'Simple payments' }
+						description={
+							'Accept credit card payments on your site with the click of a button! Sell products, take donations, ' +
+							'sell tickets - add payment buttons to any page right from the WordPress editor'
+						}
+					/>
+				</div>
+				<div className="product-purchase-features-list__item">
+					<PurchaseDetail
+						icon={ <img alt="" src="/calypso/images/illustrations/jetpack-video-hosting.svg" /> }
+						title={ translate( 'Video and audio posts' ) }
+						description={
+							'Enrich your posts and pages with video or audio. Upload as media ' +
+							'directly to your site.'
+						}
+					/>
+				</div>
+			</>
+		);
+	}
+
+	renderBusinessFeatures() {
+		const { translate } = this.props;
+		return (
+			<>
+				{ this.renderPremiumFeatures() }
+
+				<div className="product-purchase-features-list__item">
+					<PurchaseDetail
+						icon={ <img alt="" src="/calypso/images/illustrations/jetpack-concierge.svg" /> }
+						title={ 'A one-on-one session with us' }
+						description={
+							'Getting where you want is easier with an expert guide. Our experts will flatten out your learning curve.'
+						}
+					/>
+				</div>
+				<div className="product-purchase-features-list__item">
+					<PurchaseDetail
+						icon={ <img alt="" src="/calypso/images/illustrations/jetpack-apps.svg" /> }
+						title={ 'Install Plugins' }
+						description={
+							'Plugins are like smartphone apps for WordPress. They provide features like: ' +
+							'SEO and marketing, lead generation, appointment booking, and much, much more.'
+						}
+					/>
+				</div>
+				<div className="product-purchase-features-list__item">
+					<PurchaseDetail
+						icon={ <img alt="" src="/calypso/images/illustrations/jetpack-google-analytics.svg" /> }
+						title={ translate( 'Google Analytics' ) }
+						description={ translate(
+							"Complement WordPress.com's stats with Google's in-depth look at your visitors and traffic patterns."
+						) }
+					/>
+				</div>
+				<div className="product-purchase-features-list__item">
+					<PurchaseDetail
+						icon={
+							<img alt="" src="/calypso/images/illustrations/google-my-business-feature.svg" />
+						}
+						title={ translate( 'Google My Business' ) }
+						description={ translate(
+							'See how customers find you on Google -- and whether they visited your site and looked for more info on your business -- by connecting to a Google My Business location.'
+						) }
+					/>
+				</div>
+				<div className="product-purchase-features-list__item">
+					<PurchaseDetail
+						icon={ <img alt="" src="/calypso/images/illustrations/jetpack-search.svg" /> }
+						title={ translate( 'Jetpack search' ) }
+						description={ translate(
+							'Replace the default WordPress search with better results ' +
+								'and filtering powered by Elasticsearch.'
+						) }
+					/>
+				</div>
+			</>
+		);
+	}
+}
+
+const mapStateToProps = state => {
+	const selectedSite = getSelectedSite( state );
+	const selectedSiteId = getSelectedSiteId( state );
+	const currentSitePlan = getCurrentPlan( state, selectedSiteId );
+
+	return {
+		selectedSite,
+		currentSitePlan,
+		currentSitePlanSlug: currentSitePlan ? currentSitePlan.productSlug : '',
+		selectedSiteSlug: getSiteSlug( state, selectedSiteId ),
+		trackTracksEvent: recordTracksEvent,
+	};
+};
+
+export default connect( mapStateToProps )( localize( FeaturesComponent ) );
+/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/my-sites/feature-upsell/index.js
+++ b/client/my-sites/feature-upsell/index.js
@@ -13,11 +13,9 @@ import { navigation, siteSelection, sites } from 'my-sites/controller';
 import controller from './controller';
 import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
-import { getSiteFragment } from 'lib/route';
 
 export default function() {
 	if ( config.isEnabled( 'upsell/nudge-a-palooza' ) ) {
-		page( '/feature/:feature', siteSelection, sites, makeLayout, clientRender );
 		page(
 			'/feature/store/:domain',
 			siteSelection,
@@ -54,14 +52,18 @@ export default function() {
 			clientRender
 		);
 
-		page( '/feature/:feature/*', ( { path, params } ) => {
-			const siteFragment = getSiteFragment( path );
+		// Specific feature's page
+		page( /\/feature\/([a-zA-Z0-9\-]+)$/, siteSelection, sites, makeLayout, clientRender );
 
-			if ( siteFragment ) {
-				return page.redirect( `/feature/${ params.feature }/${ siteFragment }` );
-			}
-
-			return page.redirect( `/feature/${ params.feature }` );
-		} );
+		// General features page
+		page(
+			'/feature/:domain',
+			siteSelection,
+			navigation,
+			controller.features,
+			makeLayout,
+			clientRender
+		);
+		page( '/feature', siteSelection, sites, makeLayout, clientRender );
 	}
 }

--- a/client/my-sites/feature-upsell/main.jsx
+++ b/client/my-sites/feature-upsell/main.jsx
@@ -11,5 +11,12 @@ import PluginsUpsellComponent from './plugins-upsell';
 import StoreUpsellComponent from './store-upsell';
 import ThemesUpsellComponent from './themes-upsell';
 import WordAdsUpsellComponent from './ads-upsell';
+import FeaturesComponent from './features';
 
-export { PluginsUpsellComponent, StoreUpsellComponent, ThemesUpsellComponent, WordAdsUpsellComponent };
+export {
+	FeaturesComponent,
+	PluginsUpsellComponent,
+	StoreUpsellComponent,
+	ThemesUpsellComponent,
+	WordAdsUpsellComponent,
+};


### PR DESCRIPTION
Since we are adding pages with URLs like `/feature/themes`, systems asked us to keep the URL structure working by adding a `/feature` page (it was solution preferred to renaming URLs to `/feature-themes`). This PR makes it happen

Test plan:
1. Confirm you can visit all of the following URLs:
- `/feature/themes`
- `/feature/plugins`
- `/feature/store`
- `/feature/ads`
1. Confirm that after choosing a free site on each of them you are taken to appropriate upsell page
1. Confirm you can visit the following URL: `/feature`
1. Confirm that after choosing a free site you are taken to a page that looks like this:

<img width="1622" alt="features-screen" src="https://user-images.githubusercontent.com/205419/43071583-94e21e24-8e73-11e8-8639-e081b26282c3.png">
