### PR TITLE
Fixes upgrade nudge tests by adding conditions for new canManageSite prop

### DIFF
--- a/client/my-sites/upgrade-nudge/test/index.js
+++ b/client/my-sites/upgrade-nudge/test/index.js
@@ -21,6 +21,7 @@ describe( 'UpgradeNudge', () => {
 				},
 				jetpack: false,
 			},
+			canManageSite: true,
 		};
 		return merge( {}, defaultProps, overrideProps );
 	};
@@ -50,6 +51,13 @@ describe( 'UpgradeNudge', () => {
 				},
 			} );
 			delete props.feature;
+			const wrapper = shallow( <UpgradeNudge { ...props } /> );
+
+			expect( wrapper.instance().shouldDisplay() ).toBe( false );
+		} );
+
+		test( "should not display when user can't manage site", () => {
+			const props = createProps( { canManageSite: false } );
 			const wrapper = shallow( <UpgradeNudge { ...props } /> );
 
 			expect( wrapper.instance().shouldDisplay() ).toBe( false );


### PR DESCRIPTION
This PR updates the UpgradeNudge component tests to account for a new `canManageSite` prop on the component.

Test were failing previously because the new tests were merged to master without accounting for this prop.