### PR TITLE
Autosaves: Create a separate revision when autosaving a draft

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -16,7 +16,7 @@ import { v4 as uuid } from 'uuid';
 /**
  * Internal dependencies
  */
-import { autosave, saveEdited } from 'state/posts/actions';
+import { autosave, saveEdited, saveRevision } from 'state/posts/actions';
 import { addSiteFragment } from 'lib/route';
 import EditorActionBar from 'post-editor/editor-action-bar';
 import FeaturedImage from 'post-editor/editor-featured-image';
@@ -538,6 +538,10 @@ export class PostEditor extends React.Component {
 			const saveResult = await this.props.autosave();
 			if ( ! savingPublishedPost ) {
 				this.onSaveDraftSuccess( saveResult );
+
+				// Create a revision separately from the autosave
+				// @TODO throttle / debounce this separately?
+				this.props.saveRevision( this.props.siteId, this.props.post );
 			}
 		} catch ( error ) {
 			if ( ! savingPublishedPost ) {
@@ -1147,6 +1151,7 @@ const enhance = flow(
 		{
 			autosave,
 			saveEdited,
+			saveRevision,
 			editPost,
 			setEditorModePreference: partial( savePreference, 'editor-mode' ),
 			setLayoutFocus,

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import page from 'page';
 import PropTypes from 'prop-types';
-import { debounce, flow, get, partial, throttle } from 'lodash';
+import { debounce, flow, get, isEqual, partial, pick, throttle } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -16,7 +16,8 @@ import { v4 as uuid } from 'uuid';
 /**
  * Internal dependencies
  */
-import { autosave, saveEdited, saveRevision } from 'state/posts/actions';
+import { POST_REVISION_FIELDS } from 'state/posts/constants';
+import { autosave, editPost, saveEdited, saveRevision } from 'state/posts/actions';
 import { addSiteFragment } from 'lib/route';
 import EditorActionBar from 'post-editor/editor-action-bar';
 import FeaturedImage from 'post-editor/editor-featured-image';
@@ -50,7 +51,6 @@ import {
 	getEditorLoadingError,
 } from 'state/ui/editor/selectors';
 import { recordTracksEvent, recordGoogleEvent } from 'state/analytics/actions';
-import { editPost } from 'state/posts/actions';
 import {
 	getSitePost,
 	getEditedPost,
@@ -263,7 +263,14 @@ export class PostEditor extends React.Component {
 		const isInvalidURL = this.props.loadingError;
 
 		const isTrashed = get( this.props.post, 'status' ) === 'trash';
-		const hasAutosave = get( this.props.post, 'meta.data.autosave' );
+		const autosaveMetaData = get( this.props.post, 'meta.data.autosave' );
+		const hasDifferingAutosave =
+			autosaveMetaData &&
+			! this.state.isSaving &&
+			! isEqual(
+				pick( autosaveMetaData, POST_REVISION_FIELDS ),
+				pick( this.props.post, POST_REVISION_FIELDS )
+			);
 
 		const classes = classNames( 'post-editor', {
 			'is-loading': ! this.state.isEditorInitialized,
@@ -400,7 +407,7 @@ export class PostEditor extends React.Component {
 					<VerifyEmailDialog onClose={ this.closeVerifyEmailDialog } />
 				) : null }
 				{ isInvalidURL && <InvalidURLDialog onClose={ this.onClose } /> }
-				{ hasAutosave && this.state.showAutosaveDialog ? (
+				{ hasDifferingAutosave && this.state.showAutosaveDialog ? (
 					<RestorePostDialog
 						onRestore={ this.restoreAutosave }
 						onClose={ this.closeAutosaveDialog }

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -124,7 +124,7 @@ export class PostEditor extends React.Component {
 	}
 
 	autosaveFlushToRevision = () => {
-		this.props.saveRevision( this.props.siteId, this.props.post );
+		saveRevision( this.props.siteId, this.props.post );
 	};
 
 	componentWillMount() {
@@ -1166,7 +1166,6 @@ const enhance = flow(
 		{
 			autosave,
 			saveEdited,
-			saveRevision,
 			editPost,
 			setEditorModePreference: partial( savePreference, 'editor-mode' ),
 			setLayoutFocus,

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -134,7 +134,9 @@ export class PostEditor extends React.Component {
 		this.switchEditorVisualMode = this.switchEditorMode.bind( this, 'tinymce' );
 		this.switchEditorHtmlMode = this.switchEditorMode.bind( this, 'html' );
 		this.debouncedCopySelectedText = debounce( this.copySelectedText, 200 );
-		this.debouncedAutosaveFlushToRevision = debounce( this.autosaveFlushToRevision, 30000 );
+		this.debouncedAutosaveFlushToRevision = debounce( this.autosaveFlushToRevision, 10000, {
+			leading: true,
+		} );
 		this.useDefaultSidebarFocus();
 		analytics.mc.bumpStat( 'calypso_default_sidebar_mode', this.props.editorSidebarPreference );
 
@@ -149,7 +151,6 @@ export class PostEditor extends React.Component {
 		if ( nextState.isSaving && ! this.state.isSaving ) {
 			this.debouncedAutosave.cancel();
 			this.throttledAutosave.cancel();
-			this.debouncedAutosaveFlushToRevision.cancel();
 		}
 
 		if ( nextProps.isDirty ) {

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -774,3 +774,11 @@ export const autosave = () => async ( dispatch, getState ) => {
 
 	return await dispatch( saveEdited( { recordSaveEvent: false, autosave: true } ) );
 };
+
+export const saveRevision = ( siteId, post ) =>
+	savePost( siteId, null, {
+		...pick( post, [ 'content', 'excerpt', 'title' ] ),
+		status: 'inherit',
+		type: 'revision',
+		parent: post.ID,
+	} );

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -42,6 +42,7 @@ import {
 	POSTS_REQUEST_SUCCESS,
 	POSTS_REQUEST_FAILURE,
 } from 'state/action-types';
+import { POST_REVISION_FIELDS } from 'state/posts/constants';
 import { getSitePost, getEditedPost, getPostEdits, isEditedPostDirty } from 'state/posts/selectors';
 import { recordSaveEvent } from 'state/posts/stats';
 import {
@@ -783,7 +784,7 @@ export const autosave = () => async ( dispatch, getState ) => {
  */
 export const saveRevision = ( siteId, post ) =>
 	savePost( siteId, null, {
-		...pick( post, [ 'content', 'excerpt', 'title' ] ),
+		...pick( post, POST_REVISION_FIELDS ),
 		parent: post.ID,
 		status: 'inherit',
 		type: 'revision',

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -777,15 +777,21 @@ export const autosave = () => async ( dispatch, getState ) => {
 };
 
 /**
- * Save a revision of the passed-in post. Calls `savePost` which initiates a network call.
+ * Save a revision of the passed-in post. Calls `wpcom.post.add` which initiates a network call.
  * @param  {int} siteId		The site ID for use in the `savePost` call
  * @param  {object} post   post-like object with keys: 'ID', 'content', 'excerpt', 'title'
- * @returns {Promise} The return value from `savePost`
+ * @returns {Promise} The return value of `wpcom.post.add`
  */
-export const saveRevision = ( siteId, post ) =>
-	savePost( siteId, null, {
+export const saveRevision = ( siteId, post ) => {
+	const normalized = normalizePostForApi( {
 		...pick( post, POST_REVISION_FIELDS ),
 		parent: post.ID,
 		status: 'inherit',
 		type: 'revision',
 	} );
+
+	return wpcom
+		.site( siteId )
+		.post()
+		.add( { apiVersion: '1.2' }, normalized );
+};

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -775,10 +775,16 @@ export const autosave = () => async ( dispatch, getState ) => {
 	return await dispatch( saveEdited( { recordSaveEvent: false, autosave: true } ) );
 };
 
+/**
+ * Save a revision of the passed-in post. Calls `savePost` which initiates a network call.
+ * @param  {int} siteId		The site ID for use in the `savePost` call
+ * @param  {object} post   post-like object with keys: 'ID', 'content', 'excerpt', 'title'
+ * @returns {Promise} The return value from `savePost`
+ */
 export const saveRevision = ( siteId, post ) =>
 	savePost( siteId, null, {
 		...pick( post, [ 'content', 'excerpt', 'title' ] ),
+		parent: post.ID,
 		status: 'inherit',
 		type: 'revision',
-		parent: post.ID,
 	} );

--- a/client/state/posts/constants.js
+++ b/client/state/posts/constants.js
@@ -26,3 +26,5 @@ export const DEFAULT_NEW_POST_VALUES = {
 	format: 'default',
 	featured_image: '',
 };
+
+export const POST_REVISION_FIELDS = [ 'content', 'excerpt', 'title' ];


### PR DESCRIPTION
As of #19261, we are passing the `autosave` param to the API when the Editor saves its buffer. That param results in the `DOING_AUTOSAVE` constant getting set &, [consequently](https://core.trac.wordpress.org/browser/trunk/src/wp-includes/revision.php?rev=42343#L112), revisions are not saved for drafts unless the `Save` button is explicitly clicked.

This change conditionally initiates a separate request to save a revision for drafts when they're autosaved.

Fixes #20265 

Additionally, this stops showing the autosave `<RestorePostDialog />` when relevant fields are identical.

## To Test

* run this branch
* open / create a draft in the editor
* change some content & wait for the `Save` button to change to `Saved`
* a revision should be saved (The `History` button should appear when there are revisions & you should see a revision for your edits)