### PR TITLE
Move the Cart Store dependency out of build chunk: try 2

### DIFF
--- a/client/lib/cart/store/index.js
+++ b/client/lib/cart/store/index.js
@@ -40,6 +40,8 @@ import {
 	setTaxLocation,
 } from 'lib/cart-values';
 import wp from 'lib/wp';
+import { getReduxStore } from 'lib/redux-bridge';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 import { extractStoredCardMetaValue } from 'state/ui/payment/reducer';
 
@@ -59,15 +61,13 @@ const CartStore = {
 		} );
 	},
 	setSelectedSiteId( selectedSiteId ) {
-		if ( selectedSiteId && _cartKey === selectedSiteId ) {
+		const newCartKey = selectedSiteId || 'no-site';
+
+		if ( _cartKey === newCartKey ) {
 			return;
 		}
 
-		if ( ! selectedSiteId ) {
-			_cartKey = 'no-site';
-		} else {
-			_cartKey = selectedSiteId;
-		}
+		_cartKey = newCartKey;
 
 		if ( _synchronizer && _poller ) {
 			PollerPool.remove( _poller );
@@ -226,3 +226,8 @@ CartStore.dispatchToken = Dispatcher.register( payload => {
 } );
 
 export default CartStore;
+
+// Subscribe to the Redux store to get updates about the selected site
+getReduxStore().then( store =>
+	store.subscribe( () => CartStore.setSelectedSiteId( getSelectedSiteId( store.getState() ) ) )
+);

--- a/client/lib/cart/store/index.js
+++ b/client/lib/cart/store/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { assign, flow, flowRight, get, has, partialRight } from 'lodash';
+import { assign, flow, get, has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -96,10 +96,8 @@ function emitChange() {
 }
 
 function update( changeFunction ) {
-	const wrappedFunction = flowRight(
-		partialRight( fillInAllCartItemAttributes, productsList.get() ),
-		changeFunction
-	);
+	const wrappedFunction = cart =>
+		fillInAllCartItemAttributes( changeFunction( cart ), productsList.get() );
 
 	const previousCart = CartStore.get();
 	const nextCart = wrappedFunction( previousCart );

--- a/client/lib/domains/cart-utils.js
+++ b/client/lib/domains/cart-utils.js
@@ -1,0 +1,39 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { isEmpty, find, values } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { cartItems } from 'lib/cart-values';
+import { isDomainRegistration } from 'lib/products-values';
+
+/**
+ * Depending on the current step in checkout, the user's domain can be found in
+ * either the cart or the receipt.
+ *
+ * @param {?Object} receipt - The receipt for the transaction
+ * @param {?Object} cart - The cart for the transaction
+ *
+ * @return {?String} the name of the first domain for the transaction.
+ */
+export function getDomainNameFromReceiptOrCart( receipt, cart ) {
+	let domainRegistration;
+
+	if ( receipt && ! isEmpty( receipt.purchases ) ) {
+		domainRegistration = find( values( receipt.purchases ), isDomainRegistration );
+	}
+
+	if ( cartItems.hasDomainRegistration( cart ) ) {
+		domainRegistration = cartItems.getDomainRegistrations( cart )[ 0 ];
+	}
+
+	if ( domainRegistration ) {
+		return domainRegistration.meta;
+	}
+
+	return null;
+}

--- a/client/lib/domains/utils.js
+++ b/client/lib/domains/utils.js
@@ -3,16 +3,14 @@
 /**
  * External dependencies
  */
-import { drop, isEmpty, join, find, get, split, startsWith, values } from 'lodash';
+import { drop, join, get, split, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { type as domainTypes, transferStatus, gdprConsentStatus } from './constants';
-import { cartItems } from 'lib/cart-values';
-import { isDomainRegistration } from 'lib/products-values';
 
-function getDomainType( domainFromApi ) {
+export function getDomainType( domainFromApi ) {
 	if ( domainFromApi.type === 'redirect' ) {
 		return domainTypes.SITE_REDIRECT;
 	}
@@ -32,7 +30,7 @@ function getDomainType( domainFromApi ) {
 	return domainTypes.MAPPED;
 }
 
-function getTransferStatus( domainFromApi ) {
+export function getTransferStatus( domainFromApi ) {
 	if ( domainFromApi.transfer_status === 'pending_owner' ) {
 		return transferStatus.PENDING_OWNER;
 	}
@@ -56,7 +54,7 @@ function getTransferStatus( domainFromApi ) {
 	return null;
 }
 
-function getGdprConsentStatus( domainFromApi ) {
+export function getGdprConsentStatus( domainFromApi ) {
 	switch ( domainFromApi.gdpr_consent_status ) {
 		case 'NONE':
 			return gdprConsentStatus.NONE;
@@ -77,42 +75,15 @@ function getGdprConsentStatus( domainFromApi ) {
 	}
 }
 
-function getDomainRegistrationAgreementUrl( domainFromApi ) {
+export function getDomainRegistrationAgreementUrl( domainFromApi ) {
 	return get( domainFromApi, 'domain_registration_agreement_url', null );
 }
 
-/**
- * Depending on the current step in checkout, the user's domain can be found in
- * either the cart or the receipt.
- *
- * @param {?Object} receipt - The receipt for the transaction
- * @param {?Object} cart - The cart for the transaction
- *
- * @return {?String} the name of the first domain for the transaction.
- */
-function getDomainNameFromReceiptOrCart( receipt, cart ) {
-	let domainRegistration;
-
-	if ( receipt && ! isEmpty( receipt.purchases ) ) {
-		domainRegistration = find( values( receipt.purchases ), isDomainRegistration );
-	}
-
-	if ( cartItems.hasDomainRegistration( cart ) ) {
-		domainRegistration = cartItems.getDomainRegistrations( cart )[ 0 ];
-	}
-
-	if ( domainRegistration ) {
-		return domainRegistration.meta;
-	}
-
-	return null;
-}
-
-function isDomainConnectAuthorizePath( path ) {
+export function isDomainConnectAuthorizePath( path ) {
 	return startsWith( path, '/domain-connect/authorize/' );
 }
 
-function parseDomainAgainstTldList( domainFragment, tldList ) {
+export function parseDomainAgainstTldList( domainFragment, tldList ) {
 	if ( ! domainFragment ) {
 		return '';
 	}
@@ -126,13 +97,3 @@ function parseDomainAgainstTldList( domainFragment, tldList ) {
 
 	return parseDomainAgainstTldList( suffix, tldList );
 }
-
-export {
-	getDomainNameFromReceiptOrCart,
-	getDomainRegistrationAgreementUrl,
-	getDomainType,
-	getGdprConsentStatus,
-	getTransferStatus,
-	isDomainConnectAuthorizePath,
-	parseDomainAgainstTldList,
-};

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -68,7 +68,7 @@ import { isJetpackSite, isNewSite } from 'state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { canDomainAddGSuite } from 'lib/gsuite';
-import { getDomainNameFromReceiptOrCart } from 'lib/domains/utils';
+import { getDomainNameFromReceiptOrCart } from 'lib/domains/cart-utils';
 import { fetchSitesAndUser } from 'lib/signup/step-actions';
 import { siteQualifiesForPageBuilder, getEditHomeUrl } from 'lib/signup/page-builder';
 import { getProductsList, isProductsListFetching } from 'state/products-list/selectors';

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -26,7 +26,6 @@ import {
 	SELECTED_SITE_UNSUBSCRIBE,
 } from 'state/action-types';
 import analytics from 'lib/analytics';
-import cartStore from 'lib/cart/store';
 import userFactory from 'lib/user';
 import hasSitePendingAutomatedTransfer from 'state/selectors/has-site-pending-automated-transfer';
 import isFetchingAutomatedTransferStatus from 'state/selectors/is-fetching-automated-transfer-status';
@@ -161,16 +160,6 @@ const updateSelectedSiteForAnalytics = ( dispatch, action, getState ) => {
 };
 
 /**
- * Sets the selectedSiteId for lib/cart/store
- *
- * @param {function} dispatch - redux dispatch function
- * @param {number}   siteId   - the selected siteId
- */
-const updateSelectedSiteForCart = ( dispatch, { siteId } ) => {
-	cartStore.setSelectedSiteId( siteId );
-};
-
-/**
  * Sets the selectedSite for lib/keyboard-shortcuts/global
  *
  * @param {function} dispatch - redux dispatch function
@@ -233,7 +222,6 @@ const handler = ( dispatch, action, getState ) => {
 
 		case SELECTED_SITE_SET:
 			//let this fall through
-			updateSelectedSiteForCart( dispatch, action );
 			updateSelectedSiteIdForSubscribers( dispatch, action );
 
 		case SITE_RECEIVE:


### PR DESCRIPTION
Second attempt at landing #26303.

**Reorg the `lib/domains/utils` module**
Move the function `getDomainNameFromReceiptOrCart` that has some heavy dependencies into a separate module. Then Webpack will not bundle the whole `lib/domains/utils` tree into `build`, but will be able to split the modules between chunks better. Two separate modules can be bundled into chunks separately, each one in different chunk.

**Invert the control flow when Cart Store listens for selected site changes in Redux**
There is a `state/lib/middleware.js` module that imports the Cart Store and call a `setSelectedSiteId` method on it on every Redux selected site update. That means that Cart Store gets bundled into `build`.

This patch inverts the control flow: when Cart Store is first loaded (by someone who **really** needs it), it subscribes to Redux updates (using the Redux Bridge) and updates itself when needed. That removes the Cart Store from the `build` chunk.

We should eventually use this technique for all subscribers in `state/lib/middleware.js` and probably at many other places, too.

**How to test:**
This is the crucial flow that was broken in the previous attempt and is now fixed:
**1. Go to `/me/purchases/:siteId/:purchaseId`**
This is a page that shows particular purchase for a particular site. The site is not necessarily an active site present in `state.sites`. For example, disconnected Jetpack sites are no longer active and yet can have a valid purchase we want to see. Therefore, we can't just set `state.ui.selectedSiteId` and let `CartStore` pick up the change. The `CartStore`'s site ID must be set by directly calling `CartStore.setSelectedSiteId`.

**2. Click "Renew Now" (the viewed purchase must be renewable)**
This will do two things:
- add a new product to `CartStore`. Because the cart hasn't been loaded yet (it's loaded only when poller issues `CartSynchronizer._poll` request and that happens only after `CartStore` gets its first `change` listener), the change is enqueued.
- navigate to `/checkout/:siteId`

It's absolutely crucial that the navigation to `/checkout/:siteId` doesn't change the `CartStore`'s selected site ID. If it did change the ID, `CartStore` would throw away the enqueued changes and load a new cart for a new site. The cart would end up being empty and in that case the `/checkout/:siteId` route [redirects](https://github.com/Automattic/wp-calypso/blob/7f1ba4f2deea6dc83019fe26c4fb6c02298c3a38/client/my-sites/checkout/checkout/index.jsx#L287-L321) to `/plans`.

**3. Verify that you see a checkout page with the right products in the cart.**