### PR TITLE
DevDocs: Enable Gutenberg Blocks and Components in wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -27,6 +27,7 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": false,
 		"devdocs/components-usage-stats": false,
+		"devdocs/gutenberg-blocks": true,
 		"dev/test-helper": true,
 		"dev/preferences-helper": true,
 		"domains/cctlds": true,


### PR DESCRIPTION
This enables the visualization of the Gutenberg blocks and Gutenberg components in the DevDocs on the wpcalypso environment