### PR TITLE
Signup: Eslint fixes (componentWillMount, a11y)

### DIFF
--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -257,6 +257,7 @@ export class SignupProcessingScreen extends Component {
 
 				<div className="signup-processing__content">
 					<img
+						alt=""
 						src="/calypso/images/signup/confetti.svg"
 						className="signup-process-screen__confetti"
 					/>

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -33,12 +33,10 @@ export class SignupProcessingScreen extends Component {
 		useOAuth2Layout: PropTypes.bool.isRequired,
 	};
 
-	componentWillMount() {
-		this.setState( {
-			siteSlug: '',
-			hasPaidSubscription: false,
-		} );
-	}
+	state = {
+		siteSlug: '',
+		hasPaidSubscription: false,
+	};
 
 	componentWillReceiveProps( nextProps ) {
 		const dependencies = nextProps.signupDependencies;


### PR DESCRIPTION
- Replace `setState` in `componentWillMount` with `state` instance property
- Add `alt=""` for decoartive img.

These changes are trivial.

This component continues to use deprecated `componentWillReceiveProps`:

https://github.com/Automattic/wp-calypso/blob/74c943b3ad4112a3e7ab7c36760930f578c6d9ab/client/signup/processing-screen/index.jsx#L41-L55

However that change will likely be more involved, so I've left it for now.