### PR TITLE
Activity Log: Add a limit-notice at the bottom of logs

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -390,23 +390,25 @@ class ActivityLog extends Component {
 				<StatsNavigation selectedItem={ 'activity' } siteId={ siteId } slug={ slug } />
 				{ siteIsOnFreePlan && <UpgradeBanner siteId={ siteId } /> }
 				{ config.isEnabled( 'rewind-alerts' ) && siteId && <RewindAlerts siteId={ siteId } /> }
-				{ siteId && 'unavailable' === rewindState.state && (
+				{ siteId &&
+					'unavailable' === rewindState.state && (
 						<UnavailabilityNotice siteId={ siteId } siteIsOnFreePlan={ siteIsOnFreePlan } />
 					) }
-				{ 'awaitingCredentials' === rewindState.state && ! siteIsOnFreePlan && (
-					<Banner
-						icon="history"
-						href={
-							rewindState.canAutoconfigure
-								? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ slug }`
-								: `/start/rewind-setup/?siteId=${ siteId }&siteSlug=${ slug }`
-						}
-						title={ translate( 'Add site credentials' ) }
-						description={ translate(
-							'Backups and security scans require access to your site to work properly.'
-						) }
-					/>
-				) }
+				{ 'awaitingCredentials' === rewindState.state &&
+					! siteIsOnFreePlan && (
+						<Banner
+							icon="history"
+							href={
+								rewindState.canAutoconfigure
+									? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ slug }`
+									: `/start/rewind-setup/?siteId=${ siteId }&siteSlug=${ slug }`
+							}
+							title={ translate( 'Add site credentials' ) }
+							description={ translate(
+								'Backups and security scans require access to your site to work properly.'
+							) }
+						/>
+					) }
 				{ 'provisioning' === rewindState.state && (
 					<Banner
 						icon="history"
@@ -450,6 +452,14 @@ class ActivityLog extends Component {
 								</Fragment>
 							) ) }
 						</section>
+						{ siteIsOnFreePlan && (
+							<p className="activity-log__limit-notice">
+								{ translate(
+									"Since you're on a free plan, " +
+										"you'll see a limited number of events in your activity log."
+								) }
+							</p>
+						) }
 						<Pagination
 							className="activity-log__pagination is-bottom-pagination"
 							key="activity-list-pagination-bottom"

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -217,3 +217,10 @@
 		content: '\00b7\2004';
 	}
 }
+
+.activity-log__limit-notice {
+	text-align: center;
+	font-style: italic;
+	font-size: smaller;
+	padding: 20px 0;
+}


### PR DESCRIPTION
Fixes #23925

Adds a small, text notice to the bottom of a site's activity log.

<img width="1550" alt="screen shot 2018-07-23 at 3 27 14 pm" src="https://user-images.githubusercontent.com/2694219/43098424-2acf8624-8e8d-11e8-8064-9a125ff16c3d.png">

<img width="291" alt="screen shot 2018-07-23 at 3 28 39 pm" src="https://user-images.githubusercontent.com/2694219/43098437-2ed61864-8e8d-11e8-87af-b1ad92e7db4b.png">
