### PR TITLE
Imports: Rename tracks events for clarity

### DIFF
--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -51,31 +51,32 @@ class ImporterHeader extends React.PureComponent {
 
 	controlButtonClicked = () => {
 		const {
-			importerStatus: { importerId, importerState, type },
-			site: { ID: siteId },
-			startImport,
-		} = this.props;
+				importerStatus: { importerId, importerState, type },
+				site: { ID: siteId },
+				startImport,
+			} = this.props,
+			tracksType = type.endsWith( 'site-importer' ) ? type + '-wix' : type;
 
 		if ( includes( [ ...cancelStates, ...stopStates ], importerState ) ) {
 			cancelImport( siteId, importerId );
 
-			this.props.recordTracksEvent( 'calypso_importer_main_cancel_import', {
+			this.props.recordTracksEvent( 'calypso_importer_main_cancel_clicked', {
 				blog_id: siteId,
-				importer_id: type,
+				importer_id: tracksType,
 			} );
 		} else if ( includes( startStates, importerState ) ) {
 			startImport( siteId, type );
 
-			this.props.recordTracksEvent( 'calypso_importer_main_start_import', {
+			this.props.recordTracksEvent( 'calypso_importer_main_start_clicked', {
 				blog_id: siteId,
-				importer_id: type,
+				importer_id: tracksType,
 			} );
 		} else if ( includes( doneStates, importerState ) ) {
 			resetImport( siteId, importerId );
 
-			this.props.recordTracksEvent( 'calypso_importer_main_done_import', {
+			this.props.recordTracksEvent( 'calypso_importer_main_done_clicked', {
 				blog_id: siteId,
-				importer_id: type,
+				importer_id: tracksType,
 			} );
 		}
 	};

--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -53,7 +53,7 @@ class ImporterHeader extends React.PureComponent {
 		const {
 				importerStatus: { importerId, importerState, type },
 				site: { ID: siteId },
-				startImport,
+				startImportFn,
 			} = this.props,
 			tracksType = type.endsWith( 'site-importer' ) ? type + '-wix' : type;
 
@@ -65,7 +65,7 @@ class ImporterHeader extends React.PureComponent {
 				importer_id: tracksType,
 			} );
 		} else if ( includes( startStates, importerState ) ) {
-			startImport( siteId, type );
+			startImportFn( siteId, type );
 
 			this.props.recordTracksEvent( 'calypso_importer_main_start_clicked', {
 				blog_id: siteId,
@@ -152,7 +152,7 @@ class ImporterHeader extends React.PureComponent {
 }
 
 const mapDispatchToProps = dispatch => ( {
-	startImport: flowRight(
+	startImportFn: flowRight(
 		dispatch,
 		startImport
 	),

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -165,7 +165,7 @@ class SiteImporterInputPane extends React.Component {
 			...NO_ERROR_STATE,
 		} );
 
-		this.props.recordTracksEvent( 'calypso_site_importer_validate_site', {
+		this.props.recordTracksEvent( 'calypso_site_importer_validate_site_start', {
 			blog_id: this.props.site.ID,
 			site_url: urlForImport,
 		} );
@@ -197,7 +197,7 @@ class SiteImporterInputPane extends React.Component {
 					importSiteURL: resp.site_url,
 				} );
 
-				this.props.recordTracksEvent( 'calypso_site_importer_validate_site_done', {
+				this.props.recordTracksEvent( 'calypso_site_importer_validate_site_success', {
 					blog_id: this.props.site.ID,
 					site_url: resp.site_url,
 					supported_content: resp.supported_content
@@ -231,7 +231,7 @@ class SiteImporterInputPane extends React.Component {
 			...NO_ERROR_STATE,
 		} );
 
-		this.props.recordTracksEvent( 'calypso_site_importer_start_import', {
+		this.props.recordTracksEvent( 'calypso_site_importer_start_import_request', {
 			blog_id: this.props.site.ID,
 			site_url: this.state.importSiteURL,
 			supported_content: this.state.importData.supported
@@ -257,7 +257,7 @@ class SiteImporterInputPane extends React.Component {
 			.then( resp => {
 				this.setState( { loading: false } );
 
-				this.props.recordTracksEvent( 'calypso_site_importer_start_import_done', {
+				this.props.recordTracksEvent( 'calypso_site_importer_start_import_success', {
 					blog_id: this.props.site.ID,
 					site_url: this.state.importSiteURL,
 					supported_content: this.state.importData.supported

--- a/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
@@ -57,7 +57,7 @@ class SiteImporterSitePreview extends React.Component {
 					sitePreviewFailed: false,
 				} );
 
-				this.props.recordTracksEvent( 'calypso_site_importer_site_preview_done', {
+				this.props.recordTracksEvent( 'calypso_site_importer_site_preview_success', {
 					blog_id: this.props.site.ID,
 					site_url: this.state.siteURL,
 					time_taken_ms: Date.now() - this.state.previewStartTime,
@@ -70,7 +70,7 @@ class SiteImporterSitePreview extends React.Component {
 					sitePreviewFailed: true,
 				} );
 
-				this.props.recordTracksEvent( 'calypso_site_importer_site_preview_failed', {
+				this.props.recordTracksEvent( 'calypso_site_importer_site_preview_fail', {
 					blog_id: this.props.site.ID,
 					site_url: this.state.siteURL,
 					time_taken_ms: Date.now() - this.state.previewStartTime,


### PR DESCRIPTION
As discussed in p8F0Ux-1bF-p2 some of the tracks events recorded on the
import section could be ambiguous. This change attempts to remove that
ambiguity.

It can be tested by running an import and inspecting filtering the image
requests by `t.gif`. The associated event names and proporties can be
seen with these requests.