### PR TITLE
Annual Site Stats: format table values

### DIFF
--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find } from 'lodash';
+import { find, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -84,6 +84,18 @@ class AnnualSiteStats extends Component {
 		);
 	}
 
+	formatTableValue( key, value ) {
+		const { numberFormat } = this.props;
+		const singleDecimal = [ 'avg_comments', 'avg_likes' ];
+		if ( includes( singleDecimal, key ) ) {
+			return numberFormat( value, 1 );
+		}
+		if ( 'year' === key ) {
+			return value;
+		}
+		return numberFormat( value );
+	}
+
 	renderTable( data, strings ) {
 		const keys = Object.keys( strings );
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -107,7 +119,7 @@ class AnnualSiteStats extends Component {
 										const Cell = j === 0 ? 'th' : 'td';
 										return (
 											<Cell scope={ j === 0 ? 'row' : null } key={ j }>
-												{ row[ key ] }
+												{ this.formatTableValue( key, row[ key ] ) }
 											</Cell>
 										);
 									} ) }


### PR DESCRIPTION
Annual Site Stats table values were shown in their raw form. This PR formats values according to the following criteria:

1. Years are unformatted
2. `avg_comments` and `avg_likes` are formatted to a decimal place of 1, which is consistent with how the backend returns those values
3. All other numbers are formatted with no decimal precision (also how these values are returned from the server)

## Before
![screen shot 2018-08-02 at 11 31 42 am](https://user-images.githubusercontent.com/1922453/43554993-b8539358-964b-11e8-9d04-4466271cfe6f.png)

## After
![screen shot 2018-08-02 at 11 55 33 am](https://user-images.githubusercontent.com/1922453/43554997-bf1b7ebc-964b-11e8-9bb7-49de6371d332.png)

## Test
1. `http://calypso.localhost:3000/stats/day/annualstats/<my-site-slug>`
2. See the numbers formatted as expected

cc @martinremy 
Fixes https://github.com/Automattic/wp-calypso/issues/26445