### PR TITLE
SDK: Add Jetpack markdown block

### DIFF
--- a/client/gutenberg/extensions/markdown/components/markdown-renderer.jsx
+++ b/client/gutenberg/extensions/markdown/components/markdown-renderer.jsx
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import markdownConverter from '../utils/markdown-converter';
+
+const {
+	RawHTML
+} = window.wp.element;
+
+const MarkdownRenderer = function( props ) {
+	const { className, source } = props;
+
+	let content = '';
+
+	if ( source ) {
+		// converts the markdown source to HTML
+		content = markdownConverter.render( source );
+	}
+	return <RawHTML className={ className }>{ content }</RawHTML>;
+};
+
+export default MarkdownRenderer;

--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block-editor.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block-editor.jsx
@@ -1,0 +1,127 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import MarkdownRenderer from './components/markdown-renderer';
+
+const { __ } = window.wp.i18n;
+
+const {
+	ButtonGroup
+} = window.wp.components;
+
+const {
+	BlockControls,
+	PlainText
+} = window.wp.editor;
+
+const {
+	Component
+} = window.wp.element;
+
+const PANEL_EDITOR = 'editor';
+const PANEL_PREVIEW = 'preview';
+
+class JetpackMarkdownBlockEditor extends Component {
+
+	constructor() {
+		super( ...arguments );
+
+		this.updateSource = this.updateSource.bind( this );
+		this.showEditor = this.showEditor.bind( this );
+		this.showPreview = this.showPreview.bind( this );
+		this.isEmpty = this.isEmpty.bind( this );
+
+		this.state = {
+			activePanel: PANEL_EDITOR
+		};
+	}
+
+	isEmpty() {
+		const source = this.props.attributes.source;
+		return ! source || source.trim() === '';
+	}
+
+	updateSource( source ) {
+		this.props.setAttributes( { source } );
+	}
+
+	showEditor() {
+		this.setState( { activePanel: 'editor' } );
+	}
+
+	showPreview() {
+		this.setState( { activePanel: 'preview' } );
+	}
+
+	render() {
+		const { attributes, className, isSelected } = this.props;
+
+		if ( ! isSelected && this.isEmpty() ) {
+			return (
+				<p className={ `${ className }__placeholder` }>
+					{ __( 'Write your _Markdown_ **here**...' ) }
+				</p>
+			);
+		}
+
+		// Renders the editor panel or the preview panel based on component's state
+		const editorOrPreviewPanel = function() {
+			const source = attributes.source;
+
+			switch ( this.state.activePanel ) {
+				case PANEL_EDITOR:
+					return <PlainText
+						className={ `${ className }__editor` }
+						onChange={ this.updateSource }
+						aria-label={ __( 'Markdown' ) }
+						value={ attributes.source }
+					/>;
+
+				case PANEL_PREVIEW:
+					return <MarkdownRenderer
+						className={ `${ className }__preview` }
+						source={ source }
+					/>;
+			}
+		};
+
+		// Manages css classes for each panel based on component's state
+		const classesForPanel = function( panelName ) {
+			return classNames( {
+				'components-tab-button': true,
+				'is-active': this.state.activePanel === panelName,
+				[ `${ className }__${ panelName }-button` ]: true
+			} );
+		};
+
+		return (
+			<div>
+				<BlockControls >
+					<ButtonGroup>
+						<button
+							className={ classesForPanel.call( this, 'editor' ) }
+							onClick={ this.showEditor }
+						>
+							<span>{ __( 'Markdown' ) }</span>
+						</button>
+						<button
+							className={ classesForPanel.call( this, 'preview' ) }
+							onClick={ this.showPreview }
+						>
+							<span>{ __( 'Preview' ) }</span>
+						</button>
+					</ButtonGroup>
+				</BlockControls>
+				{ ( editorOrPreviewPanel.call( this ) ) }
+			</div>
+		);
+	}
+
+}
+export default JetpackMarkdownBlockEditor;

--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block-save.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block-save.jsx
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import MarkdownPreview from './components/markdown-renderer';
+
+function JetpackMarkdownBlockSave( { attributes, className } ) {
+	return <MarkdownPreview
+		className={ `${ className }-renderer` }
+		source={ attributes.source }
+	/>;
+}
+
+export default JetpackMarkdownBlockSave;

--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block.js
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block.js
@@ -1,64 +1,54 @@
-'use strict';
-
-var _react = require('react');
-
-var _react2 = _interopRequireDefault(_react);
-
-var _jetpackMarkdownBlockEditor = require('./jetpack-markdown-block-editor');
-
-var _jetpackMarkdownBlockEditor2 = _interopRequireDefault(_jetpackMarkdownBlockEditor);
-
-var _jetpackMarkdownBlockSave = require('./jetpack-markdown-block-save');
-
-var _jetpackMarkdownBlockSave2 = _interopRequireDefault(_jetpackMarkdownBlockSave);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+/**
+ * External dependencies
+ */
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var __ = window.wp.i18n.__; /**
-                             * External dependencies
-                             */
+import JetpackMarkdownBlockEditor from './jetpack-markdown-block-editor';
+import JetpackMarkdownBlockSave from './jetpack-markdown-block-save';
 
-var registerBlockType = window.wp.blocks.registerBlockType;
+const { __ } = window.wp.i18n;
 
+const {
+	registerBlockType,
+} = window.wp.blocks;
 
-registerBlockType('jetpack/markdown-block', {
+registerBlockType( 'jetpack/markdown-block', {
 
-	title: __('Markdown'),
+	title: __( 'Markdown' ),
 
-	description: [__('Write your content in plain-text Markdown syntax.'), wp.element.createElement(
-		'p',
-		null,
-		wp.element.createElement(
-			'a',
-			{ href: 'https://en.support.wordpress.com/markdown-quick-reference/' },
-			'Support Reference'
+	description: [
+		__( 'Write your content in plain-text Markdown syntax.' ),
+		(
+		<p>
+			<a href="https://en.support.wordpress.com/markdown-quick-reference/">
+			Support Reference
+			</a>
+		</p>
 		)
-	)],
+	],
 
-	icon: wp.element.createElement(
-		'svg',
-		{
-			xmlns: 'http://www.w3.org/2000/svg',
-			'class': 'dashicon',
-			width: '20',
-			height: '20',
-			viewBox: '0 0 208 128',
-			stroke: 'currentColor'
-		},
-		wp.element.createElement('rect', {
-			width: '198',
-			height: '118',
-			x: '5',
-			y: '5',
-			ry: '10',
-			'stroke-width': '10',
-			fill: 'none'
-		}),
-		wp.element.createElement('path', { d: 'M30 98v-68h20l20 25 20-25h20v68h-20v-39l-20 25-20-25v39zM155 98l-30-33h20v-35h20v35h20z' })
-	),
+	icon: <svg
+			xmlns="http://www.w3.org/2000/svg"
+			class="dashicon"
+			width="20"
+			height="20"
+			viewBox="0 0 208 128"
+			stroke="currentColor"
+		>
+			<rect
+				width="198"
+				height="118"
+				x="5"
+				y="5"
+				ry="10"
+				stroke-width="10"
+				fill="none"
+			/>
+			<path d="M30 98v-68h20l20 25 20-25h20v68h-20v-39l-20 25-20-25v39zM155 98l-30-33h20v-35h20v35h20z" />
+		</svg>,
 
 	category: 'formatting',
 
@@ -67,8 +57,8 @@ registerBlockType('jetpack/markdown-block', {
 		source: { type: 'string' }
 	},
 
-	edit: _jetpackMarkdownBlockEditor2['default'],
+	edit: JetpackMarkdownBlockEditor,
 
-	save: _jetpackMarkdownBlockSave2['default']
+	save: JetpackMarkdownBlockSave,
 
-});
+} );

--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block.js
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block.js
@@ -1,0 +1,74 @@
+'use strict';
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _jetpackMarkdownBlockEditor = require('./jetpack-markdown-block-editor');
+
+var _jetpackMarkdownBlockEditor2 = _interopRequireDefault(_jetpackMarkdownBlockEditor);
+
+var _jetpackMarkdownBlockSave = require('./jetpack-markdown-block-save');
+
+var _jetpackMarkdownBlockSave2 = _interopRequireDefault(_jetpackMarkdownBlockSave);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Internal dependencies
+ */
+var __ = window.wp.i18n.__; /**
+                             * External dependencies
+                             */
+
+var registerBlockType = window.wp.blocks.registerBlockType;
+
+
+registerBlockType('jetpack/markdown-block', {
+
+	title: __('Markdown'),
+
+	description: [__('Write your content in plain-text Markdown syntax.'), wp.element.createElement(
+		'p',
+		null,
+		wp.element.createElement(
+			'a',
+			{ href: 'https://en.support.wordpress.com/markdown-quick-reference/' },
+			'Support Reference'
+		)
+	)],
+
+	icon: wp.element.createElement(
+		'svg',
+		{
+			xmlns: 'http://www.w3.org/2000/svg',
+			'class': 'dashicon',
+			width: '20',
+			height: '20',
+			viewBox: '0 0 208 128',
+			stroke: 'currentColor'
+		},
+		wp.element.createElement('rect', {
+			width: '198',
+			height: '118',
+			x: '5',
+			y: '5',
+			ry: '10',
+			'stroke-width': '10',
+			fill: 'none'
+		}),
+		wp.element.createElement('path', { d: 'M30 98v-68h20l20 25 20-25h20v68h-20v-39l-20 25-20-25v39zM155 98l-30-33h20v-35h20v35h20z' })
+	),
+
+	category: 'formatting',
+
+	attributes: {
+		//The Markdown source is saved in the block content comments delimiter
+		source: { type: 'string' }
+	},
+
+	edit: _jetpackMarkdownBlockEditor2['default'],
+
+	save: _jetpackMarkdownBlockSave2['default']
+
+});

--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import JetpackMarkdownBlockEditor from './jetpack-markdown-block-editor';
+import JetpackMarkdownBlockSave from './jetpack-markdown-block-save';
+
+const { __ } = window.wp.i18n;
+
+const {
+	registerBlockType,
+} = window.wp.blocks;
+
+registerBlockType( 'jetpack/markdown-block', {
+
+	title: __( 'Markdown' ),
+
+	description: [
+		__( 'Write your content in plain-text Markdown syntax.' ),
+		(
+		<p>
+			<a href="https://en.support.wordpress.com/markdown-quick-reference/">
+			Support Reference
+			</a>
+		</p>
+		)
+	],
+
+	icon: <svg
+			xmlns="http://www.w3.org/2000/svg"
+			class="dashicon"
+			width="20"
+			height="20"
+			viewBox="0 0 208 128"
+			stroke="currentColor"
+		>
+			<rect
+				width="198"
+				height="118"
+				x="5"
+				y="5"
+				ry="10"
+				stroke-width="10"
+				fill="none"
+			/>
+			<path d="M30 98v-68h20l20 25 20-25h20v68h-20v-39l-20 25-20-25v39zM155 98l-30-33h20v-35h20v35h20z" />
+		</svg>,
+
+	category: 'formatting',
+
+	attributes: {
+		//The Markdown source is saved in the block content comments delimiter
+		source: { type: 'string' }
+	},
+
+	edit: JetpackMarkdownBlockEditor,
+
+	save: JetpackMarkdownBlockSave,
+
+} );

--- a/client/gutenberg/extensions/markdown/utils/markdown-converter.js
+++ b/client/gutenberg/extensions/markdown/utils/markdown-converter.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import MarkdownIt from 'markdown-it';
+
+const markdownItFull = new MarkdownIt();
+
+const MarkdownConverter = {
+
+	render( source ) {
+		return markdownItFull.render( source );
+	}
+
+};
+
+export default MarkdownConverter;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9143,6 +9143,15 @@
         "immediate": "~3.0.5"
       }
     },
+    "linkify-it": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
+      "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -9415,6 +9424,19 @@
       "integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA==",
       "dev": true
     },
+    "markdown-it": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
+      "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "entities": "~1.1.1",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      }
+    },
     "markdown-loader": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/markdown-loader/-/markdown-loader-3.0.0.tgz",
@@ -9470,6 +9492,12 @@
         "unist-util-modify-children": "^1.0.0",
         "unist-util-visit": "^1.1.0"
       }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -15624,6 +15652,12 @@
       "version": "0.7.18",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
       "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+    },
+    "uc.micro": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
+      "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.4.5",

--- a/package.json
+++ b/package.json
@@ -268,6 +268,7 @@
     "jest": "23.4.1",
     "jest-docblock": "23.2.0",
     "jest-junit-reporter": "1.1.0",
+    "markdown-it": "8.4.2",
     "md5-file": "4.0.0",
     "mixedindentlint": "1.2.0",
     "nock": "8.2.2",


### PR DESCRIPTION
This PR adds the Jetpack **Markdown** block to the set of Gutenberg extensions, based on the previous work done by @Ferdev in: https://github.com/Automattic/jetpack/pull/9705.

The code hasn't been edited at this time - the idea is to be able to build it in Calypso and use it directly in Jetpack as a Gutenberg block.

To test:
* Build the block:
    ```
    ./bin/sdk-cli.js build-block --editor-script ./client/gutenberg/extensions/markdown/jetpack-markdown-block.js
    ```
* Copy the built file from: `client/gutenberg/extensions/markdown/build/blocks-markdown.js` to Jetpack's folder - `modules/markdown/block.js`
* Checkout `try/markdown-gutenberg-block-externally-built` branch in your Jetpack installation (see https://github.com/Automattic/jetpack/pull/9954).
* Insert "Markdown" block in Gutenberg and watch out for errors.