### PR TITLE
Fix: clean up my-sites/site-settings/index.js

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -25,6 +25,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
+import { getSiteFragment } from 'calypso/lib/route';
 
 function canDeleteSite( state, siteId ) {
 	const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
@@ -119,6 +120,16 @@ export function legacyRedirects( context, next ) {
 
 	if ( redirectMap[ section ] ) {
 		return page.redirect( redirectMap[ section ] );
+	}
+
+	next();
+}
+
+export function redirectToGeneral( context, next ) {
+	const site = getSiteFragment( context.path );
+
+	if ( site ) {
+		return page.redirect( `/settings/general/${ site }` );
 	}
 
 	next();

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -122,8 +122,8 @@ export default function () {
 	page(
 		'/settings/:section',
 		legacyRedirects,
-		redirectToGeneral,
 		siteSelection,
+		redirectToGeneral,
 		sites,
 		makeLayout,
 		clientRender

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -15,6 +15,7 @@ import {
 	legacyRedirects,
 	manageConnection,
 	redirectIfCantDeleteSite,
+	redirectToGeneral,
 	redirectToTraffic,
 	startOver,
 	themeSetup,
@@ -118,5 +119,13 @@ export default function () {
 	page( '/settings/analytics/:site_id?', redirectToTraffic );
 	page( '/settings/seo/:site_id?', redirectToTraffic );
 
-	page( '/settings/:section', legacyRedirects, siteSelection, sites, makeLayout, clientRender );
+	page(
+		'/settings/:section',
+		legacyRedirects,
+		redirectToGeneral,
+		siteSelection,
+		sites,
+		makeLayout,
+		clientRender
+	);
 }


### PR DESCRIPTION
**[Status] In Progress**

From #25783

#### In `my-sites/controller.js`:

- [x] Clean up `createSitesComponent`.


#### In `my-sites/site-settings/index.js`

If the site slug is in the URL, why show a site selection UI? Let's redirect to stats right away.
The issues with `/settings` site selection could be solved similarly: by improved handling of the `/settings/*` routes:

- [x] There should be a redirect from `/settings/site.slug` to `/settings/general/site.slug` if `site.slug` is a valid site slug (number or string with dots)
- [x] This redirect should take care to coexist well with the `/settings/:section` handler that does legacy redirects

