### PR TITLE
Remove the (deprecated) jsx-a11y/label-has-for rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,9 @@ module.exports = {
 		// TODO: why did we turn this off?
 		'jest/valid-expect': 0,
 
+		// Deprecated rule, fails in some valid cases with custom input components
+		'jsx-a11y/label-has-for': 0,
+
 		// i18n-calypso translate triggers false failures
 		'jsx-a11y/anchor-has-content': 0,
 

--- a/client/components/bulk-select/index.jsx
+++ b/client/components/bulk-select/index.jsx
@@ -53,8 +53,6 @@ export class BulkSelect extends React.Component {
 
 		return (
 			<span className="bulk-select">
-				{ /* The label + input have an implicit relationship since the input is a direct child of the label. */ }
-				{ /* eslint-disable jsx-a11y/label-has-for */ }
 				<label className="bulk-select__container">
 					<input
 						type="checkbox"
@@ -66,7 +64,6 @@ export class BulkSelect extends React.Component {
 					<Count count={ this.props.selectedElements } />
 					{ this.getStateIcon() }
 				</label>
-				{ /* eslint-enable jsx-a11y/label-has-for */ }
 			</span>
 		);
 	}

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -88,8 +88,6 @@ export class EditPostStatus extends Component {
 		const showPending = post && ! isPublished && ! isScheduled && canUserPublishPosts;
 		const showRevertToDraft = isPublished || isScheduled || ( isPending && ! canUserPublishPosts );
 
-		/* TODO: fix the label a11y and enable the ESLint rule again */
-		/* eslint-disable jsx-a11y/label-has-for */
 		return (
 			<div className="edit-post-status">
 				{ this.renderPostScheduling() }
@@ -135,7 +133,6 @@ export class EditPostStatus extends Component {
 				) }
 			</div>
 		);
-		/* eslint-enable jsx-a11y/label-has-for */
 	}
 
 	renderPostScheduling() {


### PR DESCRIPTION
I think the `jsx-a11y/label-has-for` rule is doing more harm than good. I found myself writing this code and it failed:
```js
<label htmlFor="some_id">
    <Checkbox id="some_id" onChange={ ... } />
    <span>Would you like to reticulate your splines?</span>
</label>
```
It fails because it expects a nested `<input>` element inside the `<label>`, and it isn't finding one. This code works:
```js
<label htmlFor="some_id">
    <input type="checkbox" id="some_id" onChange={ ... } />
    <span>Would you like to reticulate your splines?</span>
</label>
```
This code works too, because the rule is only looking for `<label>`:
```js
<FormLabel>
    BOGUS!
</FormLabel>
```

So, this rule fails in some correct cases and lets obviously incorrect code pass. I'd say we are better off without it.

Furthermore, the `jsx-a11y/label-has-for` rule is [officially deprecated](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md) since `6.1.0`. Curiously, it's still included in the `recommended` preset.

It's deprecated in favour of the [`label-has-associated-control` rule](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-associated-control.md), also enabled by default. That rule allows to define custom label components (in our case, `FormLabel`), and custom control components (in our case, `Checkbox`, for example). The only problem I see is that the rule is too lenient, so this passes:
```js
<label>
    <input type="text"/>
</label>
```

At the very least, we should remove the `jsx-a11y/label-has-for` rule, since it's not working correctly and it's deprecated. Do you also think we should try to make the `label-has-associated-control` rule more strict?