### PR TITLE
Improve runtime performance for `InfiniteList`

### DIFF
--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -10,6 +10,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDom from 'react-dom';
+import afterLayoutFlush from 'lib/after-layout-flush';
 
 /**
  * Internal dependencies
@@ -99,9 +100,7 @@ export default class InfiniteList extends React.Component {
 			this._overrideHistoryScroll();
 		}
 		debug( 'setting scrollTop:', this.state.scrollTop );
-		this.updateScroll( {
-			triggeredByScroll: false,
-		} );
+		this.forcedScrollUpdate();
 		if ( this._contextLoaded() ) {
 			this._scrollContainer.addEventListener( 'scroll', this.onScroll );
 		}
@@ -134,9 +133,7 @@ export default class InfiniteList extends React.Component {
 		// we may have guessed item heights wrong - now we have real heights
 		if ( ! this.isScrolling ) {
 			this.cancelAnimationFrame();
-			this.updateScroll( {
-				triggeredByScroll: false,
-			} );
+			this.forcedScrollUpdate();
 		}
 	}
 
@@ -166,6 +163,7 @@ export default class InfiniteList extends React.Component {
 		this._scrollContainer.removeEventListener( 'scroll', this.onScroll );
 		this._scrollContainer.removeEventListener( 'scroll', this._resetScroll );
 		this.cancelAnimationFrame();
+		this.forcedScrollUpdate.cancel();
 		this._isMounted = false;
 	}
 
@@ -176,6 +174,12 @@ export default class InfiniteList extends React.Component {
 		}
 		this.lastScrollTop = -1;
 	}
+
+	forcedScrollUpdate = afterLayoutFlush( () =>
+		this.updateScroll( {
+			triggeredByScroll: false,
+		} )
+	);
 
 	onScroll = () => {
 		if ( this.isScrolling ) {

--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -49,7 +49,9 @@ export default class InfiniteList extends React.Component {
 	_isMounted = false;
 	smartSetState = smartSetState;
 
-	componentWillMount() {
+	constructor( ...args ) {
+		super( ...args );
+
 		const url = page.current;
 		let newState, scrollTop;
 
@@ -66,11 +68,9 @@ export default class InfiniteList extends React.Component {
 		this.scrollHelper = new ScrollHelper( this.boundsForRef );
 		this.scrollHelper.props = this.props;
 		if ( this._contextLoaded() ) {
-			this._scrollContainer = this.props.context || window;
+			this._scrollContainer = this.scrollHelper.props.context || window;
 			this.scrollHelper.updateContextHeight( this.getCurrentContextHeight() );
 		}
-
-		this.isScrolling = false;
 
 		if ( newState ) {
 			debug( 'infinite-list positions loaded from store' );
@@ -85,7 +85,7 @@ export default class InfiniteList extends React.Component {
 			};
 		}
 		debug( 'infinite list mounting', newState );
-		this.setState( newState );
+		this.state = newState;
 	}
 
 	componentDidMount() {
@@ -107,27 +107,9 @@ export default class InfiniteList extends React.Component {
 		}
 	}
 
-	componentWillReceiveProps( newProps ) {
-		this.scrollHelper.props = newProps;
-
-		// New item may have arrived, should we change the rendered range?
-		if ( ! this.isScrolling ) {
-			this.cancelAnimationFrame();
-			this.updateScroll( {
-				triggeredByScroll: false,
-			} );
-		}
-
-		// if the context changes, remove our scroll listener
-		if ( newProps.context === this.props.context ) {
-			return;
-		}
-		if ( this._contextLoaded() ) {
-			this._scrollContainer.removeEventListener( 'scroll', this._resetScroll );
-		}
-	}
-
 	componentDidUpdate( prevProps ) {
+		this.scrollHelper.props = this.props;
+
 		if ( ! this._contextLoaded() ) {
 			return;
 		}
@@ -135,6 +117,7 @@ export default class InfiniteList extends React.Component {
 		if ( this.props.context !== prevProps.context ) {
 			// remove old listener
 			if ( this._scrollContainer ) {
+				this._scrollContainer.removeEventListener( 'scroll', this._resetScroll );
 				this._scrollContainer.removeEventListener( 'scroll', this.onScroll );
 			}
 
@@ -341,6 +324,8 @@ export default class InfiniteList extends React.Component {
 	}
 
 	render() {
+		this.scrollHelper.props = this.props;
+
 		const propsToTransfer = omit( this.props, Object.keys( this.constructor.propTypes ) ),
 			spacerClassName = 'infinite-list__spacer';
 		let i,


### PR DESCRIPTION
`InfiniteList` currently runs layout synchronously during scrolling. This leads to poor runtime performance:

![image](https://user-images.githubusercontent.com/409615/44003293-53fa243a-9e48-11e8-9c27-a3dcb4f1ad74.png)

This PR delays that work until it's not expensive to run layout, improving things considerably:

![image](https://user-images.githubusercontent.com/409615/44003328-d4c0c20e-9e48-11e8-8e12-74b2aa22bb1d.png)

The remaining long frames are shorter. They seem to be related to React work upon new item load and layout calculations in other scripts (e.g. `w.js`).

This PR also rewrites `InfiniteList` to avoid deprecated React lifecycle methods.