### PR TITLE
Domains: Enable dot for domain management page (/domains/add)

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -695,6 +695,9 @@ class RegisterDomainStep extends React.Component {
 			tld_weight_overrides: getTldWeightOverrides( this.props.designType ),
 			vendor: searchVendor,
 			vertical: this.props.surveyVertical,
+			recommendation_context: get( this.props, 'selectedSite.name', '' )
+				.replace( ' ', ',' )
+				.toLocaleLowerCase(),
 			...this.getActiveFiltersForAPI(),
 		};
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -861,6 +861,8 @@ class RegisterDomainStep extends React.Component {
 
 		if ( this.props.isSignupStep ) {
 			searchVendor = abtest( 'domainSuggestionKrakenV325' );
+		} else {
+			searchVendor = abtest( 'domainManagementSuggestion' );
 		}
 
 		enqueueSearchStatReport( { query: searchQuery, section: this.props.analyticsSection } );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -148,4 +148,13 @@ export default {
 		},
 		defaultVariation: 'control',
 	},
+	domainManagementSuggestion: {
+		datestamp: '20180822',
+		variations: {
+			domainsbot: 82,
+			group_7: 18,
+		},
+		defaultVariation: 'domainsbot',
+		assignmentMethod: 'userId',
+	},
 };


### PR DESCRIPTION
This change enables dot for the domain management page. It also passes the current site title (if available) as `recommendation_context` in the query.

`recommendation_context` works in conjunction with D17429-code.

# Test Instructions
1. Spin this branch up locally or in a live branch.
2. Navigate to [`/domains/add`](http://calypso.localhost:3000/domains/add/) and select `group_6` or `group_7` for the A/B test `domainManagementSuggestion`.
3. Ensure that the domain recommendation results originate from dot.
    - You can cross reference results from [`/start/domains`](http://calypso.localhost:3000/start/domains) using `group_6` or `group_7` for the A/B test named `domainSuggestionKrakenV324`.