### PR TITLE
Guided Tours Step: store only stepPos in state and make stepCoords computed

### DIFF
--- a/client/layout/guided-tours/config-elements/step.js
+++ b/client/layout/guided-tours/config-elements/step.js
@@ -332,8 +332,7 @@ export default class Step extends Component {
 			shouldScrollTo,
 			scrollContainer: this.scrollContainer,
 		} );
-		const stepCoords = posToCss( stepPos );
-		this.setState( { stepPos, stepCoords } );
+		this.setState( { stepPos } );
 	}
 
 	render() {
@@ -357,7 +356,7 @@ export default class Step extends Component {
 		}
 
 		const { arrow, target: targetSlug } = this.props;
-		const { stepCoords, stepPos } = this.state;
+		const { stepPos } = this.state;
 
 		const classes = [
 			this.props.className,
@@ -375,7 +374,7 @@ export default class Step extends Component {
 					} ),
 		].filter( Boolean );
 
-		const style = { ...this.props.style, ...stepCoords };
+		const style = { ...this.props.style, ...posToCss( stepPos ) };
 
 		return (
 			<Card className={ classNames( ...classes ) } style={ style }>


### PR DESCRIPTION
The `Step` component stores its align position (relative to a target element, like when a Guided Tour Step is attached to a button) as `stepPos` in state and also as `stepCoords` is a slightly different form.

This patch stores only `stepPos` in state and computes `stepCoords` in `render`. This will make future updates easier, like when calling `setState` only when the position actually changes.

**How to test:**
Run a guided tour and check that steps are still positioned correctly and move when the target element scrolls around.