### PR TITLE
Checklist: Fix completed task tour regression

### DIFF
--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -50,7 +50,7 @@ class ChecklistShow extends PureComponent {
 	handleTaskDismiss = task => () => {
 		const { notify, siteId, update } = this.props;
 
-		if ( task && ! task.completed ) {
+		if ( task ) {
 			notify( 'is-success', 'You completed a task!' );
 			update( siteId, task.id );
 		}

--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -29,11 +29,17 @@ class ChecklistShow extends PureComponent {
 		this.props.loadTrackingTool( 'HotJar' );
 	}
 
+	isComplete( taskId ) {
+		return get( this.props.taskStatuses, [ taskId, 'completed' ], false );
+	}
+
 	handleTaskStart = task => () => {
 		const { requestTour, siteSlug, track } = this.props;
-
 		launchTask( {
-			task,
+			task: {
+				...task,
+				completed: task.completed || this.isComplete( task.id ),
+			},
 			location: 'checklist_show',
 			requestTour,
 			siteSlug,
@@ -62,7 +68,7 @@ class ChecklistShow extends PureComponent {
 						<Task
 							buttonPrimary={ task.buttonPrimary }
 							buttonText={ task.buttonText }
-							completed={ task.completed || get( taskStatuses, [ task.id, 'completed' ], false ) }
+							completed={ task.completed || this.isComplete( task.id ) }
 							completedButtonText={ task.completedButtonText }
 							completedTitle={ task.completedTitle }
 							description={ task.description }


### PR DESCRIPTION
Fixes a regression introduced by #26618 where Guided Tours are initiated on completed tasks. Previously, they were not.

Uses an idea from #26734:

https://github.com/Automattic/wp-calypso/blob/d701d84815655616cfcf4d314594b3505d2d6ca2/client/my-sites/plans/current-plan/jetpack-checklist/index.js#L30-L32

## Testing:

Ensure there are no regressions and the WordPress.com onboarding checklist continues to work as before.

Ensure that guided tours _are not_ initiated when starting an _already completed_ task.