### PR TITLE
Checklist: Janitorial state work

### DIFF
--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -89,7 +89,7 @@ const mapStateToProps = state => {
 	return {
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
-		taskStatuses: get( getSiteChecklist( state, siteId ), [ 'tasks' ] ),
+		taskStatuses: getSiteChecklist( state, siteId ),
 	};
 };
 

--- a/client/my-sites/stats/checklist-banner/index.jsx
+++ b/client/my-sites/stats/checklist-banner/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';

--- a/client/my-sites/stats/checklist-banner/index.jsx
+++ b/client/my-sites/stats/checklist-banner/index.jsx
@@ -1,5 +1,4 @@
 /** @format */
-
 /**
  * External dependencies
  */
@@ -20,7 +19,7 @@ import Gauge from 'components/gauge';
 import ProgressBar from 'components/progress-bar';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 import getSiteChecklist from 'state/selectors/get-site-checklist';
-import { getSite, getSiteSlug } from 'state/sites/selectors';
+import { getSiteOption, getSiteSlug } from 'state/sites/selectors';
 import { launchTask, tasks } from 'my-sites/checklist/onboardingChecklist';
 import ChecklistShowShare from 'my-sites/checklist/share';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -195,7 +194,7 @@ export class ChecklistBanner extends Component {
 const mapStateToProps = ( state, { siteId } ) => {
 	const taskStatuses = getSiteChecklist( state, siteId );
 	const siteSlug = getSiteSlug( state, siteId );
-	const siteDesignType = get( getSite( state, siteId ), [ 'options', 'design_type' ] );
+	const siteDesignType = getSiteOption( state, siteId, [ 'design_type' ] );
 
 	return {
 		siteDesignType,

--- a/client/my-sites/stats/checklist-banner/index.jsx
+++ b/client/my-sites/stats/checklist-banner/index.jsx
@@ -194,7 +194,7 @@ export class ChecklistBanner extends Component {
 }
 
 const mapStateToProps = ( state, { siteId } ) => {
-	const taskStatuses = get( getSiteChecklist( state, siteId ), [ 'tasks' ] );
+	const taskStatuses = getSiteChecklist( state, siteId );
 	const siteSlug = getSiteSlug( state, siteId );
 	const siteDesignType = get( getSite( state, siteId ), [ 'options', 'design_type' ] );
 

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -4,7 +4,7 @@
  */
 import { combineReducers, keyedReducer } from 'state/utils';
 import { SITE_CHECKLIST_RECEIVE, SITE_CHECKLIST_TASK_UPDATE } from 'state/action-types';
-import { items as itemSchemas } from './schema';
+import schema from './schema';
 
 const taskUpdate = keyedReducer( 'taskId', () => true );
 
@@ -18,7 +18,7 @@ const items = keyedReducer( 'siteId', ( state = {}, action ) => {
 	}
 	return state;
 } );
-items.schema = itemSchemas;
+items.schema = schema;
 
 export default combineReducers( {
 	items,

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -1,36 +1,24 @@
-/**
- * External dependencies
- *
- * @format
- */
-
-import { assign } from 'lodash';
-
+/** @format */
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, keyedReducer } from 'state/utils';
 import { SITE_CHECKLIST_RECEIVE, SITE_CHECKLIST_TASK_UPDATE } from 'state/action-types';
 import { items as itemSchemas } from './schema';
 
-export const items = createReducer(
-	{},
-	{
-		[ SITE_CHECKLIST_RECEIVE ]: ( state, { siteId, checklist } ) => ( {
-			...state,
-			[ siteId ]: checklist,
-		} ),
-		[ SITE_CHECKLIST_TASK_UPDATE ]: ( state, { siteId, taskId } ) => {
-			const siteState = state[ siteId ];
-			const tasks = assign( {}, siteState.tasks, { [ taskId ]: true } );
-			return {
-				...state,
-				[ siteId ]: assign( {}, siteState, { tasks } ),
-			};
-		},
-	},
-	itemSchemas
-);
+const taskUpdate = keyedReducer( 'taskId', () => true );
+
+const items = keyedReducer( 'siteId', ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SITE_CHECKLIST_RECEIVE:
+			return action.checklist;
+
+		case SITE_CHECKLIST_TASK_UPDATE:
+			return taskUpdate( state, action );
+	}
+	return state;
+} );
+items.schema = itemSchemas;
 
 export default combineReducers( {
 	items,

--- a/client/state/checklist/schema.js
+++ b/client/state/checklist/schema.js
@@ -1,5 +1,5 @@
 /** @format */
-export const items = {
+export default {
 	type: 'object',
 	additionalProperties: false,
 	patternProperties: {

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -14,7 +14,7 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { receiveSiteChecklist } from 'state/checklist/actions';
 
-export const fetchChecklist = action =>
+const fetchChecklist = action =>
 	http(
 		{
 			path: `/sites/${ action.siteId }/checklist`,
@@ -27,7 +27,7 @@ export const fetchChecklist = action =>
 		action
 	);
 
-export const receiveChecklistSuccess = ( action, checklist ) =>
+const receiveChecklistSuccess = ( action, checklist ) =>
 	receiveSiteChecklist( action.siteId, checklist );
 
 const dispatchChecklistRequest = dispatchRequestEx( {
@@ -36,7 +36,7 @@ const dispatchChecklistRequest = dispatchRequestEx( {
 	onError: noop,
 } );
 
-export const updateChecklistTask = action =>
+const updateChecklistTask = action =>
 	http(
 		{
 			path: `/sites/${ action.siteId }/checklist`,

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -1,12 +1,6 @@
 /** @format */
 
 /**
- * External dependencies
- */
-
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { SITE_CHECKLIST_REQUEST, SITE_CHECKLIST_TASK_UPDATE } from 'state/action-types';
@@ -33,7 +27,6 @@ const receiveChecklistSuccess = ( action, checklist ) =>
 const dispatchChecklistRequest = dispatchRequestEx( {
 	fetch: fetchChecklist,
 	onSuccess: receiveChecklistSuccess,
-	onError: noop,
 } );
 
 const updateChecklistTask = action =>
@@ -53,7 +46,6 @@ const updateChecklistTask = action =>
 const dispatchChecklistTaskUpdate = dispatchRequestEx( {
 	fetch: updateChecklistTask,
 	onSuccess: receiveChecklistSuccess,
-	onError: noop,
 } );
 
 export default {

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -22,7 +22,7 @@ const fromApi = makeJsonSchemaParser(
 						additionalProperties: false,
 						required: [ 'completed' ],
 						properties: {
-							completed: { type: 'boolean' },
+							completed: { type: [ 'boolean', 'null' ] },
 							url: { type: 'string' },
 						},
 					},

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -3,10 +3,35 @@
 /**
  * Internal dependencies
  */
-import { SITE_CHECKLIST_REQUEST, SITE_CHECKLIST_TASK_UPDATE } from 'state/action-types';
+import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { receiveSiteChecklist } from 'state/checklist/actions';
+import { SITE_CHECKLIST_REQUEST, SITE_CHECKLIST_TASK_UPDATE } from 'state/action-types';
+
+const fromApi = makeJsonSchemaParser(
+	{
+		type: 'object',
+		additionalProperties: true,
+		properties: {
+			tasks: {
+				type: 'object',
+				patternProperties: {
+					'.*': {
+						type: 'object',
+						additionalProperties: false,
+						required: [ 'completed' ],
+						properties: {
+							completed: { type: 'boolean' },
+							url: { type: 'string' },
+						},
+					},
+				},
+			},
+		},
+	},
+	( { tasks } ) => tasks
+);
 
 const fetchChecklist = action =>
 	http(
@@ -26,6 +51,7 @@ const receiveChecklistSuccess = ( action, checklist ) =>
 
 const dispatchChecklistRequest = dispatchRequestEx( {
 	fetch: fetchChecklist,
+	fromApi,
 	onSuccess: receiveChecklistSuccess,
 } );
 
@@ -45,6 +71,7 @@ const updateChecklistTask = action =>
 
 const dispatchChecklistTaskUpdate = dispatchRequestEx( {
 	fetch: updateChecklistTask,
+	fromApi,
 	onSuccess: receiveChecklistSuccess,
 } );
 


### PR DESCRIPTION
Design type sneaks into checklist state and is never used. It's also available from site options:
D8702-code / #20632

- Remove redundant design type from checklist state (via fromApi, data never enters Calypso)
- Modify selectors to access tasks directly (no more `{ tasks: {}, designType: "" }`)
- Leverage `keyedReducer` over `createSelector`.
- Leverage `getSiteOption` selector.

## Testing

1. **In production**, verify that the site design type is redundant data stored in two places https://wordpress.com/?debug
   1. Load checklists into state for your sites 
      ```js
      Object.keys( state.sites.items ).forEach( siteId => dispatch( { type: 'SITE_CHECKLIST_REQUEST', siteId } ) );
      ```
   1. Wait a moment for requests to complete…
   1. Look at these results and verify that the the design type provided as a site option is identical to the design type provided in the checklist except where one is `null` and the other is `""`.
      The following will produce an array of pairs the design type values from both locations filtered by for differences, e.g. `[ [ 'site', 'blog' ], [ 'blog', 'site' ], /* … */ ]`
      ```js
      Object.keys( state.sites.items ).map( k => [ state.sites.items[k].options.design_type, state.checklist.items[k].designType ] ).filter( ( [ siteDesignType, checklistDesignType ] ) => siteDesignType !== checklistDesignType )
      ```
1. This data, in addition to being redundant, appears to be unused from `state.checklist.items[ siteId ].designType`. Verify this is correct.
1. [**On this branch**](https://calypso.live/?debug&branch=update/checklist-redux-janitorial), query checklists from all your sites and ensure there are no schema warnings:      
   ```js
   Object.keys( state.sites.items ).forEach( siteId => dispatch( { type: 'SITE_CHECKLIST_REQUEST', siteId } ) );
   ```
1. Ensure checklists that depend on this state continue to work correctly. Test the completion toggle on simple sites as well as updating on completion for the checklists.
   - Simple sites
     - checklist banner at `/stats/SITE_SLUG`
     - Simple site checklist banner at `/checklist/SITE_SLUG`
   - Jetpack sites: `/plans/my-plan/SITE_SLUG`