### PR TITLE
Remember last arguments in afterLayoutFlush.

### DIFF
--- a/client/lib/after-layout-flush/index.js
+++ b/client/lib/after-layout-flush/index.js
@@ -22,46 +22,50 @@ export default function afterLayoutFlush( func ) {
 
 	let lastThis, lastArgs;
 
-	const scheduleRAF = rafFunc => ( ...args ) => {
-		lastThis = this;
-		lastArgs = args;
-
-		// if a RAF is already scheduled and not yet executed, don't schedule another one
-		if ( rafHandle !== undefined ) {
-			return;
-		}
-
-		rafHandle = requestAnimationFrame( () => {
-			// clear the handle to signal that the scheduled RAF has been executed
-			rafHandle = undefined;
-			rafFunc();
-		} );
-	};
-
-	const scheduleTimeout = timeoutFunc => ( ...args ) => {
-		if ( ! hasRAF ) {
+	const scheduleRAF = function( rafFunc ) {
+		return function( ...args ) {
 			lastThis = this;
 			lastArgs = args;
-		}
 
-		// If a timeout is already scheduled and not yet executed, don't schedule another one.
-		// Multiple `requestAnimationFrame` handlers can be scheduled and executed before the
-		// browser decides to finally execute the timeout handler.
-		if ( timeoutHandle !== undefined ) {
-			return;
-		}
+			// if a RAF is already scheduled and not yet executed, don't schedule another one
+			if ( rafHandle !== undefined ) {
+				return;
+			}
 
-		timeoutHandle = setTimeout( () => {
-			const callArgs = lastArgs;
-			const callThis = lastThis;
+			rafHandle = requestAnimationFrame( () => {
+				// clear the handle to signal that the scheduled RAF has been executed
+				rafHandle = undefined;
+				rafFunc();
+			} );
+		};
+	};
 
-			lastArgs = undefined;
-			lastThis = undefined;
+	const scheduleTimeout = function( timeoutFunc ) {
+		return function( ...args ) {
+			if ( ! hasRAF ) {
+				lastThis = this;
+				lastArgs = args;
+			}
 
-			// clear the handle to signal that the timeout handler has been executed
-			timeoutHandle = undefined;
-			timeoutFunc.apply( callThis, callArgs );
-		}, 0 );
+			// If a timeout is already scheduled and not yet executed, don't schedule another one.
+			// Multiple `requestAnimationFrame` handlers can be scheduled and executed before the
+			// browser decides to finally execute the timeout handler.
+			if ( timeoutHandle !== undefined ) {
+				return;
+			}
+
+			timeoutHandle = setTimeout( () => {
+				const callArgs = lastArgs;
+				const callThis = lastThis;
+
+				lastArgs = undefined;
+				lastThis = undefined;
+
+				// clear the handle to signal that the timeout handler has been executed
+				timeoutHandle = undefined;
+				timeoutFunc.apply( callThis, callArgs );
+			}, 0 );
+		};
 	};
 
 	// if RAF is not supported (in Node.js test environment), the wrapped function

--- a/client/lib/after-layout-flush/test/index.js
+++ b/client/lib/after-layout-flush/test/index.js
@@ -1,0 +1,131 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import sinon from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import afterLayoutFlush from '../';
+
+jest.useFakeTimers();
+
+// Simple mock for controlling requestAnimationFrame.
+let pendingRafCallbacks = [];
+
+function raf( func ) {
+	pendingRafCallbacks.push( func );
+}
+
+function runRaf() {
+	pendingRafCallbacks.forEach( callback => callback() );
+	pendingRafCallbacks = [];
+}
+
+// Helper class used to test whether `this` is preserved.
+class PreserveThisTest {
+	constructor() {
+		this.foo = 'bar';
+		this.callback = jest.fn();
+	}
+}
+
+// Wrap this in a method so we can call it at the right time and pick up
+// the current state of `requestAnimationFrame` existence.
+function setupPreserveThisTest() {
+	PreserveThisTest.prototype.wrappedFunction = afterLayoutFlush( function() {
+		return this.callback( this.foo );
+	} );
+}
+
+describe( 'afterLayoutFlush', () => {
+	describe( 'in browsers that support requestAnimationFrame', () => {
+		beforeAll( () => {
+			sinon.stub( window, 'requestAnimationFrame' ).callsFake( raf );
+		} );
+
+		test( 'should execute after a rAF followed by a timeout', () => {
+			const callback = jest.fn();
+			const wrappedFunction = afterLayoutFlush( callback );
+			wrappedFunction();
+			expect( callback ).not.toBeCalled();
+
+			runRaf();
+			expect( callback ).not.toBeCalled();
+
+			jest.runAllTimers();
+			expect( callback ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'should preserve arguments passed to wrapped function', () => {
+			const callback = jest.fn();
+			const wrappedFunction = afterLayoutFlush( callback );
+			wrappedFunction( 'foo', 'bar' );
+
+			runRaf();
+			jest.runAllTimers();
+
+			expect( callback ).toHaveBeenCalledTimes( 1 );
+			expect( callback ).toHaveBeenCalledWith( 'foo', 'bar' );
+		} );
+
+		test( 'should preserve `this` passed to wrapped function', () => {
+			setupPreserveThisTest();
+			const ptt = new PreserveThisTest();
+			ptt.wrappedFunction();
+
+			runRaf();
+			jest.runAllTimers();
+
+			expect( ptt.callback ).toHaveBeenCalledTimes( 1 );
+			expect( ptt.callback ).toHaveBeenCalledWith( 'bar' );
+		} );
+	} );
+
+	describe( 'in browsers that do not support requestAnimationFrame', () => {
+		beforeAll( () => {
+			sinon.restore();
+			sinon.stub( window, 'requestAnimationFrame' ).value( undefined );
+		} );
+
+		test( 'should execute after a timeout', () => {
+			const callback = jest.fn();
+
+			const wrappedFunction = afterLayoutFlush( callback );
+			wrappedFunction();
+			expect( callback ).not.toBeCalled();
+
+			jest.runAllTimers();
+			expect( callback ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'should preserve arguments passed to wrapped function', () => {
+			const callback = jest.fn();
+			const wrappedFunction = afterLayoutFlush( callback );
+			wrappedFunction( 'foo', 'bar' );
+
+			jest.runAllTimers();
+
+			expect( callback ).toHaveBeenCalledTimes( 1 );
+			expect( callback ).toHaveBeenCalledWith( 'foo', 'bar' );
+		} );
+
+		test( 'should preserve `this` passed to wrapped function', () => {
+			setupPreserveThisTest();
+			const ptt = new PreserveThisTest();
+			ptt.wrappedFunction();
+
+			jest.runAllTimers();
+
+			expect( ptt.callback ).toHaveBeenCalledTimes( 1 );
+			expect( ptt.callback ).toHaveBeenCalledWith( 'bar' );
+		} );
+	} );
+
+	afterAll( () => sinon.restore() );
+} );


### PR DESCRIPTION
The method can be called multiple times in quick succession. If that happens, it will now use the last set of arguments passed to it, rather than the first.

Please double-check that the logic is right, @jsnajdr! It should work for both RAF-enabled and non-RAF-enabled browsers.