### PR TITLE
Guided tours: add an one-step guided tour for the activity log

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -63,8 +63,14 @@ class StatsNavigation extends Component {
 								const navItem = navItems[ item ];
 								const intervalPath = navItem.showIntervals ? `/${ interval || 'day' }` : '';
 								const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
+								const className = 'stats-navigation__' + item;
 								return (
-									<NavItem key={ item } path={ itemPath } selected={ selectedItem === item }>
+									<NavItem
+										className={ className }
+										key={ item }
+										path={ itemPath }
+										selected={ selectedItem === item }
+									>
 										{ navItem.label }
 									</NavItem>
 								);

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -5,6 +5,8 @@
  */
 
 import { combineTours } from 'layout/guided-tours/config-elements';
+import { ActivityLogJetpackIntroTour } from 'layout/guided-tours/tours/activity-log-jetpack-intro-tour';
+import { ActivityLogWpcomIntroTour } from 'layout/guided-tours/tours/activity-log-wpcom-intro-tour';
 import { MainTour } from 'layout/guided-tours/tours/main-tour';
 import { TutorialSitePreviewTour } from 'layout/guided-tours/tours/tutorial-site-preview-tour';
 import { GDocsIntegrationTour } from 'layout/guided-tours/tours/gdocs-integration-tour';
@@ -27,6 +29,8 @@ import { SimplePaymentsEmailTour } from 'layout/guided-tours/tours/simple-paymen
 import { PluginsBasicTour } from 'layout/guided-tours/tours/plugins-basic-tour';
 
 export default combineTours( {
+	activityLogJetpackIntroTour: ActivityLogJetpackIntroTour,
+	activityLogWpcomIntroTour: ActivityLogWpcomIntroTour,
 	checklistAboutPage: ChecklistAboutPageTour,
 	checklistContactPage: ChecklistContactPageTour,
 	checklistDomainRegister: ChecklistDomainRegisterTour,

--- a/client/layout/guided-tours/tours/activity-log-jetpack-intro-tour.js
+++ b/client/layout/guided-tours/tours/activity-log-jetpack-intro-tour.js
@@ -31,7 +31,7 @@ export const ActivityLogJetpackIntroTour = makeTour(
 				<Fragment>
 					<p>
 						{ translate(
-							"Keep tabs on all your site's activity -- plugin and theme updates, user logins, " +
+							"Keep tabs on all your site's activity — plugin and theme updates, user logins, " +
 								'setting modifications, and more. {{a}}Learn more{{/a}}',
 							{ components: { a: <a href="https://jetpack.com/support/activity-log/" /> } }
 						) }

--- a/client/layout/guided-tours/tours/activity-log-jetpack-intro-tour.js
+++ b/client/layout/guided-tours/tours/activity-log-jetpack-intro-tour.js
@@ -1,0 +1,40 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Fragment } from 'react';
+import { overEvery as and } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { makeTour, Tour, Step, ButtonRow, Quit } from 'layout/guided-tours/config-elements';
+import { isSelectedSiteJetpack, isSelectedSitePlanFree } from 'state/ui/guided-tours/contexts';
+
+export const ActivityLogJetpackIntroTour = makeTour(
+	<Tour
+		name="activityLogJetpackIntroTour"
+		version="20180808"
+		path="/stats/activity/"
+		when={ and( isSelectedSiteJetpack, isSelectedSitePlanFree ) }
+	>
+		<Step name="init" arrow="top-left" target=".stats-navigation__activity" placement="below">
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"Stay informed of all your site's activity ranging from plugin and theme updates " +
+								'to user logins and settings modifications. {{a}}Learn more{{/a}}',
+							{ components: { a: <a href="https://jetpack.com/support/activity-log/" /> } }
+						) }
+					</p>
+					<ButtonRow>
+						<Quit primary>{ translate( 'Got it, thanks!' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+	</Tour>
+);

--- a/client/layout/guided-tours/tours/activity-log-jetpack-intro-tour.js
+++ b/client/layout/guided-tours/tours/activity-log-jetpack-intro-tour.js
@@ -25,8 +25,8 @@ export const ActivityLogJetpackIntroTour = makeTour(
 				<Fragment>
 					<p>
 						{ translate(
-							"Stay informed of all your site's activity ranging from plugin and theme updates " +
-								'to user logins and settings modifications. {{a}}Learn more{{/a}}',
+							"Keep tabs on all your site's activity -- plugin and theme updates, user logins, " +
+								'setting modifications, and more. {{a}}Learn more{{/a}}',
 							{ components: { a: <a href="https://jetpack.com/support/activity-log/" /> } }
 						) }
 					</p>

--- a/client/layout/guided-tours/tours/activity-log-jetpack-intro-tour.js
+++ b/client/layout/guided-tours/tours/activity-log-jetpack-intro-tour.js
@@ -20,7 +20,13 @@ export const ActivityLogJetpackIntroTour = makeTour(
 		path="/stats/activity/"
 		when={ and( isSelectedSiteJetpack, isSelectedSitePlanFree ) }
 	>
-		<Step name="init" arrow="top-left" target=".stats-navigation__activity" placement="below">
+		<Step
+			name="init"
+			arrow="top-left"
+			target=".stats-navigation__activity"
+			placement="below"
+			scrollContainer=".section-nav__mobile-header"
+		>
 			{ ( { translate } ) => (
 				<Fragment>
 					<p>

--- a/client/layout/guided-tours/tours/activity-log-wpcom-intro-tour.js
+++ b/client/layout/guided-tours/tours/activity-log-wpcom-intro-tour.js
@@ -1,0 +1,39 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Fragment } from 'react';
+import { overEvery as and } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { makeTour, Tour, Step, ButtonRow, Quit } from 'layout/guided-tours/config-elements';
+import { isSelectedSiteNotJetpack, isSelectedSitePlanFree } from 'state/ui/guided-tours/contexts';
+
+export const ActivityLogWpcomIntroTour = makeTour(
+	<Tour
+		name="activityLogWpcomIntroTour"
+		version="20180808"
+		path="/stats/activity/"
+		when={ and( isSelectedSiteNotJetpack, isSelectedSitePlanFree ) }
+	>
+		<Step name="init" arrow="top-left" target=".stats-navigation__activity" placement="below">
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"Stay informed of all your site's activity ranging from published or updated posts " +
+								'to published comments and settings modifications.'
+						) }
+					</p>
+					<ButtonRow>
+						<Quit primary>{ translate( 'Got it, thanks!' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+	</Tour>
+);

--- a/client/layout/guided-tours/tours/activity-log-wpcom-intro-tour.js
+++ b/client/layout/guided-tours/tours/activity-log-wpcom-intro-tour.js
@@ -31,7 +31,7 @@ export const ActivityLogWpcomIntroTour = makeTour(
 				<Fragment>
 					<p>
 						{ translate(
-							"Keep tabs on all your site's activity -- new posts, pages, and comments, " +
+							"Keep tabs on all your site's activity — new posts, pages, and comments, " +
 								'setting modifications, and more.'
 						) }
 					</p>

--- a/client/layout/guided-tours/tours/activity-log-wpcom-intro-tour.js
+++ b/client/layout/guided-tours/tours/activity-log-wpcom-intro-tour.js
@@ -25,8 +25,8 @@ export const ActivityLogWpcomIntroTour = makeTour(
 				<Fragment>
 					<p>
 						{ translate(
-							"Stay informed of all your site's activity ranging from published or updated posts " +
-								'to published comments and settings modifications.'
+							"Keep tabs on all your site's activity -- new posts, pages, and comments, " +
+								'setting modifications, and more.'
 						) }
 					</p>
 					<ButtonRow>

--- a/client/layout/guided-tours/tours/activity-log-wpcom-intro-tour.js
+++ b/client/layout/guided-tours/tours/activity-log-wpcom-intro-tour.js
@@ -20,7 +20,13 @@ export const ActivityLogWpcomIntroTour = makeTour(
 		path="/stats/activity/"
 		when={ and( isSelectedSiteNotJetpack, isSelectedSitePlanFree ) }
 	>
-		<Step name="init" arrow="top-left" target=".stats-navigation__activity" placement="below">
+		<Step
+			name="init"
+			arrow="top-left"
+			target=".stats-navigation__activity"
+			placement="below"
+			scrollContainer=".section-nav__mobile-header"
+		>
 			{ ( { translate } ) => (
 				<Fragment>
 					<p>

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -18,7 +18,7 @@ import { getSectionName, getSelectedSite, getSelectedSiteId } from 'state/ui/sel
 import { getLastAction } from 'state/ui/action-log/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
-import { hasDefaultSiteTitle, isCurrentPlanPaid } from 'state/sites/selectors';
+import { hasDefaultSiteTitle, isCurrentPlanPaid, isJetpackSite } from 'state/sites/selectors';
 
 const { getAll: getAllMedia } = MediaStore;
 
@@ -196,6 +196,17 @@ export const isSelectedSitePlanPaid = state => {
 };
 
 /**
+ * Returns true if the selected site has a free plan.
+ *
+ * @param {Object} state Global state tree
+ * @return {Boolean} True if selected site is on a free plan, false otherwise.
+ */
+export const isSelectedSitePlanFree = state => {
+	const siteId = getSelectedSiteId( state );
+	return siteId ? ! isCurrentPlanPaid( state, siteId ) : false;
+};
+
+/**
  * Returns true if user has just pasted something from Google Docs.
  *
  * @param {Object} state Global state tree
@@ -216,4 +227,28 @@ export const hasUserPastedFromGoogleDocs = state => {
 export const canUserEditSettingsOfSelectedSite = state => {
 	const siteId = getSelectedSiteId( state );
 	return siteId ? canCurrentUser( state, siteId, 'manage_options' ) : false;
+};
+
+/**
+ * Returns true if the current site is a jetpack site.
+ * Used in activity log tours.
+ *
+ * @param {Object} state Global state tree
+ * @return {Boolean} True if site is Jetpack, false otherwise.
+ */
+export const isSelectedSiteJetpack = state => {
+	const siteId = getSelectedSiteId( state );
+	return siteId ? isJetpackSite( state, siteId ) : false;
+};
+
+/**
+ * Returns true if the current site is not a jetpack site.
+ * Used in activity log tours.
+ *
+ * @param {Object} state Global state tree
+ * @return {Boolean} True is not Jetpack, false otherwise.
+ */
+export const isSelectedSiteNotJetpack = state => {
+	const siteId = getSelectedSiteId( state );
+	return siteId ? ! isJetpackSite( state, siteId ) : false;
 };


### PR DESCRIPTION
This PR will introduce a simply, one-step guided tour for the activity log.

It fixes #26421 by introducing the activity log with a fun, easily dismissible tour dialogue.

## For Jetpack sites:

<img width="1472" alt="screen shot 2018-08-08 at 12 27 55 pm" src="https://user-images.githubusercontent.com/2694219/43850669-8869d840-9b06-11e8-981b-62077d181514.png">


## For wordpress.com sites:

<img width="1472" alt="screen shot 2018-08-08 at 12 27 38 pm" src="https://user-images.githubusercontent.com/2694219/43850678-8ec71856-9b06-11e8-9f8c-f37c1872de75.png">

To test:

1.  Visit https://calypso.live/?branch=fix/26421-activity-log-guided-tour
2. Ensure the tour popups appear in `stats/activity` for free sites

