### PR TITLE
Fix/back button people

### DIFF
--- a/client/components/notes-formatted-block/index.jsx
+++ b/client/components/notes-formatted-block/index.jsx
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React from 'react';
+import { startsWith } from 'lodash';
 
 export const FormattedBlock = ( { content = {} } ) => {
 	const {
@@ -35,7 +36,10 @@ export const FormattedBlock = ( { content = {} } ) => {
 	switch ( type ) {
 		case 'a':
 		case 'link':
-			return <a href={ content.url }>{ descent }</a>;
+			const url = startsWith( content.url, 'https://wordpress.com/' )
+				? content.url.substr( 21 )
+				: content.url;
+			return <a href={ url }>{ descent }</a>;
 
 		case 'b':
 			return <strong>{ descent }</strong>;

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -111,7 +111,6 @@ function renderSingleTeamMember( context, next ) {
 
 	context.primary = React.createElement( EditTeamMember, {
 		userLogin: context.params.user_login,
-		prevPath: context.prevPath,
 	} );
 	next();
 }

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -27,6 +27,7 @@ import PeopleLogStore from 'lib/people/log-store';
 import { isJetpackSiteMultiSite, isJetpackSite } from 'state/sites/selectors';
 import EditUserForm from './edit-user-form';
 import { recordGoogleEvent } from 'state/analytics/actions';
+import getPreviousRoute from 'state/selectors/get-previous-route';
 
 export class EditTeamMemberForm extends Component {
 	constructor( props ) {
@@ -128,16 +129,12 @@ export class EditTeamMemberForm extends Component {
 
 	goBack = () => {
 		this.props.recordGoogleEvent( 'People', 'Clicked Back Button on User Edit' );
+		if ( this.props.previousRoute ) {
+			page.back( this.props.previousRoute );
+			return;
+		}
 		if ( this.props.siteSlug ) {
-			const teamBack = '/people/team/' + this.props.siteSlug,
-				readersBack = '/people/readers/' + this.props.siteSlug;
-			if ( this.props.prevPath === teamBack ) {
-				page.back( teamBack );
-			} else if ( this.props.prevPath === readersBack ) {
-				page.back( readersBack );
-			} else {
-				page( teamBack );
-			}
+			page( '/people/team/' + this.props.siteSlug );
 			return;
 		}
 		page( '/people/team' );
@@ -187,6 +184,7 @@ export default connect(
 			siteSlug: getSelectedSiteSlug( state ),
 			isJetpack: isJetpackSite( state, siteId ),
 			isMultisite: isJetpackSiteMultiSite( state, siteId ),
+			previousRoute: getPreviousRoute( state ),
 		};
 	},
 	{ recordGoogleEvent }

--- a/client/state/selectors/get-previous-path.js
+++ b/client/state/selectors/get-previous-path.js
@@ -1,0 +1,20 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+
+/**
+ * Gets the previous path set by a ROUTE_SET action
+ * @param {Object} state - global redux state
+ * @return {string} previous path value
+ */
+export const getPreviousPath = state => get( state, 'ui.route.path.previous', '' );
+
+export default getPreviousPath;

--- a/client/state/selectors/get-previous-query.js
+++ b/client/state/selectors/get-previous-query.js
@@ -1,0 +1,20 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+
+/**
+ * Gets the previous query set by a ROUTE_SET action
+ * @param {Object} state - global redux state
+ * @return {string} previous query value
+ */
+export const getPreviousQuery = state => get( state, 'ui.route.query.previous', '' );
+
+export default getPreviousQuery;

--- a/client/state/selectors/get-previous-route.js
+++ b/client/state/selectors/get-previous-route.js
@@ -1,0 +1,29 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { stringify } from 'qs';
+
+/**
+ * Internal dependencies
+ */
+import getPreviousPath from 'state/selectors/get-previous-path';
+import getPreviousQuery from 'state/selectors/get-previous-query';
+/**
+ * Gets the previous route set by a ROUTE_SET action
+ * @param {Object} state - global redux state
+ * @return {string} previous route value
+ */
+
+export const getPreviousRoute = state => {
+	const previousPath = getPreviousPath( state );
+	const previousQuery = getPreviousQuery( state );
+	let query = '';
+	if ( previousQuery ) {
+		query = '?' + stringify( previousQuery );
+	}
+	return previousPath + query;
+};
+
+export default getPreviousRoute;

--- a/client/state/selectors/test/get-previous-path.js
+++ b/client/state/selectors/test/get-previous-path.js
@@ -1,0 +1,33 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import getPreviousPath from 'state/selectors/get-previous-path';
+
+describe( 'getPreviousPath()', () => {
+	test( 'should return empty if the previous path is not set', () => {
+		const stateIn = {};
+		const output = getPreviousPath( stateIn );
+		expect( output ).to.eql( '' );
+	} );
+
+	test( 'should return previous path if one is found', () => {
+		const stateIn = {
+			ui: {
+				route: {
+					path: {
+						previous: '/hello',
+					},
+				},
+			},
+		};
+		const output = getPreviousPath( stateIn );
+		expect( output ).to.eql( '/hello' );
+	} );
+} );

--- a/client/state/selectors/test/get-previous-query.js
+++ b/client/state/selectors/test/get-previous-query.js
@@ -1,0 +1,33 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import getPreviousQuery from 'state/selectors/get-previous-query';
+
+describe( 'getPreviousQuery()', () => {
+	test( 'should return empty if the previous Route is not set', () => {
+		const stateIn = {};
+		const output = getPreviousQuery( stateIn );
+		expect( output ).to.eql( '' );
+	} );
+
+	test( 'should return previous query if one is found', () => {
+		const stateIn = {
+			ui: {
+				route: {
+					query: {
+						previous: { filter: 'howdy' },
+					},
+				},
+			},
+		};
+		const output = getPreviousQuery( stateIn );
+		expect( output.filter ).to.eql( 'howdy' );
+	} );
+} );

--- a/client/state/selectors/test/get-previous-route.js
+++ b/client/state/selectors/test/get-previous-route.js
@@ -1,0 +1,38 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import getPreviousRoute from 'state/selectors/get-previous-route';
+
+describe( 'getPreviousRoute()', () => {
+	test( 'should return empty if the previous Route is not set', () => {
+		const stateIn = {};
+		const output = getPreviousRoute( stateIn );
+		expect( output ).to.eql( '' );
+	} );
+
+	test( 'should return previous route if one is found', () => {
+		const stateIn = {
+			ui: {
+				route: {
+					path: {
+						previous: '/hello',
+					},
+					query: {
+						previous: {
+							filter: 'hello',
+						},
+					},
+				},
+			},
+		};
+		const output = getPreviousRoute( stateIn );
+		expect( output ).to.eql( '/hello?filter=hello' );
+	} );
+} );

--- a/client/state/ui/route/path/reducer.js
+++ b/client/state/ui/route/path/reducer.js
@@ -7,26 +7,25 @@
 /**
  * Internal dependencies
  */
-import { createReducer, combineReducers } from 'state/utils';
 import { ROUTE_SET } from 'state/action-types';
 
-const initial = createReducer(
-	'',
-	{
-		[ ROUTE_SET ]: ( state, { path } ) => ( state === '' ? path : state ),
-	},
-	{ type: 'string' }
-);
+const initialState = {
+	initial: '',
+	current: '',
+	previous: '',
+};
 
-const current = createReducer(
-	'',
-	{
-		[ ROUTE_SET ]: ( state, { path } ) => path,
-	},
-	{ type: 'string' }
-);
+export const pathReducer = ( state = initialState, action ) => {
+	const { path, type } = action;
+	switch ( type ) {
+		case ROUTE_SET:
+			return {
+				initial: state.initial === '' ? path : state.initial,
+				current: path,
+				previous: state.current === '' ? '' : state.current,
+			};
+	}
+	return state;
+};
 
-export default combineReducers( {
-	initial,
-	current,
-} );
+export default pathReducer;

--- a/client/state/ui/route/path/test/reducer.js
+++ b/client/state/ui/route/path/test/reducer.js
@@ -20,5 +20,20 @@ describe( 'reducer', () => {
 
 		expect( state.initial ).to.equal( '/themes' );
 		expect( state.current ).to.equal( '/themes' );
+		expect( state.previous ).to.equal( '' );
+	} );
+
+	it( 'should set the previous and the current route to the value of the path attribute of the previous ROUTE_SET action', () => {
+		const state = path( undefined, {
+			type: ROUTE_SET,
+			path: '/themes',
+		} );
+
+		const nextState = path( state, {
+			type: ROUTE_SET,
+			path: '/plugins',
+		} );
+		expect( nextState.previous ).to.equal( '/themes' );
+		expect( nextState.current ).to.equal( '/plugins' );
 	} );
 } );

--- a/client/state/ui/route/query/reducer.js
+++ b/client/state/ui/route/query/reducer.js
@@ -9,7 +9,6 @@ import { isEqual, omit } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
 import { ROUTE_SET } from 'state/action-types';
 
 const timestamped = query => ( {
@@ -19,24 +18,27 @@ const timestamped = query => ( {
 
 const isEqualQuery = ( a, b ) => isEqual( omit( a, '_timestamp' ), omit( b, '_timestamp' ) );
 
-const initial = createReducer(
-	false,
-	{
-		[ ROUTE_SET ]: ( state, { query } ) => ( state === false ? timestamped( query ) : state ),
-	},
-	{ type: [ 'boolean', 'object' ] }
-);
+const initialReducer = ( state, query ) => ( state === false ? timestamped( query ) : state );
+const currentReducer = ( state, query ) =>
+	! isEqualQuery( state, query ) ? timestamped( query ) : state;
 
-const current = createReducer(
-	{},
-	{
-		[ ROUTE_SET ]: ( state, { query } ) =>
-			! isEqualQuery( state, query ) ? timestamped( query ) : state,
-	},
-	{ type: 'object' }
-);
+const initialState = {
+	initial: false,
+	current: false,
+	previous: false,
+};
 
-export default combineReducers( {
-	initial,
-	current,
-} );
+export const queryReducer = ( state = initialState, action ) => {
+	const { query, type } = action;
+	switch ( type ) {
+		case ROUTE_SET:
+			return {
+				initial: initialReducer( state.initial, query ),
+				current: currentReducer( state.current, query ),
+				previous: state.current === false ? false : state.current,
+			};
+	}
+	return state;
+};
+
+export default queryReducer;

--- a/client/state/ui/route/query/test/reducer.js
+++ b/client/state/ui/route/query/test/reducer.js
@@ -22,6 +22,7 @@ describe( 'reducer', () => {
 		expect( state.initial.lang ).to.equal( 'fr' );
 		expect( state.current.retry ).to.equal( 1 );
 		expect( state.current.lang ).to.equal( 'fr' );
+		expect( state.previous ).to.equal( false );
 	} );
 
 	it( 'should only update current query the second time a ROUTE_SET action is triggered', () => {
@@ -39,5 +40,7 @@ describe( 'reducer', () => {
 		expect( state.initial.lang ).to.equal( 'fr' );
 		expect( state.current.retry ).to.equal( 2 );
 		expect( state.current.lang ).to.equal( undefined );
+		expect( state.previous.retry ).to.equal( 1 );
+		expect( state.previous.lang ).to.equal( 'fr' );
 	} );
 } );


### PR DESCRIPTION
Since we already have a currently track the initial path and query as well as the current path and query. I though it would be a good idea to also track the previous path and query. 

This is done by extending the current `ui.route` reducers to also keep track of the previous state. 
This way we are able to construct the previous route. ( path + query )

This helps us reduce the logic the that we need to figure out what the back button should link to. 

This PR only updates the login of the /people/ section but the idea is that we would be able to use the new getPreviousRoute selector to update the other sections as well. 


### To test:
Visit the activity log? 
When you click on user of the login activity does the back button take you to the activity section. 

Are you able to break the current back button some other way? 
Check for regressions.

