### PR TITLE
Component: Modularize and simplify SegmentedControl

### DIFF
--- a/client/components/segmented-control/README.md
+++ b/client/components/segmented-control/README.md
@@ -17,7 +17,7 @@ A good example for this case is navigation. Sometimes the option that is selecte
 ```jsx
 import React from 'react';
 import SegmentedControl from 'components/segmented-control';
-import ControlItem from 'components/segmented-control/item';
+import SegmentedControlItem from 'components/segmented-control/item';
 
 export default class extends React.Component {
 	// ...
@@ -25,40 +25,40 @@ export default class extends React.Component {
 	render() {
 		return (
 			<SegmentedControl>
-				<ControlItem
+				<SegmentedControlItem
 					selected={ this.state.selected === 'all' }
 					onClick={ this.handleFilterClick( 'all' ) }
 				>
 					All
-				</ControlItem>
+				</SegmentedControlItem>
 
-				<ControlItem
+				<SegmentedControlItem
 					selected={ this.state.selected === 'unread' }
 					onClick={ this.handleFilterClick( 'unread' ) }
 				>
 					Unread
-				</ControlItem>
+				</SegmentedControlItem>
 
-				<ControlItem
+				<SegmentedControlItem
 					selected={ this.state.selected === 'comments' }
 					onClick={ this.handleFilterClick( 'comments' ) }
 				>
 					Comments
-				</ControlItem>
+				</SegmentedControlItem>
 
-				<ControlItem
+				<SegmentedControlItem
 					selected={ this.state.selected === 'follows' }
 					onClick={ this.handleFilterClick( 'follows' ) }
 				>
 					Follows
-				</ControlItem>
+				</SegmentedControlItem>
 
-				<ControlItem
+				<SegmentedControlItem
 					selected={ this.state.selected === 'likes' }
 					onClick={ this.handleFilterClick( 'likes' ) }
 				>
 					Likes
-				</ControlItem>
+				</SegmentedControlItem>
 			</SegmentedControl>
 		);
 	},
@@ -91,12 +91,12 @@ The key here is that it's up to the parent component to explicitly define things
 
 ##### Control Item
 
-| Name         | Type     | Default | Description                                    |
-| ------------ | -------- | ------- | ---------------------------------------------- |
-| `selected`\* | `bool`   | `false` | Determines the selected item                   |
-| `path`       | `string` | `null`  | URL to navigate to when item is clicked        |
-| `title`      | `string` | `null`  | Title to show when hovering over item          |
-| `onClick`    |          | `null`  | Callback applied when `ControlItem` is clicked |
+| Name         | Type     | Default | Description                                             |
+| ------------ | -------- | ------- | ------------------------------------------------------- |
+| `selected`\* | `bool`   | `false` | Determines the selected item                            |
+| `path`       | `string` | `null`  | URL to navigate to when item is clicked                 |
+| `title`      | `string` | `null`  | Title to show when hovering over item                   |
+| `onClick`    |          | `null`  | Callback applied when `SegmentedControlItem` is clicked |
 
 ### Options array
 

--- a/client/components/segmented-control/README.md
+++ b/client/components/segmented-control/README.md
@@ -1,5 +1,6 @@
-Segmented Control
-===
+<!-- @format -->
+
+# Segmented Control
 
 Segmented Control manipulates the content shown following an exclusive or “either/or” pattern.
 
@@ -82,24 +83,24 @@ The key here is that it's up to the parent component to explicitly define things
 
 ##### Segmented Control
 
-Name | Type | Default | Description
---- | --- | --- | ---
-`className` | `string` | `0` | Class(es) applied to `.segmented-control`
-`style` | `string` | `0` | Inline styles applied to the main element
-`compact` | `bool` | `false` | Decreases the size
+| Name        | Type     | Default | Description                               |
+| ----------- | -------- | ------- | ----------------------------------------- |
+| `className` | `string` | `0`     | Class(es) applied to `.segmented-control` |
+| `style`     | `string` | `0`     | Inline styles applied to the main element |
+| `compact`   | `bool`   | `false` | Decreases the size                        |
 
 ##### Control Item
 
-Name | Type | Default | Description
---- | --- | --- | ---
-`selected`* | `bool` | `false` | Determines the selected item
-`path` | `string` | `null` | URL to navigate to when item is clicked
-`title` | `string` | `null` | Title to show when hovering over item
-`onClick` |  | `null` | Callback applied when `ControlItem` is clicked
+| Name         | Type     | Default | Description                                    |
+| ------------ | -------- | ------- | ---------------------------------------------- |
+| `selected`\* | `bool`   | `false` | Determines the selected item                   |
+| `path`       | `string` | `null`  | URL to navigate to when item is clicked        |
+| `title`      | `string` | `null`  | Title to show when hovering over item          |
+| `onClick`    |          | `null`  | Callback applied when `ControlItem` is clicked |
 
 ### Options array
 
-`SegmentedControl` can also be used by passing in an `options` array as a prop. This technique is great for situations where you don't want to explicitly define things like what happens when an item is clicked or which item is currently selected, etc.
+We also provide `SimplifiedSegmentedControl` which uses an `options` array as a prop. This technique is great for situations where you don't want to explicitly define things like what happens when an item is clicked or which item is currently selected, etc.
 
 A good example for this case is a form element. You don't want to have to write the logic for updating the component when a new selection is made, but you might want to hook into certain events like: when a new selection is made, what was the option?
 
@@ -107,7 +108,7 @@ A good example for this case is a form element. You don't want to have to write 
 
 ```jsx
 import React from 'react';
-import SegmentedControl from 'components/segmented-control';
+import SimplifiedSegmentedControl from 'components/segmented-control/simplified';
 
 var options = [
 	{ value: 'all', label: 'All' },
@@ -126,21 +127,21 @@ export default class extends React.Component {
 
 	render() {
 		return (
-			<SegmentedControl options={ options } onSelect={ this.handleOnSelect } />
+			<SimplifiedSegmentedControl options={ options } onSelect={ this.handleOnSelect } />
 		);
 	},
 }
 ```
 
-Note that all the "selection" logic will be applied in `SegmentedControl` itself using a simple `selected` value comparison in state. It will update itself when an option has been clicked.
+Note that all the "selection" logic will be applied in `SimplifiedSegmentedControl` itself using a simple `selected` value comparison in state. It will update itself when an option has been clicked.
 
 #### Props
 
-Name | Type | Default | Description
---- | --- | --- | ---
-`options`* | `array` | `null` | The main data set for rendering options
-`initialSelected` | `string` | `null` | Represents the initial selected option's `value`
-`onSelect` |  | `null` | Callback whenever a new item has been clicked
+| Name              | Type     | Default | Description                                      |
+| ----------------- | -------- | ------- | ------------------------------------------------ |
+| `options`\*       | `array`  | `null`  | The main data set for rendering options          |
+| `initialSelected` | `string` | `null`  | Represents the initial selected option's `value` |
+| `onSelect`        |          | `null`  | Callback whenever a new item has been clicked    |
 
 ##### `options` prop example
 
@@ -157,13 +158,13 @@ var options = [
 
 ### General guidelines
 
-* There are two states: selected and non-selected. There must always be only one selected state, no more, no less.
-* The primary style is preferred. Use your best judgement if you want to use the non-primary style to remove visual conflict with another primary elements in the view.
-* Text should be concise and specific. Use no more than two words.
-* A default selection is required. The default selection is the first option in the segmented control.
+- There are two states: selected and non-selected. There must always be only one selected state, no more, no less.
+- The primary style is preferred. Use your best judgement if you want to use the non-primary style to remove visual conflict with another primary elements in the view.
+- Text should be concise and specific. Use no more than two words.
+- A default selection is required. The default selection is the first option in the segmented control.
 
 ## Related components
 
-* To group buttons together, use the [ButtonGroup](./button-group) component.
-* To navigate between multiple pages of items, use the [Pagination](./pagination) component.
-* To alternate among related views within the same context with _tabs_, use the [SectionNav](./section-nav) component.
+- To group buttons together, use the [ButtonGroup](./button-group) component.
+- To navigate between multiple pages of items, use the [Pagination](./pagination) component.
+- To alternate among related views within the same context with _tabs_, use the [SectionNav](./section-nav) component.

--- a/client/components/segmented-control/docs/example.jsx
+++ b/client/components/segmented-control/docs/example.jsx
@@ -10,11 +10,9 @@ import React from 'react';
  * Internal dependencies
  */
 import SegmentedControl from 'components/segmented-control';
+import SimplifiedSegmentedControl from 'components/segmented-control/simplified';
 import ControlItem from 'components/segmented-control/item';
 
-/**
- * Segmented Control Demo
- */
 class SegmentedControlDemo extends React.PureComponent {
 	static displayName = 'SegmentedControl';
 
@@ -47,7 +45,7 @@ class SegmentedControlDemo extends React.PureComponent {
 				</a>
 
 				<h3>Items passed as options prop</h3>
-				<SegmentedControl
+				<SimplifiedSegmentedControl
 					options={ this.props.options }
 					onSelect={ this.selectSegment }
 					style={ controlDemoStyles }

--- a/client/components/segmented-control/index.jsx
+++ b/client/components/segmented-control/index.jsx
@@ -3,234 +3,33 @@
 /**
  * External dependencies
  */
-
-import { filter, map } from 'lodash';
 import PropTypes from 'prop-types';
-import ReactDom from 'react-dom';
 import React from 'react';
 import classNames from 'classnames';
 
-/**
- * Internal dependencies
- */
-import ControlItem from 'components/segmented-control/item';
-
-/**
- * Internal variables
- */
-let _instance = 1;
-
-/**
- * SegmentedControl
- */
-class SegmentedControl extends React.Component {
+export default class SegmentedControl extends React.Component {
 	static propTypes = {
-		initialSelected: PropTypes.string,
-		compact: PropTypes.bool,
+		children: PropTypes.node.isRequired,
 		className: PropTypes.string,
-		style: PropTypes.object,
+		compact: PropTypes.bool,
 		onSelect: PropTypes.func,
-		options: PropTypes.arrayOf(
-			PropTypes.shape( {
-				value: PropTypes.string.isRequired,
-				label: PropTypes.string.isRequired,
-				path: PropTypes.string,
-			} )
-		),
+		style: PropTypes.object,
 	};
-
-	static defaultProps = {
-		compact: false,
-	};
-
-	constructor( props ) {
-		super( props );
-		let initialSelected;
-
-		if ( props.options ) {
-			initialSelected = props.initialSelected || props.options[ 0 ].value;
-		}
-
-		this.state = {
-			selected: initialSelected,
-			keyboardNavigation: false,
-		};
-	}
-
-	componentWillMount() {
-		this.id = _instance;
-		_instance++;
-	}
-
-	componentWillUnmount() {
-		window.removeEventListener( 'keydown', this.navigateItem );
-	}
 
 	render() {
 		const segmentedClasses = {
-			'segmented-control': true,
-			'keyboard-navigation': this.state.keyboardNavigation,
 			'is-compact': this.props.compact,
 			'is-primary': this.props.primary,
 		};
 
-		if ( this.props.className ) {
-			this.props.className.split( ' ' ).forEach( function( className ) {
-				segmentedClasses[ className ] = true;
-			} );
-		}
-
 		return (
 			<ul
-				className={ classNames( segmentedClasses ) }
+				className={ classNames( 'segmented-control', segmentedClasses, this.props.className ) }
 				style={ this.props.style }
 				role="radiogroup"
-				onKeyDown={ this.navigateItem }
-				onKeyUp={ this.setKeyboardNavigation.bind( this, true ) }
 			>
-				{ this.getSegmentedItems() }
+				{ this.props.children }
 			</ul>
 		);
 	}
-
-	getSegmentedItems = () => {
-		let refIndex = 0;
-		if ( this.props.children ) {
-			// add keys and refs to children
-			return React.Children.map(
-				this.props.children,
-				function( child, index ) {
-					const newChild = React.cloneElement( child, {
-						ref: child.type === ControlItem ? 'item-' + refIndex : null,
-						key: 'item-' + index,
-						onClick: function( event ) {
-							this.setKeyboardNavigation( false );
-
-							if ( typeof child.props.onClick === 'function' ) {
-								child.props.onClick( event );
-							}
-						}.bind( this ),
-					} );
-
-					if ( child.type === ControlItem ) {
-						refIndex++;
-					}
-
-					return newChild;
-				},
-				this
-			);
-		}
-
-		return this.props.options.map( function( item, index ) {
-			return (
-				<ControlItem
-					key={ 'segmented-control-' + this.id + '-' + item.value }
-					ref={ 'item-' + index }
-					selected={ this.state.selected === item.value }
-					onClick={ this.selectItem.bind( this, item ) }
-					path={ item.path }
-					index={ index }
-					value={ item.value }
-				>
-					{ item.label }
-				</ControlItem>
-			);
-		}, this );
-	};
-
-	selectItem = option => {
-		if ( ! option ) {
-			return;
-		}
-
-		if ( this.props.onSelect ) {
-			this.props.onSelect( option );
-		}
-
-		this.setState( {
-			selected: option.value,
-			keyboardNavigation: false,
-		} );
-	};
-
-	setKeyboardNavigation = value => {
-		this.setState( {
-			keyboardNavigation: value,
-		} );
-	};
-
-	navigateItem = event => {
-		switch ( event.keyCode ) {
-			case 9: // tab
-				this.navigateItemByTabKey( event );
-				break;
-			case 32: // space
-			case 13: // enter
-				event.preventDefault();
-				document.activeElement.click();
-				break;
-			case 37: // left arrow
-				event.preventDefault();
-				this.focusSibling( 'previous' );
-				break;
-			case 39: // right arrow
-				event.preventDefault();
-				this.focusSibling( 'next' );
-				break;
-		}
-	};
-
-	navigateItemByTabKey = event => {
-		let direction = event.shiftKey ? 'previous' : 'next',
-			newIndex = this.focusSibling( direction );
-
-		// allow tabbing out of control
-		if ( newIndex !== false ) {
-			event.preventDefault();
-		}
-	};
-
-	/**
-	 * Allows for keyboard navigation
-	 * @param  {String} direction - `next` or `previous`
-	 * @return {Number|Boolean} - returns false if the newIndex is out of bounds
-	 */
-	focusSibling = direction => {
-		let increment, items, newIndex;
-
-		if ( this.props.options ) {
-			items = filter( map( this.props.options, 'value' ), Boolean );
-		} else {
-			items = filter( this.props.children, function( item ) {
-				return item.type === ControlItem;
-			} );
-		}
-
-		if ( typeof this.focused !== 'number' ) {
-			this.focused = this.getCurrentFocusedIndex();
-		}
-
-		increment = direction === 'previous' ? -1 : 1;
-		newIndex = this.focused + increment;
-		if ( newIndex >= items.length || newIndex < 0 ) {
-			return false;
-		}
-
-		ReactDom.findDOMNode( this.refs[ 'item-' + newIndex ].refs.itemLink ).focus();
-		this.focused = newIndex;
-
-		return newIndex;
-	};
-
-	getCurrentFocusedIndex = () => {
-		// item is the <li> element containing the focused link
-		let activeItem = document.activeElement.parentNode,
-			siblings = Array.prototype.slice( activeItem.parentNode.children ),
-			index = siblings.indexOf( activeItem );
-
-		return index > -1 ? index : 0;
-	};
 }
-
-export default SegmentedControl;

--- a/client/components/segmented-control/item.jsx
+++ b/client/components/segmented-control/item.jsx
@@ -8,9 +8,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-/**
- * SegmentedControlItem
- */
 class SegmentedControlItem extends React.Component {
 	static propTypes = {
 		children: PropTypes.node.isRequired,
@@ -19,10 +16,21 @@ class SegmentedControlItem extends React.Component {
 		title: PropTypes.string,
 		value: PropTypes.string,
 		onClick: PropTypes.func,
+		index: PropTypes.number,
 	};
 
 	static defaultProps = {
 		selected: false,
+	};
+
+	handleKeyEvent = event => {
+		switch ( event.keyCode ) {
+			case 13: // enter
+			case 32: // space
+				event.preventDefault();
+				document.activeElement.click();
+				break;
+		}
 	};
 
 	render() {
@@ -40,13 +48,13 @@ class SegmentedControlItem extends React.Component {
 				<a
 					href={ this.props.path }
 					className={ linkClassName }
-					ref="itemLink"
 					onClick={ this.props.onClick }
 					title={ this.props.title }
 					data-e2e-value={ this.props.value }
 					role="radio"
 					tabIndex={ 0 }
-					aria-selected={ this.props.selected }
+					aria-checked={ this.props.selected }
+					onKeyDown={ this.handleKeyEvent }
 				>
 					<span className="segmented-control__text">{ this.props.children }</span>
 				</a>

--- a/client/components/segmented-control/simplified.jsx
+++ b/client/components/segmented-control/simplified.jsx
@@ -1,0 +1,66 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import ControlItem from 'components/segmented-control/item';
+
+export default class SimplifiedSegmentedControl extends React.Component {
+	static propTypes = {
+		className: PropTypes.string,
+		compact: PropTypes.bool,
+		initialSelected: PropTypes.string,
+		onSelect: PropTypes.func,
+		options: PropTypes.arrayOf(
+			PropTypes.shape( {
+				value: PropTypes.string.isRequired,
+				label: PropTypes.string.isRequired,
+				path: PropTypes.string,
+			} )
+		).isRequired,
+		style: PropTypes.object,
+	};
+	state = { selected: this.props.initialSelected || this.props.options[ 0 ].value };
+
+	renderOptions() {
+		return this.props.options.map( ( option, index ) => (
+			<ControlItem
+				index={ index }
+				key={ index }
+				onClick={ () => {
+					this.setState( { selected: option.value } );
+					this.props.onSelect && this.props.onSelect( option );
+				} }
+				path={ option.path }
+				selected={ this.state.selected === option.value }
+				value={ option.value }
+			>
+				{ option.label }
+			</ControlItem>
+		) );
+	}
+
+	render() {
+		const segmentedClasses = {
+			'is-compact': this.props.compact,
+			'is-primary': this.props.primary,
+		};
+
+		return (
+			<ul
+				className={ classNames( 'segmented-control', segmentedClasses, this.props.className ) }
+				style={ this.props.style }
+				role="radiogroup"
+			>
+				{ this.renderOptions() }
+			</ul>
+		);
+	}
+}

--- a/client/components/segmented-control/style.scss
+++ b/client/components/segmented-control/style.scss
@@ -1,5 +1,7 @@
 /**
  * Segmented Control
+ *
+ * @format
  */
 
 .segmented-control {
@@ -14,25 +16,19 @@
 	flex: 1 1 auto;
 	cursor: pointer;
 
-	&:first-of-type {
-		.segmented-control__link {
-			border-top-left-radius: 4px;
-			border-bottom-left-radius: 4px;
-		}
+	&:first-of-type .segmented-control__link {
+		border-top-left-radius: 4px;
+		border-bottom-left-radius: 4px;
 	}
 
-	&:last-of-type {
-		.segmented-control__link {
-			border-right: solid 1px $gray-lighten-20;
-			border-top-right-radius: 4px;
-			border-bottom-right-radius: 4px;
-		}
+	&:last-of-type .segmented-control__link {
+		border-right: solid 1px $gray-lighten-20;
+		border-top-right-radius: 4px;
+		border-bottom-right-radius: 4px;
 	}
 
-	&.is-selected {
-		+ .segmented-control__item .segmented-control__link {
-			border-left-color: $gray-dark;
-		}
+	&.is-selected + .segmented-control__item .segmented-control__link {
+		border-left-color: $gray-dark;
 	}
 }
 
@@ -45,15 +41,13 @@
 	line-height: 18px;
 	color: $gray-text-min;
 	text-align: center;
+	transition: color 0.1s linear, background-color 0.1s linear;
 
 	&:focus {
 		color: $gray-dark;
 		outline: none;
+		background-color: $gray-light;
 	}
-}
-
-.keyboard-navigation .segmented-control__link:focus .segmented-control__text {
-	outline: dotted 1px $gray-dark;
 }
 
 .segmented-control__item.is-selected .segmented-control__link {
@@ -61,10 +55,9 @@
 	color: $gray-dark;
 }
 
-.notouch .segmented-control__link {
-	&:hover {
-		color: $gray-dark;
-	}
+.notouch .segmented-control__link:hover {
+	color: $gray-dark;
+	background-color: $gray-light;
 }
 
 .segmented-control__text {
@@ -84,21 +77,35 @@
 }
 
 //Primary variation
-.segmented-control.is-primary { 
-
+.segmented-control.is-primary {
 	.segmented-control__item {
-
 		&.is-selected {
-
 			.segmented-control__link {
-		  		border-color: $blue-medium;
-		 		background-color: $blue-medium;
-		 		color: $white;
-		  }
+				border-color: $blue-medium;
+				background-color: $blue-medium;
+				color: $white;
+
+				&:focus {
+					background-color: lighten( $blue-medium, 2.5% );
+				}
+			}
 
 			+ .segmented-control__item .segmented-control__link {
 				border-left-color: $blue-medium;
 			}
 		}
+	}
+
+	.segmented-control__link:focus {
+		background-color: lighten( $blue-light, 22.5% );
+	}
+}
+
+.notouch .segmented-control.is-primary {
+	.segmented-control__link:hover {
+		background-color: lighten( $blue-light, 22.5% );
+	}
+	.segmented-control__item.is-selected .segmented-control__link:hover {
+		background-color: lighten( $blue-medium, 2.5% );
 	}
 }

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/package-dialog.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/package-dialog.js
@@ -21,7 +21,7 @@ import FormSectionHeading from 'components/forms/form-section-heading';
 import FormButton from 'components/forms/form-button';
 import inputFilters from './input-filters';
 import PredefinedPackages from './predefined-packages';
-import SegmentedControl from 'components/segmented-control';
+import SimplifiedSegmentedControl from 'components/segmented-control/simplified';
 import { getPredefinedPackagesChangesSummary } from '../../state/packages/selectors';
 
 const AddPackageDialog = props => {
@@ -135,7 +135,7 @@ const AddPackageDialog = props => {
 		>
 			<FormSectionHeading>{ heading }</FormSectionHeading>
 			{ showSegmentedControl && (
-				<SegmentedControl
+				<SimplifiedSegmentedControl
 					primary
 					className="packages__mode-select"
 					initialSelected={ mode }

--- a/client/my-sites/domains/domain-management/name-servers/dns-template-selector.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/dns-template-selector.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import SegmentedControl from 'components/segmented-control';
+import SimplifiedSegmentedControl from 'components/segmented-control/simplified';
 
 class DnsTemplateSelector extends React.PureComponent {
 	handleOnSelect = option => {
@@ -20,7 +20,7 @@ class DnsTemplateSelector extends React.PureComponent {
 		const { templates } = this.props;
 
 		return (
-			<SegmentedControl
+			<SimplifiedSegmentedControl
 				primary={ true }
 				options={ templates.map( template => {
 					return {

--- a/client/my-sites/stats/stats-views/index.jsx
+++ b/client/my-sites/stats/stats-views/index.jsx
@@ -18,7 +18,7 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import getSiteStatsViewSummary from 'state/selectors/get-site-stats-view-summary';
 import Card from 'components/card';
 import Months from './months';
-import SegmentedControl from 'components/segmented-control';
+import SimplifiedSegmentedControl from 'components/segmented-control/simplified';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 
 class StatsViews extends Component {
@@ -54,7 +54,7 @@ class StatsViews extends Component {
 				<Card className={ classNames( 'stats-views', { 'is-loading': ! viewData } ) }>
 					<StatsModulePlaceholder isLoading={ ! viewData } />
 					{ viewData && (
-						<SegmentedControl
+						<SimplifiedSegmentedControl
 							className="stats-views__month-control"
 							options={ monthViewOptions }
 							onSelect={ this.toggleViews }

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -16,7 +16,7 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import Search from 'components/search';
-import SegmentedControl from 'components/segmented-control';
+import SimplifiedSegmentedControl from 'components/segmented-control/simplified';
 import KeyedSuggestions from 'components/keyed-suggestions';
 import StickyPanel from 'components/sticky-panel';
 import config from 'config';
@@ -327,7 +327,7 @@ class ThemesMagicSearchCard extends React.Component {
 						) }
 						{ isPremiumThemesEnabled &&
 							showTierThemesControl && (
-								<SegmentedControl
+								<SimplifiedSegmentedControl
 									initialSelected={ this.props.tier }
 									options={ tiers }
 									onSelect={ this.props.select }


### PR DESCRIPTION
This removes custom accessibility handling from `<SegmentedControl>` (1) and separates its `options` property handling into a separate `<SimplifiedSegmentedControl>` component (2). Deprecated code patterns and inefficient applications of 3rd party libraries have been refactored. Component documentation has also been updated accordingly. 

1) Removing custom accessibility handling allows us to remove a significant amount of unnecessary code and improves usability by adhering to the browsers' default behavior. (This removes custom support for moving button focus using left and right arrow keys.)

2) Separating `SimplifiedSegmentedControl` from `SegmentedControl` allows us to greatly simplify the codebase for each component. This results in ~20% improvement in component mounting performance.

# Testing Instructions

1. Spin up this branch locally. 
2. Navigate to the [devdocs](http://calypso.localhost:3000/devdocs/design/segmented-control) and ensure that the three example components load as expected.
3. Try tabbing and alt-tabbing through the different segmentation buttons. Ensure that the focus moves as expected. 
4. Open the [themes page](http://calypso.localhost:3000/themes/) and try out the segmented controls on the top right. 

<img width="194" alt="wordpress_themes_ _wordpress_com" src="https://user-images.githubusercontent.com/4044428/44122805-bc46406e-9fe2-11e8-83f8-e60d749a2bef.png">

5. Open the first step of the [signup flow](http://calypso.localhost:3000/start/about) while logged out and try out the segmented controls at the bottom.

<img width="473" alt="create_a_site_ _wordpress_com" src="https://user-images.githubusercontent.com/4044428/44123095-e20fbc2a-9fe3-11e8-8c02-0040cc7d1ee3.png">

