### PR TITLE
Media Library: Only attempt to clear MediaListStore if defined for a given site

### DIFF
--- a/client/lib/media/list-store.js
+++ b/client/lib/media/list-store.js
@@ -89,8 +89,10 @@ MediaListStore.ensureActiveQueryForSiteId = function( siteId ) {
 
 function clearSite( siteId ) {
 	delete MediaListStore._media[ siteId ];
-	delete MediaListStore._activeQueries[ siteId ].nextPageHandle;
-	MediaListStore._activeQueries[ siteId ].isFetchingNextPage = false;
+	if ( !! MediaListStore._activeQueries[ siteId ] ) {
+		delete MediaListStore._activeQueries[ siteId ].nextPageHandle;
+		MediaListStore._activeQueries[ siteId ].isFetchingNextPage = false;
+	}
 }
 
 function updateActiveQuery( siteId, query ) {

--- a/client/lib/media/list-store.js
+++ b/client/lib/media/list-store.js
@@ -89,10 +89,12 @@ MediaListStore.ensureActiveQueryForSiteId = function( siteId ) {
 
 function clearSite( siteId ) {
 	delete MediaListStore._media[ siteId ];
-	if ( !! MediaListStore._activeQueries[ siteId ] ) {
-		delete MediaListStore._activeQueries[ siteId ].nextPageHandle;
-		MediaListStore._activeQueries[ siteId ].isFetchingNextPage = false;
-	}
+	// Immutable equivalent to `delete MediaListStore._activeQueries[ siteId ].nextPageHandle`.
+	const { nextPageHandle, ...activeQueries } = MediaListStore._activeQueries[ siteId ] || {};
+	MediaListStore._activeQueries[ siteId ] = {
+		...activeQueries,
+		isFetchingNextPage: false,
+	};
 }
 
 function updateActiveQuery( siteId, query ) {


### PR DESCRIPTION
Fixes #26649 

Add an existence check on the `MediaListStore._activeQueries[ siteId ]` object to avoid throwing a TypeError and crashing.

When changing the Media Library source, `MediaListStore` clears the `activeQuery` property for the current site.
Though, it does so without first checking if there are active queries for the site, making it vulnerable to error out if indeed there are no active queries for the site.

## Testing Instructions

- Open the editor in both visual and HTML mode (also try refreshing to force each mode as default).
- Click on the "Add" button and select "Media from Google".
- Make sure Calypso doesn't crash.
- Try moving around the media library, and also closing it and reopening on a different source (e.g. "Free photo library", etc.), and make sure it behaves as expected.