### PR TITLE
Domain Management: Fix custom domain empty content image path

### DIFF
--- a/client/my-sites/domains/domain-management/email/index.jsx
+++ b/client/my-sites/domains/domain-management/email/index.jsx
@@ -121,7 +121,7 @@ class Email extends React.Component {
 			};
 		}
 		Object.assign( emptyContentProps, {
-			illustration: '/calypso/images/illustrations/customDomain.svg',
+			illustration: '/calypso/images/illustrations/custom-domain.svg',
 			action: translate( 'Add a Custom Domain' ),
 			actionURL: '/domains/add/' + this.props.selectedSite.slug,
 		} );


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/issues/26348

The path for the svg in the domain management empty component was incorrectly named `customDomain.svg`, when the file on disk is named `custom-domain.svg`. This change fixes that, though there is a possibility `customDomain.svg` is more in line with naming conventions in the codebase (both are used). For this fix I opted to change this specific reference instead of the image file since other places use the image.

Before:
<img width="1140" alt="screen shot 2018-07-27 at 9 32 54 am" src="https://user-images.githubusercontent.com/7132058/43327078-1b52b4fa-9180-11e8-834f-60c2ef1cbe55.png">

After:
<img width="1127" alt="screen shot 2018-07-27 at 9 33 30 am" src="https://user-images.githubusercontent.com/7132058/43327095-27ac149e-9180-11e8-9ed6-779b196b9743.png">
