### PR TITLE
SDK: remove Publicize from Jetpack bundle

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -4,5 +4,4 @@
  * Internal dependencies
  */
 import 'gutenberg/extensions/markdown/jetpack-markdown-block.jsx';
-import 'gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx';
 import 'gutenberg/extensions/tiled-gallery/tiled-gallery.jsx';


### PR DESCRIPTION
Removing for now because it fails the bundle. Introducing it back once it's fixed.

https://github.com/Automattic/jetpack/pull/10008#pullrequestreview-145180764

>it errors out; seems to be missing the gutenberg_publicize_setup global variable, which is specifically introduced for this extension. It will also be missing some more things too - see https://github.com/Automattic/jetpack/pull/9963 for details.