### PR TITLE
SDK: add Jetpack blocks preset

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -1,0 +1,8 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import 'gutenberg/extensions/tiled-gallery/tiled-gallery.jsx';
+import 'gutenberg/extensions/markdown/jetpack-markdown-block.js';
+import 'gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx';

--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -3,6 +3,6 @@
 /**
  * Internal dependencies
  */
-import 'gutenberg/extensions/tiled-gallery/tiled-gallery.jsx';
 import 'gutenberg/extensions/markdown/jetpack-markdown-block.js';
 import 'gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx';
+import 'gutenberg/extensions/tiled-gallery/tiled-gallery.jsx';

--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -3,6 +3,6 @@
 /**
  * Internal dependencies
  */
-import 'gutenberg/extensions/markdown/jetpack-markdown-block.js';
+import 'gutenberg/extensions/markdown/jetpack-markdown-block.jsx';
 import 'gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx';
 import 'gutenberg/extensions/tiled-gallery/tiled-gallery.jsx';


### PR DESCRIPTION
Bundles all Jetpack Gutenberg extensions into one file.

## Testing

```
npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/presets/jetpack/editor.js
```

You should end up with `client/gutenberg/extensions/presets/jetpack/build/jetpack-editor.js`