### PR TITLE
Importer Store:  Remove immutable, replace with regular JS objects

### DIFF
--- a/client/lib/importer/common.js
+++ b/client/lib/importer/common.js
@@ -5,7 +5,6 @@
  */
 
 import { find } from 'lodash';
-import { fromJS } from 'immutable';
 
 /**
  * Internal dependencies
@@ -73,8 +72,8 @@ export function fromApi( state ) {
 		importerId,
 		importerState: apiToAppState( importStatus ),
 		type: `importer-type-${ type }`,
-		progress: fromJS( progress ),
-		customData: fromJS( generateSourceAuthorIds( customData ) ),
+		progress,
+		customData: generateSourceAuthorIds( customData ),
 		site: { ID: siteId },
 	};
 }

--- a/client/lib/importer/store.js
+++ b/client/lib/importer/store.js
@@ -1,11 +1,8 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
-import Immutable from 'immutable';
-import { partial } from 'lodash';
+import { get, filter, includes, map, reject, set, setWith, unset } from 'lodash';
 
 /**
  * Internal dependencies
@@ -35,7 +32,7 @@ import { createReducerStore } from 'lib/store';
 /**
  * Module variables
  */
-const initialState = Immutable.fromJS( {
+const getInitialState = () => ( {
 	count: 0,
 	importers: {},
 	importerLocks: {},
@@ -46,20 +43,16 @@ const initialState = Immutable.fromJS( {
 	},
 } );
 
-const equals = ( a, b ) => a === b;
-const increment = a => a + 1;
-
-const removableStates = [ appStates.CANCEL_PENDING, appStates.DEFUNCT ];
-const shouldRemove = importer =>
-	removableStates.some( partial( equals, importer.get( 'importerState' ) ) );
-
+// Why is this here, could it not be part of the main switch?
 const adjustImporterLock = ( state, { action } ) => {
+	const newState = { ...state };
+
 	switch ( action.type ) {
 		case IMPORTS_IMPORT_LOCK:
-			return state.setIn( [ 'importerLocks', action.importerId ], true );
+			set( newState, [ 'importerLocks', action.importerId ], true );
 
 		case IMPORTS_IMPORT_UNLOCK:
-			return state.setIn( [ 'importerLocks', action.importerId ], false );
+			set( newState, [ 'importerLocks', action.importerId ], false );
 
 		default:
 			return state;
@@ -67,147 +60,146 @@ const adjustImporterLock = ( state, { action } ) => {
 };
 
 const ImporterStore = createReducerStore( function( state, payload ) {
-	let { action } = payload,
-		newState;
+	const { action } = payload;
+	let newState = { ...state };
 
 	switch ( action.type ) {
 		case IMPORTS_STORE_RESET:
 			// this is here to enable
 			// unit-testing the store
-			newState = initialState;
+			newState = getInitialState();
 			break;
 
 		case IMPORTS_FETCH:
-			newState = state.setIn( [ 'api', 'isFetching' ], true );
+			set( newState, 'api.isFetching', true );
 			break;
 
 		case IMPORTS_FETCH_FAILED:
-			newState = state
-				.setIn( [ 'api', 'isFetching' ], false )
-				.updateIn( [ 'api', 'retryCount' ], increment );
+			set( newState, 'api.isFetching', false );
+			setWith( newState, 'api.retryCount', ( retryCount = 0 ) => retryCount + 1 );
 			break;
 
 		case IMPORTS_FETCH_COMPLETED:
-			newState = state
-				.setIn( [ 'api', 'isFetching' ], false )
-				.setIn( [ 'api', 'isHydrated' ], true )
-				.setIn( [ 'api', 'retryCount' ], 0 );
+			set( newState, 'api.isFetching', false );
+			set( newState, 'api.isHydrated', true );
+			set( newState, 'api.retryCount', 0 );
+
 			break;
 
 		case IMPORTS_IMPORT_CANCEL:
 		case IMPORTS_IMPORT_RESET:
-			// Remove the specified importer from the list of current importers
-			newState = state.update( 'importers', importers => {
-				return importers.filterNot(
-					importer => importer.get( 'importerId' ) === action.importerId
-				);
-			} );
-			break;
-
-		case IMPORTS_UPLOAD_FAILED:
-			newState = state
-				.setIn( [ 'importers', action.importerId, 'importerState' ], appStates.UPLOAD_FAILURE )
-				.setIn( [ 'importers', action.importerId, 'errorData' ], {
-					type: 'uploadError',
-					description: action.error,
-				} );
-			break;
-
-		case IMPORTS_UPLOAD_COMPLETED:
-			newState = state
-				.deleteIn( [ 'importers' ], action.importerId )
-				.setIn(
-					[ 'importers', action.importerStatus.importerId ],
-					Immutable.fromJS( action.importerStatus )
-				);
-			break;
-
-		case IMPORTS_AUTHORS_START_MAPPING:
-			newState = state.setIn(
-				[ 'importers', action.importerId, 'importerState' ],
-				appStates.MAP_AUTHORS
+			setWith( newState, 'importers', importers =>
+				reject( importers, { importerId: action.importerId } )
 			);
 			break;
 
-		case IMPORTS_AUTHORS_SET_MAPPING:
-			newState = state.updateIn(
-				[ 'importers', action.importerId, 'customData', 'sourceAuthors' ],
-				authors =>
-					authors.map( author => {
-						if ( action.sourceAuthor.id !== author.get( 'id' ) ) {
-							return author;
-						}
+		case IMPORTS_UPLOAD_FAILED:
+			set(
+				newState,
+				[ 'importers', action.importerId, 'importerState' ],
+				appStates.UPLOAD_FAILURE
+			);
+			set( newState, [ 'importers', action.importerId, 'errorData' ], {
+				type: 'uploadError',
+				description: action.error,
+			} );
 
-						return author.set( 'mappedTo', action.targetAuthor );
-					} )
+			break;
+
+		case IMPORTS_UPLOAD_COMPLETED:
+			unset( newState, [ 'importers', action.importerId ] );
+			set( newState, [ 'importers', action.importerStatus.importerId ], action.importerStatus );
+			break;
+
+		case IMPORTS_AUTHORS_START_MAPPING:
+			set( newState, [ 'importers', action.importerId, 'importerState' ], appStates.MAP_AUTHORS );
+			break;
+
+		case IMPORTS_AUTHORS_SET_MAPPING:
+			const { importerId, sourceAuthor, targetAuthor } = action;
+			setWith(
+				newState,
+				[ 'importers', importerId, 'customData', 'sourceAuthors' ],
+				sourceAuthors =>
+					map(
+						sourceAuthors,
+						author =>
+							sourceAuthor.id === author.id
+								? {
+										...author,
+										mappedTo: targetAuthor,
+								  }
+								: author
+					)
 			);
 			break;
 
 		case IMPORTS_IMPORT_RECEIVE:
-			newState = state.setIn( [ 'api', 'isHydrated' ], true );
+			set( newState, 'api.isHydrated', true );
 
-			if ( newState.getIn( [ 'importerLocks', action.importerStatus.importerId ], false ) ) {
+			if ( get( newState, [ 'importerLocks', action.importerStatus.importerId ], false ) ) {
 				break;
 			}
 
+			// remove by id if the incoming instance is defunt
+			// as mentioned later, this would be taken care of by the filtering function anyway
 			if ( action.importerStatus.importerState === appStates.DEFUNCT ) {
-				newState = newState.deleteIn( [ 'importers', action.importerStatus.importerId ] );
-				break;
+				unset( newState, [ 'importers', action.importerStatus.importerId ] );
 			}
 
-			newState = newState
-				.setIn(
-					[ 'importers', action.importerStatus.importerId ],
-					Immutable.fromJS( action.importerStatus )
+			set( newState, [ 'importers', action.importerStatus.importerId ], action.importerStatus );
+
+			// We filter through all importer instances and remove any that are defunt or cancelled
+			// Do we really need the above 'delete if defunt' action then? Whats it's value?
+			setWith( newState, 'importers', importers =>
+				filter(
+					{
+						...importers,
+						[ action.importerStatus.importerId ]: action.importerStatus,
+					},
+					importer =>
+						includes( [ appStates.CANCEL_PENDING, appStates.DEFUNCT ], importer.importerState )
 				)
-				.update( 'importers', importers => importers.filterNot( shouldRemove ) );
+			);
+
 			break;
 
 		case IMPORTS_UPLOAD_SET_PROGRESS:
-			newState = state.setIn(
+			set(
+				newState,
 				[ 'importers', action.importerId, 'percentComplete' ],
 				( action.uploadLoaded / ( action.uploadTotal + Number.EPSILON ) ) * 100
 			);
 			break;
 
 		case IMPORTS_IMPORT_START:
-			const newImporter = Immutable.fromJS( {
+			const newImporter = {
 				importerId: action.importerId,
 				type: action.importerType,
 				importerState: appStates.READY_FOR_UPLOAD,
 				site: { ID: action.siteId },
-			} );
-
-			newState = state
-				.update( 'count', count => count + 1 )
-				.setIn( [ 'importers', action.importerId ], newImporter );
+			};
+			setWith( newState, 'count', ( count = 0 ) => count + 1 );
+			set( newState, [ 'importers', action.importerId ], newImporter );
 			break;
 
 		case IMPORTS_START_IMPORTING:
-			newState = state.setIn(
-				[ 'importers', action.importerId, 'importerState' ],
-				appStates.IMPORTING
-			);
+			set( newState, [ 'importers', action.importerId, 'importerState' ], appStates.IMPORTING );
 			break;
 
 		case IMPORTS_UPLOAD_START:
-			newState = state
-				.setIn( [ 'importers', action.importerId, 'importerState' ], appStates.UPLOADING )
-				.setIn( [ 'importers', action.importerId, 'filename' ], action.filename );
-			break;
-
-		default:
-			newState = state;
+			set( newState, [ 'importers', action.importerId, 'importerState' ], appStates.UPLOADING );
+			set( newState, [ 'importers', action.importerId, 'filename' ], action.filename );
 			break;
 	}
 
 	newState = adjustImporterLock( newState, payload );
 
 	return newState;
-}, initialState );
+}, getInitialState() );
 
 export function getState() {
-	return ImporterStore.get().toJS();
+	return ImporterStore.get();
 }
 
 export default ImporterStore;

--- a/client/lib/importer/test/api-interaction.js
+++ b/client/lib/importer/test/api-interaction.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { partial } from 'lodash';
+import { get, partial } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,7 +16,7 @@ import { nock, useNock } from 'test/helpers/use-nock';
 
 const testSiteId = 'en.blog.wordpress.com';
 const fetchTestState = partial( fetchState, testSiteId );
-const hydratedState = () => store.get().getIn( [ 'api', 'isHydrated' ] );
+const hydratedState = () => get( store.get(), [ 'api', 'isHydrated' ] );
 const resetStore = () => Dispatcher.handleViewAction( { type: IMPORTS_STORE_RESET } );
 
 const queuePayload = payload =>


### PR DESCRIPTION
This PR seeks to remove the use of ImmutableJS data structures inn the Importer Store.
This a step towards transferring the handling of this stores state to redux.

You'll notice I've made 2 very different commits with different approaches...
I'd started off by using Lodash's `set`, `setWith` and `unset` in the hope that I could keep logic near-enough inline with the existing Immutable calls. Unfortunately, those methods mutate the object that they work on.
Naively I though 'That's ok, we're doing `newState = { ...state }`, but the objects that are properties of `state` are still carried through and are mutated.

I've left that commit in to 'show my working out' but I'll squish the two when it comes time to merge :)

### Testing:
I'm not sure how to fully test every case.
Instead, I'd say just play around with importing - try as many scenarios as you can think of. Do they still work as expected and without error?

You can debug nicely by adding this snippet to the reducer body:

```js
	includes( [
		IMPORTS_AUTHORS_SET_MAPPING,
		IMPORTS_AUTHORS_START_MAPPING,
		IMPORTS_FETCH,
		IMPORTS_FETCH_FAILED,
		IMPORTS_FETCH_COMPLETED,
		IMPORTS_IMPORT_CANCEL,
		IMPORTS_IMPORT_LOCK,
		IMPORTS_IMPORT_RECEIVE,
		IMPORTS_IMPORT_RESET,
		IMPORTS_IMPORT_START,
		IMPORTS_IMPORT_UNLOCK,
		IMPORTS_START_IMPORTING,
		IMPORTS_STORE_RESET,
		IMPORTS_UPLOAD_FAILED,
		IMPORTS_UPLOAD_COMPLETED,
		IMPORTS_UPLOAD_SET_PROGRESS,
		IMPORTS_UPLOAD_START,
	], action.type ) && (
		console.log( action )
	);
```