### PR TITLE
Domains: Enforce a minimum query length for domain suggestion searches

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -90,6 +90,7 @@ const INITIAL_SUGGESTION_QUANTITY = 2;
 const PAGE_SIZE = 10;
 const MAX_PAGES = 3;
 const SUGGESTION_QUANTITY = isPaginationEnabled ? PAGE_SIZE * MAX_PAGES : PAGE_SIZE;
+const MIN_QUERY_LENGTH = 2;
 
 const FEATURED_SUGGESTIONS_AT_TOP = [ 'group_7', 'group_8' ];
 let searchVendor = 'domainsbot';
@@ -376,6 +377,7 @@ class RegisterDomainStep extends React.Component {
 							describedBy={ 'step-header' }
 							dir="ltr"
 							initialValue={ this.state.lastQuery }
+							minLength={ MIN_QUERY_LENGTH }
 							maxLength={ 60 }
 							onBlur={ this.save }
 							onSearch={ this.onSearch }
@@ -586,14 +588,19 @@ class RegisterDomainStep extends React.Component {
 			return;
 		}
 
-		const loadingResults = Boolean( getFixedDomainSearch( searchQuery ) );
+		let cleanedQuery = getFixedDomainSearch( searchQuery );
+		if ( cleanedQuery.length < MIN_QUERY_LENGTH ) {
+			cleanedQuery = '';
+		}
+
+		const loadingResults = Boolean( cleanedQuery );
 
 		this.setState(
 			{
 				error: null,
 				errorData: null,
 				exactMatchDomain: null,
-				lastQuery: searchQuery,
+				lastQuery: cleanedQuery,
 				lastDomainSearched: null,
 				loadingResults,
 				loadingSubdomainResults: loadingResults,
@@ -843,7 +850,11 @@ class RegisterDomainStep extends React.Component {
 
 	onSearch = ( searchQuery, { shouldQuerySubdomains = true } = {} ) => {
 		debug( 'onSearch handler was triggered with query', searchQuery );
-		const domain = getFixedDomainSearch( searchQuery );
+
+		let domain = getFixedDomainSearch( searchQuery );
+		if ( domain.length < MIN_QUERY_LENGTH ) {
+			domain = '';
+		}
 
 		this.setState(
 			{

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -60,6 +60,7 @@ class Search extends Component {
 		dir: PropTypes.oneOf( [ 'ltr', 'rtl' ] ),
 		fitsContainer: PropTypes.bool,
 		maxLength: PropTypes.number,
+		minLength: PropTypes.number,
 		hideClose: PropTypes.bool,
 		compact: PropTypes.bool,
 		hideOpenIcon: PropTypes.bool,
@@ -365,6 +366,7 @@ class Search extends Component {
 						autoCapitalize="none"
 						dir={ this.props.dir }
 						maxLength={ this.props.maxLength }
+						minLength={ this.props.minLength }
 						{ ...autocorrect }
 					/>
 					{ this.props.overlayStyling && this.renderStylingDiv() }


### PR DESCRIPTION
A single character query rarely yields meaningful domain recommendations. Thus, this change enforces a minimum query length of 2 characters for the domain search interface. 

It also adds handling for property `minLength` for `<Search />` which is propagated down to its contained [`<input />`](https://reactjs.org/docs/dom-elements.html).

# Testing instructions
1. Spin up this branch locally or via a live branch.
2. Navigate to [`/start/domains`](http://calypso.localhost:3000/start/domains).
3. Enter a single character into the search box. Ensure that no search is executed.
4. Enter more characters into the search box. Ensure that a search is executed.
5. Remove all but a single character. Ensure that the interface is reset to its initial state.