### PR TITLE
[nudge-a-palooza] Upsell/link entire updated banner

### DIFF
--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -31,6 +31,7 @@ export class Banner extends Component {
 		callToAction: PropTypes.string,
 		className: PropTypes.string,
 		description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),
+		forceHref: PropTypes.bool,
 		disableHref: PropTypes.bool,
 		dismissPreferenceName: PropTypes.string,
 		dismissTemporary: PropTypes.bool,
@@ -49,6 +50,7 @@ export class Banner extends Component {
 	};
 
 	static defaultProps = {
+		forceHref: false,
 		disableHref: false,
 		dismissTemporary: false,
 		onClick: noop,
@@ -125,7 +127,17 @@ export class Banner extends Component {
 	}
 
 	getContent() {
-		const { callToAction, description, event, feature, list, price, title, target } = this.props;
+		const {
+			callToAction,
+			forceHref,
+			description,
+			event,
+			feature,
+			list,
+			price,
+			title,
+			target,
+		} = this.props;
 
 		const prices = Array.isArray( price ) ? price : [ price ];
 
@@ -164,17 +176,22 @@ export class Banner extends Component {
 								<PlanPrice rawPrice={ prices[ 1 ] } discounted />
 							</div>
 						) }
-						{ callToAction && (
-							<Button
-								compact
-								href={ this.getHref() }
-								onClick={ this.handleClick }
-								primary
-								target={ target }
-							>
-								{ callToAction }
-							</Button>
-						) }
+						{ callToAction &&
+							( forceHref ? (
+								<Button compact primary target={ target }>
+									{ callToAction }
+								</Button>
+							) : (
+								<Button
+									compact
+									href={ this.getHref() }
+									onClick={ this.handleClick }
+									primary
+									target={ target }
+								>
+									{ callToAction }
+								</Button>
+							) ) }
 					</div>
 				) }
 			</div>
@@ -185,6 +202,7 @@ export class Banner extends Component {
 		const {
 			callToAction,
 			className,
+			forceHref,
 			disableHref,
 			dismissPreferenceName,
 			dismissTemporary,
@@ -218,8 +236,8 @@ export class Banner extends Component {
 		return (
 			<Card
 				className={ classes }
-				href={ disableHref || callToAction ? null : this.getHref() }
-				onClick={ callToAction ? noop : this.handleClick }
+				href={ ( disableHref || callToAction ) && ! forceHref ? null : this.getHref() }
+				onClick={ callToAction && ! forceHref ? noop : this.handleClick }
 			>
 				{ this.getIcon() }
 				{ this.getContent() }

--- a/client/components/banner/test/test.jsx
+++ b/client/components/banner/test/test.jsx
@@ -36,6 +36,7 @@ jest.mock( 'i18n-calypso', () => ( {
  */
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
+import { noop } from 'lodash';
 import React from 'react';
 import {
 	PLAN_FREE,
@@ -159,6 +160,51 @@ describe( 'Banner basic tests', () => {
 	test( 'should not record Tracks event when event is not specified', () => {
 		const comp = shallow( <Banner { ...props } /> );
 		assert.lengthOf( comp.find( 'TrackComponentView' ), 0 );
+	} );
+
+	test( 'should render Card with href if href prop is passed', () => {
+		const comp = shallow( <Banner { ...props } href={ '/' } /> );
+		assert.lengthOf( comp.find( 'Card' ), 1 );
+		assert.equal( '/', comp.find( 'Card' ).props().href );
+	} );
+
+	test( 'should render Card with no href if href prop is passed but disableHref is true', () => {
+		const comp = shallow( <Banner { ...props } href={ '/' } disableHref={ true } /> );
+		assert.lengthOf( comp.find( 'Card' ), 1 );
+		assert.equal( undefined, comp.find( 'Card' ).props().href );
+	} );
+
+	test( 'should render Card with href if href prop is passed but disableHref is true and forceHref is true', () => {
+		const comp = shallow(
+			<Banner { ...props } href={ '/' } disableHref={ true } forceHref={ true } />
+		);
+		assert.lengthOf( comp.find( 'Card' ), 1 );
+		assert.equal( '/', comp.find( 'Card' ).props().href );
+	} );
+
+	test( 'should render Card with no href and CTA button with href if href prop is passed and callToAction is also passed', () => {
+		const comp = shallow( <Banner { ...props } href={ '/' } callToAction="Go WordPress!" /> );
+		assert.lengthOf( comp.find( 'Card' ), 1 );
+		assert.equal( undefined, comp.find( 'Card' ).props().href );
+		assert.equal( noop, comp.find( 'Card' ).props().onClick );
+
+		assert.lengthOf( comp.find( 'Button' ), 1 );
+		assert.equal( '/', comp.find( 'Button' ).props().href );
+		assert.equal( 'Go WordPress!', comp.find( 'Button' ).props().children );
+		assert.equal( comp.instance().handleClick, comp.find( 'Button' ).props().onClick );
+	} );
+
+	test( 'should render Card with href and CTA button with no href if href prop is passed and callToAction is also passed and forceHref is true', () => {
+		const comp = shallow(
+			<Banner { ...props } href={ '/' } callToAction="Go WordPress!" forceHref={ true } />
+		);
+		assert.lengthOf( comp.find( 'Card' ), 1 );
+		assert.equal( '/', comp.find( 'Card' ).props().href );
+		assert.equal( comp.instance().handleClick, comp.find( 'Card' ).props().onClick );
+
+		assert.lengthOf( comp.find( 'Button' ), 1 );
+		assert.equal( undefined, comp.find( 'Button' ).props().href );
+		assert.equal( 'Go WordPress!', comp.find( 'Button' ).props().children );
 	} );
 } );
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -637,6 +637,7 @@ class ThemeSheet extends React.Component {
 					}
 					event="themes_plan_particular_free_with_plan"
 					callToAction={ 'View plans' }
+					forceHref={ true }
 				/>
 			);
 			previewUpsellBanner = React.cloneElement( pageUpsellBanner, {

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -45,6 +45,7 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 					title={ 'Unlock ALL premium themes with our Premium and Business plans!' }
 					event="themes_plans_free_personal"
 					callToAction={ 'View Plans' }
+					forceHref={ true }
 				/>
 			);
 		} else {


### PR DESCRIPTION
This is related to a nude-a-palooza project (p9jf6J-Hl-p2), and is about an issue with the upsell banner - namely it required users to click on the call to action "view plans" and didn't accept clicks outside of that area. We need the entire upsell banner to be clickable - this PR makes it happen. 

Test plan:

1. Assign yourself to group "themesNudgesUpdates"  of "nudgeAPalooza" test
1. Go to /themes
1. Confirm that entire upsell banner is clickable and redirects to `/plans` and not just the "view plans" button
1. Go to a specific premium theme's page
1. Confirm that entire upsell banner is clickable and redirects to `/plans` and not just the "view plans" button