### PR TITLE
Plugins: Fix redirect issue for Atomic sites

### DIFF
--- a/client/layout/guided-tours/tours/plugins-basic-tour.js
+++ b/client/layout/guided-tours/tours/plugins-basic-tour.js
@@ -13,16 +13,27 @@ import { makeTour, Tour, Step, ButtonRow, Quit } from 'layout/guided-tours/confi
 import { isEnabled } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
+import canCurrentUserManagePlugins from 'state/selectors/can-current-user-manage-plugins';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 
 const isAtomic = state => isSiteAutomatedTransfer( state, getSelectedSiteId( state ) );
+
+const userCanManagePlugins = state => {
+	const siteId = getSelectedSiteId( state );
+	if ( siteId ) {
+		return canCurrentUser( state, siteId, 'manage_options' );
+	}
+
+	return canCurrentUserManagePlugins( state );
+};
 
 export const PluginsBasicTour = makeTour(
 	<Tour
 		name="pluginsBasicTour"
 		version="20180718"
 		path={ [ '/stats', '/plugins' ] }
-		when={ and( isAtomic, isDesktop, isEnabled( 'calypsoify/plugins' ) ) }
+		when={ and( userCanManagePlugins, isAtomic, isDesktop, isEnabled( 'calypsoify/plugins' ) ) }
 	>
 		<Step
 			name="init"

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -39,6 +39,7 @@ import getSiteId from 'state/selectors/get-site-id';
 import getSites from 'state/selectors/get-sites';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import canCurrentUser from 'state/selectors/can-current-user';
 import {
 	domainManagementAddGoogleApps,
 	domainManagementContactsPrivacy,
@@ -377,17 +378,20 @@ export function siteSelection( context, next ) {
 
 	const siteId = getSiteId( getState(), siteFragment );
 	if ( siteId ) {
-		const isAtomicSite = isSiteAutomatedTransfer( getState(), siteId );
+		const state = getState();
+		const isAtomicSite = isSiteAutomatedTransfer( state, siteId );
+		const userCanManagePlugins = canCurrentUser( state, siteId, 'manage_options' );
 		const calypsoify = isAtomicSite && config.isEnabled( 'calypsoify/plugins' );
 
 		if (
 			window &&
 			window.location &&
 			window.location.replace &&
+			userCanManagePlugins &&
 			calypsoify &&
 			/^\/plugins/.test( basePath )
 		) {
-			const pluginLink = getSiteAdminUrl( getState(), siteId ) + 'plugin-install.php?calypsoify=1';
+			const pluginLink = getSiteAdminUrl( state, siteId ) + 'plugin-install.php?calypsoify=1';
 			return window.location.replace( pluginLink );
 		}
 


### PR DESCRIPTION
This patch is a fix for the previous https://github.com/Automattic/wp-calypso/pull/25767 PR.
More informarmation: https://wp.me/p58i-76F-p2

Reported issue:

> On both desktop and mobile, when switching from the Plugins page for All Sites, to an Atomic site where the user role is not admin – a 403 Forbidden page is displayed without a clearly recoverable path.

What this patch does is ignoring the redirect when the user doesn't have admin permissions on the Atomic site, showing to the user the normal page under these circumstances.

### Testing

#### Confirme the issue:

1. Visit wpcalypso.wordpress.com
2. Select All Sites in sidebar
3. Select Plugins
4. Switch to an Atomic site where current user doesn’t have an admin role – eg. Contributor, Author, Editor

<img src="https://user-images.githubusercontent.com/77539/43093732-1aa42968-8e6e-11e8-9401-b8a15e22e201.gif" width="500px" />

#### After applying the patch

1) Repeat 1-4 steps described above
2) You should achieve the right page:

<img src="https://user-images.githubusercontent.com/77539/43093631-d1e991a4-8e6d-11e8-88b8-df3d0ea23e76.png" width="400px" />

Props to @alisterscott for catching the issue.

DO NOT use a12s account for testing purpose.