### PR TITLE
Improve the display of recent Atavist posts.

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -45,7 +45,7 @@
 		}
 	}
 
-	blockquote {
+	blockquote, aside {
 		padding: 0 24px 0 32px;
 		margin: 16px 0 32px;
 		border-left: 3px solid $gray-lighten-30;
@@ -62,7 +62,7 @@
 	img {
 		max-width: 100%;
 		height: auto;
-		display: inline;
+		display: block;
 		margin: auto;
 
 		&.emoji,
@@ -73,7 +73,7 @@
 		}
 	}
 
-	audio {
+	audio, video {
 		display: block;
 		width: 100%;
 		margin: 24px auto;


### PR DESCRIPTION
Feed: `/read/feeds/84614284/`

Fixes:
 * Video Header on `/read/feeds/84614284/posts/1960168266` was not constrained to the content width
 * <aside> was not appropriately styled, e.g. post footer or top of `/read/feeds/84614284/posts/1960168274`
 * Images that were not full width were left aligned with centered caption - e.g. Book Cover in `/read/feeds/84614284/posts/1960168290`