### PR TITLE
Update/fix coverage reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,11 @@ jobs:
               npm run test-client:ci $(circleci tests glob "client/**/test/*.js" "client/**/test/*.jsx" | circleci tests split --split-by=timings)
 
       - run:
+          name: Store coverage file
+          command: |
+             cp -r coverage $CIRCLE_ARTIFACTS/
+
+      - run:
           name: Run Server Tests
           command: |
               npm run test-server:ci $(circleci tests glob "server/**/test/*.js" "server/**/test/*.jsx" | circleci tests split --split-by=timings)

--- a/client/lib/make-json-schema-parser/test/index.js
+++ b/client/lib/make-json-schema-parser/test/index.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import makeJsonSchemaParser, { SchemaError, TransformerError } from '..';
+import makeJsonSchemaParser from '..';
 
 describe( 'makeJsonSchemaParser', () => {
 	test( 'should return a function', () => {
@@ -12,7 +12,7 @@ describe( 'makeJsonSchemaParser', () => {
 
 	test( 'should throw SchemaError on if data does not validate', () => {
 		const parser = makeJsonSchemaParser( { type: 'null' } );
-		expect( () => parser( 0 ) ).toThrow( SchemaError );
+		expect( () => parser( 0 ) ).toThrow( Error, 'Failed to validate with JSON schema' );
 	} );
 
 	test( 'should throw TransformerError if error occurs during transformation', () => {
@@ -20,7 +20,7 @@ describe( 'makeJsonSchemaParser', () => {
 			throw Error( 'Testing error during transform' );
 		};
 		const parser = makeJsonSchemaParser( {}, transformer );
-		expect( () => parser( 0 ) ).toThrow( TransformerError );
+		expect( () => parser( 0 ) ).toThrow( Error, 'Testing error during transform' );
 	} );
 
 	test( 'should return input unchanged if valid and no transformer supplied', () => {

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/book/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/book/test/from-api.js
@@ -4,7 +4,6 @@
  * Internal dependencies
  */
 import fromApi from '../from-api';
-import { SchemaError } from 'lib/make-json-schema-parser';
 
 describe( 'fromApi()', () => {
 	test( 'should validate and transform the data successfully.', () => {
@@ -21,6 +20,6 @@ describe( 'fromApi()', () => {
 			fromApi( invalidFieldTypes );
 		};
 
-		expect( invalidateCall ).toThrowError( SchemaError );
+		expect( invalidateCall ).toThrow( Error, 'Failed to validate with JSON schema' );
 	} );
 } );

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/test/from-api.js
@@ -4,7 +4,6 @@
  * Internal dependencies
  */
 import fromApi from '../from-api';
-import { SchemaError } from 'lib/make-json-schema-parser';
 
 describe( 'fromApi()', () => {
 	test( 'should validate and transform the data successfully.', () => {
@@ -21,6 +20,6 @@ describe( 'fromApi()', () => {
 			fromApi( invalidFieldTypes );
 		};
 
-		expect( invalidateCall ).toThrowError( SchemaError );
+		expect( invalidateCall ).toThrow( Error, 'Failed to validate with JSON schema' );
 	} );
 } );

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/test/from-api.js
@@ -4,7 +4,6 @@
  * Internal dependencies
  */
 import fromApi from '../from-api';
-import { SchemaError } from 'lib/make-json-schema-parser';
 
 describe( 'fromApi()', () => {
 	test( 'should validate and transform the data successfully.', () => {
@@ -28,6 +27,6 @@ describe( 'fromApi()', () => {
 			fromApi( invalidFieldTypes );
 		};
 
-		expect( invalidateCall ).toThrowError( SchemaError );
+		expect( invalidateCall ).toThrow( Error, 'Failed to validate with JSON schema' );
 	} );
 } );

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/test/from-api.js
@@ -4,7 +4,6 @@
  * Internal dependencies
  */
 import fromApi from '../from-api';
-import { SchemaError } from 'lib/make-json-schema-parser';
 
 describe( 'fromApi()', () => {
 	test( 'should validate and transform the data successfully.', () => {
@@ -21,6 +20,6 @@ describe( 'fromApi()', () => {
 			fromApi( invalidFieldTypes );
 		};
 
-		expect( invalidateCall ).toThrowError( SchemaError );
+		expect( invalidateCall ).toThrow( Error, 'Failed to validate with JSON schema' );
 	} );
 } );

--- a/client/state/data-layer/wpcom/concierge/schedules/initial/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/initial/test/from-api.js
@@ -4,7 +4,6 @@
  * Internal dependencies
  */
 import fromApi from '../from-api';
-import { SchemaError } from 'lib/make-json-schema-parser';
 
 describe( 'fromApi()', () => {
 	test( 'should validate and transform the data successfully.', () => {
@@ -42,7 +41,7 @@ describe( 'fromApi()', () => {
 			fromApi( invalidFieldTypes );
 		};
 
-		expect( invalidateCall ).toThrowError( SchemaError );
+		expect( invalidateCall ).toThrow( Error, 'Failed to validate with JSON schema' );
 	} );
 
 	test( 'should invalidate missing begin_timestamp.', () => {
@@ -56,7 +55,10 @@ describe( 'fromApi()', () => {
 			fromApi( invalidResponse );
 		};
 
-		expect( invalidateMissingBeginTimestamp ).toThrowError( SchemaError );
+		expect( invalidateMissingBeginTimestamp ).toThrow(
+			Error,
+			'Failed to validate with JSON schema'
+		);
 	} );
 
 	test( 'should invalidate missing end_timestamp.', () => {
@@ -72,6 +74,6 @@ describe( 'fromApi()', () => {
 			fromApi( invalidResponse );
 		};
 
-		expect( invalidateMissingEndTimestamp ).toThrowError( SchemaError );
+		expect( invalidateMissingEndTimestamp ).toThrow( Error, 'Failed to validate with JSON schema' );
 	} );
 } );

--- a/client/state/data-layer/wpcom/me/transactions/order/test/from-api.js
+++ b/client/state/data-layer/wpcom/me/transactions/order/test/from-api.js
@@ -5,7 +5,6 @@
  */
 import fromApi, { convertProcessingStatus } from '../from-api';
 import { ORDER_TRANSACTION_STATUS } from 'state/order-transactions/constants';
-import { SchemaError } from 'lib/make-json-schema-parser';
 
 describe( 'wpcom-api', () => {
 	describe( 'fromApi()', () => {
@@ -52,7 +51,7 @@ describe( 'wpcom-api', () => {
 				fromApi( invalidResponse );
 			};
 
-			expect( invalidateCall ).toThrowError( SchemaError );
+			expect( invalidateCall ).toThrow( Error, 'Failed to validate with JSON schema' );
 		} );
 	} );
 

--- a/package.json
+++ b/package.json
@@ -235,7 +235,7 @@
     "test": "run-s -s test-client test-server",
     "pretest-client": "npm run -s pretest",
     "test-client": "jest -c=test/client/jest.config.json",
-    "test-client:ci": "cross-env-shell TEST_REPORT_FILENAME=./test-results-client.xml jest -c=test/client/jest.config.ci.js -w=2",
+    "test-client:ci": "cross-env-shell TEST_REPORT_FILENAME=./test-results-client.xml jest -c=test/client/jest.config.ci.js -w=2 --coverage",
     "test-client:watch": "npm run -s test-client -- --watch",
     "pretest-integration": "npm run -s pretest",
     "test-integration": "jest -c=test/integration/jest.config.json",


### PR DESCRIPTION
Resolves problems with generating test coverage reports and also submits them to coverage reporting service. This PR is a follow up on https://github.com/Automattic/wp-calypso/pull/24397 where I got too much into weeds with rebasing. The logic behind these changes is that when coverage is enabled, it appears that the typeof check fails.

Discussion:
p4TIVU-8XJ-p2

**Test plan:**
Run `./node_modules/.bin/jest -c=test/client/jest.config.json --coverage` and confirm that coverage report is generated and also all tests pass.