### PR TITLE
Payments: Improve manage purchase UI so that users are encourage to renew, not just update their payment method

### DIFF
--- a/client/blocks/credit-card-form/README.md
+++ b/client/blocks/credit-card-form/README.md
@@ -24,7 +24,9 @@ render() {
 
 * `createCardToken`: Function to be executed when a valid form is submitted. It is responsible for a credit card token creation which is the part of the flow.
 * `initialValues`: Optional object containing initial values for the form fields. At the moment only `name` is supported.
+* `purchase`: Optional object representing an existing purchase that the credit card will be used for. If this is passed along with `siteSlug` and if the purchase is up for renewal, the message that is displayed after successfully saving the card will give the user information about renewing the purchase with the new credit card.
 * `recordFormSubmitEvent`: Function to be executed when the user clicks the _Save Card_ button.
 * `saveStoredCard`: Optional function returning _Promise_ to be executed when a credit card token is created after the user clicked the _Save Card_ button. By default `wpcom.updateCreditCard` Redux action is executed because of legacy reasons.
+* `siteSlug`: Optional site slug that the `purchase` can be renewed for.
 * `successCallback`: Function to be executed when a credit card is successfully stored.
 * `autoFocus`: Whether the first field (cardholder name) should steal the focus when this component is rendered.  Default `true`.

--- a/client/components/card/README.md
+++ b/client/components/card/README.md
@@ -32,7 +32,8 @@ Name | Type | Default | Description
 --- | --- | --- | ---
 `className` | `string` | null | Adds CSS classes.
 `href` | `string` | null | URL of the card. Adds a right chevron icon.
-`tagName` | `string` | null | Allows you to control the tag name of the card wrapper (only if `href` is not specified).
+`fakeLink` | `bool` | false | Used for cards without a `href` that need to display as a link. The card will render as an accessible button with the same visual appearance as a link (including the right chevron icon).
+`tagName` | `string` | null | Allows you to control the tag name of the card wrapper (only if `href` and `fakeLink` are not specified).
 `target` | `string` | null | If used with `href`, this specifies where the link opens. Changes the icon to `external`.
 `compact` | `bool` | false | Decreases the size of the card.
 `highlight` | `string` | `false` | Displays a colored highlight. Can be `false` (no highlight, default), `info`, `success`, `error`, or `warning`.

--- a/client/components/card/docs/example.jsx
+++ b/client/components/card/docs/example.jsx
@@ -32,6 +32,14 @@ class Cards extends React.Component {
 				<Card href="#cards" target="_blank" rel="noopener noreferrer">
 					I am a externally linked Card
 				</Card>
+				<Card
+					fakeLink
+					onClick={ function () {
+						alert( 'Thank you for clicking me!' );
+					} }
+				>
+					I am a clickable button that looks like a link
+				</Card>
 				<Card highlight="info">I am a Card, highlighted as info</Card>
 				<Card highlight="success">I am a Card, highlighted as success</Card>
 				<Card highlight="error">I am a Card, highlighted as error</Card>

--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -8,14 +8,15 @@ import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 
-const getClassName = ( { className, compact, highlight, href, onClick } ) =>
+const getClassName = ( { className, compact, fakeLink, highlight, href, onClick } ) =>
 	classNames(
 		'card',
 		className,
 		{
-			'is-card-link': !! href,
+			'is-card-link': fakeLink || !! href,
 			'is-clickable': !! onClick,
 			'is-compact': compact,
+			'is-fake-link': fakeLink,
 			'is-highlight': highlight,
 		},
 		highlight ? 'is-' + highlight : false
@@ -24,6 +25,7 @@ const getClassName = ( { className, compact, highlight, href, onClick } ) =>
 class Card extends PureComponent {
 	static propTypes = {
 		className: PropTypes.string,
+		fakeLink: PropTypes.bool,
 		href: PropTypes.string,
 		tagName: PropTypes.oneOfType( [ PropTypes.func, PropTypes.string ] ).isRequired,
 		target: PropTypes.string,
@@ -37,7 +39,8 @@ class Card extends PureComponent {
 	};
 
 	render() {
-		const { children, compact, highlight, tagName: TagName, href, target, ...props } = this.props;
+		const { children, compact, fakeLink, highlight, tagName, href, target, ...props } = this.props;
+		const TagName = fakeLink ? 'button' : tagName;
 
 		return href ? (
 			<a { ...props } href={ href } target={ target } className={ getClassName( this.props ) }>
@@ -46,6 +49,12 @@ class Card extends PureComponent {
 			</a>
 		) : (
 			<TagName { ...props } className={ getClassName( this.props ) }>
+				{ fakeLink && (
+					<Gridicon
+						className="card__link-indicator"
+						icon={ target ? 'external' : 'chevron-right' }
+					/>
+				) }
 				{ children }
 			</TagName>
 		);

--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -5,12 +5,11 @@
 	padding: 16px;
 	box-sizing: border-box;
 	background: $white;
-	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
-		0 1px 2px $gray-lighten-30;
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, 0.5 ), 0 1px 2px $gray-lighten-30;
 
 	@include clear-fix;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		margin-bottom: 16px;
 		padding: 24px;
 	}
@@ -19,7 +18,7 @@
 	&.is-compact {
 		margin-bottom: 1px;
 
-		@include breakpoint( ">480px" ) {
+		@include breakpoint( '>480px' ) {
 			margin-bottom: 1px;
 			padding: 16px 24px;
 		}
@@ -31,6 +30,20 @@
 
 	&.is-clickable {
 		cursor: pointer;
+	}
+
+	&.is-fake-link {
+		color: $blue-wordpress;
+		font-size: 100%;
+		line-height: 1.5;
+		text-align: left;
+		width: 100%;
+
+		&:active,
+		&:focus,
+		&:hover {
+			color: $link-highlight;
+		}
 	}
 
 	&.is-highlight {
@@ -54,7 +67,6 @@
 	}
 }
 
-
 // Clickable Card
 .card__link-indicator {
 	color: $gray-text-min;
@@ -64,21 +76,22 @@
 	top: 0;
 	right: 16px;
 
-	html[dir="rtl"] & {
+	html[dir='rtl'] & {
 		&.gridicons-chevron-right {
 			transform: scaleX( -1 );
 		}
 	}
-
 }
 
-a.card:hover {
+a.card:hover,
+.is-fake-link.card:hover {
 	.card__link-indicator {
 		color: $gray-text;
 	}
 }
 
-a.card:focus {
+a.card:focus,
+.is-fake-link.card:focus {
 	outline: 0;
 
 	.card__link-indicator {

--- a/client/components/card/test/__snapshots__/index.js.snap
+++ b/client/components/card/test/__snapshots__/index.js.snap
@@ -26,6 +26,20 @@ exports[`Card should have custom class of \`test__ace\` 1`] = `
 />
 `;
 
+exports[`Card should render as a clickable fake link button 1`] = `
+<button
+  className="card is-card-link is-clickable is-fake-link"
+  onClick="test"
+>
+  <t
+    className="card__link-indicator"
+    icon="chevron-right"
+    size={24}
+  />
+  This is a fake link
+</button>
+`;
+
 exports[`Card should render children 1`] = `
 <div
   className="card"

--- a/client/components/card/test/index.js
+++ b/client/components/card/test/index.js
@@ -41,6 +41,20 @@ describe( 'Card', () => {
 		expect( card.is( '.is-card-link' ) ).toBe( true );
 		expect( card ).toMatchSnapshot();
 	} );
+	// check that it can be rendered as a clickable fake link button
+	test( 'should render as a clickable fake link button', () => {
+		const card = shallow(
+			<Card fakeLink onClick="test">
+				This is a fake link
+			</Card>
+		);
+		expect( card.is( 'a' ) ).toBe( false );
+		expect( card.is( 'button' ) ).toBe( true );
+		expect( card.is( '.is-card-link' ) ).toBe( true );
+		expect( card.is( '.is-clickable' ) ).toBe( true );
+		expect( card.is( '.is-fake-link' ) ).toBe( true );
+		expect( card ).toMatchSnapshot();
+	} );
 } );
 
 describe( 'CompactCard', () => {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -18,11 +18,11 @@ import analytics from 'lib/analytics';
 import { applyTestFiltersToPlansList } from 'lib/plans';
 import Button from 'components/button';
 import Card from 'components/card';
-import { cartItems } from 'lib/cart-values';
 import CompactCard from 'components/card/compact';
 import config from 'config';
 import {
 	getName,
+	handleRenewNowClick,
 	hasPrivacyProtection,
 	isCancelable,
 	isExpired,
@@ -70,7 +70,6 @@ import VerticalNavItem from 'components/vertical-nav/item';
 import { cancelPurchase, cancelPrivacyProtection, purchasesRoot } from '../paths';
 import { CALYPSO_CONTACT } from 'lib/url/support';
 import titles from 'me/purchases/titles';
-import { addItems } from 'lib/upgrades/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import TrackPurchasePageView from 'me/purchases/track-purchase-page-view';
 import { getCurrentUserId } from 'state/current-user/selectors';
@@ -123,34 +122,7 @@ class ManagePurchase extends Component {
 	}
 
 	handleRenew = () => {
-		const { purchase } = this.props;
-		const renewItem = cartItems.getRenewalItemFromProduct( purchase, {
-			domain: purchase.meta,
-		} );
-		const renewItems = [ renewItem ];
-
-		// Track the renew now submit
-		analytics.tracks.recordEvent( 'calypso_purchases_renew_now_click', {
-			product_slug: purchase.productSlug,
-		} );
-
-		if ( hasPrivacyProtection( purchase ) ) {
-			const privacyItem = cartItems.getRenewalItemFromCartItem(
-				cartItems.domainPrivacyProtection( {
-					domain: purchase.meta,
-				} ),
-				{
-					id: purchase.id,
-					domain: purchase.domain,
-				}
-			);
-
-			renewItems.push( privacyItem );
-		}
-
-		addItems( renewItems );
-
-		page( '/checkout/' + this.props.siteSlug );
+		handleRenewNowClick( this.props.purchase, this.props.siteSlug );
 	};
 
 	renderRenewButton() {
@@ -160,6 +132,8 @@ class ManagePurchase extends Component {
 			return null;
 		}
 
+		// This is hidden for expired and expiring subscriptions because they
+		// will get a PurchaseNotice will a renewal call-to-action instead.
 		if (
 			! isRenewable( purchase ) ||
 			isExpired( purchase ) ||
@@ -173,6 +147,27 @@ class ManagePurchase extends Component {
 			<Button className="manage-purchase__renew-button" onClick={ this.handleRenew } compact>
 				{ translate( 'Renew Now' ) }
 			</Button>
+		);
+	}
+
+	renderRenewNowNavItem() {
+		const { purchase, translate } = this.props;
+
+		if ( ! config.isEnabled( 'upgrades/checkout' ) ) {
+			return null;
+		}
+
+		// Unlike renderRenewButton(), this shows the link even for expired or
+		// expiring subscriptions (as long as they are renewable), which keeps
+		// the nav items consistent.
+		if ( ! isRenewable( purchase ) || ! this.props.site ) {
+			return null;
+		}
+
+		return (
+			<CompactCard fakeLink onClick={ this.handleRenew }>
+				{ translate( 'Renew Now' ) }
+			</CompactCard>
 		);
 	}
 
@@ -400,6 +395,7 @@ class ManagePurchase extends Component {
 					{ this.renderRenewButton() }
 				</Card>
 				<PurchasePlanDetails purchaseId={ this.props.purchaseId } />
+				{ this.renderRenewNowNavItem() }
 				{ this.renderEditPaymentMethodNavItem() }
 				{ this.renderCancelPurchaseNavItem() }
 				{ this.renderCancelPrivacyProtection() }

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -108,7 +108,9 @@ class AddCardDetails extends Component {
 				<CreditCardForm
 					apiParams={ { purchaseId: this.props.purchase.id } }
 					createCardToken={ this.createCardToken }
+					purchase={ this.props.purchase }
 					recordFormSubmitEvent={ this.recordFormSubmitEvent }
+					siteSlug={ this.props.siteSlug }
 					successCallback={ this.successCallback }
 				/>
 			</Main>
@@ -124,4 +126,7 @@ const mapStateToProps = ( state, { purchaseId } ) => ( {
 	userId: getCurrentUserId( state ),
 } );
 
-export default connect( mapStateToProps, { clearPurchases, recordTracksEvent } )( AddCardDetails );
+export default connect(
+	mapStateToProps,
+	{ clearPurchases, recordTracksEvent }
+)( AddCardDetails );

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -115,7 +115,9 @@ class EditCardDetails extends Component {
 					apiParams={ { purchaseId: this.props.purchase.id } }
 					createCardToken={ this.createCardToken }
 					initialValues={ this.props.card }
+					purchase={ this.props.purchase }
 					recordFormSubmitEvent={ this.recordFormSubmitEvent }
+					siteSlug={ this.props.siteSlug }
 					successCallback={ this.successCallback }
 				/>
 			</Main>
@@ -133,4 +135,7 @@ const mapStateToProps = ( state, { cardId, purchaseId } ) => ( {
 	userId: getCurrentUserId( state ),
 } );
 
-export default connect( mapStateToProps, { clearPurchases, recordTracksEvent } )( EditCardDetails );
+export default connect(
+	mapStateToProps,
+	{ clearPurchases, recordTracksEvent }
+)( EditCardDetails );


### PR DESCRIPTION
## The problem

There have been reports (p2MSmN-5aw-p2) that some users are updating their payment method for a subscription under the assumption that that will also cause the subscription to immediately renew.  (One possible reason they might do this is if they don't realize that clicking "Renew Now" also will give you an opportunity to use a new payment method, so they start by adding a payment method instead and then get confused afterwards.  A second possible reason is that in some cases, they don't notice the "Renew Now" button at all.)

These users will eventually be auto-renewed, but since it is confusing them that the subscription wasn't renewed right away, and since we'd like to encourage more people to go ahead and actually try the renewal right after adding a new credit card (to be able to make sure that the card can be charged with no problem) we'd like to fix this.

## Solution

This issue proposes two fixes to the subscription Manage Purchase page for the case of subscriptions that are up for renewal:
- Add a "Renew Now" link right above the "Edit Payment Method" nav item.
- If the user goes through the process of adding/editing a credit card, make the message they see after the card was added explain that the renewal hasn't happened yet, and give them a link to renew now there too.

## How to test

Add a subscription with an expiration date such it will expire soon (in the next 90 days) and then navigate to the Manage Purchase page and look for/test the new options shown in the screenshots below.

Or, add a subscription with an expiration date farther in the future, and verify that the patch doesn't change anything on the Manage Purchase page for it.

## Screenshots

### If the subscription is up for renewal soon

There's a new "Renew Now" link as shown by the arrow in the screenshot below.  (The other "Renew Now" button in this screenshot was already there before this pull request, and is more subtle in this example - although if it's expiring soon and not going to auto-renew it is in an error-style message, which is much louder.  This patch doesn't touch the existing link in either scenario, just adds the new one in the navigation below):

![renewing_soon_before_credit_card_change](https://user-images.githubusercontent.com/235183/43426670-849b59ac-9424-11e8-87c6-a8f07badd310.png)

After you click "Edit Payment Method" and successfully add a new credit card, the message you see on the screen after being redirected back to this page looks like the following (with a functional "Renew Now" link inside the message):

![renewing_soon_after_credit_card_change](https://user-images.githubusercontent.com/235183/43426677-8b89ad72-9424-11e8-87cd-3628f85f8c6d.png)

### If the subscription isn't up for renewal soon

There are no changes from before this pull request.  I'm showing screenshots here for comparison with the above.

The "Manage Purchase" page for the subscription looks like this:

![not_renewing_soon_before_credit_card_change](https://user-images.githubusercontent.com/235183/43426657-7ac9e66e-9424-11e8-90c0-84b38b0d791c.png)

With the following message after you change your payment method:

![not_renewing_soon_after_credit_card_change](https://user-images.githubusercontent.com/235183/43426664-7eb4494a-9424-11e8-9b37-31363dbf0f30.png)