### PR TITLE
Gutenberg: include @wordpress/api-fetch package

### DIFF
--- a/client/gutenberg/editor/test/index.js
+++ b/client/gutenberg/editor/test/index.js
@@ -21,6 +21,8 @@ import {
 
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 
+import apiFetch from '@wordpress/api-fetch';
+
 describe( 'Gutenberg @wordress/data package', () => {
 	describe( 'registerStore', () => {
 		it( 'should be shorthand for reducer, actions, selectors registration', () => {
@@ -145,6 +147,117 @@ describe( 'Gutenberg @wordress/blocks package', () => {
 			expect( block.innerBlocks ).toHaveLength( 1 );
 			expect( block.innerBlocks[ 0 ].name ).toBe( 'core/test-block' );
 			expect( typeof block.clientId ).toBe( 'string' );
+		} );
+	} );
+} );
+
+describe( 'Gutenberg @wordress/api-fetch package', () => {
+	// Try tests from https://github.com/WordPress/gutenberg/blob/54990c0f77294e6603cc4e0aa957c0679c1bf242/packages/api-fetch/src/test/index.js
+	describe( 'apiFetch', () => {
+		const originalFetch = window.fetch;
+		beforeAll( () => {
+			window.fetch = jest.fn();
+		} );
+
+		afterAll( () => {
+			window.fetch = originalFetch;
+		} );
+
+		it( 'should call the API propertly', () => {
+			window.fetch.mockReturnValue(
+				Promise.resolve( {
+					status: 200,
+					json() {
+						return Promise.resolve( { message: 'ok' } );
+					},
+				} )
+			);
+
+			return apiFetch( { path: '/random' } ).then( body => {
+				expect( body ).toEqual( { message: 'ok' } );
+			} );
+		} );
+
+		it( 'should return the error message properly', () => {
+			window.fetch.mockReturnValue(
+				Promise.resolve( {
+					status: 400,
+					json() {
+						return Promise.resolve( {
+							code: 'bad_request',
+							message: 'Bad Request',
+						} );
+					},
+				} )
+			);
+
+			return apiFetch( { path: '/random' } ).catch( body => {
+				expect( body ).toEqual( {
+					code: 'bad_request',
+					message: 'Bad Request',
+				} );
+			} );
+		} );
+
+		it( 'should return invalid JSON error if no json response', () => {
+			window.fetch.mockReturnValue(
+				Promise.resolve( {
+					status: 200,
+				} )
+			);
+
+			return apiFetch( { path: '/random' } ).catch( body => {
+				expect( body ).toEqual( {
+					code: 'invalid_json',
+					message: 'The response is not a valid JSON response.',
+				} );
+			} );
+		} );
+
+		it( 'should return invalid JSON error if response is not valid', () => {
+			window.fetch.mockReturnValue(
+				Promise.resolve( {
+					status: 200,
+					json() {
+						return Promise.reject();
+					},
+				} )
+			);
+
+			return apiFetch( { path: '/random' } ).catch( body => {
+				expect( body ).toEqual( {
+					code: 'invalid_json',
+					message: 'The response is not a valid JSON response.',
+				} );
+			} );
+		} );
+
+		it( 'should not try to parse the response', () => {
+			window.fetch.mockReturnValue(
+				Promise.resolve( {
+					status: 200,
+				} )
+			);
+
+			return apiFetch( { path: '/random', parse: false } ).then( response => {
+				expect( response ).toEqual( {
+					status: 200,
+				} );
+			} );
+		} );
+
+		it( 'should not try to parse the error', () => {
+			window.fetch.mockReturnValue(
+				Promise.resolve( {
+					status: 400,
+				} )
+			);
+
+			return apiFetch( { path: '/random', parse: false } ).catch( response => {
+				expect( response ).toEqual( {
+					status: 400,
+				} );
+			} );
 		} );
 	} );
 } );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1247,6 +1247,16 @@
         "webpack-log": "^1.1.2"
       }
     },
+    "@wordpress/api-fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-1.1.0.tgz",
+      "integrity": "sha512-5rVyT7U4wXAn776Q+TyKI3959dnKrcTRNW5a2xqXH3oaioxUyb39ym+AnXjBS2P0fN0Xl1kboSq6Hcr9hwp8VA==",
+      "requires": {
+        "@babel/runtime": "^7.0.0-beta.52",
+        "@wordpress/hooks": "^1.3.2",
+        "@wordpress/i18n": "^1.2.2"
+      }
+    },
     "@wordpress/autop": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-1.1.2.tgz",
@@ -1479,7 +1489,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -6450,8 +6459,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6469,13 +6477,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6488,18 +6494,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6602,8 +6605,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6613,7 +6615,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6626,20 +6627,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6656,7 +6654,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6729,8 +6726,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6740,7 +6736,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6816,8 +6811,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6847,7 +6841,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6865,7 +6858,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6904,13 +6896,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -9536,8 +9526,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "longest-streak": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@babel/preset-env": "7.0.0-beta.55",
     "@babel/preset-react": "7.0.0-beta.55",
     "@babel/runtime": "7.0.0-beta.55",
+    "@wordpress/api-fetch": "1.1.0",
     "@wordpress/blocks": "1.0.0",
     "@wordpress/data": "1.0.1",
     "autoprefixer": "9.0.2",


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/26180

Set up a Calypso test branch for `@wordpress/api-fetch` package and carry over existing tests from Gutenberg repo.

This also includes the following sub-dependencies:

- `@wordpress/i18n`

### Testing instructions

- `npm run test-client client/gutenberg/editor/test/index.js`
- Calypso smoke test
- Verify that we haven't added bloat to other bundles beside the Gutenberg branch: http://iscalypsofastyet.com/branch?branch=try/wordpress-api-fetch