### PR TITLE
[nudge-a-palooza] Re-launch test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,7 +1,7 @@
 /** @format */
 export default {
 	nudgeAPalooza: {
-		datestamp: '20180726',
+		datestamp: '20180806',
 		variations: {
 			sidebarUpsells: 20,
 			themesNudgesUpdates: 20,

--- a/config/production.json
+++ b/config/production.json
@@ -133,7 +133,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"upsell/nudge-a-palooza": false,
+		"upsell/nudge-a-palooza": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -138,7 +138,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"upsell/nudge-a-palooza": false,
+		"upsell/nudge-a-palooza": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -154,7 +154,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"upsell/nudge-a-palooza": false,
+		"upsell/nudge-a-palooza": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,


### PR DESCRIPTION
We had to stop nudgeAPalooza test because of a bug (p9jf6J-OX-p2). The problem was fixed in another PR here: https://github.com/Automattic/wp-calypso/pull/26483 and the test is now ready to re-launch.

Test plan: Confirm that nudgeAPalooza test is active in wpcalypso.wordpress.com and that choosing "sidebarUpsells" group adds "Store" and "WordAds" items to the sidebar.