### PR TITLE
Gutenberg Integration: Make Authenticated Requests to the v2 REST API

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -15,7 +15,7 @@ import { registerCoreBlocks } from '@wordpress/block-library';
 import Editor from './edit-post/editor.js';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
-import { overrideAPIPaths } from './utils';
+import { applyMiddlewares } from './utils';
 
 const editorSettings = {};
 
@@ -36,7 +36,7 @@ class GutenbergEditor extends Component {
 			return null;
 		}
 
-		overrideAPIPaths( this.props.siteSlug );
+		applyMiddlewares( this.props.siteSlug );
 
 		return (
 			<Editor settings={ editorSettings } hasFixedToolbar={ true } post={ post } onError={ noop } />

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -15,7 +15,7 @@ import { registerCoreBlocks } from '@wordpress/block-library';
 import Editor from './edit-post/editor.js';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
-import { applyMiddlewares } from './utils';
+import { applyAPIMiddlewares } from './utils';
 
 const editorSettings = {};
 
@@ -36,7 +36,7 @@ class GutenbergEditor extends Component {
 			return null;
 		}
 
-		applyMiddlewares( this.props.siteSlug );
+		applyAPIMiddlewares( this.props.siteSlug );
 
 		return (
 			<Editor settings={ editorSettings } hasFixedToolbar={ true } post={ post } onError={ noop } />

--- a/client/gutenberg/editor/utils.js
+++ b/client/gutenberg/editor/utils.js
@@ -12,7 +12,7 @@ import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:gutenberg' );
 
-export const overrideAPIPaths = siteSlug => {
+export const applyMiddlewares = siteSlug => {
 	//make authenticated calls using the WordPress.com REST Proxy
 	//bypassing the apiFetch call that uses window.fetch
 	//first middleware in, last out

--- a/client/gutenberg/editor/utils.js
+++ b/client/gutenberg/editor/utils.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { noop } from 'lodash';
+import proxy from 'wpcom-proxy-request';
 
 /**
  * Internal dependencies
@@ -13,8 +13,24 @@ import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:gutenberg' );
 
 export const overrideAPIPaths = siteSlug => {
-	// TODO: no API support for now. We'll also need to handle authorization here.
-	apiFetch.use( () => noop );
+	//make authenticated calls using the WordPress.com REST Proxy
+	//bypassing the apiFetch call that uses window.fetch
+	//first middleware in, last out
+	apiFetch.use( options => {
+		return proxy(
+			{
+				...options,
+				apiNamespace: 'wp/v2',
+			},
+			( error, body ) => {
+				if ( error ) {
+					return Promise.reject( error );
+				}
+
+				return Promise.resolve( body );
+			}
+		);
+	} );
 
 	const rootURL = 'https://public-api.wordpress.com/';
 	apiFetch.use( apiFetch.createRootURLMiddleware( rootURL ) );
@@ -22,7 +38,7 @@ export const overrideAPIPaths = siteSlug => {
 	// rewrite default API paths to match WP.com equivalents
 	// Example: /wp/v2/posts -> /wp/v2/sites/{siteSlug}/posts
 	apiFetch.use( ( options, next ) => {
-		const wpcomPath = `/wp/v2/sites/${ siteSlug }/` + options.path.replace( '/wp/v2/', '' );
+		const wpcomPath = `/sites/${ siteSlug }` + options.path.replace( '/wp/v2/', '/' );
 
 		debug( 'sending API request to: ', wpcomPath );
 

--- a/client/gutenberg/editor/utils.js
+++ b/client/gutenberg/editor/utils.js
@@ -17,19 +17,21 @@ export const applyAPIMiddlewares = siteSlug => {
 	//bypassing the apiFetch call that uses window.fetch
 	//first middleware in, last out
 	apiFetch.use( options => {
-		return wpcomProxyRequest(
-			{
-				...options,
-				apiNamespace: 'wp/v2',
-			},
-			( error, body ) => {
-				if ( error ) {
-					return Promise.reject( error );
-				}
+		return new Promise( ( resolve, reject ) => {
+			wpcomProxyRequest(
+				{
+					...options,
+					apiNamespace: 'wp/v2',
+				},
+				( error, body ) => {
+					if ( error ) {
+						return reject( error );
+					}
 
-				return Promise.resolve( body );
-			}
-		);
+					return resolve( body );
+				}
+			);
+		} );
 	} );
 
 	const rootURL = 'https://public-api.wordpress.com/';

--- a/client/gutenberg/editor/utils.js
+++ b/client/gutenberg/editor/utils.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import proxy from 'wpcom-proxy-request';
+import wpcomProxyRequest from 'wpcom-proxy-request';
 
 /**
  * Internal dependencies
@@ -12,12 +12,12 @@ import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:gutenberg' );
 
-export const applyMiddlewares = siteSlug => {
+export const applyAPIMiddlewares = siteSlug => {
 	//make authenticated calls using the WordPress.com REST Proxy
 	//bypassing the apiFetch call that uses window.fetch
 	//first middleware in, last out
 	apiFetch.use( options => {
-		return proxy(
+		return wpcomProxyRequest(
 			{
 				...options,
 				apiNamespace: 'wp/v2',
@@ -38,7 +38,7 @@ export const applyMiddlewares = siteSlug => {
 	// rewrite default API paths to match WP.com equivalents
 	// Example: /wp/v2/posts -> /wp/v2/sites/{siteSlug}/posts
 	apiFetch.use( ( options, next ) => {
-		const wpcomPath = `/sites/${ siteSlug }` + options.path.replace( '/wp/v2/', '/' );
+		const wpcomPath = options.path.replace( '/wp/v2/', `/sites/${ siteSlug }/` );
 
 		debug( 'sending API request to: ', wpcomPath );
 


### PR DESCRIPTION
Part of #26639

The PR adds a new middleware for `apiFetch` that routes all the API throughout the WordPress.com REST Proxy. This will not work on the Desktop Application until `oauthToken` detection is implemented, so only test on web.

To test this you'll have to:

* Enable debug logs by running `localStorage.setItem( 'debug', 'calypso:gutenberg' );` on your browser's console.
* Browse `calypso.localhost:3000/gutenberg/post/{site_slug}`.
* Look for `calypso:gutenberg sending API request to:` debug messages on the console.
* Verify that for each of the debug messages, there is a corresponding network request that returns correctly.

Pending Items

* Validate that the API responses are stored correctly and reflected on the UI
* Validate that there are no edge cases for `/wp/v2/` -> `/wp/v2/sites/{siteSlug}/`