### PR TITLE
Activity Log: show activity log for free WordPress.com sites

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -4,7 +4,6 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { get } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -17,11 +16,8 @@ import Intervals from './intervals';
 import FollowersCount from 'blocks/followers-count';
 import isGoogleMyBusinessLocationConnectedSelector from 'state/selectors/is-google-my-business-location-connected';
 import isSiteStore from 'state/selectors/is-site-store';
-import { isJetpackSite } from 'state/sites/selectors';
-import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { navItems, intervals as intervalConstants } from './constants';
 import config from 'config';
-import { isWpComFreePlan } from 'lib/plans';
 
 class StatsNavigation extends Component {
 	static propTypes = {
@@ -34,32 +30,11 @@ class StatsNavigation extends Component {
 	};
 
 	isValidItem = item => {
-		const {
-			isGoogleMyBusinessLocationConnected,
-			isStore,
-			isJetpack,
-			siteId,
-			isWpComPaidPlan,
-		} = this.props;
+		const { isGoogleMyBusinessLocationConnected, isStore, siteId } = this.props;
 
 		switch ( item ) {
 			case 'store':
 				return isStore;
-
-			case 'activity':
-				if ( 'undefined' === typeof siteId ) {
-					return false;
-				}
-
-				if ( isJetpack ) {
-					return true;
-				}
-
-				if ( isWpComPaidPlan ) {
-					return true;
-				}
-
-				return config.isEnabled( 'activity-log-wpcom-free' );
 
 			case 'googleMyBusiness':
 				if ( 'undefined' === typeof siteId ) {
@@ -107,15 +82,12 @@ class StatsNavigation extends Component {
 }
 
 export default connect( ( state, { siteId } ) => {
-	const productSlug = get( getCurrentPlan( state, siteId ), 'productSlug' );
 	return {
 		isGoogleMyBusinessLocationConnected: isGoogleMyBusinessLocationConnectedSelector(
 			state,
 			siteId
 		),
 		isStore: isSiteStore( state, siteId ),
-		isJetpack: isJetpackSite( state, siteId ),
-		isWpComPaidPlan: ! isWpComFreePlan( productSlug ),
 		siteId,
 	};
 } )( StatsNavigation );

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -19,8 +19,6 @@ import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import getActivityLogFilter from 'state/selectors/get-activity-log-filter';
-import { isWpComFreePlan } from 'lib/plans';
-import { getCurrentPlan } from 'state/sites/plans/selectors';
 import FollowList from 'lib/follow-list';
 import StatsInsights from './stats-insights';
 import StatsOverview from './overview';
@@ -29,7 +27,6 @@ import StatsSummary from './summary';
 import StatsPostDetail from './stats-post-detail';
 import StatsCommentFollows from './comment-follows';
 import ActivityLog from './activity-log';
-import config from 'config';
 import { isDesktop } from 'lib/viewport';
 import { setFilter } from 'state/activity-log/actions';
 import { queryToFilterState } from 'state/activity-log/utils';
@@ -391,17 +388,9 @@ export default {
 	activityLog: function( context, next ) {
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );
-		const siteHasWpcomFreePlan = isWpComFreePlan(
-			get( getCurrentPlan( state, siteId ), 'productSlug' )
-		);
 		const startDate = i18n.moment( context.query.startDate, 'YYYY-MM-DD' ).isValid()
 			? context.query.startDate
 			: undefined;
-
-		if ( siteId && siteHasWpcomFreePlan && ! config.isEnabled( 'activity-log-wpcom-free' ) ) {
-			page.redirect( '/stats' );
-			return next();
-		}
 
 		const filter = getActivityLogFilter( state, siteId );
 		const queryFilter = queryToFilterState( context.query );

--- a/config/development.json
+++ b/config/development.json
@@ -29,7 +29,6 @@
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"support_site_locales": [ "en", "es", "de", "ja", "pt-br" ],
 	"features": {
-		"activity-log-wpcom-free": true,
 		"account-recovery": true,
 		"ad-tracking": false,
 		"automated-transfer": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -19,7 +19,6 @@
 		"pt-br"
 	],
 	"features": {
-		"activity-log-wpcom-free": true,
 		"ad-tracking": false,
 		"apple-pay": true,
 		"automated-transfer": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -16,7 +16,6 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
-		"activity-log-wpcom-free": true,
 		"ad-tracking": false,
 		"automated-transfer": true,
 		"apple-pay": true,


### PR DESCRIPTION
Fixes #26126 

Removes feature flag, and makes the activity page visible to all sites including free WordPress.com sites.
