### PR TITLE
Experiment: Async loaded reducers

### DIFF
--- a/client/components/async-load/README.md
+++ b/client/components/async-load/README.md
@@ -15,6 +15,8 @@ Depending on the environment configuration, this will be transformed automatical
 
 See [`babel-plugin-transform-wpcalypso-async` documentation](https://github.com/Automattic/babel-plugin-transform-wpcalypso-async) for more information.
 
+Optionally, if you're loading a module that should not be rendered, you can use the `callback` method to define what to do when the module is loaded.
+
 ## Props
 
 The following props can be passed to the AsyncLoad component:
@@ -23,3 +25,4 @@ The following props can be passed to the AsyncLoad component:
 | ------------- | ----------------- | -------- | ------- |
 | `require`     | String (Function) | yes      | In general usage, this should be passed as a string of the module to be imported. During build, the string prop is [transformed to a function](https://github.com/Automattic/wp-calypso/tree/master/server/bundler/babel/babel-plugin-transform-wpcalypso-async) which is called to require the specified module. |
 | `placeholder` | PropTypes.node    | no       | A placeholder to be shown while the module is being asynchronously required. If omitted, a default placeholder will be shown. If `null` is provided, then no placeholder is shown. |
+| `callback`    | PropTypes.func    | no       | A callback function to be invoked when the module is loaded. Used for asynchronously loaded modules that are not intended be rendered.

--- a/client/components/async-load/index.jsx
+++ b/client/components/async-load/index.jsx
@@ -12,6 +12,7 @@ export default class AsyncLoad extends Component {
 	static propTypes = {
 		placeholder: PropTypes.node,
 		require: PropTypes.func.isRequired,
+		callback: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -56,6 +57,11 @@ export default class AsyncLoad extends Component {
 	}
 
 	render() {
+		if ( this.props.callback && this.state.component ) {
+			this.props.callback( this.state.component );
+			return null;
+		}
+
 		if ( this.state.component ) {
 			const props = omit( this.props, [ 'placeholder', 'require' ] );
 

--- a/client/components/async-load/index.jsx
+++ b/client/components/async-load/index.jsx
@@ -61,7 +61,7 @@ export default class AsyncLoad extends Component {
 	}
 
 	render() {
-		if ( this.props.callback && this.state.component ) {
+		if ( this.props.callback ) {
 			return null;
 		}
 

--- a/client/components/async-load/index.jsx
+++ b/client/components/async-load/index.jsx
@@ -44,6 +44,10 @@ export default class AsyncLoad extends Component {
 		if ( this.props.require !== prevProps.require ) {
 			this.require();
 		}
+
+		if ( this.props.callback && this.state.component ) {
+			this.props.callback( this.state.component );
+		}
 	}
 
 	require() {
@@ -58,7 +62,6 @@ export default class AsyncLoad extends Component {
 
 	render() {
 		if ( this.props.callback && this.state.component ) {
-			this.props.callback( this.state.component );
 			return null;
 		}
 

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -18,6 +18,7 @@ import accountPasswordData from 'lib/account-password-data';
 import SocialLoginComponent from 'me/social-login';
 import ConnectedAppsComponent from 'me/connected-applications';
 import AccountRecoveryComponent from 'me/security-account-recovery';
+import { requireReducer } from 'state';
 
 export function password( context, next ) {
 	if ( context.query && context.query.updated === 'password' ) {
@@ -47,6 +48,10 @@ export function twoStep( context, next ) {
 }
 
 export function connectedApplications( context, next ) {
+	asyncRequire( 'state/connected-applications/reducer', reducer => {
+		requireReducer( context.store, 'connectedApplications', reducer );
+	} );
+
 	context.primary = React.createElement( ConnectedAppsComponent, {
 		userSettings: userSettings,
 		path: context.path,

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -54,7 +54,6 @@ export function connectedApplications( context, next ) {
 			<AsyncLoad
 				require="state/connected-applications/reducer"
 				callback={ reducer => requireReducer( context.store, 'connectedApplications', reducer ) }
-				placeholder={ null }
 			/>
 			<ConnectedAppsComponent userSettings={ userSettings } path={ context.path } />
 		</>

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -54,6 +54,7 @@ export function connectedApplications( context, next ) {
 			<AsyncLoad
 				require="state/connected-applications/reducer"
 				callback={ reducer => requireReducer( context.store, 'connectedApplications', reducer ) }
+				placeholder={ null }
 			/>
 			<ConnectedAppsComponent userSettings={ userSettings } path={ context.path } />
 		</>

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -18,6 +18,7 @@ import accountPasswordData from 'lib/account-password-data';
 import SocialLoginComponent from 'me/social-login';
 import ConnectedAppsComponent from 'me/connected-applications';
 import AccountRecoveryComponent from 'me/security-account-recovery';
+import AsyncLoad from 'components/async-load';
 import { requireReducer } from 'state';
 
 export function password( context, next ) {
@@ -48,14 +49,16 @@ export function twoStep( context, next ) {
 }
 
 export function connectedApplications( context, next ) {
-	asyncRequire( 'state/connected-applications/reducer', reducer => {
-		requireReducer( context.store, 'connectedApplications', reducer );
-	} );
+	context.primary = (
+		<>
+			<AsyncLoad
+				require="state/connected-applications/reducer"
+				callback={ reducer => requireReducer( context.store, 'connectedApplications', reducer ) }
+			/>
+			<ConnectedAppsComponent userSettings={ userSettings } path={ context.path } />
+		</>
+	);
 
-	context.primary = React.createElement( ConnectedAppsComponent, {
-		userSettings: userSettings,
-		path: context.path,
-	} );
 	next();
 }
 

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -31,7 +31,6 @@ import checklist from './checklist/reducer';
 import comments from './comments/reducer';
 import componentsUsageStats from './components-usage-stats/reducer';
 import concierge from './concierge/reducer';
-import connectedApplications from './connected-applications/reducer';
 import consoleDispatcher from './console-dispatch';
 import countries from './countries/reducer';
 import countryStates from './country-states/reducer';
@@ -126,7 +125,6 @@ const reducers = {
 	comments,
 	componentsUsageStats,
 	concierge,
-	connectedApplications,
 	countries,
 	countryStates,
 	currentUser,

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -248,3 +248,18 @@ export function createReduxStore( initialState = {} ) {
 
 	return compose( ...enhancers )( createStore )( reducer, initialState );
 }
+
+export const createAsyncReducer = asyncReducers =>
+	combineReducers( {
+		...reducers,
+		...asyncReducers,
+	} );
+
+export const requireReducer = ( store, name, asyncReducer ) => {
+	if ( ! store.asyncReducers ) {
+		store.asyncReducers = {};
+	}
+
+	store.asyncReducers[ name ] = asyncReducer;
+	store.replaceReducer( createAsyncReducer( store.asyncReducers ) );
+};


### PR DESCRIPTION
This is an experimental PR to demonstrate how we can asynchronously load reducers from within the section we need them in. This allows us to remove non-essential reducers from the main build, making it lighter and faster to load. 

For demonstration purposes, I've decided to use the small reducer of a section that we recently reduxified - connected applications (`/me/security/connected-applications`). Some reducers would be more coupled to the entire app, and therefore would have to be required in more sections - this one is not one of them. 

For the purpose of keeping it simple, this PR uses the already existing `<AsyncLoad />` to asynchronously load the reducer. If we decide to go with this approach or a similar one, we could implement a special `<AsyncLoadReducer />` component to make it easier to require reducers everywhere without much pain. For the purpose we could build a babel plugin similar to `babel-plugin-transform-wpcalypso-async` to handle all the necessary transformations.

On the state side, the PR introduces a simple mechanism for injecting additional reducers that we load asynchronously to an already existing reducer.

This currently lacks tests, and could generally be improved to be better from the developer experience perspective. FWIW, this is an experiment to improve the current monolithic state situation, which might not be a problem if we start refactoring our state to use `wp.data`.

I'd love to hear some feedback and opinions about this approach.

Testing is straightforward:
* Load Calypso
* Load any section (like Reader `/`) for example.
* Verify the `state.connectedApplications` tree is missing.
* Head to `/me/security/connected-applications`.
* Verify the section loads and the reducer (`async-load-state-connected-applications-reducer`) loads.
* Verify you now have the `state.connectedApplications` state tree.
* Verify the page works like it did before.