### PR TITLE
Record click events for unlock and auth code checks.

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -533,21 +533,21 @@ class TransferDomainStep extends React.Component {
 						return;
 					}
 
-					this.setState( {
-						inboundTransferStatus: {
-							creationDate: result.creation_date,
-							email: result.admin_email,
-							loading: false,
-							losingRegistrar: result.registrar,
-							losingRegistrarIanaId: result.registrar_iana_id,
-							privacy: result.privacy,
-							termMaximumInYears: result.term_maximum_in_years,
-							transferEligibleDate: result.transfer_eligible_date,
-							transferRestrictionStatus: result.transfer_restriction_status,
-							unlocked: result.unlocked,
-						},
-					} );
-					resolve();
+					const inboundTransferStatus = {
+						creationDate: result.creation_date,
+						email: result.admin_email,
+						loading: false,
+						losingRegistrar: result.registrar,
+						losingRegistrarIanaId: result.registrar_iana_id,
+						privacy: result.privacy,
+						termMaximumInYears: result.term_maximum_in_years,
+						transferEligibleDate: result.transfer_eligible_date,
+						transferRestrictionStatus: result.transfer_restriction_status,
+						unlocked: result.unlocked,
+					};
+
+					this.setState( { inboundTransferStatus } );
+					resolve( { inboundTransferStatus } );
 				}
 			);
 		} );
@@ -565,10 +565,10 @@ class TransferDomainStep extends React.Component {
 					return;
 				}
 
-				this.setState( {
-					authCodeValid: result.success,
-				} );
-				resolve();
+				const authCodeValid = result.success;
+
+				this.setState( { authCodeValid } );
+				resolve( { authCodeValid } );
 			} );
 		} );
 	};

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -97,6 +97,17 @@ class TransferDomainPrecheck extends React.Component {
 		} );
 	};
 
+	checkLockedStatus = () => {
+		const { unlocked } = this.props;
+
+		if ( false === unlocked ) {
+			this.refreshStatus();
+		} else {
+			this.props.recordUnlockedCheckButtonClick( this.props.domain, unlocked );
+			this.showNextStep();
+		}
+	};
+
 	checkAuthCode = () => {
 		this.props.checkAuthCode( this.props.domain, this.state.authCode ).then( result => {
 			const authCodeValid = get( result, 'authCodeValid' );
@@ -239,8 +250,7 @@ class TransferDomainPrecheck extends React.Component {
 			</div>
 		);
 
-		const onButtonClick =
-			true === unlocked || null === unlocked ? this.showNextStep : this.refreshStatus;
+		const onButtonClick = this.checkLockedStatus;
 
 		return this.getSection( heading, message, buttonText, step, lockStatus, onButtonClick );
 	}
@@ -364,11 +374,16 @@ class TransferDomainPrecheck extends React.Component {
 const recordNextStep = ( domain_name, show_step ) =>
 	recordTracksEvent( 'calypso_transfer_domain_precheck_step_change', { domain_name, show_step } );
 
-const recordUnlockedCheckButtonClick = ( domain_name, is_unlocked ) =>
-	recordTracksEvent( 'calypso_transfer_domain_precheck_unlocked_check_click', {
+const recordUnlockedCheckButtonClick = ( domain_name, is_unlocked ) => {
+	if ( null === is_unlocked ) {
+		is_unlocked = 'unavailable';
+	}
+
+	return recordTracksEvent( 'calypso_transfer_domain_precheck_unlocked_check_click', {
 		domain_name,
 		is_unlocked,
 	} );
+};
 
 const recordAuthCodeCheckButtonClick = ( domain_name, auth_code_is_valid ) =>
 	recordTracksEvent( 'calypso_transfer_domain_precheck_auth_code_check_click', {

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -90,11 +91,17 @@ class TransferDomainPrecheck extends React.Component {
 	};
 
 	refreshStatus = () => {
-		this.props.refreshStatus( this.statusRefreshed );
+		this.props.refreshStatus( this.statusRefreshed ).then( result => {
+			const isUnlocked = get( result, 'inboundTransferStatus.unlocked' );
+			this.props.recordUnlockedCheckButtonClick( this.props.domain, isUnlocked );
+		} );
 	};
 
 	checkAuthCode = () => {
-		this.props.checkAuthCode( this.props.domain, this.state.authCode );
+		this.props.checkAuthCode( this.props.domain, this.state.authCode ).then( result => {
+			const authCodeValid = get( result, 'authCodeValid' );
+			this.props.recordAuthCodeCheckButtonClick( this.props.domain, authCodeValid );
+		} );
 	};
 
 	getSection( heading, message, buttonText, step, stepStatus, onButtonClick ) {
@@ -357,6 +364,20 @@ class TransferDomainPrecheck extends React.Component {
 const recordNextStep = ( domain_name, show_step ) =>
 	recordTracksEvent( 'calypso_transfer_domain_precheck_step_change', { domain_name, show_step } );
 
+const recordUnlockedCheckButtonClick = ( domain_name, is_unlocked ) => {
+	recordTracksEvent( 'calypso_transfer_domain_precheck_unlocked_check_click', {
+		domain_name,
+		is_unlocked,
+	} );
+};
+
+const recordAuthCodeCheckButtonClick = ( domain_name, auth_code_is_valid ) => {
+	recordTracksEvent( 'calypso_transfer_domain_precheck_auth_code_check_click', {
+		domain_name,
+		auth_code_is_valid,
+	} );
+};
+
 const recordContinueButtonClick = ( domain_name, losing_registrar, losing_registrar_iana_id ) =>
 	recordTracksEvent( 'calypso_transfer_domain_precheck_continue_click', {
 		domain_name,
@@ -368,6 +389,8 @@ export default connect(
 	null,
 	{
 		recordNextStep,
+		recordUnlockedCheckButtonClick,
+		recordAuthCodeCheckButtonClick,
 		recordContinueButtonClick,
 	}
 )( localize( TransferDomainPrecheck ) );

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -364,19 +364,17 @@ class TransferDomainPrecheck extends React.Component {
 const recordNextStep = ( domain_name, show_step ) =>
 	recordTracksEvent( 'calypso_transfer_domain_precheck_step_change', { domain_name, show_step } );
 
-const recordUnlockedCheckButtonClick = ( domain_name, is_unlocked ) => {
+const recordUnlockedCheckButtonClick = ( domain_name, is_unlocked ) =>
 	recordTracksEvent( 'calypso_transfer_domain_precheck_unlocked_check_click', {
 		domain_name,
 		is_unlocked,
 	} );
-};
 
-const recordAuthCodeCheckButtonClick = ( domain_name, auth_code_is_valid ) => {
+const recordAuthCodeCheckButtonClick = ( domain_name, auth_code_is_valid ) =>
 	recordTracksEvent( 'calypso_transfer_domain_precheck_auth_code_check_click', {
 		domain_name,
 		auth_code_is_valid,
 	} );
-};
 
 const recordContinueButtonClick = ( domain_name, losing_registrar, losing_registrar_iana_id ) =>
 	recordTracksEvent( 'calypso_transfer_domain_precheck_continue_click', {


### PR DESCRIPTION
We want to record when a user clicks on the buttons to check the unlock state and the auth code checks when on the pre-check page to see where users may be having trouble during an inbound transfer.

Testing:
- Start a transfer with a domain in a locked state.
- Click on the "I've unlocked my domain" button a few times.
- Then unlock your domain and enter an auth code and click on the "Check my authorization code" button a few times.

- Wait a few minutes and search for the `calypso_transfer_domain_precheck_%_check_click` actions in tracks.