### PR TITLE
SDK: Add Jetpack publicize extension

### DIFF
--- a/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
+++ b/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
@@ -10,11 +10,15 @@
  */
 
 /**
- * Internal dependencies
+ * External Dependencies
+ */
+import wp from 'wp';
+
+/**
+ * Module variables
  */
 const {
 	gutenberg_publicize_setup,
-	wp,
 	ajaxurl,
 	$,
 } = window;

--- a/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
+++ b/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
@@ -1,0 +1,87 @@
+/**
+ * Data access functions for Publicizing in Gutenberg.
+ *
+ * This file contains a set of helper functions that
+ * gather data and/or send requests for data to support
+ * the features of Publicize in Gutenberg.
+ *
+ * @file Data access functions for Gutenberg Publicize extension.
+ * @since  5.9.1
+ */
+
+/**
+ * Internal dependencies
+ */
+const {
+	gutenberg_publicize_setup,
+	wp,
+	ajaxurl,
+} = window;
+
+/**
+ * Get connection form set up data.
+ *
+ * Retrieves array of filtered connection UI data (labels, checked value,
+ * URLs, etc.) from window global. This data only updates on refresh.
+ *
+ * @see ui.php
+ *
+ * @since 5.9.1
+ *
+ * @return {object} List of filtered connection UI data.
+ */
+export function getStaticPublicizeConnections() {
+	return JSON.parse( gutenberg_publicize_setup.staticConnectionList );
+}
+
+/**
+ * Get up-to-date connection list data for post.
+ *
+ * Retrieves array of filtered connection UI data (labels, checked value).
+ * Connection list is queried based on post id because the connection
+ * filtering depends on current post.
+ *
+ * @see ui.php
+ *
+ * @since 5.9.1
+ *
+ * @param {integer} postId ID of post to query connection defaults for.
+ *
+ * @return {Promise} Promise for connection request.
+ */
+export function requestPublicizeConnections( postId ) {
+	return wp.apiRequest( {
+		path: '/publicize/posts/' + postId.toString() + '/connections',
+		contentType: 'application/json',
+		dataType: 'json',
+		processData: false,
+		method: 'GET',
+	} );
+}
+
+/**
+ * Gets list of all possible connections.
+ *
+ * Gets list of possible social sites ('twitter', 'facebook, etc..')
+ *
+ * @since 5.9.1
+ *
+ * @return {object} List of possible services that can be connected to
+ */
+export function getAllConnections() {
+	return JSON.parse( gutenberg_publicize_setup.allServices );
+}
+
+/**
+ * Verifies that all connections are still functioning.
+ *
+ * Ajax request handled by 'wp_ajax_test_publicize_conns' action
+ * in {@see publicize.php}.
+ *
+ * @since 5.9.1
+ *
+ * @return {object} List of possible services that can be connected to
+ */
+export function requestTestPublicizeConnections() {
+	return $.post( ajaxurl, { action: 'test_publicize_conns' } );
+}

--- a/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
+++ b/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
@@ -16,6 +16,7 @@ const {
 	gutenberg_publicize_setup,
 	wp,
 	ajaxurl,
+	$,
 } = window;
 
 /**

--- a/client/gutenberg/extensions/publicize/publicize-connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-connection-verify.jsx
@@ -10,6 +10,10 @@
  * @since  5.9.1
  */
 
+// Since this is a Jetpack originated block in Calypso codebase,
+// we're relaxing className rules.
+/* eslint wpcalypso/jsx-classname-namespace: 0 */
+
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/publicize/publicize-connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-connection-verify.jsx
@@ -18,12 +18,17 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import wp from 'wp';
 
 /**
  * Internal dependencies
  */
 import { requestTestPublicizeConnections } from './async-publicize-lib';
-const { __ } = window.wp.i18n;
+
+/**
+ * Module variables
+ */
+const { __ } = wp.i18n;
 
 class PublicizeConnectionVerify extends Component {
 	constructor( props ) {

--- a/client/gutenberg/extensions/publicize/publicize-connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-connection-verify.jsx
@@ -1,0 +1,122 @@
+/**
+ * Publicize connections verification component.
+ *
+ * Component to create Ajax request to check
+ * all connections. If any connection tests failed,
+ * a refresh link may be provided to the user. If
+ * no connection tests fail, this component will
+ * not render anything.
+ *
+ * @since  5.9.1
+ */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { requestTestPublicizeConnections } from './async-publicize-lib';
+const { __ } = window.wp.i18n;
+
+class PublicizeConnectionVerify extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			failedConnections: {},
+			isLoading: false,
+		};
+	}
+
+	/**
+	 * Callback for connection test request
+	 *
+	 * Receives results of connection request and
+	 * updates component state to display potentially
+	 * failed connections.
+	 *
+	 * @since 5.9.1
+	 *
+	 * @param {object} response Response from ajax action 'wp_ajax_test_publicize_conns' {@see publicize.php}
+	 */
+	connectionTestComplete = ( response ) => {
+		const failureList = response.data.filter( connection => ( ! connection.connectionTestPassed ) );
+		this.setState( {
+			failedConnections: failureList,
+			isLoading: false,
+		} );
+	}
+
+	/**
+	 * Starts request to check connections
+	 *
+	 * Checks connections with ajax action 'wp_ajax_test_publicize_conns'
+	 *
+	 * @see publicize.php
+	 *
+	 * @since 5.9.1
+	 */
+	connectionTestStart = () => {
+		requestTestPublicizeConnections().then(
+			() => this.connectionTestComplete
+		);
+	};
+
+	/**
+	 * Opens up popup so user can refresh connection
+	 *
+	 * Displays pop up with to specified URL where user
+	 * can refresh a specific connection.
+	 *
+	 * @since 5.9.1
+	 *
+	 * @param {object} event Event instance for onClick.
+	 */
+	refreshConnectionClick = ( event ) => {
+		const { href, title } = event.target;
+		event.preventDefault();
+		// open a popup window
+		// when it is closed, kick off the tests again
+		const popupWin = window.open( href, title, '' );
+		window.setInterval( () => {
+			if ( false !== popupWin.closed ) {
+				this.connectionTestStart();
+			}
+		}, 500 );
+	}
+
+	componentDidMount() {
+		this.connectionTestStart();
+	}
+
+	render() {
+		const { failedConnections } = this.state;
+		if ( failedConnections.length > 0 ) {
+			return (
+				<div className="below-h2 error publicize-token-refresh-message">
+					<p key="error-title">{ __( 'Before you hit Publish, please refresh the following connection(s) to make sure we can Publicize your post:' ) }</p>
+					{ failedConnections.filter( c => c.userCanRefresh ).map( c =>
+						<a
+							className="pub-refresh-button button"
+							title={ c.refreshText }
+							href={ c.refreshURL }
+							target={ '_refresh_' + c.serviceName }
+							onClick={ this.refreshConnectionClick }
+							key={ c.connectionID }
+
+						>
+							{ c.refreshText }
+						</a>
+					) }
+
+				</div>
+			);
+		}
+		return null;
+	}
+}
+
+export default PublicizeConnectionVerify;
+

--- a/client/gutenberg/extensions/publicize/publicize-connection.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-connection.jsx
@@ -16,9 +16,12 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-const {
-	FormToggle,
-} = window.wp.components;
+import wp from 'wp';
+
+/**
+ * Module variables
+ */
+const { FormToggle } = wp.components;
 
 class PublicizeConnection extends Component {
 	/**

--- a/client/gutenberg/extensions/publicize/publicize-connection.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-connection.jsx
@@ -7,6 +7,11 @@
  * @since  5.9.1
  */
 
+// Since this is a Jetpack originated block in Calypso codebase,
+// we're relaxing className and some accessibility rules.
+/* eslint wpcalypso/jsx-classname-namespace: 0 */
+/* eslint jsx-a11y/label-has-for: 0 */
+
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/publicize/publicize-connection.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-connection.jsx
@@ -1,0 +1,71 @@
+/**
+ * Publicize connection form component.
+ *
+ * Component to display connection label and a
+ * checkbox to enable/disable the connection for sharing.
+ *
+ * @since  5.9.1
+ */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+const {
+	FormToggle,
+} = window.wp.components;
+
+class PublicizeConnection extends Component {
+	/**
+	 * Handler for when connection is enabled/disabled.
+	 *
+	 * Calls parent's change handler in this.prop so
+	 * state change can be handled by parent.
+	 *
+	 * @since 5.9.1
+	 */
+	onConnectionChange = () => {
+		const { unique_id } = this.props.connectionData;
+		const { connectionChange, connectionOn } = this.props;
+		connectionChange( {
+			connectionID: unique_id,
+			shouldShare: ! connectionOn,
+		} );
+	}
+
+	render() {
+		const {
+			name,
+			label,
+			disabled,
+			display_name,
+		} = this.props.connectionData;
+		const { connectionOn } = this.props;
+		// Genericon names are dash separated
+		const socialName = name.replace( '_', '-' );
+
+		return (
+			<li>
+				<div className="publicize-jetpack-connection-container">
+					<label htmlFor={ label }className="jetpack-publicize-connection-label">
+						<span
+							title={ label }
+							className={ 'jetpack-publicize-gutenberg-social-icon social-logo social-logo__' + socialName }
+						>
+						</span>
+						<span>{ display_name }</span>
+					</label>
+					<FormToggle
+						id={ label }
+						className="jetpack-publicize-connection-toggle"
+						checked={ connectionOn }
+						onChange={ this.onConnectionChange }
+						disabled={ disabled }
+					/>
+				</div>
+			</li>
+		);
+	}
+}
+
+export default PublicizeConnection;

--- a/client/gutenberg/extensions/publicize/publicize-form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-form-unwrapped.jsx
@@ -19,13 +19,18 @@
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import isNil from 'lodash/isNil';
+import wp from 'wp';
 
 /**
  * Internal dependencies
  */
-const { __, _n, sprintf } = window.wp.i18n;
 import PublicizeConnection from './publicize-connection';
 import PublicizeSettingsButton from './publicize-settings-button';
+
+/**
+ * Module variables
+ */
+const { __, _n, sprintf } = wp.i18n;
 
 class PublicizeFormUnwrapped extends Component {
 	constructor( props ) {

--- a/client/gutenberg/extensions/publicize/publicize-form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-form-unwrapped.jsx
@@ -8,6 +8,11 @@
  * @since  5.9.1
  */
 
+// Since this is a Jetpack originated block in Calypso codebase,
+// we're relaxing className and some accessibility rules.
+/* eslint wpcalypso/jsx-classname-namespace: 0 */
+/* eslint jsx-a11y/label-has-for: 0 */
+
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/publicize/publicize-form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-form-unwrapped.jsx
@@ -1,0 +1,131 @@
+/**
+ * Publicize sharing form component.
+ *
+ * Displays text area and connection list to allow user
+ * to select connections to share to and write a custom
+ * sharing message.
+ *
+ * @since  5.9.1
+ */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import classnames from 'classnames';
+import isNil from 'lodash/isNil';
+
+/**
+ * Internal dependencies
+ */
+const { __, _n, sprintf } = window.wp.i18n;
+import PublicizeConnection from './publicize-connection';
+import PublicizeSettingsButton from './publicize-settings-button';
+
+class PublicizeFormUnwrapped extends Component {
+	constructor( props ) {
+		super( props );
+		const { initializePublicize, staticConnections } = this.props;
+		const initialTitle = '';
+		// Connection data format must match 'publicize' REST field registered in {@see class-jetpack-publicize-gutenberg.php}.
+		const initialActiveConnections = staticConnections.map( ( c ) => {
+			return ( {
+				unique_id: c.unique_id,
+				should_share: c.checked,
+			} );
+		} );
+		initializePublicize( initialTitle, initialActiveConnections );
+	}
+
+	/**
+	 * Check to see if form should be disabled.
+	 *
+	 * Checks full connection list to determine if all are disabled.
+	 * If they all are, it returns true to disable whole form.
+	 *
+	 * @since 5.9.1
+	 *
+	 * @return {boolean} True if whole form should be disabled.
+	 */
+	isDisabled() {
+		const { staticConnections } = this.props;
+		// Check to see if at least one connection is not disabled
+		const formEnabled = staticConnections.some( c => ! c.disabled );
+		return ! formEnabled;
+	}
+
+	/**
+	 * Checks if a connection is turned on/off.
+	 *
+	 * Looks up connection by ID in activeConnections prop which is
+	 * an array of objects with properties 'unique_id' and 'should_share';
+	 * looks for an array entry with a 'unique_id' property that matches
+	 * the parameter value. If found, the connection 'should_share' value
+	 * is returned.
+	 *
+	 * @since 5.9.1
+	 *
+	 * @param {string} uniqueId Connection ID.
+	 * @return {boolean} True if the connection is currently switched on.
+	 */
+	isConnectionOn( uniqueId ) {
+		const { activeConnections } = this.props;
+		const matchingConnection = activeConnections.find( c => uniqueId === c.unique_id );
+		if ( isNil( matchingConnection ) ) {
+			return false;
+		}
+		return matchingConnection.should_share;
+	}
+
+	render() {
+		const {
+			staticConnections,
+			connectionChange,
+			messageChange,
+			shareMessage,
+			refreshCallback,
+		} = this.props;
+		const MAXIMUM_MESSAGE_LENGTH = 256;
+		const charactersRemaining = MAXIMUM_MESSAGE_LENGTH - shareMessage.length;
+		const characterCountClass = classnames(
+			'jetpack-publicize-character-count',
+			{ 'wpas-twitter-length-limit': ( charactersRemaining <= 0 ) }
+		);
+
+		return (
+			<div className="misc-pub-section misc-pub-section-last">
+				<div id="publicize-form">
+					<ul>
+						{staticConnections.map( c =>
+							<PublicizeConnection
+								connectionData={ c }
+								key={ c.unique_id }
+								connectionOn={ this.isConnectionOn( c.unique_id ) }
+								connectionChange={ connectionChange }
+							/>
+						) }
+					</ul>
+					<PublicizeSettingsButton refreshCallback={ refreshCallback } />
+					<label className="jetpack-publicize-message-note" htmlFor="wpas-title">
+						{ __( 'Customize your message' ) }
+					</label>
+					<div className="jetpack-publicize-message-box">
+						<textarea
+							value={ shareMessage }
+							onChange={ messageChange }
+							placeholder={ __( 'Publicize + Gutenberg :)' ) }
+							disabled={ this.isDisabled() }
+							maxLength={ MAXIMUM_MESSAGE_LENGTH }
+						/>
+						<div className={ characterCountClass }>
+							{ sprintf( _n( '%d character remaining', '%d characters remaining', charactersRemaining ), charactersRemaining ) }
+						</div>
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+export default PublicizeFormUnwrapped;
+

--- a/client/gutenberg/extensions/publicize/publicize-form.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-form.jsx
@@ -1,0 +1,116 @@
+/**
+ * Higher Order Publicize sharing form composition.
+ *
+ * Uses Gutenberg data API to dispatch publicize form data to
+ * editor post data in format to match 'publicize' field
+ * schema defined in {@see class-jetpack-publicize-gutenberg.php}
+ *
+ * @since  5.9.1
+ */
+
+/**
+ * External dependencies
+ */
+import { compose } from 'redux';
+import isNil from 'lodash/isNil';
+
+/**
+ * Internal dependencies
+ */
+const {
+	withSelect,
+	withDispatch,
+} = window.wp.data;
+import PublicizeFormUnwrapped from './publicize-form-unwrapped';
+
+const PublicizeForm = compose(
+	withSelect( ( select ) => ( {
+		activeConnections: ( isNil( select( 'core/editor' ).getEditedPostAttribute( 'publicize' ) ) )
+			? [] : select( 'core/editor' ).getEditedPostAttribute( 'publicize' ).connections,
+		shareMessage: ( isNil( select( 'core/editor' ).getEditedPostAttribute( 'publicize' ) ) )
+			? '' : select( 'core/editor' ).getEditedPostAttribute( 'publicize' ).title,
+	} ) ),
+	withDispatch( ( dispatch, ownProps ) => ( {
+		/**
+		 * Directly sets post's publicize data.
+		 *
+		 * Sets initial values for publicize data this saved with post. Field schema defined in
+		 * {@see class-jetpack-publicize-gutenberg.php}. Input parameters are used as defaults.
+		 * They will be ignored if the 'publicize' field has already been set. This prevents
+		 * user changes from being erased every time pre-publish panel is opened and closed.
+		 *
+		 * @since 5.9.1
+		 *
+		 * @param {string} initTitle             String to share post with
+		 * @param {array}  initActiveConnections Array of connection data {@see class-jetpack-publicize-gutenberg.php}
+		 */
+		initializePublicize( initTitle, initActiveConnections ) {
+			const {
+				activeConnections,
+				shareMessage,
+			} = ownProps;
+			const newConnections = ( activeConnections.length > 0 ) ? activeConnections : initActiveConnections;
+			const newTitle = ( shareMessage.length > 0 ) ? shareMessage : initTitle;
+			dispatch( 'core/editor' ).editPost( {
+				publicize: {
+					title: newTitle,
+					connections: newConnections,
+				}
+			} );
+		},
+
+		/**
+		 * Update state connection enable/disable state based on checkbox.
+		 *
+		 * Saves enable/disable value to connections property in editor
+		 * in field 'publicize'.
+		 *
+		 * @since 5.9.1
+		 *
+		 * @param {Object}  options              Top-level options parameter
+		 * @param {string}  options.connectionID ID of the connection being enabled/disabled
+		 * @param {boolean} options.shouldShare  True of connection should be shared to, false otherwise
+		 */
+		connectionChange( options ) {
+			const { connectionID, shouldShare } = options;
+			const { activeConnections, shareMessage } = ownProps;
+			// Copy array (simply mutating data would cause the component to not be updated).
+			const newConnections = activeConnections.slice( 0 );
+			newConnections.forEach( ( c ) => {
+				if ( c.unique_id === connectionID ) {
+					c.should_share = shouldShare;
+				}
+			} );
+			dispatch( 'core/editor' ).editPost( {
+				publicize: {
+					title: shareMessage,
+					connections: newConnections,
+				}
+			} );
+		},
+
+		/**
+		 * Handler for when sharing message is edited.
+		 *
+		 * Saves edited message to state and to the editor
+		 * in field 'publicize'.
+		 *
+		 * @since 5.9.1
+		 *
+		 * @param {object} event Change event data from textarea element.
+		 */
+		messageChange( event ) {
+			let { shareMessage } = ownProps;
+			const { activeConnections } = ownProps;
+			shareMessage = event.target.value;
+			dispatch( 'core/editor' ).editPost( {
+				publicize: {
+					title: shareMessage,
+					connections: activeConnections,
+				}
+			} );
+		}
+	} ) ),
+)( PublicizeFormUnwrapped );
+
+export default PublicizeForm;

--- a/client/gutenberg/extensions/publicize/publicize-form.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-form.jsx
@@ -13,15 +13,20 @@
  */
 import { compose } from 'redux';
 import isNil from 'lodash/isNil';
+import wp from 'wp';
 
 /**
  * Internal dependencies
  */
+import PublicizeFormUnwrapped from './publicize-form-unwrapped';
+
+/**
+ * Module variables
+ */
 const {
 	withSelect,
 	withDispatch,
-} = window.wp.data;
-import PublicizeFormUnwrapped from './publicize-form-unwrapped';
+} = wp.data;
 
 const PublicizeForm = compose(
 	withSelect( ( select ) => ( {

--- a/client/gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx
@@ -1,0 +1,36 @@
+/**
+ * Top-level Publicize plugin for Gutenberg editor.
+ *
+ * Hooks into Gutenberg's PluginPrePublishPanel
+ * to display Jetpack's Publicize UI in the pre-
+ * publish flow.
+ *
+ * @since  5.9.1
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+const { PluginPrePublishPanel } = window.wp.editPost.__experimental;
+const { registerPlugin } = window.wp.plugins;
+import PublicizePanel from './publicize-panel';
+import publicizeStore from './publicize-gutenberg-store';
+const { data } = window.wp;
+const { registerStore } = data;
+
+const PluginRender = () => (
+	<PluginPrePublishPanel>
+		<PublicizePanel />
+	</PluginPrePublishPanel>
+);
+
+registerPlugin( 'jetpack-publicize', {
+	render: PluginRender
+} );
+
+registerStore( 'jetpack/publicize', publicizeStore );

--- a/client/gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx
@@ -12,16 +12,21 @@
  * External dependencies
  */
 import React from 'react';
+import wp from 'wp';
 
 /**
  * Internal dependencies
  */
-const { PluginPrePublishPanel } = window.wp.editPost;
-const { registerPlugin } = window.wp.plugins;
 import PublicizePanel from './publicize-panel';
 import publicizeStore from './publicize-gutenberg-store';
-const { data } = window.wp;
+
+/**
+ * Module variables
+ */
+const { data } = wp;
 const { registerStore } = data;
+const { PluginPrePublishPanel } = wp.editPost;
+const { registerPlugin } = wp.plugins;
 
 const PluginRender = () => (
 	<PluginPrePublishPanel>

--- a/client/gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx
@@ -16,7 +16,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-const { PluginPrePublishPanel } = window.wp.editPost.__experimental;
+const { PluginPrePublishPanel } = window.wp.editPost;
 const { registerPlugin } = window.wp.plugins;
 import PublicizePanel from './publicize-panel';
 import publicizeStore from './publicize-gutenberg-store';

--- a/client/gutenberg/extensions/publicize/publicize-gutenberg-store.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-gutenberg-store.jsx
@@ -1,0 +1,112 @@
+/**
+ * Publicize store for connection data
+ *
+ * Implements reducer, actions, and selector
+ * for 'jetpack/publicize' store.
+ *
+ * @since  5.9.1
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getStaticPublicizeConnections } from './async-publicize-lib';
+
+const staticConnectionList = getStaticPublicizeConnections();
+
+const DEFAULT_STATE = {
+	connections: staticConnectionList,
+	isLoading: false,
+	didFail: false,
+};
+
+const publicizeStore = {
+	reducer( state = DEFAULT_STATE, action ) {
+		switch ( action.type ) {
+			case 'GET_CONNECTIONS_START':
+				return {
+					...state,
+					isLoading: true,
+					didFail: false,
+				};
+			case 'GET_CONNECTIONS_SUCCESS':
+				return {
+					...state,
+					isLoading: false,
+					didFail: false,
+					connections: action.result,
+				};
+			case 'GET_CONNECTIONS_FAIL':
+				return {
+					...state,
+					isLoading: false,
+					didFail: true,
+				};
+		}
+		return state;
+	},
+
+	actions: {
+		/**
+		 * Action function for when request for connections starts.
+		 *
+		 * @since 5.9.1
+		 * @return {Object} action type 'GET_CONNECTIONS_START['
+		 */
+		getConnectionsStart() {
+			return {
+				type: 'GET_CONNECTIONS_START',
+			};
+		},
+
+		/**
+		 * Action function for when connection request fails
+		 *
+		 * @since 5.9.1
+		 * @return {Object} action type 'GET_CONNECTIONS_FAIL'
+		 */
+		getConnectionsFail() {
+			return {
+				type: 'GET_CONNECTIONS_FAIL',
+			};
+		},
+
+		/**
+		 * Action function for when connection request finishes
+		 *
+		 * Updates component state in response to request finishing.
+		 *
+		 * @since 5.9.1
+		 *
+		 * @param {string} resultString JSON encoded result of connection request
+		 * @return {Object} action type and (maybe) decoded JSON connection list
+		 */
+		getConnectionsDone( resultString ) {
+			try {
+				const result = JSON.parse( resultString );
+				return {
+					type: 'GET_CONNECTIONS_SUCCESS',
+					result,
+				};
+			} catch ( e ) { // JSON parse fail.
+				return {
+					type: 'GET_CONNECTIONS_FAIL',
+				};
+			}
+		},
+	},
+
+	selectors: {
+		getConnections( state ) {
+			return state.connections;
+		},
+		getIsLoading( state ) {
+			return state.isLoading;
+		},
+		getDidFail( state ) {
+			return state.didFail;
+		},
+	},
+};
+
+export default publicizeStore;

--- a/client/gutenberg/extensions/publicize/publicize-gutenberg-store.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-gutenberg-store.jsx
@@ -12,6 +12,9 @@
  */
 import { getStaticPublicizeConnections } from './async-publicize-lib';
 
+/**
+ * Module variables
+ */
 const staticConnectionList = getStaticPublicizeConnections();
 
 const DEFAULT_STATE = {

--- a/client/gutenberg/extensions/publicize/publicize-no-connections.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-no-connections.jsx
@@ -8,6 +8,10 @@
  * @since  5.9.1
  */
 
+// Since this is a Jetpack originated block in Calypso codebase,
+// we're relaxing className rules.
+/* eslint wpcalypso/jsx-classname-namespace: 0 */
+
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/publicize/publicize-no-connections.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-no-connections.jsx
@@ -16,12 +16,17 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import wp from 'wp';
 
 /**
  * Internal dependencies
  */
-const { __, sprintf } = window.wp.i18n;
 import { getAllConnections } from './async-publicize-lib';
+
+/**
+ * Module variables
+ */
+const { __, sprintf } = wp.i18n;
 
 class PublicizeNoConnections extends Component {
 	constructor( props ) {

--- a/client/gutenberg/extensions/publicize/publicize-no-connections.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-no-connections.jsx
@@ -1,0 +1,82 @@
+/**
+ * Publicize no connections info component.
+ *
+ * Displays notification if there are no connected
+ * social accounts, and includes a list of links to
+ * connect specific services.
+ *
+ * @since  5.9.1
+ */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+const { __, sprintf } = window.wp.i18n;
+import { getAllConnections } from './async-publicize-lib';
+
+class PublicizeNoConnections extends Component {
+	constructor( props ) {
+		super( props );
+		const allConnections = getAllConnections();
+		this.state = {
+			allConnections: allConnections,
+		};
+	}
+
+	/**
+	 * Opens up popup so user can view/modify the associated connection
+	 *
+	 * @since 5.9.1
+	 *
+	 * @param {object} event Event instance for onClick.
+	 */
+	connectionClick = ( event ) => {
+		const href = event.target.getAttribute( 'href' );
+		const { refreshCallback } = this.props;
+		event.preventDefault();
+		/**
+		 * Open a popup window, and
+		 * when it is closed, refresh connections
+		 */
+		const popupWin = window.open( href, '', '' );
+		const popupTimer = window.setInterval( () => {
+			if ( false !== popupWin.closed ) {
+				window.clearInterval( popupTimer );
+				refreshCallback();
+			}
+		}, 500 );
+	}
+
+	render() {
+		const { allConnections } = this.state;
+		return (
+			<div>
+				<strong>{ __( 'Connect social accounts to share post: ' ) }</strong>
+				<br />
+				<ul className="not-connected">
+					{ allConnections.map( c =>
+						<li key={ c.name }>
+							<a
+								className="pub-service"
+								key={ c.name }
+								title={ sprintf( __( 'Connect and share your posts on %s' ), c.label ) }
+								href={ c.url }
+								onClick={ this.connectionClick }
+							>
+								{ c.label }
+							</a>
+						</li>
+					) }
+				</ul>
+			</div>
+		);
+	}
+}
+
+export default PublicizeNoConnections;
+

--- a/client/gutenberg/extensions/publicize/publicize-panel.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-panel.jsx
@@ -1,0 +1,98 @@
+/**
+ * Publicize sharing panel component.
+ *
+ * Displays Publicize notifications if no
+ * services are connected or displays form if
+ * services are connected.
+ *
+ * {@see publicize.php/save_meta()}
+ *
+ * @since  5.9.1
+ */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { compose } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import {
+	requestPublicizeConnections,
+} from './async-publicize-lib';
+import PublicizeNoConnections from './publicize-no-connections';
+const {
+	withSelect,
+	withDispatch,
+} = window.wp.data;
+
+import PublicizeForm from './publicize-form';
+import PublicizeConnectionVerify from './publicize-connection-verify';
+const { __ } = window.wp.i18n;
+const { PanelBody } = window.wp.components;
+
+class PublicizePanel extends Component {
+	constructor( props ) {
+		super( props );
+	}
+
+	componentDidMount() {
+		const { getConnectionsStart } = this.props;
+		getConnectionsStart();
+	}
+
+	render() {
+		const { connections, isLoading, getConnectionsStart } = this.props;
+		const refreshText = isLoading ? __( 'Refreshing…' ) : __( 'Refresh connections' );
+		return (
+			<PanelBody
+				initialOpen={ true }
+				id="publicize-title"
+				title={
+					<span id="publicize-defaults" key="publicize-title-span">
+						{ __( 'Share this post' ) }
+					</span>
+				}
+			>
+				<div>{ __( 'Connect and select social media services to share this post.' ) }</div>
+				{ ( connections.length > 0 ) && <PublicizeForm staticConnections={ connections } refreshCallback={ getConnectionsStart } /> }
+				{ ( 0 === connections.length ) && <PublicizeNoConnections refreshCallback={ getConnectionsStart } /> }
+				<a tabIndex="0" onClick={ getConnectionsStart } disabled={ isLoading }>
+					{ refreshText }
+				</a>
+				{ ( connections.length > 0 ) && <PublicizeConnectionVerify /> }
+			</PanelBody>
+		);
+	}
+}
+
+export default PublicizePanel = compose(
+	withSelect( ( select ) => ( {
+		connections: select( 'jetpack/publicize' ).getConnections(),
+		isLoading: select( 'jetpack/publicize' ).getIsLoading(),
+		postId: select( 'core/editor' ).getCurrentPost().id,
+	} ) ),
+	withDispatch( ( dispatch, ownProps ) => ( {
+		getConnectionsDone: dispatch( 'jetpack/publicize' ).getConnectionsDone,
+		getConnectionsFail: dispatch( 'jetpack/publicize' ).getConnectionsFail,
+		/**
+		 * Starts request for current list of connections.
+		 *
+		 * @since 5.9.1
+		 */
+		getConnectionsStart() {
+			const { postId } = ownProps;
+			const {
+				getConnectionsDone,
+				getConnectionsFail,
+			} = dispatch( 'jetpack/publicize' );
+			dispatch( 'jetpack/publicize' ).getConnectionsStart();
+			requestPublicizeConnections( postId ).then(
+				( result ) => getConnectionsDone( result ),
+				() => getConnectionsFail(),
+			);
+		},
+	} ) ),
+)( PublicizePanel );

--- a/client/gutenberg/extensions/publicize/publicize-panel.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-panel.jsx
@@ -10,6 +10,13 @@
  * @since  5.9.1
  */
 
+// Since this is a Jetpack originated block in Calypso codebase,
+// we're relaxing some accessibility rules.
+/* eslint jsx-a11y/anchor-is-valid: 0 */
+/* eslint jsx-a11y/click-events-have-key-events: 0 */
+/* eslint jsx-a11y/no-static-element-interactions: 0 */
+/* eslint jsx-a11y/no-noninteractive-tabindex: 0 */
+
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/publicize/publicize-panel.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-panel.jsx
@@ -22,23 +22,25 @@
  */
 import React, { Component } from 'react';
 import { compose } from 'redux';
+import wp from 'wp';
 
 /**
  * Internal dependencies
  */
-import {
-	requestPublicizeConnections,
-} from './async-publicize-lib';
+import PublicizeConnectionVerify from './publicize-connection-verify';
+import PublicizeForm from './publicize-form';
 import PublicizeNoConnections from './publicize-no-connections';
+import { requestPublicizeConnections } from './async-publicize-lib';
+
+/**
+ * Module variables
+ */
 const {
 	withSelect,
 	withDispatch,
-} = window.wp.data;
-
-import PublicizeForm from './publicize-form';
-import PublicizeConnectionVerify from './publicize-connection-verify';
-const { __ } = window.wp.i18n;
-const { PanelBody } = window.wp.components;
+} = wp.data;
+const { __ } = wp.i18n;
+const { PanelBody } = wp.components;
 
 class PublicizePanel extends Component {
 	constructor( props ) {

--- a/client/gutenberg/extensions/publicize/publicize-settings-button.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-settings-button.jsx
@@ -1,0 +1,65 @@
+/**
+ * Publicize settings button component.
+ *
+ * Component which allows user to click to open settings
+ * in a new window/tab. If window/tab is closed, then
+ * connections will be automatically refreshed.
+ *
+ * @since  5.9.1
+ */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+const { __ } = window.wp.i18n;
+
+class PublicizeSettingsButton extends Component {
+	/**
+	 * Opens up popup so user can view/modify connections
+	 *
+	 * @since 5.9.1
+	 *
+	 * @param {object} event Event instance for onClick.
+	 */
+	settingsClick = ( event ) => {
+		const href = 'options-general.php?page=sharing&publicize_popup=true';
+		const { refreshCallback } = this.props;
+		event.preventDefault();
+		/**
+		 * Open a popup window, and
+		 * when it is closed, refresh connections
+		 */
+		const popupWin = window.open( href, '', '' );
+		const popupTimer = window.setInterval( () => {
+			if ( false !== popupWin.closed ) {
+				window.clearInterval( popupTimer );
+				refreshCallback();
+			}
+		}, 500 );
+	}
+
+	render() {
+		return (
+			<div className="jetpack-publicize-add-connection-container">
+				<span
+					className="jetpack-publicize-add-icon dashicons-plus-alt"
+				>
+				</span>
+				<a
+					onClick={ this.settingsClick }
+					tabIndex="0"
+				>
+					{ __( 'Connect another service' ) }
+				</a>
+			</div>
+		);
+	}
+}
+
+export default PublicizeSettingsButton;
+

--- a/client/gutenberg/extensions/publicize/publicize-settings-button.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-settings-button.jsx
@@ -8,6 +8,14 @@
  * @since  5.9.1
  */
 
+// Since this is a Jetpack originated block in Calypso codebase,
+// we're relaxing className and some accessibility rules.
+/* eslint wpcalypso/jsx-classname-namespace: 0 */
+/* eslint jsx-a11y/anchor-is-valid: 0 */
+/* eslint jsx-a11y/click-events-have-key-events: 0 */
+/* eslint jsx-a11y/no-static-element-interactions: 0 */
+/* eslint jsx-a11y/no-noninteractive-tabindex: 0 */
+
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/publicize/publicize-settings-button.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-settings-button.jsx
@@ -20,11 +20,12 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import wp from 'wp';
 
 /**
- * Internal dependencies
+ * Module variables
  */
-const { __ } = window.wp.i18n;
+const { __ } = wp.i18n;
 
 class PublicizeSettingsButton extends Component {
 	/**


### PR DESCRIPTION
This PR adds the Jetpack **Publicize** extension to the set of Gutenberg extensions, based on the previous work done by @c-shultz in: https://github.com/Automattic/jetpack/pull/9934.

The code hasn't been edited yet - the idea is to be able to build it in Calypso and use it directly in Jetpack as a Gutenberg plugin. The only critical fix was the import of `PluginPrePublishPanel`, which is now in the public `edit-post` API (see https://github.com/WordPress/gutenberg/pull/6798). 

To test:
* Build the extension:
    ```
    npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx
    ```
* Copy the built file from: `client/gutenberg/extensions/publicize/build/publicize-editor.js` to Jetpack's folder - `modules/publicize/assets/block.js` (don't mind the file name we're using for now)
* Checkout `try/publicize-gutenberg-block-externally-built` branch in your Jetpack installation (see https://github.com/Automattic/jetpack/pull/9963).
* Make sure your user is connected to WP.com and is connected to at least one social network account.
* Start a new Gutenberg post, attempt to publish it.
* See the Publicize UI in the pre-publish panel; make sure it doesn't fatal Gutenberg, but ignore any cosmetic issues for now.

Fixes #26362.