### PR TITLE
state: use import syntax for wpcom-api-middleware

### DIFF
--- a/client/state/index.js
+++ b/client/state/index.js
@@ -19,6 +19,7 @@ import activePromotions from './active-promotions/reducer';
 import activityLog from './activity-log/reducer';
 import analyticsTracking from './analytics/reducer';
 import applicationPasswords from './application-passwords/reducer';
+import wpcomApiMiddleware from 'state/data-layer/wpcom-api-middleware';
 import navigationMiddleware from './navigation/middleware';
 import noticesMiddleware from './notices/middleware';
 import extensionsModule from 'extensions';
@@ -217,7 +218,7 @@ export function createReduxStore( initialState = {} ) {
 		// then it could mistakenly trigger on those network
 		// responses. Therefore we need to inject the data layer
 		// as early as possible into the middleware chain.
-		require( './data-layer/wpcom-api-middleware.js' ).default,
+		wpcomApiMiddleware,
 		noticesMiddleware,
 		isBrowser && require( './happychat/middleware.js' ).default,
 		isBrowser && require( './happychat/middleware-calypso.js' ).default,


### PR DESCRIPTION
seems to save a few bytes from build.

```
chunk                                                                                             stat_size           parsed_size           gzip_size
async-load-blocks-calendar-popover~comments~post-editor                                                +0 B                  +0 B                +1 B  (+0.0%)
async-load-design-blocks                                                                               +0 B                  +0 B                -3 B  (-0.0%)
async-load-design~async-load-design-blocks~async-load-design-playground~post-editor~woocommerce        +0 B                  +0 B                +1 B  (+0.0%)
async-load-design~async-load-design-blocks~async-load-design-playground~signup~stats~woocommerce       +0 B                  +0 B                -1 B  (-0.0%)
async-load-lib-happychat-connection                                                                    +0 B                  +0 B                -1 B  (-0.1%)
async-load-lib-network-connection                                                                      +0 B                  +0 B                -1 B  (-0.1%)
async-load-post-editor-editor-sharing-accordion                                                        +0 B                  +0 B                -1 B  (-0.0%)
async-load-reader-sidebar                                                                              +0 B                  +0 B                +1 B  (+0.0%)
build                                                                                                 -90 B  (-0.0%)      -1476 B  (-0.1%)     -285 B  (-0.1%)
checkout~domains                                                                                       +0 B                  +0 B                +1 B  (+0.0%)
checkout~domains~jetpack-connect~plans~purchases~settings~signup                                       +0 B                  +0 B                +1 B  (+0.0%)
devdocs                                                                                                +0 B                  +0 B                +3 B  (+0.0%)
help                                                                                                   +0 B                  +0 B                +1 B  (+0.0%)
mailing-lists                                                                                          +0 B                  +0 B                +1 B  (+0.1%)
manifest                                                                                               +0 B                  -2 B  (-0.0%)       +3 B  (+0.1%)
notification-settings                                                                                  +0 B                  -1 B  (-0.0%)       +0 B
post-editor                                                                                            +0 B                  +0 B                -1 B  (-0.0%)
posts-custom~posts-pages                                                                               +0 B                  +0 B                -2 B  (-0.0%)
privacy                                                                                                +0 B                  +0 B                -1 B  (-0.0%)
settings                                                                                               +0 B                  +0 B                -1 B  (-0.0%)
settings-writing                                                                                       +0 B                  +0 B                -1 B  (-0.0%)
themes                                                                                                 +0 B                  +0 B                -1 B  (-0.0%)
wp-job-manager                                                                                         +0 B                  +0 B                -1 B  (-0.0%)
```

Here's the difference I see from the bundle analyzer

<img width="489" alt="screen shot 2018-07-25 at 12 42 10" src="https://user-images.githubusercontent.com/9202899/43197511-b0b943cc-900b-11e8-8cd3-d2ff79ccc1a9.png">

<img width="348" alt="screen shot 2018-07-25 at 12 47 04" src="https://user-images.githubusercontent.com/9202899/43197519-b485f31a-900b-11e8-9c03-ea53a936fbc3.png">

It seems to me there's some kind of redundant dependency which webpack may be able to resolve after moving to import syntax. That's only a guess though.