### PR TITLE
Set locale properly for the sign-up flow.

### DIFF
--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -5,6 +5,7 @@
  */
 
 import { parse, stringify } from 'qs';
+import { getLocaleSlug } from 'lib/i18n-utils';
 
 /**
  * Internal dependencies
@@ -89,7 +90,9 @@ export function injectLocalization( wpcom ) {
 export function bindState( store ) {
 	function setLocaleFromState() {
 		setLocale(
-			getCurrentUserLocaleVariant( store.getState() ) || getCurrentUserLocale( store.getState() )
+			getCurrentUserLocaleVariant( store.getState() ) ||
+				getCurrentUserLocale( store.getState() ) ||
+				getLocaleSlug()
 		);
 	}
 


### PR DESCRIPTION
## Summary
Since the current `setLocaleFromState()` function pulls the locale info from the user info, it will be always empty for logged-out flows like the signup flow. This results in all the API requests sent from logged-out flows to not have `locale` query parameter attached properly. An easy to observe case is the untranslated warning message at the last step of the signup flow:
<img width="671" alt="untranslated-message" src="https://user-images.githubusercontent.com/1842898/44128993-a22a82a8-a078-11e8-8dae-0857bb19f725.png">

This PR attempts to fix the issue by using `getLocaleSlug()` as the last locale candidate, which doesn't rely on the user info.

## Test Plan
1. Go to a localized sign-up page. e.g. http://calypso.localhost:3000/start/about/fr
1. Open the network inspector and then go through each step. For every API request, there should be `locale=fr` query string appended properly.
1. At the last step, randomly put something invalid in the email field to trigger a validation failure. A translated warning message should appear as expected, instead of an untranslated one.