### PR TITLE
Signup: Reduce redundancy in the heading and subhead copy on Domains

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -376,10 +376,7 @@ class DomainsStep extends React.Component {
 		const { translate } = this.props;
 		return 'transfer' === this.props.stepSectionName || 'mapping' === this.props.stepSectionName
 			? translate( 'Use a domain you already own with your new WordPress.com site.' )
-			: translate(
-					"Enter your site's name, or some keywords that describe it - " +
-						"we'll use this to create your new site's address."
-			  );
+			: translate( "Enter your site's name or some keywords that describe it to get started." );
 	}
 
 	renderContent() {
@@ -430,7 +427,7 @@ class DomainsStep extends React.Component {
 				backUrl={ backUrl }
 				positionInFlow={ this.props.positionInFlow }
 				signupProgress={ this.props.signupProgress }
-				fallbackHeaderText={ translate( "Let's give your site an address." ) }
+				fallbackHeaderText={ translate( 'Give your site an address.' ) }
 				fallbackSubHeaderText={ fallbackSubHeaderText }
 				stepContent={
 					<ReactCSSTransitionGroup


### PR DESCRIPTION
*  Previous screen at /about also uses "Let's", so removing that from this heading
* "site address" was mentioned in both heading and subheading, so I've reworded the subheading

Thoughts on the new copy welcome!

**Before this PR**

<img width="986" alt="screen shot 2018-07-27 at 4 13 25 pm" src="https://user-images.githubusercontent.com/2124984/43344545-1f037b2e-91b8-11e8-8d17-b29c0b9d8e56.png">

**After this PR**

<img width="995" alt="screen shot 2018-07-27 at 4 13 43 pm" src="https://user-images.githubusercontent.com/2124984/43344552-220953ca-91b8-11e8-9363-d55fc6ad8b66.png">