### PR TITLE
Checkout: Fix Chat and Payment buttons alignment

### DIFF
--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -661,19 +661,19 @@
 		display: flex;
 		flex-wrap: wrap;
 	}
-}
 
-.payment-box__payment-buttons .pay-button {
-	margin-right: 10px;
+	.pay-button {
+		margin-right: 10px;
 
-	@include breakpoint( '<960px' ) {
-		flex: 1 0 50%;
+		@include breakpoint( '<960px' ) {
+			flex: 1 0 50%;
+		}
 	}
-}
 
-.payment-box__payment-buttons .pay-button__button {
-	@include breakpoint( '<960px' ) {
-		width: 100%;
+	.pay-button__button {
+		@include breakpoint( '<960px' ) {
+			width: 100%;
+		}
 	}
 }
 

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -11,14 +11,14 @@
 		&-enter {
 			height: 0;
 			opacity: 0.01;
-			transform: translateZ(0) scale(0.8);
+			transform: translateZ( 0 ) scale( 0.8 );
 		}
 
 		&-appear-active,
 		&-enter-active {
 			height: auto;
 			opacity: 1;
-			transform: translateZ(0) scale(1);
+			transform: translateZ( 0 ) scale( 1 );
 			transition-property: height, opacity, transform;
 			transition-duration: 400ms;
 		}
@@ -30,7 +30,8 @@
 		}
 
 		.is-empty {
-			.payment-box-section, .checkout__payment-box-section {
+			.payment-box-section,
+			.checkout__payment-box-section {
 				border: 1px solid $gray-lighten-30;
 				margin: 5px 0;
 				display: flex;
@@ -55,7 +56,6 @@
 				::after {
 					content: '';
 				}
-
 			}
 
 			.payment-box__header {
@@ -104,7 +104,7 @@
 				height: 50px;
 				width: 100%;
 
-				@include breakpoint ( '>480px' ) {
+				@include breakpoint( '>480px' ) {
 					width: 80px;
 					height: 40px;
 				}
@@ -114,7 +114,7 @@
 				margin-top: 55px;
 
 				@include breakpoint( '>480px' ) {
-						margin-top: 20px;
+					margin-top: 20px;
 				}
 			}
 
@@ -171,7 +171,8 @@
 		}
 	}
 
-	button[type=submit].button-pay, button[type=submit].checkout__button-pay {
+	button[type='submit'].button-pay,
+	button[type='submit'].checkout__button-pay {
 		@include breakpoint( '<660px' ) {
 			width: 100%;
 
@@ -187,7 +188,7 @@
 	}
 
 	// Turn off number spinners
-	input[type=number] {
+	input[type='number'] {
 		-moz-appearance: textfield;
 
 		&::-webkit-outer-spin-button,
@@ -200,7 +201,8 @@
 	// Floating labels
 	// -----------------------------------
 
-	.checkout-field, .checkout__checkout-field {
+	.checkout-field,
+	.checkout__checkout-field {
 		margin-top: 15px;
 		position: relative;
 
@@ -273,7 +275,8 @@
 		}
 	}
 
-	.payment-box-actions, .checkout__payment-box-actions {
+	.payment-box-actions,
+	.checkout__payment-box-actions {
 		margin: 20px -30px 0 -30px;
 		padding: 20px 30px 0;
 		@include clear-fix;
@@ -282,7 +285,7 @@
 	.credit-card-payment-box {
 		.payment-box-sections {
 			background-color: $white;
-			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.075);
+			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.075 );
 
 			@include breakpoint( '>660px' ) {
 				box-shadow: none;
@@ -389,7 +392,7 @@
 		// Parent overflow is hidden, so 80px here is an arbitrary number
 		// to make sure this element will cover entire width of the parent.
 		// If it's wider, it's okay too.
-		width: calc(100% + 80px * 2);
+		width: calc( 100% + 80px * 2 );
 		left: -80px;
 		margin-top: 1.7em;
 		margin-bottom: 1.7em;
@@ -405,9 +408,10 @@
 
 	.paypal-payment-box,
 	.credits-payment-box {
-		.payment-box-section, .checkout__payment-box-section {
+		.payment-box-section,
+		.checkout__payment-box-section {
 			background-color: $white;
-			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.075);
+			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.075 );
 
 			@include breakpoint( '>660px' ) {
 				border: 1px solid $gray-lighten-30;
@@ -417,7 +421,8 @@
 	}
 
 	.paypal-payment-box {
-		.payment-box-section, .checkout__payment-box-section {
+		.payment-box-section,
+		.checkout__payment-box-section {
 			display: flex;
 			flex-wrap: wrap;
 			justify-content: space-between;
@@ -603,7 +608,8 @@
 // If there's no sidebar, we don't show the cart on the checkout page.
 
 @include breakpoint( '>660px' ) {
-	.pay-button, .checkout__pay-button {
+	.pay-button,
+	.checkout__pay-button {
 		float: left;
 	}
 }
@@ -619,10 +625,15 @@
 	padding-bottom: 5px;
 
 	img {
-		margin-left:8px;
+		margin-left: 8px;
 	}
 
-	&.ideal, &.giropay, &.bancontact, &.p24, &.alipay, &.eps {
+	&.ideal,
+	&.giropay,
+	&.bancontact,
+	&.p24,
+	&.alipay,
+	&.eps {
 		margin-left: 1em;
 	}
 
@@ -645,20 +656,34 @@
 	}
 }
 
-@include breakpoint( '>660px' ) {
-	.payment-box__payment-buttons {
+.payment-box__payment-buttons {
+	@include breakpoint( '>660px' ) {
 		display: flex;
-		align-items: center;
+		flex-wrap: wrap;
+	}
+}
+
+.payment-box__payment-buttons .pay-button {
+	margin-right: 10px;
+
+	@include breakpoint( '<960px' ) {
+		flex: 1 0 50%;
+	}
+}
+
+.payment-box__payment-buttons .pay-button__button {
+	@include breakpoint( '<960px' ) {
+		width: 100%;
 	}
 }
 
 .checkout__secure-payment {
-	margin-top: 10px;
 	color: $gray-lighten-10;
+	flex-grow: 1;
+	margin-top: 10px;
 
 	@include breakpoint( '>660px' ) {
-		margin: 0 10px;
-		display: inline-block;
+		flex: 1 0 40%;
 	}
 }
 
@@ -672,22 +697,31 @@
 	}
 }
 
-.checkout__payment-chat-button-icon {
-	color: $blue-wordpress;
-	margin-right: 5px;
-}
+.checkout__payment-chat-button.is-borderless {
+	color: $blue-medium;
+	text-align: left;
 
-.checkout__payment-chat-button {
 	@include breakpoint( '<660px' ) {
-		width: 100%;
 		text-align: center;
+		margin-top: 5px;
+		width: 100%;
 	}
 
 	@include breakpoint( '>960px' ) {
-		display: flex;
-		flex-grow: 1;
-		align-items: center;
-		justify-content: right;
+		justify-content: flex-end;
+	}
+
+	&:hover {
+		color: $blue-light;
+	}
+
+	&:focus {
+		color: $blue-wordpress;
+	}
+
+	.gridicon {
+		margin-right: 4px;
+		top: 9px;
 	}
 }
 
@@ -829,20 +863,20 @@
 	}
 
 	.checkout__giropay {
-	  width: 80px;
-      margin: -10px 0;
+		width: 80px;
+		margin: -10px 0;
 	}
 
 	.checkout__bancontact {
-	  width: 150px;
-	  margin: -10px 0;
+		width: 150px;
+		margin: -10px 0;
 	}
 
-  	.checkout__ideal {
-    	width: 26px;
-    	margin-bottom: 2px;
-    	margin-right: 4px;
-  	}
+	.checkout__ideal {
+		width: 26px;
+		margin-bottom: 2px;
+		margin-right: 4px;
+	}
 
 	.checkout__p24 {
 		width: 80px;
@@ -899,7 +933,7 @@
 // Emergent Paywall
 // -----------------------------------
 .checkout__emergent-paywall-form {
-	height:0;
+	height: 0;
 	width: 0;
 }
 .checkout__emergent-paywall-loading-content {
@@ -918,7 +952,6 @@
 		overflow: visible;
 	}
 }
-
 
 // Ebanx checkout fields
 // -----------------------------------
@@ -948,11 +981,11 @@
 		}
 
 		.street-number {
-			flex-basis: calc( 33% - 15px);
+			flex-basis: calc( 33% - 15px );
 		}
 
 		.address-1 {
-			flex-basis: calc( 66% - 15px);
+			flex-basis: calc( 66% - 15px );
 		}
 
 		.document,
@@ -964,7 +997,7 @@
 	}
 	.form__hidden-input a {
 		display: block;
-		font-size:  12px;
+		font-size: 12px;
 		margin-left: 15px;
 	}
 	select {


### PR DESCRIPTION
This PR fixes the alignment and colors of the Payment button, Secure Payment, and Chat buttons in Checkout.

**Before:**

In `>960px`:
![screenshot 2018-07-24 12 13 31](https://user-images.githubusercontent.com/4924246/43160960-8378d1aa-8f3b-11e8-91f1-fbc49e6d40fd.png)

In `<960px`:
![screenshot 2018-07-24 12 13 37](https://user-images.githubusercontent.com/4924246/43160961-839851d8-8f3b-11e8-88f2-ac63039c8076.png)

In `<660px`:
![screenshot 2018-07-24 12 13 46](https://user-images.githubusercontent.com/4924246/43160962-83ba1d68-8f3b-11e8-83eb-50516abb1d97.png)

**After:**

In `>960px`:
![screenshot 2018-07-24 12 12 44](https://user-images.githubusercontent.com/4924246/43161019-b2be9be8-8f3b-11e8-9053-b91772357b6c.png)

In `<960px`:
![screenshot 2018-07-24 12 12 50](https://user-images.githubusercontent.com/4924246/43161021-b2de113a-8f3b-11e8-89e0-a76c0bd47e64.png)

In `<660px`:
![screenshot 2018-07-24 12 13 08](https://user-images.githubusercontent.com/4924246/43161023-b2fa0f66-8f3b-11e8-8e63-644efecf52f4.png)

I also noticed some inconsistent with the link colors for Coupons and Order Summary, but those have to do with the `button` component itself which will have to be addressed separately.

### To Test:

For the Chat button to display, pre-sales chat has to be available and there has to be a Business plan in the cart. 

You can force it by removing the wrapper condition around `<PaymentChatButton ...>` https://github.com/Automattic/wp-calypso/blob/d588a48/client/my-sites/checkout/checkout/credit-card-payment-box.jsx#L154 , and commenting out the `showButton` condition block in https://github.com/Automattic/wp-calypso/blob/d588a48/client/components/happychat/button.jsx#L91.

Related: https://github.com/Automattic/wp-calypso/pull/25840