### PR TITLE
Fix connecting to the main connection on a service that supports multiple external users

### DIFF
--- a/client/my-sites/sharing/connections/account-dialog.jsx
+++ b/client/my-sites/sharing/connections/account-dialog.jsx
@@ -41,9 +41,10 @@ class AccountDialog extends Component {
 
 	onClose = action => {
 		const accountToConnect = this.getAccountToConnect();
-		const externalUserId = this.props.service.multiple_external_user_ID_support
-			? accountToConnect.ID
-			: 0;
+		const externalUserId =
+			this.props.service.multiple_external_user_ID_support && accountToConnect.isExternal
+				? accountToConnect.ID
+				: 0;
 
 		if ( 'connect' === action && accountToConnect ) {
 			this.props.onAccountSelected(


### PR DESCRIPTION
Something we overlooked in https://github.com/Automattic/wp-calypso/pull/26323 is that we might want to connect to the main profile of an external service, in that case we should not send the external user id either.

### Testing Instructions
- Try connecting to `tumblr` (a service that supports external user and a main profile)
- Pick the the main account, it should create the connection without any issue

### Reviews
- [ ] Product
- [ ] Code