### PR TITLE
Domains: Missed a case when the start date isn't set

### DIFF
--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -913,8 +913,7 @@ export class DomainWarnings extends React.PureComponent {
 				break;
 			case transferStatus.PENDING_REGISTRY:
 				message = translate(
-					'The transfer of {{strong}}%(domain)s{{/strong}} is in progress. ' +
-						'It should complete by %(transferFinishDate)s. We are waiting ' +
+					'The transfer of {{strong}}%(domain)s{{/strong}} is in progress. We are waiting ' +
 						'for authorization from your current domain provider to proceed. {{a}}Learn more{{/a}}',
 					{
 						components: {
@@ -929,10 +928,33 @@ export class DomainWarnings extends React.PureComponent {
 						},
 						args: {
 							domain: domainInTransfer.name,
-							transferFinishDate: domainInTransfer.transferEndDateMoment.format( 'LL' ),
 						},
 					}
 				);
+
+				if ( domainInTransfer.transferEndDateMoment ) {
+					message = translate(
+						'The transfer of {{strong}}%(domain)s{{/strong}} is in progress. ' +
+							'It should complete by %(transferFinishDate)s. We are waiting ' +
+							'for authorization from your current domain provider to proceed. {{a}}Learn more{{/a}}',
+						{
+							components: {
+								strong: <strong />,
+								a: (
+									<a
+										href={ INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS }
+										rel="noopener noreferrer"
+										target="_blank"
+									/>
+								),
+							},
+							args: {
+								domain: domainInTransfer.name,
+								transferFinishDate: domainInTransfer.transferEndDateMoment.format( 'LL' ),
+							},
+						}
+					);
+				}
 				break;
 			case transferStatus.PENDING_START:
 				compactMessage = translate( 'Domain transfer waiting' );

--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -52,16 +52,27 @@ class Transfer extends React.PureComponent {
 				<Notice status={ 'is-info' } showDismiss={ false }>
 					{ translate(
 						'This transfer has been started and is waiting for authorization from your current provider. ' +
-							'It should complete by %(transferFinishDate)s. ' +
-							'If you need to cancel the transfer, please contact them for assistance.',
-						{
-							args: {
-								transferFinishDate: domain.transferEndDateMoment.format( 'LL' ),
-							},
-						}
+							'If you need to cancel the transfer, please contact them for assistance.'
 					) }
 				</Notice>
 			);
+
+			if ( domain.transferEndDateMoment ) {
+				transferNotice = (
+					<Notice status={ 'is-info' } showDismiss={ false }>
+						{ translate(
+							'This transfer has been started and is waiting for authorization from your current provider. ' +
+								'It should complete by %(transferFinishDate)s. ' +
+								'If you need to cancel the transfer, please contact them for assistance.',
+							{
+								args: {
+									transferFinishDate: domain.transferEndDateMoment.format( 'LL' ),
+								},
+							}
+						) }
+					</Notice>
+				);
+			}
 		} else {
 			cancelNavItem = (
 				<VerticalNav>


### PR DESCRIPTION
As we don't prefill `startDate` for already started transfers, we need the default message there: https://github.com/Automattic/wp-calypso/pull/26326

To test:
- Set https://github.com/Automattic/wp-calypso/pull/26326/files#diff-f185e2d244eed9a7794bcc7d9f8e3c71R79 to null
- Open a transfer
- See proper message
- Set the date
- See proper message again