### PR TITLE
Replaced themesNudgesUpdates test group with a separate A/B tests

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,5 +1,14 @@
 /** @format */
 export default {
+	themesNudgesUpdates: {
+		datestamp: '20180827',
+		variations: {
+			test: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 	nudgeAPalooza: {
 		datestamp: '20180806',
 		variations: {

--- a/client/my-sites/checkout/cart/cart-plan-ad-theme.jsx
+++ b/client/my-sites/checkout/cart/cart-plan-ad-theme.jsx
@@ -51,7 +51,7 @@ class CartPlanAdTheme extends Component {
 			hasOnlyAPremiumTheme &&
 			selectedSite &&
 			selectedSite.plan &&
-			abtest( 'nudgeAPalooza' ) === 'themesNudgesUpdates'
+			abtest( 'themesNudgesUpdates' ) === 'test'
 		);
 	};
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -624,7 +624,7 @@ class ThemeSheet extends React.Component {
 			isPremium &&
 			! hasUnlimitedPremiumThemes &&
 			config.isEnabled( 'upsell/nudge-a-palooza' ) &&
-			abtest( 'nudgeAPalooza' ) === 'themesNudgesUpdates';
+			abtest( 'themesNudgesUpdates' ) === 'test';
 		if ( hasUpsellBanner ) {
 			// This is just for US-english audience and is not translated, remember to add translate() calls before
 			// removing a/b test check and enabling it for everyone

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -38,7 +38,7 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 	const bannerLocationBelowSearch =
 		! isJetpack &&
 		config.isEnabled( 'upsell/nudge-a-palooza' ) &&
-		abtest( 'nudgeAPalooza' ) === 'themesNudgesUpdates';
+		abtest( 'themesNudgesUpdates' ) === 'test';
 
 	const upsellUrl = `/plans/${ siteSlug }`;
 	let upsellBanner = null;


### PR DESCRIPTION
This PR replaces test group `themesNudgesUpdates` of `nudgeAPalooza` with a separate A/B tests. Instead of allocating entire traffic to a test group, this new test only allocates user who are exposed to an upsell nudge.

Test plan:

1. Choose a free site in Calypso
1. Go to `/themes` and refresh page
1. Confirm in AB test picker you were assigned to any group of `themesNudgesUpdates` test
1. Assign yourself to a "test" group
1. Confirm that on `/themes`, `/themes/photo-blog`, and theme preview the upsell nudge is dark
1. Try to purchase a premium theme and confirm there is one additional upsell nudge in shopping cart during checkout
1. Assign yourself to a "control" group
1. Confirm that on `/themes`, `/themes/photo-blog`, and theme preview the upsell nudge is white
1. Try to purchase a premium theme and confirm there is no upsell nudge in shopping cart during checkout