### PR TITLE
Guided Tours: in simplePaymentsEmailTour, reposition the bubble smoothly on sidebar scroll

### DIFF
--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -86,6 +86,8 @@ export const SimplePaymentsEmailTour = makeTour(
 			onTargetDisappear={ handleTargetDisappear }
 			when={ sectionHasSidebar }
 			keepRepositioning
+			scrollContainer=".sidebar__region"
+			shouldScrollTo
 		>
 			{ ( { translate } ) => (
 				<Fragment>


### PR DESCRIPTION
There is a repositioning interval of 3 seconds, but that's useful for sidebar layout changes:
items loading asynchronously and appearing after the bubble is already in place. Or items being
different after site switch.

Reposition on scrolling can be achieved with the `Step`'s `shouldScrollTo` and `scrollContainer`
props. That guarantees smooth repositioning instead of large jumps every 3 seconds.

**How to test:**
Run the tour by appending `?tour=simplePaymentsEmailTour` as query string. The following bubble appears:
<img width="714" alt="screen shot 2018-08-03 at 15 34 18" src="https://user-images.githubusercontent.com/664258/43646672-cace328c-9735-11e8-8f93-44fe62bd7da7.png">

Scroll the sidebar up and down and check that the bubble repositions smoothly, in real time.