### PR TITLE
Add site importer validation and help

### DIFF
--- a/client/my-sites/importer/error-pane.jsx
+++ b/client/my-sites/importer/error-pane.jsx
@@ -73,6 +73,12 @@ class SiteSettingsImporterError extends React.PureComponent {
 			case 'importError':
 				actionMessage = this.getImportError();
 				break;
+
+			case 'validationError':
+				actionMessage = this.props.description
+					? this.props.description
+					: this.props.translate( 'Data you entered are not valid' );
+				break;
 		}
 
 		return actionMessage;

--- a/client/my-sites/importer/error-pane.jsx
+++ b/client/my-sites/importer/error-pane.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import Page from 'page';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,10 +17,14 @@ import Notice from 'components/notice';
 
 class SiteSettingsImporterError extends React.PureComponent {
 	static displayName = 'SiteSettingsImporterError';
+	static defaultProps = {
+		retryImport: noop,
+	};
 
 	static propTypes = {
 		description: PropTypes.string.isRequired,
 		type: PropTypes.string.isRequired,
+		retryImport: PropTypes.func,
 	};
 
 	contactSupport = event => {
@@ -87,6 +92,7 @@ class SiteSettingsImporterError extends React.PureComponent {
 	retryImport = event => {
 		event.preventDefault();
 		event.stopPropagation();
+		this.props.retryImport();
 	};
 
 	render() {

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -136,7 +136,7 @@ class SiteImporterInputPane extends React.Component {
 
 		let errorMessage;
 		if ( ! siteURL ) {
-			errorMessage = this.props.translate( 'Please enter a URL.' );
+			errorMessage = this.props.translate( 'Please enter a valid URL.' );
 		} else if ( hostname === 'editor.wix.com' || hostname === 'www.wix.com' ) {
 			errorMessage = this.props.translate(
 				'The URL you entered is for the Wix editor which is only accessible to you. Please enter a public URL of your site using one of the formats described below.'

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -34,6 +34,11 @@ import { loadmShotsPreview } from './site-preview-actions';
 
 import { recordTracksEvent } from 'state/analytics/actions';
 
+const NO_ERROR_STATE = {
+	error: false,
+	errorMessage: '',
+	errorType: null,
+};
 class SiteImporterInputPane extends React.Component {
 	static displayName = 'SiteImporterSitePreview';
 
@@ -55,6 +60,7 @@ class SiteImporterInputPane extends React.Component {
 		importStage: 'idle',
 		error: false,
 		errorMessage: '',
+		errorType: null,
 		siteURLInput: '',
 	};
 
@@ -111,13 +117,6 @@ class SiteImporterInputPane extends React.Component {
 				} );
 			}
 		}
-	};
-
-	resetErrors = () => {
-		this.setState( {
-			error: false,
-			errorMessage: '',
-		} );
 	};
 
 	setUrl = event => {
@@ -193,7 +192,10 @@ class SiteImporterInputPane extends React.Component {
 	};
 
 	importSite = () => {
-		this.setState( { loading: true }, this.resetErrors );
+		this.setState( {
+			loading: true,
+			...NO_ERROR_STATE,
+		} );
 
 		this.props.recordTracksEvent( 'calypso_site_importer_start_import', {
 			blog_id: this.props.site.ID,
@@ -271,13 +273,11 @@ class SiteImporterInputPane extends React.Component {
 			previous_stage: this.state.importStage,
 		} );
 
-		this.setState(
-			{
-				loading: false,
-				importStage: 'idle',
-			},
-			this.resetErrors
-		);
+		this.setState( {
+			loading: false,
+			importStage: 'idle',
+			...NO_ERROR_STATE
+		} );
 	};
 
 	render() {

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -327,7 +327,6 @@ class SiteImporterInputPane extends React.Component {
 								onKeyPress={ this.validateOnEnter }
 								value={ this.state.siteURLInput }
 								placeholder="https://example.com/"
-								autoFocus={ true }
 							/>
 							<Button
 								disabled={ this.state.loading }

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -292,6 +292,8 @@ class SiteImporterInputPane extends React.Component {
 								onChange={ this.setUrl }
 								onKeyPress={ this.validateOnEnter }
 								value={ this.state.siteURLInput }
+								placeholder="https://example.com/"
+								autoFocus={ true }
 							/>
 							<Button
 								disabled={ this.state.loading }

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -139,11 +139,11 @@ class SiteImporterInputPane extends React.Component {
 			errorMessage = this.props.translate( 'Please enter a valid URL.' );
 		} else if ( hostname === 'editor.wix.com' || hostname === 'www.wix.com' ) {
 			errorMessage = this.props.translate(
-				'The URL you entered is for the Wix editor which is only accessible to you. Please enter a public URL of your site using one of the formats described below.'
+				"You've entered the URL for the Wix editor, which only you can access. Please enter your site's public URL. It should look like one of the examples below."
 			);
 		} else if ( hostname.indexOf( '.wixsite.com' ) > -1 && pathname === '/' ) {
 			errorMessage = this.props.translate(
-				'The URL you entered is not complete. Please include the part of URL which comes after wixsite.com. See below for an example.'
+				"You haven't entered the full URL. Please include the part of the URL that comes after wixsite.com. See below for an example."
 			);
 		}
 

--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -40,7 +40,7 @@
 	}
 
 	&.medium {
-		background-color: #00AB6C;
+		background-color: #00ab6c;
 	}
 
 	&.blogger-alt {
@@ -48,10 +48,10 @@
 	}
 
 	&.site-importer {
-		background-color: #FAAD4D;
+		background-color: #faad4d;
 	}
 
-	@include breakpoint(">960px") {
+	@include breakpoint( '>960px' ) {
 		width: 56px;
 		height: 56px;
 		padding: 4px;
@@ -61,7 +61,7 @@
 .importer__service-info {
 	margin-bottom: 1.5em;
 
-	@include breakpoint(">480px") {
+	@include breakpoint( '>480px' ) {
 		margin-left: 60px;
 	}
 }
@@ -71,7 +71,7 @@
 	font-weight: 300;
 	color: $gray;
 
-	@include breakpoint(">480px") {
+	@include breakpoint( '>480px' ) {
 		clear: none;
 	}
 }
@@ -93,7 +93,7 @@
 	color: $gray;
 	text-align: center;
 
-	& input {
+	input {
 		visibility: hidden;
 	}
 }
@@ -104,7 +104,7 @@
 	left: 0;
 	right: 0;
 	text-align: center;
-	transform: translateY(-50%);
+	transform: translateY( -50% );
 }
 
 .importer__upload-progress,
@@ -123,7 +123,7 @@
 .importer__import-spinner {
 	position: absolute;
 	left: 50%;
-	transform: translateX(-50%);
+	transform: translateX( -50% );
 }
 
 .importer__start {
@@ -157,7 +157,7 @@
 .importer__mapping-description {
 	margin-bottom: 16px;
 
-	& strong {
+	strong {
 		white-space: nowrap;
 	}
 }
@@ -175,14 +175,14 @@
 .importer__author-mapping {
 	height: 58px;
 
-	& .author-selector__author-toggle {
+	.author-selector__author-toggle {
 		width: 45%;
 		padding-top: 4px;
 		margin-right: -7px;
 		float: right;
 	}
 
-	& div.user {
+	div.user {
 		display: inline;
 	}
 }
@@ -213,46 +213,48 @@
 		margin-bottom: 10px;
 	}
 
-	& .site-importer__site-importer-url-input {
+	.site-importer__site-importer-url-input {
 		display: flex;
+		margin-bottom: 1.5em;
 
-		& .form-text-input {
+		.form-text-input {
 			flex-grow: 1;
 			flex-shrink: 1;
 		}
 
-		& button {
+		button {
 			flex-grow: 0;
 			flex-shrink: 0;
 		}
 	}
 
-	& .site-importer__site-importer-confirm-site-pane-container {
+	.site-importer__site-importer-example-domain {
+		font-family: monospace;
+		color: $blue-medium;
+	}
+
+	.site-importer__site-importer-confirm-site-pane-container {
 		display: flex;
 		align-content: center;
 		justify-content: center;
 		width: 100%;
 		margin-bottom: 18px;
 
-		& .site-importer__site-importer-confirm-site-label {
+		.site-importer__site-importer-confirm-site-label {
 			flex-grow: 1;
 			display: flex;
 			flex-direction: column;
 			justify-content: center;
 		}
-		& .site-importer__site-importer-confirm-site-pane-container-text {
+		.site-importer__site-importer-confirm-site-pane-container-text {
 			margin: inherit;
 		}
 
-		& button {
+		button {
 			float: none;
 			flex-grow: 0;
 			flex-shrink: 0;
 		}
-	}
-
-	& .site-importer__error-message {
-		color: red;
 	}
 }
 
@@ -261,12 +263,12 @@
 	display: flex;
 	flex-direction: column;
 
-	& .site-importer__site-preview-column-container {
-		display:flex;
+	.site-importer__site-preview-column-container {
+		display: flex;
 		flex-direction: row;
 	}
 
-	& .site-importer__site-preview-import-content {
+	.site-importer__site-preview-import-content {
 		flex-grow: 0;
 		flex-shrink: 1;
 
@@ -275,11 +277,10 @@
 		padding-left: 30px;
 	}
 
-	& .site-importer__site-preview-container {
-
+	.site-importer__site-preview-container {
 		max-width: 60%;
 
-		& .site-importer__site-preview-browser-chrome {
+		.site-importer__site-preview-browser-chrome {
 			flex-grow: 0;
 			flex-shrink: 0;
 
@@ -295,37 +296,43 @@
 			font-size: 14px;
 			letter-spacing: 2px;
 
-
 			/* Used to center the dots vertically */
 			display: flex;
 			flex-direction: column;
 			justify-content: center;
 		}
 
-		& .site-importer__site-preview-image {
+		.site-importer__site-preview-image {
+			border: 1px solid #c6d7e2;
+
 			&:after {
-				content: "";
+				content: '';
 				position: absolute;
 				top: 0;
 				bottom: 0;
 				left: 0;
 				right: 0;
-				background: linear-gradient(to bottom, rgba(255,255,255,0), rgba(255,255,255,0) 50%, rgba(255,255,255,1));
+				background: linear-gradient(
+					to bottom,
+					rgba( 255, 255, 255, 0 ),
+					rgba( 255, 255, 255, 0 ) 50%,
+					rgba( 255, 255, 255, 1 )
+				);
 			}
 		}
 
-		& .site-importer__site-preview-favicon {
+		.site-importer__site-preview-favicon {
 			vertical-align: middle;
 		}
 	}
 }
 
 .site-importer__site-preview-overlay-container.isLoading {
-	& .site-importer__site-preview-container {
+	.site-importer__site-preview-container {
 		visibility: hidden;
 	}
 
-	& .site-importer__site-preview-loading-overlay {
+	.site-importer__site-preview-loading-overlay {
 		position: absolute;
 		top: 0;
 		left: 0;


### PR DESCRIPTION
We've seen people not knowing what exactly we expect as an input. This PR adds two main examples with short descriptions and it also adds a frontend validation for the most common mistakes with (hopefully) helpful messages.

There is now a new type of error `validationError` which, contrary to others, only shows the error message and does not provide buttons to retry action or contact support as it will be pointless for a validation error. 

For the general importer error, the retry button did literally nothing so I added and API to hook on it and implemented it for the site importer.

To test:
- Navigate to My Sites > Settings > Import > Wix.com and try inputting URLs in wrong way (empty URL, free URL format but missing the part behind slash, with protocol, without protocol…) We should have a frontend validation for most and the rest is still handled by the backend.
- Make sure the help text under the input makes sense and is useful

I opted for using example.com as the premium domain format example instead of our domains like acustomdomain.com. It's much easier to read quickly and in case somebody tries to visit the URL, they won't be confused by a help article about wpcom custom domains which have nothing to do with this use-case.

Screenshot of the help text:

<img width="691" alt="screen shot 2018-07-26 at 18 33 25" src="https://user-images.githubusercontent.com/156676/43275652-abb6276c-9102-11e8-9016-c31f14f4057c.png">

Frontend validation error:

<img width="675" alt="screen shot 2018-07-26 at 18 35 49" src="https://user-images.githubusercontent.com/156676/43275674-bd692ba8-9102-11e8-87e2-6c0629aaf2fd.png">

Backend validation error (make sure "try again" actually works): 

<img width="680" alt="screen shot 2018-07-26 at 18 36 23" src="https://user-images.githubusercontent.com/156676/43275703-d29f07cc-9102-11e8-8ba8-173b7d613589.png">
