### PR TITLE
Desktop Notifications: subscribe to redux store 

### DIFF
--- a/client/lib/desktop/index.js
+++ b/client/lib/desktop/index.js
@@ -66,7 +66,7 @@ const Desktop = {
 		this.selectedSite = site;
 	},
 
-	notificationStatus: async function() {
+	notificationStatus: function() {
 		let previousHasUnseen = hasUnseenNotifications( reduxGetState() );
 
 		// Send initial status to main process

--- a/client/lib/desktop/index.js
+++ b/client/lib/desktop/index.js
@@ -16,7 +16,7 @@ import { ipcRenderer as ipc } from 'electron'; // From Electron
 import * as oAuthToken from 'lib/oauth-token';
 import userUtilities from 'lib/user/utils';
 import { getStatsPathForTab } from 'lib/route';
-import { getReduxStore, reduxGetState } from 'lib/redux-bridge';
+import { getReduxStore } from 'lib/redux-bridge';
 import hasUnseenNotifications from 'state/selectors/has-unseen-notifications';
 import isNotificationsOpen from 'state/selectors/is-notifications-open';
 import { toggleNotificationsPanel, navigate } from 'state/ui/actions';
@@ -51,7 +51,7 @@ const Desktop = {
 	selectedSite: null,
 
 	navigate: function( to ) {
-		if ( isNotificationsOpen( reduxGetState() ) ) {
+		if ( isNotificationsOpen( this.store.getState() ) ) {
 			this.toggleNotificationsPanel();
 		}
 
@@ -67,13 +67,13 @@ const Desktop = {
 	},
 
 	notificationStatus: function() {
-		let previousHasUnseen = hasUnseenNotifications( reduxGetState() );
+		let previousHasUnseen = hasUnseenNotifications( this.store.getState() );
 
 		// Send initial status to main process
 		ipc.send( 'unread-notices-count', previousHasUnseen );
 
 		this.store.subscribe( () => {
-			const hasUnseen = hasUnseenNotifications( reduxGetState() );
+			const hasUnseen = hasUnseenNotifications( this.store.getState() );
 
 			if ( hasUnseen !== previousHasUnseen ) {
 				ipc.send( 'unread-notices-count', hasUnseen );


### PR DESCRIPTION
This PR is fixing the desktop notification badge and replaces the deprecated `message` event listener with a listener on the redux store – using the newly introduced `hasUnseenNotifications` selector.

While I was at it, I cleaned up the file, removed not longer used code and replaced click events for displaying the notifications panel with the according redux action (`toggleNotificationsPanel`).

### How to test (Desktop App / macOS)
#### Test notification badge
- Point calypso submodule to this PR
- [Start app in dev mode ](https://github.com/Automattic/wp-desktop/blob/develop/docs/development.md#dev-mode)
- Create new notification
- Notification badge in dock should appear within a few seconds

#### Test general cleanup
- Navigate through the app with <kbd>Cmd</kbd>+<kbd>1-4</kbd> or via the `Window` menu
- Calypso should navigate to the selected page.

