### PR TITLE
Store Services: Fix customs info value/weight totals

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -183,7 +183,7 @@ export const submitStep = ( orderId, siteId, stepName ) => ( dispatch, getState 
 	expandFirstErroneousStep( orderId, siteId, dispatch, getState );
 };
 
-const convertToApiPackage = ( pckg, siteId, orderId, state, customsItems ) => {
+export const convertToApiPackage = ( pckg, siteId, orderId, state, customsItems ) => {
 	const apiPckg = pick( pckg, [
 		'id',
 		'box_id',

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -208,15 +208,19 @@ export const convertToApiPackage = ( pckg, siteId, orderId, state, customsItems 
 				? getProductValueFromOrder( state, productId, orderId, siteId )
 				: customsItems[ productId ].value;
 
-		apiPckg.items = uniqBy( pckg.items, 'product_id' ).map( ( { product_id } ) => ( {
-			description: customsItems[ product_id ].description,
-			quantity: sumBy( filter( pckg.items, { product_id } ), 'quantity' ),
-			value: getProductValue( product_id ),
-			weight: customsItems[ product_id ].weight,
-			hs_tariff_number: customsItems[ product_id ].tariffNumber,
-			origin_country: customsItems[ product_id ].originCountry,
-			product_id,
-		} ) );
+		apiPckg.items = uniqBy( pckg.items, 'product_id' ).map( ( { product_id } ) => {
+			const quantity = sumBy( filter( pckg.items, { product_id } ), 'quantity' );
+
+			return {
+				description: customsItems[ product_id ].description,
+				quantity,
+				value: quantity * getProductValue( product_id ),
+				weight: quantity * customsItems[ product_id ].weight,
+				hs_tariff_number: customsItems[ product_id ].tariffNumber,
+				origin_country: customsItems[ product_id ].originCountry,
+				product_id,
+			};
+		} );
 	}
 	return apiPckg;
 };

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
@@ -10,10 +10,7 @@ import nock from 'nock';
 /**
  * Internal dependencies
  */
-import {
-	openPrintingFlow,
-	convertToApiPackage,
-} from '../actions';
+import { openPrintingFlow, convertToApiPackage } from '../actions';
 import {
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP,
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW,
@@ -263,7 +260,7 @@ describe( 'Shipping label Actions', () => {
 					{
 						product_id: 123,
 						quantity: 2,
-					}
+					},
 				],
 			};
 
@@ -274,12 +271,10 @@ describe( 'Shipping label Actions', () => {
 					description: 'Product',
 					tariffNumber: '098',
 					originCountry: 'US',
-				}
+				},
 			};
 
-			expect(
-				convertToApiPackage( pckg, null, null, null, customsItems )
-			).to.deep.equal( {
+			expect( convertToApiPackage( pckg, null, null, null, customsItems ) ).to.deep.equal( {
 				id: 'id',
 				box_id: 'box_id',
 				service_id: 'service_id',
@@ -301,7 +296,7 @@ describe( 'Shipping label Actions', () => {
 						weight: 8,
 						hs_tariff_number: '098',
 						origin_country: 'US',
-					}
+					},
 				],
 			} );
 		} );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
@@ -10,7 +10,10 @@ import nock from 'nock';
 /**
  * Internal dependencies
  */
-import { openPrintingFlow } from '../actions';
+import {
+	openPrintingFlow,
+	convertToApiPackage,
+} from '../actions';
 import {
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP,
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW,
@@ -243,5 +246,64 @@ describe( 'Shipping label Actions', () => {
 		} );
 
 		nock.cleanAll();
+	} );
+
+	describe( '#convertToApiPackage', () => {
+		it( 'totals value correctly (by quantity)', () => {
+			const pckg = {
+				id: 'id',
+				box_id: 'box_id',
+				service_id: 'service_id',
+				length: 5,
+				width: 6,
+				height: 7,
+				weight: 8,
+				signature: 'signature',
+				items: [
+					{
+						product_id: 123,
+						quantity: 2,
+					}
+				],
+			};
+
+			const customsItems = {
+				123: {
+					weight: 4,
+					value: 3,
+					description: 'Product',
+					tariffNumber: '098',
+					originCountry: 'US',
+				}
+			};
+
+			expect(
+				convertToApiPackage( pckg, null, null, null, customsItems )
+			).to.deep.equal( {
+				id: 'id',
+				box_id: 'box_id',
+				service_id: 'service_id',
+				length: 5,
+				width: 6,
+				height: 7,
+				weight: 8,
+				signature: 'signature',
+				contents_type: 'merchandise',
+				restriction_type: 'none',
+				abandon_on_non_delivery: false,
+				itn: '',
+				items: [
+					{
+						product_id: 123,
+						description: 'Product',
+						quantity: 2,
+						value: 6,
+						weight: 8,
+						hs_tariff_number: '098',
+						origin_country: 'US',
+					}
+				],
+			} );
+		} );
 	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/1467

This PR modifies the `convertToApiPackage()` method to account for quantity when calculating a `CustomsItem`s `value` and `weight` properties, which are meant to be totals.