### PR TITLE
Checklist: Disable ChecklistBanner for Jetpack and Atomic sites

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -38,6 +38,7 @@ import QuerySiteKeyrings from 'components/data/query-site-keyrings';
 import QueryKeyringConnections from 'components/data/query-keyring-connections';
 import GoogleMyBusinessStatsNudge from 'blocks/google-my-business-stats-nudge';
 import isGoogleMyBusinessStatsNudgeVisibleSelector from 'state/selectors/is-google-my-business-stats-nudge-visible';
+import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 
 function updateQueryString( query = {} ) {
 	return {
@@ -151,7 +152,8 @@ class StatsSite extends Component {
 					slug={ slug }
 				/>
 				<div id="my-stats-content">
-					{ config.isEnabled( 'onboarding-checklist' ) && <ChecklistBanner siteId={ siteId } /> }
+					{ config.isEnabled( 'onboarding-checklist' ) &&
+						this.props.showChecklistBanner && <ChecklistBanner siteId={ siteId } /> }
 					{ config.isEnabled( 'google-my-business' ) &&
 						siteId && (
 							<GoogleMyBusinessStatsNudge
@@ -251,6 +253,7 @@ export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
+
 		return {
 			isJetpack,
 			hasPodcasts:
@@ -264,6 +267,7 @@ export default connect(
 				siteId
 			),
 			siteId,
+			showChecklistBanner: ! isAtomicSite( state, siteId ) && ! isJetpack,
 			slug: getSelectedSiteSlug( state ),
 		};
 	},


### PR DESCRIPTION
The Checklist banner on the stats page should not be shown (with an inaccurate list of tasks) for Jetpack or Atomic sites.

Hide the banner for those sites.

Fixes #26870

This was likely introduced by #26721 where [an equality check to hide the banner always fails](https://github.com/Automattic/wp-calypso/pull/26721/files#diff-435657f5f9b9c272e276134ceda0644dL104) for Jetpack sites (props @ockham)

## Testing
1. Visit stats for a site that should have the banner (simple) and verify the banner is present.
1. Visit stats for a site that should not show the banner (Atomic, Jetpack) and verify that the banner is not present.