### PR TITLE
Update e2e instructions for a/b tests to remove requirements for visual diff testing

### DIFF
--- a/client/lib/abtest/README.md
+++ b/client/lib/abtest/README.md
@@ -136,7 +136,7 @@ Our WordPress.com end-to-end (e2e) tests need to know which A/B test group to us
 
 ### Updating known A/B tests and overrides in the e2e tests
 
-Every time you add a new A/B test to Calypso you must update the [e2e tests repository](https://github.com/Automattic/wp-e2e-tests/) with that A/B test and set an override of behaviour.
+Every time you add a new A/B test to Calypso you must update the [e2e tests repository](https://github.com/Automattic/wp-e2e-tests/) with that A/B test and optionally set an override of behaviour.
 
 For example, if you were adding:
 
@@ -155,30 +155,34 @@ module.exports = {
 };
 ```
 
-You would need to update [config/default.json](https://github.com/Automattic/wp-e2e-tests/blob/master/config/default.json) to include:
+If your change was purely cosmetic, e.g. a text label or color change that doesn't affect functionality, you would only need to update [config/default.json](https://github.com/Automattic/wp-e2e-tests/blob/master/config/default.json) to include:
 
 ```js
 "knownABTestKeys": [
    "freeTrialButtonWording"
  ]
+ ```
 
+ This lets our e2e tests know this A/B test exists, but doesn't set or override any of the behavior, so e2e test users will be assigned to groups in the same way as anyone else.
+
+ If your change was functional, e.g. adding a new signup step, you would need to update `knownABTestKeys` and _also_ add an override to the same file:
+
+```js
  "overrideABTests": [
   [ "freeTrialButtonWording_201502160", "startFreeTrial" ]
  ]
 ```
 
-Adding the test to `knownABTestKeys` lets our e2e tests know this A/B test exists, but doesn't set or override any of the behaviour, so e2e test users will be assigned to groups in the same way as anyone else.
-
-Adding the test to `overrideABTests` ensures that all e2e test users are in the specified group so that behaviour remains the same and consistent across all e2e test runs. This is important for functional changes but also visual changes (for visual regression tests). Ideally you should aim to put the e2e tests in the most common (>50%) group, or in the default (existing) behaviour.
+This ensures that all e2e test users are in the specified group so that behavior remains the same and consistent across all e2e test runs. Ideally you should aim to put the e2e tests in the most common (>50%) group, or in the default (existing) behavior.
 
 *Note:* You should add this change to the e2e tests _before_ merging your wp-calypso change - it doesn't matter if the A/B test doesn't exist in wp-calypso yet when merging the e2e test change.
 
 ### Changing a known A/B test
 
-If you're making an update to an A/B test - changing the date for example, you should update the e2e tests in the same way as above to reflect the new date.
+If you're making an update to an A/B test - changing the date for example - you should update the e2e tests in the same way as above to reflect the new date.
 
 ### Removing a known A/B test
 
-When you're A/B test is complete and removed from `wp-calypso` you should also remove it from the e2e test config. This doesn't have to happen _immediately_ (it doesn't matter to override an A/B test that doesn't exist) but you should do it as soon as possible to keep things neat and tidy.
+When your A/B test is complete and removed from `wp-calypso` you should also remove it from the e2e test config. This doesn't have to happen _immediately_ (it doesn't matter to override an A/B test that doesn't exist) but you should do it as soon as possible to keep things neat and tidy.
 
 If your A/B test was successful and ***you're making permanent functional changes***, you should make permanent updates to the e2e tests to take into account these new functional changes. Speak to Flow Patrol if you need help.


### PR DESCRIPTION
We're removing visual diff test support (see https://github.com/Automattic/wp-e2e-tests/issues/1424).

The e2e test config now only requires an override for a/b tests that include functional changes. This update to the docs reflects that change.