### PR TITLE
Lint: Never ignore undef errors.

### DIFF
--- a/.eslines.json
+++ b/.eslines.json
@@ -6,7 +6,7 @@
   "processors": {
     "downgrade-unmodified-lines": {
       "remote": "origin/master",
-      "rulesNotToDowngrade": [ "no-unused-vars" ]
+      "rulesNotToDowngrade": [ "no-unused-vars", "no-undef" ]
     },
     "filter-when-format": {
       "rulesToIgnore": [ "indent" ]


### PR DESCRIPTION
They break everything and should not be ignored.