### PR TITLE
Revert "Remove custom memoization in `ReaderCombinedCardComponent`."

### DIFF
--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -25,7 +25,6 @@ import FollowButton from 'reader/follow-button';
 import { getPostsByKeys } from 'state/reader/posts/selectors';
 import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
 import PostBlocked from 'blocks/reader-post-card/blocked';
-import createSelector from 'lib/create-selector';
 
 class ReaderCombinedCardComponent extends React.Component {
 	static propTypes = {
@@ -164,29 +163,45 @@ class ReaderCombinedCardComponent extends React.Component {
 	}
 }
 
-export function combinedCardPostKeyToKeys( postKey ) {
+export function combinedCardPostKeyToKeys( postKey, memoized = null ) {
 	if ( ! postKey || ! postKey.postIds ) {
 		return [];
 	}
 
-	const { feedId, blogId } = postKey;
+	const feedId = postKey.feedId;
+	const blogId = postKey.blogId;
 
-	return postKey.postIds.map( postId => ( { feedId, blogId, postId } ) );
+	if ( memoized && memoized.lastPostIds === postKey.postIds ) {
+		return memoized.lastPostKeys;
+	}
+
+	const keys = postKey.postIds.map( postId => ( { feedId, blogId, postId } ) );
+
+	if ( memoized ) {
+		memoized.lastPostIds = postKey.postIds;
+		memoized.lastPostKeys = keys;
+	}
+
+	return keys;
 }
 
 export const ReaderCombinedCard = localize( ReaderCombinedCardComponent );
 
-const getPostData = createSelector(
-	( state, postKey ) => {
-		const postKeys = combinedCardPostKeyToKeys( postKey );
+// React-redux's `connect` allows for a mapStateToProps that returns a function,
+// rather than an object, binding it to a particular component instance.
+// This allows for memoization, which we strategically use here to maintain
+// references and avoid re-rendering large sections of the component tree.
+function mapStateToProps( st, ownProps ) {
+	const memoized = {};
+
+	return state => {
+		const postKeys = combinedCardPostKeyToKeys( ownProps.postKey, memoized );
+
 		return {
 			posts: getPostsByKeys( state, postKeys ),
 			postKeys,
 		};
-	},
-	state => [ state.posts ]
-);
+	};
+}
 
-export default connect( ( state, { postKey } ) => getPostData( state, postKey ) )(
-	ReaderCombinedCard
-);
+export default connect( mapStateToProps )( ReaderCombinedCard );


### PR DESCRIPTION
This reverts commit 0c5c3b020d9a4fed418d8e21079b9560d4f770c9.

When we switched from the custom memoization routine to `createSelector`, we missed that `postKey` is a complex object and not suitable as a parameter. A warning was thrown to alert us, but it was missed in dev and under review, possibly because the warning is not shown on calypso.live. 

This reverts to the working custom memoization function, keeping the perf gains while fixing how combo cards render.