### PR TITLE
Add parentheses spacing stylelint rules

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -9,6 +9,9 @@
     "function-name-case": "lower",
     "function-url-quotes": "always",
     "function-whitespace-after": "always",
+    "function-parentheses-space-inside": "always",
+
+    "media-feature-parentheses-space-inside": "always",
 
     "number-leading-zero": "always",
     "number-no-trailing-zeros": true,


### PR DESCRIPTION
Adds two rules to stylelint

```
    "function-parentheses-space-inside": "always",
    "media-feature-parentheses-space-inside": "always",
```

to test, run `npm run lint:css` and check that these rule violations appear