### PR TITLE
Link upload theme/plugin to feature pages for upsell test

### DIFF
--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -64,58 +64,40 @@ export const EligibilityWarnings = ( {
 		);
 		const title = translate( 'Business plan required' );
 		const plan = PLAN_BUSINESS;
+		const useUpsellPage =
+			config.isEnabled( 'upsell/nudge-a-palooza' ) &&
+			abtest( 'nudgeAPalooza' ) === 'customPluginAndThemeLandingPages';
+		let feature = null;
+		let href = null;
+		let event = null;
 
 		if ( 'plugins' === context ) {
-			if (
-				config.isEnabled( 'upsell/nudge-a-palooza' ) &&
-				abtest( 'nudgeAPalooza' ) === 'customPluginAndThemeLandingPages'
-			) {
-				businessUpsellBanner = (
-					<Banner
-						href={ '/feature/plugins/' + siteSlug }
-						description={ description }
-						event="calypso-plugin-eligibility-upgrade-nudge-upsell"
-						plan={ plan }
-						title={ title }
-					/>
-				);
+			feature = FEATURE_UPLOAD_PLUGINS;
+			if ( useUpsellPage ) {
+				href = '/feature/plugins/' + siteSlug;
+				event = 'calypso-plugin-eligibility-upgrade-nudge-upsell';
 			} else {
-				businessUpsellBanner = (
-					<Banner
-						description={ description }
-						feature={ FEATURE_UPLOAD_PLUGINS }
-						event="calypso-plugin-eligibility-upgrade-nudge"
-						plan={ plan }
-						title={ title }
-					/>
-				);
+				event = 'calypso-plugin-eligibility-upgrade-nudge';
 			}
-		} else if ( 'themes' === context ) {
-			if (
-				config.isEnabled( 'upsell/nudge-a-palooza' ) &&
-				abtest( 'nudgeAPalooza' ) === 'customPluginAndThemeLandingPages'
-			) {
-				businessUpsellBanner = (
-					<Banner
-						href={ '/feature/themes/' + siteSlug }
-						description={ description }
-						event="calypso-theme-eligibility-upgrade-nudge-upsell"
-						plan={ plan }
-						title={ title }
-					/>
-				);
+		} else {
+			feature = FEATURE_UPLOAD_THEMES;
+			if ( useUpsellPage ) {
+				href = '/feature/themes/' + siteSlug;
+				event = 'calypso-theme-eligibility-upgrade-nudge-upsell';
 			} else {
-				businessUpsellBanner = (
-					<Banner
-						description={ description }
-						feature={ FEATURE_UPLOAD_THEMES }
-						event="calypso-theme-eligibility-upgrade-nudge"
-						plan={ plan }
-						title={ title }
-					/>
-				);
+				event = 'calypso-theme-eligibility-upgrade-nudge';
 			}
 		}
+		businessUpsellBanner = (
+			<Banner
+				href={ href }
+				description={ description }
+				feature={ feature }
+				event={ event }
+				plan={ plan }
+				title={ title }
+			/>
+		);
 	}
 
 	return (

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -54,6 +54,36 @@ export const EligibilityWarnings = ( {
 		'eligibility-warnings__placeholder': isPlaceholder,
 	} );
 
+	let businessUpsellBanner = null;
+	if ( ! hasBusinessPlan && ! isJetpack ) {
+		const description = translate(
+			'Also get unlimited themes, advanced customization, no ads, live chat support, and more.'
+		);
+		const title = translate( 'Business plan required' );
+
+		if ( 'plugins' === context ) {
+			businessUpsellBanner = (
+				<Banner
+					description={ description }
+					feature={ FEATURE_UPLOAD_PLUGINS }
+					event={ 'calypso-plugin-eligibility-upgrade-nudge' }
+					plan={ PLAN_BUSINESS }
+					title={ title }
+				/>
+			);
+		} else {
+			businessUpsellBanner = (
+				<Banner
+					description={ description }
+					feature={ FEATURE_UPLOAD_THEMES }
+					event={ 'calypso-theme-eligibility-upgrade-nudge' }
+					plan={ PLAN_BUSINESS }
+					title={ title }
+				/>
+			);
+		}
+	}
+
 	return (
 		<div className={ classes }>
 			<PageViewTracker path="plugins/:plugin/eligibility/:site" title="Plugins > Eligibility" />
@@ -62,22 +92,7 @@ export const EligibilityWarnings = ( {
 				eventName="calypso_automated_transfer_eligibility_show_warnings"
 				eventProperties={ { context } }
 			/>
-			{ ! hasBusinessPlan &&
-				! isJetpack && (
-					<Banner
-						description={ translate(
-							'Also get unlimited themes, advanced customization, no ads, live chat support, and more.'
-						) }
-						feature={ 'plugins' === context ? FEATURE_UPLOAD_PLUGINS : FEATURE_UPLOAD_THEMES }
-						event={
-							'plugins' === context
-								? 'calypso-plugin-eligibility-upgrade-nudge'
-								: 'calypso-theme-eligibility-upgrade-nudge'
-						}
-						plan={ PLAN_BUSINESS }
-						title={ translate( 'Business plan required' ) }
-					/>
-				) }
+			{ businessUpsellBanner }
 			{ hasBusinessPlan &&
 				! isJetpack &&
 				includes( bannerHolds, 'NOT_USING_CUSTOM_DOMAIN' ) && (

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -15,6 +15,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { PLAN_BUSINESS, FEATURE_UPLOAD_PLUGINS, FEATURE_UPLOAD_THEMES } from 'lib/plans/constants';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -28,6 +29,8 @@ import QueryEligibility from 'components/data/query-atat-eligibility';
 import HoldList from './hold-list';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import WarningList from './warning-list';
+import config from 'config';
+import { abtest } from 'lib/abtest';
 
 export const EligibilityWarnings = ( {
 	backUrl,
@@ -60,27 +63,58 @@ export const EligibilityWarnings = ( {
 			'Also get unlimited themes, advanced customization, no ads, live chat support, and more.'
 		);
 		const title = translate( 'Business plan required' );
+		const plan = PLAN_BUSINESS;
 
 		if ( 'plugins' === context ) {
-			businessUpsellBanner = (
-				<Banner
-					description={ description }
-					feature={ FEATURE_UPLOAD_PLUGINS }
-					event={ 'calypso-plugin-eligibility-upgrade-nudge' }
-					plan={ PLAN_BUSINESS }
-					title={ title }
-				/>
-			);
-		} else {
-			businessUpsellBanner = (
-				<Banner
-					description={ description }
-					feature={ FEATURE_UPLOAD_THEMES }
-					event={ 'calypso-theme-eligibility-upgrade-nudge' }
-					plan={ PLAN_BUSINESS }
-					title={ title }
-				/>
-			);
+			if (
+				config.isEnabled( 'upsell/nudge-a-palooza' ) &&
+				abtest( 'nudgeAPalooza' ) === 'customPluginAndThemeLandingPages'
+			) {
+				businessUpsellBanner = (
+					<Banner
+						href={ '/feature/plugins/' + siteSlug }
+						description={ description }
+						event="calypso-plugin-eligibility-upgrade-nudge-upsell"
+						plan={ plan }
+						title={ title }
+					/>
+				);
+			} else {
+				businessUpsellBanner = (
+					<Banner
+						description={ description }
+						feature={ FEATURE_UPLOAD_PLUGINS }
+						event="calypso-plugin-eligibility-upgrade-nudge"
+						plan={ plan }
+						title={ title }
+					/>
+				);
+			}
+		} else if ( 'themes' === context ) {
+			if (
+				config.isEnabled( 'upsell/nudge-a-palooza' ) &&
+				abtest( 'nudgeAPalooza' ) === 'customPluginAndThemeLandingPages'
+			) {
+				businessUpsellBanner = (
+					<Banner
+						href={ '/feature/themes/' + siteSlug }
+						description={ description }
+						event="calypso-theme-eligibility-upgrade-nudge-upsell"
+						plan={ plan }
+						title={ title }
+					/>
+				);
+			} else {
+				businessUpsellBanner = (
+					<Banner
+						description={ description }
+						feature={ FEATURE_UPLOAD_THEMES }
+						event="calypso-theme-eligibility-upgrade-nudge"
+						plan={ plan }
+						title={ title }
+					/>
+				);
+			}
 		}
 	}
 


### PR DESCRIPTION
This change allows users allocated to the  `customPluginAndThemeLandingPages` variant of the `nudgeAPalooza` test to see the new `/feature/themes/<site>` and `/feature/plugins/<site>` upsell pages when attempting to upload a theme or plugin.

# Test plan

* set the `nudgeAPalooza` ab test to `control`
* Visit `/themes/upload/<site>` for a free site
* Clicking the banner should take you to `plans/<site>?feature=upload-plugins&plan=business-bundle`
* Visit `/plugins/upload/<site>` for a free site
* Clicking the banner should take you to `plans/<site>?feature=upload-themes&plan=business-bundle`

* set the `nudgeAPalooza` ab test to `customPluginAndThemeLandingPages`
* Visit `/themes/upload/<site>` for a free site
* Clicking the banner should take you to `/feature/themes/<site>`
* Visit `/plugins/upload/<site>` for a free site
* Clicking the banner should take you to `/feature/plugins/<site>`
