### PR TITLE
Config: enable calypsoify for stage and prod

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -20,6 +20,7 @@
 		"ad-tracking": true,
 		"apple-pay": true,
 		"automated-transfer": true,
+		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"desktop-promo": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -23,6 +23,7 @@
 		"ad-tracking": false,
 		"apple-pay": true,
 		"automated-transfer": true,
+		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"desktop-promo": true,


### PR DESCRIPTION
This PR enables the changes implemented in https://github.com/Automattic/wp-calypso/pull/25767 and https://github.com/Automattic/wp-calypso/pull/26264 for `stating` and `production`.

For more context please read the descriptions of the PRs above.