### PR TITLE
Activity Log: Add WordPress Application Actor 

### DIFF
--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -75,3 +75,4 @@ $color-print: #f8f8f8;
 $color-skype: #00AFF0;
 $color-telegram: #0088cc;
 $color-whatsapp: #43d854;
+$color-wordpressOrg: #585c60;

--- a/client/my-sites/stats/activity-log-item/activity-actor.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-actor.jsx
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
  */
 import Gravatar from 'components/gravatar';
 import JetpackLogo from 'components/jetpack-logo';
+import SocialLogo from 'social-logos';
 
 /**
  * Module constants
@@ -32,6 +33,15 @@ const HAPPINESS_ACTOR = (
 	</div>
 );
 
+const WORDPRESS_ACTOR = (
+	<div className="activity-log-item__actor">
+		<SocialLogo icon="wordpress" size={ 40 } />
+		<div className="activity-log-item__actor-info">
+			<div className="activity-log-item__actor-name">WordPress</div>
+		</div>
+	</div>
+);
+
 export default class ActivityActor extends PureComponent {
 	static propTypes = {
 		actor: PropTypes.shape( {
@@ -44,7 +54,9 @@ export default class ActivityActor extends PureComponent {
 
 	render() {
 		const { actorAvatarUrl, actorName, actorRole, actorType } = this.props;
-
+		if ( actorName === 'WordPress' && actorType === 'Application' ) {
+			return WORDPRESS_ACTOR;
+		}
 		if ( actorName === 'Jetpack' && actorType === 'Application' ) {
 			return JETPACK_ACTOR;
 		}

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -185,6 +185,7 @@
 	}
 
 	.gravatar,
+	.social-logo,
 	.jetpack-logo {
 		float: left;
 		width: 40px;
@@ -202,6 +203,12 @@
 			height: 24px;
 			margin-right: 8px;
 		}
+	}
+
+	.social-logo {
+		fill: #fff;
+		background: #585c60;
+		border-radius: 50%;
 	}
 
 	.jetpack-logo__icon-circle {

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -206,8 +206,8 @@
 	}
 
 	.social-logo {
-		fill: #fff;
-		background: #585c60;
+		fill: $white;
+		background: $color-wordpressOrg;
 		border-radius: 50%;
 	}
 


### PR DESCRIPTION
Some activities in the activity log make more sense when they are attributed to WordPress the software.

This PR fixes it by adding the WordPress actor to the activitiy log.

This is what we expect it to look like. 
![image](https://user-images.githubusercontent.com/115071/44071212-a3d08400-9f3c-11e8-9f52-8e592b92718b.png)


And this is what I got it to look like right now. 
<img width="839" alt="screen shot 2018-08-13 at 9 04 38 pm" src="https://user-images.githubusercontent.com/115071/44071226-ba979f02-9f3c-11e8-8374-bb990c7ec1cd.png">

Required D17175-code
