### PR TITLE
[nudge-a-palooza] Allocate all users for nudgeAPalooza test

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -695,6 +695,13 @@ export class MySitesSidebar extends Component {
 			);
 		}
 
+		// For the duration of nudgeAPalooza test we need to allocate all users who visit calypso.
+		// Having it here is an easy solution that makes it possible to avoid touching redux store
+		// middleware structure
+		if ( isEnabled( 'upsell/nudge-a-palooza' ) ) {
+			abtest( 'nudgeAPalooza' );
+		}
+
 		const manage = !! this.manage(),
 			configuration =
 				!! this.sharing() ||


### PR DESCRIPTION
In order to get correct numbers from the nudgeAPalooza a/b test, we need to allocate all users who visit calypso to a test group. This PR makes sure it is a case.

Test plan:
1. Go to a premium site in Calypso in private mode
1. Confirm you were allocated to some group of nudgeAPalooza test on your first visit, whether it was `/stats` or `/plans`