### PR TITLE
Activity Log: only fade 15% instead of 40% on free sites

### DIFF
--- a/client/my-sites/stats/activity-log-banner/style.scss
+++ b/client/my-sites/stats/activity-log-banner/style.scss
@@ -105,7 +105,7 @@
 	left: 0;
 	background: linear-gradient( to bottom, rgba( 243, 246, 248, 0.1 ), #f3f6f8 );
 	z-index: 179;
-	height: 40%;
+	height: 15%;
 	pointer-events: none;
 }
 


### PR DESCRIPTION
Before:

<img width="1491" alt="screen shot 2018-08-10 at 5 38 27 pm" src="https://user-images.githubusercontent.com/2694219/43982529-47db8386-9cc4-11e8-8718-a3952381f934.png">

After:

<img width="1491" alt="screen shot 2018-08-10 at 5 38 52 pm" src="https://user-images.githubusercontent.com/2694219/43982537-4d41218c-9cc4-11e8-9118-dea9f352ef81.png">
