### PR TITLE
SDK: Skip flag images copying without an environment variable

### DIFF
--- a/bin/create-scripts/block.js
+++ b/bin/create-scripts/block.js
@@ -5,6 +5,7 @@ const path = require( 'path' );
 const webpack = require( 'webpack' );
 
 const __rootDir = path.resolve( __dirname, '../../' );
+const CopyWebpackPlugin = require( path.resolve( __rootDir, 'server/bundler/copy-webpack-plugin' ) );
 const entryPath = path.resolve( __rootDir, process.argv[ 2 ] );
 const sourceDir = path.dirname( entryPath );
 const outputDir = process.argv[ 3 ] ? process.argv[ 3 ] : path.join( sourceDir, 'build' );
@@ -31,6 +32,9 @@ const config = {
 			libraryTarget: 'window',
 			library: `blocks-${ blockName }`,
 		},
+		plugins: [
+			...baseConfig.plugins.filter( plugin => ! ( plugin instanceof CopyWebpackPlugin ) ),
+		]
 	},
 };
 

--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -15,9 +15,6 @@ const buildBlock = argv => {
 	const editorScript = path.resolve( __dirname, '../', argv.editorScript );
 
 	spawnSync( 'node', [ compiler, editorScript, ( argv.outputDir || '' ) ], {
-		env: {
-			SKIP_FLAG_IMAGES: true,
-		},
 		shell: true,
 		stdio: 'inherit',
 	} );

--- a/server/bundler/copy-webpack-plugin.js
+++ b/server/bundler/copy-webpack-plugin.js
@@ -1,0 +1,13 @@
+const CopyWebpackPluginOriginal = require( 'copy-webpack-plugin' );
+
+class CopyWebpackPlugin {
+	constructor() {
+		this.plugin = new CopyWebpackPluginOriginal( ...arguments );
+	}
+
+	apply() {
+		this.plugin.apply( ...arguments );
+	}
+}
+
+module.exports = CopyWebpackPlugin;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@
  * External dependencies
  */
 const _ = require( 'lodash' );
-const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
+const CopyWebpackPlugin = require( './server/bundler/copy-webpack-plugin' );
 const fs = require( 'fs' );
 const path = require( 'path' );
 const webpack = require( 'webpack' );
@@ -36,7 +36,6 @@ const shouldMinify =
 	( process.env.MINIFY_JS !== 'false' && bundleEnv === 'production' );
 const shouldEmitStats = process.env.EMIT_STATS === 'true';
 const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
-const shouldSkipFlagImages = process.env.SKIP_FLAG_IMAGES === 'true';
 const codeSplit = config.isEnabled( 'code-splitting' );
 
 /**
@@ -209,10 +208,9 @@ const webpackConfig = {
 		} ),
 		new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),
 		new webpack.IgnorePlugin( /^props$/ ),
-		! shouldSkipFlagImages &&
-			new CopyWebpackPlugin( [
-				{ from: 'node_modules/flag-icon-css/flags/4x3', to: 'images/flags' },
-			] ),
+		new CopyWebpackPlugin( [
+			{ from: 'node_modules/flag-icon-css/flags/4x3', to: 'images/flags' },
+		] ),
 		new AssetsWriter( {
 			filename: 'assets.json',
 			path: path.join( __dirname, 'server', 'bundler' ),


### PR DESCRIPTION
This PR introduces a simple wrapper class around `CopyWebpackPlugin` to allow us to easily filter it out of any custom webpack configs (like the one we have for the SDK). It uses that to filter this plugin away from the list of plugins in the block build webpack config. Finally, it removes the environment variable `SKIP_FLAG_IMAGES` which is now unnecessary and cleans up prior logic related with it.

This is an alternative to #26260, but this time it doesn't require us to rely on an environment variable. It doesn't go very deep into the problem, but will do the job for now.

To test:
* Checkout this branch
* Build a block:`./bin/sdk-cli.js build-block --editor-script ./client/gutenberg/extensions/hello-dolly/hello-block.js`
* Verify flags are not built and not copied to the block build directory.
* Build Calypso and verify flags are copied properly by visiting a flag, like `/calypso/images/flags/bg.svg`.