### PR TITLE
Store: Hide scrollbars from Dashboard inventory alerts

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
@@ -4,7 +4,7 @@
 		align-items: normal;
 
 		.dashboard-widget__children {
-			overflow: scroll;
+			overflow: auto;
 			max-height: 190px;
 
 			@include breakpoint( "<660px" ) {


### PR DESCRIPTION
There were unnecessary scrollbars appearing in the inventory alerts of the Store Dashboard when there were no products to display or the list was short. This PR hides the scrollbars in those cases.

Before:
![image](https://user-images.githubusercontent.com/3616980/44530740-682d6480-a6ef-11e8-8c72-9dca980836a8.png)


After:
![image](https://user-images.githubusercontent.com/3616980/44530668-43d18800-a6ef-11e8-96eb-1f436444b4c2.png)

When there are enough products to make the list not to fit in the available space, the scrollbar appears as usual:
![image](https://user-images.githubusercontent.com/3616980/44533107-1556ab80-a6f5-11e8-8e45-a51277ef5b05.png)


Fixes #26805.