### PR TITLE
Jetpack: add locale to jetpack connect store route

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -5,7 +5,7 @@
 import React from 'react';
 import Debug from 'debug';
 import page from 'page';
-import { get, isEmpty, some } from 'lodash';
+import { get, isEmpty, some, dropRight } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -26,7 +26,7 @@ import PlansLanding from './plans-landing';
 import versionCompare from 'lib/version-compare';
 import { addQueryArgs, externalRedirect, sectionify } from 'lib/route';
 import { getCurrentUserId } from 'state/current-user/selectors';
-import { getLocaleFromPath, removeLocaleFromPath } from 'lib/i18n-utils';
+import { getLocaleFromPath, removeLocaleFromPath, getPathParts } from 'lib/i18n-utils';
 import switchLocale from 'lib/i18n-utils/switch-locale';
 import { hideMasterbar, setSection, showMasterbar } from 'state/ui/actions';
 import { JPC_PATH_PLANS, MOBILE_APP_REDIRECT_URL_WHITELIST } from './constants';
@@ -298,15 +298,25 @@ export function plansSelection( context, next ) {
 /**
  * Checks for a locale fragment at the end of context.path
  * and switches to that locale if the user is logged out.
+ * If the user is logged in we remove the fragment and defer to the user's settings.
  *
  * @param {Object} context -- Middleware context
  * @param {Function} next -- Call next middleware in chain
+ * @returns {Undefined} next()
  */
 export function setLoggedOutLocale( context, next ) {
 	const isLoggedIn = !! getCurrentUserId( context.store.getState() );
-	if ( ! isLoggedIn ) {
-		const locale = getLocaleFromPath( context.path );
+	const locale = getLocaleFromPath( context.path );
+
+	if ( ! locale ) {
+		return next();
+	}
+
+	if ( isLoggedIn ) {
+		page.redirect( dropRight( getPathParts( context.path ) ).join( '/' ) );
+	} else {
 		switchLocale( locale );
 	}
+
 	next();
 }

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -27,6 +27,7 @@ import versionCompare from 'lib/version-compare';
 import { addQueryArgs, externalRedirect, sectionify } from 'lib/route';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getLocaleFromPath, removeLocaleFromPath } from 'lib/i18n-utils';
+import switchLocale from 'lib/i18n-utils/switch-locale';
 import { hideMasterbar, setSection, showMasterbar } from 'state/ui/actions';
 import { JPC_PATH_PLANS, MOBILE_APP_REDIRECT_URL_WHITELIST } from './constants';
 import { login } from 'lib/paths';
@@ -291,5 +292,21 @@ export function plansSelection( context, next ) {
 			/>
 		</CheckoutData>
 	);
+	next();
+}
+
+/**
+ * Checks for a locale fragment at the end of context.path
+ * and switches to that locale if the user is logged out.
+ *
+ * @param {Object} context -- Middleware context
+ * @param {Function} next -- Call next middleware in chain
+ */
+export function setLoggedOutLocale( context, next ) {
+	const isLoggedIn = !! getCurrentUserId( context.store.getState() );
+	if ( ! isLoggedIn ) {
+		const locale = getLocaleFromPath( context.path );
+		switchLocale( locale );
+	}
 	next();
 }

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -86,7 +86,8 @@ export default function() {
 	);
 
 	page(
-		'/jetpack/connect/store/:interval(yearly|monthly)?',
+		'/jetpack/connect/store/:interval(yearly|monthly)?/:locale?',
+		controller.setLoggedOutLocale,
 		controller.plansLanding,
 		makeLayout,
 		clientRender

--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -16,6 +16,7 @@ export {
 	isLocaleVariant,
 	canBeTranslated,
 	removeLocaleFromPath,
+	getPathParts,
 } from './utils';
 
 export const getLocaleSlug = () => i18n.getLocaleSlug();

--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -22,6 +22,7 @@ export {
 	isLocaleVariant,
 	canBeTranslated,
 	removeLocaleFromPath,
+	getPathParts,
 } from './utils';
 
 export const getLocaleSlug = () => config( 'i18n_default_locale_slug' );

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -17,6 +17,7 @@ import {
 	canBeTranslated,
 	getSupportSiteLocale,
 	getForumUrl,
+	getPathParts,
 } from 'lib/i18n-utils';
 
 jest.mock( 'config', () => key => {
@@ -300,6 +301,27 @@ describe( 'utils', () => {
 		test( 'should return `en` for if neither current i18n locale slug nor passed argument is available in config', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'bonnie' );
 			expect( getForumUrl( 'clyde' ) ).toEqual( '//en.forums.wordpress.com' );
+		} );
+	} );
+
+	describe( '#getPathParts', () => {
+		test( 'should split path', () => {
+			expect( getPathParts( '/show/me/the/money' ) ).toEqual( [
+				'',
+				'show',
+				'me',
+				'the',
+				'money',
+			] );
+		} );
+		test( 'should split path and remove trailing slash', () => {
+			expect( getPathParts( '/show/me/the/money/' ) ).toEqual( [
+				'',
+				'show',
+				'me',
+				'the',
+				'money',
+			] );
 		} );
 	} );
 } );

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -20,7 +20,7 @@ import config from 'config';
  */
 const localeRegex = /^[A-Z]{2,3}(-[A-Z]{2,3})?(_[A-Z]{2,6})?$/i;
 
-function getPathParts( path ) {
+export function getPathParts( path ) {
 	// Remove trailing slash then split. If there is a trailing slash,
 	// then the end of the array could contain an empty string.
 	return path.replace( /\/$/, '' ).split( '/' );


### PR DESCRIPTION
## Background
From Jetpack.com, https://jetpack.com/install/ redirects to https://wordpress.com/jetpack/connect/store, which is in English.

This is also the case for locale subdomains such as `fr.jetpack.com/install`
![aug-20-2018 12-59-13](https://user-images.githubusercontent.com/6458278/44318480-8853ee00-a479-11e8-95fb-8da44270c78f.gif)

This PR updates the `/jetpack/connect/store` route to accept a `locale` fragment. If the user is logged out, we use this fragment to switch locales. If the user is logged in, we remove the fragment and defer to the user's preferences.

See related revision: `code-D17368`

## Testing
1. When logged out, open http://calypso.localhost:3000/jetpack/connect/store/fr 
2. Open http://calypso.localhost:3000/jetpack/connect/store/yearly/de
3. Open http://calypso.localhost:3000/jetpack/connect/store/monthly/it
4. When logged in, open the links in 1, 2 and 3

### Expectations
**At 1**: the page should switch to French
**At 2**: the page should switch to German
**At 3**: the page should switch to Italian
**At 4**: the locale route fragment should be gone and the page should remain in your chosen language