### PR TITLE
Site Settings: Display WordPress Version for Jetpack Sites

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -35,10 +35,9 @@ import { isBusiness } from 'lib/products-values';
 import { FEATURE_NO_BRANDING, PLAN_BUSINESS } from 'lib/plans/constants';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { preventWidows } from 'lib/formatting';
 import scrollTo from 'lib/scroll-to';
-import { getSelectedSite } from '../../state/ui/selectors';
 
 export class SiteSettingsFormGeneral extends Component {
 	componentWillMount() {

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -38,6 +38,7 @@ import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { preventWidows } from 'lib/formatting';
 import scrollTo from 'lib/scroll-to';
+import { getSelectedSite } from '../../state/ui/selectors';
 
 export class SiteSettingsFormGeneral extends Component {
 	componentWillMount() {
@@ -115,6 +116,24 @@ export class SiteSettingsFormGeneral extends Component {
 				</div>
 				<SiteIconSetting />
 			</div>
+		);
+	}
+
+	WordPressVersion() {
+		const { translate, selectedSite } = this.props;
+
+		return (
+			<FormFieldset>
+				<FormLabel htmlFor="wpversion">{ translate( 'WordPress Version' ) }</FormLabel>
+				<FormInput
+					name="wpversion"
+					id="wpversion"
+					data-tip-target="site-title-input"
+					type="text"
+					value={ get( selectedSite, 'options.software_version' ) }
+					disabled
+				/>
+			</FormFieldset>
 		);
 	}
 
@@ -490,6 +509,7 @@ export class SiteSettingsFormGeneral extends Component {
 						{ this.blogAddress() }
 						{ this.languageOptions() }
 						{ this.Timezone() }
+						{ siteIsJetpack && this.WordPressVersion() }
 					</form>
 				</Card>
 
@@ -571,12 +591,14 @@ const connectComponent = connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
 		const siteIsJetpack = isJetpackSite( state, siteId );
+		const selectedSite = getSelectedSite( state );
 
 		return {
 			siteIsJetpack,
 			siteSlug: getSelectedSiteSlug( state ),
 			supportsLanguageSelection:
 				! siteIsJetpack || isJetpackMinimumVersion( state, siteId, '5.9-alpha' ),
+			selectedSite,
 		};
 	},
 	null,


### PR DESCRIPTION
Fixes #2165

Adds a WordPress version to Site Settings for Jetpack Sites

**Testing Instructions**

* Visit Site Settings -> General
* Ensure this shows for a Jetpack site
* Ensure this shows for Atomic sites (they are Jetpack sites)
* Ensure this doesn't show for Simple Sites
* Works on mobile

**Example**

<img width="746" alt="screen shot 2018-07-25 at 4 32 23 pm" src="https://user-images.githubusercontent.com/128826/43183487-a1aca104-9028-11e8-9a12-9e2a1c03309d.png">
