### PR TITLE
Build: Rework the babel async transform to use import

### DIFF
--- a/server/bundler/babel/babel-plugin-transform-wpcalypso-async/index.js
+++ b/server/bundler/babel/babel-plugin-transform-wpcalypso-async/index.js
@@ -112,7 +112,7 @@ module.exports = ( { types: t } ) => {
 					const argumentWithMagicComments = t.addComment(
 						argument,
 						'leading',
-						`webpackChunkName: "${ chunkName }", webpackPrefetch: true`,
+						`webpackChunkName: "${ chunkName }"`,
 						false
 					);
 					const importCall = t.callExpression( t.identifier( 'import' ), [

--- a/server/bundler/babel/babel-plugin-transform-wpcalypso-async/index.js
+++ b/server/bundler/babel/babel-plugin-transform-wpcalypso-async/index.js
@@ -105,10 +105,10 @@ module.exports = ( { types: t } ) => {
 				}
 
 				if ( isAsync ) {
-					// Generate a chunk name based on the require path
+					// Generate a chunk name based on the module path
 					const chunkName = 'async-load-' + kebabCase( argument.value );
 
-					// Transform to asynchronous require.ensure
+					// Transform to dynamic import
 					const argumentWithMagicComments = t.addComment(
 						argument,
 						'leading',

--- a/server/bundler/babel/babel-plugin-transform-wpcalypso-async/index.js
+++ b/server/bundler/babel/babel-plugin-transform-wpcalypso-async/index.js
@@ -85,24 +85,10 @@ module.exports = ( { types: t } ) => {
 				// In both asynchronous and synchronous case, we'll finish by
 				// calling require on the loaded module. If the module is an
 				// ES2015 module, use its default export.
-				let requireCall = t.conditionalExpression(
-					t.memberExpression(
-						t.callExpression( t.identifier( 'require' ), [ argument ] ),
-						t.identifier( '__esModule' )
-					),
-					t.memberExpression(
-						t.callExpression( t.identifier( 'require' ), [ argument ] ),
-						t.identifier( 'default' )
-					),
-					t.callExpression( t.identifier( 'require' ), [ argument ] )
-				);
 
 				// If a callback was passed as an argument, wrap it as part of
 				// the transformation
 				const callback = path.node.arguments[ 1 ];
-				if ( callback ) {
-					requireCall = t.callExpression( callback, [ requireCall ] );
-				}
 
 				if ( isAsync ) {
 					// Generate a chunk name based on the module path
@@ -130,11 +116,7 @@ module.exports = ( { types: t } ) => {
 									t.blockStatement( [
 										t.expressionStatement(
 											t.callExpression( callback, [
-												t.conditionalExpression(
-													t.memberExpression( t.identifier( 'mod' ), t.identifier( '__esModule' ) ),
-													t.memberExpression( t.identifier( 'mod' ), t.identifier( 'default' ) ),
-													t.identifier( 'mod' )
-												),
+												t.memberExpression( t.identifier( 'mod' ), t.identifier( 'default' ) ),
 											] )
 										),
 									] )
@@ -148,6 +130,20 @@ module.exports = ( { types: t } ) => {
 					path.replaceWith( statement );
 				} else {
 					// Transform to synchronous require
+					let requireCall = t.conditionalExpression(
+						t.memberExpression(
+							t.callExpression( t.identifier( 'require' ), [ argument ] ),
+							t.identifier( '__esModule' )
+						),
+						t.memberExpression(
+							t.callExpression( t.identifier( 'require' ), [ argument ] ),
+							t.identifier( 'default' )
+						),
+						t.callExpression( t.identifier( 'require' ), [ argument ] )
+					);
+					if ( callback ) {
+						requireCall = t.callExpression( callback, [ requireCall ] );
+					}
 					path.replaceWith( requireCall );
 				}
 			},

--- a/server/bundler/babel/babel-plugin-transform-wpcalypso-async/test/index.js
+++ b/server/bundler/babel/babel-plugin-transform-wpcalypso-async/test/index.js
@@ -36,9 +36,9 @@ describe( 'babel-plugin-transform-wpcalypso-async', () => {
 				const code = transform( 'export default () => <AsyncLoad require="foo" />;' );
 
 				expect( code ).toBe(
-					'var _ref = function (callback) {\n  require.ensure("foo", function (require) {\n    ' +
-						'callback(require("foo").__esModule ? require("foo").default : require("foo"));\n  ' +
-						'}, "async-load-foo");\n};\n\nexport default (() => <AsyncLoad require={_ref} />);'
+					'var _ref = function (callback) {\n  import(\n  /*webpackChunkName: "async-load-foo", webpackPrefetch: true*/\n  "foo").then(function load(mod) {\n' +
+						'    callback(mod.__esModule ? mod.default : mod);\n' +
+						'  });\n};\n\nexport default (() => <AsyncLoad require={_ref} />);'
 				);
 			} );
 		} );
@@ -69,12 +69,11 @@ describe( 'babel-plugin-transform-wpcalypso-async', () => {
 		} );
 
 		describe( 'async', () => {
-			test( 'should call require directly after ensure when no callback', () => {
+			test( 'should just issue the import if no callback is specified', () => {
 				const code = transform( 'asyncRequire( "foo/bar" );' );
 
 				expect( code ).toBe(
-					'require.ensure("foo/bar", function (require) {\n  require("foo/bar").__esModule ? ' +
-						'require("foo/bar").default : require("foo/bar");\n}, "async-load-foo-bar");'
+					'import(\n/*webpackChunkName: "async-load-foo-bar", webpackPrefetch: true*/\n"foo/bar");'
 				);
 			} );
 
@@ -82,8 +81,8 @@ describe( 'babel-plugin-transform-wpcalypso-async', () => {
 				const code = transform( 'asyncRequire( "foo/bar", cb );' );
 
 				expect( code ).toBe(
-					'require.ensure("foo/bar", function (require) {\n  cb(require("foo/bar").__esModule ? ' +
-						'require("foo/bar").default : require("foo/bar"));\n}, "async-load-foo-bar");'
+					'import(\n/*webpackChunkName: "async-load-foo-bar", webpackPrefetch: true*/\n"foo/bar").then(function load(mod) {\n  cb(mod.__esModule ? ' +
+						'mod.default : mod);\n});'
 				);
 			} );
 		} );

--- a/server/bundler/babel/babel-plugin-transform-wpcalypso-async/test/index.js
+++ b/server/bundler/babel/babel-plugin-transform-wpcalypso-async/test/index.js
@@ -36,7 +36,7 @@ describe( 'babel-plugin-transform-wpcalypso-async', () => {
 				const code = transform( 'export default () => <AsyncLoad require="foo" />;' );
 
 				expect( code ).toBe(
-					'var _ref = function (callback) {\n  import(\n  /*webpackChunkName: "async-load-foo", webpackPrefetch: true*/\n  "foo").then(function load(mod) {\n' +
+					'var _ref = function (callback) {\n  import(\n  /*webpackChunkName: "async-load-foo"*/\n  "foo").then(function load(mod) {\n' +
 						'    callback(mod.__esModule ? mod.default : mod);\n' +
 						'  });\n};\n\nexport default (() => <AsyncLoad require={_ref} />);'
 				);
@@ -72,16 +72,14 @@ describe( 'babel-plugin-transform-wpcalypso-async', () => {
 			test( 'should just issue the import if no callback is specified', () => {
 				const code = transform( 'asyncRequire( "foo/bar" );' );
 
-				expect( code ).toBe(
-					'import(\n/*webpackChunkName: "async-load-foo-bar", webpackPrefetch: true*/\n"foo/bar");'
-				);
+				expect( code ).toBe( 'import(\n/*webpackChunkName: "async-load-foo-bar"*/\n"foo/bar");' );
 			} );
 
 			test( 'should invoke callback with require after ensure', () => {
 				const code = transform( 'asyncRequire( "foo/bar", cb );' );
 
 				expect( code ).toBe(
-					'import(\n/*webpackChunkName: "async-load-foo-bar", webpackPrefetch: true*/\n"foo/bar").then(function load(mod) {\n  cb(mod.__esModule ? ' +
+					'import(\n/*webpackChunkName: "async-load-foo-bar"*/\n"foo/bar").then(function load(mod) {\n  cb(mod.__esModule ? ' +
 						'mod.default : mod);\n});'
 				);
 			} );

--- a/server/bundler/babel/babel-plugin-transform-wpcalypso-async/test/index.js
+++ b/server/bundler/babel/babel-plugin-transform-wpcalypso-async/test/index.js
@@ -37,7 +37,7 @@ describe( 'babel-plugin-transform-wpcalypso-async', () => {
 
 				expect( code ).toBe(
 					'var _ref = function (callback) {\n  import(\n  /*webpackChunkName: "async-load-foo"*/\n  "foo").then(function load(mod) {\n' +
-						'    callback(mod.__esModule ? mod.default : mod);\n' +
+						'    callback(mod.default);\n' +
 						'  });\n};\n\nexport default (() => <AsyncLoad require={_ref} />);'
 				);
 			} );
@@ -79,8 +79,7 @@ describe( 'babel-plugin-transform-wpcalypso-async', () => {
 				const code = transform( 'asyncRequire( "foo/bar", cb );' );
 
 				expect( code ).toBe(
-					'import(\n/*webpackChunkName: "async-load-foo-bar"*/\n"foo/bar").then(function load(mod) {\n  cb(mod.__esModule ? ' +
-						'mod.default : mod);\n});'
+					'import(\n/*webpackChunkName: "async-load-foo-bar"*/\n"foo/bar").then(function load(mod) {\n  cb(mod.default);\n});'
 				);
 			} );
 		} );


### PR DESCRIPTION
This reworks our custom babel plugin to transform asyncRequire to use dynamic `import` statements rather than `require.ensure` statements. This allows us to take advantage of the new capabilities of [webpack's magic comments](https://webpack.js.org/api/module-methods/#import-) and prefetch or preload async assets.

## Testing Instructions
Calypso should boot and load dynamic bundles as before
Try a build with code splitting disabled. Does it still work as expected?