### PR TITLE
Checklist: Add a Tracks event upon first assignment

### DIFF
--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -339,6 +339,7 @@ export class Checkout extends React.Component {
 
 			// The onboarding checklist currently supports the blog type only.
 			if ( hasGoogleAppsInCart && domainReceiptId && 'blog' === siteDesignType ) {
+				analytics.tracks.recordEvent( 'calypso_checklist_assign', { site: selectedSite } );
 				return `/checklist/${ selectedSiteSlug }?d=gsuite`;
 			}
 
@@ -354,6 +355,7 @@ export class Checkout extends React.Component {
 		}
 
 		if ( this.props.isEligibleForCheckoutToChecklist && receipt ) {
+			analytics.tracks.recordEvent( 'calypso_checklist_assign', { site: selectedSite } );
 			return `/checklist/${ selectedSiteSlug }`;
 		}
 

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -339,7 +339,7 @@ export class Checkout extends React.Component {
 
 			// The onboarding checklist currently supports the blog type only.
 			if ( hasGoogleAppsInCart && domainReceiptId && 'blog' === siteDesignType ) {
-				analytics.tracks.recordEvent( 'calypso_checklist_assign', { site: selectedSite } );
+				analytics.tracks.recordEvent( 'calypso_checklist_assign', { site: selectedSiteSlug } );
 				return `/checklist/${ selectedSiteSlug }?d=gsuite`;
 			}
 
@@ -355,7 +355,7 @@ export class Checkout extends React.Component {
 		}
 
 		if ( this.props.isEligibleForCheckoutToChecklist && receipt ) {
-			analytics.tracks.recordEvent( 'calypso_checklist_assign', { site: selectedSite } );
+			analytics.tracks.recordEvent( 'calypso_checklist_assign', { site: selectedSiteSlug } );
 			return `/checklist/${ selectedSiteSlug }`;
 		}
 

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -339,7 +339,10 @@ export class Checkout extends React.Component {
 
 			// The onboarding checklist currently supports the blog type only.
 			if ( hasGoogleAppsInCart && domainReceiptId && 'blog' === siteDesignType ) {
-				analytics.tracks.recordEvent( 'calypso_checklist_assign', { site: selectedSiteSlug } );
+				analytics.tracks.recordEvent( 'calypso_checklist_assign', {
+					site: selectedSiteSlug,
+					plan: 'paid',
+				} );
 				return `/checklist/${ selectedSiteSlug }?d=gsuite`;
 			}
 
@@ -355,7 +358,10 @@ export class Checkout extends React.Component {
 		}
 
 		if ( this.props.isEligibleForCheckoutToChecklist && receipt ) {
-			analytics.tracks.recordEvent( 'calypso_checklist_assign', { site: selectedSiteSlug } );
+			analytics.tracks.recordEvent( 'calypso_checklist_assign', {
+				site: selectedSiteSlug,
+				plan: 'paid',
+			} );
 			return `/checklist/${ selectedSiteSlug }`;
 		}
 

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -284,6 +284,7 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	showChecklistAfterLogin = () => {
+		analytics.tracks.recordEvent( 'calypso_checklist_assign', { site: this.state.siteSlug } );
 		this.props.loginHandler( { redirectTo: `/checklist/${ this.state.siteSlug }` } );
 	};
 

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -284,7 +284,10 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	showChecklistAfterLogin = () => {
-		analytics.tracks.recordEvent( 'calypso_checklist_assign', { site: this.state.siteSlug } );
+		analytics.tracks.recordEvent( 'calypso_checklist_assign', {
+			site: this.state.siteSlug,
+			plan: 'free',
+		} );
 		this.props.loginHandler( { redirectTo: `/checklist/${ this.state.siteSlug }` } );
 	};
 


### PR DESCRIPTION
This adds Tracks events to the onboarding checklist when a user first registers for a plan and is redirected to the checklist.

**Steps to test**

1) Switch to this PR
2) Create a new site from `/start` and complete the signup process with a free site
3) Check to see if the Tracks event is being properly recorded when you're redirected to the checklist
4) Now create a new site from `/start` and complete signup with a paid plan
5) Again, check to see if the Tracks event is properly recorded when you're redirected to the checklist