### PR TITLE
Signup: Make Continue button full-width on small screens/mobile devices

### DIFF
--- a/client/signup/steps/about/style.scss
+++ b/client/signup/steps/about/style.scss
@@ -96,11 +96,11 @@
 	text-align: center;
 	margin-bottom: 20px;
 	padding: 0 15px;
+}
 
-	.button {
-		@include breakpoint( '<480px' ) {
-			width: 100%;
-		}
+.about__submit-wrapper .button {
+	@include breakpoint( '<480px' ) {
+		width: 100%;
 	}
 }
 

--- a/client/signup/steps/about/style.scss
+++ b/client/signup/steps/about/style.scss
@@ -95,6 +95,13 @@
 .about__submit-wrapper {
 	text-align: center;
 	margin-bottom: 20px;
+	padding: 0 15px;
+
+	.button {
+		@include breakpoint( '<480px' ) {
+			width: 100%;
+		}
+	}
 }
 
 .about__last-fieldset {


### PR DESCRIPTION
It was suggested we make the Continue button full-width on mobile devices. This PR does that, though now the button collides with the little help button (question mark) in the lower right. What do y'all think?

**Before this PR** 

<img width="398" alt="screen shot 2018-07-24 at 2 47 01 pm" src="https://user-images.githubusercontent.com/2124984/43159594-c2df282a-8f50-11e8-9890-db31d6556dbc.png">

**After this PR**

<img width="357" alt="screen shot 2018-07-24 at 2 45 21 pm" src="https://user-images.githubusercontent.com/2124984/43159538-9cda50be-8f50-11e8-9563-76c37a9a07e9.png">

**Steps to test**

* Switch to this PR
* Navigate to http://calypso.localhost:3000/start/about
* Check out the Continue button on a screen at less than 480px wide