### PR TITLE
Imports: Fix imports upload in Calypso dev instances and Chrome

### DIFF
--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -113,7 +113,22 @@ class UploadingPane extends React.PureComponent {
 	startUpload = file => {
 		const { startUpload } = this.props;
 
-		startUpload( this.props.importerStatus, file );
+		if ( window.chrome ) {
+			/**
+			 * This is a workaround for a Chrome issue that prevents file uploads from `calypso.localhost` through
+			 * the proxy iframe we use.
+			 *
+			 * It shouldn't add any side effects to the way the uploads work in Chrome and the workaround should be
+			 * removed once the issues listed below get fixed.
+			 *
+			 * @see https://bugs.chromium.org/p/chromium/issues/detail?id=866805
+			 * @see https://bugs.chromium.org/p/chromium/issues/detail?id=631877
+			 */
+			const newFile = new File( [ file.slice( 0, file.size ) ], file.name, { type: file.type } );
+			startUpload( this.props.importerStatus, newFile );
+		} else {
+			startUpload( this.props.importerStatus, file );
+		}
 	};
 
 	render() {

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -113,7 +113,7 @@ class UploadingPane extends React.PureComponent {
 	startUpload = file => {
 		const { startUpload } = this.props;
 
-		if ( window.chrome ) {
+		if ( window.chrome && window.chrome.webstore ) {
 			/**
 			 * This is a workaround for a Chrome issue that prevents file uploads from `calypso.localhost` through
 			 * the proxy iframe we use.


### PR DESCRIPTION
For a while we've been hitting intermittent issues when uploading files for importing while using `calypso.localhost` instances of Calypso.

Recently the issue started manifesting permanently when working on the development copy of Calypso, so we had to find a work around for it.

This PR introduces such a workaround, as suggested in [one of the Chrome Bug report comments](https://bugs.chromium.org/p/chromium/issues/detail?id=866805#c20).

More context can be found in those two Chrome Bug reports:

https://bugs.chromium.org/p/chromium/issues/detail?id=866805
https://bugs.chromium.org/p/chromium/issues/detail?id=631877

I'm not limiting it to the dev environment, as the issue has been manifesting from time to time to testing, staging and production environments from time to time too. 

To test:

1. Fire up a `calypso.localhost` instance on `master` (without the patch)
2. Go to Imports -> WordPress
3. Try to upload a file
4. Make sure the upload fails (doesn't progress past Uploading and the progress bar never fills up)
5. Checkout this branch
6. Fire up `calypso.localhost` on the branch
7. Go to Imports -> WordPress
8. Try to upload a file
9. Make sure the upload succeeds
10. Make sure there are no errors in the JS console