### PR TITLE
Build: Update Circle API to v1.1 and only build String artifact in the first container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,15 +56,19 @@ jobs:
       - run:
           name: Build calypso-strings.pot
           command: |
-            npm run translate; mkdir -p $CIRCLE_ARTIFACTS/translate
-            mv calypso-strings.pot $CIRCLE_ARTIFACTS/translate
+            if [ "$CIRCLE_NODE_INDEX" == "0" ]; then
+              npm run translate; mkdir -p $CIRCLE_ARTIFACTS/translate
+              mv calypso-strings.pot $CIRCLE_ARTIFACTS/translate
+            fi
 
       - run:
           name: Build New Strings .pot
           command: |
-            git clone https://github.com/Automattic/gp-localci-client.git
-            bash gp-localci-client/generate-new-strings-pot.sh $CIRCLE_BRANCH $CIRCLE_SHA1 $CIRCLE_ARTIFACTS/translate
-            rm -rf gp-localci-client
+            if [ "$CIRCLE_NODE_INDEX" == "0" ]; then
+              git clone https://github.com/Automattic/gp-localci-client.git
+              bash gp-localci-client/generate-new-strings-pot.sh $CIRCLE_BRANCH $CIRCLE_SHA1 $CIRCLE_ARTIFACTS/translate
+              rm -rf gp-localci-client
+            fi
 
       - run:
           name: Run Integration Tests

--- a/bin/get-circle-string-artifact-url
+++ b/bin/get-circle-string-artifact-url
@@ -4,7 +4,7 @@
 // eg: node bin/get-circle-string-artifact-url | xargs curl
 
 const https = require('https');
-const path = '/api/v1/project/Automattic/wp-calypso/latest/artifacts?branch=master&filter=successful';
+const path = '/api/v1.1/project/github/Automattic/wp-calypso/latest/artifacts?&branch=master&filter=successful';
 
 const options = {
 	host: 'circleci.com',


### PR DESCRIPTION
This PR updates the `get-circle-string-artifact-url` to use the Circle v1.1 API instead of v1, and also updates circle.yml to only build our translation strings on the first container, rather than on all 6.

### Testing Instructions
- String integration tests still pass `npm run test-integration`
- Visiting https://circleci.com/api/v1.1/project/github/Automattic/wp-calypso/latest/artifacts?&branch=update/circle-api-version&filter=successful we only see one pot artifact
- Clicking on Circle CI test results

In the first container we should see:

![screen shot 2018-08-16 at 3 24 20 pm](https://user-images.githubusercontent.com/1270189/44238282-e24a7000-a168-11e8-97e0-8780962f540b.png)
![screen shot 2018-08-16 at 3 24 33 pm](https://user-images.githubusercontent.com/1270189/44238290-ea0a1480-a168-11e8-903e-d4dedc05ec4d.png)

In other containers, we should skip processing:

![screen shot 2018-08-16 at 3 23 58 pm](https://user-images.githubusercontent.com/1270189/44238300-f5f5d680-a168-11e8-8ce4-daba8a2d63ed.png)
![screen shot 2018-08-16 at 3 24 42 pm](https://user-images.githubusercontent.com/1270189/44238306-fd1ce480-a168-11e8-8b73-df704723c288.png)


In master, we see this building in all parallel containers, which is wasteful. This should hopefully speed up test runs slightly.

