### PR TITLE
Site Indicator: Update to direct users to the activity log 

### DIFF
--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -89,19 +89,16 @@ class SiteIndicator extends Component {
 
 	updatesAvailable() {
 		const { site, siteUpdates, translate } = this.props;
-		if ( siteUpdates.wordpress && siteUpdates.wp_update_version ) {
+		const activityLogPath = '/stats/activity/' + site.slug;
+
+		if ( siteUpdates.wordpress === siteUpdates.total && site.canUpdateFiles ) {
 			return (
 				<span>
 					{ translate(
 						'A newer version of WordPress is available. {{link}}Update to %(version)s{{/link}}',
 						{
 							components: {
-								link: (
-									<WPAdminLink
-										onClick={ this.handleCoreUpdate }
-										href={ site.options.admin_url + 'update-core.php' }
-									/>
-								),
+								link: <a href={ activityLogPath } onClick={ this.handleCoreUpdate } />,
 							},
 							args: {
 								version: siteUpdates.wp_update_version,
@@ -128,6 +125,35 @@ class SiteIndicator extends Component {
 			);
 		}
 
+		if ( siteUpdates.themes === siteUpdates.total && site.canUpdateFiles ) {
+			return (
+				<span>
+					<a onClick={ this.handleThemesUpdate } href={ activityLogPath }>
+						{ translate(
+							'There is a theme update available.',
+							'There are theme updates available.',
+							{
+								count: siteUpdates.total,
+							}
+						) }
+					</a>
+				</span>
+			);
+		}
+		// Everything else expect for translations since they are not supported
+		if (
+			siteUpdates.themes + siteUpdates.plugins + siteUpdates.wordpress === siteUpdates.total &&
+			site.canUpdateFiles
+		) {
+			return (
+				<span>
+					<a onClick={ this.handleMultipleUpdate } href={ activityLogPath }>
+						{ translate( 'There are updates available.' ) }
+					</a>
+				</span>
+			);
+		}
+
 		return (
 			<span>
 				<WPAdminLink
@@ -142,22 +168,37 @@ class SiteIndicator extends Component {
 		);
 	}
 
-	handlePluginsUpdate = () => {
-		const { siteUpdates } = this.props;
+	recordEvent( event, total ) {
 		window.scrollTo( 0, 0 );
 		this.setState( { expand: false } );
-		this.props.recordGoogleEvent(
-			'Site-Indicator',
+		this.props.recordGoogleEvent( 'Site-Indicator', event, 'Total Updates', total );
+	}
+
+	handlePluginsUpdate = () => {
+		const { siteUpdates } = this.props;
+		this.recordEvent(
 			'Clicked updates available link to plugins updates',
-			'Total Updates',
+			siteUpdates && siteUpdates.total
+		);
+	};
+
+	handleThemesUpdate = () => {
+		const { siteUpdates } = this.props;
+		this.recordEvent(
+			'Clicked updates available link to theme updates',
 			siteUpdates && siteUpdates.total
 		);
 	};
 
 	handleCoreUpdate = () => {
-		this.props.recordGoogleEvent(
-			'Site-Indicator',
-			'Triggered Update WordPress Core Version From Calypso'
+		this.recordEvent( 'Clicked updates available link to WordPress updates', 1 );
+	};
+
+	handleMultipleUpdate = () => {
+		const { siteUpdates } = this.props;
+		this.recordEvent(
+			'Clicked updates available link for multiple updates',
+			siteUpdates && siteUpdates.total
 		);
 	};
 


### PR DESCRIPTION
Fixes #26123 
If a user has any updated they shouldn't have to leave calypso do deal with them. 

They should be taken care of in the activity log. 
This PR depending on what kind of update that you have should 
direct you to the activity log.

Currently the activity log can update .org themes, plugins and wordpress core. 
But it doesn't have a way to update translation files and .com themes. 

So right now the indicator that displays that an update is pending 100% accurate. 

We need to update the API to produce results that we are expecting.  

### To test

- try clicking the site indicator to display and see if it takes you to the activity log as expected? 
- If you only have plugins it will take you to the plugins section.
- If you have themes, core or plugins () it should take you to the activity log section.
- If you have theme translations it should take you to the wp-admin since that is the only place right now where a user can go and update them.

You can trigger an theme update by changing the version in style.css file
you can trigger a plugin update by changing the version number in the main plugin file. 
You can trigger a core update by changing the wp-includes/version.php file in your updates. 

Note that the site indicator doesn't show and updates for atomic sites.