### PR TITLE
Guided Tours: improve React context provided by the `makeTour` wrapper

### DIFF
--- a/client/layout/guided-tours/config-elements/conditional-block.js
+++ b/client/layout/guided-tours/config-elements/conditional-block.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import contextTypes from '../context-types';
+import { contextTypes } from '../context-types';
 
 export default class ConditionalBlock extends React.PureComponent {
 	static propTypes = {

--- a/client/layout/guided-tours/config-elements/continue.js
+++ b/client/layout/guided-tours/config-elements/continue.js
@@ -13,7 +13,7 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import { targetForSlug } from '../positioning';
-import contextTypes from '../context-types';
+import { contextTypes } from '../context-types';
 
 export default class Continue extends Component {
 	static displayName = 'Continue';

--- a/client/layout/guided-tours/config-elements/link-quit.js
+++ b/client/layout/guided-tours/config-elements/link-quit.js
@@ -13,7 +13,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import Button from 'components/button';
-import contextTypes from '../context-types';
+import { contextTypes } from '../context-types';
 
 export default class LinkQuit extends Component {
 	static displayName = 'LinkQuit';

--- a/client/layout/guided-tours/config-elements/next.js
+++ b/client/layout/guided-tours/config-elements/next.js
@@ -12,7 +12,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
-import contextTypes from '../context-types';
+import { contextTypes } from '../context-types';
 
 export default class Next extends Component {
 	static displayName = 'Next';

--- a/client/layout/guided-tours/config-elements/quit.js
+++ b/client/layout/guided-tours/config-elements/quit.js
@@ -13,7 +13,7 @@ import { translate } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import { targetForSlug } from '../positioning';
-import contextTypes from '../context-types';
+import { contextTypes } from '../context-types';
 
 export default class Quit extends Component {
 	static displayName = 'Quit';

--- a/client/layout/guided-tours/config-elements/site-link.js
+++ b/client/layout/guided-tours/config-elements/site-link.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import contextTypes from '../context-types';
+import { contextTypes } from '../context-types';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import Button from 'components/button';

--- a/client/layout/guided-tours/config-elements/step.js
+++ b/client/layout/guided-tours/config-elements/step.js
@@ -24,7 +24,7 @@ import {
 	query,
 	targetForSlug,
 } from '../positioning';
-import contextTypes from '../context-types';
+import { contextTypes } from '../context-types';
 
 const debug = debugFactory( 'calypso:guided-tours' );
 

--- a/client/layout/guided-tours/config-elements/tour.js
+++ b/client/layout/guided-tours/config-elements/tour.js
@@ -11,7 +11,7 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
-import contextTypes from '../context-types';
+import { contextTypes } from '../context-types';
 
 export default class Tour extends Component {
 	static propTypes = {

--- a/client/layout/guided-tours/context-types.js
+++ b/client/layout/guided-tours/context-types.js
@@ -6,7 +6,8 @@
 
 import PropTypes from 'prop-types';
 
-export default Object.freeze( {
+// Shape of context provided by the `makeTour` context provider
+export const childContextTypes = Object.freeze( {
 	branching: PropTypes.object.isRequired,
 	next: PropTypes.func.isRequired,
 	quit: PropTypes.func.isRequired,
@@ -19,5 +20,11 @@ export default Object.freeze( {
 	shouldPause: PropTypes.bool.isRequired,
 	step: PropTypes.string.isRequired,
 	lastAction: PropTypes.object,
-	store: PropTypes.object,
+} );
+
+// Shape of context expected by the consumers: in addition to the context from the
+// `makeTour` context provider, they expect also `store` from Redux.
+export const contextTypes = Object.freeze( {
+	...childContextTypes,
+	store: PropTypes.object.isRequired,
 } );


### PR DESCRIPTION
Some modernizations of the Guided Tour context:

1. `getChildContext` doesn't need to merge the parent context (`this.context`) and the provided context (`this.tourMeta`). This was added in #22041 to make Redux `store` available in the tour context, but it's not needed. React does the merge for us, as it supports multiple nested context providers. All we need to do is to define the right `childContextTypes` (without `store`, so that it's never overwritten by our provider) and `contextTypes` (with `store`, so that it's not masked out and is part of the consumer's context).

2. Refactored the `makeTour` component to use `getDerivedStateFromProps` to compute new context every time its props change and to use `this.state` as the source of the context. This will make migration to the new React Context API easier.

**How to test:**
Test that the Guided Tours still work -- the context is a crucial component and everything breaks down when it's not right.

Verify the context of `Step` and other components in React devtools. Does it have all the relevant properties?