### PR TITLE
Fix: Dialog Buttons squished by oversized content.

### DIFF
--- a/client/components/dialog/style.scss
+++ b/client/components/dialog/style.scss
@@ -121,6 +121,7 @@
 .dialog__action-buttons .button {
 	margin-left: 10px;
 	min-width: 80px;
+	text-align: center;
 
 	.is-left-aligned {
 		margin-left: 0;

--- a/client/components/dialog/style.scss
+++ b/client/components/dialog/style.scss
@@ -7,8 +7,11 @@
 	position: fixed;
 	right: 0;
 	top: 46px;
-	transition: background-color .2s ease-in;
-	z-index: z-index( 'root', '.dialog__backdrop' ); // try to ensure that dialogs are on top of everything else
+	transition: background-color 0.2s ease-in;
+	z-index: z-index(
+		'root',
+		'.dialog__backdrop'
+	); // try to ensure that dialogs are on top of everything else
 
 	&.dialog-enter,
 	&.dialog-leave.dialog-leave-active {
@@ -40,7 +43,7 @@
 	margin: auto 0; // IE needs a horizontal margin values to properly center flex item
 	padding: 0;
 	opacity: 1;
-	transition: opacity .2s ease-in;
+	transition: opacity 0.2s ease-in;
 
 	.dialog-enter &,
 	.dialog-leave.dialog-leave-active & {
@@ -58,7 +61,7 @@
 	padding: 16px;
 	overflow-y: auto;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		padding: 24px;
 	}
 
@@ -72,7 +75,7 @@
 		font-weight: 600;
 		height: 2em;
 		line-height: 2em;
-		margin-bottom: .5em;
+		margin-bottom: 0.5em;
 	}
 
 	p:last-child {
@@ -86,26 +89,31 @@
 	padding: 16px;
 	margin: 0;
 	text-align: right;
+	flex-shrink: 0;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		padding-left: 24px;
 		padding-right: 24px;
 	}
-	
-	@include breakpoint( "<480px" ) {
+
+	@include breakpoint( '<480px' ) {
 		display: flex;
 		flex-direction: column-reverse;
 	}
 
 	&:before {
-		content: "";
+		content: '';
 		display: block;
 		position: absolute;
 		bottom: 100%;
 		left: 16px;
 		right: 16px;
 		height: 24px;
-		background: linear-gradient( to bottom, rgba( 255,255,255, 0 ) 0%, rgba( 255,255,255, 1 ) 100% );
+		background: linear-gradient(
+			to bottom,
+			rgba( 255, 255, 255, 0 ) 0%,
+			rgba( 255, 255, 255, 1 ) 100%
+		);
 		margin-bottom: 1px;
 	}
 }
@@ -119,7 +127,7 @@
 		margin-right: 10px;
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		margin: 2px 0;
 	}
 }


### PR DESCRIPTION
With the addition of `InlineHelp`s `SupportArticleDialog`, we now have examples of our `Dialog` component showing lengthier content than before.
This has revealed a slight oversight in our use of flexbox to arrange our dialogs components: when the content is longer than the dialog content area, we start to see shrinkage of the dialog buttons container. The extent of this increases as the content increases so it's likely that this has just gone unnoticed until now.

I've added `flex-shrink: 0` to the style rules for the buttons container which seems to have fixed this up nicely :)

While I was at it, I noticed that the our `<a>` buttons don't centre align too, so I've fixed that here aswell

#### Reproduce (before patch):

- Open a support article through inline help (click the ? and find an option with a 'read more' button)
- Click 'read more'
- Make your browser window smaller / emulate a mobile device
  - Note that the action buttons at the bottom are very small

#### Test

- Follow the reproduction steps above
  - Note that the buttons now render at an expected, usable size
  - Note that both the external link and the 'close' button are centre aligned