### PR TITLE
SDK: Set output CSS file name properly

### DIFF
--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -59,12 +59,12 @@ yargs
 				requiresArg: true,
 			},
 			'output-editor-file': {
-				description: 'Name of the built editor script output file.',
+				description: 'Name of the built editor script output file (without the file extension).',
 				type: 'string',
 				requiresArg: true,
 			},
 			'output-view-file': {
-				description: 'Name of the built view script output file.',
+				description: 'Name of the built view script output file (without the file extension).',
 				type: 'string',
 				requiresArg: true,
 			},

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -54,8 +54,8 @@ exports.compile = args => {
 			mode: options.mode,
 			entry: omitBy(
 				{
-					[ options.outputEditorFile || `${ name }-editor.js` ]: options.editorScript,
-					[ options.outputViewFile || `${ name }-view.js` ]: options.viewScript,
+					[ options.outputEditorFile || `${ name }-editor` ]: options.editorScript,
+					[ options.outputViewFile || `${ name }-view` ]: options.viewScript,
 				},
 				isEmpty
 			),
@@ -68,7 +68,7 @@ exports.compile = args => {
 			},
 			output: {
 				path: options.outputDir,
-				filename: '[name]',
+				filename: '[name].js',
 				libraryTarget: 'window',
 			},
 			plugins: [


### PR DESCRIPTION
This PR updates how we set the name of the output CSS file. Currently, if we specify a `--output-editor-file=block.js`, the CSS file it will end up named `block.js.css`. This PR updates it so in that case, it'll resemble the specified output editor file, but with `.css` format.

This changes the expected format of `--output-editor-file` and `--output-view-file` args - they now expect a value without the file extension - for example `block` instead of `block.js`.

To test:
* Checkout this branch
* Run `npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/editor-notes/index.js`
* Verify build outputs the `editor-notes-editor.css` and `editor-notes-editor.js` files.
* Run `npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/editor-notes/index.js --output-editor-file=block`
* Verify build outputs the `block.css` and `block.js` files.