### PR TITLE
SDK: Skip copying of flag images when building block

### DIFF
--- a/bin/create-scripts/block.js
+++ b/bin/create-scripts/block.js
@@ -2,9 +2,6 @@
 const path = require( 'path' );
 const webpack = require( 'webpack' );
 
-// TODO: move this to the npm script, see #26258
-process.env[ 'SKIP_FLAG_IMAGES' ] = 'true';
-
 const __rootDir = path.resolve( __dirname, '../../' );
 const entryPath = path.resolve( process.argv[ 2 ] );
 const sourceDir = path.dirname( entryPath );

--- a/bin/create-scripts/block.js
+++ b/bin/create-scripts/block.js
@@ -2,6 +2,9 @@
 const path = require( 'path' );
 const webpack = require( 'webpack' );
 
+// TODO: move this to the npm script, see #26258
+process.env[ 'SKIP_FLAG_IMAGES' ] = 'true';
+
 const __rootDir = path.resolve( __dirname, '../../' );
 const entryPath = path.resolve( process.argv[ 2 ] );
 const sourceDir = path.dirname( entryPath );

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "build-client": "cross-env-shell CALYPSO_CLIENT=true NODE_PATH=$NODE_PATH:server:client:. node --max_old_space_size=8192 ./node_modules/webpack/bin/webpack.js --display-error-details --config webpack.config.js",
     "build-client-if-prod": "node -e \"process.env.CALYPSO_ENV === 'production' && process.exit(1)\" || npm run build-client",
     "build-client-if-desktop": "node -e \"process.env.CALYPSO_ENV === 'desktop' && process.exit(1)\" || npm run build-client",
-    "build-block": "node bin/create-scripts/block.js",
+    "build-block": "SKIP_FLAG_IMAGES=true node bin/create-scripts/block.js",
     "clean": "npm run -s clean:build && npm run -s clean:devdocs && npm run -s clean:public",
     "clean:build": "npm run -s rm -- build && npm run -s rm -- server/bundler .json && npm run -s rm -- .babel-cache",
     "clean:devdocs": "npm run -s rm -- server/devdocs/search-index.js && npm run -s rm -- server/devdocs/proptypes-index.json && npm run -s rm -- server/devdocs/components-usage-stats.json",

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "build-client": "cross-env-shell CALYPSO_CLIENT=true NODE_PATH=$NODE_PATH:server:client:. node --max_old_space_size=8192 ./node_modules/webpack/bin/webpack.js --display-error-details --config webpack.config.js",
     "build-client-if-prod": "node -e \"process.env.CALYPSO_ENV === 'production' && process.exit(1)\" || npm run build-client",
     "build-client-if-desktop": "node -e \"process.env.CALYPSO_ENV === 'desktop' && process.exit(1)\" || npm run build-client",
-    "build-block": "SKIP_FLAG_IMAGES=true node bin/create-scripts/block.js",
+    "build-block": "cross-env-shell SKIP_FLAG_IMAGES=true node bin/create-scripts/block.js",
     "clean": "npm run -s clean:build && npm run -s clean:devdocs && npm run -s clean:public",
     "clean:build": "npm run -s rm -- build && npm run -s rm -- server/bundler .json && npm run -s rm -- .babel-cache",
     "clean:devdocs": "npm run -s rm -- server/devdocs/search-index.js && npm run -s rm -- server/devdocs/proptypes-index.json && npm run -s rm -- server/devdocs/components-usage-stats.json",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,7 @@ const shouldMinify =
 	( process.env.MINIFY_JS !== 'false' && bundleEnv === 'production' );
 const shouldEmitStats = process.env.EMIT_STATS === 'true';
 const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
+const shouldSkipFlagImages = process.env.SKIP_FLAG_IMAGES === 'true';
 const codeSplit = config.isEnabled( 'code-splitting' );
 
 /**
@@ -206,9 +207,10 @@ const webpackConfig = {
 		} ),
 		new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),
 		new webpack.IgnorePlugin( /^props$/ ),
-		new CopyWebpackPlugin( [
-			{ from: 'node_modules/flag-icon-css/flags/4x3', to: 'images/flags' },
-		] ),
+		! shouldSkipFlagImages &&
+			new CopyWebpackPlugin( [
+				{ from: 'node_modules/flag-icon-css/flags/4x3', to: 'images/flags' },
+			] ),
 		new AssetsWriter( {
 			filename: 'assets.json',
 			path: path.join( __dirname, 'server', 'bundler' ),


### PR DESCRIPTION
This PR allows us to skip flag images copying in our webpack config, as they're not necessary for the block. 

We could also remove the `CopyWebpackPlugin` in our custom Gutenberg block webpack inherited config, but that plugin isn't recognizable, and would be pretty fragile to remove it by index.

We're setting an env var in the npm script that allows us to disable the flags copying.

To test:
* Checkout this branch
* Run `npm run build-block client/gutenberg/extensions/hello-dolly/hello-block.js`
* Verify flags are no longer copied to the build dir.
* Run calypso regularly and verify flags are copied properly by visiting a flag, like `/calypso/images/flags/bg.svg` for example