### PR TITLE
MiniSitePreview: Give component fetch responsibility

### DIFF
--- a/client/components/mini-site-preview/index.jsx
+++ b/client/components/mini-site-preview/index.jsx
@@ -2,23 +2,89 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { invoke } from 'lodash';
 
-const MiniSitePreview = ( { imageSrc } ) =>
-	imageSrc ? (
-		<div className="mini-site-preview">
-			<div className="mini-site-preview__browser-chrome">
-				<span>● ● ●</span>
+/**
+ * Internal dependencies
+ */
+import { loadmShotsPreview } from 'my-sites/importer/site-importer/site-preview-actions';
+
+export class MiniSitePreviewWrapper extends Component {
+	static propTypes = {
+		siteURL: PropTypes.string.isRequired,
+		onFetchSuccess: PropTypes.func,
+		onFetchError: PropTypes.func,
+	};
+
+	state = {
+		previewRetries: 0,
+		siteURL: this.props.siteURL,
+		sitePreviewImage: '',
+		sitePreviewFailed: false,
+		loadingPreviewImage: true,
+	};
+
+	componentDidMount() {
+		this.loadSitePreview();
+	}
+
+	loadSitePreview = () => {
+		this.setState( { loadingPreviewImage: true, previewStartTime: Date.now() } );
+
+		loadmShotsPreview( {
+			url: this.props.siteURL,
+			maxRetries: 30,
+			retryTimeout: 1000,
+		} )
+			.then( imageBlob => {
+				this.setState( {
+					loadingPreviewImage: false,
+					sitePreviewImage: imageBlob,
+					sitePreviewFailed: false,
+				} );
+
+				invoke( this.props, 'onFetchSuccess', {
+					time_taken_ms: Date.now() - this.state.previewStartTime,
+				} );
+			} )
+			.catch( () => {
+				this.setState( {
+					loadingPreviewImage: false,
+					sitePreviewImage: '',
+					sitePreviewFailed: true,
+				} );
+
+				invoke( this.props, 'onFetchError', {
+					time_taken_ms: Date.now() - this.state.previewStartTime,
+				} );
+			} );
+	};
+
+	render() {
+		const { sitePreviewImage, loadingPreviewImage } = this.state;
+
+		// TODO: Handle error cases
+		return (
+			<div className="mini-site-preview">
+				<div className="mini-site-preview__browser-chrome">
+					<span>● ● ●</span>
+				</div>
+				{ loadingPreviewImage ? (
+					<div className="mini-site-preview__image placeholder" />
+				) : (
+					<div className="mini-site-preview__image">
+						<img
+							className="mini-site-preview__favicon"
+							src={ sitePreviewImage }
+							alt="Site favicon"
+						/>
+					</div>
+				) }
 			</div>
-			<div className="mini-site-preview__image">
-				<img className="mini-site-preview__favicon" src={ imageSrc } alt="Site favicon" />
-			</div>
-		</div>
-	) : null;
+		);
+	}
+}
 
-MiniSitePreview.propTypes = {
-	imageSrc: PropTypes.string,
-};
-
-export default MiniSitePreview;
+export default MiniSitePreviewWrapper;

--- a/client/components/mini-site-preview/index.jsx
+++ b/client/components/mini-site-preview/index.jsx
@@ -11,7 +11,7 @@ import { invoke } from 'lodash';
  */
 import { loadmShotsPreview } from 'my-sites/importer/site-importer/site-preview-actions';
 
-export class MiniSitePreviewWrapper extends Component {
+export class MiniSitePreview extends Component {
 	static propTypes = {
 		siteURL: PropTypes.string.isRequired,
 		onFetchSuccess: PropTypes.func,
@@ -87,4 +87,4 @@ export class MiniSitePreviewWrapper extends Component {
 	}
 }
 
-export default MiniSitePreviewWrapper;
+export default MiniSitePreview;

--- a/client/components/mini-site-preview/style.scss
+++ b/client/components/mini-site-preview/style.scss
@@ -1,5 +1,6 @@
 .mini-site-preview {
 	max-width: 60%;
+	width: 100%;
 
 	.mini-site-preview__browser-chrome {
 		flex-grow: 0;
@@ -25,6 +26,7 @@
 
 	.mini-site-preview__image {
 		border: 1px solid #c6d7e2;
+		box-sizing: border-box;
 
 		&:after {
 			content: '';
@@ -39,6 +41,12 @@
 				rgba( 255, 255, 255, 0 ) 50%,
 				rgba( 255, 255, 255, 1 )
 			);
+		}
+
+		&.placeholder {
+			padding-top: 60%;
+			animation: pulse-light 800ms ease-in-out infinite;
+			background: transparentize( $gray-lighten-20, .5 );
 		}
 	}
 

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -68,6 +68,7 @@ class SiteImporterInputPane extends React.Component {
 		siteURLInput: '',
 		selectedEndpoint: '',
 		availableEndpoints: [],
+		importStarted: false,
 	};
 
 	componentWillMount = () => {
@@ -282,6 +283,9 @@ class SiteImporterInputPane extends React.Component {
 	importSite = () => {
 		this.setState( {
 			loading: true,
+			// This is a lick of duct-tape to avoid re-mounting
+			// the site-preview component (as that would double up analytics)
+			importStarted: true,
 			...NO_ERROR_STATE,
 		} );
 
@@ -372,6 +376,8 @@ class SiteImporterInputPane extends React.Component {
 	};
 
 	render() {
+		const { importStarted } = this.state;
+
 		return (
 			<div className="site-importer__site-importer-pane">
 				{ this.state.importStage === 'idle' && (
@@ -411,18 +417,19 @@ class SiteImporterInputPane extends React.Component {
 						) }
 					</div>
 				) }
-				{ this.state.importStage === 'importable' && (
-					<div className="site-importer__site-importer-confirm-site-pane">
-						<SiteImporterSitePreview
-							siteURL={ this.state.importSiteURL }
-							importData={ this.state.importData }
-							isLoading={ this.state.loading }
-							resetImport={ this.resetImport }
-							startImport={ this.importSite }
-							site={ this.props.site }
-						/>
-					</div>
-				) }
+				{ this.state.importStage === 'importable' &&
+					! ( importStarted && ! this.state.loading ) && (
+						<div className="site-importer__site-importer-confirm-site-pane">
+							<SiteImporterSitePreview
+								siteURL={ this.state.importSiteURL }
+								importData={ this.state.importData }
+								isLoading={ this.state.loading }
+								resetImport={ this.resetImport }
+								startImport={ this.importSite }
+								site={ this.props.site }
+							/>
+						</div>
+					) }
 				{ this.state.error && (
 					<ErrorPane
 						type={ this.state.errorType || 'importError' }

--- a/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
@@ -16,7 +16,6 @@ import Button from 'components/forms/form-button';
 import MiniSitePreview from 'components/mini-site-preview';
 import ErrorPane from 'my-sites/importer/error-pane';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { loadmShotsPreview } from 'my-sites/importer/site-importer/site-preview-actions';
 import ImportableContent from 'my-sites/importer/site-importer/site-importer-importable-content';
 
 class SiteImporterSitePreview extends React.Component {
@@ -30,56 +29,25 @@ class SiteImporterSitePreview extends React.Component {
 	};
 
 	state = {
-		previewRetries: 0,
 		siteURL: this.props.siteURL,
-		sitePreviewImage: '',
-		sitePreviewFailed: false,
-		loadingPreviewImage: true,
 	};
 
-	componentDidMount() {
-		// TODO: We might want to move this state handling to redux.
-		this.loadSitePreview();
-	}
+	trackSitePreviewSuccess = ( { time_taken_ms } ) =>
+		this.props.recordTracksEvent( 'calypso_site_importer_site_preview_success', {
+			blog_id: this.props.site.ID,
+			site_url: this.state.siteURL,
+			time_taken_ms,
+		} );
 
-	loadSitePreview = () => {
-		this.setState( { loadingPreviewImage: true, previewStartTime: Date.now() } );
-
-		loadmShotsPreview( {
-			url: this.state.siteURL,
-			maxRetries: 30,
-			retryTimeout: 1000,
-		} )
-			.then( imageBlob => {
-				this.setState( {
-					loadingPreviewImage: false,
-					sitePreviewImage: imageBlob,
-					sitePreviewFailed: false,
-				} );
-
-				this.props.recordTracksEvent( 'calypso_site_importer_site_preview_success', {
-					blog_id: this.props.site.ID,
-					site_url: this.state.siteURL,
-					time_taken_ms: Date.now() - this.state.previewStartTime,
-				} );
-			} )
-			.catch( () => {
-				this.setState( {
-					loadingPreviewImage: false,
-					sitePreviewImage: '',
-					sitePreviewFailed: true,
-				} );
-
-				this.props.recordTracksEvent( 'calypso_site_importer_site_preview_fail', {
-					blog_id: this.props.site.ID,
-					site_url: this.state.siteURL,
-					time_taken_ms: Date.now() - this.state.previewStartTime,
-				} );
-			} );
-	};
+	trackSitePreviewFailure = ( { time_taken_ms } ) =>
+		this.props.recordTracksEvent( 'calypso_site_importer_site_preview_fail', {
+			blog_id: this.props.site.ID,
+			site_url: this.state.siteURL,
+			time_taken_ms,
+		} );
 
 	render = () => {
-		const isLoading = this.props.isLoading || this.state.loadingPreviewImage;
+		const { isLoading } = this.props;
 		const isError = this.state.sitePreviewFailed;
 
 		const containerClass = classNames( 'site-importer__site-preview-overlay-container', {
@@ -103,7 +71,11 @@ class SiteImporterSitePreview extends React.Component {
 						</div>
 						<div className={ containerClass }>
 							<div className="site-importer__site-preview-column-container">
-								<MiniSitePreview imageSrc={ this.state.sitePreviewImage } />
+								<MiniSitePreview
+									siteURL={ this.state.siteURL }
+									onFetchSuccess={ this.trackSitePreviewSuccess }
+									onFetchError={ this.trackSitePreviewFailure }
+								/>
 								<ImportableContent importData={ this.props.importData } />
 							</div>
 						</div>

--- a/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
@@ -14,7 +14,6 @@ import classNames from 'classnames';
 import Spinner from 'components/spinner';
 import Button from 'components/forms/form-button';
 import MiniSitePreview from 'components/mini-site-preview';
-import ErrorPane from 'my-sites/importer/error-pane';
 import { recordTracksEvent } from 'state/analytics/actions';
 import ImportableContent from 'my-sites/importer/site-importer/site-importer-importable-content';
 
@@ -28,73 +27,54 @@ class SiteImporterSitePreview extends React.Component {
 		site: PropTypes.object,
 	};
 
-	state = {
-		siteURL: this.props.siteURL,
-	};
-
 	trackSitePreviewSuccess = ( { time_taken_ms } ) =>
 		this.props.recordTracksEvent( 'calypso_site_importer_site_preview_success', {
 			blog_id: this.props.site.ID,
-			site_url: this.state.siteURL,
+			site_url: this.props.siteURL,
 			time_taken_ms,
 		} );
 
 	trackSitePreviewFailure = ( { time_taken_ms } ) =>
 		this.props.recordTracksEvent( 'calypso_site_importer_site_preview_fail', {
 			blog_id: this.props.site.ID,
-			site_url: this.state.siteURL,
+			site_url: this.props.siteURL,
 			time_taken_ms,
 		} );
 
 	render = () => {
-		const { isLoading } = this.props;
-		const isError = this.state.sitePreviewFailed;
+		const { isLoading, siteURL } = this.props;
 
 		const containerClass = classNames( 'site-importer__site-preview-overlay-container', {
 			isLoading,
 		} );
 
-		return ! isError ? (
+		return ! isLoading ? (
 			<div>
-				{ ! isLoading && (
-					<div>
-						<div className="site-importer__site-importer-confirm-site-pane-container">
-							<div className="site-importer__site-importer-confirm-site-label">
-								{ this.props.translate( 'Is this your site?' ) }
-							</div>
-							<Button disabled={ isLoading } onClick={ this.props.startImport }>
-								{ this.props.translate( 'Yes! Start import' ) }
-							</Button>
-							<Button disabled={ isLoading } isPrimary={ false } onClick={ this.props.resetImport }>
-								{ this.props.translate( 'No' ) }
-							</Button>
-						</div>
-						<div className={ containerClass }>
-							<div className="site-importer__site-preview-column-container">
-								<MiniSitePreview
-									siteURL={ this.state.siteURL }
-									onFetchSuccess={ this.trackSitePreviewSuccess }
-									onFetchError={ this.trackSitePreviewFailure }
-								/>
-								<ImportableContent importData={ this.props.importData } />
-							</div>
-						</div>
+				<div className="site-importer__site-importer-confirm-site-pane-container">
+					<div className="site-importer__site-importer-confirm-site-label">
+						{ this.props.translate( 'Is this your site?' ) }
 					</div>
-				) }
-				{ isLoading && (
-					<div className="site-importer__site-preview-loading-overlay">
-						<Spinner />
+					<Button disabled={ isLoading } onClick={ this.props.startImport }>
+						{ this.props.translate( 'Yes! Start import' ) }
+					</Button>
+					<Button disabled={ isLoading } isPrimary={ false } onClick={ this.props.resetImport }>
+						{ this.props.translate( 'No' ) }
+					</Button>
+				</div>
+				<div className={ containerClass }>
+					<div className="site-importer__site-preview-column-container">
+						<MiniSitePreview
+							siteURL={ siteURL }
+							onFetchSuccess={ this.trackSitePreviewSuccess }
+							onFetchError={ this.trackSitePreviewFailure }
+						/>
+						<ImportableContent importData={ this.props.importData } />
 					</div>
-				) }
+				</div>
 			</div>
 		) : (
-			<div className="site-importer__site-preview-error">
-				<ErrorPane
-					type="importError"
-					description={ this.props.translate(
-						'Unable to load site preview. Please try again later.'
-					) }
-				/>
+			<div className="site-importer__site-preview-loading-overlay">
+				<Spinner />
 			</div>
 		);
 	};


### PR DESCRIPTION
This PR expands on a recent set of changes made in #26790. At the time I wasn't sure of the best way to abstract the state/fetch logic but I think I've settled on the logic changes found in this PR.
I've also tested these changes in the context of the signup importer flow and they work a charm there, too.

### To Test

- Go to `settings/import/` ([local](http://calypso.localhost:3000/settings/import/)/[calypso.live](https://calypso.live/?branch=update/give-mini-site-preview-fetch-responsibility)) and pick a site
- Choose the Wix option and enter a valid wix site (for example: https://smt593.wixsite.com/wowz/static-page )
- Tip: Set your network filter to `calypso_site_importer_site_` to better watch for relevant analytics calls.
- hit continue
  - You should see the a preview  snapshot of the given site with the expected 'browser chrome'
  - You should see an analytics event fire - make sure that the params here are as expected, particularly the `time_taken_ms` value, as the logic for that is now more complex.
