### PR TITLE
[nudge-a-palooza] Connect recordTracksEvents to dispatch to actually log CTA events

### DIFF
--- a/client/my-sites/feature-upsell/ads-upsell.jsx
+++ b/client/my-sites/feature-upsell/ads-upsell.jsx
@@ -248,8 +248,8 @@ class WordAdsUpsellComponent extends Component {
 	handleUpgradeButtonClick = () => {
 		const { trackTracksEvent, selectedSiteSlug } = this.props;
 
-		trackTracksEvent( 'calypso_upsell_landing_page_cta_click', {
-			cta_name: 'ads-upsell',
+		trackTracksEvent( 'calypso_banner_cta_click', {
+			cta_name: 'upsell-page-ads',
 		} );
 
 		page( `/checkout/${ selectedSiteSlug }/${ getPlanPath( PLAN_PREMIUM ) || '' }` );
@@ -286,9 +286,15 @@ const mapStateToProps = state => {
 				isRequestingActivePromotions( state ) ),
 		currencyCode: getCurrentUserCurrencyCode( state ),
 		selectedSiteSlug: getSiteSlug( state, selectedSiteId ),
-		trackTracksEvent: recordTracksEvent,
 	};
 };
 
-export default connect( mapStateToProps )( localize( WordAdsUpsellComponent ) );
+const mapDispatchToProps = dispatch => ( {
+	trackTracksEvent: ( name, props ) => dispatch( recordTracksEvent( name, props ) ),
+} );
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( WordAdsUpsellComponent ) );
 /* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/my-sites/feature-upsell/plugins-upsell.jsx
+++ b/client/my-sites/feature-upsell/plugins-upsell.jsx
@@ -43,8 +43,8 @@ class PluginsUpsellComponent extends Component {
 	handleUpgradeButtonClick = () => {
 		const { trackTracksEvent, selectedSiteSlug } = this.props;
 
-		trackTracksEvent( 'calypso_upsell_landing_page_cta_click', {
-			cta_name: 'plugins-upsell',
+		trackTracksEvent( 'calypso_banner_cta_click', {
+			cta_name: 'upsell-page-plugins',
 		} );
 
 		page( `/checkout/${ selectedSiteSlug }/${ getPlanPath( PLAN_BUSINESS ) || '' }` );
@@ -280,8 +280,14 @@ const mapStateToProps = state => {
 		currencyCode: getCurrentUserCurrencyCode( state ),
 		price,
 		selectedSiteSlug: getSiteSlug( state, selectedSiteId ),
-		trackTracksEvent: recordTracksEvent,
 	};
 };
 
-export default connect( mapStateToProps )( localize( PluginsUpsellComponent ) );
+const mapDispatchToProps = dispatch => ( {
+	trackTracksEvent: ( name, props ) => dispatch( recordTracksEvent( name, props ) ),
+} );
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( PluginsUpsellComponent ) );

--- a/client/my-sites/feature-upsell/store-upsell.jsx
+++ b/client/my-sites/feature-upsell/store-upsell.jsx
@@ -176,8 +176,8 @@ class StoreUpsellComponent extends Component {
 	handleUpgradeButtonClick = () => {
 		const { trackTracksEvent, selectedSiteSlug } = this.props;
 
-		trackTracksEvent( 'calypso_upsell_landing_page_cta_click', {
-			cta_name: 'store-upsell',
+		trackTracksEvent( 'calypso_banner_cta_click', {
+			cta_name: 'upsell-page-store',
 		} );
 
 		page( `/checkout/${ selectedSiteSlug }/${ getPlanPath( PLAN_BUSINESS ) || '' }` );
@@ -218,5 +218,12 @@ const mapStateToProps = state => {
 	};
 };
 
-export default connect( mapStateToProps )( localize( StoreUpsellComponent ) );
+const mapDispatchToProps = dispatch => ( {
+	trackTracksEvent: ( name, props ) => dispatch( recordTracksEvent( name, props ) ),
+} );
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( StoreUpsellComponent ) );
 /* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/my-sites/feature-upsell/themes-upsell.jsx
+++ b/client/my-sites/feature-upsell/themes-upsell.jsx
@@ -43,8 +43,8 @@ class ThemesUpsellComponent extends Component {
 	handleUpgradeButtonClick = () => {
 		const { trackTracksEvent, selectedSiteSlug } = this.props;
 
-		trackTracksEvent( 'calypso_upsell_landing_page_cta_click', {
-			cta_name: 'themes-upsell',
+		trackTracksEvent( 'calypso_banner_cta_click', {
+			cta_name: 'upsell-page-themes',
 		} );
 
 		page( `/checkout/${ selectedSiteSlug }/${ getPlanPath( PLAN_BUSINESS ) || '' }` );
@@ -280,8 +280,14 @@ const mapStateToProps = state => {
 		currencyCode: getCurrentUserCurrencyCode( state ),
 		price,
 		selectedSiteSlug: getSiteSlug( state, selectedSiteId ),
-		trackTracksEvent: recordTracksEvent,
 	};
 };
 
-export default connect( mapStateToProps )( localize( ThemesUpsellComponent ) );
+const mapDispatchToProps = dispatch => ( {
+	trackTracksEvent: ( name, props ) => dispatch( recordTracksEvent( name, props ) ),
+} );
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( ThemesUpsellComponent ) );


### PR DESCRIPTION
`trackTracksEvent` function calls did nothing because it's just an action creator and not a function that actually records the event, this PR plugs it in to `dispatch()`

Test plan:
1. Visit the following 4 pages:
- /feature/plugins
- /feature/themes
- /feature/ads
- /feature/store
2. Click on a CTA on each of them and confirm in network monitor a `calypso_banner_cta_click` event is being sent to pixel.wp.com