### PR TITLE
SDK: fix loading babel config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,6 +68,8 @@ function getAliasesForExtensions() {
 const babelLoader = {
 	loader: 'babel-loader',
 	options: {
+		configFile: path.resolve( __dirname, 'babel.config.js' ),
+		babelrc: false,
 		cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache' ),
 		cacheIdentifier,
 	},


### PR DESCRIPTION
1) Don't rely on Babel's `babel.config.js` [lookup behaviour](https://babeljs.io/docs/en/next/babelconfigjs): specify config file using an absolute path. I tested adding `sourceRoot` option instead but that didn't help. See `configFile` from [babel-core options](https://babeljs.io/docs/en/next/babel-core#options) for more info.

2) Disable `.babelrc` file lookups to stop accidentally using external config files when invoking Babel externally via `bin` scripts. I didn't observe issues like this but if we don't use `.babelrc`, suppose it's better to disable this to avoid surprises. See `babelrc` from [loader-specific options](https://github.com/babel/babel-loader#options) and from [babel-core options](https://babeljs.io/docs/en/next/babel-core#options) for more info.


Without the change, `babel-loader` would not pick Calypso's configs when adding Calypso as a dependency to another repository and running a bin script that requires Webpack+Babel config:
```
npx calypso-gutenberg-sdk build-block <block> <destination-dir>
```

Even worse, it might end up picking Babel configs from the folder where `npx` was run (e.g. Jetpack's root folder).

### Testing
Follow up testing instructions in https://github.com/Automattic/wp-calypso/pull/26273

Without the fix, Babel will fail 💥 

With the fix 👍👍  

Also, ensure that regular build for Calypso still works (I tested `npm start`)