### PR TITLE
Plans: Make CurrentPlanHeader safer

### DIFF
--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -14,8 +14,7 @@ import { invoke } from 'lodash';
 import Button from 'components/button';
 import Card from 'components/card';
 import PlanIcon from 'components/plans/plan-icon';
-import { TYPE_FREE, GROUP_JETPACK } from 'lib/plans/constants';
-import { planMatches } from 'lib/plans';
+import { isFreeJetpackPlan } from 'lib/products-values';
 import { managePurchase } from 'me/purchases/paths';
 
 export class CurrentPlanHeader extends Component {
@@ -32,7 +31,7 @@ export class CurrentPlanHeader extends Component {
 	renderPurchaseInfo() {
 		const { currentPlan, selectedSite, isExpiring, translate } = this.props;
 
-		if ( ! currentPlan || this.isJetpackFreePlan() ) {
+		if ( ! currentPlan || isFreeJetpackPlan( currentPlan ) ) {
 			return null;
 		}
 
@@ -67,15 +66,7 @@ export class CurrentPlanHeader extends Component {
 	}
 
 	render() {
-		const {
-			currentPlan,
-			includePlansLink,
-			isPlaceholder,
-			title,
-			tagLine,
-			translate,
-			selectedSite,
-		} = this.props;
+		const { currentPlan, isPlaceholder, selectedSite, tagLine, title, translate } = this.props;
 
 		const currentPlanSlug = currentPlan && currentPlan.productSlug;
 
@@ -105,20 +96,19 @@ export class CurrentPlanHeader extends Component {
 						</div>
 					</div>
 					{ this.renderPurchaseInfo() }
-					{ includePlansLink && (
-						<div className="current-plan__compare-plans">
-							<Button href={ '/plans/' + selectedSite.slug }>
-								{ translate( 'Compare Plans' ) }
-							</Button>
-						</div>
-					) }
+					{ currentPlan &&
+						isFreeJetpackPlan( currentPlan ) &&
+						selectedSite &&
+						selectedSite.slug && (
+							<div className="current-plan__compare-plans">
+								<Button href={ '/plans/' + selectedSite.slug }>
+									{ translate( 'Compare Plans' ) }
+								</Button>
+							</div>
+						) }
 				</div>
 			</div>
 		);
-	}
-
-	isJetpackFreePlan() {
-		return planMatches( this.props.currentPlanSlug, { type: TYPE_FREE, group: GROUP_JETPACK } );
 	}
 }
 

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -36,7 +36,7 @@ export class CurrentPlanHeader extends Component {
 			return null;
 		}
 
-		const hasAutoRenew = currentPlan.autoRenew;
+		const hasAutoRenew = !! currentPlan.autoRenew;
 		const classes = classNames( 'current-plan__header-purchase-info', {
 			'is-expiring': isExpiring,
 		} );
@@ -53,11 +53,14 @@ export class CurrentPlanHeader extends Component {
 									args: invoke( currentPlan, 'userFacingExpiryMoment.format', 'LL' ),
 							  } ) }
 					</span>
-					{ currentPlan.userIsOwner && (
-						<Button compact href={ managePurchase( selectedSite.slug, currentPlan.id ) }>
-							{ hasAutoRenew ? translate( 'Manage Payment' ) : translate( 'Renew Now' ) }
-						</Button>
-					) }
+					{ currentPlan.userIsOwner &&
+						currentPlan.id &&
+						selectedSite &&
+						selectedSite.slug && (
+							<Button compact href={ managePurchase( selectedSite.slug, currentPlan.id ) }>
+								{ hasAutoRenew ? translate( 'Manage Payment' ) : translate( 'Renew Now' ) }
+							</Button>
+						) }
 				</div>
 			</Card>
 		);

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -14,7 +14,7 @@ import { invoke } from 'lodash';
 import Button from 'components/button';
 import Card from 'components/card';
 import PlanIcon from 'components/plans/plan-icon';
-import { PLANS_LIST, TYPE_FREE, GROUP_JETPACK } from 'lib/plans/constants';
+import { TYPE_FREE, GROUP_JETPACK } from 'lib/plans/constants';
 import { planMatches } from 'lib/plans';
 import { managePurchase } from 'me/purchases/paths';
 
@@ -24,7 +24,6 @@ export class CurrentPlanHeader extends Component {
 		title: PropTypes.string,
 		tagLine: PropTypes.string,
 		isPlaceholder: PropTypes.bool,
-		currentPlanSlug: PropTypes.oneOf( Object.keys( PLANS_LIST ) ).isRequired,
 		currentPlan: PropTypes.object,
 		isExpiring: PropTypes.bool,
 		translate: PropTypes.func,
@@ -66,7 +65,7 @@ export class CurrentPlanHeader extends Component {
 
 	render() {
 		const {
-			currentPlanSlug,
+			currentPlan,
 			includePlansLink,
 			isPlaceholder,
 			title,
@@ -74,6 +73,8 @@ export class CurrentPlanHeader extends Component {
 			translate,
 			selectedSite,
 		} = this.props;
+
+		const currentPlanSlug = currentPlan && currentPlan.productSlug;
 
 		return (
 			<div className="current-plan__header">

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -19,7 +19,7 @@ import { managePurchase } from 'me/purchases/paths';
 
 export class CurrentPlanHeader extends Component {
 	static propTypes = {
-		selectedSite: PropTypes.object,
+		siteSlug: PropTypes.string,
 		title: PropTypes.string,
 		tagLine: PropTypes.string,
 		isPlaceholder: PropTypes.bool,
@@ -29,7 +29,7 @@ export class CurrentPlanHeader extends Component {
 	};
 
 	renderPurchaseInfo() {
-		const { currentPlan, selectedSite, isExpiring, translate } = this.props;
+		const { currentPlan, siteSlug, isExpiring, translate } = this.props;
 
 		if ( ! currentPlan || isFreeJetpackPlan( currentPlan ) ) {
 			return null;
@@ -54,9 +54,8 @@ export class CurrentPlanHeader extends Component {
 					</span>
 					{ currentPlan.userIsOwner &&
 						currentPlan.id &&
-						selectedSite &&
-						selectedSite.slug && (
-							<Button compact href={ managePurchase( selectedSite.slug, currentPlan.id ) }>
+						siteSlug && (
+							<Button compact href={ managePurchase( siteSlug, currentPlan.id ) }>
 								{ hasAutoRenew ? translate( 'Manage Payment' ) : translate( 'Renew Now' ) }
 							</Button>
 						) }
@@ -66,7 +65,7 @@ export class CurrentPlanHeader extends Component {
 	}
 
 	render() {
-		const { currentPlan, isPlaceholder, selectedSite, tagLine, title, translate } = this.props;
+		const { currentPlan, isPlaceholder, siteSlug, tagLine, title, translate } = this.props;
 
 		const currentPlanSlug = currentPlan && currentPlan.productSlug;
 
@@ -98,12 +97,9 @@ export class CurrentPlanHeader extends Component {
 					{ this.renderPurchaseInfo() }
 					{ currentPlan &&
 						isFreeJetpackPlan( currentPlan ) &&
-						selectedSite &&
-						selectedSite.slug && (
+						siteSlug && (
 							<div className="current-plan__compare-plans">
-								<Button href={ '/plans/' + selectedSite.slug }>
-									{ translate( 'Compare Plans' ) }
-								</Button>
+								<Button href={ `/plans/${ siteSlug }` }>{ translate( 'Compare Plans' ) }</Button>
 							</div>
 						) }
 				</div>

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -53,7 +53,7 @@ export class CurrentPlanHeader extends Component {
 							  } ) }
 					</span>
 					{ currentPlan.userIsOwner &&
-						currentPlan.id &&
+						Boolean( currentPlan.id ) &&
 						siteSlug && (
 							<Button compact href={ managePurchase( siteSlug, currentPlan.id ) }>
 								{ hasAutoRenew ? translate( 'Manage Payment' ) : translate( 'Renew Now' ) }

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -141,7 +141,6 @@ class CurrentPlan extends Component {
 					currentPlanSlug={ currentPlanSlug }
 					currentPlan={ currentPlan }
 					isExpiring={ isExpiring }
-					isAutomatedTransfer={ isAutomatedTransfer }
 					includePlansLink={ currentPlan && isFreeJetpackPlan( currentPlan ) }
 				/>
 				{ isEnabled( 'jetpack/checklist' ) &&

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -138,7 +138,6 @@ class CurrentPlan extends Component {
 					isPlaceholder={ isLoading }
 					title={ title }
 					tagLine={ tagLine }
-					currentPlanSlug={ currentPlanSlug }
 					currentPlan={ currentPlan }
 					isExpiring={ isExpiring }
 					includePlansLink={ currentPlan && isFreeJetpackPlan( currentPlan ) }

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -18,7 +18,6 @@ import {
 	isCurrentPlanExpiring,
 	isRequestingSitePlans,
 } from 'state/sites/plans/selectors';
-import { isFreeJetpackPlan } from 'lib/products-values';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import DocumentHead from 'components/data/document-head';
@@ -140,7 +139,6 @@ class CurrentPlan extends Component {
 					tagLine={ tagLine }
 					currentPlan={ currentPlan }
 					isExpiring={ isExpiring }
-					includePlansLink={ currentPlan && isFreeJetpackPlan( currentPlan ) }
 				/>
 				{ isEnabled( 'jetpack/checklist' ) &&
 					isJetpack &&

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -133,12 +133,12 @@ class CurrentPlan extends Component {
 				) }
 
 				<CurrentPlanHeader
-					selectedSite={ selectedSite }
 					isPlaceholder={ isLoading }
 					title={ title }
 					tagLine={ tagLine }
 					currentPlan={ currentPlan }
 					isExpiring={ isExpiring }
+					siteSlug={ selectedSite ? selectedSite.slug : null }
 				/>
 				{ isEnabled( 'jetpack/checklist' ) &&
 					isJetpack &&


### PR DESCRIPTION
Required for #26779 

`selectedSite` and subsequently the `currentPlan` are often unsafe to use and may throw errors in production. These changes are part of a fix for an observed production error and crash (#26779)

Guard unsafe `currentPlan` and `selectedSite` usage.
Use existing methods for determining Jetpack free plan, not component method.
Derive necessary props inside component where possible.
Put render logic into component.

## Testing
- Ensure the plans header renders as before at `/plans/my-plan`.
- Try testing without one or both of the `selectedSite` or `currentPlan` props, verify that the usage is safe and nothing crashes/errors:
   ```diff
   diff --git a/client/my-sites/plans/current-plan/index.jsx b/client/my-sites/plans/current-plan/index.jsx
   index 2c80ab1ab7..79541106e1 100644
   --- a/client/my-sites/plans/current-plan/index.jsx
   +++ b/client/my-sites/plans/current-plan/index.jsx
   @@ -133,11 +133,11 @@ class CurrentPlan extends Component {
    				) }
    
    				<CurrentPlanHeader
   -					selectedSite={ selectedSite }
   +					selectedSite={ null }
    					isPlaceholder={ isLoading }
    					title={ title }
    					tagLine={ tagLine }
   -					currentPlan={ currentPlan }
   +					currentPlan={ null }
    					isExpiring={ isExpiring }
    				/>
    				{ isEnabled( 'jetpack/checklist' ) &&
   ```
