### PR TITLE
Update page titles on Plans and Domains pages

### DIFF
--- a/client/my-sites/domains/domain-management/email/index.jsx
+++ b/client/my-sites/domains/domain-management/email/index.jsx
@@ -30,6 +30,7 @@ import {
 import { hasGoogleApps, hasGoogleAppsSupportedDomain, getSelectedDomain } from 'lib/domains';
 import { isPlanFeaturesEnabled } from 'lib/plans';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
+import DocumentHead from 'components/data/document-head';
 
 class Email extends React.Component {
 	static propTypes = {
@@ -46,6 +47,7 @@ class Email extends React.Component {
 	render() {
 		return (
 			<Main className="domain-management-email" wideLayout={ isPlanFeaturesEnabled() }>
+				<DocumentHead title={ this.props.translate( 'Email' ) } />
 				<SidebarNavigation />
 				{ this.headerOrUpgradesNavigation() }
 				{ this.content() }

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -47,6 +47,7 @@ import { isPlanFeaturesEnabled } from 'lib/plans';
 import DomainToPlanNudge from 'blocks/domain-to-plan-nudge';
 import { type } from 'lib/domains/constants';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
+import DocumentHead from 'components/data/document-head';
 
 export class List extends React.Component {
 	static defaultProps = {
@@ -137,6 +138,7 @@ export class List extends React.Component {
 		if ( this.props.isDomainOnly ) {
 			return (
 				<Main>
+					<DocumentHead title={ this.props.translate( 'Settings' ) } />
 					<SidebarNavigation />
 					<DomainOnly
 						hasNotice={ this.isFreshDomainOnlyRegistration() }
@@ -150,6 +152,7 @@ export class List extends React.Component {
 
 		return (
 			<Main wideLayout={ isPlanFeaturesEnabled() }>
+				<DocumentHead title={ headerText } />
 				<SidebarNavigation />
 				<UpgradesNavigation
 					path={ this.props.context.path }

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -109,7 +109,7 @@ class CurrentPlan extends Component {
 		return (
 			<Main className="current-plan" wideLayout>
 				<SidebarNavigation />
-				<DocumentHead title={ translate( 'Plans' ) } />
+				<DocumentHead title={ translate( 'My Plan' ) } />
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />
 				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }


### PR DESCRIPTION
Fixes #26378

**Before:**

![titles](https://user-images.githubusercontent.com/128826/43380479-a36beff0-9414-11e8-85a8-92dd80aef6b8.gif)

**After:**

![titles after](https://user-images.githubusercontent.com/128826/43380469-9d0c34a8-9414-11e8-88d8-6d3a6d347981.gif)

**Testing Instructions**

1. Make sure page titles are correct
2. Works for simple, Atomic and Jetpack sites
3. Check page title for Domain Only site (should be 'Settings')
