### PR TITLE
Gutenberg: Fix plugin name of Publicize

### DIFF
--- a/client/gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-gutenberg-plugin.jsx
@@ -56,7 +56,7 @@ const PluginRender = () => (
 	</Fragment>
 );
 
-registerPlugin( 'a8c/publicize', {
+registerPlugin( 'a8c-publicize', {
 	render: PluginRender
 } );
 


### PR DESCRIPTION
Seems like in #26662 we didn't account for the fact that Gutenberg has some limitations on the plugin names. When we have a slash in the plugin name, we'll see the following error:

![](https://cldup.com/NXKRSeJHZq.png)

This PR resolves that.

To test:
Follow the instructions #26603, which contains this PR. Verify you can no longer see the error when you load your Gutenberg editor.