### PR TITLE
Name current plan controller export

### DIFF
--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -14,25 +14,23 @@ import CurrentPlan from './';
 import { isFreePlan } from 'lib/products-values';
 import { getSelectedSite } from 'state/ui/selectors';
 
-export default {
-	currentPlan( context, next ) {
-		const state = context.store.getState();
+export function currentPlan( context, next ) {
+	const state = context.store.getState();
 
-		const selectedSite = getSelectedSite( state );
+	const selectedSite = getSelectedSite( state );
 
-		if ( ! selectedSite ) {
-			page.redirect( '/plans/' );
+	if ( ! selectedSite ) {
+		page.redirect( '/plans/' );
 
-			return null;
-		}
+		return null;
+	}
 
-		if ( isFreePlan( selectedSite.plan ) ) {
-			page.redirect( `/plans/${ selectedSite.slug }` );
+	if ( isFreePlan( selectedSite.plan ) ) {
+		page.redirect( `/plans/${ selectedSite.slug }` );
 
-			return null;
-		}
+		return null;
+	}
 
-		context.primary = <CurrentPlan path={ context.path } />;
-		next();
-	},
-};
+	context.primary = <CurrentPlan path={ context.path } />;
+	next();
+}

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -7,10 +7,10 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { navigation, siteSelection, sites } from 'my-sites/controller';
 import plansController from './controller';
-import currentPlanController from './current-plan/controller';
+import { currentPlan } from './current-plan/controller';
 import { makeLayout, render as clientRender } from 'controller';
+import { navigation, siteSelection, sites } from 'my-sites/controller';
 
 export default function() {
 	page( '/plans', siteSelection, sites, makeLayout, clientRender );
@@ -47,23 +47,8 @@ export default function() {
 		clientRender
 	);
 	page( '/plans/features/:feature/:domain', plansController.features, makeLayout, clientRender );
-	page(
-		'/plans/my-plan',
-		siteSelection,
-		sites,
-		navigation,
-		currentPlanController.currentPlan,
-		makeLayout,
-		clientRender
-	);
-	page(
-		'/plans/my-plan/:site',
-		siteSelection,
-		navigation,
-		currentPlanController.currentPlan,
-		makeLayout,
-		clientRender
-	);
+	page( '/plans/my-plan', siteSelection, sites, navigation, currentPlan, makeLayout, clientRender );
+	page( '/plans/my-plan/:site', siteSelection, navigation, currentPlan, makeLayout, clientRender );
 	page(
 		'/plans/select/:plan/:domain',
 		siteSelection,


### PR DESCRIPTION
Use a named export instead of a default object export.

No functional changes.

View with [no whitespace](https://github.com/Automattic/wp-calypso/pull/26738/files?w=1) changes to see export changes.

## Testing
- Ensure the my-plan page continues to work as before (`/plans/my-plan/SITE`)