### PR TITLE
Domains: Redirect to `use-your-domain` for VIP sites

### DIFF
--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import page from 'page';
-import { stringify } from 'qs';
 import { translate } from 'i18n-calypso';
 import React from 'react';
 import { get, includes, map, noop } from 'lodash';
@@ -252,11 +251,11 @@ const redirectToUseYourDomainIfVipSite = () => {
 	return ( context, next ) => {
 		const state = context.store.getState();
 		const selectedSite = getSelectedSite( state );
-		const domain = context.params.domain ? `/${ context.params.domain }` : '';
-		const query = stringify( { initialQuery: get( context, 'params.suggestion', '' ) } );
 
 		if ( selectedSite && selectedSite.is_vip ) {
-			return page.redirect( `/domains/add/use-your-domain${ domain }?${ query }` );
+			return page.redirect(
+				domainUseYourDomain( selectedSite.slug, get( context, 'params.suggestion', '' ) )
+			);
 		}
 
 		next();

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -248,15 +248,15 @@ const redirectIfNoSite = redirectTo => {
 	};
 };
 
-const redirectToAddMappingIfVipSite = () => {
+const redirectToUseYourDomainIfVipSite = () => {
 	return ( context, next ) => {
 		const state = context.store.getState();
 		const selectedSite = getSelectedSite( state );
 		const domain = context.params.domain ? `/${ context.params.domain }` : '';
-		const query = stringify( { initialQuery: context.params.suggestion } );
+		const query = stringify( { initialQuery: get( context, 'params.suggestion', '' ) } );
 
 		if ( selectedSite && selectedSite.is_vip ) {
-			return page.redirect( `/domains/add/mapping${ domain }?${ query }` );
+			return page.redirect( `/domains/add/use-your-domain${ domain }?${ query }` );
 		}
 
 		next();
@@ -293,9 +293,9 @@ export default {
 	siteRedirect,
 	mapDomain,
 	googleAppsWithRegistration,
-	redirectIfNoSite,
-	redirectToAddMappingIfVipSite,
 	redirectToDomainSearchSuggestion,
+	redirectIfNoSite,
+	redirectToUseYourDomainIfVipSite,
 	transferDomain,
 	transferDomainPrecheck,
 	useYourDomain,

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -212,7 +212,7 @@ export default function() {
 			'/domains/add',
 			siteSelection,
 			domainsController.domainsAddHeader,
-			domainsController.redirectToAddMappingIfVipSite(),
+			domainsController.redirectToUseYourDomainIfVipSite(),
 			domainsController.jetpackNoDomainsWarning,
 			sites,
 			makeLayout,
@@ -254,7 +254,7 @@ export default function() {
 			siteSelection,
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/add' ),
-			domainsController.redirectToAddMappingIfVipSite(),
+			domainsController.redirectToUseYourDomainIfVipSite(),
 			domainsController.jetpackNoDomainsWarning,
 			domainsController.domainSearch,
 			makeLayout,
@@ -266,7 +266,7 @@ export default function() {
 			siteSelection,
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/add' ),
-			domainsController.redirectToAddMappingIfVipSite(),
+			domainsController.redirectToUseYourDomainIfVipSite(),
 			domainsController.jetpackNoDomainsWarning,
 			domainsController.redirectToDomainSearchSuggestion
 		);


### PR DESCRIPTION
Previously, we've been redirecting just to the mapping step, but it seems some clients want to transfer in their domains, so let's redirect to the `use-your-domain` screen instead - which seems like the perfect fit for this use case.

### Testing
Verify that there are no regressions for regular sites - you can access domain search at `http://calypso.localhost:3000/domains/add/`.

Grab a test VIP site and verify that the above URL redirects to `http://calypso.localhost:3000/domains/add/use-your-domain/:slug?initialQuery=`. Of course, same should happen when you click Domains -> Add in Calypso. Try to transfer in a domain. Try to map a domain.

The screen you should see:
<img width="741" alt="screen shot 2018-08-02 at 12 59 05" src="https://user-images.githubusercontent.com/3392497/43580002-3773ef72-9654-11e8-8b29-774fbd3b9330.png">
