### PR TITLE
App Banners: hide stats app banner in the activity log

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -228,11 +228,12 @@ export function buildDeepLinkFragment( currentRoute, currentSection ) {
 const mapStateToProps = state => {
 	const sectionName = getSectionName( state );
 	const isNotesOpen = isNotificationsOpen( state );
+	const currentRoute = getCurrentRoute( state );
 
 	return {
 		dismissedUntil: getPreference( state, APP_BANNER_DISMISS_TIMES_PREFERENCE ),
-		currentSection: getCurrentSection( sectionName, isNotesOpen ),
-		currentRoute: getCurrentRoute( state ),
+		currentSection: getCurrentSection( sectionName, isNotesOpen, currentRoute ),
+		currentRoute,
 		fetchingPreferences: isFetchingPreferences( state ),
 		siteId: getSelectedSiteId( state ),
 	};

--- a/client/blocks/app-banner/test/app-banner.jsx
+++ b/client/blocks/app-banner/test/app-banner.jsx
@@ -7,7 +7,7 @@
  * Internal dependencies
  */
 import { getiOSDeepLink, buildDeepLinkFragment } from 'blocks/app-banner';
-import { EDITOR, NOTES, READER, STATS } from 'blocks/app-banner/utils';
+import { EDITOR, NOTES, READER, STATS, getCurrentSection } from 'blocks/app-banner/utils';
 
 describe( 'iOS deep link fragments', () => {
 	test( 'properly encodes tricky fragments', () => {
@@ -60,5 +60,31 @@ describe( 'iOS deep links', () => {
 	test( 'includes fragment in URI', () => {
 		expect( getiOSDeepLink( '/test', STATS ).includes( '#' ) ).toBeTruthy();
 		expect( getiOSDeepLink( '/test', STATS ).split( '#' )[ 1 ].length ).toBeTruthy();
+	} );
+} );
+
+describe( 'getCurrentSection', () => {
+	test( 'returns stats if in stats section', () => {
+		expect( getCurrentSection( STATS, false, '/stats/123' ) ).toBe( STATS );
+	} );
+
+	test( 'returns null for activity log page', () => {
+		expect( getCurrentSection( STATS, false, '/stats/activity/123' ) ).toBe( null );
+	} );
+
+	test( 'returns notes if notes is open', () => {
+		expect( getCurrentSection( STATS, true, '/stats/123' ) ).toBe( NOTES );
+	} );
+
+	test( 'returns reader if in reader section', () => {
+		expect( getCurrentSection( READER, false, '/' ) ).toBe( READER );
+	} );
+
+	test( 'returns editor if in editor section', () => {
+		expect( getCurrentSection( EDITOR, false, '/post/123' ) ).toBe( EDITOR );
+	} );
+
+	test( 'returns null if in a disallowed section', () => {
+		expect( getCurrentSection( 'plugins', false, '/plugins/123' ) ).toBe( null );
 	} );
 } );

--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -49,12 +49,12 @@ export function getAppBannerData( translate, sectionName ) {
 	}
 }
 
-export function getCurrentSection( currentSection, isNotesOpen ) {
+export function getCurrentSection( currentSection, isNotesOpen, currentRoute ) {
 	if ( isNotesOpen ) {
 		return NOTES;
 	}
 
-	if ( window && window.location.href.indexOf( '/stats/activity/' ) !== -1 ) {
+	if ( currentRoute && currentRoute.indexOf( '/stats/activity/' ) !== -1 ) {
 		//don't show app banner in activity log
 		return null;
 	}

--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -54,6 +54,11 @@ export function getCurrentSection( currentSection, isNotesOpen ) {
 		return NOTES;
 	}
 
+	if ( window && window.location.href.indexOf( '/stats/activity/' ) !== -1 ) {
+		//don't show app banner in activity log
+		return null;
+	}
+
 	if ( includes( ALLOWED_SECTIONS, currentSection ) ) {
 		return currentSection;
 	}


### PR DESCRIPTION
Fixes #23546 

To test:

- With this patch running, visit the activity page in Chrome
- Use [device mode](https://developers.google.com/web/tools/chrome-devtools/device-mode/) in your console to simulate a mobile device
- The 'Stats at your Fingertips' banner should not be visible on the activity page
- On other stats pages, the banner should be visible

<img width="173" alt="screen shot 2018-07-24 at 4 23 27 pm" src="https://user-images.githubusercontent.com/2694219/43164262-bb3433dc-8f5e-11e8-9e02-658368f4fc35.png">


<img width="183" alt="screen shot 2018-07-24 at 4 24 14 pm" src="https://user-images.githubusercontent.com/2694219/43164269-bfd2707a-8f5e-11e8-916c-04cbb7a66620.png">


Props @gwwar for the suggested approach.