### PR TITLE
Importers: Correct the importer type shown on the Author Mapping Pane

### DIFF
--- a/client/my-sites/importer/author-mapping-pane.jsx
+++ b/client/my-sites/importer/author-mapping-pane.jsx
@@ -32,7 +32,7 @@ class ImporterMappingPane extends React.PureComponent {
 		).isRequired,
 		sourceTitle: PropTypes.string.isRequired,
 		targetTitle: PropTypes.string.isRequired,
-		sourceType: PropTypes.string.isRequierd,
+		sourceType: PropTypes.string,
 	};
 
 	getFetchOptions = ( options = {} ) => {

--- a/client/my-sites/importer/author-mapping-pane.jsx
+++ b/client/my-sites/importer/author-mapping-pane.jsx
@@ -32,6 +32,7 @@ class ImporterMappingPane extends React.PureComponent {
 		).isRequired,
 		sourceTitle: PropTypes.string.isRequired,
 		targetTitle: PropTypes.string.isRequired,
+		sourceType: PropTypes.string.isRequierd,
 	};
 
 	getFetchOptions = ( options = {} ) => {
@@ -46,7 +47,7 @@ class ImporterMappingPane extends React.PureComponent {
 		);
 	};
 
-	getMappingDescription = ( numSourceUsers, numTargetUsers, targetTitle ) => {
+	getMappingDescription = ( numSourceUsers, numTargetUsers, targetTitle, sourceType ) => {
 		if ( numTargetUsers === 1 && numSourceUsers === 1 ) {
 			return this.props.translate(
 				'We found one author on your %(sourceType)s site. ' +
@@ -55,7 +56,7 @@ class ImporterMappingPane extends React.PureComponent {
 					'Click Start Import to proceed.',
 				{
 					args: {
-						sourceType: 'WordPress',
+						sourceType: sourceType,
 						destinationSiteTitle: targetTitle,
 					},
 					components: {
@@ -71,7 +72,7 @@ class ImporterMappingPane extends React.PureComponent {
 					'Click Start Import to proceed.',
 				{
 					args: {
-						sourceType: 'WordPress',
+						sourceType: sourceType,
 						destinationSiteTitle: targetTitle,
 					},
 					components: {
@@ -128,13 +129,15 @@ class ImporterMappingPane extends React.PureComponent {
 			onMap,
 			onStartImport,
 			siteId,
+			sourceType,
 		} = this.props;
 		const canStartImport = hasSingleAuthor || sourceAuthors.some( author => author.mappedTo );
 		const targetUserCount = this.getUserCount();
 		const mappingDescription = this.getMappingDescription(
 			sourceAuthors.length,
 			targetUserCount,
-			targetTitle
+			targetTitle,
+			sourceType
 		);
 
 		return (

--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -79,7 +79,7 @@ export default class extends React.PureComponent {
 					<ErrorPane type={ state.errorData.type } description={ state.errorData.description } />
 				) }
 				{ includes( importingStates, state.importerState ) && (
-					<ImportingPane importerStatus={ state } site={ this.props.site } />
+					<ImportingPane importerStatus={ state } { ...{ site, title } } />
 				) }
 				{ includes( uploadingStates, state.importerState ) && (
 					<UploadingPane description={ uploadDescription } importerStatus={ state } />

--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -79,7 +79,7 @@ export default class extends React.PureComponent {
 					<ErrorPane type={ state.errorData.type } description={ state.errorData.description } />
 				) }
 				{ includes( importingStates, state.importerState ) && (
-					<ImportingPane importerStatus={ state } { ...{ site, title } } />
+					<ImportingPane importerStatus={ state } sourceType={ title } { ...{ site } } />
 				) }
 				{ includes( uploadingStates, state.importerState ) && (
 					<UploadingPane description={ uploadDescription } importerStatus={ state } />

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -237,6 +237,7 @@ class ImportingPane extends React.PureComponent {
 						sourceAuthors={ customData.sourceAuthors }
 						sourceTitle={ customData.siteTitle || translate( 'Original Site' ) }
 						targetTitle={ siteName }
+						sourceType={ this.props.title }
 					/>
 				) }
 				{ this.isImporting() &&

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -105,6 +105,7 @@ class ImportingPane extends React.PureComponent {
 			ID: PropTypes.number.isRequired,
 			single_user_site: PropTypes.bool.isRequired,
 		} ).isRequired,
+		sourceType: PropTypes.string.isRequired,
 	};
 
 	getErrorMessage = ( { description } ) => {
@@ -201,6 +202,7 @@ class ImportingPane extends React.PureComponent {
 			importerStatus: { importerId, errorData = {}, customData },
 			mapAuthorFor,
 			site: { ID: siteId, name: siteName, single_user_site: hasSingleAuthor },
+			sourceType,
 		} = this.props;
 
 		const progressClasses = classNames( 'importer__import-progress', {
@@ -233,11 +235,10 @@ class ImportingPane extends React.PureComponent {
 						hasSingleAuthor={ hasSingleAuthor }
 						onMap={ mapAuthorFor( importerId ) }
 						onStartImport={ () => startImporting( this.props.importerStatus ) }
-						{ ...{ siteId } }
+						{ ...{ siteId, sourceType } }
 						sourceAuthors={ customData.sourceAuthors }
 						sourceTitle={ customData.siteTitle || translate( 'Original Site' ) }
 						targetTitle={ siteName }
-						sourceType={ this.props.title }
 					/>
 				) }
 				{ this.isImporting() &&


### PR DESCRIPTION
The importer type was hardcoded as 'WordPress'. This change passes the current importer name down as a prop so that it can be used in the message displayed in the map authors pane.

**Testing**

On wpcalypso upload start a Blogger import and observe that on the author mapping pane, it refers to "your WordPress site"

Run this branch locally or on the calypso.live link and do the same thing. You'll notice that it now refers to "your Blogger.com" site. 

Also test that a WordPress import still correctly refers to WordPress on this same screen.