### PR TITLE
Revert "[nudge-a-palooza] Enable nudge-a-palooza for everyone"

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -133,7 +133,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"upsell/nudge-a-palooza": true,
+		"upsell/nudge-a-palooza": false,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -138,7 +138,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"upsell/nudge-a-palooza": true,
+		"upsell/nudge-a-palooza": false,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#26331

Turns out we enabled `/feature/ads` and similar URLs in production, but not `/feature/ads/mysite.com` which this feature requires. Reverting feature flag for now until URLs with the site address in them are enabled as well