### PR TITLE
Activity Log: improve upgrade banners

### DIFF
--- a/client/my-sites/stats/activity-log-banner/style.scss
+++ b/client/my-sites/stats/activity-log-banner/style.scss
@@ -97,3 +97,14 @@
 .activity-log-banner__success-happychat {
 	margin-left: 16px;
 }
+
+.activity-log__fader {
+	position: absolute;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	background: linear-gradient( to bottom, rgba( 243, 246, 248, 0.1 ), #f3f6f8 );
+	z-index: 179;
+	height: 40%;
+	pointer-events: none;
+}

--- a/client/my-sites/stats/activity-log-banner/style.scss
+++ b/client/my-sites/stats/activity-log-banner/style.scss
@@ -108,3 +108,7 @@
 	height: 40%;
 	pointer-events: none;
 }
+
+.activity-log-banner__upgrade {
+	margin-top: 1px;
+}

--- a/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
@@ -21,45 +21,43 @@ import {
 class UpgradeBanner extends Component {
 	render() {
 		const { translate, isJetpack } = this.props;
-		return isJetpack ? (
+		return (
 			<div className="activity-log-banner__upgrade">
-				<Banner
-					callToAction={ translate( 'Learn more' ) }
-					dismissPreferenceName="activity-upgrade-banner-jetpack"
-					event="activity_log_upgrade_click_wpcom"
-					feature={ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY }
-					plan={ PLAN_JETPACK_PERSONAL_MONTHLY }
-					title={ translate( "Upgrade to a plan to access your site's complete log" ) }
-					description={ translate(
-						"With your free plan, your site's activity log will only display the last 20 events."
-					) }
-					list={ [
-						translate( 'Full activity for the past 30 days' ),
-						translate( 'Daily automated backups and spam filtering' ),
-						translate( 'Site migration tools and daily automated restores' ),
-						translate( 'Priority email and live chat support' ),
-					] }
-				/>
-			</div>
-		) : (
-			<div className="activity-log-banner__upgrade">
-				<Banner
-					callToAction={ translate( 'Learn more' ) }
-					dismissPreferenceName="activity-upgrade-banner-wpcom"
-					event="activity_log_upgrade_click_wpcom"
-					feature={ FEATURE_JETPACK_ESSENTIAL }
-					plan={ PLAN_PERSONAL }
-					title={ translate( "Upgrade to a plan to access your site's complete log" ) }
-					description={ translate(
-						"With your free plan, your site's activity log will only display the last 20 events."
-					) }
-					list={ [
-						translate( 'Full activity for the past 30 days' ),
-						translate( 'A custom domain name and removal of WordPress.com ads' ),
-						translate( 'Increased storage space' ),
-						translate( 'Priority email and live chat support' ),
-					] }
-				/>
+				{ isJetpack ? (
+					<Banner
+						callToAction={ translate( 'Learn more' ) }
+						event="activity_log_upgrade_click_wpcom"
+						feature={ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY }
+						plan={ PLAN_JETPACK_PERSONAL_MONTHLY }
+						title={ translate( "Upgrade to a plan to access your site's complete log" ) }
+						description={ translate(
+							"With your free plan, your site's activity log will only display the last 20 events. Upgrade and get:"
+						) }
+						list={ [
+							translate( 'Full activity for the past 30 days' ),
+							translate( 'Daily automated backups and spam filtering' ),
+							translate( 'Site migration tools and daily automated restores' ),
+							translate( 'Priority email and live chat support' ),
+						] }
+					/>
+				) : (
+					<Banner
+						callToAction={ translate( 'Learn more' ) }
+						event="activity_log_upgrade_click_wpcom"
+						feature={ FEATURE_JETPACK_ESSENTIAL }
+						plan={ PLAN_PERSONAL }
+						title={ translate( "Upgrade to a plan to access your site's complete log" ) }
+						description={ translate(
+							"With your free plan, your site's activity log will only display the last 20 events. Upgrade and get:"
+						) }
+						list={ [
+							translate( 'Full activity for the past 30 days' ),
+							translate( 'A custom domain name and removal of WordPress.com ads' ),
+							translate( 'Increased storage space' ),
+							translate( 'Priority email and live chat support' ),
+						] }
+					/>
+				) }
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
@@ -29,16 +29,15 @@ class UpgradeBanner extends Component {
 					event="activity_log_upgrade_click_wpcom"
 					feature={ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY }
 					plan={ PLAN_JETPACK_PERSONAL_MONTHLY }
-					title={ translate( "Upgrade to a Personal plan to access your site's full activity" ) }
+					title={ translate( "Upgrade to a plan to access your site's complete log" ) }
 					description={ translate(
-						'Under your current free plan, you can only view the last 20 events on your site. ' +
-							'Upgrade to the Personal plan to unlock:'
+						"With your free plan, your site's activity log will only display the last 20 events."
 					) }
 					list={ [
-						translate( "Your site's full activity for the past 30 days" ),
+						translate( 'Full activity for the past 30 days' ),
 						translate( 'Daily automated backups and spam filtering' ),
-						translate( 'Daily automated site restores and site migration tools' ),
-						translate( 'Priority email & live chat support' ),
+						translate( 'Site migration tools and daily automated restores' ),
+						translate( 'Priority email and live chat support' ),
 					] }
 				/>
 			</div>
@@ -50,16 +49,15 @@ class UpgradeBanner extends Component {
 					event="activity_log_upgrade_click_wpcom"
 					feature={ FEATURE_JETPACK_ESSENTIAL }
 					plan={ PLAN_PERSONAL }
-					title={ translate( "Upgrade to a Personal plan to access your site's full activity" ) }
+					title={ translate( "Upgrade to a plan to access your site's complete log" ) }
 					description={ translate(
-						'Under your current free plan, you can only view the last 20 events on your site. ' +
-							'Upgrade to the Personal plan to unlock:'
+						"With your free plan, your site's activity log will only display the last 20 events."
 					) }
 					list={ [
-						translate( "Your site's full activity for the past 30 days" ),
-						translate( 'Daily automated backups and spam filtering' ),
-						translate( 'Daily automated site restores and site migration tools' ),
-						translate( 'Priority email & live chat support' ),
+						translate( 'Full activity for the past 30 days' ),
+						translate( 'A custom domain name and removal of WordPress.com ads' ),
+						translate( 'Increased storage space' ),
+						translate( 'Priority email and live chat support' ),
 					] }
 				/>
 			</div>

--- a/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
@@ -11,29 +11,56 @@ import { localize } from 'i18n-calypso';
  */
 import { isJetpackSite } from 'state/sites/selectors';
 import Banner from 'components/banner';
-import { PLAN_PERSONAL, FEATURE_JETPACK_ESSENTIAL } from 'lib/plans/constants';
+import {
+	FEATURE_JETPACK_ESSENTIAL,
+	FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_PERSONAL,
+} from 'lib/plans/constants';
 
 class UpgradeBanner extends Component {
 	render() {
 		const { translate, isJetpack } = this.props;
-		if ( isJetpack ) {
-			return null;
-		}
-		return (
+		return isJetpack ? (
 			<div className="activity-log-banner__upgrade">
 				<Banner
-					callToAction={ translate( 'More Details' ) }
-					dismissPreferenceName="activity-upgrade-banner-simple"
+					callToAction={ translate( 'Learn more' ) }
+					dismissPreferenceName="activity-upgrade-banner-jetpack"
+					event="activity_log_upgrade_click_wpcom"
+					feature={ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY }
+					plan={ PLAN_JETPACK_PERSONAL_MONTHLY }
+					title={ translate( "Upgrade to a Personal plan to access your site's full activity" ) }
+					description={ translate(
+						'Under your current free plan, you can only view the last 20 events on your site. ' +
+							'Upgrade to the Personal plan to unlock:'
+					) }
+					list={ [
+						translate( "Your site's full activity for the past 30 days" ),
+						translate( 'Daily automated backups and spam filtering' ),
+						translate( 'Daily automated site restores and site migration tools' ),
+						translate( 'Priority email & live chat support' ),
+					] }
+				/>
+			</div>
+		) : (
+			<div className="activity-log-banner__upgrade">
+				<Banner
+					callToAction={ translate( 'Learn more' ) }
+					dismissPreferenceName="activity-upgrade-banner-wpcom"
 					event="activity_log_upgrade_click_wpcom"
 					feature={ FEATURE_JETPACK_ESSENTIAL }
 					plan={ PLAN_PERSONAL }
-					title={ translate(
-						'Upgrade your site today to unlock many powerful features, including:'
-					) }
+					title={ translate( "Upgrade to a Personal plan to access your site's full activity" ) }
 					description={ translate(
-						'Improve your SEO, protect your site from spammers, ' +
-							'and keep a closer eye on your site with expanded activity logs.'
+						'Under your current free plan, you can only view the last 20 events on your site. ' +
+							'Upgrade to the Personal plan to unlock:'
 					) }
+					list={ [
+						translate( "Your site's full activity for the past 30 days" ),
+						translate( 'Daily automated backups and spam filtering' ),
+						translate( 'Daily automated site restores and site migration tools' ),
+						translate( 'Priority email & live chat support' ),
+					] }
 				/>
 			</div>
 		);

--- a/client/my-sites/stats/activity-log-example/index.jsx
+++ b/client/my-sites/stats/activity-log-example/index.jsx
@@ -12,10 +12,11 @@ import { localize } from 'i18n-calypso';
 import ActivityLogItem from '../activity-log-item';
 import FeatureExample from 'components/feature-example';
 import FormattedHeader from 'components/formatted-header';
+import UpgradeBanner from '../activity-log-banner/upgrade-banner';
 
 class ActivityLogExample extends Component {
 	render() {
-		const { translate, siteId } = this.props;
+		const { translate, siteId, siteIsOnFreePlan } = this.props;
 
 		const exampleContents = [
 			{
@@ -75,6 +76,7 @@ class ActivityLogExample extends Component {
 						/>
 					) ) }
 				</FeatureExample>
+				{ siteIsOnFreePlan && <UpgradeBanner siteId={ siteId } /> }
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -37,7 +37,7 @@ import QueryJetpackPlugins from 'components/data/query-jetpack-plugins/';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import StatsNavigation from 'blocks/stats-navigation';
 import SuccessBanner from '../activity-log-banner/success-banner';
-import UnavailabilityNotice from './unavailability-notice';
+import RewindUnavailabilityNotice from './rewind-unavailability-notice';
 import { adjustMoment, getStartMoment } from './utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
@@ -391,9 +391,7 @@ class ActivityLog extends Component {
 				{ siteIsOnFreePlan && <UpgradeBanner siteId={ siteId } /> }
 				{ config.isEnabled( 'rewind-alerts' ) && siteId && <RewindAlerts siteId={ siteId } /> }
 				{ siteId &&
-					'unavailable' === rewindState.state && (
-						<UnavailabilityNotice siteId={ siteId } siteIsOnFreePlan={ siteIsOnFreePlan } />
-					) }
+					'unavailable' === rewindState.state && <RewindUnavailabilityNotice siteId={ siteId } /> }
 				{ 'awaitingCredentials' === rewindState.state &&
 					! siteIsOnFreePlan && (
 						<Banner

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -436,6 +436,7 @@ class ActivityLog extends Component {
 							total={ logs.length }
 						/>
 						<section className="activity-log__wrapper">
+							{ siteIsOnFreePlan && <div className="activity-log__fader" /> }
 							{ theseLogs.map( log => (
 								<Fragment key={ log.activityId }>
 									{ timePeriod( log ) }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -304,13 +304,13 @@ class ActivityLog extends Component {
 	}
 
 	renderNoLogsContent() {
-		const { filter, logLoadingState, siteId, translate } = this.props;
+		const { filter, logLoadingState, siteId, translate, siteIsOnFreePlan } = this.props;
 
 		const isFilterEmpty = isEqual( emptyFilter, filter );
 
 		if ( logLoadingState === 'success' ) {
 			return isFilterEmpty ? (
-				<ActivityLogExample siteId={ siteId } />
+				<ActivityLogExample siteId={ siteId } siteIsOnFreePlan={ siteIsOnFreePlan } />
 			) : (
 				<EmptyContent title={ translate( 'No matching events found.' ) } />
 			);
@@ -388,7 +388,7 @@ class ActivityLog extends Component {
 				<QuerySiteSettings siteId={ siteId } />
 				<SidebarNavigation />
 				<StatsNavigation selectedItem={ 'activity' } siteId={ siteId } slug={ slug } />
-				{ siteIsOnFreePlan && <UpgradeBanner siteId={ siteId } /> }
+
 				{ config.isEnabled( 'rewind-alerts' ) && siteId && <RewindAlerts siteId={ siteId } /> }
 				{ siteId &&
 					'unavailable' === rewindState.state && <RewindUnavailabilityNotice siteId={ siteId } /> }
@@ -450,6 +450,7 @@ class ActivityLog extends Component {
 								</Fragment>
 							) ) }
 						</section>
+						{ siteIsOnFreePlan && <UpgradeBanner siteId={ siteId } /> }
 						<Pagination
 							className="activity-log__pagination is-bottom-pagination"
 							key="activity-list-pagination-bottom"

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -450,13 +450,6 @@ class ActivityLog extends Component {
 								</Fragment>
 							) ) }
 						</section>
-						{ siteIsOnFreePlan && (
-							<p className="activity-log__limit-notice">
-								{ translate(
-									"Since you're on a free plan, you'll see limited events in your activity."
-								) }
-							</p>
-						) }
 						<Pagination
 							className="activity-log__pagination is-bottom-pagination"
 							key="activity-list-pagination-bottom"

--- a/client/my-sites/stats/activity-log/rewind-unavailability-notice.jsx
+++ b/client/my-sites/stats/activity-log/rewind-unavailability-notice.jsx
@@ -13,55 +13,20 @@ import Banner from 'components/banner';
 import { getSiteAdminUrl } from 'state/sites/selectors';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import getRewindState from 'state/selectors/get-rewind-state';
-import {
-	FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
-	PLAN_PERSONAL,
-	PLAN_JETPACK_PERSONAL,
-} from 'lib/plans/constants';
 
-export const UnavailabilityNotice = ( {
+export const RewindUnavailabilityNotice = ( {
 	adminUrl,
 	reason,
 	rewindState,
 	slug,
 	translate,
 	siteId,
-	siteIsOnFreePlan,
 } ) => {
 	if ( rewindState !== 'unavailable' ) {
 		return null;
 	}
 
 	switch ( reason ) {
-		case 'host_not_supported':
-			if ( siteIsOnFreePlan ) {
-				return (
-					<Banner
-						callToAction={ translate( 'Upgrade' ) }
-						dismissPreferenceName="activity-upgrade-banner-jetpack"
-						event="activity_log_upgrade_click_jetpack"
-						feature={ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY }
-						plan={ PLAN_JETPACK_PERSONAL }
-						title={ translate( 'Stay Safe' ) }
-						description={ translate(
-							'Protect your data with daily off-site backups, ' +
-								'and keep a closer eye on your site with expanded activity logs.'
-						) }
-					/>
-				);
-			}
-			return null;
-		case 'missing_plan':
-			return (
-				<Banner
-					plan={ PLAN_PERSONAL }
-					href={ `/plans/${ slug }` }
-					callToAction={ translate( 'Upgrade' ) }
-					title={ translate(
-						'Upgrade your Jetpack plan to restore your site to events in the past.'
-					) }
-				/>
-			);
 		case 'no_connected_jetpack':
 			return (
 				<Banner
@@ -91,7 +56,7 @@ export const UnavailabilityNotice = ( {
 	}
 };
 
-const mapStateToProps = ( state, { siteId, siteIsOnFreePlan } ) => {
+const mapStateToProps = ( state, { siteId } ) => {
 	const { reason, state: rewindState } = getRewindState( state, siteId );
 
 	return {
@@ -100,8 +65,7 @@ const mapStateToProps = ( state, { siteId, siteIsOnFreePlan } ) => {
 		rewindState,
 		slug: getSelectedSiteSlug( state ),
 		siteId,
-		siteIsOnFreePlan,
 	};
 };
 
-export default connect( mapStateToProps )( localize( UnavailabilityNotice ) );
+export default connect( mapStateToProps )( localize( RewindUnavailabilityNotice ) );


### PR DESCRIPTION
This PR will:
- move the upgrade banners to the bottom of the logs
- remove the limit text from the bottom of the logs
- fade out the logs when an upgrade banner is present

Fixes #26420

( still needs a separate checklist for wordpress.com sites )

## Screen shot WordPress.com copy

<img width="1472" alt="screen shot 2018-08-08 at 12 21 15 pm" src="https://user-images.githubusercontent.com/2694219/43850323-a859baea-9b05-11e8-9649-7a68ff5e6af1.png">

## Screen shot Jetpack copy

<img width="1472" alt="screen shot 2018-08-08 at 12 21 05 pm" src="https://user-images.githubusercontent.com/2694219/43850349-b60865e2-9b05-11e8-8582-fb80e8739c69.png">


## Screen shot small screen

<img width="272" alt="screen shot 2018-08-08 at 12 16 07 pm" src="https://user-images.githubusercontent.com/2694219/43850371-c26b4c8c-9b05-11e8-979d-c688cc809a9a.png">

## Screen shot with an empty log

<img width="1472" alt="screen shot 2018-08-08 at 12 21 34 pm" src="https://user-images.githubusercontent.com/2694219/43850387-cae282fe-9b05-11e8-9b39-a34c852cbf54.png">




