### PR TITLE
Checkout: Remove trailing zero decimals.

### DIFF
--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -28,6 +28,7 @@ import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import { removeItem } from 'lib/upgrades/actions';
 import { localize } from 'i18n-calypso';
 import { calculateMonthlyPriceForPlan, getBillingMonthsForPlan } from 'lib/plans';
+import { getCurrencyObject } from 'lib/format-currency';
 
 const getIncludedDomain = cartItems.getIncludedDomain;
 
@@ -77,12 +78,15 @@ export class CartItem extends React.Component {
 		}
 
 		const { months, monthlyPrice } = this.calcMonthlyBillingDetails();
+		const price = getCurrencyObject( monthlyPrice, currency );
 
 		return translate( '(%(monthlyPrice)s %(currency)s x %(months)d months)', {
 			args: {
 				months,
 				currency,
-				monthlyPrice: monthlyPrice.toFixed( currency === 'JPY' ? 0 : 2 ),
+				monthlyPrice: `${ price.integer }${
+					monthlyPrice - price.integer > 0 ? price.fraction : ''
+				}`,
 			},
 		} );
 	}


### PR DESCRIPTION
This PR removes trailing zero decimals from the items in Order Summary.

*Before*
<img width="277" alt="checkout_ _taggon_on_wordpress_ _wordpress_com" src="https://user-images.githubusercontent.com/212034/43446487-f8bf9c20-94e3-11e8-92de-60d49002490b.png">

*After*
<img width="277" alt="checkout_ _taggon_on_wordpress_ _wordpress_com-2" src="https://user-images.githubusercontent.com/212034/43446499-050e9fd0-94e4-11e8-82da-4bc5845a0fcc.png">

## How to test

1. Add any paid plan to the cart.
2. Move to the checkout page and check if the monthly price has no zero decimals.

