### PR TITLE
Checkout: Add/domain credit illustration

### DIFF
--- a/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
@@ -31,13 +31,17 @@ class FreeCartPaymentBox extends React.Component {
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 					<div className="payment-box-section">
 						<div className="checkout__payment-box-section-content">
-							<h6>
+							<span className="checkout__free-domain-credit-illustration">
+								<img src="/calypso/images/illustrations/custom-domain.svg" />
+							</span>
+
+							<h6 className="checkout__free-domain-credit-title">
 								{ cart.has_bundle_credit
 									? this.props.translate( 'You have a free domain credit!' )
 									: this.props.translate( "Woohoo! You don't owe us anything!" ) }
 							</h6>
 
-							<span>
+							<span className="checkout__free-domain-credit">
 								{ cart.has_bundle_credit
 									? this.props.translate(
 											'You get one free domain with your subscription to %(productName)s. Time to celebrate!',

--- a/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
@@ -31,17 +31,15 @@ class FreeCartPaymentBox extends React.Component {
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 					<div className="payment-box-section">
 						<div className="checkout__payment-box-section-content">
-							<span className="checkout__free-domain-credit-illustration">
-								<img src="/calypso/images/illustrations/custom-domain.svg" alt="" />
-							</span>
+							{ this.getDomainCreditIllustration() }
 
-							<h6 className="checkout__free-domain-credit-title">
+							<h6>
 								{ cart.has_bundle_credit
 									? this.props.translate( 'You have a free domain credit!' )
 									: this.props.translate( "Woohoo! You don't owe us anything!" ) }
 							</h6>
 
-							<span className="checkout__free-domain-credit">
+							<span>
 								{ cart.has_bundle_credit
 									? this.props.translate(
 											'You get one free domain with your subscription to %(productName)s. Time to celebrate!',
@@ -83,6 +81,20 @@ class FreeCartPaymentBox extends React.Component {
 			return product.product_name;
 		}
 		return '';
+	};
+
+	getDomainCreditIllustration = () => {
+		const cart = this.props.cart;
+
+		if ( ! cart.has_bundle_credit ) {
+			return;
+		}
+
+		return (
+			<span className="checkout__free-domain-credit-illustration">
+				<img src="/calypso/images/illustrations/custom-domain.svg" alt="" />
+			</span>
+		);
 	};
 
 	render() {

--- a/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
@@ -32,7 +32,7 @@ class FreeCartPaymentBox extends React.Component {
 					<div className="payment-box-section">
 						<div className="checkout__payment-box-section-content">
 							<span className="checkout__free-domain-credit-illustration">
-								<img src="/calypso/images/illustrations/custom-domain.svg" />
+								<img src="/calypso/images/illustrations/custom-domain.svg" alt="" />
 							</span>
 
 							<h6 className="checkout__free-domain-credit-title">

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -479,23 +479,32 @@
 				}
 			}
 
-			.checkout__free-domain-credit,
-			.checkout__free-domain-credit-title {
-				display: inline-block;
-				padding-left: 20px;
-				padding-right: 20px;
-			}
-
 			.checkout__free-domain-credit-illustration {
-				display: block;
 				max-width: 100%;
 				max-height: 150px;
-				margin-top: -10px;
-				margin-bottom: 10px;
+				margin: -10px auto 10px;
 
 				img {
 					max-width: 100%;
 					max-height: 150px;
+				}
+
+				@include breakpoint( '>960px' ) {
+					float: left;
+					margin-left: 20px;
+					width: calc(25% - 20px);
+				}
+			}
+
+			.checkout__free-domain-credit-illustration + h6,
+			.checkout__free-domain-credit-illustration + h6 + span {
+				display: block;
+				padding-left: 20px;
+
+				@include breakpoint( '>960px' ) {
+					clear: none;
+					float: left;
+					width: calc(75% - 20px);
 				}
 			}
 		}

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -478,6 +478,26 @@
 					font-size: 15px;
 				}
 			}
+
+			.checkout__free-domain-credit,
+			.checkout__free-domain-credit-title {
+				display: inline-block;
+				padding-left: 20px;
+				padding-right: 20px;
+			}
+
+			.checkout__free-domain-credit-illustration {
+				display: block;
+				max-width: 100%;
+				max-height: 150px;
+				margin-top: -10px;
+				margin-bottom: 10px;
+
+				img {
+					max-width: 100%;
+					max-height: 150px;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
If we have a domain credit, the page looks pretty sad:

<img width="745" alt="screen shot 2018-08-16 at 9 16 55 pm" src="https://user-images.githubusercontent.com/2124984/44242820-beebe900-a199-11e8-89c8-af66ca14214e.png">

I've added an illustration and tidied up the padding a bit:

<img width="753" alt="screen shot 2018-08-16 at 9 16 34 pm" src="https://user-images.githubusercontent.com/2124984/44242826-c612f700-a199-11e8-8441-9e3054dfc5ee.png">

**Steps to test**

1. Switch to this PR and start with a free site
2. Upgrade to a paid plan without a domain
3. Claim your free domain from the sidebar
4. Checkout