### PR TITLE
[nudge-a-palooza] Redirect users to feature upsell pages based on plan features and not eligibility warnings

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -95,8 +95,6 @@ export const FEATURE_ALL_PREMIUM_FEATURES_JETPACK = 'all-premium-features-jetpac
 export const FEATURE_ADVANCED_CUSTOMIZATION = 'advanced-customization';
 export const FEATURE_PREMIUM_THEMES = 'unlimited-premium-themes';
 export const FEATURE_UPLOAD_THEMES_PLUGINS = 'upload-themes-and-plugins';
-export const FEATURE_UPLOAD_THEMES_AFTER_AT = 'upload-themes-after-at';
-export const FEATURE_UPLOAD_PLUGINS_AFTER_AT = 'upload-plugins-after-at';
 export const FEATURE_GOOGLE_ANALYTICS_SIGNUP = 'google-analytics-signup';
 export const FEATURE_FREE_DOMAIN = 'free-custom-domain';
 export const FEATURE_UNLIMITED_STORAGE_SIGNUP = 'unlimited-storage-signup';
@@ -332,8 +330,6 @@ const getPlanBusinessDetails = () => ( {
 			FEATURE_ADVANCED_SEO,
 			isEnabled( 'automated-transfer' ) && FEATURE_UPLOAD_PLUGINS,
 			isEnabled( 'automated-transfer' ) && FEATURE_UPLOAD_THEMES,
-			FEATURE_UPLOAD_THEMES_AFTER_AT,
-			FEATURE_UPLOAD_PLUGINS_AFTER_AT,
 			FEATURE_GOOGLE_ANALYTICS,
 			FEATURE_NO_BRANDING,
 		] ),

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -95,6 +95,8 @@ export const FEATURE_ALL_PREMIUM_FEATURES_JETPACK = 'all-premium-features-jetpac
 export const FEATURE_ADVANCED_CUSTOMIZATION = 'advanced-customization';
 export const FEATURE_PREMIUM_THEMES = 'unlimited-premium-themes';
 export const FEATURE_UPLOAD_THEMES_PLUGINS = 'upload-themes-and-plugins';
+export const FEATURE_UPLOAD_THEMES_AFTER_AT = 'upload-themes-after-at';
+export const FEATURE_UPLOAD_PLUGINS_AFTER_AT = 'upload-plugins-after-at';
 export const FEATURE_GOOGLE_ANALYTICS_SIGNUP = 'google-analytics-signup';
 export const FEATURE_FREE_DOMAIN = 'free-custom-domain';
 export const FEATURE_UNLIMITED_STORAGE_SIGNUP = 'unlimited-storage-signup';
@@ -330,6 +332,8 @@ const getPlanBusinessDetails = () => ( {
 			FEATURE_ADVANCED_SEO,
 			isEnabled( 'automated-transfer' ) && FEATURE_UPLOAD_PLUGINS,
 			isEnabled( 'automated-transfer' ) && FEATURE_UPLOAD_THEMES,
+			FEATURE_UPLOAD_THEMES_AFTER_AT,
+			FEATURE_UPLOAD_PLUGINS_AFTER_AT,
 			FEATURE_GOOGLE_ANALYTICS,
 			FEATURE_NO_BRANDING,
 		] ),

--- a/client/my-sites/feature-upsell/main.jsx
+++ b/client/my-sites/feature-upsell/main.jsx
@@ -12,8 +12,10 @@ import StoreUpsellComponent from './store-upsell';
 import ThemesUpsellComponent from './themes-upsell';
 import WordAdsUpsellComponent from './ads-upsell';
 import FeaturesComponent from './features';
+import upsellRedirect from './upsell-redirect';
 
 export {
+	upsellRedirect,
 	FeaturesComponent,
 	PluginsUpsellComponent,
 	StoreUpsellComponent,

--- a/client/my-sites/feature-upsell/test/upsell-redirect.jsx
+++ b/client/my-sites/feature-upsell/test/upsell-redirect.jsx
@@ -1,0 +1,74 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { Wrapper } from '../upsell-redirect';
+
+/**
+ * Module variables
+ */
+
+describe( 'upsellRedirect', () => {
+	const defaultProps = {
+		siteId: 1,
+		upsellPageURL: '/',
+		shouldRedirectToUpsellPage: false,
+	};
+	describe( 'Wrapper - unit tests', () => {
+		test( 'shouldRedirectToUpsellPage() should return true if and only if plan is already available', () => {
+			const test = props => new Wrapper( props ).shouldRedirectToUpsellPage();
+			expect( test( { shouldRedirectToUpsellPage: true, loadingPlan: true } ) ).toBe( false );
+			expect( test( { shouldRedirectToUpsellPage: false, loadingPlan: true } ) ).toBe( false );
+			expect( test( { shouldRedirectToUpsellPage: false, loadingPlan: false } ) ).toBe( false );
+			expect( test( { shouldRedirectToUpsellPage: true, loadingPlan: false } ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'Wrapper - enzyme tests', () => {
+		test( 'Renders nothing when current plan is still being loaded', () => {
+			const rendered = shallow(
+				<Wrapper
+					{ ...defaultProps }
+					ComponentClass={ 'div' }
+					loadingPlan={ true }
+					shouldRedirectToUpsellPage={ true }
+				/>
+			);
+			expect( rendered.find( 'div' ).length ).toBe( 0 );
+		} );
+
+		test( 'Renders nothing when current plan is already loaded and redirect is required', () => {
+			const rendered = shallow(
+				<Wrapper
+					{ ...defaultProps }
+					ComponentClass={ 'div' }
+					loadingPlan={ false }
+					shouldRedirectToUpsellPage={ true }
+				/>
+			);
+			expect( rendered.find( 'div' ).length ).toBe( 0 );
+		} );
+
+		test( 'Renders ComponentClass when current plan is already loaded and redirect is not required', () => {
+			const rendered = shallow(
+				<Wrapper
+					{ ...defaultProps }
+					ComponentClass={ 'div' }
+					loadingPlan={ false }
+					shouldRedirectToUpsellPage={ false }
+				/>
+			);
+			expect( rendered.find( 'div' ).length ).toBe( 1 );
+		} );
+	} );
+} );

--- a/client/my-sites/feature-upsell/test/upsell-redirect.jsx
+++ b/client/my-sites/feature-upsell/test/upsell-redirect.jsx
@@ -12,7 +12,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { Wrapper } from '../upsell-redirect';
+import { UpsellRedirectWrapper } from '../upsell-redirect';
 
 /**
  * Module variables
@@ -26,7 +26,7 @@ describe( 'upsellRedirect', () => {
 	};
 	describe( 'Wrapper - unit tests', () => {
 		test( 'shouldRedirectToUpsellPage() should return true if and only if plan is already available', () => {
-			const test = props => new Wrapper( props ).shouldRedirectToUpsellPage();
+			const test = props => new UpsellRedirectWrapper( props ).shouldRedirectToUpsellPage();
 			expect( test( { shouldRedirectToUpsellPage: true, loadingPlan: true } ) ).toBe( false );
 			expect( test( { shouldRedirectToUpsellPage: false, loadingPlan: true } ) ).toBe( false );
 			expect( test( { shouldRedirectToUpsellPage: false, loadingPlan: false } ) ).toBe( false );
@@ -37,7 +37,7 @@ describe( 'upsellRedirect', () => {
 	describe( 'Wrapper - enzyme tests', () => {
 		test( 'Renders nothing when current plan is still being loaded', () => {
 			const rendered = shallow(
-				<Wrapper
+				<UpsellRedirectWrapper
 					{ ...defaultProps }
 					ComponentClass={ 'div' }
 					loadingPlan={ true }
@@ -49,7 +49,7 @@ describe( 'upsellRedirect', () => {
 
 		test( 'Renders nothing when current plan is already loaded and redirect is required', () => {
 			const rendered = shallow(
-				<Wrapper
+				<UpsellRedirectWrapper
 					{ ...defaultProps }
 					ComponentClass={ 'div' }
 					loadingPlan={ false }
@@ -61,7 +61,7 @@ describe( 'upsellRedirect', () => {
 
 		test( 'Renders ComponentClass when current plan is already loaded and redirect is not required', () => {
 			const rendered = shallow(
-				<Wrapper
+				<UpsellRedirectWrapper
 					{ ...defaultProps }
 					ComponentClass={ 'div' }
 					loadingPlan={ false }

--- a/client/my-sites/feature-upsell/upsell-redirect.jsx
+++ b/client/my-sites/feature-upsell/upsell-redirect.jsx
@@ -17,7 +17,7 @@ import { getCurrentPlan, hasFeature } from 'state/sites/plans/selectors';
 import { abtest } from 'lib/abtest';
 import config from 'config';
 
-export class Wrapper extends React.Component {
+export class UpsellRedirectWrapper extends React.Component {
 	static propTypes = {
 		siteId: PropTypes.number.isRequired,
 		ComponentClass: PropTypes.any.isRequired,
@@ -84,7 +84,7 @@ export const createMapStateToProps = (
 export const upsellRedirect = ( requiredFeature, upsellPageURL ) => {
 	return ComponentClass => {
 		const mapStateToProps = createMapStateToProps( ComponentClass, requiredFeature, upsellPageURL );
-		return connect( mapStateToProps )( Wrapper );
+		return connect( mapStateToProps )( UpsellRedirectWrapper );
 	};
 };
 

--- a/client/my-sites/feature-upsell/upsell-redirect.jsx
+++ b/client/my-sites/feature-upsell/upsell-redirect.jsx
@@ -1,0 +1,87 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getCurrentPlan, hasFeature } from 'state/sites/plans/selectors';
+import { abtest } from 'lib/abtest';
+import config from 'config';
+
+export class Wrapper extends React.Component {
+	static propTypes = {
+		siteId: PropTypes.number.isRequired,
+		ComponentClass: PropTypes.any.isRequired,
+		upsellPageURL: PropTypes.string.isRequired,
+		shouldRedirectToUpsellPage: PropTypes.bool.isRequired,
+		loadingPlan: PropTypes.bool.isRequired,
+	};
+
+	componentDidMount() {
+		this.goToUpsellPageIfRequired();
+	}
+
+	getSnapshotBeforeUpdate() {
+		this.goToUpsellPageIfRequired();
+	}
+
+	goToUpsellPageIfRequired() {
+		const props = this.props;
+		if ( this.shouldRedirectToUpsellPage() ) {
+			page.redirect( `${ props.upsellPageURL }/${ props.siteSlug }` );
+		}
+	}
+
+	shouldRedirectToUpsellPage() {
+		const props = this.props;
+		return props.shouldRedirectToUpsellPage && ! props.loadingPlan;
+	}
+
+	render() {
+		const { ComponentClass, loadingPlan, shouldRedirectToUpsellPage, ...props } = this.props;
+		if ( loadingPlan || this.shouldRedirectToUpsellPage() ) {
+			return false;
+		}
+
+		return <ComponentClass { ...props } />;
+	}
+}
+
+export const createMapStateToProps = (
+	ComponentClass,
+	requiredFeature,
+	upsellPageURL
+) => state => {
+	const siteId = getSelectedSiteId( state );
+	const currentPlan = getCurrentPlan( state, siteId );
+	const shouldRedirectToUpsellPage =
+		config.isEnabled( 'upsell/nudge-a-palooza' ) &&
+		abtest( 'nudgeAPalooza' ) === 'customPluginAndThemeLandingPages' &&
+		! hasFeature( state, siteId, requiredFeature );
+
+	return {
+		siteId,
+		ComponentClass,
+		upsellPageURL,
+		shouldRedirectToUpsellPage,
+		loadingPlan: ! currentPlan,
+	};
+};
+
+export const upsellRedirect = ( requiredFeature, upsellPageURL ) => {
+	return ComponentClass => {
+		const mapStateToProps = createMapStateToProps( ComponentClass, requiredFeature, upsellPageURL );
+		return connect( mapStateToProps )( Wrapper );
+	};
+};
+
+export default upsellRedirect;

--- a/client/my-sites/feature-upsell/upsell-redirect.jsx
+++ b/client/my-sites/feature-upsell/upsell-redirect.jsx
@@ -27,6 +27,7 @@ export class Wrapper extends React.Component {
 	};
 
 	componentDidMount() {
+		this.redirected = false;
 		this.goToUpsellPageIfRequired();
 	}
 
@@ -37,7 +38,10 @@ export class Wrapper extends React.Component {
 	goToUpsellPageIfRequired() {
 		const props = this.props;
 		if ( this.shouldRedirectToUpsellPage() ) {
-			page.redirect( `${ props.upsellPageURL }/${ props.siteSlug }` );
+			if ( ! this.redirected ) {
+				page.redirect( `${ props.upsellPageURL }/${ props.siteSlug }` );
+				this.redirected = true;
+			}
 		}
 	}
 

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -28,7 +28,7 @@ import QueryEligibility from 'components/data/query-atat-eligibility';
 import { uploadPlugin, clearPluginUpload } from 'state/plugins/upload/actions';
 import { initiateAutomatedTransferWithPluginZip } from 'state/automated-transfer/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { FEATURE_UPLOAD_PLUGINS_AFTER_AT } from 'lib/plans/constants';
+import { FEATURE_UPLOAD_PLUGINS } from 'lib/plans/constants';
 import getPluginUploadError from 'state/selectors/get-plugin-upload-error';
 import getPluginUploadProgress from 'state/selectors/get-plugin-upload-progress';
 import getUploadedPluginId from 'state/selectors/get-uploaded-plugin-id';
@@ -213,5 +213,5 @@ export default compose(
 		{ uploadPlugin, clearPluginUpload, initiateAutomatedTransferWithPluginZip, successNotice }
 	),
 	localize,
-	upsellRedirect( FEATURE_UPLOAD_PLUGINS_AFTER_AT, '/feature/plugins' )
+	upsellRedirect( FEATURE_UPLOAD_PLUGINS, '/feature/plugins' )
 )( PluginUpload );

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -51,10 +51,7 @@ import EligibilityWarnings from 'blocks/eligibility-warnings';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import { getBackPath } from 'state/themes/themes-ui/selectors';
 import { hasFeature } from 'state/sites/plans/selectors';
-import {
-	FEATURE_UNLIMITED_PREMIUM_THEMES,
-	FEATURE_UPLOAD_THEMES_AFTER_AT,
-} from 'lib/plans/constants';
+import { FEATURE_UNLIMITED_PREMIUM_THEMES, FEATURE_UPLOAD_THEMES } from 'lib/plans/constants';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-transfer/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
@@ -332,5 +329,5 @@ export default compose(
 		{ uploadTheme, clearThemeUpload, initiateThemeTransfer }
 	),
 	localize,
-	upsellRedirect( FEATURE_UPLOAD_THEMES_AFTER_AT, '/feature/themes' )
+	upsellRedirect( FEATURE_UPLOAD_THEMES, '/feature/themes' )
 )( UploadWithOptions );

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -6,9 +6,9 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import page from 'page';
 import { connect } from 'react-redux';
 import { includes, find, isEmpty } from 'lodash';
+import { compose } from 'redux';
 
 /**
  * Internal dependencies
@@ -51,13 +51,15 @@ import EligibilityWarnings from 'blocks/eligibility-warnings';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import { getBackPath } from 'state/themes/themes-ui/selectors';
 import { hasFeature } from 'state/sites/plans/selectors';
-import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
+import {
+	FEATURE_UNLIMITED_PREMIUM_THEMES,
+	FEATURE_UPLOAD_THEMES_AFTER_AT,
+} from 'lib/plans/constants';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-transfer/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import WpAdminAutoLogin from 'components/wpadmin-auto-login';
-import config from 'config';
-import { abtest } from 'lib/abtest';
+import { upsellRedirect } from 'my-sites/feature-upsell/main';
 
 const debug = debugFactory( 'calypso:themes:theme-upload' );
 
@@ -87,7 +89,6 @@ class Upload extends React.Component {
 	componentDidMount() {
 		const { siteId, inProgress } = this.props;
 		! inProgress && this.props.clearThemeUpload( siteId );
-		this.goToUpsellPageIfRequired( this.props );
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -99,18 +100,6 @@ class Upload extends React.Component {
 		if ( nextProps.showEligibility !== this.props.showEligibility ) {
 			this.setState( { showEligibility: nextProps.showEligibility } );
 		}
-
-		this.goToUpsellPageIfRequired( nextProps );
-	}
-
-	goToUpsellPageIfRequired( props ) {
-		if ( this.shouldRedirectToUpsellPage( props ) ) {
-			page.redirect( `/feature/themes/${ props.siteSlug }` );
-		}
-	}
-
-	shouldRedirectToUpsellPage( props = this.props ) {
-		return props.useUpsellPage && props.showEligibility;
 	}
 
 	onProceedClick = () => {
@@ -269,10 +258,6 @@ class Upload extends React.Component {
 			return this.renderNotAvailableForMultisite();
 		}
 
-		if ( this.shouldRedirectToUpsellPage() ) {
-			return false;
-		}
-
 		return (
 			<Main>
 				<QueryEligibility siteId={ siteId } />
@@ -304,47 +289,48 @@ const UploadWithOptions = props => {
 	return <ConnectedUpload { ...props } siteId={ siteId } theme={ uploadedTheme } />;
 };
 
-export default connect(
-	state => {
-		const siteId = getSelectedSiteId( state );
-		const site = getSelectedSite( state );
-		const themeId = getUploadedThemeId( state, siteId );
-		const isJetpack = isJetpackSite( state, siteId );
-		const { eligibilityHolds, eligibilityWarnings } = getEligibility( state, siteId );
-		// Use this selector to take advantage of eligibility card placeholders
-		// before data has loaded.
-		const isEligible = isEligibleForAutomatedTransfer( state, siteId );
-		const hasEligibilityMessages = ! (
-			isEmpty( eligibilityHolds ) && isEmpty( eligibilityWarnings )
-		);
+const mapStateToProps = state => {
+	const siteId = getSelectedSiteId( state );
+	const site = getSelectedSite( state );
+	const themeId = getUploadedThemeId( state, siteId );
+	const isJetpack = isJetpackSite( state, siteId );
+	const { eligibilityHolds, eligibilityWarnings } = getEligibility( state, siteId );
+	// Use this selector to take advantage of eligibility card placeholders
+	// before data has loaded.
+	const isEligible = isEligibleForAutomatedTransfer( state, siteId );
+	const hasEligibilityMessages = ! (
+		isEmpty( eligibilityHolds ) && isEmpty( eligibilityWarnings )
+	);
 
-		const useUpsellPage =
-			config.isEnabled( 'upsell/nudge-a-palooza' ) &&
-			abtest( 'nudgeAPalooza' ) === 'customPluginAndThemeLandingPages';
+	return {
+		siteId,
+		siteSlug: getSelectedSiteSlug( state ),
+		isBusiness: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
+		selectedSite: site,
+		isJetpack,
+		inProgress: isUploadInProgress( state, siteId ),
+		complete: isUploadComplete( state, siteId ),
+		failed: hasUploadFailed( state, siteId ),
+		themeId,
+		isMultisite: isJetpackSiteMultiSite( state, siteId ),
+		uploadedTheme: getCanonicalTheme( state, siteId, themeId ),
+		error: getUploadError( state, siteId ),
+		progressTotal: getUploadProgressTotal( state, siteId ),
+		progressLoaded: getUploadProgressLoaded( state, siteId ),
+		installing: isInstallInProgress( state, siteId ),
+		upgradeJetpack: isJetpack && ! hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ),
+		backPath: getBackPath( state ),
+		showEligibility: ! isJetpack && ( hasEligibilityMessages || ! isEligible ),
+		isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
+		siteAdminUrl: getSiteAdminUrl( state, siteId ),
+	};
+};
 
-		return {
-			siteId,
-			useUpsellPage,
-			siteSlug: getSelectedSiteSlug( state ),
-			isBusiness: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
-			selectedSite: site,
-			isJetpack,
-			inProgress: isUploadInProgress( state, siteId ),
-			complete: isUploadComplete( state, siteId ),
-			failed: hasUploadFailed( state, siteId ),
-			themeId,
-			isMultisite: isJetpackSiteMultiSite( state, siteId ),
-			uploadedTheme: getCanonicalTheme( state, siteId, themeId ),
-			error: getUploadError( state, siteId ),
-			progressTotal: getUploadProgressTotal( state, siteId ),
-			progressLoaded: getUploadProgressLoaded( state, siteId ),
-			installing: isInstallInProgress( state, siteId ),
-			upgradeJetpack: isJetpack && ! hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ),
-			backPath: getBackPath( state ),
-			showEligibility: ! isJetpack && ( hasEligibilityMessages || ! isEligible ),
-			isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
-			siteAdminUrl: getSiteAdminUrl( state, siteId ),
-		};
-	},
-	{ uploadTheme, clearThemeUpload, initiateThemeTransfer }
-)( localize( UploadWithOptions ) );
+export default compose(
+	connect(
+		mapStateToProps,
+		{ uploadTheme, clearThemeUpload, initiateThemeTransfer }
+	),
+	localize,
+	upsellRedirect( FEATURE_UPLOAD_THEMES_AFTER_AT, '/feature/themes' )
+)( UploadWithOptions );


### PR DESCRIPTION
This PR fixes a problem with a previous redirect logic: p2EDhh-tc-p2
tl;dr - business plan users who did not have an AT were unable to upload plugins and themes because they were redirected to the upsell page.

This behavior was caused by the fact that we redirected based on the presence of eligibility warnings like "upgrade to a business plan to use this feature". This logic turned out to be invalid since custom domain were also an eligibility warning. As specified in the discussion above, some timing issues may have been involved and sometimes it was OK so we got "lucky" during testing and released it.

This PR changes the approach so that we redirect based on plan features instead. It also extracts that logic into a separate file so it's easier to reason about.

Test plan:
1. Assign yourself to `customPluginAndThemeLandingPages` group of `nudgeAPalooza` test
1. On a free site, go to /themes and /plugins, click on "Upload" button and confirm you were redirected to an upsell page
1. On a premium site, go to /themes and /plugins, click on "Upload" button and confirm you were redirected to an upsell page
1. On a business site with no AT, go to /themes and /plugins, click on "Upload" button and confirm you can see a upload form with a warning saying that you should setup a domain first
1. On a business site with an AT, go to /themes and /plugins, click on "Upload" button and confirm you can see a upload form with no warnings (sometimes I get redirected to /wp-admin/plugin-install.php which is a correct behavior as well)
