### PR TITLE
Show error notice when auth code check fails and disable button while submitting.

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -561,6 +561,10 @@ class TransferDomainStep extends React.Component {
 				this.setState( { submittingAuthCodeCheck: false } );
 
 				if ( ! isEmpty( error ) ) {
+					const message = get( error, 'message' );
+					if ( message ) {
+						this.props.errorNotice( message );
+					}
 					resolve();
 					return;
 				}

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -122,7 +122,7 @@ class TransferDomainPrecheck extends React.Component {
 							<div>
 								<div className="transfer-domain-step__section-message">{ message }</div>
 								<div className="transfer-domain-step__section-action">
-									<Button compact onClick={ onButtonClick } busy={ loading }>
+									<Button compact onClick={ onButtonClick } busy={ loading } disabled={ loading }>
 										{ buttonText }
 									</Button>
 									{ stepStatus }

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -42,7 +42,7 @@ function checkAuthCode( domainName, authCode, onComplete ) {
 
 	wpcom.undocumented().checkAuthCode( domainName, authCode, function( serverError, result ) {
 		if ( serverError ) {
-			onComplete( serverError.error );
+			onComplete( { error: serverError.error, message: serverError.message } );
 			return;
 		}
 


### PR DESCRIPTION
Depends on D16791-code.

When the auth-code check fails due to throttled requests, we should show a notice to let the user know. We should also disable the button while a request is being submitted.

Testing:

Apply the patch to the back end. (See the note about testing while proxied in the diff.)

Attempt to start a transfer and on the transfer pre-check page, enter an incorrect authorization code enough times to trigger the throttling error.

Make sure that the error notice is shown.
Also make sure that the button is disabled and won't allow you to submit another check before the first one returns.

To make it easier to test, you may want to hack the callback in the endpoint to always return the `too_many_requests` error.