### PR TITLE
StatsSite: Remove component state for tab selects

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -238,7 +238,7 @@ export default {
 			<StatsSite
 				path={ context.pathname }
 				date={ date }
-				chartTab={ queryOptions.tab || 'views' }
+				chartTab={ queryOptions.tab }
 				context={ context }
 				period={ rangeOfPeriod( activeFilter.period, date ) }
 			/>

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -234,11 +234,14 @@ export default {
 		analytics.mc.bumpStat( 'calypso_stats_site_period', activeFilter.period + numPeriodAgo );
 		recordPlaceholdersTiming();
 
+		const validTabs = [ 'views', 'visitors', 'likes', 'comments' ];
+		const chartTab = validTabs.includes( queryOptions.tab ) ? queryOptions.tab : 'views';
+
 		context.primary = (
 			<StatsSite
 				path={ context.pathname }
 				date={ date }
-				chartTab={ queryOptions.tab }
+				chartTab={ chartTab }
 				context={ context }
 				period={ rangeOfPeriod( activeFilter.period, date ) }
 			/>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -8,6 +8,7 @@ import page from 'page';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { parse as parseQs, stringify as stringifyQs } from 'qs';
 
 /**
  * Internal dependencies
@@ -38,36 +39,33 @@ import QueryKeyringConnections from 'components/data/query-keyring-connections';
 import GoogleMyBusinessStatsNudge from 'blocks/google-my-business-stats-nudge';
 import isGoogleMyBusinessStatsNudgeVisibleSelector from 'state/selectors/is-google-my-business-stats-nudge-visible';
 
+function updateQueryString( query = {} ) {
+	return {
+		...parseQs( window.location.search.substring( 1 ) ),
+		...query,
+	};
+}
+
 class StatsSite extends Component {
+	static defaultProps = {
+		chartTab: 'views',
+	};
+
 	constructor( props ) {
 		super( props );
-		this.state = {
-			chartTab: this.props.chartTab,
-			tabSwitched: false,
-		};
-	}
-
-	componentWillReceiveProps( nextProps ) {
-		if ( ! this.state.tabSwitched && this.state.chartTab !== nextProps.chartTab ) {
-			this.setState( {
-				tabSwitched: true,
-				chartTab: nextProps.chartTab,
-			} );
-		}
 	}
 
 	barClick = bar => {
 		this.props.recordGoogleEvent( 'Stats', 'Clicked Chart Bar' );
-		page.redirect( this.props.path + '?startDate=' + bar.data.period );
+		const updatedQs = stringifyQs( updateQueryString( { startDate: bar.data.period } ) );
+		page.redirect( `${ window.location.pathname }?${ updatedQs }` );
 	};
 
 	switchChart = tab => {
-		if ( ! tab.loading && tab.attr !== this.state.chartTab ) {
+		if ( ! tab.loading && tab.attr !== this.props.chartTab ) {
 			this.props.recordGoogleEvent( 'Stats', 'Clicked ' + titlecase( tab.attr ) + ' Tab' );
-			this.setState( {
-				chartTab: tab.attr,
-				tabSwitched: true,
-			} );
+			const updatedQs = stringifyQs( updateQueryString( { tab: tab.attr } ) );
+			page.show( `${ window.location.pathname }?${ updatedQs }` );
 		}
 	};
 
@@ -104,7 +102,7 @@ class StatsSite extends Component {
 		let podcastList;
 
 		const query = {
-			period: period,
+			period,
 			date: endOf.format( 'YYYY-MM-DD' ),
 		};
 
@@ -167,7 +165,7 @@ class StatsSite extends Component {
 						charts={ charts }
 						queryDate={ queryDate }
 						period={ this.props.period }
-						chartTab={ this.state.chartTab }
+						chartTab={ this.props.chartTab }
 					/>
 					<StickyPanel className="stats__sticky-navigation">
 						<StatsPeriodNavigation


### PR DESCRIPTION
This change removes `state.chartTab` and `state.tabSwitched` from `<StatsSite />`. 

Instead of calling `this.setState` in `<StatsSite />`, we now update the current location's query string with `startDate` or `tab` values. Doing this allows the [stats controller](https://github.com/Automattic/wp-calypso/blob/0e5e2a347849a88bf05ad5684b77777b76dc62c7/client/my-sites/stats/controller.jsx#L241) to parse and propogate the new value down to `<StatsSite />`.

# Test Instructions
1. Check out this branch locally or in a live branch.
2. Navigate to your [stats page](http://calypso.localhost:3000/stats/) and select a site with view and visitor activity.
3. Clicking on a bar inside the bar chart near the top of the page. Verify that the query string for the tab has been properly updated (e.g. `?startDate=2018-07-06`).
4. Click on the "Visitors" tab beneath the chart. Ensure that it updates the query string with a corresponding `tab` value and preserves the previously set `startDate` value (e.g. `?startDate=2018-07-06&tab=visitors`).
5. Try manually modifying the `tab` query value (e.g. `?tab=visitorz`). Ensure that the view chart renders properly.