### PR TITLE
Update babel config for tests

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -32,7 +32,6 @@ const config = {
 		[ '@babel/plugin-proposal-class-properties', { loose: true } ],
 		[ '@babel/plugin-transform-classes', { loose: false } ],
 		[ '@babel/plugin-transform-template-literals', { loose: true } ],
-		! isCalypso && 'add-module-exports',
 		isCalypso && [
 			path.join(
 				__dirname,
@@ -58,7 +57,8 @@ const config = {
 	] ),
 	env: {
 		test: {
-			plugins: [ './server/bundler/babel/babel-lodash-es' ],
+			presets: [ [ '@babel/env', { targets: { node: 'current' } } ] ],
+			plugins: [ 'add-module-exports', './server/bundler/babel/babel-lodash-es' ],
 		},
 	},
 };


### PR DESCRIPTION
Configures Babel for tests to transpile with the Node target. This should make the transpilation a bit faster (fewer transforms to apply) and also help greatly with debugging tests: the sources in debugger are the original ones, not the transpiled ones. Async functions, for example, tend to be transpiled into code that's hard to read for humans.

Also moves the `add-module-exports` transform to the `env.test` section.

Related PR that improves the config for server (also Node): #25830.