### PR TITLE
SDK: refactor todo-extension styles

### DIFF
--- a/client/gutenberg/extensions/todo/block.js
+++ b/client/gutenberg/extensions/todo/block.js
@@ -1,5 +1,7 @@
 /** @format */
 
+/* eslint wpcalypso/jsx-classname-namespace: 0 */
+
 /**
  * External dependencies
  */
@@ -154,9 +156,10 @@ const edit = class extends Component {
 
 	render() {
 		const { items, newItemAt } = this.state;
+		const { className } = this.props;
 		return (
-			<div className="wp-editor-a8c-todo">
-				<ul className="wp-editor-a8c-todo-list">
+			<div className={ className }>
+				<ul className={ `${ className }-list` }>
 					{ items.map( ( item, itemIndex ) => {
 						const moveUp = () => {
 							this.moveUp( itemIndex );
@@ -206,7 +209,7 @@ const edit = class extends Component {
 						);
 					} ) }
 				</ul>
-				<div class="add-new-todo-item-form">
+				<div className="add-new-todo-item-form">
 					<Button onClick={ this.addNewItem }>
 						<Dashicon icon="plus" /> Add new item
 					</Button>

--- a/client/gutenberg/extensions/todo/editor.scss
+++ b/client/gutenberg/extensions/todo/editor.scss
@@ -1,29 +1,10 @@
-// Hugo's new WordPress shades of gray
-// from http://codepen.io/hugobaeta/pen/grJjVp
-$black: #000;
-$dark-gray-900: #191e23;
-$dark-gray-800: #23282d;
-$dark-gray-700: #32373c;
-$dark-gray-600: #40464d;
-$dark-gray-500: #555d66;	// use this most of the time for dark items
-$dark-gray-400: #606a73;
-$dark-gray-300: #6c7781;
-$dark-gray-200: #7e8993;
-$dark-gray-100: #8f98a1;
-$light-gray-900: #a2aab2;
-$light-gray-800: #b5bcc2;
-$light-gray-700: #ccd0d4;
-$light-gray-600: #d7dade;
-$light-gray-500: #e2e4e7;	// good for "grayed" items and borders
-$light-gray-400: #e8eaeb;
-$light-gray-300: #edeff0;
-$light-gray-200: #f3f4f5;
-$light-gray-100: #f8f9f9;
-$white: #fff;
+// Calypso colors
+@import '../../../../assets/stylesheets/shared/_colors.scss';
 
-$color-accent-green: #31843f;
+// Gutenberg colors
+@import '../../editor/edit-post/assets/stylesheets/_colors.scss';
 
-.wp-editor-a8c-todo {
+.wp-block-a8c-todo {
 	margin-bottom: 20px;
 
 	// This would be ideal but it's being overridden.
@@ -58,10 +39,10 @@ $color-accent-green: #31843f;
 
 	// Completed checklist item.
 	.item-done {
-		color: $color-accent-green;
+		color: $green-text-min;
 
 		.item-status {
-			background: $color-accent-green;
+			background: $green-text-min;
 			border: 0;
 			position: relative;
 		}
@@ -124,19 +105,16 @@ $color-accent-green: #31843f;
 				display: inline;
 			}
 		}
-
 	}
-
-
 }
 
 // We need to be super-specific here to be sure we're overwriting the default UL styling.
-.edit-post-visual-editor .wp-editor-a8c-todo .wp-editor-a8c-todo-list {
+.edit-post-visual-editor .wp-block-a8c-todo .wp-block-a8c-todo-list {
 	list-style-type: none;
 }
 
 // Same for the "add item" input.
-.editor-block-list__block .wp-editor-a8c-todo .add-new-item {
+.editor-block-list__block .wp-block-a8c-todo .add-new-item {
 	width: 100%;
 	margin-right: 6px;
 	padding: 7.5px 8px;
@@ -144,20 +122,20 @@ $color-accent-green: #31843f;
 
 // P2-specific styling.
 body:not( .wp-admin ) .gutenberg {
-	.wp-editor-a8c-todo .todolist-item {
+	.wp-block-a8c-todo .todolist-item {
 		padding: 10px 0 4px;
 	}
 }
 
 
 // Only show the "add new" form when it's strictly needed.
-.wp-editor-a8c-todo .add-new-todo-item-form {
+.wp-block-a8c-todo .add-new-todo-item-form {
 	display: none;
 }
 
 .editor-block-list__block.is-selected,
 .editor-block-list__block.is-typing {
-	.wp-editor-a8c-todo .add-new-todo-item-form {
+	.wp-block-a8c-todo .add-new-todo-item-form {
 		display: flex;
 	}
 }


### PR DESCRIPTION
To better understand what kind of flexibility blocks might need with their CSS, I looked into todo block.

Some problems, questions and possible solutions:

### Importing two color definition files
Imports Calypso color variables for `$green-text-min` and Gutenberg color variables for the rest.

💥 It's unclear just by looking at the file where each variable came from
💥 Variable names have collisions
💡Unify into one source of truth; there should be only one colour definition file.
💡Prefix colour variables. `$calypso__white` or `$gutenberg__white`. Since the latter later on come from NPM module, suppose it's the Calypso ones that we can affect.

### Block needs CSS selectors from the editor
The block has CSS like this:
```css
.editor-block-list__block.is-selected,
.editor-block-list__block.is-typing {
	.wp-block-a8c-todo .add-new-todo-item-form {
		display: flex;
	}
}
```

💥 The block wrapper cannot always be the highest CSS selector
💥 While full Gutenberg editor might have `.editor-block-list__block.is-typing` classes, can we ensure we have these available in Calypso?
💡 Stay flexible — don't wrap/prefix everything in the build. CSS prefixing needs to be manual; possibly enforced by a linter so that it's possible to turn it off when needed.
💡 Some of these cases in this extension can probably be baked out by adding CSS resets and improving specificity of CSS selectors, but not all.

### P2 specific styling
The block has some styling that's meant only for P2s.

💥 P2 specific styling ships to all environments (wp-admin, Calypso etc)
💥 Nothing about `body:not( .wp-admin ) .gutenberg` really says it's P2 specific. That could very well be Calypso, too.
💡 Preferably get rid of any needs for environment specific styling and use themes for things that need to be themed (e.g. Jetpack branding)
💡 Conditionally include styles depending on target environment. Not ideal.
