### PR TITLE
Gutenberg: Update Trials block to use @wordpress packages

### DIFF
--- a/client/gutenberg/extensions/trials/block.js
+++ b/client/gutenberg/extensions/trials/block.js
@@ -2,11 +2,10 @@
 /**
  * External dependencies
  */
-import wp from 'wp';
-const { __ } = wp.i18n;
-const { Component } = wp.element;
-const { registerBlockType } = wp.blocks;
-const { RichText, InnerBlocks } = wp.editor;
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { registerBlockType } from '@wordpress/blocks';
+import { RichText, InnerBlocks } from '@wordpress/editor';
 
 const blockAttributes = {
 	heading: {


### PR DESCRIPTION
This PR updates the Trials block to use @wordpress packages instead of the global `wp` variable. This follows the example of #26549, which did the same for the Tiled Gallery block.

To test:
* Checkout this branch.
* Run `npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/trials/block.js` if you already have the `trial` block built, or build the o2 preset if you don't: `npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/presets/o2/editor.js`
* Verify the block still builds and works properly.