### PR TITLE
Checkout: Send Jetpack sites to my-plans post-checkout

### DIFF
--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -57,7 +57,7 @@ import { GROUP_WPCOM } from 'lib/plans/constants';
 import { recordViewCheckout } from 'lib/analytics/ad-tracking';
 import { recordApplePayStatus } from 'lib/apple-pay';
 import { requestSite } from 'state/sites/actions';
-import { isNewSite } from 'state/sites/selectors';
+import { isJetpackSite, isNewSite } from 'state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { canAddGoogleApps } from 'lib/domains';
@@ -69,6 +69,7 @@ import QueryProducts from 'components/data/query-products-list';
 import { isRequestingSitePlans } from 'state/sites/plans/selectors';
 import { isRequestingPlans } from 'state/plans/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { isEnabled } from 'config';
 
 export class Checkout extends React.Component {
 	static propTypes = {
@@ -355,6 +356,10 @@ export class Checkout extends React.Component {
 
 		if ( this.props.isEligibleForCheckoutToChecklist && receipt ) {
 			return `/checklist/${ selectedSiteSlug }`;
+		}
+
+		if ( this.props.isJetpack && isEnabled( 'jetpack/checklist' ) ) {
+			return `/plans/my-plan/${ selectedSiteSlug }`;
 		}
 
 		return this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )
@@ -659,6 +664,7 @@ export default connect(
 			isPlansListFetching: isRequestingPlans( state ),
 			isSitePlansListFetching: isRequestingSitePlans( state, selectedSiteId ),
 			planSlug: getUpgradePlanSlugFromPath( state, selectedSiteId, props.product ),
+			isJetpack: isJetpackSite( state, selectedSiteId ),
 		};
 	},
 	{


### PR DESCRIPTION
The "Thank You" page would set up a user's site after plan purchase.

This functionality will be moved to the checklist available on `/plans/my-plan/SITE_SLUG` for Jetpack sites.

Rather than sending Jetpack purchases to the "Thank You" page, send them to `/plans/my-plan/SITE_SLUG`

See p6TEKc-2e8-p2 for background.

## Testing
- Purchase a Jetpack plan
- Verify you're sent to `plans/my-plan/SITE_SLUG` after checkout.
- Disable the `jetpack/checklist` flag and verify you're sent to the existing thank you page `/checkout/thank-you/SITE_SLUG/RECEIPT_ID`
- Other purchases should remain unaffected.