### PR TITLE
Imports: Enable the Blogger importer for all environments

### DIFF
--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -50,7 +50,7 @@ const importers = [
 	},
 	{
 		type: BLOGGER,
-		isImporterEnabled: isEnabled( 'manage/import/blogger' ),
+		isImporterEnabled: true,
 		component: BloggerImporter,
 	},
 	{

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -54,7 +54,6 @@
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/import/medium": true,
-		"manage/import/blogger": false,
 		"manage/import/site-importer": true,
 		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": false,

--- a/config/development.json
+++ b/config/development.json
@@ -90,7 +90,6 @@
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
-		"manage/import/blogger": true,
 		"manage/import/site-importer": true,
 		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -55,7 +55,6 @@
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
-		"manage/import/blogger": false,
 		"manage/import/site-importer": true,
 		"manage/media": true,
 		"manage/pages": true,

--- a/config/production.json
+++ b/config/production.json
@@ -57,7 +57,6 @@
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/import/medium": true,
-		"manage/import/blogger": false,
 		"manage/import/site-importer": true,
 		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -60,7 +60,6 @@
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/import/medium": true,
-		"manage/import/blogger": false,
 		"manage/import/site-importer": true,
 		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": false,

--- a/config/test.json
+++ b/config/test.json
@@ -51,7 +51,6 @@
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/import/medium": true,
-		"manage/import/blogger": false,
 		"manage/import/site-importer": true,
 		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -69,7 +69,6 @@
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
-		"manage/import/blogger": true,
 		"manage/import/site-importer": true,
 		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": true,


### PR DESCRIPTION
Combined with the API change, this enables the Blogger.com importer for all environments and removes the check for the feature being enabled.

**Testing**

1. Confirm that you aren't given the choice to import form Blogger in environments other than development and wpcalypso, by visiting, for example, https://wordpress.com/settings/import/
1. Checkout this branch and run Calypso in a different environment e.g. `CALYPSO_ENV=production npm start`
1. Now confirm that you are given the choice to import from Blogger.

