### PR TITLE
Signup: Remove no-longer used flows

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -73,20 +73,6 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			lastModified: '2017-09-01',
 		},
 
-		portfolio: {
-			steps: [ 'portfolio-themes', 'domains', 'plans', 'user' ],
-			destination: getSiteDestination,
-			description: 'Signup flow starting with portfolio themes',
-			lastModified: '2017-09-01',
-		},
-
-		store: {
-			steps: [ 'about', 'domains', 'plans', 'user' ],
-			destination: getSiteDestination,
-			description: 'Signup flow for creating an online store',
-			lastModified: '2018-01-24',
-		},
-
 		'rebrand-cities': {
 			steps: [ 'rebrand-cities-welcome', 'user' ],
 			destination: function( dependencies ) {
@@ -125,20 +111,6 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			destination: getSiteDestination,
 			description: 'The current best performing flow in AB tests',
 			lastModified: '2018-01-24',
-		},
-
-		surveystep: {
-			steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
-			destination: getSiteDestination,
-			description: 'The current best performing flow in AB tests',
-			lastModified: '2016-05-23',
-		},
-
-		'test-site': {
-			steps: process.env.NODE_ENV === 'development' ? [ 'site', 'user' ] : [ 'user' ],
-			destination: '/',
-			description: 'This flow is used to test the site step.',
-			lastModified: '2015-09-22',
 		},
 
 		'delta-discover': {
@@ -180,25 +152,6 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			destination: '/devdocs/welcome',
 			description: 'Signup flow for developers in developer environment',
 			lastModified: '2015-11-23',
-		},
-
-		pressable: {
-			steps: [ 'design-type-with-store', 'themes', 'domains', 'plans', 'user' ],
-			destination: getSiteDestination,
-			description: 'Signup flow for testing the pressable-store step',
-			lastModified: '2016-06-27',
-		},
-
-		jetpack: {
-			steps: [ 'jetpack-user' ],
-			destination: '/',
-		},
-
-		'get-dot-blog': {
-			steps: [ 'get-dot-blog-themes', 'get-dot-blog-plans' ],
-			destination: getSiteDestination,
-			description: 'Used by `get.blog` users that connect their site to WordPress.com',
-			lastModified: '2016-11-14',
 		},
 
 		'pressable-nux': {
@@ -318,14 +271,6 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		};
 	}
 
-	if ( process.env.NODE_ENV === 'development' ) {
-		flows[ 'test-plans' ] = {
-			steps: [ 'site', 'plans', 'user' ],
-			destination: getSiteDestination,
-			description: 'This flow is used to test plans choice in signup',
-			lastModified: '2016-06-30',
-		};
-	}
 	return flows;
 }
 

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -14,10 +14,8 @@ import CredsConfirmComponent from 'signup/steps/creds-confirm';
 import CredsCompleteComponent from 'signup/steps/creds-complete';
 import CredsPermissionComponent from 'signup/steps/creds-permission';
 import DesignTypeComponent from 'signup/steps/design-type';
-import DesignTypeWithStoreComponent from 'signup/steps/design-type-with-store';
 import DesignTypeWithAtomicStoreComponent from 'signup/steps/design-type-with-atomic-store';
 import DomainsStepComponent from 'signup/steps/domains';
-import GetDotBlogPlansStepComponent from 'signup/steps/get-dot-blog-plans';
 import PlansStepComponent from 'signup/steps/plans';
 import SiteComponent from 'signup/steps/site';
 import RebrandCitiesWelcomeComponent from 'signup/steps/rebrand-cities-welcome';
@@ -47,15 +45,11 @@ export default {
 	'creds-complete': CredsCompleteComponent,
 	'creds-permission': CredsPermissionComponent,
 	'design-type': DesignTypeComponent,
-	'design-type-with-store': DesignTypeWithStoreComponent,
 	'design-type-with-store-nux': DesignTypeWithAtomicStoreComponent,
 	domains: DomainsStepComponent,
 	'domains-store': DomainsStepComponent,
 	'domain-only': DomainsStepComponent,
 	'domains-theme-preselected': DomainsStepComponent,
-	'jetpack-user': UserSignupComponent,
-	'get-dot-blog-plans': GetDotBlogPlansStepComponent,
-	'get-dot-blog-themes': ThemeSelectionComponent,
 	plans: PlansStepComponent,
 	'plans-store-nux': PlansAtomicStoreComponent,
 	'plans-site-selected': PlansStepWithoutFreePlan,
@@ -77,7 +71,6 @@ export default {
 	themes: ThemeSelectionComponent,
 	'website-themes': ThemeSelectionComponent,
 	'blog-themes': ThemeSelectionComponent,
-	'portfolio-themes': ThemeSelectionComponent,
 	'themes-site-selected': ThemeSelectionComponent,
 	user: UserSignupComponent,
 	'oauth2-user': UserSignupComponent,

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -15,6 +15,7 @@ import sinon from 'sinon';
 import mockedFlows from './fixtures/flows';
 import abtest from 'lib/abtest';
 import flows from 'signup/config/flows';
+import userFactory from 'lib/user';
 
 jest.mock( 'lib/abtest', () => ( {
 	abtest: () => {},
@@ -27,7 +28,7 @@ describe( 'Signup Flows Configuration', () => {
 		let user;
 
 		beforeAll( () => {
-			user = require( 'lib/user' )();
+			user = userFactory();
 
 			sinon.stub( flows, 'getFlows' ).returns( mockedFlows );
 			sinon.stub( flows, 'getABTestFilteredFlow' ).callsFake( ( flowName, flow ) => {
@@ -44,7 +45,7 @@ describe( 'Signup Flows Configuration', () => {
 			assert.deepEqual( flows.getFlow( 'main' ).steps, [ 'user', 'site' ] );
 		} );
 
-		test( 'should remove the user step from the flow when the user is not logged in', () => {
+		test( 'should remove the user step from the flow when the user is logged in', () => {
 			user.setLoggedIn( true );
 			assert.deepEqual( flows.getFlow( 'main' ).steps, [ 'site' ] );
 			user.setLoggedIn( false );


### PR DESCRIPTION
Flows that are not currently linked to or planned to be in use are removed.

Also fixes a flows test that was broken.

Fixes #6503 

