### PR TITLE
Docs: Fix typos in Card Heading README

### DIFF
--- a/client/components/card-heading/README.md
+++ b/client/components/card-heading/README.md
@@ -1,7 +1,7 @@
 CardHeading (JSX)
 =====================
 
-This component displays a heading for a <Card>
+This component displays a heading for a `<Card>`
 
 #### How to use:
 
@@ -11,7 +11,7 @@ import CardHeading from 'components/card-heading';
 render() {
 	return (
 		<CardHeading
-			tagName={ <h1 /> }
+			tagName="h1"
 			size={ 21 }
 		>
 			Put your heading text here


### PR DESCRIPTION
* Argument type is wrong (you need to pass a string, passing a tag as in this example results in an error)
* Need to put the tag Card in backticks so it displays, right now it looks like this:

![screen shot 2018-08-22 at 15 35 22](https://user-images.githubusercontent.com/52152/44494590-35b53600-a621-11e8-84d5-8abff0858af8.png)

Testing:
* Visit https://calypso.live/devdocs/client/components/card-heading/README.md?branch=fix%2Fcard-heading-doc-typos and verify that the page now reads correctly and has the correct example code.