### PR TITLE
Activity Log: Add compact pagination

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -62,6 +62,7 @@ import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
 import { requestActivityLogs } from 'state/data-getters';
 import { emptyFilter } from 'state/activity-log/reducer';
+import { isMobile } from 'lib/viewport';
 
 const PAGE_SIZE = 20;
 
@@ -426,6 +427,7 @@ class ActivityLog extends Component {
 				) : (
 					<div>
 						<Pagination
+							compact={ isMobile() }
 							className="activity-log__pagination"
 							key="activity-list-pagination-top"
 							nextLabel={ translate( 'Older' ) }
@@ -453,6 +455,7 @@ class ActivityLog extends Component {
 						</section>
 						{ siteIsOnFreePlan && <UpgradeBanner siteId={ siteId } /> }
 						<Pagination
+							compact={ isMobile() }
 							className="activity-log__pagination is-bottom-pagination"
 							key="activity-list-pagination-bottom"
 							nextLabel={ translate( 'Older' ) }


### PR DESCRIPTION
Add pagination to be compact when viewing the screen from a mobile.

Currently when you view the activity log on the mobile device you see a broken pagination.
If you have more then expected 

Before:
![screen shot 2018-08-14 at 3 00 30 pm](https://user-images.githubusercontent.com/115071/44121012-261a968a-9fd3-11e8-9f67-65b0e1fee696.png)


After:
<img width="232" alt="screen shot 2018-08-14 at 3 00 06 pm" src="https://user-images.githubusercontent.com/115071/44121019-2b7601be-9fd3-11e8-8fef-af1b3b0924d5.png">

The desktop view stays the same.
![screen shot 2018-08-14 at 2 59 48 pm](https://user-images.githubusercontent.com/115071/44121147-b91798f2-9fd3-11e8-9f4d-915a660d8e0d.png)

Since this is done via JS you will need to refresh the page to see the change happen.


