### PR TITLE
SDK: Cleanup unnecessary required: false in yargs options

### DIFF
--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -47,7 +47,6 @@ yargs
 			'view-script': {
 				description: 'Entry for rendered-page-side JavaScript file',
 				type: 'string',
-				required: false,
 				coerce: value => path.resolve( __dirname, '../', value ),
 				requiresArg: true,
 			},


### PR DESCRIPTION
This simple PR removes an unnecessary `required: false` in the yargs options definitions of the SDK.