### PR TITLE
Add default initialQuery to MapDomainStep.

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -45,6 +45,7 @@ class MapDomainStep extends React.Component {
 
 	static defaultProps = {
 		onSave: noop,
+		initialQuery: '',
 	};
 
 	state = this.getDefaultState();


### PR DESCRIPTION
Fix for https://github.com/Automattic/wp-calypso/issues/26482

Testing:

1. on a paid plan, select Domains → Add (or go straight to https://wordpress.com/domains/add/ )
2. add any existing domain name
3. select "Yes, I own this domain"
4. select "Buy Domain Mapping"
5. select blue "Add" button
6. from the order summary on the left, remove the domain mapping by selecting the garbage can
7. Make sure that you are taken back to the mapping screen and that it shows up correctly.