### PR TITLE
Activity Log: Update plugin URL for AT sites

### DIFF
--- a/client/components/notes-formatted-block/index.jsx
+++ b/client/components/notes-formatted-block/index.jsx
@@ -4,7 +4,12 @@
  */
 import React from 'react';
 
-export const FormattedBlock = ( { content = {} } ) => {
+/**
+ * Internal Dependencies
+ */
+import { getSiteAdminPluginInstallUrl } from 'lib/plugins/utils';
+
+export const FormattedBlock = ( { content = {}, siteAdminUrl } ) => {
 	const {
 		siteId,
 		children,
@@ -65,7 +70,7 @@ export const FormattedBlock = ( { content = {} } ) => {
 			);
 
 		case 'plugin':
-			return <a href={ `/plugins/${ pluginSlug }/${ siteSlug }` }>{ descent }</a>;
+			return <a href={ getSiteAdminPluginInstallUrl( siteAdminUrl, pluginSlug ) }>{ descent }</a>;
 
 		case 'post':
 			return isTrashed ? (

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -221,3 +221,19 @@ export function normalizePluginsList( pluginsList ) {
 export function filterNotices( logs, site, pluginSlug ) {
 	return filter( logs, filterNoticesBy.bind( this, site, pluginSlug ) );
 }
+
+export function getSiteAdminPluginInstallUrl( siteAdminUrl, slug ) {
+	const pluginInstallUrl = `${ siteAdminUrl }/plugin-install.php?calypsoify=1`;
+	if ( ! slug ) {
+		return pluginInstallUrl;
+	}
+
+	return [
+		`${ pluginInstallUrl }&`,
+		'tab=search',
+		`s=${ slug }`,
+		'type=term',
+		'modal-mode=true',
+		`plugin=${ slug }`,
+	].join( '&' );
+}

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -32,6 +32,7 @@ import { getSiteFragment, sectionify } from 'lib/route';
 import notices from 'notices';
 import config from 'config';
 import analytics from 'lib/analytics';
+import { getSiteAdminPluginInstallUrl } from 'lib/plugins/utils';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import getPrimaryDomainBySiteId from 'state/selectors/get-primary-domain-by-site-id';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
@@ -388,22 +389,12 @@ export function siteSelection( context, next ) {
 			calypsoify &&
 			/^\/plugins/.test( basePath )
 		) {
-			const plugin = get( context, 'params.plugin' );
-			let pluginString = '';
-			if ( plugin ) {
-				pluginString = [
-					'tab=search',
-					`s=${ plugin }`,
-					'type=term',
-					'modal-mode=true',
-					`plugin=${ plugin }`,
-				].join( '&' );
-			}
+			const pluginUrl = getSiteAdminPluginInstallUrl(
+				getSiteAdminUrl( state, siteId ),
+				get( context, 'params.plugin' )
+			);
 
-			const pluginIstallURL = 'plugin-install.php?calypsoify=1' + `&${ pluginString }`;
-			const pluginLink = getSiteAdminUrl( state, siteId ) + pluginIstallURL;
-
-			return window.location.replace( pluginLink );
+			return window.location.replace( pluginUrl );
 		}
 
 		dispatch( setSelectedSiteId( siteId ) );

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -37,7 +37,8 @@ import getRewindState from 'state/selectors/get-rewind-state';
 import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
 import { adjustMoment } from '../activity-log/utils';
-import { getSite } from 'state/sites/selectors';
+import { getSite, getSiteAdminUrl } from 'state/sites/selectors';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 
 class ActivityLogItem extends Component {
 	static propTypes = {
@@ -83,6 +84,8 @@ class ActivityLogItem extends Component {
 			activity: { activityName, activityDescription, activityMeta },
 			translate,
 			rewindIsActive,
+			isAtomicSite,
+			siteAdminUrl,
 		} = this.props;
 
 		// If backup failed due to invalid credentials but Rewind is now active means it was fixed.
@@ -99,7 +102,14 @@ class ActivityLogItem extends Component {
 		/* There is no great way to generate a more valid React key here
 		 * but the index is probably sufficient because these sub-items
 		 * shouldn't be changing. */
-		return activityDescription.map( ( part, i ) => <FormattedBlock key={ i } content={ part } /> );
+		return activityDescription.map( ( part, i ) => (
+			<FormattedBlock
+				key={ i }
+				content={ part }
+				isAtomicSite={ isAtomicSite }
+				siteAdminUrl={ siteAdminUrl }
+			/>
+		) );
 	}
 
 	renderItemAction() {
@@ -321,6 +331,8 @@ const mapStateToProps = ( state, { activity, siteId } ) => {
 		rewindIsActive: 'active' === rewindState.state || 'provisioning' === rewindState.state,
 		canAutoconfigure: rewindState.canAutoconfigure,
 		site,
+		isAtomicSite: isSiteAutomatedTransfer( state, siteId ),
+		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 	};
 };
 


### PR DESCRIPTION
This PR updates the URL for a plugin when it's an AT site. It's part of this https://github.com/Automattic/wp-calypso/pull/25767, fixing this bug: https://github.com/Automattic/wp-calypso/issues/26570

Although right now it redirects to the browser when the route matches with the plugin one, maybe it's better to define rightly the plugin URL avoiding the redirection.

### Testing

After applying the patch to confirm the plugin link goes to the right URL for AT sites.

![image](https://user-images.githubusercontent.com/77539/44047229-257cc538-9f04-11e8-9810-d5c9198945cd.png)
