### PR TITLE
Jetpack Connect: Add additional tracking properties to the store landing page

### DIFF
--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -40,8 +40,11 @@ class PlansLanding extends Component {
 	};
 
 	componentDidMount() {
+		const { cta_id, cta_from } = this.props.context.query;
 		this.props.recordTracksEvent( 'calypso_jpc_plans_landing_view', {
 			jpc_from: 'jetpack',
+			cta_id: cta_id,
+			cta_from: cta_from,
 		} );
 
 		this.goToPlansIfAlreadyConnected();

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -43,8 +43,8 @@ class PlansLanding extends Component {
 		const { cta_id, cta_from } = this.props.context.query;
 		this.props.recordTracksEvent( 'calypso_jpc_plans_landing_view', {
 			jpc_from: 'jetpack',
-			cta_id: cta_id,
-			cta_from: cta_from,
+			cta_id,
+			cta_from,
 		} );
 
 		this.goToPlansIfAlreadyConnected();


### PR DESCRIPTION
This change allows us to include some CTA-related query args in the URL
of the store landing page and properly send them with the tracking
event that fires when the page is loaded. This will allow us to better
source conversions and better understand the origin of customers from
around jetpack.com.

Test Plan:
* Load the following URL: http://calypso.localhost:3000/jetpack/connect/store?cta_id=thisIsTheCtaID&cta_from=thisIsTheCtaFrom
* Confirm that the page loads without incident.
* Confirm that the tracking event fires, as expected, and pulls the appropriate values from the customized URL.