### PR TITLE
Chart: Avoid manually setting styles using DOM ref

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -54,12 +54,12 @@
 
 // Y-axis labels
 // 1: matches Y-axis padding
-
+$y-axis-padding: 0 20px 0 10px;
 .chart__y-axis {
 	position: relative;
 	float: right;
 	height: 200px;
-	padding: 0 20px 0 10px;
+	padding: $y-axis-padding;
 	font-size: 11px;
 	color: $gray-darken-10;
 	margin-bottom: 30px;
@@ -108,8 +108,17 @@
 	margin-left: -.5px;
 	width: 1px;
 	height: 5px;
-	background: $gray-light;
-	background-image: linear-gradient(to bottom, $gray-light 0%, $gray-lighten-20 100%);
+	background: $gray-darken-30;
+}
+
+.chart__x-axis-width-spacer {
+	color: $transparent;
+	padding: $y-axis-padding;
+	right: 0;
+
+	&::before {
+		display: none;
+	}
 }
 
 // Bar wrapper

--- a/client/components/chart/x-axis.jsx
+++ b/client/components/chart/x-axis.jsx
@@ -21,11 +21,8 @@ export default class ModuleChartXAxis extends PureComponent {
 		data: PropTypes.array.isRequired,
 	};
 
-	constructor( props ) {
-		super( props );
-		this.axisRef = React.createRef();
-		this.axisSpacerRef = React.createRef();
-	}
+	axisRef = React.createRef();
+	axisSpacerRef = React.createRef();
 
 	state = {
 		divisor: 1,

--- a/client/components/chart/x-axis.jsx
+++ b/client/components/chart/x-axis.jsx
@@ -3,9 +3,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { PureComponent } from 'react';
+import { numberFormat } from 'i18n-calypso';
 import { throttle } from 'lodash';
 
 /**
@@ -13,13 +13,19 @@ import { throttle } from 'lodash';
  */
 import Label from './label';
 
-export default class extends React.Component {
+export default class ModuleChartXAxis extends PureComponent {
 	static displayName = 'ModuleChartXAxis';
 
 	static propTypes = {
 		labelWidth: PropTypes.number.isRequired,
 		data: PropTypes.array.isRequired,
 	};
+
+	constructor( props ) {
+		super( props );
+		this.axisRef = React.createRef();
+		this.axisSpacerRef = React.createRef();
+	}
 
 	state = {
 		divisor: 1,
@@ -28,49 +34,31 @@ export default class extends React.Component {
 
 	// Add listener for window resize
 	componentDidMount() {
-		this.resizeThrottled = throttle( this.resize, 400 );
-		window.addEventListener( 'resize', this.resizeThrottled );
+		this.resize = throttle( this.resize, 400 );
+		window.addEventListener( 'resize', this.resize );
 		this.resize();
 	}
 
 	// Remove listener
 	componentWillUnmount() {
-		if ( this.resizeThrottled.cancel ) {
-			this.resizeThrottled.cancel();
+		if ( this.resize.cancel ) {
+			this.resize.cancel();
 		}
-		window.removeEventListener( 'resize', this.resizeThrottled );
+		window.removeEventListener( 'resize', this.resize );
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		this.resize( nextProps );
+	componentDidUpdate() {
+		this.resize();
 	}
 
-	resize = nextProps => {
-		let props = this.props;
-		if ( nextProps && ! ( nextProps instanceof Event ) ) {
-			props = nextProps;
-		}
-
-		const node = this.refs.axis;
-
-		/**
-		 * Overflow needs to be hidden to calculate the desired width,
-		 * but visible to display each labels' overflow :/
-		 */
-
-		node.style.overflow = 'hidden';
-		const width = node.clientWidth;
-		node.style.overflow = 'visible';
-
-		const dataCount = props.data.length || 1;
+	resize = () => {
+		const width = this.axisRef.current.clientWidth - this.axisSpacerRef.current.clientWidth;
+		const dataCount = this.props.data.length || 1;
 		const spacing = width / dataCount;
-		const labelWidth = props.labelWidth;
+		const labelWidth = this.props.labelWidth;
 		const divisor = Math.ceil( labelWidth / spacing );
 
-		this.setState( {
-			divisor: divisor,
-			spacing: spacing,
-		} );
+		this.setState( { divisor, spacing } );
 	};
 
 	render() {
@@ -91,8 +79,11 @@ export default class extends React.Component {
 		}, this );
 
 		return (
-			<div ref="axis" className="chart__x-axis">
+			<div ref={ this.axisRef } className="chart__x-axis">
 				{ labels }
+				<div ref={ this.axisSpacerRef } className="chart__x-axis-label chart__x-axis-width-spacer">
+					{ numberFormat( 100000 ) }
+				</div>
 			</div>
 		);
 	}


### PR DESCRIPTION
This change does the following:
- Removes setting DOM element style through JavaScript.
- Replaces deprecated string refs with the new [createRef API](https://reactjs.org/docs/react-api.html#reactcreateref). 
- Improves visibility of the x-axis tick marks.

Before: 
<img width="412" alt="tick marks - before" src="https://user-images.githubusercontent.com/4044428/43745780-db43a8e4-999d-11e8-9b6e-270ff8055ca0.png">

After: 
<img width="413" alt="tick marks - after" src="https://user-images.githubusercontent.com/4044428/43745860-3cc5fc70-999e-11e8-9bbf-ffcef3c54d32.png">

# Test Instructions
1. Spin up this change locally or in a Calypso live branch.
2. Navigate to [`/stats/day/`](http://calypso.localhost:3000/stats/day/) and select a site with activity. 
3. Ensure that the rendered page is identical to the [existing page on production](https://wordpress.com/stats/day).
4. Ensure that the [Charts devdocs page](http://calypso.localhost:3000/devdocs/design/chart) works as expected.

(cc @sixhours for a sanity check on the tick mark color change)