### PR TITLE
SDK: Add view-script to Gutenberg build tool

### DIFF
--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -7,7 +7,6 @@
  */
 const chalk = require( 'chalk' );
 const path = require( 'path' );
-const spawnSync = require( 'child_process' ).spawnSync;
 const yargs = require( 'yargs' );
 
 /**
@@ -39,9 +38,16 @@ yargs
 				requiresArg: true,
 			},
 			'editor-script': {
-				description: 'Entry for editor side JavaScript file',
+				description: 'Entry for editor-side JavaScript file',
 				type: 'string',
 				required: true,
+				coerce: value => path.resolve( __dirname, '../', value ),
+				requiresArg: true,
+			},
+			'view-script': {
+				description: 'Entry for rendered-page-side JavaScript file',
+				type: 'string',
+				required: false,
 				coerce: value => path.resolve( __dirname, '../', value ),
 				requiresArg: true,
 			},

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -6,6 +6,7 @@
 const chalk = require( 'chalk' );
 const path = require( 'path' );
 const webpack = require( 'webpack' );
+const { isEmpty, negate, pickBy } = require( 'lodash' );
 
 const __rootDir = path.resolve( __dirname, '../../' );
 const CopyWebpackPlugin = require( path.resolve( __rootDir, 'server/bundler/copy-webpack-plugin' ) );
@@ -25,9 +26,10 @@ exports.compile = args => {
 		...{
 			context: __rootDir,
 			mode: options.mode,
-			entry: {
-				[ `${ name }-editor-script` ]: options.editorScript,
-			},
+			entry: pickBy( {
+				[ `${ name }-editor-script.js` ]: options.editorScript,
+				[ `${ name }-view-script.js` ]: options.viewScript,
+			}, negate( isEmpty ) ),
 			externals: {
 				...baseConfig.externals,
 				wp: 'wp',
@@ -37,7 +39,7 @@ exports.compile = args => {
 			},
 			output: {
 				path: options.outputDir,
-				filename: `${ name }-editor.js`,
+				filename: '[name]',
 				libraryTarget: 'window',
 			},
 			plugins: [

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -6,7 +6,7 @@
 const chalk = require( 'chalk' );
 const path = require( 'path' );
 const webpack = require( 'webpack' );
-const { isEmpty, negate, pickBy } = require( 'lodash' );
+const { isEmpty, omitBy } = require( 'lodash' );
 
 const __rootDir = path.resolve( __dirname, '../../' );
 const CopyWebpackPlugin = require( path.resolve( __rootDir, 'server/bundler/copy-webpack-plugin' ) );
@@ -26,10 +26,10 @@ exports.compile = args => {
 		...{
 			context: __rootDir,
 			mode: options.mode,
-			entry: pickBy( {
-				[ `${ name }-editor-script.js` ]: options.editorScript,
-				[ `${ name }-view-script.js` ]: options.viewScript,
-			}, negate( isEmpty ) ),
+			entry: omitBy( {
+				[ `${ name }-editor.js` ]: options.editorScript,
+				[ `${ name }-view.js` ]: options.viewScript,
+			}, isEmpty ),
 			externals: {
 				...baseConfig.externals,
 				wp: 'wp',


### PR DESCRIPTION
There are two fundamental types of entry-points for Gutenberg
extensions: those that live in the editor; those that live in the
rendered page.

This patch introduces the option for a second entry-point which is the
script that lives on the rendered page. We will output two built files
and WordPress will need to load each of them accordingly.

**Testing**

Build a block with a view-side script by adding one and running the command:

```bash
npm run sdk:gutenberg --editor-script=my-script.js --view-script=my-script-in-browser.js
```

You should be able to run a build without the view script as well - it's optional.
In the output `build` directory you should find a file for each input.