### PR TITLE
Renovate: Include @babel/* in updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,16 +5,6 @@
   ],
   "statusCheckVerify": true,
   "ignoreDeps": [
-    "@babel/cli",
-    "@babel/core",
-    "@babel/plugin-proposal-export-default-from",
-    "@babel/plugin-syntax-jsx",
-    "@babel/plugin-transform-runtime",
-    "@babel/polyfill",
-    "@babel/preset-env",
-    "@babel/preset-react",
-    "@babel/preset-stage-2",
-    "@babel/runtime",
     "jquery"
   ],
   "labels": [


### PR DESCRIPTION
Now that we're past the move to the babel7-style config, we can drop the ignores.