### PR TITLE
Expose userAgent to the client

### DIFF
--- a/client/lib/rubberband-scroll-disable/index.js
+++ b/client/lib/rubberband-scroll-disable/index.js
@@ -1,5 +1,10 @@
 /** @format */
 
+/**
+ * Internal dependencies
+ */
+import userAgent from 'lib/user-agent';
+
 function preventScrollBounceOSX( body, event ) {
 	if (
 		( event.deltaY < 0 && body.scrollTop === 0 ) ||
@@ -10,12 +15,7 @@ function preventScrollBounceOSX( body, event ) {
 }
 
 export default function( body ) {
-	if (
-		window &&
-		window.navigator &&
-		window.navigator.userAgent &&
-		window.navigator.userAgent.indexOf( 'Macintosh' ) !== -1
-	) {
+	if ( userAgent.platform === 'Apple Mac' ) {
 		body.addEventListener( 'mousewheel', preventScrollBounceOSX.bind( window, body ) );
 	}
 }

--- a/client/lib/user-agent/index.js
+++ b/client/lib/user-agent/index.js
@@ -3,8 +3,6 @@
 /**
  * External dependencies
  */
-
-import { UserAgent } from 'express-useragent';
 import { get } from 'lodash';
 
 /*
@@ -23,6 +21,6 @@ import { get } from 'lodash';
 	For a full list of values see: https://github.com/biggora/express-useragent/blob/master/lib/express-useragent.js#L191
 
  */
-export default ( typeof window !== 'undefined' && !! get( window, 'navigator.userAgent', null )
-	? new UserAgent().parse( window.navigator.userAgent )
+export default ( typeof window !== 'undefined' && !! get( window, 'app.userAgent', null )
+	? window.app.userAgent
 	: {} );

--- a/client/lib/user-agent/index.js
+++ b/client/lib/user-agent/index.js
@@ -1,0 +1,26 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { UserAgent } from 'express-useragent';
+import { get } from 'lodash';
+
+/*
+	# Usage:
+
+	## Client:
+
+	import userAgent from 'lib/user-agent';
+
+	const { isChromeOS, isIE } = userAgent;
+
+	if ( isChromeOS && isIE ) {
+		console.log( 'Hmm, this is unorthodox!' );
+	}
+
+ */
+export default ( typeof window !== 'undefined' && !! get( window, 'navigator.userAgent', null )
+	? new UserAgent().parse( window.navigator.userAgent )
+	: {} );

--- a/client/lib/user-agent/index.js
+++ b/client/lib/user-agent/index.js
@@ -20,6 +20,8 @@ import { get } from 'lodash';
 		console.log( 'Hmm, this is unorthodox!' );
 	}
 
+	For a full list of values see: https://github.com/biggora/express-useragent/blob/master/lib/express-useragent.js#L191
+
  */
 export default ( typeof window !== 'undefined' && !! get( window, 'navigator.userAgent', null )
 	? new UserAgent().parse( window.navigator.userAgent )

--- a/client/my-sites/comments/comment/comment-html-editor/index.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { delay, each, get, map, reduce, reject } from 'lodash';
+import { delay, each, map, reduce, reject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +14,7 @@ import { delay, each, get, map, reduce, reject } from 'lodash';
 import AddImageDialog from 'my-sites/comments/comment/comment-html-editor/add-image-dialog';
 import AddLinkDialog from 'my-sites/comments/comment/comment-html-editor/add-link-dialog';
 import Button from 'components/button';
+import userAgent from 'lib/user-agent';
 
 export class CommentHtmlEditor extends Component {
 	static propTypes = {
@@ -93,14 +94,11 @@ export class CommentHtmlEditor extends Component {
 	};
 
 	insertContent = ( content, adjustCursorPosition = 0 ) => {
-		const userAgent = get( window, 'navigator.userAgent', '' );
+		const { isFirefox, isIE } = userAgent;
 
 		// In Firefox, IE, and Edge, `document.execCommand( 'insertText' )` doesn't work.
 		// @see https://bugzilla.mozilla.org/show_bug.cgi?id=1220696
-		if (
-			/(?:firefox|fxios)/i.test( userAgent ) ||
-			/(?:edge|msie |trident.+?; rv:)/i.test( userAgent )
-		) {
+		if ( isFirefox || isIE ) {
 			const { selectionEnd, value } = this.textarea;
 			const { before, after } = this.splitSelectedContent();
 			const newContent = before + content + after;

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -36,6 +36,7 @@ import ThemeEnhancements from './theme-enhancements';
 import PublishingTools from './publishing-tools';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import SpeedUpYourSite from './speed-up-site-settings';
+import userAgent from 'lib/user-agent';
 
 class SiteSettingsFormWriting extends Component {
 	renderSectionHeader( title, showButton = true ) {
@@ -54,10 +55,6 @@ class SiteSettingsFormWriting extends Component {
 				) }
 			</SectionHeader>
 		);
-	}
-
-	isMobile() {
-		return /Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile|Silk/.test( navigator.userAgent );
 	}
 
 	render() {
@@ -82,6 +79,7 @@ class SiteSettingsFormWriting extends Component {
 			translate,
 			updateFields,
 			jetpackVersionSupportsLazyImages,
+			isMobile,
 		} = this.props;
 
 		const jetpackSettingsUI = siteIsJetpack && jetpackSettingsUISupported;
@@ -195,7 +193,7 @@ class SiteSettingsFormWriting extends Component {
 					) }
 
 				{ config.isEnabled( 'press-this' ) &&
-					! this.isMobile() &&
+					! isMobile &&
 					! ( siteIsJetpack || jetpackSettingsUISupported ) && (
 						<div>
 							{ this.renderSectionHeader(
@@ -231,6 +229,7 @@ const connectComponent = connect(
 				// Masterbar can't be turned off on Atomic sites - don't show the toggle in that case
 				! siteIsAutomatedTransfer,
 			isPodcastingSupported,
+			isMobile: userAgent.isMobile,
 		};
 	},
 	{ requestPostTypes },

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -25,6 +25,7 @@ import { localize } from 'i18n-calypso';
 import MagicSearchWelcome from './welcome';
 import getThemeFilters from 'state/selectors/get-theme-filters';
 import getThemeFilterToTermTable from 'state/selectors/get-theme-filter-to-term-table';
+import userAgent from 'lib/user-agent';
 
 //We want those taxonomies if they are used to be presented in this order
 const preferredOrderOfTaxonomies = [ 'feature', 'layout', 'column', 'subject', 'style' ];
@@ -188,7 +189,7 @@ class ThemesMagicSearchCard extends React.Component {
 
 	searchTokens = input => {
 		//We are not able to scroll overlay on Edge so just create empty div
-		if ( typeof window !== 'undefined' && /(Edge)/.test( window.navigator.userAgent ) ) {
+		if ( userAgent.isEdge ) {
 			return <div />;
 		}
 

--- a/client/reader/sidebar/promo.jsx
+++ b/client/reader/sidebar/promo.jsx
@@ -19,6 +19,7 @@ import QueryUserSettings from 'components/data/query-user-settings';
 import { isMobile } from 'lib/viewport';
 import config from 'config';
 import getUserSetting from 'state/selectors/get-user-setting';
+import userAgent from 'lib/user-agent';
 
 export const ReaderSidebarPromo = ( { currentUserLocale, shouldRenderAppPromo } ) => {
 	return (
@@ -48,7 +49,7 @@ export const shouldRenderAppPromo = ( options = {} ) => {
 		isUserLocaleEnglish = 'en' === options.currentUserLocale,
 		isDesktopPromoConfiguredToRun = config.isEnabled( 'desktop-promo' ),
 		isUserDesktopAppUser = haveUserSettingsLoaded || options.isDesktopAppUser,
-		isUserOnChromeOs = /\bCrOS\b/.test( navigator.userAgent ),
+		isUserOnChromeOs = userAgent.isChromeOS,
 	} = options;
 
 	return (

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -41,7 +41,6 @@ import { logSectionResponseTime } from './analytics';
 import { setCurrentUserOnReduxStore } from 'lib/redux-helpers';
 import analytics from '../lib/analytics';
 import { getLanguage } from 'lib/i18n-utils';
-import useragent from 'express-useragent';
 
 const debug = debugFactory( 'calypso:pages' );
 
@@ -222,7 +221,6 @@ function getDefaultContext( request ) {
 	if ( request.context && request.context.lang ) {
 		lang = request.context.lang;
 	}
-
 	const context = Object.assign( {}, request.context, {
 		commitSha: process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)',
 		compileDebug: process.env.NODE_ENV === 'development',
@@ -246,7 +244,7 @@ function getDefaultContext( request ) {
 		store: createReduxStore( initialServerState ),
 		bodyClasses,
 		sectionCss,
-		userAgent: useragent.parse( request.headers[ 'user-agent' ] ),
+		userAgent: request.useragent,
 	} );
 
 	context.app = {

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -41,6 +41,7 @@ import { logSectionResponseTime } from './analytics';
 import { setCurrentUserOnReduxStore } from 'lib/redux-helpers';
 import analytics from '../lib/analytics';
 import { getLanguage } from 'lib/i18n-utils';
+import useragent from 'express-useragent';
 
 const debug = debugFactory( 'calypso:pages' );
 
@@ -245,6 +246,7 @@ function getDefaultContext( request ) {
 		store: createReduxStore( initialServerState ),
 		bodyClasses,
 		sectionCss,
+		userAgent: useragent.parse( request.headers[ 'user-agent' ] ),
 	} );
 
 	context.app = {
@@ -252,6 +254,7 @@ function getDefaultContext( request ) {
 		clientIp: request.ip ? request.ip.replace( '::ffff:', '' ) : request.ip,
 		isDebug: context.env === 'development' || context.isDebug,
 		staticUrls: staticFilesUrls,
+		userAgent: context.userAgent,
 	};
 
 	if ( calypsoEnv === 'wpcalypso' ) {


### PR DESCRIPTION
This is an experimental branch to check the build size after adding `express-useragent` the client bundle.

I've replaced uses of `navigator.userAgent` with the lib.

Background: `p4TIVU-96y-p2`

If this branch makes sense we can revert the `navigator.userAgent` replaces I've made, and merge with just the thin client `client/lib/user-agent/index.js`

## Results

### 1. Importing into the client

a20d87b95416a5704b5aba65696492630a0855d0

```
Commit: a20d87b95416a5704b5aba65696492630a0855d0
Author: ramonjd
At: 2018-08-22T04:00:15Z
Message: replacing navigator.userAgent with lib
Delta:
chunk                                     stat_size           parsed_size           gzip_size
async-load-lib-rubberband-scroll-disable       -5 B  (-1.1%)        -36 B  (-8.0%)       -6 B  (-2.0%)
async-load-reader-sidebar                     +29 B  (+0.0%)        +20 B  (+0.1%)      -13 B  (-0.2%)
build                                        +606 B  (+0.0%)       +192 B  (+0.0%)      +79 B  (+0.0%)
comments                                      -18 B  (-0.0%)        -46 B  (-0.0%)      -31 B  (-0.1%)
manifest                                       +0 B                  +0 B                -2 B  (-0.0%)
settings-writing                              -48 B  (-0.0%)        -61 B  (-0.0%)      -40 B  (-0.1%)
themes                                        -13 B  (-0.0%)        -16 B  (-0.0%)       -9 B  (-0.0%)
vendors~build                              +31634 B  (+1.1%)     +16561 B  (+1.3%)    +4497 B  (+1.4%)
```

### 2. Adding to `window.app`

03e6fbb45f6bf8e0380270be6b74b8d20b66c90e

```
Commit: 03e6fbb45f6bf8e0380270be6b74b8d20b66c90e
Author: ramonjd
At: 2018-08-22T04:59:55Z
Message: adding userAgent to `window.app`
Delta:
chunk                                     stat_size           parsed_size           gzip_size
async-load-lib-rubberband-scroll-disable       -5 B  (-1.1%)        -36 B  (-8.0%)       -6 B  (-2.0%)
async-load-reader-sidebar                     +29 B  (+0.0%)        +20 B  (+0.1%)      -13 B  (-0.2%)
build                                        +524 B  (+0.0%)       +106 B  (+0.0%)      +53 B  (+0.0%)
comments                                      -18 B  (-0.0%)        -46 B  (-0.0%)      -31 B  (-0.1%)
manifest                                       +0 B                  +0 B                -2 B  (-0.0%)
settings-writing                              -48 B  (-0.0%)        -61 B  (-0.0%)      -40 B  (-0.1%)
themes                                        -13 B  (-0.0%)        -16 B  (-0.0%)       -9 B  (-0.0%)
```
http://iscalypsofastyet.com/branch?branch=try/add-user-agent-lib

## Results
Is an extra 4.5k (+1.4%) to vendors negligible? My instinct tells me that adding extra guff to the window object is bad, but we're not winning back many bytes in the modules.