### PR TITLE
Payments: Add messaging for purchases that appear to be refundable but can't be refunded automatically

### DIFF
--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -12,7 +12,13 @@ import i18n from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import { getName, isRefundable, isSubscription, isOneTimePurchase } from 'lib/purchases';
+import {
+	getName,
+	isRefundable,
+	isSubscription,
+	isOneTimePurchase,
+	maybeWithinRefundPeriod,
+} from 'lib/purchases';
 import { isDomainRegistration, isDomainMapping } from 'lib/products-values';
 import { getIncludedDomainPurchase } from 'state/purchases/selectors';
 import { CALYPSO_CONTACT, UPDATE_NAMESERVERS } from 'lib/url/support';
@@ -316,14 +322,23 @@ const CancelPurchaseRefundInformation = ( {
 
 			{ showSupportLink && (
 				<strong className="cancel-purchase__support-information">
-					{ i18n.translate(
-						'Have a question? {{contactLink}}Ask a Happiness Engineer!{{/contactLink}}',
-						{
-							components: {
-								contactLink: <a href={ CALYPSO_CONTACT } />,
-							},
-						}
-					) }
+					{ ! isRefundable( purchase ) && maybeWithinRefundPeriod( purchase )
+						? i18n.translate(
+								'Have a question? Want to request a refund? {{contactLink}}Ask a Happiness Engineer!{{/contactLink}}',
+								{
+									components: {
+										contactLink: <a href={ CALYPSO_CONTACT } />,
+									},
+								}
+						  )
+						: i18n.translate(
+								'Have a question? {{contactLink}}Ask a Happiness Engineer!{{/contactLink}}',
+								{
+									components: {
+										contactLink: <a href={ CALYPSO_CONTACT } />,
+									},
+								}
+						  ) }
 				</strong>
 			) }
 		</div>

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -26,7 +26,14 @@ import stepsForProductAndSurvey from 'components/marketing-survey/cancel-purchas
 import nextStep from 'components/marketing-survey/cancel-purchase-form/next-step';
 import previousStep from 'components/marketing-survey/cancel-purchase-form/previous-step';
 import { INITIAL_STEP, FINAL_STEP } from 'components/marketing-survey/cancel-purchase-form/steps';
-import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'lib/purchases';
+import {
+	getIncludedDomain,
+	getName,
+	hasIncludedDomain,
+	isRemovable,
+	isRefundable,
+	maybeWithinRefundPeriod,
+} from 'lib/purchases';
 import { isDataLoading } from '../utils';
 import {
 	isBusiness,
@@ -35,6 +42,7 @@ import {
 	isJetpackPlan,
 	isPlan,
 } from 'lib/products-values';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 import notices from 'notices';
 import { purchasesRoot } from '../paths';
 import { getPurchasesError } from 'state/purchases/selectors';
@@ -294,6 +302,27 @@ class RemovePurchase extends Component {
 						{ args: { domain: productName } }
 					) }
 				</p>
+				{ ! isRefundable( purchase ) &&
+					maybeWithinRefundPeriod( purchase ) && (
+						<p>
+							<strong>
+								{ translate(
+									"We're not able to refund this purchase automatically. " +
+										"If you're canceling within %(refundPeriodInDays)s days of " +
+										'purchase, {{contactLink}}contact us{{/contactLink}} to ' +
+										'request a refund.',
+									{
+										args: {
+											refundPeriodInDays: purchase.refundPeriodInDays,
+										},
+										components: {
+											contactLink: <a href={ CALYPSO_CONTACT } />,
+										},
+									}
+								) }
+							</strong>
+						</p>
+					) }
 			</Dialog>
 		);
 	}


### PR DESCRIPTION
## The Problem

There are some unusual situations where a purchase is allowed to be refunded (based on the policy at https://en.support.wordpress.com/refunds/) but which, for various technical reasons, can't be automatically refunded when the purchase is canceled via the Calypso UI.

One example:
1. Buy a plan bundled with a domain.
2. Cancel the plan, but choose the option to leave the domain behind. You get a partial refund (for the plan only), as expected.
3. Now go to cancel the domain. You'd expect to be able to refund it and get the remainder of your money back, but you can't.  Instead you can only turn off auto-renew, and then remove it without a refund.

This is a problem - we should do our best to help users get a refund in these cases.

## Solution

Since these are edge cases and solving the underlying technical problem is hard, a simple solution for now is just to make sure these users see messages on the page explaining that they can contact support to ask for a refund.  We have to be a little careful, though; we can't *promise* a refund, since we can't actually be 100% certain they're eligible for one (if we could, that would be a case where we could just process the refund automatically and be done).

## Screenshots

When the user goes to cancel a subscription (a domain in this case, which is the primary scenario here) that isn't refundable, it used to look like this:

![old-cancel-unrefundable-within-refund-period](https://user-images.githubusercontent.com/235183/43217704-52c323f0-9010-11e8-99f9-1a3e39b1e8d8.png)

With this pull request, it still looks the same as the above if the subscription doesn't appear to be within the refund period, but if it does appear to be within the refund period, it now looks like this (the arrow points to the changes):

![new-cancel-unrefundable-within-refund-period](https://user-images.githubusercontent.com/235183/43217702-52a1c12e-9010-11e8-8b83-0e88c7224cb5.png)

A relatively subtle difference, but at this stage we aren't really sure of the user's intentions yet.

After going through the above process (which turns off auto-renew), the user can then actually remove the subscription so as to cancel it immediately.  In this case it's very likely the user would want a refund if they're eligible for one.

The removal screen for domains in this scenario used to look like this:

![old-remove-unrefundable-within-refund-period](https://user-images.githubusercontent.com/235183/43217705-52d054bc-9010-11e8-833d-c277f560f281.png)

With this pull request, it still looks the same as the above if the subscription doesn't appear to be within the refund period, but if it does appear to be within the refund period, it now looks like this:

![new-remove-unrefundable-within-refund-period](https://user-images.githubusercontent.com/235183/43217703-52b76f2e-9010-11e8-9af3-1719bd0fa454.png)

For the above "Remove" case, I only modified things for a domain; for a plan it would get more complicated since the corresponding text isn't displayed until after the user has gone through a cancellation survey, etc.  (In practice, this is much more likely to come up for domains than plans anyway.  I am not sure we know of a scenario where it would come up for a plan.)