### PR TITLE
 Importers: Avoid passing unrecognised props to mapping-description

### DIFF
--- a/client/components/site-users-fetcher/index.jsx
+++ b/client/components/site-users-fetcher/index.jsx
@@ -63,8 +63,10 @@ export default class extends React.Component {
 
 	render() {
 		const childrenProps = Object.assign( omit( this.props, 'children' ), this.state );
-		// Clone the child element along and pass along state (containing data from the store)
-		return React.cloneElement( this.props.children, childrenProps );
+
+		// If child elements are passed, clone them and
+		// pass along state (containing data from the store)
+		return this.props.children ? React.cloneElement( this.props.children, childrenProps ) : null;
 	}
 
 	_updateSiteUsers = fetchOptions => {

--- a/client/my-sites/importer/author-mapping-pane.jsx
+++ b/client/my-sites/importer/author-mapping-pane.jsx
@@ -16,8 +16,8 @@ import AuthorMapping from './author-mapping-item';
 import SiteUsersFetcher from 'components/site-users-fetcher';
 import UsersStore from 'lib/users/store';
 
-class ImporterMappingPane extends React.PureComponent {
-	static displayName = 'ImporterMappingPane';
+class AuthorMappingPane extends React.PureComponent {
+	static displayName = 'AuthorMappingPane';
 
 	static propTypes = {
 		hasSingleAuthor: PropTypes.bool.isRequired,
@@ -168,4 +168,4 @@ class ImporterMappingPane extends React.PureComponent {
 	}
 }
 
-export default localize( ImporterMappingPane );
+export default localize( AuthorMappingPane );

--- a/client/my-sites/importer/author-mapping-pane.jsx
+++ b/client/my-sites/importer/author-mapping-pane.jsx
@@ -142,9 +142,8 @@ class AuthorMappingPane extends React.PureComponent {
 
 		return (
 			<div className="importer__mapping-pane">
-				<SiteUsersFetcher fetchOptions={ this.getFetchOptions( { number: 50 } ) }>
-					<div className="importer__mapping-description">{ mappingDescription }</div>
-				</SiteUsersFetcher>
+				<SiteUsersFetcher fetchOptions={ this.getFetchOptions( { number: 50 } ) } />
+				<div className="importer__mapping-description">{ mappingDescription }</div>
 				<div className="importer__mapping-header">
 					<span className="importer__mapping-source-title">{ sourceTitle }</span>
 					<span className="importer__mapping-target-title">{ targetTitle }</span>

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -235,7 +235,8 @@ class ImportingPane extends React.PureComponent {
 						hasSingleAuthor={ hasSingleAuthor }
 						onMap={ mapAuthorFor( importerId ) }
 						onStartImport={ () => startImporting( this.props.importerStatus ) }
-						{ ...{ siteId, sourceType } }
+						siteId={ siteId }
+						sourceType={ sourceType }
 						sourceAuthors={ customData.sourceAuthors }
 						sourceTitle={ customData.siteTitle || translate( 'Original Site' ) }
 						targetTitle={ siteName }

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -16,7 +16,7 @@ import { mapAuthor, startImporting } from 'lib/importer/actions';
 import { appStates } from 'state/imports/constants';
 import { connectDispatcher } from './dispatcher-converter';
 import ProgressBar from 'components/progress-bar';
-import MappingPane from './author-mapping-pane';
+import AuthorMappingPane from './author-mapping-pane';
 import Spinner from 'components/spinner';
 
 const sum = ( a, b ) => a + b;
@@ -231,7 +231,7 @@ class ImportingPane extends React.PureComponent {
 			<div className="importer__importing-pane">
 				{ this.isImporting() && <p>{ this.getHeadingText() }</p> }
 				{ this.isMapping() && (
-					<MappingPane
+					<AuthorMappingPane
 						hasSingleAuthor={ hasSingleAuthor }
 						onMap={ mapAuthorFor( importerId ) }
 						onStartImport={ () => startImporting( this.props.importerStatus ) }


### PR DESCRIPTION
This PR fixes some invalid prop warnings seen during the author mapping stage of importing.
This was a symptom of wrapping a plain `div` element with `<siteUsersFetcher />`.
`siteUsersFetcher` fetches some data and passes this to it's `children` as props - those props are invalid on `div`s

### Reproduce
- Be sure to be on localhost so that you see these dev warnings
- On master, go through the process of importing content via the importer.
- Note the errors that are being shown in the console after uploading and hitting 'continue'.

### Testing
- After applying this patch, do the above but note that these errors have gone.
- You may still see an error thrown for a required prop that's missing. That's a different issue.