### PR TITLE
Framework: add rtlcss to Webpack

### DIFF
--- a/client/gutenberg/extensions/editor-notes/style.scss
+++ b/client/gutenberg/extensions/editor-notes/style.scss
@@ -12,6 +12,7 @@
 .editor-notes__editor-indicator {
 	position: absolute;
 	top: 0;
-	left: 8px;
+	right: auto #{"/*rtl:8px*/"};
+	left: 8px #{"/*rtl:auto*/"};
 	font-style: italic;
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1614,7 +1614,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1626,7 +1625,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -6082,13 +6080,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6101,18 +6097,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6215,8 +6208,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6226,7 +6218,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6239,20 +6230,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6269,7 +6257,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6342,8 +6329,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6353,7 +6339,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6459,7 +6444,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9625,8 +9609,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "longest-streak": {
       "version": "2.0.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,7 @@ const shouldMinify =
 	( process.env.MINIFY_JS !== 'false' && bundleEnv === 'production' );
 const shouldEmitStats = process.env.EMIT_STATS === 'true';
 const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
+const shouldRTL = process.env.RTL === 'true';
 const codeSplit = config.isEnabled( 'code-splitting' );
 
 /**
@@ -178,13 +179,16 @@ function getWebpackConfig( { externalizeWordPressPackages = false } = {}, argv )
 				},
 				{
 					test: /\.(sc|sa|c)ss$/,
-					use: _.compact( [
+					use: [
 						MiniCssExtractPlugin.loader,
 						'css-loader',
 						{
 							loader: 'postcss-loader',
 							options: {
-								plugins: [ require( 'autoprefixer' ) ],
+								plugins: _.compact( [
+									require( 'autoprefixer' ),
+									shouldRTL && require( 'rtlcss' ),
+								] ),
 							},
 						},
 						{
@@ -193,7 +197,7 @@ function getWebpackConfig( { externalizeWordPressPackages = false } = {}, argv )
 								includePaths: [ path.join( __dirname, 'client' ) ],
 							},
 						},
-					] ),
+					],
 				},
 				{
 					test: /extensions[\/\\]index/,


### PR DESCRIPTION
Adds RTL to Webpack CSS builder.

We should produce two files in one pass. Currently, this just applies RTLCSS to any CSS passing through the builder. Not great.

### Testing 

Regular
```
npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/editor-notes/index.js
```

RTL
```
RTL=true npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/editor-notes/index.js
```