### PR TITLE
Fix #26839: Update popup copy from `3 mins` to `30 mins`

### DIFF
--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -188,7 +188,7 @@ class StatsDatePicker extends Component {
 											position="bottom"
 											context={ this.statusIndicator }
 										>
-											{ translate( 'Auto-refreshing every 3 minutes' ) }
+											{ translate( 'Auto-refreshing every 30 minutes' ) }
 										</Tooltip>
 									</span>
 								</div>


### PR DESCRIPTION
<img width="238" alt="screen shot 2018-08-23 at 09 41 36" src="https://user-images.githubusercontent.com/1145270/44518051-cb4fd480-a6b8-11e8-93c9-6b4de975f653.png">

Simple copy fix after the polling reduction introduced in p10gg3-8Lb-p2