### PR TITLE
Domains: Disable query traffic to dot

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -76,14 +76,14 @@ export default {
 		defaultVariation: 'original',
 	},
 	domainSuggestionKrakenV323: {
-		datestamp: '20180726',
+		datestamp: '20180815',
 		variations: {
 			domainsbot: 0,
 			group_1: 22700,
 			group_3: 22700,
 			group_4: 22700,
-			group_6: 10000,
-			group_7: 10000,
+			group_6: 0,
+			group_7: 0,
 			group_8: 22700,
 		},
 		defaultVariation: 'domainsbot',


### PR DESCRIPTION
Due to a critical bug on dot, we need to modify the A/B test definition for `domainSuggestionKrakenV323 ` to disable all traffic to dot.

# Test instructions
1. Spin this branch up locally
2. Navigate to `/start/domains`.
3. Ensure that A/B group assignment works as expected.