### PR TITLE
SDK: make it possible to use block builder script from other repositories 

### DIFF
--- a/bin/create-scripts/block.js
+++ b/bin/create-scripts/block.js
@@ -1,11 +1,13 @@
+#!/usr/bin/env node
+
 /** @format */
 const path = require( 'path' );
 const webpack = require( 'webpack' );
 
 const __rootDir = path.resolve( __dirname, '../../' );
-const entryPath = path.resolve( process.argv[ 2 ] );
+const entryPath = path.resolve( __rootDir, process.argv[ 2 ] );
 const sourceDir = path.dirname( entryPath );
-const outputDir = path.join( sourceDir, 'build' );
+const outputDir = process.argv[ 3 ] ? process.argv[ 3 ] : path.join( sourceDir, 'build' );
 const blockName = path.basename( path.dirname( entryPath ) );
 
 const baseConfig = require( path.join( __rootDir, 'webpack.config.js' ) );
@@ -13,6 +15,7 @@ const baseConfig = require( path.join( __rootDir, 'webpack.config.js' ) );
 const config = {
 	...baseConfig,
 	...{
+		context: __rootDir,
 		mode: 'production',
 		entry: entryPath,
 		externals: {

--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -7,6 +7,7 @@ const execSync = require( 'child_process' ).execSync;
 const path = require( 'path' );
 
 const buildBlockScript = path.resolve( __dirname, 'create-scripts/block.js' );
+const crossEnvShell = path.resolve( __dirname, '../node_modules/.bin/cross-env-shell' );
 let args = process.argv;
 
 // Remove `node` and SDK script
@@ -20,7 +21,7 @@ if ( ! args.length || task !== 'build-block' ) {
 	process.exit(1);
 }
 
-execSync( `cross-env-shell SKIP_FLAG_IMAGES=true node ${ buildBlockScript } ${ args.join( ' ' ) }`, {
+execSync( `${ crossEnvShell } SKIP_FLAG_IMAGES=true node ${ buildBlockScript } ${ args.join( ' ' ) }`, {
 	shell: true,
 	stdio: 'inherit',
 } );

--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -8,13 +8,7 @@ const path = require( 'path' );
 
 const buildBlockScript = path.resolve( __dirname, 'create-scripts/block.js' );
 const crossEnvShell = path.resolve( __dirname, '../node_modules/.bin/cross-env-shell' );
-let args = process.argv;
-
-// Remove `node` and SDK script
-args.splice(0, 2);
-
-// First argument should always be the task name
-const task = args.shift();
+const [ /* node */, /* bin/sdk-cli.js */, task, ...args ] = process.argv;
 
 if ( ! args.length || task !== 'build-block' ) {
 	console.log( chalk.red( 'usage: npx calypso-gutenberg-sdk build-block <block>' ) );

--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -3,11 +3,10 @@
 /** @format */
 
 const chalk = require( 'chalk' );
-const execSync = require( 'child_process' ).execSync;
 const path = require( 'path' );
+const spawnSync = require( 'child_process' ).spawnSync;
 
 const buildBlockScript = path.resolve( __dirname, 'create-scripts/block.js' );
-const crossEnvShell = path.resolve( __dirname, '../node_modules/.bin/cross-env-shell' );
 const [ /* node */, /* bin/sdk-cli.js */, task, ...args ] = process.argv;
 
 if ( ! args.length || task !== 'build-block' ) {
@@ -15,7 +14,10 @@ if ( ! args.length || task !== 'build-block' ) {
 	process.exit(1);
 }
 
-execSync( `${ crossEnvShell } SKIP_FLAG_IMAGES=true node ${ buildBlockScript } ${ args.join( ' ' ) }`, {
+spawnSync( 'node', [ buildBlockScript, ...args ], {
+	env: {
+		SKIP_FLAG_IMAGES: true,
+	},
 	shell: true,
 	stdio: 'inherit',
 } );

--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+/** @format */
+
+const chalk = require( 'chalk' );
+const execSync = require( 'child_process' ).execSync;
+const path = require( 'path' );
+
+const buildBlockScript = path.resolve( __dirname, 'create-scripts/block.js' );
+let args = process.argv;
+
+// Remove `node` and SDK script
+args.splice(0, 2);
+
+// First argument should always be the task name
+const task = args.shift();
+
+if ( ! args.length || task !== 'build-block' ) {
+	console.log( chalk.red( 'usage: npx calypso-gutenberg-sdk build-block <block>' ) );
+	process.exit(1);
+}
+
+execSync( `cross-env-shell SKIP_FLAG_IMAGES=true node ${ buildBlockScript } ${ args.join( ' ' ) }`, {
+	shell: true,
+	stdio: 'inherit',
+} );

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/Automattic/wp-calypso.git"
   },
   "main": "index.js",
+  "bin": {
+    "wp-calypso-sdk": "./bin/create-scripts/block.js"
+  },
   "browserslist": [
     "last 2 versions",
     "Safari >= 10",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "main": "index.js",
   "bin": {
-    "wp-calypso-sdk": "./bin/create-scripts/block.js"
+    "calypso-gutenberg-sdk": "./bin/sdk-cli.js"
   },
   "browserslist": [
     "last 2 versions",


### PR DESCRIPTION
We need a `bin` ([NPM docs](https://docs.npmjs.com/files/package.json#bin)) entry point in `package.json` to be able to use the builder from plugins like Jetpack.

Our `calypso-gutenberg-sdk` command points to `bin/sdk-cli.js` file which will in future hold logic for parsing arguments. In this PR that file is super crude and simple. It accepts only one task ("build-block") and simply passes arguments onwards to existing `bin/create-scripts/block.js`

The goal is that in Jetpack folder we should be able to run:
```bash
npx calypso-gutenberg-sdk build-block \
  block-file-relative-to-calypso.js \
  output-folder-relative-to-jetpack
```

As a new feature, block-builder script takes 3rd argument which is the absolute path of destination directory for the block. Defaulting to previous `./build` directory inside Calypso if none is provided.

Paths in scripts need to resolve to `./node_modules/wp-calypso`, not to Jetpack's root. I added [`context`](https://webpack.js.org/configuration/entry-context/#context) Webpack option to block-builder to help with that.

*The blocker* I'm having right now is that Babel doesn't seem to pick up presets. I get this error:

```bash
npx calypso-gutenberg-sdk build-block client/gutenberg/extensions/hello-dolly/hello-block.js $(pwd)/_inc/build


Hash: dd586a1798f6a5a83d17
Version: webpack 4.16.2
Time: 664ms
Built at: 07/24/2018 11:29:22 AM
                Asset    Size  Chunks  Chunk Names
blocks-hello-dolly.js  10 KiB       0  main
Entrypoint main = blocks-hello-dolly.js
[0] ./client/gutenberg/extensions/hello-dolly/hello-block.js 1.89 KiB {0} [built] [failed] [1 error]

ERROR in ./client/gutenberg/extensions/hello-dolly/hello-block.js
Module build failed (from ./node_modules/thread-loader/dist/cjs.js):
Thread Loader (Worker 0)
/Users/mikael/Documents/Work/Automattic/Calypso/wp-calypso/client/gutenberg/extensions/hello-dolly/hello-block.js: Unexpected token (11:29)

   9 | 	icon: 'format-audio',
  10 | 	category: 'layout',
> 11 | 	edit: ( { isSelected } ) => <p>{ isSelected ? 'Editing Hello Dolly' : 'Viewing Hello Dolly' }</p>,
     | 	                            ^
  12 | 	save: () => <p>Saving Hello Dolly</p>,
  13 | } );
  14 |

    at Parser.raise (/Users/mikael/Documents/Work/Automattic/Calypso/wp-calypso/node_modules/@babel/parser/lib/index.js:3898:15)
    at Parser.unexpected (/Users/mikael/Documents/Work/Automattic/Calypso/wp-calypso/node_modules/@babel/parser/lib/index.js:5227:16)
    at Parser.parseExprAtom (/Users/mikael/Documents/Work/Automattic/Calypso/wp-calypso/node_modules/@babel/parser/lib/index.js:6303:20)
    at Parser.parseExprSubscripts (/Users/mikael/Documents/Work/Automattic/Calypso/wp-calypso/node_modules/@babel/parser/lib/index.js:5903:21)
    at Parser.parseMaybeUnary (/Users/mikael/Documents/Work/Automattic/Calypso/wp-calypso/node_modules/@babel/parser/lib/index.js:5882:21)
    at Parser.parseExprOps (/Users/mikael/Documents/Work/Automattic/Calypso/wp-calypso/node_modules/@babel/parser/lib/index.js:5791:21)
    at Parser.parseMaybeConditional (/Users/mikael/Documents/Work/Automattic/Calypso/wp-calypso/node_modules/@babel/parser/lib/index.js:5763:21)
    at Parser.parseMaybeAssign (/Users/mikael/Documents/Work/Automattic/Calypso/wp-calypso/node_modules/@babel/parser/lib/index.js:5710:21)
    at Parser.parseFunctionBody (/Users/mikael/Documents/Work/Automattic/Calypso/wp-calypso/node_modules/@babel/parser/lib/index.js:6892:24)
    at Parser.parseArrowExpression (/Users/mikael/Documents/Work/Automattic/Calypso/wp-calypso/node_modules/@babel/parser/lib/index.js:6852:10)
```

I assumed Webpack's `context` would solve that but might be I need to use Babel's `sourceRoot` option somewhere as well. https://babeljs.io/docs/en/babel-core

### Next steps / todo
- We'll need to use [`yargs`](https://yargs.js.org/) or similar to stop passing "nth" arguments and use flags like `--output` instead. That logic should go to `sdk-cli.js`
- Block builder script should export a method so that we don't need to rely on calling it via command line. `sdk-cli.js` should be our only CLI-entry point going forward.
- Jetpack needs a script which operates `calypso-gutenberg-sdk` command. WIP PR: https://github.com/Automattic/jetpack/pull/9944

### Testing
Running this in Calypso folder should still work:
```bash
node bin/create-scripts/block.js client/gutenberg/extensions/hello-dolly/hello-block.js
```

For further testing, you need to link Calypso to Jetpack. Later on, we'll require Calypso via dependencies.

In Calypso folder:
```bash
npm link
```

In Jetpack folder:
```bash
npm link wp-calypso
```

You can now run this in Jetpack folder:
```bash
npx calypso-gutenberg-sdk build-block client/gutenberg/extensions/hello-dolly/hello-block.js $(pwd)/_inc/build
```

...you should see the babel error. To get past that, you could modify hello-dolly with:
```
edit: () => null,
save: () => null,
```

You should end up with a file `_inc/build/blocks-hello-dolly.js` in Jetpack.