### PR TITLE
My plan: Remove redundant Fragment wrapper

### DIFF
--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -133,35 +133,33 @@ class CurrentPlan extends Component {
 					/>
 				) }
 
-				<Fragment>
-					<CurrentPlanHeader
-						selectedSite={ selectedSite }
-						isPlaceholder={ isLoading }
-						title={ title }
-						tagLine={ tagLine }
-						currentPlanSlug={ currentPlanSlug }
-						currentPlan={ currentPlan }
-						isExpiring={ isExpiring }
-						isAutomatedTransfer={ isAutomatedTransfer }
-						includePlansLink={ currentPlan && isFreeJetpackPlan( currentPlan ) }
-					/>
-					{ isEnabled( 'jetpack/checklist' ) &&
-						isJetpack &&
-						! isAutomatedTransfer && (
-							<Fragment>
-								<QueryJetpackPlugins siteIds={ [ selectedSiteId ] } />
-								<ChecklistShow />
-							</Fragment>
-						) }
-					<div
-						className={ classNames( 'current-plan__header-text current-plan__text', {
-							'is-placeholder': { isLoading },
-						} ) }
-					>
-						<h1 className="current-plan__header-heading">{ planFeaturesHeader }</h1>
-					</div>
-					<ProductPurchaseFeaturesList plan={ currentPlanSlug } isPlaceholder={ isLoading } />
-				</Fragment>
+				<CurrentPlanHeader
+					selectedSite={ selectedSite }
+					isPlaceholder={ isLoading }
+					title={ title }
+					tagLine={ tagLine }
+					currentPlanSlug={ currentPlanSlug }
+					currentPlan={ currentPlan }
+					isExpiring={ isExpiring }
+					isAutomatedTransfer={ isAutomatedTransfer }
+					includePlansLink={ currentPlan && isFreeJetpackPlan( currentPlan ) }
+				/>
+				{ isEnabled( 'jetpack/checklist' ) &&
+					isJetpack &&
+					! isAutomatedTransfer && (
+						<Fragment>
+							<QueryJetpackPlugins siteIds={ [ selectedSiteId ] } />
+							<ChecklistShow />
+						</Fragment>
+					) }
+				<div
+					className={ classNames( 'current-plan__header-text current-plan__text', {
+						'is-placeholder': { isLoading },
+					} ) }
+				>
+					<h1 className="current-plan__header-heading">{ planFeaturesHeader }</h1>
+				</div>
+				<ProductPurchaseFeaturesList plan={ currentPlanSlug } isPlaceholder={ isLoading } />
 
 				<TrackComponentView eventName={ 'calypso_plans_my_plan_view' } />
 			</Main>


### PR DESCRIPTION
Removes a redundant `React.Fragment`.

No functional changes. Producted HTML should be identical.

[View without whitespace diff](https://github.com/Automattic/wp-calypso/pull/26688/files?w=1) to see `Fragment` removal.

## Testing
- Visit `/plans/my-plan/SITE_SLUG`
- Verify behavior including generated HTML is identical.