### PR TITLE
Server Error: make sure to pass on valid context

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -1,6 +1,7 @@
 {
 	"env": "shared",
 	"env_id": "shared",
+	"favicon_url": "//s1.wp.com/i/favicon.ico",
 	"boom_analytics_enabled": false,
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": false,

--- a/config/development.json
+++ b/config/development.json
@@ -1,6 +1,7 @@
 {
 	"env": "development",
 	"env_id": "development",
+	"favicon_url": "/calypso/images/favicons/favicon-development.ico",
 	"client_slug": "browser",
 	"directly_rtm_widget_environment": "sandbox",
 	"hostname": "calypso.localhost",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -1,6 +1,7 @@
 {
 	"env": "production",
 	"env_id": "horizon",
+	"favicon_url": "/calypso/images/favicons/favicon-horizon.ico",
 	"client_slug": "browser",
 	"hostname": "horizon.wordpress.com",
 	"i18n_default_locale_slug": "en",

--- a/config/production.json
+++ b/config/production.json
@@ -1,6 +1,7 @@
 {
 	"env": "production",
 	"env_id": "production",
+	"favicon_url": "//s1.wp.com/i/favicon.ico",
 	"client_slug": "browser",
 	"hostname": "wordpress.com",
 	"i18n_default_locale_slug": "en",

--- a/config/stage.json
+++ b/config/stage.json
@@ -1,6 +1,7 @@
 {
 	"env": "production",
 	"env_id": "stage",
+	"favicon_url": "/calypso/images/favicons/favicon-staging.ico",
 	"client_slug": "browser",
 	"directly_rtm_widget_environment": "sandbox",
 	"hostname": "wordpress.com",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -1,6 +1,7 @@
 {
 	"env": "production",
 	"env_id": "wpcalypso",
+	"favicon_url": "/calypso/images/favicons/favicon-wpcalypso.ico",
 	"client_slug": "browser",
 	"directly_rtm_widget_environment": "sandbox",
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -492,7 +492,12 @@ function render404( request, response ) {
 	response.status( 404 ).send( renderJsx( '404', ctx ) );
 }
 
-function renderServerError( err, req, res ) {
+/* eslint-disable no-unused-vars */
+/* We don't use `next` but need to add it for express.js to
+   recognize this function as an error handler, hence the
+   eslint-disable. */
+function renderServerError( err, req, res, next ) {
+	/* eslint-enable no-unused-vars */
 	if ( process.env.NODE_ENV !== 'production' ) {
 		console.error( err );
 	}

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -182,21 +182,6 @@ function getAcceptedLanguagesFromHeader( header ) {
 		.filter( lang => lang );
 }
 
-const faviconUrlMap = {
-	stage: '/calypso/images/favicons/favicon-staging.ico',
-	horizon: '/calypso/images/favicons/favicon-horizon.ico',
-	development: '/calypso/images/favicons/favicon-development.ico',
-	wpcalypso: '/calypso/images/favicons/favicon-wpcalypso.ico',
-};
-
-function getFaviconUrl( env ) {
-	if ( env !== 'production' ) {
-		return faviconUrlMap[ env ];
-	}
-
-	return '//s1.wp.com/i/favicon.ico';
-}
-
 function getDefaultContext( request ) {
 	let initialServerState = {};
 	let sectionCss;
@@ -252,7 +237,7 @@ function getDefaultContext( request ) {
 			asset => ! asset.startsWith( 'manifest' )
 		),
 		manifest: getAssets().manifests.manifest,
-		faviconURL: getFaviconUrl( calypsoEnv ),
+		faviconURL: config( 'favicon_url' ),
 		isFluidWidth: !! config.isEnabled( 'fluid-width' ),
 		abTestHelper: !! config.isEnabled( 'dev/test-helper' ),
 		preferencesHelper: !! config.isEnabled( 'dev/preferences-helper' ),
@@ -515,7 +500,7 @@ function renderServerError( err, req, res ) {
 	res.status( err.status || 500 );
 	const ctx = {
 		urls: generateStaticUrls(),
-		faviconURL: getFaviconUrl( calypsoEnv ),
+		faviconURL: config( 'favicon_url' ),
 	};
 	res.send( renderJsx( '500', ctx ) );
 }

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -189,20 +189,6 @@ export function serverRender( req, res ) {
 	res.send( renderJsx( 'index', context ) );
 }
 
-export function serverRenderError( err, req, res, next ) {
-	if ( err ) {
-		if ( process.env.NODE_ENV !== 'production' ) {
-			console.error( err );
-		}
-		req.error = err;
-		res.status( err.status || 500 );
-		res.send( renderJsx( '500', req.context ) );
-		return;
-	}
-
-	next();
-}
-
 /**
  * The fallback middleware which ensures we have value for context.serverSideRender (the most common value). This is
  * executed early in the chain, but the section-specific middlewares may decide to override the value based on their


### PR DESCRIPTION
• Rename `serverRenderError` to `renderServerError` and move it to `server/pages`
• Make sure to pass on a valid (react) context object to render the 500 component

The latter is likely a fix for the `TypeError: Cannot read property 'style.css' of undefined` which you see sometimes on local calypso builds.

**What (might have) caused the error?**

If we render certain documents on the server (such as the default one, a 404 template or the 500) we expect a valid context object (= _props_ in React speech). It seems like we missed to provide one for rendering the 500 layout.

I think it's still an open question why the 500 got rendered but this PR at least should fix the render error.

Edit: Line 502 to 503 is the bug related change: https://github.com/Automattic/wp-calypso/pull/26655/files#diff-b2d6784517d1151d7e75f0287d0c6478R502

### testing

Go through these steps both on `master` and this branch locally:

1. Modify the function `render404` in `server/pages/index.js` to look like the following:

```js
// server/pages/index.js:490
function render404( request, response, next ) {
	const ctx = getDefaultContext( request );
	return next( new Error( 'some error' ) ); // <-- produce a server error
	response.status( 404 ).send( renderJsx( '404', ctx ) );
}
```

2. Run Calypso with `npm start`
3. After it built, go to `calypso.localhost:3000/blah`
4. Make sure 500 renders correctly (shouldn't on `master`)

For 1. you can likely also use any other method to produce a server error, that's only how I did it.