### PR TITLE
Domains: Add explanatory copy to Domain Mapping page.

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -21,7 +21,7 @@ import DomainRegistrationSuggestion from 'components/domains/domain-registration
 import DomainProductPrice from 'components/domains/domain-product-price';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
-import { MAP_EXISTING_DOMAIN } from 'lib/url/support';
+import { MAP_EXISTING_DOMAIN, INCOMING_DOMAIN_TRANSFER } from 'lib/url/support';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 import {
 	recordAddDomainButtonClickInMapDomain,
@@ -136,10 +136,26 @@ class MapDomainStep extends React.Component {
 
 					<div className="map-domain-step__domain-text">
 						{ translate(
-							"Update your domain's name servers to point it to your WordPress.com site. Domain registration and billing will remain at your current provider. {{a}}Learn more{{/a}}",
+							"We'll add your domain and help you change its settings so it points to your site. Keep your domain renewed with your current provider (they'll remind you when it's time.) {{a}}Learn more about adding a domain{{/a}}.",
 							{
 								components: {
 									a: <a href={ MAP_EXISTING_DOMAIN } rel="noopener noreferrer" target="_blank" />,
+								},
+							}
+						) }
+					</div>
+					<div className="map-domain-step__domain-text">
+						{ translate(
+							"You can transfer your domain's registration to WordPress.com and renew your domain and site from the same place. {{a}}Learn more about domain transfers{{/a}}.",
+							{
+								components: {
+									a: (
+										<a
+											href={ INCOMING_DOMAIN_TRANSFER }
+											rel="noopener noreferrer"
+											target="_blank"
+										/>
+									),
 								},
 							}
 						) }

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -21,6 +21,7 @@ import DomainRegistrationSuggestion from 'components/domains/domain-registration
 import DomainProductPrice from 'components/domains/domain-product-price';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
+import { MAP_EXISTING_DOMAIN } from 'lib/url/support';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 import {
 	recordAddDomainButtonClickInMapDomain,
@@ -132,6 +133,19 @@ class MapDomainStep extends React.Component {
 					</div>
 
 					{ this.domainRegistrationUpsell() }
+
+					<div className="map-domain-step__domain-text">
+						{ translate(
+							'Domain registration and billing will remain at your current provider,' +
+								" and you'll update your domain's DNS to point it to your WordPress.com site. " +
+								'{{a}}Learn more{{/a}}',
+							{
+								components: {
+									a: <a href={ MAP_EXISTING_DOMAIN } rel="noopener noreferrer" target="_blank" />,
+								},
+							}
+						) }
+					</div>
 				</form>
 			</div>
 		);

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -136,9 +136,7 @@ class MapDomainStep extends React.Component {
 
 					<div className="map-domain-step__domain-text">
 						{ translate(
-							'Domain registration and billing will remain at your current provider,' +
-								" and you'll update your domain's DNS to point it to your WordPress.com site. " +
-								'{{a}}Learn more{{/a}}',
+							"Update your domain's nameservers to point it to your WordPress.com site. Domain registration and billing will remain at your current provider. {{a}}Learn more{{/a}}",
 							{
 								components: {
 									a: <a href={ MAP_EXISTING_DOMAIN } rel="noopener noreferrer" target="_blank" />,

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -136,7 +136,7 @@ class MapDomainStep extends React.Component {
 
 					<div className="map-domain-step__domain-text">
 						{ translate(
-							"Update your domain's nameservers to point it to your WordPress.com site. Domain registration and billing will remain at your current provider. {{a}}Learn more{{/a}}",
+							"Update your domain's name servers to point it to your WordPress.com site. Domain registration and billing will remain at your current provider. {{a}}Learn more{{/a}}",
 							{
 								components: {
 									a: <a href={ MAP_EXISTING_DOMAIN } rel="noopener noreferrer" target="_blank" />,

--- a/client/components/domains/map-domain-step/style.scss
+++ b/client/components/domains/map-domain-step/style.scss
@@ -54,6 +54,11 @@
 	}
 }
 
+.map-domain-step__domain-text {
+	font-size: 0.9em;
+	margin-top: 20px;
+}
+
 .map-domain-step__add-domain .form-text-input-with-affixes__prefix {
 	flex: inherit;
 }

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -229,7 +229,7 @@ class TransferDomainStep extends React.Component {
 						{ translate(
 							'Transfer your domain away from your current provider to WordPress.com so you can update settings, ' +
 								"renew your domain, and more \u2013 right in your dashboard. We'll renew it for another year " +
-								'when the transfer is successful. {{a}}Learn more{{/a}}',
+								'when the transfer is successful. {{a}}Learn more about domain transfers.{{/a}}',
 							{
 								components: {
 									a: (


### PR DESCRIPTION
Similar to the Transfers page, let's add some explanation and a link to learn more to the Domain Mapping page. Thoughts on what the copy should say are welcome!

**Before this PR**

<img width="762" alt="screen shot 2018-08-01 at 9 36 07 am" src="https://user-images.githubusercontent.com/2124984/43524883-5c2cf322-956e-11e8-9df7-1b6e57a2d5bd.png">

**After this PR**

<img width="761" alt="screen shot 2018-08-01 at 9 35 46 am" src="https://user-images.githubusercontent.com/2124984/43524879-5aaeaaf4-956e-11e8-88ee-b6e1fe39d1cd.png">

**Steps to test:**

* Switch to this PR and navigate to `/start/domains/`
* Click "Already own a domain?" and select Buy Domain Mapping
* Check for added copy under the form.