### PR TITLE
Guided Tours: improve API of the <Step wait=... /> function

### DIFF
--- a/client/layout/guided-tours/config-elements/step.js
+++ b/client/layout/guided-tours/config-elements/step.js
@@ -150,7 +150,7 @@ export default class Step extends Component {
 
 	wait( props, context ) {
 		if ( isFunction( props.wait ) ) {
-			const ret = props.wait( props, context );
+			const ret = props.wait( { reduxStore: context.store } );
 			if ( isFunction( get( ret, 'then' ) ) ) {
 				return ret;
 			}

--- a/client/layout/guided-tours/tours/checklist-publish-post-tour.js
+++ b/client/layout/guided-tours/tours/checklist-publish-post-tour.js
@@ -34,14 +34,13 @@ function isFeaturedImageSet() {
 	return !! query( '.editor-featured-image.is-assigned' ).length;
 }
 
-function openSidebar( props, context ) {
-	const store = context.store;
-	if ( store && getCurrentLayoutFocus( store.getState() ) !== 'sidebar' ) {
-		store.dispatch( setLayoutFocus( 'sidebar' ) );
+function openSidebar( { reduxStore } ) {
+	if ( getCurrentLayoutFocus( reduxStore.getState() ) !== 'sidebar' ) {
+		reduxStore.dispatch( setLayoutFocus( 'sidebar' ) );
 	}
 
 	return new Promise( function( resolve, reject ) {
-		getCurrentLayoutFocus( store.getState() ) === 'sidebar' ? delay( resolve, 200 ) : reject();
+		getCurrentLayoutFocus( reduxStore.getState() ) === 'sidebar' ? delay( resolve, 200 ) : reject();
 	} );
 }
 


### PR DESCRIPTION
In #22041, a new prop called `wait` was introduced to the `Step` component. It can perform some operation (like opening a UI dialog or sidebar) that needs to be waited for before the step can be displayed.

This patch improves its API. Right now, it takes parameters `props` and `context`, which are arbitrary bags of arbitrary properties that expose internals of the Guided Tours system.

What we really need currently is to pass the Redux store. That's why `wait` only gets this parameter and nothing else.

In future, we might remove even the `reduxStore` param and use the Redux Bridge instead. Migrating Guided Tours to the new React Context API might make it difficult to make `store` part of the tour context.