### PR TITLE
State: Stop persisting premium plugin key

### DIFF
--- a/client/state/plugins/premium/reducer.js
+++ b/client/state/plugins/premium/reducer.js
@@ -3,8 +3,7 @@
 /**
  * External dependencies
  */
-
-import { mapValues } from 'lodash';
+import { mapValues, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -76,7 +75,7 @@ export function plugins( state = {}, action ) {
 					if ( item.error !== null ) {
 						return Object.assign( {}, item, { error: item.error.toString() } );
 					}
-					return item;
+					return omit( item, 'key' );
 				} )
 			);
 		default:

--- a/client/state/plugins/premium/schema.js
+++ b/client/state/plugins/premium/schema.js
@@ -6,13 +6,17 @@ export const pluginInstructionSchema = {
 		'^[0-9]+$': {
 			type: 'array',
 			items: {
-				required: [ 'slug', 'key' ],
+				required: [ 'slug' ],
 				properties: {
 					name: { type: 'string' },
 					slug: { type: 'string' },
-					key: { type: 'string' },
 					status: { type: 'string' },
 					error: { type: [ 'object', 'string', 'null' ] },
+
+					/* Invalidate state if the key has been persisted */
+					key: {
+						type: 'null',
+					},
 				},
 			},
 		},

--- a/client/state/plugins/premium/test/reducer.js
+++ b/client/state/plugins/premium/test/reducer.js
@@ -193,7 +193,7 @@ describe( 'premium reducer', () => {
 			expect( state ).to.eql( { 'one.site': siteWithError } );
 		} );
 
-		test( 'should serialize non-error state using identity function', () => {
+		test( 'should serialize non-error state omitting the key', () => {
 			const originalState = deepFreeze( {
 				'one.site': [
 					{
@@ -207,7 +207,17 @@ describe( 'premium reducer', () => {
 			} );
 
 			const nextState = plugins( originalState, { type: SERIALIZE } );
-			expect( nextState ).eql( originalState );
+			expect( nextState ).to.deep.eql( {
+				'one.site': [
+					{
+						slug: 'vaultpress',
+						name: 'VaultPress',
+						/* key is ommited: (key: 'vp-api-key',) */
+						status: 'done',
+						error: null,
+					},
+				],
+			} );
 		} );
 
 		test( 'should serialize just the error for errored plugins', () => {


### PR DESCRIPTION
See #26810 for prompting discussion.

## Testing instructions

- Jetpack site with a plan purchased
- Navigate to purchase from `/me/purchases`
- Look at `state.plugins.premium.plugins`
- There should be `key`s on the plugins (VaultPress + Akismet)
- Check indexedDB at same place, verify no key is persisted