### PR TITLE
Components: create InlineSupportLink

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -170,6 +170,7 @@
 @import 'components/image/style';
 @import 'components/infinite-list/style';
 @import 'components/info-popover/style';
+@import 'components/inline-support-link/style';
 @import 'components/input-chrono/style';
 @import 'components/jetpack-colophon/style';
 @import 'components/jetpack-header/style';

--- a/client/components/inline-support-link/README.md
+++ b/client/components/inline-support-link/README.md
@@ -12,7 +12,7 @@ render() {
 	const inlineSupportProps = {
 		text: 'Learn more about Podcasting',
 		supportLink: 'https://en.support.wordpress.com/audio/podcasting/',
-		supportPostId: 'https://example.com/#privacy',
+		supportPostId: 38147,
 	};
 	return (
 		<InlineSupportLink { ...inlineSupportProps } />

--- a/client/components/inline-support-link/README.md
+++ b/client/components/inline-support-link/README.md
@@ -1,7 +1,7 @@
 Inline Support Link
 ===================
 
-This component displays a link and icon. When clicked, it opens a SupportArticleDialog with an ExternalLink to the article if supplied.
+This component displays a link and icon. If `props.supportPostId` is supplied, when the link is clicked a SupportArticleDialog is opened with an `ExternalLink` to the `props.supportLink`. If no `props.supportPostId` is supplied, an `ExternalLink` to the `props.supportLink` is rendered.
 
 ## Example Usage:
 
@@ -10,7 +10,6 @@ import InlineSupportLink from 'components/inline-support-link';
 
 render() {
 	const inlineSupportProps = {
-		text: 'Learn more about Podcasting',
 		supportLink: 'https://en.support.wordpress.com/audio/podcasting/',
 		supportPostId: 38147,
 	};
@@ -23,7 +22,7 @@ render() {
 ## Props
 
 - `supportPostId` - (number) The postId of the support document.
-- `supportLink` - *optional* (string) The URL of the support document. If left out, no ExternalLink will be given.
+- `supportLink` - (string) The URL of the support document. If left out, no ExternalLink will be given.
 - `text` - *optional* (string) The link text. Default `Learn more`
 - `showText` - *optional* (bool) Whether or not to display the link text. Default `true`.
 - `showIcon` - *optional* (bool) Whether or not to display the "help-outline" Gridicon. Default `true`.

--- a/client/components/inline-support-link/README.md
+++ b/client/components/inline-support-link/README.md
@@ -1,0 +1,30 @@
+Inline Support Link
+===================
+
+This component displays a link and icon. When clicked, it opens a SupportArticleDialog with an ExternalLink to the article if supplied.
+
+## Example Usage:
+
+```js
+import InlineSupportLink from 'components/inline-support-link';
+
+render() {
+	const inlineSupportProps = {
+		text: 'Learn more about Podcasting',
+		supportLink: 'https://en.support.wordpress.com/audio/podcasting/',
+		supportPostId: 'https://example.com/#privacy',
+	};
+	return (
+		<InlineSupportLink { ...inlineSupportProps } />
+	);
+}
+```
+
+## Props
+
+- `supportPostId` - (number) The postId of the support document.
+- `supportLink` - *optional* (string) The URL of the support document. If left out, no ExternalLink will be given.
+- `text` - *optional* (string) The link text. Default `Learn more`
+- `showText` - *optional* (bool) Whether or not to display the link text. Default `true`.
+- `showIcon` - *optional* (bool) Whether or not to display the "help-outline" Gridicon. Default `true`.
+- `iconSize` - *optional* (number) Gridicon size. Default `14`.

--- a/client/components/inline-support-link/docs/example.jsx
+++ b/client/components/inline-support-link/docs/example.jsx
@@ -1,0 +1,23 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import InlineSupportLink from 'components/inline-support-link';
+
+export default class extends React.PureComponent {
+	static displayName = 'InlineSupportLink';
+
+	render() {
+		const support = {
+			supportPostId: 38147,
+			supportLink: 'https://en.support.wordpress.com/audio/podcasting/',
+		};
+		return <InlineSupportLink { ...support } />;
+	}
+}

--- a/client/components/inline-support-link/docs/example.jsx
+++ b/client/components/inline-support-link/docs/example.jsx
@@ -14,10 +14,10 @@ export default class extends React.PureComponent {
 	static displayName = 'InlineSupportLink';
 
 	render() {
-		const support = {
+		const inlineSupportProps = {
 			supportPostId: 38147,
 			supportLink: 'https://en.support.wordpress.com/audio/podcasting/',
 		};
-		return <InlineSupportLink { ...support } />;
+		return <InlineSupportLink { ...inlineSupportProps } />;
 	}
 }

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -1,0 +1,76 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import { openSupportArticleDialog } from 'state/inline-support-article/actions';
+
+class InlineSupportLink extends Component {
+	static propTypes = {
+		supportPostId: PropTypes.number,
+		supportLink: PropTypes.string,
+		showText: PropTypes.bool,
+		text: PropTypes.string,
+		showIcon: PropTypes.bool,
+		iconSize: PropTypes.number,
+	};
+
+	static defaultProps = {
+		supportPostId: null,
+		supportLink: null,
+		showText: true,
+		text: null,
+		showIcon: true,
+		iconSize: 14,
+	};
+
+	handleOpenInline = event => {
+		const { supportPostId, supportLink } = this.props;
+
+		event.preventDefault();
+		this.props.openSupportArticleDialog( { postId: supportPostId, postUrl: supportLink } );
+	};
+
+	render() {
+		const {
+			showText,
+			text,
+			supportPostId,
+			supportLink,
+			showIcon,
+			iconSize,
+			translate,
+		} = this.props;
+
+		if ( ! supportPostId ) {
+			return null;
+		}
+
+		return (
+			<a
+				className="inline-support-link"
+				href={ supportLink }
+				onClick={ this.handleOpenInline }
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				{ showText && ( text || translate( 'Learn more' ) ) }
+				{ showIcon && <Gridicon icon="help-outline" size={ iconSize } /> }
+			</a>
+		);
+	}
+}
+
+export default connect(
+	null,
+	{ openSupportArticleDialog }
+)( localize( InlineSupportLink ) );

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -12,11 +12,12 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+import ExternalLink from 'components/external-link';
 import { openSupportArticleDialog } from 'state/inline-support-article/actions';
 
 class InlineSupportLink extends Component {
 	static propTypes = {
-		supportPostId: PropTypes.number.isRequired,
+		supportPostId: PropTypes.number,
 		supportLink: PropTypes.string,
 		showText: PropTypes.bool,
 		text: PropTypes.string,
@@ -36,6 +37,10 @@ class InlineSupportLink extends Component {
 	handleClick = event => {
 		const { supportPostId, supportLink } = this.props;
 
+		if ( ! supportPostId ) {
+			return null;
+		}
+
 		event.preventDefault();
 		this.props.openSupportArticleDialog( { postId: supportPostId, postUrl: supportLink } );
 	};
@@ -51,21 +56,28 @@ class InlineSupportLink extends Component {
 			translate,
 		} = this.props;
 
-		if ( ! supportPostId ) {
+		if ( ! supportPostId && ! supportLink ) {
 			return null;
 		}
 
+		const LinkComponent = supportPostId ? 'a' : ExternalLink;
+		const externalLinkProps = ! supportPostId && {
+			icon: showIcon,
+			iconSize,
+		};
+
 		return (
-			<a
+			<LinkComponent
 				className="inline-support-link"
 				href={ supportLink }
 				onClick={ this.handleClick }
 				target="_blank"
 				rel="noopener noreferrer"
+				{ ...externalLinkProps }
 			>
 				{ showText && ( text || translate( 'Learn more' ) ) }
-				{ showIcon && <Gridicon icon="help-outline" size={ iconSize } /> }
-			</a>
+				{ supportPostId && showIcon && <Gridicon icon="help-outline" size={ iconSize } /> }
+			</LinkComponent>
 		);
 	}
 }

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -16,7 +16,7 @@ import { openSupportArticleDialog } from 'state/inline-support-article/actions';
 
 class InlineSupportLink extends Component {
 	static propTypes = {
-		supportPostId: PropTypes.number,
+		supportPostId: PropTypes.number.isRequired,
 		supportLink: PropTypes.string,
 		showText: PropTypes.bool,
 		text: PropTypes.string,
@@ -33,7 +33,7 @@ class InlineSupportLink extends Component {
 		iconSize: 14,
 	};
 
-	handleOpenInline = event => {
+	handleClick = event => {
 		const { supportPostId, supportLink } = this.props;
 
 		event.preventDefault();
@@ -59,7 +59,7 @@ class InlineSupportLink extends Component {
 			<a
 				className="inline-support-link"
 				href={ supportLink }
-				onClick={ this.handleOpenInline }
+				onClick={ this.handleClick }
 				target="_blank"
 				rel="noopener noreferrer"
 			>

--- a/client/components/inline-support-link/style.scss
+++ b/client/components/inline-support-link/style.scss
@@ -1,0 +1,13 @@
+.inline-support-link {
+	.gridicons-help-outline {
+		color: currentColor;
+		margin-left: 3px;
+		margin-right: 0px;
+		top: 2px;
+		position: relative;
+	}
+
+	&:hover {
+		cursor: pointer;
+	}
+}

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -67,6 +67,7 @@ import HeaderButton from 'components/header-button/docs/example';
 import Headers from 'components/header-cake/docs/example';
 import ImagePreloader from 'components/image-preloader/docs/example';
 import InfoPopover from 'components/info-popover/docs/example';
+import InlineSupportLink from 'components/inline-support-link/docs/example';
 import InputChrono from 'components/input-chrono/docs/example';
 import JetpackColophonExample from 'components/jetpack-colophon/docs/example';
 import JetpackHeaderExample from 'components/jetpack-header/docs/example';
@@ -210,6 +211,7 @@ class DesignAssets extends React.Component {
 					<Headers readmeFilePath="header-cake" />
 					<ImagePreloader readmeFilePath="image-preloader" />
 					<InfoPopover readmeFilePath="info-popover" />
+					<InlineSupportLink readmeFilePath="inline-support-link" />
 					<InputChrono readmeFilePath="input-chrono" />
 					<JetpackColophonExample readmeFilePath="jetpack-colophon" />
 					<JetpackHeaderExample readmeFilePath="jetpack-header" />

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -33,6 +33,7 @@ import PodcastingPrivateSiteMessage from './private-site';
 import PodcastingNoPermissionsMessage from './no-permissions';
 import PodcastingNotSupportedMessage from './not-supported';
 import PodcastingPublishNotice from './publish-notice';
+import PodcastingSupportLink from './support-link';
 import podcastingTopics from './topics';
 
 /**
@@ -220,7 +221,10 @@ class PodcastingDetails extends Component {
 						backHref={ writingHref }
 						backText={ translate( 'Writing' ) }
 					>
-						<h1>{ translate( 'Podcasting Settings' ) }</h1>
+						<h1>
+							{ translate( 'Podcasting Settings' ) }
+							<PodcastingSupportLink showText={ false } iconSize={ 16 } />
+						</h1>
 					</HeaderCake>
 					{ ! error && (
 						<Card className="podcasting-details__category-wrapper">

--- a/client/my-sites/site-settings/podcasting-details/support-link.jsx
+++ b/client/my-sites/site-settings/podcasting-details/support-link.jsx
@@ -4,29 +4,25 @@
  * External dependencies
  */
 import React from 'react';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import ExternalLink from 'components/external-link';
+import InlineSupportLink from 'components/inline-support-link';
 import { getSupportSiteLocale } from 'lib/i18n-utils';
 
-function PodcastingSupportLink( { translate } ) {
+function PodcastingSupportLink() {
 	const supportLink =
 		'https://' + getSupportSiteLocale() + '.support.wordpress.com/audio/podcasting/';
+	const supportPostId = 38147;
 
 	return (
-		<ExternalLink
-			href={ supportLink }
-			target="_blank"
-			icon
-			iconSize={ 14 }
+		<InlineSupportLink
 			className="podcasting-details__support-link"
-		>
-			{ translate( 'Learn more' ) }
-		</ExternalLink>
+			supportPostId={ supportPostId }
+			supportLink={ supportLink }
+		/>
 	);
 }
 
-export default localize( PodcastingSupportLink );
+export default PodcastingSupportLink;

--- a/client/my-sites/site-settings/podcasting-details/support-link.jsx
+++ b/client/my-sites/site-settings/podcasting-details/support-link.jsx
@@ -11,7 +11,7 @@ import React from 'react';
 import InlineSupportLink from 'components/inline-support-link';
 import { getSupportSiteLocale } from 'lib/i18n-utils';
 
-function PodcastingSupportLink() {
+function PodcastingSupportLink( { showText, iconSize } ) {
 	const supportLink =
 		'https://' + getSupportSiteLocale() + '.support.wordpress.com/audio/podcasting/';
 	const supportPostId = 38147;
@@ -21,6 +21,8 @@ function PodcastingSupportLink() {
 			className="podcasting-details__support-link"
 			supportPostId={ supportPostId }
 			supportLink={ supportLink }
+			showText={ showText }
+			iconSize={ iconSize }
 		/>
 	);
 }


### PR DESCRIPTION
This creates a link that opens the `SupportArticleDialog` with the supplied support doc. It also replaces the "Learn More" `ExternalLink` usage in the Podcasting Settings screen.

![inline-support-link](https://user-images.githubusercontent.com/942359/43294975-0c07c9ec-9110-11e8-9f88-d46cfd012faf.gif)

**To test:**
- Visit Settings > Writing > Podcasting Settings
- Enable podcasting by selecting a category
- Under "RSS Feed", click "Learn More" or the "?" Gridicon in the header
- Verify that the `SupportArticleDialog` opens with the Podcasting documentation
- Clicking "Close" or anywhere outside of the dialog should close the dialog
- Clicking "Visit Article" should open the documentation in a new tab