### PR TITLE
Gutenberg: Update Todo block to use @wordpress packages

### DIFF
--- a/client/gutenberg/extensions/todo/block.js
+++ b/client/gutenberg/extensions/todo/block.js
@@ -1,15 +1,14 @@
 /** @format */
+
 /**
  * External dependencies
  */
 import classnames from 'classnames';
-import wp from 'wp';
-
-const { Button, Dashicon } = wp.components;
-const { __ } = wp.i18n;
-const { Component } = wp.element;
-const { registerBlockType } = wp.blocks;
-const { RichText } = wp.editor;
+import { __ } from '@wordpress/i18n';
+import { Button, Dashicon } from '@wordpress/components';
+import { Component } from '@wordpress/element';
+import { registerBlockType } from '@wordpress/blocks';
+import { RichText } from '@wordpress/editor';
 
 /**
  * Internal dependencies

--- a/client/gutenberg/extensions/todo/item.js
+++ b/client/gutenberg/extensions/todo/item.js
@@ -1,11 +1,11 @@
 /** @format */
+
 /**
  * External dependencies
  */
-import wp from 'wp';
-const { Component } = wp.element;
-const { Button, Dashicon } = wp.components;
-const { RichText } = wp.editor;
+import { Button, Dashicon } from '@wordpress/components';
+import { Component } from '@wordpress/element';
+import { RichText } from '@wordpress/editor';
 
 export const ItemEditor = class extends Component {
 	constructor() {


### PR DESCRIPTION
This PR updates the Todo block to use @wordpress packages instead of the global `wp` variable. This follows the example of #26549, which did the same for the Tiled Gallery block.

To test:
* Checkout this branch.
* Run `npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/todo/block.js`
* Verify the block still builds and works properly.