### PR TITLE
disable nudge-a-palooza in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -132,7 +132,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"upsell/nudge-a-palooza": true,
+		"upsell/nudge-a-palooza": false,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,


### PR DESCRIPTION
There is a current issue with eligibility for this test where business plan users are being taken to a business plan upsell page when trying to upload a theme.

This change turns off the new nudges while the problem is resolved