### PR TITLE
My Sites: redirects to plugin page

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -5,7 +5,7 @@
 import page from 'page';
 import React from 'react';
 import i18n from 'i18n-calypso';
-import { noop, some, startsWith, uniq } from 'lodash';
+import { get, noop, some, startsWith, uniq } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -388,7 +388,21 @@ export function siteSelection( context, next ) {
 			calypsoify &&
 			/^\/plugins/.test( basePath )
 		) {
-			const pluginLink = getSiteAdminUrl( state, siteId ) + 'plugin-install.php?calypsoify=1';
+			const plugin = get( context, 'params.plugin' );
+			let pluginString = '';
+			if ( plugin ) {
+				pluginString = [
+					'tab=search',
+					`s=${ plugin }`,
+					'type=term',
+					'modal-mode=true',
+					`plugin=${ plugin }`,
+				].join( '&' );
+			}
+
+			const pluginIstallURL = 'plugin-install.php?calypsoify=1' + `&${ pluginString }`;
+			const pluginLink = getSiteAdminUrl( state, siteId ) + pluginIstallURL;
+
 			return window.location.replace( pluginLink );
 		}
 


### PR DESCRIPTION
For `plugins` route, if it's an Atomic site and if the `plugin` key is defined in context params, it redirects to the wp-admin passing the `plugin` into the query string getting the plugin details installation page.

Issue reported here: https://wp.me/pbg9X-d0g-p2


### How to test

1) go to a plugin page for all sites, for instance: http://calypso.localhost:3000/plugins/woocommerce

<img src="https://user-images.githubusercontent.com/77539/43865503-2b2cf7ba-9b39-11e8-90b5-d16c262c105b.png" width="400px" />

2) Select an Atomic site with the `Switch site` menu

<img src="https://user-images.githubusercontent.com/77539/43865473-19cabd7c-9b39-11e8-8f4b-645a5d4947de.png" width="400px" />


It should show the plugin in a modal (wp-admin)
