### PR TITLE
SupportArticles: Improve sizing on smaller devices

### DIFF
--- a/client/blocks/support-article-dialog/style.scss
+++ b/client/blocks/support-article-dialog/style.scss
@@ -1,7 +1,27 @@
 @import 'content';
 
 .support-article-dialog.dialog.card {
-	width: 80vw;
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	max-width: 100%;
+
+	@include breakpoint( '>660px' ) {
+		top: 5%;
+		bottom: 5%;
+		left: 5%;
+		right: 5%;
+		width: 90%;
+	}
+
+	@include breakpoint( '>960px' ) {
+		left: 12.5%;
+		right: 12.5%;
+		width: 75%;
+		width: 80vw;
+	}
 }
 
 .support-article-dialog__story {
@@ -11,12 +31,12 @@
 		margin: 12px 0 0;
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		font-size: 15px;
 		line-height: 24px;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		width: auto;
 	}
 }
@@ -52,17 +72,17 @@
 	margin: 56px 0 0;
 	max-width: 750px;
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		font-size: 36px;
 		line-height: 46px;
 	}
 
-	@include breakpoint( "480px-960px" ) {
+	@include breakpoint( '480px-960px' ) {
 		font-size: 32px;
 		line-height: 40px;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		margin-top: 8px;
 	}
 
@@ -94,7 +114,7 @@
 	iframe {
 		height: 100%;
 		position: absolute;
-			top: 0;
+		top: 0;
 		width: 100%;
 	}
 }


### PR DESCRIPTION
This PR aims to improve the usage of viewport width when showing our support articles inline, in a dialog.
The default widths for our dialog don't do a great job of presenting longer-form content, making reading support articles problematic and a bad user experience.

### Before

![image 3](https://user-images.githubusercontent.com/4335450/43417560-38d91c48-9433-11e8-9fa5-0f0f0f66a55f.png)

### After

600px:
<img width="362" alt="600px" src="https://user-images.githubusercontent.com/4335450/43417638-6c29974e-9433-11e8-88ba-d534357f7e26.png">
700px:
<img width="423" alt="700px" src="https://user-images.githubusercontent.com/4335450/43417639-6c42f220-9433-11e8-8ec1-0b95e9b4da7e.png">
900px:
<img width="542" alt="900px" src="https://user-images.githubusercontent.com/4335450/43417640-6c622294-9433-11e8-9af6-6beb54ea6220.png">
1000px:
<img width="603" alt="1000px" src="https://user-images.githubusercontent.com/4335450/43417641-6c7defd8-9433-11e8-8d2e-ad760f1daf19.png">


####

### Reproduce (before patch):

- Open a support article through inline help (click the ? and find an option with a 'read more' button)
- Click 'read more'
- Make your browser window smaller / emulate a mobile device
  - Note that the dialog is not making use of the full width of the screen
  - Note that the padding on the dialog content is quite heavy, further limiting the amount of display space

### Test

- Follow the reproduction steps above
  - Note that the dialog is now full width when below 660px and only limited by 5% padding between 661px and 960px