### PR TITLE
My plan: Fix null property access error

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -51,7 +51,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 export class ProductPurchaseFeaturesList extends Component {
 	static propTypes = {
-		plan: PropTypes.oneOf( Object.keys( PLANS_LIST ) ).isRequired,
+		plan: PropTypes.oneOf( Object.keys( PLANS_LIST ) ),
 		isPlaceholder: PropTypes.bool,
 	};
 

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -24,7 +24,6 @@ export class CurrentPlanHeader extends Component {
 		tagLine: PropTypes.string,
 		isPlaceholder: PropTypes.bool,
 		currentPlan: PropTypes.object,
-		currentPlanSlug: PropTypes.oneOf( Object.keys( PLANS_LIST ) ),
 		isExpiring: PropTypes.bool,
 		translate: PropTypes.func,
 	};

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -24,6 +24,7 @@ export class CurrentPlanHeader extends Component {
 		tagLine: PropTypes.string,
 		isPlaceholder: PropTypes.bool,
 		currentPlan: PropTypes.object,
+		currentPlanSlug: PropTypes.oneOf( Object.keys( PLANS_LIST ) ),
 		isExpiring: PropTypes.bool,
 		translate: PropTypes.func,
 	};

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -166,6 +166,7 @@ class CurrentPlan extends Component {
 }
 
 export default connect( state => {
+	/* eslint-disable-next-line no-unused-vars */
 	const selectedSite = getSelectedSite( state );
 	const selectedSiteId = getSelectedSiteId( state );
 	const domains = getDecoratedSiteDomains( state, selectedSiteId );
@@ -174,7 +175,8 @@ export default connect( state => {
 	const isAutomatedTransfer = isSiteAutomatedTransfer( state, selectedSiteId );
 
 	return {
-		selectedSite,
+		/* @TODO clean up, this is to force error-producing conditions */
+		selectedSite: null,
 		selectedSiteId,
 		domains,
 		isAutomatedTransfer,

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -7,6 +7,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -93,9 +94,7 @@ class CurrentPlan extends Component {
 			translate,
 		} = this.props;
 
-		// I have just observed an error on this line in production:
-		// TypeError: Cannot read property 'plan' of null
-		const currentPlanSlug = selectedSite.plan.product_slug;
+		const currentPlanSlug = get( selectedSite, [ 'plan', 'product_slug' ] );
 		const isLoading = this.isLoading();
 
 		const planConstObj = getPlan( currentPlanSlug );

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -95,13 +95,13 @@ class CurrentPlan extends Component {
 
 		// I have just observed an error on this line in production:
 		// TypeError: Cannot read property 'plan' of null
-		const currentPlanSlug = selectedSite.plan.product_slug,
-			isLoading = this.isLoading();
+		const currentPlanSlug = selectedSite.plan.product_slug;
+		const isLoading = this.isLoading();
 
-		const planConstObj = getPlan( currentPlanSlug ),
-			planFeaturesHeader = translate( '%(planName)s plan features', {
-				args: { planName: planConstObj.getTitle() },
-			} );
+		const planConstObj = getPlan( currentPlanSlug );
+		const planFeaturesHeader = translate( '%(planName)s plan features', {
+			args: { planName: planConstObj.getTitle() },
+		} );
 
 		const { title, tagLine } = this.getHeaderWording( planConstObj );
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -93,6 +93,8 @@ class CurrentPlan extends Component {
 			translate,
 		} = this.props;
 
+		// I have just observed an error on this line in production:
+		// TypeError: Cannot read property 'plan' of null
 		const currentPlanSlug = selectedSite.plan.product_slug,
 			isLoading = this.isLoading();
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -58,27 +58,6 @@ class CurrentPlan extends Component {
 		return ! selectedSite || isRequestingPlans;
 	}
 
-	getHeaderWording( planConstObj ) {
-		const { translate } = this.props;
-
-		const title = translate( 'Your site is on a %(planName)s plan', {
-			args: {
-				planName: planConstObj.getTitle(),
-			},
-		} );
-
-		const tagLine = planConstObj.getTagline
-			? planConstObj.getTagline()
-			: translate(
-					'Unlock the full potential of your site with all the features included in your plan.'
-			  );
-
-		return {
-			title: title,
-			tagLine: tagLine,
-		};
-	}
-
 	render() {
 		const {
 			selectedSite,
@@ -97,13 +76,27 @@ class CurrentPlan extends Component {
 		const currentPlanSlug = get( selectedSite, [ 'plan', 'product_slug' ] );
 		const isLoading = this.isLoading();
 
-		// Now we have problems on property access on undefined…
+		// This may return `undefined`. Be careful!
 		const planConstObj = getPlan( currentPlanSlug );
-		const planFeaturesHeader = translate( '%(planName)s plan features', {
-			args: { planName: planConstObj.getTitle() },
-		} );
 
-		const { title, tagLine } = this.getHeaderWording( planConstObj );
+		let title = '';
+		let planFeaturesHeader = '';
+		if ( planConstObj && 'function' === typeof planConstObj.getTitle ) {
+			planFeaturesHeader = translate( '%(planName)s plan features', {
+				args: { planName: planConstObj.getTitle() },
+			} );
+
+			title = translate( 'Your site is on a %(planName)s plan', {
+				args: { planName: planConstObj.getTitle() },
+			} );
+		}
+
+		let tagLine = translate(
+			'Unlock the full potential of your site with all the features included in your plan.'
+		);
+		if ( planConstObj && 'function' === typeof planConstObj.getTagline ) {
+			tagLine = planConstObj.getTagline();
+		}
 
 		const shouldQuerySiteDomains = selectedSiteId && shouldShowDomainWarnings;
 		const showDomainWarnings = hasDomainsLoaded && shouldShowDomainWarnings;

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -97,6 +97,7 @@ class CurrentPlan extends Component {
 		const currentPlanSlug = get( selectedSite, [ 'plan', 'product_slug' ] );
 		const isLoading = this.isLoading();
 
+		// Now we have problems on property access on undefined…
 		const planConstObj = getPlan( currentPlanSlug );
 		const planFeaturesHeader = translate( '%(planName)s plan features', {
 			args: { planName: planConstObj.getTitle() },


### PR DESCRIPTION
An error in production has been observed due to this unguarded `selectedSite` property access:
https://github.com/Automattic/wp-calypso/blob/59a823e9da52e98f749da7eba88aae2124a73b0e/client/my-sites/plans/current-plan/index.jsx#L97

It's generally unsafe to depend on a `selectedSite` object. Make the relevant changes to prevent this error in the future.

Depends on #26780 and #26795