### PR TITLE
PlanSetup: Remove bad semi-colon

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -549,7 +549,7 @@ class PlansSetup extends React.Component {
 
 		return (
 			<div className="jetpack-plugins-setup">
-				<PageViewTracker path="/plugins/setup/:site" title="Jetpack Plugins Setup" />;
+				<PageViewTracker path="/plugins/setup/:site" title="Jetpack Plugins Setup" />
 				<QueryPluginKeys siteId={ site.ID } />
 				<h1 className="jetpack-plugins-setup__header">
 					{ translate( 'Setting up your %(plan)s Plan', {


### PR DESCRIPTION
Remove a bad `;` from the rendered output of plan set up at `/plugins/setup/SITE_SLUG`

## Screens

### Before

<img width="766" alt="semi" src="https://user-images.githubusercontent.com/841763/44494854-7d48bb80-a63b-11e8-84e9-6503b5065bc3.png">

### After

<img width="751" alt="nope" src="https://user-images.githubusercontent.com/841763/44494871-93ef1280-a63b-11e8-92a8-c3418a19c508.png">

## Testing
- Visit https://calypso.live/plugins/setup/SITE_SLUG?branch=fix/remove-bad-semicolon for a Jetpack site on a paid plan.
- Observe no semi-colon
- Page is functionally identical