### PR TITLE
Disable the Ability to Share via Editor to a Facebook Profile

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -129,7 +129,9 @@ class PostShare extends Component {
 	}
 
 	isConnectionActive = connection =>
-		connection.status !== 'broken' && this.skipConnection( connection );
+		connection.status !== 'broken' &&
+		connection.status !== 'invalid' &&
+		this.skipConnection( connection );
 
 	activeConnections() {
 		return this.props.connections.filter( this.isConnectionActive );
@@ -346,8 +348,9 @@ class PostShare extends Component {
 		}
 
 		const brokenConnections = connections.filter( connection => connection.status === 'broken' );
+		const invalidConnections = connections.filter( connection => connection.status === 'invalid' );
 
-		if ( ! brokenConnections.length ) {
+		if ( ! ( brokenConnections.length || invalidConnections.length ) ) {
 			return null;
 		}
 
@@ -362,6 +365,32 @@ class PostShare extends Component {
 					>
 						<NoticeAction href={ `/sharing/${ siteSlug }` }>
 							{ translate( 'Reconnect' ) }
+						</NoticeAction>
+					</Notice>
+				) ) }
+				{ invalidConnections.map( connection => (
+					<Notice
+						key={ connection.keyring_connection_ID }
+						status="is-error"
+						showDismiss={ false }
+						text={
+							connection.service === 'facebook'
+								? translate( 'Connections to Facebook profiles ceased to work on August 1st.' )
+								: translate( 'Connections to %s have a permenant issue which prevents sharing.', {
+										args: connection.label,
+								  } )
+						}
+					>
+						{ connection.service === 'facebook' && (
+							<NoticeAction
+								href={ 'https://en.support.wordpress.com/publicize/#facebook-pages' }
+								external
+							>
+								{ translate( 'Learn More' ) }
+							</NoticeAction>
+						) }
+						<NoticeAction href={ `/sharing/${ siteSlug }` }>
+							{ translate( 'Disconnect' ) }
 						</NoticeAction>
 					</Notice>
 				) ) }

--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import { every, filter, identity, isEqual, find, replace, some, isFunction } from 'lodash';
+import { identity, isEqual, find, replace, some, isFunction } from 'lodash';
 import { localize } from 'i18n-calypso';
 import SocialLogo from 'social-logos';
 
@@ -340,7 +340,7 @@ export class SharingService extends Component {
 		} else if ( some( this.getConnections(), { status: 'broken' } ) ) {
 			// A problematic connection exists
 			status = 'reconnect';
-		} else if ( ! this.areAllConnectionsStillAvailable() ) {
+		} else if ( some( this.getConnections(), { status: 'invalid' } ) ) {
 			// A valid connection is not available anymore, user must reconnect
 			status = 'must-disconnect';
 		} else {
@@ -349,18 +349,6 @@ export class SharingService extends Component {
 		}
 
 		return status;
-	}
-
-	areAllConnectionsStillAvailable() {
-		// Ignore connected connections I do not own as those won't be available
-		const connectedConnections = filter(
-			this.getConnections(),
-			connection => connection.status === 'ok' && connection.user_ID === this.props.userId
-		);
-		const availableExternalAccounts = this.props.availableExternalAccounts || [];
-		return every( connectedConnections, connection =>
-			some( availableExternalAccounts, { ID: connection.external_ID } )
-		);
 	}
 
 	/**

--- a/client/post-editor/editor-sharing/accordion.jsx
+++ b/client/post-editor/editor-sharing/accordion.jsx
@@ -29,6 +29,7 @@ import { getEditedPost, getEditedPostValue } from 'state/posts/selectors';
 import { getSiteSlug, isJetpackModuleActive } from 'state/sites/selectors';
 import { getSiteUserConnections } from 'state/sharing/publicize/selectors';
 import hasBrokenSiteUserConnection from 'state/selectors/has-broken-site-user-connection';
+import hasInvalidSiteUserConnection from 'state/selectors/has-invalid-site-user-connection';
 import isPublicizeEnabled from 'state/selectors/is-publicize-enabled';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
@@ -39,6 +40,7 @@ class EditorSharingAccordion extends React.Component {
 		post: PropTypes.object,
 		connections: PropTypes.array,
 		hasBrokenConnection: PropTypes.bool,
+		hasInvalidConnection: PropTypes.bool,
 		isPublicizeEnabled: PropTypes.bool,
 		isSharingActive: PropTypes.bool,
 		isLikesActive: PropTypes.bool,
@@ -123,6 +125,17 @@ class EditorSharingAccordion extends React.Component {
 			};
 		}
 
+		if ( this.props.hasInvalidConnection ) {
+			status = {
+				type: 'error',
+				text: this.props.translate( 'A connection is broken and must be removed', {
+					comment: 'Publicize connection is invalid.',
+				} ),
+				position: isMobile() ? 'top left' : 'top',
+				onClick: this.props.onStatusClick,
+			};
+		}
+
 		return (
 			<Accordion
 				title={ this.props.translate( 'Sharing' ) }
@@ -157,6 +170,7 @@ export default connect(
 			post,
 			connections: getSiteUserConnections( state, siteId, userId ),
 			hasBrokenConnection: hasBrokenSiteUserConnection( state, siteId, userId ),
+			hasInvalidConnection: hasInvalidSiteUserConnection( state, siteId, userId ),
 			isSharingActive,
 			isLikesActive,
 			isPublicizeEnabled: isPublicizeEnabled( state, siteId, postType ),

--- a/client/post-editor/editor-sharing/publicize-connection.jsx
+++ b/client/post-editor/editor-sharing/publicize-connection.jsx
@@ -44,9 +44,10 @@ export class EditorSharingPublicizeConnection extends React.Component {
 	isConnectionSkipped = () => {
 		const { post, connection } = this.props;
 		return (
-			post &&
-			connection &&
-			includes( PostMetadata.publicizeSkipped( post ), connection.keyring_connection_ID )
+			( post &&
+				connection &&
+				includes( PostMetadata.publicizeSkipped( post ), connection.keyring_connection_ID ) ) ||
+			( connection.service === 'facebook' && ! connection.is_additional_external_user )
 		);
 	};
 
@@ -61,7 +62,11 @@ export class EditorSharingPublicizeConnection extends React.Component {
 
 	isDisabled = () => {
 		const { connection } = this.props;
-		return ! connection || connection.read_only;
+		return (
+			! connection ||
+			connection.read_only ||
+			( connection.service === 'facebook' && ! connection.is_additional_external_user )
+		);
 	};
 
 	onChange = event => {
@@ -113,12 +118,10 @@ export class EditorSharingPublicizeConnection extends React.Component {
 			<Notice
 				isCompact
 				className="editor-sharing__broken-publicize-connection"
-				status="is-warning"
+				status="is-error"
 				showDismiss={ false }
 			>
-				{ this.props.translate(
-					'Connections to Facebook profiles will cease to work on August 1st'
-				) }
+				{ this.props.translate( 'Connections to Facebook profiles ceased to work on August 1st' ) }
 			</Notice>
 		);
 	};

--- a/client/post-editor/editor-sharing/publicize-connection.jsx
+++ b/client/post-editor/editor-sharing/publicize-connection.jsx
@@ -47,7 +47,7 @@ export class EditorSharingPublicizeConnection extends React.Component {
 			( post &&
 				connection &&
 				includes( PostMetadata.publicizeSkipped( post ), connection.keyring_connection_ID ) ) ||
-			( connection.service === 'facebook' && ! connection.is_additional_external_user )
+			( connection.service === 'facebook' && ! this.isAdditionalExternalUser( connection ) )
 		);
 	};
 
@@ -65,7 +65,7 @@ export class EditorSharingPublicizeConnection extends React.Component {
 		return (
 			! connection ||
 			connection.read_only ||
-			( connection.service === 'facebook' && ! connection.is_additional_external_user )
+			( connection.service === 'facebook' && ! this.isAdditionalExternalUser( connection ) )
 		);
 	};
 
@@ -121,7 +121,21 @@ export class EditorSharingPublicizeConnection extends React.Component {
 				status="is-error"
 				showDismiss={ false }
 			>
-				{ this.props.translate( 'Connections to Facebook profiles ceased to work on August 1st' ) }
+				{ this.props.translate(
+					'Connections to Facebook profiles ceased to work on August 1st. ' +
+						'{{a}}Learn More{{/a}}',
+					{
+						components: {
+							a: (
+								<a
+									href="https://en.support.wordpress.com/publicize/#facebook-pages"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					}
+				) }
 			</Notice>
 		);
 	};

--- a/client/state/selectors/has-invalid-site-user-connection.js
+++ b/client/state/selectors/has-invalid-site-user-connection.js
@@ -1,0 +1,25 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { some } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteUserConnections } from 'state/sharing/publicize/selectors';
+
+/**
+ * Returns true if a broken Publicize connections exists for the specified site
+ * and user, or false otherwise.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @param  {Number}  userId User ID
+ * @return {Boolean}        Whether broken connection exists
+ */
+export default function hasInvalidSiteUserConnection( state, siteId, userId ) {
+	return some( getSiteUserConnections( state, siteId, userId ), { status: 'invalid' } );
+}


### PR DESCRIPTION
Requires server side patch D16795

## Specs

This change will add an error-style notice to the sharing section of the post editor and the `PostShare` component and disable the ability to select a publicize sharing connection to a profile.

### Post Editor Sharing
<img width="284" alt="screen shot 2018-08-01 at 3 33 06 pm" src="https://user-images.githubusercontent.com/2810519/43552718-80beee66-95a0-11e8-9dc7-477bcfeab74c.png">

### PostShare
<img width="738" alt="screen shot 2018-08-01 at 3 33 19 pm" src="https://user-images.githubusercontent.com/2810519/43552725-88671602-95a0-11e8-94bb-abd18a8329d0.png">

## Testing

### Getting a Facebook profile connection

To get a connection to a Facebook Profile you need to revert to an earlier change both in Calypso and server-side:

Server-side: r178744
Calypso: b00b811622c83e8573070f25ff4dd4e2874c1ecc

## Steps

1. Navigate to creating a post on the blog with a Facebook profile connection
2. Verify the message pictured above appears
3. Verify that the connection is not checkable
4. Navigate to the `/posts` page of a blog with a Facebook profile connection
5. Click the "three dot" menu of a post and click "share"
<img width="765" alt="screen shot 2018-08-01 at 3 38 34 pm" src="https://user-images.githubusercontent.com/2810519/43552832-078d1bd4-95a1-11e8-807b-24c0c24d4b5d.png">
6. Verify that the Facebook connection is disabled and the warning is displayed.