### PR TITLE
Jetpack connect: Pass calypso.live calypso_env variables together with COMMIT_SHA env var

### DIFF
--- a/client/jetpack-connect/test/utils.js
+++ b/client/jetpack-connect/test/utils.js
@@ -1,4 +1,7 @@
-/** @format */
+/**
+ * @format
+ * @jest-environment jsdom
+ */
 
 /**
  * Internal dependencies

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -61,7 +61,7 @@ export const authQueryPropTypes = PropTypes.shape( {
 
 export function addCalypsoEnvQueryArg( url ) {
 	let calypsoEnv = config( 'env_id' );
-	if ( COMMIT_SHA ) {
+	if ( COMMIT_SHA && window.location.host === 'calypso.live' ) {
 		calypsoEnv = `live-${ COMMIT_SHA }`;
 	}
 	return addQueryArgs( { calypso_env: calypsoEnv }, url );

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -60,7 +60,11 @@ export const authQueryPropTypes = PropTypes.shape( {
 } );
 
 export function addCalypsoEnvQueryArg( url ) {
-	return addQueryArgs( { calypso_env: config( 'env_id' ) }, url );
+	let calypsoEnv = config( 'env_id' );
+	if ( COMMIT_SHA ) {
+		calypsoEnv = `live-${ COMMIT_SHA }`;
+	}
+	return addQueryArgs( { calypso_env: calypsoEnv }, url );
 }
 
 /**

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -61,7 +61,7 @@ export const authQueryPropTypes = PropTypes.shape( {
 
 export function addCalypsoEnvQueryArg( url ) {
 	let calypsoEnv = config( 'env_id' );
-	if ( COMMIT_SHA && window.location.host === 'calypso.live' ) {
+	if ( window && window.COMMIT_SHA && window.location.host === 'calypso.live' ) {
 		calypsoEnv = `live-${ COMMIT_SHA }`;
 	}
 	return addQueryArgs( { calypso_env: calypsoEnv }, url );


### PR DESCRIPTION
With this PR calypso.live environment will use `live-[COMMIT_SHA]` as a `calypso_env`. This change will make it possible to finish Jetpack connection flow in calypso.live. Before this user would be redirected to wpcalypso due to same `calypso_env` used in both environments


To test:
- Make sure you have mapped WPCOM sandbox
- Apply D17314-code
- set `define('JETPACK__API_BASE', 'https://yourtestsite.wordpress.com/jetpack.');` in your Jetpack site
- Use this branch in calypso.live (https://calypso.live/?branch=add/pass-calypso-live-env-query-arg)
- Navigate to "Add new site" and paste your Jetpack site to connect. Make sure you remain on calypso.live domain after connection process succeeded


This should be merged _after_ D17314-code