### PR TITLE
Store: Fix dependencies for intl labels selectors

### DIFF
--- a/client/extensions/woocommerce/state/sites/data/locations/selectors.js
+++ b/client/extensions/woocommerce/state/sites/data/locations/selectors.js
@@ -209,3 +209,18 @@ export const getStateName = createSelector(
 export const hasStates = ( state, countryCode, siteId = getSelectedSiteId( state ) ) => {
 	return ! isEmpty( getStates( state, countryCode, siteId ) );
 };
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Object} Map with the pairs { countryCode: countryName } of all the countries in the world
+ */
+export const getAllCountryNames = createSelector(
+	( state, siteId = getSelectedSiteId( state ) ) => {
+		const countries = getAllCountries( state, siteId );
+		const names = {};
+		countries.forEach( ( { code, name } ) => ( names[ code ] = name ) );
+		return names;
+	},
+	_getSelectorDependants( 0 )
+);

--- a/client/extensions/woocommerce/state/sites/data/locations/selectors.js
+++ b/client/extensions/woocommerce/state/sites/data/locations/selectors.js
@@ -55,7 +55,7 @@ export const areLocationsErrored = ( state, siteId = getSelectedSiteId( state ) 
  * @param {number} numArgs Number of arguments the selector takes, excluding the Redux state tree and the site ID
  * @return {function} Function, as expected by the "createSelector" library
  */
-export const _getSelectorDependants = numArgs => ( state, ...args ) => {
+const _getSelectorDependants = numArgs => ( state, ...args ) => {
 	// First argument is always "state", last argument is always "siteId"
 	const siteId = args[ numArgs ];
 	const loaded = areLocationsLoaded( state, siteId );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -50,7 +50,7 @@ import {
 	areLocationsErrored,
 	getCountryName,
 	_getSelectorDependants,
-	getAllCountries,
+	getAllCountryNames,
 	getStates,
 	hasStates,
 } from 'woocommerce/state/sites/data/locations/selectors';
@@ -539,21 +539,6 @@ export const canPurchase = createSelector(
 		getForm( state, orderId, siteId ),
 		getFirstErroneousStep( state, orderId, siteId ),
 	]
-);
-
-/**
- * @param {Object} state Whole Redux state tree
- * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
- * @return {Object} Map with the pairs { countryCode: countryName } of all the countries in the world
- */
-export const getAllCountryNames = createSelector(
-	( state, siteId = getSelectedSiteId( state ) ) => {
-		const countries = getAllCountries( state, siteId );
-		const names = {};
-		countries.forEach( ( { code, name } ) => ( names[ code ] = name ) );
-		return names;
-	},
-	_getSelectorDependants( 0 )
 );
 
 /**

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -49,7 +49,6 @@ import {
 	areLocationsLoaded,
 	areLocationsErrored,
 	getCountryName,
-	_getSelectorDependants,
 	getAllCountryNames,
 	getStates,
 	hasStates,
@@ -553,7 +552,7 @@ export const getOriginCountryNames = createSelector(
 			? pick( allNames, ACCEPTED_USPS_ORIGIN_COUNTRIES )
 			: pick( allNames, DOMESTIC_US_TERRITORIES );
 	},
-	_getSelectorDependants( 0 )
+	[ getAllCountryNames, isWcsInternationalLabelsEnabled ]
 );
 
 /**
@@ -568,7 +567,7 @@ export const getDestinationCountryNames = createSelector(
 			? allNames
 			: pick( allNames, DOMESTIC_US_TERRITORIES );
 	},
-	_getSelectorDependants( 0 )
+	[ getAllCountryNames, isWcsInternationalLabelsEnabled ]
 );
 
 /**
@@ -594,7 +593,7 @@ export const getStateNames = createSelector(
 		}
 		return names;
 	},
-	_getSelectorDependants( 1 )
+	[ getStates, isWcsInternationalLabelsEnabled ]
 );
 
 export const areLabelsFullyLoaded = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {


### PR DESCRIPTION
Addresses: https://github.com/Automattic/wp-calypso/pull/24974/files/107d4d5f37a094bab92adec4ef49e6eadeeee4f2#r207342824, https://github.com/Automattic/wp-calypso/pull/24974/files/107d4d5f37a094bab92adec4ef49e6eadeeee4f2#r207354374, https://github.com/Automattic/wp-calypso/pull/24974/files/107d4d5f37a094bab92adec4ef49e6eadeeee4f2#r207354037.

This PR:
* Moves a non-WCS-dependent selector into the WC locations selectors file
* Rewrites the WCS shipping label selectors to use their immediate dependencies rather than those of their dependent selectors