### PR TITLE
Change reported path from /feature/plugins to /feature/themes

### DIFF
--- a/client/my-sites/feature-upsell/themes-upsell.jsx
+++ b/client/my-sites/feature-upsell/themes-upsell.jsx
@@ -81,8 +81,8 @@ class ThemesUpsellComponent extends Component {
 					</React.Fragment>
 				) }
 
-				<PageViewTracker path={ '/feature/plugins/:site' } title="PluginsUpsell" />
-				<DocumentHead title={ 'Plugins' } />
+				<PageViewTracker path={ '/feature/themes/:site' } title="ThemesUpsell" />
+				<DocumentHead title={ 'Themes' } />
 
 				<div className="feature-upsell__card">
 					<h1 className="feature-upsell__card-header is-capital is-main">


### PR DESCRIPTION
On page `/feature/themes` invalid pageview path was reported to tracks (`/feature/plugins`). This PR restores the correct path.

Test plan:
1. Go to /feature/themes and check page path reported to pixel.wp.com in network monitor