### PR TITLE
Activity Log: Add Activity Media Block

### DIFF
--- a/client/my-sites/stats/activity-log-item/activity-media.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-media.jsx
@@ -9,19 +9,19 @@ import Gridicon from 'gridicons';
 
 export default class ActivityMedia extends PureComponent {
 	static propTypes = {
-		icon: PropTypes.string,
-		screenshot: PropTypes.string,
-		name: PropTypes.string,
+		icon: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.string ] ),
+		thumbnail: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.string ] ),
+		name: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.string ] ),
 	};
 
 	render() {
-		const { icon, screenshot } = this.props;
-		const classes = classNames( 'activity-log-item__activity-media', icon && `is-${ icon }` );
+		const { icon, thumbnail, name } = this.props;
+		const classes = classNames( 'activity-log-item__activity-media', icon && `has-gridicon` );
 
 		return (
 			<div className={ classes }>
-				{ icon && <Gridicon icon={ icon } size={ 24 } /> }
-				{ screenshot && <img src={ screenshot } alt={ name } /> }
+				{ icon && <Gridicon icon={ icon } size={ 48 } /> }
+				{ thumbnail && <img src={ thumbnail } alt={ name } /> }
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log-item/activity-media.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-media.jsx
@@ -23,7 +23,7 @@ export default class ActivityMedia extends PureComponent {
 			icon && `has-gridicon`,
 			className
 		);
-		/* eslint-disable react/jsx-no-target-blank, wpcalypso/jsx-classname-namespace */
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div className={ classes }>
 				{ icon && <Gridicon icon={ icon } size={ 48 } /> }
@@ -31,6 +31,6 @@ export default class ActivityMedia extends PureComponent {
 				{ fullImage && <img src={ fullImage } alt={ name } className="is-full-width" /> }
 			</div>
 		);
-		/* eslint-enable react/jsx-no-target-blank, wpcalypso/jsx-classname-namespace */
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }

--- a/client/my-sites/stats/activity-log-item/activity-media.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-media.jsx
@@ -11,17 +11,24 @@ export default class ActivityMedia extends PureComponent {
 	static propTypes = {
 		icon: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.string ] ),
 		thumbnail: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.string ] ),
+		fullImage: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.string ] ),
 		name: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.string ] ),
+		className: PropTypes.string,
 	};
 
 	render() {
-		const { icon, thumbnail, name } = this.props;
-		const classes = classNames( 'activity-log-item__activity-media', icon && `has-gridicon` );
+		const { icon, thumbnail, fullImage, name, className } = this.props;
+		const classes = classNames(
+			'activity-log-item__activity-media',
+			icon && `has-gridicon`,
+			className
+		);
 
 		return (
 			<div className={ classes }>
 				{ icon && <Gridicon icon={ icon } size={ 48 } /> }
-				{ thumbnail && <img src={ thumbnail } alt={ name } /> }
+				{ thumbnail && <img src={ thumbnail } alt={ name } className="thumbnail" /> }
+				{ fullImage && <img src={ fullImage } alt={ name } className="full-width" /> }
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log-item/activity-media.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-media.jsx
@@ -1,0 +1,28 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import Gridicon from 'gridicons';
+
+export default class ActivityMedia extends PureComponent {
+	static propTypes = {
+		icon: PropTypes.string,
+		screenshot: PropTypes.string,
+		name: PropTypes.string,
+	};
+
+	render() {
+		const { icon, screenshot } = this.props;
+		const classes = classNames( 'activity-log-item__activity-media', icon && `is-${ icon }` );
+
+		return (
+			<div className={ classes }>
+				{ icon && <Gridicon icon={ icon } size={ 24 } /> }
+				{ screenshot && <img src={ screenshot } alt={ name } /> }
+			</div>
+		);
+	}
+}

--- a/client/my-sites/stats/activity-log-item/activity-media.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-media.jsx
@@ -23,13 +23,14 @@ export default class ActivityMedia extends PureComponent {
 			icon && `has-gridicon`,
 			className
 		);
-
+		/* eslint-disable react/jsx-no-target-blank, wpcalypso/jsx-classname-namespace */
 		return (
 			<div className={ classes }>
 				{ icon && <Gridicon icon={ icon } size={ 48 } /> }
-				{ thumbnail && <img src={ thumbnail } alt={ name } className="thumbnail" /> }
-				{ fullImage && <img src={ fullImage } alt={ name } className="full-width" /> }
+				{ thumbnail && <img src={ thumbnail } alt={ name } className="is-thumbnail" /> }
+				{ fullImage && <img src={ fullImage } alt={ name } className="is-full-width" /> }
 			</div>
 		);
+		/* eslint-enable react/jsx-no-target-blank, wpcalypso/jsx-classname-namespace */
 	}
 }

--- a/client/my-sites/stats/activity-log-item/activity-media.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-media.jsx
@@ -4,7 +4,6 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
 export default class ActivityMedia extends PureComponent {
@@ -18,14 +17,9 @@ export default class ActivityMedia extends PureComponent {
 
 	render() {
 		const { icon, thumbnail, fullImage, name, className } = this.props;
-		const classes = classNames(
-			'activity-log-item__activity-media',
-			icon && `has-gridicon`,
-			className
-		);
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<div className={ classes }>
+			<div className={ className }>
 				{ icon && <Gridicon icon={ icon } size={ 48 } /> }
 				{ thumbnail && <img src={ thumbnail } alt={ name } className="is-thumbnail" /> }
 				{ fullImage && <img src={ fullImage } alt={ name } className="is-full-width" /> }

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import ActivityActor from './activity-actor';
+import ActivityMedia from './activity-media';
 import ActivityIcon from './activity-icon';
 import ActivityLogConfirmDialog from '../activity-log-confirm-dialog';
 import Gridicon from 'gridicons';
@@ -55,11 +56,24 @@ class ActivityLogItem extends Component {
 	confirmRewind = () => this.props.confirmRewind( this.props.activity.rewindId );
 
 	renderHeader() {
-		const { activityTitle, actorAvatarUrl, actorName, actorRole, actorType } = this.props.activity;
-
+		const {
+			activityTitle,
+			actorAvatarUrl,
+			actorName,
+			actorRole,
+			actorType,
+			activityMedia,
+		} = this.props.activity;
 		return (
 			<div className="activity-log-item__card-header">
 				<ActivityActor { ...{ actorAvatarUrl, actorName, actorRole, actorType } } />
+				{ activityMedia && (
+					<ActivityMedia
+						icon={ ! activityMedia.available && activityMedia.gridicon }
+						name={ activityMedia.available && activityMedia.name }
+						screenshot={ activityMedia.available && activityMedia.url }
+					/>
+				) }
 				<div className="activity-log-item__description">
 					<div className="activity-log-item__description-content">
 						{ this.getActivityDescription() }

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -71,7 +71,7 @@ class ActivityLogItem extends Component {
 					<ActivityMedia
 						icon={ ! activityMedia.available && activityMedia.gridicon }
 						name={ activityMedia.available && activityMedia.name }
-						screenshot={ activityMedia.available && activityMedia.url }
+						thumbnail={ activityMedia.available && activityMedia.url }
 					/>
 				) }
 				<div className="activity-log-item__description">

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -69,9 +69,11 @@ class ActivityLogItem extends Component {
 				<ActivityActor { ...{ actorAvatarUrl, actorName, actorRole, actorType } } />
 				{ activityMedia && (
 					<ActivityMedia
+						className="is-desktop"
 						icon={ ! activityMedia.available && activityMedia.gridicon }
 						name={ activityMedia.available && activityMedia.name }
-						thumbnail={ activityMedia.available && activityMedia.url }
+						thumbnail={ activityMedia.available && activityMedia.thumbnail_url }
+						fullImage={ false }
 					/>
 				) }
 				<div className="activity-log-item__description">
@@ -80,6 +82,15 @@ class ActivityLogItem extends Component {
 					</div>
 					<div className="activity-log-item__description-summary">{ activityTitle }</div>
 				</div>
+				{ activityMedia && (
+					<ActivityMedia
+						className="is-mobile"
+						icon={ false }
+						name={ activityMedia.available && activityMedia.name }
+						thumbnail={ false }
+						fullImage={ activityMedia.available && activityMedia.medium_url }
+					/>
+				) }
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -64,13 +64,16 @@ class ActivityLogItem extends Component {
 			actorType,
 			activityMedia,
 		} = this.props.activity;
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div className="activity-log-item__card-header">
 				<ActivityActor { ...{ actorAvatarUrl, actorName, actorRole, actorType } } />
 				{ activityMedia && (
 					<ActivityMedia
-						className="is-desktop"
+						className={ classNames( {
+							'activity-log-item__activity-media': true,
+							'is-desktop': true,
+							'has-gridicon': ! activityMedia.available,
+						} ) }
 						icon={ ! activityMedia.available && activityMedia.gridicon }
 						name={ activityMedia.available && activityMedia.name }
 						thumbnail={ activityMedia.available && activityMedia.thumbnail_url }
@@ -85,7 +88,7 @@ class ActivityLogItem extends Component {
 				</div>
 				{ activityMedia && (
 					<ActivityMedia
-						className="is-mobile"
+						className="activity-log-item__activity-media is-mobile"
 						icon={ false }
 						name={ activityMedia.available && activityMedia.name }
 						thumbnail={ false }
@@ -94,7 +97,6 @@ class ActivityLogItem extends Component {
 				) }
 			</div>
 		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 
 	/**

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -64,10 +64,10 @@ class ActivityLogItem extends Component {
 			actorType,
 			activityMedia,
 		} = this.props.activity;
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div className="activity-log-item__card-header">
 				<ActivityActor { ...{ actorAvatarUrl, actorName, actorRole, actorType } } />
-				/* eslint-disable wpcalypso/jsx-classname-namespace */
 				{ activityMedia && (
 					<ActivityMedia
 						className="is-desktop"
@@ -77,14 +77,12 @@ class ActivityLogItem extends Component {
 						fullImage={ false }
 					/>
 				) }
-				/* eslint-enable wpcalypso/jsx-classname-namespace */
 				<div className="activity-log-item__description">
 					<div className="activity-log-item__description-content">
 						{ this.getActivityDescription() }
 					</div>
 					<div className="activity-log-item__description-summary">{ activityTitle }</div>
 				</div>
-				/* eslint-disable wpcalypso/jsx-classname-namespace */
 				{ activityMedia && (
 					<ActivityMedia
 						className="is-mobile"
@@ -93,10 +91,10 @@ class ActivityLogItem extends Component {
 						thumbnail={ false }
 						fullImage={ activityMedia.available && activityMedia.medium_url }
 					/>
-					/* eslint-enable wpcalypso/jsx-classname-namespace */
 				) }
 			</div>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 
 	/**

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -67,6 +67,7 @@ class ActivityLogItem extends Component {
 		return (
 			<div className="activity-log-item__card-header">
 				<ActivityActor { ...{ actorAvatarUrl, actorName, actorRole, actorType } } />
+				/* eslint-disable wpcalypso/jsx-classname-namespace */
 				{ activityMedia && (
 					<ActivityMedia
 						className="is-desktop"
@@ -76,12 +77,14 @@ class ActivityLogItem extends Component {
 						fullImage={ false }
 					/>
 				) }
+				/* eslint-enable wpcalypso/jsx-classname-namespace */
 				<div className="activity-log-item__description">
 					<div className="activity-log-item__description-content">
 						{ this.getActivityDescription() }
 					</div>
 					<div className="activity-log-item__description-summary">{ activityTitle }</div>
 				</div>
+				/* eslint-disable wpcalypso/jsx-classname-namespace */
 				{ activityMedia && (
 					<ActivityMedia
 						className="is-mobile"
@@ -90,6 +93,7 @@ class ActivityLogItem extends Component {
 						thumbnail={ false }
 						fullImage={ activityMedia.available && activityMedia.medium_url }
 					/>
+					/* eslint-enable wpcalypso/jsx-classname-namespace */
 				) }
 			</div>
 		);

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -313,6 +313,15 @@
 	color: $alert-red;
 }
 
+.activity-log-item__activity-media {
+	margin-right: 16px;
+}
+
+.activity-log-item__activity-media.has-gridicon {
+	background-color: $gray-lighten-20;
+	color: $white;
+}
+
 @keyframes fade-out-success {
 	0% {
 		opacity: 1;

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -315,11 +315,47 @@
 
 .activity-log-item__activity-media {
 	margin-right: 16px;
+	color: $white;
 }
 
-.activity-log-item__activity-media.has-gridicon {
+.activity-log-item__activity-media .gridicon {
 	background-color: $gray-lighten-20;
-	color: $white;
+}
+.activity-log-item__activity-media .thumbnail {
+	width: auto;
+	height: auto;
+	max-width: 48px;
+	max-height: 48px;
+}
+
+.activity-log-item__activity-media .full-width {
+	width: 100%;
+	margin-top: 16px;
+}
+
+.activity-log-item__activity-media {
+	&.is-mobile {
+		float: right;
+		margin-right: -50px;
+		display: block;
+		width: 100%;
+		height: auto;
+		min-width: 0;
+	}
+
+	&.is-desktop {
+		display: none;
+	}
+
+	@include breakpoint( '>960px' ) {
+		&.is-mobile {
+			display: none;
+		}
+
+		&.is-desktop {
+			display: inline-block;
+		}
+	}
 }
 
 @keyframes fade-out-success {

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -321,14 +321,14 @@
 .activity-log-item__activity-media .gridicon {
 	background-color: $gray-lighten-20;
 }
-.activity-log-item__activity-media .thumbnail {
+.activity-log-item__activity-media .is-thumbnail {
 	width: auto;
 	height: auto;
 	max-width: 48px;
 	max-height: 48px;
 }
 
-.activity-log-item__activity-media .full-width {
+.activity-log-item__activity-media .is-full-width {
 	width: 100%;
 	margin-top: 16px;
 }

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -64,6 +64,7 @@ export function processItem( item ) {
 			activityTitle: item.summary,
 			activityTs: Date.parse( published ),
 			activityDescription: parseBlock( item.content ),
+			activityMedia: get( item, 'image' ),
 			activityMeta,
 		},
 		item.rewind_id && { rewindId: item.rewind_id },


### PR DESCRIPTION
This PR updates media activities to add thumbnails for them and the appropriate gridicon when thumbnails aren't available.

<img width="1138" alt="screen shot 2018-08-10 at 1 38 32 pm" src="https://user-images.githubusercontent.com/3246867/43972780-8b5f19d6-9ca3-11e8-94e3-25344a339ffb.png">

Mobile: 

<img width="596" alt="screen shot 2018-08-10 at 1 49 03 pm" src="https://user-images.githubusercontent.com/3246867/43973001-30153a32-9ca4-11e8-82d6-69fef8835646.png">

