### PR TITLE
BillingReceipt: Add min-height for contenteditable

### DIFF
--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -46,7 +46,7 @@
 	outline: 0;
 
 	&:focus,
-	&:active	{
+	&:active {
 		width: 150px;
 	}
 }
@@ -140,7 +140,7 @@
 	position: relative;
 	overflow: auto;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		padding: 10px 20px;
 	}
 
@@ -149,7 +149,7 @@
 		min-height: 65px;
 		float: left;
 
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( '<480px' ) {
 			left: 20px;
 		}
 	}
@@ -159,7 +159,7 @@
 		float: left;
 		padding: 10px 20px;
 
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( '<480px' ) {
 			padding-top: 0;
 		}
 
@@ -174,12 +174,16 @@
 		font-style: italic;
 		padding: 5px 0 0 0;
 
-		@include breakpoint( ">480px" ) {
+		@include breakpoint( '>480px' ) {
 			position: absolute;
-				top: 10px;
-				right: 40px;
+			top: 10px;
+			right: 40px;
 		}
 	}
+}
+
+.billing-history__billing-details div[contenteditable] {
+	min-height: 1.2em;
 }
 
 .billing-history__receipt-details {
@@ -189,13 +193,13 @@
 	margin: 20px 0 0 0;
 	overflow: auto;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		padding: 20px;
 	}
 
 	li {
 		color: $gray-dark;
-			font-size: 13px;
+		font-size: 13px;
 		margin: 0 0 15px 0;
 		padding: 0;
 
@@ -226,7 +230,7 @@
 .billing-history__receipt {
 	padding: 30px 40px;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		padding: 30px 20px;
 	}
 
@@ -313,7 +317,7 @@
 	.button {
 		margin: 16px 0;
 
-		@include breakpoint( ">480px" ) {
+		@include breakpoint( '>480px' ) {
 			float: right;
 			margin: 0 1%;
 		}


### PR DESCRIPTION
In some browsers (eg: Chrome), `contenteditable` divs have a minimum height
automatically, but in others (eg: Firefox), that is not the case.

Normally it's possible for a user to edit the "billing details" section
of their receipts for accounting purposes. This is done via a
`contenteditable` div. The div has a hover state which shows a border
around the element.

When the receipt billing details section is empty, however, the div has
a height of 0 and therefore it has no hover state and cannot be clicked.

This change adds a `min-height` property to the element to make it
always visible.

Before:
![before-minheight](https://user-images.githubusercontent.com/2036909/43223875-7948f6a0-9022-11e8-9091-2d2eaa0d099d.png)

After:
![after-minheight](https://user-images.githubusercontent.com/2036909/43223880-7df24ba2-9022-11e8-8096-640437846664.png)

Fixes #26114

## Testing

Visit http://calypso.localhost:3000/me/purchases/billing and click "View Receipt" underneath any receipt.

Verify (in different browsers) that the "Billing Details" section has a vertical height and hovering over the section produces a dashed outline (see screenshots above).