### PR TITLE
SDK: Shuffle around configuration in SDK runner

### DIFF
--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 
 /** @format */
-
 /**
  * External dependencies
  */
 const chalk = require( 'chalk' );
 const path = require( 'path' );
 const yargs = require( 'yargs' );
+const webpack = require( 'webpack' );
 
 /**
  * Internal dependencies
@@ -18,8 +18,55 @@ const gutenberg = require( './sdk/gutenberg.js' );
 // pick between `npm run calypso-sdk` and `npx calypso-sdk`.
 // Show also how npm scripts require delimiter to pass arguments.
 const calleeScript = path.basename( process.argv[ 1 ] );
-const scriptName = calleeScript === path.basename( __filename ) ? 'npm run calypso-sdk' : calleeScript;
+const scriptName =
+	calleeScript === path.basename( __filename ) ? 'npm run calypso-sdk' : calleeScript;
 const delimit = scriptName.substring( 0, 3 ) === 'npm' ? '-- ' : '';
+const __rootDir = path.resolve( __dirname, '..' );
+
+const getBaseConfig = ( options = {} ) => {
+	const getConfig = require( path.join( __rootDir, 'webpack.config.js' ) );
+	const config = getConfig( options );
+
+	// these are currently Calypso-specific
+	const omitPlugins = [
+		require( path.resolve( __rootDir, 'server/bundler/copy-webpack-plugin' ) ),
+		webpack.HotModuleReplacementPlugin,
+	];
+
+	return {
+		...config,
+		optimization: {
+			splitChunks: false,
+		},
+		plugins: config.plugins.filter( plugin => ! omitPlugins.includes( plugin.constructor ) ),
+	};
+};
+
+const build = ( target, argv ) => {
+	const config = target.config( { argv, getBaseConfig, __rootDir } );
+	const compiler = webpack( config );
+
+	// watch takes an additional argument, adjust accordingly
+	const runner = argv.watch ? f => compiler.watch( {}, f ) : f => compiler.run( f );
+
+	runner( ( error, stats ) => {
+		if ( error ) {
+			console.error( error );
+			console.log( chalk.red( 'Failed to build' ) );
+			process.exit( 1 );
+		}
+
+		console.log( stats.toString() );
+
+		if ( stats.hasErrors() ) {
+			console.log( chalk.red( 'Built with errors' ) );
+		} else if ( stats.hasWarnings() ) {
+			console.log( chalk.yellow( 'Built with warnings' ) );
+		} else {
+			console.log( chalk.green( 'Built successfully' ) );
+		}
+	} );
+};
 
 yargs
 	.scriptName( scriptName )
@@ -28,54 +75,47 @@ yargs
 	.command( {
 		command: 'gutenberg',
 		desc: 'Build a Gutenberg extension',
-		builder: yargs => yargs.options( {
-			'mode': {
-				alias: 'm',
-				description: 'Choose the way how assets are optimized.',
-				type: 'string',
-				choices: [ 'production', 'development' ],
-				default: 'production',
-				requiresArg: true,
-			},
-			'editor-script': {
-				description: 'Entry for editor-side JavaScript file',
-				type: 'string',
-				required: true,
-				coerce: value => path.resolve( __dirname, '../', value ),
-				requiresArg: true,
-			},
-			'view-script': {
-				description: 'Entry for rendered-page-side JavaScript file',
-				type: 'string',
-				coerce: value => path.resolve( __dirname, '../', value ),
-				requiresArg: true,
-			},
-			'output-dir': {
-				alias: 'o',
-				description: 'Output directory for the built assets. Intermediate directories are created as required.',
-				type: 'string',
-				coerce: path.resolve,
-				requiresArg: true,
-			},
-			'output-editor-file': {
-				description: 'Name of the built editor script output file (without the file extension).',
-				type: 'string',
-				requiresArg: true,
-			},
-			'output-view-file': {
-				description: 'Name of the built view script output file (without the file extension).',
-				type: 'string',
-				requiresArg: true,
-			},
-			'watch': {
-				alias: 'w',
-				description: 'Whether to watch for changes and automatically rebuild.',
-				type: 'boolean',
-			},
-		} ),
-		handler: argv => gutenberg.compile( argv )
+		builder: yargs =>
+			yargs.options( {
+				'editor-script': {
+					description: 'Entry for editor-side JavaScript file',
+					type: 'string',
+					required: true,
+					coerce: value => path.resolve( __dirname, '../', value ),
+					requiresArg: true,
+				},
+				'view-script': {
+					description: 'Entry for rendered-page-side JavaScript file',
+					type: 'string',
+					coerce: value => path.resolve( __dirname, '../', value ),
+					requiresArg: true,
+				},
+				'output-dir': {
+					alias: 'o',
+					description:
+						'Output directory for the built assets. Intermediate directories are created as required.',
+					type: 'string',
+					coerce: path.resolve,
+					requiresArg: true,
+				},
+				'output-editor-file': {
+					description: 'Name of the built editor script output file (without the file extension).',
+					type: 'string',
+					requiresArg: true,
+				},
+				'output-view-file': {
+					description: 'Name of the built view script output file (without the file extension).',
+					type: 'string',
+					requiresArg: true,
+				},
+				watch: {
+					alias: 'w',
+					description: 'Whether to watch for changes and automatically rebuild.',
+					type: 'boolean',
+				},
+			} ),
+		handler: argv => build( gutenberg, argv ),
 	} )
 	.demandCommand( 1, chalk.red( 'You must provide a valid command!' ) )
 	.alias( 'help', 'h' )
-	.version( false )
-	.argv;
+	.version( false ).argv;

--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -47,7 +47,7 @@ const build = ( target, argv ) => {
 	const compiler = webpack( config );
 
 	// watch takes an additional argument, adjust accordingly
-	const runner = argv.watch ? f => compiler.watch( {}, f ) : f => compiler.run( f );
+	const runner = f => argv.watch ? compiler.watch( {}, f ) : compiler.run( f );
 
 	runner( ( error, stats ) => {
 		if ( error ) {

--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -43,7 +43,7 @@ const getBaseConfig = ( options = {} ) => {
 };
 
 const build = ( target, argv ) => {
-	const config = target.config( { argv, getBaseConfig, __rootDir } );
+	const config = target.config( { argv, getBaseConfig } );
 	const compiler = webpack( config );
 
 	// watch takes an additional argument, adjust accordingly

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -1,116 +1,30 @@
 /** @format */
-
 /**
  * External dependencies
  */
-const chalk = require( 'chalk' );
 const path = require( 'path' );
-const webpack = require( 'webpack' );
-const { isEmpty, omitBy } = require( 'lodash' );
 
-const __rootDir = path.resolve( __dirname, '../../' );
-const CopyWebpackPlugin = require( path.resolve(
+exports.config = ( {
+	argv: { editorScript, viewScript, outputDir, outputEditorFile, outputViewFile },
+	getBaseConfig,
 	__rootDir,
-	'server/bundler/copy-webpack-plugin'
-) );
-const getBaseConfig = require( path.join( __rootDir, 'webpack.config.js' ) );
+} ) => {
+	const baseConfig = getBaseConfig( { externalizeWordPressPackages: true } );
+	const name = path.basename( path.dirname( editorScript ).replace( /\/$/, '' ) );
 
-const omitPlugins = [
-	CopyWebpackPlugin,
-	webpack.HotModuleReplacementPlugin,
-];
-
-const wordpressPackages = [
-	'api-fetch',
-	'block-serialization-spec-parser',
-	'blocks',
-	'components',
-	'data',
-	'editor',
-	'element',
-	'i18n',
-];
-
-const getWordPressExternals = () =>
-	wordpressPackages.reduce( ( externals, package ) => {
-		externals[ `@wordpress/${ package }` ] = {
-			window: [
-				'wp',
-				// this is not as aggressive as `_.camelCase` in converting to
-				// uppercase, where Lodash will convert letters following numbers
-				package.replace(
-					/-([a-z])/g,
-					( match, letter ) => letter.toUpperCase()
-				)
-			]
-		};
-		return externals;
-	}, {} );
-
-const outputHandler = ( error, stats ) => {
-	if ( error ) {
-		console.error( error );
-		console.log( chalk.red( 'Failed to build Gutenberg extension' ) );
-		process.exit( 1 );
-	}
-
-	console.log( stats.toString() );
-
-	if ( stats.hasErrors() ) {
-		console.log( chalk.red( 'Finished building Gutenberg extension but with errors.' ) );
-	} else if ( stats.hasWarnings() ) {
-		console.log( chalk.yellow( 'Successfully built Gutenberg extension but with warnings.' ) );
-	} else {
-		console.log( chalk.green( 'Successfully built Gutenberg extension' ) );
-	}
-};
-
-exports.compile = args => {
-	const options = {
-		outputDir: path.join( path.dirname( args.editorScript ), 'build' ),
-		...args,
-	};
-
-	const name = path.basename( path.dirname( options.editorScript ).replace( /\/$/, '' ) );
-	const baseConfig = getBaseConfig();
-
-	const config = {
+	return {
 		...baseConfig,
 		...{
 			context: __rootDir,
-			mode: options.mode,
-			entry: omitBy(
-				{
-					[ options.outputEditorFile || `${ name }-editor` ]: options.editorScript,
-					[ options.outputViewFile || `${ name }-view` ]: options.viewScript,
-				},
-				isEmpty
-			),
-			externals: {
-				...baseConfig.externals,
-				...getWordPressExternals(),
-				lodash: 'lodash',
-				wp: 'wp',
-			},
-			optimization: {
-				splitChunks: false,
+			entry: {
+				...( editorScript ? { [ outputEditorFile || `${ name }-editor` ]: editorScript } : {} ),
+				...( viewScript ? { [ outputViewFile || `${ name }-view` ]: viewScript } : {} ),
 			},
 			output: {
-				path: options.outputDir,
+				path: outputDir || path.join( path.dirname( editorScript ), 'build' ),
 				filename: '[name].js',
 				libraryTarget: 'window',
 			},
-			plugins: [
-				...baseConfig.plugins.filter( plugin => omitPlugins.indexOf( plugin.constructor ) < 0 ),
-			],
 		},
 	};
-
-	const compiler = webpack( config );
-
-	if ( options.watch ) {
-		compiler.watch( {}, outputHandler );
-	} else {
-		compiler.run( outputHandler );
-	}
 };

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -7,7 +7,6 @@ const path = require( 'path' );
 exports.config = ( {
 	argv: { editorScript, viewScript, outputDir, outputEditorFile, outputViewFile },
 	getBaseConfig,
-	__rootDir,
 } ) => {
 	const baseConfig = getBaseConfig( { externalizeWordPressPackages: true } );
 	const name = path.basename( path.dirname( editorScript ).replace( /\/$/, '' ) );
@@ -15,7 +14,6 @@ exports.config = ( {
 	return {
 		...baseConfig,
 		...{
-			context: __rootDir,
 			entry: {
 				...( editorScript ? { [ outputEditorFile || `${ name }-editor` ]: editorScript } : {} ),
 				...( viewScript ? { [ outputViewFile || `${ name }-view` ]: viewScript } : {} ),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -106,7 +106,7 @@ const wordpressExternals = ( context, request, callback ) =>
  *
  * @see {@link https://webpack.js.org/configuration/configuration-types/#exporting-a-function}
  *
- * @param {object}  env additional                   config options
+ * @param {object}  env                              additional config options
  * @param {boolean} env.externalizeWordPressPackages whether to bundle or extern the `@wordpress/` packages
  * @param {object}  argv                             given by webpack?
  *

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -116,6 +116,7 @@ const wordpressExternals = ( context, request, callback ) =>
 function getWebpackConfig( { externalizeWordPressPackages = false } = {}, argv ) {
 	const webpackConfig = {
 		bail: ! isDevelopment,
+		context: __dirname,
 		entry: { build: [ path.join( __dirname, 'client', 'boot', 'app' ) ] },
 		profile: shouldEmitStats,
 		mode: isDevelopment ? 'development' : 'production',


### PR DESCRIPTION
When building with the SDK we have a generic runner - `sdk-cli.js`
and target-specific options for that runner - `gutenberg.js`. We
invoke the runner script while specifying the target which it calls.

Some of our configuration and runtime code though has been split
across these two places and some of the configuration could maybe
be moved upwards into the main Calypso config.

In this patch I'm shuffling around the configuration and execution
code to try and separate those layers more clearly. This work serves
to prepare us as well for integrating other projects, such as the
notifications panel, into the Calpyso repository.

**Testing**

Everything needs to build without regression.

The results in iscalypsofastyet.com should show no change in
the output size of the app. The same is true of built plugins for
Gutenberg that were built with this script.

We need to verify that the plugins run inside of Gutenberg too.

```bash
npm run sdk:gutenberg -- --editor-script client/gutenberg/extensions/presets/o2/editor.js --view-script client/gutenberg/extensions/presets/o2/view.js --output-dir ~/wherever/
```