### PR TITLE
SDK: Add args for output file names

### DIFF
--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -58,6 +58,16 @@ yargs
 				coerce: path.resolve,
 				requiresArg: true,
 			},
+			'output-editor-file': {
+				description: 'Name of the built editor script output file.',
+				type: 'string',
+				requiresArg: true,
+			},
+			'output-view-file': {
+				description: 'Name of the built view script output file.',
+				type: 'string',
+				requiresArg: true,
+			},
 			'watch': {
 				alias: 'w',
 				description: 'Whether to watch for changes and automatically rebuild.',

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -54,8 +54,8 @@ exports.compile = args => {
 			mode: options.mode,
 			entry: omitBy(
 				{
-					[ `${ name }-editor.js` ]: options.editorScript,
-					[ `${ name }-view.js` ]: options.viewScript,
+					[ options.outputEditorFile || `${ name }-editor.js` ]: options.editorScript,
+					[ options.outputViewFile || `${ name }-view.js` ]: options.viewScript,
 				},
 				isEmpty
 			),


### PR DESCRIPTION
This PR introduces a couple of new CLI args to the SDK, allowing us to specify the output file names:

* `--output-editor-file` - the file name of the built editor file
* `--output-view-file` - the file name of the built view file

At this point they'll be extremely useful when developing Gutenberg blocks and extensions. In combination with #26509, a developer would be able to work on a Gutenberg block and be able to see the end result immediately after a refresh in their editor, without needing to call additional commands to copy the built script to the target directory.

I realize these might end up unnecessary when we get to split out dependencies and output multiple built files from the SDK. When we reach that point - I'm happy to delete these, but for now I think they'll be useful.

To test:
* Checkout this branch.
* Run `npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/hello-dolly/hello-block.js --output-editor-file=block.js`
* Verify the file gets built and named `block.js` or whatever you've decided to call it.
* Run `npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/hello-dolly/hello-block.js --output-view-file=block.js`
* Verify the file gets built and named `block.js` or whatever you've decided to call it.
* Try specifying both output file args at the same time.
* Try building without specifying any output file args and verify the output files are still named like they were before (`hello-block-editor.js` and `hello-block-view.js`).

