### PR TITLE
Activity Log: upgrade banner text for free WordPress.com sites

### DIFF
--- a/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
@@ -22,12 +22,14 @@ class UpgradeBanner extends Component {
 		return (
 			<div className="activity-log-banner__upgrade">
 				<Banner
-					callToAction={ translate( 'Upgrade' ) }
+					callToAction={ translate( 'More Details' ) }
 					dismissPreferenceName="activity-upgrade-banner-simple"
 					event="activity_log_upgrade_click_wpcom"
 					feature={ FEATURE_JETPACK_ESSENTIAL }
 					plan={ PLAN_PERSONAL }
-					title={ translate( 'Enhance your WP.com experience' ) }
+					title={ translate(
+						'Upgrade your site today to unlock many powerful features, including:'
+					) }
 					description={ translate(
 						'Improve your SEO, protect your site from spammers, ' +
 							'and keep a closer eye on your site with expanded activity logs.'


### PR DESCRIPTION
Based on a conversation with Don Lair ( p9rlnk-oR-p2 #comment-2501 )
we've decided to update the text on our banner.

Free WordPress.com sites will see:

<img width="1547" alt="screen shot 2018-07-26 at 5 28 44 pm" src="https://user-images.githubusercontent.com/2694219/43289865-45320cf2-90fa-11e8-9c5e-61076ae7fb98.png">

<img width="263" alt="screen shot 2018-07-26 at 5 29 02 pm" src="https://user-images.githubusercontent.com/2694219/43289871-49278756-90fa-11e8-8e6b-0df89471f21a.png">
