### PR TITLE
Track free plan conversions in Google Analytics and AdWords (minus Tracks event props).

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -94,6 +94,10 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 		facebookJetpackInit: '919484458159593',
 		googleConversionLabel: 'MznpCMGHr2MQ1uXz_AM',
 		googleConversionLabelJetpack: '0fwbCL35xGIQqv3svgM',
+		googleFreeSignupConversionId: '1067250390',
+		googleFreeSignupConversionLabel: 'zKK-CKPG7ocBENbl8_wD',
+		googleFreeSignupConversionIdJetpack: '937115306',
+		googleFreeSignupConversionLabelJetpack: 'J8Z5CNTi14cBEKr97L4D',
 		criteo: '31321',
 		quantcast: 'p-3Ma3jHaQMB_bS',
 		yahooProjectId: '10000',
@@ -678,6 +682,47 @@ export function recordViewCheckout( cart ) {
 }
 
 /**
+ * Tracks a free signup conversion by generating a
+ * synthetic cart and then treating it like any other order.
+ *
+ * @param {String} slug - Signup slug.
+ * @returns {void}
+ */
+export function recordFreeSignup( slug ) {
+	if ( ! isAdTrackingAllowed() ) {
+		debug( 'recordFreeSignup: skipping as ad tracking is disallowed' );
+		return;
+	}
+
+	if ( ! hasStartedFetchingScripts ) {
+		return loadTrackingScripts( recordFreeSignup.bind( null, slug ) );
+	}
+
+	// Synthesize a cart object for free signup tracking.
+	const syntheticCart = {
+		is_free_signup: true,
+		currency: 'USD',
+		total_cost: 0,
+		products: [
+			{
+				is_free_signup: true,
+				product_id: slug,
+				product_slug: slug,
+				product_name: slug,
+				currency: 'USD',
+				volume: 1,
+				cost: 0,
+			},
+		],
+	};
+
+	// 35-byte free signup tracking ID.
+	const syntheticOrderId = 'fs_' + uuid().replace( /-/g, '' );
+
+	recordOrder( syntheticCart, syntheticOrderId );
+}
+
+/**
  * Tracks a purchase conversion
  *
  * @param {Object} cart - cart as `CartValue` object
@@ -721,25 +766,25 @@ export function recordOrder( cart, orderId ) {
 	// 3. Fire a single tracking event without any details about what was purchased
 
 	// Experian / One 2 One Media
-	if ( isExperianEnabled ) {
+	if ( isExperianEnabled && ! cart.is_free_signup ) {
 		new Image().src = EXPERIAN_CONVERSION_PIXEL_URL;
 	}
 
 	// Yahoo Gemini
-	if ( isGeminiEnabled ) {
+	if ( isGeminiEnabled && ! cart.is_free_signup ) {
 		new Image().src =
 			YAHOO_GEMINI_CONVERSION_PIXEL_URL + ( usdTotalCost !== null ? '&gv=' + usdTotalCost : '' );
 	}
 
-	if ( isAolEnabled ) {
+	if ( isAolEnabled && ! cart.is_free_signup ) {
 		new Image().src = ONE_BY_AOL_CONVERSION_PIXEL_URL;
 	}
 
-	if ( isPandoraEnabled ) {
+	if ( isPandoraEnabled && ! cart.is_free_signup ) {
 		new Image().src = PANDORA_CONVERSION_PIXEL_URL;
 	}
 
-	if ( isQuoraEnabled ) {
+	if ( isQuoraEnabled && ! cart.is_free_signup ) {
 		window.qp( 'track', 'Generic' );
 	}
 }
@@ -787,28 +832,47 @@ function recordProduct( product, orderId ) {
 		// Google AdWords
 		if ( isAdwordsEnabled ) {
 			if ( window.google_trackConversion ) {
-				window.google_trackConversion( {
-					google_conversion_id: isJetpackPlan
-						? ADWORDS_CONVERSION_ID_JETPACK
-						: ADWORDS_CONVERSION_ID,
-					google_conversion_label: isJetpackPlan
-						? TRACKING_IDS.googleConversionLabelJetpack
-						: TRACKING_IDS.googleConversionLabel,
-					google_conversion_value: product.cost,
-					google_conversion_currency: product.currency,
-					google_custom_params: {
-						product_slug: product.product_slug,
-						user_id: userId,
-						order_id: orderId,
-					},
-					google_remarketing_only: false,
-				} );
+				if ( product.is_free_signup ) {
+					window.google_trackConversion( {
+						google_conversion_id: isJetpackPlan
+							? TRACKING_IDS.googleFreeSignupConversionIdJetpack
+							: TRACKING_IDS.googleFreeSignupConversionId,
+						google_conversion_label: isJetpackPlan
+							? TRACKING_IDS.googleFreeSignupConversionLabelJetpack
+							: TRACKING_IDS.googleFreeSignupConversionLabel,
+						google_conversion_value: product.cost,
+						google_conversion_currency: product.currency,
+						google_custom_params: {
+							product_slug: product.product_slug,
+							user_id: userId,
+							order_id: orderId,
+						},
+						google_remarketing_only: false,
+					} );
+				} else {
+					window.google_trackConversion( {
+						google_conversion_id: isJetpackPlan
+							? ADWORDS_CONVERSION_ID_JETPACK
+							: ADWORDS_CONVERSION_ID,
+						google_conversion_label: isJetpackPlan
+							? TRACKING_IDS.googleConversionLabelJetpack
+							: TRACKING_IDS.googleConversionLabel,
+						google_conversion_value: product.cost,
+						google_conversion_currency: product.currency,
+						google_custom_params: {
+							product_slug: product.product_slug,
+							user_id: userId,
+							order_id: orderId,
+						},
+						google_remarketing_only: false,
+					} );
+				}
 			}
 		}
 
 		// Facebook (disabled for now as we are not sure this works as intended).
 		// The entire order is already reported to Facebook, so not absolutely necessary.
-		/* if ( isFacebookEnabled ) {
+		/* if ( isFacebookEnabled && ! product.is_free_signup ) {
 			window.fbq(
 				'trackSingle',
 				isJetpackPlan ? TRACKING_IDS.facebookJetpackInit : TRACKING_IDS.facebookInit,
@@ -824,7 +888,7 @@ function recordProduct( product, orderId ) {
 		} */
 
 		// Twitter
-		if ( isTwitterEnabled ) {
+		if ( isTwitterEnabled && ! product.is_free_signup ) {
 			window.twq( 'track', 'Purchase', {
 				value: product.cost.toString(),
 				currency: product.currency,
@@ -837,7 +901,7 @@ function recordProduct( product, orderId ) {
 		}
 
 		// Yandex Goal
-		if ( isYandexEnabled ) {
+		if ( isYandexEnabled && ! product.is_free_signup ) {
 			window.yaCounter45268389.reachGoal( 'ProductPurchase', {
 				order_id: orderId,
 				product_slug: product.product_slug,
@@ -850,7 +914,7 @@ function recordProduct( product, orderId ) {
 			const costUSD = costToUSD( product.cost, product.currency );
 
 			// Bing
-			if ( isBingEnabled ) {
+			if ( isBingEnabled && ! product.is_free_signup ) {
 				const bingParams = {
 					ec: 'purchase',
 					gv: costUSD,
@@ -863,7 +927,7 @@ function recordProduct( product, orderId ) {
 			}
 
 			// Quantcast
-			if ( isQuantcastEnabled ) {
+			if ( isQuantcastEnabled && ! product.is_free_signup ) {
 				// Note that all properties have to be strings or they won't get tracked
 				window._qevents.push( {
 					qacct: TRACKING_IDS.quantcast,
@@ -875,7 +939,7 @@ function recordProduct( product, orderId ) {
 			}
 
 			// Yahoo
-			if ( isYahooEnabled ) {
+			if ( isYahooEnabled && ! product.is_free_signup ) {
 				// Like the Quantcast tracking above, the price has to be passed as a string
 				// See: https://developer.yahoo.com/gemini/guide/dottags/installing-tags/
 				/*global YAHOO*/
@@ -913,6 +977,10 @@ function recordOrderInFloodlight( cart, orderId ) {
 		return;
 	}
 
+	if ( cart.is_free_signup ) {
+		return;
+	}
+
 	debug( 'recordOrderInFloodlight: Record purchase' );
 
 	const params = {
@@ -938,6 +1006,10 @@ function recordOrderInFloodlight( cart, orderId ) {
  */
 function recordOrderInNanigans( cart, orderId ) {
 	if ( ! isAdTrackingAllowed() || ! isNanigansEnabled ) {
+		return;
+	}
+
+	if ( cart.is_free_signup ) {
 		return;
 	}
 
@@ -983,6 +1055,10 @@ function recordOrderInNanigans( cart, orderId ) {
  */
 function recordOrderInFacebook( cart, orderId ) {
 	if ( ! isAdTrackingAllowed() || ! isFacebookEnabled ) {
+		return;
+	}
+
+	if ( cart.is_free_signup ) {
 		return;
 	}
 
@@ -1259,6 +1335,10 @@ function recordOrderInCriteo( cart, orderId ) {
 		return;
 	}
 
+	if ( cart.is_free_signup ) {
+		return;
+	}
+
 	recordInCriteo( 'trackTransaction', {
 		id: orderId,
 		currency: cart.currency,
@@ -1274,6 +1354,10 @@ function recordOrderInCriteo( cart, orderId ) {
  */
 function recordViewCheckoutInCriteo( cart ) {
 	if ( ! isAdTrackingAllowed() || ! isCriteoEnabled ) {
+		return;
+	}
+
+	if ( cart.is_free_signup ) {
 		return;
 	}
 
@@ -1494,10 +1578,16 @@ export function recordSignupStart() {
 /**
  * Record that a user completed sign up
  *
+ * @param {object} details Signup details.
+ *
  * @returns {void}
  */
-export function recordSignupCompletion() {
+export function recordSignupCompletion( { isNewUser, isNewSite, hasCartItems } ) {
 	recordSignupCompletionInFloodlight();
+
+	if ( isNewUser && isNewSite && ! hasCartItems ) {
+		recordFreeSignup( 'free-plan' );
+	}
 }
 
 export function retarget( context, next ) {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -288,8 +288,15 @@ class Signup extends React.Component {
 	handleFlowComplete = ( dependencies, destination ) => {
 		debug( 'The flow is completed. Destination: %s', destination );
 
+		const isNewUser = !! ( dependencies && dependencies.username );
+		const isNewSite = !! ( dependencies && dependencies.siteSlug );
+		const hasCartItems = !! (
+			dependencies &&
+			( dependencies.cartItem || dependencies.domainItem || dependencies.themeItem )
+		);
+
 		analytics.tracks.recordEvent( 'calypso_signup_complete', { flow: this.props.flowName } );
-		recordSignupCompletion();
+		recordSignupCompletion( { isNewUser, isNewSite, hasCartItems } );
 
 		if (
 			dependencies.cartItem ||


### PR DESCRIPTION
A fork of https://github.com/Automattic/wp-calypso/pull/26836 that is the same, except it excludes the new Tracks props; only passing the details required for tracking conversions in the analytics lib.