### PR TITLE
Shorten the immediate login success message and make it not try to explain the reason for the login

### DIFF
--- a/client/state/immediate-login/test/utils.js
+++ b/client/state/immediate-login/test/utils.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { first } from 'lodash';
+import { first, last } from 'lodash';
 
 /**
  * Internal dependencies
@@ -121,15 +121,8 @@ describe( 'immediate-login/utils', () => {
 		const messages = [
 			createImmediateLoginMessage( '', 'test@wordpress.com' ),
 			createImmediateLoginMessage( first( REASONS_FOR_MANUAL_RENEWAL ), 'test@wordpress.com' ),
+			createImmediateLoginMessage( last( REASONS_FOR_MANUAL_RENEWAL ), 'test@wordpress.com' ),
 		];
-		test( 'should return a different message per reason', () => {
-			let previous = messages[ messages.length - 1 ];
-			for ( const m of messages ) {
-				expect( typeof m ).toBe( 'string' );
-				expect( m ).not.toBe( previous );
-				previous = m;
-			}
-		} );
 		test( 'should put an email in every message', () => {
 			for ( const m of messages ) {
 				expect( m.indexOf( 'test@wordpress.com' ) ).not.toBe( -1 );

--- a/client/state/immediate-login/utils.js
+++ b/client/state/immediate-login/utils.js
@@ -3,13 +3,7 @@
 /**
  * External dependencies
  */
-import { includes } from 'lodash';
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { REASONS_FOR_MANUAL_RENEWAL } from './constants';
 
 /**
  * Processes a redux ROUTE_SET action and returns a URL that contains no parameters that
@@ -41,15 +35,10 @@ export const createPathWithoutImmediateLoginInformation = ( path, query ) => {
  * @return {string}              - Message to show to user
  */
 export const createImmediateLoginMessage = ( loginReason, email ) => {
-	if ( includes( REASONS_FOR_MANUAL_RENEWAL, loginReason ) ) {
-		return translate(
-			'We logged you in as %(email)s so you can update your payment details and renew your subscription.',
-			{
-				args: { email },
-			}
-		);
-	}
-
-	// Default message.
-	return translate( 'We logged you in as %(email)s.', { args: { email } } );
+	// It's possible to vary the message based on login reason, but currently
+	// the default message is used in all cases. (Since the user reached this
+	// page via one click from an email, the expectation is that it's the
+	// responsibility of the email and the page to make clear to the user why
+	// they're actually here, not this message.)
+	return translate( "You're logged in as %(email)s.", { args: { email } } );
 };


### PR DESCRIPTION
After some discussion, it seems like it's a good idea to shorten the message you see when you're auto-logged-in from a subscription renewal email from:

```
We logged you in as [email] so you can update your payment
details and renew your subscription.
```

to just:

```
You're logged in as [email].
```

The idea (also explained in a code comment in this patch) is that although the extra messaging is helpful in other cases (where there's an interstitial screen before the login happens), it's not necessary here since they got to this page via one click from an email.  If people are confused about what they're supposed to be doing here, it needs to be fixed in the email or on the page itself -- we shouldn't use the message to do it, because already-logged-in users would experience the same confusion but don't see this message.

To test, go to this URL as a logged-in user (you can also edit or even remove the `login_reason` parameter below):
http://calypso.localhost:3000/me/purchases?immediate_login_attempt=1&immediate_login_success=1&login_reason=plan-expired

You should see the above, shorter message on the screen.