### PR TITLE
Gutenberg: Update Markdown block to use @wordpress packages

### DIFF
--- a/client/gutenberg/extensions/markdown/components/markdown-renderer.jsx
+++ b/client/gutenberg/extensions/markdown/components/markdown-renderer.jsx
@@ -1,16 +1,14 @@
+/** @format */
+
 /**
  * External dependencies
  */
-import React from 'react';
+import { RawHTML } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import markdownConverter from '../utils/markdown-converter';
-
-const {
-	RawHTML
-} = window.wp.element;
 
 const MarkdownRenderer = function( props ) {
 	const { className, source } = props;

--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block-editor.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block-editor.jsx
@@ -1,34 +1,26 @@
+/** @format */
+
 /**
  * External dependencies
  */
-import React from 'react';
 import classNames from 'classnames';
+import { __ } from '@wordpress/i18n';
+import { BlockControls, PlainText } from '@wordpress/editor';
+import { ButtonGroup } from '@wordpress/components';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import MarkdownRenderer from './components/markdown-renderer';
 
-const { __ } = window.wp.i18n;
-
-const {
-	ButtonGroup
-} = window.wp.components;
-
-const {
-	BlockControls,
-	PlainText
-} = window.wp.editor;
-
-const {
-	Component
-} = window.wp.element;
-
+/**
+ * Module variables
+ */
 const PANEL_EDITOR = 'editor';
 const PANEL_PREVIEW = 'preview';
 
 class JetpackMarkdownBlockEditor extends Component {
-
 	constructor() {
 		super( ...arguments );
 
@@ -38,7 +30,7 @@ class JetpackMarkdownBlockEditor extends Component {
 		this.isEmpty = this.isEmpty.bind( this );
 
 		this.state = {
-			activePanel: PANEL_EDITOR
+			activePanel: PANEL_EDITOR,
 		};
 	}
 
@@ -76,18 +68,17 @@ class JetpackMarkdownBlockEditor extends Component {
 
 			switch ( this.state.activePanel ) {
 				case PANEL_EDITOR:
-					return <PlainText
-						className={ `${ className }__editor` }
-						onChange={ this.updateSource }
-						aria-label={ __( 'Markdown' ) }
-						value={ attributes.source }
-					/>;
+					return (
+						<PlainText
+							className={ `${ className }__editor` }
+							onChange={ this.updateSource }
+							aria-label={ __( 'Markdown' ) }
+							value={ attributes.source }
+						/>
+					);
 
 				case PANEL_PREVIEW:
-					return <MarkdownRenderer
-						className={ `${ className }__preview` }
-						source={ source }
-					/>;
+					return <MarkdownRenderer className={ `${ className }__preview` } source={ source } />;
 			}
 		};
 
@@ -96,13 +87,13 @@ class JetpackMarkdownBlockEditor extends Component {
 			return classNames( {
 				'components-tab-button': true,
 				'is-active': this.state.activePanel === panelName,
-				[ `${ className }__${ panelName }-button` ]: true
+				[ `${ className }__${ panelName }-button` ]: true,
 			} );
 		};
 
 		return (
 			<div>
-				<BlockControls >
+				<BlockControls>
 					<ButtonGroup>
 						<button
 							className={ classesForPanel.call( this, 'editor' ) }
@@ -118,10 +109,10 @@ class JetpackMarkdownBlockEditor extends Component {
 						</button>
 					</ButtonGroup>
 				</BlockControls>
-				{ ( editorOrPreviewPanel.call( this ) ) }
+				{ editorOrPreviewPanel.call( this ) }
 			</div>
 		);
 	}
-
 }
+
 export default JetpackMarkdownBlockEditor;

--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block-save.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block-save.jsx
@@ -1,7 +1,4 @@
-/**
- * External dependencies
- */
-import React from 'react';
+/** @format */
 
 /**
  * Internal dependencies
@@ -9,10 +6,7 @@ import React from 'react';
 import MarkdownPreview from './components/markdown-renderer';
 
 function JetpackMarkdownBlockSave( { attributes, className } ) {
-	return <MarkdownPreview
-		className={ `${ className }-renderer` }
-		source={ attributes.source }
-	/>;
+	return <MarkdownPreview className={ `${ className }-renderer` } source={ attributes.source } />;
 }
 
 export default JetpackMarkdownBlockSave;

--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
@@ -1,7 +1,10 @@
+/** @format */
+
 /**
  * External dependencies
  */
-import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -9,28 +12,18 @@ import React from 'react';
 import JetpackMarkdownBlockEditor from './jetpack-markdown-block-editor';
 import JetpackMarkdownBlockSave from './jetpack-markdown-block-save';
 
-const { __ } = window.wp.i18n;
-
-const {
-	registerBlockType,
-} = window.wp.blocks;
-
 registerBlockType( 'jetpack/markdown-block', {
-
 	title: __( 'Markdown' ),
 
 	description: [
 		__( 'Write your content in plain-text Markdown syntax.' ),
-		(
 		<p>
-			<a href="https://en.support.wordpress.com/markdown-quick-reference/">
-			Support Reference
-			</a>
-		</p>
-		)
+			<a href="https://en.support.wordpress.com/markdown-quick-reference/">Support Reference</a>
+		</p>,
 	],
 
-	icon: <svg
+	icon: (
+		<svg
 			xmlns="http://www.w3.org/2000/svg"
 			class="dashicon"
 			width="20"
@@ -38,27 +31,19 @@ registerBlockType( 'jetpack/markdown-block', {
 			viewBox="0 0 208 128"
 			stroke="currentColor"
 		>
-			<rect
-				width="198"
-				height="118"
-				x="5"
-				y="5"
-				ry="10"
-				stroke-width="10"
-				fill="none"
-			/>
+			<rect width="198" height="118" x="5" y="5" ry="10" stroke-width="10" fill="none" />
 			<path d="M30 98v-68h20l20 25 20-25h20v68h-20v-39l-20 25-20-25v39zM155 98l-30-33h20v-35h20v35h20z" />
-		</svg>,
+		</svg>
+	),
 
 	category: 'formatting',
 
 	attributes: {
 		//The Markdown source is saved in the block content comments delimiter
-		source: { type: 'string' }
+		source: { type: 'string' },
 	},
 
 	edit: JetpackMarkdownBlockEditor,
 
 	save: JetpackMarkdownBlockSave,
-
 } );

--- a/client/gutenberg/extensions/markdown/utils/markdown-converter.js
+++ b/client/gutenberg/extensions/markdown/utils/markdown-converter.js
@@ -1,3 +1,5 @@
+/** @format */
+
 /**
  * External dependencies
  */
@@ -6,11 +8,9 @@ import MarkdownIt from 'markdown-it';
 const markdownItFull = new MarkdownIt();
 
 const MarkdownConverter = {
-
 	render( source ) {
 		return markdownItFull.render( source );
-	}
-
+	},
 };
 
 export default MarkdownConverter;


### PR DESCRIPTION
This PR updates the Markdown block to use @wordpress packages instead of the global `wp` variable. This follows the example of #26549, which did the same for the Tiled Gallery block.

This reduces the build size by a bit:

Before:
![](https://cldup.com/YJxGB5xw0y.png)

After:
![](https://cldup.com/8l6-4VS2zk.png)

I've also added all the files under Prettier control, so that has made the diff a bit larger.

To test:
* Checkout this branch.
* Run a Jetpack site and checkout https://github.com/Automattic/jetpack/pull/9954/files on it.
* Run `npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx --output-dir=/DIR_TO_JETPACK/jetpack/modules/markdown/ --output-editor-file=block`
* Verify the Markdown block still works properly in the wp-admin.