### PR TITLE
Gutenberg: enable new section in wpcalypso environment

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -38,7 +38,7 @@
 		"gdpr-banner": true,
 		"google-my-business": false,
 		"google-analytics": true,
-		"gutenberg": false,
+		"gutenberg": true,
 		"happychat": false,
 		"help": true,
 		"help/courses": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -45,7 +45,7 @@
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,
-		"gutenberg": false,
+		"gutenberg": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
This allows us to view the section in calypso.live.

### Testing instructions

1. Verify that you can navigate to `/gutenberg` in https://calypso.live/?branch=update/enable-gutenberg-wpcalypso
2. Calypso smoke test.