### PR TITLE
WIP Add/single attachment view

### DIFF
--- a/client/my-sites/media/controller.js
+++ b/client/my-sites/media/controller.js
@@ -11,6 +11,7 @@ import page from 'page';
  * Internal Dependencies
  */
 import MediaComponent from 'my-sites/media/main';
+import SingleMediaComponent from 'my-sites/media/single';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { getSiteFragment } from 'lib/route';
 
@@ -28,6 +29,16 @@ export default {
 		context.primary = React.createElement( MediaComponent, {
 			filter: context.params.filter,
 			search: context.query.s,
+		} );
+		next();
+	},
+	singleMedia: function( context, next ) {
+		if ( ! getSiteFragment( context.path ) ) {
+			return page.redirect( '/media' );
+		}
+		// Render
+		context.primary = React.createElement( SingleMediaComponent, {
+			attachment: context.params.attachment,
 		} );
 		next();
 	},

--- a/client/my-sites/media/controller.js
+++ b/client/my-sites/media/controller.js
@@ -37,9 +37,7 @@ export default {
 			return page.redirect( '/media' );
 		}
 		// Render
-		context.primary = React.createElement( SingleMediaComponent, {
-			attachment: context.params.attachment,
-		} );
+		context.primary = <SingleMediaComponent attachment={ parseInt( context.params.attachment ) } />;
 		next();
 	},
 };

--- a/client/my-sites/media/controller.js
+++ b/client/my-sites/media/controller.js
@@ -32,12 +32,26 @@ export default {
 		} );
 		next();
 	},
+
 	singleMedia: function( context, next ) {
 		if ( ! getSiteFragment( context.path ) ) {
 			return page.redirect( '/media' );
 		}
 		// Render
-		context.primary = <SingleMediaComponent attachment={ parseInt( context.params.attachment ) } />;
+		context.primary = (
+			<SingleMediaComponent mediaId={ parseInt( context.params.mediaId ) } view="single" />
+		);
+		next();
+	},
+
+	editSingleMedia: function( context, next ) {
+		if ( ! getSiteFragment( context.path ) ) {
+			return page.redirect( '/media' );
+		}
+		// Render
+		context.primary = (
+			<SingleMediaComponent mediaId={ parseInt( context.params.mediaId ) } view="edit" />
+		);
 		next();
 	},
 };

--- a/client/my-sites/media/details.jsx
+++ b/client/my-sites/media/details.jsx
@@ -1,0 +1,273 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import page from 'page';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import { EditorMediaModalDetail } from 'post-editor/media-modal/detail';
+import { getMimePrefix, getMimeType } from 'lib/media/utils';
+import ImageEditor from 'blocks/image-editor';
+import VideoEditor from 'blocks/video-editor';
+import MediaActions from 'lib/media/actions';
+
+import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
+import accept from 'lib/accept';
+
+class MediaDetails extends Component {
+	static propTypes = {
+		site: PropTypes.object,
+		selected: PropTypes.number,
+		items: PropTypes.array,
+		view: PropTypes.string,
+	};
+
+	state = {
+		currentDetail: null,
+		editedImageItem: null,
+		editedVideoItem: null,
+		selectedItems: [],
+		source: '',
+	};
+
+	onBack = () => {
+		this.setState( {
+			editedImageItem: null,
+			editedVideoItem: null,
+			currentDetail: null,
+		} );
+	};
+
+	closeDetailsModal = () => {
+		this.setState( {
+			editedImageItem: null,
+			editedVideoItem: null,
+			currentDetail: null,
+		} );
+	};
+
+	onImageEditorCancel = imageEditorProps => {
+		const { resetAllImageEditorState } = imageEditorProps;
+		this.setState( { currentDetail: this.state.editedImageItem, editedImageItem: null } );
+
+		resetAllImageEditorState();
+	};
+
+	onEditorCancel = () => {
+		page( '/media/' + this.props.site.slug + '/' + this.getSelectedMedia().ID );
+	};
+
+	onImageEditorDone = ( error, blob, imageEditorProps ) => {
+		if ( error ) {
+			this.onEditImageCancel( imageEditorProps );
+			return;
+		}
+
+		const { fileName, site, ID, resetAllImageEditorState } = imageEditorProps;
+
+		const mimeType = getMimeType( fileName );
+
+		const item = {
+			ID: ID,
+			media: {
+				fileName: fileName,
+				fileContents: blob,
+				mimeType: mimeType,
+			},
+		};
+
+		MediaActions.update( site.ID, item, true );
+		resetAllImageEditorState();
+		this.setState( { currentDetail: null, editedImageItem: null, selectedItems: [] } );
+	};
+
+	getModalButtons() {
+		// do not render buttons if the media image or video editor is opened
+		if ( this.props.view === 'edit' ) {
+			return null;
+		}
+
+		const { translate } = this.props;
+
+		return [
+			{
+				action: 'delete',
+				additionalClassNames: 'media__modal-delete-item-button is-link',
+				label: translate( 'Delete' ),
+				isPrimary: false,
+				disabled: false,
+				onClick: this.deleteMediaByItemDetail,
+			},
+			{
+				action: 'confirm',
+				label: translate( 'Done' ),
+				isPrimary: true,
+				disabled: false,
+				onClose: this.closeDetailsModal,
+			},
+		];
+	}
+
+	onVideoEditorCancel = () => {
+		this.setState( { currentDetail: this.state.editedVideoItem, editedVideoItem: null } );
+	};
+
+	onVideoEditorUpdatePoster = ( { ID, posterUrl } ) => {
+		const site = this.props.site;
+
+		// Photon does not support URLs with a querystring component.
+		const urlBeforeQuery = ( posterUrl || '' ).split( '?' )[ 0 ];
+
+		if ( site ) {
+			MediaActions.edit( site.ID, {
+				ID,
+				thumbnails: {
+					fmt_hd: urlBeforeQuery,
+					fmt_dvd: urlBeforeQuery,
+					fmt_std: urlBeforeQuery,
+				},
+			} );
+		}
+
+		this.setState( { currentDetail: null, editedVideoItem: null, selectedItems: [] } );
+	};
+
+	restoreOriginalMedia = ( siteId, item ) => {
+		if ( ! siteId || ! item ) {
+			return;
+		}
+		MediaActions.update( siteId, { ID: item.ID, media_url: item.guid }, true );
+		this.setState( { currentDetail: null, editedImageItem: null, selectedItems: [] } );
+	};
+
+	setDetailSelectedIndex = index => {
+		this.setState( { currentDetail: index } );
+	};
+
+	/**
+	 * Start the process to delete media items.
+	 * `callback` is an optional parameter which will execute once the confirm dialog is accepted.
+	 * It's used especially when the item is attempting to be removed using the item detail dialog.
+	 *
+	 * @param  {Function} [callback] - callback function
+	 */
+	deleteMedia( callback ) {
+		const { translate, items } = this.props;
+		const selectedCount = items.length;
+		const confirmMessage = translate(
+			'Are you sure you want to delete this item? ' +
+				'Deleted media will no longer appear anywhere on your website, including all posts, pages, and widgets. ' +
+				'This cannot be undone.',
+			'Are you sure you want to delete these items? ' +
+				'Deleted media will no longer appear anywhere on your website, including all posts, pages, and widgets. ' +
+				'This cannot be undone.',
+			{ count: selectedCount }
+		);
+
+		accept(
+			confirmMessage,
+			accepted => {
+				if ( ! accepted ) {
+					return;
+				}
+
+				this.confirmDeleteMedia();
+				if ( callback ) {
+					callback();
+				}
+			},
+			translate( 'Delete' ),
+			null,
+			{
+				isScary: true,
+			}
+		);
+	}
+
+	enableEditMode = () => {
+		page( '/media/edit/' + this.props.site.slug + '/' + this.getSelectedMedia().ID );
+		return;
+	};
+
+	handleDeleteMediaEvent = () => {
+		this.deleteMedia();
+	};
+
+	deleteMediaByItemDetail = () => {
+		this.deleteMedia( () => this.closeDetailsModal() );
+	};
+
+	confirmDeleteMedia = () => {
+		const site = this.props.site;
+
+		if ( ! site ) {
+			return;
+		}
+
+		const selected =
+			this.props.items && this.props.items.length
+				? this.props.items
+				: MediaLibrarySelectedStore.getAll( site.ID );
+
+		MediaActions.delete( site.ID, selected );
+	};
+
+	getSelectedMedia = () => {
+		return this.props.items[ this.props.selected ];
+	};
+
+	render() {
+		const { site, view, items, selected } = this.props;
+		const mimePrefix = getMimePrefix( this.getSelectedMedia() );
+		return (
+			<Dialog
+				isVisible={ true }
+				additionalClassNames="editor-media-modal media__item-dialog"
+				buttons={ this.getModalButtons() }
+				onClose={ this.onBack }
+			>
+				{ view === 'single' && (
+					<EditorMediaModalDetail
+						site={ site }
+						backText="Back"
+						items={ items }
+						selectedIndex={ selected }
+						onReturnToList={ this.onBack }
+						onEditImageItem={ this.enableEditMode }
+						onEditVideoItem={ this.enableEditMode }
+						onRestoreItem={ this.restoreOriginalMedia }
+						onSelectedIndexChange={ this.setDetailSelectedIndex }
+					/>
+				) }
+				{ view === 'edit' &&
+					'video' !== mimePrefix && (
+						<ImageEditor
+							siteId={ site && site.ID }
+							media={ this.getSelectedMedia() }
+							onDone={ this.onImageEditorDone }
+							onCancel={ this.onEditorCancel }
+						/>
+					) }
+				{ view === 'edit' &&
+					'video' === mimePrefix && (
+						<VideoEditor
+							siteId={ site && site.ID }
+							media={ this.getSelectedMedia() }
+							onCancel={ this.onEditorCancel }
+							onUpdatePoster={ this.onVideoEditorUpdatePoster }
+						/>
+					) }
+			</Dialog>
+		);
+	}
+}
+
+export default localize( MediaDetails );

--- a/client/my-sites/media/details.jsx
+++ b/client/my-sites/media/details.jsx
@@ -30,39 +30,14 @@ class MediaDetails extends Component {
 		view: PropTypes.string,
 	};
 
-	state = {
-		currentDetail: null,
-		editedImageItem: null,
-		editedVideoItem: null,
-		selectedItems: [],
-		source: '',
-	};
-
-	onBack = () => {
-		this.setState( {
-			editedImageItem: null,
-			editedVideoItem: null,
-			currentDetail: null,
-		} );
-	};
-
 	closeDetailsModal = () => {
-		this.setState( {
-			editedImageItem: null,
-			editedVideoItem: null,
-			currentDetail: null,
-		} );
-	};
-
-	onImageEditorCancel = imageEditorProps => {
-		const { resetAllImageEditorState } = imageEditorProps;
-		this.setState( { currentDetail: this.state.editedImageItem, editedImageItem: null } );
-
-		resetAllImageEditorState();
+		page( '/media/' + this.props.site.slug + '/' );
+		return;
 	};
 
 	onEditorCancel = () => {
 		page( '/media/' + this.props.site.slug + '/' + this.getSelectedMedia().ID );
+		return;
 	};
 
 	onImageEditorDone = ( error, blob, imageEditorProps ) => {
@@ -86,7 +61,7 @@ class MediaDetails extends Component {
 
 		MediaActions.update( site.ID, item, true );
 		resetAllImageEditorState();
-		this.setState( { currentDetail: null, editedImageItem: null, selectedItems: [] } );
+		this.closeDetailsModal();
 	};
 
 	getModalButtons() {
@@ -116,10 +91,6 @@ class MediaDetails extends Component {
 		];
 	}
 
-	onVideoEditorCancel = () => {
-		this.setState( { currentDetail: this.state.editedVideoItem, editedVideoItem: null } );
-	};
-
 	onVideoEditorUpdatePoster = ( { ID, posterUrl } ) => {
 		const site = this.props.site;
 
@@ -137,7 +108,7 @@ class MediaDetails extends Component {
 			} );
 		}
 
-		this.setState( { currentDetail: null, editedVideoItem: null, selectedItems: [] } );
+		this.props.onBack();
 	};
 
 	restoreOriginalMedia = ( siteId, item ) => {
@@ -145,11 +116,11 @@ class MediaDetails extends Component {
 			return;
 		}
 		MediaActions.update( siteId, { ID: item.ID, media_url: item.guid }, true );
-		this.setState( { currentDetail: null, editedImageItem: null, selectedItems: [] } );
+		this.props.onBack();
 	};
 
 	setDetailSelectedIndex = index => {
-		this.setState( { currentDetail: index } );
+		page( '/media/' + this.props.site.slug + '/' + this.getSelectedMedia( index ).ID );
 	};
 
 	/**
@@ -220,8 +191,11 @@ class MediaDetails extends Component {
 		MediaActions.delete( site.ID, selected );
 	};
 
-	getSelectedMedia = () => {
-		return this.props.items[ this.props.selected ];
+	getSelectedMedia = ( index = null ) => {
+		if ( index === null ) {
+			return this.props.items[ this.props.selected ];
+		}
+		return this.props.items[ index ];
 	};
 
 	render() {
@@ -232,7 +206,7 @@ class MediaDetails extends Component {
 				isVisible={ true }
 				additionalClassNames="editor-media-modal media__item-dialog"
 				buttons={ this.getModalButtons() }
-				onClose={ this.onBack }
+				onClose={ this.props.onBack }
 			>
 				{ view === 'single' && (
 					<EditorMediaModalDetail
@@ -240,7 +214,7 @@ class MediaDetails extends Component {
 						backText="Back"
 						items={ items }
 						selectedIndex={ selected }
-						onReturnToList={ this.onBack }
+						onReturnToList={ this.props.onBack }
 						onEditImageItem={ this.enableEditMode }
 						onEditVideoItem={ this.enableEditMode }
 						onRestoreItem={ this.restoreOriginalMedia }

--- a/client/my-sites/media/index.js
+++ b/client/my-sites/media/index.js
@@ -28,6 +28,15 @@ export default function() {
 			clientRender
 		);
 
+		page(
+			'/media/:domain/:attachment',
+			siteSelection,
+			navigation,
+			mediaController.singleMedia,
+			makeLayout,
+			clientRender
+		);
+
 		page( '/media/*', ( { path } ) => {
 			const siteFragment = getSiteFragment( path );
 

--- a/client/my-sites/media/index.js
+++ b/client/my-sites/media/index.js
@@ -29,10 +29,19 @@ export default function() {
 		);
 
 		page(
-			'/media/:domain/:attachment',
+			'/media/:domain/:mediaId/',
 			siteSelection,
 			navigation,
 			mediaController.singleMedia,
+			makeLayout,
+			clientRender
+		);
+
+		page(
+			'/media/edit/:domain/:mediaId/',
+			siteSelection,
+			navigation,
+			mediaController.editSingleMedia,
 			makeLayout,
 			clientRender
 		);

--- a/client/my-sites/media/single.jsx
+++ b/client/my-sites/media/single.jsx
@@ -1,0 +1,119 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import { getSelectedSite } from 'state/ui/selectors';
+import DocumentHead from 'components/data/document-head';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { EditorMediaModalDetail } from 'post-editor/media-modal/detail';
+
+class SingleMediaComponent extends Component {
+	static propTypes = {
+		selectedSite: PropTypes.object,
+	};
+
+	state = {
+		currentDetail: null,
+		editedImageItem: null,
+		editedVideoItem: null,
+		selectedItems: [],
+		source: '',
+	};
+
+	// componentDidMount() {
+	// }
+	//
+	// componentDidUpdate( prevProps ) {
+	// }
+
+	render() {
+		const selectedItems = [
+			{
+				ID: 78,
+				URL: 'https://enejtest.files.wordpress.com/2014/10/tumblr_m3pm45zc4v1qjahcpo1_500.jpg',
+				guid: 'http://enejtest.files.wordpress.com/2014/10/tumblr_m3pm45zc4v1qjahcpo1_500.jpg',
+				date: '2014-10-08T22:24:21+00:00',
+				post_ID: 63,
+				author_ID: 743971,
+				file: 'tumblr_m3pm45zc4v1qjahcpo1_500.jpg',
+				mime_type: 'image/jpeg',
+				extension: 'jpg',
+				title: 'tumblr_m3pm45zC4v1qjahcpo1_500',
+				caption: '',
+				description: '',
+				alt: '',
+				icon: 'https://s1.wp.com/wp-includes/images/media/default.png',
+				thumbnails: {
+					thumbnail:
+						'https://enejtest.files.wordpress.com/2014/10/tumblr_m3pm45zc4v1qjahcpo1_500.jpg?w=107',
+					medium:
+						'https://enejtest.files.wordpress.com/2014/10/tumblr_m3pm45zc4v1qjahcpo1_500.jpg?w=215',
+					large:
+						'https://enejtest.files.wordpress.com/2014/10/tumblr_m3pm45zc4v1qjahcpo1_500.jpg?w=450',
+					'small-business-single-image':
+						'https://enejtest.files.wordpress.com/2014/10/tumblr_m3pm45zc4v1qjahcpo1_500.jpg?w=450',
+					'jetpack-portfolio-admin-thumb':
+						'https://enejtest.files.wordpress.com/2014/10/tumblr_m3pm45zc4v1qjahcpo1_500.jpg?w=50&h=50&crop=1',
+				},
+				height: 629,
+				width: 450,
+				exif: {
+					aperture: 0,
+					credit: '',
+					camera: '',
+					caption: '',
+					created_timestamp: 0,
+					copyright: '',
+					focal_length: 0,
+					iso: 0,
+					shutter_speed: 0,
+					title: '',
+					orientation: 0,
+				},
+				meta: {
+					links: {
+						self: 'https://public-api.wordpress.com/rest/v1.1/sites/68682177/media/78',
+						help: 'https://public-api.wordpress.com/rest/v1.1/sites/68682177/media/78/help',
+						site: 'https://public-api.wordpress.com/rest/v1.1/sites/68682177',
+						parent: 'https://public-api.wordpress.com/rest/v1.1/sites/68682177/posts/63',
+					},
+				},
+			},
+		];
+		return (
+			<Main wideLayout>
+				<PageViewTracker path="/media/:site/:attachment" title="Media > Attachment" />
+				<DocumentHead title="HOWDY" />
+				<div className="media__wrapper">
+					<EditorMediaModalDetail
+						site={ this.props.selectedSite }
+						items={ selectedItems }
+						selectedIndex={ 0 }
+						onReturnToList={ this.closeDetailsModal }
+						onEditImageItem={ this.editImage }
+						onEditVideoItem={ this.editVideo }
+						onRestoreItem={ this.restoreOriginalMedia }
+						onSelectedIndexChange={ this.setDetailSelectedIndex }
+					/>
+				</div>
+			</Main>
+		);
+	}
+}
+
+const mapStateToProps = state => ( {
+	selectedSite: getSelectedSite( state ),
+} );
+
+export default connect( mapStateToProps )( localize( SingleMediaComponent ) );

--- a/client/my-sites/media/single.jsx
+++ b/client/my-sites/media/single.jsx
@@ -18,9 +18,10 @@ import DocumentHead from 'components/data/document-head';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { EditorMediaModalDetail } from 'post-editor/media-modal/detail';
 
-class SingleMediaComponent extends Component {
+class SingleMedia extends Component {
 	static propTypes = {
 		selectedSite: PropTypes.object,
+		attachment: PropTypes.number,
 	};
 
 	state = {
@@ -116,4 +117,4 @@ const mapStateToProps = state => ( {
 	selectedSite: getSelectedSite( state ),
 } );
 
-export default connect( mapStateToProps )( localize( SingleMediaComponent ) );
+export default connect( mapStateToProps )( localize( SingleMedia ) );

--- a/client/my-sites/media/single.jsx
+++ b/client/my-sites/media/single.jsx
@@ -7,114 +7,50 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import Main from 'components/main';
-import { getSelectedSite } from 'state/ui/selectors';
 import DocumentHead from 'components/data/document-head';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { EditorMediaModalDetail } from 'post-editor/media-modal/detail';
+import QueryMedia from 'components/data/query-media';
+import getMediaItem from 'state/selectors/get-media-item';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+
+import { getSelectedSite } from 'state/ui/selectors';
+import MediaDetails from 'my-sites/media/details';
 
 class SingleMedia extends Component {
 	static propTypes = {
 		selectedSite: PropTypes.object,
-		attachment: PropTypes.number,
+		mediaId: PropTypes.number,
+		media: PropTypes.object,
+		view: PropTypes.string,
 	};
 
-	state = {
-		currentDetail: null,
-		editedImageItem: null,
-		editedVideoItem: null,
-		selectedItems: [],
-		source: '',
-	};
+	onBack = () => {
 
-	// componentDidMount() {
-	// }
-	//
-	// componentDidUpdate( prevProps ) {
-	// }
+	}
 
 	render() {
-		const selectedItems = [
-			{
-				ID: 78,
-				URL: 'https://enejtest.files.wordpress.com/2014/10/tumblr_m3pm45zc4v1qjahcpo1_500.jpg',
-				guid: 'http://enejtest.files.wordpress.com/2014/10/tumblr_m3pm45zc4v1qjahcpo1_500.jpg',
-				date: '2014-10-08T22:24:21+00:00',
-				post_ID: 63,
-				author_ID: 743971,
-				file: 'tumblr_m3pm45zc4v1qjahcpo1_500.jpg',
-				mime_type: 'image/jpeg',
-				extension: 'jpg',
-				title: 'tumblr_m3pm45zC4v1qjahcpo1_500',
-				caption: '',
-				description: '',
-				alt: '',
-				icon: 'https://s1.wp.com/wp-includes/images/media/default.png',
-				thumbnails: {
-					thumbnail:
-						'https://enejtest.files.wordpress.com/2014/10/tumblr_m3pm45zc4v1qjahcpo1_500.jpg?w=107',
-					medium:
-						'https://enejtest.files.wordpress.com/2014/10/tumblr_m3pm45zc4v1qjahcpo1_500.jpg?w=215',
-					large:
-						'https://enejtest.files.wordpress.com/2014/10/tumblr_m3pm45zc4v1qjahcpo1_500.jpg?w=450',
-					'small-business-single-image':
-						'https://enejtest.files.wordpress.com/2014/10/tumblr_m3pm45zc4v1qjahcpo1_500.jpg?w=450',
-					'jetpack-portfolio-admin-thumb':
-						'https://enejtest.files.wordpress.com/2014/10/tumblr_m3pm45zc4v1qjahcpo1_500.jpg?w=50&h=50&crop=1',
-				},
-				height: 629,
-				width: 450,
-				exif: {
-					aperture: 0,
-					credit: '',
-					camera: '',
-					caption: '',
-					created_timestamp: 0,
-					copyright: '',
-					focal_length: 0,
-					iso: 0,
-					shutter_speed: 0,
-					title: '',
-					orientation: 0,
-				},
-				meta: {
-					links: {
-						self: 'https://public-api.wordpress.com/rest/v1.1/sites/68682177/media/78',
-						help: 'https://public-api.wordpress.com/rest/v1.1/sites/68682177/media/78/help',
-						site: 'https://public-api.wordpress.com/rest/v1.1/sites/68682177',
-						parent: 'https://public-api.wordpress.com/rest/v1.1/sites/68682177/posts/63',
-					},
-				},
-			},
-		];
 		return (
-			<Main wideLayout>
+			<div className="main main-column media" role="main">
+				<SidebarNavigation />
+				{ this.props.selectedSite && this.props.selectedSite.ID && <QueryMedia siteId={ this.props.selectedSite.ID } mediaId={ this.props.attachmentID } /> }
 				<PageViewTracker path="/media/:site/:attachment" title="Media > Attachment" />
 				<DocumentHead title="HOWDY" />
-				<div className="media__wrapper">
-					<EditorMediaModalDetail
-						site={ this.props.selectedSite }
-						items={ selectedItems }
-						selectedIndex={ 0 }
-						onReturnToList={ this.closeDetailsModal }
-						onEditImageItem={ this.editImage }
-						onEditVideoItem={ this.editVideo }
-						onRestoreItem={ this.restoreOriginalMedia }
-						onSelectedIndexChange={ this.setDetailSelectedIndex }
-					/>
-				</div>
-			</Main>
+				<MediaDetails site={ this.props.selectedSite } items={ [ this.props.media ] } selected={ 0 } view={ this.props.view } onBack={ this.onBack } />
+			</div>
 		);
 	}
 }
 
-const mapStateToProps = state => ( {
-	selectedSite: getSelectedSite( state ),
-} );
+const mapStateToProps = ( state, { mediaId } ) => {
+	const selectedSite = getSelectedSite( state );
+	return {
+			selectedSite,
+			media: mediaId && selectedSite && selectedSite.ID ? getMediaItem( state, selectedSite.ID, mediaId ) : null,
+		}
+};
 
-export default connect( mapStateToProps )( localize( SingleMedia ) );
+export default connect( mapStateToProps )( SingleMedia );

--- a/client/my-sites/media/single.jsx
+++ b/client/my-sites/media/single.jsx
@@ -6,6 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import page from 'page';
 import { connect } from 'react-redux';
 
 /**
@@ -29,17 +30,27 @@ class SingleMedia extends Component {
 	};
 
 	onBack = () => {
-
-	}
+		page( '/media/' + this.props.selectedSite.slug );
+		return;
+	};
 
 	render() {
 		return (
 			<div className="main main-column media" role="main">
 				<SidebarNavigation />
-				{ this.props.selectedSite && this.props.selectedSite.ID && <QueryMedia siteId={ this.props.selectedSite.ID } mediaId={ this.props.attachmentID } /> }
+				{ this.props.selectedSite &&
+					this.props.selectedSite.ID && (
+						<QueryMedia siteId={ this.props.selectedSite.ID } mediaId={ this.props.attachmentID } />
+					) }
 				<PageViewTracker path="/media/:site/:attachment" title="Media > Attachment" />
 				<DocumentHead title="HOWDY" />
-				<MediaDetails site={ this.props.selectedSite } items={ [ this.props.media ] } selected={ 0 } view={ this.props.view } onBack={ this.onBack } />
+				<MediaDetails
+					site={ this.props.selectedSite }
+					items={ [ this.props.media ] }
+					selected={ 0 }
+					view={ this.props.view }
+					onBack={ this.onBack }
+				/>
 			</div>
 		);
 	}
@@ -48,9 +59,12 @@ class SingleMedia extends Component {
 const mapStateToProps = ( state, { mediaId } ) => {
 	const selectedSite = getSelectedSite( state );
 	return {
-			selectedSite,
-			media: mediaId && selectedSite && selectedSite.ID ? getMediaItem( state, selectedSite.ID, mediaId ) : null,
-		}
+		selectedSite,
+		media:
+			mediaId && selectedSite && selectedSite.ID
+				? getMediaItem( state, selectedSite.ID, mediaId )
+				: null,
+	};
 };
 
 export default connect( mapStateToProps )( SingleMedia );

--- a/client/my-sites/media/style.scss
+++ b/client/my-sites/media/style.scss
@@ -39,7 +39,7 @@
 		0 1px 2px $gray-lighten-30;
 }
 
-.single-media__item {
+.media__wrapper {
 	min-height: 700px;
 	position: relative;
 	background: $white;

--- a/client/my-sites/media/style.scss
+++ b/client/my-sites/media/style.scss
@@ -38,3 +38,9 @@
 	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
 		0 1px 2px $gray-lighten-30;
 }
+
+.single-media__item {
+	min-height: 700px;
+	position: relative;
+	background: $white;
+}

--- a/client/my-sites/media/style.scss
+++ b/client/my-sites/media/style.scss
@@ -38,9 +38,3 @@
 	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
 		0 1px 2px $gray-lighten-30;
 }
-
-.media__wrapper {
-	min-height: 700px;
-	position: relative;
-	background: $white;
-}

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -218,7 +218,7 @@ export class EditorMediaModalDetailItem extends Component {
 			return null;
 		}
 
-		return <EditorMediaModalDetailFields site={ site } item={ item } />;
+		return item && <EditorMediaModalDetailFields site={ site } item={ item } />;
 	}
 
 	renderPreviousItemButton() {

--- a/client/post-editor/media-modal/detail/index.jsx
+++ b/client/post-editor/media-modal/detail/index.jsx
@@ -29,6 +29,7 @@ class EditorMediaModalDetailBase extends React.Component {
 		onReturnToList: PropTypes.func,
 		onEdit: PropTypes.func,
 		onRestore: PropTypes.func,
+		backText: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -71,13 +72,13 @@ class EditorMediaModalDetailBase extends React.Component {
 
 		const item = items[ selectedIndex ];
 		const mimePrefix = getMimePrefix( item );
+		const backText = this.props.backText
+			? this.props.backText
+			: this.props.translate( 'Media Library' );
 
 		return (
 			<div className="editor-media-modal-detail">
-				<HeaderCake
-					onClick={ onReturnToList }
-					backText={ this.props.translate( 'Media Library' ) }
-				/>
+				<HeaderCake onClick={ onReturnToList } backText={ backText } />
 				<DetailItem
 					site={ site }
 					item={ item }


### PR DESCRIPTION
I am trying to create a single page that we can point a user to when they want to just see 1 attachment. This would solve the issue we have now in the activity log where we send the user just to the file directly. 

Currently it looks like this.
<img width="1293" alt="screen_shot_2018-08-22_at_9_45_29_am" src="https://user-images.githubusercontent.com/115071/44477693-37b2d100-a5f0-11e8-90bb-40c7cc49b0aa.png">
<img width="1284" alt="screen_shot_2018-08-22_at_9_45_23_am" src="https://user-images.githubusercontent.com/115071/44477719-49947400-a5f0-11e8-863d-e9ba242e12a0.png">

To test:
Visit the url 
http://calypso.localhost:3000/media/enejtest.wordpress.com/1232

We are not doing any fetching of the data yet. 

