### PR TITLE
Typography: Remove a hack for IE7 from long long ago

### DIFF
--- a/assets/stylesheets/shared/_reset.scss
+++ b/assets/stylesheets/shared/_reset.scss
@@ -17,7 +17,6 @@ table, caption, tbody, tfoot, thead, tr, th, td {
 	vertical-align: baseline;
 }
 html {
-	font-size: 62.5%; /* Corrects text resizing oddly in IE6/7 when body font-size is set using em units http://clagnut.com/blog/348/#c790 */
 	overflow-y: scroll; /* Keeps page centred in all browsers regardless of content height */
 	-webkit-text-size-adjust: 100%; /* Prevents iOS text size adjust after orientation change, without disabling user zoom */
 	-ms-text-size-adjust: 100%; /* www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/ */

--- a/assets/stylesheets/shared/_typography.scss
+++ b/assets/stylesheets/shared/_typography.scss
@@ -18,6 +18,21 @@ $sans-rtl: Tahoma, $sans;
 }
 
 
+// ======================================================================
+// Rem function
+//
+// Convert px to rem in a readable fashion.
+//
+// Example: font-size: rem( 21px );
+// ======================================================================
+
+$root-font-size: 16px;
+
+@function rem( $pixels, $context: $root-font-size ) {
+	@return $pixels / $context * 1rem;
+}
+
+
 // NOTE:
 // If there are exceptions to these stacks,
 // please mark them with a //typography-exception comment

--- a/assets/stylesheets/shared/mixins/_heading.scss
+++ b/assets/stylesheets/shared/mixins/_heading.scss
@@ -4,7 +4,7 @@
 
 @mixin heading {
 	color: $gray-darken-20;
-	font-size: 2rem;
+	font-size: rem( 20px );
 	font-weight: 300;
 	margin: 1em 0;
 }

--- a/client/components/readme-viewer/style.scss
+++ b/client/components/readme-viewer/style.scss
@@ -3,11 +3,11 @@
 	break-inside: avoid;
 
 	p, li {
-		font-size: 1.5rem;
+		font-size: rem( 15px );
 	}
 
 	p {
-		margin-bottom: 0.5rem;
+		margin-bottom: rem( 5px );
 	}
 
 	table {

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
@@ -129,7 +129,7 @@
 
 		.stats-widget__box-value {
 			color: $gray-darken-20;
-			font-size: 2rem;
+			font-size: rem( 20px );
 			font-weight: 400;
 		}
 

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-configured/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-configured/style.scss
@@ -23,12 +23,12 @@
 
 .credentials-configured__info-protocol {
 	font-weight: bold;
-	font-size: 1.5rem;
+	font-size: rem( 15px );
 }
 
 .credentials-configured__info-description {
 	color: $gray;
-	font-size: 1.3rem;
+	font-size: rem( 13px );
 }
 
 .credentials-configured__revoke-actions {
@@ -37,11 +37,11 @@
 
 .credentials-configured__revoke-icon {
 	color: $alert-red;
-	margin-right: .5rem;
+	margin-right: rem( 5px );
 }
 
 .credentials-configured__revoke-button.is-borderless {
-	margin-right: 2rem;
+	margin-right: rem( 20px );
 	position: relative;
 	top: -5px;
 

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/style.scss
@@ -16,11 +16,11 @@
 }
 
 .credentials-setup-flow__header-text-title {
-	font-size: 1.6rem;
+	font-size: rem( 16px );
 }
 
 .credentials-setup-flow__header-text-description {
-	font-size: 1.3rem;
+	font-size: rem( 13px );
 	font-style: italic;
 }
 

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -280,7 +280,7 @@
 
 	@include breakpoint( '<480px' ) {
 		display: block;
-		margin-top: 1.5rem;
+		margin-top: rem( 15px );
 	}
 }
 
@@ -294,7 +294,7 @@
 
 	@include breakpoint( '<480px' ) {
 		display: table;
-		margin-top: 1.5rem;
+		margin-top: rem( 15px );
 	}
 }
 

--- a/client/signup/steps/creds-complete/style.scss
+++ b/client/signup/steps/creds-complete/style.scss
@@ -1,16 +1,16 @@
 .creds-complete__card {
 	text-align: center;
 	max-width: 640px;
-	padding: 4rem;
+	padding: rem( 40px );
 	margin-top: 1px;
-	padding-bottom: 3rem;
+	padding-bottom: rem( 30px );
 }
 
 .creds-complete__title {
 	display: inline-block;
-	font-size: 2.5rem;
+	font-size: rem( 25px );
 	font-weight: 300;
-	letter-spacing: .15rem;
+	letter-spacing: rem( 1.5px );
 	color: $gray-text;
 }
 
@@ -22,7 +22,7 @@
 
 .creds-complete__description {
 	color: $gray-text-min;
-	font-size: 1.4rem;
+	font-size: rem( 14px );
 	font-weight: 100;
-	line-height: 2.5rem;
-} 
+	line-height: rem( 25px );
+}

--- a/client/signup/steps/creds-confirm/style.scss
+++ b/client/signup/steps/creds-confirm/style.scss
@@ -1,24 +1,24 @@
 .creds-confirm__card {
 	text-align: center;
 	max-width: 640px;
-	padding: 4rem;
+	padding: rem( 40px );
 	margin-top: 1px;
-	padding-bottom: 3rem;
+	padding-bottom: rem( 30px );
 }
 
 .creds-confirm__title {
 	display: inline-block;
-	font-size: 2.5rem;
+	font-size: rem( 25px );
 	font-weight: 300;
-	letter-spacing: .15rem;
+	letter-spacing: rem( 1.5px );
 	color: $gray-text;
 }
 
 .creds-confirm__description {
 	color: $gray-text-min;
-	font-size: 1.35rem;
+	font-size: rem( 13.5px );
 	font-weight: 100;
-	line-height: 2.5rem;
+	line-height: rem( 25px );
 }
 
 .creds-confirm__image {
@@ -28,5 +28,5 @@
 }
 
 .creds-confirm .button.is-primary {
-	margin-left: 1rem;
-} 
+	margin-left: rem( 10px );
+}

--- a/client/signup/steps/creds-permission/style.scss
+++ b/client/signup/steps/creds-permission/style.scss
@@ -1,24 +1,24 @@
 .creds-permission__card {
 	text-align: center;
 	max-width: 640px;
-	padding: 4rem;
+	padding: rem( 40px );
 	margin-top: 1px;
-	padding-bottom: 3rem;
+	padding-bottom: rem( 30px );
 }
 
 .creds-permission__title {
 	display: inline-block;
-	font-size: 2.5rem;
+	font-size: rem( 25px );
 	font-weight: 300;
-	letter-spacing: .15rem;
+	letter-spacing: rem( 1.5px );
 	color: $gray-text;
 }
 
 .creds-permission__description {
 	color: $gray-text-min;
-	font-size: 1.35rem;
+	font-size: rem( 13.5px );
 	font-weight: 100;
-	line-height: 2.5rem;
+	line-height: rem( 25px );
 }
 
 .creds-permission__image {

--- a/client/signup/steps/rewind-add-creds/style.scss
+++ b/client/signup/steps/rewind-add-creds/style.scss
@@ -2,6 +2,6 @@
 	img {
 		max-width: 200px;
 		display: block;
-		margin: 2rem auto;
+		margin: rem( 20px ) auto;
 	}
 }

--- a/client/signup/steps/rewind-form-creds/style.scss
+++ b/client/signup/steps/rewind-form-creds/style.scss
@@ -20,7 +20,7 @@
 	img {
 		max-width: 200px;
 		display: block;
-		margin: 2rem auto;
+		margin: rem( 20px ) auto;
 	}
 
 	.rewind-credentials-form {

--- a/client/signup/steps/rewind-migrate/style.scss
+++ b/client/signup/steps/rewind-migrate/style.scss
@@ -22,7 +22,7 @@
 	display: flex;
 	align-items: center;
 	flex-direction: column;
-	padding: 4rem 4rem 3rem;
+	padding: rem( 40px ) rem( 40px ) rem( 30px );
 	margin-top: 48px;
 
 	& + .step-wrapper__buttons .navigation-link {
@@ -35,18 +35,18 @@
 
 .rewind-switch__heading {
 	display: inline-block;
-	font-size: 2.5rem;
+	font-size: rem( 25px );
 	font-weight: 300;
-	letter-spacing: .15rem;
+	letter-spacing: rem( 1.5px );
 	color: $gray-dark;
 }
 
 .rewind-switch__description {
 	max-width: 600px;
 	color: $gray-text-min;
-	font-size: 1.35rem;
+	font-size: rem( 13.5px );
 	font-weight: 100;
-	line-height: 2.5rem;
+	line-height: rem( 25px );
 }
 
 .rewind-migrate__warning {

--- a/client/signup/steps/rewind-were-backing/style.scss
+++ b/client/signup/steps/rewind-were-backing/style.scss
@@ -2,6 +2,6 @@
 	img {
 		max-width: 200px;
 		display: block;
-		margin: 2rem auto;
+		margin: rem( 20px ) auto;
 	}
 }


### PR DESCRIPTION
This ends up interfering with components that set a font size in REMs, like the Google Material components. Removing it has ~no~ some impact on our work, and it removes a stumbling block to any future integrations of external components.

The interference manifests as tiny fonts, since the REM is now relative to the 62% set on html