### PR TITLE
Signup: Add tooltips for features on the Plans page.

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -860,6 +860,7 @@ export const FEATURES_LIST = {
 	[ FEATURE_ALL_FREE_FEATURES ]: {
 		getSlug: () => FEATURE_ALL_FREE_FEATURES,
 		getTitle: () => i18n.translate( 'All free features' ),
+		getDescription: () => i18n.translate( 'Also includes all features offered in the free plan.' ),
 	},
 
 	[ FEATURE_ALL_PERSONAL_FEATURES_JETPACK ]: {
@@ -883,6 +884,8 @@ export const FEATURES_LIST = {
 	[ FEATURE_ALL_PERSONAL_FEATURES ]: {
 		getSlug: () => FEATURE_ALL_PERSONAL_FEATURES,
 		getTitle: () => i18n.translate( 'All Personal features' ),
+		getDescription: () =>
+			i18n.translate( 'Also includes all features offered in the Personal plan.' ),
 	},
 
 	[ FEATURE_ALL_PREMIUM_FEATURES_JETPACK ]: {
@@ -906,31 +909,50 @@ export const FEATURES_LIST = {
 	[ FEATURE_ALL_PREMIUM_FEATURES ]: {
 		getSlug: () => FEATURE_ALL_PREMIUM_FEATURES,
 		getTitle: () => i18n.translate( 'All Premium features' ),
+		getDescription: () =>
+			i18n.translate( 'Also includes all features offered in the Premium plan.' ),
 	},
 
 	[ FEATURE_ADVANCED_CUSTOMIZATION ]: {
 		getSlug: () => FEATURE_ADVANCED_CUSTOMIZATION,
 		getTitle: () => i18n.translate( 'Advanced customization' ),
+		getDescription: () =>
+			i18n.translate(
+				'Customize your selected theme template with extended color schemes, background designs, and complete control over website CSS.'
+			),
 	},
 
 	[ FEATURE_FREE_DOMAIN ]: {
 		getSlug: () => FEATURE_FREE_DOMAIN,
 		getTitle: () => i18n.translate( 'Free custom domain' ),
+		getDescription: () =>
+			i18n.translate(
+				'Get a free custom domain name (example.com) with this plan to use for your website.'
+			),
 	},
 
 	[ FEATURE_PREMIUM_THEMES ]: {
 		getSlug: () => FEATURE_PREMIUM_THEMES,
 		getTitle: () => i18n.translate( 'Unlimited premium themes' ),
+		getDescription: () =>
+			i18n.translate(
+				'Unlimited access to all of our advanced premium theme templates, including templates specifically tailored for businesses.'
+			),
 	},
 
 	[ FEATURE_MONETISE ]: {
 		getSlug: () => FEATURE_MONETISE,
 		getTitle: () => i18n.translate( 'Monetize your site with ads' ),
+		getDescription: () =>
+			i18n.translate(
+				'Add advertising to your site through our WordAds program and earn money from impressions.'
+			),
 	},
 
 	[ FEATURE_UPLOAD_THEMES_PLUGINS ]: {
 		getSlug: () => FEATURE_UPLOAD_THEMES_PLUGINS,
 		getTitle: () => i18n.translate( 'Upload themes and plugins' ),
+		getDescription: () => i18n.translate( 'Upload custom themes and plugins on your site.' ),
 	},
 
 	[ FEATURE_GOOGLE_ANALYTICS_SIGNUP ]: {
@@ -941,26 +963,46 @@ export const FEATURES_LIST = {
 	[ FEATURE_EMAIL_LIVE_CHAT_SUPPORT_SIGNUP ]: {
 		getSlug: () => FEATURE_EMAIL_LIVE_CHAT_SUPPORT_SIGNUP,
 		getTitle: () => i18n.translate( 'Email and live chat support' ),
+		getDescription: () =>
+			i18n.translate(
+				'High quality support to help you get your website up and running and working how you want it.'
+			),
 	},
 
 	[ FEATURE_FREE_THEMES_SIGNUP ]: {
 		getSlug: () => FEATURE_FREE_THEMES_SIGNUP,
 		getTitle: () => i18n.translate( 'Dozens of Free Themes' ),
+		getDescription: () =>
+			i18n.translate(
+				"Access to a wide range of professional theme templates for your website so you can find the exact design you're looking for."
+			),
 	},
 
 	[ FEATURE_WP_SUBDOMAIN_SIGNUP ]: {
 		getSlug: () => FEATURE_WP_SUBDOMAIN_SIGNUP,
 		getTitle: () => i18n.translate( 'WordPress.com subdomain' ),
+		getDescription: () =>
+			i18n.translate(
+				'Your site address will use a WordPress.com subdomain (sitename.wordpress.com).'
+			),
 	},
 
 	[ FEATURE_UNLIMITED_STORAGE_SIGNUP ]: {
 		getSlug: () => FEATURE_UNLIMITED_STORAGE_SIGNUP,
 		getTitle: () => i18n.translate( 'Unlimited storage' ),
+		getDescription: () =>
+			i18n.translate(
+				"With increased storage space you'll be able to upload more images, videos, audio, and documents to your website."
+			),
 	},
 
 	[ FEATURE_ADVANCED_SEO_TOOLS ]: {
 		getSlug: () => FEATURE_ADVANCED_SEO_TOOLS,
 		getTitle: () => i18n.translate( 'Advanced SEO tools' ),
+		getDescription: () =>
+			i18n.translate(
+				"Adds tools to enhance your site's content for better results on search engines and social media."
+			),
 	},
 
 	[ FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED_SIGNUP ]: {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -10,7 +10,7 @@ $plan-features-sidebar-width: 272px;
 
 .is-section-plans .plan-features__mobile {
 	display: block;
-	@media ( min-width: $plan-features-sidebar-width + 480px ) {
+	@media (min-width: $plan-features-sidebar-width + 480px) {
 		display: none;
 	}
 }
@@ -18,7 +18,7 @@ $plan-features-sidebar-width: 272px;
 .plan-features__notice {
 	margin-bottom: 16px;
 
-	@include breakpoint( ">1040px" ) {
+	@include breakpoint( '>1040px' ) {
 		margin-bottom: 32px;
 		margin-top: -19px;
 	}
@@ -29,7 +29,7 @@ $plan-features-sidebar-width: 272px;
 	margin: 0 16px;
 	display: block;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		display: none;
 	}
 
@@ -37,11 +37,13 @@ $plan-features-sidebar-width: 272px;
 		box-shadow: none;
 	}
 
-	.foldable-card.card.is-expanded { //original rule has this specificity
+	.foldable-card.card.is-expanded {
+		//original rule has this specificity
 		margin: 0;
 	}
 
-	.foldable-card.is-expanded .foldable-card__content { //original rule has this specificity
+	.foldable-card.is-expanded .foldable-card__content {
+		//original rule has this specificity
 		padding: 0;
 	}
 
@@ -76,7 +78,7 @@ $plan-features-sidebar-width: 272px;
 
 .is-section-plans .plan-features__table {
 	display: none;
-	@media ( min-width: $plan-features-sidebar-width + 480px ) {
+	@media (min-width: $plan-features-sidebar-width + 480px) {
 		display: table;
 	}
 }
@@ -89,11 +91,11 @@ $plan-features-sidebar-width: 272px;
 	display: none;
 	table-layout: fixed;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		display: table;
 	}
 
-	@include breakpoint( "<1040px" ) {
+	@include breakpoint( '<1040px' ) {
 		border-spacing: 0;
 		margin: 0 15px;
 		width: calc( 100% - 30px );
@@ -141,7 +143,7 @@ $plan-features-sidebar-width: 272px;
 		bottom: 0;
 		margin: 0 24px;
 
-		@include breakpoint( "<1040px" ) {
+		@include breakpoint( '<1040px' ) {
 			margin: 0 12px;
 			width: calc( 100% - 24px );
 		}
@@ -181,7 +183,7 @@ $plan-features-sidebar-width: 272px;
 	border-bottom: solid 2px $gray-lighten-20;
 	background-color: $white;
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		padding: 12px 12px 0 12px;
 	}
 
@@ -207,7 +209,7 @@ $plan-features-sidebar-width: 272px;
 }
 
 .is-section-plans .plan-features__header-figure {
-	@include breakpoint( "<1280px" ) {
+	@include breakpoint( '<1280px' ) {
 		width: 24px;
 		height: 24px;
 		margin-right: 10px;
@@ -217,7 +219,7 @@ $plan-features-sidebar-width: 272px;
 .plan-features__header-figure,
 .plan-features__table.has-1-cols .plan-features__header-figure,
 .plan-features__table.has-2-cols .plan-features__header-figure {
-	@include breakpoint( "<1040px" ) {
+	@include breakpoint( '<1040px' ) {
 		display: none;
 	}
 }
@@ -232,7 +234,7 @@ $plan-features-sidebar-width: 272px;
 	color: $blue-wordpress;
 	line-height: 0.7;
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		font-size: 20px;
 	}
 }
@@ -248,7 +250,7 @@ $plan-features-sidebar-width: 272px;
 	font-style: italic;
 	font-weight: 400;
 	color: $gray-text-min;
-	line-height: .6;
+	line-height: 0.6;
 	white-space: nowrap;
 
 	&.is-placeholder {
@@ -257,7 +259,7 @@ $plan-features-sidebar-width: 272px;
 		height: 12px;
 		margin-bottom: 15px;
 
-		@include breakpoint( "<960px" ) {
+		@include breakpoint( '<960px' ) {
 			margin-bottom: 9px;
 		}
 	}
@@ -290,7 +292,7 @@ $plan-features-sidebar-width: 272px;
 		margin-bottom: 5px;
 		width: 140px;
 
-		@include breakpoint( "<960px" ) {
+		@include breakpoint( '<960px' ) {
 			height: 26px;
 		}
 	}
@@ -302,7 +304,7 @@ $plan-features-sidebar-width: 272px;
 	&.is-placeholder {
 		height: 28px;
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			height: auto;
 		}
 	}
@@ -332,11 +334,11 @@ $plan-features-sidebar-width: 272px;
 	margin: 0;
 	padding: 24px 24px 0 24px;
 
-	@include breakpoint( "<1040px" ) {
+	@include breakpoint( '<1040px' ) {
 		padding: 12px 12px 0 12px;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		padding: 20px 20px 0 20px;
 	}
 }
@@ -353,11 +355,11 @@ $plan-features-sidebar-width: 272px;
 	font-size: 14px;
 	color: $gray-dark;
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		font-size: 12px;
 	}
 
-	@include breakpoint( "<1040px" ) {
+	@include breakpoint( '<1040px' ) {
 		margin: 0 12px;
 	}
 }
@@ -387,11 +389,11 @@ $plan-features-sidebar-width: 272px;
 .plan-features__actions {
 	padding: 0 24px 24px 24px;
 
-	@include breakpoint( "<1040px" ) {
+	@include breakpoint( '<1040px' ) {
 		padding: 0 12px 12px 12px;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		padding: 0 20px 20px 20px;
 		border-bottom: solid 1px $gray-light;
 	}
@@ -405,7 +407,7 @@ $plan-features-sidebar-width: 272px;
 	width: 100%;
 	margin-top: 8px;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		margin-top: 20px;
 	}
 }
@@ -425,7 +427,6 @@ $plan-features-sidebar-width: 272px;
 	margin-left: 10px;
 }
 
-
 /*= Plans in Signup
 ========================================*/
 
@@ -441,7 +442,7 @@ $plan-features-sidebar-width: 272px;
 .plans-wrapper {
 	margin: 0 auto;
 	padding: 20px 0 10px;
-	transform: translateY(-20px);
+	transform: translateY( -20px );
 	overflow-x: auto;
 }
 
@@ -451,7 +452,7 @@ $plan-features-sidebar-width: 272px;
 	.jetpack-connect__plans & {
 		width: auto;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			max-width: 1000px;
 		}
 	}
@@ -459,7 +460,7 @@ $plan-features-sidebar-width: 272px;
 	.signup__steps & {
 		width: auto;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			max-width: 1100px;
 		}
 	}
@@ -467,14 +468,14 @@ $plan-features-sidebar-width: 272px;
 	.plan-features__table {
 		display: none;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			display: table;
 			width: 100%;
 			margin: 0;
 			padding: 0 16px;
 		}
 
-		@include breakpoint( ">1040px" ) {
+		@include breakpoint( '>1040px' ) {
 			border-spacing: 15px 0 !important;
 			padding: 0;
 		}
@@ -507,7 +508,7 @@ $plan-features-sidebar-width: 272px;
 		height: 50px;
 		margin: 16px 20px;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			float: none;
 			width: 100px;
 			height: 100px;
@@ -524,7 +525,7 @@ $plan-features-sidebar-width: 272px;
 		margin: 20px 20px -12px;
 		padding: 0;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			margin-bottom: 0;
 			padding: 0 12px;
 		}
@@ -537,6 +538,11 @@ $plan-features-sidebar-width: 272px;
 
 	.plan-features__item {
 		margin: 0 15px;
+		text-align: left;
+	}
+
+	.plan-features__item-info {
+		padding: 0 5px;
 	}
 
 	.plan-features__item-title {
@@ -564,17 +570,12 @@ $plan-features-sidebar-width: 272px;
 		display: inline;
 	}
 
-	.plan-features__item-checkmark,
-	.plan-features__item-tip-info {
-		display: none;
-	}
-
 	.plan-features__row:last-of-type .plan-features__table-item {
 		border-bottom: solid 1px lighten( $gray, 27% );
 	}
 
 	.jetpack-connect__hide-plan-icons .jetpack-connect__plans & .plan-features__pricing {
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			padding-top: 0;
 		}
 	}


### PR DESCRIPTION
Let's add some helpful information to better describe each of the features. In most cases I've stolen the copy from `/pricing` for each of the features to use in the tooltips, but a couple had to be modified to work on this page.

**Before this PR**

<img width="1099" alt="screen shot 2018-07-30 at 3 25 11 pm" src="https://user-images.githubusercontent.com/2124984/43418722-d9f83ab8-940c-11e8-970a-87e19a475267.png">

**After this PR**

<img width="1084" alt="screen shot 2018-07-30 at 3 25 27 pm" src="https://user-images.githubusercontent.com/2124984/43418730-df54cb2a-940c-11e8-9871-05cd87d7c9d6.png">
<img width="544" alt="screen shot 2018-07-30 at 3 25 36 pm" src="https://user-images.githubusercontent.com/2124984/43418731-df64d2fe-940c-11e8-821e-989dbdefd0a3.png">


**Steps to test:**

* Switch to this PR and navigate to `/start/plans/`
* Check for the presence of the tooltips next to each major feature listed.
* Check each tooltip for wording, check tooltip functionality on mobile, etc.