### PR TITLE
Shows "New Order" notifications settings for all WooCommerce sites.

### DIFF
--- a/client/me/notification-settings/blogs-settings/blog.jsx
+++ b/client/me/notification-settings/blogs-settings/blog.jsx
@@ -66,7 +66,7 @@ class BlogSettings extends Component {
 			'scheduled_publicize',
 		];
 
-		if ( site.options.is_wpcom_store ) {
+		if ( site.options.woocommerce_is_active ) {
 			settingKeys.push( 'store_order' );
 		}
 

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -38,6 +38,7 @@ export const SITE_REQUEST_OPTIONS = [
 	'is_mapped_domain',
 	'is_redirect',
 	'is_wpcom_store',
+  'woocommerce_is_active',
 	'jetpack_version',
 	'main_network_site',
 	'permalink_structure',


### PR DESCRIPTION
This PR unhides the "New Order"/`store_order` notification type in notification settings for all sites that have WooCommerce enabled regardless (inclusive of WordPress.com and Jetpack sites). Currently the `store_order` setting is available on every site on the API side but is hidden on the client side in Calypso based upon the site having WooCommerce or not on WordPress.com. The visibility setting of this should really be done on the API side, not in a client. That can be done in a future PR.

Don't merge this PR until the API change is made on WordPress.com to enable these notifications for all 

cc: @timmyc 