### PR TITLE
Remove broken link until new documentation is ready.

### DIFF
--- a/client/my-sites/domains/domain-management/dns/domain-connect-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/domain-connect-record.jsx
@@ -15,7 +15,6 @@ import classNames from 'classnames';
 import { errorNotice, removeNotice, successNotice } from 'state/notices/actions';
 import { deleteDns, addDns } from 'lib/upgrades/actions';
 import Toggle from 'components/forms/form-toggle';
-import { DOMAIN_CONNECT } from 'lib/url/support';
 import { domainConnect } from 'lib/domains/constants';
 import { getNormalizedData } from 'lib/domains/dns';
 
@@ -126,7 +125,6 @@ class DomainConnectRecord extends React.Component {
 							'Enabling this special DNS record allows you to automatically configure ' +
 								'some third party services. '
 						) }
-						<a href={ DOMAIN_CONNECT }>{ translate( 'Learn more.' ) }</a>
 					</em>
 				</div>
 			</div>


### PR DESCRIPTION
This link points to a non-existent page. Once the correct documentation has been created, I'll add the corrected link back here again.