### PR TITLE
Domains: Update the Thank You page for transfer ins to set proper expectations

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -28,7 +28,6 @@ import { localize } from 'i18n-calypso';
 import { preventWidows } from 'lib/formatting';
 import { domainManagementTransferInPrecheck } from 'my-sites/domains/paths';
 import { recordStartTransferClickInThankYou } from 'state/domains/actions';
-import { CHANGE_NAME_SERVERS } from 'lib/url/support';
 
 class CheckoutThankYouHeader extends PureComponent {
 	static propTypes = {
@@ -181,18 +180,14 @@ class CheckoutThankYouHeader extends PureComponent {
 			}
 
 			return translate(
-				'Your domain {{strong}}%(domain)s{{/strong}} was added to your site. ' +
-					'To make your newly transferred domain work with WordPress.com, you need to ' +
-					'{{updateNameserversLink}}update the nameservers{{/updateNameserversLink}}.',
+				'Your domain {{strong}}%(domain)s{{/strong}} was added to your site, but ' +
+					'but the transfer process can take up to 5 days to complete.',
 				{
 					args: {
 						domain: primaryPurchase.meta,
 					},
 					components: {
 						strong: <strong />,
-						updateNameserversLink: (
-							<a href={ CHANGE_NAME_SERVERS } target="_blank" rel="noopener noreferrer" />
-						),
 					},
 				}
 			);


### PR DESCRIPTION
As pointed out by @aidvu in https://github.com/Automattic/wp-calypso/pull/26337#issuecomment-408859976, mentioning nameserver change at this point does not make sense. We should instead set the proper expectations on the timeline of the transfer in process.

### Testing
Basically, same as https://github.com/Automattic/wp-calypso/pull/26337

Initiate a transfer-in from NUX: after creating the site, you should be presented with a screen to input the auth code. Once you get past that, you should see the updated thank you page.

Initiate a transfer-in from Domain Management: same as above, but the auth code input screen is before the checkout. The thank you screen should be the same, though.

<img width="985" alt="screen shot 2018-08-07 at 13 59 05" src="https://user-images.githubusercontent.com/3392497/43774762-891a5bb4-9a4a-11e8-9b3f-76c26b88fd8a.png">
