### PR TITLE
Prevent scrolling the background when a modal is open

### DIFF
--- a/client/components/dialog/style.scss
+++ b/client/components/dialog/style.scss
@@ -136,3 +136,7 @@
 .dialog__action-buttons .is-left-aligned {
 	float: left;
 }
+
+.ReactModal__Body--open {
+	overflow: hidden;
+}


### PR DESCRIPTION
To test:
* Go to any page on Calypso that lets you open a modal. For example, go to your site's `Settings` and change the site language.
* Try to scroll using your mouse/trackpad while having your mouse pointer outside of the modal.

What happened before:
* The background page scrolls.

What should happen:
* The user can't interact with the background page in any way, not even scrolling.

This PR blocks background scrolling in **all**  the modals in Calypso. I think that's the most sensible behaviour, since a modal dialog should prevent the user from interacting with the background entirely, and scrolling the background can be distracting. Can you folks think on any scenario when we would want the background to be scrollable?