### PR TITLE
[nudge-a-palooza] Move redirection logic from controller to higher-order components

### DIFF
--- a/client/my-sites/checkout/cart/cart-plan-ad-theme.jsx
+++ b/client/my-sites/checkout/cart/cart-plan-ad-theme.jsx
@@ -21,6 +21,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { addItem } from 'lib/upgrades/actions';
 import { PLAN_PREMIUM, FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
 import { hasFeature } from 'state/sites/plans/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -37,11 +38,12 @@ class CartPlanAdTheme extends Component {
 	};
 
 	shouldDisplayAd = () => {
-		const { cart, hasUnlimitedPremiumThemes, selectedSite } = this.props;
+		const { cart, hasUnlimitedPremiumThemes, selectedSite, isJetpack } = this.props;
 		const items = cartItems.getAll( cart );
 		const hasOnlyAPremiumTheme = items.length === 1 && items[ 0 ].product_slug === 'premium_theme';
 
 		return (
+			! isJetpack &&
 			config.isEnabled( 'upsell/nudge-a-palooza' ) &&
 			! hasUnlimitedPremiumThemes &&
 			cart.hasLoadedFromServer &&
@@ -90,6 +92,7 @@ const mapStateToProps = state => {
 	const selectedSiteId = getSelectedSiteId( state );
 
 	return {
+		isJetpack: isJetpackSite( state, selectedSiteId ),
 		hasUnlimitedPremiumThemes: hasFeature(
 			state,
 			selectedSiteId,

--- a/client/my-sites/feature-upsell/ads-upsell.jsx
+++ b/client/my-sites/feature-upsell/ads-upsell.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { compose } from 'redux';
+import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -299,7 +299,7 @@ const mapDispatchToProps = dispatch => ( {
 	trackTracksEvent: ( name, props ) => dispatch( recordTracksEvent( name, props ) ),
 } );
 
-export default compose(
+export default flowRight(
 	connect(
 		mapStateToProps,
 		mapDispatchToProps

--- a/client/my-sites/feature-upsell/ads-upsell.jsx
+++ b/client/my-sites/feature-upsell/ads-upsell.jsx
@@ -36,7 +36,7 @@ import { isRequestingPlans } from 'state/plans/selectors';
 import { getCurrencyObject } from 'lib/format-currency';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { isRequestingActivePromotions } from 'state/active-promotions/selectors';
-import { getUpsellPlanPrice, canUpgradeSiteOrRedirect } from './utils';
+import { getUpsellPlanPrice, redirectUnlessCanUpgradeSite } from './utils';
 import redirectIf from './redirect-if';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -305,7 +305,7 @@ export default compose(
 		mapDispatchToProps
 	),
 	localize,
-	canUpgradeSiteOrRedirect,
+	redirectUnlessCanUpgradeSite,
 	redirectIf( state => canCurrentUserUseAds( state ), '/ads/earnings' ),
 	redirectIf( state => canAdsBeEnabledOnCurrentSite( state ), '/ads/settings' )
 )( WordAdsUpsellComponent );

--- a/client/my-sites/feature-upsell/ads-upsell.jsx
+++ b/client/my-sites/feature-upsell/ads-upsell.jsx
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { compose } from 'redux';
 
 /**
  * Internal dependencies
@@ -20,7 +21,11 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { getPlanPath, isFreePlan } from 'lib/plans';
 import { PLAN_PREMIUM } from 'lib/plans/constants';
 import page from 'page';
-import { getSiteSlug } from 'state/sites/selectors';
+import {
+	getSiteSlug,
+	canAdsBeEnabledOnCurrentSite,
+	canCurrentUserUseAds,
+} from 'state/sites/selectors';
 import { getCurrentPlan, isRequestingSitePlans } from 'state/sites/plans/selectors';
 import DocumentHead from 'components/data/document-head';
 import QueryPlans from 'components/data/query-plans';
@@ -31,7 +36,8 @@ import { isRequestingPlans } from 'state/plans/selectors';
 import { getCurrencyObject } from 'lib/format-currency';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { isRequestingActivePromotions } from 'state/active-promotions/selectors';
-import { getUpsellPlanPrice } from './utils';
+import { getUpsellPlanPrice, canUpgradeSiteOrRedirect } from './utils';
+import redirectIf from './redirect-if';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -293,8 +299,15 @@ const mapDispatchToProps = dispatch => ( {
 	trackTracksEvent: ( name, props ) => dispatch( recordTracksEvent( name, props ) ),
 } );
 
-export default connect(
-	mapStateToProps,
-	mapDispatchToProps
-)( localize( WordAdsUpsellComponent ) );
+export default compose(
+	connect(
+		mapStateToProps,
+		mapDispatchToProps
+	),
+	localize,
+	canUpgradeSiteOrRedirect,
+	redirectIf( state => canCurrentUserUseAds( state ), '/ads/earnings' ),
+	redirectIf( state => canAdsBeEnabledOnCurrentSite( state ), '/ads/settings' )
+)( WordAdsUpsellComponent );
+
 /* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/my-sites/feature-upsell/controller.js
+++ b/client/my-sites/feature-upsell/controller.js
@@ -17,12 +17,6 @@ import {
 	WordAdsUpsellComponent,
 } from './main';
 import { getSiteFragment } from 'lib/route';
-import {
-	canCurrentUserUseStore,
-	canCurrentUserUseAds,
-	canAdsBeEnabledOnCurrentSite,
-	canCurrentUserUpgradeSite,
-} from 'state/sites/selectors';
 
 const featurePageController = ( url, callback ) => {
 	return function( context, next ) {
@@ -30,12 +24,6 @@ const featurePageController = ( url, callback ) => {
 		const siteFragment = getSiteFragment( context.path );
 		if ( ! siteFragment ) {
 			return page.redirect( url );
-		}
-
-		// Access control, users without rights to upgrade should not see these pages
-		const state = context.store.getState();
-		if ( ! canCurrentUserUpgradeSite( state ) ) {
-			return page.redirect( '/stats/' + siteFragment );
 		}
 
 		return callback( context, next, siteFragment );
@@ -48,11 +36,7 @@ export default {
 		next();
 	} ),
 
-	storeUpsell: featurePageController( '/feature/store', function( context, next, siteFragment ) {
-		if ( canCurrentUserUseStore( context.store.getState() ) ) {
-			return page.redirect( '/store/' + siteFragment );
-		}
-
+	storeUpsell: featurePageController( '/feature/store', function( context, next ) {
 		context.primary = React.createElement( StoreUpsellComponent );
 		next();
 	} ),
@@ -67,17 +51,7 @@ export default {
 		next();
 	} ),
 
-	wordAdsUpsell: featurePageController( '/feature/ads', function( context, next, siteFragment ) {
-		const state = context.store.getState();
-		if ( canCurrentUserUseAds( state ) ) {
-			return page.redirect( '/ads/earnings/' + siteFragment );
-		}
-
-		if ( canAdsBeEnabledOnCurrentSite( state ) ) {
-			return page.redirect( '/ads/settings/' + siteFragment );
-		}
-
-		// Render
+	wordAdsUpsell: featurePageController( '/feature/ads', function( context, next ) {
 		context.primary = React.createElement( WordAdsUpsellComponent );
 		next();
 	} ),

--- a/client/my-sites/feature-upsell/main.jsx
+++ b/client/my-sites/feature-upsell/main.jsx
@@ -7,18 +7,8 @@
 /**
  * Internal dependencies
  */
-import PluginsUpsellComponent from './plugins-upsell';
-import StoreUpsellComponent from './store-upsell';
-import ThemesUpsellComponent from './themes-upsell';
-import WordAdsUpsellComponent from './ads-upsell';
-import FeaturesComponent from './features';
-import upsellRedirect from './upsell-redirect';
-
-export {
-	upsellRedirect,
-	FeaturesComponent,
-	PluginsUpsellComponent,
-	StoreUpsellComponent,
-	ThemesUpsellComponent,
-	WordAdsUpsellComponent,
-};
+export PluginsUpsellComponent from './plugins-upsell';
+export StoreUpsellComponent from './store-upsell';
+export ThemesUpsellComponent from './themes-upsell';
+export WordAdsUpsellComponent from './ads-upsell';
+export FeaturesComponent from './features';

--- a/client/my-sites/feature-upsell/plugins-upsell.jsx
+++ b/client/my-sites/feature-upsell/plugins-upsell.jsx
@@ -8,6 +8,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import { compose } from 'redux';
 
 /**
  * Internal dependencies
@@ -20,14 +21,16 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
 import page from 'page';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { PLAN_BUSINESS, FEATURE_UPLOAD_PLUGINS } from 'lib/plans/constants';
 import Feature from 'my-sites/feature-upsell/feature';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QueryActivePromotions from 'components/data/query-active-promotions';
 import RefundAsterisk from 'my-sites/feature-upsell/refund-asterisk';
 import { getCurrencyObject } from 'lib/format-currency';
-import { getUpsellPlanPrice } from './utils';
+import { getUpsellPlanPrice, canUpgradeSiteOrRedirect } from './utils';
+import { hasFeature } from 'state/sites/plans/selectors';
+import redirectIf from './redirect-if';
 
 /*
  * This is just for english audience and is not translated on purpose, remember to add
@@ -287,7 +290,12 @@ const mapDispatchToProps = dispatch => ( {
 	trackTracksEvent: ( name, props ) => dispatch( recordTracksEvent( name, props ) ),
 } );
 
-export default connect(
-	mapStateToProps,
-	mapDispatchToProps
-)( localize( PluginsUpsellComponent ) );
+export default compose(
+	connect(
+		mapStateToProps,
+		mapDispatchToProps
+	),
+	localize,
+	canUpgradeSiteOrRedirect,
+	redirectIf( ( state, siteId ) => hasFeature( state, siteId, FEATURE_UPLOAD_PLUGINS ), '/plugins' )
+)( PluginsUpsellComponent );

--- a/client/my-sites/feature-upsell/plugins-upsell.jsx
+++ b/client/my-sites/feature-upsell/plugins-upsell.jsx
@@ -28,7 +28,7 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import QueryActivePromotions from 'components/data/query-active-promotions';
 import RefundAsterisk from 'my-sites/feature-upsell/refund-asterisk';
 import { getCurrencyObject } from 'lib/format-currency';
-import { getUpsellPlanPrice, canUpgradeSiteOrRedirect } from './utils';
+import { getUpsellPlanPrice, redirectUnlessCanUpgradeSite } from './utils';
 import { hasFeature } from 'state/sites/plans/selectors';
 import redirectIf from './redirect-if';
 
@@ -296,6 +296,6 @@ export default compose(
 		mapDispatchToProps
 	),
 	localize,
-	canUpgradeSiteOrRedirect,
+	redirectUnlessCanUpgradeSite,
 	redirectIf( ( state, siteId ) => hasFeature( state, siteId, FEATURE_UPLOAD_PLUGINS ), '/plugins' )
 )( PluginsUpsellComponent );

--- a/client/my-sites/feature-upsell/plugins-upsell.jsx
+++ b/client/my-sites/feature-upsell/plugins-upsell.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
-import { compose } from 'redux';
+import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -290,7 +290,7 @@ const mapDispatchToProps = dispatch => ( {
 	trackTracksEvent: ( name, props ) => dispatch( recordTracksEvent( name, props ) ),
 } );
 
-export default compose(
+export default flowRight(
 	connect(
 		mapStateToProps,
 		mapDispatchToProps

--- a/client/my-sites/feature-upsell/redirect-if.jsx
+++ b/client/my-sites/feature-upsell/redirect-if.jsx
@@ -15,7 +15,6 @@ import page from 'page';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
-import config from 'config';
 
 export class UpsellRedirectWrapper extends React.Component {
 	static propTypes = {
@@ -73,12 +72,7 @@ export const createMapStateToProps = (
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSiteSlug( state, siteId );
 	const currentPlan = getCurrentPlan( state, siteId );
-	const shouldRedirect = !! (
-		config.isEnabled( 'upsell/nudge-a-palooza' ) &&
-		currentPlan &&
-		siteSlug &&
-		shouldRedirectCallback( state, siteId )
-	);
+	const shouldRedirect = !! ( currentPlan && siteSlug && shouldRedirectCallback( state, siteId ) );
 
 	return {
 		siteId,

--- a/client/my-sites/feature-upsell/redirect-if.jsx
+++ b/client/my-sites/feature-upsell/redirect-if.jsx
@@ -22,7 +22,7 @@ export class UpsellRedirectWrapper extends React.Component {
 		siteId: PropTypes.number.isRequired,
 		ComponentClass: PropTypes.any.isRequired,
 		upsellPageURL: PropTypes.string.isRequired,
-		shouldRedirectToUpsellPage: PropTypes.bool.isRequired,
+		shouldRedirect: PropTypes.bool.isRequired,
 		loadingPlan: PropTypes.bool.isRequired,
 	};
 
@@ -40,7 +40,7 @@ export class UpsellRedirectWrapper extends React.Component {
 
 	goToUpsellPageIfRequired() {
 		const props = this.props;
-		if ( this.shouldRedirectToUpsellPage() ) {
+		if ( this.shouldRedirect() ) {
 			if ( ! this.redirected ) {
 				setTimeout( () => {
 					page.redirect( `${ props.upsellPageURL }/${ props.siteSlug }` );
@@ -50,14 +50,14 @@ export class UpsellRedirectWrapper extends React.Component {
 		}
 	}
 
-	shouldRedirectToUpsellPage() {
+	shouldRedirect() {
 		const props = this.props;
-		return props.shouldRedirectToUpsellPage && ! props.loadingPlan;
+		return props.shouldRedirect && ! props.loadingPlan;
 	}
 
 	render() {
-		const { ComponentClass, loadingPlan, shouldRedirectToUpsellPage, ...props } = this.props;
-		if ( loadingPlan || this.shouldRedirectToUpsellPage() ) {
+		const { ComponentClass, loadingPlan, shouldRedirect, ...props } = this.props;
+		if ( loadingPlan || this.shouldRedirect() ) {
 			return false;
 		}
 
@@ -73,7 +73,7 @@ export const createMapStateToProps = (
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSiteSlug( state, siteId );
 	const currentPlan = getCurrentPlan( state, siteId );
-	const shouldRedirectToUpsellPage = !! (
+	const shouldRedirect = !! (
 		config.isEnabled( 'upsell/nudge-a-palooza' ) &&
 		currentPlan &&
 		siteSlug &&
@@ -85,7 +85,7 @@ export const createMapStateToProps = (
 		siteSlug,
 		ComponentClass,
 		upsellPageURL,
-		shouldRedirectToUpsellPage,
+		shouldRedirect,
 		loadingPlan: ! currentPlan,
 	};
 };

--- a/client/my-sites/feature-upsell/redirect-if.jsx
+++ b/client/my-sites/feature-upsell/redirect-if.jsx
@@ -30,12 +30,9 @@ export class UpsellRedirectWrapper extends React.Component {
 		this.goToUpsellPageIfRequired();
 	}
 
-	getSnapshotBeforeUpdate() {
+	componentDidUpdate() {
 		this.goToUpsellPageIfRequired();
-		return null;
 	}
-
-	componentDidUpdate() {}
 
 	goToUpsellPageIfRequired() {
 		const props = this.props;

--- a/client/my-sites/feature-upsell/redirect-if.jsx
+++ b/client/my-sites/feature-upsell/redirect-if.jsx
@@ -90,9 +90,13 @@ export const createMapStateToProps = (
 	};
 };
 
-export const redirectIf = ( requiredFeature, upsellPageURL ) => {
+export const redirectIf = ( shouldRedirectCallback, upsellPageURL ) => {
 	return ComponentClass => {
-		const mapStateToProps = createMapStateToProps( ComponentClass, requiredFeature, upsellPageURL );
+		const mapStateToProps = createMapStateToProps(
+			ComponentClass,
+			shouldRedirectCallback,
+			upsellPageURL
+		);
 		return connect( mapStateToProps )( UpsellRedirectWrapper );
 	};
 };

--- a/client/my-sites/feature-upsell/store-upsell.jsx
+++ b/client/my-sites/feature-upsell/store-upsell.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { compose } from 'redux';
+import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -223,7 +223,7 @@ const mapDispatchToProps = dispatch => ( {
 	trackTracksEvent: ( name, props ) => dispatch( recordTracksEvent( name, props ) ),
 } );
 
-export default compose(
+export default flowRight(
 	connect(
 		mapStateToProps,
 		mapDispatchToProps

--- a/client/my-sites/feature-upsell/store-upsell.jsx
+++ b/client/my-sites/feature-upsell/store-upsell.jsx
@@ -33,7 +33,7 @@ import { isRequestingPlans } from 'state/plans/selectors';
 import { getCurrencyObject } from 'lib/format-currency';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { isRequestingActivePromotions } from 'state/active-promotions/selectors';
-import { getUpsellPlanPrice, canUpgradeSiteOrRedirect } from './utils';
+import { getUpsellPlanPrice, redirectUnlessCanUpgradeSite } from './utils';
 import redirectIf from './redirect-if';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -229,7 +229,7 @@ export default compose(
 		mapDispatchToProps
 	),
 	localize,
-	canUpgradeSiteOrRedirect,
+	redirectUnlessCanUpgradeSite,
 	redirectIf(
 		( state, siteId ) =>
 			canCurrentUserUseStore( state ) || hasFeature( state, siteId, FEATURE_UPLOAD_PLUGINS ),

--- a/client/my-sites/feature-upsell/store-upsell.jsx
+++ b/client/my-sites/feature-upsell/store-upsell.jsx
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { compose } from 'redux';
 
 /**
  * Internal dependencies
@@ -18,10 +19,10 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import Feature from 'my-sites/feature-upsell/feature';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getPlanPath, isFreePlan } from 'lib/plans';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { PLAN_BUSINESS, FEATURE_UPLOAD_PLUGINS } from 'lib/plans/constants';
 import page from 'page';
-import { getSiteSlug } from 'state/sites/selectors';
-import { getCurrentPlan, isRequestingSitePlans } from 'state/sites/plans/selectors';
+import { getSiteSlug, canCurrentUserUseStore } from 'state/sites/selectors';
+import { getCurrentPlan, isRequestingSitePlans, hasFeature } from 'state/sites/plans/selectors';
 import DocumentHead from 'components/data/document-head';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
@@ -32,7 +33,8 @@ import { isRequestingPlans } from 'state/plans/selectors';
 import { getCurrencyObject } from 'lib/format-currency';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { isRequestingActivePromotions } from 'state/active-promotions/selectors';
-import { getUpsellPlanPrice } from './utils';
+import { getUpsellPlanPrice, canUpgradeSiteOrRedirect } from './utils';
+import redirectIf from './redirect-if';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -221,8 +223,18 @@ const mapDispatchToProps = dispatch => ( {
 	trackTracksEvent: ( name, props ) => dispatch( recordTracksEvent( name, props ) ),
 } );
 
-export default connect(
-	mapStateToProps,
-	mapDispatchToProps
-)( localize( StoreUpsellComponent ) );
+export default compose(
+	connect(
+		mapStateToProps,
+		mapDispatchToProps
+	),
+	localize,
+	canUpgradeSiteOrRedirect,
+	redirectIf(
+		( state, siteId ) =>
+			canCurrentUserUseStore( state ) || hasFeature( state, siteId, FEATURE_UPLOAD_PLUGINS ),
+		'/store'
+	)
+)( StoreUpsellComponent );
+
 /* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/my-sites/feature-upsell/test/upsell-redirect.jsx
+++ b/client/my-sites/feature-upsell/test/upsell-redirect.jsx
@@ -22,15 +22,15 @@ describe( 'redirectIf', () => {
 	const defaultProps = {
 		siteId: 1,
 		upsellPageURL: '/',
-		shouldRedirectToUpsellPage: false,
+		shouldRedirect: false,
 	};
 	describe( 'Wrapper - unit tests', () => {
-		test( 'shouldRedirectToUpsellPage() should return true if and only if plan is already available', () => {
-			const test = props => new UpsellRedirectWrapper( props ).shouldRedirectToUpsellPage();
-			expect( test( { shouldRedirectToUpsellPage: true, loadingPlan: true } ) ).toBe( false );
-			expect( test( { shouldRedirectToUpsellPage: false, loadingPlan: true } ) ).toBe( false );
-			expect( test( { shouldRedirectToUpsellPage: false, loadingPlan: false } ) ).toBe( false );
-			expect( test( { shouldRedirectToUpsellPage: true, loadingPlan: false } ) ).toBe( true );
+		test( 'shouldRedirect() should return true if and only if plan is already available', () => {
+			const test = props => new UpsellRedirectWrapper( props ).shouldRedirect();
+			expect( test( { shouldRedirect: true, loadingPlan: true } ) ).toBe( false );
+			expect( test( { shouldRedirect: false, loadingPlan: true } ) ).toBe( false );
+			expect( test( { shouldRedirect: false, loadingPlan: false } ) ).toBe( false );
+			expect( test( { shouldRedirect: true, loadingPlan: false } ) ).toBe( true );
 		} );
 	} );
 
@@ -41,7 +41,7 @@ describe( 'redirectIf', () => {
 					{ ...defaultProps }
 					ComponentClass={ 'div' }
 					loadingPlan={ true }
-					shouldRedirectToUpsellPage={ true }
+					shouldRedirect={ true }
 				/>
 			);
 			expect( rendered.find( 'div' ).length ).toBe( 0 );
@@ -53,7 +53,7 @@ describe( 'redirectIf', () => {
 					{ ...defaultProps }
 					ComponentClass={ 'div' }
 					loadingPlan={ false }
-					shouldRedirectToUpsellPage={ true }
+					shouldRedirect={ true }
 				/>
 			);
 			expect( rendered.find( 'div' ).length ).toBe( 0 );
@@ -65,7 +65,7 @@ describe( 'redirectIf', () => {
 					{ ...defaultProps }
 					ComponentClass={ 'div' }
 					loadingPlan={ false }
-					shouldRedirectToUpsellPage={ false }
+					shouldRedirect={ false }
 				/>
 			);
 			expect( rendered.find( 'div' ).length ).toBe( 1 );

--- a/client/my-sites/feature-upsell/test/upsell-redirect.jsx
+++ b/client/my-sites/feature-upsell/test/upsell-redirect.jsx
@@ -12,13 +12,13 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { UpsellRedirectWrapper } from '../upsell-redirect';
+import { UpsellRedirectWrapper } from '../redirect-if';
 
 /**
  * Module variables
  */
 
-describe( 'upsellRedirect', () => {
+describe( 'redirectIf', () => {
 	const defaultProps = {
 		siteId: 1,
 		upsellPageURL: '/',

--- a/client/my-sites/feature-upsell/themes-upsell.jsx
+++ b/client/my-sites/feature-upsell/themes-upsell.jsx
@@ -28,7 +28,7 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import QueryActivePromotions from 'components/data/query-active-promotions';
 import RefundAsterisk from 'my-sites/feature-upsell/refund-asterisk';
 import { getCurrencyObject } from 'lib/format-currency';
-import { getUpsellPlanPrice, canUpgradeSiteOrRedirect } from './utils';
+import { getUpsellPlanPrice, redirectUnlessCanUpgradeSite } from './utils';
 import { hasFeature } from 'state/sites/plans/selectors';
 import redirectIf from './redirect-if';
 
@@ -297,6 +297,6 @@ export default compose(
 		mapDispatchToProps
 	),
 	localize,
-	canUpgradeSiteOrRedirect,
+	redirectUnlessCanUpgradeSite,
 	redirectIf( ( state, siteId ) => hasFeature( state, siteId, FEATURE_UPLOAD_THEMES ), '/themes' )
 )( ThemesUpsellComponent );

--- a/client/my-sites/feature-upsell/themes-upsell.jsx
+++ b/client/my-sites/feature-upsell/themes-upsell.jsx
@@ -6,7 +6,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { compose } from 'redux';
+import { flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
@@ -291,7 +291,7 @@ const mapDispatchToProps = dispatch => ( {
 	trackTracksEvent: ( name, props ) => dispatch( recordTracksEvent( name, props ) ),
 } );
 
-export default compose(
+export default flowRight(
 	connect(
 		mapStateToProps,
 		mapDispatchToProps

--- a/client/my-sites/feature-upsell/themes-upsell.jsx
+++ b/client/my-sites/feature-upsell/themes-upsell.jsx
@@ -6,6 +6,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { compose } from 'redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
@@ -20,14 +21,16 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
 import page from 'page';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { PLAN_BUSINESS, FEATURE_UPLOAD_THEMES } from 'lib/plans/constants';
 import Feature from 'my-sites/feature-upsell/feature';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QueryActivePromotions from 'components/data/query-active-promotions';
 import RefundAsterisk from 'my-sites/feature-upsell/refund-asterisk';
 import { getCurrencyObject } from 'lib/format-currency';
-import { getUpsellPlanPrice } from './utils';
+import { getUpsellPlanPrice, canUpgradeSiteOrRedirect } from './utils';
+import { hasFeature } from 'state/sites/plans/selectors';
+import redirectIf from './redirect-if';
 
 /*
  * This is just for english audience and is not translated on purpose, remember to add
@@ -269,6 +272,7 @@ class ThemesUpsellComponent extends Component {
 			</div>
 		);
 	}
+
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }
 
@@ -287,7 +291,12 @@ const mapDispatchToProps = dispatch => ( {
 	trackTracksEvent: ( name, props ) => dispatch( recordTracksEvent( name, props ) ),
 } );
 
-export default connect(
-	mapStateToProps,
-	mapDispatchToProps
-)( localize( ThemesUpsellComponent ) );
+export default compose(
+	connect(
+		mapStateToProps,
+		mapDispatchToProps
+	),
+	localize,
+	canUpgradeSiteOrRedirect,
+	redirectIf( ( state, siteId ) => hasFeature( state, siteId, FEATURE_UPLOAD_THEMES ), '/themes' )
+)( ThemesUpsellComponent );

--- a/client/my-sites/feature-upsell/utils.js
+++ b/client/my-sites/feature-upsell/utils.js
@@ -29,5 +29,5 @@ export const getUpsellPlanPrice = ( state, upsellPlanSlug, selectedSiteId ) => {
  * @param {React.Component} Component - Component to wrap in redirectIf
  * @return {function} Wrapped Component
  */
-export const canUpgradeSiteOrRedirect = Component =>
+export const redirectUnlessCanUpgradeSite = Component =>
 	redirectIf( state => ! canCurrentUserUpgradeSite( state ), '/stats' )( Component );

--- a/client/my-sites/feature-upsell/utils.js
+++ b/client/my-sites/feature-upsell/utils.js
@@ -10,6 +10,8 @@
 import { getPlan } from 'lib/plans';
 import { getPlanRawPrice } from 'state/plans/selectors';
 import { getPlanDiscountedRawPrice } from 'state/sites/plans/selectors';
+import { canCurrentUserUpgradeSite } from 'state/sites/selectors';
+import redirectIf from './redirect-if';
 
 export const getUpsellPlanPrice = ( state, upsellPlanSlug, selectedSiteId ) => {
 	const upsellPlan = getPlan( upsellPlanSlug );
@@ -20,3 +22,12 @@ export const getUpsellPlanPrice = ( state, upsellPlanSlug, selectedSiteId ) => {
 	} );
 	return discountedRawPrice || rawPrice;
 };
+
+/**
+ * Access control, users without rights to upgrade should not see these pages
+ *
+ * @param {React.Component} Component - Component to wrap in redirectIf
+ * @return {function} Wrapped Component
+ */
+export const canUpgradeSiteOrRedirect = Component =>
+	redirectIf( state => ! canCurrentUserUpgradeSite( state ), '/stats' )( Component );

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -22,7 +22,6 @@ import UploadDropZone from 'blocks/upload-drop-zone';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import EligibilityWarnings from 'blocks/eligibility-warnings';
 import EmptyContent from 'components/empty-content';
-import { upsellRedirect } from 'my-sites/feature-upsell/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import { uploadPlugin, clearPluginUpload } from 'state/plugins/upload/actions';
@@ -47,6 +46,9 @@ import {
 } from 'state/automated-transfer/selectors';
 import { successNotice } from 'state/notices/actions';
 import { transferStates } from 'state/automated-transfer/constants';
+import { abtest } from 'lib/abtest';
+import { hasFeature } from 'state/sites/plans/selectors';
+import redirectIf from 'my-sites/feature-upsell/redirect-if';
 
 class PluginUpload extends React.Component {
 	state = {
@@ -213,5 +215,10 @@ export default compose(
 		{ uploadPlugin, clearPluginUpload, initiateAutomatedTransferWithPluginZip, successNotice }
 	),
 	localize,
-	upsellRedirect( FEATURE_UPLOAD_PLUGINS, '/feature/plugins' )
+	redirectIf(
+		( state, siteId ) =>
+			abtest( 'nudgeAPalooza' ) === 'customPluginAndThemeLandingPages' &&
+			! hasFeature( state, siteId, FEATURE_UPLOAD_PLUGINS ),
+		'/feature/plugins'
+	)
 )( PluginUpload );

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -221,6 +221,7 @@ if ( config.isEnabled( 'upsell/nudge-a-palooza' ) ) {
 	flowRightArgs.push(
 		redirectIf(
 			( state, siteId ) =>
+				! isJetpackSite( state, siteId ) &&
 				abtest( 'nudgeAPalooza' ) === 'customPluginAndThemeLandingPages' &&
 				! hasFeature( state, siteId, FEATURE_UPLOAD_PLUGINS ),
 			'/feature/plugins'

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -218,13 +218,12 @@ const composeArgs = [
 	localize,
 ];
 
-if (
-	config.isEnabled( 'upsell/nudge-a-palooza' ) &&
-	abtest( 'nudgeAPalooza' ) === 'customPluginAndThemeLandingPages'
-) {
+if ( config.isEnabled( 'upsell/nudge-a-palooza' ) ) {
 	composeArgs.push(
 		redirectIf(
-			( state, siteId ) => ! hasFeature( state, siteId, FEATURE_UPLOAD_PLUGINS ),
+			( state, siteId ) =>
+				abtest( 'nudgeAPalooza' ) === 'customPluginAndThemeLandingPages' &&
+				! hasFeature( state, siteId, FEATURE_UPLOAD_PLUGINS ),
 			'/feature/plugins'
 		)
 	);

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -8,8 +8,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import page from 'page';
 import { localize } from 'i18n-calypso';
-import { isEmpty } from 'lodash';
-import { compose } from 'redux';
+import { isEmpty, flowRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -210,7 +209,7 @@ const mapStateToProps = state => {
 	};
 };
 
-const composeArgs = [
+const flowRightArgs = [
 	connect(
 		mapStateToProps,
 		{ uploadPlugin, clearPluginUpload, initiateAutomatedTransferWithPluginZip, successNotice }
@@ -219,7 +218,7 @@ const composeArgs = [
 ];
 
 if ( config.isEnabled( 'upsell/nudge-a-palooza' ) ) {
-	composeArgs.push(
+	flowRightArgs.push(
 		redirectIf(
 			( state, siteId ) =>
 				abtest( 'nudgeAPalooza' ) === 'customPluginAndThemeLandingPages' &&
@@ -229,4 +228,4 @@ if ( config.isEnabled( 'upsell/nudge-a-palooza' ) ) {
 	);
 }
 
-export default compose( ...composeArgs )( PluginUpload );
+export default flowRight( ...flowRightArgs )( PluginUpload );

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -184,7 +184,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	ads() {
-		const { path, canUserUpgradeSite, canUserUseAds } = this.props;
+		const { path, canUserUpgradeSite, canUserUseAds, isJetpack } = this.props;
 
 		if ( canUserUseAds ) {
 			return (
@@ -200,7 +200,7 @@ export class MySitesSidebar extends Component {
 		}
 
 		if (
-			! this.props.isJetpack &&
+			! isJetpack &&
 			isEnabled( 'upsell/nudge-a-palooza' ) &&
 			canUserUpgradeSite &&
 			abtest( 'nudgeAPalooza' ) === 'sidebarUpsells'
@@ -425,7 +425,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	store() {
-		const { canUserUpgradeSite, site, canUserUseStore } = this.props;
+		const { canUserUpgradeSite, site, canUserUseStore, isJetpack } = this.props;
 
 		if ( ! isEnabled( 'woocommerce/extension-dashboard' ) || ! site ) {
 			return null;
@@ -433,6 +433,7 @@ export class MySitesSidebar extends Component {
 
 		if ( ! canUserUseStore ) {
 			if (
+				! isJetpack &&
 				isEnabled( 'upsell/nudge-a-palooza' ) &&
 				canUserUpgradeSite &&
 				abtest( 'nudgeAPalooza' ) === 'sidebarUpsells'

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -579,7 +579,7 @@ class ThemeSheet extends React.Component {
 
 	renderSheet = () => {
 		const section = this.validateSection( this.props.section );
-		const { id, siteId, retired, isPremium, hasUnlimitedPremiumThemes } = this.props;
+		const { id, siteId, retired, isPremium, isJetpack, hasUnlimitedPremiumThemes } = this.props;
 
 		const analyticsPath = `/theme/${ id }${ section ? '/' + section : '' }${
 			siteId ? '/:site' : ''
@@ -620,6 +620,7 @@ class ThemeSheet extends React.Component {
 
 		let pageUpsellBanner, previewUpsellBanner;
 		const hasUpsellBanner =
+			! isJetpack &&
 			isPremium &&
 			! hasUnlimitedPremiumThemes &&
 			config.isEnabled( 'upsell/nudge-a-palooza' ) &&

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -20,15 +20,23 @@ import { hasFeature, isRequestingSitePlans } from 'state/sites/plans/selectors';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
-import { getSiteSlug } from 'state/sites/selectors';
+import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import config from 'config';
 import { abtest } from 'lib/abtest';
 
 const ConnectedSingleSiteWpcom = connectOptions( props => {
-	const { hasUnlimitedPremiumThemes, requestingSitePlans, siteId, siteSlug, translate } = props;
+	const {
+		hasUnlimitedPremiumThemes,
+		requestingSitePlans,
+		siteId,
+		siteSlug,
+		translate,
+		isJetpack,
+	} = props;
 
 	const displayUpsellBanner = ! requestingSitePlans && ! hasUnlimitedPremiumThemes;
 	const bannerLocationBelowSearch =
+		! isJetpack &&
 		config.isEnabled( 'upsell/nudge-a-palooza' ) &&
 		abtest( 'nudgeAPalooza' ) === 'themesNudgesUpdates';
 
@@ -84,6 +92,7 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 } );
 
 export default connect( ( state, { siteId } ) => ( {
+	isJetpack: isJetpackSite( state, siteId ),
 	siteSlug: getSiteSlug( state, siteId ),
 	hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
 	requestingSitePlans: isRequestingSitePlans( state, siteId ),

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -333,13 +333,12 @@ const composeArgs = [
 	localize,
 ];
 
-if (
-	config.isEnabled( 'upsell/nudge-a-palooza' ) &&
-	abtest( 'nudgeAPalooza' ) === 'customPluginAndThemeLandingPages'
-) {
+if ( config.isEnabled( 'upsell/nudge-a-palooza' ) ) {
 	composeArgs.push(
 		redirectIf(
-			( state, siteId ) => ! hasFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
+			( state, siteId ) =>
+				abtest( 'nudgeAPalooza' ) === 'customPluginAndThemeLandingPages' &&
+				! hasFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
 			'/feature/themes'
 		)
 	);

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -56,7 +56,8 @@ import QueryEligibility from 'components/data/query-atat-eligibility';
 import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-transfer/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import WpAdminAutoLogin from 'components/wpadmin-auto-login';
-import { upsellRedirect } from 'my-sites/feature-upsell/main';
+import redirectIf from 'my-sites/feature-upsell/redirect-if';
+import { abtest } from 'lib/abtest';
 
 const debug = debugFactory( 'calypso:themes:theme-upload' );
 
@@ -329,5 +330,10 @@ export default compose(
 		{ uploadTheme, clearThemeUpload, initiateThemeTransfer }
 	),
 	localize,
-	upsellRedirect( FEATURE_UPLOAD_THEMES, '/feature/themes' )
+	redirectIf(
+		( state, siteId ) =>
+			abtest( 'nudgeAPalooza' ) === 'customPluginAndThemeLandingPages' &&
+			! hasFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
+		'/feature/themes'
+	)
 )( UploadWithOptions );

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -7,8 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { includes, find, isEmpty } from 'lodash';
-import { compose } from 'redux';
+import { includes, find, isEmpty, flowRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -325,7 +324,7 @@ const mapStateToProps = state => {
 	};
 };
 
-const composeArgs = [
+const flowRightArgs = [
 	connect(
 		mapStateToProps,
 		{ uploadTheme, clearThemeUpload, initiateThemeTransfer }
@@ -334,7 +333,7 @@ const composeArgs = [
 ];
 
 if ( config.isEnabled( 'upsell/nudge-a-palooza' ) ) {
-	composeArgs.push(
+	flowRightArgs.push(
 		redirectIf(
 			( state, siteId ) =>
 				abtest( 'nudgeAPalooza' ) === 'customPluginAndThemeLandingPages' &&
@@ -344,4 +343,4 @@ if ( config.isEnabled( 'upsell/nudge-a-palooza' ) ) {
 	);
 }
 
-export default compose( ...composeArgs )( UploadWithOptions );
+export default flowRight( ...flowRightArgs )( UploadWithOptions );

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -336,6 +336,7 @@ if ( config.isEnabled( 'upsell/nudge-a-palooza' ) ) {
 	flowRightArgs.push(
 		redirectIf(
 			( state, siteId ) =>
+				! isJetpackSite( state, siteId ) &&
 				abtest( 'nudgeAPalooza' ) === 'customPluginAndThemeLandingPages' &&
 				! hasFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
 			'/feature/themes'


### PR DESCRIPTION
This PR revisits access control/redirection logic for upsell pages - it adds a few more redirects, and also moves them from controller level where state may not be fully loaded yet, to a higher-order component that is aware of every state change and may react accordingly. The reason is that the following bug was found:
1. User navigated to `/plugins` on a free site
1. They clicked on "upload plugin" and were redirected to an upsell page
1. They switched to a business site and still ended up on an upsell page

## Test plan:
**On calypso.localhost where upsell/nudge-a-palooza feature is enabled**
1. Go to a free site
1. Add yourself to `customPluginAndThemeLandingPages` group of nudgeAPalooza A/B test
1. Visit the following 4 pages and confirm each is loaded correctly:
* `/feature/plugins`
* `/feature/themes`
* `/feature/ads`
* `/feature/store`
1. On `/feature/plugins` switch to a premium site and confirm you end up on an upsell page
1. On `/feature/plugins` switch to a non-AT business site and confirm you end up on `/plugins`
1. On `/feature/plugins` switch to an AT business site and confirm you end up on `/plugins` or `/wp-admin/plugin-install.php`
1. On `/feature/themes` switch to a premium site and confirm you end up on an upsell page
1. On `/feature/themes` switch to a non-AT business site and confirm you end up on `/themes`
1. On `/feature/themes` switch to an AT business site and confirm you end up on `/themes`
1. On `/feature/ads` switch to a personal site and confirm you end up on an upsell page
1. On `/feature/ads` switch to a premium site and confirm you end up on wordads config or stats
1. On `/feature/ads` switch to a business site and confirm you end up on wordads config or stats
1. On `/feature/store` switch to a personal site and confirm you end up on an upsell page
1. On `/feature/store` switch to a premium site and confirm you end up on an upsell page
1. On `/feature/store` switch to a non-AT business site and confirm you end up on `/store`
1. On `/feature/store` switch to an AT business site and confirm you end up on `/store`
1. Go to a personal site that you are not eligible to upgrade and confirm that each of the 4 pages listed above redirects you to `/stats`
1. Go to `/plugins` on a free site and confirm that clicking on "Upload plugin" redirects to an upsell page
1. Go to `/plugins` on a business site and confirm that clicking on "Upload plugin" redirects to an upload page
1. Go to `/themes` on a free site and confirm that clicking on "Upload theme" redirects to an upsell page
1. Go to `/themes` on a business site and confirm that clicking on "Upload theme" redirects to an upload page
1. Add yourself to `control` group of `nudgeAPalooza` A/B test
1. Confirm you can click "Upload theme" and "Upload plugin" buttons on both free and business sites and no upsell page is displayed

**On calypso.live link below where nudge-a-palooza is disabled**
1. Add yourself to `customPluginAndThemeLandingPages` group of nudgeAPalooza A/B test
1. Confirm you can click "Upload theme" and "Upload plugin" buttons on both free and business sites and no upsell page is displayed
