### PR TITLE
SDK: Build PHP code for registering block

### DIFF
--- a/bin/create-scripts/block.js
+++ b/bin/create-scripts/block.js
@@ -1,5 +1,6 @@
 /** @format */
 const path = require( 'path' );
+const fs = require( 'fs' );
 const webpack = require( 'webpack' );
 
 const __rootDir = path.resolve( __dirname, '../../' );
@@ -31,6 +32,27 @@ const config = {
 	},
 };
 
+const funcName = 'gutenberg_register_block_' + blockName.replace( '-', '_' );
+const blockRegistration = `<?php
+add_action( 'enqueue_block_editor_assets', '${ funcName }' );
+function ${ funcName }() {
+	wp_enqueue_style(
+		'${ blockName }',
+		plugins_url( '/blocks/blocks-${ blockName }.css', __FILE__ ),
+	);
+
+	wp_enqueue_script(
+		'${ blockName }',
+		plugins_url( '/blocks/blocks-${ blockName }.js', __FILE__ ),
+	);
+}
+`;
+
 const compiler = webpack( config );
 
-compiler.run( ( error, stats ) => console.log( stats.toString() ) );
+compiler.run(
+	( error, stats ) => {
+		console.log( stats.toString() );
+		fs.writeFileSync( path.join( outputDir, `blocks-${ blockName }.php` ), blockRegistration );
+	}
+);


### PR DESCRIPTION
This PR expands the gutenberg block build process to also build the PHP code for registering the block and its assets.

Still in progress; also it's probably best to wait for #26256, which introduces a simple build process for the block's CSS.