### PR TITLE
Signup: launch G Suite upsell discount A/B test.

### DIFF
--- a/client/components/upgrades/google-apps/google-apps-dialog/product-details.jsx
+++ b/client/components/upgrades/google-apps/google-apps-dialog/product-details.jsx
@@ -5,29 +5,89 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
+import Badge from 'components/badge';
 
 class GoogleAppsProductDetails extends Component {
 	static propTypes = {
 		annualPrice: PropTypes.string.isRequired,
 		monthlyPrice: PropTypes.string.isRequired,
+		showDiscount: PropTypes.bool.isRequired,
 	};
 
-	render() {
+	static defaultProps = {
+		showDiscount: false,
+	};
+
+	renderPrice() {
 		const { translate } = this.props;
 
+		if ( this.props.showDiscount ) {
+			return (
+				<Fragment>
+					<del>
+						{ translate( '%(monthlyPrice)s per user / month', {
+							args: { monthlyPrice: this.props.monthlyPrice },
+						} ) }
+					</del>
+					<strong>
+						{ /* Do not translate this string as it is a part of an abtest. */ }
+						{ this.props.discountMonthlyPrice } per user / month
+					</strong>
+				</Fragment>
+			);
+		}
+
+		return translate( '%(monthlyPrice)s per user / month', {
+			args: { monthlyPrice: this.props.monthlyPrice },
+		} );
+	}
+
+	// Do not translate this function as it is a part of an abtest.
+	renderPromotionalCopy() {
+		if ( ! this.props.showDiscount ) {
+			return null;
+		}
+
 		return (
-			<div className="google-apps-dialog__product-details">
+			<div className="google-apps-dialog__promotional-copy">
+				LIMITED-TIME ONLY: { this.props.discountAnnualPrice } FOR THE FIRST YEAR
+				<Badge type="succes">{ this.props.discountRate }% OFF</Badge>
+			</div>
+		);
+	}
+
+	renderPeriod() {
+		if ( this.props.showDiscount ) {
+			// Do not translate this string as it is a part of an abtest.
+			return `${ this.props.annualPrice } Billed yearly`;
+		}
+
+		return this.props.translate( '%(annualPrice)s Billed yearly — get 2 months free!', {
+			args: { annualPrice: this.props.annualPrice },
+		} );
+	}
+
+	render() {
+		const { translate, showDiscount } = this.props;
+
+		return (
+			<div
+				className={ classnames( 'google-apps-dialog__product-details', {
+					'with-discount': showDiscount,
+				} ) }
+			>
 				<div className="google-apps-dialog__product-intro">
-					<h3 className="google-apps-dialog__product-name">
+					<div className="google-apps-dialog__product-name">
 						{ /* Intentionally not translable as it is a brand name and Google keeps it in English */ }
 						<span className="google-apps-dialog__product-logo">G Suite</span>
-					</h3>
+					</div>
 
 					<p>
 						{ translate(
@@ -36,21 +96,15 @@ class GoogleAppsProductDetails extends Component {
 						) }
 					</p>
 
-					<h4 className="google-apps-dialog__price-per-user">
-						{ translate( '%(monthlyPrice)s per user / month', {
-							args: { monthlyPrice: this.props.monthlyPrice },
-						} ) }
-					</h4>
+					<div className="google-apps-dialog__price-per-user">{ this.renderPrice() }</div>
 
-					<h5 className="google-apps-dialog__billing-period">
-						{ translate( '%(annualPrice)s Billed yearly — get 2 months free!', {
-							args: { annualPrice: this.props.annualPrice },
-						} ) }
-					</h5>
+					<div className="google-apps-dialog__billing-period">{ this.renderPeriod() }</div>
+
+					{ this.renderPromotionalCopy() }
 				</div>
 
-				<div className="google-apps-dialog__product-features">
-					<h5 className="google-apps-dialog__product-feature">
+				<ul className="google-apps-dialog__product-features">
+					<li className="google-apps-dialog__product-feature">
 						<img src="/calypso/images/g-suite/logo_gmail_48dp.svg" />
 						<p>
 							{ translate( 'Professional email {{nowrap}}(@%(domain)s){{/nowrap}}', {
@@ -58,23 +112,23 @@ class GoogleAppsProductDetails extends Component {
 								components: { nowrap: <span className="google-apps-dialog__domain" /> },
 							} ) }
 						</p>
-					</h5>
+					</li>
 
-					<h5 className="google-apps-dialog__product-feature">
+					<li className="google-apps-dialog__product-feature">
 						<img src="/calypso/images/g-suite/logo_drive_48dp.svg" />
 						<p>{ translate( '30GB Online File Storage' ) }</p>
-					</h5>
+					</li>
 
-					<h5 className="google-apps-dialog__product-feature">
+					<li className="google-apps-dialog__product-feature">
 						<img src="/calypso/images/g-suite/logo_docs_48dp.svg" />
 						<p>{ translate( 'Docs, spreadsheets, and more' ) }</p>
-					</h5>
+					</li>
 
-					<h5 className="google-apps-dialog__product-feature">
+					<li className="google-apps-dialog__product-feature">
 						<img src="/calypso/images/g-suite/logo_hangouts_48px.png" />
 						<p>{ translate( 'Video and voice calls' ) }</p>
-					</h5>
-				</div>
+					</li>
+				</ul>
 			</div>
 		);
 	}

--- a/client/components/upgrades/google-apps/google-apps-dialog/style.scss
+++ b/client/components/upgrades/google-apps/google-apps-dialog/style.scss
@@ -3,15 +3,23 @@
 //
 
 .google-apps-dialog__product-details {
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		display: flex;
 	}
 }
 
 .google-apps-dialog__product-intro {
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		max-width: 350px;
 		margin-right: 50px;
+	}
+
+	.google-apps-dialog__product-details.with-discount & {
+		@include breakpoint( '>960px' ) {
+			max-width: 370px;
+			margin-right: 30px;
+			flex: 370px 1 0;
+		}
 	}
 }
 
@@ -23,7 +31,7 @@
 }
 
 .google-apps-dialog__product-logo {
-	background: url('/calypso/images/upgrades/g-suite-logo.png') no-repeat left;
+	background: url( '/calypso/images/upgrades/g-suite-logo.png' ) no-repeat left;
 	background-size: 73px;
 	display: inline-block;
 	height: 19px;
@@ -50,6 +58,7 @@
 	color: $gray-dark;
 	font-size: 15px;
 	line-height: 130%;
+	list-style-type: none;
 	margin: 34px 0 1em;
 }
 
@@ -72,12 +81,58 @@
 	color: $blue-medium;
 	font-size: 18px;
 	font-weight: 600;
+	line-height: 1.3;
+
+	del {
+		text-decoration: line-through;
+		font-size: 15px;
+		font-weight: normal;
+
+		@include breakpoint( '<480px' ) {
+			display: block;
+		}
+	}
+
+	strong {
+		color: $green-jetpack;
+		margin-left: 0.3em;
+
+		@include breakpoint( '<480px' ) {
+			margin-left: 0;
+		}
+	}
 }
 
 .google-apps-dialog__billing-period {
 	color: $gray;
-	font-size: 13px;
+	font-size: 12px;
+	line-height: 1.6;
 	text-transform: uppercase;
+
+	.google-apps-dialog__product-details.with-discount & {
+		text-decoration: line-through;
+	}
+
+	@include breakpoint( '<480px' ) {
+		margin-top: 15px;
+	}
+}
+
+.google-apps-dialog__promotional-copy {
+	color: $alert-green;
+	font-size: 12px;
+	line-height: 1.6;
+}
+
+.google-apps-dialog__promotional-copy .badge {
+	background: $alert-green;
+	color: $white;
+	font-size: 12px;
+	margin-left: 5px;
+
+	@include breakpoint( '<480px' ) {
+		margin: 3px 0 0 0;
+	}
 }
 
 form.google-apps-dialog {
@@ -91,7 +146,6 @@ form.google-apps-dialog {
 	overflow: hidden;
 	transition: max-height 0.2s ease-in-out;
 }
-
 
 .google-apps-dialog__users-enter.google-apps-dialog__users-enter-active {
 	max-height: 300px;
@@ -114,7 +168,7 @@ form.google-apps-dialog {
 	}
 
 	.google-apps-dialog__user-first-name {
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			display: inline-block;
 			margin: 0 4px 0 0;
 			width: calc( 50% - 4px );
@@ -123,7 +177,7 @@ form.google-apps-dialog {
 	}
 
 	.google-apps-dialog__user-last-name {
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			display: inline-block;
 			margin: 0 0 0 5px;
 			width: calc( 50% - 5px );
@@ -161,22 +215,24 @@ form.google-apps-dialog {
 
 .google-apps-dialog__footer {
 	.google-apps-dialog__continue-button {
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( '<480px' ) {
 			width: 100%;
 			margin-top: 10px;
 		}
 
-		@include breakpoint( ">480px" ) {
+		@include breakpoint( '>480px' ) {
 			float: right;
 		}
 	}
 
 	.google-apps-dialog__checkout-button {
-		@include breakpoint( "<480px" ) {
+		color: $blue-medium;
+
+		@include breakpoint( '<480px' ) {
 			width: 100%;
 		}
 
-		@include breakpoint( ">480px" ) {
+		@include breakpoint( '>480px' ) {
 			float: left;
 		}
 	}

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -104,4 +104,12 @@ export default {
 		},
 		defaultVariation: 'no',
 	},
+	gSuiteDiscount: {
+		datestamp: '20180803',
+		variations: {
+			control: 50,
+			discount: 50,
+		},
+		defaultVariation: 'control',
+	},
 };

--- a/client/lib/google-apps/index.js
+++ b/client/lib/google-apps/index.js
@@ -12,15 +12,24 @@ import formatCurrency from 'lib/format-currency';
 const GOOGLE_APPS_LINK_PREFIX = 'https://mail.google.com/a/';
 
 function getAnnualPrice( cost, currencyCode ) {
-	return formatCurrency( cost, currencyCode );
+	return formatPrice( cost, currencyCode );
 }
 
 function getMonthlyPrice( cost, currencyCode ) {
-	return formatCurrency( cost / 10, currencyCode );
+	return formatPrice( cost / 10, currencyCode );
 }
 
 function googleAppsSettingsUrl( domainName ) {
 	return GOOGLE_APPS_LINK_PREFIX + domainName;
 }
 
-export { getAnnualPrice, getMonthlyPrice, googleAppsSettingsUrl };
+function formatPrice( cost, currencyCode, options = {} ) {
+	if ( options.precision ) {
+		const exponent = Math.pow( 10, options.precision );
+		cost = Math.round( cost * exponent ) / exponent;
+	}
+
+	return formatCurrency( cost, currencyCode, cost % 1 > 0 ? {} : { precision: 0 } );
+}
+
+export { getAnnualPrice, getMonthlyPrice, googleAppsSettingsUrl, formatPrice };

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -55,7 +55,7 @@ export class GsuiteNudge extends React.Component {
 		addItem( googleAppsCartItem );
 
 		if ( receiptId && inDiscountABTest ) {
-			applyCoupon( 'GSUITE42' );
+			applyCoupon( 'GSUITE50' );
 		}
 		page( `/checkout/${ siteSlug }` );
 	};

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -19,9 +19,10 @@ import Main from 'components/main';
 import QuerySites from 'components/data/query-sites';
 import { getSiteSlug, getSiteTitle, getSitePlan } from 'state/sites/selectors';
 import { getReceiptById } from 'state/receipts/selectors';
-import { addItem, removeItem } from 'lib/upgrades/actions';
+import { addItem, removeItem, applyCoupon } from 'lib/upgrades/actions';
 import { cartItems } from 'lib/cart-values';
 import { isDotComPlan, isBusiness } from 'lib/products-values';
+import { abtest } from 'lib/abtest';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 export class GsuiteNudge extends React.Component {
@@ -42,7 +43,7 @@ export class GsuiteNudge extends React.Component {
 	};
 
 	handleAddGoogleApps = googleAppsCartItem => {
-		const { siteSlug, receiptId } = this.props;
+		const { siteSlug, receiptId, inDiscountABTest } = this.props;
 
 		googleAppsCartItem.extra = {
 			...googleAppsCartItem.extra,
@@ -52,6 +53,10 @@ export class GsuiteNudge extends React.Component {
 		this.removePlanFromCart();
 
 		addItem( googleAppsCartItem );
+
+		if ( receiptId && inDiscountABTest ) {
+			applyCoupon( 'GSUITE42' );
+		}
 		page( `/checkout/${ siteSlug }` );
 	};
 
@@ -86,6 +91,7 @@ export class GsuiteNudge extends React.Component {
 					domain={ this.props.domain }
 					onClickSkip={ this.handleClickSkip }
 					onAddGoogleApps={ this.handleAddGoogleApps }
+					showDiscount={ this.props.inDiscountABTest }
 				/>
 			</Main>
 		);
@@ -102,6 +108,7 @@ export default connect( ( state, props ) => {
 		siteSlug: getSiteSlug( state, props.selectedSiteId ),
 		siteTitle: getSiteTitle( state, props.selectedSiteId ),
 		hasDotComBusiness,
+		inDiscountABTest: 'discount' === abtest( 'gSuiteDiscount' ),
 	};
 } )( localize( GsuiteNudge ) );
 


### PR DESCRIPTION
This will launch G Suite upsell discount abtest. For more context, see p9jf6J-Hb-p2 and p8Eqe3-sq-p2

# How to test

_Note: The following steps should be performed outside of a store sandbox because the G Suite works only with real domains._

_Note2: Do not forget to cancel both the domain and the G Suite purchases soon afterwards. Or A8C will be charged for it._

_Note3: You may need a number of free credit for the testing._

1. Ensure that you're assigned to `gsuiteDiscount` abtest with `discount` variation.
2. Create a website on a paid plan with a custom domain.
3. Make a purchase.
4. You should be able to see will see the G Suite upsell dialog.
<img width="755" alt="2018-07-27 2 19 40" src="https://user-images.githubusercontent.com/212034/43277654-a72c6bac-9143-11e8-9d32-fb849e4af03e.png">
5. When you choose to add an email address, a coupon code should be automatically applied to the cart.
<img width="275" alt="_2018-07-26_ _11_45_40" src="https://user-images.githubusercontent.com/212034/43277796-1f7c7412-9144-11e8-98f6-f2548e1f5c02.png">


