### PR TITLE
Remove Spaces From SMS/Auth Code Validation Field Examples

### DIFF
--- a/client/account-recovery/reset-password-sms-form/index.jsx
+++ b/client/account-recovery/reset-password-sms-form/index.jsx
@@ -59,7 +59,7 @@ class ResetPasswordSmsForm extends Component {
 						'Please enter the code you were sent by SMS. ' +
 							'It will look something like {{code}}%(code)s{{/code}}. You may need to wait a few moments before it arrives.',
 						{
-							args: { code: '6342 3423' },
+							args: { code: '63423423' },
 							components: { code: <code /> },
 						}
 					) }

--- a/client/me/constants.js
+++ b/client/me/constants.js
@@ -6,8 +6,8 @@
 import i18n from 'i18n-calypso';
 
 export default {
-	sixDigit2faPlaceholder: i18n.translate( 'e.g. %(example)s', { args: { example: '123 456' } } ),
-	sevenDigit2faPlaceholder: i18n.translate( 'e.g. %(example)s', { args: { example: '1234 567' } } ),
+	sixDigit2faPlaceholder: i18n.translate( 'e.g. %(example)s', { args: { example: '123456' } } ),
+	sevenDigit2faPlaceholder: i18n.translate( 'e.g. %(example)s', { args: { example: '1234567' } } ),
 	eightDigitBackupCodePlaceholder: i18n.translate( 'e.g. %(example)s', {
 		args: { example: '12345678' },
 	} ),


### PR DESCRIPTION
## Specs
Aesthetic change to mirror removing spaces from sent SMS codes. While this is related to changes in D17017 they are not required to test.

## Testing
1. Boot branch in local Calypso
2. Navigate to the [`Login` page](http://calypso.localhost:3000/log-in) with an account with SMS 2FA enabled
3. Verify that the example code has no space, like the example below <img width="666" alt="screen shot 2018-08-08 at 2 40 19 pm" src="https://user-images.githubusercontent.com/2810519/43865990-19435eec-9b19-11e8-90e3-ce2bf7366500.png">
4. Navigate to the [`Account Recovery` page](http://calypso.localhost:3000/me/security/account-recovery)
5. Add a Recovery Phone number ( you may have to delete the existing one )
6. Verify that the prompt for the code does not have a space <img width="990" alt="screen_shot_2018-08-08_at_2_42_14_pm" src="https://user-images.githubusercontent.com/2810519/43866239-dff73108-9b19-11e8-97f8-cc74acbe441a.png">
7. Navigate to the [Two-Step Authentication page](http://calypso.localhost:3000/me/security/two-step)
8. Disable Two-Step Authentication
9. Re-enable Two-Step Authentication and click `Verify via SMS`.
10. Confirm that the example code has no space as seen in the example below 
<img width="764" alt="screen shot 2018-08-08 at 2 50 13 pm" src="https://user-images.githubusercontent.com/2810519/43866522-d68510a8-9b1a-11e8-8d31-bf61394331b0.png">