### PR TITLE
Analyze CSS: adjust path resolution

### DIFF
--- a/bin/analyze-css.js
+++ b/bin/analyze-css.js
@@ -107,7 +107,7 @@ generateCSS( [ 'style.scss' ], true );
 console.log( '> Autoprefixing CSS' );
 
 glob.sync( '**/*.css', { cwd: TEMP_DIRECTORY } ).forEach( file => {
-	execSync( `npm run --silent autoprefixer -- ${ file }` );
+	execSync( `npm run --silent autoprefixer -- ${ path.resolve( TEMP_DIRECTORY, file ) }` );
 } );
 
 console.log( '> Opening CSS bundle' );


### PR DESCRIPTION
Fix an issue for `bin/analyze-css.js` where `file` doesn't resolve to the temp directory but relative to the current directory. It seems that `glob` does search correctly but doesn't append the current working directory to the filenames.

Solution: prefix filename with temp directory and resolve via path module.

### testing

Compare `npm run analyze-css` from this branch with master and make sure it doesn't throw an error on this branch (file not found).