### PR TITLE
Components: Update counted textarea component to utilize maxLength

### DIFF
--- a/client/components/forms/counted-textarea/README.md
+++ b/client/components/forms/counted-textarea/README.md
@@ -40,4 +40,8 @@ If a `className` prop is passed, it will be applied to the wrapper node.
 
 ### `acceptableLength`
 
-If passed and the value of the input exceeds the acceptable character count length, warning styles will be applied to the rendered output. If a maximum length is desired, use the browser default [`maxLength` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textareaattr-maxlength).
+If passed and the value of the input exceeds the acceptable character count length, warning styles will be applied to the rendered output. If a maximum length is desired, use the browser default [`maxLength` attribute](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Attribute/maxlength).
+
+### `helpText`
+
+If passed a string of help text, an [InfoPopover component](https://github.com/Automattic/wp-calypso/blob/master/client/components/info-popover/README.md) will be rendered alongside the text count.

--- a/client/components/forms/counted-textarea/docs/example.jsx
+++ b/client/components/forms/counted-textarea/docs/example.jsx
@@ -30,6 +30,8 @@ export default class extends React.PureComponent {
 				value={ this.state.value }
 				onChange={ this.onChange }
 				acceptableLength={ 20 }
+				maxLength={ 50 }
+				helpText={ 'Some helper text' }
 			/>
 		);
 	}

--- a/client/components/forms/counted-textarea/index.jsx
+++ b/client/components/forms/counted-textarea/index.jsx
@@ -14,6 +14,7 @@ import { omit, noop } from 'lodash';
  * Internal dependencies
  */
 import FormTextarea from 'components/forms/form-textarea';
+import InfoPopover from 'components/info-popover';
 
 export class CountedTextarea extends React.Component {
 	static propTypes = {
@@ -24,6 +25,7 @@ export class CountedTextarea extends React.Component {
 		acceptableLength: PropTypes.number,
 		showRemainingCharacters: PropTypes.bool,
 		translate: PropTypes.func,
+		helpText: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -43,11 +45,19 @@ export class CountedTextarea extends React.Component {
 
 		let panelText;
 		if ( this.props.showRemainingCharacters && this.props.acceptableLength ) {
-			panelText = this.props.translate( '%d character remaining', '%d characters remaining', {
-				context: 'Input length',
-				args: [ this.props.acceptableLength - length ],
-				count: this.props.acceptableLength - length,
-			} );
+			if ( this.props.maxLength ) {
+				panelText = this.props.translate( '%d character remaining', '%d characters remaining', {
+					context: 'Input length',
+					args: [ this.props.maxLength - length ],
+					count: this.props.maxLength - length,
+				} );
+			} else {
+				panelText = this.props.translate( '%d character remaining', '%d characters remaining', {
+					context: 'Input length',
+					args: [ this.props.acceptableLength - length ],
+					count: this.props.acceptableLength - length,
+				} );
+			}
 		} else {
 			panelText = this.props.translate( '%d character', '%d characters', {
 				context: 'Input length',
@@ -60,15 +70,27 @@ export class CountedTextarea extends React.Component {
 			<div className="counted-textarea__count-panel">
 				{ panelText }
 				{ this.props.children }
+				{ this.props.helpText ? this.renderInfoPopover() : null }
 			</div>
 		);
 	};
 
+	renderInfoPopover = () => {
+		return <InfoPopover position="top left">{ this.props.helpText }</InfoPopover>;
+	};
+
+	getClassNames = () => {
+		if ( this.props.maxLength && this.props.value.length >= this.props.maxLength ) {
+			return 'is-exceeding-max-length is-exceeding-length';
+		}
+
+		if ( this.props.acceptableLength && this.props.value.length > this.props.acceptableLength ) {
+			return 'is-exceeding-acceptable-length is-exceeding-length';
+		}
+	};
+
 	render() {
-		const classes = classNames( 'counted-textarea', this.props.className, {
-			'is-exceeding-acceptable-length':
-				this.props.acceptableLength && this.props.value.length > this.props.acceptableLength,
-		} );
+		const classes = classNames( 'counted-textarea', this.props.className, this.getClassNames() );
 
 		return (
 			<div className={ classes }>

--- a/client/components/forms/counted-textarea/style.scss
+++ b/client/components/forms/counted-textarea/style.scss
@@ -2,12 +2,18 @@
 	border: 1px solid $gray-lighten-20;
 	background-color: $gray-light;
 
-	&.is-exceeding-acceptable-length {
-		background: $alert-red;
-
+	&.is-exceeding-length {
 		.counted-textarea__count-panel,
 		.gridicons-info-outline {
 			color: $white;
+		}
+
+		&.is-exceeding-max-length {
+			background: $alert-red;
+		}
+
+		&.is-exceeding-acceptable-length {
+			background: $alert-yellow;
 		}
 	}
 }
@@ -23,4 +29,8 @@
 	padding: 8px;
 	font-size: 12px;
 	color: $gray-darken-20;
+
+	.info-popover {
+		float: right;
+	}
 }

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -434,7 +434,7 @@ export class SeoForm extends React.Component {
 										id="advanced_seo_front_page_description"
 										value={ frontPageMetaDescription || '' }
 										disabled={ isSeoDisabled }
-										maxLength="300"
+										maxLength={ 300 }
 										acceptableLength={ 159 }
 										onChange={ this.handleMetaChange }
 										className="seo-settings__front-page-description"

--- a/client/post-editor/editor-seo-accordion/index.jsx
+++ b/client/post-editor/editor-seo-accordion/index.jsx
@@ -67,12 +67,17 @@ class EditorSeoAccordion extends Component {
 						labelText={ translate( 'Meta Description' ) }
 					>
 						<CountedTextarea
-							maxLength="300"
+							maxLength={ 300 }
 							acceptableLength={ 159 }
 							placeholder={ translate( 'Write a description…' ) }
 							aria-label={ translate( 'Write a description…' ) }
 							value={ metaDescription }
 							onChange={ this.onMetaChange }
+							showRemainingCharacters={ true }
+							helpText={ translate(
+								'Search engines display up to 320 characters, but meta ' +
+									'descriptions around 160 characters work best.'
+							) }
 						/>
 					</EditorDrawerLabel>
 					{ isJetpack && (


### PR DESCRIPTION
This is an update to the `CountedTextArea` component designed to address #7969. Currently, the experience with the CountedTextArea (at least as it's used in the SEO description field in the editor) is sub-optimal. We display a red warning at a certain length, but provide no indication of why the red warning appears or how to fix it. 

This PR updates the component in several ways:

- We now differentiate between `acceptableLength` and `maxLength`. The former provides a yellow warning styling. Users can continue to input text. The latter applies a red styling and cuts off text input (using the native [`maxLength` attribute](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Attribute/maxlength) for text inputs).
- If a prop of `helpText` is supplied, we render an `infoPopover` to guide users on the appropriate text length.

I also updated the readme to fix a broken link, added a description of the `helpText` prop to the component readme, and updated the devdocs.

See full testing instructions below. I'm currently labeling this as "In Progress" as I have a few small todos:

- [ ] Add tests to `CountedTextArea` for new behavior
- [ ] Get help text copy reviewed

@chrisfromthelc I'd love to get your thoughts on how this works and specifically on these questions:
- Should we put a limit of 320 or 300 on meta description fields?
- Should we link to a support doc that elaborates on meta description length a bit more?

## To test
1. Load this branch and visit http://calypso.localhost:3000/post for a site with the Business plan.
2. Try typing into the SEO Description field. You should see that you have 300 characters remaining to enter. The color should remain gray until you hit 160 characters. At that point, it should turn yellow. At 300 characters, it should turn red and prevent you from entering text. The `InfoPopover` component should be there the entire time.

**Previous**
<img width="274" alt="previous" src="https://user-images.githubusercontent.com/7240478/43240255-cf5780cc-9052-11e8-826a-88d731982e0e.png">

**Updated**
<img width="273" alt="warning" src="https://user-images.githubusercontent.com/7240478/43240265-d748cac0-9052-11e8-877b-52d5136724d5.png">

<img width="271" alt="max length" src="https://user-images.githubusercontent.com/7240478/43240270-db846090-9052-11e8-9c99-11b4ab3eeb94.png">

<img width="272" alt="helper text" src="https://user-images.githubusercontent.com/7240478/43240272-df144464-9052-11e8-9491-8aa593cefaa9.png">

This `CountedTextarea` component is also used in a few other places that we'll want to test to make sure the experience makes sense:

**Publicize**
We use the component for [the text box containing Publicize messages](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/editor-sharing/publicize-message.jsx). We do _not_ use the `maxLength` prop in that case. Since we don't cut users off when they hit a certain character count, I think it makes more sense to use the yellow warning color instead of the red.

![screen shot 2018-07-25 at 21 40 33](https://user-images.githubusercontent.com/7240478/43240381-7d1d91f6-9053-11e8-9dd2-762b2e679981.png)

**Front Page Meta Description**
On Business sites under Settings -> Traffic (/settings/traffic/), we use the CountedTextArea for the [front page meta description field](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/site-settings/seo-settings/form.jsx). In this case, we have both an acceptable (159) and max (300) limit. The appearance should mimic the meta description field for the individual post (minus the helper text).

**People Invites**
On /people/new/, we use the component to send a custom message. This PR improves that experience because currently you get no indicator whatsoever when you hit the limit ([we have both acceptable and max limit set to 500](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/people/invite-people/index.jsx#L344)).

<img width="1280" alt="swqxb" src="https://user-images.githubusercontent.com/7240478/43240565-687bed32-9054-11e8-8597-017fc8358d1d.png">
