### PR TITLE
Update the Account Closure page to include more detail on linked accounts

### DIFF
--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -161,6 +161,11 @@ class AccountSettingsClose extends Component {
 								</p>
 								<p className="account-close__body-copy">
 									{ translate(
+										'You will not be able to log in to any other Automattic Services that use your WordPress.com account as a login. This includes WooCommerce.com, Polldaddy.com, IntenseDebate.com and Gravatar.com. Once your WordPress.com account is closed, these services will also be closed and you will lose access to any orders or support history you may have.'
+									) }
+								</p>
+								<p className="account-close__body-copy">
+									{ translate(
 										'If you have any questions at all about what happens when you close an account, ' +
 											'please {{a}}chat with someone from our support team{{/a}} first. ' +
 											"They'll explain the ramifications and help you explore alternatives. ",


### PR DESCRIPTION
When users close their WordPress.com Accounts they will also loose access to connected accounts, lets make this clearer.

Example:

<img width="773" alt="screen shot 2018-08-03 at 09 56 21" src="https://user-images.githubusercontent.com/551898/43653006-0f935262-9704-11e8-956d-47fb9fa1bff9.png">
