### PR TITLE
[nudge-a-palooza] Enable nudge-a-palooza for everyone

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -133,7 +133,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"upsell/nudge-a-palooza": false,
+		"upsell/nudge-a-palooza": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -138,7 +138,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"upsell/nudge-a-palooza": false,
+		"upsell/nudge-a-palooza": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,


### PR DESCRIPTION
Project nudge-a-palooza (p9jf6J-Hl-p2) is ready to ship, let's release it for all our users.

Test plan:
It's not possible to test this before merging

This was already reviewed and merged before but had to be reverted for reasons related to URLs configuration in production. Related PR: https://github.com/Automattic/wp-calypso/pull/26331