### PR TITLE
 Sidebar: Enable Import item in all environments

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -53,6 +53,7 @@
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
+		"manage/import-in-sidebar": true,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
 		"manage/media": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -54,6 +54,7 @@
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
+		"manage/import-in-sidebar": true,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
 		"manage/media": true,

--- a/config/production.json
+++ b/config/production.json
@@ -57,6 +57,7 @@
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
+		"manage/import-in-sidebar": true,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
 		"manage/media": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -59,6 +59,7 @@
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
+		"manage/import-in-sidebar": true,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
 		"manage/media": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -67,6 +67,7 @@
 		"manage/custom-post-types": true,
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
+		"manage/import-in-sidebar": true,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
 		"manage/media": true,


### PR DESCRIPTION
~~Note: Targeting branch `add/import-to-sidebar-behind-dev-flag` in #26416 -- will repoint at master when it lands.~~

This change enables the `manage/import-in-sidebar` flag in all environments.