### PR TITLE
SDK: Update Publicize extension to be rendered as a plugin extension

### DIFF
--- a/client/gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx
@@ -2,8 +2,8 @@
  * Top-level Publicize plugin for Gutenberg editor.
  *
  * Hooks into Gutenberg's PluginPrePublishPanel and PluginSidebar
- * to display Jetpack's Publicize UI in the pre-
- * publish flow.
+ * to display Jetpack's Publicize UI in the pre-publish flow and
+ * as a regular plugin extension.
  *
  * @since  5.9.1
  */

--- a/client/gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx
@@ -1,7 +1,7 @@
 /**
  * Top-level Publicize plugin for Gutenberg editor.
  *
- * Hooks into Gutenberg's PluginSidebarMoreMenuItem
+ * Hooks into Gutenberg's PluginPrePublishPanel and PluginSidebar
  * to display Jetpack's Publicize UI in the pre-
  * publish flow.
  *

--- a/client/gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx
@@ -1,7 +1,7 @@
 /**
  * Top-level Publicize plugin for Gutenberg editor.
  *
- * Hooks into Gutenberg's PluginPrePublishPanel
+ * Hooks into Gutenberg's PluginSidebarMoreMenuItem
  * to display Jetpack's Publicize UI in the pre-
  * publish flow.
  *
@@ -25,13 +25,32 @@ import publicizeStore from './publicize-gutenberg-store';
  */
 const { data } = wp;
 const { registerStore } = data;
-const { PluginPrePublishPanel } = wp.editPost;
+const {
+	PluginPrePublishPanel,
+	PluginSidebar,
+	PluginSidebarMoreMenuItem,
+} = wp.editPost;
 const { registerPlugin } = wp.plugins;
+const { __ } = wp.i18n;
+const { Fragment } = wp.element;
 
 const PluginRender = () => (
-	<PluginPrePublishPanel>
-		<PublicizePanel />
-	</PluginPrePublishPanel>
+	<Fragment>
+		<PluginSidebarMoreMenuItem
+			target="jetpack"
+		>
+			{ __( 'Jetpack' ) }
+		</PluginSidebarMoreMenuItem>
+		<PluginSidebar
+			name="jetpack"
+			title={ __( 'Jetpack' ) }
+		>
+			<PublicizePanel />
+		</PluginSidebar>
+		<PluginPrePublishPanel>
+			<PublicizePanel />
+		</PluginPrePublishPanel>
+	</Fragment>
 );
 
 registerPlugin( 'jetpack-publicize', {

--- a/client/gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx
@@ -19,6 +19,7 @@ import wp from 'wp';
  */
 import PublicizePanel from './publicize-panel';
 import publicizeStore from './publicize-gutenberg-store';
+import JetpackLogo from 'components/jetpack-logo';
 
 /**
  * Module variables
@@ -38,12 +39,14 @@ const PluginRender = () => (
 	<Fragment>
 		<PluginSidebarMoreMenuItem
 			target="jetpack"
+			icon={ <JetpackLogo size={ 24 } /> }
 		>
 			{ __( 'Jetpack' ) }
 		</PluginSidebarMoreMenuItem>
 		<PluginSidebar
 			name="jetpack"
 			title={ __( 'Jetpack' ) }
+			icon={ <JetpackLogo size={ 24 } /> }
 		>
 			<PublicizePanel />
 		</PluginSidebar>


### PR DESCRIPTION
This PR updates the Publicize Gutenberg extension to be rendered as a regular plugin extension in addition to being rendered in the pre-publish flow.

To test:
Follow the instructions in D16808-code.