### PR TITLE
Disable the international labels feature if the plugin isn't at least a specified version

### DIFF
--- a/client/extensions/woocommerce/app/order/order-fulfillment/index.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/index.js
@@ -41,14 +41,13 @@ import FormInputCheckbox from 'components/forms/form-checkbox';
 import FormTextInput from 'components/forms/form-text-input';
 import { isOrderFinished } from 'woocommerce/lib/order-status';
 import { isOrderUpdating } from 'woocommerce/state/sites/orders/selectors';
-import { isWcsEnabled } from 'woocommerce/state/selectors/plugins';
+import { isWcsEnabled, isWcsInternationalLabelsEnabled } from 'woocommerce/state/selectors/plugins';
 import LabelPurchaseDialog from 'woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal';
 import Notice from 'components/notice';
 import { openPrintingFlow } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
 import QueryLabels from 'woocommerce/woocommerce-services/components/query-labels';
 import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
 import { saveOrder } from 'woocommerce/state/sites/orders/actions';
-import { isEnabled } from 'config';
 
 class OrderFulfillment extends Component {
 	static propTypes = {
@@ -147,7 +146,7 @@ class OrderFulfillment extends Component {
 	};
 
 	isAddressValidForLabels( address, type ) {
-		if ( isEnabled( 'woocommerce/extension-wcservices/international-labels' ) ) {
+		if ( this.props.internationalLabelsEnabled ) {
 			// If international labels is enabled, origin must be a country with a USPS office, destination can be anywhere in the world
 			return 'destination' === type || includes( ACCEPTED_USPS_ORIGIN_COUNTRIES, address.country );
 		}
@@ -307,6 +306,7 @@ export default connect(
 
 		return {
 			wcsEnabled,
+			internationalLabelsEnabled: isWcsInternationalLabelsEnabled( state, site.ID ),
 			isSaving,
 			labelsLoaded,
 			labelsError: isLabelDataFetchError( state, order.id, site.ID ),

--- a/client/extensions/woocommerce/state/selectors/plugins.js
+++ b/client/extensions/woocommerce/state/selectors/plugins.js
@@ -7,19 +7,19 @@ import { every, find } from 'lodash';
  * Internal dependencies
  */
 import config from 'config';
-import { getPlugins, isRequestingForSites } from 'state/plugins/installed/selectors';
+import {
+	getPlugins,
+	isRequestingForSites,
+	getPluginOnSite,
+} from 'state/plugins/installed/selectors';
 import { getRequiredPluginsForCalypso } from 'woocommerce/lib/get-required-plugins';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import createSelector from 'lib/create-selector';
 
 const getWcsPluginData = createSelector(
 	( state, siteId ) => {
-		const siteIds = [ siteId ];
-		if ( isRequestingForSites( state, siteIds ) ) {
-			return null;
-		}
-
-		return find( getPlugins( state, siteIds, 'active' ), { slug: 'woocommerce-services' } );
+		const pluginData = getPluginOnSite( state, siteId, 'woocommerce-services' );
+		return pluginData && pluginData.sites[ siteId ].active ? pluginData : null;
 	},
 	( state, siteId ) => [ state.plugins.installed.plugins[ siteId ] ]
 );

--- a/client/extensions/woocommerce/state/selectors/test/plugins.js
+++ b/client/extensions/woocommerce/state/selectors/test/plugins.js
@@ -52,8 +52,8 @@ describe( 'plugins', () => {
 			configStub.restore();
 		} );
 
-		it( 'should be null if the plugin list is being requested', () => {
-			expect( isWcsEnabled( state, 4 ) ).to.be.null;
+		it( 'should be false if the plugin list is being requested', () => {
+			expect( isWcsEnabled( state, 4 ) ).to.be.false;
 		} );
 
 		it( 'should be false if the plugin is not installed', () => {

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -38,7 +38,6 @@ import {
 	isLoaded as arePackagesLoaded,
 	isFetchError as arePackagesErrored,
 } from 'woocommerce/woocommerce-services/state/packages/selectors';
-import { isEnabled } from 'config';
 import getAddressValues from 'woocommerce/woocommerce-services/lib/utils/get-address-values';
 import {
 	ACCEPTED_USPS_ORIGIN_COUNTRIES,
@@ -54,6 +53,7 @@ import {
 	getStates,
 	hasStates,
 } from 'woocommerce/state/sites/data/locations/selectors';
+import { isWcsInternationalLabelsEnabled } from 'woocommerce/state/selectors/plugins';
 
 export const getShippingLabel = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
 	return get(
@@ -564,7 +564,7 @@ export const getAllCountryNames = createSelector(
 export const getOriginCountryNames = createSelector(
 	( state, siteId = getSelectedSiteId( state ) ) => {
 		const allNames = getAllCountryNames( state, siteId );
-		return isEnabled( 'woocommerce/extension-wcservices/international-labels' )
+		return isWcsInternationalLabelsEnabled( state, siteId )
 			? pick( allNames, ACCEPTED_USPS_ORIGIN_COUNTRIES )
 			: pick( allNames, DOMESTIC_US_TERRITORIES );
 	},
@@ -579,7 +579,7 @@ export const getOriginCountryNames = createSelector(
 export const getDestinationCountryNames = createSelector(
 	( state, siteId = getSelectedSiteId( state ) ) => {
 		const allNames = getAllCountryNames( state, siteId );
-		return isEnabled( 'woocommerce/extension-wcservices/international-labels' )
+		return isWcsInternationalLabelsEnabled( state, siteId )
 			? allNames
 			: pick( allNames, DOMESTIC_US_TERRITORIES );
 	},
@@ -603,10 +603,7 @@ export const getStateNames = createSelector(
 		const names = {};
 		states.forEach( ( { code, name } ) => ( names[ code ] = name ) );
 
-		if (
-			'US' === countryCode &&
-			! isEnabled( 'woocommerce/extension-wcservices/international-labels' )
-		) {
+		if ( 'US' === countryCode && ! isWcsInternationalLabelsEnabled( state, siteId ) ) {
 			// Filter out military addresses
 			return omit( names, US_MILITARY_STATES );
 		}


### PR DESCRIPTION
The international shipping labels feature has substantial changes in the PHP plugin side, so we've decided to disable it entirely in Calypso if the plugin doesn't have the required changes.

There are 2 ways of doing this:
* The same way we've been dealing with backwards-compatibility up to now: Check an endpoint response for a particular flag / property. If it has it, then we can be sure that the plugin has the most up-to-date code. If it doesn't, it means the plugin code is from before that flag/property was introduced. This approach is favored by (at least) @marcinbot because it makes it easier to test locally.
* Enable/disable the feature by plugin version. This has the downside of having to manually edit the `Version` header comment of the plugin to test this feature before a compatible version of the plugin is released.

I took the "disable by version" approach because it's simpler and faster. If the plugin is less than `1.16.0`, we don't even need to fetch anything from the REST API, we can just disable the feature.

Are you folks OK with this approach? Honestly, I had this code sitting in my computer and I don't want to try the other approach without at least checking if this one is good enough.

What could we do to make this easier to live with? Maybe ignore the version check in `development`? Or bump the plugin version to `1.16.0` in the plugin's `add/intl-labels` branch? I think this approach would make life easier for us in the future because we could just gate features to newer versions of the plugin, without bending ourselves backwards to handle backwards-compatibility.

To test:
* Go to an international order (origin in the US, destination outside the US).
* Check that the `Print label` flow isn't available, instead the simple `Fulfill` action button is displayed.
* Go to your site, change the version in the header of the `woocommerce-services/woocommerce-services.php` file to `1.16.0` (or bigger).
* Refresh the Calypso page.
* Check that you can print a label now.