### PR TITLE
Fix typo.

### DIFF
--- a/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
@@ -115,7 +115,7 @@ class DomainConnectMapping extends React.Component {
 					<div>
 						<p>
 							{ translate(
-								'Your domain provider supports automattically configuring your ' +
+								'Your domain provider supports automatically configuring your ' +
 									'domain to use it with WordPress.com.'
 							) }
 						</p>


### PR DESCRIPTION
Fix minor spelling error that is likely an occupational hazard of working for Automattic.