### PR TITLE
Chart: Improve update performance

### DIFF
--- a/client/components/chart/bar-container.jsx
+++ b/client/components/chart/bar-container.jsx
@@ -22,6 +22,7 @@ export default class extends React.Component {
 		yAxisMax: PropTypes.number,
 		width: PropTypes.number,
 		barClick: PropTypes.func,
+		isRtl: PropTypes.bool,
 	};
 
 	buildBars = max => {
@@ -38,6 +39,7 @@ export default class extends React.Component {
 					count={ this.props.data.length }
 					chartWidth={ this.props.chartWidth }
 					setTooltip={ this.props.setTooltip }
+					isRtl={ this.props.isRtl }
 				/>
 			);
 		}, this );

--- a/client/components/chart/bar.jsx
+++ b/client/components/chart/bar.jsx
@@ -7,14 +7,8 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
-import { connect } from 'react-redux';
 
-/**
- * Internal dependencies
- */
-import isRtlSelector from 'state/selectors/is-rtl';
-
-class ModuleChartBar extends Component {
+export default class ModuleChartBar extends Component {
 	static propTypes = {
 		isTouch: PropTypes.bool,
 		tooltipPosition: PropTypes.string,
@@ -23,6 +17,7 @@ class ModuleChartBar extends Component {
 		data: PropTypes.object.isRequired,
 		max: PropTypes.number,
 		count: PropTypes.number,
+		isRtl: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -30,61 +25,6 @@ class ModuleChartBar extends Component {
 	};
 
 	state = { showPopover: false };
-
-	buildSections = () => {
-		const { active, data, max } = this.props;
-		const { nestedValue, value } = data;
-
-		const percentage = Math.ceil( ( value / max ) * 10000 ) / 100,
-			remain = 100 - percentage,
-			remainFloor = Math.max( 1, Math.floor( remain ) ),
-			sections = [],
-			spacerClassOptions = {
-				'chart__bar-section': true,
-				'is-spacer': true,
-				'is-ghost': 100 === remain && ! active,
-			},
-			remainStyle = {
-				height: remainFloor + '%',
-			},
-			valueStyle = {
-				top: remainFloor + '%',
-			};
-		let nestedBar, nestedPercentage, nestedStyle;
-
-		sections.push(
-			<div key="spacer" className={ classNames( spacerClassOptions ) } style={ remainStyle } />
-		);
-
-		if ( nestedValue ) {
-			nestedPercentage = value ? Math.ceil( ( nestedValue / value ) * 10000 ) / 100 : 0;
-
-			nestedStyle = { height: nestedPercentage + '%' };
-
-			nestedBar = (
-				<div key="nestedValue" className="chart__bar-section-inner" style={ nestedStyle } />
-			);
-		}
-
-		sections.push(
-			<div
-				ref={ this.setRef }
-				key="value"
-				className="chart__bar-section is-bar"
-				style={ valueStyle }
-			>
-				{ nestedBar }
-			</div>
-		);
-
-		sections.push(
-			<div key="label" className="chart__bar-label">
-				{ this.props.label }
-			</div>
-		);
-
-		return sections;
-	};
 
 	clickHandler = () => {
 		if ( typeof this.props.clickHandler === 'function' ) {
@@ -127,21 +67,12 @@ class ModuleChartBar extends Component {
 		const { tooltipData } = this.props.data;
 
 		return tooltipData.map( function( options, i ) {
-			const wrapperClasses = [ 'module-content-list-item' ];
-			let gridiconSpan;
-
-			if ( options.icon ) {
-				gridiconSpan = <Gridicon icon={ options.icon } size={ 18 } />;
-			}
-
-			wrapperClasses.push( options.className );
-
 			return (
-				<li key={ i } className={ wrapperClasses.join( ' ' ) }>
+				<li key={ i } className={ classNames( 'module-content-list-item', options.className ) }>
 					<span className="chart__tooltip-wrapper wrapper">
 						<span className="chart__tooltip-value value">{ options.value }</span>
 						<span className="chart__tooltip-label label">
-							{ gridiconSpan }
+							{ options.icon && <Gridicon icon={ options.icon } size={ 18 } /> }
 							{ options.label }
 						</span>
 					</span>
@@ -150,24 +81,83 @@ class ModuleChartBar extends Component {
 		} );
 	}
 
+	getPercentage() {
+		const {
+			data: { value },
+			max,
+		} = this.props;
+		return Math.ceil( ( value / max ) * 10000 ) / 100;
+	}
+
+	getNestedPercentage() {
+		const {
+			data: { nestedValue, value },
+		} = this.props;
+		return value && nestedValue ? Math.ceil( ( nestedValue / value ) * 10000 ) / 100 : 0;
+	}
+
 	setRef = ref => ( this.bar = ref );
 
-	render() {
-		const barClass = classNames( 'chart__bar', this.props.className );
-		const count = this.props.count || 1;
-		const barStyle = {
-			width: ( 1 / count ) * 100 + '%',
-		};
-
+	renderSpacer() {
+		const percentage = this.getPercentage();
 		return (
 			<div
+				key="spacer"
+				className={ classNames( {
+					'chart__bar-section': true,
+					'is-spacer': true,
+					'is-ghost': 0 === percentage && ! this.props.active,
+				} ) }
+				style={ { height: `${ Math.max( 1, Math.floor( 100 - percentage ) ) }%` } }
+			/>
+		);
+	}
+
+	renderNestedBar() {
+		const {
+			data: { nestedValue },
+		} = this.props;
+
+		return (
+			nestedValue && (
+				<div
+					key="nestedValue"
+					className="chart__bar-section-inner"
+					style={ { height: `${ this.getNestedPercentage() }%` } }
+				/>
+			)
+		);
+	}
+
+	renderBar() {
+		const percentage = this.getPercentage();
+		return (
+			<div
+				ref={ this.setRef }
+				key="value"
+				className="chart__bar-section is-bar"
+				style={ { top: `${ Math.max( 1, Math.floor( 100 - percentage ) ) }%` } }
+			>
+				{ this.renderNestedBar() }
+			</div>
+		);
+	}
+
+	render() {
+		return (
+			<div
+				role="presentation"
+				aria-hidden="true"
 				onClick={ this.clickHandler }
 				onMouseEnter={ this.mouseEnter }
 				onMouseLeave={ this.mouseLeave }
-				className={ classNames( barClass ) }
-				style={ barStyle }
+				className={ classNames( 'chart__bar', this.props.className ) }
 			>
-				{ this.buildSections() }
+				{ this.renderSpacer() }
+				{ this.renderBar() }
+				<div key="label" className="chart__bar-label">
+					{ this.props.label }
+				</div>
 				<div className="chart__bar-marker is-hundred" />
 				<div className="chart__bar-marker is-fifty" />
 				<div className="chart__bar-marker is-zero" />
@@ -175,7 +165,3 @@ class ModuleChartBar extends Component {
 		);
 	}
 }
-
-export default connect( state => ( {
-	isRtl: isRtlSelector( state ),
-} ) )( ModuleChartBar );

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { noop, throttle } from 'lodash';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -14,6 +15,7 @@ import BarContainer from './bar-container';
 import { hasTouch } from 'lib/touch-detect';
 import Tooltip from 'components/tooltip';
 import Notice from 'components/notice';
+import isRtlSelector from 'state/selectors/is-rtl';
 
 class Chart extends React.Component {
 	state = {
@@ -33,6 +35,7 @@ class Chart extends React.Component {
 		barClick: PropTypes.func,
 		translate: PropTypes.func,
 		numberFormat: PropTypes.func,
+		isRtl: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -162,6 +165,7 @@ class Chart extends React.Component {
 					isTouch={ hasTouch() }
 					chartWidth={ width }
 					setTooltip={ this.setTooltip }
+					isRtl={ this.props.isRtl }
 				/>
 				{ isTooltipVisible && (
 					<Tooltip
@@ -179,4 +183,6 @@ class Chart extends React.Component {
 	}
 }
 
-export default localize( Chart );
+export default connect( state => ( {
+	isRtl: isRtlSelector( state ),
+} ) )( localize( Chart ) );


### PR DESCRIPTION
This change refactors the chart component to avoid `connect`ing individual <Bar /> component to the Redux state. Instead, we now `connect` the top level `<Chart />` which propagates the necessary prop `isRtl` down to `<BarContainer />` which holds multiple `<Bar />`s.

From my local performance profiling, this reduced `<StatsModuleChartTabs />`'s update time by a factor of 2x (87ms to 37ms). You can reproduce this using React's recommended performance profiling technique detailed [here](https://reactjs.org/docs/optimizing-performance.html#profiling-components-with-the-chrome-performance-tab).

# Testing Instructions
1. Spin up this branch locally or in a live branch.
2. Navigate to the [stats page](http://calypso.localhost:3000/stats/day/) and select a site with some activity. 
3. Ensure that the page renders correctly.
4. Ensure that the graph properly handles resizing.
5. If desired, try profiling the page performance locally.

(When in doubt, try comparing the this branch's stats page behavior with production stats page behavior.)