### PR TITLE
Try/jetpack onboarding custom data type

### DIFF
--- a/client/components/wizard/progress-indicator.jsx
+++ b/client/components/wizard/progress-indicator.jsx
@@ -9,7 +9,10 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 const ProgressIndicator = ( { stepNumber, totalSteps, translate } ) => (
-	<div className="wizard__progress-indicator">
+	<div
+		className="wizard__progress-indicator"
+		data-e2e-type={ 'step-indicator-' + ( stepNumber + 1 ) }
+	>
 		{ translate( 'Step %(stepNumber)d of %(stepTotal)d', {
 			args: {
 				stepNumber: stepNumber + 1,

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -208,7 +208,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		const { getForwardUrl, hasBusinessAddress, siteId, translate } = this.props;
 
 		return (
-			<div className="steps__main">
+			<div className="steps__main" data-e2e-type="business-address">
 				<QuerySites siteId={ siteId } />
 
 				<JetpackLogo full size={ 45 } />

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -95,7 +95,7 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 		const { getForwardUrl, hasContactForm, siteId, translate } = this.props;
 
 		return (
-			<div className="steps__main">
+			<div className="steps__main" data-e2e-type="contact-form">
 				<QuerySites siteId={ siteId } />
 
 				<JetpackLogo full size={ 45 } />

--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -33,7 +33,7 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 		const homepageFormat = get( settings, 'homepageFormat' );
 
 		return (
-			<div className="steps__main">
+			<div className="steps__main" data-e2e-type="homepage">
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<TileGrid>

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -64,7 +64,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 		const headerText = translate( 'Welcome to WordPress!' );
 
 		return (
-			<div className="steps__main">
+			<div className="steps__main" data-e2e-type="site-title">
 				<FormattedHeader headerText={ headerText } />
 
 				<Card className="steps__form">

--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -32,7 +32,7 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 		const siteType = get( settings, 'siteType' );
 
 		return (
-			<div className="steps__main">
+			<div className="steps__main" data-e2e-type="site-type">
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<TileGrid>

--- a/client/jetpack-onboarding/steps/stats.jsx
+++ b/client/jetpack-onboarding/steps/stats.jsx
@@ -107,7 +107,7 @@ class JetpackOnboardingStatsStep extends React.Component {
 		const { activatedStats, getForwardUrl, siteId } = this.props;
 
 		return (
-			<div className="steps__main" data-e2e-type="activate-stats">
+			<div className="steps__main" data-e2e-type="stats">
 				<QuerySites siteId={ siteId } />
 
 				<JetpackLogo full size={ 45 } />

--- a/client/jetpack-onboarding/steps/stats.jsx
+++ b/client/jetpack-onboarding/steps/stats.jsx
@@ -107,7 +107,7 @@ class JetpackOnboardingStatsStep extends React.Component {
 		const { activatedStats, getForwardUrl, siteId } = this.props;
 
 		return (
-			<div className="steps__main">
+			<div className="steps__main" data-e2e-type="activate-stats">
 				<QuerySites siteId={ siteId } />
 
 				<JetpackLogo full size={ 45 } />

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -36,7 +36,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 		);
 
 		return (
-			<div className="steps__main">
+			<div className="steps__main" data-e2e-type="summary">
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<Card>

--- a/client/jetpack-onboarding/steps/woocommerce.jsx
+++ b/client/jetpack-onboarding/steps/woocommerce.jsx
@@ -41,7 +41,7 @@ class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 		const isCompleted = get( stepsCompleted, STEPS.WOOCOMMERCE ) === true;
 
 		return (
-			<div className="steps__main">
+			<div className="steps__main" data-e2e-type="woocommerce">
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<div className="steps__button-group">


### PR DESCRIPTION
Included custom data type as unique locators to reduce the use of sleeps in automated tests. Related to https://github.com/Automattic/wp-e2e-tests/issues/1196