### PR TITLE
Activity Log: fix alignement issue in the update links

### DIFF
--- a/client/my-sites/stats/activity-log-tasklist/update.jsx
+++ b/client/my-sites/stats/activity-log-tasklist/update.jsx
@@ -66,7 +66,7 @@ class ActivityLogTaskUpdate extends Component {
 							</a>
 						) : (
 							// Add button classes so unlinked names look the same.
-							<span className="activity-log-tasklist__unlinked button is-borderless">{ name }</span>
+							<span className="activity-log-tasklist__unlinked">{ name }</span>
 						) }
 						<span className="activity-log-tasklist__update-bullet">&bull;</span>
 						<span className="activity-log-tasklist__update-version">{ version }</span>


### PR DESCRIPTION
In #26717 we updated the style to have a bit more space and introduced a regression.

This PR fixes this.

Before:
![screen shot 2018-08-17 at 2 03 28 pm](https://user-images.githubusercontent.com/115071/44288795-64e53500-a226-11e8-9aee-6e29f21fc0e9.png)

After:
![screen shot 2018-08-17 at 2 03 52 pm](https://user-images.githubusercontent.com/115071/44288799-67478f00-a226-11e8-951f-d2de89ce18b8.png)

To test:
Set your Jetpack site to need a core update. 
Notice that the styling looks as expected. 