### PR TITLE
i18n: Add reactive moment and formatted date components

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -53,7 +53,11 @@ const config = {
 	env: {
 		test: {
 			presets: [ [ '@babel/env', { targets: { node: 'current' } } ] ],
-			plugins: [ 'add-module-exports', './server/bundler/babel/babel-lodash-es' ],
+			plugins: [
+				'add-module-exports',
+				'babel-plugin-dynamic-import-node',
+				'./server/bundler/babel/babel-lodash-es',
+			],
 		},
 	},
 };

--- a/client/blocks/image-selector/test/index.jsx
+++ b/client/blocks/image-selector/test/index.jsx
@@ -40,6 +40,7 @@ jest.mock( 'state/ui/selectors', () => ( {
 	getSelectedSiteId: jest.fn( () => require( './fixtures' ).DUMMY_SITE_ID ),
 	getSelectedSite: () => {},
 } ) );
+jest.mock( 'state/selectors/get-current-locale-slug', () => () => 'en' );
 
 describe( 'ImageSelector', () => {
 	const testProps = {

--- a/client/blocks/privacy-policy-banner/index.jsx
+++ b/client/blocks/privacy-policy-banner/index.jsx
@@ -19,6 +19,7 @@ import getCurrentUserRegisterDate from 'state/selectors/get-current-user-registe
 import Banner from 'components/banner';
 import config from 'config';
 import PrivacyPolicyDialog from './privacy-policy-dialog';
+import withMoment from 'components/with-localized-moment';
 
 const AUTOMATTIC_ENTITY = 'automattic';
 const PRIVACY_POLICY_PREFERENCE = 'privacy_policy';
@@ -177,4 +178,4 @@ const mapDispatchToProps = {
 export default connect(
 	mapStateToProps,
 	mapDispatchToProps
-)( localize( PrivacyPolicyBanner ) );
+)( withMoment( localize( PrivacyPolicyBanner ) ) );

--- a/client/components/formatted-date/README.md
+++ b/client/components/formatted-date/README.md
@@ -1,0 +1,4 @@
+# Formatted Date
+
+A localized, formatted date time, backed by moment's [format strings](http://momentjs.com/docs/#/displaying/format/). 
+This component will load the appropriate moment localization based on the current user's locale.

--- a/client/components/formatted-date/docs/example.js
+++ b/client/components/formatted-date/docs/example.js
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import FormattedDate from '../';
+import { setLocale } from 'state/ui/language/actions';
+import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
+
+class FormattedDateExample extends PureComponent {
+	static displayName = 'FormattedDateExample';
+
+	state = {
+		currentDate: new Date(),
+		currentDateString: new Date().toISOString(),
+		format: 'lll',
+	};
+
+	handleDateChange = evt => {
+		const val = moment( evt.target.value );
+		if ( val.isValid() ) {
+			this.setState( {
+				currentDate: val.toDate(),
+				currentDateString: evt.target.value,
+			} );
+		}
+	};
+
+	handleLocaleChange = evt => {
+		const val = evt.target.value;
+		if ( val.length === 2 || val.length === 5 ) {
+			this.props.setLocale( evt.target.value );
+		}
+	};
+
+	handleFormatChange = evt => {
+		const val = evt.target.value;
+		if ( val ) {
+			this.setState( { format: val } );
+		}
+	};
+
+	render() {
+		return (
+			<div>
+				<label>
+					Date
+					<br />
+					<input
+						type="text"
+						name="theDate"
+						onChange={ this.handleDateChange }
+						defaultValue={ this.state.currentDateString }
+					/>
+				</label>
+				<label>
+					locale
+					<br />
+					<input
+						type="text"
+						name="locale"
+						onChange={ this.handleLocaleChange }
+						defaultValue={ this.props.currentLocale }
+					/>
+				</label>
+				<label>
+					format
+					<br />
+					<input
+						type="text"
+						name="format"
+						onChange={ this.handleFormatChange }
+						defaultValue={ this.state.format }
+					/>
+				</label>
+				<FormattedDate date={ this.state.currentDate } format={ this.state.format } />
+			</div>
+		);
+	}
+}
+
+const exported = connect(
+	state => ( {
+		currentLocale: getCurrentLocaleSlug( state ),
+	} ),
+	{ setLocale }
+)( FormattedDateExample );
+exported.displayName = 'FormattedDateExample';
+
+export default exported;

--- a/client/components/formatted-date/index.js
+++ b/client/components/formatted-date/index.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import withMoment from 'components/with-localized-moment';
+
+class FormattedDate extends Component {
+	static displayName = "FormattedDate";
+	render() {
+		let date = this.props.date;
+		if ( ! this.props.moment.isMoment( date ) ) {
+			// only make a new moment if we were passed something else
+			date = this.props.moment( date );
+		}
+		return <time dateTime={ date.toISOString( true ) }>{ date.format( this.props.format ) }</time>;
+	}
+}
+
+export default withMoment( FormattedDate );

--- a/client/components/formatted-date/index.js
+++ b/client/components/formatted-date/index.js
@@ -1,20 +1,28 @@
+/** @format */
 /**
  * External dependencies
+ *
  */
+
 import React, { Component } from 'react';
 
 /**
  * Internal dependencies
  */
 import withMoment from 'components/with-localized-moment';
+import toCurrentLocale from './to-current-locale';
 
 class FormattedDate extends Component {
-	static displayName = "FormattedDate";
+	static displayName = 'FormattedDate';
 	render() {
 		let date = this.props.date;
-		if ( ! this.props.moment.isMoment( date ) ) {
+		const moment = this.props.moment;
+		if ( ! moment.isMoment( date ) ) {
 			// only make a new moment if we were passed something else
-			date = this.props.moment( date );
+			date = moment( date );
+		} else {
+			// make sure the date is in the current locale
+			date = toCurrentLocale( date );
 		}
 		return <time dateTime={ date.toISOString( true ) }>{ date.format( this.props.format ) }</time>;
 	}

--- a/client/components/formatted-date/index.js
+++ b/client/components/formatted-date/index.js
@@ -4,7 +4,7 @@
  *
  */
 
-import React, { Component } from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies
@@ -12,20 +12,17 @@ import React, { Component } from 'react';
 import withMoment from 'components/with-localized-moment';
 import toCurrentLocale from './to-current-locale';
 
-class FormattedDate extends Component {
-	static displayName = 'FormattedDate';
-	render() {
-		let date = this.props.date;
-		const moment = this.props.moment;
-		if ( ! moment.isMoment( date ) ) {
-			// only make a new moment if we were passed something else
-			date = moment( date );
-		} else {
-			// make sure the date is in the current locale
-			date = toCurrentLocale( date );
-		}
-		return <time dateTime={ date.toISOString( true ) }>{ date.format( this.props.format ) }</time>;
+function FormattedDate( { date, moment, format } ) {
+	if ( ! moment.isMoment( date ) ) {
+		// only make a new moment if we were passed something else
+		date = moment( date );
+	} else {
+		// make sure the date is in the current locale
+		date = toCurrentLocale( date );
 	}
+	return <time dateTime={ date.toISOString( true ) }>{ date.format( format ) }</time>;
 }
+
+FormattedDate.displayName = 'FormattedDate';
 
 export default withMoment( FormattedDate );

--- a/client/components/formatted-date/to-current-locale.js
+++ b/client/components/formatted-date/to-current-locale.js
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+
+export default function toCurrentLocale( m ) {
+	if ( m.locale() === moment.locale() ) {
+		return m;
+	}
+	return m.clone().locale( moment.locale() );
+}

--- a/client/components/root-child/index.jsx
+++ b/client/components/root-child/index.jsx
@@ -9,6 +9,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 
+/**
+ * Internal dependencies
+ */
+import { MomentProvider } from 'components/with-localized-moment/context';
+
 export default class RootChild extends React.Component {
 	static contextTypes = {
 		store: PropTypes.object,
@@ -46,7 +51,11 @@ export default class RootChild extends React.Component {
 		// Context is lost when creating a new render hierarchy, so ensure that
 		// we preserve the context that we care about
 		if ( this.context.store ) {
-			content = <ReduxProvider store={ this.context.store }>{ content }</ReduxProvider>;
+			content = (
+				<ReduxProvider store={ this.context.store }>
+					<MomentProvider>{ content }</MomentProvider>
+				</ReduxProvider>
+			);
 		}
 
 		ReactDom.render( content, this.container );

--- a/client/components/with-localized-moment/context.js
+++ b/client/components/with-localized-moment/context.js
@@ -16,7 +16,7 @@ import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 const { Provider, Consumer } = React.createContext( moment );
 
 class MomentProvider extends React.Component {
-	state = {};
+	state = { moment };
 
 	async checkAndLoad() {
 		const { currentLocale } = this.props;
@@ -43,7 +43,7 @@ class MomentProvider extends React.Component {
 	}
 
 	render() {
-		return <Provider value={ moment }>{ this.props.children }</Provider>;
+		return <Provider value={ this.state }>{ this.props.children }</Provider>;
 	}
 }
 

--- a/client/components/with-localized-moment/context.js
+++ b/client/components/with-localized-moment/context.js
@@ -16,27 +16,22 @@ import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 const { Provider, Consumer } = React.createContext( moment );
 
 class MomentProvider extends React.Component {
-	state = {
-		currentLocale: 'en',
-	};
+	state = {};
 
-	checkAndLoad() {
+	async checkAndLoad() {
+		const { currentLocale } = this.props;
+
 		// is moment set to the current locale?
-		if ( this.props.currentLocale === moment.locale() ) {
+		if ( currentLocale === moment.locale() ) {
 			return;
 		}
-		if ( this.props.currentLocale !== 'en' ) {
-			const loadingLocale = this.props.currentLocale;
-			import( /* webpackChunkName: "moment-locale-[request]", webpackInclude: /\.js$/ */ `moment/locale/${ loadingLocale }` ).then(
-				() => {
-					moment.locale( loadingLocale );
-					this.setState( { currentLocale: loadingLocale } );
-				}
-			);
-		} else {
-			moment.locale( 'en' );
-			this.setState( { currentLocale: 'en' } );
+
+		if ( currentLocale !== 'en' ) {
+			await import( /* webpackChunkName: "moment-locale-[request]", webpackInclude: /\.js$/ */ `moment/locale/${ currentLocale }` );
 		}
+
+		moment.locale( currentLocale );
+		this.setState( {} );
 	}
 
 	componentDidMount() {
@@ -48,7 +43,7 @@ class MomentProvider extends React.Component {
 	}
 
 	render() {
-		return <Provider value={ this.state.currentLocale }>{ this.props.children }</Provider>;
+		return <Provider value={ moment }>{ this.props.children }</Provider>;
 	}
 }
 

--- a/client/components/with-localized-moment/context.js
+++ b/client/components/with-localized-moment/context.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import React from 'react';
+import { connect } from 'react-redux';
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
+
+const { Provider, Consumer } = React.createContext( moment );
+
+class MomentProvider extends React.Component {
+	state = {
+		currentLocale: 'en',
+	};
+
+	checkAndLoad() {
+		// is moment set to the current locale?
+		if ( this.props.currentLocale === moment.locale() ) {
+			return;
+		}
+		if ( this.props.currentLocale !== 'en' ) {
+			const loadingLocale = this.props.currentLocale;
+			import( /* webpackChunkName: "moment-locale-[request]", webpackInclude: /\.js$/ */ `moment/locale/${ loadingLocale }` ).then(
+				() => {
+					moment.locale( loadingLocale );
+					this.setState( { currentLocale: loadingLocale } );
+				}
+			);
+		} else {
+			moment.locale( 'en' );
+			this.setState( { currentLocale: 'en' } );
+		}
+	}
+
+	componentDidMount() {
+		this.checkAndLoad();
+	}
+
+	componentDidUpdate() {
+		this.checkAndLoad();
+	}
+
+	render() {
+		return <Provider value={ this.state.currentLocale }>{ this.props.children }</Provider>;
+	}
+}
+
+const ConnectedMomentProvider = connect( state => ( {
+	currentLocale: getCurrentLocaleSlug( state ),
+} ) )( MomentProvider );
+
+export { ConnectedMomentProvider as MomentProvider, Consumer as MomentConsumer };

--- a/client/components/with-localized-moment/context.js
+++ b/client/components/with-localized-moment/context.js
@@ -19,7 +19,7 @@ const debug = debugFactory( 'calypso:with-localized-moment' );
 const { Provider, Consumer } = React.createContext( moment );
 
 class MomentProvider extends React.Component {
-	state = { moment, locale: 'en' };
+	state = { moment, momentLocale: 'en' };
 
 	async checkAndLoad() {
 		const { currentLocale } = this.props;
@@ -40,11 +40,14 @@ class MomentProvider extends React.Component {
 			debug( 'Loaded moment locale for %s', currentLocale );
 		}
 
-		moment.locale( currentLocale );
-		this.setState( {
-			moment,
-			locale: currentLocale,
-		} );
+		// validate that someone else hasn't already changed the moment locale
+		if ( moment.locale() !== currentLocale ) {
+			moment.locale( currentLocale );
+			this.setState( {
+				moment,
+				momentLocale: currentLocale,
+			} );
+		}
 	}
 
 	componentDidMount() {

--- a/client/components/with-localized-moment/context.js
+++ b/client/components/with-localized-moment/context.js
@@ -7,16 +7,19 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import moment from 'moment';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 
+const debug = debugFactory( 'calypso:with-localized-moment' );
+
 const { Provider, Consumer } = React.createContext( moment );
 
 class MomentProvider extends React.Component {
-	state = { moment };
+	state = { moment, locale: 'en' };
 
 	async checkAndLoad() {
 		const { currentLocale } = this.props;
@@ -27,11 +30,21 @@ class MomentProvider extends React.Component {
 		}
 
 		if ( currentLocale !== 'en' ) {
-			await import( /* webpackChunkName: "moment-locale-[request]", webpackInclude: /\.js$/ */ `moment/locale/${ currentLocale }` );
+			debug( 'Loading moment locale for %s', currentLocale );
+			try {
+				await import( /* webpackChunkName: "moment-locale-[request]", webpackInclude: /\.js$/ */ `moment/locale/${ currentLocale }` );
+			} catch ( e ) {
+				debug( 'Failed to load moment locale for %s', currentLocale );
+				return;
+			}
+			debug( 'Loaded moment locale for %s', currentLocale );
 		}
 
 		moment.locale( currentLocale );
-		this.setState( {} );
+		this.setState( {
+			moment,
+			locale: currentLocale,
+		} );
 	}
 
 	componentDidMount() {

--- a/client/components/with-localized-moment/context.js
+++ b/client/components/with-localized-moment/context.js
@@ -32,7 +32,9 @@ class MomentProvider extends React.Component {
 		if ( currentLocale !== 'en' ) {
 			debug( 'Loading moment locale for %s', currentLocale );
 			try {
-				await import( /* webpackChunkName: "moment-locale-[request]", webpackInclude: /\.js$/ */ `moment/locale/${ currentLocale }` );
+				// expose the import load promise as instance property. Useful for tests that wait for it
+				this.loadingLocalePromise = import( /* webpackChunkName: "moment-locale-[request]", webpackInclude: /\.js$/ */ `moment/locale/${ currentLocale }` );
+				await this.loadingLocalePromise;
 			} catch ( e ) {
 				debug( 'Failed to load moment locale for %s', currentLocale );
 				return;

--- a/client/components/with-localized-moment/index.js
+++ b/client/components/with-localized-moment/index.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import React from 'react';
+import { createHigherOrderComponent } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { MomentConsumer } from './context';
+
+export default createHigherOrderComponent( Wrapped => {
+	return function WithLocalizedMoment( props ) {
+		return (
+			<MomentConsumer>
+				{ momentLocale => <Wrapped { ...props } moment={ momentLocale } /> }
+			</MomentConsumer>
+		);
+	};
+}, 'WithLocalizedMoment' );

--- a/client/components/with-localized-moment/index.js
+++ b/client/components/with-localized-moment/index.js
@@ -16,7 +16,7 @@ export default createHigherOrderComponent( Wrapped => {
 	return function WithLocalizedMoment( props ) {
 		return (
 			<MomentConsumer>
-				{ momentLocale => <Wrapped { ...props } moment={ momentLocale } /> }
+				{ momentState => <Wrapped { ...props } moment={ momentState.moment } /> }
 			</MomentConsumer>
 		);
 	};

--- a/client/components/with-localized-moment/index.js
+++ b/client/components/with-localized-moment/index.js
@@ -16,7 +16,7 @@ export default createHigherOrderComponent( Wrapped => {
 	return function WithLocalizedMoment( props ) {
 		return (
 			<MomentConsumer>
-				{ momentState => <Wrapped { ...props } moment={ momentState.moment } /> }
+				{ momentState => <Wrapped { ...props } { ...momentState } /> }
 			</MomentConsumer>
 		);
 	};

--- a/client/components/with-localized-moment/test/index.js
+++ b/client/components/with-localized-moment/test/index.js
@@ -1,0 +1,126 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { createStore } from 'redux';
+import { mount } from 'enzyme';
+import globalMoment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import { MomentProvider } from '../context';
+import withMoment from '..';
+
+// helper to create state object with specified `languageSlug`
+const createState = localeSlug => ( { ui: { language: { localeSlug } } } );
+
+// reducer for the Redux store
+const reducer = ( state, action ) => {
+	switch ( action.type ) {
+		case 'SET':
+			return createState( action.languageSlug );
+		default:
+			return state;
+	}
+};
+
+// Pure component that renders a "day-name month-name" label
+// We'll be testing if it rerenders the date despite being pure
+class Label extends React.PureComponent {
+	render() {
+		const { moment, date } = this.props;
+		return moment( date ).format( 'dddd MMMM' );
+	}
+}
+
+const LabelWithMoment = withMoment( Label );
+
+// expected values of the label in different languages
+const enLabel = 'Thursday November';
+const csLabel = 'čtvrtek listopad';
+
+// helper that looks at the `MomentProvider` instance wrapped inside `Connect(MomentProvider)`
+// and gets the `promise` instance property. The provider exposes the property for testing
+// purposes so that the test can wait for the locale dynamic import to finish.
+const getMomentProviderLoadingPromise = wrapper =>
+	wrapper.childAt( 0 ).instance().loadingLocalePromise;
+
+// Set a new locale by dispatching an action to the Redux store and then wait for locale load
+// to finish inside all specified providers.
+const setLocaleAndWait = async ( languageSlug, store, ...providerWrappers ) => {
+	store.dispatch( { type: 'SET', languageSlug } );
+	await Promise.all( providerWrappers.map( getMomentProviderLoadingPromise ) );
+};
+
+describe( 'withLocalizedMoment', () => {
+	// reset the locale before and each after test, to avoid cross-test influence
+	beforeEach( () => globalMoment.locale( 'en' ) );
+	afterEach( () => globalMoment.locale( 'en' ) );
+
+	it( 'renders localized date on a repeated language switch', async () => {
+		const store = createStore( reducer, createState( 'en' ) );
+
+		const wrapper = mount(
+			<MomentProvider store={ store }>
+				<LabelWithMoment date="2018-11-01" />
+			</MomentProvider>
+		);
+
+		expect( wrapper.text() ).toEqual( enLabel );
+
+		await setLocaleAndWait( 'cs', store, wrapper );
+		expect( wrapper.text() ).toEqual( csLabel );
+
+		await setLocaleAndWait( 'en', store, wrapper );
+		expect( wrapper.text() ).toEqual( enLabel );
+
+		await setLocaleAndWait( 'cs', store, wrapper );
+		expect( wrapper.text() ).toEqual( csLabel );
+	} );
+
+	it( 'starts with flash of EN content and then rerenders when non-EN is initial state', async () => {
+		const store = createStore( reducer, createState( 'cs' ) );
+
+		const wrapper = mount(
+			<MomentProvider store={ store }>
+				<LabelWithMoment date="2018-11-01" />
+			</MomentProvider>
+		);
+
+		// initial rendering is EN, but loading CS is in progress...
+		expect( wrapper.text() ).toEqual( enLabel );
+
+		// wait for the CS load to finish...
+		await getMomentProviderLoadingPromise( wrapper );
+
+		// and verify that indeed we are CS now
+		expect( wrapper.text() ).toEqual( csLabel );
+	} );
+
+	it( 'renders localized dates when using multiple providers', async () => {
+		const store = createStore( reducer, createState( 'en' ) );
+
+		// create two identical providers connected to the same Redux store
+		const wrappers = [ 1, 2 ].map( () =>
+			mount(
+				<MomentProvider store={ store }>
+					<LabelWithMoment date="2018-11-01" />
+				</MomentProvider>
+			)
+		);
+
+		wrappers.forEach( wrapper => expect( wrapper.text() ).toEqual( enLabel ) );
+
+		await setLocaleAndWait( 'cs', store, ...wrappers );
+		wrappers.forEach( wrapper => expect( wrapper.text() ).toEqual( csLabel ) );
+
+		await setLocaleAndWait( 'en', store, ...wrappers );
+		wrappers.forEach( wrapper => expect( wrapper.text() ).toEqual( enLabel ) );
+	} );
+} );

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -14,6 +14,7 @@ import page from 'page';
 import config from 'config';
 import Layout from 'layout';
 import LayoutLoggedOut from 'layout/logged-out';
+import { MomentProvider } from 'components/with-localized-moment/context';
 import { login } from 'lib/paths';
 import { makeLayoutMiddleware } from './shared.js';
 import { isUserLoggedIn } from 'state/current-user/selectors';
@@ -27,15 +28,18 @@ export { setSection, setUpLocale } from './shared.js';
 export const ReduxWrappedLayout = ( { store, primary, secondary, redirectUri } ) => {
 	const state = store.getState();
 	const userLoggedIn = isUserLoggedIn( state );
-	let layout = <Layout primary={ primary } secondary={ secondary } />;
 
-	if ( ! userLoggedIn ) {
-		layout = (
-			<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
-		);
-	}
+	const layout = userLoggedIn ? (
+		<Layout primary={ primary } secondary={ secondary } />
+	) : (
+		<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
+	);
 
-	return <ReduxProvider store={ store }>{ layout }</ReduxProvider>;
+	return (
+		<ReduxProvider store={ store }>
+			<MomentProvider>{ layout }</MomentProvider>
+		</ReduxProvider>
+	);
 };
 
 export const makeLayout = makeLayoutMiddleware( ReduxWrappedLayout );

--- a/client/devdocs/design/component-examples.js
+++ b/client/devdocs/design/component-examples.js
@@ -34,6 +34,7 @@ export FeatureGate from 'components/feature-example/docs/example';
 export FilePickers from 'components/file-picker/docs/example';
 export FocusableExample from 'components/focusable/docs/example';
 export FoldableCard from 'components/foldable-card/docs/example';
+export FormattedDate from 'components/formatted-date/docs/example';
 export FormattedHeader from 'components/formatted-header/docs/example';
 export FormFields from 'components/forms/docs/example';
 export Gauge from 'components/gauge/docs/example';

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -59,6 +59,7 @@ import FeatureGate from 'components/feature-example/docs/example';
 import FilePickers from 'components/file-picker/docs/example';
 import FocusableExample from 'components/focusable/docs/example';
 import FoldableCard from 'components/foldable-card/docs/example';
+import FormattedDate from 'components/formatted-date/docs/example';
 import FormattedHeader from 'components/formatted-header/docs/example';
 import FormFields from 'components/forms/docs/example';
 import Gauge from 'components/gauge/docs/example';
@@ -204,6 +205,7 @@ class DesignAssets extends React.Component {
 					<FilePickers readmeFilePath="file-picker" />
 					<FocusableExample readmeFilePath="focusable" />
 					<FoldableCard readmeFilePath="foldable-card" />
+					<FormattedDate readmeFilePath="formatted-date" />
 					<FormattedHeader readmeFilePath="formatted-header" />
 					<FormFields searchKeywords="input textbox textarea radio" readmeFilePath="forms" />
 					<Gauge readmeFilePath="gauge" />

--- a/client/devdocs/design/playground-scope.js
+++ b/client/devdocs/design/playground-scope.js
@@ -41,6 +41,7 @@ export FeatureGate from 'components/feature-example';
 export FilePickers from 'components/file-picker';
 export Focusable from 'components/focusable';
 export FoldableCard from 'components/foldable-card';
+export FormattedDate from 'components/formatted-date';
 export FormattedHeader from 'components/formatted-header';
 export FormButton from 'components/forms/form-button';
 export FormButtonsBar from 'components/forms/form-buttons-bar';

--- a/client/extensions/woocommerce/app/order/order-created/index.js
+++ b/client/extensions/woocommerce/app/order/order-created/index.js
@@ -7,6 +7,8 @@ import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 
+import withLocalizedMoment from 'components/with-localized-moment';
+
 class OrderCreated extends Component {
 	static propTypes = {
 		order: PropTypes.shape( {
@@ -39,4 +41,4 @@ class OrderCreated extends Component {
 	}
 }
 
-export default localize( OrderCreated );
+export default localize( withLocalizedMoment( OrderCreated ) );

--- a/client/layout/masterbar/quick-language-switcher.jsx
+++ b/client/layout/masterbar/quick-language-switcher.jsx
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { getLocaleSlug } from 'i18n-calypso';
 
 /**
@@ -12,6 +13,7 @@ import MasterbarItem from './item';
 import LanguagePickerModal from 'components/language-picker/modal';
 import switchLocale from 'lib/i18n-utils/switch-locale';
 import config from 'config';
+import { setLocale } from 'state/ui/language/actions';
 
 class QuickLanguageSwitcher extends React.Component {
 	state = {
@@ -25,7 +27,10 @@ class QuickLanguageSwitcher extends React.Component {
 		event.preventDefault();
 	};
 
-	onSelected = languageSlug => switchLocale( languageSlug );
+	onSelected = languageSlug => {
+		switchLocale( languageSlug );
+		this.props.setLocale( languageSlug );
+	};
 
 	render() {
 		const selectedLanguageSlug = getLocaleSlug();
@@ -48,4 +53,7 @@ class QuickLanguageSwitcher extends React.Component {
 	}
 }
 
-export default QuickLanguageSwitcher;
+export default connect(
+	null,
+	{ setLocale }
+)( QuickLanguageSwitcher );

--- a/client/lib/react-helpers/index.js
+++ b/client/lib/react-helpers/index.js
@@ -8,6 +8,11 @@ import ReactDom from 'react-dom';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 
+/**
+ * Internal dependencies
+ */
+import { MomentProvider } from 'components/with-localized-moment/context';
+
 export function concatTitle( ...parts ) {
 	return parts.join( ' › ' );
 }
@@ -17,7 +22,9 @@ export function renderWithReduxStore( reactElement, domContainer, reduxStore ) {
 		'string' === typeof domContainer ? document.getElementById( domContainer ) : domContainer;
 
 	return ReactDom.render(
-		React.createElement( ReduxProvider, { store: reduxStore }, reactElement ),
+		<ReduxProvider store={ reduxStore }>
+			<MomentProvider>{ reactElement }</MomentProvider>
+		</ReduxProvider>,
 		domContainerNode
 	);
 }

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
 import CSSTransition from 'react-transition-group/CSSTransition';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
 import emailValidator from 'email-validator';
 import { debounce, flowRight as compose, get, has, map, size, update } from 'lodash';
@@ -52,6 +52,7 @@ import { canDisplayCommunityTranslator } from 'components/community-translator/u
 import { ENABLE_TRANSLATOR_KEY } from 'components/community-translator/constants';
 import AccountSettingsCloseLink from './close-link';
 import { requestGeoLocation } from 'state/data-getters';
+import withLocalizedMoment from 'components/with-localized-moment';
 
 const user = _user();
 const colorSchemeKey = 'calypso_preferences.colorScheme';
@@ -387,8 +388,8 @@ const Account = createReactClass( {
 	},
 
 	renderJoinDate() {
-		const { translate } = this.props;
-		const dateMoment = i18n.moment( user.get().date );
+		const { translate, moment } = this.props;
+		const dateMoment = moment( user.get().date );
 
 		return (
 			<span>
@@ -823,5 +824,6 @@ export default compose(
 		{ errorNotice, recordGoogleEvent, recordTracksEvent, successNotice }
 	),
 	localize,
+	withLocalizedMoment,
 	protectForm
 )( Account );

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -67,6 +67,7 @@ import { requestActivityLogs } from 'state/data-getters';
 import { emptyFilter } from 'state/activity-log/reducer';
 import { isMobile } from 'lib/viewport';
 import analytics from 'lib/analytics';
+import withLocalizedMoment from 'components/with-localized-moment';
 
 const PAGE_SIZE = 20;
 
@@ -628,4 +629,4 @@ export default connect(
 			),
 		selectPage: ( siteId, pageNumber ) => updateFilter( siteId, { page: pageNumber } ),
 	}
-)( localize( ActivityLog ) );
+)( localize( withLocalizedMoment( ActivityLog ) ) );

--- a/client/signup/steps/clone-point/index.jsx
+++ b/client/signup/steps/clone-point/index.jsx
@@ -21,6 +21,7 @@ import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
 import { adjustMoment } from 'my-sites/activity/activity-log/utils';
 import { requestActivityLogs } from 'state/data-getters';
+import withLocalizedMoment from 'components/with-localized-moment';
 
 const PAGE_SIZE = 20;
 
@@ -201,4 +202,4 @@ export default connect( ( state, ownProps ) => {
 		siteId,
 		logs: ( siteId && logs.data ) || [],
 	};
-} )( localize( ClonePointStep ) );
+} )( localize( withLocalizedMoment( ClonePointStep ) ) );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3260,6 +3260,15 @@
         "chokidar": "^2.0.4"
       }
     },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.2.0.tgz",
+      "integrity": "sha512-fP899ELUnTaBcIzmrW7nniyqqdYWrWuJUyPWHxFa/c7r7hS6KC8FscNfLlBNIoPSc55kYMGEEKjPjJGCLbE1qA==",
+      "dev": true,
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
       "resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -275,6 +275,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",
+    "babel-plugin-dynamic-import-node": "2.2.0",
     "chai": "4.2.0",
     "chai-enzyme": "1.0.0-beta.1",
     "check-node-version": "3.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -279,6 +279,7 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 			} ),
 			new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),
 			new webpack.IgnorePlugin( /^props$/ ),
+			new webpack.IgnorePlugin( /^\.\/locale$/, /moment$/ ),
 			new MiniCssExtractPluginWithRTL( {
 				filename: cssFilename,
 				rtlEnabled: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,6 +39,7 @@ const shouldEmitStats = process.env.EMIT_STATS && process.env.EMIT_STATS !== 'fa
 const shouldEmitStatsWithReasons = process.env.EMIT_STATS === 'withreasons';
 const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
 const codeSplit = config.isEnabled( 'code-splitting' );
+const isCalypsoClient = process.env.CALYPSO_CLIENT === 'true';
 
 /**
  * This function scans the /client/extensions directory in order to generate a map that looks like this:
@@ -279,7 +280,7 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 			} ),
 			new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),
 			new webpack.IgnorePlugin( /^props$/ ),
-			new webpack.IgnorePlugin( /^\.\/locale$/, /moment$/ ),
+			isCalypsoClient && new webpack.IgnorePlugin( /^\.\/locale$/, /moment$/ ),
 			new MiniCssExtractPluginWithRTL( {
 				filename: cssFilename,
 				rtlEnabled: true,


### PR DESCRIPTION
Add two new components to support loading moment locale's async. First, a `withMoment()` HoC that watches for changes to the current locale and passes a localized moment to the wrapped component. Second, a `FormattedDate` component that uses `withMoment` to provide localized, formatted dates.

To test, visit http://calypso.localhost:3000/devdocs/design/formatted-date and play around. Try changing the locale and the date and the format string.