### PR TITLE
Remove Store and Ads menu upsells for free users from the sidebar until we conclude other A/B tests

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -27,7 +27,6 @@ import SidebarItem from 'layout/sidebar/item';
 import SidebarMenu from 'layout/sidebar/menu';
 import SidebarRegion from 'layout/sidebar/region';
 import StatsSparkline from 'blocks/stats-sparkline';
-import TrackComponentView from 'lib/analytics/track-component-view';
 import JetpackLogo from 'components/jetpack-logo';
 import { isFreeTrial, isPersonal, isPremium, isBusiness } from 'lib/products-values';
 import { getCurrentUser } from 'state/current-user/selectors';
@@ -175,16 +174,8 @@ export class MySitesSidebar extends Component {
 		this.onNavigate();
 	};
 
-	trackAdsUpsellClick = () => {
-		this.trackMenuItemClick( 'ads' );
-		this.props.recordTracksEvent( 'calypso_upgrade_nudge_cta_click', {
-			cta_name: 'store_ads',
-		} );
-		this.onNavigate();
-	};
-
 	ads() {
-		const { path, canUserUpgradeSite, canUserUseAds, isJetpack } = this.props;
+		const { path, canUserUseAds } = this.props;
 
 		if ( canUserUseAds ) {
 			return (
@@ -193,25 +184,6 @@ export class MySitesSidebar extends Component {
 					selected={ itemLinkMatches( '/ads', path ) }
 					link={ '/ads/earnings' + this.props.siteSuffix }
 					onNavigate={ this.trackAdsClick }
-					icon="speaker"
-					tipTarget="wordads"
-				/>
-			);
-		}
-
-		if (
-			false && // This test is temporarily disabled until we conclude a few other ones about Oct 7th
-			! isJetpack &&
-			isEnabled( 'upsell/nudge-a-palooza' ) &&
-			canUserUpgradeSite &&
-			abtest( 'nudgeAPalooza' ) === 'sidebarUpsells'
-		) {
-			return (
-				<SidebarItem
-					label={ 'WordAds' }
-					selected={ itemLinkMatches( '/feature/ads', path ) }
-					link={ '/feature/ads' + this.props.siteSuffix }
-					onNavigate={ this.trackAdsUpsellClick }
 					icon="speaker"
 					tipTarget="wordads"
 				/>
@@ -417,40 +389,20 @@ export class MySitesSidebar extends Component {
 		this.onNavigate();
 	};
 
-	trackStoreUpsellClick = () => {
-		this.trackMenuItemClick( 'store' );
-		this.props.recordTracksEvent( 'calypso_upgrade_nudge_cta_click', {
-			cta_name: 'store_sidebar',
-		} );
-		this.onNavigate();
-	};
-
 	store() {
-		const { canUserUpgradeSite, site, canUserUseStore, isJetpack } = this.props;
+		const { translate, site, siteSuffix, canUserUseStore } = this.props;
 
 		if ( ! isEnabled( 'woocommerce/extension-dashboard' ) || ! site ) {
 			return null;
 		}
 
 		if ( ! canUserUseStore ) {
-			if (
-				false && // This test is temporarily disabled until we conclude a few other ones about Oct 7th
-				! isJetpack &&
-				isEnabled( 'upsell/nudge-a-palooza' ) &&
-				canUserUpgradeSite &&
-				abtest( 'nudgeAPalooza' ) === 'sidebarUpsells'
-			) {
-				return this.storeUpsellSidebarItem();
-			}
-
 			return null;
 		}
 
-		return this.storeSidebarItem();
-	}
-
-	storeSidebarItem() {
-		const { siteSuffix, translate } = this.props;
+		if ( ! isEnabled( 'woocommerce/extension-dashboard' ) || ! site ) {
+			return null;
+		}
 		return (
 			<SidebarItem
 				label={ translate( 'Store' ) }
@@ -458,29 +410,6 @@ export class MySitesSidebar extends Component {
 				onNavigate={ this.trackStoreClick }
 				icon="cart"
 			>
-				<div className="sidebar__chevron-right">
-					<Gridicon icon="chevron-right" />
-				</div>
-			</SidebarItem>
-		);
-	}
-
-	storeUpsellSidebarItem() {
-		const { siteSuffix, translate, path } = this.props;
-		return (
-			<SidebarItem
-				label={ translate( 'Store' ) }
-				link={ '/feature/store' + siteSuffix }
-				selected={ itemLinkMatches( '/feature/store', path ) }
-				onNavigate={ this.trackStoreUpsellClick }
-				icon="cart"
-			>
-				<TrackComponentView
-					eventName="calypso_upgrade_nudge_impression"
-					eventProperties={ {
-						cta_name: 'store_upsell',
-					} }
-				/>
 				<div className="sidebar__chevron-right">
 					<Gridicon icon="chevron-right" />
 				</div>

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -200,6 +200,7 @@ export class MySitesSidebar extends Component {
 		}
 
 		if (
+			false && // This test is temporarily disabled until we conclude a few other ones about Oct 7th
 			! isJetpack &&
 			isEnabled( 'upsell/nudge-a-palooza' ) &&
 			canUserUpgradeSite &&
@@ -433,6 +434,7 @@ export class MySitesSidebar extends Component {
 
 		if ( ! canUserUseStore ) {
 			if (
+				false && // This test is temporarily disabled until we conclude a few other ones about Oct 7th
 				! isJetpack &&
 				isEnabled( 'upsell/nudge-a-palooza' ) &&
 				canUserUpgradeSite &&

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -110,30 +110,6 @@ describe( 'MySitesSidebar', () => {
 			const wrapper = shallow( <Store /> );
 			expect( wrapper.html() ).toEqual( null );
 		} );
-
-		test( 'Should return upsell item if user who can upgrade can not use store on this site (nudge-a-palooza enabled)', () => {
-			const Sidebar = new MySitesSidebar( {
-				canUserUseStore: false,
-				canUserUpgradeSite: true,
-				...defaultProps,
-			} );
-			const Store = () => Sidebar.store();
-
-			const wrapper = shallow( <Store /> );
-			expect( wrapper.props().link ).toEqual( '/feature/store/mysite.com' );
-		} );
-
-		test( 'Should return upsell if non-managing user can not use store on this site (nudge-a-palooza enabled)', () => {
-			const Sidebar = new MySitesSidebar( {
-				canUserUseStore: false,
-				canUserUpgradeSite: true,
-				...defaultProps,
-			} );
-			const Store = () => Sidebar.store();
-
-			const wrapper = shallow( <Store /> );
-			expect( wrapper.props().link ).toEqual( '/feature/store/mysite.com' );
-		} );
 	} );
 
 	describe( 'MySitesSidebar.ads()', () => {
@@ -181,18 +157,6 @@ describe( 'MySitesSidebar', () => {
 
 			const wrapper = shallow( <Ads /> );
 			expect( wrapper.html() ).toEqual( null );
-		} );
-
-		test( "Should return upsell menu item if user can't use ads on this site but can upgrade site", () => {
-			const Sidebar = new MySitesSidebar( {
-				canUserUseAds: false,
-				canUserUpgradeSite: true,
-				...defaultProps,
-			} );
-			const Ads = () => Sidebar.ads();
-
-			const wrapper = shallow( <Ads /> );
-			expect( wrapper.props().link ).toEqual( '/feature/ads/mysite.com' );
 		} );
 
 		test( "Should return null if user can't use ads on this site upgrade site", () => {


### PR DESCRIPTION
This PR removes store and ads upsells from the global sidebar - these upsells were a part of `sidebarUpsells` test group of `nudgeAPalooza` test (p9jf6J-Hl-p2). We are replacing this large 5-way split test with a number of simple 2-way tests. These buttons may interfere with these smaller tests and so we are removing them until the other tests are concluded.

Test plan:
1. Assign yourself to `sidebarUpsells` group of `nudgeAPalooza` test
1. Confirm that for free sites there are no "Store" and "Ads" menu items
1. Confirm that for premium sites there is "Ads" menu item
1. Confirm that for business sites there are both "Store" and "Ads" menu items