### PR TITLE
Reader: replace componentWillReceiveProps

### DIFF
--- a/client/reader/conversations/intro.jsx
+++ b/client/reader/conversations/intro.jsx
@@ -32,12 +32,12 @@ class ConversationsIntro extends React.Component {
 		this.maybeRecordRenderTrack();
 	}
 
-	componentWillReceiveProps( nextProps ) {
+	componentDidUpdate( prevProps ) {
 		if (
-			this.props.hasUsedConversations !== nextProps.hasUsedConversations ||
-			this.props.isInternal !== nextProps.isInternal
+			this.props.hasUsedConversations !== prevProps.hasUsedConversations ||
+			this.props.isInternal !== prevProps.isInternal
 		) {
-			this.maybeRecordRenderTrack( nextProps );
+			this.maybeRecordRenderTrack();
 		}
 	}
 

--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -22,9 +22,9 @@ class FollowingIntro extends React.Component {
 		this.recordRenderTrack();
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		if ( this.props.isNewReader !== nextProps.isNewReader ) {
-			this.recordRenderTrack( nextProps );
+	componentDidUpdate( prevProps ) {
+		if ( this.props.isNewReader !== prevProps.isNewReader ) {
+			this.recordRenderTrack();
 		}
 	}
 

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -55,18 +55,10 @@ class SearchStream extends React.Component {
 		streamKey: PropTypes.string,
 	};
 
-	componentWillReceiveProps( nextProps ) {
-		const title = this.getTitle( nextProps );
-		if ( title !== this.state.title ) {
-			this.setState( { title } );
-		}
-	}
-
 	getTitle = ( props = this.props ) => props.query || props.translate( 'Search' );
 
 	state = {
 		selected: SEARCH_TYPES.POSTS,
-		title: this.getTitle(),
 	};
 
 	updateQuery = newValue => {
@@ -121,7 +113,7 @@ class SearchStream extends React.Component {
 		}
 
 		const documentTitle = translate( '%s ‹ Reader', {
-			args: this.state.title,
+			args: this.getTitle(),
 		} );
 
 		const TEXT_RELEVANCE_SORT = translate( 'Relevance', {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -93,8 +93,12 @@ class ReaderStream extends React.Component {
 		forcePlaceholders: false,
 	};
 
-	componentDidUpdate( { selectedPostKey } ) {
-		const { recsStreamKey, recsStream } = this.props;
+	componentDidUpdate( { selectedPostKey, streamKey } ) {
+		if ( streamKey !== this.props.streamKey ) {
+			this.props.resetCardExpansions();
+			this.props.viewStream( { streamKey } );
+			this.fetchNextPage( {} );
+		}
 
 		if ( ! keysAreEqual( selectedPostKey, this.props.selectedPostKey ) ) {
 			this.scrollToSelectedPost( true );
@@ -102,8 +106,8 @@ class ReaderStream extends React.Component {
 
 		if ( this.props.shouldRequestRecs ) {
 			this.props.requestPage( {
-				streamKey: recsStreamKey,
-				pageHandle: recsStream.pageHandle,
+				streamKey: this.props.recsStreamKey,
+				pageHandle: this.props.recsStream.pageHandle,
 			} );
 		}
 	}
@@ -162,14 +166,6 @@ class ReaderStream extends React.Component {
 		window.removeEventListener( 'popstate', this._popstate );
 		if ( 'scrollRestoration' in history ) {
 			history.scrollRestoration = 'auto';
-		}
-	}
-
-	componentDidUpdate( prevProps ) {
-		if ( prevProps.streamKey !== this.props.streamKey ) {
-			this.props.resetCardExpansions();
-			this.props.viewStream( { streamKey } );
-			this.fetchNextPage( {}, nextProps );
 		}
 	}
 

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -165,9 +165,8 @@ class ReaderStream extends React.Component {
 		}
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		const { streamKey } = nextProps;
-		if ( streamKey !== this.props.streamKey ) {
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.streamKey !== this.props.streamKey ) {
 			this.props.resetCardExpansions();
 			this.props.viewStream( { streamKey } );
 			this.fetchNextPage( {}, nextProps );

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -37,19 +37,20 @@ class TagStreamHeader extends React.Component {
 		tagImages: [],
 	};
 
-	pickTagImage = ( props = this.props ) => {
-		return sample( props.tagImages );
-	};
-
 	state = {
 		tagImages: this.props.tagImages,
-		chosenTagImage: this.pickTagImage(),
+		chosenTagImage: sample( this.props.tagImages ),
 	};
 
-	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.tagImages !== this.props.tagImages ) {
-			this.setState( { chosenTagImage: this.pickTagImage( nextProps ) } );
+	static getDerivedStateFromProps( nextProps, prevState ) {
+		if ( nextProps.tagImages === prevState.tagImages ) {
+			return null;
 		}
+
+		return {
+			tagImages: nextProps.tagImages,
+			chosenTagImage: sample( nextProps.tagImages ),
+		};
 	}
 
 	render() {

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -60,18 +60,15 @@ class TagStream extends React.Component {
 		this._isMounted = false;
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.encodedTagSlug !== this.props.encodedTagSlug ) {
-			this.checkForTwemoji( nextProps );
+	static getDerivedStateFromProps( nextProps, prevState ) {
+		if ( ! prevState.twemoji || ! nextProps.decodedTagSlug ) {
+			return null;
 		}
-	}
 
-	checkForTwemoji = () => {
-		const title = this.getTitle();
-		this.setState( {
-			isEmojiTitle: title && this.state.twemoji && this.state.twemoji.test( title ),
-		} );
-	};
+		return {
+			isEmojiTitle: prevState.twemoji.test( nextProps.decodedTagSlug ),
+		};
+	}
 
 	isSubscribed = () => {
 		const tag = find( this.props.tags, { slug: this.props.encodedTagSlug } );


### PR DESCRIPTION
`componentWillReceiveProps` was deprecated in React 16.3.0:

https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops

This PR removes all instances of it in `client/reader`.

Key places to test:
- try switching streams in Reader
- try a tag stream with an emoji title like http://calypso.localhost:3000/tag/🐶