### PR TITLE
DevDocs: Remove UserItem component from playground scope

### DIFF
--- a/client/devdocs/design/playground-scope.js
+++ b/client/devdocs/design/playground-scope.js
@@ -112,7 +112,6 @@ export TimeSince from 'components/time-since';
 export Timezone from 'components/timezone';
 export TokenFields from 'components/token-field';
 export Tooltip from 'components/tooltip';
-export UserItem from 'components/user/docs/example';
 export Version from 'components/version';
 export VerticalMenu from 'components/vertical-menu';
 export VerticalNav from 'components/vertical-nav';


### PR DESCRIPTION
@scruffian noted in https://github.com/Automattic/wp-calypso/pull/24230#discussion_r206252245 that the `UserItem` component was incorrectly included in the playground scope list.

The component won't play nicely in the playground because it requires a user prop, so rather than fixing the import path it seems better to remove it from the list for now.