### PR TITLE
Build: Have webpack.config.js export a function

### DIFF
--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -9,27 +9,32 @@ const webpack = require( 'webpack' );
 const { isEmpty, omitBy } = require( 'lodash' );
 
 const __rootDir = path.resolve( __dirname, '../../' );
-const CopyWebpackPlugin = require( path.resolve( __rootDir, 'server/bundler/copy-webpack-plugin' ) );
+const CopyWebpackPlugin = require( path.resolve(
+	__rootDir,
+	'server/bundler/copy-webpack-plugin'
+) );
 const baseConfig = require( path.join( __rootDir, 'webpack.config.js' ) );
 
 exports.compile = args => {
-
 	const options = {
 		outputDir: path.join( path.dirname( args.editorScript ), 'build' ),
-		...args
+		...args,
 	};
 
-	const name = path.basename( path.dirname( options.editorScript, ).replace( /\/$/, '' ) );
+	const name = path.basename( path.dirname( options.editorScript ).replace( /\/$/, '' ) );
 
 	const config = {
 		...baseConfig,
 		...{
 			context: __rootDir,
 			mode: options.mode,
-			entry: omitBy( {
-				[ `${ name }-editor.js` ]: options.editorScript,
-				[ `${ name }-view.js` ]: options.viewScript,
-			}, isEmpty ),
+			entry: omitBy(
+				{
+					[ `${ name }-editor.js` ]: options.editorScript,
+					[ `${ name }-view.js` ]: options.viewScript,
+				},
+				isEmpty
+			),
 			externals: {
 				...baseConfig.externals,
 				wp: 'wp',
@@ -44,7 +49,7 @@ exports.compile = args => {
 			},
 			plugins: [
 				...baseConfig.plugins.filter( plugin => ! ( plugin instanceof CopyWebpackPlugin ) ),
-			]
+			],
 		},
 	};
 

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -13,7 +13,8 @@ const CopyWebpackPlugin = require( path.resolve(
 	__rootDir,
 	'server/bundler/copy-webpack-plugin'
 ) );
-const baseConfig = require( path.join( __rootDir, 'webpack.config.js' ) );
+const getBaseConfig = require( path.join( __rootDir, 'webpack.config.js' ) );
+const baseConfig = getBaseConfig();
 
 exports.compile = args => {
 	const options = {

--- a/server/bundler/index.js
+++ b/server/bundler/index.js
@@ -7,7 +7,7 @@ const webpackMiddleware = require( 'webpack-dev-middleware' );
 const webpack = require( 'webpack' );
 const chalk = require( 'chalk' );
 const hotMiddleware = require( 'webpack-hot-middleware' );
-const webpackConfig = require( 'webpack.config' );
+const getWebpackConfig = require( 'webpack.config' );
 
 const config = require( 'config' );
 
@@ -15,7 +15,7 @@ const port = process.env.PORT || config( 'port' );
 const shouldProfile = process.env.PROFILE === 'true';
 
 function middleware( app ) {
-	const compiler = webpack( webpackConfig );
+	const compiler = webpack( getWebpackConfig() );
 	const callbacks = [];
 	let built = false;
 	let beforeFirstCompile = true;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,210 +75,212 @@ const babelLoader = {
 	},
 };
 
-const webpackConfig = {
-	bail: ! isDevelopment,
-	entry: { build: [ path.join( __dirname, 'client', 'boot', 'app' ) ] },
-	profile: shouldEmitStats,
-	mode: isDevelopment ? 'development' : 'production',
-	devtool: isDevelopment ? '#eval' : process.env.SOURCEMAP || false, // in production builds you can specify a source-map via env var
-	output: {
-		path: path.join( __dirname, 'public' ),
-		publicPath: '/calypso/',
-		filename: '[name].[chunkhash].min.js', // prefer the chunkhash, which depends on the chunk, not the entire build
-		chunkFilename: '[name].[chunkhash].min.js', // ditto
-		devtoolModuleFilenameTemplate: 'app:///[resource-path]',
-	},
-	optimization: {
-		splitChunks: {
-			chunks: codeSplit ? 'all' : 'async',
-			name: isDevelopment || shouldEmitStats,
-			maxAsyncRequests: 20,
-			maxInitialRequests: 5,
+module.exports = function( env, argv ) {
+	const webpackConfig = {
+		bail: ! isDevelopment,
+		entry: { build: [ path.join( __dirname, 'client', 'boot', 'app' ) ] },
+		profile: shouldEmitStats,
+		mode: isDevelopment ? 'development' : 'production',
+		devtool: isDevelopment ? '#eval' : process.env.SOURCEMAP || false, // in production builds you can specify a source-map via env var
+		output: {
+			path: path.join( __dirname, 'public' ),
+			publicPath: '/calypso/',
+			filename: '[name].[chunkhash].min.js', // prefer the chunkhash, which depends on the chunk, not the entire build
+			chunkFilename: '[name].[chunkhash].min.js', // ditto
+			devtoolModuleFilenameTemplate: 'app:///[resource-path]',
 		},
-		runtimeChunk: codeSplit ? { name: 'manifest' } : false,
-		moduleIds: 'named',
-		chunkIds: isDevelopment ? 'named' : 'natural',
-		minimize: shouldMinify,
-		minimizer: [
-			new UglifyJsPlugin( {
-				cache: 'docker' !== process.env.CONTAINER,
-				parallel: true,
-				sourceMap: Boolean( process.env.SOURCEMAP ),
-				uglifyOptions: {
-					compress: {
-						/**
-						 * Produces inconsistent results
-						 * Enable when the following is resolved:
-						 * https://github.com/mishoo/UglifyJS2/issues/3010
-						 */
-						collapse_vars: false,
-					},
-					mangle: {
-						safari10: true,
-					},
-					ecma: 5,
-				},
-			} ),
-		],
-	},
-	module: {
-		// avoids this warning:
-		// https://github.com/localForage/localForage/issues/577
-		noParse: /[\/\\]node_modules[\/\\]localforage[\/\\]dist[\/\\]localforage\.js$/,
-		rules: [
-			{
-				test: /\.jsx?$/,
-				exclude: /node_modules[\/\\](?!notifications-panel)/,
-				use: [
-					{
-						loader: 'thread-loader',
-						options: {
-							workers: Math.max( 2, Math.floor( os.cpus().length / 2 ) ),
+		optimization: {
+			splitChunks: {
+				chunks: codeSplit ? 'all' : 'async',
+				name: isDevelopment || shouldEmitStats,
+				maxAsyncRequests: 20,
+				maxInitialRequests: 5,
+			},
+			runtimeChunk: codeSplit ? { name: 'manifest' } : false,
+			moduleIds: 'named',
+			chunkIds: isDevelopment ? 'named' : 'natural',
+			minimize: shouldMinify,
+			minimizer: [
+				new UglifyJsPlugin( {
+					cache: 'docker' !== process.env.CONTAINER,
+					parallel: true,
+					sourceMap: Boolean( process.env.SOURCEMAP ),
+					uglifyOptions: {
+						compress: {
+							/**
+							 * Produces inconsistent results
+							 * Enable when the following is resolved:
+							 * https://github.com/mishoo/UglifyJS2/issues/3010
+							 */
+							collapse_vars: false,
 						},
-					},
-					babelLoader,
-				],
-			},
-			{
-				test: /node_modules[\/\\](redux-form|react-redux)[\/\\]es/,
-				loader: 'babel-loader',
-				options: {
-					babelrc: false,
-					plugins: [ path.join( __dirname, 'server', 'bundler', 'babel', 'babel-lodash-es' ) ],
-				},
-			},
-			{
-				test: /\.(sc|sa|c)ss$/,
-				use: [
-					MiniCssExtractPlugin.loader,
-					'css-loader',
-					{
-						loader: 'sass-loader',
-						options: {
-							includePaths: [ path.join( __dirname, 'client' ) ],
+						mangle: {
+							safari10: true,
 						},
+						ecma: 5,
 					},
-				],
-			},
-			{
-				test: /extensions[\/\\]index/,
-				exclude: path.join( __dirname, 'node_modules' ),
-				loader: path.join( __dirname, 'server', 'bundler', 'extensions-loader' ),
-			},
-			{
-				include: path.join( __dirname, 'client/sections.js' ),
-				loader: path.join( __dirname, 'server', 'bundler', 'sections-loader' ),
-			},
-			{
-				test: /\.html$/,
-				loader: 'html-loader',
-			},
-			{
-				include: require.resolve( 'tinymce/tinymce' ),
-				use: 'exports-loader?window=tinymce',
-			},
-			{
-				test: /node_modules[\/\\]tinymce/,
-				use: 'imports-loader?this=>window',
-			},
-			{
-				test: /README\.md$/,
-				use: [
-					{ loader: 'html-loader' },
-					{
-						loader: 'markdown-loader',
-						options: {
-							sanitize: true,
-							highlight: function( code, language ) {
-								const syntax = prism.languages[ language ];
-								return syntax ? prism.highlight( code, syntax ) : code;
+				} ),
+			],
+		},
+		module: {
+			// avoids this warning:
+			// https://github.com/localForage/localForage/issues/577
+			noParse: /[\/\\]node_modules[\/\\]localforage[\/\\]dist[\/\\]localforage\.js$/,
+			rules: [
+				{
+					test: /\.jsx?$/,
+					exclude: /node_modules[\/\\](?!notifications-panel)/,
+					use: [
+						{
+							loader: 'thread-loader',
+							options: {
+								workers: Math.max( 2, Math.floor( os.cpus().length / 2 ) ),
 							},
 						},
-					},
-				],
-			},
-		],
-	},
-	resolve: {
-		extensions: [ '.json', '.js', '.jsx' ],
-		modules: [ path.join( __dirname, 'client' ), 'node_modules' ],
-		alias: Object.assign(
-			{
-				'gridicons/example': 'gridicons/dist/example',
-				'react-virtualized': 'react-virtualized/dist/commonjs',
-				'social-logos/example': 'social-logos/build/example',
-				debug: path.resolve( __dirname, 'node_modules/debug' ),
-			},
-			getAliasesForExtensions()
-		),
-	},
-	node: false,
-	plugins: _.compact( [
-		! codeSplit && new webpack.optimize.LimitChunkCountPlugin( { maxChunks: 1 } ),
-		new webpack.DefinePlugin( {
-			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
-			PROJECT_NAME: JSON.stringify( config( 'project' ) ),
-			global: 'window',
-		} ),
-		new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),
-		new webpack.IgnorePlugin( /^props$/ ),
-		new CopyWebpackPlugin( [
-			{ from: 'node_modules/flag-icon-css/flags/4x3', to: 'images/flags' },
-		] ),
-		new MiniCssExtractPlugin(),
-		new AssetsWriter( {
-			filename: 'assets.json',
-			path: path.join( __dirname, 'server', 'bundler' ),
-		} ),
-		shouldCheckForCycles &&
-			new CircularDependencyPlugin( {
-				exclude: /node_modules/,
-				failOnError: false,
-				allowAsyncCycles: false,
-				cwd: process.cwd(),
-			} ),
-		shouldEmitStats &&
-			new StatsWriter( {
-				filename: 'stats.json',
-				path: __dirname,
-				stats: {
-					assets: true,
-					children: true,
-					modules: true,
-					source: false,
-					reasons: false,
-					issuer: false,
-					timings: true,
+						babelLoader,
+					],
 				},
+				{
+					test: /node_modules[\/\\](redux-form|react-redux)[\/\\]es/,
+					loader: 'babel-loader',
+					options: {
+						babelrc: false,
+						plugins: [ path.join( __dirname, 'server', 'bundler', 'babel', 'babel-lodash-es' ) ],
+					},
+				},
+				{
+					test: /\.(sc|sa|c)ss$/,
+					use: [
+						MiniCssExtractPlugin.loader,
+						'css-loader',
+						{
+							loader: 'sass-loader',
+							options: {
+								includePaths: [ path.join( __dirname, 'client' ) ],
+							},
+						},
+					],
+				},
+				{
+					test: /extensions[\/\\]index/,
+					exclude: path.join( __dirname, 'node_modules' ),
+					loader: path.join( __dirname, 'server', 'bundler', 'extensions-loader' ),
+				},
+				{
+					include: path.join( __dirname, 'client/sections.js' ),
+					loader: path.join( __dirname, 'server', 'bundler', 'sections-loader' ),
+				},
+				{
+					test: /\.html$/,
+					loader: 'html-loader',
+				},
+				{
+					include: require.resolve( 'tinymce/tinymce' ),
+					use: 'exports-loader?window=tinymce',
+				},
+				{
+					test: /node_modules[\/\\]tinymce/,
+					use: 'imports-loader?this=>window',
+				},
+				{
+					test: /README\.md$/,
+					use: [
+						{ loader: 'html-loader' },
+						{
+							loader: 'markdown-loader',
+							options: {
+								sanitize: true,
+								highlight: function( code, language ) {
+									const syntax = prism.languages[ language ];
+									return syntax ? prism.highlight( code, syntax ) : code;
+								},
+							},
+						},
+					],
+				},
+			],
+		},
+		resolve: {
+			extensions: [ '.json', '.js', '.jsx' ],
+			modules: [ path.join( __dirname, 'client' ), 'node_modules' ],
+			alias: Object.assign(
+				{
+					'gridicons/example': 'gridicons/dist/example',
+					'react-virtualized': 'react-virtualized/dist/commonjs',
+					'social-logos/example': 'social-logos/build/example',
+					debug: path.resolve( __dirname, 'node_modules/debug' ),
+				},
+				getAliasesForExtensions()
+			),
+		},
+		node: false,
+		plugins: _.compact( [
+			! codeSplit && new webpack.optimize.LimitChunkCountPlugin( { maxChunks: 1 } ),
+			new webpack.DefinePlugin( {
+				'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
+				PROJECT_NAME: JSON.stringify( config( 'project' ) ),
+				global: 'window',
 			} ),
-	] ),
-	externals: [ 'electron' ],
+			new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),
+			new webpack.IgnorePlugin( /^props$/ ),
+			new CopyWebpackPlugin( [
+				{ from: 'node_modules/flag-icon-css/flags/4x3', to: 'images/flags' },
+			] ),
+			new MiniCssExtractPlugin(),
+			new AssetsWriter( {
+				filename: 'assets.json',
+				path: path.join( __dirname, 'server', 'bundler' ),
+			} ),
+			shouldCheckForCycles &&
+				new CircularDependencyPlugin( {
+					exclude: /node_modules/,
+					failOnError: false,
+					allowAsyncCycles: false,
+					cwd: process.cwd(),
+				} ),
+			shouldEmitStats &&
+				new StatsWriter( {
+					filename: 'stats.json',
+					path: __dirname,
+					stats: {
+						assets: true,
+						children: true,
+						modules: true,
+						source: false,
+						reasons: false,
+						issuer: false,
+						timings: true,
+					},
+				} ),
+		] ),
+		externals: [ 'electron' ],
+	};
+
+	if ( calypsoEnv === 'desktop' ) {
+		// no chunks or dll here, just one big file for the desktop app
+		webpackConfig.output.filename = '[name].js';
+		webpackConfig.output.chunkFilename = '[name].js';
+	} else {
+		// jquery is only needed in the build for the desktop app
+		// see electron bug: https://github.com/atom/electron/issues/254
+		webpackConfig.externals.push( 'jquery' );
+	}
+
+	if ( isDevelopment ) {
+		// we should not use chunkhash in development: https://github.com/webpack/webpack-dev-server/issues/377#issuecomment-241258405
+		// also we don't minify so dont name them .min.js
+		webpackConfig.output.filename = '[name].js';
+		webpackConfig.output.chunkFilename = '[name].js';
+
+		webpackConfig.plugins.push( new webpack.HotModuleReplacementPlugin() );
+		webpackConfig.entry.build.unshift( 'webpack-hot-middleware/client' );
+	}
+
+	if ( ! config.isEnabled( 'desktop' ) ) {
+		webpackConfig.plugins.push(
+			new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]desktop$/, 'lodash/noop' )
+		);
+	}
+
+	return webpackConfig;
 };
-
-if ( calypsoEnv === 'desktop' ) {
-	// no chunks or dll here, just one big file for the desktop app
-	webpackConfig.output.filename = '[name].js';
-	webpackConfig.output.chunkFilename = '[name].js';
-} else {
-	// jquery is only needed in the build for the desktop app
-	// see electron bug: https://github.com/atom/electron/issues/254
-	webpackConfig.externals.push( 'jquery' );
-}
-
-if ( isDevelopment ) {
-	// we should not use chunkhash in development: https://github.com/webpack/webpack-dev-server/issues/377#issuecomment-241258405
-	// also we don't minify so dont name them .min.js
-	webpackConfig.output.filename = '[name].js';
-	webpackConfig.output.chunkFilename = '[name].js';
-
-	webpackConfig.plugins.push( new webpack.HotModuleReplacementPlugin() );
-	webpackConfig.entry.build.unshift( 'webpack-hot-middleware/client' );
-}
-
-if ( ! config.isEnabled( 'desktop' ) ) {
-	webpackConfig.plugins.push(
-		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]desktop$/, 'lodash/noop' )
-	);
-}
-
-module.exports = webpackConfig;


### PR DESCRIPTION
As [described](https://webpack.js.org/configuration/configuration-types/#exporting-a-function) by webpack docs.

The rationale for this change is enabling the Gutenberg script to easily pass options to the webpack config, as required for #26444, among others. This change might also allow us to do a few things more semantically. 

[Review with whitespace changed ignored.](https://github.com/Automattic/wp-calypso/pull/26470/files?w=1)

To test: Verify that Calypso still builds (and runs!) correctly, in different environments:
* Try `npm start`
* Try a Docker build of wpcalypso (and production, if possible)
* Run `npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/editor-notes/index.js` to verify that Gutenberg extension building still works