### PR TITLE
Git-ignore all CSS files in /public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,11 +30,8 @@ test-results*.xml
 
 /public/*.js
 /public/*.js.map
-/public/style*.css
-/public/style*.css.map
-/public/editor*.css
-/public/directly*.css
-/public/emergent-paywall*.css
+/public/*.css
+/public/*.css.map
 /public/sections/*
 /public/sections-rtl/*
 /public/images/*.svg


### PR DESCRIPTION
Changes the ignore rules to ignore all CSS and CSS sourcemap files in `/public`. There are no version-controlled CSS files in that directory and the current rules are overly specific. They were created a long time ago in pre-OSS era.

Removes unnecessary constraints on naming of CSS chunks in #26820.