### PR TITLE
Activity Log: Add a check for if we should show the activity log to non admins

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -15,6 +15,7 @@ import NavTabs from 'components/section-nav/tabs';
 import Intervals from './intervals';
 import FollowersCount from 'blocks/followers-count';
 import isGoogleMyBusinessLocationConnectedSelector from 'state/selectors/is-google-my-business-location-connected';
+import canCurrentUser from 'state/selectors/can-current-user';
 import isSiteStore from 'state/selectors/is-site-store';
 import { navItems, intervals as intervalConstants } from './constants';
 import config from 'config';
@@ -30,9 +31,12 @@ class StatsNavigation extends Component {
 	};
 
 	isValidItem = item => {
-		const { isGoogleMyBusinessLocationConnected, isStore, siteId } = this.props;
+		const { isGoogleMyBusinessLocationConnected, isStore, siteId, canViewActivityLog } = this.props;
 
 		switch ( item ) {
+			case 'activity':
+				return canViewActivityLog;
+
 			case 'store':
 				return isStore;
 
@@ -93,6 +97,7 @@ export default connect( ( state, { siteId } ) => {
 			state,
 			siteId
 		),
+		canViewActivityLog: canCurrentUser( state, siteId, 'manage_options' ),
 		isStore: isSiteStore( state, siteId ),
 		siteId,
 	};


### PR DESCRIPTION
Currently we are not checking for permissions if the link for the activity log should even appear.

So it shows it too all users that can see stats. I think we need to make sure to hide the activity log for users that are will get an error just by trying to click on the page. 

Before:
![screen_shot_2018-08-16_at_3_37_05_pm](https://user-images.githubusercontent.com/115071/44238632-6c470880-a16a-11e8-9207-439393bc729f.png)

After:
![screen_shot_2018-08-16_at_3_22_33_pm](https://user-images.githubusercontent.com/115071/44238572-3144d500-a16a-11e8-806e-85b7bb8ee566.png)


To test:
Login as an author and notice that you are not seeing the link to he activity log any more. 
