### PR TITLE
Gutenberg: prevent tips from showing when editor loads

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -5,6 +5,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { isEmpty, noop } from 'lodash';
+import { dispatch } from '@wordpress/data';
 import '@wordpress/core-data'; // Initializes core data store
 import { registerCoreBlocks } from '@wordpress/block-library';
 
@@ -26,6 +27,8 @@ const post = {
 class GutenbergEditor extends Component {
 	componentDidMount() {
 		registerCoreBlocks();
+		// Prevent Guided tour from showing when editor loads.
+		dispatch( 'core/nux' ).disableTips();
 	}
 
 	render() {


### PR DESCRIPTION
Temporarily suppresses the guided tour when editor loads to stop flooding the screen with multiple tips at once.

### Testing instructions
1. Navigate to `/gutenberg/post/{siteSlug}`.
2. Verify that no Guided tour tips are shown when editor loads.