### PR TITLE
Checkout: Use named exports from controller

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -21,40 +21,40 @@ import SecondaryCart from './cart/secondary-cart';
 import CheckoutPendingComponent from './checkout-thank-you/pending';
 import CheckoutThankYouComponent from './checkout-thank-you';
 
+export function checkout( context, next ) {
+	const { feature, plan, product } = context.params;
+
+	const state = context.store.getState();
+	const selectedSite = getSelectedSite( state );
+
+	if ( 'thank-you' === product ) {
+		return;
+	}
+
+	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
+
+	context.primary = (
+		<CheckoutData>
+			<Checkout
+				product={ product }
+				purchaseId={ context.params.purchaseId }
+				selectedFeature={ feature }
+				couponCode={ context.query.code }
+				plan={ plan }
+			/>
+		</CheckoutData>
+	);
+
+	context.secondary = (
+		<CartData>
+			<SecondaryCart selectedSite={ selectedSite } />
+		</CartData>
+	);
+	next();
+}
+
 export default {
-	checkout: function checkout( context, next ) {
-		const { feature, plan, product } = context.params;
-
-		const state = context.store.getState();
-		const selectedSite = getSelectedSite( state );
-
-		if ( 'thank-you' === product ) {
-			return;
-		}
-
-		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
-
-		context.primary = (
-			<CheckoutData>
-				<Checkout
-					product={ product }
-					purchaseId={ context.params.purchaseId }
-					selectedFeature={ feature }
-					couponCode={ context.query.code }
-					plan={ plan }
-				/>
-			</CheckoutData>
-		);
-
-		context.secondary = (
-			<CartData>
-				<SecondaryCart selectedSite={ selectedSite } />
-			</CartData>
-		);
-		next();
-	},
-
 	sitelessCheckout: function sitelessCheckout( context, next ) {
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -54,25 +54,25 @@ export function checkout( context, next ) {
 	next();
 }
 
+export function sitelessCheckout( context, next ) {
+	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
+
+	context.primary = (
+		<CheckoutData>
+			<Checkout reduxStore={ context.store } />
+		</CheckoutData>
+	);
+
+	context.secondary = (
+		<CartData>
+			<SecondaryCart />
+		</CartData>
+	);
+	next();
+}
+
 export default {
-	sitelessCheckout: function sitelessCheckout( context, next ) {
-		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
-
-		context.primary = (
-			<CheckoutData>
-				<Checkout reduxStore={ context.store } />
-			</CheckoutData>
-		);
-
-		context.secondary = (
-			<CartData>
-				<SecondaryCart />
-			</CartData>
-		);
-		next();
-	},
-
 	checkoutPending: function checkoutPending( context, next ) {
 		const orderId = Number( context.params.orderId );
 		const siteSlug = context.params.site;

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -108,29 +108,29 @@ export function checkoutThankYou( context, next ) {
 	next();
 }
 
-export default {
-	gsuiteNudge: function gsuiteNudge( context, next ) {
-		const { domain, site, receiptId } = context.params;
-		context.store.dispatch( setSection( { name: 'gsuite-nudge' }, { hasSidebar: false } ) );
+export function gsuiteNudge( context, next ) {
+	const { domain, site, receiptId } = context.params;
+	context.store.dispatch( setSection( { name: 'gsuite-nudge' }, { hasSidebar: false } ) );
 
-		const state = context.store.getState();
-		const selectedSite =
-			getSelectedSite( state ) || getSiteBySlug( state, site ) || getSiteBySlug( state, domain );
+	const state = context.store.getState();
+	const selectedSite =
+		getSelectedSite( state ) || getSiteBySlug( state, site ) || getSiteBySlug( state, domain );
 
-		if ( ! selectedSite ) {
-			return null;
-		}
+	if ( ! selectedSite ) {
+		return null;
+	}
 
-		context.primary = (
-			<CartData>
-				<GsuiteNudge
-					domain={ domain }
-					receiptId={ Number( receiptId ) }
-					selectedSiteId={ selectedSite.ID }
-				/>
-			</CartData>
-		);
+	context.primary = (
+		<CartData>
+			<GsuiteNudge
+				domain={ domain }
+				receiptId={ Number( receiptId ) }
+				selectedSiteId={ selectedSite.ID }
+			/>
+		</CartData>
+	);
 
-		next();
-	},
-};
+	next();
+}
+
+export default {};

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -83,32 +83,32 @@ export function checkoutPending( context, next ) {
 	next();
 }
 
+export function checkoutThankYou( context, next ) {
+	const receiptId = Number( context.params.receiptId );
+	const gsuiteReceiptId = Number( context.params.gsuiteReceiptId ) || 0;
+
+	const state = context.store.getState();
+	const selectedSite = getSelectedSite( state );
+
+	context.store.dispatch( setSection( { name: 'checkout-thank-you' }, { hasSidebar: false } ) );
+
+	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	context.store.dispatch( setTitle( i18n.translate( 'Thank You' ) ) );
+
+	context.primary = (
+		<CheckoutThankYouComponent
+			receiptId={ receiptId }
+			gsuiteReceiptId={ gsuiteReceiptId }
+			domainOnlySiteFlow={ isEmpty( context.params.site ) }
+			selectedFeature={ context.params.feature }
+			selectedSite={ selectedSite }
+		/>
+	);
+
+	next();
+}
+
 export default {
-	checkoutThankYou: function checkoutThankYou( context, next ) {
-		const receiptId = Number( context.params.receiptId );
-		const gsuiteReceiptId = Number( context.params.gsuiteReceiptId ) || 0;
-
-		const state = context.store.getState();
-		const selectedSite = getSelectedSite( state );
-
-		context.store.dispatch( setSection( { name: 'checkout-thank-you' }, { hasSidebar: false } ) );
-
-		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( i18n.translate( 'Thank You' ) ) );
-
-		context.primary = (
-			<CheckoutThankYouComponent
-				receiptId={ receiptId }
-				gsuiteReceiptId={ gsuiteReceiptId }
-				domainOnlySiteFlow={ isEmpty( context.params.site ) }
-				selectedFeature={ context.params.feature }
-				selectedSite={ selectedSite }
-			/>
-		);
-
-		next();
-	},
-
 	gsuiteNudge: function gsuiteNudge( context, next ) {
 		const { domain, site, receiptId } = context.params;
 		context.store.dispatch( setSection( { name: 'gsuite-nudge' }, { hasSidebar: false } ) );

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -72,18 +72,18 @@ export function sitelessCheckout( context, next ) {
 	next();
 }
 
+export function checkoutPending( context, next ) {
+	const orderId = Number( context.params.orderId );
+	const siteSlug = context.params.site;
+
+	context.store.dispatch( setSection( { name: 'checkout-thank-you' }, { hasSidebar: false } ) );
+
+	context.primary = <CheckoutPendingComponent orderId={ orderId } siteSlug={ siteSlug } />;
+
+	next();
+}
+
 export default {
-	checkoutPending: function checkoutPending( context, next ) {
-		const orderId = Number( context.params.orderId );
-		const siteSlug = context.params.site;
-
-		context.store.dispatch( setSection( { name: 'checkout-thank-you' }, { hasSidebar: false } ) );
-
-		context.primary = <CheckoutPendingComponent orderId={ orderId } siteSlug={ siteSlug } />;
-
-		next();
-	},
-
 	checkoutThankYou: function checkoutThankYou( context, next ) {
 		const receiptId = Number( context.params.receiptId );
 		const gsuiteReceiptId = Number( context.params.gsuiteReceiptId ) || 0;

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -132,5 +132,3 @@ export function gsuiteNudge( context, next ) {
 
 	next();
 }
-
-export default {};

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -22,7 +22,7 @@ import CheckoutPendingComponent from './checkout-thank-you/pending';
 import CheckoutThankYouComponent from './checkout-thank-you';
 
 export default {
-	checkout: function( context, next ) {
+	checkout: function checkout( context, next ) {
 		const { feature, plan, product } = context.params;
 
 		const state = context.store.getState();
@@ -55,7 +55,7 @@ export default {
 		next();
 	},
 
-	sitelessCheckout: function( context, next ) {
+	sitelessCheckout: function sitelessCheckout( context, next ) {
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
 
@@ -73,7 +73,7 @@ export default {
 		next();
 	},
 
-	checkoutPending: function( context, next ) {
+	checkoutPending: function checkoutPending( context, next ) {
 		const orderId = Number( context.params.orderId );
 		const siteSlug = context.params.site;
 
@@ -84,7 +84,7 @@ export default {
 		next();
 	},
 
-	checkoutThankYou: function( context, next ) {
+	checkoutThankYou: function checkoutThankYou( context, next ) {
 		const receiptId = Number( context.params.receiptId );
 		const gsuiteReceiptId = Number( context.params.gsuiteReceiptId ) || 0;
 
@@ -109,7 +109,7 @@ export default {
 		next();
 	},
 
-	gsuiteNudge( context, next ) {
+	gsuiteNudge: function gsuiteNudge( context, next ) {
 		const { domain, site, receiptId } = context.params;
 		context.store.dispatch( setSection( { name: 'gsuite-nudge' }, { hasSidebar: false } ) );
 

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -7,7 +7,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import checkoutController, {
+import {
 	checkout,
 	checkoutPending,
 	checkoutThankYou,

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -7,7 +7,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import checkoutController, { checkout, sitelessCheckout } from './controller';
+import checkoutController, { checkout, checkoutPending, sitelessCheckout } from './controller';
 import SiftScience from 'lib/siftscience';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 import { noSite, siteSelection } from 'my-sites/controller';
@@ -19,7 +19,7 @@ export default function() {
 		'/checkout/thank-you/no-site/pending/:orderId',
 		redirectLoggedOut,
 		siteSelection,
-		checkoutController.checkoutPending,
+		checkoutPending,
 		makeLayout,
 		clientRender
 	);
@@ -37,7 +37,7 @@ export default function() {
 		'/checkout/thank-you/:site/pending/:orderId',
 		redirectLoggedOut,
 		siteSelection,
-		checkoutController.checkoutPending,
+		checkoutPending,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -7,7 +7,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import checkoutController, { checkout } from './controller';
+import checkoutController, { checkout, sitelessCheckout } from './controller';
 import SiftScience from 'lib/siftscience';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 import { noSite, siteSelection } from 'my-sites/controller';
@@ -73,7 +73,7 @@ export default function() {
 		'/checkout/no-site',
 		redirectLoggedOut,
 		noSite,
-		checkoutController.sitelessCheckout,
+		sitelessCheckout,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -7,7 +7,12 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import checkoutController, { checkout, checkoutPending, sitelessCheckout } from './controller';
+import checkoutController, {
+	checkout,
+	checkoutPending,
+	checkoutThankYou,
+	sitelessCheckout,
+} from './controller';
 import SiftScience from 'lib/siftscience';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 import { noSite, siteSelection } from 'my-sites/controller';
@@ -28,7 +33,7 @@ export default function() {
 		'/checkout/thank-you/no-site/:receiptId?',
 		redirectLoggedOut,
 		noSite,
-		checkoutController.checkoutThankYou,
+		checkoutThankYou,
 		makeLayout,
 		clientRender
 	);
@@ -46,7 +51,7 @@ export default function() {
 		'/checkout/thank-you/:site/:receiptId?',
 		redirectLoggedOut,
 		siteSelection,
-		checkoutController.checkoutThankYou,
+		checkoutThankYou,
 		makeLayout,
 		clientRender
 	);
@@ -55,7 +60,7 @@ export default function() {
 		'/checkout/thank-you/:site/:receiptId/with-gsuite/:gsuiteReceiptId',
 		redirectLoggedOut,
 		siteSelection,
-		checkoutController.checkoutThankYou,
+		checkoutThankYou,
 		makeLayout,
 		clientRender
 	);
@@ -64,7 +69,7 @@ export default function() {
 		'/checkout/thank-you/features/:feature/:site/:receiptId?',
 		redirectLoggedOut,
 		siteSelection,
-		checkoutController.checkoutThankYou,
+		checkoutThankYou,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -11,6 +11,7 @@ import checkoutController, {
 	checkout,
 	checkoutPending,
 	checkoutThankYou,
+	gsuiteNudge,
 	sitelessCheckout,
 } from './controller';
 import SiftScience from 'lib/siftscience';
@@ -114,7 +115,7 @@ export default function() {
 		'/checkout/:site/with-gsuite/:domain/:receiptId?',
 		redirectLoggedOut,
 		siteSelection,
-		checkoutController.gsuiteNudge,
+		gsuiteNudge,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -7,7 +7,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import checkoutController from './controller';
+import checkoutController, { checkout } from './controller';
 import SiftScience from 'lib/siftscience';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 import { noSite, siteSelection } from 'my-sites/controller';
@@ -82,7 +82,7 @@ export default function() {
 		'/checkout/features/:feature/:domain/:plan_name?',
 		redirectLoggedOut,
 		siteSelection,
-		checkoutController.checkout,
+		checkout,
 		makeLayout,
 		clientRender
 	);
@@ -91,7 +91,7 @@ export default function() {
 		'/checkout/:domain/:product?',
 		redirectLoggedOut,
 		siteSelection,
-		checkoutController.checkout,
+		checkout,
 		makeLayout,
 		clientRender
 	);
@@ -100,7 +100,7 @@ export default function() {
 		'/checkout/:product/renew/:purchaseId/:domain',
 		redirectLoggedOut,
 		siteSelection,
-		checkoutController.checkout,
+		checkout,
 		makeLayout,
 		clientRender
 	);


### PR DESCRIPTION
Use named imports/export from the checkout controller.

No functional changes.

[No-whitespace diff](https://github.com/Automattic/wp-calypso/pull/26630/files?w=1) is likely a better representation of changes.

## Testing
1. e2e
1. Smoke test checkout routes:
   - gsuite
   - no-site
   - Jetpack
   - Site plan