### PR TITLE
Site Switcher: fix arrow direction in RTL mode (#2)

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -27,7 +27,6 @@ import getVisibleSites from 'state/selectors/get-visible-sites';
 import { infoNotice, removeNotice } from 'state/notices/actions';
 import { getNoticeLastTimeShown } from 'state/notices/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
-import isRtl from 'state/selectors/is-rtl';
 import { hasAllSitesList } from 'state/sites/selectors';
 
 class CurrentSite extends Component {
@@ -92,7 +91,7 @@ class CurrentSite extends Component {
 	};
 
 	render() {
-		const { selectedSite, translate, anySiteSelected, rtlOn } = this.props;
+		const { selectedSite, translate, anySiteSelected } = this.props;
 
 		if ( ! anySiteSelected.length || ( ! selectedSite && ! this.props.hasAllSitesList ) ) {
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -116,7 +115,7 @@ class CurrentSite extends Component {
 				{ this.props.siteCount > 1 && (
 					<span className="current-site__switch-sites">
 						<Button borderless onClick={ this.switchSites }>
-							<Gridicon icon={ rtlOn ? 'chevron-right' : 'chevron-left' } />
+							<Gridicon icon="chevron-left" />
 							<span className="current-site__switch-sites-label">
 								{ translate( 'Switch Site' ) }
 							</span>
@@ -141,7 +140,6 @@ class CurrentSite extends Component {
 
 export default connect(
 	state => ( {
-		rtlOn: isRtl( state ),
 		selectedSite: getSelectedSite( state ),
 		anySiteSelected: getSelectedOrAllSites( state ),
 		siteCount: getVisibleSites( state ).length,


### PR DESCRIPTION
This basically reverts #21093 - since a global transform [already exists](https://github.com/Automattic/wp-calypso/blob/dbc2486ad412d840f8bb90521fbcc62050e62b9a/assets/stylesheets/_main.scss#L109) for the chevron icon.

**Before**:
<img width="328" alt="screen shot 2018-08-01 at 11 08 02" src="https://user-images.githubusercontent.com/844866/43509800-543b6078-957c-11e8-8a16-6a3cc64e1a96.png">

**After**:
<img width="294" alt="screen shot 2018-08-01 at 11 11 57" src="https://user-images.githubusercontent.com/844866/43509806-588a707e-957c-11e8-9e8a-ae5c2d7d2f99.png">
