### PR TITLE
Use memoization to avoid re-renders in ReaderCombinedCardComponent.

### DIFF
--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -26,7 +26,7 @@ import { getPostsByKeys } from 'state/reader/posts/selectors';
 import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
 import PostBlocked from 'blocks/reader-post-card/blocked';
 
-class ReaderCombinedCardComponent extends React.PureComponent {
+class ReaderCombinedCardComponent extends React.Component {
 	static propTypes = {
 		posts: PropTypes.array.isRequired,
 		site: PropTypes.object,

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -56,12 +56,12 @@ class ReaderCombinedCardComponent extends React.Component {
 			this.props.postKey.blogId !== prevProps.postKey.blogId ||
 			size( this.props.posts ) !== size( prevProps.posts )
 		) {
-			this.recordRenderTrack( this.props );
+			this.recordRenderTrack();
 		}
 	}
 
-	recordRenderTrack = ( props = this.props ) => {
-		const { postKey, posts } = props;
+	recordRenderTrack = () => {
+		const { postKey, posts } = this.props;
 
 		recordTrack( 'calypso_reader_combined_card_render', {
 			blog_id: postKey.blogId,


### PR DESCRIPTION
Considerable time is being spent re-rendering instances of this component both when loading a page that uses them, as well as when navigating away from one.

This PR uses memoization in order to ensure that the existing post keys are kept, rather than re-generated every time. This means that we avoid unnecessary re-renders for this component and everything below it in the render tree.

This PR, when tested in a new account, improves responsiveness when navigating from "followed sites" to "search" by around 300ms (before: 857, after: 538) on my machine.