### PR TITLE
Delay rendering for EditorConfirmationSidebar.

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/README.md
+++ b/client/post-editor/editor-confirmation-sidebar/README.md
@@ -1,0 +1,22 @@
+EditorConfirmationSidebar
+=========================
+
+This displays a sidebar that contains a confirmation dialog shown before
+publishing.
+
+It's mostly unremarkable, save for the fact that it's been optimized for
+performance by adding a deferred state.
+
+As the component starts up, if it is in a 'closed' status, it will not render.
+This provides a small performance improvement by avoiding the instantiation of
+the entire component rendering tree, as it's not yet needed.
+
+As soon as the status changes to something other than 'closed', the component
+renders, and from that moment on, any changes to status (e.g. closing again)
+will be applied via CSS, since the cost of rendering the sub-tree has already
+been paid.
+
+The following diagram helps to illustrate the flow:
+
+![component state diagram](https://user-images.githubusercontent.com/5431237/49047676-6ca56580-f195-11e8-88ea-9084eb454b53.png)
+

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -46,7 +46,19 @@ class EditorConfirmationSidebar extends Component {
 		status: PropTypes.string,
 	};
 
-	mountSidebar = false;
+	state = {
+		hasUnclosed: false,
+	};
+
+	static getDerivedStateFromProps( props ) {
+		// In order to improve performance, `hasUnclosed` determines whether the
+		// sidebar should be rendered or not. The content has to be rendered
+		// the first time the sidebar is not in a 'closed' status.
+		if ( props.status !== 'closed' ) {
+			return { hasUnclosed: true };
+		}
+		return null;
+	}
 
 	getCloseOverlayHandler = context => () => this.props.setStatus( { status: 'closed', context } );
 
@@ -151,10 +163,8 @@ class EditorConfirmationSidebar extends Component {
 		const isSidebarActive = this.props.status === 'open';
 		const isOverlayActive = this.props.status !== 'closed';
 
-		this.mountSidebar = this.mountSidebar || isOverlayActive;
-
 		return (
-			this.mountSidebar && (
+			this.state.hasUnclosed && (
 				<div
 					className={ classnames( {
 						'editor-confirmation-sidebar': true,

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -163,6 +163,14 @@ class EditorConfirmationSidebar extends Component {
 		const isSidebarActive = this.props.status === 'open';
 		const isOverlayActive = this.props.status !== 'closed';
 
+		if ( ! this.state.hasUnclosed ) {
+			return (
+				<div className="editor-confirmation-sidebar">
+					<div key="sidebar" className="editor-confirmation-sidebar__sidebar" />
+				</div>
+			);
+		}
+
 		return (
 			this.state.hasUnclosed && (
 				<div
@@ -174,6 +182,7 @@ class EditorConfirmationSidebar extends Component {
 					{ this.renderPublishingBusyButton() }
 
 					<div
+						key="sidebar"
 						className={ classnames( {
 							'editor-confirmation-sidebar__sidebar': true,
 							'is-active': isSidebarActive,

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -46,6 +46,8 @@ class EditorConfirmationSidebar extends Component {
 		status: PropTypes.string,
 	};
 
+	mountSidebar = false;
+
 	getCloseOverlayHandler = context => () => this.props.setStatus( { status: 'closed', context } );
 
 	closeAndPublish = () => {
@@ -149,46 +151,50 @@ class EditorConfirmationSidebar extends Component {
 		const isSidebarActive = this.props.status === 'open';
 		const isOverlayActive = this.props.status !== 'closed';
 
-		return (
-			<div
-				className={ classnames( {
-					'editor-confirmation-sidebar': true,
-					'is-active': isOverlayActive,
-				} ) }
-			>
-				{ this.renderPublishingBusyButton() }
+		this.mountSidebar = this.mountSidebar || isOverlayActive;
 
+		return (
+			this.mountSidebar && (
 				<div
 					className={ classnames( {
-						'editor-confirmation-sidebar__sidebar': true,
-						'is-active': isSidebarActive,
+						'editor-confirmation-sidebar': true,
+						'is-active': isOverlayActive,
 					} ) }
 				>
-					<div className="editor-confirmation-sidebar__ground-control">
-						<div className="editor-confirmation-sidebar__close">
-							<Button
-								borderless
-								onClick={ this.getCloseOverlayHandler( 'dismiss_x' ) }
-								title={ this.props.translate( 'Close sidebar' ) }
-								aria-label={ this.props.translate( 'Close sidebar' ) }
-							>
-								<Gridicon icon="cross" />
-							</Button>
+					{ this.renderPublishingBusyButton() }
+
+					<div
+						className={ classnames( {
+							'editor-confirmation-sidebar__sidebar': true,
+							'is-active': isSidebarActive,
+						} ) }
+					>
+						<div className="editor-confirmation-sidebar__ground-control">
+							<div className="editor-confirmation-sidebar__close">
+								<Button
+									borderless
+									onClick={ this.getCloseOverlayHandler( 'dismiss_x' ) }
+									title={ this.props.translate( 'Close sidebar' ) }
+									aria-label={ this.props.translate( 'Close sidebar' ) }
+								>
+									<Gridicon icon="cross" />
+								</Button>
+							</div>
+							<div className="editor-confirmation-sidebar__action">
+								{ this.renderPublishButton() }
+							</div>
 						</div>
-						<div className="editor-confirmation-sidebar__action">
-							{ this.renderPublishButton() }
+						<div className="editor-confirmation-sidebar__content-wrap">
+							<EditorConfirmationSidebarHeader post={ this.props.post } />
+							<EditorPublishDate post={ this.props.post } setPostDate={ this.props.setPostDate } />
+							<div className="editor-confirmation-sidebar__privacy-control">
+								{ this.renderPrivacyControl() }
+							</div>
 						</div>
+						{ this.renderNoticeDisplayPreferenceCheckbox() }
 					</div>
-					<div className="editor-confirmation-sidebar__content-wrap">
-						<EditorConfirmationSidebarHeader post={ this.props.post } />
-						<EditorPublishDate post={ this.props.post } setPostDate={ this.props.setPostDate } />
-						<div className="editor-confirmation-sidebar__privacy-control">
-							{ this.renderPrivacyControl() }
-						</div>
-					</div>
-					{ this.renderNoticeDisplayPreferenceCheckbox() }
 				</div>
-			</div>
+			)
 		);
 	}
 }

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -47,15 +47,15 @@ class EditorConfirmationSidebar extends Component {
 	};
 
 	state = {
-		hasUnclosed: false,
+		doFullRender: false,
 	};
 
-	static getDerivedStateFromProps( props ) {
-		// In order to improve performance, `hasUnclosed` determines whether the
+	static getDerivedStateFromProps( props, state ) {
+		// In order to improve performance, `doFullRender` determines whether the
 		// sidebar should be rendered or not. The content has to be rendered
 		// the first time the sidebar is not in a 'closed' status.
-		if ( props.status !== 'closed' ) {
-			return { hasUnclosed: true };
+		if ( ! state.doFullRender && props.status !== 'closed' ) {
+			return { doFullRender: true };
 		}
 		return null;
 	}
@@ -163,7 +163,7 @@ class EditorConfirmationSidebar extends Component {
 		const isSidebarActive = this.props.status === 'open';
 		const isOverlayActive = this.props.status !== 'closed';
 
-		if ( ! this.state.hasUnclosed ) {
+		if ( ! this.state.doFullRender ) {
 			return (
 				<div className="editor-confirmation-sidebar">
 					<div key="sidebar" className="editor-confirmation-sidebar__sidebar" />
@@ -172,48 +172,44 @@ class EditorConfirmationSidebar extends Component {
 		}
 
 		return (
-			this.state.hasUnclosed && (
+			<div
+				className={ classnames( 'editor-confirmation-sidebar', {
+					'is-active': isOverlayActive,
+				} ) }
+			>
+				{ this.renderPublishingBusyButton() }
+
 				<div
-					className={ classnames( {
-						'editor-confirmation-sidebar': true,
-						'is-active': isOverlayActive,
+					key="sidebar"
+					className={ classnames( 'editor-confirmation-sidebar__sidebar', {
+						'is-active': isSidebarActive,
 					} ) }
 				>
-					{ this.renderPublishingBusyButton() }
-
-					<div
-						key="sidebar"
-						className={ classnames( {
-							'editor-confirmation-sidebar__sidebar': true,
-							'is-active': isSidebarActive,
-						} ) }
-					>
-						<div className="editor-confirmation-sidebar__ground-control">
-							<div className="editor-confirmation-sidebar__close">
-								<Button
-									borderless
-									onClick={ this.getCloseOverlayHandler( 'dismiss_x' ) }
-									title={ this.props.translate( 'Close sidebar' ) }
-									aria-label={ this.props.translate( 'Close sidebar' ) }
-								>
-									<Gridicon icon="cross" />
-								</Button>
-							</div>
-							<div className="editor-confirmation-sidebar__action">
-								{ this.renderPublishButton() }
-							</div>
+					<div className="editor-confirmation-sidebar__ground-control">
+						<div className="editor-confirmation-sidebar__close">
+							<Button
+								borderless
+								onClick={ this.getCloseOverlayHandler( 'dismiss_x' ) }
+								title={ this.props.translate( 'Close sidebar' ) }
+								aria-label={ this.props.translate( 'Close sidebar' ) }
+							>
+								<Gridicon icon="cross" />
+							</Button>
 						</div>
-						<div className="editor-confirmation-sidebar__content-wrap">
-							<EditorConfirmationSidebarHeader post={ this.props.post } />
-							<EditorPublishDate post={ this.props.post } setPostDate={ this.props.setPostDate } />
-							<div className="editor-confirmation-sidebar__privacy-control">
-								{ this.renderPrivacyControl() }
-							</div>
+						<div className="editor-confirmation-sidebar__action">
+							{ this.renderPublishButton() }
 						</div>
-						{ this.renderNoticeDisplayPreferenceCheckbox() }
 					</div>
+					<div className="editor-confirmation-sidebar__content-wrap">
+						<EditorConfirmationSidebarHeader post={ this.props.post } />
+						<EditorPublishDate post={ this.props.post } setPostDate={ this.props.setPostDate } />
+						<div className="editor-confirmation-sidebar__privacy-control">
+							{ this.renderPrivacyControl() }
+						</div>
+					</div>
+					{ this.renderNoticeDisplayPreferenceCheckbox() }
 				</div>
-			)
+			</div>
 		);
 	}
 }


### PR DESCRIPTION
Another quick win for making the post editor slightly faster.
Improvements are modest (10-15%), but this is such a simple change that it seems like a no-brainer.

*Note:* due to `prettier`, it looks like the changes to this PR were larger than what's actually the case. Only lines 44, 149 and 152 in the "after" pane have non-styling changes.