### PR TITLE
Sharing: Fix users cannot connect to Twitter

### DIFF
--- a/client/my-sites/sharing/connections/account-dialog.jsx
+++ b/client/my-sites/sharing/connections/account-dialog.jsx
@@ -41,12 +41,15 @@ class AccountDialog extends Component {
 
 	onClose = action => {
 		const accountToConnect = this.getAccountToConnect();
+		const externalUserId = this.props.service.multiple_external_user_ID_support
+			? accountToConnect.ID
+			: 0;
 
 		if ( 'connect' === action && accountToConnect ) {
 			this.props.onAccountSelected(
 				this.props.service,
 				accountToConnect.keyringConnectionId,
-				accountToConnect.ID
+				externalUserId
 			);
 		} else {
 			this.props.onAccountSelected();


### PR DESCRIPTION
### Investigation

Starting from the night (GMT) of July 25th, we've been receiving reports of users that couldn't connect to Twitter (p9F6qB-16J-p2).

@nylen + @Automattic/lannister pushed a big one (D16376-code) in those hours, and it might be the cause for this.
Though, I've tried investigating this and stumbled upon a possible solution.

The error displayed is `This Publicize service does not support setting an external user ID.`, which appears twice in the `external-connections.php` file.

In one of those cases, it's thrown when the request sent to `/sites/{ siteFragment }/publicize-connections/new` has an `external_user_ID` property set, and the `service_supports_additional_external_users` check fails.

This function checks for the `multiple_external_user_ID_support` property of the service, which... is `false` for Twitter.

I tried modifying manually the call without the `external_user_ID` and it worked like a charm.

So I went back to Calypso and found out that we _always_ send it.

### Fix

This PR changes this behaviour, and only send `externalUserId` to the `/sites/{ siteFragment }/publicize-connections/new` endpoint if the service allows for `multiple_external_user_ID_support`.

### Doubts

I don't have a clear understanding of what `external_user_id` does, and why it might be required or not.
As far as I can see, it's only set to true for:
- Facebook
- Tumblr
- Google My Business
(which in other words means that only these service should work 100% the same as before)

But what happens for all the other services?
I'd say Twitter is now working again, but what about, say, Google+ or LinkedIn?
Might there be some corner cases where they could break?

## Testing instructions

⚠️ This must be tested on all site types (Simple, Atomic, Jetpack)

- Open `/sharing/{ siteFragment }`.
- Smoke test all available services, and all their options (e.g. if you have multiple accounts on a service, try connecting to each).
- Make sure the connection works as expected.