### PR TITLE
Move the Cart Store dependency out of build chunk

### DIFF
--- a/client/lib/domains/cart-utils.js
+++ b/client/lib/domains/cart-utils.js
@@ -1,0 +1,39 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { isEmpty, find, values } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { cartItems } from 'lib/cart-values';
+import { isDomainRegistration } from 'lib/products-values';
+
+/**
+ * Depending on the current step in checkout, the user's domain can be found in
+ * either the cart or the receipt.
+ *
+ * @param {?Object} receipt - The receipt for the transaction
+ * @param {?Object} cart - The cart for the transaction
+ *
+ * @return {?String} the name of the first domain for the transaction.
+ */
+export function getDomainNameFromReceiptOrCart( receipt, cart ) {
+	let domainRegistration;
+
+	if ( receipt && ! isEmpty( receipt.purchases ) ) {
+		domainRegistration = find( values( receipt.purchases ), isDomainRegistration );
+	}
+
+	if ( cartItems.hasDomainRegistration( cart ) ) {
+		domainRegistration = cartItems.getDomainRegistrations( cart )[ 0 ];
+	}
+
+	if ( domainRegistration ) {
+		return domainRegistration.meta;
+	}
+
+	return null;
+}

--- a/client/lib/domains/utils.js
+++ b/client/lib/domains/utils.js
@@ -3,16 +3,14 @@
 /**
  * External dependencies
  */
-import { drop, isEmpty, join, find, split, startsWith, values } from 'lodash';
+import { drop, join, split, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { type as domainTypes, transferStatus, gdprConsentStatus } from './constants';
-import { cartItems } from 'lib/cart-values';
-import { isDomainRegistration } from 'lib/products-values';
 
-function getDomainType( domainFromApi ) {
+export function getDomainType( domainFromApi ) {
 	if ( domainFromApi.type === 'redirect' ) {
 		return domainTypes.SITE_REDIRECT;
 	}
@@ -32,7 +30,7 @@ function getDomainType( domainFromApi ) {
 	return domainTypes.MAPPED;
 }
 
-function getTransferStatus( domainFromApi ) {
+export function getTransferStatus( domainFromApi ) {
 	if ( domainFromApi.transfer_status === 'pending_owner' ) {
 		return transferStatus.PENDING_OWNER;
 	}
@@ -56,7 +54,7 @@ function getTransferStatus( domainFromApi ) {
 	return null;
 }
 
-function getGdprConsentStatus( domainFromApi ) {
+export function getGdprConsentStatus( domainFromApi ) {
 	switch ( domainFromApi.gdpr_consent_status ) {
 		case 'NONE':
 			return gdprConsentStatus.NONE;
@@ -77,38 +75,11 @@ function getGdprConsentStatus( domainFromApi ) {
 	}
 }
 
-/**
- * Depending on the current step in checkout, the user's domain can be found in
- * either the cart or the receipt.
- *
- * @param {?Object} receipt - The receipt for the transaction
- * @param {?Object} cart - The cart for the transaction
- *
- * @return {?String} the name of the first domain for the transaction.
- */
-function getDomainNameFromReceiptOrCart( receipt, cart ) {
-	let domainRegistration;
-
-	if ( receipt && ! isEmpty( receipt.purchases ) ) {
-		domainRegistration = find( values( receipt.purchases ), isDomainRegistration );
-	}
-
-	if ( cartItems.hasDomainRegistration( cart ) ) {
-		domainRegistration = cartItems.getDomainRegistrations( cart )[ 0 ];
-	}
-
-	if ( domainRegistration ) {
-		return domainRegistration.meta;
-	}
-
-	return null;
-}
-
-function isDomainConnectAuthorizePath( path ) {
+export function isDomainConnectAuthorizePath( path ) {
 	return startsWith( path, '/domain-connect/authorize/' );
 }
 
-function parseDomainAgainstTldList( domainFragment, tldList ) {
+export function parseDomainAgainstTldList( domainFragment, tldList ) {
 	if ( ! domainFragment ) {
 		return '';
 	}
@@ -122,12 +93,3 @@ function parseDomainAgainstTldList( domainFragment, tldList ) {
 
 	return parseDomainAgainstTldList( suffix, tldList );
 }
-
-export {
-	getDomainNameFromReceiptOrCart,
-	getDomainType,
-	getGdprConsentStatus,
-	getTransferStatus,
-	isDomainConnectAuthorizePath,
-	parseDomainAgainstTldList,
-};

--- a/client/lib/redux-bridge/index.js
+++ b/client/lib/redux-bridge/index.js
@@ -7,8 +7,23 @@ import Dispatcher from 'dispatcher';
 
 let reduxStore = null;
 
+let resolveReduxStorePromise;
+const reduxStorePromise = new Promise( resolve => {
+	resolveReduxStorePromise = resolve;
+} );
+
 export function setReduxStore( store ) {
 	reduxStore = store;
+	resolveReduxStorePromise( store );
+}
+
+/**
+ * Asynchronously get the current Redux store. Returns a Promise that gets resolved only
+ * after the store is set by `setReduxStore`.
+ * @returns {Promise<ReduxStore>} Promise of the Redux store object.
+ */
+export function getReduxStore() {
+	return reduxStorePromise;
 }
 
 /**

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -61,7 +61,7 @@ import { isNewSite } from 'state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { canAddGoogleApps } from 'lib/domains';
-import { getDomainNameFromReceiptOrCart } from 'lib/domains/utils';
+import { getDomainNameFromReceiptOrCart } from 'lib/domains/cart-utils';
 import { fetchSitesAndUser } from 'lib/signup/step-actions';
 import { loadTrackingTool } from 'state/analytics/actions';
 import { getProductsList, isProductsListFetching } from 'state/products-list/selectors';

--- a/client/my-sites/current-site/stale-cart-items-notice.jsx
+++ b/client/my-sites/current-site/stale-cart-items-notice.jsx
@@ -1,0 +1,69 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import CartStore from 'lib/cart/store';
+import { cartItems } from 'lib/cart-values';
+import { infoNotice, removeNotice } from 'state/notices/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { getNoticeLastTimeShown } from 'state/notices/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
+
+const staleCartItemNoticeId = 'stale-cart-item-notice';
+
+class StaleCartItemsNotice extends Component {
+	componentDidMount() {
+		CartStore.on( 'change', this.showStaleCartItemsNotice );
+	}
+
+	componentWillUnmount() {
+		CartStore.off( 'change', this.showStaleCartItemsNotice );
+	}
+
+	render() {
+		return null;
+	}
+
+	showStaleCartItemsNotice = () => {
+		// Remove any existing stale cart notice
+		this.props.removeNotice( staleCartItemNoticeId );
+
+		// Show a notice if there are stale items in the cart and it hasn't been shown in the last 10 minutes (cart abandonment)
+		if (
+			this.props.selectedSite &&
+			cartItems.hasStaleItem( CartStore.get() ) &&
+			this.props.staleCartItemNoticeLastTimeShown < Date.now() - 10 * 60 * 1000
+		) {
+			this.props.recordTracksEvent( 'calypso_cart_abandonment_notice_view' );
+
+			this.props.infoNotice( this.props.translate( 'Your cart is awaiting payment.' ), {
+				id: staleCartItemNoticeId,
+				isPersistent: false,
+				duration: 10000,
+				button: this.props.translate( 'Complete your purchase' ),
+				href: '/checkout/' + this.props.selectedSite.slug,
+				onClick: this.clickStaleCartItemsNotice,
+			} );
+		}
+	};
+
+	clickStaleCartItemsNotice = () => {
+		this.props.recordTracksEvent( 'calypso_cart_abandonment_notice_click' );
+	};
+}
+
+export default connect(
+	state => ( {
+		selectedSite: getSelectedSite( state ),
+		staleCartItemNoticeLastTimeShown: getNoticeLastTimeShown( state, staleCartItemNoticeId ),
+	} ),
+	{ infoNotice, removeNotice, recordTracksEvent }
+)( localize( StaleCartItemsNotice ) );

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -27,7 +27,6 @@ import {
 	SELECTED_SITE_UNSUBSCRIBE,
 } from 'state/action-types';
 import analytics from 'lib/analytics';
-import cartStore from 'lib/cart/store';
 import userFactory from 'lib/user';
 import hasSitePendingAutomatedTransfer from 'state/selectors/has-site-pending-automated-transfer';
 import isFetchingAutomatedTransferStatus from 'state/selectors/is-fetching-automated-transfer-status';
@@ -163,16 +162,6 @@ const updateSelectedSiteForAnalytics = ( dispatch, action, getState ) => {
 };
 
 /**
- * Sets the selectedSiteId for lib/cart/store
- *
- * @param {function} dispatch - redux dispatch function
- * @param {number}   siteId   - the selected siteId
- */
-const updateSelectedSiteForCart = ( dispatch, { siteId } ) => {
-	cartStore.setSelectedSiteId( siteId );
-};
-
-/**
  * Sets the selectedSite for lib/keyboard-shortcuts/global
  *
  * @param {function} dispatch - redux dispatch function
@@ -256,7 +245,6 @@ const handler = ( dispatch, action, getState ) => {
 
 		case SELECTED_SITE_SET:
 			//let this fall through
-			updateSelectedSiteForCart( dispatch, action );
 			updateSelectedSiteIdForSubscribers( dispatch, action );
 
 		case SITE_RECEIVE:


### PR DESCRIPTION
This PR contains three independent patches that when applied together, remove the `lib/cart/store` and `lib/cart-values` dependencies out of the `build` chunk.

**Async load the "Stale Cart Items Notice"**
When the user has something in their cart, they are reminded about that fact and nudged towards making a purchase:

<img width="774" alt="screen shot 2018-07-25 at 17 02 27" src="https://user-images.githubusercontent.com/664258/43209286-9159f5aa-902c-11e8-8b0b-b4791a1797df.png">

This PR moves this part of the `CurrentSite` component into a separate `StaleCartItemsNotice` component that's async loaded. That moves the `lib/cart-values` and `lib/products-values` dependencies into a separate chunk, out of `build`.

**Reorg the `lib/domains/utils` module**
Move the function `getDomainNameFromReceiptOrCart` that has some heavy dependencies into a separate module. Then Webpack will not bundle the whole `lib/domains/utils` tree into `build`, but will be able to split the modules between chunks better. Two separate modules can be bundled into chunks separately, each one in different chunk.

**Invert the control flow when Cart Store listens for selected site changes in Redux**
There is a `state/lib/middleware.js` module that imports the Cart Store and call a `setSelectedSiteId` method on it on every Redux selected site update. That means that Cart Store gets bundled into `build`.

This patch inverts the control flow: when Cart Store is first loaded (by someone who **really** needs it), it subscribes to Redux updates (using the Redux Bridge) and updates itself when needed. That removes the Cart Store from the `build` chunk.

We should eventually use this technique for all subscribers in `state/lib/middleware.js` and probably at many other places, too.

To make this patch easier, I added a new helper to the Redux Bridge. The problem to solve is: when the Cart Store is loaded, we install the Redux listener during the module's static initialization. But at that time we are not sure if the Redux Bridge is already initialized. It's possible that its internal `reduxStore` variable is still `null`

That's why I started exporting a `getReduxStore` function from `lib/redux-bridge` and it returns a promise: the subscription will be added in a `then` handler, after the Redux store is initialized.

**Impact on bundle size**
is [very nice](http://iscalypsofastyet.com/chunkgroups?branch=perf/reorg-domains-utils). The `build` chunk is 3% smaller and the total size to load Reader and other Calypso routes is also smaller:

<img width="899" alt="screen shot 2018-07-25 at 17 19 06" src="https://user-images.githubusercontent.com/664258/43210266-e6c77b46-902e-11e8-8e64-fb31ecfa438c.png">
