### PR TITLE
Revert "Editor: Defer mounting of children in Accordion."

### DIFF
--- a/client/components/accordion/index.jsx
+++ b/client/components/accordion/index.jsx
@@ -50,20 +50,14 @@ export default class Accordion extends Component {
 		this.props.onToggle( isExpanded );
 	};
 
-	_mountChildren = false;
-
 	render() {
 		const { className, icon, title, subtitle, status, children, e2eTitle } = this.props;
-		const isExpanded = this.state.isExpanded || this.props.forceExpand;
 		const classes = classNames( 'accordion', className, {
-			'is-expanded': isExpanded,
+			'is-expanded': this.state.isExpanded || this.props.forceExpand,
 			'has-icon': !! icon,
 			'has-subtitle': !! subtitle,
 			'has-status': !! status,
 		} );
-
-		// Keep children off the render tree until it's first expanded.
-		this._mountChildren = this._mountChildren || isExpanded;
 
 		return (
 			<div
@@ -82,11 +76,9 @@ export default class Accordion extends Component {
 					</button>
 					{ status && <AccordionStatus { ...status } /> }
 				</header>
-				{ this._mountChildren && (
-					<div className="accordion__content">
-						<div className="accordion__content-wrap">{ children }</div>
-					</div>
-				) }
+				<div className="accordion__content">
+					<div className="accordion__content-wrap">{ children }</div>
+				</div>
 			</div>
 		);
 	}

--- a/client/components/accordion/test/index.jsx
+++ b/client/components/accordion/test/index.jsx
@@ -18,7 +18,7 @@ describe( 'Accordion', () => {
 		AccordionStatus = require( '../status' );
 	} );
 
-	test( 'should render as expected with a title but no content when initially closed', () => {
+	test( 'should render as expected with a title and content', () => {
 		const wrapper = shallow( <Accordion title="Section">Content</Accordion> );
 
 		expect( wrapper.hasClass( 'accordion' ) ).toBe( true );
@@ -29,7 +29,7 @@ describe( 'Accordion', () => {
 		expect( wrapper.find( '.accordion__title' ).text() ).toBe( 'Section' );
 		expect( wrapper.find( '.accordion__subtitle' ) ).toHaveLength( 0 );
 		expect( wrapper.find( '.accordion__icon' ) ).toHaveLength( 0 );
-		expect( wrapper.find( '.accordion__content' ) ).toHaveLength( 0 );
+		expect( wrapper.find( '.accordion__content' ).text() ).toBe( 'Content' );
 	} );
 
 	test( 'should accept an icon prop to be rendered', () => {
@@ -113,15 +113,6 @@ describe( 'Accordion', () => {
 			expect( toggleSpy ).toHaveBeenCalledTimes( 1 );
 			expect( toggleSpy ).toHaveBeenCalledWith( false );
 			expect( wrapper.state( 'isExpanded' ) ).toBe( false );
-		} );
-
-		test( 'should render content when initially open', () => {
-			const wrapper = shallow(
-				<Accordion initialExpanded={ true } title="Section">
-					Content
-				</Accordion>
-			);
-			expect( wrapper.find( '.accordion__content' ).text() ).toBe( 'Content' );
 		} );
 	} );
 } );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#26227