### PR TITLE
Reader: use button element for update pill

### DIFF
--- a/client/reader/update-notice/_style.scss
+++ b/client/reader/update-notice/_style.scss
@@ -2,10 +2,10 @@
 // Slides in when there are new posts available
 .reader-update-notice {
 	position: fixed;
-		top: ( 47px + 8px );
-		right: 16px;
+	top: ( 47px + 8px );
+	right: 16px;
 	background: rgba( $orange-jazzy, 0.96 );
-	padding: 6px 18px 6px 34px;
+	padding: 8px 18px 8px 34px;
 	border-radius: 24px;
 	color: white;
 	z-index: z-index( 'root', '.reader-update-notice' );
@@ -14,7 +14,8 @@
 	opacity: 0;
 	transform: translateY( -100px );
 	pointer-events: none;
-	transition: background 0.15s ease-in-out, transform 0.20s cubic-bezier( 0.175, 0.885, 0.320, 1.275 );
+	transition: background 0.15s ease-in-out, transform 0.2s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
+	font-size: 15px;
 
 	&:hover {
 		background: $blue-medium;
@@ -32,6 +33,5 @@
 	fill: white;
 	display: inline-block;
 	position: absolute;
-	top: 8px;
 	left: 10px;
 }

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -28,7 +28,7 @@ class UpdateNotice extends React.PureComponent {
 	static defaultProps = { onClick: noop };
 
 	render() {
-		const { count } = this.props;
+		const { count, cappedUnreadCount, translate } = this.props;
 
 		const counterClasses = classnames( {
 			'reader-update-notice': true,
@@ -36,14 +36,14 @@ class UpdateNotice extends React.PureComponent {
 		} );
 
 		return (
-			<div className={ counterClasses } onClick={ this.handleClick }>
+			<button className={ counterClasses } onClick={ this.handleClick }>
 				<DocumentHead unreadCount={ count } />
 				<Gridicon icon="arrow-up" size={ 18 } />
-				{ this.props.translate( '%s new post', '%s new posts', {
-					args: [ this.props.cappedUnreadCount ],
+				{ translate( '%s new post', '%s new posts', {
+					args: [ cappedUnreadCount ],
 					count,
 				} ) }
-			</div>
+			</button>
 		);
 	}
 


### PR DESCRIPTION
This PR swaps a `<div>` for a `<button>` on the Reader update pill.

Addresses the following a11y lint failures:

* Visible, non-interactive elements with click handlers must have at least one keyboard listener                                                                                          `jsx-a11y/click-events-have-key-events`
* Elements with the 'button' interactive role must be tabbable                                                                                          `jsx-a11y/interactive-supports-focus`

From `npx eslint client/reader/* --ext js,jsx`.

Part of #25921.

### To test

Load http://calypso.localhost:3000/?at=2018-07-12T15:06:00Z and wait for around one minute. The update pill should appear.

<img width="220" alt="screen shot 2018-07-31 at 17 11 46" src="https://user-images.githubusercontent.com/17325/43439015-248b04ec-94e5-11e8-8346-97bb1db35aa2.png">

Repeat for https://wpcalypso.wordpress.com/?at=2018-07-12T15:06:00Z and compare. There should be no visual differences.