### PR TITLE
Domains: Enable dot in signup

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -860,7 +860,7 @@ class RegisterDomainStep extends React.Component {
 		}
 
 		if ( this.props.isSignupStep ) {
-			searchVendor = abtest( 'domainSuggestionKrakenV323' );
+			searchVendor = abtest( 'domainSuggestionKrakenV324' );
 		}
 
 		enqueueSearchStatReport( { query: searchQuery, section: this.props.analyticsSection } );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -75,16 +75,16 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
-	domainSuggestionKrakenV323: {
-		datestamp: '20180815',
+	domainSuggestionKrakenV324: {
+		datestamp: '20180820',
 		variations: {
 			domainsbot: 0,
-			group_1: 22700,
-			group_3: 22700,
-			group_4: 22700,
-			group_6: 0,
-			group_7: 0,
-			group_8: 22700,
+			group_1: 21,
+			group_3: 21,
+			group_4: 21,
+			group_6: 8, // dot with re-ordering
+			group_7: 8, // dot
+			group_8: 21,
 		},
 		defaultVariation: 'domainsbot',
 	},


### PR DESCRIPTION
Effectively undoes #26740. 

This change creates a new A/B test (`domainSuggestionKrakenV324`) with splits normalized to percentages. 

# Test instructions
1. Spin this branch up locally
2. Navigate to `/start/domains`.
3. Try manually assigning yourself to each of variation for `domainSuggestionKrakenV324`. Ensure that the domain suggestions work as expected.