### PR TITLE
Gutenberg: fix styling issues

### DIFF
--- a/assets/stylesheets/sections/gutenberg-editor.scss
+++ b/assets/stylesheets/sections/gutenberg-editor.scss
@@ -7,6 +7,20 @@
 @import '../shared/mixins/placeholder';
 @import '../shared/typography';
 
+// Editor package styles
+@import '../../../node_modules/@wordpress/editor/build-style/style';
+
+// Block library
+@import '../../../node_modules/@wordpress/block-library/build-style/style';
+@import '../../../node_modules/@wordpress/block-library/build-style/editor';
+@import '../../../node_modules/@wordpress/block-library/build-style/theme';
+
+// Components
+@import '../../../node_modules/@wordpress/components/build-style/style';
+
+// NUX
+@import '../../../node_modules/@wordpress/nux/build-style/style';
+
 // Calypso specific Gutenberg editor styles
 @import 'gutenberg/editor/style';
 

--- a/assets/stylesheets/sections/gutenberg-editor.scss
+++ b/assets/stylesheets/sections/gutenberg-editor.scss
@@ -7,14 +7,6 @@
 @import '../shared/mixins/placeholder';
 @import '../shared/typography';
 
-// Editor package styles
-@import '../../../node_modules/@wordpress/editor/build-style/style';
-
-// Block library
-@import '../../../node_modules/@wordpress/block-library/build-style/style';
-@import '../../../node_modules/@wordpress/block-library/build-style/editor';
-@import '../../../node_modules/@wordpress/block-library/build-style/theme';
-
 // Calypso specific Gutenberg editor styles
 @import 'gutenberg/editor/style';
 

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -16,6 +16,14 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { overrideAPIPaths } from './utils';
 
+// Gutenberg package styles
+import '@wordpress/editor/build-style/style.css';
+import '@wordpress/components/build-style/style.css';
+import '@wordpress/nux/build-style/style.css';
+import '@wordpress/block-library/build-style/style.css';
+import '@wordpress/block-library/build-style/editor.css';
+import '@wordpress/block-library/build-style/theme.css';
+
 const editorSettings = {};
 
 const post = {

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -16,14 +16,6 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { overrideAPIPaths } from './utils';
 
-// Gutenberg package styles
-import '@wordpress/editor/build-style/style.css';
-import '@wordpress/components/build-style/style.css';
-import '@wordpress/nux/build-style/style.css';
-import '@wordpress/block-library/build-style/style.css';
-import '@wordpress/block-library/build-style/editor.css';
-import '@wordpress/block-library/build-style/theme.css';
-
 const editorSettings = {};
 
 const post = {


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/26641

The aim of this PR is to match the styling of the editor shell in Calypso with current core Gutenberg layout and look.

### Visual changes

| Before | After |
| - | - |
|![screenshot from 2018-08-21 14-17-20](https://user-images.githubusercontent.com/1182160/44400881-21076e00-a54d-11e8-8124-01b10e8bf6c6.png)|![screenshot from 2018-08-21 14-02-29](https://user-images.githubusercontent.com/1182160/44400342-14821600-a54b-11e8-9179-314830fd1a82.png)|

### Testing instructions

1. Navigate to `/gutenberg/post/{siteSlug}/`
2. Calypso smoke test.
