### PR TITLE
Redux Bridge: add 'getReduxStore' fn to return a Promise with initialized store

### DIFF
--- a/client/lib/redux-bridge/index.js
+++ b/client/lib/redux-bridge/index.js
@@ -7,8 +7,23 @@ import Dispatcher from 'dispatcher';
 
 let reduxStore = null;
 
+let resolveReduxStorePromise;
+const reduxStorePromise = new Promise( resolve => {
+	resolveReduxStorePromise = resolve;
+} );
+
 export function setReduxStore( store ) {
 	reduxStore = store;
+	resolveReduxStorePromise( store );
+}
+
+/**
+ * Asynchronously get the current Redux store. Returns a Promise that gets resolved only
+ * after the store is set by `setReduxStore`.
+ * @returns {Promise<ReduxStore>} Promise of the Redux store object.
+ */
+export function getReduxStore() {
+	return reduxStorePromise;
 }
 
 /**


### PR DESCRIPTION
Returns a promise of initialized store, so that clients can wait for Redux store to be initialized and then perform some task on it.

```js
import { getReduxStore } from 'lib/redux-bridge';

// on this line, store might not be initialized yet -- we're called too early in the boot sequence
const store = await getReduxStore();
// after awaiting, the store is guaranteed to be initialized
store.dispatch( theAction() );
```