### PR TITLE
SDK: refactor block CSS name-spacing

### DIFF
--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -72,6 +72,10 @@ yargs
 				description: 'Whether to watch for changes and automatically rebuild.',
 				type: 'boolean',
 			},
+			'namespace': {
+				description: 'Wheater CSS be namespaced.',
+				type: 'boolean',
+			},
 		} ),
 		handler: argv => gutenberg.compile( argv )
 	} )

--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -72,10 +72,6 @@ yargs
 				description: 'Whether to watch for changes and automatically rebuild.',
 				type: 'boolean',
 			},
-			'namespace': {
-				description: 'Whether CSS should be namespaced.',
-				type: 'boolean',
-			},
 		} ),
 		handler: argv => gutenberg.compile( argv )
 	} )

--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -73,7 +73,7 @@ yargs
 				type: 'boolean',
 			},
 			'namespace': {
-				description: 'Wheater CSS be namespaced.',
+				description: 'Whether CSS should be namespaced.',
 				type: 'boolean',
 			},
 		} ),

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -72,7 +72,9 @@ exports.compile = args => {
 	};
 
 	const name = path.basename( path.dirname( options.editorScript ).replace( /\/$/, '' ) );
-	const baseConfig = getBaseConfig( { extensionName: name } );
+	const baseConfig = getBaseConfig( {
+		extensionName: options.namespace ? name : false
+	} );
 
 	const config = {
 		...baseConfig,

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -72,9 +72,7 @@ exports.compile = args => {
 	};
 
 	const name = path.basename( path.dirname( options.editorScript ).replace( /\/$/, '' ) );
-	const baseConfig = getBaseConfig( {
-		extensionName: options.namespace ? name : false
-	} );
+	const baseConfig = getBaseConfig();
 
 	const config = {
 		...baseConfig,

--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block-editor.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block-editor.jsx
@@ -92,7 +92,7 @@ class JetpackMarkdownBlockEditor extends Component {
 		};
 
 		return (
-			<div>
+			<div className={ className }>
 				<BlockControls>
 					<ButtonGroup>
 						<button

--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block-save.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block-save.jsx
@@ -6,7 +6,7 @@
 import MarkdownPreview from './components/markdown-renderer';
 
 function JetpackMarkdownBlockSave( { attributes, className } ) {
-	return <MarkdownPreview className={ `${ className }-renderer` } source={ attributes.source } />;
+	return <MarkdownPreview className={ className } source={ attributes.source } />;
 }
 
 export default JetpackMarkdownBlockSave;

--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
@@ -9,10 +9,11 @@ import { registerBlockType } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
+import './markdown-editor.scss';
 import JetpackMarkdownBlockEditor from './jetpack-markdown-block-editor';
 import JetpackMarkdownBlockSave from './jetpack-markdown-block-save';
 
-registerBlockType( 'jetpack/markdown-block', {
+registerBlockType( 'a8c/markdown', {
 	title: __( 'Markdown' ),
 
 	description: [

--- a/client/gutenberg/extensions/markdown/markdown-editor.scss
+++ b/client/gutenberg/extensions/markdown/markdown-editor.scss
@@ -1,0 +1,8 @@
+.wp-block-a8c-markdown__placeholder {
+	opacity: 0.5;
+	pointer-events: none;
+}
+.wp-block-a8c-markdown__preview p {
+	min-height: 1.8em;
+	white-space: pre-wrap;
+}

--- a/client/gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx
@@ -56,8 +56,8 @@ const PluginRender = () => (
 	</Fragment>
 );
 
-registerPlugin( 'jetpack-publicize', {
+registerPlugin( 'a8c/publicize', {
 	render: PluginRender
 } );
 
-registerStore( 'jetpack/publicize', publicizeStore );
+registerStore( 'a8c/publicize', publicizeStore );

--- a/client/gutenberg/extensions/publicize/publicize-gutenberg-store.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-gutenberg-store.jsx
@@ -2,7 +2,7 @@
  * Publicize store for connection data
  *
  * Implements reducer, actions, and selector
- * for 'jetpack/publicize' store.
+ * for 'a8c/publicize' store.
  *
  * @since  5.9.1
  */

--- a/client/gutenberg/extensions/publicize/publicize-panel.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-panel.jsx
@@ -79,13 +79,13 @@ class PublicizePanel extends Component {
 
 export default PublicizePanel = compose(
 	withSelect( ( select ) => ( {
-		connections: select( 'jetpack/publicize' ).getConnections(),
-		isLoading: select( 'jetpack/publicize' ).getIsLoading(),
+		connections: select( 'a8c/publicize' ).getConnections(),
+		isLoading: select( 'a8c/publicize' ).getIsLoading(),
 		postId: select( 'core/editor' ).getCurrentPost().id,
 	} ) ),
 	withDispatch( ( dispatch, ownProps ) => ( {
-		getConnectionsDone: dispatch( 'jetpack/publicize' ).getConnectionsDone,
-		getConnectionsFail: dispatch( 'jetpack/publicize' ).getConnectionsFail,
+		getConnectionsDone: dispatch( 'a8c/publicize' ).getConnectionsDone,
+		getConnectionsFail: dispatch( 'a8c/publicize' ).getConnectionsFail,
 		/**
 		 * Starts request for current list of connections.
 		 *
@@ -96,8 +96,8 @@ export default PublicizePanel = compose(
 			const {
 				getConnectionsDone,
 				getConnectionsFail,
-			} = dispatch( 'jetpack/publicize' );
-			dispatch( 'jetpack/publicize' ).getConnectionsStart();
+			} = dispatch( 'a8c/publicize' );
+			dispatch( 'a8c/publicize' ).getConnectionsStart();
 			requestPublicizeConnections( postId ).then(
 				( result ) => getConnectionsDone( result ),
 				() => getConnectionsFail(),

--- a/client/gutenberg/extensions/tiled-gallery/components/tiled-gallery-layout-square.js
+++ b/client/gutenberg/extensions/tiled-gallery/components/tiled-gallery-layout-square.js
@@ -110,10 +110,10 @@ class TiledGalleryLayoutSquare extends Component {
 
 	render() {
 		const rows = this.computeItems();
-		const linkTo = this.props.linkTo;
+		const { linkTo, className } = this.props;
 
 		return (
-			<div className="tiled-gallery">
+			<div className={ className }>
 				<div className="tiled-gallery-square tiled-gallery-unresized" data-original-width={ CONTENT_WIDTH }>
 					{ rows.map( ( row, index ) => {
 						const styleAttr = {

--- a/client/gutenberg/extensions/tiled-gallery/edit.js
+++ b/client/gutenberg/extensions/tiled-gallery/edit.js
@@ -185,8 +185,9 @@ class JetpackGalleryBlockEditor extends Component {
 		const imageTiles = (
 			<JetpackGalleryBlockSave
 				attributes={ {
-					images: images,
-					columns: columns,
+					className,
+					images,
+					columns,
 					linkTo: 'none',
 				} }
 			/>

--- a/client/gutenberg/extensions/tiled-gallery/tiled-gallery.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/tiled-gallery.jsx
@@ -4,15 +4,14 @@
 import { __ } from '@wordpress/i18n';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 
-import './tiled-gallery.scss';
-
 /**
  * Internal dependencies
  */
+import './tiled-gallery.scss';
 import JetpackGalleryBlockEditor from './edit.js';
 import JetpackGalleryBlockSave from './save.js';
 
-const JetpackGalleryBlockType = 'jetpack/gallery';
+const JetpackGalleryBlockType = 'a8c/tiled-gallery';
 
 const settings = {
 	title: __( 'Tiled Gallery' ),

--- a/client/gutenberg/extensions/tiled-gallery/tiled-gallery.scss
+++ b/client/gutenberg/extensions/tiled-gallery/tiled-gallery.scss
@@ -1,62 +1,64 @@
-.tiled-gallery-square {
-	clear: both;
-	margin: 0 0 20px;
-	overflow: hidden;
-}
-.tiled-gallery-image {
-	margin: 2px !important; /* Ensure that this value isn't overridden by themes that give content images blanket margins */
-}
-.gallery-group {
-	float: left;
-	position: relative;
-}
-.gallery-row {
-	 overflow: hidden;
-}
-.tiled-gallery-item {
-	float: left;
-	margin: 0;
-	position: relative;
-	width: inherit; /* prevents ie8 bug with inline width styles */
-	a { /* Needs to reset some properties for theme compatibility */
-		background: transparent;
-		border: none;
-		color: inherit;
+.wp-block-a8c-tiled-gallery {
+	.tiled-gallery-square {
+		clear: both;
+		margin: 0 0 20px;
+		overflow: hidden;
+	}
+	.tiled-gallery-image {
+		margin: 2px !important; /* Ensure that this value isn't overridden by themes that give content images blanket margins */
+	}
+	.gallery-group {
+		float: left;
+		position: relative;
+	}
+	.gallery-row {
+		 overflow: hidden;
+	}
+	.tiled-gallery-item {
+		float: left;
 		margin: 0;
-		padding: 0;
-		text-decoration: none;
-		width: auto;
+		position: relative;
+		width: inherit; /* prevents ie8 bug with inline width styles */
+		a { /* Needs to reset some properties for theme compatibility */
+			background: transparent;
+			border: none;
+			color: inherit;
+			margin: 0;
+			padding: 0;
+			text-decoration: none;
+			width: auto;
+		}
+		figure {
+			margin: 0;
+		}
+		.tiled-gallery-image,
+		.tiled-gallery-image:hover { /* Needs to reset some properties for theme compatibility */
+			background: none;
+			border: none;
+			box-shadow: none;
+			max-width: 100%;
+			padding: 0;
+			vertical-align: middle;
+		}
 	}
-	figure {
-		margin: 0;
-	}
-	.tiled-gallery-image,
-	.tiled-gallery-image:hover { /* Needs to reset some properties for theme compatibility */
-		background: none;
-		border: none;
-		box-shadow: none;
-		max-width: 100%;
-		padding: 0;
-		vertical-align: middle;
-	}
-}
 
-.tiled-gallery-caption { /* Captions */
-	background: #eee;
-	background: rgba( 255,255,255,0.8 );
-	color: #333;
-	font-size: 13px;
-	font-weight: 400;
-	overflow: hidden;
-	padding: 10px 0;
-	position: absolute;
-	bottom: 0;
-	text-indent: 10px;
-	text-overflow: ellipsis;
-	width: 100%;
-	white-space: nowrap;
-}
+	.tiled-gallery-caption { /* Captions */
+		background: #eee;
+		background: rgba( 255,255,255,0.8 );
+		color: #333;
+		font-size: 13px;
+		font-weight: 400;
+		overflow: hidden;
+		padding: 10px 0;
+		position: absolute;
+		bottom: 0;
+		text-indent: 10px;
+		text-overflow: ellipsis;
+		width: 100%;
+		white-space: nowrap;
+	}
 
-.tiled-gallery-item-small .tiled-gallery-caption { /* Smaller captions */
-	font-size: 11px;
+	.tiled-gallery-item-small .tiled-gallery-caption { /* Smaller captions */
+		font-size: 11px;
+	}
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1701,7 +1701,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1713,7 +1712,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3882,27 +3880,6 @@
         "randomfill": "^1.0.3"
       }
     },
-    "css": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/css/-/css-2.2.3.tgz",
-      "integrity": "sha512-0W171WccAjQGGTKLhw4m2nnl0zPHUlTO/I8td4XzJgIB8Hg3ZZx71qT4G4eX8OVsSiaAKiUMy73E3nsbPlg2DQ==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "source-map": "^0.1.38",
-        "source-map-resolve": "^0.5.1",
-        "urix": "^0.1.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        }
-      }
-    },
     "css-loader": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.0.tgz",
@@ -3937,14 +3914,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
-      }
-    },
-    "css-parse": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz",
-      "integrity": "sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=",
-      "requires": {
-        "css": "^2.0.0"
       }
     },
     "css-select": {
@@ -4009,14 +3978,6 @@
             "jsesc": "~0.5.0"
           }
         }
-      }
-    },
-    "css-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-2.0.0.tgz",
-      "integrity": "sha1-LvM9z0mMPT7oK9c9CgGsKGKM0Po=",
-      "requires": {
-        "css": "^2.0.0"
       }
     },
     "css-what": {
@@ -6214,8 +6175,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6233,13 +6193,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6252,18 +6210,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6366,8 +6321,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6377,7 +6331,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6390,20 +6343,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6420,7 +6370,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6493,8 +6442,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6504,7 +6452,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6580,8 +6527,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6611,7 +6557,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6629,7 +6574,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6668,13 +6612,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -9780,8 +9722,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "longest-streak": {
       "version": "2.0.2",
@@ -10332,31 +10273,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
-    },
-    "namespace-css-loader": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/namespace-css-loader/-/namespace-css-loader-0.0.3.tgz",
-      "integrity": "sha1-Pgqsuc4tIIw65t+qYKgriL4nDlE=",
-      "requires": {
-        "namespace-css": "git+https://github.com/jeffling/namespace-css.git#10b40d25a09e04c24a424b906613afb93f080d8e"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz",
-          "integrity": "sha1-zfIl6ImPhAolje1E/JF3Z3Cv3JM="
-        },
-        "namespace-css": {
-          "version": "git+https://github.com/jeffling/namespace-css.git#10b40d25a09e04c24a424b906613afb93f080d8e",
-          "from": "git+https://github.com/jeffling/namespace-css.git#10b40d25a09e04c24a424b906613afb93f080d8e",
-          "requires": {
-            "css-parse": "~2.0.0",
-            "css-stringify": "~2.0.0",
-            "minimist": "1.1.0",
-            "traverse": "~0.6.6"
-          }
-        }
-      }
     },
     "nan": {
       "version": "2.10.0",
@@ -15404,11 +15320,6 @@
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/tracekit/-/tracekit-0.4.5.tgz",
       "integrity": "sha512-LAb1udnpvhpgcx6/gmv7s6RO5lBwQGgAT/1VW0egSNSMvH/3xU3xKLoJ3pc+nkJ5AMv9qgTBnCkrUzbrHmCLpg=="
-    },
-    "traverse": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "tree-kit": {
       "version": "0.5.27",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,6 @@
     "mkdirp": "0.5.1",
     "moment": "2.22.2",
     "morgan": "1.9.0",
-    "namespace-css-loader": "0.0.3",
     "node-sass": "4.9.3",
     "notifications-panel": "2.2.3",
     "npm-run-all": "4.1.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,12 +80,9 @@ const babelLoader = {
  *
  * @see {@link https://webpack.js.org/configuration/configuration-types/#exporting-a-function}
  *
- * @param  {object}  env                environment options
- * @param  {string}  env.extensionName  set by bin/sdk/gutenberg.js when building Gutenberg extensions
- * @param  {object}  argv               options map
  * @return {object}                     webpack config
  */
-function getWebpackConfig( { extensionName = '' } = {}, argv ) {
+function getWebpackConfig() {
 	const webpackConfig = {
 		bail: ! isDevelopment,
 		entry: { build: [ path.join( __dirname, 'client', 'boot', 'app' ) ] },
@@ -163,10 +160,6 @@ function getWebpackConfig( { extensionName = '' } = {}, argv ) {
 					use: _.compact( [
 						MiniCssExtractPlugin.loader,
 						'css-loader',
-						extensionName && {
-							loader: 'namespace-css-loader',
-							options: `.${ extensionName }`, // Just the namespace class
-						},
 						{
 							loader: 'sass-loader',
 							options: {


### PR DESCRIPTION
Refactor block CSS namespacing.

- Namespace all the blocks with `a8c` (instead of `jetpack`). This could be coming from a variable and customizable via cli to be different for each environment.
- Disable previous automated CSS namespacing by default. Enable it again with `--namespace` CLI arg
- Namespace all CSS with `.wp-block-a8c-blockname` already in stylesheets. Could be done in Webpack but this way we have more flexibility: 
    - Markdown uses `wp-block-a8c-markdown__placeholder` -format
    - Tiled Gallery `.wp-block-a8c-tiled-gallery .tiled-gallery-image` -format.
- Doesn't take imported Calypso components into consideration yet but makes it a separate concern by not trying to namespace both the block and Calypso components using the same namespace.

### Testing
#### Previously
If you build Jetpack bundle:
```bash
npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/presets/jetpack/editor.js
```

...you would get CSS:
```css
.jetpack .tiled-gallery-square { }
```

If you build Tiled gallery block:
```bash
npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/tiled-gallery/tiled-gallery.jsx
```

...you would get CSS:
```css
.tiled-gallery .tiled-gallery-square { }
```

#### After
With this PR you should always end up with:
```css
.wp-block-a8c-tiled-gallery .tiled-gallery-square { }
```