### PR TITLE
Checklists: Don't redirect disabled Jetpack checklists

### DIFF
--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -50,7 +50,7 @@ class ChecklistMain extends PureComponent {
 	maybeRedirectJetpack( prevProps = {} ) {
 		if (
 			/**
-			 * Only send Jetpack send users to plans if a checklist will be presented. Otherwise,
+			 * Only send Jetpack users to plans if a checklist will be presented. Otherwise,
 			 * let the "Not available" view render.
 			 */
 			config.isEnabled( 'jetpack/checklist' ) &&

--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -49,6 +49,11 @@ class ChecklistMain extends PureComponent {
 	 */
 	maybeRedirectJetpack( prevProps = {} ) {
 		if (
+			/**
+			 * Only send Jetpack send users to plans if a checklist will be presented. Otherwise,
+			 * let the "Not available" view render.
+			 */
+			config.isEnabled( 'jetpack/checklist' ) &&
 			this.props.siteSlug &&
 			false === this.props.isAtomic &&
 			this.props.isJetpack &&


### PR DESCRIPTION
#26042 added redirection for Jetpack checklists. However, if a user lands on /checklist for a Jetpack site and the checklist is enabled, it doesn't make much sense to send them /plans/my-plan

Don't redirect Jetpack sites to plans if the Jetpack checklist is disabled.

## Testing
1. Disable `jetpack/checklist`
1. Visit `/checklist/SITE_SLUG` for a Jetpack site
1. You should see the disabled view.