### PR TITLE
Fix typo in the Thank You page when transferring in a domain

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -181,7 +181,7 @@ class CheckoutThankYouHeader extends PureComponent {
 
 			return translate(
 				'Your domain {{strong}}%(domain)s{{/strong}} was added to your site, but ' +
-					'but the transfer process can take up to 5 days to complete.',
+					'the transfer process can take up to 5 days to complete.',
 				{
 					args: {
 						domain: primaryPurchase.meta,


### PR DESCRIPTION
The current text says "...but but..." (visible in the screenshot at https://github.com/Automattic/wp-calypso/pull/26525).  This fixes it :)