### PR TITLE
Domains: Update subheading for domain mapping page

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -374,7 +374,7 @@ class DomainsStep extends React.Component {
 
 	getSubHeaderText() {
 		const { translate } = this.props;
-		return 'transfer' === this.props.stepSectionName
+		return 'transfer' === this.props.stepSectionName || 'mapping' === this.props.stepSectionName
 			? translate( 'Use a domain you already own with your new WordPress.com site.' )
 			: translate(
 					"Enter your site's name, or some keywords that describe it - " +


### PR DESCRIPTION
Updates the subheading on the /transfer and /mapping pages to be the same.

**Before this PR**

<img width="748" alt="screen shot 2018-07-23 at 2 23 10 pm" src="https://user-images.githubusercontent.com/2124984/43095498-04b50ea4-8e84-11e8-9200-198a590f410b.png">

**After this PR**

<img width="755" alt="screen shot 2018-07-23 at 2 23 24 pm" src="https://user-images.githubusercontent.com/2124984/43095503-0b126e04-8e84-11e8-8218-c0bd218fbe03.png">

**Steps to test**

* Switch to this PR
* Go to http://calypso.localhost:3000/start/domains/ and click on "Use a domain I own" at the bottom
* Click Transfer to WordPress.com, check subheading
* Go back, click Buy Domain Mapping, check subheading; they should be the same: "Use a domain you already own with your new WordPress.com site."