### PR TITLE
Signup: Update README

### DIFF
--- a/client/signup/README.md
+++ b/client/signup/README.md
@@ -8,11 +8,11 @@ A Step is a React component that collects data for flows.
 
 ## Creating a new flow
 
-You can define a new flow from `/client/signup/config/flows.js`, by adding a new property to the `flows` object.
+You can define a new flow from `/client/signup/config/flows-pure.js`, by adding a new property to the `flows` object in the `generateFlows` function.
 
 A flow is defined by two properties, `steps` and `destination`:
 
-- `steps` is an array listing the steps in the flow, in the order they should be presented to users. You can see a list of available steps from `/client/signup/config/steps.js`.
+- `steps` is an array listing the steps in the flow, in the order they should be presented to users. You can see a list of available steps in `/client/signup/config/steps-pure.js`.
 - `destination` is a `string` or `function` that determines which page users should be redirected to once they complete the last step in the flow. If provided as a `function`, it is called with all of the dependencies provided in the signup flow, and the user is redirected to whatever it returns.
 
 There are also three optional properties:
@@ -25,7 +25,7 @@ Example:
 account: { steps: [ 'site', 'user' ], destination: '/' }
 ```
 
-Once you've added the flow to `flows.js`, it'll be available for users at `/start/flow-name` where `flow-name` is the key of your flow in `flows`.
+Once you've added the flow to `flows-pure.js`, it'll be available for users at `/start/flow-name` where `flow-name` is the key of your flow in `flows`.
 
 *Note:* flows must include at least one step that creates a user and is able to provide a bearer token. See the `providesToken` property in "Creating a new step".
 
@@ -33,10 +33,10 @@ Once you've added the flow to `flows.js`, it'll be available for users at `/star
 
 Anyone can create steps that flow designers can use in their flows.
 
-You can add a new step to Modular Signup from `/client/signup/config/steps.js`. A step is defined by three properties:
+You can add a new step to Modular Signup from `/client/signup/config/steps-pure.js`. A step is defined by three properties:
 
-- `stepName` is the identifier used to reference a step in `/client/signup/config/flows.js`.
-- (optional) `dependencies`, which specifiy which properties this step needs from other steps in the flow in order to be processed.
+- `stepName` is the identifier used to reference a step in `/client/signup/config/flows-pure.js`.
+- (optional) `dependencies`, which specify which properties this step needs from other steps in the flow in order to be processed.
 - (optional) `providesDependencies` is an array that lets the signup framework know what dependencies the step is expected to provide. If the step does not provide all of these, or if it provides more than it says, an error will be thrown.
 - (optional) `delayApiRequestUntilComplete` is a boolean that, when true, causes the step's `apiRequestFunction` to be called only after the user has submitted every step in the signup flow. This is useful for steps that the user should be able to go back and change at any point in signup.
 
@@ -72,8 +72,7 @@ handleSubmit: function( event ) {
 
 `submitSignupStep` takes the following parameters:
 
-- a `step` object with the following properties:
- - `stepName`, the name of the step you're submitting.
+- a `step` object with the property `stepName`, the name of the step you're submitting.
 - (optional) `errors`, an array of errors that will be attached to the step. If provided, the status of the step will be set to `invalid` in the Progress Store.
 - (optional) `providedDependencies`, an object describing the data added by the step to the Dependency Store. Use this only for data that does not come from API requests.
 - (optional) `processingMessage`, a message that is displayed at the end of the flow while the user waits for the apiRequestFunction to process. For example, "Creating your account" or "Setting up your site", depending on what your step does.
@@ -83,7 +82,7 @@ Some background on `providedDependencies` and the Dependency Store: submitted st
 
 ### apiRequestFunction
 
-If your step requires certain data from other steps before it can submit to the API, you can configure its `apiRequestFunction` in `signup/config/steps.js`. This is a function that is called once the data the step requires is available.
+If your step requires certain data from other steps before it can submit to the API, you can configure its `apiRequestFunction` in `signup/config/steps-pure.js`. This is a function that is called once the data the step requires is available.
 
 ```javascript
 {
@@ -99,7 +98,7 @@ If your step requires certain data from other steps before it can submit to the 
 
 Note that here `apiRequestFunction` calls an API endpoint (`someRequest` in this example), from which they expect to get `userId`. If the API request is successful, `response.userId` is added to the Dependency Store via the callback. This is why you don't need to specify dependencies provided by API requests in `providedDependencies`.
 
-`apiRequestFunction` also receives an object containing any dependencies listed in the `dependencies` property of the step in `/client/signup/config/steps.js`. In the example above, the account step had a `dependencies` property set to `[ 'siteSlug' ]` and received the site slug in the `dependencies` argument of `apiRequestFunction` once it was called.
+`apiRequestFunction` also receives an object containing any dependencies listed in the `dependencies` property of the step in `/client/signup/config/steps-pure.js`. In the example above, the account step had a `dependencies` property set to `[ 'siteSlug' ]` and received the site slug in the `dependencies` argument of `apiRequestFunction` once it was called.
 
 The above example includes an inline function definition, but we should keep the `apiRequestFunction` values in `StepActions` (`signup/config/step-actions.js`) and include them like:
 
@@ -140,12 +139,12 @@ import helloWorldComponent from 'signup/steps/hello-world';
 'hello-world': helloWorldComponent // This is the component to show for this step
 ```
 
-5 - add the new step to `/client/signup/config/steps.js`. Include the component:
+5 - add the new step to `/client/signup/config/steps-pure.js`. Include the component in the object returned from `generateSteps`:
 
 ```javascript
-	'hello-world': {
-		stepName: 'hello-world' // has to match the property name
-	},
+'hello-world': {
+	stepName: 'hello-world' // has to match the property name
+},
 ```
 
 6 - add a new flow to `/client/signup/config/flow.js`:
@@ -157,7 +156,8 @@ hello: { // This will be the slug for the flow, i.e.: wordpress.com/start/hello
 }
 ```
 
-7 - open https://calypso.localhost:3000/start/hello in an incognito window. You should see your new React component as the first step of the flow.
+7 - open https://calypso.localhost:3000/start/hello in an incognito window. You will be redirected to 
+the first step of the flow at `/start/hello/hello-world`, where you should see your new React component.
 
 8 - now we need a way for users to move to the next step of the flow. Let's add a button and a form to the step's `render` method:
 
@@ -191,4 +191,4 @@ handleSubmit = ( event ) => {
 }
 ```
 
-9 - open https://calypso.localhost:3000/start/hello in an incognito window. You should see your updated React component, and when you click the "Get started" button you should be taken to the next step.
+9 - open https://calypso.localhost:3000/start/hello in an incognito window. On opening you should be redirected to the first step showing your updated React component, and when you click the "Get started" button you should be taken to the next step.


### PR DESCRIPTION
The README for the signup framework is slightly out of date.

* Change references to the files and functions where flows and steps are defined. Change `flows.js` and `steps.js` to `flows-pure.js` and `steps-pure.js`.
* The bullet points in the section about the parameters for `submitSignupStep` render in an ambiguous way. Make it clear that the first param is a `step` object with the property `stepName`, and that the other items are other params.
* Mention that on visiting the flow path you are redirected to the path for the first step.