### PR TITLE
SDK: Add watch option

### DIFF
--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -58,6 +58,11 @@ yargs
 				coerce: path.resolve,
 				requiresArg: true,
 			},
+			'watch': {
+				alias: 'w',
+				description: 'Whether to watch for changes and automatically rebuild.',
+				type: 'boolean',
+			},
 		} ),
 		handler: argv => gutenberg.compile( argv )
 	} )

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -15,6 +15,24 @@ const CopyWebpackPlugin = require( path.resolve(
 ) );
 const getBaseConfig = require( path.join( __rootDir, 'webpack.config.js' ) );
 
+const outputHandler = ( error, stats ) => {
+	if ( error ) {
+		console.error( error );
+		console.log( chalk.red( 'Failed to build Gutenberg extension' ) );
+		process.exit( 1 );
+	}
+
+	console.log( stats.toString() );
+
+	if ( stats.hasErrors() ) {
+		console.log( chalk.red( 'Finished building Gutenberg extension but with errors.' ) );
+	} else if ( stats.hasWarnings() ) {
+		console.log( chalk.yellow( 'Successfully built Gutenberg extension but with warnings.' ) );
+	} else {
+		console.log( chalk.green( 'Successfully built Gutenberg extension' ) );
+	}
+};
+
 exports.compile = args => {
 	const options = {
 		outputDir: path.join( path.dirname( args.editorScript ), 'build' ),
@@ -56,21 +74,9 @@ exports.compile = args => {
 
 	const compiler = webpack( config );
 
-	compiler.run( ( error, stats ) => {
-		if ( error ) {
-			console.error( error );
-			console.log( chalk.red( 'Failed to build Gutenberg extension' ) );
-			process.exit( 1 );
-		}
-
-		console.log( stats.toString() );
-
-		if ( stats.hasErrors() ) {
-			console.log( chalk.red( 'Finished building Gutenberg extension but with errors.' ) );
-		} else if ( stats.hasWarnings() ) {
-			console.log( chalk.yellow( 'Successfully built Gutenberg extension but with warnings.' ) );
-		} else {
-			console.log( chalk.green( 'Successfully built Gutenberg extension' ) );
-		}
-	} );
+	if ( options.watch ) {
+		compiler.watch( {}, outputHandler );
+	} else {
+		compiler.run( outputHandler );
+	}
 };

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -15,6 +15,11 @@ const CopyWebpackPlugin = require( path.resolve(
 ) );
 const getBaseConfig = require( path.join( __rootDir, 'webpack.config.js' ) );
 
+const omitPlugins = [
+	CopyWebpackPlugin,
+	webpack.HotModuleReplacementPlugin,
+];
+
 const outputHandler = ( error, stats ) => {
 	if ( error ) {
 		console.error( error );
@@ -67,7 +72,7 @@ exports.compile = args => {
 				libraryTarget: 'window',
 			},
 			plugins: [
-				...baseConfig.plugins.filter( plugin => ! ( plugin instanceof CopyWebpackPlugin ) ),
+				...baseConfig.plugins.filter( plugin => omitPlugins.indexOf( plugin.constructor ) < 0 ),
 			],
 		},
 	};


### PR DESCRIPTION
This PR introduces a simple watch option to allow the SDK to automatically watch for changes and issue a new build. 

It also updates the SDK webpack build process to allow removing multiple plugins from the default webpack config, and removes `HotModuleReplacementPlugin` because we don't need these for now.

To test:
* Checkout this branch
* Run `npm run sdk:gutenberg -- --watch --editor-script=client/gutenberg/extensions/hello-dolly/hello-block.js`.
* Verify it builds correctly the first time.
* Make a change in the block and save.
* Verify it issues a rebuild shortly after the save.
* Try without `--watch` and verify it builds a single time just like it did before.
* Verify you don't have any hot module replacement JSONs in the output dir.

See #26510 which allows to specify output file names, enabling us to develop blocks without having to manually move them.