### PR TITLE
Activity Log: Convert buttons to link

### DIFF
--- a/client/my-sites/stats/activity-log-tasklist/index.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/index.jsx
@@ -319,7 +319,6 @@ class ActivityLogTasklist extends Component {
 		const { translate } = this.props;
 		const numberOfUpdates = itemsToUpdate.length;
 		const queued = this.state.queued;
-
 		return (
 			<Card className="activity-log-tasklist" highlight="warning">
 				<TrackComponentView eventName={ 'calypso_activitylog_tasklist_update_impression' } />
@@ -380,6 +379,7 @@ class ActivityLogTasklist extends Component {
 							updateType={ updateType }
 							linked={ 'core' !== item.type }
 							goToPage={ this.goToPage }
+							siteSlug={ this.props.siteSlug }
 							enqueue={ this.enqueue }
 							dismiss={ this.dismiss }
 							disable={ isItemEnqueued( item.slug, queued ) }

--- a/client/my-sites/stats/activity-log-tasklist/update.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/update.jsx
@@ -10,7 +10,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import ActivityIcon from '../activity-log-item/activity-icon';
-import Button from 'components/button';
 import Card from 'components/card';
 import PopoverMenuItem from 'components/popover/menu-item';
 import SplitButton from 'components/split-button';
@@ -43,8 +42,19 @@ class ActivityLogTaskUpdate extends Component {
 	handleNameClick = () => this.props.goToPage( this.props.slug, this.props.type );
 
 	render() {
-		const { translate, name, version, type, updateType, disable, linked } = this.props;
-
+		const {
+			translate,
+			name,
+			version,
+			type,
+			updateType,
+			disable,
+			linked,
+			slug,
+			siteSlug,
+		} = this.props;
+		const url =
+			'plugin' === type ? `/plugins/${ slug }/${ siteSlug }` : `/theme/${ slug }/${ siteSlug }`;
 		return (
 			<Card className="activity-log-tasklist__task" compact>
 				<ActivityIcon
@@ -55,9 +65,9 @@ class ActivityLogTaskUpdate extends Component {
 					<div>
 						<span className="activity-log-tasklist__update-text">
 							{ linked ? (
-								<Button borderless onClick={ this.handleNameClick }>
+								<a className={ { borderless: true } } href={ url } onClick={ this.handleNameClick }>
 									{ name }
-								</Button>
+								</a>
 							) : (
 								// Add button classes so unlinked names look the same.
 								<span className="activity-log-tasklist__unlinked button is-borderless">

--- a/client/my-sites/stats/activity-log-tasklist/update.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/update.jsx
@@ -65,7 +65,7 @@ class ActivityLogTaskUpdate extends Component {
 					<div>
 						<span className="activity-log-tasklist__update-text">
 							{ linked ? (
-								<a className={ { borderless: true } } href={ url } onClick={ this.handleNameClick }>
+								<a href={ url } onClick={ this.handleNameClick }>
 									{ name }
 								</a>
 							) : (


### PR DESCRIPTION
This PR converts buttons to links so that the styling works as expected.

Tries to solve just some of the #26016 

Before:
<img width="1068" alt="screen shot 2018-08-08 at 3 55 02 pm" src="https://user-images.githubusercontent.com/115071/43868663-83ddbf04-9b23-11e8-81c0-09477ded3d2a.png">



After:
<img width="1079" alt="screen shot 2018-08-08 at 3 54 11 pm" src="https://user-images.githubusercontent.com/115071/43868638-64709ba0-9b23-11e8-8cc5-eb6929f10159.png">


To test. 
Set a plugin and a theme to update. 

Do the links shown in the updates bar work as expected? 