### PR TITLE
Activity Log: add tracks to item clicks

### DIFF
--- a/client/components/notes-formatted-block/index.jsx
+++ b/client/components/notes-formatted-block/index.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { startsWith } from 'lodash';
 
-export const FormattedBlock = ( { content = {} } ) => {
+export const FormattedBlock = ( { content = {}, onClick = null } ) => {
 	const {
 		siteId,
 		children,
@@ -15,6 +15,7 @@ export const FormattedBlock = ( { content = {} } ) => {
 		postId,
 		text = null,
 		type,
+		section,
 		siteSlug,
 		pluginSlug,
 		themeSlug,
@@ -30,7 +31,7 @@ export const FormattedBlock = ( { content = {} } ) => {
 	}
 
 	const descent = children.map( ( child, key ) => (
-		<FormattedBlock key={ key } content={ child } />
+		<FormattedBlock key={ key } content={ child } onClick={ onClick } />
 	) );
 
 	switch ( type ) {
@@ -39,7 +40,15 @@ export const FormattedBlock = ( { content = {} } ) => {
 			const url = startsWith( content.url, 'https://wordpress.com/' )
 				? content.url.substr( 21 )
 				: content.url;
-			return <a href={ url }>{ descent }</a>;
+			return (
+				<a
+					href={ url }
+					onClick={ onClick }
+					data-section={ onClick && section ? section : undefined }
+				>
+					{ descent }
+				</a>
+			);
 
 		case 'b':
 			return <strong>{ descent }</strong>;
@@ -69,7 +78,15 @@ export const FormattedBlock = ( { content = {} } ) => {
 			);
 
 		case 'plugin':
-			return <a href={ `/plugins/${ pluginSlug }/${ siteSlug }` }>{ descent }</a>;
+			return (
+				<a
+					href={ `/plugins/${ pluginSlug }/${ siteSlug }` }
+					onClick={ onClick }
+					data-section="plugins"
+				>
+					{ descent }
+				</a>
+			);
 
 		case 'post':
 			return isTrashed ? (
@@ -89,11 +106,25 @@ export const FormattedBlock = ( { content = {} } ) => {
 			}
 
 			if ( /wordpress\.com/.test( themeUri ) ) {
-				return <a href={ `/theme/${ themeSlug }/${ siteSlug }` }>{ descent }</a>;
+				return (
+					<a
+						href={ `/theme/${ themeSlug }/${ siteSlug }` }
+						onClick={ onClick }
+						data-section={ onClick ? 'themes' : undefined }
+					>
+						{ descent }
+					</a>
+				);
 			}
 
 			return (
-				<a href={ themeUri } target="_blank" rel="noopener noreferrer">
+				<a
+					href={ themeUri }
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={ onClick }
+					data-section={ onClick ? 'themes-external' : undefined }
+				>
 					{ descent }
 				</a>
 			);

--- a/client/components/notes-formatted-block/index.jsx
+++ b/client/components/notes-formatted-block/index.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { startsWith } from 'lodash';
 
-export const FormattedBlock = ( { content = {}, onClick = null } ) => {
+export const FormattedBlock = ( { content = {}, onClick = null, meta = {} } ) => {
 	const {
 		siteId,
 		children,
@@ -15,12 +15,12 @@ export const FormattedBlock = ( { content = {}, onClick = null } ) => {
 		postId,
 		text = null,
 		type,
-		section,
 		siteSlug,
 		pluginSlug,
 		themeSlug,
 		themeUri,
 	} = content;
+	const { activity } = meta;
 
 	if ( 'string' === typeof content ) {
 		return content;
@@ -41,11 +41,7 @@ export const FormattedBlock = ( { content = {}, onClick = null } ) => {
 				? content.url.substr( 21 )
 				: content.url;
 			return (
-				<a
-					href={ url }
-					onClick={ onClick }
-					data-section={ onClick && section ? section : undefined }
-				>
+				<a href={ url } onClick={ onClick } data-activity={ activity }>
 					{ descent }
 				</a>
 			);
@@ -72,7 +68,7 @@ export const FormattedBlock = ( { content = {}, onClick = null } ) => {
 
 		case 'person':
 			return (
-				<a href={ `/people/edit/${ siteId }/${ name }` }>
+				<a href={ `/people/edit/${ siteId }/${ name }` } data-activity={ activity }>
 					<strong>{ descent }</strong>
 				</a>
 			);
@@ -82,7 +78,7 @@ export const FormattedBlock = ( { content = {}, onClick = null } ) => {
 				<a
 					href={ `/plugins/${ pluginSlug }/${ siteSlug }` }
 					onClick={ onClick }
-					data-section="plugins"
+					data-activity={ activity }
 				>
 					{ descent }
 				</a>
@@ -110,7 +106,7 @@ export const FormattedBlock = ( { content = {}, onClick = null } ) => {
 					<a
 						href={ `/theme/${ themeSlug }/${ siteSlug }` }
 						onClick={ onClick }
-						data-section={ onClick ? 'themes' : undefined }
+						data-activity={ activity }
 					>
 						{ descent }
 					</a>
@@ -123,7 +119,7 @@ export const FormattedBlock = ( { content = {}, onClick = null } ) => {
 					target="_blank"
 					rel="noopener noreferrer"
 					onClick={ onClick }
-					data-section={ onClick ? 'themes-external' : undefined }
+					data-activity={ activity }
 				>
 					{ descent }
 				</a>

--- a/client/components/notes-formatted-block/index.jsx
+++ b/client/components/notes-formatted-block/index.jsx
@@ -19,6 +19,8 @@ export const FormattedBlock = ( { content = {}, onClick = null, meta = {} } ) =>
 		pluginSlug,
 		themeSlug,
 		themeUri,
+		intent,
+		section,
 	} = content;
 	const { activity } = meta;
 
@@ -31,7 +33,7 @@ export const FormattedBlock = ( { content = {}, onClick = null, meta = {} } ) =>
 	}
 
 	const descent = children.map( ( child, key ) => (
-		<FormattedBlock key={ key } content={ child } onClick={ onClick } />
+		<FormattedBlock key={ key } content={ child } onClick={ onClick } meta={ meta } />
 	) );
 
 	switch ( type ) {
@@ -41,7 +43,13 @@ export const FormattedBlock = ( { content = {}, onClick = null, meta = {} } ) =>
 				? content.url.substr( 21 )
 				: content.url;
 			return (
-				<a href={ url } onClick={ onClick } data-activity={ activity }>
+				<a
+					href={ url }
+					onClick={ onClick }
+					data-activity={ activity }
+					data-section={ section }
+					data-intent={ intent }
+				>
 					{ descent }
 				</a>
 			);
@@ -68,7 +76,13 @@ export const FormattedBlock = ( { content = {}, onClick = null, meta = {} } ) =>
 
 		case 'person':
 			return (
-				<a href={ `/people/edit/${ siteId }/${ name }` } data-activity={ activity }>
+				<a
+					href={ `/people/edit/${ siteId }/${ name }` }
+					onClick={ onClick }
+					data-activity={ activity }
+					data-section={ section }
+					data-intent={ intent }
+				>
 					<strong>{ descent }</strong>
 				</a>
 			);
@@ -79,6 +93,8 @@ export const FormattedBlock = ( { content = {}, onClick = null, meta = {} } ) =>
 					href={ `/plugins/${ pluginSlug }/${ siteSlug }` }
 					onClick={ onClick }
 					data-activity={ activity }
+					data-section={ section }
+					data-intent={ intent }
 				>
 					{ descent }
 				</a>
@@ -107,6 +123,8 @@ export const FormattedBlock = ( { content = {}, onClick = null, meta = {} } ) =>
 						href={ `/theme/${ themeSlug }/${ siteSlug }` }
 						onClick={ onClick }
 						data-activity={ activity }
+						data-section={ section }
+						data-intent={ intent }
 					>
 						{ descent }
 					</a>
@@ -120,6 +138,8 @@ export const FormattedBlock = ( { content = {}, onClick = null, meta = {} } ) =>
 					rel="noopener noreferrer"
 					onClick={ onClick }
 					data-activity={ activity }
+					data-section={ section }
+					data-intent={ intent }
 				>
 					{ descent }
 				</a>

--- a/client/components/notes-formatted-block/index.jsx
+++ b/client/components/notes-formatted-block/index.jsx
@@ -19,10 +19,8 @@ export const FormattedBlock = ( { content = {}, onClick = null, meta = {} } ) =>
 		pluginSlug,
 		themeSlug,
 		themeUri,
-		intent,
-		section,
 	} = content;
-	const { activity } = meta;
+	const { activity, intent, section } = meta;
 
 	if ( 'string' === typeof content ) {
 		return content;
@@ -80,8 +78,8 @@ export const FormattedBlock = ( { content = {}, onClick = null, meta = {} } ) =>
 					href={ `/people/edit/${ siteId }/${ name }` }
 					onClick={ onClick }
 					data-activity={ activity }
-					data-section={ section }
-					data-intent={ intent }
+					data-section="users"
+					data-intent="edit"
 				>
 					<strong>{ descent }</strong>
 				</a>
@@ -93,8 +91,8 @@ export const FormattedBlock = ( { content = {}, onClick = null, meta = {} } ) =>
 					href={ `/plugins/${ pluginSlug }/${ siteSlug }` }
 					onClick={ onClick }
 					data-activity={ activity }
-					data-section={ section }
-					data-intent={ intent }
+					data-section="plugins"
+					data-intent="view"
 				>
 					{ descent }
 				</a>
@@ -123,8 +121,8 @@ export const FormattedBlock = ( { content = {}, onClick = null, meta = {} } ) =>
 						href={ `/theme/${ themeSlug }/${ siteSlug }` }
 						onClick={ onClick }
 						data-activity={ activity }
-						data-section={ section }
-						data-intent={ intent }
+						data-section="themes"
+						data-intent="view"
 					>
 						{ descent }
 					</a>
@@ -138,8 +136,8 @@ export const FormattedBlock = ( { content = {}, onClick = null, meta = {} } ) =>
 					rel="noopener noreferrer"
 					onClick={ onClick }
 					data-activity={ activity }
-					data-section={ section }
-					data-intent={ intent }
+					data-section="themes"
+					data-intent="view"
 				>
 					{ descent }
 				</a>

--- a/client/lib/notifications/note-block-parser.js
+++ b/client/lib/notifications/note-block-parser.js
@@ -102,34 +102,45 @@ const commentNode = ( { id: commentId, post_id: postId, site_id: siteId } ) => (
 	siteId,
 } );
 
-const linkNode = ( { url } ) => ( { type: 'link', url } );
+const linkNode = ( { url, intent, section } ) => ( { type: 'link', url, intent, section } );
 
 const postNode = ( { id: postId, site_id: siteId } ) => ( { type: 'post', postId, siteId } );
 
-const siteNode = ( { id: siteId } ) => ( { type: 'site', siteId } );
+const siteNode = ( { id: siteId, intent, section } ) => ( {
+	type: 'site',
+	siteId,
+	intent,
+	section,
+} );
 
 const typedNode = ( { type } ) => ( { type } );
 
-const userNode = ( { id: userId, name, site_id: siteId } ) => ( {
+const userNode = ( { id: userId, name, site_id: siteId, intent, section } ) => ( {
 	type: 'person',
 	name,
 	siteId,
 	userId,
+	intent,
+	section,
 } );
 
-const pluginNode = ( { site_slug, slug, version } ) => ( {
+const pluginNode = ( { site_slug, slug, version, intent, section } ) => ( {
 	type: 'plugin',
 	siteSlug: site_slug,
 	pluginSlug: slug,
 	version,
+	intent,
+	section,
 } );
 
-const themeNode = ( { site_slug, slug, version, uri } ) => ( {
+const themeNode = ( { site_slug, slug, version, uri, intent, section } ) => ( {
 	type: 'theme',
 	siteSlug: site_slug,
 	themeSlug: slug,
 	themeUri: uri,
 	version,
+	intent,
+	section,
 } );
 
 const inferNode = range => {

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -138,14 +138,17 @@ class ActivityLogItem extends Component {
 		/* There is no great way to generate a more valid React key here
 		 * but the index is probably sufficient because these sub-items
 		 * shouldn't be changing. */
-		return activityDescription.map( ( part, i ) => (
-			<FormattedBlock
-				key={ i }
-				content={ part }
-				onClick={ this.trackContentLinkClick }
-				meta={ { activity: activityName } }
-			/>
-		) );
+		return activityDescription.map( ( part, i ) => {
+			const { intent, section } = part;
+			return (
+				<FormattedBlock
+					key={ i }
+					content={ part }
+					onClick={ this.trackContentLinkClick }
+					meta={ { activity: activityName, intent, section } }
+				/>
+			);
+		} );
 	}
 
 	renderItemAction() {

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -16,6 +16,7 @@ import ActivityActor from './activity-actor';
 import ActivityMedia from './activity-media';
 import ActivityIcon from './activity-icon';
 import ActivityLogConfirmDialog from '../activity-log-confirm-dialog';
+import analytics from 'lib/analytics';
 import Gridicon from 'gridicons';
 import HappychatButton from 'components/happychat/button';
 import Button from 'components/button';
@@ -54,6 +55,10 @@ class ActivityLogItem extends Component {
 	confirmBackup = () => this.props.confirmBackup( this.props.activity.rewindId );
 
 	confirmRewind = () => this.props.confirmRewind( this.props.activity.rewindId );
+
+	trackContentLinkClick = ( { target: { dataset } } ) => {
+		analytics.tracks.recordEvent( 'calypso_activitylog_item_click', dataset );
+	};
 
 	renderHeader() {
 		const {
@@ -128,7 +133,9 @@ class ActivityLogItem extends Component {
 		/* There is no great way to generate a more valid React key here
 		 * but the index is probably sufficient because these sub-items
 		 * shouldn't be changing. */
-		return activityDescription.map( ( part, i ) => <FormattedBlock key={ i } content={ part } /> );
+		return activityDescription.map( ( part, i ) => (
+			<FormattedBlock key={ i } content={ part } onClick={ this.trackContentLinkClick } />
+		) );
 	}
 
 	renderItemAction() {

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -58,10 +58,10 @@ class ActivityLogItem extends Component {
 
 	trackContentLinkClick = ( {
 		target: {
-			dataset: { activity },
+			dataset: { activity, section, intent },
 		},
 	} ) => {
-		const params = { activity };
+		const params = { activity, section, intent };
 		analytics.tracks.recordEvent( 'calypso_activitylog_item_click', params );
 	};
 

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -56,8 +56,13 @@ class ActivityLogItem extends Component {
 
 	confirmRewind = () => this.props.confirmRewind( this.props.activity.rewindId );
 
-	trackContentLinkClick = ( { target: { dataset } } ) => {
-		analytics.tracks.recordEvent( 'calypso_activitylog_item_click', dataset );
+	trackContentLinkClick = ( {
+		target: {
+			dataset: { activity },
+		},
+	} ) => {
+		const params = { activity };
+		analytics.tracks.recordEvent( 'calypso_activitylog_item_click', params );
 	};
 
 	renderHeader() {
@@ -134,7 +139,12 @@ class ActivityLogItem extends Component {
 		 * but the index is probably sufficient because these sub-items
 		 * shouldn't be changing. */
 		return activityDescription.map( ( part, i ) => (
-			<FormattedBlock key={ i } content={ part } onClick={ this.trackContentLinkClick } />
+			<FormattedBlock
+				key={ i }
+				content={ part }
+				onClick={ this.trackContentLinkClick }
+				meta={ { activity: activityName } }
+			/>
 		) );
 	}
 


### PR DESCRIPTION
This PR will allow us to add tracking details ( onClick, and extra props ) to links generated by the notes block parser, and thus, track clicks from activity log items.

see p9rlnk-sC-p2

To test:

- [Visit this branch on Calypso.live](https://calypso.live/?branch=add/tracking-links-activity-log-items)
- in your JS console, run `localStorage.setItem( 'debug', 'calypso:analytics:tracks' );` and refresh the page so you can monitor tracks events in the console
- Go to the Stats -> Activity page for one of sites
- Click on links with the logs, and ensure the expected event is tracked:

<img width="1360" alt="screen shot 2018-08-24 at 12 09 18 pm" src="https://user-images.githubusercontent.com/2694219/44595369-be091780-a796-11e8-9e7c-734655d3d6c5.png">

You should expect to see something like this in your console:

`calypso:analytics:tracks Record event "calypso_activitylog_item_click" called with props {activity: "post__updated"}`

The activity portion of the log will change based on which link you clicked.
For example, you'll instead see `{activity: "plugin__updated"}` if you click on a plugin link.

