### PR TITLE
Checklist: Update task url based on headstarted posts

### DIFF
--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -18,10 +18,12 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import getSiteChecklist from 'state/selectors/get-site-checklist';
 import { getSiteSlug } from 'state/sites/selectors';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
-import { launchTask, tasks } from '../onboardingChecklist';
+import { getTaskUrls, launchTask, tasks } from '../onboardingChecklist';
 import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
 import { createNotice } from 'state/notices/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
+import QueryPosts from 'components/data/query-posts';
+import { getSitePosts } from 'state/posts/selectors';
 
 class ChecklistShow extends PureComponent {
 	componentDidMount() {
@@ -33,11 +35,12 @@ class ChecklistShow extends PureComponent {
 	}
 
 	handleTaskStart = task => () => {
-		const { requestTour, siteSlug, track } = this.props;
+		const { requestTour, siteSlug, track, taskUrls } = this.props;
 		launchTask( {
 			task: {
 				...task,
 				completed: task.completed || this.isComplete( task.id ),
+				url: taskUrls[ task.id ] || task.url,
 			},
 			location: 'checklist_show',
 			requestTour,
@@ -61,6 +64,12 @@ class ChecklistShow extends PureComponent {
 		return (
 			<Fragment>
 				{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
+				{ siteId && (
+					<QueryPosts
+						siteId={ siteId }
+						query={ { type: 'any', number: 10, order_by: 'ID', order: 'ASC' } }
+					/>
+				) }
 				<Checklist isPlaceholder={ ! taskStatuses }>
 					{ tasks.map( task => (
 						<Task
@@ -90,6 +99,7 @@ const mapStateToProps = state => {
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
 		taskStatuses: get( getSiteChecklist( state, siteId ), [ 'tasks' ] ),
+		taskUrls: getTaskUrls( getSitePosts( state, siteId ) ),
 	};
 };
 

--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -5,6 +5,7 @@
 import page from 'page';
 import { isDesktop } from 'lib/viewport';
 import { translate } from 'i18n-calypso';
+import { find } from 'lodash';
 
 export const tasks = [
 	{
@@ -138,4 +139,25 @@ export function launchTask( { task, location, requestTour, siteSlug, track } ) {
 	if ( tour && isDesktop() ) {
 		requestTour( tour );
 	}
+}
+
+export function getTaskUrls( posts ) {
+	const urls = {};
+	const firstPost = find( posts, { type: 'post' } );
+	const contactPage = find( posts, post => {
+		return (
+			post.type === 'page' &&
+			find( post.metadata, { key: '_headstart_post', value: '_hs_contact_page' } )
+		);
+	} );
+
+	if ( firstPost ) {
+		urls.post_published = '/post/$siteSlug/' + firstPost.ID;
+	}
+
+	if ( contactPage ) {
+		urls.contact_page_updated = '/post/$siteSlug/' + contactPage.ID;
+	}
+
+	return urls;
 }

--- a/client/my-sites/stats/checklist-banner/index.jsx
+++ b/client/my-sites/stats/checklist-banner/index.jsx
@@ -22,10 +22,12 @@ import ProgressBar from 'components/progress-bar';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 import getSiteChecklist from 'state/selectors/get-site-checklist';
 import { getSite, getSiteSlug } from 'state/sites/selectors';
-import { launchTask, tasks } from 'my-sites/checklist/onboardingChecklist';
+import { getTaskUrls, launchTask, tasks } from 'my-sites/checklist/onboardingChecklist';
 import ChecklistShowShare from 'my-sites/checklist/share';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
+import QueryPosts from 'components/data/query-posts';
+import { getSitePosts } from 'state/posts/selectors';
 
 const storeKeyForNeverShow = 'sitesNeverShowChecklistBanner';
 
@@ -44,11 +46,14 @@ export class ChecklistBanner extends Component {
 	};
 
 	handleClick = () => {
-		const { requestTour, track, siteSlug } = this.props;
+		const { requestTour, track, siteSlug, taskUrls } = this.props;
 		const task = this.getTask();
 
 		launchTask( {
-			task,
+			task: {
+				...task,
+				url: taskUrls[ task.id ] || task.url,
+			},
 			location: 'checklist_banner',
 			requestTour,
 			siteSlug,
@@ -146,6 +151,12 @@ export class ChecklistBanner extends Component {
 		return (
 			<Card className="checklist-banner">
 				{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
+				{ siteId && (
+					<QueryPosts
+						siteId={ siteId }
+						query={ { type: 'any', number: 10, order_by: 'ID', order: 'ASC' } }
+					/>
+				) }
 				<div className="checklist-banner__gauge">
 					<span className="checklist-banner__gauge-additional-text">{ translate( 'setup' ) }</span>
 					<Gauge
@@ -202,6 +213,7 @@ const mapStateToProps = ( state, { siteId } ) => {
 		siteDesignType,
 		siteSlug,
 		taskStatuses,
+		taskUrls: getTaskUrls( getSitePosts( state, siteId ) ),
 	};
 };
 


### PR DESCRIPTION
A checklist task may need to change the destination URL based on the posts. For instance, "Publish your first blog post" task create a new post by default. However, once a user published a post, the task should head for it instead.

This _url_ logic is currently placed on the server-side, but it would be better if we could move the logic to Calypso. That's what this PR handles.

## How to test

1. Create a new site with default settings.
2. Apply D17317-code to your sandbox that points `public-api.wordpress.com`
3. Empty and re-headstart the site you just created by following the instruction on 1efe0-pb
4-1. "Personalize your Contact page" task should head for the new contact page instead of `/post/YOUR_SITE/2`.
4-2. "Publish your first blog post" task should not create a new post.