### PR TITLE
Give the active discount nudge a unique event property value

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -138,7 +138,7 @@ class SiteNotice extends React.Component {
 
 		return (
 			<SidebarBanner
-				ctaName="free-to-paid-sidebar"
+				ctaName="active-discount-sidebar"
 				ctaText={ ctaText || 'Upgrade' }
 				href={ `/plans/${ site.slug }?discount=${ name }` }
 				icon="info-outline"


### PR DESCRIPTION
Using a unique value here lets us distinguish between a click on the "Free domain with a plan" nudge and a discount nudge, such as "20% Off All Plans".

----------

**Test Plan:**

* Go to "My Sites" for a free site in Calypso (http://calypso.localhost:3000/)
* Open the network tab of your browser's js console and search for `calypso_upgrade_nudge_cta_click`
* In the sidebar, you should see the "Free domain with a plan" nudge.
<img width="286" alt="screen shot 2018-08-09 at 10 42 28 am" src="https://user-images.githubusercontent.com/690843/43923088-9d8157e2-9bd5-11e8-8919-91fb4eab5de0.png">

* Click the nudge and you should see a request to `t.gif` in the console. In the details of that request you should see the parameter `cta_name: free-to-paid-sidebar`.
<img width="1643" alt="screen shot 2018-08-09 at 1 19 08 pm" src="https://user-images.githubusercontent.com/690843/43923525-e8ae387e-9bd6-11e8-81e5-56ffcfb48f8a.png">

* From the backend set a user attribute
```
update_user_attribute( [USER_ID], 'SSE_weekly_marketing_email_holdout_wpcom_august_promo_en_20180101', 'send' );
```
* In [this file](https://github.com/Automattic/wp-calypso/blob/master/client/lib/discounts/active-discounts.js#L61) make sure the `endsAt` date hasn't passed for the `august20` promotion. If it has extend it.
* Refresh the page and you should now see the "20% Off All Plans" nudge instead.
* Click that nudge and again inspect the click event request parameters.
* You should now see `cta_name: active-discount-sidebar`