### PR TITLE
Sharing: Hide account profile image if loading fails

### DIFF
--- a/client/my-sites/sharing/connections/account-dialog-account.jsx
+++ b/client/my-sites/sharing/connections/account-dialog-account.jsx
@@ -6,6 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import Image from 'components/image';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
@@ -29,7 +30,7 @@ const AccountDialogAccount = ( { account, conflicting, onChange, selected, defau
 					/>
 				) }
 				{ account.picture ? (
-					<img
+					<Image
 						src={ account.picture }
 						alt={ account.name }
 						className="account-dialog-account__picture"


### PR DESCRIPTION
Fixes #24045

The Firefox default configuration includes tracking protection, which blocks images from certain third-party sites ([like Twitter's profile image source](https://github.com/mozilla/blok/issues/187)). When a user connects their site to sharing services, this blocking results in ugly overlapping text in the dialog box because the alt text, set to the username, is loaded instead.

Though this is not necessarily a bug per se, a simple fix is to use the [already existing `Image` component](https://github.com/Automattic/wp-calypso/tree/e242486b66ec240c1e2af2e2341f07d52bbdc7b2/client/components/image) in place of the `img` tag. This effectively hides the image on a loading error without doing anything too nutty or elaborate.

cc @samouri 

**Testing instructions:**

_With Tracking Protection Enabled_
1. Open Firefox in default configuration to URL: http://calypso.localhost:3000/sharing/$SOME_BLOG
2. Click connect on either LinkedIn or Twitter (may also happen with others)
3. Authorize the app, and popup should close and display dialog box
4. The connection dialog should display the username with no profile picture

_Disabled Tracking Protection_
1. Click on the upper right corner hamburger menu in Firefox, go to Preferences -> Privacy & Security -> Tracking Protection, deselect `Always` by clicking either of the remaining options
2. Reload the page
3. Repeat steps 2 & 3 above
4. The connection dialog should display the profile picture before the username

My tests keep stalling out locally after around 740 suites, but this seemed pretty minor so 🤞! Let me know if further info, changes are needed.

