### PR TITLE
Domains: Add 2px left margin to caret icon on More Extensions button

### DIFF
--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -126,6 +126,12 @@
 	}
 }
 
+.search-filters__popover-button {
+	.gridicon {
+		margin-left: 2px;
+	}
+}
+
 .search-filters__text-input-fieldset .search-filters__label {
 	margin-bottom: 0.25em;
 }

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -126,10 +126,8 @@
 	}
 }
 
-.search-filters__popover-button {
-	.gridicon {
-		margin-left: 2px;
-	}
+.search-filters__popover-button .gridicon {
+	margin-left: 2px;
 }
 
 .search-filters__text-input-fieldset .search-filters__label {


### PR DESCRIPTION
The caret needs some breathing room!

**Before this PR:**
<img width="640" alt="screen shot 2018-07-23 at 12 06 18 pm" src="https://user-images.githubusercontent.com/2124984/43089023-a22a0fda-8e71-11e8-9d2a-ad89d148f5c1.png">

**After this PR:**
<img width="640" alt="screen shot 2018-07-23 at 12 06 43 pm" src="https://user-images.githubusercontent.com/2124984/43089024-a3e0f30c-8e71-11e8-9141-9b2194a949cc.png">

**Steps to test**

1. Switch to this PR
2. Go to http://calypso.localhost:3000/start/domains
3. Check spacing on More Extensions button
