### PR TITLE
Activity Log: Updates have more space

### DIFF
--- a/client/my-sites/stats/activity-log-tasklist/style.scss
+++ b/client/my-sites/stats/activity-log-tasklist/style.scss
@@ -42,12 +42,9 @@
 
 .activity-log-tasklist__update-text {
 	font-weight: 500;
-
-	.button.is-borderless {
-		vertical-align: middle;
-		line-height: 1;
-		color: $gray-dark;
-	}
+	line-height: 21px;
+	padding-bottom:7px;
+	display: inline-block;
 }
 
 .activity-log-tasklist__update-version {
@@ -84,7 +81,7 @@
 	box-shadow: 0 -1px 0 transparentize( $gray-lighten-20, .5 );
 	padding: 16px 0;
 	color: $gray-text-min;
-	
+
 	a {
 		text-decoration: underline;
 	}

--- a/client/my-sites/stats/activity-log-tasklist/style.scss
+++ b/client/my-sites/stats/activity-log-tasklist/style.scss
@@ -28,7 +28,6 @@
 
 	.activity-log-item__activity-icon {
 		margin-right: 16px;
-		padding: 8px;
 	}
 }
 
@@ -41,11 +40,12 @@
 }
 
 .activity-log-tasklist__update-text {
-	font-weight: 500;
-	line-height: 21px;
-	padding-bottom:7px;
-	display: inline-block;
+	margin-bottom: 8px;
+	a, span {
+		font-weight: 500;
+	}
 }
+.activity-log-tasklist__update-text
 
 .activity-log-tasklist__update-version {
 	color: $gray-text-min;

--- a/client/my-sites/stats/activity-log-tasklist/update.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/update.jsx
@@ -59,19 +59,15 @@ class ActivityLogTaskUpdate extends Component {
 					activityStatus="warning"
 				/>
 				<span className="activity-log-tasklist__update-item">
-					<div>
-						<span className="activity-log-tasklist__update-text">
-							{ linked ? (
-								<a href={ url } onClick={ this.handleNameClick }>
-									{ name }
-								</a>
-							) : (
-								// Add button classes so unlinked names look the same.
-								<span className="activity-log-tasklist__unlinked button is-borderless">
-									{ name }
-								</span>
-							) }
-						</span>
+					<div className="activity-log-tasklist__update-text">
+						{ linked ? (
+							<a href={ url } onClick={ this.handleNameClick }>
+								{ name }
+							</a>
+						) : (
+							// Add button classes so unlinked names look the same.
+							<span className="activity-log-tasklist__unlinked button is-borderless">{ name }</span>
+						) }
 						<span className="activity-log-tasklist__update-bullet">&bull;</span>
 						<span className="activity-log-tasklist__update-version">{ version }</span>
 					</div>


### PR DESCRIPTION
Update the spacing of the update notices. 


Before:
Desktop
![screen shot 2018-08-15 at 8 31 47 pm](https://user-images.githubusercontent.com/115071/44185755-45d19080-a0ca-11e8-9d3d-f4f1f59deb04.png)

Mobile:
![screen shot 2018-08-15 at 8 31 22 pm](https://user-images.githubusercontent.com/115071/44185757-49651780-a0ca-11e8-8093-e79d77368330.png)

After:
Desktop:
![screen shot 2018-08-16 at 2 45 09 pm](https://user-images.githubusercontent.com/115071/44237307-e1174400-a164-11e8-9d64-a953f6911728.png)

Mobile:
![screen shot 2018-08-16 at 2 44 15 pm](https://user-images.githubusercontent.com/115071/44237300-dceb2680-a164-11e8-91a5-fd60fbea415c.png)


