### PR TITLE
SDK: Allow generation of source maps in all environments

### DIFF
--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -14,7 +14,6 @@ exports.config = ( {
 	return {
 		...baseConfig,
 		...{
-			devtool: process.env.SOURCEMAP || 'source-map',
 			entry: {
 				...( editorScript ? { [ outputEditorFile || `${ name }-editor` ]: editorScript } : {} ),
 				...( viewScript ? { [ outputViewFile || `${ name }-view` ]: viewScript } : {} ),

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -14,7 +14,7 @@ exports.config = ( {
 	return {
 		...baseConfig,
 		...{
-			devtool: 'source-map',
+			devtool: process.env.SOURCEMAP || 'source-map',
 			entry: {
 				...( editorScript ? { [ outputEditorFile || `${ name }-editor` ]: editorScript } : {} ),
 				...( viewScript ? { [ outputViewFile || `${ name }-view` ]: viewScript } : {} ),

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -14,6 +14,7 @@ exports.config = ( {
 	return {
 		...baseConfig,
 		...{
+			devtool: 'source-map',
 			entry: {
 				...( editorScript ? { [ outputEditorFile || `${ name }-editor` ]: editorScript } : {} ),
 				...( viewScript ? { [ outputViewFile || `${ name }-view` ]: viewScript } : {} ),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -120,7 +120,7 @@ function getWebpackConfig( { externalizeWordPressPackages = false } = {}, argv )
 		entry: { build: [ path.join( __dirname, 'client', 'boot', 'app' ) ] },
 		profile: shouldEmitStats,
 		mode: isDevelopment ? 'development' : 'production',
-		devtool: process.env.SOURCEMAP || ( isDevelopment ? '#eval' : false ), // in production builds you can specify a source-map via env var
+		devtool: process.env.SOURCEMAP || ( isDevelopment ? '#eval' : false ),
 		output: {
 			path: path.join( __dirname, 'public' ),
 			publicPath: '/calypso/',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -120,7 +120,7 @@ function getWebpackConfig( { externalizeWordPressPackages = false } = {}, argv )
 		entry: { build: [ path.join( __dirname, 'client', 'boot', 'app' ) ] },
 		profile: shouldEmitStats,
 		mode: isDevelopment ? 'development' : 'production',
-		devtool: isDevelopment ? '#eval' : process.env.SOURCEMAP || false, // in production builds you can specify a source-map via env var
+		devtool: process.env.SOURCEMAP || ( isDevelopment ? '#eval' : false ), // in production builds you can specify a source-map via env var
 		output: {
 			path: path.join( __dirname, 'public' ),
 			publicPath: '/calypso/',


### PR DESCRIPTION
This PR adds simple source maps generation to the SDK. It uses the `process.env.SOURCEMAP` to allow overriding the devtool (like Calypso already does), but defaults to creating production-friendly source maps instead of no source maps (contrary to Calypso core).

Question for y'all: should we also NOT build source maps by default, just like Calypso does?

To test:
* Checkout this branch
* Build an extension with the SDK (for example `SOURCEMAP=source-map npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/tiled-gallery/tiled-gallery.jsx`)
* Verify source JS and CSS source maps are created.
* Build Calypso and verify sourcemaps aren't created by default.
* Build Calypso with the `SOURCEMAP` env var and verify it works as expected, and takes precedence regardless what the environment is.