### PR TITLE
Extract the getToursHistory selector to separate module

### DIFF
--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -40,7 +40,7 @@ import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer'
 import NonSupportedJetpackVersionNotice from './not-supported-jetpack-version';
 import NoPermissionsError from './no-permissions-error';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
-import { getToursHistory } from 'state/ui/guided-tours/selectors';
+import getToursHistory from 'state/ui/guided-tours/selectors/get-tours-history';
 
 const SinglePlugin = createReactClass( {
 	displayName: 'SinglePlugin',

--- a/client/state/ui/guided-tours/selectors/get-tours-history.js
+++ b/client/state/ui/guided-tours/selectors/get-tours-history.js
@@ -1,0 +1,8 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getPreference } from 'state/preferences/selectors';
+
+export default state => getPreference( state, 'guided-tours-history' );

--- a/client/state/ui/guided-tours/selectors/index.js
+++ b/client/state/ui/guided-tours/selectors/index.js
@@ -70,17 +70,16 @@ const getToursFromFeaturesReached = createSelector(
 					return newTours ? [ ...allTours, ...newTours ] : allTours;
 				}, [] )
 		),
-	getActionLog
+	[ getActionLog ]
 );
 
 /*
  * Returns the names of the tours that the user has previously seen, both
  * recently and in the past.
  */
-const getToursSeen = createSelector(
-	state => uniq( map( getToursHistory( state ), 'tourName' ) ),
-	getToursHistory
-);
+const getToursSeen = createSelector( state => uniq( map( getToursHistory( state ), 'tourName' ) ), [
+	getToursHistory,
+] );
 
 /*
  * Returns the name and timestamp of the tour requested via the URL's query
@@ -157,14 +156,17 @@ const findTriggeredTour = state => {
 
 const isSectionBlacklisted = state => includes( BLACKLISTED_SECTIONS, getSectionName( state ) );
 
-export const hasTourJustBeenVisible = createSelector( ( state, now = Date.now() ) => {
-	const last = findLast( getActionLog( state ), {
-		type: GUIDED_TOUR_UPDATE,
-		shouldShow: false,
-	} );
-	// threshold is one minute
-	return last && now - last.timestamp < 60000;
-}, getActionLog );
+export const hasTourJustBeenVisible = createSelector(
+	( state, now = Date.now() ) => {
+		const last = findLast( getActionLog( state ), {
+			type: GUIDED_TOUR_UPDATE,
+			shouldShow: false,
+		} );
+		// threshold is one minute
+		return last && now - last.timestamp < 60000;
+	},
+	[ getActionLog ]
+);
 
 const isConflictingWithOtherHelp = state =>
 	hasTourJustBeenVisible( state ) || shouldViewBeVisible( state );

--- a/client/state/ui/guided-tours/selectors/index.js
+++ b/client/state/ui/guided-tours/selectors/index.js
@@ -27,11 +27,12 @@ import { getSectionName } from 'state/ui/selectors';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import getInitialQueryArguments from 'state/selectors/get-initial-query-arguments';
 import { getActionLog } from 'state/ui/action-log/selectors';
-import { getPreference, preferencesLastFetchedTimestamp } from 'state/preferences/selectors';
+import { preferencesLastFetchedTimestamp } from 'state/preferences/selectors';
 import { shouldViewBeVisible } from 'state/ui/first-view/selectors';
 import GuidedToursConfig from 'layout/guided-tours/config';
 import createSelector from 'lib/create-selector';
 import findOngoingTour from './find-ongoing-tour';
+import getToursHistory from './get-tours-history';
 
 const BLACKLISTED_SECTIONS = [
 	'signup',
@@ -39,7 +40,6 @@ const BLACKLISTED_SECTIONS = [
 	'checkout-thank-you', // thank you page
 ];
 
-export const getToursHistory = state => getPreference( state, 'guided-tours-history' );
 const debug = debugFactory( 'calypso:guided-tours' );
 
 const mappable = x => ( ! Array.isArray( x ) ? [ x ] : x );


### PR DESCRIPTION
Prevents the `plugins` section inflation merged in #26229. Importing the whole `guided-tours/selectors` module drags in a lot of code from `layout/guided-tours` and either duplicates a lot of code in `plugins` section, or creates an unneeded shared chunk.

ICFY results:
```
chunk                                     stat_size             parsed_size             gzip_size
async-load-layout-guided-tours            +176877 B  (+528.1%)     +88950 B  (+608.5%)   +18150 B  (+402.5%)
async-load-layout-guided-tours~plugins    -176705 B  (deleted)     -90086 B  (deleted)   -19092 B  (deleted)
plugins                                    +15865 B    (+4.6%)      +7489 B    (+4.2%)    +1943 B    (+4.8%)
```

The second commit is a little fix for `createSelector` dependants arg: it writes them explicitly as arrays. The shortcut used before doesn't work very well with selectors that return arrays.