### PR TITLE
Plugins: improve back button

### DIFF
--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -135,9 +135,8 @@ const SinglePlugin = createReactClass( {
 		);
 	},
 
-	backHref() {
-		const { navigated, prevPath, siteUrl } = this.props;
-		const shouldUseHistoryBack = window.history.length > 1 && navigated;
+	backHref( shouldUseHistoryBack ) {
+		const { prevPath, siteUrl } = this.props;
 		if ( prevPath ) {
 			return this.getPreviousListUrl();
 		}
@@ -155,7 +154,7 @@ const SinglePlugin = createReactClass( {
 		return (
 			<HeaderCake
 				isCompact={ true }
-				backHref={ this.backHref() }
+				backHref={ this.backHref( shouldUseHistoryBack ) }
 				onBackArrowClick={ recordEvent }
 				onClick={ shouldUseHistoryBack ? goBack : undefined }
 			/>

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -41,6 +41,11 @@ import NonSupportedJetpackVersionNotice from './not-supported-jetpack-version';
 import NoPermissionsError from './no-permissions-error';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import getToursHistory from 'state/ui/guided-tours/selectors/get-tours-history';
+import hasNavigated from 'state/selectors/has-navigated';
+
+function goBack() {
+	window.history.back();
+}
 
 const SinglePlugin = createReactClass( {
 	displayName: 'SinglePlugin',
@@ -131,10 +136,12 @@ const SinglePlugin = createReactClass( {
 	},
 
 	backHref() {
-		if ( this.props.prevPath ) {
+		const { navigated, prevPath, siteUrl } = this.props;
+		const shouldUseHistoryBack = window.history.length > 1 && navigated;
+		if ( prevPath ) {
 			return this.getPreviousListUrl();
 		}
-		return '/plugins/manage/' + ( this.props.siteUrl || '' );
+		return ! shouldUseHistoryBack ? '/plugins/manage/' + ( siteUrl || '' ) : null;
 	},
 
 	displayHeader( calypsoify ) {
@@ -143,11 +150,14 @@ const SinglePlugin = createReactClass( {
 		}
 
 		const recordEvent = this.recordEvent.bind( this, 'Clicked Header Plugin Back Arrow' );
+		const { navigated } = this.props;
+		const shouldUseHistoryBack = window.history.length > 1 && navigated;
 		return (
 			<HeaderCake
 				isCompact={ true }
 				backHref={ this.backHref() }
 				onBackArrowClick={ recordEvent }
+				onClick={ shouldUseHistoryBack ? goBack : undefined }
 			/>
 		);
 	},
@@ -431,6 +441,7 @@ export default connect(
 				: canCurrentUserManagePlugins( state ),
 			sites: getSelectedOrAllSitesWithPlugins( state ),
 			toursHistory: getToursHistory( state ),
+			navigated: hasNavigated( state ),
 		};
 	},
 	{


### PR DESCRIPTION
Fixes #25843 

This PR will use `history.back` to navigate when the `context.prevPath` is empty. It's a similar approach used in the [UI for a single comment](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/comments/comment-list/comment-list-header.jsx#L49).

### Testing instructions

**Ensure back button works for Activity Log links:**

- [Visit Calypso Live running this branch](https://calypso.live/?branch=fix/25843-plugins-back-button)
- Navigate to 'stats > activity' for one of your Jetpack sites
- Click on a plugin link to go to that plugin's page in calypso

<img width="1516" alt="screen shot 2018-08-17 at 2 52 24 pm" src="https://user-images.githubusercontent.com/2694219/44284046-38351b80-a22e-11e8-8bbf-45b34b03d718.png">


- Click the back button and ensure you are taken back to the activity log

<img width="1516" alt="screen shot 2018-08-17 at 2 53 46 pm" src="https://user-images.githubusercontent.com/2694219/44284060-3ff4c000-a22e-11e8-900e-74fca306cf1b.png">


**Ensure there are no regressions with the back button:**

- While still in Calypso live, click on the Plugins link in the sidebar
- Click click on a plugin's title to visit its page
- Ensure the back button takes you back to the main plugins page