### PR TITLE
Domains: Don't show the last availability status for wordpress.com subdomain searches

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -622,6 +622,7 @@ class RegisterDomainStep extends React.Component {
 			return;
 		}
 		if ( this.props.isSignupStep && domain.match( /\.wordpress\.com$/ ) ) {
+			this.setState( { lastDomainStatus: null, lastDomainIsTransferrable: false } );
 			return;
 		}
 


### PR DESCRIPTION
If you search for a domain in NUX that is already taken and then you search for wordpress.com subdomain you'll get an error that the wordpress.com subdomain is already taken. This should never happen - if a wordpress.com subdomain is already taken we show a randomized variation that is available.

To test:
1. Go to NUX
2. Enter domain that is already registered (ex. kamen.com) - you'll see that the domain is already taken
3. Now enter random wordpress.com subdomain (kj32kj32kj32kj32.wordpress.com) - the "already taken" notice should disappear (it doesn't in production)
4. Even if you enter a taken wordpress.com subdomain we still should not show that notice
