### PR TITLE
Domains: Make the "free" flag display consistent

### DIFF
--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -50,7 +50,7 @@
 		}
 	}
 
-	.no-price .domain-product-price__free-text {
+	&.no-price .domain-product-price__free-text {
 		@include breakpoint( '>660px' ) {
 			margin-left: 0;
 		}

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -53,7 +53,7 @@
 	&.is-free-domain {
 		font-size: 13px;
 		line-height: 1.7;
-		margin-top: 6px;
+		margin-top: 2px;
 
 		small {
 			font-size: 100%;

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -40,15 +40,20 @@
 	}
 
 	.domain-product-price__free-text {
-		color: $gray-darken-20;
+		color: $gray-darken-30;
 		display: block;
 		font-size: 14px;
-		margin-left: 14px;
 		font-weight: 400;
+
+		@include breakpoint( '>660px' ) {
+			margin-left: 14px;
+		}
 	}
 
 	&.is-free-domain {
 		font-size: 13px;
+		line-height: 1.7;
+		margin-top: 6px;
 
 		small {
 			font-size: 100%;
@@ -58,6 +63,12 @@
 		.domain-product-price__price {
 			opacity: 0.6;
 			text-decoration: line-through;
+		}
+
+		@include breakpoint( '>660px' ) {
+			font-size: 16px;
+			line-height: 1.5;
+			margin-top: 0;
 		}
 	}
 

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -50,6 +50,12 @@
 		}
 	}
 
+	.no-price .domain-product-price__free-text {
+		@include breakpoint( '>660px' ) {
+			margin-left: 0;
+		}
+	}
+
 	&.is-free-domain {
 		font-size: 13px;
 		line-height: 1.7;

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -40,10 +40,11 @@
 	}
 
 	.domain-product-price__free-text {
-		color: $alert-green;
+		color: $gray-darken-20;
 		display: block;
-		font-size: 11px;
-		text-transform: uppercase;
+		font-size: 14px;
+		margin-left: 14px;
+		font-weight: 400;
 	}
 
 	&.is-free-domain {


### PR DESCRIPTION
* Swap green for dark gray
* Remove text-transform and bold font
* Add left margin

**Before this PR**

<img width="1058" alt="screen shot 2018-08-13 at 10 51 29 am" src="https://user-images.githubusercontent.com/2124984/44039431-0cc1f17a-9ee7-11e8-81f5-84f7c1bba457.png">

**After this PR**

<img width="1058" alt="screen shot 2018-08-13 at 10 50 24 am" src="https://user-images.githubusercontent.com/2124984/44039430-0cb490ca-9ee7-11e8-8ae8-d7a007efbadb.png">

**Steps to test**

1) Switch to this PR and navigate to `/domains/add/`
2) Ensure the active site has a paid plan with a domain credit that has not been used
3) Check the "Free with your plan" text for the above changes