### PR TITLE
PlansNavigation: componentWillMount cleanup

### DIFF
--- a/client/my-sites/domains/navigation.jsx
+++ b/client/my-sites/domains/navigation.jsx
@@ -34,18 +34,16 @@ class PlansNavigation extends React.Component {
 	};
 
 	componentDidMount() {
-		this.dispatchToken = Dispatcher.register(
-			function( payload ) {
-				if ( payload.action.type === CART_POPUP_OPEN ) {
-					this.setState( {
-						cartVisible: true,
-						cartShowKeepSearching: payload.action.options.showKeepSearching,
-					} );
-				} else if ( payload.action.type === CART_POPUP_CLOSE ) {
-					this.setState( { cartVisible: false } );
-				}
-			}.bind( this )
-		);
+		this.dispatchToken = Dispatcher.register( payload => {
+			if ( payload.action.type === CART_POPUP_OPEN ) {
+				this.setState( {
+					cartVisible: true,
+					cartShowKeepSearching: payload.action.options.showKeepSearching,
+				} );
+			} else if ( payload.action.type === CART_POPUP_CLOSE ) {
+				this.setState( { cartVisible: false } );
+			}
+		} );
 	}
 
 	componentWillUnmount() {

--- a/client/my-sites/domains/navigation.jsx
+++ b/client/my-sites/domains/navigation.jsx
@@ -33,7 +33,7 @@ class PlansNavigation extends React.Component {
 		cartShowKeepSearching: false,
 	};
 
-	componentWillMount() {
+	componentDidMount() {
 		this.dispatchToken = Dispatcher.register(
 			function( payload ) {
 				if ( payload.action.type === CART_POPUP_OPEN ) {


### PR DESCRIPTION
Moving a file in #26780 triggered eslint errors on CI.

- Replace deprecated `componentWillMount` with `componentDidMount`.
- Replace explicit function bind with unbound arrow function.

Required for #26780 which is required for #26779 
Part of #24504 

## Screens

### Component at `domains/manage/SITE_SLUG`

<img width="579" alt="plansnavigation" src="https://user-images.githubusercontent.com/841763/44411840-6c158700-a535-11e8-831c-2732567d544b.png">

### Cart toggle
<img width="346" alt="cart" src="https://user-images.githubusercontent.com/841763/44411838-6c158700-a535-11e8-88d1-d4babdc9736b.png">


## Testing
- Verify that `PlansNavigation` renders correctly in different context (plans, my plan, domains).
- Verify that the cart popover continues to open and close correctly.