### PR TITLE
Documentation: Add readme and devdocs example for SupportArticleDialog

### DIFF
--- a/client/blocks/support-article-dialog/README.md
+++ b/client/blocks/support-article-dialog/README.md
@@ -1,0 +1,29 @@
+Support Article Dialog
+=========
+The `SupportArticleDialog` component displays a support article right in Calypso, enabling you to get useful content in front of folks without the need to link away from the app - giving a better and faster experience!
+
+The component is rendered from our main `<Layout />` component and so is available everywhere in Calypso.
+
+#### Basic usage:
+
+To launch a support article call the corresponding redux action, like so:
+
+```jsx
+import { openSupportArticleDialog } from 'state/inline-support-article/actions';
+
+onSupportLinkClick: () => {
+	const { postId, postUrl } = this.props;
+	this.props.openSupportArticleDialog( { postId, postUrl } )
+}
+render: function() {
+	return <Button onClick={ this.onSupportLinkClick } >Read More...</Button>;
+}
+```
+
+You'll notice that two properties were passed in to the `openSupportArticleDialog` action.
+These two properties are then made available to `SupportArticleDialog` via redux, and are explained below.
+
+#### Props
+
+- `postId`: (required) An id used to query the support article and get its contents.
+- `postUrl`: A user-friendly url to be used to render an external link to the article, at the bottom of the dialog.

--- a/client/blocks/support-article-dialog/docs/example.jsx
+++ b/client/blocks/support-article-dialog/docs/example.jsx
@@ -1,0 +1,40 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import { openSupportArticleDialog } from 'state/inline-support-article/actions';
+
+const postId = 143180;
+const postUrl = 'https://en.support.wordpress.com/do-i-need-a-website-a-blog-or-a-website-with-a-blog/';
+
+class SupportArticleDialogExample extends Component {
+	handleClick = () => {
+		this.props.openSupportArticleDialog( { postId, postUrl } );
+	}
+
+	render() {
+		return (
+			<div className="docs__design-assets-group">
+				<Button onClick={ this.handleClick }>Show Support Article</Button>
+			</div>
+		);
+	}
+}
+
+const ConnectedExample = connect(
+	null,
+	{
+		openSupportArticleDialog,
+	}
+)( SupportArticleDialogExample );
+
+ConnectedExample.displayName = 'SupportArticleDialog';
+
+export default ConnectedExample;

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -86,6 +86,7 @@ import ConversationCaterpillar from 'blocks/conversation-caterpillar/docs/exampl
 import ConversationFollowButton from 'blocks/conversation-follow-button/docs/example';
 import ColorSchemePicker from 'blocks/color-scheme-picker/docs/example';
 import UserMentions from 'blocks/user-mentions/docs/example';
+import SupportArticleDialog from 'blocks/support-article-dialog/docs/example';
 
 export default class AppComponents extends React.Component {
 	static displayName = 'AppComponents';
@@ -195,6 +196,7 @@ export default class AppComponents extends React.Component {
 					{ isEnabled( 'reader/user-mention-suggestions' ) && (
 						<UserMentions readmeFilePath="user-mentions" />
 					) }
+					<SupportArticleDialog />
 				</Collection>
 			</Main>
 		);


### PR DESCRIPTION
This PR adds documentation for the recently added (#26254) `SupportArticleDialog` component.

Please take a look at the docs and test the devdocs entry. Do they make sense? Do they represent the component well?

[View the readme in markdown](https://github.com/Automattic/wp-calypso/blob/092fe3b44b72bd1a99b5b1c432fb3f3b7340c2e0/client/blocks/support-article-dialog/README.md)

### Testing
Take a look at the example in the devdocs and make sure it looks and works well in both the [list view](http://calypso.localhost:3000/devdocs/blocks/) and [single component view](http://calypso.localhost:3000/devdocs/blocks/support-article-dialog)