### PR TITLE
Upgrade Prettier to 1.14.0

### DIFF
--- a/client/account-recovery/reset-password-sms-form/index.jsx
+++ b/client/account-recovery/reset-password-sms-form/index.jsx
@@ -57,7 +57,7 @@ class ResetPasswordSmsForm extends Component {
 				<p>
 					{ translate(
 						'Please enter the code you were sent by SMS. ' +
-						'It will look something like {{code}}%(code)s{{/code}}. You may need to wait a few moments before it arrives.',
+							'It will look something like {{code}}%(code)s{{/code}}. You may need to wait a few moments before it arrives.',
 						{
 							args: { code: '6342 3423' },
 							components: { code: <code /> },

--- a/client/auth/self-hosted-instructions.jsx
+++ b/client/auth/self-hosted-instructions.jsx
@@ -32,7 +32,8 @@ const SelfHostedInstructions = ( { onClickClose, translate } ) => (
 				<br />
 				<a href="http://jetpack.me/install/">
 					{ translate( 'Please follow these instructions to install Jetpack' ) }
-				</a>.
+				</a>
+				.
 			</li>
 			<li>{ translate( 'Connect Jetpack to WordPress.com.' ) }</li>
 			<li>

--- a/client/blocks/checklist/index.jsx
+++ b/client/blocks/checklist/index.jsx
@@ -59,7 +59,9 @@ export class Checklist extends Component {
 		return (
 			<div className={ classNames( 'checklist', 'is-expanded', 'is-placeholder' ) }>
 				<ChecklistHeader total={ 0 } completed={ 0 } hideCompleted={ false } />
-				{ times( this.props.placeholderCount, index => <ChecklistPlaceholder key={ index } /> ) }
+				{ times( this.props.placeholderCount, index => (
+					<ChecklistPlaceholder key={ index } />
+				) ) }
 			</div>
 		);
 	}

--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -128,7 +128,8 @@ export const HoldList = ( { holds, isPlaceholder, siteSlug, translate } ) => {
 							<div className="eligibility-warnings__message">
 								<span className="eligibility-warnings__message-title">
 									{ holdMessages[ hold ].title }
-								</span>:&nbsp;
+								</span>
+								:&nbsp;
 								<span className="eligibility-warnings__message-description">
 									{ holdMessages[ hold ].description }
 								</span>

--- a/client/blocks/eligibility-warnings/warning-list.jsx
+++ b/client/blocks/eligibility-warnings/warning-list.jsx
@@ -33,7 +33,8 @@ export const WarningList = ( { translate, warnings } ) => (
 				<div className="eligibility-warnings__warning" key={ index }>
 					<Gridicon icon="cross-small" size={ 24 } />
 					<div className="eligibility-warnings__message">
-						<span className="eligibility-warnings__message-title">{ name }</span>:&nbsp;
+						<span className="eligibility-warnings__message-title">{ name }</span>
+						:&nbsp;
 						<span className="eligibility-warnings__message-description">{ description }</span>
 					</div>
 					<div className="eligibility-warnings__action">

--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -123,14 +123,14 @@ class VerificationCodeForm extends Component {
 		if ( twoFactorAuthType === 'backup' ) {
 			helpText = translate(
 				"If you can't access your phone enter one of the 10 backup codes that were provided " +
-				'when you set up two-step authentication to continue.'
+					'when you set up two-step authentication to continue.'
 			);
 			labelText = translate( 'Backup code' );
 			smallPrint = (
 				<div className="two-factor-authentication__small-print">
 					{ translate(
 						'If you lose your device, accidentally remove the authenticator app, or are otherwise ' +
-						'locked out of your account, the only way to get back in to your account is by using a backup code.'
+							'locked out of your account, the only way to get back in to your account is by using a backup code.'
 					) }
 				</div>
 			);

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -159,7 +159,9 @@ class SharingPreviewPane extends PureComponent {
 						</p>
 					</div>
 					<VerticalMenu onClick={ this.selectPreview } initialItemIndex={ initialMenuItemIndex }>
-						{ services.map( service => <SocialItem { ...{ key: service, service } } /> ) }
+						{ services.map( service => (
+							<SocialItem { ...{ key: service, service } } />
+						) ) }
 					</VerticalMenu>
 				</div>
 				<div className="sharing-preview-pane__preview-area">

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -353,7 +353,8 @@ class SignupForm extends Component {
 			return (
 				<span>
 					<p>
-						{ notice.message }&nbsp;
+						{ notice.message }
+						&nbsp;
 						{ this.props.translate( '{{a}}Log in now{{/a}} to finish signing up.', {
 							components: {
 								a: <a href={ link } onClick={ this.props.trackLoginMidFlow } />,
@@ -401,7 +402,8 @@ class SignupForm extends Component {
 				return (
 					<span>
 						<p>
-							{ message }&nbsp;
+							{ message }
+							&nbsp;
 							{ this.props.translate( 'If this is you {{a}}log in now{{/a}}.', {
 								components: {
 									a: <a href={ link } onClick={ this.props.trackLoginMidFlow } />,

--- a/client/blocks/term-tree-selector/no-results.jsx
+++ b/client/blocks/term-tree-selector/no-results.jsx
@@ -40,7 +40,8 @@ class TermTreeSelectorNoResults extends React.PureComponent {
 		return (
 			<span className="is-empty-content">
 				{ this.props.translate( 'No results. Please try a different search.' ) }
-				&nbsp;{ createMessage }
+				&nbsp;
+				{ createMessage }
 			</span>
 		);
 	}

--- a/client/components/environment-badge/index.jsx
+++ b/client/components/environment-badge/index.jsx
@@ -53,7 +53,12 @@ function EnvironmentBadge( { badge, feedbackURL, children } ) {
 			{ /* eslint-disable wpcalypso/jsx-classname-namespace */ }
 			{ children }
 			<span className={ `environment is-${ badge } is-env` }>{ badge }</span>
-			<ExternalLink className="bug-report" href={ feedbackURL } title="Report an issue" target="_blank">
+			<ExternalLink
+				className="bug-report"
+				href={ feedbackURL }
+				title="Report an issue"
+				target="_blank"
+			>
 				<Gridicon icon="bug" size={ 18 } />
 			</ExternalLink>
 			{ /* eslint-enable wpcalypso/jsx-classname-namespace */ }

--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -216,7 +216,9 @@ export class SeoPreviewPane extends PureComponent {
 						</p>
 					</div>
 					<VerticalMenu onClick={ this.selectPreview }>
-						{ services.map( service => <SocialItem { ...{ key: service, service } } /> ) }
+						{ services.map( service => (
+							<SocialItem { ...{ key: service, service } } />
+						) ) }
 					</VerticalMenu>
 				</div>
 				<div className="seo-preview-pane__preview-area">

--- a/client/components/tinymce/plugins/wpcom-view/views/contact-form/preview-fields.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/contact-form/preview-fields.jsx
@@ -41,11 +41,9 @@ const select = ( field, index ) => (
 	<PreviewFieldset key={ 'contact-form-field-' + index }>
 		<PreviewLegend { ...field } />
 		<select>
-			{ []
-				.concat( field.options.split( ',' ) )
-				.map( ( option, optionIndex ) => (
-					<option key={ 'contact-form-select-option-' + optionIndex }>{ option }</option>
-				) ) }
+			{ [].concat( field.options.split( ',' ) ).map( ( option, optionIndex ) => (
+				<option key={ 'contact-form-select-option-' + optionIndex }>{ option }</option>
+			) ) }
 		</select>
 	</PreviewFieldset>
 );

--- a/client/components/tinymce/plugins/wpcom-view/views/contact-form/preview-required.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/contact-form/preview-required.jsx
@@ -13,7 +13,12 @@ class ContactFormViewPreviewRequired extends React.Component {
 
 	render() {
 		if ( this.props.required ) {
-			return <em>&nbsp;({ this.props.translate( 'required' ) })</em>;
+			return (
+				<em>
+					&nbsp;(
+					{ this.props.translate( 'required' ) })
+				</em>
+			);
 		}
 
 		return null;

--- a/client/devdocs/design/typography.jsx
+++ b/client/devdocs/design/typography.jsx
@@ -55,11 +55,16 @@ export default class Typography extends React.PureComponent {
 					<pre>
 						<code>
 							.design__typography-sans &#123;
-							{ '\n\t' }font-family: $sans;
-							{ '\n\t' }font-size: 16px;
-							{ '\n\t' }font-weight: 400;
-							{ '\n\t' }color: $gray-dark;
-							{ '\n' }&#125;
+							{ '\n\t' }
+							font-family: $sans;
+							{ '\n\t' }
+							font-size: 16px;
+							{ '\n\t' }
+							font-weight: 400;
+							{ '\n\t' }
+							color: $gray-dark;
+							{ '\n' }
+							&#125;
 						</code>
 					</pre>
 
@@ -89,8 +94,10 @@ export default class Typography extends React.PureComponent {
 					<pre>
 						<code>
 							.design__typography-serif &#123;
-							{ '\n\t' }font-family: $serif;
-							{ '\n' }&#125;
+							{ '\n\t' }
+							font-family: $serif;
+							{ '\n' }
+							&#125;
 						</code>
 					</pre>
 
@@ -113,9 +120,12 @@ export default class Typography extends React.PureComponent {
 					<pre>
 						<code>
 							.design__typography-code &#123;
-							{ '\n\t' }font-family: $code;
-							{ '\n\t' }font-size: 15px;
-							{ '\n' }&#125;
+							{ '\n\t' }
+							font-family: $code;
+							{ '\n\t' }
+							font-size: 15px;
+							{ '\n' }
+							&#125;
 						</code>
 					</pre>
 

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -73,8 +73,12 @@ class Document extends React.Component {
 				className={ classNames( { 'is-fluid-width': isFluidWidth } ) }
 			>
 				<Head title={ head.title } faviconURL={ faviconURL } cdn={ '//s1.wp.com' }>
-					{ head.metas.map( ( props, index ) => <meta { ...props } key={ index } /> ) }
-					{ head.links.map( ( props, index ) => <link { ...props } key={ index } /> ) }
+					{ head.metas.map( ( props, index ) => (
+						<meta { ...props } key={ index } />
+					) ) }
+					{ head.links.map( ( props, index ) => (
+						<link { ...props } key={ index } />
+					) ) }
 
 					<link
 						rel="stylesheet"
@@ -162,8 +166,12 @@ class Document extends React.Component {
 							} }
 						/>
 					) }
-					{ entrypoint.map( asset => <script key={ asset } src={ asset } /> ) }
-					{ chunkFiles.map( chunk => <script key={ chunk } src={ chunk } /> ) }
+					{ entrypoint.map( asset => (
+						<script key={ asset } src={ asset } />
+					) ) }
+					{ chunkFiles.map( chunk => (
+						<script key={ chunk } src={ chunk } />
+					) ) }
 					<script nonce={ inlineScriptNonce } type="text/javascript">
 						window.AppBoot();
 					</script>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-details-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-details-modal.js
@@ -73,7 +73,11 @@ const DetailsDialog = props => {
 
 				<dt>{ translate( 'Items' ) }</dt>
 				<dd>
-					<ul>{ productNames.map( ( productName, i ) => <li key={ i }>{ productName }</li> ) }</ul>
+					<ul>
+						{ productNames.map( ( productName, i ) => (
+							<li key={ i }>{ productName }</li>
+						) ) }
+					</ul>
 				</dd>
 			</dl>
 		</Dialog>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/summary.js
@@ -41,7 +41,8 @@ const AddressSummary = ( { values, originalValues, countriesData, expandStateNam
 				{ getValue( 'address' ) } { getValue( 'address_2' ) }
 			</p>
 			<p>
-				{ getValue( 'city' ) }, { getValue( 'state' ) }&nbsp; { getValue( 'postcode' ) }
+				{ getValue( 'city' ) }, { getValue( 'state' ) }
+				&nbsp; { getValue( 'postcode' ) }
 			</p>
 			<p>{ getValue( 'country' ) }</p>
 		</div>

--- a/client/extensions/zoninator/components/settings/zones-dashboard/index.jsx
+++ b/client/extensions/zoninator/components/settings/zones-dashboard/index.jsx
@@ -39,7 +39,9 @@ const ZonesDashboard = ( { isRequesting, siteSlug, translate, zones } ) => (
 		{ isRequesting &&
 			zones.length === 0 &&
 			times( placeholderCount, i => <ZonePlaceholder key={ i } /> ) }
-		{ zones.map( zone => <ZoneItem key={ zone.slug } zone={ zone } /> ) }
+		{ zones.map( zone => (
+			<ZoneItem key={ zone.slug } zone={ zone } />
+		) ) }
 	</div>
 );
 

--- a/client/jetpack-connect/install-step.jsx
+++ b/client/jetpack-connect/install-step.jsx
@@ -129,7 +129,8 @@ class JetpackInstallStep extends Component {
 				<div className="jetpack-connect__install-step-title">{ step.title }</div>
 				<div className="jetpack-connect__install-step-text">
 					<span>
-						{ preventWidows( step.text ) }&nbsp;
+						{ preventWidows( step.text ) }
+						&nbsp;
 						{ step.action }
 					</span>
 				</div>

--- a/client/jetpack-connect/plans-placeholder.js
+++ b/client/jetpack-connect/plans-placeholder.js
@@ -48,7 +48,9 @@ const placeholderContent = (
 										<div className="plan-features__actions">
 											<div className="plan-features__actions-buttons">
 												<div className="placeholder-text">
-													Upgrade<br />Your Plan
+													Upgrade
+													<br />
+													Your Plan
 												</div>
 											</div>
 										</div>

--- a/client/me/help/help-courses/course-videos.jsx
+++ b/client/me/help/help-courses/course-videos.jsx
@@ -25,7 +25,9 @@ export default localize( props => {
 			<Card compact className="help-courses__course-videos-label">
 				{ translate( 'Latest course' ) }
 			</Card>
-			{ videos.map( ( video, key ) => <CourseVideo { ...video } key={ key } /> ) }
+			{ videos.map( ( video, key ) => (
+				<CourseVideo { ...video } key={ key } />
+			) ) }
 		</div>
 	);
 } );

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -124,4 +124,7 @@ const mapStateToProps = ( state, { purchaseId } ) => ( {
 	userId: getCurrentUserId( state ),
 } );
 
-export default connect( mapStateToProps, { clearPurchases, recordTracksEvent } )( AddCardDetails );
+export default connect(
+	mapStateToProps,
+	{ clearPurchases, recordTracksEvent }
+)( AddCardDetails );

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -133,4 +133,7 @@ const mapStateToProps = ( state, { cardId, purchaseId } ) => ( {
 	userId: getCurrentUserId( state ),
 } );
 
-export default connect( mapStateToProps, { clearPurchases, recordTracksEvent } )( EditCardDetails );
+export default connect(
+	mapStateToProps,
+	{ clearPurchases, recordTracksEvent }
+)( EditCardDetails );

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -270,9 +270,9 @@ class Security2faEnable extends React.Component {
 				<p>
 					{ this.props.translate(
 						'Not sure what this screen means? You may need to download ' +
-						'{{authyLink}}Authy{{/authyLink}} or ' +
-						'{{googleAuthenticatorLink}}Google Authenticator{{/googleAuthenticatorLink}} ' +
-						'for your phone.',
+							'{{authyLink}}Authy{{/authyLink}} or ' +
+							'{{googleAuthenticatorLink}}Google Authenticator{{/googleAuthenticatorLink}} ' +
+							'for your phone.',
 						{
 							components: {
 								authyLink: (
@@ -345,7 +345,7 @@ class Security2faEnable extends React.Component {
 					<FormSettingExplanation>
 						{ this.props.translate(
 							'A code has been sent to your device via SMS. ' +
-							'You may request another code after one minute.'
+								'You may request another code after one minute.'
 						) }
 					</FormSettingExplanation>
 				) : null }

--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/terms-and-conditions.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/terms-and-conditions.jsx
@@ -90,7 +90,8 @@ const googleTermsAndConditions = ( { translate } ) => (
 					rel="noopener noreferrer"
 				>
 					http://www.google.com/adwords/coupons/terms.html
-				</ExternalLink>.
+				</ExternalLink>
+				.
 			</li>
 		</ol>
 	</div>

--- a/client/my-sites/checkout/checkout/stored-card.jsx
+++ b/client/my-sites/checkout/checkout/stored-card.jsx
@@ -19,7 +19,8 @@ class StoredCard extends React.Component {
 		return (
 			<div className={ cardClasses }>
 				<span className="stored-card__number">
-					{ card.card_type } ****{ card.card }
+					{ card.card_type } ****
+					{ card.card }
 				</span>
 				<span className="stored-card__name">{ card.name }</span>
 				<span className="stored-card__expiration-date">

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -194,7 +194,9 @@ export class DomainWarnings extends React.PureComponent {
 		} else {
 			offendingList = (
 				<ul>
-					{ wrongMappedDomains.map( domain => <li key={ domain.name }>{ domain.name }</li> ) }
+					{ wrongMappedDomains.map( domain => (
+						<li key={ domain.name }>{ domain.name }</li>
+					) ) }
 				</ul>
 			);
 			if ( every( map( wrongMappedDomains, 'name' ), isSubdomain ) ) {

--- a/client/my-sites/domains/domain-management/add-google-apps/domains-select.jsx
+++ b/client/my-sites/domains/domain-management/add-google-apps/domains-select.jsx
@@ -32,7 +32,12 @@ class DomainsSelect extends React.Component {
 			} );
 		} else {
 			disabled = true;
-			options = <option>{ this.props.translate( 'Loading' ) }...</option>;
+			options = (
+				<option>
+					{ this.props.translate( 'Loading' ) }
+					...
+				</option>
+			);
 		}
 
 		return (

--- a/client/my-sites/domains/domain-management/dns/domain-connect-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/domain-connect-record.jsx
@@ -134,8 +134,11 @@ class DomainConnectRecord extends React.Component {
 	}
 }
 
-export default connect( null, {
-	errorNotice,
-	removeNotice,
-	successNotice,
-} )( localize( DomainConnectRecord ) );
+export default connect(
+	null,
+	{
+		errorNotice,
+		removeNotice,
+		successNotice,
+	}
+)( localize( DomainConnectRecord ) );

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize-records.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize-records.jsx
@@ -119,7 +119,8 @@ class DomainConnectAuthorizeRecords extends Component {
 							"To set up this service, we're going to make some changes to the " +
 								'the DNS records for your domain.'
 						) }
-					</span>&nbsp;
+					</span>
+					&nbsp;
 					<a onClick={ this.toggleRecordsVisible }>{ showRecordsLinkText }</a>
 				</p>
 				{ this.renderDnsTemplateRecords() }

--- a/client/my-sites/domains/domain-management/primary-domain/index.jsx
+++ b/client/my-sites/domains/domain-management/primary-domain/index.jsx
@@ -185,8 +185,11 @@ const updatePrimaryDomainClick = ( { name, type }, success ) =>
 		} )
 	);
 
-export default connect( null, {
-	setPrimaryDomain,
-	cancelClick,
-	updatePrimaryDomainClick,
-} )( localize( PrimaryDomain ) );
+export default connect(
+	null,
+	{
+		setPrimaryDomain,
+		cancelClick,
+		updatePrimaryDomainClick,
+	}
+)( localize( PrimaryDomain ) );

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag.jsx
@@ -205,7 +205,8 @@ class SelectIpsTag extends Component {
 					) }
 				</p>
 				<p>
-					<strong>{ selectedRegistrar.tag }</strong>&nbsp;&nbsp;
+					<strong>{ selectedRegistrar.tag }</strong>
+					&nbsp;&nbsp;
 					{ selectedRegistrar.registrarName ? '(' + selectedRegistrar.registrarName + ')' : '' }
 				</p>
 				<p>

--- a/client/my-sites/google-my-business/location/index.js
+++ b/client/my-sites/google-my-business/location/index.js
@@ -57,9 +57,9 @@ function GoogleMyBusinessLocation( { children, isCompact, location, translate } 
 					<h2 className="gmb-location__name">{ location.name }</h2>
 
 					<div className="gmb-location__address">
-						{ location.description
-							.split( '\n' )
-							.map( ( line, index ) => <p key={ index }>{ line }</p> ) }
+						{ location.description.split( '\n' ).map( ( line, index ) => (
+							<p key={ index }>{ line }</p>
+						) ) }
 					</div>
 
 					{ isLocationVerified && (

--- a/client/my-sites/post-selector/no-results.jsx
+++ b/client/my-sites/post-selector/no-results.jsx
@@ -41,7 +41,8 @@ class PostSelectorNoResults extends React.Component {
 		return (
 			<span className="is-empty-content">
 				{ noResultsMessage }
-				&nbsp;{ createMessage }
+				&nbsp;
+				{ createMessage }
 			</span>
 		);
 	}

--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -180,7 +180,9 @@ export class PostTypeFilter extends Component {
 						selectedText={ selectedItem.children }
 						selectedCount={ selectedItem.count }
 					>
-						{ navItems.map( props => <NavItem { ...props } /> ) }
+						{ navItems.map( props => (
+							<NavItem { ...props } />
+						) ) }
 					</NavTabs>
 					{ ! authorToggleHidden && (
 						<AuthorSegmented author={ query.author } siteId={ siteId } statusSlug={ statusSlug } />

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -273,7 +273,8 @@ export class SiteSettingsFormGeneral extends Component {
 					onClick={ eventTracker( 'Clicked Language Field' ) }
 				/>
 				<FormSettingExplanation>
-					{ translate( "The site's primary language." ) }&nbsp;
+					{ translate( "The site's primary language." ) }
+					&nbsp;
 					<a href={ config.isEnabled( 'me/account' ) ? '/me/account' : '/settings/account/' }>
 						{ translate( "You can also modify your interface's language in your profile." ) }
 					</a>

--- a/client/my-sites/site-settings/placeholder.jsx
+++ b/client/my-sites/site-settings/placeholder.jsx
@@ -47,12 +47,15 @@ const Placeholder = ( { translate } ) => {
 			<Card>
 				<div className="site-settings__placeholder-item">Example content here</div>
 				<div className="site-settings__placeholder-item">
-					Example content here<br />
-					Example content here<br />
+					Example content here
+					<br />
+					Example content here
+					<br />
 					Example content here
 				</div>
 				<div className="site-settings__placeholder-item">
-					Example content here<br />
+					Example content here
+					<br />
 					Example content here
 				</div>
 			</Card>

--- a/client/my-sites/site-settings/podcasting-details/feed-url.jsx
+++ b/client/my-sites/site-settings/podcasting-details/feed-url.jsx
@@ -43,8 +43,7 @@ export default connect( ( state, ownProps ) => {
 
 	const siteId = getSelectedSiteId( state );
 
-	const podcastingCategory =
-		categoryId && getTerm( state, siteId, 'category', categoryId );
+	const podcastingCategory = categoryId && getTerm( state, siteId, 'category', categoryId );
 
 	let feedUrl = podcastingCategory && podcastingCategory.feed_url;
 

--- a/client/my-sites/stats/activity-log/rewind-alerts.jsx
+++ b/client/my-sites/stats/activity-log/rewind-alerts.jsx
@@ -30,7 +30,9 @@ export class RewindAlerts extends Component {
 						<div className="activity-log__threats-heading">
 							{ translate( 'These items require your immediate attention' ) }
 						</div>
-						{ threats.map( threat => <ThreatAlert key={ threat.id } threat={ threat } /> ) }
+						{ threats.map( threat => (
+							<ThreatAlert key={ threat.id } threat={ threat } />
+						) ) }
 					</Card>
 				) }
 			</Fragment>

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -43,7 +43,7 @@
 	box-sizing: border-box;
 	color: $gray-text-min;
 	background: $white;
-	border-bottom: 1px solid darken($sidebar-bg-color, 5%);
+	border-bottom: 1px solid darken( $sidebar-bg-color, 5% );
 
 	@include breakpoint( '>1040px' ) {
 		height: 40px;
@@ -57,7 +57,7 @@
 			width: 50%;
 			height: $editor-revisions-list-header-font-size;
 			align-self: center;
-			@include placeholder(23%);
+			@include placeholder( 23% );
 		}
 	}
 }
@@ -66,7 +66,7 @@
 	align-self: center;
 }
 
-@include breakpoint ('>1040px') {
+@include breakpoint( '>1040px' ) {
 	.editor-revisions-list.is-loading {
 		.editor-revisions-list__header::before {
 			align-self: flex-end;
@@ -103,7 +103,7 @@
 	height: 40px;
 	box-sizing: border-box;
 	color: $gray-text-min;
-	border-bottom: 1px solid darken($sidebar-bg-color, 5%);
+	border-bottom: 1px solid darken( $sidebar-bg-color, 5% );
 	.button:first-child,
 	.button:last-child {
 		border-radius: 0;
@@ -127,11 +127,11 @@
 	&.button[disabled],
 	&.button.disabled {
 		background: transparent;
-		color: lighten($gray-text-min, 30%);
-		border-color: darken($sidebar-bg-color, 5%);
+		color: lighten( $gray-text-min, 30% );
+		border-color: darken( $sidebar-bg-color, 5% );
 	}
 	.gridicon {
-		transform: rotate(-90deg);
+		transform: rotate( -90deg );
 	}
 
 	@include breakpoint( '>660px' ) {

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -57,7 +57,8 @@ const FollowingStream = props => {
 						components: {
 							suggestions: suggestionList,
 						},
-					} ) }&nbsp;
+					} ) }
+				&nbsp;
 			</div>
 		</Stream>
 	);

--- a/client/reader/reading-time/index.jsx
+++ b/client/reader/reading-time/index.jsx
@@ -18,7 +18,8 @@ class ReadingTime extends React.PureComponent {
 					{ this.props.translate( '~%d min', {
 						args: [ timeInMinutes ],
 						context: 'An approximate time to read something, in minutes',
-					} ) })
+					} ) }
+					)
 				</span>
 			);
 		}

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -218,7 +218,8 @@ class Site extends React.Component {
 					return (
 						<span>
 							<p>
-								{ message }&nbsp;
+								{ message }
+								&nbsp;
 								{ this.props.translate(
 									'Is this your username? {{a}}Log in now to claim this site address{{/a}}.',
 									{

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -88,18 +88,21 @@ export const getNormalizedPost = createSelector(
  * @param  {Number} siteId Site ID
  * @return {Array}         Site posts
  */
-export const getSitePosts = createSelector( ( state, siteId ) => {
-	if ( ! siteId ) {
-		return null;
-	}
+export const getSitePosts = createSelector(
+	( state, siteId ) => {
+		if ( ! siteId ) {
+			return null;
+		}
 
-	const manager = state.posts.queries[ siteId ];
-	if ( ! manager ) {
-		return [];
-	}
+		const manager = state.posts.queries[ siteId ];
+		if ( ! manager ) {
+			return [];
+		}
 
-	return manager.getItems();
-}, state => state.posts.queries );
+		return manager.getItems();
+	},
+	state => state.posts.queries
+);
 
 /**
  * Returns a post object by site ID, post ID pair.
@@ -109,18 +112,21 @@ export const getSitePosts = createSelector( ( state, siteId ) => {
  * @param  {String}  postId Post ID
  * @return {?Object}        Post object
  */
-export const getSitePost = createSelector( ( state, siteId, postId ) => {
-	if ( ! siteId ) {
-		return null;
-	}
+export const getSitePost = createSelector(
+	( state, siteId, postId ) => {
+		if ( ! siteId ) {
+			return null;
+		}
 
-	const manager = state.posts.queries[ siteId ];
-	if ( ! manager ) {
-		return null;
-	}
+		const manager = state.posts.queries[ siteId ];
+		if ( ! manager ) {
+			return null;
+		}
 
-	return manager.getItem( postId );
-}, state => state.posts.queries );
+		return manager.getItem( postId );
+	},
+	state => state.posts.queries
+);
 
 /**
  * Returns an array of normalized posts for the posts query, or null if no
@@ -462,18 +468,21 @@ export const isEditedPostDirty = createSelector(
  * @param  {Number}  postId Post ID
  * @return {Boolean}        Whether post is published
  */
-export const isPostPublished = createSelector( ( state, siteId, postId ) => {
-	const post = getSitePost( state, siteId, postId );
+export const isPostPublished = createSelector(
+	( state, siteId, postId ) => {
+		const post = getSitePost( state, siteId, postId );
 
-	if ( ! post ) {
-		return null;
-	}
+		if ( ! post ) {
+			return null;
+		}
 
-	return (
-		includes( [ 'publish', 'private' ], post.status ) ||
-		( post.status === 'future' && moment( post.date ).isBefore( moment() ) )
-	);
-}, state => state.posts.queries );
+		return (
+			includes( [ 'publish', 'private' ], post.status ) ||
+			( post.status === 'future' && moment( post.date ).isBefore( moment() ) )
+		);
+	},
+	state => state.posts.queries
+);
 
 /**
  * Returns the slug, or suggested_slug, for the edited post

--- a/client/state/selectors/can-current-user-manage-plugins.js
+++ b/client/state/selectors/can-current-user-manage-plugins.js
@@ -18,7 +18,10 @@ import canCurrentUser from 'state/selectors/can-current-user';
  * @param {Object} state  Global state tree
  * @return {Boolean} Whether the user can manage plugins or not
  */
-export default createSelector( state => {
-	const siteIds = Object.keys( get( state, 'currentUser.capabilities', {} ) );
-	return siteIds.some( siteId => canCurrentUser( state, siteId, 'manage_options' ) );
-}, state => state.currentUser.capabilities );
+export default createSelector(
+	state => {
+		const siteIds = Object.keys( get( state, 'currentUser.capabilities', {} ) );
+		return siteIds.some( siteId => canCurrentUser( state, siteId, 'manage_options' ) );
+	},
+	state => state.currentUser.capabilities
+);

--- a/client/state/selectors/get-memberships.js
+++ b/client/state/selectors/get-memberships.js
@@ -20,26 +20,29 @@ import createSelector from 'lib/create-selector';
  * @param {int}    simplePaymentId The ID of the Simple Payment to get. Optional.
  * @return {Array|Object|null}     Array of Simple Payment objects or an object if `simplePaymentId` specified.
  */
-export default createSelector( ( state, siteId, membershipsId = null ) => {
-	if ( ! siteId ) {
-		return null;
-	}
+export default createSelector(
+	( state, siteId, membershipsId = null ) => {
+		if ( ! siteId ) {
+			return null;
+		}
 
-	const membershipsProducts = get( state, `memberships.productList.items.${ siteId }`, null );
+		const membershipsProducts = get( state, `memberships.productList.items.${ siteId }`, null );
 
-	if ( ! membershipsProducts ) {
-		return null;
-	}
+		if ( ! membershipsProducts ) {
+			return null;
+		}
 
-	if ( ! membershipsId ) {
-		return orderBy( membershipsProducts, 'ID', 'desc' );
-	}
+		if ( ! membershipsId ) {
+			return orderBy( membershipsProducts, 'ID', 'desc' );
+		}
 
-	const membershipProduct = find( membershipsProducts, product => product.ID === membershipsId );
+		const membershipProduct = find( membershipsProducts, product => product.ID === membershipsId );
 
-	if ( ! membershipProduct ) {
-		return null;
-	}
+		if ( ! membershipProduct ) {
+			return null;
+		}
 
-	return membershipProduct;
-}, state => state.memberships.productList.items );
+		return membershipProduct;
+	},
+	state => state.memberships.productList.items
+);

--- a/client/state/selectors/get-simple-payments.js
+++ b/client/state/selectors/get-simple-payments.js
@@ -20,29 +20,36 @@ import createSelector from 'lib/create-selector';
  * @param {int}    simplePaymentId The ID of the Simple Payment to get. Optional.
  * @return {Array|Object|null}     Array of Simple Payment objects or an object if `simplePaymentId` specified.
  */
-export default createSelector( ( state, siteId, simplePaymentId = null ) => {
-	if ( ! siteId ) {
-		return null;
-	}
+export default createSelector(
+	( state, siteId, simplePaymentId = null ) => {
+		if ( ! siteId ) {
+			return null;
+		}
 
-	const simplePaymentProducts = get( state, `simplePayments.productList.items.${ siteId }`, null );
+		const simplePaymentProducts = get(
+			state,
+			`simplePayments.productList.items.${ siteId }`,
+			null
+		);
 
-	if ( ! simplePaymentProducts ) {
-		return null;
-	}
+		if ( ! simplePaymentProducts ) {
+			return null;
+		}
 
-	if ( ! simplePaymentId ) {
-		return orderBy( simplePaymentProducts, 'ID', 'desc' );
-	}
+		if ( ! simplePaymentId ) {
+			return orderBy( simplePaymentProducts, 'ID', 'desc' );
+		}
 
-	const simplePaymentProduct = find(
-		simplePaymentProducts,
-		product => product.ID === simplePaymentId
-	);
+		const simplePaymentProduct = find(
+			simplePaymentProducts,
+			product => product.ID === simplePaymentId
+		);
 
-	if ( ! simplePaymentProduct ) {
-		return null;
-	}
+		if ( ! simplePaymentProduct ) {
+			return null;
+		}
 
-	return simplePaymentProduct;
-}, state => state.simplePayments.productList.items );
+		return simplePaymentProduct;
+	},
+	state => state.simplePayments.productList.items
+);

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -42,14 +42,17 @@ import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
  * @param  {String}  themeId Theme ID
  * @return {?Object}         Theme object
  */
-export const getTheme = createSelector( ( state, siteId, themeId ) => {
-	const manager = state.themes.queries[ siteId ];
-	if ( ! manager ) {
-		return null;
-	}
+export const getTheme = createSelector(
+	( state, siteId, themeId ) => {
+		const manager = state.themes.queries[ siteId ];
+		if ( ! manager ) {
+			return null;
+		}
 
-	return manager.getItem( themeId );
-}, state => state.themes.queries );
+		return manager.getItem( themeId );
+	},
+	state => state.themes.queries
+);
 
 /**
  * Returns a theme object from what is considered the 'canonical' source, i.e.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1394,7 +1394,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1964,21 +1963,6 @@
             "electron-to-chromium": "^1.3.52",
             "node-releases": "^1.0.0-alpha.10"
           }
-        },
-        "postcss": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.2.tgz",
-          "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -6116,9 +6100,9 @@
       "dev": true
     },
     "flow-parser": {
-      "version": "0.73.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.73.0.tgz",
-      "integrity": "sha512-9JB+2hrKJ+S1OZ+upIwNTGlaLDRga2iC9KvpqWVFEVNlCxc51pkhNJRmA0PmUcLcEtFAW6IGBmVi70r+j+Qp9A==",
+      "version": "0.75.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.75.0.tgz",
+      "integrity": "sha512-QEyV/t9TERBOSI/zSx0zhKH6924135WPI7pMmug2n/n/4puFm4mdAq1QaKPA3IPhXDRtManbySkKhRqws5UUGA==",
       "dev": true
     },
     "flush-write-stream": {
@@ -6252,8 +6236,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6271,13 +6254,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6290,18 +6271,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6404,8 +6382,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6415,7 +6392,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6428,20 +6404,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6458,7 +6431,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6531,8 +6503,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6542,7 +6513,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6618,8 +6588,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6649,7 +6618,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6667,7 +6635,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6706,13 +6673,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -9108,6 +9073,18 @@
         "immediate": "~3.0.5"
       }
     },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
+    "linguist-languages": {
+      "version": "6.2.1-dev.20180706",
+      "resolved": "https://registry.npmjs.org/linguist-languages/-/linguist-languages-6.2.1-dev.20180706.tgz",
+      "integrity": "sha512-WtA9HA8SJZnDNUb4MKAyVVhRHGV2SyextyMHea+kWXM7eMZabnsABm971cc3lVOohKDElFvxsVRo+svglNmx0A==",
+      "dev": true
+    },
     "linkify-it": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
@@ -9265,8 +9242,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "longest-streak": {
       "version": "2.0.2",
@@ -11344,9 +11320,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.1.tgz",
-      "integrity": "sha512-c6M68yZX0bWnZ0GcX8duWcfweGeGQvYgw6w4xksRePDmrpCrLMqneN07xwce17ACWBAr0S+DoI0T31axZ21TKg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.2.tgz",
+      "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
       "requires": {
         "chalk": "^2.4.1",
         "source-map": "^0.6.1",
@@ -11605,12 +11581,12 @@
       }
     },
     "postcss-scss": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.5.tgz",
-      "integrity": "sha512-gJB1tKYMkBy0MU+COt6WXA4ZiRctAKoWLa6qD7a6bbEbBMqrpa/BhfQdN80eYMV+JkKddZVEpZlOggnGShpvyg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.6.tgz",
+      "integrity": "sha512-4EFYGHcEw+H3E06PT/pQQri06u/1VIIPjeJQaM8skB80vZuXMhp4cSNV5azmdNkontnOID/XYWEvEEELLFB1ww==",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.21"
+        "postcss": "^6.0.23"
       },
       "dependencies": {
         "postcss": {
@@ -11683,11 +11659,11 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "prettier": {
-      "version": "github:Automattic/wp-prettier#d1b87d900ae80351a8551b97037b7fb638b9e739",
-      "from": "github:Automattic/wp-prettier#wp-prettier-1.13.5",
+      "version": "github:Automattic/wp-prettier#d3a1056dd8bc8b3c8194790a044b37fc4e983ae3",
+      "from": "github:Automattic/wp-prettier#wp-prettier-1.14.0",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.49",
+        "@babel/code-frame": "7.0.0-beta.46",
         "@babel/parser": "7.0.0-beta.49",
         "@glimmer/syntax": "0.30.3",
         "camelcase": "4.1.0",
@@ -11704,48 +11680,52 @@
         "esutils": "2.0.2",
         "find-parent-dir": "0.3.0",
         "find-project-root": "1.1.1",
-        "flow-parser": "0.73.0",
+        "flow-parser": "0.75.0",
         "get-stream": "3.0.0",
         "globby": "6.1.0",
         "graphql": "0.13.2",
         "html-tag-names": "1.1.2",
         "ignore": "3.3.7",
-        "jest-docblock": "22.2.2",
+        "jest-docblock": "23.2.0",
         "json-stable-stringify": "1.0.1",
         "leven": "2.1.0",
+        "linguist-languages": "6.2.1-dev.20180706",
         "lodash.uniqby": "4.7.0",
         "mem": "1.1.0",
         "minimatch": "3.0.4",
         "minimist": "1.2.0",
+        "normalize-path": "3.0.0",
         "parse5": "3.0.3",
         "postcss-less": "1.1.5",
         "postcss-media-query-parser": "0.2.3",
-        "postcss-scss": "1.0.5",
+        "postcss-scss": "1.0.6",
         "postcss-selector-parser": "2.2.3",
         "postcss-values-parser": "1.5.0",
         "remark-parse": "5.0.0",
         "resolve": "1.5.0",
         "semver": "5.4.1",
         "string-width": "2.1.1",
-        "typescript": "2.9.0-dev.20180421",
-        "typescript-eslint-parser": "16.0.0",
+        "typescript": "3.0.0-dev.20180626",
+        "typescript-eslint-parser": "17.0.0",
         "unicode-regex": "1.0.1",
-        "unified": "6.1.6"
+        "unified": "6.1.6",
+        "yaml": "1.0.0-rc.7",
+        "yaml-unist-parser": "1.0.0-rc.2"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.49.tgz",
-          "integrity": "sha1-vs2AVIJzREDJ0TfkbXc0DmTX9Rs=",
+          "version": "7.0.0-beta.46",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz",
+          "integrity": "sha512-7BKRkmYaPZm3Yff5HGZJKCz7RqZ5jUjknsXT6Gz5YKG23J3uq9hAj0epncCB0rlqmnZ8Q+UUpQB2tCR5mT37vw==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "7.0.0-beta.49"
+            "@babel/highlight": "7.0.0-beta.46"
           }
         },
         "@babel/highlight": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.49.tgz",
-          "integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
+          "version": "7.0.0-beta.46",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.46.tgz",
+          "integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
           "dev": true,
           "requires": {
             "chalk": "^2.0.0",
@@ -11813,19 +11793,16 @@
           "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
           "dev": true
         },
-        "jest-docblock": {
-          "version": "22.2.2",
-          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.2.2.tgz",
-          "integrity": "sha512-ymqH4vzNMA0BrRfbDfQ6+b/AI0FLwuEAjBa87HUcuIz0UN76zH+Qw7lpDvhELzNmxu1EfxP9cxMRnVgkHZ7vyA==",
-          "dev": true,
-          "requires": {
-            "detect-newline": "^2.1.0"
-          }
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
           "dev": true
         },
         "parse-json": {
@@ -14149,9 +14126,9 @@
       }
     },
     "stream-each": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
-      "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
+      "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
       "requires": {
         "end-of-stream": "^1.1.0",
         "stream-shift": "^1.0.0"
@@ -14175,9 +14152,9 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "string-kit": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/string-kit/-/string-kit-0.7.13.tgz",
-      "integrity": "sha512-0I+gHF5w8nXqTtkUyQb39TeK+Ppzq5KnlUfh4n4BSyRDMBUAYMBiKtzgDBpBOMxo5X4TaczvqiQlgTHp0Y+hRA==",
+      "version": "0.7.16",
+      "resolved": "https://registry.npmjs.org/string-kit/-/string-kit-0.7.16.tgz",
+      "integrity": "sha512-AAy27UvfoScfDMDM12XlrJRJH8Cn+lKNjmzltxsYy5EMig0n1B0ErV3xm6rlikUkzh3R6IlM8WWzSPcQhIFI1Q==",
       "dev": true,
       "requires": {
         "xregexp": "^4.1.1"
@@ -15433,15 +15410,15 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.9.0-dev.20180421",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.0-dev.20180421.tgz",
-      "integrity": "sha512-Kkny/jcMLwNNPcAc8y74ql0d5O88v5FHzQzN9EuFskYPqs3Ynl2TV1KJr5DGTXtCjKmo2ZKIuTdq5zmVWK8Q+Q==",
+      "version": "3.0.0-dev.20180626",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.0-dev.20180626.tgz",
+      "integrity": "sha512-OQH9osIC4CdsVzVvsb2RenRTVPRKwSIMIpRy2J42XNOEUP+vhX56BX1Z47K3l//LEGY0xG7zF7qVKCDlUhhrlg==",
       "dev": true
     },
     "typescript-eslint-parser": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-16.0.0.tgz",
-      "integrity": "sha512-ZYYVKlHWR/RMvTCah4WfrZclb2azZipW4sbaYLJjbh6jiYn81tLUZAw/WdVLlXxaCbIawaKCA44AJPMFVArKZQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-17.0.0.tgz",
+      "integrity": "sha512-PB+iHjKbL0Lb51xBvEQOckUKzhozHjYPVeNj85ne9tpU5dZNLnHw/hlPxHnYGA5OCG+GO6jL25nQwC75AAtyhw==",
       "dev": true,
       "requires": {
         "lodash.unescape": "4.0.1",
@@ -16784,6 +16761,22 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yaml": {
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.0.0-rc.7.tgz",
+      "integrity": "sha512-tsTvdZxHPSgwv70qw0w2YeGA8VCqEpHRlYLb3T3ROhke8j92iC3t7kd2XHkiyp7pvxucKUgzzo+3Zq77WV82Kw==",
+      "dev": true
+    },
+    "yaml-unist-parser": {
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/yaml-unist-parser/-/yaml-unist-parser-1.0.0-rc.2.tgz",
+      "integrity": "sha512-6v47SuXaVlXdfEZ3OuqKSFqgynnKpAoy02i62kieGTdLU0N56iIAAGjGfzBcuOe6yDWArd1ZtgtjrD6LPK2Abg==",
+      "dev": true,
+      "requires": {
+        "lines-and-columns": "^1.1.6",
+        "tslib": "^1.9.1"
+      }
     },
     "yargs": {
       "version": "12.0.1",

--- a/package.json
+++ b/package.json
@@ -274,7 +274,7 @@
     "mixedindentlint": "1.2.0",
     "nock": "8.2.2",
     "npm-merge-driver": "2.3.5",
-    "prettier": "github:Automattic/wp-prettier#wp-prettier-1.13.5",
+    "prettier": "github:Automattic/wp-prettier#wp-prettier-1.14.0",
     "pretty-bytes": "5.1.0",
     "react-test-renderer": "16.4.1",
     "readline-sync": "1.4.9",


### PR DESCRIPTION
Prettier 1.14.0 was released [less than 24 hours ago](https://prettier.io/blog/2018/07/29/1.14.0.html) and here is a PR with an update of the WordPress fork :wink:

Changes in formatting are:

**More line breaks in JSX**
This JSX which used to be one line:
```jsx
<p><b>one</b>two<b>three</b>four</p>
```
is now broken into multiple lines:
```jsx
<p>
  <b>one</b>
  two
  <b>three</b>
  four
</p>
```

**Loops in JSX break into multiple lines**
This JSX:
```jsx
<ul>
  { items.map( item => <li>{ item.text }</li> ) }
</ul>
```
now breaks to make the loop stand out:
```jsx
<ul>
  { items.map( item => (
    <li>{ item.text }</li>
  ) ) }
</ul>
```

**Function's first argument doesn't group if the second one is a function**
Function arguments are sometimes "grouped" with fewer line breaks:
```js
createSelector( state => {
  return something;
}, state => state.posts );
```
Now, if the second argument is a function, this grouping is no longer performed and there is a regular line break:
```js
createSelector(
  state => {
    return something;
  },
  state => state.posts
);
```

**How to test:**
Special mission for @sirreal: if you can, please test the SCSS pragma issue that was mentioned in https://github.com/Automattic/wp-calypso/pull/24906#issuecomment-396833896
