### PR TITLE
Reader intro banners: use button element

### DIFF
--- a/client/reader/conversations/intro.jsx
+++ b/client/reader/conversations/intro.jsx
@@ -93,10 +93,9 @@ class ConversationsIntro extends React.Component {
 					</div>
 					<div className="conversations__intro-character" />
 
-					<div
+					<button
 						className="conversations__intro-close"
 						onClick={ this.dismiss }
-						role="button"
 						title={ translate( 'Close' ) }
 						aria-label={ translate( 'Close' ) }
 					>
@@ -105,7 +104,7 @@ class ConversationsIntro extends React.Component {
 							className="conversations__intro-close-icon"
 							title={ translate( 'Close' ) }
 						/>
-					</div>
+					</button>
 				</div>
 			</header>
 		);

--- a/client/reader/conversations/style.scss
+++ b/client/reader/conversations/style.scss
@@ -5,11 +5,11 @@
 	display: flex;
 	min-height: 140px;
 
-	@media ( min-width: 661px ) and ( max-width: 773px ) {
+	@media (min-width: 661px) and (max-width: 773px) {
 		background-position: 150px 20px;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		background-position: 120px 20px;
 	}
 
@@ -19,17 +19,19 @@
 	}
 
 	.conversations__intro-character {
-		background: url( '/calypso/images/reader/reader-conversations-characters.svg' ) no-repeat 8px bottom;
+		background: url( '/calypso/images/reader/reader-conversations-characters.svg' ) no-repeat 8px
+			bottom;
 		background-size: 97%;
 		flex: 0 0 245px;
 		min-height: 140px;
+		margin-right: -8px; // prevent right crop of illustration
 
 		// Hides the character when main content column gets too narrow
-		@media ( min-width: 661px ) and ( max-width: 840px ) {
+		@media (min-width: 661px) and (max-width: 840px) {
 			display: none;
 		}
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			display: none;
 		}
 	}
@@ -46,7 +48,7 @@
 	}
 
 	.conversations__intro-copy-hidden {
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			display: none;
 			visibility: hidden;
 		}
@@ -56,8 +58,8 @@
 // Dismiss button
 .conversations__intro .conversations__intro-close {
 	align-items: flex-start;
-	margin-top: 8px;
-	margin-right: 8px;
+	margin-top: -4px;
+	margin-right: 16px;
 	height: 24px;
 	width: 24px;
 

--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -66,11 +66,10 @@ class FollowingIntro extends React.Component {
 					</div>
 					<div className="following__intro-character" />
 
-					<div
+					<button
 						className="following__intro-close"
 						onClick={ dismiss }
 						title={ translate( 'Close' ) }
-						role="button"
 						aria-label={ translate( 'Close' ) }
 					>
 						<Gridicon
@@ -79,7 +78,7 @@ class FollowingIntro extends React.Component {
 							title={ translate( 'Close' ) }
 						/>
 						<span className="following__intro-close-icon-bg" />
-					</div>
+					</button>
 				</div>
 			</header>
 		);

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -36,17 +36,16 @@
 	background-size: 450px;
 	min-height: 140px;
 
-	@media ( min-width: 661px ) and ( max-width: 773px ) {
+	@media (min-width: 661px) and (max-width: 773px) {
 		background-position: 150px 20px;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		background-position: 120px 20px;
 	}
 
 	.following__intro-copy-hidden {
-
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			display: none;
 			visibility: hidden;
 		}
@@ -54,15 +53,16 @@
 
 	.following__intro-character {
 		background-size: 106px;
-		flex: 0 0 120px;
+		flex: 0 0 110px;
 		min-height: 140px;
+		margin-right: -2px; // prevent right cropping of illustration
 
 		// Hides the character when main content column gets too narrow
-		@media ( min-width: 661px ) and ( max-width: 773px ) {
+		@media (min-width: 661px) and (max-width: 773px) {
 			display: none;
 		}
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			background-size: 106px;
 		}
 	}
@@ -82,20 +82,20 @@
 	justify-content: center;
 	margin-left: 24px;
 
-	@media ( min-width: 661px ) and ( max-width: 773px ) {
+	@media (min-width: 661px) and (max-width: 773px) {
 		margin-bottom: 20px;
 		margin-top: 20px;
 	}
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		font-size: 16px;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		font-size: 18px;
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		font-size: 16px;
 	}
 }
@@ -103,7 +103,7 @@
 .following__search {
 	margin-top: 8px;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		margin-top: 30px;
 	}
 }
@@ -111,8 +111,8 @@
 // Dismiss button
 .following__intro .following__intro-close {
 	align-items: flex-start;
-	margin-top: 8px;
-	margin-right: 8px;
+	margin-top: -4px;
+	margin-right: 20px;
 	height: 24px;
 	width: 24px;
 
@@ -142,15 +142,14 @@
 		display: block;
 		height: 20px;
 		position: absolute;
-			left: 2px;
-			top: 2px;
+		left: 2px;
+		top: 2px;
 		z-index: z-index( 'root', '.following__intro-close-icon-bg' );
 		width: 20px;
 	}
 }
 
 .following__intro .following__intro-close {
-
 	.following__intro-close-icon {
 		fill: $gray-lighten-10;
 	}


### PR DESCRIPTION
This PR swaps `<div>`s for `<button>`s on the Reader intro banners.

Addresses the following a11y lint failures:

```
96:6  error  Visible, non-interactive elements with click handlers must have at least one keyboard listener                                                                                          jsx-a11y/click-events-have-key-events
96:6  error  Elements with the 'button' interactive role must be tabbable                                                                                          jsx-a11y/interactive-supports-focus
```

From `npx eslint client/reader/* --ext js,jsx`

### To test

Using a brand-new account, load http://calypso.localhost:3000/read/conversations and http://calypso.localhost:3000/. Make sure the close buttons on both intro banners look correct and function as expected.

Following intro (http://calypso.localhost:3000/):

<img width="849" alt="screen shot 2018-07-30 at 14 38 16" src="https://user-images.githubusercontent.com/17325/43374939-48e23098-9406-11e8-88e2-5627bc8c1d29.png">

Conversations intro (http://calypso.localhost:3000/read/conversations):

<img width="820" alt="screen shot 2018-07-30 at 15 15 33" src="https://user-images.githubusercontent.com/17325/43375813-72e202b0-940b-11e8-873c-0a4d58e1cef2.png">
