### PR TITLE
add a monorepo config for @wordpress packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,14 @@
 {
-  "extends": [
-	"config:base",
-	"default:pinDigestsDisabled"
-  ],
-  "statusCheckVerify": true,
-  "ignoreDeps": [
-    "jquery"
-  ],
-  "labels": [
-	"Framework",
-	"[Type] Task",
-	"[Status] Needs Review"
-  ]
+	"extends": [ "config:base", "default:pinDigestsDisabled" ],
+	"statusCheckVerify": true,
+	"ignoreDeps": [ "jquery" ],
+	"labels": [ "Framework", "[Type] Task", "[Status] Needs Review" ],
+	"packageRules": [
+		{
+			"packagePatterns": "^@wordpress/",
+			"groupName": "WordPress",
+			"groupSlug": "wordpress",
+			"description": "WordPress monorepo"
+		}
+	]
 }


### PR DESCRIPTION
The `@wordpress/*` packages come from a monorepo and we would like to group renovate PRs for them. This updates the config to add a grouping for those packages.

See https://renovatebot.com/docs/configuration-options/#packagerules for config settings.