### PR TITLE
Signup: Rename the G Suite upsell discount A/B test to start over.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -104,8 +104,8 @@ export default {
 		},
 		defaultVariation: 'no',
 	},
-	gSuiteDiscount: {
-		datestamp: '20180803',
+	gSuiteDiscountV2: {
+		datestamp: '20180822',
 		variations: {
 			control: 50,
 			discount: 50,

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -108,7 +108,7 @@ export default connect( ( state, props ) => {
 		siteSlug: getSiteSlug( state, props.selectedSiteId ),
 		siteTitle: getSiteTitle( state, props.selectedSiteId ),
 		hasDotComBusiness,
-		inDiscountABTest: 'discount' === abtest( 'gSuiteDiscount' ),
+		inDiscountABTest: 'discount' === abtest( 'gSuiteDiscountV2' ),
 	};
 } )( localize( GsuiteNudge ) );
 


### PR DESCRIPTION
Since we found the test was not working properly, we've decided to start the test over.
Context: p8Eqe3-sq-p2
Test plan: https://github.com/Automattic/wp-calypso/pull/26342