### PR TITLE
Fix editor bug where the edited post is null for a moment while saving

### DIFF
--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -77,25 +77,28 @@ import { getSelectedSiteId } from 'state/ui/selectors';
  * Returns an action object to be used in signalling that a post object has
  * been received.
  *
- * @param  {Object} post Post received
- * @return {Object}      Action object
+ * @param  {Object}  post       Post received
+ * @param  {?String} saveMarker Save marker in the edits log
+ * @return {Object}             Action object
  */
-export function receivePost( post ) {
-	return receivePosts( [ post ] );
+export function receivePost( post, saveMarker ) {
+	return receivePosts( [ post ], saveMarker );
 }
 
 /**
  * Returns an action object to be used in signalling that post objects have
  * been received.
  *
- * @param  {Array}  posts Posts received
- * @return {Object}       Action object
+ * @param  {Array}   posts      Posts received
+ * @param  {?String} saveMarker Save marker in the edits log
+ * @return {Object}             Action object
  */
-export function receivePosts( posts ) {
-	return {
-		type: POSTS_RECEIVE,
-		posts,
-	};
+export function receivePosts( posts, saveMarker ) {
+	const action = { type: POSTS_RECEIVE, posts };
+	if ( saveMarker ) {
+		action.saveMarker = saveMarker;
+	}
+	return action;
 }
 
 /**
@@ -261,17 +264,15 @@ export function deletePostMetadata( siteId, postId = null, metaKeys ) {
  * @param  {Number}   postId     Post ID
  * @param  {Object}   savedPost  Updated post
  * @param  {Object}   post       Post attributes
- * @param  {?String}  saveMarker Save marker in the edits log
  * @return {Object}              Action thunk
  */
-export function savePostSuccess( siteId, postId = null, savedPost, post, saveMarker = null ) {
+export function savePostSuccess( siteId, postId = null, savedPost, post ) {
 	return {
 		type: POST_SAVE_SUCCESS,
 		siteId,
 		postId,
 		savedPost,
 		post,
-		saveMarker,
 	};
 }
 
@@ -730,8 +731,8 @@ export const saveEdited = options => async ( dispatch, getState ) => {
 	// `post.ID` can be null/undefined, which means we're saving new post.
 	// `savePostSuccess` will convert the temporary ID (empty string key) in Redux
 	// to the newly assigned ID in `receivedPost.ID`.
-	dispatch( savePostSuccess( receivedPost.site_ID, post.ID, receivedPost, {}, saveMarker ) );
-	dispatch( receivePost( receivedPost ) );
+	dispatch( savePostSuccess( receivedPost.site_ID, post.ID, receivedPost, {} ) );
+	dispatch( receivePost( receivedPost, saveMarker ) );
 
 	// Only re-init the rawContent if the mode hasn't changed since the request was initiated.
 	// Changing the mode re-initializes the rawContent, so we don't want to stomp on it

--- a/client/state/posts/test/actions.js
+++ b/client/state/posts/test/actions.js
@@ -89,7 +89,6 @@ describe( 'actions', () => {
 				postId: 841,
 				savedPost: savedPost,
 				post: attributes,
-				saveMarker: null,
 			} );
 		} );
 	} );
@@ -333,7 +332,6 @@ describe( 'actions', () => {
 						ID: 13640,
 						title: 'Hello World',
 					} ),
-					saveMarker: null,
 				} );
 			} );
 		} );
@@ -376,7 +374,6 @@ describe( 'actions', () => {
 						ID: 13640,
 						title: 'Updated',
 					} ),
-					saveMarker: null,
 				} );
 			} );
 		} );

--- a/client/state/ui/editor/test/edit-save-flow.js
+++ b/client/state/ui/editor/test/edit-save-flow.js
@@ -20,9 +20,10 @@ import siteSettings from 'state/site-settings/reducer';
 import { selectedSiteId } from 'state/ui/reducer';
 import editor from 'state/ui/editor/reducer';
 import { setSelectedSiteId } from 'state/ui/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { editPost, saveEdited } from 'state/posts/actions';
 import { startEditingNewPost } from 'state/ui/editor/actions';
-import { getEditedPostValue, isEditedPostDirty } from 'state/posts/selectors';
+import { getEditedPost, getEditedPostValue, isEditedPostDirty } from 'state/posts/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 
 const SITE_ID = 123;
@@ -224,4 +225,44 @@ test( 'create post, save, type while saving, verify that edits are not lost', as
 
 	// check that post is still dirty
 	expect( isEditedPostDirty( store.getState(), SITE_ID, savedPostId ) ).toBe( true );
+} );
+
+test( 'create new post and save, verify that edited post is always valid', async () => {
+	const store = createEditorStore();
+
+	// select site and start editing new post
+	store.dispatch( setSelectedSiteId( SITE_ID ) );
+	store.dispatch( startEditingNewPost( SITE_ID ) );
+
+	// verify that the edited post is always non-null
+	store.subscribe( () => {
+		const state = store.getState();
+		const siteId = getSelectedSiteId( state );
+		const postId = getEditorPostId( state );
+		const post = getEditedPost( state, siteId, postId );
+		expect( post ).not.toBeNull();
+	} );
+
+	// edit title and content
+	const draftPostId = getEditorPostId( store.getState() );
+	store.dispatch( editPost( SITE_ID, draftPostId, { title: 'Title' } ) );
+
+	// mock the server response on save
+	nock( 'https://public-api.wordpress.com' )
+		.post( `/rest/v1.2/sites/${ SITE_ID }/posts/new?context=edit`, {
+			type: 'post',
+			status: 'draft',
+			title: 'Title',
+		} )
+		.reply( 200, {
+			global_ID: GLOBAL_ID,
+			site_ID: SITE_ID,
+			ID: POST_ID,
+			type: 'post',
+			status: 'draft',
+			title: 'Title',
+		} );
+
+	// trigger save
+	await store.dispatch( saveEdited() );
 } );


### PR DESCRIPTION
Fixes #26293. Regression caused by #26247. 

When saving a new draft where the post get assigned an ID (which was previously empty), there are two actions dispatched on save success:
```
POST_SAVE_SUCCESS
RECEIVE_POSTS
```
Both of them update the `state.posts` state. The first dispatch removes edits that are older than the save marker, the second dispatch inserts a new post into `state.posts`. But between these two dispatches, the edited post (as returned by the `getEditedPost` selector) is `null` for a moment. The edits are already removed, and the saved post is not yet inserted into Redux.

This `null` value causes the editor sidebar to be partially unmounted and the Categories accordion is among the unmounted components. Then, immediately after the next dispatch, it gets mounted again. But the internal `isExpanded` state was lost in the meantime. That's why the accordion is closed.

The fix moves the `saveMarker` logic from `POST_SAVE_SUCCESS` to `RECEIVE_POSTS`, making the `state.posts` update atomic.

There is also a new test in `client/state/ui/editor/test/edit-save-flow` that subscribes to Redux state and checks that the edited post is never `null` during and after save.
