### PR TITLE
Update BRL currency formatting

### DIFF
--- a/client/lib/format-currency/currencies.js
+++ b/client/lib/format-currency/currencies.js
@@ -116,8 +116,8 @@ export const CURRENCIES = {
 	},
 	BRL: {
 		symbol: 'R$',
-		grouping: ',',
-		decimal: '.',
+		grouping: '.',
+		decimal: ',',
 		precision: 2,
 	},
 	BSD: {

--- a/client/lib/format-currency/test/index.js
+++ b/client/lib/format-currency/test/index.js
@@ -59,7 +59,7 @@ describe( 'formatCurrency', () => {
 		} );
 		test( 'BRL', () => {
 			const money = formatCurrency( 9800900.32, 'BRL' );
-			expect( money ).to.equal( 'R$9,800,900.32' );
+			expect( money ).to.equal( 'R$9.800.900,32' );
 		} );
 	} );
 
@@ -153,8 +153,8 @@ describe( 'formatCurrency', () => {
 				const money = getCurrencyObject( 9800900.32, 'BRL' );
 				expect( money ).to.eql( {
 					symbol: 'R$',
-					integer: '9,800,900',
-					fraction: '.32',
+					integer: '9.800.900',
+					fraction: ',32',
 					sign: '',
 				} );
 			} );


### PR DESCRIPTION
It was noted in p9jf6J-Qu-p2 that BRL uses the opposite formatting compared to USD - ',' for a decimal separator and '.' for the thousands.

Test plan:
Try to get a WordPress.com Business plan. In the subscription length picker, the formatting should be with a dot and not a comma.

<img width="345" alt="screen shot 2018-08-14 at 16 18 01" src="https://user-images.githubusercontent.com/82778/44094033-b7e137fe-9fdd-11e8-9077-91daf953f09a.png">
