### PR TITLE
[nudge-a-palooza] Redirect users who want to upload plugin or theme to a dedicated upsell landing page if they are in correct test group

### DIFF
--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -92,7 +92,7 @@ class PluginUpload extends React.Component {
 
 	goToUpsellPageIfRequired( props ) {
 		if ( this.shouldRedirectToUpsellPage( props ) ) {
-			page.redirect( `/feature/themes/${ props.siteSlug }` );
+			page.redirect( `/feature/plugins/${ props.siteSlug }` );
 		}
 	}
 

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -73,7 +73,7 @@ class ThemeShowcase extends React.Component {
 		secondaryOption: optionShape,
 		getScreenshotOption: PropTypes.func,
 		siteSlug: PropTypes.string,
-		upsellBanner: PropTypes.element,
+		upsellBanner: PropTypes.any,
 		trackATUploadClick: PropTypes.func,
 	};
 


### PR DESCRIPTION
Project nudge-a-palooza (p9jf6J-Hl-p2) introduces a few upsell landing pages. 

Test plan:
1. Assign yourself to `control` group of `nudgeAPalooza` A/B test
1. Go to themes and click on "Upload theme" button, you should see a regular nudge that links to `/plans` page
1. Go to plugins and click on "Upload theme" button, you should see a regular nudge that links to `/plans` page
1. Assign yourself to `customPluginAndThemeLandingPages` group of `nudgeAPalooza` A/B test
1. Go to themes and click on "Upload theme" button, you should see an upsell landing page that links directly to checkout
1. Go to plugins and click on "Upload theme" button, you should see an upsell landing page that links directly to checkout

Here's a screencast: https://cld.wthms.co/3NEJk1