### PR TITLE
Only show google my business banner when feature is enabled

### DIFF
--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -14,7 +14,6 @@ import Gridicon from 'gridicons';
  */
 import Button from 'components/button';
 import Card from 'components/card';
-import config from 'config';
 import isGoogleMyBusinessStatsNudgeDismissed from 'state/selectors/is-google-my-business-stats-nudge-dismissed';
 import QueryPreferences from 'components/data/query-preferences';
 import SectionHeader from 'components/section-header';
@@ -67,7 +66,7 @@ class GoogleMyBusinessStatsNudge extends Component {
 	}
 
 	render() {
-		if ( ! config.isEnabled( 'google-my-business' ) || ! this.isVisible() ) {
+		if ( ! this.isVisible() ) {
 			return null;
 		}
 

--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -14,6 +14,7 @@ import Gridicon from 'gridicons';
  */
 import Button from 'components/button';
 import Card from 'components/card';
+import config from 'config';
 import isGoogleMyBusinessStatsNudgeDismissed from 'state/selectors/is-google-my-business-stats-nudge-dismissed';
 import QueryPreferences from 'components/data/query-preferences';
 import SectionHeader from 'components/section-header';
@@ -66,7 +67,7 @@ class GoogleMyBusinessStatsNudge extends Component {
 	}
 
 	render() {
-		if ( ! this.isVisible() ) {
+		if ( ! config.isEnabled( 'google-my-business' ) || ! this.isVisible() ) {
 			return null;
 		}
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -152,13 +152,14 @@ class StatsSite extends Component {
 				/>
 				<div id="my-stats-content">
 					{ config.isEnabled( 'onboarding-checklist' ) && <ChecklistBanner siteId={ siteId } /> }
-					{ siteId && (
-						<GoogleMyBusinessStatsNudge
-							siteSlug={ slug }
-							siteId={ siteId }
-							visible={ isGoogleMyBusinessStatsNudgeVisible }
-						/>
-					) }
+					{ config.isEnabled( 'google-my-business' ) &&
+						siteId && (
+							<GoogleMyBusinessStatsNudge
+								siteSlug={ slug }
+								siteId={ siteId }
+								visible={ isGoogleMyBusinessStatsNudgeVisible }
+							/>
+						) }
 					<ChartTabs
 						barClick={ this.barClick }
 						switchTab={ this.switchChart }


### PR DESCRIPTION
This PR is adding the missing feature check for the "Google my business banner". The banner is being displayed on the stats page even though the feature is disabled. 

**Note:** This PR especially targets `wp-desktop` as the feature is disabled but the banner is displayed. Clicking the CTA ends on a blank page.

### How to test
- Go to `https://wpcalypso.wordpress.com/`, click the `wpcalypso` icon (bottom right) go to preferences and delete `google-my-business-dismissible-nudge`
- In `config/development.json` set the feature flag for `google-my-business` to `true`.
- Start the dev server
- Go to a site on the business plan and see the google my business banner
- In `config/development.json` set the feature flag for `google-my-business` to `false`.
- Restart the dev server
- Go to a site on the business plan and the banner should not appear