### PR TITLE
Add a new displayAsLink property to the Card component to allow button cards to appear like links

### DIFF
--- a/client/components/card/README.md
+++ b/client/components/card/README.md
@@ -33,6 +33,7 @@ Name | Type | Default | Description
 `className` | `string` | null | Adds CSS classes.
 `href` | `string` | null | URL of the card. Adds a right chevron icon.
 `tagName` | `string` | null | Allows you to control the tag name of the card wrapper (only if `href` is not specified).
+`displayAsLink` | `bool` | false | Used for cards without a `href` that need to display as a link. Primarily intended for use when `tagName` is "button" and when an `onClick` attribute is set. The corresponding button will render with the same visual appearance as a link (including the right chevron icon).
 `target` | `string` | null | If used with `href`, this specifies where the link opens. Changes the icon to `external`.
 `compact` | `bool` | false | Decreases the size of the card.
 `highlight` | `string` | `false` | Displays a colored highlight. Can be `false` (no highlight, default), `info`, `success`, `error`, or `warning`.

--- a/client/components/card/docs/example.jsx
+++ b/client/components/card/docs/example.jsx
@@ -32,6 +32,15 @@ class Cards extends React.Component {
 				<Card href="#cards" target="_blank" rel="noopener noreferrer">
 					I am a externally linked Card
 				</Card>
+				<Card
+					tagName="button"
+					displayAsLink
+					onClick={ function () {
+						alert( 'Thank you for clicking me!' );
+					} }
+				>
+					I am a clickable button that looks like a link
+				</Card>
 				<Card highlight="info">I am a Card, highlighted as info</Card>
 				<Card highlight="success">I am a Card, highlighted as success</Card>
 				<Card highlight="error">I am a Card, highlighted as error</Card>

--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -8,12 +8,12 @@ import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 
-const getClassName = ( { className, compact, highlight, href, onClick } ) =>
+const getClassName = ( { className, compact, displayAsLink, highlight, href, onClick } ) =>
 	classNames(
 		'card',
 		className,
 		{
-			'is-card-link': !! href,
+			'is-card-link': displayAsLink || !! href,
 			'is-clickable': !! onClick,
 			'is-compact': compact,
 			'is-highlight': highlight,
@@ -24,6 +24,7 @@ const getClassName = ( { className, compact, highlight, href, onClick } ) =>
 class Card extends PureComponent {
 	static propTypes = {
 		className: PropTypes.string,
+		displayAsLink: PropTypes.bool,
 		href: PropTypes.string,
 		tagName: PropTypes.oneOfType( [ PropTypes.func, PropTypes.string ] ).isRequired,
 		target: PropTypes.string,
@@ -37,7 +38,16 @@ class Card extends PureComponent {
 	};
 
 	render() {
-		const { children, compact, highlight, tagName: TagName, href, target, ...props } = this.props;
+		const {
+			children,
+			compact,
+			displayAsLink,
+			highlight,
+			tagName: TagName,
+			href,
+			target,
+			...props
+		} = this.props;
 
 		return href ? (
 			<a { ...props } href={ href } target={ target } className={ getClassName( this.props ) }>
@@ -46,6 +56,12 @@ class Card extends PureComponent {
 			</a>
 		) : (
 			<TagName { ...props } className={ getClassName( this.props ) }>
+				{ displayAsLink && (
+					<Gridicon
+						className="card__link-indicator"
+						icon={ target ? 'external' : 'chevron-right' }
+					/>
+				) }
 				{ children }
 			</TagName>
 		);

--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -5,12 +5,11 @@
 	padding: 16px;
 	box-sizing: border-box;
 	background: $white;
-	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
-		0 1px 2px $gray-lighten-30;
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, 0.5 ), 0 1px 2px $gray-lighten-30;
 
 	@include clear-fix;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		margin-bottom: 16px;
 		padding: 24px;
 	}
@@ -19,7 +18,7 @@
 	&.is-compact {
 		margin-bottom: 1px;
 
-		@include breakpoint( ">480px" ) {
+		@include breakpoint( '>480px' ) {
 			margin-bottom: 1px;
 			padding: 16px 24px;
 		}
@@ -27,6 +26,19 @@
 
 	&.is-card-link {
 		padding-right: 48px;
+		&:not( a ) {
+			color: $blue-wordpress;
+			font-size: 100%;
+			line-height: 1.5;
+			text-align: left;
+			width: 100%;
+
+			&:active,
+			&:focus,
+			&:hover {
+				color: $link-highlight;
+			}
+		}
 	}
 
 	&.is-clickable {
@@ -54,7 +66,6 @@
 	}
 }
 
-
 // Clickable Card
 .card__link-indicator {
 	color: $gray-text-min;
@@ -64,21 +75,22 @@
 	top: 0;
 	right: 16px;
 
-	html[dir="rtl"] & {
+	html[dir='rtl'] & {
 		&.gridicons-chevron-right {
 			transform: scaleX( -1 );
 		}
 	}
-
 }
 
-a.card:hover {
+a.card:hover,
+.is-card-link.card:hover {
 	.card__link-indicator {
 		color: $gray-text;
 	}
 }
 
-a.card:focus {
+a.card:focus,
+.is-card-link.card:focus {
 	outline: 0;
 
 	.card__link-indicator {

--- a/client/components/card/test/__snapshots__/index.js.snap
+++ b/client/components/card/test/__snapshots__/index.js.snap
@@ -26,6 +26,20 @@ exports[`Card should have custom class of \`test__ace\` 1`] = `
 />
 `;
 
+exports[`Card should render as a clickable button which looks like a link 1`] = `
+<button
+  className="card is-card-link is-clickable"
+  onClick="test"
+>
+  <t
+    className="card__link-indicator"
+    icon="chevron-right"
+    size={24}
+  />
+  This is a button which looks like a link
+</button>
+`;
+
 exports[`Card should render children 1`] = `
 <div
   className="card"

--- a/client/components/card/test/index.js
+++ b/client/components/card/test/index.js
@@ -41,6 +41,19 @@ describe( 'Card', () => {
 		expect( card.is( '.is-card-link' ) ).toBe( true );
 		expect( card ).toMatchSnapshot();
 	} );
+	// check that it can be rendered as a clickable button displaying as a link
+	test( 'should render as a clickable button which looks like a link', () => {
+		const card = shallow(
+			<Card tagName="button" displayAsLink onClick="test">
+				This is a button which looks like a link
+			</Card>
+		);
+		expect( card.is( 'a' ) ).toBe( false );
+		expect( card.is( 'button' ) ).toBe( true );
+		expect( card.is( '.is-card-link' ) ).toBe( true );
+		expect( card.is( '.is-clickable' ) ).toBe( true );
+		expect( card ).toMatchSnapshot();
+	} );
 } );
 
 describe( 'CompactCard', () => {


### PR DESCRIPTION
This pull request adds a new `displayAsLink` property to the `Card` component.  When used with a card that has `tagName` set to "button", it causes the resulting `<button>` element in the HTML to display the same as a regular link card would (with the right chevron icon and other link styling).

This is useful because it's possible to have a clickable button (with an `onClick` handler but no `href`) which ultimately redirects the user to a different URL after doing some processing, and thus which should look the same as a link to the end user.

An example where this comes up is https://github.com/Automattic/wp-calypso/pull/26428 (I am pulling the code for this out of there so it can be merged separately).