### PR TITLE
Signup: Remove improved suggestion matches test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -88,14 +88,6 @@ export default {
 		},
 		defaultVariation: 'domainsbot',
 	},
-	aboutSuggestionMatches: {
-		datestamp: '20180704',
-		variations: {
-			control: 50,
-			enhancedSort: 50,
-		},
-		defaultVariation: 'control',
-	},
 	includeDotBlogSubdomainV2: {
 		datestamp: '20180813',
 		variations: {

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { invoke, noop, findKey, escapeRegExp } from 'lodash';
+import { invoke, noop, findKey } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -169,9 +169,13 @@ class AboutStep extends Component {
 	};
 
 	getSuggestions() {
-		const { query } = this.state;
+		if ( ! this.state.query ) {
+			return [];
+		}
+
+		const query = this.state.query.toLocaleLowerCase();
 		return Object.values( hints )
-			.filter( hint => query && hint.match( new RegExp( escapeRegExp( query ), 'i' ) ) )
+			.filter( hint => hint.toLocaleLowerCase().includes( query ) )
 			.sort( ( a, b ) => a.localeCompare( b ) )
 			.map( hint => ( { label: hint } ) );
 	}

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -173,7 +173,7 @@ class AboutStep extends Component {
 			return [];
 		}
 
-		const query = this.state.query.toLocaleLowerCase();
+		const query = this.state.query.trim().toLocaleLowerCase();
 		return Object.values( hints )
 			.filter( hint => hint.toLocaleLowerCase().includes( query ) )
 			.sort( ( a, b ) => a.localeCompare( b ) )

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -176,7 +176,6 @@ class AboutStep extends Component {
 		const query = this.state.query.trim().toLocaleLowerCase();
 		return Object.values( hints )
 			.filter( hint => hint.toLocaleLowerCase().includes( query ) )
-			.sort( ( a, b ) => a.localeCompare( b ) )
 			.map( hint => ( { label: hint } ) );
 	}
 

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -100,11 +100,8 @@ class AboutStep extends Component {
 	};
 
 	handleSuggestionChangeEvent = ( { target: { name, value } } ) => {
-		this.setState( { query: value } );
-		this.setState( { siteTopicValue: value } );
-
+		this.setState( { query: value, siteTopicValue: value } );
 		this.props.recordTracksEvent( 'calypso_signup_actions_select_site_topic', { value } );
-
 		this.formStateController.handleFieldChange( { name, value } );
 	};
 
@@ -172,19 +169,10 @@ class AboutStep extends Component {
 	};
 
 	getSuggestions() {
-		const query = this.state.query && escapeRegExp( this.state.query ).toLowerCase();
-		const regex = new RegExp( query, 'i' );
-
-		// Prioritize suggestions starting with query input first
-		const sortFunction = ( a, b ) =>
-			abtest( 'aboutSuggestionMatches' ) === 'enhancedSort'
-				? a.localeCompare( b ) -
-				  2 * ( b.toLowerCase().indexOf( query ) - a.toLowerCase().indexOf( query ) )
-				: a.localeCompare( b );
-
+		const { query } = this.state;
 		return Object.values( hints )
-			.filter( hint => query && hint.match( regex ) )
-			.sort( sortFunction )
+			.filter( hint => query && hint.match( new RegExp( escapeRegExp( query ), 'i' ) ) )
+			.sort( ( a, b ) => a.localeCompare( b ) )
 			.map( hint => ( { label: hint } ) );
 	}
 


### PR DESCRIPTION
Effectively reverts #25792. The A/B test for this has been inconclusive so far, so we're erring on the side of less code. 

# Testing instructions
1. Spin up this branch locally.
2. Navigate to the [signup flow](http://calypso.localhost:3000/start/about).
3. Try a variety of queries for the site topic input. Ensure that the input works as expected.