### PR TITLE
Add more manual renewal reasons for immediate login, and tweak the immediate login text

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -26,6 +26,7 @@ import {
 	getSocialAccountIsLinking,
 	getSocialAccountLinkService,
 } from 'state/login/selectors';
+import { wasManualRenewalImmediateLoginAttempted } from 'state/immediate-login/selectors';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
 import { isWooOAuth2Client } from 'lib/oauth2-clients';
@@ -46,6 +47,7 @@ class Login extends Component {
 		disableAutoFocus: PropTypes.bool,
 		isLinking: PropTypes.bool,
 		isJetpack: PropTypes.bool.isRequired,
+		isManualRenewalImmediateLoginAttempt: PropTypes.bool,
 		linkingSocialService: PropTypes.string,
 		oauth2Client: PropTypes.object,
 		privateSite: PropTypes.bool,
@@ -137,6 +139,7 @@ class Login extends Component {
 	renderHeader() {
 		const {
 			isJetpack,
+			isManualRenewalImmediateLoginAttempt,
 			linkingSocialService,
 			oauth2Client,
 			privateSite,
@@ -148,6 +151,12 @@ class Login extends Component {
 		let headerText = translate( 'Log in to your account.' );
 		let preHeader = null;
 		let postHeader = null;
+
+		if ( isManualRenewalImmediateLoginAttempt ) {
+			headerText = translate(
+				'Log in to update your payment details and renew your subscription.'
+			);
+		}
 
 		if ( twoStepNonce ) {
 			headerText = translate( 'Two-Step Authentication' );
@@ -299,6 +308,7 @@ export default connect(
 		twoFactorNotificationSent: getTwoFactorNotificationSent( state ),
 		oauth2Client: getCurrentOAuth2Client( state ),
 		isLinking: getSocialAccountIsLinking( state ),
+		isManualRenewalImmediateLoginAttempt: wasManualRenewalImmediateLoginAttempted( state ),
 		linkingSocialService: getSocialAccountLinkService( state ),
 		partnerSlug: getPartnerSlugFromQuery( state ),
 	} ),

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -36,7 +36,7 @@ import {
 } from 'state/login/selectors';
 import {
 	wasImmediateLoginAttempted,
-	wasAutoRenewalFailureImmediateLoginAttempted,
+	wasManualRenewalImmediateLoginAttempted,
 } from 'state/immediate-login/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
@@ -57,7 +57,7 @@ class HandleEmailedLinkForm extends React.Component {
 		isExpired: PropTypes.bool,
 		isFetching: PropTypes.bool,
 		isImmediateLoginAttempt: PropTypes.bool,
-		isAutoRenewalFailureImmediateLoginAttempt: PropTypes.bool,
+		isManualRenewalImmediateLoginAttempt: PropTypes.bool,
 		redirectToOriginal: PropTypes.string,
 		redirectToSanitized: PropTypes.string,
 		twoFactorEnabled: PropTypes.bool,
@@ -162,8 +162,10 @@ class HandleEmailedLinkForm extends React.Component {
 		);
 
 		let title;
-		if ( this.props.isAutoRenewalFailureImmediateLoginAttempt ) {
-			title = translate( 'Continue to WordPress.com to renew your subscription' );
+		if ( this.props.isManualRenewalImmediateLoginAttempt ) {
+			title = translate(
+				'Continue to WordPress.com to update your payment details and renew your subscription'
+			);
 		} else {
 			title =
 				this.props.clientId === config( 'wpcom_signup_id' )
@@ -220,9 +222,7 @@ const mapState = state => {
 		isExpired: getMagicLoginCurrentView( state ) === LINK_EXPIRED_PAGE,
 		isFetching: isFetchingMagicLoginAuth( state ),
 		isImmediateLoginAttempt: wasImmediateLoginAttempted( state ),
-		isAutoRenewalFailureImmediateLoginAttempt: wasAutoRenewalFailureImmediateLoginAttempted(
-			state
-		),
+		isManualRenewalImmediateLoginAttempt: wasManualRenewalImmediateLoginAttempted( state ),
 		twoFactorEnabled: isTwoFactorEnabled( state ),
 		twoFactorNotificationSent: getTwoFactorNotificationSent( state ),
 	};

--- a/client/state/immediate-login/constants.js
+++ b/client/state/immediate-login/constants.js
@@ -1,3 +1,14 @@
 /** @format */
 
-export const REASON_AUTO_RENEWAL_FAILURE = 'bd_renewal-failure';
+// Login reasons associated with manual subscription renewals. Currently these
+// all have the exact same messaging, so they are included in one constant.
+export const REASONS_FOR_MANUAL_RENEWAL = [
+	'auto-renew-failed',
+	'bd_card-expiring',
+	'bd_missing-payment',
+	'bd_renewal-failure',
+	'expired-domain-notice',
+	'plan-expired',
+	'renew-domain-expiration-notice',
+	'upcoming_expiry_notification',
+];

--- a/client/state/immediate-login/selectors.js
+++ b/client/state/immediate-login/selectors.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { get, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -86,5 +86,5 @@ export const getImmediateLoginLocale = state => {
  *                  login attempt was made from a manual renewal email
  */
 export const wasManualRenewalImmediateLoginAttempted = state => {
-	return REASONS_FOR_MANUAL_RENEWAL.indexOf( getImmediateLoginReason( state ) ) !== -1;
+	return includes( REASONS_FOR_MANUAL_RENEWAL, getImmediateLoginReason( state ) );
 };

--- a/client/state/immediate-login/selectors.js
+++ b/client/state/immediate-login/selectors.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { REASON_AUTO_RENEWAL_FAILURE } from './constants';
+import { REASONS_FOR_MANUAL_RENEWAL } from './constants';
 
 /**
  * Retrieves information about whether an immediate login attempt was made for
@@ -77,13 +77,14 @@ export const getImmediateLoginLocale = state => {
 
 /**
  * Retrieves information about whether an immediate login attempt was made from
- * a link in an auto-renewal failure email (according to query parameters
- * provided in the client request) for the current instance of Calypso.
+ * a link in an email that requested the user to manually renew a subscription
+ * (according to query parameters provided in the client request) for the
+ * current instance of Calypso.
  *
  * @param {Object} state - Global state tree
  * @return {bool} - Whether the client request indicates that an immediate
- *                  login attempt was made from an auto-renewal failure email
+ *                  login attempt was made from a manual renewal email
  */
-export const wasAutoRenewalFailureImmediateLoginAttempted = state => {
-	return REASON_AUTO_RENEWAL_FAILURE === getImmediateLoginReason( state );
+export const wasManualRenewalImmediateLoginAttempted = state => {
+	return REASONS_FOR_MANUAL_RENEWAL.indexOf( getImmediateLoginReason( state ) ) !== -1;
 };

--- a/client/state/immediate-login/test/selectors.js
+++ b/client/state/immediate-login/test/selectors.js
@@ -3,19 +3,20 @@
 /**
  * External dependencies
  */
+import { first, last } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import {
 	wasImmediateLoginAttempted,
-	wasAutoRenewalFailureImmediateLoginAttempted,
+	wasManualRenewalImmediateLoginAttempted,
 	wasImmediateLoginSuccessfulAccordingToClient,
 	getImmediateLoginReason,
 	getImmediateLoginEmail,
 	getImmediateLoginLocale,
 } from '../selectors';
-import { REASON_AUTO_RENEWAL_FAILURE } from '../constants';
+import { REASONS_FOR_MANUAL_RENEWAL } from '../constants';
 
 describe( 'immediate-login/selectors', () => {
 	describe( 'wasImmediateLoginAttempted', () => {
@@ -33,14 +34,14 @@ describe( 'immediate-login/selectors', () => {
 			expect( wasImmediateLoginAttempted( { immediateLogin: { attempt: true } } ) ).toEqual( true );
 		} );
 	} );
-	describe( 'wasAutoRenewalFailureImmediateLoginAttempted', () => {
+	describe( 'wasManualRenewalImmediateLoginAttempted', () => {
 		test( 'should return correct value from state [1]', () => {
-			expect( wasAutoRenewalFailureImmediateLoginAttempted( {} ) ).toEqual( false );
+			expect( wasManualRenewalImmediateLoginAttempted( {} ) ).toEqual( false );
 		} );
 
 		test( 'should return correct value from state [2]', () => {
 			expect(
-				wasAutoRenewalFailureImmediateLoginAttempted( {
+				wasManualRenewalImmediateLoginAttempted( {
 					immediateLogin: { reason: 'test reason' },
 				} )
 			).toEqual( false );
@@ -48,8 +49,16 @@ describe( 'immediate-login/selectors', () => {
 
 		test( 'should return correct value from state [3]', () => {
 			expect(
-				wasAutoRenewalFailureImmediateLoginAttempted( {
-					immediateLogin: { reason: REASON_AUTO_RENEWAL_FAILURE },
+				wasManualRenewalImmediateLoginAttempted( {
+					immediateLogin: { reason: first( REASONS_FOR_MANUAL_RENEWAL ) },
+				} )
+			).toEqual( true );
+		} );
+
+		test( 'should return correct value from state [4]', () => {
+			expect(
+				wasManualRenewalImmediateLoginAttempted( {
+					immediateLogin: { reason: last( REASONS_FOR_MANUAL_RENEWAL ) },
 				} )
 			).toEqual( true );
 		} );

--- a/client/state/immediate-login/test/utils.js
+++ b/client/state/immediate-login/test/utils.js
@@ -3,12 +3,13 @@
 /**
  * External dependencies
  */
+import { first } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { createPathWithoutImmediateLoginInformation, createImmediateLoginMessage } from '../utils';
-import { REASON_AUTO_RENEWAL_FAILURE } from '../constants';
+import { REASONS_FOR_MANUAL_RENEWAL } from '../constants';
 
 describe( 'immediate-login/utils', () => {
 	describe( 'createPathWithoutImmediateLoginInformation', () => {
@@ -119,7 +120,7 @@ describe( 'immediate-login/utils', () => {
 
 		const messages = [
 			createImmediateLoginMessage( '', 'test@wordpress.com' ),
-			createImmediateLoginMessage( REASON_AUTO_RENEWAL_FAILURE, 'test@wordpress.com' ),
+			createImmediateLoginMessage( first( REASONS_FOR_MANUAL_RENEWAL ), 'test@wordpress.com' ),
 		];
 		test( 'should return a different message per reason', () => {
 			let previous = messages[ messages.length - 1 ];

--- a/client/state/immediate-login/utils.js
+++ b/client/state/immediate-login/utils.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { REASON_AUTO_RENEWAL_FAILURE } from './constants';
+import { REASONS_FOR_MANUAL_RENEWAL } from './constants';
 
 /**
  * Processes a redux ROUTE_SET action and returns a URL that contains no parameters that
@@ -36,13 +36,15 @@ export const createPathWithoutImmediateLoginInformation = ( path, query ) => {
  * @return {string}              - Message to show to user
  */
 export const createImmediateLoginMessage = ( loginReason, email ) => {
-	switch ( loginReason ) {
-		case REASON_AUTO_RENEWAL_FAILURE:
-			return translate( 'We logged you in as %(email)s so you can renew your subscription.', {
+	if ( REASONS_FOR_MANUAL_RENEWAL.indexOf( loginReason ) !== -1 ) {
+		return translate(
+			'We logged you in as %(email)s so you can update your payment details and renew your subscription.',
+			{
 				args: { email },
-			} );
-
-		default:
-			return translate( 'We logged you in as %(email)s.', { args: { email } } );
+			}
+		);
 	}
+
+	// Default message.
+	return translate( 'We logged you in as %(email)s.', { args: { email } } );
 };

--- a/client/state/immediate-login/utils.js
+++ b/client/state/immediate-login/utils.js
@@ -3,7 +3,12 @@
 /**
  * External dependencies
  */
+import { includes } from 'lodash';
 import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
 import { REASONS_FOR_MANUAL_RENEWAL } from './constants';
 
 /**
@@ -36,7 +41,7 @@ export const createPathWithoutImmediateLoginInformation = ( path, query ) => {
  * @return {string}              - Message to show to user
  */
 export const createImmediateLoginMessage = ( loginReason, email ) => {
-	if ( REASONS_FOR_MANUAL_RENEWAL.indexOf( loginReason ) !== -1 ) {
+	if ( includes( REASONS_FOR_MANUAL_RENEWAL, loginReason ) ) {
 		return translate(
 			'We logged you in as %(email)s so you can update your payment details and renew your subscription.',
 			{


### PR DESCRIPTION
This is a followup to https://github.com/Automattic/wp-calypso/pull/26391 and https://github.com/Automattic/wp-calypso/pull/26503.

We're now in the process of going live with the immediate login feature and enabling it in various subscription renewal and expiration emails that get sent out by WordPress.com.  These emails all contain links that encourage people to update their payment details and manually renew their subscription.

This pull request adds on-screen login messaging for all the new emails.  Additionally, it tweaks the text to be a bit more specific and to cover the scenarios for all the renewal emails we send.

### Testing instructions

1. As a logged in user, go to:
http://calypso.localhost:3000/me/purchases?immediate_login_attempt=1&immediate_login_success=1&login_reason=plan-expired

And confirm you see the following message: `We logged you in as [email] so you can update your payment details and renew your subscription.`

2. As a logged out user, go to:
http://calypso.localhost:3000/log-in/link/use?client_id=39911&email=test@example.com&token=invalid&signature=invalid&immediate_login_attempt=1&login_reason=bd_card-expiring

And confirm you see the following message on the login confirmation form: `Continue to WordPress.com to update your payment details and renew your subscription`.  (The above link is invalid if you try to log in with it, but it still works to just see the on-screen messaging.)

3. As a logged out user, go to:
http://calypso.localhost:3000/me/purchases?immediate_login_attempt=1&login_reason=bd_missing-payment&login_email=test@example.com

And confirm you see the following message on the login form: `Log in to update your payment details and renew your subscription.`

You can also repeat the about testing with any of the login reasons found in the `REASONS_FOR_MANUAL_RENEWAL` constant in the pull request code.