### PR TITLE
Checkout: Ensure the checklist is not shown for domain purchases

### DIFF
--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -296,7 +296,13 @@ export class Checkout extends React.Component {
 
 	getCheckoutCompleteRedirectPath = () => {
 		let renewalItem;
-		const { cart, selectedSiteSlug, transaction: { step: { data: receipt } } } = this.props;
+		const {
+			cart,
+			selectedSiteSlug,
+			transaction: {
+				step: { data: receipt },
+			},
+		} = this.props;
 		const domainReceiptId = get(
 			cartItems.getGoogleApps( cart ),
 			'[0].extra.receipt_for_domain',
@@ -357,14 +363,18 @@ export class Checkout extends React.Component {
 		}
 
 		// DO NOT assign the test here.
-		if ( receipt && 'show' === getABTestVariation( 'checklistThankYouForPaidUser' ) ) {
+		if (
+			receipt &&
+			this.props.isEligibleForCheckoutToChecklist &&
+			'show' === getABTestVariation( 'checklistThankYouForPaidUser' )
+		) {
 			return `/checklist/${ selectedSiteSlug }?d=paid`;
 		}
 
 		return this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )
 			? `/checkout/thank-you/features/${
 					this.props.selectedFeature
-				}/${ selectedSiteSlug }/${ receiptId }`
+			  }/${ selectedSiteSlug }/${ receiptId }`
 			: `/checkout/thank-you/${ selectedSiteSlug }/${ receiptId }`;
 	};
 
@@ -380,7 +390,9 @@ export class Checkout extends React.Component {
 			isDomainOnly,
 			reduxStore,
 			selectedSiteId,
-			transaction: { step: { data: receipt } },
+			transaction: {
+				step: { data: receipt },
+			},
 			translate,
 		} = this.props;
 		const redirectPath = this.getCheckoutCompleteRedirectPath();

--- a/client/state/selectors/is-eligible-for-checkout-to-checklist.js
+++ b/client/state/selectors/is-eligible-for-checkout-to-checklist.js
@@ -29,6 +29,14 @@ export default function isEligibleForCheckoutToChecklist( state, siteId, cart ) 
 		return false;
 	}
 
+	if (
+		cartItems.hasDomainMapping( cart ) ||
+		cartItems.hasDomainRegistration( cart ) ||
+		cartItems.hasTransferProduct( cart )
+	) {
+		return false;
+	}
+
 	return (
 		isNewSite &&
 		'blog' === designType &&


### PR DESCRIPTION
The Thank You pages shown after checkout for domain purchases contain very important information and the checklist should never override them - or it should incorporate them. But it's most important to fix this regression first.

### Testing
Buy domain mapping, registration or transfer (either from NUX or Domain Management on an existing site). Ensure that a domain-specific page is shown on the Thank You page - regardless of the variation of the `checklistThankYouForPaidUser ` A/B test. The Checklist should _not_ be shown.

<img width="982" alt="screen shot 2018-07-26 at 17 37 52" src="https://user-images.githubusercontent.com/3392497/43274471-9b5279fa-90ff-11e8-8af1-8f4b1f526662.png">
<img width="975" alt="screen shot 2018-07-26 at 17 40 14" src="https://user-images.githubusercontent.com/3392497/43274472-9b7188e0-90ff-11e8-8050-623cf92aaa6e.png">
<img width="982" alt="screen shot 2018-07-26 at 17 58 25" src="https://user-images.githubusercontent.com/3392497/43274473-9b915f76-90ff-11e8-98ac-715412b75abc.png">
