### PR TITLE
Podcasting: add podcast property to publish Tracks events

### DIFF
--- a/client/state/posts/stats.js
+++ b/client/state/posts/stats.js
@@ -40,6 +40,7 @@ export const recordSaveEvent = () => ( dispatch, getState ) => {
 	const podcastingCategoryId = getPodcastingCategoryId( state, siteId );
 	const isPodcastEpisode =
 		podcastingCategoryId &&
+		post.terms &&
 		post.terms.category &&
 		some( post.terms.category, { ID: podcastingCategoryId } );
 	let tracksEventName = 'calypso_editor_';

--- a/client/state/posts/stats.js
+++ b/client/state/posts/stats.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import debugModule from 'debug';
-import { get } from 'lodash';
+import { get, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +14,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getEditorPostId, isConfirmationSidebarEnabled } from 'state/ui/editor/selectors';
 import { getEditedPost, getSitePost } from 'state/posts/selectors';
+import getPodcastingCategoryId from 'state/selectors/get-podcasting-category-id';
 
 /**
  * Module variables
@@ -36,6 +37,11 @@ export const recordSaveEvent = () => ( dispatch, getState ) => {
 	const currentStatus = get( getSitePost( state, siteId, postId ), 'status', 'draft' );
 	const confirmationSidebarEnabled = isConfirmationSidebarEnabled( state, siteId );
 	const nextStatus = post.status;
+	const podcastingCategoryId = getPodcastingCategoryId( state, siteId );
+	const isPodcastEpisode =
+		podcastingCategoryId &&
+		post.terms.category &&
+		some( post.terms.category, { ID: podcastingCategoryId } );
 	let tracksEventName = 'calypso_editor_';
 	let statName = false;
 	let statEvent = false;
@@ -101,6 +107,7 @@ export const recordSaveEvent = () => ( dispatch, getState ) => {
 			current_status: currentStatus,
 			next_status: nextStatus,
 			context: eventContext,
+			is_podcast_episode: isPodcastEpisode,
 		} )
 	);
 };


### PR DESCRIPTION
This adds an `is_podcast_episode` property to the `calypso_editor_` Tracks events, so that we can track podcast episode publishing, scheduling, drafting, and updating.

**To test:**
- Enable podcasting by visiting Settings > Writing > Podcasting, and choosing a category
- Enable console logging of tracks events with `localStorage.setItem( 'debug', 'calypso:analytics:tracks' );`
- Publish a new post _with_ the podcasting category assigned
- Verify that the `calypso_editor_publish` Tracks event fires with the prop `is_podcast_episode: true`
- Publish a new post _without_ the podcasting category assigned
- Verify that the `calypso_editor_publish` Tracks event fires with the prop `is_podcast_episode: false`
- Repeat the previous steps with updating, scheduling, and drafting posts.
- Verify that the matching `calypso_editor_` Tracks events fire with the correct `is_podcast_episode` prop value.