### PR TITLE
Gutenberg: Update Hello Dolly block to use @wordpress packages

### DIFF
--- a/client/gutenberg/extensions/hello-dolly/hello-block.js
+++ b/client/gutenberg/extensions/hello-dolly/hello-block.js
@@ -1,10 +1,11 @@
 /** @format */
+
 /**
  * External dependencies
  */
-import wp from 'wp';
+import { registerBlockType } from '@wordpress/blocks';
 
-wp.blocks.registerBlockType( 'calypsoberg/hello-dolly', {
+registerBlockType( 'calypsoberg/hello-dolly', {
 	title: 'Hello Dolly',
 	icon: 'format-audio',
 	category: 'layout',


### PR DESCRIPTION
This PR updates the Hello Dolly block to use @wordpress packages instead of the global `wp` variable. This follows the example of #26549, which did the same for the Tiled Gallery block.

To test:
* Checkout this branch.
* Run `npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/hello-dolly/hello-block.js`
* Verify the block still builds and works properly.