### PR TITLE
Domains: Attempt to fix flexbox incompatibility issues in IE11

### DIFF
--- a/client/components/domains/use-your-domain-step/style.scss
+++ b/client/components/domains/use-your-domain-step/style.scss
@@ -15,6 +15,7 @@
 
 	.use-your-domain-step__option-inner-wrap {
 		display: flex;
+		flex-basis: 100%;
 		justify-content: space-between;
 		flex-direction: column;
 	}
@@ -33,6 +34,10 @@
 		display: flex;
 		justify-content: center;
 		margin: 1em 0;
+		max-height: 150px;
+	}
+
+	.use-your-domain-step__option-illustration img {
 		max-height: 150px;
 	}
 


### PR DESCRIPTION
* Set a `max-height` on the images directly, as they don't respect the constraints of the flexbox container IE11
* Set `flex-basis` to `100%` to work around known issue with IE11

I would appreciate getting some eyes on this from folks using actual IE/Edge browsers; I'm testing in Browserstack.

**Before this PR**

https://cloudup.com/cYCLZXtpoPL

**After this PR**

<img width="1406" alt="screen shot 2018-07-25 at 5 03 08 pm" src="https://user-images.githubusercontent.com/2124984/43227469-d0410f60-902c-11e8-9ae4-1e42840c74f9.png">

**Steps to test**

* Switch to this PR and navigate to `/start/domains/use-your-domain` using IE11
* The layout should now be usable/readable