### PR TITLE
Domains: Standardize domain mapping text input

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -21,6 +21,7 @@ import DomainRegistrationSuggestion from 'components/domains/domain-registration
 import DomainProductPrice from 'components/domains/domain-product-price';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
+import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 import {
 	recordAddDomainButtonClickInMapDomain,
 	recordFormSubmitInMapDomain,
@@ -109,11 +110,12 @@ class MapDomainStep extends React.Component {
 					/>
 
 					<div className="map-domain-step__add-domain" role="group">
-						<input
+						<FormTextInputWithAffixes
+							prefix="http://"
 							className="map-domain-step__external-domain"
 							type="text"
 							value={ this.state.searchQuery }
-							placeholder={ translate( 'Enter a domain' ) }
+							placeholder={ translate( 'example.com' ) }
 							onBlur={ this.save }
 							onChange={ this.setSearchQuery }
 							onClick={ this.recordInputFocus }

--- a/client/components/domains/map-domain-step/style.scss
+++ b/client/components/domains/map-domain-step/style.scss
@@ -19,7 +19,7 @@
 		margin-bottom: 20px;
 		min-width: 0;
 
-		@include breakpoint( ">960px" ) {
+		@include breakpoint( '>960px' ) {
 			float: right;
 			margin-bottom: 0;
 		}
@@ -35,7 +35,7 @@
 }
 
 .map-domain-step__domain-description {
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		max-width: 75%;
 		float: left;
 		margin-bottom: 20px;
@@ -47,9 +47,13 @@
 	flex-flow: column;
 	width: 100%;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		flex-flow: row;
 	}
+}
+
+.map-domain-step__add-domain .form-text-input-with-affixes__prefix {
+	flex: inherit;
 }
 
 input.map-domain-step__external-domain {
@@ -61,7 +65,7 @@ input.map-domain-step__external-domain {
 	flex-grow: 1;
 	margin: 10px 0 0 0;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		min-width: 80px;
 		flex-grow: 0;
 		margin: 0 0 0 10px;


### PR DESCRIPTION
Ensure domain mapping text input behaves the same way as domain transfer text input, adding an "http://" prefix and using the same component.

**Before this PR:**

<img width="749" alt="screen shot 2018-07-23 at 5 14 47 pm" src="https://user-images.githubusercontent.com/2124984/43103405-f207e034-8e9b-11e8-86fa-b810ef35b436.png">

**After this PR:**

<img width="737" alt="screen shot 2018-07-23 at 5 14 20 pm" src="https://user-images.githubusercontent.com/2124984/43103413-f7669bce-8e9b-11e8-9b53-106c83fb2dcd.png">

**Steps to test:**

* Switch to this PR
* Navigate to http://calypso.localhost:3000/start/domains/mapping and click "Use a domain I own" at the bottom
* Click on "Buy Domain Mapping" and check to see that the `http://` text input prefix is present.
* Test the form itself, to make sure it still works as expected through checkout.