### PR TITLE
Domains: Domain Mapping & Transfer standardization, first steps

### DIFF
--- a/client/components/domains/map-domain-step/style.scss
+++ b/client/components/domains/map-domain-step/style.scss
@@ -7,11 +7,9 @@
 	}
 
 	p {
-		color: $gray-dark;
-		font-size: 13px;
+		font-size: 1em;
 		font-weight: 600;
 		margin-bottom: 0;
-		opacity: 0.7;
 	}
 
 	.domain-product-price {

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -179,7 +179,7 @@ class TransferDomainStep extends React.Component {
 						<div className="transfer-domain-step__domain-heading">
 							{ translate( 'Manage your domain and site together on WordPress.com.' ) }
 						</div>
-						<div>
+						<div className="transfer-domain-step__domain-text">
 							{ translate(
 								'Transfer your domain away from your current provider to WordPress.com so you can update settings, ' +
 									"renew your domain, and more \u2013 right in your dashboard. We'll renew it for another year " +
@@ -211,15 +211,15 @@ class TransferDomainStep extends React.Component {
 							suffix={ domainProductPrice }
 							autoFocus
 						/>
+						<Button
+							disabled={ ! getTld( searchQuery ) || submitting }
+							busy={ submitting }
+							className="transfer-domain-step__go button is-primary"
+							onClick={ this.handleFormSubmit }
+						>
+							{ translate( 'Transfer' ) }
+						</Button>
 					</div>
-					<Button
-						disabled={ ! getTld( searchQuery ) || submitting }
-						busy={ submitting }
-						className="transfer-domain-step__go button is-primary"
-						onClick={ this.handleFormSubmit }
-					>
-						{ translate( 'Transfer to WordPress.com' ) }
-					</Button>
 					{ this.domainRegistrationUpsell() }
 				</form>
 			</div>

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -68,25 +68,38 @@
 }
 
 .transfer-domain-step__domain-description {
-	font-size: 16px;
+	font-size: 1em;
 	margin-bottom: 20px;
 }
 
+.transfer-domain-step__domain-text {
+	font-size: 0.9em;
+}
+
 .transfer-domain-step__go {
-	margin-top: 20px;
-	margin-bottom: 10px;
+	flex-grow: 1;
+	margin: 10px 0 0;
+
+	@include breakpoint( '>660px' ) {
+		min-width: 100px;
+		flex-grow: 0;
+		margin: 0 0 0 10px;
+	}
 }
 
 .transfer-domain-step__domain-heading {
-	font-size: 18px;
 	font-weight: 500;
 	margin-bottom: 5px;
 }
 
 .transfer-domain-step__add-domain {
 	display: flex;
-	flex-direction: column;
+	flex-flow: column;
 	width: 100%;
+
+	@include breakpoint( '>660px' ) {
+		flex-flow: row;
+	}
 }
 
 .transfer-domain-step__map-option {


### PR DESCRIPTION
* Make the headings consistent with regards to font size, color, opacity
* Move the "Transfer" button next to the text input

There's a lot more to address to make these two screens similar, but this is a start.

**Before this PR**

<img width="743" alt="oldlg" src="https://user-images.githubusercontent.com/2124984/43215040-13f6444c-9009-11e8-8feb-58bb2696cc0f.png">
<img width="353" alt="oldsm" src="https://user-images.githubusercontent.com/2124984/43215041-1407866c-9009-11e8-90aa-273725215f0a.png">
<img width="747" alt="screen shot 2018-07-25 at 12 49 16 pm" src="https://user-images.githubusercontent.com/2124984/43215072-301e71b2-9009-11e8-8b9f-55bc8f2488fc.png">


**After this PR**

<img width="743" alt="newinactivelg" src="https://user-images.githubusercontent.com/2124984/43215044-19730a7c-9009-11e8-81e7-329caf837ce7.png">
<img width="750" alt="newlg" src="https://user-images.githubusercontent.com/2124984/43215045-198816e2-9009-11e8-83a8-4fade242a556.png">
<img width="338" alt="newsm" src="https://user-images.githubusercontent.com/2124984/43215046-1999a6b4-9009-11e8-8c4d-ca7f58e301bc.png">
<img width="741" alt="screen shot 2018-07-25 at 12 49 25 pm" src="https://user-images.githubusercontent.com/2124984/43215082-33346abe-9009-11e8-84e8-de55aaf83c16.png">


**Steps to test**

* Switch to this PR and navigate to `/start/domains/mapping`
* Click on "Use a domain I own"
* Check the Transfer page to see changes
* Check the Mapping page to see changes