### PR TITLE
Add the August email promo to active-discounts

### DIFF
--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -10,9 +10,11 @@ import {
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
 } from 'lib/plans/constants';
+import { translate } from 'i18n-calypso';
+// import { translate } from this.props;
 
 /**
- * No translate() used in this file since we're launching those promotions just for the EN audience
+ * No translate() used on some of these since we're launching those promotions just for the EN audience
  */
 export default [
 	{
@@ -53,5 +55,23 @@ export default [
 		plansPageNoticeTextTitle: 'Get a free domain name by upgrading to any plan listed below!',
 		plansPageNoticeText:
 			'Improve your SEO, branding, credibility, and even word-of-mouth marketing with a custom domain. All plan upgrades include a free domain name of your choice.',
+	},
+	{
+		name: 'august20',
+		startsAt: new Date( 2018, 7, 6, 0, 0, 0 ),
+		endsAt: new Date( 2018, 7, 11, 0, 0, 0 ),
+		nudgeText: translate( '20% Off All Plans' ),
+		ctaText: translate( 'UPGRADE' ),
+		plansPageNoticeText: translate(
+			'Enter coupon code “AUGUST20” during checkout to claim your 20% discount.'
+		),
+		targetPlans: [
+			{ type: TYPE_FREE, group: GROUP_WPCOM },
+			{ type: TYPE_PERSONAL, group: GROUP_WPCOM },
+			{ type: TYPE_PREMIUM, group: GROUP_WPCOM },
+			{ type: TYPE_FREE, group: GROUP_JETPACK },
+			{ type: TYPE_PERSONAL, group: GROUP_JETPACK },
+			{ type: TYPE_PREMIUM, group: GROUP_JETPACK },
+		],
 	},
 ];

--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -11,7 +11,6 @@ import {
 	TYPE_PREMIUM,
 } from 'lib/plans/constants';
 import { translate } from 'i18n-calypso';
-// import { translate } from this.props;
 
 /**
  * No translate() used on some of these since we're launching those promotions just for the EN audience

--- a/client/my-sites/plan-features/test/index.jsx
+++ b/client/my-sites/plan-features/test/index.jsx
@@ -22,6 +22,7 @@ jest.mock( 'i18n-calypso', () => ( {
 		/>
 	),
 	numberFormat: x => x,
+	translate: x => x,
 } ) );
 
 /**


### PR DESCRIPTION
We'll be sending an August promo email.
This will use that email to trigger a Calypso nudge and banner to eligible users

----------

**Test Plan**

NOTE: This relies on the changes in D16947-code

* From the backend, set a user attribute for yourself:
```
update_user_attribute( [USER_ID], 'SSE_weekly_marketing_email_holdout_wpcom_august_promo_en_20180101', 'send' );
```
* From http://calypso.localhost:3000/ go to one of your sites that is on a free, Personal, or Premium plan.
In the side bar you should see the nudge.
<img width="302" alt="screen shot 2018-08-06 at 3 53 55 pm" src="https://user-images.githubusercontent.com/690843/43745239-947056f2-9992-11e8-881a-91f6cc6f42a9.png">

* Click the nudge and you should see a banner on the plans page.
<img width="1080" alt="screen shot 2018-08-06 at 3 54 28 pm" src="https://user-images.githubusercontent.com/690843/43745253-a350bc0c-9992-11e8-952d-c2e8c1fad31a.png">
