### PR TITLE
Editor: Simple Payments plugin now queries for Plans

### DIFF
--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -19,16 +19,28 @@ import getSimplePayments from 'state/selectors/get-simple-payments';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import formatCurrency from 'lib/format-currency';
 import QuerySimplePayments from 'components/data/query-simple-payments';
+import QuerySitePlans from 'components/data/query-site-plans';
 import QueryMedia from 'components/data/query-media';
-import { hasFeature } from 'state/sites/plans/selectors';
+import { getCurrentPlan, hasFeature } from 'state/sites/plans/selectors';
 import { FEATURE_SIMPLE_PAYMENTS } from 'lib/plans/constants';
 
 class SimplePaymentsView extends Component {
 	render() {
-		const { translate, productId, product, siteId, planHasSimplePaymentsFeature } = this.props;
+		const {
+			translate,
+			productId,
+			product,
+			siteId,
+			sitePlan,
+			planHasSimplePaymentsFeature,
+		} = this.props;
 
 		if ( ! product ) {
 			return <QuerySimplePayments siteId={ siteId } productId={ productId } />;
+		}
+
+		if ( ! sitePlan ) {
+			return <QuerySitePlans siteId={ siteId } />;
 		}
 
 		if ( ! planHasSimplePaymentsFeature ) {
@@ -107,12 +119,14 @@ SimplePaymentsView = connect( ( state, props ) => {
 
 	const { id: productId = null } = shortcodeData;
 	const siteId = getSelectedSiteId( state );
+	const sitePlan = getCurrentPlan( state, siteId );
 	const product = getSimplePayments( state, siteId, productId );
 
 	return {
 		shortcodeData,
 		productId,
 		siteId,
+		sitePlan,
 		product,
 		productImage: getMediaItem( state, siteId, get( product, 'featuredImageId' ) ),
 		planHasSimplePaymentsFeature: hasFeature( state, siteId, FEATURE_SIMPLE_PAYMENTS ),


### PR DESCRIPTION
Fixes #26373 

When loading the editor directly from the _Edit_ link on a site's frontend, if the page or post has simple payment buttons they won't show correctly, displaying the admin alert instead. This is because the site's plan state isn't ready.

| Before | After |
| - | - |
| ![screen shot 2018-08-01 at 13 27 57](https://user-images.githubusercontent.com/233601/43534895-d718f8ae-958e-11e8-95d8-81862b53d369.png) | ![screen shot 2018-08-01 at 13 26 57](https://user-images.githubusercontent.com/233601/43534906-dfd01fd6-958e-11e8-9f20-7b791f332d31.png) |

To test this:

* On a Premium or Business Sites (Premium or Professional for Jetpack), add one or more Simple Payments Products to a page or post.
* Publish the changes.
* Refresh the editor.

Without this fix, the feature not supported warning will show, but with this fix applied, the product should render correctly.