### PR TITLE
Gutenberg: Add "Ground Controls" to the Toolbar

### DIFF
--- a/client/gutenberg/editor/edit-post/components/header/header-toolbar/index.js
+++ b/client/gutenberg/editor/edit-post/components/header/header-toolbar/index.js
@@ -1,7 +1,12 @@
 /**
  * External dependencies
+ *
+ * @format
  */
 import React from 'react';
+import { findLast } from 'lodash';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * WordPress dependencies
@@ -23,30 +28,126 @@ import {
 	NavigableToolbar,
 } from '@wordpress/editor';
 
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Drafts from 'layout/masterbar/drafts';
+import Site from 'blocks/site';
+import { addSiteFragment } from 'lib/route';
+import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
+import { navigate } from 'state/ui/actions';
+import { getSelectedSite } from 'state/ui/selectors';
+import { getRouteHistory } from 'state/ui/action-log/selectors';
+
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-function HeaderToolbar( { hasFixedToolbar, isLargeViewport } ) {
+function HeaderToolbar( {
+	closeEditor,
+	hasFixedToolbar,
+	isLargeViewport,
+	recordSiteButtonClick,
+	site,
+	translate,
+} ) {
+	const onCloseButtonClick = () => closeEditor();
+
 	return (
-		<NavigableToolbar
-			className="edit-post-header-toolbar"
-			aria-label={ __( 'Editor Toolbar' ) }
-		>
+		<NavigableToolbar className="edit-post-header-toolbar" aria-label={ __( 'Editor Toolbar' ) }>
+			<Button
+				borderless
+				className="edit-post-header-toolbar__back"
+				onClick={ onCloseButtonClick }
+				aria-label={ translate( 'Close' ) }
+			>
+				{ translate( 'Close' ) }
+			</Button>
+			<Site compact site={ site } indicator={ false } onSelect={ recordSiteButtonClick } />
+			<Drafts />
 			<Inserter position="bottom right" />
 			<EditorHistoryUndo />
 			<EditorHistoryRedo />
 			<TableOfContents />
-			{ hasFixedToolbar && isLargeViewport && (
-				<div className="edit-post-header-toolbar__block-toolbar">
-					<BlockToolbar />
-				</div>
-			) }
+			{ hasFixedToolbar &&
+				isLargeViewport && (
+					<div className="edit-post-header-toolbar__block-toolbar">
+						<BlockToolbar />
+					</div>
+				) }
 		</NavigableToolbar>
 	);
 }
 /* eslint-enable wpcalypso/jsx-classname-namespace */
 
+function getCloseButtonPath( routeHistory, site ) {
+	const editorPathRegex = /^\/gutenberg\/(post|page|(edit\/[^\/]+))\/[^\/]+(\/\d+)?$/i;
+	const lastEditorPath = routeHistory[ routeHistory.length - 1 ].path;
+
+	// @see post-editor/editor-ground-control/index.jsx
+	const lastNonEditorPath = findLast(
+		routeHistory,
+		action => ! action.path.match( editorPathRegex )
+	);
+	if ( lastNonEditorPath ) {
+		return lastNonEditorPath.path;
+	}
+
+	const editorPostType = lastEditorPath.match( editorPathRegex )[ 1 ];
+	let path;
+
+	// @see post-editor/post-editor.jsx
+	if ( 'post' === editorPostType ) {
+		path = '/posts';
+	} else if ( 'page' === editorPostType ) {
+		path = '/pages';
+	} else {
+		path = `/types/${ editorPostType.split( '/' )[ 1 ] }`;
+	}
+	if ( 'post' === editorPostType && site && ! site.jetpack && ! site.single_user_site ) {
+		path += '/my';
+	}
+	if ( site ) {
+		path = addSiteFragment( path, site.slug );
+	}
+	return path;
+}
+
+const mapStateToProps = state => ( {
+	routeHistory: getRouteHistory( state ),
+	site: getSelectedSite( state ),
+} );
+
+const mapDispatchToProps = dispatch => {
+	return {
+		closeEditor: ( { routeHistory, site } ) =>
+			dispatch(
+				withAnalytics(
+					recordTracksEvent( 'calypso_gutenberg_editor_close_button_click' ),
+					navigate( getCloseButtonPath( routeHistory, site ) )
+				)
+			),
+		recordSiteButtonClick: () =>
+			dispatch( recordTracksEvent( 'calypso_gutenberg_editor_site_button_click' ) ),
+	};
+};
+
+const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
+	return {
+		...ownProps,
+		...stateProps,
+		...dispatchProps,
+		closeEditor: () => dispatchProps.closeEditor( stateProps ),
+	};
+};
+
 export default compose( [
-	withSelect( ( select ) => ( {
+	withSelect( select => ( {
 		hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
 	} ) ),
 	withViewportMatch( { isLargeViewport: 'medium' } ),
-] )( HeaderToolbar );
+] )(
+	connect(
+		mapStateToProps,
+		mapDispatchToProps,
+		mergeProps
+	)( localize( HeaderToolbar ) )
+);

--- a/client/gutenberg/editor/edit-post/components/header/header-toolbar/index.js
+++ b/client/gutenberg/editor/edit-post/components/header/header-toolbar/index.js
@@ -32,7 +32,6 @@ import {
  * Internal dependencies
  */
 import Button from 'components/button';
-import Drafts from 'layout/masterbar/drafts';
 import Site from 'blocks/site';
 import { addSiteFragment } from 'lib/route';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
@@ -62,7 +61,6 @@ function HeaderToolbar( {
 				{ translate( 'Close' ) }
 			</Button>
 			<Site compact site={ site } indicator={ false } onSelect={ recordSiteButtonClick } />
-			<Drafts />
 			<Inserter position="bottom right" />
 			<EditorHistoryUndo />
 			<EditorHistoryRedo />

--- a/client/gutenberg/editor/edit-post/components/header/header-toolbar/style.scss
+++ b/client/gutenberg/editor/edit-post/components/header/header-toolbar/style.scss
@@ -76,3 +76,47 @@
 		display: block;
 	}
 }
+
+.edit-post-header-toolbar__back.is-borderless {
+	border-right: 1px solid lighten( $gray, 25% );
+	border-radius: 0;
+	color: $blue-wordpress;
+	height: 100%;
+	min-width: 80px;
+	padding: 6px 16px;
+	&:hover {
+		color: $blue-medium;
+	}
+	@include breakpoint( '>960px' ) {
+		padding: 6px 32px;
+	}
+	@include breakpoint( '<660px' ) {
+		border: none;
+	}
+}
+
+.edit-post-header-toolbar .site {
+	.site__content {
+		padding-right: 0;
+	}
+	.site__info {
+		width: auto;
+	}
+	.site__title::after {
+		width: 0;
+	}
+	@include breakpoint( '<660px' ) {
+		display: none;
+	}
+}
+
+.edit-post-header-toolbar {
+	.masterbar__drafts {
+		border-right: 1px solid lighten( $gray, 25% );
+		height: 100%;
+		margin-right: 10px;
+	}
+	.masterbar__toggle-drafts.button.is-borderless {
+		margin: 10px 8px;
+	}
+}

--- a/client/gutenberg/editor/edit-post/components/header/header-toolbar/style.scss
+++ b/client/gutenberg/editor/edit-post/components/header/header-toolbar/style.scss
@@ -90,33 +90,22 @@
 	@include breakpoint( '>960px' ) {
 		padding: 6px 32px;
 	}
-	@include breakpoint( '<660px' ) {
-		border: none;
-	}
 }
 
 .edit-post-header-toolbar .site {
-	.site__content {
-		padding-right: 0;
-	}
+	border-right: 1px solid lighten( $gray, 25% );
+	margin-right: 10px;
+
 	.site__info {
 		width: auto;
 	}
 	.site__title::after {
 		width: 0;
 	}
-	@include breakpoint( '<660px' ) {
+	&.is-compact .site__title {
+		line-height: 56px;
+	}
+	@include breakpoint( '<800px' ) {
 		display: none;
-	}
-}
-
-.edit-post-header-toolbar {
-	.masterbar__drafts {
-		border-right: 1px solid lighten( $gray, 25% );
-		height: 100%;
-		margin-right: 10px;
-	}
-	.masterbar__toggle-drafts.button.is-borderless {
-		margin: 10px 8px;
 	}
 }

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -30,8 +30,7 @@
 	}
 
 	.edit-post-header {
-		padding-top: 0;
-		padding-bottom: 0;
+		padding: 0 10px 0 0;
 		left: 0;
 		top: 0;
 	}

--- a/client/layout/masterbar/drafts.jsx
+++ b/client/layout/masterbar/drafts.jsx
@@ -117,7 +117,7 @@ class MasterbarDrafts extends Component {
 		}
 
 		return (
-			<div>
+			<div className="masterbar__drafts">
 				<QueryPostCounts siteId={ this.props.selectedSiteId } type="post" />
 				{ this.renderButton() }
 				{ this.renderPopover() }


### PR DESCRIPTION
Add Close button and Site info to the Gutenberg toolbar.

- The Close button tries to open the previous non-Gutenberg path.
It falls back to the "all posts" page for the current post type, which doesn't really work at the moment, as the post type is mocked as `post` regardless. It might make sense to regex the path instead.

- I've copied the Site info button from the Calypso editor ground control: it's supposed to do _something_ on click, but in fact it [only tracks the click](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/editor-ground-control/index.jsx#L179). 🤔 

![calypso localhost_3000_gutenberg_post_coponstestfree wordpress com_1768](https://user-images.githubusercontent.com/2070010/45492309-3e0a1800-b76c-11e8-9fec-af51c5744b09.png)

![calypso localhost_3000_gutenberg_post_coponstestfree wordpress com_1768 1](https://user-images.githubusercontent.com/2070010/45492316-43676280-b76c-11e8-8ba4-0a3512ea0e0d.png)
