### PR TITLE
Gutenberg: Update editor notes block to use @wordpress packages

### DIFF
--- a/client/gutenberg/extensions/editor-notes/index.js
+++ b/client/gutenberg/extensions/editor-notes/index.js
@@ -1,9 +1,10 @@
 /** @format */
+
 /**
  * External dependencies
  */
-import wp from 'wp';
-const { RichText } = wp.editor;
+import { registerBlockType } from '@wordpress/blocks';
+import { RichText } from '@wordpress/editor';
 
 import './style.scss';
 
@@ -34,7 +35,7 @@ const edit = ( { attributes: { notes }, className, isSelected, setAttributes } )
 
 const save = () => null;
 
-wp.blocks.registerBlockType( 'a8c/editor-notes', {
+registerBlockType( 'a8c/editor-notes', {
 	title: "Editor's Notes",
 	icon: 'welcome-write-blog',
 	category: 'common',


### PR DESCRIPTION
This PR updates the Editor Notes block to use @wordpress packages instead of the global `wp` variable. This follows the example of #26549, which did the same for the Tiled Gallery block.

This reduces the build size by a very small bit:

Before:
![](https://cldup.com/H1_RtT2s4O.png)

After:
![](https://cldup.com/T5ySqv06KU.png)

To test:
* Checkout this branch.
* Run `npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/editor-notes/index.js`
* Move the built files to Jetpack.
* Verify the block still works properly.