### PR TITLE
Gutenberg: import @wodpress/block-serialization-spec-parser package

### DIFF
--- a/client/gutenberg/editor/test/index.js
+++ b/client/gutenberg/editor/test/index.js
@@ -21,6 +21,8 @@ import {
 
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 
+import { parse } from '@wordpress/block-serialization-spec-parser';
+
 import apiFetch from '@wordpress/api-fetch';
 
 describe( 'Gutenberg @wordress/data package', () => {
@@ -148,6 +150,24 @@ describe( 'Gutenberg @wordress/blocks package', () => {
 			expect( block.innerBlocks[ 0 ].name ).toBe( 'core/test-block' );
 			expect( typeof block.clientId ).toBe( 'string' );
 		} );
+	} );
+} );
+
+describe( 'block-serialization-spec-parser', () => {
+	// Try test from https://github.com/WordPress/gutenberg/blob/54990c0f77294e6603cc4e0aa957c0679c1bf242/packages/block-serialization-spec-parser/test/index.js
+	test( 'parse() works properly', () => {
+		const result = parse( '<!-- wp:core/more --><!--more--><!-- /wp:core/more -->' );
+
+		expect( result ).toMatchInlineSnapshot( `
+Array [
+  Object {
+    "attrs": null,
+    "blockName": "core/more",
+    "innerBlocks": Array [],
+    "innerHTML": "<!--more-->",
+  },
+]
+` );
 	} );
 } );
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@babel/preset-react": "7.0.0-beta.55",
     "@babel/runtime": "7.0.0-beta.55",
     "@wordpress/api-fetch": "1.1.0",
+    "@wordpress/block-serialization-spec-parser": "1.0.1",
     "@wordpress/blocks": "1.0.0",
     "@wordpress/data": "1.0.1",
     "autoprefixer": "9.0.2",


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/26180

Set up a Calypso test branch for `@wordpress/block-serialization-spec-parser` package and carry over existing tests from Gutenberg repo.

### Testing instructions

- `npm run test-client client/gutenberg/editor/test/index.js`
- Calypso smoke test
- Verify that we haven't added bloat to other bundles beside the Gutenberg branch: http://iscalypsofastyet.com/branch?branch=try/wordpress-block-serialization