### PR TITLE
Posts: Remove post view counts from Blog Posts list

### DIFF
--- a/client/my-sites/post-type-list/post-action-counts/index.jsx
+++ b/client/my-sites/post-type-list/post-action-counts/index.jsx
@@ -119,35 +119,12 @@ class PostActionCounts extends PureComponent {
 		);
 	}
 
-	renderViewCount() {
-		const { viewCount: count, numberFormat, postId, showViews, siteSlug, translate } = this.props;
-
-		if ( count < 1 || ! showViews ) {
-			return null;
-		}
-
-		return (
-			<li>
-				<a
-					href={ `/stats/post/${ postId }/${ siteSlug }` }
-					onClick={ this.onActionClick( 'stats' ) }
-				>
-					{ translate( '%(count)s View', '%(count)s Views', {
-						count,
-						args: { count: numberFormat( count ) },
-					} ) }
-				</a>
-			</li>
-		);
-	}
-
 	render() {
 		const { postId, siteId } = this.props;
 
 		return (
 			<ul className="post-action-counts">
 				{ siteId && <QueryPostStats siteId={ siteId } postId={ postId } fields={ [ 'views' ] } /> }
-				{ this.renderViewCount() }
 				{ this.renderLikeCount() }
 				{ this.renderCommentCount() }
 			</ul>

--- a/client/my-sites/post-type-list/post-action-counts/index.jsx
+++ b/client/my-sites/post-type-list/post-action-counts/index.jsx
@@ -12,10 +12,8 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import QueryPostStats from 'components/data/query-post-stats';
 import PostLikesPopover from 'blocks/post-likes/popover';
 import { getNormalizedPost } from 'state/posts/selectors';
-import { getPostStat } from 'state/stats/posts/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { getSiteSlug, isJetpackModuleActive, isJetpackSite } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -120,11 +118,8 @@ class PostActionCounts extends PureComponent {
 	}
 
 	render() {
-		const { postId, siteId } = this.props;
-
 		return (
 			<ul className="post-action-counts">
-				{ siteId && <QueryPostStats siteId={ siteId } postId={ postId } fields={ [ 'views' ] } /> }
 				{ this.renderLikeCount() }
 				{ this.renderCommentCount() }
 			</ul>
@@ -160,7 +155,6 @@ export default connect(
 			siteId,
 			siteSlug: getSiteSlug( state, siteId ),
 			type: get( post, 'type', 'unknown' ),
-			viewCount: getPostStat( state, siteId, postId, 'views' ),
 			isCurrentLikesPopoverOpen: isLikesPopoverOpen( state, globalId ),
 		};
 	},


### PR DESCRIPTION
This PR removes the post view counts from the Blog Posts list (fixes #26708).

### Acceptance criteria from #26708 to verify

1.
- Given a site with blog posts with views
- When Blog Posts is visited
- Then the "X Views" counts are not present on the post items in the list

2.
- Given a site with blog posts with views
- When Blog Posts is visited
- Then no `/stats/post` requests are made for individual posts

3.
- Given a customer with multiple sites with blog posts with views
- When Blog Posts is visited in All My Sites mode
- Then the "X Views" counts are not present on the post items in the list

4.
- Given a customer with multiple sites with blog posts with views
- When Blog Posts is visited in All My Sites mode
- Then no `/stats/post` requests are made for individual posts
