### PR TITLE
Memberships: fix for the getDerivedStateFromProps problem

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/memberships.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/memberships.jsx
@@ -148,40 +148,20 @@ class MembershipsDialog extends Component {
 		};
 	}
 
-	static getDerivedStateFromProps( props, state ) {
-		const openedDialog = props.showDialog && ! state.showDialog;
-		const loadedAndEmpty = state.paymentButtons === null && isEmptyArray( props.paymentButtons );
-
-		if ( ! openedDialog && ! loadedAndEmpty ) {
-			return null;
+	componentDidUpdate( prevProps ) {
+		// When transitioning from hidden to visible, show and initialize the form
+		if ( this.props.showDialog && ! prevProps.showDialog ) {
+			if ( this.props.editPaymentId ) {
+				// Explicitly ordered to edit a particular button
+				this.showButtonForm( this.props.editPaymentId );
+			} else if ( isEmptyArray( this.props.paymentButtons ) ) {
+				// If the button list is loaded and empty, show the "Add New" form
+				this.showButtonForm( null );
+			} else {
+				// If the list is loading or is non-empty, show it
+				this.showButtonList();
+			}
 		}
-
-		const buttonFormState = editedPaymentId => ( {
-			activeTab: 'form',
-			editedPaymentId,
-			initialFormValues: this.getInitialFormFields( editedPaymentId ),
-		} );
-
-		const dialogState = () => {
-			if ( props.editPaymentId ) {
-				return buttonFormState( props.editPaymentId );
-			}
-
-			if ( isEmptyArray( props.paymentButtons ) ) {
-				return buttonFormState( null );
-			}
-
-			return { activeTab: 'list' };
-		};
-
-		const formState = () => buttonFormState( null );
-
-		return {
-			...( openedDialog ? dialogState() : {} ),
-			...( loadedAndEmpty ? formState() : {} ),
-			showDialog: props.showDialog,
-			paymentButtons: props.paymentButtons,
-		};
 	}
 
 	componentDidMount() {


### PR DESCRIPTION
This fixes the problem that I introduced in https://github.com/Automattic/wp-calypso/pull/26022/commits/98f7e6eb25d1c7ab0ad909e5f114d98e1960aa21

I used shiny getDerivedStateFromProps and missed the fact that this function is static.
To make it work would require refactoring half of this component.
somehow I missed that in testing.

I am using componentDidUpdate as React team endorses. There are state checks to make sure it does not blow up.

## Testing

p89M8K-4I-p2 - use Testing setting up a plan – publisher flow  -the input window should show. It does not show now.

