### PR TITLE
Header Button: update CSS selectors to be more specific

### DIFF
--- a/client/components/header-button/style.scss
+++ b/client/components/header-button/style.scss
@@ -1,4 +1,4 @@
-.header-button {
+.button.header-button {
 	align-items: center;
 	border: none;
 	border-radius: 0;
@@ -15,7 +15,7 @@
 	}
 }
 
-.header-button .gridicon.gridicons-cloud-upload {
+.button.header-button .gridicon.gridicons-cloud-upload {
 	top: 6px;
 }
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -42,7 +42,7 @@
 .plugins__header-buttons {
 	display: flex;
 
-	.header-button {
+	.button.header-button {
 		flex: auto;
 		flex-basis: 0;
 


### PR DESCRIPTION
A `HeaderButton` element has CSS class `button header-button` and the CSS selectors `.button` and `.header-button` are currently equally specific. The one that's defined later in the CSS stylesheet wins. That causes problems when component stylesheets get reordered, e.g., during conversion of the build pipeline to Webpack. See #26820.

This patch increases the specificity of the `.header-button` selectors and makes the
whole thing less fragile.

**How to test:**
Go to `/plugins/manage/:site` and verify that the styling of header buttons is not broken: the icon is centered above the text and the text is not bold:

<img width="290" alt="screen shot 2018-08-24 at 10 54 12" src="https://user-images.githubusercontent.com/664258/44575769-1509ef00-a78d-11e8-8fb4-9d5ce00a635a.png">
