### PR TITLE
Update 'Sign out' to 'Log out'

### DIFF
--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -200,7 +200,7 @@ const ReauthRequired = createReactClass( {
 						className="reauth-required__sign-out"
 						onClick={ this.getClickHandler( 'Reauth Required Log Out Link', userUtilities.logout ) }
 					>
-						{ this.props.translate( 'Not you? Sign Out' ) }
+						{ this.props.translate( 'Not you? Log out' ) }
 					</a>
 				</p>
 

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -107,9 +107,9 @@ class MeSidebar extends React.Component {
 							compact
 							className="sidebar__me-signout-button"
 							onClick={ this.onSignOut }
-							title={ translate( 'Sign out of WordPress.com' ) }
+							title={ translate( 'Log out of WordPress.com' ) }
 						>
-							{ translate( 'Sign Out' ) }
+							{ translate( 'Log Out' ) }
 						</Button>
 					</div>
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/24451

Testing **Instructions**

1. Visit /me
2. Ensure correct text displays

**Before**

<img width="276" alt="screen shot 2018-07-31 at 3 32 00 pm" src="https://user-images.githubusercontent.com/128826/43439519-e341e446-94d6-11e8-986a-56e7475615e5.png">

**After**

<img width="272" alt="screen shot 2018-07-31 at 3 31 34 pm" src="https://user-images.githubusercontent.com/128826/43439506-d7bfc1e2-94d6-11e8-8ee8-7a5e30515e6b.png">
