### PR TITLE
Guided Tours: remove memoization of the hasJustSeenTour selector

### DIFF
--- a/client/state/ui/guided-tours/selectors/index.js
+++ b/client/state/ui/guided-tours/selectors/index.js
@@ -104,13 +104,8 @@ const getTourFromQuery = createSelector(
  * Returns true if `tour` has been seen in the current Calypso session, false
  * otherwise.
  */
-const hasJustSeenTour = createSelector(
-	( state, { tour: tourName, _timestamp } ) =>
-		getToursHistory( state ).some(
-			entry => entry.tourName === tourName && entry.timestamp > _timestamp
-		),
-	[ getInitialQueryArguments, getToursHistory ]
-);
+const hasJustSeenTour = ( state, { tour, _timestamp } ) =>
+	getToursHistory( state ).some( entry => entry.tourName === tour && entry.timestamp > _timestamp );
 
 /*
  * Returns the name of the tour requested via URL query arguments if it hasn't


### PR DESCRIPTION
Removes a warning that says:

> Do not pass complex objects as arguments for a memoized selector

The warning is issued because an object `{ tour, _timestamp }` is passed as selector arg.

The simplest solution is to just remove the memoization. The return value is boolean, doesn't need to maintain identity. The selector is called only rarely, when a tour is requested using a `?tour=` URL query param. And it's quite likely that the memoization overhead is larger than the time avoided by doing a repeated linear search in a small array (tour history).

**How to test:**
1. Request a tour by appending `?tour=mediaBasicsTour` to a `/media/:site` URL. Does the tour begin?
2. Do it again. This time the tour shouldn't start, because it has been seen recently. Relies on the Redux state being persisted to IndexedDB and not cleared.