### PR TITLE
Gutenberg: Update Trial block to use @wordpress packages

### DIFF
--- a/client/gutenberg/extensions/trial/block.js
+++ b/client/gutenberg/extensions/trial/block.js
@@ -2,12 +2,11 @@
 /**
  * External dependencies
  */
-import wp from 'wp';
-const { __ } = wp.i18n;
-const { Component } = wp.element;
-const { registerBlockType } = wp.blocks;
-const { RichText } = wp.editor;
-const { Dropdown } = wp.components;
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { Dropdown } from '@wordpress/components';
+import { registerBlockType } from '@wordpress/blocks';
+import { RichText } from '@wordpress/editor';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
This PR updates the Trial block to use @wordpress packages instead of the global `wp` variable. This follows the example of #26549, which did the same for the Tiled Gallery block.

To test:
* Checkout this branch.
* Run `npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/trial/block.js`
* Verify the block still builds and works properly.