### PR TITLE
Domains: Protect selectedSite property access

### DIFF
--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -215,7 +215,7 @@ export default connect(
 		const siteId = get( selectedSite, 'ID', null );
 		const googleAppsUsers = selectedDomainName
 			? getByDomain( state, selectedDomainName )
-			: getBySite( state, selectedSite.ID );
+			: getBySite( state, siteId );
 
 		return {
 			currentUser: getCurrentUser( state ),


### PR DESCRIPTION
Protect property access on a nullable value.

`getSelectedSite` may return `null`:

https://github.com/Automattic/wp-calypso/blob/a83cbf1dd8dec839eb404f33dfba3ddb88f651a3/client/state/ui/selectors.js#L14-L27

It is unsafe to attempt to directly access properties of `null`. I observed a property access error in production when the flow navigated me to domain management after purchasing a new domain. I've addressed that error in this PR.

There are many other unguarded property accesses on this same, nullable value (`selectedSite`) throughout this component, a thorough audit would be a good idea. Please feel free to push additional fixes to this branch.