### PR TITLE
Revert "Domains: Missed a case when the start date isn't set"

### DIFF
--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -915,7 +915,8 @@ export class DomainWarnings extends React.PureComponent {
 				break;
 			case transferStatus.PENDING_REGISTRY:
 				message = translate(
-					'The transfer of {{strong}}%(domain)s{{/strong}} is in progress. We are waiting ' +
+					'The transfer of {{strong}}%(domain)s{{/strong}} is in progress. ' +
+						'It should complete by %(transferFinishDate)s. We are waiting ' +
 						'for authorization from your current domain provider to proceed. {{a}}Learn more{{/a}}',
 					{
 						components: {
@@ -930,33 +931,10 @@ export class DomainWarnings extends React.PureComponent {
 						},
 						args: {
 							domain: domainInTransfer.name,
+							transferFinishDate: domainInTransfer.transferEndDateMoment.format( 'LL' ),
 						},
 					}
 				);
-
-				if ( domainInTransfer.transferEndDateMoment ) {
-					message = translate(
-						'The transfer of {{strong}}%(domain)s{{/strong}} is in progress. ' +
-							'It should complete by %(transferFinishDate)s. We are waiting ' +
-							'for authorization from your current domain provider to proceed. {{a}}Learn more{{/a}}',
-						{
-							components: {
-								strong: <strong />,
-								a: (
-									<a
-										href={ INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS }
-										rel="noopener noreferrer"
-										target="_blank"
-									/>
-								),
-							},
-							args: {
-								domain: domainInTransfer.name,
-								transferFinishDate: domainInTransfer.transferEndDateMoment.format( 'LL' ),
-							},
-						}
-					);
-				}
 				break;
 			case transferStatus.PENDING_START:
 				compactMessage = translate( 'Domain transfer waiting' );

--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -52,27 +52,16 @@ class Transfer extends React.PureComponent {
 				<Notice status={ 'is-info' } showDismiss={ false }>
 					{ translate(
 						'This transfer has been started and is waiting for authorization from your current provider. ' +
-							'If you need to cancel the transfer, please contact them for assistance.'
+							'It should complete by %(transferFinishDate)s. ' +
+							'If you need to cancel the transfer, please contact them for assistance.',
+						{
+							args: {
+								transferFinishDate: domain.transferEndDateMoment.format( 'LL' ),
+							},
+						}
 					) }
 				</Notice>
 			);
-
-			if ( domain.transferEndDateMoment ) {
-				transferNotice = (
-					<Notice status={ 'is-info' } showDismiss={ false }>
-						{ translate(
-							'This transfer has been started and is waiting for authorization from your current provider. ' +
-								'It should complete by %(transferFinishDate)s. ' +
-								'If you need to cancel the transfer, please contact them for assistance.',
-							{
-								args: {
-									transferFinishDate: domain.transferEndDateMoment.format( 'LL' ),
-								},
-							}
-						) }
-					</Notice>
-				);
-			}
 		} else {
 			cancelNavItem = (
 				<VerticalNav>


### PR DESCRIPTION
This reverts commit 4767803568ce173a93658fadfc1aa8fcc0a58d07.

On 6th of August all new transfer ins will have end date set. Revert this change, as it's not needed anymore. It was a temporary fix, because we couldn't prefill all transfers.