### PR TITLE
SDK: Adds prev/next block from a8c-blocks

### DIFF
--- a/client/gutenberg/extensions/presets/p2/editor.js
+++ b/client/gutenberg/extensions/presets/p2/editor.js
@@ -3,4 +3,5 @@
 /**
  * Internal dependencies
  */
-import 'gutenberg/extensions/editor-notes/index.js';
+import 'gutenberg/extensions/editor-notes';
+import 'gutenberg/extensions/prev-next';

--- a/client/gutenberg/extensions/prev-next/index.js
+++ b/client/gutenberg/extensions/prev-next/index.js
@@ -1,0 +1,75 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import wp from 'wp';
+const { __ } = wp.i18n;
+const { TextControl } = wp.components;
+const { registerBlockType } = wp.blocks;
+
+require( './style.scss' );
+
+const blockAttributes = {
+	prev: {
+		type: 'string',
+		source: 'attribute',
+		selector: 'a:first-child',
+		attribute: 'href',
+	},
+	next: {
+		type: 'string',
+		source: 'attribute',
+		selector: 'a:last-child',
+		attribute: 'href',
+	},
+};
+
+const save = ( { attributes: { prev, next }, className, isEditor } ) =>
+	prev || next ? (
+		<div className={ isEditor ? className : '' }>
+			{ prev ? <a href={ prev }>← Prev</a> : <span> </span> }
+			{ next ? <a href={ next }>Next →</a> : <span> </span> }
+		</div>
+	) : (
+		<React.Fragment />
+	);
+
+registerBlockType( 'a8c/prev-next', {
+	title: __( 'Prev/Next Links' ),
+	icon: 'leftright',
+	category: 'common',
+	description: __( 'Link this post to sequential posts in a series of related posts.' ),
+	keywords: [ __( 'links' ) ],
+	attributes: blockAttributes,
+	edit: ( { attributes, className, isSelected, setAttributes } ) => {
+		if ( isSelected ) {
+			return (
+				<React.Fragment>
+					<TextControl
+						label={ __( 'Previous Post' ) }
+						value={ attributes.prev }
+						onChange={ prev => setAttributes( { prev } ) }
+					/>
+					<TextControl
+						label={ __( 'Next Post' ) }
+						value={ attributes.next }
+						onChange={ next => setAttributes( { next } ) }
+					/>
+				</React.Fragment>
+			);
+		}
+
+		if ( attributes.prev || attributes.next ) {
+			return save( { attributes, className, isEditor: true } );
+		}
+
+		return (
+			<div style={ { textAlign: 'center' } }>
+				← Add prev/next links to related posts in a series. →
+			</div>
+		);
+	},
+	save,
+} );

--- a/client/gutenberg/extensions/prev-next/style.scss
+++ b/client/gutenberg/extensions/prev-next/style.scss
@@ -1,0 +1,5 @@
+.wp-block-a8c-prev-next {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+}


### PR DESCRIPTION
Depends on #26393 

Moves code for the prev/next block into Calypso.