### PR TITLE
Upgrade Nudge: removes nudge for non admin users

### DIFF
--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -21,6 +21,7 @@ import { hasFeature } from 'state/sites/plans/selectors';
 import { getValidFeatureKeys } from 'lib/plans';
 import { isFreePlan } from 'lib/products-values';
 import TrackComponentView from 'lib/analytics/track-component-view';
+import { userCan } from 'lib/site/utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 
@@ -68,10 +69,14 @@ class UpgradeNudge extends React.Component {
 	};
 
 	shouldDisplay() {
-		const { feature, jetpack, planHasFeature, shouldDisplay, site } = this.props;
+		const { feature, jetpack, planHasFeature, shouldDisplay, site, userCanManageSite } = this.props;
 
 		if ( shouldDisplay ) {
 			return shouldDisplay();
+		}
+
+		if ( ! userCanManageSite ) {
+			return false;
 		}
 
 		if ( ! site || typeof site !== 'object' || typeof site.jetpack !== 'boolean' ) {
@@ -166,9 +171,12 @@ class UpgradeNudge extends React.Component {
 export default connect(
 	( state, ownProps ) => {
 		const siteId = getSelectedSiteId( state );
+		const site = getSelectedSite( state );
+
 		return {
-			site: getSelectedSite( state ),
+			site,
 			planHasFeature: hasFeature( state, siteId, ownProps.feature ),
+			userCanManageSite: userCan( 'manage_options', site ),
 		};
 	},
 	{ recordTracksEvent }

--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -21,8 +21,8 @@ import { hasFeature } from 'state/sites/plans/selectors';
 import { getValidFeatureKeys } from 'lib/plans';
 import { isFreePlan } from 'lib/products-values';
 import TrackComponentView from 'lib/analytics/track-component-view';
-import { userCan } from 'lib/site/utils';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { canCurrentUser } from 'state/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 
 class UpgradeNudge extends React.Component {
@@ -69,13 +69,20 @@ class UpgradeNudge extends React.Component {
 	};
 
 	shouldDisplay() {
-		const { feature, jetpack, planHasFeature, shouldDisplay, site, userCanManageSite } = this.props;
+		const {
+			feature,
+			jetpack,
+			planHasFeature,
+			shouldDisplay,
+			site,
+			canUserCanManageSite,
+		} = this.props;
 
 		if ( shouldDisplay ) {
 			return shouldDisplay();
 		}
 
-		if ( ! userCanManageSite ) {
+		if ( ! canUserCanManageSite ) {
 			return false;
 		}
 
@@ -176,7 +183,7 @@ export default connect(
 		return {
 			site,
 			planHasFeature: hasFeature( state, siteId, ownProps.feature ),
-			userCanManageSite: userCan( 'manage_options', site ),
+			canUserCanManageSite: canCurrentUser( state, siteId, 'manage_options' ),
 		};
 	},
 	{ recordTracksEvent }

--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -69,20 +69,13 @@ class UpgradeNudge extends React.Component {
 	};
 
 	shouldDisplay() {
-		const {
-			feature,
-			jetpack,
-			planHasFeature,
-			shouldDisplay,
-			site,
-			canUserCanManageSite,
-		} = this.props;
+		const { feature, jetpack, planHasFeature, shouldDisplay, site, canManageSite } = this.props;
 
 		if ( shouldDisplay ) {
 			return shouldDisplay();
 		}
 
-		if ( ! canUserCanManageSite ) {
+		if ( ! canManageSite ) {
 			return false;
 		}
 
@@ -183,7 +176,7 @@ export default connect(
 		return {
 			site,
 			planHasFeature: hasFeature( state, siteId, ownProps.feature ),
-			canUserCanManageSite: canCurrentUser( state, siteId, 'manage_options' ),
+			canManageSite: canCurrentUser( state, siteId, 'manage_options' ),
 		};
 	},
 	{ recordTracksEvent }

--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -22,7 +22,7 @@ import { getValidFeatureKeys } from 'lib/plans';
 import { isFreePlan } from 'lib/products-values';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { canCurrentUser } from 'state/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 
 class UpgradeNudge extends React.Component {


### PR DESCRIPTION
Part of #20250
Extracted from #23190

Updates the `UpgradeNudge` component to check if a user has the correct access rights to perform purchases.

To test this you'll need two users, one with full admin rights, and one _Editor_. Both on a _Free_ sites. The sites need to have more than 10 posts.

| Editor on Free Plan  | Editor on Business | Admin on Free Plan | Admin on Business |
| - | - | - | - |
| ![Insights](https://user-images.githubusercontent.com/233601/37220690-1a8a6cb8-23a6-11e8-9b9e-e5af52f91136.png) | ![Insights](https://user-images.githubusercontent.com/233601/37220729-3b9d88fe-23a6-11e8-9662-4272c5a9a7e4.png) | ![Insights](https://user-images.githubusercontent.com/233601/37222237-21e8df3a-23ab-11e8-9cdf-741d91a9a877.png) | ![Insights](https://user-images.githubusercontent.com/233601/37222275-34bc7b76-23ab-11e8-991c-415189190675.png) |

There should be no regressions for the _Admin_ user, but the _Editor_ shouldn't see the upgrade nudge.

These are the places the component is used:

| Section | Before | After |
| - | - | - |
| Stats / Traffic / Countries | ![screen shot 2018-04-10 at 12 30 54](https://user-images.githubusercontent.com/233601/38566842-1861c6c4-3cbb-11e8-868a-615ebfe9981e.png) | ![screen shot 2018-04-10 at 12 31 36](https://user-images.githubusercontent.com/233601/38566892-34b67324-3cbb-11e8-83ef-db2e3922b106.png) |
| Stats / Insights | ![screen shot 2018-04-10 at 12 38 12](https://user-images.githubusercontent.com/233601/38567263-19a58ce0-3cbc-11e8-8b98-56933c4c5dca.png) | ![screen shot 2018-04-10 at 12 39 08](https://user-images.githubusercontent.com/233601/38567308-370de520-3cbc-11e8-8631-b00818bb02ba.png) |
| My Sites / Sharing | ![screen shot 2018-04-10 at 12 34 58](https://user-images.githubusercontent.com/233601/38567079-a890dd02-3cbb-11e8-852e-e0f78f4f7e22.png) | ![screen shot 2018-04-10 at 12 35 45](https://user-images.githubusercontent.com/233601/38567144-d2ff3e4e-3cbb-11e8-9045-00917a41d384.png) |
| Blog Posts | ![screen shot 2018-04-10 at 12 45 33](https://user-images.githubusercontent.com/233601/38567628-1caf677a-3cbd-11e8-8e45-551b33b52a05.png) | ![screen shot 2018-04-10 at 12 46 00](https://user-images.githubusercontent.com/233601/38567662-2c95a37a-3cbd-11e8-81fa-21ab5f652df7.png) |
| Media / Videos | ![screen shot 2018-04-10 at 12 49 04](https://user-images.githubusercontent.com/233601/38567873-9a69b288-3cbd-11e8-8aa7-34d900813439.png) | ![screen shot 2018-04-10 at 12 49 32](https://user-images.githubusercontent.com/233601/38567901-adc82c60-3cbd-11e8-8e83-d385001cd9c0.png) |
