### PR TITLE
Activity Log: Use the shadow data to display the plugin updates.

### DIFF
--- a/client/my-sites/stats/activity-log-tasklist/to-update.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/to-update.jsx
@@ -11,7 +11,6 @@ import { get, unionBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getPluginsWithUpdates } from 'state/plugins/installed/selectors';
 import { requestSiteAlerts } from 'state/data-getters';
 
 const emptyList = [];
@@ -58,7 +57,7 @@ export default WrappedComponent => {
 	return connect( ( state, { siteId } ) => {
 		const alertsData = requestSiteAlerts( siteId );
 		return {
-			plugins: getPluginsWithUpdates( state, [ siteId ] ),
+			plugins: get( alertsData, 'data.updates.plugins', emptyList ),
 			themes: get( alertsData, 'data.updates.themes', emptyList ),
 			core: get( alertsData, 'data.updates.core', emptyList ),
 		};

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -33,7 +33,6 @@ import RewindAlerts from './rewind-alerts';
 import QueryRewindState from 'components/data/query-rewind-state';
 import QuerySiteSettings from 'components/data/query-site-settings'; // For site time offset
 import QueryRewindBackupStatus from 'components/data/query-rewind-backup-status';
-import QueryJetpackPlugins from 'components/data/query-jetpack-plugins/';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import StatsNavigation from 'blocks/stats-navigation';
 import SuccessBanner from '../activity-log-banner/success-banner';
@@ -502,7 +501,6 @@ class ActivityLog extends Component {
 				<PageViewTracker path="/stats/activity/:site" title="Stats > Activity" />
 				<DocumentHead title={ translate( 'Stats' ) } />
 				{ siteId && <QueryRewindState siteId={ siteId } /> }
-				{ siteId && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
 				{ '' !== rewindNoThanks && rewindIsNotReady
 					? siteId && <ActivityLogSwitch siteId={ siteId } redirect={ rewindNoThanks } />
 					: this.getActivityLog() }

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -81,6 +81,14 @@ export const requestSiteAlerts = siteId => {
 						} ) ),
 						warnings,
 						updates: {
+							plugins: updates.plugins.map( plugin => ( {
+								id: plugin.name,
+								name: plugin.display_name,
+								slug: plugin.slug,
+								type: plugin.type,
+								version: plugin.version,
+								update: true, // fake it till you make it
+							} ) ),
 							themes: updates.themes.map( theme => ( {
 								name: theme.name,
 								slug: theme.slug,


### PR DESCRIPTION
This PR saves one query by making sure that we get the data from the shadow site indead of the plugin api endpoint.

To test
- Set a plugin to update. By changing the version number and then visiting the updates page.
- Then visit the updates settings in the activity log.
- Click the update button.

Are you able to update the plugin as expected?