### PR TITLE
Plans: Fix wrapping issue on wordpress pricing header

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -250,8 +250,7 @@ $plan-features-sidebar-width: 272px;
 	font-style: italic;
 	font-weight: 400;
 	color: $gray-text-min;
-	line-height: 0.6;
-	white-space: nowrap;
+	line-height: normal;
 
 	&.is-placeholder {
 		@include placeholder( 23% );


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/issues/26282

Current styles caused overflow on smaller displays or longer translations. This change supports wrapping of the text a bit better, though I had to adjust the line-height to make it look acceptable.

Before:
<img width="721" alt="screen shot 2018-07-27 at 10 18 18 am" src="https://user-images.githubusercontent.com/7132058/43329626-86e79ee6-9186-11e8-80bd-0d9d517dc49b.png">

After:
<img width="721" alt="screen shot 2018-07-27 at 10 18 26 am" src="https://user-images.githubusercontent.com/7132058/43329628-8bdb3bf6-9186-11e8-898c-43a9c9ddc1bf.png">
