### PR TITLE
Remove nudgeAPalooza AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -36,18 +36,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	nudgeAPalooza: {
-		datestamp: '20180806',
-		variations: {
-			sidebarUpsells: 20,
-			themesNudgesUpdates: 20,
-			customPluginAndThemeLandingPages: 20,
-			plansBannerUpsells: 20,
-			control: 20,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	springSale30PercentOff: {
 		datestamp: '20180413',
 		variations: {

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -14,7 +14,6 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import Button from 'components/button';
 import { isEnabled } from 'config';
 import CurrentSite from 'my-sites/current-site';

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -631,13 +631,6 @@ export class MySitesSidebar extends Component {
 			);
 		}
 
-		// For the duration of nudgeAPalooza test we need to allocate all users who visit calypso.
-		// Having it here is an easy solution that makes it possible to avoid touching redux store
-		// middleware structure
-		if ( isEnabled( 'upsell/nudge-a-palooza' ) ) {
-			abtest( 'nudgeAPalooza' );
-		}
-
 		const manage = !! this.manage(),
 			configuration =
 				!! this.sharing() ||


### PR DESCRIPTION
All test groups of nudgeAPalooza were converted to a smaller 50/50 tests and so we no longer need to have `nudgeAPalooza` test. This PR removes it.

Test plan:

Confirm that no ab test-related errors are logged in console during these steps:

1. Open a free site in calypso
1. Go to /plugins, click on Upload plugin
1. Go to /plugins, click on the upsell
1. Visit specific plugin's page
1. Go to /themes