### PR TITLE
[nudge-a-palooza] Allocate users equally to each test group - comparing results will be easier this way

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -7,7 +7,7 @@ export default {
 			themesNudgesUpdates: 20,
 			customPluginAndThemeLandingPages: 20,
 			plansBannerUpsells: 20,
-			control: 40,
+			control: 20,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,7 +1,7 @@
 /** @format */
 export default {
 	nudgeAPalooza: {
-		datestamp: '20180711',
+		datestamp: '20180726',
 		variations: {
 			sidebarUpsells: 20,
 			themesNudgesUpdates: 20,


### PR DESCRIPTION
We have 5 test groups in nudgeAPalooza test and we would like each to have equal share of users for easier results analysis. Also, this PR is small enough to use it as an opportunity to update the datestamp of this test.