### PR TITLE
Activity Log: Do not show update notice to VIP sites

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -60,6 +60,7 @@ import getRestoreProgress from 'state/selectors/get-restore-progress';
 import getRewindState from 'state/selectors/get-rewind-state';
 import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
+import isVipSite from 'state/selectors/is-vip-site';
 import { requestActivityLogs } from 'state/data-getters';
 import { emptyFilter } from 'state/activity-log/reducer';
 import { isMobile } from 'lib/viewport';
@@ -521,7 +522,9 @@ export default connect(
 		const restoreStatus = rewindState.rewind && rewindState.rewind.status;
 		const filter = getActivityLogFilter( state, siteId );
 		const logs = siteId && requestActivityLogs( siteId, filter );
-		const siteIsOnFreePlan = isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) );
+		const siteIsOnFreePlan =
+			isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) ) &&
+			! isVipSite( state, siteId );
 
 		return {
 			canViewActivityLog: canCurrentUser( state, siteId, 'manage_options' ),


### PR DESCRIPTION
Currently we show the Upgrade Nudge Banner on VIP sites because the `isFreePlan` is not working as it should. 

This is more of a temporary fix until plan are added for VIP sites. 
Before:
![screen shot 2018-08-16 at 3 06 24 pm](https://user-images.githubusercontent.com/115071/44237738-8383f700-a166-11e8-9d77-ca529669a734.png)

After:
![screen shot 2018-08-16 at 3 05 39 pm](https://user-images.githubusercontent.com/115071/44237741-85e65100-a166-11e8-8c87-1c5f06cd1801.png)

Fixes: #26727

