### PR TITLE
Calypso as a PWA: Load calypso offline

### DIFF
--- a/client/components/offline/index.js
+++ b/client/components/offline/index.js
@@ -1,0 +1,47 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import EmptyContent from 'components/empty-content';
+import { isOffline } from 'state/application/selectors';
+
+class Offline extends Component {
+	static getDerivedStateFromProps( props ) {
+		return {
+			isOffline: props.isOffline,
+		};
+	}
+
+	componentDidUpdate( prevProps, prevState ) {
+		if ( prevState.isOffline && ! this.state.isOffline ) {
+			if ( typeof window !== 'undefined' ) {
+				window.location.reload();
+			}
+		}
+	}
+
+	render() {
+		const { translate } = this.props;
+		return (
+			<EmptyContent
+				illustration="/calypso/images/illustrations/error.svg"
+				title={ translate( 'No Internet' ) }
+				line={ translate(
+					'Try checking the network cables, modem and router or reconnecting to Wi-Fi'
+				) }
+			/>
+		);
+	}
+}
+
+export default connect( state => ( {
+	isOffline: isOffline( state ),
+} ) )( localize( Offline ) );

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -17,6 +17,7 @@ import { setSection as setSectionAction } from 'state/ui/actions';
 import { getSection } from 'state/ui/selectors';
 import { setLocale } from 'state/ui/language/actions';
 import isRTL from 'state/selectors/is-rtl';
+import Offline from 'components/offline';
 
 export function makeLayoutMiddleware( LayoutComponent ) {
 	return ( context, next ) => {
@@ -24,14 +25,24 @@ export function makeLayoutMiddleware( LayoutComponent ) {
 
 		// On server, only render LoggedOutLayout when logged-out.
 		if ( ! context.isServerSide || ! getCurrentUser( context.store.getState() ) ) {
-			context.layout = (
-				<LayoutComponent
-					store={ store }
-					primary={ primary }
-					secondary={ secondary }
-					redirectUri={ context.originalUrl }
-				/>
-			);
+			if ( window.navigator.onLine === false && process.env.NODE_ENV !== 'development' ) {
+				context.layout = (
+					<LayoutComponent
+						store={ store }
+						primary={ <Offline /> }
+						redirectUri={ context.originalUrl }
+					/>
+				);
+			} else {
+				context.layout = (
+					<LayoutComponent
+						store={ store }
+						primary={ primary }
+						secondary={ secondary }
+						redirectUri={ context.originalUrl }
+					/>
+				);
+			}
 		}
 		next();
 	};

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -199,17 +199,19 @@ class Document extends React.Component {
 						 `,
 						} }
 					/>
-					<script
-						nonce={ inlineScriptNonce }
-						type="text/javascript"
-						dangerouslySetInnerHTML={ {
-							__html: `
+					{ lang === 'en' && (
+						<script
+							nonce={ inlineScriptNonce }
+							type="text/javascript"
+							dangerouslySetInnerHTML={ {
+								__html: `
 							if ( 'serviceWorker' in navigator ) {
 								navigator.serviceWorker.register( '/service-worker.js' );
 							}
 						 `,
-						} }
-					/>
+							} }
+						/>
+					) }
 					<noscript className="wpcom-site__global-noscript">
 						Please enable JavaScript in your browser to enjoy WordPress.com.
 					</noscript>

--- a/client/layout/error.jsx
+++ b/client/layout/error.jsx
@@ -16,6 +16,7 @@ import { stringify } from 'qs';
  */
 import analytics from 'lib/analytics';
 import EmptyContent from 'components/empty-content';
+import Offline from 'components/offline';
 
 /**
  * Module variables
@@ -48,5 +49,9 @@ export function retry( chunkName ) {
 export function show( context, chunkName ) {
 	log( 'Chunk %s could not be loaded', chunkName );
 	analytics.mc.bumpStat( 'calypso_chunk_error', chunkName );
-	context.primary = <LoadingErrorMessage />;
+	if ( window.navigator.onLine === false ) {
+		context.primary = <Offline />;
+	} else {
+		context.primary = <LoadingErrorMessage />;
+	}
 }

--- a/client/lib/service-worker/service-worker.js
+++ b/client/lib/service-worker/service-worker.js
@@ -16,6 +16,7 @@
 const queuedMessages = [];
 const CACHE_VERSION = 'v1';
 const OFFLINE_CALYPSO_URLS = [ '/offline', '/calypso/images/illustrations/error.svg' ];
+const isProduction = self.location.origin === 'https://wordpress.com';
 
 /**
  *  We want to make sure that if the service worker gets updated that we
@@ -180,6 +181,10 @@ function cacheAssets() {
 
 function canBootOffline() {
 	let downlink = 1;
+
+	if ( isProduction ) {
+		return Promise.reject();
+	}
 
 	if ( 'connection' in navigator && 'downlink' in navigator.connection ) {
 		downlink = self.navigator.connection.downlink;

--- a/client/lib/service-worker/service-worker.js
+++ b/client/lib/service-worker/service-worker.js
@@ -15,7 +15,11 @@
 
 const queuedMessages = [];
 const CACHE_VERSION = 'v1';
-const OFFLINE_CALYPSO_URLS = [ '/offline', '/calypso/images/illustrations/error.svg' ];
+const OFFLINE_CALYPSO_URLS = [
+	'/offline',
+	'/calypso/offline.js',
+	'/calypso/images/illustrations/error.svg',
+];
 const isProduction = self.location.origin === 'https://wordpress.com';
 
 /**

--- a/client/lib/service-worker/service-worker.js
+++ b/client/lib/service-worker/service-worker.js
@@ -14,20 +14,59 @@
 /* eslint-enable */
 
 const queuedMessages = [];
+const CACHE_VERSION = 'v1';
+const OFFLINE_CALYPSO_URLS = [ '/offline', '/calypso/images/illustrations/error.svg' ];
 
 /**
  *  We want to make sure that if the service worker gets updated that we
  *  immediately claim it, to ensure we're not running stale versions of the worker
  *	See: https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/skipWaiting
  **/
-
 self.addEventListener( 'install', function( event ) {
-	event.waitUntil( self.skipWaiting() );
+	// The promise that skipWaiting() returns can be safely ignored.
+	self.skipWaiting();
+
+	event.waitUntil( cacheUrls( OFFLINE_CALYPSO_URLS, true ) );
 } );
 
 self.addEventListener( 'activate', function( event ) {
-	event.waitUntil( self.clients.claim() );
+	event.waitUntil(
+		Promise.all( [
+			// https://developers.google.com/web/updates/2017/02/navigation-preload
+			self.registration.navigationPreload && self.registration.navigationPreload.enable(),
+			// Calling clients.claim() here sets the Service Worker as the controller of the client pages.
+			// This allows the pages to start using the Service Worker immediately without reloading.
+			// https://developer.mozilla.org/en-US/docs/Web/API/Clients/claim
+			self.clients.claim(),
+			clearOldCaches(),
+		] )
+	);
 } );
+
+function sendMessages( messages, focus ) {
+	focus = focus || false;
+	return self.clients.matchAll().then( function( clientList ) {
+		if ( clientList.length > 0 ) {
+			messages.forEach( function( message ) {
+				clientList[ 0 ].postMessage( message );
+			} );
+			if ( focus ) {
+				try {
+					clientList[ 0 ].focus();
+				} catch ( err ) {
+					// Client didn't need focus
+				}
+			}
+		} else {
+			messages.forEach( function( message ) {
+				queuedMessages.push( message );
+			} );
+			if ( focus ) {
+				self.clients.openWindow( '/' );
+			}
+		}
+	} );
+}
 
 self.addEventListener( 'push', function( event ) {
 	let notification;
@@ -61,21 +100,10 @@ self.addEventListener( 'notificationclick', function( event ) {
 	notification.close();
 
 	event.waitUntil(
-		self.clients.matchAll().then( function( clientList ) {
-			if ( clientList.length > 0 ) {
-				clientList[ 0 ].postMessage( { action: 'openPanel' } );
-				clientList[ 0 ].postMessage( { action: 'trackClick', notification: notification.data } );
-				try {
-					clientList[ 0 ].focus();
-				} catch ( err ) {
-					// Client didn't need focus
-				}
-			} else {
-				queuedMessages.push( { action: 'openPanel' } );
-				queuedMessages.push( { action: 'trackClick', notification: notification.data } );
-				self.clients.openWindow( '/' );
-			}
-		} )
+		sendMessages(
+			[ { action: 'openPanel' }, { action: 'trackClick', notification: notification.data } ],
+			true
+		)
 	);
 } );
 
@@ -101,8 +129,170 @@ self.addEventListener( 'message', function( event ) {
 	}
 } );
 
-/* eslint-disable */
 self.addEventListener( 'fetch', function( event ) {
-	// this listener is required for "Add to Home Screen" support
+	const request = event.request;
+
+	if ( request.method !== 'GET' ) {
+		return;
+	}
+
+	if ( request.mode === 'navigate' ) {
+		event.respondWith( fetchNetworkFirst( request, '/offline' ) );
+		event.waitUntil( cacheAssets() );
+		return;
+	}
+
+	if ( isCacheable( request.url ) ) {
+		if ( ! navigator.onLine ) {
+			event.respondWith( fetchCacheFirst( request ) );
+		} else {
+			// Always get the freshest resource to avoid having to reload the page twice on code change.
+			// It may cause inconsistencies in the cache as some assets are not fetched on page load.
+			event.respondWith( fetchNetworkFirst( request ) );
+		}
+	}
 } );
+
+// periodically check that assets are up to date
+function cacheAssets() {
+	if ( ! navigator.onLine || ! self.registration.active ) {
+		return Promise.resolve();
+	}
+
+	// Do not cache assets if bandwidth is less than 10Mb/s
+	const downlink = self.navigator.connection.downlink || 1;
+	if ( downlink < 10 ) {
+		return cacheUrls( OFFLINE_CALYPSO_URLS, true );
+	}
+
+	return getAssetsHashFromCache().then( previousHash => {
+		return getAssets().then( function( response ) {
+			if ( previousHash !== response.hash ) {
+				return clearCache().then( function() {
+					return Promise.all( [
+						cacheUrls( response.assets ),
+						cacheUrls( OFFLINE_CALYPSO_URLS, true ),
+					] );
+				} );
+			}
+		} );
+	} );
+}
+
+/* eslint-disable */
+function isCacheable( url ) {
+	var urlObject;
+
+	if ( ! url ) {
+		return false;
+	}
+
+	if ( url[ 0 ] === '/' ) {
+		url = location.origin + url;
+	}
+
+	try {
+		urlObject = new URL( url );
+	} catch ( err ) {
+		// malformed url
+		return false;
+	}
+
+	return (
+		urlObject.origin === location.origin &&
+		urlObject.pathname.match( /\.(json|js|css|svg|gif|png|woff2?|ttf|eot|wav)$/ ) &&
+		! urlObject.pathname.match( /__webpack_hmr$|^\/socket\.io\/|^\/version$|\/flags\/[a-z]+\.svg$/ )
+	);
+}
 /* eslint-enable */
+
+function fetchCacheFirst( request ) {
+	const url = request.url || request;
+	return caches.open( CACHE_VERSION ).then( function( cache ) {
+		return caches.match( request ).then( function( cachedResponse ) {
+			if ( cachedResponse ) {
+				return cachedResponse;
+			}
+
+			return fetch( request )
+				.then( function( networkResponse ) {
+					if ( isCacheable( url ) ) {
+						cache.put( request, networkResponse.clone() );
+					}
+					return networkResponse;
+				} )
+				.catch( function() {
+					// if cache and network failed, try cache one more time without query parameters
+					return caches.match( request, { ignoreSearch: true } );
+				} );
+		} );
+	} );
+}
+
+function fetchNetworkFirst( request, fallback /* = null */ ) {
+	const url = request.url || request;
+	return caches.open( CACHE_VERSION ).then( function( cache ) {
+		return fetch( request )
+			.then( function( networkResponse ) {
+				if ( isCacheable( url ) ) {
+					cache.put( request, networkResponse.clone() );
+				}
+				return networkResponse;
+			} )
+			.catch( function() {
+				return cache.match( request ).then( function( cachedResponse ) {
+					if ( cachedResponse ) {
+						return cachedResponse;
+					}
+					if ( fallback ) {
+						return caches.match( fallback );
+					}
+					return Promise.reject();
+				} );
+			} );
+	} );
+}
+
+function getAssets() {
+	return fetchNetworkFirst( '/calypso/assets.json' ).then( function( response ) {
+		return response.json();
+	} );
+}
+
+function getAssetsHashFromCache() {
+	return caches.open( CACHE_VERSION ).then( function( cache ) {
+		return cache.match( '/calypso/assets.json' ).then( function( cachedResponse ) {
+			if ( ! cachedResponse ) {
+				return null;
+			}
+
+			return cachedResponse.json().then( function( json ) {
+				return json.hash;
+			} );
+		} );
+	} );
+}
+
+function cacheUrls( urls, force ) {
+	force = force || false;
+	return caches.open( CACHE_VERSION ).then( function( cache ) {
+		// resolve all assets
+		return cache.addAll( force ? urls : urls.filter( isCacheable ) );
+	} );
+}
+
+function clearOldCaches() {
+	return self.caches.keys().then( function( cacheNames ) {
+		return Promise.all(
+			cacheNames.map( function( cacheName ) {
+				if ( CACHE_VERSION !== cacheName ) {
+					return self.caches.delete( cacheName );
+				}
+			} )
+		);
+	} );
+}
+
+function clearCache() {
+	return self.caches.delete( CACHE_VERSION );
+}

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -146,7 +146,6 @@ export class Notifications extends Component {
 					push_notification_note_id: event.data.notification.note_id,
 					push_notification_type: event.data.notification.type,
 				} );
-
 				return;
 		}
 	};

--- a/client/offline/controller.js
+++ b/client/offline/controller.js
@@ -1,0 +1,16 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Offline from 'components/offline';
+
+export function offline( context, next ) {
+	context.primary = <Offline />;
+	next();
+}

--- a/client/offline/index.js
+++ b/client/offline/index.js
@@ -1,0 +1,11 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { offline } from './controller';
+import { makeLayout } from 'controller';
+
+export default router => {
+	router( '/offline', offline, makeLayout );
+};

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -277,6 +277,12 @@ const sections = [
 		secondary: true,
 		css: 'feature-upsell',
 	},
+	{
+		name: 'offline',
+		paths: [ '/offline' ],
+		module: 'offline',
+		enableLoggedOut: true,
+	},
 ];
 
 sections.push( {

--- a/server/bundler/assets-utils.js
+++ b/server/bundler/assets-utils.js
@@ -1,0 +1,117 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import { flatten, forEach } from 'lodash';
+import url from 'url';
+/**
+ * Internal dependencies
+ */
+import utils from 'bundler/utils';
+import sections from '../../client/sections';
+import config from 'config';
+
+const SERVER_BASE_PATH = '/public';
+const ASSETS_PATH = path.join( __dirname, 'assets.json' );
+
+export const staticFiles = [
+	{ path: 'style.css' },
+	{ path: 'editor.css' },
+	{ path: 'tinymce/skins/wordpress/wp-content.css' },
+	{ path: 'style-debug.css' },
+	{ path: 'style-rtl.css' },
+	{ path: 'style-debug-rtl.css' },
+];
+
+export const staticFilesUrls = staticFiles.reduce( ( result, file ) => {
+	if ( ! file.hash ) {
+		file.hash = utils.hashFile( process.cwd() + SERVER_BASE_PATH + '/' + file.path );
+	}
+	result[ file.path ] = utils.getUrl( file.path, file.hash );
+	return result;
+}, {} );
+
+export const getAssets = ( () => {
+	let assets;
+	return () => {
+		// refresh assets in development as those can change with webpack hot loader
+		if ( ! assets || process.env.NODE_ENV === 'development' ) {
+			const assetsContent = fs.readFileSync( ASSETS_PATH, 'utf8' );
+			assets = JSON.parse( assetsContent );
+			const shasum = crypto.createHash( 'sha1' );
+			shasum.update( assetsContent );
+			assets.hash = shasum.digest( 'hex' );
+		}
+		return assets;
+	};
+} )();
+
+export const getFilesForChunk = chunkName => {
+	const assets = getAssets();
+
+	function getChunkByName( _chunkName ) {
+		return assets.chunks.find( chunk => chunk.names.some( name => name === _chunkName ) );
+	}
+
+	function getChunkById( chunkId ) {
+		return assets.chunks.find( chunk => chunk.id === chunkId );
+	}
+
+	const chunk = getChunkByName( chunkName );
+	if ( ! chunk ) {
+		console.warn( 'cannot find the chunk ' + chunkName );
+		console.warn( 'available chunks:' );
+		assets.chunks.forEach( c => {
+			console.log( '    ' + c.id + ': ' + c.names.join( ',' ) );
+		} );
+		return [];
+	}
+
+	const allTheFiles = chunk.files.concat(
+		flatten( chunk.siblings.map( sibling => getChunkById( sibling ).files ) )
+	);
+
+	return allTheFiles;
+};
+
+/**
+ * Generate an object that maps asset names name to a server-relative urls.
+ * Assets in request and static files are included.
+ *
+ * @returns {Object} Map of asset names to urls
+ **/
+export function generateStaticUrls() {
+	const urls = { ...staticFilesUrls };
+	const assets = getAssets().assetsByChunkName;
+
+	// add sections css files
+	sections
+		.filter( section => ! section.envId || section.envId.indexOf( config( 'env_id' ) ) > -1 )
+		.forEach( section => {
+			if ( section.css ) {
+				const urlObjectLTR = url.parse( section.css.urls.ltr, true );
+				const cssNameLTR = path.resolve( '/calypso', urlObjectLTR.pathname );
+				urls[ cssNameLTR ] = {
+					hash: urlObjectLTR.query.v,
+					path: section.css.urls.ltr,
+				};
+				const urlObjectRTL = url.parse( section.css.urls.ltr, true );
+				const cssNameRTL = path.resolve( '/calypso', urlObjectRTL.pathname );
+				urls[ cssNameRTL ] = {
+					hash: urlObjectRTL.query.v,
+					path: section.css.urls.rtl,
+				};
+			}
+		} );
+
+	forEach( assets, ( asset, name ) => {
+		urls[ name ] = asset;
+	} );
+
+	return urls;
+}

--- a/server/bundler/assets-writer.js
+++ b/server/bundler/assets-writer.js
@@ -14,17 +14,11 @@ function AssetsWriter( options ) {
 		},
 		options
 	);
-	this.createOutputStream();
+	this.outputPath = path.join( this.options.path, this.options.filename );
 }
 
 Object.assign( AssetsWriter.prototype, {
-	createOutputStream: function() {
-		this.outputPath = path.join( this.options.path, this.options.filename );
-		this.outputStream = fs.createWriteStream( this.outputPath );
-	},
 	apply: function( compiler ) {
-		const self = this;
-
 		compiler.hooks.afterEmit.tap( 'AssetsWriter', compilation => {
 			const stats = compilation.getStats().toJson( {
 				hash: true,
@@ -85,7 +79,8 @@ Object.assign( AssetsWriter.prototype, {
 				} )
 			);
 
-			self.outputStream.write( JSON.stringify( statsToOutput, null, '\t' ) );
+			// we need to write synchronously to avoid reading an incomplete file in assets-utils.js `getAssets()`
+			fs.writeFileSync( this.outputPath, JSON.stringify( statsToOutput, null, '\t' ) );
 		} );
 	},
 } );

--- a/server/bundler/utils.js
+++ b/server/bundler/utils.js
@@ -28,9 +28,7 @@ function hashFile( path ) {
 
 function getUrl( filename, hash ) {
 	return (
-		URL_BASE_PATH +
-		'/' +
-		filename +
+		( filename[ 0 ] === '/' ? filename : URL_BASE_PATH + '/' + filename ) +
 		'?' +
 		qs.stringify( {
 			v: hash,

--- a/server/pwa/index.js
+++ b/server/pwa/index.js
@@ -5,11 +5,13 @@
  */
 import path from 'path';
 import express from 'express';
+import { flatten } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import manifest from './manifest';
+import { getAssets, generateStaticUrls } from 'bundler/assets-utils';
 
 export default () => {
 	const app = express();
@@ -23,6 +25,25 @@ export default () => {
 		express.static(
 			path.resolve( __dirname, '..', '..', 'client', 'lib', 'service-worker', 'service-worker.js' )
 		)
+	);
+
+	// this is used from the service worker to cache all our assets on load
+	app.get(
+		'/calypso/assets.json',
+		( () => {
+			// cache last response
+			let lastAssetsResponse;
+			return function( req, res ) {
+				const assetsHash = getAssets().hash;
+				if ( ! lastAssetsResponse || lastAssetsResponse.hash !== assetsHash ) {
+					lastAssetsResponse = {
+						assets: flatten( Object.values( generateStaticUrls() ) ),
+						hash: assetsHash,
+					};
+				}
+				res.json( lastAssetsResponse );
+			};
+		} )()
 	);
 
 	return app;


### PR DESCRIPTION
Follow up of ~~https://github.com/Automattic/wp-calypso/pull/26494~~ https://github.com/Automattic/wp-calypso/pull/26934 (will rebase when merged)

This makes Calypso load offline using a service worker.

The approach taken here is to cache all the assets asynchronously on page load, if the user's bandwidth is at least 10Mb/s.

When the application loads, the service worker will cache an offline page and will check if calypso's assets have changed since the last time and will update the cache (asynchronously) with all the assets (not just the one that were requested during the page load).

For this to work, a new resource is introduced: `/calypso/assets.json` which lists all the assets cacheable by the app (only js and css is cached for now).
It also works in development as the list of assets is refreshed when webpack rebuilds the app.

When the app is loaded offline, the offline page will be served instead of the actual page.
In development the app will still boot as usual and you will be able to develop new features and verify how they behave offline.
In production however, the app is currently disabled and a simple offline screen is displayed:

![image](https://user-images.githubusercontent.com/230230/44793848-7ffd6080-aba7-11e8-949b-d7261954d291.png)

The user's connectivity is monitored and if we're back online the app is refreshed so the current route loads correctly.

### Testing Instructions
- Load calypso once and then reload it offline (you can use the offline feature of chrome devtools), it should work
- Try editing a module, waiting for webpack to rebuild and reloading the app, it should work
- Test the production environment or edit `client/controller/shared.js` to remove the `process.env.NODE_ENV !== 'development'` condition, when reloading the app, the offline screen should be visible
- Try installing the app as a PWA (Chrome menu > Install WordPress.com) and using the app online and offline
- Try installing the app as a PWA from a branch in calypso.live
- If you have a local production environment, try logging out and navigating to https://wordpress.com or https://wordpress.com/domains offline, you should be able to see the marketing site as expected. Offline the offline calypso page should display.

### Reviews
- [ ] Code
- [ ] Product
- [ ] Design

### TODO
- [ ] Show the offline page when user is offline and logged out. This is currently not possible because the app does not boot in that case https://github.com/Automattic/wp-calypso/blob/master/client/boot/app.js#L42
- [x] Find a way to lighten the amount of assets downloaded or make it a voluntary user action. (disabled in production for now)

In another PR: Make sure users who have the app installed do not see the prompt and/or [trigger the prompt](https://developers.google.com/web/fundamentals/app-install-banners/) to install from calypso UI.