### PR TITLE
Domains: Featured domains style tweaks for mobile devices/small screens

### DIFF
--- a/client/components/domains/featured-domain-suggestions/styles/base.scss
+++ b/client/components/domains/featured-domain-suggestions/styles/base.scss
@@ -38,10 +38,15 @@
 	}
 
 	.domain-registration-suggestion__title {
-		font-size: 2em;
+		font-size: 1.6em;
 		font-weight: 600;
 		line-height: 1.2;
-		margin-bottom: 0.125em;
+		margin-bottom: 0.25em;
+
+		@include breakpoint( '>480px' ) {
+			font-size: 2em;
+			margin-bottom: 0.125em;
+		}
 	}
 
 	// .card used to increase specificity
@@ -104,10 +109,6 @@
 @include breakpoint( '<660px' ) {
 	.featured-domain-suggestions {
 		flex-flow: wrap;
-
-		.featured-domain-suggestion .domain-suggestion__action.button.is-primary {
-			width: initial;
-		}
 	}
 }
 


### PR DESCRIPTION
* Make buttons full width
* Reduce font size on domain titles

**Before this PR**

<img width="333" alt="screen shot 2018-07-24 at 4 00 35 pm" src="https://user-images.githubusercontent.com/2124984/43162990-bfdc7344-8f5a-11e8-8752-135d56c071ce.png">

**After this PR**

<img width="339" alt="screen shot 2018-07-24 at 4 00 11 pm" src="https://user-images.githubusercontent.com/2124984/43162995-c2d9df6e-8f5a-11e8-8140-e36f6a98d3f7.png">

**Steps to test**

* Switch to this PR
* Navigate to `/start/domains/` and search for a domain name
* Resize screen to less than 480px wide
* Check button styles, heading font sizes, etc.
* Also check large screen size to ensure nothing has been altered/broken