### PR TITLE
Build CSS assets with Webpack

### DIFF
--- a/assets/stylesheets/sections/login.scss
+++ b/assets/stylesheets/sections/login.scss
@@ -1,5 +1,0 @@
-/** @format */
-@import '../shared/colors';
-
-@import 'login/magic-login/style';
-@import 'login/wp-login/style';

--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -54,6 +54,12 @@ class Desktop extends React.Component {
 						}
 						type="text/css"
 					/>
+					<link
+						rel="stylesheet"
+						type="text/css"
+						data-webpack={ true }
+						href={ `/calypso/build.${ isRTL ? 'rtl.css' : 'css' }` }
+					/>
 					<link rel="stylesheet" id="desktop-css" href="/desktop/wordpress-desktop.css" />
 				</Head>
 				<body className={ classNames( { rtl: isRTL } ) }>

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -22,6 +22,10 @@ import getStylesheet from './utils/stylesheet';
 import WordPressLogo from 'components/wordpress-logo';
 import { jsonStringifyForHtml } from '../../server/sanitize';
 
+const cssChunkLink = asset => (
+	<link key={ asset } rel="stylesheet" type="text/css" data-webpack={ true } href={ asset } />
+);
+
 class Document extends React.Component {
 	render() {
 		const {
@@ -56,6 +60,8 @@ class Document extends React.Component {
 			feedbackURL,
 			inlineScriptNonce,
 		} = this.props;
+
+		const csskey = isRTL ? 'css.rtl' : 'css.ltr';
 
 		const inlineScript =
 			`COMMIT_SHA = ${ jsonStringifyForHtml( commitSha ) };\n` +
@@ -93,6 +99,8 @@ class Document extends React.Component {
 						}
 						type="text/css"
 					/>
+					{ entrypoint[ csskey ].map( cssChunkLink ) }
+					{ chunkFiles[ csskey ].map( cssChunkLink ) }
 					{ sectionCss && (
 						<link
 							rel="stylesheet"
@@ -171,10 +179,10 @@ class Document extends React.Component {
 							} }
 						/>
 					) }
-					{ entrypoint.map( asset => (
+					{ entrypoint.js.map( asset => (
 						<script key={ asset } src={ asset } />
 					) ) }
-					{ chunkFiles.map( chunk => (
+					{ chunkFiles.js.map( chunk => (
 						<script key={ chunk } src={ chunk } />
 					) ) }
 					<script nonce={ inlineScriptNonce } type="text/javascript">

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -6,6 +6,7 @@
 import request from 'superagent';
 import i18n from 'i18n-calypso';
 import debugFactory from 'debug';
+import { map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,6 +31,7 @@ function setLocaleInDOM( localeSlug, isRTL ) {
 	const cssUrl = window.app.staticUrls[ `style${ debugFlag }${ directionFlag }.css` ];
 
 	switchCSS( 'main-css', cssUrl );
+	switchWebpackCSS( isRTL );
 }
 
 let lastRequestedLocale = null;
@@ -103,6 +105,33 @@ export async function switchCSS( elementId, cssUrl ) {
 	}
 
 	newLink.id = elementId;
+}
+
+function flipRTL( url, isRTL ) {
+	if ( isRTL ) {
+		return url.endsWith( '.rtl.css' ) ? url : url.replace( /\.css$/, '.rtl.css' );
+	}
+
+	return ! url.endsWith( '.rtl.css' ) ? url : url.replace( /\.rtl.css$/, '.css' );
+}
+
+function switchWebpackCSS( isRTL ) {
+	const currentLinks = document.querySelectorAll( 'link[rel="stylesheet"][data-webpack]' );
+
+	return map( currentLinks, async currentLink => {
+		const currentHref = currentLink.getAttribute( 'href' );
+		const newHref = flipRTL( currentHref, isRTL );
+		if ( currentHref === newHref ) {
+			return;
+		}
+
+		const newLink = await loadCSS( newHref, currentLink );
+		newLink.setAttribute( 'data-webpack', true );
+
+		if ( currentLink.parentElement ) {
+			currentLink.parentElement.removeChild( currentLink );
+		}
+	} );
 }
 
 /**

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -107,7 +107,12 @@ export async function switchCSS( elementId, cssUrl ) {
 	newLink.id = elementId;
 }
 
-function flipRTL( url, isRTL ) {
+/*
+ * CSS links come in two flavors: either RTL stylesheets with `.rtl.css` suffix, or LTR ones
+ * with `.css` suffix. This function sets a desired `isRTL` flag on the supplied URL, i.e., it
+ * changes the extension if necessary.
+ */
+function setRTLFlagOnCSSLink( url, isRTL ) {
 	if ( isRTL ) {
 		return url.endsWith( '.rtl.css' ) ? url : url.replace( /\.css$/, '.rtl.css' );
 	}
@@ -120,7 +125,7 @@ function switchWebpackCSS( isRTL ) {
 
 	return map( currentLinks, async currentLink => {
 		const currentHref = currentLink.getAttribute( 'href' );
-		const newHref = flipRTL( currentHref, isRTL );
+		const newHref = setRTLFlagOnCSSLink( currentHref, isRTL );
 		if ( currentHref === newHref ) {
 			return;
 		}

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -33,6 +33,11 @@ import RequestLoginEmailForm from './request-login-email-form';
 import GlobalNotices from 'components/global-notices';
 import Gridicon from 'gridicons';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class MagicLogin extends React.Component {
 	static propTypes = {
 		path: PropTypes.string.isRequired,

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -30,6 +30,11 @@ import {
 } from 'state/analytics/actions';
 import { withEnhancers } from 'state/utils';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class Login extends React.Component {
 	static propTypes = {
 		clientId: PropTypes.string,

--- a/client/sections-helper.js
+++ b/client/sections-helper.js
@@ -34,7 +34,6 @@ export function getSections() {
 }
 
 function maybeLoadCSS( sectionName ) {
-	//eslint-disable-line no-unused-vars
 	const section = find( sections, { name: sectionName } );
 
 	if ( ! ( section && section.css ) ) {

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -411,7 +411,6 @@ sections.push( {
 	enableLoggedOut: true,
 	secondary: false,
 	isomorphic: true,
-	css: 'login',
 } );
 
 sections.push( {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1719,9 +1719,9 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-colors": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.0.5.tgz",
-      "integrity": "sha512-VVjWpkfaphxUBFarydrQ3n26zX5nIK7hcbT3/ielrvwDDyBBjuh2vuSw1P9zkPq0cfqvdw7lkYHnu+OLSfIBsg=="
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.0.6.tgz",
+      "integrity": "sha512-rY3B55KSBMMARmGXtzaG5o+kqnCrEF99rngBq5fV+cbwJepVGhDT8eB7UhSDwsJxNsMzSQDLQAyWmgi9pfzssQ=="
     },
     "ansi-escapes": {
       "version": "3.1.0",
@@ -2999,14 +2999,14 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000885",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000885.tgz",
-      "integrity": "sha512-Hy1a+UIXooG+tRlt3WnT9avMf+l999bR9J1MqlQdYKgbsYjKxV4a4rgcmiyMmdCLPBFsiRoDxdl9tnNyaq2RXw=="
+      "version": "1.0.30000886",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000886.tgz",
+      "integrity": "sha512-Vi/lcz+7gkMEa4ENyZumPENL9Ww3tg01Tc5g8s66zURUFV9weGw9QHvkAYVuZOJdqxjWYmaJXvVx3J2x6ldKeg=="
     },
     "caniuse-lite": {
-      "version": "1.0.30000885",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000885.tgz",
-      "integrity": "sha512-cXKbYwpxBLd7qHyej16JazPoUacqoVuDhvR61U7Fr5vSxMUiodzcYa1rQYRYfZ5GexV03vGZHd722vNPLjPJGQ=="
+      "version": "1.0.30000886",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000886.tgz",
+      "integrity": "sha512-xpYuY7rqc5+4q1n/l1BfSgIndaNqvXWKZ0Vk0ZXzVncCAkn0+huvIIPwcSL5YRJoW4MSRsgyNbjnKuh45GmknA=="
     },
     "capture-exit": {
       "version": "1.2.0",
@@ -6302,13 +6302,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6321,18 +6319,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6435,8 +6430,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6446,7 +6440,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6459,20 +6452,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6489,7 +6479,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6562,8 +6551,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6573,7 +6561,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6679,7 +6666,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7210,8 +7196,7 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-      "dev": true
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -8124,9 +8109,12 @@
       }
     },
     "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -9716,9 +9704,9 @@
       }
     },
     "loader-runner": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
-      "integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.1.tgz",
+      "integrity": "sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw=="
     },
     "loader-utils": {
       "version": "1.1.0",
@@ -10208,9 +10196,8 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "mini-css-extract-plugin-with-rtl": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin-with-rtl/-/mini-css-extract-plugin-with-rtl-0.1.3.tgz",
-      "integrity": "sha512-BjDTi1wITedXfeSRVFhm3uv/5RlyuuktJqWEJGBzrTdxIK7FpSydcY0zHVT9AeMMki/84JjZ9smP45jzTsBmXw==",
+      "version": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300db7027af8caa9a3015f54a34aec545cc54",
+      "from": "github:Automattic/mini-css-extract-plugin-with-rtl",
       "requires": {
         "loader-utils": "^1.1.0",
         "schema-utils": "^1.0.0",
@@ -15206,7 +15193,7 @@
     },
     "reduce-css-calc": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "requires": {
         "balanced-match": "^0.4.2",
@@ -18220,17 +18207,17 @@
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
     },
     "unique-filename": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
-      "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "requires": {
         "unique-slug": "^2.0.0"
       }
     },
     "unique-slug": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
-      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
+      "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
       "requires": {
         "imurmurhash": "^0.1.4"
       }

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "lru": "3.1.0",
     "lunr": "2.3.3",
     "marked": "0.5.0",
-    "mini-css-extract-plugin-with-rtl": "0.1.3",
+    "mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl",
     "mkdirp": "0.5.1",
     "moment": "2.22.2",
     "morgan": "1.9.1",


### PR DESCRIPTION
**Latest status:**
This PR evolved from something that was a proof of concept into a finished production-ready PR. See https://github.com/Automattic/wp-calypso/pull/26820#issuecomment-422809086 for more info about the final state of things.

**Original description from the proof-of-concept era:**
This is a proof of concept of migrating the CSS build pipeline to Webpack. Moves a few components' styles to `import './style.scss'` in the JS module, and makes sure that the CSS is built with Webpack and the stylesheets are included in the server-generated index.html on initial load.

Code splitting also seems to work very well: Webpack automatically creates CSS chunks for async-loaded sections and loads the stylesheets together with scripts when loading the section. Our custom code for "sections CSS" can be eventually removed.

See individual commit messages for details.

Largest missing piece is **support for RTL**. Completely ignored at the moment. I'm afraid we'll need to write a custom Webpack plugin, a nontrivial one, to make it work as we need it:
- generate both LTR and RTL versions of each CSS asset
- choose the right stylesheet on initial load
- load the right stylesheet when async-loading a section

If we wanted to do a gradual migration and keep both CSS pipelines in place for some time, there is one gotcha I discovered that makes this very fragile: we have some CSS rules where specificity is determined by rule order and nothing else. Example:
```css
.button {
  font-weight: bold;
}
.header-button {
  font-weight: normal;
}
```
```html
<button class="button header-button">
```
What is the resulting `font-weight` of the button? It depends on the order of the rules. The last one wins. It's very easy to break this when moving stylesheets around, as the order can change. 

Another todo: patch the other index files in `client/document` (desktop, browsehappy, support-user) to also include links to the right stylesheets.

**How to test:**
Run Calypso both in debug (`npm run start`) and production (`CALYPSO_ENV=production npm run build`) modes and verify that all stylesheets are loaded as expected.