### PR TITLE
SDK: Enable blocks in Calypso Gutenberg context

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -16,6 +16,8 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { overrideAPIPaths } from './utils';
 
+import 'gutenberg/extensions/presets/o2/editor';
+
 const editorSettings = {};
 
 const post = {

--- a/client/gutenberg/extensions/editor-notes/index.js
+++ b/client/gutenberg/extensions/editor-notes/index.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { registerBlockType } from '@wordpress/blocks';
 import { RichText } from '@wordpress/editor';
 

--- a/client/gutenberg/extensions/prev-next/block.js
+++ b/client/gutenberg/extensions/prev-next/block.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { registerBlockType } from '@wordpress/blocks';

--- a/client/gutenberg/extensions/todo/block.js
+++ b/client/gutenberg/extensions/todo/block.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { Button, Dashicon } from '@wordpress/components';


### PR DESCRIPTION
Previously we have only been generating block outputs from the SDK
but in this patch we're importing those blocks into the Gutenberg
instance inside of Calypso.

How? By importing them. :)

Hard work paying off.

**Caveat**
I had to manually import `React` in order for these not to throw an error
about JSX transformation. We need to figure this out.

**Testing**
Load the Gutenberg editor in a development environment or on the live
branch. Insert a block and select one of our custom blocks.

![in-calypso mov](https://user-images.githubusercontent.com/5431237/44108475-73e37994-9ff2-11e8-987d-f73034a400f6.gif)
