### PR TITLE
Domains: Update transfer started copy not to mention email anymore

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -28,6 +28,7 @@ import { localize } from 'i18n-calypso';
 import { preventWidows } from 'lib/formatting';
 import { domainManagementTransferInPrecheck } from 'my-sites/domains/paths';
 import { recordStartTransferClickInThankYou } from 'state/domains/actions';
+import { CHANGE_NAME_SERVERS } from 'lib/url/support';
 
 class CheckoutThankYouHeader extends PureComponent {
 	static propTypes = {
@@ -59,14 +60,8 @@ class CheckoutThankYouHeader extends PureComponent {
 			return translate( 'Thank you!' );
 		}
 
-		if ( primaryPurchase && isDomainTransfer( primaryPurchase ) ) {
-			if ( isDelayedDomainTransfer( primaryPurchase ) ) {
-				return preventWidows( translate( 'Almost done!' ) );
-			}
-
-			return preventWidows(
-				translate( 'Check your email! There are important next steps waiting in your inbox.' )
-			);
+		if ( primaryPurchase && isDelayedDomainTransfer( primaryPurchase ) ) {
+			return preventWidows( translate( 'Almost done!' ) );
 		}
 
 		return translate( 'Congratulations on your purchase!' );
@@ -186,12 +181,19 @@ class CheckoutThankYouHeader extends PureComponent {
 			}
 
 			return translate(
-				'We sent an email with an important link. Please open the email and click the link to confirm ' +
-					'that you want to transfer {{strong}}%(domainName)s{{/strong}} to WordPress.com. ' +
-					"The transfer can't complete until you do!",
+				'Your domain {{strong}}%(domain)s{{/strong}} was added to your site. ' +
+					'To make your newly transferred domain work with WordPress.com, you need to ' +
+					'{{updateNameserversLink}}update the nameservers{{/updateNameserversLink}}.',
 				{
-					args: { domainName: primaryPurchase.meta },
-					components: { strong: <strong /> },
+					args: {
+						domain: primaryPurchase.meta,
+					},
+					components: {
+						strong: <strong />,
+						updateNameserversLink: (
+							<a href={ CHANGE_NAME_SERVERS } target="_blank" rel="noopener noreferrer" />
+						),
+					},
 				}
 			);
 		}


### PR DESCRIPTION
Post-GDPR, we don't send any emails that need user action, nor is there an FOA involved. So we should not mention any emails - instead, let's tell the user to check the nameservers.

Related reports: p2MSmN-6H9-p2 and p2MSmN-6Gx-p2.

### Testing

Make sure you have `checklistThankYouForPaidUser` set to `hide` - see #26340.

Initiate a transfer-in from NUX: after creating the site, you should be presented with a screen to input the auth code. Once you get past that, you should see the updated thank you page.

Initiate a transfer-in from Domain Management: same as above, but the auth code input screen is _before_ the checkout. The thank you screen should be the same, though.

<img width="982" alt="screen shot 2018-07-26 at 17 37 52" src="https://user-images.githubusercontent.com/3392497/43274611-e5fa00a4-90ff-11e8-89e8-058c546c1f0c.png">
